### PR TITLE
Long full-length threads return a usable solid, not nil (closes #193) → v1.4.2

### DIFF
--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -250,18 +250,23 @@ extension Shape {
             return self.subtracting(combined)
         }
 
-        // A sound thread cut is a valid solid, stays within the blank (a cut only removes
-        // material), and removes *some* but not *most* material. BRepCheck alone is not enough
-        // — a botched boolean (e.g. the tightly-wound M5×0.8 analytic cutter) can be "valid"
-        // yet *add* volume, so we also bound the volume delta.
+        // A sound thread cut stays within the blank (a cut only removes material) and removes
+        // *some* but not *most* of it. These two geometric checks — envelope + volume delta —
+        // are the substantive ones; a botched boolean fails one of them (e.g. the tightly-wound
+        // M5×0.8 analytic cutter comes back BRepCheck-"valid" yet *adds* volume; a long analytic
+        // cutter subtracts to a near-no-op leaving ~full blank volume — both caught here).
         //
-        // Envelope is checked on the *optimal* (tight) box, never the default Bnd_Box: the
-        // smooth analytic helicoid's default box is its BSpline convex hull, which overshoots
-        // the real surface by ~0.1–0.35 mm (pure control-pole artifact — AddOptimal returns the
-        // blank's exact extent). Checking the loose box would wrongly flag a clean analytic cut
-        // as an escape and force the screw-loft fallback for every coarse pitch.
+        // We deliberately do NOT gate on `r.isValid`. A long faceted screw-loft thread (tens of
+        // turns) can trip BRepCheck on a benign facet self-intersection yet remain dimensionally
+        // correct and STEP-exportable (#193); gating on validity would reject it and return nil
+        // for full-length bolt threads. The smooth analytic path stays valid where it applies; the
+        // faceted fallback is allowed to be invalid-but-usable.
+        //
+        // Envelope is the *optimal* (tight) box, never the default Bnd_Box: the smooth analytic
+        // helicoid's default box is its BSpline convex hull, which overshoots the real surface by
+        // ~0.1–0.35 mm (control-pole artifact — AddOptimal returns the blank's exact extent).
         func isSoundCut(_ result: Shape?) -> Bool {
-            guard let r = result, r.isValid,
+            guard let r = result,
                   let blank = self.boundingBoxOptimal(), let cut = r.boundingBoxOptimal()
             else { return false }
             let tol = 1e-2

--- a/Tests/OCCTThreadTests/Issue193LongThreadTests.swift
+++ b/Tests/OCCTThreadTests/Issue193LongThreadTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #193: a long full-length thread (tens of turns) used to come back from `threadedShaft`
+// either `isValid == false` (v1.4.0 faceted screw-loft — a benign facet self-intersection
+// trips BRepCheck) or — once v1.4.1 gated soundness on `isValid` — as `nil`, breaking
+// full-length bolt shanks. Fix: the cut's soundness is judged on geometry (tight/optimal
+// envelope + volume delta), NOT BRepCheck validity. The smooth analytic helicoid stays valid
+// where it applies (short/medium threads); the faceted fallback is allowed to be
+// invalid-but-usable (dimensionally correct, STEP-exportable) for long threads. Separate
+// file, cf. #183.
+@Suite("Issue #193 — long full-length threads return a usable solid (not nil)")
+struct Issue193LongThreadTests {
+
+    // ISO 4017 M10 full-thread shank: thread runs almost the whole 50 mm shank at pitch 1.0,
+    // i.e. ~26 → ~49 turns. Every length must return an in-envelope solid that actually
+    // removed material — never nil, regardless of BRepCheck validity.
+    @Test("M10x1.0 long threads stay in-envelope and remove material (never nil)",
+          arguments: [26.0, 40.0, 49.0])
+    func longThreadUsable(length: Double) {
+        guard let shank = Shape.cylinder(radius: 5, height: 50) else {
+            Issue.record("no shank"); return
+        }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.0)
+        let t = shank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                    spec: spec, length: length, runout: .none)
+        #expect(t != nil)
+        guard let t else { return }
+        // In-envelope on the tight (optimal) box — a cut never escapes the blank.
+        if let b = shank.boundingBoxOptimal(), let c = t.boundingBoxOptimal() {
+            let tol = 0.05
+            #expect(c.max.x <= b.max.x + tol)
+            #expect(c.min.x >= b.min.x - tol)
+            #expect(c.max.z <= b.max.z + tol)
+            #expect(c.min.z >= b.min.z - tol)
+        }
+        // A real thread removes a shallow helical groove — some material, not most.
+        if let vb = shank.volume, let vt = t.volume {
+            #expect(vt < vb)
+            #expect(vt > vb * 0.7)
+        }
+    }
+
+    // A short/medium thread still gets the smooth analytic helicoid and stays BRepCheck-valid;
+    // only the long faceted fallback is permitted to be invalid-but-usable.
+    @Test("Short thread is the smooth analytic helicoid and is valid")
+    func shortThreadValid() {
+        guard let shank = Shape.cylinder(radius: 5, height: 30) else { Issue.record("no shank"); return }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.0)
+        guard let t = shank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                          spec: spec, length: 16, runout: .none) else {
+            Issue.record("nil"); return
+        }
+        #expect(t.isValid)
+        #expect(t.subShapes(ofType: .face).count < 40)   // smooth, not hundreds of facets
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,32 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.1
+## Current: v1.4.2
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.2 (June 2026) — long full-length threads return a usable solid, not nil (closes #193)
+
+**PATCH — regression fix.** A long full-length thread (`threadedShaft` over tens of turns, e.g. an
+ISO 4017 M10×50 full-thread shank ≈ 49 turns) came back **`nil`**. No API change.
+
+**Cause.** v1.4.1's soundness gate required `Shape.isValid`. For a long thread, the two cutter paths
+both fail that gate: the smooth analytic cutter is BRepCheck-valid but, when wound over ~40+ turns,
+OCCT's boolean degenerates to a near-no-op (the result keeps ~the full blank volume — *no groove cut*);
+the faceted screw-loft fallback *does* cut the groove correctly but trips `BRepCheck` on a benign facet
+self-intersection (`isValid == false`) — exactly the #193 symptom. With both rejected, the method
+returned `nil`.
+
+**Fix.** Soundness is now judged on **geometry, not `BRepCheck`**: the cut must stay inside the blank
+(tight/optimal envelope) and remove a sane fraction of the volume. `isValid` is no longer a gate. The
+analytic no-op is still rejected (it removes ~0 material → fails the volume check), so a long thread
+falls through to the faceted screw-loft and is returned — dimensionally correct and STEP-exportable,
+as the downstream reporter confirmed. Short/medium threads still get the smooth analytic helicoid and
+remain `isValid == true`; only the long faceted fallback is allowed to be invalid-but-usable.
 
 ### v1.4.1 (June 2026) — smooth analytic thread helicoid, with screw-loft fallback (#187)
 


### PR DESCRIPTION
Closes #193.

## Summary

A long full-length thread (`threadedShaft` over tens of turns — e.g. an ISO 4017 **M10×50 full-thread shank ≈ 49 turns**) came back **`nil`**. No API change.

## Root cause

v1.4.1's soundness gate required `Shape.isValid`. For a long thread, **both** cutter paths fail that gate (verified by instrumenting `applyThreadCut`, blank vol = 3927):

| length | analytic | screw-loft fallback |
|---|---|---|
| 26 turns | valid, vol 3859.8 ✓ | (not needed) |
| 40 turns | valid but vol **3926.99 ≈ full blank** — boolean degenerates to a **near-no-op, no groove cut** → rejected by volume check | cuts correctly (vol 3537.7) but **`isValid == false`** (benign facet self-intersection, the #193 symptom) → rejected by validity gate |
| 49 turns | same near-no-op (vol 3926.99) | cuts correctly (vol 3512.3) but `isValid == false` |

With both rejected → `nil`.

## Fix

Judge cut soundness on **geometry, not `BRepCheck`**: the result must stay inside the blank (tight/optimal envelope) **and** remove a sane fraction of the volume. `isValid` is **no longer a gate**.

- The analytic no-op is still rejected (removes ~0 material → fails the volume check), so a long thread falls through to the screw-loft and is **returned** — dimensionally correct and STEP-exportable, exactly as the reporter (OCCTSwiftPartsAgent) confirmed.
- Short/medium threads still get the smooth analytic helicoid and stay `isValid == true`; only the long faceted fallback is allowed to be invalid-but-usable.

**Design note for review:** this intentionally relaxes the validity guarantee for *long* threads — `threadedShaft` can now return a solid with `isValid == false`. That matches the reporter's real-world finding (usable + exportable) and is strictly better than the v1.4.1 `nil`, but it is a deliberate loosening, so flagging it.

## Testing

`Issue193LongThreadTests` (new): M10×1.0 at 26/40/49 turns all return an in-envelope solid that removed material (never nil); a short thread stays `isValid` + smooth (<40 faces). Full thread suite green: **#181 / #185 / #187 / #189 / #193 — 12 tests / 5 suites**.

Proposed release: **v1.4.2** (patch — regression fix, no API change). Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
