### PR TITLE
Fix #274: conditionally reverse hole wires in face(outer:holes:)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -97,6 +97,9 @@
 #include <BRepFill_OffsetAncestors.hxx>
 #include <BRepAlgo_AsDes.hxx>
 #include <BRepCheck_Analyzer.hxx>
+#include <BRepBuilderAPI_FindPlane.hxx>
+#include <BRepTools_WireExplorer.hxx>
+#include <BRepAdaptor_Curve.hxx>
 #include <ShapeUpgrade_UnifySameDomain.hxx>
 #include <HLRAppli_ReflectLines.hxx>
 #include <HLRBRep_TypeOfResultingEdge.hxx>
@@ -2666,6 +2669,60 @@ OCCTShapeRef OCCTShapeCreateFaceFromWire(OCCTWireRef wire, bool planar) {
     }
 }
 
+// Signed area of a (nominally planar) wire measured in the plane spanned by pln's
+// X/Y directions. Arc-aware: each edge is sampled along its parametric range in
+// wire-traversal order and the shoelace sum is accumulated over the sampled polyline,
+// so curved edges contribute their true bulge to the sign. The magnitude is only an
+// approximation, but the SIGN — all we use it for — is robust for simple loops.
+// A positive result means the wire winds counter-clockwise about pln's normal.
+static double occtSignedWireAreaInPlane(const TopoDS_Wire& wire, const gp_Pln& pln) {
+    const gp_Pnt origin = pln.Location();
+    const gp_Dir xDir = pln.Position().XDirection();
+    const gp_Dir yDir = pln.Position().YDirection();
+
+    auto projectUV = [&](const gp_Pnt& p, double& u, double& v) {
+        const gp_Vec d(origin, p);
+        u = d.Dot(gp_Vec(xDir));
+        v = d.Dot(gp_Vec(yDir));
+    };
+
+    double area = 0.0;
+    bool hasPrev = false;
+    double u0 = 0.0, v0 = 0.0;      // first sampled point (to close the loop)
+    double uPrev = 0.0, vPrev = 0.0; // previous sampled point
+    const int samplesPerEdge = 24;
+
+    BRepTools_WireExplorer explorer(wire);
+    for (; explorer.More(); explorer.Next()) {
+        const TopoDS_Edge& edge = explorer.Current();
+        BRepAdaptor_Curve curve(edge);
+        const double f = curve.FirstParameter();
+        const double l = curve.LastParameter();
+        // Walk the curve in the edge's traversal direction within the wire.
+        const bool reversed = (edge.Orientation() == TopAbs_REVERSED);
+        for (int s = 0; s <= samplesPerEdge; s++) {
+            const double t = (double)s / (double)samplesPerEdge;
+            const double param = reversed ? (l + (f - l) * t) : (f + (l - f) * t);
+            const gp_Pnt p = curve.Value(param);
+            double u, v;
+            projectUV(p, u, v);
+            if (!hasPrev) {
+                u0 = uPrev = u;
+                v0 = vPrev = v;
+                hasPrev = true;
+            } else {
+                area += (uPrev * v - u * vPrev);
+                uPrev = u;
+                vPrev = v;
+            }
+        }
+    }
+    if (hasPrev) {
+        area += (uPrev * v0 - u0 * vPrev); // close the loop
+    }
+    return 0.5 * area;
+}
+
 OCCTShapeRef OCCTShapeCreateFaceWithHoles(OCCTWireRef outer, const OCCTWireRef* holes, int32_t holeCount) {
     if (!outer) return nullptr;
 
@@ -2676,13 +2733,42 @@ OCCTShapeRef OCCTShapeCreateFaceWithHoles(OCCTWireRef outer, const OCCTWireRef* 
             return nullptr;
         }
 
+        // For a valid planar face with holes, each hole wire must wind OPPOSITE to
+        // the outer boundary (measured in the face plane). Callers may hand in a hole
+        // wound either way, so we CONDITIONALLY reverse: only flip a hole whose winding
+        // currently MATCHES the outer's. A hole already wound opposite is left as-is.
+        // (The previous implementation reversed every hole unconditionally, which broke
+        // callers that already passed the geometrically-correct opposite winding — #274.)
+        //
+        // Winding is decided by the sign of each wire's signed area projected onto the
+        // outer face plane. If the plane can't be determined we fall back to the old
+        // unconditional-reverse behaviour, which is correct for same-sense inputs.
+        BRepBuilderAPI_FindPlane finder(outer->wire);
+        const bool havePlane = finder.Found();
+        gp_Pln plane;
+        double outerSign = 0.0;
+        if (havePlane) {
+            plane = finder.Plane()->Pln();
+            outerSign = occtSignedWireAreaInPlane(outer->wire, plane);
+        }
+
         // Add holes (inner wires)
         for (int32_t i = 0; i < holeCount; i++) {
-            if (holes[i]) {
-                // Inner wires must be reversed to represent holes
-                TopoDS_Wire reversed = TopoDS::Wire(holes[i]->wire.Reversed());
-                makeFace.Add(reversed);
+            if (!holes[i]) continue;
+            const TopoDS_Wire& holeWire = holes[i]->wire;
+
+            bool reverse;
+            if (havePlane && outerSign != 0.0) {
+                const double holeSign = occtSignedWireAreaInPlane(holeWire, plane);
+                // Reverse only when the hole winds the SAME way as the outer.
+                // If holeSign is ~0 (degenerate), fall back to reversing.
+                reverse = (holeSign == 0.0) || (holeSign * outerSign > 0.0);
+            } else {
+                reverse = true; // no reliable plane: preserve legacy same-sense behaviour
             }
+
+            TopoDS_Wire toAdd = reverse ? TopoDS::Wire(holeWire.Reversed()) : holeWire;
+            makeFace.Add(toAdd);
         }
 
         if (!makeFace.IsDone()) {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1478,9 +1478,19 @@ public final class Shape: @unchecked Sendable {
 
     /// Create a face with holes from outer and inner wires
     ///
+    /// ## Winding contract
+    ///
+    /// Each hole wire ends up wound **opposite** to the outer boundary (measured in the
+    /// face plane), as OCCT requires for the hole to subtract area. The winding you pass
+    /// does **not** matter: the function measures each hole's signed area against the outer
+    /// and reverses a hole only when its winding currently matches the outer's. A hole you
+    /// pass already wound opposite (the geometrically correct sense) is left untouched, and
+    /// a hole wound the same way as the outer is reversed for you. Either input yields the
+    /// same valid face with the hole correctly subtracted.
+    ///
     /// - Parameters:
     ///   - outer: The outer boundary wire (closed)
-    ///   - holes: Array of inner boundary wires defining holes
+    ///   - holes: Array of inner boundary wires defining holes; any winding is accepted
     ///
     /// - Returns: A face with holes, or nil if creation fails
     ///

--- a/Tests/OCCTModelingTests/Issue274HoleWireOrientationTests.swift
+++ b/Tests/OCCTModelingTests/Issue274HoleWireOrientationTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #274: `Shape.face(outer:holes:)` (bridge `OCCTShapeCreateFaceWithHoles`) used to reverse
+/// EVERY hole wire unconditionally. That is only correct when the caller passes a hole wound the
+/// SAME way as the outer; a hole passed already wound OPPOSITE (the geometrically correct sense for
+/// a hole) was flipped back to WRONG, producing an invalid face / an un-subtracted hole.
+///
+/// The fix makes the reversal CONDITIONAL: each hole is reversed only when its winding currently
+/// matches the outer's (decided by the sign of its signed area in the face plane). Either input
+/// winding must therefore yield the SAME valid face with the hole correctly subtracted.
+///
+/// Both tests below use the SAME geometry (a 10×10 outer CCW square with a 4×4 centred hole); the
+/// only difference is the hole's authored winding, so the winding is the sole discriminator. A
+/// regression to unconditional-reverse breaks the "already opposite" case and this suite fails loudly.
+@Suite("Issue #274 — hole wire orientation is corrected conditionally")
+struct Issue274HoleWireOrientationTests {
+
+    // 10×10 outer square, authored COUNTER-CLOCKWISE (right, up, left, down). Area = 100.
+    private func outerCCW() -> Wire? {
+        Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)
+        ], closed: true)
+    }
+
+    // 4×4 centred hole authored CLOCKWISE — i.e. OPPOSITE the CCW outer (the correct hole sense).
+    private func holeCW() -> Wire? {
+        Wire.polygon3D([
+            SIMD3(3, 3, 0), SIMD3(3, 7, 0), SIMD3(7, 7, 0), SIMD3(7, 3, 0)
+        ], closed: true)
+    }
+
+    // 4×4 centred hole authored COUNTER-CLOCKWISE — i.e. the SAME sense as the outer.
+    private func holeCCW() -> Wire? {
+        Wire.polygon3D([
+            SIMD3(3, 3, 0), SIMD3(7, 3, 0), SIMD3(7, 7, 0), SIMD3(3, 7, 0)
+        ], closed: true)
+    }
+
+    private let expectedArea = 100.0 - 16.0  // outer 100 − hole 16 = 84
+
+    /// Hole passed ALREADY OPPOSITE the outer (CW vs CCW) — the correct winding a caller may already
+    /// have. This is the case the old unconditional reverse BROKE. Must produce a valid, subtracted face.
+    @Test("hole wound opposite the outer (CW) → valid face, hole subtracted")
+    func holeAlreadyOppositeIsKept() {
+        guard let outer = outerCCW(), let hole = holeCW() else { Issue.record("setup"); return }
+        guard let face = Shape.face(outer: outer, holes: [hole]) else {
+            Issue.record("face(outer:holes:) returned nil for opposite-wound hole"); return
+        }
+        #expect(face.isValid)
+        #expect(face.subShapeCount(ofType: .wire) == 2)  // outer + one real hole
+        guard let area = face.surfaceArea else { Issue.record("no surfaceArea"); return }
+        #expect(abs(area - expectedArea) < 1e-6)
+    }
+
+    /// Hole passed the SAME way as the outer (CCW) — the function must still correct it. Must produce
+    /// the identical valid, subtracted face.
+    @Test("hole wound same as the outer (CCW) → still corrected, hole subtracted")
+    func holeSameSenseIsReversed() {
+        guard let outer = outerCCW(), let hole = holeCCW() else { Issue.record("setup"); return }
+        guard let face = Shape.face(outer: outer, holes: [hole]) else {
+            Issue.record("face(outer:holes:) returned nil for same-wound hole"); return
+        }
+        #expect(face.isValid)
+        #expect(face.subShapeCount(ofType: .wire) == 2)
+        guard let area = face.surfaceArea else { Issue.record("no surfaceArea"); return }
+        #expect(abs(area - expectedArea) < 1e-6)
+    }
+
+    /// Both windings must agree: same geometry, same result regardless of authored hole winding.
+    @Test("both hole windings produce the same valid subtracted face")
+    func bothWindingsAgree() {
+        guard let outer1 = outerCCW(), let outer2 = outerCCW(),
+              let hCW = holeCW(), let hCCW = holeCCW() else { Issue.record("setup"); return }
+        guard let faceFromCW = Shape.face(outer: outer1, holes: [hCW]),
+              let faceFromCCW = Shape.face(outer: outer2, holes: [hCCW]) else {
+            Issue.record("one of the faces was nil"); return
+        }
+        #expect(faceFromCW.isValid)
+        #expect(faceFromCCW.isValid)
+        let aCW = faceFromCW.surfaceArea ?? -1
+        let aCCW = faceFromCCW.surfaceArea ?? -2
+        #expect(abs(aCW - expectedArea) < 1e-6)
+        #expect(abs(aCCW - expectedArea) < 1e-6)
+        #expect(abs(aCW - aCCW) < 1e-9)
+    }
+}

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -43,9 +43,10 @@ Creates a face with one or more through-holes.
 public static func face(outer: Wire, holes: [Wire]) -> Shape?
 ```
 
-- **Parameters:** `outer` — the outer boundary wire (closed); `holes` — array of inner boundary wires, each defining a hole.
+- **Parameters:** `outer` — the outer boundary wire (closed); `holes` — array of inner boundary wires, each defining a hole. **Any hole winding is accepted** (see below).
 - **Returns:** A face with holes, or `nil` on failure.
-- **OCCT:** `BRepBuilderAPI_MakeFace(outer, planar)` + `BRepBuilderAPI_MakeFace::Add` for each inner wire.
+- **Winding contract:** For a valid planar face, each hole must wind **opposite** to the outer boundary (measured in the face plane). You do not have to pre-orient your holes: the function measures each hole's signed area against the outer's and reverses a hole **only when its winding currently matches the outer's**. A hole passed already wound opposite (the geometrically correct sense) is kept as-is; a hole wound the same way as the outer is reversed for you. Either input yields the same valid face with the hole correctly subtracted. (Before [#274](https://github.com/SecondMouseAU/OCCTSwift/issues/274) every hole was reversed unconditionally, which broke callers that already passed the correct opposite winding.)
+- **OCCT:** `BRepBuilderAPI_MakeFace(outer, planar)` + `BRepBuilderAPI_MakeFace::Add` for each inner wire, with the wire's relative winding decided by `BRepBuilderAPI_FindPlane` + a signed-area projection onto the face plane.
 - **Example:**
   ```swift
   let outer = Wire.rectangle(width: 20, height: 20)!


### PR DESCRIPTION
## Root cause

`Shape.face(outer:holes:)` → `OCCTShapeCreateFaceWithHoles` (`Sources/OCCTBridge/src/OCCTBridge_Modeling.mm`) **unconditionally reversed every hole wire** before handing it to `BRepBuilderAPI_MakeFace::Add`:

```cpp
// Inner wires must be reversed to represent holes
TopoDS_Wire reversed = TopoDS::Wire(holes[i]->wire.Reversed());
makeFace.Add(reversed);
```

For a valid planar face, each hole must wind **opposite** the outer boundary. Unconditional reversal is correct **only** when the caller passes a hole wound the SAME way as the outer. When a caller already passes a hole wound opposite the outer (the geometrically correct sense — e.g. every interior loop of the McMaster T-slot fixture in OCCTDesignLoop #51), the blind `.Reversed()` flips it to the WRONG sense, so `BRepCheck_Analyzer` rejects the solid / the hole isn't subtracted.

## The correct rule

Reverse a hole **only when its winding currently matches the outer's**; leave a hole that is already wound opposite untouched.

Winding is decided deterministically, per hole:
1. `BRepBuilderAPI_FindPlane` on the outer wire → the face plane.
2. `occtSignedWireAreaInPlane(wire, pln)` — arc-aware signed area: each edge is walked via `BRepTools_WireExplorer` in wire-traversal order and sampled along its parametric range with `BRepAdaptor_Curve`, projecting each point onto the plane's X/Y directions and shoelace-summing. Only the **sign** is used, which is robust for simple loops (curved edges contribute their true bulge).
3. Reverse the hole iff `holeSign * outerSign > 0` (same sense). Degenerate (`~0`) or no-plane cases fall back to the legacy unconditional reverse.

This is strictly more correct than an all-or-nothing reverse: it also handles a face whose holes are **mixed-winding**.

All OCCT signatures used (`BRepBuilderAPI_FindPlane`, `BRepTools_WireExplorer`, `BRepAdaptor_Curve`, `gp_Pln`) were verified against the bundled `Libraries/OCCT.xcframework/.../Headers/*.hxx`, per repo policy.

## Tests

`Tests/OCCTModelingTests/Issue274HoleWireOrientationTests.swift` — three `@Test`s using the **same geometry** (10×10 CCW outer, 4×4 centred hole) so the **hole winding is the sole discriminator**:

- `holeAlreadyOppositeIsKept` — hole passed **CW** (already opposite the outer, the correct sense). This is the case the old code broke. Asserts `isValid` + area ≈ 84 (100 − 16).
- `holeSameSenseIsReversed` — hole passed **CCW** (same sense as outer). The function must still correct it. Asserts `isValid` + area ≈ 84.
- `bothWindingsAgree` — both inputs must produce the identical valid, subtracted face.

Because both cases assert on `isValid` **and** measured area, a regression to unconditional-reverse fails loudly: I verified that forcing the reversal back to unconditional makes the already-opposite case produce an **invalid** face with area **116** (hole not subtracted), while the same-sense case still passes.

## Verification

```
swift build            → Build complete!
swift test --filter Issue274HoleWireOrientationTests  → 3 tests, all passed
swift test --filter "Issue266FaceWithHolesTests|Issue234DegenerateHoleTests"  → 7 tests, all passed (no regression)
python3 Scripts/count-operations.py  → 4241 ✓ (unchanged — bugfix, no API change)
```

## Docs

`Shape.swift` doc-comment and `docs/reference/Shape-Features.md` now state the winding contract: holes end up opposite the outer regardless of input winding; any hole winding is accepted.

Closes #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)