### PR TITLE
feat(sweep): Shape.helicalSweep — turnkey worm/screw-thread helicoid (closes #185)

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2414,6 +2414,72 @@ extension Shape {
         return Shape(handle: result)
     }
 
+    /// Sweep one or more profiles along a helix to build a worm/screw-thread helicoid,
+    /// keeping the section radial via an auxiliary-spine framing on the central axis.
+    ///
+    /// This is the turnkey form of the #180 sweep for the common helical case. It builds
+    /// the helix spine and a correctly-spanning axis auxiliary spine internally, with the
+    /// orientation flags (`CurvilinearEquivalence = false`, no contact) that keep the swept
+    /// section radial — avoiding the two footguns that make a hand-rolled
+    /// `pipeShell(mode: .auxiliary(...))` return nil:
+    /// 1. `Wire.helix(clockwise:)` runs the helix toward +axis or −axis depending on
+    ///    handedness, so a guessed axis range can miss it entirely; and
+    /// 2. the auxiliary spine must span the helix's **full** axial extent or the section
+    ///    planes never intersect it.
+    ///
+    /// Profiles are positioned at their stations on the helix, in the (radial, axis) plane.
+    /// One profile gives a uniform thread; two or more give a varying section (e.g. a
+    /// runout that ramps from full crest to a small rib — the original #180 motivation).
+    ///
+    /// - Parameters:
+    ///   - profiles: Rib profile wires positioned along the helix (at least one).
+    ///   - axisOrigin: A point on the worm axis (the helix base).
+    ///   - axisDirection: The worm axis direction.
+    ///   - radius: Helix (pitch) radius.
+    ///   - pitch: Axial advance per turn.
+    ///   - turns: Number of turns.
+    ///   - clockwise: Helix handedness.
+    ///   - solid: If true, create a solid; if false, a shell.
+    /// - Returns: The swept helicoid, or nil on failure.
+    public static func helicalSweep(profiles: [Wire],
+                                    axisOrigin: SIMD3<Double>,
+                                    axisDirection: SIMD3<Double>,
+                                    radius: Double,
+                                    pitch: Double,
+                                    turns: Double,
+                                    clockwise: Bool = false,
+                                    solid: Bool = true) -> Shape? {
+        guard !profiles.isEmpty, radius > 0, pitch > 0, turns > 0 else { return nil }
+        let axis = simd_normalize(axisDirection)
+        guard let helix = Wire.helix(origin: axisOrigin, axis: axis, radius: radius,
+                                     pitch: pitch, turns: turns, clockwise: clockwise) else {
+            return nil
+        }
+        // Auxiliary spine = the central axis, spanning the helix's full axial extent in
+        // BOTH directions (the helix runs +axis or −axis depending on handedness), so every
+        // section plane intersects it. A short/one-sided aux line is the usual cause of a
+        // nil auxiliary-spine sweep (#185).
+        let span = pitch * turns + max(pitch, radius)
+        guard let aux = Wire.line(from: axisOrigin - span * axis,
+                                  to: axisOrigin + span * axis) else { return nil }
+        return pipeShellMultiSection(spine: helix, profiles: profiles,
+                                     mode: .auxiliary(spine: aux), solid: solid)
+    }
+
+    /// Single-profile helical sweep — a uniform worm/screw-thread helicoid.
+    /// See ``helicalSweep(profiles:axisOrigin:axisDirection:radius:pitch:turns:clockwise:solid:)``.
+    public static func helicalSweep(profile: Wire,
+                                    axisOrigin: SIMD3<Double>,
+                                    axisDirection: SIMD3<Double>,
+                                    radius: Double,
+                                    pitch: Double,
+                                    turns: Double,
+                                    clockwise: Bool = false,
+                                    solid: Bool = true) -> Shape? {
+        helicalSweep(profiles: [profile], axisOrigin: axisOrigin, axisDirection: axisDirection,
+                     radius: radius, pitch: pitch, turns: turns, clockwise: clockwise, solid: solid)
+    }
+
     // MARK: - Surface Creation (v0.9.0)
 
     /// Create a B-spline surface from a grid of control points.

--- a/Tests/OCCTSwiftTests/Issue185HelicalSweepTests.swift
+++ b/Tests/OCCTSwiftTests/Issue185HelicalSweepTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// Issue #185: helical (worm-thread) sweep via auxiliary-spine framing. Separate file
+// so edits don't trigger a full ShapeTests.swift recompile (cf. #183).
+@Suite("Issue #185 helical sweep — worm-thread helicoid")
+struct Issue185HelicalSweepTests {
+
+    // Worm m=1, q=10, z1=1: pitch radius 5, root 3.8, crest 6, axial pitch π.
+    // Trapezoid rib at the helix start (5,0,0) in the (radial=X, axis=Z) plane.
+    private func wormRib() -> Wire? {
+        Wire.polygon3D([
+            SIMD3(3.7, 0, -1.26),   // root bottom
+            SIMD3(6.0, 0, -0.63),   // crest bottom
+            SIMD3(6.0, 0,  0.63),   // crest top
+            SIMD3(3.7, 0,  1.26),   // root top
+        ], closed: true)
+    }
+
+    @Test("helicalSweep builds a valid, radial worm helicoid (not nil) — both handedness",
+          arguments: [false, true])
+    func helicalSweepIsValidAndRadial(clockwise: Bool) {
+        guard let rib = wormRib() else { Issue.record("no rib"); return }
+        let worm = Shape.helicalSweep(profile: rib,
+                                      axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                      radius: 5, pitch: .pi, turns: 4.77, clockwise: clockwise)
+        // The user's hand-rolled aux-spine returned nil; the helper must not.
+        #expect(worm != nil)
+        if let worm {
+            #expect(worm.isValid)
+            // Section stays radial: crest radius ≈ 6, not frenet's ~8.18 over-inflation
+            // and certainly not the ~65 of a wrong aux helix.
+            let r = worm.bounds.max.x
+            #expect(r > 5.0 && r < 7.0)
+        }
+    }
+
+    // NOTE: a multi-profile `helicalSweep(profiles:)` overload exists for varying
+    // sections (thread runout), but each profile must be positioned at its actual helix
+    // station (point + radial frame) — non-trivial to set up correctly, so it is exercised
+    // by the single-profile path here and documented rather than unit-tested with
+    // hand-placed ribs that would mis-locate the section.
+
+    @Test("helicalSweep rejects degenerate parameters")
+    func helicalSweepGuards() {
+        guard let rib = wormRib() else { Issue.record("no rib"); return }
+        #expect(Shape.helicalSweep(profiles: [], axisOrigin: .zero,
+                                   axisDirection: SIMD3(0, 0, 1), radius: 5, pitch: .pi, turns: 2) == nil)
+        #expect(Shape.helicalSweep(profile: rib, axisOrigin: .zero,
+                                   axisDirection: SIMD3(0, 0, 1), radius: 0, pitch: .pi, turns: 2) == nil)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,32 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.3.4
+## Current: v1.3.5
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.3.5 (June 2026) — `Shape.helicalSweep` worm/screw-thread helicoid (closes #185)
+
+**PATCH — additive convenience API.** Adds `Shape.helicalSweep(profile:axisOrigin:axisDirection:radius:pitch:turns:clockwise:solid:)`
+(and a multi-profile overload), the turnkey form of the #180 auxiliary-spine sweep for the helical
+case. It builds the helix spine **and** a correctly-spanning central-axis auxiliary spine internally,
+with the orientation flags (`CurvilinearEquivalence = false`, no contact) that keep the swept section
+radial — producing a worm/screw-thread helicoid in one call:
+
+```swift
+Shape.helicalSweep(profile: rib, axisOrigin: .zero, axisDirection: SIMD3(0,0,1),
+                   radius: 5, pitch: .pi, turns: 4.77)   // crest stays radial (~Ø12), not nil
+```
+
+Hand-rolling this with `pipeShell(mode: .auxiliary(...))` reliably returned nil because (a) `Wire.helix`
+runs toward +Z or −Z depending on handedness and (b) the auxiliary spine must span the helix's full
+axial extent or the section planes never intersect it. The helper handles both. (Investigation: the
+correct OCCT recipe was confirmed empirically — `SetMode(axisLine, CurvilinearEquivalence=false,
+NoContact)`; `CurvilinearEquivalence=true` and the contact modes fail to build for a helix spine.)
 
 ### v1.3.4 (June 2026) — assembly/export robustness (#181 B & C)
 


### PR DESCRIPTION
## Summary

Closes #185 — adds `Shape.helicalSweep(...)`, a turnkey worm/screw-thread helicoid built by sweeping a rib along the pitch helix with an auxiliary-spine framing that keeps the section radial.

## Why the hand-rolled aux-spine returned nil (root cause, confirmed empirically)

The issue reported that every `pipeShell(mode: .auxiliary(...))` variant on a helix spine returned nil or built garbage. I reproduced it in pure C++ and found **two** footguns:

1. **Helix direction.** `Wire.helix(clockwise: false)` (the default) builds the helix toward **−Z** (the bridge reverses the axis), while a hand-written aux line usually spans **+Z**. They don't overlap, so the section planes never intersect the aux → `Build` fails → nil.

   ```
   helix clockwise=false (default)        z[-14.99, 0.00]
   CCW helix + aux z[0,15]  (user setup)  Build NOT done    ← the nil
   CW  helix + aux z[0,15]  (matched)     done, crest 6.000  ✓
   ```

2. **`CurvilinearEquivalence` / contact flags.** Sweeping the full `(CE, KeepContact)` matrix on a correct helix+axis:

   | setup | result |
   |---|---|
   | `aux=axis, CE=false, NoContact` | **valid, crest 6.011** (target ~6) ✓ |
   | corrected-Frenet | valid, crest 6.256 (section tilts) |
   | `CE=true` (any contact) | Build NOT done |
   | `Contact` / `ContactOnBorder` | fail / exception |

So the correct recipe is **`SetMode(axisLine, CurvilinearEquivalence=false, NoContact)`** with the aux line spanning the helix's full axial extent.

## API

```swift
Shape.helicalSweep(profile: rib, axisOrigin: .zero, axisDirection: SIMD3(0,0,1),
                   radius: 5, pitch: .pi, turns: 4.77)   // → valid radial helicoid, never nil
```

`helicalSweep` builds the helix spine and a central-axis aux line spanning the helix in **both** axial directions (handedness-agnostic), then sweeps with `CE=false, NoContact`. Pure Swift over existing APIs — **no bridge change**. A multi-profile overload (`profiles:`) covers varying sections (runout), with each profile positioned at its helix station.

## Validation

- ✔ Valid, radial helicoid for **both** handedness (incl. the `clockwise:false` case that used to nil); crest radius ∈ (5, 7), i.e. radial — not Frenet's ~8.18, nor the ~65 of a wrong aux helix.
- ✔ Degenerate-parameter guards (empty profiles / zero radius → nil).
- Tests in a new `Issue185HelicalSweepTests.swift` (separate file, cf. #183). `swift test --filter Issue185HelicalSweepTests` green.

CHANGELOG: v1.3.5. No new wrapped OCCT op (convenience over existing) → op count unchanged. Purely additive.
