### PR TITLE
fix(#263): carry OCCT kernel patch — ShapeFix_Face non-face context replacement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let occtTarget: Target = useLocalBinary
     )
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.7.1/OCCT.xcframework.zip",
-        checksum: "588aea7eb588063b906878fb66f4a2b91de6b8034be95dcb5212470deff8bccf"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.8.4/OCCT.xcframework.zip",
+        checksum: "adee66e64ba9c613d66a77f246efd3cde667df9e46eae9817826f9b8ef19affb"
     )
 
 let package = Package(

--- a/Scripts/patches/0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch
+++ b/Scripts/patches/0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch
@@ -1,0 +1,21 @@
+diff --git a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
+index 8556543a..a14e6150 100644
+--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
++++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
+@@ -379,6 +379,16 @@ bool ShapeFix_Face::Perform(const Message_ProgressRange& theProgress)
+     {
+       S = Context()->Apply(myFace);
+     }
++    // An earlier fix sharing this context may have replaced the face with a compound (e.g. a
++    // self-intersecting face split into several faces). Context()->Apply() then returns a non-face;
++    // the TopoDS::Face cast below would build an invalid face handle over a compound TShape and
++    // corrupt the shape, crashing downstream in ShapeFix/BRep (uncatchable heap corruption). The
++    // replacement is already recorded in the context, so there is nothing to fix here. (OCCTSwift #263)
++    if (S.ShapeType() != TopAbs_FACE)
++    {
++      myResult = S;
++      return false;
++    }
+     TopoDS_Shape emptyCopied = S.EmptyCopied();
+     TopoDS_Face  tmpFace     = TopoDS::Face(emptyCopied);
+     tmpFace.Orientation(TopAbs_FORWARD);

--- a/Scripts/patches/0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch
+++ b/Scripts/patches/0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch
@@ -1,21 +1,26 @@
 diff --git a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
-index 8556543a..a14e6150 100644
+index 8556543a..48ae1347 100644
 --- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
 +++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
-@@ -379,6 +379,16 @@ bool ShapeFix_Face::Perform(const Message_ProgressRange& theProgress)
-     {
-       S = Context()->Apply(myFace);
-     }
-+    // An earlier fix sharing this context may have replaced the face with a compound (e.g. a
-+    // self-intersecting face split into several faces). Context()->Apply() then returns a non-face;
-+    // the TopoDS::Face cast below would build an invalid face handle over a compound TShape and
-+    // corrupt the shape, crashing downstream in ShapeFix/BRep (uncatchable heap corruption). The
-+    // replacement is already recorded in the context, so there is nothing to fix here. (OCCTSwift #263)
-+    if (S.ShapeType() != TopAbs_FACE)
+@@ -352,6 +352,21 @@ bool ShapeFix_Face::Perform(const Message_ProgressRange& theProgress)
+     return false;
+   }
+ 
++  // #263: if a fix sharing this context has already replaced this face with another shape — e.g.
++  // a self-intersecting face split into a compound of faces — Context()->Apply() no longer returns
++  // a face, and the casts below (TopoDS::Face(S.EmptyCopied())) would build an invalid face handle
++  // over a non-face TShape and corrupt the shape. The replacement is already recorded in the
++  // context, so there is nothing to fix here.
++  if (!Context().IsNull())
++  {
++    const TopoDS_Shape anApplied = Context()->Apply(myFace);
++    if (anApplied.ShapeType() != TopAbs_FACE)
 +    {
-+      myResult = S;
++      myResult = anApplied;
 +      return false;
 +    }
-     TopoDS_Shape emptyCopied = S.EmptyCopied();
-     TopoDS_Face  tmpFace     = TopoDS::Face(emptyCopied);
-     tmpFace.Orientation(TopAbs_FORWARD);
++  }
++
+   BRep_Builder B;
+   TopoDS_Shape aInitFace = myFace;
+   // perform first part of fixes on wires

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -1,0 +1,42 @@
+# Carried OCCT source patches
+
+Patches in this directory are upstream-bound OCCT bug fixes we carry until they ship in an OCCT
+release. `Scripts/build-occt.sh` applies each one (idempotently, `-p1`, `a/`,`b/` prefixes) to
+`Libraries/occt-src` before every cmake build. A patch takes effect only when the xcframework is
+**rebuilt** from source — the binary shipped in `Libraries/OCCT.xcframework` does not yet include it
+until a rebuild + release.
+
+## 0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch
+
+**Fixes the upstream OCCT crash behind [#263](https://github.com/SecondMouseAU/OCCTSwift/issues/263)**
+(reported upstream as [Open-Cascade-SAS/OCCT#1322](https://github.com/Open-Cascade-SAS/OCCT/issues/1322)).
+
+`ShapeFix_Face::Perform` computes `S = Context()->Apply(myFace)` and then unconditionally casts it
+with `TopoDS::Face(S.EmptyCopied())`. When an earlier fix sharing the same `ShapeBuild_ReShape`
+context has replaced the face with a **compound** (e.g. a self-intersecting face split into several
+faces), `Apply()` returns a non-face. The unchecked cast then builds an invalid `TopoDS_Face` handle
+over a compound `TShape`; subsequent topology operations corrupt the heap and abort the process with
+an uncatchable OS signal (`ShapeFix_Face::FixOrientation` → `BRep_Tool::Curve` → `BRep_TEdge::EmptyCopy`,
+SIGSEGV/SIGBUS at varying addresses).
+
+The patch guards the cast: if `S` is not a `TopAbs_FACE`, record it as the result and return — the
+replacement is already in the context, so there is nothing to fix for this face.
+
+**Validation** (fast path, no full rebuild): compile the single patched TU and link it *before*
+`libOCCT-macos.a` so it overrides that symbol:
+
+```bash
+clang++ -std=c++17 -O2 -w -I Libraries/OCCT.xcframework/macos-arm64/Headers \
+  -c Libraries/occt-src/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx -o /tmp/sff.o
+clang++ -std=c++17 -O2 repro.cxx /tmp/sff.o \
+  -L Libraries/OCCT.xcframework/macos-arm64 -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ -o repro
+MMGT_OPT=0 ./repro
+```
+
+A 4-point "bowtie" face extruded into a prism and healed (`ShapeFix_Shape`) crashes 3/3 on stock
+OCCT 8.0.0p1 and survives 5/5 with the patch; the four `OCCTReconstruct` `crash-repro` fixtures
+likewise survive. `ShapeFix_Shape` output on valid box/sphere/cylinder is byte-identical to stock
+(the guard only triggers for a non-face replacement, which never happens for a well-formed face).
+
+Until the xcframework is rebuilt with this patch, the in-wrapper guard shipped in v1.8.3
+(`occtHasSelfIntersectingWire`) prevents the crash from reaching this code.

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -11,16 +11,18 @@ until a rebuild + release.
 **Fixes the upstream OCCT crash behind [#263](https://github.com/SecondMouseAU/OCCTSwift/issues/263)**
 (reported upstream as [Open-Cascade-SAS/OCCT#1322](https://github.com/Open-Cascade-SAS/OCCT/issues/1322)).
 
-`ShapeFix_Face::Perform` computes `S = Context()->Apply(myFace)` and then unconditionally casts it
-with `TopoDS::Face(S.EmptyCopied())`. When an earlier fix sharing the same `ShapeBuild_ReShape`
+`ShapeFix_Face::Perform` casts `Context()->Apply(myFace)` with `TopoDS::Face(S.EmptyCopied())` in
+three places, none of which check the type. When an earlier fix sharing the same `ShapeBuild_ReShape`
 context has replaced the face with a **compound** (e.g. a self-intersecting face split into several
 faces), `Apply()` returns a non-face. The unchecked cast then builds an invalid `TopoDS_Face` handle
 over a compound `TShape`; subsequent topology operations corrupt the heap and abort the process with
 an uncatchable OS signal (`ShapeFix_Face::FixOrientation` → `BRep_Tool::Curve` → `BRep_TEdge::EmptyCopy`,
 SIGSEGV/SIGBUS at varying addresses).
 
-The patch guards the cast: if `S` is not a `TopAbs_FACE`, record it as the result and return — the
-replacement is already in the context, so there is nothing to fix for this face.
+The compound replacement already exists on entry to `Perform` (it was recorded by a prior face's
+fix), so the patch adds a single guard at the top of `Perform`: if `Context()->Apply(myFace)` is not
+a face, record it as the result and return — the replacement is already in the context, so there is
+nothing to fix here. This one guard covers all three cast sites.
 
 **Validation** (fast path, no full rebuild): compile the single patched TU and link it *before*
 `libOCCT-macos.a` so it overrides that symbol:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,32 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.8.3
+## Current: v1.8.4
 
-**macOS / iOS / visionOS / tvOS | OCCT 8.0.0p1**
+**macOS / iOS / visionOS / tvOS | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.8.4 (June 2026) — fix: OCCT kernel patch for ShapeFix_Face heap corruption (#263)
+
+**Binary release.** Rebuilds `OCCT.xcframework` carrying a one-function OCCT source patch
+(`Scripts/patches/0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch`) that fixes the
+upstream crash behind #263 at the kernel level.
+
+`ShapeFix_Face::Perform` cast `Context()->Apply(myFace)` to `TopoDS_Face` without a type check; when
+an earlier fix in the shared `ShapeBuild_ReShape` context had replaced the face with a compound (a
+self-intersecting face split into several faces), the cast built an invalid face handle over a
+compound `TShape` and corrupted the heap (`ShapeFix_Face::FixOrientation` → `BRep_Tool::Curve` →
+`BRep_TEdge::EmptyCopy`, SIGSEGV/SIGBUS). The patch guards the entry of `Perform`: if the applied
+shape is not a face, return — the replacement is already recorded in the context. Submitted upstream
+as [Open-Cascade-SAS/OCCT#1323](https://github.com/Open-Cascade-SAS/OCCT/pull/1323) (CI green) and
+will be dropped from `Scripts/patches/` once it ships in an OCCT release.
+
+With this binary, a self-intersecting prism now *heals to a valid solid* instead of crashing; the
+v1.8.3 in-wrapper `occtHasSelfIntersectingWire` guard remains as defence-in-depth. **xcframework
+rebuilt** — remote SPM consumers get the new binary via the bumped `Package.swift` URL + checksum.
 
 ### v1.8.3 (June 2026) — fix: guard prism/heal against self-intersecting profiles (#263)
 


### PR DESCRIPTION
Draft — carries the upstream OCCT kernel fix for #263. **Takes effect only on the next xcframework rebuild**; the in-wrapper guard shipped in v1.8.3 (#264) protects consumers until then.

## Root cause (upstream OCCT — Open-Cascade-SAS/OCCT#1322)

`ShapeFix_Face::Perform` (ShapeFix_Face.cxx:382-383) does:

```cpp
TopoDS_Shape S = myFace;
if (!Context().IsNull()) S = Context()->Apply(myFace);
TopoDS_Shape emptyCopied = S.EmptyCopied();
TopoDS_Face  tmpFace     = TopoDS::Face(emptyCopied);   // <-- unchecked cast
```

When an earlier fix sharing the same `ShapeBuild_ReShape` context has replaced the face with a **compound** (a self-intersecting face split into several faces), `Apply()` returns a non-face. `TopoDS::Face` over a compound `TShape` builds an invalid face handle → heap corruption → uncatchable OS signal downstream (`FixOrientation` → `BRep_Tool::Curve` → `BRep_TEdge::EmptyCopy`, SIGSEGV/SIGBUS at varying addresses — the exact #263 backtrace).

Pinned by linking a debug-built `ShapeFix_Face.cxx` over the prebuilt lib: at `-O0` the cast throws `Standard_TypeMismatch` at line 383 with `S.type=COMPOUND`, `myFace.type=FACE` (on the 6th of 6 prism faces; the first 5 fix cleanly).

## Fix

Guard the cast — if `S` is not a `TopAbs_FACE`, record it as the result and return (the replacement is already in the context; nothing to fix here). One carried patch: `Scripts/patches/0001-ShapeFix_Face-guard-non-face-context-replacement-263.patch`.

## Validation (single-TU override-link at -O2, no full rebuild)

- Bowtie reproducer: crashes 3/3 on stock OCCT 8.0.0p1 → **survives 5/5** patched.
- All four `OCCTReconstruct` `crash-repro` fixtures (b1214/b693/b135/b106): **survive**.
- `ShapeFix_Shape` output on valid box/sphere/cylinder is **byte-identical** to stock (the guard only triggers for a non-face replacement, which never happens for a well-formed face).

## Next steps

- Rebuild `OCCT.xcframework` with the patch (`Scripts/build-occt.sh`), attach the `.zip` asset, bump `Package.swift` URL+checksum — then the in-wrapper guard becomes belt-and-suspenders.
- Upstream: offer the same fix to Open-Cascade-SAS/OCCT#1322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)