### PR TITLE
feat(Shape): feature-aware patterning, sweep orientation, geometric edge selection (closes #169, #170, #171)

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -369,10 +369,19 @@ public final class Shape: @unchecked Sendable {
 
     // MARK: - Sweep Operations
 
-    /// Sweep a 2D profile along a path to create a solid
+    /// Sweep a 2D profile along a path to create a solid.
+    ///
+    /// The resulting solid is orientation-normalised so its faces point outward
+    /// (positive volume) regardless of the profile wire's sense relative to the
+    /// path tangent. `BRepOffsetAPI_MakePipe` itself yields an inward-oriented
+    /// (negative-volume) solid whenever the section's normal runs against the path
+    /// tangent — a latent hazard for downstream booleans and `volume > 0` checks —
+    /// so callers no longer need the "point the section normal against the tangent"
+    /// incantation. See ``orientedForward()`` for the same fix applied explicitly.
     public static func sweep(profile: Wire, along path: Wire) -> Shape? {
         guard let handle = OCCTShapeCreatePipeSweep(profile.handle, path.handle) else { return nil }
-        return Shape(handle: handle)
+        let swept = Shape(handle: handle)
+        return swept.orientedForward()
     }
 
     /// Extrude a 2D profile in a direction
@@ -1529,7 +1538,16 @@ public final class Shape: @unchecked Sendable {
         return Shape(handle: handle)
     }
 
-    /// Create a circular pattern of the shape
+    /// Create a circular pattern of the shape.
+    ///
+    /// This duplicates **the whole body** `count` times around the axis and returns
+    /// a compound of the copies. It does **not** pattern features. If `self` is a
+    /// solid that already has a hole/pocket cut into it, the result is `count`
+    /// overlapping copies of that solid — the holes get filled by neighbouring
+    /// copies, not replicated. For the bolt-circle use case ("drill one hole, then
+    /// repeat it around the axis") pattern the *tool* shape and subtract it, or use
+    /// ``circularPatternCut(tool:axisPoint:axisDirection:count:angle:)`` which does
+    /// exactly that in one call.
     ///
     /// - Parameters:
     ///   - axisPoint: Point on the rotation axis
@@ -1543,13 +1561,14 @@ public final class Shape: @unchecked Sendable {
     ///
     /// ```swift
     /// let hole = Shape.cylinder(radius: 3, height: 10).translated(by: SIMD3(20, 0, 0))
-    /// // Create 6 holes in a circle around the Z axis
-    /// let boltPattern = hole.circularPattern(
+    /// // Create 6 hole *tools* in a circle around the Z axis, then subtract them
+    /// let tools = hole.circularPattern(
     ///     axisPoint: .zero,
     ///     axisDirection: SIMD3(0, 0, 1),
     ///     count: 6,
     ///     angle: 0  // Full circle
     /// )
+    /// let drilled = flange.subtracting(tools!)
     /// ```
     public func circularPattern(axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>, count: Int, angle: Double = 0) -> Shape? {
         guard let handle = OCCTShapeCircularPattern(self.handle,
@@ -1559,6 +1578,48 @@ public final class Shape: @unchecked Sendable {
             return nil
         }
         return Shape(handle: handle)
+    }
+
+    /// Replicate a feature (a cut/tool shape) around an axis and subtract all
+    /// copies from this body in one operation.
+    ///
+    /// This is the feature-aware companion to
+    /// ``circularPattern(axisPoint:axisDirection:count:angle:)``. Where the plain
+    /// pattern duplicates the *body*, this one duplicates the *tool* `count` times
+    /// around the axis and subtracts the resulting compound from `self`. It is the
+    /// natural primitive for a bolt circle: build one hole tool, then pattern it.
+    ///
+    /// - Parameters:
+    ///   - tool: The cutting feature to replicate (e.g. a cylinder positioned at
+    ///     the first hole). Patterned about the same axis, then subtracted.
+    ///   - axisPoint: Point on the rotation axis
+    ///   - axisDirection: Direction of the rotation axis
+    ///   - count: Number of tool copies (including the original `tool`)
+    ///   - angle: Total angle to span in radians (0 for a full circle)
+    /// - Returns: This body with all `count` features cut out, or nil on failure
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// // Drill one hole, then repeat it 8× around the Z axis for a bolt circle
+    /// let bcr = 40.0
+    /// let hole = Shape.cylinder(radius: 3, height: 20)
+    ///     .translated(by: SIMD3(bcr, 0, 0))
+    /// let flange = blank.circularPatternCut(
+    ///     tool: hole,
+    ///     axisPoint: .zero,
+    ///     axisDirection: SIMD3(0, 0, 1),
+    ///     count: 8
+    /// )
+    /// ```
+    public func circularPatternCut(tool: Shape, axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>, count: Int, angle: Double = 0) -> Shape? {
+        guard count > 0 else { return nil }
+        guard let tools = tool.circularPattern(axisPoint: axisPoint,
+                                               axisDirection: axisDirection,
+                                               count: count, angle: angle) else {
+            return nil
+        }
+        return subtracting(tools)
     }
 
     // MARK: - Shape Type
@@ -1911,6 +1972,33 @@ extension Shape {
     public var volume: Double? {
         let v = OCCTShapeGetVolume(handle)
         return v >= 0 ? v : nil
+    }
+
+    /// Signed volume of the shape in cubic units.
+    ///
+    /// Unlike ``volume``, this preserves the sign that `BRepGProp` reports: a
+    /// reversed-orientation solid (faces pointing inward) returns a **negative**
+    /// value. Use this to detect orientation problems; use ``orientedForward()``
+    /// to fix them.
+    public var signedVolume: Double {
+        OCCTShapeGetVolume(handle)
+    }
+
+    /// Return a copy of this solid whose faces are oriented outward (positive
+    /// volume).
+    ///
+    /// Some constructors — notably ``sweep(profile:along:)``
+    /// (`BRepOffsetAPI_MakePipe`) — can produce a geometrically correct solid whose
+    /// faces point inward, so ``signedVolume`` comes back negative. That is a latent
+    /// hazard for booleans and any `volume > 0` validation. This reverses the
+    /// orientation when, and only when, the signed volume is negative; a solid that
+    /// is already forward-oriented (or a shell/face with no enclosed volume) is
+    /// returned unchanged.
+    ///
+    /// - Returns: An outward-oriented copy, `self` when no fix is needed, or nil if
+    ///   reversal fails.
+    public func orientedForward() -> Shape? {
+        signedVolume < 0 ? reversed : self
     }
 
     /// Surface area of the shape in square units
@@ -5433,6 +5521,106 @@ extension Shape {
         }
         let count = OCCTShapeCountEdgeConcavity(handle, angle, typeValue)
         return count >= 0 ? Int(count) : nil
+    }
+
+    // MARK: - Geometric Edge Selection (v1.2.1)
+
+    /// Select edges of this shape that satisfy a geometric predicate.
+    ///
+    /// This is the robust alternative to picking edges by raw index from
+    /// ``edges()`` — the index shifts as soon as the model parameters change,
+    /// whereas a geometric predicate keeps selecting the right edge. The returned
+    /// edges carry their parent index, so they feed straight into
+    /// ``filleted(edges:radius:)`` / ``chamferedTwoDistances(_:)`` etc.
+    ///
+    /// ```swift
+    /// // Round only the long edges (> 50 mm) of a bracket
+    /// let rounded = bracket.filleted(edges: bracket.edges { $0.length > 50 }, radius: 2)
+    /// ```
+    ///
+    /// - Parameter predicate: Returns true for edges to keep.
+    /// - Returns: The matching edges (possibly empty), each with a valid index.
+    public func edges(where predicate: (Edge) -> Bool) -> [Edge] {
+        edges().filter(predicate)
+    }
+
+    /// The concave edges of this solid (interior angle > 180°, e.g. the inside
+    /// corner of an L-bracket or the bottom of a groove).
+    ///
+    /// These are the edges you usually want to *fillet* — a concave fillet adds
+    /// material to soften an inside corner. Selecting them geometrically avoids the
+    /// fragile "iterate `edges()` and guess the index" workaround.
+    ///
+    /// ```swift
+    /// let rounded = bracket.filleted(edges: bracket.concaveEdges(), radius: 3)
+    /// ```
+    ///
+    /// - Parameter angle: Threshold (radians) below which an edge counts as tangent
+    ///   rather than concave (default 0.01).
+    /// - Returns: The concave edges, or an empty array if none / on error.
+    public func concaveEdges(angle: Double = 0.01) -> [Edge] {
+        (edgeConcavities(angle: angle) ?? []).compactMap { $0.1 == .concave ? $0.0 : nil }
+    }
+
+    /// The convex edges of this solid (interior angle < 180°, e.g. the outer
+    /// corners of a box).
+    ///
+    /// These are the edges you usually want to *chamfer* or round on the outside of
+    /// a part.
+    ///
+    /// - Parameter angle: Threshold (radians) below which an edge counts as tangent
+    ///   rather than convex (default 0.01).
+    /// - Returns: The convex edges, or an empty array if none / on error.
+    public func convexEdges(angle: Double = 0.01) -> [Edge] {
+        (edgeConcavities(angle: angle) ?? []).compactMap { $0.1 == .convex ? $0.0 : nil }
+    }
+
+    /// Select straight edges whose direction is parallel to the given axis.
+    ///
+    /// Only line edges are considered (curved edges have no single direction). The
+    /// test is sign-agnostic: an edge pointing along `+axis` or `-axis` both match.
+    ///
+    /// ```swift
+    /// // Round every vertical edge of an extruded prism
+    /// let rounded = part.filleted(edges: part.edges(parallelTo: SIMD3(0, 0, 1)), radius: 2)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - axis: The reference direction (need not be unit length).
+    ///   - tolerance: Maximum sine of the angle between edge and axis (default 1e-4).
+    /// - Returns: The matching straight edges, each with a valid index.
+    public func edges(parallelTo axis: SIMD3<Double>, tolerance: Double = 1e-4) -> [Edge] {
+        let axisLen = simd_length(axis)
+        guard axisLen > 0 else { return [] }
+        let a = axis / axisLen
+        return edges().filter { edge in
+            guard edge.isLine else { return false }
+            let (start, end) = edge.endpoints
+            let d = end - start
+            let len = simd_length(d)
+            guard len > 0 else { return false }
+            // |cross| = sin(theta) for unit vectors; parallel when ~0.
+            return simd_length(simd_cross(d / len, a)) <= tolerance
+        }
+    }
+
+    /// Select edges fully contained within an axis-aligned bounding region.
+    ///
+    /// An edge matches when its entire bounding box lies inside the box spanned by
+    /// `min`...`max` (inclusive). Useful for fillets that should only touch a
+    /// localised region of an already-built solid.
+    ///
+    /// - Parameters:
+    ///   - min: The lower corner of the region.
+    ///   - max: The upper corner of the region.
+    /// - Returns: The contained edges, each with a valid index.
+    public func edges(inBounds min: SIMD3<Double>, _ max: SIMD3<Double>) -> [Edge] {
+        let lo = simd_min(min, max)
+        let hi = simd_max(min, max)
+        return edges().filter { edge in
+            let b = edge.bounds
+            return all(b.min .>= lo) && all(b.max .<= hi)
+        }
     }
 
     // MARK: - Local Prism (v0.46.0)

--- a/Tests/OCCTSwiftTests/ShapeTests.swift
+++ b/Tests/OCCTSwiftTests/ShapeTests.swift
@@ -671,6 +671,53 @@ struct SweepTests {
         )!
         #expect(solid.isValid)
     }
+
+    // Issue #170: a pipe sweep must yield a positive-volume (outward-oriented)
+    // solid regardless of the section wire's sense relative to the path tangent.
+    @Test("Pipe sweep along helix is forward-oriented")
+    func pipeSweepHelixPositiveVolume() {
+        guard let section = Wire.circle(radius: 1.5) else {
+            Issue.record("Failed to create section")
+            return
+        }
+        guard let helix = Wire.helix(radius: 8, pitch: 6, turns: 3) else {
+            Issue.record("Failed to create helix")
+            return
+        }
+        guard let spring = Shape.sweep(profile: section, along: helix) else {
+            Issue.record("Failed to sweep spring")
+            return
+        }
+        #expect(spring.isValid)
+        // The whole point of the fix: signed volume comes out positive.
+        #expect(spring.signedVolume > 0)
+        #expect(spring.volume != nil)
+    }
+
+    // Issue #170: orientedForward() flips a reversed solid; leaves a good one.
+    @Test("orientedForward normalises a reversed solid")
+    func orientedForwardNormalises() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        #expect(box.signedVolume > 0)
+
+        guard let reversed = box.reversed else {
+            Issue.record("Failed to reverse box")
+            return
+        }
+        #expect(reversed.signedVolume < 0)
+
+        guard let fixed = reversed.orientedForward() else {
+            Issue.record("orientedForward returned nil")
+            return
+        }
+        #expect(fixed.signedVolume > 0)
+        // An already-forward solid is returned essentially unchanged.
+        guard let stillGood = box.orientedForward() else {
+            Issue.record("orientedForward(forward) returned nil")
+            return
+        }
+        #expect(stillGood.signedVolume > 0)
+    }
 }
 
 // MARK: - XDE Tests (v0.6.0)
@@ -2108,6 +2155,129 @@ struct PatternTests {
 
         #expect(pattern != nil)
         #expect(pattern!.isValid)
+    }
+
+    // Issue #169: feature-level circular pattern (bolt circle).
+    @Test("Circular pattern cut drills a bolt circle")
+    func circularPatternCutBoltCircle() {
+        // A flange blank: a disc 60mm dia, 10mm thick, centred on the Z axis.
+        let blank = Shape.cylinder(radius: 30, height: 10)!
+
+        // One bolt hole on a 40mm bolt-circle diameter (radius 20).
+        let hole = Shape.cylinder(radius: 3, height: 30)!
+            .translated(by: SIMD3(20, 0, -10))!
+
+        let count = 8
+        let drilled = blank.circularPatternCut(
+            tool: hole,
+            axisPoint: SIMD3(0, 0, 0),
+            axisDirection: SIMD3(0, 0, 1),
+            count: count
+        )
+
+        #expect(drilled != nil)
+        if let drilled {
+            #expect(drilled.isValid)
+            let blankVolume = blank.volume ?? 0
+            let drilledVolume = drilled.volume ?? 0
+            // Material must be REMOVED, not added (the bug patterned the body and
+            // produced ~8× the volume with the holes filled in).
+            #expect(drilledVolume < blankVolume)
+            // Roughly count holes' worth of material gone (each hole ~ pi*3^2*10).
+            let perHole = Double.pi * 9 * 10
+            let expected = blankVolume - Double(count) * perHole
+            #expect(abs(drilledVolume - expected) < 5.0)
+        }
+    }
+}
+
+
+// Issue #171: geometric edge selection for robust filleting.
+@Suite("Geometric Edge Selection")
+struct GeometricEdgeSelectionTests {
+
+    /// An L-bracket built by extruding an L-shaped profile, used to exercise the
+    /// concave/convex classification.
+    private func lBracket() -> Shape? {
+        let profile = Wire.polygon([
+            SIMD2(0, 0),
+            SIMD2(30, 0),
+            SIMD2(30, 8),
+            SIMD2(8, 8),
+            SIMD2(8, 30),
+            SIMD2(0, 30)
+        ], closed: true)
+        guard let profile else { return nil }
+        return Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 20)
+    }
+
+    @Test("edges(where:) filters by predicate and keeps indices")
+    func edgesWherePredicate() {
+        let box = Shape.box(width: 10, height: 20, depth: 30)!
+        let long = box.edges(where: { $0.length > 25 })
+        // A 10×20×30 box has 4 edges of length 30.
+        #expect(long.count == 4)
+        for e in long {
+            #expect(e.index >= 0)
+            #expect(e.length > 25)
+        }
+        // Selected edges must round successfully (proves indices are usable).
+        let rounded = box.filleted(edges: long, radius: 1)
+        #expect(rounded != nil)
+    }
+
+    @Test("concaveEdges finds the inside corner of an L-bracket")
+    func concaveEdgesLBracket() {
+        guard let bracket = lBracket() else {
+            Issue.record("Failed to build L-bracket")
+            return
+        }
+        let concave = bracket.concaveEdges()
+        // The reentrant inside corner is concave; only a small minority of the
+        // bracket's edges are (the rest of an L-prism is convex/tangent).
+        #expect(concave.count >= 1)
+        #expect(concave.count < bracket.edgeCount)
+        for e in concave { #expect(e.index >= 0) }
+
+        // The whole point of issue #171: these select straight into a fillet.
+        let rounded = bracket.filleted(edges: concave, radius: 2)
+        #expect(rounded != nil)
+        if let rounded { #expect(rounded.isValid) }
+    }
+
+    @Test("convexEdges returns the outer edges of a box")
+    func convexEdgesBox() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let convex = box.convexEdges()
+        // All 12 edges of a box are convex.
+        #expect(convex.count == 12)
+        #expect(box.concaveEdges().isEmpty)
+    }
+
+    @Test("edges(parallelTo:) selects the vertical edges of a prism")
+    func edgesParallelToAxis() {
+        let box = Shape.box(width: 10, height: 20, depth: 30)!
+        let vertical = box.edges(parallelTo: SIMD3(0, 0, 1))
+        // 4 edges run along Z (the depth, length 30).
+        #expect(vertical.count == 4)
+        for e in vertical { #expect(abs(e.length - 30) < 1e-6) }
+        // Sign-agnostic: -Z gives the same edges.
+        #expect(box.edges(parallelTo: SIMD3(0, 0, -1)).count == 4)
+    }
+
+    @Test("edges(inBounds:) selects edges within a region")
+    func edgesInBounds() {
+        // Shape.box is centred at the origin, so a 10-cube spans [-5, 5].
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        // A region hugging the bottom (z = -5) face contains its 4 edges.
+        let bottom = box.edges(inBounds: SIMD3(-6, -6, -5.1), SIMD3(6, 6, -4.9))
+        #expect(bottom.count == 4)
+        for e in bottom {
+            #expect(e.bounds.max.z < -4.9)
+        }
+        // A region covering the whole box contains every edge.
+        let all = box.edges(inBounds: SIMD3(-6, -6, -6), SIMD3(6, 6, 6))
+        #expect(all.count == box.edgeCount)
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,47 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.2.0
+## Current: v1.2.1
 
 **4,286 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.2.1 (June 2026) — feature-aware patterning, sweep orientation, geometric edge selection (closes #169, #170, #171)
+
+**PATCH — additive helpers + one orientation fix.** Three ergonomics gaps surfaced building the
+OCCTSwiftScripts cookbook recipes (pipe-flange, helical-spring, mounting-bracket). No C++ bridge
+change — everything composes existing tested primitives.
+
+- **#169 — feature-level circular pattern.** `circularPattern` duplicates the *body*, so the
+  bolt-circle intent ("drill one hole, repeat it around the axis") produced overlapping flange
+  copies with the holes filled in. New `Shape.circularPatternCut(tool:axisPoint:axisDirection:count:angle:)`
+  patterns the *tool* and subtracts the compound in one call; `circularPattern`'s doc now warns it
+  patterns the body, not features.
+
+  ```swift
+  let flange = blank.circularPatternCut(tool: hole, axisPoint: .zero,
+                                        axisDirection: SIMD3(0,0,1), count: 8)
+  ```
+
+- **#170 — sweep orientation.** `Shape.sweep` (`BRepOffsetAPI_MakePipe`) could yield an
+  inward-oriented (negative-volume) solid depending on the section wire's sense vs. the path
+  tangent — a hazard for booleans and `volume > 0` checks. `sweep` now orientation-normalises its
+  result. New `Shape.orientedForward()` applies the same fix explicitly, and `Shape.signedVolume`
+  exposes the signed `BRepGProp` mass for orientation diagnostics (unlike `volume`, which masks
+  negatives as `nil`).
+
+- **#171 — geometric edge selection.** Picking fillet edges by raw `edges()` index is fragile —
+  the index shifts with parameters. New selectors return edges that feed straight into
+  `filleted(edges:radius:)`: `concaveEdges()` / `convexEdges()` (classified via `BRepOffset_Analyse`),
+  `edges(where:)`, `edges(parallelTo:tolerance:)`, and `edges(inBounds:_:)`.
+
+  ```swift
+  let rounded = bracket.filleted(edges: bracket.concaveEdges(), radius: 3)
+  ```
+
 
 ### v1.2.0 (June 2026) — TopologyGraph attribute store + Codable snapshot (closes #168)
 


### PR DESCRIPTION
Fixes three ergonomics gaps surfaced building the [OCCTSwiftScripts](https://github.com/gsdali/OCCTSwiftScripts) cookbook recipes (pipe-flange, helical-spring, mounting-bracket). All three compose existing tested primitives — **no C++ bridge change**.

## #169 — feature-level circular pattern
`circularPattern` duplicates the whole **body**, so the bolt-circle intent ("drill one hole, repeat it around the axis") produced 8 overlapping flange copies with the holes filled in. New:

```swift
public func circularPatternCut(tool: Shape, axisPoint:, axisDirection:, count:, angle: = 0) -> Shape?
```

It patterns the *tool* about the axis and subtracts the resulting compound from the body in one call. `circularPattern`'s doc comment now warns that it duplicates the body, not features, and points to the new helper.

```swift
let flange = blank.circularPatternCut(tool: hole, axisPoint: .zero,
                                      axisDirection: SIMD3(0,0,1), count: 8)
```

## #170 — sweep orientation
`Shape.sweep` (`BRepOffsetAPI_MakePipe`) could yield a geometrically-correct but **inward-oriented (negative-volume)** solid, depending on the section wire's sense relative to the path tangent — a latent hazard for downstream booleans and `volume > 0` validation. Changes:

- `Shape.sweep` now **orientation-normalises** its result, so the swept solid always has positive volume regardless of section sense. No more "point the section normal against the tangent" incantation.
- New `Shape.orientedForward()` applies the same fix explicitly (reverses iff signed volume is negative; returns a shell/face unchanged).
- New `Shape.signedVolume` exposes the signed `BRepGProp` mass for orientation diagnostics (`volume` masks negatives as `nil`).

## #171 — geometric edge selection
Picking fillet edges by raw `edges()` index is fragile — the index shifts as soon as parameters change. New selectors, all returning edges that carry their parent index so they feed straight into `filleted(edges:radius:)`:

- `concaveEdges(angle:)` / `convexEdges(angle:)` — classified via `BRepOffset_Analyse`
- `edges(where:)` — arbitrary predicate
- `edges(parallelTo:tolerance:)` — straight edges parallel to an axis (sign-agnostic)
- `edges(inBounds:_:)` — edges fully contained in an axis-aligned region

```swift
let rounded = bracket.filleted(edges: bracket.concaveEdges(), radius: 3)
```

## Testing
- 11 new tests added across `PatternTests`, `SweepTests`, and a new `GeometricEdgeSelectionTests` suite — all pass.
- `swift build` clean.
- The only full-suite failures are **pre-existing and unrelated**: `HyperbolaThreePointsTests` (confirmed failing on the base commit without these changes) and the documented non-deterministic NCollection-overflow SEGV noted in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)