### PR TITLE
feat(io): instanced-assembly STEP writer — Exporter.writeSTEPAssembly (closes #173) → v1.4.6

### DIFF
--- a/Sources/OCCTSwift/Exporter.swift
+++ b/Sources/OCCTSwift/Exporter.swift
@@ -544,6 +544,36 @@ public enum Exporter {
         }
     }
 
+    // MARK: - Instanced Assembly STEP Export (#173)
+
+    /// Write an XCAF `Document` as a **product-structured STEP assembly**.
+    ///
+    /// Unlike `writeSTEP(shape:to:)`, which flattens geometry, this preserves the document's
+    /// assembly tree: each unique part label is written once as a STEP product
+    /// (`PRODUCT` / `PRODUCT_DEFINITION`) and is referenced by its located component
+    /// occurrences (`NEXT_ASSEMBLY_USAGE_OCCURRENCE` + each component's `TopLoc_Location`).
+    /// File size therefore scales with the number of *unique parts*, not total placements —
+    /// a part placed N times stores one `MANIFOLD_SOLID_BREP`, not N copies — and the file
+    /// opens as an editable assembly in standard CAD viewers. Component names and colors set
+    /// on the document are written too.
+    ///
+    /// Build the assembly with `Document.addShape(_:makeAssembly:)` for the part prototypes
+    /// and `Document.addComponent(assemblyLabelId:shapeLabelId:matrix:)` for each full-rigid
+    /// (rotation + translation) placement, then call this. The output uses the AP214 schema,
+    /// matching the rest of the STEP writers.
+    ///
+    /// - Parameters:
+    ///   - document: The XCAF document holding the assembly tree.
+    ///   - url: Destination file URL.
+    /// - Throws: `ExportError.invalidPath` for an empty path, `ExportError.exportFailed`
+    ///   if the STEP transfer/write fails.
+    public static func writeSTEPAssembly(_ document: Document, to url: URL) throws {
+        guard !url.path.isEmpty else { throw ExportError.invalidPath }
+        if !document.writeSTEP(to: url) {
+            throw ExportError.exportFailed("STEP assembly export to \(url.lastPathComponent) failed")
+        }
+    }
+
     // MARK: - STEP Optimization (v0.28.0)
 
     /// Optimize a STEP file by merging duplicate geometric entities.

--- a/Tests/OCCTXCAFTests/Issue173AssemblySTEPTests.swift
+++ b/Tests/OCCTXCAFTests/Issue173AssemblySTEPTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #173: Exporter.writeSTEPAssembly writes a product-structured (instanced) STEP —
+// one part product referenced by N located occurrences, not N geometry copies.
+@Suite("Issue #173 — instanced assembly STEP writer")
+struct Issue173AssemblySTEP {
+
+    /// Build a document with one unique part placed at `n` distinct X offsets.
+    private func makeInstancedDoc(n: Int) -> Document? {
+        guard let doc = Document.create(),
+              let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        let partId = doc.addShape(box, makeAssembly: false)
+        let asmId = doc.newShapeLabel()
+        for i in 0..<n {
+            let m: [Double] = [1, 0, 0, 0, 1, 0, 0, 0, 1, Double(i) * 20, 0, 0]
+            _ = doc.addComponent(assemblyLabelId: asmId, shapeLabelId: partId, matrix: m)
+        }
+        doc.updateAssemblies()
+        return doc
+    }
+
+    @Test("geometry is shared: 1 BREP + N occurrences, size scales with unique parts")
+    func instancedStructure() throws {
+        let n = 20
+        guard let doc = makeInstancedDoc(n: n) else { #expect(Bool(false)); return }
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue173_asm.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Exporter.writeSTEPAssembly(doc, to: url)
+
+        let text = try String(contentsOf: url, encoding: .utf8)
+        func count(_ s: String) -> Int { text.components(separatedBy: s).count - 1 }
+        // One unique part definition → exactly one solid BREP, regardless of placements.
+        #expect(count("MANIFOLD_SOLID_BREP") == 1)
+        // N located component occurrences.
+        #expect(count("NEXT_ASSEMBLY_USAGE_OCCURRENCE") == n)
+    }
+
+    @Test("round-trips: written assembly reads back with the same occurrence count")
+    func roundTrip() throws {
+        let n = 8
+        guard let doc = makeInstancedDoc(n: n) else { #expect(Bool(false)); return }
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue173_rt.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Exporter.writeSTEPAssembly(doc, to: url)
+
+        let reloaded = try Document.loadSTEP(from: url)
+        // The loaded tree should expose an assembly node whose component children
+        // count equals the number of placements we wrote.
+        var maxChildren = 0
+        func walk(_ node: AssemblyNode) {
+            maxChildren = max(maxChildren, node.children.count)
+            for c in node.children { walk(c) }
+        }
+        for r in reloaded.rootNodes { walk(r) }
+        #expect(maxChildren == n)
+    }
+
+    @Test("empty path throws, not crashes")
+    func emptyPathThrows() throws {
+        guard let doc = makeInstancedDoc(n: 2) else { #expect(Bool(false)); return }
+        #expect(throws: Exporter.ExportError.self) {
+            try Exporter.writeSTEPAssembly(doc, to: URL(fileURLWithPath: ""))
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,28 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.5
+## Current: v1.4.6
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.6 (June 2026) — instanced-assembly STEP writer (closes #173)
+
+**PATCH — additive, non-breaking.** New `Exporter.writeSTEPAssembly(_ document: Document, to url:)`
+writes an XCAF `Document` as a **product-structured STEP assembly**: each unique part label
+becomes one STEP product, referenced by its located component occurrences
+(`NEXT_ASSEMBLY_USAGE_OCCURRENCE` + each component's `TopLoc_Location`). A part placed N times
+stores **one** `MANIFOLD_SOLID_BREP`, not N copies — file size scales with unique parts, and the
+result opens as an editable assembly in standard CAD viewers (AP214). Names/colors set on the
+document are preserved.
+
+The underlying capability already existed (`Document.writeSTEP` transfers the XCAF doc via
+`STEPCAFControl_Writer`, and full rotation+translation placement landed in #174); this adds the
+named, documented, throwing convenience entry point #173 asked for, plus instancing + round-trip
+tests.
 
 ### v1.4.5 (June 2026) — mesh→shape weld tolerance is caller-tunable (#197)
 


### PR DESCRIPTION
## Summary

Adds `Exporter.writeSTEPAssembly(_ document: Document, to url:)` — the product-structured (instanced) STEP writer #173 asked for.

While auditing #173 I found the underlying capability **already exists**: `Document.writeSTEP` transfers the XCAF document via `STEPCAFControl_Writer`, which preserves assembly structure, and full rotation+translation placement landed in #174. A probe confirmed it: a document with **1 part + 20 located occurrences** writes **1** `MANIFOLD_SOLID_BREP` + **20** `NEXT_ASSEMBLY_USAGE_OCCURRENCE` (~27 KB — scales with unique parts, not placements).

What was missing was the **named, discoverable, throwing entry point** the issue specified. This PR adds it as a thin `Exporter` convenience over that path, with docs explaining the product structure and how to build the tree (`addShape(makeAssembly:)` prototypes + `addComponent(matrix:)` placements).

## Acceptance criteria (#173)

- ✅ 1 part + N occurrences → instance count = 1 part + N occurrences (test asserts `MANIFOLD_SOLID_BREP == 1`, `NEXT_ASSEMBLY_USAGE_OCCURRENCE == N`).
- ✅ File size scales with unique parts M, not total placements K (one shared BREP).
- ✅ Opens as an assembly, not a fused solid (product structure + NAUO).
- ✅ Round-trips: `writeSTEPAssembly` → `Document.loadSTEP` reproduces the occurrence count.

## Tests

`Tests/OCCTXCAFTests/Issue173AssemblySTEPTests.swift` — instancing structure, round-trip, and empty-path-throws. All pass serially (the suite trips the known non-deterministic NCollection parallel SEGV only under `--parallel`, like other STEP-IO suites; green individually and with `--no-parallel`).

## Notes

Non-breaking, source-only (no xcframework change). CHANGELOG → **v1.4.6**, numbered assuming #200 (v1.4.5) merges first — renumber if merge order changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
