### PR TITLE
docs(reference): API reference batch 1 — Edge, Face, Mesh, Exporter, ThreadFeatures

### DIFF
--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -1,0 +1,877 @@
+---
+title: Edge
+parent: API Reference
+---
+
+# Edge
+
+An `Edge` is a bounded curve in 3D space — the Swift analog of OCCT's `TopoDS_Edge`. Edges are the one-dimensional elements of B-Rep topology: each edge carries a `Geom_Curve` trimmed to a parameter range, and connects two vertices. Obtain edges by calling `shape.edges()`, `shape.edge(at:)`, or by constructing a `Wire` and extracting via `wire.edges()`.
+
+## Topics
+
+- [Initializers](#initializers) · [Properties](#properties) · [3D Curve Properties](#3d-curve-properties) · [Sampling](#sampling) · [Shape Extension for Edge Access](#shape-extension-for-edge-access) · [Edge Analysis](#edge-analysis) · [Curve Approximation](#curve-approximation) · [Edge Splitting](#edge-splitting) · [PCurve / BRepAdaptor\_Curve2d](#pcurve--brepadaptor_curve2d)
+
+---
+
+## Initializers
+
+### `Edge.init?(_ shape:)`
+
+Constructs an `Edge` by extracting the edge topology from a `Shape`. Returns `nil` if `shape` is null or wraps a non-edge topology type.
+
+```swift
+public convenience init?(_ shape: Shape)
+```
+
+Use when you have an edge-typed `Shape` (e.g. from sub-shape iteration) and need the typed `Edge` object.
+
+- **Parameters:** `shape` — a `Shape` wrapping a `TopoDS_Edge`.
+- **Returns:** `nil` if `shape` is null or its topology type is not `TopAbs_EDGE`.
+- **OCCT:** `TopoDS::Edge` — casts the underlying `TopoDS_Shape` after checking `ShapeType() == TopAbs_EDGE`.
+- **Example:**
+  ```swift
+  let shapes = box.subShapes(ofType: .edge)
+  if let edge = Edge(shapes[0]) {
+      print(edge.length)
+  }
+  ```
+
+---
+
+## Properties
+
+### `index`
+
+The index of this edge within the parent shape, or `-1` if the edge was created standalone.
+
+```swift
+public let index: Int
+```
+
+Reflects the 0-based position at which `shape.edge(at:)` returned this edge. Set to `-1` for edges obtained via `Edge(_ shape:)`.
+
+- **Example:**
+  ```swift
+  let edge = box.edge(at: 3)!
+  print(edge.index)  // 3
+  ```
+
+---
+
+### `length`
+
+The arc length of the edge.
+
+```swift
+public var length: Double { get }
+```
+
+- **Returns:** Length in model units. Returns `0` for degenerate or null edges.
+- **OCCT:** `BRepGProp::LinearProperties` — computes linear mass (= arc length) of the edge.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let edge = box.edge(at: 0)!
+  print(edge.length)  // 10.0
+  ```
+
+---
+
+### `bounds`
+
+The axis-aligned bounding box of the edge.
+
+```swift
+public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) { get }
+```
+
+- **Returns:** Tuple of the AABB min and max corners. Returns `(.zero, .zero)` on failure.
+- **OCCT:** `BRepBndLib::Add` + `Bnd_Box::Get`.
+- **Example:**
+  ```swift
+  let b = box.edge(at: 0)!.bounds
+  // b.min and b.max define the bounding box of that edge
+  ```
+
+---
+
+### `isLine`
+
+Whether this edge's underlying curve is a straight line.
+
+```swift
+public var isLine: Bool { get }
+```
+
+- **OCCT:** `BRepAdaptor_Curve::GetType()` compared to `GeomAbs_Line`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let hasLines = box.edges().contains(where: \.isLine)
+  ```
+
+---
+
+### `isCircle`
+
+Whether this edge's underlying curve is a full or partial circle.
+
+```swift
+public var isCircle: Bool { get }
+```
+
+- **OCCT:** `BRepAdaptor_Curve::GetType()` compared to `GeomAbs_Circle`.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  let circEdge = cyl.edges().first(where: \.isCircle)
+  ```
+
+---
+
+### `endpoints`
+
+The start and end 3D points of the edge (its bounding vertices).
+
+```swift
+public var endpoints: (start: SIMD3<Double>, end: SIMD3<Double>) { get }
+```
+
+Extracts the vertex positions using `TopExp::Vertices`. Returns `(.zero, .zero)` on failure (e.g. degenerate edge with no vertices).
+
+- **Returns:** Tuple of the edge's start and end vertex positions.
+- **OCCT:** `TopExp::Vertices` + `BRep_Tool::Pnt`.
+- **Example:**
+  ```swift
+  let ep = box.edge(at: 0)!.endpoints
+  print(ep.start, ep.end)
+  ```
+
+---
+
+## 3D Curve Properties
+
+Properties and methods in this section provide parametric access to the edge's underlying `Geom_Curve`. Parameters are **native OCCT curve parameters** (not normalised to `[0, 1]`); query `parameterBounds` first.
+
+---
+
+### `CurveType`
+
+Curve type classification for an edge's underlying geometry.
+
+```swift
+public enum CurveType: Int32, Sendable {
+    case line = 0, circle = 1, ellipse = 2, hyperbola = 3, parabola = 4
+    case bezierCurve = 5, bsplineCurve = 6, offsetCurve = 7, other = 8
+}
+```
+
+Matches `GeomAbs_CurveType` values from `BRepAdaptor_Curve`. Use `curveType` to distinguish geometric type before calling type-specific accessors.
+
+---
+
+### `CurveProjection`
+
+Result of projecting a point onto an edge's curve.
+
+```swift
+public struct CurveProjection: Sendable {
+    public let point: SIMD3<Double>
+    public let parameter: Double
+    public let distance: Double
+}
+```
+
+- `point` — closest point on the curve.
+- `parameter` — native curve parameter at the closest point.
+- `distance` — Euclidean distance from the query point to `point`.
+
+---
+
+### `parameterBounds`
+
+The native OCCT parameter range `[first, last]` for this edge's underlying curve.
+
+```swift
+public var parameterBounds: (first: Double, last: Double)? { get }
+```
+
+Required before calling any `at parameter:` method — OCCT parameters are not normalised. For a line of length 10 starting at the origin, `first ≈ 0` and `last ≈ 10`.
+
+- **Returns:** `(first, last)` parameter tuple, or `nil` if the edge has no 3D curve.
+- **OCCT:** `BRep_Tool::Curve` — returns the handle and its parameter range.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let edge = box.edge(at: 0)!
+  if let b = edge.parameterBounds {
+      let mid = (b.first + b.last) / 2.0
+      let pt = edge.point(at: mid)
+  }
+  ```
+
+---
+
+### `curveType`
+
+The geometric type of this edge's curve.
+
+```swift
+public var curveType: CurveType { get }
+```
+
+- **Returns:** One of `CurveType`'s cases. Returns `.other` for unknown or null curves.
+- **OCCT:** `BRepAdaptor_Curve::GetType()`.
+- **Example:**
+  ```swift
+  for edge in shape.edges() {
+      if edge.curveType == .circle {
+          // handle circular edges
+      }
+  }
+  ```
+
+---
+
+### `point(at:)`
+
+Returns the 3D position on the edge's curve at a native OCCT parameter.
+
+```swift
+public func point(at parameter: Double) -> SIMD3<Double>?
+```
+
+- **Parameters:** `parameter` — a value in `[parameterBounds.first, parameterBounds.last]`.
+- **Returns:** 3D point, or `nil` if the edge has no curve or the parameter is out of domain.
+- **OCCT:** `BRep_Tool::Curve` → `Geom_Curve::D0`.
+- **Example:**
+  ```swift
+  let edge = cyl.edges().first(where: \.isCircle)!
+  if let b = edge.parameterBounds {
+      let mid = (b.first + b.last) / 2.0
+      let pt = edge.point(at: mid)
+  }
+  ```
+
+---
+
+### `curvature(at:)`
+
+Returns the curvature (1/radius) of the edge's curve at a native parameter.
+
+```swift
+public func curvature(at parameter: Double) -> Double?
+```
+
+A straight line has curvature `0`; a circle of radius R has curvature `1/R`.
+
+- **Parameters:** `parameter` — native curve parameter.
+- **Returns:** Curvature ≥ 0, or `nil` if the tangent is undefined or the edge has no curve.
+- **OCCT:** `BRep_Tool::Curve` → `GeomLProp_CLProps::Curvature`.
+- **Example:**
+  ```swift
+  let radius = 5.0
+  let cyl = Shape.cylinder(radius: radius, height: 10)!
+  if let edge = cyl.edges().first(where: \.isCircle),
+     let b = edge.parameterBounds {
+      let curv = edge.curvature(at: (b.first + b.last) / 2.0)
+      // curv ≈ 0.2 (1/5)
+  }
+  ```
+
+---
+
+### `tangent(at:)`
+
+Returns the unit tangent vector at a native curve parameter.
+
+```swift
+public func tangent(at parameter: Double) -> SIMD3<Double>?
+```
+
+- **Parameters:** `parameter` — native curve parameter.
+- **Returns:** Unit tangent vector in the direction of increasing parameter, or `nil` if undefined.
+- **OCCT:** `BRep_Tool::Curve` → `GeomLProp_CLProps::Tangent`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  if let edge = box.edges().first(where: \.isLine),
+     let b = edge.parameterBounds {
+      let t = edge.tangent(at: (b.first + b.last) / 2.0)
+  }
+  ```
+
+---
+
+### `normal(at:)`
+
+Returns the principal normal direction at a native curve parameter.
+
+```swift
+public func normal(at parameter: Double) -> SIMD3<Double>?
+```
+
+The principal normal points toward the centre of curvature. For straight edges, curvature is zero and the normal is undefined.
+
+- **Parameters:** `parameter` — native curve parameter.
+- **Returns:** Unit normal vector, or `nil` if the curvature is zero or the tangent is undefined.
+- **OCCT:** `BRep_Tool::Curve` → `GeomLProp_CLProps::Normal`.
+- **Example:**
+  ```swift
+  if let edge = cyl.edges().first(where: \.isCircle),
+     let b = edge.parameterBounds {
+      let n = edge.normal(at: (b.first + b.last) / 2.0)
+  }
+  ```
+
+---
+
+### `centerOfCurvature(at:)`
+
+Returns the centre of curvature at a native curve parameter.
+
+```swift
+public func centerOfCurvature(at parameter: Double) -> SIMD3<Double>?
+```
+
+The centre of curvature lies on the principal normal at distance 1/κ from the curve point. Undefined (returns `nil`) for zero-curvature (straight) segments.
+
+- **Parameters:** `parameter` — native curve parameter.
+- **Returns:** 3D centre of curvature, or `nil` if curvature is zero or computation fails.
+- **OCCT:** `BRep_Tool::Curve` → `GeomLProp_CLProps::CentreOfCurvature`.
+- **Example:**
+  ```swift
+  if let edge = cyl.edges().first(where: \.isCircle),
+     let b = edge.parameterBounds {
+      let cc = edge.centerOfCurvature(at: b.first)
+      // cc is the circle centre
+  }
+  ```
+
+---
+
+### `torsion(at:)`
+
+Returns the torsion of the edge's curve at a native parameter.
+
+```swift
+public func torsion(at parameter: Double) -> Double?
+```
+
+Torsion measures the rate at which the osculating plane twists. Zero for planar curves (lines, circles, arcs). Non-zero for space curves (helices, general B-splines).
+
+- **Parameters:** `parameter` — native curve parameter.
+- **Returns:** Torsion value (can be negative), or `nil` if computation fails. Returns `0.0` for degenerate (zero-curvature cross-product) configurations.
+- **OCCT:** `Geom_Curve::D3` — uses the formula τ = (d1 × d2) · d3 / |d1 × d2|².
+- **Example:**
+  ```swift
+  // A helix has non-zero torsion
+  if let helix = Wire.helix(radius: 5, pitch: 2, turns: 3),
+     let shape = Shape.fromWire(helix) {
+      let edges = shape.edges()
+      if let edge = edges.first,
+         let b = edge.parameterBounds {
+          let tau = edge.torsion(at: b.first)
+      }
+  }
+  ```
+
+---
+
+### `project(point:)`
+
+Projects a 3D point onto this edge's curve, returning the closest point.
+
+```swift
+public func project(point: SIMD3<Double>) -> CurveProjection?
+```
+
+Uses OCCT's `GeomAPI_ProjectPointOnCurve` bounded to the edge's parameter range, ensuring the projected point lies within the edge bounds.
+
+- **Parameters:** `point` — query point in 3D space.
+- **Returns:** `CurveProjection` with the closest point, its parameter, and the distance; or `nil` if the edge has no curve or projection fails.
+- **OCCT:** `BRep_Tool::Curve` + `GeomAPI_ProjectPointOnCurve`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  if let edge = box.edges().first(where: \.isLine) {
+      let ep = edge.endpoints
+      let mid = (ep.start + ep.end) / 2.0
+      if let proj = edge.project(point: mid + SIMD3(1, 1, 1)) {
+          print(proj.distance)  // ≈ √3
+      }
+  }
+  ```
+
+---
+
+### `distance(to:)`
+
+The shortest distance from a 3D point to this edge. Returns `nil` if the projection fails.
+
+```swift
+public func distance(to point: SIMD3<Double>) -> Double?
+```
+
+Pure-Swift convenience — delegates to `project(point:)?.distance`.
+
+- **Parameters:** `point` — query point.
+- **Returns:** Distance to the nearest point on the edge, or `nil` on failure.
+- **OCCT:** Delegates to `project(point:)` → `GeomAPI_ProjectPointOnCurve`.
+- **Example:**
+  ```swift
+  if let d = edge.distance(to: SIMD3(5, 5, 5)) {
+      print("Distance to edge: \(d)")
+  }
+  ```
+
+---
+
+### `curve3D`
+
+The 3D curve underlying this edge as a standalone `Curve3D`.
+
+```swift
+public var curve3D: Curve3D? { get }
+```
+
+Returns a `Geom_TrimmedCurve` wrapping the edge's geometry, trimmed to the edge's parameter range. Returns `nil` for edges with no 3D curve representation (rare — typically pcurve-only edges before `BuildCurves3d`).
+
+Use cases include extracting `CircleProperties` from a circular edge, emitting native DXF entities, or feeding edge geometry into parametric analysis pipelines.
+
+- **Returns:** `Curve3D` wrapping a `Geom_TrimmedCurve`, or `nil` if no 3D curve exists.
+- **OCCT:** `BRepLib::BuildCurves3d` + `BRep_Tool::Curve`.
+- **Example:**
+  ```swift
+  if let edge = cyl.edges().first(where: \.isCircle),
+     let curve = edge.curve3D {
+      let props = curve.circleProperties
+  }
+  ```
+
+---
+
+## Sampling
+
+### `points(count:)`
+
+Returns uniformly-sampled points along the edge curve.
+
+```swift
+public func points(count: Int? = nil) -> [SIMD3<Double>]
+```
+
+When `count` is `nil`, automatically computes a point count at approximately 0.5 model-unit spacing (`max(2, Int(length / 0.5) + 1)`). Points are evenly spaced in the OCCT parameter domain (not arc-length).
+
+- **Parameters:** `count` — number of points to generate; `nil` = automatic.
+- **Returns:** Array of 3D points; empty on failure or for degenerate edges.
+- **OCCT:** `BRepAdaptor_Curve::Value` — samples at uniformly-spaced parameter values.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  if let circEdge = cyl.edges().first(where: \.isCircle) {
+      let pts = circEdge.points(count: 32)
+      // pts has 32 points around the circle
+  }
+  ```
+
+---
+
+## Shape Extension for Edge Access
+
+These members are declared on `Shape` in `Edge.swift` and provide indexed access to all edges in a shape.
+
+---
+
+### `edgeCount`
+
+The total number of edges in the shape.
+
+```swift
+public var edgeCount: Int { get }
+```
+
+- **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE, map)` → `map.Extent()` via `TopTools_IndexedMapOfShape`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.edgeCount)  // 12
+  ```
+
+---
+
+### `edge(at:)`
+
+Returns the edge at a given 0-based index.
+
+```swift
+public func edge(at index: Int) -> Edge? 
+```
+
+- **Parameters:** `index` — 0-based edge index.
+- **Returns:** `Edge` at the given index, or `nil` if the index is out of range.
+- **OCCT:** `TopExp::MapShapes` + `TopoDS::Edge` — extracts from `TopTools_IndexedMapOfShape` (1-based internally; index is adjusted).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  if let edge = box.edge(at: 0) {
+      print(edge.length)
+  }
+  ```
+
+---
+
+### `edges()`
+
+Returns all edges from the shape as typed `Edge` objects.
+
+```swift
+public func edges() -> [Edge]
+```
+
+Iterates `edge(at:)` from 0 to `edgeCount - 1`. The order matches `edgeCount` / `edge(at:)` — i.e., `TopTools_IndexedMapOfShape` traversal order, which can vary between runs.
+
+- **Returns:** Array of all `Edge` objects; empty if the shape has no edges.
+- **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE)` — collects all edges via indexed map.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let edges = box.edges()
+  // edges.count == 12
+  for edge in edges {
+      if edge.isLine { print(edge.length) }
+  }
+  ```
+- **Note:** Edge indices may vary across runs — iterate edges to find a specific one rather than relying on a fixed index.
+
+---
+
+## Edge Analysis
+
+### `hasCurve3D`
+
+Whether this edge has an underlying 3D curve.
+
+```swift
+public var hasCurve3D: Bool { get }
+```
+
+- **OCCT:** `ShapeAnalysis_Edge::HasCurve3d`.
+- **Example:**
+  ```swift
+  for edge in shape.edges() {
+      if edge.hasCurve3D {
+          let curve = edge.curve3D
+      }
+  }
+  ```
+
+---
+
+### `isClosed3D`
+
+Whether this edge is closed — i.e., its start and end vertices coincide.
+
+```swift
+public var isClosed3D: Bool { get }
+```
+
+Closed edges appear as the single circular edge of a cylinder face.
+
+- **OCCT:** `ShapeAnalysis_Edge::IsClosed3d`.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  let hasClosedEdge = cyl.edges().contains(where: \.isClosed3D)
+  // hasClosedEdge == true (the circular top/bottom edges)
+  ```
+
+---
+
+### `isSeam(on:)`
+
+Whether this edge is a seam edge on the given face.
+
+```swift
+public func isSeam(on face: Face) -> Bool
+```
+
+A seam edge appears twice on a face with different orientations — e.g., the seam line on a cylindrical face where the surface wraps around. Relevant for surface parameterisation and UV-space computations.
+
+- **Parameters:** `face` — the face to test against.
+- **Returns:** `true` if the edge is a seam on `face`.
+- **OCCT:** `ShapeAnalysis_Edge::IsSeam`.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  let faces = cyl.faces()
+  for edge in cyl.edges() {
+      if edge.isSeam(on: faces[0]) {
+          print("found seam edge")
+      }
+  }
+  ```
+
+---
+
+### `adjacentFaces(in:)`
+
+Returns the faces adjacent to this edge within a parent shape.
+
+```swift
+public func adjacentFaces(in shape: Shape) -> (Face, Face?)?
+```
+
+Most interior edges have exactly two adjacent faces (manifold solid). Boundary edges (on open shells) have only one. The shape must be the same solid from which this edge was extracted.
+
+- **Parameters:** `shape` — the parent shape containing this edge.
+- **Returns:** Tuple `(face1, face2)` where `face2` is `nil` for boundary edges; or `nil` if the edge has no adjacent faces in `shape`.
+- **OCCT:** `TopExp::MapShapesAndAncestors(shape, TopAbs_EDGE, TopAbs_FACE, map)`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  if let edge = box.edge(at: 0),
+     let (f1, f2) = edge.adjacentFaces(in: box) {
+      print("face1, face2:", f1, f2 as Any)
+  }
+  ```
+
+---
+
+### `dihedralAngle(between:and:at:)`
+
+Computes the dihedral angle between two faces at this edge.
+
+```swift
+public func dihedralAngle(between face1: Face, and face2: Face, at parameter: Double = 0.5) -> Double?
+```
+
+The dihedral angle is measured between the face normals evaluated at a point along the edge. A value of `π` (180°) indicates tangent (smooth) faces; less than `π` is convex; greater than `π` is concave.
+
+- **Parameters:**
+  - `face1` — first adjacent face.
+  - `face2` — second adjacent face.
+  - `parameter` — normalised position along the edge in `[0.0, 1.0]` where to measure (default: midpoint).
+- **Returns:** Dihedral angle in radians `[0, 2π]`, or `nil` on error (e.g. degenerate normals or missing PCurves).
+- **OCCT:** `BRepAdaptor_Curve` + `BRep_Tool::CurveOnSurface` + `BRepAdaptor_Surface::D1` — computes face normals from first derivatives at the UV parameter.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  for edge in box.edges() {
+      if let (f1, f2) = edge.adjacentFaces(in: box), let f2 {
+          if let angle = edge.dihedralAngle(between: f1, and: f2) {
+              // angle ≈ π/2 for all edges of a box
+              print(angle)
+          }
+      }
+  }
+  ```
+
+---
+
+## Curve Approximation
+
+### `CurveApproximation`
+
+Result of B-spline approximation of an edge's curve.
+
+```swift
+public struct CurveApproximation: Sendable {
+    public let maxError: Double
+    public let degree: Int
+    public let poleCount: Int
+}
+```
+
+- `maxError` — maximum deviation between the original curve and the B-spline approximation.
+- `degree` — B-spline degree of the result.
+- `poleCount` — number of B-spline control points (poles) in the result.
+
+---
+
+### `approximatedCurve(tolerance:maxSegments:maxDegree:)`
+
+Approximates this edge's curve as a B-spline `Curve3D`.
+
+```swift
+public func approximatedCurve(tolerance: Double = 1e-3,
+                               maxSegments: Int = 100,
+                               maxDegree: Int = 8) -> Curve3D?
+```
+
+Uses `Approx_Curve3d` with C² continuity to convert any curve type (line, circle, ellipse, etc.) into a B-spline representation. Useful for normalising geometry before export or downstream processing.
+
+- **Parameters:**
+  - `tolerance` — maximum allowed approximation error (default `1e-3`).
+  - `maxSegments` — maximum number of B-spline segments (default `100`).
+  - `maxDegree` — maximum B-spline degree (default `8`).
+- **Returns:** Approximated B-spline as a `Curve3D`, or `nil` on failure.
+- **OCCT:** `BRepAdaptor_Curve` + `Approx_Curve3d` (GeomAbs_C2).
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  if let edge = cyl.edges().first(where: \.isCircle),
+     let bspline = edge.approximatedCurve(tolerance: 1e-4) {
+      let dom = bspline.domain
+  }
+  ```
+
+---
+
+### `curveApproximationInfo(tolerance:maxSegments:maxDegree:)`
+
+Returns information about B-spline approximation without creating the curve object.
+
+```swift
+public func curveApproximationInfo(tolerance: Double = 1e-3,
+                                    maxSegments: Int = 100,
+                                    maxDegree: Int = 8) -> CurveApproximation?
+```
+
+Runs the same `Approx_Curve3d` computation as `approximatedCurve(tolerance:maxSegments:maxDegree:)` but returns only the metadata — error, degree, and pole count — without allocating a full `Curve3D`.
+
+- **Parameters:**
+  - `tolerance` — maximum allowed approximation error (default `1e-3`).
+  - `maxSegments` — maximum number of B-spline segments (default `100`).
+  - `maxDegree` — maximum B-spline degree (default `8`).
+- **Returns:** `CurveApproximation` struct, or `nil` on failure.
+- **OCCT:** `BRepAdaptor_Curve` + `Approx_Curve3d` (GeomAbs_C2) — reads `MaxError()`, `Degree()`, `NbPoles()`.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  if let edge = cyl.edges().first(where: \.isCircle),
+     let info = edge.curveApproximationInfo() {
+      print(info.maxError, info.degree, info.poleCount)
+  }
+  ```
+
+---
+
+## Edge Splitting
+
+### `split(at:vertex:)`
+
+Splits this edge into two new edges at the specified parameter value.
+
+```swift
+public func split(at parameter: Double, vertex: SIMD3<Double>) -> (Edge, Edge)?
+```
+
+Divides the edge at `parameter`, placing a new vertex at `vertex`. The two result edges share the new vertex. The original edge is not modified.
+
+- **Parameters:**
+  - `parameter` — native OCCT curve parameter at which to split (must be within `parameterBounds`).
+  - `vertex` — 3D position for the split vertex (should lie on the curve at `parameter`).
+- **Returns:** Tuple `(edge1, edge2)` representing the two halves, or `nil` if splitting fails.
+- **OCCT:** `ShapeFix_SplitTool::SplitEdge` with a synthetic planar face context.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  for edge in box.edges() where edge.isLine {
+      if let b = edge.parameterBounds,
+         let midPt = edge.point(at: (b.first + b.last) / 2.0) {
+          let midParam = (b.first + b.last) / 2.0
+          if let (e1, e2) = edge.split(at: midParam, vertex: midPt) {
+              print(e1.length, e2.length)
+          }
+      }
+      break
+  }
+  ```
+- **Note:** The synthetic planar face used internally (`gp_Pln` through the curve midpoint with Z normal) may cause `SplitEdge` to fail for space curves not lying near Z=0. Provide a curve midpoint as `vertex` for best results.
+
+---
+
+## PCurve / BRepAdaptor\_Curve2d
+
+Members in this section access the 2D parametric curve (PCurve) of an edge on a specific face — the `Geom2d_Curve` that maps the edge into the face's UV parameter space.
+
+---
+
+### `pcurveParams(on:)`
+
+Returns the 2D parametric curve parameter range for this edge on a face.
+
+```swift
+public func pcurveParams(on face: Face) -> (first: Double, last: Double)?
+```
+
+- **Parameters:** `face` — the face on which this edge lies.
+- **Returns:** `(first, last)` parameter range for the PCurve, or `nil` if no PCurve exists for this edge on `face`.
+- **OCCT:** `BRepAdaptor_Curve2d` — adaptor over the edge's PCurve on the face's surface.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 20, depth: 30)!
+  let faces = box.faces()
+  let edges = box.edges()
+  for edge in edges {
+      if let params = edge.pcurveParams(on: faces[0]) {
+          print(params.first, params.last)
+          break
+      }
+  }
+  ```
+
+---
+
+### `pcurveValue(at:on:)`
+
+Evaluates the 2D parametric curve of this edge on a face at the given parameter.
+
+```swift
+public func pcurveValue(at parameter: Double, on face: Face) -> SIMD2<Double>?
+```
+
+Returns the UV coordinate on the face's surface corresponding to the given curve parameter.
+
+- **Parameters:**
+  - `parameter` — curve parameter (within the range from `pcurveParams(on:)`).
+  - `face` — the face on which the edge lies.
+- **Returns:** UV point on the face surface, or `nil` on failure.
+- **OCCT:** `BRepAdaptor_Curve2d::Value`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 20, depth: 30)!
+  let faces = box.faces()
+  for edge in box.edges() {
+      if let params = edge.pcurveParams(on: faces[0]) {
+          let mid = (params.first + params.last) / 2.0
+          if let uv = edge.pcurveValue(at: mid, on: faces[0]) {
+              print("UV:", uv)
+              break
+          }
+      }
+  }
+  ```
+
+---
+
+### `approxCurveOnSurface(face:tolerance:maxSegments:maxDegree:)`
+
+Approximates the 3D curve of this edge on a face from its PCurve.
+
+```swift
+public func approxCurveOnSurface(face: Face, tolerance: Double = 1e-4,
+                                  maxSegments: Int = 10, maxDegree: Int = 8) -> Shape?
+```
+
+Uses `Approx_CurveOnSurface` to compute a 3D B-spline from the edge's 2D parametric curve on the given face's surface. Returns the result as a `Shape` wrapping a new `TopoDS_Edge` with the approximated 3D curve.
+
+- **Parameters:**
+  - `face` — the face whose surface defines the PCurve-to-3D mapping.
+  - `tolerance` — approximation tolerance (default `1e-4`).
+  - `maxSegments` — maximum B-spline segments (default `10`).
+  - `maxDegree` — maximum B-spline degree (default `8`).
+- **Returns:** `Shape` wrapping the new edge with approximated 3D curve, or `nil` on failure (e.g. no PCurve found).
+- **OCCT:** `BRep_Tool::CurveOnSurface` + `Approx_CurveOnSurface` (GeomAbs_C2) + `BRepBuilderAPI_MakeEdge`.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  let faces = cyl.faces()
+  let edges = cyl.edges()
+  if faces.count > 0 {
+      if let approxShape = edges[0].approxCurveOnSurface(face: faces[0]) {
+          // approxShape wraps an edge with a B-spline 3D curve
+      }
+  }
+  ```

--- a/docs/reference/Exporter.md
+++ b/docs/reference/Exporter.md
@@ -1,0 +1,826 @@
+---
+title: Exporter
+parent: API Reference
+---
+
+# Exporter
+
+`Exporter` is a caseless `enum` namespace that collects all write-to-file operations for
+OCCTSwift shapes. It covers two families of format:
+
+- **Tessellated** (STL, OBJ, PLY, GLTF/GLB) — the shape is meshed internally; a `deflection`
+  parameter controls triangle density.
+- **Exact B-Rep** (STEP, IGES, BREP) — the full analytic geometry is written without
+  approximation; these are round-trippable via the corresponding `Shape.load*` importers.
+
+All write methods throw `Exporter.ExportError` on failure. Convenience instance methods are
+defined on `Shape` (see [Shape Convenience Extensions](#shape-convenience-extensions)).
+
+The `StepModelType` enum and `Document.writeGLTF` are defined in `Document.swift` but are part
+of the export surface; both are documented here.
+
+## Topics
+
+- [ExportError](#exporterror) · [STL Export](#stl-export) · [STEP Export](#step-export) ·
+  [IGES Export](#iges-export) · [BREP Export](#brep-export) · [OBJ Export](#obj-export) ·
+  [PLY Export](#ply-export) · [GLTF Export](#gltf-export) ·
+  [STEP Optimisation](#step-optimisation) · [StepModelType](#stepmodeltype) ·
+  [Shape Convenience Extensions](#shape-convenience-extensions)
+
+---
+
+## ExportError
+
+Error type thrown by all `Exporter` write methods.
+
+```swift
+public enum ExportError: Error, LocalizedError {
+    case exportFailed(String)
+    case invalidPath
+    case invalidShape
+    case cancelled
+}
+```
+
+- `exportFailed(String)` — the underlying OCCT writer returned false or threw; the associated
+  string names the failing file.
+- `invalidPath` — the destination URL resolved to an empty path string.
+- `invalidShape` — `shape.isValid` returned `false` before the write was attempted.
+- `cancelled` — the export was cooperatively cancelled via `ImportProgress.shouldCancel()`.
+  Only thrown by the progress-overloads `writeSTEP(shape:to:progress:)` and
+  `writeIGES(shape:to:progress:)`.
+
+---
+
+## STL Export
+
+### `Exporter.writeSTL(shape:to:deflection:ascii:)`
+
+Tessellates a shape and writes an STL file.
+
+```swift
+public static func writeSTL(
+    shape: Shape,
+    to url: URL,
+    deflection: Double = 0.1,
+    ascii: Bool = false
+) throws
+```
+
+`deflection` is the maximum chord deviation in model units — smaller values produce finer meshes
+and larger files. Binary mode (`ascii: false`) is the default and produces smaller files.
+
+| Use case | deflection |
+|---|---|
+| Quick preview | 0.5 |
+| FDM print (0.2 mm layers) | 0.1 |
+| Fine FDM (0.1 mm) | 0.05 |
+| SLA / display-quality | 0.02 |
+
+- **Parameters:** `shape` — shape to tessellate; `url` — output URL (conventionally `.stl`);
+  `deflection` — max chord deviation (default 0.1); `ascii` — `true` for ASCII STL (default `false`).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidShape` if `shape.isValid` is false;
+  `ExportError.invalidPath` if `url.path` is empty;
+  `ExportError.exportFailed` if `StlAPI_Writer` fails.
+- **OCCT:** `StlAPI_Writer::Write` (binary or ASCII mode).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 5, depth: 3)!
+  try Exporter.writeSTL(shape: box, to: URL(fileURLWithPath: "/tmp/box.stl"), deflection: 0.05)
+  try Exporter.writeSTL(shape: box, to: asciiURL, deflection: 0.1, ascii: true)
+  ```
+
+---
+
+### `Exporter.stlData(shape:deflection:)`
+
+Tessellates a shape and returns the STL file contents as `Data`, without touching a permanent file.
+
+```swift
+public static func stlData(
+    shape: Shape,
+    deflection: Double = 0.1
+) throws -> Data
+```
+
+Internally writes to a UUID-named temporary file, reads it back, and removes it. Useful for
+sharing via AirDrop, email attachments, or uploading over the network.
+
+- **Parameters:** `shape` — shape to export; `deflection` — tessellation quality (default 0.1).
+- **Returns:** Binary STL `Data`.
+- **Throws:** Same as `writeSTL`; also rethrows `Data(contentsOf:)` errors if the temp file cannot be read.
+- **OCCT:** `StlAPI_Writer` (via `writeSTL`).
+- **Example:**
+  ```swift
+  let data = try Exporter.stlData(shape: myShape)
+  // Share via AirDrop, email, etc.
+  ```
+
+---
+
+## STEP Export
+
+### `Exporter.writeSTEP(shape:to:name:)`
+
+Writes a shape to STEP AP214 format. Preserves exact analytic B-Rep geometry.
+
+```swift
+public static func writeSTEP(
+    shape: Shape,
+    to url: URL,
+    name: String? = nil
+) throws
+```
+
+STEP is the standard CAD interchange format and is importable by Fusion 360, SolidWorks, FreeCAD,
+and most CAM tools. When `name` is supplied it is embedded as the product name in the STEP file.
+
+- **Parameters:** `shape` — shape to export; `url` — output URL (conventionally `.step` or `.stp`);
+  `name` — optional product name.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed` if `STEPControl_Writer` transfer or write fails.
+- **OCCT:** `STEPControl_Writer::Transfer` + `Write` (AP214, `STEPControl_AsIs` model type when no name; `STEPControl_AsIs` via `OCCTExportSTEPWithName` when a name is given).
+- **Example:**
+  ```swift
+  try Exporter.writeSTEP(shape: turnout,
+                          to: projectURL.appendingPathComponent("turnout.step"),
+                          name: "Number8Turnout")
+  ```
+- **Note:** STEP preserves topology (faces, edges, vertices). File sizes are larger than STL.
+
+---
+
+### `Exporter.writeSTEP(shape:to:progress:)`
+
+Writes a shape to STEP with cooperative progress reporting and cancellation support.
+
+```swift
+public static func writeSTEP(
+    shape: Shape,
+    to url: URL,
+    progress: ImportProgress?
+) throws
+```
+
+Pass `nil` for `progress` to disable cancellation; otherwise the export polls
+`progress.shouldCancel()` cooperatively via the OCCT message range mechanism.
+
+- **Parameters:** `shape` — shape to export; `url` — output URL; `progress` — optional
+  cancellation/progress token.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.cancelled` if `progress.shouldCancel()` fires;
+  `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `STEPControl_Writer::Transfer` with a `Message_ProgressRange` derived from the
+  `ImportProgress` context.
+- **Example:**
+  ```swift
+  let progress = ImportProgress()
+  try Exporter.writeSTEP(shape: largeModel, to: stepURL, progress: progress)
+  ```
+
+---
+
+### `Exporter.stepData(shape:name:)`
+
+Writes a shape to STEP and returns the file contents as `Data`.
+
+```swift
+public static func stepData(
+    shape: Shape,
+    name: String? = nil
+) throws -> Data
+```
+
+- **Parameters:** `shape` — shape to export; `name` — optional product name.
+- **Returns:** STEP file as `Data`.
+- **Throws:** Same as `writeSTEP(shape:to:name:)`.
+- **OCCT:** `STEPControl_Writer` (via `writeSTEP`).
+- **Example:**
+  ```swift
+  let data = try Exporter.stepData(shape: model, name: "Part1")
+  ```
+
+---
+
+### `Exporter.writeSTEP(shape:to:modelType:)`
+
+Writes a shape to STEP with an explicit STEP representation type.
+
+```swift
+public static func writeSTEP(shape: Shape, to url: URL, modelType: StepModelType) throws
+```
+
+Use `modelType` to control how geometry is encoded in the STEP file. See
+[StepModelType](#stepmodeltype) for available values.
+
+- **Parameters:** `shape` — shape; `url` — output URL; `modelType` — STEP representation type.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `STEPControl_Writer::Transfer` with the given `STEPControl_StepModelType`.
+- **Example:**
+  ```swift
+  try Exporter.writeSTEP(shape: solid, to: stepURL, modelType: .manifoldSolidBrep)
+  ```
+
+---
+
+### `Exporter.writeSTEP(shape:to:modelType:tolerance:)`
+
+Writes a shape to STEP with an explicit model type and geometric tolerance.
+
+```swift
+public static func writeSTEP(shape: Shape, to url: URL, modelType: StepModelType, tolerance: Double) throws
+```
+
+- **Parameters:** `shape` — shape; `url` — output URL; `modelType` — representation type;
+  `tolerance` — geometric tolerance written into the STEP file header.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `STEPControl_Writer::Transfer` with explicit tolerance.
+- **Example:**
+  ```swift
+  try Exporter.writeSTEP(shape: part, to: stepURL,
+                          modelType: .asIs, tolerance: 1e-4)
+  ```
+
+---
+
+### `Exporter.writeSTEPCleanDuplicates(shape:to:modelType:)`
+
+Writes a shape to STEP and deduplicates shared geometric entities to reduce file size.
+
+```swift
+public static func writeSTEPCleanDuplicates(shape: Shape, to url: URL, modelType: StepModelType = .asIs) throws
+```
+
+Merges identical surfaces, curves, and vertices during the transfer. Most effective for
+assemblies or swept shapes where many faces share the same underlying geometry.
+
+- **Parameters:** `shape` — shape; `url` — output URL; `modelType` — representation type (default `.asIs`).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `STEPControl_Writer` with a pre-transfer deduplication pass.
+- **Example:**
+  ```swift
+  try Exporter.writeSTEPCleanDuplicates(shape: assembly, to: stepURL)
+  ```
+
+---
+
+### `Exporter.writeSTEPAssembly(_:to:)`
+
+Writes an XCAF `Document` as a product-structured STEP assembly.
+
+```swift
+public static func writeSTEPAssembly(_ document: Document, to url: URL) throws
+```
+
+Unlike `writeSTEP(shape:to:)`, which flattens everything into one geometry object, this
+preserves the document's assembly tree: each unique part label is written once as a STEP
+`PRODUCT` / `PRODUCT_DEFINITION` and referenced by its placed occurrences via
+`NEXT_ASSEMBLY_USAGE_OCCURRENCE` + `TopLoc_Location`. A part placed N times generates one
+`MANIFOLD_SOLID_BREP`, not N copies. Component names and colors set on the document labels are
+also written. Build the assembly tree with `Document.addShape` and `Document.addComponent`
+before calling this. Output uses AP214 schema.
+
+- **Parameters:** `document` — XCAF document holding the assembly tree; `url` — output URL.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath` if `url.path` is empty;
+  `ExportError.exportFailed` if the `STEPCAFControl_Writer` transfer or write fails.
+- **OCCT:** `STEPCAFControl_Writer` (via `Document.writeSTEP(to:)`).
+- **Example:**
+  ```swift
+  let doc = Document()
+  let partId = doc.addShape(shaft)
+  let asmId  = doc.addShape(Shape.compound([]), makeAssembly: true)
+  doc.addComponent(assemblyLabelId: asmId, shapeLabelId: partId, matrix: .identity)
+  try Exporter.writeSTEPAssembly(doc, to: URL(fileURLWithPath: "/tmp/assembly.step"))
+  ```
+- **Note:** See the [XCAF Assemblies](../guides/cookbook/xcaf-assemblies.md) cookbook page for
+  a full assembly-build example.
+
+---
+
+## IGES Export
+
+### `Exporter.writeIGES(shape:to:)`
+
+Writes a shape to IGES format.
+
+```swift
+public static func writeIGES(
+    shape: Shape,
+    to url: URL
+) throws
+```
+
+IGES (Initial Graphics Exchange Specification) is a legacy format still commonly accepted by
+CNC machines and older CAD tools. Uses Faces mode with MM units by default. Validates the shape
+with `BRepCheck_Analyzer` before writing; returns `exportFailed` for invalid geometry.
+
+- **Parameters:** `shape` — shape to export; `url` — output URL (conventionally `.igs` or `.iges`).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed` if `IGESControl_Writer` fails.
+- **OCCT:** `IGESControl_Writer::AddShape` + `ComputeModel` + `Write`.
+- **Note:** IGES writes are serialised through an internal mutex because `IGESControl_Writer`
+  has internal global state that is not thread-safe.
+- **Example:**
+  ```swift
+  try Exporter.writeIGES(shape: part, to: URL(fileURLWithPath: "/tmp/part.igs"))
+  ```
+
+---
+
+### `Exporter.writeIGES(shape:to:progress:)`
+
+Writes a shape to IGES with cooperative progress reporting and cancellation.
+
+```swift
+public static func writeIGES(
+    shape: Shape,
+    to url: URL,
+    progress: ImportProgress?
+) throws
+```
+
+- **Parameters:** `shape` — shape; `url` — output URL; `progress` — optional cancellation token.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.cancelled`; `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed`.
+- **OCCT:** `IGESControl_Writer` with `Message_ProgressRange`.
+- **Example:**
+  ```swift
+  try Exporter.writeIGES(shape: model, to: igesURL, progress: ImportProgress())
+  ```
+
+---
+
+### `Exporter.writeIGES(shape:to:unit:)`
+
+Writes a shape to IGES with an explicit unit string.
+
+```swift
+public static func writeIGES(shape: Shape, to url: URL, unit: String) throws
+```
+
+- **Parameters:** `shape` — shape; `url` — output URL; `unit` — unit identifier, e.g. `"MM"`,
+  `"IN"`, `"M"`, `"FT"`.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `IGESControl_Writer(unit, 0)` — Faces mode with the specified unit.
+- **Example:**
+  ```swift
+  try Exporter.writeIGES(shape: part, to: igesURL, unit: "IN")
+  ```
+
+---
+
+### `Exporter.writeIGESBRep(shape:to:)`
+
+Writes a shape to IGES in BRep mode (exact geometry, not tessellated faces).
+
+```swift
+public static func writeIGESBRep(shape: Shape, to url: URL) throws
+```
+
+Passes `mode = 1` to `IGESControl_Writer`, causing it to write B-Rep entities rather than
+tessellated face entities.
+
+- **Parameters:** `shape` — shape; `url` — output URL.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `IGESControl_Writer("MM", 1)` — BRep mode.
+- **Example:**
+  ```swift
+  try Exporter.writeIGESBRep(shape: solid, to: igesURL)
+  ```
+
+---
+
+### `Exporter.writeIGES(shapes:to:)`
+
+Writes multiple shapes to a single IGES file.
+
+```swift
+public static func writeIGES(shapes: [Shape], to url: URL) throws
+```
+
+Iterates `shapes`, validates each with `BRepCheck_Analyzer`, and adds valid shapes to one
+`IGESControl_Writer`. Shapes that fail validation are silently skipped. Throws
+`ExportError.exportFailed` if no shapes were successfully added.
+
+- **Parameters:** `shapes` — array of shapes; `url` — output URL.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `IGESControl_Writer::AddShape` called per valid shape.
+- **Example:**
+  ```swift
+  try Exporter.writeIGES(shapes: [rail, sleeper, ballast], to: trackURL)
+  ```
+
+---
+
+### `Exporter.igesData(shape:)`
+
+Writes a shape to IGES and returns the file contents as `Data`.
+
+```swift
+public static func igesData(shape: Shape) throws -> Data
+```
+
+- **Parameters:** `shape` — shape to export.
+- **Returns:** IGES file as `Data`.
+- **Throws:** Same as `writeIGES(shape:to:)`.
+- **OCCT:** `IGESControl_Writer` (via `writeIGES`).
+- **Example:**
+  ```swift
+  let data = try Exporter.igesData(shape: part)
+  ```
+
+---
+
+## BREP Export
+
+### `Exporter.writeBREP(shape:to:withTriangles:withNormals:)`
+
+Writes a shape to OCCT's native BREP format.
+
+```swift
+public static func writeBREP(
+    shape: Shape,
+    to url: URL,
+    withTriangles: Bool = true,
+    withNormals: Bool = false
+) throws
+```
+
+BREP is OCCT's own serialisation format. It preserves full B-Rep precision (curves, surfaces,
+topology) with no conversion loss, and is the fastest format to write and read back. Optionally
+embeds existing triangulation data so that re-meshing on import is not required.
+
+- **Parameters:** `shape` — shape to export; `url` — output URL (conventionally `.brep`);
+  `withTriangles` — embed triangulation (default `true`);
+  `withNormals` — embed per-vertex normals with the triangulation (default `false`).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed` if `BRepTools::Write` fails.
+- **OCCT:** `BRepTools::Write(shape, path, withTriangles, withNormals, TopTools_FormatVersion_CURRENT)`.
+- **Example:**
+  ```swift
+  try Exporter.writeBREP(shape: model,
+                          to: cacheURL,
+                          withTriangles: true,
+                          withNormals: false)
+  ```
+- **Note:** BREP files are not portable across OCCT major versions; use STEP for long-term archival.
+
+---
+
+### `Exporter.brepData(shape:withTriangles:withNormals:)`
+
+Writes a shape to BREP and returns the file contents as `Data`.
+
+```swift
+public static func brepData(
+    shape: Shape,
+    withTriangles: Bool = true,
+    withNormals: Bool = false
+) throws -> Data
+```
+
+- **Parameters:** `shape` — shape; `withTriangles` — embed triangulation; `withNormals` — embed normals.
+- **Returns:** BREP file as `Data`.
+- **Throws:** Same as `writeBREP`.
+- **OCCT:** `BRepTools::Write` (via `writeBREP`).
+- **Example:**
+  ```swift
+  let data = try Exporter.brepData(shape: model)
+  ```
+
+---
+
+## OBJ Export
+
+### `Exporter.writeOBJ(shape:to:deflection:)`
+
+Tessellates a shape and writes a Wavefront OBJ file.
+
+```swift
+public static func writeOBJ(
+    shape: Shape,
+    to url: URL,
+    deflection: Double = 0.1
+) throws
+```
+
+OBJ is widely supported for 3D visualisation and modelling. The bridge meshes the shape into
+an XCAF document and writes it via `RWObj_CafWriter`.
+
+- **Parameters:** `shape` — shape; `url` — output URL (conventionally `.obj`); `deflection` — tessellation quality (default 0.1).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed` if `RWObj_CafWriter` fails.
+- **OCCT:** `RWObj_CafWriter`.
+- **Example:**
+  ```swift
+  try Exporter.writeOBJ(shape: box, to: URL(fileURLWithPath: "/tmp/box.obj"), deflection: 0.1)
+  ```
+
+---
+
+## PLY Export
+
+### `Exporter.writePLY(shape:to:deflection:)`
+
+Tessellates a shape and writes a PLY (Stanford Polygon Format) file.
+
+```swift
+public static func writePLY(
+    shape: Shape,
+    to url: URL,
+    deflection: Double = 0.1
+) throws
+```
+
+PLY is common in 3D scanning and point-cloud pipelines.
+
+- **Parameters:** `shape` — shape; `url` — output URL (conventionally `.ply`); `deflection` — tessellation quality (default 0.1).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed` if `RWPly_CafWriter` fails.
+- **OCCT:** `RWPly_CafWriter`.
+- **Example:**
+  ```swift
+  try Exporter.writePLY(shape: scan, to: URL(fileURLWithPath: "/tmp/scan.ply"))
+  ```
+
+---
+
+### `Exporter.writePLY(shape:to:deflection:normals:colors:texCoords:)`
+
+Tessellates a shape and writes a PLY file with optional per-vertex attributes.
+
+```swift
+public static func writePLY(shape: Shape, to url: URL, deflection: Double,
+                              normals: Bool = true, colors: Bool = false, texCoords: Bool = false) throws
+```
+
+- **Parameters:** `shape` — shape; `url` — output URL; `deflection` — tessellation quality;
+  `normals` — include per-vertex normals (default `true`);
+  `colors` — include per-vertex colour (default `false`);
+  `texCoords` — include UV texture coordinates (default `false`).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `RWPly_CafWriter` with attribute flags.
+- **Example:**
+  ```swift
+  try Exporter.writePLY(shape: mesh, to: plyURL, deflection: 0.05,
+                         normals: true, colors: true, texCoords: false)
+  ```
+
+---
+
+## GLTF Export
+
+`Exporter.writeGLTF` is defined in an `extension Exporter` block in `Document.swift`.
+
+### `Exporter.writeGLTF(shape:to:binary:deflection:)`
+
+Tessellates a shape and writes a GLTF or GLB file for real-time rendering or web delivery.
+
+```swift
+public static func writeGLTF(shape: Shape, to url: URL, binary: Bool = true, deflection: Double = 0.1) throws
+```
+
+`binary: true` (default) produces a self-contained `.glb` file (binary GLTF). `binary: false`
+produces a text `.gltf` file. The shape is meshed inside the bridge with the given `deflection`.
+To write GLTF with full materials/names from an XCAF document, use `Document.writeGLTF(to:binary:)`
+instead.
+
+- **Parameters:** `shape` — shape to tessellate and export; `url` — output URL (`.glb` or `.gltf`);
+  `binary` — `true` for GLB, `false` for text GLTF (default `true`);
+  `deflection` — tessellation quality (default 0.1).
+- **Returns:** `Void`.
+- **Throws:** `ExportError.exportFailed` if `RWGltf_CafWriter` fails.
+- **OCCT:** `RWGltf_CafWriter(path, isBinary)`.
+- **Example:**
+  ```swift
+  // GLB (binary) — single self-contained file
+  try Exporter.writeGLTF(shape: box, to: URL(fileURLWithPath: "/tmp/box.glb"))
+
+  // text GLTF
+  try Exporter.writeGLTF(shape: box, to: URL(fileURLWithPath: "/tmp/box.gltf"), binary: false)
+  ```
+- **Note:** There is no separate `writeGLB` method — GLB is `writeGLTF(shape:to:binary:)` with
+  `binary: true`.
+
+---
+
+## STEP Optimisation
+
+### `Exporter.optimizeSTEP(input:output:)`
+
+Reads a STEP file, deduplicates shared geometric entities, and writes the result to a new file.
+
+```swift
+public static func optimizeSTEP(input: URL, output: URL) throws
+```
+
+Can significantly reduce file size for STEP files with repeated geometry (assemblies, patterned
+features). The input file is read fresh — no in-memory shape is required.
+
+- **Parameters:** `input` — URL of the source STEP file; `output` — URL for the deduplicated output.
+- **Returns:** `Void`.
+- **Throws:** `ExportError.invalidPath` if either path is empty;
+  `ExportError.exportFailed` if the read-deduplicate-write cycle fails.
+- **OCCT:** `STEPControl_Reader` + `STEPControl_Writer` with entity deduplication.
+- **Example:**
+  ```swift
+  try Exporter.optimizeSTEP(
+      input:  URL(fileURLWithPath: "/tmp/large.step"),
+      output: URL(fileURLWithPath: "/tmp/large_opt.step")
+  )
+  ```
+
+---
+
+## StepModelType
+
+Defined in `Document.swift`; used by the `writeSTEP` and `writeSTEPCleanDuplicates` overloads.
+
+```swift
+public enum StepModelType: Int32, Sendable {
+    case asIs                        = 0
+    case manifoldSolidBrep           = 1
+    case brepWithVoids               = 2
+    case facetedBrep                 = 3
+    case facetedBrepAndBrepWithVoids = 4
+    case shellBasedSurfaceModel      = 5
+    case geometricCurveSet           = 6
+}
+```
+
+Maps to `STEPControl_StepModelType` in OCCT:
+
+| Case | OCCT value | When to use |
+|---|---|---|
+| `.asIs` | `STEPControl_AsIs` | Automatic — OCCT picks the most appropriate representation. Default for most exports. |
+| `.manifoldSolidBrep` | `STEPControl_ManifoldSolidBrep` | Solid bodies only; most interoperable with CAD tools. |
+| `.brepWithVoids` | `STEPControl_BrepWithVoids` | Solids with interior voids. |
+| `.facetedBrep` | `STEPControl_FacetedBrep` | Polyhedral shapes only. |
+| `.facetedBrepAndBrepWithVoids` | `STEPControl_FacetedBrepAndBrepWithVoids` | Mixed polyhedral + voids. |
+| `.shellBasedSurfaceModel` | `STEPControl_ShellBasedSurfaceModel` | Open shells, surface models. |
+| `.geometricCurveSet` | `STEPControl_GeometricCurveSet` | Wireframe / curve-only exports. |
+
+---
+
+## Shape Convenience Extensions
+
+The following instance methods are defined on `Shape` in `Exporter.swift`. Each delegates
+directly to the corresponding `Exporter.write…` static, accepting `self` as the `shape` argument.
+
+### `Shape.writeSTL(to:deflection:)`
+
+```swift
+public func writeSTL(to url: URL, deflection: Double = 0.1) throws
+```
+
+Delegates to `Exporter.writeSTL(shape:to:deflection:ascii:)` with `ascii: false`.
+
+- **Throws:** Same as `Exporter.writeSTL`.
+- **Example:**
+  ```swift
+  try shape.writeSTL(to: URL(fileURLWithPath: "/tmp/part.stl"), deflection: 0.05)
+  ```
+
+---
+
+### `Shape.stlData(deflection:)`
+
+```swift
+public func stlData(deflection: Double = 0.1) throws -> Data
+```
+
+- **Throws:** Same as `Exporter.stlData`.
+
+---
+
+### `Shape.writeSTEP(to:name:)`
+
+```swift
+public func writeSTEP(to url: URL, name: String? = nil) throws
+```
+
+- **Throws:** Same as `Exporter.writeSTEP(shape:to:name:)`.
+- **Example:**
+  ```swift
+  try shape.writeSTEP(to: stepURL, name: "Shaft")
+  ```
+
+---
+
+### `Shape.writeSTEP(to:modelType:)`
+
+```swift
+public func writeSTEP(to url: URL, modelType: StepModelType) throws
+```
+
+---
+
+### `Shape.writeSTEP(to:modelType:tolerance:)`
+
+```swift
+public func writeSTEP(to url: URL, modelType: StepModelType, tolerance: Double) throws
+```
+
+---
+
+### `Shape.writeSTEPCleanDuplicates(to:modelType:)`
+
+```swift
+public func writeSTEPCleanDuplicates(to url: URL, modelType: StepModelType = .asIs) throws
+```
+
+---
+
+### `Shape.stepData(name:)`
+
+```swift
+public func stepData(name: String? = nil) throws -> Data
+```
+
+---
+
+### `Shape.writeIGES(to:)`
+
+```swift
+public func writeIGES(to url: URL) throws
+```
+
+---
+
+### `Shape.igesData()`
+
+```swift
+public func igesData() throws -> Data
+```
+
+---
+
+### `Shape.writeIGES(to:unit:)`
+
+```swift
+public func writeIGES(to url: URL, unit: String) throws
+```
+
+---
+
+### `Shape.writeIGESBRep(to:)`
+
+```swift
+public func writeIGESBRep(to url: URL) throws
+```
+
+---
+
+### `Shape.writeBREP(to:withTriangles:withNormals:)`
+
+```swift
+public func writeBREP(to url: URL, withTriangles: Bool = true, withNormals: Bool = false) throws
+```
+
+---
+
+### `Shape.brepData(withTriangles:withNormals:)`
+
+```swift
+public func brepData(withTriangles: Bool = true, withNormals: Bool = false) throws -> Data
+```
+
+---
+
+### `Shape.writeOBJ(to:deflection:)`
+
+```swift
+public func writeOBJ(to url: URL, deflection: Double = 0.1) throws
+```
+
+---
+
+### `Shape.writePLY(to:deflection:)`
+
+```swift
+public func writePLY(to url: URL, deflection: Double = 0.1) throws
+```
+
+---
+
+### `Shape.writePLY(to:deflection:normals:colors:texCoords:)`
+
+```swift
+public func writePLY(to url: URL, deflection: Double,
+                      normals: Bool = true, colors: Bool = false, texCoords: Bool = false) throws
+```

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -1,0 +1,714 @@
+---
+title: Face
+parent: API Reference
+---
+
+# Face
+
+A `Face` represents a bounded surface region within a 3D solid — the Swift analog of OCCT's `TopoDS_Face`. Faces carry a reference to an underlying geometric surface (plane, cylinder, B-spline, etc.) trimmed by a boundary wire. Obtain faces by calling `Shape.faces()`, by constructing `Face(_ shape:)` from a face-typed `Shape`, or via the filtering helpers `Shape.upwardFaces()` and `Shape.horizontalFaces()`.
+
+## Topics
+
+- [Initializers](#initializers) · [Properties](#properties) · [Surface Properties (v0.18.0)](#surface-properties-v0180) · [Shape Extension — Face Analysis](#shape-extension--face-analysis) · [BRepGProp\_Face Evaluation (v0.45.0)](#brepgprop_face-evaluation-v0450)
+
+---
+
+## Initializers
+
+### `Face.init?(_ shape:)`
+
+Constructs a `Face` from a `Shape` that wraps a `TopoDS_Face`. Returns `nil` if the shape is null or wraps a non-face topology type.
+
+```swift
+public convenience init?(_ shape: Shape)
+```
+
+Inverse of `Shape.fromFace(_:)`. Use when you have a face-typed `Shape` (e.g. from `Shape.subShapes(ofType: .face)`) and need the typed `Face` object.
+
+- **Parameters:** `shape` — a `Shape` wrapping a `TopoDS_Face`.
+- **Returns:** `nil` if `shape` is null or `shape.shapeType != .face`.
+- **OCCT:** `TopoDS::Face` — checks `ShapeType() == TopAbs_FACE`, then casts the underlying `TopoDS_Shape`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let faceShapes = box.subShapes(ofType: .face)
+  if let face = Face(faceShapes[0]) {
+      print(face.surfaceType)  // .plane
+  }
+  ```
+
+---
+
+### `index`
+
+Index of this face within the parent shape from which it was extracted (`-1` if standalone).
+
+```swift
+public let index: Int
+```
+
+Set automatically when a `Face` is created via `Shape.faces()`; faces constructed via `Face(_ shape:)` get index `-1`.
+
+- **Example:**
+  ```swift
+  let faces = Shape.box(width: 10, height: 5, depth: 2)!.faces()
+  for face in faces {
+      print(face.index)  // 0, 1, 2, 3, 4, 5
+  }
+  ```
+
+---
+
+## Properties
+
+### `normal`
+
+The outward normal vector at the parametric centre of the face.
+
+```swift
+public var normal: SIMD3<Double>? { get }
+```
+
+Evaluates the surface normal at the midpoint of the face's UV parameter range. Respects face orientation (`TopAbs_REVERSED` flips the result).
+
+- **Returns:** Unit normal vector, or `nil` if the normal is undefined at the centre (e.g. degenerate face or singular parametric point).
+- **OCCT:** `BRepAdaptor_Surface` + `BRepLProp_SLProps::Normal` — adapts the face, evaluates at `(uMid, vMid)`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  for face in box.faces() {
+      if let n = face.normal {
+          print(n)  // one of ±X, ±Y, ±Z for a box
+      }
+  }
+  ```
+
+---
+
+### `outerWire`
+
+The outer boundary wire of the face.
+
+```swift
+public var outerWire: Wire? { get }
+```
+
+Returns the outermost wire (the single outer boundary loop); inner wires (holes) are not returned here.
+
+- **Returns:** The outer `Wire`, or `nil` if the face has no outer wire or retrieval fails.
+- **OCCT:** `BRepTools::OuterWire` — returns the outermost `TopoDS_Wire` of the face.
+- **Example:**
+  ```swift
+  if let face = Shape.box(width: 5, height: 5, depth: 5)!.faces().first,
+     let boundary = face.outerWire {
+      print(boundary.length)
+  }
+  ```
+
+---
+
+### `bounds`
+
+The axis-aligned bounding box of the face.
+
+```swift
+public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) { get }
+```
+
+- **Returns:** Tuple of min and max corners of the AABB. Returns `(.zero, .zero)` on error.
+- **OCCT:** `BRepBndLib::Add` + `Bnd_Box::Get`.
+- **Example:**
+  ```swift
+  let face = Shape.box(width: 10, height: 5, depth: 2)!.faces()[0]
+  let bb = face.bounds
+  // bb.min and bb.max define the face's extents
+  ```
+
+---
+
+### `isPlanar`
+
+Whether the face's underlying surface is a plane.
+
+```swift
+public var isPlanar: Bool { get }
+```
+
+- **Returns:** `true` if the underlying `GeomAbs_SurfaceType` is `GeomAbs_Plane`.
+- **OCCT:** `BRepAdaptor_Surface::GetType() == GeomAbs_Plane`.
+- **Example:**
+  ```swift
+  let face = Shape.box(width: 10, height: 10, depth: 10)!.faces()[0]
+  #expect(face.isPlanar)  // box faces are planar
+  ```
+
+---
+
+### `isHorizontal(tolerance:)`
+
+Whether the face's normal is pointing up or down (parallel to the Z axis within the given tolerance).
+
+```swift
+public func isHorizontal(tolerance: Double = 0.01) -> Bool
+```
+
+Pure-Swift: computes `abs(normal.z) > cos(tolerance)`.
+
+- **Parameters:** `tolerance` — angle tolerance in radians (default ~0.57°).
+- **Returns:** `true` if the face's centre normal is within `tolerance` of the ±Z axis; `false` if `normal` is `nil`.
+- **Example:**
+  ```swift
+  let top = Shape.box(width: 10, height: 10, depth: 5)!.faces()
+      .filter { $0.isHorizontal() }
+  #expect(top.count == 2)  // top and bottom of box
+  ```
+
+---
+
+### `isUpwardFacing(tolerance:)`
+
+Whether the face's normal points upward (positive Z component).
+
+```swift
+public func isUpwardFacing(tolerance: Double = 0.01) -> Bool
+```
+
+Pure-Swift: computes `normal.z > cos(tolerance)`.
+
+- **Parameters:** `tolerance` — angle tolerance in radians (default ~0.57°).
+- **Returns:** `true` if the face is horizontal and upward-facing; `false` if `normal` is `nil`.
+- **Example:**
+  ```swift
+  let floor = Shape.box(width: 10, height: 10, depth: 5)!.faces()
+      .filter { $0.isUpwardFacing() }
+  #expect(floor.count == 1)  // top face
+  ```
+
+---
+
+### `isDownwardFacing(tolerance:)`
+
+Whether the face's normal points downward (negative Z component).
+
+```swift
+public func isDownwardFacing(tolerance: Double = 0.01) -> Bool
+```
+
+Pure-Swift: computes `normal.z < -cos(tolerance)`.
+
+- **Parameters:** `tolerance` — angle tolerance in radians (default ~0.57°).
+- **Returns:** `true` if the face is horizontal and downward-facing; `false` if `normal` is `nil`.
+- **Example:**
+  ```swift
+  let ceiling = Shape.box(width: 10, height: 10, depth: 5)!.faces()
+      .filter { $0.isDownwardFacing() }
+  #expect(ceiling.count == 1)  // bottom face
+  ```
+
+---
+
+### `isVertical(tolerance:)`
+
+Whether the face's normal is horizontal (perpendicular to Z axis).
+
+```swift
+public func isVertical(tolerance: Double = 0.01) -> Bool
+```
+
+Pure-Swift: computes `abs(normal.z) < sin(tolerance)`.
+
+- **Parameters:** `tolerance` — angle tolerance in radians (default ~0.57°).
+- **Returns:** `true` if the face's normal lies in the XY plane within `tolerance`; `false` if `normal` is `nil`.
+- **Example:**
+  ```swift
+  let walls = Shape.box(width: 10, height: 10, depth: 5)!.faces()
+      .filter { $0.isVertical() }
+  #expect(walls.count == 4)  // four side faces
+  ```
+
+---
+
+### `zLevel`
+
+The Z coordinate of a horizontal planar face.
+
+```swift
+public var zLevel: Double? { get }
+```
+
+Returns `nil` if the face is not planar, not horizontal (normal within 0.99 of ±Z), or the bridge call fails.
+
+- **Returns:** The Z coordinate of the face's plane location, or `nil` if the face is non-planar or non-horizontal.
+- **OCCT:** `BRepAdaptor_Surface::Plane()` → `gp_Pln::Location().Z()`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 5)!
+  let zLevels = box.faces().compactMap { $0.zLevel }
+  // zLevels contains 0.0 (bottom) and 5.0 (top)
+  ```
+
+---
+
+## Surface Properties (v0.18.0)
+
+### `SurfaceType`
+
+Classification of the underlying geometric surface type.
+
+```swift
+public enum SurfaceType: Int32, Sendable {
+    case plane = 0, cylinder = 1, cone = 2, sphere = 3, torus = 4
+    case bezierSurface = 5, bsplineSurface = 6
+    case surfaceOfRevolution = 7, surfaceOfExtrusion = 8
+    case offsetSurface = 9, other = 10
+}
+```
+
+Corresponds to OCCT's `GeomAbs_SurfaceType` enumeration, mapped via `BRepAdaptor_Surface::GetType()`.
+
+---
+
+### `PrincipalCurvatures`
+
+Result of a principal curvature query at a UV parameter.
+
+```swift
+public struct PrincipalCurvatures: Sendable {
+    public let kMin: Double
+    public let kMax: Double
+    public let dirMin: SIMD3<Double>
+    public let dirMax: SIMD3<Double>
+}
+```
+
+- `kMin` / `kMax` — minimum and maximum principal curvatures (reciprocals of principal radii).
+- `dirMin` / `dirMax` — unit direction vectors of the principal curvature lines on the surface.
+
+---
+
+### `SurfaceProjection`
+
+Result of projecting a 3D point onto the face's surface.
+
+```swift
+public struct SurfaceProjection: Sendable {
+    public let point: SIMD3<Double>
+    public let u: Double
+    public let v: Double
+    public let distance: Double
+}
+```
+
+- `point` — closest 3D point on the surface.
+- `u`, `v` — UV parameters of that point.
+- `distance` — Euclidean distance from the query point to `point`.
+
+---
+
+### `uvBounds`
+
+The UV parameter bounds of the face as trimmed by its boundary wires.
+
+```swift
+public var uvBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? { get }
+```
+
+Uses `BRepTools::UVBounds` which accounts for the face's trimming wires. For integration-ready bounds that respect face orientation, use `naturalBounds` instead.
+
+- **Returns:** UV extents, or `nil` on error.
+- **OCCT:** `BRepTools::UVBounds`.
+- **Example:**
+  ```swift
+  if let uv = face.uvBounds {
+      let uMid = (uv.uMin + uv.uMax) / 2
+      let vMid = (uv.vMin + uv.vMax) / 2
+      let center = face.point(atU: uMid, v: vMid)
+  }
+  ```
+
+---
+
+### `surfaceType`
+
+The geometric surface type of this face.
+
+```swift
+public var surfaceType: SurfaceType { get }
+```
+
+Never fails — returns `.other` if the type cannot be determined.
+
+- **OCCT:** `BRepAdaptor_Surface::GetType()` mapped to `SurfaceType`.
+- **Example:**
+  ```swift
+  let cyl = Shape.cylinder(radius: 5, height: 10)!
+  let side = cyl.faces().first { $0.surfaceType == .cylinder }
+  ```
+
+---
+
+### `area(tolerance:)`
+
+The surface area of the face.
+
+```swift
+public func area(tolerance: Double = 1e-6) -> Double
+```
+
+- **Parameters:** `tolerance` — numerical integration tolerance (default 1e-6).
+- **Returns:** Area in squared model units; returns `-1.0` on error.
+- **OCCT:** `BRepGProp::SurfaceProperties` + `GProp_GProps::Mass`.
+- **Example:**
+  ```swift
+  let topFace = Shape.box(width: 10, height: 5, depth: 2)!
+      .faces().filter { $0.isUpwardFacing() }.first!
+  #expect(topFace.area() ≈ 50.0)
+  ```
+
+---
+
+### `point(atU:v:)`
+
+Evaluates the 3D point on the surface at UV parameters.
+
+```swift
+public func point(atU u: Double, v: Double) -> SIMD3<Double>?
+```
+
+- **Parameters:** `u` — U surface parameter; `v` — V surface parameter.
+- **Returns:** 3D point, or `nil` if the surface is null or evaluation fails.
+- **OCCT:** `BRep_Tool::Surface` + `Geom_Surface::D0(u, v, pnt)`.
+- **Example:**
+  ```swift
+  if let uv = face.uvBounds {
+      let mid = face.point(atU: (uv.uMin + uv.uMax) / 2,
+                           v:   (uv.vMin + uv.vMax) / 2)
+  }
+  ```
+
+---
+
+### `normal(atU:v:)`
+
+Evaluates the outward surface normal at UV parameters.
+
+```swift
+public func normal(atU u: Double, v: Double) -> SIMD3<Double>?
+```
+
+Respects face orientation (`TopAbs_REVERSED` flips the result). Uses order-1 surface properties.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Unit normal vector, or `nil` if the normal is undefined at `(u, v)`.
+- **OCCT:** `BRep_Tool::Surface` + `GeomLProp_SLProps::Normal` (order 1, `Precision::Confusion()` tolerance).
+- **Example:**
+  ```swift
+  if let uv = face.uvBounds, let n = face.normal(atU: uv.uMin, v: uv.vMin) {
+      print(n)
+  }
+  ```
+
+---
+
+### `gaussianCurvature(atU:v:)`
+
+The Gaussian curvature of the surface at UV parameters.
+
+```swift
+public func gaussianCurvature(atU u: Double, v: Double) -> Double?
+```
+
+Gaussian curvature = k₁ × k₂ (product of principal curvatures). Positive on convex/concave surfaces; negative on saddle surfaces; zero on developable surfaces.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Gaussian curvature value, or `nil` if curvature is undefined at `(u, v)`.
+- **OCCT:** `GeomLProp_SLProps::GaussianCurvature` (order 2).
+- **Example:**
+  ```swift
+  let sphere = Shape.sphere(radius: 5)!
+  if let face = sphere.faces().first, let uv = face.uvBounds {
+      let k = face.gaussianCurvature(atU: (uv.uMin + uv.uMax) / 2,
+                                     v:   (uv.vMin + uv.vMax) / 2)
+      // k ≈ 1/25 (= 1/r²) for a sphere of radius 5
+  }
+  ```
+
+---
+
+### `meanCurvature(atU:v:)`
+
+The mean curvature of the surface at UV parameters.
+
+```swift
+public func meanCurvature(atU u: Double, v: Double) -> Double?
+```
+
+Mean curvature = (k₁ + k₂) / 2. Zero on minimal surfaces; equal to 1/R on a sphere of radius R.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Mean curvature value, or `nil` if curvature is undefined at `(u, v)`.
+- **OCCT:** `GeomLProp_SLProps::MeanCurvature` (order 2).
+- **Example:**
+  ```swift
+  if let face = Shape.cylinder(radius: 5, height: 10)!.faces()
+      .first(where: { $0.surfaceType == .cylinder }),
+     let uv = face.uvBounds {
+      let h = face.meanCurvature(atU: (uv.uMin + uv.uMax) / 2,
+                                 v:   (uv.vMin + uv.vMax) / 2)
+      // h ≈ 0.1 (1/(2r)) for a cylinder
+  }
+  ```
+
+---
+
+### `principalCurvatures(atU:v:)`
+
+The principal curvatures and their directions at UV parameters.
+
+```swift
+public func principalCurvatures(atU u: Double, v: Double) -> PrincipalCurvatures?
+```
+
+Returns both principal curvature values (kMin, kMax) and their surface directions. Requires order-2 surface property evaluation.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** `PrincipalCurvatures` struct, or `nil` if curvature is undefined at `(u, v)`.
+- **OCCT:** `GeomLProp_SLProps::MinCurvature`, `MaxCurvature`, `CurvatureDirections` (order 2).
+- **Example:**
+  ```swift
+  if let uv = face.uvBounds,
+     let pc = face.principalCurvatures(atU: (uv.uMin + uv.uMax) / 2,
+                                       v:   (uv.vMin + uv.vMax) / 2) {
+      print(pc.kMin, pc.kMax, pc.dirMin, pc.dirMax)
+  }
+  ```
+
+---
+
+### `project(point:)`
+
+Projects a 3D point onto the face's surface, returning the closest point.
+
+```swift
+public func project(point: SIMD3<Double>) -> SurfaceProjection?
+```
+
+Restricts the projection to the face's UV parameter range (as returned by `BRepTools::UVBounds`).
+
+- **Parameters:** `point` — 3D query point.
+- **Returns:** `SurfaceProjection` with the closest 3D point, its UV parameters, and the distance; `nil` if no projection exists or the face is null.
+- **OCCT:** `GeomAPI_ProjectPointOnSurf::NearestPoint` / `LowerDistanceParameters` / `LowerDistance`.
+- **Example:**
+  ```swift
+  let face = Shape.box(width: 10, height: 10, depth: 10)!.faces()[0]
+  if let proj = face.project(point: SIMD3(5, 5, 20)) {
+      print(proj.point, proj.distance)
+  }
+  ```
+
+---
+
+### `allProjections(of:)`
+
+Returns all projection results (not just the nearest) for a 3D point onto the face's surface.
+
+```swift
+public func allProjections(of point: SIMD3<Double>) -> [SurfaceProjection]
+```
+
+Uses a fixed buffer of up to 32 results. For most surfaces there is only one projection; multiple results arise on periodic or multiply-connected surfaces.
+
+- **Parameters:** `point` — 3D query point.
+- **Returns:** Array of `SurfaceProjection` values (may be empty if no projections are found).
+- **OCCT:** `GeomAPI_ProjectPointOnSurf::NbPoints` / `Point(i)` / `Parameters(i)` / `Distance(i)`.
+- **Example:**
+  ```swift
+  let projections = face.allProjections(of: SIMD3(0, 0, 100))
+  for p in projections {
+      print(p.point, p.u, p.v, p.distance)
+  }
+  ```
+
+---
+
+### `intersection(with:tolerance:)`
+
+Computes the intersection curves between this face and another face.
+
+```swift
+public func intersection(with other: Face, tolerance: Double = 1e-6) -> Shape?
+```
+
+The result is a `Shape` containing intersection edges (or a compound thereof). Returns `nil` if the faces do not intersect or construction fails.
+
+- **Parameters:** `other` — the second face; `tolerance` — fuzzy intersection tolerance (default 1e-6).
+- **Returns:** A `Shape` containing the intersection curves, or `nil` if there is no intersection.
+- **OCCT:** `BRepAlgoAPI_Section` — `Approximation(true)`, `ComputePCurveOn1(true)`, `ComputePCurveOn2(true)`, `SetFuzzyValue(tolerance)`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let faces = box.faces()
+  if faces.count >= 2,
+     let seam = faces[0].intersection(with: faces[1]) {
+      // seam contains the shared edge geometry
+  }
+  ```
+
+---
+
+## Shape Extension — Face Analysis
+
+These methods are declared as extensions on `Shape` and operate on the face sub-shapes of a solid.
+
+---
+
+### `Shape.faces()`
+
+Returns all face sub-shapes of the solid as typed `Face` objects.
+
+```swift
+public func faces() -> [Face]
+```
+
+Each returned `Face` carries its ordinal `index` within the traversal order. Returns an empty array if the shape has no faces or `TopExp_Explorer` fails.
+
+- **OCCT:** `TopExp_Explorer(shape, TopAbs_FACE)` — iterates all `TopoDS_Face` sub-shapes.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let faces = box.faces()
+  #expect(faces.count == 6)
+  ```
+
+---
+
+### `Shape.horizontalFaces(tolerance:)`
+
+Returns the subset of faces whose normals point up or down.
+
+```swift
+public func horizontalFaces(tolerance: Double = 0.01) -> [Face]
+```
+
+Pure-Swift filter over `faces()` using `Face.isHorizontal(tolerance:)`.
+
+- **Parameters:** `tolerance` — angle tolerance in radians (default ~0.57°).
+- **Returns:** Faces with normals within `tolerance` of the ±Z axis.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 5)!
+  let h = box.horizontalFaces()
+  #expect(h.count == 2)
+  ```
+
+---
+
+### `Shape.upwardFaces(tolerance:)`
+
+Returns the subset of faces whose normals point upward (positive Z).
+
+```swift
+public func upwardFaces(tolerance: Double = 0.01) -> [Face]
+```
+
+Pure-Swift filter over `faces()` using `Face.isUpwardFacing(tolerance:)`. Useful for identifying pocket floors and platform surfaces in CAM.
+
+- **Parameters:** `tolerance` — angle tolerance in radians (default ~0.57°).
+- **Returns:** Upward-facing horizontal faces.
+- **Example:**
+  ```swift
+  let pocketFloors = myPart.upwardFaces()
+  for face in pocketFloors {
+      print(face.zLevel ?? "non-planar")
+  }
+  ```
+
+---
+
+### `Shape.facesByZLevel(tolerance:)`
+
+Groups horizontal faces by their Z height.
+
+```swift
+public func facesByZLevel(tolerance: Double = 0.01) -> [Double: [Face]]
+```
+
+Calls `horizontalFaces()`, then groups faces whose `zLevel` values are within `tolerance` of each other. Designed for CAM pocket detection and layer-by-layer machining analysis.
+
+- **Parameters:** `tolerance` — Z grouping tolerance; faces within this Z distance are placed in the same group.
+- **Returns:** Dictionary mapping representative Z values to arrays of horizontal faces at that level.
+- **Note:** Only planar horizontal faces (those with a non-nil `zLevel`) are included; non-planar horizontal faces are silently dropped.
+- **Example:**
+  ```swift
+  let stepped = Shape.box(width: 10, height: 10, depth: 5)! // simplified
+  let byZ = stepped.facesByZLevel()
+  for (z, faces) in byZ.sorted(by: { $0.key < $1.key }) {
+      print("Z=\(z): \(faces.count) face(s)")
+  }
+  ```
+
+---
+
+## BRepGProp\_Face Evaluation (v0.45.0)
+
+### `GPropEvaluation`
+
+Result of evaluating a face at UV parameters using `BRepGProp_Face`.
+
+```swift
+public struct GPropEvaluation: Sendable {
+    public let point: SIMD3<Double>
+    public let normal: SIMD3<Double>
+}
+```
+
+- `point` — 3D point on the surface at `(u, v)`.
+- `normal` — unnormalized surface normal (`dS/du × dS/dv`). The magnitude equals the local area element (Jacobian determinant), making it suitable for numerical surface integration.
+
+---
+
+### `naturalBounds`
+
+The natural parametric bounds of the face using `BRepGProp_Face`.
+
+```swift
+public var naturalBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? { get }
+```
+
+Unlike `uvBounds` (which uses `BRepTools::UVBounds`), this uses `BRepGProp_Face::Bounds`, which accounts for face orientation and returns integration-ready bounds.
+
+- **Returns:** UV bounds, or `nil` on error.
+- **OCCT:** `BRepGProp_Face::Bounds`.
+- **Example:**
+  ```swift
+  if let nb = face.naturalBounds {
+      let eval = face.evaluateGProp(u: (nb.uMin + nb.uMax) / 2,
+                                    v: (nb.vMin + nb.vMax) / 2)
+  }
+  ```
+
+---
+
+### `evaluateGProp(u:v:)`
+
+Evaluates the face surface at UV parameters via `BRepGProp_Face`, returning both the 3D point and the unnormalized surface normal.
+
+```swift
+public func evaluateGProp(u: Double, v: Double) -> GPropEvaluation?
+```
+
+The returned `normal` is the cross product `dS/du × dS/dv` whose magnitude equals the local surface area element. Use this for surface integration (e.g. computing area, flux integrals) rather than for visual normal shading (use `normal(atU:v:)` for unit normals).
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** `GPropEvaluation` with point and unnormalized normal, or `nil` on error.
+- **OCCT:** `BRepGProp_Face::Normal(u, v, point, normal)`.
+- **Example:**
+  ```swift
+  if let nb = face.naturalBounds,
+     let eval = face.evaluateGProp(u: (nb.uMin + nb.uMax) / 2,
+                                   v: (nb.vMin + nb.vMax) / 2) {
+      let areaElement = simd_length(eval.normal)  // Jacobian at this UV point
+      print(eval.point, eval.normal, areaElement)
+  }
+  ```
+- **Note:** The `normal` field is NOT a unit vector — its magnitude carries the area element. Call `.normalized` on it only if you need the direction without the scaling factor.

--- a/docs/reference/Mesh.md
+++ b/docs/reference/Mesh.md
@@ -1,0 +1,670 @@
+---
+title: Mesh
+parent: API Reference
+---
+
+# Mesh
+
+A `Mesh` is a triangulated surface representation — vertices, per-vertex normals, and triangle
+indices — produced by tessellating a `Shape` or built directly from raw arrays. It is the bridge
+between OCCT's exact B-Rep geometry and renderers (SceneKit, RealityKit, Metal) and mesh file
+formats (STL, OBJ, PLY). Obtain one by calling `Shape.mesh(linearDeflection:)` or
+`Shape.mesh(parameters:)`, or construct one from your own `vertices`/`indices` arrays with
+`Mesh.init(vertices:normals:indices:)`.
+
+## Topics
+
+- [Initializers](#initializers) · [Mesh Data](#mesh-data) · [Statistics](#statistics) · [Triangle Access with Face Info](#triangle-access-with-face-info) · [Mesh to Shape Conversion](#mesh-to-shape-conversion) · [Mesh Boolean Operations](#mesh-boolean-operations) · [SceneKit Integration](#scenekit-integration) · [Metal Integration](#metal-integration) · [RealityKit Integration](#realitykit-integration)
+
+---
+
+## Initializers
+
+### `Mesh.init(vertices:normals:indices:)`
+
+Constructs a `Mesh` directly from raw vertex-position and triangle-index arrays.
+
+```swift
+public convenience init?(
+    vertices: [SIMD3<Float>],
+    normals: [SIMD3<Float>]? = nil,
+    indices: [UInt32]
+)
+```
+
+Use this when you have vertex/index data from an external algorithm (decimation, smoothing,
+repair, remeshing, OBJ/STL/glTF import) and no B-Rep source. For meshes derived from OCCT
+shapes, use `Shape.mesh()` instead. When `normals` is `nil`, per-vertex normals are computed
+by averaging the face normals of adjacent triangles (smooth shading).
+
+- **Parameters:**
+  - `vertices` — per-vertex positions; must not be empty.
+  - `normals` — optional per-vertex normals; if provided must have the same count as `vertices`.
+    Pass `nil` to auto-compute smooth normals from triangle adjacency.
+  - `indices` — triangle index triples; length must be a multiple of 3, every value `< vertices.count`.
+- **Returns:** `nil` if any input is empty, `indices.count % 3 != 0`, a normal-count mismatch
+  exists, or any index is out of bounds.
+- **OCCT:** Pure-Swift validation; data is stored in the C `OCCTMesh` struct via
+  `OCCTMeshCreateFromArrays`.
+- **Example:**
+  ```swift
+  // Octahedron — normals auto-computed
+  let v: [SIMD3<Float>] = [
+      SIMD3(0, 0, 1), SIMD3(1, 0, 0), SIMD3(0, 1, 0),
+      SIMD3(-1, 0, 0), SIMD3(0, -1, 0), SIMD3(0, 0, -1),
+  ]
+  let idx: [UInt32] = [0,1,2, 0,2,3, 0,3,4, 0,4,1, 5,2,1, 5,3,2, 5,4,3, 5,1,4]
+  guard let mesh = Mesh(vertices: v, indices: idx) else { return }
+  ```
+
+---
+
+## Mesh Data
+
+### `vertexCount`
+
+The number of vertices in the mesh.
+
+```swift
+public var vertexCount: Int { get }
+```
+
+- **Returns:** Count of distinct vertex positions.
+- **OCCT:** `OCCTMeshGetVertexCount` — returns `vertices.size() / 3` from the internal float buffer.
+- **Example:**
+  ```swift
+  let mesh = Shape.box(width: 10, height: 5, depth: 3)!.mesh(linearDeflection: 0.1)!
+  print(mesh.vertexCount)
+  ```
+
+---
+
+### `triangleCount`
+
+The number of triangles in the mesh.
+
+```swift
+public var triangleCount: Int { get }
+```
+
+- **Returns:** Count of triangles; equals `indices.count / 3`.
+- **OCCT:** `OCCTMeshGetTriangleCount` — returns `indices.size() / 3` from the internal index buffer.
+- **Example:**
+  ```swift
+  print(mesh.triangleCount)
+  // indices.count == mesh.triangleCount * 3
+  ```
+
+---
+
+### `vertices`
+
+Vertex positions as an array of `SIMD3<Float>`.
+
+```swift
+public var vertices: [SIMD3<Float>] { get }
+```
+
+Each element is the 3D position of one vertex. Array length equals `vertexCount`.
+
+- **Returns:** Position array; `[]` if the mesh is empty.
+- **OCCT:** `OCCTMeshGetVertices` — copies the internal contiguous float buffer, then repackages
+  into `SIMD3`.
+- **Example:**
+  ```swift
+  for p in mesh.vertices {
+      print(p.x, p.y, p.z)
+  }
+  ```
+
+---
+
+### `normals`
+
+Per-vertex normals as an array of `SIMD3<Float>`.
+
+```swift
+public var normals: [SIMD3<Float>] { get }
+```
+
+Each normal is a unit vector perpendicular to the surface at that vertex. Array length equals
+`vertexCount`. Normals are set during tessellation (`BRepMesh_IncrementalMesh` computes them
+from face curvature) or, for array-constructed meshes, by averaging adjacent face normals.
+
+- **Returns:** Normal array; `[]` if the mesh is empty.
+- **OCCT:** `OCCTMeshGetNormals` — copies the internal normal float buffer.
+- **Example:**
+  ```swift
+  for n in mesh.normals {
+      // n is approximately unit-length
+  }
+  ```
+
+---
+
+### `indices`
+
+Triangle indices as an array of `UInt32`.
+
+```swift
+public var indices: [UInt32] { get }
+```
+
+Every three consecutive values define one triangle referencing vertices at those positions in
+`vertices`. Array length equals `triangleCount * 3`.
+
+- **Returns:** Index array; `[]` if the mesh has no triangles.
+- **OCCT:** `OCCTMeshGetIndices` — copies the internal index buffer.
+- **Example:**
+  ```swift
+  let idx = mesh.indices
+  // Triangle 0: idx[0], idx[1], idx[2]
+  // Triangle 1: idx[3], idx[4], idx[5]
+  ```
+
+---
+
+### `vertexData`
+
+Raw vertex positions as a contiguous `[Float]` interleaved array.
+
+```swift
+public var vertexData: [Float] { get }
+```
+
+Format: `[x0, y0, z0, x1, y1, z1, …]`. Length is `vertexCount * 3`. Ready for direct upload
+to a GPU buffer without repackaging.
+
+- **Returns:** Flat float array; `[]` if the mesh is empty.
+- **OCCT:** `OCCTMeshGetVertices` — same buffer copy as `vertices`, without `SIMD3` wrapping.
+- **Example:**
+  ```swift
+  let (positions, normals, indices) = mesh.metalBufferData()
+  // positions is equivalent to Data(mesh.vertexData.withUnsafeBytes { … })
+  ```
+
+---
+
+### `normalData`
+
+Raw per-vertex normals as a contiguous `[Float]` interleaved array.
+
+```swift
+public var normalData: [Float] { get }
+```
+
+Format: `[nx0, ny0, nz0, nx1, ny1, nz1, …]`. Length is `vertexCount * 3`. Pair with
+`vertexData` and `indices` for zero-copy GPU uploads.
+
+- **Returns:** Flat float array; `[]` if the mesh is empty.
+- **OCCT:** `OCCTMeshGetNormals` — same buffer copy as `normals`, without `SIMD3` wrapping.
+- **Example:**
+  ```swift
+  let posData = Data(bytes: mesh.vertexData, count: mesh.vertexData.count * 4)
+  let nrmData = Data(bytes: mesh.normalData, count: mesh.normalData.count * 4)
+  ```
+
+---
+
+## Statistics
+
+### `boundingBox`
+
+Axis-aligned bounding box of the mesh.
+
+```swift
+public var boundingBox: (min: SIMD3<Float>, max: SIMD3<Float>) { get }
+```
+
+Computed by iterating all vertex positions using Swift `min`/`max` component-wise reduction.
+
+- **Returns:** `(min, max)` corner tuple; `(.zero, .zero)` if the mesh is empty.
+- **OCCT:** Pure-Swift — iterates `vertices`.
+- **Example:**
+  ```swift
+  let (lo, hi) = mesh.boundingBox
+  print("X span:", hi.x - lo.x)
+  ```
+
+---
+
+### `size`
+
+Extent of the mesh in each dimension.
+
+```swift
+public var size: SIMD3<Float> { get }
+```
+
+Computed as `boundingBox.max − boundingBox.min`.
+
+- **Returns:** Width, height, depth of the AABB.
+- **OCCT:** Pure-Swift — delegates to `boundingBox`.
+- **Example:**
+  ```swift
+  let s = mesh.size   // SIMD3(width, height, depth)
+  ```
+
+---
+
+### `center`
+
+Centre point of the mesh bounding box.
+
+```swift
+public var center: SIMD3<Float> { get }
+```
+
+Computed as `(boundingBox.min + boundingBox.max) / 2`.
+
+- **Returns:** Centroid of the AABB.
+- **OCCT:** Pure-Swift — delegates to `boundingBox`.
+- **Example:**
+  ```swift
+  let c = mesh.center
+  ```
+
+---
+
+## Triangle Access with Face Info
+
+### `trianglesWithFaces()`
+
+Returns all triangles with their source B-Rep face index and per-triangle normal.
+
+```swift
+public func trianglesWithFaces() -> [Triangle]
+```
+
+Provides richer data than `indices` alone: each `Triangle` carries `v1`/`v2`/`v3` vertex
+indices, a `faceIndex` identifying which B-Rep face this triangle was tessellated from (−1 if
+unknown, e.g. from `Mesh.init(vertices:normals:indices:)`), and a `normal` vector. Use for
+B-Rep-face-aware picking, CAM operations that need to reason per face, or custom per-triangle
+shading.
+
+- **Returns:** Array of `Triangle` structs; `[]` if the mesh has no triangles.
+- **OCCT:** `OCCTMeshGetTrianglesWithFaces` — reads the internal `faceIndices` and
+  `triangleNormals` arrays alongside the index buffer.
+- **Example:**
+  ```swift
+  for tri in mesh.trianglesWithFaces() {
+      // tri.v1 / tri.v2 / tri.v3 : UInt32 vertex indices
+      // tri.faceIndex : Int32 (source B-Rep face, or -1)
+      // tri.normal    : SIMD3<Float>
+  }
+  ```
+
+---
+
+## Mesh to Shape Conversion
+
+### `toShape(weldTolerance:)`
+
+Converts this mesh back to a B-Rep `Shape` by sewing triangle faces into a shell.
+
+```swift
+public func toShape(weldTolerance: Double = 1e-6) -> Shape?
+```
+
+Each triangle becomes a planar B-Rep face; `BRepBuilderAPI_Sewing` merges shared edges within
+`weldTolerance` to produce a connected shell. The resulting shape is a shell (or compound of
+planar faces), not necessarily a valid manifold solid — run shape healing if you need one. The
+weld tolerance must scale with the mesh's coordinate magnitude: a value too small for a
+large-coordinate mesh leaves edges unmerged and yields an open shell.
+
+- **Parameters:** `weldTolerance` — vertex-merge tolerance in model units (default `1e-6`; raise
+  for large-coordinate meshes). Must be positive.
+- **Returns:** A `Shape` representing the tessellated geometry, or `nil` if the mesh is empty,
+  weldTolerance is ≤ 0, or sewing fails.
+- **OCCT:** `OCCTMeshToShapeWithTolerance` → `BRepBuilderAPI_MakeEdge` + `BRepBuilderAPI_MakeFace`
+  per triangle + `BRepBuilderAPI_Sewing::Perform`.
+- **Example:**
+  ```swift
+  let shape = mesh.toShape(weldTolerance: 1e-6)   // raise for large-coordinate meshes
+  ```
+- **Note:** For an STL file on disk, prefer `Shape.loadSTLRobust(from:sewingTolerance:)` which
+  sews and heals as it loads. The result of `toShape` is a faceted shell — run
+  [healing](../guides/cookbook/healing-and-validity.md) if you need a valid solid.
+
+---
+
+## Mesh Boolean Operations
+
+### `union(with:deflection:)`
+
+Performs boolean union with another mesh via a B-Rep roundtrip.
+
+```swift
+public func union(with other: Mesh, deflection: Double = 0.1) -> Mesh?
+```
+
+Both meshes are lifted to B-Rep shells (`BRepBuilderAPI_Sewing`), the union is computed
+(`BRepAlgoAPI_Fuse`), and the result is re-tessellated at `deflection`. Because the operation
+works on tessellations — not exact B-Rep — prefer the B-Rep boolean `Shape.union(_:)` when
+exact geometry matters.
+
+- **Parameters:** `other` — mesh to add; `deflection` — linear deflection for re-tessellating
+  the result (default `0.1`).
+- **Returns:** Union mesh, or `nil` if conversion or the boolean operation fails.
+- **OCCT:** `OCCTMeshUnion` → `BRepBuilderAPI_Sewing` + `BRepAlgoAPI_Fuse` +
+  `BRepMesh_IncrementalMesh`.
+- **Example:**
+  ```swift
+  guard let a = Shape.box(width: 12, height: 12, depth: 12)?.mesh(linearDeflection: 0.3),
+        let b = Shape.cylinder(at: SIMD3(6, 6, -1), direction: SIMD3(0, 0, 1),
+                               radius: 3, height: 14)?.mesh(linearDeflection: 0.3)
+  else { return }
+  let joined = a.union(with: b, deflection: 0.3)
+  ```
+- **Note:** Mesh booleans are convenient for triangle pipelines but operate on approximations.
+  For exact, valid solids prefer the B-Rep booleans and mesh the result at the end.
+
+---
+
+### `subtracting(_:deflection:)`
+
+Subtracts another mesh from this mesh via a B-Rep roundtrip.
+
+```swift
+public func subtracting(_ other: Mesh, deflection: Double = 0.1) -> Mesh?
+```
+
+Both meshes are lifted to B-Rep shells, the subtraction is computed (`BRepAlgoAPI_Cut`), and
+the result is re-tessellated at `deflection`.
+
+- **Parameters:** `other` — mesh to subtract; `deflection` — linear deflection for
+  re-tessellating the result.
+- **Returns:** Difference mesh, or `nil` on failure.
+- **OCCT:** `OCCTMeshSubtract` → `BRepBuilderAPI_Sewing` + `BRepAlgoAPI_Cut` +
+  `BRepMesh_IncrementalMesh`.
+- **Example:**
+  ```swift
+  let cut = a.subtracting(b, deflection: 0.3)   // box with a drilled hole
+  ```
+
+---
+
+### `intersection(with:deflection:)`
+
+Intersects this mesh with another mesh via a B-Rep roundtrip.
+
+```swift
+public func intersection(with other: Mesh, deflection: Double = 0.1) -> Mesh?
+```
+
+Both meshes are lifted to B-Rep shells, the intersection is computed (`BRepAlgoAPI_Common`),
+and the result is re-tessellated at `deflection`.
+
+- **Parameters:** `other` — mesh to intersect with; `deflection` — linear deflection for
+  re-tessellating the result.
+- **Returns:** Intersection mesh, or `nil` on failure.
+- **OCCT:** `OCCTMeshIntersect` → `BRepBuilderAPI_Sewing` + `BRepAlgoAPI_Common` +
+  `BRepMesh_IncrementalMesh`.
+- **Example:**
+  ```swift
+  let common = a.intersection(with: b, deflection: 0.3)
+  ```
+
+---
+
+## SceneKit Integration
+
+Available on macOS / iOS where SceneKit is importable (`#if canImport(SceneKit)`). These
+members are pure-Swift and do not call the OCCT bridge.
+
+---
+
+### `sceneKitGeometry()`
+
+Creates an `SCNGeometry` from this mesh.
+
+```swift
+public func sceneKitGeometry() -> SCNGeometry
+```
+
+Packages `vertexData` and `normalData` into `SCNGeometrySource` objects (float, 3 components,
+stride 12 bytes) and `indices` into an `SCNGeometryElement` with `.triangles` primitive type.
+Apply materials separately before adding to a scene.
+
+- **Returns:** `SCNGeometry` with vertex and normal sources; returns an empty `SCNGeometry` if
+  the mesh has no vertices.
+- **OCCT:** Pure-Swift — reads `vertexData`, `normalData`, `indices`.
+- **Example:**
+  ```swift
+  let geometry = mesh.sceneKitGeometry()
+  let material = SCNMaterial()
+  material.diffuse.contents = UIColor.gray
+  material.metalness.contents = 0.8
+  geometry.materials = [material]
+  let node = SCNNode(geometry: geometry)
+  scene.rootNode.addChildNode(node)
+  ```
+
+---
+
+### `sceneKitNode(material:)`
+
+Creates an `SCNNode` with this mesh and an optional material applied.
+
+```swift
+public func sceneKitNode(material: SCNMaterial? = nil) -> SCNNode
+```
+
+Convenience wrapper: calls `sceneKitGeometry()`, optionally assigns `material`, then wraps in
+an `SCNNode`.
+
+- **Parameters:** `material` — optional material; `nil` leaves the geometry with no applied material.
+- **Returns:** `SCNNode` ready to add to a scene.
+- **OCCT:** Pure-Swift — delegates to `sceneKitGeometry()`.
+- **Example:**
+  ```swift
+  let node = mesh.sceneKitNode(material: myMaterial)
+  scene.rootNode.addChildNode(node)
+  ```
+
+---
+
+## Metal Integration
+
+### `metalBufferData()`
+
+Returns vertex positions, normals, and indices as raw `Data` objects ready for Metal buffers.
+
+```swift
+public func metalBufferData() -> (positions: Data, normals: Data, indices: Data)
+```
+
+All three `Data` objects are interleaved-float (`Float`, 4 bytes each component). Use with
+`MTLDevice.makeBuffer(bytes:length:options:)`. Stride for positions and normals is 12 bytes
+(3 × `Float`); index buffer uses `UInt32` (4 bytes each).
+
+- **Returns:** Named tuple of `(positions: Data, normals: Data, indices: Data)`.
+- **OCCT:** Pure-Swift — repackages `vertexData`, `normalData`, `indices` into `Data`.
+- **Example:**
+  ```swift
+  let (positions, normals, indices) = mesh.metalBufferData()
+  let vertexBuffer = device.makeBuffer(
+      bytes: (positions as NSData).bytes,
+      length: positions.count,
+      options: .storageModeShared
+  )
+  ```
+
+---
+
+## RealityKit Integration
+
+Available on macOS 15+ / iOS 18+ where RealityKit is importable (`#if canImport(RealityKit)`).
+All three methods are `@MainActor`-isolated (call from the main actor inside an `if #available`
+guard).
+
+---
+
+### `realityKitMeshResource()`
+
+Creates a `MeshResource` from this mesh.
+
+```swift
+@available(iOS 18.0, macOS 15.0, *)
+@MainActor
+public func realityKitMeshResource() throws -> MeshResource
+```
+
+Builds a `MeshDescriptor` from `vertices` (positions), `normals`, and `indices`, then calls
+`MeshResource.generate(from:)`. Returns an empty `MeshResource` if the mesh has no vertices.
+
+- **Returns:** A `MeshResource` suitable for a RealityKit `ModelEntity`.
+- **Throws:** RealityKit errors from `MeshResource.generate(from:)` if the descriptor is invalid.
+- **OCCT:** Pure-Swift — reads `vertices`, `normals`, `indices`.
+- **Note:** `@MainActor`-isolated and gated to macOS 15 / iOS 18; call from the main actor inside
+  `if #available(macOS 15, iOS 18, *)`.
+- **Example:**
+  ```swift
+  if #available(macOS 15, iOS 18, *) {
+      let meshResource = try await MainActor.run {
+          try mesh.realityKitMeshResource()
+      }
+      let material = SimpleMaterial(color: .gray, isMetallic: true)
+      let entity = ModelEntity(mesh: meshResource, materials: [material])
+  }
+  ```
+
+---
+
+### `realityKitModelEntity(material:)`
+
+Creates a `ModelEntity` from this mesh with a specified material.
+
+```swift
+@available(iOS 18.0, macOS 15.0, *)
+@MainActor
+public func realityKitModelEntity(material: RealityKit.Material) throws -> ModelEntity
+```
+
+Calls `realityKitMeshResource()` then constructs `ModelEntity(mesh:materials:)`.
+
+- **Parameters:** `material` — any `RealityKit.Material` to apply.
+- **Returns:** `ModelEntity` ready to add to a RealityKit scene.
+- **Throws:** Propagates errors from `realityKitMeshResource()`.
+- **OCCT:** Pure-Swift — delegates to `realityKitMeshResource()`.
+- **Note:** `@MainActor`-isolated, macOS 15 / iOS 18 only.
+- **Example:**
+  ```swift
+  if #available(macOS 15, iOS 18, *) {
+      let entity = try await MainActor.run {
+          try mesh.realityKitModelEntity(
+              material: SimpleMaterial(color: .blue, isMetallic: true)
+          )
+      }
+      content.add(entity)
+  }
+  ```
+
+---
+
+### `realityKitModelEntity()`
+
+Creates a `ModelEntity` from this mesh with a default gray metallic material.
+
+```swift
+@available(iOS 18.0, macOS 15.0, *)
+@MainActor
+public func realityKitModelEntity() throws -> ModelEntity
+```
+
+Convenience overload: applies `SimpleMaterial(color: .gray, isMetallic: true)` and delegates to
+`realityKitModelEntity(material:)`.
+
+- **Returns:** `ModelEntity` with a gray metallic appearance.
+- **Throws:** Propagates errors from `realityKitMeshResource()`.
+- **OCCT:** Pure-Swift — delegates to `realityKitModelEntity(material:)`.
+- **Note:** `@MainActor`-isolated, macOS 15 / iOS 18 only.
+- **Example:**
+  ```swift
+  if #available(macOS 15, iOS 18, *) {
+      let entity = try await MainActor.run {
+          try mesh.realityKitModelEntity()
+      }
+  }
+  ```
+
+---
+
+## Supporting Types
+
+### `MeshParameters`
+
+Fine-grained tessellation parameters for `Shape.mesh(parameters:)`.
+
+```swift
+public struct MeshParameters: Sendable {
+    public var deflection: Double
+    public var angle: Double
+    public var deflectionInterior: Double
+    public var angleInterior: Double
+    public var minSize: Double
+    public var relative: Bool
+    public var inParallel: Bool
+    public var internalVertices: Bool
+    public var controlSurfaceDeflection: Bool
+    public var adjustMinSize: Bool
+    public var allowQualityDecrease: Bool
+    public static var `default`: MeshParameters { get }
+}
+```
+
+All fields correspond directly to `IMeshTools_Parameters` in OCCT's `BRepMesh_IncrementalMesh`
+API. Start from `MeshParameters.default` (suitable for interactive display) and adjust as
+needed.
+
+| Field | Default | Meaning |
+|---|---|---|
+| `deflection` | `0.1` | Max chord deviation on boundary edges (model units) |
+| `angle` | `0.5` rad | Max angle between adjacent facets on boundary edges |
+| `deflectionInterior` | `0` | Interior face deflection (0 = same as `deflection`) |
+| `angleInterior` | `0` | Interior face angle (0 = same as `angle`) |
+| `minSize` | `0` | Minimum element size (0 = no minimum) |
+| `relative` | `false` | If `true`, deflection is a proportion of edge length |
+| `inParallel` | `true` | Multi-threaded meshing |
+| `internalVertices` | `true` | Generate vertices inside faces, not just on edges |
+| `controlSurfaceDeflection` | `true` | Validate surface approximation quality |
+| `adjustMinSize` | `false` | Auto-adjust minSize from edge size |
+| `allowQualityDecrease` | `false` | Allow replacing an existing finer triangulation with a coarser one |
+
+- **OCCT:** `IMeshTools_Parameters` + `BRepMesh_IncrementalMesh`.
+- **Example:**
+  ```swift
+  var params = MeshParameters.default
+  params.deflection = 0.05   // fine mesh
+  params.inParallel = true
+  let mesh = shape.mesh(parameters: params)
+  ```
+- **Note:** `allowQualityDecrease` (added in issue #211): when re-meshing an already-tessellated
+  shape at a different deflection, OCCT keeps the existing mesh if it's "good enough" unless this
+  is `true`. Set it when the new deflection must actually take effect.
+
+---
+
+### `Triangle`
+
+A mesh triangle with B-Rep face association and per-triangle normal.
+
+```swift
+public struct Triangle: Sendable {
+    public let v1: UInt32
+    public let v2: UInt32
+    public let v3: UInt32
+    public let faceIndex: Int32
+    public let normal: SIMD3<Float>
+}
+```
+
+Returned by `Mesh.trianglesWithFaces()`. The `faceIndex` is the 0-based index of the B-Rep
+face this triangle was tessellated from (−1 for meshes constructed directly from arrays). Use
+`faceIndex` to correlate a picked triangle back to the original solid face for CAM or selection
+operations.
+
+- **Fields:**
+  - `v1`, `v2`, `v3` — vertex indices into `Mesh.vertices`.
+  - `faceIndex` — source B-Rep face index; −1 if unknown.
+  - `normal` — per-triangle surface normal (computed from the cross product of two edges).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -99,11 +99,11 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 | Surface | 261 | `Surface-*.md` | ☐ todo |
 | Curve3D | 195 | `Curve3D-*.md` | ☐ todo |
 | Curve2D | 233 | `Curve2D-*.md` | ☐ todo |
-| Edge | 34 | `Edge.md` | ☐ todo |
-| Face | 30 | `Face.md` | ☐ todo |
-| Mesh | 34 | `Mesh.md` | ☐ todo |
-| Exporter | 40 | `Exporter.md` | ☐ todo |
+| Edge | 36 | `Edge.md` | ✅ done |
+| Face | 32 | `Face.md` | ✅ done |
+| Mesh | 34 | `Mesh.md` | ✅ done |
+| Exporter | 39 | `Exporter.md` | ✅ done |
 | Document | 1865 | `Document-*.md` (chunked) | ☐ todo |
 | BRepGraph (TopologyGraph) | 302 | `TopologyGraph-*.md` | ☐ todo |
-| ThreadFeatures | 30 | `ThreadFeatures.md` | ☐ todo |
+| ThreadFeatures | 30 | `ThreadFeatures.md` | ✅ done |
 | _(remaining ~30 files)_ | — | — | ☐ todo |

--- a/docs/reference/ThreadFeatures.md
+++ b/docs/reference/ThreadFeatures.md
@@ -1,0 +1,623 @@
+---
+title: ThreadFeatures
+parent: API Reference
+---
+
+# ThreadFeatures
+
+OCCTSwift's thread feature API lives in `Sources/OCCTSwift/ThreadFeatures.swift`. It adds three `Shape` methods (`threadedShaft`, `threadedHole`, `threadedRod`) plus the supporting value types `ThreadSpec`, `ThreadProfile`, `ThreadForm`, `ThreadBuild`, and `RunoutStyle`. OCCT ships no kernel "thread feature"; all thread geometry is composed from already-wrapped OCCT primitives (`Shape.loft`, `Wire.arc`, `Wire.interpolate`, `Shape.sew`) in Swift — the bridge is invoked only for the fallback smooth-helicoid cutter (`OCCTShapeBuildThreadCutter`).
+
+## Topics
+
+- [Threaded features on Shape](#threaded-features-on-shape) · [ThreadSpec](#threadspec) · [ThreadProfile](#threadprofile) · [Enums](#enums)
+
+---
+
+## Threaded features on Shape
+
+### `Shape.threadedShaft(axisOrigin:axisDirection:spec:length:starts:runout:build:)`
+
+Cuts a helical V-profile external thread into a cylindrical shaft.
+
+```swift
+public func threadedShaft(axisOrigin: SIMD3<Double>,
+                           axisDirection: SIMD3<Double>,
+                           spec: ThreadSpec,
+                           length: Double? = nil,
+                           starts: Int = 1,
+                           runout: RunoutStyle = .none,
+                           build: ThreadBuild = .auto) -> Shape?
+```
+
+When `self` is a plain cylinder coaxial with the axis (the common case) and `build != .boolean` and `starts == 1`, this builds the threaded rod **directly with no boolean**: the thread's true cross-section (a "cam": root arc → flank → crest arc → flank) is lofted at closely-spaced z-slices rotated by the helix (`ruled=false`), giving a smooth, BRepCheck-valid solid of a handful of B-spline faces. Any unthreaded margin is closed by pure sewing (shoulder + cylinder + end disk). Because the boolean engine is never invoked, the result is orientation-robust and valid where a cut-the-cutter approach is faceted or fails. For non-cylinder targets, multi-start, or when the direct build fails, the method falls back to the boolean cut path (`applyThreadCut`).
+
+- **Parameters:**
+  - `axisOrigin` — a point on the shaft axis (typically the centre of the bottom face).
+  - `axisDirection` — unit vector along the shaft axis (normalised internally).
+  - `spec` — thread form and dimensions.
+  - `length` — threaded length in mm (default: `2 * spec.nominalDiameter`).
+  - `starts` — number of thread starts (1 for standard fasteners; >1 for lead screws). Multi-start forces the boolean cut path.
+  - `runout` — thread termination style at each end (see `RunoutStyle`).
+  - `build` — construction path selector; `.auto` (default) uses the smooth direct build for single-start coaxial cylinders; `.boolean` forces the in-envelope cut path so the major diameter never overshoots `spec.nominalDiameter / 2` (see `ThreadBuild`).
+- **Returns:** Threaded shape, or `nil` on sweep / boolean failure. Use `boundingBoxOptimal()` (not `bounds`) to measure the true crest radius — the BSpline pole hull overshoots by ~13%.
+- **OCCT:** Pure-Swift direct path: `Shape.loft`, `Wire.arc`, `Wire.interpolate`, `Wire.join`, `Shape.face(from:)`, `Shape.sew`, `Shape.solidFromShell` — no boolean. Fallback cut path: `OCCTShapeBuildThreadCutter` (bridge: analytic helicoid cutter), `Shape.screwSweptThreadCutter`, `Shape.subtracting`.
+- **Example:**
+  ```swift
+  guard let shank = Shape.cylinder(radius: 6, height: 24) else { return }
+  let spec = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75)
+  guard let threaded = shank.threadedShaft(axisOrigin: .zero,
+                                            axisDirection: SIMD3(0, 0, 1),
+                                            spec: spec, length: 18) else { return }
+  // threaded.isValid == true; ~9 faces (smooth), crest at nominal radius (6 mm)
+  ```
+- **Note:** For a multi-start or left-handed thread the boolean cut path is used automatically (`starts: 2` or `spec.leftHanded == true`). The tapered pipe forms (`.nptTapered`, `.bsptTapered`) always use the cut path since the smooth direct build supports parallel forms only.
+
+---
+
+### `Shape.threadedHole(axisOrigin:axisDirection:spec:depth:starts:runout:)`
+
+Cuts a helical V-profile internal thread into an existing bore.
+
+```swift
+public func threadedHole(axisOrigin: SIMD3<Double>,
+                          axisDirection: SIMD3<Double>,
+                          spec: ThreadSpec,
+                          depth: Double? = nil,
+                          starts: Int = 1,
+                          runout: RunoutStyle = .none) -> Shape?
+```
+
+Always uses the boolean cut path (`applyThreadCut` with `apexSign: +1`): a helical cutter is swept into the bore wall and subtracted from `self`. Because the cutter is cut into a thick wall (not a thin shaft), OCCT's boolean handles a smooth (`ruled=false`) helical cutter robustly, so internal threads come out smooth and BRepCheck-valid. `self` must already contain the bore (a cylinder subtracted out, or any through-hole body).
+
+- **Parameters:**
+  - `axisOrigin` — point on the bore axis (typically the centre of the entry face).
+  - `axisDirection` — unit vector along the bore, pointing into the solid material.
+  - `spec` — thread specification.
+  - `depth` — axial length of the threaded region in mm (default: `2 * spec.nominalDiameter`).
+  - `starts` — number of thread starts.
+  - `runout` — thread termination style.
+- **Returns:** Shape with the tapped thread cut, or `nil` on boolean failure.
+- **OCCT:** `OCCTShapeBuildThreadCutter` (analytic helicoid bridge, ISO-68/Unified only), `Shape.screwSweptThreadCutter` (fallback), `Shape.subtracting`.
+- **Example:**
+  ```swift
+  guard let outer = Shape.cylinder(radius: 12, height: 16),
+        let bore  = Shape.cylinder(radius: 6,  height: 16),
+        let block = outer.subtracting(bore) else { return }
+  let tapped = block.threadedHole(
+      axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+      spec: ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75),
+      depth: 14)
+  // tapped?.isValid == true
+  ```
+- **Note:** Pass the *solid body with the bore already in it* — `threadedHole` does not drill the hole. The outer surface and outer diameter are unchanged; only the bore wall gains the helical thread form.
+
+---
+
+### `Shape.threadedRod(customProfile:nominalDiameter:pitch:cutDepth:length:axisOrigin:axisDirection:leftHanded:)`
+
+Builds a smooth threaded rod from a custom radial cross-section, directly and with no boolean.
+
+```swift
+public static func threadedRod(customProfile: ThreadProfile,
+                                nominalDiameter: Double,
+                                pitch: Double,
+                                cutDepth: Double,
+                                length: Double,
+                                axisOrigin: SIMD3<Double> = .zero,
+                                axisDirection: SIMD3<Double> = SIMD3(0, 0, 1),
+                                leftHanded: Bool = false) -> Shape?
+```
+
+The entry point for threading a cylinder with a custom tooth shape (worm, screw conveyor, proprietary fastener). Composes the thread region (a `ruled=false` cam-slice loft of the profile swept along the exact helix) with the core cylinder by pure sewing — no boolean is invoked — so the result is BRepCheck-valid and analytic (a small number of B-spline faces, not a faceted multi-MB solid). The cross-section is a `ThreadProfile` in normalised `(axial, depth)` coordinates: `axial` 0…1 spans one pitch, `depth` 0 = crest (at `nominalDiameter / 2`) … 1 = root (at `nominalDiameter / 2 − cutDepth`). The profile must satisfy `ThreadProfile.supportsSmoothRodBuild` (a real crest flat, ≤ 2 flank segments); rounded or many-flank profiles do not satisfy this and return `nil`. For standard named forms (ISO, Unified, ACME, …), prefer `threadedShaft` with a `ThreadForm` spec.
+
+- **Parameters:**
+  - `customProfile` — normalised tooth cross-section; must satisfy `supportsSmoothRodBuild`.
+  - `nominalDiameter` — outer (crest) diameter in mm.
+  - `pitch` — axial advance per turn in mm.
+  - `cutDepth` — radial depth crest → root in mm (must be < `nominalDiameter / 2`).
+  - `length` — threaded length along the axis in mm.
+  - `axisOrigin` — a point on the rod axis at the thread start (default `.zero`).
+  - `axisDirection` — rod axis direction (default `SIMD3(0, 0, 1)`).
+  - `leftHanded` — helix handedness (default `false` = right-hand).
+- **Returns:** A valid, smooth threaded rod, or `nil` if inputs are degenerate, the profile does not satisfy `supportsSmoothRodBuild`, or the direct build cannot produce a valid solid. Does not silently fall back to a boolean result.
+- **OCCT:** Pure-Swift composition: `Shape.loft`, `Wire.arc`, `Wire.interpolate`, `Wire.join`, `Shape.face(from:)`, `Shape.sew`, `Shape.solidFromShell` — no boolean, no bridge cutter.
+- **Example:**
+  ```swift
+  guard let tooth = ThreadProfile(vertices: [
+      .init(axial: 0.000, depth: 1), .init(axial: 0.125, depth: 1),
+      .init(axial: 0.375, depth: 0), .init(axial: 0.625, depth: 0),
+      .init(axial: 0.875, depth: 1), .init(axial: 1.000, depth: 1),
+  ]),
+        let worm = Shape.threadedRod(customProfile: tooth, nominalDiameter: 12,
+                                     pitch: 5, cutDepth: 1.8, length: 22) else { return }
+  // worm.isValidSolid == true — smooth, analytic (handful of B-spline faces)
+  ```
+- **Note:** `ThreadProfile.supportsSmoothRodBuild` requires a real crest flat (`hasCrestFlat == true`) and at most two flank segments. Pointed-crest or multi-segment rounded profiles (knuckle, custom sinusoidal) return `nil` here and must use `threadedShaft` with the boolean cut path instead.
+
+---
+
+## ThreadSpec
+
+Full specification of a thread's form, diameter, pitch, and handedness. `Sendable`, `Hashable`, `Codable`.
+
+```swift
+public struct ThreadSpec: Sendable, Hashable, Codable
+```
+
+### `ThreadSpec.init(form:nominalDiameter:pitch:leftHanded:customProfile:customCutDepth:)`
+
+General-purpose initialiser.
+
+```swift
+public init(form: ThreadForm, nominalDiameter: Double, pitch: Double, leftHanded: Bool = false,
+            customProfile: ThreadProfile? = nil, customCutDepth: Double? = nil)
+```
+
+- **Parameters:**
+  - `form` — thread form (see `ThreadForm`).
+  - `nominalDiameter` — outer (crest) diameter in mm.
+  - `pitch` — axial advance per revolution in mm.
+  - `leftHanded` — `true` for left-hand helix (default `false`).
+  - `customProfile` — tooth cross-section for `form == .custom`; ignored otherwise.
+  - `customCutDepth` — overrides the form's default radial depth (mm); required for `.custom`.
+
+---
+
+### `ThreadSpec.init(customProfile:nominalDiameter:pitch:cutDepth:leftHanded:)`
+
+Convenience initialiser for a fully custom tooth shape — sets `form` to `.custom` and stores `customProfile`/`cutDepth`.
+
+```swift
+public init(customProfile: ThreadProfile, nominalDiameter: Double, pitch: Double,
+            cutDepth: Double, leftHanded: Bool = false)
+```
+
+- **Parameters:** as above; `cutDepth` becomes `customCutDepth`.
+
+---
+
+### `ThreadSpec.parse(_:)`
+
+Parses a standard thread designation string.
+
+```swift
+public static func parse(_ text: String) -> ThreadSpec?
+```
+
+Recognises metric `M5x0.8` / `M10` (coarse-pitch table); Unified / UNC / UNF `1/4-20 UNC`, `3/8-16`; trapezoidal `Tr40x7` / `Tr40x7LH`; ACME `1.5-4 ACME`; Whitworth `W1/2` / `1/2 BSW`; BSP parallel `G1/2`; BSP taper `R1/2` / `Rc1/2`; NPT `1/2-14 NPT`. Input is trimmed of whitespace before matching.
+
+- **Parameters:** `text` — designation string.
+- **Returns:** `ThreadSpec`, or `nil` on unrecognised input.
+- **OCCT:** Pure-Swift — no bridge calls.
+- **Example:**
+  ```swift
+  ThreadSpec.parse("M5x0.8")      // .iso68,   Ø5,    pitch 0.8
+  ThreadSpec.parse("M10")         // .iso68,   Ø10,   pitch 1.5 (coarse table)
+  ThreadSpec.parse("1/4-20 UNC")  // .unified, Ø6.35, pitch 1.27
+  ThreadSpec.parse("Tr40x7LH")    // .trapezoidal, Ø40, pitch 7, leftHanded
+  ThreadSpec.parse("G1/2")        // .bspParallel, Ø20.955, 14 TPI
+  ThreadSpec.parse("1/2-14 NPT")  // .nptTapered
+  ```
+
+---
+
+### `ThreadSpec.profile`
+
+The tooth cross-section for this spec's form, or the custom profile.
+
+```swift
+public var profile: ThreadProfile { get }
+```
+
+Dispatches on `form`: ISO-68 / Unified / NPT → `ThreadProfile.iso60V()`; Whitworth / BSP / BSPT → `.whitworth55`; ACME → `.acme29`; trapezoidal → `.trapezoidalMetric30`; square → `.square`; buttress → `.buttress`; knuckle → `.knuckle`; custom → `customProfile ?? .iso60V()`.
+
+- **Returns:** `ThreadProfile` instance for use by the modeller.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.cutDepth`
+
+Practical radial thread depth (crest → root), form-dependent.
+
+```swift
+public var cutDepth: Double { get }
+```
+
+`customCutDepth` overrides when set. Standard values: ISO-68 / Unified / NPT = `5H/8`; Whitworth / BSP / BSPT = `0.640327 × pitch`; ACME / trapezoidal / square = `0.5 × pitch`; knuckle (DIN 405) = `0.55 × pitch`; buttress (DIN 513) = `0.86777 × pitch`.
+
+- **Returns:** Radial depth in mm.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.taperRatio`
+
+Diametral taper rate (NPT / BSPT are `1:16`; all parallel forms are `0`). The radius changes by `taperRatio / 2` per unit of axial length.
+
+```swift
+public var taperRatio: Double { get }
+```
+
+- **Returns:** `1.0 / 16` for `.nptTapered` and `.bsptTapered`; `0` otherwise.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.halfFlankAngle`
+
+Half of the 60° included angle (ISO-68 / Unified).
+
+```swift
+public var halfFlankAngle: Double { get }
+```
+
+Returns `Double.pi / 6` (30°). Meaningful only for ISO-68 and Unified forms; use `spec.profile` for other forms.
+
+- **Returns:** `π/6`.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.theoreticalDepth`
+
+Theoretical (untruncated) 60° V thread depth — `H = pitch × √3 / 2` per ISO-68.
+
+```swift
+public var theoreticalDepth: Double { get }
+```
+
+- **Returns:** `pitch * sqrt(3) / 2`.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.crestFlat`
+
+Axial width of the truncated crest flat (ISO-68 external). Equal to `P/8`.
+
+```swift
+public var crestFlat: Double { get }
+```
+
+- **Returns:** `pitch / 8`.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.rootFlat`
+
+Axial width of the truncated root flat (ISO-68 external). Equal to `P/4`.
+
+```swift
+public var rootFlat: Double { get }
+```
+
+- **Returns:** `pitch / 4`.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadSpec.minorDiameter`
+
+Minor diameter — the inner diameter at the thread root (external) or crest (internal). Form-dependent via `cutDepth`.
+
+```swift
+public var minorDiameter: Double { get }
+```
+
+- **Returns:** `nominalDiameter - 2 * cutDepth`.
+- **OCCT:** Pure-Swift.
+- **Example:**
+  ```swift
+  let m12 = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75)
+  m12.theoreticalDepth   // H  ≈ 1.516
+  m12.cutDepth           // 5H/8 ≈ 0.947
+  m12.minorDiameter      // ≈ 10.106
+  ```
+
+---
+
+## ThreadProfile
+
+A thread's tooth cross-section over one pitch, normalised. `Sendable`, `Hashable`, `Codable`.
+
+```swift
+public struct ThreadProfile: Sendable, Hashable, Codable
+```
+
+`axial` runs `0…1` along the pitch; `depth` runs `0` (crest, at the major radius) … `1` (root, at the minor radius). Vertices are ordered by increasing `axial`; the profile is periodic (`first.axial == 0`, `last.axial == 1`, `first.depth == last.depth`) so consecutive teeth tile. The modeller maps a vertex to 3D as radius `rMajor − depth × cutDepth`, axial position `axial × pitch`, helix angle `θ(z) + handed × axial × 2π`.
+
+---
+
+### `ThreadProfile.Vertex`
+
+A single point in the normalised tooth outline.
+
+```swift
+public struct Vertex: Sendable, Hashable, Codable {
+    public var axial: Double   // 0…1 along the pitch
+    public var depth: Double   // 0 = crest (major R), 1 = root (minor R)
+    public init(axial: Double, depth: Double)
+}
+```
+
+---
+
+### `ThreadProfile.init?(vertices:)`
+
+Validates and creates a custom profile.
+
+```swift
+public init?(vertices: [Vertex])
+```
+
+Returns `nil` unless the vertices form a well-ordered, periodic, full-depth-spanning tooth outline: at least 3 vertices; `first.axial ≈ 0`, `last.axial ≈ 1`; `first.depth ≈ last.depth`; vertices are monotonically non-decreasing in `axial`; depth spans [0, 1] (must include a crest vertex at `depth ≈ 0` and a root vertex at `depth ≈ 1`).
+
+- **Parameters:** `vertices` — ordered vertex list defining the tooth outline.
+- **Returns:** Valid `ThreadProfile`, or `nil` if the outline violates the contract.
+- **OCCT:** Pure-Swift.
+- **Example:**
+  ```swift
+  guard let profile = ThreadProfile(vertices: [
+      .init(axial: 0.0, depth: 1), .init(axial: 0.1, depth: 1),   // root flat
+      .init(axial: 0.5, depth: 0), .init(axial: 0.6, depth: 0),   // crest flat
+      .init(axial: 0.9, depth: 1), .init(axial: 1.0, depth: 1),   // root flat
+  ]) else { return }
+  // profile.supportsSmoothRodBuild == true
+  ```
+
+---
+
+### `ThreadProfile.vertices`
+
+The ordered vertex list defining the tooth outline.
+
+```swift
+public let vertices: [Vertex]
+```
+
+---
+
+### `ThreadProfile.SegmentKind`
+
+Segment classification for the modeller and cutter.
+
+```swift
+public enum SegmentKind: Sendable, Hashable {
+    case flat   // constant depth → circular arc in 3D
+    case wall   // constant axial → radial line (square thread walls)
+    case flank  // sloped → sampled spline
+}
+```
+
+---
+
+### `ThreadProfile.Segment`
+
+A consecutive pair of vertices with its geometric classification.
+
+```swift
+public struct Segment: Sendable, Hashable {
+    public let a: Vertex, b: Vertex, kind: SegmentKind
+}
+```
+
+---
+
+### `ThreadProfile.segments`
+
+One segment per consecutive vertex pair, with `SegmentKind` classification.
+
+```swift
+public var segments: [Segment] { get }
+```
+
+- **Returns:** Array of `Segment` structs; `flat` where `a.depth ≈ b.depth`, `wall` where `a.axial ≈ b.axial`, `flank` otherwise.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadProfile.hasCrestFlat`
+
+`true` if the crest (`depth ≈ 0`) contains a real flat of non-zero axial width.
+
+```swift
+public var hasCrestFlat: Bool { get }
+```
+
+Pointed-crest profiles (a single vertex at `depth = 0`) return `false` and cannot use the smooth direct rod build path.
+
+- **Returns:** Boolean indicating the presence of a usable crest flat.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadProfile.supportsSmoothRodBuild`
+
+Whether this profile can be built by the smooth, boolean-free direct rod path.
+
+```swift
+public var supportsSmoothRodBuild: Bool { get }
+```
+
+Requires a real crest flat (`hasCrestFlat == true`) and at most two flank segments. Pointed-crest or many-flank profiles (knuckle, sinusoidal) return `false` and must use the faceted boolean cut path instead. Consumed by `Shape.threadedRod` and the direct branch of `Shape.threadedShaft`.
+
+- **Returns:** `hasCrestFlat && segments.filter { $0.kind == .flank }.count <= 2`.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadProfile.iso60V(crestFlatFraction:rootFlatFraction:)`
+
+ISO-68 / Unified 60° V profile.
+
+```swift
+public static func iso60V(crestFlatFraction: Double = 1.0 / 8,
+                           rootFlatFraction: Double = 1.0 / 4) -> ThreadProfile
+```
+
+Symmetric truncated trapezoid: root half-flats at the ends, crest flat in the middle, straight 30° flanks between. Defaults reproduce the shipped ISO-68 geometry exactly (`crest P/8`, `root P/4`).
+
+- **Parameters:** `crestFlatFraction` — crest flat as a fraction of pitch; `rootFlatFraction` — root flat as a fraction of pitch.
+- **Returns:** A valid `ThreadProfile`.
+- **OCCT:** Pure-Swift.
+
+---
+
+### `ThreadProfile.whitworth55`
+
+Whitworth / BSW / BSP 55° profile (flat-truncation, `cutDepth = 0.640327 × P`).
+
+```swift
+public static let whitworth55: ThreadProfile
+```
+
+Crest flat = root flat = `P/6`. The standard rounds the outer/inner sixth of the tooth; this is the flat-truncation of that form, which satisfies `supportsSmoothRodBuild`.
+
+---
+
+### `ThreadProfile.acme29`
+
+ACME 29° general-purpose profile (crest flat = root flat = `0.3707 × P` at `cutDepth = P/2`).
+
+```swift
+public static let acme29: ThreadProfile
+```
+
+---
+
+### `ThreadProfile.trapezoidalMetric30`
+
+ISO metric trapezoidal "Tr" 30° profile (crest flat = root flat = `0.366 × P` at `cutDepth = P/2`).
+
+```swift
+public static let trapezoidalMetric30: ThreadProfile
+```
+
+---
+
+### `ThreadProfile.square`
+
+Square thread profile — 0° radial walls, equal land and groove (`cutDepth = P/2`).
+
+```swift
+public static let square: ThreadProfile
+```
+
+---
+
+### `ThreadProfile.buttress`
+
+Buttress (DIN 513) — asymmetric 3° load flank / 30° clearance flank, `cutDepth = 0.86777 × P`.
+
+```swift
+public static let buttress: ThreadProfile
+```
+
+The near-radial (3°) load flank rises steeply to the crest; the 30° clearance flank falls back to the root. Verified against the DIN 513 table (e.g. S 10×2 → d3 = 6.528).
+
+---
+
+### `ThreadProfile.knuckle`
+
+Knuckle / round thread (DIN 405): 30°-included (15° per side) flanks with circular-arc rounded crest and root, at standard depth `0.55 × P`.
+
+```swift
+public static let knuckle: ThreadProfile
+```
+
+Small crest/root lands are kept so the smooth direct build can attach a crest flat. `supportsSmoothRodBuild` is `true` for this profile. Verified against the DIN 405 dimension table (bolt minor `d3 = d − 1.1 × P`).
+
+---
+
+## Enums
+
+### `ThreadForm`
+
+Which standard thread geometry to use. `String`, `Sendable`, `Codable`, `CaseIterable`.
+
+```swift
+public enum ThreadForm: String, Sendable, Codable, CaseIterable {
+    case iso68          // Metric M-series, 60° V
+    case unified        // Unified (UNC / UNF / metric-fine / SAE), 60° V
+    case whitworth      // BSW Whitworth, 55°
+    case bspParallel    // BSP parallel "G", Whitworth 55° form
+    case acme           // ACME general-purpose, 29° trapezoidal
+    case trapezoidal    // ISO metric trapezoidal "Tr", 30°
+    case square         // square / 0° walls
+    case buttress       // asymmetric buttress, 7° load / 45° trailing
+    case knuckle        // rounded / sinusoidal (DIN 405)
+    case nptTapered     // NPT — 60° V on a 1:16 taper
+    case bsptTapered    // BSPT — 55° on a 1:16 taper
+    case custom         // arbitrary cross-section (see ThreadSpec.customProfile)
+}
+```
+
+| Case | Form / standard | Angle | Notes |
+|---|---|---|---|
+| `.iso68` | Metric M-series | 60° V | ISO 68-1; coarse-pitch table in `ThreadSpec.parse` |
+| `.unified` | UNC / UNF / SAE / metric-fine | 60° V | Same form, just a pitch |
+| `.whitworth` | BSW / Whitworth | 55° | BS 84; flat-truncated crest/root |
+| `.bspParallel` | BSP "G" parallel | 55° | EN ISO 228 / BS 2779 |
+| `.acme` | ACME general-purpose | 29° | Power / lead screws |
+| `.trapezoidal` | ISO Tr metric | 30° | DIN 103 |
+| `.square` | Square | 0° | Equal land and groove |
+| `.buttress` | Buttress | 3°/30° | DIN 513 asymmetric |
+| `.knuckle` | Knuckle/round | 30° included, rounded | DIN 405 |
+| `.nptTapered` | NPT | 60° V on 1:16 taper | ANSI B1.20.1 |
+| `.bsptTapered` | BSPT | 55° on 1:16 taper | BS EN 10226 |
+| `.custom` | Arbitrary | — | Supply `customProfile` on `ThreadSpec` |
+
+- **OCCT:** Pure-Swift enum; consumed by `ThreadSpec.profile`, `ThreadSpec.cutDepth`, and `ThreadSpec.taperRatio`.
+- **Note:** `.acme`, `.trapezoidal`, `.square`, `.buttress`, and `.knuckle` are open for future tolerance-class (2B, 3A, etc.) parameters — those are fit-allowance tables, not form geometry, and are not currently modelled.
+
+---
+
+### `ThreadBuild`
+
+Construction path selector for `Shape.threadedShaft`. `Sendable`, `Hashable`, `Codable`.
+
+```swift
+public enum ThreadBuild: Sendable, Hashable, Codable {
+    case auto
+    case direct
+    case boolean
+}
+```
+
+| Case | Behaviour |
+|---|---|
+| `.auto` | Smooth boolean-free direct build for single-start coaxial cylinders; falls back to boolean cut otherwise. Best surface quality. |
+| `.direct` | Prefer the smooth direct build; fall back to boolean cut when unavailable (multi-start, non-cylinder, construction failure). Same as `.auto` for the common case. |
+| `.boolean` | Always use the boolean cut path. Cutter subtracted from a cylinder of radius exactly `spec.nominalDiameter / 2`, so the crest is clamped to the nominal major radius (in-envelope). Use for lead screws, studs, or worms where the outer diameter must not overshoot nominal. |
+
+- **Note:** The smooth `ruled=false` loft can bow the crest **past** the nominal major radius at coarse pitch / wide crest flats (OCCTSwift #222). Use `.boolean` when an exact outer diameter is required.
+
+---
+
+### `RunoutStyle`
+
+How a thread terminates at its ends. `Sendable`, `Hashable`.
+
+```swift
+public enum RunoutStyle: Sendable, Hashable {
+    case none
+    case filleted(radius: Double)
+    case tapered(turns: Double)
+}
+```
+
+| Case | Behaviour |
+|---|---|
+| `.none` | Hard-stop at each end (no runout). Cheap and exact but manufacturing-unrealistic. Default. |
+| `.filleted(radius:)` | Fillet the last turns' worth of helix into the underlying surface — a post-boolean/sew fillet pass of the given radius. |
+| `.tapered(turns:)` | Taper the V-profile to zero depth over the last `turns` revolutions using a law-scaled sweep. Currently falls back to `.filleted(radius: spec.pitch * 0.5)` while law-scaling is not yet wrapped (#67). |
+
+- **OCCT:** `.filleted` delegates to `Shape.filleted(radius:)` (bridge: `BRepFilletAPI_MakeFillet`). `.tapered` is a planned law-scaled pipe-shell extension (issue #67); currently approximated by `.filleted`.
+- **Example:**
+  ```swift
+  rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                    spec: spec, length: 18,
+                    runout: .filleted(radius: 0.4))
+  ```


### PR DESCRIPTION
First fan-out batch of the detailed API reference (via `/document-api`, 5 Sonnet subagents in parallel — one per type, each reading the Swift source + OCCTBridge mapping + OCCT docs and writing its own page).

| Page | members | OCCT mappings |
|------|--------:|--------------:|
| Edge | 36 | 32 |
| Face | 32 | 20 |
| Mesh | 24 | 23 |
| Exporter | 38 | 22 |
| ThreadFeatures | 32 | 19 |

(Lower OCCT counts are correct — pure-Swift helpers and enum-case entries omit the mapping per the template rules.)

Spot-checked: front-matter, signatures vs source, OCCT mappings (`STEPControl_Writer`, `BRepMesh_IncrementalMesh`, `BRepAdaptor_Curve`, …), template adherence. Coverage status table updated (one row had to be fixed by hand — the parallel agents raced editing the shared README; see note).

Docs-only. Coverage so far: Wire + these 5 = 6 types; giants (Shape, Surface, Curve2D/3D, Document, TopologyGraph) next, chunked by MARK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)