### PR TITLE
fix(#286): meshWithProgress could never cancel; retract the kernel story

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -65,6 +65,7 @@
 #include <TDocStd_Document.hxx>
 #include <XCAFApp_Application.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
+#include <IMeshTools_Parameters.hxx>
 #include <StlAPI_Writer.hxx>
 #include <StlAPI_Reader.hxx>
 #include <BinTools.hxx>
@@ -405,9 +406,17 @@ OCCTShapeRef OCCTShapeIncrementalMeshProgress(OCCTShapeRef shape,
     if (!shape) return nullptr;
     try {
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
-        Message_ProgressRange range = indicator->Start();
-        BRepMesh_IncrementalMesh mesher(shape->shape, linearDeflection, Standard_False, angularDeflection);
-        mesher.Perform(range);
+        // The (shape, linDefl, isRelative, angDefl) ctor calls Perform() internally with a null
+        // range, so it meshes uninterruptibly before any range we pass afterwards is ever polled
+        // (and a following Perform(range) then meshes a second time). Only the parameters ctor
+        // consumes a range. Leaving AngleInterior/MinSize/DeflectionInterior at their defaults
+        // matches what the other ctor did; Perform() resolves them identically (#286).
+        IMeshTools_Parameters params;
+        params.Deflection = linearDeflection;
+        params.Angle      = angularDeflection;
+        params.Relative   = Standard_False;
+        params.InParallel = Standard_False;
+        BRepMesh_IncrementalMesh mesher(shape->shape, params, indicator->Start());
         if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
         // Return a new OCCTShape wrapping the same (now-meshed) TopoDS_Shape so callers
         // can chain. The original handle is also valid.

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -758,45 +758,44 @@ public final class Shape: @unchecked Sendable {
 
     /// Generate a triangulated mesh for visualization
     ///
-    /// - Warning: **This call can hang unboundedly on offset surfaces** — the geometry
-    ///   `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`). Measured on a
-    ///   fitted-then-offset B-spline panel: a single face meshed for **>300 s without returning**
-    ///   at a *coarse* deflection (1/638 of the shape's bbox diagonal), so this is a kernel
-    ///   pathology, not a workload cost. See
-    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286).
+    /// - Warning: **This call can take minutes on a degenerate offset surface** — the geometry
+    ///   `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`). It is not a hang:
+    ///   measured on the fitted-then-offset B-spline panel from
+    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286), one face took **249 s** and
+    ///   emitted **1.4 M triangles** at a *coarse* deflection (1/638 of the shape's bbox diagonal).
+    ///   It terminates; earlier reports of an unbounded hang were timeouts set below that.
     ///
-    ///   **Cause** (OCCT `V8_0_0_p1`): `BRepMesh_MeshAlgoFactory::GetAlgo` lumps
-    ///   `GeomAbs_OffsetSurface` in with `GeomAbs_OtherSurface`, handing it a
-    ///   `BRepMesh_UndefinedRangeSplitter` whose `getUndefinedIntervalNb()` returns a constant
-    ///   `1` — so an offset surface gets *no* parametric subdivision, however wiggly its basis
-    ///   B-spline is. (The same B-spline meshed directly gets `BRepMesh_NURBSRangeSplitter`,
-    ///   which subdivides by `NbUPoles()-1`.) The Delaunay insertion then starts from a
-    ///   near-empty grid and `BRepMesh_Delaun::createTrianglesOnNewVertices` blows up.
-    ///
-    ///   There is **no in-process way to bound it**, and it is worth being precise about why:
-    ///   - **A timeout cannot work — verified empirically, not assumed.**
-    ///     `createTrianglesOnNewVertices` *does* poll (`aPS.More()`) in its outer per-vertex
-    ///     loop, but the hang is inside a *single* iteration of that loop, so the poll is never
-    ///     reached. A 10 s cancel deadline via
-    ///     ``meshWithProgress(linearDeflection:angularDeflection:progress:)`` was measured
-    ///     **not to fire at all** on the #286 solid (killed at 120 s). Do not rely on it as a
-    ///     timeout for untrusted geometry.
-    ///   - **A validity pre-check cannot catch it.** The measured offending solid reports
-    ///     `isValid == true`.
+    ///   **Cause** — the offset surface is *self-intersecting*, and the mesher's angular criterion
+    ///   cannot converge on it. Offsetting a surface by more than its local radius of curvature
+    ///   produces cusps. On the #286 panel the basis fit's minimum principal curvature radius is
+    ///   `2.6e-05` against an offset of `1.27`, so **23.8 %** of the domain is cusped and the
+    ///   surface normal swings by up to `π` across one. `BRepMesh` splits any triangle link whose
+    ///   end normals differ by more than `AngleInterior` (= `2 × angularDeflection`), but at a
+    ///   normal *discontinuity* splitting never helps — halving a link that straddles a cusp just
+    ///   moves the cusp into one half. So `BRepMesh_DelaunayDeflectionControlMeshAlgo::optimizeMesh`
+    ///   runs all 11 of its passes demanding ~80 k splits each, long after linear deflection is
+    ///   satisfied (it reached 1.82 against a 2.48 target by pass 6). `MinSize`
+    ///   (= `linearDeflection / 10`) is the only backstop. This is invalid input, not an OCCT
+    ///   defect: a well-formed offset surface meshes normally.
     ///
     ///   **Mitigations**, in order of preference:
     ///   1. **Don't mesh geometry you haven't sanity-checked.** `bounds` is a cheap `Bnd_Box`
     ///      query with no tessellation — comparing a thickened solid's bbox against its source's
     ///      is enough to reject the ballooned offsets that trigger this, and is what the
-    ///      downstream caller in #286 adopted.
-    ///   2. ``withSurfacesAsBSpline(extrusion:revolution:offset:plane:)`` with `offset: true`
-    ///      converts the `Geom_OffsetSurface` to a plain B-spline first. Measured on the #286
-    ///      solid this turns the unbounded hang into a **bounded 125 s** (526 k vertices) — it
-    ///      terminates, but is not fast, so treat it as a rescue path rather than a default.
-    ///   3. Mesh in a separate process if you must tessellate untrusted offset geometry.
-    ///
-    ///   Well-formed offset solids mesh normally; this only bites on pathological
-    ///   (e.g. ballooned or near-degenerate) fitted-then-offset surfaces.
+    ///      downstream caller in #286 adopted. Note `isValid` will *not* catch it: the measured
+    ///      offending solid reports `isValid == true`, because a self-intersecting offset surface
+    ///      is still a topologically valid face.
+    ///   2. **Bound it with a deadline.** ``meshWithProgress(linearDeflection:angularDeflection:progress:)``
+    ///      interrupts this reliably — a 10 s deadline returns in 10.1 s on the #286 face. (Before
+    ///      v1.11.1 the bridge meshed inside a constructor that never polled the progress range, so
+    ///      cancellation appeared not to work; that was our bug, now fixed.)
+    ///   3. **Raise `angularDeflection`,** which raises the `AngleInterior` threshold that is doing
+    ///      all the splitting here, or raise `MinSize` via ``mesh(parameters:)`` to make the
+    ///      backstop bite sooner.
+    ///   4. ``withSurfacesAsBSpline(extrusion:revolution:offset:plane:)`` with `offset: true`
+    ///      approximates the `Geom_OffsetSurface` with a plain B-spline, which smooths the cusps
+    ///      the angular check is choking on. Measured on the #286 solid: 125 s / 526 k vertices —
+    ///      faster, but it resamples the geometry, so treat it as a rescue path, not a default.
     public func mesh(
         linearDeflection: Double = 0.1,
         angularDeflection: Double = 0.5
@@ -812,13 +811,34 @@ public final class Shape: @unchecked Sendable {
     /// cancel via `progress.shouldCancel()`. After meshing completes, the shape's faces
     /// have triangulations attached and `mesh()` (no progress) can extract them.
     ///
-    /// - Important: **This cancels a long mesh; it cannot interrupt a hung one.** OCCT polls the
-    ///   range at checkpoints — before each face (`BRepMesh_FaceDiscret`), and per vertex inside
-    ///   `BRepMesh_Delaun::createTrianglesOnNewVertices` — but a hang that occurs *between* two
-    ///   checkpoints is unreachable. Measured on the #286 solid: a 10 s cancel deadline **never
-    ///   fired** (killed at 120 s). Do not rely on this as a timeout for untrusted geometry —
-    ///   see the warning on ``mesh(linearDeflection:angularDeflection:)`` and
-    ///   [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286).
+    /// This is the supported way to bound meshing of untrusted geometry: OCCT polls the range
+    /// densely (before each face in `BRepMesh_FaceDiscret`, at each deflection-control pass, and
+    /// per vertex in `BRepMesh_Delaun`), so a wall-clock deadline in `shouldCancel()` interrupts
+    /// even the pathological offset surfaces of
+    /// [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286). Measured on the #286 face,
+    /// which takes 249 s to mesh in full: a 10 s deadline throws ``ImportError/cancelled`` after
+    /// 10.1 s, having polled 154,898 times.
+    ///
+    /// ```swift
+    /// final class Deadline: ImportProgress, @unchecked Sendable {
+    ///     private let start = Date()
+    ///     func progress(fraction: Double, step: String) {}
+    ///     func shouldCancel() -> Bool { Date().timeIntervalSince(start) > 10 }
+    /// }
+    ///
+    /// do {
+    ///     _ = try shape.meshWithProgress(linearDeflection: 0.1, progress: Deadline())
+    /// } catch ImportError.cancelled {
+    ///     // Gave up after 10s — the geometry is probably degenerate; see `bounds` pre-checks.
+    /// }
+    /// ```
+    ///
+    /// - Note: Before v1.11.1 this could not cancel at all. The bridge used the
+    ///   `BRepMesh_IncrementalMesh(shape, linDefl, isRelative, angDefl)` constructor, which calls
+    ///   `Perform()` internally with a *null* progress range — the whole mesh was built
+    ///   uninterruptibly before the range was polled, and the shape was then meshed a second time.
+    ///   Cancellation still *threw*, because `UserBreak()` was checked afterwards, which is what
+    ///   made the defect look like an OCCT limitation in v1.10.2's docs.
     ///
     /// - Throws: `ImportError.cancelled` if the meshing was cancelled cooperatively.
     /// - Returns: The same shape (with triangulations attached) on success, or nil on

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -1507,6 +1507,67 @@ struct MeshAndExportProgressTests {
         }
     }
 
+    /// Cancels once a wall-clock budget elapses, and counts how often it was asked.
+    final class Deadline: ImportProgress, @unchecked Sendable {
+        private let lock = NSLock()
+        private let start = Date()
+        private let budget: TimeInterval
+        private var _polls = 0
+
+        init(budget: TimeInterval) { self.budget = budget }
+        var polls: Int { lock.lock(); defer { lock.unlock() }; return _polls }
+        func progress(fraction: Double, step: String) {}
+        func shouldCancel() -> Bool {
+            lock.lock(); _polls += 1; lock.unlock()
+            return Date().timeIntervalSince(start) > budget
+        }
+    }
+
+    /// Regression for #286: cancellation must *interrupt* meshing, not be evaluated after it
+    /// has already finished.
+    ///
+    /// The bridge used to call `BRepMesh_IncrementalMesh(shape, linDefl, isRelative, angDefl)`,
+    /// whose constructor runs `Perform()` internally with a null progress range. The whole mesh
+    /// was therefore built uninterruptibly before the range was ever polled, and the following
+    /// `Perform(range)` meshed the shape a second time. Cancellation still *threw* — `UserBreak()`
+    /// was checked afterwards — which is why `meshCancellation` above passed the entire time and
+    /// the defect reached users as "no in-process timeout can bound this". Assert on elapsed time,
+    /// which is the part that was actually broken.
+    ///
+    /// Self-calibrating against a baseline mesh so it does not encode machine speed.
+    @Test("Shape.meshWithProgress interrupts meshing rather than cancelling after it (#286)")
+    func meshCancellationInterrupts() throws {
+        guard let baseline = Shape.sphere(radius: 10) else {
+            Issue.record("sphere construction failed"); return
+        }
+        let t0 = Date()
+        _ = try baseline.meshWithProgress(linearDeflection: 0.001, angularDeflection: 0.1)
+        let full = Date().timeIntervalSince(t0)
+
+        // Too quick to time meaningfully; there is no interruption window to observe.
+        guard full > 0.5 else { return }
+
+        guard let subject = Shape.sphere(radius: 10) else {
+            Issue.record("sphere construction failed"); return
+        }
+        let deadline = Deadline(budget: full * 0.25)
+        let t1 = Date()
+        do {
+            _ = try subject.meshWithProgress(linearDeflection: 0.001, angularDeflection: 0.1,
+                                             progress: deadline)
+            Issue.record("meshWithProgress ran to completion instead of cancelling")
+            return
+        } catch ImportError.cancelled {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)"); return
+        }
+        let elapsed = Date().timeIntervalSince(t1)
+        #expect(deadline.polls > 0, "cancellation was never polled — the progress range was not consumed")
+        #expect(elapsed < full * 0.7,
+                "cancelled after \(elapsed)s against a \(full)s uncancelled mesh — meshing ran to completion before the range was polled (#286)")
+    }
+
     @Test("Exporter.writeSTEP with progress: nil round-trips a file")
     func exportSTEPWithProgressNil() throws {
         guard let box = Shape.box(width: 4, height: 4, depth: 4) else {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,57 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.11.0
+## Current: v1.11.1
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.11.1 (July 2026) — fix: `meshWithProgress` could never cancel; retract the #286 kernel story (#286)
+
+**`Shape.meshWithProgress` now actually cancels.** The bridge used the
+`BRepMesh_IncrementalMesh(shape, linDefl, isRelative, angDefl)` constructor, which calls `Perform()`
+*internally* with a null `Message_ProgressRange`. The entire mesh was therefore built uninterruptibly
+inside the constructor, before the range we passed to the following `Perform(range)` was ever polled —
+and that second call meshed the shape a **second time**. Cancellation still *threw*, because
+`UserBreak()` was checked afterwards, so the pre-existing test passed and the defect shipped. Fixed by
+using the `IMeshTools_Parameters` + `Message_ProgressRange` constructor, the only one that consumes a
+range. Meshing behaviour is otherwise unchanged: both constructors leave
+`AngleInterior`/`MinSize`/`DeflectionInterior` at defaults, which `Perform()` resolves identically.
+
+Measured on the #286 face (249 s to mesh in full): a 10 s deadline now throws `ImportError.cancelled`
+after 10.1 s, having polled 154,898 times. Previously it ran past 400 s without cancelling.
+
+**v1.10.2's account of #286 was wrong in every substantive claim, and is retracted.** Each was checked
+by measuring or building it rather than by reading:
+
+| Claim (v1.10.2) | Measured |
+|---|---|
+| `Shape.mesh` hangs unboundedly on offset surfaces | **Terminates in 249 s**, `status=0`, 1.4 M triangles. Earlier "hangs" were 120 s / 300 s timeouts set below that. |
+| No in-process timeout can bound it — "measured, not inferred" | **A 10 s deadline returns in 10.1 s.** The "10 s cancel never fired" measurement was our own `meshWithProgress` bug, above — not an OCCT limitation. |
+| Root cause is `BRepMesh_MeshAlgoFactory::GetAlgo` handing offsets a `BRepMesh_UndefinedRangeSplitter` | **Disproven by building it.** Routing `GeomAbs_OffsetSurface` to `BRepMesh_NURBSRangeSplitter` leaves the runtime identical. `getUndefinedIntervalNb()` is dead code here: `NbUIntervals(CN)` forwards to the basis adaptor and returns **11, not 1**, so the `if (aIntervalsNb == 1)` branch never runs and the two splitters behave identically. (`NbUPoles()` also *throws* `Standard_NoSuchObject` on an offset adaptor, so the proposed one-liner was unsafe regardless.) |
+| The hang is in `BRepMesh_Delaun::createTrianglesOnNewVertices` | Stack samples put 100 % of time in `BRepMesh_DelaunayDeflectionControlMeshAlgo::optimizeMesh`. |
+
+**Actual cause — invalid input, not an OCCT defect.** The offset surface is *self-intersecting*.
+Offsetting by more than the local radius of curvature produces cusps: the #286 basis fit's minimum
+principal curvature radius is `2.6e-05` against an offset of `1.27`, so **23.8 %** of its domain is
+cusped and the surface normal swings by up to `π` across one. `BRepMesh` splits any triangle link whose
+end normals differ by more than `AngleInterior` (= `2 × angularDeflection`), but at a normal
+*discontinuity* splitting never converges — halving a link that straddles a cusp just moves the cusp
+into one half. So `optimizeMesh` runs all 11 passes demanding ~80 k splits each, long after linear
+deflection is satisfied (1.82 against a 2.48 target by pass 6, with linear splits at **zero** from pass
+4); `MinSize` (= `linearDeflection / 10`) is the only backstop, rejecting ~200 k splits per pass.
+
+**No upstream OCCT issue or patch is warranted** — retracting v1.10.2's "an upstream OCCT fix is being
+attempted". No xcframework rebuild either: the binary is unchanged. A well-formed offset surface meshes
+normally.
+
+`Shape.mesh` and `Shape.meshWithProgress` docs and `docs/reference/Shape.md` rewritten against the
+measurements, and the mitigation list now leads with the deadline that actually works. The `bounds`
+pre-check remains the best first line of defence, and `isValid` still will not catch this (a
+self-intersecting offset surface is a topologically valid face).
 
 ### v1.11.0 (July 2026) — feat: absorb a boolean's history into the graph, so a picked face survives it (#290)
 
@@ -107,6 +151,10 @@ were counted in API_REFERENCE's own example lists while being undocumented — `
 documented beside their siblings. The remaining 37 are tracked in #294.
 
 ### v1.10.2 (July 2026) — docs: `Shape.mesh` can hang unboundedly on offset surfaces (#286)
+
+> **Retracted by v1.11.1.** Every substantive claim below is false: the mesh is not unbounded (249 s),
+> cancellation *does* work (the failed 10 s deadline was our own bridge bug), and the splitter root
+> cause was disproven by building the proposed fix. Kept for history; see v1.11.1.
 
 Documentation only; no code change — because there is no correct in-process code change to make, and
 saying so precisely is the useful output.

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1246,20 +1246,17 @@ public func mesh(
       // use mesh.triangles, mesh.normals, etc.
   }
   ```
-- **⚠️ Can hang unboundedly on offset surfaces.** The geometry `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`) can put OCCT's mesher into an effectively non-terminating state. Measured on a fitted-then-offset B-spline panel: one face meshed for **>300 s without returning** at a *coarse* deflection (1/638 of the bbox diagonal) — a kernel pathology, not a workload cost ([#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286)).
+- **⚠️ Can take minutes on a degenerate offset surface.** The geometry `shelled(thickness:)` / `offset(by:)` produce (`Geom_OffsetSurface`) can be enormously expensive to mesh. It is **not** a hang: measured on the fitted-then-offset B-spline panel from [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286), one face took **249 s** and produced **1.4 M triangles** at a *coarse* deflection (1/638 of the bbox diagonal). It terminates — earlier reports of an unbounded hang were timeouts set below 249 s.
 
-  **Cause** (OCCT `V8_0_0_p1`): `BRepMesh_MeshAlgoFactory::GetAlgo` lumps `GeomAbs_OffsetSurface` in with `GeomAbs_OtherSurface`, handing it a `BRepMesh_UndefinedRangeSplitter` whose `getUndefinedIntervalNb()` returns a constant `1` — so an offset surface gets *no* parametric subdivision, however wiggly its basis B-spline is. (The same B-spline meshed directly gets `BRepMesh_NURBSRangeSplitter`, which subdivides by `NbUPoles()-1`.) The Delaunay insertion then starts from a near-empty grid and `BRepMesh_Delaun::createTrianglesOnNewVertices` blows up.
+  **Cause** — the offset surface is *self-intersecting*, and the mesher's angular criterion cannot converge on it. Offsetting by more than the local radius of curvature produces cusps: on the #286 panel the basis fit's minimum principal curvature radius is `2.6e-05` against an offset of `1.27`, so **23.8 %** of the domain is cusped and the normal swings by up to `π` across one. `BRepMesh` splits any triangle link whose end normals differ by more than `AngleInterior` (= `2 × angularDeflection`), but at a normal *discontinuity* splitting never helps — halving a link that straddles a cusp just moves the cusp into one half. `BRepMesh_DelaunayDeflectionControlMeshAlgo::optimizeMesh` therefore runs all 11 passes demanding ~80 k splits each, long after linear deflection is met (1.82 against a 2.48 target by pass 6); `MinSize` (= `linearDeflection / 10`) is the only backstop.
 
-  **It cannot be bounded in-process**, and the reasons are worth knowing:
-  - **A timeout cannot work — verified, not assumed.** `createTrianglesOnNewVertices` *does* poll (`aPS.More()`) in its outer per-vertex loop, but the hang is inside a *single* iteration, so the poll is never reached. A 10 s cancel deadline via `meshWithProgress` was measured **not to fire at all** (killed at 120 s).
-  - **A validity pre-check cannot catch it.** The measured offending solid reports `isValid == true`.
+  This is invalid input, not an OCCT defect — a well-formed offset surface meshes normally. Note `isValid` will **not** catch it (the offending solid reports `isValid == true`): a self-intersecting offset surface is still a topologically valid face.
 
   Mitigations, best first:
   1. **Sanity-check before meshing.** `bounds` is a cheap `Bnd_Box` query (no tessellation) — comparing a thickened solid's bbox against its source's rejects the ballooned offsets that trigger this.
-  2. `withSurfacesAsBSpline(offset: true)` converts the offset surface to a plain B-spline first. On the #286 solid this turns the hang into a **bounded 125 s** (526 k verts) — it terminates, but it is a rescue path, not a default.
-  3. Mesh in a separate process for untrusted offset geometry.
-
-  Well-formed offset solids mesh normally; this bites only on pathological (ballooned / near-degenerate) fitted-then-offset surfaces.
+  2. **Bound it with a deadline.** [`meshWithProgress`](#meshwithprogresslineardeflectionangulardeflectionprogress) interrupts this reliably — a 10 s deadline returns in 10.1 s on the #286 face.
+  3. **Raise `angularDeflection`** (it sets the `AngleInterior` threshold doing all the splitting), or raise `MinSize` via `mesh(parameters:)` so the backstop bites sooner.
+  4. `withSurfacesAsBSpline(offset: true)` approximates the offset surface with a plain B-spline, smoothing the cusps the angular check chokes on: 125 s / 526 k verts on the #286 solid. It resamples the geometry, so it is a rescue path, not a default.
 
 ---
 
@@ -1276,7 +1273,9 @@ public func meshWithProgress(
 ) throws -> Shape
 ```
 
-Wraps `BRepMesh_IncrementalMesh::Perform(Message_ProgressRange&)` so callers can observe meshing progress on large assemblies and cooperatively cancel.
+Wraps `BRepMesh_IncrementalMesh(shape, IMeshTools_Parameters, Message_ProgressRange)` so callers can observe meshing progress on large assemblies and cooperatively cancel.
+
+This is the supported way to **bound meshing of untrusted geometry**. OCCT polls the range densely — before each face (`BRepMesh_FaceDiscret`), at each deflection-control pass, and per vertex in `BRepMesh_Delaun` — so a wall-clock deadline in `shouldCancel()` interrupts even the pathological offset surfaces of [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286). Measured on the #286 face, which needs 249 s to mesh in full: a 10 s deadline throws `ImportError.cancelled` after 10.1 s, having polled 154,898 times.
 
 - **Parameters:**
   - `linearDeflection`, `angularDeflection` — same as `mesh()`.
@@ -1284,16 +1283,22 @@ Wraps `BRepMesh_IncrementalMesh::Perform(Message_ProgressRange&)` so callers can
 - **Returns:** `self` (with triangulations attached) on success.
 - **Throws:** `ImportError.cancelled` if the meshing was cancelled cooperatively.
 - **OCCT:** `BRepMesh_IncrementalMesh` with `Message_ProgressRange` (via `OCCTShapeIncrementalMeshProgress`).
-- **Example:**
+- **Example** — bound an untrusted mesh to 10 seconds:
   ```swift
-  class MyProgress: ImportProgress {
-      func shouldCancel() -> Bool { false }
-      func report(fraction: Double) { print("Meshing: \(Int(fraction * 100))%") }
+  final class Deadline: ImportProgress, @unchecked Sendable {
+      private let start = Date()
+      func progress(fraction: Double, step: String) {}
+      func shouldCancel() -> Bool { Date().timeIntervalSince(start) > 10 }
   }
-  let prog = MyProgress()
-  try shape.meshWithProgress(linearDeflection: 0.02, progress: prog)
-  let mesh = shape.mesh()  // triangulations are now attached
+
+  do {
+      try shape.meshWithProgress(linearDeflection: 0.02, progress: Deadline())
+      let mesh = shape.mesh()  // triangulations are now attached
+  } catch ImportError.cancelled {
+      // Gave up after 10s — the geometry is probably degenerate.
+  }
   ```
+- **Fixed in v1.11.1:** cancellation previously did not work at all. The bridge used the `BRepMesh_IncrementalMesh(shape, linDefl, isRelative, angDefl)` constructor, which calls `Perform()` internally with a *null* progress range: the whole mesh was built uninterruptibly before the range was polled, and the shape was then meshed a second time. Cancellation still *threw* (`UserBreak()` was checked afterwards), which is why v1.10.2 documented this as an OCCT limitation.
 
 ---
 


### PR DESCRIPTION
Fixes the one real bug behind #286 — which turned out to be **ours, not OpenCASCADE's** — and retracts the kernel story v1.10.2/v1.10.3 shipped.

## The bug: `meshWithProgress` could never cancel

```cpp
BRepMesh_IncrementalMesh mesher(shape->shape, linearDeflection, Standard_False, angularDeflection);
// ^ this ctor calls Perform() INTERNALLY with a null range: the whole mesh is built
//   right here, uninterruptibly, before any range is polled
mesher.Perform(range);   // <- and this meshes the shape a SECOND time
```

Cancellation still *threw* — `UserBreak()` is checked afterwards — so the existing test passed and the defect shipped as "OCCT can't be interrupted". Fixed by using the `IMeshTools_Parameters` + `Message_ProgressRange` ctor, the only one that consumes a range.

**Meshing behaviour is unchanged.** Both ctors leave `AngleInterior`/`MinSize`/`DeflectionInterior` at defaults, which `Perform()` resolves identically; only `Deflection`/`Angle`/`Relative`/`InParallel` are set, matching the old ctor's arguments exactly.

Measured on `panel286_face2.brep` (249 s to mesh in full), through the Swift API:

```
threw cancelled after 10.12s  (polls=154898)
```

Previously it ran past **400 s** without cancelling (worse than the 249 s baseline, because it meshed twice).

## The regression test

Asserts on **elapsed time**, which is the part that was actually broken. An always-cancel test passes either way — which is exactly why the pre-existing `meshCancellation` test (which accepts *both* outcomes: *"Acceptable: meshing may complete before any cancellation checkpoint"*) never caught this.

Self-calibrating against a baseline mesh so it doesn't encode machine speed. Confirmed to **fail** against the old bridge:

```
✘ Expectation failed: (elapsed → 1.7343) < (full * 0.7 → 1.2771)
  cancelled after 1.734s against a 1.824s uncancelled mesh — meshing ran to
  completion before the range was polled (#286)
```

and pass after (2.1 s, no fixture needed — a `sphere(radius: 10)` at deflection 0.001).

## Retraction

Every substantive claim in #286 / v1.10.2 is false. Each was checked by measuring or building it:

| Claim | Measured |
|---|---|
| `Shape.mesh` **hangs unboundedly** on offset surfaces | **Terminates in 249 s**, `status=0`, 1.4 M triangles. The 120 s/300 s "hangs" were timeouts set below that. |
| **No in-process timeout can bound it** | **10 s deadline returns in 10.1 s.** That measurement was the bridge bug above. |
| Root cause is `GetAlgo` handing offsets a `BRepMesh_UndefinedRangeSplitter` | **Disproven by building the proposed one-liner** (symbol override verified via an instrumented TU): runtime identical. `NbUIntervals(CN)` forwards to the basis adaptor and returns **11, not 1**, so `getUndefinedIntervalNb()` is dead code and the two splitters behave identically here. `NbUPoles()` also *throws* `Standard_NoSuchObject` on an offset adaptor. |
| Hang is in `BRepMesh_Delaun::createTrianglesOnNewVertices` | Stack samples: **100 % in `BRepMesh_DelaunayDeflectionControlMeshAlgo::optimizeMesh`**. |

**Actual cause — invalid input, not an OCCT defect.** The offset surface is self-intersecting:

```
offset = -1.26648
basis min principal radius over 14641 samples = 2.59277e-05
samples where basis curvature radius < |offset| (CUSP): 3491 / 14641  (23.844%)
offset-surface adjacent-normal swing: max = 3.13779 rad (= pi)
```

`BRepMesh` splits any link whose end normals differ by more than `AngleInterior` (= `2 × angularDeflection`), but at a normal *discontinuity* splitting never converges. Per-pass instrumentation of `optimizeMesh`:

| pass | linear (centre) | linear (link) | **angular** | minSize rejects | maxDefl |
|---|---|---|---|---|---|
| 1 | 269 | 826 | **36,532** | 125,838 | 38.63 |
| 4 | 0 | 11 | **80,065** | 153,844 | 4.50 |
| 6 | 0 | 0 | **82,010** | 202,691 | **1.82** (target 2.48) |

Linear deflection is met by pass 6 and contributes **zero** splits from pass 4 — yet ~80 k angular splits/pass keep coming. `MinSize` is the only backstop. It runs its 11 passes, hits 1.4 M triangles, stops.

**No upstream OCCT issue or patch is warranted**, and no xcframework rebuild is needed — retracting v1.10.3's "an upstream OCCT fix is being attempted".

## Docs

`Shape.mesh` / `meshWithProgress` doc comments, `docs/reference/Shape.md` and `docs/CHANGELOG.md` rewritten against the measurements. The mitigation list now leads with the deadline that works; v1.10.2 entry carries retraction notices. The `bounds` pre-check remains the best first line of defence, and `isValid` still won't catch this (a self-intersecting offset surface is a topologically valid face).

## Verification

- `swift build` clean; `OCCTIOTests` + `OCCTMeshTests` green (204 tests, 53 suites).
- Full suite `swift test --no-parallel` running; will confirm before tagging.
- Regression test verified red against the old bridge, green against the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
