### PR TITLE
docs: binary-sharing guide + Package.resolved pin-drop footgun (#260)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,12 @@ import Foundation
 // OCCTSwift's in-place (gitignored) `Libraries/OCCT.xcframework` and SHARE the single copy. A URL
 // consumer clones OCCTSwift into .build/checkouts (no `Libraries/`), so this still falls back to the
 // remote zip there.
+//
+// ⚠️ Package.resolved FOOTGUN (#260): a consumer that reaches OCCTSwift via a LOCAL PATH dep (or a
+// local-path SPM mirror) turns it into a *local package*, which SPM does NOT pin — so the occtswift
+// pin (and its transitive OCCT-family pins) is silently dropped from the consumer's Package.resolved
+// on every build. Do NOT commit that churn: the committed Package.resolved must be the URL-pinned one
+// produced with NO local sibling present (i.e. on CI / a fresh clone). See docs/guides/sharing-the-xcframework.md.
 let occtPackageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 let useLocalBinary: Bool = {
     if ProcessInfo.processInfo.environment["OCCTSWIFT_REMOTE"] == "1" { return false }

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ See [docs/guides/building-occt.md](docs/guides/building-occt.md) for details.
 | [Architecture Overview](docs/architecture/overview.md) | Three-layer design, memory management, conventions |
 | [Adding Features](docs/guides/adding-features.md) | How to wrap new OCCT operations |
 | [OCCT Concepts](docs/guides/occt-concepts.md) | B-Rep topology, handles, shapes primer |
+| [Sharing the xcframework](docs/guides/sharing-the-xcframework.md) | Share one local copy across ecosystem repos + the `Package.resolved` pin footgun (#260) |
 | [API Reference (mapping)](docs/API_REFERENCE.md) | Full operation-by-operation mapping to OCCT classes |
 | [API Reference (detailed)](docs/reference/) | Per-type function reference — signatures, OCCT mapping, examples (built progressively) |
 | [Thread Safety](docs/thread-safety.md) | OCCTSerial mutex, parallel execution notes |

--- a/docs/guides/sharing-the-xcframework.md
+++ b/docs/guides/sharing-the-xcframework.md
@@ -1,0 +1,96 @@
+# Sharing the OCCT.xcframework across local repos
+
+`OCCT.xcframework` is ~1.3 GB. On a machine where you develop several ecosystem
+repos at once (OCCTSwiftTools, OCCTSwiftViewport, OCCTReconstruct, OCCTMCP, …),
+the default setup makes **each repo download and extract its own copy** into
+`.build/artifacts/` — easily 25–35 GB of duplicates. This guide explains how the
+ecosystem shares a single copy, and the one **`Package.resolved` footgun** that
+sharing introduces (issue #260).
+
+## How sharing works (#259)
+
+OCCTSwift's `Package.swift` auto-detects its binary target:
+
+- **Local path** — `.binaryTarget(path: "Libraries/OCCT.xcframework")` when the
+  in-place framework is found.
+- **Remote URL** — `.binaryTarget(url:checksum:)` otherwise (CI / SPI / remote SPM).
+
+Detection resolves against the **manifest's own directory** (`#filePath`), not the
+process CWD. That's the key: when OCCTSwift is consumed as a **local path
+dependency**, its manifest finds its in-place (gitignored) `Libraries/OCCT.xcframework`
+and the consumer references that single copy — **no per-repo extraction**.
+
+Consumers opt in with a small helper that prefers a local sibling, else the URL pin:
+
+```swift
+import Foundation
+
+// Prefer ../<name> when present (shared binary), else the published URL (CI / fresh clones).
+func occtDep(_ name: String, from version: String) -> Package.Dependency {
+    let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+        return .package(path: "../\(name)")
+    }
+    return .package(url: "https://github.com/gsdali/\(name).git", from: Version(version)!)
+}
+```
+
+```swift
+dependencies: [ occtDep("OCCTSwift", from: "1.7.1") ]
+```
+
+A local-path **SPM mirror** (`swift package config set-mirror`) achieves the same
+binary sharing without editing `Package.swift`, and has the **same** footgun below.
+
+## ⚠️ The `Package.resolved` footgun (#260)
+
+SPM **never pins local packages**. So the moment a consumer reaches OCCTSwift via a
+path dependency (or a local-path mirror), the `occtswift` pin — **and every
+transitive OCCT-family pin it brought** (occtswifttools, occtswiftio, …) — is
+**silently removed** from that consumer's `Package.resolved`, and rewritten on every
+`swift build` / `swift package resolve`.
+
+```text
+# OCCTMCP, before sharing — pins present:
+"identity": "occtswift",     "version": "1.8.0"
+"identity": "occtswiftais",  "version": "1.0.3"   …
+
+# after one local `swift build` with sharing on:
+Package.resolved: 1 file changed, 1 insertion(+), 64 deletions(-)   ← all OCCT pins gone
+```
+
+If that pin-stripped `Package.resolved` is committed, **CI and other machines get a
+non-reproducible (or broken) resolve** — the one file that exists to guarantee
+reproducibility is the one sharing quietly breaks.
+
+### Why there's no "pinned AND shared" option in stock SPM
+
+Sharing the binary requires the consumer to resolve OCCTSwift **locally** (so its
+in-place `Libraries/` is visible). A URL/git dependency is pinned but is checked out
+to a tag **without** the gitignored `Libraries/` → it falls back to the URL and
+extracts its own 1.3 GB. A mirror pointed at a local *git clone* keeps the pin but,
+again, checks out a tag without `Libraries/` → extracts. **Pinned ⇒ extracts;
+shared ⇒ unpinned.** Pick per consumer.
+
+## Recommended workflow
+
+- **Library packages** (their product is a library others depend on, e.g.
+  OCCTSwiftTools/IO/Mesh/AIS/CADKit): per SPM best practice, **don't commit
+  `Package.resolved`** at all — add it to `.gitignore`. No footgun.
+- **Apps / executables** that commit `Package.resolved` for reproducibility
+  (OCCTReconstruct, OCCTMCP, OCCTStudio, swiftGCS, …): **let CI own
+  `Package.resolved`.** The committed file must be the **URL-pinned** version, which
+  the `occtDep` helper produces automatically when **no local sibling is present**
+  (CI / a fresh clone). Locally, **do not stage the path-dep churn** — `git checkout
+  -- Package.resolved` before committing, or regenerate it in a sibling-free checkout.
+- If you don't need the disk savings in a given repo, just keep the plain URL dep
+  there — it stays pinned (at the cost of its own 1.3 GB extraction).
+
+## Reclaiming duplicate copies
+
+```bash
+# remove extracted per-repo copies (regenerated on next build / shared if path-dep)
+find ~/Projects -type d -path "*/artifacts/occtswift" -exec rm -rf {} +
+# prune old-version download zips from the global cache (keep the current pin)
+ls -d ~/Library/Caches/org.swift.swiftpm/artifacts/*OCCT*xcframework_zip   # review, then rm the old ones
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ figure (interactive 3D where it helps). The **[Cookbook index](guides/cookbook/)
 - [Architecture](architecture/overview.md) — the three-layer design and memory model.
 - [Adding Features](guides/adding-features.md) — bridge header → impl → Swift → test.
 - [Building OCCT](guides/building-occt.md) — rebuild the `OCCT.xcframework` from source.
+- [Sharing the xcframework](guides/sharing-the-xcframework.md) — one shared local copy across repos + the `Package.resolved` pin footgun (#260).
 - [Thread Safety](thread-safety.md) · [Naming Conventions](naming-conventions.md) ·
   [Versioning (SemVer)](SEMVER.md) · [Ecosystem](ecosystem.md)
 


### PR DESCRIPTION
Closes #260.

## The footgun (confirmed)
The #259 local path-dep / mirror sharing makes OCCTSwift a *local package*, which SPM never pins. Reproduced on OCCTMCP — a single `swift build` dropped the `occtswift` pin **and all transitive OCCT-family pins** from `Package.resolved` (64 deletions). Committing that breaks CI/reproducibility.

## Why there's no "pinned AND shared" in stock SPM
Sharing the binary needs OCCTSwift resolved *locally* (so its in-place `Libraries/` is visible). A URL/git dep is pinned but checks out a tag *without* the gitignored `Libraries/` → extracts its own 1.3 GB. A mirror to a local *git clone* keeps the pin but likewise extracts. **Pinned ⇒ extracts; shared ⇒ unpinned.**

## Fix (document + guard, per maintainer choice)
- **`docs/guides/sharing-the-xcframework.md`** — documents the #259 mechanism, the footgun, the tradeoff, and the recommended workflow:
  - **Library** packages: don't commit `Package.resolved` (gitignore) — no footgun.
  - **App/executable** consumers: let **CI own `Package.resolved`** (the `occtDep` helper produces the URL-pinned version with no sibling present); never commit the local path-dep churn (`git checkout -- Package.resolved` before committing).
- Inline ⚠️ warning in the `Package.swift` `#filePath` comment.
- Linked from README + docs index.

Docs-only; no behaviour change, no xcframework rebuild. (Also cleaned up 2 dirty pin-dropped `Package.resolved` files I'd left in OCCTMCP/OCCTSwiftScripts during the trial.)