### PR TITLE
feat(boolean): fuzzy value + glue options on union/subtracting/intersection (closes #202) → v1.4.7

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -621,6 +621,13 @@ OCCTShapeRef OCCTShapeUnion(OCCTShapeRef shape1, OCCTShapeRef shape2);
 OCCTShapeRef OCCTShapeSubtract(OCCTShapeRef shape1, OCCTShapeRef shape2);
 OCCTShapeRef OCCTShapeIntersect(OCCTShapeRef shape1, OCCTShapeRef shape2);
 
+// Boolean ops with robustness levers: fuzzyValue (tolerance-based fuzzy boolean;
+// <= 0 keeps OCCT's default), glue (0 = off, 1 = BOPAlgo_GlueShift, 2 = BOPAlgo_GlueFull;
+// glue helps when arguments share coincident faces). #202
+OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue);
+OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue);
+OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue);
+
 // MARK: - Modifications
 
 OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius);

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -9759,6 +9759,47 @@ OCCTShapeRef OCCTShapeIntersect(OCCTShapeRef shape1, OCCTShapeRef shape2) {
     }
 }
 
+// --- Boolean ops with fuzzy value + glue (#202) ---
+// Shared driver: BRepAlgoAPI_Fuse/Cut/Common all derive from
+// BRepAlgoAPI_BooleanOperation, so the option setters are identical across ops.
+template <typename BoolOpT>
+static OCCTShapeRef runBooleanEx(OCCTShapeRef shape1, OCCTShapeRef shape2,
+                                 double fuzzyValue, int32_t glue) {
+    if (!shape1 || !shape2) return nullptr;
+    occtEnsureSignals();
+    try {
+        OCC_CATCH_SIGNALS
+        BoolOpT op;
+        TopTools_ListOfShape args;  args.Append(shape1->shape);
+        TopTools_ListOfShape tools; tools.Append(shape2->shape);
+        op.SetArguments(args);
+        op.SetTools(tools);
+        if (fuzzyValue > 0.0) op.SetFuzzyValue(fuzzyValue);
+        switch (glue) {
+            case 1:  op.SetGlue(BOPAlgo_GlueShift); break;
+            case 2:  op.SetGlue(BOPAlgo_GlueFull);  break;
+            default: op.SetGlue(BOPAlgo_GlueOff);   break;
+        }
+        op.Build();
+        if (!op.IsDone()) return nullptr;
+        return new OCCTShape(op.Shape());
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue) {
+    return runBooleanEx<BRepAlgoAPI_Fuse>(shape1, shape2, fuzzyValue, glue);
+}
+
+OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue) {
+    return runBooleanEx<BRepAlgoAPI_Cut>(shape1, shape2, fuzzyValue, glue);
+}
+
+OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue) {
+    return runBooleanEx<BRepAlgoAPI_Common>(shape1, shape2, fuzzyValue, glue);
+}
+
 // MARK: - Modifications
 
 OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius) {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -481,9 +481,31 @@ public final class Shape: @unchecked Sendable {
 
     // MARK: - Boolean Operations
 
+    /// Glue mode for boolean operations (`BOPAlgo_GlueEnum`).
+    ///
+    /// Gluing speeds up and hardens booleans when the arguments share **coincident
+    /// faces**, by telling the algorithm those faces touch instead of intersecting them.
+    /// Only use it when the touching faces really are coincident — gluing two solids that
+    /// genuinely interpenetrate produces a wrong result.
+    public enum BooleanGlue: Int32, Sendable {
+        /// No gluing (OCCT default — full intersection).
+        case off = 0
+        /// `BOPAlgo_GlueShift` — arguments may share coincident faces but are otherwise disjoint.
+        case shift = 1
+        /// `BOPAlgo_GlueFull` — all arguments are known to share coincident faces (fastest, strictest).
+        case full = 2
+    }
+
     /// Union (add) two shapes together.
-    public func union(_ other: Shape) -> Shape? {
-        guard let handle = OCCTShapeUnion(self.handle, other.handle) else { return nil }
+    ///
+    /// - Parameters:
+    ///   - other: The shape to fuse with `self`.
+    ///   - fuzzyValue: Tolerance-based fuzzy value (`SetFuzzyValue`). `0` (default) keeps OCCT's
+    ///     default tolerance; a small positive value (e.g. `1e-4`) helps near-tangent / nearly
+    ///     coincident faces fuse cleanly. Negative values are ignored.
+    ///   - glue: Glue mode for coincident-face arguments (default `.off`). See ``BooleanGlue``.
+    public func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape? {
+        guard let handle = OCCTShapeUnionEx(self.handle, other.handle, fuzzyValue, glue.rawValue) else { return nil }
         return Shape(handle: handle)
     }
 
@@ -492,14 +514,27 @@ public final class Shape: @unchecked Sendable {
     public func union(with other: Shape) -> Shape? { union(other) }
 
     /// Subtract another shape from this one.
-    public func subtracting(_ other: Shape) -> Shape? {
-        guard let handle = OCCTShapeSubtract(self.handle, other.handle) else { return nil }
+    ///
+    /// - Parameters:
+    ///   - other: The tool shape to remove from `self`.
+    ///   - fuzzyValue: Tolerance-based fuzzy value (`SetFuzzyValue`). `0` (default) keeps OCCT's
+    ///     default tolerance; raise it slightly when a thin-wall cut under-subtracts. Negative
+    ///     values are ignored.
+    ///   - glue: Glue mode for coincident-face arguments (default `.off`). See ``BooleanGlue``.
+    public func subtracting(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape? {
+        guard let handle = OCCTShapeSubtractEx(self.handle, other.handle, fuzzyValue, glue.rawValue) else { return nil }
         return Shape(handle: handle)
     }
 
     /// Intersection of two shapes.
-    public func intersection(_ other: Shape) -> Shape? {
-        guard let handle = OCCTShapeIntersect(self.handle, other.handle) else { return nil }
+    ///
+    /// - Parameters:
+    ///   - other: The shape to intersect with `self`.
+    ///   - fuzzyValue: Tolerance-based fuzzy value (`SetFuzzyValue`). `0` (default) keeps OCCT's
+    ///     default tolerance. Negative values are ignored.
+    ///   - glue: Glue mode for coincident-face arguments (default `.off`). See ``BooleanGlue``.
+    public func intersection(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape? {
+        guard let handle = OCCTShapeIntersectEx(self.handle, other.handle, fuzzyValue, glue.rawValue) else { return nil }
         return Shape(handle: handle)
     }
 

--- a/Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift
+++ b/Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #202: BRepAlgoAPI boolean fuzzy value + glue options exposed on the boolean ops.
+@Suite("Issue #202 — boolean fuzzy value + glue options")
+struct Issue202BooleanOptions {
+
+    /// Two unit cubes stacked along Z, sharing the coincident face at z = 10.
+    private func stackedBoxes() -> (Shape, Shape)? {
+        guard let lower = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let upper = Shape.box(origin: SIMD3(0, 0, 10), width: 10, height: 10, depth: 10) else {
+            return nil
+        }
+        return (lower, upper)
+    }
+
+    @Test("default parameters preserve existing behavior")
+    func defaultParity() {
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        // No-arg call still resolves (defaults fuzzyValue: 0, glue: .off) and gives the union volume.
+        if let u = a.union(b) { #expect(abs((u.volume ?? 0) - 2000.0) < 1.0) }
+        else { #expect(Bool(false), "union(_:) returned nil") }
+
+        guard let big = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let tool = Shape.box(origin: SIMD3(2, 2, 0), width: 6, height: 6, depth: 10) else {
+            #expect(Bool(false)); return
+        }
+        if let cut = big.subtracting(tool) { #expect(abs((cut.volume ?? 0) - (1000.0 - 360.0)) < 1.0) }
+        else { #expect(Bool(false), "subtracting(_:) returned nil") }
+    }
+
+    // Issue case 1: union of consecutive chunk solids that share a boundary cross-section.
+    @Test("glued union of coincident-face solids is valid with correct volume")
+    func gluedUnion() {
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        for glue in [Shape.BooleanGlue.shift, .full] {
+            guard let u = a.union(b, fuzzyValue: 0, glue: glue) else {
+                #expect(Bool(false), "glued union (\(glue)) returned nil"); continue
+            }
+            #expect(u.isValid)
+            #expect(u.shellCount == 1)                       // fused into a single shell
+            #expect(abs((u.volume ?? 0) - 2000.0) < 1.0)     // no over/under-volume
+        }
+    }
+
+    // Issue case 2: thin-wall subtract should remove exactly the inner solid's volume.
+    @Test("fuzzy subtract of a thin wall removes the full inner volume")
+    func fuzzyThinWallSubtract() {
+        guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              // inner leaves a 1mm wall on X/Y, open through Z → removes 8*8*10 = 640
+              let inner = Shape.box(origin: SIMD3(1, 1, 0), width: 8, height: 8, depth: 10) else {
+            #expect(Bool(false)); return
+        }
+        guard let shell = outer.subtracting(inner, fuzzyValue: 1e-4, glue: .off) else {
+            #expect(Bool(false), "fuzzy subtract returned nil"); return
+        }
+        #expect(shell.isValid)
+        #expect(abs((shell.volume ?? 0) - (1000.0 - 640.0)) < 1.0)
+    }
+
+    @Test("fuzzy intersection returns the overlap volume")
+    func fuzzyIntersection() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10) else {
+            #expect(Bool(false)); return
+        }
+        guard let x = a.intersection(b, fuzzyValue: 1e-4) else {
+            #expect(Bool(false), "fuzzy intersection returned nil"); return
+        }
+        #expect(abs((x.volume ?? 0) - 500.0) < 1.0)          // 5*10*10 overlap
+    }
+
+    @Test("negative fuzzy value is ignored, not fatal")
+    func negativeFuzzyIgnored() {
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        if let u = a.union(b, fuzzyValue: -5) { #expect(abs((u.volume ?? 0) - 2000.0) < 1.0) }
+        else { #expect(Bool(false), "union with negative fuzzy returned nil") }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,33 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.6
+## Current: v1.4.7
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.4.7 (June 2026) — boolean fuzzy value + glue options (closes #202)
+
+**PATCH — additive, non-breaking.** `Shape.union` / `subtracting` / `intersection` now expose the two
+`BRepAlgoAPI_BooleanOperation` robustness levers OCCT provides for **coincident / near-tangent faces**,
+where the default boolean can silently under-subtract or inflate volume:
+
+```swift
+func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape?
+// same trailing parameters on subtracting(_:) and intersection(_:)
+```
+
+- `fuzzyValue` → `SetFuzzyValue` (tolerance-based fuzzy boolean; `0` keeps OCCT's default, negatives ignored).
+- `glue` → `SetGlue` — new `Shape.BooleanGlue` enum: `.off` (default), `.shift` (`BOPAlgo_GlueShift`),
+  `.full` (`BOPAlgo_GlueFull`). Gluing hardens & speeds up unions/cuts of solids known to share
+  coincident faces (e.g. consecutive analytic loft chunks, thin-wall shells).
+
+Defaults reproduce prior behavior exactly. Implemented via a shared templated bridge driver
+(`OCCTShapeUnionEx`/`SubtractEx`/`IntersectEx`) over the common `BRepAlgoAPI_BooleanOperation` base.
+Source-only (no xcframework change).
 
 ### v1.4.6 (June 2026) — instanced-assembly STEP writer (closes #173)
 


### PR DESCRIPTION
## Summary

Exposes the two `BRepAlgoAPI_BooleanOperation` robustness levers requested in #202 on `Shape.union` / `subtracting` / `intersection` — for the coincident / near-tangent face cases (chunked analytic loft unions, thin-wall subtracts) where the default boolean silently under-subtracts or inflates volume.

```swift
func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape?
// same trailing params on subtracting(_:) and intersection(_:)
```

- **`fuzzyValue`** → `SetFuzzyValue` (tolerance-based fuzzy boolean; `0` keeps OCCT's default, negatives ignored).
- **`glue`** → `SetGlue`, via new `Shape.BooleanGlue` enum: `.off` (default), `.shift` (`BOPAlgo_GlueShift`), `.full` (`BOPAlgo_GlueFull`).

Defaults reproduce prior behavior **exactly** — the no-arg calls are unchanged.

## Implementation

- Bridge: a shared **templated driver** `runBooleanEx<BoolOpT>` over the common `BRepAlgoAPI_BooleanOperation` base (Fuse/Cut/Common), exposed as `OCCTShapeUnionEx` / `OCCTShapeSubtractEx` / `OCCTShapeIntersectEx`. The original `OCCTShapeUnion/Subtract/Intersect` are retained.
- Swift: `union`/`subtracting`/`intersection` gained the two defaulted params and route to the `*Ex` bridge fns (no overload — single method each, so `a.union(b)` stays unambiguous).
- The `.off` + `fuzzy 0` path matches the prior two-arg-constructor behavior (verified by a default-parity test).

## Tests

`Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift` (5, all pass serially):
- default-parameter parity (no behavior change),
- glued union of two solids sharing a coincident face → valid, single shell, correct volume (issue case 1),
- fuzzy thin-wall subtract removes the full inner volume (issue case 2),
- fuzzy intersection overlap volume,
- negative fuzzy value ignored (not fatal).

## Notes

Non-breaking, source-only (no xcframework change). CHANGELOG → **v1.4.7**. Scoped to `fuzzyValue` + `glue` to match the issue's requested signature; `SetCheckInverted`/`SetUseOBB` (listed as "optional" in the issue) are left out to keep the API tidy — easy to add later if wanted.

> Unrelated: while running the full Modeling target I hit a **pre-existing** SIGSEGV in `extrudeEdgeByVector` (reproduced on clean `main`, unrelated to this change) — flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
