### PR TITLE
Metal visualization wrappers for ViewportKit integration

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1213,6 +1213,96 @@ int32_t OCCTSelectorPickRect(OCCTSelectorRef sel, OCCTCameraRef cam,
                              double xMin, double yMin, double xMax, double yMax,
                              OCCTPickResult* out, int32_t maxResults);
 
+// MARK: - Clip Plane (Metal Visualization)
+
+typedef struct OCCTClipPlane* OCCTClipPlaneRef;
+
+/// Create a clip plane from an equation Ax + By + Cz + D = 0
+OCCTClipPlaneRef OCCTClipPlaneCreate(double a, double b, double c, double d);
+void OCCTClipPlaneDestroy(OCCTClipPlaneRef plane);
+
+void OCCTClipPlaneSetEquation(OCCTClipPlaneRef plane, double a, double b, double c, double d);
+void OCCTClipPlaneGetEquation(OCCTClipPlaneRef plane, double* a, double* b, double* c, double* d);
+
+/// Get the reversed equation (for back-face clipping)
+void OCCTClipPlaneGetReversedEquation(OCCTClipPlaneRef plane, double* a, double* b, double* c, double* d);
+
+void OCCTClipPlaneSetOn(OCCTClipPlaneRef plane, bool on);
+bool OCCTClipPlaneIsOn(OCCTClipPlaneRef plane);
+
+void OCCTClipPlaneSetCapping(OCCTClipPlaneRef plane, bool on);
+bool OCCTClipPlaneIsCapping(OCCTClipPlaneRef plane);
+
+void OCCTClipPlaneSetCappingColor(OCCTClipPlaneRef plane, double r, double g, double b);
+void OCCTClipPlaneGetCappingColor(OCCTClipPlaneRef plane, double* r, double* g, double* b);
+
+/// Set capping hatch style (see Aspect_HatchStyle values)
+void OCCTClipPlaneSetCappingHatch(OCCTClipPlaneRef plane, int32_t style);
+int32_t OCCTClipPlaneGetCappingHatch(OCCTClipPlaneRef plane);
+void OCCTClipPlaneSetCappingHatchOn(OCCTClipPlaneRef plane, bool on);
+bool OCCTClipPlaneIsCappingHatchOn(OCCTClipPlaneRef plane);
+
+/// Probe a point against the clip plane chain. Returns: 0=Out, 1=In, 2=On
+int32_t OCCTClipPlaneProbePoint(OCCTClipPlaneRef plane, double x, double y, double z);
+
+/// Probe an axis-aligned bounding box against the clip plane chain. Returns: 0=Out, 1=In, 2=On
+int32_t OCCTClipPlaneProbeBox(OCCTClipPlaneRef plane,
+                               double xMin, double yMin, double zMin,
+                               double xMax, double yMax, double zMax);
+
+/// Chain another plane for logical AND clipping (conjunction)
+void OCCTClipPlaneSetChainNext(OCCTClipPlaneRef plane, OCCTClipPlaneRef next);
+/// Get the number of planes in the forward chain (including this one)
+int32_t OCCTClipPlaneChainLength(OCCTClipPlaneRef plane);
+
+// MARK: - Z-Layer Settings (Metal Visualization)
+
+typedef struct OCCTZLayerSettings* OCCTZLayerSettingsRef;
+
+OCCTZLayerSettingsRef OCCTZLayerSettingsCreate(void);
+void OCCTZLayerSettingsDestroy(OCCTZLayerSettingsRef settings);
+
+void OCCTZLayerSettingsSetName(OCCTZLayerSettingsRef settings, const char* name);
+
+void OCCTZLayerSettingsSetDepthTest(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetDepthTest(OCCTZLayerSettingsRef settings);
+void OCCTZLayerSettingsSetDepthWrite(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetDepthWrite(OCCTZLayerSettingsRef settings);
+void OCCTZLayerSettingsSetClearDepth(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetClearDepth(OCCTZLayerSettingsRef settings);
+
+/// Set polygon offset: mode (0=Off,1=Fill,2=Line,4=Point,7=All), factor, units
+void OCCTZLayerSettingsSetPolygonOffset(OCCTZLayerSettingsRef settings, int32_t mode, float factor, float units);
+void OCCTZLayerSettingsGetPolygonOffset(OCCTZLayerSettingsRef settings, int32_t* mode, float* factor, float* units);
+
+/// Convenience: set minimal positive depth offset (factor=1, units=1)
+void OCCTZLayerSettingsSetDepthOffsetPositive(OCCTZLayerSettingsRef settings);
+/// Convenience: set minimal negative depth offset (factor=1, units=-1)
+void OCCTZLayerSettingsSetDepthOffsetNegative(OCCTZLayerSettingsRef settings);
+
+void OCCTZLayerSettingsSetImmediate(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetImmediate(OCCTZLayerSettingsRef settings);
+void OCCTZLayerSettingsSetRaytracable(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetRaytracable(OCCTZLayerSettingsRef settings);
+
+void OCCTZLayerSettingsSetEnvironmentTexture(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetEnvironmentTexture(OCCTZLayerSettingsRef settings);
+
+void OCCTZLayerSettingsSetRenderInDepthPrepass(OCCTZLayerSettingsRef settings, bool on);
+bool OCCTZLayerSettingsGetRenderInDepthPrepass(OCCTZLayerSettingsRef settings);
+
+/// Set culling distance (set to negative or zero to disable)
+void OCCTZLayerSettingsSetCullingDistance(OCCTZLayerSettingsRef settings, double distance);
+double OCCTZLayerSettingsGetCullingDistance(OCCTZLayerSettingsRef settings);
+
+/// Set culling size (set to negative or zero to disable)
+void OCCTZLayerSettingsSetCullingSize(OCCTZLayerSettingsRef settings, double size);
+double OCCTZLayerSettingsGetCullingSize(OCCTZLayerSettingsRef settings);
+
+/// Set layer origin (for coordinate precision in large scenes)
+void OCCTZLayerSettingsSetOrigin(OCCTZLayerSettingsRef settings, double x, double y, double z);
+void OCCTZLayerSettingsGetOrigin(OCCTZLayerSettingsRef settings, double* x, double* y, double* z);
+
 // MARK: - Advanced Blends & Surface Filling (v0.14.0)
 
 /// Apply variable radius fillet to a specific edge

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1229,9 +1229,22 @@ int32_t OCCTSelectorPickRect(OCCTSelectorRef sel, OCCTCameraRef cam,
                              double xMin, double yMin, double xMax, double yMax,
                              OCCTPickResult* out, int32_t maxResults);
 
-// MARK: - Display Drawer (Metal Visualization)
+/// Polyline (lasso) pick: select shapes within a closed polygon defined by 2D pixel points.
+/// polyXY is an array of x,y pairs (length = pointCount * 2).
+int32_t OCCTSelectorPickPoly(OCCTSelectorRef sel, OCCTCameraRef cam,
+                             double viewW, double viewH,
+                             const double* polyXY, int32_t pointCount,
+                             OCCTPickResult* out, int32_t maxResults);
+
+// MARK: - Drawer-Aware Mesh Extraction
 
 typedef struct OCCTDrawer* OCCTDrawerRef;
+
+/// Extract shaded mesh using a DisplayDrawer for tessellation control.
+bool OCCTShapeGetShadedMeshWithDrawer(OCCTShapeRef shape, OCCTDrawerRef drawer, OCCTShadedMeshData* out);
+bool OCCTShapeGetEdgeMeshWithDrawer(OCCTShapeRef shape, OCCTDrawerRef drawer, OCCTEdgeMeshData* out);
+
+// MARK: - Display Drawer (Metal Visualization)
 
 OCCTDrawerRef OCCTDrawerCreate(void);
 void OCCTDrawerDestroy(OCCTDrawerRef drawer);

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1194,6 +1194,8 @@ typedef struct {
     int32_t shapeId;
     double depth;
     double pointX, pointY, pointZ;
+    int32_t subShapeType;   // TopAbs_ShapeEnum: 7=VERTEX, 6=EDGE, 5=WIRE, 4=FACE, 8=SHAPE
+    int32_t subShapeIndex;  // 1-based index of sub-shape within parent, 0 if whole shape
 } OCCTPickResult;
 
 OCCTSelectorRef OCCTSelectorCreate(void);
@@ -1202,6 +1204,20 @@ void            OCCTSelectorDestroy(OCCTSelectorRef sel);
 bool OCCTSelectorAddShape(OCCTSelectorRef sel, OCCTShapeRef shape, int32_t shapeId);
 bool OCCTSelectorRemoveShape(OCCTSelectorRef sel, int32_t shapeId);
 void OCCTSelectorClear(OCCTSelectorRef sel);
+
+/// Activate a selection mode for a shape (0=shape, 1=vertex, 2=edge, 3=wire, 4=face).
+/// Mode 0 is activated automatically when adding a shape.
+void OCCTSelectorActivateMode(OCCTSelectorRef sel, int32_t shapeId, int32_t mode);
+
+/// Deactivate a selection mode for a shape. Pass -1 to deactivate all modes.
+void OCCTSelectorDeactivateMode(OCCTSelectorRef sel, int32_t shapeId, int32_t mode);
+
+/// Check if a selection mode is active for a shape.
+bool OCCTSelectorIsModeActive(OCCTSelectorRef sel, int32_t shapeId, int32_t mode);
+
+/// Set pixel tolerance for picking near edges/vertices (default 2).
+void OCCTSelectorSetPixelTolerance(OCCTSelectorRef sel, int32_t tolerance);
+int32_t OCCTSelectorGetPixelTolerance(OCCTSelectorRef sel);
 
 int32_t OCCTSelectorPick(OCCTSelectorRef sel, OCCTCameraRef cam,
                          double viewW, double viewH,
@@ -1212,6 +1228,49 @@ int32_t OCCTSelectorPickRect(OCCTSelectorRef sel, OCCTCameraRef cam,
                              double viewW, double viewH,
                              double xMin, double yMin, double xMax, double yMax,
                              OCCTPickResult* out, int32_t maxResults);
+
+// MARK: - Display Drawer (Metal Visualization)
+
+typedef struct OCCTDrawer* OCCTDrawerRef;
+
+OCCTDrawerRef OCCTDrawerCreate(void);
+void OCCTDrawerDestroy(OCCTDrawerRef drawer);
+
+/// Chordal deviation coefficient (relative to bounding box). Default ~0.001.
+void OCCTDrawerSetDeviationCoefficient(OCCTDrawerRef drawer, double coeff);
+double OCCTDrawerGetDeviationCoefficient(OCCTDrawerRef drawer);
+
+/// Angular deviation in radians. Default 20 degrees (M_PI/9).
+void OCCTDrawerSetDeviationAngle(OCCTDrawerRef drawer, double angle);
+double OCCTDrawerGetDeviationAngle(OCCTDrawerRef drawer);
+
+/// Maximal chordal deviation (absolute). Applies when type of deflection is absolute.
+void OCCTDrawerSetMaximalChordialDeviation(OCCTDrawerRef drawer, double deviation);
+double OCCTDrawerGetMaximalChordialDeviation(OCCTDrawerRef drawer);
+
+/// Type of deflection: 0=relative (default), 1=absolute.
+void OCCTDrawerSetTypeOfDeflection(OCCTDrawerRef drawer, int32_t type);
+int32_t OCCTDrawerGetTypeOfDeflection(OCCTDrawerRef drawer);
+
+/// Auto-triangulation on/off. Default true.
+void OCCTDrawerSetAutoTriangulation(OCCTDrawerRef drawer, bool on);
+bool OCCTDrawerGetAutoTriangulation(OCCTDrawerRef drawer);
+
+/// Number of iso-parameter lines (U and V). Default 1.
+void OCCTDrawerSetIsoOnTriangulation(OCCTDrawerRef drawer, bool on);
+bool OCCTDrawerGetIsoOnTriangulation(OCCTDrawerRef drawer);
+
+/// Discretisation (number of points for curves). Default 30.
+void OCCTDrawerSetDiscretisation(OCCTDrawerRef drawer, int32_t value);
+int32_t OCCTDrawerGetDiscretisation(OCCTDrawerRef drawer);
+
+/// Face boundary display on/off. Default false.
+void OCCTDrawerSetFaceBoundaryDraw(OCCTDrawerRef drawer, bool on);
+bool OCCTDrawerGetFaceBoundaryDraw(OCCTDrawerRef drawer);
+
+/// Wire frame display on/off. Default true.
+void OCCTDrawerSetWireDraw(OCCTDrawerRef drawer, bool on);
+bool OCCTDrawerGetWireDraw(OCCTDrawerRef drawer);
 
 // MARK: - Clip Plane (Metal Visualization)
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1129,6 +1129,90 @@ OCCTShapeRef OCCTShapeRemoveSmallFaces(OCCTShapeRef shape, double minArea);
 /// @return Simplified shape, or NULL on failure
 OCCTShapeRef OCCTShapeSimplify(OCCTShapeRef shape, double tolerance);
 
+// MARK: - Camera (Metal Visualization)
+
+typedef struct OCCTCamera* OCCTCameraRef;
+
+OCCTCameraRef OCCTCameraCreate(void);
+void          OCCTCameraDestroy(OCCTCameraRef cam);
+
+void OCCTCameraSetEye(OCCTCameraRef cam, double x, double y, double z);
+void OCCTCameraGetEye(OCCTCameraRef cam, double* x, double* y, double* z);
+void OCCTCameraSetCenter(OCCTCameraRef cam, double x, double y, double z);
+void OCCTCameraGetCenter(OCCTCameraRef cam, double* x, double* y, double* z);
+void OCCTCameraSetUp(OCCTCameraRef cam, double x, double y, double z);
+void OCCTCameraGetUp(OCCTCameraRef cam, double* x, double* y, double* z);
+
+void OCCTCameraSetProjectionType(OCCTCameraRef cam, int type);
+int  OCCTCameraGetProjectionType(OCCTCameraRef cam);
+void OCCTCameraSetFOV(OCCTCameraRef cam, double degrees);
+double OCCTCameraGetFOV(OCCTCameraRef cam);
+void OCCTCameraSetScale(OCCTCameraRef cam, double scale);
+double OCCTCameraGetScale(OCCTCameraRef cam);
+void OCCTCameraSetZRange(OCCTCameraRef cam, double zNear, double zFar);
+void OCCTCameraGetZRange(OCCTCameraRef cam, double* zNear, double* zFar);
+void OCCTCameraSetAspect(OCCTCameraRef cam, double aspect);
+
+void OCCTCameraGetProjectionMatrix(OCCTCameraRef cam, float* out16);
+void OCCTCameraGetViewMatrix(OCCTCameraRef cam, float* out16);
+
+void OCCTCameraProject(OCCTCameraRef cam, double wX, double wY, double wZ,
+                       double* sX, double* sY, double* sZ);
+void OCCTCameraUnproject(OCCTCameraRef cam, double sX, double sY, double sZ,
+                         double* wX, double* wY, double* wZ);
+
+void OCCTCameraFitBBox(OCCTCameraRef cam, double xMin, double yMin, double zMin,
+                       double xMax, double yMax, double zMax);
+
+// MARK: - Presentation Mesh (Metal Visualization)
+
+typedef struct {
+    float* vertices;
+    int32_t vertexCount;
+    int32_t* indices;
+    int32_t triangleCount;
+} OCCTShadedMeshData;
+
+typedef struct {
+    float* vertices;
+    int32_t vertexCount;
+    int32_t* segmentStarts;
+    int32_t segmentCount;
+} OCCTEdgeMeshData;
+
+bool OCCTShapeGetShadedMesh(OCCTShapeRef shape, double deflection, OCCTShadedMeshData* out);
+void OCCTShadedMeshDataFree(OCCTShadedMeshData* data);
+
+bool OCCTShapeGetEdgeMesh(OCCTShapeRef shape, double deflection, OCCTEdgeMeshData* out);
+void OCCTEdgeMeshDataFree(OCCTEdgeMeshData* data);
+
+// MARK: - Selector (Metal Visualization)
+
+typedef struct OCCTSelector* OCCTSelectorRef;
+
+typedef struct {
+    int32_t shapeId;
+    double depth;
+    double pointX, pointY, pointZ;
+} OCCTPickResult;
+
+OCCTSelectorRef OCCTSelectorCreate(void);
+void            OCCTSelectorDestroy(OCCTSelectorRef sel);
+
+bool OCCTSelectorAddShape(OCCTSelectorRef sel, OCCTShapeRef shape, int32_t shapeId);
+bool OCCTSelectorRemoveShape(OCCTSelectorRef sel, int32_t shapeId);
+void OCCTSelectorClear(OCCTSelectorRef sel);
+
+int32_t OCCTSelectorPick(OCCTSelectorRef sel, OCCTCameraRef cam,
+                         double viewW, double viewH,
+                         double pixelX, double pixelY,
+                         OCCTPickResult* out, int32_t maxResults);
+
+int32_t OCCTSelectorPickRect(OCCTSelectorRef sel, OCCTCameraRef cam,
+                             double viewW, double viewH,
+                             double xMin, double yMin, double xMax, double yMax,
+                             OCCTPickResult* out, int32_t maxResults);
+
 // MARK: - Advanced Blends & Surface Filling (v0.14.0)
 
 /// Apply variable radius fillet to a specific edge

--- a/Sources/OCCTSwift/Camera.swift
+++ b/Sources/OCCTSwift/Camera.swift
@@ -1,0 +1,145 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// A 3D camera backed by OpenCASCADE Graphic3d_Camera.
+///
+/// Provides projection/view matrices in Metal-compatible format (column-major,
+/// zero-to-one depth range) and project/unproject utilities for coordinate conversion.
+public final class Camera: @unchecked Sendable {
+    let handle: OCCTCameraRef
+
+    public enum ProjectionType: Int32, Sendable {
+        case perspective = 0
+        case orthographic = 1
+    }
+
+    public init() {
+        handle = OCCTCameraCreate()
+    }
+
+    deinit {
+        OCCTCameraDestroy(handle)
+    }
+
+    // MARK: - Position
+
+    public var eye: SIMD3<Double> {
+        get {
+            var x = 0.0, y = 0.0, z = 0.0
+            OCCTCameraGetEye(handle, &x, &y, &z)
+            return SIMD3(x, y, z)
+        }
+        set {
+            OCCTCameraSetEye(handle, newValue.x, newValue.y, newValue.z)
+        }
+    }
+
+    public var center: SIMD3<Double> {
+        get {
+            var x = 0.0, y = 0.0, z = 0.0
+            OCCTCameraGetCenter(handle, &x, &y, &z)
+            return SIMD3(x, y, z)
+        }
+        set {
+            OCCTCameraSetCenter(handle, newValue.x, newValue.y, newValue.z)
+        }
+    }
+
+    public var up: SIMD3<Double> {
+        get {
+            var x = 0.0, y = 0.0, z = 0.0
+            OCCTCameraGetUp(handle, &x, &y, &z)
+            return SIMD3(x, y, z)
+        }
+        set {
+            OCCTCameraSetUp(handle, newValue.x, newValue.y, newValue.z)
+        }
+    }
+
+    // MARK: - Projection Parameters
+
+    public var projectionType: ProjectionType {
+        get {
+            ProjectionType(rawValue: Int32(OCCTCameraGetProjectionType(handle))) ?? .perspective
+        }
+        set {
+            OCCTCameraSetProjectionType(handle, Int32(newValue.rawValue))
+        }
+    }
+
+    public var fieldOfView: Double {
+        get { OCCTCameraGetFOV(handle) }
+        set { OCCTCameraSetFOV(handle, newValue) }
+    }
+
+    public var scale: Double {
+        get { OCCTCameraGetScale(handle) }
+        set { OCCTCameraSetScale(handle, newValue) }
+    }
+
+    public var zRange: (near: Double, far: Double) {
+        get {
+            var zNear = 0.0, zFar = 0.0
+            OCCTCameraGetZRange(handle, &zNear, &zFar)
+            return (zNear, zFar)
+        }
+        set {
+            OCCTCameraSetZRange(handle, newValue.near, newValue.far)
+        }
+    }
+
+    public var aspect: Double {
+        get { 1.0 } // Write-only in OCCT; getter not exposed
+        set { OCCTCameraSetAspect(handle, newValue) }
+    }
+
+    // MARK: - Matrices (Metal-compatible, column-major, [0,1] depth)
+
+    public var projectionMatrix: simd_float4x4 {
+        var data = [Float](repeating: 0, count: 16)
+        OCCTCameraGetProjectionMatrix(handle, &data)
+        return simd_float4x4(
+            SIMD4(data[0], data[1], data[2], data[3]),
+            SIMD4(data[4], data[5], data[6], data[7]),
+            SIMD4(data[8], data[9], data[10], data[11]),
+            SIMD4(data[12], data[13], data[14], data[15])
+        )
+    }
+
+    public var viewMatrix: simd_float4x4 {
+        var data = [Float](repeating: 0, count: 16)
+        OCCTCameraGetViewMatrix(handle, &data)
+        return simd_float4x4(
+            SIMD4(data[0], data[1], data[2], data[3]),
+            SIMD4(data[4], data[5], data[6], data[7]),
+            SIMD4(data[8], data[9], data[10], data[11]),
+            SIMD4(data[12], data[13], data[14], data[15])
+        )
+    }
+
+    // MARK: - Coordinate Conversion
+
+    /// Project a world-space point to normalized screen coordinates.
+    public func project(_ point: SIMD3<Double>) -> SIMD3<Double> {
+        var sX = 0.0, sY = 0.0, sZ = 0.0
+        OCCTCameraProject(handle, point.x, point.y, point.z, &sX, &sY, &sZ)
+        return SIMD3(sX, sY, sZ)
+    }
+
+    /// Unproject a screen-space point to world coordinates.
+    public func unproject(_ point: SIMD3<Double>) -> SIMD3<Double> {
+        var wX = 0.0, wY = 0.0, wZ = 0.0
+        OCCTCameraUnproject(handle, point.x, point.y, point.z, &wX, &wY, &wZ)
+        return SIMD3(wX, wY, wZ)
+    }
+
+    // MARK: - Fitting
+
+    /// Adjust camera to fit the given axis-aligned bounding box in view.
+    public func fit(boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)) {
+        OCCTCameraFitBBox(handle,
+                          boundingBox.min.x, boundingBox.min.y, boundingBox.min.z,
+                          boundingBox.max.x, boundingBox.max.y, boundingBox.max.z)
+    }
+}

--- a/Sources/OCCTSwift/ClipPlane.swift
+++ b/Sources/OCCTSwift/ClipPlane.swift
@@ -1,0 +1,166 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// A clipping plane that can be used to cut geometry during rendering.
+///
+/// Wraps OCCT's `Graphic3d_ClipPlane`. The plane equation `Ax + By + Cz + D = 0`
+/// defines the half-space: points with `Ax + By + Cz + D > 0` are visible.
+///
+/// For Metal rendering, the equation maps directly to `[[clip_distance]]` in the
+/// vertex shader. Apple Silicon supports up to 8 hardware-accelerated clip distances.
+public final class ClipPlane: @unchecked Sendable {
+    let handle: OCCTClipPlaneRef
+
+    /// Result of probing a point or bounding box against the clip plane.
+    public enum ClipState: Int32, Sendable {
+        /// Fully outside the clipping region (should be discarded).
+        case out = 0
+        /// Fully inside the clipping region (not clipped).
+        case `in` = 1
+        /// On the boundary or partially clipped.
+        case on = 2
+    }
+
+    /// Standard hatch patterns for capping surfaces.
+    public enum HatchStyle: Int32, Sendable {
+        case solid = 0
+        case gridDiagonal = 1
+        case gridDiagonalWide = 2
+        case grid = 3
+        case gridWide = 4
+        case diagonal45 = 5
+        case diagonal135 = 6
+        case horizontal = 7
+        case vertical = 8
+        case diagonal45Wide = 9
+        case diagonal135Wide = 10
+        case horizontalWide = 11
+        case verticalWide = 12
+    }
+
+    /// Create a clip plane from the equation `Ax + By + Cz + D = 0`.
+    ///
+    /// - Parameter equation: The plane equation coefficients (A, B, C, D).
+    public init(equation: SIMD4<Double>) {
+        handle = OCCTClipPlaneCreate(equation.x, equation.y, equation.z, equation.w)
+    }
+
+    /// Create a clip plane from a normal vector and distance from origin.
+    ///
+    /// The equation is `normal.x * x + normal.y * y + normal.z * z + distance = 0`.
+    /// - Parameters:
+    ///   - normal: The plane normal (will be used as-is, should be normalized).
+    ///   - distance: Signed distance from the origin along the normal.
+    public init(normal: SIMD3<Double>, distance: Double) {
+        handle = OCCTClipPlaneCreate(normal.x, normal.y, normal.z, distance)
+    }
+
+    deinit {
+        OCCTClipPlaneDestroy(handle)
+    }
+
+    // MARK: - Equation
+
+    /// The plane equation coefficients (A, B, C, D) where `Ax + By + Cz + D = 0`.
+    public var equation: SIMD4<Double> {
+        get {
+            var a = 0.0, b = 0.0, c = 0.0, d = 0.0
+            OCCTClipPlaneGetEquation(handle, &a, &b, &c, &d)
+            return SIMD4(a, b, c, d)
+        }
+        set {
+            OCCTClipPlaneSetEquation(handle, newValue.x, newValue.y, newValue.z, newValue.w)
+        }
+    }
+
+    /// The reversed equation (negated coefficients), useful for back-face clipping.
+    public var reversedEquation: SIMD4<Double> {
+        var a = 0.0, b = 0.0, c = 0.0, d = 0.0
+        OCCTClipPlaneGetReversedEquation(handle, &a, &b, &c, &d)
+        return SIMD4(a, b, c, d)
+    }
+
+    // MARK: - Enable/Disable
+
+    /// Whether the clip plane is active.
+    public var isOn: Bool {
+        get { OCCTClipPlaneIsOn(handle) }
+        set { OCCTClipPlaneSetOn(handle, newValue) }
+    }
+
+    // MARK: - Capping
+
+    /// Whether capping (cross-section fill) is enabled.
+    ///
+    /// When enabled, the clipped cross-section surface is rendered. In Metal,
+    /// this is implemented using the stencil buffer technique:
+    /// 1. Render back faces with stencil increment
+    /// 2. Render front faces with stencil decrement
+    /// 3. Fill where stencil != 0 with capping material
+    public var isCapping: Bool {
+        get { OCCTClipPlaneIsCapping(handle) }
+        set { OCCTClipPlaneSetCapping(handle, newValue) }
+    }
+
+    /// The color used for the capping surface (RGB, values in 0...1).
+    public var cappingColor: SIMD3<Double> {
+        get {
+            var r = 0.0, g = 0.0, b = 0.0
+            OCCTClipPlaneGetCappingColor(handle, &r, &g, &b)
+            return SIMD3(r, g, b)
+        }
+        set {
+            OCCTClipPlaneSetCappingColor(handle, newValue.x, newValue.y, newValue.z)
+        }
+    }
+
+    /// The hatch pattern used on the capping surface.
+    public var hatchStyle: HatchStyle {
+        get { HatchStyle(rawValue: OCCTClipPlaneGetCappingHatch(handle)) ?? .solid }
+        set { OCCTClipPlaneSetCappingHatch(handle, newValue.rawValue) }
+    }
+
+    /// Whether hatch pattern rendering is enabled on the capping surface.
+    public var isHatchOn: Bool {
+        get { OCCTClipPlaneIsCappingHatchOn(handle) }
+        set { OCCTClipPlaneSetCappingHatchOn(handle, newValue) }
+    }
+
+    // MARK: - Probing
+
+    /// Test a world-space point against the clip plane (or chain of planes).
+    ///
+    /// - Parameter point: The 3D point to test.
+    /// - Returns: The clip state indicating if the point is inside, outside, or on the boundary.
+    public func probe(point: SIMD3<Double>) -> ClipState {
+        ClipState(rawValue: OCCTClipPlaneProbePoint(handle, point.x, point.y, point.z)) ?? .out
+    }
+
+    /// Test an axis-aligned bounding box against the clip plane (or chain of planes).
+    ///
+    /// - Parameter box: The bounding box defined by (min, max) corners.
+    /// - Returns: The clip state indicating if the box is fully inside, fully outside, or partially clipped.
+    public func probe(box: (min: SIMD3<Double>, max: SIMD3<Double>)) -> ClipState {
+        ClipState(rawValue: OCCTClipPlaneProbeBox(handle,
+            box.min.x, box.min.y, box.min.z,
+            box.max.x, box.max.y, box.max.z)) ?? .out
+    }
+
+    // MARK: - Chaining
+
+    /// Chain another clip plane for logical AND clipping (conjunction).
+    ///
+    /// When planes are chained, a point must satisfy ALL planes in the chain
+    /// to be considered visible. This creates complex clipping regions.
+    ///
+    /// - Parameter plane: The next plane in the chain, or `nil` to clear.
+    public func chainNext(_ plane: ClipPlane?) {
+        OCCTClipPlaneSetChainNext(handle, plane?.handle)
+    }
+
+    /// The number of planes in the forward chain (including this one).
+    public var chainLength: Int {
+        Int(OCCTClipPlaneChainLength(handle))
+    }
+}

--- a/Sources/OCCTSwift/DisplayDrawer.swift
+++ b/Sources/OCCTSwift/DisplayDrawer.swift
@@ -1,0 +1,102 @@
+import Foundation
+import OCCTBridge
+
+/// Display attribute controller for tessellation quality and wireframe rendering.
+///
+/// Wraps OCCT's `Prs3d_Drawer`, which controls how shapes are tessellated
+/// and displayed. In a Metal renderer, these settings affect mesh generation
+/// quality and which edge types are extracted.
+public final class DisplayDrawer: @unchecked Sendable {
+    let handle: OCCTDrawerRef
+
+    /// Type of deflection control for tessellation.
+    public enum DeflectionType: Int32, Sendable {
+        /// Deviation is relative to the bounding box size.
+        case relative = 0
+        /// Deviation is an absolute distance value.
+        case absolute = 1
+    }
+
+    public init() {
+        handle = OCCTDrawerCreate()
+    }
+
+    deinit {
+        OCCTDrawerDestroy(handle)
+    }
+
+    // MARK: - Tessellation Quality
+
+    /// Chordal deviation coefficient (relative to bounding box diagonal).
+    ///
+    /// Lower values produce finer tessellation. Default is approximately 0.001.
+    /// Only applies when ``deflectionType`` is `.relative`.
+    public var deviationCoefficient: Double {
+        get { OCCTDrawerGetDeviationCoefficient(handle) }
+        set { OCCTDrawerSetDeviationCoefficient(handle, newValue) }
+    }
+
+    /// Angular deviation in radians.
+    ///
+    /// Controls how finely curved surfaces are approximated.
+    /// Default is approximately 0.35 radians (20 degrees).
+    public var deviationAngle: Double {
+        get { OCCTDrawerGetDeviationAngle(handle) }
+        set { OCCTDrawerSetDeviationAngle(handle, newValue) }
+    }
+
+    /// Maximal chordal deviation as an absolute distance.
+    ///
+    /// The maximum distance between the tessellation and the actual surface.
+    /// Only applies when ``deflectionType`` is `.absolute`.
+    public var maximalChordialDeviation: Double {
+        get { OCCTDrawerGetMaximalChordialDeviation(handle) }
+        set { OCCTDrawerSetMaximalChordialDeviation(handle, newValue) }
+    }
+
+    /// Type of deflection control.
+    ///
+    /// - `.relative`: Deviation is computed relative to the bounding box size.
+    /// - `.absolute`: Deviation is a fixed distance value.
+    public var deflectionType: DeflectionType {
+        get { DeflectionType(rawValue: OCCTDrawerGetTypeOfDeflection(handle)) ?? .relative }
+        set { OCCTDrawerSetTypeOfDeflection(handle, newValue.rawValue) }
+    }
+
+    /// Whether automatic triangulation is enabled. Default is `true`.
+    public var autoTriangulation: Bool {
+        get { OCCTDrawerGetAutoTriangulation(handle) }
+        set { OCCTDrawerSetAutoTriangulation(handle, newValue) }
+    }
+
+    // MARK: - Isolines and Discretisation
+
+    /// Whether iso-parameter lines are drawn on triangulated surfaces.
+    public var isoOnTriangulation: Bool {
+        get { OCCTDrawerGetIsoOnTriangulation(handle) }
+        set { OCCTDrawerSetIsoOnTriangulation(handle, newValue) }
+    }
+
+    /// Number of discretisation points for curve approximation. Default is 30.
+    public var discretisation: Int32 {
+        get { OCCTDrawerGetDiscretisation(handle) }
+        set { OCCTDrawerSetDiscretisation(handle, newValue) }
+    }
+
+    // MARK: - Edge Display
+
+    /// Whether face boundary edges are drawn. Default is `false`.
+    ///
+    /// When enabled, edges at face boundaries (where two faces meet)
+    /// are included in wireframe rendering.
+    public var faceBoundaryDraw: Bool {
+        get { OCCTDrawerGetFaceBoundaryDraw(handle) }
+        set { OCCTDrawerSetFaceBoundaryDraw(handle, newValue) }
+    }
+
+    /// Whether wireframe edges are drawn. Default is `true`.
+    public var wireDraw: Bool {
+        get { OCCTDrawerGetWireDraw(handle) }
+        set { OCCTDrawerSetWireDraw(handle, newValue) }
+    }
+}

--- a/Sources/OCCTSwift/PresentationMesh.swift
+++ b/Sources/OCCTSwift/PresentationMesh.swift
@@ -1,0 +1,112 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// Interleaved triangle mesh data suitable for Metal vertex buffers.
+///
+/// Vertices and normals are stored per-vertex. Indices define triangles
+/// (3 indices per triangle).
+public struct ShadedMeshData: Sendable {
+    /// Per-vertex positions.
+    public let vertices: [SIMD3<Float>]
+
+    /// Per-vertex normals (same count as vertices).
+    public let normals: [SIMD3<Float>]
+
+    /// Triangle indices (3 per triangle, referencing into vertices/normals).
+    public let indices: [UInt32]
+
+    /// Number of triangles.
+    public var triangleCount: Int { indices.count / 3 }
+}
+
+/// Edge wireframe data suitable for Metal line rendering.
+///
+/// Vertices are 3D positions. `segmentStarts` marks where each edge polyline
+/// begins in the vertex array. Segment `i` spans vertices from
+/// `segmentStarts[i]` to `segmentStarts[i+1] - 1` (or end of array for the last).
+public struct EdgeMeshData: Sendable {
+    /// All edge polyline vertices.
+    public let vertices: [SIMD3<Float>]
+
+    /// Index where each edge polyline begins.
+    public let segmentStarts: [Int]
+
+    /// Number of edge segments.
+    public var segmentCount: Int { segmentStarts.count }
+}
+
+public extension Shape {
+    /// Extract a triangulated mesh from the shape for shaded rendering.
+    ///
+    /// - Parameter deflection: Tessellation chord deviation. Smaller values produce
+    ///   finer meshes. Default is 0.1.
+    /// - Returns: Shaded mesh data, or `nil` if tessellation fails.
+    func shadedMesh(deflection: Double = 0.1) -> ShadedMeshData? {
+        var data = OCCTShadedMeshData()
+        guard OCCTShapeGetShadedMesh(handle, deflection, &data) else {
+            return nil
+        }
+        defer { OCCTShadedMeshDataFree(&data) }
+
+        let vertCount = Int(data.vertexCount)
+        let triCount = Int(data.triangleCount)
+
+        // Deinterleave positions and normals from the packed buffer
+        var positions = [SIMD3<Float>]()
+        var normals = [SIMD3<Float>]()
+        positions.reserveCapacity(vertCount)
+        normals.reserveCapacity(vertCount)
+
+        for i in 0..<vertCount {
+            let base = i * 6
+            positions.append(SIMD3(data.vertices[base],
+                                   data.vertices[base + 1],
+                                   data.vertices[base + 2]))
+            normals.append(SIMD3(data.vertices[base + 3],
+                                  data.vertices[base + 4],
+                                  data.vertices[base + 5]))
+        }
+
+        // Copy indices
+        var indices = [UInt32]()
+        indices.reserveCapacity(triCount * 3)
+        for i in 0..<(triCount * 3) {
+            indices.append(UInt32(data.indices[i]))
+        }
+
+        return ShadedMeshData(vertices: positions, normals: normals, indices: indices)
+    }
+
+    /// Extract edge wireframe polylines from the shape.
+    ///
+    /// - Parameter deflection: Tessellation chord deviation. Default is 0.1.
+    /// - Returns: Edge mesh data, or `nil` if extraction fails.
+    func edgeMesh(deflection: Double = 0.1) -> EdgeMeshData? {
+        var data = OCCTEdgeMeshData()
+        guard OCCTShapeGetEdgeMesh(handle, deflection, &data) else {
+            return nil
+        }
+        defer { OCCTEdgeMeshDataFree(&data) }
+
+        let vertCount = Int(data.vertexCount)
+        let segCount = Int(data.segmentCount)
+
+        var positions = [SIMD3<Float>]()
+        positions.reserveCapacity(vertCount)
+        for i in 0..<vertCount {
+            let base = i * 3
+            positions.append(SIMD3(data.vertices[base],
+                                   data.vertices[base + 1],
+                                   data.vertices[base + 2]))
+        }
+
+        var starts = [Int]()
+        starts.reserveCapacity(segCount)
+        for i in 0..<segCount {
+            starts.append(Int(data.segmentStarts[i]))
+        }
+
+        return EdgeMeshData(vertices: positions, segmentStarts: starts)
+    }
+}

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -1,0 +1,101 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// BVH-accelerated hit testing for interactive picking without OpenGL.
+///
+/// Manages a set of shapes identified by integer IDs and performs
+/// point or rectangle picking against them using a camera's projection.
+public final class Selector: @unchecked Sendable {
+    let handle: OCCTSelectorRef
+
+    /// Result of a pick operation.
+    public struct PickResult: Sendable {
+        /// The shape ID that was assigned when adding the shape.
+        public let shapeId: Int32
+
+        /// Depth of the hit (distance from camera).
+        public let depth: Double
+
+        /// 3D world-space point where the pick intersected.
+        public let point: SIMD3<Double>
+    }
+
+    public init() {
+        handle = OCCTSelectorCreate()
+    }
+
+    deinit {
+        OCCTSelectorDestroy(handle)
+    }
+
+    /// Add a shape to the selector with a unique integer ID.
+    ///
+    /// If a shape with the same ID already exists, it is replaced.
+    /// - Returns: `true` if the shape was added successfully.
+    @discardableResult
+    public func add(shape: Shape, id: Int32) -> Bool {
+        OCCTSelectorAddShape(handle, shape.handle, id)
+    }
+
+    /// Remove a shape by its ID.
+    /// - Returns: `true` if the shape was found and removed.
+    @discardableResult
+    public func remove(id: Int32) -> Bool {
+        OCCTSelectorRemoveShape(handle, id)
+    }
+
+    /// Remove all shapes from the selector.
+    public func clearAll() {
+        OCCTSelectorClear(handle)
+    }
+
+    /// Pick shapes at a single pixel coordinate.
+    ///
+    /// - Parameters:
+    ///   - pixel: Pixel coordinates in the viewport.
+    ///   - camera: The camera providing projection/view transforms.
+    ///   - viewSize: Viewport size in pixels (width, height).
+    ///   - maxResults: Maximum number of results to return (default 32).
+    /// - Returns: Array of pick results sorted by depth (nearest first).
+    public func pick(at pixel: SIMD2<Double>,
+                     camera: Camera,
+                     viewSize: SIMD2<Double>,
+                     maxResults: Int = 32) -> [PickResult] {
+        var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
+        let count = OCCTSelectorPick(handle, camera.handle,
+                                     viewSize.x, viewSize.y,
+                                     pixel.x, pixel.y,
+                                     &buffer, Int32(maxResults))
+        return (0..<Int(count)).map { i in
+            PickResult(shapeId: buffer[i].shapeId,
+                       depth: buffer[i].depth,
+                       point: SIMD3(buffer[i].pointX, buffer[i].pointY, buffer[i].pointZ))
+        }
+    }
+
+    /// Pick shapes within a rectangular region.
+    ///
+    /// - Parameters:
+    ///   - rect: Rectangle defined by (min, max) pixel coordinates.
+    ///   - camera: The camera providing projection/view transforms.
+    ///   - viewSize: Viewport size in pixels (width, height).
+    ///   - maxResults: Maximum number of results to return (default 32).
+    /// - Returns: Array of pick results for all shapes intersecting the rectangle.
+    public func pick(rect: (min: SIMD2<Double>, max: SIMD2<Double>),
+                     camera: Camera,
+                     viewSize: SIMD2<Double>,
+                     maxResults: Int = 32) -> [PickResult] {
+        var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
+        let count = OCCTSelectorPickRect(handle, camera.handle,
+                                         viewSize.x, viewSize.y,
+                                         rect.min.x, rect.min.y,
+                                         rect.max.x, rect.max.y,
+                                         &buffer, Int32(maxResults))
+        return (0..<Int(count)).map { i in
+            PickResult(shapeId: buffer[i].shapeId,
+                       depth: buffer[i].depth,
+                       point: SIMD3(buffer[i].pointX, buffer[i].pointY, buffer[i].pointZ))
+        }
+    }
+}

--- a/Sources/OCCTSwift/ZLayerSettings.swift
+++ b/Sources/OCCTSwift/ZLayerSettings.swift
@@ -1,0 +1,184 @@
+import Foundation
+import simd
+import OCCTBridge
+
+/// Configuration for a rendering Z-layer that controls depth testing, polygon offset,
+/// and other render-pass properties.
+///
+/// Wraps OCCT's `Graphic3d_ZLayerSettings`. In a Metal renderer, these settings map to:
+/// - `MTLDepthStencilDescriptor` (depth test/write)
+/// - Depth attachment `loadAction` (clear depth)
+/// - `setDepthBias()` on `MTLRenderCommandEncoder` (polygon offset)
+/// - Render pass ordering (layer priority)
+public final class ZLayerSettings: @unchecked Sendable {
+    let handle: OCCTZLayerSettingsRef
+
+    // MARK: - Predefined Layer IDs
+
+    /// 2D underlay layer (drawn behind everything).
+    public static let bottomOSD: Int32 = -5
+    /// Main 3D scene layer (default).
+    public static let `default`: Int32 = 0
+    /// 3D overlay layer (inherits depth from default layer).
+    public static let top: Int32 = -2
+    /// 3D overlay layer (independent depth buffer).
+    public static let topmost: Int32 = -3
+    /// 2D overlay layer for annotations and UI.
+    public static let topOSD: Int32 = -4
+
+    /// Polygon offset mode controlling which primitives receive the offset.
+    public enum PolygonOffsetMode: Int32, Sendable {
+        case off = 0
+        /// Apply offset to filled polygons (shaded faces).
+        case fill = 1
+        /// Apply offset to line primitives.
+        case line = 2
+        /// Apply offset to point primitives.
+        case point = 4
+        /// Apply offset to all primitive types.
+        case all = 7
+    }
+
+    /// Polygon offset parameters for depth bias.
+    ///
+    /// Maps to Metal's `setDepthBias(depthBias:slopeScale:clamp:)` on the render encoder.
+    /// - `factor` corresponds to `slopeScale`
+    /// - `units` corresponds to `depthBias`
+    public struct PolygonOffset: Sendable {
+        public var mode: PolygonOffsetMode
+        public var factor: Float
+        public var units: Float
+
+        public init(mode: PolygonOffsetMode = .off, factor: Float = 0, units: Float = 0) {
+            self.mode = mode
+            self.factor = factor
+            self.units = units
+        }
+    }
+
+    public init() {
+        handle = OCCTZLayerSettingsCreate()
+    }
+
+    deinit {
+        OCCTZLayerSettingsDestroy(handle)
+    }
+
+    // MARK: - Depth
+
+    /// Whether depth testing is enabled for this layer.
+    public var depthTestEnabled: Bool {
+        get { OCCTZLayerSettingsGetDepthTest(handle) }
+        set { OCCTZLayerSettingsSetDepthTest(handle, newValue) }
+    }
+
+    /// Whether depth writing is enabled for this layer.
+    public var depthWriteEnabled: Bool {
+        get { OCCTZLayerSettingsGetDepthWrite(handle) }
+        set { OCCTZLayerSettingsSetDepthWrite(handle, newValue) }
+    }
+
+    /// Whether to clear the depth buffer before rendering this layer.
+    ///
+    /// In Metal, this maps to `loadAction = .clear` on the depth attachment
+    /// for the layer's render pass.
+    public var clearDepth: Bool {
+        get { OCCTZLayerSettingsGetClearDepth(handle) }
+        set { OCCTZLayerSettingsSetClearDepth(handle, newValue) }
+    }
+
+    // MARK: - Polygon Offset
+
+    /// Polygon offset (depth bias) parameters for this layer.
+    public var polygonOffset: PolygonOffset {
+        get {
+            var mode: Int32 = 0, factor: Float = 0, units: Float = 0
+            OCCTZLayerSettingsGetPolygonOffset(handle, &mode, &factor, &units)
+            return PolygonOffset(mode: PolygonOffsetMode(rawValue: mode) ?? .off,
+                                 factor: factor, units: units)
+        }
+        set {
+            OCCTZLayerSettingsSetPolygonOffset(handle, newValue.mode.rawValue,
+                                               newValue.factor, newValue.units)
+        }
+    }
+
+    /// Set a minimal positive depth offset (factor=1, units=1).
+    ///
+    /// Useful for pushing coplanar geometry slightly away from the camera.
+    public func setDepthOffsetPositive() {
+        OCCTZLayerSettingsSetDepthOffsetPositive(handle)
+    }
+
+    /// Set a minimal negative depth offset (factor=1, units=-1).
+    ///
+    /// Useful for pulling coplanar geometry slightly toward the camera
+    /// (e.g., wireframe overlay on shaded geometry).
+    public func setDepthOffsetNegative() {
+        OCCTZLayerSettingsSetDepthOffsetNegative(handle)
+    }
+
+    // MARK: - Rendering Options
+
+    /// Whether this layer is drawn after all normal layers (immediate mode).
+    public var isImmediate: Bool {
+        get { OCCTZLayerSettingsGetImmediate(handle) }
+        set { OCCTZLayerSettingsSetImmediate(handle, newValue) }
+    }
+
+    /// Whether objects in this layer participate in ray tracing.
+    public var isRaytracable: Bool {
+        get { OCCTZLayerSettingsGetRaytracable(handle) }
+        set { OCCTZLayerSettingsSetRaytracable(handle, newValue) }
+    }
+
+    /// Whether environment texture is applied to objects in this layer.
+    public var useEnvironmentTexture: Bool {
+        get { OCCTZLayerSettingsGetEnvironmentTexture(handle) }
+        set { OCCTZLayerSettingsSetEnvironmentTexture(handle, newValue) }
+    }
+
+    /// Whether objects in this layer are rendered in the depth pre-pass.
+    public var renderInDepthPrepass: Bool {
+        get { OCCTZLayerSettingsGetRenderInDepthPrepass(handle) }
+        set { OCCTZLayerSettingsSetRenderInDepthPrepass(handle, newValue) }
+    }
+
+    // MARK: - Culling
+
+    /// Distance-based culling threshold.
+    ///
+    /// Objects farther than this distance from the camera origin are culled.
+    /// A very large value (default) disables distance culling.
+    public var cullingDistance: Double {
+        get { OCCTZLayerSettingsGetCullingDistance(handle) }
+        set { OCCTZLayerSettingsSetCullingDistance(handle, newValue) }
+    }
+
+    /// Size-based culling threshold.
+    ///
+    /// Objects smaller than this screen-space size are culled.
+    /// A very large value (default) disables size culling.
+    public var cullingSize: Double {
+        get { OCCTZLayerSettingsGetCullingSize(handle) }
+        set { OCCTZLayerSettingsSetCullingSize(handle, newValue) }
+    }
+
+    // MARK: - Origin
+
+    /// Layer origin for coordinate precision in large scenes.
+    ///
+    /// When working with very large coordinates (e.g., geospatial), setting
+    /// a layer origin near the camera avoids floating-point precision issues
+    /// in the model-view matrix.
+    public var origin: SIMD3<Double> {
+        get {
+            var x = 0.0, y = 0.0, z = 0.0
+            OCCTZLayerSettingsGetOrigin(handle, &x, &y, &z)
+            return SIMD3(x, y, z)
+        }
+        set {
+            OCCTZLayerSettingsSetOrigin(handle, newValue.x, newValue.y, newValue.z)
+        }
+    }
+}

--- a/Tests/OCCTSwiftTests/ShapeTests.swift
+++ b/Tests/OCCTSwiftTests/ShapeTests.swift
@@ -2637,7 +2637,7 @@ struct PresentationMeshTests {
 
     @Test("Box shaded mesh has 12 triangles")
     func boxShadedMesh() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let mesh = box.shadedMesh(deflection: 0.1)
 
         #expect(mesh != nil)
@@ -2646,14 +2646,14 @@ struct PresentationMeshTests {
 
         // All normals should be non-zero
         for normal in mesh!.normals {
-            let len = sqrt(normal.x*normal.x + normal.y*normal.y + normal.z*normal.z)
+            let len = Float(sqrt(Double(normal.x*normal.x + normal.y*normal.y + normal.z*normal.z)))
             #expect(len > 0.5)
         }
     }
 
     @Test("Cylinder shaded mesh has triangles")
     func cylinderShadedMesh() {
-        let cyl = Shape.cylinder(radius: 5, height: 10)
+        let cyl = Shape.cylinder(radius: 5, height: 10)!
         let mesh = cyl.shadedMesh(deflection: 0.1)
 
         #expect(mesh != nil)
@@ -2663,7 +2663,7 @@ struct PresentationMeshTests {
 
     @Test("Box edge mesh has 12 segments")
     func boxEdgeMesh() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let edges = box.edgeMesh(deflection: 0.1)
 
         #expect(edges != nil)
@@ -2673,7 +2673,7 @@ struct PresentationMeshTests {
 
     @Test("Sphere edge mesh produces valid segments")
     func sphereEdgeMesh() {
-        let sphere = Shape.sphere(radius: 5)
+        let sphere = Shape.sphere(radius: 5)!
         let edges = sphere.edgeMesh(deflection: 0.1)
 
         #expect(edges != nil)
@@ -2687,7 +2687,7 @@ struct SelectorTests {
 
     @Test("Add and pick box at center")
     func pickBoxAtCenter() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = Camera()
         cam.eye = SIMD3(0, 0, 50)
         cam.center = SIMD3(0, 0, 0)
@@ -2715,7 +2715,7 @@ struct SelectorTests {
 
     @Test("Pick miss at far corner")
     func pickMiss() {
-        let box = Shape.box(width: 1, height: 1, depth: 1)
+        let box = Shape.box(width: 1, height: 1, depth: 1)!
         let cam = Camera()
         cam.eye = SIMD3(0, 0, 50)
         cam.center = SIMD3(0, 0, 0)
@@ -2739,10 +2739,10 @@ struct SelectorTests {
 
     @Test("Multiple shapes return correct IDs")
     func multipleShapes() {
-        let box1 = Shape.box(width: 10, height: 10, depth: 10)
-            .translated(by: SIMD3(-20, 0, 0))
-        let box2 = Shape.box(width: 10, height: 10, depth: 10)
-            .translated(by: SIMD3(20, 0, 0))
+        let box1 = Shape.box(width: 10, height: 10, depth: 10)!
+            .translated(by: SIMD3(-20, 0, 0))!
+        let box2 = Shape.box(width: 10, height: 10, depth: 10)!
+            .translated(by: SIMD3(20, 0, 0))!
 
         let cam = Camera()
         cam.eye = SIMD3(0, 0, 100)
@@ -2762,7 +2762,7 @@ struct SelectorTests {
 
     @Test("Remove shape then pick returns miss")
     func removeShape() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
 
         let selector = Selector()
         selector.add(shape: box, id: 99)
@@ -2786,7 +2786,7 @@ struct SelectorTests {
 
     @Test("Rectangle pick covers geometry")
     func rectanglePick() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
 
         let cam = Camera()
         cam.eye = SIMD3(0, 0, 50)
@@ -2814,7 +2814,7 @@ struct SelectorTests {
     @Test("Clear all removes everything")
     func clearAll() {
         let selector = Selector()
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         selector.add(shape: box, id: 1)
         selector.add(shape: box, id: 2)
         selector.clearAll()
@@ -2854,7 +2854,7 @@ struct SelectorSubShapeTests {
     @Test("Mode 0 (shape) is active by default")
     func defaultMode() {
         let selector = Selector()
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         selector.add(shape: box, id: 1)
         #expect(selector.isModeActive(.shape, for: 1) == true)
     }
@@ -2862,7 +2862,7 @@ struct SelectorSubShapeTests {
     @Test("Activate face mode")
     func activateFaceMode() {
         let selector = Selector()
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         selector.add(shape: box, id: 1)
 
         selector.activateMode(.face, for: 1)
@@ -2872,7 +2872,7 @@ struct SelectorSubShapeTests {
     @Test("Deactivate mode")
     func deactivateMode() {
         let selector = Selector()
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         selector.add(shape: box, id: 1)
 
         selector.activateMode(.face, for: 1)
@@ -2884,7 +2884,7 @@ struct SelectorSubShapeTests {
 
     @Test("Face mode pick returns face sub-shape type")
     func faceModePick() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
 
         let selector = Selector()
@@ -2908,7 +2908,7 @@ struct SelectorSubShapeTests {
 
     @Test("Edge mode pick returns edge sub-shape type")
     func edgeModePick() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
 
         let selector = Selector()
@@ -2941,7 +2941,7 @@ struct SelectorSubShapeTests {
 
     @Test("Shape mode pick returns shape sub-shape type with index 0")
     func shapeModePick() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
 
         let selector = Selector()
@@ -3334,7 +3334,7 @@ struct PolylinePickTests {
 
     @Test("Polygon enclosing shape returns hit")
     func polygonHit() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
         let selector = Selector()
         selector.add(shape: box, id: 1)
@@ -3358,7 +3358,7 @@ struct PolylinePickTests {
 
     @Test("Polygon missing shape returns empty")
     func polygonMiss() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
         let selector = Selector()
         selector.add(shape: box, id: 1)
@@ -3389,7 +3389,7 @@ struct PolylinePickTests {
 
     @Test("Triangular polygon selects shape")
     func triangularPolygon() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
         let selector = Selector()
         selector.add(shape: box, id: 42)
@@ -3418,7 +3418,7 @@ struct DrawerMeshTests {
 
     @Test("Shaded mesh with default drawer produces valid mesh")
     func shadedMeshDefaultDrawer() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let drawer = DisplayDrawer()
 
         let mesh = box.shadedMesh(drawer: drawer)
@@ -3432,7 +3432,7 @@ struct DrawerMeshTests {
 
     @Test("Edge mesh with default drawer produces valid segments")
     func edgeMeshDefaultDrawer() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let drawer = DisplayDrawer()
 
         let mesh = box.edgeMesh(drawer: drawer)
@@ -3445,7 +3445,7 @@ struct DrawerMeshTests {
 
     @Test("Finer deviation produces more triangles for curved shape")
     func finerDeviationMoreTriangles() {
-        let sphere = Shape.sphere(radius: 10)
+        let sphere = Shape.sphere(radius: 10)!
 
         let coarseDrawer = DisplayDrawer()
         coarseDrawer.deviationCoefficient = 0.1
@@ -3465,7 +3465,7 @@ struct DrawerMeshTests {
 
     @Test("Absolute deflection type works")
     func absoluteDeflection() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
         let drawer = DisplayDrawer()
         drawer.deflectionType = .absolute
         drawer.maximalChordialDeviation = 0.5

--- a/docs/METAL_VISUALIZATION_API.md
+++ b/docs/METAL_VISUALIZATION_API.md
@@ -1,0 +1,627 @@
+# OCCTSwift Metal Visualization API
+
+Branch: `feature/metal-visualization`
+Date: 2026-02-14
+
+## Overview
+
+This branch adds a complete set of OCCT wrappers for building a Metal-based CAD
+viewport without any OpenGL dependency. It extracts geometry, camera math, selection,
+and display configuration from OCCT and exposes them as Swift types that map directly
+to Metal concepts.
+
+**What this gives you:**
+
+- Camera matrices in `simd_float4x4` format with Metal's [0,1] depth range
+- Triangle meshes and edge wireframes ready for `MTLBuffer`
+- BVH-accelerated hit testing (point, rectangle, and lasso pick)
+- Sub-shape selection (pick individual faces, edges, or vertices)
+- Clip plane equations for `[[clip_distance]]`
+- Z-layer settings for `MTLDepthStencilDescriptor` and `setDepthBias()`
+- Tessellation quality control via `DisplayDrawer`
+
+**What this does NOT include:**
+
+- Any Metal rendering code (that's ViewportKit's job)
+- OpenGL, V3d, or AIS dependencies
+- GPU pick-ID buffer (see [ViewportKit#6](https://github.com/gsdali/ViewportKit/issues/6))
+
+## Dependency
+
+Add OCCTSwift as a package dependency and target the `feature/metal-visualization`
+branch:
+
+```swift
+.package(url: "https://github.com/gsdali/OCCTSwift.git", branch: "feature/metal-visualization")
+```
+
+All types are in the `OCCTSwift` module:
+
+```swift
+import OCCTSwift
+```
+
+---
+
+## API Reference
+
+### Camera
+
+Wraps `Graphic3d_Camera`. Produces Metal-compatible projection/view matrices.
+
+```swift
+let cam = Camera()
+
+// Position
+cam.eye    = SIMD3(0, 0, 50)
+cam.center = SIMD3(0, 0, 0)
+cam.up     = SIMD3(0, 1, 0)
+
+// Projection
+cam.projectionType = .perspective   // or .orthographic
+cam.fieldOfView    = 45.0           // degrees (perspective only)
+cam.scale          = 100.0          // orthographic only
+cam.zRange         = (near: 0.1, far: 1000.0)
+cam.aspect         = Double(viewWidth) / Double(viewHeight)
+
+// Matrices — column-major, [0,1] depth, ready for Metal uniform buffer
+let proj: simd_float4x4 = cam.projectionMatrix
+let view: simd_float4x4 = cam.viewMatrix
+
+// Coordinate conversion
+let screen = cam.project(SIMD3(5, 5, 0))      // world → screen
+let world  = cam.unproject(SIMD3(0.5, 0.5, 0)) // screen → world
+
+// Auto-frame
+cam.fit(boundingBox: (min: shape.boundingBox.min,
+                      max: shape.boundingBox.max))
+```
+
+**Metal mapping:**
+- `projectionMatrix` / `viewMatrix` → shader uniform buffer
+- Matrices use Metal's [0,1] depth range (not OpenGL's [-1,1])
+- `simd_float4x4` layout matches `float4x4` in MSL
+
+---
+
+### PresentationMesh — Shaded Mesh Extraction
+
+Extract triangulated meshes and edge wireframes from any `Shape`.
+
+#### Shaded mesh (triangles + normals)
+
+```swift
+let box = Shape.box(width: 10, height: 10, depth: 10)
+
+if let mesh = box.shadedMesh(deflection: 0.1) {
+    // mesh.vertices: [SIMD3<Float>]  — vertex positions
+    // mesh.normals:  [SIMD3<Float>]  — per-vertex normals
+    // mesh.indices:  [UInt32]        — triangle indices (3 per tri)
+    // mesh.triangleCount: Int
+
+    // Create Metal buffers
+    let vBuf = device.makeBuffer(bytes: mesh.vertices,
+                                 length: mesh.vertices.count * MemoryLayout<SIMD3<Float>>.stride)
+    let iBuf = device.makeBuffer(bytes: mesh.indices,
+                                 length: mesh.indices.count * MemoryLayout<UInt32>.stride)
+}
+```
+
+#### Edge wireframe (polylines)
+
+```swift
+if let edges = box.edgeMesh(deflection: 0.1) {
+    // edges.vertices:      [SIMD3<Float>]  — all polyline vertices
+    // edges.segmentStarts: [Int]           — index where each edge begins
+    // edges.segmentCount:  Int
+
+    // Draw each edge as a line strip:
+    for i in 0..<edges.segmentCount {
+        let start = edges.segmentStarts[i]
+        let end = (i + 1 < edges.segmentCount)
+            ? edges.segmentStarts[i + 1]
+            : edges.vertices.count
+        let count = end - start
+        // encoder.drawPrimitives(type: .lineStrip, vertexStart: start, vertexCount: count)
+    }
+}
+```
+
+#### Drawer-controlled tessellation
+
+Use a `DisplayDrawer` for fine-grained control over tessellation quality:
+
+```swift
+let drawer = DisplayDrawer()
+drawer.deviationCoefficient = 0.0005  // finer than default
+drawer.deviationAngle = 0.2           // radians
+
+let fineMesh = sphere.shadedMesh(drawer: drawer)
+let fineEdges = sphere.edgeMesh(drawer: drawer)
+```
+
+---
+
+### Selector — BVH-Accelerated Hit Testing
+
+Interactive picking without OpenGL. Uses OCCT's 3-level BVH for fast traversal
+even on large assemblies.
+
+#### Setup
+
+```swift
+let selector = Selector()
+
+// Register shapes with unique IDs
+selector.add(shape: boxShape, id: 1)
+selector.add(shape: cylinderShape, id: 2)
+
+// Enable sub-shape selection modes
+selector.activateMode(.face, for: 1)   // pick faces on shape 1
+selector.activateMode(.edge, for: 1)   // also pick edges on shape 1
+
+// Adjust tolerance for thin geometry
+selector.pixelTolerance = 4  // pixels (default 2)
+```
+
+#### Point pick (click)
+
+```swift
+let results = selector.pick(
+    at: SIMD2(mouseX, mouseY),
+    camera: cam,
+    viewSize: SIMD2(viewWidth, viewHeight)
+)
+
+if let hit = results.first {
+    hit.shapeId      // Int32 — the ID you assigned
+    hit.depth         // Double — distance from camera
+    hit.point         // SIMD3<Double> — world-space hit point
+    hit.subShapeType  // .face, .edge, .vertex, .shape, etc.
+    hit.subShapeIndex // Int32 — 1-based index within parent (0 = whole shape)
+}
+```
+
+#### Rectangle pick (rubber band)
+
+```swift
+let results = selector.pick(
+    rect: (min: SIMD2(x1, y1), max: SIMD2(x2, y2)),
+    camera: cam,
+    viewSize: SIMD2(viewWidth, viewHeight)
+)
+// results contains all shapes/sub-shapes intersecting the rectangle
+```
+
+#### Polygon pick (lasso)
+
+```swift
+let lasso: [SIMD2<Double>] = [
+    SIMD2(100, 50),
+    SIMD2(200, 100),
+    SIMD2(180, 200),
+    SIMD2(80, 180),
+    SIMD2(100, 50),   // close the polygon
+]
+let results = selector.pick(
+    polygon: lasso,
+    camera: cam,
+    viewSize: SIMD2(viewWidth, viewHeight)
+)
+```
+
+#### Selection modes
+
+| Mode | Picks | Raw value |
+|------|-------|-----------|
+| `.shape` | Entire shape as one entity | 0 |
+| `.vertex` | Individual vertices | 1 |
+| `.edge` | Individual edges | 2 |
+| `.wire` | Connected edge loops | 3 |
+| `.face` | Individual faces | 4 |
+
+Multiple modes can be active simultaneously. Mode 0 (shape) is activated by
+default when a shape is added.
+
+#### Sub-shape types in results
+
+| SubShapeType | Meaning | Raw value |
+|---|---|---|
+| `.compound` | Compound shape | 0 |
+| `.compsolid` | Compound solid | 1 |
+| `.solid` | Solid body | 2 |
+| `.shell` | Shell | 3 |
+| `.face` | Face | 4 |
+| `.wire` | Wire | 5 |
+| `.edge` | Edge | 6 |
+| `.vertex` | Vertex | 7 |
+| `.shape` | Generic shape | 8 |
+
+#### Lifecycle
+
+```swift
+selector.remove(id: 1)           // remove one shape
+selector.clearAll()               // remove all shapes
+selector.deactivateMode(.face, for: 2)  // stop picking faces on shape 2
+```
+
+---
+
+### ClipPlane
+
+Wraps `Graphic3d_ClipPlane`. The equation `Ax + By + Cz + D = 0` defines a
+half-space where `Ax + By + Cz + D > 0` is visible.
+
+```swift
+// Clip everything below Y=5
+let plane = ClipPlane(equation: SIMD4(0, 1, 0, -5))
+plane.isOn = true
+
+// Or from normal + distance
+let plane2 = ClipPlane(normal: SIMD3(0, 0, 1), distance: -10)
+```
+
+**Metal vertex shader mapping:**
+
+```metal
+vertex VertexOut main_vertex(...) {
+    VertexOut out;
+    out.position = ...;
+    // clipPlane is SIMD4<Float> from ClipPlane.equation
+    out.clipDist[0] = dot(clipPlane.xyz, worldPos.xyz) + clipPlane.w;
+    return out;
+}
+```
+
+#### Capping (cross-section fill)
+
+```swift
+plane.isCapping = true
+plane.cappingColor = SIMD3(0.8, 0.2, 0.2)  // red cross-section
+plane.hatchStyle = .diagonal45
+plane.isHatchOn = true
+```
+
+Metal implementation: stencil increment on back faces, stencil decrement on
+front faces, fill where stencil != 0.
+
+#### Probing
+
+Test geometry against clip planes on the CPU side for culling:
+
+```swift
+let state = plane.probe(point: SIMD3(0, 10, 0))  // .in, .out, or .on
+
+let boxState = plane.probe(box: (min: SIMD3(-5, -5, -5),
+                                  max: SIMD3(5, 5, 5)))
+// .in = fully visible, .out = fully clipped, .on = partially clipped
+```
+
+#### Chaining (AND logic)
+
+Combine multiple planes to create complex clipping regions:
+
+```swift
+let top = ClipPlane(equation: SIMD4(0, -1, 0, 10))    // clip above Y=10
+let bottom = ClipPlane(equation: SIMD4(0, 1, 0, -2))   // clip below Y=2
+top.chainNext(bottom)  // both must pass → slice between Y=2 and Y=10
+
+top.chainLength  // 2
+```
+
+---
+
+### ZLayerSettings
+
+Configuration for rendering layers. Controls depth testing, polygon offset, and
+render order.
+
+```swift
+let settings = ZLayerSettings()
+
+// Depth
+settings.depthTestEnabled  = true
+settings.depthWriteEnabled = true
+settings.clearDepth        = false  // true → loadAction: .clear
+
+// Polygon offset (depth bias for wireframe-on-shaded)
+settings.polygonOffset = ZLayerSettings.PolygonOffset(
+    mode: .fill,
+    factor: 1.0,   // → setDepthBias slopeScale
+    units: 1.0     // → setDepthBias depthBias
+)
+// Or use convenience methods:
+settings.setDepthOffsetPositive()  // push away from camera
+settings.setDepthOffsetNegative()  // pull toward camera
+
+// Render options
+settings.isImmediate = false          // draw in normal pass order
+settings.isRaytracable = true         // participate in ray tracing
+settings.renderInDepthPrepass = true  // include in early-Z pass
+
+// Culling
+settings.cullingDistance = 10000.0   // cull objects farther than this
+settings.cullingSize = 2.0           // cull objects smaller than 2px
+
+// Large-scene precision
+settings.origin = SIMD3(1_000_000, 0, 0)  // layer origin near camera
+```
+
+**Predefined layer IDs:**
+
+| Layer | ID | Purpose |
+|-------|---:|---------|
+| `ZLayerSettings.bottomOSD` | -5 | 2D underlay |
+| `ZLayerSettings.default` | 0 | Main 3D scene |
+| `ZLayerSettings.top` | -2 | 3D overlay (inherits depth) |
+| `ZLayerSettings.topmost` | -3 | 3D overlay (own depth) |
+| `ZLayerSettings.topOSD` | -4 | 2D overlay (annotations, UI) |
+
+---
+
+### DisplayDrawer
+
+Controls tessellation quality and wireframe display.
+
+```swift
+let drawer = DisplayDrawer()
+
+// Tessellation quality
+drawer.deflectionType       = .relative       // or .absolute
+drawer.deviationCoefficient = 0.001           // relative to bbox (finer = smaller)
+drawer.deviationAngle       = 0.35            // radians (~20°)
+drawer.maximalChordialDeviation = 0.1         // for .absolute mode
+drawer.autoTriangulation    = true
+
+// Edge display
+drawer.faceBoundaryDraw = true    // show face boundaries
+drawer.wireDraw         = true    // show wireframe edges
+
+// Curve discretisation
+drawer.discretisation   = 30     // points per curve
+drawer.isoOnTriangulation = false // iso-parameter lines
+```
+
+Use with mesh extraction:
+
+```swift
+let mesh = shape.shadedMesh(drawer: drawer)
+let edges = shape.edgeMesh(drawer: drawer)
+```
+
+---
+
+## Integration Guide for ViewportKit
+
+### Minimum viable integration
+
+The fastest path to interactive selection in a Metal viewport:
+
+1. **Camera sync** — Feed your Metal camera state into an OCCTSwift `Camera`:
+
+```swift
+let occtCamera = Camera()
+
+func updateOCCTCamera(from metalView: MTKView) {
+    occtCamera.eye = myEye
+    occtCamera.center = myCenter
+    occtCamera.up = myUp
+    occtCamera.fieldOfView = myFOV
+    occtCamera.aspect = Double(metalView.drawableSize.width / metalView.drawableSize.height)
+    occtCamera.zRange = (near: myNear, far: myFar)
+}
+```
+
+Or go the other direction — use `Camera` as the source of truth and read its
+matrices for your Metal uniform buffer:
+
+```swift
+struct Uniforms {
+    var projectionMatrix: simd_float4x4
+    var viewMatrix: simd_float4x4
+}
+
+var uniforms = Uniforms(
+    projectionMatrix: occtCamera.projectionMatrix,
+    viewMatrix: occtCamera.viewMatrix
+)
+```
+
+2. **Mesh extraction** — Get vertex data for Metal buffers:
+
+```swift
+func loadShape(_ shape: Shape) -> (MTLBuffer, MTLBuffer, Int)? {
+    guard let mesh = shape.shadedMesh(deflection: 0.1) else { return nil }
+
+    // Interleave positions + normals for a single vertex buffer
+    var interleaved = [Float]()
+    interleaved.reserveCapacity(mesh.vertices.count * 6)
+    for i in 0..<mesh.vertices.count {
+        interleaved.append(contentsOf: [mesh.vertices[i].x, mesh.vertices[i].y, mesh.vertices[i].z])
+        interleaved.append(contentsOf: [mesh.normals[i].x, mesh.normals[i].y, mesh.normals[i].z])
+    }
+
+    let vBuf = device.makeBuffer(bytes: interleaved,
+                                  length: interleaved.count * MemoryLayout<Float>.stride,
+                                  options: .storageModeShared)!
+    let iBuf = device.makeBuffer(bytes: mesh.indices,
+                                  length: mesh.indices.count * MemoryLayout<UInt32>.stride,
+                                  options: .storageModeShared)!
+    return (vBuf, iBuf, mesh.indices.count)
+}
+```
+
+3. **Hit testing** — Handle clicks:
+
+```swift
+let selector = Selector()
+
+func onShapeAdded(_ shape: Shape, id: Int32) {
+    selector.add(shape: shape, id: id)
+    selector.activateMode(.face, for: id)
+}
+
+func onClick(at pixel: CGPoint, in view: MTKView) {
+    updateOCCTCamera(from: view)
+    let size = view.drawableSize
+    let results = selector.pick(
+        at: SIMD2(Double(pixel.x), Double(pixel.y)),
+        camera: occtCamera,
+        viewSize: SIMD2(Double(size.width), Double(size.height))
+    )
+    if let hit = results.first {
+        print("Hit shape \(hit.shapeId), face \(hit.subShapeIndex)")
+        selectedShapes.insert(hit.shapeId)  // highlight in next frame
+    }
+}
+```
+
+### Selection state management
+
+OCCT's `Selector` handles the picking algorithm. Selection state (which shapes
+are selected, highlight, selection schemes) is managed in Swift:
+
+```swift
+var selectedShapes = Set<Int32>()
+
+func select(_ results: [Selector.PickResult], mode: SelectionScheme) {
+    switch mode {
+    case .replace:
+        selectedShapes = Set(results.map(\.shapeId))
+    case .add:
+        selectedShapes.formUnion(results.map(\.shapeId))
+    case .toggle:
+        for r in results {
+            if selectedShapes.contains(r.shapeId) {
+                selectedShapes.remove(r.shapeId)
+            } else {
+                selectedShapes.insert(r.shapeId)
+            }
+        }
+    }
+}
+```
+
+Highlighting is a shader uniform per draw call:
+
+```metal
+fragment float4 main_fragment(..., constant bool& isSelected [[buffer(3)]]) {
+    float4 color = shadedColor;
+    if (isSelected) {
+        color.rgb = mix(color.rgb, float3(0.2, 0.5, 1.0), 0.4);
+    }
+    return color;
+}
+```
+
+### Clip planes in the render pipeline
+
+```swift
+let clipPlane = ClipPlane(equation: SIMD4(0, 1, 0, -5))
+clipPlane.isOn = true
+
+// In your render pass:
+var clipEq = clipPlane.equation
+encoder.setVertexBytes(&clipEq, length: MemoryLayout<SIMD4<Double>>.stride, index: 4)
+```
+
+```metal
+struct VertexOut {
+    float4 position [[position]];
+    float  clipDist [[clip_distance]] [1];
+};
+
+vertex VertexOut main_vertex(..., constant float4& clipPlane [[buffer(4)]]) {
+    VertexOut out;
+    out.position = uniforms.proj * uniforms.view * float4(pos, 1.0);
+    out.clipDist[0] = dot(clipPlane.xyz, worldPos.xyz) + clipPlane.w;
+    return out;
+}
+```
+
+### Z-layer render pass setup
+
+```swift
+func configureRenderPass(for layer: ZLayerSettings) -> MTLRenderPassDescriptor {
+    let desc = MTLRenderPassDescriptor()
+
+    if layer.clearDepth {
+        desc.depthAttachment.loadAction = .clear
+    } else {
+        desc.depthAttachment.loadAction = .load
+    }
+
+    return desc
+}
+
+func configureDepthStencil(for layer: ZLayerSettings) -> MTLDepthStencilState {
+    let desc = MTLDepthStencilDescriptor()
+    desc.isDepthWriteEnabled = layer.depthWriteEnabled
+    desc.depthCompareFunction = layer.depthTestEnabled ? .less : .always
+    return device.makeDepthStencilState(descriptor: desc)!
+}
+
+func configureEncoder(_ encoder: MTLRenderCommandEncoder, for layer: ZLayerSettings) {
+    let offset = layer.polygonOffset
+    if offset.mode != .off {
+        encoder.setDepthBias(Float(offset.units), slopeScale: Float(offset.factor), clamp: 0)
+    }
+}
+```
+
+---
+
+## Test Coverage
+
+232 tests total, including these suites for the new APIs:
+
+| Suite | Tests | What it covers |
+|-------|------:|----------------|
+| Camera Tests | 6 | Default state, matrices, project/unproject roundtrip, ortho mode, fit bbox |
+| Presentation Mesh Tests | 4 | Box mesh (12 tris), cylinder mesh, box edges (12 segments), sphere edges |
+| Selector Tests | 6 | Point pick hit/miss, multiple shapes, remove, rectangle pick, clear |
+| Selector Sub-Shape Modes | 7 | Default mode, activate/deactivate, face pick, edge pick, pixel tolerance, shape pick |
+| Polyline Pick | 4 | Polygon hit, polygon miss, too few points, triangular polygon |
+| Drawer Mesh Extraction | 4 | Default drawer mesh, edge mesh, finer deviation, absolute deflection |
+| Display Drawer | 10 | All properties: deviation, angle, chordial, deflection type, auto-tri, iso, discretisation, boundaries, wire |
+| Clip Plane | 15 | Equation, reversed, enable, capping, color, hatch, probe point/box, chain, clear chain |
+| Z-Layer Settings | 13 | Depth test/write, clear depth, polygon offset, immediate, raytracable, culling, origin, predefined IDs |
+
+Run all tests:
+
+```bash
+swift test
+```
+
+---
+
+## Branch Details
+
+```
+Branch: feature/metal-visualization
+Base:   main
+
+Commits:
+  c97e84d  Add polyline (lasso) pick and Drawer-aware mesh extraction
+  ed05d2d  Add sub-shape selection modes and display drawer wrapper
+  9458920  Add ClipPlane and ZLayerSettings wrappers (Phases 5-6)
+  a651591  Add Metal visualization wrappers: Camera, PresentationMesh, Selector
+
+Files changed: 9 files, +3,438 lines
+  Sources/OCCTBridge/include/OCCTBridge.h   +246
+  Sources/OCCTBridge/src/OCCTBridge.mm      +1,224
+  Sources/OCCTSwift/Camera.swift            +145  (new)
+  Sources/OCCTSwift/ClipPlane.swift         +166  (new)
+  Sources/OCCTSwift/DisplayDrawer.swift     +102  (new)
+  Sources/OCCTSwift/PresentationMesh.swift  +185  (new)
+  Sources/OCCTSwift/Selector.swift          +227  (new)
+  Sources/OCCTSwift/ZLayerSettings.swift    +184  (new)
+  Tests/OCCTSwiftTests/ShapeTests.swift     +959
+```
+
+---
+
+## Related
+
+- [VISUALIZATION_WRAPPING_PLAN.md](VISUALIZATION_WRAPPING_PLAN.md) — Full architectural plan with OCCT class analysis
+- [ViewportKit#6](https://github.com/gsdali/ViewportKit/issues/6) — GPU-accelerated pick-ID buffer (Phase 4, Metal-side)


### PR DESCRIPTION
## Summary

- **Camera** — `Graphic3d_Camera` wrapper producing `simd_float4x4` matrices with Metal [0,1] depth range, plus project/unproject and auto-framing
- **PresentationMesh** — Triangle mesh and edge wireframe extraction from shapes, with optional `DisplayDrawer`-controlled tessellation quality
- **Selector** — BVH-accelerated hit testing: point pick, rectangle pick, and lasso (polygon) pick with sub-shape selection modes (face, edge, vertex, wire)
- **ClipPlane** — `Graphic3d_ClipPlane` wrapper with plane equation, capping, hatch styles, probe methods, and AND-chaining for `[[clip_distance]]`
- **ZLayerSettings** — `Graphic3d_ZLayerSettings` wrapper for depth test/write, polygon offset (`setDepthBias`), culling, and render layer ordering
- **DisplayDrawer** — `Prs3d_Drawer` wrapper for tessellation quality control (deviation coefficient/angle, deflection type, wireframe/boundary display)

6 new Swift types, +4,065 lines, 235 tests passing (69 new tests across 9 suites).

Rebased on v0.14.0 (optional-returning Shape API). Full API documentation with Metal integration examples: [`docs/METAL_VISUALIZATION_API.md`](docs/METAL_VISUALIZATION_API.md)

## Do not merge

Waiting for ViewportKit integration testing before merge.

## Test plan

- [x] `swift build` compiles
- [x] `swift test` — 235 tests pass (0 failures)
- [ ] ViewportKit integration: camera matrix sync
- [ ] ViewportKit integration: mesh extraction → MTLBuffer
- [ ] ViewportKit integration: click-to-pick with Selector
- [ ] ViewportKit integration: clip plane rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)