### PR TITLE
test(helical): full-envelope helicalSweep test + honest docstring (#185/#187)

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2415,17 +2415,24 @@ extension Shape {
     }
 
     /// Sweep one or more profiles along a helix to build a worm/screw-thread helicoid,
-    /// keeping the section radial via an auxiliary-spine framing on the central axis.
+    /// keeping the section *approximately* radial via an auxiliary-spine framing on the axis.
     ///
     /// This is the turnkey form of the #180 sweep for the common helical case. It builds
     /// the helix spine and a correctly-spanning axis auxiliary spine internally, with the
     /// orientation flags (`CurvilinearEquivalence = false`, no contact) that keep the swept
-    /// section radial — avoiding the two footguns that make a hand-rolled
+    /// section roughly radial — avoiding the two footguns that make a hand-rolled
     /// `pipeShell(mode: .auxiliary(...))` return nil:
     /// 1. `Wire.helix(clockwise:)` runs the helix toward +axis or −axis depending on
     ///    handedness, so a guessed axis range can miss it entirely; and
     /// 2. the auxiliary spine must span the helix's **full** axial extent or the section
     ///    planes never intersect it.
+    ///
+    /// - Important: The auxiliary-spine framing is **not exactly radial** — the result bulges
+    ///   ~10–15% beyond the nominal radius for moderate profiles, and for **narrow / fine-pitch
+    ///   profiles (e.g. ISO thread V-forms) it balloons severely (≈2× radius) and is unusable**.
+    ///   Use this for coarse worm/auger-style ribs, not precise fastener threads. A future
+    ///   analytic-helicoid path will give an exact thread flank — see the thread-helicoid
+    ///   tracking issue. (This is why `threadedShaft`/`threadedHole` do **not** use it.)
     ///
     /// Profiles are positioned at their stations on the helix, in the (radial, axis) plane.
     /// One profile gives a uniform thread; two or more give a varying section (e.g. a

--- a/Tests/OCCTSwiftTests/Issue185HelicalSweepTests.swift
+++ b/Tests/OCCTSwiftTests/Issue185HelicalSweepTests.swift
@@ -30,10 +30,18 @@ struct Issue185HelicalSweepTests {
         #expect(worm != nil)
         if let worm {
             #expect(worm.isValid)
-            // Section stays radial: crest radius ≈ 6, not frenet's ~8.18 over-inflation
-            // and certainly not the ~65 of a wrong aux helix.
-            let r = worm.bounds.max.x
-            #expect(r > 5.0 && r < 7.0)
+            // Full XY envelope check (the original test only checked max.x and missed the
+            // opposite side). The rib crest is at radius 6; the aux-spine framing is not
+            // perfectly radial — it bulges ~10–15% (measured ~6.9), so the realistic
+            // envelope is ~radius 7. The point of this bound is to catch the CATASTROPHIC
+            // failure mode (radius ~8–11) seen with narrow / fine-pitch profiles, while
+            // documenting the mild bulge that helicalSweep does have. See #187.
+            let b = worm.bounds
+            let maxR = 7.0
+            #expect(b.max.x <= maxR)
+            #expect(b.min.x >= -maxR)
+            #expect(b.max.y <= maxR)
+            #expect(b.min.y >= -maxR)
         }
     }
 


### PR DESCRIPTION
Non-breaking test + doc fix.

- **#185 test** now asserts the **full XY envelope** (it previously only checked `max.x` and missed the opposite-side bulge). Threshold ~radius 7 documents helicalSweep's real ~10–15% bulge while catching the catastrophic ~2× balloon mode.
- **`helicalSweep` docstring** corrected: it keeps the section only *approximately* radial and **balloons for narrow/fine-pitch (thread) profiles** — so it's for coarse worm/auger ribs, not precise fastener threads. Points to #187.

No behavior change. Part of the #181-C/#185 investigation; the exact thread fix is tracked in #187.