### PR TITLE
fix: clear the construction-context association on Document deinit (#277)

### DIFF
--- a/Sources/OCCTSwift/ConstructionContext.swift
+++ b/Sources/OCCTSwift/ConstructionContext.swift
@@ -232,12 +232,32 @@ extension Document {
         return new
     }
 
-    // Weak-key associated storage for construction contexts, since Document is
-    // a final class we can't extend with stored properties. Uses ObjectIdentifier
-    // keyed on the instance pointer; cleans up when the Document deinits.
+    /// Drop this document's associated construction context. Called from `Document.deinit`.
+    ///
+    /// This is not optional bookkeeping: the association is keyed on `ObjectIdentifier`, which is
+    /// the instance pointer and is therefore only unique among *live* objects. If the entry
+    /// outlives the document, the next `Document` allocated at the recycled address resolves to
+    /// this one's context and silently inherits its entities (#277).
+    internal func releaseConstructionContext() {
+        Self.constructionContextStorage.clear(for: self)
+    }
+
+    // Associated storage for construction contexts, since Document is a final class we can't
+    // extend with stored properties. Strongly keyed on ObjectIdentifier (the instance pointer);
+    // entries are removed in `Document.deinit` via `releaseConstructionContext()` — see #277 for
+    // why that cleanup is load-bearing rather than mere tidiness.
     fileprivate static let constructionContextStorage = DocumentAssociatedStorage<ConstructionContext>()
 }
 
+/// Side-table associating a value with an object, for final classes that can't take stored
+/// properties via an extension.
+///
+/// - Important: keys are `ObjectIdentifier`, i.e. the raw instance pointer, which is unique only
+///   among **live** objects. Owners MUST call ``clear(for:)`` from their `deinit`. An entry that
+///   outlives its owner is not merely a leak — the allocator readily hands the same address to the
+///   next instance, which then resolves to the dead owner's value and inherits its state. This is
+///   not theoretical: it shipped, and in a tight create/destroy loop *every* new instance inherited
+///   its predecessor's context (#277).
 internal final class DocumentAssociatedStorage<T: AnyObject>: @unchecked Sendable {
     private let lock = NSLock()
     private var table: [ObjectIdentifier: T] = [:]

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -19,6 +19,9 @@ public final class Document: @unchecked Sendable {
     }
 
     deinit {
+        // Must happen before this instance's memory can be recycled — the construction-context
+        // association is keyed on the instance pointer (#277).
+        releaseConstructionContext()
         OCCTDocumentRelease(handle)
     }
 

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -370,6 +370,36 @@ struct ConstructionLayerTests {
         // Each materialized shape shows up on the CONSTRUCTION layer.
         #expect(doc.constructionShapeLabels.count >= 3)
     }
+
+    /// Regression guard for #277.
+    ///
+    /// `Document.constructionContext` is associated via a table keyed on
+    /// `ObjectIdentifier(document)` — i.e. the instance pointer, which is only unique among
+    /// *live* objects. The entry used to never be removed, so once a Document died its context
+    /// stayed in the table; a later Document allocated at the recycled address would then
+    /// inherit the dead one's entities. That surfaced as intermittent failures in
+    /// `materializeAll()` above (4 entities materialized where the test added 3).
+    ///
+    /// Every freshly created Document must start with an empty context, always.
+    @Test("A fresh Document never inherits a dead Document's construction context (#277)")
+    func constructionContextDoesNotLeakAcrossDocuments() {
+        for i in 0..<200 {
+            autoreleasepool {
+                guard let doc = Document.create() else {
+                    Issue.record("Document.create() returned nil"); return
+                }
+                let ctx = doc.constructionContext
+
+                #expect(ctx.count == (planes: 0, axes: 0, points: 0),
+                        "iteration \(i): a fresh Document inherited a dead Document's construction context (#277)")
+
+                // Populate, then let the document die at scope exit so the next iteration is
+                // very likely to reuse this address.
+                _ = ctx.add(.absolute(SIMD3(1, 2, 3)), name: "origin")
+                _ = ctx.add(.absolute(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1)), name: "XY")
+            }
+        }
+    }
 }
 
 // MARK: - v0.145 #76: Sheet templates, title blocks, projection symbols

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,35 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.9.0
+## Current: v1.9.1
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.9.1 (July 2026) — fix: a new Document could inherit a dead Document's construction context (#277)
+
+`Document.constructionContext` is resolved through a side table keyed on `ObjectIdentifier(document)`
+— the raw instance pointer, which is unique only among **live** objects. The entry was never removed
+(a `clear(for:)` existed but was never wired to `Document.deinit`), so a context outlived its
+document; the allocator then readily handed the same address to the next `Document`, which resolved
+to the dead one's context and silently inherited its entities.
+
+This was not a rare race. In a tight create/destroy loop **every** new `Document` reused the address
+and accumulated its predecessors' entities monotonically (1 → 2 → 3 → …). It surfaced as an
+intermittent failure in the `materializeAll()` test — 4 entities materialized where 3 were added — but
+the same fault hits any app that creates and releases documents over its lifetime: fresh documents
+silently carrying dead ones' construction geometry, plus an unbounded leak of every
+`ConstructionContext` ever created.
+
+`Document.deinit` now clears the association before the instance's memory can be recycled. No API
+change — the documented guarantee (one context per `Document` instance, released with it) is simply
+true now. `DocumentAssociatedStorage` carries a warning that owners must clear on `deinit`, since the
+pattern silently reintroduces this if they don't.
+
+Bumped **PATCH** per the cohort SemVer policy: bug fix, no public API change.
 
 ### v1.9.0 (July 2026) — perf: `allEdgePolylines` is O(edges), not O(edges²) (#275)
 

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -774,6 +774,7 @@ public var constructionContext: ConstructionContext { get }
 
 Construction entities live alongside the document's shapes but are not part of the XDE shape tree. Each `Document` instance gets exactly one `ConstructionContext`; repeated access returns the same object.
 
+- **Lifetime:** the context is tied to the `Document` instance and is released with it. A newly created `Document` always starts with an empty context, and its entities are never visible to any other document. (Before v1.9.1 this did not hold — see [#277](https://github.com/SecondMouseAU/OCCTSwift/issues/277).)
 - **Example:**
   ```swift
   let doc = Document()


### PR DESCRIPTION
Closes #277.

## The bug

`Document.constructionContext` resolves through a side table keyed on `ObjectIdentifier(document)` — the raw instance pointer, which is unique only among **live** objects.

The entry was never removed. `DocumentAssociatedStorage` had a `clear(for:)` and a comment claiming it *"cleans up when the Document deinits"* — but nothing ever called it, and `Document.deinit` only released the OCCT handle. So a context outlived its document, and the allocator readily handed the same address to the next `Document`, which resolved to the dead one's context and silently inherited its entities.

(The old comment was doubly wrong: the table is neither weak-keyed nor self-cleaning.)

## Severity — worse than the issue described

I filed #277 calling this an intermittent flake. Reproducing it properly showed it's deterministic under load: in a tight create/destroy loop **every** new `Document` reuses the address and accumulates its predecessors' entities monotonically:

```
iteration 1: ctx.count → (planes: 1, axes: 0, points: 1)   // expected all-zero
iteration 2: ctx.count → (planes: 2, axes: 0, points: 2)
iteration 3: ctx.count → (planes: 3, axes: 0, points: 3)
...
```

The `materializeAll()` test flake (4 entities materialized where 3 were added) was just where it happened to surface. The same fault hits **any app that creates and releases documents over its lifetime** — fresh documents silently carrying dead ones' construction geometry — plus an unbounded leak of every `ConstructionContext` ever created.

## The fix

`Document.deinit` now clears the association before the instance's memory can be recycled.

No API change — the guarantee the docs already promised (*"Each `Document` instance gets exactly one `ConstructionContext`"*) is simply true now. I picked the explicit deinit hook over `NSMapTable` weak keys or `objc_setAssociatedObject`: it's deterministic, purges immediately rather than on next table mutation, and needs no ObjC-runtime dependency.

`DocumentAssociatedStorage`'s doc comment now states that owners MUST clear on `deinit`, and why — the pattern silently reintroduces this otherwise. It has exactly one user today (verified), so the fix's scope is complete.

## Tests

200 create/populate/destroy cycles asserting every fresh `Document` starts with an empty context. **Verified to fail against the unfixed code** (the climbing counts above) and pass against this — a real guard, not a passing decoration.

Full suite: 4,357 tests, 1 pre-existing unrelated failure (`cone()`, which fails identically on clean `main`). `materializeAll()` no longer flakes.