### PR TITLE
docs(reference): Surface — chunked across 5 pages (batch 2)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -96,7 +96,7 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 |------|------:|------|--------|
 | Wire | 61 | `Wire.md` | ✅ done |
 | Shape | 993 | `Shape-*.md` (chunked) | ☐ todo |
-| Surface | 261 | `Surface-*.md` | ☐ todo |
+| Surface | 234 | `Surface.md` + 4 (Analytic Types, BSpline & Bezier, Analysis, Advanced) | ✅ done |
 | Curve3D | 195 | `Curve3D-*.md` | ☐ todo |
 | Curve2D | 233 | `Curve2D-*.md` | ☐ todo |
 | Edge | 36 | `Edge.md` | ✅ done |

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -1,0 +1,1260 @@
+---
+title: Surface — Advanced Construction
+parent: API Reference
+---
+
+# Surface — Advanced Construction
+
+This page covers the higher-level surface construction APIs: energy-minimising plate and NLPlate
+surfaces, Bezier and BSpline fills, face-from-surface conversions, constrained geometry factories,
+and GeomTools persistence. For the core `Surface` type (properties, analytic primitives, swept
+surfaces, evaluation), see the main Surface page.
+
+## Topics
+
+- [Advanced Plate Surfaces](#advanced-plate-surfaces-v0230) · [Bezier Surface Fill](#bezier-surface-fill-v0310) · [BSpline Fill from Boundary Curves](#bspline-fill-from-boundary-curves-v0430) · [Face from Surface](#face-from-surface-v0330) · [Constrained Construction, Knot Splitting, Conversions](#constrained-geometry-construction-knot-splitting-conversions-v0500) · [LocalAnalysis](#localanalysis) · [GeomFill NSections](#geomfill_nsections-v0680) · [NLPlate G2/G3, IncrementalSolve, GeomFill_Generator](#nlplate-g2g3-incrementalsolve-geomfill_generator-v0690) · [Extrema, gce Factories, GeomTools Persistence](#extrema-gce-factories-geomtools-persistence-v0800)
+
+---
+
+## Advanced Plate Surfaces (v0.23.0)
+
+### `Surface.plateThrough(_:degree:tolerance:)`
+
+Creates a plate surface (parametric BSpline) that passes through a set of unordered 3D points.
+
+```swift
+public static func plateThrough(
+    _ points: [SIMD3<Double>],
+    degree: Int = 3,
+    tolerance: Double = 0.01
+) -> Surface?
+```
+
+Unlike the grid-based `fromPointGrid`, the points need no ordering or row/column counts — suitable
+for scattered probe data, feature points, or any unstructured point set. See also the
+[Surfaces from Points](../guides/cookbook/surfaces-from-points.md) cookbook page.
+
+- **Parameters:** `points` — 3D point cloud (minimum 3); `degree` — maximum polynomial degree; `tolerance` — approximation tolerance.
+- **Returns:** BSpline surface, or `nil` if fewer than 3 points or `GeomPlate_MakeApprox` fails.
+- **OCCT:** `GeomPlate_BuildPlateSurface` + `GeomPlate_PointConstraint` + `GeomPlate_MakeApprox`.
+- **Example:**
+  ```swift
+  let points: [SIMD3<Double>] = [
+      SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2),
+      SIMD3(0, 10, 1), SIMD3(5, 5, 3),
+  ]
+  if let plate = Surface.plateThrough(points, degree: 3, tolerance: 0.01) {
+      let face = plate.toFace()
+  }
+  ```
+
+---
+
+### `nlPlateDeformed(constraints:maxIterations:tolerance:)`
+
+Deforms this surface to pass through target positions using the non-linear plate solver (NLPlate G0 — position-only constraints).
+
+```swift
+public func nlPlateDeformed(
+    constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>)],
+    maxIterations: Int = 4,
+    tolerance: Double = 1e-3
+) -> Surface?
+```
+
+Each constraint pins the surface at a (u, v) parameter to a desired 3D location. The solver
+computes a displacement field on the existing surface; the result preserves the original shape
+except where pulled by the constraints.
+
+- **Parameters:** `constraints` — array of `(uv, target)` pairs (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
+- **Returns:** New deformed surface, or `nil` if the array is empty or the solver fails.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0Constraint` + `GeomPlate_MakeApprox`.
+- **Example:**
+  ```swift
+  let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+  if let bumped = plane.nlPlateDeformed(
+      constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))],
+      maxIterations: 4, tolerance: 1e-3
+  ) {
+      let face = bumped.toFace()
+  }
+  ```
+- **Note:** Distinct from fitting a fresh surface to a point set — the existing parametrisation is preserved.
+
+---
+
+### `nlPlateDeformedG1(constraints:maxIterations:tolerance:)`
+
+Deforms this surface with position and tangent constraints (NLPlate G0+G1).
+
+```swift
+public func nlPlateDeformedG1(
+    constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
+                   tangentU: SIMD3<Double>, tangentV: SIMD3<Double>)],
+    maxIterations: Int = 4,
+    tolerance: Double = 1e-3
+) -> Surface?
+```
+
+Extends `nlPlateDeformed` by also constraining the partial derivatives (tangent vectors) in
+the U and V directions at each constraint point. Use to enforce tangency continuity at the
+constrained locations.
+
+- **Parameters:** `constraints` — array of `(uv, target, tangentU, tangentV)` tuples (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
+- **Returns:** New deformed surface, or `nil` on failure.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG1Constraint` + `GeomPlate_MakeApprox`.
+- **Example:**
+  ```swift
+  if let shaped = plane.nlPlateDeformedG1(
+      constraints: [(
+          uv: SIMD2(0.5, 0.5),
+          target: SIMD3(5, 5, 2),
+          tangentU: SIMD3(1, 0, 0),
+          tangentV: SIMD3(0, 1, 0)
+      )],
+      maxIterations: 4, tolerance: 1e-3
+  ) {
+      let face = shaped.toFace()
+  }
+  ```
+
+---
+
+## Bezier Surface Fill (v0.31.0)
+
+### `BezierFillStyle`
+
+Filling style for Bezier surface construction from boundary curves.
+
+```swift
+public enum BezierFillStyle: Int32, Sendable {
+    case stretch = 0
+    case coons   = 1
+    case curved  = 2
+}
+```
+
+- `stretch` — minimal surface area (flattest).
+- `coons` — bilinear blending between boundaries.
+- `curved` — smooth curved interpolation (most curved).
+
+---
+
+### `Surface.bezierFill(_:_:_:_:style:)`
+
+Creates a Bezier surface by filling 4 Bezier boundary curves.
+
+```swift
+public static func bezierFill(
+    _ c1: Curve3D, _ c2: Curve3D, _ c3: Curve3D, _ c4: Curve3D,
+    style: BezierFillStyle = .stretch
+) -> Surface?
+```
+
+The four curves must be Bezier curves forming a closed boundary (connected end-to-end in order).
+
+- **Parameters:** `c1`–`c4` — four Bezier boundary curves in order; `style` — fill style.
+- **Returns:** Bezier surface, or `nil` if any curve is not Bezier or the fill fails.
+- **OCCT:** `GeomFill_BezierCurves` (4-curve constructor).
+- **Example:**
+  ```swift
+  // c1..c4 are Bezier curves forming a closed boundary
+  if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .coons) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+### `Surface.bezierFill(_:_:style:)`
+
+Creates a Bezier surface by filling 2 Bezier boundary curves as opposite edges.
+
+```swift
+public static func bezierFill(
+    _ c1: Curve3D, _ c2: Curve3D,
+    style: BezierFillStyle = .stretch
+) -> Surface?
+```
+
+- **Parameters:** `c1`, `c2` — two opposing Bezier boundary curves; `style` — fill style.
+- **Returns:** Bezier surface, or `nil` on failure.
+- **OCCT:** `GeomFill_BezierCurves` (2-curve constructor).
+- **Example:**
+  ```swift
+  if let surf = Surface.bezierFill(bottom, top, style: .coons) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+## BSpline Fill from Boundary Curves (v0.43.0)
+
+### `Surface.FillStyle`
+
+Filling style for BSpline surface construction from boundary curves.
+
+```swift
+public enum FillStyle: Int32, Sendable {
+    case stretch = 0
+    case coons   = 1
+    case curved  = 2
+}
+```
+
+- `stretch` — minimal curvature between boundaries.
+- `coons` — moderate curvature (Coons-style blending).
+- `curved` — maximum curvature.
+
+---
+
+### `Surface.bsplineFill(curve1:curve2:style:)`
+
+Creates a BSpline surface spanning between 2 boundary curves.
+
+```swift
+public static func bsplineFill(
+    curve1: Curve3D,
+    curve2: Curve3D,
+    style: FillStyle = .coons
+) -> Surface?
+```
+
+Both curves must be BSpline (created via `Curve3D.bspline` or `Curve3D.interpolate`). The result
+spans from `curve1` to `curve2` in the V direction. See also the
+[Gordon Surfaces](../guides/cookbook/gordon-surfaces.md) cookbook for the full fill-vs-Gordon
+decision guide.
+
+- **Parameters:** `curve1`, `curve2` — BSpline boundary curves; `style` — fill style.
+- **Returns:** BSpline surface, or `nil` if either curve is not BSpline or fill fails.
+- **OCCT:** `GeomFill_BSplineCurves` (2-curve constructor).
+- **Example:**
+  ```swift
+  guard let c1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(5,0,2), SIMD3(10,0,0)]),
+        let c2 = Curve3D.interpolate(points: [SIMD3(0,5,0), SIMD3(5,5,3), SIMD3(10,5,0)])
+  else { return }
+  if let surf = Surface.bsplineFill(curve1: c1, curve2: c2, style: .coons) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+### `Surface.bsplineFill(curves:style:)`
+
+Creates a BSpline surface bounded by 4 boundary curves.
+
+```swift
+public static func bsplineFill(
+    curves: (Curve3D, Curve3D, Curve3D, Curve3D),
+    style: FillStyle = .coons
+) -> Surface?
+```
+
+The four curves must be BSpline and connected end-to-end in order (bottom, right, top, left).
+
+- **Parameters:** `curves` — four BSpline boundary curves in order; `style` — fill style.
+- **Returns:** BSpline surface, or `nil` on failure.
+- **OCCT:** `GeomFill_BSplineCurves` (4-curve constructor).
+- **Example:**
+  ```swift
+  // Four BSpline curves forming a closed loop
+  if let surf = Surface.bsplineFill(curves: (bottom, right, top, left), style: .coons) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+## Face from Surface (v0.33.0)
+
+### `toFace(tolerance:)`
+
+Creates a face from this surface using its full parameter domain.
+
+```swift
+public func toFace(tolerance: Double = 1e-6) -> Shape?
+```
+
+Delegates to `Shape.face(from:uRange:vRange:tolerance:)` with the full `domain.uMin...uMax` and
+`domain.vMin...vMax` ranges. The standard way to convert a parametric `Surface` to a renderable
+or sewable `Shape`.
+
+- **Parameters:** `tolerance` — face creation tolerance.
+- **Returns:** Face shape covering the surface's full UV domain, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace` (via `Shape.face`).
+- **Example:**
+  ```swift
+  if let surf = Surface.plateThrough(pts), let face = surf.toFace() {
+      let mesh = face.mesh(linearDeflection: 0.1, angularDeflection: 0.3)
+  }
+  ```
+
+---
+
+### `toFace(uRange:vRange:tolerance:)`
+
+Creates a face from this surface with specific UV parameter bounds.
+
+```swift
+public func toFace(
+    uRange: ClosedRange<Double>,
+    vRange: ClosedRange<Double>,
+    tolerance: Double = 1e-6
+) -> Shape?
+```
+
+Use to cut out a rectangular UV sub-patch of the surface. For a non-rectangular region, use
+`toFace(uvBoundary:)`.
+
+- **Parameters:** `uRange` — U parameter range; `vRange` — V parameter range; `tolerance` — tolerance.
+- **Returns:** Face shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace` (via `Shape.face`).
+- **Example:**
+  ```swift
+  if let face = surf.toFace(uRange: 0.0...0.5, vRange: 0.0...1.0) {
+      // half of the surface in U
+  }
+  ```
+
+---
+
+### `toFace(uvBoundary:)`
+
+Creates a face trimmed to a non-rectangular region defined by a closed boundary polygon in UV space.
+
+```swift
+public func toFace(uvBoundary: [SIMD2<Double>]) -> Shape?
+```
+
+Each segment of the polygon becomes a 2D edge carrying a pcurve on the surface, so the face
+footprint follows the polygon exactly — unlike `toFace(uRange:vRange:)`, which only makes
+rectangular UV patches. Ideal for reconstructing a fitted analytic surface trimmed to the
+real boundary of a region.
+
+- **Parameters:** `uvBoundary` — closed polygon of (u, v) points (minimum 3; the closing segment is implicit).
+- **Returns:** The trimmed face, or `nil` if fewer than 3 points or construction fails.
+- **OCCT:** `OCCTShapeCreateFaceFromSurfaceUVPolygon` → `BRepBuilderAPI_MakeFace` with pcurve-backed edges.
+- **Example:**
+  ```swift
+  // Triangle trimmed from a BSpline surface in UV space
+  let boundary = [SIMD2(0.1, 0.1), SIMD2(0.9, 0.1), SIMD2(0.5, 0.8)]
+  if let face = surf.toFace(uvBoundary: boundary) {
+      let mesh = face.mesh(linearDeflection: 0.1, angularDeflection: 0.3)
+  }
+  ```
+
+---
+
+## Constrained Geometry Construction, Knot Splitting, Conversions (v0.50.0)
+
+### `Surface.conicalSurface(origin:direction:semiAngle:radius:)`
+
+Creates an infinite conical surface from an axis placement, semi-angle, and base radius.
+
+```swift
+public static func conicalSurface(
+    origin: SIMD3<Double> = .zero,
+    direction: SIMD3<Double> = SIMD3(0, 0, 1),
+    semiAngle: Double,
+    radius: Double
+) -> Surface?
+```
+
+- **Parameters:** `origin` — apex axis origin; `direction` — axis direction; `semiAngle` — half-angle in radians (must be in (0, π/2)); `radius` — base radius at the origin.
+- **Returns:** Conical surface, or `nil` if `semiAngle` is out of range or construction fails.
+- **OCCT:** `Geom_ConicalSurface` with `gp_Ax3`.
+- **Example:**
+  ```swift
+  if let cone = Surface.conicalSurface(semiAngle: .pi / 6, radius: 5) {
+      let face = cone.toFace(uRange: 0...2 * .pi, vRange: 0...20)
+  }
+  ```
+
+---
+
+### `Surface.conicalSurface(point1:point2:r1:r2:)`
+
+Creates a conical surface passing through two points with specified radii.
+
+```swift
+public static func conicalSurface(
+    point1: SIMD3<Double>,
+    point2: SIMD3<Double>,
+    r1: Double,
+    r2: Double
+) -> Surface?
+```
+
+The axis runs from `point1` to `point2`. The cone is defined by radius `r1` at `point1` and `r2`
+at `point2`.
+
+- **Parameters:** `point1` — first axis point; `point2` — second axis point; `r1` — radius at `point1`; `r2` — radius at `point2`.
+- **Returns:** Conical surface, or `nil` on failure.
+- **OCCT:** `Geom_ConicalSurface` derived from the two-point-radii geometry.
+- **Example:**
+  ```swift
+  if let cone = Surface.conicalSurface(
+      point1: SIMD3(0, 0, 0), point2: SIMD3(0, 0, 10),
+      r1: 5, r2: 2
+  ) {
+      let face = cone.toFace(uRange: 0...2 * .pi, vRange: 0...10)
+  }
+  ```
+
+---
+
+### `Surface.cylindricalSurface(origin:direction:radius:)`
+
+Creates a cylindrical surface from an axis and radius.
+
+```swift
+public static func cylindricalSurface(
+    origin: SIMD3<Double> = .zero,
+    direction: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> Surface?
+```
+
+- **Parameters:** `origin` — axis base point; `direction` — axis direction; `radius` — cylinder radius.
+- **Returns:** Cylindrical surface, or `nil` on failure.
+- **OCCT:** `Geom_CylindricalSurface` with `gp_Ax3`.
+- **Example:**
+  ```swift
+  if let cyl = Surface.cylindricalSurface(radius: 5) {
+      let face = cyl.toFace(uRange: 0...2 * .pi, vRange: 0...20)
+  }
+  ```
+
+---
+
+### `Surface.cylindricalSurface(point1:point2:point3:)`
+
+Creates a cylindrical surface through three points.
+
+```swift
+public static func cylindricalSurface(
+    point1: SIMD3<Double>,
+    point2: SIMD3<Double>,
+    point3: SIMD3<Double>
+) -> Surface?
+```
+
+The axis passes through `point1` and `point2`; the radius is the distance from `point3` to
+the axis.
+
+- **Parameters:** `point1` — first axis point; `point2` — second axis point; `point3` — point defining the radius.
+- **Returns:** Cylindrical surface, or `nil` on failure.
+- **OCCT:** `Geom_CylindricalSurface` from the three-point geometry.
+- **Example:**
+  ```swift
+  if let cyl = Surface.cylindricalSurface(
+      point1: SIMD3(0, 0, 0),
+      point2: SIMD3(0, 0, 10),
+      point3: SIMD3(5, 0, 0)
+  ) {
+      let face = cyl.toFace(uRange: 0...2 * .pi, vRange: 0...10)
+  }
+  ```
+
+---
+
+### `Surface.planeFromPoints(_:_:_:)`
+
+Creates a plane surface through three points.
+
+```swift
+public static func planeFromPoints(
+    _ point1: SIMD3<Double>,
+    _ point2: SIMD3<Double>,
+    _ point3: SIMD3<Double>
+) -> Surface?
+```
+
+- **Parameters:** `point1`, `point2`, `point3` — three non-collinear points.
+- **Returns:** Plane surface, or `nil` if points are collinear.
+- **OCCT:** `Geom_Plane` from `gp_Pln` (three-point constructor).
+- **Example:**
+  ```swift
+  if let plane = Surface.planeFromPoints(
+      SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(0, 10, 0)
+  ) {
+      let face = plane.toFace(uRange: 0...10, vRange: 0...10)
+  }
+  ```
+
+---
+
+### `Surface.planeFromPointNormal(point:normal:)`
+
+Creates a plane surface from a point and normal direction.
+
+```swift
+public static func planeFromPointNormal(
+    point: SIMD3<Double>,
+    normal: SIMD3<Double>
+) -> Surface?
+```
+
+- **Parameters:** `point` — a point on the plane; `normal` — plane normal direction.
+- **Returns:** Plane surface, or `nil` on failure.
+- **OCCT:** `Geom_Plane` from `gp_Pln(gp_Pnt, gp_Dir)`.
+- **Example:**
+  ```swift
+  if let plane = Surface.planeFromPointNormal(
+      point: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1)
+  ) {
+      let face = plane.toFace(uRange: -10...10, vRange: -10...10)
+  }
+  ```
+
+---
+
+### `Surface.trimmedCone(point1:point2:r1:r2:)`
+
+Creates a trimmed (bounded) conical surface between two endpoints with specified radii.
+
+```swift
+public static func trimmedCone(
+    point1: SIMD3<Double>,
+    point2: SIMD3<Double>,
+    r1: Double,
+    r2: Double
+) -> Surface?
+```
+
+Unlike `conicalSurface`, the result is a `Geom_RectangularTrimmedSurface` already bounded to the
+axial extent between `point1` and `point2`.
+
+- **Parameters:** `point1` — base centre (with radius `r1`); `point2` — top centre (with radius `r2`); `r1`, `r2` — respective radii.
+- **Returns:** Bounded trimmed conical surface, or `nil` on failure.
+- **OCCT:** `GC_MakeTrimmedCone`.
+- **Example:**
+  ```swift
+  if let cone = Surface.trimmedCone(
+      point1: SIMD3(0, 0, 0), point2: SIMD3(0, 0, 10),
+      r1: 5, r2: 2
+  ) {
+      let face = cone.toFace()
+  }
+  ```
+
+---
+
+### `Surface.trimmedCylinder(origin:direction:radius:height:)`
+
+Creates a trimmed (bounded) cylindrical surface from axis, radius, and height.
+
+```swift
+public static func trimmedCylinder(
+    origin: SIMD3<Double> = .zero,
+    direction: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double,
+    height: Double
+) -> Surface?
+```
+
+- **Parameters:** `origin` — base centre; `direction` — axis direction; `radius` — cylinder radius; `height` — axial height (negative = downward).
+- **Returns:** Bounded trimmed cylindrical surface, or `nil` on failure.
+- **OCCT:** `GC_MakeTrimmedCylinder`.
+- **Example:**
+  ```swift
+  if let cyl = Surface.trimmedCylinder(radius: 5, height: 20) {
+      let face = cyl.toFace()
+  }
+  ```
+
+---
+
+### `knotSplitting(uContinuity:vContinuity:)`
+
+Analyses where a BSpline surface would need to be split to achieve a given continuity level.
+
+```swift
+public func knotSplitting(uContinuity: Int = 1, vContinuity: Int = 1) -> KnotSplitResult
+```
+
+Returns the number of U and V splits needed; does not modify the surface.
+
+- **Parameters:** `uContinuity` — desired U continuity (0=C0, 1=C1, 2=C2); `vContinuity` — desired V continuity.
+- **Returns:** `KnotSplitResult` with `uSplitCount` and `vSplitCount`.
+- **OCCT:** `BSplSLib::KnotSplitting`.
+- **Example:**
+  ```swift
+  let result = surf.knotSplitting(uContinuity: 2, vContinuity: 2)
+  print("U splits needed:", result.uSplitCount)
+  print("V splits needed:", result.vSplitCount)
+  ```
+
+---
+
+### `Surface.joinBezierPatches(_:rows:cols:)`
+
+Joins a rectangular grid of Bezier surface patches into a single BSpline surface.
+
+```swift
+public static func joinBezierPatches(
+    _ patches: [Surface],
+    rows: Int,
+    cols: Int
+) -> Surface?
+```
+
+Adjacent patches must share boundary curves. The `patches` array is row-major (`patches[v * cols + u]`).
+
+- **Parameters:** `patches` — 2D array of Bezier surfaces (row-major order; must equal `rows * cols`); `rows` — patch row count; `cols` — patch column count.
+- **Returns:** Combined BSpline surface, or `nil` if the count doesn't match `rows * cols` or joining fails.
+- **OCCT:** `GeomConvert_CompBezierSurfacesToBSplineSurface`.
+- **Example:**
+  ```swift
+  // Assume patches is a 2×2 grid of Bezier surfaces
+  if let combined = Surface.joinBezierPatches(patches, rows: 2, cols: 2) {
+      let face = combined.toFace()
+  }
+  ```
+
+---
+
+### `convertToAnalytical(tolerance:)`
+
+Tries to recognise this BSpline or Bezier surface as a plane, cylinder, cone, sphere, or torus.
+
+```swift
+public func convertToAnalytical(tolerance: Double = 1e-4) -> AnalyticalConversion?
+```
+
+- **Parameters:** `tolerance` — recognition tolerance.
+- **Returns:** `AnalyticalConversion` with the recognised surface and its `gap` (max deviation), or `nil` if not recognisable.
+- **OCCT:** `ShapeCustom_Surface::ConvertToAnalytical`.
+- **Example:**
+  ```swift
+  if let result = surf.convertToAnalytical(tolerance: 1e-4) {
+      print("recognised surface, gap:", result.gap)
+  }
+  ```
+
+---
+
+### `splitByContinuity(criterion:tolerance:)`
+
+Analyses and splits a BSpline surface at continuity breaks.
+
+```swift
+public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> ContinuitySplitResult
+```
+
+- **Parameters:** `criterion` — continuity level (0=C0, 1=C1, 2=C2, 3=C3); `tolerance` — tolerance for continuity checking.
+- **Returns:** `ContinuitySplitResult` with `wasSplit`, `alreadyMeetsCriterion`, `uSplitCount`, and `vSplitCount`.
+- **OCCT:** `BSplSLib::SplitByContinuity`.
+- **Example:**
+  ```swift
+  let r = surf.splitByContinuity(criterion: 2)
+  if r.alreadyMeetsCriterion {
+      print("surface is already C2")
+  } else {
+      print("needs \(r.uSplitCount) U splits and \(r.vSplitCount) V splits")
+  }
+  ```
+
+---
+
+## LocalAnalysis
+
+### `continuityWith(_:u1:v1:u2:v2:order:)`
+
+Analyses the geometric continuity between this surface at (u1, v1) and another surface at (u2, v2).
+
+```swift
+public func continuityWith(
+    _ other: Surface,
+    u1: Double, v1: Double,
+    u2: Double, v2: Double,
+    order: Int = 4
+) -> ContinuityAnalysis?
+```
+
+Returns C0, G1, C1, G2, C2 status in a single call. The `ContinuityAnalysis` struct exposes
+both raw angular values and Boolean convenience flags (`isC0`, `isG1`, `isC1`, `isG2`, `isC2`).
+
+- **Parameters:** `other` — second surface; `u1`, `v1` — UV parameters on this surface; `u2`, `v2` — UV parameters on `other`; `order` — maximum order to check (0=C0 … 4=C2).
+- **Returns:** `ContinuityAnalysis`, or `nil` if analysis fails.
+- **OCCT:** `LocalAnalysis_SurfaceContinuity`.
+- **Example:**
+  ```swift
+  if let ca = surf1.continuityWith(surf2, u1: 1.0, v1: 0.5, u2: 0.0, v2: 0.5) {
+      #expect(ca.isG1)
+      print("C0 gap:", ca.c0Value, "G1 angle:", ca.g1Angle)
+  }
+  ```
+
+---
+
+## GeomFill_NSections (v0.68.0)
+
+### `Surface.nSections(curves:params:)`
+
+Creates a BSpline surface by lofting through N section curves at specified parameter values.
+
+```swift
+public static func nSections(curves: [Curve3D], params: [Double]) -> Surface?
+```
+
+`curves` and `params` must have the same length (minimum 2). The `params` array assigns a V
+parameter to each section, typically in `0...1` order.
+
+- **Parameters:** `curves` — section curves (minimum 2); `params` — V parameter for each section (same count as `curves`).
+- **Returns:** BSpline surface, or `nil` if counts don't match or `GeomFill_NSections` fails.
+- **OCCT:** `GeomFill_NSections`.
+- **Example:**
+  ```swift
+  guard let c1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(5,0,0), SIMD3(10,0,0)]),
+        let c2 = Curve3D.interpolate(points: [SIMD3(0,5,2), SIMD3(5,5,4), SIMD3(10,5,2)])
+  else { return }
+  if let surf = Surface.nSections(curves: [c1, c2], params: [0, 1]) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+### `Surface.nSectionsInfo(curves:params:)`
+
+Queries the pole count, knot count, and degree that `nSections` would produce, without building
+the surface.
+
+```swift
+public static func nSectionsInfo(
+    curves: [Curve3D],
+    params: [Double]
+) -> (poleCount: Int, knotCount: Int, degree: Int)?
+```
+
+- **Parameters:** `curves` — section curves (minimum 2); `params` — V parameters (same count).
+- **Returns:** Tuple of `(poleCount, knotCount, degree)`, or `nil` on failure.
+- **OCCT:** `GeomFill_NSections` (introspection without surface extraction).
+- **Example:**
+  ```swift
+  if let info = Surface.nSectionsInfo(curves: [c1, c2], params: [0, 1]) {
+      print("poles:", info.poleCount, "degree:", info.degree)
+  }
+  ```
+
+---
+
+## NLPlate G2/G3, IncrementalSolve, GeomFill_Generator (v0.69.0)
+
+### `nlPlateDeformedG2(constraints:maxIterations:tolerance:)`
+
+Deforms this surface with position, tangent, and curvature constraints (NLPlate G0+G2).
+
+```swift
+public func nlPlateDeformedG2(
+    constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
+                   tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
+                   curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>)],
+    maxIterations: Int = 4,
+    tolerance: Double = 1e-3
+) -> Surface?
+```
+
+Extends `nlPlateDeformedG1` by also constraining the second derivatives (curvature tensors) at
+each point. Produces curvature-continuous deformations. Each constraint carries 20 doubles.
+
+- **Parameters:** `constraints` — array of constraint tuples (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
+- **Returns:** New deformed surface, or `nil` on failure.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG2Constraint` + `GeomPlate_MakeApprox`.
+- **Example:**
+  ```swift
+  if let deformed = surf.nlPlateDeformedG2(constraints: [(
+      uv: SIMD2(0.5, 0.5), target: SIMD3(5, 5, 3),
+      tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+      curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero
+  )]) {
+      let face = deformed.toFace()
+  }
+  ```
+
+---
+
+### `nlPlateDeformedG3(constraints:maxIterations:tolerance:)`
+
+Deforms this surface with G0+G1+G2+G3 constraints (position, tangent, curvature, and third-order derivatives).
+
+```swift
+public func nlPlateDeformedG3(
+    constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
+                   tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
+                   curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>,
+                   d3UUU: SIMD3<Double>, d3UUV: SIMD3<Double>, d3UVV: SIMD3<Double>, d3VVV: SIMD3<Double>)],
+    maxIterations: Int = 4,
+    tolerance: Double = 1e-3
+) -> Surface?
+```
+
+The highest-order NLPlate constraint set: 32 doubles per constraint (uv + target + 3 first
+derivatives + 3 second derivatives + 4 third derivatives). Achieves G3-continuous deformations.
+
+- **Parameters:** `constraints` — G0+G1+G2+G3 constraint tuples (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
+- **Returns:** New deformed surface, or `nil` on failure.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG3Constraint` + `GeomPlate_MakeApprox`.
+- **Example:**
+  ```swift
+  if let deformed = surf.nlPlateDeformedG3(constraints: [(
+      uv: SIMD2(0.5, 0.5),
+      target: SIMD3(5, 5, 3),
+      tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+      curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero,
+      d3UUU: .zero, d3UUV: .zero, d3UVV: .zero, d3VVV: .zero
+  )]) {
+      let face = deformed.toFace()
+  }
+  ```
+
+---
+
+### `nlPlateDeformedIncremental(constraints:maxOrder:initConstraintOrder:nbIncrements:)`
+
+Deforms this surface with G0 constraints using the incremental NLPlate solver strategy.
+
+```swift
+public func nlPlateDeformedIncremental(
+    constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>)],
+    maxOrder: Int = 2,
+    initConstraintOrder: Int = 1,
+    nbIncrements: Int = 4
+) -> Surface?
+```
+
+Progressively adds constraints for better convergence on challenging constraint sets where the
+standard `nlPlateDeformed` may not converge well.
+
+- **Parameters:** `constraints` — G0 constraint pairs (non-empty); `maxOrder` — maximum polynomial order; `initConstraintOrder` — initial constraint order; `nbIncrements` — number of increments.
+- **Returns:** New deformed surface, or `nil` on failure.
+- **OCCT:** `NLPlate_NLPlate::IncrementalSolve` + `GeomPlate_MakeApprox`.
+- **Example:**
+  ```swift
+  if let deformed = surf.nlPlateDeformedIncremental(
+      constraints: [(uv: SIMD2(0.5, 0.5), target: SIMD3(5, 5, 3))],
+      nbIncrements: 6
+  ) {
+      let face = deformed.toFace()
+  }
+  ```
+
+---
+
+### `nlPlateDerivative(constraints:u:v:iu:iv:)`
+
+Evaluates the partial derivative of the NLPlate G0 displacement field at a UV point.
+
+```swift
+public func nlPlateDerivative(
+    constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>)],
+    u: Double, v: Double,
+    iu: Int = 1, iv: Int = 0
+) -> SIMD3<Double>?
+```
+
+Solves the NLPlate problem with the given G0 constraints and returns the (iu, iv)-th partial
+derivative at (u, v) without approximating the surface.
+
+- **Parameters:** `constraints` — G0 constraint pairs; `u`, `v` — evaluation parameters; `iu`, `iv` — derivative orders in U and V.
+- **Returns:** Derivative vector, or `nil` on failure.
+- **OCCT:** `NLPlate_NLPlate::Evaluate`.
+- **Example:**
+  ```swift
+  if let d = surf.nlPlateDerivative(
+      constraints: [(uv: SIMD2(0.5, 0.5), target: SIMD3(5, 5, 2))],
+      u: 0.5, v: 0.5, iu: 1, iv: 0
+  ) {
+      print("dU displacement at (0.5, 0.5):", d)
+  }
+  ```
+
+---
+
+### `Surface.generatedFromSections(curves:tolerance:)`
+
+Generates a ruled/lofted surface from a sequence of section curves using linear interpolation in V.
+
+```swift
+public static func generatedFromSections(
+    curves: [Curve3D],
+    tolerance: Double = 1e-6
+) -> Surface?
+```
+
+Uses `GeomFill_Generator` (linear V-direction interpolation), which is simpler and faster than
+`nSections` but less flexible — the V blending is always linear between consecutive sections.
+
+- **Parameters:** `curves` — section curves (minimum 2); `tolerance` — parametric tolerance.
+- **Returns:** Generated surface, or `nil` if fewer than 2 curves or `GeomFill_Generator` fails.
+- **OCCT:** `GeomFill_Generator`.
+- **Example:**
+  ```swift
+  guard let c1 = Curve3D.interpolate(points: [SIMD3(0,0,0), SIMD3(10,0,0)]),
+        let c2 = Curve3D.interpolate(points: [SIMD3(0,5,3), SIMD3(10,5,3)])
+  else { return }
+  if let surf = Surface.generatedFromSections(curves: [c1, c2]) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+### `Surface.degeneratedBoundaryValue(point:first:last:parameter:)`
+
+Evaluates a degenerated boundary (a boundary that has collapsed to a single point) at a parameter.
+
+```swift
+public static func degeneratedBoundaryValue(
+    point: SIMD3<Double>,
+    first: Double = 0,
+    last: Double = 1,
+    parameter: Double
+) -> SIMD3<Double>
+```
+
+Returns `point` regardless of `parameter` — models the apex of a cone or any other degenerate
+pole boundary.
+
+- **Parameters:** `point` — the degenerate point; `first`, `last` — parameter range; `parameter` — evaluation parameter.
+- **Returns:** The degenerate point (always equal to `point`).
+- **OCCT:** `GeomFill_DegeneratedBound::Value`.
+- **Example:**
+  ```swift
+  let apex = Surface.degeneratedBoundaryValue(
+      point: SIMD3(0, 0, 10), first: 0, last: 1, parameter: 0.5
+  )
+  // apex == SIMD3(0, 0, 10)
+  ```
+
+---
+
+### `Surface.isDegeneratedBoundary(point:first:last:)`
+
+Returns `true` — always, for degenerated boundaries defined by a single point.
+
+```swift
+public static func isDegeneratedBoundary(
+    point: SIMD3<Double>,
+    first: Double = 0,
+    last: Double = 1
+) -> Bool
+```
+
+- **Parameters:** `point` — the degenerate point; `first`, `last` — parameter range.
+- **Returns:** Always `true`.
+- **OCCT:** `GeomFill_DegeneratedBound::IsDegenerated`.
+- **Note:** Provided for API completeness when working with `GeomFill` boundary objects.
+
+---
+
+### `boundaryWithSurfaceEvaluate(curve2d:first:last:parameter:)`
+
+Evaluates a boundary-with-surface (a 2D curve on this surface) at a parameter, returning the 3D point and surface normal.
+
+```swift
+public func boundaryWithSurfaceEvaluate(
+    curve2d: Curve2D,
+    first: Double,
+    last: Double,
+    parameter: Double
+) -> (point: SIMD3<Double>, normal: SIMD3<Double>)?
+```
+
+- **Parameters:** `curve2d` — a 2D curve lying on this surface; `first`, `last` — parameter range of the 2D curve; `parameter` — evaluation parameter.
+- **Returns:** Tuple of `(point, normal)` at the boundary parameter, or `nil` on failure.
+- **OCCT:** `GeomFill_BoundWithSurf::Value` + normal from the host surface.
+- **Example:**
+  ```swift
+  if let seg = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(1, 0)),
+     let (pt, n) = surf.boundaryWithSurfaceEvaluate(curve2d: seg, first: 0, last: 1, parameter: 0.5) {
+      print("boundary point:", pt, "normal:", n)
+  }
+  ```
+
+---
+
+### `Surface.averagePlane(points:boundaryPointCount:tolerance:)`
+
+Computes the average plane through a set of 3D points.
+
+```swift
+public static func averagePlane(
+    points: [SIMD3<Double>],
+    boundaryPointCount: Int? = nil,
+    tolerance: Double = 1e-3
+) -> AveragePlaneResult?
+```
+
+Returns the plane normal, origin, and UV bounding box. Also handles the collinear case, returning
+`isLine == true` with a line origin and direction.
+
+- **Parameters:** `points` — 3D points (minimum 3); `boundaryPointCount` — number of boundary points used for orientation (defaults to all points); `tolerance` — planarity check tolerance.
+- **Returns:** `AveragePlaneResult`, or `nil` if the point set is degenerate.
+- **OCCT:** `GeomPlate_BuildAveragePlane`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [.zero, SIMD3(10,0,0), SIMD3(0,10,0), SIMD3(10,10,0.1)]
+  if let result = Surface.averagePlane(points: pts) {
+      if result.isPlane { print("normal:", result.normal) }
+  }
+  ```
+
+---
+
+### `Surface.plateErrors(points:tolerance:maxDegree:maxSegments:)`
+
+Builds a plate surface through points and reports G0, G1, and G2 approximation errors.
+
+```swift
+public static func plateErrors(
+    points: [SIMD3<Double>],
+    tolerance: Double = 1e-3,
+    maxDegree: Int = 8,
+    maxSegments: Int = 9
+) -> (g0Error: Double, g1Error: Double, g2Error: Double)?
+```
+
+- **Parameters:** `points` — 3D points (minimum 3); `tolerance` — approximation tolerance; `maxDegree` — maximum BSpline degree; `maxSegments` — maximum BSpline segments.
+- **Returns:** Tuple of positional (`g0Error`), tangential (`g1Error`), and curvature (`g2Error`) errors, or `nil` on failure.
+- **OCCT:** `GeomPlate_BuildPlateSurface` + `GeomPlate_MakeApprox` (error query).
+- **Example:**
+  ```swift
+  if let err = Surface.plateErrors(points: pts) {
+      print("G0:", err.g0Error, "G1:", err.g1Error, "G2:", err.g2Error)
+  }
+  ```
+
+---
+
+## Extrema, gce Factories, GeomTools Persistence (v0.80.0)
+
+### `extremaPS(point:)`
+
+Computes point-to-surface extrema (nearest/farthest points).
+
+```swift
+public func extremaPS(point: SIMD3<Double>) -> PointSurfaceExtrema
+```
+
+- **Parameters:** `point` — the query point.
+- **Returns:** `PointSurfaceExtrema` with `isDone` and `count` (number of extremum solutions).
+- **OCCT:** `Extrema_ExtPS`.
+- **Example:**
+  ```swift
+  let e = surf.extremaPS(point: SIMD3(5, 5, 10))
+  if e.isDone {
+      for i in 1...e.count {
+          let p = surf.extremaPSPoint(point: SIMD3(5, 5, 10), index: i)
+          print("dist²:", p.squareDistance, "uv:", p.u, p.v)
+      }
+  }
+  ```
+
+---
+
+### `extremaPSPoint(point:index:)`
+
+Returns the Nth extremum from a point-surface extrema computation (1-based).
+
+```swift
+public func extremaPSPoint(point: SIMD3<Double>, index: Int) -> ExtremaPointOnSurface
+```
+
+- **Parameters:** `point` — the query point; `index` — 1-based extremum index.
+- **Returns:** `ExtremaPointOnSurface` with `squareDistance`, `point`, `u`, and `v`.
+- **OCCT:** `Extrema_ExtPS::Point` / `SquareDistance`.
+- **Note:** Call `extremaPS(point:)` first to confirm `isDone` and obtain the valid `count`.
+
+---
+
+### `extremaSS(other:)`
+
+Computes surface-to-surface extrema.
+
+```swift
+public func extremaSS(other: Surface) -> SurfaceSurfaceExtrema
+```
+
+- **Parameters:** `other` — the second surface.
+- **Returns:** `SurfaceSurfaceExtrema` with `isDone`, `isParallel`, and `count`.
+- **OCCT:** `Extrema_ExtSS`.
+- **Example:**
+  ```swift
+  let e = surf1.extremaSS(other: surf2)
+  if e.isDone, !e.isParallel {
+      for i in 1...e.count {
+          let pair = surf1.extremaSSPoint(other: surf2, index: i)
+          print("dist²:", pair.squareDistance)
+      }
+  }
+  ```
+
+---
+
+### `extremaSSPoint(other:index:)`
+
+Returns the Nth extremum pair from a surface-surface extrema computation.
+
+```swift
+public func extremaSSPoint(other: Surface, index: Int) -> Curve3D.ExtremaPointPair
+```
+
+- **Parameters:** `other` — the second surface; `index` — 1-based extremum index.
+- **Returns:** `Curve3D.ExtremaPointPair` with `squareDistance`, `point1`, `param1`, `point2`, `param2`.
+- **OCCT:** `Extrema_ExtSS::Points` / `SquareDistance`.
+
+---
+
+### `Surface.coneFrom2PointsRadii(p1:p2:radius1:radius2:)`
+
+Creates a conical surface from 2 axis points and 2 radii using the `gce_MakeCone` factory.
+
+```swift
+public static func coneFrom2PointsRadii(
+    p1: SIMD3<Double>,
+    p2: SIMD3<Double>,
+    radius1: Double,
+    radius2: Double
+) -> Surface?
+```
+
+- **Parameters:** `p1`, `p2` — axis points; `radius1` — radius at `p1`; `radius2` — radius at `p2`.
+- **Returns:** Conical surface, or `nil` on failure.
+- **OCCT:** `gce_MakeCone(gp_Pnt, gp_Pnt, Standard_Real, Standard_Real)`.
+- **Example:**
+  ```swift
+  if let cone = Surface.coneFrom2PointsRadii(
+      p1: .zero, p2: SIMD3(0, 0, 10), radius1: 5, radius2: 2
+  ) {
+      let face = cone.toFace()
+  }
+  ```
+
+---
+
+### `Surface.cylinderFrom3Points(p1:p2:p3:)`
+
+Creates a cylindrical surface from 3 points using the `gce_MakeCylinder` factory.
+
+```swift
+public static func cylinderFrom3Points(
+    p1: SIMD3<Double>,
+    p2: SIMD3<Double>,
+    p3: SIMD3<Double>
+) -> Surface?
+```
+
+The axis passes through `p1` and `p2`; `p3` defines the radius (its distance to the axis).
+
+- **Parameters:** `p1`, `p2` — axis points; `p3` — radius-defining point.
+- **Returns:** Cylindrical surface, or `nil` on failure.
+- **OCCT:** `gce_MakeCylinder(gp_Pnt, gp_Pnt, gp_Pnt)`.
+- **Example:**
+  ```swift
+  if let cyl = Surface.cylinderFrom3Points(
+      p1: .zero, p2: SIMD3(0, 0, 10), p3: SIMD3(5, 0, 0)
+  ) {
+      let face = cyl.toFace(uRange: 0...2 * .pi, vRange: 0...10)
+  }
+  ```
+
+---
+
+### `Surface.planeFromEquation(a:b:c:d:)`
+
+Creates a plane surface from the equation Ax + By + Cz + D = 0.
+
+```swift
+public static func planeFromEquation(
+    a: Double, b: Double, c: Double, d: Double
+) -> Surface?
+```
+
+- **Parameters:** `a`, `b`, `c` — normal direction coefficients; `d` — plane offset.
+- **Returns:** Plane surface, or `nil` on failure.
+- **OCCT:** `gce_MakePln(Standard_Real, Standard_Real, Standard_Real, Standard_Real)`.
+- **Example:**
+  ```swift
+  // XY plane at Z = 5: 0x + 0y + 1z - 5 = 0
+  if let plane = Surface.planeFromEquation(a: 0, b: 0, c: 1, d: -5) {
+      let face = plane.toFace(uRange: -10...10, vRange: -10...10)
+  }
+  ```
+
+---
+
+### `Surface.planeFrom3Points(p1:p2:p3:)`
+
+Creates a plane surface from 3 points using the `gce_MakePln` factory.
+
+```swift
+public static func planeFrom3Points(
+    p1: SIMD3<Double>,
+    p2: SIMD3<Double>,
+    p3: SIMD3<Double>
+) -> Surface?
+```
+
+- **Parameters:** `p1`, `p2`, `p3` — three non-collinear points.
+- **Returns:** Plane surface, or `nil` if points are collinear.
+- **OCCT:** `gce_MakePln(gp_Pnt, gp_Pnt, gp_Pnt)`.
+- **Example:**
+  ```swift
+  if let plane = Surface.planeFrom3Points(
+      p1: .zero, p2: SIMD3(10, 0, 0), p3: SIMD3(0, 10, 0)
+  ) {
+      let face = plane.toFace(uRange: 0...10, vRange: 0...10)
+  }
+  ```
+
+---
+
+### `Surface.serializeSurfaces(_:)`
+
+Serialises an array of surfaces to a string using `GeomTools_SurfaceSet`.
+
+```swift
+public static func serializeSurfaces(_ surfaces: [Surface]) -> String?
+```
+
+The produced string can be stored and later restored with `deserializeSurfaces(_:)`. Uses OCCT's
+native binary-text stream format.
+
+- **Parameters:** `surfaces` — array of surfaces to serialise.
+- **Returns:** Serialised string, or `nil` on failure.
+- **OCCT:** `GeomTools_SurfaceSet::Write`.
+- **Example:**
+  ```swift
+  if let data = Surface.serializeSurfaces([surf1, surf2]) {
+      // save data to disk
+      if let restored = Surface.deserializeSurfaces(data) {
+          print("restored \(restored.count) surfaces")
+      }
+  }
+  ```
+
+---
+
+### `Surface.deserializeSurfaces(_:)`
+
+Deserialises surfaces from a string produced by `serializeSurfaces(_:)`.
+
+```swift
+public static func deserializeSurfaces(_ data: String) -> [Surface]?
+```
+
+- **Parameters:** `data` — string produced by `serializeSurfaces(_:)`.
+- **Returns:** Array of restored surfaces, or `nil` if parsing fails or the string is empty.
+- **OCCT:** `GeomTools_SurfaceSet::Read`.
+- **Example:**
+  ```swift
+  if let surfaces = Surface.deserializeSurfaces(savedData) {
+      for s in surfaces {
+          let face = s.toFace()
+      }
+  }
+  ```

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -1,0 +1,646 @@
+---
+title: Surface — Analysis
+parent: API Reference
+---
+
+# Surface — Analysis
+
+This page covers the analysis and query members of `Surface`: curvature/normal analysis at a point, singularity detection, surface-to-surface and curve-to-surface extrema, point/curve projection onto a surface, surface–surface and curve–surface intersection, and batch UV evaluation. For factory methods, B-spline/Bezier construction, and operations see the main `Surface` page.
+
+## Topics
+
+- [Local Properties](#local-properties) · [LocalAnalysis](#localanalysis) · [Surface Singularity Analysis](#surface-singularity-analysis-v0370) · [Surface Extrema](#surface-extrema) · [ShapeAnalysis\_Surface Expansion](#shapeanalysis_surface-expansion-v0490) · [Curve Projection](#curve-projection-v0220) · [Surface Intersection & Conversion](#surface-intersection--conversion-v0300) · [Surface-Surface Intersection](#surface-surface-intersection-v0350) · [Curve-Surface Intersection](#curve-surface-intersection-v0350) · [Batch Evaluation](#batch-evaluation-v0290)
+
+---
+
+## Local Properties
+
+Differential geometry queries evaluated at a parametric point `(u, v)` on the surface, backed by `GeomLProp_SLProps`.
+
+---
+
+### `gaussianCurvature(atU:v:)`
+
+Returns the Gaussian curvature at `(u, v)`.
+
+```swift
+public func gaussianCurvature(atU u: Double, v: Double) -> Double
+```
+
+The Gaussian curvature is the product of the two principal curvatures (`kMin × kMax`). Positive on a convex surface, negative in a saddle region, zero on a developable surface.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Gaussian curvature value (signed); `0` if `GeomLProp_SLProps` cannot compute derivatives at that point.
+- **OCCT:** `GeomLProp_SLProps::GaussianCurvature`.
+- **Example:**
+  ```swift
+  if let sphere = Surface.sphere(radius: 5) {
+      let k = sphere.gaussianCurvature(atU: 0, v: 0)  // ≈ 0.04 (1/R²)
+  }
+  ```
+
+---
+
+### `meanCurvature(atU:v:)`
+
+Returns the mean curvature at `(u, v)`.
+
+```swift
+public func meanCurvature(atU u: Double, v: Double) -> Double
+```
+
+The mean curvature is the arithmetic mean of the two principal curvatures: `(kMin + kMax) / 2`. Zero on a minimal surface (e.g., a flat plane in its own parameter domain).
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Mean curvature value (signed).
+- **OCCT:** `GeomLProp_SLProps::MeanCurvature`.
+- **Example:**
+  ```swift
+  if let cyl = Surface.cylinder(radius: 10, height: 50) {
+      let h = cyl.meanCurvature(atU: 0, v: 0.5)  // ≈ 0.05 (1/(2R))
+  }
+  ```
+
+---
+
+### `PrincipalCurvatures`
+
+Struct returned by `principalCurvatures(atU:v:)`.
+
+```swift
+public struct PrincipalCurvatures: Sendable {
+    public let kMin: Double
+    public let kMax: Double
+    public let dirMin: SIMD3<Double>
+    public let dirMax: SIMD3<Double>
+}
+```
+
+- `kMin` / `kMax` — minimum and maximum principal curvatures.
+- `dirMin` / `dirMax` — corresponding principal curvature directions in 3D.
+
+---
+
+### `principalCurvatures(atU:v:)`
+
+Returns the principal curvatures and their directions at `(u, v)`.
+
+```swift
+public func principalCurvatures(atU u: Double, v: Double) -> PrincipalCurvatures?
+```
+
+Uses `GeomLProp_SLProps` to extract both principal curvature values and the orthogonal surface directions along which they act. Returns `nil` if the point is singular or derivatives cannot be computed.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** `PrincipalCurvatures` struct, or `nil` at a singular or degenerate point.
+- **OCCT:** `GeomLProp_SLProps::CurvatureDirections` + `MinCurvature` + `MaxCurvature`.
+- **Example:**
+  ```swift
+  if let srf = Surface.sphere(radius: 5),
+     let pc  = srf.principalCurvatures(atU: 0, v: 0) {
+      print(pc.kMin, pc.kMax)  // both ≈ 0.2 (1/R) for a sphere
+  }
+  ```
+
+---
+
+## LocalAnalysis
+
+Continuity analysis between two surfaces at a shared junction, backed by `LocalAnalysis_SurfaceContinuity`.
+
+---
+
+### `ContinuityAnalysis`
+
+Struct returned by `continuityWith(_:u1:v1:u2:v2:order:)`.
+
+```swift
+public struct ContinuityAnalysis: Sendable {
+    public let status: Int
+    public let c0Value: Double
+    public let g1Angle: Double
+    public let c1UAngle: Double
+    public let c1VAngle: Double
+    public let flags: Int
+    public var isC0: Bool { flags & 1  != 0 }
+    public var isG1: Bool { flags & 2  != 0 }
+    public var isC1: Bool { flags & 4  != 0 }
+    public var isG2: Bool { flags & 8  != 0 }
+    public var isC2: Bool { flags & 16 != 0 }
+}
+```
+
+- `status` — raw `GeomAbs_Shape` continuity status code.
+- `c0Value` — positional gap distance at the junction.
+- `g1Angle` — angle between surface normals at the junction (radians).
+- `c1UAngle` / `c1VAngle` — angles between first derivatives in U and V directions.
+- `flags` — bitmask: bit 0 = C0, bit 1 = G1, bit 2 = C1, bit 3 = G2, bit 4 = C2.
+- Computed boolean helpers `isC0` … `isC2` decode the bitmask.
+
+---
+
+### `continuityWith(_:u1:v1:u2:v2:order:)`
+
+Analyses the continuity between this surface at `(u1, v1)` and another surface at `(u2, v2)`.
+
+```swift
+public func continuityWith(
+    _ other: Surface,
+    u1: Double, v1: Double,
+    u2: Double, v2: Double,
+    order: Int = 4
+) -> ContinuityAnalysis?
+```
+
+`order` controls the maximum continuity level tested: 0 = C0, 1 = G1, 2 = C1, 3 = G2, 4 = C2. Use this to verify that two adjacent surface patches meet smoothly at a shared seam.
+
+- **Parameters:** `other` — the second surface; `u1`/`v1` — parameters on this surface; `u2`/`v2` — parameters on `other`; `order` — maximum order to check (0–4, default 4).
+- **Returns:** `ContinuityAnalysis`, or `nil` if `LocalAnalysis_SurfaceContinuity` fails (e.g. degenerate point, invalid order).
+- **OCCT:** `LocalAnalysis_SurfaceContinuity`.
+- **Example:**
+  ```swift
+  if let a = ContinuityAnalysis(
+         s1.continuityWith(s2, u1: u1, v1: v1, u2: u2, v2: v2)
+     ) {
+      print(a.isG1, a.g1Angle)
+  }
+  // safe unwrap form:
+  if let ca = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0) {
+      print(ca.isC1)
+  }
+  ```
+
+---
+
+## Surface Singularity Analysis (v0.37.0)
+
+Degenerate-region detection backed by `ShapeAnalysis_Surface`.
+
+---
+
+### `singularityCount(tolerance:)`
+
+Returns the number of singularities (poles or degenerate regions) on this surface.
+
+```swift
+public func singularityCount(tolerance: Double = 1e-6) -> Int
+```
+
+A singularity is a parameter value at which the surface normal vanishes (e.g., the poles of a sphere or the apex of a cone). Returns 0 when the surface has no degenerate regions within the given tolerance.
+
+- **Parameters:** `tolerance` — detection precision (default `1e-6`).
+- **Returns:** Count of singularities; 0 if none found.
+- **OCCT:** `ShapeAnalysis_Surface` singularity methods.
+- **Example:**
+  ```swift
+  if let sphere = Surface.sphere(radius: 5) {
+      let n = sphere.singularityCount()  // 2 — north and south poles
+  }
+  ```
+
+---
+
+### `isDegenerated(at:tolerance:)`
+
+Returns `true` if the given 3D point lies at a degenerate region of the surface.
+
+```swift
+public func isDegenerated(at point: SIMD3<Double>, tolerance: Double = 1e-6) -> Bool
+```
+
+- **Parameters:** `point` — 3D point to test; `tolerance` — degeneration precision.
+- **Returns:** `true` if the point is within `tolerance` of a degenerate region.
+- **OCCT:** `ShapeAnalysis_Surface` degeneration check.
+- **Example:**
+  ```swift
+  if let sphere = Surface.sphere(radius: 5) {
+      let atPole = sphere.isDegenerated(at: SIMD3(0, 0, 5))
+  }
+  ```
+
+---
+
+### `hasSingularities(tolerance:)`
+
+Returns `true` if the surface has any singularities within the given tolerance.
+
+```swift
+public func hasSingularities(tolerance: Double = 1e-6) -> Bool
+```
+
+Convenience wrapper over `singularityCount(tolerance:)`.
+
+- **Parameters:** `tolerance` — detection precision (default `1e-6`).
+- **Returns:** `true` when `singularityCount(tolerance:) > 0`.
+- **OCCT:** Delegates to `ShapeAnalysis_Surface` via `singularityCount`.
+- **Example:**
+  ```swift
+  if let cone = Surface.cone(radius: 5, height: 10, halfAngle: .pi / 6) {
+      print(cone.hasSingularities())  // true — apex is singular
+  }
+  ```
+
+---
+
+## Surface Extrema
+
+Minimum-distance computation between two surfaces, backed by `GeomAPI_ExtremaSurfaceSurface`.
+
+---
+
+### `SurfaceExtremaResult`
+
+Struct returned by `extrema(to:uvBounds1:uvBounds2:)`.
+
+```swift
+public struct SurfaceExtremaResult {
+    public let distance: Double
+    public let point1:   SIMD3<Double>
+    public let point2:   SIMD3<Double>
+    public let uv1:      SIMD2<Double>
+    public let uv2:      SIMD2<Double>
+}
+```
+
+- `distance` — minimum distance between the two surfaces.
+- `point1` / `point2` — nearest points on the first and second surface respectively.
+- `uv1` / `uv2` — UV parameters on each surface at the nearest point.
+
+---
+
+### `extrema(to:uvBounds1:uvBounds2:)`
+
+Computes the minimum distance between this surface and another.
+
+```swift
+public func extrema(
+    to other: Surface,
+    uvBounds1: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? = nil,
+    uvBounds2: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? = nil
+) -> SurfaceExtremaResult?
+```
+
+When `uvBounds1` or `uvBounds2` is `nil`, the bridge substitutes `(0, 1, 0, 1)` — valid for surfaces already in the unit parameter domain; supply explicit bounds for surfaces with other parameter ranges. Returns `nil` when no extrema are found.
+
+- **Parameters:** `other` — the second surface; `uvBounds1` — optional UV bounds restricting the search on this surface; `uvBounds2` — optional UV bounds on `other`.
+- **Returns:** `SurfaceExtremaResult`, or `nil` if `GeomAPI_ExtremaSurfaceSurface` finds no solution.
+- **OCCT:** `GeomAPI_ExtremaSurfaceSurface`.
+- **Example:**
+  ```swift
+  if let s1 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+     let s2 = Surface.plane(origin: SIMD3(0, 0, 10), normal: SIMD3(0, 0, 1)),
+     let ex = s1.extrema(to: s2) {
+      print(ex.distance)  // ≈ 10.0
+  }
+  ```
+- **Note:** Infinite (untrimmed) surfaces need explicit `uvBounds` to bound the search; otherwise the solver may fail or return a nonsensical result.
+
+---
+
+## ShapeAnalysis\_Surface Expansion (v0.49.0)
+
+UV parameter recovery via `ShapeAnalysis_Surface::ValueOfUV` and `NextValueOfUV`.
+
+---
+
+### `UVProjection`
+
+Struct returned by `valueOfUV(point:precision:)` and `nextValueOfUV(previousUV:point:precision:)`.
+
+```swift
+public struct UVProjection: Sendable {
+    public let uv:  SIMD2<Double>
+    public let gap: Double
+}
+```
+
+- `uv` — surface UV parameters at the closest surface point.
+- `gap` — distance between the input 3D point and the surface evaluated at `uv`. A nonzero gap means the input point was not exactly on the surface.
+
+---
+
+### `valueOfUV(point:precision:)`
+
+Projects a 3D point onto the surface and returns UV parameters.
+
+```swift
+public func valueOfUV(point: SIMD3<Double>, precision: Double = 1e-6) -> UVProjection
+```
+
+Suitable for a one-off query when no hint is available. For sequential queries along a path, `nextValueOfUV(previousUV:point:precision:)` is faster.
+
+- **Parameters:** `point` — 3D point to project; `precision` — projection precision (default `1e-6`).
+- **Returns:** `UVProjection` (never `nil`; a non-zero `gap` indicates the point was off-surface).
+- **OCCT:** `ShapeAnalysis_Surface::ValueOfUV`.
+- **Example:**
+  ```swift
+  if let srf = Surface.sphere(radius: 5) {
+      let proj = srf.valueOfUV(point: SIMD3(0, 0, 5))
+      print(proj.uv, proj.gap)
+  }
+  ```
+
+---
+
+### `nextValueOfUV(previousUV:point:precision:)`
+
+Projects a 3D point using a previously found UV as a starting hint.
+
+```swift
+public func nextValueOfUV(
+    previousUV: SIMD2<Double>,
+    point:      SIMD3<Double>,
+    precision:  Double = 1e-6
+) -> UVProjection
+```
+
+More efficient than `valueOfUV(point:precision:)` when projecting a sequence of closely-spaced points (e.g. sampling along a curve on the surface). The previous result is used as the initial guess, reducing solver iterations.
+
+- **Parameters:** `previousUV` — UV result from the prior point; `point` — new 3D point to project; `precision` — projection precision (default `1e-6`).
+- **Returns:** `UVProjection` for `point`.
+- **OCCT:** `ShapeAnalysis_Surface::NextValueOfUV`.
+- **Example:**
+  ```swift
+  if let srf = Surface.sphere(radius: 5) {
+      var prev = srf.valueOfUV(point: SIMD3(5, 0, 0)).uv
+      for pt in samplePoints {
+          let p = srf.nextValueOfUV(previousUV: prev, point: pt)
+          prev = p.uv
+      }
+  }
+  ```
+
+---
+
+## Curve Projection (v0.22.0)
+
+Project curves and points onto surfaces, returning UV-space or 3D curves. Backed by `GeomProjLib` and `GeomAPI_ProjectPointOnSurf`.
+
+---
+
+### `SurfaceProjection`
+
+Struct returned by `projectPoint(_:)`.
+
+```swift
+public struct SurfaceProjection: Sendable {
+    public let u:        Double
+    public let v:        Double
+    public let distance: Double
+}
+```
+
+- `u` / `v` — surface UV parameters at the closest point.
+- `distance` — 3D distance from the input point to the surface.
+
+---
+
+### `projectCurve(_:tolerance:)`
+
+Projects a 3D curve onto this surface, returning a 2D parametric (UV) curve.
+
+```swift
+public func projectCurve(_ curve: Curve3D, tolerance: Double = 1e-4) -> Curve2D?
+```
+
+Uses `GeomProjLib::Curve2d` for analytic (normal) projection. The resulting `Curve2D` is in the surface's UV parameter space and is suitable for defining pcurves or trimming boundaries.
+
+- **Parameters:** `curve` — the 3D curve to project; `tolerance` — projection tolerance (default `1e-4`).
+- **Returns:** 2D UV-space curve, or `nil` if the projection fails (e.g. curve not projectable onto the surface within tolerance).
+- **OCCT:** `GeomProjLib::Curve2d`.
+- **Example:**
+  ```swift
+  if let srf  = Surface.cylinder(radius: 10, height: 50),
+     let line = Curve3D.line(from: SIMD3(10, 0, 0), to: SIMD3(10, 0, 50)),
+     let uv   = srf.projectCurve(line) {
+      // uv is the isoline in cylinder UV space
+  }
+  ```
+
+---
+
+### `projectCurveSegments(_:tolerance:)`
+
+Projects a 3D curve onto this surface, returning multiple UV-space segments.
+
+```swift
+public func projectCurveSegments(_ curve: Curve3D, tolerance: Double = 1e-4) -> [Curve2D]
+```
+
+Uses `ProjLib_CompProjectedCurve`, which handles cases where the curve projection crosses surface seams or boundaries and maps to disconnected UV segments. Returns an empty array on failure.
+
+- **Parameters:** `curve` — the 3D curve to project; `tolerance` — projection tolerance (default `1e-4`).
+- **Returns:** Array of 2D UV curves (may be empty if projection fails or the curve does not intersect the surface domain).
+- **OCCT:** `ProjLib_CompProjectedCurve`.
+- **Example:**
+  ```swift
+  if let srf    = Surface.sphere(radius: 10),
+     let spiral = Curve3D.helix(radius: 10, pitch: 2, turns: 3) {
+      let segs = srf.projectCurveSegments(spiral)
+      // segs may contain multiple UV segments when the helix crosses the seam
+  }
+  ```
+
+---
+
+### `projectCurve3D(_:)`
+
+Projects a 3D curve onto this surface, returning a 3D curve that lies on the surface.
+
+```swift
+public func projectCurve3D(_ curve: Curve3D) -> Curve3D?
+```
+
+Uses `GeomProjLib::Project` for normal projection. The result is a 3D curve — unlike `projectCurve(_:tolerance:)`, it is not in UV space.
+
+- **Parameters:** `curve` — the 3D curve to project.
+- **Returns:** 3D curve lying on the surface, or `nil` on failure.
+- **OCCT:** `GeomProjLib::Project`.
+- **Example:**
+  ```swift
+  if let srf  = Surface.sphere(radius: 10),
+     let line = Curve3D.line(from: SIMD3(0, 0, -20), to: SIMD3(0, 0, 20)),
+     let onSrf = srf.projectCurve3D(line) {
+      // onSrf is the meridian arc on the sphere
+  }
+  ```
+
+---
+
+### `projectPoint(_:)`
+
+Projects a 3D point onto this surface and returns the closest UV parameters and distance.
+
+```swift
+public func projectPoint(_ point: SIMD3<Double>) -> SurfaceProjection?
+```
+
+Uses `GeomAPI_ProjectPointOnSurf` to find the nearest surface point. Returns `nil` if the projection fails (e.g. the surface is degenerate).
+
+- **Parameters:** `point` — 3D point to project.
+- **Returns:** `SurfaceProjection` with `u`, `v`, and `distance`, or `nil` on failure.
+- **OCCT:** `GeomAPI_ProjectPointOnSurf`.
+- **Example:**
+  ```swift
+  if let srf  = Surface.sphere(radius: 5),
+     let proj = srf.projectPoint(SIMD3(3, 4, 0)) {
+      print(proj.u, proj.v, proj.distance)  // distance ≈ 0 (point is on the sphere)
+  }
+  ```
+
+---
+
+## Surface Intersection & Conversion (v0.30.0)
+
+---
+
+### `intersections(with:tolerance:maxCurves:)`
+
+Intersects this surface with another and returns the intersection curves.
+
+```swift
+public func intersections(with other: Surface, tolerance: Double = 1e-6, maxCurves: Int = 50) -> [Curve3D]
+```
+
+Returns an empty array when the surfaces do not intersect. This is the earlier (v0.30.0) intersection method; see also `intersectionCurves(with:tolerance:)` added in v0.35.0.
+
+- **Parameters:** `other` — the second surface; `tolerance` — intersection tolerance (default `1e-6`); `maxCurves` — upper bound on the number of returned curves (default 50).
+- **Returns:** Array of 3D intersection curves (may be empty).
+- **OCCT:** `GeomAPI_IntSS`.
+- **Example:**
+  ```swift
+  if let plane  = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+     let sphere = Surface.sphere(radius: 5) {
+      let curves = plane.intersections(with: sphere)
+      // curves contains the great circle where the plane cuts the sphere
+  }
+  ```
+
+---
+
+### `toAnalytical(tolerance:)`
+
+Converts a freeform surface to an analytic surface if it can be recognised as one.
+
+```swift
+public func toAnalytical(tolerance: Double = 1e-4) -> Surface?
+```
+
+Recognises planes, cylinders, cones, spheres, and tori within the given tolerance. Returns the analytic surface type. Useful after fitting operations that produce a B-spline approximation of a canonical shape.
+
+- **Parameters:** `tolerance` — recognition tolerance (default `1e-4`).
+- **Returns:** The equivalent analytic `Surface`, or `nil` if the surface is not recognisable as a standard type.
+- **OCCT:** `GeomConvert_ApproxSurface` recognition path (canonical-surface detection).
+- **Example:**
+  ```swift
+  if let bspSphere = someFittedSurface.toAnalytical() {
+      // bspSphere is now a Geom_SphericalSurface if recognised
+  }
+  ```
+
+---
+
+## Surface-Surface Intersection (v0.35.0)
+
+---
+
+### `intersectionCurves(with:tolerance:)`
+
+Computes intersection curves between this surface and another.
+
+```swift
+public func intersectionCurves(with other: Surface, tolerance: Double = 1e-6) -> [Curve3D]
+```
+
+Uses `GeomAPI_IntSS` with a fixed internal cap of 64 curves. This is the v0.35.0 counterpart to `intersections(with:tolerance:maxCurves:)`; both call the same underlying algorithm but with different buffer sizes and naming.
+
+- **Parameters:** `other` — the surface to intersect with; `tolerance` — intersection tolerance (default `1e-6`).
+- **Returns:** Array of 3D intersection curves (empty if no intersection).
+- **OCCT:** `GeomAPI_IntSS`.
+- **Example:**
+  ```swift
+  if let cyl1 = Surface.cylinder(radius: 5, height: 20),
+     let cyl2 = Surface.cylinder(radius: 5, height: 20) {
+      let curves = cyl1.intersectionCurves(with: cyl2)
+  }
+  ```
+
+---
+
+## Curve-Surface Intersection (v0.35.0)
+
+---
+
+### `CurveSurfaceIntersection`
+
+Public struct representing a single curve–surface intersection point.
+
+```swift
+public struct CurveSurfaceIntersection: Sendable {
+    public var point:           SIMD3<Double>
+    public var surfaceUV:       SIMD2<Double>
+    public var curveParameter:  Double
+}
+```
+
+- `point` — 3D coordinates of the intersection.
+- `surfaceUV` — surface UV parameters at the intersection.
+- `curveParameter` — parameter along the curve at the intersection.
+
+---
+
+### `Curve3D.intersections(with:)`
+
+Computes the intersection points between a curve and a surface.
+
+```swift
+// declared in extension Curve3D:
+public func intersections(with surface: Surface) -> [CurveSurfaceIntersection]
+```
+
+Returns all intersection points (tangent and transverse) up to an internal cap of 64. Returns an empty array when the curve does not pierce the surface.
+
+- **Parameters:** `surface` — the surface to intersect with.
+- **Returns:** Array of `CurveSurfaceIntersection` values (may be empty).
+- **OCCT:** `GeomAPI_IntCS`.
+- **Example:**
+  ```swift
+  if let line = Curve3D.line(from: SIMD3(0, 0, -10), to: SIMD3(0, 0, 10)),
+     let srf  = Surface.sphere(radius: 5) {
+      let hits = line.intersections(with: srf)
+      // hits.count == 2 for a line passing through a sphere
+      for h in hits {
+          print(h.point, h.curveParameter)
+      }
+  }
+  ```
+
+---
+
+## Batch Evaluation (v0.29.0)
+
+---
+
+### `evaluateGrid(uParameters:vParameters:)`
+
+Evaluates the surface at a grid of UV parameters in a single call.
+
+```swift
+public func evaluateGrid(uParameters: [Double], vParameters: [Double]) -> [[SIMD3<Double>]]
+```
+
+Returns a 2D array indexed `[vIndex][uIndex]` — V is the outer index. This is significantly faster than individual `point(atU:v:)` calls when building a dense mesh or sampling a parameter grid.
+
+- **Parameters:** `uParameters` — array of U parameter values; `vParameters` — array of V parameter values.
+- **Returns:** 2D array of 3D positions of size `[vParameters.count][uParameters.count]`, or empty if either input is empty or the evaluated count mismatches.
+- **OCCT:** `Geom_Surface::D0` called per grid point via the bridge buffer.
+- **Example:**
+  ```swift
+  if let srf = Surface.sphere(radius: 5) {
+      let us = stride(from: 0.0, through: Double.pi * 2, by: 0.1).map { $0 }
+      let vs = stride(from: -.pi / 2, through: .pi / 2, by: 0.1).map { $0 }
+      let grid = srf.evaluateGrid(uParameters: us, vParameters: vs)
+      // grid[i][j] is the 3D point at (us[j], vs[i])
+  }
+  ```
+- **Note:** Result is empty (not a partial result) if the internal buffer fill count does not match `uParameters.count × vParameters.count`.

--- a/docs/reference/Surface-Analytic-Types.md
+++ b/docs/reference/Surface-Analytic-Types.md
@@ -1,0 +1,745 @@
+---
+title: Surface — Analytic Types
+parent: API Reference
+---
+
+# Surface — Analytic Types
+
+These members expose the type-specific properties of the six analytic surface kinds: plane, sphere, torus, cylinder, cone, and swept surface. They are accessed via typed nested structs (e.g. `surface.planeProperties`) and are meaningful only when the underlying `Surface` wraps an OCCT object of that kind — calling them on a mismatched type returns zero/nil silently. See the main `Surface` page for construction methods, evaluation, and operations.
+
+## Topics
+
+- [Geom_Plane Properties](#geom_plane-properties-v01080) · [Geom_SphericalSurface Properties](#geom_sphericalsurface-properties-v01080) · [Geom_ToroidalSurface Properties](#geom_toroidalsurface-properties-v01080) · [Geom_CylindricalSurface Properties](#geom_cylindricalsurface-properties-v01080) · [Geom_ConicalSurface Properties](#geom_conicalsurface-properties-v01080) · [Geom_SweptSurface Properties](#geom_sweptsurface-properties-v01080)
+
+---
+
+## Geom_Plane Properties (v0.108.0)
+
+### `planeProperties`
+
+Returns the plane-specific property accessor for this surface.
+
+```swift
+public var planeProperties: PlaneProperties { get }
+```
+
+Meaningful only when the surface wraps a `Geom_Plane`. Accessing members on a non-plane surface returns zeroed values or `nil`.
+
+- **Returns:** A `PlaneProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_Plane` — accessed via `Handle(Geom_Plane)::DownCast`.
+- **Example:**
+  ```swift
+  if let surf = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) {
+      let pp = surf.planeProperties
+  }
+  ```
+
+---
+
+### `PlaneProperties.coefficients`
+
+The plane equation coefficients in the form `Ax + By + Cz + D = 0`.
+
+```swift
+public var coefficients: (a: Double, b: Double, c: Double, d: Double) { get }
+```
+
+The normal vector `(A, B, C)` is unit-length. `D` is the signed distance from the origin to the plane (negative when the origin is on the positive normal side).
+
+- **Returns:** Tuple `(a, b, c, d)` satisfying `Ax + By + Cz + D = 0`. Returns all-zero if the surface is not a `Geom_Plane`.
+- **OCCT:** `Geom_Plane::Coefficients`.
+- **Example:**
+  ```swift
+  if let surf = Surface.plane(origin: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1)) {
+      let c = surf.planeProperties.coefficients
+      // c.c ≈ 1.0, c.d ≈ -5.0
+  }
+  ```
+
+---
+
+### `PlaneProperties.uIso(_:)`
+
+A U iso-curve on the plane at the given U parameter.
+
+```swift
+public func uIso(_ u: Double) -> Curve3D?
+```
+
+On a `Geom_Plane`, a U iso-curve is a line running in the V direction at the specified U coordinate.
+
+- **Parameters:** `u` — U parameter value.
+- **Returns:** The iso-curve as a `Curve3D`, or `nil` if the surface is not a plane or the call fails.
+- **OCCT:** `Geom_Plane::UIso`.
+- **Example:**
+  ```swift
+  if let surf = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) {
+      if let iso = surf.planeProperties.uIso(2.0) {
+          let pt = iso.point(at: 0.0)
+      }
+  }
+  ```
+
+---
+
+### `PlaneProperties.vIso(_:)`
+
+A V iso-curve on the plane at the given V parameter.
+
+```swift
+public func vIso(_ v: Double) -> Curve3D?
+```
+
+On a `Geom_Plane`, a V iso-curve is a line running in the U direction at the specified V coordinate.
+
+- **Parameters:** `v` — V parameter value.
+- **Returns:** The iso-curve as a `Curve3D`, or `nil` if the surface is not a plane or the call fails.
+- **OCCT:** `Geom_Plane::VIso`.
+- **Example:**
+  ```swift
+  if let surf = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) {
+      if let iso = surf.planeProperties.vIso(3.0) {
+          let pt = iso.point(at: 0.0)
+      }
+  }
+  ```
+
+---
+
+### `PlaneProperties.pln`
+
+The plane's geometric data: origin point and outward normal.
+
+```swift
+public var pln: (origin: SIMD3<Double>, normal: SIMD3<Double>) { get }
+```
+
+The origin is the plane's location point (`gp_Pln::Location`). The normal is the unit direction of the plane's Z axis (`gp_Pln::Axis::Direction`).
+
+- **Returns:** Tuple `(origin, normal)`. Returns `(.zero, .zero)` if the surface is not a `Geom_Plane`.
+- **OCCT:** `Geom_Plane::Pln` → `gp_Pln::Location` + `gp_Pln::Axis::Direction`.
+- **Example:**
+  ```swift
+  if let surf = Surface.plane(origin: SIMD3(1, 2, 3), normal: SIMD3(0, 1, 0)) {
+      let p = surf.planeProperties.pln
+      // p.origin ≈ SIMD3(1, 2, 3), p.normal ≈ SIMD3(0, 1, 0)
+  }
+  ```
+
+---
+
+## Geom_SphericalSurface Properties (v0.108.0)
+
+### `sphereProperties`
+
+Returns the sphere-specific property accessor for this surface.
+
+```swift
+public var sphereProperties: SphereProperties { get }
+```
+
+Meaningful only when the surface wraps a `Geom_SphericalSurface`. Members return zero/nil for other surface kinds.
+
+- **Returns:** A `SphereProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_SphericalSurface` — accessed via `Handle(Geom_SphericalSurface)::DownCast`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 10) {
+      let sp = surf.sphereProperties
+  }
+  ```
+
+---
+
+### `SphereProperties.radius`
+
+The radius of the sphere.
+
+```swift
+public var radius: Double { get }
+```
+
+- **Returns:** Radius in model units, or `0` if the surface is not a sphere.
+- **OCCT:** `Geom_SphericalSurface::Radius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 10) {
+      let r = surf.sphereProperties.radius  // 10.0
+  }
+  ```
+
+---
+
+### `SphereProperties.setRadius(_:)`
+
+Mutates the sphere's radius in place.
+
+```swift
+@discardableResult
+public func setRadius(_ r: Double) -> Bool
+```
+
+Modifies the underlying `Geom_SphericalSurface` handle. The change is reflected in all `Surface` values that share this handle.
+
+- **Parameters:** `r` — new radius (must be > 0 per OCCT conventions).
+- **Returns:** `true` on success, `false` if the surface is not a sphere or `r` is invalid.
+- **OCCT:** `Geom_SphericalSurface::SetRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 5) {
+      surf.sphereProperties.setRadius(8)
+  }
+  ```
+
+---
+
+### `SphereProperties.area`
+
+The total surface area of the sphere (4πr²).
+
+```swift
+public var area: Double { get }
+```
+
+- **Returns:** Surface area in model units², or `0` if the surface is not a sphere.
+- **OCCT:** `Geom_SphericalSurface::Area`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 1) {
+      let a = surf.sphereProperties.area  // ≈ 12.566 (4π)
+  }
+  ```
+
+---
+
+### `SphereProperties.volume`
+
+The volume enclosed by the sphere (4/3 πr³).
+
+```swift
+public var volume: Double { get }
+```
+
+- **Returns:** Volume in model units³, or `0` if the surface is not a sphere.
+- **OCCT:** `Geom_SphericalSurface::Volume`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 1) {
+      let v = surf.sphereProperties.volume  // ≈ 4.189 (4π/3)
+  }
+  ```
+
+---
+
+### `SphereProperties.center`
+
+The centre point of the sphere.
+
+```swift
+public var center: SIMD3<Double> { get }
+```
+
+- **Returns:** Centre position in model space, or `.zero` if the surface is not a sphere.
+- **OCCT:** `Geom_SphericalSurface::Sphere().Location()`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: SIMD3(1, 2, 3), radius: 5) {
+      let c = surf.sphereProperties.center  // SIMD3(1, 2, 3)
+  }
+  ```
+
+---
+
+### `SphereProperties.uIso(_:)`
+
+A U iso-curve on the sphere at the given U parameter.
+
+```swift
+public func uIso(_ u: Double) -> Curve3D?
+```
+
+On `Geom_SphericalSurface`, U is the longitude angle; a U iso-curve is a meridian circle.
+
+- **Parameters:** `u` — U parameter (longitude angle in radians, range [0, 2π]).
+- **Returns:** The iso-curve as a `Curve3D`, or `nil` if the surface is not a sphere or the call fails.
+- **OCCT:** `Geom_SphericalSurface::UIso`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 5) {
+      if let meridian = surf.sphereProperties.uIso(0) {
+          let len = meridian.length
+      }
+  }
+  ```
+
+---
+
+### `SphereProperties.vIso(_:)`
+
+A V iso-curve on the sphere at the given V parameter.
+
+```swift
+public func vIso(_ v: Double) -> Curve3D?
+```
+
+On `Geom_SphericalSurface`, V is the latitude angle; a V iso-curve is a parallel circle.
+
+- **Parameters:** `v` — V parameter (latitude angle in radians, range [-π/2, π/2]).
+- **Returns:** The iso-curve as a `Curve3D`, or `nil` if the surface is not a sphere or the call fails.
+- **OCCT:** `Geom_SphericalSurface::VIso`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: .zero, radius: 5) {
+      if let equator = surf.sphereProperties.vIso(0) {
+          let len = equator.length  // ≈ 31.416 (2π*5)
+      }
+  }
+  ```
+
+---
+
+### `SphereProperties.sphere`
+
+The sphere's geometric data: centre point and radius in a single call.
+
+```swift
+public var sphere: (center: SIMD3<Double>, radius: Double) { get }
+```
+
+More efficient than reading `center` and `radius` separately when both are needed.
+
+- **Returns:** Tuple `(center, radius)`. Returns `(.zero, 0)` if the surface is not a sphere.
+- **OCCT:** `Geom_SphericalSurface::Sphere` → `gp_Sphere::Location` + `gp_Sphere::Radius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.sphere(center: SIMD3(1, 0, 0), radius: 3) {
+      let s = surf.sphereProperties.sphere
+      // s.center ≈ SIMD3(1, 0, 0), s.radius ≈ 3.0
+  }
+  ```
+
+---
+
+## Geom_ToroidalSurface Properties (v0.108.0)
+
+### `torusProperties`
+
+Returns the torus-specific property accessor for this surface.
+
+```swift
+public var torusProperties: TorusProperties { get }
+```
+
+Meaningful only when the surface wraps a `Geom_ToroidalSurface`. Members return zero or `false` for other surface kinds.
+
+- **Returns:** A `TorusProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_ToroidalSurface` — accessed via `Handle(Geom_ToroidalSurface)::DownCast`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      let tp = surf.torusProperties
+  }
+  ```
+
+---
+
+### `TorusProperties.majorRadius`
+
+The major radius of the torus (distance from the torus centre to the tube centre).
+
+```swift
+public var majorRadius: Double { get }
+```
+
+- **Returns:** Major radius in model units, or `0` if the surface is not a torus.
+- **OCCT:** `Geom_ToroidalSurface::MajorRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      let R = surf.torusProperties.majorRadius  // 10.0
+  }
+  ```
+
+---
+
+### `TorusProperties.minorRadius`
+
+The minor radius of the torus (tube cross-section radius).
+
+```swift
+public var minorRadius: Double { get }
+```
+
+- **Returns:** Minor radius in model units, or `0` if the surface is not a torus.
+- **OCCT:** `Geom_ToroidalSurface::MinorRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      let r = surf.torusProperties.minorRadius  // 2.0
+  }
+  ```
+
+---
+
+### `TorusProperties.setMajorRadius(_:)`
+
+Mutates the torus major radius in place.
+
+```swift
+@discardableResult
+public func setMajorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new major radius (must be > 0 and > minor radius per OCCT).
+- **Returns:** `true` on success, `false` if the surface is not a torus or the value is invalid.
+- **OCCT:** `Geom_ToroidalSurface::SetMajorRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      surf.torusProperties.setMajorRadius(12)
+  }
+  ```
+
+---
+
+### `TorusProperties.setMinorRadius(_:)`
+
+Mutates the torus minor radius in place.
+
+```swift
+@discardableResult
+public func setMinorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new minor radius (must be > 0 and < major radius per OCCT).
+- **Returns:** `true` on success, `false` if the surface is not a torus or the value is invalid.
+- **OCCT:** `Geom_ToroidalSurface::SetMinorRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      surf.torusProperties.setMinorRadius(3)
+  }
+  ```
+
+---
+
+### `TorusProperties.area`
+
+The total surface area of the torus (4π²Rr).
+
+```swift
+public var area: Double { get }
+```
+
+- **Returns:** Surface area in model units², or `0` if the surface is not a torus.
+- **OCCT:** `Geom_ToroidalSurface::Area`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      let a = surf.torusProperties.area  // ≈ 789.6 (4π²×10×2)
+  }
+  ```
+
+---
+
+### `TorusProperties.volume`
+
+The volume enclosed by the torus (2π²Rr²).
+
+```swift
+public var volume: Double { get }
+```
+
+- **Returns:** Volume in model units³, or `0` if the surface is not a torus.
+- **OCCT:** `Geom_ToroidalSurface::Volume`.
+- **Example:**
+  ```swift
+  if let surf = Surface.torus(majorRadius: 10, minorRadius: 2) {
+      let v = surf.torusProperties.volume  // ≈ 789.6 (2π²×10×4)
+  }
+  ```
+
+---
+
+## Geom_CylindricalSurface Properties (v0.108.0)
+
+### `cylinderProperties`
+
+Returns the cylinder-specific property accessor for this surface.
+
+```swift
+public var cylinderProperties: CylinderProperties { get }
+```
+
+Meaningful only when the surface wraps a `Geom_CylindricalSurface`. Members return zero/nil for other surface kinds.
+
+- **Returns:** A `CylinderProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_CylindricalSurface` — accessed via `Handle(Geom_CylindricalSurface)::DownCast`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cylinder(radius: 5, height: 20) {
+      let cp = surf.cylinderProperties
+  }
+  ```
+
+---
+
+### `CylinderProperties.radius`
+
+The radius of the cylindrical surface.
+
+```swift
+public var radius: Double { get }
+```
+
+- **Returns:** Radius in model units, or `0` if the surface is not a cylinder.
+- **OCCT:** `Geom_CylindricalSurface::Radius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cylinder(radius: 5, height: 20) {
+      let r = surf.cylinderProperties.radius  // 5.0
+  }
+  ```
+
+---
+
+### `CylinderProperties.setRadius(_:)`
+
+Mutates the cylinder's radius in place.
+
+```swift
+@discardableResult
+public func setRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new radius (must be > 0).
+- **Returns:** `true` on success, `false` if the surface is not a cylinder or the value is invalid.
+- **OCCT:** `Geom_CylindricalSurface::SetRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cylinder(radius: 5, height: 20) {
+      surf.cylinderProperties.setRadius(8)
+  }
+  ```
+
+---
+
+### `CylinderProperties.axis`
+
+The cylinder's axis: a position point on the axis and the axis unit direction.
+
+```swift
+public var axis: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+The axis runs through the cylinder centre along the height direction. The position is `gp_Cylinder::Axis().Location()`.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the surface is not a cylinder.
+- **OCCT:** `Geom_CylindricalSurface::Cylinder().Axis()` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cylinder(radius: 5, height: 20) {
+      let ax = surf.cylinderProperties.axis
+      // ax.direction ≈ SIMD3(0, 0, 1) for a Z-axis cylinder
+  }
+  ```
+
+---
+
+### `CylinderProperties.uIso(_:)`
+
+A U iso-curve on the cylindrical surface at the given U parameter.
+
+```swift
+public func uIso(_ u: Double) -> Curve3D?
+```
+
+On `Geom_CylindricalSurface`, U is the angular parameter; a U iso-curve is a line (generator) running parallel to the cylinder axis.
+
+- **Parameters:** `u` — U parameter (angle in radians, range [0, 2π]).
+- **Returns:** The iso-curve (a line) as a `Curve3D`, or `nil` if the surface is not a cylinder or the call fails.
+- **OCCT:** `Geom_CylindricalSurface::UIso`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cylinder(radius: 5, height: 20) {
+      if let gen = surf.cylinderProperties.uIso(0) {
+          // gen is the generator line at angle 0
+      }
+  }
+  ```
+
+---
+
+## Geom_ConicalSurface Properties (v0.108.0)
+
+### `coneProperties`
+
+Returns the cone-specific property accessor for this surface.
+
+```swift
+public var coneProperties: ConeProperties { get }
+```
+
+Meaningful only when the surface wraps a `Geom_ConicalSurface`. Members return zero for other surface kinds.
+
+- **Returns:** A `ConeProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_ConicalSurface` — accessed via `Handle(Geom_ConicalSurface)::DownCast`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cone(semiAngle: .pi / 6, refRadius: 5) {
+      let cp = surf.coneProperties
+  }
+  ```
+
+---
+
+### `ConeProperties.semiAngle`
+
+The semi-angle of the cone (half the apex angle), in radians.
+
+```swift
+public var semiAngle: Double { get }
+```
+
+A semi-angle of 0 would be a cylinder; π/2 would be a flat disc. For physical cones the value is typically in (0, π/2).
+
+- **Returns:** Semi-angle in radians, or `0` if the surface is not a cone.
+- **OCCT:** `Geom_ConicalSurface::SemiAngle`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cone(semiAngle: .pi / 6, refRadius: 5) {
+      let a = surf.coneProperties.semiAngle  // ≈ 0.524 (π/6)
+  }
+  ```
+
+---
+
+### `ConeProperties.refRadius`
+
+The reference radius of the cone at its origin plane.
+
+```swift
+public var refRadius: Double { get }
+```
+
+This is the radius at the cone's reference position (`gp_Cone::RefRadius`), i.e. at V = 0 in the parametric domain.
+
+- **Returns:** Reference radius in model units, or `0` if the surface is not a cone.
+- **OCCT:** `Geom_ConicalSurface::RefRadius`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cone(semiAngle: .pi / 6, refRadius: 5) {
+      let r0 = surf.coneProperties.refRadius  // 5.0
+  }
+  ```
+
+---
+
+### `ConeProperties.apex`
+
+The apex (tip) of the cone.
+
+```swift
+public var apex: SIMD3<Double> { get }
+```
+
+The apex is where the cone's generator lines converge. For a cone with `refRadius > 0`, the apex is offset from the origin along the cone axis by `refRadius / tan(semiAngle)`.
+
+- **Returns:** Apex position in model space, or `.zero` if the surface is not a cone.
+- **OCCT:** `Geom_ConicalSurface::Apex`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cone(semiAngle: .pi / 4, refRadius: 5) {
+      let tip = surf.coneProperties.apex
+      // tip is 5.0 units along the axis from the reference plane
+  }
+  ```
+
+---
+
+### `ConeProperties.axis`
+
+The cone's axis: a position point on the axis and the axis unit direction.
+
+```swift
+public var axis: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+The axis runs through the apex along the cone's height direction. The position is `gp_Cone::Axis().Location()`.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the surface is not a cone.
+- **OCCT:** `Geom_ConicalSurface::Cone().Axis()` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let surf = Surface.cone(semiAngle: .pi / 6, refRadius: 5) {
+      let ax = surf.coneProperties.axis
+      // ax.direction ≈ SIMD3(0, 0, 1) for a Z-axis cone
+  }
+  ```
+
+---
+
+## Geom_SweptSurface Properties (v0.108.0)
+
+### `sweptProperties`
+
+Returns the swept-surface-specific property accessor for this surface.
+
+```swift
+public var sweptProperties: SweptProperties { get }
+```
+
+`Geom_SweptSurface` is the abstract base of `Geom_SurfaceOfLinearExtrusion` and `Geom_SurfaceOfRevolution`. These properties are valid for both subclasses. Members return zero/nil for non-swept surface kinds.
+
+- **Returns:** A `SweptProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_SweptSurface` — accessed via `Handle(Geom_SweptSurface)::DownCast`.
+- **Example:**
+  ```swift
+  if let surf = Surface.extrusion(profile: Wire.circle(radius: 3)!, direction: SIMD3(0, 0, 1)) {
+      let sp = surf.sweptProperties
+  }
+  ```
+
+---
+
+### `SweptProperties.direction`
+
+The sweep direction of the surface.
+
+```swift
+public var direction: SIMD3<Double> { get }
+```
+
+For a `Geom_SurfaceOfLinearExtrusion`, this is the extrusion direction. For `Geom_SurfaceOfRevolution`, this is the revolution axis direction.
+
+- **Returns:** Unit direction vector, or `.zero` if the surface is not a swept surface.
+- **OCCT:** `Geom_SweptSurface::Direction`.
+- **Example:**
+  ```swift
+  if let surf = Surface.extrusion(profile: Wire.circle(radius: 3)!, direction: SIMD3(0, 0, 1)) {
+      let d = surf.sweptProperties.direction  // ≈ SIMD3(0, 0, 1)
+  }
+  ```
+
+---
+
+### `SweptProperties.basisCurve`
+
+The basis curve that was swept to create this surface.
+
+```swift
+public var basisCurve: Curve3D? { get }
+```
+
+For an extrusion, this is the profile curve. For a revolution surface, this is the generating curve rotated around the axis.
+
+- **Returns:** The basis `Curve3D`, or `nil` if the surface is not a swept surface or the curve handle is null.
+- **OCCT:** `Geom_SweptSurface::BasisCurve`.
+- **Example:**
+  ```swift
+  if let surf = Surface.extrusion(profile: Wire.circle(radius: 3)!, direction: SIMD3(0, 0, 1)) {
+      if let basis = surf.sweptProperties.basisCurve {
+          let len = basis.length
+      }
+  }
+  ```

--- a/docs/reference/Surface-BSpline-Bezier.md
+++ b/docs/reference/Surface-BSpline-Bezier.md
@@ -1,0 +1,1245 @@
+---
+title: Surface — BSpline & Bezier
+parent: API Reference
+---
+
+# Surface — BSpline & Bezier
+
+This page documents the freeform B-spline and Bézier pole, knot, weight, and degree accessors/mutators on `Surface`, as well as the utility methods for local evaluation, iso-curve extraction, and patch decomposition. See the main [Surface](Surface.md) page for construction, evaluation, and all other sections.
+
+## Topics
+
+- [BSpline/Bezier Queries](#bsplinebezier-queries) · [BSpline Deep Methods (v0.125.0)](#v01250-bspline-surface-deep-method-completion) · [Bezier Deep Methods (v0.125.0)](#v01250-bezier-surface-deep-method-completion) · [BSpline Completions (v0.126.0)](#bspline-surface-completions-v01260) · [Bezier Completions (v0.126.0)](#bezier-surface-completions-v01260) · [Bezier Completions (v0.127.0)](#v01270-bezier-surface-completions) · [Bezier Completions (v0.129.0)](#v01290-bezier-surface-completions) · [Surface to Bezier Patches (v0.36.0)](#surface-to-bezier-patches-v0360) · [BSpline Bezier Patch Grid (v0.40.0)](#bspline-bezier-patch-grid-v0400)
+
+---
+
+## BSpline/Bezier Queries
+
+Generic pole, degree, and grid-count accessors that work on both `Geom_BSplineSurface` and `Geom_BezierSurface`. Return 0 / empty for surfaces of other types.
+
+---
+
+### `uPoleCount`
+
+Number of control points in the U direction.
+
+```swift
+public var uPoleCount: Int { get }
+```
+
+- **Returns:** Pole count in U, or 0 if the surface is not BSpline/Bezier.
+- **OCCT:** `Geom_BSplineSurface::NbUPoles` / `Geom_BezierSurface::NbUPoles`.
+- **Example:**
+  ```swift
+  let n = surface.uPoleCount
+  ```
+
+---
+
+### `vPoleCount`
+
+Number of control points in the V direction.
+
+```swift
+public var vPoleCount: Int { get }
+```
+
+- **Returns:** Pole count in V, or 0 if the surface is not BSpline/Bezier.
+- **OCCT:** `Geom_BSplineSurface::NbVPoles` / `Geom_BezierSurface::NbVPoles`.
+- **Example:**
+  ```swift
+  let n = surface.vPoleCount
+  ```
+
+---
+
+### `poles`
+
+All control points as a 2D row-major array `[uRow][vCol]`.
+
+```swift
+public var poles: [[SIMD3<Double>]] { get }
+```
+
+- **Returns:** `[[SIMD3<Double>]]` of size `uPoleCount × vPoleCount`, or `[]` if not BSpline/Bezier or if the internal buffer read fails.
+- **OCCT:** `Geom_BSplineSurface::Poles` / `Geom_BezierSurface::Poles` — row/column iteration over the internal `TColgp_Array2OfPnt`.
+- **Example:**
+  ```swift
+  for (i, row) in surface.poles.enumerated() {
+      for (j, pt) in row.enumerated() {
+          print("P[\(i)][\(j)] =", pt)
+      }
+  }
+  ```
+
+---
+
+### `uDegree`
+
+Polynomial degree in the U direction.
+
+```swift
+public var uDegree: Int { get }
+```
+
+- **Returns:** Degree in U, or 0 for non-spline surfaces.
+- **OCCT:** `Geom_BSplineSurface::UDegree` / `Geom_BezierSurface::UDegree`.
+- **Example:**
+  ```swift
+  let deg = surface.uDegree  // e.g. 3 for cubic
+  ```
+
+---
+
+### `vDegree`
+
+Polynomial degree in the V direction.
+
+```swift
+public var vDegree: Int { get }
+```
+
+- **Returns:** Degree in V, or 0 for non-spline surfaces.
+- **OCCT:** `Geom_BSplineSurface::VDegree` / `Geom_BezierSurface::VDegree`.
+- **Example:**
+  ```swift
+  let deg = surface.vDegree
+  ```
+
+---
+
+## v0.125.0: BSpline Surface Deep Method Completion
+
+Low-level evaluation methods on `Geom_BSplineSurface` restricted to a specific knot span. All knot-span indices are 1-based and obtained from `bsplineLocateU`/`bsplineLocateV`.
+
+---
+
+### `bsplineLocalD0(u:v:fromUK1:toUK2:fromVK1:toVK2:)`
+
+Point evaluation restricted to a knot span.
+
+```swift
+public func bsplineLocalD0(u: Double, v: Double, fromUK1: Int, toUK2: Int,
+                            fromVK1: Int, toVK2: Int) -> SIMD3<Double>
+```
+
+- **Parameters:** `u`, `v` — parameter values; `fromUK1`/`toUK2` — U knot span indices (1-based); `fromVK1`/`toVK2` — V knot span indices (1-based).
+- **Returns:** Point on the surface at `(u, v)`. Returns `SIMD3.zero` if the surface is not BSpline or evaluation fails.
+- **OCCT:** `Geom_BSplineSurface::LocalD0`.
+- **Example:**
+  ```swift
+  let (uk1, uk2) = surface.bsplineLocateU(u: 0.5, paramTol: 1e-9)
+  let (vk1, vk2) = surface.bsplineLocateV(v: 0.5, paramTol: 1e-9)
+  let pt = surface.bsplineLocalD0(u: 0.5, v: 0.5,
+                                   fromUK1: uk1, toUK2: uk2,
+                                   fromVK1: vk1, toVK2: vk2)
+  ```
+
+---
+
+### `bsplineLocalD1(u:v:fromUK1:toUK2:fromVK1:toVK2:)`
+
+Point and first partial derivatives restricted to a knot span.
+
+```swift
+public func bsplineLocalD1(u: Double, v: Double, fromUK1: Int, toUK2: Int,
+                            fromVK1: Int, toVK2: Int)
+    -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>)
+```
+
+- **Parameters:** As `bsplineLocalD0`.
+- **Returns:** Tuple of the surface point, dS/dU, and dS/dV. All components are zero-vectors on failure.
+- **OCCT:** `Geom_BSplineSurface::LocalD1`.
+- **Example:**
+  ```swift
+  let r = surface.bsplineLocalD1(u: 0.5, v: 0.5,
+                                  fromUK1: uk1, toUK2: uk2,
+                                  fromVK1: vk1, toVK2: vk2)
+  print(r.point, r.d1u, r.d1v)
+  ```
+
+---
+
+### `bsplineLocalD2(u:v:fromUK1:toUK2:fromVK1:toVK2:)`
+
+Point, first, and second partial derivatives restricted to a knot span.
+
+```swift
+public func bsplineLocalD2(u: Double, v: Double, fromUK1: Int, toUK2: Int,
+                            fromVK1: Int, toVK2: Int)
+    -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>,
+        d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>)
+```
+
+- **Returns:** Point plus d/dU, d/dV, d²/dU², d²/dV², d²/dUdV. All zero on failure.
+- **OCCT:** `Geom_BSplineSurface::LocalD2`.
+- **Example:**
+  ```swift
+  let r = surface.bsplineLocalD2(u: 0.5, v: 0.5,
+                                  fromUK1: uk1, toUK2: uk2,
+                                  fromVK1: vk1, toVK2: vk2)
+  ```
+
+---
+
+### `bsplineLocalD3(u:v:fromUK1:toUK2:fromVK1:toVK2:)`
+
+Point through third partial derivatives restricted to a knot span.
+
+```swift
+public func bsplineLocalD3(u: Double, v: Double, fromUK1: Int, toUK2: Int,
+                            fromVK1: Int, toVK2: Int)
+    -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>,
+        d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>,
+        d3u: SIMD3<Double>, d3v: SIMD3<Double>, d3uuv: SIMD3<Double>, d3uvv: SIMD3<Double>)
+```
+
+- **Returns:** 10-element tuple covering point and all partial derivatives through order 3. All zero on failure.
+- **OCCT:** `Geom_BSplineSurface::LocalD3`.
+- **Example:**
+  ```swift
+  let r = surface.bsplineLocalD3(u: 0.5, v: 0.5,
+                                  fromUK1: uk1, toUK2: uk2,
+                                  fromVK1: vk1, toVK2: vk2)
+  ```
+
+---
+
+### `bsplineLocalDN(u:v:fromUK1:toUK2:fromVK1:toVK2:nu:nv:)`
+
+Arbitrary-order partial derivative restricted to a knot span.
+
+```swift
+public func bsplineLocalDN(u: Double, v: Double, fromUK1: Int, toUK2: Int,
+                            fromVK1: Int, toVK2: Int, nu: Int, nv: Int) -> SIMD3<Double>
+```
+
+- **Parameters:** `nu` — U derivative order; `nv` — V derivative order.
+- **Returns:** The `(nu, nv)` partial derivative vector. Zero on failure.
+- **OCCT:** `Geom_BSplineSurface::LocalDN`.
+- **Example:**
+  ```swift
+  let d = surface.bsplineLocalDN(u: 0.5, v: 0.5,
+                                  fromUK1: uk1, toUK2: uk2,
+                                  fromVK1: vk1, toVK2: vk2, nu: 2, nv: 1)
+  ```
+
+---
+
+### `bsplineLocalValue(u:v:fromUK1:toUK2:fromVK1:toVK2:)`
+
+Point evaluation using `LocalValue` (alias of `LocalD0` in most OCCT versions).
+
+```swift
+public func bsplineLocalValue(u: Double, v: Double, fromUK1: Int, toUK2: Int,
+                               fromVK1: Int, toVK2: Int) -> SIMD3<Double>
+```
+
+- **Returns:** Point on the surface at `(u, v)` within the knot span. Zero on failure.
+- **OCCT:** `Geom_BSplineSurface::LocalValue`.
+- **Example:**
+  ```swift
+  let pt = surface.bsplineLocalValue(u: 0.5, v: 0.5,
+                                      fromUK1: uk1, toUK2: uk2,
+                                      fromVK1: vk1, toVK2: vk2)
+  ```
+
+---
+
+### `bsplineUIso(u:)`
+
+Extracts the U isoparametric curve at parameter `u` from a BSpline surface.
+
+```swift
+public func bsplineUIso(u: Double) -> Curve3D?
+```
+
+- **Parameters:** `u` — U parameter value within the surface's U domain.
+- **Returns:** The iso-curve as a `Curve3D`, or `nil` if the surface is not BSpline or extraction fails.
+- **OCCT:** `Geom_BSplineSurface::UIso`.
+- **Example:**
+  ```swift
+  if let iso = surface.bsplineUIso(u: 0.5) {
+      let pt = iso.point(at: 0.0)
+  }
+  ```
+
+---
+
+### `bsplineVIso(v:)`
+
+Extracts the V isoparametric curve at parameter `v` from a BSpline surface.
+
+```swift
+public func bsplineVIso(v: Double) -> Curve3D?
+```
+
+- **Parameters:** `v` — V parameter value within the surface's V domain.
+- **Returns:** The iso-curve as a `Curve3D`, or `nil` on failure.
+- **OCCT:** `Geom_BSplineSurface::VIso`.
+- **Example:**
+  ```swift
+  if let iso = surface.bsplineVIso(v: 0.5) {
+      let pt = iso.point(at: 0.0)
+  }
+  ```
+
+---
+
+### `bsplineLocateU(u:paramTol:)`
+
+Finds the knot span indices bracketing U parameter `u`.
+
+```swift
+public func bsplineLocateU(u: Double, paramTol: Double) -> (i1: Int, i2: Int)
+```
+
+- **Parameters:** `u` — parameter value; `paramTol` — tolerance for knot coincidence.
+- **Returns:** `(i1, i2)` — 1-based knot indices such that `UKnot(i1) ≤ u ≤ UKnot(i2)`. Both are 0 on failure.
+- **OCCT:** `Geom_BSplineSurface::LocateU`.
+- **Example:**
+  ```swift
+  let (i1, i2) = surface.bsplineLocateU(u: 0.5, paramTol: 1e-9)
+  ```
+
+---
+
+### `bsplineLocateV(v:paramTol:)`
+
+Finds the knot span indices bracketing V parameter `v`.
+
+```swift
+public func bsplineLocateV(v: Double, paramTol: Double) -> (i1: Int, i2: Int)
+```
+
+- **Parameters:** `v` — parameter value; `paramTol` — tolerance for knot coincidence.
+- **Returns:** `(i1, i2)` 1-based knot indices. Both 0 on failure.
+- **OCCT:** `Geom_BSplineSurface::LocateV`.
+- **Example:**
+  ```swift
+  let (j1, j2) = surface.bsplineLocateV(v: 0.5, paramTol: 1e-9)
+  ```
+
+---
+
+### `bsplineUKnot(index:)`
+
+Returns the U knot value at the given 1-based index.
+
+```swift
+public func bsplineUKnot(index: Int) -> Double
+```
+
+- **Parameters:** `index` — 1-based knot index.
+- **Returns:** Knot value, or 0.0 on failure.
+- **OCCT:** `Geom_BSplineSurface::UKnot`.
+- **Example:**
+  ```swift
+  let k = surface.bsplineUKnot(index: 1)
+  ```
+
+---
+
+### `bsplineVKnot(index:)`
+
+Returns the V knot value at the given 1-based index.
+
+```swift
+public func bsplineVKnot(index: Int) -> Double
+```
+
+- **Parameters:** `index` — 1-based knot index.
+- **Returns:** Knot value, or 0.0 on failure.
+- **OCCT:** `Geom_BSplineSurface::VKnot`.
+- **Example:**
+  ```swift
+  let k = surface.bsplineVKnot(index: 1)
+  ```
+
+---
+
+### `bsplineUMultiplicity(index:)`
+
+Returns the U knot multiplicity at the given 1-based index.
+
+```swift
+public func bsplineUMultiplicity(index: Int) -> Int
+```
+
+- **Parameters:** `index` — 1-based knot index.
+- **Returns:** Multiplicity (≥ 1), or 0 on failure.
+- **OCCT:** `Geom_BSplineSurface::UMultiplicity`.
+- **Example:**
+  ```swift
+  let m = surface.bsplineUMultiplicity(index: 1)
+  ```
+
+---
+
+### `bsplineVMultiplicity(index:)`
+
+Returns the V knot multiplicity at the given 1-based index.
+
+```swift
+public func bsplineVMultiplicity(index: Int) -> Int
+```
+
+- **Parameters:** `index` — 1-based knot index.
+- **Returns:** Multiplicity (≥ 1), or 0 on failure.
+- **OCCT:** `Geom_BSplineSurface::VMultiplicity`.
+- **Example:**
+  ```swift
+  let m = surface.bsplineVMultiplicity(index: 1)
+  ```
+
+---
+
+### `bsplineUKnotDistribution`
+
+Knot distribution type in the U direction.
+
+```swift
+public var bsplineUKnotDistribution: Int { get }
+```
+
+- **Returns:** Integer code: 0 = NonUniform, 1 = Uniform, 2 = QuasiUniform, 3 = PiecewiseBezier. 0 also on failure.
+- **OCCT:** `Geom_BSplineSurface::UKnotDistribution` — returns a `GeomAbs_BSplKnotDistribution` enum cast to `Int32`.
+- **Example:**
+  ```swift
+  let dist = surface.bsplineUKnotDistribution  // 3 = PiecewiseBezier
+  ```
+
+---
+
+### `bsplineVKnotDistribution`
+
+Knot distribution type in the V direction.
+
+```swift
+public var bsplineVKnotDistribution: Int { get }
+```
+
+- **Returns:** Same codes as `bsplineUKnotDistribution`.
+- **OCCT:** `Geom_BSplineSurface::VKnotDistribution`.
+- **Example:**
+  ```swift
+  let dist = surface.bsplineVKnotDistribution
+  ```
+
+---
+
+### `bsplinePoles`
+
+All control points of a BSpline surface as a flat array in row-major order.
+
+```swift
+public var bsplinePoles: [SIMD3<Double>] { get }
+```
+
+Iterates the internal `TColgp_Array2OfPnt` in (U-row, V-col) order. Total count = `NbUPoles × NbVPoles`.
+
+- **Returns:** Flat array of `uPoleCount × vPoleCount` points, or `[]` if not BSpline or pole count is 0.
+- **OCCT:** `Geom_BSplineSurface::Poles`.
+- **Example:**
+  ```swift
+  let flat = surface.bsplinePoles
+  ```
+
+---
+
+### `bsplineBounds`
+
+Parameter domain of a BSpline surface.
+
+```swift
+public var bsplineBounds: (u1: Double, u2: Double, v1: Double, v2: Double) { get }
+```
+
+- **Returns:** The `(u1, u2, v1, v2)` parameter range. All zeros on failure.
+- **OCCT:** `Geom_BSplineSurface::Bounds`.
+- **Example:**
+  ```swift
+  let b = surface.bsplineBounds
+  // e.g. (0.0, 1.0, 0.0, 1.0)
+  ```
+
+---
+
+### `bsplineIsUClosed`
+
+Whether the BSpline surface is closed in U.
+
+```swift
+public var bsplineIsUClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_BSplineSurface::IsUClosed`.
+- **Example:**
+  ```swift
+  if surface.bsplineIsUClosed { /* cylindrical topology */ }
+  ```
+
+---
+
+### `bsplineIsVClosed`
+
+Whether the BSpline surface is closed in V.
+
+```swift
+public var bsplineIsVClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_BSplineSurface::IsVClosed`.
+- **Example:**
+  ```swift
+  if surface.bsplineIsVClosed { }
+  ```
+
+---
+
+## v0.125.0: Bezier Surface Deep Method Completion
+
+---
+
+### `bezierUIso(u:)`
+
+Extracts the U isoparametric curve at `u` from a Bezier surface.
+
+```swift
+public func bezierUIso(u: Double) -> Curve3D?
+```
+
+- **Parameters:** `u` — U parameter (domain `[0, 1]` for Bezier surfaces).
+- **Returns:** Iso-curve as `Curve3D`, or `nil` on failure.
+- **OCCT:** `Geom_BezierSurface::UIso`.
+- **Example:**
+  ```swift
+  if let iso = surface.bezierUIso(u: 0.5) { }
+  ```
+
+---
+
+### `bezierVIso(v:)`
+
+Extracts the V isoparametric curve at `v` from a Bezier surface.
+
+```swift
+public func bezierVIso(v: Double) -> Curve3D?
+```
+
+- **Parameters:** `v` — V parameter (domain `[0, 1]`).
+- **Returns:** Iso-curve as `Curve3D`, or `nil` on failure.
+- **OCCT:** `Geom_BezierSurface::VIso`.
+- **Example:**
+  ```swift
+  if let iso = surface.bezierVIso(v: 0.5) { }
+  ```
+
+---
+
+### `bezierIsUClosed`
+
+Whether the Bezier surface is closed in U.
+
+```swift
+public var bezierIsUClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::IsUClosed`.
+- **Example:**
+  ```swift
+  let closed = surface.bezierIsUClosed
+  ```
+
+---
+
+### `bezierIsVClosed`
+
+Whether the Bezier surface is closed in V.
+
+```swift
+public var bezierIsVClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::IsVClosed`.
+- **Example:**
+  ```swift
+  let closed = surface.bezierIsVClosed
+  ```
+
+---
+
+### `bezierIsUPeriodic`
+
+Whether the Bezier surface is periodic in U.
+
+```swift
+public var bezierIsUPeriodic: Bool { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::IsUPeriodic`. Bezier surfaces are never periodic; always returns `false`.
+- **Example:**
+  ```swift
+  let p = surface.bezierIsUPeriodic  // always false
+  ```
+
+---
+
+### `bezierIsVPeriodic`
+
+Whether the Bezier surface is periodic in V.
+
+```swift
+public var bezierIsVPeriodic: Bool { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::IsVPeriodic`. Always `false` for Bezier surfaces.
+- **Example:**
+  ```swift
+  let p = surface.bezierIsVPeriodic
+  ```
+
+---
+
+### `bezierContinuity`
+
+Continuity class of the Bezier surface.
+
+```swift
+public var bezierContinuity: Int { get }
+```
+
+- **Returns:** Integer code: 0 = C0, 1 = C1, 2 = C2, 3 = C3, 4 = CN. Bezier surfaces are CN by construction (returns 4).
+- **OCCT:** `Geom_BezierSurface::Continuity`.
+- **Example:**
+  ```swift
+  let c = surface.bezierContinuity  // 4 (CN)
+  ```
+
+---
+
+### `bezierIsCNu(_:)`
+
+Whether the Bezier surface is at least CN-continuous in U.
+
+```swift
+public func bezierIsCNu(_ n: Int) -> Bool
+```
+
+- **Parameters:** `n` — desired continuity order.
+- **Returns:** `true` for any `n` (Bezier surfaces are infinitely differentiable).
+- **OCCT:** `Geom_BezierSurface::IsCNu`.
+- **Example:**
+  ```swift
+  let ok = surface.bezierIsCNu(3)  // true
+  ```
+
+---
+
+### `bezierIsCNv(_:)`
+
+Whether the Bezier surface is at least CN-continuous in V.
+
+```swift
+public func bezierIsCNv(_ n: Int) -> Bool
+```
+
+- **Parameters:** `n` — desired continuity order.
+- **Returns:** `true` for any `n`.
+- **OCCT:** `Geom_BezierSurface::IsCNv`.
+- **Example:**
+  ```swift
+  let ok = surface.bezierIsCNv(2)  // true
+  ```
+
+---
+
+### `bezierPoles`
+
+All control points of a Bezier surface as a flat row-major array.
+
+```swift
+public var bezierPoles: [SIMD3<Double>] { get }
+```
+
+- **Returns:** Flat array of `bezierNbUPoles × bezierNbVPoles` points, or `[]` on failure.
+- **OCCT:** `Geom_BezierSurface::Poles`.
+- **Example:**
+  ```swift
+  let pts = surface.bezierPoles
+  ```
+
+---
+
+### `bezierWeights`
+
+All weights of a rational Bezier surface as a flat row-major array.
+
+```swift
+public var bezierWeights: [Double]? { get }
+```
+
+- **Returns:** Flat array of `bezierNbUPoles × bezierNbVPoles` weights, or `nil` if the surface is non-rational or not Bezier.
+- **OCCT:** `Geom_BezierSurface::Weights`.
+- **Example:**
+  ```swift
+  if let w = surface.bezierWeights {
+      print("rational, first weight:", w[0])
+  }
+  ```
+
+---
+
+### `bezierBounds`
+
+Parameter domain of a Bezier surface.
+
+```swift
+public var bezierBounds: (u1: Double, u2: Double, v1: Double, v2: Double) { get }
+```
+
+- **Returns:** `(0.0, 1.0, 0.0, 1.0)` for standard Bezier surfaces. All zeros on failure.
+- **OCCT:** `Geom_BezierSurface::Bounds`.
+- **Example:**
+  ```swift
+  let b = surface.bezierBounds
+  ```
+
+---
+
+### `bezierNbUPoles`
+
+Number of U poles (rows) for a Bezier surface.
+
+```swift
+public var bezierNbUPoles: Int { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::NbUPoles`.
+- **Example:**
+  ```swift
+  let n = surface.bezierNbUPoles
+  ```
+
+---
+
+### `bezierNbVPoles`
+
+Number of V poles (columns) for a Bezier surface.
+
+```swift
+public var bezierNbVPoles: Int { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::NbVPoles`.
+- **Example:**
+  ```swift
+  let n = surface.bezierNbVPoles
+  ```
+
+---
+
+### `bezierUDegree`
+
+U degree of a Bezier surface (= `bezierNbUPoles - 1`).
+
+```swift
+public var bezierUDegree: Int { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::UDegree`.
+- **Example:**
+  ```swift
+  let d = surface.bezierUDegree
+  ```
+
+---
+
+### `bezierVDegree`
+
+V degree of a Bezier surface (= `bezierNbVPoles - 1`).
+
+```swift
+public var bezierVDegree: Int { get }
+```
+
+- **OCCT:** `Geom_BezierSurface::VDegree`.
+- **Example:**
+  ```swift
+  let d = surface.bezierVDegree
+  ```
+
+---
+
+## BSpline Surface Completions (v0.126.0)
+
+---
+
+### `bsplineUMultiplicities`
+
+All U knot multiplicities as a flat array.
+
+```swift
+public var bsplineUMultiplicities: [Int] { get }
+```
+
+- **Returns:** Array of length `NbUKnots`, or `[]` on failure.
+- **OCCT:** `Geom_BSplineSurface::UMultiplicity` called per knot index.
+- **Example:**
+  ```swift
+  let mults = surface.bsplineUMultiplicities
+  ```
+
+---
+
+### `bsplineVMultiplicities`
+
+All V knot multiplicities as a flat array.
+
+```swift
+public var bsplineVMultiplicities: [Int] { get }
+```
+
+- **Returns:** Array of length `NbVKnots`, or `[]` on failure.
+- **OCCT:** `Geom_BSplineSurface::VMultiplicity` called per knot index.
+- **Example:**
+  ```swift
+  let mults = surface.bsplineVMultiplicities
+  ```
+
+---
+
+### `bsplineUReverse()`
+
+Reverses the U parameter direction of the BSpline surface in place.
+
+```swift
+@discardableResult
+public func bsplineUReverse() -> Bool
+```
+
+- **Returns:** `true` on success, `false` if the surface is not BSpline or the call throws.
+- **OCCT:** `Geom_BSplineSurface::UReverse`.
+- **Example:**
+  ```swift
+  surface.bsplineUReverse()
+  ```
+
+---
+
+### `bsplineVReverse()`
+
+Reverses the V parameter direction of the BSpline surface in place.
+
+```swift
+@discardableResult
+public func bsplineVReverse() -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BSplineSurface::VReverse`.
+- **Example:**
+  ```swift
+  surface.bsplineVReverse()
+  ```
+
+---
+
+### `bsplinePeriodicNormalization(u:v:)`
+
+Normalises U, V parameters for a periodic BSpline surface (maps them into the fundamental period).
+
+```swift
+public func bsplinePeriodicNormalization(u: inout Double, v: inout Double) -> Bool
+```
+
+- **Parameters:** `u`, `v` — parameter values; modified in place.
+- **Returns:** `true` on success, `false` if the surface is not BSpline or the call throws.
+- **OCCT:** `Geom_BSplineSurface::PeriodicNormalization`.
+- **Example:**
+  ```swift
+  var u = 3.5, v = -0.2
+  surface.bsplinePeriodicNormalization(u: &u, v: &v)
+  ```
+
+---
+
+## Bezier Surface Completions (v0.126.0)
+
+---
+
+### `bezierInsertPoleColAfter(_:poles:)`
+
+Inserts a new column of poles after the given column index in a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierInsertPoleColAfter(_ colIndex: Int, poles: [SIMD3<Double>]) -> Bool
+```
+
+- **Parameters:** `colIndex` — 1-based column index after which to insert; `poles` — new pole column (`poles.count` must equal `bezierNbUPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::InsertPoleColAfter`.
+- **Example:**
+  ```swift
+  let newCol = Array(repeating: SIMD3<Double>(1, 0, 0), count: surface.bezierNbUPoles)
+  surface.bezierInsertPoleColAfter(1, poles: newCol)
+  ```
+
+---
+
+### `bezierInsertPoleRowAfter(_:poles:)`
+
+Inserts a new row of poles after the given row index in a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierInsertPoleRowAfter(_ rowIndex: Int, poles: [SIMD3<Double>]) -> Bool
+```
+
+- **Parameters:** `rowIndex` — 1-based row index; `poles` — new pole row (`poles.count` must equal `bezierNbVPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::InsertPoleRowAfter`.
+- **Example:**
+  ```swift
+  let newRow = Array(repeating: SIMD3<Double>(0, 1, 0), count: surface.bezierNbVPoles)
+  surface.bezierInsertPoleRowAfter(1, poles: newRow)
+  ```
+
+---
+
+### `bezierRemovePoleCol(_:)`
+
+Removes a column of poles from a Bezier surface (1-based index).
+
+```swift
+@discardableResult
+public func bezierRemovePoleCol(_ colIndex: Int) -> Bool
+```
+
+- **Parameters:** `colIndex` — 1-based column index to remove.
+- **Returns:** `true` on success. The surface must have at least 2 columns.
+- **OCCT:** `Geom_BezierSurface::RemovePoleCol`.
+- **Example:**
+  ```swift
+  surface.bezierRemovePoleCol(1)
+  ```
+
+---
+
+### `bezierRemovePoleRow(_:)`
+
+Removes a row of poles from a Bezier surface (1-based index).
+
+```swift
+@discardableResult
+public func bezierRemovePoleRow(_ rowIndex: Int) -> Bool
+```
+
+- **Parameters:** `rowIndex` — 1-based row index to remove. The surface must have at least 2 rows.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::RemovePoleRow`.
+- **Example:**
+  ```swift
+  surface.bezierRemovePoleRow(1)
+  ```
+
+---
+
+### `bezierIncreaseDegree(uDeg:vDeg:)`
+
+Increases the degree of a Bezier surface in U and/or V.
+
+```swift
+@discardableResult
+public func bezierIncreaseDegree(uDeg: Int, vDeg: Int) -> Bool
+```
+
+- **Parameters:** `uDeg` — new U degree (must be ≥ current U degree); `vDeg` — new V degree.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::Increase`.
+- **Note:** Degree can only increase, never decrease.
+- **Example:**
+  ```swift
+  surface.bezierIncreaseDegree(uDeg: 4, vDeg: 4)
+  ```
+
+---
+
+### `bezierUReverse()`
+
+Reverses the U parameter direction of a Bezier surface in place.
+
+```swift
+@discardableResult
+public func bezierUReverse() -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::UReverse`.
+- **Example:**
+  ```swift
+  surface.bezierUReverse()
+  ```
+
+---
+
+### `bezierVReverse()`
+
+Reverses the V parameter direction of a Bezier surface in place.
+
+```swift
+@discardableResult
+public func bezierVReverse() -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::VReverse`.
+- **Example:**
+  ```swift
+  surface.bezierVReverse()
+  ```
+
+---
+
+## v0.127.0: Bezier Surface Completions
+
+---
+
+### `bezierSetPoleColWeights(vIndex:poles:weights:)`
+
+Sets a full column of poles with associated weights on a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierSetPoleColWeights(vIndex: Int, poles: [SIMD3<Double>], weights: [Double]) -> Bool
+```
+
+- **Parameters:** `vIndex` — 1-based V (column) index; `poles` — new pole positions (`count == bezierNbUPoles`); `weights` — corresponding weights (same count).
+- **Returns:** `true` on success. Returns `false` if `poles.count != weights.count`.
+- **OCCT:** `Geom_BezierSurface::SetPoleCol(vIndex, poles, weights)`.
+- **Example:**
+  ```swift
+  let poles = Array(repeating: SIMD3<Double>(0, 0, 1), count: surface.bezierNbUPoles)
+  let weights = Array(repeating: 1.0, count: surface.bezierNbUPoles)
+  surface.bezierSetPoleColWeights(vIndex: 1, poles: poles, weights: weights)
+  ```
+
+---
+
+### `bezierSetPoleRowWeights(uIndex:poles:weights:)`
+
+Sets a full row of poles with associated weights on a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierSetPoleRowWeights(uIndex: Int, poles: [SIMD3<Double>], weights: [Double]) -> Bool
+```
+
+- **Parameters:** `uIndex` — 1-based U (row) index; `poles` — new pole positions (`count == bezierNbVPoles`); `weights` — corresponding weights.
+- **Returns:** `true` on success. Returns `false` if counts mismatch.
+- **OCCT:** `Geom_BezierSurface::SetPoleRow(uIndex, poles, weights)`.
+- **Example:**
+  ```swift
+  let poles = Array(repeating: SIMD3<Double>(0, 1, 0), count: surface.bezierNbVPoles)
+  let weights = Array(repeating: 1.0, count: surface.bezierNbVPoles)
+  surface.bezierSetPoleRowWeights(uIndex: 1, poles: poles, weights: weights)
+  ```
+
+---
+
+## v0.129.0: Bezier Surface Completions
+
+---
+
+### `bezierInsertPoleColBefore(_:poles:)`
+
+Inserts a new column of poles before the given column index in a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierInsertPoleColBefore(_ colIndex: Int, poles: [SIMD3<Double>]) -> Bool
+```
+
+- **Parameters:** `colIndex` — 1-based column index before which to insert; `poles` — new pole column (`poles.count` must equal `bezierNbUPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::InsertPoleColBefore`.
+- **Example:**
+  ```swift
+  let newCol = Array(repeating: SIMD3<Double>.zero, count: surface.bezierNbUPoles)
+  surface.bezierInsertPoleColBefore(1, poles: newCol)
+  ```
+
+---
+
+### `bezierInsertPoleRowBefore(_:poles:)`
+
+Inserts a new row of poles before the given row index in a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierInsertPoleRowBefore(_ rowIndex: Int, poles: [SIMD3<Double>]) -> Bool
+```
+
+- **Parameters:** `rowIndex` — 1-based row index before which to insert; `poles.count` must equal `bezierNbVPoles`.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::InsertPoleRowBefore`.
+- **Example:**
+  ```swift
+  let newRow = Array(repeating: SIMD3<Double>.zero, count: surface.bezierNbVPoles)
+  surface.bezierInsertPoleRowBefore(1, poles: newRow)
+  ```
+
+---
+
+### `bezierSetPoleCol(vIndex:poles:)`
+
+Sets a column of poles (without changing weights) on a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierSetPoleCol(vIndex: Int, poles: [SIMD3<Double>]) -> Bool
+```
+
+- **Parameters:** `vIndex` — 1-based V (column) index; `poles` — new positions (count must equal `bezierNbUPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::SetPoleCol(vIndex, poles)`.
+- **Example:**
+  ```swift
+  let col = Array(repeating: SIMD3<Double>(0, 0, 2), count: surface.bezierNbUPoles)
+  surface.bezierSetPoleCol(vIndex: 2, poles: col)
+  ```
+
+---
+
+### `bezierSetPoleRow(uIndex:poles:)`
+
+Sets a row of poles (without changing weights) on a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierSetPoleRow(uIndex: Int, poles: [SIMD3<Double>]) -> Bool
+```
+
+- **Parameters:** `uIndex` — 1-based U (row) index; `poles` — new positions (count must equal `bezierNbVPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::SetPoleRow(uIndex, poles)`.
+- **Example:**
+  ```swift
+  let row = Array(repeating: SIMD3<Double>(0, 0, 2), count: surface.bezierNbVPoles)
+  surface.bezierSetPoleRow(uIndex: 1, poles: row)
+  ```
+
+---
+
+### `bezierSetWeightCol(vIndex:weights:)`
+
+Sets a column of weights on a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierSetWeightCol(vIndex: Int, weights: [Double]) -> Bool
+```
+
+- **Parameters:** `vIndex` — 1-based V (column) index; `weights` — new weight values (count must equal `bezierNbUPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::SetWeightCol`.
+- **Example:**
+  ```swift
+  let w = Array(repeating: 2.0, count: surface.bezierNbUPoles)
+  surface.bezierSetWeightCol(vIndex: 1, weights: w)
+  ```
+
+---
+
+### `bezierSetWeightRow(uIndex:weights:)`
+
+Sets a row of weights on a Bezier surface.
+
+```swift
+@discardableResult
+public func bezierSetWeightRow(uIndex: Int, weights: [Double]) -> Bool
+```
+
+- **Parameters:** `uIndex` — 1-based U (row) index; `weights` — new weight values (count must equal `bezierNbVPoles`).
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_BezierSurface::SetWeightRow`.
+- **Example:**
+  ```swift
+  let w = Array(repeating: 0.5, count: surface.bezierNbVPoles)
+  surface.bezierSetWeightRow(uIndex: 2, weights: w)
+  ```
+
+---
+
+## Surface to Bezier Patches (v0.36.0)
+
+---
+
+### `toBezierPatches()`
+
+Decomposes this surface into an unordered flat array of Bezier patches.
+
+```swift
+public func toBezierPatches() -> [Surface]
+```
+
+Converts to BSpline first if necessary (via `GeomConvert::SurfaceToBSplineSurface`), then decomposes into a grid of Bezier patches. The grid is iterated U-major (U varies in the outer loop, V in the inner loop). Up to 256 patches are returned.
+
+- **Returns:** Array of `Surface` objects (each wrapping a `Geom_BezierSurface`), or `[]` if conversion fails.
+- **OCCT:** `GeomConvert::SurfaceToBSplineSurface` + `GeomConvert_BSplineSurfaceToBezierSurface::Patch`.
+- **Note:** Grid dimensions are not returned. Use `toBezierPatchGrid()` instead when you need `(uCount, vCount)`.
+- **Example:**
+  ```swift
+  let patches = surface.toBezierPatches()
+  for patch in patches {
+      let poles = patch.bezierPoles
+  }
+  ```
+
+---
+
+## BSpline Bezier Patch Grid (v0.40.0)
+
+---
+
+### `BezierPatchGrid`
+
+Result type returned by `toBezierPatchGrid()`, describing the decomposed patch layout.
+
+```swift
+public struct BezierPatchGrid {
+    public let uCount: Int      // Number of patches in U direction
+    public let vCount: Int      // Number of patches in V direction
+    public let patches: [Surface] // Patches in row-major order (U varies faster)
+}
+```
+
+Access individual patches with `patches[u * grid.vCount + v]` (0-based).
+
+---
+
+### `toBezierPatchGrid()`
+
+Decomposes this BSpline surface into a structured grid of Bezier patches.
+
+```swift
+public func toBezierPatchGrid() -> BezierPatchGrid?
+```
+
+Returns the patches together with their U/V grid dimensions. Only works on `Geom_BSplineSurface` instances; returns `nil` for other surface types or on failure. Up to 256 patches are supported.
+
+- **Returns:** `BezierPatchGrid` with `uCount`, `vCount`, and all patches in row-major order, or `nil` if the surface is not BSpline or decomposition fails.
+- **OCCT:** `GeomConvert_BSplineSurfaceToBezierSurface::NbUPatches`, `NbVPatches`, `Patch`.
+- **Example:**
+  ```swift
+  if let grid = surface.toBezierPatchGrid() {
+      print("Grid:", grid.uCount, "×", grid.vCount)
+      for u in 0..<grid.uCount {
+          for v in 0..<grid.vCount {
+              let patch = grid.patches[u * grid.vCount + v]
+              print("  patch poles:", patch.bezierNbUPoles, "×", patch.bezierNbVPoles)
+          }
+      }
+  }
+  ```

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -1,0 +1,1275 @@
+---
+title: Surface
+parent: API Reference
+---
+
+# Surface
+
+A `Surface` is a parametric 2D manifold in 3D space — the Swift analog of OCCT's `Geom_Surface` class hierarchy. It wraps analytic surfaces (plane, cylinder, cone, sphere, torus), swept surfaces (extrusion, revolution), and freeform surfaces (Bezier, BSpline) polymorphically behind a single opaque handle. Obtain a surface via one of the static factory methods, by extracting it from a `Face` (`face.surface`), or by converting a `Shape` to its underlying geometry.
+
+> **Note:** `Surface` is documented across several pages — see also **Surface — Analytic Types**, **Surface — BSpline & Bezier**, **Surface — Analysis**, and **Surface — Advanced Construction**.
+
+## Topics
+
+- [Properties](#properties) · [Evaluation](#evaluation) · [Analytic Surfaces](#analytic-surfaces) · [Swept Surfaces](#swept-surfaces) · [Freeform Surfaces](#freeform-surfaces) · [Operations](#operations) · [Conversion](#conversion) · [Iso Curves](#iso-curves) · [Pipe Surfaces](#pipe-surfaces) · [Draw Methods](#draw-methods) · [Bounding Box](#bounding-box) · [Surface Transform (v0.128.0)](#surface-transform-v01280) · [GeomEval Surface Factories (v0.130.0)](#geomeval-surface-factories-v01300) · [GeomEval TBezier / AHTBezier Surfaces (v0.131.0)](#geomeval-tbezier--ahtbezier-surfaces-v01310) · [v0.115.0: Surface from point grid, normal, curvatures](#v01150-surface-from-point-grid-normal-curvatures)
+
+---
+
+## Properties
+
+### `SurfaceType`
+
+Classification enum matching OCCT's `GeomAbs_SurfaceType`.
+
+```swift
+public enum SurfaceType: Int32, Sendable {
+    case plane = 0, cylinder = 1, cone = 2, sphere = 3, torus = 4
+    case bezierSurface = 5, bsplineSurface = 6
+    case surfaceOfRevolution = 7, surfaceOfExtrusion = 8
+    case offsetSurface = 9, other = 10
+}
+```
+
+Use `surfaceKind` to query which case applies to a given `Surface` instance.
+
+---
+
+### `surfaceKind`
+
+The specific geometric kind of this surface.
+
+```swift
+public var surfaceKind: SurfaceType { get }
+```
+
+- **Returns:** The `SurfaceType` case that classifies this surface.
+- **OCCT:** `GeomAdaptor_Surface::GetType` (via `OCCTSurfaceGetType`).
+- **Example:**
+  ```swift
+  let s = Surface.sphere(center: .zero, radius: 5)!
+  print(s.surfaceKind)  // .sphere
+  ```
+
+---
+
+### `Continuity`
+
+Continuity class enum derived from `GeomAbs_Shape`.
+
+```swift
+public enum Continuity: Int32, Sendable, CaseIterable {
+    case c0 = 0, g1 = 1, c1 = 2, g2 = 3, c2 = 4, c3 = 5, cN = 6
+}
+```
+
+---
+
+### `continuityClass`
+
+The overall continuity of the surface.
+
+```swift
+public var continuityClass: Continuity { get }
+```
+
+- **Returns:** A `Continuity` value describing positional through CN continuity.
+- **OCCT:** `Geom_Surface::Continuity`.
+- **Example:**
+  ```swift
+  let bsp = Surface.bspline(poles: ..., ...)!
+  print(bsp.continuityClass)  // typically .c2
+  ```
+
+---
+
+### `isPlane`, `isCylinder`, `isCone`, `isSphere`, `isTorus`
+
+Boolean type-test properties.
+
+```swift
+public var isPlane:    Bool { get }
+public var isCylinder: Bool { get }
+public var isCone:     Bool { get }
+public var isSphere:   Bool { get }
+public var isTorus:    Bool { get }
+```
+
+Convenience wrappers around `surfaceKind`. All query `surfaceKind == .<type>`.
+
+- **Example:**
+  ```swift
+  if surface.isSphere { /* analytic sphere geometry available */ }
+  ```
+
+---
+
+### `isBezier`, `isBSpline`, `isSurfaceOfRevolution`, `isSurfaceOfExtrusion`, `isOffsetSurface`
+
+Additional boolean type-test properties.
+
+```swift
+public var isBezier:              Bool { get }
+public var isBSpline:             Bool { get }
+public var isSurfaceOfRevolution: Bool { get }
+public var isSurfaceOfExtrusion:  Bool { get }
+public var isOffsetSurface:       Bool { get }
+```
+
+---
+
+### `domain`
+
+The parameter domain (uMin, uMax, vMin, vMax).
+
+```swift
+public var domain: (uMin: Double, uMax: Double, vMin: Double, vMax: Double) { get }
+```
+
+For infinite analytic surfaces (planes, full cylinders) the returned bounds may be very large values. Always clamp before iterating.
+
+- **Returns:** Tuple of four doubles describing the full UV parameter range.
+- **OCCT:** `Geom_Surface::Bounds`.
+- **Example:**
+  ```swift
+  let d = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!.domain
+  // d.uMin, d.uMax will be large (±1e100)
+  ```
+
+---
+
+### `isUClosed`
+
+Whether the surface is closed in the U direction.
+
+```swift
+public var isUClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_Surface::IsUClosed`.
+
+---
+
+### `isVClosed`
+
+Whether the surface is closed in the V direction.
+
+```swift
+public var isVClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_Surface::IsVClosed`.
+
+---
+
+### `isUPeriodic`
+
+Whether the surface is periodic in the U direction.
+
+```swift
+public var isUPeriodic: Bool { get }
+```
+
+- **OCCT:** `Geom_Surface::IsUPeriodic`.
+
+---
+
+### `isVPeriodic`
+
+Whether the surface is periodic in the V direction.
+
+```swift
+public var isVPeriodic: Bool { get }
+```
+
+- **OCCT:** `Geom_Surface::IsVPeriodic`.
+
+---
+
+### `uPeriod`
+
+The period in the U direction, if periodic.
+
+```swift
+public var uPeriod: Double? { get }
+```
+
+- **Returns:** Period value, or `nil` if `isUPeriodic` is `false`.
+- **OCCT:** `Geom_Surface::UPeriod`.
+
+---
+
+### `vPeriod`
+
+The period in the V direction, if periodic.
+
+```swift
+public var vPeriod: Double? { get }
+```
+
+- **Returns:** Period value, or `nil` if `isVPeriodic` is `false`.
+- **OCCT:** `Geom_Surface::VPeriod`.
+
+---
+
+## Evaluation
+
+### `point(atU:v:)`
+
+Evaluate the surface point at (u, v).
+
+```swift
+public func point(atU u: Double, v: Double) -> SIMD3<Double>
+```
+
+- **Parameters:** `u` — U parameter; `v` — V parameter. Both must lie within `domain`.
+- **Returns:** 3D point on the surface.
+- **OCCT:** `Geom_Surface::D0`.
+- **Example:**
+  ```swift
+  let s = Surface.sphere(center: .zero, radius: 5)!
+  let pt = s.point(atU: 0, v: 0)  // (5, 0, 0)
+  ```
+
+---
+
+### `d1(atU:v:)`
+
+First-order derivatives at (u, v).
+
+```swift
+public func d1(atU u: Double, v: Double) -> (point: SIMD3<Double>, du: SIMD3<Double>, dv: SIMD3<Double>)
+```
+
+Returns the point together with the first partial derivatives in U and V in a single call.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Tuple of position, dS/dU, and dS/dV.
+- **OCCT:** `Geom_Surface::D1`.
+- **Example:**
+  ```swift
+  let (pt, du, dv) = surface.d1(atU: 0.5, v: 0.5)
+  let normal = simd_cross(du, dv)
+  ```
+
+---
+
+### `d2(atU:v:)`
+
+Second-order derivatives at (u, v).
+
+```swift
+public func d2(atU u: Double, v: Double) -> (
+    point: SIMD3<Double>,
+    d1u: SIMD3<Double>, d1v: SIMD3<Double>,
+    d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>
+)
+```
+
+Returns position, first partials, and second partials (including the mixed partial d²S/dUdV) in a single call.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Tuple of point, ∂S/∂U, ∂S/∂V, ∂²S/∂U², ∂²S/∂V², ∂²S/∂U∂V.
+- **OCCT:** `Geom_Surface::D2`.
+- **Example:**
+  ```swift
+  let (pt, d1u, d1v, d2u, d2v, d2uv) = surface.d2(atU: 0.3, v: 0.7)
+  ```
+
+---
+
+### `normal(atU:v:)`
+
+Surface normal at (u, v).
+
+```swift
+public func normal(atU u: Double, v: Double) -> SIMD3<Double>?
+```
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Unit normal vector, or `nil` at singular points where the tangent plane is degenerate.
+- **OCCT:** `GeomLProp_SLProps::Normal`.
+- **Example:**
+  ```swift
+  if let n = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!.normal(atU: 0, v: 0) {
+      // n ≈ SIMD3(0, 0, 1)
+  }
+  ```
+
+---
+
+## Analytic Surfaces
+
+### `Surface.plane(origin:normal:)`
+
+Creates an infinite plane from a point and normal direction.
+
+```swift
+public static func plane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Surface?
+```
+
+The surface is infinite in both U and V. Trim it with `trimmed(u1:u2:v1:v2:)` or convert to a face with `toFace(uRange:vRange:)` before use in B-Rep operations.
+
+- **Parameters:** `origin` — a point on the plane; `normal` — outward normal direction.
+- **Returns:** `Geom_Plane` surface, or `nil` if `normal` is zero-length.
+- **OCCT:** `Geom_Plane(gp_Pnt, gp_Dir)`.
+- **Example:**
+  ```swift
+  let floor = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))
+  ```
+
+---
+
+### `Surface.cylinder(origin:axis:radius:)`
+
+Creates a cylindrical surface.
+
+```swift
+public static func cylinder(origin: SIMD3<Double>, axis: SIMD3<Double>,
+                             radius: Double) -> Surface?
+```
+
+The cylinder is infinite along `axis`. U is the angular parameter (0 to 2π), V is the axial parameter.
+
+- **Parameters:** `origin` — base point on the axis; `axis` — axis direction; `radius` — cylinder radius (must be > 0).
+- **Returns:** `Geom_CylindricalSurface`, or `nil` on failure.
+- **OCCT:** `Geom_CylindricalSurface(gp_Ax3, radius)`.
+- **Example:**
+  ```swift
+  let cyl = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5)
+  ```
+
+---
+
+### `Surface.cone(origin:axis:radius:semiAngle:)`
+
+Creates a conical surface.
+
+```swift
+public static func cone(origin: SIMD3<Double>, axis: SIMD3<Double>,
+                         radius: Double, semiAngle: Double) -> Surface?
+```
+
+The cone apex is located along `axis` from `origin`. `semiAngle` is in radians and must be in (0, π/2).
+
+- **Parameters:** `origin` — axis base point; `axis` — cone axis direction; `radius` — base radius; `semiAngle` — half-angle in radians.
+- **Returns:** `Geom_ConicalSurface`, or `nil` on failure.
+- **OCCT:** `Geom_ConicalSurface(gp_Ax3, semiAngle, radius)`.
+- **Example:**
+  ```swift
+  let cone = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1),
+                           radius: 10, semiAngle: .pi / 6)
+  ```
+
+---
+
+### `Surface.sphere(center:radius:)`
+
+Creates a spherical surface.
+
+```swift
+public static func sphere(center: SIMD3<Double>, radius: Double) -> Surface?
+```
+
+U is the longitude parameter (0 to 2π), V is the latitude parameter (−π/2 to π/2). The surface is closed in U and has singular poles at V = ±π/2.
+
+- **Parameters:** `center` — sphere centre; `radius` — sphere radius (must be > 0).
+- **Returns:** `Geom_SphericalSurface`, or `nil` on failure.
+- **OCCT:** `Geom_SphericalSurface(gp_Ax3, radius)`.
+- **Example:**
+  ```swift
+  let sphere = Surface.sphere(center: .zero, radius: 10)
+  ```
+
+---
+
+### `Surface.torus(origin:axis:majorRadius:minorRadius:)`
+
+Creates a toroidal surface.
+
+```swift
+public static func torus(origin: SIMD3<Double>, axis: SIMD3<Double>,
+                          majorRadius: Double, minorRadius: Double) -> Surface?
+```
+
+Both U and V are angular parameters (0 to 2π). The surface is closed and periodic in both directions.
+
+- **Parameters:** `origin` — torus centre; `axis` — torus symmetry axis; `majorRadius` — distance from centre to tube centre; `minorRadius` — tube radius. Both radii must be > 0 and `minorRadius < majorRadius`.
+- **Returns:** `Geom_ToroidalSurface`, or `nil` on failure.
+- **OCCT:** `Geom_ToroidalSurface(gp_Ax3, majorRadius, minorRadius)`.
+- **Example:**
+  ```swift
+  let torus = Surface.torus(origin: .zero, axis: SIMD3(0, 0, 1),
+                              majorRadius: 20, minorRadius: 5)
+  ```
+
+---
+
+## Swept Surfaces
+
+### `Surface.extrusion(profile:direction:)`
+
+Creates a surface by extruding a curve along a direction.
+
+```swift
+public static func extrusion(profile: Curve3D, direction: SIMD3<Double>) -> Surface?
+```
+
+Produces a `Geom_SurfaceOfLinearExtrusion`. The U parameter follows the profile curve; the V parameter measures distance along the extrusion direction. The surface is infinite in V.
+
+- **Parameters:** `profile` — the generator curve; `direction` — extrusion direction vector.
+- **Returns:** Extrusion surface, or `nil` if `direction` is zero or construction fails.
+- **OCCT:** `Geom_SurfaceOfLinearExtrusion(profile, direction)`.
+- **Example:**
+  ```swift
+  if let line = Curve3D.line(from: .zero, to: SIMD3(10, 0, 0)),
+     let surf = Surface.extrusion(profile: line, direction: SIMD3(0, 0, 1)) {
+      let trimmed = surf.trimmed(u1: 0, u2: 1, v1: 0, v2: 20)
+  }
+  ```
+
+---
+
+### `Surface.revolution(meridian:axisOrigin:axisDirection:)`
+
+Creates a surface of revolution by revolving a curve around an axis.
+
+```swift
+public static func revolution(meridian: Curve3D,
+                               axisOrigin: SIMD3<Double>,
+                               axisDirection: SIMD3<Double>) -> Surface?
+```
+
+The U parameter is the angle of revolution (0 to 2π); V follows the meridian curve parameter. Pass a `trimmed(u1:u2:v1:v2:)` result to limit the angular sweep.
+
+- **Parameters:** `meridian` — the profile curve to revolve; `axisOrigin` — origin of the revolution axis; `axisDirection` — direction of the revolution axis.
+- **Returns:** `Geom_SurfaceOfRevolution`, or `nil` on failure.
+- **OCCT:** `Geom_SurfaceOfRevolution(meridian, gp_Ax1)`.
+- **Example:**
+  ```swift
+  if let profile = Curve3D.line(from: SIMD3(5, 0, 0), to: SIMD3(5, 0, 10)),
+     let surf = Surface.revolution(meridian: profile,
+                                    axisOrigin: .zero,
+                                    axisDirection: SIMD3(0, 0, 1)) {
+      // surf is a cylinder of radius 5 and infinite height
+  }
+  ```
+
+---
+
+## Freeform Surfaces
+
+### `Surface.bezier(poles:weights:)`
+
+Creates a Bezier surface from a 2D grid of control points.
+
+```swift
+public static func bezier(poles: [[SIMD3<Double>]],
+                           weights: [[Double]]? = nil) -> Surface?
+```
+
+`poles` is a 2D array indexed `[uRow][vCol]`, both dimensions must be ≥ 2. The surface degree in U is `poles.count − 1` and in V is `poles[0].count − 1`. When `weights` is `nil` the surface is non-rational.
+
+- **Parameters:**
+  - `poles` — 2D grid of control points (minimum 2×2).
+  - `weights` — optional 2D grid of per-pole weights (same dimensions as `poles`); `nil` = uniform 1.0.
+- **Returns:** `Geom_BezierSurface`, or `nil` if dimensions are invalid or construction fails.
+- **OCCT:** `Geom_BezierSurface(TColgp_Array2OfPnt)` or the weighted overload.
+- **Example:**
+  ```swift
+  let poles: [[SIMD3<Double>]] = [
+      [SIMD3(0, 0, 0), SIMD3(0, 5, 1)],
+      [SIMD3(5, 0, 1), SIMD3(5, 5, 0)]
+  ]
+  if let s = Surface.bezier(poles: poles) {
+      let pt = s.point(atU: 0.5, v: 0.5)
+  }
+  ```
+
+---
+
+### `Surface.bspline(poles:weights:knotsU:multiplicitiesU:knotsV:multiplicitiesV:degreeU:degreeV:)`
+
+Creates a BSpline surface with full explicit control.
+
+```swift
+public static func bspline(poles: [[SIMD3<Double>]],
+                            weights: [[Double]]? = nil,
+                            knotsU: [Double], multiplicitiesU: [Int32],
+                            knotsV: [Double], multiplicitiesV: [Int32],
+                            degreeU: Int, degreeV: Int) -> Surface?
+```
+
+`poles` is indexed `[uRow][vCol]`. Knot vectors and multiplicities must satisfy standard BSpline constraints (sum of multiplicities = number of poles + degree + 1 in each direction). When `weights` is `nil` the surface is non-rational.
+
+- **Parameters:**
+  - `poles` — 2D control point grid (minimum 2×2).
+  - `weights` — optional 2D weight grid; `nil` = non-rational.
+  - `knotsU`, `knotsV` — distinct knot values in U and V.
+  - `multiplicitiesU`, `multiplicitiesV` — per-knot multiplicities.
+  - `degreeU`, `degreeV` — polynomial degrees in U and V (≥ 1).
+- **Returns:** `Geom_BSplineSurface`, or `nil` if parameters are invalid.
+- **OCCT:** `Geom_BSplineSurface(poles, knotsU, knotsV, multsU, multsV, degU, degV)`.
+- **Example:**
+  ```swift
+  // Bilinear (degree 1×1) BSpline — a flat quad patch
+  let poles: [[SIMD3<Double>]] = [
+      [SIMD3(0, 0, 0), SIMD3(0, 10, 0)],
+      [SIMD3(10, 0, 0), SIMD3(10, 10, 2)]
+  ]
+  let s = Surface.bspline(
+      poles: poles,
+      knotsU: [0, 1], multiplicitiesU: [2, 2],
+      knotsV: [0, 1], multiplicitiesV: [2, 2],
+      degreeU: 1, degreeV: 1
+  )
+  ```
+
+---
+
+## Operations
+
+### `trimmed(u1:u2:v1:v2:)`
+
+Creates a rectangular trim of this surface.
+
+```swift
+public func trimmed(u1: Double, u2: Double, v1: Double, v2: Double) -> Surface?
+```
+
+The trim bounds must be within the surface `domain`. Use this to bound infinite analytic surfaces (planes, cylinders) before face creation.
+
+- **Parameters:** `u1`, `u2` — U parameter bounds; `v1`, `v2` — V parameter bounds.
+- **Returns:** `Geom_RectangularTrimmedSurface`, or `nil` on failure.
+- **OCCT:** `Geom_RectangularTrimmedSurface(surface, u1, u2, v1, v2)`.
+- **Example:**
+  ```swift
+  let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+  let patch = plane.trimmed(u1: 0, u2: 10, v1: 0, v2: 10)
+  ```
+
+---
+
+### `offset(distance:)`
+
+Creates an offset surface at a given distance from this surface.
+
+```swift
+public func offset(distance: Double) -> Surface?
+```
+
+Positive distance offsets in the direction of the surface normal. Complex surfaces may produce self-intersections; use `ShapeHealing` tools to fix them before B-Rep operations.
+
+- **Parameters:** `distance` — offset distance in model units.
+- **Returns:** `Geom_OffsetSurface`, or `nil` on failure.
+- **OCCT:** `Geom_OffsetSurface(surface, distance)`.
+- **Example:**
+  ```swift
+  let sphere = Surface.sphere(center: .zero, radius: 10)!
+  let outer = sphere.offset(distance: 2)  // radius-12 sphere
+  ```
+
+---
+
+### `translated(by:)`
+
+Returns a translated copy of this surface.
+
+```swift
+public func translated(by delta: SIMD3<Double>) -> Surface?
+```
+
+- **Parameters:** `delta` — translation vector.
+- **Returns:** New surface shifted by `delta`, or `nil` on failure.
+- **OCCT:** `Geom_Surface::Translated(gp_Vec)`.
+- **Example:**
+  ```swift
+  let moved = sphere.translated(by: SIMD3(0, 0, 5))
+  ```
+
+---
+
+### `rotated(axisOrigin:axisDirection:angle:)`
+
+Returns a rotated copy of this surface.
+
+```swift
+public func rotated(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
+                     angle: Double) -> Surface?
+```
+
+- **Parameters:** `axisOrigin` — a point on the rotation axis; `axisDirection` — axis direction; `angle` — angle in radians.
+- **Returns:** Rotated surface copy, or `nil` on failure.
+- **OCCT:** `Geom_Surface::Rotated(gp_Ax1, angle)`.
+- **Example:**
+  ```swift
+  let tilted = cylinder.rotated(axisOrigin: .zero, axisDirection: SIMD3(0, 1, 0), angle: .pi / 4)
+  ```
+
+---
+
+### `scaled(center:factor:)`
+
+Returns a scaled copy of this surface.
+
+```swift
+public func scaled(center: SIMD3<Double>, factor: Double) -> Surface?
+```
+
+- **Parameters:** `center` — scaling centre point; `factor` — scale factor (negative mirrors through centre).
+- **Returns:** Scaled surface copy, or `nil` on failure.
+- **OCCT:** `Geom_Surface::Scaled(gp_Pnt, factor)`.
+- **Example:**
+  ```swift
+  let doubled = sphere.scaled(center: .zero, factor: 2)
+  ```
+
+---
+
+### `mirrored(planeOrigin:planeNormal:)`
+
+Returns a mirrored copy of this surface across a plane.
+
+```swift
+public func mirrored(planeOrigin: SIMD3<Double>, planeNormal: SIMD3<Double>) -> Surface?
+```
+
+- **Parameters:** `planeOrigin` — a point on the mirror plane; `planeNormal` — plane normal direction.
+- **Returns:** Mirrored surface copy, or `nil` on failure.
+- **OCCT:** `Geom_Surface::Mirrored(gp_Ax2)`.
+- **Example:**
+  ```swift
+  let reflected = cone.mirrored(planeOrigin: .zero, planeNormal: SIMD3(1, 0, 0))
+  ```
+
+---
+
+## Conversion
+
+### `toBSpline()`
+
+Converts this surface to a BSpline representation.
+
+```swift
+public func toBSpline() -> Surface?
+```
+
+Uses OCCT's exact conversion for analytic surfaces. Infinite surfaces must be trimmed first. The result is a `Geom_BSplineSurface`.
+
+- **Returns:** BSpline surface, or `nil` if conversion fails (e.g. surface is already a non-convertible type).
+- **OCCT:** `GeomConvert::SurfaceToBSplineSurface`.
+- **Note:** Infinite surfaces (planes, full cylinders) will cause conversion to fail — trim the domain first with `trimmed(u1:u2:v1:v2:)`.
+- **Example:**
+  ```swift
+  let sphere = Surface.sphere(center: .zero, radius: 10)!
+  let trimmed = sphere.trimmed(u1: 0, u2: .pi * 2, v1: -.pi / 2, v2: .pi / 2)!
+  let bsp = trimmed.toBSpline()
+  ```
+
+---
+
+### `approximated(tolerance:continuity:maxSegments:maxDegree:)`
+
+Approximates this surface as a BSpline surface within a tolerance.
+
+```swift
+public func approximated(tolerance: Double = 0.01, continuity: Int = 2,
+                          maxSegments: Int = 100, maxDegree: Int = 10) -> Surface?
+```
+
+Useful when exact `toBSpline()` conversion is unavailable (e.g. offset or composite surfaces).
+
+- **Parameters:**
+  - `tolerance` — maximum approximation deviation.
+  - `continuity` — desired continuity order (0=C0, 1=C1, 2=C2).
+  - `maxSegments` — maximum number of BSpline segments.
+  - `maxDegree` — maximum polynomial degree.
+- **Returns:** Approximated BSpline surface, or `nil` on failure.
+- **OCCT:** `GeomConvert_ApproxSurface`.
+- **Example:**
+  ```swift
+  let offset = sphere.offset(distance: 1)!
+  let bsp = offset.approximated(tolerance: 0.001)
+  ```
+
+---
+
+## Iso Curves
+
+### `uIso(at:)`
+
+Extracts a U-iso curve (constant U, varying V).
+
+```swift
+public func uIso(at u: Double) -> Curve3D?
+```
+
+- **Parameters:** `u` — the fixed U parameter value.
+- **Returns:** A `Curve3D` at the given U value, or `nil` on failure.
+- **OCCT:** `Geom_Surface::UIso(u)`.
+- **Example:**
+  ```swift
+  // Extract the meridian at U=0 on a sphere
+  let meridian = Surface.sphere(center: .zero, radius: 10)!.uIso(at: 0)
+  ```
+
+---
+
+### `vIso(at:)`
+
+Extracts a V-iso curve (constant V, varying U).
+
+```swift
+public func vIso(at v: Double) -> Curve3D?
+```
+
+- **Parameters:** `v` — the fixed V parameter value.
+- **Returns:** A `Curve3D` at the given V value, or `nil` on failure.
+- **OCCT:** `Geom_Surface::VIso(v)`.
+- **Example:**
+  ```swift
+  // Extract the equatorial circle of a sphere
+  let equator = Surface.sphere(center: .zero, radius: 10)!.vIso(at: 0)
+  ```
+
+---
+
+## Pipe Surfaces
+
+### `Surface.pipe(path:radius:)`
+
+Creates a pipe surface by sweeping a circle along a path.
+
+```swift
+public static func pipe(path: Curve3D, radius: Double) -> Surface?
+```
+
+The cross-section is a circle of the given radius. Orientation is determined by the Frenet frame of the path.
+
+- **Parameters:** `path` — sweep path curve; `radius` — pipe radius (must be > 0).
+- **Returns:** Pipe surface, or `nil` if construction fails (e.g. path is too tightly curved for the radius).
+- **OCCT:** `GeomFill_Pipe(path, radius)::Perform`.
+- **Example:**
+  ```swift
+  if let helix = Curve3D.bspline(throughPoints: [SIMD3(0,0,0), SIMD3(5,5,5)]),
+     let pipe = Surface.pipe(path: helix, radius: 2) {
+      let face = pipe.toFace()
+  }
+  ```
+
+---
+
+### `Surface.pipe(path:section:)`
+
+Creates a pipe surface by sweeping a section curve along a path.
+
+```swift
+public static func pipe(path: Curve3D, section: Curve3D) -> Surface?
+```
+
+The section curve defines the cross-sectional shape at each point along `path`.
+
+- **Parameters:** `path` — sweep path curve; `section` — cross-section curve.
+- **Returns:** Pipe surface, or `nil` on failure.
+- **OCCT:** `GeomFill_Pipe(path, section)::Perform`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arcOfCircle(center: .zero, radius: 3,
+                                    startAngle: 0, endAngle: .pi),
+     let line = Curve3D.line(from: .zero, to: SIMD3(0, 0, 10)),
+     let pipe = Surface.pipe(path: line, section: arc) {
+      let trimmed = pipe.trimmed(u1: 0, u2: 1, v1: 0, v2: 1)
+  }
+  ```
+
+---
+
+## Draw Methods
+
+### `drawGrid(uLineCount:vLineCount:pointsPerLine:)`
+
+Draws iso-parameter grid lines for Metal visualisation.
+
+```swift
+public func drawGrid(uLineCount: Int = 10, vLineCount: Int = 10,
+                     pointsPerLine: Int = 50) -> [[SIMD3<Double>]]
+```
+
+Samples `uLineCount` U-iso lines and `vLineCount` V-iso lines, each discretised to `pointsPerLine` 3D points. Infinite surfaces are clamped to ±100 before sampling.
+
+- **Parameters:** `uLineCount` — number of U iso-lines; `vLineCount` — number of V iso-lines; `pointsPerLine` — points per iso-line.
+- **Returns:** Array of polylines (one per iso-line), empty if the surface is null.
+- **OCCT:** `Geom_Surface::Bounds` + `Geom_Surface::D0` via `OCCTSurfaceDrawGrid`.
+- **Example:**
+  ```swift
+  let gridLines = surface.drawGrid(uLineCount: 10, vLineCount: 10, pointsPerLine: 50)
+  // Pass to Metal vertex buffer for wireframe preview
+  ```
+
+---
+
+### `drawMesh(uCount:vCount:)`
+
+Samples a uniform mesh grid of points for Metal visualisation.
+
+```swift
+public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> [[SIMD3<Double>]]
+```
+
+Returns a 2D array indexed `[uIndex][vIndex]` of evaluated surface points on a uniform UV grid.
+
+- **Parameters:** `uCount` — number of U sample points; `vCount` — number of V sample points.
+- **Returns:** 2D array of 3D points, or `[]` if sampling fails.
+- **OCCT:** `Geom_Surface::D0` sampled on a uniform UV grid.
+- **Example:**
+  ```swift
+  let mesh = surface.drawMesh(uCount: 30, vCount: 30)
+  // mesh[i][j] is the surface point at the ith U and jth V sample
+  ```
+
+---
+
+## Bounding Box
+
+### `boundingBox`
+
+The axis-aligned bounding box of this surface.
+
+```swift
+public var boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)? { get }
+```
+
+Returns `nil` for infinite surfaces (planes, full cylinders) because `BndLib_AddSurface` cannot produce a finite box. Trim the surface first.
+
+- **Returns:** Tuple of min and max AABB corners, or `nil` for infinite or degenerate surfaces.
+- **OCCT:** `GeomAdaptor_Surface` + `BndLib_AddSurface::Add`.
+- **Example:**
+  ```swift
+  let sphere = Surface.sphere(center: .zero, radius: 5)!
+  if let bb = sphere.boundingBox {
+      // bb.min ≈ SIMD3(-5, -5, -5), bb.max ≈ SIMD3(5, 5, 5)
+  }
+  ```
+
+---
+
+## Surface Transform (v0.128.0)
+
+In-place transform variants that modify the surface geometry directly rather than returning a copy. All return `@discardableResult Bool`.
+
+---
+
+### `translate(dx:dy:dz:)`
+
+Translates the surface in place.
+
+```swift
+@discardableResult
+public func translate(dx: Double, dy: Double, dz: Double) -> Bool
+```
+
+- **Parameters:** `dx`, `dy`, `dz` — translation components.
+- **Returns:** `true` if successful.
+- **OCCT:** `Geom_Surface::Translate(gp_Vec)` applied in-place via `OCCTSurfaceTransform`.
+
+---
+
+### `rotate(axisOrigin:axisDirection:angle:)`
+
+Rotates the surface in place around an axis.
+
+```swift
+@discardableResult
+public func rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angle: Double) -> Bool
+```
+
+- **Parameters:** `axisOrigin` — point on the rotation axis; `axisDirection` — axis direction; `angle` — angle in radians.
+- **Returns:** `true` if successful.
+- **OCCT:** `Geom_Surface::Rotate(gp_Ax1, angle)` in-place.
+
+---
+
+### `scale(center:factor:)`
+
+Scales the surface in place from a centre point.
+
+```swift
+@discardableResult
+public func scale(center: SIMD3<Double>, factor: Double) -> Bool
+```
+
+- **Parameters:** `center` — scaling origin; `factor` — scale factor.
+- **Returns:** `true` if successful.
+- **OCCT:** `Geom_Surface::Scale(gp_Pnt, factor)` in-place.
+
+---
+
+### `mirrorPoint(_:)`
+
+Mirrors the surface in place through a point.
+
+```swift
+@discardableResult
+public func mirrorPoint(_ point: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `point` — the mirror centre.
+- **Returns:** `true` if successful.
+- **OCCT:** `Geom_Surface::Mirror(gp_Pnt)` in-place.
+
+---
+
+### `mirrorAxis(origin:direction:)`
+
+Mirrors the surface in place through an axis.
+
+```swift
+@discardableResult
+public func mirrorAxis(origin: SIMD3<Double>, direction: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `origin` — a point on the mirror axis; `direction` — axis direction.
+- **Returns:** `true` if successful.
+- **OCCT:** `Geom_Surface::Mirror(gp_Ax1)` in-place.
+
+---
+
+### `mirrorPlane(origin:normal:)`
+
+Mirrors the surface in place through a plane.
+
+```swift
+@discardableResult
+public func mirrorPlane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `origin` — a point on the mirror plane; `normal` — plane normal direction.
+- **Returns:** `true` if successful.
+- **OCCT:** `Geom_Surface::Mirror(gp_Ax2)` in-place.
+
+---
+
+## GeomEval Surface Factories (v0.130.0)
+
+Parametric surface factories backed by `Geom_CartesianPoint`-derived evaluator surfaces. All return `nil` on invalid parameters.
+
+---
+
+### `Surface.ellipsoid(a:b:c:)`
+
+Creates a triaxial ellipsoid surface.
+
+```swift
+public static func ellipsoid(a: Double, b: Double, c: Double) -> Surface?
+```
+
+Parametrisation: `P(u,v) = a·cos(v)·cos(u)·X + b·cos(v)·sin(u)·Y + c·sin(v)·Z`.
+
+- **Parameters:** `a` — semi-axis along X (> 0); `b` — semi-axis along Y (> 0); `c` — semi-axis along Z (> 0).
+- **Returns:** Ellipsoid surface, or `nil` if any semi-axis ≤ 0.
+- **OCCT:** `OCCTGeomEvalEllipsoidCreate` — custom `Geom_Surface` evaluator.
+- **Example:**
+  ```swift
+  let ellipsoid = Surface.ellipsoid(a: 10, b: 6, c: 4)
+  ```
+
+---
+
+### `Surface.hyperboloid(r1:r2:twoSheets:)`
+
+Creates a hyperboloid of revolution surface.
+
+```swift
+public static func hyperboloid(r1: Double, r2: Double, twoSheets: Bool = false) -> Surface?
+```
+
+- **Parameters:** `r1` — first semi-axis radius (> 0); `r2` — second semi-axis radius (> 0); `twoSheets` — if `true`, creates a two-sheet hyperboloid.
+- **Returns:** Hyperboloid surface, or `nil` on failure.
+- **OCCT:** `OCCTGeomEvalHyperboloidCreate`.
+
+---
+
+### `Surface.paraboloid(focal:)`
+
+Creates a circular paraboloid of revolution surface.
+
+```swift
+public static func paraboloid(focal: Double) -> Surface?
+```
+
+- **Parameters:** `focal` — focal distance (must be > 0).
+- **Returns:** Paraboloid surface, or `nil` if `focal ≤ 0`.
+- **OCCT:** `OCCTGeomEvalParaboloidCreate`.
+- **Example:**
+  ```swift
+  let dish = Surface.paraboloid(focal: 5)
+  ```
+
+---
+
+### `Surface.circularHelicoid(pitch:)`
+
+Creates a circular helicoid (ruled surface).
+
+```swift
+public static func circularHelicoid(pitch: Double) -> Surface?
+```
+
+Parametrisation: `S(u,v) = v·cos(u)·X + v·sin(u)·Y + (P·u / 2π)·Z`.
+
+- **Parameters:** `pitch` — axial advance per 2π turn (must be ≠ 0).
+- **Returns:** Helicoid surface, or `nil` on failure.
+- **OCCT:** `OCCTGeomEvalCircularHelicoidCreate`.
+- **Example:**
+  ```swift
+  let helicoid = Surface.circularHelicoid(pitch: 3.0)
+  ```
+
+---
+
+### `Surface.hyperbolicParaboloid(a:b:)`
+
+Creates a hyperbolic paraboloid (saddle surface).
+
+```swift
+public static func hyperbolicParaboloid(a: Double, b: Double) -> Surface?
+```
+
+Parametrisation: `P(u,v) = u·X + v·Y + (u²/a² − v²/b²)·Z`.
+
+- **Parameters:** `a` — first semi-axis length (> 0); `b` — second semi-axis length (> 0).
+- **Returns:** Saddle surface, or `nil` on failure.
+- **OCCT:** `OCCTGeomEvalHypParaboloidCreate`.
+
+---
+
+### `Surface.gordon(profiles:guides:tolerance:)`
+
+Builds a Gordon surface from a network of profile and guide curves.
+
+```swift
+public static func gordon(profiles: [Curve3D], guides: [Curve3D], tolerance: Double = 1e-3) -> Surface?
+```
+
+Requires at least 2 profile curves (V-direction) and 2 guide curves (U-direction) that form a complete grid: every profile must intersect every guide within `tolerance`.
+
+- **Parameters:** `profiles` — profile curves (V-direction, ≥ 2); `guides` — guide curves (U-direction, ≥ 2); `tolerance` — geometric tolerance for intersection detection.
+- **Returns:** Gordon BSpline surface, or `nil` if construction fails.
+- **OCCT:** `OCCTGeomFillGordon` / `GeomFill_Gordon`.
+- **Note:** Use `gordonReport(profiles:guides:tolerance:allowApproximateFallback:)` to get detailed failure diagnostics.
+- **Example:**
+  ```swift
+  // Requires profiles and guides to intersect at a grid of points
+  if let surf = Surface.gordon(profiles: profiles, guides: guides, tolerance: 1e-3) {
+      let face = surf.toFace()
+  }
+  ```
+
+---
+
+### `GordonResultStatus`
+
+Result status enum mirroring `GeomFill_Gordon::ResultStatus`.
+
+```swift
+public enum GordonResultStatus: Int, Sendable {
+    case notStarted, done, invalidInput, conversionFailed, intersectionFailed,
+         orderingFailed, reparametrizationFailed, compatibilityFailed,
+         curveCompatibilityFailed, rationalReparametrizationFailed,
+         skinningFailed, referenceSurfaceFailed, knotAlignmentFailed,
+         rationalDegreeOverflow, rationalConstructionFailed,
+         periodicityFailed, approximationFailed, constructionFailed
+}
+```
+
+---
+
+### `GordonResult`
+
+Outcome struct returned by `gordonReport(...)`.
+
+```swift
+public struct GordonResult: Sendable {
+    public let surface: Surface?
+    public let status: GordonResultStatus
+    public let isApproximate: Bool
+}
+```
+
+`isApproximate` is `true` when the result was produced by a sampled B-spline fallback rather than exact interpolation.
+
+---
+
+### `Surface.gordonReport(profiles:guides:tolerance:allowApproximateFallback:)`
+
+Builds a Gordon surface, returning the result status and approximate flag.
+
+```swift
+public static func gordonReport(profiles: [Curve3D], guides: [Curve3D],
+                                 tolerance: Double = 1e-3,
+                                 allowApproximateFallback: Bool = false) -> GordonResult
+```
+
+- **Parameters:** `profiles` — profile curves (≥ 2); `guides` — guide curves (≥ 2); `tolerance` — intersection tolerance; `allowApproximateFallback` — permit sampled B-spline fallback when exact construction fails.
+- **Returns:** `GordonResult` with the surface (or `nil`), status code, and approximate flag.
+- **OCCT:** `OCCTGeomFillGordonReport`.
+
+---
+
+### `NetworkSurfaceStatus`
+
+Result status enum mirroring `GeomFill_NetworkSurface::ResultStatus`.
+
+```swift
+public enum NetworkSurfaceStatus: Int, Sendable {
+    case notStarted, done, invalidInput, curveCompatibilityFailed,
+         skinningFailed, referenceSurfaceFailed, knotAlignmentFailed,
+         rationalDegreeOverflow, rationalConstructionFailed,
+         constructionFailed, periodicityFailed
+}
+```
+
+---
+
+### `Surface.networkSurface(profiles:guides:tolerance:)`
+
+Builds a surface with the low-level `GeomFill_NetworkSurface` builder.
+
+```swift
+public static func networkSurface(profiles: [Curve3D], guides: [Curve3D],
+                                   tolerance: Double = 1e-3)
+    -> (surface: Surface?, status: NetworkSurfaceStatus)
+```
+
+Curves are converted to non-periodic BSplines and an intersection grid is sampled. This is a lower-level alternative to `gordon(...)` for cases requiring manual control over the network construction.
+
+- **Parameters:** `profiles` — profile curves in U, at least 2; `guides` — guide curves in V, at least 2; `tolerance` — geometric tolerance for closed-seam checks.
+- **Returns:** Tuple of the surface (or `nil`) and a status code.
+- **OCCT:** `OCCTGeomFillNetworkSurface` / `GeomFill_NetworkSurface`.
+
+---
+
+## GeomEval TBezier / AHTBezier Surfaces (v0.131.0)
+
+### `Surface.tBezier(poles:uCount:vCount:alphaU:alphaV:)`
+
+Creates a Trigonometric Bezier surface.
+
+```swift
+public static func tBezier(poles: [SIMD3<Double>], uCount: Int, vCount: Int,
+                             alphaU: Double, alphaV: Double) -> Surface?
+```
+
+A tensor-product surface using trigonometric Bernstein-like bases in both U and V. Parameter domain is U ∈ `[0, π/alphaU]`, V ∈ `[0, π/alphaV]`.
+
+- **Parameters:**
+  - `poles` — control points in row-major order (must have exactly `uCount * vCount` elements).
+  - `uCount` — number of poles in U (must be odd, ≥ 3).
+  - `vCount` — number of poles in V (must be odd, ≥ 3).
+  - `alphaU` — frequency parameter in U (> 0).
+  - `alphaV` — frequency parameter in V (> 0).
+- **Returns:** TBezier surface, or `nil` if counts are invalid or even.
+- **OCCT:** `OCCTGeomEvalTBezierSurfaceCreate`.
+- **Example:**
+  ```swift
+  var poles = [SIMD3<Double>](repeating: .zero, count: 9)
+  // fill 3×3 grid ...
+  let s = Surface.tBezier(poles: poles, uCount: 3, vCount: 3, alphaU: 1, alphaV: 1)
+  ```
+
+---
+
+### `Surface.ahtBezier(poles:uCount:vCount:algDegreeU:algDegreeV:alphaU:alphaV:betaU:betaV:)`
+
+Creates an Algebraic-Hyperbolic-Trigonometric (AHT) Bezier surface.
+
+```swift
+public static func ahtBezier(poles: [SIMD3<Double>], uCount: Int, vCount: Int,
+                               algDegreeU: Int, algDegreeV: Int,
+                               alphaU: Double, alphaV: Double,
+                               betaU: Double, betaV: Double) -> Surface?
+```
+
+A tensor-product surface using mixed AHT bases in both U and V. Parameter domain is U, V ∈ `[0, 1]`. Combines algebraic (polynomial), hyperbolic, and trigonometric basis functions.
+
+- **Parameters:**
+  - `poles` — control points in row-major order (`uCount * vCount` elements).
+  - `uCount`, `vCount` — grid dimensions (≥ 1).
+  - `algDegreeU`, `algDegreeV` — algebraic degree in U and V (≥ 0).
+  - `alphaU`, `alphaV` — hyperbolic frequency in U and V (≥ 0).
+  - `betaU`, `betaV` — trigonometric frequency in U and V (≥ 0).
+- **Returns:** AHT Bezier surface, or `nil` on invalid parameters.
+- **OCCT:** `OCCTGeomEvalAHTBezierSurfaceCreate`.
+
+---
+
+## v0.115.0: Surface from point grid, normal, curvatures
+
+### `Surface.fromPointGrid(points:uCount:vCount:degMin:degMax:continuity:tolerance:)`
+
+Approximates a BSpline surface through a grid of 3D points.
+
+```swift
+public static func fromPointGrid(points: [SIMD3<Double>], uCount: Int, vCount: Int,
+                                  degMin: Int = 3, degMax: Int = 8,
+                                  continuity: Int = 2, tolerance: Double = 1e-3) -> Surface?
+```
+
+Points must be in row-major order: `point[v * uCount + u]`. Uses `GeomAPI_PointsToBSplineSurface` for the fit.
+
+- **Parameters:**
+  - `points` — flat array of 3D points in row-major order (must have exactly `uCount * vCount` elements).
+  - `uCount` — number of points in U direction.
+  - `vCount` — number of points in V direction.
+  - `degMin` — minimum BSpline degree (default 3).
+  - `degMax` — maximum BSpline degree (default 8).
+  - `continuity` — desired continuity (0=C0, 1=C1, 2=C2; default 2).
+  - `tolerance` — approximation tolerance.
+- **Returns:** Fitted BSpline surface, or `nil` if `points.count ≠ uCount * vCount` or fitting fails.
+- **OCCT:** `GeomAPI_PointsToBSplineSurface`.
+- **Example:**
+  ```swift
+  // Build a 4×4 grid from a sampled cloud
+  var pts = [SIMD3<Double>]()
+  for v in 0..<4 { for u in 0..<4 {
+      pts.append(SIMD3(Double(u), Double(v), sin(Double(u + v))))
+  }}
+  if let surf = Surface.fromPointGrid(points: pts, uCount: 4, vCount: 4) {
+      let bb = surf.boundingBox
+  }
+  ```
+
+---
+
+### `normal(u:v:)`
+
+Computes the surface normal at (u, v).
+
+```swift
+public func normal(u: Double, v: Double) -> SIMD3<Double>
+```
+
+Always returns a vector; at singular points the result may be the zero vector. Prefer the optional-returning `normal(atU:v:)` (from the Evaluation section) when singularity detection matters.
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Surface normal vector at (u, v).
+- **OCCT:** `GeomLProp_SLProps::Normal`.
+
+---
+
+### `curvatures(u:v:)`
+
+Computes Gaussian and mean curvature at (u, v).
+
+```swift
+public func curvatures(u: Double, v: Double) -> (gaussian: Double, mean: Double)
+```
+
+- **Parameters:** `u` — U parameter; `v` — V parameter.
+- **Returns:** Tuple of Gaussian curvature (K = k_min × k_max) and mean curvature (H = (k_min + k_max) / 2).
+- **OCCT:** `GeomLProp_SLProps::GaussianCurvature` and `MeanCurvature`.
+- **Example:**
+  ```swift
+  let sphere = Surface.sphere(center: .zero, radius: 5)!
+  let (K, H) = sphere.curvatures(u: 0, v: 0)
+  // K ≈ 0.04 (= 1/25), H ≈ 0.2 (= 1/5)
+  ```


### PR DESCRIPTION
First **giant** in the detailed API reference — `Surface` (234 decls), split by `// MARK:` into 5 subagent jobs (parallel Sonnet), each a child of **API Reference**:

| Page | entries | covers |
|------|--------:|--------|
| `Surface.md` | 63 | construction & use (analytic/swept/freeform, ops, conversion, iso-curves, pipe, transform, factories) |
| Surface — Analytic Types | 34 | Plane / Sphere / Torus / Cylinder / Cone / Swept property accessors |
| Surface — BSpline & Bezier | 64 | poles / knots / weights / degree + deep completions |
| Surface — Analysis | 25 | local props, singularities, extrema / projection, intersections |
| Surface — Advanced Construction | 47 | Plate / NLPlate, fills, Face-from-surface (#233), constrained construction, persistence |

**233 entries total**; the chunks cover every MARK section exactly once (no gaps/overlaps). Spot-checked front-matter, signatures vs source, and OCCT mappings (`GeomLProp_SLProps`, `GeomAPI_IntSS`/`IntCS`, `GeomPlate_*`, `ShapeAnalysis_Surface`, …). Subagents touched only their own pages (README-race fix); the orchestrator updated the status table.

Validates MARK-chunking + nav nesting on a real giant. Curve3D / Curve2D / Shape / Document follow the same pattern next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)