### PR TITLE
feat(shape): add ShapeMeasurements to kernel (issue #100)

### DIFF
--- a/Sources/OCCTSwift/ShapeMeasurements.swift
+++ b/Sources/OCCTSwift/ShapeMeasurements.swift
@@ -1,0 +1,83 @@
+// ShapeMeasurements.swift
+// OCCTSwift
+//
+// Per-face area / centroid / perimeter + per-edge length reports for
+// dimension widgets, BOM extractors, and other measurement-driven UIs.
+
+import simd
+
+/// Measurements computed from a `Shape`'s topology, indexed parallel to its
+/// face / edge enumeration so consumers (e.g. AIS-layer dimension widgets)
+/// can resolve a picked face / edge index directly to its scalar measurement.
+public struct ShapeMeasurements: Sendable {
+    /// `faceAreas[i]` is the area of `shape.faces()[i]`.
+    public let faceAreas: [Double]
+
+    /// `edgeLengths[i]` is the arc length of `shape.edge(at: i)` (0..<shape.edgeCount).
+    public let edgeLengths: [Double]
+
+    /// `faceCentroids[i]` is the surface center-of-mass of `shape.faces()[i]`,
+    /// computed via `BRepGProp_Sinert`.
+    public let faceCentroids: [SIMD3<Double>]
+
+    /// `facePerimeters[i]` is the outer-wire length of `shape.faces()[i]`, or
+    /// `nil` if the face has no outer wire or wire length is unavailable.
+    ///
+    /// **Caveat**: this is the *outer-boundary* length, not a parametric arc
+    /// length. For trimmed faces (a face with internal holes), this excludes
+    /// the inner-wire perimeters — usually what dimension widgets want, but
+    /// worth knowing.
+    public let facePerimeters: [Double?]
+
+    public init(
+        faceAreas: [Double],
+        edgeLengths: [Double],
+        faceCentroids: [SIMD3<Double>] = [],
+        facePerimeters: [Double?] = []
+    ) {
+        self.faceAreas = faceAreas
+        self.edgeLengths = edgeLengths
+        self.faceCentroids = faceCentroids
+        self.facePerimeters = facePerimeters
+    }
+
+    /// Sum of all face areas — useful as a quick total-surface metric.
+    public var totalFaceArea: Double { faceAreas.reduce(0, +) }
+
+    /// Sum of all edge lengths.
+    public var totalEdgeLength: Double { edgeLengths.reduce(0, +) }
+
+    /// Sum of all available face perimeters (`nil` entries are skipped).
+    public var totalFacePerimeter: Double {
+        facePerimeters.reduce(0) { acc, p in acc + (p ?? 0) }
+    }
+}
+
+extension Shape {
+    /// Compute per-face area / centroid / perimeter + per-edge length for this shape.
+    /// - Parameter linearTolerance: tolerance forwarded to `Face.area(tolerance:)`.
+    ///   Defaults to OCCT's `1e-6` — tighten only if you hit precision issues.
+    public func measure(linearTolerance: Double = 1e-6) -> ShapeMeasurements {
+        let faceList = faces()
+        let faceAreas = faceList.map { $0.area(tolerance: linearTolerance) }
+        let faceCentroids = faceList.map { face -> SIMD3<Double> in
+            let s = face.surfaceInertia
+            return SIMD3(s.centerX, s.centerY, s.centerZ)
+        }
+        let facePerimeters: [Double?] = faceList.map { $0.outerWire?.length }
+
+        let count = edgeCount
+        var edgeLengths: [Double] = []
+        edgeLengths.reserveCapacity(count)
+        for i in 0..<count {
+            edgeLengths.append(edge(at: i)?.length ?? 0)
+        }
+
+        return ShapeMeasurements(
+            faceAreas: faceAreas,
+            edgeLengths: edgeLengths,
+            faceCentroids: faceCentroids,
+            facePerimeters: facePerimeters
+        )
+    }
+}

--- a/Tests/OCCTSwiftTests/ShapeTests.swift
+++ b/Tests/OCCTSwiftTests/ShapeTests.swift
@@ -49400,3 +49400,107 @@ struct ConvexBendIssue89 {
                  "auto vol=\(vAuto), explicit vol=\(vExplicit)")
     }
 }
+
+@Suite("ShapeMeasurements")
+struct ShapeMeasurementsTests {
+
+    @Test func boxFaceAreasMatchExpectedTotals() {
+        guard let box = Shape.box(width: 2, height: 3, depth: 5) else {
+            Issue.record("Shape.box returned nil")
+            return
+        }
+        let m = box.measure()
+        // Box has 6 faces. Total surface area = 2*(2*3 + 3*5 + 2*5) = 2*31 = 62.
+        #expect(m.faceAreas.count == 6)
+        #expect(abs(m.totalFaceArea - 62.0) < 1e-6,
+                "expected 62.0, got \(m.totalFaceArea)")
+        // Areas should occur in 3 pairs (front/back, top/bottom, left/right).
+        let sorted = m.faceAreas.sorted()
+        #expect(abs(sorted[0] - sorted[1]) < 1e-6)
+        #expect(abs(sorted[2] - sorted[3]) < 1e-6)
+        #expect(abs(sorted[4] - sorted[5]) < 1e-6)
+    }
+
+    @Test func boxEdgeLengthsMatchExpectedTotals() {
+        guard let box = Shape.box(width: 2, height: 3, depth: 5) else {
+            Issue.record("Shape.box returned nil")
+            return
+        }
+        let m = box.measure()
+        // Box has 12 edges: 4 of length 2, 4 of length 3, 4 of length 5.
+        // Total = 4*(2+3+5) = 40.
+        #expect(m.edgeLengths.count == 12)
+        #expect(abs(m.totalEdgeLength - 40.0) < 1e-6,
+                "expected 40.0, got \(m.totalEdgeLength)")
+    }
+
+    @Test func cylinderTotalsAreFinite() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 10) else {
+            Issue.record("Shape.cylinder returned nil")
+            return
+        }
+        let m = cyl.measure()
+        #expect(m.faceAreas.count >= 3)
+        #expect(m.totalFaceArea > 0)
+        #expect(m.totalFaceArea.isFinite)
+        #expect(m.totalEdgeLength > 0)
+        #expect(m.totalEdgeLength.isFinite)
+    }
+
+    @Test func boxFaceCentroidsLieInsideFaceBounds() {
+        guard let box = Shape.box(width: 2, height: 3, depth: 5) else {
+            Issue.record("Shape.box returned nil")
+            return
+        }
+        let m = box.measure()
+        #expect(m.faceCentroids.count == 6,
+                "one centroid per face, parallel to faceAreas")
+        let faceList = box.faces()
+        for (i, c) in m.faceCentroids.enumerated() {
+            let b = faceList[i].bounds
+            #expect(c.x >= b.min.x - 1e-6 && c.x <= b.max.x + 1e-6,
+                    "face \(i) centroid X=\(c.x) outside [\(b.min.x), \(b.max.x)]")
+            #expect(c.y >= b.min.y - 1e-6 && c.y <= b.max.y + 1e-6,
+                    "face \(i) centroid Y=\(c.y) outside [\(b.min.y), \(b.max.y)]")
+            #expect(c.z >= b.min.z - 1e-6 && c.z <= b.max.z + 1e-6,
+                    "face \(i) centroid Z=\(c.z) outside [\(b.min.z), \(b.max.z)]")
+        }
+    }
+
+    @Test func boxFacePerimetersMatchExpectedTotals() {
+        guard let box = Shape.box(width: 2, height: 3, depth: 5) else {
+            Issue.record("Shape.box returned nil")
+            return
+        }
+        let m = box.measure()
+        #expect(m.facePerimeters.count == 6)
+        // 2x3 face perimeter 10 (×2), 3x5 perimeter 16 (×2), 2x5 perimeter 14 (×2).
+        // Total = 20 + 32 + 28 = 80.
+        #expect(abs(m.totalFacePerimeter - 80.0) < 1e-6,
+                "expected 80.0 total face perimeter, got \(m.totalFacePerimeter)")
+        #expect(m.facePerimeters.allSatisfy { $0 != nil },
+                "all box faces have a closed outer wire")
+    }
+
+    @Test func cylinderTopBottomCentroidsAreOnAxis() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 10) else {
+            Issue.record("Shape.cylinder returned nil")
+            return
+        }
+        // Find the two circular cap faces by area: pi*r^2 = pi*25 ≈ 78.54.
+        // Their centroids should lie on the cylinder axis (X=Y=0 in OCCT's
+        // default cylinder placement, which puts the axis on Z).
+        let m = cyl.measure()
+        let capArea = .pi * 25.0
+        var capCount = 0
+        for (i, area) in m.faceAreas.enumerated() {
+            if abs(area - capArea) < 1e-3 {
+                capCount += 1
+                let c = m.faceCentroids[i]
+                #expect(abs(c.x) < 1e-6, "cap \(i) centroid X=\(c.x), expected 0")
+                #expect(abs(c.y) < 1e-6, "cap \(i) centroid Y=\(c.y), expected 0")
+            }
+        }
+        #expect(capCount == 2, "cylinder has 2 circular caps, found \(capCount)")
+    }
+}


### PR DESCRIPTION
## Summary
- Hoist `ShapeMeasurements` (per-face areas / centroids / perimeters + per-edge lengths) and `Shape.measure(linearTolerance:)` from `OCCTSwiftTools` into the `OCCTSwift` kernel.
- Pure Swift relocation — no bridge changes. Uses existing kernel APIs (`Face.area`, `Face.surfaceInertia`, `Face.outerWire`, `Edge.length`).
- Lets dimension widgets / BOM extractors call `shape.measure()` without depending on `OCCTSwiftTools` (which transitively pulls in `OCCTSwiftViewport`).

## Coordination
- Tools-side removal of `ShapeMeasurements` lands in `OCCTSwiftTools` **after** this PR merges and downstream consumers re-target their imports.
- The `t_metadataIncludesMeasurementsWhenRequested` test stays in `OCCTSwiftTools` because it exercises Tools-specific `CADFileLoader.shapeToBodyAndMetadata`.

## Test plan
- [x] `swift build` clean
- [x] `swift test --filter "ShapeMeasurements"` 6/6 pass:
  - `boxFaceAreasMatchExpectedTotals`
  - `boxEdgeLengthsMatchExpectedTotals`
  - `cylinderTotalsAreFinite`
  - `boxFaceCentroidsLieInsideFaceBounds`
  - `boxFacePerimetersMatchExpectedTotals`
  - `cylinderTopBottomCentroidsAreOnAxis`

Closes #100 (kernel side).
