### PR TITLE
fix(modeling): faceAddHole rejects degenerate hole wires (#234)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -7321,8 +7321,37 @@ OCCTShapeRef OCCTMakeFaceFromSurfaceWire(OCCTSurfaceRef surface, OCCTShapeRef wi
 OCCTShapeRef OCCTMakeFaceAddHole(OCCTShapeRef face, OCCTShapeRef wire) {
     if (!face || !wire) return nullptr;
     try {
+        TopoDS_Wire w = TopoDS::Wire(wire->shape);
+
+        // #234: reject a DEGENERATE hole wire (fewer than 3 distinct vertices, or all-collinear =
+        // zero enclosed area). Adding such a wire yields a non-nil-but-invalid face; extruding it
+        // gives an invalid prism that SIGSEGVs OCCT's ShapeFix (`healed()`) downstream — an OS
+        // signal the bridge's catch(...) cannot recover. Failing here (return nil) breaks the chain.
+        TopTools_IndexedMapOfShape vmap;
+        TopExp::MapShapes(w, TopAbs_VERTEX, vmap);
+        std::vector<gp_Pnt> pts;
+        for (int i = 1; i <= vmap.Extent(); i++) {
+            gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(vmap(i)));
+            bool dup = false;
+            for (const gp_Pnt& q : pts) { if (q.Distance(p) < Precision::Confusion()) { dup = true; break; } }
+            if (!dup) pts.push_back(p);
+        }
+        if (pts.size() < 3) return nullptr;                     // sub-3-distinct-vertex → degenerate
+        // Collinearity (zero area): farthest pair defines a line; if every point lies on it, reject.
+        gp_Pnt a = pts[0], b = pts[0];
+        double maxd = 0;
+        for (const gp_Pnt& p : pts) { double d = a.Distance(p); if (d > maxd) { maxd = d; b = p; } }
+        if (maxd < Precision::Confusion()) return nullptr;      // all coincident
+        gp_Vec dir(a, b); dir.Normalize();
+        double maxPerp = 0;
+        for (const gp_Pnt& p : pts) {
+            double perp = gp_Vec(a, p).Crossed(dir).Magnitude();   // perpendicular distance to the line
+            if (perp > maxPerp) maxPerp = perp;
+        }
+        if (maxPerp < Precision::Confusion()) return nullptr;   // collinear → zero-area → degenerate
+
         BRepBuilderAPI_MakeFace mf(TopoDS::Face(face->shape));
-        mf.Add(TopoDS::Wire(wire->shape));
+        mf.Add(w);
         if (!mf.IsDone()) return nullptr;
         auto result = new OCCTShape();
         result->shape = mf.Shape();

--- a/Tests/OCCTModelingTests/Issue234DegenerateHoleTests.swift
+++ b/Tests/OCCTModelingTests/Issue234DegenerateHoleTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #234: `faceAddHole` accepted a degenerate (2-vertex / zero-area) hole wire, producing an
+/// invalid prism that then SIGSEGV'd OCCT's `ShapeFix` (`healed()`) — an uncatchable OS signal.
+/// Fix: `faceAddHole` rejects degenerate hole wires (returns nil), breaking the crash chain at the
+/// source. These tests guard that (and that valid holes still work).
+@Suite("Issue #234 — faceAddHole rejects degenerate hole wires")
+struct Issue234DegenerateHoleTests {
+
+    /// The exact reproducer from the issue: a 2-vertex outer loop + a 2-vertex (zero-area) hole.
+    @Test("Degenerate 2-vertex hole wire is rejected (was a healed() SIGSEGV)")
+    func degenerateHoleRejected() {
+        let p0 = SIMD3<Double>(22.2519, 89.7903, -124.5146)
+        let p1 = SIMD3<Double>(22.2500, 89.7480, -124.5146)
+        let h0 = SIMD3<Double>(22.9525, 89.6252, -124.5146)
+        let h1 = SIMD3<Double>(22.9460, 89.7480, -124.5146)
+        guard let w = Wire.polygon3D([p0, p1], closed: true),
+              let face = Shape.face(from: w, planar: true),
+              let hw = Wire.polygon3D([h0, h1], closed: true),
+              let hs = Shape.fromWire(hw) else { Issue.record("setup"); return }
+        // The fix: faceAddHole declines the degenerate hole instead of returning an invalid face
+        // (whose prism would SIGSEGV healed()). No crash; graceful nil.
+        #expect(Shape.faceAddHole(face: face, wire: hs) == nil)
+    }
+
+    /// A collinear (3-vertex, zero-area) hole is also rejected.
+    @Test("Collinear zero-area hole wire is rejected")
+    func collinearHoleRejected() {
+        guard let outer = Wire.polygon3D([SIMD3(0,0,0), SIMD3(10,0,0), SIMD3(10,10,0), SIMD3(0,10,0)], closed: true),
+              let face = Shape.face(from: outer, planar: true),
+              let hw = Wire.polygon3D([SIMD3(2,5,0), SIMD3(5,5,0), SIMD3(8,5,0)], closed: true),  // collinear
+              let hs = Shape.fromWire(hw) else { Issue.record("setup"); return }
+        #expect(Shape.faceAddHole(face: face, wire: hs) == nil)
+    }
+
+    /// A valid (non-degenerate) hole still works and heals without crashing — regression guard.
+    @Test("Valid hole still produces a healable solid")
+    func validHoleStillWorks() {
+        guard let outer = Wire.polygon3D([SIMD3(0,0,0), SIMD3(10,0,0), SIMD3(10,10,0), SIMD3(0,10,0)], closed: true),
+              let face = Shape.face(from: outer, planar: true),
+              let hw = Wire.polygon3D([SIMD3(3,3,0), SIMD3(7,3,0), SIMD3(5,7,0)], closed: true),  // real triangle
+              let hs = Shape.fromWire(hw),
+              let holed = Shape.faceAddHole(face: face, wire: hs) else {
+            Issue.record("valid hole rejected by the guard (over-rejection regression)"); return
+        }
+        // The fix didn't break the accept-path: a real triangular hole is still added (non-nil above),
+        // and the downstream extrude + heal complete without crashing (the heal may return nil).
+        let prism = holed.extruded(by: SIMD3(0, 0, 2))
+        _ = prism?.healed()   // must not SIGSEGV
+        #expect(prism != nil)
+    }
+}


### PR DESCRIPTION
Fixes the reported crash in #234.

## Root cause

`Shape.faceAddHole` (`OCCTMakeFaceAddHole`) accepted a **degenerate** hole wire (2-vertex / zero-area / collinear) and returned a non-nil but invalid face. Extruding it gave an invalid prism that **SIGSEGV'd OCCT's `ShapeFix`** when `Shape.healed()` ran — an OS signal the bridge `catch(...)` can't recover, and uncatchable in-process. Reproduced exactly (the issue's slab coordinates crash every run).

## Fix

Guard at the source: `OCCTMakeFaceAddHole` now rejects a hole wire with **< 3 distinct vertices** or **all-collinear (zero-area)** points, returning `nil`. The invalid prism is never built, so the uncatchable `healed()` crash never fires.

This addresses the issue's first (and root) ask. The second — "`healed()` should never SIGSEGV on *any* invalid input" — can't be fully defended in-process (the fault is inside OCCT's uncatchable `ShapeFix`); guarding the construction that produces such input is the robust fix.

## Tests (`Issue234DegenerateHoleTests`, all pass)
- The exact 2-vertex reproducer hole → `faceAddHole` returns nil (was the SIGSEGV).
- A collinear 3-vertex (zero-area) hole → rejected.
- A real triangular hole → still accepted; extrude + heal complete without crashing (no over-rejection regression).

Bridge-only change (no new op, no README count change, no xcframework change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)