### PR TITLE
feat(sweep): multi-section pipe shell — Shape.pipeShellMultiSection (closes #180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,286 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0
+**4,287 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1511,6 +1511,30 @@ OCCTShapeRef OCCTShapeCreatePipeShellWithBinormal(OCCTWireRef spine, OCCTWireRef
 OCCTShapeRef OCCTShapeCreatePipeShellWithAuxSpine(OCCTWireRef spine, OCCTWireRef profile,
                                                    OCCTWireRef auxSpine, bool solid);
 
+/// Create a variable-section pipe shell from several profiles (issue #180).
+/// Adds each profile (positioned in 3D along the spine) to a single
+/// BRepOffsetAPI_MakePipeShell, producing a smooth swept solid/shell that
+/// interpolates between sections. Supports every orientation mode:
+///   - OCCTPipeModeFixedBinormal uses (bnX, bnY, bnZ)
+///   - OCCTPipeModeAuxiliary uses auxSpine (must be non-NULL for that mode)
+/// @param spine Path wire for sweep
+/// @param profiles Array of profile wires (length profileCount, all non-NULL)
+/// @param profileCount Number of profiles (>= 1)
+/// @param mode Sweep mode controlling profile orientation
+/// @param bnX, bnY, bnZ Fixed binormal (used only for OCCTPipeModeFixedBinormal)
+/// @param auxSpine Auxiliary spine (used only for OCCTPipeModeAuxiliary; else NULL)
+/// @param withContact If true, move each profile to touch the spine before sweeping
+/// @param withCorrection If true, rotate the profile to stay orthogonal to the spine
+/// @param solid If true, create solid; if false, create shell
+/// @return Swept shape, or NULL on failure
+OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
+                                                  const OCCTWireRef* profiles, int32_t profileCount,
+                                                  OCCTPipeMode mode,
+                                                  double bnX, double bnY, double bnZ,
+                                                  OCCTWireRef auxSpine,
+                                                  bool withContact, bool withCorrection,
+                                                  bool solid);
+
 
 // MARK: - Surfaces & Curves (v0.9.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -556,6 +556,60 @@ OCCTShapeRef OCCTShapeCreatePipeShellWithAuxSpine(OCCTWireRef spine, OCCTWireRef
     }
 }
 
+// Multi-section pipe shell (#180): one MakePipeShell, several Add() calls.
+OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
+                                                  const OCCTWireRef* profiles, int32_t profileCount,
+                                                  OCCTPipeMode mode,
+                                                  double bnX, double bnY, double bnZ,
+                                                  OCCTWireRef auxSpine,
+                                                  bool withContact, bool withCorrection,
+                                                  bool solid) {
+    if (!spine || !profiles || profileCount < 1) return nullptr;
+    if (mode == OCCTPipeModeAuxiliary && !auxSpine) return nullptr;
+
+    try {
+        BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
+
+        switch (mode) {
+            case OCCTPipeModeFrenet:
+                pipeShell.SetMode(Standard_False);
+                break;
+            case OCCTPipeModeCorrectedFrenet:
+                pipeShell.SetMode(Standard_True);
+                break;
+            case OCCTPipeModeFixedBinormal:
+                pipeShell.SetMode(gp_Dir(bnX, bnY, bnZ));
+                break;
+            case OCCTPipeModeAuxiliary:
+                pipeShell.SetMode(auxSpine->wire, Standard_False);
+                break;
+        }
+
+        // Add every profile (variable cross-section).
+        for (int32_t i = 0; i < profileCount; ++i) {
+            if (!profiles[i]) return nullptr;
+            pipeShell.Add(profiles[i]->wire,
+                          withContact ? Standard_True : Standard_False,
+                          withCorrection ? Standard_True : Standard_False);
+        }
+
+        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
+        pipeShell.Build();
+        if (!pipeShell.IsDone()) return nullptr;
+
+        TopoDS_Shape result = pipeShell.Shape();
+        if (solid) {
+            pipeShell.MakeSolid();
+            if (pipeShell.IsDone()) {
+                result = pipeShell.Shape();
+            }
+        }
+        return new OCCTShape(result);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 // MARK: - Surface Construction (v0.9.0)
 
 OCCTShapeRef OCCTShapeCreateBSplineSurface(const double* poles, int32_t uCount, int32_t vCount,

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2360,6 +2360,60 @@ extension Shape {
         return Shape(handle: result)
     }
 
+    /// Sweep several profiles along a spine for a variable-section pipe shell.
+    ///
+    /// This is the multi-section form of ``pipeShell(spine:profile:mode:solid:)``: each
+    /// profile is positioned in 3D at its station along the spine, and OCCT interpolates a
+    /// smooth solid (or shell) that passes through every section. It supports the same
+    /// orientation modes — including ``PipeSweepMode/auxiliary(spine:)``, which keeps the
+    /// section oriented by a secondary curve (e.g. a thread rib that ramps from a runout to
+    /// full crest along a helix while staying radial to the axis).
+    ///
+    /// - Parameters:
+    ///   - spine: Path wire along which to sweep.
+    ///   - profiles: Profile wires, each positioned at its station along the spine. At least
+    ///     one is required; two or more give a genuinely varying section.
+    ///   - mode: Sweep mode controlling profile orientation (incl. `.auxiliary(spine:)`).
+    ///   - withContact: If true, each profile is moved to touch the spine before sweeping.
+    ///   - withCorrection: If true, each profile is rotated to stay orthogonal to the spine.
+    ///   - solid: If true, create a solid; if false, a shell.
+    /// - Returns: Swept shape, or nil on failure.
+    public static func pipeShellMultiSection(
+        spine: Wire,
+        profiles: [Wire],
+        mode: PipeSweepMode = .frenet,
+        withContact: Bool = false,
+        withCorrection: Bool = false,
+        solid: Bool = true
+    ) -> Shape? {
+        guard !profiles.isEmpty else { return nil }
+
+        let modeValue: OCCTPipeMode
+        var binormal = SIMD3<Double>(0, 0, 0)
+        var auxHandle: OCCTWireRef? = nil
+        switch mode {
+        case .frenet:
+            modeValue = OCCTPipeModeFrenet
+        case .correctedFrenet:
+            modeValue = OCCTPipeModeCorrectedFrenet
+        case .fixed(let bn):
+            modeValue = OCCTPipeModeFixedBinormal
+            binormal = bn
+        case .auxiliary(let aux):
+            modeValue = OCCTPipeModeAuxiliary
+            auxHandle = aux.handle
+        }
+
+        let handles: [OCCTWireRef?] = profiles.map { $0.handle }
+        guard let result = handles.withUnsafeBufferPointer({ buffer in
+            OCCTShapeCreatePipeShellMultiSection(
+                spine.handle, buffer.baseAddress, Int32(profiles.count),
+                modeValue, binormal.x, binormal.y, binormal.z,
+                auxHandle, withContact, withCorrection, solid)
+        }) else { return nil }
+        return Shape(handle: result)
+    }
+
     // MARK: - Surface Creation (v0.9.0)
 
     /// Create a B-spline surface from a grid of control points.

--- a/Tests/OCCTSwiftTests/ShapeTests.swift
+++ b/Tests/OCCTSwiftTests/ShapeTests.swift
@@ -1275,6 +1275,54 @@ struct AdvancedModelingTests {
         #expect(shell != nil)
     }
 
+    // MARK: - Multi-section pipe shell (#180)
+
+    @Test("Multi-section pipe shell (Frenet) sweeps varying-radius circles into a valid solid")
+    func multiSectionFrenetVaryingRadius() {
+        guard let spine = Wire.line(from: .zero, to: SIMD3(0, 0, 10)) else {
+            Issue.record("Could not create spine"); return
+        }
+        // Three coaxial circles of different radius at z = 0, 5, 10 (a "vase").
+        let stations = Array(zip([0.0, 5.0, 10.0], [2.0, 1.0, 2.0])).compactMap {
+            Wire.circle(origin: SIMD3(0, 0, $0.0), normal: SIMD3(0, 0, 1), radius: $0.1)
+        }
+        #expect(stations.count == 3)
+
+        let pipe = Shape.pipeShellMultiSection(spine: spine, profiles: stations, mode: .frenet, solid: true)
+        #expect(pipe != nil)
+        if let pipe {
+            #expect(pipe.isValid)
+            if let v = pipe.volume { #expect(v > 0) }
+        }
+    }
+
+    @Test("Multi-section pipe shell with auxiliary spine (the #180 worm-thread case)")
+    func multiSectionAuxiliarySpine() {
+        guard let spine = Wire.line(from: .zero, to: SIMD3(0, 0, 10)),
+              let aux = Wire.line(from: SIMD3(3, 0, 0), to: SIMD3(3, 0, 10)) else {
+            Issue.record("Could not create spine/aux"); return
+        }
+        guard let c0 = Wire.circle(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), radius: 2.0),
+              let c1 = Wire.circle(origin: SIMD3(0, 0, 10), normal: SIMD3(0, 0, 1), radius: 1.0) else {
+            Issue.record("Could not create profiles"); return
+        }
+        let pipe = Shape.pipeShellMultiSection(
+            spine: spine, profiles: [c0, c1], mode: .auxiliary(spine: aux), solid: true)
+        #expect(pipe != nil)
+        if let pipe { #expect(pipe.isValid) }
+    }
+
+    @Test("Multi-section pipe shell: empty profiles return nil, single profile is allowed")
+    func multiSectionProfileCountBounds() {
+        guard let spine = Wire.line(from: .zero, to: SIMD3(0, 0, 10)),
+              let one = Wire.circle(origin: .zero, normal: SIMD3(0, 0, 1), radius: 2.0) else {
+            Issue.record("Could not create spine/profile"); return
+        }
+        #expect(Shape.pipeShellMultiSection(spine: spine, profiles: []) == nil)
+        // A single profile degenerates to an ordinary pipe shell — must still build.
+        #expect(Shape.pipeShellMultiSection(spine: spine, profiles: [one], mode: .frenet) != nil)
+    }
+
     // MARK: - Curve Analysis Tests (v0.9.0)
 
     @Test("Wire length of straight line")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,26 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.3.2
+## Current: v1.3.3
 
-**4,286 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
+**4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.3.3 (June 2026) — multi-section pipe shell (closes #180)
+
+**PATCH — additive API.** Adds `Shape.pipeShellMultiSection(spine:profiles:mode:withContact:withCorrection:solid:)`,
+the multi-section form of `pipeShell`. Several profiles positioned along the spine are swept into a
+single variable cross-section solid/shell via repeated `BRepOffsetAPI_MakePipeShell::Add`. Supports
+all orientation modes including `.auxiliary(spine:)`, so a thread rib can ramp from a runout to full
+crest along a helix while staying radial — the worm-thread case that single-profile `pipeShellWithLaw`
+(Frenet-only, degenerates on near-zero scaling) could not express.
+
+```swift
+Shape.pipeShellMultiSection(spine: helix, profiles: [fullRib, runoutRib], mode: .auxiliary(spine: axis))
+```
 
 ### v1.3.2 (June 2026) — fix loft (ThruSections) SIGSEGV on mismatched profiles (closes #176)
 


### PR DESCRIPTION
## Summary

Closes #180 — adds a multi-section (variable cross-section) pipe-shell wrapper.

`BRepOffsetAPI_MakePipeShell` supports adding **several** profiles along the spine to interpolate a smooth variable-section sweep. OCCTSwift previously wrapped only the single-profile cases (`pipeShell`, `pipeShellWithTransition`, `pipeShellWithLaw`). This adds the multi-section form, including the combination of multiple profiles **with auxiliary-spine orientation** that the motivating use case (worm-thread runout in OCCTReconstruct) needs.

## API

```swift
public static func pipeShellMultiSection(
    spine: Wire,
    profiles: [Wire],                 // positioned in 3D at their stations along the spine
    mode: PipeSweepMode = .frenet,    // incl. .auxiliary(spine:)
    withContact: Bool = false,
    withCorrection: Bool = false,
    solid: Bool = true
) -> Shape?
```

Backed by one new bridge function `OCCTShapeCreatePipeShellMultiSection` (one `MakePipeShell`, a `SetMode` per the chosen mode, an `Add(profile, withContact, withCorrection)` per profile, then `Build`/`MakeSolid`).

## Why this over `pipeShellWithLaw`

For the worm-thread runout, the single-profile law approach fails every way (Frenet-only loses the radial orientation; scaling a section toward ~0 degenerates the pipe). Adding the full rib at the inner station and a small rib at the runout end with `.auxiliary(spine:)` lets OCCT interpolate the crest ramp in one valid solid.

## Validation

- **Ground-truth C++** (all build valid solids): Frenet 3-section (vol 58.64), auxiliary-spine on a smooth helix (vol 32.49), auxiliary-spine straight ± contact (vol 73.30).
- **Swift tests** (3, all pass):
  - Frenet varying-radius circles → non-nil, `isValid`, volume > 0
  - Auxiliary-spine 2-section (the #180 worm-thread case) → non-nil, `isValid`
  - Empty profiles → nil; single profile → still builds
- `swift build` clean; `swift test --filter multiSection` green.

## Docs

- CHANGELOG: v1.3.3 entry. README op count 4,286 → 4,287. (Patch bump — tiny additive API.)

No ABI/behaviour change to existing APIs; purely additive.
