### PR TITLE
feat: WithFullHistory for sew/quilt/heal + hard-bounded isSelfIntersecting (#327, #319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,247 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,248 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,241 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,247 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -4783,6 +4783,46 @@ OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromDefeature(OCCTShapeRef _Nonn
                                                                 OCCTShapeRef _Nullable * _Nullable outResult);
 
 
+// MARK: - Sewing / quilting / healing with full history (issue #327)
+//
+// Same OCCTBooleanHistoryRef handle as booleans/Tier 2 above, so the Swift
+// ShapeHistoryRef/record(of:)/OCCTBRepGraphAddWithHistory surface is shared
+// unchanged. These algorithms don't derive from BRepBuilderAPI_MakeShape, so
+// the history isn't synthesized from a retained builder — each function below
+// builds a BRepTools_History directly (via BRepTools_ReShape::History() for
+// sewing/healing, or a manual per-subshape walk for quilting) and wraps it.
+
+/// Sew multiple shapes into a connected shell/solid, with full per-input-subshape
+/// history (vertex/edge merges, small-face removal).
+// Note: `shapes` intentionally has no nullability annotation on the pointer
+// itself (matches OCCTShapeSew) — Swift's UnsafeMutableBufferPointer.baseAddress
+// is always Optional, and an unannotated C pointer imports leniently enough to
+// accept it directly without unwrapping at the call site.
+OCCTBooleanHistoryRef _Nullable OCCTShapeSewWithHistory(const OCCTShapeRef* shapes,
+                                                          int32_t count, double tolerance,
+                                                          OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Self-sew (merge disconnected faces within one shape), with full history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeSewSingleWithHistory(OCCTShapeRef _Nonnull shape,
+                                                                 double tolerance,
+                                                                 OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Quilt multiple shapes (faces/shells) into a single shell, with full history.
+/// See OCCTShapeSewWithHistory above for why `shapes` is unannotated.
+OCCTBooleanHistoryRef _Nullable OCCTShapeQuiltWithHistory(OCCTShapeRef* shapes,
+                                                             int32_t count,
+                                                             OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Heal/repair a shape (ShapeFix_Shape), with full history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHealWithHistory(OCCTShapeRef _Nonnull shape,
+                                                            OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Create a solid from a closed shell (BRepBuilderAPI_MakeSolid + ShapeFix_Solid
+/// orientation fix), with full history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef _Nonnull shell,
+                                                                           OCCTShapeRef _Nullable * _Nullable outResult);
+
+
 // MARK: - Thick Solid / Hollowing (v0.37.0)
 
 /// Create a hollowed (thick) solid by removing faces and offsetting inward.

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -1169,6 +1169,10 @@ OCCTShapeRef OCCTShapeQuilt(OCCTShapeRef* shapes, int32_t count) {
     }
 }
 
+// OCCTShapeQuiltWithHistory lives further down (MARK: - Sewing / quilting /
+// healing with full history, issue #327) — it constructs OCCTBooleanHistory,
+// whose definition comes later in this file.
+
 // MARK: - Revolution from Curve (v0.31.0)
 
 #include <BRepPrimAPI_MakeRevolution.hxx>
@@ -1690,17 +1694,28 @@ struct OCCTBooleanHistory {
     // Builder kept alive for the lifetime of the handle. unique_ptr because
     // BRepBuilderAPI_MakeShape carries large internal state and is not
     // safely copyable. Upcast from concrete Fuse / Cut / Common / Splitter.
+    // Null when `prebuilt` is used instead (sewing / quilting / healing,
+    // issue #327 — those algorithms don't derive from BRepBuilderAPI_MakeShape).
     std::unique_ptr<BRepBuilderAPI_MakeShape> op;
 
     // The shapes the builder ran on. Retained because BRepTools_History's
     // template constructor needs the argument list to know which subshapes to
     // walk, and a type-erased BRepBuilderAPI_MakeShape cannot report its own
-    // inputs. See OCCTBooleanHistoryAsBRepToolsHistory.
+    // inputs. See OCCTBooleanHistoryAsBRepToolsHistory. Unused when `prebuilt`
+    // is set.
     TopTools_ListOfShape args;
+
+    // Already-complete history for algorithms that expose one natively
+    // (BRepTools_ReShape::History(), used by sewing and healing) or that need
+    // hand-built history (quilting). Set instead of `op`/`args`.
+    Handle(BRepTools_History) prebuilt;
 
     OCCTBooleanHistory(std::unique_ptr<BRepBuilderAPI_MakeShape> theOp,
                        const TopTools_ListOfShape& theArgs)
         : op(std::move(theOp)), args(theArgs) {}
+
+    explicit OCCTBooleanHistory(const Handle(BRepTools_History)& thePrebuilt)
+        : prebuilt(thePrebuilt) {}
 };
 
 // Convenience for the common 1- and 2-argument builders.
@@ -1779,7 +1794,9 @@ int32_t OCCTBooleanHistoryModified(OCCTBooleanHistoryRef h, OCCTShapeRef inputSu
                                      OCCTShapeRef* outRefs, int32_t maxCount) {
     if (!h || !inputSubShape) return -1;
     try {
-        const TopTools_ListOfShape& list = h->op->Modified(inputSubShape->shape);
+        const TopTools_ListOfShape& list = h->op
+            ? h->op->Modified(inputSubShape->shape)
+            : h->prebuilt->Modified(inputSubShape->shape);
         int32_t count = 0;
         for (TopTools_ListIteratorOfListOfShape it(list); it.More(); it.Next()) {
             if (outRefs && count < maxCount) {
@@ -1796,7 +1813,12 @@ int32_t OCCTBooleanHistoryGenerated(OCCTBooleanHistoryRef h, OCCTShapeRef inputS
                                       OCCTShapeRef* outRefs, int32_t maxCount) {
     if (!h || !inputSubShape) return -1;
     try {
-        const TopTools_ListOfShape& list = h->op->Generated(inputSubShape->shape);
+        // Sewing/quilting/healing (prebuilt) never populate Generated — they
+        // only replace or remove, never create lower/higher-dimension topology
+        // — but BRepTools_History::Generated still returns a valid empty list.
+        const TopTools_ListOfShape& list = h->op
+            ? h->op->Generated(inputSubShape->shape)
+            : h->prebuilt->Generated(inputSubShape->shape);
         int32_t count = 0;
         for (TopTools_ListIteratorOfListOfShape it(list); it.More(); it.Next()) {
             if (outRefs && count < maxCount) {
@@ -1811,11 +1833,13 @@ int32_t OCCTBooleanHistoryGenerated(OCCTBooleanHistoryRef h, OCCTShapeRef inputS
 bool OCCTBooleanHistoryIsDeleted(OCCTBooleanHistoryRef h, OCCTShapeRef inputSubShape) {
     if (!h || !inputSubShape) return false;
     try {
-        return h->op->IsDeleted(inputSubShape->shape);
+        return h->op ? h->op->IsDeleted(inputSubShape->shape)
+                      : h->prebuilt->IsRemoved(inputSubShape->shape);
     } catch (...) { return false; }
 }
 
-// Synthesize a standalone BRepTools_History from the retained builder.
+// Synthesize a standalone BRepTools_History from the retained builder, or hand
+// back the already-complete one for sewing/quilting/healing (issue #327).
 //
 // BRepTools_History's template constructor walks the argument list and copies
 // Modified / Generated / IsDeleted for each supported subshape, so it works off
@@ -1827,10 +1851,20 @@ bool OCCTBooleanHistoryIsDeleted(OCCTBooleanHistoryRef h, OCCTShapeRef inputSubS
 // (BRepTools_History::IsSupportedType) — wires, shells and compounds are not
 // carried, so absorbing this into a graph records nothing for those kinds.
 OCCTHistoryRef OCCTBooleanHistoryAsBRepToolsHistory(OCCTBooleanHistoryRef h) {
-    if (!h || !h->op) return nullptr;
+    if (!h) return nullptr;
     try {
         auto* ref = new OCCTHistoryStorage();
-        ref->history = new BRepTools_History(h->args, *h->op);
+        if (h->op) {
+            ref->history = new BRepTools_History(h->args, *h->op);
+        } else if (!h->prebuilt.IsNull()) {
+            // Shared Handle (ref-counted) — cheap, and keeps `h` independently
+            // queryable via OCCTBooleanHistoryModified/Generated/IsDeleted after
+            // this call, same as the synthesized-from-op case.
+            ref->history = h->prebuilt;
+        } else {
+            delete ref;
+            return nullptr;
+        }
         return ref;
     } catch (...) { return nullptr; }
 }
@@ -2872,6 +2906,186 @@ OCCTShapeRef OCCTShapeSewTwo(OCCTShapeRef shape1, OCCTShapeRef shape2, double to
 
     OCCTShapeRef shapes[2] = { shape1, shape2 };
     return OCCTShapeSew(shapes, 2, tolerance);
+}
+
+// MARK: - Sewing with full history (issue #327)
+//
+// BRepBuilderAPI_Sewing isn't a BRepBuilderAPI_MakeShape (no Modified/Generated/
+// IsDeleted), but its constructor always allocates its own BRepTools_ReShape
+// context (confirmed in occt-src BRepBuilderAPI_Sewing.cxx) and records every
+// vertex/edge merge and small-face removal into it via Replace()/Remove() during
+// Perform(). So GetContext()->History() gives a complete, native BRepTools_History
+// — no manual per-subshape walk needed. When two inputs merge into one shared
+// output (the common case for sewing), BOTH inputs are recorded as Modified into
+// that output (BRepTools_ReShape::Replace is called for each), not one Modified +
+// one Removed — verified by reading the vertex-merge code path directly.
+
+OCCTBooleanHistoryRef OCCTShapeSewWithHistory(const OCCTShapeRef* shapes, int32_t count,
+                                                double tolerance, OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shapes || count < 1) return nullptr;
+    try {
+        BRepBuilderAPI_Sewing sewing(tolerance);
+        for (int32_t i = 0; i < count; i++) {
+            if (shapes[i]) sewing.Add(shapes[i]->shape);
+        }
+        sewing.Perform();
+        TopoDS_Shape sewn = sewing.SewedShape();
+        if (sewn.IsNull()) return nullptr;
+
+        if (sewn.ShapeType() == TopAbs_SHELL) {
+            TopoDS_Shell shell = TopoDS::Shell(sewn);
+            if (shell.Closed()) {
+                BRepBuilderAPI_MakeSolid makeSolid(shell);
+                if (makeSolid.IsDone()) sewn = makeSolid.Solid();
+            }
+        }
+
+        Handle(BRepTools_History) hist = sewing.GetContext()->History();
+        if (hist.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(sewn);
+        return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
+}
+
+// Self-sew (mirrors OCCTShapeSewSingle in OCCTBridge_Healing.mm) with full
+// history. Lives here, not next to its plain counterpart, because
+// OCCTBooleanHistory is private to this translation unit — every function that
+// constructs one has to live in this file (same constraint the Tier 2
+// fillet/chamfer/shell/defeature *WithHistory functions above are already under).
+OCCTBooleanHistoryRef OCCTShapeSewSingleWithHistory(OCCTShapeRef shape, double tolerance,
+                                                      OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape) return nullptr;
+    try {
+        BRepBuilderAPI_Sewing sewing(tolerance);
+        sewing.Add(shape->shape);
+        sewing.Perform();
+        TopoDS_Shape sewn = sewing.SewedShape();
+        if (sewn.IsNull()) return nullptr;
+
+        if (sewn.ShapeType() == TopAbs_SHELL) {
+            TopoDS_Shell shell = TopoDS::Shell(sewn);
+            if (shell.Closed()) {
+                BRepBuilderAPI_MakeSolid makeSolid(shell);
+                if (makeSolid.IsDone()) sewn = makeSolid.Solid();
+            }
+        }
+
+        Handle(BRepTools_History) hist = sewing.GetContext()->History();
+        if (hist.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(sewn);
+        return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
+}
+
+// Quilt with full history. BRepTools_Quilt has no ReShape context and no
+// Modified/Generated/IsDeleted — only single-shape IsCopied()/Copy() — so
+// unlike sewing/healing this needs a manual per-subshape walk to build the
+// BRepTools_History by hand.
+OCCTBooleanHistoryRef OCCTShapeQuiltWithHistory(OCCTShapeRef* shapes, int32_t count,
+                                                  OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shapes || count <= 0) return nullptr;
+    try {
+        BRepTools_Quilt quilt;
+        for (int32_t i = 0; i < count; i++) {
+            if (!shapes[i]) return nullptr;
+            quilt.Add(shapes[i]->shape);
+        }
+        TopoDS_Shape result = quilt.Shells();
+        if (result.IsNull()) return nullptr;
+
+        Handle(BRepTools_History) hist = new BRepTools_History();
+        TopTools_IndexedMapOfShape subMap;
+        for (int32_t i = 0; i < count; i++) {
+            subMap.Clear();
+            TopExp::MapShapes(shapes[i]->shape, subMap);
+            for (int32_t j = 1; j <= subMap.Extent(); j++) {
+                const TopoDS_Shape& sub = subMap(j);
+                if (!BRepTools_History::IsSupportedType(sub)) continue;
+                if (quilt.IsCopied(sub)) {
+                    hist->AddModified(sub, quilt.Copy(sub));
+                }
+            }
+        }
+
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
+}
+
+// MARK: - Healing with full history (issue #327)
+//
+// ShapeFix_Shape isn't a BRepBuilderAPI_MakeShape either, but ShapeFix_Shape::
+// Init auto-creates a ShapeBuild_ReShape context when none is set (confirmed in
+// occt-src) and every internal sub-fixer (Solid/Shell/Face/Wire/Edge) shares it,
+// so Context()->History() after Perform() is complete and safe without an
+// explicit SetContext() call. (ShapeFix_Solid, used below for solid(from:), does
+// NOT auto-create one — see OCCTShapeCreateSolidFromShellWithHistory.)
+
+#include <ShapeFix_Shape.hxx>
+
+OCCTBooleanHistoryRef OCCTShapeHealWithHistory(OCCTShapeRef shape, OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape) return nullptr;
+    try {
+        if (occtHasSelfIntersectingWire(shape->shape)) return nullptr;
+        Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
+        fixer->Perform();
+        TopoDS_Shape result = fixer->Shape();
+        if (result.IsNull()) return nullptr;
+
+        Handle(BRepTools_History) hist = fixer->Context()->History();
+        if (hist.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
+}
+
+// MARK: - Solid from shell with full history (issue #327)
+//
+// Unlike sewing/healing, BRepBuilderAPI_MakeSolid genuinely derives from
+// BRepBuilderAPI_MakeShape (fits the existing template-synthesis path), but a
+// solid built from an already-closed shell doesn't modify/generate any of the
+// shell's sub-shapes — it only wraps it — so the templated ctor would report
+// nothing. The one stage that can actually touch sub-shape identity is the
+// ShapeFix_Solid orientation-fix pass, so that's the history source here.
+// ShapeFix_Solid::Init does NOT auto-create a context (verified in occt-src,
+// unlike ShapeFix_Shape above) — SetContext() must be called explicitly before
+// Perform(), or Context()->History() below would dereference a null Handle.
+OCCTBooleanHistoryRef OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef shell,
+                                                                  OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shell) return nullptr;
+    try {
+        TopoDS_Shell topoShell;
+        if (shell->shape.ShapeType() == TopAbs_SHELL) {
+            topoShell = TopoDS::Shell(shell->shape);
+        } else {
+            TopExp_Explorer exp(shell->shape, TopAbs_SHELL);
+            if (!exp.More()) return nullptr;
+            topoShell = TopoDS::Shell(exp.Current());
+        }
+
+        BRepBuilderAPI_MakeSolid makeSolid(topoShell);
+        if (!makeSolid.IsDone()) return nullptr;
+        TopoDS_Solid solid = makeSolid.Solid();
+        if (solid.IsNull()) return nullptr;
+
+        ShapeFix_Solid fixer(solid);
+        fixer.SetContext(new ShapeBuild_ReShape);
+        fixer.Perform();
+        TopoDS_Shape result = fixer.Solid();
+        if (result.IsNull() || result.ShapeType() != TopAbs_SOLID) {
+            result = solid;  // Fall back to the unfixed solid, same as OCCTShapeCreateSolidFromShell.
+        }
+
+        Handle(BRepTools_History) hist = fixer.Context()->History();
+        if (hist.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
 }
 
 OCCTWireRef OCCTWireInterpolate(const double* points, int32_t count, bool closed, double tolerance) {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -5081,6 +5081,95 @@ extension Shape {
     }
 }
 
+// MARK: - Sewing / quilting / healing with full history (issue #327)
+
+extension Shape {
+    /// Sew multiple shapes into a connected shell or solid, with full
+    /// per-input-subshape history (vertex/edge merges, small-face removal).
+    ///
+    /// Where two coincident inputs merge into one shared output (the common
+    /// case for sewing), both inputs show up as `modified` into that same
+    /// output sub-shape — there is no ambiguity between which side "won".
+    ///
+    /// - Returns: `(result, history)` on success; nil on failure.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let faces = [topFace, bottomFace, frontFace, backFace, leftFace, rightFace]
+    /// guard let (solid, history) = Shape.sewWithFullHistory(shapes: faces, tolerance: 1e-6) else { return }
+    /// let record = history.record(of: topFace)
+    /// print(record.modified, record.isDeleted)
+    /// ```
+    public static func sewWithFullHistory(shapes: [Shape], tolerance: Double = 1e-6)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        guard !shapes.isEmpty else { return nil }
+        var shapeHandles = shapes.map { $0.handle as OCCTShapeRef? }
+        var resultRef: OCCTShapeRef?
+        let h = shapeHandles.withUnsafeMutableBufferPointer { buffer in
+            OCCTShapeSewWithHistory(buffer.baseAddress, Int32(shapes.count), tolerance, &resultRef)
+        }
+        guard let h, let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Sew this shape with another, with full per-input-subshape history.
+    public func sewnWithFullHistory(with other: Shape, tolerance: Double = 1e-6)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        Shape.sewWithFullHistory(shapes: [self, other], tolerance: tolerance)
+    }
+
+    /// Sew disconnected faces within this shape together, with full history.
+    public func sewnWithFullHistory(tolerance: Double = 1e-6)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeSewSingleWithHistory(handle, tolerance, &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Quilt multiple shapes (faces/shells) into a single shell, with full
+    /// per-input-subshape history.
+    public static func quiltWithFullHistory(_ shapes: [Shape])
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        guard !shapes.isEmpty else { return nil }
+        var handles = shapes.map { $0.handle as OCCTShapeRef? }
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeQuiltWithHistory(&handles, Int32(shapes.count), &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Attempt to repair/heal the shape, with full per-input-subshape history.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// guard let (healed, history) = brokenShape.healedWithFullHistory() else { return }
+    /// let record = history.record(of: someFace)
+    /// ```
+    public func healedWithFullHistory() -> (result: Shape, history: ShapeHistoryRef)? {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHealWithHistory(handle, &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Create a solid from a closed shell, with full per-input-subshape
+    /// history. History only reflects the orientation-fix pass — wrapping an
+    /// already-closed shell into a solid does not itself modify any sub-shape.
+    public static func solidWithFullHistory(from shell: Shape) -> (result: Shape, history: ShapeHistoryRef)? {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeCreateSolidFromShellWithHistory(shell.handle, &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+}
+
 // MARK: - Thick Solid / Hollowing (v0.37.0)
 
 extension Shape {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1968,6 +1968,62 @@ public final class Shape: @unchecked Sendable {
         }
     }
 
+    /// Whether this shape self-intersects, with a **true hard wall-clock deadline** (#319) —
+    /// unlike ``isSelfIntersecting(timeout:)``, this returns at `hardTimeout` even if OCCT never
+    /// reaches a checkpoint to poll.
+    ///
+    /// Runs the check on a detached background thread against a `deepCopy()` of this shape
+    /// (independent geometry — the standard pattern for concurrent OCCT work; see
+    /// `docs/thread-safety.md`) and waits on the calling thread with a real deadline. If the
+    /// deadline passes first, this returns `nil` immediately and the background computation is
+    /// **abandoned, not cancelled** — it keeps running orphaned on its own thread until it
+    /// eventually completes. That is a deliberate trade (burned CPU for a caller-side wall-clock
+    /// guarantee), the same one the #286 mesher-hang caller accepted.
+    ///
+    /// - Important: `BOPAlgo_ArgumentAnalyzer`'s safety when run on a background thread
+    ///   concurrently with unrelated OCCT calls on other threads was verified with a
+    ///   ThreadSanitizer stress test (60 bursts × 8 threads — half running self-intersection
+    ///   checks on independent self-intersecting shapes, half running unrelated fuse+mesh work,
+    ///   480 operations total): zero TSan race reports, zero wrong-but-plausible results. That
+    ///   covers one stress shape and one access pattern, not an exhaustive audit of every
+    ///   `BOPAlgo_ArgumentAnalyzer`/`Intf_Interference` code path — prefer
+    ///   ``isSelfIntersecting(timeout:)`` unless a caller genuinely needs a hard in-process
+    ///   wall-clock guarantee (e.g. no process/subprocess isolation available).
+    ///
+    /// - Parameter hardTimeout: Seconds to wait before giving up and returning `nil`.
+    /// - Returns: `true`/`false` if the check completed in time, `nil` if the deadline passed
+    ///   first (indeterminate — the background check may still be running).
+    ///
+    /// ```swift
+    /// // Bound total wall-clock time even on a pathological B-spline solid with no
+    /// // OCCT checkpoints in its self-interference phase.
+    /// switch solid.isSelfIntersecting(hardTimeout: 5) {
+    /// case .some(true):  print("self-intersects")
+    /// case .some(false): print("clean")
+    /// case .none:        print("deadline hit — treat as unknown, not clean")
+    /// }
+    /// ```
+    public func isSelfIntersecting(hardTimeout: Double) -> Bool? {
+        final class SelfIntersectResultBox: @unchecked Sendable {
+            var rawResult: Int32 = -1
+        }
+        let probe = deepCopy() ?? self
+        let box = SelfIntersectResultBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            box.rawResult = OCCTShapeSelfIntersectsBounded(probe.handle, 0)
+            semaphore.signal()
+        }
+        guard semaphore.wait(timeout: .now() + hardTimeout) == .success else {
+            return nil
+        }
+        switch box.rawResult {
+        case 1:  return true
+        case 0:  return false
+        default: return nil
+        }
+    }
+
     // MARK: - Sub-Shape Extraction
 
     /// Get the number of sub-shapes of a given topological type.

--- a/Tests/OCCTModelingTests/Issue208SelfIntersectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue208SelfIntersectionTests.swift
@@ -37,3 +37,39 @@ struct Issue208SelfIntersection {
         #expect(r == nil || r == true)
     }
 }
+
+// #319: a genuinely hard-bounded variant, following up on #293 (which documented that
+// isSelfIntersecting(timeout:) is cooperative-only). Runs the check on a detached worker
+// thread against a deepCopy(), with the calling thread enforcing the real deadline.
+@Suite("Issue #319 — hard-bounded self-intersection check")
+struct Issue319HardBoundedSelfIntersection {
+
+    @Test("a clean solid reports not self-intersecting")
+    func cleanSolidIsClean() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { #expect(Bool(false)); return }
+        #expect(box.isSelfIntersecting(hardTimeout: 30) == false)
+    }
+
+    @Test("two overlapping solids in one compound are detected as self-intersecting")
+    func overlappingCompoundIsSelfIntersecting() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10),
+              let compound = Shape.compound([a, b]) else { #expect(Bool(false)); return }
+        #expect(compound.isSelfIntersecting(hardTimeout: 30) == true)
+    }
+
+    @Test("a near-zero deadline returns near that deadline, not after the full check — the property timeout: cannot offer")
+    func deadlineIsActuallyHard() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10),
+              let compound = Shape.compound([a, b]) else { #expect(Bool(false)); return }
+        let start = Date()
+        let r = compound.isSelfIntersecting(hardTimeout: 0.001)
+        let elapsed = Date().timeIntervalSince(start)
+        // Either it found a fault before the deadline (true) or the deadline won (nil) —
+        // both are acceptable outcomes. What matters is the CALLER'S wall-clock time, which
+        // must track the deadline rather than the check's full (potentially unbounded) duration.
+        #expect(r == nil || r == true)
+        #expect(elapsed < 2.0, "hard deadline should bound the caller's wall-clock time, got \(elapsed)s")
+    }
+}

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -6288,3 +6288,165 @@ struct FeatureSpecCodableTests {
         }
     }
 }
+
+// MARK: - Sewing / Quilting / Healing with Full History (issue #327)
+
+@Suite("Sewing / Quilting / Healing with Full History")
+struct SewQuiltHealFullHistoryTests {
+    /// Two independently-created unit-10 squares in the XY plane, positioned so
+    /// face1's right edge (x=5) exactly coincides with face2's left edge — two
+    /// genuinely distinct TopoDS_Edge instances, not a shared one.
+    static func touchingFaces() -> (face1: Shape, face2: Shape) {
+        let face1 = Shape.face(from: Wire.rectangle(width: 10, height: 10)!)!
+        let face2 = face1.translated(by: SIMD3(10, 0, 0))!
+        return (face1, face2)
+    }
+
+    static func edgeNearX(_ shape: Shape, _ x: Double) -> Shape {
+        shape.subShapes(ofType: .edge).min { abs($0.center.x - x) < abs($1.center.x - x) }!
+    }
+
+    @Test("Sew: two touching inputs merge into ONE shared output edge, both reported Modified")
+    func sewManyToOneMerge() {
+        let (face1, face2) = Self.touchingFaces()
+        guard let r = Shape.sewWithFullHistory(shapes: [face1, face2], tolerance: 1e-6) else {
+            Issue.record("sew should succeed for two touching faces")
+            return
+        }
+        #expect(r.result.isValid)
+
+        let edge1 = Self.edgeNearX(face1, 5)
+        let edge2 = Self.edgeNearX(face2, 5)
+        let rec1 = r.history.record(of: edge1)
+        let rec2 = r.history.record(of: edge2)
+        #expect(!rec1.isDeleted)
+        #expect(!rec2.isDeleted)
+
+        guard let out1 = rec1.modified.first, let out2 = rec2.modified.first else {
+            Issue.record("expected both shared-edge inputs to be Modified into an output edge")
+            return
+        }
+        // The #327 "faithfulness" open question: sewing's many-to-one merge
+        // records BOTH inputs as Modified into the SAME output edge — neither
+        // side is silently dropped or treated as Removed.
+        #expect(out1.isSame(as: out2))
+    }
+
+    @Test("Sew: non-touching input reports queryable, non-deleted history")
+    func sewUnmergedFaceHistory() {
+        let face1 = Shape.face(from: Wire.rectangle(width: 10, height: 10)!)!
+        let face2 = Shape.face(from: Wire.circle(radius: 5)!)!
+        guard let r = Shape.sewWithFullHistory(shapes: [face1, face2], tolerance: 1e-6) else {
+            Issue.record("sew should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        let rec = r.history.record(of: face1.subShapes(ofType: .edge).first!)
+        #expect(!rec.isDeleted)
+    }
+
+    @Test("sewnWithFullHistory(with:) instance convenience matches the static form")
+    func sewnWithFullHistoryConvenience() {
+        let (face1, face2) = Self.touchingFaces()
+        guard let r = face1.sewnWithFullHistory(with: face2, tolerance: 1e-6) else {
+            Issue.record("sewn(with:) should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        let edge1 = Self.edgeNearX(face1, 5)
+        #expect(!r.history.record(of: edge1).isDeleted)
+    }
+
+    @Test("Self-sew (sewnWithFullHistory(tolerance:)) merges two touching faces in one compound")
+    func selfSewWithHistory() {
+        let (face1, face2) = Self.touchingFaces()
+        guard let compound = Shape.compound([face1, face2]) else {
+            Issue.record("compound construction should succeed")
+            return
+        }
+        guard let r = compound.sewnWithFullHistory(tolerance: 1e-6) else {
+            Issue.record("self-sew should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+    }
+
+    @Test("Quilt: box's own faces produce a valid shell with queryable, non-deleted history")
+    func quiltBoxFacesWithHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let faces = box.subShapes(ofType: .face)
+        guard let r = Shape.quiltWithFullHistory(faces) else {
+            Issue.record("quilt should succeed on a box's own faces")
+            return
+        }
+        #expect(r.result.isValid)
+        for face in faces {
+            #expect(!r.history.record(of: face).isDeleted)
+        }
+    }
+
+    @Test("Healed shape returns full history queryable on every input face")
+    func healedWithHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let r = box.healedWithFullHistory() else {
+            Issue.record("heal should succeed on a valid box")
+            return
+        }
+        #expect(r.result.isValid)
+        for face in box.subShapes(ofType: .face) {
+            #expect(!r.history.record(of: face).isDeleted)
+        }
+    }
+
+    @Test("Solid from shell returns full history queryable on every input face")
+    func solidFromShellWithHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let shell = box.subShapes(ofType: .shell).first else {
+            Issue.record("box should expose its own shell")
+            return
+        }
+        guard let r = Shape.solidWithFullHistory(from: shell) else {
+            Issue.record("solid(from:) with history should succeed")
+            return
+        }
+        #expect(r.result.volume! > 0)
+        for face in box.subShapes(ofType: .face) {
+            #expect(!r.history.record(of: face).isDeleted)
+        }
+    }
+
+    @Test("History handle from sew survives; record(of:) is callable repeatedly")
+    func sewHistoryHandleSurvives() {
+        let (face1, face2) = Self.touchingFaces()
+        guard let r = Shape.sewWithFullHistory(shapes: [face1, face2], tolerance: 1e-6) else {
+            Issue.record("sew should succeed")
+            return
+        }
+        let edge1 = Self.edgeNearX(face1, 5)
+        let r1 = r.history.record(of: edge1)
+        let r2 = r.history.record(of: edge1)
+        #expect(r1.modified.count == r2.modified.count)
+        #expect(r1.isDeleted == r2.isDeleted)
+    }
+
+    @Test("A sew's history can be absorbed into a TopologyGraph (issue #290 integration)")
+    func sewHistoryAbsorbsIntoGraph() {
+        let (face1, face2) = Self.touchingFaces()
+        guard let compound = Shape.compound([face1, face2]),
+              let graph = TopologyGraph(shape: compound),
+              let root = graph.findNode(for: compound) else {
+            Issue.record("graph setup failed")
+            return
+        }
+        guard let r = Shape.sewWithFullHistory(shapes: [face1, face2], tolerance: 1e-6) else {
+            Issue.record("sew should succeed")
+            return
+        }
+        #expect(graph.historyRecordCount == 0)
+        let added = graph.add(r.result, absorbing: r.history,
+                              inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+                              operationName: "sew")
+        #expect(added != nil, "add(absorbing:) should succeed for a sew's synthesized history")
+        #expect(graph.historyRecordCount > 0, "absorb should have written history records")
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,241** | |
+| **Total** | **4,247** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,247** | |
+| **Total** | **4,248** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,48 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.13.0
+## Current: v1.13.1
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #323 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.13.1 (July 2026) — feat: hard-bounded `isSelfIntersecting`, TSan-verified (#319)
+
+Follow-up to #293 (closed, doc-only fix): `isSelfIntersecting(timeout:)` is cooperative — it can only
+return once OCCT polls, and `BOPAlgo_ArgumentAnalyzer`'s self-interference phase has at least one long
+checkpoint-free stretch (`Intf_Interference::Insert`). #319 tracked two tracks; only Track 1 ships here.
+
+**New: `Shape.isSelfIntersecting(hardTimeout:)`** — a genuinely hard wall-clock bound. Runs the check
+on a detached background thread against a `deepCopy()` (independent geometry, the standard pattern for
+concurrent OCCT work), and waits on the calling thread with a real `DispatchSemaphore` deadline. If the
+deadline passes first, returns `nil` immediately and the background computation is **abandoned, not
+cancelled** — it keeps running orphaned until it eventually completes (burned CPU traded for a
+caller-side guarantee, the same trade the #286 mesher-hang caller made). Additive: `timeout:` is
+unchanged, and the two overload labels (`timeout:` / `hardTimeout:`) disambiguate cleanly.
+
+**Prerequisite work, not skipped:** the reason this wasn't done alongside the v1.12.5 doc fix was an
+open question — is `BOPAlgo_ArgumentAnalyzer` safe to run on a worker thread concurrently with
+unrelated OCCT calls on other threads? That shape of concurrency (not OCCT's own internal
+`SetRunParallel`, and not this project's usual "independent shapes on independent threads" pattern
+either, since the *caller* keeps running) had no precedent in this codebase. Investigated with the same
+method that found #298's fillet race: a minimal OCCT build (`FoundationClasses` + `ModelingData` +
+`ModelingAlgorithms` only) with `-fsanitize=thread`, then a stress harness — 60 bursts × 8 threads, half
+running self-intersection checks on independent self-intersecting compounds (36 overlapping boxes,
+genuine interference so `Intf_Interference::Insert` does real work), half running unrelated
+fuse+mesh work concurrently on independent shapes. 480 operations, zero TSan race reports, zero
+wrong-but-plausible results. That's a positive signal on one stress shape and one access pattern, not
+an exhaustive audit — the doc comment says so explicitly, and `isSelfIntersecting(timeout:)` stays the
+default recommendation unless a caller genuinely needs the hard guarantee.
+
+**Track 2 (upstream OCCT report: missing checkpoints + the `Intf_Interference::Insert` quadratic)
+remains blocked** — still needs the minimal, un-thrashed reproducer from a quiet-host OCCTReconstruct
+#208 re-run, which has not happened. No action taken on Track 2 in this release.
+
+New suite `Issue319HardBoundedSelfIntersection` (`OCCTModelingTests`), 3 tests. No kernel change, no
+xcframework rebuild — reuses the v1.12.9 binary.
 
 ### v1.13.0 (July 2026) — feat: `*WithFullHistory` for sewing, quilting, and healing (#327)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,71 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.12.10
+## Current: v1.13.0
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #323 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.13.0 (July 2026) — feat: `*WithFullHistory` for sewing, quilting, and healing (#327)
+
+`add(_:absorbing:inputRoots:operationName:)` (#290) solved "an operation rebuilt the shape, keep my
+selection" for booleans and Tier 2 modification ops — but only when the operation hands back a
+`ShapeHistoryRef`, and the operations at the heart of a mesh-to-B-Rep pipeline (sew → heal → solid)
+returned a bare `Shape?` with nothing to absorb.
+
+**New, all returning `(result: Shape, history: ShapeHistoryRef)`:**
+
+- `Shape.sewWithFullHistory(shapes:tolerance:)`, `.sewnWithFullHistory(with:tolerance:)`,
+  `.sewnWithFullHistory(tolerance:)` (self-sew)
+- `Shape.quiltWithFullHistory(_:)`
+- `Shape.healedWithFullHistory()`
+- `Shape.solidWithFullHistory(from:)`
+
+```swift
+let (shell, history) = Shape.sewWithFullHistory(shapes: faces, tolerance: 1e-6)!
+let record = history.record(of: someInputFace)   // .modified / .generated / .isDeleted
+graph.add(shell, absorbing: history, inputRoots: [root], operationName: "sew")
+```
+
+**Implementation:** none of these algorithms derive from `BRepBuilderAPI_MakeShape`, so the existing
+`OCCTBooleanHistoryAsBRepToolsHistory` template-synthesis path (built for booleans/fillet/chamfer/
+thick-solid) doesn't apply directly. `OCCTBooleanHistory` (the opaque handle behind `ShapeHistoryRef`)
+now optionally carries an already-built `Handle(BRepTools_History)` instead of a retained builder:
+
+- **Sewing** (`sew`/`sewn` both directions) — `BRepBuilderAPI_Sewing` always allocates its own
+  `BRepTools_ReShape` context (confirmed in `occt-src`) and records every vertex/edge merge and
+  small-face removal into it via `Replace()`/`Remove()` during `Perform()`, so
+  `GetContext()->History()` is complete and native — no manual walk needed.
+- **Healing** (`healed`) — `ShapeFix_Shape::Init` auto-creates its `ShapeBuild_ReShape` context, so
+  `Context()->History()` is likewise safe and complete without an explicit `SetContext()` call.
+- **Solid from shell** (`solid(from:)`) — the one case that's the mirror image: `BRepBuilderAPI_MakeSolid`
+  genuinely fits the template-synthesis path, but wrapping an already-closed shell into a solid doesn't
+  modify any sub-shape, so that path would report nothing. The real history source is the
+  `ShapeFix_Solid` orientation-fix pass — and unlike `ShapeFix_Shape`, `ShapeFix_Solid::Init` does
+  **not** auto-create a context (verified in `occt-src`), so the bridge now calls
+  `SetContext(new ShapeBuild_ReShape)` explicitly before `Perform()`.
+- **Quilting** — `BRepTools_Quilt` has no `ReShape` context and no `Modified`/`Generated`/`IsDeleted`,
+  only single-shape `IsCopied()`/`Copy()`, so this is the one manual per-subshape walk in the group.
+
+**Faithfulness question answered:** the issue asked whether sewing's many-to-one merges (two coincident
+input edges becoming one output edge — the *normal* case for sewing, not an edge case) are represented
+cleanly. Confirmed by reading `BRepBuilderAPI_Sewing`'s vertex-merge code directly, and by a regression
+test: **both merged inputs are recorded as Modified into the same output edge** — neither side is
+silently dropped or marked Removed. `Shape.isSame(as:)` verifies the two records' outputs are the
+identical edge.
+
+**Not implemented: `Mesh.toShapeWithFullHistory`.** The issue's own open question floated this as a
+possible answer, and it's the right one: `Mesh.toShape` builds every face from scratch out of raw
+vertex/index arrays — there is no input `TopoDS_Shape` for `ShapeHistoryRef.record(of:)` to be called
+with in the first place, so a `*WithFullHistory` variant would be a hollow stub that always returns
+empty records. Identity for a mesh-to-B-Rep pipeline has to be established *after* the mesh-to-shape
+step, not carried through it.
+
+New suite `SewQuiltHealFullHistoryTests` (`OCCTModelingTests`), 9 tests. No kernel change, no
+xcframework rebuild — reuses the v1.12.9 binary.
 
 ### v1.12.10 (July 2026): docs, BREP graph durable identity and UIDs cookbook
 


### PR DESCRIPTION
## Summary

Two independent features, landing together, tagged as two separate releases (v1.13.0, v1.13.1) after merge:

- **#327** — `*WithFullHistory` variants for sewing (`sew`/`sewn` both directions), `quilt`, `healed()`, and `solid(from:)`, extending the #290 `ShapeHistoryRef`/`add(_:absorbing:)` pattern to the mesh-to-B-Rep pipeline. Answers the issue's "faithfulness" question (many-to-one sewing merges record both inputs as Modified into the same output) with a regression test. `Mesh.toShapeWithFullHistory` intentionally not implemented — no input `TopoDS_Shape` to key history on, so it would be a hollow stub; documented in CHANGELOG.
- **#319** (Track 1 only) — `isSelfIntersecting(hardTimeout:)`, a genuinely hard wall-clock bound via a detached worker thread + `DispatchSemaphore`, as a follow-up to #293. Shipped only after verifying `BOPAlgo_ArgumentAnalyzer`'s thread-safety under that concurrency shape with a TSan-instrumented OCCT build + an 8-thread stress harness (480 operations, zero races). Track 2 (upstream OCCT report) remains blocked on an external repro and is untouched.

## Test plan

- [x] `swift build` — zero errors
- [x] `swift test --filter SewQuiltHealFullHistoryTests` — 9/9 pass
- [x] `swift test --filter Issue319HardBoundedSelfIntersection` — 3/3 pass
- [x] `swift test --filter BooleanFullHistoryTests` / `Tier2HistoryTests` — pre-existing #290 history tests unaffected
- [x] `Scripts/count-operations.py` — README/API_REFERENCE totals consistent (4,248)
- [x] TSan stress harness (ad hoc, not committed): 60 bursts × 8 threads, zero race reports — see #319 commit message for methodology

No kernel change, no xcframework rebuild — both reuse the v1.12.9 binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)