### PR TITLE
docs(#286): correct the mechanism — root-caused to the mesher's splitter choice

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -765,15 +765,22 @@ public final class Shape: @unchecked Sendable {
     ///   pathology, not a workload cost. See
     ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286).
     ///
+    ///   **Cause** (OCCT `V8_0_0_p1`): `BRepMesh_MeshAlgoFactory::GetAlgo` lumps
+    ///   `GeomAbs_OffsetSurface` in with `GeomAbs_OtherSurface`, handing it a
+    ///   `BRepMesh_UndefinedRangeSplitter` whose `getUndefinedIntervalNb()` returns a constant
+    ///   `1` — so an offset surface gets *no* parametric subdivision, however wiggly its basis
+    ///   B-spline is. (The same B-spline meshed directly gets `BRepMesh_NURBSRangeSplitter`,
+    ///   which subdivides by `NbUPoles()-1`.) The Delaunay insertion then starts from a
+    ///   near-empty grid and `BRepMesh_Delaun::createTrianglesOnNewVertices` blows up.
+    ///
     ///   There is **no in-process way to bound it**, and it is worth being precise about why:
-    ///   - **A timeout cannot work.** OCCT polls for cancellation *between* faces
-    ///     (`BRepMesh_FaceDiscret::FaceListFunctor::operator()` checks `myScope.More()` before
-    ///     calling `process()`), and the Delaunay triangulation itself
-    ///     (`BRepMesh_DelaunayBaseMeshAlgo::generateMesh` → the `BRepMesh_Delaun` constructor)
-    ///     takes no progress range at all. A hang inside **one** face is therefore
-    ///     uninterruptible — ``meshWithProgress(linearDeflection:angularDeflection:progress:)``
-    ///     does not help here (it only buys per-face granularity, i.e. cancelling *between*
-    ///     faces of a multi-face shape).
+    ///   - **A timeout cannot work — verified empirically, not assumed.**
+    ///     `createTrianglesOnNewVertices` *does* poll (`aPS.More()`) in its outer per-vertex
+    ///     loop, but the hang is inside a *single* iteration of that loop, so the poll is never
+    ///     reached. A 10 s cancel deadline via
+    ///     ``meshWithProgress(linearDeflection:angularDeflection:progress:)`` was measured
+    ///     **not to fire at all** on the #286 solid (killed at 120 s). Do not rely on it as a
+    ///     timeout for untrusted geometry.
     ///   - **A validity pre-check cannot catch it.** The measured offending solid reports
     ///     `isValid == true`.
     ///
@@ -805,15 +812,13 @@ public final class Shape: @unchecked Sendable {
     /// cancel via `progress.shouldCancel()`. After meshing completes, the shape's faces
     /// have triangulations attached and `mesh()` (no progress) can extract them.
     ///
-    /// - Important: **Cancellation granularity is per-face, and only *between* faces.** OCCT
-    ///   checks the progress range before it starts each face
-    ///   (`BRepMesh_FaceDiscret::FaceListFunctor::operator()`), and the Delaunay triangulation
-    ///   itself (`BRepMesh_DelaunayBaseMeshAlgo::generateMesh` → `BRepMesh_Delaun`) takes no
-    ///   range and never polls. So this cancels a long *many-face* mesh, but **cannot interrupt
-    ///   a single face that hangs** — see the warning on
-    ///   ``mesh(linearDeflection:angularDeflection:)`` and
-    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286). Do not rely on this as a
-    ///   timeout for untrusted geometry.
+    /// - Important: **This cancels a long mesh; it cannot interrupt a hung one.** OCCT polls the
+    ///   range at checkpoints — before each face (`BRepMesh_FaceDiscret`), and per vertex inside
+    ///   `BRepMesh_Delaun::createTrianglesOnNewVertices` — but a hang that occurs *between* two
+    ///   checkpoints is unreachable. Measured on the #286 solid: a 10 s cancel deadline **never
+    ///   fired** (killed at 120 s). Do not rely on this as a timeout for untrusted geometry —
+    ///   see the warning on ``mesh(linearDeflection:angularDeflection:)`` and
+    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286).
     ///
     /// - Throws: `ImportError.cancelled` if the meshing was cancelled cooperatively.
     /// - Returns: The same shape (with triangulations attached) on success, or nil on

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,33 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### v1.10.3 (July 2026) — docs: correct the #286 mechanism (root-caused to the mesher's splitter choice)
+
+Corrects v1.10.2, which named the wrong OCCT code. The conclusion there was right — `Shape.mesh` can
+hang unboundedly on offset surfaces, and no in-process timeout can bound it — but the stated mechanism
+was wrong, and it pointed anyone investigating at the wrong function.
+
+**v1.10.2 said:** the hang is in the range-less `BRepMesh_Delaun` constructor, so cancellation is never
+polled.
+
+**Actually** (from a stack sample of the hang, plus OCCT `V8_0_0_p1` source): the hang is in
+`BRepMesh_Delaun::createTrianglesOnNewVertices`, reached via `postProcessMesh → insertNodes →
+AddVertices`. That function *does* receive a progress range and *does* poll it (`aPS.More()`) in its
+outer per-vertex loop — but the hang is inside a *single* iteration, so the poll is never reached. The
+"no timeout is possible" conclusion is unchanged and is now **verified rather than inferred**: a 10 s
+cancel deadline via `meshWithProgress` was measured not to fire at all (killed at 120 s).
+
+**Root cause, now identified:** `BRepMesh_MeshAlgoFactory::GetAlgo` lumps `GeomAbs_OffsetSurface` in
+with `GeomAbs_OtherSurface` and hands it a `BRepMesh_UndefinedRangeSplitter`, whose
+`getUndefinedIntervalNb()` returns a constant `1`. An offset surface therefore gets **no parametric
+subdivision at all**, however wiggly its basis B-spline is, while the same B-spline meshed directly
+gets `BRepMesh_NURBSRangeSplitter` (subdividing by `NbUPoles()-1`). The Delaunay insertion starts from
+a near-empty grid and blows up. This also explains why the documented
+`withSurfacesAsBSpline(offset: true)` mitigation works: it converts the surface to a B-spline, which
+routes it to the correct splitter.
+
+An upstream OCCT fix is being attempted against this root cause; see #286.
+
 ### v1.10.2 (July 2026) — docs: `Shape.mesh` can hang unboundedly on offset surfaces (#286)
 
 Documentation only; no code change. `Shape.mesh(linearDeflection:angularDeflection:)` can put OCCT's

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1217,8 +1217,10 @@ public func mesh(
   ```
 - **⚠️ Can hang unboundedly on offset surfaces.** The geometry `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`) can put OCCT's mesher into an effectively non-terminating state. Measured on a fitted-then-offset B-spline panel: one face meshed for **>300 s without returning** at a *coarse* deflection (1/638 of the bbox diagonal) — a kernel pathology, not a workload cost ([#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286)).
 
+  **Cause** (OCCT `V8_0_0_p1`): `BRepMesh_MeshAlgoFactory::GetAlgo` lumps `GeomAbs_OffsetSurface` in with `GeomAbs_OtherSurface`, handing it a `BRepMesh_UndefinedRangeSplitter` whose `getUndefinedIntervalNb()` returns a constant `1` — so an offset surface gets *no* parametric subdivision, however wiggly its basis B-spline is. (The same B-spline meshed directly gets `BRepMesh_NURBSRangeSplitter`, which subdivides by `NbUPoles()-1`.) The Delaunay insertion then starts from a near-empty grid and `BRepMesh_Delaun::createTrianglesOnNewVertices` blows up.
+
   **It cannot be bounded in-process**, and the reasons are worth knowing:
-  - **A timeout cannot work.** OCCT polls cancellation *between* faces (`BRepMesh_FaceDiscret`), and the Delaunay triangulation (`BRepMesh_Delaun`) takes no progress range and never polls. A hang inside **one** face is uninterruptible, so `meshWithProgress` does **not** help.
+  - **A timeout cannot work — verified, not assumed.** `createTrianglesOnNewVertices` *does* poll (`aPS.More()`) in its outer per-vertex loop, but the hang is inside a *single* iteration, so the poll is never reached. A 10 s cancel deadline via `meshWithProgress` was measured **not to fire at all** (killed at 120 s).
   - **A validity pre-check cannot catch it.** The measured offending solid reports `isValid == true`.
 
   Mitigations, best first:


### PR DESCRIPTION
Corrects #288 (v1.10.2). **The conclusion there was right; the stated mechanism was wrong**, and it pointed anyone investigating at the wrong OCCT function. Docs only.

## What I got wrong

v1.10.2 claimed the hang sits in the **range-less `BRepMesh_Delaun` constructor**, so cancellation is never polled. I inferred that from reading `generateMesh`, and stopped reading too early.

A stack sample of the actual hang says otherwise — 100% of samples are here:

```
BRepMesh_DelaunayDeflectionControlMeshAlgo::postProcessMesh
 → BRepMesh_DelaunayNodeInsertionMeshAlgo::insertNodes
   → BRepMesh_Delaun::AddVertices(…, Message_ProgressRange const&)
     → BRepMesh_Delaun::createTrianglesOnNewVertices(…, Message_ProgressRange const&)   ← 4778/4778
```

That function **does** take a progress range and **does** poll it (`aPS.More()`) in its outer per-vertex loop. My cited reason was simply not the reason.

## The conclusion is unchanged — and now verified rather than inferred

The hang is inside a *single* iteration of that outer loop, so the poll is never reached. Rather than infer again, I measured it: a **10 s cancel deadline via `meshWithProgress` never fired at all** (process killed at 120 s). "No in-process timeout is possible" stands.

## Root cause, now actually identified

`BRepMesh_MeshAlgoFactory::GetAlgo` (OCCT `V8_0_0_p1`):

```cpp
case GeomAbs_BezierSurface:
case GeomAbs_BSplineSurface:
  return new DeflectionControlMeshAlgo<BRepMesh_NURBSRangeSplitter>::Type;
case GeomAbs_OffsetSurface:      // ← lumped in with "other"
case GeomAbs_OtherSurface:
default:
  return new DeflectionControlMeshAlgo<BRepMesh_UndefinedRangeSplitter>::Type;
```

and

```cpp
int BRepMesh_UndefinedRangeSplitter::getUndefinedIntervalNb(...) const { return 1; }
```

An offset surface therefore gets **no parametric subdivision at all**, however wiggly its basis B-spline is — while that same B-spline meshed directly gets `BRepMesh_NURBSRangeSplitter` (`NbUPoles()-1` intervals). The Delaunay insertion starts from a near-empty grid and `createTrianglesOnNewVertices` blows up.

This also explains, retroactively, **why the documented `withSurfacesAsBSpline(offset: true)` mitigation works** (hang → bounded 125 s): converting to a B-spline routes the surface to the correct splitter. That was an empirical finding in v1.10.2; now it has a reason.

An upstream OCCT fix is being attempted against this root cause — brief on #286.