### PR TITLE
feat(thread)!: screw-motion thread cutter — correct in-envelope helicoid (closes #187) [v1.4.0, breaking]

### DIFF
--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -133,58 +133,11 @@ public struct ThreadSpec: Sendable, Hashable, Codable {
 }
 
 // MARK: - V-profile construction
-
-/// Geometry of a single thread-form cutter: a truncated trapezoidal profile with
-/// 30° flanks on either side of a central apex, living in the plane perpendicular
-/// to the helix tangent at the given anchor point.
-///
-/// For a cut that becomes a real 60° thread, this trapezoid — not a bare triangle —
-/// is the correct shape: ISO-68 truncates the crest (small flat at the tip, width
-/// `crestFlat * 2`) and the root flares wider (flat along the bore wall of width
-/// `rootFlat * 2`). Between them the flanks run at ±30° from the apex axis.
-internal struct ThreadCutterProfile {
-    let helixAnchor: SIMD3<Double>
-    let axisDirection: SIMD3<Double>
-    let radialDirection: SIMD3<Double>     // points from axis toward helixAnchor
-    let tangentialDirection: SIMD3<Double> // e_axis × e_radial
-    let radius: Double
-    let pitch: Double
-    let helixTangent: SIMD3<Double>
-
-    /// Binormal in the helix's normal plane — perpendicular to both the helix tangent
-    /// and the radial (principal-normal) direction. Mostly axial with a small tilt;
-    /// this is the "axial-ish" direction within the profile plane.
-    var binormal: SIMD3<Double> {
-        simd_normalize(simd_cross(helixTangent, radialDirection))
-    }
-
-    /// Truncated trapezoidal profile wire, apex pointing `apexSign * radialDirection`.
-    /// `apexSign = +1` → apex radially outward (internal-thread cutter, bore→wall).
-    /// `apexSign = -1` → apex radially inward (external-thread cutter, shaft→core).
-    ///
-    /// The root base is extended by `bleedDepth` in the direction opposite the apex.
-    /// Without this, the base would sit exactly on the cylindrical bore / shaft
-    /// surface, and OCCT's boolean subtract skips "touching-but-not-overlapping"
-    /// inputs — the thread would show up as a no-op.
-    func wire(spec: ThreadSpec, apexSign: Double) -> Wire? {
-        let depth = spec.cutDepth
-        let crestHalfWidth = spec.crestFlat / 2
-        let rootHalfWidth  = spec.rootFlat / 2
-        let bleedDepth = max(depth * 0.05, 1e-3)
-        let B = binormal
-        let R = radialDirection * apexSign
-
-        // Four trapezoid vertices in 3D. Ordered so the wire closes as a simple polygon.
-        // Root-base bleeds slightly *past* the helix radius on the opposite side from the
-        // apex; crest is the deepest cut point.
-        let p0 = helixAnchor + (-rootHalfWidth) * B + (-bleedDepth) * R      // root left
-        let p1 = helixAnchor + depth * R + (-crestHalfWidth) * B             // crest left
-        let p2 = helixAnchor + depth * R + ( crestHalfWidth) * B             // crest right
-        let p3 = helixAnchor + ( rootHalfWidth) * B + (-bleedDepth) * R      // root right
-
-        return Wire.polygon3D([p0, p1, p2, p3], closed: true)
-    }
-}
+//
+// The ISO-68 truncated-trapezoid V-profile is now generated directly per screw section in
+// `Shape.screwSweptThreadCutter`; the earlier `ThreadCutterProfile` (a single profile in the
+// helix tangent-normal plane, for a pipe-shell sweep) was removed in #187 because that sweep
+// bulged the section with the helix lead.
 
 private func orthonormalRadial(axis: SIMD3<Double>) -> SIMD3<Double> {
     let a = simd_normalize(axis)
@@ -254,61 +207,32 @@ extension Shape {
 
         let axis = simd_normalize(axisDirection)
 
-        // Build one cutter per thread start. The helix wire's actual start point and
-        // tangent (not our pre-computed estimates) anchor the V-profile — this matters
-        // because `Wire.helix` places θ=0 at a default X direction of its internal
-        // gp_Ax3 that we don't control.
+        // Build one cutter per thread start as a SCREW-MOTION sweep of the axial V-profile.
+        //
+        // A pipe-shell sweep (corrected-Frenet or auxiliary-spine) re-frames the section
+        // along the helix and bulges it outward with the lead — the #181-C garbage / #185
+        // over-inflation. Instead, transport the V-profile by a pure screw motion (rotate
+        // about the axis + translate along it), so every section stays in its OWN axial
+        // plane → a true, in-envelope helicoid. The screw path is approximated by ruled
+        // lofting through closely-spaced screw-transformed sections (#187).
+        let radial0 = orthonormalRadial(axis: axis)
+        let tangential0 = simd_normalize(simd_cross(axis, radial0))
+        let handed: Double = spec.leftHanded ? -1 : 1
+        // Sections per turn: trades accuracy (helix chord error) for loft + boolean cost.
+        // 14/turn keeps the crest chord error ~0.1 mm at typical fastener radii while keeping
+        // the section count (hence the boolean's face count) manageable; capped for very long
+        // fine-pitch threads. (Performance is tracked in #187 — a true helical surface would
+        // avoid the faceting/cost trade entirely.)
+        let nSections = min(220, max(20, Int((turns * 14).rounded())))
+
         var cutters: [Shape] = []
-        for i in 0..<starts {
-            let startAxisOrigin: SIMD3<Double>
-            if starts == 1 {
-                startAxisOrigin = axisOrigin
-            } else {
-                // For multi-start we need distinct helices. Can't tell Wire.helix a
-                // starting phase directly, so we offset the axis origin by a fraction
-                // of the pitch along the axis — each helix then starts at the same
-                // default X direction but at a different axial position, giving the
-                // same visual effect as angular offset for a closed-form spiral.
-                let axialOffset = spec.pitch * Double(i) / Double(starts)
-                startAxisOrigin = axisOrigin + axialOffset * axis
-            }
-            guard let helixWire = Wire.helix(origin: startAxisOrigin,
-                                             axis: axis,
-                                             radius: helixRadius,
-                                             pitch: spec.pitch,
-                                             turns: turns,
-                                             clockwise: spec.leftHanded) else { return nil }
-            guard let info = helixWire.curveInfo else { return nil }
-            let helixAnchor = info.startPoint
-            guard let startTangent = helixWire.tangent(at: 0) else { return nil }
-
-            // Derive radial direction at the helix start: vector from axis projection
-            // onto the axis line, to the helix anchor. Then build tangential from
-            // axis × radial (it's the in-plane vector perpendicular to the radial
-            // and the axis; we keep it even though we don't strictly need it for
-            // the profile wire now).
-            let anchorOffset = helixAnchor - axisOrigin
-            let axialComponent = simd_dot(anchorOffset, axis) * axis
-            let radial = anchorOffset - axialComponent
-            let radialLen = simd_length(radial)
-            guard radialLen > 1e-9 else { return nil }
-            let radialUnit = radial / radialLen
-            let tangentialUnit = simd_normalize(simd_cross(axis, radialUnit))
-
-            // Build a V-profile consistent with the ACTUAL helix tangent (accounts
-            // for whatever default X-direction OCCT picked internally).
-            let profileBuilder = ThreadCutterProfile(helixAnchor: helixAnchor,
-                                                      axisDirection: axis,
-                                                      radialDirection: radialUnit,
-                                                      tangentialDirection: tangentialUnit,
-                                                      radius: helixRadius,
-                                                      pitch: spec.pitch,
-                                                      helixTangent: startTangent)
-            guard let profile = profileBuilder.wire(spec: spec, apexSign: apexSign) else {
-                return nil
-            }
-            guard let cutter = Shape.pipeShell(spine: helixWire, profile: profile,
-                                                mode: .correctedFrenet) else {
+        for s in 0..<starts {
+            // Multi-start: distinct helices share the axis, offset by an angular phase.
+            let phase = 2 * Double.pi * Double(s) / Double(starts)
+            guard let cutter = Shape.screwSweptThreadCutter(
+                axisOrigin: axisOrigin, axis: axis, radial0: radial0, tangential0: tangential0,
+                spec: spec, turns: turns, apexSign: apexSign, helixRadius: helixRadius,
+                phase: phase, handed: handed, nSections: nSections) else {
                 return nil
             }
             cutters.append(cutter)
@@ -322,21 +246,14 @@ extension Shape {
         }
         guard let threaded = self.subtracting(combinedCutter) else { return nil }
 
-        // A thread cut should not extend FAR beyond the blank. The current corrected-Frenet
-        // sweep is imperfect: it produces an asymmetric directional bulge, so even a valid
-        // external thread's bounding box overruns the blank's by a bit. Measured overruns
-        // (relative to the thread cut depth, which scales the bulge):
-        //   - valid fastener threads (M5–M10):      ~1.25 * cutDepth
-        //   - coarse worm-pitch garbage (#181-C):   ~3.1 * cutDepth  (balloons to ~2x radius,
-        //                                            self-intersects, crashes STEP export)
-        // The v1.3.4 guard used `1e-3 * extent`, far below even the valid-thread overrun, so
-        // it wrongly nil'd ordinary bolts (#189 — broke 37 downstream fastener tests). Use a
-        // `2 * cutDepth` threshold: it sits cleanly between the two populations — valid
-        // threads pass, the catastrophic balloon is still rejected. (BRepCheck reports the
-        // garbage "valid", so this envelope check is the only signal that catches it.)
-        // The proper fix is to rebuild the cutter so it does not bulge at all — #187.
+        // Safety net: a thread cut only removes material, so the result is a subset of the
+        // blank. With the screw-motion cutter (above) the result is genuinely in-envelope
+        // (overrun is only tessellation/bleed), so this rarely trips — but it still catches
+        // any pathological boolean result that BRepCheck wrongly reports "valid" before it
+        // reaches STEP export (#181-C). Tolerance one cut depth: comfortably above the clean
+        // result's tiny overrun, well below a catastrophic balloon.
         let blank = self.bounds, cut = threaded.bounds
-        let tol = 2 * spec.cutDepth
+        let tol = spec.cutDepth
         guard cut.min.x >= blank.min.x - tol, cut.min.y >= blank.min.y - tol,
               cut.min.z >= blank.min.z - tol, cut.max.x <= blank.max.x + tol,
               cut.max.y <= blank.max.y + tol, cut.max.z <= blank.max.z + tol
@@ -355,5 +272,44 @@ extension Shape {
             // radius as a reasonable approximation.
             return threaded.filleted(radius: spec.pitch * 0.5) ?? threaded
         }
+    }
+
+    /// One thread start's cutter, built by sweeping the axial ISO-68 V-profile through a
+    /// pure screw motion (rotate about the axis + translate along it) and ruled-lofting the
+    /// closely-spaced sections. Each section stays in its own axial plane, so the helicoid
+    /// is in-envelope (no pipe-shell lead bulge — #187). Ruled lofting (straight surfaces
+    /// between sections) avoids the radial overshoot that smooth-spline lofting introduces.
+    fileprivate static func screwSweptThreadCutter(
+        axisOrigin: SIMD3<Double>, axis: SIMD3<Double>,
+        radial0: SIMD3<Double>, tangential0: SIMD3<Double>,
+        spec: ThreadSpec, turns: Double, apexSign: Double, helixRadius: Double,
+        phase: Double, handed: Double, nSections: Int
+    ) -> Shape? {
+        let depth = spec.cutDepth
+        let rootHalf = spec.rootFlat / 2
+        let crestHalf = spec.crestFlat / 2
+        let bleed = max(depth * 0.05, 1e-3)
+        // apexSign −1 (external): apex inward, root bleeds outward past the shaft surface.
+        // apexSign +1 (internal): apex outward into the bore wall, root bleeds inward.
+        let rootR = helixRadius - apexSign * bleed
+        let crestR = helixRadius + apexSign * depth
+
+        var sections: [Wire] = []
+        sections.reserveCapacity(nSections + 1)
+        for i in 0...nSections {
+            let f = Double(i) / Double(nSections)
+            let theta = handed * (phase + 2 * Double.pi * turns * f)
+            let z = spec.pitch * turns * f
+            let radial = cos(theta) * radial0 + sin(theta) * tangential0
+            let axisPt = axisOrigin + z * axis
+            // Trapezoid in the (radial, axis) plane: width along the axis, depth along radial.
+            let p0 = axisPt + rootR * radial - rootHalf * axis    // root −
+            let p1 = axisPt + crestR * radial - crestHalf * axis  // crest −
+            let p2 = axisPt + crestR * radial + crestHalf * axis  // crest +
+            let p3 = axisPt + rootR * radial + rootHalf * axis    // root +
+            guard let w = Wire.polygon3D([p0, p1, p2, p3], closed: true) else { return nil }
+            sections.append(w)
+        }
+        return Shape.loft(profiles: sections, solid: true, ruled: true)
     }
 }

--- a/Tests/OCCTSwiftTests/Issue187ScrewThreadTests.swift
+++ b/Tests/OCCTSwiftTests/Issue187ScrewThreadTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #187: threadedShaft/threadedHole rebuild their cutter with a SCREW-MOTION sweep
+// (ruled loft through screw-transformed axial sections) instead of a pipe-shell. The
+// result is a true in-envelope helicoid — no lead bulge — so the thread crest sits at
+// the nominal radius (vs the old ~1.25x-cutDepth directional bulge) and even coarse
+// worm pitches now build correctly. Separate file, cf. #183.
+@Suite("Issue #187 — screw-motion thread cutter (tight envelope)")
+struct Issue187ScrewThreadTests {
+
+    // (nominalDiameter, pitch). Includes a coarse worm pitch that used to nil / balloon.
+    @Test("threadedShaft cuts a TIGHT in-envelope thread (crest ~= nominal radius)",
+          arguments: [
+            (6.0, 1.0),    // M6
+            (8.0, 1.25),   // M8
+            (10.0, 1.5),   // M10
+            (12.0, 1.75),  // M12 (used to balloon to ~radius 11)
+            (12.0, 3.14159) // worm pitch (the #181-C/#185 case)
+          ] as [(Double, Double)])
+    func tightInEnvelopeThread(nominal: Double, pitch: Double) {
+        let r = nominal / 2
+        guard let shank = Shape.cylinder(radius: r, height: 22) else {
+            Issue.record("no shank"); return
+        }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: nominal, pitch: pitch)
+        let threaded = shank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                           spec: spec, length: 16, runout: .none)
+        #expect(threaded != nil)
+        guard let threaded else { return }
+        #expect(threaded.isValid)
+        // TIGHT envelope: the crest sits at the nominal radius. Allow only tessellation /
+        // ruled-facet margin (~0.25 mm) — far below the old ~0.6–5 mm directional bulge.
+        let b = shank.bounds, c = threaded.bounds
+        let tol = 0.25
+        #expect(c.max.x <= b.max.x + tol)
+        #expect(c.min.x >= b.min.x - tol)
+        #expect(c.max.y <= b.max.y + tol)
+        #expect(c.min.y >= b.min.y - tol)
+        // A real thread removes a shallow helical groove.
+        if let vBlank = shank.volume, let vThread = threaded.volume {
+            #expect(vThread < vBlank)
+            #expect(vThread > vBlank * 0.7)
+        }
+    }
+
+    @Test("threadedShaft is deterministic (same bounds across runs)")
+    func deterministic() {
+        guard let shank = Shape.cylinder(radius: 3, height: 20) else { Issue.record("no shank"); return }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 6, pitch: 1.0)
+        func run() -> Double? {
+            shank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                spec: spec, length: 16)?.bounds.max.x
+        }
+        let a = run(), b = run()
+        #expect(a != nil); #expect(b != nil)
+        if let a, let b { #expect(abs(a - b) < 1e-4) }
+    }
+
+    @Test("threadedHole cuts a valid in-envelope thread into a bore wall")
+    func threadedHoleValid() {
+        guard let outer = Shape.cylinder(radius: 12, height: 16),
+              let bore = Shape.cylinder(radius: 6, height: 16),
+              let block = outer.subtracting(bore) else { Issue.record("no annulus"); return }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75)
+        let tapped = block.threadedHole(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                        spec: spec, depth: 14)
+        #expect(tapped != nil)
+        if let tapped {
+            #expect(tapped.isValid)
+            // Tapping the bore wall only adds material toward the axis; outer Ø24 unchanged.
+            #expect(tapped.bounds.max.x <= block.bounds.max.x + 0.25)
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,37 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.3.6
+## Current: v1.4.0
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.0 (June 2026) — correct, in-envelope thread geometry (closes #187)
+
+**MINOR — BEHAVIOUR CHANGE to `threadedShaft` / `threadedHole`.** The thread output geometry changes:
+both now produce a **correct, in-envelope helicoid** for every pitch, including coarse worm pitches
+that previously returned `nil` or garbage.
+
+**Why it changed.** The cutter was a `BRepOffsetAPI_MakePipeShell` sweep of a V-profile along the
+helix. That sweep re-frames the section with the helix lead, so it **bulged the thread outward**
+(~1.25× cut depth for fasteners, ~3.1× for worm pitches → a self-intersecting ≈2×-radius balloon that
+crashed STEP export — #181-C/#185). The cutter is now built by a **screw-motion sweep**: the axial
+V-profile is transported by a pure rotate-about-axis + translate-along-axis motion (every section
+stays in its own axial plane), ruled-lofted, and subtracted. The result's crest sits at the nominal
+radius (within ~0.1 mm tessellation), deterministically.
+
+**Migration.** No API change (same signatures, still `Shape?`). But:
+- the produced thread **mesh / STEP geometry differs** — snapshot/byte-exact consumers must rebaseline;
+- threads that returned `nil` at coarse/worm pitch now return a valid solid;
+- the V-form is faceted (ruled loft, ~14 sections/turn) rather than a smooth pipe surface;
+- **performance:** ~1 s per thread (loft + boolean over the section facets). For many threads, expect
+  it to dominate; a true analytic helical surface (future work) would remove the faceting/cost trade.
+
+The #181-C envelope guard is retained as a thin safety net (now 1× cut depth) but effectively never
+trips on the in-envelope result.
 
 ### v1.3.6 (June 2026) — fix: thread envelope guard rejected valid fastener threads (closes #189)
 


### PR DESCRIPTION
## Summary

Closes #187 — rebuilds the `threadedShaft` / `threadedHole` cutter so it produces a **correct, in-envelope thread helicoid** for every pitch (including coarse worm pitches that previously returned `nil`/garbage).

> ⚠️ **Breaking behaviour change** — the produced thread geometry differs. Same API, but mesh/STEP output changes and previously-`nil` coarse pitches now build. Proposed as **v1.4.0**. Flagging for review per your note on careful docs.

## The change

The cutter was a `BRepOffsetAPI_MakePipeShell` sweep of a V-profile along the helix. That sweep re-frames the section with the helix lead, **bulging the thread outward**:

| | overrun / cutDepth |
|---|---|
| fasteners (M5–M10) | ~1.25× (mildly malformed, crest proud) |
| worm pitch (#181-C) | ~3.1× (self-intersecting ~2×-radius balloon, crashes STEP) |

Now it's a **screw-motion sweep**: the axial ISO-68 V-profile is transported by a pure *rotate-about-axis + translate-along-axis* motion (every section stays in its own axial plane), **ruled**-lofted (ruled avoids the radial overshoot smooth lofting introduces), and subtracted. The investigation + proof are on #187.

## Validation (new `Issue187ScrewThreadTests.swift`)

- ✔ **Tight** in-envelope (crest ≤ nominal + 0.25 mm) across **M6, M8, M10, M12, and worm pitch π** — vs the old ~0.6–5 mm bulge.
- ✔ Deterministic (same bounds across runs).
- ✔ `threadedHole` valid.
- ✔ The #189 fastener regression tests still pass.

## Trade-offs

- **Perf: ~1 s/thread** (loft + boolean over ~14 sections/turn). For many threads this dominates; an analytic helical surface would remove the faceting/cost trade (noted on #187).
- The V-form is **faceted** (ruled loft) rather than a smooth pipe surface.
- The #181-C envelope guard is retained as a thin 1×cutDepth safety net (effectively never trips now).

## Migration

No source change for callers. But: rebaseline any snapshot/byte-exact thread tests; coarse/worm pitches now return a solid instead of `nil`; threads are faceted.

Source-only — no OCCT binary change. CHANGELOG: v1.4.0 with a migration note.
