### PR TITLE
fix(robustness): serialize STEP writers + guard threadedShaft envelope (#181 B/C)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -136,6 +136,9 @@ bool OCCTDocumentWriteSTEP(OCCTDocumentRef doc, const char* path) {
     if (!doc || !path) return false;
 
     try {
+        // STEP and IGES writers share OCCT's non-thread-safe Interface_Static
+        // globals; serialize all DE writes on one lock (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         STEPCAFControl_Writer writer;
         writer.SetColorMode(Standard_True);
         writer.SetNameMode(Standard_True);

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -108,6 +108,8 @@ bool OCCTExportSTEP(OCCTShapeRef shape, const char* path) {
     if (!shape || !path) return false;
 
     try {
+        // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         // Use a scoped block to ensure all OCCT objects are destroyed before return
         bool success = false;
         {
@@ -417,6 +419,8 @@ bool OCCTExportSTEPProgress(OCCTShapeRef shape, const char* path,
     clearCancelOut(outCancelled);
     if (!shape || !path) return false;
     try {
+        // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
         Interface_Static::SetCVal("write.step.schema", "AP214");
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
@@ -469,6 +473,8 @@ bool OCCTDocumentWriteSTEPProgress(OCCTDocumentRef doc, const char* path,
     clearCancelOut(outCancelled);
     if (!doc || !path) return false;
     try {
+        // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         STEPCAFControl_Writer writer;
         writer.SetColorMode(Standard_True);
         writer.SetNameMode(Standard_True);
@@ -907,6 +913,8 @@ bool OCCTExportPLY(OCCTShapeRef shape, const char* path, double deflection) {
 bool OCCTExportSTEPWithMode(OCCTShapeRef shape, const char* path, int32_t modelType) {
     if (!shape || !path) return false;
     try {
+        // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
         Interface_Static::SetCVal("write.step.schema", "AP214");
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
@@ -921,6 +929,8 @@ bool OCCTExportSTEPWithModeAndTolerance(OCCTShapeRef shape, const char* path,
                                          int32_t modelType, double tolerance) {
     if (!shape || !path) return false;
     try {
+        // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
         Interface_Static::SetCVal("write.step.schema", "AP214");
         writer.SetTolerance(tolerance);
@@ -935,6 +945,8 @@ bool OCCTExportSTEPWithModeAndTolerance(OCCTShapeRef shape, const char* path,
 bool OCCTExportSTEPCleanDuplicates(OCCTShapeRef shape, const char* path, int32_t modelType) {
     if (!shape || !path) return false;
     try {
+        // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
+        std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
         Interface_Static::SetCVal("write.step.schema", "AP214");
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);

--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -322,6 +322,23 @@ extension Shape {
         }
         guard let threaded = self.subtracting(combinedCutter) else { return nil }
 
+        // A thread cut only removes material, so a correct result is a subset of the
+        // blank: its bounds must lie within the blank's (plus numeric tolerance). When
+        // the helical V-cutter self-intersects (coarse pitch / steep lead, but also
+        // observed at bolt pitch) OCCT's boolean yields a non-deterministic solid that
+        // can extend well outside the blank — BRepCheck still reports it "valid", so the
+        // envelope is the reliable signal. Such a solid crashes downstream STEP export;
+        // reject it rather than return garbage (#181-C). Callers can fall back (e.g. a
+        // smooth-cylinder worm body). NOTE: the cut is a subset of the blank, so this
+        // guard never rejects a geometrically correct thread.
+        let blank = self.bounds, cut = threaded.bounds
+        let extent = blank.max - blank.min
+        let tol = 1e-6 + 1e-3 * max(extent.x, max(extent.y, extent.z))
+        guard cut.min.x >= blank.min.x - tol, cut.min.y >= blank.min.y - tol,
+              cut.min.z >= blank.min.z - tol, cut.max.x <= blank.max.x + tol,
+              cut.max.y <= blank.max.y + tol, cut.max.z <= blank.max.z + tol
+        else { return nil }
+
         switch runout {
         case .none:
             return threaded

--- a/Tests/OCCTSwiftTests/Issue181RobustnessTests.swift
+++ b/Tests/OCCTSwiftTests/Issue181RobustnessTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// Robustness fixes for issue #181 (kept in their own file so edits here don't
+// trigger a full recompile of the monolithic ShapeTests.swift — see #183).
+@Suite("Issue #181 robustness — threaded shaft envelope + STEP writer")
+struct Issue181RobustnessTests {
+
+    // C: the core invariant. A thread cut only removes material, so whatever
+    // `threadedShaft` returns must be a subset of the blank — never material outside
+    // it. Before the guard, the helical-cutter boolean could (non-deterministically)
+    // return a BRepCheck-"valid" solid extending well past the blank (e.g. ~Ø22 on a
+    // Ø12 blank), which then crashed STEP export. The guard returns nil for those,
+    // so across a range of pitches the result is always nil OR strictly in-envelope.
+    @Test("threadedShaft is always nil or within the blank envelope, never garbage (#181-C)",
+          arguments: [1.0, 1.75, 2.0, 3.14159])
+    func threadedShaftNeverEscapesEnvelope(pitch: Double) {
+        guard let blank = Shape.cylinder(radius: 6, height: 18) else {
+            Issue.record("could not create blank"); return
+        }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: pitch)
+        let result = blank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                         spec: spec, length: 16)
+        // nil is acceptable (failed/garbage cut); a returned solid must be in-envelope.
+        if let result {
+            let b = blank.bounds, c = result.bounds
+            let tol = 1e-3
+            #expect(c.max.x <= b.max.x + tol)
+            #expect(c.max.y <= b.max.y + tol)
+            #expect(c.max.z <= b.max.z + tol)
+            #expect(c.min.x >= b.min.x - tol)
+            #expect(c.min.y >= b.min.y - tol)
+            #expect(c.min.z >= b.min.z - tol)
+        }
+    }
+
+    // B: the serialization lock must not deadlock or break a normal single STEP write.
+    @Test("Single STEP export still succeeds after writer serialization (#181-B)")
+    func singleSTEPExportStillWorks() throws {
+        guard let box = Shape.box(width: 4, height: 3, depth: 2) else {
+            Issue.record("could not create box"); return
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt181_single_\(UUID().uuidString).step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try box.writeSTEP(to: url)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+        #expect((size ?? 0) > 0)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,34 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.3.3
+## Current: v1.3.4
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.3.4 (June 2026) — assembly/export robustness (#181 B & C)
+
+**PATCH — robustness fixes, no API change.**
+
+- **STEP writer serialization (#181-B).** Concurrent `writeSTEP` calls could SIGSEGV because
+  OCCT's `STEPCAFControl`/`STEPControl` writers share non-thread-safe `Interface_Static` globals
+  with IGES. All STEP/IGES write entry points now serialize on the shared data-exchange mutex, so
+  parallel exports queue instead of crashing. (The crash is an uncatchable signal, so internal
+  serialization — not documentation — is the fix.)
+- **`threadedShaft` envelope guard (#181-C).** At coarse pitch / steep lead (and, observed here,
+  even at bolt pitch) the helical V-cutter self-intersects and the boolean subtract returns a
+  non-deterministic solid that BRepCheck reports "valid" yet extends well outside the blank
+  (≈Ø22 on a Ø12 blank) — which then crashed downstream STEP export. A thread cut can only remove
+  material, so `threadedShaft` now returns `nil` when the result escapes the blank envelope rather
+  than handing back garbage. Callers should fall back (e.g. a smooth-cylinder worm body).
+
+Note on #181-A (XCAF `setColor`/`setName` on auto-created component labels): could not reproduce as
+an OCCT or bridge fault — `XCAFDoc_ColorTool::SetColor` on auto-created/reference component labels is
+robust in isolation, and the bridge already fails safe on unregistered labels. Left open pending a
+minimal reproducer.
 
 ### v1.3.3 (June 2026) — multi-section pipe shell (closes #180)
 


### PR DESCRIPTION
## Summary

Two wrapper-level robustness fixes from #181. Both problems surfaced as the same uncatchable `*** Abort *** ... SIGSEGV` banner but have separate causes. **No upstream OCCT patch is warranted** — see the per-item notes.

## B — Concurrent `writeSTEP` SIGSEGV → serialized

OCCT's `STEPCAFControl_Writer` / `STEPControl_Writer` share non-thread-safe `Interface_Static` globals (and mutate them via `SetCVal`) with the IGES writers, so two `writeSTEP` calls on different threads crash. The fix serializes **every** STEP/IGES write entry point on the existing shared data-exchange mutex (`igesMutex`). Several STEP writers were unguarded: `OCCTDocumentWriteSTEP`, `WriteSTEPProgress`, `OCCTExportSTEP`, `OCCTExportSTEPProgress`, `OCCTExportSTEPWithMode`, `OCCTExportSTEPWithModeAndTolerance`, `OCCTExportSTEPCleanDuplicates`.

Internal serialization (not documentation) is the right fix because the failure is an uncatchable signal. This is expected OCCT behaviour (its DE writers are not thread-safe) — **not an OCCT bug**, so no upstream PR.

## C — `threadedShaft` returns out-of-envelope garbage → guarded

At coarse pitch / steep lead — **and, empirically, even at bolt pitch (M12×1.75) in this build** — the helical V-cutter pipe-shell self-intersects and the boolean subtract returns a **non-deterministic** solid. Diagnostic on a Ø12 blank (radius 6):

```
[DIAG] isValid=true  cutMax=(11.26, 9.34, 15.0)   ← material out to ~Ø22 on a Ø12 blank
```

BRepCheck reports it **valid**, so `isValid` is not a usable signal. But a thread *cut* can only remove material, so the result must be a subset of the blank. `threadedShaft` now returns `nil` when the result escapes the blank envelope rather than handing back garbage that crashes downstream STEP export. The invariant (`result ⊆ blank`) can never reject a geometrically correct thread.

This is garbage-in (self-intersecting cutter) → undefined boolean — also **not a clean OCCT bug** to patch upstream; the wrapper's job is to not return the garbage.

## A — not reproduced (no change)

XCAF `setColor`/`setName` on auto-created `makeAssembly:true` component labels: I could not reproduce this as an OCCT or bridge fault. Two pure-C++ reproducers (basic + nested gear-train) call `XCAFDoc_ColorTool::SetColor` on the auto-created/reference component labels and **pass** — OCCT is robust here. The bridge already null-guards (`getLabel().IsNull()` → no-op). Left open pending a minimal Swift reproducer that actually crashes.

## Tests

New `Tests/OCCTSwiftTests/Issue181RobustnessTests.swift` (separate file so edits don't trigger a full `ShapeTests.swift` recompile — cf. #183):

- ✔ Single STEP export still succeeds (the new lock doesn't deadlock/break single writes)
- ✔ `threadedShaft` is always `nil` or within the blank envelope across 4 pitches (never garbage)

`swift test --filter Issue181RobustnessTests` green. CHANGELOG: v1.3.4.

Partially addresses #181 (B, C). A remains open.
