### PR TITLE
docs(reference): backfill per-type pages for the #266 face APIs

### DIFF
--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -1758,6 +1758,76 @@ public var face: Shape? { get }
 
 ---
 
+### `FaceFixer.setMode(_:_:)` — per-pass control (#266)
+
+Enable / disable an individual `ShapeFix_Face` healing pass before `perform()`. Previously
+`perform()` ran with hardcoded defaults; this exposes each pass so callers can, e.g., turn off the
+natural-bound pass that can balloon a trimmed face.
+
+```swift
+public enum Pass: Int32, Sendable {
+    case wire, orientation, addNaturalBound, missingSeam, smallAreaWire,
+         removeSmallAreaFace, intersectingWires, loopWires, splitFace,
+         autoCorrectPrecision, periodicDegenerated
+}
+public enum Toggle: Int32, Sendable { case auto = -1, off = 0, on = 1 }
+public func setMode(_ pass: Pass, _ toggle: Toggle)
+```
+
+- **OCCT:** `ShapeFix_Face::Fix*Mode()` reference setters.
+- **Example:**
+  ```swift
+  let fixer = FaceFixer(face: trimmedFace)
+  fixer?.setMode(.addNaturalBound, .off)   // don't add the surface's natural bound
+  fixer?.perform()
+  ```
+
+---
+
+### `FaceFixer` — individual fix passes (#266)
+
+Run a single fix pass directly.
+
+```swift
+@discardableResult public func fixIntersectingWires() -> Bool
+@discardableResult public func fixPeriodicDegenerated() -> Bool
+@discardableResult public func fixWiresTwoCoincEdges() -> Bool
+@discardableResult public func fixLoopWire() -> Bool
+```
+
+- **OCCT:** `ShapeFix_Face::FixIntersectingWires` / `FixPeriodicDegenerated` / `FixWiresTwoCoincEdges` / `FixLoopWire`.
+
+---
+
+### `FaceFixer.result` / `FaceFixer.status(_:)` (#266)
+
+`result` returns the true fix output — a **face**, or a **shell** when `fixMissingSeam()` split the
+face into several (unlike `face`, which is always a face). `status(_:)` queries which passes fired /
+failed after `perform()`.
+
+```swift
+public var result: Shape? { get }
+public enum Status: Int32, Sendable { case ok, done1, /* … */ done8, fail1, /* … */ fail8, done, fail }
+public func status(_ status: Status) -> Bool
+```
+
+- **OCCT:** `ShapeFix_Face::Result` / `ShapeFix_Root::Status`.
+
+---
+
+### `FaceFixer.setMaxTolerance(_:)` / `setMinTolerance(_:)` (#266)
+
+Clamp the tolerance the fixer may assign to the healed face. Call before `perform()`.
+
+```swift
+public func setMaxTolerance(_ maxTolerance: Double)
+public func setMinTolerance(_ minTolerance: Double)
+```
+
+- **OCCT:** `ShapeFix_Root::SetMaxTolerance` / `SetMinTolerance`.
+
+---
+
 ### `IntCSResult`
 
 Full multi-result curve-surface intersection using `GeomAPI_IntCS`.

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -1371,6 +1371,74 @@ If you already have the boundary in UV space, call `Surface.toFace(uvBoundary:)`
 
 ---
 
+### `Shape.face(from:outer:innerWires:)` (#266)
+
+Trim a surface by an **outer** boundary **with interior hole wires** (windows / cutouts) — a single
+face with real openings. Wraps `BRepBuilderAPI_MakeFace(surface, outer)` + `.Add(hole)` per hole +
+`ShapeFix_Face`; hole winding is normalized automatically.
+
+```swift
+public static func face(from surface: Surface, outer: Wire, innerWires: [Wire]) -> Shape?
+```
+
+- **OCCT:** `BRepBuilderAPI_MakeFace(surface, outer)` + `Add(hole)` + `ShapeFix_Face`.
+- **Example:**
+  ```swift
+  // A fitted panel surface trimmed to its outline, with two window cutouts:
+  let panel = Shape.face(from: fittedSurface, outer: outline, innerWires: [window1, window2])
+  ```
+
+---
+
+## Face Analysis (#266 follow-up)
+
+Per-wire validity checks (`BRepCheck_Face`), Gauss-integration introspection (`BRepGProp_Face`), and
+the V tangent (`BRepLProp_SLProps`) for a single face.
+
+### `Shape.checkFaceIntersectingWires/WireImbrication/WireOrientation(geometricControls:)`
+
+The specific `BRepCheck_Status` for one wire-topology check: do the boundary wires intersect, are they
+correctly nested (one outer, the rest holes), and are they correctly oriented. `.checkFail` if the
+shape isn't a single face.
+
+```swift
+public func checkFaceIntersectingWires(geometricControls: Bool = true) -> CheckStatus
+public func checkFaceWireImbrication(geometricControls: Bool = true) -> CheckStatus
+public func checkFaceWireOrientation(geometricControls: Bool = true) -> CheckStatus
+```
+
+- **OCCT:** `BRepCheck_Face::IntersectWires` / `ClassifyWires` / `OrientationOfWires`.
+
+### `Shape.faceIntegrationOrders` / `faceIntegrationKnotsU()` / `faceIntegrationKnotsV()` / `faceSurfaceIntegration(precision:)` / `faceBoundaryIntegration(edgeIndex:precision:)`
+
+`BRepGProp_Face` Gauss-integration introspection — the quadrature a face needs for exact surface
+integrals (non-trivial only for BSpline faces), and per-boundary-edge integration.
+
+```swift
+public var faceIntegrationOrders: (u: Int, v: Int)? { get }
+public func faceIntegrationKnotsU() -> [Double]
+public func faceIntegrationKnotsV() -> [Double]
+public func faceSurfaceIntegration(precision: Double = 1e-6) -> (order: Int, uSubs: Int, vSubs: Int)?
+public func faceBoundaryIntegration(edgeIndex: Int, precision: Double = 1e-6)
+    -> (order: Int, subs: Int, knots: [Double])?
+```
+
+- **OCCT:** `BRepGProp_Face::UIntegrationOrder`/`VIntegrationOrder`, `GetUKnots`/`VKnots`, `SIntOrder`/`SUIntSubs`/`SVIntSubs`, and the edge-loaded `LIntOrder`/`LIntSubs`/`LKnots`.
+
+### `Shape.faceLPropTangentU/V(u:v:)`
+
+The two axes of the tangent plane at a face `(u, v)` — the V companion (`faceLPropTangentV`) makes the
+tangent plane two-sided.
+
+```swift
+public func faceLPropTangentU(u: Double, v: Double) -> SIMD3<Double>?
+public func faceLPropTangentV(u: Double, v: Double) -> SIMD3<Double>?
+```
+
+- **OCCT:** `BRepLProp_SLProps::TangentU` / `TangentV`.
+
+---
+
 ## Edges to Faces
 
 ### `Shape.facesFromEdges(_:onlyPlanar:)`

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -372,6 +372,75 @@ More efficient than `valueOfUV(point:precision:)` when projecting a sequence of 
 
 ---
 
+### `uvFromIso(_:precision:)` (#266)
+
+Refine a `(u, v)` for a 3D point by projecting it onto the surface's iso-lines — more robust near
+degeneracies than plain `projectPoint(_:)`. Returns the parameters and the 3D gap (a very large gap
+means the projection effectively failed).
+
+```swift
+public func uvFromIso(_ point: SIMD3<Double>, precision: Double = 1e-6)
+    -> (u: Double, v: Double, gap: Double)?
+```
+
+- **OCCT:** `ShapeAnalysis_Surface::UVFromIso`.
+
+---
+
+### `singularity(_:precision:)` (#266)
+
+Full detail of singularity `index` (**0-based**, `0..<singularityCount(...)`) — the pole point, the
+degenerate iso-line's 2D endpoints + parameters, and its direction. Complements
+`singularityCount(tolerance:)` (count only).
+
+```swift
+public struct Singularity: Sendable {
+    public let point: SIMD3<Double>       // 3D pole
+    public let firstUV, lastUV: SIMD2<Double>
+    public let firstParameter, lastParameter: Double
+    public let isUIso: Bool               // degenerate iso is U-iso (else V-iso)
+    public let precision: Double
+}
+public func singularity(_ index: Int, precision: Double = 1e-6) -> Singularity?
+```
+
+- **OCCT:** `ShapeAnalysis_Surface::Singularity`.
+- **Example:**
+  ```swift
+  if let apex = cone.singularity(0) { print("apex at", apex.point) }
+  ```
+
+---
+
+### `projectDegenerated(_:neighbour:precision:)` (#266)
+
+Resolve the indeterminate 2D coordinate of a point lying in a singularity (e.g. a cone apex), taking
+the well-defined coordinate from a `neighbour` 2D point.
+
+```swift
+public func projectDegenerated(_ point: SIMD3<Double>, neighbour: SIMD2<Double>,
+                               precision: Double = 1e-6) -> SIMD2<Double>?
+```
+
+- **OCCT:** `ShapeAnalysis_Surface::ProjectDegenerated`.
+
+---
+
+### `projectPoint(_:uDomain:vDomain:precision:)` (#266)
+
+Project a 3D point onto the surface **restricted to a U/V domain** (`SetDomain`) — disambiguates
+projection on periodic or self-overlapping surfaces. Returns the `(u, v)` and the 3D gap.
+
+```swift
+public func projectPoint(_ point: SIMD3<Double>, uDomain: ClosedRange<Double>,
+                         vDomain: ClosedRange<Double>, precision: Double = 1e-6)
+    -> (uv: SIMD2<Double>, gap: Double)?
+```
+
+- **OCCT:** `ShapeAnalysis_Surface::SetDomain` + `ValueOfUV` + `Gap`.
+
+---
+
 ## Curve Projection (v0.22.0)
 
 Project curves and points onto surfaces, returning UV-space or 3D curves. Backed by `GeomProjLib` and `GeomAPI_ProjectPointOnSurf`.


### PR DESCRIPTION
Brings the per-type `docs/reference/` pages current for v1.8.6–1.8.8 (they updated README/API_REFERENCE/CHANGELOG but not the reference pages — the gap the new `okf/policies/docs-current.md` targets).

- **Document-Mesh-Fixing.md** (FaceFixer): `setMode`, the four individual fix passes, `result`/`status`, `setMax/MinTolerance`.
- **Surface-Analysis.md** (ShapeAnalysis_Surface): `uvFromIso`, `singularity(_:)`, `projectDegenerated`, domain-restricted `projectPoint`.
- **Shape-Healing.md**: `face(from:outer:innerWires:)` + a new **Face Analysis (#266)** section (BRepCheck_Face checks, BRepGProp_Face integration, `faceLPropTangentU/V`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)