### PR TITLE
test(modeling): fix extrudeEdgeByVector double-free SIGSEGV (closes #204)

### DIFF
--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -5696,13 +5696,10 @@ struct ExtendedExtrusionTests {
     }
 
     @Test func extrudeEdgeByVector() {
-        // Extrude a wire to create a face
-        let wire = Wire.line(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
-        if let wire {
-            let face = Shape(handle: wire.handle)
-            // Use the wire directly via bridge
-        }
-        // Simpler: extrude a face
+        // #204: the previous body wrapped a Wire's handle in a Shape
+        // (`Shape(handle: wire.handle)`), double-owning the C++ handle — both the
+        // Wire and the Shape freed it on scope exit → double-free → SIGSEGV. That
+        // block was dead code (the resulting `face` was never used). Removed.
         let rect = Wire.rectangle(width: 5, height: 5)
         if let rect {
             let face = Shape.face(from: rect)


### PR DESCRIPTION
## Summary

Fixes the deterministic SIGSEGV in `extrudeEdgeByVector` (#204). It was a **double-free in the test**, not a kernel bug.

```swift
// before — dead code that double-owns the wire's C++ handle:
let wire = Wire.line(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
if let wire {
    let face = Shape(handle: wire.handle)   // Shape now owns the SAME pointer as wire
    // Use the wire directly via bridge        (face unused)
}
```

`Shape(handle:)` is an ownership-transfer init (`deinit` → `OCCTShapeRelease` → `delete`). Passing `wire.handle` made both the `Wire` and the `Shape` free the same pointer on scope exit → double-free → heap corruption → SIGSEGV that aborted the whole `OCCTModelingTests` run. The block was dead code (`face` unused), so it's simply removed; the working `extrudedInfinite` portion stays.

## Verification

- The previously-crashing suite passes 3× in a row.
- **Full `OCCTModelingTests` target now passes: 400 tests / 129 suites** (it previously aborted mid-run at `extrudeEdgeByVector`).

## Scope

Test-only. `Wire.handle` and `Shape(handle:)` are both `internal`, so no shipped/SPM-consumer path could trigger this. Not an OCCT defect (no kernel call involved) → no upstream PR.

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
