### PR TITLE
fix: an XDE STEP read silently corrupted every later STEP write (#280)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -20,6 +20,8 @@
 #include <Standard_ErrorHandler.hxx>   // OCC_CATCH_SIGNALS (#175)
 #include <STEPControl_Reader.hxx>
 #include <STEPControl_Writer.hxx>
+#include <STEPControl_Controller.hxx>
+#include <XSControl_WorkSession.hxx>
 #include <STEPControl_StepModelType.hxx>
 #include <STEPCAFControl_Reader.hxx>
 #include <STEPCAFControl_Writer.hxx>
@@ -104,6 +106,48 @@ bool OCCTExportSTLWithMode(OCCTShapeRef shape, const char* path, double deflecti
     }
 }
 
+
+namespace {
+
+/// Repair the STEP writer's shape-processing config, which an XDE read silently breaks.
+///
+/// Upstream OCCT bug (8.0.0p1). `STEPCAFControl_Controller`'s constructor replaces the actor
+/// its base class just configured:
+///
+///     STEPControl_Controller::STEPControl_Controller() {          // base: configures its actor
+///       ActWrite->SetShapeProcessFlags({SplitCommonVertex, DirectFaces});
+///     }
+///     STEPCAFControl_Controller::STEPCAFControl_Controller() {    // derived: overwrites it,
+///       myAdaptorWrite = new STEPCAFControl_ActorWrite;           // and configures nothing
+///     }
+///
+/// `STEPCAFControl_Controller::Init()` then `AutoRecord()`s that controller under the *same*
+/// "STEP"/"step" names as the plain one, and `STEPControl_Writer::SetWS()` unconditionally does
+/// `SelectNorm("STEP")` — so after any XDE STEP read (`Document.loadSTEP`, i.e. a
+/// `STEPCAFControl_Reader` merely being constructed) every shape-level write resolves to an actor
+/// with EMPTY OperationsFlags. `DirectFaces` therefore never runs, and faces built on indirect
+/// (left-handed) surfaces are silently dropped: a cone frustum writes as a 2-face solid missing
+/// its lateral CONICAL_SURFACE and 63% of its volume, still reporting `isValid == true`.
+///
+/// Isolated to exactly that flag: applying `DirectFaces` alone fixes it; `SplitCommonVertex` alone
+/// does not, and the ShapeFix parameters are irrelevant. See SecondMouseAU/OCCTSwift#280.
+///
+/// FIXED UPSTREAM, NOT IN OUR BUILD: OCCT PR #1334 ("Data Exchange - initialize STEP writer healing
+/// parameters", merged 2026-07-10) added an `InitializeMissingParameters()` call to
+/// `STEPControl_Writer::Transfer`, which restores exactly these flags. Our pinned V8_0_0_p1 (tagged
+/// 2026-06-16) *defines* that method but never calls it — it is dead code there — and it is
+/// `private`, so we cannot invoke it ourselves. Retire this workaround once the bundled OCCT moves
+/// past that commit; the test in OCCTIOTests covers the behaviour either way.
+///
+/// Installing a freshly-constructed plain controller restores the configuration the writer should
+/// have had. The session is created fresh per write, so this has no global effect. Document-level
+/// writes are unaffected — they use `STEPCAFControl_Writer` and want the CAF actor.
+void repairSTEPWriterActor(STEPControl_Writer& writer) {
+    writer.WS()->SetController(new STEPControl_Controller);
+}
+
+}  // namespace
+
 bool OCCTExportSTEP(OCCTShapeRef shape, const char* path) {
     if (!shape || !path) return false;
 
@@ -114,6 +158,7 @@ bool OCCTExportSTEP(OCCTShapeRef shape, const char* path) {
         bool success = false;
         {
             STEPControl_Writer writer;
+            repairSTEPWriterActor(writer);   // #280
             Interface_Static::SetCVal("write.step.schema", "AP214");
 
             IFSelect_ReturnStatus status = writer.Transfer(shape->shape, STEPControl_AsIs);
@@ -140,6 +185,7 @@ bool OCCTExportSTEPWithName(OCCTShapeRef shape, const char* path, const char* na
         bool success = false;
         {
             STEPControl_Writer writer;
+            repairSTEPWriterActor(writer);   // #280
             Interface_Static::SetCVal("write.step.schema", "AP214");
             if (name) {
                 Interface_Static::SetCVal("write.step.product.name", name);
@@ -422,6 +468,7 @@ bool OCCTExportSTEPProgress(OCCTShapeRef shape, const char* path,
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
+        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
         Message_ProgressRange range = indicator->Start();
@@ -438,6 +485,7 @@ bool OCCTExportSTEPWithModeProgress(OCCTShapeRef shape, const char* path, int32_
     if (!shape || !path) return false;
     try {
         STEPControl_Writer writer;
+        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
         Message_ProgressRange range = indicator->Start();
@@ -729,6 +777,7 @@ bool OCCTStepTidyOptimize(const char* inputPath, const char* outputPath) {
         reader.TransferRoots();
 
         STEPControl_Writer writer;
+        repairSTEPWriterActor(writer);   // #280
         for (int i = 1; i <= reader.NbShapes(); i++) {
             writer.Transfer(reader.Shape(i), STEPControl_AsIs);
         }
@@ -916,6 +965,7 @@ bool OCCTExportSTEPWithMode(OCCTShapeRef shape, const char* path, int32_t modelT
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
+        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
         IFSelect_ReturnStatus status = writer.Transfer(shape->shape, mode);
@@ -932,6 +982,7 @@ bool OCCTExportSTEPWithModeAndTolerance(OCCTShapeRef shape, const char* path,
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
+        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         writer.SetTolerance(tolerance);
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
@@ -948,6 +999,7 @@ bool OCCTExportSTEPCleanDuplicates(OCCTShapeRef shape, const char* path, int32_t
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
+        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
         IFSelect_ReturnStatus status = writer.Transfer(shape->shape, mode);

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -1933,21 +1933,23 @@ struct STEPWriterCAFCorruptionTests {
         )
     }
 
-    /// Regression guard for #280 (currently a known issue — see below).
+    /// Regression guard for #280.
     ///
     /// Merely constructing a `STEPCAFControl_Reader` — i.e. any XDE STEP read, such as
-    /// `Document.loadSTEP` — permanently corrupts every later shape-level STEP write in the
-    /// process: the frustum's periodic conical face is silently dropped from the written file,
-    /// leaving a 2-face solid missing 63% of its volume that still reports `isValid == true`.
+    /// `Document.loadSTEP` — used to permanently corrupt every later shape-level STEP write in the
+    /// process: the frustum's lateral conical face was silently dropped from the written file,
+    /// leaving a 2-face solid missing 63% of its volume that still reported `isValid == true`.
     ///
-    /// The mechanism is NOT understood. Ruled out empirically (#280): the controller name
-    /// registration (pinning/re-recording the plain `STEPControl_Controller` changes nothing) and
-    /// `Interface_Static` (values are byte-identical between a good and a corrupted write). No
-    /// `StepModelType` dodges it. Suspected upstream OCCT 8.0.0p1.
+    /// Upstream OCCT 8.0.0p1 bug: `STEPCAFControl_Controller`'s constructor overwrites the actor
+    /// its base class configured, without re-applying `SetShapeProcessFlags`, and then
+    /// `AutoRecord()`s itself under the same "STEP" name the plain writer resolves by. The actor's
+    /// OperationsFlags end up empty, so `DirectFaces` never runs and faces on indirect
+    /// (left-handed) surfaces — a frustum's cone — are dropped. Worked around in the bridge by
+    /// installing a freshly-constructed plain controller on each shape-level write.
     ///
-    /// A write must not care what was read earlier in the process. This is also the real cause of
-    /// the long-standing `cone()` failure in OCCTStressTests, which passes in isolation and fails
-    /// in a full run purely because OCCTIOTests does a CAF read first.
+    /// This is also the cause of the long-standing `cone()` failure in OCCTStressTests, which
+    /// passed in isolation and failed in every full run purely because OCCTIOTests reads a STEP
+    /// first.
     @Test("A CAF STEP read must not corrupt later shape-level STEP writes")
     func cafReadDoesNotPoisonShapeWriter() throws {
         let analyticVolume = (Double.pi * 10 / 3) * (25 + 10 + 4)   // 130π ≈ 408.407
@@ -1964,21 +1966,12 @@ struct STEPWriterCAFCorruptionTests {
         try box.writeSTEP(to: boxURL)
         #expect(Document.loadSTEP(from: boxURL, modes: STEPReaderModes()) != nil)
 
-        // KNOWN ISSUE (#280) — unfixed. Wrapped so it documents the bug without adding a red
-        // test, and so this flips to an *unexpected pass* (a failure telling you to delete this
-        // wrapper) the moment the underlying bug is fixed.
-        //
-        // Mechanism is still unknown: it is NOT the controller name registration and NOT
-        // Interface_Static (both ruled out empirically — see #280). Trigger is narrowed to the
-        // mere construction of a STEPCAFControl_Reader. Suspected upstream OCCT 8.0.0p1.
-        try withKnownIssue("#280: a CAF STEP read corrupts later shape-level STEP writes") {
-            let after = try coneRoundTrip("after")
-            #expect(after.conicalInFile == 1,
-                    "CONICAL_SURFACE dropped from the written file (#280)")
-            #expect(after.faces == 3,
-                    "frustum lost a face: \(after.faces) (#280)")
-            #expect(abs(after.volume - analyticVolume) / analyticVolume < 0.01,
-                    "frustum volume corrupted: \(after.volume) vs \(analyticVolume) (#280)")
-        }
+        let after = try coneRoundTrip("after")
+        #expect(after.conicalInFile == 1,
+                "CONICAL_SURFACE dropped from the written file (#280)")
+        #expect(after.faces == 3,
+                "frustum lost a face: \(after.faces) (#280)")
+        #expect(abs(after.volume - analyticVolume) / analyticVolume < 0.01,
+                "frustum volume corrupted: \(after.volume) vs \(analyticVolume) (#280)")
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,35 @@ mesh-scale STL imports (OCCTMCP#75).
 New test: sphere fixture proves indices survive a real skip (returned pairs match the per-index
 accessor exactly; skipped indices are exactly those the per-index accessor rejects).
 
+### v1.9.2 (July 2026) — fix: an XDE STEP read silently corrupted every later STEP write (#280)
+
+Reading a STEP through `Document.loadSTEP` permanently corrupted every subsequent
+`Exporter.writeSTEP` in the process. A cone frustum wrote as a **2-face solid missing its lateral
+`CONICAL_SURFACE` and 63% of its volume** (408.407 → 151.844), still reporting `isValid == true`.
+Read a STEP, write a STEP, geometry silently gone — an ordinary app sequence.
+
+Upstream OCCT bug. `STEPCAFControl_Controller`'s constructor overwrites the actor its base class
+just configured, without re-applying `SetShapeProcessFlags`, then `AutoRecord()`s itself under the
+same `"STEP"` name the plain writer resolves by — and `STEPControl_Writer::SetWS()` unconditionally
+re-runs `SelectNorm("STEP")`. So after any XDE read (a `STEPCAFControl_Reader` merely being
+*constructed* is enough) every shape-level write ran with **empty** `OperationsFlags`:
+`DirectFaces` never ran, and faces on indirect (left-handed) surfaces — a frustum's cone — were
+dropped. That is why only the cone was affected; box/cylinder/sphere/torus have no indirect
+surfaces.
+
+Fixed upstream in OCCT PR #1334 (merged 2026-07-10), which added an `InitializeMissingParameters()`
+call to `STEPControl_Writer::Transfer`. Our pinned **V8_0_0_p1** (tagged 2026-06-16) predates it —
+it *defines* that method but never calls it, and it is `private`. The bridge therefore installs a
+freshly-constructed plain controller on each shape-level write, restoring the flags the writer
+should have had. Retire the workaround when the bundled OCCT moves past that commit.
+
+This was also the cause of the long-standing `cone()` failure in `StressFormatRoundTripTests`, which
+passed in isolation and failed in every full run purely because `OCCTIOTests` reads a STEP first. It
+was never flaky — it was correctly reporting this bug. **The full suite is now green: 4,359 tests,
+0 failures.**
+
+Bumped **PATCH**: bug fix, no public API change.
+
 ### v1.9.1 (July 2026) — fix: a new Document could inherit a dead Document's construction context (#277)
 
 `Document.constructionContext` is resolved through a side table keyed on `ObjectIdentifier(document)`


### PR DESCRIPTION
Closes #280. **Full suite is green for the first time: 4,359 tests, 0 failures.**

## The bug

Reading a STEP through `Document.loadSTEP` permanently corrupted every later `Exporter.writeSTEP` in the process. A cone frustum wrote as a 2-face solid missing its lateral `CONICAL_SURFACE` and 63% of its volume (408.407 → 151.844), still reporting `isValid == true`. Read a STEP, write a STEP, geometry silently gone — an ordinary app sequence.

## Root cause — pinpointed in OCCT

`STEPCAFControl_Controller`'s constructor overwrites the actor its base class just configured, and configures nothing:

```cpp
STEPControl_Controller::STEPControl_Controller() {          // base: configures its actor
  ActWrite->SetShapeFixParameters(DESTEP_Parameters::GetDefaultShapeFixParameters(), ...);
  aDefaultProcFlags.set(ShapeProcess::Operation::SplitCommonVertex);
  aDefaultProcFlags.set(ShapeProcess::Operation::DirectFaces);
  ActWrite->SetShapeProcessFlags(aDefaultProcFlags);
}

STEPCAFControl_Controller::STEPCAFControl_Controller() {    // derived: overwrites it…
  occ::handle<STEPCAFControl_ActorWrite> ActWrite = new STEPCAFControl_ActorWrite;
  myAdaptorWrite = ActWrite;                               // …and configures nothing
}
```

`Init()` then `AutoRecord()`s that controller under the **same** `"STEP"`/`"step"` names as the plain one, and `STEPControl_Writer::SetWS()` **unconditionally** re-runs `SelectNorm("STEP")`. So after any XDE read, every shape-level write resolves to an actor with **empty** `OperationsFlags` — `DirectFaces` never runs, and faces on indirect (left-handed) surfaces are dropped.

That is why **only the cone** was ever affected: a frustum's lateral `CONICAL_SURFACE` is built on an indirect placement; box/cylinder/sphere/torus have none.

Narrowed empirically to exactly one flag:

| applied to the resolved actor | result |
|---|---|
| nothing (baseline) | 2 faces ❌ |
| `SetShapeFixParameters` only | 2 faces ❌ |
| `SetShapeProcessFlags` | 3 faces ✅ |
| → `DirectFaces` **alone** | 3 faces ✅ |
| → `SplitCommonVertex` alone | 2 faces ❌ |

Trigger is narrowed to **construction alone** — no `ReadFile`, no `Transfer`, no document. `Document.create()` does not trip it.

## Already fixed upstream — no PR needed

OCCT **PR #1334** ("Data Exchange - initialize STEP writer healing parameters", merged **2026-07-10**) added an `InitializeMissingParameters()` call to `STEPControl_Writer::Transfer`, which restores exactly these flags:

```cpp
if (!GetShapeProcessFlags().second) {
  aFlags.set(ShapeProcess::Operation::SplitCommonVertex);
  aFlags.set(ShapeProcess::Operation::DirectFaces);
  SetShapeProcessFlags(aFlags);
}
```

Our pinned **V8_0_0_p1** (tagged **2026-06-16**) predates it by ~3 weeks: it *defines* that method but **never calls it** — dead code there — and it is `private`, so we cannot invoke it ourselves.

So there is nothing to contribute upstream; a PR would duplicate #1334. This lands the equivalent fix on our side.

## The fix

The bridge installs a freshly-constructed plain controller on each of the 8 shape-level write paths, restoring the configuration the writer should have had. The work session is created fresh per write, so there is no global effect. Document-level writes are untouched — `STEPCAFControl_Writer` legitimately wants the CAF actor.

**Retire this workaround when the bundled OCCT moves past #1334** — noted in the code and changelog. The test covers the behaviour either way.

## Tests

- New `STEPWriterCAFCorruptionTests` — self-contained: does the XDE read itself, then asserts the frustum still round-trips (faces, `CONICAL_SURFACE` present in the file, volume within 1% of the analytic 130π). It deliberately asserts no clean "before" baseline, since the poison is process-wide and another suite usually trips it first in a full run.
- `cone()` in `StressFormatRoundTripTests` now passes in the full suite. It was never flaky — it was correctly reporting this bug all along, and should not have been quarantined.