### PR TITLE
feat(surface): face from surface bounded by a wire / UV polygon (#233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,288 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,290 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 
@@ -76,7 +76,7 @@ OCCTSwift provides method-level coverage of all user-facing OCCT classes. Key ar
 | Wires & Edges | 56 | rectangle, circle, polygon, arc, BSpline, NURBS, helix, fillet2D, chamfer2D |
 | 2D Curves | 97 | full Geom2d — lines, conics, BSplines, Bezier, Gcc constraint solver, hatching |
 | 3D Curves | 84 | full Geom — lines, conics, BSplines, Bezier, interpolation, projection, evaluation |
-| Surfaces | 86 | analytic, swept, freeform, plate, NLPlate, curvature, projection, trimming |
+| Surfaces | 88 | analytic, swept, freeform, plate, NLPlate, curvature, projection, trimming (rectangular UV, UV-polygon, or 3D-wire bounded) |
 | Face / Edge Analysis | 54 | UV queries, normals, curvature, projection, classification, primary axis, surface type predicates |
 | Feature-Based | 36 | boss, pocket, drill, split, pattern, rib, revolution, draft prism |
 | Healing & Analysis | 69 | fix, unify, simplify, NURBS convert, sew, wire/face/shell repair |

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -4426,6 +4426,17 @@ OCCTShapeRef OCCTShapeCreateFaceFromSurface(OCCTSurfaceRef surface,
                                              double vMin, double vMax,
                                              double tolerance);
 
+/// Build a face on a surface trimmed to a non-rectangular region given by a closed UV-space
+/// boundary polygon (uv = [u0,v0,u1,v1,...], `count` points, >= 3). #233.
+/// @return Trimmed face shape, or NULL on failure.
+OCCTShapeRef OCCTShapeCreateFaceFromSurfaceUVPolygon(OCCTSurfaceRef surface,
+                                                     const double* uv, int32_t count);
+
+/// Build a face from a surface bounded by a 3D wire lying (approximately) on it; pcurves are
+/// projected via ShapeFix_Face. #233.
+/// @return Trimmed face shape, or NULL on failure.
+OCCTShapeRef OCCTShapeCreateFaceFromSurfaceWire(OCCTSurfaceRef surface, OCCTWireRef wire);
+
 
 // MARK: - Edges to Faces (v0.33.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -167,6 +167,9 @@
 #include <BRepBuilderAPI_MakeSolid.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
+#include <GCE2d_MakeSegment.hxx>
+#include <Geom2d_TrimmedCurve.hxx>
+#include <ShapeFix_Face.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
 #include <Geom_Circle.hxx>
 #include <Geom_TrimmedCurve.hxx>
@@ -2105,6 +2108,59 @@ OCCTShapeRef OCCTShapeCreateFaceFromSurface(OCCTSurfaceRef surface,
         BRepBuilderAPI_MakeFace maker(surface->surface, uMin, uMax, vMin, vMax, tolerance);
         if (!maker.IsDone()) return nullptr;
         return new OCCTShape(maker.Face());
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+// Build a face on a surface trimmed to a non-rectangular region given by a closed UV-space
+// polygon (uv = [u0,v0,u1,v1,...], count points). Each segment becomes a 2D edge with a pcurve
+// on the surface, so the face footprint follows the polygon rather than a rectangular UV patch
+// (OCCTSwift #233). Returns NULL on failure.
+OCCTShapeRef OCCTShapeCreateFaceFromSurfaceUVPolygon(OCCTSurfaceRef surface,
+                                                     const double* uv, int32_t count) {
+    if (!surface || surface->surface.IsNull() || !uv || count < 3) return nullptr;
+    try {
+        Handle(Geom_Surface) surf = surface->surface;
+        BRepBuilderAPI_MakeWire wireMaker;
+        for (int32_t i = 0; i < count; i++) {
+            int32_t j = (i + 1) % count;
+            gp_Pnt2d a(uv[2 * i], uv[2 * i + 1]);
+            gp_Pnt2d b(uv[2 * j], uv[2 * j + 1]);
+            if (a.Distance(b) < Precision::Confusion()) continue;   // skip degenerate segment
+            Handle(Geom2d_TrimmedCurve) seg = GCE2d_MakeSegment(a, b).Value();
+            TopoDS_Edge e = BRepBuilderAPI_MakeEdge(seg, surf).Edge();
+            wireMaker.Add(e);
+        }
+        if (!wireMaker.IsDone()) return nullptr;
+        BRepBuilderAPI_MakeFace faceMaker(surf, wireMaker.Wire(), Standard_True);
+        if (!faceMaker.IsDone()) return nullptr;
+        TopoDS_Face face = faceMaker.Face();
+        BRepLib::BuildCurves3d(face);   // add 3D curves from the pcurves
+        return new OCCTShape(face);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+// Build a face from a surface bounded by a 3D wire that (approximately) lies on the surface.
+// The wire's edges may lack pcurves, so ShapeFix_Face projects them onto the surface. Returns
+// NULL on failure (OCCTSwift #233).
+OCCTShapeRef OCCTShapeCreateFaceFromSurfaceWire(OCCTSurfaceRef surface, OCCTWireRef wire) {
+    if (!surface || surface->surface.IsNull() || !wire || wire->wire.IsNull()) return nullptr;
+    try {
+        Handle(Geom_Surface) surf = surface->surface;
+        BRepBuilderAPI_MakeFace faceMaker(surf, wire->wire, Standard_True);
+        if (!faceMaker.IsDone()) return nullptr;
+        TopoDS_Face face = faceMaker.Face();
+        // The 3D wire's edges likely have no pcurves on this surface — project to add them.
+        ShapeFix_Face fixer(face);
+        fixer.Perform();
+        TopoDS_Face fixed = fixer.Face();
+        BRepLib::BuildCurves3d(fixed);
+        BRepCheck_Analyzer chk(fixed);
+        if (!chk.IsValid()) return nullptr;
+        return new OCCTShape(fixed);
     } catch (...) {
         return nullptr;
     }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -4247,6 +4247,45 @@ extension Shape {
                                                       tolerance) else { return nil }
         return Shape(handle: h)
     }
+
+    /// Create a face from a surface bounded by a **3D wire**, trimming the surface to the wire's
+    /// footprint. Useful for reconstruction: trim a fitted analytic surface (cylinder / cone /
+    /// sphere / B-spline) to a region's real boundary instead of a rectangular UV patch.
+    ///
+    /// Two strategies, tried in order:
+    /// 1. If the wire genuinely lies on the surface (its edges have, or admit, pcurves), build the
+    ///    face directly (`BRepBuilderAPI_MakeFace` + `ShapeFix_Face` to project pcurves) — exact.
+    /// 2. Otherwise (e.g. a sampled boundary polyline whose straight chords don't lie on the
+    ///    surface), project the wire's ordered points onto the surface's UV and trim by that
+    ///    polygon — robust, the same path as ``Surface/toFace(uvBoundary:)``.
+    ///
+    /// If you already have the boundary in UV space, call ``Surface/toFace(uvBoundary:)`` directly.
+    ///
+    /// - Parameters:
+    ///   - surface: The parametric surface to trim.
+    ///   - boundary: A closed wire on (or near) the surface.
+    /// - Returns: The trimmed face, or nil on failure. Note: a boundary crossing a periodic seam
+    ///   (e.g. the u = 0/2π seam of a cylinder) isn't handled by the projection fallback.
+    public static func face(from surface: Surface, boundary: Wire) -> Shape? {
+        // 1) Exact: the wire lies on the surface.
+        if let h = OCCTShapeCreateFaceFromSurfaceWire(surface.handle, boundary.handle) {
+            return Shape(handle: h)
+        }
+        // 2) Fallback: project the wire's ordered boundary points to UV and trim by that polygon.
+        var uv: [SIMD2<Double>] = []
+        for i in 0..<boundary.orderedEdgeCount {
+            guard let pts = boundary.orderedEdgePoints(at: i) else { continue }
+            for p in pts {
+                guard let proj = surface.projectPoint(p) else { continue }
+                let q = SIMD2(proj.u, proj.v)
+                if let last = uv.last, simd_distance(last, q) < 1e-9 { continue }   // dedup shared vertices
+                uv.append(q)
+            }
+        }
+        if let f = uv.first, let l = uv.last, simd_distance(f, l) < 1e-9 { uv.removeLast() }
+        guard uv.count >= 3 else { return nil }
+        return surface.toFace(uvBoundary: uv)
+    }
 }
 
 // MARK: - Edges to Faces (v0.33.0)

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1755,7 +1755,14 @@ public final class Shape: @unchecked Sendable {
 
     // MARK: - Bounds
 
-    /// Get the axis-aligned bounding box of the shape
+    /// Get the axis-aligned bounding box of the shape.
+    ///
+    /// - Important: This is OCCT's **default** `Bnd_Box`, which for B-spline / faceted surfaces is
+    ///   the *control-point hull* — it can **over-report** the true extent (e.g. by ~one thread lead
+    ///   for a threaded shaft, OCCTSwift #232 / #213). For a tight extent use ``boundingBoxOptimal()``
+    ///   (`Bnd_Box::AddOptimal`), or — the unambiguous ground truth — the min/max of ``mesh(linearDeflection:angularDeflection:)``
+    ///   vertices. A `threadedShaft` / `threadedHole` solid is bounded *exactly* to its `length` / `depth`;
+    ///   `bounds` reporting past that is the hull artifact, not real geometry.
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         var minX: Double = 0, minY: Double = 0, minZ: Double = 0
         var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -879,6 +879,26 @@ extension Surface {
         return Shape.face(from: self, uRange: uRange, vRange: vRange, tolerance: tolerance)
     }
 
+    /// Create a face trimmed to a **non-rectangular** region of this surface, given by a closed
+    /// boundary polygon in **UV space** (≥ 3 points, e.g. `[SIMD2(u,v), …]`). Each segment becomes
+    /// a 2D edge carrying a pcurve on the surface, so the face footprint follows the polygon —
+    /// unlike ``toFace(uRange:vRange:tolerance:)``, which can only make a rectangular UV patch.
+    ///
+    /// Ideal for reconstructing a fitted analytic surface (cylinder / cone / sphere / B-spline)
+    /// trimmed to a region's real boundary rather than over-extending to the UV bounding box.
+    ///
+    /// - Parameter uvBoundary: Closed polygon of `(u, v)` points (the closing segment is implicit).
+    /// - Returns: The trimmed face, or nil on failure.
+    public func toFace(uvBoundary: [SIMD2<Double>]) -> Shape? {
+        guard uvBoundary.count >= 3 else { return nil }
+        var flat = [Double](); flat.reserveCapacity(uvBoundary.count * 2)
+        for p in uvBoundary { flat.append(p.x); flat.append(p.y) }
+        guard let h = flat.withUnsafeBufferPointer({ buf in
+            OCCTShapeCreateFaceFromSurfaceUVPolygon(handle, buf.baseAddress, Int32(uvBoundary.count))
+        }) else { return nil }
+        return Shape(handle: h)
+    }
+
     // MARK: - Surface-Surface Intersection (v0.35.0)
 
     /// Compute intersection curves between this surface and another.

--- a/Tests/OCCTSurfaceTests/Issue233FaceFromSurfaceWireTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue233FaceFromSurfaceWireTests.swift
@@ -1,0 +1,50 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #233: build a face from a surface trimmed to a non-rectangular region — a UV-space
+/// boundary polygon (`Surface.toFace(uvBoundary:)`) or a 3D boundary wire (`Shape.face(from:boundary:)`).
+@Suite("Issue #233 — face from surface bounded by a wire")
+struct Issue233FaceFromSurfaceWireTests {
+
+    @Test("UV-polygon trims a cylinder to a non-rectangular footprint")
+    func uvPolygonTrimsCylinder() {
+        guard let cyl = Surface.cylindricalSurface(radius: 5) else { Issue.record("surface"); return }
+        // A non-rectangular region in (u = angle, v = height).
+        let region: [SIMD2<Double>] = [SIMD2(0.2, 0), SIMD2(2.0, 1), SIMD2(1.5, 6), SIMD2(0.0, 4)]
+        guard let face = cyl.toFace(uvBoundary: region) else { Issue.record("toFace(uvBoundary:)"); return }
+        #expect(face.isValid)
+        guard let trimmedArea = face.surfaceArea else { Issue.record("area"); return }
+        #expect(trimmedArea > 0)
+
+        // The rectangular UV patch over the polygon's bounding box (u 0…2, v 0…6) is strictly larger
+        // — confirming the face follows the polygon, not the box.
+        if let rect = cyl.toFace(uRange: 0...2, vRange: 0...6), let rectArea = rect.surfaceArea {
+            #expect(trimmedArea < rectArea)          // non-rectangular trim removed area
+            #expect(trimmedArea > rectArea * 0.4)    // …but it's a real region, not collapsed
+        }
+    }
+
+    @Test("UV-polygon needs at least 3 points")
+    func uvPolygonTooFew() {
+        guard let cyl = Surface.cylindricalSurface(radius: 5) else { Issue.record("surface"); return }
+        #expect(cyl.toFace(uvBoundary: [SIMD2(0, 0), SIMD2(1, 1)]) == nil)
+    }
+
+    @Test("3D wire on the surface trims it (face(from:boundary:))")
+    func wireBoundaryTrimsCylinder() {
+        guard let cyl = Surface.cylindricalSurface(radius: 5) else { Issue.record("surface"); return }
+        // A closed 3D wire whose vertices lie on the cylinder (radius 5, axis Z).
+        let pts: [SIMD3<Double>] = [(0.2, 0.0), (2.0, 1.0), (1.5, 6.0), (0.0, 4.0)].map { (a, h) in
+            SIMD3(5 * cos(a), 5 * sin(a), h)
+        }
+        guard let wire = Wire.polygon3D(pts, closed: true) else { Issue.record("wire"); return }
+        // The straight chords don't lie on the cylinder, so the exact path declines — but the
+        // projection fallback (project ordered points → UV → trim) builds a valid trimmed face.
+        guard let face = Shape.face(from: cyl, boundary: wire) else {
+            Issue.record("face(from:boundary:) returned nil"); return
+        }
+        #expect(face.isValid)
+        if let a = face.surfaceArea { #expect(a > 0) }
+    }
+}

--- a/Tests/OCCTThreadTests/Issue232BoundsTests.swift
+++ b/Tests/OCCTThreadTests/Issue232BoundsTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #232: `threadedShaft(build: .boolean)` / `threadedHole` were reported to run ~one lead
+/// past `length`/`depth`. Investigation found the threaded **solid is bounded exactly to the
+/// requested span** — the overshoot is `Shape.bounds` (OCCT's default `Bnd_Box`) over-reporting for
+/// the B-spline/faceted thread surfaces (the control-hull artifact, cf. #213), not real geometry.
+///
+/// These tests lock that in using the **mesh-vertex extent** (the unambiguous ground truth: mesh
+/// vertices lie on the actual faces), not `bounds`.
+@Suite("Issue #232 — threaded solids are bounded exactly to length/depth")
+struct Issue232BoundsTests {
+
+    /// min/max along +Z of a shape's actual triangulated geometry.
+    static func meshZExtent(_ shape: Shape, deflection: Double = 0.1) -> (min: Double, max: Double)? {
+        guard let m = shape.mesh(linearDeflection: deflection) else { return nil }
+        let zs = m.vertices.map { Double($0.z) }
+        guard let lo = zs.min(), let hi = zs.max() else { return nil }
+        return (lo, hi)
+    }
+
+    @Test("External boolean thread spans exactly [0, length]")
+    func externalBooleanExact() {
+        let length = 60.0, pitch = 3.0
+        guard let rod = Shape.cylinder(radius: 6, height: length),
+              let t = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                        spec: ThreadSpec(form: .trapezoidal, nominalDiameter: 12, pitch: pitch),
+                                        length: length, build: .boolean),
+              let z = Self.meshZExtent(t) else {
+            Issue.record("build/mesh failed"); return
+        }
+        // Real geometry stays within the requested span (no overshoot past the faces)…
+        #expect(z.min >= -0.05)
+        #expect(z.max <= length + 0.05)
+        // …and the thread actually reaches both ends (not trimmed short).
+        #expect(z.min < pitch)
+        #expect(z.max > length - pitch)
+    }
+
+    @Test("ISO-68 external boolean thread spans exactly [0, length]")
+    func iso68BooleanExact() {
+        let length = 30.0, pitch = 1.5
+        guard let rod = Shape.cylinder(radius: 5, height: length),
+              let t = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                        spec: ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: pitch),
+                                        length: length, build: .boolean),
+              let z = Self.meshZExtent(t) else {
+            Issue.record("build/mesh failed"); return
+        }
+        #expect(z.min >= -0.05)
+        #expect(z.max <= length + 0.05)
+        #expect(z.max > length - pitch)
+    }
+
+    @Test("Internal threaded hole stays within the block faces")
+    func internalHoleExact() {
+        let depth = 8.4
+        let r = 9.5 / 3.0.squareRoot()
+        let pts = (0..<6).map { i -> SIMD2<Double> in
+            let a = Double(i) * .pi / 3 + .pi / 6; return SIMD2(r * cos(a), r * sin(a))
+        }
+        guard let hex = Wire.polygon(pts),
+              let prism = Shape.extrude(profile: hex, direction: SIMD3(0, 0, 1), length: depth),
+              let bore = Shape.cylinder(at: SIMD3(0, 0, -1), direction: SIMD3(0, 0, 1), radius: 5, height: depth + 2),
+              let block = prism.subtracting(bore),
+              let nut = block.threadedHole(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                           spec: ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.5), depth: depth),
+              let z = Self.meshZExtent(nut) else {
+            Issue.record("build/mesh failed"); return
+        }
+        // The thread can't poke past the block's flat faces.
+        #expect(z.min >= -0.05)
+        #expect(z.max <= depth + 0.05)
+    }
+}


### PR DESCRIPTION
Closes #233 — build a face from a surface trimmed to a **non-rectangular** region, instead of only a rectangular UV patch (`toFace(uRange:vRange:)`).

## API

- **`Surface.toFace(uvBoundary: [SIMD2<Double>])`** — a closed UV-space boundary polygon (≥3 pts). Each segment becomes a 2D edge with a pcurve on the surface → `BRepBuilderAPI_MakeFace(surf, wire)` + `BuildCurves3d`. The robust primary path, and the direct fit for reconstruction (which has UV polygons).
- **`Shape.face(from: Surface, boundary: Wire)`** — a 3D boundary wire. Tries the exact `MakeFace` + `ShapeFix_Face` (pcurve projection) for wires that lie on the surface; **falls back to projecting the wire's ordered points to UV** and trimming by that polygon — so it handles sampled boundary polylines whose straight chords don't lie on the surface (the OCCTReconstruct case). Seam-crossing boundaries aren't handled by the fallback (documented).

## Verification

Ground-truthed against the kernel first (cylinder region: trimmed area **39.75** vs **60** for the full UV box). Tests (`Issue233FaceFromSurfaceWireTests`, all pass):
- UV polygon yields a valid face whose area is strictly between the full UV patch and collapsed.
- `< 3` points → nil.
- 3D chord-polyline wire → valid trimmed face via the projection fallback.

Bridge: `OCCTShapeCreateFaceFromSurfaceUVPolygon`, `OCCTShapeCreateFaceFromSurfaceWire` (additive). README Surfaces 86→88, total 4,290. No xcframework change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)