### PR TITLE
fix(loft): guard ThruSections polar-method SIGSEGV on mismatched profiles (#176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,11 @@ Opaque handle types (`OCCTShapeRef`, `OCCTWireRef`, `OCCTFaceRef`, `OCCTEdgeRef`
 - `BRepExtrema_ExtCC` crashes when edges are parallel — guard with `if (result.isParallel) { return result; }` before accessing points
 - Container-overflow in NCollection on arm64 macOS — pre-existing OCCT race condition that manifests as non-deterministic SEGV under parallel test execution
 - `LocOpe_SplitDrafts` throws on incompatible geometry — always wrap `Perform()` in try-catch in bridge
+- `BRepOffsetAPI_ThruSections` (loft) SIGSEGVs (null deref, "Address 8") on mismatched closed profiles — `BRepFill_CompatibleWires::SameNumberByPolarMethod` over-advances an unguarded correspondence-list iterator. It's an OS signal, so the bridge `catch(...)` cannot save it. Fixed by the source patch in `Scripts/patches/0001-BRepFill_CompatibleWires-guard-polar-iterator.patch`, applied by `build-occt.sh` at xcframework build time (filed upstream; issue #176). Note: `OCC_CATCH_SIGNALS` is inert in our build (no `OCC_CONVERT_SIGNALS`) — do not rely on it for signal safety.
+
+### Carrying OCCT source patches
+
+`Scripts/patches/*.patch` are upstream-bound fixes applied to `occt-src` (idempotently) by `build-occt.sh` before each cmake build. Drop a `git diff` (`-p1`, prefixes `a/`,`b/`) in that dir to carry a new one. Existing build trees (`occt-build-*`) pin a stale macOS SDK sysroot and can no longer incrementally compile — a fresh `cmake` configure (clean build dir) is required to pick up patches.
 
 ## Release Process
 

--- a/Scripts/build-occt.sh
+++ b/Scripts/build-occt.sh
@@ -77,6 +77,28 @@ else
 fi
 
 # --------------------
+# Apply local OCCT patches (idempotent)
+# --------------------
+# Patches in Scripts/patches/ are upstream-bound bug fixes we carry until they
+# ship in an OCCT release. Each is applied with -p1 relative to occt-src.
+#   0001  BRepFill_CompatibleWires polar-iterator over-advance -> SIGSEGV on
+#         mismatched closed loft profiles (filed upstream; OCCTSwift issue #176)
+if compgen -G "$SCRIPT_DIR/patches/*.patch" > /dev/null; then
+    echo ">>> Applying local OCCT patches..."
+    for p in "$SCRIPT_DIR"/patches/*.patch; do
+        if git -C occt-src apply --reverse --check "$p" 2>/dev/null; then
+            echo "    already applied: $(basename "$p")"
+        elif git -C occt-src apply --check "$p" 2>/dev/null; then
+            git -C occt-src apply "$p"
+            echo "    applied: $(basename "$p")"
+        else
+            echo "    ERROR: cannot apply $(basename "$p") cleanly" >&2
+            exit 1
+        fi
+    done
+fi
+
+# --------------------
 # Common CMake options (minimal build for modeling + export)
 # --------------------
 

--- a/Scripts/patches/0001-BRepFill_CompatibleWires-guard-polar-iterator.patch
+++ b/Scripts/patches/0001-BRepFill_CompatibleWires-guard-polar-iterator.patch
@@ -1,0 +1,29 @@
+diff --git a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
+index 71cd13ee..2af535c7 100644
+--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
++++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
+@@ -1307,12 +1307,23 @@ void BRepFill_CompatibleWires::SameNumberByPolarMethod(const bool WithRotation)
+     gp_Pnt                                   PPs = Curve.Value(0.1 * (U1 + 9 * U2));
+     NCollection_List<TopoDS_Shape>::Iterator itF(MapVLV(VF)), itL(MapVLV(VL));
+     int                                      rang = ideb;
+-    while (rang < i)
++    while (rang < i && itF.More() && itL.More())
+     {
+       itF.Next();
+       itL.Next();
+       rang++;
+     }
++    if (!itF.More() || !itL.More())
++    {
++      // The vertex-correspondence chain in MapVLV is shorter than the section
++      // index: the polar method failed to propagate a correspondence to every
++      // section (e.g. wildly mismatched / non-coaxial closed profiles). Without
++      // this guard the iterators advance past the end of the list and
++      // itF.Value()/itL.Value() dereference a null node (Address 8) -> SIGSEGV
++      // in release builds. Fail gracefully instead.
++      myStatus = BRepFill_ThruSectionErrorStatus_Failed;
++      return;
++    }
+     TopoDS_Vertex   V1 = TopoDS::Vertex(itF.Value()), V2 = TopoDS::Vertex(itL.Value());
+     TopoDS_Edge     Esol;
+     double          scalmax = 0.;

--- a/Tests/OCCTSwiftTests/ShapeTests.swift
+++ b/Tests/OCCTSwiftTests/ShapeTests.swift
@@ -9774,8 +9774,11 @@ struct DistAngleChamferTests {
 @Suite("OCCT signal handling (#175)")
 struct OCCTSignalHandlingTests {
     /// Degenerate / incompatible loft profiles must FAIL GRACEFULLY (return nil) rather than
-    /// SIGSEGV the process — proves OSD::SetSignal + OCC_CATCH_SIGNALS convert the OCCT signal into
-    /// a catchable Standard_Failure. If signal handling regresses, this test crashes the runner.
+    /// SIGSEGV the process. NOTE: the SIGSEGV class here is NOT caught by OCC_CATCH_SIGNALS — that
+    /// macro is inert unless OCCT is compiled with OCC_CONVERT_SIGNALS (it is not, by design: the
+    /// setjmp/longjmp path corrupts allocator state). The crash is instead prevented at source by
+    /// the BRepFill_CompatibleWires polar-iterator guard carried in Scripts/patches/ (issue #176).
+    /// If that patch is dropped from the xcframework, this test crashes the runner.
     @Test("Degenerate loft returns nil, does not crash")
     func degenerateLoftIsCaught() {
         // A valid square, a wildly different many-gon, and a near-degenerate (collinear) wire —
@@ -9789,6 +9792,40 @@ struct OCCTSignalHandlingTests {
         // Tessellating a possibly-invalid solid must also not crash.
         if let s = Shape.box(width: 1, height: 1, depth: 1) { _ = s.mesh(linearDeflection: 0.01) }
         #expect(Bool(true))   // reaching here means no crash
+    }
+}
+
+@Suite("Loft polar-method SIGSEGV regression (#176)")
+struct LoftPolarMethodCrashTests {
+    /// Exact profile set from issue #176 (Kiha 40 body 1068): 8 mismatched convex polygons
+    /// (alternating 5- and 4-vertex, with a 2.5-unit gap near z=0). On an UNPATCHED OCCT this
+    /// deterministically SIGSEGVs single-threaded inside
+    /// BRepFill_CompatibleWires::SameNumberByPolarMethod — the correspondence-list iterators
+    /// over-advance and dereference a null list node ("Address 8"). The bridge's catch(...) cannot
+    /// save it (it is an OS signal, not a C++ exception). The fix is the source patch in
+    /// Scripts/patches/0001-BRepFill_CompatibleWires-guard-polar-iterator.patch. With it, Build()
+    /// fails gracefully (this returns nil) instead of crashing. If this test ever crashes the
+    /// runner, the patch has been lost from the xcframework.
+    @Test("Mismatched polar-method profiles return without crashing")
+    func mismatchedPolarProfilesDoNotCrash() {
+        // local (x, y) per station; z is the third tuple element
+        let stations: [(z: Double, pts: [(Double, Double)])] = [
+            (-3.7500, [(-0.0502, 2.1681), (-0.0162, 0.2239), (0.0463, 0.2250), (0.0357, 0.8300), (0.0123, 2.1692)]),
+            (-2.9167, [(-0.0162, 0.2239), (0.0007, -0.7416), (0.0632, -0.7405), (0.0556, -0.3053), (0.0463, 0.2250)]),
+            (-2.0833, [(-0.0451, -1.2651), (0.0174, -1.2640), (0.0689, -1.0639), (0.0632, -0.7405), (0.0007, -0.7416)]),
+            (-1.2500, [(-0.1048, -1.3334), (-0.0423, -1.3323), (0.0174, -1.2640), (-0.0451, -1.2651)]),
+            (1.2500,  [(-0.1048, -1.3334), (-0.0423, -1.3323), (0.0174, -1.2640), (-0.0451, -1.2651)]),
+            (2.0833,  [(-0.0451, -1.2651), (0.0174, -1.2640), (0.0689, -1.0639), (0.0632, -0.7405), (0.0007, -0.7416)]),
+            (2.9167,  [(-0.0162, 0.2239), (0.0007, -0.7416), (0.0632, -0.7405), (0.0556, -0.3053), (0.0463, 0.2250)]),
+            (3.7500,  [(-0.0502, 2.1681), (-0.0162, 0.2239), (0.0463, 0.2250), (0.0357, 0.8300), (0.0123, 2.1692)]),
+        ]
+        let profiles = stations.compactMap { station in
+            Wire.polygon3D(station.pts.map { SIMD3($0.0, $0.1, station.z) }, closed: true)
+        }
+        #expect(profiles.count == stations.count)
+        // The call must return (nil or a shape) without aborting the process.
+        _ = Shape.loft(profiles: profiles, solid: true)
+        #expect(Bool(true))   // reaching here means the polar-method crash did not fire
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,30 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.2.0
+## Current: v1.3.1
 
 **4,286 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.3.1 (June 2026) — fix loft (ThruSections) SIGSEGV on mismatched profiles (closes #176)
+
+**PATCH — robustness fix, no API change.** `Shape.loft` (and any `BRepOffsetAPI_ThruSections`
+path) could SIGSEGV and abort the host process on mismatched closed profiles — e.g. machine-generated
+profile sets with differing vertex counts. The crash is an upstream OCCT null dereference in
+`BRepFill_CompatibleWires::SameNumberByPolarMethod` (unguarded correspondence-list iterator
+over-advance); because it surfaces as an OS signal, the bridge's `catch(...)` could not intercept it.
+
+Fixed by carrying a minimal source patch
+(`Scripts/patches/0001-BRepFill_CompatibleWires-guard-polar-iterator.patch`, applied by
+`build-occt.sh`) and rebuilding the xcframework. Loft now fails gracefully (`nil`) on such inputs.
+Reported and fixed upstream: OpenCASCADE/OCCT issue #1297, PR #1298.
+
+Note: the `OCC_CATCH_SIGNALS` guards added in v1.2.1/v1.2.2 are inert in this build (OCCT is not
+compiled with `OCC_CONVERT_SIGNALS`) and do not provide signal safety; this patch addresses the
+crash at its source instead.
 
 ### v1.2.0 (June 2026) — TopologyGraph attribute store + Codable snapshot (closes #168)
 


### PR DESCRIPTION
## Summary

Fixes the deterministic loft/`ThruSections` **SIGSEGV** reported in #176 (follow-up to #175). The crash is an upstream OCCT null dereference; we carry a minimal source patch and rebuild the xcframework.

## Root cause

`BRepFill_CompatibleWires::SameNumberByPolarMethod` advances the `MapVLV` vertex-correspondence-list iterators (`itF`/`itL`) with **no `More()` guard**, then dereferences `itF.Value()`/`itL.Value()`. On mismatched closed profiles the correspondence chain is shorter than the section index, so the iterators run off the end and read a null list node → SIGSEGV at "Address 8". It's **release-only UB** (a debug build returns `IsDone()==0`), and because it surfaces as an **OS signal** the bridge's `catch(...)` can't intercept it.

Also confirmed: `OCC_CATCH_SIGNALS` (added in v1.2.1/v1.2.2) is **inert** in our build — it expands to nothing without `OCC_CONVERT_SIGNALS`, which we don't define (the setjmp/longjmp path corrupts allocator state). Those guards don't provide signal safety; this PR fixes the crash at its source instead and corrects the misleading test comment.

## Changes

- **`Scripts/patches/0001-BRepFill_CompatibleWires-guard-polar-iterator.patch`** — 6-line `More()` guard → `myStatus = Failed; return`, consistent with the function's other failure exits.
- **`Scripts/build-occt.sh`** — applies `Scripts/patches/*.patch` to `occt-src` idempotently before each cmake build (detects already-applied via `git apply --reverse --check`).
- **`Tests/OCCTSwiftTests/ShapeTests.swift`** — new suite `Loft polar-method SIGSEGV regression (#176)` using the exact body-1068 profile set; corrected the `#175` signal-handling comment.
- **`CLAUDE.md`** — Known OCCT Bugs entry + how patches are carried.
- **`docs/CHANGELOG.md`** — v1.3.1 entry.

## Validation

- Reproduced the SIGSEGV in pure C++ (exit 139), backtrace → `SameNumberByPolarMethod`.
- Proved the fix: patched TU linked **ahead of the real release archive** → crash gone, `IsDone=0`.
- Rebuilt the OCCT slice with the patch; the new regression test **passes patched** and **SIGSEGVs ("Address 8") on the unpatched lib** (negative control). No regression in valid lofts (ruled/shell/smooth).

## Upstream

Reported and fixed upstream: **OpenCASCADE/OCCT#1297** (issue), **OpenCASCADE/OCCT#1298** (PR, ready for review, CLA approved, CI green).

## Note for release

The crash fix only takes effect once the **xcframework is rebuilt** with the patch (the binary is a gitignored release artifact). This branch's source changes + a full `build-occt.sh` rebuild are both required. The v1.3.1 release (zip, checksum, `Package.swift` URL/checksum bump, tag, asset upload) is a follow-up once this merges — the 7-platform rebuild is already done locally and validated on macOS.

Closes #176.
