### PR TITLE
Add robust STEP import with sewing, solid creation, and healing

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -147,6 +147,30 @@ bool OCCTExportSTEPWithName(OCCTShapeRef shape, const char* path, const char* na
 
 OCCTShapeRef OCCTImportSTEP(const char* path);
 
+// MARK: - Robust STEP Import
+
+/// Import result structure with diagnostics
+typedef struct {
+    OCCTShapeRef shape;
+    int originalType;   // TopAbs_ShapeEnum: 0=Compound, 1=CompSolid, 2=Solid, 3=Shell, 4=Face, etc.
+    int resultType;     // Type after processing
+    bool sewingApplied;
+    bool solidCreated;
+    bool healingApplied;
+} OCCTSTEPImportResult;
+
+/// Import STEP file with robust handling: sewing, solid creation, and shape healing
+OCCTShapeRef OCCTImportSTEPRobust(const char* path);
+
+/// Import STEP file with diagnostic information
+OCCTSTEPImportResult OCCTImportSTEPWithDiagnostics(const char* path);
+
+/// Get shape type (TopAbs_ShapeEnum value)
+int OCCTShapeGetType(OCCTShapeRef shape);
+
+/// Check if shape is a valid closed solid
+bool OCCTShapeIsValidSolid(OCCTShapeRef shape);
+
 // MARK: - Bounds
 
 void OCCTShapeGetBounds(OCCTShapeRef shape, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 **Major upgrade to OCCT 8.0.0-rc3**
 
+### Added
+
+#### Robust STEP Import
+- **`Shape.loadRobust(from:)`** - Import STEP files with automatic repair
+  - Sews disconnected faces into connected geometry
+  - Converts shells to valid closed solids
+  - Applies shape healing for geometry issues
+  - Recommended for files from external CAD systems
+
+- **`Shape.loadWithDiagnostics(from:)`** - Import with processing information
+  - Returns `ImportResult` with shape and diagnostic flags
+  - Shows what processing was applied (sewing, solid creation, healing)
+  - Useful for debugging import issues
+
+- **`Shape.shapeType`** - Get topological type (Solid, Shell, Face, etc.)
+- **`Shape.isValidSolid`** - Check if shape is a valid closed solid
+
+**C Bridge Functions:**
+```c
+OCCTShapeRef OCCTImportSTEPRobust(const char* path);
+OCCTSTEPImportResult OCCTImportSTEPWithDiagnostics(const char* path);
+int OCCTShapeGetType(OCCTShapeRef shape);
+bool OCCTShapeIsValidSolid(OCCTShapeRef shape);
+```
+
 ### Changed
 - **Upgraded OpenCASCADE to 8.0.0-rc3** (from 7.8.1)
 - Build script now uses GitHub for RC releases


### PR DESCRIPTION
## Summary

Implements robust STEP file import that automatically repairs geometry issues commonly encountered when importing files from external CAD systems.

### New Functions

**C Bridge:**
- `OCCTImportSTEPRobust()` - Import with automatic repair
- `OCCTImportSTEPWithDiagnostics()` - Import with processing info
- `OCCTShapeGetType()` - Get shape type
- `OCCTShapeIsValidSolid()` - Validate closed solid

**Swift API:**
- `Shape.loadRobust(from:)` - Recommended for external STEP files
- `Shape.loadWithDiagnostics(from:)` - Debug import issues
- `Shape.shapeType` - Get topological type
- `Shape.isValidSolid` - Check if valid solid

### Processing Pipeline

1. Configure reader with precision settings
2. Sew disconnected faces (`BRepBuilderAPI_Sewing`)
3. Convert shells to solids (`BRepBuilderAPI_MakeSolid`)
4. Apply shape healing (`ShapeFix_Shape`)

### Example Usage

```swift
// Simple robust import
let shape = try Shape.loadRobust(from: stepFile)

// Import with diagnostics
let result = try Shape.loadWithDiagnostics(from: stepFile)
print(result.summary)  // "Shell → Solid (processing: sewing, solid creation, healing)"
```

## Test Plan

- [x] All 23 existing tests pass
- [x] macOS build succeeds
- [x] iOS build succeeds

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)