### PR TITLE
feat: *WithFullHistory parity for translate/rotate/scale/mirror/patterns (#331)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,248 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,254 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -4823,6 +4823,51 @@ OCCTBooleanHistoryRef _Nullable OCCTShapeCreateSolidFromShellWithHistory(OCCTSha
                                                                            OCCTShapeRef _Nullable * _Nullable outResult);
 
 
+// MARK: - Transform / pattern with full history (issue #331)
+//
+// Same OCCTBooleanHistoryRef handle as above. translate/rotate/scale/mirror
+// derive their history from a retained BRepBuilderAPI_Transform (same op/args
+// synthesis path as fillet/chamfer/defeature). Patterns (linear/circular) are
+// N:1 — history maps each source sub-shape to all N pattern-instance sub-shapes.
+
+/// Translate by (dx, dy, dz), with retained history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromTranslate(OCCTShapeRef _Nonnull shape,
+                                                                 double dx, double dy, double dz,
+                                                                 OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Rotate around an axis through the origin, with retained history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromRotate(OCCTShapeRef _Nonnull shape,
+                                                              double axisX, double axisY, double axisZ,
+                                                              double angle,
+                                                              OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Scale uniformly from the origin, with retained history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromScale(OCCTShapeRef _Nonnull shape,
+                                                             double factor,
+                                                             OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Mirror across a plane, with retained history.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromMirror(OCCTShapeRef _Nonnull shape,
+                                                              double originX, double originY, double originZ,
+                                                              double normalX, double normalY, double normalZ,
+                                                              OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Linear pattern (N copies along direction), with history mapping each source
+/// sub-shape to all N corresponding pattern-instance sub-shapes.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromLinearPattern(OCCTShapeRef _Nonnull shape,
+                                                                     double dirX, double dirY, double dirZ,
+                                                                     double spacing, int32_t count,
+                                                                     OCCTShapeRef _Nullable * _Nullable outResult);
+
+/// Circular pattern (N copies around an axis), with history mapping each source
+/// sub-shape to all N corresponding pattern-instance sub-shapes.
+OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromCircularPattern(OCCTShapeRef _Nonnull shape,
+                                                                       double axisX, double axisY, double axisZ,
+                                                                       double axisDirX, double axisDirY, double axisDirZ,
+                                                                       int32_t count, double angle,
+                                                                       OCCTShapeRef _Nullable * _Nullable outResult);
+
+
 // MARK: - Thick Solid / Hollowing (v0.37.0)
 
 /// Create a hollowed (thick) solid by removing faces and offsetting inward.

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -1688,6 +1688,7 @@ int32_t OCCTShapeFuseWithHistory(OCCTShapeRef shape1, OCCTShapeRef shape2,
 #include <BRepAlgoAPI_Splitter.hxx>
 #include <BRepBuilderAPI_MakeShape.hxx>
 #include <TopoDS_Iterator.hxx>
+#include <functional>
 #include <memory>
 
 struct OCCTBooleanHistory {
@@ -3085,6 +3086,179 @@ OCCTBooleanHistoryRef OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef shel
         if (hist.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
         return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
+}
+
+// MARK: - Transform / pattern with full history (issue #331)
+//
+// translate/rotate/scale/mirror use BRepBuilderAPI_Transform, which (unlike
+// sewing/healing above) genuinely derives from BRepBuilderAPI_MakeShape — same
+// op/args synthesis path as fillet/chamfer/defeature. theCopyGeom=true (the
+// existing plain OCCTShapeTranslate/Rotate/Scale/Mirror already pass this) makes
+// BRepBuilderAPI_Transform::Perform take the myUseModif=true branch unconditionally
+// (BRepBuilderAPI_Transform.cxx), so Modified()/Generated() always come from the
+// real BRepTools_Modifier rather than the "just relocated, nothing modified"
+// short-circuit used when reusing the same TShape with a new Location.
+//
+// Patterns (linear/circular) are N:1: each instance is an independent
+// BRepBuilderAPI_Transform run on the same source shape, so history there can't
+// use the single-op synthesis path. Instead each instance's Modified/Generated
+// results are added onto one shared BRepTools_History keyed by the ORIGINAL
+// source sub-shape (AddModified/AddGenerated append per call, they don't
+// replace — confirmed in BRepTools_History.hxx), so a source sub-shape maps to
+// all N corresponding pattern-instance sub-shapes.
+
+OCCTBooleanHistoryRef OCCTShapeHistoryFromTranslate(OCCTShapeRef shape, double dx, double dy, double dz,
+                                                     OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape) return nullptr;
+    try {
+        gp_Trsf transform;
+        transform.SetTranslation(gp_Vec(dx, dy, dz));
+        std::unique_ptr<BRepBuilderAPI_Transform> op(
+            new BRepBuilderAPI_Transform(shape->shape, transform, Standard_True));
+        if (!op->IsDone()) return nullptr;
+        TopoDS_Shape result = op->Shape();
+        if (result.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
+    } catch (...) { return nullptr; }
+}
+
+OCCTBooleanHistoryRef OCCTShapeHistoryFromRotate(OCCTShapeRef shape, double axisX, double axisY, double axisZ,
+                                                  double angle, OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape) return nullptr;
+    try {
+        gp_Ax1 axis(gp_Pnt(0, 0, 0), gp_Dir(axisX, axisY, axisZ));
+        gp_Trsf transform;
+        transform.SetRotation(axis, angle);
+        std::unique_ptr<BRepBuilderAPI_Transform> op(
+            new BRepBuilderAPI_Transform(shape->shape, transform, Standard_True));
+        if (!op->IsDone()) return nullptr;
+        TopoDS_Shape result = op->Shape();
+        if (result.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
+    } catch (...) { return nullptr; }
+}
+
+OCCTBooleanHistoryRef OCCTShapeHistoryFromScale(OCCTShapeRef shape, double factor, OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape) return nullptr;
+    try {
+        gp_Trsf transform;
+        transform.SetScale(gp_Pnt(0, 0, 0), factor);
+        std::unique_ptr<BRepBuilderAPI_Transform> op(
+            new BRepBuilderAPI_Transform(shape->shape, transform, Standard_True));
+        if (!op->IsDone()) return nullptr;
+        TopoDS_Shape result = op->Shape();
+        if (result.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
+    } catch (...) { return nullptr; }
+}
+
+OCCTBooleanHistoryRef OCCTShapeHistoryFromMirror(OCCTShapeRef shape,
+                                                  double originX, double originY, double originZ,
+                                                  double normalX, double normalY, double normalZ,
+                                                  OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape) return nullptr;
+    try {
+        gp_Ax2 mirrorPlane(gp_Pnt(originX, originY, originZ), gp_Dir(normalX, normalY, normalZ));
+        gp_Trsf transform;
+        transform.SetMirror(mirrorPlane);
+        std::unique_ptr<BRepBuilderAPI_Transform> op(
+            new BRepBuilderAPI_Transform(shape->shape, transform, Standard_True));
+        if (!op->IsDone()) return nullptr;
+        TopoDS_Shape result = op->Shape();
+        if (result.IsNull()) return nullptr;
+        if (outResult) *outResult = new OCCTShape(result);
+        return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
+    } catch (...) { return nullptr; }
+}
+
+// Shared by both pattern history functions: apply `count` transforms (the i-th
+// given by `trsfForIndex`) to `shape`, add each instance to a compound, and fold
+// each instance's Modified/Generated for the original sub-shapes into one
+// BRepTools_History. Returns the compound in `outResult` and the history handle,
+// or nullptr if no instance succeeded.
+static OCCTBooleanHistoryRef occtPatternHistory(OCCTShapeRef shape, int32_t count,
+                                                 const std::function<gp_Trsf(int32_t)>& trsfForIndex,
+                                                 OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    if (!shape || count < 1) return nullptr;
+    try {
+        BRep_Builder builder;
+        TopoDS_Compound compound;
+        builder.MakeCompound(compound);
+
+        TopTools_IndexedMapOfShape subMap;
+        TopExp::MapShapes(shape->shape, subMap);
+
+        Handle(BRepTools_History) hist = new BRepTools_History();
+        bool anyDone = false;
+        for (int32_t i = 0; i < count; i++) {
+            BRepBuilderAPI_Transform xform(shape->shape, trsfForIndex(i), Standard_True);
+            if (!xform.IsDone()) continue;
+            anyDone = true;
+            builder.Add(compound, xform.Shape());
+
+            for (int32_t j = 1; j <= subMap.Extent(); j++) {
+                const TopoDS_Shape& sub = subMap(j);
+                if (!BRepTools_History::IsSupportedType(sub)) continue;
+                for (TopTools_ListIteratorOfListOfShape it(xform.Modified(sub)); it.More(); it.Next()) {
+                    hist->AddModified(sub, it.Value());
+                }
+                for (TopTools_ListIteratorOfListOfShape it(xform.Generated(sub)); it.More(); it.Next()) {
+                    hist->AddGenerated(sub, it.Value());
+                }
+            }
+        }
+        if (!anyDone) return nullptr;
+
+        if (outResult) *outResult = new OCCTShape(compound);
+        return new OCCTBooleanHistory(hist);
+    } catch (...) { return nullptr; }
+}
+
+OCCTBooleanHistoryRef OCCTShapeHistoryFromLinearPattern(OCCTShapeRef shape,
+                                                         double dirX, double dirY, double dirZ,
+                                                         double spacing, int32_t count,
+                                                         OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    try {
+        // gp_Vec::Normalize throws on a zero-length vector — guard it here (the
+        // plain OCCTShapeLinearPattern does the same inside its own try/catch);
+        // occtPatternHistory's try/catch only covers what happens after this call.
+        gp_Vec direction(dirX, dirY, dirZ);
+        direction.Normalize();
+        return occtPatternHistory(shape, count, [&](int32_t i) {
+            gp_Trsf transform;
+            transform.SetTranslation(direction * (spacing * i));
+            return transform;
+        }, outResult);
+    } catch (...) { return nullptr; }
+}
+
+OCCTBooleanHistoryRef OCCTShapeHistoryFromCircularPattern(OCCTShapeRef shape,
+                                                           double axisX, double axisY, double axisZ,
+                                                           double axisDirX, double axisDirY, double axisDirZ,
+                                                           int32_t count, double angle,
+                                                           OCCTShapeRef* outResult) {
+    if (outResult) *outResult = nullptr;
+    try {
+        // gp_Dir's constructor throws on a zero-length vector — same guarding
+        // rationale as OCCTShapeHistoryFromLinearPattern above.
+        gp_Ax1 axis(gp_Pnt(axisX, axisY, axisZ), gp_Dir(axisDirX, axisDirY, axisDirZ));
+        double totalAngle = (angle == 0) ? (2.0 * M_PI) : angle;
+        double stepAngle = (count > 0) ? (totalAngle / count) : 0.0;
+        return occtPatternHistory(shape, count, [&](int32_t i) {
+            gp_Trsf transform;
+            transform.SetRotation(axis, stepAngle * i);
+            return transform;
+        }, outResult);
     } catch (...) { return nullptr; }
 }
 

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -5226,6 +5226,111 @@ extension Shape {
     }
 }
 
+// MARK: - Transforms / patterns with full history (issue #331)
+
+extension Shape {
+    /// Translate the shape, with full per-input-subshape history.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// guard let (moved, history) = body.translatedWithFullHistory(by: SIMD3(10, 0, 0)) else { return }
+    /// let record = history.record(of: someFace)
+    /// ```
+    public func translatedWithFullHistory(by offset: SIMD3<Double>)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHistoryFromTranslate(handle, offset.x, offset.y, offset.z, &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Rotate around an axis through the origin, with full per-input-subshape history.
+    public func rotatedWithFullHistory(axis: SIMD3<Double>, angle: Double)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHistoryFromRotate(handle, axis.x, axis.y, axis.z, angle, &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Scale uniformly from the origin, with full per-input-subshape history.
+    public func scaledWithFullHistory(by factor: Double)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHistoryFromScale(handle, factor, &resultRef),
+              let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Mirror across a plane, with full per-input-subshape history.
+    public func mirroredWithFullHistory(planeNormal: SIMD3<Double>, planeOrigin: SIMD3<Double> = .zero)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHistoryFromMirror(
+            handle,
+            planeOrigin.x, planeOrigin.y, planeOrigin.z,
+            planeNormal.x, planeNormal.y, planeNormal.z,
+            &resultRef
+        ), let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Create a linear pattern of the shape, with full history.
+    ///
+    /// The pattern is N:1 (deterministic): each instance's sub-shapes
+    /// correspond to the source's by construction, so a source sub-shape's
+    /// `history.record(of:).modified` reports all `count` corresponding
+    /// instance sub-shapes — one per copy, including the original at index 0.
+    ///
+    /// - Returns: `(result, history)` where `result` is a compound of all
+    ///   copies, same as ``linearPattern(direction:spacing:count:)``.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let hole = Shape.cylinder(radius: 3, height: 10)
+    /// guard let (row, history) = hole.linearPatternWithFullHistory(
+    ///     direction: SIMD3(20, 0, 0), spacing: 20, count: 5
+    /// ) else { return }
+    /// let copies = history.record(of: someHoleFace).modified // 5 corresponding faces
+    /// ```
+    public func linearPatternWithFullHistory(direction: SIMD3<Double>, spacing: Double, count: Int)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHistoryFromLinearPattern(
+            handle, direction.x, direction.y, direction.z, spacing, Int32(count), &resultRef
+        ), let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+
+    /// Create a circular pattern of the shape, with full history.
+    ///
+    /// Same N:1 semantics as ``linearPatternWithFullHistory(direction:spacing:count:)``
+    /// — see ``circularPattern(axisPoint:axisDirection:count:angle:)`` for what
+    /// "duplicates the whole body" means for feature-cut use cases.
+    ///
+    /// - Returns: `(result, history)` where `result` is a compound of all copies.
+    public func circularPatternWithFullHistory(axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>,
+                                                count: Int, angle: Double = 0)
+        -> (result: Shape, history: ShapeHistoryRef)?
+    {
+        var resultRef: OCCTShapeRef?
+        guard let h = OCCTShapeHistoryFromCircularPattern(
+            handle,
+            axisPoint.x, axisPoint.y, axisPoint.z,
+            axisDirection.x, axisDirection.y, axisDirection.z,
+            Int32(count), angle, &resultRef
+        ), let resultRef else { return nil }
+        return (Shape(handle: resultRef), ShapeHistoryRef(h))
+    }
+}
+
 // MARK: - Thick Solid / Hollowing (v0.37.0)
 
 extension Shape {

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -6450,3 +6450,158 @@ struct SewQuiltHealFullHistoryTests {
         #expect(graph.historyRecordCount > 0, "absorb should have written history records")
     }
 }
+
+@Suite("Transform / pattern *WithFullHistory (issue #331)")
+struct TransformPatternFullHistoryTests {
+    @Test("Translate: every input face is Modified exactly once, none deleted")
+    func translateHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let r = box.translatedWithFullHistory(by: SIMD3(5, 0, 0)) else {
+            Issue.record("translate should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        #expect(abs(r.result.volume! - box.volume!) < 1e-6)
+        for face in box.subShapes(ofType: .face) {
+            let rec = r.history.record(of: face)
+            #expect(!rec.isDeleted)
+            #expect(rec.modified.count == 1)
+        }
+    }
+
+    @Test("Rotate: every input face is Modified exactly once, none deleted")
+    func rotateHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let r = box.rotatedWithFullHistory(axis: SIMD3(0, 0, 1), angle: .pi / 4) else {
+            Issue.record("rotate should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        for face in box.subShapes(ofType: .face) {
+            let rec = r.history.record(of: face)
+            #expect(!rec.isDeleted)
+            #expect(rec.modified.count == 1)
+        }
+    }
+
+    @Test("Scale: every input face is Modified exactly once; result volume scales by factor^3")
+    func scaleHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let r = box.scaledWithFullHistory(by: 2.0) else {
+            Issue.record("scale should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        #expect(abs(r.result.volume! - box.volume! * 8) < 1e-3)
+        for face in box.subShapes(ofType: .face) {
+            let rec = r.history.record(of: face)
+            #expect(!rec.isDeleted)
+            #expect(rec.modified.count == 1)
+        }
+    }
+
+    @Test("Mirror: every input face is Modified exactly once, none deleted")
+    func mirrorHistory() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let r = box.mirroredWithFullHistory(planeNormal: SIMD3(1, 0, 0)) else {
+            Issue.record("mirror should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        for face in box.subShapes(ofType: .face) {
+            let rec = r.history.record(of: face)
+            #expect(!rec.isDeleted)
+            #expect(rec.modified.count == 1)
+        }
+    }
+
+    @Test("Linear pattern: each input face maps to exactly `count` instance faces")
+    func linearPatternHistory() {
+        let hole = Shape.cylinder(radius: 3, height: 10)!
+        let count = 4
+        guard let r = hole.linearPatternWithFullHistory(direction: SIMD3(20, 0, 0), spacing: 20, count: count) else {
+            Issue.record("linear pattern should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        for face in hole.subShapes(ofType: .face) {
+            let rec = r.history.record(of: face)
+            #expect(!rec.isDeleted)
+            #expect(rec.modified.count == count,
+                    "expected \(count) pattern-instance faces, got \(rec.modified.count)")
+        }
+    }
+
+    @Test("Circular pattern: each input face maps to exactly `count` instance faces")
+    func circularPatternHistory() {
+        let hole = Shape.cylinder(radius: 3, height: 10)!.translated(by: SIMD3(20, 0, 0))!
+        let count = 6
+        guard let r = hole.circularPatternWithFullHistory(
+            axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: count
+        ) else {
+            Issue.record("circular pattern should succeed")
+            return
+        }
+        #expect(r.result.isValid)
+        for face in hole.subShapes(ofType: .face) {
+            let rec = r.history.record(of: face)
+            #expect(!rec.isDeleted)
+            #expect(rec.modified.count == count,
+                    "expected \(count) pattern-instance faces, got \(rec.modified.count)")
+        }
+    }
+
+    @Test("A translate's history can be absorbed into a TopologyGraph (issue #290 integration)")
+    func translateHistoryAbsorbsIntoGraph() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let graph = TopologyGraph(shape: box),
+              let root = graph.findNode(for: box) else {
+            Issue.record("graph setup failed")
+            return
+        }
+        guard let r = box.translatedWithFullHistory(by: SIMD3(5, 0, 0)) else {
+            Issue.record("translate should succeed")
+            return
+        }
+        #expect(graph.historyRecordCount == 0)
+        let added = graph.add(r.result, absorbing: r.history,
+                              inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+                              operationName: "translate")
+        #expect(added != nil, "add(absorbing:) should succeed for a translate's synthesized history")
+        #expect(graph.historyRecordCount > 0, "absorb should have written history records")
+    }
+
+    @Test("Linear pattern with a zero-length direction fails gracefully (does not crash)")
+    func linearPatternZeroDirectionDoesNotCrash() {
+        let hole = Shape.cylinder(radius: 3, height: 10)!
+        let r = hole.linearPatternWithFullHistory(direction: .zero, spacing: 20, count: 4)
+        #expect(r == nil)
+    }
+
+    @Test("Circular pattern with a zero-length axis direction fails gracefully (does not crash)")
+    func circularPatternZeroAxisDoesNotCrash() {
+        let hole = Shape.cylinder(radius: 3, height: 10)!
+        let r = hole.circularPatternWithFullHistory(axisPoint: .zero, axisDirection: .zero, count: 6)
+        #expect(r == nil)
+    }
+
+    @Test("A linear pattern's history can be absorbed into a TopologyGraph (issue #290 integration)")
+    func linearPatternHistoryAbsorbsIntoGraph() {
+        let hole = Shape.cylinder(radius: 3, height: 10)!
+        guard let graph = TopologyGraph(shape: hole),
+              let root = graph.findNode(for: hole) else {
+            Issue.record("graph setup failed")
+            return
+        }
+        guard let r = hole.linearPatternWithFullHistory(direction: SIMD3(20, 0, 0), spacing: 20, count: 3) else {
+            Issue.record("linear pattern should succeed")
+            return
+        }
+        #expect(graph.historyRecordCount == 0)
+        let added = graph.add(r.result, absorbing: r.history,
+                              inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+                              operationName: "linearPattern")
+        #expect(added != nil, "add(absorbing:) should succeed for a pattern's synthesized history")
+        #expect(graph.historyRecordCount > 0, "absorb should have written history records")
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,248** | |
+| **Total** | **4,254** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,63 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.13.1
+## Current: v1.14.0
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #323 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.14.0 (July 2026) — feat: `*WithFullHistory` parity for translate/rotate/scale/mirror/patterns (#331)
+
+Extends the #290 `ShapeHistoryRef`/`add(_:absorbing:)` pattern — already shipped for booleans, fillet/
+chamfer/shell/defeature (#165), and sew/quilt/heal (#327, v1.13.0) — to the last gap: transforms and
+patterns. Consumers doing incremental persistent-identity tracking (OCCTMCP #91/#93) previously had to
+fall back to a generation reset after any of these ops, losing continuity for `GraphUID`s minted before
+the transform.
+
+**New, all returning `(result: Shape, history: ShapeHistoryRef)`:**
+
+- `Shape.translatedWithFullHistory(by:)`
+- `Shape.rotatedWithFullHistory(axis:angle:)`
+- `Shape.scaledWithFullHistory(by:)`
+- `Shape.mirroredWithFullHistory(planeNormal:planeOrigin:)`
+- `Shape.linearPatternWithFullHistory(direction:spacing:count:)`
+- `Shape.circularPatternWithFullHistory(axisPoint:axisDirection:count:angle:)`
+
+```swift
+let hole = Shape.cylinder(radius: 3, height: 10)!
+let (row, history) = hole.linearPatternWithFullHistory(direction: SIMD3(20, 0, 0), spacing: 20, count: 5)!
+let copies = history.record(of: someHoleFace).modified   // 5 corresponding instance faces
+graph.add(row, absorbing: history, inputRoots: [root], operationName: "linearPattern")
+```
+
+**Implementation — two different shapes, unlike the #327 batch:**
+
+- **translate/rotate/scale/mirror** all bottom out in `BRepBuilderAPI_Transform`, which (unlike
+  sewing/healing) genuinely derives from `BRepBuilderAPI_MakeShape` — so these reuse the existing
+  `OCCTBooleanHistoryAsBRepToolsHistory` retained-builder/args synthesis path unchanged, the same one
+  fillet/chamfer/defeature use. The plain (non-history) transform functions already construct
+  `BRepBuilderAPI_Transform` with `theCopyGeom = true`, which forces
+  `BRepBuilderAPI_Transform::Perform` down its `myUseModif = true` branch unconditionally (confirmed in
+  `BRepBuilderAPI_Transform.cxx`) — so `Modified()`/`Generated()` always come from the real
+  `BRepTools_Modifier`, never the "same TShape, just relocated" short-circuit that would otherwise
+  report nothing.
+- **Patterns are N:1**, not 1:1, so the single-builder synthesis path doesn't apply: each pattern
+  instance is an independent `BRepBuilderAPI_Transform` run against the same source shape. History is
+  built manually — one shared `BRepTools_History`, with every instance's `Modified`/`Generated` results
+  for each *original* source sub-shape folded in via `AddModified`/`AddGenerated` (confirmed these
+  append rather than replace, in `BRepTools_History.hxx`) — so a source sub-shape's history record
+  reports all `count` corresponding instance sub-shapes, one per copy including the identity-transformed
+  original at index 0.
+
+New suite `TransformPatternFullHistoryTests` (`OCCTModelingTests`), 10 tests, including two graph-absorb
+integration tests (one 1:1 transform, one N:1 pattern) proving both history shapes flow through
+`OCCTBRepGraphAddWithHistory` correctly, and two zero-length-direction regression tests for the
+exception-safety fix caught in review (`gp_Vec::Normalize`/`gp_Dir`'s constructor throw on a zero
+vector; the pattern wrappers now guard that inside their own try/catch instead of leaving it to the
+caller). No kernel change, no xcframework rebuild — reuses the v1.12.9 binary.
 
 ### v1.13.1 (July 2026) — feat: hard-bounded `isSelfIntersecting`, TSan-verified (#319)
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -2141,3 +2141,145 @@ History reports each removed face as deleted and surrounding faces as modified.
   ```swift
   if let (defeatured, history) = cad.defeaturedWithFullHistory(faces: [12, 13]) { }
   ```
+
+---
+
+### `translatedWithFullHistory(by:)`
+
+Translate the shape with full per-input-subshape history.
+
+```swift
+public func translatedWithFullHistory(by offset: SIMD3<Double>)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:** `offset` — translation vector.
+- **Returns:** Result shape and history, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` (via `OCCTShapeHistoryFromTranslate`).
+- **Example:**
+  ```swift
+  if let (moved, history) = box.translatedWithFullHistory(by: SIMD3(5, 0, 0)) {
+      let record = history.record(of: someFace)   // exactly one modified face
+  }
+  ```
+
+---
+
+### `rotatedWithFullHistory(axis:angle:)`
+
+Rotate around an axis through the origin with full per-input-subshape history.
+
+```swift
+public func rotatedWithFullHistory(axis: SIMD3<Double>, angle: Double)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:**
+  - `axis` — rotation axis direction (through the origin).
+  - `angle` — rotation angle in radians.
+- **Returns:** Result shape and history, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` (via `OCCTShapeHistoryFromRotate`).
+- **Example:**
+  ```swift
+  if let (tilted, history) = box.rotatedWithFullHistory(axis: SIMD3(0, 0, 1), angle: .pi / 4) { }
+  ```
+
+---
+
+### `scaledWithFullHistory(by:)`
+
+Scale uniformly from the origin with full per-input-subshape history.
+
+```swift
+public func scaledWithFullHistory(by factor: Double)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:** `factor` — uniform scale factor.
+- **Returns:** Result shape and history, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` (via `OCCTShapeHistoryFromScale`).
+- **Example:**
+  ```swift
+  if let (big, history) = box.scaledWithFullHistory(by: 2.0) { }
+  ```
+
+---
+
+### `mirroredWithFullHistory(planeNormal:planeOrigin:)`
+
+Mirror across a plane with full per-input-subshape history.
+
+```swift
+public func mirroredWithFullHistory(planeNormal: SIMD3<Double>, planeOrigin: SIMD3<Double> = .zero)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:**
+  - `planeNormal` — normal of the mirror plane.
+  - `planeOrigin` — a point on the mirror plane (default origin).
+- **Returns:** Result shape and history, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` (via `OCCTShapeHistoryFromMirror`).
+- **Example:**
+  ```swift
+  if let (reflected, history) = part.mirroredWithFullHistory(planeNormal: SIMD3(0, 1, 0)) { }
+  ```
+
+---
+
+### `linearPatternWithFullHistory(direction:spacing:count:)`
+
+Create a linear pattern of the shape with full history.
+
+```swift
+public func linearPatternWithFullHistory(direction: SIMD3<Double>, spacing: Double, count: Int)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+The pattern is N:1 (deterministic): each instance's sub-shapes correspond to the source's by
+construction. `history.record(of:)` on a source sub-shape reports all `count` corresponding instance
+sub-shapes as `modified` — one per copy, including the identity-transformed original at index 0.
+
+- **Parameters:**
+  - `direction` — pattern direction (normalized internally).
+  - `spacing` — distance between copies.
+  - `count` — number of copies, including the original.
+- **Returns:** Compound of all copies and history, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` × `count`, folded into one `BRepTools_History` (via
+  `OCCTShapeHistoryFromLinearPattern`).
+- **Example:**
+  ```swift
+  let hole = Shape.cylinder(radius: 3, height: 10)!
+  if let (row, history) = hole.linearPatternWithFullHistory(direction: SIMD3(20, 0, 0), spacing: 20, count: 5) {
+      let copies = history.record(of: someHoleFace).modified   // 5 corresponding faces
+  }
+  ```
+
+---
+
+### `circularPatternWithFullHistory(axisPoint:axisDirection:count:angle:)`
+
+Create a circular pattern of the shape with full history.
+
+```swift
+public func circularPatternWithFullHistory(axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>,
+                                            count: Int, angle: Double = 0)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+Same N:1 semantics as `linearPatternWithFullHistory(direction:spacing:count:)` — see
+`circularPattern(axisPoint:axisDirection:count:angle:)` for what "duplicates the whole body" means for
+feature-cut use cases (drill one hole, pattern the tool, subtract).
+
+- **Parameters:**
+  - `axisPoint` — point on the rotation axis.
+  - `axisDirection` — direction of the rotation axis.
+  - `count` — number of copies, including the original.
+  - `angle` — total angle to span in radians (0 = full circle).
+- **Returns:** Compound of all copies and history, or nil on failure.
+- **OCCT:** `BRepBuilderAPI_Transform` × `count`, folded into one `BRepTools_History` (via
+  `OCCTShapeHistoryFromCircularPattern`).
+- **Example:**
+  ```swift
+  let hole = Shape.cylinder(radius: 3, height: 10)!.translated(by: SIMD3(20, 0, 0))!
+  if let (tools, history) = hole.circularPatternWithFullHistory(axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 6) { }
+  ```


### PR DESCRIPTION
## Summary

Closes #331. Extends the #290 `ShapeHistoryRef`/`add(_:absorbing:)` pattern — already shipped for booleans, fillet/chamfer/shell/defeature (#165), and sew/quilt/heal (#327, v1.13.0) — to the last gap: transforms and patterns.

**New, all returning `(result: Shape, history: ShapeHistoryRef)`:**

- `Shape.translatedWithFullHistory(by:)`
- `Shape.rotatedWithFullHistory(axis:angle:)`
- `Shape.scaledWithFullHistory(by:)`
- `Shape.mirroredWithFullHistory(planeNormal:planeOrigin:)`
- `Shape.linearPatternWithFullHistory(direction:spacing:count:)`
- `Shape.circularPatternWithFullHistory(axisPoint:axisDirection:count:angle:)`

**Implementation:**

- translate/rotate/scale/mirror bottom out in `BRepBuilderAPI_Transform`, which genuinely derives from `BRepBuilderAPI_MakeShape` (unlike sewing/healing), so these reuse the existing retained-builder/args `OCCTBooleanHistoryAsBRepToolsHistory` synthesis path unchanged — the same one fillet/chamfer/defeature already use.
- Patterns are **N:1**, not 1:1 — each instance is an independent `BRepBuilderAPI_Transform` run against the same source shape, so history is built manually: one shared `BRepTools_History` with every instance's `Modified`/`Generated` results folded onto the *original* source sub-shape via `AddModified`/`AddGenerated` (these append rather than replace). A source sub-shape's history record ends up reporting all `count` corresponding instance sub-shapes.

**Caught in review:** the pattern wrappers initially normalized the direction vector / built the axis `gp_Dir` *outside* any try/catch, unlike the plain `OCCTShapeLinearPattern`/`OCCTShapeCircularPattern` which guard this — a zero-length direction would throw uncaught (`gp_Vec::Normalize` / `gp_Dir`'s constructor both throw on a zero vector) and crash the process. Fixed by wrapping the setup in its own try/catch before delegating to the shared history-folding helper, and regression-tested (`linearPatternZeroDirectionDoesNotCrash`, `circularPatternZeroAxisDoesNotCrash`).

No kernel change, no xcframework rebuild — reuses the v1.12.9 binary. MINOR version bump (v1.13.1 → v1.14.0) per `docs/SEMVER.md` (additive public API).

## Test plan

- [x] `swift build` — zero errors
- [x] New suite `TransformPatternFullHistoryTests` (`OCCTModelingTests`), 10 tests — all pass, including 2 graph-absorb integration tests and 2 zero-vector crash-regression tests
- [x] `swift test --filter OCCTModelingTests` — 436 tests pass, no regressions
- [x] `swift test --filter OCCTTopologyGraphTests` — 170 tests pass, no regressions (graph-absorb path exercised)
- [x] `Scripts/count-operations.py` — README/API_REFERENCE totals verified consistent (4,254)
- [x] Docs updated: README.md, docs/API_REFERENCE.md, docs/CHANGELOG.md (v1.14.0 entry), docs/reference/Shape-Healing.md (6 new API entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)