### PR TITLE
docs(#286): Shape.mesh can hang unboundedly on offset surfaces

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -757,6 +757,39 @@ public final class Shape: @unchecked Sendable {
     // MARK: - Meshing
 
     /// Generate a triangulated mesh for visualization
+    ///
+    /// - Warning: **This call can hang unboundedly on offset surfaces** — the geometry
+    ///   `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`). Measured on a
+    ///   fitted-then-offset B-spline panel: a single face meshed for **>300 s without returning**
+    ///   at a *coarse* deflection (1/638 of the shape's bbox diagonal), so this is a kernel
+    ///   pathology, not a workload cost. See
+    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286).
+    ///
+    ///   There is **no in-process way to bound it**, and it is worth being precise about why:
+    ///   - **A timeout cannot work.** OCCT polls for cancellation *between* faces
+    ///     (`BRepMesh_FaceDiscret::FaceListFunctor::operator()` checks `myScope.More()` before
+    ///     calling `process()`), and the Delaunay triangulation itself
+    ///     (`BRepMesh_DelaunayBaseMeshAlgo::generateMesh` → the `BRepMesh_Delaun` constructor)
+    ///     takes no progress range at all. A hang inside **one** face is therefore
+    ///     uninterruptible — ``meshWithProgress(linearDeflection:angularDeflection:progress:)``
+    ///     does not help here (it only buys per-face granularity, i.e. cancelling *between*
+    ///     faces of a multi-face shape).
+    ///   - **A validity pre-check cannot catch it.** The measured offending solid reports
+    ///     `isValid == true`.
+    ///
+    ///   **Mitigations**, in order of preference:
+    ///   1. **Don't mesh geometry you haven't sanity-checked.** `bounds` is a cheap `Bnd_Box`
+    ///      query with no tessellation — comparing a thickened solid's bbox against its source's
+    ///      is enough to reject the ballooned offsets that trigger this, and is what the
+    ///      downstream caller in #286 adopted.
+    ///   2. ``withSurfacesAsBSpline(extrusion:revolution:offset:plane:)`` with `offset: true`
+    ///      converts the `Geom_OffsetSurface` to a plain B-spline first. Measured on the #286
+    ///      solid this turns the unbounded hang into a **bounded 125 s** (526 k vertices) — it
+    ///      terminates, but is not fast, so treat it as a rescue path rather than a default.
+    ///   3. Mesh in a separate process if you must tessellate untrusted offset geometry.
+    ///
+    ///   Well-formed offset solids mesh normally; this only bites on pathological
+    ///   (e.g. ballooned or near-degenerate) fitted-then-offset surfaces.
     public func mesh(
         linearDeflection: Double = 0.1,
         angularDeflection: Double = 0.5
@@ -771,6 +804,16 @@ public final class Shape: @unchecked Sendable {
     /// observe meshing progress on large or finely-tessellated assemblies and cooperatively
     /// cancel via `progress.shouldCancel()`. After meshing completes, the shape's faces
     /// have triangulations attached and `mesh()` (no progress) can extract them.
+    ///
+    /// - Important: **Cancellation granularity is per-face, and only *between* faces.** OCCT
+    ///   checks the progress range before it starts each face
+    ///   (`BRepMesh_FaceDiscret::FaceListFunctor::operator()`), and the Delaunay triangulation
+    ///   itself (`BRepMesh_DelaunayBaseMeshAlgo::generateMesh` → `BRepMesh_Delaun`) takes no
+    ///   range and never polls. So this cancels a long *many-face* mesh, but **cannot interrupt
+    ///   a single face that hangs** — see the warning on
+    ///   ``mesh(linearDeflection:angularDeflection:)`` and
+    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286). Do not rely on this as a
+    ///   timeout for untrusted geometry.
     ///
     /// - Throws: `ImportError.cancelled` if the meshing was cancelled cooperatively.
     /// - Returns: The same shape (with triangulations attached) on success, or nil on

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,33 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### v1.10.2 (July 2026) — docs: `Shape.mesh` can hang unboundedly on offset surfaces (#286)
+
+Documentation only; no code change. `Shape.mesh(linearDeflection:angularDeflection:)` can put OCCT's
+mesher into an effectively non-terminating state on the `Geom_OffsetSurface` geometry that
+`shelled(thickness:)` / `offset(by:)` produce.
+
+Reproduced standalone from a real fitted-then-offset B-spline panel: a **single face meshed for
+>300 s without returning**, at a *coarse* deflection (2.48 against a 1583 bbox diagonal — 1/638). This
+is a kernel pathology, not a workload cost.
+
+Two things this is **not**, both worth recording because both were the obvious first guesses:
+
+- **Not fixable with a timeout.** OCCT polls cancellation only *between* faces
+  (`BRepMesh_FaceDiscret::FaceListFunctor::operator()` checks `myScope.More()` before `process()`),
+  and the Delaunay triangulation itself (`BRepMesh_DelaunayBaseMeshAlgo::generateMesh` → the
+  `BRepMesh_Delaun` constructor) takes no progress range and never polls. A hang inside **one** face
+  is uninterruptible, so `meshWithProgress` cannot rescue it — its docs now say so rather than
+  implying a cancellation guarantee it can't honour.
+- **Not catchable by a validity pre-check.** The offending solid reports `isValid == true`.
+
+Mitigations documented on `mesh`, best first: sanity-check with `bounds` (a cheap `Bnd_Box` query, no
+tessellation) before meshing untrusted offsets; `withSurfacesAsBSpline(offset: true)`, which converts
+the offset surface to a plain B-spline and turns the hang into a bounded 125 s / 526 k verts (a rescue
+path, not a default); or mesh out-of-process.
+
+Well-formed offset solids are unaffected.
+
 ### v1.10.1 (July 2026) — OCCT rebuild carrying the #280 kernel fix; consumer builds are warning-free (#281)
 
 **Rebuilt `OCCT.xcframework`** (all three slices) carrying a new carried patch,

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1215,6 +1215,18 @@ public func mesh(
       // use mesh.triangles, mesh.normals, etc.
   }
   ```
+- **⚠️ Can hang unboundedly on offset surfaces.** The geometry `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`) can put OCCT's mesher into an effectively non-terminating state. Measured on a fitted-then-offset B-spline panel: one face meshed for **>300 s without returning** at a *coarse* deflection (1/638 of the bbox diagonal) — a kernel pathology, not a workload cost ([#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286)).
+
+  **It cannot be bounded in-process**, and the reasons are worth knowing:
+  - **A timeout cannot work.** OCCT polls cancellation *between* faces (`BRepMesh_FaceDiscret`), and the Delaunay triangulation (`BRepMesh_Delaun`) takes no progress range and never polls. A hang inside **one** face is uninterruptible, so `meshWithProgress` does **not** help.
+  - **A validity pre-check cannot catch it.** The measured offending solid reports `isValid == true`.
+
+  Mitigations, best first:
+  1. **Sanity-check before meshing.** `bounds` is a cheap `Bnd_Box` query (no tessellation) — comparing a thickened solid's bbox against its source's rejects the ballooned offsets that trigger this.
+  2. `withSurfacesAsBSpline(offset: true)` converts the offset surface to a plain B-spline first. On the #286 solid this turns the hang into a **bounded 125 s** (526 k verts) — it terminates, but it is a rescue path, not a default.
+  3. Mesh in a separate process for untrusted offset geometry.
+
+  Well-formed offset solids mesh normally; this bites only on pathological (ballooned / near-degenerate) fitted-then-offset surfaces.
 
 ---
 


### PR DESCRIPTION
Addresses #286. **Docs only — because there is no correct code change to make in-process, and saying so precisely is the useful output.** Full analysis and a standalone reproducer are on the issue.

## Reproduced

Pure-OCCTSwift reproducer built from the real fixture (OCCTReconstruct `mmd_kiha10_skin_open.stl`, panel 0, with the `fitBallooned`/`solidBallooned` gates bypassed): load an 862 KB BREP, call `mesh(linearDeflection: 2.48058, angularDeflection: 0.3)` → **never returns** (killed at 300 s; the issue reported 45 s).

Isolated to **one face**: face 2, `surfaceType == offsetSurface` — the `Geom_OffsetSurface` that `shelled()` created over the fitted B-spline. It hangs *alone*.

Two facts that reshape the problem:
- The deflection is **coarse** — 2.48 against a 1583 bbox diagonal (1/638). This is a kernel pathology, **not** an expensive workload.
- The solid is **`isValid == true`**.

## Why neither proposed fix works

The issue suggested "a wrapper-level timeout or a pre-flight validity/degeneracy check". I tried to build the timeout, then read OCCT `V8_0_0_p1`'s source to find out why it couldn't be made to work:

- **A timeout cannot work.** Cancellation is polled only *between* faces — `BRepMesh_FaceDiscret::FaceListFunctor::operator()` checks `myScope.More()` **before** calling `process()` — and the triangulation itself takes no progress range at all:
  ```cpp
  // BRepMesh_DelaunayBaseMeshAlgo::generateMesh
  BRepMesh_Delaun aMesher(aStructure, aVerticesOrder, ...);  // ← no range, never polls
  if (!theRange.More()) { return; }                          // ← only AFTER it completes
  ```
  So a hang inside **one** face is uninterruptible. `meshWithProgress` cannot rescue this — and its docs previously implied a cancellation guarantee it can't honour, so they now state the per-face granularity explicitly.
- **A validity pre-check cannot catch it** — the offending solid is `isValid == true`.

## What this PR does

Documents the fragility precisely on `mesh`, corrects `meshWithProgress`'s docs, and records the mitigations, best first:

1. **Sanity-check before meshing** — `bounds` is a cheap `Bnd_Box` query with no tessellation; comparing a thickened solid's bbox against its source's rejects the ballooned offsets that trigger this. (This is what the downstream caller in #286 independently landed, and it's the right answer.)
2. **`withSurfacesAsBSpline(offset: true)`** — converts the offset surface to a plain B-spline first. **Measured: turns the unbounded hang into a bounded 125 s / 526 k verts.** It terminates, but it's a rescue path, not a default.
3. Mesh out-of-process for untrusted offset geometry.

Well-formed offset solids mesh normally; this bites only on pathological (ballooned / near-degenerate) fitted-then-offset surfaces.

## Not closing #286

This makes the trap visible and survivable; it does not fix the kernel. Leaving the issue open for the upstream OCCT report — I searched and found no existing upstream issue for it.