### PR TITLE
Poly HLR for fast 2D drawings of threaded solids + tunable deflection (closes #196) → v1.4.3

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -9391,13 +9391,15 @@ OCCTShapeRef _Nullable OCCTHLRGetEdgesByCategory(OCCTShapeRef _Nonnull shape,
 
 /// Get edges by fine-grained category from a polygon-based (fast) HLR drawing.
 /// Note: IsoLine and Outline3d categories are not available for poly HLR (returns NULL).
-/// @param shape Input shape (must be triangulated)
+/// @param shape Input shape (meshed internally for the polyhedral projection)
 /// @param dirX,dirY,dirZ View direction
 /// @param category Edge category to extract
+/// @param deflection Linear mesh deflection (mm) for the internal triangulation —
+///        smaller = finer drawing (more, shorter edges), larger = coarser/faster
 /// @return Shape containing edges, or NULL if none
 OCCTShapeRef _Nullable OCCTHLRPolyGetEdgesByCategory(OCCTShapeRef _Nonnull shape,
     double dirX, double dirY, double dirZ,
-    OCCTHLREdgeCategory category);
+    OCCTHLREdgeCategory category, double deflection);
 
 /// Get edges using the generic CompoundOfEdges API from exact HLR.
 /// @param shape Input shape

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -6288,14 +6288,14 @@ OCCTShapeRef _Nullable OCCTHLRGetEdgesByCategory(OCCTShapeRef _Nonnull shape,
 
 OCCTShapeRef _Nullable OCCTHLRPolyGetEdgesByCategory(OCCTShapeRef _Nonnull shape,
     double dirX, double dirY, double dirZ,
-    OCCTHLREdgeCategory category) {
+    OCCTHLREdgeCategory category, double deflection) {
     if (!shape) return nullptr;
     // IsoLine and Outline3d not available for poly HLR
     if (category == OCCTHLREdgeVisibleIso || category == OCCTHLREdgeHiddenIso ||
         category == OCCTHLREdgeVisibleOutline3d) return nullptr;
     try {
-        // Ensure triangulation
-        BRepMesh_IncrementalMesh mesh(shape->shape, 0.1);
+        // Ensure triangulation (caller-tunable: finer = more drawing detail, coarser = faster)
+        BRepMesh_IncrementalMesh mesh(shape->shape, deflection);
 
         gp_Dir viewDir(dirX, dirY, dirZ);
         gp_Ax2 projAxis(gp_Pnt(0, 0, 0), viewDir);

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -10061,10 +10061,24 @@ extension Shape {
     }
 
     /// Get edges by fine-grained category using fast polygon-based HLR.
-    /// Note: `.visibleIso`, `.hiddenIso`, and `.visibleOutline3d` are not available for poly HLR.
-    public func hlrPolyEdges(direction: SIMD3<Double>, category: HLREdgeCategory) -> Shape? {
+    ///
+    /// Polyhedral HLR projects the shape's *triangulation*, so it is dramatically faster than
+    /// exact `hlrEdges` on curved surfaces — e.g. ~48× on an analytic helicoid thread (#196).
+    /// Prefer this for 2D drawings of threaded / curved solids.
+    ///
+    /// - Parameters:
+    ///   - direction: View direction.
+    ///   - category: Edge category to extract.
+    ///   - deflection: Linear mesh deflection (mm) for the internal triangulation. Smaller = finer
+    ///     drawing (more, shorter edges); larger = coarser and faster. Default `0.1`. Meshing is
+    ///     *incremental* (`BRepMesh_IncrementalMesh`): it refines but never coarsens an existing
+    ///     triangulation, so on a shape already meshed more finely (e.g. by a prior export) this
+    ///     value is a floor, not an override.
+    /// - Note: `.visibleIso`, `.hiddenIso`, and `.visibleOutline3d` are not available for poly HLR.
+    public func hlrPolyEdges(direction: SIMD3<Double>, category: HLREdgeCategory,
+                             deflection: Double = 0.1) -> Shape? {
         guard let h = OCCTHLRPolyGetEdgesByCategory(handle, direction.x, direction.y, direction.z,
-            OCCTHLREdgeCategory(rawValue: UInt32(category.rawValue))) else { return nil }
+            OCCTHLREdgeCategory(rawValue: UInt32(category.rawValue)), deflection) else { return nil }
         return Shape(handle: h)
     }
 

--- a/Tests/OCCTThreadTests/Issue196PolyHLRTests.swift
+++ b/Tests/OCCTThreadTests/Issue196PolyHLRTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #196: the v1.4.1 smooth analytic thread helicoid is HLR-hostile — projecting its BSpline
+// faces with OCCT's *exact* HLR (`hlrEdges` / HLRBRep_Algo) computes analytic helical
+// silhouettes and blows up (~19× slower 2D drawing pipeline vs the v1.4.0 faceted thread).
+// The fix is NOT to change the solid: polyhedral HLR (`hlrPolyEdges` / HLRBRep_PolyAlgo)
+// projects the *triangulation* instead, so it is fast on any surface (measured ~48× faster
+// than exact HLR on this thread) while the one analytic solid stays smooth for STEP. The mesh
+// `deflection` is now caller-tunable so drawing pipelines can trade fidelity for speed.
+// Separate file, cf. #183.
+@Suite("Issue #196 — polyhedral HLR for threaded solids (fast 2D drawings)")
+struct Issue196PolyHLRTests {
+
+    private func analyticThread() -> Shape? {
+        guard let shank = Shape.cylinder(radius: 5, height: 50) else { return nil }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.0)
+        return shank.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                   spec: spec, length: 26, runout: .none)
+    }
+
+    @Test("poly HLR projects the analytic thread to 2D edges")
+    func polyHLRProducesEdges() {
+        guard let t = analyticThread() else { Issue.record("no thread"); return }
+        let edges = t.hlrPolyEdges(direction: SIMD3(1, 0, 0), category: .visibleSharp)
+        #expect(edges != nil)
+        if let edges { #expect(edges.subShapes(ofType: .edge).count > 0) }
+    }
+
+    // NB: each deflection is exercised on its OWN fresh thread. BRepMesh_IncrementalMesh is
+    // incremental — it refines an existing triangulation but never coarsens it — so calling
+    // fine-then-coarse on the *same* shape would reuse the fine mesh and mask the parameter.
+    @Test("deflection is honoured — coarser mesh yields fewer drawing edges")
+    func deflectionControlsDetail() {
+        guard let tFine = analyticThread(), let tCoarse = analyticThread() else {
+            Issue.record("no thread"); return
+        }
+        let dir = SIMD3<Double>(1, 0, 0)
+        let fine = tFine.hlrPolyEdges(direction: dir, category: .visibleSharp, deflection: 0.05)?
+            .subShapes(ofType: .edge).count
+        let coarse = tCoarse.hlrPolyEdges(direction: dir, category: .visibleSharp, deflection: 0.8)?
+            .subShapes(ofType: .edge).count
+        #expect(fine != nil); #expect(coarse != nil)
+        if let fine, let coarse {
+            #expect(fine > 0); #expect(coarse > 0)
+            #expect(coarse < fine)   // coarser triangulation → fewer, longer edges
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,31 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.2
+## Current: v1.4.3
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.3 (June 2026) — fast 2D drawings of threaded solids via polyhedral HLR (closes #196)
+
+**PATCH — additive + guidance.** The v1.4.1 smooth analytic thread helicoid is HLR-hostile under
+OCCT's **exact** HLR (`hlrEdges` / `HLRBRep_Algo`): projecting its BSpline faces computes analytic
+helical silhouettes and blows up — a downstream 2D-drawing pipeline measured **~19× slower** vs the
+v1.4.0 faceted thread.
+
+**The fix is not to change the solid.** OCCT's **polyhedral** HLR (`hlrPolyEdges` / `HLRBRep_PolyAlgo`,
+already wrapped) projects the shape's *triangulation*, so it is fast on any surface — **measured ~48×
+faster** than exact HLR on an analytic M10 thread (337 ms vs 16.4 s, side view) — while the one
+analytic solid stays smooth for STEP. **Prefer `hlrPolyEdges` for 2D drawings of threaded / curved
+solids; reserve exact `hlrEdges` for analytically simple shapes.**
+
+`hlrPolyEdges(direction:category:deflection:)` now exposes the internal mesh **`deflection`** (mm,
+default `0.1`) so drawing pipelines can trade fidelity (more, shorter edges) for speed. Non-breaking —
+the default reproduces prior output. (No GPU offload needed; the polyhedral CPU path already recovers
+the speed. The broader hardcoded-constant sweep this surfaced is tracked in #197.)
 
 ### v1.4.2 (June 2026) — long full-length threads return a usable solid, not nil (closes #193)
 


### PR DESCRIPTION
Closes #196.

## Summary

The v1.4.1 smooth analytic thread helicoid is **HLR-hostile under OCCT's *exact* HLR** (`hlrEdges` / `HLRBRep_Algo`): projecting its BSpline faces computes analytic helical silhouettes and blows up — a downstream 2D-drawing pipeline measured **~19× slower** vs the v1.4.0 faceted thread.

**The fix is not to change the solid.** OCCT's **polyhedral** HLR (`hlrPolyEdges` / `HLRBRep_PolyAlgo`, already wrapped) projects the shape's *triangulation*, so it is fast on any surface — while the one analytic solid stays smooth for STEP.

### Benchmark (analytic M10×26 thread, side view — worst case)

| HLR path | time | edges |
|---|---|---|
| Exact (`hlrEdges` → `HLRBRep_Algo`) | **16,361 ms** | 381 |
| Poly (`hlrPolyEdges` → `HLRBRep_PolyAlgo`) | **337 ms** | 1820 |
| | **48.5× faster** | |

**No GPU offload needed** — OCCT's HLR is *vector* hidden-line (exact 2D edges → DXF); a GPU/raster approach would be a large reimplementation with different output. The polyhedral CPU path already recovers ~50×, and is the standard fix for helical-HLR blowup.

## Changes

- **`hlrPolyEdges(direction:category:deflection:)`** now exposes the internal mesh **`deflection`** (mm, default `0.1` — previously hardcoded in the bridge) so drawing pipelines can trade fidelity (more, shorter edges) for speed. Non-breaking: the default reproduces prior output.
- Doc + CHANGELOG **guidance**: prefer poly HLR for 2D drawings of threaded/curved solids; reserve exact HLR for analytically simple shapes.
- **Caveat documented**: `BRepMesh_IncrementalMesh` is incremental (refines, never coarsens), so on an already-finer-meshed shape the `deflection` acts as a floor, not an override.

This is source-only (the `OCCTBridge` target compiles from source; only the OCCT xcframework is binary) — no Package.swift / checksum change.

## Testing

`Issue196PolyHLRTests`: poly HLR projects the analytic thread to 2D edges; the `deflection` parameter changes drawing edge density (validated on *fresh* shapes — see the incremental-mesh note). All thread suites green (#181/#185/#187/#189/#193/#196).

## Follow-up

`hlrPolyEdges`'s hardcoded deflection was one instance of a broader pattern — spun out a sweep for other hardcoded constants that should be defaulted parameters as #197.

Proposed release: **v1.4.3** (patch — additive + guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
