### PR TITLE
docs: backfill API_REFERENCE for #266 face APIs + mandate docs-per-release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,15 @@ Each release adds ~100 new operations following this strict order:
 5. `swift build` — zero errors
 6. Tests
 7. `swift test` — all pass
-8. Update README.md (table counts, feature bullets, totals)
+8. **Update docs — MANDATORY every release (OKF release discipline), even for a one-method change:**
+   - `README.md` (table counts, feature bullets, totals)
+   - `docs/API_REFERENCE.md` (op-count tables + Total + Swift→OCCT mapping rows for the new ops)
+   - `docs/CHANGELOG.md` (the release entry)
+   - any `docs/reference/<Type>.md` page covering a changed type
+   - `///` doc comments with a fenced ```swift``` snippet on every new public API (context7 harvests these)
 9. `git commit`, `git push`, `git tag vX.Y.Z`, `gh release create`
+
+> No release ships with stale docs. If an API surface changed, the docs change in the **same** release.
 
 ## Workflow Automations
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -311,7 +311,7 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **ShapeAnalysis_FreeBounds Simplified** | 3 | freeBoundsClosedCount, freeBoundsClosedWires, freeBoundsOpenWires |
 | **Geom_TrimmedCurve** | 5 | trimmed, startPoint, endPoint, trimmedBasis, setTrim |
 | **BRepLib_FindSurface** | 3 | findSurface, findSurfaceTolerance, findSurfaceExisted |
-| **ShapeAnalysis_Surface Extensions** | 5 | projectPointUV, hasSingularitiesSA, singularityCountSA, isUClosedSA, isVClosedSA |
+| **ShapeAnalysis_Surface Extensions** | 9 | projectPointUV, hasSingularitiesSA, singularityCountSA, isUClosedSA, isVClosedSA, uvFromIso, singularity(detail), projectDegenerated, projectPoint(uDomain:vDomain:) |
 | **Resource_Manager** | 9 | create, release, setString, setInt, setReal, find, getString, getInt, getReal |
 | **TopExp Adjacency** | 9 | edgeFirstVertex, edgeLastVertex, edgeVertices, wireVertices, commonVertex, edgeFaceAdjacency, vertexEdgeAdjacency, adjacentFaces(forEdge), adjacentEdges(forVertex) |
 | **Poly_Connect Mesh Adjacency** | 3 | meshTriangleAdjacency, meshNodeTriangle, meshNodeTriangleCount |
@@ -370,7 +370,7 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **BSplineCurve 2D Manipulation** | 12 | knotCount, poleCount, degree, isRational, getPole, setPole, setWeight, insertKnot, removeKnot, segment, increaseDegree, resolution |
 | **BezierCurve Manipulation** | 10 | getPole, setPole, setWeight, insertPoleAfter, removePole, segment, increaseDegree, isRational, degree, poleCount |
 | **BRepTools/BRepLib Utilities** | 10 | clean, cleanGeometry, removeUnusedPCurves, update, checkSameRange, sameRange, buildCurve3d, updateTolerances, updateInnerTolerances, updateEdgeTolerance |
-| **MakeFace Extras** | 6 | fromSphere, fromTorus, fromCone, fromSurfaceWire, addHole, copy |
+| **MakeFace Extras** | 7 | fromSphere, fromTorus, fromCone, fromSurfaceWire, fromSurfaceWireWithHoles, addHole, copy |
 | **BRepBuilderAPI_Sewing Detailed** | 8 | create, release, add, perform, result, nbFreeEdges, nbContigousEdges, nbDegeneratedShapes |
 | **Hatch_Hatcher** | 7 | create, release, addXLine, addYLine, trim, nbLines, nbIntervals |
 | **Edge/Face Extraction** | 9 | extractCurve3D, extractPCurve, edgeTolerance, isDegenerated, extractSurface, faceTolerance, wireCount, vertexTolerance, vertexPoint |
@@ -426,7 +426,9 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **ProjectionOnSurface** | 8 | create, release, nbPoints, point, parameters, distance, lowerDistance, lowerParams |
 | **ShapeDistance (DistShapeShape)** | 12 | create, release, isDone, value, nbSolution, pointOnShape1, pointOnShape2, supportType1, supportType2, supportShape1, supportShape2 |
 | **WireFixer** | 12 | create, release, fixReorder, fixConnected, fixSmall, fixDegenerated, fixSelfIntersection, fixLacking, fixClosed, fixGaps3d, fixEdgeCurves, wire |
-| **FaceFixer** | 8 | create, release, perform, fixOrientation, fixAddNaturalBound, fixMissingSeam, fixSmallAreaWire, face |
+| **FaceFixer** | 15 | create, release, perform, fixOrientation, fixAddNaturalBound, fixMissingSeam, fixSmallAreaWire, face, setMode, fixIntersectingWires, fixPeriodicDegenerated, fixWiresTwoCoincEdges, fixLoopWire, result, status |
+| **BRepCheck_Face Diagnostics** | 3 | checkFaceIntersectingWires, checkFaceWireImbrication, checkFaceWireOrientation |
+| **BRepGProp_Face Integration** | 2 | faceIntegrationOrders, faceIntegrationKnotsU |
 | **MakeFace Completions** | 3 | fromSurfaceUV, fromGpPlane, fromGpCylinder |
 | **IntCS Full Results** | 6 | create, release, nbPoints, point (with params), nbSegments |
 | **BSplineCurve Mutations** | 8 | setKnot, getKnotSequence, getWeights, insertKnots, movePoint, localValue, maxDegree, locateU |
@@ -479,7 +481,7 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **3408** | |
+| **Total** | **3425** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -680,6 +682,7 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 |-----------|------------|
 | `Shape.face(from:)` | `BRepBuilderAPI_MakeFace` |
 | `Shape.face(outer:holes:)` | `BRepBuilderAPI_MakeFace` |
+| `Shape.face(from:outer:innerWires:)` | `BRepBuilderAPI_MakeFace(surface, outer)` + `.Add(hole)` + `ShapeFix_Face` |
 | `Shape.solid(from:)` | `BRepBuilderAPI_MakeSolid` |
 | `Shape.sew(shapes:tolerance:)` | `BRepBuilderAPI_Sewing` |
 | `Wire.interpolate(through:)` | `GeomAPI_Interpolate` |

--- a/okf/index.md
+++ b/okf/index.md
@@ -36,3 +36,7 @@ See [`references/`](references/index.md) — OpenCASCADE upstream and licensing 
 - Binary target auto-selects a local `Libraries/OCCT.xcframework` (path-dep / dev) or the remote
   release zip (URL / CI); see `Package.swift` for the `#filePath`-based detection.
 - Published to the Swift Package Index via `.spi.yml`.
+- **Release discipline (OKF standard):** documentation updates are **mandatory with every release** —
+  no release ships with stale docs. Any change to a public API surface updates, in the same release,
+  `README.md`, `docs/API_REFERENCE.md`, `docs/CHANGELOG.md`, the relevant `docs/reference/` page, and
+  the `///` doc comments (with a runnable ```swift``` snippet for context7). See `CLAUDE.md` → Release Process.


### PR DESCRIPTION
Answers "are the docs updated?" — they were **not** fully. v1.8.6/v1.8.7 shipped with `///` comments + CHANGELOG but `docs/API_REFERENCE.md` (the canonical op inventory) was stale.

## Docs backfill (`docs/API_REFERENCE.md`)
- FaceFixer **8 → 15** (setMode, fixIntersectingWires, fixPeriodicDegenerated, fixWiresTwoCoincEdges, fixLoopWire, result, status)
- MakeFace Extras **6 → 7** (fromSurfaceWireWithHoles)
- ShapeAnalysis_Surface Extensions **5 → 9** (uvFromIso, singularity-detail, projectDegenerated, projectPoint domain)
- new rows: **BRepCheck_Face Diagnostics (3)**, **BRepGProp_Face Integration (2)**
- Total **3408 → 3425**; added the `face(from:outer:innerWires:)` Swift→OCCT mapping

## Process (so it doesn't recur)
- `CLAUDE.md` Release Process step 8 expanded: docs updates are **mandatory every release** (README + API_REFERENCE + CHANGELOG + reference page + `///` snippet).
- `okf/index.md` gained a release-discipline note.
- Ecosystem-wide: added a **"Release discipline"** section to `SecondMouseAU/ecosystem` `OKF-STANDARD.md` (already committed) — "documentation updates are mandatory with every release; no release ships with stale docs."

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)