### PR TITLE
docs: reconcile carried-patch records with upstream OCCT PRs (audit)

### DIFF
--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -89,9 +89,9 @@ The patch converts the fillet-path shared statics to `static thread_local` (each
 
 This is the same class of fix, in the same engine, as [Open-Cascade-SAS/OCCT#1180](https://github.com/Open-Cascade-SAS/OCCT/pull/1180) (19 TKBool globals → `thread_local` across 8 files); `STATIC_SOLIDINDEX` and these were not covered by it.
 
-**Validation:** the isolated pure-C++ repro (`fuse` two/three prisms → fillet the seam, 8 threads) returns BRepCheck-invalid solids across several wrong volumes on stock p1, and 0/1600 invalid with a single correct volume after the patch. ThreadSanitizer reports the `STATIC_SOLIDINDEX` and `BlendFunc` scratch races on stock p1 and is clean on the fillet path after the patch (only an unrelated benign `BOPAlgo_InitMessages` lazy-init race remains, in the boolean path — orthogonal). While this patch is carried, the in-wrapper `occtFilletMutex` shipped in v1.12.1 serialises fillet/chamfer builds so the corruption cannot reach consumers.
+**Validation:** the isolated pure-C++ repro (`fuse` two/three prisms → fillet the seam, 8 threads) returns BRepCheck-invalid solids across several wrong volumes on stock p1, and 0/1600 invalid with a single correct volume after the patch. ThreadSanitizer reports the `STATIC_SOLIDINDEX` and `BlendFunc` scratch races on stock p1 and is clean on the fillet path after the patch (only an unrelated benign `BOPAlgo_InitMessages` lazy-init race remains, in the boolean path — orthogonal). The in-wrapper `occtFilletMutex` that v1.12.1 shipped as the interim guard was **already removed in v1.12.3** once this kernel patch made fillet reentrant — the patch is now the sole protection.
 
-**Retire** once the bundled OCCT includes these `thread_local` conversions (upstream PR pending), at which point the `occtFilletMutex` guard can also be dropped.
+**Submitted upstream** as [Open-Cascade-SAS/OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374) (open). **Retire** once an upstream OCCT release includes these `thread_local` conversions and we re-pin to it.
 
 ## 0004-ShapeAnalysis_FreeBounds-init-owires-empty-input-310.patch
 

--- a/okf/references/carried-occt-patches.md
+++ b/okf/references/carried-occt-patches.md
@@ -22,9 +22,10 @@ OCCT's own `.clang-format`, and OCCT's terse comment style — not OCCTSwift's.
 
 | Patch | Fixes | Upstream | Retire when |
 |-------|-------|----------|-------------|
-| `0001-ShapeFix_Face-…-263` | ShapeFix_Face compound-context crash ([#263](https://github.com/SecondMouseAU/OCCTSwift/issues/263)) | [OCCT#1322](https://github.com/Open-Cascade-SAS/OCCT/issues/1322) | bundled OCCT includes the guard |
-| `0002-STEPControl_Writer-…-1334` | XDE STEP read corrupts later STEP writes ([#280](https://github.com/SecondMouseAU/OCCTSwift/issues/280)) | [OCCT#1334](https://github.com/Open-Cascade-SAS/OCCT/pull/1334) (merged upstream) | bundled OCCT moves past that commit |
-| `0003-TopOpeBRep-non-reentrant-globals-fillet-298` | Concurrent fillet/chamfer corrupts geometry — non-reentrant `STATIC_SOLIDINDEX` in the TopOpeBRepBuild solid reconstruction ([#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298)) | **[OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)** — filed, not yet released | **an upstream OCCT release includes the `thread_local` conversion** |
+| `0001-ShapeFix_Face-…-263` | ShapeFix_Face compound-context crash ([#263](https://github.com/SecondMouseAU/OCCTSwift/issues/263)) | [OCCT#1322](https://github.com/Open-Cascade-SAS/OCCT/issues/1322) — **issue only, no fix PR submitted yet** | bundled OCCT includes the guard |
+| `0002-STEPControl_Writer-…-1334` | XDE STEP read corrupts later STEP writes ([#280](https://github.com/SecondMouseAU/OCCTSwift/issues/280)) | [OCCT#1334](https://github.com/Open-Cascade-SAS/OCCT/pull/1334) (their fix, merged upstream — we backport) | bundled OCCT moves past that commit |
+| `0003-TopOpeBRep-non-reentrant-globals-fillet-298` | Concurrent fillet/chamfer corrupts geometry — non-reentrant `STATIC_SOLIDINDEX` in the TopOpeBRepBuild solid reconstruction ([#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298)) | **[OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)** (our PR, open — not yet released) | **an upstream OCCT release includes the `thread_local` conversion** |
+| `0004-ShapeAnalysis_FreeBounds-…-310` | `ShapeAnalysis_FreeBounds` SIGSEGV on a compound of 2+ disjoint free-boundary components ([#310](https://github.com/SecondMouseAU/OCCTSwift/issues/310)) | [OCCT#1376](https://github.com/Open-Cascade-SAS/OCCT/issues/1376) (repro) → **[OCCT#1377](https://github.com/Open-Cascade-SAS/OCCT/pull/1377)** (our fix PR, open) | bundled OCCT includes the fix |
 
 **#298 status:** we ship the fix now via patch `0003` (xcframework rebuilt in v1.12.3);
 we keep carrying it — and building our own xcframework — **until an upstream OCCT


### PR DESCRIPTION
Audit of the four carried OCCT patches against upstream Open-Cascade-SAS/OCCT.

**Verified — source changes match the upstream PRs exactly** (line-by-line): 0002's `InitializeMissingParameters();` == OCCT#1334; 0003's `thread_local` conversions == OCCT#1374; 0004's `owires` init == OCCT#1377. (Upstream PRs additionally carry GTest files, which our source-only patches correctly omit.)

**Doc-currency fixes in this PR:**
- **okf table** was missing the **0004** row entirely — added, with #1376 (repro issue) → #1377 (fix PR, open). Also annotated each row's provenance: 0001 issue-only, 0002 their-fix-we-backport, 0003/0004 our open PRs.
- **README 0003** said the upstream PR was 'pending' → now names **OCCT#1374 (open)**; and corrected stale `occtFilletMutex` text (that interim guard was removed in v1.12.3 — the patch is now the sole protection).

**Retirement:** none retireable — no OCCT release includes any fix yet (#1334 merged to master after every existing tag incl. our V8_0_0_p1 pin; #1374/#1377 open; #1322 unfixed).

Docs-only; no `.patch` file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)