### PR TITLE
docs(reference): Shape — chunked, 9 pages (batch 4)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -95,7 +95,7 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 | Type | decls | page | status |
 |------|------:|------|--------|
 | Wire | 61 | `Wire.md` | ✅ done |
-| Shape | 993 | `Shape-*.md` (chunked) | ☐ todo |
+| Shape | 867 | `Shape.md` + 8 (Features, Healing, Measurement, Builders I/II, HLR-Geom, Recognition, Completions) | ✅ done |
 | Surface | 234 | `Surface.md` + 4 (Analytic Types, BSpline & Bezier, Analysis, Advanced) | ✅ done |
 | Curve3D | 177 | `Curve3D.md` + 3 (Analytic Types, Analysis, Construction) | ✅ done |
 | Curve2D | 205 | `Curve2D.md` + 3 (Analytic Types, Analysis, Constraint Solvers) | ✅ done |

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1,0 +1,1820 @@
+---
+title: Shape — Builders & Boolean Internals I
+parent: API Reference
+---
+
+# Shape — Builders & Boolean Internals I
+
+These members are low-level OCCT builder and algorithm wrappers — polyhedral geometry, history tracking, 2D fillet engines, shell/solid builders, Boolean splitters, ray/contour intersection, mesh utilities, and surface-fill algorithms — exposed directly on `Shape`. See the main [Shape](#) page for the core topology, transform, and measurement API (free-boundary analysis is on the **Shape — Measurement** page).
+
+## Topics
+
+- [v0.50 Polyhedral Distance / History / Wire-Vertex / Nearest Plane](#v050-polyhedral-distance--history--wire-vertex--nearest-plane) · [v0.51 BRepLib\_MakeSolid / GC Transforms / ChFi2d\_AnaFilletAlgo](#v051-breplib_makesolid--gc-transforms--chfi2d_anafilletalgo) · [BRepFill\_Generator / AdvancedEvolved / OffsetWire / Draft / Pipe / CompatibleWires](#brepfill_generator--advancedevolved--offsetwire--draft--pipe--compatiblewires) · [ChFi2d\_FilletAlgo](#chfi2d_filletalgo) · [BRepTools\_Substitution](#breptools_substitution) · [ShapeUpgrade\_ShellSewing](#shapeupgrade_shellsewing) · [LocOpe\_BuildShape](#locope_buildshape) · [BOPAlgo Splitter / ArgumentAnalyzer](#bopalgo-splitter--argumentanalyzer) · [IntCurvesFace Intersection](#intcurvesface-intersection) · [Contap Contour Analysis](#contap-contour-analysis) · [BRepMesh\_Deflection](#brepmesh_deflection) · [BRepBuilderAPI\_MakeShapeOnMesh](#brepbuilderapi_makeshapeonmesh) · [GeomPlate\_Surface](#geomplate_surface) · [CellsBuilder](#cellsbuilder) · [BRepLib\_MakeEdge / MakeFace / MakeShell / ToolTriangulatedShape / PointCloudShape](#breplib_makeedge--makeface--makeshell--tooltriangulatedshape--pointcloudshape) · [BRepBuilderAPI\_MakeEdge2d](#brepbuilderapi_makeedge2d) · [BRepTools\_Modifier + NurbsConvert](#breptools_modifier--nurbsconvert) · [ShapeCustom\_Direct / TrsfModification](#shapecustom_direct--trsfmodification) · [LocOpe Builders](#locope-builders) · [CPnts\_UniformDeflection](#cpnts_uniformdeflection) · [IntCurvesFace\_ShapeIntersector](#intcurvesface_shapeintersector) · [GeomLProp\_CLProps / SLProps](#geomlprop_clprops--slprops) · [BRepOffset\_SimpleOffset](#brepoffset_simpleoffset) · [Approx\_CurvilinearParameter](#approx_curvilinearparameter) · [GeomInt\_IntSS](#geomint_intss) · [Contap\_Contour](#contap_contour) · [BRepFeat\_Builder](#brepfeat_builder) · [GeomFill Trihedron Laws / Coons / Curved / CoonsAlgPatch](#geomfill-trihedron-laws--coons--curved--coonsalgpatch)
+
+---
+
+## v0.50 Polyhedral Distance / History / Wire-Vertex / Nearest Plane
+
+### `PolyhedralDistance`
+
+Result of an approximate (mesh-based) distance query.
+
+```swift
+public struct PolyhedralDistance {
+    public let distance: Double
+    public let point1: SIMD3<Double>
+    public let point2: SIMD3<Double>
+}
+```
+
+- **Fields:** `distance` — approximate distance; `point1` — closest point on the first shape; `point2` — closest point on the second shape.
+
+---
+
+### `polyhedralDistance(to:)`
+
+Compute fast polyhedral (approximate) distance to another shape.
+
+```swift
+public func polyhedralDistance(to other: Shape) -> PolyhedralDistance?
+```
+
+Both shapes must be meshed (have triangulation). Faster than exact distance but less precise.
+
+- **Parameters:** `other` — the shape to measure against.
+- **Returns:** `PolyhedralDistance`, or `nil` if either shape has no triangulation or computation fails.
+- **OCCT:** `BRepExtrema_Poly` via `OCCTShapePolyhedralDistance`.
+- **Example:**
+  ```swift
+  if let d = box.polyhedralDistance(to: sphere) {
+      print(d.distance)
+  }
+  ```
+
+---
+
+### `History`
+
+Shape modification history for tracking what happened during operations.
+
+```swift
+public class History {
+    public init?()
+    public func addModified(initial: Shape, modified: Shape)
+    public func addGenerated(initial: Shape, generated: Shape)
+    public func remove(_ shape: Shape)
+    public func isRemoved(_ shape: Shape) -> Bool
+    public var hasModified: Bool { get }
+    public var hasGenerated: Bool { get }
+    public var hasRemoved: Bool { get }
+    public func modifiedCount(of shape: Shape) -> Int
+    public func generatedCount(of shape: Shape) -> Int
+}
+```
+
+A reference-counted history store wrapping `OCCTHistoryRef`. Freed in `deinit`.
+
+- **OCCT:** `BRepTools_History` / `OCCTHistory*` bridge family.
+
+#### `History.init?()`
+
+Create an empty history object.
+
+```swift
+public init?()
+```
+
+- **Returns:** New `History`, or `nil` if the underlying handle cannot be allocated.
+- **OCCT:** `OCCTHistoryCreate`.
+
+#### `addModified(initial:modified:)`
+
+Record that an initial shape was modified into a new shape.
+
+```swift
+public func addModified(initial: Shape, modified: Shape)
+```
+
+- **OCCT:** `OCCTHistoryAddModified`.
+
+#### `addGenerated(initial:generated:)`
+
+Record that an initial shape produced a new generated shape.
+
+```swift
+public func addGenerated(initial: Shape, generated: Shape)
+```
+
+- **OCCT:** `OCCTHistoryAddGenerated`.
+
+#### `remove(_:)`
+
+Record that a shape was removed during the operation.
+
+```swift
+public func remove(_ shape: Shape)
+```
+
+- **OCCT:** `OCCTHistoryRemove`.
+
+#### `isRemoved(_:)`
+
+Check whether a shape was recorded as removed.
+
+```swift
+public func isRemoved(_ shape: Shape) -> Bool
+```
+
+- **OCCT:** `OCCTHistoryIsRemoved`.
+
+#### `hasModified`, `hasGenerated`, `hasRemoved`
+
+Whether any modifications / generations / removals were recorded.
+
+```swift
+public var hasModified: Bool { get }
+public var hasGenerated: Bool { get }
+public var hasRemoved: Bool { get }
+```
+
+- **OCCT:** `OCCTHistoryHasModified`, `OCCTHistoryHasGenerated`, `OCCTHistoryHasRemoved`.
+
+#### `modifiedCount(of:)`
+
+Number of shapes the given initial shape was modified to.
+
+```swift
+public func modifiedCount(of shape: Shape) -> Int
+```
+
+- **OCCT:** `OCCTHistoryModifiedCount`.
+
+#### `generatedCount(of:)`
+
+Number of shapes generated from the given initial shape.
+
+```swift
+public func generatedCount(of shape: Shape) -> Int
+```
+
+- **OCCT:** `OCCTHistoryGeneratedCount`.
+
+---
+
+### `WireVertexAnalysis`
+
+Result of wire vertex connectivity analysis.
+
+```swift
+public struct WireVertexAnalysis {
+    public let edgeCount: Int
+    public let isDone: Bool
+}
+```
+
+---
+
+### `WireVertexStatus`
+
+Vertex connection status codes.
+
+```swift
+public enum WireVertexStatus: Int32 {
+    case sameVertex = 0
+    case sameCoords = 1
+    case close = 2
+    case end = 3
+    case start = 4
+    case intersection = 5
+    case disjoined = -1
+    case unknown = -2
+}
+```
+
+---
+
+### `wireVertexAnalysis(precision:)`
+
+Analyze wire vertex connections for gaps, overlaps, and intersections.
+
+```swift
+public func wireVertexAnalysis(precision: Double = 0.01) -> WireVertexAnalysis
+```
+
+- **Parameters:** `precision` — tolerance for vertex comparison.
+- **Returns:** `WireVertexAnalysis` with edge count and a completion flag.
+- **OCCT:** `ShapeAnalysis_WireVertex` via `OCCTShapeWireVertexAnalysis`.
+- **Example:**
+  ```swift
+  let a = wire.wireVertexAnalysis(precision: 1e-4)
+  print(a.edgeCount, a.isDone)
+  ```
+
+---
+
+### `wireVertexStatus(precision:index:)`
+
+Get the status of a specific vertex in a wire.
+
+```swift
+public func wireVertexStatus(precision: Double = 0.01, index: Int) -> WireVertexStatus
+```
+
+- **Parameters:** `precision` — analysis tolerance; `index` — 0-based vertex index.
+- **Returns:** `WireVertexStatus` case, or `.unknown` for unrecognised codes.
+- **OCCT:** `OCCTShapeWireVertexStatus`.
+
+---
+
+### `NearestPlane`
+
+Result of least-squares plane fitting.
+
+```swift
+public struct NearestPlane {
+    public let normal: SIMD3<Double>
+    public let origin: SIMD3<Double>
+    public let maxDeviation: Double
+}
+```
+
+- **Fields:** `normal` — fitted plane normal; `origin` — a point on the plane; `maxDeviation` — maximum distance from any input point to the fitted plane.
+
+---
+
+### `Shape.nearestPlane(to:)`
+
+Fit the nearest plane to a set of 3D points using least-squares.
+
+```swift
+public static func nearestPlane(to points: [SIMD3<Double>]) -> NearestPlane?
+```
+
+- **Parameters:** `points` — array of at least 3 points.
+- **Returns:** `NearestPlane`, or `nil` if fewer than 3 points are provided or fitting fails.
+- **OCCT:** `gp_Pln` / `OCCTShapeNearestPlane`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(1,0,0), SIMD3(0,1,0)]
+  if let plane = Shape.nearestPlane(to: pts) {
+      print(plane.normal)  // ≈ (0, 0, 1)
+  }
+  ```
+
+---
+
+## v0.51 BRepLib\_MakeSolid / GC Transforms / ChFi2d\_AnaFilletAlgo
+
+### `Shape.solidFromShell(_:)`
+
+Create a solid from a shell shape using `BRepLib_MakeSolid`.
+
+```swift
+public static func solidFromShell(_ shell: Shape) -> Shape?
+```
+
+- **Parameters:** `shell` — a shape containing a closed shell (e.g. from `shellFromSurface`).
+- **Returns:** Solid shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeSolid` via `OCCTShapeMakeSolidFromShell`.
+- **Example:**
+  ```swift
+  if let solid = Shape.solidFromShell(myShell) {
+      print(solid.isValid)
+  }
+  ```
+
+---
+
+### `mirroredAboutPoint(_:)`
+
+Mirror this shape about a point (point symmetry / inversion).
+
+```swift
+public func mirroredAboutPoint(_ point: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `point` — centre of the point mirror.
+- **Returns:** Mirrored shape, or `nil` on failure.
+- **OCCT:** `gp_Trsf` point mirror via `OCCTShapeMirrorAboutPoint`.
+- **Example:**
+  ```swift
+  let inverted = box.mirroredAboutPoint(SIMD3(5, 0, 0))
+  ```
+
+---
+
+### `mirroredAboutAxis(origin:direction:)`
+
+Mirror this shape about an axis line.
+
+```swift
+public func mirroredAboutAxis(origin: SIMD3<Double>, direction: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `origin` — a point on the axis; `direction` — axis direction.
+- **Returns:** Mirrored shape, or `nil` on failure.
+- **OCCT:** `gp_Trsf` axis mirror via `OCCTShapeMirrorAboutAxis`.
+
+---
+
+### `scaledAboutPoint(_:factor:)`
+
+Scale this shape about a specific centre point.
+
+```swift
+public func scaledAboutPoint(_ center: SIMD3<Double>, factor: Double) -> Shape?
+```
+
+Unlike `scaled(by:)` which scales about the origin, this scales about the given point.
+
+- **Parameters:** `center` — centre of scaling; `factor` — scale factor.
+- **Returns:** Scaled shape, or `nil` on failure.
+- **OCCT:** `gp_Trsf` scale via `OCCTShapeScaleAboutPoint`.
+
+---
+
+### `translated(from:to:)`
+
+Translate this shape by the vector from one point to another.
+
+```swift
+public func translated(from: SIMD3<Double>, to: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `from` — start of the translation vector; `to` — end of the translation vector.
+- **Returns:** Translated shape, or `nil` on failure.
+- **OCCT:** `gp_Vec` translation via `OCCTShapeTranslateByPoints`.
+
+---
+
+### `AnaFilletResult`
+
+Result of a 2D analytical fillet operation.
+
+```swift
+public struct AnaFilletResult {
+    public let fillet: Shape
+    public let edge1: Shape
+    public let edge2: Shape
+}
+```
+
+- **Fields:** `fillet` — the arc edge; `edge1`, `edge2` — trimmed input edges.
+
+---
+
+### `Shape.anaFillet(edge1:edge2:planeOrigin:planeNormal:radius:)` (Shape overload)
+
+Compute a 2D analytical fillet between two edge shapes.
+
+```swift
+public static func anaFillet(
+    edge1: Shape,
+    edge2: Shape,
+    planeOrigin: SIMD3<Double> = .zero,
+    planeNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> AnaFilletResult?
+```
+
+Uses `ChFi2d_AnaFilletAlgo` for fast exact fillet computation in a plane. Supports only line and arc-of-circle edges.
+
+- **Parameters:** `edge1`, `edge2` — edge shapes; `planeOrigin` — a point on the working plane; `planeNormal` — plane normal; `radius` — fillet radius.
+- **Returns:** `AnaFilletResult`, or `nil` if computation fails.
+- **OCCT:** `ChFi2d_AnaFilletAlgo` via `OCCTChFi2dAnaFillet`.
+- **Example:**
+  ```swift
+  if let r = Shape.anaFillet(edge1: e1, edge2: e2, radius: 2) {
+      // r.fillet, r.edge1, r.edge2
+  }
+  ```
+
+---
+
+### `Shape.anaFillet(edge1:edge2:planeOrigin:planeNormal:radius:)` (Edge overload)
+
+Convenience overload accepting `Edge` objects directly.
+
+```swift
+public static func anaFillet(
+    edge1: Edge, edge2: Edge,
+    planeOrigin: SIMD3<Double> = .zero,
+    planeNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> AnaFilletResult?
+```
+
+- **OCCT:** `ChFi2d_AnaFilletAlgo` (via `Shape.fromEdge` conversion then `OCCTChFi2dAnaFillet`).
+
+---
+
+### `Shape.anaFillet(wire:edgeIndex:planeOrigin:planeNormal:radius:)`
+
+Compute a 2D analytical fillet between two adjacent edges of a wire.
+
+```swift
+public static func anaFillet(
+    wire: Wire, edgeIndex: Int = 0,
+    planeOrigin: SIMD3<Double> = .zero,
+    planeNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> AnaFilletResult?
+```
+
+Edge indices are 0-based; the fillet is computed between `edges[edgeIndex]` and `edges[edgeIndex + 1]`.
+
+- **Parameters:** `wire` — source wire; `edgeIndex` — index of the first edge; remaining parameters as above.
+- **Returns:** `AnaFilletResult`, or `nil` if indices are out of range or fillet fails.
+- **OCCT:** `ChFi2d_AnaFilletAlgo`.
+
+---
+
+## BRepFill\_Generator / AdvancedEvolved / OffsetWire / Draft / Pipe / CompatibleWires
+
+### `Shape.ruledShell(from:)`
+
+Create a ruled shell by lofting between multiple wire sections.
+
+```swift
+public static func ruledShell(from wires: [Wire]) -> Shape?
+```
+
+Each pair of adjacent wires generates a ruled surface between them. Wires should have the same number of edges for best results.
+
+- **Parameters:** `wires` — at least 2 wires.
+- **Returns:** Shell shape, or `nil` on failure.
+- **OCCT:** `BRepFill_Generator` via `OCCTBRepFillGenerator`.
+- **Example:**
+  ```swift
+  let bottom = Wire.rectangle(width: 10, height: 10)!
+  let top = Wire.circle(center: SIMD3(0, 0, 5), radius: 5)!
+  if let shell = Shape.ruledShell(from: [bottom, top]) { }
+  ```
+
+---
+
+### `Shape.advancedEvolved(spine:profile:tolerance:solid:)`
+
+Create an evolved solid from a spine wire and profile wire.
+
+```swift
+public static func advancedEvolved(
+    spine: Wire, profile: Wire,
+    tolerance: Double = 1e-3, solid: Bool = true
+) -> Shape?
+```
+
+The profile is oriented perpendicular to the spine at each point and swept along it.
+
+- **Parameters:** `spine` — sweep path; `profile` — cross-section; `tolerance` — geometric tolerance; `solid` — produce a solid when `true`.
+- **Returns:** Evolved shape, or `nil` on failure.
+- **OCCT:** `BRepFill_AdvancedEvolved` via `OCCTBRepFillAdvancedEvolved`.
+
+---
+
+### `Shape.offsetWire(face:offset:)`
+
+Offset a planar wire on its face.
+
+```swift
+public static func offsetWire(face: Face, offset: Double) -> Shape?
+```
+
+Positive offset expands outward; negative shrinks inward.
+
+- **Parameters:** `face` — face containing the wire to offset; `offset` — signed offset distance.
+- **Returns:** Offset wire shape, or `nil` on failure.
+- **OCCT:** `BRepFill_OffsetWire` via `OCCTBRepFillOffsetWire`.
+
+---
+
+### `Shape.draft(wire:direction:angle:length:)`
+
+Create a draft surface from a wire along a direction with a taper angle.
+
+```swift
+public static func draft(
+    wire: Wire, direction: SIMD3<Double>,
+    angle: Double, length: Double
+) -> Shape?
+```
+
+The wire is projected along `direction` for `length`, with faces tapered at `angle` from the direction.
+
+- **Parameters:** `wire` — base profile; `direction` — draft direction; `angle` — taper angle in radians; `length` — draft length.
+- **Returns:** Draft shape, or `nil` on failure.
+- **OCCT:** `BRepFill_Draft` via `OCCTBRepFillDraft`.
+
+---
+
+### `PipeSweepResult`
+
+Result of a pipe sweep operation.
+
+```swift
+public struct PipeSweepResult {
+    public let shape: Shape
+    public let errorOnSurface: Double
+}
+```
+
+- **Fields:** `shape` — the swept pipe; `errorOnSurface` — surface approximation error.
+
+---
+
+### `Shape.pipeSweep(spine:profile:)`
+
+Create a pipe sweep of a profile along a spine with error reporting.
+
+```swift
+public static func pipeSweep(spine: Wire, profile: Wire) -> PipeSweepResult?
+```
+
+Sweeps the profile wire along the spine wire using a corrected Frenet trihedron.
+
+- **Parameters:** `spine` — sweep path; `profile` — cross-section wire.
+- **Returns:** `PipeSweepResult`, or `nil` on failure.
+- **OCCT:** `BRepFill_Pipe` via `OCCTBRepFillPipe`.
+- **Example:**
+  ```swift
+  if let result = Shape.pipeSweep(spine: path, profile: circle) {
+      print(result.errorOnSurface)
+  }
+  ```
+
+---
+
+### `Shape.compatibleWires(_:)`
+
+Make wires compatible for lofting (same number of edges, consistently oriented).
+
+```swift
+public static func compatibleWires(_ wires: [Wire]) -> [Wire]?
+```
+
+Resamples wires so they have the same edge count and orientation, which improves lofting quality.
+
+- **Parameters:** `wires` — at least 2 wires to normalize.
+- **Returns:** Array of compatible `Wire` objects, or `nil` on failure.
+- **OCCT:** `BRepFill_CompatibleWires` via `OCCTBRepFillCompatibleWires`.
+
+---
+
+## ChFi2d\_FilletAlgo
+
+### `FilletAlgoResult`
+
+Result of a 2D iterative fillet operation.
+
+```swift
+public struct FilletAlgoResult {
+    public let fillet: Shape
+    public let edge1: Shape
+    public let edge2: Shape
+    public let resultCount: Int
+}
+```
+
+- **Fields:** `fillet` — the arc edge; `edge1`, `edge2` — trimmed edges; `resultCount` — number of fillet solutions found.
+
+---
+
+### `Shape.filletAlgo(edge1:edge2:planeOrigin:planeNormal:radius:)` (Shape overload)
+
+Compute a 2D iterative fillet between two edge shapes in a plane.
+
+```swift
+public static func filletAlgo(
+    edge1: Shape, edge2: Shape,
+    planeOrigin: SIMD3<Double> = .zero,
+    planeNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> FilletAlgoResult?
+```
+
+Uses `ChFi2d_FilletAlgo` which supports general edge types, unlike `anaFillet` which is limited to lines and arcs.
+
+- **Parameters:** `edge1`, `edge2` — edge shapes; `planeOrigin`, `planeNormal` — working plane; `radius` — fillet radius.
+- **Returns:** `FilletAlgoResult`, or `nil` on failure.
+- **OCCT:** `ChFi2d_FilletAlgo` via `OCCTChFi2dFilletAlgo`.
+
+---
+
+### `Shape.filletAlgo(edge1:edge2:planeOrigin:planeNormal:radius:)` (Edge overload)
+
+Convenience overload accepting `Edge` objects directly.
+
+```swift
+public static func filletAlgo(
+    edge1: Edge, edge2: Edge,
+    planeOrigin: SIMD3<Double> = .zero,
+    planeNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> FilletAlgoResult?
+```
+
+- **OCCT:** `ChFi2d_FilletAlgo`.
+
+---
+
+### `Shape.filletAlgo(wire:edgeIndex:planeOrigin:planeNormal:radius:)`
+
+Compute a 2D iterative fillet between two adjacent edges of a wire.
+
+```swift
+public static func filletAlgo(
+    wire: Wire, edgeIndex: Int = 0,
+    planeOrigin: SIMD3<Double> = .zero,
+    planeNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+    radius: Double
+) -> FilletAlgoResult?
+```
+
+- **Parameters:** `wire` — source wire; `edgeIndex` — 0-based index of the first edge.
+- **Returns:** `FilletAlgoResult`, or `nil` if indices are out of range or fillet fails.
+- **OCCT:** `ChFi2d_FilletAlgo`.
+
+---
+
+## BRepTools\_Substitution
+
+### `substituted(replacing:with:)`
+
+Substitute a topological sub-shape within this shape and rebuild the parent.
+
+```swift
+public func substituted(replacing oldSubShape: Shape, with newSubShape: Shape) -> Shape?
+```
+
+Replaces a vertex, edge, or face with another sub-shape and rebuilds the containing topology.
+
+- **Parameters:** `oldSubShape` — the sub-shape to replace; `newSubShape` — the replacement.
+- **Returns:** Modified shape, or `nil` on failure.
+- **OCCT:** `BRepTools_Substitution` via `OCCTBRepToolsSubstitute`.
+
+---
+
+## ShapeUpgrade\_ShellSewing
+
+### `shellSewing(tolerance:)`
+
+Sew disconnected shells in this shape.
+
+```swift
+public func shellSewing(tolerance: Double = 1e-6) -> Shape?
+```
+
+Connects shells that share edges within the given tolerance.
+
+- **Parameters:** `tolerance` — sewing tolerance (default `1e-6`).
+- **Returns:** Sewn shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ShellSewing` via `OCCTShapeUpgradeShellSewing`.
+
+---
+
+## LocOpe\_BuildShape
+
+### `builtFromFaces()`
+
+Build a shape from the faces of this shape.
+
+```swift
+public func builtFromFaces() -> Shape?
+```
+
+Extracts all faces and reconstructs them into a shell or solid.
+
+- **Returns:** Rebuilt shape, or `nil` on failure.
+- **OCCT:** `LocOpe_BuildShape` via `OCCTLocOpeBuildShape`.
+
+---
+
+## BOPAlgo Splitter / ArgumentAnalyzer
+
+### `Shape.split(objects:by:)`
+
+Split shapes by tool shapes using `BOPAlgo_Splitter`.
+
+```swift
+public static func split(objects: [Shape], by tools: [Shape]) -> Shape?
+```
+
+Partitions the object shapes using the tool shapes as cutting geometry. All fragments are returned in a single compound.
+
+- **Parameters:** `objects` — shapes to be split; `tools` — cutting tools.
+- **Returns:** Compound of all split fragments, or `nil` on failure.
+- **OCCT:** `BOPAlgo_Splitter` via `OCCTBOPAlgoSplit`.
+- **Example:**
+  ```swift
+  let fragments = Shape.split(objects: [block], by: [cuttingPlane])
+  ```
+
+---
+
+### `BooleanOperation`
+
+Boolean operation type for argument analysis.
+
+```swift
+public enum BooleanOperation: Int32 {
+    case fuse = 0
+    case common = 1
+    case cut = 2
+    case cut21 = 3
+    case section = 4
+}
+```
+
+---
+
+### `Shape.analyzeBoolean(_:_:operation:)`
+
+Analyze whether two shapes are valid for a Boolean operation.
+
+```swift
+public static func analyzeBoolean(_ shape1: Shape, _ shape2: Shape,
+                                   operation: BooleanOperation = .fuse) -> Bool
+```
+
+Checks for self-intersection, small edges, and argument type compatibility.
+
+- **Parameters:** `shape1` — object shape; `shape2` — tool shape; `operation` — the operation to validate.
+- **Returns:** `true` if the shapes pass validation for the given operation.
+- **OCCT:** `BOPAlgo_ArgumentAnalyzer` via `OCCTBOPAlgoAnalyzeArguments`.
+
+---
+
+## IntCurvesFace Intersection
+
+### `LineFaceIntersection`
+
+Result of a line-face intersection.
+
+```swift
+public struct LineFaceIntersection {
+    public let point: SIMD3<Double>
+    public let parameter: Double
+}
+```
+
+- **Fields:** `point` — 3D intersection point; `parameter` — line parameter at intersection.
+
+---
+
+### `intersectLine(origin:direction:paramRange:)`
+
+Intersect a line with this shape (must be a face).
+
+```swift
+public func intersectLine(origin: SIMD3<Double>, direction: SIMD3<Double>,
+                          paramRange: ClosedRange<Double> = -1000...1000) -> [LineFaceIntersection]
+```
+
+- **Parameters:** `origin` — line origin; `direction` — line direction; `paramRange` — parameter bounds on the line.
+- **Returns:** Array of intersection results (may be empty).
+- **OCCT:** `IntCurvesFace_Intersector` via `OCCTIntersectLineFace`.
+- **Example:**
+  ```swift
+  let hits = face.intersectLine(origin: SIMD3(0, 0, -10), direction: SIMD3(0, 0, 1))
+  ```
+
+---
+
+## Contap Contour Analysis
+
+### `ContourType`
+
+Contour type from analytical contour computation.
+
+```swift
+public enum ContourType: Int32 {
+    case line = 0
+    case circle = 1
+    case other = 2
+}
+```
+
+---
+
+### `ContourResult`
+
+Result of an analytical contour computation.
+
+```swift
+public struct ContourResult {
+    public let type: ContourType
+    public let count: Int
+    public let data: [Double]
+}
+```
+
+- **Fields:** `type` — contour geometry kind; `count` — number of contours; `data` — raw parameters (for circles: centre and radius; for lines: location and direction).
+
+---
+
+### `Shape.contourSphereDir(center:radius:direction:)`
+
+Compute the silhouette contour of a sphere for an orthographic view direction.
+
+```swift
+public static func contourSphereDir(center: SIMD3<Double>, radius: Double,
+                                     direction: SIMD3<Double>) -> ContourResult?
+```
+
+- **Parameters:** `center` — sphere centre; `radius` — sphere radius; `direction` — orthographic view direction.
+- **Returns:** `ContourResult`, or `nil` on failure.
+- **OCCT:** `Contap_ContAna` via `OCCTContapSphereDir`.
+
+---
+
+### `Shape.contourCylinderDir(origin:axis:radius:direction:)`
+
+Compute the silhouette contour of a cylinder for an orthographic view direction.
+
+```swift
+public static func contourCylinderDir(origin: SIMD3<Double>, axis: SIMD3<Double>,
+                                       radius: Double, direction: SIMD3<Double>) -> ContourResult?
+```
+
+- **Parameters:** `origin` — cylinder axis origin; `axis` — axis direction; `radius` — radius; `direction` — view direction.
+- **Returns:** `ContourResult`, or `nil` on failure.
+- **OCCT:** `Contap_ContAna` via `OCCTContapCylinderDir`.
+
+---
+
+### `Shape.contourSphereEye(center:radius:eye:)`
+
+Compute the silhouette contour of a sphere for a perspective eye point.
+
+```swift
+public static func contourSphereEye(center: SIMD3<Double>, radius: Double,
+                                     eye: SIMD3<Double>) -> ContourResult?
+```
+
+- **Parameters:** `center` — sphere centre; `radius` — sphere radius; `eye` — perspective eye point.
+- **Returns:** `ContourResult`, or `nil` on failure.
+- **OCCT:** `Contap_ContAna` via `OCCTContapSphereEye`.
+
+---
+
+## BRepMesh\_Deflection
+
+### `computeAbsoluteDeflection(relativeDeflection:maxShapeSize:)`
+
+Convert a relative deflection value to an absolute deflection for meshing.
+
+```swift
+public func computeAbsoluteDeflection(relativeDeflection: Double, maxShapeSize: Double) -> Double?
+```
+
+- **Parameters:** `relativeDeflection` — relative deflection; `maxShapeSize` — maximum dimension of the shape.
+- **Returns:** Absolute deflection, or `nil` if computation fails (negative result from bridge).
+- **OCCT:** `BRepMesh_Deflection` via `OCCTComputeAbsoluteDeflection`.
+
+---
+
+### `Shape.deflectionIsConsistent(current:required:allowDecrease:ratio:)`
+
+Check whether a mesh deflection is consistent with requirements.
+
+```swift
+public static func deflectionIsConsistent(current: Double, required: Double,
+                                           allowDecrease: Bool = false,
+                                           ratio: Double = 0.1) -> Bool
+```
+
+- **Parameters:** `current` — current deflection; `required` — required deflection; `allowDecrease` — permit finer mesh than required; `ratio` — comparison ratio (0–1).
+- **Returns:** `true` if the current deflection is acceptable.
+- **OCCT:** `BRepMesh_Deflection::IsConsistent` via `OCCTDeflectionIsConsistent`.
+
+---
+
+## BRepBuilderAPI\_MakeShapeOnMesh
+
+### `Shape.fromMesh(points:triangles:)`
+
+Build a topological shape from a triangulated mesh.
+
+```swift
+public static func fromMesh(points: [SIMD3<Double>], triangles: [(Int32, Int32, Int32)]) -> Shape?
+```
+
+- **Parameters:** `points` — mesh vertices; `triangles` — index triples using 1-based indices into `points`.
+- **Returns:** Shape from the mesh, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeShapeOnMesh` via `OCCTShapeFromMesh`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(1,0,0), SIMD3(0,1,0)]
+  let tris: [(Int32, Int32, Int32)] = [(1, 2, 3)]
+  let shape = Shape.fromMesh(points: pts, triangles: tris)
+  ```
+
+---
+
+## GeomPlate\_Surface
+
+### `Shape.plateSurface(points:tolerance:maxDegree:maxSegments:)`
+
+Build a smooth plate surface through point constraints.
+
+```swift
+public static func plateSurface(points: [SIMD3<Double>], tolerance: Double = 1e-3,
+                                 maxDegree: Int = 8, maxSegments: Int = 20) -> Shape?
+```
+
+Creates a smooth BSpline surface that passes through or near the given points. Useful for surfaces from scattered point data.
+
+- **Parameters:** `points` — 3D points to fit; `tolerance` — approximation tolerance; `maxDegree` — max BSpline degree; `maxSegments` — max BSpline segments.
+- **Returns:** Face with plate surface, or `nil` on failure.
+- **OCCT:** `GeomPlate_BuildPlateSurface` + `GeomPlate_MakeApprox` via `OCCTGeomPlateSurface`.
+
+---
+
+## CellsBuilder
+
+Builder for Boolean cell operations. Partitions input shapes into cells (volumetric fragments), assigns material IDs, and lets you select which cells to include in the result. The class is a standalone `final class`, not a member of `Shape`.
+
+### `CellsBuilder.init?(shapes:)`
+
+Create a `CellsBuilder` by partitioning a set of input shapes into cells.
+
+```swift
+public init?(shapes: [Shape])
+```
+
+- **Parameters:** `shapes` — input shapes to partition.
+- **Returns:** `CellsBuilder`, or `nil` if partitioning fails.
+- **OCCT:** `BOPAlgo_CellsBuilder` via `OCCTCellsBuilderCreate`.
+
+---
+
+### `addAllToResult(material:)`
+
+Add all split cells to the result with a given material ID.
+
+```swift
+public func addAllToResult(material: Int32 = 0)
+```
+
+- **Parameters:** `material` — material ID to assign (default `0`).
+- **OCCT:** `OCCTCellsBuilderAddAllToResult`.
+
+---
+
+### `removeAllFromResult()`
+
+Remove all cells from the current result.
+
+```swift
+public func removeAllFromResult()
+```
+
+- **OCCT:** `OCCTCellsBuilderRemoveAllFromResult`.
+
+---
+
+### `removeInternalBoundaries()`
+
+Merge adjacent cells that share the same material ID, removing internal faces.
+
+```swift
+public func removeInternalBoundaries()
+```
+
+- **OCCT:** `BOPAlgo_CellsBuilder::RemoveInternalBoundaries` via `OCCTCellsBuilderRemoveInternalBoundaries`.
+
+---
+
+### `result()`
+
+Get the current result shape.
+
+```swift
+public func result() -> Shape?
+```
+
+- **Returns:** Result compound shape, or `nil` if no cells have been added.
+- **OCCT:** `OCCTCellsBuilderGetResult`.
+- **Example:**
+  ```swift
+  if let cb = CellsBuilder(shapes: [box, sphere]) {
+      cb.addAllToResult(material: 1)
+      cb.removeInternalBoundaries()
+      let merged = cb.result()
+  }
+  ```
+
+---
+
+## BRepLib\_MakeEdge / MakeFace / MakeShell / ToolTriangulatedShape / PointCloudShape
+
+### `Shape.edgeFromLine(origin:direction:p1:p2:)`
+
+Create an edge from a line with parameter bounds.
+
+```swift
+public static func edgeFromLine(
+    origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    p1: Double,
+    p2: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin` — line origin point; `direction` — line direction; `p1`, `p2` — parameter bounds.
+- **Returns:** Edge shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeEdge(gp_Lin, p1, p2)` via `OCCTBRepLibMakeEdgeFromLine`.
+
+---
+
+### `Shape.edgeFromPoints(_:_:)`
+
+Create an edge from two 3D points.
+
+```swift
+public static func edgeFromPoints(_ p1: SIMD3<Double>, _ p2: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `p1`, `p2` — start and end points.
+- **Returns:** Edge shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeEdge(gp_Pnt, gp_Pnt)` via `OCCTBRepLibMakeEdgeFromPoints`.
+
+---
+
+### `Shape.edgeFromCircle(center:axis:radius:p1:p2:)`
+
+Create an edge from a circle arc with parameter bounds.
+
+```swift
+public static func edgeFromCircle(
+    center: SIMD3<Double>,
+    axis: SIMD3<Double>,
+    radius: Double,
+    p1: Double,
+    p2: Double
+) -> Shape?
+```
+
+- **Parameters:** `center` — circle centre; `axis` — normal axis; `radius` — radius; `p1`, `p2` — angular bounds in radians.
+- **Returns:** Edge shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeEdge(gp_Circ, p1, p2)` via `OCCTBRepLibMakeEdgeFromCircle`.
+
+---
+
+### `Shape.faceFromPlane(origin:normal:uRange:vRange:tolerance:)`
+
+Create a face from a plane surface with UV bounds.
+
+```swift
+public static func faceFromPlane(
+    origin: SIMD3<Double>,
+    normal: SIMD3<Double>,
+    uRange: ClosedRange<Double>,
+    vRange: ClosedRange<Double>,
+    tolerance: Double = 1e-6
+) -> Shape?
+```
+
+- **Parameters:** `origin` — point on the plane; `normal` — plane normal; `uRange`, `vRange` — parameter bounds; `tolerance` — vertex tolerance.
+- **Returns:** Face shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeFace(gp_Pln, ...)` via `OCCTBRepLibMakeFaceFromPlane`.
+
+---
+
+### `Shape.faceFromCylinder(origin:axis:radius:uRange:vRange:tolerance:)`
+
+Create a face from a cylindrical surface with UV bounds.
+
+```swift
+public static func faceFromCylinder(
+    origin: SIMD3<Double>,
+    axis: SIMD3<Double>,
+    radius: Double,
+    uRange: ClosedRange<Double>,
+    vRange: ClosedRange<Double>,
+    tolerance: Double = 1e-6
+) -> Shape?
+```
+
+- **Parameters:** `origin` — axis origin; `axis` — axis direction; `radius` — cylinder radius; `uRange` — angular bounds (radians); `vRange` — axial bounds; `tolerance` — vertex tolerance.
+- **Returns:** Face shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeFace(gp_Cylinder, ...)` via `OCCTBRepLibMakeFaceFromCylinder`.
+
+---
+
+### `Shape.shellFromPlane(origin:normal:uRange:vRange:)`
+
+Create a shell from a plane surface with UV bounds.
+
+```swift
+public static func shellFromPlane(
+    origin: SIMD3<Double>,
+    normal: SIMD3<Double>,
+    uRange: ClosedRange<Double>,
+    vRange: ClosedRange<Double>
+) -> Shape?
+```
+
+- **Parameters:** `origin` — point on the plane; `normal` — plane normal; `uRange`, `vRange` — parameter bounds.
+- **Returns:** Shell shape, or `nil` on failure.
+- **OCCT:** `BRepLib_MakeShell(gp_Pln, ...)` via `OCCTBRepLibMakeShellFromPlane`.
+
+---
+
+### `computeNormals()`
+
+Compute normals on the triangulation of all faces in this shape.
+
+```swift
+public func computeNormals() -> Bool
+```
+
+The shape must be meshed first.
+
+- **Returns:** `true` if normals were computed successfully.
+- **OCCT:** `BRepLib_ToolTriangulatedShape::ComputeNormals` via `OCCTBRepLibComputeNormals`.
+
+---
+
+### `PointCloudResult`
+
+Point cloud positions and normals.
+
+```swift
+public struct PointCloudResult: Sendable {
+    public let points: [SIMD3<Double>]
+    public let normals: [SIMD3<Double>]
+}
+```
+
+---
+
+### `pointCloudByTriangulation()`
+
+Generate a point cloud from this shape's triangulation.
+
+```swift
+public func pointCloudByTriangulation() -> PointCloudResult?
+```
+
+The shape must be meshed first. One point and normal per triangulation node.
+
+- **Returns:** `PointCloudResult`, or `nil` if the shape has no triangulation or generation fails.
+- **OCCT:** `BRepLib_PointCloudShape::GetPoints` via `OCCTBRepLibPointCloudByTriangulation`.
+
+---
+
+### `pointCloudByDensity(_:)`
+
+Generate a point cloud from this shape by density (points per unit area).
+
+```swift
+public func pointCloudByDensity(_ density: Double) -> PointCloudResult?
+```
+
+The shape must be meshed first.
+
+- **Parameters:** `density` — target number of points per unit area.
+- **Returns:** `PointCloudResult`, or `nil` on failure.
+- **OCCT:** `BRepLib_PointCloudShape::GetPointsByDensity` via `OCCTBRepLibPointCloudByDensity`.
+
+---
+
+## BRepBuilderAPI\_MakeEdge2d
+
+### `Shape.edge2d(from:to:)`
+
+Create a 2D edge from two 2D points.
+
+```swift
+public static func edge2d(from p1: SIMD2<Double>, to p2: SIMD2<Double>) -> Shape?
+```
+
+- **Parameters:** `p1`, `p2` — start and end points in 2D.
+- **Returns:** 2D edge shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeEdge2d(gp_Pnt2d, gp_Pnt2d)` via `OCCTMakeEdge2dFromPoints`.
+
+---
+
+### `Shape.edge2dFromCircle(center:direction:radius:p1:p2:)`
+
+Create a 2D edge from a circle arc with parameter bounds.
+
+```swift
+public static func edge2dFromCircle(
+    center: SIMD2<Double>,
+    direction: SIMD2<Double>,
+    radius: Double,
+    p1: Double,
+    p2: Double
+) -> Shape?
+```
+
+- **Parameters:** `center` — 2D circle centre; `direction` — orientation; `radius` — radius; `p1`, `p2` — angular bounds.
+- **Returns:** 2D edge shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeEdge2d(gp_Circ2d, p1, p2)` via `OCCTMakeEdge2dFromCircle`.
+
+---
+
+### `Shape.edge2dFromLine(origin:direction:p1:p2:)`
+
+Create a 2D edge from a line with parameter bounds.
+
+```swift
+public static func edge2dFromLine(
+    origin: SIMD2<Double>,
+    direction: SIMD2<Double>,
+    p1: Double,
+    p2: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin` — 2D line origin; `direction` — line direction; `p1`, `p2` — parameter bounds.
+- **Returns:** 2D edge shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeEdge2d(gp_Lin2d, p1, p2)` via `OCCTMakeEdge2dFromLine`.
+
+---
+
+## BRepTools\_Modifier + NurbsConvert
+
+### `nurbsConvertViaModifier()`
+
+Convert this shape to NURBS using `BRepTools_Modifier` with `BRepTools_NurbsConvertModification`.
+
+```swift
+public func nurbsConvertViaModifier() -> Shape?
+```
+
+- **Returns:** NURBS-converted shape, or `nil` on failure.
+- **OCCT:** `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` via `OCCTBRepToolsModifierNurbsConvert`.
+- **Note:** Prefer `nurbsConvert()` for straightforward conversions; use this variant when you need the modifier-based pipeline.
+
+---
+
+## ShapeCustom\_Direct / TrsfModification
+
+### `directModification()`
+
+Orient face normals outward using `ShapeCustom_DirectModification`.
+
+```swift
+public func directModification() -> Shape?
+```
+
+- **Returns:** Shape with consistently outward-oriented face normals, or `nil` on failure.
+- **OCCT:** `ShapeCustom_DirectModification` via `OCCTShapeCustomDirectModification`.
+
+---
+
+### `trsfModificationScale(_:)`
+
+Apply a uniform scale with proper tolerance handling via `ShapeCustom_TrsfModification`.
+
+```swift
+public func trsfModificationScale(_ scaleFactor: Double) -> Shape?
+```
+
+Unlike the basic `scaled(by:)` transform, this propagates tolerance updates correctly through the topology.
+
+- **Parameters:** `scaleFactor` — uniform scale factor.
+- **Returns:** Scaled shape, or `nil` on failure.
+- **OCCT:** `ShapeCustom_TrsfModification` via `OCCTShapeCustomTrsfModificationScale`.
+
+---
+
+## LocOpe Builders
+
+### `buildWires(faceIndex:)`
+
+Build wires from the edges of a face.
+
+```swift
+public func buildWires(faceIndex: Int32 = 0) -> [Shape]?
+```
+
+- **Parameters:** `faceIndex` — 1-based face index (`0` = all edges).
+- **Returns:** Array of wire shapes, or `nil` on failure.
+- **OCCT:** `LocOpe_BuildWires` via `OCCTLocOpeBuildWires`.
+
+---
+
+### `splitByWireOnFace(_:faceIndex:)`
+
+Split a face of this shape by projecting a wire onto it.
+
+```swift
+public func splitByWireOnFace(_ wire: Shape, faceIndex: Int32) -> Shape?
+```
+
+- **Parameters:** `wire` — the splitting wire shape; `faceIndex` — 1-based index of the face to split.
+- **Returns:** Modified shape with the face split, or `nil` on failure.
+- **OCCT:** `LocOpe_WiresOnShape` + `LocOpe_Spliter` via `OCCTLocOpeSplitByWireOnFace`.
+
+---
+
+### `curveShapeIntersect(origin:direction:)`
+
+Intersect a line with this shape and return parameter values on the line.
+
+```swift
+public func curveShapeIntersect(
+    origin: SIMD3<Double>,
+    direction: SIMD3<Double>
+) -> [Double]?
+```
+
+- **Parameters:** `origin` — line origin; `direction` — line direction.
+- **Returns:** Array of parameter values where the line intersects the shape, or `nil` on failure.
+- **OCCT:** `LocOpe_CurveShapeIntersector` via `OCCTLocOpeCurveShapeIntersectLine`.
+
+---
+
+## CPnts\_UniformDeflection
+
+### `DeflectionResult`
+
+Discretization result with parameters and 3D points.
+
+```swift
+public struct DeflectionResult: Sendable {
+    public let parameters: [Double]
+    public let points: [SIMD3<Double>]
+}
+```
+
+---
+
+### `uniformDeflection(_:)`
+
+Discretize an edge by uniform deflection over its full parameter range.
+
+```swift
+public func uniformDeflection(_ deflection: Double) -> DeflectionResult?
+```
+
+- **Parameters:** `deflection` — maximum chord deflection.
+- **Returns:** `DeflectionResult`, or `nil` on failure.
+- **OCCT:** `GCPnts_UniformDeflection` via `OCCTCPntsUniformDeflection`.
+- **Example:**
+  ```swift
+  if let d = edge.uniformDeflection(0.1) {
+      // d.points — evenly deflection-spaced 3D samples
+  }
+  ```
+
+---
+
+### `uniformDeflection(_:range:)`
+
+Discretize an edge by uniform deflection within a parameter range.
+
+```swift
+public func uniformDeflection(_ deflection: Double, range: ClosedRange<Double>) -> DeflectionResult?
+```
+
+- **Parameters:** `deflection` — maximum chord deflection; `range` — parameter range to sample.
+- **Returns:** `DeflectionResult`, or `nil` on failure.
+- **OCCT:** `GCPnts_UniformDeflection` with range via `OCCTCPntsUniformDeflectionRange`.
+
+---
+
+## IntCurvesFace\_ShapeIntersector
+
+### `RayIntersection`
+
+Ray-shape intersection result.
+
+```swift
+public struct RayIntersection: Sendable {
+    public let point: SIMD3<Double>
+    public let parameter: Double
+}
+```
+
+- **Fields:** `point` — 3D hit point; `parameter` — parameter on the ray.
+
+---
+
+### `rayIntersect(origin:direction:)`
+
+Intersect a ray with all faces of this shape.
+
+```swift
+public func rayIntersect(
+    origin: SIMD3<Double>,
+    direction: SIMD3<Double>
+) -> [RayIntersection]?
+```
+
+- **Parameters:** `origin` — ray origin; `direction` — ray direction.
+- **Returns:** Array of intersections sorted by parameter, or `nil` on failure (empty shape, no triangulation, etc.).
+- **OCCT:** `IntCurvesFace_ShapeIntersector` via `OCCTIntCurvesFaceShapeIntersect`.
+- **Example:**
+  ```swift
+  if let hits = solid.rayIntersect(origin: SIMD3(0, 0, -10), direction: SIMD3(0, 0, 1)) {
+      let entry = hits.first
+  }
+  ```
+
+---
+
+### `rayIntersectNearest(origin:direction:)`
+
+Find the nearest intersection of a ray with this shape.
+
+```swift
+public func rayIntersectNearest(
+    origin: SIMD3<Double>,
+    direction: SIMD3<Double>
+) -> RayIntersection?
+```
+
+- **Parameters:** `origin` — ray origin; `direction` — ray direction.
+- **Returns:** Nearest `RayIntersection`, or `nil` if no intersection is found.
+- **OCCT:** `IntCurvesFace_ShapeIntersector` (nearest) via `OCCTIntCurvesFaceShapeIntersectNearest`.
+
+---
+
+## GeomLProp\_CLProps / SLProps
+
+These types are declared at module scope (not nested in `Shape`), then used via `Shape` methods.
+
+### `CurveLocalProperties`
+
+Local curve properties at a parameter point.
+
+```swift
+public struct CurveLocalProperties: Sendable {
+    public let point: SIMD3<Double>
+    public let tangent: SIMD3<Double>?
+    public let normal: SIMD3<Double>?
+    public let centerOfCurvature: SIMD3<Double>?
+    public let curvature: Double
+}
+```
+
+- `tangent` and `normal` are `nil` at inflection or degenerate points; `centerOfCurvature` is `nil` when curvature ≈ 0.
+
+---
+
+### `SurfaceLocalProperties`
+
+Local surface properties at a (U,V) parameter point.
+
+```swift
+public struct SurfaceLocalProperties: Sendable {
+    public let point: SIMD3<Double>
+    public let normal: SIMD3<Double>?
+    public let tangentU: SIMD3<Double>?
+    public let tangentV: SIMD3<Double>?
+    public let maxCurvature: Double
+    public let minCurvature: Double
+    public let meanCurvature: Double
+    public let gaussianCurvature: Double
+    public let isUmbilic: Bool
+}
+```
+
+---
+
+### `curveLocalProps(at:)`
+
+Compute curve local properties at a parameter on an edge shape.
+
+```swift
+public func curveLocalProps(at param: Double) -> CurveLocalProperties
+```
+
+- **Parameters:** `param` — curve parameter.
+- **Returns:** `CurveLocalProperties` at the given parameter.
+- **OCCT:** `GeomLProp_CLProps` via `OCCTGeomLPropCLProps`.
+- **Example:**
+  ```swift
+  let props = edge.curveLocalProps(at: 0.5)
+  if let t = props.tangent { print(t) }
+  ```
+
+---
+
+### `surfaceLocalProps(u:v:)`
+
+Compute surface local properties at (U,V) on a face shape.
+
+```swift
+public func surfaceLocalProps(u: Double, v: Double) -> SurfaceLocalProperties
+```
+
+- **Parameters:** `u`, `v` — surface parameters.
+- **Returns:** `SurfaceLocalProperties` at the given parameter point.
+- **OCCT:** `GeomLProp_SLProps` via `OCCTGeomLPropSLProps`.
+- **Example:**
+  ```swift
+  let props = face.surfaceLocalProps(u: 0.0, v: 0.0)
+  print(props.gaussianCurvature)
+  ```
+
+---
+
+## BRepOffset\_SimpleOffset
+
+### `simpleOffsetShape(distance:tolerance:)`
+
+Create a simple surface offset of this shape.
+
+```swift
+public func simpleOffsetShape(distance: Double, tolerance: Double = 1e-3) -> Shape?
+```
+
+- **Parameters:** `distance` — offset distance; `tolerance` — geometric tolerance.
+- **Returns:** Offset shape, or `nil` on failure.
+- **OCCT:** `BRepOffset_SimpleOffset` via `OCCTBRepOffsetSimpleOffset`.
+
+---
+
+## Approx\_CurvilinearParameter
+
+### `curvilinearParameter(tolerance:maxDegree:maxSegments:)`
+
+Reparameterize an edge curve by arc length, returning a BSpline edge.
+
+```swift
+public func curvilinearParameter(tolerance: Double = 1e-3, maxDegree: Int = 8, maxSegments: Int = 50) -> Shape?
+```
+
+- **Parameters:** `tolerance` — approximation tolerance; `maxDegree` — max BSpline degree; `maxSegments` — max segment count.
+- **Returns:** Edge with arc-length parameterization, or `nil` on failure.
+- **OCCT:** `Approx_CurvilinearParameter` via `OCCTApproxCurvilinearParameter`.
+
+---
+
+## GeomInt\_IntSS
+
+### `SurfaceIntersectionResult`
+
+Surface-surface intersection result (reference-counted class).
+
+```swift
+public class SurfaceIntersectionResult {
+    public var curveCount: Int { get }
+    public func curve(_ index: Int) -> Shape?
+    public var pointCount: Int { get }
+    public func point(_ index: Int) -> SIMD3<Double>
+}
+```
+
+- **Members:** `curveCount` — number of intersection curves; `curve(_:)` — 1-based curve retrieval as an edge shape; `pointCount` — number of isolated points; `point(_:)` — 1-based point retrieval.
+- **OCCT:** `GeomInt_IntSS` via `OCCTGeomIntSS*`.
+
+---
+
+### `Shape.surfaceSurfaceIntersection(face1:face2:tolerance:)`
+
+Compute the surface-surface intersection between two face shapes.
+
+```swift
+public static func surfaceSurfaceIntersection(face1: Shape, face2: Shape, tolerance: Double = 1e-6) -> SurfaceIntersectionResult?
+```
+
+- **Parameters:** `face1`, `face2` — face shapes; `tolerance` — intersection tolerance.
+- **Returns:** `SurfaceIntersectionResult`, or `nil` if no intersection or construction fails.
+- **OCCT:** `GeomInt_IntSS` via `OCCTGeomIntSSCreate`.
+- **Example:**
+  ```swift
+  if let r = Shape.surfaceSurfaceIntersection(face1: f1, face2: f2) {
+      for i in 1...r.curveCount {
+          let curve = r.curve(i)
+      }
+  }
+  ```
+
+---
+
+## Contap\_Contour
+
+### `ContourLineType`
+
+Contour line type from `Contap_Contour` analysis.
+
+```swift
+public enum ContourLineType: Int32, Sendable {
+    case line = 0
+    case circle = 1
+    case walking = 2
+    case restriction = 3
+}
+```
+
+---
+
+### `ContapContourResult`
+
+Contour computation result (reference-counted class).
+
+```swift
+public class ContapContourResult {
+    public var lineCount: Int { get }
+    public func pointCount(line: Int) -> Int
+    public func point(line: Int, index: Int) -> SIMD3<Double>
+    public func points(line: Int) -> [SIMD3<Double>]
+    public func lineType(_ line: Int) -> ContourLineType?
+}
+```
+
+- All indices are 1-based.
+- **OCCT:** `Contap_Contour` via `OCCTContapContour*`.
+
+---
+
+### `contapContourDirection(_:)`
+
+Compute contour lines on a face with an orthographic projection direction.
+
+```swift
+public func contapContourDirection(_ direction: SIMD3<Double>) -> ContapContourResult?
+```
+
+- **Parameters:** `direction` — orthographic view direction.
+- **Returns:** `ContapContourResult` if contours are found, or `nil` otherwise.
+- **OCCT:** `Contap_Contour(dir)` via `OCCTContapContourDirection`.
+
+---
+
+### `contapContourEye(_:)`
+
+Compute contour lines on a face with a perspective eye point.
+
+```swift
+public func contapContourEye(_ eye: SIMD3<Double>) -> ContapContourResult?
+```
+
+- **Parameters:** `eye` — perspective eye point.
+- **Returns:** `ContapContourResult` if contours are found, or `nil` otherwise.
+- **OCCT:** `Contap_Contour(eye)` via `OCCTContapContourEye`.
+
+---
+
+## BRepFeat\_Builder
+
+### `featFuse(with:)`
+
+Feature-based fuse (union with part selection).
+
+```swift
+public func featFuse(with tool: Shape) -> Shape?
+```
+
+- **Parameters:** `tool` — the tool shape to fuse.
+- **Returns:** Fused shape, or `nil` on failure.
+- **OCCT:** `BRepFeat_Builder` (fuse mode) via `OCCTBRepFeatBuilderFuse`.
+
+---
+
+### `featCut(with:)`
+
+Feature-based cut (subtraction with part selection).
+
+```swift
+public func featCut(with tool: Shape) -> Shape?
+```
+
+- **Parameters:** `tool` — the tool shape to subtract.
+- **Returns:** Cut shape, or `nil` on failure.
+- **OCCT:** `BRepFeat_Builder` (cut mode) via `OCCTBRepFeatBuilderCut`.
+
+---
+
+## GeomFill Trihedron Laws / Coons / Curved / CoonsAlgPatch
+
+### `TrihedronFrame`
+
+Tangent, normal, binormal frame at a curve parameter.
+
+```swift
+public struct TrihedronFrame: Sendable {
+    public let tangent: SIMD3<Double>
+    public let normal: SIMD3<Double>
+    public let binormal: SIMD3<Double>
+}
+```
+
+---
+
+### `draftTrihedron(at:biNormal:angle:)`
+
+Evaluate a draft trihedron frame on an edge at a parameter.
+
+```swift
+public func draftTrihedron(at param: Double, biNormal: SIMD3<Double>, angle: Double) -> TrihedronFrame?
+```
+
+- **Parameters:** `param` — curve parameter; `biNormal` — fixed bi-normal direction; `angle` — draft angle in radians.
+- **Returns:** `TrihedronFrame`, or `nil` if the tangent is degenerate.
+- **OCCT:** `GeomFill_DraftTrihedron` via `OCCTGeomFillDraftTrihedron`.
+
+---
+
+### `discreteTrihedron(at:)`
+
+Evaluate a discrete trihedron frame on an edge at a parameter.
+
+```swift
+public func discreteTrihedron(at param: Double) -> TrihedronFrame?
+```
+
+- **Parameters:** `param` — curve parameter.
+- **Returns:** `TrihedronFrame`, or `nil` if the tangent is degenerate.
+- **OCCT:** `GeomFill_DiscreteTrihedron` via `OCCTGeomFillDiscreteTrihedron`.
+
+---
+
+### `correctedFrenet(at:)`
+
+Evaluate a corrected Frenet frame on an edge at a parameter.
+
+```swift
+public func correctedFrenet(at param: Double) -> TrihedronFrame?
+```
+
+- **Parameters:** `param` — curve parameter.
+- **Returns:** `TrihedronFrame`, or `nil` if the tangent is degenerate.
+- **OCCT:** `GeomFill_CorrectedFrenet` via `OCCTGeomFillCorrectedFrenet`.
+
+---
+
+### `FillingPoleGrid`
+
+Pole grid result from `GeomFill_Coons` or `GeomFill_Curved`.
+
+```swift
+public struct FillingPoleGrid: Sendable {
+    public let poles: [SIMD3<Double>]
+    public let nbU: Int
+    public let nbV: Int
+}
+```
+
+- **Fields:** `poles` — control points in row-major (U-major) order; `nbU`, `nbV` — grid dimensions.
+
+---
+
+### `Shape.coonsFilling(boundary1:boundary2:boundary3:boundary4:)`
+
+Compute a Coons filling pole grid from four boundary point arrays.
+
+```swift
+public static func coonsFilling(
+    boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
+    boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
+) -> FillingPoleGrid?
+```
+
+All four boundary arrays must have the same length (≥ 2). The result is a BSpline control-point grid, not a `Shape` — use `Surface.bspline(...)` to construct a surface from it.
+
+- **Parameters:** `boundary1`–`boundary4` — point arrays for the four boundaries of the patch.
+- **Returns:** `FillingPoleGrid`, or `nil` if sizes are mismatched or computation fails.
+- **OCCT:** `GeomFill_Coons` via `OCCTGeomFillCoonsPoles`.
+
+---
+
+### `Shape.curvedFilling(boundary1:boundary2:boundary3:boundary4:)`
+
+Compute a curved filling pole grid from four boundary point arrays.
+
+```swift
+public static func curvedFilling(
+    boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
+    boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
+) -> FillingPoleGrid?
+```
+
+Similar to `coonsFilling` but uses `GeomFill_Curved` which preserves surface curvature better for curved boundaries.
+
+- **Parameters:** `boundary1`–`boundary4` — point arrays for the four boundaries.
+- **Returns:** `FillingPoleGrid`, or `nil` on failure.
+- **OCCT:** `GeomFill_Curved` via `OCCTGeomFillCurvedPoles`.
+
+---
+
+### `Shape.coonsAlgPatch(edge1:edge2:edge3:edge4:evalU:evalV:)`
+
+Evaluate a Coons algorithmic patch from four boundary edges at a UV grid.
+
+```swift
+public static func coonsAlgPatch(
+    edge1: Shape, edge2: Shape, edge3: Shape, edge4: Shape,
+    evalU: Int = 10, evalV: Int = 10
+) -> [SIMD3<Double>]?
+```
+
+Returns evaluated 3D points over a `evalU × evalV` parameter grid. Indices in the result are in row-major order (U-major).
+
+- **Parameters:** `edge1`–`edge4` — boundary edge shapes; `evalU`, `evalV` — sampling count in each direction.
+- **Returns:** Flat array of `evalU × evalV` 3D points, or `nil` if all points are degenerate.
+- **OCCT:** `GeomFill_CoonsAlgPatch` via `OCCTGeomFillCoonsAlgPatchEval`.
+- **Example:**
+  ```swift
+  if let pts = Shape.coonsAlgPatch(edge1: e1, edge2: e2, edge3: e3, edge4: e4,
+                                    evalU: 5, evalV: 5) {
+      // pts.count == 25
+  }
+  ```

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -1,0 +1,2189 @@
+---
+title: Shape — Builders & Boolean Internals II
+parent: API Reference
+---
+
+# Shape — Builders & Boolean Internals II
+
+Continuation of the low-level builder and algorithm wrappers on `Shape` — covering GeomFill sweep/evolved-section, projection, offset, iso-curve evaluation, parameter transfer, boolean section/feature removal, shape build/extend/upgrade utilities, 2D vector math, topological transition analysis, GeomFill trihedrons, 2D polygon interference, analytical 2D circle construction, IntTools intersection, BOPAlgo builders, BRepFeat split/hole/glue, LocOpe split/glue, and 2D chamfer/fillet APIs.
+
+See also: **[Shape](Shape.md)** (index).
+
+## Topics
+
+- [GeomFill\_Sweep](#geomfill_sweep) · [GeomFill\_EvolvedSection](#geomfill_evolvedsection) · [ProjLib\_ComputeApprox](#projlib_computeapprox) · [BRepOffset\_Offset](#brepoffset_offset) · [Adaptor3d\_IsoCurve](#adaptor3d_isocurve) · [ShapeAnalysis\_TransferParametersProj](#shapeanalysis_transferparametersrproj) · [BOPAlgo\_RemoveFeatures](#bopalgo_removefeatures) · [BOPAlgo\_Section](#bopalgo_section) · [ShapeBuild\_Edge](#shapebuild_edge) · [ShapeBuild\_Vertex](#shapebuild_vertex) · [ShapeExtend\_Explorer](#shapeextend_explorer) · [ShapeUpgrade\_FaceDivide](#shapeupgrade_facedivide) · [ShapeUpgrade\_WireDivide](#shapeupgrade_wiredivide) · [ShapeUpgrade\_EdgeDivide](#shapeupgrade_edgedivide) · [ShapeUpgrade\_ClosedEdgeDivide](#shapeupgrade_closededgedivide) · [ShapeUpgrade\_FixSmallCurves](#shapeupgrade_fixsmallcurves) · [ShapeUpgrade\_FixSmallBezierCurves](#shapeupgrade_fixsmallbeziercurves) · [ShapeUpgrade\_ConvertCurve3dToBezier](#shapeupgrade_convertcurve3dtobezier) · [ShapeUpgrade\_ConvertSurfaceToBezierBasis](#shapeupgrade_convertsurfacetobezierbasis) · [2D Vector/Direction Utilities & LProp](#2d-vectordirection-utilities--lprop) · [TopTrans Surface Transition](#toptrans-surface-transition) · [TopTrans Curve Transition](#toptrans-curve-transition) · [GeomFill Trihedrons](#geomfill-trihedrons) · [Polygon Interference](#polygon-interference) · [GccAna\_Circ2d3Tan](#gccana_circ2d3tan) · [IntTools](#inttools) · [BOPAlgo Builder](#bopalgo-builder) · [BOPTools](#boptools) · [IntTools\_BeanFaceIntersector](#inttools_beanfaceintersector) · [BOPAlgo\_WireSplitter](#bopalgo_wiresplitter) · [BRepFeat\_SplitShape](#brepfeat_splitshape) · [BRepFeat\_MakeCylindricalHole](#brepfeat_makecylindricalhole) · [BRepFeat\_Gluer](#brepfeat_gluer) · [LocOpe\_WiresOnShape + LocOpe\_Spliter](#locope_wiresonshape--locope_spliter) · [LocOpe\_Gluer](#locope_gluer) · [ChFi2d\_Builder](#chfi2d_builder) · [ChFi2d\_ChamferAPI](#chfi2d_chamferapi) · [ChFi2d\_FilletAPI](#chfi2d_filletapi) · [FilletSurf\_Builder](#filletsorf_builder)
+
+---
+
+## GeomFill\_Sweep
+
+### `Shape.geomFillSweep(path:section:)`
+
+Sweep a section edge along a path edge to create a surface face.
+
+```swift
+public static func geomFillSweep(path: Shape, section: Shape) -> Shape?
+```
+
+- **Parameters:** `path` — edge defining the sweep path. `section` — edge defining the cross-section profile.
+- **Returns:** A `Shape` wrapping the swept face, or `nil` on failure.
+- **OCCT:** `GeomFill_Sweep`
+- **Example:**
+  ```swift
+  if let face = Shape.geomFillSweep(path: pathEdge, section: sectionEdge) {
+      // face is a swept surface
+  }
+  ```
+
+---
+
+## GeomFill\_EvolvedSection
+
+### `evolvedSectionInfo()`
+
+Get evolved section info for an edge curve.
+
+```swift
+public func evolvedSectionInfo() -> EvolvedSectionInfo
+```
+
+- **Returns:** `EvolvedSectionInfo` with `nbPoles`, `nbKnots`, `degree`, and `isRational`.
+- **OCCT:** `GeomFill_EvolvedSection`
+- **Example:**
+  ```swift
+  let info = edge.evolvedSectionInfo()
+  print(info.degree, info.isRational)
+  ```
+
+---
+
+## ProjLib\_ComputeApprox
+
+### `projectOntoSurface(_:tolerance:)`
+
+Project this edge's 3D curve onto a face's surface, returning an edge-on-surface.
+
+```swift
+public func projectOntoSurface(_ face: Shape, tolerance: Double = 1e-3) -> Shape?
+```
+
+- **Parameters:** `face` — target face. `tolerance` — approximation tolerance.
+- **Returns:** Projected edge as shape, or `nil` on failure.
+- **OCCT:** `ProjLib_ComputeApprox`
+- **Example:**
+  ```swift
+  if let proj = edge.projectOntoSurface(face) { }
+  ```
+
+---
+
+### `projectOntoPolarSurface(_:tolerance:)`
+
+Project this edge's 3D curve onto a polar surface (sphere, torus).
+
+```swift
+public func projectOntoPolarSurface(_ face: Shape, tolerance: Double = 1e-3) -> Shape?
+```
+
+- **Parameters:** `face` — polar face. `tolerance` — approximation tolerance.
+- **Returns:** Projected edge as shape, or `nil` on failure.
+- **OCCT:** `ProjLib_ComputeApproxOnPolarSurface`
+- **Example:**
+  ```swift
+  if let proj = edge.projectOntoPolarSurface(sphereFace) { }
+  ```
+
+---
+
+## BRepOffset\_Offset
+
+### `offsetFace(distance:)`
+
+Offset a face by a distance, creating a new offset face.
+
+```swift
+public func offsetFace(distance: Double) -> Shape?
+```
+
+- **Parameters:** `distance` — signed offset amount; positive moves along the face normal.
+- **Returns:** Offset face, or `nil` on failure.
+- **OCCT:** `BRepOffset_Offset`
+- **Example:**
+  ```swift
+  if let off = face.offsetFace(distance: 2.0) { }
+  ```
+
+---
+
+## Adaptor3d\_IsoCurve
+
+### `uIsoCurvePoints(u:count:)`
+
+Evaluate sample points along a U-iso curve on a face.
+
+```swift
+public func uIsoCurvePoints(u: Double, count: Int = 20) -> [SIMD3<Double>]
+```
+
+- **Parameters:** `u` — U parameter value. `count` — number of sample points.
+- **Returns:** Array of 3D points along the iso curve.
+- **OCCT:** `Adaptor3d_IsoCurve` (iso kind 0 = U)
+- **Example:**
+  ```swift
+  let pts = face.uIsoCurvePoints(u: 0.5, count: 50)
+  ```
+
+---
+
+### `vIsoCurvePoints(v:count:)`
+
+Evaluate sample points along a V-iso curve on a face.
+
+```swift
+public func vIsoCurvePoints(v: Double, count: Int = 20) -> [SIMD3<Double>]
+```
+
+- **Parameters:** `v` — V parameter value. `count` — number of sample points.
+- **Returns:** Array of 3D points along the iso curve.
+- **OCCT:** `Adaptor3d_IsoCurve` (iso kind 1 = V)
+- **Example:**
+  ```swift
+  let pts = face.vIsoCurvePoints(v: 0.25)
+  ```
+
+---
+
+### `uIsoCurveEdge(u:vMin:vMax:)`
+
+Extract a U-iso curve from a face as an edge.
+
+```swift
+public func uIsoCurveEdge(u: Double, vMin: Double, vMax: Double) -> Shape?
+```
+
+- **Parameters:** `u` — U parameter. `vMin`/`vMax` — V parameter range for the edge.
+- **Returns:** Edge shape representing the iso curve, or `nil` on failure.
+- **OCCT:** `Adaptor3d_IsoCurve`
+- **Example:**
+  ```swift
+  if let e = face.uIsoCurveEdge(u: 0.5, vMin: 0, vMax: 1) { }
+  ```
+
+---
+
+### `vIsoCurveEdge(v:uMin:uMax:)`
+
+Extract a V-iso curve from a face as an edge.
+
+```swift
+public func vIsoCurveEdge(v: Double, uMin: Double, uMax: Double) -> Shape?
+```
+
+- **Parameters:** `v` — V parameter. `uMin`/`uMax` — U parameter range for the edge.
+- **Returns:** Edge shape representing the iso curve, or `nil` on failure.
+- **OCCT:** `Adaptor3d_IsoCurve`
+- **Example:**
+  ```swift
+  if let e = face.vIsoCurveEdge(v: 0.5, uMin: 0, uMax: 1) { }
+  ```
+
+---
+
+## ShapeAnalysis\_TransferParametersProj
+
+### `transferParameterToFace(_:face:)`
+
+Transfer a parameter from edge to face coordinate system via projection.
+
+```swift
+public func transferParameterToFace(_ param: Double, face: Shape) -> Double
+```
+
+- **Parameters:** `param` — edge parameter. `face` — face to transfer into.
+- **Returns:** Corresponding parameter in the face's coordinate system.
+- **OCCT:** `ShapeAnalysis_TransferParametersProj` (toFace = true)
+- **Example:**
+  ```swift
+  let faceParam = edge.transferParameterToFace(0.5, face: face)
+  ```
+
+---
+
+### `transferParameterFromFace(_:face:)`
+
+Transfer a parameter from face to edge coordinate system via projection.
+
+```swift
+public func transferParameterFromFace(_ param: Double, face: Shape) -> Double
+```
+
+- **Parameters:** `param` — face parameter. `face` — face to transfer from.
+- **Returns:** Corresponding parameter in the edge's coordinate system.
+- **OCCT:** `ShapeAnalysis_TransferParametersProj` (toFace = false)
+- **Example:**
+  ```swift
+  let edgeParam = edge.transferParameterFromFace(0.5, face: face)
+  ```
+
+---
+
+## BOPAlgo\_RemoveFeatures
+
+### `removeFeatures(faces:)`
+
+Remove features (faces) from a solid shape, healing the result.
+
+```swift
+public func removeFeatures(faces: [Shape]) -> Shape?
+```
+
+- **Parameters:** `faces` — array of face shapes to remove (e.g. fillets, boss faces, holes).
+- **Returns:** Healed shape with features removed, or `nil` on failure.
+- **OCCT:** `BOPAlgo_RemoveFeatures`
+- **Example:**
+  ```swift
+  let faces = solid.subShapes(ofType: .face)
+  if let cleaned = solid.removeFeatures(faces: [faces[2]]) { }
+  ```
+
+---
+
+## BOPAlgo\_Section
+
+### `section(with:)`
+
+Compute section (intersection curves/vertices) between this shape and tools.
+
+```swift
+public func section(with tools: [Shape]) -> Shape?
+```
+
+- **Parameters:** `tools` — tool shapes to intersect with this shape.
+- **Returns:** Compound of intersection edges and vertices, or `nil` on failure.
+- **OCCT:** `BOPAlgo_Section`
+- **Example:**
+  ```swift
+  if let sect = solid.section(with: [plane]) { }
+  ```
+
+---
+
+### `Shape.section(shapes:)`
+
+Compute section between multiple shapes (static variant).
+
+```swift
+public static func section(shapes: [Shape]) -> Shape?
+```
+
+- **Parameters:** `shapes` — at least 2 shapes; all are treated as equal arguments.
+- **Returns:** Compound of intersection edges and vertices, or `nil` on failure (requires ≥ 2 shapes).
+- **OCCT:** `BOPAlgo_Section`
+- **Example:**
+  ```swift
+  if let sect = Shape.section(shapes: [box, sphere]) { }
+  ```
+
+---
+
+## ShapeBuild\_Edge
+
+### `copyEdge(sharePCurves:)`
+
+Copy an edge, optionally sharing its PCurves with the original.
+
+```swift
+public func copyEdge(sharePCurves: Bool = true) -> Shape?
+```
+
+- **Parameters:** `sharePCurves` — if `true`, the copy shares PCurves with the original edge.
+- **Returns:** Copied edge as shape, or `nil` on failure.
+- **OCCT:** `ShapeBuild_Edge::Copy`
+- **Example:**
+  ```swift
+  if let copy = edge.copyEdge() { }
+  ```
+
+---
+
+### `copyEdgeReplacingVertices(startVertex:endVertex:)`
+
+Copy an edge, replacing its start and/or end vertices.
+
+```swift
+public func copyEdgeReplacingVertices(startVertex: Shape?, endVertex: Shape?) -> Shape?
+```
+
+- **Parameters:** `startVertex` — new start vertex, or `nil` to keep original. `endVertex` — new end vertex, or `nil` to keep original.
+- **Returns:** Edge with replaced vertices, or `nil` on failure.
+- **OCCT:** `ShapeBuild_Edge::CopyReplaceVertices`
+- **Example:**
+  ```swift
+  if let e = edge.copyEdgeReplacingVertices(startVertex: v1, endVertex: nil) { }
+  ```
+
+---
+
+### `setEdgeRange3d(first:last:)`
+
+Set the 3D parameter range on this edge shape.
+
+```swift
+public func setEdgeRange3d(first: Double, last: Double)
+```
+
+- **Parameters:** `first` — start parameter. `last` — end parameter.
+- **OCCT:** `ShapeBuild_Edge::SetRange3d`
+- **Example:**
+  ```swift
+  edge.setEdgeRange3d(first: 0, last: 1)
+  ```
+
+---
+
+### `buildEdgeCurve3d()`
+
+Rebuild the 3D curve of an edge from its PCurves.
+
+```swift
+@discardableResult
+public func buildEdgeCurve3d() -> Bool
+```
+
+- **Returns:** `true` if the curve was rebuilt successfully.
+- **OCCT:** `ShapeBuild_Edge::BuildCurve3d`
+- **Example:**
+  ```swift
+  edge.buildEdgeCurve3d()
+  ```
+
+---
+
+### `removeEdgeCurve3d()`
+
+Remove the 3D curve from this edge.
+
+```swift
+public func removeEdgeCurve3d()
+```
+
+- **OCCT:** `ShapeBuild_Edge::RemoveCurve3d`
+- **Example:**
+  ```swift
+  edge.removeEdgeCurve3d()
+  ```
+
+---
+
+### `copyEdgeRanges(from:)`
+
+Copy parameter ranges from another edge to this edge.
+
+```swift
+public func copyEdgeRanges(from source: Shape)
+```
+
+- **Parameters:** `source` — edge from which to copy ranges.
+- **OCCT:** `ShapeBuild_Edge::CopyRanges`
+- **Example:**
+  ```swift
+  edge.copyEdgeRanges(from: sourceEdge)
+  ```
+
+---
+
+### `copyEdgePCurves(from:)`
+
+Copy PCurves from another edge to this edge.
+
+```swift
+public func copyEdgePCurves(from source: Shape)
+```
+
+- **Parameters:** `source` — edge from which to copy PCurves.
+- **OCCT:** `ShapeBuild_Edge::CopyPCurves`
+- **Example:**
+  ```swift
+  edge.copyEdgePCurves(from: sourceEdge)
+  ```
+
+---
+
+### `removeEdgePCurve(onFace:)`
+
+Remove the PCurve from this edge for a given face.
+
+```swift
+public func removeEdgePCurve(onFace face: Shape)
+```
+
+- **Parameters:** `face` — the face whose PCurve should be removed from this edge.
+- **OCCT:** `ShapeBuild_Edge::RemovePCurve`
+- **Example:**
+  ```swift
+  edge.removeEdgePCurve(onFace: face)
+  ```
+
+---
+
+### `reassignEdgePCurve(from:to:)`
+
+Reassign a PCurve from one face to another.
+
+```swift
+@discardableResult
+public func reassignEdgePCurve(from oldFace: Shape, to newFace: Shape) -> Bool
+```
+
+- **Parameters:** `oldFace` — face that currently holds the PCurve. `newFace` — destination face.
+- **Returns:** `true` if reassignment succeeded.
+- **OCCT:** `ShapeBuild_Edge::ReassignPCurve`
+- **Example:**
+  ```swift
+  edge.reassignEdgePCurve(from: oldFace, to: newFace)
+  ```
+
+---
+
+## ShapeBuild\_Vertex
+
+### `combineVertex(with:tolFactor:)`
+
+Combine this vertex shape with another at their average position.
+
+```swift
+public func combineVertex(with other: Shape, tolFactor: Double = 1.0001) -> Shape?
+```
+
+- **Parameters:** `other` — vertex to combine with. `tolFactor` — tolerance scale factor.
+- **Returns:** Combined vertex as shape, or `nil` on failure.
+- **OCCT:** `ShapeBuild_Vertex::CombineVertex`
+- **Example:**
+  ```swift
+  if let v = v1.combineVertex(with: v2) { }
+  ```
+
+---
+
+### `Shape.combineVertices(point1:tol1:point2:tol2:tolFactor:)`
+
+Create a vertex by combining two 3D points with tolerances.
+
+```swift
+public static func combineVertices(
+    point1: SIMD3<Double>, tol1: Double,
+    point2: SIMD3<Double>, tol2: Double,
+    tolFactor: Double = 1.0001
+) -> Shape?
+```
+
+- **Parameters:** `point1`/`tol1` — first point and its tolerance. `point2`/`tol2` — second point and its tolerance. `tolFactor` — scale factor applied to the combined tolerance.
+- **Returns:** Combined vertex, or `nil` on failure.
+- **OCCT:** `ShapeBuild_Vertex::CombineVertex` (from points)
+- **Example:**
+  ```swift
+  if let v = Shape.combineVertices(point1: .zero, tol1: 1e-7, point2: SIMD3(0,0,0.001), tol2: 1e-7) { }
+  ```
+
+---
+
+## ShapeExtend\_Explorer
+
+### `ShapeFilterType`
+
+Shape type enum for filtering compounds.
+
+```swift
+public enum ShapeFilterType: Int32, Sendable {
+    case compound = 0, compsolid = 1, solid = 2, shell = 3
+    case face = 4, wire = 5, edge = 6, vertex = 7
+}
+```
+
+Matches `TopAbs_ShapeEnum` values used by `ShapeExtend_Explorer`.
+
+---
+
+### `sortedCompound(type:explore:)`
+
+Filter this compound, extracting only sub-shapes of the specified type.
+
+```swift
+public func sortedCompound(type: ShapeFilterType, explore: Bool = true) -> Shape?
+```
+
+- **Parameters:** `type` — target shape type. `explore` — if `true`, recurse into sub-compounds.
+- **Returns:** Compound of matching sub-shapes, or `nil` on failure.
+- **OCCT:** `ShapeExtend_Explorer::SortedCompound`
+- **Example:**
+  ```swift
+  if let faces = compound.sortedCompound(type: .face) { }
+  ```
+
+---
+
+### `predominantShapeType(lookInsideCompounds:)`
+
+Get the predominant shape type in this compound.
+
+```swift
+public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilterType
+```
+
+- **Parameters:** `lookInsideCompounds` — if `true`, inspect sub-compounds.
+- **Returns:** The most-common `ShapeFilterType` found.
+- **OCCT:** `ShapeExtend_Explorer::ShapeType`
+- **Example:**
+  ```swift
+  let t = compound.predominantShapeType()
+  ```
+
+---
+
+## ShapeUpgrade\_FaceDivide
+
+### `divideFace()`
+
+Divide a face using surface segmentation.
+
+```swift
+public func divideFace() -> Shape?
+```
+
+- **Returns:** Divided shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_FaceDivide`
+- **Example:**
+  ```swift
+  if let divided = face.divideFace() { }
+  ```
+
+---
+
+## ShapeUpgrade\_WireDivide
+
+### `divideWire(onFace:)`
+
+Divide a wire on a face.
+
+```swift
+public func divideWire(onFace face: Shape) -> Shape?
+```
+
+- **Parameters:** `face` — face the wire lies on.
+- **Returns:** Divided wire as shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_WireDivide`
+- **Example:**
+  ```swift
+  if let w = wire.divideWire(onFace: face) { }
+  ```
+
+---
+
+## ShapeUpgrade\_EdgeDivide
+
+### `EdgeDivideResult`
+
+Result of an edge divide analysis.
+
+```swift
+public struct EdgeDivideResult: Sendable {
+    public let hasCurve2d: Bool
+    public let hasCurve3d: Bool
+}
+```
+
+---
+
+### `analyzeEdgeDivide(onFace:)`
+
+Analyze an edge for potential division on a face.
+
+```swift
+public func analyzeEdgeDivide(onFace face: Shape) -> EdgeDivideResult?
+```
+
+- **Parameters:** `face` — face context for the edge.
+- **Returns:** Analysis result indicating 2D/3D curve presence, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_EdgeDivide::Compute`
+- **Example:**
+  ```swift
+  if let r = edge.analyzeEdgeDivide(onFace: face) {
+      print(r.hasCurve3d)
+  }
+  ```
+
+---
+
+## ShapeUpgrade\_ClosedEdgeDivide
+
+### `canDivideClosedEdge(onFace:)`
+
+Check if a closed (seam) edge can be divided on a face.
+
+```swift
+public func canDivideClosedEdge(onFace face: Shape) -> Bool
+```
+
+- **Parameters:** `face` — face context.
+- **Returns:** `true` if the edge is closed and divisible.
+- **OCCT:** `ShapeUpgrade_ClosedEdgeDivide::Compute`
+- **Example:**
+  ```swift
+  if edge.canDivideClosedEdge(onFace: face) { }
+  ```
+
+---
+
+## ShapeUpgrade\_FixSmallCurves
+
+### `fixSmallCurves(tolerance:)`
+
+Fix small curves in this shape.
+
+```swift
+public func fixSmallCurves(tolerance: Double = 1e-6) -> Shape?
+```
+
+- **Parameters:** `tolerance` — threshold below which curves are considered small.
+- **Returns:** Fixed shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_FixSmallCurves`
+- **Example:**
+  ```swift
+  if let fixed = shape.fixSmallCurves() { }
+  ```
+
+---
+
+## ShapeUpgrade\_FixSmallBezierCurves
+
+### `fixSmallBezierCurves(tolerance:)`
+
+Fix small Bezier curves in this shape.
+
+```swift
+public func fixSmallBezierCurves(tolerance: Double = 1e-6) -> Shape?
+```
+
+- **Parameters:** `tolerance` — detection threshold.
+- **Returns:** Fixed shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_FixSmallBezierCurves`
+- **Example:**
+  ```swift
+  if let fixed = shape.fixSmallBezierCurves() { }
+  ```
+
+---
+
+## ShapeUpgrade\_ConvertCurve3dToBezier
+
+### `convertCurves3dToBezier(lineMode:circleMode:conicMode:)`
+
+Convert 3D curves in this shape to Bezier representation.
+
+```swift
+public func convertCurves3dToBezier(lineMode: Bool = true, circleMode: Bool = true,
+                                     conicMode: Bool = true) -> Shape?
+```
+
+- **Parameters:** `lineMode` — convert line segments. `circleMode` — convert circles. `conicMode` — convert other conics.
+- **Returns:** Shape with Bezier curves, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ConvertCurve3dToBezier`
+- **Example:**
+  ```swift
+  if let bez = shape.convertCurves3dToBezier(lineMode: false) { }
+  ```
+
+---
+
+## ShapeUpgrade\_ConvertSurfaceToBezierBasis
+
+### `convertSurfacesToBezier(planeMode:revolutionMode:extrusionMode:bsplineMode:)`
+
+Convert surfaces in this shape to Bezier patches.
+
+```swift
+public func convertSurfacesToBezier(planeMode: Bool = true, revolutionMode: Bool = true,
+                                     extrusionMode: Bool = true, bsplineMode: Bool = true) -> Shape?
+```
+
+- **Parameters:** `planeMode` — convert planes. `revolutionMode` — convert revolution surfaces. `extrusionMode` — convert extrusions. `bsplineMode` — convert BSpline surfaces.
+- **Returns:** Shape with Bezier surfaces, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ConvertSurfaceToBezierBasis`
+- **Example:**
+  ```swift
+  if let bez = shape.convertSurfacesToBezier(bsplineMode: false) { }
+  ```
+
+---
+
+## 2D Vector/Direction Utilities & LProp
+
+### `Shape.vector2DAngle(a:b:)`
+
+Signed angle between two 2D vectors, in radians (range −π to π).
+
+```swift
+public static func vector2DAngle(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
+```
+
+- **OCCT:** `gp_Vec2d::Angle`
+- **Example:**
+  ```swift
+  let angle = Shape.vector2DAngle(a: SIMD2(1, 0), b: SIMD2(0, 1))  // π/2
+  ```
+
+---
+
+### `Shape.vector2DCross(a:b:)`
+
+Cross product of two 2D vectors (scalar Z component).
+
+```swift
+public static func vector2DCross(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
+```
+
+- **OCCT:** `gp_Vec2d::Crossed`
+- **Example:**
+  ```swift
+  let z = Shape.vector2DCross(a: SIMD2(1, 0), b: SIMD2(0, 1))  // 1.0
+  ```
+
+---
+
+### `Shape.vector2DDot(a:b:)`
+
+Dot product of two 2D vectors.
+
+```swift
+public static func vector2DDot(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
+```
+
+- **OCCT:** `gp_Vec2d::Dot`
+- **Example:**
+  ```swift
+  let d = Shape.vector2DDot(a: SIMD2(1, 0), b: SIMD2(0.5, 0.5))
+  ```
+
+---
+
+### `Shape.vector2DMagnitude(_:)`
+
+Magnitude of a 2D vector.
+
+```swift
+public static func vector2DMagnitude(_ v: SIMD2<Double>) -> Double
+```
+
+- **OCCT:** `gp_Vec2d::Magnitude`
+- **Example:**
+  ```swift
+  let m = Shape.vector2DMagnitude(SIMD2(3, 4))  // 5.0
+  ```
+
+---
+
+### `Shape.vector2DNormalized(_:)`
+
+Return a normalized copy of a 2D vector.
+
+```swift
+public static func vector2DNormalized(_ v: SIMD2<Double>) -> SIMD2<Double>
+```
+
+- **OCCT:** `gp_Vec2d::Normalized`
+- **Example:**
+  ```swift
+  let n = Shape.vector2DNormalized(SIMD2(3, 4))
+  ```
+
+---
+
+### `Shape.direction2DNormalized(_:)`
+
+Create a normalized 2D direction from components.
+
+```swift
+public static func direction2DNormalized(_ v: SIMD2<Double>) -> SIMD2<Double>
+```
+
+- **OCCT:** `gp_Dir2d` constructor (normalizes on construction)
+- **Example:**
+  ```swift
+  let d = Shape.direction2DNormalized(SIMD2(1, 1))
+  ```
+
+---
+
+### `Shape.direction2DAngle(a:b:)`
+
+Signed angle between two 2D directions, in radians.
+
+```swift
+public static func direction2DAngle(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
+```
+
+- **OCCT:** `gp_Dir2d::Angle`
+- **Example:**
+  ```swift
+  let angle = Shape.direction2DAngle(a: SIMD2(1, 0), b: SIMD2(0, 1))
+  ```
+
+---
+
+### `Shape.direction2DCross(a:b:)`
+
+Cross product of two 2D directions.
+
+```swift
+public static func direction2DCross(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
+```
+
+- **OCCT:** `gp_Dir2d::Crossed`
+- **Example:**
+  ```swift
+  let z = Shape.direction2DCross(a: SIMD2(1, 0), b: SIMD2(0, 1))
+  ```
+
+---
+
+### `CurvaturePointType`
+
+Type of a special curvature point found by LProp analysis.
+
+```swift
+public enum CurvaturePointType: Int32 {
+    case inflection = 0
+    case minimumCurvature = 1
+    case maximumCurvature = 2
+}
+```
+
+---
+
+### `CurvatureSpecialPoint`
+
+A special point on a curve at a given parameter.
+
+```swift
+public struct CurvatureSpecialPoint {
+    public let parameter: Double
+    public let type: CurvaturePointType
+}
+```
+
+---
+
+### `Shape.analyticCurvaturePoints(curveType:first:last:)`
+
+Compute curvature special points (inflections, min/max curvature) for an analytic curve type.
+
+```swift
+public static func analyticCurvaturePoints(curveType: Int32, first: Double,
+                                            last: Double) -> [CurvatureSpecialPoint]
+```
+
+- **Parameters:** `curveType` — 0=Line, 1=Circle, 2=Ellipse, 3=Hyperbola, 4=Parabola. `first`/`last` — parameter domain.
+- **Returns:** Array of special points; empty if none found.
+- **OCCT:** `LProp_AnalyticCurInf`
+- **Example:**
+  ```swift
+  let pts = Shape.analyticCurvaturePoints(curveType: 2, first: 0, last: .pi)
+  ```
+
+---
+
+## TopTrans Surface Transition
+
+### `TopologicalState`
+
+OCCT `TopAbs_State` mapping.
+
+```swift
+public enum TopologicalState: Int32, Sendable {
+    case `in` = 0, out = 1, on = 2, unknown = 3
+}
+```
+
+---
+
+### `SurfaceTransitionResult`
+
+Result of a surface or curve transition analysis.
+
+```swift
+public struct SurfaceTransitionResult: Sendable {
+    public let stateBefore: TopologicalState
+    public let stateAfter: TopologicalState
+}
+```
+
+---
+
+### `Shape.surfaceTransition(tangent:normal:surfaceNormal:tolerance:surfaceOrientation:boundaryOrientation:)`
+
+Analyze topological state before and after a curve crosses a surface boundary.
+
+```swift
+public static func surfaceTransition(
+    tangent: SIMD3<Double>, normal: SIMD3<Double>,
+    surfaceNormal: SIMD3<Double>, tolerance: Double = 1e-6,
+    surfaceOrientation: Int = 0, boundaryOrientation: Int = 0
+) -> SurfaceTransitionResult
+```
+
+- **Parameters:** `tangent` — curve tangent at crossing. `normal` — boundary normal. `surfaceNormal` — normal of the crossed surface. `tolerance` — angular tolerance. `surfaceOrientation`/`boundaryOrientation` — 0=FORWARD, 1=REVERSED.
+- **Returns:** States before and after the surface crossing.
+- **OCCT:** `TopTrans_SurfaceTransition`
+- **Example:**
+  ```swift
+  let r = Shape.surfaceTransition(tangent: t, normal: n, surfaceNormal: sn)
+  ```
+
+---
+
+### `Shape.surfaceTransitionWithCurvature(...)`
+
+Extended surface transition analysis that accounts for surface curvature.
+
+```swift
+public static func surfaceTransitionWithCurvature(
+    tangent: SIMD3<Double>, normal: SIMD3<Double>,
+    maxDirection: SIMD3<Double>, minDirection: SIMD3<Double>,
+    maxCurvature: Double, minCurvature: Double,
+    surfaceNormal: SIMD3<Double>,
+    surfaceMaxDirection: SIMD3<Double>, surfaceMinDirection: SIMD3<Double>,
+    surfaceMaxCurvature: Double, surfaceMinCurvature: Double,
+    tolerance: Double = 1e-6,
+    surfaceOrientation: Int = 0, boundaryOrientation: Int = 0
+) -> SurfaceTransitionResult
+```
+
+- **Parameters:** Principal curvature directions and magnitudes for both the boundary and the surface at the crossing point, plus tangent and normals.
+- **Returns:** States before and after.
+- **OCCT:** `TopTrans_SurfaceTransition` (with curvature)
+- **Example:**
+  ```swift
+  let r = Shape.surfaceTransitionWithCurvature(
+      tangent: t, normal: n,
+      maxDirection: md, minDirection: nd,
+      maxCurvature: k1, minCurvature: k2,
+      surfaceNormal: sn,
+      surfaceMaxDirection: smd, surfaceMinDirection: snd,
+      surfaceMaxCurvature: sk1, surfaceMinCurvature: sk2)
+  ```
+
+---
+
+## TopTrans Curve Transition
+
+### `Shape.curveTransition(tangent:boundaryTangent:boundaryNormal:curvature:tolerance:surfaceOrientation:boundaryOrientation:)`
+
+Analyze topological state before and after a curve crosses a boundary element.
+
+```swift
+public static func curveTransition(
+    tangent: SIMD3<Double>,
+    boundaryTangent: SIMD3<Double>, boundaryNormal: SIMD3<Double>,
+    curvature: Double = 0.0, tolerance: Double = 1e-6,
+    surfaceOrientation: Int = 0, boundaryOrientation: Int = 0
+) -> SurfaceTransitionResult
+```
+
+- **Parameters:** `tangent` — curve tangent. `boundaryTangent`/`boundaryNormal` — boundary element geometry. `curvature` — boundary curvature (0 for straight boundary).
+- **Returns:** `SurfaceTransitionResult` with before/after states.
+- **OCCT:** `TopTrans_CurveTransition`
+- **Example:**
+  ```swift
+  let r = Shape.curveTransition(tangent: t, boundaryTangent: bt, boundaryNormal: bn)
+  ```
+
+---
+
+### `Shape.curveTransitionWithCurvature(tangent:curveNormal:curveCurvature:boundaryTangent:boundaryNormal:surfaceCurvature:tolerance:surfaceOrientation:boundaryOrientation:)`
+
+Curve transition analysis accounting for boundary curve curvature.
+
+```swift
+public static func curveTransitionWithCurvature(
+    tangent: SIMD3<Double>,
+    curveNormal: SIMD3<Double>, curveCurvature: Double,
+    boundaryTangent: SIMD3<Double>, boundaryNormal: SIMD3<Double>,
+    surfaceCurvature: Double, tolerance: Double = 1e-6,
+    surfaceOrientation: Int = 0, boundaryOrientation: Int = 0
+) -> SurfaceTransitionResult
+```
+
+- **Returns:** `SurfaceTransitionResult` with before/after states.
+- **OCCT:** `TopTrans_CurveTransition` (with curvature)
+- **Example:**
+  ```swift
+  let r = Shape.curveTransitionWithCurvature(
+      tangent: t, curveNormal: cn, curveCurvature: kc,
+      boundaryTangent: bt, boundaryNormal: bn, surfaceCurvature: ks)
+  ```
+
+---
+
+## GeomFill Trihedrons
+
+### `frenetTrihedron(at:)`
+
+Evaluate a Frenet trihedron on an edge at a parameter.
+
+```swift
+public func frenetTrihedron(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)?
+```
+
+- **Parameters:** `param` — curve parameter.
+- **Returns:** Tuple of tangent, normal, binormal, or `nil` if the trihedron cannot be computed (e.g. inflection point).
+- **OCCT:** `GeomFill_Frenet`
+- **Example:**
+  ```swift
+  if let f = edge.frenetTrihedron(at: 0.5) {
+      print(f.tangent, f.normal, f.binormal)
+  }
+  ```
+
+---
+
+### `constantBiNormalTrihedron(at:biNormal:)`
+
+Evaluate a constant-binormal trihedron on an edge at a parameter.
+
+```swift
+public func constantBiNormalTrihedron(at param: Double, biNormal: SIMD3<Double>) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)?
+```
+
+- **Parameters:** `param` — curve parameter. `biNormal` — fixed binormal direction.
+- **Returns:** Trihedron tuple, or `nil` on failure.
+- **OCCT:** `GeomFill_ConstantBiNormal`
+- **Example:**
+  ```swift
+  if let f = edge.constantBiNormalTrihedron(at: 0.5, biNormal: SIMD3(0, 0, 1)) { }
+  ```
+
+---
+
+### `Shape.fixedTrihedron(tangent:normal:at:)`
+
+Evaluate a fixed (constant) trihedron at any parameter.
+
+```swift
+public static func fixedTrihedron(tangent: SIMD3<Double>, normal: SIMD3<Double>, at param: Double = 0) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)
+```
+
+- **Parameters:** `tangent`/`normal` — fixed trihedron directions. `param` — parameter (unused geometrically; for API consistency).
+- **Returns:** Trihedron tuple (binormal = tangent × normal).
+- **OCCT:** `GeomFill_Fixed`
+- **Example:**
+  ```swift
+  let f = Shape.fixedTrihedron(tangent: SIMD3(1,0,0), normal: SIMD3(0,1,0))
+  ```
+
+---
+
+### `darbouxTrihedron(onFace:at:)`
+
+Evaluate a Darboux trihedron on an edge lying on a face.
+
+```swift
+public func darbouxTrihedron(onFace face: Shape, at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)?
+```
+
+- **Parameters:** `face` — the supporting face. `param` — curve parameter.
+- **Returns:** Darboux frame (tangent, surface normal, binormal), or `nil` on failure.
+- **OCCT:** `GeomFill_Darboux`
+- **Example:**
+  ```swift
+  if let f = edge.darbouxTrihedron(onFace: face, at: 0.5) { }
+  ```
+
+---
+
+## Polygon Interference
+
+### `PolygonIntersection`
+
+Result of 2D polygon interference computation.
+
+```swift
+public struct PolygonIntersection: Sendable {
+    public let points: [SIMD2<Double>]
+}
+```
+
+---
+
+### `Shape.polygonInterference(poly1:poly2:)`
+
+Compute intersection points between two 2D polylines.
+
+```swift
+public static func polygonInterference(
+    poly1: [SIMD2<Double>], poly2: [SIMD2<Double>]
+) -> PolygonIntersection
+```
+
+- **Parameters:** `poly1`/`poly2` — ordered arrays of 2D vertices defining each polyline.
+- **Returns:** `PolygonIntersection` with intersection points (may be empty).
+- **OCCT:** `Intf_InterferencePolygon2d`
+- **Example:**
+  ```swift
+  let result = Shape.polygonInterference(poly1: pts1, poly2: pts2)
+  ```
+
+---
+
+### `Shape.polygonSelfInterference(polygon:)`
+
+Compute self-intersection points of a 2D polyline.
+
+```swift
+public static func polygonSelfInterference(
+    polygon: [SIMD2<Double>]
+) -> PolygonIntersection
+```
+
+- **Parameters:** `polygon` — ordered 2D vertices.
+- **Returns:** Self-intersection points.
+- **OCCT:** `Intf_InterferencePolygon2d` (self-interference mode)
+- **Example:**
+  ```swift
+  let result = Shape.polygonSelfInterference(polygon: pts)
+  ```
+
+---
+
+## GccAna\_Circ2d3Tan
+
+### `Circle2DSolution`
+
+A circle solution from a GccAna tangency solver.
+
+```swift
+public struct Circle2DSolution: Sendable {
+    public let centerX: Double
+    public let centerY: Double
+    public let radius: Double
+}
+```
+
+---
+
+### `Shape.circleThrough3Points(p1:p2:p3:tolerance:)`
+
+Find circles through 3 points (circumscribed circle).
+
+```swift
+public static func circleThrough3Points(
+    p1: SIMD2<Double>, p2: SIMD2<Double>, p3: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Circle2DSolution]
+```
+
+- **Returns:** Array of circle solutions (typically 0 or 1).
+- **OCCT:** `GccAna_Circ2d3Tan` (3 points)
+- **Example:**
+  ```swift
+  let sols = Shape.circleThrough3Points(p1: SIMD2(0,0), p2: SIMD2(1,0), p3: SIMD2(0,1))
+  ```
+
+---
+
+### `Shape.circleTangent3Lines(l1Point:l1Dir:l2Point:l2Dir:l3Point:l3Dir:tolerance:)`
+
+Find circles tangent to 3 lines.
+
+```swift
+public static func circleTangent3Lines(
+    l1Point: SIMD2<Double>, l1Dir: SIMD2<Double>,
+    l2Point: SIMD2<Double>, l2Dir: SIMD2<Double>,
+    l3Point: SIMD2<Double>, l3Dir: SIMD2<Double>,
+    tolerance: Double = 1e-6
+) -> [Circle2DSolution]
+```
+
+- **Returns:** Array of up to 8 tangent circles.
+- **OCCT:** `GccAna_Circ2d3Tan` (3 lines)
+- **Example:**
+  ```swift
+  let sols = Shape.circleTangent3Lines(
+      l1Point: .zero, l1Dir: SIMD2(1,0),
+      l2Point: SIMD2(0,1), l2Dir: SIMD2(1,0),
+      l3Point: .zero, l3Dir: SIMD2(0,1))
+  ```
+
+---
+
+### `Shape.circleTangent3Circles(c1Center:c1Radius:c2Center:c2Radius:c3Center:c3Radius:tolerance:)`
+
+Find circles tangent to 3 circles (Apollonius problem).
+
+```swift
+public static func circleTangent3Circles(
+    c1Center: SIMD2<Double>, c1Radius: Double,
+    c2Center: SIMD2<Double>, c2Radius: Double,
+    c3Center: SIMD2<Double>, c3Radius: Double,
+    tolerance: Double = 1e-6
+) -> [Circle2DSolution]
+```
+
+- **Returns:** Array of up to 8 solution circles.
+- **OCCT:** `GccAna_Circ2d3Tan` (3 circles)
+- **Example:**
+  ```swift
+  let sols = Shape.circleTangent3Circles(
+      c1Center: SIMD2(-2,0), c1Radius: 1,
+      c2Center: SIMD2(2,0), c2Radius: 1,
+      c3Center: SIMD2(0,2), c3Radius: 1)
+  ```
+
+---
+
+### `Shape.circleTangent2CirclesPoint(c1Center:c1Radius:c2Center:c2Radius:point:tolerance:)`
+
+Find circles tangent to 2 circles and passing through 1 point.
+
+```swift
+public static func circleTangent2CirclesPoint(
+    c1Center: SIMD2<Double>, c1Radius: Double,
+    c2Center: SIMD2<Double>, c2Radius: Double,
+    point: SIMD2<Double>, tolerance: Double = 1e-6
+) -> [Circle2DSolution]
+```
+
+- **OCCT:** `GccAna_Circ2d3Tan` (2 circles + point)
+- **Example:**
+  ```swift
+  let sols = Shape.circleTangent2CirclesPoint(
+      c1Center: .zero, c1Radius: 1,
+      c2Center: SIMD2(3,0), c2Radius: 1,
+      point: SIMD2(1.5, 2))
+  ```
+
+---
+
+### `Shape.circleTangentCircle2Points(circleCenter:circleRadius:p1:p2:tolerance:)`
+
+Find circles tangent to 1 circle and passing through 2 points.
+
+```swift
+public static func circleTangentCircle2Points(
+    circleCenter: SIMD2<Double>, circleRadius: Double,
+    p1: SIMD2<Double>, p2: SIMD2<Double>, tolerance: Double = 1e-6
+) -> [Circle2DSolution]
+```
+
+- **OCCT:** `GccAna_Circ2d3Tan` (circle + 2 points)
+- **Example:**
+  ```swift
+  let sols = Shape.circleTangentCircle2Points(
+      circleCenter: .zero, circleRadius: 1,
+      p1: SIMD2(3,0), p2: SIMD2(0,3))
+  ```
+
+---
+
+### `Shape.circleTangent2LinesPoint(l1Point:l1Dir:l2Point:l2Dir:point:tolerance:)`
+
+Find circles tangent to 2 lines and passing through 1 point.
+
+```swift
+public static func circleTangent2LinesPoint(
+    l1Point: SIMD2<Double>, l1Dir: SIMD2<Double>,
+    l2Point: SIMD2<Double>, l2Dir: SIMD2<Double>,
+    point: SIMD2<Double>, tolerance: Double = 1e-6
+) -> [Circle2DSolution]
+```
+
+- **OCCT:** `GccAna_Circ2d3Tan` (2 lines + point)
+- **Example:**
+  ```swift
+  let sols = Shape.circleTangent2LinesPoint(
+      l1Point: .zero, l1Dir: SIMD2(1,0),
+      l2Point: .zero, l2Dir: SIMD2(0,1),
+      point: SIMD2(2,2))
+  ```
+
+---
+
+## IntTools
+
+### `CommonPartType`
+
+Type of an edge-edge or edge-face intersection common part.
+
+```swift
+public enum CommonPartType: Int32, Sendable {
+    case vertex = 0
+    case edge = 1
+}
+```
+
+---
+
+### `CommonPart`
+
+A single intersection common part from IntTools.
+
+```swift
+public struct CommonPart: Sendable {
+    public let type: CommonPartType
+    public let param1Range: (first: Double, last: Double)
+    public let param2Range: (first: Double, last: Double)
+    public let point: SIMD3<Double>
+}
+```
+
+---
+
+### `edgeEdgeIntersection(with:)`
+
+Intersect two edges to find common vertices and edge overlaps.
+
+```swift
+public func edgeEdgeIntersection(with other: Shape) -> [CommonPart]?
+```
+
+- **Parameters:** `other` — second edge.
+- **Returns:** Array of common parts, or `nil` if intersection failed.
+- **OCCT:** `IntTools_EdgeEdge`
+- **Example:**
+  ```swift
+  if let parts = e1.edgeEdgeIntersection(with: e2) {
+      for p in parts { print(p.type, p.point) }
+  }
+  ```
+
+---
+
+### `edgeFaceIntersection(with:)`
+
+Intersect an edge with a face to find common vertices and edge overlaps.
+
+```swift
+public func edgeFaceIntersection(with face: Shape) -> [CommonPart]?
+```
+
+- **Parameters:** `face` — face to intersect with.
+- **Returns:** Array of common parts, or `nil` on failure.
+- **OCCT:** `IntTools_EdgeFace`
+- **Example:**
+  ```swift
+  if let parts = edge.edgeFaceIntersection(with: face) { }
+  ```
+
+---
+
+### `FaceFaceCurve`
+
+An intersection curve from a face-face intersection.
+
+```swift
+public struct FaceFaceCurve: Sendable {
+    public let start: SIMD3<Double>?
+    public let end: SIMD3<Double>?
+}
+```
+
+---
+
+### `FaceFacePoint`
+
+An intersection point from a face-face intersection.
+
+```swift
+public struct FaceFacePoint: Sendable {
+    public let pointOnFace1: SIMD3<Double>
+    public let pointOnFace2: SIMD3<Double>
+}
+```
+
+---
+
+### `FaceFaceResult`
+
+Result of a face-face intersection.
+
+```swift
+public struct FaceFaceResult: Sendable {
+    public let curves: [FaceFaceCurve]
+    public let points: [FaceFacePoint]
+    public let isTangent: Bool
+}
+```
+
+---
+
+### `faceFaceIntersection(with:tolerance:)`
+
+Intersect two faces to find intersection curves and points.
+
+```swift
+public func faceFaceIntersection(with other: Shape, tolerance: Double = 1e-7) -> FaceFaceResult?
+```
+
+- **Parameters:** `other` — second face. `tolerance` — approximation tolerance.
+- **Returns:** `FaceFaceResult`, or `nil` on failure.
+- **OCCT:** `IntTools_FaceFace`
+- **Example:**
+  ```swift
+  if let r = f1.faceFaceIntersection(with: f2) {
+      print(r.curves.count, r.isTangent)
+  }
+  ```
+
+---
+
+### `classifyPoint2d(u:v:tolerance:)`
+
+Classify a UV point relative to a face boundary in parameter space.
+
+```swift
+public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-7) -> OCCTSwift.PointClassification
+```
+
+- **Parameters:** `u`/`v` — UV coordinates. `tolerance` — classification tolerance.
+- **Returns:** `.inside`, `.onBoundary`, `.outside`, or `.unknown`.
+- **OCCT:** `IntTools_FClass2d::Perform`
+- **Example:**
+  ```swift
+  let c = face.classifyPoint2d(u: 0.5, v: 0.5)
+  ```
+
+---
+
+### `isHole(tolerance:)`
+
+Check if a face represents a hole (inner-wire orientation).
+
+```swift
+public func isHole(tolerance: Double = 1e-7) -> Bool
+```
+
+- **Returns:** `true` if the face is classified as a hole.
+- **OCCT:** `IntTools_FClass2d` (IsHole query)
+- **Example:**
+  ```swift
+  if face.isHole() { }
+  ```
+
+---
+
+## BOPAlgo Builder
+
+### `buildFaces(from:)`
+
+Build faces from edges that lie on this face's surface.
+
+```swift
+public func buildFaces(from edges: [Shape]) -> [Shape]?
+```
+
+- **Parameters:** `edges` — edge shapes on this face's surface.
+- **Returns:** Array of result face shapes, or `nil` on failure.
+- **OCCT:** `BOPAlgo_BuilderFace`
+- **Example:**
+  ```swift
+  if let faces = face.buildFaces(from: edges) { }
+  ```
+
+---
+
+### `Shape.buildSolids(from:)`
+
+Build solids from a closed set of faces.
+
+```swift
+public static func buildSolids(from faces: [Shape]) -> [Shape]?
+```
+
+- **Parameters:** `faces` — face shapes forming closed volumes.
+- **Returns:** Array of result solid shapes, or `nil` on failure.
+- **OCCT:** `BOPAlgo_BuilderSolid`
+- **Example:**
+  ```swift
+  if let solids = Shape.buildSolids(from: faces) { }
+  ```
+
+---
+
+### `splitShell()`
+
+Split a shell into connected components.
+
+```swift
+public func splitShell() -> [Shape]?
+```
+
+- **Returns:** Array of shell shapes (one per connected component), or `nil` on failure.
+- **OCCT:** `BOPAlgo_ShellSplitter`
+- **Example:**
+  ```swift
+  if let shells = shell.splitShell() { }
+  ```
+
+---
+
+### `edgesToWires(tolerance:)`
+
+Connect a compound of edges into wires.
+
+```swift
+public func edgesToWires(tolerance: Double = 1e-7) -> Shape?
+```
+
+- **Parameters:** `tolerance` — edge connection tolerance.
+- **Returns:** Compound of wires, or `nil` on failure.
+- **OCCT:** `BOPAlgo_Tools::EdgesToWires`
+- **Example:**
+  ```swift
+  if let wires = edgeCompound.edgesToWires() { }
+  ```
+
+---
+
+### `wiresToFaces(tolerance:)`
+
+Build planar faces from a compound of wires.
+
+```swift
+public func wiresToFaces(tolerance: Double = 1e-7) -> Shape?
+```
+
+- **Parameters:** `tolerance` — face building tolerance.
+- **Returns:** Compound of faces, or `nil` on failure.
+- **OCCT:** `BOPAlgo_Tools::WiresToFaces`
+- **Example:**
+  ```swift
+  if let faces = wireCompound.wiresToFaces() { }
+  ```
+
+---
+
+## BOPTools
+
+### `Shape.normalOnEdge(edge:face:)`
+
+Get the normal to a face at an edge location.
+
+```swift
+public static func normalOnEdge(edge: Shape, face: Shape) -> SIMD3<Double>?
+```
+
+- **Parameters:** `edge` — edge on the face. `face` — containing face.
+- **Returns:** Unit normal direction, or `nil` on failure.
+- **OCCT:** `BOPTools_AlgoTools3D::GetNormalToFaceOnEdge`
+- **Example:**
+  ```swift
+  if let n = Shape.normalOnEdge(edge: e, face: f) { }
+  ```
+
+---
+
+### `pointInFace()`
+
+Find a point strictly inside this face.
+
+```swift
+public func pointInFace() -> SIMD3<Double>?
+```
+
+- **Returns:** A 3D point in the interior of this face, or `nil` on failure.
+- **OCCT:** `BOPTools_AlgoTools3D::PointInFace`
+- **Example:**
+  ```swift
+  if let pt = face.pointInFace() { }
+  ```
+
+---
+
+### `isEmpty`
+
+Check if this shape has no sub-shapes.
+
+```swift
+public var isEmpty: Bool { get }
+```
+
+- **OCCT:** `BOPTools_AlgoTools3D::IsEmptyShape`
+- **Example:**
+  ```swift
+  if shape.isEmpty { }
+  ```
+
+---
+
+### `isOpenShell`
+
+Check if this shell is open (not all edges shared by two faces).
+
+```swift
+public var isOpenShell: Bool { get }
+```
+
+- **OCCT:** `BOPTools_AlgoTools::IsOpenShell`
+- **Example:**
+  ```swift
+  if shell.isOpenShell { }
+  ```
+
+---
+
+## IntTools\_BeanFaceIntersector
+
+### `BeanFaceIntersection`
+
+Result of an edge-face coincidence check.
+
+```swift
+public struct BeanFaceIntersection: Sendable {
+    public let ranges: [(first: Double, last: Double)]
+    public let minSquareDistance: Double
+}
+```
+
+---
+
+### `Shape.beanFaceIntersect(edge:face:)`
+
+Find coincident parameter ranges where an edge lies on a face surface.
+
+```swift
+public static func beanFaceIntersect(edge: Shape, face: Shape) -> BeanFaceIntersection?
+```
+
+- **Parameters:** `edge` — edge curve to test. `face` — face surface to test against.
+- **Returns:** Ranges of coincidence and minimum squared distance, or `nil` on failure.
+- **OCCT:** `IntTools_BeanFaceIntersector`
+- **Example:**
+  ```swift
+  if let r = Shape.beanFaceIntersect(edge: e, face: f) {
+      print(r.ranges.count, r.minSquareDistance)
+  }
+  ```
+
+---
+
+## BOPAlgo\_WireSplitter
+
+### `Shape.makeWire(from:)`
+
+Assemble edges into a connected wire using BOPAlgo_WireSplitter.
+
+```swift
+public static func makeWire(from edges: [Shape]) -> Shape?
+```
+
+- **Parameters:** `edges` — array of edge shapes to connect.
+- **Returns:** Result wire as shape, or `nil` on failure.
+- **OCCT:** `BOPAlgo_WireSplitter::MakeWire`
+- **Example:**
+  ```swift
+  if let wire = Shape.makeWire(from: [e1, e2, e3]) { }
+  ```
+
+---
+
+## BRepFeat\_SplitShape
+
+### `splitByEdge(_:onFace:)`
+
+Split this shape by adding an edge to a face.
+
+```swift
+public func splitByEdge(_ edge: Shape, onFace face: Shape) -> Shape?
+```
+
+- **Parameters:** `edge` — edge to add as a split line. `face` — face the edge lies on.
+- **Returns:** Result shape with the split face, or `nil` on failure.
+- **OCCT:** `BRepFeat_SplitShape`
+- **Example:**
+  ```swift
+  if let split = solid.splitByEdge(e, onFace: face) { }
+  ```
+
+---
+
+### `splitByWire(_:onFace:)`
+
+Split this shape by adding a wire to a face.
+
+```swift
+public func splitByWire(_ wire: Shape, onFace face: Shape) -> Shape?
+```
+
+- **Parameters:** `wire` — wire to split along. `face` — face the wire lies on.
+- **Returns:** Result shape with split face, or `nil` on failure.
+- **OCCT:** `BRepFeat_SplitShape`
+- **Example:**
+  ```swift
+  if let split = solid.splitByWire(w, onFace: face) { }
+  ```
+
+---
+
+### `SplitShapeResult`
+
+Result of a multi-pair split-shape operation.
+
+```swift
+public struct SplitShapeResult: Sendable {
+    public let shape: Shape
+    public let leftFaces: [Shape]
+    public let rightFaces: [Shape]
+}
+```
+
+---
+
+### `splitWithSides(edgesOnFaces:)`
+
+Split this shape with multiple edge-on-face pairs, returning left/right face classifications.
+
+```swift
+public func splitWithSides(edgesOnFaces: [(edge: Shape, face: Shape)]) -> SplitShapeResult?
+```
+
+- **Parameters:** `edgesOnFaces` — array of `(edge, face)` pairs; each edge is added to the corresponding face.
+- **Returns:** Split result with the resulting shape and left/right face arrays, or `nil` on failure.
+- **OCCT:** `BRepFeat_SplitShape` with `Left()`/`Right()` queries
+- **Example:**
+  ```swift
+  if let r = solid.splitWithSides(edgesOnFaces: [(edge: e, face: f)]) {
+      print(r.leftFaces.count, r.rightFaces.count)
+  }
+  ```
+
+---
+
+## BRepFeat\_MakeCylindricalHole
+
+### `cylindricalHole(axisOrigin:axisDirection:radius:)`
+
+Drill a through cylindrical hole in this shape.
+
+```swift
+public func cylindricalHole(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double) -> Shape?
+```
+
+- **Parameters:** `axisOrigin` — hole axis origin. `axisDirection` — hole axis direction. `radius` — hole radius.
+- **Returns:** Shape with hole, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakeCylindricalHole::Perform`
+- **Example:**
+  ```swift
+  if let holed = solid.cylindricalHole(axisOrigin: .zero, axisDirection: SIMD3(0,0,1), radius: 5) { }
+  ```
+
+---
+
+### `cylindricalHoleBlind(axisOrigin:axisDirection:radius:depth:)`
+
+Drill a blind cylindrical hole to a specified depth.
+
+```swift
+public func cylindricalHoleBlind(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double, depth: Double) -> Shape?
+```
+
+- **Parameters:** `depth` — hole depth from entry face.
+- **Returns:** Shape with blind hole, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakeCylindricalHole::PerformBlind`
+- **Example:**
+  ```swift
+  if let holed = solid.cylindricalHoleBlind(axisOrigin: .zero, axisDirection: SIMD3(0,0,1), radius: 5, depth: 10) { }
+  ```
+
+---
+
+### `cylindricalHoleThruNext(axisOrigin:axisDirection:radius:)`
+
+Drill a cylindrical hole through to the next face encountered.
+
+```swift
+public func cylindricalHoleThruNext(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double) -> Shape?
+```
+
+- **Returns:** Shape with hole stopping at the first inner face, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakeCylindricalHole::PerformThruNext`
+- **Example:**
+  ```swift
+  if let holed = solid.cylindricalHoleThruNext(axisOrigin: .zero, axisDirection: SIMD3(0,1,0), radius: 3) { }
+  ```
+
+---
+
+### `CylindricalHoleStatus`
+
+Status result for a cylindrical hole operation.
+
+```swift
+public enum CylindricalHoleStatus: Int32, Sendable {
+    case noError = 0
+    case invalidPlacement = 1
+    case holeTooLong = 2
+    case unknown = 3
+}
+```
+
+---
+
+### `cylindricalHoleStatus(axisOrigin:axisDirection:radius:)`
+
+Check whether a cylindrical hole can be drilled without modifying the shape.
+
+```swift
+public func cylindricalHoleStatus(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double) -> CylindricalHoleStatus
+```
+
+- **Returns:** A `CylindricalHoleStatus` indicating feasibility.
+- **OCCT:** `BRepFeat_MakeCylindricalHole` (status query)
+- **Example:**
+  ```swift
+  let s = solid.cylindricalHoleStatus(axisOrigin: .zero, axisDirection: SIMD3(0,0,1), radius: 5)
+  if s == .noError { }
+  ```
+
+---
+
+## BRepFeat\_Gluer
+
+### `glue(_:facePairs:)`
+
+Glue another shape onto this shape by binding matching face pairs.
+
+```swift
+public func glue(_ gluedShape: Shape, facePairs: [(base: Shape, glued: Shape)]) -> Shape?
+```
+
+- **Parameters:** `gluedShape` — shape to merge onto this one. `facePairs` — matching face pairs: `base` from this shape, `glued` from `gluedShape`.
+- **Returns:** Glued result shape, or `nil` on failure.
+- **OCCT:** `BRepFeat_Gluer`
+- **Example:**
+  ```swift
+  if let r = base.glue(toAttach, facePairs: [(base: bf, glued: gf)]) { }
+  ```
+
+---
+
+## LocOpe\_WiresOnShape + LocOpe\_Spliter
+
+### `LocOpeSplitResult`
+
+Result of a `LocOpe_Spliter` operation.
+
+```swift
+public struct LocOpeSplitResult: Sendable {
+    public let shape: Shape
+    public let directLeftFaces: [Shape]
+}
+```
+
+---
+
+### `locOpeSplit(wiresOnFaces:)`
+
+Split this shape by projecting wires onto specific faces using `LocOpe_Spliter`.
+
+```swift
+public func locOpeSplit(wiresOnFaces: [(wire: Shape, face: Shape)]) -> LocOpeSplitResult?
+```
+
+- **Parameters:** `wiresOnFaces` — pairs binding each wire to the face it lies on.
+- **Returns:** Split result with direct-left faces, or `nil` on failure.
+- **OCCT:** `LocOpe_WiresOnShape` + `LocOpe_Spliter`
+- **Example:**
+  ```swift
+  if let r = solid.locOpeSplit(wiresOnFaces: [(wire: w, face: f)]) {
+      print(r.directLeftFaces.count)
+  }
+  ```
+
+---
+
+### `locOpeSplitAuto(wires:)`
+
+Split this shape by automatically projecting wires onto faces.
+
+```swift
+public func locOpeSplitAuto(wires: [Shape]) -> Shape?
+```
+
+- **Parameters:** `wires` — wires to project and split by; faces are determined automatically.
+- **Returns:** Result shape, or `nil` on failure.
+- **OCCT:** `LocOpe_WiresOnShape::BindAll` + `LocOpe_Spliter`
+- **Example:**
+  ```swift
+  if let r = solid.locOpeSplitAuto(wires: [w]) { }
+  ```
+
+---
+
+## LocOpe\_Gluer
+
+### `locOpeGlue(_:facePairs:edgePairs:)`
+
+Glue another shape onto this shape using `LocOpe_Gluer` with optional edge binding.
+
+```swift
+public func locOpeGlue(_ gluedShape: Shape,
+                       facePairs: [(base: Shape, glued: Shape)],
+                       edgePairs: [(base: Shape, glued: Shape)] = []) -> Shape?
+```
+
+- **Parameters:** `gluedShape` — shape to glue. `facePairs` — at least one required matching face pair. `edgePairs` — optional edge pairs for precise alignment.
+- **Returns:** Result shape, or `nil` on failure (including empty `facePairs`).
+- **OCCT:** `LocOpe_Gluer`
+- **Example:**
+  ```swift
+  if let r = base.locOpeGlue(toGlue, facePairs: [(base: bf, glued: gf)]) { }
+  ```
+
+---
+
+## ChFi2d\_Builder
+
+All `ChFi2d_Builder` methods operate exclusively on **planar faces**, not solids. Extract the target face first if working from a solid.
+
+### `addFillet2d(vertexIndex:radius:)`
+
+Add a 2D fillet at a vertex on a planar face.
+
+```swift
+public func addFillet2d(vertexIndex: Int, radius: Double) -> Shape?
+```
+
+- **Parameters:** `vertexIndex` — 0-based vertex index. `radius` — fillet radius.
+- **Returns:** Result face with fillet, or `nil` if the shape is not a planar face.
+- **OCCT:** `ChFi2d_Builder::AddFillet`
+- **Example:**
+  ```swift
+  let face = solid.subShapes(ofType: .face)[0]
+  if let filleted = face.addFillet2d(vertexIndex: 0, radius: 1.0) { }
+  ```
+
+---
+
+### `addChamfer2d(edge1Index:edge2Index:d1:d2:)`
+
+Add a 2D chamfer between two edges on a planar face.
+
+```swift
+public func addChamfer2d(edge1Index: Int, edge2Index: Int, d1: Double, d2: Double) -> Shape?
+```
+
+- **Parameters:** `edge1Index`/`edge2Index` — 0-based edge indices. `d1`/`d2` — chamfer distances on each edge.
+- **Returns:** Result face with chamfer, or `nil` on failure.
+- **OCCT:** `ChFi2d_Builder::AddChamfer`
+- **Example:**
+  ```swift
+  if let ch = face.addChamfer2d(edge1Index: 0, edge2Index: 1, d1: 1.0, d2: 1.0) { }
+  ```
+
+---
+
+### `addChamfer2dAngle(edgeIndex:vertexIndex:distance:angle:)`
+
+Add a 2D chamfer defined by distance and angle on a planar face.
+
+```swift
+public func addChamfer2dAngle(edgeIndex: Int, vertexIndex: Int, distance: Double, angle: Double) -> Shape?
+```
+
+- **Parameters:** `edgeIndex` — reference edge. `vertexIndex` — vertex to chamfer. `distance` — distance on the edge. `angle` — chamfer angle in radians.
+- **Returns:** Result face with chamfer, or `nil` on failure.
+- **OCCT:** `ChFi2d_Builder::AddChamfer` (distance + angle)
+- **Example:**
+  ```swift
+  if let ch = face.addChamfer2dAngle(edgeIndex: 0, vertexIndex: 1, distance: 1.0, angle: .pi/4) { }
+  ```
+
+---
+
+### `modifyFillet2d(originalFace:filletEdgeIndex:newRadius:)`
+
+Modify an existing fillet radius on a face.
+
+```swift
+public func modifyFillet2d(originalFace: Shape, filletEdgeIndex: Int, newRadius: Double) -> Shape?
+```
+
+- **Parameters:** `originalFace` — face before the fillet was added. `filletEdgeIndex` — 0-based index of the fillet edge in `self`. `newRadius` — new fillet radius.
+- **Returns:** Result face with modified fillet, or `nil` on failure.
+- **OCCT:** `ChFi2d_Builder::ModifyFillet`
+- **Example:**
+  ```swift
+  if let modified = filletedFace.modifyFillet2d(originalFace: original, filletEdgeIndex: 0, newRadius: 2.0) { }
+  ```
+
+---
+
+### `removeFillet2d(originalFace:filletEdgeIndex:)`
+
+Remove a fillet from a face, restoring the original corner.
+
+```swift
+public func removeFillet2d(originalFace: Shape, filletEdgeIndex: Int) -> Shape?
+```
+
+- **Parameters:** `originalFace` — face before the fillet. `filletEdgeIndex` — 0-based fillet edge index in `self`.
+- **Returns:** Face with fillet removed, or `nil` on failure.
+- **OCCT:** `ChFi2d_Builder::RemoveFillet`
+- **Example:**
+  ```swift
+  if let r = filletedFace.removeFillet2d(originalFace: original, filletEdgeIndex: 0) { }
+  ```
+
+---
+
+### `removeChamfer2d(originalFace:chamferEdgeIndex:)`
+
+Remove a chamfer from a face.
+
+```swift
+public func removeChamfer2d(originalFace: Shape, chamferEdgeIndex: Int) -> Shape?
+```
+
+- **Parameters:** `originalFace` — face before the chamfer. `chamferEdgeIndex` — 0-based chamfer edge index in `self`.
+- **Returns:** Face with chamfer removed, or `nil` on failure.
+- **OCCT:** `ChFi2d_Builder::RemoveChamfer`
+- **Example:**
+  ```swift
+  if let r = chamferedFace.removeChamfer2d(originalFace: original, chamferEdgeIndex: 0) { }
+  ```
+
+---
+
+## ChFi2d\_ChamferAPI
+
+### `Chamfer2DEdgeResult`
+
+Result of a standalone 2D chamfer between two edges.
+
+```swift
+public struct Chamfer2DEdgeResult: Sendable {
+    public let chamferEdge: Shape
+    public let modifiedEdge1: Shape
+    public let modifiedEdge2: Shape
+}
+```
+
+---
+
+### `Shape.chamfer2dEdges(edge1:edge2:d1:d2:)`
+
+Create a chamfer between two linear edges using `ChFi2d_ChamferAPI`.
+
+```swift
+public static func chamfer2dEdges(edge1: Shape, edge2: Shape, d1: Double, d2: Double) -> Chamfer2DEdgeResult?
+```
+
+- **Parameters:** `edge1`/`edge2` — linear edges sharing a vertex. `d1`/`d2` — chamfer distances on each edge.
+- **Returns:** `Chamfer2DEdgeResult` with chamfer edge and trimmed originals, or `nil` on failure.
+- **OCCT:** `ChFi2d_ChamferAPI`
+- **Example:**
+  ```swift
+  if let r = Shape.chamfer2dEdges(edge1: e1, edge2: e2, d1: 1.0, d2: 1.0) {
+      let chamfer = r.chamferEdge
+  }
+  ```
+
+---
+
+## ChFi2d\_FilletAPI
+
+### `Fillet2DEdgeResult`
+
+Result of a standalone 2D fillet between two edges.
+
+```swift
+public struct Fillet2DEdgeResult: Sendable {
+    public let filletEdge: Shape
+    public let modifiedEdge1: Shape
+    public let modifiedEdge2: Shape
+    public let solutionCount: Int
+}
+```
+
+---
+
+### `Shape.fillet2dEdges(edge1:edge2:planeNormal:radius:nearPoint:)`
+
+Create a fillet between two edges in a plane using `ChFi2d_FilletAPI`.
+
+```swift
+public static func fillet2dEdges(edge1: Shape, edge2: Shape,
+                                 planeNormal: SIMD3<Double>,
+                                 radius: Double,
+                                 nearPoint: SIMD3<Double>) -> Fillet2DEdgeResult?
+```
+
+- **Parameters:** `edge1`/`edge2` — edges to fillet. `planeNormal` — normal of the plane containing the edges. `radius` — fillet radius. `nearPoint` — point near the desired fillet location, used to select among multiple solutions.
+- **Returns:** `Fillet2DEdgeResult` with the fillet arc, trimmed edges, and solution count, or `nil` on failure.
+- **OCCT:** `ChFi2d_FilletAPI` (selects analytical or iterative algorithm automatically)
+- **Example:**
+  ```swift
+  if let r = Shape.fillet2dEdges(
+      edge1: e1, edge2: e2,
+      planeNormal: SIMD3(0, 0, 1),
+      radius: 2.0,
+      nearPoint: SIMD3(1, 1, 0)) {
+      print(r.solutionCount)
+  }
+  ```
+
+---
+
+## FilletSurf\_Builder
+
+### `FilletSurfaceInfo`
+
+Geometry information for one computed fillet surface.
+
+```swift
+public struct FilletSurfaceInfo: Sendable {
+    public let surface: Surface
+    public let supportFace1: Shape
+    public let supportFace2: Shape
+    public let tolerance: Double
+    public let firstParameter: Double
+    public let lastParameter: Double
+    public let startStatus: Int
+    public let endStatus: Int
+}
+```
+
+---
+
+### `FilletSurfaceResult`
+
+Result of `FilletSurf_Builder` computation.
+
+```swift
+public struct FilletSurfaceResult: Sendable {
+    public let surfaces: [FilletSurfaceInfo]
+    public let status: Int  // 0=ok, 1=notOk, 2=partial
+}
+```
+
+---
+
+### `filletSurfaces(edges:radius:)`
+
+Compute fillet surface geometry on this shape without modifying its topology.
+
+```swift
+public func filletSurfaces(edges: [Shape], radius: Double) -> FilletSurfaceResult?
+```
+
+- **Parameters:** `edges` — edges to fillet. `radius` — fillet radius.
+- **Returns:** `FilletSurfaceResult` with NURBS fillet surfaces and support faces, or `nil` on total failure. `status == 1` with an empty `surfaces` array also maps to `nil`.
+- **OCCT:** `FilletSurf_Builder`
+- **Note:** Returns raw surface geometry only — does not produce a new solid. Use `Shape.fillet(edges:radius:)` to produce a filleted solid.
+- **Example:**
+  ```swift
+  if let r = solid.filletSurfaces(edges: [e1, e2], radius: 1.0) {
+      for info in r.surfaces {
+          print(info.surface, info.tolerance)
+      }
+  }
+  ```

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1,0 +1,1869 @@
+---
+title: Shape — Advanced Sweeps & API Completions
+parent: API Reference
+---
+
+# Shape — Advanced Sweeps & API Completions
+
+This page documents the advanced sweep, fill, proximity, and B-Rep query members of `Shape`
+from the v0.79.0–v0.128.0 range. For the primary `Shape` type overview, constructors, and
+boolean/transform/topology operations see the main **Shape** page (forthcoming as `Shape.md`).
+
+## Topics
+
+- [CoherentTriangulation](#coherenttriangulation) · [BRepFill_Evolved](#brepfill_evolved) · [BRepFill_OffsetAncestors](#brepfill_offsetancestors) · [BRepExtrema_DistanceSS](#brepextrema_distancess) · [BRepGProp_VinertGK](#brepgprop_vinertgk) · [GeomFill_Profiler](#geomfill_profiler) · [GeomFill_Stretch](#geomfill_stretch) · [GeomFill_LocationDraft](#geomfill_locationdraft) · [GeomFill_GuideTrihedronAC](#geomfill_guidetrihedronac) · [GeomFill_GuideTrihedronPlan](#geomfill_guidetrihedronplan) · [GeomFill_SectionPlacement](#geomfill_sectionplacement) · [BRepFill_NSections](#brepfill_nsections) · [GeomFill_AppSurf](#geomfill_appsurf) · [ShapeFix_ComposeShell](#shapefix_composeshell) · [Transform, Boolean & Shape Query expansions (v0.115.0)](#transform-boolean--shape-query-expansions-v01150) · [ThruSections builder](#thrusections-builder-v01150) · [ShapeFixer builder](#shapefixer-builder-v01150) · [BRep_Tool completions v0.126.0](#brep_tool-completions-v01260) · [Section with plane/surface & polygon queries v0.127.0](#section-with-planesurface--brep_tool-polygon-queries-v01270) · [BRep_Tool completions v0.128.0](#brep_tool-completions-v01280)
+
+---
+
+## CoherentTriangulation
+
+Mutable coherent triangulation for mesh editing operations, wrapping `Poly_CoherentTriangulation`.
+
+### `CoherentTriangulation.create()`
+
+Creates an empty coherent triangulation.
+
+```swift
+public static func create() -> CoherentTriangulation
+```
+
+- **Returns:** A new empty `CoherentTriangulation`.
+- **OCCT:** `Poly_CoherentTriangulation` (default constructor).
+- **Example:**
+  ```swift
+  let ct = CoherentTriangulation.create()
+  ```
+
+---
+
+### `CoherentTriangulation.createFromMesh(_:deflection:)`
+
+Creates a coherent triangulation from the triangulation of the first face of a meshed shape.
+
+```swift
+public static func createFromMesh(_ shape: Shape, deflection: Double = 0.1) -> CoherentTriangulation?
+```
+
+- **Parameters:** `shape` — a `Shape` that has already been meshed. `deflection` — linear deflection used for auto-triangulation if the shape is not yet meshed; default `0.1`.
+- **Returns:** A `CoherentTriangulation` populated from the face's triangulation, or `nil` if the shape has no triangulation.
+- **OCCT:** `Poly_CoherentTriangulation`, `BRep_Tool::Triangulation`.
+- **Example:**
+  ```swift
+  let box = Shape.box(dx: 10, dy: 10, dz: 10)!
+  if let ct = CoherentTriangulation.createFromMesh(box) {
+      print(ct.triangleCount)
+  }
+  ```
+
+---
+
+### `setNode(x:y:z:)`
+
+Adds a node at the given coordinates.
+
+```swift
+public func setNode(x: Double, y: Double, z: Double) -> Int
+```
+
+- **Returns:** The 0-based index of the newly created node.
+- **OCCT:** `Poly_CoherentTriangulation::SetNode`.
+- **Example:**
+  ```swift
+  let ct = CoherentTriangulation.create()
+  let i0 = ct.setNode(x: 0, y: 0, z: 0)
+  ```
+
+---
+
+### `addTriangle(_:_:_:)`
+
+Adds a triangle from three 0-based node indices.
+
+```swift
+@discardableResult
+public func addTriangle(_ n0: Int, _ n1: Int, _ n2: Int) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `Poly_CoherentTriangulation::AddTriangle`.
+- **Example:**
+  ```swift
+  let ok = ct.addTriangle(0, 1, 2)
+  ```
+
+---
+
+### `removeTriangle(at:)`
+
+Removes a triangle by its 0-based index.
+
+```swift
+@discardableResult
+public func removeTriangle(at index: Int) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `Poly_CoherentTriangulation::RemoveTriangle`.
+
+---
+
+### `triangleCount`
+
+Number of triangles in the coherent triangulation.
+
+```swift
+public var triangleCount: Int { get }
+```
+
+- **OCCT:** `Poly_CoherentTriangulation::NTriangles`.
+
+---
+
+### `computeLinks()`
+
+Computes edge links between adjacent triangles.
+
+```swift
+public func computeLinks() -> Int
+```
+
+- **Returns:** The number of links computed.
+- **OCCT:** `Poly_CoherentTriangulation::ComputeLinks`.
+
+---
+
+### `linkCount`
+
+Number of edge links. Call `computeLinks()` first.
+
+```swift
+public var linkCount: Int { get }
+```
+
+- **OCCT:** `Poly_CoherentTriangulation::NLinks`.
+
+---
+
+### `setDeflection(_:)`
+
+Sets the deflection value on the triangulation.
+
+```swift
+public func setDeflection(_ value: Double)
+```
+
+- **OCCT:** `Poly_CoherentTriangulation::SetDeflection`.
+
+---
+
+### `deflection`
+
+The current deflection value of the triangulation.
+
+```swift
+public var deflection: Double { get }
+```
+
+- **OCCT:** `Poly_CoherentTriangulation::Deflection`.
+
+---
+
+### `removeDegenerated(tolerance:)`
+
+Removes degenerated triangles whose area is below the given tolerance.
+
+```swift
+@discardableResult
+public func removeDegenerated(tolerance: Double) -> Bool
+```
+
+- **Returns:** `true` if any degenerated triangles were removed.
+- **OCCT:** `Poly_CoherentTriangulation::RemoveDegenerated`.
+
+---
+
+### `getResult()`
+
+Converts the coherent triangulation back to standard node/triangle counts.
+
+```swift
+public func getResult() -> (nodeCount: Int, triangleCount: Int)?
+```
+
+- **Returns:** A tuple of `(nodeCount, triangleCount)`, or `nil` on failure.
+- **OCCT:** `Poly_CoherentTriangulation`.
+
+---
+
+### `nodeCoords(at:)`
+
+Gets the coordinates of a node by its 1-based index (after calling `getResult()`).
+
+```swift
+public func nodeCoords(at index: Int) -> (x: Double, y: Double, z: Double)?
+```
+
+- **Returns:** The `(x, y, z)` coordinates of the node, or `nil` if the index is out of range.
+- **OCCT:** `Poly_CoherentTriangulation`.
+
+---
+
+## BRepFill_Evolved
+
+### `Shape.evolved(spineFace:profileWire:axisOrigin:axisNormal:axisXDir:joinType:makeSolid:)`
+
+Creates an evolved shape by sweeping a 2D wire profile along the boundary of a planar face.
+
+```swift
+public static func evolved(spineFace: Shape, profileWire: Shape,
+                            axisOrigin: SIMD3<Double> = SIMD3(0, 0, 0),
+                            axisNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+                            axisXDir: SIMD3<Double> = SIMD3(1, 0, 0),
+                            joinType: Int = 0, makeSolid: Bool = false) -> Shape?
+```
+
+- **Parameters:**
+  - `spineFace` — planar face whose boundary edges define the sweep path.
+  - `profileWire` — 2D wire cross-section to sweep.
+  - `axisOrigin`, `axisNormal`, `axisXDir` — coordinate system of the profile plane; defaults to the XY plane at the origin.
+  - `joinType` — join strategy between adjacent sweep segments: `0`=Arc (round), `1`=Tangent, `2`=Intersection.
+  - `makeSolid` — `true` to cap the result into a solid.
+- **Returns:** The evolved `Shape`, or `nil` if the operation fails.
+- **OCCT:** `BRepFill_Evolved`.
+- **Example:**
+  ```swift
+  let face = Shape.box(dx: 20, dy: 10, dz: 1)!
+  let profile = Wire.rectangle(width: 2, height: 2)!.asShape
+  if let evo = Shape.evolved(spineFace: face, profileWire: profile) {
+      print(evo.isValid)
+  }
+  ```
+
+---
+
+## BRepFill_OffsetAncestors
+
+Traces the ancestry of edges in an offset wire back to the original face edges. Wraps `BRepFill_OffsetAncestors`.
+
+### `OffsetAncestors.create(face:offset:joinType:)`
+
+Creates an offset-ancestors tracker for a face offset by the given distance.
+
+```swift
+public static func create(face: Shape, offset: Double, joinType: Int = 0) -> OffsetAncestors?
+```
+
+- **Parameters:**
+  - `face` — the source face.
+  - `offset` — signed offset distance.
+  - `joinType` — `0`=Arc, `1`=Tangent, `2`=Intersection.
+- **Returns:** An `OffsetAncestors` instance, or `nil` if the operation fails.
+- **OCCT:** `BRepFill_OffsetAncestors`.
+
+---
+
+### `isDone`
+
+Whether the offset and ancestry computation succeeded.
+
+```swift
+public var isDone: Bool { get }
+```
+
+- **OCCT:** `BRepFill_OffsetAncestors::IsDone`.
+
+---
+
+### `hasAncestor(_:)`
+
+Checks if an offset edge has a recorded ancestor.
+
+```swift
+public func hasAncestor(_ edge: Shape) -> Bool
+```
+
+- **OCCT:** `BRepFill_OffsetAncestors::HasAncestor`.
+
+---
+
+### `ancestor(of:)`
+
+Returns the original edge that gave rise to the given offset edge.
+
+```swift
+public func ancestor(of edge: Shape) -> Shape?
+```
+
+- **Returns:** The ancestor `Shape`, or `nil` if the edge has no recorded ancestor.
+- **OCCT:** `BRepFill_OffsetAncestors::Ancestor`.
+- **Example:**
+  ```swift
+  if let oa = OffsetAncestors.create(face: myFace, offset: 2.0), oa.isDone {
+      for edge in offsetWireEdges {
+          if let orig = oa.ancestor(of: edge) { print("traced") }
+      }
+  }
+  ```
+
+---
+
+## BRepExtrema_DistanceSS
+
+### `distanceSS(to:deflection:)`
+
+Computes the minimum distance between two sub-shapes using Gauss-point sampling.
+
+```swift
+public func distanceSS(to other: Shape, deflection: Double = 100.0) -> DistanceSSResult
+```
+
+- **Parameters:**
+  - `other` — the second shape.
+  - `deflection` — sampling deflection; smaller values give finer sampling at a performance cost; default `100.0`.
+- **Returns:** A `DistanceSSResult` containing `.distance`, `.point1`, `.point2`, `.solutionCount`, and `.isDone`.
+- **OCCT:** `BRepExtrema_DistanceSS`.
+- **Example:**
+  ```swift
+  let a = Shape.box(dx: 5, dy: 5, dz: 5)!
+  let b = Shape.box(dx: 5, dy: 5, dz: 5)!.translated(x: 10, y: 0, z: 0)!
+  let r = a.distanceSS(to: b)
+  if r.isDone { print(r.distance) }
+  ```
+
+---
+
+### `DistanceSSResult`
+
+Result struct returned by `distanceSS(to:deflection:)`.
+
+```swift
+public struct DistanceSSResult {
+    public let distance: Double
+    public let point1: SIMD3<Double>
+    public let point2: SIMD3<Double>
+    public let solutionCount: Int
+    public let isDone: Bool
+}
+```
+
+---
+
+## BRepGProp_VinertGK
+
+### `vinertGK(location:tolerance:computeCG:)`
+
+Computes volume inertia properties of a face using Gauss-Kronrod numerical integration.
+
+```swift
+public func vinertGK(location: SIMD3<Double> = SIMD3(0, 0, 0),
+                     tolerance: Double = 0.001, computeCG: Bool = true) -> VinertGKResult
+```
+
+- **Parameters:**
+  - `location` — the reference point for inertia computation; defaults to the origin.
+  - `tolerance` — relative integration error bound; default `0.001`.
+  - `computeCG` — whether to compute the centre of gravity; default `true`.
+- **Returns:** A `VinertGKResult` with `.mass`, `.errorReached`, `.absoluteError`, and `.center`.
+- **OCCT:** `BRepGProp_VinertGK`.
+- **Note:** This method operates on a face shape. The `.mass` field is the signed volume contribution.
+- **Example:**
+  ```swift
+  let face = Shape.box(dx: 10, dy: 10, dz: 10)!.faces.first!
+  let gi = face.vinertGK()
+  print(gi.mass, gi.center)
+  ```
+
+---
+
+### `VinertGKResult`
+
+Result struct returned by `vinertGK(location:tolerance:computeCG:)`.
+
+```swift
+public struct VinertGKResult {
+    public let mass: Double
+    public let errorReached: Double
+    public let absoluteError: Double
+    public let center: SIMD3<Double>
+}
+```
+
+---
+
+## GeomFill_Profiler
+
+`CurveProfiler` homogenizes a set of `Curve3D` values into a single compatible BSpline representation, which is a prerequisite for multi-section surface operations. Wraps `GeomFill_Profiler`.
+
+### `CurveProfiler.create()`
+
+Creates a new, empty curve profiler.
+
+```swift
+public static func create() -> CurveProfiler
+```
+
+- **OCCT:** `GeomFill_Profiler`.
+
+---
+
+### `addCurve(_:)`
+
+Adds a curve to the profiler.
+
+```swift
+public func addCurve(_ curve: Curve3D)
+```
+
+- **OCCT:** `GeomFill_Profiler::AddCurve`.
+
+---
+
+### `perform(tolerance:)`
+
+Performs the homogenization of all added curves.
+
+```swift
+@discardableResult
+public func perform(tolerance: Double = 1e-6) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `GeomFill_Profiler::Perform`.
+
+---
+
+### `degree`
+
+Degree of the resulting homogenized BSpline curves.
+
+```swift
+public var degree: Int { get }
+```
+
+- **OCCT:** `GeomFill_Profiler::Degree`.
+
+---
+
+### `poleCount`
+
+Number of poles per homogenized curve.
+
+```swift
+public var poleCount: Int { get }
+```
+
+- **OCCT:** `GeomFill_Profiler::NbPoles`.
+
+---
+
+### `knotCount`
+
+Number of knots in the homogenized representation.
+
+```swift
+public var knotCount: Int { get }
+```
+
+- **OCCT:** `GeomFill_Profiler::NbKnots`.
+
+---
+
+### `isPeriodic`
+
+Whether the homogenized curves are periodic.
+
+```swift
+public var isPeriodic: Bool { get }
+```
+
+- **OCCT:** `GeomFill_Profiler::IsPeriodic`.
+
+---
+
+### `poles(curveIndex:)`
+
+Returns the poles for a specific curve (1-based index) after `perform()`.
+
+```swift
+public func poles(curveIndex: Int) -> [SIMD3<Double>]
+```
+
+- **Parameters:** `curveIndex` — 1-based index of the curve.
+- **Returns:** An array of 3D pole positions, or empty if not computed or index is out of range.
+- **OCCT:** `GeomFill_Profiler::Poles`.
+
+---
+
+### `knotsAndMults()`
+
+Returns the knot vector and multiplicities of the homogenized representation.
+
+```swift
+public func knotsAndMults() -> (knots: [Double], mults: [Int])
+```
+
+- **Returns:** A tuple of parallel arrays; empty arrays on failure or before `perform()`.
+- **OCCT:** `GeomFill_Profiler::Knots`, `GeomFill_Profiler::Mults`.
+- **Example:**
+  ```swift
+  let profiler = CurveProfiler.create()
+  profiler.addCurve(c1)
+  profiler.addCurve(c2)
+  if profiler.perform() {
+      let (knots, mults) = profiler.knotsAndMults()
+      print(knots)
+  }
+  ```
+
+---
+
+## GeomFill_Stretch
+
+### `Surface.stretchFill(p1:p2:p3:p4:)`
+
+Creates a BSpline surface by stretch-filling from four ordered boundary point arrays.
+
+```swift
+public static func stretchFill(p1: [SIMD3<Double>], p2: [SIMD3<Double>],
+                                p3: [SIMD3<Double>], p4: [SIMD3<Double>]) -> StretchFillResult?
+```
+
+- **Parameters:** `p1`–`p4` — four boundary polylines, all of equal length ≥ 2. The order is: bottom, right, top, left (or equivalent opposing boundary pairs).
+- **Returns:** A `StretchFillResult` containing pole grid dimensions and the flat pole array, or `nil` if the arrays have mismatched lengths, are too short, or the algorithm fails.
+- **OCCT:** `GeomFill_Stretch`.
+- **Example:**
+  ```swift
+  let p1: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(10,0,0)]
+  let p2: [SIMD3<Double>] = [SIMD3(10,0,0), SIMD3(10,10,0)]
+  let p3: [SIMD3<Double>] = [SIMD3(10,10,0), SIMD3(0,10,0)]
+  let p4: [SIMD3<Double>] = [SIMD3(0,10,0), SIMD3(0,0,0)]
+  if let r = Surface.stretchFill(p1: p1, p2: p2, p3: p3, p4: p4) {
+      print(r.nbUPoles, r.nbVPoles)
+  }
+  ```
+
+---
+
+### `StretchFillResult`
+
+Result struct returned by `Surface.stretchFill(p1:p2:p3:p4:)`.
+
+```swift
+public struct StretchFillResult {
+    public let nbUPoles: Int
+    public let nbVPoles: Int
+    public let isRational: Bool
+    public let poles: [SIMD3<Double>]
+}
+```
+
+The `poles` array is laid out in row-major order: `poles[i * nbVPoles + j]` gives the pole at `(i, j)`.
+
+---
+
+## GeomFill_LocationDraft
+
+`LocationDraft` implements a draft-angle location law for pipe/sweep operations. It positions a profile along a path while applying a specified taper angle. Wraps `GeomFill_LocationDraft`.
+
+### `LocationDraft.create(direction:angle:)`
+
+Creates a draft location law with a draft direction and angle.
+
+```swift
+public static func create(direction: SIMD3<Double>, angle: Double) -> LocationDraft
+```
+
+- **Parameters:** `direction` — the draft direction vector. `angle` — draft angle in radians.
+- **OCCT:** `GeomFill_LocationDraft`.
+
+---
+
+### `setCurve(_:)`
+
+Sets the sweep path curve on the location law.
+
+```swift
+@discardableResult
+public func setCurve(_ curve: Curve3D) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `GeomFill_LocationDraft::SetCurve`.
+
+---
+
+### `evaluate(at:)`
+
+Evaluates the location frame (rotation matrix + translation) at a path parameter.
+
+```swift
+public func evaluate(at param: Double) -> (matrix: [Double], translation: SIMD3<Double>)?
+```
+
+- **Returns:** A tuple where `matrix` is a flat 9-element row-major 3×3 rotation matrix and `translation` is the origin offset, or `nil` on failure.
+- **OCCT:** `GeomFill_LocationDraft::D0`.
+
+---
+
+### `setAngle(_:)`
+
+Updates the draft angle (radians).
+
+```swift
+public func setAngle(_ angle: Double)
+```
+
+- **OCCT:** `GeomFill_LocationDraft::SetAngle`.
+
+---
+
+### `direction`
+
+The current draft direction vector.
+
+```swift
+public var direction: SIMD3<Double> { get }
+```
+
+- **OCCT:** `GeomFill_LocationDraft::Direction`.
+- **Example:**
+  ```swift
+  let ld = LocationDraft.create(direction: SIMD3(0, 0, 1), angle: 0.1)
+  ld.setCurve(spine)
+  if let frame = ld.evaluate(at: 0.5) {
+      print(frame.translation)
+  }
+  ```
+
+---
+
+## GeomFill_GuideTrihedronAC
+
+`GuideTrihedronAC` computes an arc-length-corrected Frenet-like trihedron along a sweep path guided by an auxiliary curve. Wraps `GeomFill_GuideTrihedronAC`.
+
+### `GuideTrihedronAC.create(guideCurve:)`
+
+Creates a guide trihedron law using an arc-length correction guide.
+
+```swift
+public static func create(guideCurve: Curve3D) -> GuideTrihedronAC
+```
+
+- **Parameters:** `guideCurve` — the guide curve that influences the trihedron orientation.
+- **OCCT:** `GeomFill_GuideTrihedronAC`.
+
+---
+
+### `setCurve(_:)` (GuideTrihedronAC)
+
+Sets the sweep path curve.
+
+```swift
+@discardableResult
+public func setCurve(_ curve: Curve3D) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `GeomFill_GuideTrihedronAC::SetCurve`.
+
+---
+
+### `evaluate(at:)` (GuideTrihedronAC)
+
+Evaluates the trihedron frame at the given path parameter.
+
+```swift
+public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)?
+```
+
+- **Returns:** The tangent, normal, and binormal vectors at `param`, or `nil` on failure.
+- **OCCT:** `GeomFill_GuideTrihedronAC::D0`.
+- **Example:**
+  ```swift
+  let gta = GuideTrihedronAC.create(guideCurve: guide)
+  gta.setCurve(spine)
+  if let frame = gta.evaluate(at: 0.0) {
+      print(frame.tangent)
+  }
+  ```
+
+---
+
+## GeomFill_GuideTrihedronPlan
+
+`GuideTrihedronPlan` computes a planar guide trihedron for sweep operations, keeping the profile in planes normal to the guide. Wraps `GeomFill_GuideTrihedronPlan`.
+
+### `GuideTrihedronPlan.create(guideCurve:)`
+
+Creates a planar guide trihedron law from a guide curve.
+
+```swift
+public static func create(guideCurve: Curve3D) -> GuideTrihedronPlan
+```
+
+- **OCCT:** `GeomFill_GuideTrihedronPlan`.
+
+---
+
+### `setCurve(_:)` (GuideTrihedronPlan)
+
+Sets the sweep path curve.
+
+```swift
+@discardableResult
+public func setCurve(_ curve: Curve3D) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `GeomFill_GuideTrihedronPlan::SetCurve`.
+
+---
+
+### `evaluate(at:)` (GuideTrihedronPlan)
+
+Evaluates the trihedron frame at the given path parameter.
+
+```swift
+public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)?
+```
+
+- **Returns:** The tangent, normal, and binormal vectors at `param`, or `nil` on failure.
+- **OCCT:** `GeomFill_GuideTrihedronPlan::D0`.
+
+---
+
+## GeomFill_SectionPlacement
+
+### `Curve3D.sectionPlacement(section:direction:draftAngle:tolerance:)`
+
+Places a section curve optimally onto a path curve using a draft location law, returning the closest-approach parameters and geometry.
+
+```swift
+public func sectionPlacement(section: Curve3D,
+                              direction: SIMD3<Double> = SIMD3(0, 0, 1),
+                              draftAngle: Double = 0,
+                              tolerance: Double = 1e-3) -> SectionPlacementResult
+```
+
+Called on the path curve (`self`).
+
+- **Parameters:**
+  - `section` — the profile curve to place.
+  - `direction` — draft direction; defaults to +Z.
+  - `draftAngle` — taper angle in radians; default `0`.
+  - `tolerance` — positional tolerance; default `1e-3`.
+- **Returns:** A `SectionPlacementResult` (always returned; check `.isDone`).
+- **OCCT:** `GeomFill_SectionPlacement`.
+- **Example:**
+  ```swift
+  let r = spine.sectionPlacement(section: profile)
+  if r.isDone { print(r.parameterOnPath, r.distance) }
+  ```
+
+---
+
+### `SectionPlacementResult`
+
+Result struct returned by `sectionPlacement(section:direction:draftAngle:tolerance:)`.
+
+```swift
+public struct SectionPlacementResult {
+    public let parameterOnPath: Double
+    public let parameterOnSection: Double
+    public let distance: Double
+    public let angle: Double
+    public let isDone: Bool
+}
+```
+
+---
+
+## BRepFill_NSections
+
+`NSections` encodes an N-section law describing how a set of wire cross-sections varies along a sweep or loft. Wraps `BRepFill_NSections`.
+
+### `NSections.create(wires:)`
+
+Creates an N-section law from an array of wire shapes.
+
+```swift
+public static func create(wires: [Shape]) -> NSections?
+```
+
+- **Parameters:** `wires` — two or more wire shapes representing the cross-section sequence.
+- **Returns:** An `NSections` instance, or `nil` on failure.
+- **OCCT:** `BRepFill_NSections`.
+
+---
+
+### `lawCount`
+
+Number of section laws (one per wire pair interval).
+
+```swift
+public var lawCount: Int { get }
+```
+
+- **OCCT:** `BRepFill_NSections::NbLaw`.
+
+---
+
+### `isConstant`
+
+Whether the section is constant (all wires are identical).
+
+```swift
+public var isConstant: Bool { get }
+```
+
+- **OCCT:** `BRepFill_NSections::IsConstant`.
+
+---
+
+### `isVertex`
+
+Whether the section degenerates to a point vertex.
+
+```swift
+public var isVertex: Bool { get }
+```
+
+- **OCCT:** `BRepFill_NSections::IsVertex`.
+- **Example:**
+  ```swift
+  if let ns = NSections.create(wires: [w1, w2, w3]) {
+      print(ns.lawCount, ns.isConstant)
+  }
+  ```
+
+---
+
+## GeomFill_AppSurf
+
+### `Surface.appSurf(curves:degMin:degMax:tol3d:tol2d:)`
+
+Approximates a BSpline surface from a sequence of section curves.
+
+```swift
+public static func appSurf(curves: [Curve3D], degMin: Int = 3, degMax: Int = 8,
+                            tol3d: Double = 1e-3, tol2d: Double = 1e-3) -> AppSurfResult?
+```
+
+- **Parameters:**
+  - `curves` — ordered section curves to interpolate/approximate.
+  - `degMin`, `degMax` — minimum and maximum allowed BSpline degree.
+  - `tol3d`, `tol2d` — 3D and 2D fitting tolerances.
+- **Returns:** An `AppSurfResult` on success, or `nil` if the algorithm fails.
+- **OCCT:** `GeomFill_AppSurf`.
+- **Example:**
+  ```swift
+  if let r = Surface.appSurf(curves: [c1, c2, c3]) {
+      print(r.uDegree, r.vDegree, r.nbUPoles, r.nbVPoles)
+  }
+  ```
+
+---
+
+### `AppSurfResult`
+
+Result struct returned by `Surface.appSurf(curves:degMin:degMax:tol3d:tol2d:)`.
+
+```swift
+public struct AppSurfResult {
+    public let uDegree: Int
+    public let vDegree: Int
+    public let nbUPoles: Int
+    public let nbVPoles: Int
+    public let nbUKnots: Int
+    public let nbVKnots: Int
+    public let isDone: Bool
+}
+```
+
+---
+
+## ShapeFix_ComposeShell
+
+### `composeShell(precision:)`
+
+Splits a face into sub-faces using a composite surface grid, repairing topology at the seams.
+
+```swift
+public func composeShell(precision: Double = 1e-6) -> Shape?
+```
+
+- **Returns:** A `Shape` containing the repaired/split faces, or `nil` on failure.
+- **OCCT:** `ShapeFix_ComposeShell`.
+- **Example:**
+  ```swift
+  if let fixed = myFace.composeShell() {
+      print(fixed.isValid)
+  }
+  ```
+
+---
+
+## Transform, Boolean & Shape Query expansions (v0.115.0)
+
+### `transformed(matrix:)`
+
+Applies a general affine transformation (rotation + translation) described by a 12-element matrix.
+
+```swift
+public func transformed(matrix: [Double]) -> Shape?
+```
+
+`matrix` must have exactly 12 elements in row-major 3×4 layout:
+`[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]`.
+
+- **Returns:** The transformed `Shape`, or `nil` if `matrix.count != 12`.
+- **OCCT:** `BRepBuilderAPI_Transform`, `gp_Trsf`.
+- **Example:**
+  ```swift
+  // Identity rotation, translate by (5, 0, 0)
+  let m: [Double] = [1,0,0, 0,1,0, 0,0,1, 5,0,0]
+  if let moved = box.transformed(matrix: m) { print(moved.isValid) }
+  ```
+
+---
+
+### `gTransformed(matrix:)`
+
+Applies a general affine transformation supporting non-uniform scaling.
+
+```swift
+public func gTransformed(matrix: [Double]) -> Shape?
+```
+
+`matrix` must have exactly 12 elements, row-major 3×4:
+`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`.
+
+- **Returns:** The transformed `Shape`, or `nil` if `matrix.count != 12`.
+- **OCCT:** `BRepBuilderAPI_GTransform`, `gp_GTrsf`.
+- **Note:** The layout convention differs slightly from `transformed(matrix:)` — each row is `[r_i0, r_i1, r_i2, t_i]`.
+
+---
+
+### `section(with:tolerance:)`
+
+Computes a boolean section with a fuzzy tolerance.
+
+```swift
+public func section(with other: Shape, tolerance: Double) -> Shape?
+```
+
+- **Parameters:** `other` — the tool shape. `tolerance` — fuzzy coincidence tolerance.
+- **Returns:** A `Shape` containing the intersection edges/wires, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Section` with fuzzy value.
+
+---
+
+### `split(tools:tolerance:)`
+
+Splits this shape by multiple tool shapes simultaneously.
+
+```swift
+public func split(tools: [Shape], tolerance: Double = 0) -> Shape?
+```
+
+- **Parameters:** `tools` — array of splitting shapes. `tolerance` — fuzzy tolerance; default `0`.
+- **Returns:** The split compound `Shape`, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Splitter`.
+
+---
+
+### `BooleanHistoryResult`
+
+Result struct for boolean operations with change-history flags.
+
+```swift
+public struct BooleanHistoryResult: Sendable {
+    public let shape: Shape
+    public let hasDeleted: Bool
+    public let hasModified: Bool
+    public let hasGenerated: Bool
+}
+```
+
+---
+
+### `subtractedWithHistory(_:tolerance:)`
+
+Performs a boolean subtraction and returns change-history flags alongside the result shape.
+
+```swift
+public func subtractedWithHistory(_ tool: Shape, tolerance: Double = 0) -> BooleanHistoryResult?
+```
+
+- **Returns:** A `BooleanHistoryResult`, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Cut` with history builder.
+- **Example:**
+  ```swift
+  if let r = solid.subtractedWithHistory(hole) {
+      print(r.hasModified, r.shape.isValid)
+  }
+  ```
+
+---
+
+### `defeature(faces:tolerance:)`
+
+Removes specified faces from the shape (defeaturing).
+
+```swift
+public func defeature(faces: [Shape], tolerance: Double = 0) -> Shape?
+```
+
+- **Parameters:** `faces` — the face shapes to remove. `tolerance` — fuzzy tolerance; default `0`.
+- **Returns:** The defeatured `Shape`, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Defeaturing`.
+
+---
+
+### `triangulationNodeCount`
+
+Number of triangulation nodes on a face.
+
+```swift
+public var triangulationNodeCount: Int32 { get }
+```
+
+- **OCCT:** `BRep_Tool::Triangulation` → `Poly_Triangulation::NbNodes`.
+
+---
+
+### `triangulationTriangleCount`
+
+Number of triangles in the face triangulation.
+
+```swift
+public var triangulationTriangleCount: Int32 { get }
+```
+
+- **OCCT:** `Poly_Triangulation::NbTriangles`.
+
+---
+
+### `triangulationDeflection`
+
+The deflection value stored on the face triangulation.
+
+```swift
+public var triangulationDeflection: Double { get }
+```
+
+- **OCCT:** `Poly_Triangulation::Deflection`.
+
+---
+
+### `triangulationNode(at:)`
+
+Returns the 3D coordinates of a triangulation node by its 1-based index.
+
+```swift
+public func triangulationNode(at index: Int32) -> SIMD3<Double>
+```
+
+- **OCCT:** `Poly_Triangulation::Node`.
+
+---
+
+### `triangulationTriangle(at:)`
+
+Returns the three 1-based node indices of a triangle by its 1-based index.
+
+```swift
+public func triangulationTriangle(at index: Int32) -> (Int32, Int32, Int32)
+```
+
+- **OCCT:** `Poly_Triangulation::Triangle`.
+
+---
+
+### `triangulationHasNormals`
+
+Whether the face triangulation stores per-node normals.
+
+```swift
+public var triangulationHasNormals: Bool { get }
+```
+
+- **OCCT:** `Poly_Triangulation::HasNormals`.
+
+---
+
+### `triangulationNormal(at:)`
+
+Returns the normal vector at a triangulation node by its 1-based index.
+
+```swift
+public func triangulationNormal(at index: Int32) -> SIMD3<Double>
+```
+
+- **OCCT:** `Poly_Triangulation::Normal`.
+
+---
+
+### `triangulationHasUVNodes`
+
+Whether the face triangulation stores per-node UV coordinates.
+
+```swift
+public var triangulationHasUVNodes: Bool { get }
+```
+
+- **OCCT:** `Poly_Triangulation::HasUVNodes`.
+
+---
+
+### `triangulationUVNode(at:)`
+
+Returns the UV coordinates of a triangulation node by its 1-based index.
+
+```swift
+public func triangulationUVNode(at index: Int32) -> SIMD2<Double>
+```
+
+- **OCCT:** `Poly_Triangulation::UVNode`.
+
+---
+
+### `edgeParameterAtArcLength(_:from:)`
+
+Finds the curve parameter on this edge at the given arc length from a start parameter.
+
+```swift
+public func edgeParameterAtArcLength(_ arcLength: Double, from startParam: Double) -> Double
+```
+
+- **OCCT:** `GCPnts_AbscissaPoint`.
+
+---
+
+### `edgeArcLength`
+
+The total arc length of this edge.
+
+```swift
+public var edgeArcLength: Double { get }
+```
+
+- **OCCT:** `GCPnts_AbscissaPoint` / `BRepAdaptor_Curve`.
+
+---
+
+### `edgeArcLength(from:to:)`
+
+Computes the arc length of this edge between two parameter values.
+
+```swift
+public func edgeArcLength(from u1: Double, to u2: Double) -> Double
+```
+
+- **OCCT:** `GCPnts_AbscissaPoint`.
+
+---
+
+### `edgeParameterAtFraction(_:)`
+
+Returns the curve parameter at a fractional position (0–1) along the total edge length.
+
+```swift
+public func edgeParameterAtFraction(_ fraction: Double) -> Double
+```
+
+- **OCCT:** `GCPnts_AbscissaPoint`.
+
+---
+
+### `edgeAdaptorDomain`
+
+The parameter domain `[first, last]` of the edge curve via `BRepAdaptor_Curve`.
+
+```swift
+public var edgeAdaptorDomain: ClosedRange<Double> { get }
+```
+
+- **OCCT:** `BRepAdaptor_Curve::FirstParameter`, `LastParameter`.
+
+---
+
+### `edgeAdaptorValue(at:)`
+
+Evaluates the edge curve at a parameter, returning the 3D point.
+
+```swift
+public func edgeAdaptorValue(at param: Double) -> SIMD3<Double>
+```
+
+- **OCCT:** `BRepAdaptor_Curve::Value`.
+
+---
+
+### `edgeAdaptorCurveType`
+
+The curve type of the edge as a `GeomAbs_CurveType` integer (`0`=Line, `1`=Circle, etc.).
+
+```swift
+public var edgeAdaptorCurveType: Int32 { get }
+```
+
+- **OCCT:** `BRepAdaptor_Curve::GetType`.
+
+---
+
+### `faceAdaptorBounds`
+
+The UV parameter bounds of a face surface via `BRepAdaptor_Surface`.
+
+```swift
+public var faceAdaptorBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Double) { get }
+```
+
+- **OCCT:** `BRepAdaptor_Surface::FirstUParameter`, `LastUParameter`, `FirstVParameter`, `LastVParameter`.
+
+---
+
+### `faceAdaptorValue(u:v:)`
+
+Evaluates the face surface at (u, v), returning the 3D point.
+
+```swift
+public func faceAdaptorValue(u: Double, v: Double) -> SIMD3<Double>
+```
+
+- **OCCT:** `BRepAdaptor_Surface::Value`.
+
+---
+
+### `faceAdaptorSurfaceType`
+
+The surface type of the face as a `GeomAbs_SurfaceType` integer (`0`=Plane, `1`=Cylinder, etc.).
+
+```swift
+public var faceAdaptorSurfaceType: Int32 { get }
+```
+
+- **OCCT:** `BRepAdaptor_Surface::GetType`.
+
+---
+
+### `obbVolume`
+
+Volume of the oriented bounding box (OBB) of this shape.
+
+```swift
+public var obbVolume: Double { get }
+```
+
+- **OCCT:** `Bnd_OBB` via `BRepBndLib::AddOBB`.
+
+---
+
+### `maxEdgeTolerance`
+
+Maximum tolerance across all edges in this shape.
+
+```swift
+public var maxEdgeTolerance: Double { get }
+```
+
+- **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.
+
+---
+
+### `maxFaceTolerance`
+
+Maximum tolerance across all faces in this shape.
+
+```swift
+public var maxFaceTolerance: Double { get }
+```
+
+- **OCCT:** `ShapeAnalysis_ShapeTolerance`.
+
+---
+
+### `maxVertexTolerance`
+
+Maximum tolerance across all vertices in this shape.
+
+```swift
+public var maxVertexTolerance: Double { get }
+```
+
+- **OCCT:** `ShapeAnalysis_ShapeTolerance`.
+
+---
+
+### `hasFreeEdges`
+
+Whether this shape contains free (non-shared) edges.
+
+```swift
+public var hasFreeEdges: Bool { get }
+```
+
+- **OCCT:** `ShapeAnalysis_FreeBounds` or `BRepCheck_Analyzer`.
+
+---
+
+### `hasFreeWires`
+
+Whether this shape contains free (non-shared) wires.
+
+```swift
+public var hasFreeWires: Bool { get }
+```
+
+- **OCCT:** `ShapeAnalysis_FreeBounds`.
+
+---
+
+### `hasFreeFaces`
+
+Whether this shape contains free (non-shared) faces.
+
+```swift
+public var hasFreeFaces: Bool { get }
+```
+
+- **OCCT:** `ShapeAnalysis_FreeBounds`.
+
+---
+
+### `boundingDiagonal`
+
+Length of the axis-aligned bounding box diagonal.
+
+```swift
+public var boundingDiagonal: Double { get }
+```
+
+- **OCCT:** `BRepBndLib::Add`, `Bnd_Box::CornerMin`/`CornerMax`.
+
+---
+
+### `centroid`
+
+Volumetric centroid of this shape.
+
+```swift
+public var centroid: SIMD3<Double> { get }
+```
+
+- **OCCT:** `GProp_GProps` via `BRepGProp::VolumeProperties`.
+
+---
+
+### `totalEdgeLength`
+
+Sum of arc lengths of all edges in this shape.
+
+```swift
+public var totalEdgeLength: Double { get }
+```
+
+- **OCCT:** `BRepGProp::LinearProperties`, `GProp_GProps::Mass`.
+
+---
+
+## ThruSections builder (v0.115.0)
+
+`ThruSectionsBuilder` drives `BRepOffsetAPI_ThruSections` through a builder pattern, providing full control over smoothing, degree, and continuity before building.
+
+### `ThruSectionsBuilder.init(isSolid:isRuled:precision:)`
+
+Creates a loft builder.
+
+```swift
+public init(isSolid: Bool = true, isRuled: Bool = false, precision: Double = 1e-6)
+```
+
+- **Parameters:**
+  - `isSolid` — `true` (default) caps the ends to produce a solid; `false` gives a shell.
+  - `isRuled` — `true` uses ruled (linear) surfaces between sections; `false` (default) uses BSpline.
+  - `precision` — 3D tolerance; default `1e-6`.
+- **OCCT:** `BRepOffsetAPI_ThruSections`.
+- **Note:** Mixing closed and open profiles causes a SIGSEGV inside OCCT (`BRepFill_CompatibleWires`). A source patch shipped with this xcframework guards the iterator; still, ensure all profiles have the same open/closed status.
+
+---
+
+### `addWire(_:)` (ThruSectionsBuilder)
+
+Adds a wire profile as the next cross-section.
+
+```swift
+public func addWire(_ wire: Shape)
+```
+
+- **OCCT:** `BRepOffsetAPI_ThruSections::AddWire`.
+
+---
+
+### `addVertex(_:)` (ThruSectionsBuilder)
+
+Adds a vertex (degenerate point) as a tip section.
+
+```swift
+public func addVertex(_ vertex: Shape)
+```
+
+- **OCCT:** `BRepOffsetAPI_ThruSections::AddVertex`.
+
+---
+
+### `setSmoothing(_:)`
+
+Enables or disables smoothing of the loft surface.
+
+```swift
+public func setSmoothing(_ smoothing: Bool)
+```
+
+- **OCCT:** `BRepOffsetAPI_ThruSections::SetSmoothing`.
+
+---
+
+### `setMaxDegree(_:)`
+
+Sets the maximum BSpline degree used for the loft.
+
+```swift
+public func setMaxDegree(_ maxDeg: Int)
+```
+
+- **OCCT:** `BRepOffsetAPI_ThruSections::SetMaxDegree`.
+
+---
+
+### `setContinuity(_:)` (ThruSectionsBuilder)
+
+Sets the desired continuity of the lofted surface.
+
+```swift
+public func setContinuity(_ continuity: Int)
+```
+
+- **Parameters:** `continuity` — `0`=C0, `1`=C1, `2`=C2.
+- **OCCT:** `BRepOffsetAPI_ThruSections::SetContinuity`.
+
+---
+
+### `build()` (ThruSectionsBuilder)
+
+Executes the loft algorithm.
+
+```swift
+@discardableResult
+public func build() -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `BRepOffsetAPI_ThruSections::Build`.
+
+---
+
+### `shape` (ThruSectionsBuilder)
+
+The result shape after a successful `build()`.
+
+```swift
+public var shape: Shape? { get }
+```
+
+- **Returns:** The lofted `Shape`, or `nil` if `build()` has not been called or failed.
+- **OCCT:** `BRepOffsetAPI_ThruSections::Shape`.
+- **Example:**
+  ```swift
+  let builder = ThruSectionsBuilder(isSolid: true)
+  builder.addWire(bottomWire)
+  builder.addWire(topWire)
+  builder.setSmoothing(true)
+  if builder.build(), let loft = builder.shape {
+      print(loft.isValid)
+  }
+  ```
+
+---
+
+## ShapeFixer builder (v0.115.0)
+
+`ShapeFixer` provides configurable shape repair via `ShapeFix_Shape`, exposing precision, tolerance bounds, and per-fix status reporting.
+
+### `ShapeFixer.init(shape:)`
+
+Creates a fixer for the given shape.
+
+```swift
+public init(shape: Shape)
+```
+
+- **OCCT:** `ShapeFix_Shape`.
+
+---
+
+### `setPrecision(_:)` (ShapeFixer)
+
+Sets the working precision for repair algorithms.
+
+```swift
+public func setPrecision(_ precision: Double)
+```
+
+- **OCCT:** `ShapeFix_Root::SetPrecision`.
+
+---
+
+### `setMaxTolerance(_:)`
+
+Sets the upper bound on tolerances that the fixer may assign.
+
+```swift
+public func setMaxTolerance(_ maxTol: Double)
+```
+
+- **OCCT:** `ShapeFix_Root::SetMaxTolerance`.
+
+---
+
+### `setMinTolerance(_:)`
+
+Sets the lower bound on tolerances that the fixer may assign.
+
+```swift
+public func setMinTolerance(_ minTol: Double)
+```
+
+- **OCCT:** `ShapeFix_Root::SetMinTolerance`.
+
+---
+
+### `perform()` (ShapeFixer)
+
+Runs all applicable shape-fixing algorithms.
+
+```swift
+@discardableResult
+public func perform() -> Bool
+```
+
+- **Returns:** `true` if any fix was applied.
+- **OCCT:** `ShapeFix_Shape::Perform`.
+
+---
+
+### `shape` (ShapeFixer)
+
+The repaired shape after `perform()`.
+
+```swift
+public var shape: Shape? { get }
+```
+
+- **Returns:** The fixed `Shape`, or `nil` if `perform()` has not been called or produced nothing.
+- **OCCT:** `ShapeFix_Shape::Shape`.
+
+---
+
+### `status(_:)`
+
+Queries the fix result status.
+
+```swift
+public func status(_ type: Int) -> Bool
+```
+
+- **Parameters:** `type` — `1`=OK (no fix needed), `2`=DONE (fix applied), `3`=FAIL (fix attempted but failed).
+- **Returns:** `true` if the queried status flag is set.
+- **OCCT:** `ShapeFix_Shape::Status`.
+- **Example:**
+  ```swift
+  let fixer = ShapeFixer(shape: badShape)
+  fixer.setPrecision(1e-4)
+  fixer.perform()
+  if let fixed = fixer.shape { print(fixer.status(2)) } // true = something was fixed
+  ```
+
+---
+
+## BRep_Tool completions (v0.126.0)
+
+### `Shape.curveOnSurface(edge:face:)`
+
+Returns the 2D parametric curve (pcurve) of an edge on a face, with its parameter range.
+
+```swift
+public static func curveOnSurface(edge: Shape, face: Shape) -> (curve: Curve2D, first: Double, last: Double)?
+```
+
+- **Returns:** A tuple of the 2D `Curve2D` and its `first`/`last` parameter range, or `nil` if no pcurve exists.
+- **OCCT:** `BRep_Tool::CurveOnSurface`.
+
+---
+
+### `Shape.hasContinuity(edge:face1:face2:)`
+
+Checks whether an edge has recorded continuity regularity between two adjacent faces.
+
+```swift
+public static func hasContinuity(edge: Shape, face1: Shape, face2: Shape) -> Bool
+```
+
+- **OCCT:** `BRep_Tool::HasContinuity`.
+
+---
+
+### `Shape.continuity(edge:face1:face2:)`
+
+Returns the continuity order of an edge between two faces as a `GeomAbs_Shape` integer.
+
+```swift
+public static func continuity(edge: Shape, face1: Shape, face2: Shape) -> Int
+```
+
+- **Returns:** `GeomAbs_Shape` integer: `0`=C0, `1`=G1, `2`=C1, `3`=G2, `4`=C2, `5`=C3, `6`=CN.
+- **OCCT:** `BRep_Tool::Continuity`.
+
+---
+
+### `Shape.hasAnyContinuity(edge:)`
+
+Checks whether an edge has any recorded continuity on any pair of its surfaces.
+
+```swift
+public static func hasAnyContinuity(edge: Shape) -> Bool
+```
+
+- **OCCT:** `BRep_Tool::HasContinuity` (any-surface overload).
+
+---
+
+### `Shape.maxContinuity(edge:)`
+
+Returns the maximum continuity of an edge across all surface pairs it belongs to.
+
+```swift
+public static func maxContinuity(edge: Shape) -> Int
+```
+
+- **Returns:** The highest `GeomAbs_Shape` integer found.
+- **OCCT:** `BRep_Tool::MaxContinuity`.
+
+---
+
+### `Shape.isDegenerated(edge:)`
+
+Returns `true` if the edge is degenerated (collapsed to a point in 3D).
+
+```swift
+public static func isDegenerated(edge: Shape) -> Bool
+```
+
+- **OCCT:** `BRep_Tool::Degenerated`.
+
+---
+
+### `Shape.naturalRestriction(face:)`
+
+Returns the value of the `NaturalRestriction` flag on a face.
+
+```swift
+public static func naturalRestriction(face: Shape) -> Bool
+```
+
+A face with natural restriction uses the full parameter domain of its surface as its boundary without additional wire loops.
+
+- **OCCT:** `BRep_Tool::NaturalRestriction`.
+
+---
+
+### `Shape.rangeOnFace(edge:face:)`
+
+Returns the parameter range of an edge's pcurve on a given face.
+
+```swift
+public static func rangeOnFace(edge: Shape, face: Shape) -> (first: Double, last: Double)?
+```
+
+- **Returns:** The `(first, last)` parameter range, or `nil` if no pcurve exists.
+- **OCCT:** `BRep_Tool::Range`.
+
+---
+
+### `Shape.parameterOnFace(vertex:edge:face:)`
+
+Returns the parameter of a vertex on the pcurve of an edge on a face.
+
+```swift
+public static func parameterOnFace(vertex: Shape, edge: Shape, face: Shape) -> Double?
+```
+
+- **Returns:** The parameter value, or `nil` on failure.
+- **OCCT:** `BRep_Tool::Parameter`.
+
+---
+
+### `Shape.parametersOnFace(vertex:face:)`
+
+Returns the UV parameters of a vertex on a face.
+
+```swift
+public static func parametersOnFace(vertex: Shape, face: Shape) -> (u: Double, v: Double)?
+```
+
+- **Returns:** The `(u, v)` parameter pair, or `nil` if the vertex does not lie on the face.
+- **OCCT:** `BRep_Tool::Parameters`.
+
+---
+
+### `Shape.uvPoints(edge:face:)`
+
+Returns the UV coordinates at both endpoints of an edge on a face.
+
+```swift
+public static func uvPoints(edge: Shape, face: Shape) -> (firstU: Double, firstV: Double, lastU: Double, lastV: Double)?
+```
+
+- **Returns:** Four UV values describing the start and end 2D positions, or `nil` on failure.
+- **OCCT:** `BRep_Tool::UVPoints`.
+
+---
+
+### `maxTolerance(subShapeType:)`
+
+Returns the maximum tolerance of all sub-shapes of the specified type within this shape.
+
+```swift
+public func maxTolerance(subShapeType: Int) -> Double
+```
+
+- **Parameters:** `subShapeType` — OCCT `TopAbs_ShapeEnum` integer: `4`=FACE, `6`=EDGE, `7`=VERTEX.
+- **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.
+
+---
+
+## Section with plane/surface & BRep_Tool Polygon queries (v0.127.0)
+
+### `sectionWithPlane(normal:origin:)`
+
+Computes the section (intersection edges) of this shape with a plane.
+
+```swift
+public func sectionWithPlane(normal: SIMD3<Double>, origin: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `normal` — outward normal of the cutting plane. `origin` — any point on the plane.
+- **Returns:** A `Shape` containing the section edges/wires, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Section` with an internal `gp_Pln`.
+- **Example:**
+  ```swift
+  if let section = solid.sectionWithPlane(normal: SIMD3(0,0,1), origin: SIMD3(0,0,5)) {
+      print(section.edges.count)
+  }
+  ```
+
+---
+
+### `sectionWithSurface(_:)`
+
+Computes the section (intersection curves) of this shape with an arbitrary surface.
+
+```swift
+public func sectionWithSurface(_ surface: Surface) -> Shape?
+```
+
+- **Returns:** A `Shape` containing the section edges, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Section` with a `Geom_Surface` tool.
+
+---
+
+### `Shape.curveOnPlane(edge:surface:)`
+
+Returns the 2D projection of an edge onto a planar surface, with parameter range.
+
+```swift
+public static func curveOnPlane(edge: Shape, surface: Surface) -> (curve: Curve2D, first: Double, last: Double)?
+```
+
+- **Returns:** A `Curve2D` and its parameter range, or `nil` if projection fails.
+- **OCCT:** `BRep_Tool::CurveOnPlane`.
+
+---
+
+### `Shape.polygon3D(edge:)`
+
+Returns the 3D polygon of a meshed edge (discrete approximation from triangulation).
+
+```swift
+public static func polygon3D(edge: Shape) -> [SIMD3<Double>]?
+```
+
+The shape must have been meshed (`mesh(deflection:)`) before calling this.
+
+- **Returns:** An ordered array of 3D points along the edge, or `nil` if no polygon is stored.
+- **OCCT:** `BRep_Tool::Polygon3D`, `Poly_Polygon3D::Nodes`.
+
+---
+
+### `Shape.polygonOnTriangulation(edge:)`
+
+Returns the triangulation-node indices of a meshed edge as a 1-based index array.
+
+```swift
+public static func polygonOnTriangulation(edge: Shape) -> [Int]?
+```
+
+The shape must have been meshed first.
+
+- **Returns:** An array of 1-based indices into the parent face's `Poly_Triangulation`, or `nil` if not available.
+- **OCCT:** `BRep_Tool::PolygonOnTriangulation`, `Poly_PolygonOnTriangulation::Nodes`.
+
+---
+
+## BRep_Tool completions (v0.128.0)
+
+### `Shape.isClosedOnFace(edge:face:)`
+
+Checks whether an edge is topologically closed on a face (i.e., the edge has two pcurves on the face with opposing orientations).
+
+```swift
+public static func isClosedOnFace(edge: Shape, face: Shape) -> Bool
+```
+
+- **OCCT:** `BRep_Tool::IsClosed`.
+
+---
+
+### `Shape.polygonOnSurface(edge:face:)`
+
+Returns the 2D polygon (UV) of a meshed edge on a face.
+
+```swift
+public static func polygonOnSurface(edge: Shape, face: Shape) -> [SIMD2<Double>]?
+```
+
+The shape must have been meshed first.
+
+- **Returns:** An ordered array of 2D UV points, or `nil` if not available.
+- **OCCT:** `BRep_Tool::PolygonOnSurface`, `Poly_Polygon2D::Nodes`.
+
+---
+
+### `Shape.setUVPoints(edge:face:first:last:)`
+
+Sets the UV endpoint coordinates of an edge on a face (updates the stored 2D boundary).
+
+```swift
+@discardableResult
+public static func setUVPoints(edge: Shape, face: Shape,
+                                first: SIMD2<Double>, last: SIMD2<Double>) -> Bool
+```
+
+- **Returns:** `true` on success.
+- **OCCT:** `BRep_Tool::UVPoints` (setter overload via `BRep_Builder`).
+- **Example:**
+  ```swift
+  let ok = Shape.setUVPoints(edge: e, face: f,
+                              first: SIMD2(0, 0), last: SIMD2(1, 0))
+  ```

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1,0 +1,1696 @@
+---
+title: Shape — Features, Sweeps & Surface Building
+parent: API Reference
+---
+
+# Shape — Features, Sweeps & Surface Building
+
+This page documents the Shape API from **Geometry Construction** through **Plate Surfaces** (source lines 1258–3344 of `Shape.swift`). It covers face and solid assembly, feature-based modeling (bosses, pockets, holes, patterns), shape inspection, slicing, measurement, advanced pipe sweeps, surface building, and healing. For the primitive factories, boolean operations, and transforms that precede this range, see the main **Shape** index page (not yet written; use `Surface.md` as an exemplar for style).
+
+## Topics
+
+- [Geometry Construction](#geometry-construction-v0110) · [Feature-Based Modeling](#feature-based-modeling-v0120) · [Shape Type](#shape-type) · [Sub-Shape Extraction](#sub-shape-extraction) · [Bounds](#bounds) · [Slicing](#slicing) · [Operators](#operators) · [Measurement & Analysis](#measurement--analysis-v070) · [Convenience Overloads](#wireenface-convenience-overloads) · [Selective Fillet / Draft / Defeaturing](#selective-fillet-draft--defeaturing) · [Advanced / Variable-Section Pipe Sweep](#advanced--variable-section-pipe-sweep) · [Surface Creation](#surface-creation-v090) · [Shape Healing / Analysis / Fixing / Unification](#shape-healing--analysis-v0130) · [Advanced Blends & Surface Filling](#advanced-blends--surface-filling-v0140) · [Variable Radius Fillet](#variable-radius-fillet-v0140) · [Multi-Edge Blend](#multi-edge-blend-v0140) · [Surface Filling](#surface-filling-v0140) · [Plate Surfaces](#plate-surfaces-v0140--v0230)
+
+---
+
+## Geometry Construction (v0.11.0)
+
+### `Shape.face(from:planar:)`
+
+Creates a planar face from a closed wire.
+
+```swift
+public static func face(from wire: Wire, planar: Bool = true) -> Shape?
+```
+
+- **Parameters:** `wire` — a closed wire defining the face boundary; `planar` — if `true` (default), requires the wire to be planar.
+- **Returns:** A face shape, or `nil` if the wire is not closed, not planar (when `planar: true`), or construction fails.
+- **OCCT:** `BRepBuilderAPI_MakeFace(wire, planar)`.
+- **Example:**
+  ```swift
+  let rect = Wire.rectangle(width: 10, height: 5)!
+  let face = Shape.face(from: rect)!
+  let box = face.extruded(direction: [0, 0, 1], length: 3)
+  ```
+
+---
+
+### `Shape.face(outer:holes:)`
+
+Creates a face with one or more through-holes.
+
+```swift
+public static func face(outer: Wire, holes: [Wire]) -> Shape?
+```
+
+- **Parameters:** `outer` — the outer boundary wire (closed); `holes` — array of inner boundary wires, each defining a hole.
+- **Returns:** A face with holes, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace(outer, planar)` + `BRepBuilderAPI_MakeFace::Add` for each inner wire.
+- **Example:**
+  ```swift
+  let outer = Wire.rectangle(width: 20, height: 20)!
+  let hole1 = Wire.circle(radius: 3)!.translated(x: -5, y: 0, z: 0)
+  let hole2 = Wire.circle(radius: 3)!.translated(x: 5, y: 0, z: 0)
+  if let face = Shape.face(outer: outer, holes: [hole1, hole2]) {
+      let extruded = face.extruded(direction: [0, 0, 1], length: 5)
+  }
+  ```
+
+---
+
+### `Shape.solid(from:)`
+
+Creates a solid from a closed shell.
+
+```swift
+public static func solid(from shell: Shape) -> Shape?
+```
+
+The shell must be closed (no gaps). A shell produced by `sew(shapes:)` is typically already closed when all boundary faces are included.
+
+- **Parameters:** `shell` — a shell shape (from sewing or face assembly).
+- **Returns:** A solid shape, or `nil` if the shell is not closed.
+- **OCCT:** `BRepBuilderAPI_MakeSolid(shell)`.
+- **Example:**
+  ```swift
+  let sewn = Shape.sew(shapes: faces, tolerance: 1e-6)!
+  let solid = Shape.solid(from: sewn)!
+  ```
+
+---
+
+### `Shape.sew(shapes:tolerance:)`
+
+Sews multiple shapes into a connected shell or solid.
+
+```swift
+public static func sew(shapes: [Shape], tolerance: Double = 1e-6) -> Shape?
+```
+
+Connects faces that share edges within `tolerance`. Useful for repairing imported geometry or joining separately created faces. If the result is closed, OCCT promotes it to a solid.
+
+- **Parameters:** `shapes` — array of shapes (faces, shells) to sew; `tolerance` — maximum gap size to close (default 1e-6).
+- **Returns:** Sewn shape (shell or solid if closed), or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Sewing`.
+- **Example:**
+  ```swift
+  let solid = Shape.sew(shapes: [top, bottom, front, back, left, right], tolerance: 0.01)
+  ```
+
+---
+
+### `Shape.sew(_:with:tolerance:)`
+
+Sews exactly two shapes together.
+
+```swift
+public static func sew(_ shape: Shape, with other: Shape, tolerance: Double = 1e-6) -> Shape?
+```
+
+- **Parameters:** `shape` — first shape; `other` — second shape; `tolerance` — gap tolerance.
+- **Returns:** Sewn shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Sewing` (two-argument convenience).
+
+---
+
+### `sewn(with:tolerance:)`
+
+Sews this shape with another (instance method).
+
+```swift
+public func sewn(with other: Shape, tolerance: Double = 1e-6) -> Shape?
+```
+
+Calls `Shape.sew(self, with: other, tolerance:)`.
+
+- **Parameters:** `other` — shape to sew with; `tolerance` — gap tolerance.
+- **Returns:** Sewn shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Sewing`.
+
+---
+
+## Feature-Based Modeling (v0.12.0)
+
+### `withPrism(profile:direction:height:fuse:)`
+
+Adds or removes material via a prismatic extrusion feature.
+
+```swift
+public func withPrism(profile: Wire, direction: SIMD3<Double>, height: Double, fuse: Bool) -> Shape?
+```
+
+When `fuse` is `true`, material is added (boss); when `false`, material is removed (pocket). The profile should already be positioned on a face of the receiver.
+
+- **Parameters:** `profile` — wire profile to extrude; `direction` — extrusion direction; `height` — feature height; `fuse` — `true` = add material, `false` = remove material.
+- **Returns:** Modified shape, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakePrism` + `BRepAlgoAPI_Fuse` or `BRepAlgoAPI_Cut`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 50, height: 50, depth: 10)
+  let profile = Wire.circle(radius: 5)!.translated(x: 25, y: 25, z: 10)
+  let withBoss = box.withPrism(profile: profile, direction: SIMD3(0, 0, 1), height: 5, fuse: true)
+  ```
+
+---
+
+### `withBoss(profile:direction:height:)`
+
+Adds a raised feature (boss) to the shape. Convenience wrapper for `withPrism(..., fuse: true)`.
+
+```swift
+public func withBoss(profile: Wire, direction: SIMD3<Double>, height: Double) -> Shape?
+```
+
+- **Parameters:** `profile` — profile wire; `direction` — extrusion direction; `height` — boss height.
+- **Returns:** Shape with added boss, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakePrism` (fuse mode).
+
+---
+
+### `withPocket(profile:direction:depth:)`
+
+Creates a depression (pocket) in the shape. Convenience wrapper for `withPrism(..., fuse: false)`.
+
+```swift
+public func withPocket(profile: Wire, direction: SIMD3<Double>, depth: Double) -> Shape?
+```
+
+- **Parameters:** `profile` — profile wire defining the pocket boundary; `direction` — pocket direction (into the shape); `depth` — pocket depth.
+- **Returns:** Shape with pocket, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakePrism` (cut mode).
+
+---
+
+### `drilled(at:direction:radius:depth:)`
+
+Drills a cylindrical hole into the shape.
+
+```swift
+public func drilled(at position: SIMD3<Double>, direction: SIMD3<Double>,
+                    radius: Double, depth: Double = 0) -> Shape?
+```
+
+`depth: 0` creates a through-hole (the cylinder is made large enough to penetrate the shape entirely).
+
+- **Parameters:** `position` — hole-centre point on the entry face; `direction` — drill direction (into the shape); `radius` — hole radius; `depth` — hole depth, or `0` for through-hole.
+- **Returns:** Shape with drilled hole, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace` + `BRepAlgoAPI_Cut` (internal cylinder cutter).
+- **Example:**
+  ```swift
+  let plate = Shape.box(width: 50, height: 50, depth: 10)
+  if let drilled = plate.drilled(at: SIMD3(25, 25, 10), direction: SIMD3(0, 0, -1),
+                                   radius: 5, depth: 0) {
+      // through-hole centred at (25, 25)
+  }
+  ```
+
+---
+
+### `split(by:)`
+
+Splits the shape using a cutting tool shape.
+
+```swift
+public func split(by tool: Shape) -> [Shape]?
+```
+
+- **Parameters:** `tool` — shape to use as cutting tool (typically a face or solid).
+- **Returns:** Array of result shapes after the split, or `nil` on failure. The array will have at least two elements when the cut produces distinct pieces.
+- **OCCT:** `BRepAlgoAPI_BuilderAlgo` (multi-split general cutter).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 20, height: 20, depth: 20)
+  let plane = Shape.face(from: Wire.rectangle(width: 40, height: 40)!)!
+                   .translated(by: SIMD3(0, 0, 10))
+  if let halves = box.split(by: plane) {
+      // halves.count == 2
+  }
+  ```
+
+---
+
+### `split(atPlane:normal:)`
+
+Splits the shape by an infinite plane.
+
+```swift
+public func split(atPlane point: SIMD3<Double>, normal: SIMD3<Double>) -> [Shape]?
+```
+
+- **Parameters:** `point` — a point on the cutting plane; `normal` — plane normal direction.
+- **Returns:** Array of result shapes, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace` (build cutting plane) + `BRepAlgoAPI_BuilderAlgo`.
+- **Example:**
+  ```swift
+  let cube = Shape.box(width: 20, height: 20, depth: 20)
+  let halves = cube.split(atPlane: SIMD3(0, 0, 10), normal: SIMD3(0, 0, 1))
+  ```
+
+---
+
+### `Shape.glue(_:_:tolerance:)`
+
+Glues two shapes together at coincident faces.
+
+```swift
+public static func glue(_ shape1: Shape, _ shape2: Shape, tolerance: Double = 1e-6) -> Shape?
+```
+
+More efficient than boolean union when the shapes have perfectly coincident faces. Uses OCCT's glue option (`BRepAlgoAPI_Fuse` with `GlueFull`) to avoid full topology re-computation.
+
+- **Parameters:** `shape1` — first shape; `shape2` — second shape with coincident faces; `tolerance` — face-matching tolerance.
+- **Returns:** Glued shape, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Fuse` with glue option.
+
+---
+
+### `Shape.evolved(spine:profile:)`
+
+Creates an evolved shape (profile swept along spine with orientation tracking).
+
+```swift
+public static func evolved(spine: Wire, profile: Wire) -> Shape?
+```
+
+The profile is swept along the spine and its orientation evolves to remain perpendicular to the spine tangent.
+
+- **Parameters:** `spine` — path wire; `profile` — profile wire to sweep.
+- **Returns:** Evolved shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeEvolved`.
+
+---
+
+### `Shape.evolvedAdvanced(spine:profile:joinType:axeProf:solid:volume:tolerance:)`
+
+Creates an evolved shape with full parameter control.
+
+```swift
+public static func evolvedAdvanced(spine: Shape, profile: Wire,
+                                   joinType: OffsetJoinType = .arc,
+                                   axeProf: Bool = true,
+                                   solid: Bool = true,
+                                   volume: Bool = false,
+                                   tolerance: Double = 1e-4) -> Shape?
+```
+
+- **Parameters:**
+  - `spine` — spine shape (any topology accepted).
+  - `profile` — profile wire.
+  - `joinType` — how to join offset edges at corners (default `.arc`).
+  - `axeProf` — if `true`, profile is in global coordinates; if `false`, local to the spine.
+  - `solid` — produce a solid result when `true`.
+  - `volume` — use volume mode (removes self-intersections) when `true`.
+  - `tolerance` — construction tolerance.
+- **Returns:** Evolved shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeEvolved`.
+
+---
+
+### `linearPattern(direction:spacing:count:)`
+
+Creates a linear array of this shape.
+
+```swift
+public func linearPattern(direction: SIMD3<Double>, spacing: Double, count: Int) -> Shape?
+```
+
+Returns a compound containing `count` copies of the shape, spaced `spacing` apart along `direction`.
+
+- **Parameters:** `direction` — pattern direction vector; `spacing` — distance between copies; `count` — number of copies (including the original).
+- **Returns:** Compound of all copies, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` applied iteratively, collected into a `TopoDS_Compound`.
+- **Example:**
+  ```swift
+  let hole = Shape.cylinder(radius: 3, height: 10)
+  let row = hole.linearPattern(direction: SIMD3(20, 0, 0), spacing: 20, count: 5)
+  ```
+
+---
+
+### `circularPattern(axisPoint:axisDirection:count:angle:)`
+
+Creates a circular array of this shape around an axis.
+
+```swift
+public func circularPattern(axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>,
+                             count: Int, angle: Double = 0) -> Shape?
+```
+
+Duplicates the **entire body** `count` times around `axisPoint`/`axisDirection` and returns a compound. It does **not** pattern features — to replicate a cut feature, see `circularPatternCut(tool:...)`.
+
+- **Parameters:** `axisPoint` — point on the rotation axis; `axisDirection` — axis direction; `count` — number of copies (including original); `angle` — total arc to span in radians (`0` = full circle).
+- **Returns:** Compound of all copies, or `nil` on failure.
+- **OCCT:** `gp_Trsf::SetRotation` applied iteratively.
+- **Example:**
+  ```swift
+  let holeTool = Shape.cylinder(radius: 3, height: 20).translated(by: SIMD3(40, 0, 0))
+  let tools = holeTool.circularPattern(axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 6)
+  let drilled = flange.subtracting(tools!)
+  ```
+
+---
+
+### `circularPatternCut(tool:axisPoint:axisDirection:count:angle:)`
+
+Replicates a cut feature around an axis and subtracts all copies from this body.
+
+```swift
+public func circularPatternCut(tool: Shape, axisPoint: SIMD3<Double>,
+                                axisDirection: SIMD3<Double>, count: Int,
+                                angle: Double = 0) -> Shape?
+```
+
+Combines `circularPattern` of `tool` with `subtracting` in a single call. The natural primitive for bolt circles.
+
+- **Parameters:** `tool` — the cutting feature (e.g. a cylinder at the first hole position); `axisPoint` — rotation axis point; `axisDirection` — axis direction; `count` — number of tool copies (including original); `angle` — arc span in radians (`0` = full circle).
+- **Returns:** This body with all `count` features cut out, or `nil` on failure.
+- **OCCT:** `circularPattern` + `BRepAlgoAPI_Cut`.
+- **Example:**
+  ```swift
+  let hole = Shape.cylinder(radius: 3, height: 20).translated(by: SIMD3(40, 0, 0))
+  let flangeWithHoles = blank.circularPatternCut(
+      tool: hole, axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 8
+  )
+  ```
+
+---
+
+## Shape Type
+
+### `ShapeType`
+
+Topological type of a shape, matching `TopAbs_ShapeEnum`.
+
+```swift
+public enum ShapeType: Int, CustomStringConvertible, Sendable {
+    case compound = 0
+    case compSolid = 1
+    case solid = 2
+    case shell = 3
+    case face = 4
+    case wire = 5
+    case edge = 6
+    case vertex = 7
+    case unknown = -1
+}
+```
+
+Used by `shapeType`, `subShapeCount(ofType:)`, `subShape(type:index:)`, and `subShapes(ofType:)`.
+
+---
+
+### `shapeType`
+
+The topological type of this shape.
+
+```swift
+public var shapeType: ShapeType { get }
+```
+
+- **Returns:** The `ShapeType` case for this shape's root topology.
+- **OCCT:** `TopoDS_Shape::ShapeType` (via `OCCTShapeGetType`).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)
+  print(box.shapeType)  // .solid
+  ```
+
+---
+
+### `isValidSolid`
+
+Whether the shape is a topologically valid closed solid.
+
+```swift
+public var isValidSolid: Bool { get }
+```
+
+Runs `BRepCheck_Analyzer` — a **topology** check only. It does not detect global self-intersection (overlapping faces). A self-intersecting B-spline solid can pass this check yet cause booleans to hang or return garbage. Use `isSelfIntersecting(timeout:)` for the complementary geometric check.
+
+- **Returns:** `true` if `BRepCheck_Analyzer` reports no errors.
+- **OCCT:** `BRepCheck_Analyzer` (via `OCCTShapeIsValidSolid`).
+
+---
+
+### `isSelfIntersecting(timeout:)`
+
+Checks whether the shape has overlapping or interfering sub-faces.
+
+```swift
+public func isSelfIntersecting(timeout: Double = 30) -> Bool?
+```
+
+Backed by `BOPAlgo_ArgumentAnalyzer`'s self-interference test. Expensive (seconds on B-spline solids), so wall-clock bounded by `timeout`.
+
+- **Parameters:** `timeout` — seconds before the check gives up (default 30). `0` or negative = unbounded.
+- **Returns:** `true` = self-interference found; `false` = shape is clean; `nil` = indeterminate (timed out / errored — treat as "unknown", not "clean").
+- **OCCT:** `BOPAlgo_ArgumentAnalyzer` (via `OCCTShapeSelfIntersectsBounded`).
+- **Example:**
+  ```swift
+  guard let solid = Shape.loft(profiles: ps, ruled: false)?.orientedForward(),
+        solid.isSelfIntersecting() == false else { /* reject */ return }
+  ```
+
+---
+
+### `ImportError`
+
+Error type for failed STEP/IGES/BREP imports.
+
+```swift
+public enum ImportError: Error, LocalizedError {
+    case importFailed(String)
+    case cancelled
+}
+```
+
+- `importFailed` — carries a human-readable message describing why the import failed.
+- `cancelled` — the import was cancelled via `ImportProgress.shouldCancel()`.
+
+---
+
+### `ShapeType` (companion enum to `Shape.shapeType`)
+
+*(See `ShapeType` entry above in this section.)*
+
+---
+
+### `ImportResult`
+
+Result of a robust STEP import that includes diagnostic information.
+
+```swift
+public struct ImportResult: Sendable {
+    public let shape: Shape
+    public let originalType: ShapeType
+    public let resultType: ShapeType
+    public let sewingApplied: Bool
+    public let solidCreated: Bool
+    public let healingApplied: Bool
+    public var summary: String { get }
+}
+```
+
+`summary` returns a human-readable description such as `"Shell → Solid (processing: sewing, solid creation)"`.
+
+---
+
+## Sub-Shape Extraction
+
+### `subShapeCount(ofType:)`
+
+Returns the number of sub-shapes of a given topological type.
+
+```swift
+public func subShapeCount(ofType type: ShapeType) -> Int
+```
+
+- **Parameters:** `type` — the topological type to count (e.g. `.face`, `.edge`, `.vertex`).
+- **Returns:** Count of sub-shapes of that type.
+- **OCCT:** `TopExp::MapShapes` (via `OCCTShapeGetSubShapeCount`).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)
+  print(box.subShapeCount(ofType: .face))  // 6
+  ```
+
+---
+
+### `subShape(type:index:)`
+
+Returns a sub-shape by topological type and zero-based index.
+
+```swift
+public func subShape(type: ShapeType, index: Int) -> Shape?
+```
+
+Uses `TopExp::MapShapes` to enumerate sub-shapes of the given type.
+
+- **Parameters:** `type` — topological type; `index` — zero-based index.
+- **Returns:** The sub-shape as a `Shape`, or `nil` if `index` is out of range.
+- **OCCT:** `TopExp::MapShapes` + index lookup (via `OCCTShapeGetSubShapeByTypeIndex`).
+- **Note:** Edge indices are not guaranteed to be stable across calls or OCCT versions. Iterate to find a working index for edge-specific operations.
+
+---
+
+### `subShapes(ofType:)`
+
+Returns all sub-shapes of a given topological type as an array.
+
+```swift
+public func subShapes(ofType type: ShapeType) -> [Shape]
+```
+
+- **Parameters:** `type` — topological type.
+- **Returns:** Array of all sub-shapes of that type (may be empty).
+- **OCCT:** Calls `subShapeCount` + `subShape(type:index:)` iteratively.
+
+---
+
+## Bounds
+
+### `bounds`
+
+Axis-aligned bounding box of the shape.
+
+```swift
+public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) { get }
+```
+
+Uses OCCT's default `Bnd_Box`, which for B-spline and faceted surfaces is the **control-point hull** and can over-report the true extent. For a tight AABB use `boundingBoxOptimal()` (`Bnd_Box::AddOptimal`), or the ground-truth min/max of `mesh(...)` vertices.
+
+- **Returns:** Tuple of min and max AABB corners.
+- **OCCT:** `BRepBndLib::Add` (via `OCCTShapeGetBounds`).
+- **Example:**
+  ```swift
+  let b = Shape.box(width: 10, height: 5, depth: 3).bounds
+  // b.min ≈ SIMD3(0, 0, 0), b.max ≈ SIMD3(10, 5, 3)
+  ```
+
+---
+
+### `size`
+
+Size of the bounding box (max − min).
+
+```swift
+public var size: SIMD3<Double> { get }
+```
+
+- **Returns:** `bounds.max − bounds.min`.
+
+---
+
+### `center`
+
+Centre of the bounding box.
+
+```swift
+public var center: SIMD3<Double> { get }
+```
+
+- **Returns:** `(bounds.min + bounds.max) / 2`.
+
+---
+
+## Slicing
+
+### `sliceAtZ(_:)`
+
+Slices the shape at a given Z height, returning the cross-section as loose edges.
+
+```swift
+public func sliceAtZ(_ z: Double) -> Shape?
+```
+
+- **Parameters:** `z` — the Z-plane height at which to section.
+- **Returns:** A shape containing the cross-section edges, or `nil` if no intersection exists at that Z.
+- **OCCT:** `BRepAlgoAPI_Section`.
+
+---
+
+### `sectionWiresAtZ(_:tolerance:)`
+
+Returns closed wires from a section at a Z level.
+
+```swift
+public func sectionWiresAtZ(_ z: Double, tolerance: Double = 1e-6) -> [Wire]
+```
+
+Unlike `sliceAtZ`, this chains the section edges into closed wires suitable for offset or CAM operations. Use a larger `tolerance` (e.g. `1e-4`) for imprecise geometry.
+
+- **Parameters:** `z` — Z level to section at; `tolerance` — tolerance for connecting edges into wires.
+- **Returns:** Array of closed `Wire` objects; empty if no contours exist at that level.
+- **OCCT:** `BRepAlgoAPI_Section` + `BRepBuilderAPI_MakeWire` (via `OCCTShapeSectionWiresAtZ`).
+- **Example:**
+  ```swift
+  let model = try Shape.load(from: stepFile)
+  let contours = model.sectionWiresAtZ(5.0)
+  for contour in contours {
+      if let offset = contour.offset(by: toolRadius) { /* CAM boundary */ }
+  }
+  ```
+
+---
+
+### `edgePoints(at:maxPoints:)`
+
+Returns sampled points along the edge at the given index.
+
+```swift
+public func edgePoints(at index: Int, maxPoints: Int = 20) -> [SIMD3<Double>]
+```
+
+Points are uniformly sampled from start to end of the edge curve.
+
+- **Parameters:** `index` — edge index (0 to `subShapeCount(ofType: .edge) − 1`); `maxPoints` — maximum points to return (capped at 20 internally).
+- **Returns:** Array of 3D points along the edge curve.
+- **OCCT:** `BRep_Tool::Curve` + `GCPnts_UniformParameter` (via `OCCTShapeGetEdgePoints`).
+
+---
+
+### `contourPoints(maxPoints:)`
+
+Returns the start vertices of all edges in the shape.
+
+```swift
+public func contourPoints(maxPoints: Int = 1000) -> [SIMD3<Double>]
+```
+
+Returns edge **start** vertices only, not intermediate curve samples. For curved edges use `edgePoints(at:maxPoints:)` instead. Suitable for simple polygon contours from Z-plane slices.
+
+- **Parameters:** `maxPoints` — maximum number of points to return.
+- **Returns:** Array of 3D points (one per edge start vertex).
+- **OCCT:** `TopExp_Explorer` over `TopAbs_EDGE` (via `OCCTShapeGetContourPoints`).
+
+---
+
+## Operators
+
+Boolean operator overloads on `Shape`. All return `Shape?`.
+
+### `+(lhs:rhs:)`
+
+```swift
+public static func + (lhs: Shape, rhs: Shape) -> Shape?
+```
+
+Union of two shapes. Calls `lhs.union(rhs)`.
+
+- **OCCT:** `BRepAlgoAPI_Fuse`.
+
+---
+
+### `-(lhs:rhs:)`
+
+```swift
+public static func - (lhs: Shape, rhs: Shape) -> Shape?
+```
+
+Subtraction. Calls `lhs.subtracting(rhs)`.
+
+- **OCCT:** `BRepAlgoAPI_Cut`.
+
+---
+
+### `&(lhs:rhs:)`
+
+```swift
+public static func & (lhs: Shape, rhs: Shape) -> Shape?
+```
+
+Intersection. Calls `lhs.intersection(rhs)`.
+
+- **OCCT:** `BRepAlgoAPI_Common`.
+
+---
+
+## Measurement & Analysis (v0.7.0)
+
+### `ShapeProperties`
+
+Mass and geometric properties of a shape.
+
+```swift
+public struct ShapeProperties: Sendable, Equatable {
+    public var volume: Double
+    public var surfaceArea: Double
+    public var mass: Double
+    public var centerOfMass: SIMD3<Double>
+    public var momentOfInertia: simd_double3x3
+}
+```
+
+Returned by `properties(density:)`.
+
+---
+
+### `DistanceResult`
+
+Result of a minimum-distance measurement between two shapes.
+
+```swift
+public struct DistanceResult: Sendable, Equatable {
+    public var distance: Double
+    public var pointOnShape1: SIMD3<Double>
+    public var pointOnShape2: SIMD3<Double>
+    public var solutionCount: Int
+}
+```
+
+Returned by `distance(to:deflection:)`.
+
+---
+
+### `properties(density:)`
+
+Returns full mass properties of the shape.
+
+```swift
+public func properties(density: Double = 1.0) -> ShapeProperties?
+```
+
+- **Parameters:** `density` — material density for mass calculation (default 1.0).
+- **Returns:** `ShapeProperties` including volume, surface area, centre of mass, and inertia tensor; or `nil` if calculation fails.
+- **OCCT:** `BRepGProp::VolumeProperties` + `BRepGProp::SurfaceProperties` (via `OCCTShapeGetProperties`).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)
+  if let p = box.properties(density: 7.8) {
+      print("mass: \(p.mass), CoM: \(p.centerOfMass)")
+  }
+  ```
+
+---
+
+### `volume`
+
+Volume of the shape in cubic units. Returns `nil` if the shape has no volume (e.g. a face).
+
+```swift
+public var volume: Double? { get }
+```
+
+- **Returns:** Non-negative volume, or `nil` if OCCT returns a negative sentinel.
+- **OCCT:** `BRepGProp::VolumeProperties` (via `OCCTShapeGetVolume`).
+
+---
+
+### `signedVolume`
+
+Signed volume of the shape. Negative for reversed-orientation solids.
+
+```swift
+public var signedVolume: Double { get }
+```
+
+Unlike `volume`, preserves the sign. A solid whose faces point inward (e.g. produced by `sweep(profile:along:)`) has a negative `signedVolume`. Use `orientedForward()` to fix the orientation.
+
+- **OCCT:** `BRepGProp::VolumeProperties`.
+
+---
+
+### `orientedForward()`
+
+Returns a copy of this solid whose faces are oriented outward (positive volume).
+
+```swift
+public func orientedForward() -> Shape?
+```
+
+Reverses orientation only when `signedVolume < 0`. Already-correct solids, shells, and faces are returned unchanged.
+
+- **Returns:** Outward-oriented copy, `self` if no fix needed, or `nil` if reversal fails.
+- **OCCT:** `TopoDS_Shape::Reverse` applied via `reversed` when `signedVolume < 0`.
+- **Example:**
+  ```swift
+  if let solid = Shape.sweep(profile: profile, along: path)?.orientedForward() {
+      // solid.signedVolume > 0 guaranteed
+  }
+  ```
+
+---
+
+### `surfaceArea`
+
+Surface area of the shape in square units.
+
+```swift
+public var surfaceArea: Double? { get }
+```
+
+- **Returns:** Non-negative area, or `nil` on failure.
+- **OCCT:** `BRepGProp::SurfaceProperties` (via `OCCTShapeGetSurfaceArea`).
+
+---
+
+### `centerOfMass`
+
+Centre of mass (centroid) of the shape.
+
+```swift
+public var centerOfMass: SIMD3<Double>? { get }
+```
+
+- **Returns:** Centroid position, or `nil` on failure.
+- **OCCT:** `BRepGProp::VolumeProperties` (via `OCCTShapeGetCenterOfMass`).
+
+---
+
+### `distance(to:deflection:)`
+
+Computes the minimum distance between this shape and another.
+
+```swift
+public func distance(to other: Shape, deflection: Double = 1e-6) -> DistanceResult?
+```
+
+- **Parameters:** `other` — the target shape; `deflection` — tolerance for curved geometry.
+- **Returns:** `DistanceResult` with the distance and closest points, or `nil` on failure.
+- **OCCT:** `BRepExtrema_DistShapeShape`.
+- **Example:**
+  ```swift
+  let box1 = Shape.box(width: 5, height: 5, depth: 5)
+  let box2 = Shape.box(width: 5, height: 5, depth: 5).translated(by: SIMD3(10, 0, 0))
+  if let d = box1.distance(to: box2) { print(d.distance) }  // 5.0
+  ```
+
+---
+
+### `minDistance(to:)`
+
+Returns just the minimum distance scalar.
+
+```swift
+public func minDistance(to other: Shape) -> Double?
+```
+
+- **Returns:** Minimum distance, or `nil` on failure.
+- **OCCT:** `BRepExtrema_DistShapeShape` (via `distance(to:deflection:)`).
+
+---
+
+### `intersects(_:tolerance:)`
+
+Tests whether this shape intersects another within a tolerance.
+
+```swift
+public func intersects(_ other: Shape, tolerance: Double = 1e-6) -> Bool
+```
+
+- **Parameters:** `other` — shape to test against; `tolerance` — distance threshold.
+- **Returns:** `true` if the shapes overlap or touch within `tolerance`.
+- **OCCT:** `BRepExtrema_DistShapeShape` (distance ≤ tolerance).
+
+---
+
+## Wire / Edge / Face Convenience Overloads
+
+The following overloads lift `Wire`, `Edge`, and `Face` into `Shape` before dispatching. They have the same semantics as their `Shape`-typed counterparts.
+
+### `distance(to:deflection:)` — Wire, Edge, Face
+
+```swift
+public func distance(to wire: Wire, deflection: Double = 1e-6) -> DistanceResult?
+public func distance(to edge: Edge, deflection: Double = 1e-6) -> DistanceResult?
+public func distance(to face: Face, deflection: Double = 1e-6) -> DistanceResult?
+```
+
+---
+
+### `intersects(_:tolerance:)` — Wire, Edge, Face
+
+```swift
+public func intersects(_ wire: Wire, tolerance: Double = 1e-6) -> Bool
+public func intersects(_ edge: Edge, tolerance: Double = 1e-6) -> Bool
+public func intersects(_ face: Face, tolerance: Double = 1e-6) -> Bool
+```
+
+---
+
+### `vertexCount`
+
+Number of vertices (corner points) in the shape.
+
+```swift
+public var vertexCount: Int { get }
+```
+
+- **OCCT:** `TopExp::MapShapes(TopAbs_VERTEX)` (via `OCCTShapeGetVertexCount`).
+
+---
+
+### `vertices()`
+
+Returns all vertex positions of the shape.
+
+```swift
+public func vertices() -> [SIMD3<Double>]
+```
+
+- **Returns:** Array of vertex coordinates. Order matches `TopExp::MapShapes` enumeration.
+- **OCCT:** `TopExp::MapShapes(TopAbs_VERTEX)` + `BRep_Tool::Pnt` (via `OCCTShapeGetVertices`).
+- **Note:** `vertices()` is a **method**, not a property.
+
+---
+
+### `vertex(at:)`
+
+Returns the vertex at a specific zero-based index.
+
+```swift
+public func vertex(at index: Int) -> SIMD3<Double>?
+```
+
+- **Parameters:** `index` — zero-based vertex index.
+- **Returns:** Vertex position, or `nil` if index is out of bounds.
+- **OCCT:** `TopExp::MapShapes` + `BRep_Tool::Pnt` (via `OCCTShapeGetVertexAt`).
+
+---
+
+## Selective Fillet / Draft / Defeaturing
+
+### `PipeSweepMode`
+
+Orientation mode for advanced pipe sweep.
+
+```swift
+public enum PipeSweepMode: Sendable {
+    case frenet
+    case correctedFrenet
+    case fixed(binormal: SIMD3<Double>)
+    case auxiliary(spine: Wire)
+}
+```
+
+- `.frenet` — standard Frenet trihedron; profile tracks spine curvature.
+- `.correctedFrenet` — avoids twist at inflection points.
+- `.fixed(binormal:)` — fixed binormal direction; profile keeps constant orientation.
+- `.auxiliary(spine:)` — twist controlled by a secondary curve.
+
+---
+
+### `PipeTransitionMode`
+
+Transition behaviour at spine discontinuities.
+
+```swift
+public enum PipeTransitionMode: Int32, Sendable {
+    case transformed = 0
+    case rightCorner = 1
+    case roundCorner = 2
+}
+```
+
+---
+
+### `filleted(edges:radius:)`
+
+Fillets specific edges with a uniform radius.
+
+```swift
+public func filleted(edges: [Edge], radius: Double) -> Shape?
+```
+
+- **Parameters:** `edges` — edges to fillet (must have valid `index` values from this shape); `radius` — fillet radius (must be > 0).
+- **Returns:** Filleted shape, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeFilletEdges`).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)
+  let edges = box.subShapes(ofType: .edge).compactMap { Edge($0) }
+  if let rounded = box.filleted(edges: Array(edges.prefix(4)), radius: 1.0) { }
+  ```
+
+---
+
+### `filleted(edges:startRadius:endRadius:)`
+
+Fillets specific edges with a linear radius interpolation.
+
+```swift
+public func filleted(edges: [Edge], startRadius: Double, endRadius: Double) -> Shape?
+```
+
+The radius varies linearly from `startRadius` at the start of each edge to `endRadius` at its end.
+
+- **Parameters:** `edges` — edges to fillet; `startRadius` — radius at edge start (> 0); `endRadius` — radius at edge end (> 0).
+- **Returns:** Filleted shape, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet` with law-driven radius (via `OCCTShapeFilletEdgesLinear`).
+
+---
+
+### `drafted(faces:direction:angle:neutralPlane:)`
+
+Adds draft angles to faces for mold release.
+
+```swift
+public func drafted(
+    faces: [Face],
+    direction: SIMD3<Double>,
+    angle: Double,
+    neutralPlane: (point: SIMD3<Double>, normal: SIMD3<Double>)
+) -> Shape?
+```
+
+- **Parameters:**
+  - `faces` — faces to add draft to (must have valid `index` values).
+  - `direction` — pull direction (typically the mold-open direction).
+  - `angle` — draft angle in radians (typically 1–5°).
+  - `neutralPlane` — point and normal of the plane where draft angle is zero.
+- **Returns:** Drafted shape, or `nil` on failure.
+- **OCCT:** `OCCTShapeDraft` (internal `Draft_MakeDraft`-based implementation).
+
+---
+
+### `withoutFeatures(faces:)`
+
+Removes faces and heals the resulting gaps by extending adjacent faces.
+
+```swift
+public func withoutFeatures(faces: [Face]) -> Shape?
+```
+
+Useful for simplifying imported geometry or removing small features before analysis.
+
+- **Parameters:** `faces` — faces to remove (must have valid `index` values from this shape).
+- **Returns:** Shape with features removed, or `nil` on failure.
+- **OCCT:** `BOPAlgo_Defeaturing` (via `OCCTShapeRemoveFeatures`).
+
+---
+
+## Advanced / Variable-Section Pipe Sweep
+
+### `Shape.pipeShell(spine:profile:mode:solid:)`
+
+Creates a pipe sweep with advanced orientation mode control.
+
+```swift
+public static func pipeShell(
+    spine: Wire,
+    profile: Wire,
+    mode: PipeSweepMode = .frenet,
+    solid: Bool = true
+) -> Shape?
+```
+
+- **Parameters:**
+  - `spine` — path wire.
+  - `profile` — profile wire to sweep.
+  - `mode` — sweep orientation mode (`.frenet`, `.correctedFrenet`, `.fixed(binormal:)`, `.auxiliary(spine:)`).
+  - `solid` — `true` = solid result; `false` = shell.
+- **Returns:** Swept shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakePipeShell`.
+- **Example:**
+  ```swift
+  let spine = Wire.helix(origin: .zero, axis: SIMD3(0,0,1), radius: 10, pitch: 5, turns: 3)!
+  let profile = Wire.circle(radius: 1)!
+  let pipe = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet)
+  ```
+
+---
+
+### `Shape.pipeShellWithTransition(spine:profile:mode:transition:solid:)`
+
+Creates a pipe sweep with both orientation mode and spine-corner transition control.
+
+```swift
+public static func pipeShellWithTransition(
+    spine: Wire,
+    profile: Wire,
+    mode: PipeSweepMode = .frenet,
+    transition: PipeTransitionMode = .transformed,
+    solid: Bool = true
+) -> Shape?
+```
+
+- **Parameters:**
+  - `spine`, `profile` — as for `pipeShell`.
+  - `mode` — orientation mode (`.frenet` or `.correctedFrenet`; other modes fall back to Frenet).
+  - `transition` — corner transition style.
+  - `solid` — produce a solid when `true`.
+- **Returns:** Swept shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakePipeShell`.
+
+---
+
+### `Shape.pipeShellWithLaw(spine:profile:law:solid:)`
+
+Sweeps a profile along a spine with a law function controlling cross-section scaling.
+
+```swift
+public static func pipeShellWithLaw(
+    spine: Wire,
+    profile: Wire,
+    law: LawFunction,
+    solid: Bool = true
+) -> Shape?
+```
+
+The law value defines how the profile scales along the spine: 1.0 = no scaling, 2.0 = double size.
+
+- **Parameters:** `spine` — path wire; `profile` — profile wire; `law` — a `LawFunction` defining the scale along the spine; `solid` — produce a solid.
+- **Returns:** Swept shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakePipeShell` with law function (via `OCCTShapeCreatePipeShellWithLaw`).
+
+---
+
+### `Shape.pipeShellMultiSection(spine:profiles:mode:withContact:withCorrection:solid:)`
+
+Sweeps multiple profiles along a spine for a variable-section result.
+
+```swift
+public static func pipeShellMultiSection(
+    spine: Wire,
+    profiles: [Wire],
+    mode: PipeSweepMode = .frenet,
+    withContact: Bool = false,
+    withCorrection: Bool = false,
+    solid: Bool = true
+) -> Shape?
+```
+
+Each profile is positioned in 3D at its station along the spine, and OCCT interpolates a smooth solid that passes through every section. Supports all `PipeSweepMode` cases, including `.auxiliary(spine:)` for twist control.
+
+- **Parameters:**
+  - `spine` — path wire.
+  - `profiles` — section wires, each pre-positioned at its station (at least one required).
+  - `mode` — orientation mode.
+  - `withContact` — if `true`, each profile is moved to touch the spine.
+  - `withCorrection` — if `true`, each profile is rotated to stay orthogonal to the spine.
+  - `solid` — produce a solid when `true`.
+- **Returns:** Swept shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakePipeShell` multi-profile form (via `OCCTShapeCreatePipeShellMultiSection`).
+
+---
+
+### `Shape.helicalSweep(profiles:axisOrigin:axisDirection:radius:pitch:turns:clockwise:solid:)`
+
+Sweeps one or more profiles along a helix to build a helicoid (worm / screw-thread rib).
+
+```swift
+public static func helicalSweep(profiles: [Wire],
+                                 axisOrigin: SIMD3<Double>,
+                                 axisDirection: SIMD3<Double>,
+                                 radius: Double,
+                                 pitch: Double,
+                                 turns: Double,
+                                 clockwise: Bool = false,
+                                 solid: Bool = true) -> Shape?
+```
+
+Builds the helix spine and an auxiliary spine that spans the full axial extent internally, then delegates to `pipeShellMultiSection(mode: .auxiliary(...))`. One profile gives a uniform rib; two or more give a varying section.
+
+- **Parameters:**
+  - `profiles` — rib profile wires positioned in the (radial, axis) plane (at least one).
+  - `axisOrigin` — a point on the worm axis.
+  - `axisDirection` — worm axis direction.
+  - `radius` — helix pitch radius (must be > 0).
+  - `pitch` — axial advance per turn (must be > 0).
+  - `turns` — number of turns (must be > 0).
+  - `clockwise` — helix handedness.
+  - `solid` — produce a solid when `true`.
+- **Returns:** The swept helicoid, or `nil` on failure.
+- **OCCT:** `Wire.helix` + `BRepOffsetAPI_MakePipeShell` auxiliary-spine mode.
+- **Note:** The auxiliary-spine framing is approximately radial, not exactly — results bulge ~10–15% beyond the nominal radius for moderate profiles, and balloon severely for fine-pitch V-forms. Use `threadedShaft` / `threadedHole` for precise fastener threads. Do **not** boolean this helicoid with a coaxial cylinder — coincident faces cause BOP to fail (see OCCTSwift #225, #213, #181). Use `threadedRod(customProfile:...)` instead.
+- **Example:**
+  ```swift
+  let profile = Wire.rectangle(width: 3, height: 2)!  // rib cross-section
+  let worm = Shape.helicalSweep(profiles: [profile],
+                                 axisOrigin: .zero,
+                                 axisDirection: SIMD3(0, 0, 1),
+                                 radius: 15, pitch: 8, turns: 4)
+  ```
+
+---
+
+### `Shape.helicalSweep(profile:axisOrigin:axisDirection:radius:pitch:turns:clockwise:solid:)`
+
+Single-profile convenience overload for `helicalSweep(profiles:...)`.
+
+```swift
+public static func helicalSweep(profile: Wire,
+                                 axisOrigin: SIMD3<Double>,
+                                 axisDirection: SIMD3<Double>,
+                                 radius: Double,
+                                 pitch: Double,
+                                 turns: Double,
+                                 clockwise: Bool = false,
+                                 solid: Bool = true) -> Shape?
+```
+
+Calls `helicalSweep(profiles: [profile], ...)`.
+
+---
+
+## Surface Creation (v0.9.0)
+
+### `Shape.surface(poles:uDegree:vDegree:)`
+
+Creates a B-spline surface face from a 2D grid of control points.
+
+```swift
+public static func surface(
+    poles: [[SIMD3<Double>]],
+    uDegree: Int = 3,
+    vDegree: Int = 3
+) -> Shape?
+```
+
+`poles` is indexed `[uIndex][vIndex]`. Requires at least `uDegree + 1` rows and `vDegree + 1` columns.
+
+- **Parameters:**
+  - `poles` — 2D array of control points.
+  - `uDegree` — degree in U (default 3, cubic).
+  - `vDegree` — degree in V (default 3, cubic).
+- **Returns:** A face shape backed by the B-spline surface, or `nil` on failure.
+- **OCCT:** `Geom_BSplineSurface` + `BRepBuilderAPI_MakeFace` (via `OCCTShapeCreateBSplineSurface`).
+- **Example:**
+  ```swift
+  let poles: [[SIMD3<Double>]] = [
+      [SIMD3(0,0,0), SIMD3(0,10,0), SIMD3(0,20,0), SIMD3(0,30,0)],
+      [SIMD3(10,0,2), SIMD3(10,10,2), SIMD3(10,20,2), SIMD3(10,30,2)],
+      [SIMD3(20,0,2), SIMD3(20,10,2), SIMD3(20,20,2), SIMD3(20,30,2)],
+      [SIMD3(30,0,0), SIMD3(30,10,0), SIMD3(30,20,0), SIMD3(30,30,0)]
+  ]
+  let surf = Shape.surface(poles: poles)
+  ```
+
+---
+
+### `Shape.ruled(profile1:profile2:)`
+
+Creates a ruled surface between two wires.
+
+```swift
+public static func ruled(profile1: Wire, profile2: Wire) -> Shape?
+```
+
+Connects corresponding points on the two boundary wires with straight lines. Returns a shell.
+
+- **Parameters:** `profile1` — first boundary wire; `profile2` — second boundary wire.
+- **Returns:** A shell shape containing the ruled surface, or `nil` on failure.
+- **OCCT:** `BRepFill::Shell(wire1, wire2)` (via `OCCTShapeCreateRuled`).
+- **Example:**
+  ```swift
+  let bottom = Wire.circle(radius: 10)!
+  let top = Wire.circle(radius: 5)!.translated(by: SIMD3(0, 0, 20))
+  let cone = Shape.ruled(profile1: bottom, profile2: top)
+  ```
+
+---
+
+### `shelled(thickness:openFaces:)`
+
+Creates a hollow solid with specific faces left open.
+
+```swift
+public func shelled(thickness: Double, openFaces: [Face]) -> Shape?
+```
+
+- **Parameters:** `thickness` — wall thickness (positive = inward, negative = outward); `openFaces` — faces to leave open (must have valid `index` values).
+- **Returns:** Shelled shape with specified faces open, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeThickSolid::MakeThickSolidByJoin` (via `OCCTShapeShellWithOpenFaces`).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 20, height: 20, depth: 20)
+  let tops = box.subShapes(ofType: .face).compactMap { Face($0) }.filter { $0.normal?.z ?? 0 > 0.9 }
+  let openBox = box.shelled(thickness: 2.0, openFaces: tops)
+  ```
+
+---
+
+## Shape Healing / Analysis (v0.13.0)
+
+### `ShapeAnalysisResult`
+
+Result of a shape analysis scan.
+
+```swift
+public struct ShapeAnalysisResult {
+    public let smallEdgeCount: Int
+    public let smallFaceCount: Int
+    public let gapCount: Int
+    public let selfIntersectionCount: Int
+    public let freeEdgeCount: Int
+    public let freeFaceCount: Int
+    public let hasInvalidTopology: Bool
+    public var totalProblems: Int { get }
+    public var isHealthy: Bool { get }
+}
+```
+
+`isHealthy` is `true` when `totalProblems == 0 && !hasInvalidTopology`.
+
+---
+
+### `analyze(tolerance:)`
+
+Analyzes a shape for problems such as small edges, gaps, and invalid topology.
+
+```swift
+public func analyze(tolerance: Double = 1e-6) -> ShapeAnalysisResult?
+```
+
+- **Parameters:** `tolerance` — size threshold for detecting small features.
+- **Returns:** `ShapeAnalysisResult` with problem counts, or `nil` if the analysis itself fails.
+- **OCCT:** `ShapeAnalysis_Shell` + `ShapeAnalysis_CheckSmallFace` + `BRepCheck_Analyzer` (via `OCCTShapeAnalyze`).
+- **Example:**
+  ```swift
+  if let a = shape.analyze(tolerance: 0.001) {
+      if !a.isHealthy { print("\(a.totalProblems) problems found") }
+  }
+  ```
+
+---
+
+### `fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`
+
+Fixes shape problems with detailed control over what to repair.
+
+```swift
+public func fixed(tolerance: Double = 1e-6,
+                  fixSolid: Bool = true,
+                  fixShell: Bool = true,
+                  fixFace: Bool = true,
+                  fixWire: Bool = true) -> Shape?
+```
+
+- **Parameters:**
+  - `tolerance` — tolerance for fixing operations.
+  - `fixSolid` — whether to fix solid orientation.
+  - `fixShell` — whether to fix shell closure.
+  - `fixFace` — whether to fix face issues.
+  - `fixWire` — whether to fix wire issues.
+- **Returns:** Fixed shape, or `nil` on failure.
+- **OCCT:** `ShapeFix_Shape` (via `OCCTShapeFixDetailed`).
+- **Example:**
+  ```swift
+  // Fix only wire and face issues
+  let fixed = shape.fixed(tolerance: 0.001, fixSolid: false, fixShell: false)
+  ```
+
+---
+
+### `unified(unifyEdges:unifyFaces:concatBSplines:)`
+
+Merges faces and edges that lie on the same geometry after boolean operations.
+
+```swift
+public func unified(unifyEdges: Bool = true,
+                    unifyFaces: Bool = true,
+                    concatBSplines: Bool = true) -> Shape?
+```
+
+- **Parameters:**
+  - `unifyEdges` — merge edges on the same curve.
+  - `unifyFaces` — merge faces on the same surface.
+  - `concatBSplines` — concatenate adjacent B-spline edges / faces.
+- **Returns:** Unified shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_UnifySameDomain` (via `OCCTShapeUnifySameDomain`).
+- **Example:**
+  ```swift
+  let result = box - cyl1 - cyl2
+  let clean = result?.unified()
+  ```
+
+---
+
+### `withoutSmallFaces(minArea:)`
+
+Removes faces smaller than the given area threshold.
+
+```swift
+public func withoutSmallFaces(minArea: Double) -> Shape?
+```
+
+- **Parameters:** `minArea` — minimum face area; faces below this are removed.
+- **Returns:** Cleaned shape, or `nil` on failure.
+- **OCCT:** `ShapeAnalysis_CheckSmallFace` + `ShapeUpgrade_UnifySameDomain` (via `OCCTShapeRemoveSmallFaces`).
+
+---
+
+### `simplified(tolerance:)`
+
+Convenience method combining `unified()` and `healed()`.
+
+```swift
+public func simplified(tolerance: Double = 1e-6) -> Shape?
+```
+
+- **Parameters:** `tolerance` — tolerance for simplification.
+- **Returns:** Simplified shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_UnifySameDomain` + `ShapeFix_Shape` (via `OCCTShapeSimplify`).
+
+---
+
+### `Wire.fixed(tolerance:)`
+
+Fixes wire problems such as gaps, degenerate edges, and incorrect ordering.
+
+```swift
+public func fixed(tolerance: Double = 1e-6) -> Wire?
+```
+
+- **Parameters:** `tolerance` — tolerance for fixing.
+- **Returns:** Fixed wire, or `nil` on failure.
+- **OCCT:** `ShapeFix_Wire` (via `OCCTWireFix`).
+- **Example:**
+  ```swift
+  let fixedWire = problematicWire.fixed(tolerance: 0.001)
+  ```
+
+---
+
+### `Face.fixed(tolerance:)`
+
+Fixes face problems such as incorrect wire orientation, missing seams, and surface parameters.
+
+```swift
+public func fixed(tolerance: Double = 1e-6) -> Shape?
+```
+
+Returns the fixed result as a `Shape` (not `Face`) because the repair can restructure topology.
+
+- **Parameters:** `tolerance` — tolerance for fixing.
+- **Returns:** Fixed face as a `Shape`, or `nil` on failure.
+- **OCCT:** `ShapeFix_Face` (via `OCCTFaceFix`).
+
+---
+
+## Advanced Blends & Surface Filling (v0.14.0)
+
+### `SurfaceContinuity`
+
+Continuity specification for surface filling operations.
+
+```swift
+public enum SurfaceContinuity: Int32 {
+    case c0 = 0   // positional — surfaces touch
+    case g1 = 1   // tangent — smooth transition
+    case g2 = 2   // curvature — very smooth
+}
+```
+
+---
+
+### `PlateConstraintOrder`
+
+Constraint order for plate surface construction (v0.23.0).
+
+```swift
+public enum PlateConstraintOrder: Int32 {
+    case g0 = 0   // position only
+    case g1 = 1   // position + tangent
+    case g2 = 2   // position + tangent + curvature
+}
+```
+
+---
+
+### `FillingParameters`
+
+Parameters for N-sided surface filling.
+
+```swift
+public struct FillingParameters {
+    public var continuity: SurfaceContinuity
+    public var tolerance: Double
+    public var maxDegree: Int
+    public var maxSegments: Int
+
+    public init(continuity: SurfaceContinuity = .g1, tolerance: Double = 1e-4,
+                maxDegree: Int = 8, maxSegments: Int = 9)
+}
+```
+
+---
+
+## Variable Radius Fillet (v0.14.0)
+
+### `filletedVariable(edgeIndex:radiusProfile:)`
+
+Applies a variable-radius fillet to a single edge.
+
+```swift
+public func filletedVariable(
+    edgeIndex: Int,
+    radiusProfile: [(parameter: Double, radius: Double)]
+) -> Shape?
+```
+
+Parameters are normalised from 0.0 (start) to 1.0 (end). At least two profile points are required.
+
+- **Parameters:** `edgeIndex` — index of the edge to fillet; `radiusProfile` — array of `(parameter, radius)` pairs (minimum 2).
+- **Returns:** Filleted shape, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet` with law-driven radius (via `OCCTShapeFilletVariable`).
+- **Example:**
+  ```swift
+  // Radius varies from 1 mm at start to 3 mm at end
+  let filleted = shape.filletedVariable(
+      edgeIndex: 0,
+      radiusProfile: [(0.0, 1.0), (1.0, 3.0)]
+  )
+  ```
+
+---
+
+## Multi-Edge Blend (v0.14.0)
+
+### `blendedEdges(_:)`
+
+Applies fillets to multiple edges, each with its own radius.
+
+```swift
+public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Shape?
+```
+
+- **Parameters:** `edgeRadii` — array of `(edgeIndex, radius)` pairs.
+- **Returns:** Filleted shape with per-edge radii applied, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeBlendEdges`).
+- **Example:**
+  ```swift
+  let blended = shape.blendedEdges([
+      (0, 1.0),
+      (1, 2.0),
+      (2, 0.5)
+  ])
+  ```
+
+---
+
+## Surface Filling (v0.14.0)
+
+### `Shape.fill(boundaries:parameters:)`
+
+Fills an N-sided boundary with a smooth surface.
+
+```swift
+public static func fill(
+    boundaries: [Wire],
+    parameters: FillingParameters = FillingParameters()
+) -> Shape?
+```
+
+Creates a face that passes through the given boundary wires with the specified continuity. Each wire's edges are added as edge constraints to the filler.
+
+- **Parameters:** `boundaries` — wires defining the boundary (at least one); `parameters` — filling parameters (continuity, tolerance, degree, segments).
+- **Returns:** Face shape covering the boundary, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeFilling` (via `OCCTShapeFill`).
+- **Example:**
+  ```swift
+  let w1 = Wire.line(from: SIMD3(0,0,0), to: SIMD3(10,0,0))!
+  let w2 = Wire.line(from: SIMD3(10,0,0), to: SIMD3(10,10,5))!
+  let w3 = Wire.line(from: SIMD3(10,10,5), to: SIMD3(0,10,3))!
+  let w4 = Wire.line(from: SIMD3(0,10,3), to: SIMD3(0,0,0))!
+  let face = Shape.fill(boundaries: [w1, w2, w3, w4],
+                         parameters: FillingParameters(continuity: .g1))
+  ```
+
+---
+
+## Plate Surfaces (v0.14.0 / v0.23.0)
+
+### `Shape.plateSurface(through:tolerance:)`
+
+Creates a surface that interpolates through scattered 3D points.
+
+```swift
+public static func plateSurface(
+    through points: [SIMD3<Double>],
+    tolerance: Double = 0.01
+) -> Shape?
+```
+
+Requires at least 3 points.
+
+- **Parameters:** `points` — 3D points the surface must pass through (minimum 3); `tolerance` — approximation tolerance.
+- **Returns:** A face backed by a `GeomPlate_Surface`, or `nil` on failure.
+- **OCCT:** `GeomPlate_BuildPlateSurface` + `GeomPlate_MakeApprox` + `BRepBuilderAPI_MakeFace` (via `OCCTShapePlatePoints`).
+- **Example:**
+  ```swift
+  let face = Shape.plateSurface(through: [
+      SIMD3(0,0,0), SIMD3(10,0,1), SIMD3(10,10,2),
+      SIMD3(0,10,1), SIMD3(5,5,3)
+  ], tolerance: 0.01)
+  ```
+
+---
+
+### `Shape.plateSurface(constrainedBy:continuity:tolerance:)`
+
+Creates a plate surface constrained by boundary curves.
+
+```swift
+public static func plateSurface(
+    constrainedBy curves: [Wire],
+    continuity: SurfaceContinuity = .g1,
+    tolerance: Double = 0.01
+) -> Shape?
+```
+
+- **Parameters:** `curves` — wires defining the boundary constraints (at least one); `continuity` — continuity requirement at boundaries; `tolerance` — approximation tolerance.
+- **Returns:** Face shape, or `nil` on failure.
+- **OCCT:** `GeomPlate_BuildPlateSurface` with curve constraints (via `OCCTShapePlateCurves`).
+
+---
+
+### `Shape.plateSurface(through:orders:degree:pointsOnCurves:iterations:tolerance:)` (v0.23.0)
+
+Creates a plate surface through points with per-point constraint orders.
+
+```swift
+public static func plateSurface(
+    through points: [SIMD3<Double>],
+    orders: [PlateConstraintOrder],
+    degree: Int = 3,
+    pointsOnCurves: Int = 15,
+    iterations: Int = 2,
+    tolerance: Double = 0.01
+) -> Shape?
+```
+
+Each point independently specifies G0 (position), G1 (position + tangent), or G2 (position + tangent + curvature) continuity.
+
+- **Parameters:**
+  - `points` — 3D points (minimum 3); must match `orders.count`.
+  - `orders` — per-point constraint orders.
+  - `degree` — maximum polynomial degree (default 3).
+  - `pointsOnCurves` — sample points on internal curves (default 15).
+  - `iterations` — solver iterations (default 2).
+  - `tolerance` — approximation tolerance.
+- **Returns:** Face shape, or `nil` on failure.
+- **OCCT:** `GeomPlate_BuildPlateSurface` + `NLPlate_NLPlate` + `GeomPlate_MakeApprox` (via `OCCTShapePlatePointsAdvanced`).
+
+---
+
+### `Shape.plateSurface(pointConstraints:curveConstraints:degree:tolerance:)` (v0.23.0)
+
+Creates a plate surface with mixed point and curve constraints.
+
+```swift
+public static func plateSurface(
+    pointConstraints points: [(point: SIMD3<Double>, order: PlateConstraintOrder)],
+    curveConstraints curves: [(wire: Wire, order: PlateConstraintOrder)],
+    degree: Int = 3,
+    tolerance: Double = 0.01
+) -> Shape?
+```
+
+At least one of `points` or `curves` must be non-empty.
+
+- **Parameters:**
+  - `points` — point constraints, each with a position and a `PlateConstraintOrder`.
+  - `curves` — curve constraints, each with a `Wire` and a `PlateConstraintOrder`.
+  - `degree` — maximum polynomial degree (default 3).
+  - `tolerance` — approximation tolerance.
+- **Returns:** Face shape, or `nil` on failure.
+- **OCCT:** `GeomPlate_BuildPlateSurface` with `GeomPlate_PointConstraint` + `GeomPlate_CurveConstraint` (via `OCCTShapePlateMixed`).
+- **Example:**
+  ```swift
+  let boundary = Wire.rectangle(width: 20, height: 20)!
+  let face = Shape.plateSurface(
+      pointConstraints: [(SIMD3(10, 10, 5), .g0)],
+      curveConstraints: [(boundary, .g1)]
+  )
+  ```

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -1,0 +1,1802 @@
+---
+title: Shape — HLR, Intervals, Mesh Props & Geom Primitives
+parent: API Reference
+---
+
+# Shape — HLR, Intervals, Mesh Props & Geom Primitives
+
+This page documents the v0.73 / v0.76 batch of `Shape`-adjacent APIs covering hidden-line removal, interval arithmetic, curve/surface/ray intersection, mesh properties, geometric inertia, and the standalone `Geom_*` entity wrappers. See the main **Shape** type page for the primary `Shape` class (constructors, transforms, booleans, etc.).
+
+## Topics
+
+- [v0.73.0: TKHlr — Extended HLR, ReflectLines, TopCnx, Intrv](#v0730-tkhlr--extended-hlr-reflectlines-topcnx-intrv) · [Intrv_Interval (Interval with Tolerances)](#intrv_interval-interval-with-tolerances) · [Intrv_Intervals (Sorted Non-Overlapping Interval Sequence)](#intrv_intervals-sorted-non-overlapping-interval-sequence) · [ShapeRayIntersection (BRepIntCurveSurface_Inter)](#shaperayintersection-brepintcurvesurface_inter) · [ShapeConstruct (Triangulation)](#shapeconstruct-triangulation) · [Surface Extensions (ShapeCustom_Surface periodic + gap)](#surface-extensions-shapecustom_surface-periodic--gap) · [MeshCinert (Linear Mass Properties from Mesh)](#meshcinert-linear-mass-properties-from-mesh) · [MeshProps (Surface/Volume Properties from Mesh)](#meshprops-surfacevolume-properties-from-mesh) · [MeshShapeTool (Static Mesh Utilities)](#meshshapetool-static-mesh-utilities) · [ValidateEdge (BRepLib_ValidateEdge)](#validateedge-breplib_validateedge) · [BiTgte_Blend (Rolling-Ball Blend)](#bitgte_blend-rolling-ball-blend) · [GeomConvert_ApproxCurve/Surface](#geomconvert_approxcurvesurface) · [GCPnts_QuasiUniformAbscissa](#gcpnts_quasiuniformabscissa) · [GCPnts_TangentialDeflection](#gcpnts_tangentialdeflection) · [BRepGProp_Cinert (Curve Inertia per Edge)](#brepgprop_cinert-curve-inertia-per-edge) · [BRepGProp_Sinert (Surface Inertia per Face)](#brepgprop_sinert-surface-inertia-per-face) · [BRepGProp_Vinert (Volume Inertia per Face)](#brepgprop_vinert-volume-inertia-per-face) · [ShapeConstruct_ProjectCurveOnSurface](#shapeconstruct_projectcurveonsurface) · [BRepPreviewAPI_MakeBox](#breppreviewapi_makebox) · [GeomPoint3D (Geom_CartesianPoint)](#geompoint3d-geom_cartesianpoint) · [GeomDirection (Geom_Direction)](#geomdirection-geom_direction) · [GeomVector3D (Geom_VectorWithMagnitude)](#geomvector3d-geom_vectorwithmagnitude) · [Axis1Placement (Geom_Axis1Placement)](#axis1placement-geom_axis1placement)
+
+---
+
+## v0.73.0: TKHlr — Extended HLR, ReflectLines, TopCnx, Intrv
+
+### `HLREdgeCategory`
+
+Fine-grained HLR edge categories for exact and polygon-based hidden line removal.
+
+```swift
+public enum HLREdgeCategory: Int32, Sendable {
+    case visibleSharp = 0
+    case visibleSmooth = 1
+    case visibleSewn = 2
+    case visibleOutline = 3
+    case visibleIso = 4
+    case visibleOutline3d = 5
+    case hiddenSharp = 6
+    case hiddenSmooth = 7
+    case hiddenSewn = 8
+    case hiddenOutline = 9
+    case hiddenIso = 10
+}
+```
+
+Used with `hlrEdges(direction:category:)` and `hlrPolyEdges(direction:category:deflection:)` to select which edge class to extract. `.visibleIso`, `.hiddenIso`, and `.visibleOutline3d` are available for exact HLR only.
+
+---
+
+### `HLREdgeType`
+
+HLR result edge type for the generic `CompoundOfEdges` and `ReflectLines` APIs.
+
+```swift
+public enum HLREdgeType: Int32, Sendable {
+    case undefined = 0
+    case isoLine = 1
+    case outLine = 2
+    case rg1Line = 3
+    case rgNLine = 4
+    case sharp = 5
+}
+```
+
+Used with `hlrCompoundOfEdges(direction:edgeType:visible:in3d:)` and the `reflectLinesFiltered` family.
+
+---
+
+### `hlrEdges(direction:category:)`
+
+Extracts edges by fine-grained category using exact HLR (hidden line removal).
+
+```swift
+public func hlrEdges(direction: SIMD3<Double>, category: HLREdgeCategory) -> Shape?
+```
+
+- **Parameters:** `direction` — view direction vector; `category` — which class of edges to extract.
+- **Returns:** Compound of extracted edges, or `nil` if none exist for that category.
+- **OCCT:** `HLRBRep_Algo` / `HLRBRep_HLRToShape` via `OCCTHLRGetEdgesByCategory`.
+- **Example:**
+  ```swift
+  if let edges = shape.hlrEdges(direction: SIMD3(0, 0, -1), category: .visibleSharp) {
+      // edges is a compound of visible sharp edges in the -Z view
+  }
+  ```
+
+---
+
+### `hlrPolyEdges(direction:category:deflection:)`
+
+Extracts edges by fine-grained category using fast polygon-based (poly) HLR.
+
+```swift
+public func hlrPolyEdges(direction: SIMD3<Double>, category: HLREdgeCategory,
+                         deflection: Double = 0.1) -> Shape?
+```
+
+Poly HLR projects the shape's triangulation rather than its exact geometry, making it dramatically faster on curved solids (e.g. ~48× on an analytic helicoid). Prefer this for 2D drawings of threaded or curved parts. `.visibleIso`, `.hiddenIso`, and `.visibleOutline3d` are not available for poly HLR.
+
+- **Parameters:**
+  - `direction` — view direction vector.
+  - `category` — edge class to extract.
+  - `deflection` — linear mesh deflection (mm) for the internal triangulation. Smaller = finer drawing; larger = coarser and faster. Default `0.1`. Meshing is incremental: existing finer triangulations are not coarsened.
+- **Returns:** Compound of extracted edges, or `nil` if none exist.
+- **OCCT:** `HLRBRep_PolyAlgo` / `HLRBRep_PolyHLRToShape` via `OCCTHLRPolyGetEdgesByCategory`.
+- **Example:**
+  ```swift
+  if let vis = shape.hlrPolyEdges(direction: SIMD3(0, 0, -1),
+                                   category: .visibleSharp, deflection: 0.05) {
+      // vis contains visible sharp edges, finely meshed
+  }
+  ```
+
+---
+
+### `hlrCompoundOfEdges(direction:edgeType:visible:in3d:)`
+
+Extracts a compound of edges using the generic `CompoundOfEdges` API from exact HLR.
+
+```swift
+public func hlrCompoundOfEdges(direction: SIMD3<Double>, edgeType: HLREdgeType,
+                                visible: Bool, in3d: Bool) -> Shape?
+```
+
+- **Parameters:**
+  - `direction` — view direction vector.
+  - `edgeType` — edge type filter (`HLREdgeType`).
+  - `visible` — `true` for visible edges, `false` for hidden.
+  - `in3d` — `true` to return 3D edges; `false` for projected 2D edges.
+- **Returns:** Compound of matching edges, or `nil` on failure.
+- **OCCT:** `HLRBRep_HLRToShape::CompoundOfEdges` via `OCCTHLRCompoundOfEdges`.
+- **Example:**
+  ```swift
+  if let outlines = shape.hlrCompoundOfEdges(direction: SIMD3(0, 0, -1),
+                                              edgeType: .outLine, visible: true, in3d: true) {
+      // outlines contains the visible silhouette edges in 3D
+  }
+  ```
+
+---
+
+### `reflectLines(normal:viewPoint:up:)`
+
+Computes reflect (silhouette) lines on a shape for a given view.
+
+```swift
+public func reflectLines(normal: SIMD3<Double>, viewPoint: SIMD3<Double>,
+                         up: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:**
+  - `normal` — view plane normal direction.
+  - `viewPoint` — eye/target position.
+  - `up` — up direction for the view frame.
+- **Returns:** Compound of reflect line edges in 3D, or `nil` on failure.
+- **OCCT:** `HLRAppli_ReflectLines` via `OCCTHLRReflectLines`.
+- **Example:**
+  ```swift
+  if let silhouette = shape.reflectLines(normal: SIMD3(0, 0, 1),
+                                          viewPoint: SIMD3(0, 0, 100),
+                                          up: SIMD3(0, 1, 0)) {
+      // silhouette is a compound of outline curves
+  }
+  ```
+
+---
+
+### `reflectLinesFiltered(normal:viewPoint:up:edgeType:visible:in3d:)`
+
+Computes reflect lines and filters the result by edge type and visibility.
+
+```swift
+public func reflectLinesFiltered(normal: SIMD3<Double>, viewPoint: SIMD3<Double>,
+                                  up: SIMD3<Double>, edgeType: HLREdgeType,
+                                  visible: Bool, in3d: Bool) -> Shape?
+```
+
+- **Parameters:**
+  - `normal` — view plane normal direction.
+  - `viewPoint` — eye/target position.
+  - `up` — up direction.
+  - `edgeType` — edge type to extract.
+  - `visible` — `true` for visible, `false` for hidden.
+  - `in3d` — `true` for 3D edges, `false` for projected.
+- **Returns:** Filtered compound of reflect line edges, or `nil` on failure.
+- **OCCT:** `HLRAppli_ReflectLines` / `CompoundOfEdges` via `OCCTHLRReflectLinesFiltered`.
+
+---
+
+### `EdgeFaceTransitionResult`
+
+Result of an edge-face transition computation.
+
+```swift
+public struct EdgeFaceTransitionResult: Sendable {
+    public let transition: Int           // TopAbs_Orientation: 0=FORWARD, 1=REVERSED, 2=INTERNAL, 3=EXTERNAL
+    public let boundaryTransition: Int   // TopAbs_Orientation for boundary
+}
+```
+
+---
+
+### `FaceInterference`
+
+Face interference description passed to `edgeFaceTransition(edgeTangent:edgeNormal:edgeCurvature:faces:)`.
+
+```swift
+public struct FaceInterference: Sendable {
+    public let tangent: SIMD3<Double>
+    public let normal: SIMD3<Double>
+    public let curvature: Double
+    public let orientation: Int32        // TopAbs_Orientation
+    public let transition: Int32         // TopAbs_Orientation
+    public let boundaryTransition: Int32 // TopAbs_Orientation
+    public let tolerance: Double
+
+    public init(tangent: SIMD3<Double>, normal: SIMD3<Double>, curvature: Double,
+                orientation: Int32, transition: Int32, boundaryTransition: Int32,
+                tolerance: Double)
+}
+```
+
+---
+
+### `Shape.edgeFaceTransition(edgeTangent:edgeNormal:edgeCurvature:faces:)`
+
+Computes the cumulated edge-face transition orientation for multiple face interferences on an edge.
+
+```swift
+public static func edgeFaceTransition(edgeTangent: SIMD3<Double>,
+                                      edgeNormal: SIMD3<Double>,
+                                      edgeCurvature: Double,
+                                      faces: [FaceInterference]) -> EdgeFaceTransitionResult
+```
+
+- **Parameters:**
+  - `edgeTangent` — edge tangent direction.
+  - `edgeNormal` — edge normal direction (use `.zero` for linear edges).
+  - `edgeCurvature` — edge curvature (0 for linear edges).
+  - `faces` — array of `FaceInterference` descriptors.
+- **Returns:** `EdgeFaceTransitionResult` with cumulated `transition` and `boundaryTransition` orientations.
+- **OCCT:** `TopCnx_EdgeFaceTransition` via `OCCTTopCnxEdgeFaceTransition`.
+
+---
+
+## Intrv_Interval (Interval with Tolerances)
+
+### `Interval`
+
+A real interval `[start, end]` with optional per-endpoint tolerances, wrapping `Intrv_Interval`.
+
+```swift
+public final class Interval: @unchecked Sendable
+```
+
+---
+
+### `Interval.init(start:end:tolStart:tolEnd:)`
+
+Creates an interval with bounds and optional tolerances.
+
+```swift
+public init(start: Double, end: Double, tolStart: Float = 0, tolEnd: Float = 0)
+```
+
+- **Parameters:** `start` — lower bound; `end` — upper bound; `tolStart` — tolerance at start; `tolEnd` — tolerance at end.
+- **OCCT:** `Intrv_Interval(start, end, tolStart, tolEnd)` via `OCCTIntrvIntervalCreate`.
+- **Example:**
+  ```swift
+  let iv = Interval(start: 0.0, end: 1.0, tolStart: 1e-6, tolEnd: 1e-6)
+  ```
+
+---
+
+### `Interval.Bounds`
+
+The bounds and tolerances of an interval.
+
+```swift
+public struct Bounds: Sendable {
+    public let start: Double
+    public let end: Double
+    public let tolStart: Float
+    public let tolEnd: Float
+}
+```
+
+---
+
+### `bounds`
+
+Gets the interval bounds and tolerances.
+
+```swift
+public var bounds: Bounds { get }
+```
+
+- **Returns:** `Bounds` struct with `start`, `end`, `tolStart`, `tolEnd`.
+- **OCCT:** `Intrv_Interval::Start`, `End`, `TolStart`, `TolEnd` via `OCCTIntrvIntervalBounds`.
+
+---
+
+### `isProbablyEmpty`
+
+Whether the interval is probably empty.
+
+```swift
+public var isProbablyEmpty: Bool { get }
+```
+
+- **Returns:** `true` if `start + tolStart > end - tolEnd`.
+- **OCCT:** `Intrv_Interval::IsVoid` via `OCCTIntrvIntervalIsProbablyEmpty`.
+
+---
+
+### `position(relativeTo:)`
+
+Position of this interval relative to another.
+
+```swift
+public func position(relativeTo other: Interval) -> Int
+```
+
+- **Parameters:** `other` — the reference interval.
+- **Returns:** `Intrv_Position` enum raw value (0 = Before … 12 = After).
+- **OCCT:** `Intrv_Interval::Position` via `OCCTIntrvIntervalPosition`.
+
+---
+
+### `isBefore(_:)`
+
+Whether this interval is entirely before another.
+
+```swift
+public func isBefore(_ other: Interval) -> Bool
+```
+
+- **OCCT:** `Intrv_Interval::IsBefore` via `OCCTIntrvIntervalIsBefore`.
+
+---
+
+### `isAfter(_:)`
+
+Whether this interval is entirely after another.
+
+```swift
+public func isAfter(_ other: Interval) -> Bool
+```
+
+- **OCCT:** `Intrv_Interval::IsAfter` via `OCCTIntrvIntervalIsAfter`.
+
+---
+
+### `isInside(_:)`
+
+Whether this interval is entirely inside another.
+
+```swift
+public func isInside(_ other: Interval) -> Bool
+```
+
+- **OCCT:** `Intrv_Interval::IsInside` via `OCCTIntrvIntervalIsInside`.
+
+---
+
+### `isEnclosing(_:)`
+
+Whether this interval entirely encloses another.
+
+```swift
+public func isEnclosing(_ other: Interval) -> Bool
+```
+
+- **OCCT:** `Intrv_Interval::IsEnclosing` via `OCCTIntrvIntervalIsEnclosing`.
+
+---
+
+### `isSimilar(to:)`
+
+Whether this interval has the same bounds as another (within tolerances).
+
+```swift
+public func isSimilar(to other: Interval) -> Bool
+```
+
+- **OCCT:** `Intrv_Interval::IsSimilar` via `OCCTIntrvIntervalIsSimilar`.
+
+---
+
+### `setStart(_:tolerance:)`
+
+Sets the start bound.
+
+```swift
+public func setStart(_ start: Double, tolerance: Float = 0)
+```
+
+- **Parameters:** `start` — new start value; `tolerance` — new start tolerance.
+- **OCCT:** `Intrv_Interval::SetStart` via `OCCTIntrvIntervalSetStart`.
+
+---
+
+### `setEnd(_:tolerance:)`
+
+Sets the end bound.
+
+```swift
+public func setEnd(_ end: Double, tolerance: Float = 0)
+```
+
+- **Parameters:** `end` — new end value; `tolerance` — new end tolerance.
+- **OCCT:** `Intrv_Interval::SetEnd` via `OCCTIntrvIntervalSetEnd`.
+
+---
+
+### `fuseAtStart(_:tolerance:)`
+
+Extends the start bound outward (union at start).
+
+```swift
+public func fuseAtStart(_ start: Double, tolerance: Float = 0)
+```
+
+- **Parameters:** `start` — new start bound (must be ≤ current start to extend); `tolerance` — new tolerance.
+- **OCCT:** `Intrv_Interval::FuseAtStart` via `OCCTIntrvIntervalFuseAtStart`.
+
+---
+
+### `fuseAtEnd(_:tolerance:)`
+
+Extends the end bound outward (union at end).
+
+```swift
+public func fuseAtEnd(_ end: Double, tolerance: Float = 0)
+```
+
+- **OCCT:** `Intrv_Interval::FuseAtEnd` via `OCCTIntrvIntervalFuseAtEnd`.
+
+---
+
+### `cutAtStart(_:tolerance:)`
+
+Trims the start bound inward.
+
+```swift
+public func cutAtStart(_ start: Double, tolerance: Float = 0)
+```
+
+- **OCCT:** `Intrv_Interval::CutAtStart` via `OCCTIntrvIntervalCutAtStart`.
+
+---
+
+### `cutAtEnd(_:tolerance:)`
+
+Trims the end bound inward.
+
+```swift
+public func cutAtEnd(_ end: Double, tolerance: Float = 0)
+```
+
+- **OCCT:** `Intrv_Interval::CutAtEnd` via `OCCTIntrvIntervalCutAtEnd`.
+
+---
+
+## Intrv_Intervals (Sorted Non-Overlapping Interval Sequence)
+
+### `IntervalSet`
+
+A sorted sequence of non-overlapping `Intrv_Interval` objects supporting set-theoretic operations.
+
+```swift
+public final class IntervalSet: @unchecked Sendable
+```
+
+---
+
+### `IntervalSet.init(start:end:)`
+
+Creates an interval set containing a single interval.
+
+```swift
+public init(start: Double, end: Double)
+```
+
+- **OCCT:** `Intrv_Intervals(Intrv_Interval)` via `OCCTIntrvIntervalsCreate`.
+- **Example:**
+  ```swift
+  let set = IntervalSet(start: 0.0, end: 10.0)
+  ```
+
+---
+
+### `IntervalSet.init()`
+
+Creates an empty interval set.
+
+```swift
+public init()
+```
+
+- **OCCT:** `Intrv_Intervals()` via `OCCTIntrvIntervalsCreateEmpty`.
+
+---
+
+### `count`
+
+Number of non-overlapping intervals in the set.
+
+```swift
+public var count: Int { get }
+```
+
+- **OCCT:** `Intrv_Intervals::Length` via `OCCTIntrvIntervalsCount`.
+
+---
+
+### `bounds(at:)`
+
+Gets the bounds of the interval at a zero-based index.
+
+```swift
+public func bounds(at index: Int) -> Interval.Bounds
+```
+
+- **Parameters:** `index` — zero-based interval index (internally maps to 1-based OCCT indexing).
+- **Returns:** `Interval.Bounds` for that interval.
+- **OCCT:** `Intrv_Intervals::Value` via `OCCTIntrvIntervalsValue`.
+
+---
+
+### `unite(start:end:)`
+
+Adds an interval to the set (union).
+
+```swift
+public func unite(start: Double, end: Double)
+```
+
+- **OCCT:** `Intrv_Intervals::Unite` via `OCCTIntrvIntervalsUnite`.
+- **Example:**
+  ```swift
+  let set = IntervalSet(start: 0.0, end: 5.0)
+  set.unite(start: 7.0, end: 10.0)
+  // set now has two intervals: [0,5] and [7,10]
+  ```
+
+---
+
+### `subtract(start:end:)`
+
+Subtracts an interval from the set.
+
+```swift
+public func subtract(start: Double, end: Double)
+```
+
+- **OCCT:** `Intrv_Intervals::Subtract` via `OCCTIntrvIntervalsSubtract`.
+
+---
+
+### `intersect(start:end:)`
+
+Intersects the set with an interval, keeping only the overlap.
+
+```swift
+public func intersect(start: Double, end: Double)
+```
+
+- **OCCT:** `Intrv_Intervals::Intersect` via `OCCTIntrvIntervalsIntersect`.
+
+---
+
+### `xUnite(start:end:)`
+
+Applies exclusive union (symmetric difference) with an interval.
+
+```swift
+public func xUnite(start: Double, end: Double)
+```
+
+- **OCCT:** `Intrv_Intervals::XUnite` via `OCCTIntrvIntervalsXUnite`.
+
+---
+
+## ShapeRayIntersection (BRepIntCurveSurface_Inter)
+
+### `ShapeRayIntersection`
+
+Iterator over line/curve–shape intersection results, wrapping `BRepIntCurveSurface_Inter`.
+
+```swift
+public final class ShapeRayIntersection: @unchecked Sendable
+```
+
+---
+
+### `ShapeRayIntersection.Hit`
+
+A single intersection hit between the line/curve and a face.
+
+```swift
+public struct Hit {
+    public let x: Double, y: Double, z: Double  // 3D intersection point
+    public let u: Double, v: Double              // UV parameters on face surface
+    public let w: Double                         // parameter on the curve/line
+}
+```
+
+---
+
+### `ShapeRayIntersection.init?(shape:originX:originY:originZ:dirX:dirY:dirZ:tolerance:)`
+
+Creates an intersection of a line with a shape.
+
+```swift
+public init?(shape: Shape, originX: Double, originY: Double, originZ: Double,
+             dirX: Double, dirY: Double, dirZ: Double, tolerance: Double = 1e-6)
+```
+
+- **Parameters:** `shape` — target B-Rep shape; `originX/Y/Z` — ray origin; `dirX/Y/Z` — ray direction; `tolerance` — intersection tolerance.
+- **Returns:** `nil` if initialisation fails.
+- **OCCT:** `BRepIntCurveSurface_Inter::Init(shape, gp_Lin)` via `OCCTCurveSurfaceInterCreateLine`.
+- **Example:**
+  ```swift
+  if let inter = ShapeRayIntersection(shape: box,
+                                       originX: 0, originY: 0, originZ: -10,
+                                       dirX: 0, dirY: 0, dirZ: 1) {
+      let hits = inter.allHits()
+  }
+  ```
+
+---
+
+### `ShapeRayIntersection.init?(shape:curve:tolerance:)`
+
+Creates an intersection of a `Curve3D` with a shape.
+
+```swift
+public init?(shape: Shape, curve: Curve3D, tolerance: Double = 1e-6)
+```
+
+- **Parameters:** `shape` — target shape; `curve` — 3D curve; `tolerance` — intersection tolerance.
+- **Returns:** `nil` if initialisation fails.
+- **OCCT:** `BRepIntCurveSurface_Inter::Init(shape, curve)` via `OCCTCurveSurfaceInterCreateCurve`.
+
+---
+
+### `hasMore`
+
+Whether more intersection results are available for iteration.
+
+```swift
+public var hasMore: Bool { get }
+```
+
+- **OCCT:** `BRepIntCurveSurface_Inter::More` via `OCCTCurveSurfaceInterMore`.
+
+---
+
+### `next()`
+
+Advances to the next intersection result.
+
+```swift
+public func next()
+```
+
+- **OCCT:** `BRepIntCurveSurface_Inter::Next` via `OCCTCurveSurfaceInterNext`.
+
+---
+
+### `currentHit`
+
+Returns the current intersection hit data.
+
+```swift
+public var currentHit: Hit { get }
+```
+
+- **Returns:** `Hit` with 3D point, UV face parameters, and curve parameter `w`.
+- **OCCT:** `BRepIntCurveSurface_Inter::Pnt`, `UParameter`, `VParameter`, `WParameter` via `OCCTCurveSurfaceInterHit`.
+
+---
+
+### `currentFace`
+
+Returns the face at the current intersection.
+
+```swift
+public var currentFace: Face? { get }
+```
+
+- **Returns:** The `Face` that was hit, or `nil` on failure.
+- **OCCT:** `BRepIntCurveSurface_Inter::Face` via `OCCTCurveSurfaceInterFace`.
+
+---
+
+### `allHits()`
+
+Collects all intersection hits by draining the iterator.
+
+```swift
+public func allHits() -> [Hit]
+```
+
+- **Returns:** Array of all `Hit` values (may be empty if no intersections).
+- **Note:** Calling this exhausts the iterator — `hasMore` will be `false` afterward.
+- **Example:**
+  ```swift
+  if let inter = ShapeRayIntersection(shape: shape,
+                                       originX: 0, originY: 0, originZ: 50,
+                                       dirX: 0, dirY: 0, dirZ: -1) {
+      for hit in inter.allHits() {
+          print("hit at z=\(hit.z), u=\(hit.u), v=\(hit.v)")
+      }
+  }
+  ```
+
+---
+
+## ShapeConstruct (Triangulation)
+
+### `Shape.triangulationFromPoints(_:)`
+
+Creates a triangulated face from a flat list of 3D points.
+
+```swift
+public static func triangulationFromPoints(_ points: [(Double, Double, Double)]) -> Shape?
+```
+
+- **Parameters:** `points` — ordered list of 3D coordinate triples.
+- **Returns:** A triangulated `Shape` (face), or `nil` on failure.
+- **OCCT:** `ShapeConstruct_MakeTriangulation` via `OCCTShapeConstructTriangulationFromPoints`.
+- **Example:**
+  ```swift
+  let pts = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.5, 1.0, 0.0)]
+  if let tri = Shape.triangulationFromPoints(pts) {
+      // tri is a triangulated face
+  }
+  ```
+
+---
+
+### `Shape.triangulationFromWire(_:)`
+
+Creates a triangulated face from a planar wire.
+
+```swift
+public static func triangulationFromWire(_ wire: Wire) -> Shape?
+```
+
+- **Parameters:** `wire` — a closed planar wire to triangulate.
+- **Returns:** A triangulated `Shape`, or `nil` on failure.
+- **OCCT:** `ShapeConstruct_MakeTriangulation` via `OCCTShapeConstructTriangulationFromWire`.
+- **Example:**
+  ```swift
+  if let rect = Wire.rectangle(width: 10, height: 5),
+     let tri = Shape.triangulationFromWire(rect) {
+      // tri is a mesh of the rectangle
+  }
+  ```
+
+---
+
+## Surface Extensions (ShapeCustom_Surface periodic + gap)
+
+### `Surface.convertToPeriodic()`
+
+Converts a surface to periodic form.
+
+```swift
+public func convertToPeriodic() -> Surface?
+```
+
+- **Returns:** The periodified surface, or `nil` if the surface is already periodic or cannot be converted.
+- **OCCT:** `ShapeCustom_Surface::ConvertToPeriodic` via `OCCTSurfaceConvertToPeriodic`.
+- **Example:**
+  ```swift
+  if let periodic = surface.convertToPeriodic() {
+      print(periodic.isUPeriodic)  // true for converted cylinder/cone
+  }
+  ```
+
+---
+
+### `conversionGap`
+
+The distance between the original and periodically converted surface (conversion error).
+
+```swift
+public var conversionGap: Double { get }
+```
+
+- **Returns:** Gap value in model units; 0.0 if no conversion has been applied.
+- **OCCT:** `ShapeCustom_Surface::Gap` via `OCCTSurfaceConversionGap`.
+
+---
+
+## MeshCinert (Linear Mass Properties from Mesh)
+
+### `MeshCinertResult`
+
+Result of linear mass property computation from polygon points.
+
+```swift
+public struct MeshCinertResult {
+    public let mass: Double
+    public let centerX: Double, centerY: Double, centerZ: Double
+}
+```
+
+---
+
+### `Edge.meshPolygonPoints()`
+
+Prepares polygon points from a meshed edge for use with `meshCinertCompute(points:)`.
+
+```swift
+public func meshPolygonPoints() -> [(Double, Double, Double)]
+```
+
+- **Returns:** Array of 3D coordinate triples from the edge's mesh polygon (up to 1000 points).
+- **OCCT:** `BRepGProp_MeshCinert::PreparePolygon` via `OCCTMeshCinertPreparePolygon`.
+- **Example:**
+  ```swift
+  let pts = someEdge.meshPolygonPoints()
+  let props = meshCinertCompute(points: pts)
+  ```
+
+---
+
+### `meshCinertCompute(points:)`
+
+Computes linear mass properties (mass and centre of mass) from polygon point coordinates.
+
+```swift
+public func meshCinertCompute(points: [(Double, Double, Double)]) -> MeshCinertResult
+```
+
+This is a free function (not a method). Feed it the output of `Edge.meshPolygonPoints()`.
+
+- **Parameters:** `points` — array of 3D coordinate triples.
+- **Returns:** `MeshCinertResult` with `mass` (total arc length) and centre coordinates.
+- **OCCT:** `BRepGProp_MeshCinert::Perform` via `OCCTMeshCinertCompute`.
+
+---
+
+## MeshProps (Surface/Volume Properties from Mesh)
+
+### `MeshPropsType`
+
+Selects the type of mesh property to compute.
+
+```swift
+public enum MeshPropsType {
+    case volume
+    case surface
+}
+```
+
+---
+
+### `MeshPropsResult`
+
+Result of mesh property computation.
+
+```swift
+public struct MeshPropsResult {
+    public let mass: Double
+    public let centerX: Double, centerY: Double, centerZ: Double
+}
+```
+
+`mass` is surface area when `type == .surface`, or enclosed volume when `type == .volume`.
+
+---
+
+### `Face.meshProps(type:)`
+
+Computes mesh surface or volume properties for a triangulated face.
+
+```swift
+public func meshProps(type: MeshPropsType) -> MeshPropsResult
+```
+
+- **Parameters:** `type` — `.surface` for area and centroid, `.volume` for enclosed volume and centroid.
+- **Returns:** `MeshPropsResult` with mass and centre of mass.
+- **OCCT:** `BRepGProp_MeshProps` (Sinert/Vinert path) via `OCCTMeshPropsCompute`.
+- **Example:**
+  ```swift
+  let result = triangulatedFace.meshProps(type: .surface)
+  print("area =", result.mass)
+  ```
+
+---
+
+## MeshShapeTool (Static Mesh Utilities)
+
+### `Face.maxMeshTolerance`
+
+Maximum tolerance of edges and vertices on this face.
+
+```swift
+public var maxMeshTolerance: Double { get }
+```
+
+- **Returns:** Maximum tolerance in model units.
+- **OCCT:** `BRepMesh_ShapeTool::MaxFaceTolerance` via `OCCTMeshShapeToolMaxFaceTolerance`.
+
+---
+
+### `Face.uvPoints(edge:)`
+
+Gets the UV parameter points of an edge on this face.
+
+```swift
+public func uvPoints(edge: Edge) -> (u1: Double, v1: Double, u2: Double, v2: Double)?
+```
+
+- **Parameters:** `edge` — an edge that lies on this face.
+- **Returns:** Tuple of UV parameters at each end of the edge, or `nil` if the edge is not on this face.
+- **OCCT:** `BRepMesh_ShapeTool::UVPoints` via `OCCTMeshShapeToolUVPoints`.
+- **Example:**
+  ```swift
+  if let uv = face.uvPoints(edge: edge) {
+      print("start UV: (\(uv.u1), \(uv.v1))")
+  }
+  ```
+
+---
+
+### `Shape.meshMaxDimension`
+
+Maximum dimension of this shape's bounding box (useful for mesh sizing heuristics).
+
+```swift
+public var meshMaxDimension: Double { get }
+```
+
+- **Returns:** The largest of the bounding box width, height, and depth.
+- **OCCT:** `BRepMesh_ShapeTool::BoxMaxDimension` via `OCCTMeshShapeToolBoxMaxDimension`.
+
+---
+
+## ValidateEdge (BRepLib_ValidateEdge)
+
+### `ValidateEdgeResult`
+
+Result of 3D curve vs curve-on-surface consistency check.
+
+```swift
+public struct ValidateEdgeResult {
+    public let isDone: Bool
+    public let isWithinTolerance: Bool
+    public let maxDistance: Double
+    public let tolerance: Double
+}
+```
+
+---
+
+### `Edge.validate(on:tolerance:)`
+
+Validates edge geometry against a face (3D curve vs curve-on-surface consistency).
+
+```swift
+public func validate(on face: Face, tolerance: Double = 1e-3) -> ValidateEdgeResult
+```
+
+- **Parameters:** `face` — the face containing this edge's pcurve; `tolerance` — acceptable maximum deviation.
+- **Returns:** `ValidateEdgeResult` with `isDone`, `isWithinTolerance`, `maxDistance`, and the tested `tolerance`.
+- **OCCT:** `BRepLib_ValidateEdge` via `OCCTValidateEdge`.
+- **Example:**
+  ```swift
+  let result = edge.validate(on: face)
+  if !result.isWithinTolerance {
+      print("max deviation:", result.maxDistance)
+  }
+  ```
+
+---
+
+## BiTgte_Blend (Rolling-Ball Blend)
+
+### `Shape.biTgteBlend(edgeIndices:radius:tolerance:nubs:)`
+
+Creates a rolling-ball blend on specified edges using `BiTgte_Blend`.
+
+```swift
+public func biTgteBlend(edgeIndices: [Int], radius: Double, tolerance: Double = 1e-3,
+                        nubs: Bool = false) -> Shape?
+```
+
+`BiTgte_Blend` is an alternative blend algorithm that can handle configurations where `BRepFilletAPI_MakeFillet` fails.
+
+- **Parameters:**
+  - `edgeIndices` — zero-based indices of edges to blend (as returned by the shape's topology explorer).
+  - `radius` — blend radius.
+  - `tolerance` — geometric tolerance.
+  - `nubs` — if `true`, outputs NUBS (Non-Uniform B-Spline) surfaces; if `false`, outputs NURBS.
+- **Returns:** Blended shape, or `nil` if blending fails.
+- **OCCT:** `BiTgte_Blend::Perform` via `OCCTBiTgteBlend`.
+- **Example:**
+  ```swift
+  if let blended = box.biTgteBlend(edgeIndices: [0, 1, 2], radius: 2.0) {
+      // blended has rounded edges
+  }
+  ```
+
+---
+
+## GeomConvert_ApproxCurve/Surface
+
+### `ApproxContinuity`
+
+Continuity level for BSpline approximation.
+
+```swift
+public enum ApproxContinuity: Int32 {
+    case c0 = 0, c1 = 1, c2 = 2, c3 = 3
+}
+```
+
+---
+
+### `ApproxCurveResult`
+
+Result of curve approximation including the output curve, error, and status.
+
+```swift
+public struct ApproxCurveResult {
+    public let curve: Curve3D?
+    public let maxError: Double
+    public let isDone: Bool
+    public let hasResult: Bool
+}
+```
+
+---
+
+### `Curve3D.approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)`
+
+Approximates a 3D curve as a BSpline with detailed result information.
+
+```swift
+public func approxWithDetails(tolerance: Double, continuity: ApproxContinuity = .c2,
+                               maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult
+```
+
+- **Parameters:**
+  - `tolerance` — maximum approximation deviation.
+  - `continuity` — desired continuity of the output BSpline.
+  - `maxSegments` — maximum number of BSpline segments.
+  - `maxDegree` — maximum polynomial degree.
+- **Returns:** `ApproxCurveResult` with the output `Curve3D` (or `nil`), `maxError`, and status flags.
+- **OCCT:** `GeomConvert_ApproxCurve` via `OCCTGeomConvertApproxCurve`.
+- **Example:**
+  ```swift
+  let result = curve.approxWithDetails(tolerance: 0.01, continuity: .c2)
+  if result.isDone, let bsp = result.curve {
+      print("max error:", result.maxError)
+  }
+  ```
+
+---
+
+### `ApproxSurfaceResult`
+
+Result of surface approximation including the output surface, error, and status.
+
+```swift
+public struct ApproxSurfaceResult {
+    public let surface: Surface?
+    public let maxError: Double
+    public let isDone: Bool
+    public let hasResult: Bool
+}
+```
+
+---
+
+### `Surface.approxWithDetails(tolerance:uContinuity:vContinuity:maxDegree:maxSegments:)`
+
+Approximates a surface as a BSpline with detailed result information.
+
+```swift
+public func approxWithDetails(tolerance: Double, uContinuity: ApproxContinuity = .c1,
+                               vContinuity: ApproxContinuity = .c1,
+                               maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult
+```
+
+- **Parameters:**
+  - `tolerance` — maximum approximation deviation.
+  - `uContinuity` — desired continuity in U direction.
+  - `vContinuity` — desired continuity in V direction.
+  - `maxDegree` — maximum polynomial degree.
+  - `maxSegments` — maximum number of BSpline segments.
+- **Returns:** `ApproxSurfaceResult` with the output `Surface` (or `nil`), `maxError`, and status flags.
+- **OCCT:** `GeomConvert_ApproxSurface` via `OCCTGeomConvertApproxSurface`.
+- **Note:** Prefer `Surface.approximated(tolerance:continuity:maxSegments:maxDegree:)` for simpler use; use this variant when you need the error and status separately.
+- **Example:**
+  ```swift
+  let result = surface.approxWithDetails(tolerance: 0.001)
+  if result.isDone, let bsp = result.surface {
+      print("max error:", result.maxError)
+  }
+  ```
+
+---
+
+## GCPnts_QuasiUniformAbscissa
+
+### `Edge.quasiUniformParameters(count:)`
+
+Computes a quasi-uniform parameter distribution along an edge.
+
+```swift
+public func quasiUniformParameters(count: Int) -> [Double]
+```
+
+The returned parameters are distributed so that the chord lengths between consecutive curve points are approximately equal.
+
+- **Parameters:** `count` — desired number of parameter values.
+- **Returns:** Array of curve parameters of length ≤ `count`.
+- **OCCT:** `GCPnts_QuasiUniformAbscissa` via `OCCTGCPntsQuasiUniform`.
+- **Example:**
+  ```swift
+  let params = edge.quasiUniformParameters(count: 20)
+  // params has ~20 evenly-spaced (by chord) parameter values
+  ```
+
+---
+
+## GCPnts_TangentialDeflection
+
+### `TangentialDeflectionPoint`
+
+A sampled point from tangential deflection discretisation.
+
+```swift
+public struct TangentialDeflectionPoint {
+    public let parameter: Double
+    public let x: Double, y: Double, z: Double
+}
+```
+
+---
+
+### `Edge.tangentialDeflectionPoints(angularDeflection:curvatureDeflection:minPoints:)`
+
+Samples an edge using combined angular and chordal deflection criteria.
+
+```swift
+public func tangentialDeflectionPoints(angularDeflection: Double = 0.1,
+                                       curvatureDeflection: Double = 0.1,
+                                       minPoints: Int = 2) -> [TangentialDeflectionPoint]
+```
+
+This is the standard adaptive sampling algorithm used by OCCT's meshing pipeline; it produces denser samples where curvature is high.
+
+- **Parameters:**
+  - `angularDeflection` — maximum angular deviation between consecutive tangents (radians).
+  - `curvatureDeflection` — maximum chordal deviation (model units).
+  - `minPoints` — minimum number of sample points (must be ≥ 2).
+- **Returns:** Array of `TangentialDeflectionPoint` values (up to 10000).
+- **OCCT:** `GCPnts_TangentialDeflection` via `OCCTGCPntsTangentialDeflection`.
+- **Example:**
+  ```swift
+  let pts = edge.tangentialDeflectionPoints(angularDeflection: 0.05,
+                                             curvatureDeflection: 0.1)
+  for pt in pts {
+      print("t=\(pt.parameter): (\(pt.x), \(pt.y), \(pt.z))")
+  }
+  ```
+
+---
+
+## BRepGProp_Cinert (Curve Inertia per Edge)
+
+### `CurveInertia`
+
+Curve linear inertia properties (arc length and centre of mass).
+
+```swift
+public struct CurveInertia {
+    public let length: Double
+    public let centerX: Double, centerY: Double, centerZ: Double
+}
+```
+
+---
+
+### `Edge.curveInertia`
+
+Computes linear inertia (arc length and centre of mass) for this edge.
+
+```swift
+public var curveInertia: CurveInertia { get }
+```
+
+- **Returns:** `CurveInertia` with `length` and centre of mass coordinates.
+- **OCCT:** `BRepGProp_Cinert` via `OCCTBRepGPropCinert`.
+- **Example:**
+  ```swift
+  let inertia = edge.curveInertia
+  print("length:", inertia.length)
+  print("center:", inertia.centerX, inertia.centerY, inertia.centerZ)
+  ```
+
+---
+
+## BRepGProp_Sinert (Surface Inertia per Face)
+
+### `FaceSurfaceInertia`
+
+Face surface inertia properties (area and centre of mass).
+
+```swift
+public struct FaceSurfaceInertia {
+    public let area: Double
+    public let centerX: Double, centerY: Double, centerZ: Double
+    public let epsilon: Double
+}
+```
+
+`epsilon` is the integration error bound; it is `0` for the non-adaptive overload.
+
+---
+
+### `Face.surfaceInertia`
+
+Computes surface inertia (area and centre of mass) for this face.
+
+```swift
+public var surfaceInertia: FaceSurfaceInertia { get }
+```
+
+- **Returns:** `FaceSurfaceInertia` with `area` and centre of mass (`epsilon` = 0).
+- **OCCT:** `BRepGProp_Sinert` via `OCCTBRepGPropSinert`.
+- **Example:**
+  ```swift
+  let inertia = face.surfaceInertia
+  print("area:", inertia.area)
+  ```
+
+---
+
+### `Face.surfaceInertia(epsilon:)`
+
+Computes surface inertia using adaptive numerical integration to the given error bound.
+
+```swift
+public func surfaceInertia(epsilon: Double) -> FaceSurfaceInertia
+```
+
+- **Parameters:** `epsilon` — target integration error bound.
+- **Returns:** `FaceSurfaceInertia` with `area`, centre of mass, and actual `epsilon` achieved.
+- **OCCT:** `BRepGProp_Sinert` adaptive overload via `OCCTBRepGPropSinertAdaptive`.
+
+---
+
+## BRepGProp_Vinert (Volume Inertia per Face)
+
+### `FaceVolumeInertia`
+
+Face volume inertia contribution.
+
+```swift
+public struct FaceVolumeInertia {
+    public let volume: Double
+    public let centerX: Double, centerY: Double, centerZ: Double
+}
+```
+
+---
+
+### `Face.volumeInertia`
+
+Computes the volume inertia contribution from this face (relative to the origin).
+
+```swift
+public var volumeInertia: FaceVolumeInertia { get }
+```
+
+- **Returns:** `FaceVolumeInertia` with signed `volume` and centre of mass.
+- **OCCT:** `BRepGProp_Vinert` via `OCCTBRepGPropVinert`.
+- **Example:**
+  ```swift
+  let vi = face.volumeInertia
+  print("volume contribution:", vi.volume)
+  ```
+
+---
+
+### `Face.volumeInertia(planeNormal:planeDistance:)`
+
+Computes volume inertia with respect to a reference plane.
+
+```swift
+public func volumeInertia(planeNormal: SIMD3<Double>, planeDistance: Double = 0) -> FaceVolumeInertia
+```
+
+- **Parameters:**
+  - `planeNormal` — normal of the reference plane.
+  - `planeDistance` — signed distance from origin to the plane along `planeNormal`.
+- **Returns:** `FaceVolumeInertia` measured relative to the given plane.
+- **OCCT:** `BRepGProp_Vinert(face, gp_Pln)` via `OCCTBRepGPropVinertPlane`.
+
+---
+
+## ShapeConstruct_ProjectCurveOnSurface
+
+### `Curve3D.projectOnSurface(_:firstParam:lastParam:precision:)`
+
+Projects a 3D curve onto a surface, returning a 2D (UV) curve.
+
+```swift
+public func projectOnSurface(_ surface: Surface, firstParam: Double? = nil,
+                              lastParam: Double? = nil, precision: Double = 1e-6) -> Curve2D?
+```
+
+- **Parameters:**
+  - `surface` — target surface.
+  - `firstParam` — start of the curve parameter range (default: `domain.lowerBound`).
+  - `lastParam` — end of the curve parameter range (default: `domain.upperBound`).
+  - `precision` — projection tolerance.
+- **Returns:** A `Curve2D` in UV parameter space of the surface, or `nil` if projection fails.
+- **OCCT:** `ShapeConstruct_ProjectCurveOnSurface::Perform` via `OCCTProjectCurveOnSurface`.
+- **Example:**
+  ```swift
+  if let pcurve = curve3D.projectOnSurface(surface, precision: 1e-6) {
+      // pcurve is the 2D UV representation of curve3D on surface
+  }
+  ```
+
+---
+
+## BRepPreviewAPI_MakeBox
+
+### `Shape.previewBox(width:height:depth:)`
+
+Creates a preview box shape that handles degenerate dimensions gracefully.
+
+```swift
+public static func previewBox(width: Double, height: Double, depth: Double) -> Shape?
+```
+
+Unlike `Shape.box(width:height:depth:)`, this factory accepts degenerate inputs and returns the appropriate lower-dimensional shape: a box for fully 3D dimensions, a face for one zero dimension, an edge for two zero dimensions, or a vertex for all-zero dimensions.
+
+- **Parameters:** `width` — X dimension; `height` — Y dimension; `depth` — Z dimension.
+- **Returns:** A `Shape` (solid, face, edge, or vertex), or `nil` on failure.
+- **OCCT:** `BRepPreviewAPI_MakeBox` via `OCCTPreviewBox`.
+- **Example:**
+  ```swift
+  // Returns a Face (sheet) when depth is 0
+  if let sheet = Shape.previewBox(width: 10, height: 5, depth: 0) {
+      print(sheet.shapeType)  // .face
+  }
+  ```
+
+---
+
+## GeomPoint3D (Geom_CartesianPoint)
+
+### `GeomPoint3D`
+
+A Handle-managed 3D geometric point, wrapping `Geom_CartesianPoint`.
+
+```swift
+public final class GeomPoint3D: @unchecked Sendable
+```
+
+Useful when you need OCCT's geometry-level point entity (rather than a raw `SIMD3<Double>`) for operations that take `Handle(Geom_Point)` arguments.
+
+---
+
+### `GeomPoint3D.init(x:y:z:)`
+
+Creates a geometric point at the given coordinates.
+
+```swift
+public init(x: Double, y: Double, z: Double)
+```
+
+- **OCCT:** `Geom_CartesianPoint(x, y, z)` via `OCCTGeomPoint3DCreate`.
+
+---
+
+### `GeomPoint3D.init(simd:)`
+
+Creates a geometric point from a `SIMD3<Double>`.
+
+```swift
+public init(simd: SIMD3<Double>)
+```
+
+---
+
+### `x`, `y`, `z`
+
+The Cartesian coordinates of this point.
+
+```swift
+public var x: Double { get }
+public var y: Double { get }
+public var z: Double { get }
+```
+
+- **OCCT:** `Geom_CartesianPoint::X`, `Y`, `Z`.
+
+---
+
+### `coordinates`
+
+The coordinates as a `SIMD3<Double>`.
+
+```swift
+public var coordinates: SIMD3<Double> { get }
+```
+
+---
+
+### `setCoordinates(x:y:z:)`
+
+Sets the point coordinates.
+
+```swift
+public func setCoordinates(x: Double, y: Double, z: Double)
+```
+
+- **OCCT:** `Geom_CartesianPoint::SetCoord` via `OCCTGeomPoint3DSetCoord`.
+
+---
+
+### `distance(to:)`
+
+Returns the Euclidean distance to another geometric point.
+
+```swift
+public func distance(to other: GeomPoint3D) -> Double
+```
+
+- **OCCT:** `Geom_Point::Distance` via `OCCTGeomPoint3DDistance`.
+- **Example:**
+  ```swift
+  let a = GeomPoint3D(x: 0, y: 0, z: 0)
+  let b = GeomPoint3D(x: 3, y: 4, z: 0)
+  print(a.distance(to: b))  // 5.0
+  ```
+
+---
+
+### `squareDistance(to:)`
+
+Returns the squared Euclidean distance to another geometric point.
+
+```swift
+public func squareDistance(to other: GeomPoint3D) -> Double
+```
+
+- **OCCT:** `Geom_Point::SquareDistance` via `OCCTGeomPoint3DSquareDistance`.
+
+---
+
+### `translate(dx:dy:dz:)`
+
+Translates this point in place.
+
+```swift
+public func translate(dx: Double, dy: Double, dz: Double)
+```
+
+- **OCCT:** `Geom_CartesianPoint::Translate(gp_Vec)` via `OCCTGeomPoint3DTranslate`.
+
+---
+
+## GeomDirection (Geom_Direction)
+
+### `GeomDirection`
+
+A Handle-managed 3D unit vector (always normalised), wrapping `Geom_Direction`.
+
+```swift
+public final class GeomDirection: @unchecked Sendable
+```
+
+The input vector is automatically normalised on construction. Use this when downstream OCCT APIs require a `Handle(Geom_Direction)`.
+
+---
+
+### `GeomDirection.init(x:y:z:)`
+
+Creates a unit direction from component values. The vector is normalised automatically.
+
+```swift
+public init(x: Double, y: Double, z: Double)
+```
+
+- **OCCT:** `Geom_Direction(x, y, z)` via `OCCTGeomDirectionCreate`.
+- **Example:**
+  ```swift
+  let up = GeomDirection(x: 0, y: 0, z: 1)
+  ```
+
+---
+
+### `GeomDirection.init(simd:)`
+
+Creates a unit direction from a `SIMD3<Double>`.
+
+```swift
+public init(simd: SIMD3<Double>)
+```
+
+---
+
+### `coordinates`
+
+The unit vector as a `SIMD3<Double>`.
+
+```swift
+public var coordinates: SIMD3<Double> { get }
+```
+
+- **OCCT:** `Geom_Direction::X`, `Y`, `Z` via `OCCTGeomDirectionCoords`.
+
+---
+
+### `setCoordinates(x:y:z:)`
+
+Sets the direction; the new vector is automatically normalised.
+
+```swift
+public func setCoordinates(x: Double, y: Double, z: Double)
+```
+
+- **OCCT:** `Geom_Direction::SetCoord` via `OCCTGeomDirectionSetCoord`.
+
+---
+
+### `crossed(with:)`
+
+Returns the cross product with another direction.
+
+```swift
+public func crossed(with other: GeomDirection) -> GeomDirection?
+```
+
+- **Returns:** A new `GeomDirection` perpendicular to both, or `nil` if the vectors are parallel (cross product is zero).
+- **OCCT:** `Geom_Direction::Cross` via `OCCTGeomDirectionCrossed`.
+- **Example:**
+  ```swift
+  let x = GeomDirection(x: 1, y: 0, z: 0)
+  let y = GeomDirection(x: 0, y: 1, z: 0)
+  if let z = x.crossed(with: y) {
+      print(z.coordinates)  // SIMD3(0, 0, 1)
+  }
+  ```
+
+---
+
+## GeomVector3D (Geom_VectorWithMagnitude)
+
+### `GeomVector3D`
+
+A Handle-managed 3D vector with arbitrary magnitude, wrapping `Geom_VectorWithMagnitude`. Unlike `GeomDirection`, the vector may have any non-negative length including zero.
+
+```swift
+public final class GeomVector3D: @unchecked Sendable
+```
+
+---
+
+### `GeomVector3D.init(x:y:z:)`
+
+Creates a vector from component values.
+
+```swift
+public init(x: Double, y: Double, z: Double)
+```
+
+- **OCCT:** `Geom_VectorWithMagnitude(x, y, z)` via `OCCTGeomVector3DCreate`.
+
+---
+
+### `GeomVector3D.init(simd:)`
+
+Creates a vector from a `SIMD3<Double>`.
+
+```swift
+public init(simd: SIMD3<Double>)
+```
+
+---
+
+### `GeomVector3D.init(from:to:)`
+
+Creates a vector from point `p1` to point `p2`.
+
+```swift
+public init(from p1: SIMD3<Double>, to p2: SIMD3<Double>)
+```
+
+- **OCCT:** `Geom_VectorWithMagnitude(p1, p2)` via `OCCTGeomVector3DFromPoints`.
+- **Example:**
+  ```swift
+  let v = GeomVector3D(from: SIMD3(0, 0, 0), to: SIMD3(3, 4, 0))
+  print(v.magnitude)  // 5.0
+  ```
+
+---
+
+### `coordinates`
+
+The vector components as a `SIMD3<Double>`.
+
+```swift
+public var coordinates: SIMD3<Double> { get }
+```
+
+- **OCCT:** `Geom_Vector::X`, `Y`, `Z` via `OCCTGeomVector3DCoords`.
+
+---
+
+### `magnitude`
+
+The Euclidean length of this vector.
+
+```swift
+public var magnitude: Double { get }
+```
+
+- **OCCT:** `Geom_Vector::Magnitude` via `OCCTGeomVector3DMagnitude`.
+
+---
+
+### `dot(_:)`
+
+Dot product with another vector.
+
+```swift
+public func dot(_ other: GeomVector3D) -> Double
+```
+
+- **OCCT:** `Geom_Vector::Dot` via `OCCTGeomVector3DDot`.
+
+---
+
+### `added(_:)`
+
+Returns the sum of this vector and another.
+
+```swift
+public func added(_ other: GeomVector3D) -> GeomVector3D
+```
+
+- **OCCT:** `Geom_Vector::Added` via `OCCTGeomVector3DAdded`.
+
+---
+
+### `multiplied(by:)`
+
+Returns this vector scaled by a scalar.
+
+```swift
+public func multiplied(by scalar: Double) -> GeomVector3D
+```
+
+- **OCCT:** `Geom_VectorWithMagnitude::Multiplied` via `OCCTGeomVector3DMultiplied`.
+
+---
+
+### `normalized()`
+
+Returns a normalised copy of this vector.
+
+```swift
+public func normalized() -> GeomVector3D?
+```
+
+- **Returns:** Unit vector in the same direction, or `nil` if `magnitude` is near zero.
+- **OCCT:** `Geom_VectorWithMagnitude::Normalized` via `OCCTGeomVector3DNormalized`.
+- **Example:**
+  ```swift
+  let v = GeomVector3D(x: 3, y: 4, z: 0)
+  if let u = v.normalized() {
+      print(u.magnitude)  // ~1.0
+  }
+  ```
+
+---
+
+### `crossed(_:)`
+
+Returns the cross product with another vector.
+
+```swift
+public func crossed(_ other: GeomVector3D) -> GeomVector3D
+```
+
+- **Returns:** A new `GeomVector3D` perpendicular to both inputs.
+- **OCCT:** `Geom_VectorWithMagnitude::Crossed` via `OCCTGeomVector3DCrossed`.
+
+---
+
+## Axis1Placement (Geom_Axis1Placement)
+
+### `Axis1Placement`
+
+A Handle-managed 3D axis (origin point + direction), wrapping `Geom_Axis1Placement`. Used as a placement entity for geometry operations that require an `Axis1`.
+
+```swift
+public final class Axis1Placement: @unchecked Sendable
+```
+
+---
+
+### `Axis1Placement.init(origin:direction:)`
+
+Creates an axis placement from an origin point and a direction vector.
+
+```swift
+public init(origin: SIMD3<Double>, direction: SIMD3<Double>)
+```
+
+- **Parameters:** `origin` — the axis origin point; `direction` — the axis direction (normalised internally).
+- **OCCT:** `Geom_Axis1Placement(gp_Pnt, gp_Dir)` via `OCCTAxis1PlacementCreate`.
+- **Example:**
+  ```swift
+  let axis = Axis1Placement(origin: .zero, direction: SIMD3(0, 0, 1))
+  ```
+
+---
+
+### `location`
+
+The origin point of the axis.
+
+```swift
+public var location: SIMD3<Double> { get }
+```
+
+- **OCCT:** `Geom_Axis1Placement::Location` via `OCCTAxis1PlacementLocation`.
+
+---
+
+### `direction`
+
+The unit direction of the axis.
+
+```swift
+public var direction: SIMD3<Double> { get }
+```
+
+- **OCCT:** `Geom_Axis1Placement::Direction` via `OCCTAxis1PlacementDirection`.
+
+---
+
+### `reverse()`
+
+Reverses the axis direction in place.
+
+```swift
+public func reverse()
+```
+
+- **OCCT:** `Geom_Axis1Placement::Reverse` via `OCCTAxis1PlacementReverse`.
+
+---
+
+### `reversed()`
+
+Returns a new axis with the direction reversed.
+
+```swift
+public func reversed() -> Axis1Placement
+```
+
+- **Returns:** A new `Axis1Placement` with the same origin and the direction negated.
+- **OCCT:** `Geom_Axis1Placement::Reversed` via `OCCTAxis1PlacementReversed`.
+- **Example:**
+  ```swift
+  let axis = Axis1Placement(origin: .zero, direction: SIMD3(0, 0, 1))
+  let flipped = axis.reversed()
+  print(flipped.direction)  // SIMD3(0, 0, -1)
+  ```
+
+---
+
+### `setDirection(_:)`
+
+Sets the axis direction.
+
+```swift
+public func setDirection(_ dir: SIMD3<Double>)
+```
+
+- **OCCT:** `Geom_Axis1Placement::SetDirection` via `OCCTAxis1PlacementSetDirection`.
+
+---
+
+### `setLocation(_:)`
+
+Sets the axis origin point.
+
+```swift
+public func setLocation(_ loc: SIMD3<Double>)
+```
+
+- **OCCT:** `Geom_Axis1Placement::SetLocation` via `OCCTAxis1PlacementSetLocation`.

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -1,0 +1,2055 @@
+---
+title: Shape — Healing, Recognition & Feature Ops
+parent: API Reference
+---
+
+# Shape — Healing, Recognition & Feature Ops
+
+This page covers geometry repair, shape upgrade, point classification, proximity, wedge and half-space primitives, sub-shape manipulation, periodic shapes, draft, non-uniform scale, shell/vertex creation, offset, edge fusion, volume building, canonical recognition, wireframe fixing, boolean validation, splits, multi-tool booleans, feature operations, and per-input boolean history for [`Shape`](Shape.md). For core creation, transforms, and mesh operations see the main `Shape` page (todo).
+
+## Topics
+
+- [Advanced Healing](#advanced-healing) · [Point Classification](#point-classification) · [Shape Proximity](#shape-proximity) · [Wedge Primitive](#wedge-primitive) · [NURBS Conversion](#nurbs-conversion) · [Fast Sewing](#fast-sewing) · [Normal Projection](#normal-projection) · [Half-Space](#half-space) · [Sub-Shape Replacement](#sub-shape-replacement) · [Periodic Shapes](#periodic-shapes) · [Draft from Shape](#draft-from-shape) · [Non-Uniform Scale](#non-uniform-scale) · [Shell & Vertex Creation](#shell--vertex-creation) · [Simple Offset](#simple-offset) · [Middle Path](#middle-path) · [Fuse Edges](#fuse-edges) · [Volume from Faces](#volume-from-faces) · [Shape Contents](#shape-contents) · [Canonical Recognition](#canonical-recognition) · [Find Surface](#find-surface) · [Fix Wireframe](#fix-wireframe) · [Remove Internal Wires](#remove-internal-wires) · [Contiguous Edges](#contiguous-edges) · [Quilt Faces](#quilt-faces) · [Fix Small Faces](#fix-small-faces) · [Remove Locations](#remove-locations) · [Revolution from Curve](#revolution-from-curve) · [Linear Rib Feature](#linear-rib-feature) · [Revolution Form Feature](#revolution-form-feature) · [Draft Prism Feature](#draft-prism-feature) · [Revolution Feature](#revolution-feature) · [Face from Surface](#face-from-surface) · [Edges to Faces](#edges-to-faces) · [Shape-to-Shape Section](#shape-to-shape-section) · [Boolean Pre-Validation](#boolean-pre-validation) · [Split Shape by Wire](#split-shape-by-wire) · [Split by Angle](#split-by-angle) · [Drop Small Edges](#drop-small-edges) · [Multi-Tool Boolean Fuse](#multi-tool-boolean-fuse) · [Multi-Offset Wire](#multi-offset-wire) · [Cylindrical Projection](#cylindrical-projection) · [Same Parameter](#same-parameter) · [Conical Projection](#conical-projection) · [Encode Regularity](#encode-regularity) · [Update Tolerances](#update-tolerances) · [Divide by Number](#divide-by-number) · [Boolean with History](#boolean-with-history)
+
+---
+
+## Advanced Healing
+
+### `GeometricContinuity`
+
+Target continuity level for shape divide operations.
+
+```swift
+public enum GeometricContinuity: Int32, Sendable {
+    case c0 = 0
+    case c1 = 1
+    case c2 = 2
+    case c3 = 3
+}
+```
+
+Pass to `divided(at:)` to split a shape at discontinuities of the specified geometric continuity.
+
+---
+
+### `divided(at:)`
+
+Divide a shape at continuity discontinuities.
+
+```swift
+public func divided(at continuity: GeometricContinuity) -> Shape?
+```
+
+Splits the shape wherever its underlying geometry drops below the requested continuity class.
+
+- **Parameters:** `continuity` — target minimum continuity; the shape is split at any face/edge boundary that does not meet this standard.
+- **Returns:** Divided shape, or nil on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideContinuity` (via `OCCTShapeDivide`).
+- **Example:**
+  ```swift
+  if let divided = myShape.divided(at: .c1) {
+      // faces now have at least C1 continuity boundaries
+  }
+  ```
+
+---
+
+### `directFaces()`
+
+Convert geometry to direct faces (canonical surfaces).
+
+```swift
+public func directFaces() -> Shape?
+```
+
+Applies `ShapeCustom_DirectModification` to replace indirect or offset surface references with direct canonical geometry, normalising outward face normals.
+
+- **Returns:** Shape with canonical surfaces, or nil on failure.
+- **OCCT:** `ShapeCustom_DirectModification` (via `OCCTShapeDirectFaces`).
+- **Example:**
+  ```swift
+  if let direct = imported.directFaces() {
+      // surfaces are now stored directly, not via references
+  }
+  ```
+
+---
+
+### `scaledGeometry(factor:)`
+
+Scale shape geometry by a factor.
+
+```swift
+public func scaledGeometry(factor: Double) -> Shape?
+```
+
+Unlike `scaled(by:)` which applies a topological `gp_Trsf`, this modifies the underlying curve and surface pole coordinates directly.
+
+- **Parameters:** `factor` — uniform scale factor applied to all geometry definitions.
+- **Returns:** Scaled shape, or nil on failure.
+- **OCCT:** `ShapeCustom_TrsfModification` (via `OCCTShapeScaleGeometry`).
+- **Example:**
+  ```swift
+  if let mmShape = inchShape.scaledGeometry(factor: 25.4) {
+      // geometry converted from inches to millimetres
+  }
+  ```
+
+---
+
+### `bsplineRestriction(surfaceTolerance:curveTolerance:maxDegree:maxSegments:)`
+
+Convert BSpline surfaces to their closest analytical form.
+
+```swift
+public func bsplineRestriction(surfaceTolerance: Double = 0.01,
+                               curveTolerance: Double = 0.01,
+                               maxDegree: Int = 9,
+                               maxSegments: Int = 10000) -> Shape?
+```
+
+Attempts to simplify BSpline surfaces to planes, cylinders, cones, spheres, or tori within the supplied tolerances. Surfaces that cannot be recognised remain as BSplines with degree and segment count capped at the supplied limits.
+
+- **Parameters:**
+  - `surfaceTolerance` — maximum allowable deviation for surface approximation (default 0.01).
+  - `curveTolerance` — maximum allowable deviation for curve approximation (default 0.01).
+  - `maxDegree` — maximum BSpline degree to allow (default 9).
+  - `maxSegments` — maximum number of BSpline segments (default 10000).
+- **Returns:** Shape with restricted BSplines, or nil on failure.
+- **OCCT:** `ShapeCustom_BSplineRestriction` (via `OCCTShapeBSplineRestriction`).
+- **Example:**
+  ```swift
+  if let simplified = imported.bsplineRestriction(surfaceTolerance: 0.001, curveTolerance: 0.001) {
+      print(simplified.contents.faces)
+  }
+  ```
+
+---
+
+### `sweptToElementary()`
+
+Convert swept surfaces to elementary (canonical) surfaces.
+
+```swift
+public func sweptToElementary() -> Shape?
+```
+
+Recognises surfaces of extrusion and revolution that degenerate into planes, cylinders, cones, spheres, or tori, and replaces them with the exact canonical form.
+
+- **Returns:** Shape with elementary surfaces, or nil on failure.
+- **OCCT:** `ShapeCustom_SweptToElementary` (via `OCCTShapeSweptToElementary`).
+- **Example:**
+  ```swift
+  if let canonical = swept.sweptToElementary() {
+      // cylindrical extrusion is now a true Geom_CylindricalSurface
+  }
+  ```
+
+---
+
+### `revolutionToElementary()`
+
+Convert surfaces of revolution to elementary surfaces.
+
+```swift
+public func revolutionToElementary() -> Shape?
+```
+
+Similar to `sweptToElementary()` but targets only surfaces of revolution.
+
+- **Returns:** Shape with elementary surfaces, or nil on failure.
+- **OCCT:** `ShapeCustom_SweptToElementary` (via `OCCTShapeRevolutionToElementary`).
+- **Example:**
+  ```swift
+  if let canonical = importedRevol.revolutionToElementary() { }
+  ```
+
+---
+
+### `convertedToBSpline()`
+
+Convert all surfaces to BSpline representation.
+
+```swift
+public func convertedToBSpline() -> Shape?
+```
+
+Replaces every analytic and swept surface with an equivalent BSpline/NURBS form. Useful for export to systems that only handle polynomial geometry.
+
+- **Returns:** Shape with BSpline surfaces, or nil on failure.
+- **OCCT:** `ShapeCustom_BSplineRestriction` / `BRepBuilderAPI_NurbsConvert` (via `OCCTShapeConvertToBSpline`).
+- **Example:**
+  ```swift
+  if let bspline = solid.convertedToBSpline() {
+      // all faces backed by Geom_BSplineSurface
+  }
+  ```
+
+---
+
+### `sewn(tolerance:)`
+
+Sew disconnected faces in this shape together.
+
+```swift
+public func sewn(tolerance: Double = 1e-6) -> Shape?
+```
+
+Applies `BRepBuilderAPI_Sewing` to merge near-coincident edges and produce a closed shell or solid.
+
+- **Parameters:** `tolerance` — sewing tolerance; edges closer than this distance are merged (default 1e-6).
+- **Returns:** Sewn shape, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Sewing` (via `OCCTShapeSewSingle`).
+- **Example:**
+  ```swift
+  if let shell = faceCompound.sewn(tolerance: 1e-4) { }
+  ```
+
+---
+
+### `upgraded(tolerance:)`
+
+Upgrade shape: sew + make solid + heal pipeline.
+
+```swift
+public func upgraded(tolerance: Double = 1e-6) -> Shape?
+```
+
+Applies a complete upgrade pipeline: sewing of disconnected faces, an attempt to build a solid from the resulting shells, and a final `ShapeFix_Shape` healing pass.
+
+- **Parameters:** `tolerance` — tolerance used for sewing and healing (default 1e-6).
+- **Returns:** Upgraded shape, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTShapeUpgrade`).
+- **Example:**
+  ```swift
+  if let solid = roughImport.upgraded(tolerance: 0.01) {
+      #expect(solid.isValid)
+  }
+  ```
+
+---
+
+## Point Classification
+
+### `PointClassification`
+
+Classification of a point relative to a shape or face.
+
+```swift
+public enum PointClassification: Int32, Sendable {
+    case inside    = 0   // TopAbs_IN
+    case outside   = 1   // TopAbs_OUT
+    case onBoundary = 2  // TopAbs_ON
+    case unknown   = 3   // TopAbs_UNKNOWN
+}
+```
+
+---
+
+### `Shape.classify(point:tolerance:)`
+
+Classify a point relative to this solid.
+
+```swift
+public func classify(point: SIMD3<Double>, tolerance: Double = 1e-6) -> PointClassification
+```
+
+Determines whether a 3D point is inside, outside, or on the boundary of this shape. The shape should be a closed solid for reliable results.
+
+- **Parameters:**
+  - `point` — the 3D world-space point to classify.
+  - `tolerance` — boundary-detection tolerance (default 1e-6).
+- **Returns:** `.inside`, `.outside`, `.onBoundary`, or `.unknown`.
+- **OCCT:** `BRepClass3d_SolidClassifier` (via `OCCTClassifyPointInSolid`).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let result = box.classify(point: SIMD3(5, 5, 5))
+  #expect(result == .inside)
+  ```
+
+---
+
+### `Face.classify(point:tolerance:)`
+
+Classify a point relative to this face using a 3D point.
+
+```swift
+public func classify(point: SIMD3<Double>, tolerance: Double = 1e-6) -> PointClassification
+```
+
+Projects the 3D point to the face's surface and tests whether the resulting UV coordinate lies inside the face boundary.
+
+- **Parameters:**
+  - `point` — 3D point to classify.
+  - `tolerance` — boundary-detection tolerance (default 1e-6).
+- **Returns:** `.inside`, `.outside`, `.onBoundary`, or `.unknown`.
+- **OCCT:** `BRepClass_FaceClassifier` (via `OCCTClassifyPointOnFace`).
+- **Example:**
+  ```swift
+  let face: Face = ...
+  let cls = face.classify(point: SIMD3(1, 1, 0))
+  ```
+
+---
+
+### `Face.classify(u:v:tolerance:)`
+
+Classify a point relative to this face using UV parameters.
+
+```swift
+public func classify(u: Double, v: Double, tolerance: Double = 1e-6) -> PointClassification
+```
+
+Tests the given parametric UV coordinate directly against the face boundary — faster than the 3D overload when UV is already known.
+
+- **Parameters:**
+  - `u` — U parameter on the face's surface.
+  - `v` — V parameter on the face's surface.
+  - `tolerance` — boundary-detection tolerance (default 1e-6).
+- **Returns:** `.inside`, `.outside`, `.onBoundary`, or `.unknown`.
+- **OCCT:** `BRepClass_FaceClassifier` (via `OCCTClassifyPointOnFaceUV`).
+- **Example:**
+  ```swift
+  let face: Face = ...
+  let cls = face.classify(u: 0.5, v: 0.5)
+  ```
+
+---
+
+## Shape Proximity
+
+### `FaceProximityPair`
+
+A pair of face indices detected as near-miss (within tolerance).
+
+```swift
+public struct FaceProximityPair: Sendable {
+    public let face1Index: Int
+    public let face2Index: Int
+}
+```
+
+Each instance identifies one pair of faces — one from `self`, one from `other` — that lie within the supplied tolerance. Indices refer to the face-iteration order of the respective shape.
+
+---
+
+### `proximityFaces(with:tolerance:deflection:)`
+
+Detect face pairs between this shape and another that are within tolerance.
+
+```swift
+public func proximityFaces(with other: Shape, tolerance: Double, deflection: Double = 0.1) -> [FaceProximityPair]
+```
+
+Triangulates both shapes and tests proximity using `BRepExtrema_ShapeProximity`.
+
+- **Parameters:**
+  - `other` — the second shape to test against.
+  - `tolerance` — maximum gap distance for a pair to be reported.
+  - `deflection` — linear mesh deflection for proximity triangulation (default 0.1 mm).
+- **Returns:** Array of `FaceProximityPair`; may be empty.
+- **OCCT:** `BRepExtrema_ShapeProximity` (via `OCCTShapeProximity`).
+- **Example:**
+  ```swift
+  let pairs = partA.proximityFaces(with: partB, tolerance: 0.5)
+  for p in pairs {
+      print("face \(p.face1Index) ↔ face \(p.face2Index)")
+  }
+  ```
+
+---
+
+### `selfIntersects`
+
+Check if this shape self-intersects.
+
+```swift
+public var selfIntersects: Bool { get }
+```
+
+- **Returns:** `true` if the shape has self-intersecting faces.
+- **OCCT:** `BOPAlgo_CheckerSI` (via `OCCTShapeSelfIntersects`).
+- **Example:**
+  ```swift
+  if shape.selfIntersects {
+      // apply healing before booleans
+  }
+  ```
+
+---
+
+## Wedge Primitive
+
+### `Shape.wedge(dx:dy:dz:ltx:)`
+
+Create a wedge (tapered box).
+
+```swift
+public static func wedge(dx: Double, dy: Double, dz: Double, ltx: Double) -> Shape?
+```
+
+A wedge is a box whose top face is narrowed in the X direction. When `ltx == dx` the result is a regular box; when `ltx == 0` the result is a pyramid.
+
+- **Parameters:**
+  - `dx` — width in X.
+  - `dy` — height in Y.
+  - `dz` — depth in Z.
+  - `ltx` — width of the top face in X (0 to dx).
+- **Returns:** Wedge solid, or nil if parameters are invalid (any dimension ≤ 0 or `ltx` < 0).
+- **OCCT:** `BRepPrimAPI_MakeWedge` (via `OCCTShapeCreateWedge`).
+- **Example:**
+  ```swift
+  if let wedge = Shape.wedge(dx: 10, dy: 5, dz: 8, ltx: 4) { }
+  ```
+
+---
+
+### `Shape.wedge(dx:dy:dz:xmin:zmin:xmax:zmax:)`
+
+Create an advanced wedge with custom top-face bounds.
+
+```swift
+public static func wedge(dx: Double, dy: Double, dz: Double,
+                         xmin: Double, zmin: Double,
+                         xmax: Double, zmax: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `dx`, `dy`, `dz` — box dimensions.
+  - `xmin`, `zmin`, `xmax`, `zmax` — top face bounds within the XZ plane of the box.
+- **Returns:** Wedge solid, or nil on failure.
+- **OCCT:** `BRepPrimAPI_MakeWedge` (via `OCCTShapeCreateWedgeAdvanced`).
+- **Example:**
+  ```swift
+  if let w = Shape.wedge(dx: 10, dy: 5, dz: 8, xmin: 2, zmin: 1, xmax: 8, zmax: 7) { }
+  ```
+
+---
+
+### `Shape.wedge(at:direction:dx:dy:dz:ltx:)`
+
+Create an oriented wedge at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func wedge(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    dx: Double, dy: Double, dz: Double,
+    ltx: Double
+) -> Shape?
+```
+
+- **Parameters:**
+  - `origin` — corner point of the wedge.
+  - `direction` — axis direction for the wedge height (normalised internally).
+  - `dx`, `dy`, `dz` — dimensions in the local frame.
+  - `ltx` — width of top face in X (0 to dx).
+- **Returns:** Wedge solid, or nil on failure.
+- **OCCT:** `BRepPrimAPI_MakeWedge` (via `OCCTShapeCreateWedgeOriented`).
+- **Example:**
+  ```swift
+  if let w = Shape.wedge(at: SIMD3(0, 0, 5), direction: SIMD3(0, 0, 1),
+                         dx: 10, dy: 5, dz: 8, ltx: 4) { }
+  ```
+
+---
+
+## NURBS Conversion
+
+### `convertedToNURBS()`
+
+Convert all curves and surfaces to NURBS representation.
+
+```swift
+public func convertedToNURBS() -> Shape?
+```
+
+Ensures uniform polynomial representation before export or for algorithms that require NURBS geometry (e.g. certain CAM kernels).
+
+- **Returns:** Shape with all geometry as NURBS, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_NurbsConvert` (via `OCCTShapeConvertToNURBS`).
+- **Example:**
+  ```swift
+  if let nurbs = solid.convertedToNURBS() {
+      // export to a NURBS-only format
+  }
+  ```
+
+---
+
+## Fast Sewing
+
+### `fastSewn(tolerance:)`
+
+Sew faces using the fast sewing algorithm.
+
+```swift
+public func fastSewn(tolerance: Double = 1e-6) -> Shape?
+```
+
+Faster than `sewn(tolerance:)` for large models with many faces, but handles fewer edge cases (non-manifold topology, very irregular gaps).
+
+- **Parameters:** `tolerance` — sewing tolerance (default 1e-6).
+- **Returns:** Sewn shape, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_FastSewing` (via `OCCTShapeFastSewn`).
+- **Example:**
+  ```swift
+  if let shell = largeFaceSoup.fastSewn(tolerance: 1e-4) { }
+  ```
+
+---
+
+## Normal Projection
+
+### `normalProjection(of:tolerance3D:tolerance2D:maxDegree:maxSegments:)`
+
+Project a wire or edge onto this shape along surface normals.
+
+```swift
+public func normalProjection(of wireOrEdge: Shape,
+                              tolerance3D: Double = 1e-4,
+                              tolerance2D: Double = 1e-5,
+                              maxDegree: Int = 14,
+                              maxSegments: Int = 16) -> Shape?
+```
+
+Projects `wireOrEdge` onto `self` along the normal of the nearest surface face, producing a wire that lies exactly on the surface. The result is approximated as BSplines within the given tolerances.
+
+- **Parameters:**
+  - `wireOrEdge` — the wire or edge `Shape` to project.
+  - `tolerance3D` — 3D approximation tolerance (default 1e-4).
+  - `tolerance2D` — 2D (parametric) approximation tolerance (default 1e-5).
+  - `maxDegree` — maximum BSpline degree for the result (default 14).
+  - `maxSegments` — maximum BSpline segments (default 16).
+- **Returns:** Projected shape (compound of wires), or nil on failure.
+- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeNormalProjection`).
+- **Example:**
+  ```swift
+  let logo: Shape = ...  // a planar wire
+  if let onSurface = cylinder.normalProjection(of: logo) { }
+  ```
+
+---
+
+## Half-Space
+
+### `Shape.halfSpace(face:referencePoint:)`
+
+Create a half-space solid from a face.
+
+```swift
+public static func halfSpace(face: Shape, referencePoint: SIMD3<Double>) -> Shape?
+```
+
+A half-space is an infinite solid bounded by the dividing face. The reference point indicates which side of the face is considered "solid."
+
+- **Parameters:**
+  - `face` — a `Shape` containing the dividing face.
+  - `referencePoint` — a point on the desired solid side of the face.
+- **Returns:** Half-space solid, or nil on failure.
+- **OCCT:** `BRepPrimAPI_MakeHalfSpace` (via `OCCTShapeCreateHalfSpace`).
+- **Example:**
+  ```swift
+  let plane = Shape.face(from: Surface.plane(origin: .zero, normal: SIMD3(0,0,1))!,
+                         uRange: -100...100, vRange: -100...100)!
+  if let upper = Shape.halfSpace(face: plane, referencePoint: SIMD3(0, 0, 1)) { }
+  ```
+
+---
+
+## Sub-Shape Replacement
+
+### `replacingSubShape(_:with:)`
+
+Replace a sub-shape within this shape.
+
+```swift
+public func replacingSubShape(_ oldSubShape: Shape, with newSubShape: Shape) -> Shape?
+```
+
+- **Parameters:**
+  - `oldSubShape` — the sub-shape to replace (face, edge, vertex, etc.).
+  - `newSubShape` — the replacement sub-shape of the same type.
+- **Returns:** Modified shape, or nil on failure.
+- **OCCT:** `BRepTools_ReShape` (via `OCCTShapeReplaceSubShape`).
+- **Example:**
+  ```swift
+  if let modified = compound.replacingSubShape(oldFace, with: newFace) { }
+  ```
+
+---
+
+### `removingSubShape(_:)`
+
+Remove a sub-shape from this shape.
+
+```swift
+public func removingSubShape(_ subShape: Shape) -> Shape?
+```
+
+- **Parameters:** `subShape` — the sub-shape to remove.
+- **Returns:** Modified shape, or nil on failure.
+- **OCCT:** `BRepTools_ReShape` (via `OCCTShapeRemoveSubShape`).
+- **Example:**
+  ```swift
+  if let cleaned = compound.removingSubShape(unwantedFace) { }
+  ```
+
+---
+
+## Periodic Shapes
+
+### `makePeriodic(xPeriod:yPeriod:zPeriod:)`
+
+Make this shape periodic in one or more directions.
+
+```swift
+public func makePeriodic(xPeriod: Double? = nil,
+                          yPeriod: Double? = nil,
+                          zPeriod: Double? = nil) -> Shape?
+```
+
+- **Parameters:**
+  - `xPeriod` — period in X, or nil for no periodicity in X.
+  - `yPeriod` — period in Y, or nil for no periodicity in Y.
+  - `zPeriod` — period in Z, or nil for no periodicity in Z.
+- **Returns:** Periodic shape, or nil on failure.
+- **OCCT:** `BOPAlgo_MakePeriodic` (via `OCCTShapeMakePeriodic`).
+- **Example:**
+  ```swift
+  if let lattice = cell.makePeriodic(xPeriod: 5.0, yPeriod: 5.0) { }
+  ```
+
+---
+
+### `repeated(xPeriod:xCount:yPeriod:yCount:zPeriod:zCount:)`
+
+Repeat this shape periodically in one or more directions.
+
+```swift
+public func repeated(xPeriod: Double? = nil, xCount: Int = 0,
+                      yPeriod: Double? = nil, yCount: Int = 0,
+                      zPeriod: Double? = nil, zCount: Int = 0) -> Shape?
+```
+
+- **Parameters:**
+  - `xPeriod` — period in X (nil = no repetition in X).
+  - `xCount` — number of repetitions along X.
+  - `yPeriod`, `yCount` — period and count in Y.
+  - `zPeriod`, `zCount` — period and count in Z.
+- **Returns:** Repeated shape, or nil on failure.
+- **OCCT:** `BOPAlgo_MakePeriodic` (via `OCCTShapeRepeat`).
+- **Example:**
+  ```swift
+  if let grid = cell.repeated(xPeriod: 5, xCount: 4, yPeriod: 5, yCount: 3) { }
+  ```
+
+---
+
+## Draft from Shape
+
+### `draft(direction:angle:length:)`
+
+Create a draft shell by sweeping this shape along a direction with a taper angle.
+
+```swift
+public func draft(direction: SIMD3<Double>, angle: Double, length: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `direction` — draft direction vector.
+  - `angle` — taper angle in radians.
+  - `length` — maximum draft length.
+- **Returns:** Draft shell shape, or nil on failure.
+- **OCCT:** `BRepOffsetAPI_MakeDraft` (via `OCCTShapeMakeDraft`).
+- **Example:**
+  ```swift
+  if let drafted = profile.draft(direction: SIMD3(0, 0, -1), angle: 0.05, length: 20) { }
+  ```
+
+---
+
+## Non-Uniform Scale
+
+### `nonUniformScaled(sx:sy:sz:)`
+
+Scale this shape non-uniformly along each axis.
+
+```swift
+public func nonUniformScaled(sx: Double, sy: Double, sz: Double) -> Shape?
+```
+
+Unlike `scaled(by:)` (uniform), this applies independent scale factors per axis using a general affine transform.
+
+- **Parameters:**
+  - `sx` — scale factor along X.
+  - `sy` — scale factor along Y.
+  - `sz` — scale factor along Z.
+- **Returns:** Scaled shape, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_GTransform` (via `OCCTShapeNonUniformScale`).
+- **Example:**
+  ```swift
+  if let stretched = shape.nonUniformScaled(sx: 2, sy: 1, sz: 0.5) { }
+  ```
+
+---
+
+## Shell & Vertex Creation
+
+### `Shape.shell(from:)` *(Surface overload)*
+
+Create a shell from a parametric surface.
+
+```swift
+public static func shell(from surface: Surface) -> Shape?
+```
+
+Converts a `Surface` to a topological shell shape (a single face inside a shell, no trimming).
+
+- **Parameters:** `surface` — the parametric surface to convert.
+- **Returns:** Shell shape, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_MakeShell` (via `OCCTShapeCreateShellFromSurface`).
+- **Example:**
+  ```swift
+  let cyl = Surface.cylinder(radius: 5, height: 10)!
+  if let shell = Shape.shell(from: cyl) { }
+  ```
+
+---
+
+### `Shape.vertex(at:)`
+
+Create a vertex shape at a point.
+
+```swift
+public static func vertex(at point: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `point` — the 3D position of the vertex.
+- **Returns:** Vertex-type `Shape`, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_MakeVertex` (via `OCCTShapeCreateVertex`).
+- **Example:**
+  ```swift
+  if let v = Shape.vertex(at: SIMD3(1, 2, 3)) { }
+  ```
+
+---
+
+## Simple Offset
+
+### `simpleOffset(by:)`
+
+Create a simple surface-level offset of this shape.
+
+```swift
+public func simpleOffset(by distance: Double) -> Shape?
+```
+
+Moves each face by a constant distance without filleting intersections. Faster than `offset(by:)` for thin-wall shell operations where sharp offset corners are acceptable.
+
+- **Parameters:** `distance` — offset distance; positive moves outward.
+- **Returns:** Offset shape, or nil on failure.
+- **OCCT:** `BRepOffset_SimpleOffset` (via `OCCTShapeSimpleOffset`).
+- **Example:**
+  ```swift
+  if let thick = sheet.simpleOffset(by: 1.5) { }
+  ```
+
+---
+
+## Middle Path
+
+### `middlePath(start:end:)`
+
+Extract the middle (spine) path from a pipe-like shape.
+
+```swift
+public func middlePath(start startShape: Shape, end endShape: Shape) -> Shape?
+```
+
+Given the two end faces or wires of a pipe-like solid, computes the medial spine wire running through the centre. Useful for reverse-engineering sweep parameters from imported geometry.
+
+- **Parameters:**
+  - `startShape` — one end of the pipe (face or wire shape).
+  - `endShape` — the other end of the pipe (face or wire shape).
+- **Returns:** Middle path wire, or nil on failure.
+- **OCCT:** `BRepOffsetAPI_MiddlePath` (via `OCCTShapeMiddlePath`).
+- **Example:**
+  ```swift
+  if let spine = pipeSolid.middlePath(start: capA, end: capB) { }
+  ```
+
+---
+
+## Fuse Edges
+
+### `fusedEdges()`
+
+Merge connected edges that lie on the same curve.
+
+```swift
+public func fusedEdges() -> Shape?
+```
+
+Removes unnecessary edge splits introduced by boolean operations or sewing, simplifying topology for downstream algorithms and display.
+
+- **Returns:** Shape with fused edges, or nil on failure.
+- **OCCT:** `ShapeUpgrade_UnifySameDomain` / `BRepAlgo_FaceRestrictor` (via `OCCTShapeFuseEdges`).
+- **Example:**
+  ```swift
+  if let clean = boolResult.fusedEdges() { }
+  ```
+
+---
+
+## Volume from Faces
+
+### `Shape.makeVolume(from:)`
+
+Create a solid volume from a set of overlapping faces/shells.
+
+```swift
+public static func makeVolume(from shapes: [Shape]) -> Shape?
+```
+
+Closes open geometry or creates solids from imported face soups by computing the volume enclosed by the input faces.
+
+- **Parameters:** `shapes` — array of face or shell shapes.
+- **Returns:** Solid shape, or nil on failure.
+- **OCCT:** `BOPAlgo_MakerVolume` (via `OCCTShapeMakeVolume`).
+- **Example:**
+  ```swift
+  if let solid = Shape.makeVolume(from: [bottom, sides, top]) { }
+  ```
+
+---
+
+### `Shape.makeConnected(_:)`
+
+Connect separate shapes by making them share common geometry.
+
+```swift
+public static func makeConnected(_ shapes: [Shape]) -> Shape?
+```
+
+Makes shapes share geometry at coincident boundaries. Particularly useful for finite element mesh preparation where shapes must be conformally connected.
+
+- **Parameters:** `shapes` — array of shapes to connect.
+- **Returns:** Connected compound shape, or nil on failure.
+- **OCCT:** `BOPAlgo_MakeConnected` (via `OCCTShapeMakeConnected`).
+- **Example:**
+  ```swift
+  if let mesh = Shape.makeConnected([block1, block2, block3]) { }
+  ```
+
+---
+
+## Shape Contents
+
+### `ShapeContents`
+
+Census of sub-shape counts in a shape.
+
+```swift
+public struct ShapeContents: Sendable {
+    public let solids:    Int
+    public let shells:    Int
+    public let faces:     Int
+    public let wires:     Int
+    public let edges:     Int
+    public let vertices:  Int
+    public let freeEdges: Int
+    public let freeWires: Int
+    public let freeFaces: Int
+}
+```
+
+---
+
+### `contents`
+
+Get a census of sub-shape counts in this shape.
+
+```swift
+public var contents: ShapeContents { get }
+```
+
+Reports topology complexity metrics: counts of solids, shells, faces, wires, edges, vertices, and free (unconnected) elements.
+
+- **Returns:** A `ShapeContents` struct populated from `BRepTools` traversal.
+- **OCCT:** `BRepTools` iteration (via `OCCTShapeGetContents`).
+- **Example:**
+  ```swift
+  let c = solid.contents
+  print("faces: \(c.faces), freeEdges: \(c.freeEdges)")
+  ```
+
+---
+
+## Canonical Recognition
+
+### `CanonicalForm`
+
+Recognised canonical geometric form.
+
+```swift
+public struct CanonicalForm: Sendable {
+    public enum FormType: Int32, Sendable {
+        case unknown = 0, plane = 1, cylinder = 2, cone = 3, sphere = 4
+        case line = 5, circle = 6, ellipse = 7
+    }
+    public let type:      FormType
+    public let origin:    SIMD3<Double>
+    public let direction: SIMD3<Double>
+    public let radius:    Double
+    public let radius2:   Double
+    public let gap:       Double
+}
+```
+
+- `origin` and `direction` define the axis or normal of the recognised form.
+- `radius` is the primary radius; `radius2` is the secondary radius (used for ellipses and cones).
+- `gap` reports the fitting residual.
+
+---
+
+### `recognizeCanonical(tolerance:)`
+
+Recognise canonical geometric forms in this shape.
+
+```swift
+public func recognizeCanonical(tolerance: Double = 1e-4) -> CanonicalForm?
+```
+
+Identifies whether the shape's geometry matches a canonical form (plane, cylinder, cone, sphere, line, circle, ellipse) within the supplied tolerance.
+
+- **Parameters:** `tolerance` — recognition tolerance (default 1e-4).
+- **Returns:** A `CanonicalForm` describing the recognised form, or nil if none is found.
+- **OCCT:** `ShapeAnalysis_Curve` / `BRepGProp` recognition (via `OCCTShapeRecognizeCanonical`).
+- **Example:**
+  ```swift
+  if let form = face.recognizeCanonical() {
+      switch form.type {
+      case .cylinder: print("radius: \(form.radius)")
+      default: break
+      }
+  }
+  ```
+
+---
+
+## Find Surface
+
+### `findSurface(tolerance:)`
+
+Find the underlying surface of a shape (edges or wire).
+
+```swift
+public func findSurface(tolerance: Double = -1) -> Surface?
+```
+
+Determines the best-fit surface for a set of edges or a wire. Useful for reconstructing faces from imported wireframes.
+
+- **Parameters:** `tolerance` — surface-fitting tolerance; pass -1 to use an automatic value (default).
+- **Returns:** The best-fit `Surface`, or nil if none could be determined.
+- **OCCT:** `BRepBuilderAPI_FindPlane` / `GeomPlate` (via `OCCTShapeFindSurface`).
+- **Example:**
+  ```swift
+  if let surface = wireFrame.findSurface() {
+      print(surface.surfaceKind)
+  }
+  ```
+
+---
+
+## Fix Wireframe
+
+### `fixedWireframe(tolerance:)`
+
+Fix wireframe issues (small edges, gaps).
+
+```swift
+public func fixedWireframe(tolerance: Double = 1e-4) -> Shape?
+```
+
+Applies `ShapeFix_Wireframe` to close small gaps and remove degenerate edges in the shape's wires.
+
+- **Parameters:** `tolerance` — fixing tolerance (default 1e-4).
+- **Returns:** Shape with fixed wireframe, or nil on failure.
+- **OCCT:** `ShapeFix_Wireframe` (via `OCCTShapeFixWireframe`).
+- **Example:**
+  ```swift
+  if let fixed = imported.fixedWireframe(tolerance: 0.01) { }
+  ```
+
+---
+
+## Remove Internal Wires
+
+### `removingInternalWires(minArea:)`
+
+Remove internal wires (holes) smaller than a minimum area.
+
+```swift
+public func removingInternalWires(minArea: Double) -> Shape?
+```
+
+Drops holes in faces whose area is below `minArea`. Useful for cleaning up small artefact holes from boolean or import operations.
+
+- **Parameters:** `minArea` — minimum area threshold; holes smaller than this are removed.
+- **Returns:** Shape with small holes removed, or nil on failure.
+- **OCCT:** `ShapeFix_Shape` / hole-removal pass (via `OCCTShapeRemoveInternalWires`).
+- **Example:**
+  ```swift
+  if let clean = sheet.removingInternalWires(minArea: 0.25) { }
+  ```
+
+---
+
+## Contiguous Edges
+
+### `contiguousEdgeCount(tolerance:)`
+
+Find pairs of edges that are coincident within tolerance.
+
+```swift
+public func contiguousEdgeCount(tolerance: Double = 1e-6) -> Int
+```
+
+Returns the count of edge pairs that are geometrically coincident (within `tolerance`) but not yet sewn. Useful as a pre-sewing diagnostic.
+
+- **Parameters:** `tolerance` — contiguity tolerance (default 1e-6).
+- **Returns:** Number of contiguous (but unsewn) edge pairs found.
+- **OCCT:** `BRepBuilderAPI_Sewing` probe (via `OCCTShapeFindContiguousEdges`).
+- **Example:**
+  ```swift
+  let gaps = faceSoup.contiguousEdgeCount(tolerance: 0.01)
+  print("\(gaps) sewable edge pairs found")
+  ```
+
+---
+
+## Quilt Faces
+
+### `Shape.quilt(_:)`
+
+Quilt multiple shapes (faces/shells) together into a single shell.
+
+```swift
+public static func quilt(_ shapes: [Shape]) -> Shape?
+```
+
+Joins faces that share common edges into a connected shell by identifying and merging coincident edge pairs.
+
+- **Parameters:** `shapes` — array of face or shell shapes to quilt.
+- **Returns:** Quilted shell, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Sewing` (via `OCCTShapeQuilt`).
+- **Example:**
+  ```swift
+  if let shell = Shape.quilt([top, bottom, left, right, front, back]) { }
+  ```
+
+---
+
+## Fix Small Faces
+
+### `fixingSmallFaces(tolerance:)`
+
+Fix small faces by removing or merging them.
+
+```swift
+public func fixingSmallFaces(tolerance: Double = 1e-4) -> Shape?
+```
+
+Applies `ShapeFix_FixSmallFace` to identify and remove degenerate or very small faces that can cause issues in boolean and meshing operations.
+
+- **Parameters:** `tolerance` — precision tolerance for identifying small faces (default 1e-4).
+- **Returns:** Shape with small faces removed, or nil on failure.
+- **OCCT:** `ShapeFix_FixSmallFace` (via `OCCTShapeFixSmallFaces`).
+- **Example:**
+  ```swift
+  if let clean = boolResult.fixingSmallFaces(tolerance: 0.001) { }
+  ```
+
+---
+
+## Remove Locations
+
+### `removingLocations()`
+
+Remove all location transforms, baking them into the geometry.
+
+```swift
+public func removingLocations() -> Shape?
+```
+
+Converts a shape with nested `TopLoc_Location` transforms (as set by assembly placement) into an equivalent shape with all geometry coordinates in the global frame.
+
+- **Returns:** Shape with locations removed (geometry in world coordinates), or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Copy` with location removal (via `OCCTShapeRemoveLocations`).
+- **Example:**
+  ```swift
+  if let flat = assemblyShape.removingLocations() {
+      // all faces/edges now have identity location
+  }
+  ```
+
+---
+
+## Revolution from Curve
+
+### `Shape.revolution(meridian:axisOrigin:axisDirection:angle:)`
+
+Create a solid of revolution by revolving a meridian curve.
+
+```swift
+public static func revolution(meridian: Curve3D,
+                              axisOrigin: SIMD3<Double> = .zero,
+                              axisDirection: SIMD3<Double> = SIMD3<Double>(0, 0, 1),
+                              angle: Double = 2 * .pi) -> Shape?
+```
+
+Unlike `Shape.revolution(profile:...)` which takes a wire, this revolves a `Geom_Curve` (e.g. a BSpline or arc) directly around the specified axis.
+
+- **Parameters:**
+  - `meridian` — the curve to revolve.
+  - `axisOrigin` — origin of the revolution axis (default `.zero`).
+  - `axisDirection` — direction of the revolution axis (default Z+).
+  - `angle` — revolution angle in radians (default full revolution, 2π).
+- **Returns:** Revolved shape, or nil on failure.
+- **OCCT:** `BRepPrimAPI_MakeRevol` (via `OCCTShapeCreateRevolutionFromCurve`).
+- **Example:**
+  ```swift
+  let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi)!
+  if let solid = Shape.revolution(meridian: arc, axisDirection: SIMD3(0, 1, 0)) { }
+  ```
+
+---
+
+## Linear Rib Feature
+
+### `addingLinearRib(profile:direction:draftDirection:fuse:)`
+
+Add a linear rib feature to a shape.
+
+```swift
+public func addingLinearRib(profile: Wire,
+                            direction: SIMD3<Double>,
+                            draftDirection: SIMD3<Double>,
+                            fuse: Bool = true) -> Shape?
+```
+
+Creates a rib (reinforcement) or slot by extruding a wire profile in a given direction against the base shape.
+
+- **Parameters:**
+  - `profile` — wire profile of the rib.
+  - `direction` — extrusion direction of the rib.
+  - `draftDirection` — secondary direction controlling draft angle.
+  - `fuse` — `true` to add material (rib); `false` to remove material (slot).
+- **Returns:** Shape with rib/slot added, or nil on failure.
+- **OCCT:** `BRepFeat_MakeLinearForm` (via `OCCTShapeAddLinearRib`).
+- **Example:**
+  ```swift
+  if let ribbed = body.addingLinearRib(profile: ribWire,
+                                       direction: SIMD3(0, 0, 1),
+                                       draftDirection: SIMD3(1, 0, 0)) { }
+  ```
+
+---
+
+## Revolution Form Feature
+
+### `addingRevolutionForm(profile:axisOrigin:axisDirection:height1:height2:fuse:)`
+
+Add a revolution form (revolved rib or groove) to a shape.
+
+```swift
+public func addingRevolutionForm(profile: Wire,
+                                 axisOrigin: SIMD3<Double>,
+                                 axisDirection: SIMD3<Double>,
+                                 height1: Double, height2: Double,
+                                 fuse: Bool = true) -> Shape?
+```
+
+Similar to `addingLinearRib`, but the rib profile follows a rotational path around the given axis — useful for knurling and annular ribs.
+
+- **Parameters:**
+  - `profile` — wire profile of the rib.
+  - `axisOrigin` — origin of the revolution axis.
+  - `axisDirection` — direction of the revolution axis.
+  - `height1` — height on one side of the profile.
+  - `height2` — height on the other side.
+  - `fuse` — `true` for rib (add material); `false` for groove (remove material).
+- **Returns:** Shape with revolution form, or nil on failure.
+- **OCCT:** `BRepFeat_MakeRevolutionForm` (via `OCCTShapeAddRevolutionForm`).
+- **Example:**
+  ```swift
+  if let knurled = shaft.addingRevolutionForm(profile: profileWire,
+                                              axisOrigin: .zero,
+                                              axisDirection: SIMD3(0, 0, 1),
+                                              height1: 2, height2: 2) { }
+  ```
+
+---
+
+## Draft Prism Feature
+
+### `addingDraftPrism(profile:sketchFaceIndex:draftAngle:height:fuse:)`
+
+Add a draft prism (tapered extrusion) to a shape.
+
+```swift
+public func addingDraftPrism(profile: Wire, sketchFaceIndex: Int,
+                             draftAngle: Double, height: Double,
+                             fuse: Bool = true) -> Shape?
+```
+
+Creates a boss or pocket with draft angle (taper), commonly used in injection mould design.
+
+- **Parameters:**
+  - `profile` — wire profile to extrude.
+  - `sketchFaceIndex` — 0-based index of the face on which the profile sits.
+  - `draftAngle` — draft angle in degrees.
+  - `height` — extrusion height.
+  - `fuse` — `true` to add material (boss); `false` to cut (pocket).
+- **Returns:** Shape with draft prism, or nil on failure.
+- **OCCT:** `BRepFeat_MakeDPrism` (via `OCCTShapeDraftPrism`).
+- **Example:**
+  ```swift
+  if let boss = mould.addingDraftPrism(profile: bossWire, sketchFaceIndex: 0,
+                                       draftAngle: 2.0, height: 15) { }
+  ```
+
+---
+
+### `addingDraftPrismThruAll(profile:sketchFaceIndex:draftAngle:fuse:)`
+
+Add a draft prism that extends through the entire shape.
+
+```swift
+public func addingDraftPrismThruAll(profile: Wire, sketchFaceIndex: Int,
+                                    draftAngle: Double,
+                                    fuse: Bool = true) -> Shape?
+```
+
+Like `addingDraftPrism` but the extrusion continues until it exits the opposite side of the shape.
+
+- **Parameters:**
+  - `profile` — wire profile to extrude.
+  - `sketchFaceIndex` — 0-based index of the sketch face.
+  - `draftAngle` — draft angle in degrees.
+  - `fuse` — `true` to add material; `false` to cut.
+- **Returns:** Shape with through-all draft prism, or nil on failure.
+- **OCCT:** `BRepFeat_MakeDPrism` (via `OCCTShapeDraftPrismThruAll`).
+- **Example:**
+  ```swift
+  if let pocket = mould.addingDraftPrismThruAll(profile: holeWire,
+                                                sketchFaceIndex: 2,
+                                                draftAngle: 1.5, fuse: false) { }
+  ```
+
+---
+
+## Revolution Feature
+
+### `addingRevolvedFeature(profile:sketchFaceIndex:axisOrigin:axisDirection:angle:fuse:)`
+
+Add a revolved feature (boss or pocket) to a shape.
+
+```swift
+public func addingRevolvedFeature(profile: Wire, sketchFaceIndex: Int,
+                                  axisOrigin: SIMD3<Double>,
+                                  axisDirection: SIMD3<Double>,
+                                  angle: Double = 360,
+                                  fuse: Bool = true) -> Shape?
+```
+
+Revolves a profile around an axis to add or remove material — the parametric solid modelling equivalent of a lathe operation.
+
+- **Parameters:**
+  - `profile` — wire profile to revolve.
+  - `sketchFaceIndex` — 0-based index of the face on which the profile sits.
+  - `axisOrigin` — origin of the revolution axis.
+  - `axisDirection` — direction of the revolution axis.
+  - `angle` — revolution angle in degrees (default 360).
+  - `fuse` — `true` to add material (boss); `false` to cut (pocket).
+- **Returns:** Shape with revolved feature, or nil on failure.
+- **OCCT:** `BRepFeat_MakeRevol` (via `OCCTShapeRevolFeature`).
+- **Example:**
+  ```swift
+  if let groove = shaft.addingRevolvedFeature(profile: grooveWire, sketchFaceIndex: 0,
+                                              axisOrigin: .zero,
+                                              axisDirection: SIMD3(0, 0, 1),
+                                              angle: 360, fuse: false) { }
+  ```
+
+---
+
+### `addingRevolvedFeatureThruAll(profile:sketchFaceIndex:axisOrigin:axisDirection:fuse:)`
+
+Add a revolved feature that revolves through 360 degrees.
+
+```swift
+public func addingRevolvedFeatureThruAll(profile: Wire, sketchFaceIndex: Int,
+                                         axisOrigin: SIMD3<Double>,
+                                         axisDirection: SIMD3<Double>,
+                                         fuse: Bool = true) -> Shape?
+```
+
+Convenience overload that always performs a full 360° revolution.
+
+- **Parameters:**
+  - `profile`, `sketchFaceIndex`, `axisOrigin`, `axisDirection` — same as above.
+  - `fuse` — `true` to add; `false` to cut.
+- **Returns:** Shape with through-all revolved feature, or nil on failure.
+- **OCCT:** `BRepFeat_MakeRevol` (via `OCCTShapeRevolFeatureThruAll`).
+- **Example:**
+  ```swift
+  if let annularSlot = disc.addingRevolvedFeatureThruAll(profile: slotWire,
+                                                         sketchFaceIndex: 0,
+                                                         axisOrigin: .zero,
+                                                         axisDirection: SIMD3(0, 0, 1),
+                                                         fuse: false) { }
+  ```
+
+---
+
+## Face from Surface
+
+### `Shape.face(from:uRange:vRange:tolerance:)`
+
+Create a face from a surface with specific UV parameter bounds.
+
+```swift
+public static func face(from surface: Surface,
+                        uRange: ClosedRange<Double>,
+                        vRange: ClosedRange<Double>,
+                        tolerance: Double = 1e-6) -> Shape?
+```
+
+- **Parameters:**
+  - `surface` — the parametric surface.
+  - `uRange` — U parameter range (uMin...uMax).
+  - `vRange` — V parameter range (vMin...vMax).
+  - `tolerance` — tolerance for face creation (default 1e-6).
+- **Returns:** Face shape, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace` (via `OCCTShapeCreateFaceFromSurface`).
+- **Example:**
+  ```swift
+  let cyl = Surface.cylinder(radius: 5, height: 10)!
+  if let face = Shape.face(from: cyl, uRange: 0...(.pi), vRange: 0...10) { }
+  ```
+
+---
+
+### `Shape.face(from:boundary:)`
+
+Create a face from a surface bounded by a 3D wire.
+
+```swift
+public static func face(from surface: Surface, boundary: Wire) -> Shape?
+```
+
+Tries two strategies in order:
+1. **Exact:** if the wire genuinely lies on the surface (edges have or admit pcurves), builds the face directly with `ShapeFix_Face` to project pcurves.
+2. **Fallback:** projects the wire's ordered points onto the surface UV and trims by that polygon — same path as `Surface.toFace(uvBoundary:)`.
+
+If you already have the boundary in UV space, call `Surface.toFace(uvBoundary:)` directly for efficiency.
+
+- **Parameters:**
+  - `surface` — the parametric surface to trim.
+  - `boundary` — a closed wire on (or near) the surface.
+- **Returns:** Trimmed face shape, or nil on failure. A boundary crossing a periodic seam (e.g. the u = 0/2π seam of a cylinder) is not handled by the projection fallback.
+- **OCCT:** `BRepBuilderAPI_MakeFace` + `ShapeFix_Face` (via `OCCTShapeCreateFaceFromSurfaceWire`).
+- **Example:**
+  ```swift
+  let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+  let boundary: Wire = ...   // a closed planar wire
+  if let face = Shape.face(from: plane, boundary: boundary) { }
+  ```
+
+---
+
+## Edges to Faces
+
+### `Shape.facesFromEdges(_:onlyPlanar:)`
+
+Reconstruct faces from a compound of loose edges.
+
+```swift
+public static func facesFromEdges(_ compound: Shape, onlyPlanar: Bool = true) -> Shape?
+```
+
+Takes a shape containing edges, builds closed wires from them, and creates faces from those wires.
+
+- **Parameters:**
+  - `compound` — shape containing the edges to assemble.
+  - `onlyPlanar` — if `true`, only creates planar faces (default `true`).
+- **Returns:** Compound of faces, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_MakeFace` + wire recovery (via `OCCTShapeEdgesToFaces`).
+- **Example:**
+  ```swift
+  if let faces = Shape.facesFromEdges(edgeCompound, onlyPlanar: false) { }
+  ```
+
+---
+
+## Shape-to-Shape Section
+
+### `section(_:)`
+
+Compute the intersection curves/edges between two shapes.
+
+```swift
+public func section(_ other: Shape) -> Shape?
+```
+
+Returns the intersection geometry (edges/wires) where the two shapes meet. Useful for contact curves, trim boundaries, and interference analysis.
+
+- **Parameters:** `other` — the second shape to intersect with.
+- **Returns:** Shape containing intersection edges, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Section` (via `OCCTShapeSection`).
+- **Example:**
+  ```swift
+  let plane = Shape.box(width: 100, height: 100, depth: 0.1)!
+  if let crossSection = solid.section(plane) { }
+  ```
+
+---
+
+### `section(with:)` *(deprecated)*
+
+```swift
+@available(*, deprecated, renamed: "section(_:)",
+           message: "Use section(_:) to match subtracting(_:) and Set convention")
+public func section(with other: Shape) -> Shape?
+```
+
+Deprecated alias for `section(_:)`. Use `section(_:)` instead.
+
+---
+
+## Boolean Pre-Validation
+
+### `isValidForBoolean`
+
+Check whether this shape is valid for boolean operations.
+
+```swift
+public var isValidForBoolean: Bool { get }
+```
+
+- **Returns:** `true` if the shape passes the OCCT boolean readiness check.
+- **OCCT:** `BRepAlgoAPI_Check` (via `OCCTShapeBooleanCheck`).
+- **Example:**
+  ```swift
+  guard shape.isValidForBoolean else { return }
+  let result = shape.union(other)
+  ```
+
+---
+
+### `isValidForBoolean(with:)`
+
+Check whether two shapes are valid for boolean operations with each other.
+
+```swift
+public func isValidForBoolean(with other: Shape) -> Bool
+```
+
+- **Parameters:** `other` — the second shape to check compatibility with.
+- **Returns:** `true` if both shapes are suitable for boolean operations together.
+- **OCCT:** `BRepAlgoAPI_Check` (via `OCCTShapeBooleanCheck`).
+- **Example:**
+  ```swift
+  guard partA.isValidForBoolean(with: partB) else { return }
+  ```
+
+---
+
+## Split Shape by Wire
+
+### `splittingFace(with:faceIndex:)`
+
+Split a face by imprinting a wire onto it.
+
+```swift
+public func splittingFace(with wire: Wire, faceIndex: Int) -> Shape?
+```
+
+The wire is projected/imprinted onto the specified face, dividing it into multiple faces. Useful for mesh preparation and feature line imprinting.
+
+- **Parameters:**
+  - `wire` — wire to imprint onto the face.
+  - `faceIndex` — 0-based index of the face to split.
+- **Returns:** Shape with the face split by the wire, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Splitter` (via `OCCTShapeSplitByWire`).
+- **Example:**
+  ```swift
+  if let split = plate.splittingFace(with: splitWire, faceIndex: 0) { }
+  ```
+
+---
+
+## Split by Angle
+
+### `splitByAngle(_:)`
+
+Split surfaces that span more than a specified angle.
+
+```swift
+public func splitByAngle(_ maxAngleDegrees: Double) -> Shape?
+```
+
+Useful for export to systems that cannot handle full 360° surfaces (e.g. splitting a full cylinder into quarter-cylinders).
+
+- **Parameters:** `maxAngleDegrees` — maximum surface angular span in degrees (e.g. 90 for quarter-turns).
+- **Returns:** Shape with surfaces split at angle boundaries, or nil on failure.
+- **OCCT:** `ShapeUpgrade_ShapeSplitAngle` (via `OCCTShapeSplitByAngle`).
+- **Example:**
+  ```swift
+  if let split = fullCylinder.splitByAngle(90) {
+      // cylinder is now 4 quarter-cylindrical faces
+  }
+  ```
+
+---
+
+## Drop Small Edges
+
+### `droppingSmallEdges(tolerance:)`
+
+Remove degenerate/tiny edges from a shape.
+
+```swift
+public func droppingSmallEdges(tolerance: Double = 1e-6) -> Shape?
+```
+
+Useful for cleaning up imported geometry with tolerance issues where very short edges prevent boolean or meshing operations.
+
+- **Parameters:** `tolerance` — tolerance below which edges are considered small and removed (default 1e-6).
+- **Returns:** Shape with small edges removed, or nil on failure.
+- **OCCT:** `ShapeFix_Wireframe` small-edge removal (via `OCCTShapeDropSmallEdges`).
+- **Example:**
+  ```swift
+  if let clean = imported.droppingSmallEdges(tolerance: 0.001) { }
+  ```
+
+---
+
+## Multi-Tool Boolean Fuse
+
+### `Shape.fuseAll(_:)`
+
+Fuse multiple shapes simultaneously.
+
+```swift
+public static func fuseAll(_ shapes: [Shape]) -> Shape?
+```
+
+More robust than sequential pairwise `union(with:)` calls — processes all intersections at once, avoiding intermediate tolerance accumulation. Requires at least two shapes.
+
+- **Parameters:** `shapes` — array of shapes to fuse (must have ≥ 2 elements).
+- **Returns:** Fused shape, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Fuse` multi-tool mode (via `OCCTShapeFuseMulti`).
+- **Example:**
+  ```swift
+  if let merged = Shape.fuseAll([a, b, c, d]) { }
+  ```
+
+---
+
+## Multi-Offset Wire
+
+### `multiOffsetWires(offsets:joinType:)`
+
+Generate multiple parallel offset wires from a planar face boundary.
+
+```swift
+public func multiOffsetWires(offsets: [Double],
+                             joinType: OffsetJoinType = .arc) -> [Wire]
+```
+
+More efficient than calling `Wire.offset` multiple times, and produces consistent results for CNC toolpath generation.
+
+- **Parameters:**
+  - `offsets` — array of offset distances (positive = outward, negative = inward).
+  - `joinType` — how to join offset segments (default `.arc`).
+- **Returns:** Array of offset `Wire`s (may be empty on failure or empty input).
+- **OCCT:** `BRepOffsetAPI_MakeOffset` (via `OCCTWireMultiOffset`).
+- **Example:**
+  ```swift
+  let paths = faceBoundary.multiOffsetWires(offsets: [-0.5, -1.0, -1.5])
+  // paths[0] is the innermost wire, [2] is outermost
+  ```
+
+### `OffsetJoinType`
+
+Join type for offset operations.
+
+```swift
+public enum OffsetJoinType: Int32, Sendable {
+    case arc          = 0   // fill gaps with pipe arcs and spheres (smooth)
+    case tangent      = 1   // tangent extension of faces
+    case intersection = 2   // extend and intersect adjacent faces (sharp edges)
+}
+```
+
+---
+
+## Cylindrical Projection
+
+### `Shape.projectWire(_:onto:direction:)` *(Shape overload)*
+
+Project a wire/edge shape onto another shape along a direction (cylindrical projection).
+
+```swift
+public static func projectWire(_ wire: Shape, onto target: Shape,
+                               direction: SIMD3<Double>) -> Shape?
+```
+
+Parallel-ray projection (like an orthographic shadow) — each point on `wire` is projected along `direction` until it hits `target`.
+
+- **Parameters:**
+  - `wire` — wire or edge `Shape` to project.
+  - `target` — target shape to project onto.
+  - `direction` — projection direction (rays are parallel).
+- **Returns:** Compound of projected wires, or nil on failure.
+- **OCCT:** `BRepOffsetAPI_NormalProjection` with direction (via `OCCTShapeProjectWire`).
+- **Example:**
+  ```swift
+  if let projected = Shape.projectWire(logoShape, onto: cylinder,
+                                       direction: SIMD3(1, 0, 0)) { }
+  ```
+
+---
+
+### `Shape.projectWire(_:onto:direction:)` *(Wire overload)*
+
+Project a Wire onto another shape along a direction (cylindrical projection).
+
+```swift
+public static func projectWire(_ wire: Wire, onto target: Shape,
+                               direction: SIMD3<Double>) -> Shape?
+```
+
+Convenience overload accepting a `Wire` directly; internally converts it to a `Shape` then delegates to the `Shape` overload.
+
+- **Parameters:** Same as the `Shape` overload but `wire` is a `Wire`.
+- **Returns:** Compound of projected wires, or nil on failure.
+- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeProjectWire`).
+- **Example:**
+  ```swift
+  if let projected = Shape.projectWire(logoWire, onto: surface, direction: SIMD3(0, 0, -1)) { }
+  ```
+
+---
+
+## Same Parameter
+
+### `sameParameter(tolerance:)`
+
+Enforce same-parameter consistency on the shape.
+
+```swift
+public func sameParameter(tolerance: Double = 1e-6) -> Shape?
+```
+
+Ensures 3D and 2D (pcurve) representations of edges are consistent in their parametrisation. Important after importing geometry or performing complex operations that may desynchronise 3D/2D curves.
+
+- **Parameters:** `tolerance` — tolerance for the same-parameter check (default 1e-6).
+- **Returns:** Fixed shape, or nil on failure.
+- **OCCT:** `BRepLib::SameParameter` (via `OCCTShapeSameParameter`).
+- **Example:**
+  ```swift
+  if let fixed = imported.sameParameter(tolerance: 1e-5) { }
+  ```
+
+---
+
+## Conical Projection
+
+### `Shape.projectWireConical(_:onto:eye:)` *(Shape overload)*
+
+Project a wire/edge shape onto another shape from a point (conical projection).
+
+```swift
+public static func projectWireConical(_ wire: Shape, onto target: Shape,
+                                      eye: SIMD3<Double>) -> Shape?
+```
+
+Unlike cylindrical projection (parallel rays), conical projection fans rays out from a point source — like a spotlight or perspective camera.
+
+- **Parameters:**
+  - `wire` — wire or edge `Shape` to project.
+  - `target` — target shape to project onto.
+  - `eye` — point source of the projection rays.
+- **Returns:** Compound of projected wires, or nil on failure.
+- **OCCT:** `BRepOffsetAPI_NormalProjection` with point source (via `OCCTShapeProjectWireConical`).
+- **Example:**
+  ```swift
+  if let shadow = Shape.projectWireConical(outlineShape, onto: ground,
+                                           eye: SIMD3(0, 0, 100)) { }
+  ```
+
+---
+
+### `Shape.projectWireConical(_:onto:eye:)` *(Wire overload)*
+
+Project a Wire onto another shape from a point (conical projection).
+
+```swift
+public static func projectWireConical(_ wire: Wire, onto target: Shape,
+                                      eye: SIMD3<Double>) -> Shape?
+```
+
+Convenience overload accepting a `Wire` directly.
+
+- **Parameters:** Same as the `Shape` overload but `wire` is a `Wire`.
+- **Returns:** Compound of projected wires, or nil on failure.
+- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeProjectWireConical`).
+- **Example:**
+  ```swift
+  if let shadow = Shape.projectWireConical(outline, onto: floor, eye: lightPos) { }
+  ```
+
+---
+
+## Encode Regularity
+
+### `encodingRegularity(toleranceDegrees:)`
+
+Mark smooth (G1-continuous) edges as "regular."
+
+```swift
+public func encodingRegularity(toleranceDegrees: Double = 1e-10) -> Shape?
+```
+
+Downstream algorithms (e.g. offset, draft) can skip regular edges for better performance. The angular tolerance controls what counts as smooth.
+
+- **Parameters:** `toleranceDegrees` — angular tolerance in degrees; edges whose dihedral angle deviates less than this from 180° are marked regular (default 1e-10, effectively exact smoothness).
+- **Returns:** Shape with regularity encoded, or nil on failure.
+- **OCCT:** `BRepLib::EncodeRegularity` (via `OCCTShapeEncodeRegularity`).
+- **Example:**
+  ```swift
+  if let encoded = fillet.encodingRegularity(toleranceDegrees: 0.01) { }
+  ```
+
+---
+
+## Update Tolerances
+
+### `updatingTolerances(verifyFaces:)`
+
+Recalculate and update geometric tolerances on the shape.
+
+```swift
+public func updatingTolerances(verifyFaces: Bool = true) -> Shape?
+```
+
+- **Parameters:** `verifyFaces` — whether to verify and correct face tolerances (default `true`).
+- **Returns:** Shape with updated tolerances, or nil on failure.
+- **OCCT:** `BRepLib::UpdateTolerances` (via `OCCTShapeUpdateTolerances`).
+- **Example:**
+  ```swift
+  if let tightened = result.updatingTolerances() { }
+  ```
+
+---
+
+## Divide by Number
+
+### `dividedByNumber(_:)`
+
+Split faces into approximately the specified number of patches.
+
+```swift
+public func dividedByNumber(_ parts: Int) -> Shape?
+```
+
+Subdivides each face into approximately `parts` parametric patches. Useful for mesh preparation and parametric surface subdivision. Requires `parts > 1`.
+
+- **Parameters:** `parts` — approximate number of patches per face.
+- **Returns:** Shape with divided faces, or nil if `parts ≤ 1` or on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideArea` (via `OCCTShapeDivideByNumber`).
+- **Example:**
+  ```swift
+  if let subdivided = face.dividedByNumber(4) { }
+  ```
+
+---
+
+## Boolean with History
+
+### `BooleanResult`
+
+Result of a boolean operation with shape tracking.
+
+```swift
+public struct BooleanResult: Sendable {
+    public let shape: Shape
+    public let modifiedFaces: [Shape]
+}
+```
+
+- `shape` — the result of the boolean operation.
+- `modifiedFaces` — faces in the result that are modifications of faces from the first operand.
+
+---
+
+### `fuseWithHistory(_:)`
+
+Fuse this shape with another and track which faces were modified.
+
+```swift
+public func fuseWithHistory(_ other: Shape) -> BooleanResult?
+```
+
+- **Parameters:** `other` — shape to fuse with.
+- **Returns:** `BooleanResult` with result shape and modified-face tracking, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Fuse` with history (via `OCCTShapeFuseWithHistory`).
+- **Example:**
+  ```swift
+  if let result = base.fuseWithHistory(tool) {
+      print("\(result.modifiedFaces.count) faces modified")
+  }
+  ```
+
+---
+
+### `ShapeHistoryRecord`
+
+Per-input-subshape history for a boolean operation.
+
+```swift
+public struct ShapeHistoryRecord: Sendable {
+    public let modified:   [Shape]
+    public let generated:  [Shape]
+    public let isDeleted:  Bool
+}
+```
+
+- `modified` — output sub-shapes that are modifications of the tracked input (one face may split into several).
+- `generated` — output sub-shapes generated from the input but not replacing it (e.g. fillet faces generated from an edge).
+- `isDeleted` — `true` if the input was deleted with no replacement.
+
+---
+
+### `ShapeHistoryRef`
+
+Retained handle to a boolean operation's builder, queryable for per-input history.
+
+```swift
+public final class ShapeHistoryRef: @unchecked Sendable
+```
+
+Used by tools that need to track selection IDs across boolean / split mutations (e.g. parametric editors that replay features). Released automatically when the reference is deallocated.
+
+#### `record(of:)`
+
+Look up the post-mutation history of one input sub-shape.
+
+```swift
+public func record(of inputSubShape: Shape) -> ShapeHistoryRecord
+```
+
+- **Parameters:** `inputSubShape` — any face, edge, or vertex from an original input shape.
+- **Returns:** `ShapeHistoryRecord` describing what happened to that sub-shape.
+- **OCCT:** `BRepAlgoAPI_BuilderAlgo::Modified` / `Generated` / `IsDeleted` (via `OCCTBooleanHistoryModified`, `OCCTBooleanHistoryGenerated`, `OCCTBooleanHistoryIsDeleted`).
+- **Example:**
+  ```swift
+  if let (result, history) = base.unionWithFullHistory(tool) {
+      let record = history.record(of: someFace)
+      print("deleted: \(record.isDeleted), modified into \(record.modified.count) faces")
+  }
+  ```
+
+---
+
+### `unionWithFullHistory(_:)`
+
+Boolean union with full per-input-subshape history.
+
+```swift
+public func unionWithFullHistory(_ other: Shape) -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:** `other` — shape to union with.
+- **Returns:** Tuple of result shape and queryable `ShapeHistoryRef`, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Fuse` (via `OCCTBooleanUnionWithHistory`).
+- **Example:**
+  ```swift
+  if let (result, history) = a.unionWithFullHistory(b) {
+      let record = history.record(of: aFace)
+  }
+  ```
+
+---
+
+### `subtractedWithFullHistory(_:)`
+
+Boolean subtract with full per-input-subshape history.
+
+```swift
+public func subtractedWithFullHistory(_ tool: Shape) -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:** `tool` — shape to subtract from `self`.
+- **Returns:** Tuple of result shape and history, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Cut` (via `OCCTBooleanSubtractWithHistory`).
+- **Example:**
+  ```swift
+  if let (result, history) = body.subtractedWithFullHistory(pocket) { }
+  ```
+
+---
+
+### `intersectionWithFullHistory(_:)`
+
+Boolean intersect with full per-input-subshape history.
+
+```swift
+public func intersectionWithFullHistory(_ other: Shape) -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:** `other` — shape to intersect with.
+- **Returns:** Tuple of result shape and history, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Common` (via `OCCTBooleanIntersectWithHistory`).
+- **Example:**
+  ```swift
+  if let (result, history) = shapeA.intersectionWithFullHistory(shapeB) { }
+  ```
+
+---
+
+### `splitWithFullHistory(by:)`
+
+Split `self` by `tool` with full per-input-subshape history.
+
+```swift
+public func splitWithFullHistory(by tool: Shape) -> (pieces: [Shape], history: ShapeHistoryRef)?
+```
+
+The top-level children of the compound result are returned as individual pieces. Query history per input sub-shape via `history.record(of:)`.
+
+- **Parameters:** `tool` — shape to split with (acts as a cutting tool).
+- **Returns:** Tuple of pieces array and history, or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Splitter` (via `OCCTBooleanSplitWithHistory`).
+- **Example:**
+  ```swift
+  if let (pieces, history) = solid.splitWithFullHistory(by: plane) {
+      print("\(pieces.count) pieces")
+  }
+  ```
+
+---
+
+### `filletedWithFullHistory(radius:edges:)`
+
+Apply a uniform-radius fillet to the given edges with history tracking.
+
+```swift
+public func filletedWithFullHistory(radius: Double, edges: [Int])
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:**
+  - `radius` — fillet radius.
+  - `edges` — 0-based edge indices to fillet.
+- **Returns:** Result shape and history, or nil on failure or empty edge list.
+- **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeHistoryFromFilletEdges`).
+- **Example:**
+  ```swift
+  if let (result, history) = box.filletedWithFullHistory(radius: 2, edges: [0, 1, 2]) { }
+  ```
+
+---
+
+### `filletedWithFullHistory(edge:startRadius:endRadius:)`
+
+Variable-radius fillet on a single edge with history tracking.
+
+```swift
+public func filletedWithFullHistory(edge: Int, startRadius: Double, endRadius: Double)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+Radius varies linearly from `startRadius` (at the edge's first parameter) to `endRadius` (at last).
+
+- **Parameters:**
+  - `edge` — 0-based edge index.
+  - `startRadius` — radius at the start of the edge.
+  - `endRadius` — radius at the end of the edge.
+- **Returns:** Result shape and history, or nil on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet` variable-radius (via `OCCTShapeHistoryFromFilletEdgeVariable`).
+- **Example:**
+  ```swift
+  if let (result, _) = body.filletedWithFullHistory(edge: 3, startRadius: 1, endRadius: 3) { }
+  ```
+
+---
+
+### `chamferedWithFullHistory(distance:edges:)`
+
+Apply a uniform chamfer to the given edges with history tracking.
+
+```swift
+public func chamferedWithFullHistory(distance: Double, edges: [Int])
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:**
+  - `distance` — chamfer distance.
+  - `edges` — 0-based edge indices to chamfer.
+- **Returns:** Result shape and history, or nil on failure or empty edge list.
+- **OCCT:** `BRepFilletAPI_MakeChamfer` (via `OCCTShapeHistoryFromChamferEdges`).
+- **Example:**
+  ```swift
+  if let (chamfered, history) = part.chamferedWithFullHistory(distance: 1, edges: [4, 5]) { }
+  ```
+
+---
+
+### `shelledWithFullHistory(facesToRemove:thickness:tolerance:)`
+
+Shell / hollow a shape with history tracking.
+
+```swift
+public func shelledWithFullHistory(facesToRemove: [Int], thickness: Double, tolerance: Double = 1e-3)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+Removes the listed faces and offsets the remaining shell inward by `thickness` (negative = outward). Returns per-face history.
+
+- **Parameters:**
+  - `facesToRemove` — 0-based indices of faces to remove (become openings).
+  - `thickness` — wall thickness; positive = inward offset.
+  - `tolerance` — offset tolerance (default 1e-3).
+- **Returns:** Result shape and history, or nil on failure or empty face list.
+- **OCCT:** `BRepOffsetAPI_MakeThickSolid` (via `OCCTShapeHistoryFromShell`).
+- **Example:**
+  ```swift
+  if let (hollow, history) = block.shelledWithFullHistory(facesToRemove: [0], thickness: 2) { }
+  ```
+
+---
+
+### `defeaturedWithFullHistory(faces:)`
+
+Defeature: remove given faces by reconnecting surrounding topology, with history.
+
+```swift
+public func defeaturedWithFullHistory(faces: [Int])
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+History reports each removed face as deleted and surrounding faces as modified.
+
+- **Parameters:** `faces` — 0-based indices of faces to remove.
+- **Returns:** Result shape and history, or nil on failure or empty face list.
+- **OCCT:** `BRepAlgoAPI_Defeaturing` (via `OCCTShapeHistoryFromDefeature`).
+- **Example:**
+  ```swift
+  if let (defeatured, history) = cad.defeaturedWithFullHistory(faces: [12, 13]) { }
+  ```

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -1,0 +1,2250 @@
+---
+title: Shape — Measurement, Sub-Shapes & Local Operations
+parent: API Reference
+---
+
+# Shape — Measurement, Sub-Shapes & Local Operations
+
+This page covers the measurement, decomposition, healing, and local-operation APIs on `Shape` (source lines 4955–6935). For the core primitives, Boolean operations, and transforms, see the main **[Shape](Shape.md)** page.
+
+## Topics
+
+- [Sub-Shape Extraction](#sub-shape-extraction-v0380) · [Fuse and Blend](#fuse-and-blend-v0380) · [Multi-Edge Evolving Fillet](#multi-edge-evolving-fillet-v0380) · [Per-Face Variable Offset](#per-face-variable-offset-v0380) · [Free Boundary Analysis](#free-boundary-analysis-v0390) · [Pipe Feature](#pipe-feature-v0390) · [Semi-Infinite Extrusion](#semi-infinite-extrusion-v0390) · [Prism Until Face](#prism-until-face-v0390) · [Inertia Properties](#inertia-properties-v0400) · [Extended Distance](#extended-distance-v0400) · [Find Surface](#find-surface-v0400) · [Shape Surgery](#shape-surgery-v0410) · [Plane Detection](#plane-detection-v0410) · [Closed Edge Splitting](#closed-edge-splitting-v0410) · [Geometry Conversion](#geometry-conversion-v0410) · [Face Restriction](#face-restriction-v0410) · [Solid Construction / 2D Fillet / Point Cloud](#solid-construction-2d-fillet-and-point-cloud-v0420) · [Face Subdivision](#face-subdivision-v0430) · [Curve-on-Surface Check](#curve-on-surface-check) · [Edge Connection](#edge-connection) · [Self-Intersection Detection](#self-intersection-detection-v0450) · [Bezier Conversion](#bezier-conversion) · [Edge Concavity Analysis](#edge-concavity-analysis-v0460) · [Geometric Edge Selection](#geometric-edge-selection-v121) · [Local Prism / Volume Inertia](#local-prism-and-volume-inertia-v0460) · [Local Revolution](#local-revolution-v0470) · [Draft Prism](#draft-prism-v0470) · [Constrained Filling](#constrained-filling-v0470) · [Shape Validity Checking](#shape-validity-checking-v0470) · [Local Operations / Validation / Fixing / Extrema](#local-operations-validation-fixing-and-extrema-v0480) · [ShapeAnalysis FreeBoundsProperties](#shapeanalysis-freeboundsproperties)
+
+---
+
+## Sub-Shape Extraction (v0.38.0)
+
+### `solidCount`
+
+Number of solid sub-shapes in this shape.
+
+```swift
+public var solidCount: Int { get }
+```
+
+- **OCCT:** `BRep_Builder` / `TopExp_Explorer` (via `OCCTShapeGetSolidCount`).
+- **Example:**
+  ```swift
+  let box = Shape.box(dx: 10, dy: 10, dz: 10)!
+  print(box.solidCount)  // 1
+  ```
+
+---
+
+### `solids`
+
+Extract all solid sub-shapes.
+
+```swift
+public var solids: [Shape] { get }
+```
+
+- **Returns:** Array of solid sub-shapes; empty if none.
+- **OCCT:** `TopExp_Explorer` with `TopAbs_SOLID`.
+- **Example:**
+  ```swift
+  let compound = Shape.compound([box1, box2])
+  let all = compound.solids  // [box1, box2]
+  ```
+
+---
+
+### `shellCount`
+
+Number of shell sub-shapes.
+
+```swift
+public var shellCount: Int { get }
+```
+
+- **OCCT:** `OCCTShapeGetShellCount`.
+
+---
+
+### `outerShell`
+
+The outer shell of this solid.
+
+```swift
+public var outerShell: Shape? { get }
+```
+
+For a solid with internal voids (multiple shells), returns the shell bounding the outer body, distinguishing it from inner void shells. Returns `nil` if the shape is not a solid or has no shell.
+
+- **Returns:** The outer shell, or `nil` if the shape is not a solid or has no shell.
+- **OCCT:** `BRepClass3d::OuterShell`.
+- **Example:**
+  ```swift
+  if let outer = hollowSolid.outerShell {
+      print(outer.faceCount)
+  }
+  ```
+
+---
+
+### `innerShells`
+
+Inner (void / cavity) shells of this solid — every shell except `outerShell`.
+
+```swift
+public var innerShells: [Shape] { get }
+```
+
+- **Returns:** Empty for a solid with no internal voids, or for a non-solid.
+- **OCCT:** `OCCTShapeInnerShells`.
+- **Example:**
+  ```swift
+  let cavities = part.innerShells
+  print("cavity count: \(cavities.count)")
+  ```
+
+---
+
+### `shells`
+
+Extract all shell sub-shapes.
+
+```swift
+public var shells: [Shape] { get }
+```
+
+- **Returns:** Array of all shell sub-shapes (inner and outer).
+- **OCCT:** `TopExp_Explorer` with `TopAbs_SHELL` (via `OCCTShapeGetShells`).
+
+---
+
+### `wireCount`
+
+Number of wire sub-shapes.
+
+```swift
+public var wireCount: Int { get }
+```
+
+- **OCCT:** `OCCTShapeGetWireCount`.
+
+---
+
+### `wires`
+
+Extract all wire sub-shapes.
+
+```swift
+public var wires: [Shape] { get }
+```
+
+- **Returns:** Array of wire sub-shapes; empty if none.
+- **OCCT:** `TopExp_Explorer` with `TopAbs_WIRE` (via `OCCTShapeGetWires`).
+
+---
+
+## Fuse and Blend (v0.38.0)
+
+### `fusedAndBlended(with:radius:)`
+
+Fuse with another shape and fillet the intersection edges.
+
+```swift
+public func fusedAndBlended(with other: Shape, radius: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `other` — Shape to fuse with.
+  - `radius` — Fillet radius applied to intersection edges after fusion.
+- **Returns:** Fused and filleted shape, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Fuse` + `BRepFilletAPI_MakeFillet`.
+- **Example:**
+  ```swift
+  if let result = boxA.fusedAndBlended(with: boxB, radius: 2.0) {
+      print(result.isValid)
+  }
+  ```
+
+---
+
+### `cutAndBlended(with:radius:)`
+
+Cut another shape from this shape and fillet the intersection edges.
+
+```swift
+public func cutAndBlended(with other: Shape, radius: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `other` — Shape to cut from this shape.
+  - `radius` — Fillet radius applied to intersection edges after cutting.
+- **Returns:** Cut and filleted shape, or `nil` on failure.
+- **OCCT:** `BRepAlgoAPI_Cut` + `BRepFilletAPI_MakeFillet`.
+
+---
+
+## Multi-Edge Evolving Fillet (v0.38.0)
+
+### `EvolvingFilletEdge`
+
+Describes an evolving radius along an edge for filleting.
+
+```swift
+public struct EvolvingFilletEdge: Sendable {
+    public var edgeIndex: Int
+    public var radiusPoints: [(parameter: Double, radius: Double)]
+    public init(edgeIndex: Int, radiusPoints: [(parameter: Double, radius: Double)])
+}
+```
+
+- `edgeIndex` — 1-based edge index.
+- `radiusPoints` — Array of `(parameter, radius)` pairs defining the radius evolution along the edge.
+
+---
+
+### `filletEvolving(_:)`
+
+Apply evolving-radius fillets to multiple edges simultaneously.
+
+```swift
+public func filletEvolving(_ edges: [EvolvingFilletEdge]) -> Shape?
+```
+
+- **Parameters:** `edges` — Array of edge specifications with radius evolution; must not be empty.
+- **Returns:** Filleted shape, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet` with evolving law (via `OCCTShapeFilletEvolving`).
+- **Example:**
+  ```swift
+  let spec = EvolvingFilletEdge(edgeIndex: 1, radiusPoints: [(0.0, 1.0), (1.0, 3.0)])
+  if let filled = box.filletEvolving([spec]) {
+      print(filled.isValid)
+  }
+  ```
+
+---
+
+## Per-Face Variable Offset (v0.38.0)
+
+### `offsetPerFace(defaultOffset:faceOffsets:tolerance:joinType:)`
+
+Offset a shape with different distances per face.
+
+```swift
+public func offsetPerFace(defaultOffset: Double,
+                           faceOffsets: [Int: Double],
+                           tolerance: Double = 1e-3,
+                           joinType: OffsetJoinType = .arc) -> Shape?
+```
+
+- **Parameters:**
+  - `defaultOffset` — Default offset distance applied to all faces not listed in `faceOffsets`.
+  - `faceOffsets` — Dictionary mapping 1-based face indices to custom offset distances.
+  - `tolerance` — Offset tolerance.
+  - `joinType` — Join strategy for offset gaps (`.arc` or `.intersection`).
+- **Returns:** Offset shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeThickSolid` (via `OCCTShapeOffsetPerFace`).
+- **Example:**
+  ```swift
+  if let result = solid.offsetPerFace(defaultOffset: 1.0,
+                                       faceOffsets: [1: 2.0, 3: 0.5]) {
+      print(result.isValid)
+  }
+  ```
+
+---
+
+## Free Boundary Analysis (v0.39.0)
+
+### `FreeBoundsResult`
+
+Result of free boundary analysis.
+
+```swift
+public struct FreeBoundsResult: Sendable {
+    public let wires: Shape
+    public let closedCount: Int
+    public let openCount: Int
+}
+```
+
+- `wires` — Compound shape containing all free boundary wires.
+- `closedCount` — Number of closed free boundary wires.
+- `openCount` — Number of open free boundary wires.
+
+---
+
+### `freeBounds(sewingTolerance:)`
+
+Analyze free boundary wires (open edges not shared by two faces).
+
+```swift
+public func freeBounds(sewingTolerance: Double = 1e-6) -> FreeBoundsResult?
+```
+
+Free boundaries indicate gaps in a shell. A watertight shell has no free boundaries.
+
+- **Parameters:** `sewingTolerance` — Tolerance for grouping free edges into wires.
+- **Returns:** Free bounds result, or `nil` if no free boundaries are found.
+- **OCCT:** `ShapeAnalysis_FreeBounds`.
+- **Example:**
+  ```swift
+  if let fb = shell.freeBounds() {
+      print("open gaps: \(fb.openCount)")
+  }
+  ```
+
+---
+
+### `fixedFreeBounds(sewingTolerance:closingTolerance:)`
+
+Fix free boundary wires by closing gaps.
+
+```swift
+public func fixedFreeBounds(sewingTolerance: Double = 1e-6,
+                             closingTolerance: Double = 1e-4) -> (shape: Shape, fixedCount: Int)?
+```
+
+- **Parameters:**
+  - `sewingTolerance` — Tolerance for sewing free edges.
+  - `closingTolerance` — Maximum distance to close a gap.
+- **Returns:** Tuple of `(fixed shape, number of wires fixed)`, or `nil` on failure.
+- **OCCT:** `ShapeFix_Shape` / `ShapeAnalysis_FreeBounds` (via `OCCTShapeFixFreeBounds`).
+
+---
+
+## Pipe Feature (v0.39.0)
+
+### `pipeFeature(profile:sketchFaceIndex:spine:fuse:)`
+
+Create a pipe feature by sweeping a profile along a spine, fused with or cut from this shape.
+
+```swift
+public func pipeFeature(profile: Shape, sketchFaceIndex: Int,
+                        spine: Wire, fuse: Bool = true) -> Shape?
+```
+
+- **Parameters:**
+  - `profile` — Profile shape (face) to sweep along the spine.
+  - `sketchFaceIndex` — 0-based index of the face on this shape where the profile sits.
+  - `spine` — Wire defining the sweep path.
+  - `fuse` — If `true`, adds material; if `false`, removes material.
+- **Returns:** Modified shape, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakePipe` (via `OCCTShapePipeFeatureFromProfile`).
+
+---
+
+## Semi-Infinite Extrusion (v0.39.0)
+
+### `extrudedSemiInfinite(direction:infinite:)`
+
+Extrude a shape semi-infinitely in a direction.
+
+```swift
+public func extrudedSemiInfinite(direction: SIMD3<Double>, infinite: Bool = false) -> Shape?
+```
+
+Creates a solid that extends infinitely in one direction from the profile. Useful for half-spaces and trimming operations.
+
+- **Parameters:**
+  - `direction` — Direction of extrusion.
+  - `infinite` — If `true`, extrude in both directions (fully infinite); if `false`, extrude in one direction (semi-infinite).
+- **Returns:** Extruded shape, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeHalfSpace` / `BRepBuilderAPI_MakeSolid` (via `OCCTShapeExtrudeSemiInfinite`).
+
+---
+
+## Prism Until Face (v0.39.0)
+
+### `prismUntilFace(profile:sketchFaceIndex:direction:fuse:untilFaceIndex:)`
+
+Extrude a profile until it reaches a target face, with automatic fuse/cut.
+
+```swift
+public func prismUntilFace(profile: Shape, sketchFaceIndex: Int,
+                           direction: SIMD3<Double>, fuse: Bool = true,
+                           untilFaceIndex: Int? = nil) -> Shape?
+```
+
+Uses `BRepFeat_MakePrism` which handles the until-face computation more robustly than a simple extrusion + Boolean.
+
+- **Parameters:**
+  - `profile` — Profile face to extrude.
+  - `sketchFaceIndex` — 0-based face index on this shape where the profile sits.
+  - `direction` — Extrusion direction.
+  - `fuse` — If `true`, adds material; if `false`, removes material.
+  - `untilFaceIndex` — 0-based face index on this shape where extrusion stops. Pass `nil` for thru-all.
+- **Returns:** Modified shape, or `nil` on failure.
+- **OCCT:** `BRepFeat_MakePrism` (via `OCCTShapePrismUntilFace`).
+
+---
+
+## Inertia Properties (v0.40.0)
+
+### `InertiaProperties`
+
+Volume-based (or surface-area-based) inertia properties.
+
+```swift
+public struct InertiaProperties {
+    public let mass: Double
+    public let centerOfMass: SIMD3<Double>
+    public let inertiaMatrix: [Double]
+    public let principalMoments: SIMD3<Double>
+    public let principalAxes: (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)
+    public let hasSymmetryAxis: Bool
+    public let hasSymmetryPoint: Bool
+}
+```
+
+- `mass` — Volume (for `inertiaProperties()`) or surface area (for `surfaceInertiaProperties()`).
+- `inertiaMatrix` — 9-element row-major 3×3 inertia tensor `[Ixx, Ixy, Ixz, Iyx, Iyy, Iyz, Izx, Izy, Izz]`.
+- `principalAxes` — Three unit vectors for the principal axes of inertia.
+
+---
+
+### `inertiaProperties()`
+
+Compute volume-based inertia properties.
+
+```swift
+public func inertiaProperties() -> InertiaProperties?
+```
+
+- **Returns:** Inertia properties, or `nil` if computation fails.
+- **OCCT:** `BRepGProp::VolumeProperties` (via `OCCTShapeInertiaProperties`).
+- **Example:**
+  ```swift
+  if let props = solid.inertiaProperties() {
+      print("volume: \(props.mass)")
+      print("center of mass: \(props.centerOfMass)")
+  }
+  ```
+
+---
+
+### `surfaceInertiaProperties()`
+
+Compute surface-area-based inertia properties.
+
+```swift
+public func surfaceInertiaProperties() -> InertiaProperties?
+```
+
+The `mass` field contains total surface area rather than volume.
+
+- **Returns:** Inertia properties, or `nil` if computation fails.
+- **OCCT:** `BRepGProp::SurfaceProperties` (via `OCCTShapeSurfaceInertiaProperties`).
+
+---
+
+## Extended Distance (v0.40.0)
+
+### `DistanceSolution`
+
+A closest-point solution between two shapes.
+
+```swift
+public struct DistanceSolution {
+    public let point1: SIMD3<Double>
+    public let point2: SIMD3<Double>
+    public let distance: Double
+}
+```
+
+---
+
+### `allDistanceSolutions(to:maxSolutions:)`
+
+Compute all distance extrema solutions between this shape and another.
+
+```swift
+public func allDistanceSolutions(to other: Shape, maxSolutions: Int = 32) -> [DistanceSolution]?
+```
+
+Returns all extremal point pairs (not just the minimum). Useful for finding multiple closest/farthest point pairs.
+
+- **Parameters:**
+  - `other` — The other shape.
+  - `maxSolutions` — Maximum number of solutions to return.
+- **Returns:** Array of distance solutions, or `nil` on failure.
+- **OCCT:** `BRepExtrema_DistShapeShape` (via `OCCTShapeAllDistanceSolutions`).
+- **Example:**
+  ```swift
+  if let solutions = shapeA.allDistanceSolutions(to: shapeB) {
+      let min = solutions.min(by: { $0.distance < $1.distance })
+      print("minimum distance: \(min?.distance ?? 0)")
+  }
+  ```
+
+---
+
+### `isInside(_:)`
+
+Check if this shape is fully contained inside another shape.
+
+```swift
+public func isInside(_ container: Shape) -> Bool?
+```
+
+- **Parameters:** `container` — The potential container shape.
+- **Returns:** `true` if this shape is inside the container; `nil` on failure.
+- **OCCT:** `BRepExtrema_DistShapeShape` inner solution detection (via `OCCTShapeIsInnerDistance`).
+
+---
+
+### `DistanceSupportType`
+
+Support type for a distance solution point.
+
+```swift
+public enum DistanceSupportType: Int32, Sendable {
+    case vertex = 0
+    case onEdge = 1
+    case inFace = 2
+}
+```
+
+---
+
+### `DistanceSolutionDetail`
+
+Detailed parametric info for a distance solution.
+
+```swift
+public struct DistanceSolutionDetail: Sendable {
+    public let supportType1: DistanceSupportType
+    public let supportType2: DistanceSupportType
+    public let paramEdge1: Double
+    public let paramEdge2: Double
+    public let paramFaceUV1: (u: Double, v: Double)
+    public let paramFaceUV2: (u: Double, v: Double)
+}
+```
+
+---
+
+### `distanceSolutionDetail(to:solutionIndex:)`
+
+Get detailed parametric info for a specific distance solution.
+
+```swift
+public func distanceSolutionDetail(to other: Shape, solutionIndex: Int) -> DistanceSolutionDetail?
+```
+
+Returns the support type (vertex/edge/face) and parametric location for each closest point. Use in conjunction with `allDistanceSolutions(to:)` to obtain the solution index.
+
+- **Parameters:**
+  - `other` — The other shape.
+  - `solutionIndex` — 0-based index into the solutions returned by `allDistanceSolutions(to:)`.
+- **Returns:** Detail struct, or `nil` on failure.
+- **OCCT:** `BRepExtrema_DistShapeShape` (via `OCCTShapeDistanceSolutionDetail`).
+
+---
+
+## Find Surface (v0.40.0)
+
+### `findSurfaceEx(tolerance:onlyPlane:)`
+
+Find the underlying geometric surface shared by a shape's edges.
+
+```swift
+public func findSurfaceEx(tolerance: Double = 1e-6, onlyPlane: Bool = false) -> Surface?
+```
+
+Analyzes the edges of a shape to determine if they lie on a common geometric surface.
+
+- **Parameters:**
+  - `tolerance` — Tolerance for surface detection.
+  - `onlyPlane` — If `true`, only look for planar surfaces.
+- **Returns:** The underlying surface, or `nil` if none found.
+- **OCCT:** `BRepLib_FindSurface` (via `OCCTShapeFindSurfaceEx`).
+- **Example:**
+  ```swift
+  if let surf = wire.findSurfaceEx(onlyPlane: true) {
+      print(surf.surfaceKind)  // .plane
+  }
+  ```
+
+---
+
+## Shape Surgery (v0.41.0)
+
+### `removingSubShapes(_:)`
+
+Remove sub-shapes from this shape surgically.
+
+```swift
+public func removingSubShapes(_ subShapes: [Shape]) -> Shape?
+```
+
+Uses `BRepTools_ReShape` to remove faces, edges, or vertices while preserving the remaining topology.
+
+- **Parameters:** `subShapes` — Sub-shapes to remove.
+- **Returns:** Shape with sub-shapes removed, or `nil` on failure.
+- **OCCT:** `BRepTools_ReShape` (via `OCCTShapeRemoveSubShapes`).
+
+---
+
+### `replacingSubShapes(_:)`
+
+Replace sub-shapes within this shape.
+
+```swift
+public func replacingSubShapes(_ replacements: [(old: Shape, new: Shape)]) -> Shape?
+```
+
+- **Parameters:** `replacements` — Array of `(old, new)` shape pairs.
+- **Returns:** Shape with replacements applied, or `nil` on failure.
+- **OCCT:** `BRepTools_ReShape` (via `OCCTShapeReplaceSubShapes`).
+
+---
+
+## Plane Detection (v0.41.0)
+
+### `DetectedPlane`
+
+Result of plane detection.
+
+```swift
+public struct DetectedPlane {
+    public let normal: SIMD3<Double>
+    public let origin: SIMD3<Double>
+}
+```
+
+---
+
+### `findPlane(tolerance:)`
+
+Find if this shape's edges lie in a plane.
+
+```swift
+public func findPlane(tolerance: Double = 1e-6) -> DetectedPlane?
+```
+
+- **Parameters:** `tolerance` — Tolerance for planarity check.
+- **Returns:** Detected plane, or `nil` if the shape is not planar.
+- **OCCT:** `BRepBuilderAPI_FindPlane` (via `OCCTShapeFindPlane`).
+- **Example:**
+  ```swift
+  if let plane = wire.findPlane() {
+      print("normal: \(plane.normal)")
+  }
+  ```
+
+---
+
+## Closed Edge Splitting (v0.41.0)
+
+### `dividedClosedEdges(splitPoints:)`
+
+Split closed (periodic) edges in the shape.
+
+```swift
+public func dividedClosedEdges(splitPoints: Int = 1) -> Shape?
+```
+
+Periodic edges (like circles) can cause issues in some algorithms. This splits each closed edge into segments.
+
+- **Parameters:** `splitPoints` — Number of split points per closed edge (default `1`, which doubles the edge count).
+- **Returns:** Shape with closed edges split, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideAngle` / `BRep_Builder` (via `OCCTShapeDivideClosedEdges`).
+
+---
+
+## Geometry Conversion (v0.41.0)
+
+### `withSurfacesAsBSpline(extrusion:revolution:offset:plane:)`
+
+Convert all surfaces to BSpline form.
+
+```swift
+public func withSurfacesAsBSpline(extrusion: Bool = true, revolution: Bool = true,
+                                   offset: Bool = true, plane: Bool = false) -> Shape?
+```
+
+- **Parameters:**
+  - `extrusion` — Convert extrusion surfaces (default `true`).
+  - `revolution` — Convert revolution surfaces (default `true`).
+  - `offset` — Convert offset surfaces (default `true`).
+  - `plane` — Convert planar surfaces (default `false`).
+- **Returns:** Shape with converted surfaces, or `nil` on failure.
+- **OCCT:** `ShapeCustom::ConvertToBSpline` (via `OCCTShapeCustomConvertToBSpline`).
+
+---
+
+### `withSurfacesAsRevolution()`
+
+Convert surfaces to revolution form where possible.
+
+```swift
+public func withSurfacesAsRevolution() -> Shape?
+```
+
+- **Returns:** Shape with surfaces converted to surfaces of revolution, or `nil` on failure.
+- **OCCT:** `ShapeCustom::ConvertToRevolution` (via `OCCTShapeCustomConvertToRevolution`).
+
+---
+
+## Face Restriction (v0.41.0)
+
+### `faceRestricted(by:)`
+
+Create restricted faces from a face and wire boundaries.
+
+```swift
+public func faceRestricted(by boundaries: [Wire]) -> [Shape]?
+```
+
+Uses `BRepAlgo_FaceRestrictor` to build faces on the underlying surface of this shape's first face, bounded by the given wires.
+
+- **Parameters:** `boundaries` — Wire boundaries that define the restricted regions.
+- **Returns:** Array of restricted face shapes (up to 64), or `nil` on failure.
+- **OCCT:** `BRepAlgo_FaceRestrictor` (via `OCCTShapeFaceRestrict`).
+
+---
+
+## Solid Construction, 2D Fillet and Point Cloud (v0.42.0)
+
+### `solidFromShells(_:)`
+
+Create a solid from one or more shell shapes.
+
+```swift
+public static func solidFromShells(_ shells: [Shape]) -> Shape?
+```
+
+The first shape provides the outer shell; additional shapes provide cavity (inner) shells.
+
+- **Parameters:** `shells` — Array of shapes containing shells; must not be empty.
+- **Returns:** Solid shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_MakeSolid` (via `OCCTSolidFromShells`).
+- **Example:**
+  ```swift
+  if let solid = Shape.solidFromShells([outerShell, innerShell]) {
+      print(solid.isValid)
+  }
+  ```
+
+---
+
+### `fillet2D(vertexIndices:radii:)`
+
+Apply 2D fillets (rounded corners) to a planar face at specified vertices.
+
+```swift
+public func fillet2D(vertexIndices: [Int], radii: [Double]) -> Shape?
+```
+
+- **Parameters:**
+  - `vertexIndices` — 0-based indices of vertices to fillet.
+  - `radii` — Fillet radius for each vertex; must match `vertexIndices` count.
+- **Returns:** Modified shape with fillets, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet2d` (via `OCCTFace2DFillet`).
+- **Note:** `vertexIndices` and `radii` must have equal length; mismatch returns `nil`.
+
+---
+
+### `chamfer2D(edgePairs:distances:)`
+
+Apply 2D chamfers (angled cuts) to a planar face between adjacent edge pairs.
+
+```swift
+public func chamfer2D(edgePairs: [(Int, Int)], distances: [Double]) -> Shape?
+```
+
+- **Parameters:**
+  - `edgePairs` — Array of `(edge1Index, edge2Index)` pairs (0-based) identifying adjacent edges.
+  - `distances` — Chamfer distance for each edge pair.
+- **Returns:** Modified shape with chamfers, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet2d` (via `OCCTFace2DChamfer`).
+
+---
+
+### `PointCloudGeometry`
+
+Classification of a point cloud's geometric arrangement.
+
+```swift
+public enum PointCloudGeometry {
+    case point(SIMD3<Double>)
+    case linear(origin: SIMD3<Double>, direction: SIMD3<Double>)
+    case planar(origin: SIMD3<Double>, normal: SIMD3<Double>)
+    case space
+}
+```
+
+- `.point` — All points are coincident.
+- `.linear` — Points are collinear.
+- `.planar` — Points are coplanar.
+- `.space` — Points are dispersed in 3D space.
+
+---
+
+### `analyzePointCloud(_:tolerance:)`
+
+Analyze a set of 3D points to determine their geometric arrangement.
+
+```swift
+public static func analyzePointCloud(_ points: [SIMD3<Double>], tolerance: Double = 1e-6) -> PointCloudGeometry?
+```
+
+- **Parameters:**
+  - `points` — Array of 3D points (minimum 1).
+  - `tolerance` — Tolerance for classification.
+- **Returns:** Classification result, or `nil` on failure.
+- **OCCT:** `GProp_PEquation` (via `OCCTAnalyzePointCloud`).
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [.init(0,0,0), .init(1,0,0), .init(2,0,0)]
+  if case .linear(let o, let d) = Shape.analyzePointCloud(pts) {
+      print("line direction: \(d)")
+  }
+  ```
+
+---
+
+## Face Subdivision (v0.43.0)
+
+### `dividedByArea(maxArea:)`
+
+Subdivide faces whose area exceeds a maximum threshold.
+
+```swift
+public func dividedByArea(maxArea: Double) -> Shape?
+```
+
+- **Parameters:** `maxArea` — Maximum face area; faces larger than this are split.
+- **Returns:** Shape with subdivided faces, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideArea` (via `OCCTShapeDivideByArea`).
+
+---
+
+### `dividedByParts(_:)`
+
+Subdivide faces into a target number of parts.
+
+```swift
+public func dividedByParts(_ parts: Int) -> Shape?
+```
+
+- **Parameters:** `parts` — Target number of parts per face.
+- **Returns:** Shape with subdivided faces, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideArea` in splitting-by-number mode (via `OCCTShapeDivideByParts`).
+
+---
+
+### `SmallFaceInfo`
+
+Result of small/degenerate face analysis.
+
+```swift
+public struct SmallFaceInfo: Sendable {
+    public let isSpotFace: Bool
+    public let isStripFace: Bool
+    public let isTwisted: Bool
+    public let spotLocation: SIMD3<Double>?
+}
+```
+
+- `isSpotFace` — Face collapsed to a point.
+- `isStripFace` — Face with negligible width.
+- `isTwisted` — Face with twisted geometry.
+- `spotLocation` — Location of a spot face (only set when `isSpotFace` is `true`).
+
+---
+
+### `checkSmallFaces(tolerance:)`
+
+Check faces for degenerate conditions (spot, strip, twisted).
+
+```swift
+public func checkSmallFaces(tolerance: Double = 1e-6) -> [SmallFaceInfo]
+```
+
+Returns only faces that have at least one degenerate condition.
+
+- **Parameters:** `tolerance` — Analysis tolerance.
+- **Returns:** Array of degenerate face descriptions; empty if none found.
+- **OCCT:** `ShapeAnalysis_CheckSmallFace` (via `OCCTShapeCheckSmallFaces`).
+
+---
+
+### `purgedLocations`
+
+Purge problematic location datums from the shape.
+
+```swift
+public var purgedLocations: Shape? { get }
+```
+
+Removes negative-scale and non-unit-scale transforms from the shape and all sub-shapes. Useful for cleaning imported geometry from STEP/IGES files.
+
+- **Returns:** Cleaned shape, or `nil` if purge was unnecessary or failed.
+- **OCCT:** `BRepLib::SameParameter` / transform purge (via `OCCTShapePurgeLocations`).
+
+---
+
+## Curve-on-Surface Check
+
+### `CurveOnSurfaceCheck`
+
+Result of a curve-on-surface consistency check.
+
+```swift
+public struct CurveOnSurfaceCheck {
+    public let maxDistance: Double
+    public let maxParameter: Double
+}
+```
+
+- `maxDistance` — Maximum deviation between 3D edge curves and their pcurves on faces.
+- `maxParameter` — Curve parameter where the maximum deviation occurs.
+
+---
+
+### `curveOnSurfaceCheck`
+
+Check edge-on-surface consistency.
+
+```swift
+public var curveOnSurfaceCheck: CurveOnSurfaceCheck? { get }
+```
+
+Examines all edge-face pairs in the shape and reports the maximum deviation between each edge's 3D curve and its parametric curve (pcurve) on the face surface.
+
+- **Returns:** Check result, or `nil` if the check fails.
+- **OCCT:** `BRep_Tool::CurveOnSurface` / `ShapeAnalysis_Edge` (via `OCCTShapeCheckCurveOnSurface`).
+
+---
+
+## Edge Connection
+
+### `connectedEdges`
+
+Connect edges by merging shared vertices in the shape.
+
+```swift
+public var connectedEdges: Shape? { get }
+```
+
+Identifies edges that share geometric positions and merges their vertices. Useful for healing imported geometry where topologically disconnected edges actually meet at the same point.
+
+- **Returns:** Shape with connected edges, or `nil` on failure.
+- **OCCT:** `ShapeFix_EdgeConnect` (via `OCCTShapeConnectEdges`).
+
+---
+
+## Self-Intersection Detection (v0.45.0)
+
+### `SelfIntersectionResult`
+
+Result of a self-intersection check.
+
+```swift
+public struct SelfIntersectionResult: Sendable {
+    public let overlapCount: Int
+    public let isDone: Bool
+}
+```
+
+---
+
+### `selfIntersection(tolerance:meshDeflection:)`
+
+Check the shape for self-intersection using BVH-accelerated triangle mesh overlap.
+
+```swift
+public func selfIntersection(tolerance: Double = 0.001,
+                              meshDeflection: Double = 0.5) -> SelfIntersectionResult?
+```
+
+Meshes the shape and detects overlapping triangle pairs.
+
+- **Parameters:**
+  - `tolerance` — Tolerance for detecting intersections.
+  - `meshDeflection` — Mesh deflection for triangulation.
+- **Returns:** Self-intersection result, or `nil` if the check failed.
+- **OCCT:** `BRepExtrema_SelfIntersection` (via `OCCTShapeSelfIntersection`).
+- **Example:**
+  ```swift
+  if let si = shape.selfIntersection() {
+      print("overlapping pairs: \(si.overlapCount)")
+  }
+  ```
+
+---
+
+## Bezier Conversion
+
+### `convertedToBezier`
+
+Convert all curves and surfaces in the shape to Bezier representations.
+
+```swift
+public var convertedToBezier: Shape? { get }
+```
+
+Replaces BSpline curves and surfaces with their Bezier equivalents. Converts 2D/3D curves, surfaces, lines, circles, conics, planes, revolutions, extrusions, and BSpline entities.
+
+- **Returns:** Shape with Bezier geometry, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ShapeConvertToBezier` (via `OCCTShapeConvertToBezier`).
+
+---
+
+## Edge Concavity Analysis (v0.46.0)
+
+### `EdgeConcavity`
+
+Edge concavity type from `BRepOffset_Analyse`.
+
+```swift
+public enum EdgeConcavity: Sendable {
+    case convex
+    case concave
+    case tangent
+}
+```
+
+- `.convex` — Edge connects two faces at a convex angle (e.g., outer corner of a box).
+- `.concave` — Edge connects two faces at a concave angle (e.g., inner corner of a groove).
+- `.tangent` — Edge connects two faces with a smooth (tangent) transition.
+
+---
+
+### `edgeConcavities(angle:)`
+
+Classify all edges by their concavity type.
+
+```swift
+public func edgeConcavities(angle: Double = 0.01) -> [(Edge, EdgeConcavity)]?
+```
+
+Analyzes the angles between adjacent faces at each edge.
+
+- **Parameters:** `angle` — Threshold angle (radians) for tangent classification.
+- **Returns:** Array of `(edge, concavity)` pairs in edge order, or `nil` on error.
+- **OCCT:** `BRepOffset_Analyse` (via `OCCTShapeAnalyzeEdgeConcavity`).
+
+---
+
+### `edgeConcavityCount(_:angle:)`
+
+Count edges of a specific concavity type.
+
+```swift
+public func edgeConcavityCount(_ type: EdgeConcavity, angle: Double = 0.01) -> Int?
+```
+
+- **Parameters:**
+  - `type` — Concavity type to count.
+  - `angle` — Threshold angle (radians) for tangent classification.
+- **Returns:** Count of matching edges, or `nil` on error.
+- **OCCT:** `BRepOffset_Analyse` (via `OCCTShapeCountEdgeConcavity`).
+
+---
+
+## Geometric Edge Selection (v1.2.1)
+
+### `edges(where:)`
+
+Select edges of this shape that satisfy a geometric predicate.
+
+```swift
+public func edges(where predicate: (Edge) -> Bool) -> [Edge]
+```
+
+A robust alternative to picking edges by raw index from `edges()` — the index shifts when model parameters change, whereas a geometric predicate keeps selecting the right edge.
+
+- **Parameters:** `predicate` — Returns `true` for edges to keep.
+- **Returns:** The matching edges (possibly empty), each with a valid index.
+- **Example:**
+  ```swift
+  // Round only long edges (> 50 mm)
+  let targets = bracket.edges { $0.length > 50 }
+  let rounded = bracket.filleted(edges: targets, radius: 2)
+  ```
+
+---
+
+### `concaveEdges(angle:)`
+
+The concave edges of this solid (interior angle > 180°).
+
+```swift
+public func concaveEdges(angle: Double = 0.01) -> [Edge]
+```
+
+Concave edges are typically the ones you want to fillet to add material to an inside corner.
+
+- **Parameters:** `angle` — Threshold (radians) below which an edge counts as tangent rather than concave.
+- **Returns:** The concave edges, or an empty array if none or on error.
+- **Example:**
+  ```swift
+  let rounded = bracket.filleted(edges: bracket.concaveEdges(), radius: 3)
+  ```
+
+---
+
+### `convexEdges(angle:)`
+
+The convex edges of this solid (interior angle < 180°).
+
+```swift
+public func convexEdges(angle: Double = 0.01) -> [Edge]
+```
+
+Convex edges are the outer corners of a part, typically the ones you want to chamfer or round.
+
+- **Parameters:** `angle` — Threshold (radians) below which an edge counts as tangent rather than convex.
+- **Returns:** The convex edges, or an empty array if none or on error.
+
+---
+
+### `edges(parallelTo:tolerance:)`
+
+Select straight edges whose direction is parallel to a given axis.
+
+```swift
+public func edges(parallelTo axis: SIMD3<Double>, tolerance: Double = 1e-4) -> [Edge]
+```
+
+Only line edges are considered (curved edges have no single direction). The test is sign-agnostic: edges pointing along `+axis` or `-axis` both match.
+
+- **Parameters:**
+  - `axis` — The reference direction (need not be unit length).
+  - `tolerance` — Maximum sine of the angle between edge and axis.
+- **Returns:** The matching straight edges, each with a valid index.
+- **Example:**
+  ```swift
+  // Round every vertical edge of an extruded prism
+  let verticals = part.edges(parallelTo: SIMD3(0, 0, 1))
+  let rounded = part.filleted(edges: verticals, radius: 2)
+  ```
+
+---
+
+### `edges(inBounds:_:)`
+
+Select edges fully contained within an axis-aligned bounding region.
+
+```swift
+public func edges(inBounds min: SIMD3<Double>, _ max: SIMD3<Double>) -> [Edge]
+```
+
+An edge matches when its entire bounding box lies inside the box spanned by `min...max` (inclusive).
+
+- **Parameters:**
+  - `min` — Lower corner of the region.
+  - `max` — Upper corner of the region.
+- **Returns:** The contained edges, each with a valid index.
+
+---
+
+## Local Prism and Volume Inertia (v0.46.0)
+
+### `localPrism(direction:)`
+
+Create a local prism (extrusion) from this shape along a direction.
+
+```swift
+public func localPrism(direction: SIMD3<Double>) -> Shape?
+```
+
+Uses `LocOpe_Prism` which tracks generated shapes for each input sub-shape.
+
+- **Parameters:** `direction` — Direction and distance of extrusion.
+- **Returns:** Extruded shape, or `nil` on failure.
+- **OCCT:** `LocOpe_Prism` (via `OCCTLocOpePrism`).
+
+---
+
+### `localPrism(direction:translation:)`
+
+Create a local prism with an additional translation.
+
+```swift
+public func localPrism(direction: SIMD3<Double>, translation: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:**
+  - `direction` — Primary direction and distance of extrusion.
+  - `translation` — Secondary translation vector.
+- **Returns:** Extruded shape, or `nil` on failure.
+- **OCCT:** `LocOpe_Prism` (via `OCCTLocOpePrismWithTranslation`).
+
+---
+
+### `VolumeInertia`
+
+Volume inertia properties of a solid shape.
+
+```swift
+public struct VolumeInertia: Sendable {
+    public let volume: Double
+    public let centerOfMass: SIMD3<Double>
+    public let inertiaTensor: [Double]
+    public let principalMoments: SIMD3<Double>
+    public let principalAxes: (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)
+    public let gyrationRadii: SIMD3<Double>
+}
+```
+
+- `inertiaTensor` — 9-element row-major 3×3 inertia tensor.
+- `gyrationRadii` — Radii of gyration about the three principal axes.
+
+---
+
+### `volumeInertia`
+
+Compute volume inertia properties of this shape.
+
+```swift
+public var volumeInertia: VolumeInertia? { get }
+```
+
+- **Returns:** Volume inertia result, or `nil` on error.
+- **OCCT:** `BRepGProp::VolumeProperties` (via `OCCTShapeVolumeInertia`).
+- **Example:**
+  ```swift
+  if let vi = solid.volumeInertia {
+      print("volume: \(vi.volume)")
+      print("gyration radii: \(vi.gyrationRadii)")
+  }
+  ```
+
+---
+
+### `SurfaceInertia`
+
+Surface inertia properties of a shape.
+
+```swift
+public struct SurfaceInertia: Sendable {
+    public let area: Double
+    public let centerOfMass: SIMD3<Double>
+    public let inertiaTensor: [Double]
+    public let principalMoments: SIMD3<Double>
+}
+```
+
+---
+
+### `surfaceInertia`
+
+Compute surface (area) inertia properties of this shape.
+
+```swift
+public var surfaceInertia: SurfaceInertia? { get }
+```
+
+- **Returns:** Surface inertia result, or `nil` on error.
+- **OCCT:** `BRepGProp::SurfaceProperties` (via `OCCTShapeSurfaceInertia`).
+
+---
+
+## Local Revolution (v0.47.0)
+
+### `localRevolution(axisOrigin:axisDirection:angle:)`
+
+Create a revolved shape by rotating a profile around an axis.
+
+```swift
+public func localRevolution(axisOrigin: SIMD3<Double>,
+                             axisDirection: SIMD3<Double>,
+                             angle: Double) -> Shape?
+```
+
+Uses `LocOpe_Revol` for local revolution operations with shape tracking.
+
+- **Parameters:**
+  - `axisOrigin` — Origin point of the rotation axis.
+  - `axisDirection` — Direction of the rotation axis.
+  - `angle` — Rotation angle in radians.
+- **Returns:** Revolved shape, or `nil` on failure.
+- **OCCT:** `LocOpe_Revol` (via `OCCTLocOpeRevol`).
+
+---
+
+### `localRevolution(axisOrigin:axisDirection:angle:angularOffset:)`
+
+Create a revolved shape with an angular offset.
+
+```swift
+public func localRevolution(axisOrigin: SIMD3<Double>,
+                             axisDirection: SIMD3<Double>,
+                             angle: Double,
+                             angularOffset: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `axisOrigin` — Origin point of the rotation axis.
+  - `axisDirection` — Direction of the rotation axis.
+  - `angle` — Rotation angle in radians.
+  - `angularOffset` — Angular offset for positioning in radians.
+- **Returns:** Revolved shape, or `nil` on failure.
+- **OCCT:** `LocOpe_Revol` (via `OCCTLocOpeRevolWithOffset`).
+
+---
+
+## Draft Prism (v0.47.0)
+
+These methods are on `Face`, not `Shape`.
+
+### `Face.draftPrism(height1:height2:angle:)`
+
+Create a draft prism (tapered extrusion) from this face.
+
+```swift
+public func draftPrism(height1: Double, height2: Double, angle: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `height1` — First height.
+  - `height2` — Second height.
+  - `angle` — Draft angle in radians.
+- **Returns:** Draft prism shape, or `nil` on failure.
+- **OCCT:** `LocOpe_DPrism` (via `OCCTLocOpeDPrism`).
+
+---
+
+### `Face.draftPrism(height:angle:)`
+
+Create a draft prism with a single height.
+
+```swift
+public func draftPrism(height: Double, angle: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `height` — Extrusion height.
+  - `angle` — Draft angle in radians.
+- **Returns:** Draft prism shape, or `nil` on failure.
+- **OCCT:** `LocOpe_DPrism` (via `OCCTLocOpeDPrismSingleHeight`).
+
+---
+
+## Constrained Filling (v0.47.0)
+
+### `ConstrainedFillInfo`
+
+Information about a constrained-fill BSpline surface.
+
+```swift
+public struct ConstrainedFillInfo: Sendable {
+    public let uDegree: Int
+    public let vDegree: Int
+    public let uPoles: Int
+    public let vPoles: Int
+}
+```
+
+---
+
+### `constrainedFill(edge1:edge2:edge3:edge4:maxDegree:maxSegments:)`
+
+Create a surface by filling a region bounded by 3 or 4 edge curves.
+
+```swift
+public static func constrainedFill(edge1: Edge, edge2: Edge, edge3: Edge,
+                                    edge4: Edge? = nil,
+                                    maxDegree: Int = 8,
+                                    maxSegments: Int = 15) -> Shape?
+```
+
+- **Parameters:**
+  - `edge1`, `edge2`, `edge3` — Required boundary edges.
+  - `edge4` — Optional fourth boundary edge; pass `nil` for a 3-sided fill.
+  - `maxDegree` — Maximum BSpline degree.
+  - `maxSegments` — Maximum number of segments.
+- **Returns:** Face shape built on the filled BSpline surface, or `nil` on failure.
+- **OCCT:** `GeomFill_ConstrainedFilling` (via `OCCTGeomFillConstrained`).
+
+---
+
+### `constrainedFillInfo`
+
+Get BSpline surface info from a constrained fill result.
+
+```swift
+public var constrainedFillInfo: ConstrainedFillInfo? { get }
+```
+
+- **Returns:** Surface info (degrees and pole counts), or `nil` if not a BSpline surface.
+- **OCCT:** `Geom_BSplineSurface` (via `OCCTGeomFillConstrainedInfo`).
+
+---
+
+## Shape Validity Checking (v0.47.0)
+
+### `CheckStatus`
+
+Shape check error status codes from `BRepCheck`.
+
+```swift
+public enum CheckStatus: Int32, Sendable, CaseIterable {
+    case noError = 0
+    case invalidPointOnCurve = 1
+    case invalidPointOnCurveOnSurface = 2
+    case invalidPointOnSurface = 3
+    case no3DCurve = 4
+    case multiple3DCurve = 5
+    case invalid3DCurve = 6
+    case noCurveOnSurface = 7
+    case invalidCurveOnSurface = 8
+    case invalidCurveOnClosedSurface = 9
+    case invalidSameRangeFlag = 10
+    case invalidSameParameterFlag = 11
+    case invalidDegeneratedFlag = 12
+    case freeEdge = 13
+    case invalidMultiConnexity = 14
+    case invalidRange = 15
+    case emptyWire = 16
+    case redundantEdge = 17
+    case selfIntersectingWire = 18
+    case noSurface = 19
+    case invalidWire = 20
+    case redundantWire = 21
+    case intersectingWires = 22
+    case invalidImbricationOfWires = 23
+    case emptyShell = 24
+    case redundantFace = 25
+    case invalidImbricationOfShells = 26
+    case unorientableShape = 27
+    case notClosed = 28
+    case notConnected = 29
+    case subshapeNotInShape = 30
+    case badOrientation = 31
+    case badOrientationOfSubshape = 32
+    case invalidPolygonOnTriangulation = 33
+    case invalidToleranceValue = 34
+    case enclosedRegion = 35
+    case checkFail = 36
+}
+```
+
+---
+
+### `CheckResult`
+
+Result of a shape validity check.
+
+```swift
+public struct CheckResult: Sendable {
+    public let isValid: Bool
+    public let errorCount: Int
+    public let firstError: CheckStatus?
+}
+```
+
+---
+
+### `checkResult`
+
+Check the overall validity of this shape.
+
+```swift
+public var checkResult: CheckResult { get }
+```
+
+- **Returns:** Check result with validity flag, error count, and first error code.
+- **OCCT:** `BRepCheck_Analyzer` (via `OCCTCheckShape`).
+- **Example:**
+  ```swift
+  let cr = shape.checkResult
+  if !cr.isValid, let err = cr.firstError {
+      print("invalid: \(err)")
+  }
+  ```
+
+---
+
+### `detailedCheckStatuses`
+
+Get detailed error status codes for this shape.
+
+```swift
+public var detailedCheckStatuses: [CheckStatus] { get }
+```
+
+Returns all individual error codes found during validation. Useful for diagnosing exactly what's wrong with an invalid shape.
+
+- **Returns:** Array of check status codes; empty if valid.
+- **OCCT:** `BRepCheck_Analyzer` (via `OCCTCheckShapeDetailed`).
+
+---
+
+### `Face.faceCheckResult`
+
+Check the validity of this face using `BRepCheck_Face`.
+
+```swift
+public var faceCheckResult: Shape.CheckResult { get }
+```
+
+More targeted than `Shape.checkResult` — includes wire intersection checks and face-specific validation.
+
+- **Returns:** Check result.
+- **OCCT:** `BRepCheck_Face` (via `OCCTCheckFace`).
+
+---
+
+## Local Operations, Validation, Fixing and Extrema (v0.48.0)
+
+### `localPipe(along:)`
+
+Perform a pipe sweep of this shape along a wire spine with shape tracking.
+
+```swift
+public func localPipe(along spine: Wire) -> Shape?
+```
+
+- **Parameters:** `spine` — Wire spine to sweep along.
+- **Returns:** Swept shape, or `nil` on failure.
+- **OCCT:** `LocOpe_Pipe` (via `OCCTLocOpePipe`).
+
+---
+
+### `localLinearForm(direction:from:to:)`
+
+Perform a linear form (translation sweep) of this shape with shape tracking.
+
+```swift
+public func localLinearForm(direction: SIMD3<Double>,
+                            from start: SIMD3<Double>,
+                            to end: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:**
+  - `direction` — Direction vector of the sweep.
+  - `start` — Start point of the sweep.
+  - `end` — End point of the sweep.
+- **Returns:** Swept shape, or `nil` on failure.
+- **OCCT:** `LocOpe_LinearForm` (via `OCCTLocOpeLinearForm`).
+
+---
+
+### `localRevolutionForm(axisOrigin:axisDirection:angle:)`
+
+Perform a revolution form of this shape with shape tracking.
+
+```swift
+public func localRevolutionForm(axisOrigin: SIMD3<Double>,
+                                 axisDirection: SIMD3<Double>,
+                                 angle: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `axisOrigin` — Origin point of the rotation axis.
+  - `axisDirection` — Direction of the rotation axis.
+  - `angle` — Rotation angle in radians.
+- **Returns:** Revolved shape, or `nil` on failure.
+- **OCCT:** `LocOpe_RevolutionForm` (via `OCCTLocOpeRevolutionForm`).
+
+---
+
+### `splitFace(at:with:)`
+
+Split a face of this shape by adding a wire on it.
+
+```swift
+public func splitFace(at faceIndex: Int, with wire: Wire) -> Shape?
+```
+
+- **Parameters:**
+  - `faceIndex` — 0-based index of the face to split.
+  - `wire` — Wire lying on the face that defines the split.
+- **Returns:** Modified shape with the face split, or `nil` on failure.
+- **OCCT:** `LocOpe_SplitShape` (via `OCCTLocOpeSplitShapeByWire`).
+
+---
+
+### `splitEdge(at:parameter:)`
+
+Split an edge of this shape at a parameter.
+
+```swift
+public func splitEdge(at edgeIndex: Int, parameter: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `edgeIndex` — 0-based index of the edge to split.
+  - `parameter` — Parameter along the edge (0.0–1.0) where the split occurs.
+- **Returns:** The split edge parts as a compound, or `nil` on failure.
+- **OCCT:** `LocOpe_SplitShape` (via `OCCTLocOpeSplitShapeByVertex`).
+
+---
+
+### `splitDrafts(faceIndex:wire:direction:planeOrigin:planeNormal:angle:)`
+
+Split a face with draft angles on both sides of a wire.
+
+```swift
+public func splitDrafts(faceIndex: Int, wire: Wire,
+                        direction: SIMD3<Double>,
+                        planeOrigin: SIMD3<Double>,
+                        planeNormal: SIMD3<Double>,
+                        angle: Double) -> Shape?
+```
+
+- **Parameters:**
+  - `faceIndex` — 0-based index of the face to split.
+  - `wire` — Wire defining the split line.
+  - `direction` — Extraction direction.
+  - `planeOrigin` — Origin of the neutral plane.
+  - `planeNormal` — Normal of the neutral plane.
+  - `angle` — Draft angle in radians.
+- **Returns:** Modified shape with draft, or `nil` on failure.
+- **OCCT:** `LocOpe_SplitDrafts` (via `OCCTLocOpeSplitDrafts`).
+- **Note:** `LocOpe_SplitDrafts::Perform()` can throw on incompatible geometry; the bridge wraps it in a try-catch.
+
+---
+
+### `commonEdges(with:)`
+
+Find edges in common between this shape and another.
+
+```swift
+public func commonEdges(with other: Shape) -> [Edge]
+```
+
+- **Parameters:** `other` — Shape to compare with.
+- **Returns:** Array of common edges (up to 100).
+- **OCCT:** `LocOpe_FindEdges` (via `OCCTLocOpeFindEdges`).
+
+---
+
+### `edgesInFace(at:)`
+
+Find edges of this shape that lie in a specific face.
+
+```swift
+public func edgesInFace(at faceIndex: Int) -> [Edge]
+```
+
+- **Parameters:** `faceIndex` — 0-based index of the face to check.
+- **Returns:** Array of edges found in the face (up to 100).
+- **OCCT:** `LocOpe_FindEdgesInFace` (via `OCCTLocOpeFindEdgesInFace`).
+
+---
+
+### `CSIntersection`
+
+Result of a curve-shape intersection.
+
+```swift
+public struct CSIntersection: Sendable {
+    public let point: SIMD3<Double>
+    public let parameter: Double
+    public let faceUV: SIMD2<Double>
+}
+```
+
+---
+
+### `intersectLine(origin:direction:)` *(LocOpe_CSIntersector variant)*
+
+Intersect a line with this shape to find intersection points.
+
+```swift
+public func intersectLine(origin: SIMD3<Double>, direction: SIMD3<Double>) -> [CSIntersection]
+```
+
+- **Parameters:**
+  - `origin` — Line origin.
+  - `direction` — Line direction.
+- **Returns:** Array of intersection points with curve parameters and face UV coordinates.
+- **OCCT:** `LocOpe_CSIntersector` (via `OCCTLocOpeCSIntersectLine`).
+- **Note:** This overload returns `[CSIntersection]` with face UV. A separate `IntCurvesFace`-backed overload in v0.61.0 returns `[LineFaceIntersection]`.
+
+---
+
+### `analyzeValidity(geometryChecks:)`
+
+Perform comprehensive validity analysis on this shape.
+
+```swift
+public func analyzeValidity(geometryChecks: Bool = true) -> Bool
+```
+
+- **Parameters:** `geometryChecks` — Whether to include geometry-level checks.
+- **Returns:** `true` if the shape is valid.
+- **OCCT:** `BRepCheck_Analyzer` (via `OCCTBRepCheckAnalyzerIsValid`).
+
+---
+
+### `TopAbs_ShapeEnum`
+
+Sub-shape type specifier.
+
+```swift
+public enum TopAbs_ShapeEnum: Int32, Sendable {
+    case compound = 0, compsolid = 1, solid = 2, shell = 3
+    case face = 4, wire = 5, edge = 6, vertex = 7
+}
+```
+
+---
+
+### `isSubShapeValid(type:at:)`
+
+Check if a specific sub-shape is valid within this shape's context.
+
+```swift
+public func isSubShapeValid(type: TopAbs_ShapeEnum, at index: Int) -> Bool
+```
+
+- **Parameters:**
+  - `type` — Type of sub-shape to check.
+  - `index` — 0-based index of the sub-shape.
+- **Returns:** `true` if the sub-shape is valid.
+- **OCCT:** `BRepCheck_Analyzer` (via `OCCTBRepCheckSubShapeValid`).
+
+---
+
+### `checkEdge(at:)`
+
+Check validity of an edge by index.
+
+```swift
+public func checkEdge(at index: Int) -> CheckResult
+```
+
+- **Parameters:** `index` — 0-based edge index.
+- **Returns:** Check result for the specified edge.
+- **OCCT:** `BRepCheck_Edge` (via `OCCTCheckEdge`).
+
+---
+
+### `checkWire(at:)`
+
+Check validity of a wire by index.
+
+```swift
+public func checkWire(at index: Int) -> CheckResult
+```
+
+- **OCCT:** `BRepCheck_Wire` (via `OCCTCheckWire`).
+
+---
+
+### `checkShell(at:)`
+
+Check validity of a shell by index.
+
+```swift
+public func checkShell(at index: Int) -> CheckResult
+```
+
+- **OCCT:** `BRepCheck_Shell` (via `OCCTCheckShell`).
+
+---
+
+### `checkVertex(at:)`
+
+Check validity of a vertex by index.
+
+```swift
+public func checkVertex(at index: Int) -> CheckResult
+```
+
+- **OCCT:** `BRepCheck_Vertex` (via `OCCTCheckVertex`).
+
+---
+
+### `limitTolerance(min:max:)`
+
+Limit all tolerances in this shape to a given range.
+
+```swift
+@discardableResult
+public func limitTolerance(min: Double, max: Double) -> Bool
+```
+
+- **Parameters:**
+  - `min` — Minimum tolerance.
+  - `max` — Maximum tolerance.
+- **Returns:** `true` if any tolerance was changed.
+- **OCCT:** `ShapeFix_ShapeTolerance::LimitTolerance` (via `OCCTShapeFixLimitTolerance`).
+
+---
+
+### `setTolerance(_:)`
+
+Set all tolerances in this shape to a specific value.
+
+```swift
+public func setTolerance(_ tolerance: Double)
+```
+
+- **Parameters:** `tolerance` — Tolerance value to set on all sub-shapes.
+- **OCCT:** `ShapeFix_ShapeTolerance::SetTolerance` (via `OCCTShapeFixSetTolerance`).
+
+---
+
+### `splitCommonVertices()`
+
+Split vertices that are shared between edges in incompatible ways.
+
+```swift
+public func splitCommonVertices() -> Shape?
+```
+
+- **Returns:** Fixed shape, or `nil` on failure.
+- **OCCT:** `ShapeFix_SplitCommonVertex` (via `OCCTShapeFixSplitCommonVertex`).
+
+---
+
+### `connectedFaces(tolerance:)`
+
+Connect adjacent faces in this shape's shell.
+
+```swift
+public func connectedFaces(tolerance: Double = 1e-4) -> Shape?
+```
+
+- **Parameters:** `tolerance` — Connection tolerance.
+- **Returns:** Fixed shape with connected faces, or `nil` on failure.
+- **OCCT:** `ShapeFix_FaceConnect` (via `OCCTShapeFixFaceConnect`).
+
+---
+
+### `fixEdgeSameParameter(tolerance:)`
+
+Fix same-parameter inconsistencies on all edges.
+
+```swift
+@discardableResult
+public func fixEdgeSameParameter(tolerance: Double = 0) -> Int
+```
+
+- **Parameters:** `tolerance` — Fixing tolerance (0 = default).
+- **Returns:** Number of edges fixed.
+- **OCCT:** `ShapeFix_Edge::FixSameParameter` (via `OCCTShapeFixEdgeSameParameter`).
+
+---
+
+### `fixEdgeVertexTolerance()`
+
+Fix vertex tolerance issues on all edges.
+
+```swift
+@discardableResult
+public func fixEdgeVertexTolerance() -> Int
+```
+
+- **Returns:** Number of edges fixed.
+- **OCCT:** `ShapeFix_Edge::FixVertexTolerance` (via `OCCTShapeFixEdgeVertexTolerance`).
+
+---
+
+### `fixWireVertices(precision:)`
+
+Fix vertex issues in all wires of this shape.
+
+```swift
+@discardableResult
+public func fixWireVertices(precision: Double = 1e-4) -> Int
+```
+
+- **Parameters:** `precision` — Precision for fixing.
+- **Returns:** Number of fixes applied.
+- **OCCT:** `ShapeFix_WireVertex` (via `OCCTShapeFixWireVertex`).
+
+---
+
+### `EdgeEdgeExtrema`
+
+Result of edge-edge distance extrema computation.
+
+```swift
+public struct EdgeEdgeExtrema: Sendable {
+    public let distance: Double
+    public let paramOnEdge1: Double
+    public let paramOnEdge2: Double
+    public let pointOnEdge1: SIMD3<Double>
+    public let pointOnEdge2: SIMD3<Double>
+    public let isParallel: Bool
+    public let solutionCount: Int
+}
+```
+
+---
+
+### `edgeEdgeExtrema(edgeIndex1:other:edgeIndex2:)`
+
+Compute distance extrema between two edges by index.
+
+```swift
+public func edgeEdgeExtrema(edgeIndex1: Int, other: Shape, edgeIndex2: Int) -> EdgeEdgeExtrema?
+```
+
+- **Parameters:**
+  - `edgeIndex1` — 0-based index of the first edge in this shape.
+  - `other` — Shape containing the second edge.
+  - `edgeIndex2` — 0-based index of the second edge in `other`.
+- **Returns:** Extrema result, or `nil` if no solutions or if edges are parallel.
+- **OCCT:** `BRepExtrema_ExtCC` (via `OCCTBRepExtremaExtCC`).
+- **Note:** Returns `nil` when edges are parallel (`isParallel == true`). Check `solutionCount > 0` guards this in the bridge.
+
+---
+
+### `PointFaceExtrema`
+
+Result of point-face distance extrema computation.
+
+```swift
+public struct PointFaceExtrema: Sendable {
+    public let distance: Double
+    public let faceUV: SIMD2<Double>
+    public let pointOnFace: SIMD3<Double>
+    public let solutionCount: Int
+}
+```
+
+---
+
+### `pointFaceExtrema(point:faceIndex:)`
+
+Compute distance from a point to a face.
+
+```swift
+public func pointFaceExtrema(point: SIMD3<Double>, faceIndex: Int) -> PointFaceExtrema?
+```
+
+- **Parameters:**
+  - `point` — 3D point.
+  - `faceIndex` — 0-based face index in this shape.
+- **Returns:** Extrema result, or `nil` on failure.
+- **OCCT:** `BRepExtrema_ExtPF` (via `OCCTBRepExtremaExtPF`).
+
+---
+
+### `FaceFaceExtrema`
+
+Result of face-face distance extrema computation.
+
+```swift
+public struct FaceFaceExtrema: Sendable {
+    public let distance: Double
+    public let face1UV: SIMD2<Double>
+    public let face2UV: SIMD2<Double>
+    public let pointOnFace1: SIMD3<Double>
+    public let pointOnFace2: SIMD3<Double>
+    public let solutionCount: Int
+}
+```
+
+---
+
+### `faceFaceExtrema(faceIndex1:other:faceIndex2:)`
+
+Compute distance extrema between two faces.
+
+```swift
+public func faceFaceExtrema(faceIndex1: Int, other: Shape, faceIndex2: Int) -> FaceFaceExtrema?
+```
+
+- **Parameters:**
+  - `faceIndex1` — 0-based index of the first face in this shape.
+  - `other` — Shape containing the second face.
+  - `faceIndex2` — 0-based index of the second face in `other`.
+- **Returns:** Extrema result, or `nil` on failure.
+- **OCCT:** `BRepExtrema_ExtFF` (via `OCCTBRepExtremaExtFF`).
+
+---
+
+### `dividedClosedFaces(splitPoints:)`
+
+Divide closed (wrapping) faces in this shape.
+
+```swift
+public func dividedClosedFaces(splitPoints: Int = 1) -> Shape?
+```
+
+Uses `ShapeUpgrade_ShapeDivideClosed` to split faces that wrap completely around (e.g., the lateral face of a cylinder).
+
+- **Parameters:** `splitPoints` — Number of split points per closed face.
+- **Returns:** Shape with divided faces, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideClosed` (via `OCCTShapeUpgradeDivideClosed`).
+
+---
+
+### `ContinuityLevel`
+
+Continuity level for shape division.
+
+```swift
+public enum ContinuityLevel: Int32, Sendable {
+    case c0 = 0, c1 = 1, c2 = 2, c3 = 3, cn = 4, g1 = 5, g2 = 6
+}
+```
+
+---
+
+### `dividedByContinuity(criterion:tolerance:)`
+
+Divide this shape at continuity breaks.
+
+```swift
+public func dividedByContinuity(criterion: ContinuityLevel = .c1, tolerance: Double = 1e-4) -> Shape?
+```
+
+Splits faces and edges at points where the geometry drops below the required continuity level.
+
+- **Parameters:**
+  - `criterion` — Minimum required continuity level.
+  - `tolerance` — Tolerance for continuity check.
+- **Returns:** Divided shape, or `nil` if no divisions needed or on failure.
+- **OCCT:** `ShapeUpgrade_ShapeDivideContinuity` (via `OCCTShapeUpgradeDivideContinuity`).
+
+---
+
+### `PointEdgeExtrema`
+
+Result of point-edge distance extrema computation.
+
+```swift
+public struct PointEdgeExtrema: Sendable {
+    public let distance: Double
+    public let parameter: Double
+    public let pointOnEdge: SIMD3<Double>
+    public let solutionCount: Int
+}
+```
+
+---
+
+### `pointEdgeExtrema(point:edgeIndex:)`
+
+Compute minimum distance from a point to an edge of this shape.
+
+```swift
+public func pointEdgeExtrema(point: SIMD3<Double>, edgeIndex: Int) -> PointEdgeExtrema?
+```
+
+- **Parameters:**
+  - `point` — 3D point.
+  - `edgeIndex` — 0-based edge index.
+- **Returns:** Extrema result, or `nil` on failure.
+- **OCCT:** `BRepExtrema_ExtPC` (via `OCCTBRepExtremaExtPC`).
+
+---
+
+### `EdgeFaceExtrema`
+
+Result of edge-face distance extrema computation.
+
+```swift
+public struct EdgeFaceExtrema: Sendable {
+    public let distance: Double
+    public let paramOnEdge: Double
+    public let faceUV: SIMD2<Double>
+    public let pointOnEdge: SIMD3<Double>
+    public let pointOnFace: SIMD3<Double>
+    public let isParallel: Bool
+    public let solutionCount: Int
+}
+```
+
+---
+
+### `edgeFaceExtrema(edgeIndex:other:faceIndex:)`
+
+Compute distance extrema between an edge and a face.
+
+```swift
+public func edgeFaceExtrema(edgeIndex: Int, other: Shape, faceIndex: Int) -> EdgeFaceExtrema?
+```
+
+- **Parameters:**
+  - `edgeIndex` — 0-based edge index in this shape.
+  - `other` — Shape containing the face.
+  - `faceIndex` — 0-based face index in `other`.
+- **Returns:** Extrema result, or `nil` if parallel or computation fails.
+- **OCCT:** `BRepExtrema_ExtCF` (via `OCCTBRepExtremaExtCF`).
+- **Note:** When `isParallel` is `true`, the returned struct has zero distance and `solutionCount == 0`.
+
+---
+
+### `removeSmallSolids(volumeThreshold:)`
+
+Remove small solids from this shape based on volume threshold.
+
+```swift
+public func removeSmallSolids(volumeThreshold: Double) -> Shape?
+```
+
+- **Parameters:** `volumeThreshold` — Solids with volume below this threshold are removed.
+- **Returns:** Shape with small solids removed, or `nil` on failure.
+- **OCCT:** `ShapeFix_FixSmallSolid` (via `OCCTShapeFixRemoveSmallSolids`).
+
+---
+
+### `mergeSmallSolids(widthFactorThreshold:)`
+
+Merge small solids into adjacent larger solids.
+
+```swift
+public func mergeSmallSolids(widthFactorThreshold: Double) -> Shape?
+```
+
+Small solids are merged into their neighbors rather than removed.
+
+- **Parameters:** `widthFactorThreshold` — Width factor below which solids are merged.
+- **Returns:** Shape with small solids merged, or `nil` on failure.
+- **OCCT:** `ShapeFix_FixSmallSolid` (via `OCCTShapeFixMergeSmallSolids`).
+
+---
+
+### `BSplineContinuity`
+
+Continuity requirement for BSpline restriction.
+
+```swift
+public enum BSplineContinuity: Int32, Sendable {
+    case c0 = 0, c1 = 1, c2 = 2, c3 = 3
+}
+```
+
+---
+
+### `bsplineRestriction(tol3d:tol2d:maxDegree:maxSegments:continuity3d:continuity2d:degreePriority:rational:)`
+
+Simplify BSpline surfaces and curves by restricting degree and segment count.
+
+```swift
+public func bsplineRestriction(
+    tol3d: Double = 0.01, tol2d: Double = 0.01,
+    maxDegree: Int = 8, maxSegments: Int = 100,
+    continuity3d: BSplineContinuity = .c1, continuity2d: BSplineContinuity = .c1,
+    degreePriority: Bool = true, rational: Bool = false
+) -> Shape?
+```
+
+- **Parameters:**
+  - `tol3d` — 3D approximation tolerance.
+  - `tol2d` — 2D approximation tolerance.
+  - `maxDegree` — Maximum BSpline degree.
+  - `maxSegments` — Maximum number of segments.
+  - `continuity3d` — 3D continuity requirement.
+  - `continuity2d` — 2D continuity requirement.
+  - `degreePriority` — If `true`, prioritize degree reduction over segment reduction.
+  - `rational` — Allow rational BSplines.
+- **Returns:** Simplified shape, or `nil` on failure.
+- **OCCT:** `ShapeCustom::BSplineRestriction` (via `OCCTShapeCustomBSplineRestriction`).
+
+---
+
+## ShapeAnalysis FreeBoundsProperties
+
+### `FreeBoundInfo`
+
+Properties of a single free bound (boundary wire).
+
+```swift
+public struct FreeBoundInfo: Sendable {
+    public let area: Double
+    public let perimeter: Double
+    public let ratio: Double
+    public let width: Double
+    public let notchCount: Int
+}
+```
+
+- `ratio` — `area / perimeter²` (shape factor).
+
+---
+
+### `FreeBoundsAnalysis`
+
+Summary result of free bounds analysis.
+
+```swift
+public struct FreeBoundsAnalysis: Sendable {
+    public let totalCount: Int
+    public let closedCount: Int
+    public let openCount: Int
+}
+```
+
+---
+
+### `freeBoundsAnalysis(tolerance:)`
+
+Analyze free bounds (boundary wires) of this shape.
+
+```swift
+public func freeBoundsAnalysis(tolerance: Double) -> FreeBoundsAnalysis
+```
+
+Free bounds are edges that belong to only one face.
+
+- **Parameters:** `tolerance` — Sewing tolerance for finding free bounds.
+- **Returns:** Analysis summary with closed and open bound counts.
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsAnalyze`).
+- **Example:**
+  ```swift
+  let fb = shell.freeBoundsAnalysis(tolerance: 1e-6)
+  print("open: \(fb.openCount), closed: \(fb.closedCount)")
+  ```
+
+---
+
+### `closedFreeBoundInfo(tolerance:index:)`
+
+Get properties of a closed free bound.
+
+```swift
+public func closedFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo?
+```
+
+- **Parameters:**
+  - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
+  - `index` — 0-based index of the closed free bound.
+- **Returns:** Properties, or `nil` if the index is out of range.
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetClosedBoundInfo`).
+
+---
+
+### `openFreeBoundInfo(tolerance:index:)`
+
+Get properties of an open free bound.
+
+```swift
+public func openFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo?
+```
+
+- **Parameters:**
+  - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
+  - `index` — 0-based index of the open free bound.
+- **Returns:** Properties, or `nil` if the index is out of range.
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetOpenBoundInfo`).
+
+---
+
+### `closedFreeBoundWire(tolerance:index:)`
+
+Get the wire shape of a closed free bound.
+
+```swift
+public func closedFreeBoundWire(tolerance: Double, index: Int) -> Shape?
+```
+
+- **Parameters:**
+  - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
+  - `index` — 0-based index of the closed free bound.
+- **Returns:** Wire as a `Shape`, or `nil` if the index is out of range.
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetClosedBoundWire`).
+
+---
+
+### `openFreeBoundWire(tolerance:index:)`
+
+Get the wire shape of an open free bound.
+
+```swift
+public func openFreeBoundWire(tolerance: Double, index: Int) -> Shape?
+```
+
+- **Parameters:**
+  - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
+  - `index` — 0-based index of the open free bound.
+- **Returns:** Wire as a `Shape`, or `nil` if the index is out of range.
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetOpenBoundWire`).

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -1,0 +1,1508 @@
+---
+title: Shape — Geometry Recognition & Polygon/Triangulation Data
+parent: API Reference
+---
+
+# Shape — Geometry Recognition & Polygon/Triangulation Data
+
+This page documents the geometry-utility and polygon/triangulation public API from `Sources/OCCTSwift/Shape.swift` (lines 11078–12192). It covers coordinate-system helpers, curve/surface construction utilities, 2D constraint solvers, shape modification tools, and the full polygon and triangulation layer. See the main [Shape](Shape.md) page for the core B-Rep API.
+
+## Topics
+
+- [Axis2Placement](#axis2placement) · [ShapeConstruct_Curve extensions](#shapeconstruct_curve-extensions) · [Bisector utilities](#bisector-utilities) · [GeomLib_Tool — Parameter Finding](#geomlib_tool--parameter-finding) · [GeomLib_IsPlanarSurface](#geomlib_isplanarsurface) · [GeomLib_CheckBSplineCurve / Check2dBSplineCurve](#geomlib_checkbsplinecurve--check2dbsplinecurve) · [GeomLib_Interpolate](#geomlib_interpolate) · [GccAna_Circ2d2TanRad](#gccana_circ2d2tanrad) · [GccAna_Circ2dTanCen](#gccana_circ2dtancen) · [GccAna_Lin2d2Tan](#gccana_lin2d2tan) · [Approx_SameParameter](#approx_sameparameter) · [ShapeUpgrade Curve Splitting](#shapeupgrade-curve-splitting) · [Shape Modifications](#shape-modifications) · [Surface Splitting](#surface-splitting) · [Curve/Surface Recognition](#curvesurface-recognition) · [Polygon2D](#polygon2d) · [Triangulation](#triangulation) · [Polygon3D](#polygon3d) · [PolygonOnTriangulation](#polygonontriangulation) · [Mesh Node Merging](#mesh-node-merging)
+
+---
+
+## Axis2Placement
+
+A standalone Swift class wrapping `Geom_Axis2Placement` — a right-handed 3D coordinate system with an origin, a main (Z) direction, and an X direction. Used to define placement frames for geometry factories.
+
+### `Axis2Placement.init(origin:normal:xDirection:)`
+
+Creates a right-handed 3D axis placement.
+
+```swift
+public init(origin: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>)
+```
+
+- **Parameters:** `origin` — origin point; `normal` — main (Z) direction; `xDirection` — X direction (must not be parallel to `normal`).
+- **OCCT:** `Geom_Axis2Placement(gp_Pnt, gp_Dir main, gp_Dir xDir)` via `OCCTAxis2PlacementCreate`.
+- **Example:**
+  ```swift
+  let ax = Axis2Placement(origin: SIMD3(0, 0, 10),
+                           normal: SIMD3(0, 0, 1),
+                           xDirection: SIMD3(1, 0, 0))
+  ```
+
+---
+
+### `location`
+
+The origin of this placement.
+
+```swift
+public var location: SIMD3<Double> { get }
+```
+
+- **Returns:** The origin point.
+- **OCCT:** `Geom_Axis2Placement::Location` via `OCCTAxis2PlacementLocation`.
+
+---
+
+### `mainDirection`
+
+The main (Z) direction of this placement.
+
+```swift
+public var mainDirection: SIMD3<Double> { get }
+```
+
+- **Returns:** The main axis direction.
+- **OCCT:** `Geom_Axis2Placement::Direction` via `OCCTAxis2PlacementDirection`.
+
+---
+
+### `xDirection`
+
+The X direction of this placement.
+
+```swift
+public var xDirection: SIMD3<Double> { get }
+```
+
+- **Returns:** The X-axis direction.
+- **OCCT:** `Geom_Axis2Placement::XDirection` via `OCCTAxis2PlacementXDirection`.
+
+---
+
+### `yDirection`
+
+The Y direction of this placement (computed from main × X).
+
+```swift
+public var yDirection: SIMD3<Double> { get }
+```
+
+- **Returns:** The Y-axis direction.
+- **OCCT:** `Geom_Axis2Placement::YDirection` via `OCCTAxis2PlacementYDirection`.
+
+---
+
+### `setDirection(_:)`
+
+Sets the main (Z) direction in place.
+
+```swift
+public func setDirection(_ dir: SIMD3<Double>)
+```
+
+- **Parameters:** `dir` — new main direction.
+- **OCCT:** `Geom_Axis2Placement::SetDirection` via `OCCTAxis2PlacementSetDirection`.
+
+---
+
+### `setXDirection(_:)`
+
+Sets the X direction in place.
+
+```swift
+public func setXDirection(_ dir: SIMD3<Double>)
+```
+
+- **Parameters:** `dir` — new X direction (must not be parallel to the main direction).
+- **OCCT:** `Geom_Axis2Placement::SetXDirection` via `OCCTAxis2PlacementSetXDirection`.
+
+---
+
+## ShapeConstruct_Curve extensions
+
+Extensions on `Curve3D` and `Curve2D` that expose `ShapeConstruct_Curve` utilities for B-Spline conversion and endpoint adjustment.
+
+### `Curve3D.convertSegmentToBSpline(first:last:precision:)`
+
+Converts a segment of this 3D curve to a BSpline using `ShapeConstruct_Curve`.
+
+```swift
+public func convertSegmentToBSpline(first: Double, last: Double,
+                                     precision: Double = 1e-6) -> Curve3D?
+```
+
+- **Parameters:** `first` — start parameter; `last` — end parameter; `precision` — geometric tolerance.
+- **Returns:** New `Curve3D` as a BSpline, or `nil` on failure.
+- **OCCT:** `ShapeConstruct_Curve::ConvertToBSpline` via `OCCTShapeConstructConvertToBSpline3D`.
+- **Example:**
+  ```swift
+  if let bsp = curve.convertSegmentToBSpline(first: 0, last: 1) {
+      print(bsp.degree)
+  }
+  ```
+
+---
+
+### `Curve3D.adjustEndpoints(start:end:)`
+
+Adjusts the 3D curve endpoints to match given 3D points.
+
+```swift
+public func adjustEndpoints(start: SIMD3<Double>, end: SIMD3<Double>) -> Bool
+```
+
+- **Parameters:** `start` — desired start point; `end` — desired end point.
+- **Returns:** `true` on success.
+- **OCCT:** `ShapeConstruct_Curve::AdjustCurve` via `OCCTShapeConstructAdjustCurve3D`.
+
+---
+
+### `Curve2D.convertSegmentToBSpline(first:last:precision:)`
+
+Converts a segment of this 2D curve to a BSpline using `ShapeConstruct_Curve`.
+
+```swift
+public func convertSegmentToBSpline(first: Double, last: Double,
+                                     precision: Double = 1e-6) -> Curve2D?
+```
+
+- **Parameters:** `first` — start parameter; `last` — end parameter; `precision` — geometric tolerance.
+- **Returns:** New `Curve2D` as a BSpline, or `nil` on failure.
+- **OCCT:** `ShapeConstruct_Curve::ConvertToBSpline` via `OCCTShapeConstructConvertToBSpline2D`.
+
+---
+
+### `Curve2D.adjustEndpoints(start:end:)`
+
+Adjusts the 2D curve endpoints to match given 2D points.
+
+```swift
+public func adjustEndpoints(start: (Double, Double), end: (Double, Double)) -> Bool
+```
+
+- **Parameters:** `start` — desired start point as `(x, y)`; `end` — desired end point as `(x, y)`.
+- **Returns:** `true` on success.
+- **OCCT:** `ShapeConstruct_Curve::AdjustCurve2d` via `OCCTShapeConstructAdjustCurve2D`.
+
+---
+
+## Bisector utilities
+
+Free-function bisector utilities and their associated value types.
+
+### `BisectorPoint`
+
+Point on a bisector curve with parameter and distance information.
+
+```swift
+public struct BisectorPoint {
+    public let paramOnC1: Double
+    public let paramOnC2: Double
+    public let paramOnBis: Double
+    public let distance: Double
+    public let x: Double
+    public let y: Double
+    public let isInfinite: Bool
+}
+```
+
+---
+
+### `BisectorIntersection`
+
+Result of a bisector-vs-bisector intersection computation.
+
+```swift
+public struct BisectorIntersection {
+    public let x: Double
+    public let y: Double
+    public let paramOnFirst: Double
+    public let paramOnSecond: Double
+}
+```
+
+---
+
+### `bisectorIntersections(a:b:c:d:)`
+
+Computes intersections between the perpendicular bisectors of two point pairs.
+
+```swift
+public func bisectorIntersections(
+    a: (Double, Double), b: (Double, Double),
+    c: (Double, Double), d: (Double, Double)
+) -> [BisectorIntersection]
+```
+
+The bisector of `(a, b)` is intersected with the bisector of `(c, d)`. The result is the circumcenter when the two pairs form a triangle.
+
+- **Parameters:** `a`, `b` — first point pair; `c`, `d` — second point pair, all as `(x, y)`.
+- **Returns:** Array of intersection points (zero, one, or two).
+- **OCCT:** `Bisector_BisecCC` / `Bisector_Inter` via `OCCTBisectorInterPointPoint`.
+- **Example:**
+  ```swift
+  let hits = bisectorIntersections(a: (0, 0), b: (4, 0),
+                                    c: (4, 0), d: (2, 3))
+  // hits[0] is the circumcenter of the triangle
+  ```
+
+---
+
+## GeomLib_Tool — Parameter Finding
+
+Extensions on `Curve3D`, `Surface`, and `Curve2D` for locating parameter values corresponding to 3D/2D points.
+
+### `Curve3D.parameterOf(point:maxDistance:)`
+
+Finds the parameter of a 3D point on this curve.
+
+```swift
+public func parameterOf(point: SIMD3<Double>, maxDistance: Double = 1.0) -> Double?
+```
+
+- **Parameters:** `point` — 3D point to locate; `maxDistance` — maximum allowed distance from the curve.
+- **Returns:** Parameter value, or `nil` if the point lies farther than `maxDistance` from the curve.
+- **OCCT:** `GeomLib_Tool::Parameter` via `OCCTGeomLibToolParameter3D`.
+- **Example:**
+  ```swift
+  if let t = curve.parameterOf(point: SIMD3(1, 2, 3), maxDistance: 0.01) {
+      let pt = curve.point(at: t)
+  }
+  ```
+
+---
+
+### `Surface.parametersOf(point:maxDistance:)`
+
+Finds the UV parameters of a 3D point on this surface.
+
+```swift
+public func parametersOf(point: SIMD3<Double>, maxDistance: Double = 1.0) -> (u: Double, v: Double)?
+```
+
+- **Parameters:** `point` — 3D point to locate; `maxDistance` — maximum allowed distance from the surface.
+- **Returns:** `(u, v)` parameter tuple, or `nil` if the point lies farther than `maxDistance`.
+- **OCCT:** `GeomLib_Tool::Parameters` via `OCCTGeomLibToolParametersSurface`.
+- **Example:**
+  ```swift
+  let s = Surface.sphere(center: .zero, radius: 5)!
+  if let uv = s.parametersOf(point: SIMD3(5, 0, 0), maxDistance: 0.1) {
+      print(uv.u, uv.v)
+  }
+  ```
+
+---
+
+### `Curve2D.parameterOf(point:maxDistance:)`
+
+Finds the parameter of a 2D point on this curve.
+
+```swift
+public func parameterOf(point: SIMD2<Double>, maxDistance: Double = 1.0) -> Double?
+```
+
+- **Parameters:** `point` — 2D point to locate; `maxDistance` — maximum allowed distance from the curve.
+- **Returns:** Parameter value, or `nil` if the point is too far from the curve.
+- **OCCT:** `GeomLib_Tool::Parameter` via `OCCTGeomLibToolParameter2D`.
+
+---
+
+## GeomLib_IsPlanarSurface
+
+Extensions on `Surface` for planarity testing.
+
+### `Surface.isPlanar(tolerance:)`
+
+Checks if this surface is planar within a given tolerance.
+
+```swift
+public func isPlanar(tolerance: Double = 1e-7) -> Bool
+```
+
+- **Parameters:** `tolerance` — planarity tolerance.
+- **Returns:** `true` if the surface is planar within `tolerance`.
+- **OCCT:** `GeomLib_IsPlanarSurface::IsPlanar` via `OCCTGeomLibIsPlanarSurface`.
+- **Example:**
+  ```swift
+  let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+  print(plane.isPlanar())  // true
+  ```
+
+---
+
+### `Surface.planarPlane(tolerance:)`
+
+Returns the underlying plane parameters if this surface is planar.
+
+```swift
+public func planarPlane(tolerance: Double = 1e-7) -> (origin: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>)?
+```
+
+- **Parameters:** `tolerance` — planarity tolerance.
+- **Returns:** Tuple of `(origin, normal, xDirection)` if planar, `nil` otherwise.
+- **OCCT:** `GeomLib_IsPlanarSurface::Plane` via `OCCTGeomLibPlanarSurfacePlane`.
+- **Example:**
+  ```swift
+  if let plane = surface.planarPlane() {
+      print(plane.normal)
+  }
+  ```
+
+---
+
+## GeomLib_CheckBSplineCurve / Check2dBSplineCurve
+
+Extensions on `Curve3D` and `Curve2D` for detecting and fixing reversed end tangents on BSpline curves.
+
+### `Curve3D.checkBSplineTangents(tolerance:angularTolerance:)`
+
+Checks if this BSpline curve has reversed end tangents.
+
+```swift
+public func checkBSplineTangents(tolerance: Double = 0.01,
+                                  angularTolerance: Double = 0.1) -> (fixFirst: Bool, fixLast: Bool)?
+```
+
+- **Parameters:** `tolerance` — positional tolerance; `angularTolerance` — angular tolerance in radians.
+- **Returns:** `(fixFirst, fixLast)` indicating which ends need fixing, or `nil` if not a BSpline or check failed.
+- **OCCT:** `GeomLib_CheckBSplineCurve` via `OCCTGeomLibCheckBSpline3D`.
+
+---
+
+### `Curve3D.fixBSplineTangents(fixFirst:fixLast:tolerance:angularTolerance:)`
+
+Fixes reversed end tangents on a BSpline curve.
+
+```swift
+public func fixBSplineTangents(fixFirst: Bool, fixLast: Bool,
+                                tolerance: Double = 0.01,
+                                angularTolerance: Double = 0.1) -> Curve3D?
+```
+
+- **Parameters:** `fixFirst` — fix the start tangent; `fixLast` — fix the end tangent; `tolerance` — positional tolerance; `angularTolerance` — angular tolerance.
+- **Returns:** New `Curve3D` with corrected tangents, or `nil` on failure.
+- **OCCT:** `GeomLib_CheckBSplineCurve::FixTangent` via `OCCTGeomLibFixBSpline3D`.
+- **Example:**
+  ```swift
+  if let flags = curve.checkBSplineTangents(),
+     (flags.fixFirst || flags.fixLast) {
+      let fixed = curve.fixBSplineTangents(fixFirst: flags.fixFirst, fixLast: flags.fixLast)
+  }
+  ```
+
+---
+
+### `Curve2D.checkBSplineTangents(tolerance:angularTolerance:)`
+
+Checks if this 2D BSpline curve has reversed end tangents.
+
+```swift
+public func checkBSplineTangents(tolerance: Double = 0.01,
+                                  angularTolerance: Double = 0.1) -> (fixFirst: Bool, fixLast: Bool)?
+```
+
+- **Parameters:** `tolerance` — positional tolerance; `angularTolerance` — angular tolerance.
+- **Returns:** `(fixFirst, fixLast)` flags, or `nil` if not a BSpline or check failed.
+- **OCCT:** `GeomLib_Check2dBSplineCurve` via `OCCTGeomLibCheckBSpline2D`.
+
+---
+
+### `Curve2D.fixBSplineTangents(fixFirst:fixLast:tolerance:angularTolerance:)`
+
+Fixes reversed end tangents on a 2D BSpline curve.
+
+```swift
+public func fixBSplineTangents(fixFirst: Bool, fixLast: Bool,
+                                tolerance: Double = 0.01,
+                                angularTolerance: Double = 0.1) -> Curve2D?
+```
+
+- **Parameters:** `fixFirst` — fix the start tangent; `fixLast` — fix the end tangent; `tolerance` — positional tolerance; `angularTolerance` — angular tolerance.
+- **Returns:** Fixed `Curve2D`, or `nil` on failure.
+- **OCCT:** `GeomLib_Check2dBSplineCurve::FixTangent` via `OCCTGeomLibFixBSpline2D`.
+
+---
+
+## GeomLib_Interpolate
+
+### `Curve3D.polynomialInterpolation(degree:points:parameters:)`
+
+Creates a BSpline curve by polynomial interpolation of 3D points at given parameters.
+
+```swift
+public static func polynomialInterpolation(degree: Int, points: [SIMD3<Double>],
+                                            parameters: [Double]) -> Curve3D?
+```
+
+`points` and `parameters` must have equal counts (≥ 2). The parameter values define how the polynomial fits progress along the curve.
+
+- **Parameters:** `degree` — polynomial degree; `points` — interpolation points; `parameters` — parameter values corresponding to each point.
+- **Returns:** Interpolated BSpline `Curve3D`, or `nil` if counts mismatch or interpolation fails.
+- **OCCT:** `GeomLib_Interpolate` via `OCCTGeomLibInterpolate`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(5,3,0), SIMD3(10,0,0)]
+  let params: [Double] = [0, 0.5, 1]
+  if let c = Curve3D.polynomialInterpolation(degree: 2, points: pts, parameters: params) {
+      let pt = c.point(at: 0.25)
+  }
+  ```
+
+---
+
+## GccAna_Circ2d2TanRad
+
+Free functions and supporting types for computing 2D circles tangent to two lines or through two points with a given radius.
+
+### `Circle2DSolution`
+
+A 2D circle solution returned by circle construction functions.
+
+```swift
+public struct Circle2DSolution: Sendable {
+    public let center: SIMD2<Double>
+    public let radius: Double
+}
+```
+
+---
+
+### `circlesTangentToLines(_:_:_:_:radius:tolerance:)`
+
+Finds circles tangent to two 2D lines with a given radius.
+
+```swift
+public func circlesTangentToLines(_ l1Origin: SIMD2<Double>, _ l1Direction: SIMD2<Double>,
+                                   _ l2Origin: SIMD2<Double>, _ l2Direction: SIMD2<Double>,
+                                   radius: Double, tolerance: Double = 1e-6) -> [Circle2DSolution]
+```
+
+- **Parameters:** `l1Origin`, `l1Direction` — first line (point + direction); `l2Origin`, `l2Direction` — second line; `radius` — required circle radius; `tolerance` — geometric tolerance.
+- **Returns:** Array of up to four `Circle2DSolution` values (may be empty if no solution exists).
+- **OCCT:** `GccAna_Circ2d2TanRad` (Lin+Lin variant) via `OCCTGccAnaCirc2d2TanRadLineLin`.
+- **Example:**
+  ```swift
+  let circles = circlesTangentToLines(SIMD2(0,0), SIMD2(1,0),
+                                       SIMD2(0,0), SIMD2(0,1),
+                                       radius: 3)
+  ```
+
+---
+
+### `circlesThroughPointsWithRadius(_:_:radius:tolerance:)`
+
+Finds circles passing through two 2D points with a given radius.
+
+```swift
+public func circlesThroughPointsWithRadius(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
+                                            radius: Double,
+                                            tolerance: Double = 1e-6) -> [Circle2DSolution]
+```
+
+- **Parameters:** `p1`, `p2` — two points to pass through; `radius` — required circle radius; `tolerance` — geometric tolerance.
+- **Returns:** Array of up to two `Circle2DSolution` values.
+- **OCCT:** `GccAna_Circ2d2TanRad` (Pnt+Pnt variant) via `OCCTGccAnaCirc2d2TanRadPntPnt`.
+- **Example:**
+  ```swift
+  let circles = circlesThroughPointsWithRadius(SIMD2(-3, 0), SIMD2(3, 0), radius: 5)
+  ```
+
+---
+
+## GccAna_Circ2dTanCen
+
+Free functions for computing 2D circles with a given centre.
+
+### `circleThroughPointCentered(point:center:)`
+
+Finds the circle centered at a given point that passes through another point.
+
+```swift
+public func circleThroughPointCentered(point: SIMD2<Double>,
+                                        center: SIMD2<Double>) -> Circle2DSolution?
+```
+
+- **Parameters:** `point` — a point on the circle; `center` — the required circle centre.
+- **Returns:** A `Circle2DSolution`, or `nil` if no solution exists.
+- **OCCT:** `GccAna_Circ2dTanCen` (Pnt+Pnt variant) via `OCCTGccAnaCirc2dTanCenPntPnt`.
+- **Example:**
+  ```swift
+  if let c = circleThroughPointCentered(point: SIMD2(5, 0), center: .zero) {
+      print(c.radius)  // 5.0
+  }
+  ```
+
+---
+
+### `circleTangentToLineCentered(lineOrigin:lineDirection:center:)`
+
+Finds the circle centred at a given point that is tangent to a line.
+
+```swift
+public func circleTangentToLineCentered(lineOrigin: SIMD2<Double>,
+                                         lineDirection: SIMD2<Double>,
+                                         center: SIMD2<Double>) -> Circle2DSolution?
+```
+
+- **Parameters:** `lineOrigin` — a point on the line; `lineDirection` — line direction; `center` — required circle centre.
+- **Returns:** A `Circle2DSolution`, or `nil` if no solution exists.
+- **OCCT:** `GccAna_Circ2dTanCen` (Lin+Pnt variant) via `OCCTGccAnaCirc2dTanCenLinPnt`.
+- **Example:**
+  ```swift
+  if let c = circleTangentToLineCentered(lineOrigin: SIMD2(0, 3),
+                                          lineDirection: SIMD2(1, 0),
+                                          center: SIMD2(2, 0)) {
+      print(c.radius)  // 3.0
+  }
+  ```
+
+---
+
+## GccAna_Lin2d2Tan
+
+Free functions and supporting types for 2D line construction.
+
+### `Line2DSolution`
+
+A 2D line solution returned by line construction functions.
+
+```swift
+public struct Line2DSolution: Sendable {
+    public let origin: SIMD2<Double>
+    public let direction: SIMD2<Double>
+}
+```
+
+---
+
+### `lineThroughPoints(_:_:tolerance:)`
+
+Finds the line passing through two 2D points.
+
+```swift
+public func lineThroughPoints(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
+                               tolerance: Double = 1e-6) -> Line2DSolution?
+```
+
+- **Parameters:** `p1`, `p2` — two points; `tolerance` — geometric tolerance.
+- **Returns:** A `Line2DSolution`, or `nil` if the points coincide within tolerance.
+- **OCCT:** `GccAna_Lin2d2Tan` (Pnt+Pnt variant) via `OCCTGccAnaLin2d2TanPntPnt`.
+- **Example:**
+  ```swift
+  if let line = lineThroughPoints(SIMD2(0, 0), SIMD2(1, 1)) {
+      print(line.direction)
+  }
+  ```
+
+---
+
+### `linesTangentToCircleThroughPoint(circleCenter:circleRadius:point:tolerance:)`
+
+Finds lines tangent to a circle and passing through a given point.
+
+```swift
+public func linesTangentToCircleThroughPoint(circleCenter: SIMD2<Double>,
+                                              circleRadius: Double,
+                                              point: SIMD2<Double>,
+                                              tolerance: Double = 1e-6) -> [Line2DSolution]
+```
+
+- **Parameters:** `circleCenter`, `circleRadius` — the circle; `point` — point the line must pass through; `tolerance` — geometric tolerance.
+- **Returns:** Array of up to two `Line2DSolution` values (one if the point lies on the circle).
+- **OCCT:** `GccAna_Lin2d2Tan` (Circ+Pnt variant) via `OCCTGccAnaLin2d2TanCircPnt`.
+- **Example:**
+  ```swift
+  let tangents = linesTangentToCircleThroughPoint(circleCenter: .zero,
+                                                   circleRadius: 3,
+                                                   point: SIMD2(5, 0))
+  ```
+
+---
+
+## Approx_SameParameter
+
+### `SameParameterResult`
+
+Result of a same-parameterisation check between a 3D curve and a 2D curve on a surface.
+
+```swift
+public struct SameParameterResult: Sendable {
+    public let isSameParameter: Bool
+    public let toleranceReached: Double
+}
+```
+
+`toleranceReached` is the maximum distance between the 3D curve and the surface-evaluated 2D curve.
+
+---
+
+### `Curve3D.checkSameParameter(curve2D:surface:tolerance:)`
+
+Checks if a 2D curve on a surface has the same parameterisation as this 3D curve.
+
+```swift
+public func checkSameParameter(curve2D: Curve2D, surface: Surface,
+                                tolerance: Double = 1e-6) -> SameParameterResult?
+```
+
+- **Parameters:** `curve2D` — the 2D curve; `surface` — the surface; `tolerance` — parameterisation tolerance.
+- **Returns:** `SameParameterResult`, or `nil` if the check fails.
+- **OCCT:** `Approx_SameParameter` via `OCCTApproxSameParameter`.
+- **Example:**
+  ```swift
+  if let r = curve3d.checkSameParameter(curve2D: pcurve, surface: face.surface!) {
+      print(r.isSameParameter, r.toleranceReached)
+  }
+  ```
+
+---
+
+## ShapeUpgrade Curve Splitting
+
+Extensions on `Curve3D` and `Curve2D` for splitting by continuity and converting to Bezier or arc/segment decompositions.
+
+### `Curve3D.splitByContinuity(criterion:tolerance:)`
+
+Splits this 3D curve at continuity breaks.
+
+```swift
+public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> [Curve3D]
+```
+
+- **Parameters:** `criterion` — continuity criterion: 0=C0, 1=C1, 2=C2, 3=C3, 4=CN; `tolerance` — geometric tolerance.
+- **Returns:** Array of `Curve3D` segments; may be a single-element array if no breaks are found.
+- **OCCT:** `ShapeUpgrade_SplitCurve3dContinuity` via `OCCTSplitCurve3dContinuity`.
+- **Example:**
+  ```swift
+  let segments = curve.splitByContinuity(criterion: 1)
+  ```
+
+---
+
+### `Curve2D.splitByContinuity(criterion:tolerance:)`
+
+Splits this 2D curve at continuity breaks.
+
+```swift
+public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> [Curve2D]
+```
+
+- **Parameters:** `criterion` — continuity criterion: 0=C0, 1=C1, 2=C2, 3=C3, 4=CN; `tolerance` — geometric tolerance.
+- **Returns:** Array of `Curve2D` segments.
+- **OCCT:** `ShapeUpgrade_SplitCurve2dContinuity` via `OCCTSplitCurve2dContinuity`.
+
+---
+
+### `Curve2D.convertToBezierSegments()`
+
+Converts this 2D curve to Bezier segments via `ShapeUpgrade`.
+
+```swift
+public func convertToBezierSegments() -> [Curve2D]
+```
+
+- **Returns:** Array of `Curve2D` Bezier segments. Returns an empty array on failure.
+- **OCCT:** `ShapeUpgrade_ConvertCurve2dToBezier` via `OCCTConvertCurve2dToBezier`.
+
+---
+
+### `Curve2D.approxArcsAndSegments(tolerance:angleTolerance:)`
+
+Approximates this 2D curve as a sequence of arcs and line segments.
+
+```swift
+public func approxArcsAndSegments(tolerance: Double, angleTolerance: Double) -> [Curve2D]
+```
+
+- **Parameters:** `tolerance` — positional approximation tolerance; `angleTolerance` — angular tolerance in radians.
+- **Returns:** Array of `Curve2D` arcs and segments. Returns an empty array on failure.
+- **OCCT:** `Geom2dConvert_ApproxArcsSegments` via `OCCTGeom2dConvertApproxArcsSegments`.
+
+---
+
+## Shape Modifications
+
+`Shape` extension methods wrapping `BRepTools` modification helpers.
+
+### `Shape.trsfModification(_:a11:a12:a13:a14:a21:a22:a23:a24:a31:a32:a33:a34:)`
+
+Applies a 3×4 affine transformation matrix to a shape via `BRepTools_TrsfModification`.
+
+```swift
+public static func trsfModification(_ shape: Shape,
+                                      a11: Double, a12: Double, a13: Double, a14: Double,
+                                      a21: Double, a22: Double, a23: Double, a24: Double,
+                                      a31: Double, a32: Double, a33: Double, a34: Double) -> Shape?
+```
+
+The matrix is specified row-major. Supports uniform scaling and rotation but not non-uniform scaling; use `gtrsfModification` for general affine transforms.
+
+- **Parameters:** `shape` — input shape; `a11`…`a34` — row-major 3×4 transformation matrix coefficients.
+- **Returns:** Transformed shape, or `nil` on failure.
+- **OCCT:** `BRepTools_TrsfModification` via `OCCTShapeTrsfModification`.
+- **Example:**
+  ```swift
+  // Translate by (10, 0, 0)
+  if let moved = Shape.trsfModification(box,
+                                         a11: 1, a12: 0, a13: 0, a14: 10,
+                                         a21: 0, a22: 1, a23: 0, a24: 0,
+                                         a31: 0, a32: 0, a33: 1, a34: 0) {
+      // use moved
+  }
+  ```
+
+---
+
+### `Shape.gtrsfModification(_:a11:a12:a13:a14:a21:a22:a23:a24:a31:a32:a33:a34:)`
+
+Applies a general (non-uniform) 3×4 transformation matrix via `BRepTools_GTrsfModification`.
+
+```swift
+public static func gtrsfModification(_ shape: Shape,
+                                       a11: Double, a12: Double, a13: Double, a14: Double,
+                                       a21: Double, a22: Double, a23: Double, a24: Double,
+                                       a31: Double, a32: Double, a33: Double, a34: Double) -> Shape?
+```
+
+Supports non-uniform scaling. Convert the shape to NURBS first for non-affine transforms to ensure geometry validity.
+
+- **Parameters:** `shape` — input shape; `a11`…`a34` — row-major 3×4 matrix.
+- **Returns:** Transformed shape, or `nil` on failure.
+- **OCCT:** `BRepTools_GTrsfModification` via `OCCTShapeGTrsfModification`.
+
+---
+
+### `Shape.deepCopy(_:copyGeometry:copyMesh:)`
+
+Creates a deep copy of a shape via `BRepTools_CopyModification`.
+
+```swift
+public static func deepCopy(_ shape: Shape,
+                              copyGeometry: Bool = true,
+                              copyMesh: Bool = true) -> Shape?
+```
+
+- **Parameters:** `shape` — shape to copy; `copyGeometry` — whether to copy underlying geometry; `copyMesh` — whether to copy cached triangulations.
+- **Returns:** Independent deep copy, or `nil` on failure.
+- **OCCT:** `BRepTools_CopyModification` via `OCCTShapeCopyModification`.
+- **Example:**
+  ```swift
+  if let copy = Shape.deepCopy(original) {
+      // Modifications to copy do not affect original
+  }
+  ```
+
+---
+
+### `Shape.bsplineRestrictionAdvanced(_:approxSurface:approxCurve3d:approxCurve2d:tol3d:tol2d:continuity3d:continuity2d:maxDegree:maxSegments:priorityDegree:convertRational:)`
+
+Restricts BSpline degree and segment count in a shape with fine-grained control.
+
+```swift
+public static func bsplineRestrictionAdvanced(_ shape: Shape,
+                                                approxSurface: Bool = true,
+                                                approxCurve3d: Bool = true,
+                                                approxCurve2d: Bool = true,
+                                                tol3d: Double = 0.01,
+                                                tol2d: Double = 0.01,
+                                                continuity3d: Int = 2,
+                                                continuity2d: Int = 2,
+                                                maxDegree: Int = 5,
+                                                maxSegments: Int = 20,
+                                                priorityDegree: Bool = true,
+                                                convertRational: Bool = false) -> Shape?
+```
+
+- **Parameters:** `approxSurface`/`approxCurve3d`/`approxCurve2d` — which geometry types to process; `tol3d`/`tol2d` — tolerances; `continuity3d`/`continuity2d` — required continuity (0=C0…6=CN); `maxDegree` — maximum polynomial degree; `maxSegments` — maximum segment count; `priorityDegree` — `true` = reduce degree first, `false` = reduce segments first; `convertRational` — convert rational BSplines to non-rational.
+- **Returns:** Restricted shape, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ConvertSurfaceToBSplineSurface` / `ShapeUpgrade_BSplineRestriction` via `OCCTShapeBSplineRestrictionAdvanced`.
+
+---
+
+### `Shape.convertToBSplineAdvanced(_:extrusionMode:revolutionMode:offsetMode:planeMode:)`
+
+Converts surfaces in a shape to BSpline with per-type control.
+
+```swift
+public static func convertToBSplineAdvanced(_ shape: Shape,
+                                              extrusionMode: Bool = true,
+                                              revolutionMode: Bool = true,
+                                              offsetMode: Bool = true,
+                                              planeMode: Bool = false) -> Shape?
+```
+
+- **Parameters:** `extrusionMode` — convert extrusion surfaces; `revolutionMode` — convert revolution surfaces; `offsetMode` — convert offset surfaces; `planeMode` — convert planes.
+- **Returns:** Shape with BSpline surfaces, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_ConvertSurfaceToBSplineSurface` via `OCCTShapeConvertToBSplineAdvanced`.
+
+---
+
+## Surface Splitting
+
+`Surface` extension for splitting surfaces by continuity, angle, or area.
+
+### `Surface.SplitResult`
+
+Result of a surface splitting operation.
+
+```swift
+public struct SplitResult: Sendable {
+    public let uSplitCount: Int
+    public let vSplitCount: Int
+}
+```
+
+---
+
+### `Surface.splitSurfaceByContinuity(criterion:tolerance:)`
+
+Splits this surface at continuity breaks.
+
+```swift
+public func splitSurfaceByContinuity(criterion: Int, tolerance: Double) -> SplitResult?
+```
+
+- **Parameters:** `criterion` — continuity criterion: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN; `tolerance` — geometric tolerance.
+- **Returns:** `SplitResult` with U and V split counts, or `nil` if no splits are found.
+- **OCCT:** `ShapeUpgrade_SplitSurface` / continuity variant via `OCCTSplitSurfaceContinuity`.
+
+---
+
+### `Surface.splitByAngle(_:)`
+
+Splits this surface where the normal varies by more than a maximum angle.
+
+```swift
+public func splitByAngle(_ maxAngle: Double) -> SplitResult?
+```
+
+- **Parameters:** `maxAngle` — maximum allowed normal deviation in radians.
+- **Returns:** `SplitResult`, or `nil` if no splits are needed.
+- **OCCT:** `ShapeUpgrade_SplitSurfaceAngle` via `OCCTSplitSurfaceAngle`.
+
+---
+
+### `Surface.splitByArea(parts:intoSquares:)`
+
+Splits this surface into approximately equal-area parts.
+
+```swift
+public func splitByArea(parts: Int, intoSquares: Bool = false) -> SplitResult?
+```
+
+- **Parameters:** `parts` — desired number of parts; `intoSquares` — if `true`, target square patches.
+- **Returns:** `SplitResult`, or `nil` on failure.
+- **OCCT:** `ShapeUpgrade_SplitSurfaceArea` via `OCCTSplitSurfaceArea`.
+
+---
+
+## Curve/Surface Recognition
+
+Types and extensions for recognising and converting geometry to analytical (canonical) forms.
+
+### `CurveToAnalyticalResult`
+
+Result of converting a 3D curve to its analytical form.
+
+```swift
+public struct CurveToAnalyticalResult: Sendable {
+    public let curve: Curve3D
+    public let newFirst: Double
+    public let newLast: Double
+    public let gap: Double
+}
+```
+
+`gap` is the maximum deviation between the original and the recognized analytical curve.
+
+---
+
+### `Curve3D.toAnalytical(tolerance:first:last:)`
+
+Attempts to convert this curve to an analytical form (line, circle, ellipse, etc.).
+
+```swift
+public func toAnalytical(tolerance: Double, first: Double, last: Double) -> CurveToAnalyticalResult?
+```
+
+- **Parameters:** `tolerance` — recognition tolerance; `first`, `last` — parameter range to examine.
+- **Returns:** `CurveToAnalyticalResult` with the simplified curve and gap, or `nil` if no analytical form is recognised.
+- **OCCT:** `GeomConvert_CurveToAnaCurve` via `OCCTGeomConvertCurveToAnalytical`.
+- **Example:**
+  ```swift
+  if let r = bsplineCurve.toAnalytical(tolerance: 1e-4, first: 0, last: 1) {
+      print(r.curve.curveKind, r.gap)
+  }
+  ```
+
+---
+
+### `Curve3D.arePointsLinear(_:tolerance:)`
+
+Checks whether a set of 3D points are collinear within a tolerance.
+
+```swift
+public static func arePointsLinear(_ points: [SIMD3<Double>],
+                                    tolerance: Double) -> (isLinear: Bool, deviation: Double)
+```
+
+- **Parameters:** `points` — array of 3D points; `tolerance` — collinearity tolerance.
+- **Returns:** `(isLinear, deviation)` — `isLinear` indicates collinearity; `deviation` is the maximum perpendicular distance from the best-fit line.
+- **OCCT:** `GeomConvert_ConvType::IsLinear` via `OCCTGeomConvertIsLinear`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [.zero, SIMD3(1,0,0), SIMD3(2,0,0)]
+  let (linear, dev) = Curve3D.arePointsLinear(pts, tolerance: 1e-6)
+  // linear == true, dev ≈ 0
+  ```
+
+---
+
+### `SurfaceToAnalyticalResult`
+
+Result of converting a surface to its analytical form.
+
+```swift
+public struct SurfaceToAnalyticalResult: Sendable {
+    public let surface: Surface
+    public let gap: Double
+}
+```
+
+---
+
+### `Surface.toAnalyticalWithGap(tolerance:)`
+
+Attempts to convert this surface to an analytical form.
+
+```swift
+public func toAnalyticalWithGap(tolerance: Double) -> SurfaceToAnalyticalResult?
+```
+
+- **Parameters:** `tolerance` — recognition tolerance.
+- **Returns:** `SurfaceToAnalyticalResult` with the simplified surface and deviation, or `nil` if no analytical form is recognised.
+- **OCCT:** `GeomConvert_SurfToAnaSurf` via `OCCTGeomConvertSurfToAnalytical`.
+- **Example:**
+  ```swift
+  if let r = bsplineSurface.toAnalyticalWithGap(tolerance: 1e-5) {
+      print(r.surface.surfaceKind, r.gap)
+  }
+  ```
+
+---
+
+### `Surface.toAnalyticalWithGap(tolerance:uMin:uMax:vMin:vMax:)`
+
+Attempts to convert this surface to an analytical form within UV bounds.
+
+```swift
+public func toAnalyticalWithGap(tolerance: Double,
+                                  uMin: Double, uMax: Double,
+                                  vMin: Double, vMax: Double) -> SurfaceToAnalyticalResult?
+```
+
+- **Parameters:** `tolerance` — recognition tolerance; `uMin`, `uMax`, `vMin`, `vMax` — UV parameter bounds to consider.
+- **Returns:** `SurfaceToAnalyticalResult`, or `nil` on failure.
+- **OCCT:** `GeomConvert_SurfToAnaSurf` (bounded variant) via `OCCTGeomConvertSurfToAnalyticalBounded`.
+
+---
+
+### `Surface.isCanonical`
+
+Whether this surface is already in a canonical (analytical) form.
+
+```swift
+public var isCanonical: Bool { get }
+```
+
+- **Returns:** `true` if the surface is a plane, sphere, cylinder, cone, or torus rather than a BSpline.
+- **OCCT:** `GeomConvert_ConvType::IsCanonical` via `OCCTGeomConvertIsCanonical`.
+
+---
+
+## Polygon2D
+
+`Polygon2D` is a standalone Swift class wrapping `Poly_Polygon2D` — a sequence of 2D points used to represent a parametric-space polygon on a face.
+
+### `Polygon2D.create(points:)`
+
+Creates a 2D polygon from an array of 2D points.
+
+```swift
+public static func create(points: [SIMD2<Double>]) -> Polygon2D?
+```
+
+- **Parameters:** `points` — ordered sequence of 2D points.
+- **Returns:** `Polygon2D`, or `nil` on failure.
+- **OCCT:** `Poly_Polygon2D` via `OCCTPolyPolygon2DCreate`.
+- **Example:**
+  ```swift
+  if let poly = Polygon2D.create(points: [SIMD2(0,0), SIMD2(1,0), SIMD2(0.5,1)]) {
+      print(poly.nodeCount)  // 3
+  }
+  ```
+
+---
+
+### `Polygon2D.nodeCount`
+
+The number of nodes in this polygon.
+
+```swift
+public var nodeCount: Int { get }
+```
+
+- **OCCT:** `Poly_Polygon2D::NbNodes` via `OCCTPolyPolygon2DNbNodes`.
+
+---
+
+### `Polygon2D.node(at:)`
+
+Returns the 2D point at a given 0-based index.
+
+```swift
+public func node(at index: Int) -> SIMD2<Double>?
+```
+
+- **Parameters:** `index` — 0-based node index.
+- **Returns:** `SIMD2<Double>` position, or `nil` if the index is out of range.
+- **OCCT:** `Poly_Polygon2D::Nodes` via `OCCTPolyPolygon2DNode`.
+
+---
+
+### `Polygon2D.nodes()`
+
+Returns all nodes.
+
+```swift
+public func nodes() -> [SIMD2<Double>]
+```
+
+- **Returns:** Array of all 2D node positions in sequence order.
+
+---
+
+### `Polygon2D.deflection`
+
+The deflection value associated with this polygon.
+
+```swift
+public var deflection: Double { get set }
+```
+
+- **OCCT:** `Poly_Polygon2D::Deflection` / `SetDeflection` via `OCCTPolyPolygon2DDeflection` / `OCCTPolyPolygon2DSetDeflection`.
+
+---
+
+### `Polygon2D.copy()`
+
+Creates a deep copy of this polygon.
+
+```swift
+public func copy() -> Polygon2D?
+```
+
+- **Returns:** Independent copy, or `nil` on failure.
+- **OCCT:** `Poly_Polygon2D::Copy` via `OCCTPolyPolygon2DCopy`.
+
+---
+
+## Triangulation
+
+`Triangulation` wraps `Poly_Triangulation` — a 3D mesh defined by node positions and triangle vertex indices. Used as input to `TopologyGraph.createTriangulationRep(_:)` for populating the cached mesh tier of a graph. Triangle indices are 0-based on the Swift boundary; the bridge converts to OCCT's 1-based representation internally.
+
+### `Triangulation.create(nodes:triangles:)`
+
+Creates a triangulation from node positions and triangle vertex indices.
+
+```swift
+public static func create(nodes: [SIMD3<Double>], triangles: [Int]) -> Triangulation?
+```
+
+- **Parameters:** `nodes` — 3D node positions; `triangles` — triangle vertex indices, 0-based, three per triangle (`triangles.count` must be a multiple of 3).
+- **Returns:** `Triangulation`, or `nil` if inputs are empty, `triangles.count` is not a multiple of 3, or any index is out of range.
+- **OCCT:** `Poly_Triangulation(nbNodes, nbTriangles)` via `OCCTPolyTriangulationCreate`.
+- **Example:**
+  ```swift
+  let nodes: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(1,0,0), SIMD3(0,1,0)]
+  if let tri = Triangulation.create(nodes: nodes, triangles: [0, 1, 2]) {
+      print(tri.triangleCount)  // 1
+  }
+  ```
+
+---
+
+### `Triangulation.nodeCount`
+
+The number of nodes.
+
+```swift
+public var nodeCount: Int { get }
+```
+
+- **OCCT:** `Poly_Triangulation::NbNodes` via `OCCTPolyTriangulationNbNodes`.
+
+---
+
+### `Triangulation.triangleCount`
+
+The number of triangles.
+
+```swift
+public var triangleCount: Int { get }
+```
+
+- **OCCT:** `Poly_Triangulation::NbTriangles` via `OCCTPolyTriangulationNbTriangles`.
+
+---
+
+### `Triangulation.node(at:)`
+
+Returns the 3D position of a node at a given 0-based index.
+
+```swift
+public func node(at index: Int) -> SIMD3<Double>?
+```
+
+- **Parameters:** `index` — 0-based node index.
+- **Returns:** Node position, or `nil` if out of range.
+- **OCCT:** `Poly_Triangulation::Node` via `OCCTPolyTriangulationNode`.
+
+---
+
+### `Triangulation.triangle(at:)`
+
+Returns the three 0-based vertex indices for a triangle.
+
+```swift
+public func triangle(at index: Int) -> (Int, Int, Int)?
+```
+
+- **Parameters:** `index` — 0-based triangle index.
+- **Returns:** Tuple of three 0-based node indices, or `nil` if out of range.
+- **OCCT:** `Poly_Triangulation::Triangle` via `OCCTPolyTriangulationTriangle`.
+- **Example:**
+  ```swift
+  if let (n0, n1, n2) = tri.triangle(at: 0) {
+      let p0 = tri.node(at: n0)
+  }
+  ```
+
+---
+
+### `Triangulation.deflection`
+
+The deflection value of this triangulation.
+
+```swift
+public var deflection: Double { get set }
+```
+
+- **OCCT:** `Poly_Triangulation::Deflection` / `SetDeflection` via `OCCTPolyTriangulationDeflection` / `OCCTPolyTriangulationSetDeflection`.
+
+---
+
+## Polygon3D
+
+`Polygon3D` wraps `Poly_Polygon3D` — a sequence of 3D points with optional curve parameters, used to represent an edge approximation in 3D space.
+
+### `Polygon3D.create(points:)`
+
+Creates a 3D polygon from an array of 3D points.
+
+```swift
+public static func create(points: [SIMD3<Double>]) -> Polygon3D?
+```
+
+- **Parameters:** `points` — ordered sequence of 3D points.
+- **Returns:** `Polygon3D`, or `nil` on failure.
+- **OCCT:** `Poly_Polygon3D` via `OCCTPolyPolygon3DCreate`.
+
+---
+
+### `Polygon3D.create(points:parameters:)`
+
+Creates a 3D polygon with curve parameters.
+
+```swift
+public static func create(points: [SIMD3<Double>], parameters: [Double]) -> Polygon3D?
+```
+
+- **Parameters:** `points` — ordered 3D points; `parameters` — corresponding curve parameter values (must have the same count as `points`).
+- **Returns:** `Polygon3D` with parameters, or `nil` on failure.
+- **OCCT:** `Poly_Polygon3D` (parameterised overload) via `OCCTPolyPolygon3DCreateWithParams`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [SIMD3(0,0,0), SIMD3(5,0,0), SIMD3(10,0,0)]
+  let params: [Double] = [0, 0.5, 1]
+  if let poly = Polygon3D.create(points: pts, parameters: params) {
+      print(poly.hasParameters)  // true
+  }
+  ```
+
+---
+
+### `Polygon3D.nodeCount`
+
+The number of nodes.
+
+```swift
+public var nodeCount: Int { get }
+```
+
+- **OCCT:** `Poly_Polygon3D::NbNodes` via `OCCTPolyPolygon3DNbNodes`.
+
+---
+
+### `Polygon3D.node(at:)`
+
+Returns the 3D position at a given 0-based node index.
+
+```swift
+public func node(at index: Int) -> SIMD3<Double>?
+```
+
+- **Parameters:** `index` — 0-based node index.
+- **Returns:** Node position, or `nil` if out of range.
+- **OCCT:** `Poly_Polygon3D::Nodes` via `OCCTPolyPolygon3DNode`.
+
+---
+
+### `Polygon3D.nodes()`
+
+Returns all nodes.
+
+```swift
+public func nodes() -> [SIMD3<Double>]
+```
+
+- **Returns:** Array of all 3D node positions in sequence order.
+
+---
+
+### `Polygon3D.hasParameters`
+
+Whether this polygon has curve parameters.
+
+```swift
+public var hasParameters: Bool { get }
+```
+
+- **OCCT:** `Poly_Polygon3D::HasParameters` via `OCCTPolyPolygon3DHasParameters`.
+
+---
+
+### `Polygon3D.parameter(at:)`
+
+Returns the curve parameter at a given 0-based index.
+
+```swift
+public func parameter(at index: Int) -> Double
+```
+
+- **Parameters:** `index` — 0-based index.
+- **Returns:** The curve parameter value. Returns 0 if `hasParameters` is `false`.
+- **OCCT:** `Poly_Polygon3D::Parameter` via `OCCTPolyPolygon3DParameter`.
+
+---
+
+### `Polygon3D.deflection`
+
+The deflection value of this polygon.
+
+```swift
+public var deflection: Double { get set }
+```
+
+- **OCCT:** `Poly_Polygon3D::Deflection` / `SetDeflection` via `OCCTPolyPolygon3DDeflection` / `OCCTPolyPolygon3DSetDeflection`.
+
+---
+
+## PolygonOnTriangulation
+
+`PolygonOnTriangulation` wraps `Poly_PolygonOnTriangulation` — a polygon defined as a sequence of indices into a shared `Triangulation`, with optional curve parameters. Used to associate an edge's 2D approximation with a face triangulation.
+
+### `PolygonOnTriangulation.create(nodeIndices:)`
+
+Creates a polygon from node indices into a triangulation.
+
+```swift
+public static func create(nodeIndices: [Int32]) -> PolygonOnTriangulation?
+```
+
+- **Parameters:** `nodeIndices` — array of 0-based node indices into the associated triangulation.
+- **Returns:** `PolygonOnTriangulation`, or `nil` on failure.
+- **OCCT:** `Poly_PolygonOnTriangulation` via `OCCTPolyPolygonOnTriCreate`.
+
+---
+
+### `PolygonOnTriangulation.create(nodeIndices:parameters:)`
+
+Creates a polygon from node indices with curve parameters.
+
+```swift
+public static func create(nodeIndices: [Int32], parameters: [Double]) -> PolygonOnTriangulation?
+```
+
+- **Parameters:** `nodeIndices` — 0-based node indices; `parameters` — corresponding curve parameter values.
+- **Returns:** `PolygonOnTriangulation` with parameters, or `nil` on failure.
+- **OCCT:** `Poly_PolygonOnTriangulation` (parameterised overload) via `OCCTPolyPolygonOnTriCreateWithParams`.
+- **Example:**
+  ```swift
+  if let poly = PolygonOnTriangulation.create(nodeIndices: [0, 5, 12],
+                                               parameters: [0, 0.5, 1]) {
+      print(poly.nodeCount)  // 3
+  }
+  ```
+
+---
+
+### `PolygonOnTriangulation.nodeCount`
+
+The number of nodes referenced by this polygon.
+
+```swift
+public var nodeCount: Int { get }
+```
+
+- **OCCT:** `Poly_PolygonOnTriangulation::NbNodes` via `OCCTPolyPolygonOnTriNbNodes`.
+
+---
+
+### `PolygonOnTriangulation.nodeIndex(at:)`
+
+Returns the triangulation node index at a given 0-based position.
+
+```swift
+public func nodeIndex(at position: Int) -> Int
+```
+
+- **Parameters:** `position` — 0-based position in the polygon's node sequence.
+- **Returns:** 0-based index into the associated triangulation's node array.
+- **OCCT:** `Poly_PolygonOnTriangulation::Node` via `OCCTPolyPolygonOnTriNode`.
+
+---
+
+### `PolygonOnTriangulation.hasParameters`
+
+Whether this polygon has curve parameters.
+
+```swift
+public var hasParameters: Bool { get }
+```
+
+- **OCCT:** `Poly_PolygonOnTriangulation::HasParameters` via `OCCTPolyPolygonOnTriHasParameters`.
+
+---
+
+### `PolygonOnTriangulation.parameter(at:)`
+
+Returns the curve parameter at a given 0-based index.
+
+```swift
+public func parameter(at index: Int) -> Double
+```
+
+- **Parameters:** `index` — 0-based index.
+- **Returns:** The curve parameter value. Returns 0 if `hasParameters` is `false`.
+- **OCCT:** `Poly_PolygonOnTriangulation::Parameter` via `OCCTPolyPolygonOnTriParameter`.
+
+---
+
+### `PolygonOnTriangulation.deflection`
+
+The deflection value of this polygon.
+
+```swift
+public var deflection: Double { get set }
+```
+
+- **OCCT:** `Poly_PolygonOnTriangulation::Deflection` / `SetDeflection` via `OCCTPolyPolygonOnTriDeflection` / `OCCTPolyPolygonOnTriSetDeflection`.
+
+---
+
+### `PolygonOnTriangulation.copy()`
+
+Creates a deep copy of this polygon.
+
+```swift
+public func copy() -> PolygonOnTriangulation?
+```
+
+- **Returns:** Independent copy, or `nil` on failure.
+- **OCCT:** `Poly_PolygonOnTriangulation::Copy` via `OCCTPolyPolygonOnTriCopy`.
+
+---
+
+### `PolygonOnTriangulation.setNodes(_:)`
+
+Overwrites the node-index array in place.
+
+```swift
+@discardableResult
+public func setNodes(_ nodeIndices: [Int32]) -> Bool
+```
+
+The supplied array must have the same length as `nodeCount`.
+
+- **Parameters:** `nodeIndices` — replacement node index array (same count as `nodeCount`).
+- **Returns:** `true` on success, `false` on size mismatch.
+- **OCCT:** `Poly_PolygonOnTriangulation::ChangeNodeArray` via `OCCTPolyPolygonOnTriSetNodes`.
+
+---
+
+### `PolygonOnTriangulation.setParameters(_:)`
+
+Overwrites the parameter array in place.
+
+```swift
+@discardableResult
+public func setParameters(_ params: [Double]) -> Bool
+```
+
+Requires `hasParameters == true` and the array length must equal `nodeCount`.
+
+- **Parameters:** `params` — replacement parameter array.
+- **Returns:** `true` on success, `false` if `hasParameters` is `false` or lengths mismatch.
+- **OCCT:** `Poly_PolygonOnTriangulation::ChangeParameterArray` via `OCCTPolyPolygonOnTriSetParameters`.
+
+---
+
+## Mesh Node Merging
+
+### `MergedMeshData`
+
+Output of merging triangulation nodes across all faces of a meshed shape.
+
+```swift
+public struct MergedMeshData: Sendable {
+    public let vertices: [SIMD3<Float>]
+    public let normals: [SIMD3<Float>]
+    public let indices: [UInt32]
+    public let triangleCount: Int
+    public let vertexCount: Int
+}
+```
+
+Normals are computed per merged vertex using the `smoothAngle` threshold.
+
+---
+
+### `mergedMeshNodes(from:smoothAngle:mergeTolerance:)`
+
+Merges nodes from all face triangulations of a meshed shape into a single indexed mesh suitable for GPU upload.
+
+```swift
+public func mergedMeshNodes(from shape: Shape,
+                              smoothAngle: Double,
+                              mergeTolerance: Double = 0.0) -> MergedMeshData?
+```
+
+- **Parameters:** `shape` — a shape that has been triangulated (e.g., via `Mesh.from(shape:)`); `smoothAngle` — normal-smoothing angle threshold in radians; `mergeTolerance` — distance threshold for merging nodes (0 = positional identity only).
+- **Returns:** `MergedMeshData` with interleaved vertex, normal, and index arrays, or `nil` if the shape has no triangulation or the output would exceed 1 000 000 vertices / 3 000 000 indices.
+- **OCCT:** `BRep_Builder` face iteration + `Poly_Triangulation` via `OCCTPolyMergeNodes`.
+- **Example:**
+  ```swift
+  let shape = Shape.box(dx: 10, dy: 10, dz: 10)!
+  _ = Mesh.from(shape: shape, deflection: 0.1)
+  if let mesh = mergedMeshNodes(from: shape, smoothAngle: .pi / 6) {
+      // Upload mesh.vertices and mesh.indices to a Metal vertex buffer
+      print(mesh.vertexCount, mesh.triangleCount)
+  }
+  ```

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1,0 +1,1877 @@
+---
+title: Shape
+parent: API Reference
+---
+
+# Shape
+
+`Shape` is OCCTSwift's central B-Rep type, wrapping OCCT's `TopoDS_Shape` hierarchy. It represents any B-Rep entity — solid, shell, face, wire, edge, vertex, or compound — and provides construction, boolean, modification, transformation, meshing, and format-import operations. Obtain a `Shape` via a static factory (e.g. `Shape.box()`, `Shape.loft()`), a sweep or boolean operation on an existing `Shape`, or by importing a STEP/IGES/BREP/STL/OBJ file.
+
+> **Note:** `Shape` is large — documented across several pages. This is the core (construction, booleans, modifications, meshing, import); see also the other **Shape — …** pages for features, healing, measurement, local operations, and the low-level OCCT builder wrappers.
+
+## Topics
+
+- [Lifecycle](#lifecycle) · [Primitive Creation](#primitive-creation) · [Sweep Operations](#sweep-operations) · [Boolean Operations](#boolean-operations) · [Modifications](#modifications) · [Transformations](#transformations) · [Compound Operations](#compound-operations) · [Conversion](#conversion) · [Validation](#validation) · [Meshing](#meshing) · [Edge Discretization](#edge-discretization) · [Import](#import) · [STEP Reader Control](#step-reader-control) · [Robust STEP Import](#robust-step-import) · [IGES Import](#iges-import) · [IGES Reader Control](#iges-reader-control) · [BREP Import](#brep-import) · [STL Import](#stl-import) · [OBJ Import](#obj-import)
+
+---
+
+## Lifecycle
+
+### `init(handle:)`
+
+Internal designated initialiser; takes ownership of a bridge handle.
+
+```swift
+internal init(handle: OCCTShapeRef)
+```
+
+Not part of the public API — all public entry points return `Shape?` optionals and manage memory internally.
+
+---
+
+### `deinit`
+
+Releases the underlying OCCT shape handle.
+
+```swift
+deinit
+```
+
+- **OCCT:** `OCCTShapeRelease` → `TopoDS_Shape` reference count decremented.
+
+---
+
+## Primitive Creation
+
+### `Shape.box(width:height:depth:)`
+
+Create a box centered at the origin.
+
+```swift
+public static func box(width: Double, height: Double, depth: Double) -> Shape?
+```
+
+- **Parameters:** `width`, `height`, `depth` — extents along X, Y, Z respectively.
+- **Returns:** A solid box, or `nil` if any dimension is non-positive.
+- **OCCT:** `BRepPrimAPI_MakeBox`.
+- **Example:**
+  ```swift
+  if let box = Shape.box(width: 10, height: 5, depth: 3) {
+      // box.isValid == true
+  }
+  ```
+
+---
+
+### `Shape.box(origin:width:height:depth:)`
+
+Create a box at a specific position.
+
+```swift
+public static func box(
+    origin: SIMD3<Double>,
+    width: Double,
+    height: Double,
+    depth: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin` — corner point of the box; `width`, `height`, `depth` — extents along X, Y, Z.
+- **Returns:** A solid box at the given position, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeBox`.
+- **Example:**
+  ```swift
+  if let box = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10) {
+      // volume == 1000
+  }
+  ```
+
+---
+
+### `Shape.box(at:direction:width:height:depth:)`
+
+Create a box at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func box(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    width: Double,
+    height: Double,
+    depth: Double
+) -> Shape?
+```
+
+- **Parameters:**
+  - `origin` — corner point of the box.
+  - `direction` — axis direction for the box height (will be normalised).
+  - `width` — X extent in local frame.
+  - `height` — Y extent in local frame.
+  - `depth` — extent along `direction`.
+- **Returns:** Oriented solid box, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeBox` (via `OCCTShapeCreateBoxOriented`).
+- **Example:**
+  ```swift
+  if let box = Shape.box(at: .zero, direction: SIMD3(0, 0, 1), width: 4, height: 4, depth: 10) {
+      // box tilted along Z
+  }
+  ```
+
+---
+
+### `Shape.cylinder(radius:height:)`
+
+Create a cylinder along the Z axis with base at the origin.
+
+```swift
+public static func cylinder(radius: Double, height: Double) -> Shape?
+```
+
+- **Parameters:** `radius` — base circle radius; `height` — height along Z.
+- **Returns:** A solid cylinder, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCylinder`.
+- **Example:**
+  ```swift
+  if let cyl = Shape.cylinder(radius: 2, height: 10) {
+      // volume ≈ 125.66
+  }
+  ```
+
+---
+
+### `Shape.cylinder(at:bottomZ:radius:height:)`
+
+Create a cylinder at a specific XY position with a specified Z base.
+
+```swift
+public static func cylinder(
+    at position: SIMD2<Double>,
+    bottomZ: Double,
+    radius: Double,
+    height: Double
+) -> Shape?
+```
+
+- **Parameters:** `position` — XY centre of base circle; `bottomZ` — Z coordinate of base; `radius`, `height`.
+- **Returns:** Positioned cylinder, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCylinder` (via `OCCTShapeCreateCylinderAt`).
+- **Example:**
+  ```swift
+  if let cyl = Shape.cylinder(at: SIMD2(3, 4), bottomZ: 0, radius: 1.5, height: 8) { }
+  ```
+
+---
+
+### `Shape.cylinder(at:direction:radius:height:)`
+
+Create a cylinder at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func cylinder(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    radius: Double,
+    height: Double
+) -> Shape?
+```
+
+- **Parameters:**
+  - `origin` — centre of the base circle.
+  - `direction` — axis direction (will be normalised).
+  - `radius` — cylinder radius.
+  - `height` — height along `direction`.
+- **Returns:** Oriented cylinder, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCylinder` (via `OCCTShapeCreateCylinderOriented`).
+- **Example:**
+  ```swift
+  guard let cyl = Shape.cylinder(at: SIMD3(0, 0, -8),
+                                 direction: SIMD3(0, 0, 1),
+                                 radius: 3, height: 16) else { return }
+  ```
+
+---
+
+### `Shape.cylinder(radius:height:angle:)`
+
+Create a partial cylinder (angular segment) along the Z axis.
+
+```swift
+public static func cylinder(radius: Double, height: Double, angle: Double) -> Shape?
+```
+
+- **Parameters:** `radius`, `height`; `angle` — angular extent in radians (`0 < angle <= 2*pi`).
+- **Returns:** Partial cylinder sector, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCylinder` (via `OCCTShapeCreateCylinderPartial`).
+- **Example:**
+  ```swift
+  if let half = Shape.cylinder(radius: 5, height: 10, angle: .pi) { }
+  ```
+
+---
+
+### `Shape.cylinder(at:direction:radius:height:angle:)`
+
+Create a partial cylinder (angular segment) at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func cylinder(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    radius: Double,
+    height: Double,
+    angle: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin`, `direction`, `radius`, `height`, `angle` — angular extent in radians (`0 < angle <= 2*pi`).
+- **Returns:** Oriented partial cylinder, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCylinder` (via `OCCTShapeCreateCylinderOrientedPartial`).
+
+---
+
+### `Shape.toolSweep(radius:height:from:to:)`
+
+Create a tool-sweep solid — the volume swept by a cylindrical tool moving between two points.
+
+```swift
+public static func toolSweep(
+    radius: Double,
+    height: Double,
+    from start: SIMD3<Double>,
+    to end: SIMD3<Double>
+) -> Shape?
+```
+
+Used for CAM simulation to compute material removal volumes.
+
+- **Parameters:** `radius`, `height` — tool dimensions; `start`, `end` — tool centre path.
+- **Returns:** Swept solid volume, or `nil` on failure.
+- **OCCT:** `OCCTShapeCreateToolSweep`.
+- **Example:**
+  ```swift
+  if let sweep = Shape.toolSweep(radius: 2, height: 5,
+                                 from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)) { }
+  ```
+
+---
+
+### `Shape.sphere(radius:)`
+
+Create a sphere centred at the origin.
+
+```swift
+public static func sphere(radius: Double) -> Shape?
+```
+
+- **Parameters:** `radius` — sphere radius.
+- **Returns:** Solid sphere, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeSphere`.
+- **Example:**
+  ```swift
+  if let ball = Shape.sphere(radius: 5) {
+      // volume ≈ 523.6
+  }
+  ```
+
+---
+
+### `Shape.sphere(center:radius:)`
+
+Create a sphere at a specific centre point.
+
+```swift
+public static func sphere(center: SIMD3<Double>, radius: Double) -> Shape?
+```
+
+- **Parameters:** `center` — centre of the sphere; `radius`.
+- **Returns:** Positioned sphere, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeSphere` (via `OCCTShapeCreateSphereAtCenter`).
+- **Example:**
+  ```swift
+  if let ball = Shape.sphere(center: SIMD3(0, 0, 10), radius: 3) { }
+  ```
+
+---
+
+### `Shape.sphere(at:direction:radius:)`
+
+Create an oriented sphere at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func sphere(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    radius: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin` — centre; `direction` — axis direction (affects parameterisation); `radius`.
+- **Returns:** Oriented sphere, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeSphere` (via `OCCTShapeCreateSphereOriented`).
+
+---
+
+### `Shape.sphere(radius:angle:)`
+
+Create a partial sphere (angular segment).
+
+```swift
+public static func sphere(radius: Double, angle: Double) -> Shape?
+```
+
+- **Parameters:** `radius`; `angle` — angular extent in radians (`0 < angle <= 2*pi`).
+- **Returns:** Sphere sector, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeSphere` (via `OCCTShapeCreateSpherePartial`).
+
+---
+
+### `Shape.sphere(at:direction:radius:angle:)`
+
+Create a partial sphere (angular segment) at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func sphere(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    radius: Double,
+    angle: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin`, `direction`, `radius`, `angle` — angular extent in radians.
+- **Returns:** Oriented sphere sector, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeSphere` (via `OCCTShapeCreateSphereOrientedPartial`).
+
+---
+
+### `Shape.sphere(at:direction:radius:angle1:angle2:)`
+
+Create a sphere latitude segment at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func sphere(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    radius: Double,
+    angle1: Double,
+    angle2: Double
+) -> Shape?
+```
+
+- **Parameters:**
+  - `origin` — centre of the sphere.
+  - `direction` — axis direction (affects parameterisation).
+  - `radius` — sphere radius.
+  - `angle1` — lower latitude bound in radians (−π/2 to π/2).
+  - `angle2` — upper latitude bound in radians (−π/2 to π/2).
+- **Returns:** Latitude-band sphere segment, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeSphere` (via `OCCTShapeCreateSphereOrientedSegment`).
+
+---
+
+### `Shape.cone(bottomRadius:topRadius:height:)`
+
+Create a cone along the Z axis.
+
+```swift
+public static func cone(bottomRadius: Double, topRadius: Double, height: Double) -> Shape?
+```
+
+- **Parameters:** `bottomRadius` — radius at the base; `topRadius` — radius at the top (0 = true cone); `height`.
+- **Returns:** Solid cone or frustum, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCone`.
+- **Example:**
+  ```swift
+  if let cone = Shape.cone(bottomRadius: 5, topRadius: 0, height: 10) { }
+  if let frustum = Shape.cone(bottomRadius: 5, topRadius: 3, height: 8) { }
+  ```
+
+---
+
+### `Shape.cone(at:direction:bottomRadius:topRadius:height:)`
+
+Create a cone at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func cone(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    bottomRadius: Double,
+    topRadius: Double,
+    height: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin` — centre of the base circle; `direction` — axis (will be normalised); `bottomRadius`, `topRadius`, `height`.
+- **Returns:** Oriented cone/frustum, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCone` (via `OCCTShapeCreateConeOriented`).
+
+---
+
+### `Shape.cone(at:direction:bottomRadius:topRadius:height:angle:)`
+
+Create a partial cone (angular segment) at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func cone(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    bottomRadius: Double,
+    topRadius: Double,
+    height: Double,
+    angle: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin`, `direction`, `bottomRadius`, `topRadius`, `height`; `angle` — angular extent in radians (`0 < angle <= 2*pi`).
+- **Returns:** Oriented cone sector, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeCone` (via `OCCTShapeCreateConeOrientedPartial`).
+
+---
+
+### `Shape.torus(majorRadius:minorRadius:)`
+
+Create a torus in the XY plane.
+
+```swift
+public static func torus(majorRadius: Double, minorRadius: Double) -> Shape?
+```
+
+- **Parameters:** `majorRadius` — distance from torus centre to tube centre; `minorRadius` — tube radius.
+- **Returns:** Solid torus, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeTorus`.
+- **Example:**
+  ```swift
+  if let ring = Shape.torus(majorRadius: 10, minorRadius: 2) { }
+  ```
+
+---
+
+### `Shape.torus(at:direction:majorRadius:minorRadius:)`
+
+Create a torus at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func torus(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    majorRadius: Double,
+    minorRadius: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin` — centre of the torus; `direction` — normal to the torus plane; `majorRadius`, `minorRadius`.
+- **Returns:** Oriented torus, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeTorus` (via `OCCTShapeCreateTorusOriented`).
+
+---
+
+### `Shape.torus(at:direction:majorRadius:minorRadius:angle:)`
+
+Create a partial torus (angular segment) at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func torus(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    majorRadius: Double,
+    minorRadius: Double,
+    angle: Double
+) -> Shape?
+```
+
+- **Parameters:** `origin`, `direction`, `majorRadius`, `minorRadius`; `angle` — angular extent in radians (`0 < angle <= 2*pi`).
+- **Returns:** Oriented torus sector, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeTorus` (via `OCCTShapeCreateTorusOrientedPartial`).
+
+---
+
+### `Shape.torus(at:direction:majorRadius:minorRadius:angle1:angle2:)`
+
+Create a torus tube segment at an arbitrary origin along an arbitrary direction.
+
+```swift
+public static func torus(
+    at origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    majorRadius: Double,
+    minorRadius: Double,
+    angle1: Double,
+    angle2: Double
+) -> Shape?
+```
+
+- **Parameters:**
+  - `origin` — centre of the torus.
+  - `direction` — axis direction (normal to torus plane).
+  - `majorRadius`, `minorRadius`.
+  - `angle1` — start angle of the tube section in radians.
+  - `angle2` — end angle of the tube section in radians.
+- **Returns:** Tube-segment torus, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeTorus` (via `OCCTShapeCreateTorusOrientedSegment`).
+
+---
+
+## Sweep Operations
+
+### `Shape.sweep(profile:along:)`
+
+Sweep a 2D profile wire along a path wire to create a solid.
+
+```swift
+public static func sweep(profile: Wire, along path: Wire) -> Shape?
+```
+
+The result is orientation-normalised so its faces always point outward (positive volume), regardless of how the profile's normal relates to the path tangent. You do not need to manually orient the section against the tangent.
+
+- **Parameters:** `profile` — closed cross-section wire placed at the path's start; `path` — spine wire.
+- **Returns:** Swept solid, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakePipe`.
+- **Example:**
+  ```swift
+  guard let section = Wire.circle(origin: SIMD3(16, 0, 0),
+                                  normal: SIMD3(0, 1, 0), radius: 5),
+        let path = Wire.arc(center: .zero, radius: 16,
+                            startAngle: 0, endAngle: .pi / 2),
+        let elbow = Shape.sweep(profile: section, along: path) else { return }
+  // elbow.isValid == true
+  ```
+
+---
+
+### `Shape.extrude(profile:direction:length:)`
+
+Extrude a 2D profile wire in a direction to create a prism.
+
+```swift
+public static func extrude(profile: Wire, direction: SIMD3<Double>, length: Double) -> Shape?
+```
+
+- **Parameters:** `profile` — closed profile wire; `direction` — extrusion direction (need not be unit length); `length` — extrusion distance.
+- **Returns:** Solid prism, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakePrism`.
+- **Example:**
+  ```swift
+  guard let profile = Wire.rectangle(width: 20, height: 12),
+        let prism = Shape.extrude(profile: profile,
+                                  direction: SIMD3(0, 0, 1), length: 8) else { return }
+  // prism.volume == 20 * 12 * 8 == 1920
+  ```
+
+---
+
+### `Shape.revolve(profile:axisOrigin:axisDirection:angle:)`
+
+Revolve a 2D profile wire around an axis.
+
+```swift
+public static func revolve(
+    profile: Wire,
+    axisOrigin: SIMD3<Double>,
+    axisDirection: SIMD3<Double>,
+    angle: Double = .pi * 2
+) -> Shape?
+```
+
+- **Parameters:**
+  - `profile` — meridian wire in a plane containing the axis.
+  - `axisOrigin` — a point on the revolution axis.
+  - `axisDirection` — axis direction vector.
+  - `angle` — sweep angle in radians (default full 2π).
+- **Returns:** Revolution solid, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeRevol`.
+- **Example:**
+  ```swift
+  guard let meridian = Wire.polygon([
+      SIMD2(5, 0), SIMD2(7, 0), SIMD2(7, 10), SIMD2(5, 10)
+  ], closed: true),
+        let drum = Shape.revolve(profile: meridian,
+                                 axisOrigin: .zero,
+                                 axisDirection: SIMD3(0, 1, 0),
+                                 angle: 2 * .pi) else { return }
+  ```
+
+---
+
+### `extruded(by:)`
+
+Extrude an existing shape (any topology) along a vector.
+
+```swift
+public func extruded(by vector: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `vector` — translation vector; its magnitude determines the extrusion distance.
+- **Returns:** Extruded shape, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakePrism` (via `OCCTShapeCreateExtrusionShape`).
+- **Example:**
+  ```swift
+  if let solid = face.extruded(by: SIMD3(0, 0, 5)) { }
+  ```
+
+---
+
+### `extrudedInfinite(direction:infinite:)`
+
+Extrude an existing shape to infinity (or semi-infinity) along a direction.
+
+```swift
+public func extrudedInfinite(direction: SIMD3<Double>, infinite: Bool = true) -> Shape?
+```
+
+Useful for half-space cutters in booleans (e.g. slice a solid).
+
+- **Parameters:** `direction` — extrusion direction; `infinite` — if `true`, both directions; if `false`, semi-infinite.
+- **Returns:** Infinite-extent shape (shell), or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakePrism` (via `OCCTShapeCreateExtrusionInfinite`).
+- **Example:**
+  ```swift
+  // Cut anything above z = 0 from a solid
+  guard let plane = Shape.face(from: Wire.rectangle(width: 200, height: 200)!),
+        let halfSpace = plane.extrudedInfinite(direction: SIMD3(0, 0, 1)),
+        let trimmed = solid.subtracting(halfSpace) else { return }
+  ```
+
+---
+
+### `revolved(axisOrigin:axisDirection:)`
+
+Revolve an existing shape around an axis by a full 360 degrees.
+
+```swift
+public func revolved(
+    axisOrigin: SIMD3<Double>,
+    axisDirection: SIMD3<Double>
+) -> Shape?
+```
+
+- **Parameters:** `axisOrigin` — point on revolution axis; `axisDirection` — axis direction.
+- **Returns:** Revolution solid, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeRevol` (via `OCCTShapeCreateRevolutionFull`).
+
+---
+
+### `revolved(axisOrigin:axisDirection:angle:)`
+
+Revolve an existing shape around an axis by a partial angle.
+
+```swift
+public func revolved(
+    axisOrigin: SIMD3<Double>,
+    axisDirection: SIMD3<Double>,
+    angle: Double
+) -> Shape?
+```
+
+- **Parameters:** `axisOrigin`, `axisDirection`; `angle` — sweep angle in radians.
+- **Returns:** Partial revolution solid, or `nil` on failure.
+- **OCCT:** `BRepPrimAPI_MakeRevol` (via `OCCTShapeCreateRevolutionPartial`).
+
+---
+
+### `Shape.loft(profiles:solid:)`
+
+Loft through multiple profile wires.
+
+```swift
+public static func loft(profiles: [Wire], solid: Bool = true) -> Shape?
+```
+
+- **Parameters:** `profiles` — ordered array of profile wires; `solid` — `true` (default) creates a closed solid, `false` creates an open shell.
+- **Returns:** Lofted shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_ThruSections`.
+- **Note:** Mismatched closed/open profiles can trigger a SIGSEGV in `BRepFill_CompatibleWires` when using smooth (non-ruled) lofts — see the CLAUDE.md note on this known upstream bug and the patch in `Scripts/patches/`.
+- **Example:**
+  ```swift
+  guard let base = Wire.circle(radius: 5),
+        let top = Wire.circle(origin: SIMD3(0, 0, 20), normal: SIMD3(0, 0, 1), radius: 2),
+        let transition = Shape.loft(profiles: [base, top], solid: true) else { return }
+  ```
+
+---
+
+### `Shape.loft(profiles:solid:ruled:firstVertex:lastVertex:)`
+
+Loft through profile wires with advanced options.
+
+```swift
+public static func loft(profiles: [Wire], solid: Bool = true, ruled: Bool,
+                        firstVertex: SIMD3<Double>? = nil,
+                        lastVertex: SIMD3<Double>? = nil) -> Shape?
+```
+
+- **Parameters:**
+  - `profiles` — ordered profile wires.
+  - `solid` — solid vs shell.
+  - `ruled` — `true` = ruled (flat/faceted) surfaces between profiles; `false` = smooth B-spline blend.
+  - `firstVertex` — optional starting tip point for cone/taper shapes.
+  - `lastVertex` — optional ending tip point for cone/taper shapes.
+- **Returns:** Lofted shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_ThruSections` (via `OCCTShapeCreateLoftAdvanced`).
+- **Example:**
+  ```swift
+  // Ruled loft (flat sides)
+  let ruled = Shape.loft(profiles: [bottom, upper], solid: true, ruled: true)
+  // Smooth loft
+  let smooth = Shape.loft(profiles: [bottom, upper], solid: true, ruled: false)
+
+  // Taper to a point (cone tip)
+  guard let circle = Wire.circle(radius: 5) else { return }
+  let cone = Shape.loft(profiles: [circle], solid: true, ruled: true,
+                        lastVertex: SIMD3(0, 0, 10))
+  ```
+
+---
+
+## Boolean Operations
+
+### `BooleanGlue`
+
+Glue mode enum for boolean operations (`BOPAlgo_GlueEnum`).
+
+```swift
+public enum BooleanGlue: Int32, Sendable {
+    case off   = 0  // No gluing — full intersection (default)
+    case shift = 1  // BOPAlgo_GlueShift — coincident but otherwise disjoint faces
+    case full  = 2  // BOPAlgo_GlueFull  — all faces coincident (fastest, strictest)
+}
+```
+
+Gluing speeds up booleans when arguments share coincident faces. Only use when faces truly coincide — gluing genuinely interpenetrating solids produces a wrong result.
+
+---
+
+### `defaultBooleanTimeout`
+
+Default wall-clock timeout for boolean operations, in seconds.
+
+```swift
+public static let defaultBooleanTimeout: Double = 120
+```
+
+A self-intersecting or inside-out operand (e.g. from `loft(ruled: false)`) can make `BRepAlgoAPI_Cut` spin indefinitely; boolean operations abort and return `nil` once this elapses. Pass `0` or negative to disable. Override per call via the `timeout:` parameter.
+
+---
+
+### `union(_:fuzzyValue:glue:timeout:)`
+
+Union (fuse) two shapes together.
+
+```swift
+public func union(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                  timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
+```
+
+Also available as the `+` operator.
+
+- **Parameters:**
+  - `other` — the shape to fuse with `self`.
+  - `fuzzyValue` — tolerance (`SetFuzzyValue`). `0` = OCCT default; a small positive value (e.g. `1e-4`) helps near-tangent/coincident faces fuse cleanly. Negative = ignored.
+  - `glue` — glue mode for coincident-face arguments.
+  - `timeout` — wall-clock bound in seconds; `nil` result if elapsed.
+- **Returns:** Fused solid, or `nil` on failure or timeout.
+- **OCCT:** `BRepAlgoAPI_Fuse` (via `OCCTShapeUnionEx`).
+- **Example:**
+  ```swift
+  guard let box = Shape.box(width: 10, height: 10, depth: 10),
+        let cyl = Shape.cylinder(at: SIMD3(0, 0, -8), direction: SIMD3(0, 0, 1),
+                                 radius: 3, height: 16) else { return }
+  let fused = box.union(cyl)           // or: box + cyl
+  // Fuzzy: near-tangent walls fuse cleanly
+  let clean = outer.union(inner, fuzzyValue: 2.1e-5)
+  // Glue: stacked blocks sharing a face
+  let stacked = lower.union(upper, glue: .shift)
+  ```
+- **Note:** The deprecated `union(with:)` overload is available for compatibility; prefer `union(_:)`.
+
+---
+
+### `union(with:)` *(deprecated)*
+
+```swift
+@available(*, deprecated, renamed: "union(_:)", ...)
+public func union(with other: Shape) -> Shape? { union(other) }
+```
+
+Renamed to `union(_:)`. Use `union(_:fuzzyValue:glue:timeout:)` instead.
+
+---
+
+### `subtracting(_:fuzzyValue:glue:timeout:)`
+
+Subtract another shape from this one.
+
+```swift
+public func subtracting(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
+```
+
+Also available as the `-` operator.
+
+- **Parameters:**
+  - `other` — the tool shape to remove from `self`.
+  - `fuzzyValue` — tolerance. Raise slightly when a thin-wall cut under-subtracts.
+  - `glue` — glue mode.
+  - `timeout` — wall-clock bound in seconds.
+- **Returns:** Result of `self − other`, or `nil` on failure or timeout.
+- **OCCT:** `BRepAlgoAPI_Cut` (via `OCCTShapeSubtractEx`).
+- **Example:**
+  ```swift
+  guard let box = Shape.box(width: 10, height: 10, depth: 10),
+        let cyl = Shape.cylinder(at: SIMD3(0, 0, -8), direction: SIMD3(0, 0, 1),
+                                 radius: 3, height: 16) else { return }
+  let drilled = box.subtracting(cyl)   // or: box - cyl
+  ```
+
+---
+
+### `intersection(_:fuzzyValue:glue:timeout:)`
+
+Intersection of two shapes.
+
+```swift
+public func intersection(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                         timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
+```
+
+Also available as the `&` operator.
+
+- **Parameters:**
+  - `other` — the shape to intersect with `self`.
+  - `fuzzyValue` — tolerance.
+  - `glue` — glue mode.
+  - `timeout` — wall-clock bound in seconds.
+- **Returns:** The volume common to both shapes, or `nil` on failure or timeout.
+- **OCCT:** `BRepAlgoAPI_Common` (via `OCCTShapeIntersectEx`).
+- **Example:**
+  ```swift
+  let common = box.intersection(cyl)  // or: box & cyl
+  ```
+- **Note:** The deprecated `intersection(with:)` overload is available for compatibility; prefer `intersection(_:)`.
+
+---
+
+### `intersection(with:)` *(deprecated)*
+
+```swift
+@available(*, deprecated, renamed: "intersection(_:)", ...)
+public func intersection(with other: Shape) -> Shape? { intersection(other) }
+```
+
+Renamed to `intersection(_:)`. Use `intersection(_:fuzzyValue:glue:timeout:)` instead.
+
+---
+
+## Modifications
+
+### `filleted(radius:)`
+
+Fillet (round) all edges with a given radius.
+
+```swift
+public func filleted(radius: Double) -> Shape?
+```
+
+- **Parameters:** `radius` — fillet radius.
+- **Returns:** Shape with all edges rounded, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeFillet`.
+- **Example:**
+  ```swift
+  if let rounded = Shape.box(width: 10, height: 10, depth: 10)?.filleted(radius: 1) { }
+  ```
+
+---
+
+### `chamfered(distance:)`
+
+Chamfer all edges with a given distance.
+
+```swift
+public func chamfered(distance: Double) -> Shape?
+```
+
+- **Parameters:** `distance` — chamfer distance (equal on both sides).
+- **Returns:** Shape with all edges chamfered, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeChamfer`.
+- **Example:**
+  ```swift
+  if let bevelled = Shape.box(width: 10, height: 10, depth: 10)?.chamfered(distance: 0.5) { }
+  ```
+
+---
+
+### `chamferedTwoDistances(_:)`
+
+Chamfer specific edges with two different distances (asymmetric).
+
+```swift
+public func chamferedTwoDistances(_ edges: [(edgeIndex: Int, faceIndex: Int, dist1: Double, dist2: Double)]) -> Shape?
+```
+
+Each entry specifies an edge, a reference face adjacent to that edge, and two distances. `dist1` is measured on the reference face side, `dist2` on the opposite side.
+
+- **Parameters:** `edges` — array of `(edgeIndex, faceIndex, dist1, dist2)` tuples.
+- **Returns:** Chamfered shape, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeChamfer` (via `OCCTShapeChamferTwoDistances`).
+- **Example:**
+  ```swift
+  if let c = box.chamferedTwoDistances([(edgeIndex: 0, faceIndex: 0, dist1: 1.0, dist2: 2.0)]) { }
+  ```
+
+---
+
+### `chamferedDistAngle(_:)`
+
+Chamfer specific edges with a distance and angle.
+
+```swift
+public func chamferedDistAngle(_ edges: [(edgeIndex: Int, faceIndex: Int, distance: Double, angleDegrees: Double)]) -> Shape?
+```
+
+Each entry specifies an edge, a reference face adjacent to that edge, a distance measured on the reference face, and a chamfer angle in degrees (must be between 0 and 90, exclusive).
+
+- **Parameters:** `edges` — array of `(edgeIndex, faceIndex, distance, angleDegrees)` tuples.
+- **Returns:** Chamfered shape, or `nil` on failure.
+- **OCCT:** `BRepFilletAPI_MakeChamfer` (via `OCCTShapeChamferDistAngle`).
+
+---
+
+### `shelled(thickness:)`
+
+Create a hollow shell by removing material from the inside.
+
+```swift
+public func shelled(thickness: Double) -> Shape?
+```
+
+- **Parameters:** `thickness` — wall thickness (positive = shell walls of this thickness).
+- **Returns:** Hollow shell, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeThickSolid`.
+- **Example:**
+  ```swift
+  if let shell = Shape.box(width: 10, height: 10, depth: 10)?.shelled(thickness: 1) { }
+  ```
+
+---
+
+### `offset(by:)` *(simple)*
+
+Offset all faces by a distance.
+
+```swift
+public func offset(by distance: Double) -> Shape?
+```
+
+- **Parameters:** `distance` — offset distance (positive = outward, negative = inward).
+- **Returns:** Offset shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeOffsetShape` (via `OCCTShapeOffset`).
+- **Example:**
+  ```swift
+  if let grown = box.offset(by: 1.0) { }
+  ```
+
+---
+
+### `offset(by:tolerance:joinType:removeInternalEdges:)`
+
+Offset all faces using the proper join algorithm (`PerformByJoin`).
+
+```swift
+public func offset(by distance: Double, tolerance: Double = 1e-7,
+                   joinType: OffsetJoinType = .arc,
+                   removeInternalEdges: Bool = false) -> Shape?
+```
+
+More robust than the simple `offset(by:)` overload; handles gap-filling between parallel faces.
+
+- **Parameters:**
+  - `distance` — offset distance (positive = outward, negative = inward).
+  - `tolerance` — coincidence tolerance (default `1e-7`).
+  - `joinType` — how to fill gaps between offset faces: `.arc` (smooth), `.tangent`, or `.intersection` (sharp).
+  - `removeInternalEdges` — whether to clean up internal edges.
+- **Returns:** Offset shape, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeOffsetShape::PerformByJoin` (via `OCCTShapeOffsetByJoin`).
+- **Example:**
+  ```swift
+  if let grown = box.offset(by: 1.0, joinType: .intersection) { }
+  ```
+
+---
+
+## Transformations
+
+### `translated(by:)`
+
+Translate the shape.
+
+```swift
+public func translated(by offset: SIMD3<Double>) -> Shape?
+```
+
+- **Parameters:** `offset` — translation vector.
+- **Returns:** Translated shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` (via `OCCTShapeTranslate`).
+- **Example:**
+  ```swift
+  if let moved = box.translated(by: SIMD3(5, 0, 0)) { }
+  ```
+
+---
+
+### `rotated(axis:angle:)`
+
+Rotate the shape around an axis through the origin.
+
+```swift
+public func rotated(axis: SIMD3<Double>, angle: Double) -> Shape?
+```
+
+- **Parameters:** `axis` — rotation axis vector (need not be unit length); `angle` — angle in radians.
+- **Returns:** Rotated shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` / `gp_Trsf` (via `OCCTShapeRotate`).
+- **Example:**
+  ```swift
+  if let tilted = box.rotated(axis: SIMD3(0, 0, 1), angle: .pi / 4) { }
+  ```
+
+---
+
+### `scaled(by:)`
+
+Scale the shape uniformly from the origin.
+
+```swift
+public func scaled(by factor: Double) -> Shape?
+```
+
+- **Parameters:** `factor` — uniform scale factor.
+- **Returns:** Scaled shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` / `gp_Trsf` (via `OCCTShapeScale`).
+- **Example:**
+  ```swift
+  if let big = box.scaled(by: 2.0) { }
+  ```
+
+---
+
+### `mirrored(planeNormal:planeOrigin:)`
+
+Mirror the shape across a plane.
+
+```swift
+public func mirrored(planeNormal: SIMD3<Double>, planeOrigin: SIMD3<Double> = .zero) -> Shape?
+```
+
+- **Parameters:** `planeNormal` — normal of the mirror plane; `planeOrigin` — point on the mirror plane (default origin).
+- **Returns:** Mirrored shape, or `nil` on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` / `gp_Trsf` (via `OCCTShapeMirror`).
+- **Example:**
+  ```swift
+  // Mirror a shape across the XZ plane (normal = +Y)
+  if let reflected = part.mirrored(planeNormal: SIMD3(0, 1, 0)) { }
+  ```
+
+---
+
+## Compound Operations
+
+### `Shape.compound(_:)`
+
+Combine multiple shapes into a compound (grouping only — no boolean merge).
+
+```swift
+public static func compound(_ shapes: [Shape]) -> Shape?
+```
+
+- **Parameters:** `shapes` — array of shapes to group.
+- **Returns:** A `TopoDS_Compound` holding all shapes, or `nil` if the array is empty or creation fails.
+- **OCCT:** `BRep_Builder::MakeCompound` / `BRep_Builder::Add` (via `OCCTShapeCreateCompound`).
+- **Example:**
+  ```swift
+  guard let box = Shape.box(width: 10, height: 5, depth: 3),
+        let cyl = Shape.cylinder(radius: 2, height: 8) else { return }
+  if let group = Shape.compound([box, cyl]) {
+      // group.isValid == true; shapes remain separate
+  }
+  ```
+
+---
+
+## Conversion
+
+### `Shape.fromWire(_:)`
+
+Wrap a `Wire` as a `Shape` to access edge extraction and other Shape methods.
+
+```swift
+public static func fromWire(_ wire: Wire) -> Shape?
+```
+
+Since `TopoDS_Wire` inherits from `TopoDS_Shape` in OCCT, this is a lightweight conversion that enables using Shape methods (e.g. `allEdgePolylines()`) on wire geometry without creating solid geometry.
+
+- **Parameters:** `wire` — the wire to wrap.
+- **Returns:** A `Shape` wrapping the wire, or `nil` on failure.
+- **OCCT:** `TopoDS` shape-type promotion (via `OCCTShapeFromWire`).
+- **Example:**
+  ```swift
+  if let wireAsShape = Shape.fromWire(myWire) {
+      let polylines = wireAsShape.allEdgePolylines()
+  }
+  ```
+
+---
+
+### `Shape.fromEdge(_:)`
+
+Wrap an `Edge` as a `Shape` to use it with Shape-based APIs.
+
+```swift
+public static func fromEdge(_ edge: Edge) -> Shape?
+```
+
+Since `TopoDS_Edge` inherits from `TopoDS_Shape` in OCCT, this is a lightweight conversion.
+
+- **Parameters:** `edge` — the edge to wrap.
+- **Returns:** A `Shape` wrapping the edge, or `nil` on failure.
+- **OCCT:** `TopoDS` shape-type promotion (via `OCCTShapeFromEdge`).
+
+---
+
+### `Shape.fromFace(_:)`
+
+Wrap a `Face` as a `Shape` to use it with Shape-based APIs.
+
+```swift
+public static func fromFace(_ face: Face) -> Shape?
+```
+
+Since `TopoDS_Face` inherits from `TopoDS_Shape` in OCCT, this is a lightweight conversion.
+
+- **Parameters:** `face` — the face to wrap.
+- **Returns:** A `Shape` wrapping the face, or `nil` on failure.
+- **OCCT:** `TopoDS` shape-type promotion (via `OCCTShapeFromFace`).
+
+---
+
+## Validation
+
+### `isValid`
+
+Check if the shape is topologically and geometrically valid.
+
+```swift
+public var isValid: Bool { get }
+```
+
+- **Returns:** `true` if the shape passes OCCT's checker; `false` otherwise.
+- **OCCT:** `BRepCheck_Analyzer` (via `OCCTShapeIsValid`).
+- **Example:**
+  ```swift
+  guard let box = Shape.box(width: 10, height: 10, depth: 10),
+        box.isValid else { return }
+  ```
+
+---
+
+### `healed()`
+
+Attempt to repair and heal the shape.
+
+```swift
+public func healed() -> Shape?
+```
+
+- **Returns:** A healed shape, or `nil` if healing fails entirely.
+- **OCCT:** `ShapeFix_Shape` (via `OCCTShapeHeal`).
+- **Note:** Healing fixes common issues (gaps, bad tolerances, degenerate edges) but cannot repair fundamentally broken topology. Check `isValid` after healing.
+- **Example:**
+  ```swift
+  guard let repaired = importedShape.healed(), repaired.isValid else { return }
+  ```
+
+---
+
+## Meshing
+
+### `mesh(linearDeflection:angularDeflection:)`
+
+Generate a triangulated mesh for visualisation.
+
+```swift
+public func mesh(
+    linearDeflection: Double = 0.1,
+    angularDeflection: Double = 0.5
+) -> Mesh?
+```
+
+- **Parameters:**
+  - `linearDeflection` — maximum chord deviation from curved faces (smaller = finer mesh, default `0.1`).
+  - `angularDeflection` — maximum angular deviation in radians (default `0.5`).
+- **Returns:** A `Mesh` containing triangles and normals, or `nil` on failure.
+- **OCCT:** `BRepMesh_IncrementalMesh`.
+- **Example:**
+  ```swift
+  if let mesh = box.mesh(linearDeflection: 0.05, angularDeflection: 0.3) {
+      // use mesh.triangles, mesh.normals, etc.
+  }
+  ```
+
+---
+
+### `meshWithProgress(linearDeflection:angularDeflection:progress:)`
+
+Generate a triangulated mesh with progress and cancellation support.
+
+```swift
+@discardableResult
+public func meshWithProgress(
+    linearDeflection: Double = 0.1,
+    angularDeflection: Double = 0.5,
+    progress: ImportProgress? = nil
+) throws -> Shape
+```
+
+Wraps `BRepMesh_IncrementalMesh::Perform(Message_ProgressRange&)` so callers can observe meshing progress on large assemblies and cooperatively cancel.
+
+- **Parameters:**
+  - `linearDeflection`, `angularDeflection` — same as `mesh()`.
+  - `progress` — optional `ImportProgress` object; call `shouldCancel()` to abort cooperatively.
+- **Returns:** `self` (with triangulations attached) on success.
+- **Throws:** `ImportError.cancelled` if the meshing was cancelled cooperatively.
+- **OCCT:** `BRepMesh_IncrementalMesh` with `Message_ProgressRange` (via `OCCTShapeIncrementalMeshProgress`).
+- **Example:**
+  ```swift
+  class MyProgress: ImportProgress {
+      func shouldCancel() -> Bool { false }
+      func report(fraction: Double) { print("Meshing: \(Int(fraction * 100))%") }
+  }
+  let prog = MyProgress()
+  try shape.meshWithProgress(linearDeflection: 0.02, progress: prog)
+  let mesh = shape.mesh()  // triangulations are now attached
+  ```
+
+---
+
+### `mesh(parameters:)`
+
+Generate a triangulated mesh with enhanced parameters.
+
+```swift
+public func mesh(parameters: MeshParameters) -> Mesh?
+```
+
+Provides fine-grained control over tessellation quality, useful for CAM toolpath generation or high-quality visualisation.
+
+- **Parameters:** `parameters` — a `MeshParameters` struct with deflection, parallelism, and other options.
+- **Returns:** A `Mesh` with the specified quality settings, or `nil` on failure.
+- **OCCT:** `BRepMesh_IncrementalMesh` (via `OCCTShapeCreateMeshWithParams`).
+- **Example:**
+  ```swift
+  var params = MeshParameters.default
+  params.deflection = 0.02   // very fine mesh
+  params.inParallel = true   // multi-threaded
+  if let mesh = shape.mesh(parameters: params) { }
+  ```
+
+---
+
+## Edge Discretization
+
+### `edgePolyline(at:deflection:maxPoints:)`
+
+Get a discretised edge as a polyline.
+
+```swift
+public func edgePolyline(
+    at index: Int,
+    deflection: Double = 0.1,
+    maxPoints: Int = 1000
+) -> [SIMD3<Double>]?
+```
+
+Adaptively samples points along a B-Rep edge using curvature-based deflection control. Useful for contour toolpath generation, edge visualisation, and G-code generation.
+
+- **Parameters:**
+  - `index` — edge index (0-based).
+  - `deflection` — maximum chord deviation.
+  - `maxPoints` — maximum number of points to return.
+- **Returns:** Array of 3D points along the edge, or `nil` if the edge is not found.
+- **OCCT:** `GCPnts_TangentialDeflection` / `BRep_Tool::Curve` (via `OCCTShapeGetEdgePolyline`).
+- **Example:**
+  ```swift
+  if let pts = shape.edgePolyline(at: 0, deflection: 0.01) {
+      // pts is [SIMD3<Double>] — contour points
+  }
+  ```
+- **Note:** Edge indices may vary between runs for complex shapes; iterate to find a working index.
+
+---
+
+### `allEdgePolylines(deflection:maxPointsPerEdge:)`
+
+Get all edges as discretised polylines.
+
+```swift
+public func allEdgePolylines(
+    deflection: Double = 0.1,
+    maxPointsPerEdge: Int = 1000
+) -> [[SIMD3<Double>]]
+```
+
+Calls `edgePolyline` for each edge in the shape. Also calls `OCCTShapeBuildCurves3d` beforehand to ensure lofted/swept shapes (which may have only pcurves) have explicit 3D curves before discretisation.
+
+- **Parameters:**
+  - `deflection` — maximum chord deviation per edge.
+  - `maxPointsPerEdge` — maximum points per edge.
+- **Returns:** Array of polylines, one per edge. Edges that fail discretisation are skipped.
+- **OCCT:** `BRepLib::BuildCurves3d` + `GCPnts_TangentialDeflection` (via `OCCTShapeBuildCurves3d` and `OCCTShapeGetEdgePolyline`).
+- **Example:**
+  ```swift
+  let wireframe = shape.allEdgePolylines(deflection: 0.05)
+  for polyline in wireframe {
+      // draw polyline.map { CGPoint(x: $0.x, y: $0.y) }
+  }
+  ```
+
+---
+
+## Import
+
+### `Shape.load(from:progress:)`
+
+Load a shape from a STEP file (URL form).
+
+```swift
+public static func load(from url: URL, progress: ImportProgress? = nil) throws -> Shape
+```
+
+Convenience alias for `loadSTEP(fromPath:progress:)`.
+
+- **Parameters:** `url` — URL to the STEP file; `progress` — optional progress/cancellation channel.
+- **Returns:** Imported shape.
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on other failure.
+- **OCCT:** `STEPControl_Reader` (via `OCCTImportSTEPProgress`).
+- **Example:**
+  ```swift
+  guard let url = Bundle.main.url(forResource: "part", withExtension: "step") else { return }
+  let shape = try Shape.load(from: url)
+  ```
+
+---
+
+### `Shape.load(fromPath:progress:)`
+
+Load a shape from a STEP file path.
+
+```swift
+public static func load(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **Parameters:** `path` — file system path to the STEP file; `progress` — optional progress/cancellation.
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader` (via `OCCTImportSTEPProgress`).
+
+---
+
+### `Shape.loadSTEP(from:progress:)`
+
+Load a shape from a STEP file (alias with explicit naming).
+
+```swift
+public static func loadSTEP(from url: URL, progress: ImportProgress? = nil) throws -> Shape
+```
+
+Explicit alias for `load(from:progress:)`. Identical behaviour.
+
+- **OCCT:** `STEPControl_Reader`.
+
+---
+
+### `Shape.loadSTEP(fromPath:progress:)`
+
+Load a shape from a STEP file path with optional progress.
+
+```swift
+public static func loadSTEP(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader` (via `OCCTImportSTEPProgress`).
+
+---
+
+## STEP Reader Control
+
+### `Shape.stepRootCount(url:)`
+
+Get the number of transferable roots in a STEP file.
+
+```swift
+public static func stepRootCount(url: URL) -> Int
+```
+
+Use this to inspect a STEP file before importing specific roots with `loadSTEPRoot(from:rootIndex:)`.
+
+- **Parameters:** `url` — URL to the STEP file.
+- **Returns:** Number of roots (0 if the file cannot be read).
+- **OCCT:** `STEPControl_Reader::TransferRoots` (via `OCCTSTEPReaderNbRoots`).
+- **Example:**
+  ```swift
+  let count = Shape.stepRootCount(url: stepURL)
+  for i in 1...count {
+      let root = try Shape.loadSTEPRoot(from: stepURL, rootIndex: i)
+  }
+  ```
+
+---
+
+### `Shape.stepRootCount(path:)`
+
+Get the number of transferable roots in a STEP file (path form).
+
+```swift
+public static func stepRootCount(path: String) -> Int
+```
+
+- **OCCT:** `STEPControl_Reader` (via `OCCTSTEPReaderNbRoots`).
+
+---
+
+### `Shape.loadSTEPRoot(from:rootIndex:)`
+
+Import a specific root from a STEP file (1-based index).
+
+```swift
+public static func loadSTEPRoot(from url: URL, rootIndex: Int) throws -> Shape
+```
+
+- **Parameters:** `url` — URL to the STEP file; `rootIndex` — 1-based root index.
+- **Returns:** The imported shape for that root.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader::Transfer` (via `OCCTImportSTEPRoot`).
+
+---
+
+### `Shape.loadSTEPRoot(fromPath:rootIndex:)`
+
+Import a specific root from a STEP file by path (1-based index).
+
+```swift
+public static func loadSTEPRoot(fromPath path: String, rootIndex: Int) throws -> Shape
+```
+
+- **OCCT:** `STEPControl_Reader` (via `OCCTImportSTEPRoot`).
+
+---
+
+### `Shape.loadSTEP(from:unitInMeters:progress:)`
+
+Import a STEP file with a specific system length unit.
+
+```swift
+public static func loadSTEP(from url: URL, unitInMeters: Double, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **Parameters:**
+  - `url` — URL to the STEP file.
+  - `unitInMeters` — system length unit in metres (e.g. `0.001` for mm, `0.0254` for inch).
+  - `progress` — optional progress/cancellation channel.
+- **Returns:** The imported shape in the specified unit system.
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader` with `Interface_Static` unit setting (via `OCCTImportSTEPWithUnitProgress`).
+
+---
+
+### `Shape.loadSTEP(fromPath:unitInMeters:progress:)`
+
+Import a STEP file with a specific system length unit (path form).
+
+```swift
+public static func loadSTEP(fromPath path: String, unitInMeters: Double, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **OCCT:** `STEPControl_Reader` (via `OCCTImportSTEPWithUnitProgress`).
+
+---
+
+### `Shape.stepShapeCount(url:)`
+
+Get the number of shapes in a STEP file after full transfer.
+
+```swift
+public static func stepShapeCount(url: URL) -> Int
+```
+
+- **Returns:** Number of shapes (0 if the file cannot be read).
+- **OCCT:** `STEPControl_Reader::NbShapes` (via `OCCTSTEPReaderNbShapes`).
+
+---
+
+### `Shape.stepShapeCount(path:)`
+
+Get the number of shapes in a STEP file after full transfer (path form).
+
+```swift
+public static func stepShapeCount(path: String) -> Int
+```
+
+- **OCCT:** `STEPControl_Reader` (via `OCCTSTEPReaderNbShapes`).
+
+---
+
+## Robust STEP Import
+
+### `Shape.loadRobust(from:)`
+
+Load a STEP file with robust handling: sewing, solid creation, and shape healing.
+
+```swift
+public static func loadRobust(from url: URL) throws -> Shape
+```
+
+Recommended for STEP files that may contain disconnected faces needing sewing, shells needing conversion to solids, or geometry issues requiring healing.
+
+- **Parameters:** `url` — URL to the STEP file.
+- **Returns:** Processed shape suitable for CAM operations.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader` + `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTImportSTEPRobust`).
+- **Example:**
+  ```swift
+  let shape = try Shape.loadRobust(from: stepURL)
+  print(shape.isValid)   // typically true
+  ```
+
+---
+
+### `Shape.loadRobust(fromPath:)`
+
+Load a STEP file with robust handling from a file path.
+
+```swift
+public static func loadRobust(fromPath path: String) throws -> Shape
+```
+
+- **OCCT:** `STEPControl_Reader` + sewing + solid creation + healing (via `OCCTImportSTEPRobust`).
+
+---
+
+### `Shape.loadWithDiagnostics(from:)`
+
+Load a STEP file with diagnostic information about the processing steps applied.
+
+```swift
+public static func loadWithDiagnostics(from url: URL) throws -> ImportResult
+```
+
+Returns an `ImportResult` struct containing the shape and information about what processing (sewing, solid creation, healing) was applied.
+
+- **Parameters:** `url` — URL to the STEP file.
+- **Returns:** `ImportResult` with `shape`, `originalType`, `resultType`, `sewingApplied`, `solidCreated`, and `healingApplied`.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader` + `OCCTImportSTEPWithDiagnostics`.
+- **Example:**
+  ```swift
+  let result = try Shape.loadWithDiagnostics(from: stepFile)
+  print(result.summary)   // e.g. "Shell → Solid (processing: sewing, solid creation, healing)"
+  let shape = result.shape
+  ```
+
+---
+
+## IGES Import
+
+### `Shape.loadIGES(from:progress:)`
+
+Load a shape from an IGES file.
+
+```swift
+public static func loadIGES(from url: URL, progress: ImportProgress? = nil) throws -> Shape
+```
+
+IGES is a legacy CAD format still commonly used in manufacturing and older CAD systems.
+
+- **Parameters:** `url` — URL to the `.igs` or `.iges` file; `progress` — optional progress/cancellation.
+- **Returns:** Imported shape.
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
+- **OCCT:** `IGESControl_Reader` (via `OCCTImportIGESProgress`).
+- **Example:**
+  ```swift
+  let shape = try Shape.loadIGES(from: igesURL)
+  ```
+
+---
+
+### `Shape.loadIGES(fromPath:progress:)`
+
+Load a shape from an IGES file path.
+
+```swift
+public static func loadIGES(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **OCCT:** `IGESControl_Reader` (via `OCCTImportIGESProgress`).
+
+---
+
+### `Shape.loadIGESRobust(from:progress:)`
+
+Load an IGES file with automatic repair (sewing and healing).
+
+```swift
+public static func loadIGESRobust(from url: URL, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **Parameters:** `url` — URL to the IGES file; `progress` — optional progress/cancellation channel.
+- **Returns:** Processed shape with healing applied.
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
+- **OCCT:** `IGESControl_Reader` + `BRepBuilderAPI_Sewing` + `ShapeFix_Shape` (via `OCCTImportIGESRobustProgress`).
+
+---
+
+### `Shape.loadIGESRobust(fromPath:progress:)`
+
+Load an IGES file with automatic repair from a path.
+
+```swift
+public static func loadIGESRobust(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape
+```
+
+- **OCCT:** `IGESControl_Reader` + sewing + healing (via `OCCTImportIGESRobustProgress`).
+
+---
+
+## IGES Reader Control
+
+### `Shape.igesRootCount(url:)`
+
+Get the number of transferable roots in an IGES file.
+
+```swift
+public static func igesRootCount(url: URL) -> Int
+```
+
+- **Returns:** Number of roots (0 if the file cannot be read).
+- **OCCT:** `IGESControl_Reader` (via `OCCTIGESReaderNbRoots`).
+
+---
+
+### `Shape.igesRootCount(path:)`
+
+Get the number of transferable roots in an IGES file (path form).
+
+```swift
+public static func igesRootCount(path: String) -> Int
+```
+
+- **OCCT:** `IGESControl_Reader` (via `OCCTIGESReaderNbRoots`).
+
+---
+
+### `Shape.loadIGESRoot(from:rootIndex:)`
+
+Import a specific root from an IGES file (1-based index).
+
+```swift
+public static func loadIGESRoot(from url: URL, rootIndex: Int) throws -> Shape
+```
+
+- **Parameters:** `url` — URL to the IGES file; `rootIndex` — 1-based root index.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `IGESControl_Reader::Transfer` (via `OCCTImportIGESRoot`).
+
+---
+
+### `Shape.loadIGESRoot(fromPath:rootIndex:)`
+
+Import a specific root from an IGES file by path (1-based index).
+
+```swift
+public static func loadIGESRoot(fromPath path: String, rootIndex: Int) throws -> Shape
+```
+
+- **OCCT:** `IGESControl_Reader` (via `OCCTImportIGESRoot`).
+
+---
+
+### `Shape.igesShapeCount(url:)`
+
+Get the number of shapes in an IGES file after full transfer.
+
+```swift
+public static func igesShapeCount(url: URL) -> Int
+```
+
+- **OCCT:** `IGESControl_Reader::NbShapes` (via `OCCTIGESReaderNbShapes`).
+
+---
+
+### `Shape.igesShapeCount(path:)`
+
+Get the number of shapes in an IGES file after full transfer (path form).
+
+```swift
+public static func igesShapeCount(path: String) -> Int
+```
+
+- **OCCT:** `IGESControl_Reader` (via `OCCTIGESReaderNbShapes`).
+
+---
+
+### `Shape.loadIGESVisible(from:)`
+
+Import only visible entities from an IGES file.
+
+```swift
+public static func loadIGESVisible(from url: URL) throws -> Shape
+```
+
+- **Parameters:** `url` — URL to the IGES file.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `IGESControl_Reader` with visibility filtering (via `OCCTImportIGESVisible`).
+
+---
+
+### `Shape.loadIGESVisible(fromPath:)`
+
+Import only visible entities from an IGES file (path form).
+
+```swift
+public static func loadIGESVisible(fromPath path: String) throws -> Shape
+```
+
+- **OCCT:** `IGESControl_Reader` (via `OCCTImportIGESVisible`).
+
+---
+
+## BREP Import
+
+### `Shape.loadBREP(from:)`
+
+Load a shape from OCCT's native BREP format.
+
+```swift
+public static func loadBREP(from url: URL) throws -> Shape
+```
+
+BREP is OCCT's native exact B-Rep format. It preserves full precision and is useful for fast caching of intermediate results, debugging geometry, and archiving exact geometry.
+
+- **Parameters:** `url` — URL to the `.brep` file.
+- **Returns:** Imported shape.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `BRep_Builder` / `BRepTools::Read` (via `OCCTImportBREP`).
+- **Example:**
+  ```swift
+  let shape = try Shape.loadBREP(from: brepURL)
+  ```
+
+---
+
+### `Shape.loadBREP(fromPath:)`
+
+Load a shape from a BREP file path.
+
+```swift
+public static func loadBREP(fromPath path: String) throws -> Shape
+```
+
+- **OCCT:** `BRep_Builder` / `BRepTools::Read` (via `OCCTImportBREP`).
+
+---
+
+## STL Import
+
+### `Shape.loadSTL(from:)`
+
+Load a shape from an STL file.
+
+```swift
+public static func loadSTL(from url: URL) throws -> Shape
+```
+
+- **Parameters:** `url` — URL to the `.stl` file.
+- **Returns:** Imported shape (a shell of triangulated faces).
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `StlAPI_Reader` (via `OCCTImportSTL`).
+- **Example:**
+  ```swift
+  let mesh = try Shape.loadSTL(from: stlURL)
+  ```
+
+---
+
+### `Shape.loadSTL(fromPath:)`
+
+Load a shape from an STL file path.
+
+```swift
+public static func loadSTL(fromPath path: String) throws -> Shape
+```
+
+- **OCCT:** `StlAPI_Reader` (via `OCCTImportSTL`).
+
+---
+
+### `Shape.loadSTLRobust(from:sewingTolerance:)`
+
+Load an STL file with robust healing (sew + solid creation + heal).
+
+```swift
+public static func loadSTLRobust(from url: URL, sewingTolerance: Double = 1e-6) throws -> Shape
+```
+
+- **Parameters:**
+  - `url` — URL to the STL file.
+  - `sewingTolerance` — tolerance for sewing disconnected faces (default `1e-6`).
+- **Returns:** Processed shape suitable for solid operations.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `StlAPI_Reader` + `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTImportSTLRobust`).
+- **Example:**
+  ```swift
+  let solid = try Shape.loadSTLRobust(from: stlURL, sewingTolerance: 1e-5)
+  print(solid.isValid)
+  ```
+
+---
+
+### `Shape.loadSTLRobust(fromPath:sewingTolerance:)`
+
+Load an STL file with robust healing from a path.
+
+```swift
+public static func loadSTLRobust(fromPath path: String, sewingTolerance: Double = 1e-6) throws -> Shape
+```
+
+- **OCCT:** `StlAPI_Reader` + sewing + healing (via `OCCTImportSTLRobust`).
+
+---
+
+## OBJ Import
+
+### `Shape.loadOBJ(from:)`
+
+Load a shape from an OBJ file.
+
+```swift
+public static func loadOBJ(from url: URL) throws -> Shape
+```
+
+- **Parameters:** `url` — URL to the `.obj` file.
+- **Returns:** Imported shape.
+- **Throws:** `ImportError.importFailed` on failure.
+- **OCCT:** `RWObj_CafReader` (via `OCCTImportOBJ`).
+- **Example:**
+  ```swift
+  let shape = try Shape.loadOBJ(from: objURL)
+  ```
+
+---
+
+### `Shape.loadOBJ(fromPath:)`
+
+Load a shape from an OBJ file path.
+
+```swift
+public static func loadOBJ(fromPath path: String) throws -> Shape
+```
+
+- **OCCT:** `RWObj_CafReader` (via `OCCTImportOBJ`).


### PR DESCRIPTION
Batch 4 — the biggest type, **`Shape` (867 decls)**, split into **9 parallel Sonnet subagent jobs by contiguous line range** (Shape has ~250 fine-grained MARKs, so line ranges guarantee a complete partition — no gaps/overlaps), all children of API Reference:

| Page | lines | entries |
|------|------:|--------:|
| `Shape.md` (core) | 1–1257 | 97 |
| Shape — Features, Sweeps & Surface Building | 1258–3344 | 87 |
| Shape — Healing, Recognition & Feature Ops | 3345–4954 | 89 |
| Shape — Measurement, Sub-Shapes & Local Operations | 4955–6935 | 127 |
| Shape — Builders & Boolean Internals I | 6936–8587 | ~98 |
| Shape — Builders & Boolean Internals II | 8588–10215 | 117 |
| Shape — HLR, Intervals, Mesh Props & Geom Primitives | 10216–11077 | 113 |
| Shape — Geometry Recognition & Polygon/Triangulation Data | 11078–12192 | 86 |
| Shape — Advanced Sweeps & API Completions | 12193–EOF | 124 |

~930 entries total. Verified: front-matter, signatures vs source, OCCT mappings. Caught + trimmed one boundary double-doc (`ShapeAnalysis_FreeBoundsProperties` appeared in both Measurement and Builders-1 — kept in Measurement). The remaining same-named headings across pages are legitimately distinct members on different nested geom types (`direction`/`location` on Axis1/Axis2Placement, etc.).

Coverage now: Wire, Edge, Face, Mesh, Exporter, ThreadFeatures, Surface (×5), Curve3D (×4), Curve2D (×4), **Shape (×9)**. Remaining: Document, TopologyGraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)