### PR TITLE
Add selection API for ray-casting and face/edge index access

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -336,6 +336,82 @@ OCCTFaceRef* OCCTShapeGetHorizontalFaces(OCCTShapeRef shape, double tolerance, i
 /// @return Array of face references for upward-facing horizontal faces
 OCCTFaceRef* OCCTShapeGetUpwardFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount);
 
+// MARK: - Ray Casting & Selection (Issues #12, #13, #14)
+
+/// Ray hit result structure
+typedef struct {
+    double point[3];        // 3D intersection point
+    double normal[3];       // Surface normal at hit
+    int32_t faceIndex;      // Index of hit face
+    double distance;        // Distance from ray origin
+    double uv[2];           // UV parameters on surface
+} OCCTRayHit;
+
+/// Cast ray against shape and return all intersections
+/// @param shape The shape to test against
+/// @param originX, originY, originZ Ray origin
+/// @param dirX, dirY, dirZ Ray direction (will be normalized)
+/// @param tolerance Intersection tolerance
+/// @param outHits Output array for hits (caller allocates)
+/// @param maxHits Maximum number of hits to return
+/// @return Number of hits found, or -1 on error
+int32_t OCCTShapeRaycast(
+    OCCTShapeRef shape,
+    double originX, double originY, double originZ,
+    double dirX, double dirY, double dirZ,
+    double tolerance,
+    OCCTRayHit* outHits,
+    int32_t maxHits
+);
+
+/// Get total number of faces in a shape
+int32_t OCCTShapeGetFaceCount(OCCTShapeRef shape);
+
+/// Get face by index (0-based)
+/// @param shape The shape containing faces
+/// @param index Face index (0-based)
+/// @return Face reference, or NULL if index out of bounds
+OCCTFaceRef OCCTShapeGetFaceAtIndex(OCCTShapeRef shape, int32_t index);
+
+// MARK: - Edge Access (Issue #14)
+
+typedef struct OCCTEdge* OCCTEdgeRef;
+
+/// Get total number of edges in a shape
+int32_t OCCTShapeGetTotalEdgeCount(OCCTShapeRef shape);
+
+/// Get edge by index (0-based)
+/// @param shape The shape containing edges
+/// @param index Edge index (0-based)
+/// @return Edge reference, or NULL if index out of bounds. Caller must release.
+OCCTEdgeRef OCCTShapeGetEdgeAtIndex(OCCTShapeRef shape, int32_t index);
+
+/// Release an edge reference
+void OCCTEdgeRelease(OCCTEdgeRef edge);
+
+/// Get edge length
+double OCCTEdgeGetLength(OCCTEdgeRef edge);
+
+/// Get edge bounding box
+void OCCTEdgeGetBounds(OCCTEdgeRef edge, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ);
+
+/// Get points along edge curve
+/// @param edge The edge to sample
+/// @param count Number of points to generate
+/// @param outPoints Output array [x,y,z,...] (caller allocates count*3 doubles)
+/// @return Actual number of points written
+int32_t OCCTEdgeGetPoints(OCCTEdgeRef edge, int32_t count, double* outPoints);
+
+/// Check if edge is a line
+bool OCCTEdgeIsLine(OCCTEdgeRef edge);
+
+/// Check if edge is a circle/arc
+bool OCCTEdgeIsCircle(OCCTEdgeRef edge);
+
+/// Get start and end vertices of edge
+void OCCTEdgeGetEndpoints(OCCTEdgeRef edge, double* startX, double* startY, double* startZ, double* endX, double* endY, double* endZ);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -1,0 +1,110 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// An edge from a 3D solid shape - represents a curve between vertices
+public final class Edge: @unchecked Sendable {
+    internal let handle: OCCTEdgeRef
+    
+    internal init(handle: OCCTEdgeRef) {
+        self.handle = handle
+    }
+    
+    deinit {
+        OCCTEdgeRelease(handle)
+    }
+    
+    // MARK: - Properties
+    
+    /// Get the length of the edge
+    public var length: Double {
+        OCCTEdgeGetLength(handle)
+    }
+    
+    /// Get the bounding box of the edge
+    public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
+        var minX: Double = 0, minY: Double = 0, minZ: Double = 0
+        var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
+        OCCTEdgeGetBounds(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
+        return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
+    }
+    
+    /// Check if the edge is a straight line
+    public var isLine: Bool {
+        OCCTEdgeIsLine(handle)
+    }
+    
+    /// Check if the edge is a circular arc
+    public var isCircle: Bool {
+        OCCTEdgeIsCircle(handle)
+    }
+    
+    /// Get the start and end points of the edge
+    public var endpoints: (start: SIMD3<Double>, end: SIMD3<Double>) {
+        var startX: Double = 0, startY: Double = 0, startZ: Double = 0
+        var endX: Double = 0, endY: Double = 0, endZ: Double = 0
+        OCCTEdgeGetEndpoints(handle, &startX, &startY, &startZ, &endX, &endY, &endZ)
+        return (start: SIMD3(startX, startY, startZ), end: SIMD3(endX, endY, endZ))
+    }
+    
+    // MARK: - Sampling
+    
+    /// Get points along the edge curve
+    /// - Parameter count: Number of points to generate (default: automatic based on length)
+    /// - Returns: Array of 3D points along the edge
+    public func points(count: Int? = nil) -> [SIMD3<Double>] {
+        let pointCount = count ?? max(2, Int(length / 0.5) + 1)  // ~0.5mm spacing default
+        guard pointCount >= 2 else { return [] }
+        
+        var buffer = [Double](repeating: 0, count: pointCount * 3)
+        let actualCount = OCCTEdgeGetPoints(handle, Int32(pointCount), &buffer)
+        
+        guard actualCount > 0 else { return [] }
+        
+        var result = [SIMD3<Double>]()
+        result.reserveCapacity(Int(actualCount))
+        
+        for i in 0..<Int(actualCount) {
+            let x = buffer[i * 3]
+            let y = buffer[i * 3 + 1]
+            let z = buffer[i * 3 + 2]
+            result.append(SIMD3(x, y, z))
+        }
+        
+        return result
+    }
+}
+
+// MARK: - Shape Extension for Edge Access
+
+extension Shape {
+    /// Get total number of edges in the shape
+    public var edgeCount: Int {
+        Int(OCCTShapeGetTotalEdgeCount(handle))
+    }
+    
+    /// Get edge by index (0-based)
+    /// - Parameter index: The edge index
+    /// - Returns: Edge at the given index, or nil if index is out of bounds
+    public func edge(at index: Int) -> Edge? {
+        guard let edgeHandle = OCCTShapeGetEdgeAtIndex(handle, Int32(index)) else {
+            return nil
+        }
+        return Edge(handle: edgeHandle)
+    }
+    
+    /// Get all edges from the shape
+    public func edges() -> [Edge] {
+        let count = edgeCount
+        var edges = [Edge]()
+        edges.reserveCapacity(count)
+        
+        for i in 0..<count {
+            if let edge = edge(at: i) {
+                edges.append(edge)
+            }
+        }
+        
+        return edges
+    }
+}

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -60,6 +60,20 @@ public final class Face: @unchecked Sendable {
         return n.z > cos(tolerance)
     }
 
+    /// Check if the face is downward-facing (normal points down)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    public func isDownwardFacing(tolerance: Double = 0.01) -> Bool {
+        guard let n = normal else { return false }
+        return n.z < -cos(tolerance)
+    }
+
+    /// Check if the face is vertical (normal is horizontal)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    public func isVertical(tolerance: Double = 0.01) -> Bool {
+        guard let n = normal else { return false }
+        return abs(n.z) < sin(tolerance)
+    }
+
     /// Get the Z level of a horizontal planar face
     /// Returns nil if face is not horizontal or not planar
     public var zLevel: Double? {

--- a/Sources/OCCTSwift/Selection.swift
+++ b/Sources/OCCTSwift/Selection.swift
@@ -1,0 +1,110 @@
+import Foundation
+import simd
+import OCCTBridge
+
+// MARK: - Ray Hit Result
+
+/// Result from a ray cast against a shape
+public struct RayHit: Sendable {
+    /// 3D point where ray intersects surface
+    public let point: SIMD3<Double>
+    
+    /// Surface normal at intersection point
+    public let normal: SIMD3<Double>
+    
+    /// Index of the face that was hit (0-based)
+    public let faceIndex: Int
+    
+    /// Distance from ray origin to intersection point
+    public let distance: Double
+    
+    /// UV parameters on the surface at intersection
+    public let uv: SIMD2<Double>
+}
+
+// MARK: - Shape Ray Casting Extension
+
+extension Shape {
+    /// Cast a ray against the shape and find all intersections
+    /// - Parameters:
+    ///   - origin: Starting point of the ray
+    ///   - direction: Direction of the ray (will be normalized)
+    ///   - tolerance: Intersection tolerance (default: 0.001)
+    ///   - maxHits: Maximum number of hits to return (default: 100)
+    /// - Returns: Array of ray hits sorted by distance
+    public func raycast(
+        origin: SIMD3<Double>,
+        direction: SIMD3<Double>,
+        tolerance: Double = 0.001,
+        maxHits: Int = 100
+    ) -> [RayHit] {
+        guard maxHits > 0 else { return [] }
+        
+        // Allocate buffer for hits
+        var hitBuffer = [OCCTRayHit](repeating: OCCTRayHit(), count: maxHits)
+        
+        let hitCount = OCCTShapeRaycast(
+            handle,
+            origin.x, origin.y, origin.z,
+            direction.x, direction.y, direction.z,
+            tolerance,
+            &hitBuffer,
+            Int32(maxHits)
+        )
+        
+        guard hitCount > 0 else { return [] }
+        
+        // Convert to Swift structs
+        var results = [RayHit]()
+        results.reserveCapacity(Int(hitCount))
+        
+        for i in 0..<Int(hitCount) {
+            let hit = hitBuffer[i]
+            results.append(RayHit(
+                point: SIMD3(hit.point.0, hit.point.1, hit.point.2),
+                normal: SIMD3(hit.normal.0, hit.normal.1, hit.normal.2),
+                faceIndex: Int(hit.faceIndex),
+                distance: hit.distance,
+                uv: SIMD2(hit.uv.0, hit.uv.1)
+            ))
+        }
+        
+        // Sort by distance (nearest first)
+        results.sort { $0.distance < $1.distance }
+        
+        return results
+    }
+    
+    /// Cast a ray and return only the nearest hit
+    /// - Parameters:
+    ///   - origin: Starting point of the ray
+    ///   - direction: Direction of the ray
+    ///   - tolerance: Intersection tolerance
+    /// - Returns: Nearest hit, or nil if no intersection
+    public func raycastNearest(
+        origin: SIMD3<Double>,
+        direction: SIMD3<Double>,
+        tolerance: Double = 0.001
+    ) -> RayHit? {
+        raycast(origin: origin, direction: direction, tolerance: tolerance, maxHits: 100).first
+    }
+}
+
+// MARK: - Shape Face Index Access Extension
+
+extension Shape {
+    /// Get total number of faces in the shape
+    public var faceCount: Int {
+        Int(OCCTShapeGetFaceCount(handle))
+    }
+    
+    /// Get face by index (0-based)
+    /// - Parameter index: The face index
+    /// - Returns: Face at the given index, or nil if index is out of bounds
+    public func face(at index: Int) -> Face? {
+        guard let faceHandle = OCCTShapeGetFaceAtIndex(handle, Int32(index)) else {
+            return nil
+        }
+        return Face(handle: faceHandle)
+    }
+}

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -314,7 +314,8 @@ public final class Shape: @unchecked Sendable {
         deflection: Double = 0.1,
         maxPointsPerEdge: Int = 1000
     ) -> [[SIMD3<Double>]] {
-        let count = edgeCount
+        // Get edge count directly from C API
+        let count = Int(OCCTShapeGetTotalEdgeCount(handle))
         var result: [[SIMD3<Double>]] = []
         result.reserveCapacity(count)
 
@@ -497,11 +498,6 @@ public final class Shape: @unchecked Sendable {
             }
         }
         return wires
-    }
-
-    /// Get the number of edges in this shape (useful after slicing)
-    public var edgeCount: Int {
-        Int(OCCTShapeGetEdgeCount(handle))
     }
 
     /// Get points along an edge at the given index.


### PR DESCRIPTION
## Summary

This PR adds comprehensive selection and indexing APIs for issues #12, #13, #14, and #15.

### Features Added

**Ray-casting (#12)**
- `OCCTShapeRaycast()` - Cast ray against shape using OCCT `IntCurvesFace_ShapeIntersector`
- Returns hit points, normals, face indices, distances, and UV parameters
- Swift: `Shape.raycast(origin:direction:tolerance:maxHits:)` and `Shape.raycastNearest()`

**Face Index Access (#13)**
- `OCCTShapeGetFaceCount()` - Get total face count
- `OCCTShapeGetFaceAtIndex()` - Get face by index (0-based)
- Swift: `Shape.faceCount` and `Shape.face(at:)`

**Edge Index Access (#14)**
- `OCCTShapeGetTotalEdgeCount()` - Get total edge count
- `OCCTShapeGetEdgeAtIndex()` - Get edge by index (0-based)
- `OCCTEdgeGetLength/Bounds/Points/IsLine/IsCircle/Endpoints` - Edge properties
- Swift: New `Edge` class with full edge analysis capabilities
- Swift: `Shape.edgeCount`, `Shape.edge(at:)`, `Shape.edges()`

**Face Classification Helpers (#15)**
- `Face.isDownwardFacing(tolerance:)` - Check if normal points down
- `Face.isVertical(tolerance:)` - Check if normal is horizontal

### Files Changed

- `Sources/OCCTBridge/include/OCCTBridge.h` - C API declarations
- `Sources/OCCTBridge/src/OCCTBridge.mm` - OCCT implementations
- `Sources/OCCTSwift/Edge.swift` - New Edge class
- `Sources/OCCTSwift/Selection.swift` - New RayHit and raycast APIs
- `Sources/OCCTSwift/Face.swift` - Additional classification helpers
- `Sources/OCCTSwift/Shape.swift` - Updated edge count to use new API

## Test plan

- [ ] Build with local OCCT.xcframework
- [ ] Test ray-casting against simple box shape
- [ ] Verify face/edge index access returns correct geometry
- [ ] Confirm edge properties (length, bounds, curve type) are accurate

Note: The OCCT.xcframework binary needs to be uploaded to v0.4.0 release for CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)