### PR TITLE
docs: fix writeBREP allowInvalid signature drift and stale CHANGELOG header

### DIFF
--- a/Sources/OCCTSwift/Exporter.swift
+++ b/Sources/OCCTSwift/Exporter.swift
@@ -384,21 +384,31 @@ public enum Exporter {
     ///   - url: Destination file URL (should end in .brep)
     ///   - withTriangles: Include triangulation data (default: true)
     ///   - withNormals: Include normals with triangulation (default: false)
+    ///   - allowInvalid: When `true`, skip the `shape.isValid` pre-check and
+    ///     serialize the shape as-is. BREP is OCCT's lossless native format and
+    ///     `BRepTools::Write` does not require a topologically valid shape, so an
+    ///     in-progress reconstruction (a compound of loose analytic faces, possibly
+    ///     with a few invalid faces) can be persisted and later loaded for
+    ///     measurement / diagnostics. Defaults to `false` (the validity gate,
+    ///     matching the other exporters).
     ///
     /// - Throws: `ExportError` if export fails
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 20, depth: 30)
+    /// try Exporter.writeBREP(shape: box, to: URL(fileURLWithPath: "/tmp/box.brep"))
+    ///
+    /// // Persist an in-progress reconstruction that has not been healed yet.
+    /// try Exporter.writeBREP(shape: partialCompound,
+    ///                        to: URL(fileURLWithPath: "/tmp/wip.brep"),
+    ///                        allowInvalid: true)
+    /// ```
     ///
     /// ## Use Cases
     ///
     /// - Fast caching of intermediate geometry results
     /// - Debugging geometry issues
     /// - Archiving exact geometry for later processing
-    /// - Parameter allowInvalid: When `true`, skip the `shape.isValid`
-    ///   pre-check and serialize the shape as-is. BREP is OCCT's lossless
-    ///   native format and `BRepTools::Write` does not require a topologically
-    ///   valid shape, so an in-progress reconstruction (a compound of loose
-    ///   analytic faces, possibly with a few invalid faces) can be persisted
-    ///   and later loaded for measurement / diagnostics. Defaults to `false`
-    ///   (the validity gate, matching the other exporters).
     public static func writeBREP(
         shape: Shape,
         to url: URL,
@@ -707,6 +717,13 @@ extension Shape {
     ///   - url: Destination file URL
     ///   - withTriangles: Include triangulation data (default: true)
     ///   - withNormals: Include normals with triangulation (default: false)
+    ///   - allowInvalid: Skip the `isValid` pre-check and serialize as-is
+    ///     (default: false). See ``Exporter/writeBREP(shape:to:withTriangles:withNormals:allowInvalid:)``.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 20, depth: 30)
+    /// try box.writeBREP(to: URL(fileURLWithPath: "/tmp/box.brep"))
+    /// ```
     public func writeBREP(to url: URL, withTriangles: Bool = true, withNormals: Bool = false,
                           allowInvalid: Bool = false) throws {
         try Exporter.writeBREP(shape: self, to: url, withTriangles: withTriangles,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -716,7 +716,7 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `shape.writeSTL(to:deflection:)` | `StlAPI_Writer` |
 | `shape.writeSTEP(to:)` | `STEPControl_Writer` |
 | `shape.writeIGES(to:)` | `IGESControl_Writer` |
-| `shape.writeBREP(to:)` | `BRepTools::Write` |
+| `shape.writeBREP(to:allowInvalid:)` | `BRepTools::Write` |
 | `shape.writeOBJ(to:deflection:)` | `RWObj_CafWriter` |
 | `shape.writePLY(to:deflection:)` | `RWPly_CafWriter` |
 | `Exporter.optimizeSTEP(input:output:)` | `StepTidy_DuplicateCleaner` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.10.0
+## Current: v1.10.1
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 

--- a/docs/reference/Exporter.md
+++ b/docs/reference/Exporter.md
@@ -444,7 +444,7 @@ public static func igesData(shape: Shape) throws -> Data
 
 ## BREP Export
 
-### `Exporter.writeBREP(shape:to:withTriangles:withNormals:)`
+### `Exporter.writeBREP(shape:to:withTriangles:withNormals:allowInvalid:)`
 
 Writes a shape to OCCT's native BREP format.
 
@@ -453,8 +453,19 @@ public static func writeBREP(
     shape: Shape,
     to url: URL,
     withTriangles: Bool = true,
-    withNormals: Bool = false
+    withNormals: Bool = false,
+    allowInvalid: Bool = false
 ) throws
+```
+
+`allowInvalid` (added in v1.8.0) skips the `shape.isValid` pre-check and serializes the shape
+as-is. `BRepTools::Write` does not require a topologically valid shape, so an in-progress
+reconstruction can be persisted and reloaded for measurement / diagnostics:
+
+```swift
+try Exporter.writeBREP(shape: partialCompound,
+                       to: URL(fileURLWithPath: "/tmp/wip.brep"),
+                       allowInvalid: true)
 ```
 
 BREP is OCCT's own serialisation format. It preserves full B-Rep precision (curves, surfaces,
@@ -786,10 +797,11 @@ public func writeIGESBRep(to url: URL) throws
 
 ---
 
-### `Shape.writeBREP(to:withTriangles:withNormals:)`
+### `Shape.writeBREP(to:withTriangles:withNormals:allowInvalid:)`
 
 ```swift
-public func writeBREP(to url: URL, withTriangles: Bool = true, withNormals: Bool = false) throws
+public func writeBREP(to url: URL, withTriangles: Bool = true, withNormals: Bool = false,
+                      allowInvalid: Bool = false) throws
 ```
 
 ---

--- a/docs/reference/Exporter.md
+++ b/docs/reference/Exporter.md
@@ -474,7 +474,8 @@ embeds existing triangulation data so that re-meshing on import is not required.
 
 - **Parameters:** `shape` — shape to export; `url` — output URL (conventionally `.brep`);
   `withTriangles` — embed triangulation (default `true`);
-  `withNormals` — embed per-vertex normals with the triangulation (default `false`).
+  `withNormals` — embed per-vertex normals with the triangulation (default `false`);
+  `allowInvalid` — skip the `isValid` pre-check and serialise as-is (default `false`).
 - **Returns:** `Void`.
 - **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
   `ExportError.exportFailed` if `BRepTools::Write` fails.


### PR DESCRIPTION
Found while reconciling the `context` MCP index against the shipped release: the index was pinned at **occtswift@1.8.2** while **v1.10.1** is current — nine releases of drift. Before re-indexing, I audited whether the docs were actually current. Mostly yes (the CHANGELOG is complete through v1.10.1 and `docs/reference/` was diligently backfilled), but these were genuinely stale:

### `writeBREP(allowInvalid:)` — docs describe an API that no longer exists
`allowInvalid:` shipped in **v1.8.0**, ~2 months and 11 releases ago, but the docs never followed:

- `docs/reference/Exporter.md` documented the **pre-v1.8.0 signature** for both the static (`:447`) and instance (`:789`) overloads.
- `docs/API_REFERENCE.md` mapped `shape.writeBREP(to:)` with no hint of the parameter.
- In-source, the `- Parameter allowInvalid:` line was appended **after** the `## Use Cases` heading, so it rendered as a use-case bullet instead of a parameter. The instance overload omitted the param doc entirely.

This one mattered enough to fix before indexing — re-indexing would have baked a wrong signature into the answer every agent gets from `context`.

### Stale CHANGELOG header
`docs/CHANGELOG.md:10` said `## Current: v1.10.0` while the v1.10.1 entry sits eight lines below it.

### Also added
A fenced ```swift``` snippet on both `writeBREP` overloads, per the release discipline in `CLAUDE.md` step 8.

## Not in this PR
The sweep also turned up an **operation-count divergence**: `README.md` says 4,313, `docs/API_REFERENCE.md` says 3,431, and API_REFERENCE's own category rows sum to **3,320**. Both headline numbers were written in the same commit (`41d0956`, v1.8.8) and both predate v1.10.0. That needs a decision on which counting method is canonical, so it is filed separately rather than guessed at here.

## Verification
`swift build` — clean. Docs-only + doc-comment changes; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)