### PR TITLE
docs(okf): policy — upstream OCCT PRs use OCCT's clang-format + concise comment style

### DIFF
--- a/okf/index.md
+++ b/okf/index.md
@@ -45,3 +45,4 @@ See [`references/`](references/index.md) — OpenCASCADE upstream and licensing 
 
 - [Query `context` first for OCCT / OCCTSwift docs](policies/context-first.md)
 - [Documentation updates are mandatory](policies/docs-current.md)
+- [Upstream OCCT PRs follow OCCT's house style](policies/upstream-occt-style.md)

--- a/okf/policies/upstream-occt-style.md
+++ b/okf/policies/upstream-occt-style.md
@@ -1,0 +1,34 @@
+---
+type: policy
+title: Upstream OCCT PRs follow OCCT's house style
+description: PRs offered to OpenCASCADE must be clang-formatted with OCCT's own .clang-format and use OCCT's concise comment style — not OCCTSwift's.
+tags: [policy, occt, upstream, contributing, formatting]
+timestamp: 2026-07-19
+---
+
+# Upstream OCCT PRs follow OCCT's house style
+
+We contribute fixes upstream, not just issues — the [carried OCCT patches](../references/carried-occt-patches.md)
+are written to be offered to OpenCASCADE, and each is retired once an upstream release contains it.
+A patch only lands upstream if it reads like OCCT's own code. Two hard requirements before opening
+(or attaching a patch to) an OCCT PR:
+
+1. **Format with OCCT's `.clang-format`, not ours.** Run `clang-format` against the `.clang-format`
+   file at the root of the OCCT source tree the patch applies to — over only the lines you changed.
+   Do not reformat surrounding code, and do not fall back to OCCTSwift's or your editor's default
+   style: OCCT's braces, indentation, and column limits differ from ours, and a diff that reformats
+   untouched lines will be rejected on sight.
+
+2. **Match OCCT's concise comment house style.** OCCT comments are terse — a brief `//!` Doxygen
+   header on a declaration, a short `//` note only where the logic isn't self-evident, no narration.
+   Do **not** carry OCCTSwift's expansive doc-comment voice (the multi-sentence "why", runnable
+   examples, issue back-references) into upstream C++. State the mechanism and stop. Keep our own
+   rationale — issue numbers, the reproducer, workaround history — in the PR description / commit
+   message, never in the source comments.
+
+This is a **context switch, not our default**: inside OCCTSwift (the `.mm` bridge and the Swift API)
+we keep our own conventions, including the verbose doc comments the [docs-current](docs-current.md)
+policy expects. OCCT's house style applies only to code destined for the OCCT tree.
+
+See OCCT's own coding rules and contribution workflow (dev.opencascade.org) for the authoritative
+detail; this policy just makes the two non-negotiables explicit so a patch isn't bounced on style.

--- a/okf/references/carried-occt-patches.md
+++ b/okf/references/carried-occt-patches.md
@@ -16,6 +16,10 @@ ahead of an official OCCT release. Each patch is **temporary**: retire it once t
 bundled OCCT version includes the fix. Full rationale + validation per patch lives in
 `Scripts/patches/README.md` — this note is the ecosystem-level pointer.
 
+Each patch is also meant to be **offered upstream** as an OCCT PR. When you do, follow
+[Upstream OCCT PRs follow OCCT's house style](../policies/upstream-occt-style.md): clang-format with
+OCCT's own `.clang-format`, and OCCT's terse comment style — not OCCTSwift's.
+
 | Patch | Fixes | Upstream | Retire when |
 |-------|-------|----------|-------------|
 | `0001-ShapeFix_Face-…-263` | ShapeFix_Face compound-context crash ([#263](https://github.com/SecondMouseAU/OCCTSwift/issues/263)) | [OCCT#1322](https://github.com/Open-Cascade-SAS/OCCT/issues/1322) | bundled OCCT includes the guard |


### PR DESCRIPTION
Adds an OKF policy: when offering a carried OCCT patch upstream as an OpenCASCADE PR, two hard requirements so it isn't rejected on style —

1. **clang-format with OCCT's own `.clang-format`** (over changed lines only), not OCCTSwift's or an editor default.
2. **OCCT's concise `//!` comment house style**, not our verbose doc-comment voice; keep our rationale/issue-refs in the PR description, not the source.

Framed as a context switch — our own bridge/Swift conventions still apply inside OCCTSwift. New file `okf/policies/upstream-occt-style.md`, linked from `okf/index.md` and cross-linked from the carried-patches reference (the patches this governs).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)