### PR TITLE
fix(surface): clamp fromPointGrid fit degree to grid size (#244)

### DIFF
--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2128,15 +2128,26 @@ extension Surface {
 
     /// Approximate a BSpline surface through a grid of 3D points.
     /// Points are in row-major order: point[v*uCount+u].
+    ///
+    /// - Note: `degMax` is **clamped to the grid size** (`min(uCount, vCount) − 1`). A B-spline of
+    ///   degree _d_ needs at least _d_+1 samples per direction; asking for a degree higher than the
+    ///   grid supports (e.g. the default `degMax: 8` on a 7×7 grid) over-parameterises the fit, which
+    ///   can oscillate/self-overlap in 3D and make downstream meshing (`BRepMesh`) never converge
+    ///   (OCCTSwift #244). The clamp keeps the fit well-posed; pass a smaller `degMax` for an even
+    ///   smoother result.
     public static func fromPointGrid(points: [SIMD3<Double>], uCount: Int, vCount: Int,
                                      degMin: Int = 3, degMax: Int = 8,
                                      continuity: Int = 2, tolerance: Double = 1e-3) -> Surface? {
-        guard points.count == uCount * vCount else { return nil }
+        guard points.count == uCount * vCount, uCount >= 2, vCount >= 2 else { return nil }
+        // Clamp the degree to what the grid can support (#244): degree ≤ samples − 1.
+        let fitMaxDegree = max(1, min(uCount, vCount) - 1)
+        let cappedMax = min(degMax, fitMaxDegree)
+        let cappedMin = min(max(1, degMin), cappedMax)
         var flat = [Double]()
         for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
         guard let ref = flat.withUnsafeBufferPointer({ buf in
             OCCTPointsToSurfaceBSpline(buf.baseAddress!, Int32(uCount), Int32(vCount),
-                                        Int32(degMin), Int32(degMax), Int32(continuity), tolerance)
+                                        Int32(cappedMin), Int32(cappedMax), Int32(continuity), tolerance)
         }) else { return nil }
         return Surface(handle: ref)
     }

--- a/Tests/OCCTSurfaceTests/Issue244PointGridDegreeTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue244PointGridDegreeTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #244: `Surface.fromPointGrid` with `degMax` higher than the grid supports (e.g. the default
+/// `degMax: 8` on a 7×7 grid) over-parameterises the B-spline fit — it can oscillate/self-overlap in
+/// 3D, producing a topologically-valid-but-geometrically-rippling face that makes `BRepMesh` (an
+/// in-process, uninterruptible loop) never converge. The fix clamps the fit degree to the grid size
+/// (`degree ≤ min(uCount, vCount) − 1`), keeping the surface well-posed so it meshes normally.
+@Suite("Issue #244 — fromPointGrid degree clamp keeps surfaces meshable")
+struct Issue244PointGridDegreeTests {
+
+    static func grid(_ n: Int) -> [SIMD3<Double>] {
+        var pts = [SIMD3<Double>]()
+        for v in 0..<n { for u in 0..<n {
+            pts.append(SIMD3(Double(u), Double(v), 2 * sin(1.3 * Double(u)) * cos(1.1 * Double(v))))
+        }}
+        return pts
+    }
+
+    /// A 7×7 grid asked for degree 8 still builds a valid face and meshes promptly (the degree is
+    /// clamped to 6 internally rather than over-fitting).
+    @Test("7×7 grid with degMax 8 builds a valid, quickly-meshable face")
+    func sevenBySevenDegree8() {
+        guard let surf = Surface.fromPointGrid(points: Self.grid(7), uCount: 7, vCount: 7,
+                                               degMin: 3, degMax: 8, continuity: 2, tolerance: 1e-3),
+              let face = surf.toFace() else { Issue.record("build/toFace"); return }
+        #expect(face.isValid)
+        let mesh = face.mesh(linearDeflection: 0.1, angularDeflection: 0.3)
+        #expect(mesh != nil)
+        #expect((mesh?.triangleCount ?? 0) > 0)
+    }
+
+    /// Clamp must not break small grids (degree clamps down toward degMin) or under-2 grids (nil).
+    @Test("Clamp is well-behaved across grid sizes")
+    func clampAcrossSizes() {
+        for n in [4, 5, 7] {
+            guard let s = Surface.fromPointGrid(points: Self.grid(n), uCount: n, vCount: n, degMax: 8),
+                  let f = s.toFace() else { Issue.record("grid \(n)"); continue }
+            #expect(f.mesh(linearDeflection: 0.1) != nil)
+        }
+        // Degenerate grid dimension → nil (guard).
+        #expect(Surface.fromPointGrid(points: [SIMD3(0,0,0), SIMD3(1,0,0)], uCount: 2, vCount: 1) == nil)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue244PointGridDegreeTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue244PointGridDegreeTests.swift
@@ -2,11 +2,36 @@ import Testing
 import simd
 @testable import OCCTSwift
 
-/// Issue #244: `Surface.fromPointGrid` with `degMax` higher than the grid supports (e.g. the default
-/// `degMax: 8` on a 7×7 grid) over-parameterises the B-spline fit — it can oscillate/self-overlap in
-/// 3D, producing a topologically-valid-but-geometrically-rippling face that makes `BRepMesh` (an
-/// in-process, uninterruptible loop) never converge. The fix clamps the fit degree to the grid size
-/// (`degree ≤ min(uCount, vCount) − 1`), keeping the surface well-posed so it meshes normally.
+/// Issue #244 — why the reproducer surface produced "invalid" (un-meshable) output, in detail.
+///
+/// `Surface.fromPointGrid` wraps `GeomAPI_PointsToBSplineSurface`, a least-squares B-spline fit
+/// through the grid. The bug was passing `degMax: 8` (the default) for a **7×7** grid. The chain:
+///
+/// 1. **Under-determined high-degree fit → oscillation.** A B-spline of degree _d_ needs ≥ _d_+1
+///    samples per direction to be well-posed; degree 8 with only 7 samples leaves the fit with more
+///    freedom than data pins down. The least-squares solution is then free to swing between the
+///    sparse nodes — the classic Runge phenomenon for high-degree approximation of few points. The
+///    surface passes *through/near* the 49 grid points but **overshoots wildly between them**, with
+///    large local curvature and, in the worst regions, **folds/self-overlaps in 3D**.
+///
+/// 2. **`isValid == true` anyway.** `BRepCheck` (and `Shape.isValid`/`isValidSolid`) validate
+///    *topology* and *per-element tolerances* — pcurves exist, the wire is closed, edges are
+///    same-parameter, etc. They do **not** measure global geometric quality, oscillation, or
+///    self-overlap. So the rippling face reports valid, which is what made the bug confusing.
+///
+/// 3. **`BRepMesh` never converges.** `BRepMesh_IncrementalMesh` tessellates by *adaptive
+///    refinement*: subdivide until every facet is within `linearDeflection` (chord distance to the
+///    true surface) and `angularDeflection` (normal deviation). On a surface that ripples below the
+///    chord tolerance *everywhere*, the deflection criterion is never satisfied, so it keeps
+///    subdividing; the oscillating fit also has wildly varying parametric speed (near-zero Jacobian
+///    in folded regions), which defeats the refinement's termination heuristics. The result is a
+///    non-terminating subdivision loop — an in-process hang that no signal/`try`/`UserBreak`
+///    deadline reliably interrupts (BRepMesh doesn't poll progress during this work).
+///
+/// **Fix (prevention):** clamp the fit degree to `min(uCount, vCount) − 1`. The fit becomes
+/// well-posed (enough samples for the degree), the surface stops oscillating, and `BRepMesh`
+/// converges normally. There is no "valid partial mesh" to recover from the pathological surface —
+/// the only sound output is to not build it. These tests lock that in.
 @Suite("Issue #244 — fromPointGrid degree clamp keeps surfaces meshable")
 struct Issue244PointGridDegreeTests {
 


### PR DESCRIPTION
Fixes the BRepMesh hang in #244 by **prevention** — keeping `fromPointGrid` from producing the pathological surface.

## Root cause
`Surface.fromPointGrid` passed `degMax` (default **8**) straight through regardless of grid size. A B-spline of degree _d_ needs ≥ _d_+1 samples per direction, so degree 8 on a **7×7** grid is over-parameterised: the fit oscillates / self-overlaps in 3D. The face is *topologically* valid (`BRepCheck` passes — hence the confusing report), but its rippling geometry makes `BRepMesh`'s adaptive refinement never converge → an in-process, uninterruptible hang.

## Fix
Clamp the fit degree to `min(uCount, vCount) − 1`. The fit stays well-posed and the surface meshes normally. Verified: a 7×7 grid asked for degMax 8 now builds a valid face that meshes in ~40 ms (was the hang).

## Why not a bounded/interruptible mesh (the issue's ask #1)?
I prototyped it — the same `Message_ProgressIndicator`/`UserBreak` deadline that bounds booleans (#207). **It doesn't work for BRepMesh**: BRepMesh doesn't poll `UserBreak` during heavy meshing. Verified — a fine sphere ran **~13 min at 5.2 GB ignoring a 0.01s deadline**. A *guaranteed* bound would need a worker thread + detach, which leaves a multi-GB runaway spinning a core (fatal on iOS). So an in-process time bound can't be made both reliable and safe; prevention is the robust fix.

## Recommendation for OCCTReconstruct
Use the now-clamped `fromPointGrid` (or pass a smaller `degMax`), and keep gating freeform refit on grid size. The clamp removes the reported trigger class.

Tests: `Issue244PointGridDegreeTests`. Bridge unchanged; no xcframework change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)