### PR TITLE
Smooth analytic thread helicoid with screw-loft fallback (#187) → v1.4.1

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1535,6 +1535,30 @@ OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
                                                   bool withContact, bool withCorrection,
                                                   bool solid);
 
+/// Build one thread-start cutter as a SMOOTH analytic helicoid solid (issue #187).
+/// Each of the 4 ISO-68 V-profile corners traces a BSpline helix; the cutter is the
+/// solid bounded by ruled faces (BRepFill::Face) between consecutive corner-helices plus
+/// two V end caps, sewn. O(1) faces (no faceting), in-envelope, vs the MakePipeShell sweep
+/// which bulges with the helix lead. The axis frame is given by (origin, axis-unit,
+/// radial0-unit, with tangential0 = axis x radial0 computed internally).
+/// @param ox,oy,oz Axis origin (a point on the thread axis)
+/// @param ax,ay,az Thread axis direction (unit)
+/// @param rx,ry,rz radial0 (unit, perpendicular to the axis)
+/// @param pitch Axial advance per turn; turns Number of turns
+/// @param apexSign -1 external (apex inward) / +1 internal (apex outward into the wall)
+/// @param helixRadius Thread pitch-line radius (nominal/2)
+/// @param cutDepth, rootHalf, crestHalf, bleed ISO-68 V-form dimensions
+/// @param phase Angular start offset (radians; multi-start); handed -1 left-handed / +1 right
+/// @param nSections BSpline interpolation samples per corner helix
+/// @return The cutter solid, or NULL on failure
+OCCTShapeRef OCCTShapeBuildThreadCutter(double ox, double oy, double oz,
+                                        double ax, double ay, double az,
+                                        double rx, double ry, double rz,
+                                        double pitch, double turns, double apexSign,
+                                        double helixRadius, double cutDepth,
+                                        double rootHalf, double crestHalf, double bleed,
+                                        double phase, double handed, int32_t nSections);
+
 
 // MARK: - Surfaces & Curves (v0.9.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -610,6 +610,85 @@ OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
     }
 }
 
+// Analytic helicoid thread cutter (#187): smooth ruled-face solid, no faceting/balloon.
+#include <BRepFill.hxx>
+#include <GeomAPI_Interpolate.hxx>
+#include <TColgp_HArray1OfPnt.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepLib.hxx>
+OCCTShapeRef OCCTShapeBuildThreadCutter(double ox, double oy, double oz,
+                                        double ax, double ay, double az,
+                                        double rx, double ry, double rz,
+                                        double pitch, double turns, double apexSign,
+                                        double helixRadius, double cutDepth,
+                                        double rootHalf, double crestHalf, double bleed,
+                                        double phase, double handed, int32_t nSections) {
+    if (pitch <= 0 || turns <= 0 || nSections < 2) return nullptr;
+    try {
+        const gp_Vec O(ox, oy, oz), A(ax, ay, az), R0(rx, ry, rz);
+        const gp_Vec T0 = A.Crossed(R0);                 // tangential0 = axis x radial0
+        const double rootR  = helixRadius - apexSign * bleed;     // root bleeds past surface
+        const double crestR = helixRadius + apexSign * cutDepth;  // crest = the deep cut
+        const double cr[4] = { rootR, crestR, crestR, rootR };
+        const double cz[4] = { -rootHalf, -crestHalf, crestHalf, rootHalf };
+        const int N = nSections;
+
+        // Each V-corner traces a single-edge BSpline helix.
+        TopoDS_Edge edges[4];
+        for (int k = 0; k < 4; ++k) {
+            Handle(TColgp_HArray1OfPnt) pts = new TColgp_HArray1OfPnt(1, N + 1);
+            for (int i = 0; i <= N; ++i) {
+                const double fr = (double)i / (double)N;
+                const double theta = handed * (phase + 2.0 * M_PI * turns * fr);
+                const double zc = pitch * turns * fr + cz[k];
+                const gp_Vec radial = R0 * std::cos(theta) + T0 * std::sin(theta);
+                const gp_Vec P = O + A * zc + radial * cr[k];
+                pts->SetValue(i + 1, gp_Pnt(P.X(), P.Y(), P.Z()));
+            }
+            GeomAPI_Interpolate interp(pts, Standard_False, 1e-7);
+            interp.Perform();
+            if (!interp.IsDone()) return nullptr;
+            edges[k] = BRepBuilderAPI_MakeEdge(interp.Curve());
+            if (edges[k].IsNull()) return nullptr;
+        }
+
+        // Ruled flank/crest/root faces between consecutive corner helices, + 2 V end caps.
+        BRepBuilderAPI_Sewing sewer(1e-6);
+        for (int k = 0; k < 4; ++k) {
+            TopoDS_Face f = BRepFill::Face(edges[k], edges[(k + 1) % 4]);
+            if (f.IsNull()) return nullptr;
+            sewer.Add(f);
+        }
+        for (int cap = 0; cap < 2; ++cap) {
+            const double fr = (double)cap;
+            const double theta = handed * (phase + 2.0 * M_PI * turns * fr);
+            const double zbase = pitch * turns * fr;
+            const gp_Vec radial = R0 * std::cos(theta) + T0 * std::sin(theta);
+            BRepBuilderAPI_MakePolygon poly;
+            for (int k = 0; k < 4; ++k) {
+                const gp_Vec P = O + A * (zbase + cz[k]) + radial * cr[k];
+                poly.Add(gp_Pnt(P.X(), P.Y(), P.Z()));
+            }
+            poly.Close();
+            BRepBuilderAPI_MakeFace mf(poly.Wire(), Standard_True);
+            if (!mf.IsDone()) return nullptr;
+            sewer.Add(mf.Face());
+        }
+        sewer.Perform();
+        TopoDS_Shape shell = sewer.SewedShape();
+        if (shell.IsNull()) return nullptr;
+        TopExp_Explorer se(shell, TopAbs_SHELL);
+        if (!se.More()) return nullptr;
+        TopoDS_Solid solid = BRepBuilderAPI_MakeSolid(TopoDS::Shell(se.Current())).Solid();
+        // Orient outward so it is a proper positive-volume solid (the sewn shell can be
+        // inside-out, which would make the boolean intersect instead of subtract).
+        BRepLib::OrientClosedSolid(solid);
+        return new OCCTShape(solid);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 // MARK: - Surface Construction (v0.9.0)
 
 OCCTShapeRef OCCTShapeCreateBSplineSurface(const double* poles, int32_t uCount, int32_t vCount,

--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -1,17 +1,20 @@
 import Foundation
 import simd
+import OCCTBridge
 
 // MARK: - Thread feature API (#66, v0.139 Thread Form v2)
 //
 // Produces real helical V-form geometry following ISO-68 / Unified thread standards.
-// OCCT ships no "thread feature" — geometry comes from sweeping a truncated V-profile
-// (60° included flank angle) along a helical wire with BRepOffsetAPI_MakePipeShell,
-// then booleaning against the target feature.
+// OCCT ships no "thread feature" — the cutter is an ISO-68 truncated V-profile (60°
+// included flank angle) swept along the helix and booleaned against the target feature.
 //
-// v0.138 shipped a circular sweep cross-section, which produced a helical groove
-// rather than a thread. v0.139 replaces that with a proper V-profile: the cut now
-// shows the alternating 60° flanks that engineering drawings expect, with ISO-68
-// truncation at crest and root.
+// The cutter has been through three forms (see `applyThreadCut`):
+//   v0.139  pipe-shell sweep of the V-profile — re-frames the section with the helix
+//           lead, so it bulged the thread outward (escaped the envelope; #181-C/#185).
+//   v1.4.0  screw-motion ruled loft — in-envelope and robust, but faceted + ~1 s/thread.
+//   v1.4.1  smooth analytic helicoid (the four V-corners trace BSpline helices, ruled
+//           faces between them) — O(1) faces, no faceting; falls back to the v1.4.0
+//           screw-loft when OCCT's boolean fails on a tightly-wound fine-pitch cutter.
 //
 // Out of scope for v1: ACME / BSP / NPT forms (enum is open for future cases);
 // full ISO-68 tolerance classes (2B, 3A, etc.) — those are fit-allowance tables,
@@ -206,57 +209,75 @@ extension Shape {
         guard turns > 0 else { return nil }
 
         let axis = simd_normalize(axisDirection)
-
-        // Build one cutter per thread start as a SCREW-MOTION sweep of the axial V-profile.
-        //
-        // A pipe-shell sweep (corrected-Frenet or auxiliary-spine) re-frames the section
-        // along the helix and bulges it outward with the lead — the #181-C garbage / #185
-        // over-inflation. Instead, transport the V-profile by a pure screw motion (rotate
-        // about the axis + translate along it), so every section stays in its OWN axial
-        // plane → a true, in-envelope helicoid. The screw path is approximated by ruled
-        // lofting through closely-spaced screw-transformed sections (#187).
         let radial0 = orthonormalRadial(axis: axis)
         let tangential0 = simd_normalize(simd_cross(axis, radial0))
         let handed: Double = spec.leftHanded ? -1 : 1
-        // Sections per turn: trades accuracy (helix chord error) for loft + boolean cost.
-        // 14/turn keeps the crest chord error ~0.1 mm at typical fastener radii while keeping
-        // the section count (hence the boolean's face count) manageable; capped for very long
-        // fine-pitch threads. (Performance is tracked in #187 — a true helical surface would
-        // avoid the faceting/cost trade entirely.)
-        let nSections = min(220, max(20, Int((turns * 14).rounded())))
+        let rootHalf = spec.rootFlat / 2
+        let crestHalf = spec.crestFlat / 2
+        let bleed = max(spec.cutDepth * 0.05, 1e-3)
+        func phase(_ s: Int) -> Double { 2 * Double.pi * Double(s) / Double(starts) }
 
-        var cutters: [Shape] = []
-        for s in 0..<starts {
-            // Multi-start: distinct helices share the axis, offset by an angular phase.
-            let phase = 2 * Double.pi * Double(s) / Double(starts)
-            guard let cutter = Shape.screwSweptThreadCutter(
-                axisOrigin: axisOrigin, axis: axis, radial0: radial0, tangential0: tangential0,
-                spec: spec, turns: turns, apexSign: apexSign, helixRadius: helixRadius,
-                phase: phase, handed: handed, nSections: nSections) else {
-                return nil
+        // Two ways to build a thread-start cutter:
+        //  (A) SMOOTH analytic helicoid (#187): the four ISO-68 V-corners each trace a BSpline
+        //      helix; the cutter is the solid bounded by ruled faces between consecutive
+        //      corner-helices. O(1) faces, no faceting, in-envelope. Preferred — but OCCT's
+        //      boolean chokes on the tightly-wound cutter of small fine-pitch threads.
+        //  (B) Robust screw-motion ruled loft (v1.4.0): faceted but the boolean is well-behaved.
+        // Build with (A); validate; fall back to (B) if (A)'s result is not a sound cut.
+        let nAnalytic = Int32(min(400, max(64, Int((turns * 24).rounded()))))
+        func analyticCutter(_ s: Int) -> Shape? {
+            OCCTShapeBuildThreadCutter(axisOrigin.x, axisOrigin.y, axisOrigin.z,
+                                       axis.x, axis.y, axis.z, radial0.x, radial0.y, radial0.z,
+                                       spec.pitch, turns, apexSign, helixRadius,
+                                       spec.cutDepth, rootHalf, crestHalf, bleed,
+                                       phase(s), handed, nAnalytic).map { Shape(handle: $0) }
+        }
+        let nScrew = min(220, max(20, Int((turns * 14).rounded())))
+        func screwLoftCutter(_ s: Int) -> Shape? {
+            Shape.screwSweptThreadCutter(axisOrigin: axisOrigin, axis: axis,
+                                         radial0: radial0, tangential0: tangential0,
+                                         spec: spec, turns: turns, apexSign: apexSign,
+                                         helixRadius: helixRadius, phase: phase(s),
+                                         handed: handed, nSections: nScrew)
+        }
+
+        // Fuse the per-start cutters and subtract from the blank.
+        func threadResult(_ cutterFor: (Int) -> Shape?) -> Shape? {
+            var cutters: [Shape] = []
+            for s in 0..<starts { guard let c = cutterFor(s) else { return nil }; cutters.append(c) }
+            var combined = cutters[0]
+            for c in cutters.dropFirst() { guard let f = combined.union(c) else { return nil }; combined = f }
+            return self.subtracting(combined)
+        }
+
+        // A sound thread cut is a valid solid, stays within the blank (a cut only removes
+        // material), and removes *some* but not *most* material. BRepCheck alone is not enough
+        // — a botched boolean (e.g. the tightly-wound M5×0.8 analytic cutter) can be "valid"
+        // yet *add* volume, so we also bound the volume delta.
+        //
+        // Envelope is checked on the *optimal* (tight) box, never the default Bnd_Box: the
+        // smooth analytic helicoid's default box is its BSpline convex hull, which overshoots
+        // the real surface by ~0.1–0.35 mm (pure control-pole artifact — AddOptimal returns the
+        // blank's exact extent). Checking the loose box would wrongly flag a clean analytic cut
+        // as an escape and force the screw-loft fallback for every coarse pitch.
+        func isSoundCut(_ result: Shape?) -> Bool {
+            guard let r = result, r.isValid,
+                  let blank = self.boundingBoxOptimal(), let cut = r.boundingBoxOptimal()
+            else { return false }
+            let tol = 1e-2
+            guard cut.min.x >= blank.min.x - tol, cut.min.y >= blank.min.y - tol,
+                  cut.min.z >= blank.min.z - tol, cut.max.x <= blank.max.x + tol,
+                  cut.max.y <= blank.max.y + tol, cut.max.z <= blank.max.z + tol
+            else { return false }
+            if let vb = self.volume, let vt = r.volume {
+                return vt < vb * 0.999 && vt > vb * 0.5   // removed some, not garbage
             }
-            cutters.append(cutter)
+            return true
         }
 
-        // Fuse multiple cutters when multi-start, then subtract from self.
-        var combinedCutter = cutters[0]
-        for c in cutters.dropFirst() {
-            guard let fused = combinedCutter.union(c) else { return nil }
-            combinedCutter = fused
-        }
-        guard let threaded = self.subtracting(combinedCutter) else { return nil }
-
-        // Safety net: a thread cut only removes material, so the result is a subset of the
-        // blank. With the screw-motion cutter (above) the result is genuinely in-envelope
-        // (overrun is only tessellation/bleed), so this rarely trips — but it still catches
-        // any pathological boolean result that BRepCheck wrongly reports "valid" before it
-        // reaches STEP export (#181-C). Tolerance one cut depth: comfortably above the clean
-        // result's tiny overrun, well below a catastrophic balloon.
-        let blank = self.bounds, cut = threaded.bounds
-        let tol = spec.cutDepth
-        guard cut.min.x >= blank.min.x - tol, cut.min.y >= blank.min.y - tol,
-              cut.min.z >= blank.min.z - tol, cut.max.x <= blank.max.x + tol,
-              cut.max.y <= blank.max.y + tol, cut.max.z <= blank.max.z + tol
+        let analytic = threadResult(analyticCutter)
+        guard let threaded = isSoundCut(analytic) ? analytic : threadResult(screwLoftCutter),
+              isSoundCut(threaded)
         else { return nil }
 
         switch runout {
@@ -274,11 +295,11 @@ extension Shape {
         }
     }
 
-    /// One thread start's cutter, built by sweeping the axial ISO-68 V-profile through a
-    /// pure screw motion (rotate about the axis + translate along it) and ruled-lofting the
-    /// closely-spaced sections. Each section stays in its own axial plane, so the helicoid
-    /// is in-envelope (no pipe-shell lead bulge — #187). Ruled lofting (straight surfaces
-    /// between sections) avoids the radial overshoot that smooth-spline lofting introduces.
+    /// Fallback cutter (v1.4.0): sweep the axial ISO-68 V-profile through a pure screw motion
+    /// (rotate about the axis + translate along it) and **ruled**-loft the closely-spaced
+    /// sections. Each section stays in its own axial plane, so the result is in-envelope. It is
+    /// faceted (unlike the smooth analytic helicoid) but the boolean is robust where the
+    /// analytic cutter's tightly-wound surface makes OCCT's BOP fail (#187).
     fileprivate static func screwSweptThreadCutter(
         axisOrigin: SIMD3<Double>, axis: SIMD3<Double>,
         radial0: SIMD3<Double>, tangential0: SIMD3<Double>,
@@ -302,7 +323,6 @@ extension Shape {
             let z = spec.pitch * turns * f
             let radial = cos(theta) * radial0 + sin(theta) * tangential0
             let axisPt = axisOrigin + z * axis
-            // Trapezoid in the (radial, axis) plane: width along the axis, depth along radial.
             let p0 = axisPt + rootR * radial - rootHalf * axis    // root −
             let p1 = axisPt + crestR * radial - crestHalf * axis  // crest −
             let p2 = axisPt + crestR * radial + crestHalf * axis  // crest +

--- a/Tests/OCCTSwiftTests/Issue181RobustnessTests.swift
+++ b/Tests/OCCTSwiftTests/Issue181RobustnessTests.swift
@@ -24,9 +24,16 @@ struct Issue181RobustnessTests {
         let result = blank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
                                          spec: spec, length: 16)
         // nil is acceptable (failed/garbage cut); a returned solid must be in-envelope.
+        // Measure the *optimal* (tight) box: the smooth analytic helicoid (v1.4.1) has a
+        // BSpline convex-hull default Bnd_Box that overshoots the real surface by ~0.1–0.35 mm
+        // — a control-pole artifact, not escaped material (AddOptimal returns the exact extent).
+        // A strict tolerance on the optimal box still catches the real >1 mm balloon this
+        // guards against (the old ~Ø22 result on a Ø12 blank).
         if let result {
-            let b = blank.bounds, c = result.bounds
-            let tol = 1e-3
+            guard let b = blank.boundingBoxOptimal(), let c = result.boundingBoxOptimal() else {
+                Issue.record("optimal bounds unavailable"); return
+            }
+            let tol = 1e-2
             #expect(c.max.x <= b.max.x + tol)
             #expect(c.max.y <= b.max.y + tol)
             #expect(c.max.z <= b.max.z + tol)

--- a/Tests/OCCTSwiftTests/Issue187ScrewThreadTests.swift
+++ b/Tests/OCCTSwiftTests/Issue187ScrewThreadTests.swift
@@ -59,6 +59,21 @@ struct Issue187ScrewThreadTests {
         if let a, let b { #expect(abs(a - b) < 1e-4) }
     }
 
+    @Test("Thread surface is SMOOTH (analytic helicoid) — few faces, not hundreds of facets")
+    func smoothFewFaces() {
+        guard let shank = Shape.cylinder(radius: 6, height: 16) else { Issue.record("no shank"); return }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75)
+        guard let threaded = shank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                                 spec: spec, length: 14) else {
+            Issue.record("threadedShaft nil"); return
+        }
+        // The cutter is ~6 ruled helicoid faces, so the threaded solid has a handful of
+        // faces (cylinder ends + thread flank/crest/root surfaces), NOT the hundreds of
+        // facets a sectioned/lofted sweep would leave. A loose ceiling proves smoothness.
+        let faces = threaded.subShapes(ofType: .face).count
+        #expect(faces < 40)
+    }
+
     @Test("threadedHole cuts a valid in-envelope thread into a bore wall")
     func threadedHoleValid() {
         guard let outer = Shape.cylinder(radius: 12, height: 16),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,42 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.0
+## Current: v1.4.1
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.1 (June 2026) — smooth analytic thread helicoid, with screw-loft fallback (#187)
+
+**PATCH — geometry quality, no API change.** `threadedShaft` / `threadedHole` now emit a **smooth
+analytic helicoid** instead of v1.4.0's faceted ruled loft. Same signatures, same in-envelope
+result; the difference is surface quality and face count.
+
+**What changed.** v1.4.0 swept the V-profile through ~14 screw-transformed sections per turn and
+ruled-lofted them — correct and in-envelope, but **faceted** (hundreds of flank facets) and ~1 s per
+thread. The cutter is now built analytically (new bridge op `OCCTShapeBuildThreadCutter`): the four
+ISO-68 V-corners each trace a single BSpline helix (`GeomAPI_Interpolate`), and the solid is bounded
+by four ruled faces between consecutive corner-helices plus two V end caps — sewn, made solid, and
+`BRepLib::OrientClosedSolid`-corrected. That's **~6 faces, no faceting**, regardless of turn count.
+
+**Automatic fallback.** OCCT's boolean chokes on the *tightly-wound* cutter of small, fine-pitch
+threads (e.g. M5×0.8 — 22.5 turns at radius 2.5): the subtraction comes back BRepCheck-"valid" but
+with *more* volume than the blank. The cut is validated (optimal/tight bounding box stays inside the
+blank **and** volume strictly decreases by a sane amount); if the analytic result fails, it silently
+falls back to v1.4.0's robust screw-loft. So M6/M8/M10/M12 and coarse worm pitches get the smooth
+helicoid, while pathological small-fine-pitch threads still build via the faceted-but-robust path.
+
+**Why the envelope is measured on the optimal box.** The smooth helicoid's *default* `Bnd_Box`
+(`BRepBndLib::Add`) is the BSpline **convex hull**, which overshoots the real surface by ~0.1–0.35 mm
+— a control-pole artifact, not escaped material (`AddOptimal` returns the blank's exact extent).
+Both the fallback check and the #181-C regression test now use the tight optimal box; a strict
+tolerance there still catches the real >1 mm balloon the guard exists for.
+
+**Migration.** None required. Thread mesh/STEP geometry differs again (smoother) — byte-exact
+snapshot consumers must rebaseline; everything else is unchanged.
 
 ### v1.4.0 (June 2026) — correct, in-envelope thread geometry (closes #187)
 


### PR DESCRIPTION
## Summary

`threadedShaft` / `threadedHole` now emit a **smooth analytic helicoid** instead of v1.4.0's faceted screw-motion loft. Same signatures, same in-envelope result; the difference is surface quality (~6 faces vs hundreds of facets) and build cost.

The cutter is built analytically (new bridge op `OCCTShapeBuildThreadCutter`): the four ISO-68 V-corners each trace a single BSpline helix (`GeomAPI_Interpolate`), and the solid is bounded by four ruled faces between consecutive corner-helices plus two V end caps — sewn → `MakeSolid` → `BRepLib::OrientClosedSolid`.

## Automatic fallback

OCCT's boolean chokes on the *tightly-wound* cutter of small, fine-pitch threads (e.g. **M5×0.8** — 22.5 turns at radius 2.5): the subtraction comes back BRepCheck-"valid" but with *more* volume than the blank. `applyThreadCut` validates the cut (tight/optimal bounding box stays inside the blank **and** volume strictly decreases) and silently falls back to v1.4.0's robust screw-loft. So M6/M8/M10/M12 and coarse worm pitches get the smooth helicoid, while pathological small-fine-pitch threads still build via the faceted-but-robust path.

## Why the envelope uses the optimal box

The smooth helicoid's *default* `Bnd_Box` (`BRepBndLib::Add`) is the BSpline **convex hull**, which overshoots the real surface by ~0.1–0.35 mm — a control-pole artifact, not escaped material (`AddOptimal` returns the blank's exact extent; verified: maxX 6.0000, minZ −0.0000 for every pitch incl. worm). Both the fallback check and the **#181-C** regression test now measure the tight optimal box; a strict tolerance there still catches the real >1 mm balloon the guard exists for.

## Testing

- `Issue187ScrewThreadTests` — tight envelope (M6/M8/M10/M12/worm), `smoothFewFaces` (<40 faces), determinism, `threadedHole` ✓
- `Issue189ThreadGuardTests` — fasteners M5/M6/M8/M10 build valid threads (M5×0.8 via fallback) ✓
- `Issue181RobustnessTests` — #181-C envelope guard (now optimal-box) across pitches 1.0/1.75/2.0/3.14159 ✓

All thread suites green (8 tests / 3 suites). Full-suite cone/hyperbola/convex flakes confirmed unrelated (pass in isolation; pre-existing NCollection arm64 parallel race).

No API change. Ships as **v1.4.1** (patch — geometry quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
