### PR TITLE
feat(#266 follow-up): face healing & validation surface (~16 ops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,291 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,307 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -5766,6 +5766,13 @@ typedef struct {
 /// @return Check result
 OCCTShapeCheckResult OCCTCheckFace(OCCTFaceRef face);
 
+/// BRepCheck_Face per-check diagnostics — the specific BRepCheck_Status for one wire-topology check
+/// of a face. `geometricControls` toggles the (more expensive) geometric intersection checks.
+/// Returns OCCTCheckCheckFail if `face` is not a face. #266 follow-up.
+OCCTCheckStatus OCCTBRepCheckFaceIntersectWires(OCCTShapeRef face, bool geometricControls);
+OCCTCheckStatus OCCTBRepCheckFaceClassifyWires(OCCTShapeRef face, bool geometricControls);
+OCCTCheckStatus OCCTBRepCheckFaceOrientationOfWires(OCCTShapeRef face, bool geometricControls);
+
 /// Check validity of a solid.
 /// @param shape Solid shape to check
 /// @return Check result
@@ -13648,6 +13655,40 @@ bool OCCTSurfaceIsUClosedSA(OCCTSurfaceRef _Nonnull surface, double preci);
 /// Check if surface is spatially V-closed at given precision.
 bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef _Nonnull surface, double preci);
 
+// --- ShapeAnalysis_Surface extras + BRepGProp_Face (#266 follow-up) ---
+
+/// Refine a (U,V) for a 3D point by projecting onto the surface's iso-lines; returns the 3D gap.
+double OCCTSurfaceUVFromIso(OCCTSurfaceRef _Nonnull surface, double px, double py, double pz,
+                            double preci, double* _Nonnull u, double* _Nonnull v);
+
+/// Detail of singularity #num (1-based): pole 3D point, first/last 2D points + params of the
+/// degenerate iso-line, and whether it is U-iso. `preci` is in/out. Returns false if num out of range.
+bool OCCTSurfaceSingularityDetail(OCCTSurfaceRef _Nonnull surface, int32_t num, double* _Nonnull preci,
+                                  double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
+                                  double* _Nonnull firstU, double* _Nonnull firstV,
+                                  double* _Nonnull lastU, double* _Nonnull lastV,
+                                  double* _Nonnull firstPar, double* _Nonnull lastPar,
+                                  bool* _Nonnull uIsoDegenerate);
+
+/// Adjust the indeterminate 2D coordinate of a point in a surface singularity, taking the fixed
+/// coordinate from a neighbour 2D point. Returns the resolved (ru, rv).
+bool OCCTSurfaceProjectDegenerated(OCCTSurfaceRef _Nonnull surface, double px, double py, double pz,
+                                   double preci, double neighbourU, double neighbourV,
+                                   double* _Nonnull ru, double* _Nonnull rv);
+
+/// Project a 3D point onto a surface restricted to the [u1,u2]×[v1,v2] domain (SetDomain) — for
+/// periodic / self-overlapping surfaces. Returns the 3D gap, or -1 on failure.
+double OCCTSurfaceProjectPointUVInDomain(OCCTSurfaceRef _Nonnull surface, double px, double py, double pz,
+                                         double preci, double u1, double u2, double v1, double v2,
+                                         double* _Nonnull u, double* _Nonnull v);
+
+/// BRepGProp_Face Gauss-integration orders in U and V (non-zero only for BSpline faces).
+bool OCCTBRepGPropFaceIntegrationOrders(OCCTShapeRef _Nonnull face, int32_t* _Nonnull uOrder,
+                                        int32_t* _Nonnull vOrder);
+
+/// BRepGProp_Face U-direction integration knots; fills up to maxCount, returns the count.
+int32_t OCCTBRepGPropFaceUKnots(OCCTShapeRef _Nonnull face, double* _Nullable buffer, int32_t maxCount);
+
 // --- Resource_Manager ---
 
 typedef struct OCCTResourceManager* OCCTResourceManagerRef;
@@ -16483,6 +16524,34 @@ bool OCCTFaceFixerFixSmallAreaWire(OCCTFaceFixerRef _Nonnull fixer);
 
 /// Get the resulting fixed face.
 OCCTShapeRef _Nullable OCCTFaceFixerFace(OCCTFaceFixerRef _Nonnull fixer);
+
+// --- ShapeFix_Face control surface (#266 follow-up) ---
+
+/// Toggle an individual ShapeFix_Face healing pass before Perform(). `modeId` selects the pass
+/// (0 FixWire, 1 FixOrientation, 2 FixAddNaturalBound, 3 FixMissingSeam, 4 FixSmallAreaWire,
+/// 5 RemoveSmallAreaFace, 6 FixIntersectingWires, 7 FixLoopWires, 8 FixSplitFace,
+/// 9 AutoCorrectPrecision, 10 FixPeriodicDegenerated). `value`: -1 = default/auto, 0 = off, 1 = on.
+void OCCTFaceFixerSetMode(OCCTFaceFixerRef _Nonnull fixer, int32_t modeId, int32_t value);
+
+/// Fix self-intersecting wires on the face.
+bool OCCTFaceFixerFixIntersectingWires(OCCTFaceFixerRef _Nonnull fixer);
+
+/// Reconstruct a degenerate edge at a pole on a periodic surface.
+bool OCCTFaceFixerFixPeriodicDegenerated(OCCTFaceFixerRef _Nonnull fixer);
+
+/// Remove coincident-edge pairs from the face's wires.
+bool OCCTFaceFixerFixWiresTwoCoincEdges(OCCTFaceFixerRef _Nonnull fixer);
+
+/// Split a wire that loops back on itself (result wires are discarded; returns whether it fixed).
+bool OCCTFaceFixerFixLoopWire(OCCTFaceFixerRef _Nonnull fixer);
+
+/// The result of the fix — a Face, or a Shell when FixMissingSeam split the face. May differ from
+/// OCCTFaceFixerFace (which always returns a Face).
+OCCTShapeRef _Nullable OCCTFaceFixerResult(OCCTFaceFixerRef _Nonnull fixer);
+
+/// Query which fixes fired after Perform(). `status`: 0 = OK (no flags), 1..8 = DONE1..DONE8,
+/// 9..16 = FAIL1..FAIL8, 17 = DONE (any), 18 = FAIL (any).
+bool OCCTFaceFixerStatus(OCCTFaceFixerRef _Nonnull fixer, int32_t status);
 
 // --- BRepBuilderAPI_MakeFace completions ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -63,6 +63,8 @@
 #include <ShapeAnalysis_Shell.hxx>
 #include <ShapeAnalysis_Wire.hxx>
 #include <ShapeFix_Face.hxx>
+#include <ShapeExtend_Status.hxx>
+#include <NCollection_Sequence.hxx>
 #include <ShapeFix_Shape.hxx>
 #include <ShapeFix_Wire.hxx>
 #include <ShapeUpgrade_UnifySameDomain.hxx>
@@ -1629,6 +1631,42 @@ OCCTShapeCheckResult OCCTCheckFace(OCCTFaceRef face) {
         result.firstError = OCCTCheckCheckFail;
         return result;
     }
+}
+
+// --- BRepCheck_Face per-check diagnostics (#266 follow-up) ---
+// Each returns the specific BRepCheck_Status for one wire-topology check. The checks build on each
+// other (intersection → imbrication/classification → orientation), so the later ones run the
+// prerequisite passes first to be robust when called standalone.
+
+OCCTCheckStatus OCCTBRepCheckFaceIntersectWires(OCCTShapeRef face, bool geometricControls) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return OCCTCheckCheckFail;
+    try {
+        Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
+        checker->GeometricControls(geometricControls);
+        return mapBRepCheckStatus(checker->IntersectWires());
+    } catch (...) { return OCCTCheckCheckFail; }
+}
+
+OCCTCheckStatus OCCTBRepCheckFaceClassifyWires(OCCTShapeRef face, bool geometricControls) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return OCCTCheckCheckFail;
+    try {
+        Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
+        checker->GeometricControls(geometricControls);
+        checker->IntersectWires();
+        return mapBRepCheckStatus(checker->ClassifyWires());
+    } catch (...) { return OCCTCheckCheckFail; }
+}
+
+OCCTCheckStatus OCCTBRepCheckFaceOrientationOfWires(OCCTShapeRef face, bool geometricControls) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return OCCTCheckCheckFail;
+    try {
+        Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
+        checker->GeometricControls(geometricControls);
+        checker->IntersectWires();
+        checker->ClassifyWires();
+        BRepCheck_Status st = checker->OrientationOfWires();
+        return mapBRepCheckStatus(st);
+    } catch (...) { return OCCTCheckCheckFail; }
 }
 
 OCCTShapeCheckResult OCCTCheckSolid(OCCTShapeRef shape) {
@@ -3917,6 +3955,72 @@ OCCTShapeRef OCCTFaceFixerFace(OCCTFaceFixerRef fixer) {
         ref->shape = f;
         return ref;
     } catch (...) { return nullptr; }
+}
+
+// --- ShapeFix_Face control surface (#266 follow-up) ---
+
+void OCCTFaceFixerSetMode(OCCTFaceFixerRef fixer, int32_t modeId, int32_t value) {
+    if (!fixer || fixer->fixer.IsNull()) return;
+    try {
+        ShapeFix_Face& f = *fixer->fixer;
+        switch (modeId) {
+            case 0:  f.FixWireMode() = value; break;
+            case 1:  f.FixOrientationMode() = value; break;
+            case 2:  f.FixAddNaturalBoundMode() = value; break;
+            case 3:  f.FixMissingSeamMode() = value; break;
+            case 4:  f.FixSmallAreaWireMode() = value; break;
+            case 5:  f.RemoveSmallAreaFaceMode() = value; break;
+            case 6:  f.FixIntersectingWiresMode() = value; break;
+            case 7:  f.FixLoopWiresMode() = value; break;
+            case 8:  f.FixSplitFaceMode() = value; break;
+            case 9:  f.AutoCorrectPrecisionMode() = value; break;
+            case 10: f.FixPeriodicDegeneratedMode() = value; break;
+            default: break;
+        }
+    } catch (...) {}
+}
+
+bool OCCTFaceFixerFixIntersectingWires(OCCTFaceFixerRef fixer) {
+    if (!fixer || fixer->fixer.IsNull()) return false;
+    try { return fixer->fixer->FixIntersectingWires(); }
+    catch (...) { return false; }
+}
+
+bool OCCTFaceFixerFixPeriodicDegenerated(OCCTFaceFixerRef fixer) {
+    if (!fixer || fixer->fixer.IsNull()) return false;
+    try { return fixer->fixer->FixPeriodicDegenerated(); }
+    catch (...) { return false; }
+}
+
+bool OCCTFaceFixerFixWiresTwoCoincEdges(OCCTFaceFixerRef fixer) {
+    if (!fixer || fixer->fixer.IsNull()) return false;
+    try { return fixer->fixer->FixWiresTwoCoincEdges(); }
+    catch (...) { return false; }
+}
+
+bool OCCTFaceFixerFixLoopWire(OCCTFaceFixerRef fixer) {
+    if (!fixer || fixer->fixer.IsNull()) return false;
+    try {
+        NCollection_Sequence<TopoDS_Shape> resWires;
+        return fixer->fixer->FixLoopWire(resWires);
+    } catch (...) { return false; }
+}
+
+OCCTShapeRef OCCTFaceFixerResult(OCCTFaceFixerRef fixer) {
+    if (!fixer || fixer->fixer.IsNull()) return nullptr;
+    try {
+        TopoDS_Shape s = fixer->fixer->Result();
+        if (s.IsNull()) return nullptr;
+        auto ref = new OCCTShape();
+        ref->shape = s;
+        return ref;
+    } catch (...) { return nullptr; }
+}
+
+bool OCCTFaceFixerStatus(OCCTFaceFixerRef fixer, int32_t status) {
+    if (!fixer || fixer->fixer.IsNull()) return false;
+    try { return fixer->fixer->Status(static_cast<ShapeExtend_Status>(status)); }
+    catch (...) { return false; }
 }
 
 // MARK: - WireFixer extended (hoisted with struct)

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -3539,6 +3539,107 @@ bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci) {
     } catch (...) { return false; }
 }
 
+// --- ShapeAnalysis_Surface extras + BRepGProp_Face (#266 follow-up) ---
+#include <gp_Pnt2d.hxx>
+#include <BRepGProp_Face.hxx>
+#include <NCollection_HArray1.hxx>
+
+/// UVFromIso: refine a (U,V) for P3D by projecting onto the surface's iso-lines; returns the best
+/// 3D gap (very large on failure).
+double OCCTSurfaceUVFromIso(OCCTSurfaceRef surface, double px, double py, double pz,
+                            double preci, double* u, double* v) {
+    try {
+        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+        double U = 0, V = 0;
+        double d = sas->UVFromIso(gp_Pnt(px, py, pz), preci, U, V);
+        if (u) *u = U;
+        if (v) *v = V;
+        return d;
+    } catch (...) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
+}
+
+/// Detail of singularity #num (1-based): 3D pole point, first/last 2D points of the degenerate
+/// iso-line, its first/last parameters, and whether it is a U-iso (else V-iso). `preci` is in/out.
+bool OCCTSurfaceSingularityDetail(OCCTSurfaceRef surface, int32_t num, double* preci,
+                                  double* px, double* py, double* pz,
+                                  double* firstU, double* firstV, double* lastU, double* lastV,
+                                  double* firstPar, double* lastPar, bool* uIsoDegenerate) {
+    try {
+        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+        gp_Pnt P3d; gp_Pnt2d f2, l2; double fp = 0, lp = 0; Standard_Boolean uiso = Standard_False;
+        double pr = preci ? *preci : 0.0;
+        if (!sas->Singularity(num, pr, P3d, f2, l2, fp, lp, uiso)) return false;
+        if (preci) *preci = pr;
+        if (px) *px = P3d.X(); if (py) *py = P3d.Y(); if (pz) *pz = P3d.Z();
+        if (firstU) *firstU = f2.X(); if (firstV) *firstV = f2.Y();
+        if (lastU) *lastU = l2.X(); if (lastV) *lastV = l2.Y();
+        if (firstPar) *firstPar = fp; if (lastPar) *lastPar = lp;
+        if (uIsoDegenerate) *uIsoDegenerate = uiso;
+        return true;
+    } catch (...) { return false; }
+}
+
+/// ProjectDegenerated: adjust the indeterminate 2D coordinate of a point lying in a surface
+/// singularity, taking the fixed coordinate from a `neighbour` 2D point. Returns the resolved (ru,rv).
+bool OCCTSurfaceProjectDegenerated(OCCTSurfaceRef surface, double px, double py, double pz,
+                                   double preci, double neighbourU, double neighbourV,
+                                   double* ru, double* rv) {
+    try {
+        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+        gp_Pnt2d result;
+        if (!sas->ProjectDegenerated(gp_Pnt(px, py, pz), preci, gp_Pnt2d(neighbourU, neighbourV), result))
+            return false;
+        if (ru) *ru = result.X();
+        if (rv) *rv = result.Y();
+        return true;
+    } catch (...) { return false; }
+}
+
+/// Like OCCTSurfaceProjectPointUV but restricts the search to the [u1,u2]×[v1,v2] domain
+/// (ShapeAnalysis_Surface::SetDomain) — disambiguates projection on periodic / self-overlapping
+/// surfaces. Returns the 3D gap (Gap()), or -1 on failure.
+double OCCTSurfaceProjectPointUVInDomain(OCCTSurfaceRef surface, double px, double py, double pz,
+                                         double preci, double u1, double u2, double v1, double v2,
+                                         double* u, double* v) {
+    try {
+        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+        sas->SetDomain(u1, u2, v1, v2);
+        gp_Pnt2d uv = sas->ValueOfUV(gp_Pnt(px, py, pz), preci);
+        if (u) *u = uv.X();
+        if (v) *v = uv.Y();
+        return sas->Gap();
+    } catch (...) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
+}
+
+/// BRepGProp_Face Gauss-integration orders (number of integration points) in U and V — non-zero
+/// only for BSpline faces. Returns false if `face` is not a face.
+bool OCCTBRepGPropFaceIntegrationOrders(OCCTShapeRef face, int32_t* uOrder, int32_t* vOrder) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return false;
+    try {
+        BRepGProp_Face gf(TopoDS::Face(face->shape));
+        if (uOrder) *uOrder = gf.UIntegrationOrder();
+        if (vOrder) *vOrder = gf.VIntegrationOrder();
+        return true;
+    } catch (...) { return false; }
+}
+
+/// BRepGProp_Face U-direction integration knots (BSpline spans over the face's U range). Fills up to
+/// `maxCount` into `buffer` and returns the count, or 0 on failure.
+int32_t OCCTBRepGPropFaceUKnots(OCCTShapeRef face, double* buffer, int32_t maxCount) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return 0;
+    try {
+        BRepGProp_Face gf(TopoDS::Face(face->shape));
+        double u1, u2, v1, v2; gf.Bounds(u1, u2, v1, v2);
+        Handle(NCollection_HArray1<double>) knots = gf.GetUKnots(u1, u2);
+        if (knots.IsNull()) return 0;
+        int32_t n = 0;
+        for (int i = knots->Lower(); i <= knots->Upper() && n < maxCount; i++, n++) {
+            if (buffer) buffer[n] = knots->Value(i);
+        }
+        return n;
+    } catch (...) { return 0; }
+}
+
 // MARK: - v0.105: GeomConvert_BSplineSurfaceKnotSplitting
 // MARK: - GeomConvert_BSplineSurfaceKnotSplitting (v0.105.0)
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -11870,6 +11870,64 @@ public final class FaceFixer: @unchecked Sendable {
         guard let r = OCCTFaceFixerFace(ref) else { return nil }
         return Shape(handle: r)
     }
+
+    // MARK: - Per-pass control (#266 follow-up)
+
+    /// An individual `ShapeFix_Face` healing pass that can be toggled before ``perform()``.
+    public enum Pass: Int32, Sendable {
+        case wire = 0, orientation, addNaturalBound, missingSeam, smallAreaWire,
+             removeSmallAreaFace, intersectingWires, loopWires, splitFace,
+             autoCorrectPrecision, periodicDegenerated
+    }
+
+    /// Whether a pass runs: `.auto` (the default heuristic), `.off`, or `.on` (force).
+    public enum Toggle: Int32, Sendable { case auto = -1, off = 0, on = 1 }
+
+    /// Enable / disable an individual healing pass before calling ``perform()``.
+    ///
+    /// ```swift
+    /// // Heal a face but DON'T add the surface's natural bound (which can balloon a trimmed face):
+    /// let fixer = FaceFixer(face: f)
+    /// fixer?.setMode(.addNaturalBound, .off)
+    /// fixer?.perform()
+    /// ```
+    public func setMode(_ pass: Pass, _ toggle: Toggle) {
+        OCCTFaceFixerSetMode(ref, pass.rawValue, toggle.rawValue)
+    }
+
+    /// Fix self-intersecting wires on the face.
+    @discardableResult public func fixIntersectingWires() -> Bool { OCCTFaceFixerFixIntersectingWires(ref) }
+
+    /// Reconstruct a degenerate edge at a pole on a periodic surface.
+    @discardableResult public func fixPeriodicDegenerated() -> Bool { OCCTFaceFixerFixPeriodicDegenerated(ref) }
+
+    /// Remove coincident-edge pairs from the face's wires.
+    @discardableResult public func fixWiresTwoCoincEdges() -> Bool { OCCTFaceFixerFixWiresTwoCoincEdges(ref) }
+
+    /// Split a wire that loops back on itself.
+    @discardableResult public func fixLoopWire() -> Bool { OCCTFaceFixerFixLoopWire(ref) }
+
+    /// The result of the fix — usually a face, but a **shell** when ``fixMissingSeam()`` split the
+    /// face into several. Unlike ``face`` (always a face), this returns the true multi-face result.
+    public var result: Shape? {
+        guard let r = OCCTFaceFixerResult(ref) else { return nil }
+        return Shape(handle: r)
+    }
+
+    /// A status flag recorded by the fixer (which passes fired / failed) — query after ``perform()``.
+    public enum Status: Int32, Sendable {
+        case ok = 0
+        case done1 = 1, done2, done3, done4, done5, done6, done7, done8
+        case fail1 = 9, fail2, fail3, fail4, fail5, fail6, fail7, fail8
+        /// Any DONEi flag set (a fix fired).
+        case done = 17
+        /// Any FAILi flag set (a fix failed).
+        case fail = 18
+    }
+
+    /// Whether the given status flag is set after ``perform()`` (e.g. `.done` = something was fixed,
+    /// `.fail` = a pass failed).
+    public func status(_ status: Status) -> Bool { OCCTFaceFixerStatus(ref, status.rawValue) }
 }
 
 // --- IntCSResult class ---

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6297,6 +6297,47 @@ extension Shape {
             CheckStatus(rawValue: Int32(buffer[i].rawValue))
         }
     }
+
+    // MARK: - BRepCheck_Face per-wire diagnostics (#266 follow-up)
+
+    /// `BRepCheck_Face` — do this face's boundary wires intersect one another? Returns
+    /// `.intersectingWires` / `.selfIntersectingWire` on a hit, `.noError` if clean, `.checkFail`
+    /// if the shape isn't a single face. `geometricControls` enables the (costlier) geometric checks.
+    public func checkFaceIntersectingWires(geometricControls: Bool = true) -> CheckStatus {
+        CheckStatus(rawValue: Int32(OCCTBRepCheckFaceIntersectWires(handle, geometricControls).rawValue)) ?? .checkFail
+    }
+
+    /// `BRepCheck_Face` — are the face's wires correctly nested (one outer, the rest enclosed as
+    /// holes)? Returns `.invalidImbricationOfWires` when nesting is wrong.
+    public func checkFaceWireImbrication(geometricControls: Bool = true) -> CheckStatus {
+        CheckStatus(rawValue: Int32(OCCTBRepCheckFaceClassifyWires(handle, geometricControls).rawValue)) ?? .checkFail
+    }
+
+    /// `BRepCheck_Face` — are the face's wires correctly oriented (outer CCW, holes CW)? Returns
+    /// `.badOrientationOfSubshape` / `.unorientableShape` on a problem.
+    public func checkFaceWireOrientation(geometricControls: Bool = true) -> CheckStatus {
+        CheckStatus(rawValue: Int32(OCCTBRepCheckFaceOrientationOfWires(handle, geometricControls).rawValue)) ?? .checkFail
+    }
+
+    // MARK: - BRepGProp_Face integration (#266 follow-up)
+
+    /// `BRepGProp_Face` Gauss-integration orders (number of integration points) in U and V — the
+    /// quadrature this face needs for exact surface integrals. Non-trivial only for BSpline faces;
+    /// nil if the shape isn't a single face.
+    public var faceIntegrationOrders: (u: Int, v: Int)? {
+        var u: Int32 = 0, v: Int32 = 0
+        guard OCCTBRepGPropFaceIntegrationOrders(handle, &u, &v) else { return nil }
+        return (Int(u), Int(v))
+    }
+
+    /// `BRepGProp_Face` U-direction integration knots — the BSpline span boundaries used when
+    /// integrating over the face's U range (just `[uMin, uMax]` for non-BSpline faces).
+    public func faceIntegrationKnotsU() -> [Double] {
+        var buffer = [Double](repeating: 0, count: 256)
+        let n = OCCTBRepGPropFaceUKnots(handle, &buffer, 256)
+        guard n > 0 else { return [] }
+        return Array(buffer.prefix(Int(n)))
+    }
 }
 
 // MARK: - Face Validity Checking (v0.47.0)

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -991,6 +991,72 @@ extension Surface {
         singularityCount(tolerance: tolerance) > 0
     }
 
+    // MARK: - ShapeAnalysis_Surface extras (#266 follow-up)
+
+    /// Refine a (U,V) for a 3D point by projecting it onto this surface's iso-lines — more robust
+    /// near degeneracies than plain ``projectPoint(_:)``. Returns the parameters and the 3D gap; a
+    /// very large gap means the projection effectively failed.
+    public func uvFromIso(_ point: SIMD3<Double>, precision: Double = 1e-6) -> (u: Double, v: Double, gap: Double)? {
+        var u = 0.0, v = 0.0
+        let gap = OCCTSurfaceUVFromIso(handle, point.x, point.y, point.z, precision, &u, &v)
+        guard gap >= 0 else { return nil }
+        return (u, v, gap)
+    }
+
+    /// Detail of a surface singularity (a degenerate iso-line collapsing to a pole), e.g. the apex
+    /// of a cone or the poles of a sphere.
+    public struct Singularity: Sendable {
+        /// The 3D pole point.
+        public let point: SIMD3<Double>
+        /// First / last 2D (u,v) points of the degenerate iso-line.
+        public let firstUV: SIMD2<Double>
+        public let lastUV: SIMD2<Double>
+        /// First / last parameter along the iso-line.
+        public let firstParameter: Double
+        public let lastParameter: Double
+        /// True if the degenerate iso-line is a U-iso (else a V-iso).
+        public let isUIso: Bool
+        /// The precision at which the singularity was detected.
+        public let precision: Double
+    }
+
+    /// Full detail of singularity `index` (**0-based**, `0..<singularityCount(...)`), or nil if out
+    /// of range. Unlike ``singularityCount(tolerance:)`` (count only) this returns the pole point,
+    /// iso-line 2D endpoints + parameters, and the iso direction.
+    public func singularity(_ index: Int, precision: Double = 1e-6) -> Singularity? {
+        var pr = precision, px = 0.0, py = 0.0, pz = 0.0
+        var fu = 0.0, fv = 0.0, lu = 0.0, lv = 0.0, fp = 0.0, lp = 0.0
+        var uiso = false
+        guard OCCTSurfaceSingularityDetail(handle, Int32(index + 1), &pr, &px, &py, &pz,
+                                           &fu, &fv, &lu, &lv, &fp, &lp, &uiso) else { return nil }
+        return Singularity(point: SIMD3(px, py, pz), firstUV: SIMD2(fu, fv), lastUV: SIMD2(lu, lv),
+                           firstParameter: fp, lastParameter: lp, isUIso: uiso, precision: pr)
+    }
+
+    /// Resolve the indeterminate 2D coordinate of a point lying in a singularity (e.g. a cone apex),
+    /// taking the well-defined coordinate from a `neighbour` 2D point. Returns the resolved (u,v).
+    public func projectDegenerated(_ point: SIMD3<Double>, neighbour: SIMD2<Double>,
+                                   precision: Double = 1e-6) -> SIMD2<Double>? {
+        var ru = 0.0, rv = 0.0
+        guard OCCTSurfaceProjectDegenerated(handle, point.x, point.y, point.z, precision,
+                                            neighbour.x, neighbour.y, &ru, &rv) else { return nil }
+        return SIMD2(ru, rv)
+    }
+
+    /// Project a 3D point onto this surface, restricting the parameter search to the given U/V
+    /// domain — disambiguates projection on periodic or self-overlapping surfaces. Returns the (u,v)
+    /// and the 3D gap, or nil on failure.
+    public func projectPoint(_ point: SIMD3<Double>, uDomain: ClosedRange<Double>,
+                             vDomain: ClosedRange<Double>, precision: Double = 1e-6)
+        -> (uv: SIMD2<Double>, gap: Double)? {
+        var u = 0.0, v = 0.0
+        let gap = OCCTSurfaceProjectPointUVInDomain(handle, point.x, point.y, point.z, precision,
+                                                    uDomain.lowerBound, uDomain.upperBound,
+                                                    vDomain.lowerBound, vDomain.upperBound, &u, &v)
+        guard gap >= 0 else { return nil }
+        return (SIMD2(u, v), gap)
+    }
+
     public func toBezierPatches() -> [Surface] {
         let maxPatches: Int32 = 256
         var patchRefs = [OCCTSurfaceRef?](repeating: nil, count: Int(maxPatches))

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -2491,3 +2491,58 @@ struct SelfIntersectingProfileGuard263 {
         }
     }
 }
+
+// MARK: - #266 follow-up: ShapeFix_Face control + BRepCheck_Face diagnostics
+
+@Suite("Issue #266 follow-up — face healing control & checks")
+struct Issue266FaceHealingControlTests {
+
+    /// A 10×10 planar face on the z=0 plane.
+    private func planarFace() -> Shape? {
+        guard let plane = Surface.plane(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1)),
+              let outer = Wire.polygon3D([
+                  SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)
+              ], closed: true) else { return nil }
+        return Shape.face(from: plane, outer: outer, innerWires: [])
+    }
+
+    @Test("FaceFixer per-pass control: set modes, perform, read result/status")
+    func faceFixerControl() {
+        guard let face = planarFace(), let fixer = FaceFixer(face: face) else { Issue.record("setup"); return }
+        // Toggle individual passes (the natural-bound pass is the one that ballooned a face earlier).
+        fixer.setMode(.addNaturalBound, .off)
+        fixer.setMode(.orientation, .on)
+        fixer.setMode(.intersectingWires, .auto)
+        fixer.perform()
+        // Result/face are retrievable and valid; a clean face needs no failure-level fix.
+        if let r = fixer.result { #expect(r.isValid) }
+        if let f = fixer.face { #expect(f.isValid) }
+        #expect(!fixer.status(.fail))
+    }
+
+    @Test("FaceFixer individual fix passes run without crashing")
+    func faceFixerIndividualPasses() {
+        guard let face = planarFace(), let fixer = FaceFixer(face: face) else { Issue.record("setup"); return }
+        // These must execute and return a Bool (no crash) on a clean face.
+        _ = fixer.fixIntersectingWires()
+        _ = fixer.fixWiresTwoCoincEdges()
+        _ = fixer.fixLoopWire()
+        _ = fixer.fixPeriodicDegenerated()
+        #expect(fixer.face != nil)
+    }
+
+    @Test("BRepCheck_Face diagnostics: a clean face passes all three")
+    func checkCleanFace() {
+        guard let face = planarFace() else { Issue.record("setup"); return }
+        #expect(face.checkFaceIntersectingWires() == .noError)
+        #expect(face.checkFaceWireImbrication() == .noError)
+        #expect(face.checkFaceWireOrientation() == .noError)
+    }
+
+    @Test("BRepCheck_Face diagnostics: a non-face yields checkFail")
+    func checkNonFace() {
+        guard let box = Shape.box(width: 1, height: 1, depth: 1) else { Issue.record("setup"); return }
+        #expect(box.checkFaceIntersectingWires() == .checkFail)
+        #expect(box.checkFaceWireOrientation() == .checkFail)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue266FaceAnalysisFollowupTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue266FaceAnalysisFollowupTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #266 follow-up: ShapeAnalysis_Surface extras (UVFromIso / Singularity-detail / ProjectDegenerated
+/// / domain-restricted projection) and BRepGProp_Face integration introspection.
+@Suite("Issue #266 follow-up — surface analysis extras")
+struct Issue266FaceAnalysisFollowupTests {
+
+    @Test("UVFromIso refines (u,v) for a point on a cylinder")
+    func uvFromIsoOnCylinder() {
+        guard let cyl = Surface.cylindricalSurface(radius: 5) else { Issue.record("surface"); return }
+        // A point on the cylinder (radius 5, axis Z) at angle ~0, height 3.
+        guard let r = cyl.uvFromIso(SIMD3(5, 0, 3), precision: 1e-6) else {
+            Issue.record("uvFromIso nil"); return
+        }
+        #expect(r.gap < 1e-3)                 // the point lies on the surface
+        #expect(abs(r.v - 3) < 1e-6)          // v is the height
+    }
+
+    @Test("singularity detail at a cone apex")
+    func coneSingularity() {
+        guard let cone = Surface.cone(origin: SIMD3(0, 0, 0), axis: SIMD3(0, 0, 1),
+                                      radius: 5, semiAngle: 0.5) else { Issue.record("cone"); return }
+        #expect(cone.singularityCount() >= 1)        // a cone has a degenerate apex
+        guard let s = cone.singularity(0) else { Issue.record("singularity(0) nil"); return }
+        // The apex sits on the axis (x ≈ y ≈ 0); the iso-line collapses to it.
+        #expect(abs(s.point.x) < 1e-6)
+        #expect(abs(s.point.y) < 1e-6)
+        #expect(simd_distance(s.firstUV, s.lastUV) > 0)   // a real degenerate iso, not a point
+    }
+
+    @Test("out-of-range singularity index returns nil")
+    func singularityOutOfRange() {
+        guard let cone = Surface.cone(origin: SIMD3(0, 0, 0), axis: SIMD3(0, 0, 1),
+                                      radius: 5, semiAngle: 0.5) else { Issue.record("cone"); return }
+        #expect(cone.singularity(99) == nil)
+    }
+
+    @Test("domain-restricted projection lands inside the domain")
+    func projectInDomain() {
+        guard let cyl = Surface.cylindricalSurface(radius: 5) else { Issue.record("surface"); return }
+        guard let r = cyl.projectPoint(SIMD3(5, 0, 2), uDomain: 0...(.pi), vDomain: 0...10) else {
+            Issue.record("projectPoint(domain) nil"); return
+        }
+        #expect(r.gap < 1e-3)
+        #expect(r.uv.y >= -1e-6 && r.uv.y <= 10 + 1e-6)   // v within the requested domain
+    }
+
+    @Test("BRepGProp_Face integration orders + U knots on a planar face")
+    func integrationIntrospection() {
+        guard let plane = Surface.plane(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1)),
+              let outer = Wire.polygon3D([
+                  SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)
+              ], closed: true),
+              let face = Shape.face(from: plane, outer: outer, innerWires: []) else {
+            Issue.record("face setup"); return
+        }
+        // Orders are defined (planar ⇒ small/zero), and the U-knot span covers at least [uMin,uMax].
+        #expect(face.faceIntegrationOrders != nil)
+        let knots = face.faceIntegrationKnotsU()
+        #expect(knots.count >= 2)
+        if knots.count >= 2 { #expect(knots.first! <= knots.last!) }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,33 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.8.6
+## Current: v1.8.7
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.8.7 (June 2026) — feat: face healing & validation surface (#266 follow-up)
+
+**New APIs (~16 ops).** Rounds out the face-analysis surface flagged by the coverage audit:
+
+- **`ShapeFix_Face` per-pass control** (`FaceFixer`): `setMode(_:_:)` toggles any of the 11 healing
+  passes (wire, orientation, **addNaturalBound**, missingSeam, smallAreaWire, removeSmallAreaFace,
+  intersectingWires, loopWires, splitFace, autoCorrectPrecision, periodicDegenerated) before
+  `perform()`; plus `fixIntersectingWires()`, `fixPeriodicDegenerated()`, `fixWiresTwoCoincEdges()`,
+  `fixLoopWire()`, `result` (Face **or** Shell), and `status(_:)`. Previously `perform()` ran with
+  hardcoded defaults — e.g. no way to turn off the natural-bound pass that can balloon a trimmed face.
+- **`BRepCheck_Face` per-wire diagnostics** (`Shape`): `checkFaceIntersectingWires`,
+  `checkFaceWireImbrication`, `checkFaceWireOrientation` — the specific `BRepCheck_Status` per check.
+- **`ShapeAnalysis_Surface` extras** (`Surface`): `uvFromIso`, `singularity(_:)` (full pole/iso
+  detail), `projectDegenerated`, and domain-restricted `projectPoint(_:uDomain:vDomain:)`.
+- **`BRepGProp_Face`** (`Shape`): `faceIntegrationOrders`, `faceIntegrationKnotsU()`.
+
+Swift-only; no xcframework change. The audit's "rebound a face on its own surface" and "3D point
+classifier" candidates were verified **already wrapped** (`faceAddHole` and `OCCTClassifyPointOnFace`)
+and not duplicated.
 
 ### v1.8.6 (June 2026) — feat: face-from-surface with interior holes (#266)
 


### PR DESCRIPTION
Follow-up to #266 — wraps the face-analysis gaps surfaced by the coverage audit (high / medium / low tiers).

## New APIs

**`ShapeFix_Face` per-pass control** (`FaceFixer`)
- `setMode(_ pass:_ toggle:)` — toggle any of the 11 healing passes (wire, orientation, **addNaturalBound**, missingSeam, smallAreaWire, removeSmallAreaFace, intersectingWires, loopWires, splitFace, autoCorrectPrecision, periodicDegenerated) before `perform()`.
- `fixIntersectingWires()`, `fixPeriodicDegenerated()`, `fixWiresTwoCoincEdges()`, `fixLoopWire()`, `result` (Face **or** Shell), `status(_:)`.
- *Motivation:* `perform()` previously ran with hardcoded defaults — no way to turn off the natural-bound pass that ballooned a trimmed face (the footgun we hit in the #266 rebound experiment).

**`BRepCheck_Face` per-wire diagnostics** (`Shape`)
- `checkFaceIntersectingWires`, `checkFaceWireImbrication`, `checkFaceWireOrientation` → the specific `BRepCheck_Status`.

**`ShapeAnalysis_Surface` extras** (`Surface`)
- `uvFromIso`, `singularity(_:)` (full pole/iso detail), `projectDegenerated`, domain-restricted `projectPoint(_:uDomain:vDomain:)`.

**`BRepGProp_Face`** (`Shape`)
- `faceIntegrationOrders`, `faceIntegrationKnotsU()`.

## Verified-not-gaps (not duplicated)
The audit's "rebound a face on its surface" and "3D point classifier" candidates were ground-truthed as **already wrapped** — `Shape.faceAddHole` (== `MakeFace(face,wire)`) and `OCCTClassifyPointOnFace` (== `BRepClass_FaceClassifier(face, gp_Pnt, tol)`). `BRepGProp_Face::GetTKnots` was skipped (requires a loaded boundary arc — not a face-level query).

## Tests
`Issue266FaceAnalysisFollowupTests` (5) + `Issue266FaceHealingControlTests` (4). Surface + ShapeHealing domains green (595 tests). Swift-only; no xcframework change. README op count 4,291 → 4,307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)