### PR TITLE
fix(#298): serialise 3D fillet/chamfer — non-reentrant blend statics in OCCT

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge.mm
@@ -19,6 +19,13 @@ std::recursive_mutex& occtGlobalMutex() {
 void OCCTSerialLockAcquire(void) { occtGlobalMutex().lock(); }
 void OCCTSerialLockRelease(void) { occtGlobalMutex().unlock(); }
 
+// #298: serialises 3D fillet/chamfer builds against each other (non-reentrant
+// blend statics in OCCT's TKFillet). See OCCTBridge_Internal.h for the full why.
+std::recursive_mutex& occtFilletMutex() {
+    static std::recursive_mutex mutex;
+    return mutex;
+}
+
 // Install OCCT's signal handlers once (issue #175). OSD::SetSignal(false) installs
 // SIGSEGV/SIGBUS/SIGFPE handlers without enabling the FPE-trapping FP mask, so that
 // signals raised inside OCCT become catchable via OCC_CATCH_SIGNALS instead of aborting

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -436,6 +436,7 @@ OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
         TopoDS_Edge edge = TopoDS::Edge(edgeMap(edgeIndex + 1));  // OCCT uses 1-based indexing
 
         // Create fillet maker
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Add edge with variable radius
@@ -667,6 +668,7 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
         // Create fillet maker
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Add each edge with its radius

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -187,6 +187,28 @@ struct OCCTHistoryStorage {
 std::recursive_mutex& occtGlobalMutex();
 std::mutex& igesMutex();
 
+// #298: 3D fillet/chamfer serialization lock.
+//
+// BRepFilletAPI_MakeFillet's constant- and evolutive-radius blend solvers
+// (BlendFunc_ConstRad / BlendFunc_EvolRad) and the shared ChFi3d_Builder curve
+// checker keep their geometric work variables in function-local `static`s ("to
+// avoid systematic reallocation"). That makes the blend evaluation NON-REENTRANT:
+// two threads filleting at once interleave writes to the same statics, the solver
+// converges on a corrupted surface, and the result is a wrong-but-plausible solid
+// that fails BRepCheck — silent bad geometry, not a crash or a thrown error.
+// Reproduced in pure OCCT with no wrapper involved (issue #298).
+//
+// Hold this lock around every 3D fillet/chamfer Build(). It is DISTINCT from
+// occtGlobalMutex(): booleans, meshing, and everything else stay fully parallel —
+// only fillet/chamfer builds serialise against each other. Recursive so a fillet
+// wrapper that nests another cannot self-deadlock. 2D fillets
+// (BRepFilletAPI_MakeFillet2d) use the separate analytic ChFi2d toolkit with no
+// such statics and are intentionally NOT guarded.
+//
+// This is a mitigation. The real fix de-statics those OCCT work variables
+// (Scripts/patches/0003) so the lock can be dropped. See docs/thread-safety.md.
+std::recursive_mutex& occtFilletMutex();
+
 // === OCCT signal handling ===
 //
 // Installs OCCT's signal handlers (OSD::SetSignal) once, so that OS signals

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -321,6 +321,7 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
     if (!shape || !edgeIndices || edgeCount <= 0 || radius <= 0) return nullptr;
 
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Build edge index map for lookup
@@ -350,6 +351,7 @@ OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeI
     if (startRadius <= 0 || endRadius <= 0) return nullptr;
 
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Build edge index map for lookup
@@ -1221,6 +1223,7 @@ OCCTShapeRef OCCTShapeChamferTwoDistances(OCCTShapeRef shape,
                                            int32_t count) {
     if (!shape || !edgeIndices || !faceIndices || !dist1 || !dist2 || count <= 0) return nullptr;
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeChamfer chamfer(shape->shape);
         TopTools_IndexedMapOfShape edgeMap, faceMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
@@ -1251,6 +1254,7 @@ OCCTShapeRef OCCTShapeChamferDistAngle(OCCTShapeRef shape,
                                         int32_t count) {
     if (!shape || !edgeIndices || !faceIndices || !distances || !anglesDeg || count <= 0) return nullptr;
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeChamfer chamfer(shape->shape);
         TopTools_IndexedMapOfShape edgeMap, faceMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
@@ -1876,6 +1880,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdges(OCCTShapeRef shape,
     try {
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
         for (int32_t i = 0; i < count; i++) {
             int32_t idx = edgeIndices[i] + 1; // 0-based to 1-based
@@ -1903,6 +1908,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdgeVariable(OCCTShapeRef shape,
         int32_t idx = edgeIndex + 1;
         if (idx < 1 || idx > edgeMap.Extent()) return nullptr;
         TopoDS_Edge edge = TopoDS::Edge(edgeMap(idx));
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
         op->Add(edge);
         // Map the variable radius along the edge: (param=0, startR), (param=1, endR).
@@ -1928,6 +1934,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromChamferEdges(OCCTShapeRef shape,
     try {
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         std::unique_ptr<BRepFilletAPI_MakeChamfer> op(new BRepFilletAPI_MakeChamfer(shape->shape));
         for (int32_t i = 0; i < count; i++) {
             int32_t idx = edgeIndices[i] + 1;
@@ -2346,6 +2353,7 @@ OCCTShapeRef OCCTShapeFuseAndBlend(OCCTShapeRef shape1, OCCTShapeRef shape2, dou
         const TopTools_ListOfShape& sectionEdges = fuse.SectionEdges();
 
         // Step 3: Fillet those edges
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(fuseResult);
         // Add section edges
         for (TopTools_ListIteratorOfListOfShape it(sectionEdges); it.More(); it.Next()) {
@@ -2401,6 +2409,7 @@ OCCTShapeRef OCCTShapeCutAndBlend(OCCTShapeRef shape1, OCCTShapeRef shape2, doub
         }
 
         // Step 2: Fillet
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(cutResult);
         for (TopTools_ListIteratorOfListOfShape it(sectionEdges); it.More(); it.Next()) {
             if (it.Value().ShapeType() == TopAbs_EDGE) {
@@ -2434,6 +2443,7 @@ OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         int rpOffset = 0;
@@ -8365,6 +8375,7 @@ bool OCCTFilletBuilderAddEdgeEvolving(OCCTFilletBuilderRef builder, OCCTEdgeRef 
 OCCTShapeRef OCCTFilletBuilderBuild(OCCTFilletBuilderRef builder) {
     if (!builder) return nullptr;
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         builder->fillet.Build();
         if (!builder->fillet.IsDone()) return nullptr;
         return new OCCTShape(builder->fillet.Shape());
@@ -8470,6 +8481,7 @@ bool OCCTChamferBuilderAddEdgeDistAngle(OCCTChamferBuilderRef builder,
 OCCTShapeRef OCCTChamferBuilderBuild(OCCTChamferBuilderRef builder) {
     if (!builder) return nullptr;
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         builder->chamfer.Build();
         if (!builder->chamfer.IsDone()) return nullptr;
         return new OCCTShape(builder->chamfer.Shape());
@@ -10055,6 +10067,7 @@ int32_t OCCTShapeSelfIntersectsBounded(OCCTShapeRef shape, double timeoutSeconds
 OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius) {
     if (!shape) return nullptr;
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Add fillet to all edges
@@ -10075,6 +10088,7 @@ OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius) {
 OCCTShapeRef OCCTShapeChamfer(OCCTShapeRef shape, double distance) {
     if (!shape) return nullptr;
     try {
+        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeChamfer chamfer(shape->shape);
 
         // Add chamfer to all edges

--- a/Tests/OCCTThreadTests/Issue298FilletThreadSafetyTests.swift
+++ b/Tests/OCCTThreadTests/Issue298FilletThreadSafetyTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// Issue #298: filleting a boolean result is thread-unsafe in OCCT's TKFillet.
+//
+// BRepFilletAPI_MakeFillet's constant/evolutive-radius blend solvers keep their
+// geometric work variables in function-local `static`s, so two threads filleting
+// at once corrupt each other's intermediate surfaces. The result is not a crash
+// and not an empty shape — it is a wrong-but-plausible solid (one solid, positive
+// volume) that fails BRepCheck. Reproduced in pure OCCT with no wrapper (#298).
+//
+// SheetMetal.Builder.build chains extrude → fuse → fillet, so a multi-flange part
+// hits exactly this path. Before the fix, ~60% of concurrent U-channel builds came
+// back invalid with volumes scattered across a dozen distinct wrong values; the
+// correct part is a single volume. The bridge now serialises 3D fillet/chamfer
+// builds (occtFilletMutex), so every concurrent build must match the single value
+// a lone build produces.
+//
+// This suite is deliberately concurrency-heavy; if the lock regresses it fails
+// loudly rather than flaking, because the corruption rate at this width is high.
+@Suite("Issue #298 — fillet-of-boolean is thread-safe (SheetMetal build)")
+struct Issue298FilletThreadSafetyTests {
+
+    private static func uChannel() -> (flanges: [SheetMetal.Flange], bends: [SheetMetal.Bend]) {
+        let bottom = SheetMetal.Flange(
+            id: "bottom",
+            profile: [SIMD2(0, 0), SIMD2(40, 0), SIMD2(40, 20), SIMD2(0, 20)],
+            origin: SIMD3<Double>(0, 0, 0),
+            normal: SIMD3<Double>(0, 0, 1),
+            uAxis: SIMD3<Double>(1, 0, 0),
+            vAxis: SIMD3<Double>(0, 1, 0))
+        let left = SheetMetal.Flange(
+            id: "left",
+            profile: [SIMD2(0, 0), SIMD2(20, 0), SIMD2(20, 15), SIMD2(0, 15)],
+            origin: SIMD3<Double>(0, 0, 0),
+            normal: SIMD3<Double>(-1, 0, 0),
+            uAxis: SIMD3<Double>(0, 1, 0),
+            vAxis: SIMD3<Double>(0, 0, 1))
+        let right = SheetMetal.Flange(
+            id: "right",
+            profile: [SIMD2(0, 0), SIMD2(20, 0), SIMD2(20, 15), SIMD2(0, 15)],
+            origin: SIMD3<Double>(40, 0, 0),
+            normal: SIMD3<Double>(1, 0, 0),
+            uAxis: SIMD3<Double>(0, 1, 0),
+            vAxis: SIMD3<Double>(0, 0, 1))
+        return ([bottom, left, right],
+                [SheetMetal.Bend(from: "bottom", to: "left", radius: 1.5),
+                 SheetMetal.Bend(from: "bottom", to: "right", radius: 1.5)])
+    }
+
+    /// The reference volume from a single, uncontended build. Any concurrent build
+    /// that disagrees by more than a rounding tolerance got corrupted geometry.
+    private static func referenceVolume() throws -> Double {
+        let (flanges, bends) = uChannel()
+        let s = try SheetMetal.Builder(thickness: 2).build(flanges: flanges, bends: bends)
+        let v = try #require(s.volume)
+        #expect(s.isValid)
+        #expect(s.subShapes(ofType: .solid).count == 1)
+        return v
+    }
+
+    @Test("Concurrent U-channel builds all match the single-build result")
+    func concurrentUChannelBuildsAreConsistent() async throws {
+        let reference = try Self.referenceVolume()
+        let tolerance = max(1e-3, reference * 1e-6)
+
+        struct Outcome: Sendable {
+            var threw = 0, invalid = 0, wrongSolidCount = 0, wrongVolume = 0
+            var sampleVolumes: [Double] = []
+        }
+
+        let agg = await withTaskGroup(of: Outcome.self) { group -> Outcome in
+            for _ in 0..<8 {
+                group.addTask {
+                    var o = Outcome()
+                    let builder = SheetMetal.Builder(thickness: 2)
+                    for _ in 0..<25 {
+                        let (flanges, bends) = Self.uChannel()
+                        guard let s = try? builder.build(flanges: flanges, bends: bends) else {
+                            o.threw += 1; continue
+                        }
+                        if !s.isValid { o.invalid += 1 }
+                        if s.subShapes(ofType: .solid).count != 1 { o.wrongSolidCount += 1 }
+                        let v = s.volume ?? 0
+                        if abs(v - reference) > tolerance {
+                            o.wrongVolume += 1
+                            if o.sampleVolumes.count < 5 { o.sampleVolumes.append(v) }
+                        }
+                    }
+                    return o
+                }
+            }
+            var total = Outcome()
+            for await o in group {
+                total.threw += o.threw
+                total.invalid += o.invalid
+                total.wrongSolidCount += o.wrongSolidCount
+                total.wrongVolume += o.wrongVolume
+                if total.sampleVolumes.count < 5 {
+                    total.sampleVolumes.append(contentsOf: o.sampleVolumes)
+                }
+            }
+            return total
+        }
+
+        #expect(agg.threw == 0, "some concurrent builds threw (expected 0 of 200)")
+        #expect(agg.invalid == 0,
+                "concurrent builds returned BRepCheck-invalid solids (expected 0 of 200)")
+        #expect(agg.wrongSolidCount == 0,
+                "concurrent builds returned != 1 solid (expected 0 of 200)")
+        #expect(agg.wrongVolume == 0,
+                "concurrent builds diverged from reference volume \(reference); sample corrupted volumes \(agg.sampleVolumes) — the #298 race")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,48 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.12.0
+## Current: v1.12.1
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.12.1 (July 2026) — fix: concurrent 3D fillet/chamfer builds no longer corrupt each other (#298)
+
+**Filleting a shape on two threads at once returned wrong-but-plausible geometry.** Reported as
+`SheetMetal.Builder.build` returning an invalid solid under parallel test execution (~8 of 10 runs),
+but the root cause is upstream and independent of the wrapper. `BRepFilletAPI_MakeFillet`'s
+constant- and evolutive-radius blend solvers (`BlendFunc_ConstRad`, `BlendFunc_EvolRad`) and the
+shared `ChFi3d_Builder` curve checker keep their geometric work variables in function-local
+`static`s — process-global state, "to avoid systematic reallocation". Two threads filleting at once
+interleave writes to those statics, the solver converges on a corrupted surface, and the result is a
+solid with one shell and a positive volume that nonetheless fails `BRepCheck` — silent bad geometry,
+not a crash and not a thrown error.
+
+Reproduced in **pure OCCT with no OCCTSwift code involved**: a fuse-then-fillet on eight threads
+produced BRepCheck-invalid solids with volumes scattered across several wrong values, while the same
+build on one thread was bit-for-bit deterministic and correct. A plain box fillet (which takes OCCT's
+analytic `ChFiKPart` fast path, not the numerical blend) is unaffected; only filleting a boolean
+result, which needs the general path, trips it.
+
+The issue's own diagnosis was corrected on three points: the result is *not* an empty shape (so the
+suggested "reject empty results" guard would not have caught it), the boolean is *not* implicated
+(the fuse is thread-safe and returns the correct shape every time), and it is unrelated to the
+NCollection arm64 SEGV.
+
+**Fix.** The bridge now serialises every 3D fillet and chamfer build under a dedicated recursive
+mutex (`occtFilletMutex`), distinct from `OCCTSerial`. Fillet/chamfer are now always safe to call
+concurrently with no caller-side lock; booleans, meshing, sweeps, and everything else stay fully
+parallel — only fillet/chamfer builds serialise against each other. 2D fillets
+(`BRepFilletAPI_MakeFillet2d`, the analytic `ChFi2d` toolkit) have no such statics and are not
+guarded. Verified: the originally-failing `OCCTMiscTests` target passes 8/8 parallel runs, and a new
+`Issue298FilletThreadSafetyTests` regression fails reliably without the lock and passes with it.
+
+This is a mitigation. The permanent fix de-statics the work variables in OCCT itself so the lock can
+be dropped and fillet/chamfer become genuinely parallel — tracked as a follow-up `occt-src` patch
+and an upstream report. See `docs/thread-safety.md` for the full write-up.
 
 ### v1.12.0 (July 2026) — fix: a `GraphUID` no longer resolves against a graph that didn't mint it (#295)
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -21,11 +21,13 @@ OCCT has several thread-unsafe patterns:
 
 4. **Shared geometry after booleans** — Boolean operations can produce result shapes that share edge/face geometry with input shapes via the same `TopoDS_TShape` handles. Subsequent operations on both the original and result can race on shared adaptors.
 
+5. **Non-reentrant statics in the 3D fillet/chamfer solver (issue #298)** — `BRepFilletAPI_MakeFillet`'s constant- and evolutive-radius blend functions (`BlendFunc_ConstRad`, `BlendFunc_EvolRad`) and the shared `ChFi3d_Builder` curve checker keep their geometric work variables in function-local `static`s ("to avoid systematic reallocation"). This is **process-global** state, not per-object: two threads running *any two* fillet/chamfer builds at once — even on completely independent shapes — interleave writes to the same statics. The solver then converges on a corrupted surface and returns a **wrong-but-plausible solid** (one solid, positive volume) that fails `BRepCheck` — silent bad geometry, not a crash and not a thrown error. This is distinct from items 1–4: no geometry is shared at the Swift level, yet the operation still races. Reproduced in pure OCCT with no wrapper involved. The bridge now serialises these builds internally (see below), so consumers are protected transparently.
+
 ## What IS Thread-Safe
 
 - **Handle reference counting** (`occ::handle<T>`) — atomic `std::atomic_int` refcount
 - **Reading shape topology** — immutable once built
-- **Completely independent shapes** — shapes with no shared TShapes or geometry handles
+- **Completely independent shapes** — shapes with no shared TShapes or geometry handles — **with one exception:** 3D fillet and chamfer builds are not safe to run concurrently even on independent shapes, because of the process-global statics in item 5. The bridge serialises them for you (see [3D fillet/chamfer serialization](#3d-filletchamfer-serialization-issue-298)); you get correct geometry, just no parallel speedup on those specific ops.
 - **OCCT's internal parallel algorithms** — `BOPAlgo_*` with `SetRunParallel(true)`, `BRepCheck_Analyzer` with `SetParallel(true)`, `BRepMesh_IncrementalMesh`
 
 ## The Solution
@@ -63,7 +65,9 @@ let original = Shape.box(width: 10, height: 10, depth: 10)!
 // Create 4 independent copies for parallel processing
 let copies = (0..<4).map { _ in original.deepCopy()! }
 
-// Process each copy on a different thread — safe because they share nothing
+// Process each copy on a different thread. Independence protects against the
+// shared-geometry races (items 1–4); the `filleted` call is *additionally* safe
+// because the bridge serialises fillet builds internally (item 5, issue #298).
 DispatchQueue.concurrentPerform(iterations: 4) { i in
     let result = copies[i].filleted(radius: Double(i + 1))
     // Use result...
@@ -80,6 +84,32 @@ OCCTSerial.lock()
 defer { OCCTSerial.unlock() }
 // Multiple OCCT operations that must be atomic
 ```
+
+### 3D fillet/chamfer serialization (issue #298)
+
+The problem in item 5 above cannot be solved by `deepCopy()` or by the caller
+holding `OCCTSerial` — the racing state lives in OCCT's own function-local
+statics, not in any shape the caller can see or copy. So the bridge serialises it
+at the source: **every 3D fillet and chamfer build runs under a dedicated
+recursive mutex** (`occtFilletMutex` in the C bridge), separate from `OCCTSerial`.
+
+What this means for you:
+
+- **Fillet/chamfer are always safe to call concurrently**, with no lock on your
+  side and no `deepCopy()` required. `Shape.filleted`, `Shape.chamfered`, the
+  fillet/chamfer builders, and `SheetMetal.Builder.build` (which fillets internally)
+  all go through the guarded path.
+- **Only fillet/chamfer builds serialise against each other.** Booleans, meshing,
+  extrudes, sweeps, and everything else stay fully parallel. Filleting on thread A
+  does not block a boolean on thread B.
+- **2D fillets/chamfers (`BRepFilletAPI_MakeFillet2d`) are not affected** — they use
+  the separate analytic `ChFi2d` toolkit, which has no such statics, and are not
+  serialised.
+
+This is a mitigation for an upstream OCCT defect. The permanent fix de-statics the
+work variables in `BlendFunc_ConstRad`/`BlendFunc_EvolRad` (carried as an `occt-src`
+patch); once that ships in the pinned kernel the bridge lock can be dropped and
+fillet/chamfer become genuinely parallel.
 
 ## Performance
 


### PR DESCRIPTION
## Summary

Fixes #298. Concurrent 3D fillet/chamfer builds returned **wrong-but-plausible** solids — one shell, positive volume, but failing `BRepCheck`. Reported as `SheetMetal.Builder.build` going invalid under parallel test runs (~8/10), but the **root cause is upstream OCCT and wrapper-independent**.

`BRepFilletAPI_MakeFillet`'s constant/evolutive-radius blend solvers (`BlendFunc_ConstRad`, `BlendFunc_EvolRad`) and the shared `ChFi3d_Builder` curve checker keep their geometric work variables in function-local `static`s ("to avoid systematic reallocation") — process-global, non-reentrant. Two threads filleting at once interleave writes and the solver converges on a corrupted surface. Silent bad geometry: not empty, not a crash, not a thrown error.

## Proof (pure OCCT, no wrapper)

| Test | 1 thread | 8 threads |
|---|---|---|
| Fuse only | clean | **clean** (200/200) |
| Fillet a plain box (analytic `ChFiKPart` path) | clean | **clean** (120/120) |
| **Fuse + seam fillet** (numerical blend path) | clean (50/50, 1 volume) | **34/200 invalid, 5 distinct volumes** |
| Fuse concurrent + **fillet under a lock** | — | **0/200 invalid, correct volume** |

Only filleting a boolean result trips it (the general numerical path); pristine-box fillets take the analytic fast path and never enter `BlendFunc`.

## Fix (mitigation)

Guard every 3D fillet/chamfer build with a dedicated recursive mutex (`occtFilletMutex`), **distinct from `OCCTSerial`**. Fillet/chamfer are now always safe to call concurrently with no caller-side lock; booleans, meshing, sweeps, and everything else stay **fully parallel** — only fillet/chamfer serialise against each other. 2D fillets (`BRepFilletAPI_MakeFillet2d`, analytic `ChFi2d`) have no such statics and are not guarded.

The permanent fix (follow-up PR) de-statics the OCCT work variables via an `occt-src` patch so the lock can be dropped and fillet/chamfer become genuinely parallel; upstream report to Open Cascade to accompany it.

## Corrects the issue's diagnosis

- The result is **not empty** — so the suggested "reject empty results in `unionFailed`" guard would not have caught it.
- The **boolean is not implicated** — the fuse is thread-safe and returns the correct shape every time.
- **Unrelated** to the NCollection arm64 SEGV.

## Verification

- New regression `Issue298FilletThreadSafetyTests` (OCCTThreadTests): **fails reliably without the lock, passes with it** (negative control run by neutering the guards, rebuilding, and observing FFF → restored → passes).
- Originally-failing `OCCTMiscTests` target: **8/8** parallel runs clean (was ~8/10 failing).
- OCCTModelingTests (409), OCCTThreadTests (55), OCCTShapeHealingTests (212): all pass.

## Docs

- `docs/thread-safety.md`: new problem #5 (non-reentrant statics) + a "3D fillet/chamfer serialization" section; corrected the over-broad "independent shapes are thread-safe" guarantee.
- `docs/CHANGELOG.md`: v1.12.1.

Source-only change — no xcframework rebuild, no `Package.swift` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)