### PR TITLE
v1.7.1 — p1 follow-up ops + clean-headers xcframework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,8 @@ let occtTarget: Target = useLocalBinary
     )
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/gsdali/OCCTSwift/releases/download/v1.7.0/OCCT.xcframework.zip",
-        checksum: "25128bef4a62424cf29293c4ac861d249524c53e8e23ec309d884605bf56bd12"
+        url: "https://github.com/gsdali/OCCTSwift/releases/download/v1.7.1/OCCT.xcframework.zip",
+        checksum: "588aea7eb588063b906878fb66f4a2b91de6b8034be95dcb5212470deff8bccf"
     )
 
 let package = Package(

--- a/Scripts/build-occt.sh
+++ b/Scripts/build-occt.sh
@@ -99,6 +99,18 @@ if compgen -G "$SCRIPT_DIR/patches/*.patch" > /dev/null; then
 fi
 
 # --------------------
+# Clean stale install prefixes
+# --------------------
+# cmake --install ADDS/overwrites headers but never DELETES ones that no longer exist in the source.
+# Reusing an install dir across OCCT versions therefore leaks removed/renamed headers (e.g. GA's
+# Approx_BSplineApproxInterp.hxx, BRepGraph_Builder/History/RepId/LayerRegularity.hxx, GeomFill_
+# GordonBuilder.hxx) into the packaged xcframework, where they masquerade as current API. Wipe the
+# install prefixes every run so only the current version's headers are staged. (Build dirs are already
+# rm -rf'd per platform below.)
+rm -rf occt-install-ios occt-install-sim occt-install-macos \
+       occt-install-xros occt-install-xrsim occt-install-tvos occt-install-tvsim
+
+# --------------------
 # Common CMake options (minimal build for modeling + export)
 # --------------------
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -20475,8 +20475,11 @@ void OCCTBRepGraphSetShellIsClosed(OCCTBRepGraphRef _Nonnull graph, int32_t shel
 // invalid ids.
 
 // Add operations (Ref-typed return)
-int32_t OCCTBRepGraphEdgeAddInternalVertex(OCCTBRepGraphRef _Nonnull graph, int32_t edgeIndex, int32_t vertexIndex, int32_t orientation);
-int32_t OCCTBRepGraphFaceAddVertex(OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex, int32_t vertexIndex, int32_t orientation);
+// NOTE: EdgeAddInternalVertex / FaceAddVertex return an int64_t supplement-attachment uid (-1 on
+// failure) in OCCT 8.0.0p1 — these are runtime BRepGraph_LayerTopoSupplement attachments, not core
+// ref ids. The `orientation` param is accepted for source-compat but ignored by the supplement layer.
+int64_t OCCTBRepGraphEdgeAddInternalVertex(OCCTBRepGraphRef _Nonnull graph, int32_t edgeIndex, int32_t vertexIndex, int32_t orientation);
+int64_t OCCTBRepGraphFaceAddVertex(OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex, int32_t vertexIndex, int32_t orientation);
 int32_t OCCTBRepGraphShellAddChild(OCCTBRepGraphRef _Nonnull graph, int32_t shellIndex, int32_t childKind, int32_t childIndex, int32_t orientation);
 int32_t OCCTBRepGraphSolidAddChild(OCCTBRepGraphRef _Nonnull graph, int32_t solidIndex, int32_t childKind, int32_t childIndex, int32_t orientation);
 int32_t OCCTBRepGraphCompoundAddChild(OCCTBRepGraphRef _Nonnull graph, int32_t compoundIndex, int32_t childKind, int32_t childIndex, int32_t orientation);
@@ -20486,7 +20489,9 @@ int32_t OCCTBRepGraphCompSolidAddSolid(OCCTBRepGraphRef _Nonnull graph, int32_t 
 bool OCCTBRepGraphEdgeRemoveVertex(OCCTBRepGraphRef _Nonnull graph, int32_t edgeIndex, int32_t vertexRefIndex);
 int32_t OCCTBRepGraphEdgeReplaceVertex(OCCTBRepGraphRef _Nonnull graph, int32_t edgeIndex, int32_t oldVertexRefIndex, int32_t newVertexIndex);
 bool OCCTBRepGraphWireRemoveCoEdge(OCCTBRepGraphRef _Nonnull graph, int32_t wireIndex, int32_t coedgeRefIndex);
-bool OCCTBRepGraphFaceRemoveVertex(OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex, int32_t vertexRefIndex);
+// NOTE: 2nd param is now the int64_t supplement-attachment uid returned by FaceAddVertex (OCCT 8.0.0p1),
+// not a core ref index. faceIndex is unused (uid is layer-global).
+bool OCCTBRepGraphFaceRemoveVertex(OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex, int64_t attachmentUID);
 bool OCCTBRepGraphFaceRemoveWire(OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex, int32_t wireRefIndex);
 bool OCCTBRepGraphShellRemoveFace(OCCTBRepGraphRef _Nonnull graph, int32_t shellIndex, int32_t faceRefIndex);
 bool OCCTBRepGraphShellRemoveChild(OCCTBRepGraphRef _Nonnull graph, int32_t shellIndex, int32_t childRefIndex);
@@ -20636,6 +20641,102 @@ int32_t OCCTBRepGraphSampleFaceUVGrid(
 int32_t OCCTBRepGraphSampleEdgeCurve(
     OCCTBRepGraphRef _Nonnull graph, int32_t edgeIndex,
     int32_t count, double* _Nonnull outPoints);
+
+// MARK: - Durable identity (BRepGraph::UIDsView) — OCCT 8.0.0p1
+
+/// Return the durable node UID for the node identified by (nodeKind, nodeIndex).
+/// On success, writes the UID kind to *outUIDKind and the monotonic counter to
+/// *outCounter, and returns true. Returns false (and leaves outputs untouched)
+/// if the node is invalid/removed/out of bounds. counter == 0 is the invalid sentinel.
+bool OCCTBRepGraphNodeUID(OCCTBRepGraphRef _Nonnull graph,
+                          int32_t nodeKind, int32_t nodeIndex,
+                          int32_t* _Nonnull outUIDKind, uint32_t* _Nonnull outCounter);
+
+/// Resolve a node UID (uidKind, counter) back to a NodeId.
+/// On success, writes the node kind to *outNodeKind and the per-kind index to
+/// *outNodeIndex, and returns true. Returns false if the UID does not resolve.
+bool OCCTBRepGraphNodeFromUID(OCCTBRepGraphRef _Nonnull graph,
+                              int32_t uidKind, uint32_t counter,
+                              int32_t* _Nonnull outNodeKind, int32_t* _Nonnull outNodeIndex);
+
+/// True if a node UID (uidKind, counter) exists in this graph generation.
+bool OCCTBRepGraphHasNodeUID(OCCTBRepGraphRef _Nonnull graph,
+                             int32_t uidKind, uint32_t counter);
+
+/// Return the durable reference UID for the reference (refKind, refIndex).
+/// Writes the UID kind to *outUIDKind and the counter to *outCounter; returns
+/// true on success, false if the reference is invalid/removed/out of bounds.
+bool OCCTBRepGraphRefUID(OCCTBRepGraphRef _Nonnull graph,
+                         int32_t refKind, int32_t refIndex,
+                         int32_t* _Nonnull outUIDKind, uint32_t* _Nonnull outCounter);
+
+/// Resolve a reference UID (uidKind, counter) back to a RefId.
+/// Writes the ref kind to *outRefKind and the per-kind index to *outRefIndex;
+/// returns true on success, false if the UID does not resolve.
+bool OCCTBRepGraphRefFromUID(OCCTBRepGraphRef _Nonnull graph,
+                             int32_t uidKind, uint32_t counter,
+                             int32_t* _Nonnull outRefKind, int32_t* _Nonnull outRefIndex);
+
+/// True if a reference UID (uidKind, counter) exists in this graph generation.
+bool OCCTBRepGraphHasRefUID(OCCTBRepGraphRef _Nonnull graph,
+                            int32_t uidKind, uint32_t counter);
+
+/// Return the durable item UID for the node (nodeKind, nodeIndex).
+/// Writes the item domain (1 = Node, 2 = Reference) to *outDomain, the kind to
+/// *outKind, and the counter to *outCounter; returns true on success.
+bool OCCTBRepGraphItemUIDOfNode(OCCTBRepGraphRef _Nonnull graph,
+                                int32_t nodeKind, int32_t nodeIndex,
+                                int32_t* _Nonnull outDomain, int32_t* _Nonnull outKind,
+                                uint32_t* _Nonnull outCounter);
+
+/// Resolve an item UID (domain, kind, counter) back to an item id.
+/// Writes the item domain to *outDomain, the kind to *outKind and per-kind index
+/// to *outIndex; returns true on success, false if the UID does not resolve.
+bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef _Nonnull graph,
+                              int32_t domain, int32_t kind, uint32_t counter,
+                              int32_t* _Nonnull outDomain, int32_t* _Nonnull outKind,
+                              int32_t* _Nonnull outIndex);
+
+/// Return the current graph generation counter (incremented on each Clear()).
+uint32_t OCCTBRepGraphGeneration(OCCTBRepGraphRef _Nonnull graph);
+
+// MARK: - GeomFill_NetworkSurface / GeomFill_Gordon report — OCCT 8.0.0p1
+
+/// Build a Gordon surface (GeomFill_Gordon) reporting status and approximate flag.
+/// approximationMode: 0 = ExactOnly (default), 1 = AllowApproximateFallback.
+/// Writes the GeomFill_Gordon::ResultStatus ordinal to *outStatus and the
+/// IsApproximate flag to *outIsApproximate. Returns the surface or NULL.
+OCCTSurfaceRef _Nullable OCCTGeomFillGordonReport(
+    const OCCTCurve3DRef _Nonnull * _Nonnull profiles, int32_t profileCount,
+    const OCCTCurve3DRef _Nonnull * _Nonnull guides, int32_t guideCount,
+    double tolerance, int32_t approximationMode,
+    int32_t* _Nonnull outStatus, bool* _Nonnull outIsApproximate);
+
+/// Build a surface with the low-level GeomFill_NetworkSurface builder from a
+/// profile/guide curve network. Writes the GeomFill_NetworkSurface::ResultStatus
+/// ordinal to *outStatus. Returns the surface or NULL.
+OCCTSurfaceRef _Nullable OCCTGeomFillNetworkSurface(
+    const OCCTCurve3DRef _Nonnull * _Nonnull profiles, int32_t profileCount,
+    const OCCTCurve3DRef _Nonnull * _Nonnull guides, int32_t guideCount,
+    double tolerance, int32_t* _Nonnull outStatus);
+
+// MARK: - Poly copy / mutators — OCCT 8.0.0p1
+
+/// Deep-copy a Poly_Polygon2D (Poly_Polygon2D::Copy()). Returns NULL on failure.
+OCCTPolyPolygon2DRef _Nullable OCCTPolyPolygon2DCopy(OCCTPolyPolygon2DRef _Nonnull ref);
+
+/// Deep-copy a Poly_PolygonOnTriangulation. Returns NULL on failure.
+OCCTPolyPolygonOnTriRef _Nullable OCCTPolyPolygonOnTriCopy(OCCTPolyPolygonOnTriRef _Nonnull ref);
+
+/// Overwrite the node-index array via ChangeNodeArray(). count must equal NbNodes().
+/// Returns true on success, false on size mismatch / error.
+bool OCCTPolyPolygonOnTriSetNodes(OCCTPolyPolygonOnTriRef _Nonnull ref,
+                                  const int* _Nonnull nodeIndices, int count);
+
+/// Overwrite the parameter array via ChangeParameterArray(). Requires HasParameters()
+/// and count == NbNodes(). Returns true on success, false otherwise.
+bool OCCTPolyPolygonOnTriSetParameters(OCCTPolyPolygonOnTriRef _Nonnull ref,
+                                       const double* _Nonnull params, int count);
 
 #ifdef __cplusplus
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -53,6 +53,7 @@ static GeomAbs_Shape continuityFromInt(int val) {
     }
 }
 
+
 // === Extracted BRepGraph block ===
 //
 // Verbatim copy of lines 55486–EOF from OCCTBridge.mm at the time of issue #99.
@@ -62,6 +63,12 @@ static GeomAbs_Shape continuityFromInt(int val) {
 #include <BRepGraph.hxx>
 #include <BRepGraph_TopoView.hxx>
 #include <BRepGraph_Tool.hxx>
+#include <BRepGraph_LayerRegistry.hxx>
+// NOTE: BRepGraph_LayerRegularity.hxx is NOT included — it is an upstream p1 bug: it marks `override`
+// on OnNodeRemoved(node,replacement)/OnCompact() which do not exist as virtuals in BRepGraph_Layer,
+// so the header does not compile (AppleClang) and the .cxx is absent from libOCCT (0 symbols). Edge
+// regularity/continuity via the graph layer is therefore unavailable in 8.0.0p1; the shape-based
+// BRep_Tool::MaxContinuity path (OCCTBRepToolMaxContinuity) is unaffected.
 #include <BRepGraph_ReverseIterator.hxx>
 #include <BRepGraph_RefsView.hxx>
 #include <BRepGraphInc_Relations.hxx>
@@ -78,6 +85,23 @@ static GeomAbs_Shape continuityFromInt(int val) {
 #include <BRepGraphInc_RepId.hxx>
 // OCCT 8.0.0p1 removed BRepGraph_Builder; shape ingestion is now BRepGraph::ShapesView::Add().
 #include <BRepGraph_ShapesView.hxx>
+// TopoSupplement runtime layer (vertex-supplement attachments) — issue: un-stub vertex ops.
+#include <BRepGraph_SupplementEditor.hxx>
+#include <BRepGraph_SupplementIterator.hxx>
+#include <BRepGraph_LayerTopoSupplement.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <TopoDS_Vertex.hxx>
+// Surface-equality classes for FaceSameDomain derivation.
+#include <Geom_Plane.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_ToroidalSurface.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Lin.hxx>
 
 // OCCT 8.0.0p1 side-registry (issue: rep-id ABI preservation)
 // ------------------------------------------------------------
@@ -121,6 +145,24 @@ static BRepGraph_NodeId::Kind kindFromInt(int32_t k) {
         case 8: return BRepGraph_NodeId::Kind::CoEdge;
         default: return BRepGraph_NodeId::Kind::Solid;
     }
+}
+
+// --- TopoSupplement helpers (vertex-supplement attachments) ---
+//
+// The supplement layer stores TopoDS_Shapes, not graph vertex indices. To attach
+// "graph vertex v" we build a TopoDS_Vertex from that vertex def's point.
+static TopoDS_Vertex bgVertexShapeFromIndex(OCCTBRepGraphRef g, int32_t vertexIndex) {
+    gp_Pnt p = BRepGraph_Tool::Vertex::Pnt(g->graph, BRepGraph_VertexId(vertexIndex));
+    return BRepBuilderAPI_MakeVertex(p).Vertex();
+}
+
+// Count supplement attachments of a given kind owned by a core node.
+static int32_t bgSupplementCount(OCCTBRepGraphRef g, BRepGraph_NodeId owner,
+                                 BRepGraph_LayerTopoSupplement::AttachmentKind kind) {
+    int32_t n = 0;
+    for (BRepGraph_SupplementIterator it(g->graph, owner); it.More(); it.Next())
+        if (it.Value().Kind == kind) ++n;
+    return n;
 }
 
 OCCTBRepGraphRef OCCTBRepGraphCreate(OCCTShapeRef shape, bool parallel) {
@@ -594,8 +636,9 @@ bool OCCTBRepGraphEdgeHasPolygon3D(OCCTBRepGraphRef g, int32_t edgeIndex) {
     } catch (...) { return false; }
 }
 
-// OCCT 8.0.0p1: per-edge max-regularity continuity is no longer exposed publicly
-// (continuity is per (edge, face1, face2) and not aggregated). Stubbed.
+// OCCT 8.0.0p1: edge continuity is conceptually the BRepGraph_LayerRegularity layer, but that class is
+// broken in p1 (uncompilable header / absent from libOCCT — see the include note above), so the graph
+// path is unavailable. Use the shape-based Shape.maxContinuity (BRep_Tool::MaxContinuity) instead.
 int32_t OCCTBRepGraphEdgeMaxContinuity(OCCTBRepGraphRef, int32_t) { return 0; }
 
 // --- Face Geometry ---
@@ -606,9 +649,16 @@ double OCCTBRepGraphFaceTolerance(OCCTBRepGraphRef g, int32_t faceIndex) {
     catch (...) { return 0; }
 }
 
-// OCCT 8.0.0p1: the face "natural restriction" flag is no longer stored or exposed publicly
-// (the incidence model derives restriction from wires). Stubbed.
-bool OCCTBRepGraphFaceIsNaturalRestriction(OCCTBRepGraphRef, int32_t) { return false; }
+// OCCT 8.0.0p1: the face "natural restriction" flag is no longer stored as an explicit bit; it is
+// derived from the incidence model. A face using its surface's natural bounds has no bounding wires,
+// so NbWires == 0. NOTE: p1 normalizes natural-bound faces (it always materializes a bounding wire),
+// so this is typically FALSE on real graphs (e.g. a box face has NbWires == 1).
+bool OCCTBRepGraphFaceIsNaturalRestriction(OCCTBRepGraphRef g, int32_t faceIndex) {
+    if (!g) return false;
+    try {
+        return BRepGraph_Tool::Face::NbWires(g->graph, BRepGraph_FaceId(faceIndex)) == 0;
+    } catch (...) { return false; }
+}
 
 bool OCCTBRepGraphFaceHasSurface(OCCTBRepGraphRef g, int32_t faceIndex) {
     if (!g) return false;
@@ -1093,10 +1143,77 @@ int32_t OCCTBRepGraphNbActiveCurves2D(OCCTBRepGraphRef g) {
 }
 
 // --- SameDomain ---
-// OCCT 8.0.0p1: TopoView::FaceOps no longer exposes a SameDomain() query (no public same-domain
-// adjacency survived the incidence-table redesign). Stubbed.
-int32_t OCCTBRepGraphFaceSameDomainCount(OCCTBRepGraphRef, int32_t) { return 0; }
-void OCCTBRepGraphFaceSameDomainIndices(OCCTBRepGraphRef, int32_t, int32_t*) {}
+// OCCT 8.0.0p1: TopoView::FaceOps no longer exposes a SameDomain() query, but the relation is
+// derivable: face G is "same-domain" with face F when they are adjacent (share an edge — via the
+// bgAdjacentFaces helper) AND lie on the geometrically-equal surface. We compare the two face
+// surfaces by DynamicType, then by defining geometry for the common analytic cases; any other
+// surface type is treated as not-equal (conservative).
+static bool bgSurfacesSameDomain(const occ::handle<Geom_Surface>& a,
+                                 const occ::handle<Geom_Surface>& b) {
+    if (a.IsNull() || b.IsNull()) return false;
+    if (a->DynamicType() != b->DynamicType()) return false;
+    const double tol = Precision::Confusion();
+    const double angTol = Precision::Angular();
+
+    if (auto pa = occ::handle<Geom_Plane>::DownCast(a)) {
+        auto pb = occ::handle<Geom_Plane>::DownCast(b);
+        gp_Pln A = pa->Pln(), B = pb->Pln();
+        // Coplanar: parallel normals AND each location lies on the other's plane.
+        if (!A.Axis().Direction().IsParallel(B.Axis().Direction(), angTol)) return false;
+        return A.Distance(B.Location()) <= tol;
+    }
+    if (auto ca = occ::handle<Geom_CylindricalSurface>::DownCast(a)) {
+        auto cb = occ::handle<Geom_CylindricalSurface>::DownCast(b);
+        if (Abs(ca->Radius() - cb->Radius()) > tol) return false;
+        const gp_Ax1 A = ca->Axis(), B = cb->Axis();
+        if (!A.Direction().IsParallel(B.Direction(), angTol)) return false;
+        return A.Location().Distance(B.Location()) <= tol
+            || gp_Lin(A).Distance(B.Location()) <= tol;
+    }
+    if (auto co = occ::handle<Geom_ConicalSurface>::DownCast(a)) {
+        auto cb = occ::handle<Geom_ConicalSurface>::DownCast(b);
+        if (Abs(co->SemiAngle() - cb->SemiAngle()) > angTol) return false;
+        if (Abs(co->RefRadius() - cb->RefRadius()) > tol) return false;
+        const gp_Ax1 A = co->Axis(), B = cb->Axis();
+        if (!A.Direction().IsParallel(B.Direction(), angTol)) return false;
+        return co->Apex().Distance(cb->Apex()) <= tol;
+    }
+    if (auto sa = occ::handle<Geom_SphericalSurface>::DownCast(a)) {
+        auto sb = occ::handle<Geom_SphericalSurface>::DownCast(b);
+        if (Abs(sa->Radius() - sb->Radius()) > tol) return false;
+        return sa->Location().Distance(sb->Location()) <= tol;
+    }
+    if (auto ta = occ::handle<Geom_ToroidalSurface>::DownCast(a)) {
+        auto tb = occ::handle<Geom_ToroidalSurface>::DownCast(b);
+        if (Abs(ta->MajorRadius() - tb->MajorRadius()) > tol) return false;
+        if (Abs(ta->MinorRadius() - tb->MinorRadius()) > tol) return false;
+        const gp_Ax1 A = ta->Axis(), B = tb->Axis();
+        if (!A.Direction().IsParallel(B.Direction(), angTol)) return false;
+        return ta->Location().Distance(tb->Location()) <= tol;
+    }
+    return false;
+}
+
+static std::set<int32_t> bgSameDomainFaces(OCCTBRepGraphRef g, int32_t faceIndex) {
+    std::set<int32_t> out;
+    const occ::handle<Geom_Surface>& sf = BRepGraph_Tool::Face::Surface(g->graph, BRepGraph_FaceId(faceIndex));
+    if (sf.IsNull()) return out;
+    for (int32_t other : bgAdjacentFaces(g, faceIndex)) {
+        if (other == faceIndex) continue;
+        const occ::handle<Geom_Surface>& so = BRepGraph_Tool::Face::Surface(g->graph, BRepGraph_FaceId(other));
+        if (bgSurfacesSameDomain(sf, so)) out.insert(other);
+    }
+    return out;
+}
+
+int32_t OCCTBRepGraphFaceSameDomainCount(OCCTBRepGraphRef g, int32_t faceIndex) {
+    if (!g) return 0;
+    try { return (int32_t)bgSameDomainFaces(g, faceIndex).size(); } catch (...) { return 0; }
+}
+void OCCTBRepGraphFaceSameDomainIndices(OCCTBRepGraphRef g, int32_t faceIndex, int32_t* out) {
+    if (!g || !out) return;
+    try { int i = 0; for (int32_t f : bgSameDomainFaces(g, faceIndex)) out[i++] = f; } catch (...) {}
+}
 
 // --- Copy and Transform ---
 
@@ -1362,9 +1479,17 @@ int32_t OCCTBRepGraphFaceNbWires(OCCTBRepGraphRef g, int32_t faceIndex) {
     } catch (...) { return 0; }
 }
 
-// OCCT 8.0.0p1: faces no longer carry direct vertex references (FaceRelations holds only
-// WireRefIds + ParentFaceRefIds). No public face-vertex-ref count. Stubbed.
-int32_t OCCTBRepGraphFaceNbVertexRefs(OCCTBRepGraphRef, int32_t) { return 0; }
+// OCCT 8.0.0p1: faces no longer carry direct vertex references in the core FaceRelations
+// (only WireRefIds + ParentFaceRefIds survive). Face-direct vertices are now a supplemental,
+// runtime concept stored in BRepGraph_LayerTopoSupplement: this counts the FaceDirectVertex
+// attachments on the face node (0 on a freshly built graph until faceAddVertex adds one).
+int32_t OCCTBRepGraphFaceNbVertexRefs(OCCTBRepGraphRef g, int32_t faceIndex) {
+    if (!g) return 0;
+    try {
+        return bgSupplementCount(g, BRepGraph_NodeId(BRepGraph_NodeId::Kind::Face, faceIndex),
+                                 BRepGraph_LayerTopoSupplement::AttachmentKind::FaceDirectVertex);
+    } catch (...) { return 0; }
+}
 
 // --- Edge Definition Details ---
 
@@ -1898,12 +2023,37 @@ void OCCTBRepGraphSetShellIsClosed(OCCTBRepGraphRef, int32_t, bool) {}
 
 // --- Add operations ---
 
-// OCCT 8.0.0p1: edges no longer support adding internal/supplemental vertex usages through the
-// public Editor (only boundary start/end vertex refs persist). No equivalent — stubbed.
-int32_t OCCTBRepGraphEdgeAddInternalVertex(OCCTBRepGraphRef, int32_t, int32_t, int32_t) { return -1; }
+// OCCT 8.0.0p1: edges no longer carry internal/supplemental vertex usages in the core; they are
+// now runtime supplement attachments (BRepGraph_LayerTopoSupplement, EdgeInternalVertex). Attach a
+// TopoDS_Vertex built from the graph vertex's point and return the layer-local attachment uid.
+// `orientation` is unused by the supplement layer — kept for source-compat, ignored.
+int64_t OCCTBRepGraphEdgeAddInternalVertex(OCCTBRepGraphRef g, int32_t edgeIndex, int32_t vertexIndex, int32_t /*orientation*/) {
+    if (!g) return -1;
+    try {
+        TopoDS_Vertex v = bgVertexShapeFromIndex(g, vertexIndex);
+        if (v.IsNull()) return -1;
+        uint64_t uid = g->graph.Editor().Supplement().AttachToEdge(
+            BRepGraph_EdgeId(edgeIndex), v,
+            BRepGraph_LayerTopoSupplement::AttachmentKind::EdgeInternalVertex);
+        return uid != 0 ? (int64_t)uid : -1;
+    } catch (...) { return -1; }
+}
 
-// OCCT 8.0.0p1: faces no longer carry direct vertex usages (FaceRelations has only wires). Stubbed.
-int32_t OCCTBRepGraphFaceAddVertex(OCCTBRepGraphRef, int32_t, int32_t, int32_t) { return -1; }
+// OCCT 8.0.0p1: faces no longer carry direct vertex usages in the core (FaceRelations has only
+// wires). Face-direct vertices are now runtime supplement attachments. Attach a TopoDS_Vertex
+// built from the graph vertex's point and return the layer-local attachment uid.
+// `orientation` is unused by the supplement layer — kept for source-compat, ignored.
+int64_t OCCTBRepGraphFaceAddVertex(OCCTBRepGraphRef g, int32_t faceIndex, int32_t vertexIndex, int32_t /*orientation*/) {
+    if (!g) return -1;
+    try {
+        TopoDS_Vertex v = bgVertexShapeFromIndex(g, vertexIndex);
+        if (v.IsNull()) return -1;
+        uint64_t uid = g->graph.Editor().Supplement().AttachToFace(
+            BRepGraph_FaceId(faceIndex), v,
+            BRepGraph_LayerTopoSupplement::AttachmentKind::FaceDirectVertex);
+        return uid != 0 ? (int64_t)uid : -1;
+    } catch (...) { return -1; }
+}
 
 int32_t OCCTBRepGraphShellAddChild(OCCTBRepGraphRef g, int32_t shellIndex,
                                     int32_t childKind, int32_t childIndex, int32_t orientation) {
@@ -1990,8 +2140,15 @@ bool OCCTBRepGraphWireRemoveCoEdge(OCCTBRepGraphRef g, int32_t wireIndex, int32_
     } catch (...) { return false; }
 }
 
-// OCCT 8.0.0p1: faces no longer own direct vertex refs (FaceOps::RemoveVertex removed). Stubbed.
-bool OCCTBRepGraphFaceRemoveVertex(OCCTBRepGraphRef, int32_t, int32_t) { return false; }
+// OCCT 8.0.0p1: faces no longer own direct vertex refs in the core. The face-direct vertex is now a
+// runtime supplement attachment, removed by its layer-local uid (the value returned by faceAddVertex,
+// NOT a core ref index). The faceIndex param is unused — the uid is globally unique within the layer.
+bool OCCTBRepGraphFaceRemoveVertex(OCCTBRepGraphRef g, int32_t /*faceIndex*/, int64_t attachmentUID) {
+    if (!g || attachmentUID < 0) return false;
+    try {
+        return g->graph.Editor().Supplement().RemoveAttachment((uint64_t)attachmentUID);
+    } catch (...) { return false; }
+}
 
 bool OCCTBRepGraphFaceRemoveWire(OCCTBRepGraphRef g, int32_t faceIndex, int32_t wireRefIndex) {
     if (!g) return false;
@@ -2315,10 +2472,10 @@ void OCCTBRepGraphSetChildRefChildDefId(OCCTBRepGraphRef g, int32_t childRefInde
 // (UV endpoints are derived from the PCurve via BRepGraph_Tool::CoEdge::UVPoints). No-op.
 void OCCTBRepGraphSetCoEdgeUVBox(OCCTBRepGraphRef, int32_t, double, double, double, double) {}
 
-// OCCT 8.0.0p1: EdgeOps::SetRegularity was removed — edge continuity across an (edge, face1, face2)
-// is no longer a settable field (continuity is derived). No public equivalent; report failure.
+// OCCT 8.0.0p1: edge regularity would live in BRepGraph_LayerRegularity, but that class is broken in
+// p1 (uncompilable header / absent from libOCCT — see the include note near the top of this file), so
+// there is no working write path. Report failure. continuityFromInt() is kept for the cut-path wrappers.
 int32_t OCCTBRepGraphSetEdgeRegularity(OCCTBRepGraphRef, int32_t, int32_t, int32_t, int32_t) {
-    // continuityFromInt() is otherwise unused now; keep it referenced to avoid an unused-static warning.
     (void)&continuityFromInt;
     return 0;
 }
@@ -2966,4 +3123,138 @@ double OCCTEdgeGetDihedralAngle(OCCTEdgeRef edge, OCCTFaceRef face1, OCCTFaceRef
     } catch (...) {
         return -1;
     }
+}
+
+// MARK: - Durable identity (BRepGraph::UIDsView) — OCCT 8.0.0p1
+
+#include <BRepGraph_UID.hxx>
+#include <BRepGraph_RefUID.hxx>
+#include <BRepGraph_ItemUID.hxx>
+#include <BRepGraph_UIDsView.hxx>
+
+// Maps a raw BRepGraph_RefId::Kind enum ordinal (0..6 as defined in the header)
+// straight back to the enum. Distinct from refKindFromInt() above, which carries a
+// legacy ABI remap; the UID round-trip uses the actual enum ordinals we emit.
+static BRepGraph_RefId::Kind refKindFromRawOrdinal(int32_t k) {
+    switch (k) {
+        case 0: return BRepGraph_RefId::Kind::Shell;
+        case 1: return BRepGraph_RefId::Kind::Face;
+        case 2: return BRepGraph_RefId::Kind::Wire;
+        case 3: return BRepGraph_RefId::Kind::Vertex;
+        case 4: return BRepGraph_RefId::Kind::Solid;
+        case 5: return BRepGraph_RefId::Kind::Child;
+        case 6: return BRepGraph_RefId::Kind::Occurrence;
+        default: return BRepGraph_RefId::Kind::Shell;
+    }
+}
+
+bool OCCTBRepGraphNodeUID(OCCTBRepGraphRef graph,
+                          int32_t nodeKind, int32_t nodeIndex,
+                          int32_t* outUIDKind, uint32_t* outCounter) {
+    if (!graph) return false;
+    try {
+        BRepGraph_NodeId node(kindFromInt(nodeKind), (uint32_t)nodeIndex);
+        BRepGraph_UID uid = graph->graph.UIDs().Of(node);
+        if (!uid.IsValid()) return false;
+        *outUIDKind = (int32_t)uid.Kind;
+        *outCounter = uid.Counter;
+        return true;
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphNodeFromUID(OCCTBRepGraphRef graph,
+                              int32_t uidKind, uint32_t counter,
+                              int32_t* outNodeKind, int32_t* outNodeIndex) {
+    if (!graph) return false;
+    try {
+        BRepGraph_UID uid(kindFromInt(uidKind), counter);
+        BRepGraph_NodeId node = graph->graph.UIDs().NodeIdFrom(uid);
+        if (!node.IsValid()) return false;
+        *outNodeKind = (int32_t)node.NodeKind;
+        *outNodeIndex = (int32_t)node.Index;
+        return true;
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphHasNodeUID(OCCTBRepGraphRef graph, int32_t uidKind, uint32_t counter) {
+    if (!graph) return false;
+    try {
+        BRepGraph_UID uid(kindFromInt(uidKind), counter);
+        return graph->graph.UIDs().Has(uid);
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphRefUID(OCCTBRepGraphRef graph,
+                         int32_t refKind, int32_t refIndex,
+                         int32_t* outUIDKind, uint32_t* outCounter) {
+    if (!graph) return false;
+    try {
+        BRepGraph_RefId ref(refKindFromRawOrdinal(refKind), (uint32_t)refIndex);
+        BRepGraph_RefUID uid = graph->graph.UIDs().Of(ref);
+        if (!uid.IsValid()) return false;
+        *outUIDKind = (int32_t)uid.Kind;
+        *outCounter = uid.Counter;
+        return true;
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphRefFromUID(OCCTBRepGraphRef graph,
+                             int32_t uidKind, uint32_t counter,
+                             int32_t* outRefKind, int32_t* outRefIndex) {
+    if (!graph) return false;
+    try {
+        BRepGraph_RefUID uid(refKindFromRawOrdinal(uidKind), counter);
+        BRepGraph_RefId ref = graph->graph.UIDs().RefIdFrom(uid);
+        if (!ref.IsValid()) return false;
+        *outRefKind = (int32_t)ref.RefKind;
+        *outRefIndex = (int32_t)ref.Index;
+        return true;
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphHasRefUID(OCCTBRepGraphRef graph, int32_t uidKind, uint32_t counter) {
+    if (!graph) return false;
+    try {
+        BRepGraph_RefUID uid(refKindFromRawOrdinal(uidKind), counter);
+        return graph->graph.UIDs().Has(uid);
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphItemUIDOfNode(OCCTBRepGraphRef graph,
+                                int32_t nodeKind, int32_t nodeIndex,
+                                int32_t* outDomain, int32_t* outKind,
+                                uint32_t* outCounter) {
+    if (!graph) return false;
+    try {
+        BRepGraph_NodeId node(kindFromInt(nodeKind), (uint32_t)nodeIndex);
+        BRepGraph_ItemId item(node);
+        BRepGraph_ItemUID uid = graph->graph.UIDs().Of(item);
+        if (!uid.IsValid()) return false;
+        *outDomain = (int32_t)uid.ItemDomain();
+        *outKind = (int32_t)uid.RawKind();
+        *outCounter = (uint32_t)uid.Counter();
+        return true;
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef graph,
+                              int32_t domain, int32_t kind, uint32_t counter,
+                              int32_t* outDomain, int32_t* outKind, int32_t* outIndex) {
+    if (!graph) return false;
+    try {
+        BRepGraph_ItemUID uid = (domain == (int32_t)BRepGraph_ItemUID::Domain::Reference)
+            ? BRepGraph_ItemUID::Reference(refKindFromRawOrdinal(kind), (size_t)counter)
+            : BRepGraph_ItemUID::Node(kindFromInt(kind), (size_t)counter);
+        BRepGraph_ItemId item = graph->graph.UIDs().ItemIdFrom(uid);
+        if (!item.IsValid()) return false;
+        *outDomain = (int32_t)item.ItemDomain();
+        *outKind = (int32_t)item.RawKind();
+        *outIndex = (int32_t)item.Index();
+        return true;
+    } catch (...) { return false; }
+}
+
+uint32_t OCCTBRepGraphGeneration(OCCTBRepGraphRef graph) {
+    if (!graph) return 0;
+    try { return graph->graph.UIDs().Generation(); } catch (...) { return 0; }
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
@@ -1127,6 +1127,61 @@ void OCCTPolyPolygonOnTriRelease(OCCTPolyPolygonOnTriRef _Nonnull ref) {
     delete reinterpret_cast<Poly_PolygonOnTriangulationOpaque*>(ref);
 }
 
+// MARK: - Poly copy / mutators — OCCT 8.0.0p1
+
+OCCTPolyPolygon2DRef _Nullable OCCTPolyPolygon2DCopy(OCCTPolyPolygon2DRef _Nonnull ref) {
+    try {
+        auto* p = reinterpret_cast<Poly_Polygon2DOpaque*>(ref);
+        Handle(Poly_Polygon2D) copy = p->polygon->Copy();
+        if (copy.IsNull()) return nullptr;
+        return reinterpret_cast<OCCTPolyPolygon2DRef>(new Poly_Polygon2DOpaque{copy});
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+OCCTPolyPolygonOnTriRef _Nullable OCCTPolyPolygonOnTriCopy(OCCTPolyPolygonOnTriRef _Nonnull ref) {
+    try {
+        auto* p = reinterpret_cast<Poly_PolygonOnTriangulationOpaque*>(ref);
+        Handle(Poly_PolygonOnTriangulation) copy = p->polygon->Copy();
+        if (copy.IsNull()) return nullptr;
+        return reinterpret_cast<OCCTPolyPolygonOnTriRef>(new Poly_PolygonOnTriangulationOpaque{copy});
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+bool OCCTPolyPolygonOnTriSetNodes(OCCTPolyPolygonOnTriRef _Nonnull ref,
+                                  const int* _Nonnull nodeIndices, int count) {
+    try {
+        auto* p = reinterpret_cast<Poly_PolygonOnTriangulationOpaque*>(ref);
+        NCollection_Array1<int>& arr = p->polygon->ChangeNodeArray();
+        if (count != arr.Length()) return false;
+        for (int i = 0; i < count; i++) {
+            arr.SetValue(arr.Lower() + i, nodeIndices[i]);
+        }
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool OCCTPolyPolygonOnTriSetParameters(OCCTPolyPolygonOnTriRef _Nonnull ref,
+                                       const double* _Nonnull params, int count) {
+    try {
+        auto* p = reinterpret_cast<Poly_PolygonOnTriangulationOpaque*>(ref);
+        if (!p->polygon->HasParameters()) return false;
+        NCollection_Array1<double>& arr = p->polygon->ChangeParameterArray();
+        if (count != arr.Length()) return false;
+        for (int i = 0; i < count; i++) {
+            arr.SetValue(arr.Lower() + i, params[i]);
+        }
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 // MARK: - Poly_MergeNodesTool (v0.78)
 // MARK: - Poly_MergeNodesTool
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -6236,3 +6236,122 @@ OCCTSurfaceRef OCCTGeomEvalAHTBezierSurfaceCreate(
         return ref;
     } catch (...) { return nullptr; }
 }
+
+// MARK: - GeomFill_Gordon report + GeomFill_NetworkSurface — OCCT 8.0.0p1
+
+#include <GeomFill_NetworkSurface.hxx>
+
+// Build a Gordon surface reporting status + approximate flag.
+OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t profileCount,
+                                        const OCCTCurve3DRef* guides, int32_t guideCount,
+                                        double tolerance, int32_t approximationMode,
+                                        int32_t* outStatus, bool* outIsApproximate) {
+    if (outStatus) *outStatus = (int32_t)GeomFill_Gordon::ResultStatus::NotStarted;
+    if (outIsApproximate) *outIsApproximate = false;
+    if (!profiles || !guides || profileCount < 2 || guideCount < 2) {
+        if (outStatus) *outStatus = (int32_t)GeomFill_Gordon::ResultStatus::InvalidInput;
+        return nullptr;
+    }
+    try {
+        NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
+        for (int i = 0; i < profileCount; i++) {
+            if (!profiles[i]) return nullptr;
+            profs.SetValue(i, profiles[i]->curve);
+        }
+        NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
+        for (int i = 0; i < guideCount; i++) {
+            if (!guides[i]) return nullptr;
+            gds.SetValue(i, guides[i]->curve);
+        }
+
+        GeomFill_Gordon gordon;
+        gordon.SetApproximationMode(approximationMode == 1
+            ? GeomFill_Gordon::ApproximationMode::AllowApproximateFallback
+            : GeomFill_Gordon::ApproximationMode::ExactOnly);
+        gordon.Init(profs, gds, tolerance);
+        gordon.Perform();
+
+        if (outStatus) *outStatus = (int32_t)gordon.Status();
+        if (outIsApproximate) *outIsApproximate = gordon.IsApproximate();
+
+        if (!gordon.IsDone()) return nullptr;
+        auto surf = gordon.Surface();
+        if (surf.IsNull()) return nullptr;
+
+        auto ref = new OCCTSurface();
+        ref->surface = surf;
+        return ref;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+// Low-level GeomFill_NetworkSurface builder. Takes profile + guide curves and
+// builds a compatible non-periodic B-spline network: profiles are evaluated in
+// U, guides in V; the intersection grid is sampled at the natural [first,last]
+// parameter range of each curve, and the profile/guide locator parameters are
+// uniformly spaced. Returns the surface or NULL; writes the ResultStatus ordinal.
+OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_t profileCount,
+                                          const OCCTCurve3DRef* guides, int32_t guideCount,
+                                          double tolerance, int32_t* outStatus) {
+    if (outStatus) *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::NotStarted;
+    if (!profiles || !guides || profileCount < 2 || guideCount < 2) {
+        if (outStatus) *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::InvalidInput;
+        return nullptr;
+    }
+    try {
+        // Convert inputs to explicit non-periodic B-spline curves.
+        NCollection_Array1<occ::handle<Geom_BSplineCurve>> profs(1, profileCount);
+        for (int i = 0; i < profileCount; i++) {
+            if (!profiles[i] || profiles[i]->curve.IsNull()) return nullptr;
+            Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(profiles[i]->curve);
+            if (bs.IsNull()) return nullptr;
+            if (bs->IsPeriodic()) bs->SetNotPeriodic();
+            profs.SetValue(i + 1, bs);
+        }
+        NCollection_Array1<occ::handle<Geom_BSplineCurve>> gds(1, guideCount);
+        for (int i = 0; i < guideCount; i++) {
+            if (!guides[i] || guides[i]->curve.IsNull()) return nullptr;
+            Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(guides[i]->curve);
+            if (bs.IsNull()) return nullptr;
+            if (bs->IsPeriodic()) bs->SetNotPeriodic();
+            gds.SetValue(i + 1, bs);
+        }
+
+        // Uniform locator parameters in [0,1].
+        NCollection_Array1<double> profileParams(1, profileCount);
+        for (int i = 0; i < profileCount; i++)
+            profileParams.SetValue(i + 1, profileCount > 1 ? (double)i / (profileCount - 1) : 0.0);
+        NCollection_Array1<double> guideParams(1, guideCount);
+        for (int j = 0; j < guideCount; j++)
+            guideParams.SetValue(j + 1, guideCount > 1 ? (double)j / (guideCount - 1) : 0.0);
+
+        // Intersection grid: row = profile (i), col = guide (j). Sample profile i
+        // at the parameter matching guide j's normalized position along the profile.
+        NCollection_Array2<gp_Pnt> ipts(1, profileCount, 1, guideCount);
+        NCollection_Array2<double> iwts(1, profileCount, 1, guideCount);
+        for (int i = 0; i < profileCount; i++) {
+            const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
+            double f = pc->FirstParameter(), l = pc->LastParameter();
+            for (int j = 0; j < guideCount; j++) {
+                double t = guideCount > 1 ? f + (l - f) * ((double)j / (guideCount - 1)) : f;
+                ipts.SetValue(i + 1, j + 1, pc->Value(t));
+                iwts.SetValue(i + 1, j + 1, 1.0);
+            }
+        }
+
+        GeomFill_NetworkSurface net;
+        net.Init(profs, gds, profileParams, guideParams, ipts, iwts, tolerance, false, false);
+        net.Perform();
+        if (outStatus) *outStatus = (int32_t)net.Status();
+        if (!net.IsDone()) return nullptr;
+
+        const Handle(Geom_BSplineSurface)& surf = net.Surface();
+        if (surf.IsNull()) return nullptr;
+        auto ref = new OCCTSurface();
+        ref->surface = surf;
+        return ref;
+    } catch (...) {
+        return nullptr;
+    }
+}

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -1427,14 +1427,21 @@ public final class TopologyGraph: @unchecked Sendable {
 
     // MARK: - EditorView Add operations (v0.161.0)
 
-    /// Add an internal vertex reference to an edge. Returns the new vertex-ref id, or nil on failure.
-    /// - Parameter orientation: 0=Forward, 1=Reversed, 2=Internal, 3=External (default Internal).
+    /// Attach an internal vertex (built from the graph vertex's point) to an edge as a runtime
+    /// supplement attachment. Returns the layer-local attachment uid, or nil on failure.
+    /// - Note: Edge-internal vertices are a supplemental, runtime concept in OCCT 8.0.0p1
+    ///   (`BRepGraph_LayerTopoSupplement`); a clean shape has none until one is added here.
+    /// - Parameter orientation: accepted for source-compat but ignored by the supplement layer.
     public func edgeAddInternalVertex(_ edgeIndex: Int, vertexIndex: Int, orientation: Int = 2) -> Int? {
         let id = Int(OCCTBRepGraphEdgeAddInternalVertex(handle, Int32(edgeIndex), Int32(vertexIndex), Int32(orientation)))
         return id >= 0 ? id : nil
     }
 
-    /// Add a vertex reference to a face. Returns the new vertex-ref id, or nil.
+    /// Attach a direct vertex (built from the graph vertex's point) to a face as a runtime supplement
+    /// attachment. Returns the layer-local attachment uid, or nil on failure.
+    /// - Note: Face-direct vertices are a supplemental, runtime concept in OCCT 8.0.0p1
+    ///   (`BRepGraph_LayerTopoSupplement`); a clean box has none until one is added here.
+    /// - Parameter orientation: accepted for source-compat but ignored by the supplement layer.
     public func faceAddVertex(_ faceIndex: Int, vertexIndex: Int, orientation: Int = 0) -> Int? {
         let id = Int(OCCTBRepGraphFaceAddVertex(handle, Int32(faceIndex), Int32(vertexIndex), Int32(orientation)))
         return id >= 0 ? id : nil
@@ -1482,9 +1489,10 @@ public final class TopologyGraph: @unchecked Sendable {
         OCCTBRepGraphWireRemoveCoEdge(handle, Int32(wireIndex), Int32(coedgeRefIndex))
     }
 
-    /// Detach a vertex ref from a face definition.
-    public func faceRemoveVertex(_ faceIndex: Int, vertexRefIndex: Int) -> Bool {
-        OCCTBRepGraphFaceRemoveVertex(handle, Int32(faceIndex), Int32(vertexRefIndex))
+    /// Detach a face-direct vertex supplement attachment by its uid (the value returned by
+    /// `faceAddVertex`). Returns true if the attachment existed and was removed.
+    public func faceRemoveVertex(_ faceIndex: Int, attachmentUID: Int) -> Bool {
+        OCCTBRepGraphFaceRemoveVertex(handle, Int32(faceIndex), Int64(attachmentUID))
     }
 
     /// Detach a wire ref from a face definition.
@@ -1921,5 +1929,127 @@ public final class TopologyGraph: @unchecked Sendable {
             points.append(SIMD3(buffer[i * 3], buffer[i * 3 + 1], buffer[i * 3 + 2]))
         }
         return points
+    }
+
+    // MARK: - Durable Identity (UID / RefUID / ItemUID) — OCCT 8.0.0p1
+
+    /// A durable node identifier: a `(kind, counter)` pair that persists across graph
+    /// mutations (compaction, node removal) within one graph generation. Unlike a
+    /// `(kind, index)` `NodeRef`, the counter never repeats within a kind and is stable
+    /// even when vector indices shift. `counter == 0` is the invalid sentinel.
+    ///
+    /// `kind` is the raw `BRepGraph_NodeId::Kind` ordinal
+    /// (0 Solid, 1 Shell, 2 Face, 3 Wire, 4 Edge, 5 Vertex, 6 Compound,
+    /// 7 CompSolid, 8 CoEdge, 10 Product, 11 Occurrence).
+    public struct GraphUID: Sendable, Hashable, Codable {
+        public var kind: Int
+        public var counter: UInt32
+        public init(kind: Int, counter: UInt32) {
+            self.kind = kind
+            self.counter = counter
+        }
+        /// True if this UID has a non-zero counter (it may still fail to resolve in a graph).
+        public var isValid: Bool { counter > 0 }
+    }
+
+    /// A durable reference-entry identifier `(kind, counter)`.
+    ///
+    /// `kind` is the raw `BRepGraph_RefId::Kind` ordinal
+    /// (0 Shell, 1 Face, 2 Wire, 3 Vertex, 4 Solid, 5 Child, 6 Occurrence).
+    public struct GraphRefUID: Sendable, Hashable, Codable {
+        public var kind: Int
+        public var counter: UInt32
+        public init(kind: Int, counter: UInt32) {
+            self.kind = kind
+            self.counter = counter
+        }
+        public var isValid: Bool { counter > 0 }
+    }
+
+    /// A durable generic item identifier covering both definition nodes and reference
+    /// entries. `domain` is 1 for a node, 2 for a reference; `kind` is the raw kind
+    /// ordinal in that domain's enum space.
+    public struct GraphItemUID: Sendable, Hashable, Codable {
+        public var domain: Int
+        public var kind: Int
+        public var counter: UInt32
+        public init(domain: Int, kind: Int, counter: UInt32) {
+            self.domain = domain
+            self.kind = kind
+            self.counter = counter
+        }
+        public var isValid: Bool { counter > 0 }
+    }
+
+    /// Return the durable UID for a node, or `nil` if the node is invalid/removed/out of bounds.
+    /// - Parameters:
+    ///   - kind: raw `BRepGraph_NodeId::Kind` ordinal (e.g. 2 = Face).
+    ///   - index: per-kind node index.
+    public func uid(ofNodeKind kind: Int, index: Int) -> GraphUID? {
+        var uidKind: Int32 = 0
+        var counter: UInt32 = 0
+        guard OCCTBRepGraphNodeUID(handle, Int32(kind), Int32(index), &uidKind, &counter) else { return nil }
+        return GraphUID(kind: Int(uidKind), counter: counter)
+    }
+
+    /// Resolve a node UID back to its `(kind, index)`, or `nil` if it does not resolve
+    /// in the current graph generation.
+    public func node(forUID uid: GraphUID) -> (kind: Int, index: Int)? {
+        var nodeKind: Int32 = 0
+        var nodeIndex: Int32 = 0
+        guard OCCTBRepGraphNodeFromUID(handle, Int32(uid.kind), uid.counter, &nodeKind, &nodeIndex) else { return nil }
+        return (Int(nodeKind), Int(nodeIndex))
+    }
+
+    /// True if a node UID is valid and exists in this graph generation.
+    public func contains(uid: GraphUID) -> Bool {
+        OCCTBRepGraphHasNodeUID(handle, Int32(uid.kind), uid.counter)
+    }
+
+    /// Return the durable RefUID for a reference entry, or `nil` if invalid/removed.
+    /// - Parameters:
+    ///   - kind: raw `BRepGraph_RefId::Kind` ordinal.
+    ///   - index: per-kind reference index.
+    public func uid(ofRefKind kind: Int, index: Int) -> GraphRefUID? {
+        var uidKind: Int32 = 0
+        var counter: UInt32 = 0
+        guard OCCTBRepGraphRefUID(handle, Int32(kind), Int32(index), &uidKind, &counter) else { return nil }
+        return GraphRefUID(kind: Int(uidKind), counter: counter)
+    }
+
+    /// Resolve a RefUID back to its `(kind, index)`, or `nil` if it does not resolve.
+    public func ref(forUID uid: GraphRefUID) -> (kind: Int, index: Int)? {
+        var refKind: Int32 = 0
+        var refIndex: Int32 = 0
+        guard OCCTBRepGraphRefFromUID(handle, Int32(uid.kind), uid.counter, &refKind, &refIndex) else { return nil }
+        return (Int(refKind), Int(refIndex))
+    }
+
+    /// True if a RefUID is valid and exists in this graph generation.
+    public func contains(uid: GraphRefUID) -> Bool {
+        OCCTBRepGraphHasRefUID(handle, Int32(uid.kind), uid.counter)
+    }
+
+    /// Return the durable ItemUID for a node, or `nil` if invalid/removed.
+    public func itemUID(ofNodeKind kind: Int, index: Int) -> GraphItemUID? {
+        var domain: Int32 = 0
+        var itemKind: Int32 = 0
+        var counter: UInt32 = 0
+        guard OCCTBRepGraphItemUIDOfNode(handle, Int32(kind), Int32(index), &domain, &itemKind, &counter) else { return nil }
+        return GraphItemUID(domain: Int(domain), kind: Int(itemKind), counter: counter)
+    }
+
+    /// Resolve an ItemUID back to its `(domain, kind, index)`, or `nil` if it does not resolve.
+    public func item(forUID uid: GraphItemUID) -> (domain: Int, kind: Int, index: Int)? {
+        var domain: Int32 = 0
+        var itemKind: Int32 = 0
+        var index: Int32 = 0
+        guard OCCTBRepGraphItemFromUID(handle, Int32(uid.domain), Int32(uid.kind), uid.counter, &domain, &itemKind, &index) else { return nil }
+        return (Int(domain), Int(itemKind), Int(index))
+    }
+
+    /// The current graph generation counter, incremented each time the graph is cleared/rebuilt.
+    public var generation: UInt32 {
+        OCCTBRepGraphGeneration(handle)
     }
 }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -11625,6 +11625,12 @@ public final class Polygon2D: @unchecked Sendable {
         get { OCCTPolyPolygon2DDeflection(handle) }
         set { OCCTPolyPolygon2DSetDeflection(handle, newValue) }
     }
+
+    /// Create a deep copy of this polygon (`Poly_Polygon2D::Copy()`).
+    public func copy() -> Polygon2D? {
+        guard let ref = OCCTPolyPolygon2DCopy(handle) else { return nil }
+        return Polygon2D(handle: ref)
+    }
 }
 
 // MARK: - Triangulation (v0.160.0)
@@ -11827,6 +11833,32 @@ public final class PolygonOnTriangulation: @unchecked Sendable {
     public var deflection: Double {
         get { OCCTPolyPolygonOnTriDeflection(handle) }
         set { OCCTPolyPolygonOnTriSetDeflection(handle, newValue) }
+    }
+
+    /// Create a deep copy of this polygon (`Poly_PolygonOnTriangulation::Copy()`).
+    public func copy() -> PolygonOnTriangulation? {
+        guard let ref = OCCTPolyPolygonOnTriCopy(handle) else { return nil }
+        return PolygonOnTriangulation(handle: ref)
+    }
+
+    /// Overwrite the node-index array in place (`ChangeNodeArray()`).
+    /// The supplied array must have the same length as `nodeCount`.
+    /// - Returns: true on success, false on size mismatch.
+    @discardableResult
+    public func setNodes(_ nodeIndices: [Int32]) -> Bool {
+        nodeIndices.withUnsafeBufferPointer { buf in
+            OCCTPolyPolygonOnTriSetNodes(handle, buf.baseAddress!, Int32(nodeIndices.count))
+        }
+    }
+
+    /// Overwrite the parameter array in place (`ChangeParameterArray()`).
+    /// Requires `hasParameters` and an array length equal to `nodeCount`.
+    /// - Returns: true on success, false otherwise.
+    @discardableResult
+    public func setParameters(_ params: [Double]) -> Bool {
+        params.withUnsafeBufferPointer { buf in
+            OCCTPolyPolygonOnTriSetParameters(handle, buf.baseAddress!, Int32(params.count))
+        }
     }
 }
 

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2683,6 +2683,110 @@ extension Surface {
             }
         }
     }
+
+    /// Result status of a Gordon surface build, mirroring `GeomFill_Gordon::ResultStatus`.
+    public enum GordonResultStatus: Int, Sendable {
+        case notStarted = 0
+        case done
+        case invalidInput
+        case conversionFailed
+        case intersectionFailed
+        case orderingFailed
+        case reparametrizationFailed
+        case compatibilityFailed
+        case curveCompatibilityFailed
+        case rationalReparametrizationFailed
+        case skinningFailed
+        case referenceSurfaceFailed
+        case knotAlignmentFailed
+        case rationalDegreeOverflow
+        case rationalConstructionFailed
+        case periodicityFailed
+        case approximationFailed
+        case constructionFailed
+    }
+
+    /// Outcome of `gordonReport(...)`: surface (nil on failure), status, and whether the
+    /// result was produced by approximate fallback (no exact interpolation guarantee).
+    public struct GordonResult: Sendable {
+        public let surface: Surface?
+        public let status: GordonResultStatus
+        public let isApproximate: Bool
+    }
+
+    /// Result status of a network-surface build, mirroring `GeomFill_NetworkSurface::ResultStatus`.
+    public enum NetworkSurfaceStatus: Int, Sendable {
+        case notStarted = 0
+        case done
+        case invalidInput
+        case curveCompatibilityFailed
+        case skinningFailed
+        case referenceSurfaceFailed
+        case knotAlignmentFailed
+        case rationalDegreeOverflow
+        case rationalConstructionFailed
+        case constructionFailed
+        case periodicityFailed
+    }
+
+    /// Build a Gordon surface, returning the result status and approximate flag.
+    /// - Parameters:
+    ///   - profiles: profile curves (V-direction), at least 2.
+    ///   - guides: guide curves (U-direction), at least 2.
+    ///   - tolerance: geometric tolerance for intersection detection.
+    ///   - allowApproximateFallback: if true, permit a sampled B-spline fallback when exact
+    ///     construction fails (result marked `isApproximate`); default false (`ExactOnly`).
+    public static func gordonReport(profiles: [Curve3D], guides: [Curve3D],
+                                    tolerance: Double = 1e-3,
+                                    allowApproximateFallback: Bool = false) -> GordonResult {
+        guard profiles.count >= 2, guides.count >= 2 else {
+            return GordonResult(surface: nil, status: .invalidInput, isApproximate: false)
+        }
+        let profileRefs = profiles.map { $0.handle }
+        let guideRefs = guides.map { $0.handle }
+        var statusRaw: Int32 = 0
+        var isApprox: Bool = false
+        let surfaceRef: OCCTSurfaceRef? = profileRefs.withUnsafeBufferPointer { pBuf in
+            guideRefs.withUnsafeBufferPointer { gBuf in
+                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else { return nil as OCCTSurfaceRef? }
+                return OCCTGeomFillGordonReport(pPtr, Int32(profiles.count),
+                                                gPtr, Int32(guides.count),
+                                                tolerance, allowApproximateFallback ? 1 : 0,
+                                                &statusRaw, &isApprox)
+            }
+        }
+        let status = GordonResultStatus(rawValue: Int(statusRaw)) ?? .notStarted
+        let surface = surfaceRef.map { Surface(handle: $0) }
+        return GordonResult(surface: surface, status: status, isApproximate: isApprox)
+    }
+
+    /// Build a surface with the low-level `GeomFill_NetworkSurface` builder from a
+    /// profile/guide curve network. The curves are converted to non-periodic B-splines,
+    /// an intersection grid is sampled along each profile, and locator parameters are
+    /// uniformly spaced. Returns the surface (nil on failure) and the result status.
+    /// - Parameters:
+    ///   - profiles: profile curves evaluated in U, at least 2.
+    ///   - guides: guide curves evaluated in V, at least 2.
+    ///   - tolerance: geometric tolerance for closed-seam checks.
+    public static func networkSurface(profiles: [Curve3D], guides: [Curve3D],
+                                      tolerance: Double = 1e-3)
+        -> (surface: Surface?, status: NetworkSurfaceStatus) {
+        guard profiles.count >= 2, guides.count >= 2 else { return (nil, .invalidInput) }
+        let profileRefs = profiles.map { $0.handle }
+        let guideRefs = guides.map { $0.handle }
+        var statusRaw: Int32 = 0
+        let surfaceRef: OCCTSurfaceRef? = profileRefs.withUnsafeBufferPointer { pBuf in
+            guideRefs.withUnsafeBufferPointer { gBuf in
+                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else { return nil as OCCTSurfaceRef? }
+                return OCCTGeomFillNetworkSurface(pPtr, Int32(profiles.count),
+                                                  gPtr, Int32(guides.count),
+                                                  tolerance, &statusRaw)
+            }
+        }
+        let status = NetworkSurfaceStatus(rawValue: Int(statusRaw)) ?? .notStarted
+        let surface = surfaceRef.map { Surface(handle: $0) }
+        return (surface, status)
+    }
 }
 
 // MARK: - GeomEval TBezier / AHTBezier Surfaces (v0.131.0)

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -1334,7 +1334,7 @@ struct EditorViewAddRemoveTests {
                 #expect(graph.edgeRemoveVertex(0, vertexRefIndex: 99999) == false)
                 #expect(graph.edgeReplaceVertex(0, oldVertexRefIndex: 99999, newVertexIndex: 0) == nil)
                 #expect(graph.wireRemoveCoEdge(0, coedgeRefIndex: 99999) == false)
-                #expect(graph.faceRemoveVertex(0, vertexRefIndex: 99999) == false)
+                #expect(graph.faceRemoveVertex(0, attachmentUID: 99999) == false)
                 #expect(graph.faceRemoveWire(0, wireRefIndex: 99999) == false)
                 #expect(graph.shellRemoveFace(0, faceRefIndex: 99999) == false)
                 #expect(graph.shellRemoveChild(0, childRefIndex: 99999) == false)

--- a/Tests/OCCTMeshTests/OCCTMeshTests.swift
+++ b/Tests/OCCTMeshTests/OCCTMeshTests.swift
@@ -961,3 +961,73 @@ struct MeshViewCountsTests {
         }
     }
 }
+
+// MARK: - Poly copy / mutators — OCCT 8.0.0p1
+
+@Suite("Poly Copy & Mutators")
+struct PolyCopyMutatorTests {
+
+    @Test("Polygon2D copy preserves contents")
+    func polygon2DCopy() {
+        let pts = [SIMD2<Double>(0, 0), SIMD2<Double>(1, 0), SIMD2<Double>(1, 1)]
+        guard let poly = Polygon2D.create(points: pts) else { return }
+        poly.deflection = 0.25
+        guard let copy = poly.copy() else {
+            Issue.record("Polygon2D.copy() returned nil")
+            return
+        }
+        #expect(copy.nodeCount == poly.nodeCount)
+        for i in 0..<poly.nodeCount {
+            if let a = poly.node(at: i), let b = copy.node(at: i) {
+                #expect(abs(a.x - b.x) < 1e-12)
+                #expect(abs(a.y - b.y) < 1e-12)
+            }
+        }
+        #expect(abs(copy.deflection - 0.25) < 1e-12)
+    }
+
+    @Test("PolygonOnTriangulation copy preserves nodes")
+    func polygonOnTriCopy() {
+        let indices: [Int32] = [1, 2, 3, 4]
+        guard let poly = PolygonOnTriangulation.create(nodeIndices: indices) else { return }
+        guard let copy = poly.copy() else {
+            Issue.record("PolygonOnTriangulation.copy() returned nil")
+            return
+        }
+        #expect(copy.nodeCount == poly.nodeCount)
+        for i in 0..<poly.nodeCount {
+            #expect(copy.nodeIndex(at: i) == poly.nodeIndex(at: i))
+        }
+    }
+
+    @Test("PolygonOnTriangulation setNodes mutates in place")
+    func polygonOnTriSetNodes() {
+        let indices: [Int32] = [1, 2, 3, 4]
+        guard let poly = PolygonOnTriangulation.create(nodeIndices: indices) else { return }
+        #expect(poly.setNodes([5, 6, 7, 8]))
+        #expect(poly.nodeIndex(at: 0) == 5)
+        #expect(poly.nodeIndex(at: 3) == 8)
+        // Size mismatch must be rejected.
+        #expect(!poly.setNodes([1, 2]))
+    }
+
+    @Test("PolygonOnTriangulation setParameters mutates in place")
+    func polygonOnTriSetParameters() {
+        let indices: [Int32] = [1, 2, 3]
+        let params: [Double] = [0.0, 1.0, 2.0]
+        guard let poly = PolygonOnTriangulation.create(nodeIndices: indices, parameters: params) else { return }
+        #expect(poly.hasParameters)
+        #expect(poly.setParameters([10.0, 20.0, 30.0]))
+        #expect(abs(poly.parameter(at: 1) - 20.0) < 1e-12)
+        // Size mismatch rejected.
+        #expect(!poly.setParameters([1.0]))
+    }
+
+    @Test("setParameters fails when polygon has no parameters")
+    func setParametersWithoutParams() {
+        let indices: [Int32] = [1, 2, 3]
+        guard let poly = PolygonOnTriangulation.create(nodeIndices: indices) else { return }
+        #expect(!poly.hasParameters)
+        #expect(!poly.setParameters([0.0, 1.0, 2.0]))
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -4969,3 +4969,59 @@ struct DrawingSymbolsTests {
         #expect(detail.translate == SIMD2(200, 100))
     }
 }
+
+// MARK: - GeomFill Gordon report + NetworkSurface — OCCT 8.0.0p1
+
+@Suite("GeomFill — Gordon Report & Network Surface")
+struct GeomFillGordonReportTests {
+
+    private func makeNetwork() -> ([Curve3D], [Curve3D])? {
+        guard let p1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(5,0,0), SIMD3(10,0,0)]),
+              let p2 = Curve3D.interpolate(points: [SIMD3(0,10,0), SIMD3(5,10,0), SIMD3(10,10,0)]),
+              let g1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(0,5,0), SIMD3(0,10,0)]),
+              let g2 = Curve3D.interpolate(points: [SIMD3(10,0,0), SIMD3(10,5,0), SIMD3(10,10,0)])
+        else { return nil }
+        return ([p1, p2], [g1, g2])
+    }
+
+    @Test func gordonReportDoneForGoodNetwork() {
+        guard let (profiles, guides) = makeNetwork() else { return }
+        let result = Surface.gordonReport(profiles: profiles, guides: guides, tolerance: 1e-3)
+        #expect(result.status == .done)
+        #expect(result.surface != nil)
+        #expect(result.isApproximate == false)
+    }
+
+    @Test func gordonReportInvalidInput() {
+        guard let p1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(10,0,0)]) else { return }
+        let result = Surface.gordonReport(profiles: [p1], guides: [p1])
+        #expect(result.surface == nil)
+        #expect(result.status == .invalidInput)
+    }
+
+    @Test func gordonReportApproximateFallbackMode() {
+        guard let (profiles, guides) = makeNetwork() else { return }
+        // With fallback enabled a good network still builds; status must be a defined value.
+        let result = Surface.gordonReport(profiles: profiles, guides: guides,
+                                          tolerance: 1e-3, allowApproximateFallback: true)
+        #expect(result.status == .done)
+    }
+
+    @Test func networkSurfaceBuildsOrReportsStatus() {
+        guard let (profiles, guides) = makeNetwork() else { return }
+        let (surface, status) = Surface.networkSurface(profiles: profiles, guides: guides, tolerance: 1e-3)
+        // The low-level builder either produces a surface (status .done) or reports a
+        // defined non-.notStarted failure status — never silently returns notStarted.
+        #expect(status != .notStarted)
+        if status == .done {
+            #expect(surface != nil)
+        }
+    }
+
+    @Test func networkSurfaceTooFewCurves() {
+        guard let p1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(10,0,0)]) else { return }
+        let (surface, status) = Surface.networkSurface(profiles: [p1], guides: [p1])
+        #expect(surface == nil)
+        #expect(status == .invalidInput)
+    }
+}

--- a/Tests/OCCTTopologyGraphTests/OCCTTopologyGraphTests.swift
+++ b/Tests/OCCTTopologyGraphTests/OCCTTopologyGraphTests.swift
@@ -2328,3 +2328,133 @@ struct ContainedInTests {
         }
     }
 }
+
+// MARK: - Durable Identity (UID / RefUID / ItemUID) — OCCT 8.0.0p1
+
+@Suite("TopologyGraph Durable UID")
+struct TopologyGraphDurableUIDTests {
+    // Face kind ordinal in BRepGraph_NodeId::Kind is 2.
+    private let faceKind = 2
+
+    @Test func nodeUIDRoundTrip() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let graph = TopologyGraph(shape: box) else { return }
+        #expect(graph.faceCount == 6)
+
+        // Every face should yield a valid UID that round-trips back to the same node.
+        for i in 0..<graph.faceCount {
+            guard let uid = graph.uid(ofNodeKind: faceKind, index: i) else {
+                Issue.record("face \(i) had no UID")
+                continue
+            }
+            #expect(uid.isValid)
+            #expect(graph.contains(uid: uid))
+            if let resolved = graph.node(forUID: uid) {
+                #expect(resolved.kind == faceKind)
+                #expect(resolved.index == i)
+            } else {
+                Issue.record("UID for face \(i) did not resolve")
+            }
+        }
+    }
+
+    @Test func foreignUIDDoesNotResolve() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let graph = TopologyGraph(shape: box) else { return }
+
+        // A fabricated UID with a wildly out-of-range counter must not resolve.
+        let bogus = TopologyGraph.GraphUID(kind: faceKind, counter: 999_999)
+        #expect(!graph.contains(uid: bogus))
+        #expect(graph.node(forUID: bogus) == nil)
+
+        // The invalid sentinel (counter 0) is never valid.
+        let invalid = TopologyGraph.GraphUID(kind: faceKind, counter: 0)
+        #expect(!invalid.isValid)
+        #expect(!graph.contains(uid: invalid))
+    }
+
+    @Test func generationIsStable() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let graph = TopologyGraph(shape: box) else { return }
+        // Generation is a simple monotonic counter; reading it twice is stable.
+        let g1 = graph.generation
+        let g2 = graph.generation
+        #expect(g1 == g2)
+    }
+
+    @Test func itemUIDOfNode() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let graph = TopologyGraph(shape: box) else { return }
+        guard graph.faceCount > 0 else { return }
+
+        if let item = graph.itemUID(ofNodeKind: faceKind, index: 0) {
+            #expect(item.isValid)
+            #expect(item.domain == 1) // 1 == Node domain
+            if let resolved = graph.item(forUID: item) {
+                #expect(resolved.domain == 1)
+                #expect(resolved.kind == faceKind)
+                #expect(resolved.index == 0)
+            } else {
+                Issue.record("item UID did not resolve")
+            }
+        }
+    }
+}
+
+// MARK: - Supplement vertex attachments (un-stubbed against OCCT 8.0.0p1 TopoSupplement layer)
+//
+// Face-direct and edge-internal vertices are a supplemental, RUNTIME concept in 8.0.0p1
+// (BRepGraph_LayerTopoSupplement): a freshly built (clean) box graph has none until one is
+// attached via faceAddVertex / edgeAddInternalVertex. The returned value is a layer-local
+// attachment uid (not a core ref index); removal is by that uid.
+@Suite("TopologyGraph Supplement Vertices")
+struct TopologyGraphSupplementVertexTests {
+    @Test func faceDirectVertexAttachCountRemove() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)
+        guard let box else { Issue.record("box build failed"); return }
+        let graph = TopologyGraph(shape: box)
+        guard let graph else { Issue.record("graph build failed"); return }
+
+        // Clean box: no face-direct vertices until we add one.
+        #expect(graph.faceVertexRefCount(0) == 0)
+
+        let uid = graph.faceAddVertex(0, vertexIndex: 0)
+        #expect(uid != nil)
+        if let uid {
+            #expect(uid >= 0)
+            // The attachment now shows up in the FaceDirectVertex count for face 0.
+            #expect(graph.faceVertexRefCount(0) >= 1)
+
+            // Removing by the returned uid succeeds and drops the count back.
+            #expect(graph.faceRemoveVertex(0, attachmentUID: uid) == true)
+            #expect(graph.faceVertexRefCount(0) == 0)
+
+            // Removing the same uid again returns false (already gone).
+            #expect(graph.faceRemoveVertex(0, attachmentUID: uid) == false)
+        }
+    }
+
+    @Test func edgeInternalVertexAttach() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)
+        guard let box else { Issue.record("box build failed"); return }
+        let graph = TopologyGraph(shape: box)
+        guard let graph else { Issue.record("graph build failed"); return }
+
+        // Attaching an edge-internal vertex returns a non-nil layer-local uid.
+        let uid = graph.edgeAddInternalVertex(0, vertexIndex: 0)
+        #expect(uid != nil)
+        if let uid { #expect(uid >= 0) }
+    }
+
+    // FaceIsNaturalRestriction: honest read of NbWires == 0. p1 normalizes natural-bound faces
+    // (it always materializes a bounding wire) so a box face is NOT a natural-restriction face.
+    @Test func boxFacesNotNaturalRestriction() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)
+        guard let box else { Issue.record("box build failed"); return }
+        let graph = TopologyGraph(shape: box)
+        guard let graph else { Issue.record("graph build failed"); return }
+        for i in 0..<graph.faceCount {
+            #expect(graph.isFaceNaturalRestriction(i) == false)
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,47 @@ nav_order: 4
 
 All notable changes to OCCTSwift.
 
-## Current: v1.7.0
+## Current: v1.7.1
 
-**4,294 wrapped operations | macOS / iOS / visionOS / tvOS | OCCT 8.0.0p1**
+**macOS / iOS / visionOS / tvOS | OCCT 8.0.0p1**
 
 ---
 
 ## Release History
+
+### v1.7.1 (June 2026) — p1 follow-ups + xcframework header hygiene
+
+**Additive + a packaging fix.** New p1 operations and a corrected xcframework (no stale headers).
+
+#### New operations
+- **BRepGraph durable identity** — `TopologyGraph` UID/RefUID/ItemUID accessors (`uid(ofNodeKind:index:)`,
+  `node(forUID:)`, `contains(uid:)`, ref/item variants, `generation`) over `BRepGraph::UIDsView`, giving
+  persist-safe identifiers (the migration note's `UID`/`RefUID`/`ItemUID`, vs the non-durable NodeId/RefId).
+- **`Surface.networkSurface(profiles:guides:tolerance:)`** — wraps the new `GeomFill_NetworkSurface`
+  low-level Gordon builder, with a `NetworkSurfaceStatus`.
+- **`Surface.gordonReport(…)`** — exposes `GeomFill_Gordon`'s new `Status()`/`IsApproximate()` and the
+  `ExactOnly`/approximate-fallback `ApproximationMode` (`GordonResult` + `GordonResultStatus`).
+- **`Polygon2D.copy()`, `PolygonOnTriangulation.copy()/setNodes()/setParameters()`** — the new
+  `Poly_*` copy/mutator APIs.
+- **BRepGraph reads, now real:** `faceSameDomain(of:)` (derived from edge-incidence + surface equality),
+  face/edge adjacency & shared-edges (derived from first-class reverse relations), `faceIsNaturalRestriction`
+  (`Tool::Face::NbWires == 0`).
+- **BRepGraph vertex-supplement:** `faceAddVertex`/`edgeAddInternalVertex`/`faceRemoveVertex`/`faceNbVertexRefs`
+  now back onto the `BRepGraph_LayerTopoSupplement` layer (uid/shape-based; the v1.7.0 stubs were no-ops).
+
+#### Packaging fix — stale headers removed from the xcframework
+`build-occt.sh` reused the CMake install prefix across builds; `cmake --install` adds headers but never
+deletes removed ones, so **18 OCCT 8.0.0-GA headers** that p1 removed/renamed (e.g.
+`Approx_BSplineApproxInterp.hxx`, `BRepGraph_Builder/History/RepId/MeshCache/LayerRegularity.hxx`,
+`GeomFill_GordonBuilder.hxx`) **leaked into the v1.7.0 framework**, where they masqueraded as current
+API (their symbols were never in the library). The build script now wipes the install prefixes each run,
+and the v1.7.1 xcframework contains **only real p1 headers**. (Functionally harmless in v1.7.0 — the
+phantom headers had no symbols — but misleading.)
+
+> Note on edge regularity/continuity: one of those phantom headers (`BRepGraph_LayerRegularity`) made it
+> look like a graph-level regularity API existed in p1. It does not (p1 ships `BRepGraph_LayerParametric`
+> instead); `TopologyGraph.edgeMaxContinuity`/`setEdgeRegularity` remain no-ops. Use `Shape.maxContinuity`
+> (`BRep_Tool::MaxContinuity`) for edge continuity.
 
 ### v1.7.0 (June 2026) — OCCT 8.0.0p1 upgrade; BRepGraph realigned to its redesigned model
 


### PR DESCRIPTION
Follow-up to the OCCT 8.0.0p1 upgrade (v1.7.0): new operations + a corrected xcframework.

## New operations
- **BRepGraph durable identity** — `TopologyGraph` UID/RefUID/ItemUID accessors (`BRepGraph::UIDsView`), the persist-safe identifiers the p1 migration note recommends over NodeId/RefId.
- **`Surface.networkSurface`** (`GeomFill_NetworkSurface`) and **`Surface.gordonReport`** (`GeomFill_Gordon` Status/IsApproximate/ApproximationMode).
- **`Polygon2D.copy()`, `PolygonOnTriangulation.copy()/setNodes()/setParameters()`** (new `Poly_*` APIs).
- BRepGraph reads now real: `faceSameDomain` (derived), face/edge adjacency + shared-edges (reverse relations), `faceIsNaturalRestriction`.
- BRepGraph vertex-supplement (`faceAddVertex`/`edgeAddInternalVertex`/`faceRemoveVertex`/`faceNbVertexRefs`) backed by `BRepGraph_LayerTopoSupplement` (the v1.7.0 stubs were no-ops).

## Packaging fix — stale headers removed
`build-occt.sh` reused the CMake install prefix, so `cmake --install` leaked **18 OCCT 8.0.0-GA headers** that p1 removed/renamed (`Approx_BSplineApproxInterp`, `BRepGraph_Builder/History/RepId/MeshCache/LayerRegularity`, `GeomFill_GordonBuilder`, …) into the **v1.7.0** framework, where they masqueraded as current API (their symbols were never in the library — functionally harmless, but misleading). The script now wipes `occt-install-*` each run; the v1.7.1 xcframework contains **only real p1 headers** (the sole remaining install-only header is the generated `Standard_Version.hxx`).

> This also resolves the earlier confusion: `BRepGraph_LayerRegularity` was one of those phantom GA headers — there is **no** p1 graph regularity layer (p1 has `BRepGraph_LayerParametric`). `TopologyGraph.edgeMaxContinuity`/`setEdgeRegularity` remain no-ops; use `Shape.maxContinuity`.

## Transition
v1.7.1 re-attaches the OCCT 8.0.0 GA binary (`OCCT-8.0.0-GA.xcframework.zip`); pinning **OCCTSwift ≤ v1.6.3** still resolves GA from the untouched v1.3.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
