### PR TITLE
fix(#298): fix fillet reentrancy in the kernel; drop the serialization lock

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,14 +33,14 @@ let occtTarget: Target = useLocalBinary
         name: "OCCT",
         path: "Libraries/OCCT.xcframework"
     )
-    // v1.10.1 rebuild: OCCT 8.0.0p1 + our carried patches — 0001 (ShapeFix_Face guard, #263) and
-    // 0002 (backport of upstream OCCT#1334, #280). Bump BOTH url and checksum whenever the
-    // xcframework is rebuilt, or URL-resolving consumers silently keep the previous kernel while
-    // local sibling builds get the new one.
+    // v1.12.3 rebuild: OCCT 8.0.0p1 + our carried patches — 0001 (ShapeFix_Face guard, #263),
+    // 0002 (backport of upstream OCCT#1334, #280), and 0003 (fillet TopOpeBRep thread_local, #298).
+    // Bump BOTH url and checksum whenever the xcframework is rebuilt, or URL-resolving consumers
+    // silently keep the previous kernel while local sibling builds get the new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.10.1/OCCT.xcframework.zip",
-        checksum: "a1f816ea9b5308dafc9187933431b3f36793377ed7fa2567692305fac0255927"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.12.3/OCCT.xcframework.zip",
+        checksum: "9daee3da6f0655a927ee8deebfa1306b282f2f0da459b35383ef9c7de0555cc2"
     )
 
 let package = Package(

--- a/Scripts/patches/0003-TopOpeBRep-non-reentrant-globals-fillet-298.patch
+++ b/Scripts/patches/0003-TopOpeBRep-non-reentrant-globals-fillet-298.patch
@@ -1,0 +1,144 @@
+From: OCCTSwift ecosystem <noreply@secondmouse.au>
+Subject: [PATCH] Modeling - make BRepFilletAPI_MakeFillet reentrant across threads
+
+Two independent BRepFilletAPI_MakeFillet builds, on independent shapes, running on
+separate threads corrupt each other and produce a wrong-but-plausible solid that
+fails BRepCheck -- silent bad geometry, no crash and no thrown error. This violates
+OCCT's documented concurrency model ("algorithms on different threads in different
+contexts"). The cause is file-scope / function-local `static` state on the fillet
+path. ThreadSanitizer on an 8-thread fuse+fillet stress (V8_0_0_p1) pinpoints them.
+
+FUNCTIONAL (causes the geometry corruption):
+  * TopOpeBRepBuild_Builder.cxx  STATIC_SOLIDINDEX -- SplitSolid sets it to 1/2 to
+    tell FillSolid which operand it is splitting; FillSolid reads it back to pick the
+    operand shape. Concurrent solid reconstructions (ChFi3d_Builder::Compute ->
+    TopOpeBRepBuild_HBuilder::MergeSolid) interleave the writes and FillSolid
+    mis-classifies faces, dropping material. Fixing this one variable makes a stress
+    of 1600 concurrent fillet builds return correct geometry every time (was ~15-20%
+    corrupt).
+  * TopOpeBRep_kpart.cxx  STATIC_lastVPind -- same cross-call-cache pattern
+    ("the vp on which was computed the last CPI"), read back to index the VPoint
+    list; converted for the same reason.
+
+BENIGN DATA RACES on the same path (no geometry corruption observed, but still UB;
+converted so concurrent fillet is TSan-clean) -- the constant/evolutive-radius blend
+solvers' per-parameter scratch cache and the ChFi3d curve checker's reused adaptor:
+  * BlendFunc_ConstRad.cxx, BlendFunc_EvolRad.cxx  (ComputeValues scratch)
+  * ChFi3d_Builder_6.cxx  (checkcurve)
+
+All are converted to `static thread_local`, which preserves the exact single-thread
+behaviour (each thread keeps its own copy of the cross-call state) while making
+independent instances on separate threads reentrant. This is the same class of fix,
+in the same engine, as Open-Cascade-SAS/OCCT#1180 (19 TKBool globals -> thread_local
+across 8 files); STATIC_SOLIDINDEX and these were not covered by it.
+
+Reported downstream as OCCTSwift #298.
+
+diff --git a/src/ModelingAlgorithms/TKBool/TopOpeBRep/TopOpeBRep_kpart.cxx b/src/ModelingAlgorithms/TKBool/TopOpeBRep/TopOpeBRep_kpart.cxx
+index 94b16fba..fbe26283 100644
+--- a/src/ModelingAlgorithms/TKBool/TopOpeBRep/TopOpeBRep_kpart.cxx
++++ b/src/ModelingAlgorithms/TKBool/TopOpeBRep/TopOpeBRep_kpart.cxx
+@@ -38,7 +38,13 @@ extern bool TopOpeBRep_GetcontextNEWKP();
+ 
+ // VP<STATIC_lastVPind> is the vp on which was computed the last CPI.
+ // if no CPI is computed yet, <STATIC_lastVPind> = 0.
+-static int STATIC_lastVPind;
++// #298: `thread_local` (was plain `static`). This carries the "last VPoint index"
++// across calls and is read back to index the VPoint list — per-thread cross-call
++// state. Plain `static` shared it across threads, so concurrent intersections
++// (reachable from concurrent fillets via the TopOpeBRep engine) could read another
++// thread's index. Same functional non-reentrant-global class as STATIC_SOLIDINDEX;
++// fixed defensively (the audit found it, though the #298 repro exercised SOLIDINDEX).
++static thread_local int STATIC_lastVPind;
+ 
+ #define M_FORWARD(st) (st == TopAbs_FORWARD)
+ #define M_REVERSED(st) (st == TopAbs_REVERSED)
+diff --git a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder.cxx b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder.cxx
+index d866d860..55a7b5b6 100644
+--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder.cxx
++++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder.cxx
+@@ -70,7 +70,15 @@ Standard_EXPORT void debspf(const int i)
+ }
+ #endif
+ 
+-static int STATIC_SOLIDINDEX = 0;
++// #298: `thread_local` (was plain `static`). SplitSolid sets this to 1/2 to tell
++// FillSolid which of the two operands it is currently splitting, and FillSolid
++// reads it back. Plain `static` shared that mode flag across threads, so two
++// concurrent solid reconstructions (e.g. two independent fillets, whose
++// ChFi3d_Builder::Compute reconstructs via TopOpeBRepBuild::MergeSolid) clobbered
++// each other's index and mis-classified faces — silent wrong geometry, no crash.
++// Per-thread storage keeps the single-thread flow identical. Matches the TKBool
++// thread_local conversions already landed for this engine.
++static thread_local int STATIC_SOLIDINDEX = 0;
+ 
+ //=================================================================================================
+ 
+diff --git a/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_ConstRad.cxx b/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_ConstRad.cxx
+index 9b099dbc..5bff8677 100644
+--- a/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_ConstRad.cxx
++++ b/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_ConstRad.cxx
+@@ -138,12 +138,15 @@ bool BlendFunc_ConstRad::ComputeValues(const math_Vector& X,
+                                        const bool         byParam,
+                                        const double       Param)
+ {
+-  // static declaration to avoid systematic reallocation
+-
+-  static gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
+-  static gp_Vec d1gui, d2gui, d3gui;
+-  static gp_Pnt ptgui;
+-  static double invnormtg, dinvnormtg;
++  // These persist across calls as a per-parameter cache (the t_OK / myX_OK guards
++  // below skip recomputation when T / X are unchanged and read them back), so they
++  // cannot be made function-local. Plain `static` shared that cache across threads,
++  // so concurrent fillet builds raced on it. `thread_local` keeps the caching while
++  // giving each thread its own copy. (#298 — matches the TKBool thread_local work.)
++  static thread_local gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
++  static thread_local gp_Vec d1gui, d2gui, d3gui;
++  static thread_local gp_Pnt ptgui;
++  static thread_local double invnormtg, dinvnormtg;
+   double        T = Param, aux;
+ 
+   // Case of implicite parameter
+diff --git a/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_EvolRad.cxx b/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_EvolRad.cxx
+index faf25679..312350ab 100644
+--- a/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_EvolRad.cxx
++++ b/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_EvolRad.cxx
+@@ -196,12 +196,15 @@ bool BlendFunc_EvolRad::ComputeValues(const math_Vector& X,
+                                       const bool         byParam,
+                                       const double       Param)
+ {
+-  // static declaration to avoid systematic realloc
+-
+-  static gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
+-  static gp_Vec d1gui, d2gui, d3gui;
+-  static gp_Pnt ptgui;
+-  static double invnormtg, dinvnormtg;
++  // These persist across calls as a per-parameter cache (the t_OK / myX_OK guards
++  // below skip recomputation when T / X are unchanged and read them back), so they
++  // cannot be made function-local. Plain `static` shared that cache across threads,
++  // so concurrent fillet builds raced on it. `thread_local` keeps the caching while
++  // giving each thread its own copy. (#298 — matches the TKBool thread_local work.)
++  static thread_local gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
++  static thread_local gp_Vec d1gui, d2gui, d3gui;
++  static thread_local gp_Pnt ptgui;
++  static thread_local double invnormtg, dinvnormtg;
+   double        T = Param, aux;
+ 
+   // Case of implicit parameter
+diff --git a/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx b/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
+index b4d23e9a..106ff49d 100644
+--- a/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
++++ b/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
+@@ -641,7 +641,10 @@ bool ChFi3d_Builder::StoreData(occ::handle<ChFiDS_SurfData>&         Data,
+                                const bool                            Reversed)
+ {
+   // Small control tools.
+-  static occ::handle<GeomAdaptor_Curve> checkcurve;
++  // #298: `thread_local` (was plain `static`) — reused scratch adaptor shared across
++  // calls; plain `static` shared it across threads, racing concurrent fillet builds.
++  // Per-thread lazy allocation keeps the reuse while making it reentrant.
++  static thread_local occ::handle<GeomAdaptor_Curve> checkcurve;
+   if (checkcurve.IsNull())
+   {
+     checkcurve = new GeomAdaptor_Curve();

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -73,3 +73,22 @@ long-standing `cone()` failure in `StressFormatRoundTripTests`, which passed in 
 every full run because `OCCTIOTests` reads a STEP first.
 
 **Retire** once the bundled OCCT moves past upstream `e2de4398ca6bf034074e6921599da76a9941c792`.
+
+## 0003-TopOpeBRep-non-reentrant-globals-fillet-298.patch
+
+**Fixes the upstream OCCT thread-safety defect behind [#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298)** — concurrent `BRepFilletAPI_MakeFillet` builds on independent shapes corrupt each other.
+
+`BRepFilletAPI_MakeFillet` reconstructs its result solid through the legacy `TopOpeBRepBuild` boolean engine (`ChFi3d_Builder::Compute` → `TopOpeBRepBuild_HBuilder::MergeSolid` → `TopOpeBRepBuild_Builder::SplitSolid`), which passes state between methods through **file-scope `static` variables**. That makes it non-reentrant: two fillet builds on separate threads produce a wrong-but-plausible solid that fails `BRepCheck` — silent bad geometry, no crash, no thrown error.
+
+ThreadSanitizer on an 8-thread fuse+fillet stress (V8_0_0_p1) pinpoints the **functional** culprit as `STATIC_SOLIDINDEX` in `TopOpeBRepBuild_Builder.cxx`: `SplitSolid` sets it to 1/2 to tell `FillSolid` which operand it is splitting, and `FillSolid` reads it back to pick the operand shape. Concurrent reconstructions interleave the writes, so `FillSolid` mis-classifies faces and drops material (the ~260-unit volume loss in the repro). Fixing that one variable makes a stress of 1600 concurrent fillet builds return correct geometry every time (was ~15–20% corrupt).
+
+The patch converts the fillet-path shared statics to `static thread_local` (each thread keeps its own copy of the cross-call state; single-thread behaviour is unchanged):
+
+- **Functional** (cause the corruption): `STATIC_SOLIDINDEX` (`TopOpeBRepBuild_Builder.cxx`) and `STATIC_lastVPind` (`TopOpeBRep_kpart.cxx`, same cross-call-cache pattern, converted for the same reason).
+- **Benign data races** on the same path (no geometry corruption observed — `STATIC_SOLIDINDEX` alone already gives correct geometry — but still UB; converted so concurrent fillet is TSan-clean): the constant/evolutive-radius blend solvers' scratch cache (`BlendFunc_ConstRad.cxx`, `BlendFunc_EvolRad.cxx`) and the ChFi3d curve checker's reused adaptor (`ChFi3d_Builder_6.cxx`).
+
+This is the same class of fix, in the same engine, as [Open-Cascade-SAS/OCCT#1180](https://github.com/Open-Cascade-SAS/OCCT/pull/1180) (19 TKBool globals → `thread_local` across 8 files); `STATIC_SOLIDINDEX` and these were not covered by it.
+
+**Validation:** the isolated pure-C++ repro (`fuse` two/three prisms → fillet the seam, 8 threads) returns BRepCheck-invalid solids across several wrong volumes on stock p1, and 0/1600 invalid with a single correct volume after the patch. ThreadSanitizer reports the `STATIC_SOLIDINDEX` and `BlendFunc` scratch races on stock p1 and is clean on the fillet path after the patch (only an unrelated benign `BOPAlgo_InitMessages` lazy-init race remains, in the boolean path — orthogonal). While this patch is carried, the in-wrapper `occtFilletMutex` shipped in v1.12.1 serialises fillet/chamfer builds so the corruption cannot reach consumers.
+
+**Retire** once the bundled OCCT includes these `thread_local` conversions (upstream PR pending), at which point the `occtFilletMutex` guard can also be dropped.

--- a/Sources/OCCTBridge/src/OCCTBridge.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge.mm
@@ -19,13 +19,6 @@ std::recursive_mutex& occtGlobalMutex() {
 void OCCTSerialLockAcquire(void) { occtGlobalMutex().lock(); }
 void OCCTSerialLockRelease(void) { occtGlobalMutex().unlock(); }
 
-// #298: serialises 3D fillet/chamfer builds against each other (non-reentrant
-// blend statics in OCCT's TKFillet). See OCCTBridge_Internal.h for the full why.
-std::recursive_mutex& occtFilletMutex() {
-    static std::recursive_mutex mutex;
-    return mutex;
-}
-
 // Install OCCT's signal handlers once (issue #175). OSD::SetSignal(false) installs
 // SIGSEGV/SIGBUS/SIGFPE handlers without enabling the FPE-trapping FP mask, so that
 // signals raised inside OCCT become catchable via OCC_CATCH_SIGNALS instead of aborting

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -436,7 +436,6 @@ OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
         TopoDS_Edge edge = TopoDS::Edge(edgeMap(edgeIndex + 1));  // OCCT uses 1-based indexing
 
         // Create fillet maker
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Add edge with variable radius
@@ -668,7 +667,6 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
         // Create fillet maker
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Add each edge with its radius

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -186,28 +186,10 @@ struct OCCTHistoryStorage {
 
 std::recursive_mutex& occtGlobalMutex();
 std::mutex& igesMutex();
-
-// #298: 3D fillet/chamfer serialization lock.
-//
-// BRepFilletAPI_MakeFillet's constant- and evolutive-radius blend solvers
-// (BlendFunc_ConstRad / BlendFunc_EvolRad) and the shared ChFi3d_Builder curve
-// checker keep their geometric work variables in function-local `static`s ("to
-// avoid systematic reallocation"). That makes the blend evaluation NON-REENTRANT:
-// two threads filleting at once interleave writes to the same statics, the solver
-// converges on a corrupted surface, and the result is a wrong-but-plausible solid
-// that fails BRepCheck — silent bad geometry, not a crash or a thrown error.
-// Reproduced in pure OCCT with no wrapper involved (issue #298).
-//
-// Hold this lock around every 3D fillet/chamfer Build(). It is DISTINCT from
-// occtGlobalMutex(): booleans, meshing, and everything else stay fully parallel —
-// only fillet/chamfer builds serialise against each other. Recursive so a fillet
-// wrapper that nests another cannot self-deadlock. 2D fillets
-// (BRepFilletAPI_MakeFillet2d) use the separate analytic ChFi2d toolkit with no
-// such statics and are intentionally NOT guarded.
-//
-// This is a mitigation. The real fix de-statics those OCCT work variables
-// (Scripts/patches/0003) so the lock can be dropped. See docs/thread-safety.md.
-std::recursive_mutex& occtFilletMutex();
+// #298: the fillet/chamfer serialization lock (occtFilletMutex) was removed in
+// v1.12.3 — the underlying OCCT non-reentrancy (STATIC_SOLIDINDEX and the blend
+// scratch) is now fixed in the pinned kernel via Scripts/patches/0003, so 3D
+// fillet/chamfer builds are reentrant and no longer need serialising.
 
 // === OCCT signal handling ===
 //

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -321,7 +321,6 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
     if (!shape || !edgeIndices || edgeCount <= 0 || radius <= 0) return nullptr;
 
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Build edge index map for lookup
@@ -351,7 +350,6 @@ OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeI
     if (startRadius <= 0 || endRadius <= 0) return nullptr;
 
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Build edge index map for lookup
@@ -1223,7 +1221,6 @@ OCCTShapeRef OCCTShapeChamferTwoDistances(OCCTShapeRef shape,
                                            int32_t count) {
     if (!shape || !edgeIndices || !faceIndices || !dist1 || !dist2 || count <= 0) return nullptr;
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeChamfer chamfer(shape->shape);
         TopTools_IndexedMapOfShape edgeMap, faceMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
@@ -1254,7 +1251,6 @@ OCCTShapeRef OCCTShapeChamferDistAngle(OCCTShapeRef shape,
                                         int32_t count) {
     if (!shape || !edgeIndices || !faceIndices || !distances || !anglesDeg || count <= 0) return nullptr;
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeChamfer chamfer(shape->shape);
         TopTools_IndexedMapOfShape edgeMap, faceMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
@@ -1880,7 +1876,6 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdges(OCCTShapeRef shape,
     try {
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
         for (int32_t i = 0; i < count; i++) {
             int32_t idx = edgeIndices[i] + 1; // 0-based to 1-based
@@ -1908,7 +1903,6 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdgeVariable(OCCTShapeRef shape,
         int32_t idx = edgeIndex + 1;
         if (idx < 1 || idx > edgeMap.Extent()) return nullptr;
         TopoDS_Edge edge = TopoDS::Edge(edgeMap(idx));
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
         op->Add(edge);
         // Map the variable radius along the edge: (param=0, startR), (param=1, endR).
@@ -1934,7 +1928,6 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromChamferEdges(OCCTShapeRef shape,
     try {
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         std::unique_ptr<BRepFilletAPI_MakeChamfer> op(new BRepFilletAPI_MakeChamfer(shape->shape));
         for (int32_t i = 0; i < count; i++) {
             int32_t idx = edgeIndices[i] + 1;
@@ -2353,7 +2346,6 @@ OCCTShapeRef OCCTShapeFuseAndBlend(OCCTShapeRef shape1, OCCTShapeRef shape2, dou
         const TopTools_ListOfShape& sectionEdges = fuse.SectionEdges();
 
         // Step 3: Fillet those edges
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(fuseResult);
         // Add section edges
         for (TopTools_ListIteratorOfListOfShape it(sectionEdges); it.More(); it.Next()) {
@@ -2409,7 +2401,6 @@ OCCTShapeRef OCCTShapeCutAndBlend(OCCTShapeRef shape1, OCCTShapeRef shape2, doub
         }
 
         // Step 2: Fillet
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(cutResult);
         for (TopTools_ListIteratorOfListOfShape it(sectionEdges); it.More(); it.Next()) {
             if (it.Value().ShapeType() == TopAbs_EDGE) {
@@ -2443,7 +2434,6 @@ OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         int rpOffset = 0;
@@ -8375,7 +8365,6 @@ bool OCCTFilletBuilderAddEdgeEvolving(OCCTFilletBuilderRef builder, OCCTEdgeRef 
 OCCTShapeRef OCCTFilletBuilderBuild(OCCTFilletBuilderRef builder) {
     if (!builder) return nullptr;
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         builder->fillet.Build();
         if (!builder->fillet.IsDone()) return nullptr;
         return new OCCTShape(builder->fillet.Shape());
@@ -8481,7 +8470,6 @@ bool OCCTChamferBuilderAddEdgeDistAngle(OCCTChamferBuilderRef builder,
 OCCTShapeRef OCCTChamferBuilderBuild(OCCTChamferBuilderRef builder) {
     if (!builder) return nullptr;
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         builder->chamfer.Build();
         if (!builder->chamfer.IsDone()) return nullptr;
         return new OCCTShape(builder->chamfer.Shape());
@@ -10067,7 +10055,6 @@ int32_t OCCTShapeSelfIntersectsBounded(OCCTShapeRef shape, double timeoutSeconds
 OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius) {
     if (!shape) return nullptr;
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
         // Add fillet to all edges
@@ -10088,7 +10075,6 @@ OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius) {
 OCCTShapeRef OCCTShapeChamfer(OCCTShapeRef shape, double distance) {
     if (!shape) return nullptr;
     try {
-        std::lock_guard<std::recursive_mutex> _filletLock(occtFilletMutex());  // #298
         BRepFilletAPI_MakeChamfer chamfer(shape->shape);
 
         // Add chamfer to all edges

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,23 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.12.2
+## Current: v1.12.3
 
-**macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263 ShapeFix kernel patch)**
+**macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.12.3 (July 2026) — fix: concurrent fillet/chamfer fixed in the kernel; serialization lock removed (#298)
+
+**The real fix for #298 lands in the pinned OCCT, and the interim bridge lock is gone — concurrent fillet/chamfer run in parallel again.** v1.12.1 stopped the corruption by serialising every 3D fillet/chamfer build behind a bridge mutex (`occtFilletMutex`); that was correct but cost the parallelism. This release fixes the root cause in the kernel and drops the lock.
+
+**Root cause (found with ThreadSanitizer).** `BRepFilletAPI_MakeFillet` reconstructs its result solid through OCCT's legacy `TopOpeBRepBuild` boolean engine (`ChFi3d_Builder::Compute` → `TopOpeBRepBuild_HBuilder::MergeSolid` → `TopOpeBRepBuild_Builder::SplitSolid`), which passed state between methods through a file-scope `static`, `STATIC_SOLIDINDEX`: `SplitSolid` sets it to 1/2 to tell `FillSolid` which operand it is splitting, and `FillSolid` reads it back to pick the operand shape. Two fillet builds on independent shapes on separate threads clobbered each other's flag, so `FillSolid` mis-classified faces and returned a wrong-but-plausible solid (one solid, positive volume, fails `BRepCheck`). This is *not* the `BlendFunc` scratch the v1.12.1 notes first suspected — those statics do race, but benignly; `STATIC_SOLIDINDEX` alone accounts for the corruption.
+
+**Fix.** `Scripts/patches/0003-TopOpeBRep-non-reentrant-globals-fillet-298.patch` converts the fillet-path statics to `thread_local` (each thread keeps its own copy; single-thread behaviour is unchanged): `STATIC_SOLIDINDEX` and `STATIC_lastVPind` (functional), plus the `BlendFunc_ConstRad`/`EvolRad` and `ChFi3d_Builder` `checkcurve` scratch (benign, converted so the path is TSan-clean). The xcframework was rebuilt with the patch, so the kernel is reentrant and the `occtFilletMutex` guard (16 bridge call sites) was removed. Upstreamed as [Open-Cascade-SAS/OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374); the carried patch is retired once it ships in the pinned kernel.
+
+**Verification.** Pure-C++ 8-thread stress: 0/1600 concurrent fillet builds invalid with a single correct volume (was ~15–20% corrupt), and ThreadSanitizer reports the fillet path clean. `Issue298FilletThreadSafetyTests` now passes with the lock removed. **Binary release** — the xcframework changed, so `Package.swift` picks up the new URL + checksum; remote SPM consumers get the rebuilt binary.
 
 ### v1.12.2 (July 2026) — fix: graph construction now runs OCCT's `Clear()` rebuild boundary (#303)
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -21,13 +21,13 @@ OCCT has several thread-unsafe patterns:
 
 4. **Shared geometry after booleans** — Boolean operations can produce result shapes that share edge/face geometry with input shapes via the same `TopoDS_TShape` handles. Subsequent operations on both the original and result can race on shared adaptors.
 
-5. **Non-reentrant statics in the 3D fillet/chamfer solver (issue #298)** — `BRepFilletAPI_MakeFillet`'s constant- and evolutive-radius blend functions (`BlendFunc_ConstRad`, `BlendFunc_EvolRad`) and the shared `ChFi3d_Builder` curve checker keep their geometric work variables in function-local `static`s ("to avoid systematic reallocation"). This is **process-global** state, not per-object: two threads running *any two* fillet/chamfer builds at once — even on completely independent shapes — interleave writes to the same statics. The solver then converges on a corrupted surface and returns a **wrong-but-plausible solid** (one solid, positive volume) that fails `BRepCheck` — silent bad geometry, not a crash and not a thrown error. This is distinct from items 1–4: no geometry is shared at the Swift level, yet the operation still races. Reproduced in pure OCCT with no wrapper involved. The bridge now serialises these builds internally (see below), so consumers are protected transparently.
+5. **Non-reentrant statics in the fillet solid-reconstruction (issue #298) — fixed in v1.12.3.** `BRepFilletAPI_MakeFillet` reconstructs its result solid through OCCT's legacy `TopOpeBRepBuild` boolean engine (`ChFi3d_Builder::Compute` → `TopOpeBRepBuild_HBuilder::MergeSolid` → `TopOpeBRepBuild_Builder::SplitSolid`), which passed state between methods through file-scope `static` variables. The functional culprit is `STATIC_SOLIDINDEX`: `SplitSolid` sets it to 1/2 to tell `FillSolid` which operand it is splitting, and `FillSolid` reads it back to pick the operand shape. That made the whole fillet/chamfer path **non-reentrant**: two builds on *independent* shapes on separate threads clobbered each other's flag, so `FillSolid` mis-classified faces and returned a **wrong-but-plausible solid** (one solid, positive volume, but fails `BRepCheck`) — silent bad geometry, not a crash. Distinct from items 1–4: no geometry is shared at the Swift level, yet the operation raced on a process-global. ThreadSanitizer on a concurrent fuse+fillet stress pinpointed it (the blend solver's scratch caches — `BlendFunc_ConstRad`/`EvolRad`, `ChFi3d_Builder` `checkcurve` — also raced, but benignly: `STATIC_SOLIDINDEX` alone accounts for the corruption). **Fixed** by converting the fillet-path statics to `thread_local` (carried as `Scripts/patches/0003`, upstreamed as [Open-Cascade-SAS/OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)); the pinned xcframework now includes the fix, so fillet/chamfer are genuinely reentrant and the interim `occtFilletMutex` serialization shipped in v1.12.1 has been **removed** — concurrent fillet/chamfer builds run in parallel again.
 
 ## What IS Thread-Safe
 
 - **Handle reference counting** (`occ::handle<T>`) — atomic `std::atomic_int` refcount
 - **Reading shape topology** — immutable once built
-- **Completely independent shapes** — shapes with no shared TShapes or geometry handles — **with one exception:** 3D fillet and chamfer builds are not safe to run concurrently even on independent shapes, because of the process-global statics in item 5. The bridge serialises them for you (see [3D fillet/chamfer serialization](#3d-filletchamfer-serialization-issue-298)); you get correct geometry, just no parallel speedup on those specific ops.
+- **Completely independent shapes** — shapes with no shared TShapes or geometry handles. This now includes 3D fillet and chamfer: the process-global statics that made them unsafe (item 5) were fixed in v1.12.3, so concurrent fillet/chamfer builds on independent shapes are safe again — and parallel (no longer serialised).
 - **OCCT's internal parallel algorithms** — `BOPAlgo_*` with `SetRunParallel(true)`, `BRepCheck_Analyzer` with `SetParallel(true)`, `BRepMesh_IncrementalMesh`
 
 ## The Solution
@@ -66,8 +66,8 @@ let original = Shape.box(width: 10, height: 10, depth: 10)!
 let copies = (0..<4).map { _ in original.deepCopy()! }
 
 // Process each copy on a different thread. Independence protects against the
-// shared-geometry races (items 1–4); the `filleted` call is *additionally* safe
-// because the bridge serialises fillet builds internally (item 5, issue #298).
+// shared-geometry races (items 1–4); the `filleted` call is safe because the
+// fillet path is reentrant as of v1.12.3 (item 5, issue #298).
 DispatchQueue.concurrentPerform(iterations: 4) { i in
     let result = copies[i].filleted(radius: Double(i + 1))
     // Use result...
@@ -85,31 +85,28 @@ defer { OCCTSerial.unlock() }
 // Multiple OCCT operations that must be atomic
 ```
 
-### 3D fillet/chamfer serialization (issue #298)
+### 3D fillet/chamfer thread safety (issue #298)
 
-The problem in item 5 above cannot be solved by `deepCopy()` or by the caller
-holding `OCCTSerial` — the racing state lives in OCCT's own function-local
-statics, not in any shape the caller can see or copy. So the bridge serialises it
-at the source: **every 3D fillet and chamfer build runs under a dedicated
-recursive mutex** (`occtFilletMutex` in the C bridge), separate from `OCCTSerial`.
+Fillet and chamfer are **safe to call concurrently on independent shapes**, with no
+lock on your side and no `deepCopy()` required — `Shape.filleted`, `Shape.chamfered`,
+the fillet/chamfer builders, and `SheetMetal.Builder.build` (which fillets internally)
+are all reentrant.
 
-What this means for you:
+This required a kernel fix, not just caller discipline: the racing state (item 5)
+lived in OCCT's own file-scope statics, not in any shape the caller could copy. The
+history:
 
-- **Fillet/chamfer are always safe to call concurrently**, with no lock on your
-  side and no `deepCopy()` required. `Shape.filleted`, `Shape.chamfered`, the
-  fillet/chamfer builders, and `SheetMetal.Builder.build` (which fillets internally)
-  all go through the guarded path.
-- **Only fillet/chamfer builds serialise against each other.** Booleans, meshing,
-  extrudes, sweeps, and everything else stay fully parallel. Filleting on thread A
-  does not block a boolean on thread B.
-- **2D fillets/chamfers (`BRepFilletAPI_MakeFillet2d`) are not affected** — they use
-  the separate analytic `ChFi2d` toolkit, which has no such statics, and are not
-  serialised.
+- **v1.12.1** shipped an interim mitigation — a dedicated bridge mutex
+  (`occtFilletMutex`) serialised every 3D fillet/chamfer build. Correct, but it meant
+  fillet/chamfer could not run in parallel.
+- **v1.12.3** ships the real fix in the pinned kernel (`Scripts/patches/0003`,
+  upstreamed as [OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)):
+  the fillet-path statics are `thread_local`, so the operation is genuinely reentrant.
+  The `occtFilletMutex` serialization was **removed** — concurrent fillet/chamfer
+  builds now run fully in parallel, like every other operation.
 
-This is a mitigation for an upstream OCCT defect. The permanent fix de-statics the
-work variables in `BlendFunc_ConstRad`/`BlendFunc_EvolRad` (carried as an `occt-src`
-patch); once that ships in the pinned kernel the bridge lock can be dropped and
-fillet/chamfer become genuinely parallel.
+2D fillets/chamfers (`BRepFilletAPI_MakeFillet2d`) were never affected — they use the
+separate analytic `ChFi2d` toolkit with no such statics.
 
 ## Performance
 


### PR DESCRIPTION
Completes #298. v1.12.1 stopped the corruption by serialising every 3D fillet/chamfer build behind a bridge mutex (`occtFilletMutex`); this replaces that with the real kernel fix and removes the lock, so concurrent fillet/chamfer run in parallel again.

## Root cause (ThreadSanitizer)

`BRepFilletAPI_MakeFillet` reconstructs its result solid through OCCT's legacy `TopOpeBRepBuild` engine (`ChFi3d_Builder::Compute` → `TopOpeBRepBuild_HBuilder::MergeSolid` → `TopOpeBRepBuild_Builder::SplitSolid`), which passed state between methods through a file-scope `static`, `STATIC_SOLIDINDEX`: `SplitSolid` sets it to 1/2 to tell `FillSolid` which operand it is splitting, and `FillSolid` reads it back to pick the operand shape. Two fillet builds on independent shapes on separate threads clobbered each other's flag, so `FillSolid` mis-classified faces and returned a wrong-but-plausible solid (one solid, positive volume, fails `BRepCheck`). This is **not** the `BlendFunc` scratch the v1.12.1 notes first suspected — those race benignly.

## Fix

- **`Scripts/patches/0003`** converts the fillet-path statics to `thread_local` (each thread keeps its own copy; single-thread behaviour unchanged): `STATIC_SOLIDINDEX` + `STATIC_lastVPind` (functional), plus `BlendFunc_ConstRad`/`EvolRad` + `ChFi3d_Builder` `checkcurve` scratch (benign, converted so the path is TSan-clean). Upstreamed as [Open-Cascade-SAS/OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374).
- **xcframework rebuilt** with 0003; `Package.swift` url+checksum bumped to v1.12.3.
- **`occtFilletMutex` removed** (16 bridge guard sites) — the kernel is reentrant now.

## Verification

- Pure-C++ 8-thread stress: **0/1600 concurrent fillet builds invalid** with a single correct volume (was ~15–20% corrupt); ThreadSanitizer reports the fillet path clean.
- `Issue298FilletThreadSafetyTests` passes **with the lock removed**; `OCCTModelingTests` (409), `OCCTThreadTests` (55) pass against the patched binary.

Binary release — remote SPM consumers pick up the rebuilt lock-free kernel via the new url + checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)