### PR TITLE
fix(#302): robust importers silently dropped all but the first body

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1062,6 +1062,7 @@ typedef struct {
     bool sewingApplied;
     bool solidCreated;
     bool healingApplied;
+    int solidsCreated;  // How many shells became solids: >1 means a multibody file (#302)
 } OCCTSTEPImportResult;
 
 /// Import STEP file with robust handling: sewing, solid creation, and shape healing

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -71,6 +71,8 @@
 #include <BinTools.hxx>
 #include <BRepTools.hxx>
 #include <BRep_Builder.hxx>
+#include <TopoDS_Iterator.hxx>
+#include <TopoDS_Compound.hxx>
 
 // MARK: - Export
 
@@ -207,6 +209,50 @@ static inline void setCancelOut(bool* outCancelled, opencascade::handle<BridgePr
     if (outCancelled && !ind.IsNull()) *outCancelled = ind->UserBreak() ? true : false;
 }
 
+// Turn every shell a sewing produced into a solid, rather than only the first (#302).
+//
+// The robust importers used to do `TopExp_Explorer(sewed, TopAbs_SHELL)` and keep `.Current()`
+// alone, so every body after the first was silently discarded: 10 boxes in, 1 box out, no error.
+// Sewing itself is fine -- it returns one shell per body -- the truncation was ours.
+//
+// Iterates a compound's IMMEDIATE children rather than exploring for shells, because an explorer
+// descends INTO solids: a hollow body owns an outer shell plus one per void, and solidifying those
+// separately would split one body into several. Shapes we cannot solidify are passed through
+// untouched rather than dropped -- losing them silently is the defect being fixed.
+//
+// Shape of the result follows the input, since a sewing yields a bare SHELL for a single body and
+// a compound of shells for several: one body in, one solid out; several in, a compound of solids.
+// theSolidsCreated counts only shells actually converted, matching `solidCreated`'s meaning.
+static TopoDS_Shape occtSolidifyShells(const TopoDS_Shape& theShape, int& theSolidsCreated) {
+    if (theShape.IsNull()) return theShape;
+
+    const TopAbs_ShapeEnum type = theShape.ShapeType();
+    if (type == TopAbs_SHELL) {
+        BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(theShape));
+        if (makeSolid.IsDone()) { theSolidsCreated++; return makeSolid.Solid(); }
+        return theShape;
+    }
+    if (type == TopAbs_COMPOUND || type == TopAbs_COMPSOLID) {
+        BRep_Builder builder;
+        TopoDS_Compound out;
+        builder.MakeCompound(out);
+        int children = 0;
+        for (TopoDS_Iterator it(theShape); it.More(); it.Next()) {
+            builder.Add(out, occtSolidifyShells(it.Value(), theSolidsCreated));
+            children++;
+        }
+        if (children == 0) return theShape;
+        if (children == 1) {
+            // One body in, a plain solid out -- don't wrap it in a compound. Only unwrap to a
+            // SOLID: a lone face or an unsolidifiable shell stays wrapped, as it was before.
+            TopoDS_Iterator it(out);
+            if (it.Value().ShapeType() == TopAbs_SOLID) return it.Value();
+        }
+        return out;
+    }
+    return theShape; // SOLID, FACE, anything else: not ours to touch
+}
+
 }
 
 OCCTShapeRef OCCTImportSTEPProgress(const char* path,
@@ -278,11 +324,8 @@ OCCTShapeRef OCCTImportSTEPRobustProgress(const char* path,
 
             TopoDS_Shape resultShape = sewedShape;
             if (sewedShape.ShapeType() != TopAbs_SOLID) {
-                TopExp_Explorer shellExp(sewedShape, TopAbs_SHELL);
-                if (shellExp.More()) {
-                    BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
-                    if (makeSolid.IsDone()) resultShape = makeSolid.Solid();
-                }
+                int solidsCreated = 0;
+                resultShape = occtSolidifyShells(sewedShape, solidsCreated);
             }
             ShapeFix_Shape fixer(resultShape);
             fixer.Perform(repair.Next(9));
@@ -643,16 +686,11 @@ OCCTShapeRef OCCTImportSTEPRobust(const char* path) {
             TopoDS_Shape sewedShape = sewing.SewedShape();
             if (sewedShape.IsNull()) sewedShape = shape;
 
-            // Try to create solid from shell
+            // Create a solid from every shell, not just the first (#302)
             TopoDS_Shape resultShape = sewedShape;
             if (sewedShape.ShapeType() != TopAbs_SOLID) {
-                TopExp_Explorer shellExp(sewedShape, TopAbs_SHELL);
-                if (shellExp.More()) {
-                    BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
-                    if (makeSolid.IsDone()) {
-                        resultShape = makeSolid.Solid();
-                    }
-                }
+                int solidsCreated = 0;
+                resultShape = occtSolidifyShells(sewedShape, solidsCreated);
             }
 
             // Apply shape healing
@@ -674,7 +712,7 @@ OCCTShapeRef OCCTImportSTEPRobust(const char* path) {
 }
 
 OCCTSTEPImportResult OCCTImportSTEPWithDiagnostics(const char* path) {
-    OCCTSTEPImportResult result = {nullptr, -1, -1, false, false, false};
+    OCCTSTEPImportResult result = {nullptr, -1, -1, false, false, false, 0};
     if (!path) return result;
 
     try {
@@ -707,15 +745,14 @@ OCCTSTEPImportResult OCCTImportSTEPWithDiagnostics(const char* path) {
                 result.sewingApplied = true;
             }
 
-            // Try solid creation
+            // Create a solid from every shell, not just the first (#302)
             if (shape.ShapeType() != TopAbs_SOLID) {
-                TopExp_Explorer shellExp(shape, TopAbs_SHELL);
-                if (shellExp.More()) {
-                    BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
-                    if (makeSolid.IsDone()) {
-                        shape = makeSolid.Solid();
-                        result.solidCreated = true;
-                    }
+                int solidsCreated = 0;
+                TopoDS_Shape solidified = occtSolidifyShells(shape, solidsCreated);
+                if (solidsCreated > 0) {
+                    shape = solidified;
+                    result.solidCreated = true;
+                    result.solidsCreated = solidsCreated;
                 }
             }
         }
@@ -799,16 +836,11 @@ OCCTShapeRef OCCTImportSTLRobust(const char* path, double sewingTolerance) {
         TopoDS_Shape sewedShape = sewing.SewedShape();
         if (sewedShape.IsNull()) sewedShape = shape;
 
-        // Try to create solid from shell
+        // Create a solid from every shell, not just the first (#302)
         TopoDS_Shape resultShape = sewedShape;
         if (sewedShape.ShapeType() != TopAbs_SOLID) {
-            TopExp_Explorer shellExp(sewedShape, TopAbs_SHELL);
-            if (shellExp.More()) {
-                BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
-                if (makeSolid.IsDone()) {
-                    resultShape = makeSolid.Solid();
-                }
-            }
+            int solidsCreated = 0;
+            resultShape = occtSolidifyShells(sewedShape, solidsCreated);
         }
 
         // Apply shape healing

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1211,7 +1211,8 @@ public final class Shape: @unchecked Sendable {
             resultType: ShapeType(rawValue: Int(result.resultType)) ?? .unknown,
             sewingApplied: result.sewingApplied,
             solidCreated: result.solidCreated,
-            healingApplied: result.healingApplied
+            healingApplied: result.healingApplied,
+            solidsCreated: Int(result.solidsCreated)
         )
     }
 
@@ -2164,11 +2165,20 @@ public struct ImportResult: Sendable {
     /// Whether shape healing was applied
     public let healingApplied: Bool
 
+    /// How many shells were turned into solids.
+    ///
+    /// `> 1` means the file held several bodies and ``shape`` is a compound of that many solids.
+    /// Before v1.11.3 every body after the first was silently discarded, so this count is the fact
+    /// that was quietly wrong — a truncated import still returned a perfectly valid solid (#302).
+    public let solidsCreated: Int
+
     /// Human-readable summary of the import processing
     public var summary: String {
         var steps: [String] = []
         if sewingApplied { steps.append("sewing") }
-        if solidCreated { steps.append("solid creation") }
+        if solidCreated {
+            steps.append(solidsCreated > 1 ? "solid creation (\(solidsCreated) bodies)" : "solid creation")
+        }
         if healingApplied { steps.append("healing") }
         let processing = steps.isEmpty ? "none" : steps.joined(separator: ", ")
         return "\(originalType) → \(resultType) (processing: \(processing))"

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2196,3 +2196,122 @@ struct RobustImportProgressTests {
         #expect(shape.faceCount == 6, "expected the box back, got \(shape.faceCount) faces")
     }
 }
+
+/// Regressions for #302: the robust importers sewed, then kept only the **first** shell, silently
+/// discarding every body after it — 10 boxes in, 1 box out, no error and no diagnostic.
+///
+/// These assert on **body count**, not validity. That distinction is the whole point: a truncated
+/// import returned a perfectly well-formed solid, which is exactly why the defect shipped
+/// unnoticed. `isValid` was true the entire time. Same lesson as #286/#300 — assert the property
+/// that was actually broken, not the one that happens to be easy to check.
+@Suite("v1.11.3 Multibody robust import (issue #302)")
+struct MultibodyRobustImportTests {
+
+    /// 10 separate solid bodies, the ordinary multibody assembly.
+    private func tenBoxes() -> Shape? {
+        let boxes = (0..<10).compactMap { i in
+            Shape.box(width: 10, height: 10, depth: 10)?
+                .translated(by: SIMD3(Double(i) * 30, 0, 0))
+        }
+        guard boxes.count == 10 else { return nil }
+        return Shape.compound(boxes)
+    }
+
+    @Test("Shape.loadRobust keeps every body of a multibody STEP (#302)")
+    func stepRobustKeepsAllBodies() throws {
+        guard let compound = tenBoxes() else { Issue.record("compound construction failed"); return }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt302_multibody.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try compound.writeSTEP(to: url)
+
+        let shape = try Shape.loadRobust(fromPath: url.path)
+        #expect(shape.solidCount == 10,
+                "loadRobust returned \(shape.solidCount) of 10 bodies — the rest were silently dropped (#302)")
+        #expect(shape.faceCount == 60, "expected 60 faces, got \(shape.faceCount) (#302)")
+        #expect(shape.shapeType == .compound, "multibody input should come back a compound, got \(shape.shapeType)")
+        #expect(shape.isValid)
+    }
+
+    @Test("Shape.loadSTLRobust keeps every body of a multibody STL (#302)")
+    func stlRobustKeepsAllBodies() throws {
+        guard let compound = tenBoxes() else { Issue.record("compound construction failed"); return }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt302_multibody.stl")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Exporter.writeSTL(shape: compound, to: url, deflection: 0.1)
+
+        let shape = try Shape.loadSTLRobust(fromPath: url.path, sewingTolerance: 1e-6)
+        // Tessellated: each box is 12 triangles, so bodies are what matters, not face count.
+        #expect(shape.solidCount == 10,
+                "loadSTLRobust returned \(shape.solidCount) of 10 bodies — the rest were silently dropped (#302)")
+        #expect(shape.isValid)
+    }
+
+    @Test("Shape.loadWithDiagnostics keeps every body and reports the count (#302)")
+    func diagnosticsKeepsAllBodiesAndCounts() throws {
+        guard let compound = tenBoxes() else { Issue.record("compound construction failed"); return }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt302_multibody_diag.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try compound.writeSTEP(to: url)
+
+        let result = try Shape.loadWithDiagnostics(from: url)
+        #expect(result.shape.solidCount == 10,
+                "loadWithDiagnostics returned \(result.shape.solidCount) of 10 bodies (#302)")
+        #expect(result.solidsCreated == 10,
+                "expected solidsCreated == 10, got \(result.solidsCreated) — the count is what made the loss visible (#302)")
+        #expect(result.solidCreated)
+    }
+
+    /// Guards the hazard the fix was designed around: a hollow body owns an **outer shell plus one
+    /// shell per void**. "Solidify every shell" naively — via `TopExp_Explorer(_, TopAbs_SHELL)` —
+    /// descends *into* solids and would turn one hollow body into two, trading data loss for
+    /// corruption. `occtSolidifyShells` walks a compound's immediate children instead, so a void
+    /// stays a void. Asserted on volume, which is what a lost void would change.
+    @Test("Shape.loadRobust does not split a body with an internal void (#302)")
+    func internalVoidNotSplit() throws {
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let sphere = Shape.sphere(radius: 5),
+              let hollow = box.subtracting(sphere) else {
+            Issue.record("hollow construction failed"); return
+        }
+        let expected = 8000.0 - (4.0 / 3.0 * Double.pi * 125.0)
+        #expect(hollow.shellCount == 2, "fixture should own an outer and a void shell, got \(hollow.shellCount)")
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt302_void.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try hollow.writeSTEP(to: url)
+
+        let shape = try Shape.loadRobust(fromPath: url.path)
+        #expect(shape.solidCount == 1,
+                "hollow body split into \(shape.solidCount) solids — the void shell was solidified separately (#302)")
+        #expect(shape.shellCount == 2, "lost the void shell: \(shape.shellCount) shells (#302)")
+        if let volume = shape.volume {
+            #expect(abs(volume - expected) / expected < 0.001,
+                    "volume \(volume) vs expected \(expected) — the void was filled in (#302)")
+        }
+        #expect(shape.isValid)
+    }
+
+    /// The other half of the contract: a single body must still come back a plain solid, not a
+    /// compound wrapping one. This is what keeps existing single-body callers untouched.
+    @Test("Shape.loadRobust still returns a plain solid for a single body (#302)")
+    func singleBodyStillSolid() throws {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box construction failed"); return
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt302_singlebody.step")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try box.writeSTEP(to: url)
+
+        let shape = try Shape.loadRobust(fromPath: url.path)
+        #expect(shape.shapeType == .solid,
+                "single-body import should stay a plain solid, got \(shape.shapeType) — existing callers depend on this (#302)")
+        #expect(shape.solidCount == 1)
+        #expect(shape.faceCount == 6)
+        #expect(shape.isValid)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,62 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.11.2
+## Current: v1.11.3
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.11.3 (July 2026) — fix: robust importers silently dropped all but the first body (#302)
+
+**A multibody file lost every body after the first.** Ten boxes in, one box out — no error, no
+diagnostic, and a perfectly valid solid returned. Found while sweeping the robust import paths for
+#300; it is a data-loss defect rather than a progress one, so it was filed and fixed separately.
+
+Every robust importer sewed and then took **the first shell only**:
+
+```cpp
+TopExp_Explorer shellExp(sewedShape, TopAbs_SHELL);
+if (shellExp.More()) {                                    // <-- first shell, no loop
+    BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
+    if (makeSolid.IsDone()) resultShape = makeSolid.Solid();
+}
+```
+
+Measured on a 10-box compound (10 solids, 60 faces), through the public API:
+
+| API | before | after |
+|---|---|---|
+| `Shape.loadRobust` (STEP) | 1 solid, 6 faces | **10 solids, 60 faces** |
+| `Shape.loadSTLRobust` | 1 solid, 12 faces | **10 solids** |
+| `Shape.loadWithDiagnostics` | 1 solid, 6 faces | **10 solids**, `solidsCreated == 10` |
+
+The sewing was never at fault — `BRepBuilderAPI_Sewing` returns one shell per body, and the bridge
+discarded nine of them. `Shape.load` / `loadSTL` (the plain loaders) were never affected, and
+`loadIGESRobust` is not either: the IGES path only transfers and heals, so it has no `MakeSolid`
+step to truncate.
+
+**Behaviour change — the return type now follows the file.** A multibody import returns a
+**compound of solids**; a single-body import still returns a plain **solid**, exactly as before, so
+existing single-body callers are untouched. Callers that handle both must not assume `.solid`.
+
+**`ImportResult.solidsCreated: Int`** (new) reports how many shells became solids, alongside the
+existing `solidCreated: Bool`. The count is precisely the fact that was silently wrong.
+
+Shells that `MakeSolid` rejects are now carried through as shells rather than dropped — losing them
+quietly is the defect being fixed.
+
+The fix walks a compound's **immediate children** rather than exploring for shells, because an
+explorer descends *into* solids: a hollow body owns an outer shell plus one per void, and
+solidifying those separately would split one body into two — trading data loss for corruption. A
+regression test covers it (a box with an internal spherical void survives with both shells and its
+exact volume).
+
+Regression tests assert on **body count**, not validity. That distinction is the point: a truncated
+import returned a well-formed solid and `isValid` was true throughout, which is why this shipped
+unnoticed. Same lesson as #286/#300 — assert the property that was actually broken.
 
 ### v1.11.2 (July 2026) — fix: robust-import healing ran outside the caller's progress range (#300)
 

--- a/docs/guides/cookbook/meshing-and-export.md
+++ b/docs/guides/cookbook/meshing-and-export.md
@@ -93,7 +93,7 @@ Instance methods mirror the statics where handy: `box.writeSTL(to:deflection:)`,
 let step = try Shape.load(from: stepURL)            // STEP (also Shape.loadSTEP)
 let iges = try Shape.loadIGES(from: igesURL)        // loadIGESRobust heals tolerance issues
 let brep = try Shape.loadBREP(from: brepURL)        // exact + triangulation if exported with it
-let stl  = try Shape.loadSTLRobust(from: stlURL, sewingTolerance: 1e-6)   // auto sew + heal
+let stl  = try Shape.loadSTLRobust(from: stlURL, sewingTolerance: 1e-6)   // auto sew + heal; compound if multibody
 ```
 
 For mesh formats prefer the **robust** loaders (`loadSTLRobust`) — they sew and heal the seams a raw

--- a/docs/guides/cookbook/working-with-meshes.md
+++ b/docs/guides/cookbook/working-with-meshes.md
@@ -96,7 +96,7 @@ let shape = mesh.toShape(weldTolerance: 1e-6)   // raise for large-coordinate me
 ```
 
 The result is a faceted shell, not necessarily a valid solid — run [healing](healing-and-validity.md)
-if you need one. (For an STL on disk, prefer `Shape.loadSTLRobust`, which sews + heals as it loads.)
+if you need one. (For an STL on disk, prefer `Shape.loadSTLRobust`, which sews + heals as it loads — a multibody mesh comes back as a compound of solids.)
 
 ## Hand it to a renderer
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1611,7 +1611,7 @@ Recommended for STEP files that may contain disconnected faces needing sewing, s
 Every phase is bounded by `progress`: the transfer spans `fraction` 0…0.5 and the repair (sewing, then healing) 0.5…1.0, matching their measured cost — repair is ~50% of the work on a solid. A wall-clock deadline in `shouldCancel()` therefore bounds the whole call, and cancelling mid-repair throws rather than returning the partially-repaired shape.
 
 - **Parameters:** `url` — URL to the STEP file; `progress` — optional progress/cancellation channel.
-- **Returns:** Processed shape suitable for CAM operations.
+- **Returns:** Processed shape — a plain **solid** for a single-body file, a **compound of solids** when the file holds several bodies.
 - **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
 - **OCCT:** `STEPControl_Reader` + `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTImportSTEPRobustProgress`).
 - **Example:**
@@ -1635,6 +1635,13 @@ Every phase is bounded by `progress`: the transfer spans `fraction` 0…0.5 and 
   }
   ```
 - **Limitation — parsing is not covered:** OCCT's `STEPControl_Reader::ReadFile` takes no `Message_ProgressRange`, so the file is parsed *before* the progress indicator exists. Reading a large STEP file reports nothing and cannot be cancelled; `fraction` and the deadline bound only the transfer and repair that follow.
+- **Multibody (v1.11.3):** every body is sewn and solidified. Don't assume `.solid` — check `shapeType` or iterate `subShapes(ofType: .solid)`:
+  ```swift
+  let shape = try Shape.loadRobust(from: stepURL)
+  let bodies = shape.shapeType == .solid ? [shape] : shape.subShapes(ofType: .solid)
+  print("\(bodies.count) bodies")
+  ```
+- **Fixed in v1.11.3:** every body after the first was silently discarded — a 10-body STEP returned 1 body as a valid solid, with no error ([#302](https://github.com/SecondMouseAU/OCCTSwift/issues/302)).
 - **New in v1.11.2:** `progress:`. The progress-capable bridge function existed but no Swift API reached it, so a robust STEP import could not be observed or cancelled at all ([#300](https://github.com/SecondMouseAU/OCCTSwift/issues/300)). Existing `loadRobust(from:)` call sites are unaffected — the parameter defaults to `nil`.
 
 ---
@@ -1666,7 +1673,7 @@ public static func loadWithDiagnostics(from url: URL) throws -> ImportResult
 Returns an `ImportResult` struct containing the shape and information about what processing (sewing, solid creation, healing) was applied.
 
 - **Parameters:** `url` — URL to the STEP file.
-- **Returns:** `ImportResult` with `shape`, `originalType`, `resultType`, `sewingApplied`, `solidCreated`, and `healingApplied`.
+- **Returns:** `ImportResult` with `shape`, `originalType`, `resultType`, `sewingApplied`, `solidCreated`, `solidsCreated`, and `healingApplied`.
 - **Throws:** `ImportError.importFailed` on failure.
 - **OCCT:** `STEPControl_Reader` + `OCCTImportSTEPWithDiagnostics`.
 - **Example:**
@@ -1675,6 +1682,14 @@ Returns an `ImportResult` struct containing the shape and information about what
   print(result.summary)   // e.g. "Shell → Solid (processing: sewing, solid creation, healing)"
   let shape = result.shape
   ```
+- **Example — how many bodies did the file hold?**
+  ```swift
+  let result = try Shape.loadWithDiagnostics(from: stepFile)
+  if result.solidsCreated > 1 {
+      print("\(result.solidsCreated) bodies — result.shape is a compound of solids")
+  }
+  ```
+- **`solidsCreated` (new in v1.11.3):** how many shells became solids. `> 1` means a multibody file and `shape` is a compound of that many solids. Before v1.11.3 every body after the first was silently discarded, so this count is the fact that was quietly wrong — a truncated import still returned a valid solid ([#302](https://github.com/SecondMouseAU/OCCTSwift/issues/302)).
 
 ---
 
@@ -1947,7 +1962,7 @@ public static func loadSTLRobust(from url: URL, sewingTolerance: Double = 1e-6) 
 - **Parameters:**
   - `url` — URL to the STL file.
   - `sewingTolerance` — tolerance for sewing disconnected faces (default `1e-6`).
-- **Returns:** Processed shape suitable for solid operations.
+- **Returns:** Processed shape — a plain **solid** for a single-body file, a **compound of solids** when the mesh holds several disconnected bodies.
 - **Throws:** `ImportError.importFailed` on failure.
 - **OCCT:** `StlAPI_Reader` + `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTImportSTLRobust`).
 - **Example:**
@@ -1955,6 +1970,13 @@ public static func loadSTLRobust(from url: URL, sewingTolerance: Double = 1e-6) 
   let solid = try Shape.loadSTLRobust(from: stlURL, sewingTolerance: 1e-5)
   print(solid.isValid)
   ```
+- **Multibody:** every disconnected body is sewn and solidified. Don't assume `.solid` — check `shapeType` or iterate `subShapes(ofType: .solid)`:
+  ```swift
+  let shape = try Shape.loadSTLRobust(from: stlURL)
+  let bodies = shape.shapeType == .solid ? [shape] : shape.subShapes(ofType: .solid)
+  print("\(bodies.count) bodies")
+  ```
+- **Fixed in v1.11.3:** every body after the first was silently discarded — a 10-body STL returned 1 body as a valid solid, with no error ([#302](https://github.com/SecondMouseAU/OCCTSwift/issues/302)).
 
 ---
 


### PR DESCRIPTION
Closes #302. Found while sweeping the robust import paths for #300; filed and fixed separately since it's data loss, not a progress defect.

## The defect

Ten boxes in, one box out — no error, no diagnostic, and a **perfectly valid solid** returned. Every robust importer sewed and then kept only the first shell:

```cpp
TopExp_Explorer shellExp(sewedShape, TopAbs_SHELL);
if (shellExp.More()) {                                    // <-- first shell, no loop
    BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
    if (makeSolid.IsDone()) resultShape = makeSolid.Solid();
}
```

Measured on a 10-box compound (10 solids, 60 faces), through the public API:

| API | before | after |
|---|---|---|
| `Shape.loadRobust` (STEP) | 1 solid, 6 faces | **10 solids, 60 faces** |
| `Shape.loadSTLRobust` | 1 solid, 12 faces | **10 solids** |
| `Shape.loadWithDiagnostics` | 1 solid, 6 faces | **10 solids**, `solidsCreated == 10` |

**The sewing was never at fault.** `BRepBuilderAPI_Sewing` returns one shell per body — the bridge discarded nine of them. The plain loaders (`load`, `loadSTL`) were never affected, and `loadIGESRobust` isn't either: the IGES path only transfers and heals, so it has no `MakeSolid` step to truncate.

## Return type now follows the file

- **Multibody** → a `Compound` of solids.
- **Single body** → a plain `Solid`, exactly as before.

Existing single-body callers are untouched, and a test pins that half of the contract — **it passes both before and after the fix**, which is what proves the change is confined to the broken case. Callers handling both must not assume `.solid`; the docs show the `shapeType == .solid ? [shape] : subShapes(ofType: .solid)` pattern.

`ImportResult.solidsCreated: Int` (new) reports how many shells became solids, alongside the existing `solidCreated: Bool` — the count is precisely the fact that was silently wrong.

## The hazard this was designed around

"Solidify every shell" is *not* simply `TopExp_Explorer(_, TopAbs_SHELL)` over everything. **A hollow body owns an outer shell plus one shell per void**, and an explorer descends *into* solids — so the naive fix would split one hollow body into two, trading data loss for corruption.

`occtSolidifyShells` walks a compound's **immediate children** instead. Verified: a box with an internal spherical void survives `loadRobust` with both shells and its exact volume (7476.401 vs 7476.401 analytic), and that's now a regression test. Shells that `MakeSolid` rejects are passed through rather than dropped — losing them quietly is the defect being fixed.

Structure was measured rather than assumed, and it shaped the design — `SewedShape()` returns a **bare `SHELL`** for a single body, not a compound:

| input | `SewedShape()` |
|---|---|
| 10 solid boxes | COMPOUND of 10 SHELL children |
| 60 loose faces | COMPOUND of 10 SHELL children |
| single box | bare **SHELL** |

## Tests assert body count, not validity

That distinction is the whole point: a truncated import returned a well-formed solid and `isValid` was true throughout, which is exactly why this shipped unnoticed. All three multibody tests are confirmed to fail against the pre-fix behaviour — *"loadRobust returned 1 of 10 bodies"* — while the single-body and void tests pass either way.

## Verification

- `swift build` — clean.
- `OCCTIOTests` **137 tests / 34 suites** ✓ · `OCCTMeshTests` (75) ✓ · `OCCTShapeHealingTests` (212) ✓ · `OCCTIntegrationTests` (19) ✓ · `OCCTModelingTests` (409) ✓ · `OCCTTopologyTests` (401) ✓
- Operation count **4237**, README and API_REFERENCE agree (`Scripts/count-operations.py`).
- Docs: CHANGELOG (v1.11.3), `docs/reference/Shape.md` (all three APIs + the multibody pattern), and both cookbook pages that recommend `loadSTLRobust`.

No xcframework rebuild; no upstream OCCT issue warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)