### PR TITLE
docs+test: #232 thread bounds are exact (Bnd_Box over-report)

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1755,7 +1755,14 @@ public final class Shape: @unchecked Sendable {
 
     // MARK: - Bounds
 
-    /// Get the axis-aligned bounding box of the shape
+    /// Get the axis-aligned bounding box of the shape.
+    ///
+    /// - Important: This is OCCT's **default** `Bnd_Box`, which for B-spline / faceted surfaces is
+    ///   the *control-point hull* — it can **over-report** the true extent (e.g. by ~one thread lead
+    ///   for a threaded shaft, OCCTSwift #232 / #213). For a tight extent use ``boundingBoxOptimal()``
+    ///   (`Bnd_Box::AddOptimal`), or — the unambiguous ground truth — the min/max of ``mesh(linearDeflection:angularDeflection:)``
+    ///   vertices. A `threadedShaft` / `threadedHole` solid is bounded *exactly* to its `length` / `depth`;
+    ///   `bounds` reporting past that is the hull artifact, not real geometry.
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         var minX: Double = 0, minY: Double = 0, minZ: Double = 0
         var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0

--- a/Tests/OCCTThreadTests/Issue232BoundsTests.swift
+++ b/Tests/OCCTThreadTests/Issue232BoundsTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #232: `threadedShaft(build: .boolean)` / `threadedHole` were reported to run ~one lead
+/// past `length`/`depth`. Investigation found the threaded **solid is bounded exactly to the
+/// requested span** — the overshoot is `Shape.bounds` (OCCT's default `Bnd_Box`) over-reporting for
+/// the B-spline/faceted thread surfaces (the control-hull artifact, cf. #213), not real geometry.
+///
+/// These tests lock that in using the **mesh-vertex extent** (the unambiguous ground truth: mesh
+/// vertices lie on the actual faces), not `bounds`.
+@Suite("Issue #232 — threaded solids are bounded exactly to length/depth")
+struct Issue232BoundsTests {
+
+    /// min/max along +Z of a shape's actual triangulated geometry.
+    static func meshZExtent(_ shape: Shape, deflection: Double = 0.1) -> (min: Double, max: Double)? {
+        guard let m = shape.mesh(linearDeflection: deflection) else { return nil }
+        let zs = m.vertices.map { Double($0.z) }
+        guard let lo = zs.min(), let hi = zs.max() else { return nil }
+        return (lo, hi)
+    }
+
+    @Test("External boolean thread spans exactly [0, length]")
+    func externalBooleanExact() {
+        let length = 60.0, pitch = 3.0
+        guard let rod = Shape.cylinder(radius: 6, height: length),
+              let t = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                        spec: ThreadSpec(form: .trapezoidal, nominalDiameter: 12, pitch: pitch),
+                                        length: length, build: .boolean),
+              let z = Self.meshZExtent(t) else {
+            Issue.record("build/mesh failed"); return
+        }
+        // Real geometry stays within the requested span (no overshoot past the faces)…
+        #expect(z.min >= -0.05)
+        #expect(z.max <= length + 0.05)
+        // …and the thread actually reaches both ends (not trimmed short).
+        #expect(z.min < pitch)
+        #expect(z.max > length - pitch)
+    }
+
+    @Test("ISO-68 external boolean thread spans exactly [0, length]")
+    func iso68BooleanExact() {
+        let length = 30.0, pitch = 1.5
+        guard let rod = Shape.cylinder(radius: 5, height: length),
+              let t = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                        spec: ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: pitch),
+                                        length: length, build: .boolean),
+              let z = Self.meshZExtent(t) else {
+            Issue.record("build/mesh failed"); return
+        }
+        #expect(z.min >= -0.05)
+        #expect(z.max <= length + 0.05)
+        #expect(z.max > length - pitch)
+    }
+
+    @Test("Internal threaded hole stays within the block faces")
+    func internalHoleExact() {
+        let depth = 8.4
+        let r = 9.5 / 3.0.squareRoot()
+        let pts = (0..<6).map { i -> SIMD2<Double> in
+            let a = Double(i) * .pi / 3 + .pi / 6; return SIMD2(r * cos(a), r * sin(a))
+        }
+        guard let hex = Wire.polygon(pts),
+              let prism = Shape.extrude(profile: hex, direction: SIMD3(0, 0, 1), length: depth),
+              let bore = Shape.cylinder(at: SIMD3(0, 0, -1), direction: SIMD3(0, 0, 1), radius: 5, height: depth + 2),
+              let block = prism.subtracting(bore),
+              let nut = block.threadedHole(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                           spec: ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.5), depth: depth),
+              let z = Self.meshZExtent(nut) else {
+            Issue.record("build/mesh failed"); return
+        }
+        // The thread can't poke past the block's flat faces.
+        #expect(z.min >= -0.05)
+        #expect(z.max <= depth + 0.05)
+    }
+}


### PR DESCRIPTION
Investigation of #232 — `threadedShaft(build: .boolean)` / `threadedHole` reported to run ~one lead past `length`/`depth`.

## Finding: not a geometry bug

The threaded **solid is bounded exactly to the requested span**. The reported overshoot is `Shape.bounds` (OCCT's default `Bnd_Box`) over-reporting for the B-spline/faceted thread surfaces — the control-hull artifact already documented for #213 — not real geometry.

Confirmed three ways:

| case | requested | **mesh-vertex extent (ground truth)** | `.bounds` (artifact) |
|---|---|---|---|
| External Tr12×3 `.boolean` | z 0…60 | **0.0 … 60.0** | −0.95 … 60.95 |
| Internal M10 nut | z 0…8.4 | **0.0 … 8.4** | −0.30 … 8.77 |

(An attempted "over-build the cutter past the ends" change left the *real* extent unchanged at `[0, length]` while only inflating `.bounds` — so it was reverted; **no behavior change** here.)

## Changes

- **`Shape.bounds` doc** now warns it over-reports for curved/faceted geometry (threads especially) and points to `boundingBoxOptimal()` / the mesh-vertex extent for a true measure.
- **`Issue232BoundsTests`** asserts the mesh-vertex Z extent is exactly `[0, length]` (external `.boolean`, ISO-68 + Tr) and within the block (internal hole) — locking in the correct behavior.

Issue #232 is **left open** for now (the reporter may have more detail, e.g. a STEP-viewer measurement to reconcile); this PR documents and guards the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)