### PR TITLE
feat(boolean)!: time-bound union/subtracting/intersection so they never hang (closes #206) → v1.5.0

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -624,9 +624,11 @@ OCCTShapeRef OCCTShapeIntersect(OCCTShapeRef shape1, OCCTShapeRef shape2);
 // Boolean ops with robustness levers: fuzzyValue (tolerance-based fuzzy boolean;
 // <= 0 keeps OCCT's default), glue (0 = off, 1 = BOPAlgo_GlueShift, 2 = BOPAlgo_GlueFull;
 // glue helps when arguments share coincident faces). #202
-OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue);
-OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue);
-OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue);
+// timeoutSeconds bounds the build via a wall-clock UserBreak watchdog; <= 0 means no
+// bound. On timeout (or failure) the op returns NULL instead of hanging. #206
+OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue, double timeoutSeconds);
+OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue, double timeoutSeconds);
+OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue, double timeoutSeconds);
 
 // MARK: - Modifications
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -9759,12 +9759,41 @@ OCCTShapeRef OCCTShapeIntersect(OCCTShapeRef shape1, OCCTShapeRef shape2) {
     }
 }
 
-// --- Boolean ops with fuzzy value + glue (#202) ---
+// --- Boolean ops with fuzzy value + glue + timeout (#202, #206) ---
+#include <Message_ProgressIndicator.hxx>
+#include <Message_ProgressRange.hxx>
+#include <Message_ProgressScope.hxx>
+#include <chrono>
+
+// Wall-clock watchdog: asks the BOP to stop once a deadline passes. OCCT's
+// BRepAlgoAPI_*::Build(range) polls UserBreak() at scope boundaries and leaves
+// IsDone() == false when it trips — so a pathological operand that would
+// otherwise spin forever (#206: self-intersecting B-spline loft) returns
+// promptly instead of hanging. Verified to interrupt the real #206 operands.
+class OCCTBoolTimeoutBreaker : public Message_ProgressIndicator {
+public:
+    explicit OCCTBoolTimeoutBreaker(double seconds)
+        : myDeadline(std::chrono::steady_clock::now()
+            + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                std::chrono::duration<double>(seconds))) {}
+
+    Standard_Boolean UserBreak() override {
+        return (std::chrono::steady_clock::now() >= myDeadline) ? Standard_True : Standard_False;
+    }
+    void Show(const Message_ProgressScope&, const Standard_Boolean) override {}
+
+    DEFINE_STANDARD_RTTI_INLINE(OCCTBoolTimeoutBreaker, Message_ProgressIndicator)
+private:
+    std::chrono::steady_clock::time_point myDeadline;
+};
+DEFINE_STANDARD_HANDLE(OCCTBoolTimeoutBreaker, Message_ProgressIndicator)
+
 // Shared driver: BRepAlgoAPI_Fuse/Cut/Common all derive from
 // BRepAlgoAPI_BooleanOperation, so the option setters are identical across ops.
+// timeoutSeconds <= 0 means no time bound (run to completion).
 template <typename BoolOpT>
 static OCCTShapeRef runBooleanEx(OCCTShapeRef shape1, OCCTShapeRef shape2,
-                                 double fuzzyValue, int32_t glue) {
+                                 double fuzzyValue, int32_t glue, double timeoutSeconds) {
     if (!shape1 || !shape2) return nullptr;
     occtEnsureSignals();
     try {
@@ -9780,7 +9809,15 @@ static OCCTShapeRef runBooleanEx(OCCTShapeRef shape1, OCCTShapeRef shape2,
             case 2:  op.SetGlue(BOPAlgo_GlueFull);  break;
             default: op.SetGlue(BOPAlgo_GlueOff);   break;
         }
-        op.Build();
+        if (timeoutSeconds > 0.0) {
+            Handle(OCCTBoolTimeoutBreaker) breaker = new OCCTBoolTimeoutBreaker(timeoutSeconds);
+            Message_ProgressRange range = breaker->Start();
+            op.Build(range);
+        } else {
+            op.Build();
+        }
+        // IsDone() is false both on genuine failure and when the watchdog
+        // interrupted the build — either way there is no usable result.
         if (!op.IsDone()) return nullptr;
         return new OCCTShape(op.Shape());
     } catch (...) {
@@ -9788,16 +9825,16 @@ static OCCTShapeRef runBooleanEx(OCCTShapeRef shape1, OCCTShapeRef shape2,
     }
 }
 
-OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue) {
-    return runBooleanEx<BRepAlgoAPI_Fuse>(shape1, shape2, fuzzyValue, glue);
+OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue, double timeoutSeconds) {
+    return runBooleanEx<BRepAlgoAPI_Fuse>(shape1, shape2, fuzzyValue, glue, timeoutSeconds);
 }
 
-OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue) {
-    return runBooleanEx<BRepAlgoAPI_Cut>(shape1, shape2, fuzzyValue, glue);
+OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue, double timeoutSeconds) {
+    return runBooleanEx<BRepAlgoAPI_Cut>(shape1, shape2, fuzzyValue, glue, timeoutSeconds);
 }
 
-OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue) {
-    return runBooleanEx<BRepAlgoAPI_Common>(shape1, shape2, fuzzyValue, glue);
+OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1, OCCTShapeRef shape2, double fuzzyValue, int32_t glue, double timeoutSeconds) {
+    return runBooleanEx<BRepAlgoAPI_Common>(shape1, shape2, fuzzyValue, glue, timeoutSeconds);
 }
 
 // MARK: - Modifications

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -496,6 +496,12 @@ public final class Shape: @unchecked Sendable {
         case full = 2
     }
 
+    /// Default wall-clock bound (seconds) for the boolean ops. A self-intersecting /
+    /// inside-out operand (e.g. from `loft(ruled: false)`) can make `BRepAlgoAPI_Cut`
+    /// spin indefinitely; the boolean ops abort and return `nil` once this elapses rather
+    /// than hanging a pipeline. Override per call; pass `0` (or negative) to disable. (#206)
+    public static let defaultBooleanTimeout: Double = 120
+
     /// Union (add) two shapes together.
     ///
     /// - Parameters:
@@ -504,8 +510,11 @@ public final class Shape: @unchecked Sendable {
     ///     default tolerance; a small positive value (e.g. `1e-4`) helps near-tangent / nearly
     ///     coincident faces fuse cleanly. Negative values are ignored.
     ///   - glue: Glue mode for coincident-face arguments (default `.off`). See ``BooleanGlue``.
-    public func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape? {
-        guard let handle = OCCTShapeUnionEx(self.handle, other.handle, fuzzyValue, glue.rawValue) else { return nil }
+    ///   - timeout: Wall-clock bound in seconds (default ``defaultBooleanTimeout``, 120s). Returns
+    ///     `nil` if the operation doesn't finish in time instead of hanging. `0`/negative = unbounded.
+    public func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                      timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        guard let handle = OCCTShapeUnionEx(self.handle, other.handle, fuzzyValue, glue.rawValue, timeout) else { return nil }
         return Shape(handle: handle)
     }
 
@@ -521,8 +530,11 @@ public final class Shape: @unchecked Sendable {
     ///     default tolerance; raise it slightly when a thin-wall cut under-subtracts. Negative
     ///     values are ignored.
     ///   - glue: Glue mode for coincident-face arguments (default `.off`). See ``BooleanGlue``.
-    public func subtracting(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape? {
-        guard let handle = OCCTShapeSubtractEx(self.handle, other.handle, fuzzyValue, glue.rawValue) else { return nil }
+    ///   - timeout: Wall-clock bound in seconds (default ``defaultBooleanTimeout``, 120s). Returns
+    ///     `nil` if the operation doesn't finish in time instead of hanging. `0`/negative = unbounded.
+    public func subtracting(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        guard let handle = OCCTShapeSubtractEx(self.handle, other.handle, fuzzyValue, glue.rawValue, timeout) else { return nil }
         return Shape(handle: handle)
     }
 
@@ -533,8 +545,11 @@ public final class Shape: @unchecked Sendable {
     ///   - fuzzyValue: Tolerance-based fuzzy value (`SetFuzzyValue`). `0` (default) keeps OCCT's
     ///     default tolerance. Negative values are ignored.
     ///   - glue: Glue mode for coincident-face arguments (default `.off`). See ``BooleanGlue``.
-    public func intersection(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off) -> Shape? {
-        guard let handle = OCCTShapeIntersectEx(self.handle, other.handle, fuzzyValue, glue.rawValue) else { return nil }
+    ///   - timeout: Wall-clock bound in seconds (default ``defaultBooleanTimeout``, 120s). Returns
+    ///     `nil` if the operation doesn't finish in time instead of hanging. `0`/negative = unbounded.
+    public func intersection(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        guard let handle = OCCTShapeIntersectEx(self.handle, other.handle, fuzzyValue, glue.rawValue, timeout) else { return nil }
         return Shape(handle: handle)
     }
 

--- a/Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift
+++ b/Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #206: boolean ops must not hang indefinitely on a pathological (self-intersecting,
+// inside-out) operand. They run under a wall-clock watchdog (OCCT progress UserBreak)
+// and return nil at the deadline instead of spinning forever.
+//
+// The original repro is a self-intersecting B-spline solid from loft(ruled: false) that
+// made BRepAlgoAPI_Cut spin >5 min (operands: OCCTReconstruct nurbs_env/nurbs_cav.brep).
+// We don't bundle those 520 KB fixtures; instead these tests assert the watchdog
+// *mechanism* deterministically: a deadline already in the past interrupts the build at
+// its first progress checkpoint, even for an otherwise-fast valid boolean. The real
+// operands were verified separately to return nil within the timeout (was an infinite hang).
+@Suite("Issue #206 — boolean timeout watchdog")
+struct Issue206BooleanTimeout {
+
+    private func overlappingBoxes() -> (Shape, Shape)? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10) else { return nil }
+        return (a, b)
+    }
+
+    @Test("a deadline already past interrupts the build → nil (all three ops)")
+    func tinyTimeoutInterrupts() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        let tiny = 1e-7
+        #expect(a.union(b, timeout: tiny) == nil)
+        #expect(a.subtracting(b, timeout: tiny) == nil)
+        #expect(a.intersection(b, timeout: tiny) == nil)
+    }
+
+    @Test("a sane timeout leaves valid booleans unaffected, with correct volumes")
+    func saneTimeoutSucceeds() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        // union 1000 + 1000 - 500(overlap) = 1500; intersection 500; subtract 1000-500 = 500
+        if let u = a.union(b, timeout: 60) { #expect(abs((u.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "union nil under 60s") }
+        if let x = a.intersection(b, timeout: 60) { #expect(abs((x.volume ?? 0) - 500) < 1) }
+        else { #expect(Bool(false), "intersection nil under 60s") }
+        if let s = a.subtracting(b, timeout: 60) { #expect(abs((s.volume ?? 0) - 500) < 1) }
+        else { #expect(Bool(false), "subtract nil under 60s") }
+    }
+
+    @Test("default timeout and unbounded (0) both produce the same valid result")
+    func defaultAndUnboundedParity() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        let def = a.union(b)              // default timeout (Shape.defaultBooleanTimeout)
+        let unbounded = a.union(b, timeout: 0)
+        #expect(def != nil)
+        #expect(unbounded != nil)
+        if let d = def, let z = unbounded {
+            #expect(abs((d.volume ?? -1) - (z.volume ?? -2)) < 1)
+        }
+        #expect(Shape.defaultBooleanTimeout == 120)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,41 @@
 
 All notable changes to OCCTSwift.
 
-## Current: v1.4.7
+## Current: v1.5.0
 
 **4,287 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0**
 
 ---
 
 ## Release History
+
+### v1.5.0 (June 2026) — boolean ops are time-bounded; never hang indefinitely (closes #206)
+
+**MINOR — additive param + a default-behavior change.** `Shape.union` / `subtracting` /
+`intersection` could **hang indefinitely** on a self-intersecting / inside-out operand — e.g. a
+B-spline solid from `loft(ruled: false)` that reports `isValidSolid == true` yet poisons the
+boolean. `BRepAlgoAPI_Cut` on the reported operands spun for >5 min on a 66-face input.
+
+The boolean ops now run under a **wall-clock watchdog** (OCCT's `Message_ProgressRange` +
+`UserBreak`) and return `nil` at a deadline instead of spinning forever:
+
+```swift
+func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+           timeout: Double = Shape.defaultBooleanTimeout) -> Shape?   // and subtracting / intersection
+```
+
+- **`timeout`** — seconds; default `Shape.defaultBooleanTimeout` (**120s**). `0`/negative = unbounded
+  (the prior behavior). Verified to interrupt the real #206 operands (was an infinite hang → now `nil`).
+- **Default-behavior change:** a boolean that genuinely runs longer than 120s now returns `nil`
+  instead of completing/blocking. Pathological hangs are bounded; raise `timeout` (or pass `0`) for
+  legitimately heavy booleans.
+
+**Why a timeout and not an operand pre-check:** the cheap detectors don't catch the reported
+`env` operand — `BRepCheck_Analyzer` reports it *valid* and its volume sits within its bounding box;
+only `BOPAlgo_ArgumentAnalyzer` flags it, and that itself ran >50s on the input. The watchdog is the
+only general, bounded guard. (The separate `cav` operand has negative volume, so a downstream
+`volume > 0 && analyzeValidity(geometryChecks:)` gate remains a useful cheap fast-fail and is still
+recommended.) Source-only (no xcframework change).
 
 ### v1.4.7 (June 2026) — boolean fuzzy value + glue options (closes #202)
 


### PR DESCRIPTION
## Summary

`Shape.union` / `subtracting` / `intersection` could **hang indefinitely** on a self-intersecting / inside-out operand — e.g. a B-spline solid from `loft(ruled: false)` that reports `isValidSolid == true` but poisons the boolean. On the reported operands `BRepAlgoAPI_Cut` spun for **>5 min** on a 66-face input. A non-terminating call on bounded input is the worst failure mode for an automated pipeline (#206).

The boolean ops now run under a **wall-clock watchdog** and return `nil` at a deadline instead of spinning forever:

```swift
func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
           timeout: Double = Shape.defaultBooleanTimeout) -> Shape?   // + subtracting / intersection
```

- **`timeout`** — seconds; default `Shape.defaultBooleanTimeout` = **120s**. `0`/negative = unbounded (prior behavior).
- ⚠️ **Default-behavior change** → MINOR (**v1.5.0**): a boolean that genuinely runs >120s now returns `nil` instead of completing/blocking. Raise `timeout` or pass `0` for legitimately heavy booleans.

## How it works

A `Message_ProgressIndicator` (`OCCTBoolTimeoutBreaker`) whose `UserBreak()` trips after the deadline; OCCT's `BRepAlgoAPI_*::Build(range)` polls it at scope boundaries and leaves `IsDone() == false` when it fires → the wrapper returns `nil`. Implemented in the shared `runBooleanEx<BoolOpT>` driver over the `BRepAlgoAPI_BooleanOperation` base (so it composes with the #202 fuzzy/glue levers).

## Investigation — why a watchdog, not an operand pre-check

I characterized the real operands (`nurbs_env` / `nurbs_cav`) with a C++ ground-truth:

| operand | `BRepCheck` valid | volume | vs bbox | cheap to reject? |
|---|---|---|---|---|
| `env` | **true** | 139024 | well *within* bbox (3.1e9) | **no** — looks valid |
| `cav` | — | **−1.36e8** (negative) | — | yes (vol ≤ 0) |

- `BOPAlgo_ArgumentAnalyzer` *does* flag `env`'s self-interference, but it **ran >50s** on the input — not a viable fast gate.
- A `Message_ProgressRange` + `UserBreak` deadline **does** interrupt the hanging `Cut` (verified: returned at 5.0s with `IsDone()==false`).

So the watchdog is the only **general, bounded** guard. (The `cav`-type negative-volume case is still cheaply catchable downstream; the issue's `volume > 0 && analyzeValidity(geometryChecks:)` gate remains a useful fast-fail and is recommended — see note on request #2 below.)

## Tests

`Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift` (3, deterministic, self-contained — no bundled fixtures):
- a deadline already past interrupts the build → `nil` for all three ops;
- a sane timeout leaves valid booleans unaffected with correct volumes (union 1500, intersection 500, subtract 500);
- default timeout and unbounded (`0`) produce the same valid result; `defaultBooleanTimeout == 120`.

Full `OCCTModelingTests` target green (403 tests / 130 suites); #202 fuzzy/glue suite intact. Separately verified end-to-end on the real `nurbs_env.subtracting(nurbs_cav, timeout: 10)` → returned `nil` at ~10s (was an infinite hang).

## On request #2 (loft self-intersection detection)

Deferred deliberately: the reported `env` is **not cheaply detectable** (`BRepCheck` passes; `ArgumentAnalyzer` hangs), so a loft-output validity gate can't catch it without the same cost — and changing `loft`'s default to reject on a volume heuristic risks false-rejecting valid lofts. The watchdog protects against `env` regardless. The cheap downstream gate still helps for the `cav`-type and stays recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
