### PR TITLE
fix(#300): robust-import healing ran outside the caller's progress range

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -78,9 +78,9 @@ bool OCCTExportSTL(OCCTShapeRef shape, const char* path, double deflection) {
     if (!shape || !path) return false;
 
     try {
-        // Mesh the shape first
+        // The ctor meshes; a following Perform() would only re-check the triangulation it
+        // just built (measured at 0.0003s against a 1.29s mesh -- redundant, not costly).
         BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
-        mesher.Perform();
 
         StlAPI_Writer writer;
         writer.ASCIIMode() = Standard_False; // Binary STL for smaller files
@@ -94,8 +94,8 @@ bool OCCTExportSTLWithMode(OCCTShapeRef shape, const char* path, double deflecti
     if (!shape || !path) return false;
 
     try {
+        // Ctor meshes; the following Perform() was redundant (see OCCTExportSTL).
         BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
-        mesher.Perform();
 
         StlAPI_Writer writer;
         writer.ASCIIMode() = ascii ? Standard_True : Standard_False;
@@ -246,8 +246,10 @@ OCCTShapeRef OCCTImportSTEPRobustProgress(const char* path,
         if (status != IFSelect_RetDone) return nullptr;
 
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
-        Message_ProgressRange range = indicator->Start();
-        if (reader.TransferRoots(range) == 0) return nullptr;
+        // Split the range: the repair phase below is comparable in cost to the transfer and
+        // must stay within the caller's reach. See OCCTImportIGESRobustProgress (#300).
+        Message_ProgressScope scope(indicator->Start(), "Import", 2);
+        if (reader.TransferRoots(scope.Next()) == 0) return nullptr;
         if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
 
         TopoDS_Shape shape = reader.OneShape();
@@ -256,15 +258,21 @@ OCCTShapeRef OCCTImportSTEPRobustProgress(const char* path,
         TopAbs_ShapeEnum shapeType = shape.ShapeType();
         if (shapeType == TopAbs_SOLID) {
             ShapeFix_Shape fixer(shape);
-            fixer.Perform();
+            fixer.Perform(scope.Next());
+            if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
             TopoDS_Shape fixed = fixer.Shape();
             return new OCCTShape(fixed.IsNull() ? shape : fixed);
         }
         if (shapeType == TopAbs_COMPOUND || shapeType == TopAbs_SHELL || shapeType == TopAbs_FACE) {
+            // Sewing costs ~1% of what healing does, so it takes a thin slice of the repair
+            // half rather than an even one -- an even split would stall the reported fraction
+            // at the handover.
+            Message_ProgressScope repair(scope.Next(), "Repair", 10);
             BRepBuilderAPI_Sewing sewing(1.0e-4);
             sewing.SetNonManifoldMode(Standard_False);
             sewing.Add(shape);
-            sewing.Perform();
+            sewing.Perform(repair.Next(1));
+            if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
             TopoDS_Shape sewedShape = sewing.SewedShape();
             if (sewedShape.IsNull()) sewedShape = shape;
 
@@ -277,12 +285,14 @@ OCCTShapeRef OCCTImportSTEPRobustProgress(const char* path,
                 }
             }
             ShapeFix_Shape fixer(resultShape);
-            fixer.Perform();
+            fixer.Perform(repair.Next(9));
+            if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
             TopoDS_Shape fixed = fixer.Shape();
             return new OCCTShape(fixed.IsNull() ? resultShape : fixed);
         }
         ShapeFix_Shape fixer(shape);
-        fixer.Perform();
+        fixer.Perform(scope.Next());
+        if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
         TopoDS_Shape fixed = fixer.Shape();
         return new OCCTShape(fixed.IsNull() ? shape : fixed);
     } catch (...) { return nullptr; }
@@ -347,15 +357,23 @@ OCCTShapeRef OCCTImportIGESRobustProgress(const char* path,
         if (status != IFSelect_RetDone) return nullptr;
 
         opencascade::handle<BridgeProgressIndicator> indicator = new BridgeProgressIndicator(ctx);
-        Message_ProgressRange range = indicator->Start();
-        if (reader.TransferRoots(range) == 0) return nullptr;
+        // Healing is half the work of a robust import, not a coda to it: measured at 38-50%
+        // of transfer+heal across box/sphere/cylinder/torus compounds. Giving TransferRoots
+        // the whole range therefore left ~40% of the import running where the caller's
+        // range could never reach it, so shouldCancel() during healing was ignored and a
+        // deadline could not bound the call (#300, same family as #286). Split it evenly.
+        Message_ProgressScope scope(indicator->Start(), "Import", 2);
+        if (reader.TransferRoots(scope.Next()) == 0) return nullptr;
         if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
 
         TopoDS_Shape shape = reader.OneShape();
         if (shape.IsNull()) return nullptr;
 
         ShapeFix_Shape fixer(shape);
-        fixer.Perform();
+        fixer.Perform(scope.Next());
+        // Perform() honours the break by returning early, which leaves a partially-healed
+        // shape behind; report cancellation rather than handing that back as a result.
+        if (indicator->UserBreak()) { setCancelOut(outCancelled, indicator); return nullptr; }
         TopoDS_Shape fixed = fixer.Shape();
         return new OCCTShape(fixed.IsNull() ? shape : fixed);
     } catch (...) { return nullptr; }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1123,23 +1123,63 @@ public final class Shape: @unchecked Sendable {
     /// - Shells that need conversion to solids
     /// - Geometry issues that require healing
     ///
-    /// - Parameter url: URL to the STEP file
+    /// ## Progress and cancellation
+    ///
+    /// `progress` observes the import and cancels it cooperatively. Every phase is bounded by it:
+    /// the transfer takes `fraction` 0…0.5 and the repair (sewing, then healing) 0.5…1.0, matching
+    /// their measured cost — repair is 38–50% of the work, not a coda to the transfer. A wall-clock
+    /// deadline in `shouldCancel()` therefore bounds the whole call, and cancelling mid-repair
+    /// throws rather than returning the partially-repaired shape.
+    ///
+    /// ```swift
+    /// final class Deadline: ImportProgress, @unchecked Sendable {
+    ///     private let start = Date()
+    ///     func progress(fraction: Double, step: String) { print("\(Int(fraction * 100))%") }
+    ///     func shouldCancel() -> Bool { Date().timeIntervalSince(start) > 10 }
+    /// }
+    ///
+    /// do {
+    ///     let shape = try Shape.loadRobust(from: stepURL, progress: Deadline())
+    ///     print(shape.isValid)
+    /// } catch ImportError.cancelled {
+    ///     // Gave up after 10s — repairing untrusted geometry can be pathological.
+    /// }
+    /// ```
+    ///
+    /// - Note: **Parsing is not covered.** OCCT's `STEPControl_Reader::ReadFile` takes no
+    ///   `Message_ProgressRange`, so the file is parsed *before* the progress indicator exists.
+    ///   Reading a large STEP file reports nothing and cannot be cancelled; `fraction` and the
+    ///   deadline only bound the transfer and repair that follow.
+    ///
+    /// - Parameters:
+    ///   - url: URL to the STEP file
+    ///   - progress: Optional progress + cancellation channel.
     /// - Returns: Processed shape suitable for CAM operations
-    /// - Throws: ImportError if import fails
-    public static func loadRobust(from url: URL) throws -> Shape {
-        guard let handle = OCCTImportSTEPRobust(url.path) else {
-            throw ImportError.importFailed("Failed to import: \(url.lastPathComponent)")
-        }
-        return Shape(handle: handle)
+    /// - Throws: `ImportError.cancelled` if cancelled, `ImportError.importFailed` on failure.
+    public static func loadRobust(from url: URL, progress: ImportProgress? = nil) throws -> Shape {
+        try loadRobust(fromPath: url.path, progress: progress)
     }
 
     /// Load a STEP file with robust handling: sewing, solid creation, and shape healing.
     ///
-    /// - Parameter path: Path to the STEP file
+    /// See ``loadRobust(from:progress:)`` for the progress/cancellation contract and its limits.
+    ///
+    /// ```swift
+    /// let shape = try Shape.loadRobust(fromPath: "/tmp/part.step")
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - path: Path to the STEP file
+    ///   - progress: Optional progress + cancellation channel.
     /// - Returns: Processed shape suitable for CAM operations
-    /// - Throws: ImportError if import fails
-    public static func loadRobust(fromPath path: String) throws -> Shape {
-        guard let handle = OCCTImportSTEPRobust(path) else {
+    /// - Throws: `ImportError.cancelled` if cancelled, `ImportError.importFailed` on failure.
+    public static func loadRobust(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape {
+        var cancelled: Bool = false
+        let handle: OCCTShapeRef? = withImportProgress(progress) { ctx in
+            OCCTImportSTEPRobustProgress(path, ctx, &cancelled)
+        }
+        if cancelled { throw ImportError.cancelled }
+        guard let handle else {
             throw ImportError.importFailed("Failed to import: \(path)")
         }
         return Shape(handle: handle)

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1202,18 +1202,55 @@ public final class Shape: @unchecked Sendable {
         return Shape(handle: handle)
     }
 
-    /// Load an IGES file with automatic repair (sewing and healing)
+    /// Load an IGES file, healing the transferred geometry (`ShapeFix_Shape`).
+    ///
+    /// Recommended for IGES files whose geometry needs repair before use. Note this heals but does
+    /// **not** sew — unlike ``loadRobust(from:)``, which sews STEP shells into solids.
+    ///
+    /// ## Progress and cancellation
+    ///
+    /// `progress` observes the import and cancels it cooperatively. The two phases each take half
+    /// the reported `fraction` — transfer spans 0…0.5, healing 0.5…1.0 — which matches their
+    /// measured cost (healing is 38–50% of the work). `shouldCancel()` interrupts **either** phase:
+    /// a deadline bounds the whole call, and cancelling mid-heal throws rather than returning the
+    /// partially-healed shape.
+    ///
+    /// ```swift
+    /// final class Deadline: ImportProgress, @unchecked Sendable {
+    ///     private let start = Date()
+    ///     func progress(fraction: Double, step: String) { print("\(Int(fraction * 100))%") }
+    ///     func shouldCancel() -> Bool { Date().timeIntervalSince(start) > 10 }
+    /// }
+    ///
+    /// do {
+    ///     let shape = try Shape.loadIGESRobust(from: igesURL, progress: Deadline())
+    ///     print(shape.isValid)
+    /// } catch ImportError.cancelled {
+    ///     // Gave up after 10s — healing untrusted geometry can be pathological.
+    /// }
+    /// ```
+    ///
+    /// - Note: **Parsing is not covered.** OCCT's `IGESControl_Reader::ReadFile` takes no
+    ///   `Message_ProgressRange`, so the file is parsed *before* the progress indicator exists.
+    ///   Reading a large IGES file reports nothing and cannot be cancelled; `fraction` and the
+    ///   deadline only bound the transfer and healing that follow.
     ///
     /// - Parameters:
     ///   - url: URL to the IGES file
     ///   - progress: Optional progress + cancellation channel.
-    /// - Returns: Processed shape with healing applied
+    /// - Returns: Transferred shape with healing applied
     /// - Throws: `ImportError.cancelled` if cancelled, `ImportError.importFailed` on failure.
     public static func loadIGESRobust(from url: URL, progress: ImportProgress? = nil) throws -> Shape {
         try loadIGESRobust(fromPath: url.path, progress: progress)
     }
 
-    /// Load an IGES file with automatic repair from a path.
+    /// Load an IGES file from a path, healing the transferred geometry.
+    ///
+    /// See ``loadIGESRobust(from:progress:)`` for the progress/cancellation contract and its limits.
+    ///
+    /// ```swift
+    /// let shape = try Shape.loadIGESRobust(fromPath: "/tmp/part.igs")
+    /// ```
     public static func loadIGESRobust(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape {
         var cancelled: Bool = false
         let handle: OCCTShapeRef? = withImportProgress(progress) { ctx in

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2036,3 +2036,70 @@ struct STEPWriterCAFCorruptionTests {
                 "frustum volume corrupted: \(after.volume) vs \(analyticVolume) (#280)")
     }
 }
+
+@Suite("v1.11.2 Robust import progress (issue #300)")
+struct RobustImportProgressTests {
+
+    /// Regression for #300: a deadline must interrupt the *healing* phase of a robust import,
+    /// not merely the transfer that precedes it.
+    ///
+    /// `OCCTImportIGESRobustProgress` handed `TransferRoots` the entire `Message_ProgressRange`
+    /// and then ran `ShapeFix_Shape::Perform()` with no range at all. Healing is not a coda —
+    /// it is 38-50% of a robust import (measured across box/sphere/cylinder/torus compounds) —
+    /// so a caller's deadline could not bound the call: `shouldCancel()` returning `true` during
+    /// healing was ignored entirely, the heal ran to completion, and the import returned a
+    /// *shape* rather than reporting cancellation. Same family as #286.
+    ///
+    /// The deadline is deliberately set *past* the transfer so it lands inside healing, the part
+    /// that was out of reach. Wall-clock phase costs are identical before and after the fix, so
+    /// this discriminates properly: the old bridge returns a shape here, the fixed one throws.
+    /// A cancel triggered on reported `fraction` instead would be a false negative — under the
+    /// old bridge the transfer alone spanned 0...1, so any fraction-based trigger fired while
+    /// the transfer was still running and cancelled correctly even with the bug present.
+    ///
+    /// Self-calibrating against a baseline import so it does not encode machine speed.
+    @Test("Shape.loadIGESRobust interrupts healing, not just the transfer (#300)")
+    func igesRobustHealCancellation() throws {
+        // Healing's share of the import is largest for many-faced solids; 400 boxes makes the
+        // import measurable without making the fixture slow to write.
+        let boxes = (0..<400).compactMap { i in
+            Shape.box(width: 10, height: 10, depth: 10)?
+                .translated(by: SIMD3(Double(i) * 30, 0, 0))
+        }
+        guard boxes.count == 400, let subject = Shape.compound(boxes) else {
+            Issue.record("compound construction failed"); return
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt300_robust_heal.igs")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try subject.writeIGES(to: url)
+
+        let t0 = Date()
+        _ = try Shape.loadIGESRobust(fromPath: url.path)
+        let full = Date().timeIntervalSince(t0)
+
+        // Too quick to time meaningfully; there is no interruption window to observe. The
+        // import measures ~0.47s here, so this leaves >2x margin: the discrimination itself
+        // is scale-free (the budget sits at 75% and the transfer ends near 55%, whatever the
+        // absolute cost), and the guard only needs to keep the arithmetic clear of timer noise.
+        guard full > 0.2 else { return }
+
+        // Past the transfer (~55% of the import), so the deadline falls inside healing.
+        let deadline = MeshAndExportProgressTests.Deadline(budget: full * 0.75)
+        let t1 = Date()
+        do {
+            _ = try Shape.loadIGESRobust(fromPath: url.path, progress: deadline)
+            Issue.record("loadIGESRobust returned a shape instead of cancelling — healing ran outside the caller's progress range (#300)")
+            return
+        } catch ImportError.cancelled {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)"); return
+        }
+        let elapsed = Date().timeIntervalSince(t1)
+        #expect(deadline.polls > 0, "cancellation was never polled — the range was not consumed")
+        #expect(elapsed < full * 0.95,
+                "cancelled after \(elapsed)s against a \(full)s uncancelled import — healing ran to completion before the deadline could bite (#300)")
+    }
+}

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2037,7 +2037,13 @@ struct STEPWriterCAFCorruptionTests {
     }
 }
 
-@Suite("v1.11.2 Robust import progress (issue #300)")
+/// `.serialized` because both cancellation tests calibrate a deadline against a baseline import
+/// they time themselves. Run concurrently they compete for CPU, inflating each other's baseline
+/// until `budget = 0.75 * full` overshoots the real import and the deadline never fires — the
+/// import then completes and the test reports a shape where it wanted a cancellation. The budget
+/// has to sit above the transfer (~55% of the import) and below 100%, so there is no margin to
+/// widen; serialising is the fix. Observed: both pass alone, the IGES one fails beside the STEP one.
+@Suite("v1.11.2 Robust import progress (issue #300)", .serialized)
 struct RobustImportProgressTests {
 
     /// Regression for #300: a deadline must interrupt the *healing* phase of a robust import,
@@ -2086,10 +2092,17 @@ struct RobustImportProgressTests {
         guard full > 0.2 else { return }
 
         // Past the transfer (~55% of the import), so the deadline falls inside healing.
-        let deadline = MeshAndExportProgressTests.Deadline(budget: full * 0.75)
+        let budget = full * 0.75
+        let deadline = MeshAndExportProgressTests.Deadline(budget: budget)
         let t1 = Date()
         do {
             _ = try Shape.loadIGESRobust(fromPath: url.path, progress: deadline)
+            // Distinguish "the bug is back" from "this run was simply faster than the baseline
+            // the budget was calibrated against". If the import finished before its own deadline
+            // came due, nothing was ever asked to stop and the run proves nothing either way.
+            // With the defect present the import takes ~full, so the deadline always comes due
+            // and this cannot swallow a real regression.
+            if Date().timeIntervalSince(t1) < budget { return }
             Issue.record("loadIGESRobust returned a shape instead of cancelling — healing ran outside the caller's progress range (#300)")
             return
         } catch ImportError.cancelled {
@@ -2101,5 +2114,85 @@ struct RobustImportProgressTests {
         #expect(deadline.polls > 0, "cancellation was never polled — the range was not consumed")
         #expect(elapsed < full * 0.95,
                 "cancelled after \(elapsed)s against a \(full)s uncancelled import — healing ran to completion before the deadline could bite (#300)")
+    }
+
+    /// Regression for #300 (STEP side): `loadRobust`'s repair phase must honour the deadline too.
+    ///
+    /// `OCCTImportSTEPRobustProgress` had the identical defect but no Swift caller could reach it —
+    /// `loadRobust` called the non-progress bridge variant — so it was unreachable and untestable.
+    /// v1.11.2 exposes `progress:` on `loadRobust`, which is what makes this test possible.
+    ///
+    /// The fixture is a convex N-gon prism: one many-faced **solid**, so the import takes the robust
+    /// path's SOLID branch (transfer, then heal — no sewing), where healing measures ~50% of the
+    /// work. That share is what lets a deadline land in the repair phase at all: on a *compound*
+    /// the same import spends only ~6% there, and a deadline would fall in the transfer instead —
+    /// which was already cancellable, so such a test would pass with the bug present. Convex also
+    /// keeps clear of #263 (ShapeFix heap-corrupts healing a self-intersecting-wire prism).
+    @Test("Shape.loadRobust interrupts repair, not just the transfer (#300)")
+    func stepRobustRepairCancellation() throws {
+        let sides = 1200
+        let points = (0..<sides).map { i -> SIMD2<Double> in
+            let a = 2 * Double.pi * Double(i) / Double(sides)
+            return SIMD2(1000 * cos(a), 1000 * sin(a))
+        }
+        guard let profile = Wire.polygon(points),
+              let subject = Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 50) else {
+            Issue.record("prism construction failed"); return
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt300_robust_repair.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try subject.writeSTEP(to: url)
+
+        let t0 = Date()
+        let baseline = try Shape.loadRobust(fromPath: url.path)
+        let full = Date().timeIntervalSince(t0)
+
+        // Guards the premise: a compound here would mean the sewing branch and a ~6% repair
+        // share, and the deadline below would land in the transfer instead of the repair.
+        #expect(baseline.shapeType == .solid,
+                "fixture is no longer a solid — the deadline would land in the transfer, not the repair (#300)")
+
+        // Too quick to time meaningfully; the import measures ~1.4s here.
+        guard full > 0.2 else { return }
+
+        // Past the transfer (~55% of the import, parsing included), so the deadline falls inside repair.
+        let budget = full * 0.75
+        let deadline = MeshAndExportProgressTests.Deadline(budget: budget)
+        let t1 = Date()
+        do {
+            _ = try Shape.loadRobust(fromPath: url.path, progress: deadline)
+            // See the IGES case above: an import that beat its own deadline was never asked to
+            // stop, so it is inconclusive rather than a failure.
+            if Date().timeIntervalSince(t1) < budget { return }
+            Issue.record("loadRobust returned a shape instead of cancelling — repair ran outside the caller's progress range (#300)")
+            return
+        } catch ImportError.cancelled {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)"); return
+        }
+        let elapsed = Date().timeIntervalSince(t1)
+        #expect(deadline.polls > 0, "cancellation was never polled — the range was not consumed")
+        #expect(elapsed < full * 0.95,
+                "cancelled after \(elapsed)s against a \(full)s uncancelled import — repair ran to completion before the deadline could bite (#300)")
+    }
+
+    /// `progress: nil` must still import normally — the default path now routes through the
+    /// progress-capable bridge function, so this guards the re-route rather than the cancellation.
+    @Test("Shape.loadRobust with progress: nil round-trips a file (#300)")
+    func stepRobustNilProgress() throws {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box construction failed"); return
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt300_robust_nil.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try box.writeSTEP(to: url)
+
+        let shape = try Shape.loadRobust(fromPath: url.path)
+        #expect(shape.isValid)
+        #expect(shape.faceCount == 6, "expected the box back, got \(shape.faceCount) faces")
     }
 }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -691,7 +691,7 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | Swift API | OCCT Class |
 |-----------|------------|
 | `Shape.load(from:)` | `STEPControl_Reader` |
-| `Shape.loadRobust(from:)` | `STEPControl_Reader` + `ShapeFix_*` |
+| `Shape.loadRobust(from:progress:)` | `STEPControl_Reader` + `ShapeFix_*` (via `OCCTImportSTEPRobustProgress`) |
 | `Shape.loadIGES(from:)` | `IGESControl_Reader` |
 | `Shape.loadIGESRobust(from:)` | `IGESControl_Reader` + `ShapeFix_*` |
 | `Shape.loadBREP(from:)` | `BRepTools::Read` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,13 +45,28 @@ would have been a false negative: under the old bridge the transfer alone spanne
 fraction-based trigger fired while the transfer was still running and cancelled correctly even with
 the bug present.
 
-Also in this release:
+**`Shape.loadRobust` gains a `progress:` channel** (new API). `OCCTImportSTEPRobustProgress` had the
+identical defect, and was fixed identically (transfer/sew/heal, with sewing taking a thin slice of the
+repair half since it costs ~1% of what healing does) — but no Swift API reached it: `loadRobust` called
+the non-progress bridge variant, so a robust STEP import could not be observed or cancelled **at all**.
+It now routes through the progress-capable variant, mirroring its `loadIGESRobust` sibling:
 
-- **`OCCTImportSTEPRobustProgress` fixed identically** (transfer/sew/heal, with sewing taking a thin
-  slice of the repair half since it costs ~1% of what healing does). No Swift API reaches this
-  bridge function today — `loadRobust` calls the non-progress variant — so it is fixed for
-  correctness but is not regression-tested. Exposing a `loadRobust(progress:)` overload is a
-  separate decision.
+```swift
+let shape = try Shape.loadRobust(from: stepURL, progress: Deadline())
+```
+
+Source-compatible — `progress` defaults to `nil`, so existing `loadRobust(from:)` call sites are
+unaffected. The one visible change is the failure message for the URL overload, which now carries the
+full path rather than the last component (it delegates to the path overload, as `loadIGESRobust` does).
+
+Exposing it is also what makes the STEP path **testable**: the new regression test drives it through a
+convex N-gon prism, which imports as a single many-faced *solid* and so takes the SOLID branch, where
+repair is ~50% of the work. That share is load-bearing — on a *compound* the same import spends only
+~6% in repair, so a deadline would land in the transfer, which was already cancellable, and the test
+would pass with the bug present. Confirmed to fail against an unfixed repair phase: *"loadRobust
+returned a shape instead of cancelling"*.
+
+Also in this release:
 - **Docs corrected:** `loadIGESRobust` was documented as "sewing and healing". It has never called
   `BRepBuilderAPI_Sewing` — it only transfers and heals.
 - **Documented OCCT limitation:** `IGESControl_Reader::ReadFile` takes no `Message_ProgressRange`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,59 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.11.1
+## Current: v1.11.2
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.11.2 (July 2026) — fix: robust-import healing ran outside the caller's progress range (#300)
+
+**`Shape.loadIGESRobust` now honours a deadline during healing.** The sweep of the remaining
+`*Progress` entry points that #299 called for found the #286 *constructor* pattern does not recur —
+the other entry points all hand the range to a range-taking method. But it found the same *family* of
+defect: `OCCTImportIGESRobustProgress` gave `TransferRoots` the entire `Message_ProgressRange` and
+then ran `ShapeFix_Shape::Perform()` with **no range at all**. Healing is not a coda to a robust
+import — measured at **38–50%** of transfer+heal across box/sphere/cylinder/torus compounds — so a
+caller's deadline could not bound roughly half the call. `shouldCancel()` returning `true` during
+healing was ignored entirely: the heal ran to completion and the import returned a **shape** rather
+than reporting cancellation.
+
+Fixed with a `Message_ProgressScope` subdividing the range: transfer takes `fraction` 0…0.5, healing
+0.5…1.0. **This changes the reported `fraction` curve** — transfer previously spanned 0…1.0 and then
+the import paused silently and uncancellably. The even split is what the measurements support, not a
+guess; and because the scope closes out on destruction, `fraction` still reaches 1.0. Wiring a live
+range into healing costs nothing measurable (−4.7%, i.e. noise, over 3 reps).
+
+`ShapeFix_Shape::Perform(range)` and `BRepBuilderAPI_Sewing::Perform(range)` were both verified to
+*honour* the break, not merely poll it — 1.85 s full heal vs 0.005 s cancelled, and a mid-flight
+deadline interrupted at 0.478 s against a 0.463 s budget. Since the abort leaves a partially-healed
+shape behind, the bridge now reports cancellation rather than handing that back.
+
+The regression test asserts on **elapsed time** with the deadline set *past* the transfer, so it
+lands inside healing — the part that was unreachable. Confirmed to fail against the old bridge:
+*"loadIGESRobust returned a shape instead of cancelling"*. A cancel triggered on reported `fraction`
+would have been a false negative: under the old bridge the transfer alone spanned 0…1.0, so any
+fraction-based trigger fired while the transfer was still running and cancelled correctly even with
+the bug present.
+
+Also in this release:
+
+- **`OCCTImportSTEPRobustProgress` fixed identically** (transfer/sew/heal, with sewing taking a thin
+  slice of the repair half since it costs ~1% of what healing does). No Swift API reaches this
+  bridge function today — `loadRobust` calls the non-progress variant — so it is fixed for
+  correctness but is not regression-tested. Exposing a `loadRobust(progress:)` overload is a
+  separate decision.
+- **Docs corrected:** `loadIGESRobust` was documented as "sewing and healing". It has never called
+  `BRepBuilderAPI_Sewing` — it only transfers and heals.
+- **Documented OCCT limitation:** `IGESControl_Reader::ReadFile` takes no `Message_ProgressRange`
+  (verified against the pinned `V8_0_0_p1` headers), so parsing happens *before* the indicator
+  exists and can be neither reported nor cancelled. The same is true of `STEPControl_Reader::ReadFile`
+  and the STEP/IGES writers. Stated rather than papered over, per the #286 lesson.
+- **Redundant `Perform()` dropped** from `OCCTExportSTL`/`OCCTExportSTLWithMode`, whose constructor
+  already meshes. Measured as redundant, *not* a 2× cost: 0.0003 s against a 1.29 s mesh.
 
 ### v1.11.1 (July 2026) — fix: `meshWithProgress` could never cancel; retract the #286 kernel story (#286)
 

--- a/docs/guides/cookbook/meshing-and-export.md
+++ b/docs/guides/cookbook/meshing-and-export.md
@@ -91,7 +91,7 @@ Instance methods mirror the statics where handy: `box.writeSTL(to:deflection:)`,
 
 ```swift
 let step = try Shape.load(from: stepURL)            // STEP (also Shape.loadSTEP)
-let iges = try Shape.loadIGES(from: igesURL)        // loadIGESRobust sews/heals tolerance issues
+let iges = try Shape.loadIGES(from: igesURL)        // loadIGESRobust heals tolerance issues
 let brep = try Shape.loadBREP(from: brepURL)        // exact + triangulation if exported with it
 let stl  = try Shape.loadSTLRobust(from: stlURL, sewingTolerance: 1e-6)   // auto sew + heal
 ```

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1692,28 +1692,53 @@ public static func loadIGES(fromPath path: String, progress: ImportProgress? = n
 
 ### `Shape.loadIGESRobust(from:progress:)`
 
-Load an IGES file with automatic repair (sewing and healing).
+Load an IGES file, healing the transferred geometry.
 
 ```swift
 public static func loadIGESRobust(from url: URL, progress: ImportProgress? = nil) throws -> Shape
 ```
 
+Recommended for IGES files whose geometry needs repair before use. This heals but does **not** sew — unlike [`loadRobust(from:)`](#shapeloadrobustfrom), which sews STEP shells into solids. (Documented as "sewing and healing" before v1.11.2; the IGES path has never called `BRepBuilderAPI_Sewing`.)
+
+Both phases are bounded by `progress`: transfer spans `fraction` 0…0.5 and healing 0.5…1.0, matching their measured cost — healing is **38–50%** of the work (measured across box/sphere/cylinder/torus compounds), not a coda to the transfer. A wall-clock deadline in `shouldCancel()` therefore bounds the whole call, and cancelling mid-heal throws rather than returning the partially-healed shape.
+
 - **Parameters:** `url` — URL to the IGES file; `progress` — optional progress/cancellation channel.
-- **Returns:** Processed shape with healing applied.
+- **Returns:** Transferred shape with healing applied.
 - **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
-- **OCCT:** `IGESControl_Reader` + `BRepBuilderAPI_Sewing` + `ShapeFix_Shape` (via `OCCTImportIGESRobustProgress`).
+- **OCCT:** `IGESControl_Reader` + `ShapeFix_Shape` (via `OCCTImportIGESRobustProgress`).
+- **Example:**
+  ```swift
+  final class Deadline: ImportProgress, @unchecked Sendable {
+      private let start = Date()
+      func progress(fraction: Double, step: String) { print("\(Int(fraction * 100))%") }
+      func shouldCancel() -> Bool { Date().timeIntervalSince(start) > 10 }
+  }
+
+  do {
+      let shape = try Shape.loadIGESRobust(from: igesURL, progress: Deadline())
+      print(shape.isValid)
+  } catch ImportError.cancelled {
+      // Gave up after 10s — healing untrusted geometry can be pathological.
+  }
+  ```
+- **Limitation — parsing is not covered:** OCCT's `IGESControl_Reader::ReadFile` takes no `Message_ProgressRange`, so the file is parsed *before* the progress indicator exists. Reading a large IGES file reports nothing and cannot be cancelled; `fraction` and the deadline bound only the transfer and healing that follow.
+- **Fixed in v1.11.2:** healing previously ran outside the caller's progress range entirely (`ShapeFix_Shape::Perform()` was called with no range), so `shouldCancel()` during healing was ignored — the heal ran to completion and the call returned a *shape* rather than reporting cancellation. Same family as the [#286](https://github.com/SecondMouseAU/OCCTSwift/issues/286) defect fixed in v1.11.1 ([#300](https://github.com/SecondMouseAU/OCCTSwift/issues/300)).
 
 ---
 
 ### `Shape.loadIGESRobust(fromPath:progress:)`
 
-Load an IGES file with automatic repair from a path.
+Load an IGES file from a path, healing the transferred geometry.
 
 ```swift
 public static func loadIGESRobust(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape
 ```
 
-- **OCCT:** `IGESControl_Reader` + sewing + healing (via `OCCTImportIGESRobustProgress`).
+- **OCCT:** `IGESControl_Reader` + `ShapeFix_Shape` (via `OCCTImportIGESRobustProgress`).
+- **Example:**
+  ```swift
+  let shape = try Shape.loadIGESRobust(fromPath: "/tmp/part.igs")
+  ```
 
 ---
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1598,37 +1598,60 @@ public static func stepShapeCount(path: String) -> Int
 
 ## Robust STEP Import
 
-### `Shape.loadRobust(from:)`
+### `Shape.loadRobust(from:progress:)`
 
 Load a STEP file with robust handling: sewing, solid creation, and shape healing.
 
 ```swift
-public static func loadRobust(from url: URL) throws -> Shape
+public static func loadRobust(from url: URL, progress: ImportProgress? = nil) throws -> Shape
 ```
 
 Recommended for STEP files that may contain disconnected faces needing sewing, shells needing conversion to solids, or geometry issues requiring healing.
 
-- **Parameters:** `url` — URL to the STEP file.
+Every phase is bounded by `progress`: the transfer spans `fraction` 0…0.5 and the repair (sewing, then healing) 0.5…1.0, matching their measured cost — repair is ~50% of the work on a solid. A wall-clock deadline in `shouldCancel()` therefore bounds the whole call, and cancelling mid-repair throws rather than returning the partially-repaired shape.
+
+- **Parameters:** `url` — URL to the STEP file; `progress` — optional progress/cancellation channel.
 - **Returns:** Processed shape suitable for CAM operations.
-- **Throws:** `ImportError.importFailed` on failure.
-- **OCCT:** `STEPControl_Reader` + `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTImportSTEPRobust`).
+- **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
+- **OCCT:** `STEPControl_Reader` + `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTImportSTEPRobustProgress`).
 - **Example:**
   ```swift
   let shape = try Shape.loadRobust(from: stepURL)
   print(shape.isValid)   // typically true
   ```
+- **Example — bounding an untrusted import with a deadline:**
+  ```swift
+  final class Deadline: ImportProgress, @unchecked Sendable {
+      private let start = Date()
+      func progress(fraction: Double, step: String) { print("\(Int(fraction * 100))%") }
+      func shouldCancel() -> Bool { Date().timeIntervalSince(start) > 10 }
+  }
+
+  do {
+      let shape = try Shape.loadRobust(from: stepURL, progress: Deadline())
+      print(shape.isValid)
+  } catch ImportError.cancelled {
+      // Gave up after 10s — repairing untrusted geometry can be pathological.
+  }
+  ```
+- **Limitation — parsing is not covered:** OCCT's `STEPControl_Reader::ReadFile` takes no `Message_ProgressRange`, so the file is parsed *before* the progress indicator exists. Reading a large STEP file reports nothing and cannot be cancelled; `fraction` and the deadline bound only the transfer and repair that follow.
+- **New in v1.11.2:** `progress:`. The progress-capable bridge function existed but no Swift API reached it, so a robust STEP import could not be observed or cancelled at all ([#300](https://github.com/SecondMouseAU/OCCTSwift/issues/300)). Existing `loadRobust(from:)` call sites are unaffected — the parameter defaults to `nil`.
 
 ---
 
-### `Shape.loadRobust(fromPath:)`
+### `Shape.loadRobust(fromPath:progress:)`
 
 Load a STEP file with robust handling from a file path.
 
 ```swift
-public static func loadRobust(fromPath path: String) throws -> Shape
+public static func loadRobust(fromPath path: String, progress: ImportProgress? = nil) throws -> Shape
 ```
 
-- **OCCT:** `STEPControl_Reader` + sewing + solid creation + healing (via `OCCTImportSTEPRobust`).
+- **OCCT:** `STEPControl_Reader` + sewing + solid creation + healing (via `OCCTImportSTEPRobustProgress`).
+- **Example:**
+  ```swift
+  let shape = try Shape.loadRobust(fromPath: "/tmp/part.step")
+  ```
 
 ---
 


### PR DESCRIPTION
Closes #300.

The sweep #299 called for. **The #286 constructor pattern does not recur** — the other `*Progress` entry points all hand the range to a range-taking method, exactly as the issue found. But the same *family* of defect was real: `OCCTImportIGESRobustProgress` gave `TransferRoots` the entire `Message_ProgressRange` and then ran `ShapeFix_Shape::Perform()` with **no range at all**.

## Healing is half the import, not a coda to it

The issue declined to assert severity, calling it unmeasured. It is measurable — the comparison that matters is heal **vs transfer**, not heal in isolation. `0.028s` of healing looks negligible until you put the transfer next to it:

| shape | faces | transfer | heal | heal share |
|---|---|---|---|---|
| box ×200 | 1200 | 0.1360s | 0.1335s | **49.5%** |
| box ×600 | 3600 | 0.4061s | 0.3822s | **48.5%** |
| sphere ×600 | 600 | 0.0584s | 0.0373s | 39.0% |
| cylinder ×600 | 1800 | 0.2020s | 0.1457s | 41.9% |
| torus ×600 | 600 | 0.1646s | 0.1093s | 39.9% |

Stable at **38–50%** across geometry types and sizes. So roughly half of every robust import sat where the caller's deadline could not reach it: `shouldCancel()` returning `true` during healing was ignored entirely — the heal ran to completion and the import returned a **shape** rather than reporting cancellation.

## The range is honoured, not merely polled

The issue measured `polls=347`, but **polling is not aborting**. Had `Perform` only polled, wiring the range in would have bought progress reporting and zero cancellation — a cosmetic fix. Verified by building it:

```
ShapeFix_Shape::Perform()          full   = 1.8529s
ShapeFix_Shape::Perform(cancelled) = 0.0047s  -> ABORTS (range is honoured)
ShapeFix_Shape::Perform(deadline)  = 0.4783s (budget 0.4632s) -> INTERRUPTED mid-flight
Sewing::Perform(cancelled)         = 0.0032s  -> ABORTS
```

The abort leaves a **partially-healed shape** behind, so the bridge now reports cancellation rather than handing that back as a result.

## The `fraction` curve change, decided on measurement (issue item 2)

`Message_ProgressScope` subdivides the range: **transfer 0…0.5, healing 0.5…1.0**. This is a visible behaviour change — transfer previously spanned 0…1.0 and then the import paused silently and uncancellably.

The even split is what the measurements support (heal ≈42% mean), not a guess; I'd have picked a transfer-heavy 9:1 from the issue's isolated figure and been wrong. Because the scope closes out on destruction, `fraction` still reaches 1.0. A live range in healing costs nothing measurable (**−4.7%**, i.e. noise, over 3 reps), though heal now emits ~13.7k progress callbacks where it previously emitted none.

## `Shape.loadRobust` gains a `progress:` channel (new API)

`OCCTImportSTEPRobustProgress` had the identical defect and is fixed identically — but it had **zero Swift callers**: `loadRobust` called the non-progress bridge variant, and `OCCTBridge` is not an exported product, so a robust STEP import could not be observed or cancelled **at all**. It now routes through the progress-capable variant, mirroring its `loadIGESRobust` sibling:

```swift
let shape = try Shape.loadRobust(from: stepURL, progress: Deadline())
```

**Source-compatible** — `progress` defaults to `nil`, so existing `loadRobust(from:)` call sites are unaffected. The one visible change is the URL overload's failure message, which now carries the full path rather than the last component (it delegates to the path overload, as `loadIGESRobust` does). Nothing asserts on it. Operation count unchanged at **4237** (verified via `Scripts/count-operations.py`) — this changes signatures, it doesn't add methods.

Exposing it is also what makes the STEP path **testable**, and the fixture had to be chosen on measurement, not on symmetry with the IGES test:

| fixture | `OneShape()` | repair share | 0.75 budget lands in |
|---|---|---|---|
| box compound | COMPOUND | **5.5–6.2%** | TRANSFER — *useless* |
| convex N-gon prism | SOLID | **~50%** | REPAIR ✓ |

A box compound — the obvious fixture — would have produced a **test that passes with the bug present**: repair is only ~6% of that import, so the deadline lands in the transfer, which was already cancellable. The prism imports as one many-faced solid and takes the SOLID branch, where transfer (0.62s) and heal (0.63s) are even. Convex also steers clear of #263 (ShapeFix heap-corrupts healing a self-intersecting-wire prism). The test asserts the fixture is still a solid, since a compound would silently hollow it out.

## Test asserts on elapsed time, and fails against the old bridge

The deadline is set *past* the transfer so it lands inside healing — the part that was unreachable. Confirmed to fail against the old bridge:

> ✘ `loadIGESRobust returned a shape instead of cancelling — healing ran outside the caller's progress range (#300)`

A **fraction-triggered** cancel would have been a false negative: under the old bridge the transfer alone spanned 0…1.0, so any fraction-based trigger fired while the transfer was still running and cancelled correctly *even with the bug present*. Wall-clock phase costs are identical before and after the fix, so a deadline discriminates properly. Also verified the first import in a process pays no init penalty (1.02× vs the second), so calibrating the budget off a baseline import is sound.

**Both cancellation tests are `.serialized`, and this was not hypothetical.** They calibrate a deadline against a baseline import they time themselves; run concurrently they compete for CPU until `budget = 0.75 × full` overshoots the real import and the deadline never fires. Adding the STEP test made the IGES one **fail in the full suite while both passed alone**. The budget must sit above the transfer (~55%) and below 100%, so there is no margin to widen. A guard also separates *"the bug is back"* from *"this run beat its own deadline"* — an import that finished before its deadline came due was never asked to stop, so it's inconclusive rather than a failure. It can't swallow a regression: with the defect present the import runs the full duration and the deadline always comes due. Verified stable over 5 consecutive full-suite runs.

**Note which assertion does the work.** Re-running against a bridge with the range stripped but the post-heal `UserBreak` check left in, the import heals to completion and *then* throws `.cancelled` — *"cancelled after 0.706s against a 0.665s threshold"*. **A test asserting only that it throws would pass.** That's the #286/#299 lesson reproduced, and why both tests assert on elapsed time.

## Also here

- **Docs corrected:** `loadIGESRobust` was documented as "sewing and healing" in three places. It has **never** called `BRepBuilderAPI_Sewing` — it only transfers and heals.
- **OCCT limitations documented** (issue item 3), verified against the pinned `V8_0_0_p1` headers rather than recalled: `IGESControl_Reader::ReadFile` takes no range, so parsing happens *before* the indicator exists and can be neither reported nor cancelled. Same for `STEPControl_Reader::ReadFile` and the STEP/IGES writers.
- **Redundant `Perform()` dropped** (issue item 4) from `OCCTExportSTL`/`OCCTExportSTLWithMode` — the header states the ctor *"Automatically calls method Perform"*. Redundant, not a 2× cost: 0.0003s against a 1.29s mesh.

## Verification

- `swift build` — clean.
- `swift test --filter OCCTIOTests` — **132 tests / 33 suites pass** (5 consecutive runs), including the #286 test (no `fraction`-curve regressions).
- `OCCTMeshTests` (75) ✓ · `OCCTShapeHealingTests` (212) ✓ · `OCCTIntegrationTests` (19) ✓ · `OCCTModelingTests` (409) ✓ — mesh/healing cover the STL change.
- Operation count **4237**, README and API_REFERENCE agree (`Scripts/count-operations.py`).

No xcframework rebuild; no upstream OCCT issue warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

