### PR TITLE
chore: rebuild OCCT with the #280 kernel fix; consumer builds warning-free (#281)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,10 +33,14 @@ let occtTarget: Target = useLocalBinary
         name: "OCCT",
         path: "Libraries/OCCT.xcframework"
     )
+    // v1.10.1 rebuild: OCCT 8.0.0p1 + our carried patches — 0001 (ShapeFix_Face guard, #263) and
+    // 0002 (backport of upstream OCCT#1334, #280). Bump BOTH url and checksum whenever the
+    // xcframework is rebuilt, or URL-resolving consumers silently keep the previous kernel while
+    // local sibling builds get the new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.8.5/OCCT.xcframework.zip",
-        checksum: "c15e1a32ef4bbf28157f9d8d413cdf2f9cd065f86b5e8ade1391e562fbe78572"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.10.1/OCCT.xcframework.zip",
+        checksum: "a1f816ea9b5308dafc9187933431b3f36793377ed7fa2567692305fac0255927"
     )
 
 let package = Package(
@@ -80,7 +84,22 @@ let package = Package(
                 .headerSearchPath("../../Libraries/OCCT.xcframework/xros-arm64-simulator/Headers", .when(platforms: [.visionOS])),
                 .headerSearchPath("../../Libraries/OCCT.xcframework/tvos-arm64/Headers", .when(platforms: [.tvOS])),
                 .headerSearchPath("../../Libraries/OCCT.xcframework/tvos-arm64-simulator/Headers", .when(platforms: [.tvOS])),
-                .define("OCCT_AVAILABLE", to: "1")
+                .define("OCCT_AVAILABLE", to: "1"),
+                // OCCT 8.0 deprecates its own legacy spellings (Standard_True/Standard_Real,
+                // TopTools_* map/list typedefs, TColStd_Array1Of*, …) in favour of native C++ types
+                // and explicit NCollection_* templates. This bridge still uses the legacy names, so
+                // every consumer build inherited ~684 -Wdeprecated-declarations from our .mm files —
+                // drowning out real warnings downstream (issue #281).
+                //
+                // OCCT_NO_DEPRECATED is OCCT's own opt-out (Standard_Macro.hxx), so this silences
+                // exactly OCCT's deprecation attributes and nothing else. It is scoped to this
+                // target, and it is a `.define` rather than `.unsafeFlags` deliberately: unsafeFlags
+                // is rejected by SwiftPM for any package consumed as a dependency, which would break
+                // every downstream consumer.
+                //
+                // This buys quiet, not absolution — the legacy spellings are still deprecated and
+                // will eventually be removed upstream. Migrating the call sites is tracked in #281.
+                .define("OCCT_NO_DEPRECATED")
             ],
             linkerSettings: [
                 .linkedLibrary("c++")

--- a/Scripts/patches/0002-STEPControl_Writer-initialize-missing-shape-processing-1334.patch
+++ b/Scripts/patches/0002-STEPControl_Writer-initialize-missing-shape-processing-1334.patch
@@ -1,0 +1,43 @@
+From: OCCTSwift ecosystem <noreply@secondmouse.au>
+Subject: [PATCH] STEPControl_Writer: initialize missing shape-processing setup on Transfer
+
+Backport of upstream Open-Cascade-SAS/OCCT#1334 ("Data Exchange - initialize STEP
+writer healing parameters", merged 2026-07-10), which lands after our V8_0_0_p1 pin
+(tagged 2026-06-16).
+
+V8_0_0_p1 already defines STEPControl_Writer::InitializeMissingParameters() — which
+restores the default ShapeFix parameters and the default ShapeProcess operation flags
+(SplitCommonVertex, DirectFaces) when they are absent — but never calls it. It is dead
+code in p1, and it is private, so a consumer cannot invoke it either.
+
+That matters because STEPCAFControl_Controller's constructor replaces the actor its base
+STEPControl_Controller constructor had just configured, without re-applying
+SetShapeProcessFlags, and then AutoRecord()s itself under the same "STEP"/"step" names
+the plain writer resolves by (STEPControl_Writer::SetWS unconditionally re-runs
+SelectNorm("STEP")). So after any XDE STEP read — merely constructing a
+STEPCAFControl_Reader is enough — every shape-level STEP write runs with EMPTY
+OperationsFlags: DirectFaces never runs, and faces built on indirect (left-handed)
+surfaces are silently dropped from the output.
+
+Concretely, a cone frustum (r1=5, r2=2, h=10) writes as a 2-face solid whose lateral
+CONICAL_SURFACE and seam LINEs are missing entirely, with 63% of its volume gone
+(408.407 -> 151.844), while still reporting isValid == true. See
+SecondMouseAU/OCCTSwift#280.
+
+This is the upstream fix, unmodified in effect: call InitializeMissingParameters() at
+the point of transfer so the writer's shape processing is configured regardless of which
+controller ended up registered under the "STEP" norm.
+
+Retire this patch once the bundled OCCT moves past upstream commit
+e2de4398ca6bf034074e6921599da76a9941c792 (the #1334 merge).
+
+--- a/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.cxx
++++ b/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.cxx
+@@ -155,6 +155,7 @@
+     occ::down_cast<STEPControl_ActorWrite>(WS()->NormAdaptor()->ActorWrite());
+   ActWrite->SetGroupMode(
+     occ::down_cast<StepData_StepModel>(thesession->Model())->InternalParameters.WriteAssembly);
++  InitializeMissingParameters();
+   return thesession->TransferWriteShape(sh, compgraph, theProgress);
+ }
+

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -42,3 +42,34 @@ likewise survive. `ShapeFix_Shape` output on valid box/sphere/cylinder is byte-i
 
 Until the xcframework is rebuilt with this patch, the in-wrapper guard shipped in v1.8.3
 (`occtHasSelfIntersectingWire`) prevents the crash from reaching this code.
+
+## 0002-STEPControl_Writer-initialize-missing-shape-processing-1334.patch
+
+**Backports [Open-Cascade-SAS/OCCT#1334](https://github.com/Open-Cascade-SAS/OCCT/pull/1334)** ("Data
+Exchange - initialize STEP writer healing parameters", merged 2026-07-10), which lands *after* our
+`V8_0_0_p1` pin (tagged 2026-06-16). Fixes [#280](https://github.com/SecondMouseAU/OCCTSwift/issues/280).
+
+`STEPCAFControl_Controller`'s constructor replaces the actor its base `STEPControl_Controller`
+constructor had just configured, without re-applying `SetShapeProcessFlags`, and then `AutoRecord()`s
+itself under the same `"STEP"`/`"step"` names the plain writer resolves by —
+`STEPControl_Writer::SetWS()` unconditionally re-runs `SelectNorm("STEP")`. So after **any** XDE STEP
+read (merely *constructing* a `STEPCAFControl_Reader` is enough — no `ReadFile`, no `Transfer`, no
+document), every shape-level STEP write ran with **empty** `OperationsFlags`: `DirectFaces` never ran,
+and faces built on indirect (left-handed) surfaces were silently dropped.
+
+A cone frustum (r1=5, r2=2, h=10) wrote as a 2-face solid with its lateral `CONICAL_SURFACE` and seam
+`LINE`s missing and 63% of its volume gone (408.407 → 151.844) — while still reporting
+`isValid == true`. Only cones were affected: box/cylinder/sphere/torus have no indirect surfaces.
+
+p1 already *defines* `STEPControl_Writer::InitializeMissingParameters()` (which restores the default
+ShapeFix parameters **and** the `SplitCommonVertex`/`DirectFaces` flags when absent) but never calls
+it — dead code there, and `private`, so a consumer cannot invoke it either. The patch is upstream's
+one-line fix: call it at the point of transfer.
+
+**Validation:** `STEPWriterCAFCorruptionTests` in `Tests/OCCTIOTests` does the XDE read itself and
+asserts the frustum still round-trips (3 faces, `CONICAL_SURFACE` present in the file, volume within
+1% of the analytic 130π). Red against the stock p1 binary, green after this rebuild. It also fixes the
+long-standing `cone()` failure in `StressFormatRoundTripTests`, which passed in isolation and failed in
+every full run because `OCCTIOTests` reads a STEP first.
+
+**Retire** once the bundled OCCT moves past upstream `e2de4398ca6bf034074e6921599da76a9941c792`.

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -937,7 +937,7 @@ int32_t OCCTCurve3DEvaluateGrid(OCCTCurve3DRef curve, const double* params, int3
         }
 
         NCollection_Array1<gp_Pnt> results = evaluator.EvaluateGrid(paramArr);
-        int32_t n = results.Size();
+        int32_t n = static_cast<int32_t>(results.Size());
         for (int32_t i = 0; i < n; i++) {
             const gp_Pnt& pt = results.Value(i + 1);
             outXYZ[i*3]   = pt.X();
@@ -962,7 +962,7 @@ int32_t OCCTCurve3DEvaluateGridD1(OCCTCurve3DRef curve, const double* params, in
         }
 
         NCollection_Array1<GeomGridEval::CurveD1> results = evaluator.EvaluateGridD1(paramArr);
-        int32_t n = results.Size();
+        int32_t n = static_cast<int32_t>(results.Size());
         for (int32_t i = 0; i < n; i++) {
             const GeomGridEval::CurveD1& r = results.Value(i + 1);
             outXYZ[i*3]     = r.Point.X();

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -3907,7 +3907,7 @@ int32_t OCCTAssemblyItemIdPathCount(const char *str) {
     try {
         TCollection_AsciiString aStr(str);
         XCAFDoc_AssemblyItemId id(aStr);
-        return id.GetPath().Size();
+        return static_cast<int32_t>(id.GetPath().Size());
     } catch (...) { return 0; }
 }
 
@@ -4594,7 +4594,7 @@ int OCCTDocumentDimTolDimensionCount(OCCTDocumentRef document) {
         XCAFDimTolObjects_Tool tool(document->doc);
         NCollection_Sequence<Handle(XCAFDimTolObjects_DimensionObject)> dims;
         tool.GetDimensions(dims);
-        return dims.Size();
+        return static_cast<int>(dims.Size());
     } catch (...) { return 0; }
 }
 
@@ -4605,7 +4605,7 @@ int OCCTDocumentDimTolToleranceCount(OCCTDocumentRef document) {
         NCollection_Sequence<Handle(XCAFDimTolObjects_DatumObject)> datums;
         NCollection_DataMap<Handle(XCAFDimTolObjects_GeomToleranceObject), Handle(XCAFDimTolObjects_DatumObject)> datumMap;
         tool.GetGeomTolerances(tols, datums, datumMap);
-        return tols.Size();
+        return static_cast<int>(tols.Size());
     } catch (...) { return 0; }
 }
 
@@ -5725,7 +5725,7 @@ int32_t OCCTDeltaEndTime(void* delta) {
 int32_t OCCTDeltaAttributeDeltaCount(void* delta) {
     try {
         auto* ptr = static_cast<Handle(TDF_Delta)*>(delta);
-        return (*ptr)->AttributeDeltas().Size();
+        return static_cast<int32_t>((*ptr)->AttributeDeltas().Size());
     } catch (...) { return 0; }
 }
 
@@ -6927,7 +6927,7 @@ int32_t OCCTDocumentColorToolGetAllColors(OCCTDocumentRef doc, int64_t** outLabe
     try {
         NCollection_Sequence<TDF_Label> labels;
         doc->colorTool->GetColors(labels);
-        int count = labels.Size();
+        int count = static_cast<int>(labels.Size());
         if (count == 0) return 0;
         int64_t* ids = (int64_t*)malloc(count * sizeof(int64_t));
         if (!ids) return 0;

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -120,7 +120,7 @@ int32_t OCCTCurve2DEvaluateGrid(OCCTCurve2DRef curve,
         }
 
         NCollection_Array1<gp_Pnt2d> results = evaluator.EvaluateGrid(paramArr);
-        int32_t n = results.Size();
+        int32_t n = static_cast<int32_t>(results.Size());
         for (int32_t i = 0; i < n; i++) {
             const gp_Pnt2d& pt = results.Value(i + 1);
             outXY[i*2]   = pt.X();
@@ -145,7 +145,7 @@ int32_t OCCTCurve2DEvaluateGridD1(OCCTCurve2DRef curve,
         }
 
         NCollection_Array1<Geom2dGridEval::CurveD1> results = evaluator.EvaluateGridD1(paramArr);
-        int32_t n = results.Size();
+        int32_t n = static_cast<int32_t>(results.Size());
         for (int32_t i = 0; i < n; i++) {
             const Geom2dGridEval::CurveD1& r = results.Value(i + 1);
             outXY[i*2]     = r.Point.X();

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -20,8 +20,6 @@
 #include <Standard_ErrorHandler.hxx>   // OCC_CATCH_SIGNALS (#175)
 #include <STEPControl_Reader.hxx>
 #include <STEPControl_Writer.hxx>
-#include <STEPControl_Controller.hxx>
-#include <XSControl_WorkSession.hxx>
 #include <STEPControl_StepModelType.hxx>
 #include <STEPCAFControl_Reader.hxx>
 #include <STEPCAFControl_Writer.hxx>
@@ -107,47 +105,6 @@ bool OCCTExportSTLWithMode(OCCTShapeRef shape, const char* path, double deflecti
 }
 
 
-namespace {
-
-/// Repair the STEP writer's shape-processing config, which an XDE read silently breaks.
-///
-/// Upstream OCCT bug (8.0.0p1). `STEPCAFControl_Controller`'s constructor replaces the actor
-/// its base class just configured:
-///
-///     STEPControl_Controller::STEPControl_Controller() {          // base: configures its actor
-///       ActWrite->SetShapeProcessFlags({SplitCommonVertex, DirectFaces});
-///     }
-///     STEPCAFControl_Controller::STEPCAFControl_Controller() {    // derived: overwrites it,
-///       myAdaptorWrite = new STEPCAFControl_ActorWrite;           // and configures nothing
-///     }
-///
-/// `STEPCAFControl_Controller::Init()` then `AutoRecord()`s that controller under the *same*
-/// "STEP"/"step" names as the plain one, and `STEPControl_Writer::SetWS()` unconditionally does
-/// `SelectNorm("STEP")` — so after any XDE STEP read (`Document.loadSTEP`, i.e. a
-/// `STEPCAFControl_Reader` merely being constructed) every shape-level write resolves to an actor
-/// with EMPTY OperationsFlags. `DirectFaces` therefore never runs, and faces built on indirect
-/// (left-handed) surfaces are silently dropped: a cone frustum writes as a 2-face solid missing
-/// its lateral CONICAL_SURFACE and 63% of its volume, still reporting `isValid == true`.
-///
-/// Isolated to exactly that flag: applying `DirectFaces` alone fixes it; `SplitCommonVertex` alone
-/// does not, and the ShapeFix parameters are irrelevant. See SecondMouseAU/OCCTSwift#280.
-///
-/// FIXED UPSTREAM, NOT IN OUR BUILD: OCCT PR #1334 ("Data Exchange - initialize STEP writer healing
-/// parameters", merged 2026-07-10) added an `InitializeMissingParameters()` call to
-/// `STEPControl_Writer::Transfer`, which restores exactly these flags. Our pinned V8_0_0_p1 (tagged
-/// 2026-06-16) *defines* that method but never calls it — it is dead code there — and it is
-/// `private`, so we cannot invoke it ourselves. Retire this workaround once the bundled OCCT moves
-/// past that commit; the test in OCCTIOTests covers the behaviour either way.
-///
-/// Installing a freshly-constructed plain controller restores the configuration the writer should
-/// have had. The session is created fresh per write, so this has no global effect. Document-level
-/// writes are unaffected — they use `STEPCAFControl_Writer` and want the CAF actor.
-void repairSTEPWriterActor(STEPControl_Writer& writer) {
-    writer.WS()->SetController(new STEPControl_Controller);
-}
-
-}  // namespace
-
 bool OCCTExportSTEP(OCCTShapeRef shape, const char* path) {
     if (!shape || !path) return false;
 
@@ -158,7 +115,6 @@ bool OCCTExportSTEP(OCCTShapeRef shape, const char* path) {
         bool success = false;
         {
             STEPControl_Writer writer;
-            repairSTEPWriterActor(writer);   // #280
             Interface_Static::SetCVal("write.step.schema", "AP214");
 
             IFSelect_ReturnStatus status = writer.Transfer(shape->shape, STEPControl_AsIs);
@@ -185,7 +141,6 @@ bool OCCTExportSTEPWithName(OCCTShapeRef shape, const char* path, const char* na
         bool success = false;
         {
             STEPControl_Writer writer;
-            repairSTEPWriterActor(writer);   // #280
             Interface_Static::SetCVal("write.step.schema", "AP214");
             if (name) {
                 Interface_Static::SetCVal("write.step.product.name", name);
@@ -468,7 +423,6 @@ bool OCCTExportSTEPProgress(OCCTShapeRef shape, const char* path,
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
-        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
         Message_ProgressRange range = indicator->Start();
@@ -485,7 +439,6 @@ bool OCCTExportSTEPWithModeProgress(OCCTShapeRef shape, const char* path, int32_
     if (!shape || !path) return false;
     try {
         STEPControl_Writer writer;
-        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
         Message_ProgressRange range = indicator->Start();
@@ -777,7 +730,6 @@ bool OCCTStepTidyOptimize(const char* inputPath, const char* outputPath) {
         reader.TransferRoots();
 
         STEPControl_Writer writer;
-        repairSTEPWriterActor(writer);   // #280
         for (int i = 1; i <= reader.NbShapes(); i++) {
             writer.Transfer(reader.Shape(i), STEPControl_AsIs);
         }
@@ -965,7 +917,6 @@ bool OCCTExportSTEPWithMode(OCCTShapeRef shape, const char* path, int32_t modelT
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
-        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
         IFSelect_ReturnStatus status = writer.Transfer(shape->shape, mode);
@@ -982,7 +933,6 @@ bool OCCTExportSTEPWithModeAndTolerance(OCCTShapeRef shape, const char* path,
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
-        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         writer.SetTolerance(tolerance);
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
@@ -999,7 +949,6 @@ bool OCCTExportSTEPCleanDuplicates(OCCTShapeRef shape, const char* path, int32_t
         // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B).
         std::lock_guard<std::mutex> deLock(igesMutex());
         STEPControl_Writer writer;
-        repairSTEPWriterActor(writer);   // #280
         Interface_Static::SetCVal("write.step.schema", "AP214");
         STEPControl_StepModelType mode = static_cast<STEPControl_StepModelType>(modelType);
         IFSelect_ReturnStatus status = writer.Transfer(shape->shape, mode);
@@ -1709,7 +1658,7 @@ void OCCTMessengerRelease(OCCTMessengerRef messenger) {
 int OCCTMessengerPrinterCount(OCCTMessengerRef messenger) {
     try {
         auto* m = static_cast<Message_Messenger*>(messenger);
-        return m->Printers().Size();
+        return static_cast<int>(m->Printers().Size());
     } catch (...) { return 0; }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -5146,7 +5146,7 @@ bool OCCTLocOpeBuildWires(OCCTShapeRef shape, int32_t faceIndex,
         if (!bw.IsDone()) return false;
 
         const NCollection_List<TopoDS_Shape>& result = bw.Result();
-        int32_t n = result.Size();
+        int32_t n = static_cast<int32_t>(result.Size());
         *outCount = n;
         if (n == 0) { *outWires = nullptr; return true; }
         *outWires = (OCCTShapeRef*)malloc(n * sizeof(OCCTShapeRef));
@@ -5602,7 +5602,7 @@ bool OCCTBOPAlgoBuilderFace(OCCTShapeRef _Nonnull baseFace,
         }
 
         const TopTools_ListOfShape& areas = bf.Areas();
-        int32_t n = areas.Size();
+        int32_t n = static_cast<int32_t>(areas.Size());
         *outFaceCount = n;
         if (n == 0) {
             *outFaces = nullptr;
@@ -5640,7 +5640,7 @@ bool OCCTBOPAlgoBuilderSolid(const OCCTShapeRef _Nonnull * _Nonnull faces, int32
         }
 
         const TopTools_ListOfShape& areas = bs.Areas();
-        int32_t n = areas.Size();
+        int32_t n = static_cast<int32_t>(areas.Size());
         *outSolidCount = n;
         if (n == 0) {
             *outSolids = nullptr;
@@ -5676,7 +5676,7 @@ bool OCCTBOPAlgoShellSplitter(OCCTShapeRef _Nonnull shell,
         }
 
         const TopTools_ListOfShape& shells = ss.Shells();
-        int32_t n = shells.Size();
+        int32_t n = static_cast<int32_t>(shells.Size());
         *outShellCount = n;
         if (n == 0) {
             *outShells = nullptr;
@@ -5879,7 +5879,7 @@ OCCTShapeRef _Nullable OCCTBRepFeatSplitShapeWithSides(OCCTShapeRef _Nonnull sha
 
         // Left faces
         const TopTools_ListOfShape& leftList = splitter.Left();
-        int32_t nl = leftList.Size();
+        int32_t nl = static_cast<int32_t>(leftList.Size());
         *outLeftCount = nl;
         if (nl > 0) {
             *outLeft = (OCCTShapeRef*)malloc(nl * sizeof(OCCTShapeRef));
@@ -5891,7 +5891,7 @@ OCCTShapeRef _Nullable OCCTBRepFeatSplitShapeWithSides(OCCTShapeRef _Nonnull sha
 
         // Right faces
         const TopTools_ListOfShape& rightList = splitter.Right();
-        int32_t nr = rightList.Size();
+        int32_t nr = static_cast<int32_t>(rightList.Size());
         *outRightCount = nr;
         if (nr > 0) {
             *outRight = (OCCTShapeRef*)malloc(nr * sizeof(OCCTShapeRef));
@@ -6031,7 +6031,7 @@ OCCTShapeRef _Nullable OCCTLocOpeSplitByWires(OCCTShapeRef _Nonnull shape,
 
         // Direct left faces
         const TopTools_ListOfShape& dl = spliter.DirectLeft();
-        int32_t n = dl.Size();
+        int32_t n = static_cast<int32_t>(dl.Size());
         *outDirectLeftCount = n;
         if (n > 0) {
             *outDirectLeft = (OCCTShapeRef*)malloc(n * sizeof(OCCTShapeRef));
@@ -6886,7 +6886,7 @@ int32_t OCCTShapeBuildLoops(OCCTShapeRef shape, int32_t faceIndex) {
             edgeExp.Next();
         }
         loop.Perform();
-        return loop.NewWires().Size();
+        return static_cast<int32_t>(loop.NewWires().Size());
     } catch (...) { return -1; }
 }
 // MARK: - Draft_Modification (v0.98.0)
@@ -8789,7 +8789,7 @@ int32_t OCCTFilletBuilderGenerated(OCCTFilletBuilderRef builder, OCCTShapeRef sh
     *outShapes = nullptr;
     try {
         const TopTools_ListOfShape& list = builder->fillet.Generated(shape->shape);
-        int count = list.Size();
+        int count = static_cast<int>(list.Size());
         if (count == 0) return 0;
         OCCTShapeRef* shapes = (OCCTShapeRef*)malloc(count * sizeof(OCCTShapeRef));
         if (!shapes) return 0;
@@ -8808,7 +8808,7 @@ int32_t OCCTFilletBuilderModified(OCCTFilletBuilderRef builder, OCCTShapeRef sha
     *outShapes = nullptr;
     try {
         const TopTools_ListOfShape& list = builder->fillet.Modified(shape->shape);
-        int count = list.Size();
+        int count = static_cast<int>(list.Size());
         if (count == 0) return 0;
         OCCTShapeRef* shapes = (OCCTShapeRef*)malloc(count * sizeof(OCCTShapeRef));
         if (!shapes) return 0;
@@ -8841,7 +8841,7 @@ int32_t OCCTChamferBuilderGenerated(OCCTChamferBuilderRef builder, OCCTShapeRef 
     *outShapes = nullptr;
     try {
         const TopTools_ListOfShape& list = builder->chamfer.Generated(shape->shape);
-        int32_t count = list.Size();
+        int32_t count = static_cast<int32_t>(list.Size());
         if (count == 0) return 0;
         *outShapes = (OCCTShapeRef*)malloc(count * sizeof(OCCTShapeRef));
         int32_t i = 0;
@@ -8858,7 +8858,7 @@ int32_t OCCTChamferBuilderModified(OCCTChamferBuilderRef builder, OCCTShapeRef s
     *outShapes = nullptr;
     try {
         const TopTools_ListOfShape& list = builder->chamfer.Modified(shape->shape);
-        int32_t count = list.Size();
+        int32_t count = static_cast<int32_t>(list.Size());
         if (count == 0) return 0;
         *outShapes = (OCCTShapeRef*)malloc(count * sizeof(OCCTShapeRef));
         int32_t i = 0;

--- a/Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
@@ -1808,7 +1808,7 @@ void OCCTFontMgrInitDatabase(void) {
 int OCCTFontMgrFontCount(void) {
     try {
         ensureFontList();
-        return g_fontList.Size();
+        return static_cast<int>(g_fontList.Size());
     } catch (...) { return 0; }
 }
 

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -585,7 +585,11 @@ public final class TopologyGraph: @unchecked Sendable {
                                               &sequence)
         }
         guard ok else { return nil }
-        let opName = String(cString: opNameBuffer)
+        // The bridge fills a fixed 128-byte buffer and NUL-terminates it. Decode only up to that
+        // terminator — String(decoding:as:) over the whole buffer would carry the NUL padding into
+        // the string.
+        let opName = String(decoding: opNameBuffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) },
+                            as: UTF8.self)
 
         // Collect originals.
         let count = Int(OCCTBRepGraphHistoryGetRecordOriginalsCount(handle, Int32(index)))

--- a/Sources/OCCTSwift/Mesh.swift
+++ b/Sources/OCCTSwift/Mesh.swift
@@ -214,7 +214,7 @@ public final class Mesh: @unchecked Sendable {
 
         let handle: OCCTMeshRef? = vertexFloats.withUnsafeBufferPointer { vbuf in
             indices.withUnsafeBufferPointer { ibuf in
-                if var nFloats = normalFloatsStorage {
+                if let nFloats = normalFloatsStorage {
                     return nFloats.withUnsafeBufferPointer { nbuf in
                         OCCTMeshCreateFromArrays(
                             vbuf.baseAddress,

--- a/Sources/OCCTSwift/SheetMetal.swift
+++ b/Sources/OCCTSwift/SheetMetal.swift
@@ -482,10 +482,10 @@ public enum SheetMetal {
             let aOuterOffset = thickness * a.normal
             let bOuterOffset = thickness * b.normal
 
+            // Only the v=0 (kissStart) cross-section is constructed; the far end at
+            // kissEnd falls out of the extrusion along the seam below.
             let aOuter0 = kissStart + aOuterOffset
-            let aOuter1 = kissEnd   + aOuterOffset
             let bOuter0 = kissStart + bOuterOffset
-            let bOuter1 = kissEnd   + bOuterOffset
 
             // Wire for the cross-section at v=0 (kissStart end). Three
             // edges: line K→A, line K→C, arc C→A.
@@ -496,20 +496,11 @@ public enum SheetMetal {
             if abs(radius - radiusB) > 1e-4 * max(radius, radiusB) {
                 return nil
             }
-            // The arc plane normal: must be parallel to the seam (so the
-            // arc lies in the cross-section plane). Use seamUnit; sign
-            // determines the arc traversal direction.
-            //
-            // We want the arc to curve through the "open" quadrant of
-            // the bend — the side opposite to where the flanges' bodies
-            // sit. That open direction = `-(aNormalDir + bNormalDir)`
-            // projected to the cross-section plane. We pick the seamUnit
-            // sign so the arc bulges that way.
-            let arcNormalCandidate = seamUnit
-            // Determine the sign empirically by checking which sign of
-            // arcNormal makes the arc midpoint lie on the open side.
-            // The arc midpoint at angle (startAngle+endAngle)/2 around
-            // the kiss point with radius `radius`.
+            // The arc must curve through the "open" quadrant of the bend — the side
+            // opposite to where the flanges' bodies sit. Rather than pick an arc-plane
+            // normal and derive a traversal sign from it, the arc is built through three
+            // points (start → midpoint → end) below, so the midpoint alone fixes the
+            // curvature direction.
             let aDir = Vector3DMath.normalize(aOuter0 - kissStart) ?? SIMD3(0, 0, 0)
             let cDir = Vector3DMath.normalize(bOuter0 - kissStart) ?? SIMD3(0, 0, 0)
             // The "expected" arc midpoint direction = (aDir + cDir)/2,
@@ -542,13 +533,11 @@ public enum SheetMetal {
 
             guard let face = Shape.face(from: wire, planar: true) else { return nil }
 
-            // Extrude the cross-section face along the seam direction.
-            let seamLength = Vector3DMath.modulus(kissEnd - kissStart)
+            // Extrude the cross-section face along the seam. `extruded(by:)` takes the full
+            // vector (direction and length together), unlike
+            // `Shape.extrude(profile:direction:length:)`, which wants a wire profile rather
+            // than the face we have here.
             let extrudeVec = (kissEnd - kissStart)
-            // Extrude direction is from kissStart toward kissEnd; length
-            // is seamLength. `Shape.extrude(profile:direction:length:)`
-            // takes a wire profile, but we have a face — use
-            // Shape.extruded(by:) instead, which extrudes any shape.
             return face.extruded(by: extrudeVec)
         }
 

--- a/Sources/OCCTTest/main.swift
+++ b/Sources/OCCTTest/main.swift
@@ -19,7 +19,7 @@ print("   - Sphere: \(sphere.isValid ? "valid" : "invalid")")
 // Test 2: Boolean operations
 print()
 print("2. Boolean operations...")
-let combined = box.union(with: cylinder.translated(by: [5, 0, 0])!)!
+let combined = box.union(cylinder.translated(by: [5, 0, 0])!)!
 print("   - Union: \(combined.isValid ? "valid" : "invalid")")
 
 let subtracted = box.subtracting(sphere)!

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,41 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### v1.10.1 (July 2026) — OCCT rebuild carrying the #280 kernel fix; consumer builds are warning-free (#281)
+
+**Rebuilt `OCCT.xcframework`** (all three slices) carrying a new carried patch,
+`0002-STEPControl_Writer-initialize-missing-shape-processing-1334.patch` — a backport of upstream
+[OCCT#1334](https://github.com/Open-Cascade-SAS/OCCT/pull/1334) (merged 2026-07-10), which lands after
+our `V8_0_0_p1` pin (2026-06-16). This fixes [#280](https://github.com/SecondMouseAU/OCCTSwift/issues/280)
+**in the kernel**, so the v1.9.2 bridge workaround (`repairSTEPWriterActor`, which installed a plain
+controller on each of the 8 shape-level write paths) is **removed** — verified by deleting it and
+confirming the regression test still passes against the rebuilt binary.
+
+**Build warnings: 797 → 0** ([#281](https://github.com/SecondMouseAU/OCCTSwift/issues/281)).
+
+- **684 `-Wdeprecated-declarations` → 0.** OCCT 8.0 deprecates its own legacy spellings
+  (`Standard_True`, `Standard_Real`, `TopTools_*`, `TColStd_Array1Of*`, …) which this bridge still
+  uses. Defining OCCT's own `OCCT_NO_DEPRECATED` opt-out on the `OCCTBridge` target silences exactly
+  those attributes and nothing else. Deliberately a `.define` and not `.unsafeFlags` — SwiftPM rejects
+  `unsafeFlags` in any package consumed as a dependency, which would break every downstream consumer.
+  This buys quiet, not absolution: migrating the call sites off the legacy spellings is still tracked
+  in #281.
+- **23 `-Wshorten-64-to-32` → 0.** All 23 were the same shape — an `NCollection` container's
+  `.Size()` (`size_t`) assigned to `int32_t`/`int`. Now explicit `static_cast`. To be clear, these were
+  **not** latent bugs: unlike the `quantize()` Int32 overflow (OCCTSwiftViewport#30), a container with
+  >2^31 elements is not reachable here. The casts document intent and stop the noise.
+- **Swift hygiene.** Removed four dead bindings in `SheetMetal.swift` (`aOuter1`/`bOuter1`,
+  `arcNormalCandidate`, `seamLength`) — each was leftover from a superseded approach that the
+  surrounding comments already described, so the stale comments went too; none was an unfinished
+  calculation. `Mesh.swift` `var`→`let`. Also fixed two warnings not listed in #281 that a cached build
+  had been hiding: a deprecated `String(cString:)` in `BRepGraph.swift` (decoding now stops at the
+  bridge's NUL terminator — `String(decoding:as:)` over the whole fixed 128-byte buffer would have
+  carried the NUL padding into the string) and a deprecated `union(with:)` in `OCCTTest`.
+
+Full suite: **4,359 tests, 0 failures.** Consumer builds inherit no warnings from this package.
+
+Bumped **PATCH**: no public API change — a kernel rebuild, a workaround removal, and build hygiene.
+
 ### v1.10.0 (July 2026) — feat: `allEdgePolylinesIndexed` — bulk wireframe with pick identity (#275 follow-up)
 
 `allEdgePolylines` is dense: when a degenerate/failed edge is skipped (a sphere's pole seams, a


### PR DESCRIPTION
Closes #281. Completes #280 (fixes it in the kernel, so the v1.9.2 workaround comes out).

## 1. OCCT rebuilt with the #280 fix

New carried patch `0002-…-1334.patch` — a backport of upstream **[OCCT#1334](https://github.com/Open-Cascade-SAS/OCCT/pull/1334)** ("Data Exchange - initialize STEP writer healing parameters", merged **2026-07-10**), which lands after our `V8_0_0_p1` pin (**2026-06-16**). All 3 slices rebuilt.

p1 already *defines* `STEPControl_Writer::InitializeMissingParameters()` — restoring the ShapeFix parameters **and** the `SplitCommonVertex`/`DirectFaces` flags — but never calls it (dead code, and `private`, so unreachable from our side). The patch is upstream's one-line call.

**The workaround is removed.** `repairSTEPWriterActor` (v1.9.2, across the 8 shape-level write paths) is gone — verified by deleting it and confirming the regression test still passes against the rebuilt binary. The kernel now fixes it on its own.

**`Package.swift`'s URL `binaryTarget` is bumped to the v1.10.1 release + new checksum** (`a1f816ea…`). Without that, URL-resolving consumers would silently keep the old kernel while local sibling builds got the fix — the exact split that makes this class of bug so hard to see.

## 2. Build warnings: 797 → 0

| category | before | after | how |
|---|---:|---:|---|
| `-Wdeprecated-declarations` | 684 | **0** | OCCT's own `OCCT_NO_DEPRECATED` opt-out on `OCCTBridge` |
| `-Wshorten-64-to-32` | 23 | **0** | explicit `static_cast` |
| Swift hygiene | 5 (+2) | **0** | dead bindings, `var`→`let`, deprecated APIs |

**On the deprecations:** `OCCT_NO_DEPRECATED` is OCCT's own macro (`Standard_Macro.hxx`), so it silences exactly OCCT's deprecation attributes and nothing else, scoped to our target. It is a `.define` and **not** `.unsafeFlags` deliberately — SwiftPM rejects `unsafeFlags` in any package consumed as a dependency, which would have broken every downstream consumer. This buys quiet, not absolution: the legacy spellings are still deprecated and will eventually be removed, so **migrating the call sites stays open on #281**.

**On the narrowing warnings** — being straight about these: all 23 were the same shape, an `NCollection` container's `.Size()` (`size_t`) assigned to `int32_t`/`int`. They are **not** latent bugs. Unlike the `quantize()` Int32 overflow (OCCTSwiftViewport#30, reachable at ±21,474.8 units), a container with >2^31 elements isn't reachable here. The casts document intent and stop the noise — no behaviour change.

**On the dead bindings** — the issue asked to check whether any indicated an unfinished calculation. None did: `seamLength`, `arcNormalCandidate`, `aOuter1`/`bOuter1` were each leftover from an approach the surrounding comments already described as superseded (`extruded(by:)` takes the full vector; the arc is built through three points; only the v=0 cross-section is constructed and extruded). Removed the stale comments with them.

Also fixed two warnings **not** listed in #281 that a cached build had been hiding: a deprecated `String(cString:)` in `BRepGraph.swift` and `union(with:)` in `OCCTTest`. The former needed care — the bridge fills a fixed 128-byte NUL-terminated buffer, and the naive `String(decoding:as:)` replacement would have carried the NUL padding into the string, so decoding now stops at the terminator.

## Verification

- `swift build`: **0 warnings**
- Full suite: **4,359 tests, 0 failures** — including all six STEP `cone()` round-trips
- Patch applies cleanly and idempotently (`build-occt.sh` reports "already applied" on re-run)