### PR TITLE
feat(mesh): tunable weld tolerance on Mesh.toShape (#197) → v1.4.5

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -800,6 +800,13 @@ int32_t OCCTMeshGetTrianglesWithFaces(OCCTMeshRef mesh, OCCTTriangle* outTriangl
 /// @return Shape containing triangulated faces, or NULL on failure
 OCCTShapeRef OCCTMeshToShape(OCCTMeshRef mesh);
 
+/// Convert a mesh to a B-Rep shape with a caller-supplied sewing (vertex-weld) tolerance.
+/// The weld tolerance must scale with the mesh's coordinate magnitude — too small for a
+/// large-coordinate mesh leaves the shell open. @param weldTolerance edge-merge tolerance
+/// (model units); pass 1e-6 to reproduce the default behaviour of OCCTMeshToShape.
+/// @return Shape containing triangulated faces, or NULL on failure
+OCCTShapeRef OCCTMeshToShapeWithTolerance(OCCTMeshRef mesh, double weldTolerance);
+
 // MARK: - Mesh Booleans (via B-Rep roundtrip)
 
 /// Perform boolean union on two meshes

--- a/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
@@ -411,12 +411,13 @@ int32_t OCCTMeshGetTrianglesWithFaces(OCCTMeshRef mesh, OCCTTriangle* outTriangl
 
 // MARK: - Mesh to Shape Conversion
 
-OCCTShapeRef OCCTMeshToShape(OCCTMeshRef mesh) {
+OCCTShapeRef OCCTMeshToShapeWithTolerance(OCCTMeshRef mesh, double weldTolerance) {
     if (!mesh || mesh->indices.empty()) return nullptr;
+    if (!(weldTolerance > 0.0)) return nullptr;  // reject 0/negative/NaN
 
     try {
         // Use sewing to create a shell from triangles
-        BRepBuilderAPI_Sewing sewing(1e-6);  // Tolerance for edge merging
+        BRepBuilderAPI_Sewing sewing(weldTolerance);  // Tolerance for edge merging
 
         int32_t triCount = static_cast<int32_t>(mesh->indices.size() / 3);
 
@@ -462,6 +463,10 @@ OCCTShapeRef OCCTMeshToShape(OCCTMeshRef mesh) {
     } catch (...) {
         return nullptr;
     }
+}
+
+OCCTShapeRef OCCTMeshToShape(OCCTMeshRef mesh) {
+    return OCCTMeshToShapeWithTolerance(mesh, 1e-6);
 }
 
 // MARK: - Mesh Booleans (via B-Rep Roundtrip)

--- a/Sources/OCCTSwift/Mesh.swift
+++ b/Sources/OCCTSwift/Mesh.swift
@@ -434,9 +434,14 @@ public final class Mesh: @unchecked Sendable {
     /// - Note: The resulting shape is a shell/compound of planar faces.
     ///         It may not be a valid solid depending on the mesh topology.
     ///
+    /// - Parameter weldTolerance: Vertex-merge tolerance used to sew adjacent triangle
+    ///   faces into a shell, in model units. This must scale with the mesh's coordinate
+    ///   magnitude — a value too small for a large-coordinate mesh leaves shared edges
+    ///   unmerged and yields an open shell. The default (`1e-6`) suits meshes around unit
+    ///   scale; raise it for large parts. Must be positive.
     /// - Returns: A `Shape` representing the mesh geometry, or `nil` on failure
-    public func toShape() -> Shape? {
-        guard let shapeHandle = OCCTMeshToShape(handle) else {
+    public func toShape(weldTolerance: Double = 1e-6) -> Shape? {
+        guard let shapeHandle = OCCTMeshToShapeWithTolerance(handle, weldTolerance) else {
             return nil
         }
         return Shape(handle: shapeHandle)

--- a/Tests/OCCTMeshTests/OCCTMeshTests.swift
+++ b/Tests/OCCTMeshTests/OCCTMeshTests.swift
@@ -194,6 +194,46 @@ struct MeshTests {
         #expect(shape != nil)
     }
 
+    // issue #197: Mesh.toShape weld tolerance is now caller-tunable.
+    @Test("toShape weldTolerance: default parity, guards, and large-mesh welding")
+    func meshToShapeWeldTolerance() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let mesh = box.mesh(linearDeflection: 0.5)!
+
+        // Default and an explicit 1e-6 must behave identically (non-breaking).
+        if let d = mesh.toShape(), let e = mesh.toShape(weldTolerance: 1e-6) {
+            #expect(d.edges(where: { _ in true }).count == e.edges(where: { _ in true }).count)
+        } else {
+            #expect(Bool(false), "default / explicit-1e-6 toShape returned nil")
+        }
+
+        // Non-positive tolerances are rejected (no crash, returns nil).
+        #expect(mesh.toShape(weldTolerance: 0) == nil)
+        #expect(mesh.toShape(weldTolerance: -1) == nil)
+
+        // Two coplanar triangles whose facing edges (y=0 and y=gap) are 0.5 apart — as
+        // happens when shared vertices in an imported mesh are stored as independent,
+        // slightly-differing floats. At the default 1e-6 they stay two free edges; at a
+        // scale-appropriate tolerance they weld into one, dropping the edge count.
+        let gap: Float = 0.5
+        let verts: [SIMD3<Float>] = [
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(5, 5, 0),        // triangle 1, base edge at y=0
+            SIMD3(0, gap, 0), SIMD3(10, gap, 0), SIMD3(5, -5, 0),   // triangle 2, base edge at y=gap
+        ]
+        guard let gappy = Mesh(vertices: verts, indices: [0, 1, 2, 3, 4, 5]) else {
+            #expect(Bool(false), "Failed to build gappy mesh"); return
+        }
+        if let tight = gappy.toShape(weldTolerance: 1e-6),
+           let welded = gappy.toShape(weldTolerance: 2.0) {
+            let tightEdges = tight.edges(where: { _ in true }).count
+            let weldedEdges = welded.edges(where: { _ in true }).count
+            #expect(weldedEdges < tightEdges,
+                    "scale-appropriate weld (\(weldedEdges)) should merge edges vs 1e-6 (\(tightEdges))")
+        } else {
+            #expect(Bool(false), "gappy-mesh toShape returned nil")
+        }
+    }
+
     @Test("Mesh boolean union")
     func meshBooleanUnion() {
         let box1 = Shape.box(width: 10, height: 10, depth: 10)!

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.4
+## Current: v1.4.5
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.5 (June 2026) — mesh→shape weld tolerance is caller-tunable (#197)
+
+**PATCH — additive, non-breaking.** `Mesh.toShape()` sewed its triangles into a shell at a
+**hardcoded `1e-6`** weld tolerance. That tolerance must scale with the mesh's coordinate
+magnitude — too small for a large-coordinate (or imprecise, imported) mesh leaves shared edges
+unmerged and silently yields an open shell. It now takes `weldTolerance: Double = 1e-6` (the
+default reproduces prior output); non-positive values return `nil`. From the #197 hardcoded-constant
+sweep — the audit (see issue) found this the one remaining genuine knob; the rest of the `1e-X`
+literals are internal correctness epsilons left as-is.
 
 ### v1.4.4 (June 2026) — mesh deflection is caller-tunable on auto-meshing utilities (#197)
 


### PR DESCRIPTION
## Summary

From the #197 hardcoded-constant audit (full report posted on the issue), the **one remaining genuine caller-facing knob** was `Mesh.toShape()`'s sewing tolerance, hardcoded at `1e-6`. That weld tolerance must scale with the mesh's coordinate magnitude — too small for a large-coordinate or imprecise (imported) mesh leaves shared edges unmerged and silently yields an **open shell**.

This is the same anti-pattern that motivated #197 (mesh deflection), now applied to the weld tolerance.

## Changes

- **Swift:** `Mesh.toShape(weldTolerance: Double = 1e-6) -> Shape?` — default reproduces prior output; non-positive values return `nil`.
- **Bridge:** new `OCCTMeshToShapeWithTolerance(mesh, weldTolerance)`; the existing `OCCTMeshToShape(mesh)` now delegates to it with `1e-6`, so the ABI is intact.
- **Test:** default/explicit-`1e-6` parity, non-positive guards, and a deterministic two-triangle mesh whose shared edge is split by a `0.5` gap — proving a scale-appropriate tolerance welds (fewer edges) where `1e-6` does not.

Non-breaking, source-only (no xcframework change). PATCH → v1.4.5; CHANGELOG updated.

## Audit outcome for #197

Mesh deflection (#196/#199) and curve/2D discretization were already done/parameterized; sewing had this one knob; the remaining ~111 `1e-X` literals are internal correctness epsilons. Recommend keeping #197 open as the on-demand tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
