### PR TITLE
docs(#319): correct OCCTReconstruct #208 status in CHANGELOG

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,8 +44,11 @@ an exhaustive audit — the doc comment says so explicitly, and `isSelfIntersect
 default recommendation unless a caller genuinely needs the hard guarantee.
 
 **Track 2 (upstream OCCT report: missing checkpoints + the `Intf_Interference::Insert` quadratic)
-remains blocked** — still needs the minimal, un-thrashed reproducer from a quiet-host OCCTReconstruct
-#208 re-run, which has not happened. No action taken on Track 2 in this release.
+remains blocked** — still needs the minimal, un-thrashed reproducer this issue originally hoped would
+fall out of a quiet-host OCCTReconstruct #208 re-run. That hasn't happened: #208 itself is closed
+(2026-07-18, no linked commit — superseded by a re-scoped successor line, not resolved), and neither
+it nor its successors (#252, #254, the currently-open #292) touch self-intersection or timeouts at
+all. No reproducer exists anywhere in that repo as of this release. No action taken on Track 2.
 
 New suite `Issue319HardBoundedSelfIntersection` (`OCCTModelingTests`), 3 tests. No kernel change, no
 xcframework rebuild — reuses the v1.12.9 binary.


### PR DESCRIPTION
Small correction, caught by the user: the v1.13.1 CHANGELOG entry said OCCTReconstruct #208 just needed a "re-run" — implying it's a live, ongoing issue. It's actually closed (2026-07-18, no linked commit), superseded by a re-scoped successor line (#252 O4 pivot). Confirmed neither #208 nor its successors (#252, #254, currently-open #292) touch self-intersection/timeouts at all. Substance unchanged — Track 2 still has no reproducer and remains blocked — just the citation was wrong.

Also corrected in a follow-up comment on #319 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)