### PR TITLE
feat(#266): close the face-analysis tail (5 low-value leftovers, 6 ops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,307 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,313 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -13689,6 +13689,23 @@ bool OCCTBRepGPropFaceIntegrationOrders(OCCTShapeRef _Nonnull face, int32_t* _No
 /// BRepGProp_Face U-direction integration knots; fills up to maxCount, returns the count.
 int32_t OCCTBRepGPropFaceUKnots(OCCTShapeRef _Nonnull face, double* _Nullable buffer, int32_t maxCount);
 
+/// BRepGProp_Face V-direction integration knots (companion to UKnots); fills up to maxCount, returns count.
+int32_t OCCTBRepGPropFaceVKnots(OCCTShapeRef _Nonnull face, double* _Nullable buffer, int32_t maxCount);
+
+/// BRepGProp_Face precision-driven surface integration parameters: order (points) for tolerance `eps`,
+/// and the U / V subinterval counts. Returns false if `face` is not a face.
+bool OCCTBRepGPropFaceSurfaceIntegration(OCCTShapeRef _Nonnull face, double eps,
+                                         int32_t* _Nonnull order, int32_t* _Nonnull uSubs,
+                                         int32_t* _Nonnull vSubs);
+
+/// BRepGProp_Face boundary (edge-loaded) integration: loads face edge #edgeIndex as the boundary arc
+/// and returns its integration order (for tolerance `eps`), subinterval count, and knots (up to
+/// maxKnots into knotBuffer). Returns false if the face/edge is invalid or the edge can't be loaded.
+bool OCCTBRepGPropFaceBoundaryIntegration(OCCTShapeRef _Nonnull face, int32_t edgeIndex, double eps,
+                                          int32_t* _Nonnull order, int32_t* _Nonnull subs,
+                                          double* _Nullable knotBuffer, int32_t maxKnots,
+                                          int32_t* _Nonnull knotCount);
+
 // --- Resource_Manager ---
 
 typedef struct OCCTResourceManager* OCCTResourceManagerRef;
@@ -16009,6 +16026,10 @@ bool OCCTFaceLPropIsUmbilic(OCCTShapeRef _Nonnull face, double u, double v);
 bool OCCTFaceLPropTangentU(OCCTShapeRef _Nonnull face, double u, double v,
                               double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
 
+/// Get tangent in V direction on face at (u, v) — the other axis of the tangent plane. #266 follow-up.
+bool OCCTFaceLPropTangentV(OCCTShapeRef _Nonnull face, double u, double v,
+                              double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+
 // MARK: - MathPoly_Laguerre (v0.111.0)
 
 /// Find real roots of a polynomial using Laguerre's method.
@@ -16552,6 +16573,10 @@ OCCTShapeRef _Nullable OCCTFaceFixerResult(OCCTFaceFixerRef _Nonnull fixer);
 /// Query which fixes fired after Perform(). `status`: 0 = OK (no flags), 1..8 = DONE1..DONE8,
 /// 9..16 = FAIL1..FAIL8, 17 = DONE (any), 18 = FAIL (any).
 bool OCCTFaceFixerStatus(OCCTFaceFixerRef _Nonnull fixer, int32_t status);
+
+/// Clamp the max / min tolerance the fixer may set on the healed face (ShapeFix_Root). Call before Perform().
+void OCCTFaceFixerSetMaxTolerance(OCCTFaceFixerRef _Nonnull fixer, double maxTolerance);
+void OCCTFaceFixerSetMinTolerance(OCCTFaceFixerRef _Nonnull fixer, double minTolerance);
 
 // --- BRepBuilderAPI_MakeFace completions ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -4023,6 +4023,16 @@ bool OCCTFaceFixerStatus(OCCTFaceFixerRef fixer, int32_t status) {
     catch (...) { return false; }
 }
 
+void OCCTFaceFixerSetMaxTolerance(OCCTFaceFixerRef fixer, double maxTolerance) {
+    if (!fixer || fixer->fixer.IsNull()) return;
+    try { fixer->fixer->SetMaxTolerance(maxTolerance); } catch (...) {}
+}
+
+void OCCTFaceFixerSetMinTolerance(OCCTFaceFixerRef fixer, double minTolerance) {
+    if (!fixer || fixer->fixer.IsNull()) return;
+    try { fixer->fixer->SetMinTolerance(minTolerance); } catch (...) {}
+}
+
 // MARK: - WireFixer extended (hoisted with struct)
 // --- WireFixer extended ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1636,6 +1636,20 @@ bool OCCTFaceLPropTangentU(OCCTShapeRef face, double u, double v, double* dx, do
     } catch (...) { return false; }
 }
 
+bool OCCTFaceLPropTangentV(OCCTShapeRef face, double u, double v, double* dx, double* dy, double* dz) {
+    *dx = 0; *dy = 0; *dz = 0;
+    if (!face) return false;
+    try {
+        BRepAdaptor_Surface as(TopoDS::Face(face->shape));
+        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        if (!props.IsTangentVDefined()) return false;
+        gp_Dir tan;
+        props.TangentV(tan);
+        *dx = tan.X(); *dy = tan.Y(); *dz = tan.Z();
+        return true;
+    } catch (...) { return false; }
+}
+
 // MARK: - v0.114: Shape mass properties expansion
 // --- Shape mass properties expansion ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -3543,6 +3543,10 @@ bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci) {
 #include <gp_Pnt2d.hxx>
 #include <BRepGProp_Face.hxx>
 #include <NCollection_HArray1.hxx>
+#include <NCollection_Array1.hxx>
+#include <TopExp.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
 
 /// UVFromIso: refine a (U,V) for P3D by projecting onto the surface's iso-lines; returns the best
 /// 3D gap (very large on failure).
@@ -3638,6 +3642,60 @@ int32_t OCCTBRepGPropFaceUKnots(OCCTShapeRef face, double* buffer, int32_t maxCo
         }
         return n;
     } catch (...) { return 0; }
+}
+
+int32_t OCCTBRepGPropFaceVKnots(OCCTShapeRef face, double* buffer, int32_t maxCount) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return 0;
+    try {
+        BRepGProp_Face gf(TopoDS::Face(face->shape));
+        int n = gf.SVIntSubs(); if (n < 1) n = 1;   // array is sized to the V subinterval count
+        NCollection_Array1<double> k(1, n);
+        gf.VKnots(k);
+        int32_t c = 0;
+        for (int i = k.Lower(); i <= k.Upper() && c < maxCount; i++, c++) {
+            if (buffer) buffer[c] = k.Value(i);
+        }
+        return c;
+    } catch (...) { return 0; }
+}
+
+bool OCCTBRepGPropFaceSurfaceIntegration(OCCTShapeRef face, double eps,
+                                         int32_t* order, int32_t* uSubs, int32_t* vSubs) {
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return false;
+    try {
+        BRepGProp_Face gf(TopoDS::Face(face->shape));
+        if (order) *order = gf.SIntOrder(eps);
+        if (uSubs) *uSubs = gf.SUIntSubs();
+        if (vSubs) *vSubs = gf.SVIntSubs();
+        return true;
+    } catch (...) { return false; }
+}
+
+bool OCCTBRepGPropFaceBoundaryIntegration(OCCTShapeRef face, int32_t edgeIndex, double eps,
+                                          int32_t* order, int32_t* subs,
+                                          double* knotBuffer, int32_t maxKnots, int32_t* knotCount) {
+    if (knotCount) *knotCount = 0;
+    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return false;
+    try {
+        TopoDS_Face f = TopoDS::Face(face->shape);
+        TopTools_IndexedMapOfShape emap;
+        TopExp::MapShapes(f, TopAbs_EDGE, emap);
+        if (edgeIndex < 0 || edgeIndex >= emap.Extent()) return false;
+        BRepGProp_Face gf(f);
+        if (!gf.Load(TopoDS::Edge(emap(edgeIndex + 1)))) return false;   // load the boundary arc
+        if (order) *order = gf.LIntOrder(eps);
+        int s = gf.LIntSubs();
+        if (subs) *subs = s;
+        int n = s < 1 ? 1 : s;
+        NCollection_Array1<double> k(1, n);
+        gf.LKnots(k);
+        int32_t c = 0;
+        for (int i = k.Lower(); i <= k.Upper() && c < maxKnots; i++, c++) {
+            if (knotBuffer) knotBuffer[c] = k.Value(i);
+        }
+        if (knotCount) *knotCount = c;
+        return true;
+    } catch (...) { return false; }
 }
 
 // MARK: - v0.105: GeomConvert_BSplineSurfaceKnotSplitting

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -10832,6 +10832,14 @@ extension Shape {
         let ok = OCCTFaceLPropTangentU(handle, u, v, &dx, &dy, &dz)
         return ok ? SIMD3(dx, dy, dz) : nil
     }
+
+    /// Get tangent in V direction on a face at (u, v) — the second axis of the tangent plane
+    /// (companion to ``faceLPropTangentU(u:v:)``). Returns nil if the V tangent is undefined.
+    public func faceLPropTangentV(u: Double, v: Double) -> SIMD3<Double>? {
+        var dx = 0.0, dy = 0.0, dz = 0.0
+        let ok = OCCTFaceLPropTangentV(handle, u, v, &dx, &dy, &dz)
+        return ok ? SIMD3(dx, dy, dz) : nil
+    }
 }
 
 // MARK: - GridEval Curve3D Extensions (v0.111.0)
@@ -11928,6 +11936,12 @@ public final class FaceFixer: @unchecked Sendable {
     /// Whether the given status flag is set after ``perform()`` (e.g. `.done` = something was fixed,
     /// `.fail` = a pass failed).
     public func status(_ status: Status) -> Bool { OCCTFaceFixerStatus(ref, status.rawValue) }
+
+    /// Clamp the maximum tolerance the fixer may assign to the healed face. Call before ``perform()``.
+    public func setMaxTolerance(_ maxTolerance: Double) { OCCTFaceFixerSetMaxTolerance(ref, maxTolerance) }
+
+    /// Clamp the minimum tolerance the fixer may assign to the healed face. Call before ``perform()``.
+    public func setMinTolerance(_ minTolerance: Double) { OCCTFaceFixerSetMinTolerance(ref, minTolerance) }
 }
 
 // --- IntCSResult class ---

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6338,6 +6338,35 @@ extension Shape {
         guard n > 0 else { return [] }
         return Array(buffer.prefix(Int(n)))
     }
+
+    /// `BRepGProp_Face` V-direction integration knots — companion to ``faceIntegrationKnotsU()``.
+    public func faceIntegrationKnotsV() -> [Double] {
+        var buffer = [Double](repeating: 0, count: 256)
+        let n = OCCTBRepGPropFaceVKnots(handle, &buffer, 256)
+        guard n > 0 else { return [] }
+        return Array(buffer.prefix(Int(n)))
+    }
+
+    /// `BRepGProp_Face` precision-driven surface integration parameters: the Gauss `order` (number of
+    /// points) needed for tolerance `precision`, and the number of U / V subintervals. nil if the
+    /// shape isn't a single face.
+    public func faceSurfaceIntegration(precision: Double = 1e-6) -> (order: Int, uSubs: Int, vSubs: Int)? {
+        var order: Int32 = 0, u: Int32 = 0, v: Int32 = 0
+        guard OCCTBRepGPropFaceSurfaceIntegration(handle, precision, &order, &u, &v) else { return nil }
+        return (Int(order), Int(u), Int(v))
+    }
+
+    /// `BRepGProp_Face` boundary integration: loads face edge `edgeIndex` as the boundary arc and
+    /// returns its integration `order` (for `precision`), subinterval count, and knot values.
+    /// nil if the shape isn't a face or the edge can't be loaded.
+    public func faceBoundaryIntegration(edgeIndex: Int, precision: Double = 1e-6)
+        -> (order: Int, subs: Int, knots: [Double])? {
+        var order: Int32 = 0, subs: Int32 = 0, knotCount: Int32 = 0
+        var buffer = [Double](repeating: 0, count: 256)
+        guard OCCTBRepGPropFaceBoundaryIntegration(handle, Int32(edgeIndex), precision,
+                                                   &order, &subs, &buffer, 256, &knotCount) else { return nil }
+        return (Int(order), Int(subs), Array(buffer.prefix(Int(knotCount))))
+    }
 }
 
 // MARK: - Face Validity Checking (v0.47.0)

--- a/Tests/OCCTSurfaceTests/Issue266FaceAnalysisFollowupTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue266FaceAnalysisFollowupTests.swift
@@ -62,4 +62,57 @@ struct Issue266FaceAnalysisFollowupTests {
         #expect(knots.count >= 2)
         if knots.count >= 2 { #expect(knots.first! <= knots.last!) }
     }
+
+    // A 10×10 planar face on z=0.
+    private func planarFace() -> Shape? {
+        guard let plane = Surface.plane(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1)),
+              let outer = Wire.polygon3D([
+                  SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)
+              ], closed: true) else { return nil }
+        return Shape.face(from: plane, outer: outer, innerWires: [])
+    }
+
+    @Test("tangent plane is two-sided: TangentU and TangentV both defined and independent")
+    func faceTangentUandV() {
+        guard let face = planarFace() else { Issue.record("setup"); return }
+        guard let tu = face.faceLPropTangentU(u: 5, v: 5),
+              let tv = face.faceLPropTangentV(u: 5, v: 5) else {
+            Issue.record("tangent nil"); return
+        }
+        // On a plane the two tangents span the plane — not parallel.
+        let cross = simd_cross(tu, tv)
+        #expect(simd_length(cross) > 0.5)   // ~unit (orthonormal axes) ⇒ well clear of parallel
+    }
+
+    @Test("BRepGProp_Face V knots + surface-integration params")
+    func vKnotsAndSurfaceIntegration() {
+        guard let face = planarFace() else { Issue.record("setup"); return }
+        #expect(face.faceIntegrationKnotsV().count >= 1)
+        guard let si = face.faceSurfaceIntegration() else { Issue.record("surfaceIntegration nil"); return }
+        #expect(si.order >= 1)          // some Gauss order
+        #expect(si.uSubs >= 1)
+        #expect(si.vSubs >= 1)
+    }
+
+    @Test("BRepGProp_Face boundary integration on a face edge")
+    func boundaryIntegration() {
+        guard let face = planarFace() else { Issue.record("setup"); return }
+        guard let bi = face.faceBoundaryIntegration(edgeIndex: 0) else {
+            Issue.record("boundaryIntegration nil"); return
+        }
+        #expect(bi.order >= 1)
+        #expect(bi.subs >= 1)
+        #expect(bi.knots.count >= 1)
+        // An out-of-range edge index fails cleanly.
+        #expect(face.faceBoundaryIntegration(edgeIndex: 99) == nil)
+    }
+
+    @Test("FaceFixer tolerance clamps run without crashing")
+    func faceFixerTolerances() {
+        guard let face = planarFace(), let fixer = FaceFixer(face: face) else { Issue.record("setup"); return }
+        fixer.setMinTolerance(1e-7)
+        fixer.setMaxTolerance(1e-2)
+        fixer.perform()
+        if let r = fixer.result { #expect(r.isValid) }
+    }
 }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -426,9 +426,10 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **ProjectionOnSurface** | 8 | create, release, nbPoints, point, parameters, distance, lowerDistance, lowerParams |
 | **ShapeDistance (DistShapeShape)** | 12 | create, release, isDone, value, nbSolution, pointOnShape1, pointOnShape2, supportType1, supportType2, supportShape1, supportShape2 |
 | **WireFixer** | 12 | create, release, fixReorder, fixConnected, fixSmall, fixDegenerated, fixSelfIntersection, fixLacking, fixClosed, fixGaps3d, fixEdgeCurves, wire |
-| **FaceFixer** | 15 | create, release, perform, fixOrientation, fixAddNaturalBound, fixMissingSeam, fixSmallAreaWire, face, setMode, fixIntersectingWires, fixPeriodicDegenerated, fixWiresTwoCoincEdges, fixLoopWire, result, status |
+| **FaceFixer** | 17 | create, release, perform, fixOrientation, fixAddNaturalBound, fixMissingSeam, fixSmallAreaWire, face, setMode, fixIntersectingWires, fixPeriodicDegenerated, fixWiresTwoCoincEdges, fixLoopWire, result, status, setMaxTolerance, setMinTolerance |
 | **BRepCheck_Face Diagnostics** | 3 | checkFaceIntersectingWires, checkFaceWireImbrication, checkFaceWireOrientation |
-| **BRepGProp_Face Integration** | 2 | faceIntegrationOrders, faceIntegrationKnotsU |
+| **BRepGProp_Face Integration** | 5 | faceIntegrationOrders, faceIntegrationKnotsU, faceIntegrationKnotsV, faceSurfaceIntegration, faceBoundaryIntegration |
+| **BRepLProp_SLProps Face Tangent** | 1 | faceLPropTangentV (companion to faceLPropTangentU) |
 | **MakeFace Completions** | 3 | fromSurfaceUV, fromGpPlane, fromGpCylinder |
 | **IntCS Full Results** | 6 | create, release, nbPoints, point (with params), nbSegments |
 | **BSplineCurve Mutations** | 8 | setKnot, getKnotSequence, getWeights, insertKnots, movePoint, localValue, maxDegree, locateU |
@@ -481,7 +482,7 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **3425** | |
+| **Total** | **3431** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,28 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.8.7
+## Current: v1.8.8
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.8.8 (July 2026) — feat: close the face-analysis tail (#266 follow-up, 6 ops)
+
+Wraps the five low-value leftovers from the post-v1.8.7 face-gap re-audit — the face surface is now
+complete:
+
+- **`BRepLProp_SLProps` V tangent** (`Shape.faceLPropTangentV`) — the tangent plane is now two-sided
+  (was `TangentU`-only).
+- **`BRepGProp_Face` integration internals** (`Shape`): `faceIntegrationKnotsV`, `faceSurfaceIntegration`
+  (precision-driven Gauss order + U/V subinterval counts), `faceBoundaryIntegration(edgeIndex:)`
+  (edge-loaded boundary order/subs/knots).
+- **`ShapeFix_Face` tolerance clamps** (`FaceFixer`): `setMaxTolerance`, `setMinTolerance`.
+
+Swift-only; no xcframework change. `BRepGProp_Face::GetTKnots` remains deliberately unwrapped
+(needs a loaded boundary arc and is subsumed by `faceBoundaryIntegration`).
 
 ### v1.8.7 (June 2026) — feat: face healing & validation surface (#266 follow-up)
 


### PR DESCRIPTION
Wraps the five low-value leftovers from the post-v1.8.7 face-gap re-audit — after this the face surface has no remaining gaps.

- **`BRepLProp_SLProps` V tangent** (`Shape.faceLPropTangentV`) — tangent plane now two-sided (was `TangentU`-only).
- **`BRepGProp_Face` integration internals** (`Shape`): `faceIntegrationKnotsV`, `faceSurfaceIntegration` (precision-driven Gauss order + U/V subinterval counts), `faceBoundaryIntegration(edgeIndex:)` (edge-loaded order/subs/knots).
- **`ShapeFix_Face` tolerance clamps** (`FaceFixer`): `setMaxTolerance`, `setMinTolerance`.

Array sizing for `UKnots`/`VKnots`/`LKnots` was ground-truthed (= `S*IntSubs` / `LIntSubs`). `BRepGProp_Face::GetTKnots` stays deliberately unwrapped (needs a loaded boundary arc; subsumed by `faceBoundaryIntegration`).

Tests: 4 new cases. Surface + ShapeHealing green (599). Swift-only; reuses the v1.8.5 binary. Docs updated (README 4,307→4,313; API_REFERENCE +6/Total 3,431; CHANGELOG v1.8.8) per the OKF release-discipline rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)