### PR TITLE
docs(site): fix dark mode + duplicate API Reference, clean nav, refresh home

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,11 +1,12 @@
 ---
-title: API Reference
-nav_order: 3
+title: API Map (Swift ↔ OCCT)
+nav_order: 4
 ---
 
-# API Reference
+# API Map (Swift ↔ OCCT)
 
-Complete mapping of OCCTSwift operations to OCCT C++ classes.
+Complete mapping of OCCTSwift operations to OCCT C++ classes. For the detailed per-type function
+reference (signatures, parameters, examples), see [API Reference](reference/).
 
 ## Wrapped Operations Summary
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-nav_order: 4
+nav_order: 13
 ---
 
 # Changelog

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,21 +1,8 @@
-<!-- Follow the OS dark/light setting. just-the-docs v0.3.3 ships both
-     `just-the-docs-default.css` (light) and `just-the-docs-dark.css`; the theme's
-     <head> loads the light one unconditionally (and gives it no id), so we swap the
-     stylesheet href based on `prefers-color-scheme`. This include is rendered *after*
-     that <link>, so the swap runs synchronously in <head> before first paint. -->
-<script>
-(function () {
-  var mq = window.matchMedia('(prefers-color-scheme: dark)');
-  function applyScheme() {
-    var link = document.querySelector('link[rel="stylesheet"][href*="just-the-docs-"]');
-    if (!link) return;
-    link.href = link.href.replace(
-      /just-the-docs-(default|dark)\.css/,
-      'just-the-docs-' + (mq.matches ? 'dark' : 'default') + '.css'
-    );
-  }
-  applyScheme();
-  if (mq.addEventListener) { mq.addEventListener('change', applyScheme); }
-  else if (mq.addListener) { mq.addListener(applyScheme); }   // older Safari
-})();
-</script>
+<!-- Follow the OS dark/light setting (no JS). The theme's <head> always loads
+     just-the-docs-default.css (light); here we additionally load the dark scheme,
+     gated to `prefers-color-scheme: dark`. This include renders *after* the theme's
+     stylesheet <link>, so in dark mode the dark rules win by source order. The browser
+     applies/removes it natively as the OS appearance changes — no flash, no script. -->
+<link rel="stylesheet"
+      href="{{ '/assets/css/just-the-docs-dark.css' | relative_url }}"
+      media="(prefers-color-scheme: dark)">

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-nav_order: 7
+nav_order: 6
 ---
 
 # OCCTSwift Architecture Overview

--- a/docs/guides/adding-features.md
+++ b/docs/guides/adding-features.md
@@ -1,6 +1,6 @@
 ---
 title: Adding Features
-nav_order: 6
+nav_order: 7
 ---
 
 # Adding Features to OCCTSwift

--- a/docs/guides/building-occt.md
+++ b/docs/guides/building-occt.md
@@ -1,6 +1,6 @@
 ---
 title: Building OCCT
-nav_order: 9
+nav_order: 8
 ---
 
 # Building OpenCASCADE for iOS/macOS

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ nav_order: 1
 
 # OCCTSwift documentation
 
-A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.0) —
+A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.0p1) —
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS / iOS / visionOS / tvOS**.
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++.
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,290 wrapped operations.**
 
 ```swift
 import OCCTSwift
@@ -22,20 +22,39 @@ try drilled?.writeSTEP(to: outputURL)       // exact B-Rep, ready for CAD/CAM
 ## Cookbook
 
 Task-oriented, example-rich guides — each a short bit of prose plus runnable Swift and a rendered
-figure. Start here:
+figure (interactive 3D where it helps). The **[Cookbook index](guides/cookbook/)** lists all areas:
 
-- **[Booleans](guides/cookbook/booleans.md)** — union / subtracting / intersection, fuzzy value, glue, timeout, self-intersection checks.
-- [Cookbook index](guides/cookbook/) — all areas (more landing progressively).
+[Booleans](guides/cookbook/booleans.md) ·
+[Threads](guides/cookbook/threads.md) ·
+[Helices & Springs](guides/cookbook/helices.md) ·
+[Lofting & Sweeps](guides/cookbook/lofting-and-sweeps.md) ·
+[Helical Sweeps](guides/cookbook/helical-sweeps.md) ·
+[Healing & Validity](guides/cookbook/healing-and-validity.md) ·
+[Meshing & Export](guides/cookbook/meshing-and-export.md) ·
+[XCAF Assemblies](guides/cookbook/xcaf-assemblies.md) ·
+[Topology Graph](guides/cookbook/topology-graph.md) ·
+[Gordon Surfaces](guides/cookbook/gordon-surfaces.md) ·
+[Surfaces from Points](guides/cookbook/surfaces-from-points.md) ·
+[Working with Meshes](guides/cookbook/working-with-meshes.md)
 
 ## Reference
 
-- [API Reference](API_REFERENCE.md) — the full Swift → OCCT operation mapping.
+- **[API Reference](reference/)** — the detailed, per-type function reference: signatures, parameters,
+  the OCCT class each method wraps, and runnable examples. Built progressively (Wire, Edge, Face, Mesh,
+  Exporter, ThreadFeatures so far).
+- [API Map (Swift ↔ OCCT)](API_REFERENCE.md) — the compact operation-to-OCCT-class mapping table.
 - [Changelog](CHANGELOG.md) — release-by-release history.
-- [OCCT concepts](guides/occt-concepts.md) — B-Rep topology, handles, shapes primer.
-- [Adding features](guides/adding-features.md) — bridge header → impl → Swift → test.
+
+## Guides & concepts
+
+- [OCCT Concepts](guides/occt-concepts.md) — B-Rep topology, handles, shapes primer.
 - [Architecture](architecture/overview.md) — the three-layer design and memory model.
+- [Adding Features](guides/adding-features.md) — bridge header → impl → Swift → test.
+- [Building OCCT](guides/building-occt.md) — rebuild the `OCCT.xcframework` from source.
+- [Thread Safety](thread-safety.md) · [Naming Conventions](naming-conventions.md) ·
+  [Versioning (SemVer)](SEMVER.md) · [Ecosystem](ecosystem.md)
 
 ## Project
 
 - Source & issues: [github.com/gsdali/OCCTSwift](https://github.com/gsdali/OCCTSwift)
-- Install via Swift Package Manager — pin `from: "1.5.0"`.
+- Install via Swift Package Manager — pin `from: "1.0.0"` (SemVer-stable since v1.0.0).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-nav_order: 5
+nav_order: 3
 has_children: true
 ---
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -1,6 +1,6 @@
 ---
 title: Thread Safety
-nav_order: 8
+nav_order: 9
 ---
 
 # Thread Safety in OCCTSwift


### PR DESCRIPTION
Addresses the docs-site issues:

- **Dark mode wasn't being picked up.** Replaced the JS stylesheet-href swap with a browser-native media-gated `<link rel="stylesheet" href="…dark.css" media="(prefers-color-scheme: dark)">` in `head_custom.html` — no JS, no flash, applies/removes live as the OS appearance changes. (Verified the dark CSS is genuinely dark — `#27262b` bg — and resolves on the site.)
- **"API Reference" appeared twice** in the nav: both `docs/reference/` (the new detailed per-type reference) and `docs/API_REFERENCE.md` (the mapping table) were titled "API Reference". Retitled the table **"API Map (Swift ↔ OCCT)"**; the detailed reference keeps "API Reference".
- **Nav order** cleaned (was colliding at `nav_order: 5` and scattered): Home · Cookbook · API Reference · API Map · OCCT Concepts · Architecture · Adding Features · Building OCCT · Thread Safety · Naming Conventions · Versioning · Ecosystem · Changelog.
- **Home page refreshed** to reflect reality: all 12 cookbook areas linked, the new detailed API reference, 4,290 ops, SPM pin `from: "1.0.0"` (was a stale `1.5.0` and Booleans-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)