### PR TITLE
docs(cookbook): nest BREP graph UID page under Topology Graph

### DIFF
--- a/docs/guides/cookbook/index.md
+++ b/docs/guides/cookbook/index.md
@@ -56,7 +56,7 @@ using the static PNG as the loading poster. Code → figure → 3D model all com
 - [Meshing & Export](meshing-and-export.md) — `mesh` (deflection), the `Mesh` type, `mesh.toShape`, and STL / OBJ / STEP / IGES / BREP / glTF export + import.
 - [XCAF Assemblies](xcaf-assemblies.md) — `Document` trees, components & instancing, names / colors / materials, and structured STEP / GLB round-trip.
 - [Topology Graph](topology-graph.md) — `TopologyGraph` node counts, adjacency & shared edges, per-graph UIDs, and history tracking through operations.
-- [BREP Graph: Durable Identity & UIDs](topology-graph-uids.md): the deep dive on identity. The three UID flavours, minting and resolving, the one-graph-instance scope rule (#295), what preserves identity versus mints a new one, and persistence.
+  - [BREP Graph: Durable Identity & UIDs](topology-graph-uids.md): the deep dive on identity. The three UID flavours, minting and resolving, the one-graph-instance scope rule (#295), what preserves identity versus mints a new one, and persistence.
 - [Gordon Surfaces](gordon-surfaces.md) — skin a surface through a network of profile + guide curves (`Surface.gordon` / `gordonReport`), with build diagnostics.
 - [Surfaces from Points](surfaces-from-points.md) — fit a B-spline through a grid (`fromPointGrid`) or a scattered cloud (`plateThrough`), and deform-to-targets (`nlPlateDeformed`).
 - [Working with Meshes](working-with-meshes.md) — the `Mesh` type: build from arrays, inspect, mesh-level booleans, triangle↔face picking, `toShape`, and SceneKit / RealityKit / Metal interop.

--- a/docs/guides/cookbook/topology-graph-uids.md
+++ b/docs/guides/cookbook/topology-graph-uids.md
@@ -1,7 +1,8 @@
 ---
 title: "BREP Graph: Durable Identity & UIDs"
-parent: Cookbook
-nav_order: 13
+parent: Topology Graph
+grand_parent: Cookbook
+nav_order: 1
 ---
 
 # BREP Graph: Durable Identity & UIDs

--- a/docs/guides/cookbook/topology-graph.md
+++ b/docs/guides/cookbook/topology-graph.md
@@ -2,6 +2,7 @@
 title: Topology Graph
 parent: Cookbook
 nav_order: 9
+has_children: true
 ---
 
 # Topology Graph


### PR DESCRIPTION
Organizational only. Makes the durable-identity/UIDs deep-dive a subsection of Topology Graph rather than a sibling cookbook:

- `topology-graph.md` gains `has_children: true`.
- `topology-graph-uids.md` moves to `parent: Topology Graph`, `grand_parent: Cookbook` (3-level nesting, supported by just-the-docs v0.3.3), `nav_order: 1`.
- The cookbook index lists it as a sub-bullet under Topology Graph.

No content change. No release; it rides the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)