### PR TITLE
docs(reference): Curve3D + Curve2D — chunked, 8 pages (batch 3)

### DIFF
--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1,0 +1,1435 @@
+---
+title: Curve2D — Analysis
+parent: API Reference
+---
+
+# Curve2D — Analysis
+
+This page covers the analysis and query members of `Curve2D`: differential geometry (curvature, normal, inflection), bounding box, general-purpose intersection/projection/extrema, batch evaluation, analytical intersection primitives, 2D extrema solvers, detailed curvature-inflection classification via `Geom2dLProp`, approximation/simplification via `ShapeCustom_Curve2d` and `Approx_Curve2d`, interpolation, arc-length and trim, local extrema and gce factory construction, serialization/persistence, energy-minimal fair curves, and `Point2D` integration. For primitive construction, B-spline/Bezier operations, and transforms see the main `Curve2D` page.
+
+## Topics
+
+- [Local Properties (Curvature, Normal, Inflection)](#local-properties-curvature-normal-inflection) · [Bounding Box](#bounding-box) · [Analysis](#analysis) · [Batch Evaluation (v0.28.0)](#batch-evaluation-v0280) · [Extrema 2D](#extrema-2d) · [Geom2dLProp: Curvature Inflection/Extrema](#geom2dlprop-curvature-inflectionextrema) · [IntAna2d Analytical Intersections](#intana2d-analytical-intersections) · [ShapeCustom\_Curve2d & Approx\_Curve2d (v0.52.0)](#shapecustom_curve2d--approx_curve2d-v0520) · [v0.115.0: Interpolation expansion, trim, length](#v01150-interpolation-expansion-trim-length) · [v0.80.0: Extrema, gce factories, GeomTools persistence](#v0800-extrema-gce-factories-geomtools-persistence) · [FairCurve](#faircurve) · [Point2D Integration](#point2d-integration)
+
+---
+
+## Local Properties (Curvature, Normal, Inflection)
+
+Differential geometry queries evaluated at a parametric point on the curve, backed by `Geom2dLProp_CLProps2d`.
+
+---
+
+### `curvature(at:)`
+
+Returns the signed curvature (1 / radius of curvature) at parameter `u`.
+
+```swift
+public func curvature(at u: Double) -> Double
+```
+
+Returns `0` for straight segments or when `Geom2dLProp_CLProps2d` cannot compute the value at the given point.
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Curvature value; `0` on error or for a straight segment.
+- **OCCT:** `Geom2dLProp_CLProps2d::Curvature`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5) {
+      let k = circle.curvature(at: 0)  // ≈ 0.2 (1/R)
+  }
+  ```
+
+---
+
+### `normal(at:)`
+
+Returns the unit inward normal vector at parameter `u`.
+
+```swift
+public func normal(at u: Double) -> SIMD2<Double>?
+```
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Unit normal, or `nil` if undefined (e.g. curvature is zero on a straight line).
+- **OCCT:** `Geom2dLProp_CLProps2d::Normal`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let n = circle.normal(at: 0) {
+      print(n)  // ≈ (-1, 0) pointing toward center
+  }
+  ```
+
+---
+
+### `tangentDirection(at:)`
+
+Returns the unit tangent direction at parameter `u`.
+
+```swift
+public func tangentDirection(at u: Double) -> SIMD2<Double>?
+```
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Unit tangent, or `nil` if undefined.
+- **OCCT:** `Geom2dLProp_CLProps2d::Tangent`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let t = circle.tangentDirection(at: 0) {
+      print(t)  // ≈ (0, 1)
+  }
+  ```
+
+---
+
+### `centerOfCurvature(at:)`
+
+Returns the center of the osculating circle at parameter `u`.
+
+```swift
+public func centerOfCurvature(at u: Double) -> SIMD2<Double>?
+```
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Center of curvature, or `nil` if curvature is zero (straight segment).
+- **OCCT:** `Geom2dLProp_CLProps2d::CentreOfCurvature`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let coc = circle.centerOfCurvature(at: 0) {
+      print(coc)  // ≈ (0, 0) — the center of the circle itself
+  }
+  ```
+
+---
+
+### `inflectionPoints()`
+
+Finds all inflection points (where curvature changes sign) and returns their parameter values.
+
+```swift
+public func inflectionPoints() -> [Double]
+```
+
+Capped internally at 256 results.
+
+- **Returns:** Array of parameter values at inflection points (may be empty).
+- **OCCT:** `Geom2dLProp_CLProps2d` inflection detection.
+- **Example:**
+  ```swift
+  if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
+      let inflections = spline.inflectionPoints()
+  }
+  ```
+
+---
+
+### `curvatureExtrema()`
+
+Finds local minima and maxima of curvature magnitude.
+
+```swift
+public func curvatureExtrema() -> [Curve2DSpecialPoint]
+```
+
+Returns `Curve2DSpecialPoint` values with `.minCurvature` or `.maxCurvature` type classification. Capped at 256 results.
+
+- **Returns:** Array of special points (may be empty).
+- **OCCT:** `Geom2dLProp_CLProps2d` curvature extrema.
+- **Example:**
+  ```swift
+  if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
+      for sp in spline.curvatureExtrema() {
+          print(sp.parameter, sp.type)
+      }
+  }
+  ```
+
+---
+
+### `allSpecialPoints()`
+
+Returns all special points — both inflection points and curvature extrema — in a single pass.
+
+```swift
+public func allSpecialPoints() -> [Curve2DSpecialPoint]
+```
+
+Capped internally at 256 results.
+
+- **Returns:** Array of `Curve2DSpecialPoint` values (`.inflection`, `.minCurvature`, or `.maxCurvature`).
+- **OCCT:** `Geom2dLProp_CLProps2d`.
+- **Example:**
+  ```swift
+  if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
+      let special = spline.allSpecialPoints()
+  }
+  ```
+
+---
+
+### `Curve2DSpecialPointType`
+
+Enum classifying a special point on a curve.
+
+```swift
+public enum Curve2DSpecialPointType: Int32, Sendable {
+    case inflection    = 0
+    case minCurvature  = 1
+    case maxCurvature  = 2
+}
+```
+
+---
+
+### `Curve2DSpecialPoint`
+
+Struct returned by `curvatureExtrema()` and `allSpecialPoints()`.
+
+```swift
+public struct Curve2DSpecialPoint: Sendable {
+    public let parameter: Double
+    public let type: Curve2DSpecialPointType
+}
+```
+
+- `parameter` — curve parameter at the special point.
+- `type` — inflection, minimum curvature, or maximum curvature.
+
+---
+
+## Bounding Box
+
+---
+
+### `boundingBox`
+
+The axis-aligned bounding box of this curve.
+
+```swift
+public var boundingBox: (min: SIMD2<Double>, max: SIMD2<Double>)?
+```
+
+- **Returns:** Tuple with `min` and `max` corners, or `nil` if the underlying curve has no computable bounding box.
+- **OCCT:** `Geom2dAdaptor_Curve` + `BndLib_Add2dCurve`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let bb = circle.boundingBox {
+      print(bb.min, bb.max)  // ≈ (-5,-5), (5,5)
+  }
+  ```
+
+---
+
+## Analysis
+
+General-purpose 2D intersection, projection, and extrema members of `Curve2D`.
+
+---
+
+### `Curve2DIntersection`
+
+Struct representing an intersection between two 2D curves.
+
+```swift
+public struct Curve2DIntersection: Sendable {
+    public let point:      SIMD2<Double>
+    public let parameter1: Double
+    public let parameter2: Double
+}
+```
+
+- `point` — 2D intersection coordinate.
+- `parameter1` / `parameter2` — parameters on the first and second curves at the intersection.
+
+---
+
+### `Curve2DProjection`
+
+Struct representing a projection of a point onto a 2D curve.
+
+```swift
+public struct Curve2DProjection: Sendable {
+    public let point:     SIMD2<Double>
+    public let parameter: Double
+    public let distance:  Double
+}
+```
+
+- `point` — nearest point on the curve.
+- `parameter` — curve parameter at that point.
+- `distance` — distance from the queried point to the curve.
+
+---
+
+### `Curve2DExtremaResult`
+
+Struct representing a distance extremum between two 2D curves.
+
+```swift
+public struct Curve2DExtremaResult: Sendable {
+    public let pointOnCurve1: SIMD2<Double>
+    public let pointOnCurve2: SIMD2<Double>
+    public let parameter1:    Double
+    public let parameter2:    Double
+    public let distance:      Double
+}
+```
+
+---
+
+### `intersections(with:tolerance:)`
+
+Finds all intersection points between this curve and another.
+
+```swift
+public func intersections(with other: Curve2D, tolerance: Double = 1e-6) -> [Curve2DIntersection]
+```
+
+Capped at 128 results.
+
+- **Parameters:** `other` — the curve to intersect with; `tolerance` — intersection tolerance (default `1e-6`).
+- **Returns:** Array of `Curve2DIntersection` values (may be empty).
+- **OCCT:** `Geom2dAPI_InterCurveCurve`.
+- **Example:**
+  ```swift
+  if let c1 = Curve2D.circle(center: .zero, radius: 5),
+     let c2 = Curve2D.circle(center: SIMD2(3, 0), radius: 5) {
+      let pts = c1.intersections(with: c2)
+      // pts.count == 2 for overlapping circles
+  }
+  ```
+
+---
+
+### `selfIntersections(tolerance:)`
+
+Finds all self-intersection points of this curve.
+
+```swift
+public func selfIntersections(tolerance: Double = 1e-6) -> [Curve2DIntersection]
+```
+
+Capped at 128 results.
+
+- **Parameters:** `tolerance` — intersection tolerance (default `1e-6`).
+- **Returns:** Array of `Curve2DIntersection` values (may be empty).
+- **OCCT:** `Geom2dAPI_InterCurveCurve` self-intersection mode.
+- **Example:**
+  ```swift
+  if let figure8 = makeFigureEightCurve() {
+      let si = figure8.selfIntersections()
+  }
+  ```
+
+---
+
+### `project(point:)`
+
+Projects a point onto this curve, returning the single nearest projection.
+
+```swift
+public func project(point p: SIMD2<Double>) -> Curve2DProjection?
+```
+
+- **Parameters:** `p` — 2D point to project.
+- **Returns:** Nearest `Curve2DProjection`, or `nil` on failure (negative distance sentinel from bridge).
+- **OCCT:** `Geom2dAPI_ProjectPointOnCurve`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let proj = circle.project(point: SIMD2(3, 4)) {
+      print(proj.parameter, proj.distance)  // distance ≈ 0 (point is on the circle)
+  }
+  ```
+
+---
+
+### `allProjections(of:)`
+
+Projects a point onto this curve, returning all projection solutions.
+
+```swift
+public func allProjections(of p: SIMD2<Double>) -> [Curve2DProjection]
+```
+
+Capped at 64 results. Useful when there are multiple equidistant points (e.g. projecting the center onto a circle).
+
+- **Parameters:** `p` — 2D point to project.
+- **Returns:** Array of `Curve2DProjection` values (may be empty).
+- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (all solutions).
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5) {
+      let projs = circle.allProjections(of: .zero)
+      // all points on the circle are equidistant
+  }
+  ```
+
+---
+
+### `minDistance(to:)`
+
+Finds the minimum distance between this curve and another.
+
+```swift
+public func minDistance(to other: Curve2D) -> Curve2DExtremaResult?
+```
+
+- **Parameters:** `other` — the curve to measure distance to.
+- **Returns:** `Curve2DExtremaResult` for the closest pair of points, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_ExtremaCurveCurve` (minimum solution).
+- **Example:**
+  ```swift
+  if let c1 = Curve2D.circle(center: .zero, radius: 3),
+     let c2 = Curve2D.circle(center: SIMD2(10, 0), radius: 3),
+     let ex = c1.minDistance(to: c2) {
+      print(ex.distance)  // ≈ 4.0
+  }
+  ```
+
+---
+
+### `allExtrema(with:)`
+
+Finds all distance extrema (local min and max distances) between this curve and another.
+
+```swift
+public func allExtrema(with other: Curve2D) -> [Curve2DExtremaResult]
+```
+
+Capped at 64 results.
+
+- **Parameters:** `other` — the curve to compute extrema against.
+- **Returns:** Array of `Curve2DExtremaResult` values (may be empty).
+- **OCCT:** `Geom2dAPI_ExtremaCurveCurve` (all solutions).
+- **Example:**
+  ```swift
+  if let c1 = Curve2D.circle(center: .zero, radius: 3),
+     let c2 = Curve2D.circle(center: SIMD2(10, 0), radius: 3) {
+      let extrema = c1.allExtrema(with: c2)
+      // extrema.count == 2 (closest and farthest pair of points)
+  }
+  ```
+
+---
+
+## Batch Evaluation (v0.28.0)
+
+---
+
+### `evaluateGrid(_:)`
+
+Evaluates the curve at multiple parameter values in a single call.
+
+```swift
+public func evaluateGrid(_ parameters: [Double]) -> [SIMD2<Double>]
+```
+
+Uses OCCT's optimised grid evaluator; faster than calling `point(at:)` repeatedly for dense sampling.
+
+- **Parameters:** `parameters` — array of parameter values.
+- **Returns:** Array of 2D points corresponding to each parameter; empty if `parameters` is empty.
+- **OCCT:** `Geom2dAdaptor_Curve::Value` via bridge buffer.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5) {
+      let params = stride(from: 0.0, through: 2 * .pi, by: 0.01).map { $0 }
+      let points = circle.evaluateGrid(params)
+  }
+  ```
+
+---
+
+### `evaluateGridD1(_:)`
+
+Evaluates the curve and its first derivative at multiple parameter values in a single call.
+
+```swift
+public func evaluateGridD1(_ parameters: [Double]) -> [(point: SIMD2<Double>, tangent: SIMD2<Double>)]
+```
+
+- **Parameters:** `parameters` — array of parameter values.
+- **Returns:** Array of `(point, tangent)` tuples; empty if `parameters` is empty.
+- **OCCT:** `Geom2dAdaptor_Curve::D1` via bridge buffer.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5) {
+      let params = [0.0, .pi / 2, .pi, 3 * .pi / 2]
+      let results = circle.evaluateGridD1(params)
+      for r in results { print(r.point, r.tangent) }
+  }
+  ```
+
+---
+
+## Extrema 2D
+
+Elementary 2D curve–curve and point–curve distance solvers (`Extrema_ExtElC2d`, `Extrema_ExtPElC2d`, `Extrema_ExtCC2d`).
+
+---
+
+### `Extrema2DResult`
+
+Struct representing a single distance extremum between two 2D elements.
+
+```swift
+public struct Extrema2DResult: Sendable {
+    public let squareDistance: Double
+    public var distance: Double { squareDistance.squareRoot() }
+    public let param1:  Double
+    public let param2:  Double
+    public let point1:  SIMD2<Double>
+    public let point2:  SIMD2<Double>
+}
+```
+
+- `squareDistance` — squared distance (avoids sqrt cost).
+- `distance` — computed square root of `squareDistance`.
+- `param1` / `param2` — parameters on the first and second elements.
+- `point1` / `point2` — closest points on each element.
+
+---
+
+### `Extrema2d.distanceBetweenLines(line1Point:line1Dir:line2Point:line2Dir:tolerance:)`
+
+Computes the distance between two 2D lines.
+
+```swift
+public static func distanceBetweenLines(
+    line1Point: SIMD2<Double>, line1Dir: SIMD2<Double>,
+    line2Point: SIMD2<Double>, line2Dir: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> (isParallel: Bool, results: [Extrema2DResult])
+```
+
+When lines are parallel, `isParallel` is `true` and one result with the perpendicular distance is returned.
+
+- **Returns:** `(isParallel, results)` — when parallel: one result with distance; when intersecting: one result with distance zero.
+- **OCCT:** `Extrema_ExtElC2d` (line–line).
+- **Example:**
+  ```swift
+  let r = Extrema2d.distanceBetweenLines(
+      line1Point: .zero, line1Dir: SIMD2(1, 0),
+      line2Point: SIMD2(0, 5), line2Dir: SIMD2(1, 0))
+  // r.isParallel == true, r.results.first?.distance ≈ 5
+  ```
+
+---
+
+### `Extrema2d.distanceBetweenLineAndCircle(linePoint:lineDir:circleCenter:circleRadius:tolerance:)`
+
+Computes distance extrema between a 2D line and a 2D circle.
+
+```swift
+public static func distanceBetweenLineAndCircle(
+    linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    circleCenter: SIMD2<Double>, circleRadius: Double,
+    tolerance: Double = 1e-6
+) -> [Extrema2DResult]
+```
+
+- **Returns:** Array of extrema results (min and/or max distance points; may be empty on failure).
+- **OCCT:** `Extrema_ExtElC2d` (line–circle).
+- **Example:**
+  ```swift
+  let extrema = Extrema2d.distanceBetweenLineAndCircle(
+      linePoint: SIMD2(0, 10), lineDir: SIMD2(1, 0),
+      circleCenter: .zero, circleRadius: 5)
+  ```
+
+---
+
+### `Extrema2d.distanceFromPointToCircle(point:circleCenter:circleRadius:tolerance:)`
+
+Returns the closest and farthest points on a 2D circle from a given point.
+
+```swift
+public static func distanceFromPointToCircle(
+    point: SIMD2<Double>,
+    circleCenter: SIMD2<Double>, circleRadius: Double,
+    tolerance: Double = 1e-6
+) -> [Extrema2DResult]
+```
+
+- **Returns:** Array of up to 2 results (min and max distance to the circle).
+- **OCCT:** `Extrema_ExtPElC2d` (point–circle).
+- **Example:**
+  ```swift
+  let extrema = Extrema2d.distanceFromPointToCircle(
+      point: SIMD2(10, 0), circleCenter: .zero, circleRadius: 5)
+  // extrema[0].distance ≈ 5 (near), extrema[1].distance ≈ 15 (far)
+  ```
+
+---
+
+### `Extrema2d.distanceFromPointToLine(point:linePoint:lineDir:tolerance:)`
+
+Returns the closest point on a 2D line from a given point.
+
+```swift
+public static func distanceFromPointToLine(
+    point: SIMD2<Double>,
+    linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Extrema2DResult]
+```
+
+- **Returns:** Array with one result (the foot of the perpendicular from the point to the line).
+- **OCCT:** `Extrema_ExtPElC2d` (point–line).
+- **Example:**
+  ```swift
+  let r = Extrema2d.distanceFromPointToLine(
+      point: SIMD2(3, 4),
+      linePoint: .zero, lineDir: SIMD2(1, 0))
+  // r.first?.distance ≈ 4
+  ```
+
+---
+
+### `Extrema2d.distanceBetweenCurves(_:first1:last1:_:first2:last2:)`
+
+Finds all distance extrema between two arbitrary 2D curves within given parameter ranges.
+
+```swift
+public static func distanceBetweenCurves(
+    _ c1: Curve2D, first1: Double, last1: Double,
+    _ c2: Curve2D, first2: Double, last2: Double
+) -> [Extrema2DResult]
+```
+
+Capped at 32 results.
+
+- **Parameters:** `c1`/`c2` — the two curves; `first1`/`last1` — parameter range on `c1`; `first2`/`last2` — parameter range on `c2`.
+- **Returns:** Array of `Extrema2DResult` values for all local extrema (may be empty).
+- **OCCT:** `Extrema_ExtCC2d`.
+- **Example:**
+  ```swift
+  if let c1 = Curve2D.circle(center: .zero, radius: 3),
+     let c2 = Curve2D.circle(center: SIMD2(8, 0), radius: 2) {
+      let ex = Extrema2d.distanceBetweenCurves(c1, first1: 0, last1: 2 * .pi,
+                                               c2, first2: 0, last2: 2 * .pi)
+  }
+  ```
+
+---
+
+## Geom2dLProp: Curvature Inflection/Extrema
+
+Higher-resolution curvature feature detection via `Geom2dLProp_NumericCurInf2d`.
+
+---
+
+### `CurInfType`
+
+Enum classifying a curvature feature point.
+
+```swift
+public enum CurInfType: Int32, Sendable {
+    case curvatureMinimum = 0
+    case curvatureMaximum = 1
+    case inflection       = 2
+}
+```
+
+---
+
+### `CurInfPoint`
+
+Struct returned by `curvatureExtremaDetailed()` and `inflectionPointsDetailed()`.
+
+```swift
+public struct CurInfPoint: Sendable {
+    public let parameter: Double
+    public let type:      CurInfType
+}
+```
+
+---
+
+### `curvatureExtremaDetailed()`
+
+Finds local curvature extrema with min/max type classification.
+
+```swift
+public func curvatureExtremaDetailed() -> [CurInfPoint]
+```
+
+Unlike `curvatureExtrema()` (which returns `Curve2DSpecialPoint`), this returns `CurInfPoint` values using the `CurInfType` enum. Capped at 64 results.
+
+- **Returns:** Array of `CurInfPoint` with `.curvatureMinimum` or `.curvatureMaximum` type.
+- **OCCT:** `Geom2dLProp_NumericCurInf2d::PerformCurExt`.
+- **Example:**
+  ```swift
+  if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
+      for pt in spline.curvatureExtremaDetailed() {
+          print(pt.parameter, pt.type)
+      }
+  }
+  ```
+
+---
+
+### `inflectionPointsDetailed()`
+
+Finds inflection points with type information.
+
+```swift
+public func inflectionPointsDetailed() -> [CurInfPoint]
+```
+
+Like `inflectionPoints()` but returns `CurInfPoint` values (all with `.inflection` type) rather than bare `Double` parameters. Capped at 64 results.
+
+- **Returns:** Array of `CurInfPoint` (all `.inflection`).
+- **OCCT:** `Geom2dLProp_NumericCurInf2d::PerformInf`.
+- **Example:**
+  ```swift
+  if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
+      let infl = spline.inflectionPointsDetailed()
+  }
+  ```
+
+---
+
+## IntAna2d Analytical Intersections
+
+Exact (closed-form) intersection between elementary 2D curves. All methods return `[Intersection2DPoint]`.
+
+---
+
+### `Intersection2DPoint`
+
+Struct representing an analytical 2D intersection result.
+
+```swift
+public struct Intersection2DPoint: Sendable {
+    public let point:  SIMD2<Double>
+    public let param1: Double
+    public let param2: Double
+}
+```
+
+- `point` — 2D coordinates of the intersection.
+- `param1` / `param2` — parameters on each input element at the intersection.
+
+---
+
+### `IntAna2d.intersectLines(line1Point:line1Dir:line2Point:line2Dir:)`
+
+Intersects two 2D lines analytically.
+
+```swift
+public static func intersectLines(
+    line1Point: SIMD2<Double>, line1Dir: SIMD2<Double>,
+    line2Point: SIMD2<Double>, line2Dir: SIMD2<Double>
+) -> [Intersection2DPoint]
+```
+
+Returns 0 results for parallel lines, 1 result for a transverse intersection.
+
+- **Returns:** Array of `Intersection2DPoint` (0 or 1 elements).
+- **OCCT:** `IntAna2d_AnaIntersection` (line–line).
+- **Example:**
+  ```swift
+  let pts = IntAna2d.intersectLines(
+      line1Point: .zero, line1Dir: SIMD2(1, 0),
+      line2Point: .zero, line2Dir: SIMD2(0, 1))
+  // pts.count == 1, pts[0].point ≈ (0, 0)
+  ```
+
+---
+
+### `IntAna2d.intersectLineCircle(linePoint:lineDir:circleCenter:circleRadius:)`
+
+Intersects a 2D line and a circle analytically.
+
+```swift
+public static func intersectLineCircle(
+    linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    circleCenter: SIMD2<Double>, circleRadius: Double
+) -> [Intersection2DPoint]
+```
+
+Returns 0, 1 (tangent), or 2 intersection points.
+
+- **Returns:** Array of 0–2 `Intersection2DPoint` values.
+- **OCCT:** `IntAna2d_AnaIntersection` (line–circle).
+- **Example:**
+  ```swift
+  let pts = IntAna2d.intersectLineCircle(
+      linePoint: SIMD2(0, -10), lineDir: SIMD2(0, 1),
+      circleCenter: .zero, circleRadius: 5)
+  // pts.count == 2 (chord through circle)
+  ```
+
+---
+
+### `IntAna2d.intersectCircles(center1:radius1:center2:radius2:)`
+
+Intersects two 2D circles analytically.
+
+```swift
+public static func intersectCircles(
+    center1: SIMD2<Double>, radius1: Double,
+    center2: SIMD2<Double>, radius2: Double
+) -> [Intersection2DPoint]
+```
+
+Returns 0 (disjoint or concentric), 1 (tangent), or 2 intersection points.
+
+- **Returns:** Array of 0–2 `Intersection2DPoint` values.
+- **OCCT:** `IntAna2d_AnaIntersection` (circle–circle).
+- **Example:**
+  ```swift
+  let pts = IntAna2d.intersectCircles(
+      center1: .zero, radius1: 5,
+      center2: SIMD2(6, 0), radius2: 5)
+  // pts.count == 2
+  ```
+
+---
+
+## ShapeCustom\_Curve2d & Approx\_Curve2d (v0.52.0)
+
+Curve simplification, linearity detection, and BSpline approximation from `ShapeCustom_Curve2d` and `Approx_Curve2d`.
+
+---
+
+### `isLinear(tolerance:)`
+
+Checks whether this 2D BSpline curve has nearly collinear control points.
+
+```swift
+public func isLinear(tolerance: Double = 1e-6) -> (isLinear: Bool, deviation: Double)?
+```
+
+- **Parameters:** `tolerance` — maximum allowed deviation from a straight line.
+- **Returns:** Tuple `(isLinear, deviation)` where `deviation` is the actual maximum deviation, or `nil` if the curve is not a BSpline.
+- **OCCT:** `ShapeCustom_Curve2d::IsLinear`.
+- **Example:**
+  ```swift
+  if let seg = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0)),
+     let bsp = seg.toBSpline(),
+     let check = bsp.isLinear() {
+      print(check.isLinear, check.deviation)  // true, ≈ 0
+  }
+  ```
+
+---
+
+### `convertToLine(first:last:tolerance:)`
+
+Converts a nearly-linear 2D curve to a line within the given parameter range.
+
+```swift
+public func convertToLine(
+    first: Double, last: Double, tolerance: Double = 1e-3
+) -> (line: Curve2D, newFirst: Double, newLast: Double, deviation: Double)?
+```
+
+Returns the equivalent line curve along with reparametrized bounds, or `nil` if the curve is not within tolerance of a line.
+
+- **Parameters:** `first`/`last` — parameter range to check; `tolerance` — deviation tolerance.
+- **Returns:** Tuple `(line, newFirst, newLast, deviation)`, or `nil` if not linear within tolerance.
+- **OCCT:** `ShapeCustom_Curve2d::ConvertToLine`.
+- **Example:**
+  ```swift
+  if let bsp = someCurve.toBSpline(),
+     let result = bsp.convertToLine(first: 0, last: 1) {
+      let line = result.line
+  }
+  ```
+
+---
+
+### `simplifyBSpline(tolerance:)`
+
+Removes unnecessary knots from a 2D BSpline in place.
+
+```swift
+@discardableResult
+public func simplifyBSpline(tolerance: Double = 1e-6) -> Bool
+```
+
+Mutates the receiver. Returns `true` if any knots were removed.
+
+- **Parameters:** `tolerance` — maximum allowed shape deviation after removal.
+- **Returns:** `true` if simplification occurred.
+- **OCCT:** `ShapeCustom_Curve2d::SimplifyBSpline`.
+- **Example:**
+  ```swift
+  if let bsp = someCurve.toBSpline() {
+      bsp.simplifyBSpline(tolerance: 1e-4)
+  }
+  ```
+
+---
+
+### `approximated(first:last:toleranceU:toleranceV:maxDegree:maxSegments:)`
+
+Approximates this 2D curve as a BSpline over a given parameter range.
+
+```swift
+public func approximated(
+    first: Double, last: Double,
+    toleranceU: Double = 1e-6, toleranceV: Double = 1e-6,
+    maxDegree: Int = 8, maxSegments: Int = 100
+) -> Curve2D?
+```
+
+Distinct from the instance method `approximated(tolerance:continuity:maxSegments:maxDegree:)` (which takes continuity as a parameter). This overload uses `Approx_Curve2d` and accepts separate U/V tolerances.
+
+- **Parameters:** `first`/`last` — parameter range; `toleranceU`/`toleranceV` — approximation tolerances; `maxDegree` — maximum polynomial degree (default 8); `maxSegments` — maximum number of segments (default 100).
+- **Returns:** Approximated BSpline `Curve2D`, or `nil` on failure.
+- **OCCT:** `Approx_Curve2d`.
+- **Example:**
+  ```swift
+  if let approx = someCurve.approximated(first: 0, last: 1, toleranceU: 1e-4) {
+      print(approx.degree)
+  }
+  ```
+
+---
+
+## v0.115.0: Interpolation expansion, trim, length
+
+---
+
+### `interpolate(points:startTangent:endTangent:)`
+
+Interpolates a 2D BSpline through a sequence of points with prescribed endpoint tangents.
+
+```swift
+public static func interpolate(
+    points: [SIMD2<Double>],
+    startTangent: SIMD2<Double>,
+    endTangent: SIMD2<Double>
+) -> Curve2D?
+```
+
+- **Parameters:** `points` — interpolation points; `startTangent`/`endTangent` — tangent directions at the first and last point.
+- **Returns:** Interpolated BSpline, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_Interpolate` (with tangent constraints).
+- **Example:**
+  ```swift
+  let pts: [SIMD2<Double>] = [.zero, SIMD2(5, 3), SIMD2(10, 0)]
+  if let curve = Curve2D.interpolate(
+      points: pts,
+      startTangent: SIMD2(1, 0),
+      endTangent: SIMD2(1, 0)) {
+      print(curve.domain)
+  }
+  ```
+
+---
+
+### `interpolatePeriodic(points:)`
+
+Interpolates a closed (periodic) 2D BSpline through a sequence of points.
+
+```swift
+public static func interpolatePeriodic(points: [SIMD2<Double>]) -> Curve2D?
+```
+
+- **Parameters:** `points` — interpolation points (do not repeat the first point at the end; the bridge closes the curve automatically).
+- **Returns:** Periodic BSpline, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_Interpolate` (periodic).
+- **Example:**
+  ```swift
+  let pts: [SIMD2<Double>] = [SIMD2(5, 0), SIMD2(0, 5), SIMD2(-5, 0), SIMD2(0, -5)]
+  if let loop = Curve2D.interpolatePeriodic(points: pts) {
+      print(loop.isClosed)
+  }
+  ```
+
+---
+
+### `approximate(points:degMin:degMax:continuity:tolerance:)`
+
+Approximates (fits) a 2D BSpline through a set of points with degree and continuity control.
+
+```swift
+public static func approximate(
+    points: [SIMD2<Double>],
+    degMin: Int = 3, degMax: Int = 8,
+    continuity: Int = 2, tolerance: Double = 1e-3
+) -> Curve2D?
+```
+
+- **Parameters:** `points` — sample points to approximate; `degMin`/`degMax` — degree range; `continuity` — desired continuity (0=C0, 1=C1, 2=C2); `tolerance` — maximum fitting error.
+- **Returns:** Approximated BSpline, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_PointsToBSpline`.
+- **Example:**
+  ```swift
+  let pts = (0..<20).map { i -> SIMD2<Double> in
+      let t = Double(i) / 19 * 2 * .pi
+      return SIMD2(cos(t) * 5, sin(t) * 3)
+  }
+  if let ellipseApprox = Curve2D.approximate(points: pts) {
+      print(ellipseApprox.degree)
+  }
+  ```
+
+---
+
+### `arcLength(from:to:)`
+
+Computes the arc length of this curve between two parameter values.
+
+```swift
+public func arcLength(from u1: Double, to u2: Double) -> Double
+```
+
+- **Parameters:** `u1`/`u2` — parameter range.
+- **Returns:** Arc length value (always non-negative when `u1 ≤ u2`).
+- **OCCT:** `GeomAdaptor_Curve` + `GCPnts_AbscissaPoint::Length`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5) {
+      let halfCircumference = circle.arcLength(from: 0, to: .pi)  // ≈ 15.71
+  }
+  ```
+
+---
+
+### `splitAtContinuity(continuity:tolerance:maxSegments:)`
+
+Splits this curve at discontinuities of the requested continuity level.
+
+```swift
+public func splitAtContinuity(
+    continuity: Int = 1, tolerance: Double = 1e-6,
+    maxSegments: Int = 32
+) -> [Curve2D]
+```
+
+- **Parameters:** `continuity` — 0=C0, 1=C1, 2=C2; `tolerance` — detection tolerance; `maxSegments` — upper bound on returned segments.
+- **Returns:** Array of sub-curves (one per continuous segment); may be empty if the curve has no discontinuities or the split fails.
+- **OCCT:** `Geom2dConvert::C0BSplineToArrayOfC1BSplineCurve` and related splitting utilities.
+- **Example:**
+  ```swift
+  if let composite = Curve2D.join([seg1, seg2, seg3]) {
+      let pieces = composite.splitAtContinuity(continuity: 1)
+  }
+  ```
+
+---
+
+## v0.80.0: Extrema, gce factories, GeomTools persistence
+
+Local extrema search, factory construction from `gce_Make*` classes, and serialization via `GeomTools_Curve2dSet`.
+
+---
+
+### `LocalExtrema2dResult`
+
+Struct returned by `locateExtremaCC(range1:other:range2:seedU:seedV:)`.
+
+```swift
+public struct LocalExtrema2dResult: Sendable {
+    public let isDone:         Bool
+    public let squareDistance: Double
+    public let point1:         SIMD2<Double>
+    public let param1:         Double
+    public let point2:         SIMD2<Double>
+    public let param2:         Double
+}
+```
+
+- `isDone` — `true` if a local extremum was found near the seed parameters.
+- `squareDistance` — squared distance at the local extremum.
+- `point1`/`point2` — closest points on each curve.
+- `param1`/`param2` — parameters at those points.
+
+---
+
+### `locateExtremaCC(range1:other:range2:seedU:seedV:)`
+
+Finds a local curve–curve extremum near given seed parameters using `Extrema_LocateExtCC2d`.
+
+```swift
+public func locateExtremaCC(
+    range1: ClosedRange<Double>? = nil,
+    other: Curve2D,
+    range2: ClosedRange<Double>? = nil,
+    seedU: Double, seedV: Double
+) -> LocalExtrema2dResult
+```
+
+When `range1`/`range2` are `nil`, the curve's full `domain` is used. Useful for finding a specific local minimum when the approximate location is known.
+
+- **Parameters:** `range1`/`range2` — optional parameter ranges on `self` and `other`; `seedU`/`seedV` — initial parameter guesses on `self` and `other`.
+- **Returns:** `LocalExtrema2dResult` (check `isDone` before using distance/point fields).
+- **OCCT:** `Extrema_LocateExtCC2d`.
+- **Example:**
+  ```swift
+  if let c1 = Curve2D.circle(center: .zero, radius: 3),
+     let c2 = Curve2D.circle(center: SIMD2(8, 0), radius: 2) {
+      let r = c1.locateExtremaCC(other: c2, seedU: 0, seedV: .pi)
+      if r.isDone { print(r.squareDistance.squareRoot()) }
+  }
+  ```
+
+---
+
+### `circleFromCenterRadius(center:radius:)`
+
+Creates a 2D circle from a center point and radius using `gce_MakeCirc2d`.
+
+```swift
+public static func circleFromCenterRadius(center: SIMD2<Double>, radius: Double) -> Curve2D?
+```
+
+- **Parameters:** `center` — center point; `radius` — radius.
+- **Returns:** `Curve2D` (circle), or `nil` on failure (e.g. radius ≤ 0).
+- **OCCT:** `gce_MakeCirc2d` (center + radius constructor).
+- **Example:**
+  ```swift
+  if let c = Curve2D.circleFromCenterRadius(center: SIMD2(1, 2), radius: 4) {
+      print(c.circleProperties.radius)  // 4.0
+  }
+  ```
+
+---
+
+### `circleThrough3Points(_:_:_:)`
+
+Creates a 2D circle through three points using `gce_MakeCirc2d`.
+
+```swift
+public static func circleThrough3Points(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>, _ p3: SIMD2<Double>
+) -> Curve2D?
+```
+
+- **Parameters:** `p1`, `p2`, `p3` — three non-collinear points.
+- **Returns:** `Curve2D` (circle), or `nil` if points are collinear or coincident.
+- **OCCT:** `gce_MakeCirc2d` (3-point constructor).
+- **Example:**
+  ```swift
+  if let c = Curve2D.circleThrough3Points(SIMD2(5,0), SIMD2(0,5), SIMD2(-5,0)) {
+      print(c.circleProperties.center)  // ≈ (0, 0)
+  }
+  ```
+
+---
+
+### `lineFrom2Points(_:_:)`
+
+Creates a 2D line through two points using `gce_MakeLin2d`.
+
+```swift
+public static func lineFrom2Points(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>) -> Curve2D?
+```
+
+- **Parameters:** `p1`, `p2` — two distinct points.
+- **Returns:** `Curve2D` (infinite line), or `nil` if points coincide.
+- **OCCT:** `gce_MakeLin2d` (2-point constructor).
+- **Example:**
+  ```swift
+  if let line = Curve2D.lineFrom2Points(SIMD2(0, 0), SIMD2(1, 1)) {
+      print(line.lineProperties.direction)  // ≈ (0.707, 0.707)
+  }
+  ```
+
+---
+
+### `lineFromEquation(a:b:c:)`
+
+Creates a 2D line from the equation `Ax + By + C = 0` using `gce_MakeLin2d`.
+
+```swift
+public static func lineFromEquation(a: Double, b: Double, c: Double) -> Curve2D?
+```
+
+- **Parameters:** `a`, `b`, `c` — line equation coefficients.
+- **Returns:** `Curve2D` (infinite line), or `nil` on failure (e.g. `a == 0 && b == 0`).
+- **OCCT:** `gce_MakeLin2d` (equation constructor).
+- **Example:**
+  ```swift
+  // y = 2 → 0·x + 1·y − 2 = 0
+  if let line = Curve2D.lineFromEquation(a: 0, b: 1, c: -2) {
+      print(line.lineProperties.location)  // ≈ (0, 2)
+  }
+  ```
+
+---
+
+### `ellipseFromCenterDir(center:direction:majorRadius:minorRadius:)`
+
+Creates a 2D ellipse from center, major-axis direction, and semi-radii using `gce_MakeElips2d`.
+
+```swift
+public static func ellipseFromCenterDir(
+    center: SIMD2<Double>, direction: SIMD2<Double>,
+    majorRadius: Double, minorRadius: Double
+) -> Curve2D?
+```
+
+- **Parameters:** `center` — center point; `direction` — unit direction of the major axis; `majorRadius`/`minorRadius` — semi-axes.
+- **Returns:** `Curve2D` (ellipse), or `nil` if radii are non-positive.
+- **OCCT:** `gce_MakeElips2d`.
+- **Example:**
+  ```swift
+  if let e = Curve2D.ellipseFromCenterDir(
+      center: .zero, direction: SIMD2(1, 0),
+      majorRadius: 5, minorRadius: 3) {
+      print(e.ellipseProperties.majorRadius)
+  }
+  ```
+
+---
+
+### `hyperbolaFromCenterDir(center:direction:majorRadius:minorRadius:)`
+
+Creates a 2D hyperbola from center, direction, and semi-radii using `gce_MakeHypr2d`.
+
+```swift
+public static func hyperbolaFromCenterDir(
+    center: SIMD2<Double>, direction: SIMD2<Double>,
+    majorRadius: Double, minorRadius: Double
+) -> Curve2D?
+```
+
+- **Parameters:** `center` — center; `direction` — unit direction of the real axis; `majorRadius`/`minorRadius` — real and imaginary semi-axes.
+- **Returns:** `Curve2D` (hyperbola), or `nil` on failure.
+- **OCCT:** `gce_MakeHypr2d`.
+- **Example:**
+  ```swift
+  if let h = Curve2D.hyperbolaFromCenterDir(
+      center: .zero, direction: SIMD2(1, 0),
+      majorRadius: 4, minorRadius: 3) {
+      print(h.hyperbolaProperties.eccentricity)
+  }
+  ```
+
+---
+
+### `parabolaFromCenterDir(center:direction:focal:)`
+
+Creates a 2D parabola from center, axis direction, and focal distance using `gce_MakeParab2d`.
+
+```swift
+public static func parabolaFromCenterDir(
+    center: SIMD2<Double>, direction: SIMD2<Double>,
+    focal: Double
+) -> Curve2D?
+```
+
+- **Parameters:** `center` — vertex of the parabola; `direction` — axis direction; `focal` — focal distance.
+- **Returns:** `Curve2D` (parabola), or `nil` on failure.
+- **OCCT:** `gce_MakeParab2d`.
+- **Example:**
+  ```swift
+  if let p = Curve2D.parabolaFromCenterDir(
+      center: .zero, direction: SIMD2(1, 0), focal: 2) {
+      print(p.parabolaProperties.focal)  // 2.0
+  }
+  ```
+
+---
+
+### `serializeCurves(_:)`
+
+Serializes an array of 2D curves to a string using `GeomTools_Curve2dSet`.
+
+```swift
+public static func serializeCurves(_ curves: [Curve2D]) -> String?
+```
+
+The resulting string can be stored to disk or passed across process boundaries, then deserialized with `deserializeCurves(_:)`.
+
+- **Parameters:** `curves` — array of curves to serialize.
+- **Returns:** Serialized string, or `nil` on failure.
+- **OCCT:** `GeomTools_Curve2dSet::Write`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.circle(center: .zero, radius: 5),
+     let data = Curve2D.serializeCurves([c]) {
+      try? data.write(toFile: "/tmp/curves.dat", atomically: true, encoding: .utf8)
+  }
+  ```
+
+---
+
+### `deserializeCurves(_:)`
+
+Deserializes an array of 2D curves from a string produced by `serializeCurves(_:)`.
+
+```swift
+public static func deserializeCurves(_ data: String) -> [Curve2D]?
+```
+
+- **Parameters:** `data` — serialized curve string.
+- **Returns:** Array of restored `Curve2D` values, or `nil` if the string is invalid or empty.
+- **OCCT:** `GeomTools_Curve2dSet::Read`.
+- **Example:**
+  ```swift
+  if let data = try? String(contentsOfFile: "/tmp/curves.dat", encoding: .utf8),
+     let curves = Curve2D.deserializeCurves(data) {
+      print(curves.count)
+  }
+  ```
+
+---
+
+## FairCurve
+
+Energy-minimising curves (`FairCurve_Batten`, `FairCurve_MinimalVariation`) that model the elastic behaviour of a physical spline.
+
+---
+
+### `FairCurveCode`
+
+Enum indicating the convergence status of a fair-curve computation.
+
+```swift
+public enum FairCurveCode: Int32, Sendable {
+    case ok               = 0
+    case notConverged     = 1
+    case infiniteSliding  = 2
+    case nullHeight       = 3
+}
+```
+
+---
+
+### `fairCurveBatten(p1:p2:height:slope:angle1:angle2:constraintOrder1:constraintOrder2:freeSliding:)`
+
+Creates a fair curve (batten) of minimal bending energy between two 2D points.
+
+```swift
+public static func fairCurveBatten(
+    p1: SIMD2<Double>, p2: SIMD2<Double>,
+    height: Double = 1.0, slope: Double = 0.0,
+    angle1: Double = 0.0, angle2: Double = 0.0,
+    constraintOrder1: Int = 1, constraintOrder2: Int = 1,
+    freeSliding: Bool = true
+) -> (curve: Curve2D, code: FairCurveCode)?
+```
+
+`constraintOrder` controls what is constrained at each endpoint: 0 = position only, 1 = position + tangent, 2 = position + tangent + curvature.
+
+- **Parameters:** `p1`/`p2` — endpoints; `height` — cross-section height; `slope` — slope parameter; `angle1`/`angle2` — tangent angle constraints (radians); `constraintOrder1`/`constraintOrder2` — constraint orders; `freeSliding` — whether the batten can slide freely.
+- **Returns:** `(curve, code)` tuple, or `nil` on internal failure. Check `code == .ok` before trusting the curve.
+- **OCCT:** `FairCurve_Batten::Compute`.
+- **Example:**
+  ```swift
+  if let result = Curve2D.fairCurveBatten(
+      p1: .zero, p2: SIMD2(10, 0),
+      height: 0.5, angle1: .pi / 6, angle2: -.pi / 6) {
+      if result.code == .ok {
+          print(result.curve.domain)
+      }
+  }
+  ```
+- **Note:** Returns `nil` (not `.notConverged`) only when the bridge itself fails; `.notConverged` is returned inside the tuple with a partially-computed curve.
+
+---
+
+### `fairCurveMinimalVariation(p1:p2:height:slope:angle1:angle2:constraintOrder1:constraintOrder2:freeSliding:physicalRatio:curvature1:curvature2:)`
+
+Creates a fair curve with minimal curvature variation between two 2D points.
+
+```swift
+public static func fairCurveMinimalVariation(
+    p1: SIMD2<Double>, p2: SIMD2<Double>,
+    height: Double = 1.0, slope: Double = 0.0,
+    angle1: Double = 0.0, angle2: Double = 0.0,
+    constraintOrder1: Int = 1, constraintOrder2: Int = 1,
+    freeSliding: Bool = true,
+    physicalRatio: Double = 0.0,
+    curvature1: Double = 0.0, curvature2: Double = 0.0
+) -> (curve: Curve2D, code: FairCurveCode)?
+```
+
+`physicalRatio` blends between pure batten (0) and minimal-variation (1) behaviour. Curvature constraints are active only when `constraintOrder >= 2`.
+
+- **Parameters:** `p1`/`p2` — endpoints; `height`/`slope` — physical parameters; `angle1`/`angle2` — tangent angles; `constraintOrder1`/`constraintOrder2` — constraint orders; `freeSliding`; `physicalRatio` — 0–1 blend; `curvature1`/`curvature2` — endpoint curvatures (used when order ≥ 2).
+- **Returns:** `(curve, code)` tuple, or `nil` on internal failure.
+- **OCCT:** `FairCurve_MinimalVariation::Compute`.
+- **Example:**
+  ```swift
+  if let result = Curve2D.fairCurveMinimalVariation(
+      p1: .zero, p2: SIMD2(10, 0),
+      physicalRatio: 0.5) {
+      if result.code == .ok {
+          let pts = result.curve.evaluateGrid([0, 0.25, 0.5, 0.75, 1.0])
+      }
+  }
+  ```
+
+---
+
+## Point2D Integration
+
+Bridge between `Curve2D` and the `Point2D` type for point-based construction and projection.
+
+---
+
+### `pointAt(_:)`
+
+Evaluates the curve at parameter `t`, returning a `Point2D`.
+
+```swift
+public func pointAt(_ t: Double) -> Point2D?
+```
+
+- **Parameters:** `t` — curve parameter.
+- **Returns:** `Point2D` at parameter `t`, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Value` via `Point2D` bridge.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let pt = circle.pointAt(0) {
+      print(pt)
+  }
+  ```
+
+---
+
+### `segment(from:to:)` _(Point2D overload)_
+
+Creates a line segment between two `Point2D` instances.
+
+```swift
+public static func segment(from p1: Point2D, to p2: Point2D) -> Curve2D?
+```
+
+Distinct from `segment(from:to:)` taking `SIMD2<Double>` parameters.
+
+- **Parameters:** `p1`/`p2` — `Point2D` endpoints.
+- **Returns:** `Curve2D` (trimmed line segment), or `nil` on failure.
+- **OCCT:** `GCE2d_MakeSegment`.
+- **Example:**
+  ```swift
+  if let a = someEdge.startPoint2D,
+     let b = someEdge.endPoint2D,
+     let seg = Curve2D.segment(from: a, to: b) {
+      print(seg.domain)
+  }
+  ```
+
+---
+
+### `project(_:)` _(Point2D overload)_
+
+Projects a `Point2D` onto this curve.
+
+```swift
+public func project(_ point: Point2D) -> (parameter: Double, distance: Double)?
+```
+
+- **Parameters:** `point` — the `Point2D` to project.
+- **Returns:** `(parameter, distance)` tuple, or `nil` on failure (negative distance sentinel).
+- **OCCT:** `Geom2dAPI_ProjectPointOnCurve`.
+- **Example:**
+  ```swift
+  if let circle = Curve2D.circle(center: .zero, radius: 5),
+     let pt = circle.pointAt(.pi / 4),
+     let proj = circle.project(pt) {
+      print(proj.parameter, proj.distance)  // distance ≈ 0
+  }
+  ```

--- a/docs/reference/Curve2D-Analytic-Types.md
+++ b/docs/reference/Curve2D-Analytic-Types.md
@@ -1,0 +1,1271 @@
+---
+title: Curve2D — Analytic Types
+parent: API Reference
+---
+
+# Curve2D — Analytic Types
+
+These members expose the type-specific properties of the five analytic 2D curve kinds (circle, ellipse, hyperbola, parabola, line) plus an offset-curve accessor, and provide B-spline/Bézier query and mutation methods; they are meaningful only when the underlying `Curve2D` wraps an OCCT object of the matching kind — accessing them on a mismatched type returns zero/nil/false silently. See the main `Curve2D` page for construction, evaluation, and general operations.
+
+## Topics
+
+- [BSpline Queries](#bspline-queries) · [Geom2d_Circle Properties](#geom2d_circle-properties-v01080) · [Geom2d_Ellipse Properties](#geom2d_ellipse-properties-v01080) · [Geom2d_Hyperbola Properties](#geom2d_hyperbola-properties-v01080) · [Geom2d_Parabola Properties](#geom2d_parabola-properties-v01080) · [Geom2d_Line Properties](#geom2d_line-properties-v01080) · [Geom2d_OffsetCurve Properties](#geom2d_offsetcurve-properties-v01080) · [Geom2d_BSplineCurve Deep Methods](#geom2d_bsplinecurve-deep-method-completion-v01250) · [Bezier 2D Completions](#bezier-2d-completions-v01260)
+
+---
+
+## BSpline Queries
+
+### `poleCount`
+
+The number of control points (poles), or `nil` if the curve is not a BSpline or Bézier.
+
+```swift
+public var poleCount: Int? { get }
+```
+
+- **Returns:** Pole count, or `nil` for non-spline curve kinds.
+- **OCCT:** `Geom2d_BSplineCurve::NbPoles` / `Geom2d_BezierCurve::NbPoles`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.bspline(points: [.zero, SIMD2(1, 0), SIMD2(1, 1)]) {
+      if let n = c.poleCount { /* n == 3 */ }
+  }
+  ```
+
+---
+
+### `poles`
+
+The control points (poles) as an array, or `nil` if the curve is not a BSpline or Bézier.
+
+```swift
+public var poles: [SIMD2<Double>]? { get }
+```
+
+- **Returns:** Array of 2D pole coordinates in OCCT 1-based order (index 0 = pole 1), or `nil`.
+- **OCCT:** `Geom2d_BSplineCurve::Pole(i)` / `Geom2d_BezierCurve::Pole(i)`.
+- **Example:**
+  ```swift
+  if let pts = curve.poles {
+      for p in pts { print(p) }
+  }
+  ```
+
+---
+
+### `degree`
+
+The curve degree, or `nil` if the curve is not a BSpline or Bézier.
+
+```swift
+public var degree: Int? { get }
+```
+
+- **Returns:** Polynomial degree (≥ 1), or `nil` for non-spline kinds.
+- **OCCT:** `Geom2d_BSplineCurve::Degree` / `Geom2d_BezierCurve::Degree`.
+- **Example:**
+  ```swift
+  if let deg = curve.degree { /* typically 3 for cubic */ }
+  ```
+
+---
+
+## Geom2d_Circle Properties (v0.108.0)
+
+### `circleProperties`
+
+Access 2D circle-specific properties. Meaningful only when the underlying curve is a `Geom2d_Circle`.
+
+```swift
+public var circleProperties: CircleProperties { get }
+```
+
+- **Returns:** A `CircleProperties` accessor backed by the same internal handle. Members return zero/false for non-circle curves.
+- **OCCT:** `Geom2d_Circle` — accessed via `Handle(Geom2d_Circle)::DownCast`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.circle(center: .zero, radius: 5) {
+      let props = c.circleProperties
+  }
+  ```
+
+---
+
+### `CircleProperties.radius`
+
+The radius of the 2D circle.
+
+```swift
+public var radius: Double { get }
+```
+
+- **Returns:** Radius in model units, or `0` if the curve is not a circle.
+- **OCCT:** `Geom2d_Circle::Radius`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.circle(center: .zero, radius: 5) {
+      let r = c.circleProperties.radius  // 5.0
+  }
+  ```
+
+---
+
+### `CircleProperties.setRadius(_:)`
+
+Mutates the circle's radius in place.
+
+```swift
+@discardableResult
+public func setRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new radius (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a circle or `r` is invalid.
+- **OCCT:** `Geom2d_Circle::SetRadius`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.circle(center: .zero, radius: 5) {
+      c.circleProperties.setRadius(8)
+  }
+  ```
+
+---
+
+### `CircleProperties.eccentricity`
+
+The eccentricity of the circle (always `0.0`).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** `0.0` for a valid circle, or `0` if the curve is not a circle.
+- **OCCT:** `Geom2d_Circle::Eccentricity`.
+- **Example:**
+  ```swift
+  let e = c.circleProperties.eccentricity  // 0.0
+  ```
+
+---
+
+### `CircleProperties.center`
+
+The centre point of the circle.
+
+```swift
+public var center: SIMD2<Double> { get }
+```
+
+- **Returns:** Centre in model space, or `.zero` if the curve is not a circle.
+- **OCCT:** `Geom2d_Circle::Circ2d().Location()`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.circle(center: SIMD2(1, 2), radius: 5) {
+      let ctr = c.circleProperties.center  // SIMD2(1, 2)
+  }
+  ```
+
+---
+
+### `CircleProperties.xAxis`
+
+The X axis of the circle's local coordinate system (position + direction).
+
+```swift
+public var xAxis: (position: SIMD2<Double>, direction: SIMD2<Double>) { get }
+```
+
+The position is a point on the axis; the direction is the unit X axis direction.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the curve is not a circle.
+- **OCCT:** `Geom2d_Circle::XAxis` → `gp_Ax2d::Location` + `gp_Ax2d::Direction`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.circle(center: .zero, radius: 5) {
+      let ax = c.circleProperties.xAxis
+      // ax.direction ≈ SIMD2(1, 0)
+  }
+  ```
+
+---
+
+## Geom2d_Ellipse Properties (v0.108.0)
+
+### `ellipseProperties`
+
+Access 2D ellipse-specific properties. Meaningful only when the underlying curve is a `Geom2d_Ellipse`.
+
+```swift
+public var ellipseProperties: EllipseProperties { get }
+```
+
+- **Returns:** An `EllipseProperties` accessor backed by the same internal handle.
+- **OCCT:** `Geom2d_Ellipse` — accessed via `Handle(Geom2d_Ellipse)::DownCast`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.ellipse(majorRadius: 5, minorRadius: 3) {
+      let props = c.ellipseProperties
+  }
+  ```
+
+---
+
+### `EllipseProperties.majorRadius`
+
+The major (semi-major) radius of the ellipse.
+
+```swift
+public var majorRadius: Double { get }
+```
+
+- **Returns:** Major radius in model units, or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom2d_Ellipse::MajorRadius`.
+- **Example:**
+  ```swift
+  let a = c.ellipseProperties.majorRadius
+  ```
+
+---
+
+### `EllipseProperties.minorRadius`
+
+The minor (semi-minor) radius of the ellipse.
+
+```swift
+public var minorRadius: Double { get }
+```
+
+- **Returns:** Minor radius in model units, or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom2d_Ellipse::MinorRadius`.
+- **Example:**
+  ```swift
+  let b = c.ellipseProperties.minorRadius
+  ```
+
+---
+
+### `EllipseProperties.setMajorRadius(_:)`
+
+Mutates the ellipse's major radius in place.
+
+```swift
+@discardableResult
+public func setMajorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new major radius (must be ≥ minor radius per OCCT).
+- **Returns:** `true` on success, `false` if the curve is not an ellipse or the value is invalid.
+- **OCCT:** `Geom2d_Ellipse::SetMajorRadius`.
+- **Example:**
+  ```swift
+  c.ellipseProperties.setMajorRadius(10)
+  ```
+
+---
+
+### `EllipseProperties.setMinorRadius(_:)`
+
+Mutates the ellipse's minor radius in place.
+
+```swift
+@discardableResult
+public func setMinorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new minor radius (must be ≤ major radius per OCCT).
+- **Returns:** `true` on success, `false` if the curve is not an ellipse or the value is invalid.
+- **OCCT:** `Geom2d_Ellipse::SetMinorRadius`.
+- **Example:**
+  ```swift
+  c.ellipseProperties.setMinorRadius(2)
+  ```
+
+---
+
+### `EllipseProperties.eccentricity`
+
+The eccentricity of the ellipse (`√(1 − (b/a)²)`).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** Eccentricity in [0, 1), or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom2d_Ellipse::Eccentricity`.
+- **Example:**
+  ```swift
+  let e = c.ellipseProperties.eccentricity
+  ```
+
+---
+
+### `EllipseProperties.focal`
+
+The focal distance of the ellipse (distance between the two foci).
+
+```swift
+public var focal: Double { get }
+```
+
+- **Returns:** Distance between foci (`2ae`), or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom2d_Ellipse::Focal`.
+- **Example:**
+  ```swift
+  let f = c.ellipseProperties.focal
+  ```
+
+---
+
+### `EllipseProperties.focus1`
+
+The first focus of the ellipse.
+
+```swift
+public var focus1: SIMD2<Double> { get }
+```
+
+- **Returns:** First focus point in model space, or `.zero` if the curve is not an ellipse.
+- **OCCT:** `Geom2d_Ellipse::Focus1`.
+- **Example:**
+  ```swift
+  let f1 = c.ellipseProperties.focus1
+  ```
+
+---
+
+## Geom2d_Hyperbola Properties (v0.108.0)
+
+### `hyperbolaProperties`
+
+Access 2D hyperbola-specific properties. Meaningful only when the underlying curve is a `Geom2d_Hyperbola`.
+
+```swift
+public var hyperbolaProperties: HyperbolaProperties { get }
+```
+
+- **Returns:** A `HyperbolaProperties` accessor backed by the same internal handle.
+- **OCCT:** `Geom2d_Hyperbola` — accessed via `Handle(Geom2d_Hyperbola)::DownCast`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.hyperbola(majorRadius: 4, minorRadius: 3) {
+      let props = c.hyperbolaProperties
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.majorRadius`
+
+The major radius of the hyperbola (real semi-axis).
+
+```swift
+public var majorRadius: Double { get }
+```
+
+- **Returns:** Major radius, or `0` if the curve is not a hyperbola.
+- **OCCT:** `Geom2d_Hyperbola::MajorRadius`.
+- **Example:**
+  ```swift
+  let a = c.hyperbolaProperties.majorRadius
+  ```
+
+---
+
+### `HyperbolaProperties.minorRadius`
+
+The minor radius of the hyperbola (imaginary semi-axis).
+
+```swift
+public var minorRadius: Double { get }
+```
+
+- **Returns:** Minor radius, or `0` if the curve is not a hyperbola.
+- **OCCT:** `Geom2d_Hyperbola::MinorRadius`.
+- **Example:**
+  ```swift
+  let b = c.hyperbolaProperties.minorRadius
+  ```
+
+---
+
+### `HyperbolaProperties.eccentricity`
+
+The eccentricity of the hyperbola (`√(1 + (b/a)²)`, always > 1).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** Eccentricity (> 1 for a valid hyperbola), or `0` if not a hyperbola.
+- **OCCT:** `Geom2d_Hyperbola::Eccentricity`.
+- **Example:**
+  ```swift
+  let e = c.hyperbolaProperties.eccentricity  // > 1.0
+  ```
+
+---
+
+### `HyperbolaProperties.focal`
+
+The focal distance of the hyperbola (distance between the two foci).
+
+```swift
+public var focal: Double { get }
+```
+
+- **Returns:** Distance between foci, or `0` if not a hyperbola.
+- **OCCT:** `Geom2d_Hyperbola::Focal`.
+- **Example:**
+  ```swift
+  let f = c.hyperbolaProperties.focal
+  ```
+
+---
+
+### `HyperbolaProperties.focus1`
+
+The first focus of the hyperbola.
+
+```swift
+public var focus1: SIMD2<Double> { get }
+```
+
+- **Returns:** First focus point, or `.zero` if not a hyperbola.
+- **OCCT:** `Geom2d_Hyperbola::Focus1`.
+- **Example:**
+  ```swift
+  let f1 = c.hyperbolaProperties.focus1
+  ```
+
+---
+
+## Geom2d_Parabola Properties (v0.108.0)
+
+### `parabolaProperties`
+
+Access 2D parabola-specific properties. Meaningful only when the underlying curve is a `Geom2d_Parabola`.
+
+```swift
+public var parabolaProperties: ParabolaProperties { get }
+```
+
+- **Returns:** A `ParabolaProperties` accessor backed by the same internal handle.
+- **OCCT:** `Geom2d_Parabola` — accessed via `Handle(Geom2d_Parabola)::DownCast`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.parabola(focal: 2) {
+      let props = c.parabolaProperties
+  }
+  ```
+
+---
+
+### `ParabolaProperties.focal`
+
+The focal distance of the parabola (distance from vertex to focus).
+
+```swift
+public var focal: Double { get }
+```
+
+- **Returns:** Focal distance, or `0` if the curve is not a parabola.
+- **OCCT:** `Geom2d_Parabola::Focal`.
+- **Example:**
+  ```swift
+  let f = c.parabolaProperties.focal
+  ```
+
+---
+
+### `ParabolaProperties.setFocal(_:)`
+
+Mutates the parabola's focal distance in place.
+
+```swift
+@discardableResult
+public func setFocal(_ f: Double) -> Bool
+```
+
+- **Parameters:** `f` — new focal distance (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a parabola or `f` is invalid.
+- **OCCT:** `Geom2d_Parabola::SetFocal`.
+- **Example:**
+  ```swift
+  c.parabolaProperties.setFocal(3)
+  ```
+
+---
+
+### `ParabolaProperties.focus`
+
+The focus point of the parabola.
+
+```swift
+public var focus: SIMD2<Double> { get }
+```
+
+- **Returns:** Focus point in model space, or `.zero` if not a parabola.
+- **OCCT:** `Geom2d_Parabola::Focus`.
+- **Example:**
+  ```swift
+  let fp = c.parabolaProperties.focus
+  ```
+
+---
+
+### `ParabolaProperties.eccentricity`
+
+The eccentricity of the parabola (always `1.0`).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** `1.0` for a valid parabola, or `0` if not a parabola.
+- **OCCT:** `Geom2d_Parabola::Eccentricity`.
+- **Example:**
+  ```swift
+  let e = c.parabolaProperties.eccentricity  // 1.0
+  ```
+
+---
+
+### `ParabolaProperties.parameter`
+
+The parameter of the parabola (equal to `2 * focal`).
+
+```swift
+public var parameter: Double { get }
+```
+
+- **Returns:** `2 * focal`, or `0` if not a parabola.
+- **OCCT:** `Geom2d_Parabola::Parameter`.
+- **Example:**
+  ```swift
+  let p = c.parabolaProperties.parameter  // == 2 * focal
+  ```
+
+---
+
+## Geom2d_Line Properties (v0.108.0)
+
+### `lineProperties`
+
+Access 2D line-specific properties. Meaningful only when the underlying curve is a `Geom2d_Line`.
+
+```swift
+public var lineProperties: LineProperties { get }
+```
+
+- **Returns:** A `LineProperties` accessor backed by the same internal handle.
+- **OCCT:** `Geom2d_Line` — accessed via `Handle(Geom2d_Line)::DownCast`.
+- **Example:**
+  ```swift
+  if let c = Curve2D.line(from: .zero, to: SIMD2(1, 0)) {
+      let props = c.lineProperties
+  }
+  ```
+
+---
+
+### `LineProperties.direction`
+
+The unit direction of the 2D line.
+
+```swift
+public var direction: SIMD2<Double> { get }
+```
+
+- **Returns:** Unit direction vector, or `.zero` if the curve is not a line.
+- **OCCT:** `Geom2d_Line::Direction` (via `gp_Lin2d::Direction`).
+- **Example:**
+  ```swift
+  let d = c.lineProperties.direction  // e.g. SIMD2(1, 0)
+  ```
+
+---
+
+### `LineProperties.location`
+
+The origin (location) of the 2D line.
+
+```swift
+public var location: SIMD2<Double> { get }
+```
+
+- **Returns:** A point on the line through which the parametric origin passes, or `.zero` if not a line.
+- **OCCT:** `Geom2d_Line::Location` (via `gp_Lin2d::Location`).
+- **Example:**
+  ```swift
+  let loc = c.lineProperties.location
+  ```
+
+---
+
+### `LineProperties.setDirection(_:)`
+
+Mutates the line's direction in place.
+
+```swift
+@discardableResult
+public func setDirection(_ d: SIMD2<Double>) -> Bool
+```
+
+- **Parameters:** `d` — new direction (need not be unit; OCCT normalises it).
+- **Returns:** `true` on success, `false` if the curve is not a line.
+- **OCCT:** `Geom2d_Line::SetDirection`.
+- **Example:**
+  ```swift
+  c.lineProperties.setDirection(SIMD2(0, 1))
+  ```
+
+---
+
+### `LineProperties.setLocation(_:)`
+
+Mutates the line's origin point in place.
+
+```swift
+@discardableResult
+public func setLocation(_ p: SIMD2<Double>) -> Bool
+```
+
+- **Parameters:** `p` — new location point.
+- **Returns:** `true` on success, `false` if the curve is not a line.
+- **OCCT:** `Geom2d_Line::SetLocation`.
+- **Example:**
+  ```swift
+  c.lineProperties.setLocation(SIMD2(1, 2))
+  ```
+
+---
+
+### `LineProperties.distance(to:)`
+
+The perpendicular distance from the line to a 2D point.
+
+```swift
+public func distance(to point: SIMD2<Double>) -> Double
+```
+
+- **Parameters:** `point` — the query point in model space.
+- **Returns:** Perpendicular distance; `0` if the curve is not a line.
+- **OCCT:** `Geom2d_Line::Distance` (via `gp_Lin2d::Distance`).
+- **Example:**
+  ```swift
+  let d = c.lineProperties.distance(to: SIMD2(0, 3))
+  ```
+
+---
+
+### `LineProperties.lin2d`
+
+The `gp_Lin2d` representation of the line (location + direction).
+
+```swift
+public var lin2d: (location: SIMD2<Double>, direction: SIMD2<Double>) { get }
+```
+
+Retrieves both the origin point and direction in a single call.
+
+- **Returns:** Tuple `(location, direction)`. Returns `(.zero, .zero)` if not a line.
+- **OCCT:** `Geom2d_Line::Lin2d` → `gp_Lin2d::Location` + `gp_Lin2d::Direction`.
+- **Example:**
+  ```swift
+  let lin = c.lineProperties.lin2d
+  // lin.location, lin.direction
+  ```
+
+---
+
+## Geom2d_OffsetCurve Properties (v0.108.0)
+
+### `offsetProperties`
+
+Access 2D offset-curve-specific properties. Meaningful only when the underlying curve is a `Geom2d_OffsetCurve`.
+
+```swift
+public var offsetProperties: OffsetProperties { get }
+```
+
+- **Returns:** An `OffsetProperties` accessor backed by the same internal handle.
+- **OCCT:** `Geom2d_OffsetCurve` — accessed via `Handle(Geom2d_OffsetCurve)::DownCast`.
+- **Example:**
+  ```swift
+  if let base = Curve2D.circle(center: .zero, radius: 5),
+     let oc = base.offset(by: 1) {
+      let props = oc.offsetProperties
+  }
+  ```
+
+---
+
+### `OffsetProperties.offset`
+
+The signed offset value.
+
+```swift
+public var offset: Double { get }
+```
+
+Positive values offset to the left of the curve direction; negative to the right.
+
+- **Returns:** Offset distance, or `0` if the curve is not an offset curve.
+- **OCCT:** `Geom2d_OffsetCurve::Offset`.
+- **Example:**
+  ```swift
+  let v = oc.offsetProperties.offset  // 1.0
+  ```
+
+---
+
+### `OffsetProperties.setOffset(_:)`
+
+Mutates the offset value in place.
+
+```swift
+@discardableResult
+public func setOffset(_ v: Double) -> Bool
+```
+
+- **Parameters:** `v` — new offset distance.
+- **Returns:** `true` on success, `false` if the curve is not an offset curve.
+- **OCCT:** `Geom2d_OffsetCurve::SetOffsetValue`.
+- **Example:**
+  ```swift
+  oc.offsetProperties.setOffset(2.0)
+  ```
+
+---
+
+### `OffsetProperties.basisCurve`
+
+The basis curve from which this offset curve was derived.
+
+```swift
+public var basisCurve: Curve2D? { get }
+```
+
+- **Returns:** The underlying `Curve2D`, or `nil` if the curve is not an offset curve or the basis handle is null.
+- **OCCT:** `Geom2d_OffsetCurve::BasisCurve`.
+- **Example:**
+  ```swift
+  if let basis = oc.offsetProperties.basisCurve {
+      let r = basis.circleProperties.radius
+  }
+  ```
+
+---
+
+## Geom2d_BSplineCurve Deep Method Completion (v0.125.0)
+
+### `bsplineLocalD0(u:fromK1:toK2:)`
+
+Evaluates the curve position within a specific knot span.
+
+```swift
+public func bsplineLocalD0(u: Double, fromK1: Int, toK2: Int) -> SIMD2<Double>
+```
+
+- **Parameters:** `u` — parameter value; `fromK1`, `toK2` — knot span indices (1-based, obtained from `bsplineLocateU`).
+- **Returns:** Point on the curve at `u` within the span. Returns `.zero` if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::LocalD0`.
+- **Example:**
+  ```swift
+  let (k1, k2) = curve.bsplineLocateU(u: 0.5, paramTol: 1e-7)
+  let pt = curve.bsplineLocalD0(u: 0.5, fromK1: k1, toK2: k2)
+  ```
+
+---
+
+### `bsplineLocalD1(u:fromK1:toK2:)`
+
+Evaluates position and first derivative within a knot span.
+
+```swift
+public func bsplineLocalD1(u: Double, fromK1: Int, toK2: Int)
+    -> (point: SIMD2<Double>, v1: SIMD2<Double>)
+```
+
+- **Parameters:** `u` — parameter; `fromK1`, `toK2` — knot span indices.
+- **Returns:** Tuple `(point, v1)` where `v1` is the first derivative vector.
+- **OCCT:** `Geom2d_BSplineCurve::LocalD1`.
+- **Example:**
+  ```swift
+  let (k1, k2) = curve.bsplineLocateU(u: 0.5, paramTol: 1e-7)
+  let r = curve.bsplineLocalD1(u: 0.5, fromK1: k1, toK2: k2)
+  // r.point, r.v1
+  ```
+
+---
+
+### `bsplineLocalD2(u:fromK1:toK2:)`
+
+Evaluates position and first two derivatives within a knot span.
+
+```swift
+public func bsplineLocalD2(u: Double, fromK1: Int, toK2: Int)
+    -> (point: SIMD2<Double>, v1: SIMD2<Double>, v2: SIMD2<Double>)
+```
+
+- **Parameters:** `u` — parameter; `fromK1`, `toK2` — knot span indices.
+- **Returns:** Tuple `(point, v1, v2)`.
+- **OCCT:** `Geom2d_BSplineCurve::LocalD2`.
+- **Example:**
+  ```swift
+  let r = curve.bsplineLocalD2(u: 0.5, fromK1: k1, toK2: k2)
+  ```
+
+---
+
+### `bsplineLocalD3(u:fromK1:toK2:)`
+
+Evaluates position and first three derivatives within a knot span.
+
+```swift
+public func bsplineLocalD3(u: Double, fromK1: Int, toK2: Int)
+    -> (point: SIMD2<Double>, v1: SIMD2<Double>, v2: SIMD2<Double>, v3: SIMD2<Double>)
+```
+
+- **Parameters:** `u` — parameter; `fromK1`, `toK2` — knot span indices.
+- **Returns:** Tuple `(point, v1, v2, v3)`.
+- **OCCT:** `Geom2d_BSplineCurve::LocalD3`.
+- **Example:**
+  ```swift
+  let r = curve.bsplineLocalD3(u: 0.5, fromK1: k1, toK2: k2)
+  ```
+
+---
+
+### `bsplineLocalDN(u:fromK1:toK2:n:)`
+
+Evaluates the N-th derivative within a knot span.
+
+```swift
+public func bsplineLocalDN(u: Double, fromK1: Int, toK2: Int, n: Int) -> SIMD2<Double>
+```
+
+- **Parameters:** `u` — parameter; `fromK1`, `toK2` — span indices; `n` — derivative order.
+- **Returns:** N-th derivative vector at `u` within the span.
+- **OCCT:** `Geom2d_BSplineCurve::LocalDN`.
+- **Example:**
+  ```swift
+  let d2 = curve.bsplineLocalDN(u: 0.5, fromK1: k1, toK2: k2, n: 2)
+  ```
+
+---
+
+### `bsplineLocalValue(u:fromK1:toK2:)`
+
+Evaluates only the curve value (no derivatives) within a knot span.
+
+```swift
+public func bsplineLocalValue(u: Double, fromK1: Int, toK2: Int) -> SIMD2<Double>
+```
+
+- **Parameters:** `u` — parameter; `fromK1`, `toK2` — span indices.
+- **Returns:** Point on the curve.
+- **OCCT:** `Geom2d_BSplineCurve::LocalValue`.
+- **Example:**
+  ```swift
+  let pt = curve.bsplineLocalValue(u: 0.5, fromK1: k1, toK2: k2)
+  ```
+
+---
+
+### `bsplineLocateU(u:paramTol:)`
+
+Locates the knot span indices enclosing a parameter value.
+
+```swift
+public func bsplineLocateU(u: Double, paramTol: Double) -> (i1: Int, i2: Int)
+```
+
+- **Parameters:** `u` — parameter to locate; `paramTol` — tolerance for coincidence with a knot.
+- **Returns:** Tuple `(i1, i2)` of 1-based knot indices bracketing `u`. Use as `fromK1`/`toK2` in local evaluation methods.
+- **OCCT:** `Geom2d_BSplineCurve::LocateU`.
+- **Example:**
+  ```swift
+  let (k1, k2) = curve.bsplineLocateU(u: 0.5, paramTol: 1e-7)
+  ```
+
+---
+
+### `bsplineFirstUKnotIndex`
+
+The index of the first knot (lower bound of the valid span range).
+
+```swift
+public var bsplineFirstUKnotIndex: Int { get }
+```
+
+- **Returns:** 1-based index of the first knot; `0` if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::FirstUKnotIndex`.
+- **Example:**
+  ```swift
+  let lo = curve.bsplineFirstUKnotIndex
+  ```
+
+---
+
+### `bsplineLastUKnotIndex`
+
+The index of the last knot (upper bound of the valid span range).
+
+```swift
+public var bsplineLastUKnotIndex: Int { get }
+```
+
+- **Returns:** 1-based index of the last knot; `0` if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::LastUKnotIndex`.
+- **Example:**
+  ```swift
+  let hi = curve.bsplineLastUKnotIndex
+  ```
+
+---
+
+### `bsplineKnot(index:)`
+
+Returns the knot value at a 1-based index.
+
+```swift
+public func bsplineKnot(index: Int) -> Double
+```
+
+- **Parameters:** `index` — 1-based knot index (valid range: `bsplineFirstUKnotIndex ... bsplineLastUKnotIndex`).
+- **Returns:** Knot parameter value; `0` if not a BSpline or index is out of range.
+- **OCCT:** `Geom2d_BSplineCurve::Knot`.
+- **Example:**
+  ```swift
+  let k = curve.bsplineKnot(index: 2)
+  ```
+
+---
+
+### `bsplineKnotDistribution`
+
+The knot distribution type of the BSpline.
+
+```swift
+public var bsplineKnotDistribution: Int { get }
+```
+
+- **Returns:** Integer code: `0` = NonUniform, `1` = Uniform, `2` = QuasiUniform, `3` = PiecewiseBezier; `0` also if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::KnotDistribution`.
+- **Example:**
+  ```swift
+  let dist = curve.bsplineKnotDistribution
+  ```
+
+---
+
+### `bsplineMultiplicity(index:)`
+
+The knot multiplicity at a 1-based index.
+
+```swift
+public func bsplineMultiplicity(index: Int) -> Int
+```
+
+- **Parameters:** `index` — 1-based knot index.
+- **Returns:** Multiplicity at the knot; `0` if not a BSpline or index is out of range.
+- **OCCT:** `Geom2d_BSplineCurve::Multiplicity`.
+- **Example:**
+  ```swift
+  let m = curve.bsplineMultiplicity(index: 1)
+  ```
+
+---
+
+### `bsplineMultiplicities`
+
+All knot multiplicities as an array.
+
+```swift
+public var bsplineMultiplicities: [Int] { get }
+```
+
+- **Returns:** Array of multiplicity values in knot order; empty if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::Multiplicities` (via repeated `Multiplicity`).
+- **Example:**
+  ```swift
+  let mults = curve.bsplineMultiplicities
+  ```
+
+---
+
+### `bsplineStartPoint`
+
+The start point of the BSpline (at first parameter).
+
+```swift
+public var bsplineStartPoint: SIMD2<Double> { get }
+```
+
+- **Returns:** Start point; `.zero` if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::StartPoint`.
+- **Example:**
+  ```swift
+  let s = curve.bsplineStartPoint
+  ```
+
+---
+
+### `bsplineEndPoint`
+
+The end point of the BSpline (at last parameter).
+
+```swift
+public var bsplineEndPoint: SIMD2<Double> { get }
+```
+
+- **Returns:** End point; `.zero` if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::EndPoint`.
+- **Example:**
+  ```swift
+  let e = curve.bsplineEndPoint
+  ```
+
+---
+
+### `bsplinePoles`
+
+All control points (poles) of the BSpline.
+
+```swift
+public var bsplinePoles: [SIMD2<Double>] { get }
+```
+
+Equivalent to iterating `Pole(i)` for `i` in 1...NbPoles. Prefer this over `poles` when you know the curve is a BSpline (avoids Bézier fallback).
+
+- **Returns:** Array of poles in order; empty if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::Pole(i)`.
+- **Example:**
+  ```swift
+  for p in curve.bsplinePoles { print(p) }
+  ```
+
+---
+
+### `bsplineIsClosed`
+
+Whether the BSpline is closed (start and end poles coincide within tolerance).
+
+```swift
+public var bsplineIsClosed: Bool { get }
+```
+
+- **Returns:** `true` if closed; `false` if open or not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::IsClosed`.
+- **Example:**
+  ```swift
+  if curve.bsplineIsClosed { /* closed loop */ }
+  ```
+
+---
+
+### `bsplineIsPeriodic`
+
+Whether the BSpline is periodic.
+
+```swift
+public var bsplineIsPeriodic: Bool { get }
+```
+
+- **Returns:** `true` if periodic; `false` otherwise.
+- **OCCT:** `Geom2d_BSplineCurve::IsPeriodic`.
+- **Example:**
+  ```swift
+  if curve.bsplineIsPeriodic { /* periodic */ }
+  ```
+
+---
+
+### `bsplineContinuity`
+
+The global geometric continuity of the BSpline.
+
+```swift
+public var bsplineContinuity: Int { get }
+```
+
+- **Returns:** Integer code: `0` = C0, `1` = C1, `2` = C2, `3` = C3, `4` = CN; `0` if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::Continuity`.
+- **Example:**
+  ```swift
+  let cont = curve.bsplineContinuity  // typically 2 (C2) for cubic B-splines
+  ```
+
+---
+
+### `bsplineIsCN(_:)`
+
+Tests whether the BSpline is at least C*n* continuous.
+
+```swift
+public func bsplineIsCN(_ n: Int) -> Bool
+```
+
+- **Parameters:** `n` — continuity order to test.
+- **Returns:** `true` if the curve is at least C*n*; `false` otherwise or if not a BSpline.
+- **OCCT:** `Geom2d_BSplineCurve::IsCN`.
+- **Example:**
+  ```swift
+  if curve.bsplineIsCN(2) { /* C2 continuous */ }
+  ```
+
+---
+
+## Bezier 2D Completions (v0.126.0)
+
+### `bezierInsertPoleAfter(_:point:)`
+
+Inserts a new pole after a given 1-based index in a 2D Bézier curve.
+
+```swift
+@discardableResult
+public func bezierInsertPoleAfter(_ index: Int, point: SIMD2<Double>) -> Bool
+```
+
+- **Parameters:** `index` — 1-based index after which to insert; `point` — new pole coordinates.
+- **Returns:** `true` on success, `false` if not a Bézier or `index` is out of range.
+- **OCCT:** `Geom2d_BezierCurve::InsertPoleAfter`.
+- **Example:**
+  ```swift
+  curve.bezierInsertPoleAfter(1, point: SIMD2(0.5, 0.5))
+  ```
+
+---
+
+### `bezierRemovePole(_:)`
+
+Removes the pole at a given 1-based index from a 2D Bézier curve.
+
+```swift
+@discardableResult
+public func bezierRemovePole(_ index: Int) -> Bool
+```
+
+Removing a pole lowers the degree by one. A Bézier must have at least 2 poles.
+
+- **Parameters:** `index` — 1-based pole index to remove.
+- **Returns:** `true` on success, `false` if not a Bézier or the operation would violate constraints.
+- **OCCT:** `Geom2d_BezierCurve::RemovePole`.
+- **Example:**
+  ```swift
+  curve.bezierRemovePole(2)
+  ```
+
+---
+
+### `bezierSegment(u1:u2:)`
+
+Restricts a 2D Bézier curve to the parameter interval `[u1, u2]` in place.
+
+```swift
+@discardableResult
+public func bezierSegment(u1: Double, u2: Double) -> Bool
+```
+
+The curve is reparametrized so the new domain is `[0, 1]`.
+
+- **Parameters:** `u1`, `u2` — start and end parameters within the current domain `[0, 1]`.
+- **Returns:** `true` on success, `false` if not a Bézier.
+- **OCCT:** `Geom2d_BezierCurve::Segment`.
+- **Example:**
+  ```swift
+  curve.bezierSegment(u1: 0.25, u2: 0.75)
+  ```
+
+---
+
+### `bezierIncreaseDegree(_:)`
+
+Raises the degree of a 2D Bézier curve (adds poles to preserve shape).
+
+```swift
+@discardableResult
+public func bezierIncreaseDegree(_ degree: Int) -> Bool
+```
+
+Degree elevation is exact — the curve shape does not change.
+
+- **Parameters:** `degree` — new degree (must be greater than the current degree).
+- **Returns:** `true` on success, `false` if not a Bézier or the requested degree is not higher.
+- **OCCT:** `Geom2d_BezierCurve::Increase`.
+- **Example:**
+  ```swift
+  curve.bezierIncreaseDegree(4)
+  ```
+
+---
+
+### `bezierStartPoint`
+
+The start point of the Bézier curve (first pole).
+
+```swift
+public var bezierStartPoint: SIMD2<Double> { get }
+```
+
+- **Returns:** Start point; `.zero` if not a Bézier.
+- **OCCT:** `Geom2d_BezierCurve::StartPoint`.
+- **Example:**
+  ```swift
+  let s = curve.bezierStartPoint
+  ```
+
+---
+
+### `bezierEndPoint`
+
+The end point of the Bézier curve (last pole).
+
+```swift
+public var bezierEndPoint: SIMD2<Double> { get }
+```
+
+- **Returns:** End point; `.zero` if not a Bézier.
+- **OCCT:** `Geom2d_BezierCurve::EndPoint`.
+- **Example:**
+  ```swift
+  let e = curve.bezierEndPoint
+  ```
+
+---
+
+### `bezierPoles`
+
+All control points of the 2D Bézier curve.
+
+```swift
+public var bezierPoles: [SIMD2<Double>] { get }
+```
+
+- **Returns:** Array of poles in order (index 0 = pole 1); empty if not a Bézier.
+- **OCCT:** `Geom2d_BezierCurve::Pole(i)`.
+- **Example:**
+  ```swift
+  for p in curve.bezierPoles { print(p) }
+  ```
+
+---
+
+### `bezierReverse()`
+
+Reverses the parametric direction of a 2D Bézier curve in place.
+
+```swift
+@discardableResult
+public func bezierReverse() -> Bool
+```
+
+Poles are reordered so the new start pole is the old end pole.
+
+- **Returns:** `true` on success, `false` if not a Bézier.
+- **OCCT:** `Geom2d_BezierCurve::Reverse`.
+- **Example:**
+  ```swift
+  curve.bezierReverse()
+  ```

--- a/docs/reference/Curve2D-Constraint-Solvers.md
+++ b/docs/reference/Curve2D-Constraint-Solvers.md
@@ -1,0 +1,1029 @@
+---
+title: Curve2D — Constraint Solvers
+parent: API Reference
+---
+
+# Curve2D — Constraint Solvers
+
+These APIs implement 2D geometric-constraint solving: qualifier-based circle and line construction (the GCC/Geom2dGcc tangency families), analytical and approximate bisector curves, and parallel hatch generation. For the core `Curve2D` type (primitive curves, BSpline/Bezier, evaluation, local properties), see the main `Curve2D` pages.
+
+## Topics
+
+- [Bisector (Geom2d)](#bisector-geom2d) · [Result Types](#result-types) · [Gcc Constraint Solver — Enums and Solution Types](#gcc-constraint-solver--enums-and-solution-types) · [Circle Construction (Geom2dGcc)](#circle-construction-geom2dgcc) · [Line Construction (Geom2dGcc)](#line-construction-geom2dgcc) · [Hatching](#hatching) · [GccAna Bisectors](#gccana-bisectors) · [GccAna Line Solvers](#gccana-line-solvers) · [GccAna Circle On-Constraint Solvers](#gccana-circle-on-constraint-solvers) · [Geom2dGcc Circle On-Constraint Solvers](#geom2dgcc-circle-on-constraint-solvers) · [Bisector_BisecAna](#bisector_bisecana)
+
+---
+
+## Bisector (Geom2d)
+
+These members live on `Curve2D` (instance methods) and wrap the approximate `Bisector_BisecCC` / `Bisector_BisecPC` classes. For the analytical counterpart see [Bisector_BisecAna](#bisector_bisecana) below.
+
+### `bisector(with:origin:side:)`
+
+Computes the approximate bisector curve between this curve and another.
+
+```swift
+public func bisector(with other: Curve2D, origin: SIMD2<Double>,
+                     side: Bool = true) -> Curve2D?
+```
+
+The bisector is the locus of points equidistant from both curves. `origin` steers which branch is returned; `side` controls orientation sense.
+
+- **Parameters:** `other` — the second curve; `origin` — point near the desired branch; `side` — orientation sense.
+- **Returns:** Bisector as a `Curve2D`, or `nil` on failure.
+- **OCCT:** `Bisector_BisecCC`.
+- **Example:**
+  ```swift
+  let c1 = Curve2D.circle(center: .zero, radius: 3)!
+  let c2 = Curve2D.circle(center: SIMD2(6, 0), radius: 2)!
+  if let bis = c1.bisector(with: c2, origin: SIMD2(3, 0)) {
+      let pt = bis.point(at: bis.parameterRange!.lowerBound)
+  }
+  ```
+
+---
+
+### `bisector(withPoint:origin:side:)`
+
+Computes the approximate bisector curve between a point and this curve.
+
+```swift
+public func bisector(withPoint point: SIMD2<Double>, origin: SIMD2<Double>,
+                     side: Bool = true) -> Curve2D?
+```
+
+- **Parameters:** `point` — the fixed point; `origin` — point near the desired branch; `side` — orientation sense.
+- **Returns:** Bisector as a `Curve2D`, or `nil` on failure.
+- **OCCT:** `Bisector_BisecPC`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 4)!
+  if let bis = circle.bisector(withPoint: SIMD2(8, 0), origin: SIMD2(4, 0)) {
+      let range = bis.parameterRange
+  }
+  ```
+
+---
+
+## Result Types
+
+Shared value types used by the constraint-solver and analysis APIs.
+
+### `Curve2DIntersection`
+
+An intersection point between two 2D curves.
+
+```swift
+public struct Curve2DIntersection: Sendable {
+    public let point: SIMD2<Double>
+    public let parameter1: Double
+    public let parameter2: Double
+}
+```
+
+- `point` — the 2D intersection point.
+- `parameter1` — curve parameter on the first curve.
+- `parameter2` — curve parameter on the second curve.
+
+---
+
+### `Curve2DProjection`
+
+A projection of a point onto a 2D curve.
+
+```swift
+public struct Curve2DProjection: Sendable {
+    public let point: SIMD2<Double>
+    public let parameter: Double
+    public let distance: Double
+}
+```
+
+- `point` — projected point on the curve.
+- `parameter` — curve parameter at the projected point.
+- `distance` — distance from the original point to the curve.
+
+---
+
+### `Curve2DExtremaResult`
+
+A distance extremum between two 2D curves.
+
+```swift
+public struct Curve2DExtremaResult: Sendable {
+    public let pointOnCurve1: SIMD2<Double>
+    public let pointOnCurve2: SIMD2<Double>
+    public let parameter1: Double
+    public let parameter2: Double
+    public let distance: Double
+}
+```
+
+---
+
+### `Curve2DSpecialPointType`
+
+Type of a special point on a curve.
+
+```swift
+public enum Curve2DSpecialPointType: Int32, Sendable {
+    case inflection    = 0
+    case minCurvature  = 1
+    case maxCurvature  = 2
+}
+```
+
+---
+
+### `Curve2DSpecialPoint`
+
+A special point (inflection or curvature extremum) on a 2D curve.
+
+```swift
+public struct Curve2DSpecialPoint: Sendable {
+    public let parameter: Double
+    public let type: Curve2DSpecialPointType
+}
+```
+
+---
+
+## Gcc Constraint Solver — Enums and Solution Types
+
+Types used throughout both the `Geom2dGcc` and `GccAna` solver families.
+
+### `Curve2DQualifier`
+
+Qualifier for how a curve participates in a geometric constraint.
+
+```swift
+public enum Curve2DQualifier: Int32, Sendable {
+    case unqualified = 0
+    case enclosing   = 1
+    case enclosed    = 2
+    case outside     = 3
+}
+```
+
+- `unqualified` — solution position relative to the curve is unconstrained.
+- `enclosing` — the solution circle encloses the qualified curve.
+- `enclosed` — the solution circle is enclosed by the qualified curve.
+- `outside` — the solution circle is outside the qualified curve.
+
+Pass these alongside curves in every `Curve2DGcc` solver call.
+
+---
+
+### `Curve2DCircleSolution`
+
+A circle solution from the Gcc constraint solver.
+
+```swift
+public struct Curve2DCircleSolution: Sendable {
+    public let center: SIMD2<Double>
+    public let radius: Double
+}
+```
+
+---
+
+### `Curve2DLineSolution`
+
+A line solution from the Gcc constraint solver.
+
+```swift
+public struct Curve2DLineSolution: Sendable {
+    public let point: SIMD2<Double>
+    public let direction: SIMD2<Double>
+}
+```
+
+- `point` — a point on the line.
+- `direction` — unit direction vector of the line.
+
+---
+
+### `Curve2DHatchSegment`
+
+A hatch segment produced by the hatching algorithm.
+
+```swift
+public struct Curve2DHatchSegment: Sendable {
+    public let start: SIMD2<Double>
+    public let end: SIMD2<Double>
+}
+```
+
+---
+
+## Circle Construction (Geom2dGcc)
+
+Members of `Curve2DGcc` that find circles satisfying tangency, point, and radius constraints using the `Geom2dGcc` package. All return an array of solutions (may be empty if no solution exists).
+
+### `Curve2DGcc.circlesTangentTo(_:_:_:_:_:_:tolerance:)`
+
+Finds circles tangent to three curves.
+
+```swift
+public static func circlesTangentTo(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    _ c3: Curve2D, _ q3: Curve2DQualifier = .unqualified,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+Up to 8 solutions (Apollonius problem for general curves).
+
+- **Parameters:** `c1`–`c3` — three curves; `q1`–`q3` — qualifiers for each; `tolerance` — solver tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2d3Tan`.
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentTo(
+      arcA, .outside, arcB, .outside, arcC, .outside)
+  for sol in circles {
+      print("center:", sol.center, "radius:", sol.radius)
+  }
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToTwoCurvesAndPoint(_:_:_:_:point:tolerance:)`
+
+Finds circles tangent to two curves and passing through a point.
+
+```swift
+public static func circlesTangentToTwoCurvesAndPoint(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    point: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `c1`, `c2` — curves; `q1`, `q2` — qualifiers; `point` — pass-through point; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2d3Tan` (two-curve + point variant).
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentToTwoCurvesAndPoint(
+      c1, .unqualified, c2, .unqualified, point: SIMD2(5, 0))
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentWithCenter(_:_:center:tolerance:)`
+
+Finds circles tangent to a curve with a given center point.
+
+```swift
+public static func circlesTangentWithCenter(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    center: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+The center is fixed; the radius is determined by the tangency condition.
+
+- **Parameters:** `curve` — the curve; `qualifier` — qualifier; `center` — fixed center; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2dTanCen`.
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentWithCenter(
+      ellipse, .outside, center: SIMD2(0, 8))
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToTwoCurves(_:_:_:_:radius:tolerance:)`
+
+Finds circles tangent to two curves with a given radius.
+
+```swift
+public static func circlesTangentToTwoCurves(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    radius: Double,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `c1`, `c2` — curves; `q1`, `q2` — qualifiers; `radius` — fixed radius; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2d2TanRad`.
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentToTwoCurves(
+      c1, .unqualified, c2, .unqualified, radius: 3)
+  for sol in circles {
+      print(sol.center, sol.radius)
+  }
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToPointWithRadius(_:_:point:radius:tolerance:)`
+
+Finds circles tangent to a curve, passing through a point, with a given radius.
+
+```swift
+public static func circlesTangentToPointWithRadius(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    point: SIMD2<Double>, radius: Double,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `curve` — tangent curve; `qualifier` — qualifier; `point` — pass-through point; `radius` — fixed radius; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2d2TanRad` (curve + point variant).
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentToPointWithRadius(
+      arc, .outside, point: SIMD2(10, 0), radius: 2)
+  ```
+
+---
+
+### `Curve2DGcc.circlesThroughTwoPoints(_:_:radius:tolerance:)`
+
+Finds circles through two points with a given radius.
+
+```swift
+public static func circlesThroughTwoPoints(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
+    radius: Double,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `p1`, `p2` — two pass-through points; `radius` — fixed radius; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions (0, 1, or 2).
+- **OCCT:** `Geom2dGcc_Circ2d2TanRad` (point + point variant).
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesThroughTwoPoints(
+      SIMD2(0, 0), SIMD2(4, 0), radius: 3)
+  ```
+
+---
+
+### `Curve2DGcc.circleThroughThreePoints(_:_:_:tolerance:)`
+
+Finds the circle through three points.
+
+```swift
+public static func circleThroughThreePoints(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>, _ p3: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+Returns at most one solution (the circumscribed circle of the three points).
+
+- **Parameters:** `p1`, `p2`, `p3` — three non-collinear points; `tolerance` — tolerance.
+- **Returns:** Array with 0 or 1 solution.
+- **OCCT:** `Geom2dGcc_Circ2d3Tan` (three-point variant).
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circleThroughThreePoints(
+      SIMD2(0, 0), SIMD2(4, 0), SIMD2(2, 3))
+  if let c = circles.first {
+      print("circumcircle radius:", c.radius)
+  }
+  ```
+
+---
+
+## Line Construction (Geom2dGcc)
+
+### `Curve2DGcc.linesTangentTo(_:_:_:_:tolerance:)`
+
+Finds lines tangent to two curves.
+
+```swift
+public static func linesTangentTo(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    tolerance: Double = 1e-6
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `c1`, `c2` — curves; `q1`, `q2` — qualifiers; `tolerance` — tolerance.
+- **Returns:** Array of line solutions.
+- **OCCT:** `Geom2dGcc_Lin2d2Tan`.
+- **Example:**
+  ```swift
+  let lines = Curve2DGcc.linesTangentTo(circleA, .outside, circleB, .outside)
+  for l in lines {
+      print("through:", l.point, "dir:", l.direction)
+  }
+  ```
+
+---
+
+### `Curve2DGcc.linesTangentToPoint(_:_:point:tolerance:)`
+
+Finds lines tangent to a curve and passing through a point.
+
+```swift
+public static func linesTangentToPoint(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    point: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `curve` — the curve; `qualifier` — qualifier; `point` — pass-through point; `tolerance` — tolerance.
+- **Returns:** Array of line solutions (typically 0 or 2 for a circle).
+- **OCCT:** `Geom2dGcc_Lin2d2Tan` (curve + point variant).
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 4)!
+  let tangents = Curve2DGcc.linesTangentToPoint(circle, .outside, point: SIMD2(10, 0))
+  ```
+
+---
+
+## Hatching
+
+### `Curve2DGcc.hatch(boundaries:origin:direction:spacing:tolerance:)`
+
+Generates parallel hatch lines clipped to a region bounded by curves.
+
+```swift
+public static func hatch(boundaries: [Curve2D],
+                         origin: SIMD2<Double> = .zero,
+                         direction: SIMD2<Double> = SIMD2(1, 0),
+                         spacing: Double,
+                         tolerance: Double = 1e-6) -> [Curve2DHatchSegment]
+```
+
+Each `Curve2DHatchSegment` is a line segment clipped to lie inside the boundary region. The boundary curves must form a closed region; the algorithm uses `Geom2dHatch_Hatcher` internally.
+
+- **Parameters:** `boundaries` — closed boundary curves defining the hatch region; `origin` — origin point of the hatch pattern; `direction` — hatch line direction (unit vector); `spacing` — distance between hatch lines; `tolerance` — intersection tolerance.
+- **Returns:** Array of hatch segments inside the boundary.
+- **OCCT:** `Geom2dHatch_Hatcher` + `Geom2dHatch_Intersector`.
+- **Example:**
+  ```swift
+  let boundary = [Curve2D.rectangle(center: .zero, width: 10, height: 8)!]
+  let hatches = Curve2DGcc.hatch(
+      boundaries: boundary,
+      direction: SIMD2(1, 1) / sqrt(2),
+      spacing: 1.0)
+  for seg in hatches {
+      print(seg.start, "→", seg.end)
+  }
+  ```
+
+---
+
+## GccAna Bisectors
+
+`GccAnaBisector` provides closed-form (exact) bisectors between elementary 2D shapes: points, lines (as point+direction), and circles (as center+radius). Results use `Curve2DLineSolution` for line bisectors and `BisecSolution` for conic bisectors.
+
+### `BisecType`
+
+Classification of a bisector curve type.
+
+```swift
+public enum BisecType: Int32, Sendable {
+    case line      = 0
+    case circle    = 1
+    case ellipse   = 2
+    case hyperbola = 3
+    case parabola  = 4
+    case point     = 5
+}
+```
+
+---
+
+### `BisecSolution`
+
+A bisector solution from an analytical bisector computation.
+
+```swift
+public struct BisecSolution: Sendable {
+    public let type: BisecType
+    public let position: SIMD2<Double>
+    public let secondary: SIMD2<Double>
+    public let radius: Double
+}
+```
+
+- `type` — geometric type of the bisector curve.
+- `position` — primary position: center for circles, a point on the line for lines, focus for conics.
+- `secondary` — secondary values: direction for lines, semi-axes for conics.
+- `radius` — radius for circle-type bisectors; 0 otherwise.
+
+---
+
+### `GccAnaBisector.ofPoints(_:_:)`
+
+Computes the perpendicular bisector of two points.
+
+```swift
+public static func ofPoints(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>
+) -> Curve2DLineSolution?
+```
+
+Returns the line equidistant from both points.
+
+- **Parameters:** `p1`, `p2` — the two points.
+- **Returns:** A `Curve2DLineSolution` for the perpendicular bisector line, or `nil` on failure.
+- **OCCT:** `GccAna_Pnt2dBisec`.
+- **Example:**
+  ```swift
+  if let bis = GccAnaBisector.ofPoints(SIMD2(0, 0), SIMD2(4, 0)) {
+      print("midpoint on bisector:", bis.point) // (2, 0)
+  }
+  ```
+
+---
+
+### `GccAnaBisector.ofLines(line1Point:line1Dir:line2Point:line2Dir:)`
+
+Computes the angle bisectors of two lines.
+
+```swift
+public static func ofLines(
+    line1Point: SIMD2<Double>, line1Dir: SIMD2<Double>,
+    line2Point: SIMD2<Double>, line2Dir: SIMD2<Double>
+) -> [Curve2DLineSolution]
+```
+
+Two intersecting lines have two angle bisectors (interior and exterior). Returns up to 2 solutions.
+
+- **Parameters:** `line1Point`, `line1Dir` — point and direction of line 1; `line2Point`, `line2Dir` — point and direction of line 2.
+- **Returns:** Array of up to 2 bisector lines.
+- **OCCT:** `GccAna_Lin2dBisec`.
+- **Example:**
+  ```swift
+  let bisectors = GccAnaBisector.ofLines(
+      line1Point: .zero, line1Dir: SIMD2(1, 0),
+      line2Point: .zero, line2Dir: SIMD2(0, 1))
+  // Two bisectors at 45° and 135°
+  ```
+
+---
+
+### `GccAnaBisector.ofLineAndPoint(linePoint:lineDir:point:)`
+
+Computes the bisector between a line and a point.
+
+```swift
+public static func ofLineAndPoint(
+    linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    point: SIMD2<Double>
+) -> BisecSolution?
+```
+
+The bisector is typically a parabola with the point as focus and the line as directrix.
+
+- **Parameters:** `linePoint`, `lineDir` — point and direction of the line; `point` — the fixed point.
+- **Returns:** A `BisecSolution` (usually `type == .parabola`), or `nil` on failure.
+- **OCCT:** `GccAna_LinPnt2dBisec`.
+- **Example:**
+  ```swift
+  if let sol = GccAnaBisector.ofLineAndPoint(
+      linePoint: SIMD2(0, -2), lineDir: SIMD2(1, 0),
+      point: SIMD2(0, 2)
+  ) {
+      print("bisector type:", sol.type) // .parabola
+  }
+  ```
+
+---
+
+### `GccAnaBisector.ofCircles(center1:radius1:center2:radius2:)`
+
+Computes bisectors between two circles (up to 4 solutions).
+
+```swift
+public static func ofCircles(
+    center1: SIMD2<Double>, radius1: Double,
+    center2: SIMD2<Double>, radius2: Double
+) -> [BisecSolution]
+```
+
+- **Parameters:** `center1`, `radius1` — first circle; `center2`, `radius2` — second circle.
+- **Returns:** Array of up to 4 bisector curves.
+- **OCCT:** `GccAna_Circ2dBisec`.
+- **Example:**
+  ```swift
+  let bisectors = GccAnaBisector.ofCircles(
+      center1: .zero, radius1: 3,
+      center2: SIMD2(8, 0), radius2: 2)
+  for b in bisectors { print(b.type, b.position) }
+  ```
+
+---
+
+### `GccAnaBisector.ofCircleAndLine(center:radius:linePoint:lineDir:)`
+
+Computes bisectors between a circle and a line.
+
+```swift
+public static func ofCircleAndLine(
+    center: SIMD2<Double>, radius: Double,
+    linePoint: SIMD2<Double>, lineDir: SIMD2<Double>
+) -> [BisecSolution]
+```
+
+- **Parameters:** `center`, `radius` — the circle; `linePoint`, `lineDir` — point and direction of the line.
+- **Returns:** Array of bisector curve solutions.
+- **OCCT:** `GccAna_CircLin2dBisec`.
+- **Example:**
+  ```swift
+  let bisectors = GccAnaBisector.ofCircleAndLine(
+      center: SIMD2(5, 0), radius: 2,
+      linePoint: .zero, lineDir: SIMD2(0, 1))
+  ```
+
+---
+
+### `GccAnaBisector.ofCircleAndPoint(center:radius:point:)`
+
+Computes bisectors between a circle and a point.
+
+```swift
+public static func ofCircleAndPoint(
+    center: SIMD2<Double>, radius: Double,
+    point: SIMD2<Double>
+) -> [BisecSolution]
+```
+
+- **Parameters:** `center`, `radius` — the circle; `point` — the fixed point.
+- **Returns:** Array of bisector curve solutions.
+- **OCCT:** `GccAna_CircPnt2dBisec`.
+- **Example:**
+  ```swift
+  let bisectors = GccAnaBisector.ofCircleAndPoint(
+      center: .zero, radius: 4, point: SIMD2(10, 0))
+  ```
+
+---
+
+## GccAna Line Solvers
+
+Extensions on `Curve2DGcc` that use the analytical `GccAna` package for exact line construction between elementary shapes (points and circles represented as scalars, not `Curve2D` handles).
+
+### `Curve2DGcc.lineParallelThrough(point:parallelTo:lineDir:)`
+
+Line through a point parallel to a reference line.
+
+```swift
+public static func lineParallelThrough(
+    point: SIMD2<Double>,
+    parallelTo linePoint: SIMD2<Double>, lineDir: SIMD2<Double>
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `point` — the pass-through point; `linePoint`, `lineDir` — reference line.
+- **Returns:** Array with one solution (the unique parallel line through the point).
+- **OCCT:** `GccAna_Lin2dTanPar`.
+- **Example:**
+  ```swift
+  let lines = Curve2DGcc.lineParallelThrough(
+      point: SIMD2(0, 3),
+      parallelTo: .zero, lineDir: SIMD2(1, 0))
+  ```
+
+---
+
+### `Curve2DGcc.linesTangentParallel(circleCenter:circleRadius:qualifier:parallelTo:lineDir:)`
+
+Lines tangent to a circle, parallel to a reference line.
+
+```swift
+public static func linesTangentParallel(
+    circleCenter: SIMD2<Double>, circleRadius: Double,
+    qualifier: Curve2DQualifier = .unqualified,
+    parallelTo linePoint: SIMD2<Double>, lineDir: SIMD2<Double>
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `circleCenter`, `circleRadius` — the circle; `qualifier` — qualifier; `linePoint`, `lineDir` — reference line direction.
+- **Returns:** Array of parallel tangent lines (0 or 2 solutions).
+- **OCCT:** `GccAna_Lin2dTanPar`.
+- **Example:**
+  ```swift
+  let lines = Curve2DGcc.linesTangentParallel(
+      circleCenter: .zero, circleRadius: 3, qualifier: .outside,
+      parallelTo: .zero, lineDir: SIMD2(1, 0))
+  ```
+
+---
+
+### `Curve2DGcc.linePerpendicularThrough(point:perpendicularTo:lineDir:)`
+
+Line through a point perpendicular to a reference line.
+
+```swift
+public static func linePerpendicularThrough(
+    point: SIMD2<Double>,
+    perpendicularTo linePoint: SIMD2<Double>, lineDir: SIMD2<Double>
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `point` — the pass-through point; `linePoint`, `lineDir` — reference line.
+- **Returns:** Array with one solution.
+- **OCCT:** `GccAna_Lin2dTanPer`.
+- **Example:**
+  ```swift
+  let lines = Curve2DGcc.linePerpendicularThrough(
+      point: SIMD2(3, 5),
+      perpendicularTo: .zero, lineDir: SIMD2(1, 0))
+  ```
+
+---
+
+### `Curve2DGcc.linesTangentPerpendicular(circleCenter:circleRadius:qualifier:perpendicularTo:lineDir:)`
+
+Lines tangent to a circle, perpendicular to a reference line.
+
+```swift
+public static func linesTangentPerpendicular(
+    circleCenter: SIMD2<Double>, circleRadius: Double,
+    qualifier: Curve2DQualifier = .unqualified,
+    perpendicularTo linePoint: SIMD2<Double>, lineDir: SIMD2<Double>
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `circleCenter`, `circleRadius` — the circle; `qualifier` — qualifier; `linePoint`, `lineDir` — reference line direction.
+- **Returns:** Array of perpendicular tangent lines.
+- **OCCT:** `GccAna_Lin2dTanPer`.
+- **Example:**
+  ```swift
+  let lines = Curve2DGcc.linesTangentPerpendicular(
+      circleCenter: .zero, circleRadius: 3,
+      perpendicularTo: .zero, lineDir: SIMD2(1, 0))
+  ```
+
+---
+
+### `Curve2DGcc.lineAtAngleThrough(point:referenceLine:lineDir:angle:)`
+
+Line through a point at a given angle to a reference line.
+
+```swift
+public static func lineAtAngleThrough(
+    point: SIMD2<Double>,
+    referenceLine linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    angle: Double
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `point` — pass-through point; `linePoint`, `lineDir` — reference line; `angle` — angle in radians from the reference line.
+- **Returns:** Array of line solutions.
+- **OCCT:** `GccAna_Lin2dTanObl`.
+- **Example:**
+  ```swift
+  let lines = Curve2DGcc.lineAtAngleThrough(
+      point: SIMD2(0, 4),
+      referenceLine: .zero, lineDir: SIMD2(1, 0),
+      angle: .pi / 4)
+  ```
+
+---
+
+### `Curve2DGcc.linesTangentAtAngle(_:_:referenceLine:lineDir:angle:tolerance:)`
+
+Lines tangent to a curve at a given angle to a reference line (Geom2dGcc iterative solver).
+
+```swift
+public static func linesTangentAtAngle(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    referenceLine linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    angle: Double, tolerance: Double = 1e-6
+) -> [Curve2DLineSolution]
+```
+
+Unlike `lineAtAngleThrough`, this accepts an arbitrary `Curve2D` (not just a point) and uses the iterative `Geom2dGcc` solver.
+
+- **Parameters:** `curve` — the tangent curve; `qualifier` — qualifier; `linePoint`, `lineDir` — reference line; `angle` — angle in radians; `tolerance` — solver tolerance.
+- **Returns:** Array of line solutions.
+- **OCCT:** `Geom2dGcc_Lin2dTanObl`.
+- **Example:**
+  ```swift
+  let ellipse = Curve2D.ellipse(center: .zero, majorRadius: 5, minorRadius: 3)!
+  let lines = Curve2DGcc.linesTangentAtAngle(
+      ellipse, .outside,
+      referenceLine: .zero, lineDir: SIMD2(1, 0),
+      angle: .pi / 3)
+  ```
+
+---
+
+## GccAna Circle On-Constraint Solvers
+
+Extensions on `Curve2DGcc` that constrain the circle center to lie on an additional line or circle.
+
+### `Curve2DGcc.circlesTangentToTwoLinesOnLine(line1Point:line1Dir:q1:line2Point:line2Dir:q2:centerOnPoint:centerOnDir:tolerance:)`
+
+Finds circles tangent to two lines with center constrained to a third line.
+
+```swift
+public static func circlesTangentToTwoLinesOnLine(
+    line1Point: SIMD2<Double>, line1Dir: SIMD2<Double>, q1: Curve2DQualifier = .unqualified,
+    line2Point: SIMD2<Double>, line2Dir: SIMD2<Double>, q2: Curve2DQualifier = .unqualified,
+    centerOnPoint: SIMD2<Double>, centerOnDir: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `line1Point`, `line1Dir`, `q1` — first tangent line and qualifier; `line2Point`, `line2Dir`, `q2` — second tangent line and qualifier; `centerOnPoint`, `centerOnDir` — center-constraint line; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions with center on the specified line.
+- **OCCT:** `GccAna_Circ2d2TanOn`.
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentToTwoLinesOnLine(
+      line1Point: .zero, line1Dir: SIMD2(1, 0), q1: .unqualified,
+      line2Point: .zero, line2Dir: SIMD2(0, 1), q2: .unqualified,
+      centerOnPoint: SIMD2(2, 0), centerOnDir: SIMD2(0, 1))
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToLineOnLineWithRadius(linePoint:lineDir:qualifier:centerOnPoint:centerOnDir:radius:tolerance:)`
+
+Finds circles tangent to a line, with center on a second line, and a given radius.
+
+```swift
+public static func circlesTangentToLineOnLineWithRadius(
+    linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
+    qualifier: Curve2DQualifier = .unqualified,
+    centerOnPoint: SIMD2<Double>, centerOnDir: SIMD2<Double>,
+    radius: Double, tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `linePoint`, `lineDir` — tangent line; `qualifier` — qualifier; `centerOnPoint`, `centerOnDir` — center-constraint line; `radius` — fixed radius; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `GccAna_Circ2dTanOnRad`.
+- **Example:**
+  ```swift
+  let circles = Curve2DGcc.circlesTangentToLineOnLineWithRadius(
+      linePoint: .zero, lineDir: SIMD2(1, 0),
+      centerOnPoint: SIMD2(0, 3), centerOnDir: SIMD2(1, 0),
+      radius: 3)
+  ```
+
+---
+
+## Geom2dGcc Circle On-Constraint Solvers
+
+Iterative on-constraint solvers that accept arbitrary `Curve2D` objects (not restricted to lines/circles).
+
+### `Curve2DGcc.circlesTangentToTwoCurvesOnCurve(_:_:_:_:centerOn:tolerance:initParam1:initParam2:initParamOn:)`
+
+Finds circles tangent to two curves with the center constrained to a third curve.
+
+```swift
+public static func circlesTangentToTwoCurvesOnCurve(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    centerOn: Curve2D,
+    tolerance: Double = 1e-6,
+    initParam1: Double = 0, initParam2: Double = 0, initParamOn: Double = 0
+) -> [Curve2DCircleSolution]
+```
+
+The iterative solver uses starting parameters `initParam1`, `initParam2`, `initParamOn` for convergence near a desired solution.
+
+- **Parameters:** `c1`, `c2` — tangent curves; `q1`, `q2` — qualifiers; `centerOn` — center-constraint curve; `tolerance` — solver tolerance; `initParam1`, `initParam2`, `initParamOn` — initial parameter guesses.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2d2TanOn`.
+- **Example:**
+  ```swift
+  let rail = Curve2D.interpolate(
+      points: [SIMD2(0,5), SIMD2(5,5), SIMD2(10,5)])!
+  let circles = Curve2DGcc.circlesTangentToTwoCurvesOnCurve(
+      arcA, .outside, arcB, .outside, centerOn: rail)
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentOnCurveWithRadius(_:_:centerOn:radius:tolerance:)`
+
+Finds circles tangent to a curve, with the center on a second curve, and a given radius.
+
+```swift
+public static func circlesTangentOnCurveWithRadius(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    centerOn: Curve2D,
+    radius: Double, tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `curve` — tangent curve; `qualifier` — qualifier; `centerOn` — center-constraint curve; `radius` — fixed radius; `tolerance` — tolerance.
+- **Returns:** Array of circle solutions.
+- **OCCT:** `Geom2dGcc_Circ2dTanOnRad`.
+- **Example:**
+  ```swift
+  let spine = Curve2D.interpolate(
+      points: [SIMD2(0, 4), SIMD2(5, 4), SIMD2(10, 4)])!
+  let circles = Curve2DGcc.circlesTangentOnCurveWithRadius(
+      arc, .outside, centerOn: spine, radius: 2)
+  ```
+
+---
+
+## Bisector_BisecAna
+
+Instance methods on `Curve2D` that compute exact analytical bisectors via the OCCT `Bisector_BisecAna` class. Unlike the approximate `Bisector_BisecCC`/`BisecPC` methods above, these produce analytical conic curves.
+
+### `bisector(with:referencePoint:direction1:direction2:sense:tolerance:)`
+
+Computes the analytical bisector between this curve and another.
+
+```swift
+public func bisector(
+    with other: Curve2D,
+    referencePoint: SIMD2<Double>,
+    direction1: SIMD2<Double>, direction2: SIMD2<Double>,
+    sense: Double = 1.0, tolerance: Double = 1e-6
+) -> Curve2D?
+```
+
+The bisector is the locus of points equidistant from both curves. `referencePoint` steers the solver toward a specific branch; `direction1` and `direction2` are tangent directions of each curve at the reference.
+
+- **Parameters:** `other` — second curve; `referencePoint` — point near the desired branch; `direction1` — tangent of this curve at reference; `direction2` — tangent of `other` at reference; `sense` — orientation sense (1.0 or -1.0); `tolerance` — geometric tolerance.
+- **Returns:** Bisector as a `Curve2D` (analytical conic), or `nil` on failure.
+- **OCCT:** `Bisector_BisecAna` (curve–curve constructor).
+- **Example:**
+  ```swift
+  let c1 = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0))!
+  let c2 = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(0, 1))!
+  if let bis = c1.bisector(
+      with: c2,
+      referencePoint: SIMD2(1, 1),
+      direction1: SIMD2(1, 0), direction2: SIMD2(0, 1)
+  ) {
+      let pt = bis.point(at: bis.parameterRange!.lowerBound)
+  }
+  ```
+- **Note:** This overload's label set (`with:referencePoint:direction1:direction2:`) distinguishes it from the approximate `bisector(with:origin:side:)` overload.
+
+---
+
+### `bisector(withPoint:referencePoint:direction1:direction2:sense:tolerance:)`
+
+Computes the analytical bisector between this curve and a point.
+
+```swift
+public func bisector(
+    withPoint point: SIMD2<Double>,
+    referencePoint: SIMD2<Double>,
+    direction1: SIMD2<Double>, direction2: SIMD2<Double>,
+    sense: Double = 1.0, tolerance: Double = 1e-6
+) -> Curve2D?
+```
+
+- **Parameters:** `point` — the fixed point; `referencePoint` — steering point; `direction1` — curve tangent at reference; `direction2` — direction from `point` at reference; `sense` — orientation sense; `tolerance` — tolerance.
+- **Returns:** Bisector as a `Curve2D`, or `nil` on failure.
+- **OCCT:** `Bisector_BisecAna` (curve–point constructor).
+- **Example:**
+  ```swift
+  let arc = Curve2D.circle(center: .zero, radius: 3)!
+  if let bis = arc.bisector(
+      withPoint: SIMD2(8, 0),
+      referencePoint: SIMD2(4, 0),
+      direction1: SIMD2(0, 1), direction2: SIMD2(-1, 0)
+  ) {
+      let range = bis.parameterRange
+  }
+  ```
+
+---
+
+### `Curve2D.bisectorBetweenPoints(_:_:referencePoint:direction1:direction2:sense:tolerance:)`
+
+Computes the analytical perpendicular bisector between two points (result is a line).
+
+```swift
+public static func bisectorBetweenPoints(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
+    referencePoint: SIMD2<Double>,
+    direction1: SIMD2<Double>, direction2: SIMD2<Double>,
+    sense: Double = 1.0, tolerance: Double = 1e-6
+) -> Curve2D?
+```
+
+- **Parameters:** `p1`, `p2` — the two points; `referencePoint` — steering point; `direction1` — direction from `p1` at reference; `direction2` — direction from `p2` at reference; `sense` — orientation sense; `tolerance` — tolerance.
+- **Returns:** Bisector (line) as a `Curve2D`, or `nil` on failure.
+- **OCCT:** `Bisector_BisecAna` (point–point constructor).
+- **Example:**
+  ```swift
+  if let bis = Curve2D.bisectorBetweenPoints(
+      SIMD2(0, 0), SIMD2(6, 0),
+      referencePoint: SIMD2(3, 1),
+      direction1: SIMD2(1, 0), direction2: SIMD2(-1, 0)
+  ) {
+      let pt = bis.point(at: bis.parameterRange!.lowerBound)
+  }
+  ```

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -1,0 +1,1479 @@
+---
+title: Curve2D
+parent: API Reference
+---
+
+# Curve2D
+
+A `Curve2D` is a parametric 2D curve — the Swift analog of OCCT's `Geom2d_Curve` class hierarchy. It wraps lines, segments, circles, arcs, ellipses, parabolas, hyperbolas, BSplines, and Bezier curves polymorphically behind a single opaque handle. `Curve2D` instances are used as pcurves (parameter-space curves on surfaces), 2D profiles, and constraint inputs. Obtain one via the static factory methods on `Curve2D`, `Curve2DGcc`, or by evaluating an existing curve at a point.
+
+> **Note:** `Curve2D` is documented across several pages — see also **Curve2D — Analytic Types**, **Curve2D — Analysis**, and **Curve2D — Constraint Solvers**.
+
+## Topics
+
+- [Properties](#properties) · [Evaluation](#evaluation) · [Primitive Curves](#primitive-curves) · [Draw (Discretization for Metal)](#draw-discretization-for-metal) · [BSpline & Bezier](#bspline--bezier) · [Operations](#operations) · [Additional Arc Types](#additional-arc-types) · [Conversion Extras](#conversion-extras) · [Conversion](#conversion) · [Circle Construction](#circle-construction) · [Line Construction](#line-construction) · [Curve2D Transform (v0.128.0)](#curve2d-transform-v01280) · [Geom2dEval TBezier / AHTBezier Curves (v0.131.0)](#geom2deval-tbezier--ahtbezier-curves-v01310) · [v0.51.0: GC_MakeLine2d variants](#v0510-gc_makeline2d-variants)
+
+---
+
+## Properties
+
+### `domain`
+
+The parametric domain of the curve as a closed range `[first, last]`.
+
+```swift
+public var domain: ClosedRange<Double> { get }
+```
+
+Use `domain.lowerBound` and `domain.upperBound` when calling `point(at:)`, `d1(at:)`, or any parameter-based method.
+
+- **Returns:** Closed range of valid parameter values.
+- **OCCT:** `Geom2d_Curve::FirstParameter` / `LastParameter`.
+- **Example:**
+  ```swift
+  let arc = Curve2D.arcOfCircle(center: .zero, radius: 5, startAngle: 0, endAngle: .pi)!
+  let d = arc.domain   // 0...π
+  let mid = arc.point(at: (d.lowerBound + d.upperBound) / 2)
+  ```
+
+---
+
+### `isClosed`
+
+Whether the curve forms a closed loop.
+
+```swift
+public var isClosed: Bool { get }
+```
+
+- **OCCT:** `Geom2d_Curve::IsClosed`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  #expect(circle.isClosed == true)
+  ```
+
+---
+
+### `isPeriodic`
+
+Whether the curve is periodic (e.g. a full circle or ellipse).
+
+```swift
+public var isPeriodic: Bool { get }
+```
+
+- **OCCT:** `Geom2d_Curve::IsPeriodic`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  #expect(seg.isPeriodic == false)
+  ```
+
+---
+
+### `period`
+
+The period of the curve, or `nil` if the curve is not periodic.
+
+```swift
+public var period: Double? { get }
+```
+
+- **Returns:** Period value, or `nil` if `isPeriodic` is `false`.
+- **OCCT:** `Geom2d_Curve::Period`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  if let p = circle.period { print(p) }  // ≈ 2π
+  ```
+
+---
+
+### `startPoint`
+
+The point at the start of the parameter domain.
+
+```swift
+public var startPoint: SIMD2<Double> { get }
+```
+
+Convenience for `point(at: domain.lowerBound)`.
+
+- **OCCT:** `Geom2d_Curve::Value(FirstParameter)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(1, 2), to: SIMD2(4, 5))!
+  print(seg.startPoint)  // SIMD2(1.0, 2.0)
+  ```
+
+---
+
+### `endPoint`
+
+The point at the end of the parameter domain.
+
+```swift
+public var endPoint: SIMD2<Double> { get }
+```
+
+Convenience for `point(at: domain.upperBound)`.
+
+- **OCCT:** `Geom2d_Curve::Value(LastParameter)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(1, 2), to: SIMD2(4, 5))!
+  print(seg.endPoint)  // SIMD2(4.0, 5.0)
+  ```
+
+---
+
+## Evaluation
+
+### `point(at:)`
+
+Evaluates the 2D curve position at a parameter.
+
+```swift
+public func point(at u: Double) -> SIMD2<Double>
+```
+
+- **Parameters:** `u` — parameter value within `domain`.
+- **Returns:** 2D point on the curve.
+- **OCCT:** `Geom2d_Curve::Value(u)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  let mid = seg.point(at: (seg.domain.lowerBound + seg.domain.upperBound) / 2)
+  // mid ≈ SIMD2(5, 0)
+  ```
+
+---
+
+### `d1(at:)`
+
+Evaluates the position and first derivative (tangent) at a parameter.
+
+```swift
+public func d1(at u: Double) -> (point: SIMD2<Double>, tangent: SIMD2<Double>)
+```
+
+The tangent vector is not normalised — its magnitude depends on the parameterisation.
+
+- **Parameters:** `u` — parameter value within `domain`.
+- **Returns:** Tuple of position and first-derivative vector.
+- **OCCT:** `Geom2d_Curve::D1(u, P, V1)`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  let (pos, tan) = circle.d1(at: 0)
+  ```
+
+---
+
+### `d2(at:)`
+
+Evaluates position, first derivative, and second derivative at a parameter.
+
+```swift
+public func d2(at u: Double) -> (point: SIMD2<Double>, d1: SIMD2<Double>, d2: SIMD2<Double>)
+```
+
+- **Parameters:** `u` — parameter value within `domain`.
+- **Returns:** Tuple of position, first derivative, and second derivative.
+- **OCCT:** `Geom2d_Curve::D2(u, P, V1, V2)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  let (pt, v1, v2) = seg.d2(at: 0)
+  // v2 ≈ SIMD2(0, 0) — zero second derivative for a line
+  ```
+
+---
+
+## Primitive Curves
+
+### `Curve2D.line(through:direction:)`
+
+Creates an infinite line through a point in a direction.
+
+```swift
+public static func line(through point: SIMD2<Double>, direction: SIMD2<Double>) -> Curve2D?
+```
+
+The curve is unbounded; its domain is `(-∞, +∞)`. Use `segment(from:to:)` for a bounded segment.
+
+- **Parameters:** `point` — a point on the line; `direction` — line direction (need not be normalised).
+- **Returns:** Infinite line curve, or `nil` if `direction` is zero.
+- **OCCT:** `Geom2d_Line(gp_Lin2d(point, direction))`.
+- **Example:**
+  ```swift
+  let line = Curve2D.line(through: .zero, direction: SIMD2(1, 0))
+  ```
+
+---
+
+### `Curve2D.segment(from:to:)`
+
+Creates a bounded line segment between two points.
+
+```swift
+public static func segment(from p1: SIMD2<Double>, to p2: SIMD2<Double>) -> Curve2D?
+```
+
+- **Parameters:** `p1` — start point; `p2` — end point.
+- **Returns:** Segment curve, or `nil` if the points coincide.
+- **OCCT:** `Geom2d_TrimmedCurve` wrapping a `Geom2d_Line`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 5))!
+  print(seg.length!)  // ≈ 11.18
+  ```
+
+---
+
+### `Curve2D.circle(center:radius:)`
+
+Creates a full (untrimmed) circle.
+
+```swift
+public static func circle(center: SIMD2<Double>, radius: Double) -> Curve2D?
+```
+
+The circle is periodic with period `2π`. U=0 starts on the positive X axis of the local frame.
+
+- **Parameters:** `center` — circle centre; `radius` — circle radius (must be > 0).
+- **Returns:** Full circle curve, or `nil` if `radius ≤ 0`.
+- **OCCT:** `Geom2d_Circle(gp_Circ2d(...))`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  #expect(circle.isClosed)
+  ```
+
+---
+
+### `Curve2D.arcOfCircle(center:radius:startAngle:endAngle:)`
+
+Creates a circular arc between two angles.
+
+```swift
+public static func arcOfCircle(center: SIMD2<Double>, radius: Double,
+                               startAngle: Double, endAngle: Double) -> Curve2D?
+```
+
+- **Parameters:** `center` — circle centre; `radius` — radius (> 0); `startAngle` — start angle in radians; `endAngle` — end angle in radians.
+- **Returns:** Circular arc, or `nil` on failure.
+- **OCCT:** `GCE2d_MakeArcOfCircle` → `Geom2d_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve2D.arcOfCircle(center: .zero, radius: 5,
+                                 startAngle: 0, endAngle: .pi / 2)!
+  ```
+
+---
+
+### `Curve2D.arcThrough(_:_:_:)`
+
+Creates a circular arc passing through three points.
+
+```swift
+public static func arcThrough(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
+                              _ p3: SIMD2<Double>) -> Curve2D?
+```
+
+OCCT derives the centre and radius from the three points. The arc sweeps from `p1` through `p2` to `p3`.
+
+- **Parameters:** `p1` — start point; `p2` — interior point; `p3` — end point.
+- **Returns:** Arc curve, or `nil` if points are collinear or coincident.
+- **OCCT:** `GCE2d_MakeArcOfCircle(p1, p2, p3)` → `Geom2d_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve2D.arcThrough(SIMD2(5, 0), SIMD2(0, 5), SIMD2(-5, 0))
+  ```
+
+---
+
+### `Curve2D.ellipse(center:majorRadius:minorRadius:rotation:)`
+
+Creates a full ellipse.
+
+```swift
+public static func ellipse(center: SIMD2<Double>, majorRadius: Double,
+                           minorRadius: Double, rotation: Double = 0) -> Curve2D?
+```
+
+- **Parameters:** `center` — ellipse centre; `majorRadius` — semi-major axis (must be ≥ `minorRadius`); `minorRadius` — semi-minor axis; `rotation` — rotation of the major axis from the X axis in radians (default 0).
+- **Returns:** Full ellipse curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Ellipse(gp_Elips2d(...))`.
+- **Example:**
+  ```swift
+  let ellipse = Curve2D.ellipse(center: .zero, majorRadius: 10, minorRadius: 5)!
+  ```
+
+---
+
+### `Curve2D.arcOfEllipse(center:majorRadius:minorRadius:rotation:startAngle:endAngle:)`
+
+Creates an elliptical arc between two angles.
+
+```swift
+public static func arcOfEllipse(center: SIMD2<Double>, majorRadius: Double,
+                                minorRadius: Double, rotation: Double = 0,
+                                startAngle: Double, endAngle: Double) -> Curve2D?
+```
+
+- **Parameters:** `center` — centre; `majorRadius` — semi-major axis; `minorRadius` — semi-minor axis; `rotation` — major-axis rotation in radians (default 0); `startAngle`/`endAngle` — arc bounds in radians.
+- **Returns:** Elliptical arc, or `nil` on failure.
+- **OCCT:** `GCE2d_MakeArcOfEllipse` → `Geom2d_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve2D.arcOfEllipse(center: .zero, majorRadius: 10, minorRadius: 5,
+                                  startAngle: 0, endAngle: .pi)
+  ```
+
+---
+
+### `Curve2D.parabola(focus:direction:focalLength:)`
+
+Creates a parabola.
+
+```swift
+public static func parabola(focus: SIMD2<Double>, direction: SIMD2<Double>,
+                            focalLength: Double) -> Curve2D?
+```
+
+- **Parameters:** `focus` — focus point; `direction` — axis direction from vertex toward focus; `focalLength` — distance from vertex to focus (must be > 0).
+- **Returns:** Parabola curve, or `nil` if `focalLength ≤ 0`.
+- **OCCT:** `Geom2d_Parabola(gp_Parab2d(...))`.
+- **Example:**
+  ```swift
+  let par = Curve2D.parabola(focus: SIMD2(0, 2), direction: SIMD2(0, 1), focalLength: 2)
+  ```
+
+---
+
+### `Curve2D.hyperbola(center:majorRadius:minorRadius:rotation:)`
+
+Creates a hyperbola.
+
+```swift
+public static func hyperbola(center: SIMD2<Double>, majorRadius: Double,
+                             minorRadius: Double, rotation: Double = 0) -> Curve2D?
+```
+
+- **Parameters:** `center` — hyperbola centre; `majorRadius` — real semi-axis; `minorRadius` — imaginary semi-axis (both must be > 0); `rotation` — major-axis rotation in radians (default 0).
+- **Returns:** Hyperbola curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Hyperbola(gp_Hypr2d(...))`.
+- **Example:**
+  ```swift
+  let hyp = Curve2D.hyperbola(center: .zero, majorRadius: 3, minorRadius: 2)
+  ```
+
+---
+
+## Draw (Discretization for Metal)
+
+### `drawAdaptive(angularDeflection:chordalDeflection:maxPoints:)`
+
+Adaptively discretizes the curve using angular and chordal deflection criteria.
+
+```swift
+public func drawAdaptive(angularDeflection: Double = 0.1,
+                         chordalDeflection: Double = 0.01,
+                         maxPoints: Int = 4096) -> [SIMD2<Double>]
+```
+
+Concentrates sample points where curvature is high and fewer where the curve is straight, producing an efficient polyline for Metal rendering.
+
+- **Parameters:** `angularDeflection` — maximum angle between consecutive tangents (radians); `chordalDeflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Returns:** Array of 2D points along the curve; empty on failure.
+- **OCCT:** `GCPnts_TangentialDeflection` (via `OCCTCurve2DDrawAdaptive`).
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  let pts = circle.drawAdaptive(angularDeflection: 0.05, chordalDeflection: 0.005)
+  // pts suitable for Metal vertex buffer
+  ```
+
+---
+
+### `drawUniform(pointCount:)`
+
+Discretizes the curve at exactly `pointCount` uniformly-spaced arc-length points.
+
+```swift
+public func drawUniform(pointCount: Int) -> [SIMD2<Double>]
+```
+
+- **Parameters:** `pointCount` — desired number of output points.
+- **Returns:** Array of 2D points; empty on failure.
+- **OCCT:** `GCPnts_UniformAbscissa` (via `OCCTCurve2DDrawUniform`).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  let pts = seg.drawUniform(pointCount: 11)
+  // pts[5] ≈ SIMD2(5, 0)
+  ```
+
+---
+
+### `drawDeflection(deflection:maxPoints:)`
+
+Discretizes the curve using a maximum chordal-deflection criterion.
+
+```swift
+public func drawDeflection(deflection: Double = 0.01,
+                           maxPoints: Int = 4096) -> [SIMD2<Double>]
+```
+
+- **Parameters:** `deflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Returns:** Array of 2D points; empty on failure.
+- **OCCT:** `GCPnts_UniformDeflection` (via `OCCTCurve2DDrawDeflection`).
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 10)!
+  let pts = circle.drawDeflection(deflection: 0.01)
+  ```
+
+---
+
+## BSpline & Bezier
+
+### `Curve2D.bspline(poles:weights:knots:multiplicities:degree:)`
+
+Creates a BSpline (or rational NURBS) curve from control points, knots, multiplicities, and degree.
+
+```swift
+public static func bspline(poles: [SIMD2<Double>], weights: [Double]? = nil,
+                           knots: [Double], multiplicities: [Int32],
+                           degree: Int) -> Curve2D?
+```
+
+When `weights` is `nil` all pole weights default to 1.0 (non-rational BSpline).
+
+- **Parameters:**
+  - `poles` — control points (minimum 2).
+  - `weights` — per-pole weights (`nil` = uniform 1.0).
+  - `knots` — distinct knot values.
+  - `multiplicities` — per-knot multiplicity.
+  - `degree` — curve degree (≥ 1).
+- **Returns:** BSpline/NURBS curve, or `nil` if parameters are invalid.
+- **OCCT:** `Geom2d_BSplineCurve(poles, knots, multiplicities, degree)`.
+- **Example:**
+  ```swift
+  let poles: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(5, 10), SIMD2(10, 0)]
+  let knots = [0.0, 1.0]
+  let mults: [Int32] = [4, 4]
+  let bsp = Curve2D.bspline(poles: poles, knots: knots, multiplicities: mults, degree: 3)
+  ```
+
+---
+
+### `Curve2D.bezier(poles:weights:)`
+
+Creates a Bezier curve from control points with optional rational weights.
+
+```swift
+public static func bezier(poles: [SIMD2<Double>], weights: [Double]? = nil) -> Curve2D?
+```
+
+The curve passes through the first and last pole. The degree equals `poles.count − 1`.
+
+- **Parameters:** `poles` — control points (minimum 2); `weights` — per-pole rational weights (`nil` = uniform 1.0).
+- **Returns:** Bezier curve, or `nil` if fewer than 2 poles or construction fails.
+- **OCCT:** `Geom2d_BezierCurve(poles)` or the weighted overload.
+- **Example:**
+  ```swift
+  let bez = Curve2D.bezier(poles: [SIMD2(0, 0), SIMD2(5, 10), SIMD2(10, 0)])!
+  print(bez.startPoint)  // SIMD2(0, 0)
+  ```
+
+---
+
+### `Curve2D.interpolate(through:closed:tolerance:)`
+
+Interpolates a smooth BSpline curve through the given points.
+
+```swift
+public static func interpolate(through points: [SIMD2<Double>], closed: Bool = false,
+                               tolerance: Double = 1e-6) -> Curve2D?
+```
+
+The curve passes exactly through every point. Use `closed: true` for a periodic loop.
+
+- **Parameters:** `points` — interpolation points (minimum 2); `closed` — closed/periodic curve; `tolerance` — point coincidence tolerance.
+- **Returns:** Interpolated BSpline, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_Interpolate` + `Perform()`.
+- **Example:**
+  ```swift
+  let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(5, 5), SIMD2(10, 0)]
+  if let c = Curve2D.interpolate(through: pts) {
+      print(c.point(at: c.domain.lowerBound))  // ≈ SIMD2(0, 0)
+  }
+  ```
+
+---
+
+### `Curve2D.interpolate(through:startTangent:endTangent:tolerance:)`
+
+Interpolates through points with constrained endpoint tangents.
+
+```swift
+public static func interpolate(through points: [SIMD2<Double>],
+                               startTangent: SIMD2<Double>,
+                               endTangent: SIMD2<Double>,
+                               tolerance: Double = 1e-6) -> Curve2D?
+```
+
+- **Parameters:** `points` — interpolation points; `startTangent` — tangent at the first point; `endTangent` — tangent at the last point; `tolerance` — precision.
+- **Returns:** Interpolated BSpline, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_Interpolate::Load(startTangent, endTangent)` + `Perform()`.
+- **Example:**
+  ```swift
+  let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(10, 10)]
+  let c = Curve2D.interpolate(through: pts,
+                               startTangent: SIMD2(1, 0),
+                               endTangent: SIMD2(0, 1))
+  ```
+
+---
+
+### `Curve2D.interpolate(through:tangents:closed:tolerance:)`
+
+Interpolates through points with per-point tangent constraints at arbitrary indices.
+
+```swift
+public static func interpolate(through points: [SIMD2<Double>],
+                               tangents: [Int: SIMD2<Double>],
+                               closed: Bool = false,
+                               tolerance: Double = 1e-6) -> Curve2D?
+```
+
+Use this when you need tangent continuity at specific interior transition points — for example where a straight section meets a circular arc.
+
+- **Parameters:** `points` — interpolation points (≥ 2); `tangents` — dictionary mapping point index to unit tangent direction (unconstrained indices use C2); `closed` — closed/periodic curve; `tolerance` — coincidence tolerance.
+- **Returns:** Interpolated BSpline, or `nil` on failure.
+- **OCCT:** `OCCTCurve2DInterpolateWithInteriorTangents`.
+- **Example:**
+  ```swift
+  let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(5, 5), SIMD2(10, 0)]
+  let c = Curve2D.interpolate(through: pts, tangents: [1: SIMD2(1, 0)])
+  ```
+
+---
+
+### `Curve2D.fit(through:minDegree:maxDegree:tolerance:)`
+
+Approximates a BSpline curve fitting through points within tolerance.
+
+```swift
+public static func fit(through points: [SIMD2<Double>], minDegree: Int = 3,
+                       maxDegree: Int = 8, tolerance: Double = 1e-3) -> Curve2D?
+```
+
+Unlike `interpolate`, the fitted curve minimises squared error — it does not necessarily pass exactly through every point. Good for noisy data.
+
+- **Parameters:** `points` — data points; `minDegree`/`maxDegree` — degree range; `tolerance` — approximation error.
+- **Returns:** Approximating BSpline, or `nil` on failure.
+- **OCCT:** `Geom2dAPI_PointsToBSpline` (via `OCCTCurve2DFitPoints`).
+- **Example:**
+  ```swift
+  let pts: [SIMD2<Double>] = stride(from: 0.0, to: 10.0, by: 0.5).map {
+      SIMD2($0, sin($0))
+  }
+  let c = Curve2D.fit(through: pts)
+  ```
+
+---
+
+### `poleCount`
+
+The number of control points (poles), or `nil` if not a BSpline or Bezier.
+
+```swift
+public var poleCount: Int? { get }
+```
+
+- **Returns:** Pole count, or `nil`.
+- **OCCT:** `Geom2d_BSplineCurve::NbPoles` / `Geom2d_BezierCurve::NbPoles`.
+- **Example:**
+  ```swift
+  let bez = Curve2D.bezier(poles: [SIMD2(0,0), SIMD2(5,5), SIMD2(10,0)])!
+  #expect(bez.poleCount == 3)
+  ```
+
+---
+
+### `poles`
+
+The control points (poles), or `nil` if not a BSpline or Bezier.
+
+```swift
+public var poles: [SIMD2<Double>]? { get }
+```
+
+- **Returns:** Array of 2D control points, or `nil`.
+- **OCCT:** `Geom2d_BSplineCurve::Poles` / `Geom2d_BezierCurve::Poles`.
+- **Example:**
+  ```swift
+  let bez = Curve2D.bezier(poles: [SIMD2(0,0), SIMD2(5,5), SIMD2(10,0)])!
+  if let pts = bez.poles { #expect(pts.count == 3) }
+  ```
+
+---
+
+### `degree`
+
+The polynomial degree, or `nil` if not a BSpline or Bezier.
+
+```swift
+public var degree: Int? { get }
+```
+
+- **OCCT:** `Geom2d_BSplineCurve::Degree` / `Geom2d_BezierCurve::Degree`.
+- **Example:**
+  ```swift
+  let bez = Curve2D.bezier(poles: [SIMD2(0,0), SIMD2(5,5), SIMD2(10,0)])!
+  #expect(bez.degree == 2)
+  ```
+
+---
+
+## Operations
+
+### `trimmed(from:to:)`
+
+Creates a trimmed copy of this curve between two parameters.
+
+```swift
+public func trimmed(from u1: Double, to u2: Double) -> Curve2D?
+```
+
+- **Parameters:** `u1` — lower trim parameter; `u2` — upper trim parameter (must satisfy `u1 < u2`).
+- **Returns:** Trimmed curve, or `nil` on failure.
+- **OCCT:** `Geom2d_TrimmedCurve(curve, u1, u2)`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  let halfArc = circle.trimmed(from: 0, to: .pi)
+  ```
+
+---
+
+### `offset(by:)`
+
+Creates an offset curve at the given distance.
+
+```swift
+public func offset(by distance: Double) -> Curve2D?
+```
+
+Positive distance offsets to the left of the curve direction.
+
+- **Parameters:** `distance` — signed offset distance.
+- **Returns:** Offset curve, or `nil` on failure.
+- **OCCT:** `Geom2d_OffsetCurve(curve, distance)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  let parallel = seg.offset(by: 5)
+  ```
+
+---
+
+### `reversed()`
+
+Creates a reversed copy of this curve (parameter direction flipped).
+
+```swift
+public func reversed() -> Curve2D?
+```
+
+Start and end points are swapped.
+
+- **Returns:** Reversed curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Reversed()`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  let rev = seg.reversed()!
+  print(rev.startPoint)  // SIMD2(10, 0)
+  ```
+
+---
+
+### `translated(by:)`
+
+Creates a translated copy of this curve.
+
+```swift
+public func translated(by delta: SIMD2<Double>) -> Curve2D?
+```
+
+- **Parameters:** `delta` — translation vector.
+- **Returns:** Translated curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Translated(gp_Vec2d)`.
+- **Example:**
+  ```swift
+  let c = Curve2D.circle(center: .zero, radius: 5)!
+  let moved = c.translated(by: SIMD2(10, 0))!
+  print(moved.point(at: 0).x)  // ≈ 15.0
+  ```
+
+---
+
+### `rotated(around:angle:)`
+
+Creates a rotated copy of this curve.
+
+```swift
+public func rotated(around center: SIMD2<Double>, angle: Double) -> Curve2D?
+```
+
+- **Parameters:** `center` — rotation centre point; `angle` — rotation angle in radians.
+- **Returns:** Rotated curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Rotated(gp_Pnt2d, angle)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(1, 0), to: SIMD2(10, 0))!
+  let rotated = seg.rotated(around: .zero, angle: .pi / 2)
+  ```
+
+---
+
+### `scaled(from:factor:)`
+
+Creates a scaled copy of this curve.
+
+```swift
+public func scaled(from center: SIMD2<Double>, factor: Double) -> Curve2D?
+```
+
+- **Parameters:** `center` — fixed point of scaling; `factor` — scale factor.
+- **Returns:** Scaled curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Scaled(gp_Pnt2d, factor)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(5, 0))!
+  let doubled = seg.scaled(from: .zero, factor: 2)!
+  print(doubled.length!)  // 10.0
+  ```
+
+---
+
+### `mirrored(acrossLine:direction:)`
+
+Creates a copy mirrored across an axis line.
+
+```swift
+public func mirrored(acrossLine point: SIMD2<Double>, direction: SIMD2<Double>) -> Curve2D?
+```
+
+- **Parameters:** `point` — a point on the mirror axis; `direction` — axis direction.
+- **Returns:** Mirrored curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Mirror(gp_Ax2d)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(0, 1), to: SIMD2(10, 1))!
+  let mir = seg.mirrored(acrossLine: .zero, direction: SIMD2(1, 0))
+  ```
+
+---
+
+### `mirrored(acrossPoint:)`
+
+Creates a copy mirrored through a point.
+
+```swift
+public func mirrored(acrossPoint point: SIMD2<Double>) -> Curve2D?
+```
+
+- **Parameters:** `point` — the point of symmetry.
+- **Returns:** Mirrored curve, or `nil` on failure.
+- **OCCT:** `Geom2d_Curve::Mirror(gp_Pnt2d)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(4, 0))!
+  let mir = seg.mirrored(acrossPoint: SIMD2(2, 0))!
+  ```
+
+---
+
+### `length`
+
+The total arc length of the curve, or `nil` on error.
+
+```swift
+public var length: Double? { get }
+```
+
+- **Returns:** Arc length in model units, or `nil` if measurement fails.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor)`.
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(3, 4))!
+  print(seg.length!)  // 5.0
+  ```
+
+---
+
+### `length(from:to:)`
+
+Arc length between two parameter values.
+
+```swift
+public func length(from u1: Double, to u2: Double) -> Double?
+```
+
+- **Parameters:** `u1` — start parameter; `u2` — end parameter.
+- **Returns:** Arc length, or `nil` on failure.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 1)!
+  let d = circle.domain
+  let halfLen = circle.length(from: d.lowerBound, to: d.lowerBound + .pi)
+  // halfLen ≈ π
+  ```
+
+---
+
+### `parameterAtLength(_:from:)`
+
+Returns the curve parameter at the given arc-length distance from a starting parameter.
+
+```swift
+public func parameterAtLength(_ arcLength: Double, from fromParameter: Double? = nil) -> Double?
+```
+
+Use this to trim a curve to a specific arc length, or to place features at measured positions along a composite curve.
+
+- **Parameters:** `arcLength` — desired arc-length distance; may be negative to travel in reverse; `fromParameter` — starting parameter (defaults to `domain.lowerBound`).
+- **Returns:** Parameter value at the given arc-length offset, or `nil` if the computation fails.
+- **OCCT:** `GCPnts_AbscissaPoint` (via `OCCTCurve2DParameterAtLength`).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  if let u = seg.parameterAtLength(5) {
+      let pt = seg.point(at: u)  // ≈ SIMD2(5, 0)
+  }
+  ```
+
+---
+
+## Additional Arc Types
+
+### `Curve2D.arcOfHyperbola(center:majorRadius:minorRadius:rotation:startAngle:endAngle:)`
+
+Creates a trimmed arc of a hyperbola.
+
+```swift
+public static func arcOfHyperbola(center: SIMD2<Double>, majorRadius: Double,
+                                  minorRadius: Double, rotation: Double = 0,
+                                  startAngle: Double, endAngle: Double) -> Curve2D?
+```
+
+- **Parameters:** `center` — hyperbola centre; `majorRadius` — real semi-axis; `minorRadius` — imaginary semi-axis; `rotation` — major-axis rotation in radians (default 0); `startAngle`/`endAngle` — arc bounds in radians.
+- **Returns:** Hyperbolic arc, or `nil` on failure.
+- **OCCT:** `GCE2d_MakeArcOfHyperbola` → `Geom2d_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve2D.arcOfHyperbola(center: .zero, majorRadius: 3, minorRadius: 2,
+                                    startAngle: -1, endAngle: 1)
+  ```
+
+---
+
+### `Curve2D.arcOfParabola(focus:direction:focalLength:startParam:endParam:)`
+
+Creates a trimmed arc of a parabola.
+
+```swift
+public static func arcOfParabola(focus: SIMD2<Double>, direction: SIMD2<Double>,
+                                 focalLength: Double,
+                                 startParam: Double, endParam: Double) -> Curve2D?
+```
+
+- **Parameters:** `focus` — focus point; `direction` — axis direction; `focalLength` — focal distance (> 0); `startParam`/`endParam` — parameter range of the arc.
+- **Returns:** Parabolic arc, or `nil` on failure.
+- **OCCT:** `GCE2d_MakeArcOfParabola` → `Geom2d_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve2D.arcOfParabola(focus: SIMD2(0, 1), direction: SIMD2(0, 1),
+                                   focalLength: 1, startParam: -2, endParam: 2)
+  ```
+
+---
+
+## Conversion Extras
+
+### `approximated(tolerance:continuity:maxSegments:maxDegree:)`
+
+Re-approximates this curve as a BSpline with controlled degree and continuity.
+
+```swift
+public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
+                         maxSegments: Int = 100, maxDegree: Int = 8) -> Curve2D?
+```
+
+`continuity` maps to `GeomAbs_Shape`: 0=C0, 1=C1, 2=C2, 3=C3.
+
+- **Parameters:** `tolerance` — maximum approximation error; `continuity` — desired continuity order; `maxSegments` — maximum number of BSpline segments; `maxDegree` — maximum polynomial degree.
+- **Returns:** Approximated BSpline, or `nil` on failure.
+- **OCCT:** `Approx_Curve2d` (via `OCCTCurve2DApproximate`).
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  let approx = circle.approximated(tolerance: 0.01, continuity: 2)
+  ```
+
+---
+
+### `splitIndicesAtDiscontinuities(continuity:)`
+
+Finds knot indices where a BSpline has continuity discontinuities.
+
+```swift
+public func splitIndicesAtDiscontinuities(continuity: Int = 1) -> [Int]?
+```
+
+- **Parameters:** `continuity` — desired continuity level to check (0=C0, 1=C1, etc.).
+- **Returns:** Array of knot indices where continuity drops below the requested level, or `nil` if not a BSpline or no discontinuities found.
+- **OCCT:** `Geom2d_BSplineCurve` knot analysis (via `OCCTCurve2DSplitAtDiscontinuities`).
+- **Example:**
+  ```swift
+  if let bsp = Curve2D.bspline(poles: [...], knots: [...], multiplicities: [...], degree: 3) {
+      let indices = bsp.splitIndicesAtDiscontinuities(continuity: 1)
+  }
+  ```
+
+---
+
+### `toArcsAndSegments(tolerance:angleTolerance:)`
+
+Approximates this curve as a sequence of arcs and line segments.
+
+```swift
+public func toArcsAndSegments(tolerance: Double = 0.01,
+                              angleTolerance: Double = 0.04) -> [Curve2D]?
+```
+
+Useful for CNC G-code generation where only arcs and lines are supported.
+
+- **Parameters:** `tolerance` — maximum approximation error; `angleTolerance` — maximum angular deviation for arc fitting.
+- **Returns:** Array of arc/segment `Curve2D` objects, or `nil` on failure.
+- **OCCT:** `Geom2dConvert_ApproxCurve` arc-and-segment decomposition.
+- **Example:**
+  ```swift
+  let ellipse = Curve2D.ellipse(center: .zero, majorRadius: 10, minorRadius: 5)!
+  if let arcs = ellipse.toArcsAndSegments(tolerance: 0.01) {
+      // arcs suitable for G02/G03/G01 G-code output
+  }
+  ```
+
+---
+
+## Conversion
+
+### `toBSpline(tolerance:)`
+
+Converts this curve to an equivalent BSpline representation.
+
+```swift
+public func toBSpline(tolerance: Double = 1e-6) -> Curve2D?
+```
+
+Any analytic curve (line, circle, ellipse, arc) can be represented exactly as a rational BSpline. Required before using BSpline-specific query APIs.
+
+- **Parameters:** `tolerance` — conversion precision.
+- **Returns:** BSpline curve, or `nil` if conversion fails.
+- **OCCT:** `Geom2dConvert::CurveToBSplineCurve(curve)`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 5)!
+  if let bsp = circle.toBSpline() {
+      print(bsp.poleCount!)  // NURBS representation of the circle
+  }
+  ```
+
+---
+
+### `toBezierSegments()`
+
+Splits a BSpline curve into its constituent Bezier segments.
+
+```swift
+public func toBezierSegments() -> [Curve2D]?
+```
+
+- **Returns:** Array of Bezier segment curves, or `nil` if the curve is not a BSpline or decomposition fails.
+- **OCCT:** `Geom2dConvert_BSplineCurveToBezierCurve::Arc(i)`.
+- **Example:**
+  ```swift
+  let bsp = Curve2D.interpolate(through: [SIMD2(0,0), SIMD2(3,4), SIMD2(6,0)])!
+  if let segs = bsp.toBezierSegments() {
+      print(segs.count)
+  }
+  ```
+
+---
+
+### `Curve2D.join(_:tolerance:)`
+
+Joins multiple curves into a single BSpline.
+
+```swift
+public static func join(_ curves: [Curve2D], tolerance: Double = 1e-6) -> Curve2D?
+```
+
+Each input curve is converted to BSpline form before concatenation. Curves must meet end-to-end within `tolerance`.
+
+- **Parameters:** `curves` — curves to join in order; `tolerance` — endpoint gap tolerance.
+- **Returns:** Joined BSpline, or `nil` if the array is empty or joining fails.
+- **OCCT:** `Geom2dConvert_CompCurveToBSplineCurve` (via `OCCTCurve2DJoinToBSpline`).
+- **Example:**
+  ```swift
+  let seg1 = Curve2D.segment(from: .zero, to: SIMD2(5, 0))!
+  let seg2 = Curve2D.segment(from: SIMD2(5, 0), to: SIMD2(10, 5))!
+  if let joined = Curve2D.join([seg1, seg2]) {
+      print(joined.length!)
+  }
+  ```
+
+---
+
+## Circle Construction
+
+Methods on `Curve2DGcc` that construct circles satisfying geometric constraints. See the `Curve2DGcc` enum for the full solver; the entries below correspond to the `// MARK: - Circle Construction` section.
+
+### `Curve2DGcc.circlesTangentTo(_:_:_:_:_:_:tolerance:)`
+
+Finds circles tangent to three curves.
+
+```swift
+public static func circlesTangentTo(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    _ c3: Curve2D, _ q3: Curve2DQualifier = .unqualified,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `c1`/`c2`/`c3` — input curves; `q1`/`q2`/`q3` — qualifiers (`.unqualified`, `.enclosing`, `.enclosed`, `.outside`); `tolerance` — geometric tolerance.
+- **Returns:** Array of `Curve2DCircleSolution` values (each with `center` and `radius`); may be empty.
+- **OCCT:** `Geom2dGcc_Circ2d3Tan`.
+- **Example:**
+  ```swift
+  let c1 = Curve2D.circle(center: SIMD2(-5, 0), radius: 2)!
+  let c2 = Curve2D.circle(center: SIMD2(5, 0), radius: 2)!
+  let c3 = Curve2D.circle(center: SIMD2(0, 5), radius: 2)!
+  let sols = Curve2DGcc.circlesTangentTo(c1, .outside, c2, .outside, c3, .outside)
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToTwoCurvesAndPoint(_:_:_:_:point:tolerance:)`
+
+Finds circles tangent to two curves and passing through a point.
+
+```swift
+public static func circlesTangentToTwoCurvesAndPoint(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    point: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `c1`/`c2` — input curves; `q1`/`q2` — qualifiers; `point` — required pass-through point; `tolerance` — tolerance.
+- **Returns:** Array of solutions.
+- **OCCT:** `Geom2dGcc_Circ2d2TanPt`.
+- **Example:**
+  ```swift
+  let sols = Curve2DGcc.circlesTangentToTwoCurvesAndPoint(
+      c1, .unqualified, c2, .unqualified, point: SIMD2(0, 0))
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentWithCenter(_:_:center:tolerance:)`
+
+Finds circles tangent to a curve with a given center point.
+
+```swift
+public static func circlesTangentWithCenter(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    center: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `curve` — input curve; `qualifier` — qualifier; `center` — desired circle centre; `tolerance` — tolerance.
+- **Returns:** Array of solutions.
+- **OCCT:** `Geom2dGcc_Circ2dTanCen`.
+- **Example:**
+  ```swift
+  let sols = Curve2DGcc.circlesTangentWithCenter(circle, .outside, center: SIMD2(10, 0))
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToTwoCurves(_:_:_:_:radius:tolerance:)`
+
+Finds circles tangent to two curves with a given radius.
+
+```swift
+public static func circlesTangentToTwoCurves(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    radius: Double,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `c1`/`c2` — input curves; `q1`/`q2` — qualifiers; `radius` — required radius; `tolerance` — tolerance.
+- **Returns:** Array of solutions.
+- **OCCT:** `Geom2dGcc_Circ2d2TanRad`.
+- **Example:**
+  ```swift
+  let sols = Curve2DGcc.circlesTangentToTwoCurves(c1, .outside, c2, .outside, radius: 3)
+  ```
+
+---
+
+### `Curve2DGcc.circlesTangentToPointWithRadius(_:_:point:radius:tolerance:)`
+
+Finds circles tangent to a curve, passing through a point, with a given radius.
+
+```swift
+public static func circlesTangentToPointWithRadius(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    point: SIMD2<Double>, radius: Double,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `curve` — input curve; `qualifier` — qualifier; `point` — pass-through point; `radius` — required radius; `tolerance` — tolerance.
+- **Returns:** Array of solutions.
+- **OCCT:** `Geom2dGcc_Circ2dTanPtRad`.
+- **Example:**
+  ```swift
+  let sols = Curve2DGcc.circlesTangentToPointWithRadius(
+      circle, .outside, point: SIMD2(0, 0), radius: 4)
+  ```
+
+---
+
+### `Curve2DGcc.circlesThroughTwoPoints(_:_:radius:tolerance:)`
+
+Finds circles through two points with a given radius.
+
+```swift
+public static func circlesThroughTwoPoints(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
+    radius: Double,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `p1`/`p2` — required pass-through points; `radius` — required radius; `tolerance` — tolerance.
+- **Returns:** Array of solutions (0, 1, or 2).
+- **OCCT:** `Geom2dGcc_Circ2d2PtRad`.
+- **Example:**
+  ```swift
+  let sols = Curve2DGcc.circlesThroughTwoPoints(SIMD2(-3, 0), SIMD2(3, 0), radius: 5)
+  ```
+
+---
+
+### `Curve2DGcc.circleThroughThreePoints(_:_:_:tolerance:)`
+
+Finds the circle through three points.
+
+```swift
+public static func circleThroughThreePoints(
+    _ p1: SIMD2<Double>, _ p2: SIMD2<Double>, _ p3: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DCircleSolution]
+```
+
+- **Parameters:** `p1`/`p2`/`p3` — three points; `tolerance` — coincidence tolerance.
+- **Returns:** Array with one solution, or empty if collinear.
+- **OCCT:** `Geom2dGcc_Circ2d3Pt`.
+- **Example:**
+  ```swift
+  let sols = Curve2DGcc.circleThroughThreePoints(
+      SIMD2(5, 0), SIMD2(0, 5), SIMD2(-5, 0))
+  ```
+
+---
+
+## Line Construction
+
+Methods on `Curve2DGcc` that construct lines satisfying geometric constraints. Corresponds to `// MARK: - Line Construction`.
+
+### `Curve2DGcc.linesTangentTo(_:_:_:_:tolerance:)`
+
+Finds lines tangent to two curves.
+
+```swift
+public static func linesTangentTo(
+    _ c1: Curve2D, _ q1: Curve2DQualifier = .unqualified,
+    _ c2: Curve2D, _ q2: Curve2DQualifier = .unqualified,
+    tolerance: Double = 1e-6
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `c1`/`c2` — input curves; `q1`/`q2` — qualifiers; `tolerance` — tolerance.
+- **Returns:** Array of `Curve2DLineSolution` values (each with a `point` on the line and `direction`).
+- **OCCT:** `Geom2dGcc_Lin2d2Tan`.
+- **Example:**
+  ```swift
+  let c1 = Curve2D.circle(center: SIMD2(-5, 0), radius: 2)!
+  let c2 = Curve2D.circle(center: SIMD2(5, 0), radius: 2)!
+  let lines = Curve2DGcc.linesTangentTo(c1, .outside, c2, .outside)
+  ```
+
+---
+
+### `Curve2DGcc.linesTangentToPoint(_:_:point:tolerance:)`
+
+Finds lines tangent to a curve and passing through a point.
+
+```swift
+public static func linesTangentToPoint(
+    _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
+    point: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Curve2DLineSolution]
+```
+
+- **Parameters:** `curve` — input curve; `qualifier` — qualifier; `point` — pass-through point; `tolerance` — tolerance.
+- **Returns:** Array of line solutions.
+- **OCCT:** `Geom2dGcc_Lin2dTanPt`.
+- **Example:**
+  ```swift
+  let circle = Curve2D.circle(center: .zero, radius: 3)!
+  let lines = Curve2DGcc.linesTangentToPoint(circle, .outside, point: SIMD2(10, 0))
+  ```
+
+---
+
+## Curve2D Transform (v0.128.0)
+
+In-place mutation methods that modify the curve handle directly, unlike `translated(by:)` / `rotated(around:…)` which return new copies.
+
+### `TransformType2D`
+
+Enum encoding the type of in-place 2D transform.
+
+```swift
+public enum TransformType2D: Int32, Sendable {
+    case translation = 0
+    case rotation = 1
+    case scale = 2
+    case mirrorPoint = 3
+    case mirrorAxis = 4
+}
+```
+
+Used internally by the in-place transform methods below.
+
+---
+
+### `translate(dx:dy:)`
+
+Translates the curve in place by `(dx, dy)`.
+
+```swift
+@discardableResult
+public func translate(dx: Double, dy: Double) -> Bool
+```
+
+- **Parameters:** `dx`, `dy` — displacement components.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom2d_Curve::Translate(gp_Vec2d)` (in-place, via `OCCTCurve2DTransform`).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+  seg.translate(dx: 0, dy: 5)
+  print(seg.startPoint)  // SIMD2(0, 5)
+  ```
+
+---
+
+### `rotate(center:angle:)`
+
+Rotates the curve in place around a centre point.
+
+```swift
+@discardableResult
+public func rotate(center: SIMD2<Double>, angle: Double) -> Bool
+```
+
+- **Parameters:** `center` — rotation centre; `angle` — rotation angle in radians.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom2d_Curve::Rotate(gp_Pnt2d, angle)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(1, 0), to: SIMD2(10, 0))!
+  seg.rotate(center: .zero, angle: .pi / 2)
+  ```
+
+---
+
+### `scale(center:factor:)`
+
+Scales the curve in place from a centre point.
+
+```swift
+@discardableResult
+public func scale(center: SIMD2<Double>, factor: Double) -> Bool
+```
+
+- **Parameters:** `center` — fixed point of scaling; `factor` — scale factor.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom2d_Curve::Scale(gp_Pnt2d, factor)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(5, 0))!
+  seg.scale(center: .zero, factor: 2)
+  print(seg.length!)  // 10.0
+  ```
+
+---
+
+### `mirrorPoint(_:)`
+
+Mirrors the curve in place through a point.
+
+```swift
+@discardableResult
+public func mirrorPoint(_ point: SIMD2<Double>) -> Bool
+```
+
+- **Parameters:** `point` — point of symmetry.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom2d_Curve::Mirror(gp_Pnt2d)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: .zero, to: SIMD2(4, 0))!
+  seg.mirrorPoint(SIMD2(2, 0))
+  ```
+
+---
+
+### `mirrorAxis(origin:direction:)`
+
+Mirrors the curve in place through an axis.
+
+```swift
+@discardableResult
+public func mirrorAxis(origin: SIMD2<Double>, direction: SIMD2<Double>) -> Bool
+```
+
+- **Parameters:** `origin` — a point on the mirror axis; `direction` — axis direction.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom2d_Curve::Mirror(gp_Ax2d)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve2D.segment(from: SIMD2(0, 2), to: SIMD2(10, 2))!
+  seg.mirrorAxis(origin: .zero, direction: SIMD2(1, 0))
+  ```
+
+---
+
+## Geom2dEval TBezier / AHTBezier Curves (v0.131.0)
+
+### `Curve2D.tBezier(poles:alpha:)`
+
+Creates a 2D Trigonometric Bezier curve.
+
+```swift
+public static func tBezier(poles: [SIMD2<Double>], alpha: Double) -> Curve2D?
+```
+
+Uses a trigonometric Bernstein-like basis `{1, sin(α·t), cos(α·t), …}`. Parameter domain is `[0, π/α]`. Can represent circular arcs exactly without rational weights.
+
+- **Parameters:** `poles` — 2D control points (count must be odd and ≥ 3); `alpha` — frequency parameter (must be > 0).
+- **Returns:** TBezier curve, or `nil` if `poles.count < 3`, count is even, or `alpha ≤ 0`.
+- **OCCT:** `OCCTGeom2dEvalTBezierCurveCreate`.
+- **Example:**
+  ```swift
+  let poles: [SIMD2<Double>] = [SIMD2(1, 0), SIMD2(0, 1), SIMD2(-1, 0)]
+  if let tb = Curve2D.tBezier(poles: poles, alpha: 1.0) {
+      let pts = tb.drawAdaptive()
+  }
+  ```
+
+---
+
+### `Curve2D.ahtBezier(poles:algDegree:alpha:beta:)`
+
+Creates a 2D Algebraic-Hyperbolic-Trigonometric (AHT) Bezier curve.
+
+```swift
+public static func ahtBezier(poles: [SIMD2<Double>], algDegree: Int, alpha: Double, beta: Double) -> Curve2D?
+```
+
+Uses a mixed basis: `{1, t, …, t^k, sinh(α·t), cosh(α·t), sin(β·t), cos(β·t)}`. The number of poles must equal `algDegree + 1 + 2*(alpha>0) + 2*(beta>0)`. Parameter range is `[0, 1]`.
+
+- **Parameters:** `poles` — 2D control points; `algDegree` — algebraic polynomial degree (≥ 0); `alpha` — hyperbolic frequency (≥ 0; 0 omits hyperbolic terms); `beta` — trigonometric frequency (≥ 0; 0 omits trig terms).
+- **Returns:** AHT Bezier curve, or `nil` if the pole count is wrong or construction fails.
+- **OCCT:** `OCCTGeom2dEvalAHTBezierCurveCreate`.
+- **Example:**
+  ```swift
+  // Degree-2 algebraic + trig: needs 3 + 0 + 2 = 5 poles
+  let poles: [SIMD2<Double>] = [
+      SIMD2(0, 0), SIMD2(2, 1), SIMD2(4, 0),
+      SIMD2(6, 1), SIMD2(8, 0)
+  ]
+  let aht = Curve2D.ahtBezier(poles: poles, algDegree: 2, alpha: 0, beta: .pi)
+  ```
+
+---
+
+## v0.51.0: GC_MakeLine2d variants
+
+### `Curve2D.lineThroughPoints(_:_:)`
+
+Creates a 2D infinite line passing through two points.
+
+```swift
+public static func lineThroughPoints(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>) -> Curve2D?
+```
+
+Unlike `segment(from:to:)` which creates a finite segment, this creates an infinite line through the two points.
+
+- **Parameters:** `p1` — first point on the line; `p2` — second point on the line.
+- **Returns:** 2D infinite line, or `nil` if points coincide.
+- **OCCT:** `GC_MakeLine2d(p1, p2)` (via `OCCTCurve2DMakeLineThroughPoints`).
+- **Example:**
+  ```swift
+  let line = Curve2D.lineThroughPoints(SIMD2(0, 0), SIMD2(5, 3))
+  ```
+
+---
+
+### `Curve2D.lineParallel(point:direction:distance:)`
+
+Creates a 2D line parallel to a reference line at a given signed offset.
+
+```swift
+public static func lineParallel(
+    point: SIMD2<Double>, direction: SIMD2<Double>, distance: Double
+) -> Curve2D?
+```
+
+Positive `distance` offsets to the left of the direction.
+
+- **Parameters:** `point` — a point on the reference line; `direction` — reference line direction; `distance` — signed offset distance.
+- **Returns:** 2D infinite line, or `nil` on failure.
+- **OCCT:** `GC_MakeLine2d` parallel variant (via `OCCTCurve2DMakeLineParallel`).
+- **Example:**
+  ```swift
+  let line = Curve2D.lineParallel(
+      point: .zero, direction: SIMD2(1, 0), distance: 5)
+  // Creates y = 5 (5 units above the X axis)
+  ```

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -1,0 +1,1203 @@
+---
+title: Curve3D — Analysis
+parent: API Reference
+---
+
+# Curve3D — Analysis
+
+This page covers the analysis and query members of `Curve3D`: curvature and local differential geometry, projection onto planes and surfaces, curve-to-curve and curve-to-surface distance and intersection, quasi-uniform sampling, `ShapeAnalysis_Curve` utilities, continuity analysis, extrema (curve–curve, curve–surface, point–curve), `ProjLib` surface projection, and `gce` analytic-curve factories. For factory methods, B-spline/Bezier construction, and geometric operations see the main [`Curve3D`](Curve3D.md) page.
+
+## Topics
+
+- [Local Properties](#local-properties) · [LocalAnalysis](#localanalysis) · [Projection (v0.22.0)](#projection-v0220) · [Batch Evaluation (v0.29.0)](#batch-evaluation-v0290) · [Curve Distance & Intersection (v0.30.0)](#curve-distance--intersection-v0300) · [Quasi-Uniform Sampling (v0.31.0)](#quasi-uniform-sampling-v0310) · [ShapeAnalysis\_Curve Expansion (v0.49.0)](#shapeanalysis_curve-expansion-v0490) · [v0.80.0: Extrema, ProjLib, gce Factories](#v0800-extrema-projlib-gce-factories) · [ExtremaPC — Point-Curve Distance (v0.130.0)](#extremapc--point-curve-distance-v01300)
+
+---
+
+## Local Properties
+
+Differential geometry queries at a parameter value on the curve, backed by `GeomLProp_CLProps`.
+
+---
+
+### `curvature(at:)`
+
+Returns the curvature at parameter `u`.
+
+```swift
+public func curvature(at u: Double) -> Double
+```
+
+The curvature is the reciprocal of the radius of the osculating circle at `u`. Zero on a straight line; larger values indicate tighter bends.
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Curvature value; `0` when `GeomLProp_CLProps` cannot compute it (e.g. tangent is zero-length).
+- **OCCT:** `GeomLProp_CLProps::Curvature`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi) {
+      let k = arc.curvature(at: 0)  // ≈ 0.2 (1/R)
+  }
+  ```
+
+---
+
+### `tangentDirection(at:)`
+
+Returns the unit tangent direction at parameter `u`.
+
+```swift
+public func tangentDirection(at u: Double) -> SIMD3<Double>?
+```
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Unit tangent vector, or `nil` when the tangent cannot be computed (e.g. at a cusp).
+- **OCCT:** `GeomLProp_CLProps::Tangent`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.line(from: .zero, to: SIMD3(1, 0, 0)),
+     let t = c.tangentDirection(at: 0) {
+      // t ≈ SIMD3(1, 0, 0)
+  }
+  ```
+
+---
+
+### `normal(at:)`
+
+Returns the principal normal direction at parameter `u`.
+
+```swift
+public func normal(at u: Double) -> SIMD3<Double>?
+```
+
+The principal normal points toward the center of curvature.
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Unit principal normal vector, or `nil` on a straight segment (curvature is zero, normal is undefined).
+- **OCCT:** `GeomLProp_CLProps::Normal`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let n = arc.normal(at: 0) {
+      // n points inward toward center
+  }
+  ```
+
+---
+
+### `centerOfCurvature(at:)`
+
+Returns the center of the osculating circle at parameter `u`.
+
+```swift
+public func centerOfCurvature(at u: Double) -> SIMD3<Double>?
+```
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** 3D center of curvature, or `nil` when curvature is zero (straight segment).
+- **OCCT:** `GeomLProp_CLProps::CentreOfCurvature`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let c = arc.centerOfCurvature(at: 0) {
+      // c ≈ SIMD3(0, 0, 0) — center of the arc
+  }
+  ```
+
+---
+
+### `torsion(at:)`
+
+Returns the torsion at parameter `u` (the rate of change of the osculating plane).
+
+```swift
+public func torsion(at u: Double) -> Double
+```
+
+Torsion is zero for planar curves. Non-zero values indicate the curve is twisting out of its local plane.
+
+- **Parameters:** `u` — curve parameter.
+- **Returns:** Torsion value (signed); `0` for planar curves or when torsion cannot be computed.
+- **OCCT:** `GeomLProp_CLProps::Torsion`.
+- **Example:**
+  ```swift
+  if let helix = Curve3D.helix(radius: 5, pitch: 2, turns: 3) {
+      let tau = helix.torsion(at: 0)  // non-zero for a helix
+  }
+  ```
+
+---
+
+## LocalAnalysis
+
+Continuity analysis between two curves at a shared junction, backed by `LocalAnalysis_CurveContinuity`.
+
+---
+
+### `ContinuityAnalysis`
+
+Struct returned by `continuityWith(_:u1:u2:order:)`.
+
+```swift
+public struct ContinuityAnalysis: Sendable {
+    public let status: Int
+    public let c0Value: Double
+    public let g1Angle: Double
+    public let c1Angle: Double
+    public let c1Ratio: Double
+    public let c2Angle: Double
+    public let c2Ratio: Double
+    public let g2Angle: Double
+    public let g2CurvatureVariation: Double
+    public let flags: Int
+    public var isC0: Bool { flags & 1  != 0 }
+    public var isG1: Bool { flags & 2  != 0 }
+    public var isC1: Bool { flags & 4  != 0 }
+    public var isG2: Bool { flags & 8  != 0 }
+    public var isC2: Bool { flags & 16 != 0 }
+}
+```
+
+- `status` — raw `GeomAbs_Shape` continuity code (0=C0, 1=G1, 2=C1, 3=G2, 4=C2).
+- `c0Value` — positional gap distance at the junction.
+- `g1Angle` — angle between tangent directions (radians).
+- `c1Angle` / `c1Ratio` — angle and magnitude ratio between first derivatives.
+- `c2Angle` / `c2Ratio` — angle and magnitude ratio between second derivatives.
+- `g2Angle` — angle between osculating planes.
+- `g2CurvatureVariation` — curvature variation at the junction.
+- `flags` — bitmask encoding continuity levels; decoded by computed boolean helpers `isC0` … `isC2`.
+
+---
+
+### `continuityWith(_:u1:u2:order:)`
+
+Analyses the continuity between this curve at parameter `u1` and another curve at parameter `u2`.
+
+```swift
+public func continuityWith(_ other: Curve3D, u1: Double, u2: Double, order: Int = 4) -> ContinuityAnalysis?
+```
+
+`order` controls the maximum continuity level tested: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2 (default). Use at shared endpoints when assembling curves that are expected to meet smoothly.
+
+- **Parameters:** `other` — the second curve; `u1` — parameter on this curve; `u2` — parameter on `other`; `order` — highest order to test (0–4, default 4).
+- **Returns:** `ContinuityAnalysis`, or `nil` if `LocalAnalysis_CurveContinuity` fails (e.g. degenerate tangent, invalid order).
+- **OCCT:** `LocalAnalysis_CurveContinuity`.
+- **Example:**
+  ```swift
+  if let ca = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
+      print(ca.isG1, ca.g1Angle)
+  }
+  ```
+
+---
+
+## Projection (v0.22.0)
+
+Project this curve onto a plane along a direction, returning a 3D curve in that plane.
+
+---
+
+### `projectedOnPlane(origin:normal:direction:)`
+
+Projects this curve onto a plane along a specified direction.
+
+```swift
+public func projectedOnPlane(
+    origin:    SIMD3<Double>,
+    normal:    SIMD3<Double>,
+    direction: SIMD3<Double>
+) -> Curve3D?
+```
+
+Uses `GeomProjLib::ProjectOnPlane`. The result is a 3D curve lying in the target plane. The projection direction must not be parallel to the plane normal.
+
+- **Parameters:** `origin` — a point on the target plane; `normal` — the plane normal; `direction` — projection direction (must not be parallel to `normal`).
+- **Returns:** Projected 3D curve lying in the plane, or `nil` if projection fails.
+- **OCCT:** `GeomProjLib::ProjectOnPlane`.
+- **Example:**
+  ```swift
+  if let helix = Curve3D.helix(radius: 5, pitch: 2, turns: 3),
+     let proj  = helix.projectedOnPlane(
+         origin: .zero,
+         normal: SIMD3(0, 0, 1),
+         direction: SIMD3(0, 0, 1)) {
+      // proj is the spiral footprint of the helix on the XY plane
+  }
+  ```
+
+---
+
+## Batch Evaluation (v0.29.0)
+
+Evaluate a curve at many parameter values in a single bridge call for efficiency.
+
+---
+
+### `evaluateGrid(_:)`
+
+Evaluates the curve at multiple parameter values in one call.
+
+```swift
+public func evaluateGrid(_ parameters: [Double]) -> [SIMD3<Double>]
+```
+
+Significantly faster than calling `point(at:)` in a loop for large parameter arrays. Returns an empty array when `parameters` is empty or the bridge call fails.
+
+- **Parameters:** `parameters` — array of curve parameter values.
+- **Returns:** Array of 3D points in the same order as `parameters`. Length equals `parameters.count` on success; may be shorter if the bridge returns fewer valid results.
+- **OCCT:** `Geom_Curve::D0` per point, batched through the bridge.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi) {
+      let params = stride(from: arc.domain.lowerBound,
+                          through: arc.domain.upperBound,
+                          by: 0.1).map { $0 }
+      let pts = arc.evaluateGrid(params)
+  }
+  ```
+
+---
+
+### `evaluateGridD1(_:)`
+
+Evaluates the curve and its first derivative at multiple parameter values in one call.
+
+```swift
+public func evaluateGridD1(_ parameters: [Double]) -> [(point: SIMD3<Double>, tangent: SIMD3<Double>)]
+```
+
+Returns point and (unnormalized) tangent vector at each parameter. Suitable for building polylines with tangent information for rendering or downstream processing.
+
+- **Parameters:** `parameters` — array of curve parameter values.
+- **Returns:** Array of `(point, tangent)` tuples. The tangent is the first derivative, not the unit tangent — normalize if needed.
+- **OCCT:** `Geom_Curve::D1` per point, batched through the bridge.
+- **Example:**
+  ```swift
+  if let c = Curve3D.bspline(points: myPoints) {
+      let params = stride(from: 0.0, through: 1.0, by: 0.05).map { $0 }
+      let pts = c.evaluateGridD1(params)
+      for (pt, tan) in pts {
+          // pt is position; tan is tangent vector at that parameter
+      }
+  }
+  ```
+
+---
+
+### `planeNormal(tolerance:)`
+
+Returns the plane normal if this curve is planar, or `nil` if it is not.
+
+```swift
+public func planeNormal(tolerance: Double = 0) -> SIMD3<Double>?
+```
+
+Uses `ShapeAnalysis_Curve::IsPlanar` to test whether the curve lies in a plane within `tolerance`. A returned normal is not unit-normalized; normalize it before use.
+
+- **Parameters:** `tolerance` — planarity tolerance (default `0` uses OCCT internal precision).
+- **Returns:** The plane normal direction if the curve is planar within tolerance, or `nil` if not planar.
+- **OCCT:** `ShapeAnalysis_Curve::IsPlanar`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let n = arc.planeNormal() {
+      // n ≈ SIMD3(0, 0, 1) for an arc in the XY plane
+  }
+  ```
+
+---
+
+## Curve Distance & Intersection (v0.30.0)
+
+Minimum-distance, extrema, and intersection between curves and surfaces.
+
+---
+
+### `CurveExtremaResult`
+
+Struct representing a single extremal distance result between two curves.
+
+```swift
+public struct CurveExtremaResult: Sendable {
+    public let distance:   Double
+    public let point1:     SIMD3<Double>
+    public let point2:     SIMD3<Double>
+    public let parameter1: Double
+    public let parameter2: Double
+}
+```
+
+- `distance` — distance between the two extremal points.
+- `point1` / `point2` — closest (or farthest) points on the first and second curve respectively.
+- `parameter1` / `parameter2` — parameter values on each curve at the extremal points.
+
+---
+
+### `CurveSurfaceHit`
+
+Struct representing a single curve–surface intersection point.
+
+```swift
+public struct CurveSurfaceHit: Sendable {
+    public let point:          SIMD3<Double>
+    public let curveParameter: Double
+    public let surfaceU:       Double
+    public let surfaceV:       Double
+}
+```
+
+- `point` — 3D intersection coordinates.
+- `curveParameter` — parameter along the curve at the intersection.
+- `surfaceU` / `surfaceV` — surface UV parameters at the intersection.
+
+---
+
+### `minDistance(to:)` (curve overload)
+
+Returns the minimum distance from this curve to another curve.
+
+```swift
+public func minDistance(to other: Curve3D) -> Double?
+```
+
+- **Parameters:** `other` — the curve to measure against.
+- **Returns:** Minimum distance, or `nil` when `GeomAPI_ExtremaCurveCurve` finds no extrema.
+- **OCCT:** `GeomAPI_ExtremaCurveCurve::LowerDistance`.
+- **Example:**
+  ```swift
+  if let c1 = Curve3D.line(from: .zero, to: SIMD3(10, 0, 0)),
+     let c2 = Curve3D.line(from: SIMD3(0, 5, 0), to: SIMD3(10, 5, 0)),
+     let d  = c1.minDistance(to: c2) {
+      print(d)  // ≈ 5.0
+  }
+  ```
+
+---
+
+### `extrema(with:maxCount:)`
+
+Finds all extremal distances (closest and farthest point pairs) between this curve and another.
+
+```swift
+public func extrema(with other: Curve3D, maxCount: Int = 20) -> [CurveExtremaResult]
+```
+
+Returns up to `maxCount` results. For simple queries where only the minimum distance matters, prefer `minDistance(to:)`.
+
+- **Parameters:** `other` — the second curve; `maxCount` — maximum number of extrema to return (default 20).
+- **Returns:** Array of `CurveExtremaResult` values (may be empty if the algorithm finds nothing).
+- **OCCT:** `GeomAPI_ExtremaCurveCurve`.
+- **Example:**
+  ```swift
+  if let c1 = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let c2 = Curve3D.arc(center: SIMD3(10, 0, 0), radius: 3, startAngle: 0, endAngle: .pi) {
+      let results = c1.extrema(with: c2)
+      if let closest = results.min(by: { $0.distance < $1.distance }) {
+          print(closest.distance)
+      }
+  }
+  ```
+
+---
+
+### `intersections(with:maxHits:)` (surface overload)
+
+Finds intersection points between this curve and a surface.
+
+```swift
+public func intersections(with surface: Surface, maxHits: Int = 100) -> [CurveSurfaceHit]
+```
+
+Returns an empty array when the curve does not pierce the surface. Both transverse and tangent intersections are returned.
+
+- **Parameters:** `surface` — the surface to intersect with; `maxHits` — upper bound on returned hits (default 100).
+- **Returns:** Array of `CurveSurfaceHit` values (may be empty).
+- **OCCT:** `GeomAPI_IntCS`.
+- **Example:**
+  ```swift
+  if let line = Curve3D.line(from: SIMD3(0, 0, -10), to: SIMD3(0, 0, 10)),
+     let srf  = Surface.sphere(radius: 5) {
+      let hits = line.intersections(with: srf)
+      // hits.count == 2 for a line passing through the center of the sphere
+  }
+  ```
+
+---
+
+### `minDistance(to:)` (surface overload)
+
+Returns the minimum distance from this curve to a surface.
+
+```swift
+public func minDistance(to surface: Surface) -> Double?
+```
+
+- **Parameters:** `surface` — the surface to measure against.
+- **Returns:** Minimum distance, or `nil` when `GeomAPI_ExtremaCurveSurface` finds no solution.
+- **OCCT:** `GeomAPI_ExtremaCurveSurface::LowerDistance`.
+- **Example:**
+  ```swift
+  if let c   = Curve3D.line(from: SIMD3(0, 0, 10), to: SIMD3(10, 0, 10)),
+     let srf = Surface.sphere(radius: 5),
+     let d   = c.minDistance(to: srf) {
+      print(d)  // ≈ 5.0 (line is 10 units from center, sphere radius 5)
+  }
+  ```
+
+---
+
+### `toAnalytical(tolerance:)`
+
+Converts a freeform curve to an analytic curve if it can be recognised as one.
+
+```swift
+public func toAnalytical(tolerance: Double = 1e-4) -> Curve3D?
+```
+
+Recognises lines, circles, and ellipses within the given tolerance. Useful after fitting operations that produce a B-spline approximation of a canonical shape.
+
+- **Parameters:** `tolerance` — recognition tolerance (default `1e-4`).
+- **Returns:** Analytic `Curve3D` (a `Geom_Line`, `Geom_Circle`, or `Geom_Ellipse`), or `nil` if the curve is not recognisable as a standard type.
+- **OCCT:** `GeomConvert_CurveToAnaCurve`.
+- **Example:**
+  ```swift
+  if let approxCircle = someFittedCurve.toAnalytical() {
+      // approxCircle is now a Geom_Circle if recognised
+  }
+  ```
+
+---
+
+## Quasi-Uniform Sampling (v0.31.0)
+
+Distribute sample points approximately evenly along curve arc length, backed by `GCPnts_QuasiUniformAbscissa` and `GCPnts_QuasiUniformDeflection`.
+
+---
+
+### `quasiUniformParameters(count:)`
+
+Returns parameter values at quasi-uniform arc-length intervals.
+
+```swift
+public func quasiUniformParameters(count: Int) -> [Double]
+```
+
+Uses `GCPnts_QuasiUniformAbscissa` to space `count` parameters approximately evenly along the arc length of the curve. The result is suitable for passing to `evaluateGrid(_:)`.
+
+- **Parameters:** `count` — desired number of sample parameters.
+- **Returns:** Array of parameter values of length up to `count`; empty on failure.
+- **OCCT:** `GCPnts_QuasiUniformAbscissa`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.bspline(points: myPoints) {
+      let params = c.quasiUniformParameters(count: 50)
+      let pts = c.evaluateGrid(params)
+  }
+  ```
+
+---
+
+### `quasiUniformDeflectionPoints(deflection:maxPoints:)`
+
+Returns 3D sample points distributed so that the chord deviation stays within `deflection`.
+
+```swift
+public func quasiUniformDeflectionPoints(deflection: Double, maxPoints: Int = 500) -> [SIMD3<Double>]
+```
+
+Uses `GCPnts_QuasiUniformDeflection`. Tighter curves produce more points; straighter segments produce fewer. The result is suitable for polygon rendering.
+
+- **Parameters:** `deflection` — maximum allowed chord deviation from the curve; `maxPoints` — upper bound on returned points (default 500).
+- **Returns:** Array of 3D points (may be empty on failure).
+- **OCCT:** `GCPnts_QuasiUniformDeflection`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi) {
+      let pts = arc.quasiUniformDeflectionPoints(deflection: 0.01)
+      // pts is a polyline approximation with ≤0.01 chord error
+  }
+  ```
+
+---
+
+## ShapeAnalysis\_Curve Expansion (v0.49.0)
+
+Point-projection, range validation, and parametric sampling via `ShapeAnalysis_Curve`.
+
+---
+
+### `PointProjection`
+
+Struct returned by `projectPoint(_:precision:)`.
+
+```swift
+public struct PointProjection: Sendable {
+    public let distance:  Double
+    public let parameter: Double
+    public let point:     SIMD3<Double>
+}
+```
+
+- `distance` — 3D distance from the query point to the projected point on the curve.
+- `parameter` — parameter on the curve at the closest point.
+- `point` — 3D coordinates of the closest point on the curve.
+
+---
+
+### `projectPoint(_:precision:)`
+
+Projects a 3D point onto this curve to find the closest point.
+
+```swift
+public func projectPoint(_ point: SIMD3<Double>, precision: Double = 1e-6) -> PointProjection
+```
+
+Uses `ShapeAnalysis_Curve::Project`. Always returns a result (never `nil`); a non-zero `distance` indicates the query point was not on the curve.
+
+- **Parameters:** `point` — 3D point to project; `precision` — projection precision (default `1e-6`).
+- **Returns:** `PointProjection` with distance, parameter, and closest curve point.
+- **OCCT:** `ShapeAnalysis_Curve::Project`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.line(from: .zero, to: SIMD3(10, 0, 0)) {
+      let proj = c.projectPoint(SIMD3(5, 3, 0))
+      print(proj.point)     // ≈ SIMD3(5, 0, 0)
+      print(proj.distance)  // ≈ 3.0
+  }
+  ```
+
+---
+
+### `distance(to:precision:)`
+
+Returns the shortest distance from a 3D point to this curve.
+
+```swift
+public func distance(to point: SIMD3<Double>, precision: Double = 1e-6) -> Double
+```
+
+Convenience wrapper over `projectPoint(_:precision:)` when only the scalar distance is needed.
+
+- **Parameters:** `point` — query point; `precision` — projection precision (default `1e-6`).
+- **Returns:** Shortest distance from `point` to the curve.
+- **OCCT:** Delegates to `ShapeAnalysis_Curve::Project` via `projectPoint(_:precision:)`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.line(from: .zero, to: SIMD3(10, 0, 0)) {
+      let d = c.distance(to: SIMD3(5, 3, 0))  // ≈ 3.0
+  }
+  ```
+
+---
+
+### `ValidatedRange`
+
+Struct returned by `validateRange(first:last:precision:)`.
+
+```swift
+public struct ValidatedRange: Sendable {
+    public let first:       Double
+    public let last:        Double
+    public let wasAdjusted: Bool
+}
+```
+
+- `first` / `last` — validated (and possibly clamped) parameter bounds.
+- `wasAdjusted` — `true` if the input range was outside the curve's parametric domain and was adjusted.
+
+---
+
+### `validateRange(first:last:precision:)`
+
+Validates and optionally adjusts a parameter range to lie within the curve's parametric domain.
+
+```swift
+public func validateRange(first: Double, last: Double, precision: Double = 1e-6) -> ValidatedRange
+```
+
+Uses `ShapeAnalysis_Curve::ValidateRange`. Useful before trimming or sampling a curve when the input parameters may be slightly outside the domain.
+
+- **Parameters:** `first` — desired start parameter; `last` — desired end parameter; `precision` — tolerance for domain comparison (default `1e-6`).
+- **Returns:** `ValidatedRange` with adjusted `first`/`last` and a flag indicating whether adjustment occurred.
+- **OCCT:** `ShapeAnalysis_Curve::ValidateRange`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi) {
+      let vr = c.validateRange(first: -0.001, last: 3.15)
+      // vr.wasAdjusted == true; vr.first clamped to domain start
+  }
+  ```
+
+---
+
+### `samplePoints(first:last:maxPoints:)`
+
+Returns sample points distributed along the curve between two parameter values.
+
+```swift
+public func samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> [SIMD3<Double>]
+```
+
+Uses `ShapeAnalysis_Curve::GetSamplePoints`. The distribution is chosen internally by OCCT for good geometric coverage, not strict arc-length uniformity. For uniform spacing see `quasiUniformParameters(count:)`.
+
+- **Parameters:** `first` — start parameter; `last` — end parameter; `maxPoints` — upper bound on returned points (default 1000).
+- **Returns:** Array of 3D sample points (may be empty on failure).
+- **OCCT:** `ShapeAnalysis_Curve::GetSamplePoints`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.bspline(points: myPoints) {
+      let lo = c.domain.lowerBound
+      let hi = c.domain.upperBound
+      let pts = c.samplePoints(first: lo, last: hi, maxPoints: 200)
+  }
+  ```
+
+---
+
+## v0.80.0: Extrema, ProjLib, gce Factories
+
+Low-level `Extrema_ExtCC` / `Extrema_ExtCS` curve-curve and curve-surface distance, `ProjLib` surface projection, and `gce` analytic-curve factories.
+
+---
+
+### `CurveCurveExtrema`
+
+Summary result of a curve-curve extrema computation.
+
+```swift
+public struct CurveCurveExtrema: Sendable {
+    public let isDone:     Bool
+    public let isParallel: Bool
+    public let count:      Int
+}
+```
+
+- `isDone` — `true` when the algorithm completed successfully.
+- `isParallel` — `true` when the two curves are parallel (distance is constant along the range).
+- `count` — number of extremal point pairs found.
+
+---
+
+### `ExtremaPointPair`
+
+A single extremal point pair returned by `extremaCCPoint(...)` or `extremaCSPoint(...)`.
+
+```swift
+public struct ExtremaPointPair: Sendable {
+    public let squareDistance: Double
+    public let point1:         SIMD3<Double>
+    public let param1:         Double
+    public let point2:         SIMD3<Double>
+    public let param2:         Double
+}
+```
+
+- `squareDistance` — squared distance between the two extremal points (take `sqrt` for actual distance).
+- `point1` / `param1` — point and parameter on the first curve (or query curve for curve-surface).
+- `point2` / `param2` — point and parameter on the second curve, or UV parameters packed as `(u, v, 0)` for curve-surface.
+
+---
+
+### `extremaCC(range1:other:range2:)`
+
+Computes curve-to-curve extrema using `Extrema_ExtCC`.
+
+```swift
+public func extremaCC(
+    range1: ClosedRange<Double>? = nil,
+    other:  Curve3D,
+    range2: ClosedRange<Double>? = nil
+) -> CurveCurveExtrema
+```
+
+When `range1` or `range2` is `nil`, the curve's full `domain` is used. Check `isParallel` before accessing individual point pairs — the `Known OCCT Bugs` section notes that `BRepExtrema_ExtCC` can crash on parallel edges (guarded in the bridge).
+
+- **Parameters:** `range1` — optional parameter range restricting the search on this curve; `other` — the second curve; `range2` — optional parameter range on `other`.
+- **Returns:** `CurveCurveExtrema` summary; use `extremaCCPoint(...)` to retrieve individual pairs.
+- **OCCT:** `Extrema_ExtCC`.
+- **Example:**
+  ```swift
+  if let c1 = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let c2 = Curve3D.arc(center: SIMD3(20, 0, 0), radius: 3, startAngle: 0, endAngle: .pi) {
+      let ex = c1.extremaCC(other: c2)
+      if ex.isDone && !ex.isParallel {
+          for i in 1...ex.count {
+              let pair = c1.extremaCCPoint(other: c2, index: i)
+              print(pair.squareDistance.squareRoot())
+          }
+      }
+  }
+  ```
+
+---
+
+### `extremaCCPoint(range1:other:range2:index:)`
+
+Returns the Nth extremal point pair from a curve-curve computation (1-based index).
+
+```swift
+public func extremaCCPoint(
+    range1: ClosedRange<Double>? = nil,
+    other:  Curve3D,
+    range2: ClosedRange<Double>? = nil,
+    index:  Int
+) -> ExtremaPointPair
+```
+
+Re-runs `Extrema_ExtCC` internally; call only after `extremaCC(...)` confirms `isDone` and `count >= index`.
+
+- **Parameters:** `range1` — optional range on this curve; `other` — the second curve; `range2` — optional range on `other`; `index` — 1-based extremum index.
+- **Returns:** `ExtremaPointPair` for the Nth extremum.
+- **OCCT:** `Extrema_ExtCC`.
+
+---
+
+### `LocalExtremaResult`
+
+Result of a local curve-curve extremum search near a seed.
+
+```swift
+public struct LocalExtremaResult: Sendable {
+    public let isDone:         Bool
+    public let squareDistance: Double
+    public let point1:         SIMD3<Double>
+    public let param1:         Double
+    public let point2:         SIMD3<Double>
+    public let param2:         Double
+}
+```
+
+- `isDone` — `true` when the local solver converged.
+- Other fields are the same as `ExtremaPointPair`.
+
+---
+
+### `locateExtremaCC(range1:other:range2:seedU:seedV:)`
+
+Finds a local curve-curve extremum near seed parameters.
+
+```swift
+public func locateExtremaCC(
+    range1: ClosedRange<Double>? = nil,
+    other:  Curve3D,
+    range2: ClosedRange<Double>? = nil,
+    seedU:  Double,
+    seedV:  Double
+) -> LocalExtremaResult
+```
+
+Uses `Extrema_LocateExtCC` for a fast local search around `(seedU, seedV)`. Useful when you already have a good initial guess (e.g. from a prior `extremaCC` call) and want to refine it.
+
+- **Parameters:** `range1` — optional range on this curve; `other` — the second curve; `range2` — optional range on `other`; `seedU` — initial parameter guess on this curve; `seedV` — initial parameter guess on `other`.
+- **Returns:** `LocalExtremaResult` with convergence flag and result.
+- **OCCT:** `Extrema_LocateExtCC`.
+- **Example:**
+  ```swift
+  if let c1 = Curve3D.bspline(points: pts1),
+     let c2 = Curve3D.bspline(points: pts2) {
+      let local = c1.locateExtremaCC(other: c2, seedU: 0.5, seedV: 0.3)
+      if local.isDone {
+          print(local.squareDistance.squareRoot())
+      }
+  }
+  ```
+
+---
+
+### `CurveSurfaceExtrema`
+
+Summary result of a curve-surface extrema computation.
+
+```swift
+public struct CurveSurfaceExtrema: Sendable {
+    public let isDone:     Bool
+    public let isParallel: Bool
+    public let count:      Int
+}
+```
+
+Fields mirror `CurveCurveExtrema`.
+
+---
+
+### `extremaCS(range:surface:)`
+
+Computes curve-to-surface extrema.
+
+```swift
+public func extremaCS(
+    range:   ClosedRange<Double>? = nil,
+    surface: Surface
+) -> CurveSurfaceExtrema
+```
+
+- **Parameters:** `range` — optional parameter range on this curve; `surface` — the target surface.
+- **Returns:** `CurveSurfaceExtrema` summary; use `extremaCSPoint(...)` for individual results.
+- **OCCT:** `Extrema_ExtCS`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.line(from: SIMD3(0, 0, 10), to: SIMD3(10, 0, 10)),
+     let s = Surface.sphere(radius: 5) {
+      let ex = c.extremaCS(surface: s)
+      if ex.isDone {
+          let pair = c.extremaCSPoint(surface: s, index: 1)
+          print(pair.squareDistance.squareRoot())
+      }
+  }
+  ```
+
+---
+
+### `extremaCSPoint(range:surface:index:)`
+
+Returns the Nth extremal point pair from a curve-surface computation (1-based index).
+
+```swift
+public func extremaCSPoint(
+    range:   ClosedRange<Double>? = nil,
+    surface: Surface,
+    index:   Int
+) -> ExtremaPointPair
+```
+
+- **Parameters:** `range` — optional parameter range on this curve; `surface` — the target surface; `index` — 1-based extremum index.
+- **Returns:** `ExtremaPointPair`; `param2` encodes the surface U parameter, and `point2.z` encodes V.
+- **OCCT:** `Extrema_ExtCS`.
+
+---
+
+### `projectOnSurface(_:range:tolerance:)`
+
+Projects this curve onto a surface, returning a B-spline approximation of the on-surface curve.
+
+```swift
+public func projectOnSurface(
+    _ surface:  Surface,
+    range:      ClosedRange<Double>? = nil,
+    tolerance:  Double = 1e-3
+) -> Curve3D?
+```
+
+Uses `ProjLib_ProjectOnSurface` / `ProjLib_ComputeApprox` to produce a B-spline approximation of the 3D curve lying on the surface.
+
+- **Parameters:** `surface` — the surface to project onto; `range` — optional parameter range on this curve (defaults to full domain); `tolerance` — approximation tolerance (default `1e-3`).
+- **Returns:** A new `Curve3D` (B-spline) lying on the surface, or `nil` on failure.
+- **OCCT:** `OCCTProjLibProjectOnSurface` → `ProjLib_ProjectOnSurface`.
+- **Example:**
+  ```swift
+  if let line = Curve3D.line(from: SIMD3(0, 0, -10), to: SIMD3(0, 0, 10)),
+     let sph  = Surface.sphere(radius: 10),
+     let onSph = line.projectOnSurface(sph) {
+      // onSph is a B-spline arc along the sphere meridian
+  }
+  ```
+
+---
+
+### `circleThrough3Points(_:_:_:)`
+
+Creates a circle through three 3D points.
+
+```swift
+public static func circleThrough3Points(
+    _ p1: SIMD3<Double>,
+    _ p2: SIMD3<Double>,
+    _ p3: SIMD3<Double>
+) -> Curve3D?
+```
+
+- **Parameters:** `p1`, `p2`, `p3` — three non-collinear points.
+- **Returns:** A `Geom_Circle` passing through all three points, or `nil` if the points are collinear.
+- **OCCT:** `gce_MakeCirc` (3-point constructor).
+- **Example:**
+  ```swift
+  if let c = Curve3D.circleThrough3Points(
+      SIMD3(5, 0, 0), SIMD3(0, 5, 0), SIMD3(-5, 0, 0)) {
+      // c is the circle with radius 5 in the XY plane
+  }
+  ```
+
+---
+
+### `circleFromCenterNormal(center:normal:radius:)`
+
+Creates a circle from a center point, normal direction, and radius.
+
+```swift
+public static func circleFromCenterNormal(
+    center: SIMD3<Double>,
+    normal: SIMD3<Double>,
+    radius: Double
+) -> Curve3D?
+```
+
+- **Parameters:** `center` — center of the circle; `normal` — plane normal; `radius` — circle radius.
+- **Returns:** A `Geom_Circle`, or `nil` on failure (e.g. zero normal or radius).
+- **OCCT:** `gce_MakeCirc` (center + normal + radius constructor).
+- **Example:**
+  ```swift
+  if let c = Curve3D.circleFromCenterNormal(
+      center: .zero, normal: SIMD3(0, 0, 1), radius: 10) {
+      // c is a circle of radius 10 in the XY plane
+  }
+  ```
+
+---
+
+### `lineFrom2Points(_:_:)`
+
+Creates a line (infinite) through two 3D points.
+
+```swift
+public static func lineFrom2Points(_ p1: SIMD3<Double>, _ p2: SIMD3<Double>) -> Curve3D?
+```
+
+- **Parameters:** `p1`, `p2` — two distinct points on the line.
+- **Returns:** A `Geom_Line`, or `nil` if the points are coincident.
+- **OCCT:** `gce_MakeLin`.
+- **Example:**
+  ```swift
+  if let l = Curve3D.lineFrom2Points(SIMD3(0, 0, 0), SIMD3(1, 0, 0)) {
+      // l is an infinite line along the X axis
+  }
+  ```
+
+---
+
+### `directionFrom2Points(_:_:)`
+
+Computes a unit direction vector from two 3D points.
+
+```swift
+public static func directionFrom2Points(
+    _ p1: SIMD3<Double>,
+    _ p2: SIMD3<Double>
+) -> SIMD3<Double>?
+```
+
+A pure-math utility; does not create a curve. Returns `nil` when the points are coincident.
+
+- **Parameters:** `p1` — origin point; `p2` — destination point.
+- **Returns:** Unit direction vector from `p1` toward `p2`, or `nil` if `p1 == p2`.
+- **OCCT:** `gce_MakeDir`.
+- **Example:**
+  ```swift
+  if let d = Curve3D.directionFrom2Points(SIMD3(0, 0, 0), SIMD3(3, 4, 0)) {
+      // d ≈ SIMD3(0.6, 0.8, 0)
+  }
+  ```
+
+---
+
+### `ellipseFromCenterNormal(center:normal:majorRadius:minorRadius:)`
+
+Creates a full ellipse from a center, normal, and semi-axis lengths.
+
+```swift
+public static func ellipseFromCenterNormal(
+    center:      SIMD3<Double>,
+    normal:      SIMD3<Double>,
+    majorRadius: Double,
+    minorRadius: Double
+) -> Curve3D?
+```
+
+- **Parameters:** `center` — center of the ellipse; `normal` — plane normal; `majorRadius` — semi-major axis length; `minorRadius` — semi-minor axis length (must be ≤ `majorRadius`).
+- **Returns:** A `Geom_Ellipse`, or `nil` on failure.
+- **OCCT:** `gce_MakeElips`.
+- **Example:**
+  ```swift
+  if let e = Curve3D.ellipseFromCenterNormal(
+      center: .zero, normal: SIMD3(0, 0, 1),
+      majorRadius: 10, minorRadius: 5) {
+      // e is an ellipse with semi-axes 10 and 5 in the XY plane
+  }
+  ```
+
+---
+
+### `hyperbolaFromCenterNormal(center:normal:majorRadius:minorRadius:)`
+
+Creates a hyperbola from a center, normal, and semi-axis lengths.
+
+```swift
+public static func hyperbolaFromCenterNormal(
+    center:      SIMD3<Double>,
+    normal:      SIMD3<Double>,
+    majorRadius: Double,
+    minorRadius: Double
+) -> Curve3D?
+```
+
+- **Parameters:** `center` — center; `normal` — plane normal; `majorRadius` — semi-transverse axis; `minorRadius` — semi-conjugate axis.
+- **Returns:** A `Geom_Hyperbola`, or `nil` on failure.
+- **OCCT:** `gce_MakeHypr`.
+- **Example:**
+  ```swift
+  if let h = Curve3D.hyperbolaFromCenterNormal(
+      center: .zero, normal: SIMD3(0, 0, 1),
+      majorRadius: 5, minorRadius: 3) { }
+  ```
+
+---
+
+### `parabolaFromCenterNormal(center:normal:focal:)`
+
+Creates a parabola from a vertex (center), normal, and focal distance.
+
+```swift
+public static func parabolaFromCenterNormal(
+    center: SIMD3<Double>,
+    normal: SIMD3<Double>,
+    focal:  Double
+) -> Curve3D?
+```
+
+- **Parameters:** `center` — vertex (apex) of the parabola; `normal` — plane normal; `focal` — focal distance (distance from vertex to focus).
+- **Returns:** A `Geom_Parabola`, or `nil` on failure.
+- **OCCT:** `gce_MakeParab`.
+- **Example:**
+  ```swift
+  if let p = Curve3D.parabolaFromCenterNormal(
+      center: .zero, normal: SIMD3(0, 0, 1), focal: 2) { }
+  ```
+
+---
+
+### `serializeCurves(_:)`
+
+Serializes an array of curves to a string using `GeomTools_CurveSet`.
+
+```swift
+public static func serializeCurves(_ curves: [Curve3D]) -> String?
+```
+
+The format is OCCT's internal text stream format, suitable for persistence or interprocess transfer. Round-trip with `deserializeCurves(_:)`.
+
+- **Parameters:** `curves` — curves to serialize.
+- **Returns:** Serialized string, or `nil` on failure.
+- **OCCT:** `GeomTools_CurveSet::Write`.
+- **Example:**
+  ```swift
+  if let c1 = Curve3D.line(from: .zero, to: SIMD3(1, 0, 0)),
+     let c2 = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let data = Curve3D.serializeCurves([c1, c2]) {
+      // store or transmit `data`
+  }
+  ```
+
+---
+
+### `deserializeCurves(_:)`
+
+Deserializes curves from a string produced by `serializeCurves(_:)`.
+
+```swift
+public static func deserializeCurves(_ data: String) -> [Curve3D]?
+```
+
+- **Parameters:** `data` — string produced by `serializeCurves(_:)`.
+- **Returns:** Array of reconstructed `Curve3D` values, or `nil` if parsing fails or yields no curves.
+- **OCCT:** `GeomTools_CurveSet::Read`.
+- **Example:**
+  ```swift
+  if let curves = Curve3D.deserializeCurves(storedData) {
+      for c in curves { /* use c */ }
+  }
+  ```
+
+---
+
+## ExtremaPC — Point-Curve Distance (v0.130.0)
+
+All-extrema and minimum-distance computation from a point to a curve, backed by `Extrema_ExtPC`.
+
+---
+
+### `ExtremumResult`
+
+Struct returned by `extrema(from:)` and `extrema(from:uMin:uMax:)`.
+
+```swift
+public struct ExtremumResult: Sendable {
+    public let parameter: Double
+    public let distance:  Double
+    public let point:     SIMD3<Double>
+}
+```
+
+- `parameter` — curve parameter at the extremal point.
+- `distance` — distance from the query point to the extremal curve point.
+- `point` — 3D coordinates of the extremal point on the curve.
+
+---
+
+### `extrema(from:)`
+
+Finds all extrema (closest and farthest points) from a query point to this curve.
+
+```swift
+public func extrema(from point: SIMD3<Double>) -> [ExtremumResult]
+```
+
+Uses `Extrema_ExtPC` over the full curve domain. Returns up to 64 results. The minimum-distance result is the `ExtremumResult` with the smallest `distance`.
+
+- **Parameters:** `point` — the query point.
+- **Returns:** Array of `ExtremumResult` values (empty on failure or no extrema found).
+- **OCCT:** `Extrema_ExtPC`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi) {
+      let results = arc.extrema(from: SIMD3(3, 4, 0))
+      if let nearest = results.min(by: { $0.distance < $1.distance }) {
+          print(nearest.point, nearest.distance)
+      }
+  }
+  ```
+
+---
+
+### `extrema(from:uMin:uMax:)`
+
+Finds all extrema from a point to a bounded segment of this curve.
+
+```swift
+public func extrema(from point: SIMD3<Double>, uMin: Double, uMax: Double) -> [ExtremumResult]
+```
+
+Restricts the search to `[uMin, uMax]` using `Extrema_ExtPC` with bounded adaptor. Returns up to 64 results.
+
+- **Parameters:** `point` — query point; `uMin` — lower parameter bound; `uMax` — upper parameter bound.
+- **Returns:** Array of `ExtremumResult` values within the specified range (empty on failure).
+- **OCCT:** `Extrema_ExtPC` with bounded `GeomAdaptor_Curve`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.bspline(points: myPoints) {
+      let lo = c.domain.lowerBound
+      let mid = (lo + c.domain.upperBound) / 2
+      let results = c.extrema(from: SIMD3(1, 2, 3), uMin: lo, uMax: mid)
+  }
+  ```
+
+---
+
+### `minimumDistance(from:)`
+
+Returns the minimum distance from a point to this curve.
+
+```swift
+public func minimumDistance(from point: SIMD3<Double>) -> Double?
+```
+
+Convenience method backed by `Extrema_ExtPC`. Returns `nil` when the algorithm fails to find any extremum.
+
+- **Parameters:** `point` — the query point.
+- **Returns:** Minimum distance, or `nil` on failure.
+- **OCCT:** `Extrema_ExtPC` via `OCCTExtremaPCMinDistance`.
+- **Example:**
+  ```swift
+  if let c = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi),
+     let d = c.minimumDistance(from: SIMD3(0, 10, 0)) {
+      print(d)  // ≈ 5.0
+  }
+  ```

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -1,0 +1,1255 @@
+---
+title: Curve3D — Analytic Types
+parent: API Reference
+---
+
+# Curve3D — Analytic Types
+
+These members expose type-specific properties of analytic curves (circle, ellipse, hyperbola, parabola, line) plus B-spline/Bézier pole/knot/weight accessors. They are valid only when the underlying curve is of the matching kind — accessing them on a mismatched curve type returns zero/nil silently. See the main [Curve3D](Curve3D.md) page for construction methods, evaluation, and operations.
+
+## Topics
+
+- [BSpline Queries](#bspline-queries) · [BSpline Knot Splitting (v0.40.0)](#bspline-knot-splitting-v0400) · [Geom_Circle Properties (v0.108.0)](#geom_circle-properties-v01080) · [Geom_Ellipse Properties (v0.108.0)](#geom_ellipse-properties-v01080) · [Geom_Hyperbola Properties (v0.108.0)](#geom_hyperbola-properties-v01080) · [Geom_Parabola Properties (v0.108.0)](#geom_parabola-properties-v01080) · [Geom_Line Properties (v0.108.0)](#geom_line-properties-v01080) · [Bezier Curve deep method completion (v0.125.0)](#bezier-curve-deep-method-completion-v01250) · [Bezier 3D completions (v0.126.0)](#bezier-3d-completions-v01260) · [BSpline completions (v0.127.0)](#bspline-completions-v01270)
+
+---
+
+## BSpline Queries
+
+### `poleCount`
+
+Number of poles (control points), or `nil` if the curve is not a B-spline or Bézier.
+
+```swift
+public var poleCount: Int? { get }
+```
+
+- **Returns:** Pole count, or `nil` when the curve cannot be downcast to `Geom_BSplineCurve` or `Geom_BezierCurve`.
+- **OCCT:** `Geom_BSplineCurve::NbPoles` / `Geom_BezierCurve::NbPoles`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bspline(poles: pts, knots: knots, multiplicities: mults, degree: 3) {
+      if let n = curve.poleCount { /* n == pts.count */ }
+  }
+  ```
+
+---
+
+### `poles`
+
+All poles (control points) of a B-spline or Bézier curve.
+
+```swift
+public var poles: [SIMD3<Double>]? { get }
+```
+
+- **Returns:** Array of pole positions in model space, or `nil` if the curve is not a B-spline/Bézier or retrieval fails.
+- **OCCT:** `Geom_BSplineCurve::Pole` / `Geom_BezierCurve::Pole` (iterated via `NbPoles`).
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bspline(poles: pts, knots: knots, multiplicities: mults, degree: 3),
+     let poles = curve.poles {
+      for p in poles { print(p) }
+  }
+  ```
+
+---
+
+### `degree`
+
+Polynomial degree of the B-spline or Bézier curve.
+
+```swift
+public var degree: Int { get }
+```
+
+- **Returns:** Degree of the curve, or `-1` if the curve is not a B-spline or Bézier.
+- **OCCT:** `Geom_BSplineCurve::Degree` / `Geom_BezierCurve::Degree`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bspline(poles: pts, knots: knots, multiplicities: mults, degree: 3) {
+      let d = curve.degree  // 3
+  }
+  ```
+
+---
+
+## BSpline Knot Splitting (v0.40.0)
+
+### `ContinuityOrder`
+
+Continuity level used for knot-splitting analysis.
+
+```swift
+public enum ContinuityOrder: Int32 {
+    case c0 = 0   // positional
+    case c1 = 1   // tangent
+    case c2 = 2   // curvature
+}
+```
+
+Pass to `continuityBreaks(minContinuity:)` to specify the minimum required continuity across knots.
+
+---
+
+### `continuityBreaks(minContinuity:)`
+
+Parameter values where the B-spline's internal continuity drops below the specified level.
+
+```swift
+public func continuityBreaks(minContinuity: ContinuityOrder = .c1) -> [Double]?
+```
+
+Only works on `Geom_BSplineCurve`. Returns knot parameters where the curve's continuity is strictly less than `minContinuity`. Useful for splitting a composite B-spline into smooth segments.
+
+- **Parameters:** `minContinuity` — minimum continuity to require (default `.c1`).
+- **Returns:** Array of parameter values at continuity breaks (up to 256), or `nil` if the curve is not a B-spline.
+- **OCCT:** `GeomConvert_BSplineCurveKnotSplitting::NbSplits` / `SplitValue`, resolved via `Geom_BSplineCurve::Knot`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bspline(poles: pts, knots: knots, multiplicities: mults, degree: 3),
+     let breaks = curve.continuityBreaks(minContinuity: .c1) {
+      let segments = curve.toBezierSegments() // split at each break
+  }
+  ```
+
+---
+
+## Geom_Circle Properties (v0.108.0)
+
+### `circleProperties`
+
+Returns the circle-specific property accessor for this curve.
+
+```swift
+public var circleProperties: CircleProperties { get }
+```
+
+Meaningful only when the curve wraps a `Geom_Circle`. Accessing members on a non-circle returns zero.
+
+- **Returns:** A `CircleProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_Circle` — accessed via `Handle(Geom_Circle)::DownCast`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      let cp = curve.circleProperties
+  }
+  ```
+
+---
+
+### `CircleProperties.radius`
+
+The radius of the circle.
+
+```swift
+public var radius: Double { get }
+```
+
+- **Returns:** Radius in model units, or `0` if the curve is not a `Geom_Circle`.
+- **OCCT:** `Geom_Circle::Radius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      let r = curve.circleProperties.radius  // 5.0
+  }
+  ```
+
+---
+
+### `CircleProperties.setRadius(_:)`
+
+Mutates the circle's radius in place.
+
+```swift
+@discardableResult
+public func setRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new radius (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a circle or the value is invalid.
+- **OCCT:** `Geom_Circle::SetRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      curve.circleProperties.setRadius(8)
+  }
+  ```
+
+---
+
+### `CircleProperties.eccentricity`
+
+The eccentricity of the circle (always `0.0`).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** `0.0` for any circle; `0` if the curve is not a circle.
+- **OCCT:** `Geom_Circle::Eccentricity`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      let e = curve.circleProperties.eccentricity  // 0.0
+  }
+  ```
+
+---
+
+### `CircleProperties.center`
+
+The centre point of the circle.
+
+```swift
+public var center: SIMD3<Double> { get }
+```
+
+- **Returns:** Centre position in model space, or `.zero` if the curve is not a circle.
+- **OCCT:** `Geom_Circle::Circ().Location()` via `gp_Circ::Location`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1), radius: 5) {
+      let c = curve.circleProperties.center  // SIMD3(1, 2, 3)
+  }
+  ```
+
+---
+
+### `CircleProperties.xAxis`
+
+The X axis of the circle's local frame: a position point and direction.
+
+```swift
+public var xAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+The X axis lies in the circle's plane, pointing toward the zero-angle parameter position.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the curve is not a circle.
+- **OCCT:** `Geom_Circle::XAxis` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      let ax = curve.circleProperties.xAxis
+  }
+  ```
+
+---
+
+### `CircleProperties.yAxis`
+
+The Y axis of the circle's local frame: a position point and direction.
+
+```swift
+public var yAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+The Y axis lies in the circle's plane, 90° counterclockwise from the X axis.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the curve is not a circle.
+- **OCCT:** `Geom_Circle::YAxis` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      let ay = curve.circleProperties.yAxis
+  }
+  ```
+
+---
+
+## Geom_Ellipse Properties (v0.108.0)
+
+### `ellipseProperties`
+
+Returns the ellipse-specific property accessor for this curve.
+
+```swift
+public var ellipseProperties: EllipseProperties { get }
+```
+
+Meaningful only when the curve wraps a `Geom_Ellipse`. Accessing members on a non-ellipse returns zero.
+
+- **Returns:** An `EllipseProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_Ellipse` — accessed via `Handle(Geom_Ellipse)::DownCast`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let ep = curve.ellipseProperties
+  }
+  ```
+
+---
+
+### `EllipseProperties.majorRadius`
+
+The major radius (semi-major axis length).
+
+```swift
+public var majorRadius: Double { get }
+```
+
+- **Returns:** Major radius in model units, or `0` if the curve is not a `Geom_Ellipse`.
+- **OCCT:** `Geom_Ellipse::MajorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let R = curve.ellipseProperties.majorRadius  // 10.0
+  }
+  ```
+
+---
+
+### `EllipseProperties.minorRadius`
+
+The minor radius (semi-minor axis length).
+
+```swift
+public var minorRadius: Double { get }
+```
+
+- **Returns:** Minor radius in model units, or `0` if the curve is not a `Geom_Ellipse`.
+- **OCCT:** `Geom_Ellipse::MinorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let r = curve.ellipseProperties.minorRadius  // 5.0
+  }
+  ```
+
+---
+
+### `EllipseProperties.setMajorRadius(_:)`
+
+Mutates the ellipse's major radius in place.
+
+```swift
+@discardableResult
+public func setMajorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new major radius (must be > minor radius per OCCT).
+- **Returns:** `true` on success, `false` if the curve is not an ellipse or the value is invalid.
+- **OCCT:** `Geom_Ellipse::SetMajorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      curve.ellipseProperties.setMajorRadius(12)
+  }
+  ```
+
+---
+
+### `EllipseProperties.setMinorRadius(_:)`
+
+Mutates the ellipse's minor radius in place.
+
+```swift
+@discardableResult
+public func setMinorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new minor radius (must be < major radius per OCCT).
+- **Returns:** `true` on success, `false` if the curve is not an ellipse or the value is invalid.
+- **OCCT:** `Geom_Ellipse::SetMinorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      curve.ellipseProperties.setMinorRadius(3)
+  }
+  ```
+
+---
+
+### `EllipseProperties.eccentricity`
+
+The eccentricity of the ellipse (0 < e < 1).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** Eccentricity `e = sqrt(1 − (b/a)²)`, or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom_Ellipse::Eccentricity`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let e = curve.ellipseProperties.eccentricity  // ≈ 0.866
+  }
+  ```
+
+---
+
+### `EllipseProperties.focal`
+
+The focal distance (distance between the two foci, i.e. `2c`).
+
+```swift
+public var focal: Double { get }
+```
+
+- **Returns:** `2 * sqrt(a² − b²)`, or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom_Ellipse::Focal`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let f = curve.ellipseProperties.focal  // ≈ 17.32
+  }
+  ```
+
+---
+
+### `EllipseProperties.focus1`
+
+The first focus point.
+
+```swift
+public var focus1: SIMD3<Double> { get }
+```
+
+- **Returns:** First focus position in model space, or `.zero` if the curve is not an ellipse.
+- **OCCT:** `Geom_Ellipse::Focus1`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let f1 = curve.ellipseProperties.focus1
+  }
+  ```
+
+---
+
+### `EllipseProperties.focus2`
+
+The second focus point.
+
+```swift
+public var focus2: SIMD3<Double> { get }
+```
+
+- **Returns:** Second focus position in model space, or `.zero` if the curve is not an ellipse.
+- **OCCT:** `Geom_Ellipse::Focus2`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let f2 = curve.ellipseProperties.focus2
+  }
+  ```
+
+---
+
+### `EllipseProperties.parameter`
+
+The semi-latus rectum (`b² / a`).
+
+```swift
+public var parameter: Double { get }
+```
+
+- **Returns:** Semi-latus rectum in model units, or `0` if the curve is not an ellipse.
+- **OCCT:** `Geom_Ellipse::Parameter`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let p = curve.ellipseProperties.parameter  // 2.5 (25/10)
+  }
+  ```
+
+---
+
+### `EllipseProperties.directrix1`
+
+The first directrix (position + direction).
+
+```swift
+public var directrix1: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+The directrix is perpendicular to the major axis. Its distance from the centre is `a / e`.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the curve is not an ellipse.
+- **OCCT:** `Geom_Ellipse::Directrix1` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                  majorRadius: 10, minorRadius: 5) {
+      let d1 = curve.ellipseProperties.directrix1
+  }
+  ```
+
+---
+
+## Geom_Hyperbola Properties (v0.108.0)
+
+### `hyperbolaProperties`
+
+Returns the hyperbola-specific property accessor for this curve.
+
+```swift
+public var hyperbolaProperties: HyperbolaProperties { get }
+```
+
+Meaningful only when the curve wraps a `Geom_Hyperbola`. Accessing members on a non-hyperbola returns zero.
+
+- **Returns:** A `HyperbolaProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_Hyperbola` — accessed via `Handle(Geom_Hyperbola)::DownCast`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let hp = curve.hyperbolaProperties
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.majorRadius`
+
+The major radius (real semi-axis).
+
+```swift
+public var majorRadius: Double { get }
+```
+
+- **Returns:** Real semi-axis length in model units, or `0` if the curve is not a `Geom_Hyperbola`.
+- **OCCT:** `Geom_Hyperbola::MajorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let a = curve.hyperbolaProperties.majorRadius  // 5.0
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.minorRadius`
+
+The minor radius (imaginary semi-axis).
+
+```swift
+public var minorRadius: Double { get }
+```
+
+- **Returns:** Imaginary semi-axis length in model units, or `0` if the curve is not a `Geom_Hyperbola`.
+- **OCCT:** `Geom_Hyperbola::MinorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let b = curve.hyperbolaProperties.minorRadius  // 3.0
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.setMajorRadius(_:)`
+
+Mutates the hyperbola's major radius in place.
+
+```swift
+@discardableResult
+public func setMajorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new major radius (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a hyperbola or the value is invalid.
+- **OCCT:** `Geom_Hyperbola::SetMajorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      curve.hyperbolaProperties.setMajorRadius(7)
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.setMinorRadius(_:)`
+
+Mutates the hyperbola's minor radius in place.
+
+```swift
+@discardableResult
+public func setMinorRadius(_ r: Double) -> Bool
+```
+
+- **Parameters:** `r` — new minor radius (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a hyperbola or the value is invalid.
+- **OCCT:** `Geom_Hyperbola::SetMinorRadius`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      curve.hyperbolaProperties.setMinorRadius(4)
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.eccentricity`
+
+The eccentricity of the hyperbola (e > 1).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** `e = sqrt(1 + (b/a)²) > 1`, or `0` if the curve is not a hyperbola.
+- **OCCT:** `Geom_Hyperbola::Eccentricity`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let e = curve.hyperbolaProperties.eccentricity  // ≈ 1.166
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.focal`
+
+The focal distance (distance between the two foci, i.e. `2c`).
+
+```swift
+public var focal: Double { get }
+```
+
+- **Returns:** `2 * sqrt(a² + b²)`, or `0` if the curve is not a hyperbola.
+- **OCCT:** `Geom_Hyperbola::Focal`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let f = curve.hyperbolaProperties.focal  // ≈ 11.66
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.focus1`
+
+The first focus point.
+
+```swift
+public var focus1: SIMD3<Double> { get }
+```
+
+- **Returns:** First focus in model space, or `.zero` if the curve is not a hyperbola.
+- **OCCT:** `Geom_Hyperbola::Focus1`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let f1 = curve.hyperbolaProperties.focus1
+  }
+  ```
+
+---
+
+### `HyperbolaProperties.asymptote1`
+
+The first asymptote (position + direction).
+
+```swift
+public var asymptote1: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+For a standard hyperbola with semi-axes `a`, `b`, the asymptote direction is `(a, b, 0)` (normalised). The two asymptotes are symmetric about the transverse axis.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the curve is not a hyperbola.
+- **OCCT:** `Geom_Hyperbola::Asymptote1` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                    majorRadius: 5, minorRadius: 3) {
+      let a1 = curve.hyperbolaProperties.asymptote1
+  }
+  ```
+
+---
+
+## Geom_Parabola Properties (v0.108.0)
+
+### `parabolaProperties`
+
+Returns the parabola-specific property accessor for this curve.
+
+```swift
+public var parabolaProperties: ParabolaProperties { get }
+```
+
+Meaningful only when the curve wraps a `Geom_Parabola`. Accessing members on a non-parabola returns zero.
+
+- **Returns:** A `ParabolaProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_Parabola` — accessed via `Handle(Geom_Parabola)::DownCast`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      let pp = curve.parabolaProperties
+  }
+  ```
+
+---
+
+### `ParabolaProperties.focal`
+
+The focal distance of the parabola.
+
+```swift
+public var focal: Double { get }
+```
+
+Distance from the vertex to the focus. The directrix is the same distance on the opposite side of the vertex.
+
+- **Returns:** Focal length in model units, or `0` if the curve is not a `Geom_Parabola`.
+- **OCCT:** `Geom_Parabola::Focal`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      let f = curve.parabolaProperties.focal  // 3.0
+  }
+  ```
+
+---
+
+### `ParabolaProperties.setFocal(_:)`
+
+Mutates the parabola's focal distance in place.
+
+```swift
+@discardableResult
+public func setFocal(_ f: Double) -> Bool
+```
+
+- **Parameters:** `f` — new focal distance (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a parabola or `f` is invalid.
+- **OCCT:** `Geom_Parabola::SetFocal`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      curve.parabolaProperties.setFocal(5)
+  }
+  ```
+
+---
+
+### `ParabolaProperties.focus`
+
+The focus point of the parabola.
+
+```swift
+public var focus: SIMD3<Double> { get }
+```
+
+- **Returns:** Focus position in model space, or `.zero` if the curve is not a parabola.
+- **OCCT:** `Geom_Parabola::Focus`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      let fpt = curve.parabolaProperties.focus
+  }
+  ```
+
+---
+
+### `ParabolaProperties.eccentricity`
+
+The eccentricity of the parabola (always `1.0`).
+
+```swift
+public var eccentricity: Double { get }
+```
+
+- **Returns:** `1.0` for any parabola; `0` if the curve is not a parabola.
+- **OCCT:** `Geom_Parabola::Eccentricity`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      let e = curve.parabolaProperties.eccentricity  // 1.0
+  }
+  ```
+
+---
+
+### `ParabolaProperties.parameter`
+
+The parameter of the parabola (`2 * focal`).
+
+```swift
+public var parameter: Double { get }
+```
+
+Half the length of the latus rectum; the perpendicular chord through the focus.
+
+- **Returns:** `2 * focal` in model units, or `0` if the curve is not a parabola.
+- **OCCT:** `Geom_Parabola::Parameter`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      let p = curve.parabolaProperties.parameter  // 6.0
+  }
+  ```
+
+---
+
+### `ParabolaProperties.directrix`
+
+The directrix of the parabola (position + direction).
+
+```swift
+public var directrix: (position: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+The directrix is a line perpendicular to the parabola's axis at distance `focal` on the opposite side of the vertex from the focus.
+
+- **Returns:** Tuple `(position, direction)`. Returns `(.zero, .zero)` if the curve is not a parabola.
+- **OCCT:** `Geom_Parabola::Directrix` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      let d = curve.parabolaProperties.directrix
+  }
+  ```
+
+---
+
+## Geom_Line Properties (v0.108.0)
+
+### `lineProperties`
+
+Returns the line-specific property accessor for this curve.
+
+```swift
+public var lineProperties: LineProperties { get }
+```
+
+Meaningful only when the curve wraps a `Geom_Line`. Accessing members on a non-line returns zero.
+
+- **Returns:** A `LineProperties` value backed by the same internal handle.
+- **OCCT:** `Geom_Line` — accessed via `Handle(Geom_Line)::DownCast`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: .zero, direction: SIMD3(1, 0, 0)) {
+      let lp = curve.lineProperties
+  }
+  ```
+
+---
+
+### `LineProperties.direction`
+
+The unit direction vector of the line.
+
+```swift
+public var direction: SIMD3<Double> { get }
+```
+
+- **Returns:** Unit direction, or `.zero` if the curve is not a `Geom_Line`.
+- **OCCT:** `Geom_Line::Lin().Direction()`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: .zero, direction: SIMD3(1, 0, 0)) {
+      let d = curve.lineProperties.direction  // SIMD3(1, 0, 0)
+  }
+  ```
+
+---
+
+### `LineProperties.location`
+
+The origin (location) point of the line.
+
+```swift
+public var location: SIMD3<Double> { get }
+```
+
+- **Returns:** Origin position in model space, or `.zero` if the curve is not a line.
+- **OCCT:** `Geom_Line::Lin().Location()`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: SIMD3(1, 2, 3), direction: SIMD3(0, 0, 1)) {
+      let loc = curve.lineProperties.location  // SIMD3(1, 2, 3)
+  }
+  ```
+
+---
+
+### `LineProperties.setDirection(_:)`
+
+Mutates the line's direction in place.
+
+```swift
+@discardableResult
+public func setDirection(_ d: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `d` — new direction (will be normalised by OCCT via `gp_Dir`; must be non-zero).
+- **Returns:** `true` on success, `false` if the curve is not a line or `d` is degenerate.
+- **OCCT:** `Geom_Line::SetDirection`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: .zero, direction: SIMD3(1, 0, 0)) {
+      curve.lineProperties.setDirection(SIMD3(0, 1, 0))
+  }
+  ```
+
+---
+
+### `LineProperties.setLocation(_:)`
+
+Mutates the line's origin point in place.
+
+```swift
+@discardableResult
+public func setLocation(_ p: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `p` — new origin point.
+- **Returns:** `true` on success, `false` if the curve is not a line.
+- **OCCT:** `Geom_Line::SetLocation`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: .zero, direction: SIMD3(1, 0, 0)) {
+      curve.lineProperties.setLocation(SIMD3(5, 0, 0))
+  }
+  ```
+
+---
+
+### `LineProperties.position`
+
+The line's position axis: origin location and unit direction.
+
+```swift
+public var position: (location: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+Combines location and direction into a single call via the underlying `gp_Ax1`.
+
+- **Returns:** Tuple `(location, direction)`. Returns `(.zero, .zero)` if the curve is not a line.
+- **OCCT:** `Geom_Line::Position` → `gp_Ax1::Location` + `gp_Ax1::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: SIMD3(1, 0, 0), direction: SIMD3(0, 1, 0)) {
+      let pos = curve.lineProperties.position
+  }
+  ```
+
+---
+
+### `LineProperties.lin`
+
+The `gp_Lin` representation: origin location and unit direction.
+
+```swift
+public var lin: (location: SIMD3<Double>, direction: SIMD3<Double>) { get }
+```
+
+Equivalent to `position` but reads the data via `Geom_Line::Lin()` rather than `Geom_Line::Position()`. Both return the same values in practice.
+
+- **Returns:** Tuple `(location, direction)`. Returns `(.zero, .zero)` if the curve is not a line.
+- **OCCT:** `Geom_Line::Lin()` → `gp_Lin::Location` + `gp_Lin::Direction`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.line(origin: .zero, direction: SIMD3(0, 0, 1)) {
+      let l = curve.lineProperties.lin
+  }
+  ```
+
+---
+
+## Bezier Curve deep method completion (v0.125.0)
+
+### `bezierStartPoint`
+
+The start point (first pole) of the Bézier curve.
+
+```swift
+public var bezierStartPoint: SIMD3<Double> { get }
+```
+
+Returns `.zero` if the curve is not a `Geom_BezierCurve`.
+
+- **OCCT:** `Geom_BezierCurve::StartPoint`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      let start = curve.bezierStartPoint  // SIMD3(0,0,0)
+  }
+  ```
+
+---
+
+### `bezierEndPoint`
+
+The end point (last pole) of the Bézier curve.
+
+```swift
+public var bezierEndPoint: SIMD3<Double> { get }
+```
+
+Returns `.zero` if the curve is not a `Geom_BezierCurve`.
+
+- **OCCT:** `Geom_BezierCurve::EndPoint`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      let end = curve.bezierEndPoint  // SIMD3(2,0,0)
+  }
+  ```
+
+---
+
+### `bezierPoles`
+
+All poles of the Bézier curve as an array.
+
+```swift
+public var bezierPoles: [SIMD3<Double>] { get }
+```
+
+Returns an empty array if the curve is not a `Geom_BezierCurve` or has no poles.
+
+- **OCCT:** `Geom_BezierCurve::NbPoles` + `Geom_BezierCurve::Pole` (iterated).
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      let pts = curve.bezierPoles  // count == 3
+  }
+  ```
+
+---
+
+### `bezierWeights`
+
+All weights of the rational Bézier curve.
+
+```swift
+public var bezierWeights: [Double]? { get }
+```
+
+- **Returns:** Array of weights (one per pole), or `nil` if the curve is non-rational or not a Bézier.
+- **OCCT:** `Geom_BezierCurve::Weight` (iterated) — returns `nil` when the curve is non-rational.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)],
+                                 weights: [1, 0.5, 1]) {
+      if let w = curve.bezierWeights { print(w) }
+  }
+  ```
+
+---
+
+### `bezierIsClosed`
+
+Whether the Bézier curve is geometrically closed.
+
+```swift
+public var bezierIsClosed: Bool { get }
+```
+
+- **Returns:** `true` if the first and last pole coincide within tolerance; always `false` for non-Bézier curves.
+- **OCCT:** `Geom_BezierCurve::IsClosed`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(0,0,0)]) {
+      let closed = curve.bezierIsClosed  // true
+  }
+  ```
+
+---
+
+### `bezierIsPeriodic`
+
+Whether the Bézier curve is periodic.
+
+```swift
+public var bezierIsPeriodic: Bool { get }
+```
+
+Bézier curves are never periodic in OCCT; this always returns `false` for `Geom_BezierCurve`.
+
+- **Returns:** `false` for any Bézier curve; `false` for non-Bézier curves.
+- **OCCT:** `Geom_BezierCurve::IsPeriodic`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      let p = curve.bezierIsPeriodic  // false
+  }
+  ```
+
+---
+
+### `bezierContinuity`
+
+The global continuity class of the Bézier curve (0 = C0, 1 = C1, 2 = C2, 3 = C3, 4 = CN).
+
+```swift
+public var bezierContinuity: Int { get }
+```
+
+A Bézier curve of degree ≥ 1 is always C∞ (returns `4` = CN). Returns `0` for non-Bézier curves.
+
+- **OCCT:** `Geom_BezierCurve::Continuity` → `GeomAbs_Shape` mapped to Int.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      let cont = curve.bezierContinuity  // 4 (CN)
+  }
+  ```
+
+---
+
+### `bezierIsCN(_:)`
+
+Whether the Bézier curve is at least C`n` continuous.
+
+```swift
+public func bezierIsCN(_ n: Int) -> Bool
+```
+
+- **Parameters:** `n` — required continuity order.
+- **Returns:** `true` if the curve is at least C`n`; `false` for non-Bézier curves.
+- **OCCT:** `Geom_BezierCurve::IsCN`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      let ok = curve.bezierIsCN(2)  // true
+  }
+  ```
+
+---
+
+## Bezier 3D completions (v0.126.0)
+
+### `bezierInsertPoleBefore(_:point:)`
+
+Insert a pole before a given index in the Bézier curve (1-based).
+
+```swift
+@discardableResult
+public func bezierInsertPoleBefore(_ index: Int, point: SIMD3<Double>) -> Bool
+```
+
+Modifies the underlying `Geom_BezierCurve` in place, increasing the pole count by one and raising the degree by one.
+
+- **Parameters:**
+  - `index` — 1-based insertion position (the new pole is placed before this index).
+  - `point` — new control point position.
+- **Returns:** `true` on success, `false` if the curve is not a Bézier or the index is out of range.
+- **OCCT:** `Geom_BezierCurve::InsertPoleAfter` (called with `index − 1` to implement before semantics).
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(2,0,0)]) {
+      curve.bezierInsertPoleBefore(2, point: SIMD3(1, 1, 0))
+      // curve now has 3 poles
+  }
+  ```
+
+---
+
+### `bezierReverse()`
+
+Reverse the parameterization of the Bézier curve in place.
+
+```swift
+@discardableResult
+public func bezierReverse() -> Bool
+```
+
+Poles are reordered so the curve traces the same path in the opposite parameter direction.
+
+- **Returns:** `true` on success, `false` if the curve is not a Bézier.
+- **OCCT:** `Geom_BezierCurve::Reverse`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
+      curve.bezierReverse()
+      let start = curve.bezierStartPoint  // now SIMD3(2,0,0)
+  }
+  ```
+
+---
+
+### `bezierSetPoleWithWeight(index:point:weight:)`
+
+Set a pole and its weight simultaneously on a rational Bézier curve.
+
+```swift
+@discardableResult
+public func bezierSetPoleWithWeight(index: Int, point: SIMD3<Double>, weight: Double) -> Bool
+```
+
+- **Parameters:**
+  - `index` — 1-based pole index.
+  - `point` — new control point position.
+  - `weight` — new weight for the pole (must be > 0).
+- **Returns:** `true` on success, `false` if the curve is not a Bézier, the index is out of range, or the weight is non-positive.
+- **OCCT:** `Geom_BezierCurve::SetPole` + `Geom_BezierCurve::SetWeight`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)],
+                                 weights: [1, 1, 1]) {
+      curve.bezierSetPoleWithWeight(index: 2, point: SIMD3(1, 2, 0), weight: 0.5)
+  }
+  ```
+
+---
+
+## BSpline completions (v0.127.0)
+
+### `bsplinePeriodicNormalization(_:)`
+
+Normalize a parameter value for a periodic B-spline curve.
+
+```swift
+public func bsplinePeriodicNormalization(_ u: Double) -> Double?
+```
+
+Maps an arbitrary parameter value into the curve's fundamental period `[first, first + period)`.
+
+- **Parameters:** `u` — raw parameter value.
+- **Returns:** Normalized parameter in the fundamental period, or `nil` if the curve is not a periodic B-spline.
+- **OCCT:** `Geom_BSplineCurve::PeriodicNormalization`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.interpolatePeriodic(points: pts),
+     let norm = curve.bsplinePeriodicNormalization(7.5) {
+      let pt = curve.point(at: norm)
+  }
+  ```
+
+---
+
+### `bsplineIsG1(tFirst:tLast:angularTolerance:)`
+
+Check G1 (tangent) continuity of a B-spline on a parameter range.
+
+```swift
+public func bsplineIsG1(tFirst: Double, tLast: Double, angularTolerance: Double = 0.01) -> Bool
+```
+
+Uses OCCT's `Geom_BSplineCurve::IsG1` to verify that the curve's tangent direction changes by at most `angularTolerance` radians everywhere in `[tFirst, tLast]`.
+
+- **Parameters:**
+  - `tFirst` — start of parameter range.
+  - `tLast` — end of parameter range.
+  - `angularTolerance` — angular tolerance in radians (default `0.01`).
+- **Returns:** `true` if G1 continuous on the range; `false` otherwise or if the curve is not a B-spline.
+- **OCCT:** `Geom_BSplineCurve::IsG1`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.bspline(poles: pts, knots: knots, multiplicities: mults, degree: 3) {
+      let d = curve.domain
+      let smooth = curve.bsplineIsG1(tFirst: d.lowerBound, tLast: d.upperBound)
+  }
+  ```

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -1,0 +1,537 @@
+---
+title: Curve3D — Construction
+parent: API Reference
+---
+
+# Curve3D — Construction
+
+This page documents higher-level `Curve3D` construction APIs: arcs of conics (hyperbola, parabola), three-point ellipse and hyperbola factories, periodic conversion, parameter-splitting, expanded interpolation variants, and arc-length utilities. For the core type overview, primitives, BSpline/Bezier construction, operations, and transforms, see the main [Curve3D](Curve3D.md) page.
+
+## Topics
+
+- [Arc Construction, Periodic Conversion, Splitting (v0.50.0)](#arc-construction-periodic-conversion-splitting-v0500) · [GC_MakeEllipse/Hyperbola Three-Point Constructors (v0.51.0)](#gc_makeellipsehyperbola-three-point-constructors-v0510) · [Interpolation Expansion, Length, Closest Point (v0.115.0)](#interpolation-expansion-length-closest-point-v01150)
+
+---
+
+## Arc Construction, Periodic Conversion, Splitting (v0.50.0)
+
+### `Curve3D.arcOfHyperbola(center:direction:majorRadius:minorRadius:alpha1:alpha2:sense:)`
+
+Creates a trimmed arc of a hyperbola between two parameter values.
+
+```swift
+public static func arcOfHyperbola(
+    center: SIMD3<Double> = .zero,
+    direction: SIMD3<Double> = SIMD3(0, 0, 1),
+    majorRadius: Double,
+    minorRadius: Double,
+    alpha1: Double,
+    alpha2: Double,
+    sense: Bool = true
+) -> Curve3D?
+```
+
+The hyperbola lies in the plane whose normal is `direction`. `alpha1` and `alpha2` are the start and end hyperbolic parameters (not angles). `sense: true` preserves the natural parameterization direction.
+
+- **Parameters:** `center` — hyperbola centre; `direction` — plane normal; `majorRadius` — real semi-axis (a); `minorRadius` — imaginary semi-axis (b); `alpha1` — start parameter; `alpha2` — end parameter; `sense` — parameterization direction (`true` = natural).
+- **Returns:** Trimmed hyperbolic arc, or `nil` on failure.
+- **OCCT:** `GC_MakeArcOfHyperbola(gp_Hypr, alpha1, alpha2, sense)` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arcOfHyperbola(
+      majorRadius: 5, minorRadius: 3,
+      alpha1: -1.0, alpha2: 1.0
+  ) {
+      let pts = arc.drawAdaptive()
+  }
+  ```
+
+---
+
+### `Curve3D.arcOfParabola(center:direction:focalDistance:alpha1:alpha2:sense:)`
+
+Creates a trimmed arc of a parabola between two parameter values.
+
+```swift
+public static func arcOfParabola(
+    center: SIMD3<Double> = .zero,
+    direction: SIMD3<Double> = SIMD3(0, 0, 1),
+    focalDistance: Double,
+    alpha1: Double,
+    alpha2: Double,
+    sense: Bool = true
+) -> Curve3D?
+```
+
+The parabola vertex is at `center` and the focal distance determines its opening width. `alpha1` and `alpha2` are the parabolic parameters bounding the arc.
+
+- **Parameters:** `center` — parabola vertex; `direction` — plane normal; `focalDistance` — focal distance (must be > 0); `alpha1` — start parameter; `alpha2` — end parameter; `sense` — parameterization direction.
+- **Returns:** Trimmed parabolic arc, or `nil` on failure.
+- **OCCT:** `GC_MakeArcOfParabola(gp_Parab, alpha1, alpha2, sense)` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  if let arc = Curve3D.arcOfParabola(focalDistance: 4, alpha1: -3.0, alpha2: 3.0) {
+      let mid = arc.point(at: arc.domain.lowerBound + (arc.domain.upperBound - arc.domain.lowerBound) / 2)
+  }
+  ```
+
+---
+
+### `convertToPeriodic()`
+
+Converts a closed BSpline curve to its periodic form.
+
+```swift
+public func convertToPeriodic() -> Curve3D?
+```
+
+The curve must be closed (start point equals end point). The resulting periodic BSpline seamlessly wraps around without a visible join. Use this before surfaces or wires that require periodic input.
+
+- **Returns:** Periodic BSpline curve, or `nil` if the curve is not closed or periodic conversion is not possible.
+- **OCCT:** `ShapeCustom_Curve::ConvertToPeriodic`.
+- **Example:**
+  ```swift
+  if let closed = Curve3D.interpolate(points: [
+      SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(-1, 0, 0), SIMD3(0, -1, 0)
+  ], closed: true) {
+      if let periodic = closed.convertToPeriodic() {
+          #expect(periodic.isPeriodic)
+      }
+  }
+  ```
+
+---
+
+### `SplitResult`
+
+A pair of curve segments produced by `splitAt(parameter:)`.
+
+```swift
+public struct SplitResult {
+    public let first: Curve3D   // segment before the split parameter
+    public let second: Curve3D  // segment after the split parameter
+}
+```
+
+---
+
+### `splitAt(parameter:)`
+
+Splits this curve at a parameter value into two segments.
+
+```swift
+public func splitAt(parameter: Double) -> SplitResult?
+```
+
+The split parameter must lie strictly inside the curve's domain (`domain.lowerBound < parameter < domain.upperBound`). Returns two curves whose domains cover `[first, parameter]` and `[parameter, last]` respectively.
+
+- **Parameters:** `parameter` — split position within the open interior of `domain`.
+- **Returns:** `SplitResult` with `first` and `second` segments, or `nil` if `parameter` is outside the open interior or splitting fails.
+- **OCCT:** `ShapeUpgrade_SplitCurve3d::Perform` → `TColGeom_HArray1OfCurve`.
+- **Example:**
+  ```swift
+  if let seg = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)),
+     let result = seg.splitAt(parameter: seg.domain.lowerBound + (seg.domain.upperBound - seg.domain.lowerBound) / 2) {
+      #expect(result.first.endPoint.x < result.second.startPoint.x + 1e-6)
+  }
+  ```
+
+---
+
+## GC_MakeEllipse/Hyperbola Three-Point Constructors (v0.51.0)
+
+### `Curve3D.ellipseThreePoints(s1:s2:center:)`
+
+Creates a full ellipse defined by two axis endpoints and a centre.
+
+```swift
+public static func ellipseThreePoints(
+    s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>
+) -> Curve3D?
+```
+
+`s1` is the end of the major axis (determines major radius and axis direction); `s2` defines the extent of the minor axis. The plane is determined by the three points. This form is convenient when the three geometric points are known but the radii and normal must be derived.
+
+- **Parameters:** `s1` — major axis endpoint; `s2` — minor axis extent point; `center` — ellipse centre.
+- **Returns:** Full ellipse curve, or `nil` if the three points are degenerate or `GC_MakeEllipse` fails.
+- **OCCT:** `GC_MakeEllipse(gp_Pnt s1, gp_Pnt s2, gp_Pnt center)`.
+- **Example:**
+  ```swift
+  if let ellipse = Curve3D.ellipseThreePoints(
+      s1: SIMD3(10, 0, 0), s2: SIMD3(0, 5, 0), center: .zero
+  ) {
+      let pts = ellipse.drawAdaptive()
+  }
+  ```
+
+---
+
+### `Curve3D.hyperbolaThreePoints(s1:s2:center:)`
+
+Creates a full hyperbola defined by two axis endpoints and a centre.
+
+```swift
+public static func hyperbolaThreePoints(
+    s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>
+) -> Curve3D?
+```
+
+`s1` is the end of the real (transverse) axis; `s2` defines the extent of the imaginary (conjugate) axis. Analogous to `ellipseThreePoints` for hyperbolas.
+
+- **Parameters:** `s1` — transverse axis endpoint; `s2` — conjugate axis extent point; `center` — hyperbola centre.
+- **Returns:** Full hyperbola curve, or `nil` on failure.
+- **OCCT:** `GC_MakeHyperbola(gp_Pnt s1, gp_Pnt s2, gp_Pnt center)`.
+- **Example:**
+  ```swift
+  if let hyp = Curve3D.hyperbolaThreePoints(
+      s1: SIMD3(5, 0, 0), s2: SIMD3(0, 3, 0), center: .zero
+  ) {
+      let arc = hyp.trimmed(from: -1.0, to: 1.0)
+  }
+  ```
+
+---
+
+## Interpolation Expansion, Length, Closest Point (v0.115.0)
+
+### `Curve3D.interpolate(points:startTangent:endTangent:)`
+
+Interpolates a BSpline through points with constrained endpoint tangents.
+
+```swift
+public static func interpolate(
+    points: [SIMD3<Double>],
+    startTangent: SIMD3<Double>,
+    endTangent: SIMD3<Double>
+) -> Curve3D?
+```
+
+Like `interpolate(points:closed:tolerance:)` but pins the tangent direction at the first and last interpolation points. Useful when the approach and departure directions are known (e.g. G1 join to adjacent geometry).
+
+- **Parameters:** `points` — interpolation points (minimum 2); `startTangent` — tangent at the first point; `endTangent` — tangent at the last point.
+- **Returns:** Interpolated BSpline, or `nil` on failure.
+- **OCCT:** `GeomAPI_Interpolate::Load(startTangent, endTangent)` + `Perform()`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.interpolate(
+      points: [SIMD3(0, 0, 0), SIMD3(5, 5, 0), SIMD3(10, 0, 0)],
+      startTangent: SIMD3(1, 0, 0),
+      endTangent: SIMD3(1, 0, 0)
+  ) {
+      let len = curve.totalArcLength
+  }
+  ```
+
+---
+
+### `Curve3D.interpolate(points:tangents:tangentFlags:)`
+
+Interpolates a BSpline with per-point tangent constraints.
+
+```swift
+public static func interpolate(
+    points: [SIMD3<Double>],
+    tangents: [SIMD3<Double>],
+    tangentFlags: [Bool]
+) -> Curve3D?
+```
+
+Each point can independently opt in or out of its tangent constraint via `tangentFlags`. All three arrays must have the same length.
+
+- **Parameters:** `points` — interpolation points; `tangents` — desired tangent at each point; `tangentFlags` — `true` to enforce the corresponding tangent, `false` to ignore it.
+- **Returns:** Interpolated BSpline, or `nil` if array lengths differ or interpolation fails.
+- **OCCT:** `GeomAPI_Interpolate::Load(tangents, tangentFlags)` + `Perform()`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(5,3,0), SIMD3(10,0,0)]
+  let tans: [SIMD3<Double>] = [SIMD3(1,1,0), SIMD3(1,0,0), SIMD3(1,-1,0)]
+  let flags = [true, false, true]  // enforce only first and last tangents
+  if let curve = Curve3D.interpolate(points: pts, tangents: tans, tangentFlags: flags) {
+      let d = curve.domain
+      #expect(curve.point(at: d.lowerBound).x < 1e-6)
+  }
+  ```
+
+---
+
+### `Curve3D.interpolate(points:parameters:)`
+
+Interpolates a BSpline at explicitly specified parameter values.
+
+```swift
+public static func interpolate(
+    points: [SIMD3<Double>],
+    parameters: [Double]
+) -> Curve3D?
+```
+
+Controls the parameterization explicitly — each point is placed at the corresponding parameter value. `points` and `parameters` must have the same length. Parameters must be strictly increasing.
+
+- **Parameters:** `points` — interpolation points; `parameters` — parameter value for each point (same count, strictly increasing).
+- **Returns:** Interpolated BSpline, or `nil` if counts differ or construction fails.
+- **OCCT:** `GeomAPI_Interpolate(pts, params, Standard_False, tol)` + `Perform()`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(3,5,0), SIMD3(10,0,0)]
+  let params = [0.0, 0.3, 1.0]
+  if let curve = Curve3D.interpolate(points: pts, parameters: params) {
+      #expect(abs(curve.point(at: 0.3).y - 5.0) < 0.5)
+  }
+  ```
+
+---
+
+### `Curve3D.interpolatePeriodic(points:)`
+
+Interpolates a periodic (closed) BSpline through the given points.
+
+```swift
+public static func interpolatePeriodic(points: [SIMD3<Double>]) -> Curve3D?
+```
+
+The resulting curve is periodic: it passes through all points and closes smoothly back to the first point without an explicit closing segment. The first and last points need not coincide.
+
+- **Parameters:** `points` — interpolation points (minimum 2, typically 3 or more for a non-degenerate loop).
+- **Returns:** Periodic interpolated BSpline, or `nil` on failure.
+- **OCCT:** `GeomAPI_Interpolate(pts, Standard_True, tol)` + `Perform()`.
+- **Example:**
+  ```swift
+  if let loop = Curve3D.interpolatePeriodic(points: [
+      SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(-1, 0, 0), SIMD3(0, -1, 0)
+  ]) {
+      #expect(loop.isPeriodic)
+  }
+  ```
+
+---
+
+### `Curve3D.approximate(points:degMin:degMax:continuity:tolerance:)`
+
+Approximates a BSpline through points with degree and continuity control.
+
+```swift
+public static func approximate(
+    points: [SIMD3<Double>],
+    degMin: Int = 3,
+    degMax: Int = 8,
+    continuity: Int = 2,
+    tolerance: Double = 1e-3
+) -> Curve3D?
+```
+
+Unlike `interpolate`, the curve does not pass exactly through every point; it minimises deviation within `tolerance`. `continuity` maps to `GeomAbs_Shape`: 0=C0, 1=G1, 2=C1.
+
+- **Parameters:** `points` — data points (minimum 2); `degMin` — minimum polynomial degree; `degMax` — maximum polynomial degree; `continuity` — minimum continuity order (0=C0, 1=G1, 2=C1); `tolerance` — maximum allowed deviation.
+- **Returns:** Approximating BSpline, or `nil` on failure.
+- **OCCT:** `GeomAPI_PointsToBSpline(pts, degMin, degMax, continuity, tolerance)`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [
+      SIMD3(0,0,0), SIMD3(2,3,0), SIMD3(5,1,0), SIMD3(8,4,0), SIMD3(10,0,0)
+  ]
+  if let curve = Curve3D.approximate(points: pts, degMin: 3, degMax: 8,
+                                      continuity: 2, tolerance: 1e-3) {
+      let len = curve.totalArcLength
+  }
+  ```
+
+---
+
+### `Curve3D.approximate(points:parameters:degMin:degMax:continuity:tolerance:)`
+
+Approximates a BSpline with explicit parameter values at each point.
+
+```swift
+public static func approximate(
+    points: [SIMD3<Double>],
+    parameters: [Double],
+    degMin: Int = 3,
+    degMax: Int = 8,
+    continuity: Int = 2,
+    tolerance: Double = 1e-3
+) -> Curve3D?
+```
+
+Combines approximation with explicit parameterization — useful when the data comes with known parameter stamps (e.g. timestamps or arc-length fractions).
+
+- **Parameters:** `points` — data points; `parameters` — parameter for each point (same count, strictly increasing); `degMin`/`degMax` — degree bounds; `continuity` — minimum continuity; `tolerance` — maximum deviation.
+- **Returns:** Approximating BSpline, or `nil` if counts differ or construction fails.
+- **OCCT:** `GeomAPI_PointsToBSpline(pts, params, degMin, degMax, continuity, tolerance)`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(3,5,0), SIMD3(10,0,0)]
+  let params = [0.0, 0.3, 1.0]
+  if let curve = Curve3D.approximate(points: pts, parameters: params, degMin: 2, degMax: 6) {
+      let len = curve.totalArcLength
+  }
+  ```
+
+---
+
+### `arcLength(from:to:)`
+
+The arc length of this curve between two parameter values.
+
+```swift
+public func arcLength(from u1: Double, to u2: Double) -> Double
+```
+
+Non-optional; returns `0` if the curve is invalid or an exception occurs internally.
+
+- **Parameters:** `u1` — start parameter; `u2` — end parameter (must satisfy `u1 ≤ u2`).
+- **Returns:** Arc length in model units.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(GeomAdaptor_Curve(curve, u1, u2))`.
+- **Example:**
+  ```swift
+  if let curve = Curve3D.interpolate(
+      points: [SIMD3(0,0,0), SIMD3(10,0,0)],
+      startTangent: SIMD3(1,0,0), endTangent: SIMD3(1,0,0)
+  ) {
+      let d = curve.domain
+      let len = curve.arcLength(from: d.lowerBound, to: d.upperBound)
+      #expect(len > 0)
+  }
+  ```
+
+---
+
+### `parameterAtLength(_:from:)`
+
+Finds the parameter at a given arc-length distance from a starting parameter.
+
+```swift
+public func parameterAtLength(_ arcLength: Double, from startParam: Double? = nil) -> Double
+```
+
+Uses `GCPnts_AbscissaPoint` for accurate arc-length parameterisation. Positive `arcLength` advances forward; negative reverses. Returns `0` on internal failure.
+
+- **Parameters:** `arcLength` — distance to advance along the curve; `startParam` — starting parameter (defaults to `domain.lowerBound`).
+- **Returns:** The parameter value at the specified arc-length distance from `startParam`.
+- **OCCT:** `GCPnts_AbscissaPoint(adaptor, arcLength, startParam)::Parameter`.
+- **Example:**
+  ```swift
+  let line = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(10,0,0))!
+  let midParam = line.parameterAtLength(5.0)
+  let midPt = line.point(at: midParam)
+  #expect(abs(midPt.x - 5.0) < 0.01)
+  ```
+
+---
+
+### `totalArcLength`
+
+The total arc length of the curve over its full domain.
+
+```swift
+public var totalArcLength: Double { get }
+```
+
+Integrates the curve from `domain.lowerBound` to `domain.upperBound`. Distinct from the `length` property on the main page (which returns `Double?`); this always returns a `Double` (0 on failure).
+
+- **Returns:** Total arc length in model units.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(GeomAdaptor_Curve(curve))`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 10)!
+  let circumference = circle.totalArcLength
+  #expect(abs(circumference - 2 * Double.pi * 10) < 0.1)
+  ```
+
+---
+
+### `arcLengthBetween(_:_:)`
+
+The arc length between two parameter values.
+
+```swift
+public func arcLengthBetween(_ param1: Double, _ param2: Double) -> Double
+```
+
+Like `arcLength(from:to:)` but with unlabelled parameters. Returns `0` on failure.
+
+- **Parameters:** `param1` — first parameter; `param2` — second parameter.
+- **Returns:** Arc length between the two parameters.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor, param1, param2)`.
+- **Example:**
+  ```swift
+  let line = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(10,0,0))!
+  let d = line.domain
+  let half = line.arcLengthBetween(d.lowerBound, (d.lowerBound + d.upperBound) / 2)
+  #expect(abs(half - 5.0) < 0.01)
+  ```
+
+---
+
+### `closestParameter(to:)`
+
+Finds the parameter of the closest point on this curve to a given 3D point.
+
+```swift
+public func closestParameter(to point: SIMD3<Double>) -> Double
+```
+
+Uses a projection; returns `0` if projection finds no points or an exception occurs.
+
+- **Parameters:** `point` — the query point in 3D space.
+- **Returns:** Parameter `u` such that `self.point(at: u)` is the nearest point on the curve to `point`.
+- **OCCT:** `GeomAPI_ProjectPointOnCurve::LowerDistanceParameter`.
+- **Example:**
+  ```swift
+  if let line = Curve3D.line(through: .zero, direction: SIMD3(1,0,0)) {
+      let param = line.closestParameter(to: SIMD3(5, 3, 0))
+      #expect(abs(param - 5.0) < 0.1)
+  }
+  ```
+
+---
+
+### `splitAtContinuity(continuity:tolerance:maxSegments:)`
+
+Splits this curve at continuity discontinuities, returning the resulting segments.
+
+```swift
+public func splitAtContinuity(
+    continuity: Int = 1,
+    tolerance: Double = 1e-6,
+    maxSegments: Int = 32
+) -> [Curve3D]
+```
+
+The curve is first converted to BSpline form, then split at C1 (or higher) discontinuities. For `continuity > 1` the implementation returns the single converted BSpline unchanged (higher-order splitting not yet implemented). Returns an empty array on failure.
+
+- **Parameters:** `continuity` — continuity level to split at (0=C0, 1=C1); `tolerance` — discontinuity detection tolerance; `maxSegments` — maximum output segment count.
+- **Returns:** Array of BSpline curve segments (at least one on success).
+- **OCCT:** `GeomConvert::C0BSplineToArrayOfC1BSplineCurve` (for `continuity ≤ 1`).
+- **Example:**
+  ```swift
+  if let curve = Curve3D.fit(points: [SIMD3(0,0,0), SIMD3(5,5,0), SIMD3(10,0,0)]) {
+      let segs = curve.splitAtContinuity()
+      #expect(segs.count >= 1)
+  }
+  ```
+
+---
+
+### `Curve3D.concatenateG1(curves:tolerance:)`
+
+Concatenates an array of curves into a single BSpline with G1 continuity.
+
+```swift
+public static func concatenateG1(curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D?
+```
+
+Each input curve is converted to BSpline form before joining. Curves must connect end-to-end within `tolerance`.
+
+- **Parameters:** `curves` — ordered array of curves to join; `tolerance` — endpoint gap tolerance.
+- **Returns:** Joined BSpline curve, or `nil` if the array is empty or conversion fails.
+- **OCCT:** `GeomConvert_CompCurveToBSplineCurve::Add` + `BSplineCurve()`.
+- **Example:**
+  ```swift
+  let pts1: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(5,5,0), SIMD3(10,0,0)]
+  let pts2: [SIMD3<Double>] = [SIMD3(10,0,0), SIMD3(15,-5,0), SIMD3(20,0,0)]
+  if let c1 = Curve3D.fit(points: pts1),
+     let c2 = Curve3D.fit(points: pts2),
+     let joined = Curve3D.concatenateG1(curves: [c1, c2]) {
+      #expect(joined.totalArcLength > c1.totalArcLength)
+  }
+  ```

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -1,0 +1,1319 @@
+---
+title: Curve3D
+parent: API Reference
+---
+
+# Curve3D
+
+A `Curve3D` is a parametric 3D curve — the Swift analog of OCCT's `Geom_Curve` class hierarchy. It wraps lines, segments, circles, ellipses, arcs, parabolas, hyperbolas, BSplines, Bezier curves, and specialty curves (helix, sine wave, TBezier, AHT Bezier) polymorphically behind a single opaque handle. Obtain a `Curve3D` via one of the static factory methods on `Curve3D`, by extracting it from an `Edge`, or by converting a `Wire` edge's underlying geometry.
+
+> **Note:** `Curve3D` is documented across several pages — see also **Curve3D — Analytic Types**, **Curve3D — Analysis**, and **Curve3D — Construction**.
+
+## Topics
+
+- [Properties](#properties) · [Evaluation](#evaluation) · [Primitive Curves](#primitive-curves) · [BSpline & Bezier](#bspline--bezier) · [Operations](#operations) · [Conversion (GeomConvert)](#conversion-geomconvert) · [Draw (Discretization for Metal)](#draw-discretization-for-metal) · [Bounding Box](#bounding-box) · [Ellipse Arcs](#ellipse-arcs) · [Curve joining (v0.49.0)](#curve-joining-v0490) · [Curve3D Transform (v0.128.0)](#curve3d-transform-v01280) · [GeomEval Analytical Curve Factories (v0.130.0)](#geomeval-analytical-curve-factories-v01300) · [GeomEval TBezier / AHTBezier Curves, TransformedCurve (v0.131.0)](#geomeval-tbezier--ahtbezier-curves-transformedcurve-v01310)
+
+---
+
+## Properties
+
+### `domain`
+
+The parametric domain `[first, last]` of the curve.
+
+```swift
+public var domain: ClosedRange<Double> { get }
+```
+
+OCCT curves are defined over a specific parameter interval. Use `domain.lowerBound` and `domain.upperBound` when calling `point(at:)`, `d1(at:)`, `d2(at:)`, and related methods.
+
+- **Returns:** A closed range of valid parameter values for this curve.
+- **OCCT:** `Geom_Curve::FirstParameter` / `LastParameter`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  let d = circle.domain   // 0...2π
+  let mid = circle.point(at: (d.lowerBound + d.upperBound) / 2)
+  ```
+
+---
+
+### `isClosed`
+
+Whether the curve forms a closed loop (start point equals end point).
+
+```swift
+public var isClosed: Bool { get }
+```
+
+- **OCCT:** `Geom_Curve::IsClosed`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  #expect(circle.isClosed == true)
+  ```
+
+---
+
+### `isPeriodic`
+
+Whether the curve repeats with a fixed period.
+
+```swift
+public var isPeriodic: Bool { get }
+```
+
+- **OCCT:** `Geom_Curve::IsPeriodic`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+  #expect(seg.isPeriodic == false)
+  ```
+
+---
+
+### `period`
+
+The period of the curve, or `nil` if the curve is not periodic.
+
+```swift
+public var period: Double? { get }
+```
+
+- **Returns:** Period value, or `nil` if `isPeriodic` is `false`.
+- **OCCT:** `Geom_Curve::Period`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  if let p = circle.period { print(p) }  // ≈ 2π
+  ```
+
+---
+
+### `startPoint`
+
+The 3D point at the start of the parametric domain.
+
+```swift
+public var startPoint: SIMD3<Double> { get }
+```
+
+Convenience for `point(at: domain.lowerBound)`.
+
+- **OCCT:** `Geom_Curve::Value(FirstParameter)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(1, 2, 3), to: SIMD3(4, 5, 6))!
+  print(seg.startPoint)  // SIMD3(1.0, 2.0, 3.0)
+  ```
+
+---
+
+### `endPoint`
+
+The 3D point at the end of the parametric domain.
+
+```swift
+public var endPoint: SIMD3<Double> { get }
+```
+
+Convenience for `point(at: domain.upperBound)`.
+
+- **OCCT:** `Geom_Curve::Value(LastParameter)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(1, 2, 3), to: SIMD3(4, 5, 6))!
+  print(seg.endPoint)  // SIMD3(4.0, 5.0, 6.0)
+  ```
+
+---
+
+## Evaluation
+
+### `point(at:)`
+
+Evaluates the 3D point on the curve at a given parameter.
+
+```swift
+public func point(at u: Double) -> SIMD3<Double>
+```
+
+- **Parameters:** `u` — parameter value within `domain`.
+- **Returns:** 3D position on the curve.
+- **OCCT:** `Geom_Curve::Value(u)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+  let mid = seg.point(at: (seg.domain.lowerBound + seg.domain.upperBound) / 2)
+  // mid ≈ SIMD3(5, 0, 0)
+  ```
+
+---
+
+### `d1(at:)`
+
+Evaluates the position and first derivative (tangent) at a parameter.
+
+```swift
+public func d1(at u: Double) -> (point: SIMD3<Double>, tangent: SIMD3<Double>)
+```
+
+The tangent vector is not normalised — its magnitude depends on the parameterization. For a unit tangent, normalise the result.
+
+- **Parameters:** `u` — parameter value within `domain`.
+- **Returns:** Tuple of position and first-derivative vector.
+- **OCCT:** `Geom_Curve::D1(u, P, V1)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  let (pos, tan) = circle.d1(at: 0)
+  ```
+
+---
+
+### `d2(at:)`
+
+Evaluates position, first derivative, and second derivative at a parameter.
+
+```swift
+public func d2(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>)
+```
+
+The second derivative is needed for curvature and osculating-circle calculations.
+
+- **Parameters:** `u` — parameter value within `domain`.
+- **Returns:** Tuple of position, first derivative, and second derivative.
+- **OCCT:** `Geom_Curve::D2(u, P, V1, V2)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+  let (pt, v1, v2) = seg.d2(at: 0)
+  // v2 ≈ SIMD3(0, 0, 0) — zero second derivative for a line
+  ```
+
+---
+
+## Primitive Curves
+
+### `Curve3D.line(through:direction:)`
+
+Creates an infinite line through a point in a direction.
+
+```swift
+public static func line(through point: SIMD3<Double>, direction: SIMD3<Double>) -> Curve3D?
+```
+
+The curve is not bounded; its domain is `(-∞, +∞)`. Use `trimmed(from:to:)` or `segment(from:to:)` if a bounded segment is required.
+
+- **Parameters:** `point` — a point on the line; `direction` — line direction (need not be normalised).
+- **Returns:** Line curve, or `nil` if `direction` is zero.
+- **OCCT:** `Geom_Line(gp_Lin(point, direction))`.
+- **Example:**
+  ```swift
+  let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))
+  ```
+
+---
+
+### `Curve3D.segment(from:to:)`
+
+Creates a bounded line segment between two points.
+
+```swift
+public static func segment(from p1: SIMD3<Double>, to p2: SIMD3<Double>) -> Curve3D?
+```
+
+Equivalent to an infinite line trimmed to the arc-length interval `[0, distance(p1, p2)]`.
+
+- **Parameters:** `p1` — start point; `p2` — end point.
+- **Returns:** Segment curve, or `nil` if `p1` and `p2` coincide.
+- **OCCT:** `GC_MakeSegment(p1, p2)` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 5, 3))!
+  print(seg.length)  // ≈ 11.58
+  ```
+
+---
+
+### `Curve3D.circle(center:normal:radius:)`
+
+Creates a full (unrimmed) circle in a plane defined by a centre point and normal.
+
+```swift
+public static func circle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double) -> Curve3D?
+```
+
+The circle is periodic with period `2π`. The X axis of the local frame is determined by OCCT's `gp_Ax2` construction from `normal`.
+
+- **Parameters:** `center` — circle centre; `normal` — plane normal; `radius` — circle radius (must be > 0).
+- **Returns:** Full circle curve, or `nil` if `radius ≤ 0` or `normal` is zero.
+- **OCCT:** `Geom_Circle(gp_Ax2(...), radius)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  #expect(circle.isClosed)
+  ```
+
+---
+
+### `Curve3D.arcOfCircle(start:interior:end:)`
+
+Creates a circular arc through three specified points.
+
+```swift
+public static func arcOfCircle(start: SIMD3<Double>, interior: SIMD3<Double>, end: SIMD3<Double>) -> Curve3D?
+```
+
+OCCT derives the centre and radius from the three points. The arc sweeps from `start` through `interior` to `end`.
+
+- **Parameters:** `start` — first endpoint; `interior` — a point on the arc; `end` — second endpoint.
+- **Returns:** Arc curve, or `nil` if the three points are collinear or coincident.
+- **OCCT:** `GC_MakeArcOfCircle(start, interior, end)` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve3D.arcOfCircle(
+      start: SIMD3(5, 0, 0), interior: SIMD3(0, 5, 0), end: SIMD3(-5, 0, 0))!
+  ```
+
+---
+
+### `Curve3D.arc(through:_:_:)`
+
+Alias for `arcOfCircle(start:interior:end:)`.
+
+```swift
+public static func arc(through p1: SIMD3<Double>, _ pm: SIMD3<Double>, _ p2: SIMD3<Double>) -> Curve3D?
+```
+
+- **Parameters:** `p1` — first endpoint; `pm` — interior midpoint; `p2` — second endpoint.
+- **Returns:** Arc curve, or `nil` if points are collinear or coincident.
+- **OCCT:** `GC_MakeArcOfCircle` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve3D.arc(through: SIMD3(5, 0, 0), SIMD3(0, 5, 0), SIMD3(-5, 0, 0))
+  ```
+
+---
+
+### `Curve3D.ellipse(center:normal:majorRadius:minorRadius:)`
+
+Creates a full ellipse in a plane defined by a centre and normal.
+
+```swift
+public static func ellipse(center: SIMD3<Double>, normal: SIMD3<Double>,
+                           majorRadius: Double, minorRadius: Double) -> Curve3D?
+```
+
+The major axis direction is determined automatically by `gp_Ax2`. Use `arcOfEllipse` to create a bounded arc.
+
+- **Parameters:** `center` — ellipse centre; `normal` — plane normal; `majorRadius` — semi-major axis (must be > `minorRadius`); `minorRadius` — semi-minor axis (must be > 0).
+- **Returns:** Full ellipse curve, or `nil` on failure.
+- **OCCT:** `Geom_Ellipse(gp_Ax2(...), majorRadius, minorRadius)`.
+- **Example:**
+  ```swift
+  let ellipse = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                majorRadius: 10, minorRadius: 5)!
+  ```
+
+---
+
+### `Curve3D.parabola(center:normal:focal:)`
+
+Creates a parabola with the given focal distance in a plane.
+
+```swift
+public static func parabola(center: SIMD3<Double>, normal: SIMD3<Double>, focal: Double) -> Curve3D?
+```
+
+- **Parameters:** `center` — vertex of the parabola; `normal` — plane normal; `focal` — focal distance (must be > 0).
+- **Returns:** Parabola curve, or `nil` if `focal ≤ 0`.
+- **OCCT:** `Geom_Parabola(gp_Ax2(...), focal)`.
+- **Example:**
+  ```swift
+  let par = Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 2)
+  ```
+
+---
+
+### `Curve3D.hyperbola(center:normal:majorRadius:minorRadius:)`
+
+Creates a hyperbola in a plane defined by a centre and normal.
+
+```swift
+public static func hyperbola(center: SIMD3<Double>, normal: SIMD3<Double>,
+                             majorRadius: Double, minorRadius: Double) -> Curve3D?
+```
+
+- **Parameters:** `center` — hyperbola centre; `normal` — plane normal; `majorRadius` — real semi-axis; `minorRadius` — imaginary semi-axis (both must be > 0).
+- **Returns:** Hyperbola curve, or `nil` on failure.
+- **OCCT:** `Geom_Hyperbola(gp_Ax2(...), majorRadius, minorRadius)`.
+- **Example:**
+  ```swift
+  let hyp = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                               majorRadius: 3, minorRadius: 2)
+  ```
+
+---
+
+## BSpline & Bezier
+
+### `Curve3D.bspline(poles:weights:knots:multiplicities:degree:)`
+
+Creates a BSpline (or rational NURBS) curve from explicit poles, knots, multiplicities, and degree.
+
+```swift
+public static func bspline(poles: [SIMD3<Double>], weights: [Double]? = nil,
+                           knots: [Double], multiplicities: [Int32],
+                           degree: Int) -> Curve3D?
+```
+
+When `weights` is `nil`, all pole weights default to 1.0 (non-rational B-spline). Provides complete control over knot structure for CAD data exchange use cases.
+
+- **Parameters:**
+  - `poles` — control points (minimum 2).
+  - `weights` — per-pole weights (`nil` = uniform 1.0).
+  - `knots` — distinct knot values.
+  - `multiplicities` — per-knot multiplicity.
+  - `degree` — curve degree (≥ 1).
+- **Returns:** BSpline/NURBS curve, or `nil` if parameters are invalid.
+- **OCCT:** `Geom_BSplineCurve(poles, knots, multiplicities, degree)`.
+- **Example:**
+  ```swift
+  let poles: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(5,10,0), SIMD3(10,0,0)]
+  let knots = [0.0, 1.0]
+  let mults: [Int32] = [4, 4]
+  let bsp = Curve3D.bspline(poles: poles, knots: knots, multiplicities: mults, degree: 3)
+  ```
+
+---
+
+### `Curve3D.bezier(poles:weights:)`
+
+Creates a Bezier curve from control points, with optional rational weights.
+
+```swift
+public static func bezier(poles: [SIMD3<Double>], weights: [Double]? = nil) -> Curve3D?
+```
+
+The curve passes through the first and last pole. Interior poles act as attractors. The degree equals `poles.count - 1`.
+
+- **Parameters:** `poles` — control points (minimum 2); `weights` — per-pole rational weights (`nil` = uniform 1.0).
+- **Returns:** Bezier curve, or `nil` if fewer than 2 poles or construction fails.
+- **OCCT:** `Geom_BezierCurve(poles)` or `Geom_BezierCurve(poles, weights)`.
+- **Example:**
+  ```swift
+  let bez = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(5,10,0), SIMD3(10,0,0)])!
+  print(bez.startPoint)  // SIMD3(0, 0, 0)
+  ```
+
+---
+
+### `Curve3D.interpolate(points:closed:tolerance:)`
+
+Creates a BSpline that passes exactly through all specified points.
+
+```swift
+public static func interpolate(points: [SIMD3<Double>], closed: Bool = false,
+                               tolerance: Double = 1e-6) -> Curve3D?
+```
+
+Unlike `bspline(poles:…)`, the curve passes exactly through every point. Use `closed: true` for a periodic loop.
+
+- **Parameters:** `points` — points the curve must pass through (minimum 2); `closed` — closed/periodic curve; `tolerance` — interpolation precision.
+- **Returns:** Interpolated BSpline curve, or `nil` on failure.
+- **OCCT:** `GeomAPI_Interpolate` + `Perform()`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [
+      SIMD3(0,0,0), SIMD3(5,5,0), SIMD3(10,0,0), SIMD3(15,5,0)
+  ]
+  if let curve = Curve3D.interpolate(points: pts) {
+      print(curve.point(at: curve.domain.lowerBound))  // ≈ SIMD3(0,0,0)
+  }
+  ```
+
+---
+
+### `Curve3D.interpolate(points:startTangent:endTangent:tolerance:)`
+
+Creates a BSpline through points with constrained endpoint tangents.
+
+```swift
+public static func interpolate(points: [SIMD3<Double>],
+                               startTangent: SIMD3<Double>,
+                               endTangent: SIMD3<Double>,
+                               tolerance: Double = 1e-6) -> Curve3D?
+```
+
+- **Parameters:** `points` — interpolation points; `startTangent` — tangent at the first point; `endTangent` — tangent at the last point; `tolerance` — precision.
+- **Returns:** Interpolated BSpline, or `nil` on failure.
+- **OCCT:** `GeomAPI_Interpolate::Load(startTangent, endTangent)` + `Perform()`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(10, 10, 0)]
+  let curve = Curve3D.interpolate(
+      points: pts,
+      startTangent: SIMD3(1, 0, 0),
+      endTangent: SIMD3(0, 1, 0))
+  ```
+
+---
+
+### `Curve3D.fit(points:minDegree:maxDegree:tolerance:)`
+
+Fits a BSpline curve through points using least-squares approximation.
+
+```swift
+public static func fit(points: [SIMD3<Double>], minDegree: Int = 3, maxDegree: Int = 8,
+                       tolerance: Double = 1e-3) -> Curve3D?
+```
+
+Unlike `interpolate`, the fitted curve does not necessarily pass through every point — it minimises squared error, which produces smoother results from noisy data.
+
+- **Parameters:** `points` — data points; `minDegree`/`maxDegree` — degree range; `tolerance` — approximation error.
+- **Returns:** Approximating BSpline, or `nil` on failure.
+- **OCCT:** `GeomAPI_PointsToBSpline` (via `OCCTCurve3DFitPoints`).
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = stride(from: 0.0, to: 10.0, by: 0.5).map {
+      SIMD3($0, sin($0), 0)
+  }
+  let curve = Curve3D.fit(points: pts)
+  ```
+
+---
+
+### `poleCount`
+
+The number of control poles, or `nil` if the curve is not a BSpline or Bezier.
+
+```swift
+public var poleCount: Int? { get }
+```
+
+- **Returns:** Pole count, or `nil` if the underlying curve has no poles (e.g. a line or circle).
+- **OCCT:** `Geom_BSplineCurve::NbPoles` / `Geom_BezierCurve::NbPoles`.
+- **Example:**
+  ```swift
+  let bez = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(5,5,0), SIMD3(10,0,0)])!
+  #expect(bez.poleCount == 3)
+  ```
+
+---
+
+### `poles`
+
+The control points of a BSpline or Bezier curve.
+
+```swift
+public var poles: [SIMD3<Double>]? { get }
+```
+
+- **Returns:** Array of control points, or `nil` if the curve is not a BSpline or Bezier.
+- **OCCT:** `Geom_BSplineCurve::Poles` / `Geom_BezierCurve::Poles`.
+- **Example:**
+  ```swift
+  let original: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(5,5,0), SIMD3(10,0,0)]
+  let bez = Curve3D.bezier(poles: original)!
+  if let pts = bez.poles {
+      #expect(pts.count == 3)
+  }
+  ```
+
+---
+
+### `degree`
+
+The polynomial degree of a BSpline or Bezier curve.
+
+```swift
+public var degree: Int { get }
+```
+
+Returns `-1` if the underlying curve is not a BSpline or Bezier.
+
+- **OCCT:** `Geom_BSplineCurve::Degree` / `Geom_BezierCurve::Degree`.
+- **Example:**
+  ```swift
+  let bez = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(5,5,0), SIMD3(10,0,0)])!
+  #expect(bez.degree == 2)
+  ```
+
+---
+
+## Operations
+
+### `trimmed(from:to:)`
+
+Trims the curve to a sub-interval `[u1, u2]` of its parameter domain.
+
+```swift
+public func trimmed(from u1: Double, to u2: Double) -> Curve3D?
+```
+
+- **Parameters:** `u1` — lower trim parameter; `u2` — upper trim parameter (must satisfy `u1 < u2`).
+- **Returns:** Trimmed curve, or `nil` if trimming fails.
+- **OCCT:** `Geom_TrimmedCurve(curve, u1, u2)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  let halfCircle = circle.trimmed(from: 0, to: .pi)
+  ```
+
+---
+
+### `reversed()`
+
+Returns a copy of the curve with reversed parameterization.
+
+```swift
+public func reversed() -> Curve3D?
+```
+
+The start and end points are swapped. The domain is adjusted to remain positive.
+
+- **Returns:** Reversed curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Reversed()`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(10,0,0))!
+  let rev = seg.reversed()!
+  print(rev.startPoint)  // SIMD3(10, 0, 0)
+  ```
+
+---
+
+### `translated(by:)`
+
+Returns a copy of the curve translated by a displacement vector.
+
+```swift
+public func translated(by delta: SIMD3<Double>) -> Curve3D?
+```
+
+- **Parameters:** `delta` — translation vector.
+- **Returns:** Translated curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Translate(gp_Vec)`.
+- **Example:**
+  ```swift
+  let c = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)!
+  let lifted = c.translated(by: SIMD3(0, 0, 10))!
+  print(lifted.point(at: 0).z)  // 10.0
+  ```
+
+---
+
+### `rotated(around:direction:angle:)`
+
+Returns a copy of the curve rotated around an axis.
+
+```swift
+public func rotated(around axisOrigin: SIMD3<Double>, direction: SIMD3<Double>,
+                    angle: Double) -> Curve3D?
+```
+
+- **Parameters:** `axisOrigin` — a point on the rotation axis; `direction` — axis direction; `angle` — rotation angle in radians.
+- **Returns:** Rotated curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Rotate(gp_Ax1, angle)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(1,0,0), to: SIMD3(10,0,0))!
+  let rotated = seg.rotated(around: .zero, direction: SIMD3(0,0,1), angle: .pi/2)
+  ```
+
+---
+
+### `scaled(from:factor:)`
+
+Returns a copy of the curve scaled from a centre point.
+
+```swift
+public func scaled(from center: SIMD3<Double>, factor: Double) -> Curve3D?
+```
+
+- **Parameters:** `center` — fixed point of the scaling; `factor` — scale factor.
+- **Returns:** Scaled curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Scale(gp_Pnt, factor)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(10,0,0))!
+  let doubled = seg.scaled(from: .zero, factor: 2)!
+  print(doubled.length!)  // 20.0
+  ```
+
+---
+
+### `mirrored(acrossPoint:)`
+
+Returns a copy of the curve mirrored through a point.
+
+```swift
+public func mirrored(acrossPoint point: SIMD3<Double>) -> Curve3D?
+```
+
+- **Parameters:** `point` — the point of symmetry.
+- **Returns:** Mirrored curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Mirror(gp_Pnt)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(1,0,0), to: SIMD3(4,0,0))!
+  let mir = seg.mirrored(acrossPoint: SIMD3(2.5, 0, 0))!
+  ```
+
+---
+
+### `mirrored(acrossAxis:direction:)`
+
+Returns a copy of the curve mirrored across an axis (line).
+
+```swift
+public func mirrored(acrossAxis point: SIMD3<Double>, direction: SIMD3<Double>) -> Curve3D?
+```
+
+- **Parameters:** `point` — a point on the axis; `direction` — axis direction.
+- **Returns:** Mirrored curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Mirror(gp_Ax1)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0,1,0), to: SIMD3(10,1,0))!
+  let mir = seg.mirrored(acrossAxis: .zero, direction: SIMD3(1,0,0))
+  ```
+
+---
+
+### `mirrored(acrossPlane:normal:)`
+
+Returns a copy of the curve mirrored across a plane.
+
+```swift
+public func mirrored(acrossPlane point: SIMD3<Double>, normal: SIMD3<Double>) -> Curve3D?
+```
+
+- **Parameters:** `point` — a point on the plane; `normal` — plane normal.
+- **Returns:** Mirrored curve, or `nil` on failure.
+- **OCCT:** `Geom_Curve::Mirror(gp_Ax2)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0,0,5), to: SIMD3(10,0,5))!
+  let mir = seg.mirrored(acrossPlane: .zero, normal: SIMD3(0,0,1))
+  ```
+
+---
+
+### `length`
+
+The total arc length of the curve over its full domain.
+
+```swift
+public var length: Double? { get }
+```
+
+- **Returns:** Arc length in model units, or `nil` if measurement fails (e.g. infinite line with unbounded domain).
+- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(3, 4, 0))!
+  print(seg.length!)  // 5.0
+  ```
+
+---
+
+### `length(from:to:)`
+
+The arc length between two parameter values.
+
+```swift
+public func length(from u1: Double, to u2: Double) -> Double?
+```
+
+- **Parameters:** `u1` — start parameter; `u2` — end parameter.
+- **Returns:** Arc length, or `nil` on failure.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 1)!
+  let d = circle.domain
+  let halfLen = circle.length(from: d.lowerBound, to: d.lowerBound + .pi)
+  // halfLen ≈ π
+  ```
+
+---
+
+## Conversion (GeomConvert)
+
+### `toBSpline()`
+
+Converts the curve to an equivalent `Geom_BSplineCurve` representation.
+
+```swift
+public func toBSpline() -> Curve3D?
+```
+
+Any analytic curve (line, circle, ellipse, arc) can be represented exactly as a rational BSpline. Required before using BSpline-specific query APIs.
+
+- **Returns:** BSpline curve, or `nil` if conversion fails.
+- **OCCT:** `GeomConvert::CurveToBSplineCurve(curve)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)!
+  if let bsp = circle.toBSpline() {
+      print(bsp.poleCount!)  // NURBS representation of the circle
+  }
+  ```
+
+---
+
+### `toBezierSegments()`
+
+Splits a BSpline curve into an array of Bezier segment curves.
+
+```swift
+public func toBezierSegments() -> [Curve3D]?
+```
+
+The input must be (or be convertible to) a `Geom_BSplineCurve`. Internally converts the curve to BSpline first if needed.
+
+- **Returns:** Array of Bezier segment curves, or `nil` if the curve cannot be split (e.g. unbounded line) or the result is empty.
+- **OCCT:** `GeomConvert_BSplineCurveToBezierCurve::Arc(i)`.
+- **Example:**
+  ```swift
+  let bsp = Curve3D.interpolate(points: [
+      SIMD3(0,0,0), SIMD3(3,4,0), SIMD3(6,0,0), SIMD3(9,4,0)
+  ])!
+  if let segs = bsp.toBezierSegments() {
+      print(segs.count)  // number of Bezier arcs
+  }
+  ```
+
+---
+
+### `Curve3D.join(_:tolerance:)`
+
+Joins multiple curves into a single BSpline by converting and concatenating them.
+
+```swift
+public static func join(_ curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D?
+```
+
+Each input curve is converted to BSpline form before joining. Curves must meet end-to-end within `tolerance`. Prefer `joined(curves:tolerance:)` (v0.49.0) which uses `GeomConvert_CompCurveToBSplineCurve` directly.
+
+- **Parameters:** `curves` — curves to join in order; `tolerance` — gap tolerance for endpoint matching.
+- **Returns:** Joined BSpline curve, or `nil` if the array is empty or joining fails.
+- **OCCT:** `GeomConvert::CurveToBSplineCurve` + `GeomConvert_CompCurveToBSplineCurve`.
+- **Example:**
+  ```swift
+  let seg1 = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(5,0,0))!
+  let seg2 = Curve3D.segment(from: SIMD3(5,0,0), to: SIMD3(10,5,0))!
+  if let joined = Curve3D.join([seg1, seg2]) {
+      print(joined.length!)
+  }
+  ```
+
+---
+
+### `approximated(tolerance:continuity:maxSegments:maxDegree:)`
+
+Approximates this curve with a BSpline of specified continuity.
+
+```swift
+public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
+                         maxSegments: Int = 100, maxDegree: Int = 8) -> Curve3D?
+```
+
+Useful for converting an analytical curve to a polynomial BSpline with controlled accuracy. `continuity` maps to `GeomAbs_Shape`: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2.
+
+- **Parameters:** `tolerance` — approximation error; `continuity` — minimum continuity order; `maxSegments` — maximum number of BSpline spans; `maxDegree` — maximum polynomial degree.
+- **Returns:** Approximating BSpline, or `nil` on failure.
+- **OCCT:** `GeomConvert_ApproxCurve(curve, tolerance, continuity, maxSegments, maxDegree)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)!
+  let approx = circle.approximated(tolerance: 0.01, continuity: 2)
+  ```
+
+---
+
+## Draw (Discretization for Metal)
+
+### `drawAdaptive(angularDeflection:chordalDeflection:maxPoints:)`
+
+Discretizes the curve using adaptive angular and chordal deflection criteria.
+
+```swift
+public func drawAdaptive(angularDeflection: Double = 0.1,
+                         chordalDeflection: Double = 0.01,
+                         maxPoints: Int = 4096) -> [SIMD3<Double>]
+```
+
+Concentrates sample points where the curve bends sharply, producing an efficient polyline for Metal rendering. Returns an empty array if the curve cannot be discretized.
+
+- **Parameters:** `angularDeflection` — maximum angle between consecutive tangents (radians); `chordalDeflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Returns:** Array of 3D points along the curve; never force-unwrap.
+- **OCCT:** `GCPnts_TangentialDeflection(adaptor, angularDefl, chordalDefl)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)!
+  let pts = circle.drawAdaptive(angularDeflection: 0.05, chordalDeflection: 0.005)
+  // pts suitable for Metal vertex buffer
+  ```
+
+---
+
+### `drawUniform(pointCount:)`
+
+Discretizes the curve at uniform arc-length intervals.
+
+```swift
+public func drawUniform(pointCount: Int) -> [SIMD3<Double>]
+```
+
+All consecutive point pairs are separated by the same arc-length. Good for even distribution of sample points regardless of curvature.
+
+- **Parameters:** `pointCount` — desired number of output points.
+- **Returns:** Array of 3D points, or empty array on failure.
+- **OCCT:** `GCPnts_UniformAbscissa(adaptor, pointCount)`.
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+  let pts = seg.drawUniform(pointCount: 11)
+  // pts[5] ≈ SIMD3(5, 0, 0)
+  ```
+
+---
+
+### `drawDeflection(deflection:maxPoints:)`
+
+Discretizes the curve using a pure chordal-deflection criterion.
+
+```swift
+public func drawDeflection(deflection: Double = 0.01,
+                           maxPoints: Int = 4096) -> [SIMD3<Double>]
+```
+
+- **Parameters:** `deflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Returns:** Array of 3D points; empty on failure.
+- **OCCT:** `GCPnts_UniformDeflection(adaptor, deflection)`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 10)!
+  let pts = circle.drawDeflection(deflection: 0.01)
+  ```
+
+---
+
+## Bounding Box
+
+### `boundingBox`
+
+The axis-aligned bounding box of the curve.
+
+```swift
+public var boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)? { get }
+```
+
+- **Returns:** Tuple of min and max corner coordinates, or `nil` if the bounding box cannot be computed (e.g. unbounded line).
+- **OCCT:** `BRepBndLib::AddGenev` / `Bnd_Box` (via `OCCTCurve3DGetBoundingBox`).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(1,2,3), to: SIMD3(4,5,6))!
+  if let bb = seg.boundingBox {
+      // bb.min ≈ SIMD3(1, 2, 3), bb.max ≈ SIMD3(4, 5, 6)
+  }
+  ```
+
+---
+
+## Ellipse Arcs
+
+### `Curve3D.arcOfEllipse(center:normal:majorRadius:minorRadius:startAngle:endAngle:counterclockwise:)`
+
+Creates an elliptical arc between two angular parameters.
+
+```swift
+public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
+                                majorRadius: Double, minorRadius: Double,
+                                startAngle: Double, endAngle: Double,
+                                counterclockwise: Bool = true) -> Curve3D?
+```
+
+The major axis direction is determined by OCCT's `gp_Ax2` construction from `normal`. Angles are measured from the major axis in the ellipse plane.
+
+- **Parameters:** `center` — ellipse centre; `normal` — plane normal; `majorRadius` — semi-major axis; `minorRadius` — semi-minor axis; `startAngle`/`endAngle` — arc bounds in radians; `counterclockwise` — winding direction.
+- **Returns:** Elliptical arc curve, or `nil` on failure.
+- **OCCT:** `GC_MakeArcOfEllipse(elips, angle1, angle2, sense)` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve3D.arcOfEllipse(
+      center: .zero, normal: SIMD3(0, 0, 1),
+      majorRadius: 10, minorRadius: 5,
+      startAngle: 0, endAngle: .pi)
+  ```
+
+---
+
+### `Curve3D.arcOfEllipse(center:normal:majorRadius:minorRadius:from:to:counterclockwise:)`
+
+Creates an elliptical arc through two endpoint points on the ellipse.
+
+```swift
+public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
+                                majorRadius: Double, minorRadius: Double,
+                                from: SIMD3<Double>, to: SIMD3<Double>,
+                                counterclockwise: Bool = true) -> Curve3D?
+```
+
+Both `from` and `to` must lie on the ellipse (within tolerance). Use this form when angles are not known but the endpoint coordinates are.
+
+- **Parameters:** `center` — ellipse centre; `normal` — plane normal; `majorRadius`/`minorRadius` — ellipse radii; `from` — start point on the ellipse; `to` — end point on the ellipse; `counterclockwise` — winding direction.
+- **Returns:** Elliptical arc curve, or `nil` if points do not lie on the ellipse or construction fails.
+- **OCCT:** `GC_MakeArcOfEllipse(elips, from, to, sense)` → `Geom_TrimmedCurve`.
+- **Example:**
+  ```swift
+  let arc = Curve3D.arcOfEllipse(
+      center: .zero, normal: SIMD3(0, 0, 1),
+      majorRadius: 10, minorRadius: 5,
+      from: SIMD3(10, 0, 0), to: SIMD3(-10, 0, 0))
+  ```
+
+---
+
+## Curve joining (v0.49.0)
+
+### `Curve3D.joined(curves:tolerance:)`
+
+Joins multiple curves end-to-end into a single BSpline curve.
+
+```swift
+public static func joined(curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D?
+```
+
+Uses `GeomConvert_CompCurveToBSplineCurve` to concatenate curves in order. Curves must meet end-to-end within `tolerance`. This is the preferred join method for v0.49.0+ (compared to the older `Curve3D.join(_:tolerance:)` which uses a different internal code path).
+
+- **Parameters:** `curves` — ordered array of curves to concatenate; `tolerance` — endpoint gap tolerance.
+- **Returns:** Joined BSpline curve, or `nil` if the array is empty or any gap exceeds `tolerance`.
+- **OCCT:** `GeomConvert_CompCurveToBSplineCurve::Add` + `BSplineCurve()`.
+- **Example:**
+  ```swift
+  let seg1 = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(5,0,0))!
+  let seg2 = Curve3D.segment(from: SIMD3(5,0,0), to: SIMD3(10,5,0))!
+  if let joined = Curve3D.joined(curves: [seg1, seg2]) {
+      print(joined.length!)
+  }
+  ```
+
+---
+
+## Curve3D Transform (v0.128.0)
+
+In-place mutation methods that modify the curve handle directly, unlike the `translated(by:)` / `rotated(around:…)` family which return new copies.
+
+### `TransformType`
+
+Enum encoding the type of in-place transform to apply.
+
+```swift
+public enum TransformType: Int32, Sendable {
+    case translation = 0
+    case rotation = 1
+    case scale = 2
+    case mirrorPoint = 3
+    case mirrorAxis = 4
+    case mirrorPlane = 5
+}
+```
+
+Used internally by the in-place transform methods below.
+
+---
+
+### `translate(dx:dy:dz:)`
+
+Translates the curve in place by `(dx, dy, dz)`.
+
+```swift
+@discardableResult
+public func translate(dx: Double, dy: Double, dz: Double) -> Bool
+```
+
+- **Parameters:** `dx`, `dy`, `dz` — displacement components.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_Curve::Translate(gp_Vec)` (in-place, via `OCCTCurve3DTransform`).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+  seg.translate(dx: 0, dy: 5, dz: 0)
+  print(seg.startPoint)  // SIMD3(0, 5, 0)
+  ```
+
+---
+
+### `rotate(axisOrigin:axisDirection:angle:)`
+
+Rotates the curve in place around an axis.
+
+```swift
+@discardableResult
+public func rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angle: Double) -> Bool
+```
+
+- **Parameters:** `axisOrigin` — point on the rotation axis; `axisDirection` — axis direction; `angle` — rotation angle in radians.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_Curve::Rotate(gp_Ax1, angle)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(1, 0, 0), to: SIMD3(10, 0, 0))!
+  seg.rotate(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1), angle: .pi / 2)
+  ```
+
+---
+
+### `scale(center:factor:)`
+
+Scales the curve in place from a centre point.
+
+```swift
+@discardableResult
+public func scale(center: SIMD3<Double>, factor: Double) -> Bool
+```
+
+- **Parameters:** `center` — fixed point of scaling; `factor` — scale factor.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_Curve::Scale(gp_Pnt, factor)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(5, 0, 0))!
+  seg.scale(center: .zero, factor: 2)
+  print(seg.length!)  // 10.0
+  ```
+
+---
+
+### `mirrorPoint(_:)`
+
+Mirrors the curve in place through a point.
+
+```swift
+@discardableResult
+public func mirrorPoint(_ point: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `point` — point of symmetry.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_Curve::Mirror(gp_Pnt)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(4, 0, 0))!
+  seg.mirrorPoint(SIMD3(2, 0, 0))
+  ```
+
+---
+
+### `mirrorAxis(origin:direction:)`
+
+Mirrors the curve in place through an axis (line).
+
+```swift
+@discardableResult
+public func mirrorAxis(origin: SIMD3<Double>, direction: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `origin` — a point on the mirror axis; `direction` — axis direction.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_Curve::Mirror(gp_Ax1)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0, 2, 0), to: SIMD3(10, 2, 0))!
+  seg.mirrorAxis(origin: .zero, direction: SIMD3(1, 0, 0))
+  ```
+
+---
+
+### `mirrorPlane(origin:normal:)`
+
+Mirrors the curve in place through a plane.
+
+```swift
+@discardableResult
+public func mirrorPlane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `origin` — a point on the mirror plane; `normal` — plane normal.
+- **Returns:** `true` on success.
+- **OCCT:** `Geom_Curve::Mirror(gp_Ax2)` (in-place).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: SIMD3(0, 0, 3), to: SIMD3(10, 0, 3))!
+  seg.mirrorPlane(origin: .zero, normal: SIMD3(0, 0, 1))
+  ```
+
+---
+
+## GeomEval Analytical Curve Factories (v0.130.0)
+
+### `Curve3D.circularHelix(radius:pitch:)`
+
+Creates a circular helix curve.
+
+```swift
+public static func circularHelix(radius: Double, pitch: Double) -> Curve3D?
+```
+
+The helix is parameterized as `C(t) = R·cos(t)·X + R·sin(t)·Y + (P·t / 2π)·Z`, where R is the radius and P is the pitch. Negative `pitch` produces a left-handed helix.
+
+- **Parameters:** `radius` — helix radius (must be > 0); `pitch` — axial advance per full 2π turn (may be negative for left-hand winding).
+- **Returns:** Helix curve, or `nil` if `radius ≤ 0`.
+- **OCCT:** `GeomEval_CircularHelixCurve(ax, radius, pitch)`.
+- **Example:**
+  ```swift
+  if let helix = Curve3D.circularHelix(radius: 5, pitch: 2) {
+      let pts = helix.drawAdaptive()
+      // pts trace one full revolution from t=0 to t=2π
+  }
+  ```
+- **Note:** Use `trimmed(from:to:)` to limit the helix to a specific number of turns: `helix.trimmed(from: 0, to: turns * 2 * .pi)`.
+
+---
+
+### `Curve3D.sineWave(amplitude:omega:phase:)`
+
+Creates a 3D sine wave curve along the X axis.
+
+```swift
+public static func sineWave(amplitude: Double, omega: Double, phase: Double = 0.0) -> Curve3D?
+```
+
+Parameterized as `C(t) = t·X + A·sin(ω·t + φ)·Y`. The curve extends infinitely along X; trim it for practical use.
+
+- **Parameters:** `amplitude` — wave amplitude (must be > 0); `omega` — angular frequency (must be > 0); `phase` — phase offset in radians (default 0).
+- **Returns:** Sine wave curve, or `nil` if `amplitude ≤ 0` or `omega ≤ 0`.
+- **OCCT:** `GeomEval_SineWaveCurve(ax, amplitude, omega, phase)`.
+- **Example:**
+  ```swift
+  if let wave = Curve3D.sineWave(amplitude: 2, omega: .pi) {
+      let bounded = wave.trimmed(from: 0, to: 4)
+      let pts = bounded?.drawAdaptive() ?? []
+  }
+  ```
+
+---
+
+## GeomEval TBezier / AHTBezier Curves, TransformedCurve (v0.131.0)
+
+### `translated(tx:ty:tz:)`
+
+Creates a translated copy of this curve via `GeomAdaptor_TransformedCurve`.
+
+```swift
+public func translated(tx: Double, ty: Double, tz: Double) -> Curve3D?
+```
+
+This overload differs from `translated(by:)` — it uses `GeomAdaptor_TransformedCurve` internally, which may preserve the adaptor wrapper rather than modifying the underlying `Geom_Curve` handle.
+
+- **Parameters:** `tx`, `ty`, `tz` — translation components.
+- **Returns:** Translated curve, or `nil` on error.
+- **OCCT:** `GeomAdaptor_TransformedCurve` (via `OCCTGeomAdaptorTransformedCurveCreate`).
+- **Example:**
+  ```swift
+  let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+  if let moved = seg.translated(tx: 0, ty: 5, tz: 0) {
+      print(moved.startPoint)  // SIMD3(0, 5, 0)
+  }
+  ```
+
+---
+
+### `Curve3D.tBezier(poles:alpha:)`
+
+Creates a 3D Trigonometric Bezier curve.
+
+```swift
+public static func tBezier(poles: [SIMD3<Double>], alpha: Double) -> Curve3D?
+```
+
+Uses a trigonometric Bernstein-like basis `{1, sin(α·t), cos(α·t), …}`. The parameter domain is `[0, π/α]`. Can represent circular arcs exactly without rational weights.
+
+- **Parameters:** `poles` — control points (count must be odd and ≥ 3); `alpha` — frequency parameter (must be > 0).
+- **Returns:** TBezier curve, or `nil` if `poles.count < 3`, `poles.count` is even, or `alpha ≤ 0`.
+- **OCCT:** `GeomEval_TBezierCurve(poles, alpha)`.
+- **Example:**
+  ```swift
+  let poles: [SIMD3<Double>] = [SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(-1, 0, 0)]
+  if let tb = Curve3D.tBezier(poles: poles, alpha: 1.0) {
+      let pts = tb.drawAdaptive()
+  }
+  ```
+
+---
+
+### `Curve3D.tBezierRational(poles:weights:alpha:)`
+
+Creates a rational 3D Trigonometric Bezier curve.
+
+```swift
+public static func tBezierRational(poles: [SIMD3<Double>], weights: [Double], alpha: Double) -> Curve3D?
+```
+
+Extends `tBezier` with per-pole rational weights (all must be > 0). Requires `poles.count == weights.count`.
+
+- **Parameters:** `poles` — control points (odd count ≥ 3); `weights` — positive per-pole weights (same count as `poles`); `alpha` — frequency parameter (> 0).
+- **Returns:** Rational TBezier curve, or `nil` if count constraints are violated or construction fails.
+- **OCCT:** `GeomEval_TBezierCurve(poles, weights, alpha)`.
+- **Example:**
+  ```swift
+  let poles: [SIMD3<Double>] = [SIMD3(1,0,0), SIMD3(0,1,0), SIMD3(-1,0,0)]
+  let weights = [1.0, 0.707, 1.0]
+  let tb = Curve3D.tBezierRational(poles: poles, weights: weights, alpha: 1.0)
+  ```
+
+---
+
+### `Curve3D.ahtBezier(poles:algDegree:alpha:beta:)`
+
+Creates a 3D Algebraic-Hyperbolic-Trigonometric (AHT) Bezier curve.
+
+```swift
+public static func ahtBezier(poles: [SIMD3<Double>], algDegree: Int, alpha: Double, beta: Double) -> Curve3D?
+```
+
+Uses a mixed basis: `{1, t, …, t^k, sinh(α·t), cosh(α·t), sin(β·t), cos(β·t)}`. The number of poles must equal `algDegree + 1 + 2*(alpha>0) + 2*(beta>0)`. Parameter range is `[0, 1]`.
+
+- **Parameters:** `poles` — control points; `algDegree` — algebraic polynomial degree (≥ 0); `alpha` — hyperbolic frequency (≥ 0; 0 omits hyperbolic terms); `beta` — trigonometric frequency (≥ 0; 0 omits trig terms).
+- **Returns:** AHT Bezier curve, or `nil` if the pole count is wrong or construction fails.
+- **OCCT:** `GeomEval_AHTBezierCurve(poles, algDegree, alpha, beta)`.
+- **Example:**
+  ```swift
+  // Degree-2 algebraic + trig: needs 3+0+2 = 5 poles
+  let poles: [SIMD3<Double>] = [
+      SIMD3(0,0,0), SIMD3(2,1,0), SIMD3(4,0,0),
+      SIMD3(6,1,0), SIMD3(8,0,0)
+  ]
+  let aht = Curve3D.ahtBezier(poles: poles, algDegree: 2, alpha: 0, beta: .pi)
+  ```
+
+---
+
+### `Curve3D.ahtBezierRational(poles:weights:algDegree:alpha:beta:)`
+
+Creates a rational 3D AHT Bezier curve.
+
+```swift
+public static func ahtBezierRational(poles: [SIMD3<Double>], weights: [Double],
+                                     algDegree: Int, alpha: Double, beta: Double) -> Curve3D?
+```
+
+Rational extension of `ahtBezier`. Requires `poles.count == weights.count` and all weights > 0.
+
+- **Parameters:** `poles` — control points; `weights` — positive per-pole weights; `algDegree` — algebraic degree; `alpha` — hyperbolic frequency; `beta` — trigonometric frequency.
+- **Returns:** Rational AHT Bezier curve, or `nil` if constraints are violated.
+- **OCCT:** `GeomEval_AHTBezierCurve(poles, weights, algDegree, alpha, beta)`.
+- **Example:**
+  ```swift
+  let poles: [SIMD3<Double>] = [
+      SIMD3(0,0,0), SIMD3(2,1,0), SIMD3(4,0,0),
+      SIMD3(6,1,0), SIMD3(8,0,0)
+  ]
+  let weights = [1.0, 1.0, 1.0, 1.0, 1.0]
+  let aht = Curve3D.ahtBezierRational(poles: poles, weights: weights,
+                                       algDegree: 2, alpha: 0, beta: .pi)
+  ```

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -97,8 +97,8 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 | Wire | 61 | `Wire.md` | ✅ done |
 | Shape | 993 | `Shape-*.md` (chunked) | ☐ todo |
 | Surface | 234 | `Surface.md` + 4 (Analytic Types, BSpline & Bezier, Analysis, Advanced) | ✅ done |
-| Curve3D | 195 | `Curve3D-*.md` | ☐ todo |
-| Curve2D | 233 | `Curve2D-*.md` | ☐ todo |
+| Curve3D | 177 | `Curve3D.md` + 3 (Analytic Types, Analysis, Construction) | ✅ done |
+| Curve2D | 205 | `Curve2D.md` + 3 (Analytic Types, Analysis, Constraint Solvers) | ✅ done |
 | Edge | 36 | `Edge.md` | ✅ done |
 | Face | 32 | `Face.md` | ✅ done |
 | Mesh | 34 | `Mesh.md` | ✅ done |


### PR DESCRIPTION
Batch 3 of the detailed API reference — both **curve giants**, each split by `// MARK:` into 4 parallel Sonnet subagent jobs (children of API Reference).

**Curve3D (177 decls → 188 entries)**
| Page | entries |
|------|--------:|
| `Curve3D.md` (core) | 60 |
| Curve3D — Analytic Types | 59 |
| Curve3D — Analysis | 49 |
| Curve3D — Construction | 20 |

**Curve2D (205 decls → 239 entries)**
| Page | entries |
|------|--------:|
| `Curve2D.md` (core) | 68 |
| Curve2D — Analytic Types | 68 |
| Curve2D — Analysis | 61 |
| Curve2D — Constraint Solvers | 42 |

Every MARK section covered exactly once. Spot-checked front-matter, signatures vs source, and OCCT mappings (`GeomLProp_CLProps`, `GeomAPI_ExtremaCurveCurve`, `GeomAPI_IntCS`, `GccAna_*`, `Geom2dGcc_*`, `Bisector_BisecAna`, …). Subagents touched only their own pages; orchestrator updated the status table.

Coverage now: Wire, Edge, Face, Mesh, Exporter, ThreadFeatures, Surface (×5), **Curve3D (×4), Curve2D (×4)**. Remaining giants: Shape, Document, TopologyGraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)