### PR TITLE
feat(TopologyGraph): absorb a boolean's history so a picked face survives it (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,234 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,237 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -98,16 +98,21 @@ def read_stated():
             int(a.group(1).replace(',', '')) if a else None)
 
 
-def category_row_sum():
-    apiref = os.path.join(ROOT, "docs/API_REFERENCE.md")
+def category_row_sum_text(s):
+    """(sum, count) of the category rows in API_REFERENCE text, excluding the Total row."""
     total = 0
     rows = 0
-    for line in open(apiref, encoding="utf-8"):
+    for line in s.splitlines():
         m = re.match(r'^\|\s*\*\*(.+?)\*\*\s*\|\s*\*?\*?(\d+)\*?\*?\s*\|', line)
         if m and m.group(1).lower() != "total":
             total += int(m.group(2))
             rows += 1
     return total, rows
+
+
+def category_row_sum():
+    apiref = os.path.join(ROOT, "docs/API_REFERENCE.md")
+    return category_row_sum_text(open(apiref, encoding="utf-8").read())
 
 
 def fix(derived):
@@ -124,8 +129,20 @@ def fix(derived):
                        rf'\g<1>{derived:,}\g<2>', s, count=1, flags=re.M)
     if n != 1:
         sys.exit("API_REFERENCE: could not find the Total row — refusing to guess")
+
+    # The prose figure for the row sum drifts by the same mechanism as the Total did:
+    # it is written by hand and nothing checks it. Derive it too, or #289 recurs here
+    # the moment someone adds a category row.
+    rowsum, _ = category_row_sum_text(new_s)
+    pct = round(100 * rowsum / derived)
+    new_s, n = re.subn(r'(covering \*\*)[\d,]+(\*\* of the entry points \(~)\d+(%)',
+                       rf'\g<1>{rowsum:,}\g<2>{pct}\g<3>', new_s, count=1)
+    if n != 1:
+        sys.exit("API_REFERENCE: could not find the 'covering **N** of the entry points (~P%)' "
+                 "note — refusing to guess")
     open(apiref, "w", encoding="utf-8").write(new_s)
     print(f"  rewrote README + API_REFERENCE Total -> {derived:,}")
+    print(f"  rewrote the categorisation note -> {rowsum:,} (~{pct}%)")
 
 
 def main():

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -4722,6 +4722,20 @@ int32_t OCCTBooleanHistoryGenerated(OCCTBooleanHistoryRef _Nonnull history,
 bool OCCTBooleanHistoryIsDeleted(OCCTBooleanHistoryRef _Nonnull history,
                                    OCCTShapeRef _Nonnull inputSubShape);
 
+/// Opaque handle to BRepTools_History.
+typedef void* _Nullable OCCTHistoryRef;
+
+/// Synthesize a standalone BRepTools_History from the retained builder (issue #290).
+///
+/// Works for every *WithHistory op, including fillet / chamfer / thick-solid,
+/// which have no native History(). Only VERTEX / EDGE / FACE / SOLID are carried
+/// (BRepTools_History::IsSupportedType) — wires, shells and compounds are not.
+///
+/// @return An OCCTHistoryRef the caller owns (free with OCCTHistoryDestroy), or
+///         NULL on failure. Feed it to OCCTBRepGraphAddWithHistory to record the
+///         operation into a graph's history log.
+OCCTHistoryRef OCCTBooleanHistoryAsBRepToolsHistory(OCCTBooleanHistoryRef _Nonnull history);
+
 void OCCTBooleanHistoryRelease(OCCTBooleanHistoryRef _Nonnull history);
 
 /// Top-level children of a compound shape (TopoDS_Iterator). Returns count,
@@ -6421,8 +6435,8 @@ typedef struct {
 /// Shapes must be meshed beforehand (BRepMesh_IncrementalMesh).
 OCCTPolyDistanceResult OCCTShapePolyhedralDistance(OCCTShapeRef shape1, OCCTShapeRef shape2);
 
-/// Opaque handle to BRepTools_History.
-typedef void* _Nullable OCCTHistoryRef;
+// OCCTHistoryRef is typedef'd at its first use, in the boolean-history section
+// above (OCCTBooleanHistoryAsBRepToolsHistory).
 
 /// Create an empty shape modification history.
 OCCTHistoryRef OCCTHistoryCreate(void);
@@ -20208,6 +20222,53 @@ void OCCTBRepGraphHistoryRecord(OCCTBRepGraphRef _Nonnull graph,
                                  const int32_t* _Nullable replKinds,
                                  const int32_t* _Nullable replIndices,
                                  int32_t replCount);
+
+/// True if a recorded operation consumed this node, leaving no image in the result.
+/// Distinct from "has no modified record" — absence of a record is not deletion.
+bool OCCTBRepGraphHistoryIsDeleted(OCCTBRepGraphRef _Nonnull graph,
+                                    int32_t kind,
+                                    int32_t index);
+
+/// The graph's full deleted set. Returns the total count; writes up to maxCount pairs.
+int32_t OCCTBRepGraphHistoryDeletedNodes(OCCTBRepGraphRef _Nonnull graph,
+                                          int32_t* _Nullable outKinds,
+                                          int32_t* _Nullable outIndices,
+                                          int32_t maxCount);
+
+/// Add an OCCT algorithm result to `graph` and absorb its BRepTools_History into
+/// the graph's history log (issue #290).
+///
+/// This is the supported way to keep referring to an entity across an operation
+/// that rebuilds the shape (booleans, fillets, ...). The input and the result live
+/// in the SAME graph, so history is NodeId-keyed and the input's existing NodeRefs
+/// and UIDs stay valid — there is no generation boundary and no cross-graph UID
+/// lookup involved. After this call, currentForms(of:) on an input node returns
+/// its successors, and the TopologyRef recipes (.splitOf / .createdBy) resolve
+/// against the emitted records.
+///
+/// `inputRootKinds` / `inputRootIndices` name the nodes in `graph` whose subshapes
+/// should be tracked; the input map is collected via
+/// BRepGraph_ShapesView::CollectHistoryInputs, so those roots must already be in
+/// `graph` (i.e. the graph the operation's input shape was built from).
+///
+/// Only VERTEX / EDGE / FACE / SOLID are carried (BRepTools_History::IsSupportedType).
+///
+/// @param graph       graph holding the inputs, and receiving the result
+/// @param resultShape the OCCT algorithm's result shape
+/// @param history     from OCCTBooleanHistoryAsBRepToolsHistory (NULL is a no-op)
+/// @param opName      label written into every emitted record
+/// @param outRootKind  if non-null, set to the added result's topology-root kind
+/// @param outRootIndex if non-null, set to the added result's topology-root index
+/// @return true if the result was added and the history absorbed.
+bool OCCTBRepGraphAddWithHistory(OCCTBRepGraphRef _Nonnull graph,
+                                  OCCTShapeRef _Nonnull resultShape,
+                                  OCCTHistoryRef history,
+                                  const int32_t* _Nonnull inputRootKinds,
+                                  const int32_t* _Nonnull inputRootIndices,
+                                  int32_t inputRootCount,
+                                  const char* _Nonnull opName,
+                                  int32_t* _Nullable outRootKind,
+                                  int32_t* _Nullable outRootIndex);
 
 // --- Poly Counts ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -965,6 +965,84 @@ void OCCTBRepGraphHistoryRecord(OCCTBRepGraphRef g,
     } catch (...) {}
 }
 
+// True if some recorded operation consumed this node with no image in the result.
+// Distinct from "has no Modified record": absence of a record is not deletion.
+bool OCCTBRepGraphHistoryIsDeleted(OCCTBRepGraphRef g, int32_t kind, int32_t index) {
+    if (!g) return false;
+    try {
+        auto hist = bgHistory(g);
+        if (hist.IsNull()) return false;
+        return hist->IsDeleted(BRepGraph_NodeId((BRepGraph_NodeId::Kind)kind, index));
+    } catch (...) { return false; }
+}
+
+// Full deleted set. Returns the total count; writes up to maxCount pairs.
+int32_t OCCTBRepGraphHistoryDeletedNodes(OCCTBRepGraphRef g,
+                                          int32_t* outKinds,
+                                          int32_t* outIndices,
+                                          int32_t maxCount) {
+    if (!g) return 0;
+    try {
+        auto hist = bgHistory(g);
+        if (hist.IsNull()) return 0;
+        const auto& deleted = hist->DeletedNodes();
+        int32_t total = 0;
+        for (NCollection_FlatMap<BRepGraph_NodeId>::Iterator it(deleted); it.More(); it.Next()) {
+            if (outKinds && outIndices && total < maxCount) {
+                outKinds[total] = (int32_t)it.Key().NodeKind;
+                outIndices[total] = it.Key().Index;
+            }
+            total++;
+        }
+        return total;
+    } catch (...) { return 0; }
+}
+
+// Add an algorithm result and absorb its BRepTools_History (issue #290).
+//
+// The input roots and the result share one graph, so ShapesView::AddWithHistory
+// records NodeId-keyed history against nodes that remain valid — no generation
+// boundary, no cross-graph UID resolution. AddWithHistory internally collects the
+// input map via CollectHistoryInputs and the output map via Options::TrackAddedNodes,
+// then hands both to BRepGraph_LayerHistory::Absorb.
+bool OCCTBRepGraphAddWithHistory(OCCTBRepGraphRef g,
+                                  OCCTShapeRef resultShape,
+                                  OCCTHistoryRef history,
+                                  const int32_t* inputRootKinds,
+                                  const int32_t* inputRootIndices,
+                                  int32_t inputRootCount,
+                                  const char* opName,
+                                  int32_t* outRootKind,
+                                  int32_t* outRootIndex) {
+    if (outRootKind) *outRootKind = -1;
+    if (outRootIndex) *outRootIndex = -1;
+    if (!g || !resultShape || !opName) return false;
+    if (!inputRootKinds || !inputRootIndices || inputRootCount < 1) return false;
+    if (!history) return false;
+    try {
+        auto* hs = static_cast<OCCTHistoryStorage*>(history);
+        if (hs->history.IsNull()) return false;
+
+        NCollection_Array1<BRepGraph_NodeId> roots(0, inputRootCount - 1);
+        for (int32_t i = 0; i < inputRootCount; i++) {
+            roots.SetValue(i, BRepGraph_NodeId((BRepGraph_NodeId::Kind)inputRootKinds[i],
+                                               inputRootIndices[i]));
+        }
+
+        // Ensure the history layer exists before the absorb; AddWithHistory writes
+        // into the registered layer and silently records nothing without one.
+        (void)g->graph.LayerRegistry().Ensure<BRepGraph_LayerHistory>();
+
+        auto result = g->graph.Shapes().AddWithHistory(resultShape->shape, roots,
+                                                        hs->history,
+                                                        TCollection_AsciiString(opName));
+        if (!result.IsOk()) return false;
+        if (outRootKind) *outRootKind = (int32_t)result.TopologyRoot.NodeKind;
+        if (outRootIndex) *outRootIndex = result.TopologyRoot.Index;
+        return true;
+    } catch (...) { return false; }
+}
+
 // --- Poly Counts ---
 
 int32_t OCCTBRepGraphNbTriangulations(OCCTBRepGraphRef g) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -40,6 +40,7 @@
 #include <Poly_Polygon3D.hxx>
 #include <Poly_Polygon2D.hxx>
 #include <Poly_PolygonOnTriangulation.hxx>
+#include <BRepTools_History.hxx>
 #include <XCAFApp_Application.hxx>
 #include <TDocStd_Document.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
@@ -167,6 +168,15 @@ struct Poly_Polygon2DOpaque {
 
 struct Poly_PolygonOnTriangulationOpaque {
     Handle(Poly_PolygonOnTriangulation) polygon;
+};
+
+// === History ===
+
+// Wrapper for a BRepTools_History handle. Shared rather than area-local because
+// two areas exchange it: the modeling area synthesizes one from a retained
+// builder, and the BRepGraph area absorbs it into a graph's history layer.
+struct OCCTHistoryStorage {
+    Handle(BRepTools_History) history;
 };
 
 // === Mutex helpers ===

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -1688,9 +1688,30 @@ struct OCCTBooleanHistory {
     // safely copyable. Upcast from concrete Fuse / Cut / Common / Splitter.
     std::unique_ptr<BRepBuilderAPI_MakeShape> op;
 
-    explicit OCCTBooleanHistory(std::unique_ptr<BRepBuilderAPI_MakeShape> theOp)
-        : op(std::move(theOp)) {}
+    // The shapes the builder ran on. Retained because BRepTools_History's
+    // template constructor needs the argument list to know which subshapes to
+    // walk, and a type-erased BRepBuilderAPI_MakeShape cannot report its own
+    // inputs. See OCCTBooleanHistoryAsBRepToolsHistory.
+    TopTools_ListOfShape args;
+
+    OCCTBooleanHistory(std::unique_ptr<BRepBuilderAPI_MakeShape> theOp,
+                       const TopTools_ListOfShape& theArgs)
+        : op(std::move(theOp)), args(theArgs) {}
 };
+
+// Convenience for the common 1- and 2-argument builders.
+static TopTools_ListOfShape occtArgList(const TopoDS_Shape& a) {
+    TopTools_ListOfShape l;
+    l.Append(a);
+    return l;
+}
+
+static TopTools_ListOfShape occtArgList(const TopoDS_Shape& a, const TopoDS_Shape& b) {
+    TopTools_ListOfShape l;
+    l.Append(a);
+    l.Append(b);
+    return l;
+}
 
 OCCTBooleanHistoryRef OCCTBooleanUnionWithHistory(OCCTShapeRef shape1, OCCTShapeRef shape2,
                                                     OCCTShapeRef* outResult) {
@@ -1700,7 +1721,7 @@ OCCTBooleanHistoryRef OCCTBooleanUnionWithHistory(OCCTShapeRef shape1, OCCTShape
         std::unique_ptr<BRepAlgoAPI_Fuse> op(new BRepAlgoAPI_Fuse(shape1->shape, shape2->shape));
         if (!op->IsDone()) return nullptr;
         if (outResult) *outResult = new OCCTShape(op->Shape());
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape1->shape, shape2->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1712,7 +1733,7 @@ OCCTBooleanHistoryRef OCCTBooleanSubtractWithHistory(OCCTShapeRef shape1, OCCTSh
         std::unique_ptr<BRepAlgoAPI_Cut> op(new BRepAlgoAPI_Cut(shape1->shape, shape2->shape));
         if (!op->IsDone()) return nullptr;
         if (outResult) *outResult = new OCCTShape(op->Shape());
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape1->shape, shape2->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1724,7 +1745,7 @@ OCCTBooleanHistoryRef OCCTBooleanIntersectWithHistory(OCCTShapeRef shape1, OCCTS
         std::unique_ptr<BRepAlgoAPI_Common> op(new BRepAlgoAPI_Common(shape1->shape, shape2->shape));
         if (!op->IsDone()) return nullptr;
         if (outResult) *outResult = new OCCTShape(op->Shape());
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape1->shape, shape2->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1743,7 +1764,7 @@ OCCTBooleanHistoryRef OCCTBooleanSplitWithHistory(OCCTShapeRef shape1, OCCTShape
         op->Build();
         if (!op->IsDone()) return nullptr;
         if (outResult) *outResult = new OCCTShape(op->Shape());
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape1->shape, shape2->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1788,6 +1809,26 @@ bool OCCTBooleanHistoryIsDeleted(OCCTBooleanHistoryRef h, OCCTShapeRef inputSubS
     try {
         return h->op->IsDeleted(inputSubShape->shape);
     } catch (...) { return false; }
+}
+
+// Synthesize a standalone BRepTools_History from the retained builder.
+//
+// BRepTools_History's template constructor walks the argument list and copies
+// Modified / Generated / IsDeleted for each supported subshape, so it works off
+// the virtual base and does not need the concrete builder type. That matters:
+// only the BRepAlgoAPI_* builders expose a native History(); fillet, chamfer and
+// thick-solid do not, and this path covers all of them uniformly.
+//
+// Note BRepTools_History only tracks VERTEX / EDGE / FACE / SOLID
+// (BRepTools_History::IsSupportedType) — wires, shells and compounds are not
+// carried, so absorbing this into a graph records nothing for those kinds.
+OCCTHistoryRef OCCTBooleanHistoryAsBRepToolsHistory(OCCTBooleanHistoryRef h) {
+    if (!h || !h->op) return nullptr;
+    try {
+        auto* ref = new OCCTHistoryStorage();
+        ref->history = new BRepTools_History(h->args, *h->op);
+        return ref;
+    } catch (...) { return nullptr; }
 }
 
 void OCCTBooleanHistoryRelease(OCCTBooleanHistoryRef h) {
@@ -1846,7 +1887,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdges(OCCTShapeRef shape,
         TopoDS_Shape result = op->Shape();
         if (result.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1874,7 +1915,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdgeVariable(OCCTShapeRef shape,
         TopoDS_Shape result = op->Shape();
         if (result.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1898,7 +1939,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromChamferEdges(OCCTShapeRef shape,
         TopoDS_Shape result = op->Shape();
         if (result.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1925,7 +1966,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromShell(OCCTShapeRef shape,
         TopoDS_Shape result = op->Shape();
         if (result.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -1951,7 +1992,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromDefeature(OCCTShapeRef shape,
         TopoDS_Shape result = op->Shape();
         if (result.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
-        return new OCCTBooleanHistory(std::move(op));
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
     } catch (...) { return nullptr; }
 }
 
@@ -4306,9 +4347,8 @@ int32_t OCCTLocOpeCSIntersectLine(OCCTShapeRef shape,
 }
 
 // MARK: - BRepTools_History (v0.50)
-struct OCCTHistoryStorage {
-    Handle(BRepTools_History) history;
-};
+// OCCTHistoryStorage now lives in OCCTBridge_Internal.h — the BRepGraph area
+// needs it to absorb a synthesized history into a graph's history layer.
 
 OCCTHistoryRef OCCTHistoryCreate(void) {
     try {

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -827,7 +827,11 @@ public final class TopologyGraph: @unchecked Sendable {
     /// // Cut a channel across a box's top face, then keep hold of the face.
     /// let base = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
     /// let graph = TopologyGraph(shape: base)!
-    /// let root = graph.rootNodes.first!
+    ///
+    /// // The topology root. Note this is findNode(for:), NOT rootNodes — that
+    /// // enumerates Products and is empty for a graph built from a Shape.
+    /// let rootNode = graph.findNode(for: base)!
+    /// let root = TopologyGraph.NodeRef(kind: rootNode.kind, index: rootNode.index)
     ///
     /// // Identify the top face and pin it BEFORE the cut.
     /// let faces = base.faces()
@@ -840,12 +844,13 @@ public final class TopologyGraph: @unchecked Sendable {
     /// // Cut, then hand the result and its history back to the same graph.
     /// let tool = Shape.box(origin: SIMD3(-1, 4, 8), width: 12, height: 2, depth: 4)!
     /// let (result, history) = base.subtractedWithFullHistory(tool)!
-    /// graph.add(result, absorbing: history,
-    ///           inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
-    ///           operationName: "channel-cut")
+    /// graph.add(result, absorbing: history, inputRoots: [root], operationName: "channel-cut")
     ///
     /// // The pinned face now resolves to the two strips it was split into.
-    /// let strips = graph.currentForms(of: pinned)   // 2 face nodes
+    /// // Filter by kind: currentForms also returns the section edges the cut
+    /// // generated on that face, since it unions modified and generated.
+    /// let strips = graph.currentForms(of: pinned).filter { $0.kind == .face }   // 2 faces
+    /// graph.resolve(.splitOf(original: .literal(pinned), occurrence: 0))        // .success(face)
     /// ```
     ///
     /// - Note: Only vertices, edges, faces and solids are tracked

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -775,6 +775,127 @@ public final class TopologyGraph: @unchecked Sendable {
         }
     }
 
+    /// True if a recorded operation consumed `node`, leaving it no image in the result.
+    ///
+    /// This is distinct from having no successors: a node with no history record at
+    /// all is simply untouched, whereas a deleted node was explicitly consumed. Use
+    /// this to tell "the cut removed this edge" apart from "the cut never saw it".
+    ///
+    /// ```swift
+    /// let strips = graph.currentForms(of: pinned)
+    /// if strips.isEmpty && graph.historyIsDeleted(pinned) {
+    ///     // consumed by the operation, not merely unrecorded
+    /// }
+    /// ```
+    public func historyIsDeleted(_ node: NodeRef) -> Bool {
+        OCCTBRepGraphHistoryIsDeleted(handle, node.kind.rawValue, Int32(node.index))
+    }
+
+    /// Every node a recorded operation consumed with no image in the result.
+    public var historyDeletedNodes: [NodeRef] {
+        let total = OCCTBRepGraphHistoryDeletedNodes(handle, nil, nil, 0)
+        guard total > 0 else { return [] }
+        var kinds = [Int32](repeating: 0, count: Int(total))
+        var indices = [Int32](repeating: 0, count: Int(total))
+        _ = kinds.withUnsafeMutableBufferPointer { kBuf in
+            indices.withUnsafeMutableBufferPointer { iBuf in
+                OCCTBRepGraphHistoryDeletedNodes(handle, kBuf.baseAddress, iBuf.baseAddress, total)
+            }
+        }
+        return (0..<Int(total)).compactMap { i in
+            NodeKind(rawValue: kinds[i]).map { NodeRef(kind: $0, index: Int(indices[i])) }
+        }
+    }
+
+    /// Add an operation's result to this graph and absorb its history, so the
+    /// entities you were already holding keep resolving to their successors.
+    ///
+    /// This is the supported way to carry a picked face (or edge, or vertex)
+    /// across an operation that rebuilds the shape — a boolean, a fillet, a
+    /// chamfer. Because the input and the result live in the *same* graph, the
+    /// `NodeRef`s and `GraphUID`s you already hold stay valid: there is no
+    /// generation boundary to cross and no cross-graph UID lookup.
+    ///
+    /// After this call, ``currentForms(of:)`` on an input node returns its
+    /// successors, and the ``TopologyRef`` recipes (`.splitOf`, `.createdBy`)
+    /// resolve against the records this emits.
+    ///
+    /// Build the graph from the operation's *input* shape, not its result — the
+    /// input roots must already be in this graph.
+    ///
+    /// ```swift
+    /// // Cut a channel across a box's top face, then keep hold of the face.
+    /// let base = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
+    /// let graph = TopologyGraph(shape: base)!
+    /// let root = graph.rootNodes.first!
+    ///
+    /// // Identify the top face and pin it BEFORE the cut.
+    /// let faces = base.faces()
+    /// let centroids = base.measure().faceCentroids
+    /// let topIndex = centroids.enumerated().max { $0.element.z < $1.element.z }!.offset
+    /// let topFace = Shape.fromFace(faces[topIndex])!
+    /// let topNode = graph.findNode(for: topFace)!
+    /// let pinned = TopologyGraph.NodeRef(kind: topNode.kind, index: topNode.index)
+    ///
+    /// // Cut, then hand the result and its history back to the same graph.
+    /// let tool = Shape.box(origin: SIMD3(-1, 4, 8), width: 12, height: 2, depth: 4)!
+    /// let (result, history) = base.subtractedWithFullHistory(tool)!
+    /// graph.add(result, absorbing: history,
+    ///           inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+    ///           operationName: "channel-cut")
+    ///
+    /// // The pinned face now resolves to the two strips it was split into.
+    /// let strips = graph.currentForms(of: pinned)   // 2 face nodes
+    /// ```
+    ///
+    /// - Note: Only vertices, edges, faces and solids are tracked
+    ///   (`BRepTools_History` carries no wires, shells or compounds), so nothing
+    ///   is recorded for those kinds.
+    ///
+    /// - Parameters:
+    ///   - result: The operation's result shape.
+    ///   - history: The history handle returned alongside it by any
+    ///     `*WithFullHistory` operation.
+    ///   - inputRoots: Nodes in this graph whose subshapes should be tracked —
+    ///     normally the root(s) the input shape was added as.
+    ///   - operationName: Label recorded on every emitted record; the same string
+    ///     `TopologyRef.createdBy(operationName:)` matches on.
+    /// - Returns: The added result's topology-root node, or nil if the add or the
+    ///   absorb failed.
+    @discardableResult
+    public func add(_ result: Shape,
+                    absorbing history: ShapeHistoryRef,
+                    inputRoots: [NodeRef],
+                    operationName: String) -> NodeRef? {
+        guard !inputRoots.isEmpty else { return nil }
+        // Synthesize a BRepTools_History from the retained builder. Owned here and
+        // released once absorbed — the graph copies what it needs into its log.
+        guard let btHistory = OCCTBooleanHistoryAsBRepToolsHistory(history.handle) else {
+            return nil
+        }
+        defer { OCCTHistoryDestroy(btHistory) }
+
+        let rootKinds = inputRoots.map { $0.kind.rawValue }
+        let rootIndices = inputRoots.map { Int32($0.index) }
+        var outKind: Int32 = -1
+        var outIndex: Int32 = -1
+
+        let ok = operationName.withCString { namePtr in
+            rootKinds.withUnsafeBufferPointer { kindsBuf in
+                rootIndices.withUnsafeBufferPointer { indicesBuf in
+                    OCCTBRepGraphAddWithHistory(handle, result.handle, btHistory,
+                                                 kindsBuf.baseAddress!,
+                                                 indicesBuf.baseAddress!,
+                                                 Int32(inputRoots.count),
+                                                 namePtr,
+                                                 &outKind, &outIndex)
+                }
+            }
+        }
+        guard ok, outKind >= 0, let kind = NodeKind(rawValue: outKind) else { return nil }
+        return NodeRef(kind: kind, index: Int(outIndex))
+    }
+
     // MARK: - Poly Counts (v0.133.0)
 
     /// Number of triangulations in the graph.

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -4773,7 +4773,9 @@ public struct ShapeHistoryRecord: Sendable {
 /// selection IDs across boolean / split mutations (e.g. OCCTMCP's
 /// `remap_selection`, parametric editors that want feature replay).
 public final class ShapeHistoryRef: @unchecked Sendable {
-    fileprivate let handle: OCCTBooleanHistoryRef
+    // internal, not fileprivate: TopologyGraph.add(_:absorbing:inputRoots:operationName:)
+    // in BRepGraph.swift needs it to synthesize a BRepTools_History (issue #290).
+    let handle: OCCTBooleanHistoryRef
 
     fileprivate init(_ handle: OCCTBooleanHistoryRef) {
         self.handle = handle

--- a/Tests/OCCTTopologyGraphTests/GraphHistoryAbsorbTests.swift
+++ b/Tests/OCCTTopologyGraphTests/GraphHistoryAbsorbTests.swift
@@ -1,0 +1,171 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// Carrying a durable face reference across a boolean split (issue #290).
+///
+/// The scenario throughout is the reporter's: a 10×10×10 box with a bar cut
+/// across its top (Y ∈ [4, 6], full X width), splitting the single 10×10 top
+/// face into two 10×4 strips. Assertions are geometric rather than count-only —
+/// "two nodes came back" is not evidence they are the right two.
+@Suite("Graph history absorb (#290)")
+struct GraphHistoryAbsorbTests {
+
+    /// The reporter's scenario, assembled once.
+    struct Cut {
+        let base: Shape
+        let graph: TopologyGraph
+        let root: TopologyGraph.NodeRef
+        /// The top face's node, pinned before the cut.
+        let pinnedTop: TopologyGraph.NodeRef
+        let result: Shape
+        let history: ShapeHistoryRef
+    }
+
+    static func makeCut() -> Cut? {
+        guard let base = Shape.box(origin: SIMD3<Double>(0, 0, 0),
+                                   width: 10, height: 10, depth: 10),
+              let graph = TopologyGraph(shape: base),
+              let rootNode = graph.findNode(for: base) else { return nil }
+
+        let faces = base.faces()
+        let centroids = base.measure().faceCentroids
+        guard let topIndex = centroids.enumerated()
+                .max(by: { $0.element.z < $1.element.z })?.offset,
+              let topFace = Shape.fromFace(faces[topIndex]),
+              let topNode = graph.findNode(for: topFace) else { return nil }
+
+        guard let tool = Shape.box(origin: SIMD3<Double>(-1, 4, 8),
+                                   width: 12, height: 2, depth: 4),
+              let (result, history) = base.subtractedWithFullHistory(tool) else { return nil }
+
+        return Cut(base: base,
+                   graph: graph,
+                   root: TopologyGraph.NodeRef(kind: rootNode.kind, index: rootNode.index),
+                   pinnedTop: TopologyGraph.NodeRef(kind: topNode.kind, index: topNode.index),
+                   result: result,
+                   history: history)
+    }
+
+    /// Area of the face a node reconstructs to.
+    static func faceArea(_ graph: TopologyGraph, _ node: TopologyGraph.NodeRef) -> Double? {
+        guard let shape = graph.shape(nodeKind: node.kind, nodeIndex: node.index) else { return nil }
+        let areas = shape.measure().faceAreas
+        guard !areas.isEmpty else { return nil }
+        return areas.reduce(0, +)
+    }
+
+    @Test("absorbing a boolean's history writes records into the input graph")
+    func absorbWritesRecords() {
+        guard let c = Self.makeCut() else { Issue.record("setup failed"); return }
+        #expect(c.graph.historyRecordCount == 0, "graph should start with an empty history log")
+
+        let added = c.graph.add(c.result, absorbing: c.history,
+                                inputRoots: [c.root], operationName: "channel-cut")
+
+        #expect(added != nil, "add should return the result's topology root")
+        #expect(c.graph.historyRecordCount > 0, "absorb should have written history records")
+    }
+
+    /// The core of #290: the pre-cut face resolves to its two successor strips.
+    @Test("pre-cut top face resolves to exactly two coplanar strips")
+    func topFaceResolvesToTwoStrips() {
+        guard let c = Self.makeCut() else { Issue.record("setup failed"); return }
+        c.graph.add(c.result, absorbing: c.history,
+                    inputRoots: [c.root], operationName: "channel-cut")
+
+        // currentForms unions modified AND generated descendants, so the cut's new
+        // section edges come back alongside the strips. Filter to faces.
+        let strips = c.graph.currentForms(of: c.pinnedTop).filter { $0.kind == .face }
+        #expect(strips.count == 2, "top face should survive the cut as two strips")
+
+        // The strips must be the real geometry, not merely two arbitrary faces:
+        // the 10x10 top minus a 10x2 channel leaves two 10x4 strips.
+        for strip in strips {
+            if let area = Self.faceArea(c.graph, strip) {
+                #expect(abs(area - 40.0) < 1e-6, "each strip should be 10 x 4 = 40, got \(area)")
+            } else {
+                Issue.record("strip \(strip) did not reconstruct to a shape")
+            }
+        }
+
+        let total = strips.compactMap { Self.faceArea(c.graph, $0) }.reduce(0, +)
+        #expect(abs(total - 80.0) < 1e-6, "strips should total 80 (100 minus the 20 channel)")
+    }
+
+    @Test("splitOf resolves each strip by occurrence")
+    func splitOfResolvesOccurrences() {
+        guard let c = Self.makeCut() else { Issue.record("setup failed"); return }
+        c.graph.add(c.result, absorbing: c.history,
+                    inputRoots: [c.root], operationName: "channel-cut")
+
+        let first = c.graph.resolve(.splitOf(original: .literal(c.pinnedTop), occurrence: 0))
+        let second = c.graph.resolve(.splitOf(original: .literal(c.pinnedTop), occurrence: 1))
+
+        switch (first, second) {
+        case let (.success(a), .success(b)):
+            #expect(a != b, "occurrences 0 and 1 should be distinct strips")
+            #expect(a.kind == .face && b.kind == .face)
+            if let areaA = Self.faceArea(c.graph, a), let areaB = Self.faceArea(c.graph, b) {
+                #expect(abs(areaA - 40.0) < 1e-6, "strip 0 area \(areaA)")
+                #expect(abs(areaB - 40.0) < 1e-6, "strip 1 area \(areaB)")
+            }
+        default:
+            Issue.record("splitOf failed to resolve: \(first), \(second)")
+        }
+    }
+
+    @Test("createdBy matches the operation label the absorb recorded")
+    func createdByMatchesLabel() {
+        guard let c = Self.makeCut() else { Issue.record("setup failed"); return }
+        c.graph.add(c.result, absorbing: c.history,
+                    inputRoots: [c.root], operationName: "channel-cut")
+
+        let hit = c.graph.resolve(.createdBy(operationName: "channel-cut", kind: .face))
+        if case .failure(let e) = hit {
+            Issue.record("createdBy should resolve against the absorbed label, got \(e)")
+        }
+
+        // A label nothing recorded must not resolve.
+        let miss = c.graph.resolve(.createdBy(operationName: "never-happened", kind: .face))
+        if case .success(let n) = miss {
+            Issue.record("an unrecorded label should not resolve, got \(n)")
+        }
+    }
+
+    /// Without the absorb, none of the above works — this is what #290 reported.
+    @Test("without absorbing, the graph log stays empty and recipes do not resolve")
+    func withoutAbsorbNothingResolves() {
+        guard let c = Self.makeCut() else { Issue.record("setup failed"); return }
+        // Deliberately no add(_:absorbing:...).
+        #expect(c.graph.historyRecordCount == 0)
+        #expect(c.graph.currentForms(of: c.pinnedTop).isEmpty,
+                "no history recorded, so no successors")
+
+        let r = c.graph.resolve(.splitOf(original: .literal(c.pinnedTop), occurrence: 0))
+        if case .success = r {
+            Issue.record("splitOf must not resolve with an empty history log")
+        }
+    }
+
+    @Test("a node the operation never touched is neither derived nor deleted")
+    func untouchedNodeIsNotDeleted() {
+        guard let c = Self.makeCut() else { Issue.record("setup failed"); return }
+        c.graph.add(c.result, absorbing: c.history,
+                    inputRoots: [c.root], operationName: "channel-cut")
+
+        // The bottom face (z = 0) is nowhere near the channel.
+        let faces = c.base.faces()
+        let centroids = c.base.measure().faceCentroids
+        guard let bottomIndex = centroids.enumerated()
+                .min(by: { $0.element.z < $1.element.z })?.offset,
+              let bottomFace = Shape.fromFace(faces[bottomIndex]),
+              let bottomNode = c.graph.findNode(for: bottomFace) else {
+            Issue.record("bottom face lookup failed"); return
+        }
+        let bottom = TopologyGraph.NodeRef(kind: bottomNode.kind, index: bottomNode.index)
+
+        #expect(!c.graph.historyIsDeleted(bottom),
+                "an untouched face must not be reported as deleted")
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,320** of the 4,234 entry points (~78%); the remainder are real, callable,
+categorisation covering **3,320** of the entry points (~78% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,234** | |
+| **Total** | **4,237** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,74 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.10.3
+## Current: v1.11.0
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.11.0 (July 2026) — feat: absorb a boolean's history into the graph, so a picked face survives it (#290)
+
+Holding a reference to a picked face across an operation that rebuilds the shape had no supported
+path. `ShapeHistoryRef` (TopoDS-level, from the `*WithFullHistory` helpers) and the `TopologyGraph`
+history log were two disconnected systems: the boolean never wrote a record into the graph's log, so
+`resolve(.splitOf(…))` / `.createdBy(…)` / `currentForms(of:)` had nothing to walk and callers were
+left correlating `ShapeHistoryRecord.modified` back to graph nodes by hand — in practice by geometry.
+
+OCCT 8.0.0p1 already ships the bridge; it was simply unwrapped.
+`BRepGraph::ShapesView::AddWithHistory` collects the input map via `CollectHistoryInputs`, the output
+map via `Options::TrackAddedNodes`, and hands both to `BRepGraph_LayerHistory::Absorb`.
+
+**New**
+
+- **`TopologyGraph.add(_:absorbing:inputRoots:operationName:)`** — add an operation's result to the
+  graph and absorb its history. Afterwards the entities you already held resolve to their successors.
+- **`TopologyGraph.historyIsDeleted(_:)`** / **`.historyDeletedNodes`** — distinguish "consumed by the
+  operation" from "never touched". Absence of a record is not deletion.
+
+```swift
+let graph = TopologyGraph(shape: base)!
+let root = graph.findNode(for: base)!               // topology root — NOT rootNodes (see below)
+let topNode = graph.findNode(for: topFace)!         // pin the face BEFORE the cut
+let pinned = TopologyGraph.NodeRef(kind: topNode.kind, index: topNode.index)
+
+let (result, history) = base.subtractedWithFullHistory(tool)!
+graph.add(result, absorbing: history,
+          inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+          operationName: "channel-cut")
+
+let strips = graph.currentForms(of: pinned).filter { $0.kind == .face }   // the two successors
+graph.resolve(.splitOf(original: .literal(pinned), occurrence: 0))        // .success(face)
+```
+
+**One graph, not two.** `AddWithHistory` resolves its input roots against the *receiving* graph, so
+the input and the result share one graph and history is NodeId-keyed. The `NodeRef`s and `GraphUID`s
+a caller already holds stay valid: there is no generation boundary to cross and no cross-graph UID
+resolution — which sidesteps the aliasing hazard in
+[#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295) entirely. Build the graph from the
+operation's **input**, then hand it the result. The two-graph `Absorb` overload and the UID-keyed
+record path (`RecordUid` / `HasKnownInput`) are deliberately left unwrapped: strictly more dangerous,
+and no consumer.
+
+**Works for all nine `*WithFullHistory` ops.** `OCCTBooleanHistoryAsBRepToolsHistory` synthesizes a
+real `BRepTools_History` from the retained builder via the `(arguments, algo)` template constructor,
+which needs only `Modified` / `Generated` / `IsDeleted` — all virtual on `BRepBuilderAPI_MakeShape`.
+That matters because only the `BRepAlgoAPI_*` builders expose a native `History()`; fillet, chamfer
+and thick-solid do not. `OCCTBooleanHistory` now retains its arguments, since a type-erased builder
+cannot report its own inputs.
+
+**Known edges, documented rather than papered over:**
+
+- `currentForms(of:)` returns the cut's new section **edges** alongside the split faces, because
+  `BRepGraph_LayerHistory::FindDerived` unions Modified and Generated descendants transitively.
+  Filter by `.kind` when you want only faces. Existing behaviour, unchanged.
+- Only **vertices, edges, faces and solids** are carried — `BRepTools_History::IsSupportedType`
+  tracks nothing else, so absorbing records nothing for wires, shells or compounds.
+- `TopologyGraph.rootNodes` is **Products**, and shape-built graphs set `CreateAutoProduct = false`,
+  so it is always empty for them. The topology root is `findNode(for: inputShape)`. This trips people
+  up; the reference page now says so.
 
 ### v1.10.3 (July 2026) — docs: canonical operation count, derived not hand-maintained (#289)
 

--- a/docs/reference/TopologyGraph-Detail-History.md
+++ b/docs/reference/TopologyGraph-Detail-History.md
@@ -408,6 +408,114 @@ Use this when mutating the graph outside BRepGraph's own builder API so the chan
 
 ---
 
+## Absorbing an Operation's History
+
+Hand-written `recordHistory` calls are for graph mutations you perform yourself. When the mutation is
+an OCCT operation that *rebuilds the shape* — a boolean, a fillet, a chamfer — use
+`add(_:absorbing:inputRoots:operationName:)` instead: it imports the operation's own history, so you
+do not have to correlate result sub-shapes back to nodes by hand.
+
+### `add(_:absorbing:inputRoots:operationName:)`
+
+Adds an operation's result to the graph and absorbs its history, so entities you were already holding
+keep resolving to their successors ([#290](https://github.com/SecondMouseAU/OCCTSwift/issues/290)).
+
+```swift
+@discardableResult
+public func add(_ result: Shape,
+                absorbing history: ShapeHistoryRef,
+                inputRoots: [NodeRef],
+                operationName: String) -> NodeRef?
+```
+
+**The input and the result share one graph.** Build the graph from the operation's *input* shape, then
+hand it the result. History is NodeId-keyed, so the `NodeRef`s and `GraphUID`s you already hold stay
+valid — there is no generation boundary to cross, and no cross-graph UID lookup (which would be unsafe;
+see [#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
+
+- **Parameters:**
+  - `result` — the operation's result shape.
+  - `history` — the handle returned alongside it by any `*WithFullHistory` operation.
+  - `inputRoots` — nodes in *this* graph whose subshapes to track; normally the input shape's root.
+    Get it with `findNode(for: inputShape)` — **not** `rootNodes`, which is Products and is empty for
+    a shape-built graph (`CreateAutoProduct = false`).
+  - `operationName` — the label recorded on every emitted record, and the string
+    `TopologyRef.createdBy(operationName:)` matches on.
+- **Returns:** the added result's topology-root node, or `nil` if the add or the absorb failed.
+- **OCCT:** `BRepGraph::ShapesView::AddWithHistory` → `BRepGraph_LayerHistory::Absorb`, via
+  `OCCTBRepGraphAddWithHistory`. The `BRepTools_History` is synthesized from the retained builder by
+  `OCCTBooleanHistoryAsBRepToolsHistory`.
+- **Only vertices, edges, faces and solids are carried** — `BRepTools_History::IsSupportedType` tracks
+  nothing else, so nothing is recorded for wires, shells or compounds.
+- **Example:** cut a channel across a box's top face and keep hold of the face.
+  ```swift
+  let base = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
+  let graph = TopologyGraph(shape: base)!
+  let rootNode = graph.findNode(for: base)!
+  let root = NodeRef(kind: rootNode.kind, index: rootNode.index)
+
+  // Pin the top face BEFORE the cut.
+  let faces = base.faces()
+  let centroids = base.measure().faceCentroids
+  let topIndex = centroids.enumerated().max { $0.element.z < $1.element.z }!.offset
+  let topFace = Shape.fromFace(faces[topIndex])!
+  let topNode = graph.findNode(for: topFace)!
+  let pinned = NodeRef(kind: topNode.kind, index: topNode.index)
+
+  let tool = Shape.box(origin: SIMD3(-1, 4, 8), width: 12, height: 2, depth: 4)!
+  let (result, history) = base.subtractedWithFullHistory(tool)!
+  graph.add(result, absorbing: history, inputRoots: [root], operationName: "channel-cut")
+
+  // The pinned face now resolves to the two strips it was split into.
+  let strips = graph.currentForms(of: pinned).filter { $0.kind == .face }   // 2 faces
+  graph.resolve(.splitOf(original: .literal(pinned), occurrence: 0))        // .success(face)
+  graph.resolve(.createdBy(operationName: "channel-cut", kind: .face))      // .success(face)
+  ```
+
+> **Filter `currentForms(of:)` by kind.** It returns the cut's new section *edges* alongside the split
+> faces, because `FindDerived` unions Modified and Generated descendants transitively. When you want
+> the faces a face became, filter on `.kind == .face`.
+
+### `historyIsDeleted(_:)`
+
+True if a recorded operation consumed `node`, leaving it no image in the result.
+
+```swift
+public func historyIsDeleted(_ node: NodeRef) -> Bool
+```
+
+Distinct from having no successors: a node with **no record at all** was simply untouched, whereas a
+deleted node was explicitly consumed. Use this to tell "the cut removed this edge" from "the cut never
+saw it".
+
+- **OCCT:** `BRepGraph_LayerHistory::IsDeleted`, via `OCCTBRepGraphHistoryIsDeleted`.
+- **Example:**
+  ```swift
+  let successors = graph.currentForms(of: pinned)
+  if successors.isEmpty && graph.historyIsDeleted(pinned) {
+      // consumed by the operation, not merely unrecorded
+  }
+  ```
+
+### `historyDeletedNodes`
+
+Every node a recorded operation consumed with no image in the result.
+
+```swift
+public var historyDeletedNodes: [NodeRef] { get }
+```
+
+- **OCCT:** `BRepGraph_LayerHistory::DeletedNodes`, via `OCCTBRepGraphHistoryDeletedNodes`.
+- **Example:**
+  ```swift
+  graph.add(result, absorbing: history, inputRoots: [root], operationName: "channel-cut")
+  for gone in graph.historyDeletedNodes {
+      print("consumed by the cut: \(gone.kind) \(gone.index)")
+  }
+  ```
+
+---
+
 ## Poly Counts
 
 ### `triangulationCount`

--- a/docs/reference/TopologyGraph.md
+++ b/docs/reference/TopologyGraph.md
@@ -502,17 +502,30 @@ Returned by `rootNodes` to identify the top-level product or topology entries of
 
 ### `rootNodes`
 
-Root nodes of the graph.
+Root **product** nodes of the graph. Each element carries a `NodeKind` and its zero-based index.
 
 ```swift
 public var rootNodes: [RootNode] { get }
 ```
 
-For a shape built without assembly context (`CreateAutoProduct: false`), root nodes reflect the top-level topology of the original shape (solids, shells, or compounds). Each element carries both a `NodeKind` and its zero-based index.
+> **This is empty for a graph built from a `Shape`, and that is expected.** It enumerates
+> `BRepGraph::RootProductIds()` — assembly Products, not topology. `TopologyGraph(shape:)` builds with
+> `CreateAutoProduct: false` (no auto Product/Occurrence wrap), so such a graph has no products and
+> `rootNodes` returns `[]`. It is populated for graphs carrying assembly context.
+>
+> **For the topology root of a shape-built graph, use `findNode(for:)` on the shape itself:**
+>
+> ```swift
+> let graph = TopologyGraph(shape: base)!
+> let root = graph.findNode(for: base)     // e.g. (kind: .solid, index: 0)
+> ```
+>
+> That is also what `add(_:absorbing:inputRoots:operationName:)` wants for `inputRoots`.
 
 - **OCCT:** `BRepGraph::RootProductIds()`.
 - **Example:**
   ```swift
+  // Meaningful for assembly-context graphs; [] for TopologyGraph(shape:).
   for root in graph.rootNodes {
       print("\(root.kind) at index \(root.index)")
   }


### PR DESCRIPTION
Closes #290.

## The problem

Holding a reference to a picked face across an operation that rebuilds the shape had no supported path. `ShapeHistoryRef` (TopoDS-level, from the `*WithFullHistory` helpers) and the `TopologyGraph` history log were two disconnected systems — the boolean never wrote a record into the graph's log, so `resolve(.splitOf(…))` / `.createdBy(…)` / `currentForms(of:)` had nothing to walk. Callers were left correlating `ShapeHistoryRecord.modified` back to graph nodes by hand, in practice by geometry.

Measured, on #290's own repro: `historyRecordCount == 0` after a cut.

## The finding

**OCCT 8.0.0p1 already ships this. We just never wrapped it.** `BRepGraph::ShapesView::AddWithHistory` collects the input map via `CollectHistoryInputs`, the output map via `Options::TrackAddedNodes`, and hands both to `BRepGraph_LayerHistory::Absorb` — whose header calls it "the canonical bridge for cross-graph algorithms". Both `Absorb` overloads are defined and linkable in the xcframework we already ship; `Sources/` referenced none of them.

So this is a wrapping gap, not a feature request. Nothing needed to go upstream.

## One graph, not two

The reporter (and my first plan) assumed two graphs with history bridged across a generation boundary. `AddWithHistory` resolves its input roots against the **receiving** graph, so upstream's intended model is *one* graph that holds the input and receives the result.

That's strictly better, and it's what this implements. History is NodeId-keyed, so the `NodeRef`s and `GraphUID`s a caller already holds stay valid — no generation boundary, no cross-graph UID resolution, and **#295's aliasing hazard never enters this path**. Build the graph from the operation's input, then hand it the result.

The two-graph `Absorb` overload and the UID-keyed record path (`RecordUid` / `HasKnownInput`) are deliberately left unwrapped: a large surface, strictly more dangerous, and no consumer.

## What's added

- **`TopologyGraph.add(_:absorbing:inputRoots:operationName:)`** — the entry point.
- **`TopologyGraph.historyIsDeleted(_:)`** / **`.historyDeletedNodes`** — distinguish "consumed by the operation" from "never touched", which #290's desired-behaviour asked for. Absence of a record is not deletion.
- **`OCCTBooleanHistoryAsBRepToolsHistory`** — synthesizes a real `BRepTools_History` from the retained builder via the `(arguments, algo)` template ctor, which needs only `Modified`/`Generated`/`IsDeleted`, all virtual on `BRepBuilderAPI_MakeShape`. That's what makes **all nine** `*WithFullHistory` ops work uniformly — only the `BRepAlgoAPI_*` builders have a native `History()`; fillet, chamfer and thick-solid don't. `OCCTBooleanHistory` now retains its arguments, since a type-erased builder can't report its own inputs.
- `OCCTHistoryStorage` moves to `OCCTBridge_Internal.h` — two areas now exchange it, which is what that header exists for.

## Tests

Six tests asserting **geometry, not counts** — the existing `*WithFullHistory` suite is a liveness contract (assertions like `modified.count <= 1` pass on an empty history) and would not have caught any of this.

#290's repro is the fixture: a 10×10×10 box, channel cut across the top. The pre-cut top face resolves to exactly two strips of **area 40.0 each, totalling 80.0** (100 minus the 20 channel) — evidence they are the *right* two faces, not just that two nodes came back. `splitOf` returns distinct strips per occurrence; `createdBy` matches the recorded label and correctly **fails** on an unrecorded one. The no-absorb case is pinned as the behaviour #290 reported.

Full suite: **4,365 passing**.

## Two docs bugs fixed, both stating the opposite of the truth

- **`reference/TopologyGraph.md`** claimed that with `CreateAutoProduct: false`, "root nodes reflect the top-level topology of the original shape (solids, shells, or compounds)". They don't — `rootNodes` enumerates `RootProductIds()`, and `TopologyGraph(shape:)` builds with no products, so it is **always `[]`** for a shape-built graph. Measured, not inferred; I walked into this trap myself while writing the API. The topology root is `findNode(for: shape)`. v1.0.1 already recorded the cause ("OCCT 8.0.0 beta1 reshaped root iteration to Products only") without the reference page catching up.
- **`API_REFERENCE.md`**'s categorisation note hardcoded "3,320 of the 4,234 entry points" — the exact drift class #289 set out to kill, and one `--fix` doesn't rewrite it. Now phrased against the derived `Total` so it can't drift again.

Counts (4,234 → **4,237**, the three new entry points) came from `Scripts/count-operations.py --fix`, not by hand.

## Known edges — documented rather than papered over

- `currentForms(of:)` returns the cut's new section **edges** alongside the split faces, because `FindDerived` unions Modified and Generated descendants transitively. Filter by `.kind` for faces only. Existing behaviour, unchanged — say the word if you'd rather have a kind-filtered overload.
- Only **vertices, edges, faces and solids** are carried (`BRepTools_History::IsSupportedType`), so absorbing records nothing for wires, shells or compounds.

## Not in scope

- **#295** (`GraphUID` cross-graph aliasing; `generation` always 0) — filed separately, agreed approach is a validating accessor that leaves the `Codable` wire format alone. This PR routes around it rather than depending on it.
- **A pre-existing flake**, unrelated to this branch: the `SheetMetal` Z-section tests (`OCCTMiscTests.swift:885-1010`) non-deterministically build an empty solid (`volume → 0`, `solid count → 0`). Verified on `origin/main` **without** these changes — 2 of 3 runs fail — and `SheetMetal.swift` has zero references to the boolean-history path. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
