### PR TITLE
perf: allEdgePolylines is O(edges), not O(edges²) (#275)

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -786,6 +786,10 @@ OCCTMeshRef OCCTMeshCreateFromArrays(
 void OCCTShapeBuildCurves3d(OCCTShapeRef shape);
 
 /// Get discretized edge as polyline points
+///
+/// Rebuilds the shape's edge map on every call, so looping this over every edge is O(edges²) —
+/// use OCCTShapeComputeAllEdgePolylines for iterate-all-edges consumers (issue #275).
+///
 /// @param shape The shape containing edges
 /// @param edgeIndex Index of the edge (0-based)
 /// @param deflection Linear deflection for discretization
@@ -793,6 +797,37 @@ void OCCTShapeBuildCurves3d(OCCTShapeRef shape);
 /// @param maxPoints Maximum points to return
 /// @return Number of points written, or -1 on error
 int32_t OCCTShapeGetEdgePolyline(OCCTShapeRef shape, int32_t edgeIndex, double deflection, double* outPoints, int32_t maxPoints);
+
+// --- Bulk edge discretisation (handle-based) — issue #275 ---
+
+/// An immutable set of discretised edge polylines, computed in one pass.
+typedef struct OCCTEdgePolylines* OCCTEdgePolylinesRef;
+
+/// Discretise every edge of `shape` in a single pass, building the edge map once — O(edges),
+/// versus O(edges²) for an OCCTShapeGetEdgePolyline loop over the same shape.
+///
+/// Edge ordering matches OCCTShapeGetTotalEdgeCount / OCCTShapeGetEdgePolyline (the same
+/// TopExp::MapShapes ordering). Degenerate edges and edges that fail discretisation are kept as
+/// entries with a point count of 0, so indices stay aligned with the shape's edge indices.
+///
+/// @param shape The shape containing edges
+/// @param deflection Linear deflection for discretization
+/// @param maxPointsPerEdge Maximum points per edge (must be >= 2)
+/// @return A handle the caller must release with OCCTEdgePolylinesRelease, or NULL on error
+OCCTEdgePolylinesRef _Nullable OCCTShapeComputeAllEdgePolylines(OCCTShapeRef shape, double deflection, int32_t maxPointsPerEdge);
+
+/// Release a polyline set.
+void OCCTEdgePolylinesRelease(OCCTEdgePolylinesRef _Nullable polys);
+
+/// Number of edges in the set (matches the source shape's edge count).
+int32_t OCCTEdgePolylinesGetEdgeCount(OCCTEdgePolylinesRef _Nullable polys);
+
+/// Number of points for the edge at `edgeIndex` (0-based); 0 if degenerate or failed.
+int32_t OCCTEdgePolylinesGetPointCount(OCCTEdgePolylinesRef _Nullable polys, int32_t edgeIndex);
+
+/// Copy the edge's points as [x,y,z,...] into `outPoints` (caller allocates).
+/// @return Number of points written (never more than maxPoints), or 0.
+int32_t OCCTEdgePolylinesCopyPoints(OCCTEdgePolylinesRef _Nullable polys, int32_t edgeIndex, double* outPoints, int32_t maxPoints);
 
 // MARK: - Triangle Access
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
@@ -301,11 +301,87 @@ void OCCTShapeBuildCurves3d(OCCTShapeRef shape) {
     } catch (...) {}
 }
 
+namespace {
+
+/// Discretise one edge into `outPoints` (flat xyz triples). Returns points written, or -1.
+///
+/// `parentShape` + `fallbackMap` back the pcurve fallback: the edge→face ancestor map is built
+/// lazily on first use and reused across calls, so a bulk caller pays for it at most once
+/// (and not at all when no edge needs the fallback).
+int32_t DiscretizeEdgeInto(const TopoDS_Edge& edge,
+                           double deflection,
+                           int32_t maxPoints,
+                           const TopoDS_Shape& parentShape,
+                           std::unique_ptr<TopTools_IndexedDataMapOfShapeListOfShape>& fallbackMap,
+                           double* outPoints) {
+    // Skip degenerate edges (zero-length, e.g. poles of spheres)
+    if (BRep_Tool::Degenerated(edge)) return -1;
+
+    // Try primary path: BRepAdaptor_Curve + TangentialDeflection
+    try {
+        BRepAdaptor_Curve curve(edge);
+        GCPnts_TangentialDeflection discretizer(curve, deflection, 0.1);
+
+        if (discretizer.NbPoints() >= 2) {
+            int32_t numPoints = std::min(discretizer.NbPoints(), maxPoints);
+            for (int32_t i = 0; i < numPoints; i++) {
+                gp_Pnt pt = discretizer.Value(i + 1);
+                outPoints[i * 3 + 0] = pt.X();
+                outPoints[i * 3 + 1] = pt.Y();
+                outPoints[i * 3 + 2] = pt.Z();
+            }
+            return numPoints;
+        }
+    } catch (...) {
+        // BRepAdaptor_Curve failed — fall through to pcurve fallback
+    }
+
+    // Fallback: evaluate pcurve on parent surface
+    // Find a face that owns this edge and use its pcurve + surface
+    if (!fallbackMap) {
+        fallbackMap.reset(new TopTools_IndexedDataMapOfShapeListOfShape());
+        TopExp::MapShapesAndAncestors(parentShape, TopAbs_EDGE, TopAbs_FACE, *fallbackMap);
+    }
+
+    int32_t mapIndex = fallbackMap->FindIndex(edge);
+    if (mapIndex > 0) {
+        const TopTools_ListOfShape& faces = (*fallbackMap)(mapIndex);
+        if (!faces.IsEmpty()) {
+            TopoDS_Face face = TopoDS::Face(faces.First());
+            Standard_Real first, last;
+            Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(edge, face, first, last);
+            if (!pcurve.IsNull()) {
+                Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
+                if (!surface.IsNull()) {
+                    int32_t numPoints = std::min(maxPoints, (int32_t)50);
+                    if (numPoints < 2) numPoints = 2;
+                    for (int32_t i = 0; i < numPoints; i++) {
+                        double t = (numPoints == 1) ? first : first + (last - first) * i / (numPoints - 1);
+                        gp_Pnt2d uv = pcurve->Value(t);
+                        gp_Pnt pt;
+                        surface->D0(uv.X(), uv.Y(), pt);
+                        outPoints[i * 3 + 0] = pt.X();
+                        outPoints[i * 3 + 1] = pt.Y();
+                        outPoints[i * 3 + 2] = pt.Z();
+                    }
+                    return numPoints;
+                }
+            }
+        }
+    }
+
+    return -1;
+}
+
+}  // namespace
+
 int32_t OCCTShapeGetEdgePolyline(OCCTShapeRef shape, int32_t edgeIndex, double deflection, double* outPoints, int32_t maxPoints) {
     if (!shape || !outPoints || maxPoints < 2 || edgeIndex < 0) return -1;
 
     try {
-        // Use IndexedMap to match OCCTShapeGetTotalEdgeCount ordering
+        // Use IndexedMap to match OCCTShapeGetTotalEdgeCount ordering.
+        // NOTE: this rebuilds the map on every call — O(edges²) across a whole shape. Use
+        // OCCTShapeComputeAllEdgePolylines for iterate-all-edges consumers (issue #275).
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
@@ -313,64 +389,83 @@ int32_t OCCTShapeGetEdgePolyline(OCCTShapeRef shape, int32_t edgeIndex, double d
 
         TopoDS_Edge edge = TopoDS::Edge(edgeMap(edgeIndex + 1));  // OCCT is 1-based
 
-        // Skip degenerate edges (zero-length, e.g. poles of spheres)
-        if (BRep_Tool::Degenerated(edge)) return -1;
-
-        // Try primary path: BRepAdaptor_Curve + TangentialDeflection
-        try {
-            BRepAdaptor_Curve curve(edge);
-            GCPnts_TangentialDeflection discretizer(curve, deflection, 0.1);
-
-            if (discretizer.NbPoints() >= 2) {
-                int32_t numPoints = std::min(discretizer.NbPoints(), maxPoints);
-                for (int32_t i = 0; i < numPoints; i++) {
-                    gp_Pnt pt = discretizer.Value(i + 1);
-                    outPoints[i * 3 + 0] = pt.X();
-                    outPoints[i * 3 + 1] = pt.Y();
-                    outPoints[i * 3 + 2] = pt.Z();
-                }
-                return numPoints;
-            }
-        } catch (...) {
-            // BRepAdaptor_Curve failed — fall through to pcurve fallback
-        }
-
-        // Fallback: evaluate pcurve on parent surface
-        // Find a face that owns this edge and use its pcurve + surface
-        TopTools_IndexedDataMapOfShapeListOfShape edgeFaceMap;
-        TopExp::MapShapesAndAncestors(shape->shape, TopAbs_EDGE, TopAbs_FACE, edgeFaceMap);
-
-        int32_t mapIndex = edgeFaceMap.FindIndex(edge);
-        if (mapIndex > 0) {
-            const TopTools_ListOfShape& faces = edgeFaceMap(mapIndex);
-            if (!faces.IsEmpty()) {
-                TopoDS_Face face = TopoDS::Face(faces.First());
-                Standard_Real first, last;
-                Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(edge, face, first, last);
-                if (!pcurve.IsNull()) {
-                    Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
-                    if (!surface.IsNull()) {
-                        int32_t numPoints = std::min(maxPoints, (int32_t)50);
-                        if (numPoints < 2) numPoints = 2;
-                        for (int32_t i = 0; i < numPoints; i++) {
-                            double t = (numPoints == 1) ? first : first + (last - first) * i / (numPoints - 1);
-                            gp_Pnt2d uv = pcurve->Value(t);
-                            gp_Pnt pt;
-                            surface->D0(uv.X(), uv.Y(), pt);
-                            outPoints[i * 3 + 0] = pt.X();
-                            outPoints[i * 3 + 1] = pt.Y();
-                            outPoints[i * 3 + 2] = pt.Z();
-                        }
-                        return numPoints;
-                    }
-                }
-            }
-        }
-
-        return -1;
+        std::unique_ptr<TopTools_IndexedDataMapOfShapeListOfShape> fallbackMap;
+        return DiscretizeEdgeInto(edge, deflection, maxPoints, shape->shape, fallbackMap, outPoints);
     } catch (...) {
         return -1;
     }
+}
+
+// MARK: - Bulk Edge Discretization (issue #275)
+
+struct OCCTEdgePolylines {
+    std::vector<double> points;    // flat xyz triples, all edges concatenated
+    std::vector<int32_t> offsets;  // per-edge start index into `points`, in triples
+    std::vector<int32_t> counts;   // per-edge point count (0 = degenerate / failed)
+};
+
+OCCTEdgePolylinesRef OCCTShapeComputeAllEdgePolylines(OCCTShapeRef shape, double deflection, int32_t maxPointsPerEdge) {
+    if (!shape || maxPointsPerEdge < 2) return nullptr;
+
+    try {
+        // The whole point of this entry: build the edge map ONCE, then walk it.
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
+        const int32_t edgeCount = edgeMap.Extent();
+
+        std::unique_ptr<OCCTEdgePolylines> result(new OCCTEdgePolylines());
+        result->offsets.reserve(edgeCount);
+        result->counts.reserve(edgeCount);
+
+        std::unique_ptr<TopTools_IndexedDataMapOfShapeListOfShape> fallbackMap;
+        std::vector<double> scratch(static_cast<size_t>(maxPointsPerEdge) * 3);
+
+        for (int32_t i = 1; i <= edgeCount; i++) {  // OCCT is 1-based
+            TopoDS_Edge edge = TopoDS::Edge(edgeMap(i));
+            int32_t n = DiscretizeEdgeInto(edge, deflection, maxPointsPerEdge, shape->shape,
+                                           fallbackMap, scratch.data());
+            if (n <= 0) {
+                result->offsets.push_back(0);
+                result->counts.push_back(0);
+                continue;
+            }
+            result->offsets.push_back(static_cast<int32_t>(result->points.size() / 3));
+            result->counts.push_back(n);
+            result->points.insert(result->points.end(), scratch.begin(), scratch.begin() + static_cast<size_t>(n) * 3);
+        }
+
+        return result.release();
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void OCCTEdgePolylinesRelease(OCCTEdgePolylinesRef polys) {
+    delete polys;
+}
+
+int32_t OCCTEdgePolylinesGetEdgeCount(OCCTEdgePolylinesRef polys) {
+    if (!polys) return 0;
+    return static_cast<int32_t>(polys->counts.size());
+}
+
+int32_t OCCTEdgePolylinesGetPointCount(OCCTEdgePolylinesRef polys, int32_t edgeIndex) {
+    if (!polys || edgeIndex < 0 || edgeIndex >= static_cast<int32_t>(polys->counts.size())) return 0;
+    return polys->counts[edgeIndex];
+}
+
+int32_t OCCTEdgePolylinesCopyPoints(OCCTEdgePolylinesRef polys, int32_t edgeIndex, double* outPoints, int32_t maxPoints) {
+    if (!polys || !outPoints || maxPoints < 1) return 0;
+    if (edgeIndex < 0 || edgeIndex >= static_cast<int32_t>(polys->counts.size())) return 0;
+
+    const int32_t n = std::min(polys->counts[edgeIndex], maxPoints);
+    if (n <= 0) return 0;
+
+    const size_t start = static_cast<size_t>(polys->offsets[edgeIndex]) * 3;
+    std::copy(polys->points.begin() + start,
+              polys->points.begin() + start + static_cast<size_t>(n) * 3,
+              outPoints);
+    return n;
 }
 
 // MARK: - Direct Triangle Access

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -858,12 +858,13 @@ public final class Shape: @unchecked Sendable {
 
     /// Get all edges as discretized polylines.
     ///
-    /// Convenience method that calls `edgePolyline` for each edge in the shape.
+    /// Discretizes every edge in a single bridge pass. Edges that fail discretization
+    /// (including degenerate ones) are skipped.
     ///
     /// - Parameters:
     ///   - deflection: Maximum chord deviation
     ///   - maxPointsPerEdge: Maximum points per edge
-    /// - Returns: Array of polylines, one per edge
+    /// - Returns: Array of polylines, one per successfully discretized edge
     public func allEdgePolylines(
         deflection: Double = 0.1,
         maxPointsPerEdge: Int = 1000
@@ -872,14 +873,35 @@ public final class Shape: @unchecked Sendable {
         // have pcurves; this ensures explicit 3D curves exist before discretization.
         OCCTShapeBuildCurves3d(handle)
 
-        let count = Int(OCCTShapeGetTotalEdgeCount(handle))
+        // One bulk pass: the bridge builds the edge map once. Looping `edgePolyline(at:)`
+        // instead rebuilds it per call, making this O(edges²) — 20 s for a 12k-edge shell,
+        // and unusable on mesh-scale shapes (issue #275).
+        guard maxPointsPerEdge >= 2,
+              let polys = OCCTShapeComputeAllEdgePolylines(handle, deflection, Int32(maxPointsPerEdge))
+        else { return [] }
+        defer { OCCTEdgePolylinesRelease(polys) }
+
+        let count = Int(OCCTEdgePolylinesGetEdgeCount(polys))
         var result: [[SIMD3<Double>]] = []
         result.reserveCapacity(count)
 
+        var scratch = [Double](repeating: 0, count: maxPointsPerEdge * 3)
         for i in 0..<count {
-            if let polyline = edgePolyline(at: i, deflection: deflection, maxPoints: maxPointsPerEdge) {
-                result.append(polyline)
+            let written = scratch.withUnsafeMutableBufferPointer { buffer in
+                Int(OCCTEdgePolylinesCopyPoints(polys, Int32(i), buffer.baseAddress, Int32(maxPointsPerEdge)))
             }
+            guard written > 0 else { continue }  // degenerate / failed — skipped, as before
+
+            var polyline: [SIMD3<Double>] = []
+            polyline.reserveCapacity(written)
+            for j in 0..<written {
+                polyline.append(SIMD3(
+                    scratch[j * 3],
+                    scratch[j * 3 + 1],
+                    scratch[j * 3 + 2]
+                ))
+            }
+            result.append(polyline)
         }
 
         return result

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -315,6 +315,79 @@ struct EdgeDiscretizationTests {
         let polyline = box.edgePolyline(at: 100, deflection: 0.1)
         #expect(polyline == nil)
     }
+
+    // MARK: - Bulk edge discretisation (#275)
+
+    /// The bulk path must agree point-for-point with the per-index accessor it replaced —
+    /// same edge ordering, same discretisation, same skip behaviour.
+    @Test("Bulk allEdgePolylines matches the per-index accessor exactly")
+    func bulkEdgePolylinesMatchPerIndex() {
+        // A box (planar edges) and a cylinder (curved edges + the seam) cover both the
+        // BRepAdaptor_Curve path and multi-point discretisation.
+        for shape in [Shape.box(width: 10, height: 10, depth: 10)!,
+                      Shape.cylinder(radius: 5, height: 20)!] {
+            let bulk = shape.allEdgePolylines(deflection: 0.1)
+
+            var perIndex: [[SIMD3<Double>]] = []
+            for i in 0..<shape.edgeCount {
+                if let poly = shape.edgePolyline(at: i, deflection: 0.1, maxPoints: 1000) {
+                    perIndex.append(poly)
+                }
+            }
+
+            #expect(bulk.count == perIndex.count)
+            for (b, p) in zip(bulk, perIndex) {
+                #expect(b.count == p.count)
+                for (bp, pp) in zip(b, p) {
+                    #expect(bp.x == pp.x)
+                    #expect(bp.y == pp.y)
+                    #expect(bp.z == pp.z)
+                }
+            }
+        }
+    }
+
+    /// Regression guard for #275: `allEdgePolylines` must scale ~linearly in edge count.
+    ///
+    /// The old implementation rebuilt the full `TopTools_IndexedMapOfShape` inside every
+    /// per-index call, so total work grew quadratically (measured on the issue: 800 edges
+    /// 0.11 s → 3,136 edges 1.29 s → 12,033 edges 20.3 s). We compare per-edge cost between
+    /// a small and a ~10x larger shape: linear keeps the ratio ~flat, quadratic makes it grow
+    /// with the edge count. The bound is deliberately loose (8x) so this asserts the
+    /// complexity class, not wall-clock — it should not go red on a slow or busy machine.
+    @Test("allEdgePolylines scales linearly, not quadratically, in edge count")
+    func allEdgePolylinesScalesLinearly() {
+        func perEdgeCost(gridSide: Int) -> (cost: Double, edges: Int) {
+            // A compound of many small boxes: edge count scales with the box count, and
+            // every edge is independent, so total work should be linear in edges.
+            var boxes: [Shape] = []
+            for i in 0..<gridSide {
+                for j in 0..<gridSide {
+                    boxes.append(Shape.box(width: 1, height: 1, depth: 1)!
+                        .translated(by: SIMD3(Double(i) * 2, Double(j) * 2, 0))!)
+                }
+            }
+            let compound = Shape.compound(boxes)!
+            let edges = compound.edgeCount
+
+            let start = Date()
+            let polylines = compound.allEdgePolylines(deflection: 0.1)
+            let elapsed = Date().timeIntervalSince(start)
+
+            #expect(polylines.count == edges)
+            return (elapsed / Double(edges), edges)
+        }
+
+        let small = perEdgeCost(gridSide: 3)    // 9 boxes   → 108 edges
+        let large = perEdgeCost(gridSide: 10)   // 100 boxes → 1200 edges
+
+        // Sanity: the large case really is ~10x the edges, or the guard proves nothing.
+        #expect(large.edges > small.edges * 5)
+
+        // Linear → per-edge cost stays roughly constant. Quadratic → it grows ~11x here.
+        #expect(large.cost < small.cost * 8,
+                "per-edge cost grew \(large.cost / small.cost)x from \(small.edges) to \(large.edges) edges — allEdgePolylines looks quadratic again (#275)")
+    }
 }
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,42 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.8.8
+## Current: v1.9.0
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.9.0 (July 2026) — perf: `allEdgePolylines` is O(edges), not O(edges²) (#275)
+
+`Shape.allEdgePolylines` looped `edgePolyline(at:)`, and every one of those calls rebuilt the shape's
+full `TopTools_IndexedMapOfShape` — so extracting a wireframe was quadratic in edge count. Measured on
+a box compound: **12,288 edges went from 15.5 s to 0.017 s (~900x)**; 3,072 edges from 0.93 s to
+0.004 s. The old cost curve made mesh-scale shapes effectively unusable (an STL lands one face per
+facet, so a 442k-triangle scan is ~1.3M edges), which is what forced OCCTMCP to route around the
+bridge in v1.13.0 (OCCTMCP#75/#77).
+
+The bridge now discretises every edge in one pass, building the edge map once:
+
+- **New C API** — `OCCTShapeComputeAllEdgePolylines(shape, deflection, maxPointsPerEdge)` returns an
+  `OCCTEdgePolylinesRef` handle, read via `OCCTEdgePolylinesGetEdgeCount` / `…GetPointCount` /
+  `…CopyPoints` and freed with `OCCTEdgePolylinesRelease`. Edge ordering matches
+  `OCCTShapeGetTotalEdgeCount` / `OCCTShapeGetEdgePolyline`; failed/degenerate edges are retained as
+  0-point entries so indices stay aligned with the shape's edge indices.
+- The pcurve fallback's edge→face ancestor map is now also built at most once per call, instead of
+  once per edge that needs it.
+
+**No Swift API change.** `allEdgePolylines`' signature, ordering and skip-on-failure behaviour are
+unchanged — output is byte-identical to the old per-index path (covered by a parity test over box and
+cylinder), just dramatically faster. `edgePolyline(at:)` is unchanged and still rebuilds the map per
+call; it is now documented as one-off-lookup only. Bumped **MINOR** per the cohort SemVer policy: new
+C surface, additive.
+
+This fixes the `allEdgePolylines` hot path only — the ~24 other per-index accessors (`edge(at:)`,
+face/vertex variants) still rebuild their maps per call. Caching the map on `OCCTShape` with
+mutation-invalidation is the structural fix, left open on #275.
 
 ### v1.8.8 (July 2026) — feat: close the face-analysis tail (#266 follow-up, 6 ops)
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1304,6 +1304,7 @@ Adaptively samples points along a B-Rep edge using curvature-based deflection co
   }
   ```
 - **Note:** Edge indices may vary between runs for complex shapes; iterate to find a working index.
+- **Performance:** This rebuilds the shape's edge map on every call. Use it for one-off lookups; to walk every edge use [`allEdgePolylines(deflection:maxPointsPerEdge:)`](#alledgepolylinesdeflectionmaxpointsperedge), which builds the map once — looping this instead is O(edges²) ([#275](https://github.com/SecondMouseAU/OCCTSwift/issues/275)).
 
 ---
 
@@ -1318,13 +1319,14 @@ public func allEdgePolylines(
 ) -> [[SIMD3<Double>]]
 ```
 
-Calls `edgePolyline` for each edge in the shape. Also calls `OCCTShapeBuildCurves3d` beforehand to ensure lofted/swept shapes (which may have only pcurves) have explicit 3D curves before discretisation.
+Discretises every edge in a single bridge pass, building the shape's edge map once. Also calls `OCCTShapeBuildCurves3d` beforehand to ensure lofted/swept shapes (which may have only pcurves) have explicit 3D curves before discretisation.
 
 - **Parameters:**
   - `deflection` — maximum chord deviation per edge.
-  - `maxPointsPerEdge` — maximum points per edge.
-- **Returns:** Array of polylines, one per edge. Edges that fail discretisation are skipped.
-- **OCCT:** `BRepLib::BuildCurves3d` + `GCPnts_TangentialDeflection` (via `OCCTShapeBuildCurves3d` and `OCCTShapeGetEdgePolyline`).
+  - `maxPointsPerEdge` — maximum points per edge (values below 2 return `[]`).
+- **Returns:** Array of polylines, one per edge. Edges that fail discretisation (including degenerate ones) are skipped.
+- **OCCT:** `BRepLib::BuildCurves3d` + `GCPnts_TangentialDeflection` (via `OCCTShapeBuildCurves3d` and `OCCTShapeComputeAllEdgePolylines`).
+- **Performance:** Prefer this over a `for i in 0..<shape.edgeCount { shape.edgePolyline(at: i) }` loop. `edgePolyline(at:)` rebuilds the edge map on every call, so that loop is O(edges²) — 15 s for a 12k-edge shape, versus 0.02 s here ([#275](https://github.com/SecondMouseAU/OCCTSwift/issues/275)).
 - **Example:**
   ```swift
   let wireframe = shape.allEdgePolylines(deflection: 0.05)


### PR DESCRIPTION
Closes #275.

`Shape.allEdgePolylines` looped `edgePolyline(at:)`, and every one of those calls rebuilt the shape's full `TopTools_IndexedMapOfShape` — so extracting a wireframe was quadratic in edge count.

Measured on a box compound, bulk vs the old per-index loop:

| edges | old loop | new bulk | speedup |
|---:|---:|---:|---:|
| 972 | 0.088 s | 0.002 s | 57x |
| 3,072 | 0.925 s | 0.004 s | 219x |
| 12,288 | **15.476 s** | **0.017 s** | **903x** |

which tracks the issue's own numbers (12,033 edges → 20.3 s).

## What changed

The bridge now discretises every edge in one pass, building the edge map once:

- **New C API** — `OCCTShapeComputeAllEdgePolylines(shape, deflection, maxPointsPerEdge)` returns an `OCCTEdgePolylinesRef` handle, read via `OCCTEdgePolylinesGetEdgeCount` / `…GetPointCount` / `…CopyPoints`, freed with `OCCTEdgePolylinesRelease`. Follows the existing `OCCTFreeBoundsProps` compute-once-handle pattern already in this bridge.
- Per-edge discretisation logic is now **shared** with `OCCTShapeGetEdgePolyline` instead of duplicated, so the two paths can't drift.
- The pcurve fallback's edge→face ancestor map (`MapShapesAndAncestors`, itself expensive) is now built at most once per call rather than once per edge that needs it.

**No Swift API change.** `allEdgePolylines`' signature, ordering and skip-on-failure behaviour are unchanged; output is byte-identical to the old per-index path. `edgePolyline(at:)` is untouched and still rebuilds the map per call — now documented as one-off-lookup only.

## Tests

- **Parity** — bulk output matches the per-index accessor point-for-point over box + cylinder (covers the `BRepAdaptor_Curve` path and multi-point discretisation).
- **Scaling guard** — compares per-edge cost across a ~11x edge-count jump. I verified this test **fails against the old quadratic implementation** and passes against this one, so it's a real guard rather than a passing decoration. Bound is loose (8x) so it asserts complexity class, not wall-clock.

## Scope

Fixes the `allEdgePolylines` hot path only — the small, safe win from the issue's option (1). The ~24 other per-index accessors (`edge(at:)`, face/vertex variants) still rebuild their maps per call; caching the map on `OCCTShape` with mutation-invalidation is option (2), the structural fix, left open on #275.

## Test suite status

Full suite: 4,356 tests, 2 pre-existing failures, both verified **not** caused by this change:
- `cone()` (STEP round-trip) — clean `main` fails it with byte-identical values (0.628 / 0.716 / 2≠3).
- `materializeAll()` — a pre-existing flake: it failed in only one of two runs on *identical* code here, and not on clean `main`. Root cause is unrelated to this PR (`DocumentAssociatedStorage` keys on `ObjectIdentifier`, i.e. the instance pointer, so a new `Document` at a recycled address inherits the previous one's `ConstructionContext`). Filed separately.