### PR TITLE
chore: point binaryTarget URL at SecondMouseAU (org rename)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let occtTarget: Target = useLocalBinary
     )
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/gsdali/OCCTSwift/releases/download/v1.7.1/OCCT.xcframework.zip",
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.7.1/OCCT.xcframework.zip",
         checksum: "588aea7eb588063b906878fb66f4a2b91de6b8034be95dcb5212470deff8bccf"
     )
 


### PR DESCRIPTION
OCCTSwift moved to the `SecondMouseAU` org. Flip the remote `binaryTarget` release URL to the canonical owner. Same asset (repo id 1124012575 unchanged) → **checksum unchanged**. Verified by forcing `OCCTSWIFT_REMOTE=1` and resolving: SwiftPM downloads from the new URL and checksum verification passes (exit 0). Old `gsdali` URL still redirects, so existing consumer pins keep resolving.