### PR TITLE
test(#280): pin down the CAF-read → STEP-write corruption as a known issue

### DIFF
--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -1910,3 +1910,75 @@ struct SVGWriterTests {
         #expect(content.contains("297"))
     }
 }
+
+// MARK: - #280: a CAF STEP read corrupts later shape-level STEP writes
+
+@Suite("STEP writer corruption after a CAF read (#280)")
+struct STEPWriterCAFCorruptionTests {
+
+    /// Round-trip a frustum (3 faces: lateral cone + two discs) and report what survives.
+    private func coneRoundTrip(_ tag: String) throws -> (faces: Int, volume: Double, conicalInFile: Int) {
+        let cone = Shape.cone(bottomRadius: 5, topRadius: 2, height: 10)!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt-280-\(tag)-\(UUID().uuidString).step")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Exporter.writeSTEP(shape: cone, to: url, modelType: .asIs)
+        let text = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let reimported = try Shape.load(from: url)
+        return (
+            faces: reimported.subShapeCount(ofType: .face),
+            volume: reimported.volume ?? 0,
+            conicalInFile: text.components(separatedBy: "CONICAL_SURFACE").count - 1
+        )
+    }
+
+    /// Regression guard for #280 (currently a known issue — see below).
+    ///
+    /// Merely constructing a `STEPCAFControl_Reader` — i.e. any XDE STEP read, such as
+    /// `Document.loadSTEP` — permanently corrupts every later shape-level STEP write in the
+    /// process: the frustum's periodic conical face is silently dropped from the written file,
+    /// leaving a 2-face solid missing 63% of its volume that still reports `isValid == true`.
+    ///
+    /// The mechanism is NOT understood. Ruled out empirically (#280): the controller name
+    /// registration (pinning/re-recording the plain `STEPControl_Controller` changes nothing) and
+    /// `Interface_Static` (values are byte-identical between a good and a corrupted write). No
+    /// `StepModelType` dodges it. Suspected upstream OCCT 8.0.0p1.
+    ///
+    /// A write must not care what was read earlier in the process. This is also the real cause of
+    /// the long-standing `cone()` failure in OCCTStressTests, which passes in isolation and fails
+    /// in a full run purely because OCCTIOTests does a CAF read first.
+    @Test("A CAF STEP read must not corrupt later shape-level STEP writes")
+    func cafReadDoesNotPoisonShapeWriter() throws {
+        let analyticVolume = (Double.pi * 10 / 3) * (25 + 10 + 4)   // 130π ≈ 408.407
+
+        // Do the CAF read ourselves so the test is self-contained. Note we deliberately do NOT
+        // assert a clean "before" baseline: the poison is process-wide and permanent, and in a
+        // full run another suite's CAF read has usually already tripped it before we get here —
+        // a baseline assertion would make this test order-dependent (and fail for the wrong
+        // reason). The invariant below holds regardless of what ran earlier.
+        let box = Shape.box(width: 10, height: 20, depth: 30)!
+        let boxURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt-280-poison-\(UUID().uuidString).step")
+        defer { try? FileManager.default.removeItem(at: boxURL) }
+        try box.writeSTEP(to: boxURL)
+        #expect(Document.loadSTEP(from: boxURL, modes: STEPReaderModes()) != nil)
+
+        // KNOWN ISSUE (#280) — unfixed. Wrapped so it documents the bug without adding a red
+        // test, and so this flips to an *unexpected pass* (a failure telling you to delete this
+        // wrapper) the moment the underlying bug is fixed.
+        //
+        // Mechanism is still unknown: it is NOT the controller name registration and NOT
+        // Interface_Static (both ruled out empirically — see #280). Trigger is narrowed to the
+        // mere construction of a STEPCAFControl_Reader. Suspected upstream OCCT 8.0.0p1.
+        try withKnownIssue("#280: a CAF STEP read corrupts later shape-level STEP writes") {
+            let after = try coneRoundTrip("after")
+            #expect(after.conicalInFile == 1,
+                    "CONICAL_SURFACE dropped from the written file (#280)")
+            #expect(after.faces == 3,
+                    "frustum lost a face: \(after.faces) (#280)")
+            #expect(abs(after.volume - analyticVolume) / analyticVolume < 0.01,
+                    "frustum volume corrupted: \(after.volume) vs \(analyticVolume) (#280)")
+        }
+    }
+}


### PR DESCRIPTION
Refs #280. **Does not fix it** — this lands the investigation as an executable, self-contained reproduction.

## What this documents

Constructing a `STEPCAFControl_Reader` — i.e. any `Document.loadSTEP` — permanently corrupts **every later shape-level STEP write in the process**. The frustum's periodic conical face is silently dropped from the written file:

| | before | after |
|---|---:|---:|
| `CONICAL_SURFACE` in file | 1 | **0** |
| `ADVANCED_FACE` | 3 | **2** |
| `LINE` (seam edges) | 5 | **0** |
| volume | 408.407 | **151.844** |
| `isValid` | true | **true** (!) |

Only the two planar discs survive. Read a STEP, write a STEP, geometry is silently corrupted — an ordinary app sequence.

## This is the real cause of the `cone()` "flake"

`cone()` in `StressFormatRoundTripTests` fails on every full run and passes in isolation, purely because `OCCTIOTests` does a CAF read first. **It is not flaky and should not be quarantined or deleted — it is correctly reporting this bug.** It has been ambient noise that everyone steps around; it's a real defect.

## Why `withKnownIssue`

It documents the defect without adding a red test, and flips to an *unexpected pass* — a failure telling you to delete the wrapper — the moment the bug is fixed. Full suite: 4,359 tests, 3 real failures (only `cone()`, unchanged), plus 3 known issues from this test.

## What I ruled out (so nobody re-treads it)

I originally filed #280 with a confident root cause — the CAF controller re-registering under the global `"STEP"` name so `STEPControl_Writer::SelectNorm("STEP")` picks up the CAF `ActorWrite`. **That theory is disproven** and the issue body has been corrected:

- **Not the controller registration** — pinning the plain `STEPControl_Controller` on the writer's own session, setting it *after* construction, and re-`AutoRecord()`ing it under `"STEP"` all change nothing.
- **Not `Interface_Static`** — every write-related value is byte-identical between a good write and a corrupted one (`write.step.schema=AP214IS`, `write.surfacecurve.mode=On`, `write.step.sequence=ToSTEP`, …).
- **Not `StepModelType`** — `asIs` / `manifoldSolidBrep` / `shellBasedSurfaceModel` all corrupt identically.
- **Trigger narrowed to construction alone** — no `ReadFile`, no `Transfer`, no document. `Document.create()` (XCAF init) does not trip it.

The dropped face is the periodic/seam-bearing one, which hints at closed-face shape processing rather than anything schema/unit related. Every lever available at our layer has been tried; this looks like **upstream OCCT 8.0.0p1** and likely needs an upstream report or a dig into `XSAlgo`/`ShapeProcess` internals the bundled headers don't expose.

## Test design note

It deliberately asserts no clean "before" baseline. The poison is process-wide and permanent, so in a full run another suite has usually already tripped it — a baseline assertion made the test order-dependent and fail for the wrong reason (caught in a full-suite run before landing).