### PR TITLE
Derive the operation count from source rather than hand-maintaining it (#289)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,313 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,234 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+count-operations.py — derive OCCTSwift's canonical operation count and keep the two
+headline figures from drifting apart.
+
+CANONICAL COUNTING RULE (decided on issue #289):
+
+    One row per distinct public Swift entry point; overloads counted separately.
+
+Concretely, an "operation" is any of these in the `OCCTSwift` module:
+
+    public func / public static func / public class func
+    public init
+    public var  — computed only (has a `{` accessor block)
+    public subscript
+
+Overloads count separately: `cylinder(radius:height:)` and
+`cylinder(at:direction:radius:height:)` are two operations, because they are two distinct
+entry points a caller can reach.
+
+NOT operations (they are data, not entry points):
+    public let                       — stored constants
+    public var x: T = ...            — stored properties (no accessor block)
+    enum cases, typealiases, types   — documented, but not called
+
+Why derive rather than hand-maintain: README and docs/API_REFERENCE.md desynced by 882
+across 11 releases, and API_REFERENCE's own Total sat 111 above the sum of its rows —
+both written in the same commit, so at most one was ever right (#289).
+
+Usage:
+    ./Scripts/count-operations.py           # report; exit 1 if the docs disagree
+    ./Scripts/count-operations.py --fix     # rewrite README + API_REFERENCE Total
+    ./Scripts/count-operations.py --audit   # list counted entry points with no reference doc
+"""
+import re
+import sys
+import glob
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+FUNC = re.compile(r'^\s*public\s+(?:static\s+|class\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)')
+INIT = re.compile(r'^\s*public\s+(?:convenience\s+)?init[?!]?\s*\(')
+# computed property: an accessor block `{` and no `=` before it. A stored `public let x: T`
+# or `public var x = 0` has no brace and is data, not an entry point.
+CVAR = re.compile(r'^\s*public\s+(?:static\s+)?var\s+([A-Za-z_][A-Za-z0-9_]*)\b[^=]*\{')
+SUBS = re.compile(r'^\s*public\s+(?:static\s+)?subscript\s*\(')
+# reference docs use both ### and #### for entry points
+DOC_HEADING = re.compile(r'^#{3,4} `([^`]+)`')
+
+
+def count_entry_points():
+    """Returns (total, breakdown, {name: (file, line)})."""
+    breakdown = {"func": 0, "init": 0, "computed var": 0, "subscript": 0}
+    names = {}
+    for f in sorted(glob.glob(os.path.join(ROOT, "Sources/OCCTSwift/*.swift"))):
+        rel = os.path.relpath(f, ROOT)
+        for i, line in enumerate(open(f, encoding="utf-8", errors="replace"), 1):
+            m = FUNC.match(line)
+            if m:
+                breakdown["func"] += 1
+                names.setdefault(m.group(1), (rel, i))
+                continue
+            if INIT.match(line):
+                breakdown["init"] += 1
+                continue
+            m = CVAR.match(line)
+            if m:
+                breakdown["computed var"] += 1
+                names.setdefault(m.group(1), (rel, i))
+                continue
+            if SUBS.match(line):
+                breakdown["subscript"] += 1
+    return sum(breakdown.values()), breakdown, names
+
+
+def documented_names():
+    doc = set()
+    for f in glob.glob(os.path.join(ROOT, "docs/reference/*.md")):
+        for line in open(f, encoding="utf-8", errors="replace"):
+            m = DOC_HEADING.match(line)
+            if not m:
+                continue
+            # `Type.name(labels:)` -> `name`
+            h = m.group(1).split('(')[0].split('.')[-1].strip()
+            if h:
+                doc.add(h)
+    return doc
+
+
+def read_stated():
+    """The two headline figures currently in the docs."""
+    readme = os.path.join(ROOT, "README.md")
+    apiref = os.path.join(ROOT, "docs/API_REFERENCE.md")
+    r = re.search(r'\*\*([\d,]+) wrapped operations\*\*', open(readme, encoding="utf-8").read())
+    a = re.search(r'^\|\s*\*\*Total\*\*\s*\|\s*\*\*([\d,]+)\*\*\s*\|', open(apiref, encoding="utf-8").read(), re.M)
+    return (int(r.group(1).replace(',', '')) if r else None,
+            int(a.group(1).replace(',', '')) if a else None)
+
+
+def category_row_sum():
+    apiref = os.path.join(ROOT, "docs/API_REFERENCE.md")
+    total = 0
+    rows = 0
+    for line in open(apiref, encoding="utf-8"):
+        m = re.match(r'^\|\s*\*\*(.+?)\*\*\s*\|\s*\*?\*?(\d+)\*?\*?\s*\|', line)
+        if m and m.group(1).lower() != "total":
+            total += int(m.group(2))
+            rows += 1
+    return total, rows
+
+
+def fix(derived):
+    readme = os.path.join(ROOT, "README.md")
+    s = open(readme, encoding="utf-8").read()
+    new_s, n = re.subn(r'\*\*[\d,]+ wrapped operations\*\*', f'**{derived:,} wrapped operations**', s, count=1)
+    if n != 1:
+        sys.exit("README: could not find the 'N wrapped operations' headline — refusing to guess")
+    open(readme, "w", encoding="utf-8").write(new_s)
+
+    apiref = os.path.join(ROOT, "docs/API_REFERENCE.md")
+    s = open(apiref, encoding="utf-8").read()
+    new_s, n = re.subn(r'^(\|\s*\*\*Total\*\*\s*\|\s*\*\*)[\d,]+(\*\*\s*\|)',
+                       rf'\g<1>{derived:,}\g<2>', s, count=1, flags=re.M)
+    if n != 1:
+        sys.exit("API_REFERENCE: could not find the Total row — refusing to guess")
+    open(apiref, "w", encoding="utf-8").write(new_s)
+    print(f"  rewrote README + API_REFERENCE Total -> {derived:,}")
+
+
+def main():
+    derived, breakdown, names = count_entry_points()
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    if mode == "--audit":
+        doc = documented_names()
+        undoc = sorted(set(names) - doc)
+        print(f"counted entry points with NO reference doc: {len(undoc)}\n")
+        for n in undoc:
+            f, i = names[n]
+            print(f"  {n:<34} {f}:{i}")
+        return 1 if undoc else 0
+
+    print("Canonical rule (#289): one row per distinct public Swift entry point; overloads counted separately.\n")
+    for k, v in sorted(breakdown.items(), key=lambda x: -x[1]):
+        print(f"  {k:<15} {v:>5}")
+    print(f"  {'DERIVED':<15} {derived:>5}\n")
+
+    readme_n, apiref_n = read_stated()
+    rowsum, rowcount = category_row_sum()
+    print(f"  README headline        {readme_n:>5}" + ("  ✓" if readme_n == derived else f"  ✗ (should be {derived})"))
+    print(f"  API_REFERENCE Total    {apiref_n:>5}" + ("  ✓" if apiref_n == derived else f"  ✗ (should be {derived})"))
+    print(f"  sum of {rowcount} category rows  {rowsum:>5}   (illustrative categorisation; see the note in API_REFERENCE)")
+
+    if mode == "--fix":
+        fix(derived)
+        return 0
+    return 0 if (readme_n == derived and apiref_n == derived) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -5,8 +5,29 @@ nav_order: 4
 
 # API Map (Swift ↔ OCCT)
 
-Complete mapping of OCCTSwift operations to OCCT C++ classes. For the detailed per-type function
+Mapping of OCCTSwift operations to OCCT C++ classes. For the detailed per-type function
 reference (signatures, parameters, examples), see [API Reference](reference/).
+
+## How operations are counted
+
+> **One row per distinct public Swift entry point; overloads counted separately.**
+
+An operation is any `public func` / `static func`, `public init`, `public var` **with an accessor
+block** (a computed property), or `public subscript` in the `OCCTSwift` module. Overloads count
+separately — `cylinder(radius:height:)` and `cylinder(at:direction:radius:height:)` are two entry
+points a caller can reach, so they are two operations. Stored properties (`public let`, `public var x = …`)
+are data, not entry points, and are not counted; nor are types or enum cases, which are documented
+but not called.
+
+**The `Total` below is derived, not hand-maintained.** Run `Scripts/count-operations.py` (`--fix`
+rewrites both this Total and the README headline; exit 1 if they disagree). Hand-maintained totals in
+two files desynced by 882 across 11 releases before this rule existed — see
+[#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
+
+**The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
+categorisation covering **3,320** of the 4,234 entry points (~78%); the remainder are real, callable,
+and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
+a map of the major areas, and the `Total` as the count.
 
 ## Wrapped Operations Summary
 
@@ -482,7 +503,7 @@ reference (signatures, parameters, examples), see [API Reference](reference/).
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **3431** | |
+| **Total** | **4,234** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,43 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.10.2
+## Current: v1.10.3
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.10.3 (July 2026) — docs: canonical operation count, derived not hand-maintained (#289)
+
+The headline operation count was stated in two places with **three numbers in play**: README said
+4,313, `docs/API_REFERENCE.md`'s `Total` said 3,431, and that table's own 470 category rows summed to
+3,320. Both headline figures were last written in the *same* commit, so at most one was ever right,
+and both predated v1.10.0.
+
+**Canonical rule, now written down** (`docs/API_REFERENCE.md` § How operations are counted):
+
+> One row per distinct public Swift entry point; overloads counted separately.
+
+An operation is any `public func`/`static func`, `public init`, `public var` **with an accessor
+block**, or `public subscript` in the `OCCTSwift` module. Stored properties, types and enum cases are
+data, not entry points, and are not counted. The derived count is **4,234**.
+
+**Derived, not hand-maintained.** `Scripts/count-operations.py` computes it from source and rewrites
+both figures (`--fix`), exiting 1 if they disagree — the drift class is now mechanically impossible.
+`--audit` lists counted entry points with no reference page.
+
+The 882 gap turned out to be exactly what #289 suspected: **two divergent methodologies.** README's
+4,313 was ~the full entry-point surface (80 off today's derived 4,234 — stale, not wrong-in-kind),
+while API_REFERENCE's rows are a curated *categorisation* covering 3,320 (~78%) of the surface. The
+`Total` and the row sum were never measuring the same thing; the table now says so explicitly rather
+than implying the rows should add up.
+
+**Docs coverage audit** (the same pass): 39 counted entry points had no reference documentation. Two
+were counted in API_REFERENCE's own example lists while being undocumented — `Shape.commonAll(_:)`
+(Booleans) and `hollowed(removingFaces:thickness:tolerance:joinType:)` (Modifications) — both now
+documented beside their siblings. The remaining 37 are tracked in #294.
 
 ### v1.10.2 (July 2026) — docs: `Shape.mesh` can hang unboundedly on offset surfaces (#286)
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -1628,6 +1628,26 @@ More robust than sequential pairwise `union(with:)` calls — processes all inte
 
 ---
 
+### `Shape.commonAll(_:)`
+
+Intersect multiple shapes simultaneously — the intersection counterpart to `fuseAll(_:)`.
+
+```swift
+public static func commonAll(_ shapes: [Shape]) -> Shape?
+```
+
+Computes the common volume of all inputs at once. Same rationale as `fuseAll(_:)`: multi-tool mode avoids the intermediate tolerance accumulation of chained pairwise `intersection(_:)` calls. Requires at least two shapes.
+
+- **Parameters:** `shapes` — array of shapes to intersect (must have ≥ 2 elements).
+- **Returns:** Common shape (intersection of all), or nil on failure.
+- **OCCT:** `BRepAlgoAPI_Common` multi-tool mode (via `OCCTShapeCommonMulti`).
+- **Example:**
+  ```swift
+  if let overlap = Shape.commonAll([a, b, c]) { }
+  ```
+
+---
+
 ## Multi-Offset Wire
 
 ### `multiOffsetWires(offsets:joinType:)`

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -947,9 +947,40 @@ public func shelled(thickness: Double) -> Shape?
 - **Parameters:** `thickness` — wall thickness (positive = shell walls of this thickness).
 - **Returns:** Hollow shell, or `nil` on failure.
 - **OCCT:** `BRepOffsetAPI_MakeThickSolid`.
+- **Warning:** The offset surfaces this produces (`Geom_OffsetSurface`) can hang the mesher unboundedly on pathological input — see the warning on [`mesh(linearDeflection:angularDeflection:)`](#meshlineardeflectionangulardeflection) ([#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286)).
 - **Example:**
   ```swift
   if let shell = Shape.box(width: 10, height: 10, depth: 10)?.shelled(thickness: 1) { }
+  ```
+
+---
+
+### `hollowed(removingFaces:thickness:tolerance:joinType:)`
+
+Remove the specified faces and shell the rest to a uniform wall thickness — the removed faces become the openings.
+
+```swift
+public func hollowed(removingFaces faceIndices: [Int],
+                     thickness: Double,
+                     tolerance: Double = 1e-3,
+                     joinType: OffsetJoinType = .arc) -> Shape?
+```
+
+Where `shelled(thickness:)` closes the solid entirely, this is the open-box case: pass the 0-based indices of the faces to remove. Returns `nil` if `faceIndices` is empty.
+
+- **Parameters:**
+  - `faceIndices` — 0-based indices of the faces to remove (they become openings).
+  - `thickness` — wall thickness (positive = offset inward).
+  - `tolerance` — tolerance for the operation (default `1e-3`).
+  - `joinType` — how to join offset edges (default `.arc`).
+- **Returns:** Hollowed solid, or `nil` on failure.
+- **OCCT:** `BRepOffsetAPI_MakeThickSolid` (via `OCCTShapeMakeThickSolid`).
+- **Warning:** As with `shelled(thickness:)`, the resulting offset surfaces can hang the mesher on pathological input ([#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286)).
+- **Example:**
+  ```swift
+  // An open-topped box: remove face 5, keep 1 mm walls.
+  if let tray = Shape.box(width: 20, height: 20, depth: 10)?
+                     .hollowed(removingFaces: [5], thickness: 1) { }
   ```
 
 ---


### PR DESCRIPTION
Closes #289.

## What #289 asked

Why does README say **4,313 wrapped operations** while `docs/API_REFERENCE.md` says **3,431**?

## What it turned out to be

Three numbers, not two — API_REFERENCE's `Total` (3,431) was itself 111 above the sum of its own 470
category rows (3,320). Both headline figures were last written in the **same commit**, so at most one
was ever right, and both predate v1.10.0.

The 882 gap is **two divergent methodologies**, exactly as #289 suspected:

- README's 4,313 was ~the full public entry-point surface — 80 off today's derived 4,234, so **stale, not wrong-in-kind**.
- API_REFERENCE's rows are a curated **categorisation** covering 3,320 (~78%) of that surface. `Total` and the row sum were never measuring the same thing.

## What this PR does

**Writes the rule down** (`docs/API_REFERENCE.md` § How operations are counted), per the methodology agreed on the issue:

> One row per distinct public Swift entry point; overloads counted separately.

An operation is any `public func`/`static func`, `public init`, `public var` **with an accessor block**, or `public subscript` in the `OCCTSwift` module. Stored properties, types and enum cases are data, not entry points, and are not counted.

| | |
|---|---|
| `func` | 3,109 |
| computed `var` | 948 |
| `init` | 176 |
| `subscript` | 1 |
| **Derived** | **4,234** |

**Makes it derived, not hand-maintained.** `Scripts/count-operations.py` computes the count from source and rewrites both figures (`--fix`), exiting 1 if they disagree. The drift class is now mechanically impossible rather than merely corrected — which is the point, given it survived 11 releases.

**Stops the table implying its rows are a total.** The 470 category rows are labelled illustrative, with the ~78% coverage stated explicitly.

## Docs coverage audit

The same pass (`--audit`) found 39 counted entry points with no reference doc. **Two were listed in API_REFERENCE's own example rows while being undocumented** — `Shape.commonAll(_:)` (Booleans) and `hollowed(removingFaces:thickness:tolerance:joinType:)` (Modifications). Both are now documented beside their siblings, with the #286 offset-surface mesher-hang warning cross-linked from `hollowed`/`shelled` since those are what produce that input class.

The remaining 37 are **#294**, with the caveat recorded there that `--audit` matches by bare name and so over-reports on generic names like `get`/`cols`/`z`.

## Verification

```
$ ./Scripts/count-operations.py
  README headline         4234  ✓
  API_REFERENCE Total     4234  ✓
  sum of 470 category rows   3320   (illustrative categorisation; see the note in API_REFERENCE)
$ swift build   # 0 errors, 0 warnings
```

Docs-only + a script; no source change. Needs a tag to reach agents regardless — `context` indexes by release tag — so this should ship as **v1.10.3** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)