### PR TITLE
fix(threads): single-start threadedShaft always smooth; deprecate .boolean (#254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ OCCTSwift provides method-level coverage of all user-facing OCCT classes. Key ar
 | Colors & Materials | 63 | Quantity_Color, sRGB/Lab/HLS, PBR materials, named colors |
 | Geometry Factories | 90+ | GC/GCE2d/gce factories, convert to BSpline, analytical recognition |
 | Drawings & Dimensions | 32 | HLR projection, visible/hidden/outline edges, linear/radial/diameter/angular dimensions, centrelines, auto-centreline from revolution axes, DXF R12 writer |
-| Thread Features | 23 | ThreadForm (ISO-68/Unified), ThreadSpec parser (M5x0.8, 1/4-20 UNC), truncated 60° V-profile, multi-start, runout styles, Shape.threadedHole, Shape.threadedShaft (ThreadBuild `.auto`/`.direct`/`.boolean` — in-envelope cut for headless lead screws/studs/worms), Shape.threadedRod (smooth worm/screw from a custom ThreadProfile, boolean-free) |
+| Thread Features | 23 | ThreadForm (ISO-68/Unified), ThreadSpec parser (M5x0.8, 1/4-20 UNC), truncated 60° V-profile, multi-start, runout styles, Shape.threadedHole, Shape.threadedShaft (smooth direct build for single-start; ThreadBuild `.auto`/`.direct`, `.boolean` deprecated — #254), Shape.threadedRod (smooth worm/screw from a custom ThreadProfile, boolean-free) |
 | Sheet Metal | 3 | `SheetMetal.Flange` + `Bend` + `Builder.build` — declarative flange-and-bend composition via extrude + union + fillet |
 
 For the full operation-by-operation mapping to OCCT classes, see [docs/API_REFERENCE.md](docs/API_REFERENCE.md).

--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -206,21 +206,30 @@ public enum RunoutStyle: Sendable, Hashable {
 }
 
 /// Which construction path ``Shape/threadedShaft(axisOrigin:axisDirection:spec:length:starts:runout:build:)``
-/// uses to cut an external thread. The two paths differ in their outer envelope (#222).
+/// uses to build an external thread.
+///
+/// For a **single-start** thread on a plain coaxial cylinder (the overwhelmingly common case) all
+/// surviving modes now produce the same smooth, BRepCheck-valid **direct** build (#213) — there is
+/// no longer a reason to choose between them. The boolean cut path remains only for the cases the
+/// direct build cannot handle (multi-start, non-cylinder targets), where it is **faceted and
+/// unreliable** — see ``boolean`` and #254.
 public enum ThreadBuild: Sendable, Hashable, Codable {
-    /// Original heuristic: the smooth, boolean-free direct rod build (#213) for a single-start
-    /// thread on a plain coaxial cylinder, and the boolean cut path otherwise. Best surface
-    /// quality, but the direct build's `ruled:false` loft can bow the crest **past** the nominal
-    /// major radius at coarse pitch / wide crest flats (#222).
+    /// Smooth, boolean-free direct rod build (#213) for a single-start thread on a plain coaxial
+    /// cylinder; the boolean cut path otherwise (multi-start / non-cylinder). The recommended
+    /// default. The earlier crest-overshoot concern (#222) was shown by #232 to be a `Bnd_Box`
+    /// control-hull over-report, not real geometry — the direct crest is in-envelope.
     case auto
-    /// Prefer the smooth direct build, falling back to the boolean cut when it is unavailable
-    /// (multi-start, non-cylinder target, or a construction failure). Same envelope caveat as
-    /// `.auto` — may exceed `spec.nominalDiameter / 2` at coarse pitch.
+    /// Prefer the smooth direct build, falling back to the boolean cut only when the direct build
+    /// is unavailable (multi-start, non-cylinder target, or a construction failure). For a
+    /// single-start coaxial cylinder this is identical to ``auto``.
     case direct
-    /// Always use the boolean cut path. The cutter is subtracted from a cylinder of radius exactly
-    /// `spec.nominalDiameter / 2`, so the crest is clamped to the nominal major radius (in-envelope)
-    /// — at the cost of the direct build's smooth crest. Use for headless single-start parts
-    /// (lead screws, studs, worms) where the outer diameter must not overshoot nominal.
+    /// **Deprecated (#254).** Formerly forced the boolean cut path to clamp a supposed crest
+    /// overshoot — but #232 established that overshoot was only a `Bnd_Box` over-report, so the
+    /// direct build was correct all along. The forced cut path produces a *faceted, frequently
+    /// disconnected* thread (a helical scatter of rectangular notches rather than a continuous
+    /// groove) and offers no envelope advantage. Now treated exactly like ``auto`` — single-start
+    /// coaxial cylinders get the smooth direct build. Use ``auto`` or ``direct``.
+    @available(*, deprecated, message: "Use .auto or .direct — .boolean no longer differs for buildable threads and its forced cut path is faceted/unreliable (#254/#232).")
     case boolean
 }
 
@@ -474,10 +483,15 @@ extension Shape {
     /// see ``buildThreadedRodDirect`` and OCCTSwift #213. For non-cylinder targets, multi-start,
     /// or if the direct build fails, it falls back to the boolean cut path (``applyThreadCut``).
     ///
-    /// - Parameter build: chooses the construction path (#222). `.auto` (default) keeps the
-    ///   smooth direct build for single-start coaxial cylinders; `.boolean` forces the in-envelope
-    ///   cut path so a headless single-start part (lead screw / stud / worm) never overshoots the
-    ///   nominal major diameter. See ``ThreadBuild``.
+    /// - Parameter build: chooses the construction path. `.auto` (default) and `.direct` use the
+    ///   smooth, boolean-free direct build for single-start coaxial cylinders and fall back to the
+    ///   faceted cut path only for multi-start / non-cylinder targets. `.boolean` is **deprecated**
+    ///   (#254): it formerly forced the cut path, which produces a faceted, frequently disconnected
+    ///   thread; it is now treated like `.auto`. See ``ThreadBuild``.
+    ///
+    /// - Note: **Multi-start** threads (`starts > 1`) currently have no direct build and use the
+    ///   faceted boolean cut, which can come out as a helical scatter of disconnected notches rather
+    ///   than a continuous thread (#254). For multi-start a smooth direct build is a known gap.
     public func threadedShaft(axisOrigin: SIMD3<Double>,
                                axisDirection: SIMD3<Double>,
                                spec: ThreadSpec,
@@ -486,7 +500,11 @@ extension Shape {
                                runout: RunoutStyle = .none,
                                build: ThreadBuild = .auto) -> Shape? {
         let len = length ?? (2 * spec.nominalDiameter)
-        if build != .boolean, starts == 1,
+        // Single-start coaxial cylinders always take the smooth direct build, regardless of `build`
+        // (#254): the cut path's only historical advantage — an "in-envelope" crest — was disproved
+        // by #232, and it otherwise yields a faceted/disconnected thread. `.boolean` is deprecated
+        // and handled here identically to `.auto`/`.direct`.
+        if starts == 1,
            let direct = buildThreadedRodDirect(axisOrigin: axisOrigin, axisDirection: axisDirection,
                                                spec: spec, length: len) {
             switch runout {

--- a/Tests/OCCTThreadTests/Issue222EnvelopeTests.swift
+++ b/Tests/OCCTThreadTests/Issue222EnvelopeTests.swift
@@ -3,47 +3,52 @@ import Foundation
 import simd
 @testable import OCCTSwift
 
-// #222: at coarse pitch / wide crest flats the smooth direct build (#213) bows the crest past the
-// nominal major radius (+14–21%). `threadedShaft(build: .boolean)` forces the in-envelope cut path
-// (cutter subtracted from a cylinder of radius exactly major/2), so a headless single-start part —
-// lead screw, stud, worm — never overshoots nominal. These guard that contract.
-@Suite("Issue #222 — coarse-pitch thread envelope")
+// #222 (revised by #232 / #254): the smooth direct build (#213) was *reported* to bow the crest past
+// the nominal major radius at coarse pitch / wide crest flats (+14–21%). #232 then showed that
+// "overshoot" is a `Shape.bounds` (OCCT `Bnd_Box`) **control-hull artifact** — the B-spline convex
+// hull bulges out, but the real surface (optimal box / mesh vertices) sits exactly at nominal. So the
+// direct build is genuinely in-envelope; the old `.boolean` cut path it motivated has no advantage and
+// is deprecated (#254). These tests now guard the *true* contract, measured tightly.
+@Suite("Issue #222 — coarse-pitch thread crest is in-envelope (tight measure)")
 struct Issue222Envelope {
 
-    /// Max radial extent of a z-axis rod (its outer/crest radius), mesh-independent via the AABB.
-    private func crestRadius(_ s: Shape) -> Double {
-        let b = s.bounds
+    /// Crest radius from the **optimal** box (tight; AddOptimal) — the ground truth, not `Bnd_Box`.
+    private func crestRadiusOptimal(_ s: Shape) -> Double? {
+        guard let b = s.boundingBoxOptimal() else { return nil }
         return max(abs(b.max.x), abs(b.min.x), abs(b.max.y), abs(b.min.y))
     }
 
-    @Test("`.boolean` keeps the crest within the nominal major radius (iso68, coarse)")
-    func booleanInEnvelopeISO() {
-        guard let rod = Shape.cylinder(radius: 6, height: 40) else { #expect(Bool(false)); return }
-        let spec = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75)
-        let threaded = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
-                                         spec: spec, length: 40, starts: 1, runout: .none, build: .boolean)
-        guard let t = threaded else { #expect(Bool(false), "build: .boolean returned nil"); return }
-        #expect(t.isValid)
-        let r = crestRadius(t)
-        // Nominal major radius is 6.0; allow a small tessellation/healing margin. The direct build
-        // measures ~6.85 here (+14%), so 1.02 cleanly separates in-envelope from the overshoot.
-        #expect(r <= 6.0 * 1.02, "crest radius \(r) exceeds nominal major radius 6.0 (#222)")
-        if let v0 = rod.volume, let v1 = t.volume {
-            #expect(v1 < v0, "no material removed — not a real thread")
-        }
+    /// Crest radius from mesh vertices (independent tight ground truth — verts lie on real faces).
+    private func crestRadiusMesh(_ s: Shape) -> Double? {
+        guard let m = s.mesh(linearDeflection: 0.05) else { return nil }
+        return m.vertices.reduce(0.0) { max($0, Double((($1.x * $1.x) + ($1.y * $1.y)).squareRoot())) }
     }
 
-    @Test("`.boolean` keeps the crest within the nominal major radius (Tr trapezoidal, coarse)")
-    func booleanInEnvelopeTrapezoidal() {
+    @Test("Direct build keeps the crest within the nominal major radius (iso68, coarse)")
+    func directInEnvelopeISO() {
+        guard let rod = Shape.cylinder(radius: 6, height: 40) else { #expect(Bool(false)); return }
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: 12, pitch: 1.75)   // nominal major radius 6.0
+        let threaded = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                         spec: spec, length: 40, build: .direct)
+        guard let t = threaded else { #expect(Bool(false), "direct build returned nil"); return }
+        #expect(t.isValid)
+        // Both tight measures must sit at ~6.0 (the Bnd_Box `bounds` reads ~6.85 here — the artifact).
+        if let r = crestRadiusOptimal(t) { #expect(r <= 6.0 * 1.005, "optimal crest \(r) > nominal 6.0") }
+        if let r = crestRadiusMesh(t)    { #expect(r <= 6.0 * 1.005, "mesh crest \(r) > nominal 6.0") }
+        if let v0 = rod.volume, let v1 = t.volume { #expect(v1 < v0, "no material removed — not a real thread") }
+    }
+
+    @Test("Direct build keeps the crest within the nominal major radius (Tr trapezoidal, coarse)")
+    func directInEnvelopeTrapezoidal() {
         guard let rod = Shape.cylinder(radius: 6, height: 40) else { #expect(Bool(false)); return }
         let spec = ThreadSpec(form: .trapezoidal, nominalDiameter: 12, pitch: 3.0)
         let threaded = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
-                                         spec: spec, length: 40, starts: 1, runout: .none, build: .boolean)
-        guard let t = threaded else { #expect(Bool(false), "build: .boolean returned nil"); return }
+                                         spec: spec, length: 40, build: .direct)
+        guard let t = threaded else { #expect(Bool(false), "direct build returned nil"); return }
         #expect(t.isValid)
-        let r = crestRadius(t)
-        // Direct build is the worst case here: ~7.28 (+21%). Boolean must stay at ~6.0.
-        #expect(r <= 6.0 * 1.02, "crest radius \(r) exceeds nominal major radius 6.0 (#222)")
+        // `bounds` reads ~7.28 here (+21%); the real crest is at 6.0.
+        if let r = crestRadiusOptimal(t) { #expect(r <= 6.0 * 1.005, "optimal crest \(r) > nominal 6.0") }
+        if let r = crestRadiusMesh(t)    { #expect(r <= 6.0 * 1.005, "mesh crest \(r) > nominal 6.0") }
     }
 
     @Test("default `.auto` still builds a valid single-start rod (no regression)")

--- a/Tests/OCCTThreadTests/Issue232BoundsTests.swift
+++ b/Tests/OCCTThreadTests/Issue232BoundsTests.swift
@@ -2,10 +2,11 @@ import Testing
 import simd
 @testable import OCCTSwift
 
-/// Issue #232: `threadedShaft(build: .boolean)` / `threadedHole` were reported to run ~one lead
-/// past `length`/`depth`. Investigation found the threaded **solid is bounded exactly to the
-/// requested span** — the overshoot is `Shape.bounds` (OCCT's default `Bnd_Box`) over-reporting for
-/// the B-spline/faceted thread surfaces (the control-hull artifact, cf. #213), not real geometry.
+/// Issue #232: `threadedShaft` / `threadedHole` were reported to run ~one lead past `length`/`depth`.
+/// Investigation found the threaded **solid is bounded exactly to the requested span** — the overshoot
+/// is `Shape.bounds` (OCCT's default `Bnd_Box`) over-reporting for the B-spline/faceted thread surfaces
+/// (the control-hull artifact, cf. #213), not real geometry. (Originally exercised via the now-deprecated
+/// `.boolean` cut path; uses `.direct` since #254 routes single-start builds there.)
 ///
 /// These tests lock that in using the **mesh-vertex extent** (the unambiguous ground truth: mesh
 /// vertices lie on the actual faces), not `bounds`.
@@ -26,7 +27,7 @@ struct Issue232BoundsTests {
         guard let rod = Shape.cylinder(radius: 6, height: length),
               let t = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
                                         spec: ThreadSpec(form: .trapezoidal, nominalDiameter: 12, pitch: pitch),
-                                        length: length, build: .boolean),
+                                        length: length, build: .direct),
               let z = Self.meshZExtent(t) else {
             Issue.record("build/mesh failed"); return
         }
@@ -44,7 +45,7 @@ struct Issue232BoundsTests {
         guard let rod = Shape.cylinder(radius: 5, height: length),
               let t = rod.threadedShaft(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
                                         spec: ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: pitch),
-                                        length: length, build: .boolean),
+                                        length: length, build: .direct),
               let z = Self.meshZExtent(t) else {
             Issue.record("build/mesh failed"); return
         }

--- a/Tests/OCCTThreadTests/Issue254BuildModesTests.swift
+++ b/Tests/OCCTThreadTests/Issue254BuildModesTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #254: `threadedShaft(build: .boolean)` (and `.boolean` generally) forced the faceted
+/// screw-loft cut path, whose helical cutter is the classic OCCT BOP trap — the subtraction comes
+/// back as a helical scatter of **disconnected rectangular notches** (hundreds of faces) rather than
+/// a continuous thread, even though the solid is `isValid` with roughly the right volume. Because
+/// #232 disproved the only reason `.boolean` existed (a `Bnd_Box`-artifact "crest overshoot" — the
+/// direct build is in-envelope, see `Issue222Envelope`), `.boolean` is now deprecated and
+/// single-start coaxial cylinders take the smooth direct build for **every** build mode.
+@Suite("Issue #254 — single-start threads are smooth helices for every build mode")
+struct Issue254BuildModes {
+
+    private func shaft(_ build: ThreadBuild) -> Shape? {
+        Shape.cylinder(radius: 5, height: 26)?.threadedShaft(
+            axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+            spec: ThreadSpec(form: .iso68, nominalDiameter: 10, pitch: 1.5),
+            length: 26, runout: .none, build: build)
+    }
+
+    // Exercise the deprecated `.boolean` without a deprecation warning (calling it from a deprecated
+    // context suppresses the diagnostic) — we deliberately prove it no longer regresses.
+    @available(*, deprecated)
+    private func booleanShaft() -> Shape? { shaft(.boolean) }
+
+    @Test("`.auto`, `.direct` and (deprecated) `.boolean` all yield the same smooth helix")
+    func allModesAreDirect() {
+        guard let auto = shaft(.auto), let direct = shaft(.direct), let boolean = booleanShaft() else {
+            Issue.record("build failed"); return
+        }
+        let fAuto = auto.subShapes(ofType: .face).count
+        let fDirect = direct.subShapes(ofType: .face).count
+        let fBool = boolean.subShapes(ofType: .face).count
+        // The smooth direct helix is a small handful of faces. The old faceted cut produced ~893;
+        // a low ceiling cleanly separates "smooth helix" from "notch scatter".
+        #expect(fDirect < 40, "direct build should be a smooth low-face helix, got \(fDirect)")
+        #expect(fAuto == fDirect, "auto must match direct for single-start, got \(fAuto) vs \(fDirect)")
+        #expect(fBool == fDirect, "deprecated .boolean must now match direct, got \(fBool) vs \(fDirect)")
+    }
+
+    @Test("Single-start `.boolean` crest is in-envelope and material was removed")
+    func booleanIsInEnvelope() {
+        guard let t = booleanShaft() else { Issue.record("boolean build failed"); return }
+        #expect(t.isValid)
+        if let o = t.boundingBoxOptimal() {
+            let r = max(abs(o.max.x), abs(o.min.x), abs(o.max.y), abs(o.min.y))
+            #expect(r <= 5.0 * 1.005, "crest \(r) should be at nominal 5.0")
+        }
+        if let blank = Shape.cylinder(radius: 5, height: 26)?.volume, let v = t.volume {
+            #expect(v < blank, "no material removed — not a real thread")
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,34 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.8.0
+## Current: v1.8.1
 
 **macOS / iOS / visionOS / tvOS | OCCT 8.0.0p1**
 
 ---
 
 ## Release History
+
+### v1.8.1 (June 2026) — fix: single-start `threadedShaft` is always a smooth helix; deprecate `.boolean` (#254)
+
+**Fix.** `threadedShaft(build: .boolean)` produced a *faceted, disconnected* thread — a helical
+scatter of rectangular notches rather than a continuous groove — because it forced the screw-loft
+boolean cut path, whose tightly-wound helical cutter is the classic OCCT BOP failure (cf. #213/#225).
+The solid was `isValid` with roughly the right volume, so only rendering exposed it.
+
+`.boolean` only ever existed to clamp a supposed crest "overshoot" from #222 — but #232 established
+that overshoot is a `Bnd_Box` control-hull **artifact** (verified here: the direct build's crest
+measures **exactly nominal** by both `boundingBoxOptimal()` and mesh vertices, while `.bounds`
+over-reads +14–21%). With no remaining reason to prefer it, **single-start coaxial-cylinder threads
+now take the smooth, boolean-free direct build (#213) for every build mode**, and `ThreadBuild.boolean`
+is **deprecated** (now treated as `.auto`). Use `.auto` or `.direct`.
+
+`.auto` / `.direct` single-start behaviour is unchanged (they already built direct). Swift-only change —
+no xcframework rebuild.
+
+**Known limitation:** multi-start threads (`starts > 1`) and non-cylinder targets still use the
+faceted cut path, which can come out as disconnected notches — a smooth multi-start/internal direct
+build is a tracked gap.
 
 ### v1.8.0 (June 2026) — feat: `Exporter.writeBREP(allowInvalid:)`
 

--- a/docs/reference/ThreadFeatures.md
+++ b/docs/reference/ThreadFeatures.md
@@ -29,7 +29,7 @@ public func threadedShaft(axisOrigin: SIMD3<Double>,
                            build: ThreadBuild = .auto) -> Shape?
 ```
 
-When `self` is a plain cylinder coaxial with the axis (the common case) and `build != .boolean` and `starts == 1`, this builds the threaded rod **directly with no boolean**: the thread's true cross-section (a "cam": root arc → flank → crest arc → flank) is lofted at closely-spaced z-slices rotated by the helix (`ruled=false`), giving a smooth, BRepCheck-valid solid of a handful of B-spline faces. Any unthreaded margin is closed by pure sewing (shoulder + cylinder + end disk). Because the boolean engine is never invoked, the result is orientation-robust and valid where a cut-the-cutter approach is faceted or fails. For non-cylinder targets, multi-start, or when the direct build fails, the method falls back to the boolean cut path (`applyThreadCut`).
+When `self` is a plain cylinder coaxial with the axis (the common case) and `starts == 1`, this builds the threaded rod **directly with no boolean** for every build mode (`.boolean` is deprecated and treated as `.auto` since #254): the thread's true cross-section (a "cam": root arc → flank → crest arc → flank) is lofted at closely-spaced z-slices rotated by the helix (`ruled=false`), giving a smooth, BRepCheck-valid solid of a handful of B-spline faces. Any unthreaded margin is closed by pure sewing (shoulder + cylinder + end disk). Because the boolean engine is never invoked, the result is orientation-robust and valid where a cut-the-cutter approach is faceted or fails. For non-cylinder targets, multi-start, or when the direct build fails, the method falls back to the boolean cut path (`applyThreadCut`).
 
 - **Parameters:**
   - `axisOrigin` — a point on the shaft axis (typically the centre of the bottom face).
@@ -38,8 +38,8 @@ When `self` is a plain cylinder coaxial with the axis (the common case) and `bui
   - `length` — threaded length in mm (default: `2 * spec.nominalDiameter`).
   - `starts` — number of thread starts (1 for standard fasteners; >1 for lead screws). Multi-start forces the boolean cut path.
   - `runout` — thread termination style at each end (see `RunoutStyle`).
-  - `build` — construction path selector; `.auto` (default) uses the smooth direct build for single-start coaxial cylinders; `.boolean` forces the in-envelope cut path so the major diameter never overshoots `spec.nominalDiameter / 2` (see `ThreadBuild`).
-- **Returns:** Threaded shape, or `nil` on sweep / boolean failure. Use `boundingBoxOptimal()` (not `bounds`) to measure the true crest radius — the BSpline pole hull overshoots by ~13%.
+  - `build` — construction path selector; `.auto` (default) and `.direct` use the smooth direct build for single-start coaxial cylinders. `.boolean` is **deprecated** (#254) and now behaves like `.auto`. See `ThreadBuild`.
+- **Returns:** Threaded shape, or `nil` on sweep / boolean failure. Use `boundingBoxOptimal()` (not `bounds`) to measure the true crest radius — the BSpline pole hull overshoots by ~13–21%.
 - **OCCT:** Pure-Swift direct path: `Shape.loft`, `Wire.arc`, `Wire.interpolate`, `Wire.join`, `Shape.face(from:)`, `Shape.sew`, `Shape.solidFromShell` — no boolean. Fallback cut path: `OCCTShapeBuildThreadCutter` (bridge: analytic helicoid cutter), `Shape.screwSweptThreadCutter`, `Shape.subtracting`.
 - **Example:**
   ```swift
@@ -588,11 +588,12 @@ public enum ThreadBuild: Sendable, Hashable, Codable {
 
 | Case | Behaviour |
 |---|---|
-| `.auto` | Smooth boolean-free direct build for single-start coaxial cylinders; falls back to boolean cut otherwise. Best surface quality. |
-| `.direct` | Prefer the smooth direct build; fall back to boolean cut when unavailable (multi-start, non-cylinder, construction failure). Same as `.auto` for the common case. |
-| `.boolean` | Always use the boolean cut path. Cutter subtracted from a cylinder of radius exactly `spec.nominalDiameter / 2`, so the crest is clamped to the nominal major radius (in-envelope). Use for lead screws, studs, or worms where the outer diameter must not overshoot nominal. |
+| `.auto` | Smooth boolean-free direct build for single-start coaxial cylinders; falls back to the boolean cut otherwise (multi-start / non-cylinder). The recommended default. |
+| `.direct` | Prefer the smooth direct build; fall back to the boolean cut when unavailable (multi-start, non-cylinder, construction failure). Identical to `.auto` for single-start coaxial cylinders. |
+| `.boolean` | **Deprecated (#254).** Formerly forced the boolean cut path; now treated exactly like `.auto` (single-start coaxial cylinders take the smooth direct build). Its forced cut path produced a *faceted, frequently disconnected* thread and offered no envelope advantage. Use `.auto` or `.direct`. |
 
-- **Note:** The smooth `ruled=false` loft can bow the crest **past** the nominal major radius at coarse pitch / wide crest flats (OCCTSwift #222). Use `.boolean` when an exact outer diameter is required.
+- **Note (#222 / #232 / #254):** the direct build's crest sits **at** the nominal major radius — the earlier "overshoot" report was a `Bnd_Box` control-hull artifact. Measure the true crest with `boundingBoxOptimal()` or mesh vertices (both read nominal); `bounds` over-reads by ~13–21% on the B-spline helicoid. There is no longer a reason to force the cut path for an "exact outer diameter".
+- **Known limitation:** multi-start threads (`starts > 1`) and non-cylinder targets still use the faceted boolean cut, which can come out as disconnected notches rather than a continuous helix — a smooth multi-start/internal direct build is a tracked gap.
 
 ---
 


### PR DESCRIPTION
Closes #254.

## Symptom (confirmed by headless render)
`threadedShaft(build: .boolean)` and all multi-start threads rendered as a **helical scatter of disconnected rectangular notches**, not a continuous thread:

| `.direct` (correct) | `.boolean` (broken) |
|---|---|
| 7-face smooth helix | 893-face notch scatter |

The solid was `isValid` with ~the right volume (the ~220 notches' removed volume happens to sum near the real groove's), so it slipped past validity/volume checks — only rendering exposed it.

## Root cause
`.boolean` forced the screw-loft boolean **cut path**, whose tightly-wound helical cutter is the well-documented OCCT BOP failure (cf. #213/#225) — the subtraction degenerates into isolated pockets.

`.boolean` only ever existed to clamp a supposed crest "overshoot" from #222. But **#232 showed that overshoot is a `Bnd_Box` control-hull artifact** — and this PR verifies it: the direct build's crest measures **exactly nominal** by both `boundingBoxOptimal()` and mesh vertices, while `.bounds` over-reads +14–21%:

```
iso68 coarse — nominal=6.0  bounds=6.845  optimal=6.000  meshVerts=6.000
Tr   coarse  — nominal=6.0  bounds=7.283  optimal=6.000  meshVerts=6.000
```

So the direct build was correct all along and `.boolean` has no remaining purpose.

## Fix
- **Single-start coaxial-cylinder threads now take the smooth, boolean-free direct build (#213) for every build mode** — dropped the `build != .boolean` exclusion in `threadedShaft`.
- **`ThreadBuild.boolean` is deprecated** (`@available(*, deprecated)`), now treated exactly as `.auto`. Use `.auto`/`.direct`.
- `.auto`/`.direct` single-start behaviour unchanged.
- **Swift-only change — no xcframework rebuild** (bridge untouched).

## Tests
- Rewrote `Issue222EnvelopeTests` to the **tight** measure (crest == nominal via optimal box + mesh verts), reflecting the corrected #232/#254 understanding.
- `Issue232BoundsTests`: `.boolean` → `.direct` (boolean is deprecated and now equals direct).
- New `Issue254BuildModesTests`: `.auto`/`.direct`/`.boolean` all yield the same low-face smooth helix; `.boolean` single-start is in-envelope.
- Full thread suite: **49 tests green**.

## Known limitation (documented)
Multi-start (`starts > 1`) and non-cylinder targets still use the faceted cut path, which can come out as disconnected notches — a smooth multi-start/internal **direct** build is a tracked gap (no direct alternative exists yet). Per the issue, documented rather than silently broken.

CHANGELOG **v1.8.1** + ThreadFeatures reference + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)