### PR TITLE
Fix #272: drilled(at:direction:) ignored direction — bore now follows the requested axis

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -2927,14 +2927,16 @@ OCCTShapeRef OCCTShapeDrillHole(OCCTShapeRef shape,
             actualDepth = diagonal * 2;  // Make sure it goes through
         }
 
-        // Calculate the bottom of the hole (endpoint of drill)
-        double bottomX = posX + direction.X() * actualDepth;
-        double bottomY = posY + direction.Y() * actualDepth;
-        double bottomZ = posZ + direction.Z() * actualDepth;
-
-        // Create cylinder using OCCTShapeCreateCylinderAt pattern
-        // The cylinder's base is at the "bottom" of the hole, extending upward
-        OCCTShapeRef cylRef = OCCTShapeCreateCylinderAt(bottomX, bottomY, bottomZ, radius, actualDepth);
+        // Build the cutting cylinder ALONG the requested (normalized) drill
+        // direction, with its base at the drill entry point and extending into
+        // the shape for actualDepth. Using the oriented constructor keeps the
+        // cylinder's axis aligned with `direction`; the previous code built the
+        // cylinder hardcoded along +Z (via OCCTShapeCreateCylinderAt), so any
+        // non-Z direction drilled the wrong axis (issue #272).
+        OCCTShapeRef cylRef = OCCTShapeCreateCylinderOriented(
+            posX, posY, posZ,
+            direction.X(), direction.Y(), direction.Z(),
+            radius, actualDepth);
         if (!cylRef) return nullptr;
 
         // Subtract using the existing working function

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1633,19 +1633,27 @@ public final class Shape: @unchecked Sendable {
 
     /// Drill a cylindrical hole into the shape
     ///
+    /// The bore is cut **along `direction`** — any axis, not just Z. The direction is
+    /// normalized internally; a zero-length direction returns `nil`.
+    ///
     /// - Parameters:
-    ///   - position: Position of hole center on surface
-    ///   - direction: Drill direction (into the shape)
+    ///   - position: Position of hole center on the entry surface
+    ///   - direction: Drill direction (into the shape); any non-zero axis
     ///   - radius: Hole radius
     ///   - depth: Hole depth (0 for through-hole)
     ///
-    /// - Returns: Shape with drilled hole, or nil on failure
+    /// - Returns: Shape with drilled hole, or nil on failure (including a zero-length direction)
     ///
     /// ## Example
     ///
     /// ```swift
     /// let plate = Shape.box(width: 50, height: 50, depth: 10)
+    /// // Through-hole down the Z axis:
     /// let drilled = plate.drilled(at: SIMD3(25, 25, 10), direction: SIMD3(0, 0, -1), radius: 5, depth: 0)
+    ///
+    /// // A hole bored across the width (+X) — e.g. a bolt hole through a bar:
+    /// let bar = Shape.box(width: 200, height: 60, depth: 16)
+    /// let cross = bar?.drilled(at: SIMD3(-101, 0, 0), direction: SIMD3(1, 0, 0), radius: 6.5, depth: 0)
     /// ```
     public func drilled(at position: SIMD3<Double>, direction: SIMD3<Double>, radius: Double, depth: Double = 0) -> Shape? {
         guard let handle = OCCTShapeDrillHole(self.handle,

--- a/Tests/OCCTModelingTests/Issue272DrilledDirectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue272DrilledDirectionTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #272: `Shape.drilled(at:direction:radius:depth:)` ignored its `direction` argument — the
+/// C++ bridge (`OCCTShapeDrillHole`) built the cutting cylinder via `OCCTShapeCreateCylinderAt`,
+/// which hardcodes the cylinder axis to +Z (`gp_Dir(0, 0, 1)`). So drilling along any non-Z
+/// direction repositioned the cylinder's base along the requested direction but still bored up +Z,
+/// cutting the wrong axis (and, for a base point pushed outside the shape, removing nothing at all).
+///
+/// Fix: build the cylinder with `OCCTShapeCreateCylinderOriented(pos, direction, r, depth)`, whose
+/// `gp_Ax2(origin, direction)` orients the bore along the requested (normalized) direction.
+///
+/// These tests are DISCRIMINATING against the old hardcoded-Z behaviour: they drill a block that is
+/// much wider in X than in Z along +X, and assert the removed material actually runs the full X
+/// extent (and that a point on the +X bore axis is now outside the solid). Under the old bug the +X
+/// bore cylinder landed entirely outside the block, so ~zero volume was removed and the axis point
+/// stayed inside — both assertions below would fail.
+@Suite("Issue #272 — drilled honours a non-Z direction")
+struct Issue272DrilledDirectionTests {
+
+    // Block centered at origin: X[-30,30] (60 wide), Y[-10,10] (20), Z[-6,6] (12 thick).
+    // X extent (60) >> Z extent (12), so an X-bore and a Z-bore remove very different volumes.
+    private func makeBlock() -> Shape { Shape.box(width: 60, height: 20, depth: 12)! }
+    private let radius = 3.0
+
+    /// Drilling +X through the wide axis removes material along X — proving the bore follows the
+    /// requested direction rather than +Z. Under the old bug this removed ~nothing.
+    @Test("Drilling +X bores along X (not Z): removes the full X-extent of material")
+    func drillsAlongXNotZ() {
+        let block = makeBlock()
+        let original = block.volume ?? 0
+
+        // Enter from just outside the -X face, bore along +X, through-hole (depth 0).
+        guard let drilledX = block.drilled(at: SIMD3(-31, 0, 0),
+                                           direction: SIMD3(1, 0, 0),
+                                           radius: radius, depth: 0) else {
+            Issue.record("drilled(+X) returned nil"); return
+        }
+        #expect(drilledX.isValid)
+
+        let removed = original - (drilledX.volume ?? 0)
+        // A bore running the full 60mm X extent removes π·r²·60. The old +Z-hardcoded bore landed
+        // outside the block and removed ~0, so this assertion fails against the bug.
+        let expectedXBore = Double.pi * radius * radius * 60.0
+        #expect(abs(removed - expectedXBore) < 5.0)
+
+        // The block centre lies on the +X bore axis (Y=0, Z=0): after an X through-hole it must be
+        // OUTSIDE the solid. Under the old +Z bore it stayed inside.
+        #expect(drilledX.classify(point: SIMD3(0, 0, 0)) == .outside)
+        // A point off the bore axis but still in the block (Y=8) stays inside — the solid survived.
+        #expect(drilledX.classify(point: SIMD3(0, 8, 0)) == .inside)
+    }
+
+    /// Direct comparison: drilling the SAME block along +X vs +Z removes very different amounts of
+    /// material (X extent 60 vs Z extent 12). With the old hardcoded-Z bridge both directions bored
+    /// up Z, so this discrimination was impossible.
+    @Test("Drilling +X vs +Z on the same block removes different material")
+    func xAndZBoresDiffer() {
+        let original = makeBlock().volume ?? 0
+
+        guard let drilledX = makeBlock().drilled(at: SIMD3(-31, 0, 0),
+                                                 direction: SIMD3(1, 0, 0),
+                                                 radius: radius, depth: 0),
+              let drilledZ = makeBlock().drilled(at: SIMD3(0, 0, 7),
+                                                 direction: SIMD3(0, 0, -1),
+                                                 radius: radius, depth: 0) else {
+            Issue.record("drill setup failed"); return
+        }
+
+        let removedX = original - (drilledX.volume ?? 0)
+        let removedZ = original - (drilledZ.volume ?? 0)
+
+        // Z bore removes π·r²·12 (thin axis); X bore removes π·r²·60 (wide axis).
+        #expect(abs(removedZ - Double.pi * radius * radius * 12.0) < 5.0)
+        #expect(abs(removedX - Double.pi * radius * radius * 60.0) < 5.0)
+        // The X bore must remove strictly (and substantially) more than the Z bore.
+        #expect(removedX > removedZ + 100.0)
+    }
+}

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -192,16 +192,23 @@ public func drilled(at position: SIMD3<Double>, direction: SIMD3<Double>,
 
 `depth: 0` creates a through-hole (the cylinder is made large enough to penetrate the shape entirely).
 
-- **Parameters:** `position` — hole-centre point on the entry face; `direction` — drill direction (into the shape); `radius` — hole radius; `depth` — hole depth, or `0` for through-hole.
-- **Returns:** Shape with drilled hole, or `nil` on failure.
-- **OCCT:** `BRepBuilderAPI_MakeFace` + `BRepAlgoAPI_Cut` (internal cylinder cutter).
+The bore is cut **along `direction`** — any axis, not just Z. `direction` is normalized internally; a zero/degenerate direction returns `nil`.
+
+- **Parameters:** `position` — hole-centre point on the entry face; `direction` — drill direction (into the shape), any non-zero axis; `radius` — hole radius; `depth` — hole depth, or `0` for through-hole.
+- **Returns:** Shape with drilled hole, or `nil` on failure (including a zero-length `direction`).
+- **OCCT:** `BRepPrimAPI_MakeCylinder` (oriented via `gp_Ax2(position, direction)`) + `BRepAlgoAPI_Cut` (internal cylinder cutter).
 - **Example:**
   ```swift
   let plate = Shape.box(width: 50, height: 50, depth: 10)
   if let drilled = plate.drilled(at: SIMD3(25, 25, 10), direction: SIMD3(0, 0, -1),
                                    radius: 5, depth: 0) {
-      // through-hole centred at (25, 25)
+      // through-hole down the Z axis, centred at (25, 25)
   }
+
+  // A hole bored across the width (+X), e.g. a bolt hole through a bar:
+  let bar = Shape.box(width: 200, height: 60, depth: 16)
+  let cross = bar?.drilled(at: SIMD3(-101, 0, 0), direction: SIMD3(1, 0, 0),
+                           radius: 6.5, depth: 0)   // bore runs along +X, not Z
   ```
 
 ---


### PR DESCRIPTION
## Root cause

`Shape.drilled(at:direction:radius:depth:)` ignored its `direction` argument. The bridge `OCCTShapeDrillHole` (`Sources/OCCTBridge/src/OCCTBridge_Modeling.mm`) built its cutting cylinder via `OCCTShapeCreateCylinderAt`, which hardcodes the cylinder axis to +Z:

```cpp
// OCCTBridge_Modeling.mm:9467 (OCCTShapeCreateCylinderAt)
gp_Ax2 axis(gp_Pnt(cx, cy, bottomZ), gp_Dir(0, 0, 1));
```

`OCCTShapeDrillHole` shifted the cylinder's *base point* along `direction` but the cylinder itself always bored up +Z. For any non-Z `direction` this cut the wrong axis; when the shifted base fell outside the shape, the cut removed **no material at all** and silently returned a wrong solid (issue #272, found cutting cross-holes through a fishplate width in OCCTDesignLoop #44).

## Fix

Build the cutter with the oriented constructor instead:

```cpp
OCCTShapeRef cylRef = OCCTShapeCreateCylinderOriented(
    posX, posY, posZ,
    direction.X(), direction.Y(), direction.Z(),
    radius, actualDepth);
```

`OCCTShapeCreateCylinderOriented` uses `gp_Ax2(origin, direction)`, so the bore runs along the normalized requested direction from the entry point. The existing zero/degenerate-direction guard (`return nullptr`) and normalization in `OCCTShapeDrillHole` are retained. `BRepPrimAPI_MakeCylinder(gp_Ax2, R, H)` / `gp_Ax2(P, V)` semantics were verified against the bundled OCCT headers (`gp_Ax2(P, V)` = origin P, main direction V; cylinder built from the Ax2 location along its main axis).

## How the test discriminates

`Tests/OCCTModelingTests/Issue272DrilledDirectionTests.swift` drills a **60×20×12** block (X much wider than Z), centred at origin:

- **`drillsAlongXNotZ`** — bores +X through and asserts removed volume ≈ `π·r²·60` (the full X extent) and that the block centre `(0,0,0)`, on the +X bore axis, is now `.outside` the solid. Under the old +Z behaviour the +X cutter base landed at X≈98 (outside the block), removing ~0 material and leaving the centre `.inside` — so **both assertions fail against the bug**.
- **`xAndZBoresDiffer`** — drills the same block +X vs +Z and asserts the removed volumes differ (`π·r²·60` vs `π·r²·12`), impossible when both bored up Z.

## Verification

```
swift build      → Build complete! (23.85s)
swift test --filter Issue272DrilledDirectionTests
  ✔ Test run with 2 tests in 1 suite passed after 0.009 seconds.
swift test --filter DrillingTests            → 3 tests passed (no regression)
swift test --filter OCCTModelingTests        → 411 tests in 133 suites passed
```

## Docs

`docs/reference/Shape-Features.md` and the `drilled(...)` doc-comment now state the bore follows any axis, note the zero-direction → nil behaviour, correct the OCCT note to `BRepPrimAPI_MakeCylinder` + `BRepAlgoAPI_Cut`, and add a non-Z (+X) example. `Scripts/count-operations.py` still reports a consistent 4241 (pure bugfix, no public entry-point change).

Closes #272.