### PR TITLE
Add face analysis for solid-based CAM pocket detection

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -19,6 +19,7 @@ extern "C" {
 typedef struct OCCTShape* OCCTShapeRef;
 typedef struct OCCTWire* OCCTWireRef;
 typedef struct OCCTMesh* OCCTMeshRef;
+typedef struct OCCTFace* OCCTFaceRef;
 
 // MARK: - Shape Creation (Primitives)
 
@@ -182,6 +183,66 @@ void OCCTFreeWireArray(OCCTWireRef* wires, int32_t count);
 /// Free only the array container, not the wires - use when Swift takes ownership of wire handles
 /// @param wires Array of wire references
 void OCCTFreeWireArrayOnly(OCCTWireRef* wires);
+
+// MARK: - Face Analysis (for solid-based CAM)
+
+/// Get all faces from a shape
+/// @param shape The shape to extract faces from
+/// @param outCount Output: number of faces returned
+/// @return Array of face references, or NULL on failure. Caller must free with OCCTFreeFaceArray.
+OCCTFaceRef* OCCTShapeGetFaces(OCCTShapeRef shape, int32_t* outCount);
+
+/// Free an array of faces (frees faces AND array)
+/// @param faces Array of face references
+/// @param count Number of faces in the array
+void OCCTFreeFaceArray(OCCTFaceRef* faces, int32_t count);
+
+/// Free only the face array container, not the faces - use when Swift takes ownership
+/// @param faces Array of face references
+void OCCTFreeFaceArrayOnly(OCCTFaceRef* faces);
+
+/// Release a single face
+void OCCTFaceRelease(OCCTFaceRef face);
+
+/// Get the normal vector at the center of a face
+/// @param face The face to get normal from
+/// @param outNx, outNy, outNz Output: normal vector components
+/// @return true if successful, false if normal could not be computed
+bool OCCTFaceGetNormal(OCCTFaceRef face, double* outNx, double* outNy, double* outNz);
+
+/// Get the outer wire (boundary) of a face
+/// @param face The face to get outer wire from
+/// @return Wire reference, or NULL on failure. Caller must release with OCCTWireRelease.
+OCCTWireRef OCCTFaceGetOuterWire(OCCTFaceRef face);
+
+/// Get the bounding box of a face
+/// @param face The face to get bounds from
+void OCCTFaceGetBounds(OCCTFaceRef face, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ);
+
+/// Check if a face is planar (flat)
+/// @param face The face to check
+/// @return true if the face is planar
+bool OCCTFaceIsPlanar(OCCTFaceRef face);
+
+/// Get the Z level of a horizontal planar face
+/// @param face The face to get Z from
+/// @param outZ Output: Z coordinate of the face plane
+/// @return true if face is horizontal and Z was computed, false otherwise
+bool OCCTFaceGetZLevel(OCCTFaceRef face, double* outZ);
+
+/// Get horizontal faces from a shape (faces with normals pointing up or down)
+/// @param shape The shape to search
+/// @param tolerance Angle tolerance in radians (e.g., 0.01 for ~0.5 degrees)
+/// @param outCount Output: number of faces returned
+/// @return Array of face references for horizontal faces only
+OCCTFaceRef* OCCTShapeGetHorizontalFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount);
+
+/// Get upward-facing horizontal faces (potential pocket floors)
+/// @param shape The shape to search
+/// @param tolerance Angle tolerance in radians
+/// @param outCount Output: number of faces returned
+/// @return Array of face references for upward-facing horizontal faces
+OCCTFaceRef* OCCTShapeGetUpwardFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount);
 
 #ifdef __cplusplus
 }

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -1,0 +1,162 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// A face from a 3D solid shape - represents a bounded surface
+public final class Face: @unchecked Sendable {
+    internal let handle: OCCTFaceRef
+
+    internal init(handle: OCCTFaceRef) {
+        self.handle = handle
+    }
+
+    deinit {
+        OCCTFaceRelease(handle)
+    }
+
+    // MARK: - Properties
+
+    /// Get the normal vector at the center of the face
+    public var normal: SIMD3<Double>? {
+        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        guard OCCTFaceGetNormal(handle, &nx, &ny, &nz) else {
+            return nil
+        }
+        return SIMD3(nx, ny, nz)
+    }
+
+    /// Get the outer wire (boundary) of the face
+    public var outerWire: Wire? {
+        guard let wireHandle = OCCTFaceGetOuterWire(handle) else {
+            return nil
+        }
+        return Wire(handle: wireHandle)
+    }
+
+    /// Get the bounding box of the face
+    public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
+        var minX: Double = 0, minY: Double = 0, minZ: Double = 0
+        var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
+        OCCTFaceGetBounds(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
+        return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
+    }
+
+    /// Check if the face is planar (flat)
+    public var isPlanar: Bool {
+        OCCTFaceIsPlanar(handle)
+    }
+
+    /// Check if the face is horizontal (normal points up or down)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    public func isHorizontal(tolerance: Double = 0.01) -> Bool {
+        guard let n = normal else { return false }
+        return abs(n.z) > cos(tolerance)
+    }
+
+    /// Check if the face is upward-facing (normal points up)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    public func isUpwardFacing(tolerance: Double = 0.01) -> Bool {
+        guard let n = normal else { return false }
+        return n.z > cos(tolerance)
+    }
+
+    /// Get the Z level of a horizontal planar face
+    /// Returns nil if face is not horizontal or not planar
+    public var zLevel: Double? {
+        var z: Double = 0
+        guard OCCTFaceGetZLevel(handle, &z) else {
+            return nil
+        }
+        return z
+    }
+}
+
+// MARK: - Shape Extension for Face Analysis
+
+extension Shape {
+    /// Get all faces from the solid
+    public func faces() -> [Face] {
+        var count: Int32 = 0
+        guard let faceArray = OCCTShapeGetFaces(handle, &count) else {
+            return []
+        }
+        // Use OCCTFreeFaceArrayOnly - Swift Face objects now own the face handles
+        // and will release them in their deinit. We only need to free the array container.
+        defer { OCCTFreeFaceArrayOnly(faceArray) }
+
+        var faces: [Face] = []
+        for i in 0..<Int(count) {
+            if let faceHandle = faceArray[i] {
+                faces.append(Face(handle: faceHandle))
+            }
+        }
+
+        return faces
+    }
+
+    /// Get horizontal faces (normals pointing up or down)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    public func horizontalFaces(tolerance: Double = 0.01) -> [Face] {
+        var count: Int32 = 0
+        guard let faceArray = OCCTShapeGetHorizontalFaces(handle, tolerance, &count) else {
+            return []
+        }
+        defer { OCCTFreeFaceArrayOnly(faceArray) }
+
+        var faces: [Face] = []
+        for i in 0..<Int(count) {
+            if let faceHandle = faceArray[i] {
+                faces.append(Face(handle: faceHandle))
+            }
+        }
+
+        return faces
+    }
+
+    /// Get upward-facing horizontal faces (potential pocket floors)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    public func upwardFaces(tolerance: Double = 0.01) -> [Face] {
+        var count: Int32 = 0
+        guard let faceArray = OCCTShapeGetUpwardFaces(handle, tolerance, &count) else {
+            return []
+        }
+        defer { OCCTFreeFaceArrayOnly(faceArray) }
+
+        var faces: [Face] = []
+        for i in 0..<Int(count) {
+            if let faceHandle = faceArray[i] {
+                faces.append(Face(handle: faceHandle))
+            }
+        }
+
+        return faces
+    }
+
+    /// Get faces grouped by Z level (for CAM pocket detection)
+    /// - Parameter tolerance: Z tolerance for grouping faces
+    /// - Returns: Dictionary mapping Z levels to arrays of faces at that level
+    public func facesByZLevel(tolerance: Double = 0.01) -> [Double: [Face]] {
+        let horizontal = horizontalFaces()
+        var result: [Double: [Face]] = [:]
+
+        for face in horizontal {
+            guard let z = face.zLevel else { continue }
+
+            // Find existing group within tolerance
+            var foundGroup = false
+            for (existingZ, _) in result {
+                if abs(existingZ - z) < tolerance {
+                    result[existingZ]?.append(face)
+                    foundGroup = true
+                    break
+                }
+            }
+
+            if !foundGroup {
+                result[z] = [face]
+            }
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

Add face analysis capabilities to OCCTSwift for solid-based CAM pocket detection.

Closes #5

## Changes

### C++ Bridge (OCCTBridge)
- Add `OCCTFace` opaque handle type
- Add face exploration: `OCCTShapeGetFaces()`, `OCCTShapeGetHorizontalFaces()`, `OCCTShapeGetUpwardFaces()`
- Add face properties: `OCCTFaceGetNormal()`, `OCCTFaceGetOuterWire()`, `OCCTFaceGetBounds()`, `OCCTFaceIsPlanar()`, `OCCTFaceGetZLevel()`
- Add memory management: `OCCTFreeFaceArray()`, `OCCTFreeFaceArrayOnly()`, `OCCTFaceRelease()`

### Swift API
- New `Face` class with properties: `normal`, `outerWire`, `bounds`, `isPlanar`, `zLevel`
- New helper methods: `isHorizontal()`, `isUpwardFacing()`
- Shape extensions: `faces()`, `horizontalFaces()`, `upwardFaces()`, `facesByZLevel()`

## Use Case

This enables detecting pockets in solid models that cannot be detected using Z-slicing.

For example, CAM_test_2 has internal pockets that the wire-based approach (`sectionWiresAtZ`) couldn't detect because wire offset fails on certain geometry. With face analysis:

```
Face Analysis Debug
==================================================
Total faces: 31
- Horizontal (up):   7
- Horizontal (down): 1
- Vertical:          17
- Other:             6

Pocket analysis:
Found 6 potential pocket floor(s)
- 5 of 6 have wires that can be offset for toolpath
```

## Test plan

- [x] Builds on macOS
- [x] Face extraction works on test STEP files
- [x] Normal calculation handles face orientation
- [x] Outer wire extraction works
- [x] Wire offset works on extracted pocket wires (5/6 cases)
