### PR TITLE
Expose mesh deflection on auto-meshing utilities (#197 — mesh-deflection area) → v1.4.4

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -2685,7 +2685,8 @@ typedef struct {
 int32_t OCCTShapeProximity(OCCTShapeRef shape1, OCCTShapeRef shape2,
                             double tolerance,
                             OCCTFaceProximityPair* outPairs,
-                            int32_t maxPairs);
+                            int32_t maxPairs,
+                            double deflection);
 
 /// Check if a shape self-intersects
 bool OCCTShapeSelfIntersects(OCCTShapeRef shape);
@@ -10315,7 +10316,7 @@ int OCCTPolyMergeNodes(OCCTShapeRef _Nonnull shapeRef,
 typedef void* OCCTCoherentTriangulationRef;
 
 OCCTCoherentTriangulationRef OCCTCoherentTriangulationCreate(void);
-OCCTCoherentTriangulationRef OCCTCoherentTriangulationCreateFromMesh(OCCTShapeRef _Nonnull shapeRef);
+OCCTCoherentTriangulationRef OCCTCoherentTriangulationCreateFromMesh(OCCTShapeRef _Nonnull shapeRef, double deflection);
 int OCCTCoherentTriangulationSetNode(OCCTCoherentTriangulationRef _Nonnull ref, double x, double y, double z);
 bool OCCTCoherentTriangulationAddTriangle(OCCTCoherentTriangulationRef _Nonnull ref, int n0, int n1, int n2);
 bool OCCTCoherentTriangulationRemoveTriangle(OCCTCoherentTriangulationRef _Nonnull ref, int triIndex);
@@ -13414,14 +13415,16 @@ OCCTShapeRef _Nullable OCCTShapeFixSmallEdges(OCCTShapeRef _Nonnull shape, doubl
 /// Write a shape's triangulation to binary STL file. Shape is meshed automatically.
 /// @param shape The shape to write
 /// @param filePath Output file path
+/// @param deflection Linear mesh deflection (mm) for the auto-triangulation
 /// @return true on success
-bool OCCTShapeWriteSTLBinary(OCCTShapeRef _Nonnull shape, const char* _Nonnull filePath);
+bool OCCTShapeWriteSTLBinary(OCCTShapeRef _Nonnull shape, const char* _Nonnull filePath, double deflection);
 
 /// Write a shape's triangulation to ASCII STL file. Shape is meshed automatically.
 /// @param shape The shape to write
 /// @param filePath Output file path
+/// @param deflection Linear mesh deflection (mm) for the auto-triangulation
 /// @return true on success
-bool OCCTShapeWriteSTLAscii(OCCTShapeRef _Nonnull shape, const char* _Nonnull filePath);
+bool OCCTShapeWriteSTLAscii(OCCTShapeRef _Nonnull shape, const char* _Nonnull filePath, double deflection);
 
 /// Read an STL file and return as a triangulated shape (face with triangulation).
 /// @param filePath Input STL file path
@@ -13450,7 +13453,7 @@ bool OCCTCurve3DIsPeriodicSA(OCCTCurve3DRef _Nonnull curve);
 int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef _Nonnull shape, double tolerance,
                                         int32_t* _Nonnull outFaceIdx1,
                                         int32_t* _Nonnull outFaceIdx2,
-                                        int32_t maxPairs);
+                                        int32_t maxPairs, double deflection);
 
 // --- Geom_OffsetCurve basis curve ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
@@ -1203,11 +1203,11 @@ OCCTCoherentTriangulationRef OCCTCoherentTriangulationCreate(void) {
     } catch (...) { return nullptr; }
 }
 
-OCCTCoherentTriangulationRef OCCTCoherentTriangulationCreateFromMesh(OCCTShapeRef _Nonnull shapeRef) {
+OCCTCoherentTriangulationRef OCCTCoherentTriangulationCreateFromMesh(OCCTShapeRef _Nonnull shapeRef, double deflection) {
     try {
         const TopoDS_Shape& shape = *(const TopoDS_Shape*)shapeRef;
         // Mesh the shape first
-        BRepMesh_IncrementalMesh mesh(shape, 0.1);
+        BRepMesh_IncrementalMesh mesh(shape, deflection);
         // Find first face triangulation
         for (TopExp_Explorer exp(shape, TopAbs_FACE); exp.More(); exp.Next()) {
             TopoDS_Face face = TopoDS::Face(exp.Current());
@@ -1365,11 +1365,11 @@ OCCTPoint3D OCCTCoordSystemUpDirection(int system) {
 // MARK: - v0.100: RWStl direct binary/ASCII STL I/O
 // --- RWStl direct binary/ASCII STL I/O ---
 
-bool OCCTShapeWriteSTLBinary(OCCTShapeRef shape, const char* filePath) {
+bool OCCTShapeWriteSTLBinary(OCCTShapeRef shape, const char* filePath, double deflection) {
     if (!shape || !filePath) return false;
     try {
         // Mesh the shape
-        BRepMesh_IncrementalMesh mesher(shape->shape, 0.1);
+        BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
 
         // Collect first non-null triangulation
         TopExp_Explorer ex(shape->shape, TopAbs_FACE);
@@ -1385,10 +1385,10 @@ bool OCCTShapeWriteSTLBinary(OCCTShapeRef shape, const char* filePath) {
     } catch (...) { return false; }
 }
 
-bool OCCTShapeWriteSTLAscii(OCCTShapeRef shape, const char* filePath) {
+bool OCCTShapeWriteSTLAscii(OCCTShapeRef shape, const char* filePath, double deflection) {
     if (!shape || !filePath) return false;
     try {
-        BRepMesh_IncrementalMesh mesher(shape->shape, 0.1);
+        BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
 
         TopExp_Explorer ex(shape->shape, TopAbs_FACE);
         for (; ex.More(); ex.Next()) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -592,13 +592,14 @@ OCCTCurveProjectionResult OCCTEdgeProjectPoint(OCCTEdgeRef edge,
 int32_t OCCTShapeProximity(OCCTShapeRef shape1, OCCTShapeRef shape2,
                             double tolerance,
                             OCCTFaceProximityPair* outPairs,
-                            int32_t maxPairs) {
+                            int32_t maxPairs,
+                            double deflection) {
     if (!shape1 || !shape2 || !outPairs || maxPairs <= 0) return 0;
 
     try {
         // BRepExtrema_ShapeProximity requires triangulated shapes
-        BRepMesh_IncrementalMesh mesh1(shape1->shape, 0.1);
-        BRepMesh_IncrementalMesh mesh2(shape2->shape, 0.1);
+        BRepMesh_IncrementalMesh mesh1(shape1->shape, deflection);
+        BRepMesh_IncrementalMesh mesh2(shape2->shape, deflection);
 
         BRepExtrema_ShapeProximity prox(shape1->shape, shape2->shape, (Standard_Real)tolerance);
         prox.Perform();

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1806,10 +1806,10 @@ int32_t OCCTBoundSortBoxCompare(OCCTBoundSortBoxRef bsb,
 
 int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
                                         int32_t* outFaceIdx1, int32_t* outFaceIdx2,
-                                        int32_t maxPairs) {
+                                        int32_t maxPairs, double deflection) {
     if (!shape || !outFaceIdx1 || !outFaceIdx2 || maxPairs <= 0) return -1;
     try {
-        BRepMesh_IncrementalMesh mesher(shape->shape, 0.1);
+        BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
 
         BRepExtrema_SelfIntersection selfInt(shape->shape, tolerance);
         selfInt.Perform();

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -6482,19 +6482,23 @@ extension Shape {
 extension Shape {
 
     /// Write this shape's triangulation to a binary STL file.
-    /// The shape is meshed automatically with 0.1 deflection.
-    /// - Parameter filePath: Output file path.
+    /// The shape is meshed automatically.
+    /// - Parameters:
+    ///   - filePath: Output file path.
+    ///   - deflection: Linear mesh deflection (mm) for the auto-triangulation. Default `0.1`.
     /// - Returns: true on success.
-    public func writeSTLBinary(to filePath: String) -> Bool {
-        OCCTShapeWriteSTLBinary(handle, filePath)
+    public func writeSTLBinary(to filePath: String, deflection: Double = 0.1) -> Bool {
+        OCCTShapeWriteSTLBinary(handle, filePath, deflection)
     }
 
     /// Write this shape's triangulation to an ASCII STL file.
-    /// The shape is meshed automatically with 0.1 deflection.
-    /// - Parameter filePath: Output file path.
+    /// The shape is meshed automatically.
+    /// - Parameters:
+    ///   - filePath: Output file path.
+    ///   - deflection: Linear mesh deflection (mm) for the auto-triangulation. Default `0.1`.
     /// - Returns: true on success.
-    public func writeSTLAscii(to filePath: String) -> Bool {
-        OCCTShapeWriteSTLAscii(handle, filePath)
+    public func writeSTLAscii(to filePath: String, deflection: Double = 0.1) -> Bool {
+        OCCTShapeWriteSTLAscii(handle, filePath, deflection)
     }
 
     /// Read an STL file and return as a triangulated shape.
@@ -6541,12 +6545,14 @@ extension Shape {
     /// - Parameters:
     ///   - tolerance: Overlap tolerance (default: 0.0).
     ///   - maxPairs: Maximum number of pairs to return (default: 100).
+    ///   - deflection: Linear mesh deflection (mm) for the detection triangulation. Default `0.1`.
     /// - Returns: Array of overlapping face index pairs, empty if none found.
     public func selfIntersectionPairs(tolerance: Double = 0.0,
-                                       maxPairs: Int = 100) -> [OverlapPair] {
+                                       maxPairs: Int = 100,
+                                       deflection: Double = 0.1) -> [OverlapPair] {
         var idx1 = [Int32](repeating: 0, count: maxPairs)
         var idx2 = [Int32](repeating: 0, count: maxPairs)
-        let count = OCCTShapeSelfIntersectionPairs(handle, tolerance, &idx1, &idx2, Int32(maxPairs))
+        let count = OCCTShapeSelfIntersectionPairs(handle, tolerance, &idx1, &idx2, Int32(maxPairs), deflection)
         guard count > 0 else { return [] }
         return (0..<Int(count)).map {
             OverlapPair(faceIndex1: Int(idx1[$0]), faceIndex2: Int(idx2[$0]))

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -3391,10 +3391,11 @@ extension Shape {
         public let face2Index: Int
     }
 
-    /// Detect face pairs between this shape and another that are within tolerance
-    public func proximityFaces(with other: Shape, tolerance: Double) -> [FaceProximityPair] {
+    /// Detect face pairs between this shape and another that are within tolerance.
+    /// - Parameter deflection: Linear mesh deflection (mm) for the proximity triangulation. Default `0.1`.
+    public func proximityFaces(with other: Shape, tolerance: Double, deflection: Double = 0.1) -> [FaceProximityPair] {
         var buffer = [OCCTFaceProximityPair](repeating: OCCTFaceProximityPair(), count: 256)
-        let count = OCCTShapeProximity(handle, other.handle, tolerance, &buffer, 256)
+        let count = OCCTShapeProximity(handle, other.handle, tolerance, &buffer, 256, deflection)
 
         var pairs = [FaceProximityPair]()
         for i in 0..<Int(count) {
@@ -11800,8 +11801,9 @@ public final class CoherentTriangulation: @unchecked Sendable {
     }
 
     /// Create a coherent triangulation from a meshed shape's first face triangulation.
-    public static func createFromMesh(_ shape: Shape) -> CoherentTriangulation? {
-        guard let ref = OCCTCoherentTriangulationCreateFromMesh(shape.handle) else { return nil }
+    /// - Parameter deflection: Linear mesh deflection (mm) for the auto-triangulation. Default `0.1`.
+    public static func createFromMesh(_ shape: Shape, deflection: Double = 0.1) -> CoherentTriangulation? {
+        guard let ref = OCCTCoherentTriangulationCreateFromMesh(shape.handle, deflection) else { return nil }
         return CoherentTriangulation(handle: ref)
     }
 

--- a/Tests/OCCTMeshTests/Issue197MeshDeflectionTests.swift
+++ b/Tests/OCCTMeshTests/Issue197MeshDeflectionTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #197: mesh deflection was hardcoded to 0.1 in several auto-meshing utility functions
+// (STL writers, coherent-triangulation builder, proximity, self-intersection). Each now
+// exposes a `deflection:` parameter (default 0.1, non-breaking) so callers can trade
+// triangulation fidelity for speed/size — the same class of knob exposed for poly HLR in #196.
+//
+// NB: BRepMesh_IncrementalMesh is incremental (refines, never coarsens), so each deflection
+// must be exercised on its OWN fresh shape, or a prior finer mesh would mask the parameter.
+@Suite("Issue #197 — mesh deflection is a caller-tunable parameter")
+struct Issue197MeshDeflectionTests {
+
+    private func sphere() -> Shape? { Shape.sphere(radius: 10) }
+
+    @Test("binary STL: finer deflection yields a larger file (more triangles)")
+    func stlBinaryDeflection() throws {
+        guard let coarseShape = sphere(), let fineShape = sphere() else {
+            Issue.record("no sphere"); return
+        }
+        let dir = FileManager.default.temporaryDirectory
+        let coarseURL = dir.appendingPathComponent("occt197_coarse_\(UUID().uuidString).stl")
+        let fineURL = dir.appendingPathComponent("occt197_fine_\(UUID().uuidString).stl")
+        defer { try? FileManager.default.removeItem(at: coarseURL); try? FileManager.default.removeItem(at: fineURL) }
+
+        #expect(coarseShape.writeSTLBinary(to: coarseURL.path, deflection: 1.0))
+        #expect(fineShape.writeSTLBinary(to: fineURL.path, deflection: 0.05))
+
+        let coarseSize = (try? FileManager.default.attributesOfItem(atPath: coarseURL.path))?[.size] as? Int ?? 0
+        let fineSize = (try? FileManager.default.attributesOfItem(atPath: fineURL.path))?[.size] as? Int ?? 0
+        // Binary STL size = 84 + 50·triangles, so size is a direct proxy for triangle count.
+        #expect(coarseSize > 0)
+        #expect(fineSize > coarseSize)
+    }
+
+    @Test("default deflection (0.1) still writes a valid STL")
+    func stlDefaultUnchanged() {
+        guard let s = sphere() else { Issue.record("no sphere"); return }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt197_default_\(UUID().uuidString).stl")
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(s.writeSTLBinary(to: url.path))   // default deflection
+        let size = (try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int ?? 0
+        #expect(size > 84)
+    }
+
+    @Test("coherent triangulation builds at the requested deflection")
+    func coherentTriangulationDeflection() {
+        guard let s = sphere() else { Issue.record("no sphere"); return }
+        let tri = CoherentTriangulation.createFromMesh(s, deflection: 0.2)
+        #expect(tri != nil)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,28 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.3
+## Current: v1.4.4
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.4 (June 2026) — mesh deflection is caller-tunable on auto-meshing utilities (#197)
+
+**PATCH — additive, non-breaking.** Several utility functions auto-triangulated their input at a
+**hardcoded `0.1` mm** deflection, leaving callers no control over fidelity/speed. Each now takes a
+`deflection: Double = 0.1` parameter (the default reproduces prior output). First slice of the #197
+hardcoded-constant sweep — the *mesh deflection* area:
+
+- `Shape.writeSTLBinary(to:deflection:)` / `writeSTLAscii(to:deflection:)` — STL export resolution.
+- `Shape.proximityFaces(with:tolerance:deflection:)` — proximity triangulation.
+- `Shape.selfIntersectionPairs(tolerance:maxPairs:deflection:)` — self-intersection triangulation.
+- `CoherentTriangulation.createFromMesh(_:deflection:)`.
+
+(The primary STL path `Exporter.writeSTL(shape:to:deflection:)` already exposed this.) Source-only;
+remaining #197 areas — tolerances, sampling counts — tracked in the issue.
 
 ### v1.4.3 (June 2026) — fast 2D drawings of threaded solids via polyhedral HLR (closes #196)
 


### PR DESCRIPTION
First slice of #197 — the **mesh-deflection** area.

## Summary

Several auto-meshing utility functions triangulated their input at a **hardcoded `0.1` mm** deflection, so callers had no control over fidelity/speed/size. Each now takes a trailing `deflection: Double = 0.1` — the default reproduces prior output, so it's **non-breaking**.

| API | knob |
|---|---|
| `Shape.writeSTLBinary(to:deflection:)` / `writeSTLAscii(to:deflection:)` | STL export resolution |
| `Shape.proximityFaces(with:tolerance:deflection:)` | proximity triangulation |
| `Shape.selfIntersectionPairs(tolerance:maxPairs:deflection:)` | self-intersection triangulation |
| `CoherentTriangulation.createFromMesh(_:deflection:)` | triangulation builder |

(The primary STL path `Exporter.writeSTL(shape:to:deflection:)` already exposed this; poly HLR was done in #196.)

## Scope

This is intentionally **just the mesh-deflection area** — per #197's "small PRs by area" plan. The remaining areas (sewing/approx **tolerances**, **sampling/discretization counts**) stay tracked in #197 for follow-up PRs.

## Testing

`Issue197MeshDeflectionTests`: binary STL size (= 84 + 50·triangles, a direct proxy for triangle count) grows with finer deflection on *fresh* shapes (the `BRepMesh_IncrementalMesh` refine-only caveat applies); the default still writes a valid STL; coherent triangulation builds at the requested deflection. Build clean, no stray callers of the changed bridge signatures.

Source-only (the `OCCTBridge` target compiles from source). Proposed release: **v1.4.4** (patch — additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
