### PR TITLE
fix(#303): run OCCT's Clear() rebuild boundary when building a graph

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -20910,9 +20910,10 @@ bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef _Nonnull graph,
 
 /// Return the current graph generation counter.
 ///
-/// NOTE: always 0 in practice. OCCT only advances it from BRepGraph::Clear(), which
-/// nothing in this bridge calls, so it cannot distinguish two graphs. Use
-/// OCCTBRepGraphInstanceID for that. See issue #295.
+/// NOTE: always 1 in practice. OCCT advances it only from BRepGraph::Clear(); this bridge
+/// calls Clear() exactly once, when it builds a graph (#303), and never rebuilds one, so the
+/// counter lands at 1 and is identical for every graph. It cannot distinguish two graphs — use
+/// OCCTBRepGraphInstanceID for that. See issues #295 and #303.
 uint32_t OCCTBRepGraphGeneration(OCCTBRepGraphRef _Nonnull graph);
 
 /// Return this graph's instance id — unique among every graph this process creates, and

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -134,30 +134,25 @@ static GeomAbs_Shape continuityFromInt(int val) {
 // This id mirrors OCCT's own graph identity, BRepGraph::UIDs().GraphGUID() — same concept,
 // same lifecycle rules (fresh per build; inherited by a full copy; preserved by compaction).
 // Upstream intends the GUID for exactly this job ("Generation + GraphGUID protect against
-// stale UID aliasing", BRepGraphInc_Storage.hxx:1597). We cannot read it, on three counts —
-// each measured against the pinned 8.0.0p1 kernel, not assumed:
-//   1. myGraphGUID is default-constructed and only ever populated by BRepGraph::Clear()
-//      (BRepGraph.cxx: SetGraphGUID(generateRandomGUID()) — still true on upstream master
-//      as of 2026-07). Our build path is ctor + Shapes().Add(), which skips Clear(), so
-//      every graph reports the all-zero GUID and no two graphs differ. Upstream's own
-//      GTests do `myGraph.Clear(); myGraph.Shapes().Add(box);` — Clear() is their intended
-//      rebuild boundary (PR #1237), and their GraphGUID_AfterBuild_IsValid test only
-//      passes because the fixture calls it. So this one is our gap, not upstream's — see
-//      issue #303 about adopting the Clear()-then-Add lifecycle. It does not change
-//      the analysis below, which is why that follow-up cannot replace this id.
-//   2. Even populated it would not fix this bug. BRepGraph_UID is (Kind, Counter) and
-//      carries no GUID, so UIDsView::NodeIdFrom cannot consult one — two Clear()ed
-//      graphs with distinct GUIDs still cross-resolve each other's UIDs. The check has
-//      to live where the UID does, which is above the kernel. For the same reason
-//      UIDsView::IsStale accepts a foreign VersionStamp: a stamp carries Generation
-//      (equal across graphs), not the GUID.
-//   3. BRepGraph_Copy::Perform overwrites the target's GUID with the source's, so a
-//      CopyFace graph — one face out of many — would inherit the source's identity and
-//      alias straight back to a wrong node.
-// None of GraphGUID/StampOf/IsStale/ToGUID is currently wrapped, so no Swift caller can
-// reach the broken behaviour; if we ever wrap them, note that ToGUID's documented
-// "globally unique across different graph instances" is false on the no-Clear() path —
-// it hashes in the all-zero GUID and returns identical GUIDs for different graphs.
+// stale UID aliasing", BRepGraphInc_Storage.hxx:1597). Since #303 our construction paths call
+// BRepGraph::Clear() (Clear() is upstream's declared rebuild boundary, PR #1237), so the GUID
+// is now populated and its lifecycle matches this id one-for-one — measured against the pinned
+// 8.0.0p1 kernel, not assumed: Create/CopyFace mint a fresh GUID, Copy/Transform inherit the
+// source's via Perform. We still do not surface it as the UID's graphID, on two counts:
+//   1. It would not fix this bug. BRepGraph_UID is (Kind, Counter) and carries no GUID, so
+//      UIDsView::NodeIdFrom cannot consult one — two Clear()ed graphs with distinct GUIDs
+//      still cross-resolve each other's UIDs. The provenance check has to live where the UID
+//      does, which is above the kernel. For the same reason UIDsView::IsStale accepts a
+//      foreign VersionStamp: a stamp carries Generation (equal across graphs), not the GUID.
+//   2. Folding a 128-bit GUID into this uint64 id would reintroduce the collision risk the
+//      random-seeded counter already avoids, and would couple our provenance check to OCCT's
+//      GUID lifecycle staying stable across kernel upgrades (BRepGraph is actively developed
+//      upstream). The counter is exact in-process and needs no such guarantee.
+// A caveat worth pinning for whoever wraps GraphGUID/StampOf/IsStale/ToGUID next: pre-#303 the
+// GUID was the all-zero default (ctor + Shapes().Add() skips Clear()), which made ToGUID's
+// documented "globally unique across different graph instances" false — it hashed in the zero
+// GUID and returned identical GUIDs for different graphs. Clear() is what fixes that, so any
+// such wrapper must not regress the Clear()-then-build lifecycle these entry points now follow.
 static uint64_t nextGraphInstanceID() {
     static std::atomic<uint64_t> counter{[] {
         std::random_device rd;
@@ -222,6 +217,14 @@ OCCTBRepGraphRef OCCTBRepGraphCreate(OCCTShapeRef shape, bool parallel) {
     if (!shape) return nullptr;
     try {
         auto ref = new OCCTBRepGraph();
+        // Clear() before the first Add() is upstream's declared rebuild boundary (PR #1237):
+        // it is the only call that stamps the graph's identity — IncrementGeneration() +
+        // SetGraphGUID(random) — so skipping it left every graph at generation 0 / all-zero
+        // GUID (#303). On a freshly-constructed graph Clear() only stamps identity and empties
+        // already-empty storage; the BRepGraph_LayerHistory layer the ctor registers survives
+        // it (LayerRegistry::ClearAll is documented "without unregistering services", and
+        // ground-truth-verified: history recording still works post-Clear on the pinned kernel).
+        ref->graph.Clear();
         // OCCT 8.0.0p1 removed BRepGraph_Builder; shape ingestion is now BRepGraph::ShapesView::Add().
         BRepGraph::ShapesView::Options opts;
         opts.Parallel = parallel;
@@ -1352,6 +1355,9 @@ OCCTBRepGraphRef OCCTBRepGraphCopy(OCCTBRepGraphRef g, bool copyGeom) {
     if (!g) return nullptr;
     try {
         auto ref = new OCCTBRepGraph();
+        // No Clear() here (unlike Create/CopyFace): Perform transplants the source's whole
+        // identity — generation and GraphGUID included — into the fresh target, so a pre-Clear
+        // would just be overwritten. That inheritance is exactly what we want (see below).
         // OCCT 8.0.0p1: Perform now copies source INTO a target graph and returns bool.
         auto geomPolicy = copyGeom ? BRepGraph_Copy::GeomPolicy::Copy : BRepGraph_Copy::GeomPolicy::Share;
         if (!BRepGraph_Copy::Perform(g->graph, ref->graph, geomPolicy)) { delete ref; return nullptr; }
@@ -1370,6 +1376,13 @@ OCCTBRepGraphRef OCCTBRepGraphCopyFace(OCCTBRepGraphRef g, int32_t faceIndex, bo
     if (!g) return nullptr;
     try {
         auto ref = new OCCTBRepGraph();
+        // copyFace is a fresh build, not a copy: CopyNode lifts one node into an empty graph with
+        // counters restarting at 1 (that is #295's whole point). So it gets a fresh identity like
+        // Create — Clear() stamps a new generation + GUID. CopyNode does NOT transplant the source
+        // GUID (measured on 8.0.0p1: a no-Clear CopyNode target stays generation 0 / all-zero;
+        // only Copy/Transform's Perform transplants), so the fresh GUID survives the CopyNode below
+        // and matches this graph's fresh, non-inherited instanceID (#303).
+        ref->graph.Clear();
         // OCCT 8.0.0p1: CopyNode copies into a target graph and returns the mapped node id.
         auto geomPolicy = copyGeom ? BRepGraph_Copy::GeomPolicy::Copy : BRepGraph_Copy::GeomPolicy::Share;
         auto mapped = BRepGraph_Copy::CopyNode(
@@ -1395,6 +1408,8 @@ OCCTBRepGraphRef OCCTBRepGraphTransformTranslation(OCCTBRepGraphRef g,
         gp_Trsf trsf;
         trsf.SetTranslation(gp_Vec(dx, dy, dz));
         auto ref = new OCCTBRepGraph();
+        // No Clear() here, same as OCCTBRepGraphCopy: Transform::Perform transplants the source's
+        // identity (generation + GraphGUID) into the target, so the placed graph inherits it.
         // OCCT 8.0.0p1: Perform now transforms source INTO a target graph and returns bool.
         auto geomPolicy = copyGeom ? BRepGraph_Copy::GeomPolicy::Copy : BRepGraph_Copy::GeomPolicy::Share;
         if (!BRepGraph_Transform::Perform(g->graph, ref->graph, trsf, geomPolicy)) { delete ref; return nullptr; }

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -2332,13 +2332,14 @@ public final class TopologyGraph: @unchecked Sendable {
         OCCTBRepGraphInstanceID(handle)
     }
 
-    /// The graph generation counter — **always 0**.
+    /// The graph generation counter — **always 1**.
     ///
-    /// OCCT advances this only from `BRepGraph::Clear()`, which nothing in OCCTSwift calls, so it
-    /// never changes and cannot tell two graphs apart or detect a stale cache. Nothing replaces it:
-    /// ``node(forUID:)`` already rejects a UID from another graph, and ``instanceID`` compares graph
-    /// identity directly (#295).
-    @available(*, deprecated, message: "Always 0 — OCCTSwift never clears a graph, so this counter never advances and guards nothing. node(forUID:) rejects foreign UIDs on its own; use instanceID to compare graph identity.")
+    /// OCCT advances this only from `BRepGraph::Clear()`. OCCTSwift calls `Clear()` exactly once,
+    /// when it builds the graph (#303), and never rebuilds an existing one — so the counter lands
+    /// at 1 and stays there. It is the same 1 for every graph, so it still cannot tell two graphs
+    /// apart or detect a stale cache. Nothing replaces it: ``node(forUID:)`` already rejects a UID
+    /// from another graph, and ``instanceID`` compares graph identity directly (#295).
+    @available(*, deprecated, message: "Always 1 — OCCTSwift clears a graph once at build and never rebuilds it, so this counter never advances past 1 and is identical for every graph. node(forUID:) rejects foreign UIDs on its own; use instanceID to compare graph identity.")
     public var generation: UInt32 {
         OCCTBRepGraphGeneration(handle)
     }

--- a/Tests/OCCTTopologyGraphTests/OCCTTopologyGraphTests.swift
+++ b/Tests/OCCTTopologyGraphTests/OCCTTopologyGraphTests.swift
@@ -2550,20 +2550,26 @@ struct TopologyGraphDurableUIDTests {
         }
     }
 
-    /// `generation` is deprecated because it is a constant 0, not a counter: OCCT only advances it
-    /// from `BRepGraph::Clear()`, which OCCTSwift never calls. Pinned so the deprecation note stays
-    /// honest — if a future OCCT or bridge change ever makes it move, this fails and the docs and
-    /// the `@available` message have to be revisited (#295).
+    /// `generation` is deprecated because it is a constant, not a counter: OCCT only advances it
+    /// from `BRepGraph::Clear()`, which OCCTSwift calls exactly once at build (#303) and never
+    /// again — so every graph reports 1, and compaction (which preserves identity) leaves it 1.
+    /// Pinned so the deprecation note stays honest — if a future OCCT or bridge change ever makes
+    /// it move past 1, this fails and the docs and the `@available` message have to be revisited
+    /// (#295, #303).
     @available(*, deprecated, message: "Exercises the deprecated `generation` on purpose.")
-    @Test func generationIsAlwaysZero() {
+    @Test func generationIsAlwaysOne() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let graph = TopologyGraph(shape: box) else { return }
-        #expect(graph.generation == 0)
+        #expect(graph.generation == 1)          // Clear()-at-build stamps generation 1 (#303)
         graph.compact()
-        #expect(graph.generation == 0)
+        #expect(graph.generation == 1)          // compaction preserves identity
         if let other = TopologyGraph(shape: box) {
-            #expect(other.generation == 0)      // a second graph: same 0, hence useless as identity
+            #expect(other.generation == 1)      // a second graph: same 1, hence useless as identity
             #expect(other.instanceID != graph.instanceID)
+        }
+        // copyFace is a fresh build, so it too is stamped 1 (its instanceID is fresh — #295).
+        if let copied = graph.copyFace(0) {
+            #expect(copied.generation == 1)
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,47 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.12.1
+## Current: v1.12.2
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
 
 ---
 
 ## Release History
+
+### v1.12.2 (July 2026) — fix: graph construction now runs OCCT's `Clear()` rebuild boundary (#303)
+
+**Every graph OCCTSwift built reported `generation == 0` and an all-zero `GraphGUID`.** The bridge
+built a graph with the constructor plus `Shapes().Add(shape)`, and never called `BRepGraph::Clear()`
+— which upstream treats as *the* rebuild boundary (PR #1237) and is the only call that stamps a
+graph's identity (`IncrementGeneration()` + `SetGraphGUID(random)`). Skipping it left the kernel's
+own version-stamp machinery unarmed on our path: `GraphGUID` stayed the default all-zeros, so
+`BRepGraph_VersionStamp::ToGUID` — documented as making per-node GUIDs *"globally unique across
+different graph instances"* — would have hashed in the zero GUID and returned identical GUIDs for
+different graphs. Nothing user-visible broke (none of `GraphGUID` / `StampOf` / `IsStale` / `ToGUID`
+is wrapped), but it was a live trap for whoever wraps that surface next.
+
+Surfaced while fixing #295, and verified independent of it: giving graphs real GUIDs does **not** stop
+a foreign UID resolving, because `BRepGraph_UID` is `(Kind, Counter)` and carries no GUID for
+`NodeIdFrom` to compare. #295's `instanceID` provenance check is still needed and unchanged.
+
+**Fix.** `OCCTBRepGraphCreate` and `OCCTBRepGraphCopyFace` now call `graph.Clear()` before ingesting
+the shape, matching upstream's declared lifecycle. `copy()` / `translated()` deliberately do not:
+`BRepGraph_Copy`/`_Transform::Perform` transplant the source's whole identity (generation + GUID)
+into the target, so a pre-`Clear()` would just be overwritten — the inheritance is what we want.
+`copyFace()` does get a `Clear()`: it is a fresh build with counters restarting at 1, and
+ground truth on the pinned 8.0.0p1 kernel confirms `CopyNode` does **not** transplant the source
+GUID, so the fresh stamp survives and matches the graph's fresh `instanceID`.
+
+**Verified safe first** (the issue's load-bearing unknown): `Clear()` calls
+`LayerRegistry::ClearAll()`, which the header documents as clearing layer data *"without
+unregistering services"* — so the `BRepGraph_LayerHistory` layer the constructor registers, which
+#290's `add(_:absorbing:…)` depends on, survives. Ground-truth-confirmed against the pinned kernel:
+after `Clear()`-then-`Add()`, the history layer is still registered and recording works; the #290
+history-absorb suite and the #295 provenance suite both stay green.
+
+- **Changed:** `TopologyGraph.generation` is now a constant **1** (was 0). Still deprecated and still
+  useless as identity — it is the same 1 for every graph. Use `instanceID` to compare graph identity.
 
 ### v1.12.1 (July 2026) — fix: concurrent 3D fillet/chamfer builds no longer corrupt each other (#298)
 

--- a/docs/reference/TopologyGraph-Editor-Identity.md
+++ b/docs/reference/TopologyGraph-Editor-Identity.md
@@ -994,14 +994,14 @@ Identity here is the graph object, not the geometry: two graphs built from the s
 
 ### `generation` *(deprecated)*
 
-**Always 0.** Deprecated in v1.12.0.
+**Always 1.** Deprecated in v1.12.0; value changed from 0 to 1 in v1.12.2.
 
 ```swift
 @available(*, deprecated)
 public var generation: UInt32 { get }
 ```
 
-OCCT advances this only from `BRepGraph::Clear()`, which nothing in OCCTSwift calls, so it never changes: it cannot tell two graphs apart, and it cannot detect a stale cache. Nothing replaces it — `node(forUID:)` rejects a UID from another graph on its own, and `instanceID` compares graph identity directly.
+OCCT advances this only from `BRepGraph::Clear()`. Since v1.12.2 ([#303](https://github.com/SecondMouseAU/OCCTSwift/issues/303)) OCCTSwift calls `Clear()` exactly once, when it builds a graph, and never rebuilds an existing one — so the counter lands at 1 and stays there. It is the same 1 for every graph, so it still cannot tell two graphs apart or detect a stale cache. Nothing replaces it — `node(forUID:)` rejects a UID from another graph on its own, and `instanceID` compares graph identity directly.
 
 Earlier revisions of this page suggested comparing a cached `storedOwnGen` against `generation` to detect a stale mesh. That recipe never worked and has been removed: `storedOwnGen` is a per-entity mesh field (`FaceMeshEntry::MeshGeneration`), not this counter, so the two were never comparable ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
 


### PR DESCRIPTION
Closes #303.

## Problem

`OCCTBRepGraphCreate` built a graph with the constructor + `Shapes().Add(shape)` and never called `BRepGraph::Clear()` — which upstream treats as *the* rebuild boundary (PR #1237) and is the only call that stamps a graph's identity (`IncrementGeneration()` + `SetGraphGUID(random)`). So every graph OCCTSwift built reported `generation == 0` and an all-zero `GraphGUID`, leaving the kernel's own version-stamp machinery unarmed on our path. Nothing user-visible broke (none of `GraphGUID`/`StampOf`/`IsStale`/`ToGUID` is wrapped), but it was a live trap for whoever wraps that surface next — `ToGUID`'s documented *"globally unique across different graph instances"* would have hashed in the zero GUID and returned identical GUIDs for different graphs.

Independent of #295, as that issue noted: real GUIDs do **not** stop a foreign UID resolving (`BRepGraph_UID` is `(Kind, Counter)` and carries no GUID). #295's `instanceID` provenance check stays needed and unchanged.

## Fix

`OCCTBRepGraphCreate` and `OCCTBRepGraphCopyFace` now call `graph.Clear()` before ingesting the shape.

| Path | `Clear()`? | Why |
|------|-----------|-----|
| `Create` | **yes** | fresh build → fresh identity |
| `copyFace()` | **yes** | fresh build (CopyNode restarts counters at 1) → fresh identity |
| `copy()` / `translated()` | no | `Perform` transplants the source's whole identity; a pre-`Clear()` would be overwritten, and the inheritance is what we want |

Ground truth on the pinned 8.0.0p1 kernel corrected the issue's premise: `CopyNode` does **not** transplant the source GUID (a no-`Clear()` CopyNode target stays generation 0 / all-zero — only `Copy`/`Transform`'s `Perform` transplants). So Clearing the copyFace target gives it a fresh, distinct GUID that survives `CopyNode` and matches its fresh `instanceID`. GraphGUID and `instanceID` now agree on identity across every path.

## Safety — the issue's load-bearing unknown

`Clear()` calls `LayerRegistry::ClearAll()`, which the pinned header documents as clearing layer data *"without unregistering services"* — so the `BRepGraph_LayerHistory` layer the constructor registers, which #290's `add(_:absorbing:…)` depends on, survives. Ground-truth-confirmed against the pinned kernel: after `Clear()`-then-`Add()` the history layer is still registered and recording works. The #290 history-absorb suite and the #295 provenance suite both stay green.

## Impact

- `TopologyGraph.generation` is now a constant **1** (was 0). Still deprecated, still identical for every graph → still useless as identity; use `instanceID`. Renamed `generationIsAlwaysZero` → `generationIsAlwaysOne`.
- No new/removed operations; op count unchanged.

## Verification

- `swift build` clean; `swift test --filter OCCTTopologyGraphTests` → **170/170 pass** (incl. #290 history-absorb + #295 provenance).
- Ground-truth C++ against `Libraries/OCCT.xcframework` (8.0.0p1): `Clear()`+`Add()` → generation 1, non-zero GUID, history layer registered + writable; two Cleared graphs get distinct GUIDs; `CopyNode` leaves a non-Cleared target at generation 0.

Docs: `docs/CHANGELOG.md` (v1.12.2), `docs/reference/TopologyGraph-Editor-Identity.md`, bridge/Swift `///` comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)