### PR TITLE
chore: onboard the Swift API to context7 (context7.json)

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "OCCTSwift",
+  "description": "Comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.0 — B-Rep solid modeling for macOS, iOS, visionOS and tvOS. Shapes, wires, surfaces, curves, booleans, fillets, sweeps, lofts, threads, healing, meshing, STEP/IGES/STL/glTF I/O, and XDE/OCAF assemblies.",
+  "folders": [
+    "docs",
+    "Sources/OCCTSwift"
+  ],
+  "excludeFolders": [
+    "Tests",
+    "Scripts",
+    "Libraries",
+    "Sources/OCCTBridge",
+    "Sources/OCCTTest"
+  ],
+  "rules": [
+    "Import the module with `import OCCTSwift`; the pre-built OCCT xcframework is bundled, no source build is needed.",
+    "Factory methods are static on the type: `Shape.box(...)`, `Shape.cylinder(...)`, `Wire.rectangle(...)`, `Curve3D.interpolate(...)`.",
+    "Fallible factories and operations return optionals — unwrap with `guard let` / `if let`, never force-unwrap.",
+    "Boolean operators on `Shape`: `a - b` subtract, `a + b` union, `a & b` intersect; method forms are `subtracting`, `union`, `intersection`.",
+    "Memory is handle-based with release-on-deinit — there is no manual free/release in Swift; just let values go out of scope.",
+    "`vertices()` is a method, not a property; edge indices may vary between runs, so iterate edges to find one when testing edge-specific operations.",
+    "Export via `Exporter` (e.g. `Exporter.writeSTEP`, `writeSTL`, `writeGLTF`); load assemblies via `Document.load(from:)`."
+  ]
+}


### PR DESCRIPTION
Adds a root `context7.json` so [context7](https://context7.com) indexes the **OCCTSwift Swift API** (the way it already indexes upstream OCCT at `/open-cascade-sas/occt`). First concrete step of issue #210's acceptance criterion #1.

## What it does

- **Scopes the crawl** to `docs/` (cookbook + guides + API reference) and `Sources/OCCTSwift` (the public Swift surface). Root `README.md` is always included.
- **Excludes** the test targets, the 20k-line C++ `OCCTBridge`, the OCCT xcframework, and build scripts — so the indexed content is the Swift API, not OCCT's C++ internals (which already have their own context7 entry).
- **Adds usage `rules`** so coding agents get correct OCCTSwift idioms: `import OCCTSwift`, static factories, optional unwrapping, boolean operators (`a - b` / `a + b` / `a & b`), and handle-based memory.

## Remaining steps (after merge)

context7 reads `context7.json` from the **default branch**, so this must merge first, then:

1. **Submit the repo** (keyless for public repos) at <https://context7.com/add-library?tab=github> with `https://github.com/gsdali/OCCTSwift` — indexing takes ~15–30 min.
2. *(optional)* **Claim the library** at `https://context7.com/gsdali/OCCTSwift/admin` for an admin panel + higher refresh limits.
3. *(optional)* Add the **context7 GitHub Action** to refresh on push (needs a `CONTEXT7_API_KEY` repo secret).

Then re-query context7 with a Swift-API question (e.g. *"how to subtract two shapes with a fuzzy value in OCCTSwift"*) to confirm the snippets are indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)