### PR TITLE
fix(#295): a GraphUID no longer resolves against a graph that didn't mint it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,237 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,241 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -20908,8 +20908,21 @@ bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef _Nonnull graph,
                               int32_t* _Nonnull outDomain, int32_t* _Nonnull outKind,
                               int32_t* _Nonnull outIndex);
 
-/// Return the current graph generation counter (incremented on each Clear()).
+/// Return the current graph generation counter.
+///
+/// NOTE: always 0 in practice. OCCT only advances it from BRepGraph::Clear(), which
+/// nothing in this bridge calls, so it cannot distinguish two graphs. Use
+/// OCCTBRepGraphInstanceID for that. See issue #295.
 uint32_t OCCTBRepGraphGeneration(OCCTBRepGraphRef _Nonnull graph);
+
+/// Return this graph's instance id — unique among every graph this process creates, and
+/// distinct (with overwhelming probability) from ids minted by any other process.
+///
+/// A BRepGraph_UID is only meaningful inside the graph that minted it: counters restart
+/// at 1 per graph, so a UID from one graph lands in another's valid range and resolves to
+/// an unrelated node. Pairing a UID with this id is what lets the Swift layer reject a
+/// foreign UID instead of silently returning a wrong node (#295). Never returns 0.
+uint64_t OCCTBRepGraphInstanceID(OCCTBRepGraphRef _Nonnull graph);
 
 // MARK: - GeomFill_NetworkSurface / GeomFill_Gordon report — OCCT 8.0.0p1
 

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -19,6 +19,8 @@
 // Area-specific OCCT headers — the foundation set + handle wrappers come from
 // OCCTBridge_Internal.h, this block is just the BRepGraph-block extras.
 
+#include <atomic>
+#include <random>
 #include <set>
 #include <vector>
 #include <TopAbs_Orientation.hxx>
@@ -120,8 +122,59 @@ static GeomAbs_Shape continuityFromInt(int val) {
 #include <Geom_Curve.hxx>
 #include <Geom2d_Curve.hxx>
 
+// Mints the per-instance id every OCCTBRepGraph carries (#295).
+//
+// The sequence starts at a random point rather than at 1. Within a process a plain
+// counter would do, but GraphUID is Codable: a UID persisted by one process could be
+// resolved by another, and two processes both counting from 1 would hand out the same
+// ids — re-introducing the very aliasing this id exists to prevent, across the
+// persistence boundary. Seeding randomly makes that collision ~2^-64 while keeping
+// in-process uniqueness exact (the counter only ever increments).
+//
+// This id mirrors OCCT's own graph identity, BRepGraph::UIDs().GraphGUID() — same concept,
+// same lifecycle rules (fresh per build; inherited by a full copy; preserved by compaction).
+// Upstream intends the GUID for exactly this job ("Generation + GraphGUID protect against
+// stale UID aliasing", BRepGraphInc_Storage.hxx:1597). We cannot read it, on three counts —
+// each measured against the pinned 8.0.0p1 kernel, not assumed:
+//   1. myGraphGUID is default-constructed and only ever populated by BRepGraph::Clear()
+//      (BRepGraph.cxx: SetGraphGUID(generateRandomGUID()) — still true on upstream master
+//      as of 2026-07). Our build path is ctor + Shapes().Add(), which skips Clear(), so
+//      every graph reports the all-zero GUID and no two graphs differ. Upstream's own
+//      GTests do `myGraph.Clear(); myGraph.Shapes().Add(box);` — Clear() is their intended
+//      rebuild boundary (PR #1237), and their GraphGUID_AfterBuild_IsValid test only
+//      passes because the fixture calls it. So this one is our gap, not upstream's — see
+//      issue #303 about adopting the Clear()-then-Add lifecycle. It does not change
+//      the analysis below, which is why that follow-up cannot replace this id.
+//   2. Even populated it would not fix this bug. BRepGraph_UID is (Kind, Counter) and
+//      carries no GUID, so UIDsView::NodeIdFrom cannot consult one — two Clear()ed
+//      graphs with distinct GUIDs still cross-resolve each other's UIDs. The check has
+//      to live where the UID does, which is above the kernel. For the same reason
+//      UIDsView::IsStale accepts a foreign VersionStamp: a stamp carries Generation
+//      (equal across graphs), not the GUID.
+//   3. BRepGraph_Copy::Perform overwrites the target's GUID with the source's, so a
+//      CopyFace graph — one face out of many — would inherit the source's identity and
+//      alias straight back to a wrong node.
+// None of GraphGUID/StampOf/IsStale/ToGUID is currently wrapped, so no Swift caller can
+// reach the broken behaviour; if we ever wrap them, note that ToGUID's documented
+// "globally unique across different graph instances" is false on the no-Clear() path —
+// it hashes in the all-zero GUID and returns identical GUIDs for different graphs.
+static uint64_t nextGraphInstanceID() {
+    static std::atomic<uint64_t> counter{[] {
+        std::random_device rd;
+        return ((uint64_t)rd() << 32) ^ (uint64_t)rd();
+    }()};
+    uint64_t id;
+    // 0 is the "unstamped" sentinel on the Swift side; skip it on the (2^-64) wrap.
+    do { id = counter.fetch_add(1, std::memory_order_relaxed); } while (id == 0);
+    return id;
+}
+
 struct OCCTBRepGraph {
     BRepGraph graph;
+    // Identifies this graph instance. Fresh by default; the copy/transform entry points
+    // overwrite it to inherit the source's, mirroring what the kernel does with its own
+    // identity — see nextGraphInstanceID() and OCCTBRepGraphCopy().
+    uint64_t instanceID = nextGraphInstanceID();
     // Parallel side-registries: index == the legacy "rep id".
     std::vector<occ::handle<Poly_Triangulation>>            triReps;
     std::vector<occ::handle<Poly_Polygon3D>>                poly3dReps;
@@ -1302,6 +1355,13 @@ OCCTBRepGraphRef OCCTBRepGraphCopy(OCCTBRepGraphRef g, bool copyGeom) {
         // OCCT 8.0.0p1: Perform now copies source INTO a target graph and returns bool.
         auto geomPolicy = copyGeom ? BRepGraph_Copy::GeomPolicy::Copy : BRepGraph_Copy::GeomPolicy::Share;
         if (!BRepGraph_Copy::Perform(g->graph, ref->graph, geomPolicy)) { delete ref; return nullptr; }
+        // A full copy INHERITS the source's identity — the kernel says so itself: Perform
+        // transplants every per-kind UID counter, the Generation, and the GraphGUID from source
+        // to target (BRepGraph_Copy.cxx). Nodes land 1:1, so every source UID resolves in the
+        // copy to the very same node; measured on a box, all 6 face UIDs map to the
+        // geometrically identical face. Minting a fresh id here would reject those lookups and
+        // silently break a working, kernel-sanctioned correspondence (#295).
+        ref->instanceID = g->instanceID;
         return ref;
     } catch (...) { return nullptr; }
 }
@@ -1317,6 +1377,12 @@ OCCTBRepGraphRef OCCTBRepGraphCopyFace(OCCTBRepGraphRef g, int32_t faceIndex, bo
             BRepGraph_NodeId(BRepGraph_NodeId::Kind::Face, faceIndex),
             geomPolicy);
         if (!mapped.IsValid()) { delete ref; return nullptr; }
+        // Deliberately NOT inheriting the source's id, unlike Copy() above: CopyNode lifts one
+        // face into an empty graph and does not transplant the counter space, so the extracted
+        // face restarts at counter 1. That counter belongs to the source's face 0, so a source
+        // UID would resolve here to whichever face was extracted — a wrong node, which is
+        // exactly #295. Verified: on a box, face 0's UID resolved inside copyFace(3) and
+        // returned face 3. A fresh id makes those lookups return nil instead.
         return ref;
     } catch (...) { return nullptr; }
 }
@@ -1332,6 +1398,10 @@ OCCTBRepGraphRef OCCTBRepGraphTransformTranslation(OCCTBRepGraphRef g,
         // OCCT 8.0.0p1: Perform now transforms source INTO a target graph and returns bool.
         auto geomPolicy = copyGeom ? BRepGraph_Copy::GeomPolicy::Copy : BRepGraph_Copy::GeomPolicy::Share;
         if (!BRepGraph_Transform::Perform(g->graph, ref->graph, trsf, geomPolicy)) { delete ref; return nullptr; }
+        // Same reasoning as OCCTBRepGraphCopy: Transform::Perform copies the graph wholesale
+        // and transplants identity, so a source UID names the same node in the placed graph
+        // (measured: all 6 box face UIDs map to the same face, merely translated).
+        ref->instanceID = g->instanceID;
         return ref;
     } catch (...) { return nullptr; }
 }
@@ -3335,4 +3405,9 @@ bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef graph,
 uint32_t OCCTBRepGraphGeneration(OCCTBRepGraphRef graph) {
     if (!graph) return 0;
     try { return graph->graph.UIDs().Generation(); } catch (...) { return 0; }
+}
+
+uint64_t OCCTBRepGraphInstanceID(OCCTBRepGraphRef graph) {
+    if (!graph) return 0;
+    return graph->instanceID;
 }

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -812,9 +812,10 @@ public final class TopologyGraph: @unchecked Sendable {
     ///
     /// This is the supported way to carry a picked face (or edge, or vertex)
     /// across an operation that rebuilds the shape — a boolean, a fillet, a
-    /// chamfer. Because the input and the result live in the *same* graph, the
-    /// `NodeRef`s and `GraphUID`s you already hold stay valid: there is no
-    /// generation boundary to cross and no cross-graph UID lookup.
+    /// chamfer. Because the input and the result live in the *same* graph
+    /// instance, the `NodeRef`s and `GraphUID`s you already hold stay valid:
+    /// there is no second graph to look them up in, and a UID only ever means
+    /// something in the graph that minted it (#295).
     ///
     /// After this call, ``currentForms(of:)`` on an input node returns its
     /// successors, and the ``TopologyRef`` recipes (`.splitOf`, `.createdBy`)
@@ -2063,51 +2064,162 @@ public final class TopologyGraph: @unchecked Sendable {
 
     // MARK: - Durable Identity (UID / RefUID / ItemUID) — OCCT 8.0.0p1
 
-    /// A durable node identifier: a `(kind, counter)` pair that persists across graph
-    /// mutations (compaction, node removal) within one graph generation. Unlike a
-    /// `(kind, index)` `NodeRef`, the counter never repeats within a kind and is stable
-    /// even when vector indices shift. `counter == 0` is the invalid sentinel.
+    /// A durable node identifier: a `(kind, counter)` pair that persists across mutations of
+    /// **the one graph instance that minted it** — compaction, node removal — where a
+    /// `(kind, index)` ``NodeRef`` does not. The counter never repeats within a kind and is
+    /// stable when vector indices shift. `counter == 0` is the invalid sentinel.
+    ///
+    /// The scope is the graph *instance*, not the shape and not a "generation". Every graph
+    /// allocates counters from 1 independently, so the same `(kind, counter)` names some
+    /// unrelated node in every other graph — a box's face UID would otherwise resolve happily
+    /// against a cylinder. ``graphID`` records which instance minted the UID, and
+    /// ``TopologyGraph/node(forUID:)`` rejects one that came from anywhere else (#295).
+    ///
+    /// To carry a selection across a *modelling operation* rather than across mutations of one
+    /// graph, absorb the operation's history — see
+    /// ``TopologyGraph/add(_:absorbing:inputRoots:operationName:)``.
     ///
     /// `kind` is the raw `BRepGraph_NodeId::Kind` ordinal
     /// (0 Solid, 1 Shell, 2 Face, 3 Wire, 4 Edge, 5 Vertex, 6 Compound,
     /// 7 CompSolid, 8 CoEdge, 10 Product, 11 Occurrence).
+    ///
+    /// ```swift
+    /// let graph = TopologyGraph(shape: box)!
+    /// let uid = graph.uid(ofNodeKind: 2, index: 3)!    // a face, by kind + index
+    ///
+    /// // The UID still names that face after a mutation renumbers the indices:
+    /// graph.compact()
+    /// if let node = graph.node(forUID: uid) {
+    ///     print("that face is now index \(node.index)")
+    /// }
+    ///
+    /// // A UID from another graph resolves to nothing, rather than to a wrong node:
+    /// let other = TopologyGraph(shape: cylinder)!
+    /// print(other.node(forUID: uid))      // nil
+    /// print(other.contains(uid: uid))     // false
+    /// ```
     public struct GraphUID: Sendable, Hashable, Codable {
-        public var kind: Int
-        public var counter: UInt32
+        public let kind: Int
+        public let counter: UInt32
+
+        /// The instance that minted this UID — its ``TopologyGraph/instanceID``.
+        ///
+        /// `0` means unstamped: built by hand, or decoded from a payload written before
+        /// OCCTSwift recorded provenance. An unstamped UID resolves in no graph.
+        public let graphID: UInt64
+
+        @available(*, deprecated, message: "A hand-built GraphUID has no provenance (graphID 0) and resolves in no graph. Mint one with TopologyGraph.uid(ofNodeKind:index:).")
         public init(kind: Int, counter: UInt32) {
+            self.init(kind: kind, counter: counter, graphID: 0)
+        }
+
+        internal init(kind: Int, counter: UInt32, graphID: UInt64) {
             self.kind = kind
             self.counter = counter
+            self.graphID = graphID
         }
-        /// True if this UID has a non-zero counter (it may still fail to resolve in a graph).
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            kind = try c.decode(Int.self, forKey: .kind)
+            counter = try c.decode(UInt32.self, forKey: .counter)
+            // Payloads written before #295 have no graphID. Decode them as unstamped instead of
+            // failing the load: they resolve nowhere, which is the honest answer, since they never
+            // carried the provenance that says which graph they meant.
+            graphID = try c.decodeIfPresent(UInt64.self, forKey: .graphID) ?? 0
+        }
+
+        /// True if this UID has a non-zero counter. It may still fail to resolve — because it was
+        /// minted by a different graph, or because its node has since been removed.
         public var isValid: Bool { counter > 0 }
     }
 
     /// A durable reference-entry identifier `(kind, counter)`.
     ///
+    /// Scoped to one graph instance exactly as ``GraphUID`` is, and stamped with ``graphID`` for
+    /// the same reason: reference counters also restart at 1 per graph.
+    ///
     /// `kind` is the raw `BRepGraph_RefId::Kind` ordinal
     /// (0 Shell, 1 Face, 2 Wire, 3 Vertex, 4 Solid, 5 Child, 6 Occurrence).
+    ///
+    /// ```swift
+    /// let graph = TopologyGraph(shape: assembly)!
+    /// if let uid = graph.uid(ofRefKind: 1, index: 0),      // a face reference
+    ///    let ref = graph.ref(forUID: uid) {
+    ///     print("face ref at index \(ref.index)")
+    /// }
+    /// ```
     public struct GraphRefUID: Sendable, Hashable, Codable {
-        public var kind: Int
-        public var counter: UInt32
+        public let kind: Int
+        public let counter: UInt32
+
+        /// The instance that minted this UID — its ``TopologyGraph/instanceID``. `0` means
+        /// unstamped, which resolves in no graph. See ``GraphUID/graphID``.
+        public let graphID: UInt64
+
+        @available(*, deprecated, message: "A hand-built GraphRefUID has no provenance (graphID 0) and resolves in no graph. Mint one with TopologyGraph.uid(ofRefKind:index:).")
         public init(kind: Int, counter: UInt32) {
+            self.init(kind: kind, counter: counter, graphID: 0)
+        }
+
+        internal init(kind: Int, counter: UInt32, graphID: UInt64) {
             self.kind = kind
             self.counter = counter
+            self.graphID = graphID
         }
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            kind = try c.decode(Int.self, forKey: .kind)
+            counter = try c.decode(UInt32.self, forKey: .counter)
+            graphID = try c.decodeIfPresent(UInt64.self, forKey: .graphID) ?? 0
+        }
+
         public var isValid: Bool { counter > 0 }
     }
 
     /// A durable generic item identifier covering both definition nodes and reference
     /// entries. `domain` is 1 for a node, 2 for a reference; `kind` is the raw kind
     /// ordinal in that domain's enum space.
+    ///
+    /// Scoped to one graph instance and stamped with ``graphID``, exactly as ``GraphUID`` is.
+    ///
+    /// ```swift
+    /// let graph = TopologyGraph(shape: box)!
+    /// if let uid = graph.itemUID(ofNodeKind: 2, index: 0),
+    ///    let item = graph.item(forUID: uid) {
+    ///     print("domain \(item.domain) kind \(item.kind) index \(item.index)")
+    /// }
+    /// ```
     public struct GraphItemUID: Sendable, Hashable, Codable {
-        public var domain: Int
-        public var kind: Int
-        public var counter: UInt32
+        public let domain: Int
+        public let kind: Int
+        public let counter: UInt32
+
+        /// The instance that minted this UID — its ``TopologyGraph/instanceID``. `0` means
+        /// unstamped, which resolves in no graph. See ``GraphUID/graphID``.
+        public let graphID: UInt64
+
+        @available(*, deprecated, message: "A hand-built GraphItemUID has no provenance (graphID 0) and resolves in no graph. Mint one with TopologyGraph.itemUID(ofNodeKind:index:).")
         public init(domain: Int, kind: Int, counter: UInt32) {
+            self.init(domain: domain, kind: kind, counter: counter, graphID: 0)
+        }
+
+        internal init(domain: Int, kind: Int, counter: UInt32, graphID: UInt64) {
             self.domain = domain
             self.kind = kind
             self.counter = counter
+            self.graphID = graphID
         }
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            domain = try c.decode(Int.self, forKey: .domain)
+            kind = try c.decode(Int.self, forKey: .kind)
+            counter = try c.decode(UInt32.self, forKey: .counter)
+            graphID = try c.decodeIfPresent(UInt64.self, forKey: .graphID) ?? 0
+        }
+
         public var isValid: Bool { counter > 0 }
     }
 
@@ -2119,21 +2231,26 @@ public final class TopologyGraph: @unchecked Sendable {
         var uidKind: Int32 = 0
         var counter: UInt32 = 0
         guard OCCTBRepGraphNodeUID(handle, Int32(kind), Int32(index), &uidKind, &counter) else { return nil }
-        return GraphUID(kind: Int(uidKind), counter: counter)
+        return GraphUID(kind: Int(uidKind), counter: counter, graphID: instanceID)
     }
 
-    /// Resolve a node UID back to its `(kind, index)`, or `nil` if it does not resolve
-    /// in the current graph generation.
+    /// Resolve a node UID back to its `(kind, index)`, or `nil` if this graph did not mint it
+    /// or its node no longer exists here.
+    ///
+    /// A UID minted by another graph returns `nil` even when its counter is in range for this
+    /// one — which it usually is, since counters restart per graph (#295).
     public func node(forUID uid: GraphUID) -> (kind: Int, index: Int)? {
+        guard uid.graphID == instanceID else { return nil }
         var nodeKind: Int32 = 0
         var nodeIndex: Int32 = 0
         guard OCCTBRepGraphNodeFromUID(handle, Int32(uid.kind), uid.counter, &nodeKind, &nodeIndex) else { return nil }
         return (Int(nodeKind), Int(nodeIndex))
     }
 
-    /// True if a node UID is valid and exists in this graph generation.
+    /// True if this graph minted the UID and the node it names still exists here.
     public func contains(uid: GraphUID) -> Bool {
-        OCCTBRepGraphHasNodeUID(handle, Int32(uid.kind), uid.counter)
+        guard uid.graphID == instanceID else { return false }
+        return OCCTBRepGraphHasNodeUID(handle, Int32(uid.kind), uid.counter)
     }
 
     /// Return the durable RefUID for a reference entry, or `nil` if invalid/removed.
@@ -2144,20 +2261,23 @@ public final class TopologyGraph: @unchecked Sendable {
         var uidKind: Int32 = 0
         var counter: UInt32 = 0
         guard OCCTBRepGraphRefUID(handle, Int32(kind), Int32(index), &uidKind, &counter) else { return nil }
-        return GraphRefUID(kind: Int(uidKind), counter: counter)
+        return GraphRefUID(kind: Int(uidKind), counter: counter, graphID: instanceID)
     }
 
-    /// Resolve a RefUID back to its `(kind, index)`, or `nil` if it does not resolve.
+    /// Resolve a RefUID back to its `(kind, index)`, or `nil` if this graph did not mint it
+    /// or the reference no longer exists here.
     public func ref(forUID uid: GraphRefUID) -> (kind: Int, index: Int)? {
+        guard uid.graphID == instanceID else { return nil }
         var refKind: Int32 = 0
         var refIndex: Int32 = 0
         guard OCCTBRepGraphRefFromUID(handle, Int32(uid.kind), uid.counter, &refKind, &refIndex) else { return nil }
         return (Int(refKind), Int(refIndex))
     }
 
-    /// True if a RefUID is valid and exists in this graph generation.
+    /// True if this graph minted the RefUID and the reference it names still exists here.
     public func contains(uid: GraphRefUID) -> Bool {
-        OCCTBRepGraphHasRefUID(handle, Int32(uid.kind), uid.counter)
+        guard uid.graphID == instanceID else { return false }
+        return OCCTBRepGraphHasRefUID(handle, Int32(uid.kind), uid.counter)
     }
 
     /// Return the durable ItemUID for a node, or `nil` if invalid/removed.
@@ -2166,11 +2286,13 @@ public final class TopologyGraph: @unchecked Sendable {
         var itemKind: Int32 = 0
         var counter: UInt32 = 0
         guard OCCTBRepGraphItemUIDOfNode(handle, Int32(kind), Int32(index), &domain, &itemKind, &counter) else { return nil }
-        return GraphItemUID(domain: Int(domain), kind: Int(itemKind), counter: counter)
+        return GraphItemUID(domain: Int(domain), kind: Int(itemKind), counter: counter, graphID: instanceID)
     }
 
-    /// Resolve an ItemUID back to its `(domain, kind, index)`, or `nil` if it does not resolve.
+    /// Resolve an ItemUID back to its `(domain, kind, index)`, or `nil` if this graph did not
+    /// mint it or the item no longer exists here.
     public func item(forUID uid: GraphItemUID) -> (domain: Int, kind: Int, index: Int)? {
+        guard uid.graphID == instanceID else { return nil }
         var domain: Int32 = 0
         var itemKind: Int32 = 0
         var index: Int32 = 0
@@ -2178,7 +2300,45 @@ public final class TopologyGraph: @unchecked Sendable {
         return (Int(domain), Int(itemKind), Int(index))
     }
 
-    /// The current graph generation counter, incremented each time the graph is cleared/rebuilt.
+    /// Identifies this graph instance for as long as it lives.
+    ///
+    /// Unique among every graph this process builds, and — because the sequence starts at a random
+    /// point — distinct from any other process's ids with overwhelming probability. Every UID this
+    /// graph mints carries it, which is how ``node(forUID:)`` tells one of its own nodes from a node
+    /// of some other graph (#295).
+    ///
+    /// Identity here is the graph object, not the geometry: two graphs built from the same shape
+    /// have different ids, and so a UID from one does not resolve in the other. A rebuild is a new
+    /// graph by the same token.
+    ///
+    /// ``copy()`` and ``translated(dx:dy:dz:copyGeometry:)`` **inherit** this id, because the kernel
+    /// copies the graph wholesale — it transplants the UID counter space itself, so a copy genuinely
+    /// is the same identity and every UID keeps naming the same node. ``copyFace(_:copyGeometry:)``
+    /// does not: it lifts one face into a new graph, which gets its own id.
+    ///
+    /// ```swift
+    /// let graph = TopologyGraph(shape: box)!
+    /// let uid = graph.uid(ofNodeKind: 2, index: 0)!
+    /// print(uid.graphID == graph.instanceID)      // true — this graph minted it
+    ///
+    /// let copy = graph.copy()!
+    /// print(copy.instanceID == graph.instanceID)  // true — a copy is the same identity
+    /// print(copy.node(forUID: uid) != nil)        // true — and names the same face
+    ///
+    /// let rebuilt = TopologyGraph(shape: box)!    // same shape, new graph
+    /// print(rebuilt.node(forUID: uid))            // nil
+    /// ```
+    public var instanceID: UInt64 {
+        OCCTBRepGraphInstanceID(handle)
+    }
+
+    /// The graph generation counter — **always 0**.
+    ///
+    /// OCCT advances this only from `BRepGraph::Clear()`, which nothing in OCCTSwift calls, so it
+    /// never changes and cannot tell two graphs apart or detect a stale cache. Nothing replaces it:
+    /// ``node(forUID:)`` already rejects a UID from another graph, and ``instanceID`` compares graph
+    /// identity directly (#295).
+    @available(*, deprecated, message: "Always 0 — OCCTSwift never clears a graph, so this counter never advances and guards nothing. node(forUID:) rejects foreign UIDs on its own; use instanceID to compare graph identity.")
     public var generation: UInt32 {
         OCCTBRepGraphGeneration(handle)
     }

--- a/Tests/OCCTTopologyGraphTests/OCCTTopologyGraphTests.swift
+++ b/Tests/OCCTTopologyGraphTests/OCCTTopologyGraphTests.swift
@@ -2358,28 +2358,213 @@ struct TopologyGraphDurableUIDTests {
         }
     }
 
-    @Test func foreignUIDDoesNotResolve() {
+    /// A UID minted by a *different* graph must not resolve — the case that matters, and the one
+    /// that silently returned a wrong node before #295. Its counter is in range for the foreign
+    /// graph (counters restart at 1 per graph), so nothing but provenance can reject it.
+    @Test func uidFromAnotherGraphDoesNotResolve() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let cyl = Shape.cylinder(radius: 3, height: 7),
+              let boxGraph = TopologyGraph(shape: box),
+              let cylGraph = TopologyGraph(shape: cyl) else { return }
+
+        guard let boxFaceUID = boxGraph.uid(ofNodeKind: faceKind, index: 2) else {
+            Issue.record("box face 2 had no UID"); return
+        }
+        // Precondition for the test to be meaningful: the counter is one the cylinder graph
+        // would consider perfectly valid, and did resolve to a cylinder face before the fix.
+        #expect(boxFaceUID.counter <= UInt32(cylGraph.faceCount))
+
+        #expect(cylGraph.node(forUID: boxFaceUID) == nil)
+        #expect(!cylGraph.contains(uid: boxFaceUID))
+        // ...while it still resolves in the graph that minted it.
+        #expect(boxGraph.node(forUID: boxFaceUID) != nil)
+    }
+
+    /// Two graphs over the *same* shape are still two graphs: identity is the instance, not the
+    /// geometry. This is the case a consumer is most likely to assume works.
+    @Test func uidDoesNotCrossIdenticallyBuiltGraphs() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let a = TopologyGraph(shape: box),
+              let b = TopologyGraph(shape: box) else { return }
+        #expect(a.instanceID != b.instanceID)
+        guard let uid = a.uid(ofNodeKind: faceKind, index: 1) else { return }
+        #expect(b.node(forUID: uid) == nil)
+        #expect(!b.contains(uid: uid))
+    }
+
+    /// Mean sampled position + normal — a signature that actually distinguishes a box's faces.
+    /// (A single grid corner does not: adjacent faces share corners.)
+    private func faceSignature(_ g: TopologyGraph, _ i: Int,
+                               shift: SIMD3<Double> = .zero) -> String? {
+        guard let s = g.sampleFaceUVGrid(faceIndex: i, uSamples: 3, vSamples: 3),
+              !s.positions.isEmpty, !s.normals.isEmpty else { return nil }
+        var c = SIMD3<Double>(0, 0, 0)
+        for p in s.positions { c += p }
+        c = c / Double(s.positions.count) - shift
+        var n = SIMD3<Double>(0, 0, 0)
+        for v in s.normals { n += v }
+        n /= Double(s.normals.count)
+        return String(format: "c(%.3f,%.3f,%.3f) n(%.3f,%.3f,%.3f)", c.x, c.y, c.z, n.x, n.y, n.z)
+    }
+
+    /// A full `copy()` INHERITS the source's identity, so every source UID still resolves — and
+    /// resolves to the geometrically same face. This is the kernel's own contract, not an
+    /// accident: `BRepGraph_Copy::Perform` transplants the UID counter space, the Generation and
+    /// the GraphGUID into the target. Guards the #295 provenance check against over-rejecting.
+    @Test func uidSurvivesAFullCopyAndNamesTheSameFace() {
+        guard let box = Shape.box(width: 10, height: 20, depth: 30),
+              let graph = TopologyGraph(shape: box),
+              let copy = graph.copy() else { return }
+        #expect(copy.instanceID == graph.instanceID)   // a copy is the same identity
+        #expect(copy.faceCount == graph.faceCount)
+
+        // The signature must actually discriminate, or the assertions below prove nothing.
+        let sigs = (0..<graph.faceCount).compactMap { faceSignature(graph, $0) }
+        #expect(Set(sigs).count == graph.faceCount)
+
+        for i in 0..<graph.faceCount {
+            guard let uid = graph.uid(ofNodeKind: faceKind, index: i) else { continue }
+            guard let r = copy.node(forUID: uid) else {
+                Issue.record("face \(i)'s UID stopped resolving through copy()"); continue
+            }
+            #expect(faceSignature(graph, i) == faceSignature(copy, r.index))
+        }
+    }
+
+    /// `translated()` copies the graph wholesale too, so identity and UID correspondence carry
+    /// across exactly as with `copy()` — the faces are merely moved.
+    @Test func uidSurvivesATranslationAndNamesTheSameFace() {
+        let d = SIMD3<Double>(100, 200, 300)
+        guard let box = Shape.box(width: 10, height: 20, depth: 30),
+              let graph = TopologyGraph(shape: box),
+              let moved = graph.translated(dx: d.x, dy: d.y, dz: d.z) else { return }
+        #expect(moved.instanceID == graph.instanceID)
+        for i in 0..<graph.faceCount {
+            guard let uid = graph.uid(ofNodeKind: faceKind, index: i) else { continue }
+            guard let r = moved.node(forUID: uid) else {
+                Issue.record("face \(i)'s UID stopped resolving through translated()"); continue
+            }
+            #expect(faceSignature(graph, i) == faceSignature(moved, r.index, shift: d))
+        }
+    }
+
+    /// `copyFace()` is the opposite case: it lifts ONE face into an empty graph without
+    /// transplanting the counter space, so the extracted face restarts at counter 1 — the
+    /// source's face-0 counter. Before #295 a source UID resolved here and returned the wrong
+    /// face. The extracted graph gets a fresh identity, so it now returns nil.
+    @Test func uidDoesNotCrossACopiedOutFace() {
+        guard let box = Shape.box(width: 10, height: 20, depth: 30),
+              let graph = TopologyGraph(shape: box),
+              let lifted = graph.copyFace(3) else { return }
+        #expect(lifted.instanceID != graph.instanceID)
+        #expect(lifted.faceCount == 1)
+        // The lifted face IS source face 3, sitting at index 0.
+        #expect(faceSignature(lifted, 0) == faceSignature(graph, 3))
+
+        // Source face 0's counter (1) is in range here and used to return face 3.
+        guard let uidFace0 = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
+        #expect(uidFace0.counter == 1)
+        #expect(lifted.node(forUID: uidFace0) == nil)
+        #expect(!lifted.contains(uid: uidFace0))
+    }
+
+    /// An out-of-range counter must not resolve either. Stamped with this graph's own id, so it
+    /// tests the counter path rather than being rejected on provenance first.
+    @Test func outOfRangeCounterDoesNotResolve() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
         guard let graph = TopologyGraph(shape: box) else { return }
 
-        // A fabricated UID with a wildly out-of-range counter must not resolve.
-        let bogus = TopologyGraph.GraphUID(kind: faceKind, counter: 999_999)
+        let bogus = TopologyGraph.GraphUID(kind: faceKind, counter: 999_999, graphID: graph.instanceID)
         #expect(!graph.contains(uid: bogus))
         #expect(graph.node(forUID: bogus) == nil)
 
         // The invalid sentinel (counter 0) is never valid.
-        let invalid = TopologyGraph.GraphUID(kind: faceKind, counter: 0)
+        let invalid = TopologyGraph.GraphUID(kind: faceKind, counter: 0, graphID: graph.instanceID)
         #expect(!invalid.isValid)
         #expect(!graph.contains(uid: invalid))
     }
 
-    @Test func generationIsStable() {
+    /// A UID with no provenance — hand-built, or decoded from a pre-#295 payload — resolves nowhere,
+    /// even when its counter names a real node in the graph asked.
+    @Test func unstampedUIDResolvesNowhere() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
         guard let graph = TopologyGraph(shape: box) else { return }
-        // Generation is a simple monotonic counter; reading it twice is stable.
-        let g1 = graph.generation
-        let g2 = graph.generation
-        #expect(g1 == g2)
+        guard let real = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
+
+        let unstamped = TopologyGraph.GraphUID(kind: real.kind, counter: real.counter, graphID: 0)
+        #expect(unstamped.isValid)              // the counter is a real one...
+        #expect(graph.node(forUID: unstamped) == nil)   // ...but it names no graph
+        #expect(!graph.contains(uid: unstamped))
+    }
+
+    /// The property the UID exists for: it survives a mutation that renumbers indices, within the
+    /// graph that minted it. Guards against the #295 provenance check over-rejecting.
+    @Test func uidSurvivesCompactionOfItsOwnGraph() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = TopologyGraph(shape: box),
+              let uid = graph.uid(ofNodeKind: faceKind, index: 3) else { return }
+        let idBefore = graph.instanceID
+        graph.compact()
+        #expect(graph.instanceID == idBefore)   // compaction mutates in place; same instance
+        #expect(graph.contains(uid: uid))
+        #expect(graph.node(forUID: uid) != nil)
+    }
+
+    /// Provenance travels through `Codable`; a pre-#295 payload (no `graphID`) still decodes,
+    /// as an unstamped UID rather than a decode failure.
+    @Test func uidCodableCarriesProvenance() throws {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = TopologyGraph(shape: box),
+              let uid = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
+
+        let round = try JSONDecoder().decode(TopologyGraph.GraphUID.self,
+                                             from: try JSONEncoder().encode(uid))
+        #expect(round == uid)
+        #expect(round.graphID == graph.instanceID)
+        #expect(graph.node(forUID: round) != nil)
+
+        let legacy = Data(#"{"kind":2,"counter":1}"#.utf8)
+        let decoded = try JSONDecoder().decode(TopologyGraph.GraphUID.self, from: legacy)
+        #expect(decoded.graphID == 0)
+        #expect(graph.node(forUID: decoded) == nil)
+    }
+
+    /// RefUIDs and ItemUIDs restart their counters per graph exactly as node UIDs do, and carry
+    /// the same provenance.
+    @Test func refAndItemUIDsDoNotCrossGraphs() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let cyl = Shape.cylinder(radius: 3, height: 7),
+              let boxGraph = TopologyGraph(shape: box),
+              let cylGraph = TopologyGraph(shape: cyl) else { return }
+
+        // Ref kind 1 == Face reference entry.
+        if let refUID = boxGraph.uid(ofRefKind: 1, index: 0) {
+            #expect(boxGraph.ref(forUID: refUID) != nil)
+            #expect(cylGraph.ref(forUID: refUID) == nil)
+            #expect(!cylGraph.contains(uid: refUID))
+        }
+
+        if let itemUID = boxGraph.itemUID(ofNodeKind: faceKind, index: 2) {
+            #expect(boxGraph.item(forUID: itemUID) != nil)
+            #expect(cylGraph.item(forUID: itemUID) == nil)
+        }
+    }
+
+    /// `generation` is deprecated because it is a constant 0, not a counter: OCCT only advances it
+    /// from `BRepGraph::Clear()`, which OCCTSwift never calls. Pinned so the deprecation note stays
+    /// honest — if a future OCCT or bridge change ever makes it move, this fails and the docs and
+    /// the `@available` message have to be revisited (#295).
+    @available(*, deprecated, message: "Exercises the deprecated `generation` on purpose.")
+    @Test func generationIsAlwaysZero() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = TopologyGraph(shape: box) else { return }
+        #expect(graph.generation == 0)
+        graph.compact()
+        #expect(graph.generation == 0)
+        if let other = TopologyGraph(shape: box) {
+            #expect(other.generation == 0)      // a second graph: same 0, hence useless as identity
+            #expect(other.instanceID != graph.instanceID)
+        }
     }
 
     @Test func itemUIDOfNode() {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,237** | |
+| **Total** | **4,241** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.11.3
+## Current: v1.12.0
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
@@ -15,6 +15,67 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### v1.12.0 (July 2026) — fix: a `GraphUID` no longer resolves against a graph that didn't mint it (#295)
+
+**`node(forUID:)` returned a wrong node instead of `nil` for a UID from an unrelated graph.**
+`GraphUID` carried no graph identity: it is a `(kind, counter)` pair, and every `TopologyGraph`
+allocates counters from 1 independently. A UID minted from a box therefore landed inside a cylinder
+graph's valid counter range and resolved cleanly — to an unrelated face. `contains(uid:)` returned
+`true`. No error, no `nil`, just a plausible wrong answer:
+
+```swift
+let boxUID = boxGraph.uid(ofNodeKind: 2, index: 2)!   // a face of the BOX
+cylGraph.node(forUID: boxUID)     // was: Optional((kind: 2, index: 2))  — now: nil
+cylGraph.contains(uid: boxUID)    // was: true                           — now: false
+```
+
+The documented safeguard could never have caught it. `generation` is a **constant 0**, and the
+staleness recipe the docs gave compared it against `storedOwnGen`, a per-entity mesh field that was
+never the same counter.
+
+**Fix.** Every graph carries an `instanceID`, and every UID it mints records it as `graphID`.
+`node(forUID:)` / `contains(uid:)` / `ref(forUID:)` / `item(forUID:)` reject a UID from any other
+graph. The id follows the same lifecycle rules as OCCT's own graph identity (`GraphGUID`), which
+OCCTSwift cannot read because the kernel only populates it in `BRepGraph::Clear()` — a call our build
+path skips (see #303).
+
+**Identity follows the kernel's rule** — whether an operation transplants the UID counter space:
+
+| Operation | Identity | UIDs |
+|---|---|---|
+| `compact()`, node removal, `add(_:absorbing:…)` | same instance | keep resolving |
+| `copy()`, `translated()` | inherited | keep resolving, naming the same nodes |
+| `copyFace()` | fresh | source UIDs now return `nil` (they returned a **wrong face** before) |
+| a new graph over any shape, incl. a rebuild | fresh | source UIDs now return `nil` |
+
+`copy()` and `translated()` are **unaffected**: `BRepGraph_Copy`/`_Transform::Perform` transplant the
+counter space, Generation and GraphGUID into the target, so a copy genuinely is the same identity and
+every source UID resolves to the same node. Only `copyFace()` — which lifts one face into an empty
+graph, restarting counters at 1 — aliased, and it is now rejected.
+
+- **New:** `TopologyGraph.instanceID`; `graphID` on `GraphUID`, `GraphRefUID`, `GraphItemUID`.
+- **Deprecated:** `TopologyGraph.generation` — always 0, guards nothing. Also the hand-built
+  `GraphUID(kind:counter:)` initializers: a UID with no provenance resolves in no graph, so mint them
+  with `uid(ofNodeKind:index:)`.
+- **Immutable fields:** `kind` / `counter` / `domain` are now `let`. A mutable counter beside an
+  immutable `graphID` let a caller forge provenance — mutate a minted UID's counter and it would
+  resolve to an arbitrary node, the exact bug this release closes. Mutating a UID was never coherent
+  and no code in the ecosystem did it, but this is technically source-breaking for anyone who did.
+- **Persistence:** a UID does not survive a rebuild, and never legitimately did — it only appeared to,
+  because rebuilding the same shape re-allocates counters identically, with nothing checking it was
+  the same shape. Store `(kind, index)` with the shape and re-mint after rebuilding. This matches
+  OCCT's model, where a UID is an anchor into a *persisted graph model*; OCCT does not yet expose a
+  graph serializer, and its `GraphGUID` is regenerated on every rebuild by design.
+- **Codable:** payloads written before this release have no `graphID` and decode as unstamped
+  (`graphID == 0`), which resolves nowhere rather than failing the load.
+- **Equality:** `graphID` participates in `Hashable`/`Equatable`, so UIDs from unrelated graphs no
+  longer compare equal or collapse together in a `Set`. Within one graph (and across a copy),
+  equality is unchanged.
+
+Unchanged: a UID still survives compaction and node removal within its own graph — that is what it is
+for, and it is now the property the tests actually check. The previous `foreignUIDDoesNotResolve` test
+only fabricated an *out-of-range* counter, which the reverse-index rejected anyway; a genuinely
+foreign UID is in-range. Surfaced while investigating #290.
 ### v1.11.3 (July 2026) — fix: robust importers silently dropped all but the first body (#302)
 
 **A multibody file lost every body after the first.** Ten boxes in, one box out — no error, no

--- a/docs/guides/cookbook/index.md
+++ b/docs/guides/cookbook/index.md
@@ -55,7 +55,7 @@ using the static PNG as the loading poster. Code → figure → 3D model all com
 - [Healing & Validity](healing-and-validity.md) — `isValid` / `isValidSolid` / `isSelfIntersecting`, `analyze`, `orientedForward`, and the repair ops (`healed` / `fixed` / `unified` / `sewn`).
 - [Meshing & Export](meshing-and-export.md) — `mesh` (deflection), the `Mesh` type, `mesh.toShape`, and STL / OBJ / STEP / IGES / BREP / glTF export + import.
 - [XCAF Assemblies](xcaf-assemblies.md) — `Document` trees, components & instancing, names / colors / materials, and structured STEP / GLB round-trip.
-- [Topology Graph](topology-graph.md) — `TopologyGraph` node counts, adjacency & shared edges, durable UIDs, and history tracking through operations.
+- [Topology Graph](topology-graph.md) — `TopologyGraph` node counts, adjacency & shared edges, per-graph UIDs, and history tracking through operations.
 - [Gordon Surfaces](gordon-surfaces.md) — skin a surface through a network of profile + guide curves (`Surface.gordon` / `gordonReport`), with build diagnostics.
 - [Surfaces from Points](surfaces-from-points.md) — fit a B-spline through a grid (`fromPointGrid`) or a scattered cloud (`plateThrough`), and deform-to-targets (`nlPlateDeformed`).
 - [Working with Meshes](working-with-meshes.md) — the `Mesh` type: build from arrays, inspect, mesh-level booleans, triangle↔face picking, `toShape`, and SceneKit / RealityKit / Metal interop.

--- a/docs/guides/cookbook/topology-graph.md
+++ b/docs/guides/cookbook/topology-graph.md
@@ -7,9 +7,9 @@ nav_order: 9
 # Topology Graph
 
 A `Shape` is a B-Rep — a graph of solids, shells, faces, wires, edges and vertices wired together by
-incidence. `TopologyGraph` exposes that graph for **queries** (counts, adjacency, shared edges) and
-gives every node a **durable identity** that survives modelling operations — useful for selection,
-analysis, and persisting references across sessions.
+incidence. `TopologyGraph` exposes that graph for **queries** (counts, adjacency, shared edges), gives
+every node an identity that survives mutation of that graph, and can absorb an operation's **history**
+so a selection survives the operation too — useful for selection and analysis.
 
 ## Build the graph
 
@@ -68,13 +68,58 @@ if let resolved = graph.node(forUID: uid) {
 }
 ```
 
-UIDs are scoped to a **generation** (`graph.generation`, bumped on rebuild) — validate the generation
-matches before reusing a UID across a rebuild. Parallel kinds exist for references (`GraphRefUID`) and
-domain-scoped items (`GraphItemUID`).
+A UID is scoped to the **one graph instance** that minted it. Counters restart at 1 in every graph, so
+a UID from another graph would name an unrelated node; each UID carries the minting graph's
+`instanceID` as `graphID`, and the resolvers return `nil` rather than a wrong node:
+
+```swift
+let other = TopologyGraph(shape: Shape.cylinder(radius: 3, height: 7)!)!
+other.node(forUID: uid)      // nil — uid belongs to `graph`, not to `other`
+other.contains(uid: uid)     // false
+```
+
+`copy()` and `translated()` copy the whole graph and **keep** that identity, so UIDs carry across and
+name the same nodes. `copyFace()` lifts a single face into a new graph and does not, so its UIDs are
+its own. Parallel kinds exist for references (`GraphRefUID`) and domain-scoped items (`GraphItemUID`),
+with the same scope.
+
+```swift
+let copy = graph.copy()!
+copy.node(forUID: uid)                  // resolves — same face, same identity
+
+let lifted = graph.copyFace(3)!         // one face, at index 0, new identity
+lifted.node(forUID: uid)                // nil
+lifted.uid(ofNodeKind: faceKind, index: 0)   // mint from the new graph instead
+```
+
+### UIDs and persistence
+
+A rebuild is a **new graph**, so a UID does not survive one — build the graph again from the same
+shape and the old UIDs are void. Storing a `GraphUID` in a file and resolving it after a rebuild does
+not work (and before v1.12.0 it appeared to work, silently returning a wrong node on any other model).
+
+To carry a selection across a save/load today, store the `(kind, index)` with the shape and re-mint
+after rebuilding:
+
+```swift
+// save:  the shape, plus the node address you care about
+let saved = (kind: faceKind, index: 3)
+// load:  rebuild, then re-mint
+let reloaded = TopologyGraph(shape: Shape.fromBREPString(brep)!)!
+let uid = reloaded.uid(ofNodeKind: saved.kind, index: saved.index)
+```
+
+This matches OCCT's own model: upstream's design treats a UID as a *persistence anchor into a
+persisted graph model* — you would persist the graph (its defs, refs and UID vectors) and the UID
+anchors into it. OCCT does not yet expose a serializer for the graph model, and OCCTSwift's
+`snapshot()` stores the source BREP and rebuilds, which is precisely the case upstream defines as a
+new identity (its `GraphGUID` is regenerated on every rebuild).
 
 > **NodeRef vs UID.** `NodeRef(kind:index:)` is an ephemeral, in-memory pointer (fine for a single
-> traversal); `GraphUID` is the durable handle to persist or carry across operations. Don't store
-> raw indices and expect them to mean the same node later.
+> traversal); `GraphUID` keeps naming the same node as *this* graph mutates. Don't store raw indices
+> and expect them to mean the same node later — and don't expect a UID to mean anything in a
+> different graph. To carry a selection across a modelling operation, absorb that operation's
+> history (next section).
 
 ## Tracking nodes through operations (history)
 

--- a/docs/reference/TopologyGraph-Detail-History.md
+++ b/docs/reference/TopologyGraph-Detail-History.md
@@ -430,8 +430,8 @@ public func add(_ result: Shape,
 
 **The input and the result share one graph.** Build the graph from the operation's *input* shape, then
 hand it the result. History is NodeId-keyed, so the `NodeRef`s and `GraphUID`s you already hold stay
-valid — there is no generation boundary to cross, and no cross-graph UID lookup (which would be unsafe;
-see [#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
+valid — there is no second graph to look them up in, and a UID only ever means something in the graph
+that minted it ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
 
 - **Parameters:**
   - `result` — the operation's result shape.

--- a/docs/reference/TopologyGraph-Editor-Identity.md
+++ b/docs/reference/TopologyGraph-Editor-Identity.md
@@ -516,7 +516,7 @@ The stored generation counter from when the cached face mesh was last committed.
 public func cachedFaceMeshStoredOwnGen(_ faceIndex: Int) -> UInt32
 ```
 
-Compare against `generation` to detect stale caches.
+This is the entry's own field (`FaceMeshEntry::MeshGeneration`), maintained by OCCT's mesh cache. It is **not** comparable to the graph's `generation` counter, and this page previously said to compare them — it never worked (#295).
 
 - **OCCT:** `OCCTBRepGraphCachedFaceMeshStoredOwnGen`.
 
@@ -730,20 +730,51 @@ public func sampleEdgeCurve(edgeIndex: Int, count: Int) -> [SIMD3<Double>]
 
 ## Durable Identity (UID / RefUID / ItemUID)
 
-*(OCCT 8.0.0p1)* The UID system provides counter-based identifiers that remain stable across graph mutations (compaction, node removal) within one graph generation. Unlike `(kind, index)` pairs, counters never repeat within a kind and survive vector-index shifts. A counter of `0` is always the invalid sentinel.
+*(OCCT 8.0.0p1)* The UID system provides counter-based identifiers that remain stable across mutations of **the one graph instance that minted them** — compaction, node removal. Unlike `(kind, index)` pairs, counters never repeat within a kind and survive vector-index shifts. A counter of `0` is always the invalid sentinel.
+
+### Scope: one graph instance
+
+A UID is meaningful only inside the graph that minted it. Every graph allocates counters from 1 independently, so the same `(kind, counter)` names some unrelated node in every other graph. Each UID therefore carries a `graphID` — the `instanceID` of the graph that minted it — and the resolvers reject a UID from anywhere else:
+
+```swift
+let boxGraph = TopologyGraph(shape: box)!
+let cylGraph = TopologyGraph(shape: cylinder)!
+
+let faceUID = boxGraph.uid(ofNodeKind: 2, index: 2)!   // a face of the BOX
+boxGraph.node(forUID: faceUID)      // Optional((kind: 2, index: 2))
+cylGraph.node(forUID: faceUID)      // nil  — not this graph's UID
+cylGraph.contains(uid: faceUID)     // false
+```
+
+The scope is the graph *instance*, not the shape: two graphs built from the same shape are two instances, and a UID from one does not resolve in the other. A rebuild is likewise a new instance.
+
+Which operations carry identity across follows the kernel's own rule — whether it transplants the UID counter space into the target:
+
+| Operation | Identity | UIDs |
+|---|---|---|
+| `compact()`, node removal, `add(_:absorbing:…)` | same instance, mutated in place | keep resolving |
+| `copy()`, `translated()` | **inherited** — `BRepGraph_Copy`/`_Transform::Perform` transplant the counter space, Generation and GraphGUID | keep resolving, naming the same nodes |
+| `copyFace()` | **fresh** — `CopyNode` lifts one face without the counter space | source UIDs return `nil` |
+| a new graph over any shape (incl. a rebuild of the same one) | fresh | source UIDs return `nil` |
+
+To carry a selection across a *modelling operation* rather than across mutations of one graph, absorb the operation's history — see [`add(_:absorbing:inputRoots:operationName:)`](TopologyGraph-Detail-History.md#add_absorbinginputrootsoperationname). To carry one across a save/load, store `(kind, index)` with the shape and re-mint after rebuilding — see [Topology Graph § UIDs and persistence](../guides/cookbook/topology-graph.md#uids-and-persistence).
+
+> Before v1.12.0 UIDs carried no provenance, so a UID from an unrelated graph resolved to a plausible but wrong node instead of returning `nil`. `copyFace()` was affected the same way. ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295))
 
 ### `GraphUID`
 
-A durable node identifier: a `(kind, counter)` pair for a definition node.
+A durable node identifier: a `(kind, counter)` pair for a definition node, stamped with the graph that minted it.
 
 ```swift
 public struct GraphUID: Sendable, Hashable, Codable {
     public var kind: Int
     public var counter: UInt32
-    public init(kind: Int, counter: UInt32)
+    public let graphID: UInt64
     public var isValid: Bool { get }
 }
 ```
+
+`graphID` is the `instanceID` of the minting graph. `0` means unstamped — built by hand, or decoded from a payload written before v1.12.0 — and resolves in no graph. Mint UIDs with `uid(ofNodeKind:index:)` rather than constructing them.
 
 `kind` is the raw `BRepGraph_NodeId::Kind` ordinal:
 
@@ -767,13 +798,13 @@ public struct GraphUID: Sendable, Hashable, Codable {
 
 ### `GraphRefUID`
 
-A durable reference-entry identifier: a `(kind, counter)` pair for a reference (ref) node.
+A durable reference-entry identifier: a `(kind, counter)` pair for a reference (ref) node. Scoped to one graph instance and stamped with `graphID`, exactly as `GraphUID` is.
 
 ```swift
 public struct GraphRefUID: Sendable, Hashable, Codable {
     public var kind: Int
     public var counter: UInt32
-    public init(kind: Int, counter: UInt32)
+    public let graphID: UInt64
     public var isValid: Bool { get }
 }
 ```
@@ -794,14 +825,14 @@ public struct GraphRefUID: Sendable, Hashable, Codable {
 
 ### `GraphItemUID`
 
-A durable generic item identifier covering both definition nodes (`domain == 1`) and reference entries (`domain == 2`).
+A durable generic item identifier covering both definition nodes (`domain == 1`) and reference entries (`domain == 2`). Scoped to one graph instance and stamped with `graphID`, exactly as `GraphUID` is.
 
 ```swift
 public struct GraphItemUID: Sendable, Hashable, Codable {
     public var domain: Int
     public var kind: Int
     public var counter: UInt32
-    public init(domain: Int, kind: Int, counter: UInt32)
+    public let graphID: UInt64
     public var isValid: Bool { get }
 }
 ```
@@ -832,14 +863,14 @@ public func uid(ofNodeKind kind: Int, index: Int) -> GraphUID?
 
 ### `node(forUID:)`
 
-Resolve a `GraphUID` back to its `(kind, index)` in the current graph generation.
+Resolve a `GraphUID` back to its `(kind, index)` in this graph.
 
 ```swift
 public func node(forUID uid: GraphUID) -> (kind: Int, index: Int)?
 ```
 
-- **Parameters:** `uid` — a `GraphUID` previously obtained from `uid(ofNodeKind:index:)`.
-- **Returns:** `(kind, index)` tuple if the UID resolves in the current generation, or `nil` if the node no longer exists.
+- **Parameters:** `uid` — a `GraphUID` previously obtained from this graph's `uid(ofNodeKind:index:)`.
+- **Returns:** `(kind, index)` tuple if the UID resolves, or `nil` if this graph did not mint it or the node no longer exists. A UID minted by another graph returns `nil` even when its counter is in range here — which it usually is, since counters restart per graph.
 - **OCCT:** `BRepGraph_NodeId` reverse lookup (via `OCCTBRepGraphNodeFromUID`).
 - **Example:**
   ```swift
@@ -854,7 +885,7 @@ public func node(forUID uid: GraphUID) -> (kind: Int, index: Int)?
 
 ### `contains(uid:) — GraphUID`
 
-Return `true` if a `GraphUID` is valid and exists in this graph generation.
+Return `true` if this graph minted the `GraphUID` and the node it names still exists here.
 
 ```swift
 public func contains(uid: GraphUID) -> Bool
@@ -893,7 +924,7 @@ public func ref(forUID uid: GraphRefUID) -> (kind: Int, index: Int)?
 
 ### `contains(uid:) — GraphRefUID`
 
-Return `true` if a `GraphRefUID` is valid and exists in this graph generation.
+Return `true` if this graph minted the `GraphRefUID` and the reference it names still exists here.
 
 ```swift
 public func contains(uid: GraphRefUID) -> Bool
@@ -935,21 +966,43 @@ public func item(forUID uid: GraphItemUID) -> (domain: Int, kind: Int, index: In
 
 ---
 
-### `generation`
+### `instanceID`
 
-The current graph generation counter.
+Identifies this graph instance for as long as it lives.
 
 ```swift
+public var instanceID: UInt64 { get }
+```
+
+Unique among every graph this process builds, and — because the sequence starts at a random point — distinct from any other process's ids with overwhelming probability. Every UID this graph mints carries it as `graphID`, which is how `node(forUID:)` tells one of its own nodes from a node of some other graph.
+
+Identity here is the graph object, not the geometry: two graphs built from the same shape have different ids.
+
+- **OCCT:** none — assigned by the bridge per `OCCTBRepGraph` (via `OCCTBRepGraphInstanceID`).
+- **Example:**
+  ```swift
+  let graph = TopologyGraph(shape: box)!
+  let uid = graph.uid(ofNodeKind: 2, index: 0)!
+  print(uid.graphID == graph.instanceID)   // true — this graph minted it
+
+  let rebuilt = TopologyGraph(shape: box)!  // same shape, new instance
+  print(rebuilt.instanceID == graph.instanceID)   // false
+  print(rebuilt.node(forUID: uid))                // nil
+  ```
+
+---
+
+### `generation` *(deprecated)*
+
+**Always 0.** Deprecated in v1.12.0.
+
+```swift
+@available(*, deprecated)
 public var generation: UInt32 { get }
 ```
 
-Incremented each time the graph is cleared or rebuilt. Compare a cached `storedOwnGen` value against `generation` to detect whether a cached mesh is stale.
+OCCT advances this only from `BRepGraph::Clear()`, which nothing in OCCTSwift calls, so it never changes: it cannot tell two graphs apart, and it cannot detect a stale cache. Nothing replaces it — `node(forUID:)` rejects a UID from another graph on its own, and `instanceID` compares graph identity directly.
+
+Earlier revisions of this page suggested comparing a cached `storedOwnGen` against `generation` to detect a stale mesh. That recipe never worked and has been removed: `storedOwnGen` is a per-entity mesh field (`FaceMeshEntry::MeshGeneration`), not this counter, so the two were never comparable ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
 
 - **OCCT:** `BRepGraph` generation field (via `OCCTBRepGraphGeneration`).
-- **Example:**
-  ```swift
-  let gen = graph.generation
-  // After rebuild:
-  let cachedGen = graph.cachedFaceMeshStoredOwnGen(0)
-  let isStale = cachedGen != gen
-  ```


### PR DESCRIPTION
Fixes #295.

## The bug

`GraphUID` carried no graph identity. It is a `(kind, counter)` pair and every `TopologyGraph` allocates counters from 1 independently, so a UID minted from a box landed inside an unrelated cylinder graph's valid counter range and resolved — to a wrong face, silently:

```swift
let boxUID = boxGraph.uid(ofNodeKind: 2, index: 2)!   // a face of the BOX
cylGraph.node(forUID: boxUID)     // was: Optional((kind: 2, index: 2))  — now: nil
cylGraph.contains(uid: boxUID)    // was: true                           — now: false
```

The documented safeguard could never have caught it: `generation` is a constant 0, and the docs' staleness recipe compared it against `storedOwnGen`, a per-entity mesh field that was never the same counter.

## The fix

Every graph carries an `instanceID`; every UID it mints records it as `graphID`; the five resolvers reject a UID from any other graph. `GraphRefUID` / `GraphItemUID` too — same defect, same mechanism.

**Identity follows the kernel's own rule** — whether the operation transplants the UID counter space:

| Operation | Identity | UIDs |
|---|---|---|
| `compact()`, node removal, `add(_:absorbing:…)` | same instance | keep resolving |
| `copy()`, `translated()` | **inherited** | keep resolving, naming the same nodes |
| `copyFace()` | **fresh** | source UIDs return `nil` (returned a **wrong face** before) |
| new graph over any shape, incl. a rebuild | fresh | source UIDs return `nil` |

`copy()`/`translated()` are unaffected — `BRepGraph_Copy`/`_Transform::Perform` transplant every per-kind UID counter, the Generation *and* the GraphGUID into the target, so a copy genuinely **is** the same identity. Measured: all 6 box face UIDs map through both to the geometrically identical face. Only `copyFace()` aliased (`CopyNode` restarts counters at 1, so source face 0's UID returned face 3 out of `copyFace(3)`), and it is now rejected.

## Why not OCCT's own `GraphGUID`

It exists and is the same concept — but it cannot serve, on three counts measured against the pinned kernel, not assumed:

1. It is all-zeros on our path: only `BRepGraph::Clear()` populates it and our build skips that call (filed separately as #303 — upstream's own GTest fixture calls `Clear()` before `Add()`).
2. **Even populated it would not fix this.** `BRepGraph_UID` carries no GUID, so `NodeIdFrom` has nothing to compare — two `Clear()`ed graphs with distinct GUIDs still cross-resolve. `IsStale()` accepts foreign stamps for the same reason.
3. `BRepGraph_Copy` transplants the GUID for `CopyNode` too, so a `copyFace` graph would inherit the source's identity and alias straight back.

## Notable

- **`kind`/`counter`/`domain` are now `let`.** A mutable counter beside an immutable `graphID` let a caller forge provenance via the *blessed* API. Nothing in the ecosystem mutates a UID (checked), but this is technically source-breaking.
- **`generation` deprecated** (constant 0, guards nothing), as are the hand-built UID initializers.
- **Persistence claim removed from the docs.** The cookbook advertised "persisting references across sessions" — a capability OCCT doesn't ship and we don't implement. Upstream's model anchors a UID into a *persisted graph model*; there's no graph serializer, and `GraphGUID` is regenerated on every rebuild by design. Docs now say: store `(kind, index)` with the shape, re-mint after rebuild.
- **v1.12.0**, MINOR per `docs/SEMVER.md` (additive public API: `instanceID`, `graphID`).

## Testing

`foreignUIDDoesNotResolve` gave false confidence: it only fabricated an *out-of-range* counter, which the reverse-index rejected anyway, so it asserted a property the code did not have. Rewritten against the real box/cylinder case and **verified to fail without the guard**, while durability across compaction and through `copy()`/`translated()` keeps passing. The copy tests likewise fail against an earlier revision of this fix that minted a fresh id on copy.

The face signature is a sampled centroid+normal — a single UV-grid corner is shared between adjacent box faces and cannot tell them apart (my first probe made exactly that mistake).

Full suite: 4375 tests, one pre-existing failure in `Issue #89: convex bends` (sheet metal), which fails 2-of-3 runs on unmodified `main` — unrelated, and worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
