### PR TITLE
fix(#263): guard prism/heal wrappers against self-intersecting profiles

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge.mm
@@ -401,3 +401,34 @@ struct OCCTSewing {
 // OCCTShape, OCCTWire, OCCTMesh, OCCTFace, OCCTEdge, OCCTDocument, OCCTDrawing
 // are now defined in OCCTBridge_Internal.h (imported above).
 
+// MARK: - #263 self-intersecting-wire guard
+
+#include <BRepCheck_Result.hxx>
+#include <BRepCheck_ListOfStatus.hxx>
+
+// A self-intersecting wire (BRepCheck_SelfIntersectingWire) — typically a mesh-derived
+// outline that crosses itself — extrudes into a prism whose subsequent ShapeFix_Shape
+// heal corrupts the heap and aborts with an uncatchable OS signal (#263; backtrace
+// ShapeFix_Face::FixOrientation → BRep_Tool::Curve → BRep_TEdge::EmptyCopy). The bug is
+// upstream in OCCT, but OCC_CATCH_SIGNALS is inert in this build, so the only safe defence
+// is to PREVENT the crashing prism: detect the bad wire and refuse the op. Such a profile
+// can never form a valid extruded solid, so returning nil loses nothing.
+bool occtHasSelfIntersectingWire(const TopoDS_Shape& s) {
+    if (s.IsNull()) return false;
+    try {
+        BRepCheck_Analyzer analyzer(s);
+        if (analyzer.IsValid()) return false;   // fast path: a valid shape can't carry the flag
+        for (TopExp_Explorer we(s, TopAbs_WIRE); we.More(); we.Next()) {
+            Handle(BRepCheck_Result) res = analyzer.Result(we.Current());
+            if (res.IsNull()) continue;
+            for (BRepCheck_ListIteratorOfListOfStatus it(res->Status()); it.More(); it.Next()) {
+                if (it.Value() == BRepCheck_SelfIntersectingWire) return true;
+            }
+        }
+    } catch (...) {
+        // A BRepCheck that itself throws on the input is a strong "do not proceed" signal.
+        return true;
+    }
+    return false;
+}
+

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -4398,6 +4398,10 @@ bool OCCTShapeIsValid(OCCTShapeRef shape) {
 OCCTShapeRef OCCTShapeHeal(OCCTShapeRef shape) {
     if (!shape) return nullptr;
     try {
+        // #263: ShapeFix_Shape heap-corrupts (uncatchable OS signal) when healing a solid built
+        // from a self-intersecting wire — e.g. a prism extruded from a degenerate mesh-derived
+        // outline. ShapeFix cannot repair a self-intersection anyway, so refuse such input.
+        if (occtHasSelfIntersectingWire(shape->shape)) return nullptr;
         Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
         fixer->Perform();
         return new OCCTShape(fixer->Shape());

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -186,4 +186,15 @@ std::mutex& igesMutex();
 // booleans, sweep, fillet…). Definition lives in OCCTBridge.mm. See issue #175.
 void occtEnsureSignals();
 
+// === #263: self-intersecting-wire guard ===
+//
+// Returns true if `s` contains a wire that BRepCheck flags as SelfIntersectingWire
+// (and/or a face/shape flagged UnorientableShape). Such a profile extrudes into a
+// prism that crashes OCCT's ShapeFix_Shape with uncatchable heap corruption (#263) —
+// and an OS signal raised inside OCCT cannot be caught here (OCC_CATCH_SIGNALS is inert
+// without OCC_CONVERT_SIGNALS in this build). So the prism/heal wrappers must DETECT and
+// refuse the input (return nil) rather than build/heal the crashing solid. Cheap: a pure
+// BRepCheck topology pass, no meshing. Definition lives in OCCTBridge.mm. See issue #263.
+bool occtHasSelfIntersectingWire(const TopoDS_Shape& s);
+
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -9703,6 +9703,10 @@ OCCTShapeRef OCCTShapeCreateExtrusion(OCCTWireRef profile, double dx, double dy,
         BRepBuilderAPI_MakeFace faceMaker(profile->wire);
         if (!faceMaker.IsDone()) return nullptr;
 
+        // #263: a self-intersecting profile extrudes into a prism that heap-corrupts OCCT's
+        // ShapeFix downstream (uncatchable OS signal). Refuse it here so the chain breaks with nil.
+        if (occtHasSelfIntersectingWire(faceMaker.Face())) return nullptr;
+
         BRepPrimAPI_MakePrism maker(faceMaker.Face(), direction);
         maker.Build();
         if (!maker.IsDone()) return nullptr;
@@ -9745,7 +9749,12 @@ OCCTShapeRef OCCTShapeCreateExtrusionInfinite(OCCTShapeRef shape,
 OCCTShapeRef OCCTShapeCreateExtrusionShape(OCCTShapeRef shape,
     double dx, double dy, double dz) {
     if (!shape) return nullptr;
+    occtEnsureSignals();
     try {
+        OCC_CATCH_SIGNALS
+        // #263: a self-intersecting profile (e.g. a face-with-holes whose outline crosses itself)
+        // extrudes into a prism that heap-corrupts OCCT's ShapeFix downstream. Refuse it here.
+        if (occtHasSelfIntersectingWire(shape->shape)) return nullptr;
         gp_Vec vec(dx, dy, dz);
         BRepPrimAPI_MakePrism maker(shape->shape, vec);
         maker.Build();

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -2443,3 +2443,51 @@ struct UnifySameDomainBuilderTests {
         }
     }
 }
+
+// MARK: - #263: self-intersecting-profile crash guard
+
+/// A self-intersecting ("bowtie") outline, extruded into a prism and then healed by OCCT's
+/// `ShapeFix_Shape`, corrupts the heap and aborts the process with an uncatchable OS signal
+/// (#263 — upstream OCCT; backtrace `ShapeFix_Face::FixOrientation` → `BRep_Tool::Curve` →
+/// `BRep_TEdge::EmptyCopy`). Since `OCC_CATCH_SIGNALS` is inert in this build, the bridge cannot
+/// recover from the signal — so the prism/heal wrappers detect the `BRepCheck_SelfIntersectingWire`
+/// status and refuse the input, returning `nil` instead of crashing. A self-intersecting profile can
+/// never form a valid extruded solid, so refusing it loses nothing. These tests would abort the
+/// whole test process (not just fail) prior to the guard.
+@Suite("Self-Intersecting Profile Crash Guard (#263)")
+struct SelfIntersectingProfileGuard263 {
+    /// Bowtie quad: (0,0)→(1,1)→(1,0)→(0,1)→close — the two diagonals cross, so the wire
+    /// self-intersects. `BRepCheck` flags it `SelfIntersectingWire` / `UnorientableShape`.
+    static func bowtieWire() -> Wire? {
+        Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(1, 1, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0),
+        ], closed: true)
+    }
+
+    @Test("extrude refuses a self-intersecting profile (returns nil, never crashes)")
+    func extrudeRefusesSelfIntersecting() {
+        guard let wire = Self.bowtieWire() else { return }
+        let solid = Shape.extrude(profile: wire, direction: SIMD3(0, 0, 1), length: 1)
+        #expect(solid == nil)
+    }
+
+    @Test("heal refuses a self-intersecting shape (returns nil, never crashes)")
+    func healRefusesSelfIntersecting() {
+        guard let wire = Self.bowtieWire(), let face = Shape.face(from: wire, planar: true) else { return }
+        let healed = face.healed()
+        #expect(healed == nil)
+    }
+
+    @Test("a clean convex profile still extrudes and heals")
+    func cleanProfileStillWorks() {
+        guard let wire = Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(1, 1, 0), SIMD3(0, 1, 0),
+        ], closed: true) else { return }
+        let solid = Shape.extrude(profile: wire, direction: SIMD3(0, 0, 1), length: 1)
+        #expect(solid != nil)
+        if let s = solid {
+            #expect(s.isValidSolid)
+            #expect(s.healed() != nil)   // healing a valid solid is unaffected by the guard
+        }
+    }
+}


### PR DESCRIPTION
Closes #263.

## Root cause (determined: **upstream OCCT**, not OCCTSwift)

The four deterministic crashers in #263 all reduce to the same upstream OCCT fault.
Isolated to a **pure-OCCT reproducer** (no OCCTSwift):

| step | result |
|------|--------|
| read the degenerate mesh-derived face (BREP) | ok |
| `BRepPrimAPI_MakePrism` on it | **ok** (builds) |
| `ShapeFix_Shape::Perform()` on the *bare face* | **ok** |
| `ShapeFix_Shape::Perform()` on the *prism* | **CRASH** |

So the trigger is **extrude-then-heal**, and the crash is exactly the #263 backtrace:
`ShapeFix_Shape::Perform` → `ShapeFix_Face::FixOrientation` → `ShapeAnalysis_Edge::Curve3d`
→ `BRep_Tool::Curve` → `BRep_TEdge::EmptyCopy()` writing through a corrupt pointer
(SIGSEGV/SIGBUS at varying addresses — heap-corruption signature).

The defect in every body: `BRepCheck_Analyzer` flags the profile wire as
**`SelfIntersectingWire`** (+ face/shape `UnorientableShape`). A 4-point **bowtie quad**
reproduces it deterministically (3/3 SIGBUS). ASan over reify (OCCTSwift + Swift + swiftGCS
instrumented) found **no** double-free in our code — the bad free is inside OCCT.

This is an upstream OCCT robustness bug (reported separately). But `OCC_CATCH_SIGNALS` is
**inert** in this build (no `OCC_CONVERT_SIGNALS`), so once the OS signal is raised inside
OCCT the bridge `catch(...)` cannot recover — the only safe option is to **prevent** the call.

## Fix

A cheap, no-meshing `BRepCheck_Analyzer` pass (`occtHasSelfIntersectingWire`) that detects the
`SelfIntersectingWire` status; the extrude and heal wrappers refuse such input and return `nil`:

- `OCCTBridge.mm` — `occtHasSelfIntersectingWire` helper
- `OCCTShapeCreateExtrusion`, `OCCTShapeCreateExtrusionShape` — guard the input face
- `OCCTShapeHeal` — guard the input solid

A self-intersecting profile can never form a valid extruded solid, so returning `nil` loses
nothing (matches the existing #234 degenerate-hole-wire guard in `OCCTMakeFaceAddHole`).

## Verification

- New regression suite `SelfIntersectingProfileGuard263` (bowtie extrude/heal → `nil`, no crash;
  clean convex profile still extrudes+heals). 3/3 pass.
- Full **Modeling** (409) + **ShapeHealing** (208) domains pass — no regressions.
- End-to-end: rebuilt `OCCTReconstruct` `reify` against this branch — the four `Fixtures/crash-repro`
  bodies that crashed **8/8** now exit cleanly (b1214 even builds a valid solid; b693/b135/b106
  report "not buildable" gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)