### PR TITLE
feat(io): Exporter.writeBREP(allowInvalid:) to persist invalid shapes

### DIFF
--- a/Sources/OCCTSwift/Exporter.swift
+++ b/Sources/OCCTSwift/Exporter.swift
@@ -392,13 +392,21 @@ public enum Exporter {
     /// - Fast caching of intermediate geometry results
     /// - Debugging geometry issues
     /// - Archiving exact geometry for later processing
+    /// - Parameter allowInvalid: When `true`, skip the `shape.isValid`
+    ///   pre-check and serialize the shape as-is. BREP is OCCT's lossless
+    ///   native format and `BRepTools::Write` does not require a topologically
+    ///   valid shape, so an in-progress reconstruction (a compound of loose
+    ///   analytic faces, possibly with a few invalid faces) can be persisted
+    ///   and later loaded for measurement / diagnostics. Defaults to `false`
+    ///   (the validity gate, matching the other exporters).
     public static func writeBREP(
         shape: Shape,
         to url: URL,
         withTriangles: Bool = true,
-        withNormals: Bool = false
+        withNormals: Bool = false,
+        allowInvalid: Bool = false
     ) throws {
-        guard shape.isValid else {
+        guard allowInvalid || shape.isValid else {
             throw ExportError.invalidShape
         }
 
@@ -699,8 +707,10 @@ extension Shape {
     ///   - url: Destination file URL
     ///   - withTriangles: Include triangulation data (default: true)
     ///   - withNormals: Include normals with triangulation (default: false)
-    public func writeBREP(to url: URL, withTriangles: Bool = true, withNormals: Bool = false) throws {
-        try Exporter.writeBREP(shape: self, to: url, withTriangles: withTriangles, withNormals: withNormals)
+    public func writeBREP(to url: URL, withTriangles: Bool = true, withNormals: Bool = false,
+                          allowInvalid: Bool = false) throws {
+        try Exporter.writeBREP(shape: self, to: url, withTriangles: withTriangles,
+                               withNormals: withNormals, allowInvalid: allowInvalid)
     }
 
     /// Get BREP data for this shape.

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -102,6 +102,37 @@ struct BREPTests {
         #expect(data.count > 0)
     }
 
+    @Test("writeBREP(allowInvalid:) persists an invalid shape that the default gate rejects")
+    func writeBREPAllowInvalid() throws {
+        // A long full-length thread comes back invalid-but-usable (faceted
+        // screw-loft; benign facet self-intersection trips BRepCheck) — the
+        // canonical "loose/invalid but dimensionally real" shape (#193).
+        let shank = Shape.cylinder(radius: 5, height: 50)!
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.0)
+        guard let invalid = shank.threadedShaft(
+            axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+            spec: spec, length: 49, runout: .none), !invalid.isValid else {
+            // If this build produced a valid thread, the fixture no longer
+            // exercises the gate — skip rather than assert a false negative.
+            return
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_allow_invalid_\(UUID().uuidString).brep")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Default gate rejects it.
+        #expect(throws: Exporter.ExportError.self) {
+            try invalid.writeBREP(to: tempURL)
+        }
+        // allowInvalid: true serializes as-is...
+        try invalid.writeBREP(to: tempURL, allowInvalid: true)
+        #expect(FileManager.default.fileExists(atPath: tempURL.path))
+        // ...and it loads back for measurement (loadBREP doesn't gate on validity).
+        let reloaded = try Shape.loadBREP(from: tempURL)
+        #expect(reloaded.faces().count == invalid.faces().count)
+    }
+
     @Test("BREP roundtrip preserves geometry exactly")
     func brepRoundtrip() throws {
         let original = Shape.box(width: 20, height: 15, depth: 10)!

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,24 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.7.11
+## Current: v1.8.0
 
 **macOS / iOS / visionOS / tvOS | OCCT 8.0.0p1**
 
 ---
 
 ## Release History
+
+### v1.8.0 (June 2026) — feat: `Exporter.writeBREP(allowInvalid:)`
+
+**Feature (additive).** `Exporter.writeBREP` (and the `Shape.writeBREP` instance wrapper) gain an
+`allowInvalid: Bool = false` parameter. When `true`, the `shape.isValid` pre-check is skipped and the
+shape is serialized as-is. BREP is OCCT's lossless native format and `BRepTools::Write` does not
+require a topologically valid shape, so an in-progress reconstruction — a compound of loose analytic
+faces, possibly with a few invalid faces — can be persisted and later reloaded for measurement /
+diagnostics (`Shape.loadBREP` already does not gate on validity). Default `false` preserves the
+existing validity gate, matching the other exporters. Enables OCCTMCP #41 (measure an imperfect
+reconstruction without forcing it through the validity gate). No xcframework change.
 
 ### v1.7.11 (June 2026) — fix: `fromPointGrid` degree clamp prevents a BRepMesh hang (#244)
 


### PR DESCRIPTION
## Why

`Exporter.writeBREP` gated on `shape.isValid`, so an **in-progress reconstruction** — a compound of loose analytic faces, possibly with a few invalid faces — could not be serialized. But BREP is OCCT's lossless native format and `BRepTools::Write` does **not** require a topologically valid shape, and `Shape.loadBREP` already doesn't gate on read. So the write gate was the lone blocker to round-tripping an imperfect shape for measurement.

## Change

Add `allowInvalid: Bool = false` to `Exporter.writeBREP` and the `Shape.writeBREP` instance wrapper. When `true`, skip the `isValid` pre-check and serialize as-is. Default `false` preserves the existing gate (and the other exporters are unchanged).

## Enables

OCCTMCP #41 — load an invalid/loose-face reconstruction into the scene so `compute_metrics` / `measure_deviation` / `validate_geometry` (all of which load via the non-gating `loadBREP`) can run on it.

## Test

A long full-length thread returns invalid-but-usable (faceted screw-loft, #193) — the canonical real-but-invalid shape. The default gate rejects it; `allowInvalid: true` persists it and it reloads with the same face count. No xcframework change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)