### PR TITLE
Make count-operations --audit type-aware; document the true gaps (#294)

### DIFF
--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -48,44 +48,119 @@ SUBS = re.compile(r'^\s*public\s+(?:static\s+)?subscript\s*\(')
 # reference docs use both ### and #### for entry points
 DOC_HEADING = re.compile(r'^#{3,4} `([^`]+)`')
 
+# A type/extension declaration whose body encloses the entry points below it. Captures the
+# type name so a counted op carries a `Type.name` identity, not just `name` (issue #294).
+TYPE_DECL = re.compile(
+    r'^\s*(?:(?:public|internal|private|fileprivate|final|open|package)\s+)*'
+    r'(?:struct|class|enum|actor|extension|protocol)\s+([A-Za-z_][A-Za-z0-9_.]*)')
+# A public member as it appears inside a ```swift code block in the reference docs.
+DOC_MEMBER = re.compile(
+    r'^\s*(?:@\w+\s+)*public\s+(?:static\s+|class\s+|convenience\s+|final\s+)*'
+    r'(?:func\s+([A-Za-z_]\w*)|var\s+([A-Za-z_]\w*))')
+# A backtick span that names a type (possibly nested, `Outer.Inner`) rather than a member call.
+TYPEISH = re.compile(r'^[A-Z][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$')
+
+
+def _enclosing_type(stack):
+    """Innermost type name on the brace stack, or None at file scope."""
+    return stack[-1][0].split('.')[-1] if stack else None
+
 
 def count_entry_points():
-    """Returns (total, breakdown, {name: (file, line)})."""
+    """Returns (total, breakdown, ops) where ops maps (type, name) -> (file, line).
+
+    `type` is the innermost enclosing struct/class/enum/actor/extension name (last
+    component of a nested/qualified name), or None at file scope. Overloads and same-named
+    members on different types collapse to one row per (type, name), which is all the audit
+    needs — the derived Total still comes from `breakdown`, which counts every declaration.
+    """
     breakdown = {"func": 0, "init": 0, "computed var": 0, "subscript": 0}
-    names = {}
+    ops = {}
     for f in sorted(glob.glob(os.path.join(ROOT, "Sources/OCCTSwift/*.swift"))):
         rel = os.path.relpath(f, ROOT)
+        stack = []      # [(type_name, brace_depth_at_open)]
+        depth = 0
         for i, line in enumerate(open(f, encoding="utf-8", errors="replace"), 1):
+            code = re.sub(r'//.*', '', line)   # crude line-comment strip for brace counting
+            enc = _enclosing_type(stack)
             m = FUNC.match(line)
             if m:
                 breakdown["func"] += 1
-                names.setdefault(m.group(1), (rel, i))
-                continue
-            if INIT.match(line):
+                ops.setdefault((enc, m.group(1)), (rel, i))
+            elif INIT.match(line):
                 breakdown["init"] += 1
-                continue
-            m = CVAR.match(line)
-            if m:
-                breakdown["computed var"] += 1
-                names.setdefault(m.group(1), (rel, i))
-                continue
-            if SUBS.match(line):
-                breakdown["subscript"] += 1
-    return sum(breakdown.values()), breakdown, names
+            else:
+                m = CVAR.match(line)
+                if m:
+                    breakdown["computed var"] += 1
+                    ops.setdefault((enc, m.group(1)), (rel, i))
+                elif SUBS.match(line):
+                    breakdown["subscript"] += 1
+
+            # maintain the enclosing-type stack
+            td = TYPE_DECL.match(line)
+            opens, closes = code.count('{'), code.count('}')
+            depth += opens - closes
+            if td is not None and opens > closes:
+                # body opens and stays open below this line; a one-liner like
+                # `enum Toggle { case a, b }` (opens == closes) encloses nothing.
+                stack.append((td.group(1), depth))
+            else:
+                while stack and depth < stack[-1][1]:
+                    stack.pop()
+    return sum(breakdown.values()), breakdown, ops
 
 
-def documented_names():
-    doc = set()
+def documented_index():
+    """Scan docs/reference/*.md and return (typed, bare).
+
+    `typed` is a set of (type, name) pairs the docs associate with an owning type — parsed
+    from `### `Type.name(...)`` headings AND from the public members listed inside a ```swift
+    code block that sits under a `### `Type`` heading. `bare` is the set of names documented
+    by a heading that carries NO type qualifier (e.g. `### `analyze(tolerance:)`` or a
+    multi-span `### `x`, `y`, `z``), which match any owning type by name alone.
+    """
+    typed = set()
+    bare = set()
     for f in glob.glob(os.path.join(ROOT, "docs/reference/*.md")):
+        cur_type = None       # owning type for the current section's code blocks
+        in_code = False
         for line in open(f, encoding="utf-8", errors="replace"):
-            m = DOC_HEADING.match(line)
-            if not m:
+            if line.lstrip().startswith("```"):
+                in_code = not in_code
                 continue
-            # `Type.name(labels:)` -> `name`
-            h = m.group(1).split('(')[0].split('.')[-1].strip()
-            if h:
-                doc.add(h)
-    return doc
+            if in_code:
+                m = DOC_MEMBER.match(line)
+                if m and cur_type:
+                    typed.add((cur_type, m.group(1) or m.group(2)))
+                continue
+            if not line.lstrip().startswith("#"):
+                continue
+            spans = re.findall(r'`([^`]+)`', line)
+            # A heading governs the ```swift block beneath it; derive that block's owning
+            # (innermost) type so its members register under the same type the source side
+            # sees. Read the type from the first backtick span, or — for a plain heading like
+            # `## DXFError` with no backticks — from the heading text itself. Distinguish by
+            # the last dotted component:
+            #   `ImportResult` / `Outer.Inner`  (last is a Type)   -> owner = innermost type
+            #   `Shape.faceLPropTangentU/V(...)` (last is a member) -> owner = its qualifier
+            #   `analyze(tolerance:)`            (bare member)      -> owner unchanged
+            ctx_src = spans[0] if spans else line.lstrip().lstrip('#').strip()
+            parts = ctx_src.split('(')[0].strip().split('.')
+            if TYPEISH.match(parts[-1]):
+                cur_type = parts[-1]
+            elif len(parts) >= 2 and spans:
+                cur_type = parts[-2]
+            for span in spans:
+                s = span.split('(')[0].strip()
+                if not s:
+                    continue
+                if '.' in s:
+                    t, n = s.rsplit('.', 1)
+                    typed.add((t.split('.')[-1], n))
+                else:
+                    bare.add(s)
+    return typed, bare
 
 
 def read_stated():
@@ -146,16 +221,24 @@ def fix(derived):
 
 
 def main():
-    derived, breakdown, names = count_entry_points()
+    derived, breakdown, ops = count_entry_points()
     mode = sys.argv[1] if len(sys.argv) > 1 else ""
 
     if mode == "--audit":
-        doc = documented_names()
-        undoc = sorted(set(names) - doc)
+        typed_doc, bare_doc = documented_index()
+        # Type-aware match: a counted (type, name) is documented if the docs associate that
+        # exact (type, name) — via a `Type.name` heading or a member listed in the type's
+        # code block — OR if `name` appears in a type-less heading (matches any owner). This
+        # eliminates the bare-name false positives the old matcher over-reported (#294).
+        undoc = sorted(
+            (t, n, ops[(t, n)])
+            for (t, n) in ops
+            if (t, n) not in typed_doc and n not in bare_doc
+        )
         print(f"counted entry points with NO reference doc: {len(undoc)}\n")
-        for n in undoc:
-            f, i = names[n]
-            print(f"  {n:<34} {f}:{i}")
+        for t, n, (f, i) in undoc:
+            qual = f"{t}.{n}" if t else n
+            print(f"  {qual:<42} {f}:{i}")
         return 1 if undoc else 0
 
     print("Canonical rule (#289): one row per distinct public Swift entry point; overloads counted separately.\n")

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -1159,6 +1159,62 @@ public func transpose()
 
 ---
 
+## OSD_Environment
+
+Namespace wrapping `OSD_Environment` — read, set, and remove process environment variables
+through OCCT's platform-neutral OSD layer (rather than POSIX `getenv`/`setenv` directly). Useful
+for toggling OCCT's own environment switches (e.g. `CSF_*` resource paths) from Swift.
+
+### `Environment.get(_:)`
+
+Get the value of an environment variable.
+
+```swift
+public static func get(_ name: String) -> String?
+```
+
+- **Parameters:** `name` — the variable name.
+- **Returns:** The value, or `nil` if the variable is unset.
+- **OCCT:** `OSD_Environment(name).Value()` (via `OCCTEnvironmentGet`).
+- **Example:**
+  ```swift
+  let paths = Environment.get("CSF_PluginDefaults")
+  ```
+
+---
+
+### `Environment.set(_:value:)`
+
+Set (create or overwrite) an environment variable in the current process.
+
+```swift
+@discardableResult
+public static func set(_ name: String, value: String) -> Bool
+```
+
+- **Parameters:** `name` — the variable name; `value` — the value to store.
+- **Returns:** `true` on success. The result is discardable.
+- **OCCT:** `OSD_Environment(name, value).Build()` (via `OCCTEnvironmentSet`).
+- **Example:**
+  ```swift
+  Environment.set("CSF_MDTVFontDirectory", value: "/usr/share/fonts")
+  ```
+
+---
+
+### `Environment.remove(_:)`
+
+Remove an environment variable from the current process.
+
+```swift
+public static func remove(_ name: String)
+```
+
+- **Parameters:** `name` — the variable name to unset.
+- **OCCT:** `OSD_Environment(name).Remove()` (via `OCCTEnvironmentRemove`).
+
+---
+
 ## math_Gauss
 
 Namespace wrapping `math_Gauss` — direct Gaussian elimination for square linear systems.

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1174,6 +1174,70 @@ public func orientedBoundingBoxDetailed(optimal: Bool = false) -> DetailedOBB?
 
 ---
 
+### `Shape.OrientedBoundingBox`
+
+An oriented (rotated) bounding box that fits tightly around a shape. Unlike the flat
+`DetailedOBB`, this value bundles the half-sizes as a single `SIMD3<Double>` and adds two
+computed conveniences (`volume`, `dimensions`); it is the return type of
+`orientedBoundingBox(optimal:)`.
+
+```swift
+public struct OrientedBoundingBox: Sendable {
+    public var center: SIMD3<Double>        // box centre in world space
+    public var xDirection: SIMD3<Double>    // unit axis directions of the box frame
+    public var yDirection: SIMD3<Double>
+    public var zDirection: SIMD3<Double>
+    public var halfSizes: SIMD3<Double>     // half-extents along x/y/z axes
+    public var volume: Double { get }       // 8 · hx · hy · hz
+    public var dimensions: SIMD3<Double> { get }  // 2 · halfSizes (full edge lengths)
+}
+```
+
+- **OCCT:** populated from `Bnd_OBB` (via `BRepBndLib::AddOBB`).
+
+---
+
+### `Shape.orientedBoundingBox(optimal:)`
+
+Compute the oriented (tight-fit, rotated) bounding box of the shape as an
+`OrientedBoundingBox` value. Where the axis-aligned `boundingBox` is cheap but loose for
+rotated geometry, the OBB rotates to hug the shape, so its `volume` is a far better proxy for
+how much space the part actually occupies.
+
+```swift
+public func orientedBoundingBox(optimal: Bool = false) -> OrientedBoundingBox?
+```
+
+- **Parameters:** `optimal` — when `true`, compute a tighter box from precise geometry (slower);
+  when `false` (default), use the triangulation/vertex-based fit.
+- **Returns:** The `OrientedBoundingBox`, or `nil` if the shape is void.
+- **OCCT:** `BRepBndLib::AddOBB` → `Bnd_OBB` (via `OCCTShapeOrientedBoundingBox`).
+- **Example:**
+  ```swift
+  if let obb = shape.orientedBoundingBox() {
+      print(obb.dimensions)  // full edge lengths of the tight box
+      print(obb.volume)      // occupied volume, rotation-independent
+  }
+  ```
+
+---
+
+### `Shape.orientedBoundingBoxCorners(optimal:)`
+
+Return the 8 corner points of the shape's oriented bounding box, ready for drawing a wireframe
+box or feeding a collision/packing check.
+
+```swift
+public func orientedBoundingBoxCorners(optimal: Bool = false) -> [SIMD3<Double>]?
+```
+
+- **Parameters:** `optimal` — same tight-vs-fast trade-off as `orientedBoundingBox(optimal:)`.
+- **Returns:** An array of exactly 8 corner points in world space, or `nil` if the shape is void.
+- **OCCT:** `Bnd_OBB::GetVertex` over the box built by `BRepBndLib::AddOBB` (via
+  `OCCTOrientedBoundingBoxCorners`).
+
+---
+
 ## ShapeAnalysis_ShapeTolerance Extensions
 
 Extensions on `Shape` for querying sub-shape tolerances.

--- a/docs/reference/Document.md
+++ b/docs/reference/Document.md
@@ -759,6 +759,7 @@ Errors that can occur when working with XDE documents.
 public enum DocumentError: Error, LocalizedError {
     case loadFailed(url: URL)
     case writeFailed(url: URL)
+    public var errorDescription: String? { get }
 }
 ```
 

--- a/docs/reference/Drawing.md
+++ b/docs/reference/Drawing.md
@@ -754,6 +754,7 @@ Error type for 2D drawing operations.
 ```swift
 public enum DrawingError: Error, LocalizedError {
     case projectionFailed
+    public var errorDescription: String? { get }
 }
 ```
 

--- a/docs/reference/Export-Vector.md
+++ b/docs/reference/Export-Vector.md
@@ -27,6 +27,7 @@ Error type thrown by `PDFWriter.write(to:)` and `Exporter.writePDF` variants.
 public enum PDFError: Error, LocalizedError {
     case writeFailed(String)
     case drawingEmpty
+    public var errorDescription: String? { get }
 }
 ```
 
@@ -375,6 +376,7 @@ Error type thrown by `SVGWriter.write(to:)` and `Exporter.writeSVG` variants.
 ```swift
 public enum SVGError: Error, LocalizedError {
     case writeFailed(String)
+    public var errorDescription: String? { get }
 }
 ```
 
@@ -672,6 +674,7 @@ Error type thrown by `DXFWriter.write(to:)` and `Exporter.writeDXF` variants.
 public enum DXFError: Error, LocalizedError {
     case writeFailed(String)
     case drawingEmpty
+    public var errorDescription: String? { get }
 }
 ```
 

--- a/docs/reference/Exporter.md
+++ b/docs/reference/Exporter.md
@@ -39,6 +39,7 @@ public enum ExportError: Error, LocalizedError {
     case invalidPath
     case invalidShape
     case cancelled
+    public var errorDescription: String? { get }
 }
 ```
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -461,6 +461,7 @@ Error type for failed STEP/IGES/BREP imports.
 public enum ImportError: Error, LocalizedError {
     case importFailed(String)
     case cancelled
+    public var errorDescription: String? { get }
 }
 ```
 


### PR DESCRIPTION
## Summary

Closes #294.

`Scripts/count-operations.py --audit` matched a counted entry point's **bare name** against the last path-component of every reference-doc heading, with no notion of the owning type. It over-reported generic names (`get`, `cols`, `z`, `summary`, ...) and could not tell `Document.get` from another `get`. This PR makes both sides of the comparison type-aware, then documents the handful of genuinely-undocumented entry points that survive.

## The type-aware matcher (`Scripts/count-operations.py`)

- **Source side:** `count_entry_points()` now tracks the enclosing `struct`/`class`/`enum`/`actor`/`extension` via a brace-depth stack, so each counted op carries a `Type.name` identity (innermost type for nested/qualified names). A one-liner type body such as `enum Toggle { case a, b }` correctly encloses nothing (this had been mis-attributing the following members, e.g. `Toggle.setMode`, `SegmentKind.segments`).
- **Doc side:** `documented_index()` derives the owning type from a heading (`Type.name(...)`, nested `Outer.Inner`, or a plain `## DXFError`) **and** from the public members listed inside the ```swift code block that a type heading governs. Multi-span headings like `` ### `x`, `y`, `z` `` now contribute every name, not just the first.
- **Match rule:** compare on `(Type, name)`; fall back to a bare-name match only when a heading carries no type qualifier.
- Default and `--fix` behaviour, guard-rails, and the derived **Total (4241)** are unchanged — the Total still comes from `breakdown`, not from the audit identity. `./Scripts/count-operations.py` (default) still exits 0 with README and API_REFERENCE Totals consistent.

## Before / after `--audit`

| | undocumented |
|---|---|
| Before (bare-name matcher) | **37** |
| After precision fix, before new docs | **11** |
| After documenting the 11 | **0** |

26 of the original 37 were **false positives** — already documented under multi-span headings (the 8 Surface type predicates, the 5 Curve3D `ContinuityAnalysis` continuity flags), inside a type's code block (`curveCount`, `lineCount`, `lineType`, `summary`, `totalProblems`, `isHealthy`, `totalCount`, `totalMaterialized`), or under a shorthand heading (`hasGenerated`/`hasRemoved`, the `faceIntegration*` family, `faceLPropTangentV`, the `checkFace*` helpers). The type-aware matcher associates them correctly and stops flagging them.

## Families documented (the 11 true gaps)

- **Oriented bounding box** → `docs/reference/Document-Transforms.md`: the `OrientedBoundingBox` struct, `Shape.orientedBoundingBox(optimal:)`, `Shape.orientedBoundingBoxCorners(optimal:)` (the AABB and `orientedBoundingBoxDetailed`/`DetailedOBB` were documented; the `OrientedBoundingBox`-returning pair was not).
- **OSD_Environment** → `docs/reference/Document-Math-Bounds.md` (alongside the existing `OSD_Timer`/`OSD_MemInfo` sections): `Environment.get(_:)`, `Environment.set(_:value:)`, `Environment.remove(_:)`. OCCT mappings verified against `OSD_Environment.hxx` (`Value()`/`Build()`/`Remove()`).
- **`LocalizedError.errorDescription`** on `DXFError`, `DocumentError`, `DrawingError`, `ExportError`, `ImportError`, `PDFError`, `SVGError` — added to each error enum's existing doc code block (the prose already referenced `errorDescription`; the code block omitted it). These are **public by protocol requirement** and cannot be made `internal`, so documenting is the only option.

## On the suspected accidentally-public internals

The issue flagged the `checkFace*` helpers (`Shape.swift:6405-6417`) and the `faceIntegration*` / `faceLPropTangentV` / `faceSurfaceIntegration` / `faceBoundaryIntegration` intermediate area/mass steps as candidates to make `internal` rather than document. It turns out **they are already documented** (in `docs/reference/Shape-Healing.md`), so they do **not** survive the type-aware audit as gaps and this PR does not touch them. Per the task I did not change any `public`→`internal` visibility. If shrinking the public surface is still wanted, these ~9 helpers remain the natural candidates for a **separate** human decision (an API change with release implications) — but that is out of scope here and no longer a documentation gap.

## Verification

- `./Scripts/count-operations.py --audit` → `0` undocumented, exit 0.
- `./Scripts/count-operations.py` (default) → DERIVED 4241, README ✓, API_REFERENCE Total ✓, exit 0.
- No `public` declarations changed, so the Total is unchanged.

Per the ecosystem docs rule, these doc changes become visible to `context` only once tagged in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)