### PR TITLE
docs(okf): note the #298 fillet patch is carried until an upstream OCCT release

### DIFF
--- a/okf/references/carried-occt-patches.md
+++ b/okf/references/carried-occt-patches.md
@@ -1,0 +1,29 @@
+---
+type: reference
+title: Carried OCCT source patches
+resource: https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/patches
+tags: [occt, patches, upstream, thread-safety, kernel]
+description: Upstream-bound OCCT fixes OCCTSwift carries in its xcframework build until they ship in an OCCT release.
+timestamp: 2026-07-18
+---
+
+# Carried OCCT source patches
+
+OCCTSwift bundles a prebuilt `OCCT.xcframework`. When we find an upstream OCCT bug, we
+carry a source patch in [`Scripts/patches/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/patches)
+that `Scripts/build-occt.sh` applies before each build, so the fix ships in our binary
+ahead of an official OCCT release. Each patch is **temporary**: retire it once the
+bundled OCCT version includes the fix. Full rationale + validation per patch lives in
+`Scripts/patches/README.md` — this note is the ecosystem-level pointer.
+
+| Patch | Fixes | Upstream | Retire when |
+|-------|-------|----------|-------------|
+| `0001-ShapeFix_Face-…-263` | ShapeFix_Face compound-context crash ([#263](https://github.com/SecondMouseAU/OCCTSwift/issues/263)) | [OCCT#1322](https://github.com/Open-Cascade-SAS/OCCT/issues/1322) | bundled OCCT includes the guard |
+| `0002-STEPControl_Writer-…-1334` | XDE STEP read corrupts later STEP writes ([#280](https://github.com/SecondMouseAU/OCCTSwift/issues/280)) | [OCCT#1334](https://github.com/Open-Cascade-SAS/OCCT/pull/1334) (merged upstream) | bundled OCCT moves past that commit |
+| `0003-TopOpeBRep-non-reentrant-globals-fillet-298` | Concurrent fillet/chamfer corrupts geometry — non-reentrant `STATIC_SOLIDINDEX` in the TopOpeBRepBuild solid reconstruction ([#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298)) | **[OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)** — filed, not yet released | **an upstream OCCT release includes the `thread_local` conversion** |
+
+**#298 status:** we ship the fix now via patch `0003` (xcframework rebuilt in v1.12.3);
+we keep carrying it — and building our own xcframework — **until an upstream OCCT
+release contains OCCT#1374**. When that lands and we re-pin to that OCCT version, drop
+`0003`. (The in-wrapper `occtFilletMutex` serialization that v1.12.1 shipped was already
+removed in v1.12.3 once the kernel patch made fillet reentrant.)

--- a/okf/references/index.md
+++ b/okf/references/index.md
@@ -13,3 +13,6 @@ timestamp: 2026-06-18
 - **Licensing** — OCCT is LGPL-2.1 with an exception; see `LICENSE` and `OCCT_LGPL_EXCEPTION.md`
   in the repo root.
 - **Swift Package Index** — package page driven by `.spi.yml`.
+- [**Carried OCCT source patches**](carried-occt-patches.md) — upstream-bound OCCT fixes we build
+  into the xcframework until they ship in an OCCT release (currently `0003`/#298, carried until
+  [OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374) is released).


### PR DESCRIPTION
Adds `okf/references/carried-occt-patches.md` recording the upstream-bound OCCT source patches we build into the xcframework (0001/#263, 0002/#280, 0003/#298) and each patch's retire-when condition, linked from the references index. Per request: makes explicit that `0003` (the fillet `TopOpeBRep` `thread_local` fix) is carried until an upstream OCCT release contains [OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374). Points to `Scripts/patches/README.md` for the full per-patch detail rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)