### PR TITLE
rename: TopologyGraph → BRepGraph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ one domain never recompiles the rest. The old 50k-line `ShapeTests.swift` monoli
 suite into these targets (each `Tests/OCCT<Domain>Tests/`, declared in `Package.swift`):
 
 `Analysis`, `Curve`, `Drawing`, `Foundation`, `Geom2d`, `IO`, `Integration`, `Math`, `Mesh`,
-`Misc`, `Modeling`, `ShapeHealing`, `Stress`, `Surface`, `Thread`, `TopologyGraph`, `Topology`, `XCAF`.
+`Misc`, `Modeling`, `ShapeHealing`, `Stress`, `Surface`, `Thread`, `BRepGraph`, `Topology`, `XCAF`.
 
 - **Add a new suite** to the domain target that best matches it (e.g. a fillet suite → `OCCTModelingTests`,
   a `Curve2D` suite → `OCCTGeom2dTests`). If nothing fits, use `OCCTMiscTests`. Each target is a separate

--- a/Package.swift
+++ b/Package.swift
@@ -131,7 +131,7 @@ let package = Package(
         .testTarget(name: "OCCTStressTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTStressTests"),
         .testTarget(name: "OCCTSurfaceTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTSurfaceTests"),
         .testTarget(name: "OCCTThreadTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTThreadTests"),
-        .testTarget(name: "OCCTTopologyGraphTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTTopologyGraphTests"),
+        .testTarget(name: "OCCTBRepGraphTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTBRepGraphTests"),
         .testTarget(name: "OCCTTopologyTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTTopologyTests"),
         .testTarget(name: "OCCTXCAFTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTXCAFTests"),
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ OCCTSwift is the kernel of a layered family of packages, all SemVer-stable from 
 
 | Package | Role |
 |---------|------|
-| **OCCTSwift** (this repo) | Core Swift wrapper — shapes, curves, surfaces, OCAF, TopologyGraph, drawing/projection, ML samplers. Bundles the OCCT 8.0.0p1 xcframework. |
+| **OCCTSwift** (this repo) | Core Swift wrapper — shapes, curves, surfaces, OCAF, BRepGraph, drawing/projection, ML samplers. Bundles the OCCT 8.0.0p1 xcframework. |
 | [OCCTSwiftIO](https://github.com/SecondMouseAU/OCCTSwiftIO) | Headless CAD file I/O — STEP / IGES / STL / OBJ / BREP loaders + glTF / GLB / OBJ / PLY / STEP / BREP exporters. No Viewport dep. |
 | [OCCTSwiftMesh](https://github.com/SecondMouseAU/OCCTSwiftMesh) | Mesh-domain algorithms — decimation, smoothing, repair (vendors `meshoptimizer`). |
 | [OCCTSwiftViewport](https://github.com/SecondMouseAU/OCCTSwiftViewport) | Metal-based 3D viewport component (UIKit / AppKit / SwiftUI). |

--- a/Sources/OCCTSwift/BRepGraph+Attributes.swift
+++ b/Sources/OCCTSwift/BRepGraph+Attributes.swift
@@ -1,8 +1,8 @@
-// TopologyGraph+Attributes.swift
+// BRepGraph+Attributes.swift
 //
-// Per-node attribute store + Codable graph snapshot for `TopologyGraph` (OCCTSwift #168).
+// Per-node attribute store + Codable graph snapshot for `BRepGraph` (OCCTSwift #168).
 //
-// `TopologyGraph` nodes are bare `(kind, index)` pairs with no payload, and the type wraps an
+// `BRepGraph` nodes are bare `(kind, index)` pairs with no payload, and the type wraps an
 // opaque C++ handle with no serialization. This file adds a pure Swift-side sidecar that lets
 // callers attach arbitrary typed metadata to any `NodeRef` and round-trip it (export → edit →
 // import) via `GraphSnapshot`. No C++ bridge change — the store never touches the C++ graph.
@@ -15,7 +15,7 @@ import OCCTBridge
 
 // MARK: - AttrValue
 
-extension TopologyGraph {
+extension BRepGraph {
     /// A typed, Codable attribute value. Closed set keeps the snapshot round-trip lossless.
     public enum AttrValue: Codable, Hashable, Sendable {
         case bool(Bool)
@@ -37,20 +37,20 @@ extension TopologyGraph {
 
 // MARK: - NodeAttributeStore
 
-/// Per-node attribute bag keyed by ``TopologyGraph/NodeRef``.
+/// Per-node attribute bag keyed by ``BRepGraph/NodeRef``.
 ///
 /// Keys are caller-namespaced strings (e.g. `"reconstruct.residualRMS"`). Encodes as a
 /// deterministically-ordered array of `{node, attrs}` entries — JSON object keys must be
 /// strings, and the sorted order keeps snapshots diffable and round-trips stable.
 public struct NodeAttributeStore: Codable, Sendable, Equatable {
-    public private(set) var storage: [TopologyGraph.NodeRef: [String: TopologyGraph.AttrValue]]
+    public private(set) var storage: [BRepGraph.NodeRef: [String: BRepGraph.AttrValue]]
 
-    public init(storage: [TopologyGraph.NodeRef: [String: TopologyGraph.AttrValue]] = [:]) {
+    public init(storage: [BRepGraph.NodeRef: [String: BRepGraph.AttrValue]] = [:]) {
         self.storage = storage
     }
 
     /// All attributes on a node (empty dictionary if none).
-    public subscript(node: TopologyGraph.NodeRef) -> [String: TopologyGraph.AttrValue] {
+    public subscript(node: BRepGraph.NodeRef) -> [String: BRepGraph.AttrValue] {
         get { storage[node] ?? [:] }
         set {
             if newValue.isEmpty { storage[node] = nil } else { storage[node] = newValue }
@@ -58,24 +58,24 @@ public struct NodeAttributeStore: Codable, Sendable, Equatable {
     }
 
     /// Read one attribute, or nil if unset.
-    public func value(_ key: String, for node: TopologyGraph.NodeRef) -> TopologyGraph.AttrValue? {
+    public func value(_ key: String, for node: BRepGraph.NodeRef) -> BRepGraph.AttrValue? {
         storage[node]?[key]
     }
 
     /// Set one attribute.
-    public mutating func set(_ key: String, _ value: TopologyGraph.AttrValue, for node: TopologyGraph.NodeRef) {
+    public mutating func set(_ key: String, _ value: BRepGraph.AttrValue, for node: BRepGraph.NodeRef) {
         storage[node, default: [:]][key] = value
     }
 
     /// Remove one attribute. Drops the node entry entirely once its last attribute is cleared.
-    public mutating func clear(_ key: String, for node: TopologyGraph.NodeRef) {
+    public mutating func clear(_ key: String, for node: BRepGraph.NodeRef) {
         guard var attrs = storage[node] else { return }
         attrs[key] = nil
         storage[node] = attrs.isEmpty ? nil : attrs
     }
 
     /// Remove every attribute on a node.
-    public mutating func removeAll(for node: TopologyGraph.NodeRef) {
+    public mutating func removeAll(for node: BRepGraph.NodeRef) {
         storage[node] = nil
     }
 
@@ -90,18 +90,18 @@ public struct NodeAttributeStore: Codable, Sendable, Equatable {
     /// `[String: AttrValue]` dictionary) avoids JSON's non-deterministic dictionary key order.
     private struct KeyValue: Codable {
         let key: String
-        let value: TopologyGraph.AttrValue
+        let value: BRepGraph.AttrValue
     }
 
     private struct Entry: Codable {
-        let node: TopologyGraph.NodeRef
+        let node: BRepGraph.NodeRef
         let attrs: [KeyValue]
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let entries = try container.decode([Entry].self)
-        var dict: [TopologyGraph.NodeRef: [String: TopologyGraph.AttrValue]] = [:]
+        var dict: [BRepGraph.NodeRef: [String: BRepGraph.AttrValue]] = [:]
         for e in entries where !e.attrs.isEmpty {
             dict[e.node] = Dictionary(uniqueKeysWithValues: e.attrs.map { ($0.key, $0.value) })
         }
@@ -131,7 +131,7 @@ public struct NodeAttributeStore: Codable, Sendable, Equatable {
 /// A persistable, round-trippable snapshot of a graph's attributes plus its source shape.
 ///
 /// The graph *structure* is not serialized — it is re-derived deterministically by rebuilding
-/// `TopologyGraph` from `brep`. Only the source shape (as a BREP string) and the attribute
+/// `BRepGraph` from `brep`. Only the source shape (as a BREP string) and the attribute
 /// store travel in the snapshot.
 public struct GraphSnapshot: Codable, Sendable, Equatable {
     /// Current on-disk format version. Bump on any breaking schema change.
@@ -162,7 +162,7 @@ public struct GraphSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-/// Errors raised while snapshotting or rebuilding a `TopologyGraph`.
+/// Errors raised while snapshotting or rebuilding a `BRepGraph`.
 public enum GraphSnapshotError: Error, Equatable, Sendable {
     /// The graph has no captured source shape to serialize (e.g. built from a handle directly).
     case noSourceShape
@@ -176,7 +176,7 @@ public enum GraphSnapshotError: Error, Equatable, Sendable {
 
 // MARK: - snapshot / restore
 
-extension TopologyGraph {
+extension BRepGraph {
     /// Read one attribute on a node, or nil if unset.
     public func attribute(_ key: String, for node: NodeRef) -> AttrValue? {
         attributes.value(key, for: node)
@@ -199,7 +199,7 @@ extension TopologyGraph {
     /// for deterministic node indexing), and reattach the attributes.
     ///
     /// - Important: Attributes are keyed by `NodeRef` (`kind` + `index`). This relies on
-    ///   `TopologyGraph(shape:)` producing identical node indexing for the same BREP — which is
+    ///   `BRepGraph(shape:)` producing identical node indexing for the same BREP — which is
     ///   why the rebuild pins `parallel: false`. See the round-trip determinism test.
     public convenience init(snapshot: GraphSnapshot) throws {
         guard snapshot.formatVersion <= GraphSnapshot.currentFormatVersion else {

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -10,24 +10,24 @@ import OCCTBridge
 
 /// A graph-based representation of B-Rep topology.
 ///
-/// `TopologyGraph` provides cache-friendly traversal, O(1) upward navigation,
+/// `BRepGraph` provides cache-friendly traversal, O(1) upward navigation,
 /// and parallel geometry extraction over a shape's topology. Built from a
 /// `Shape`, it indexes all faces, edges, vertices, wires, shells, and solids
 /// as flat entity vectors with integer cross-references.
 ///
 /// ```swift
 /// let box = Shape.box(width: 10, height: 10, depth: 10)
-/// let graph = TopologyGraph(shape: box)!
+/// let graph = BRepGraph(shape: box)!
 /// print(graph.stats)  // faces: 6, edges: 12, vertices: 8
 ///
 /// // Fast adjacency queries
 /// let neighbors = graph.adjacentFaces(of: 0)  // [1, 2, 3, 4]
 /// let shared = graph.sharedEdges(between: 0, and: 1)  // [3]
 /// ```
-public final class TopologyGraph: @unchecked Sendable {
+public final class BRepGraph: @unchecked Sendable {
     internal let handle: OCCTBRepGraphRef
 
-    /// Per-node attribute store (see `TopologyGraph+Attributes.swift`).
+    /// Per-node attribute store (see `BRepGraph+Attributes.swift`).
     ///
     /// Holds arbitrary typed metadata keyed by ``NodeRef`` — fit residuals, provenance,
     /// mesh-region sets, etc. Pure Swift sidecar; never touches the underlying C++ graph.
@@ -313,7 +313,7 @@ public final class TopologyGraph: @unchecked Sendable {
         public let curves2D: Int
 
         public var description: String {
-            "TopologyGraph.Stats(solids: \(solids), shells: \(shells), faces: \(faces), " +
+            "BRepGraph.Stats(solids: \(solids), shells: \(shells), faces: \(faces), " +
             "wires: \(wires), edges: \(edges), vertices: \(vertices), coedges: \(coedges), " +
             "nodes: \(totalNodes), surfaces: \(surfaces), curves3D: \(curves3D), curves2D: \(curves2D))"
         }
@@ -542,7 +542,7 @@ public final class TopologyGraph: @unchecked Sendable {
 
     // MARK: - History Record Readback (v0.141, #72 Phase 0)
 
-    /// A (kind, index) pair identifying a node in a `TopologyGraph`.
+    /// A (kind, index) pair identifying a node in a `BRepGraph`.
     ///
     /// This is the Swift mirror of OCCT's `BRepGraph_NodeId`. Two pairs with the
     /// same kind+index refer to the same node **within a given graph instance**;
@@ -827,12 +827,12 @@ public final class TopologyGraph: @unchecked Sendable {
     /// ```swift
     /// // Cut a channel across a box's top face, then keep hold of the face.
     /// let base = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
-    /// let graph = TopologyGraph(shape: base)!
+    /// let graph = BRepGraph(shape: base)!
     ///
     /// // The topology root. Note this is findNode(for:), NOT rootNodes — that
     /// // enumerates Products and is empty for a graph built from a Shape.
     /// let rootNode = graph.findNode(for: base)!
-    /// let root = TopologyGraph.NodeRef(kind: rootNode.kind, index: rootNode.index)
+    /// let root = BRepGraph.NodeRef(kind: rootNode.kind, index: rootNode.index)
     ///
     /// // Identify the top face and pin it BEFORE the cut.
     /// let faces = base.faces()
@@ -840,7 +840,7 @@ public final class TopologyGraph: @unchecked Sendable {
     /// let topIndex = centroids.enumerated().max { $0.element.z < $1.element.z }!.offset
     /// let topFace = Shape.fromFace(faces[topIndex])!
     /// let topNode = graph.findNode(for: topFace)!
-    /// let pinned = TopologyGraph.NodeRef(kind: topNode.kind, index: topNode.index)
+    /// let pinned = BRepGraph.NodeRef(kind: topNode.kind, index: topNode.index)
     ///
     /// // Cut, then hand the result and its history back to the same graph.
     /// let tool = Shape.box(origin: SIMD3(-1, 4, 8), width: 12, height: 2, depth: 4)!
@@ -1023,25 +1023,25 @@ public final class TopologyGraph: @unchecked Sendable {
     // MARK: - Copy and Transform (v0.133.0)
 
     /// Deep copy of the graph.
-    public func copy(copyGeometry: Bool = true) -> TopologyGraph? {
+    public func copy(copyGeometry: Bool = true) -> BRepGraph? {
         guard let ref = OCCTBRepGraphCopy(handle, copyGeometry) else { return nil }
-        return TopologyGraph(borrowedHandle: ref)
+        return BRepGraph(borrowedHandle: ref)
     }
 
     /// Copy a single face sub-graph.
-    public func copyFace(_ faceIndex: Int, copyGeometry: Bool = true) -> TopologyGraph? {
+    public func copyFace(_ faceIndex: Int, copyGeometry: Bool = true) -> BRepGraph? {
         guard let ref = OCCTBRepGraphCopyFace(handle, Int32(faceIndex), copyGeometry) else {
             return nil
         }
-        return TopologyGraph(borrowedHandle: ref)
+        return BRepGraph(borrowedHandle: ref)
     }
 
     /// Transform the graph by a translation.
-    public func translated(dx: Double, dy: Double, dz: Double, copyGeometry: Bool = true) -> TopologyGraph? {
+    public func translated(dx: Double, dy: Double, dz: Double, copyGeometry: Bool = true) -> BRepGraph? {
         guard let ref = OCCTBRepGraphTransformTranslation(handle, dx, dy, dz, copyGeometry) else {
             return nil
         }
-        return TopologyGraph(borrowedHandle: ref)
+        return BRepGraph(borrowedHandle: ref)
     }
 
     /// Internal initializer from an already-created handle (takes ownership).
@@ -2073,18 +2073,18 @@ public final class TopologyGraph: @unchecked Sendable {
     /// allocates counters from 1 independently, so the same `(kind, counter)` names some
     /// unrelated node in every other graph — a box's face UID would otherwise resolve happily
     /// against a cylinder. ``graphID`` records which instance minted the UID, and
-    /// ``TopologyGraph/node(forUID:)`` rejects one that came from anywhere else (#295).
+    /// ``BRepGraph/node(forUID:)`` rejects one that came from anywhere else (#295).
     ///
     /// To carry a selection across a *modelling operation* rather than across mutations of one
     /// graph, absorb the operation's history — see
-    /// ``TopologyGraph/add(_:absorbing:inputRoots:operationName:)``.
+    /// ``BRepGraph/add(_:absorbing:inputRoots:operationName:)``.
     ///
     /// `kind` is the raw `BRepGraph_NodeId::Kind` ordinal
     /// (0 Solid, 1 Shell, 2 Face, 3 Wire, 4 Edge, 5 Vertex, 6 Compound,
     /// 7 CompSolid, 8 CoEdge, 10 Product, 11 Occurrence).
     ///
     /// ```swift
-    /// let graph = TopologyGraph(shape: box)!
+    /// let graph = BRepGraph(shape: box)!
     /// let uid = graph.uid(ofNodeKind: 2, index: 3)!    // a face, by kind + index
     ///
     /// // The UID still names that face after a mutation renumbers the indices:
@@ -2094,7 +2094,7 @@ public final class TopologyGraph: @unchecked Sendable {
     /// }
     ///
     /// // A UID from another graph resolves to nothing, rather than to a wrong node:
-    /// let other = TopologyGraph(shape: cylinder)!
+    /// let other = BRepGraph(shape: cylinder)!
     /// print(other.node(forUID: uid))      // nil
     /// print(other.contains(uid: uid))     // false
     /// ```
@@ -2102,13 +2102,13 @@ public final class TopologyGraph: @unchecked Sendable {
         public let kind: Int
         public let counter: UInt32
 
-        /// The instance that minted this UID — its ``TopologyGraph/instanceID``.
+        /// The instance that minted this UID — its ``BRepGraph/instanceID``.
         ///
         /// `0` means unstamped: built by hand, or decoded from a payload written before
         /// OCCTSwift recorded provenance. An unstamped UID resolves in no graph.
         public let graphID: UInt64
 
-        @available(*, deprecated, message: "A hand-built GraphUID has no provenance (graphID 0) and resolves in no graph. Mint one with TopologyGraph.uid(ofNodeKind:index:).")
+        @available(*, deprecated, message: "A hand-built GraphUID has no provenance (graphID 0) and resolves in no graph. Mint one with BRepGraph.uid(ofNodeKind:index:).")
         public init(kind: Int, counter: UInt32) {
             self.init(kind: kind, counter: counter, graphID: 0)
         }
@@ -2143,7 +2143,7 @@ public final class TopologyGraph: @unchecked Sendable {
     /// (0 Shell, 1 Face, 2 Wire, 3 Vertex, 4 Solid, 5 Child, 6 Occurrence).
     ///
     /// ```swift
-    /// let graph = TopologyGraph(shape: assembly)!
+    /// let graph = BRepGraph(shape: assembly)!
     /// if let uid = graph.uid(ofRefKind: 1, index: 0),      // a face reference
     ///    let ref = graph.ref(forUID: uid) {
     ///     print("face ref at index \(ref.index)")
@@ -2153,11 +2153,11 @@ public final class TopologyGraph: @unchecked Sendable {
         public let kind: Int
         public let counter: UInt32
 
-        /// The instance that minted this UID — its ``TopologyGraph/instanceID``. `0` means
+        /// The instance that minted this UID — its ``BRepGraph/instanceID``. `0` means
         /// unstamped, which resolves in no graph. See ``GraphUID/graphID``.
         public let graphID: UInt64
 
-        @available(*, deprecated, message: "A hand-built GraphRefUID has no provenance (graphID 0) and resolves in no graph. Mint one with TopologyGraph.uid(ofRefKind:index:).")
+        @available(*, deprecated, message: "A hand-built GraphRefUID has no provenance (graphID 0) and resolves in no graph. Mint one with BRepGraph.uid(ofRefKind:index:).")
         public init(kind: Int, counter: UInt32) {
             self.init(kind: kind, counter: counter, graphID: 0)
         }
@@ -2185,7 +2185,7 @@ public final class TopologyGraph: @unchecked Sendable {
     /// Scoped to one graph instance and stamped with ``graphID``, exactly as ``GraphUID`` is.
     ///
     /// ```swift
-    /// let graph = TopologyGraph(shape: box)!
+    /// let graph = BRepGraph(shape: box)!
     /// if let uid = graph.itemUID(ofNodeKind: 2, index: 0),
     ///    let item = graph.item(forUID: uid) {
     ///     print("domain \(item.domain) kind \(item.kind) index \(item.index)")
@@ -2196,11 +2196,11 @@ public final class TopologyGraph: @unchecked Sendable {
         public let kind: Int
         public let counter: UInt32
 
-        /// The instance that minted this UID — its ``TopologyGraph/instanceID``. `0` means
+        /// The instance that minted this UID — its ``BRepGraph/instanceID``. `0` means
         /// unstamped, which resolves in no graph. See ``GraphUID/graphID``.
         public let graphID: UInt64
 
-        @available(*, deprecated, message: "A hand-built GraphItemUID has no provenance (graphID 0) and resolves in no graph. Mint one with TopologyGraph.itemUID(ofNodeKind:index:).")
+        @available(*, deprecated, message: "A hand-built GraphItemUID has no provenance (graphID 0) and resolves in no graph. Mint one with BRepGraph.itemUID(ofNodeKind:index:).")
         public init(domain: Int, kind: Int, counter: UInt32) {
             self.init(domain: domain, kind: kind, counter: counter, graphID: 0)
         }
@@ -2317,7 +2317,7 @@ public final class TopologyGraph: @unchecked Sendable {
     /// does not: it lifts one face into a new graph, which gets its own id.
     ///
     /// ```swift
-    /// let graph = TopologyGraph(shape: box)!
+    /// let graph = BRepGraph(shape: box)!
     /// let uid = graph.uid(ofNodeKind: 2, index: 0)!
     /// print(uid.graphID == graph.instanceID)      // true — this graph minted it
     ///
@@ -2325,7 +2325,7 @@ public final class TopologyGraph: @unchecked Sendable {
     /// print(copy.instanceID == graph.instanceID)  // true — a copy is the same identity
     /// print(copy.node(forUID: uid) != nil)        // true — and names the same face
     ///
-    /// let rebuilt = TopologyGraph(shape: box)!    // same shape, new graph
+    /// let rebuilt = BRepGraph(shape: box)!    // same shape, new graph
     /// print(rebuilt.node(forUID: uid))            // nil
     /// ```
     public var instanceID: UInt64 {
@@ -2344,3 +2344,8 @@ public final class TopologyGraph: @unchecked Sendable {
         OCCTBRepGraphGeneration(handle)
     }
 }
+
+/// `BRepGraph`'s prior name (#333). `TopologyGraph` read as too close to the `TopoDS_*` family on a
+/// skim without signaling that this type specifically wraps the BRepGraph durable-identity engine.
+@available(*, deprecated, renamed: "BRepGraph")
+public typealias TopologyGraph = BRepGraph

--- a/Sources/OCCTSwift/ConstructionContext.swift
+++ b/Sources/OCCTSwift/ConstructionContext.swift
@@ -5,7 +5,7 @@ import simd
 //
 // Document-level collection of named construction entities. Each entity gets a
 // typed opaque ID on insertion; the context resolves entities on demand against
-// any given TopologyGraph. Entities are stored by value — storage is lightweight
+// any given BRepGraph. Entities are stored by value — storage is lightweight
 // and thread-safe via an internal lock.
 //
 // Persistence: the XCAF `CONSTRUCTION` layer hosts any shapes tagged as
@@ -152,21 +152,21 @@ public final class ConstructionContext: @unchecked Sendable {
 
     // MARK: - Resolution
 
-    public func resolve(_ id: PlaneID, in graph: TopologyGraph) -> Result<Placement, ConstructionResolutionError> {
+    public func resolve(_ id: PlaneID, in graph: BRepGraph) -> Result<Placement, ConstructionResolutionError> {
         guard let plane = self.plane(id) else {
             return .failure(.notApplicable("plane id \(id.raw) not registered"))
         }
         return graph.resolve(plane)
     }
 
-    public func resolve(_ id: AxisID, in graph: TopologyGraph) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
+    public func resolve(_ id: AxisID, in graph: BRepGraph) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
         guard let axis = self.axis(id) else {
             return .failure(.notApplicable("axis id \(id.raw) not registered"))
         }
         return graph.resolve(axis)
     }
 
-    public func resolve(_ id: PointID, in graph: TopologyGraph) -> Result<SIMD3<Double>, ConstructionResolutionError> {
+    public func resolve(_ id: PointID, in graph: BRepGraph) -> Result<SIMD3<Double>, ConstructionResolutionError> {
         guard let point = self.point(id) else {
             return .failure(.notApplicable("point id \(id.raw) not registered"))
         }
@@ -187,7 +187,7 @@ public final class ConstructionContext: @unchecked Sendable {
     /// Inspect every registered entity against the given graph, return those that
     /// fail resolution. Useful for agent workflows to detect broken references
     /// after a model edit.
-    public func allBroken(in graph: TopologyGraph) -> BrokenEntities {
+    public func allBroken(in graph: BRepGraph) -> BrokenEntities {
         var brokenPlanes: [(id: PlaneID, error: ConstructionResolutionError)] = []
         var brokenAxes: [(id: AxisID, error: ConstructionResolutionError)] = []
         var brokenPoints: [(id: PointID, error: ConstructionResolutionError)] = []

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -100,10 +100,10 @@ public enum ConstructionResolutionError: Error, Sendable {
     case topology(TopologyResolutionError)
     case notApplicable(String)               // e.g. "face is not planar"
     case degenerate(String)                  // e.g. "parallel planes"
-    case missingGeometry(TopologyGraph.NodeRef)
+    case missingGeometry(BRepGraph.NodeRef)
 }
 
-extension TopologyGraph {
+extension BRepGraph {
     public func resolve(_ plane: ConstructionPlane) -> Result<Placement, ConstructionResolutionError> {
         switch plane {
         case .absolute(let origin, let normal):
@@ -336,7 +336,7 @@ extension TopologyGraph {
 
 // MARK: - childIndices (shared helper, used by .containedIn in TopologyRef and by Phase 2 resolvers)
 
-extension TopologyGraph {
+extension BRepGraph {
     /// Indices of descendant nodes of a given kind from a root node.
     /// Complements the existing `childCount(rootKind:rootIndex:targetKind:)`.
     public func childIndices(rootKind: NodeKind, rootIndex: Int, targetKind: NodeKind) -> [Int] {

--- a/Sources/OCCTSwift/ConstructionLayer.swift
+++ b/Sources/OCCTSwift/ConstructionLayer.swift
@@ -74,7 +74,7 @@ extension ConstructionContext {
     /// Returns a breakdown of what got materialised and what failed to resolve.
     @discardableResult
     public func materialize(in document: Document,
-                            graph: TopologyGraph,
+                            graph: BRepGraph,
                             options: MaterializeOptions = MaterializeOptions()) -> MaterializationResult {
         var planeShapes: [(id: PlaneID, labelId: Int64)] = []
         var axisShapes: [(id: AxisID, labelId: Int64)] = []

--- a/Sources/OCCTSwift/FeatureReconstructor.swift
+++ b/Sources/OCCTSwift/FeatureReconstructor.swift
@@ -17,7 +17,7 @@ import simd
 // survives subsequent mutations, rather than an index-based heuristic.
 //
 // This is the v1 implementation. It:
-//   - Does not yet use TopologyGraph history recording during dispatch (the
+//   - Does not yet use BRepGraph history recording during dispatch (the
 //     shapes produced are built from primitives; each FeatureSpec gets tagged
 //     with its own opName so downstream callers can use TopologyRef.createdBy
 //     against the final graph).
@@ -607,7 +607,7 @@ public struct FeatureReconstructor: Sendable {
     /// Edge indices of `target` that were "contributed by" `source` — heuristic:
     /// edges of target whose midpoint lies within a small tolerance of any edge
     /// midpoint of source. Useful for "fillet the edges the extrude created"
-    /// without needing full TopologyGraph history.
+    /// without needing full BRepGraph history.
     private static func edgeIndicesContributedBy(target: Shape,
                                                   source: Shape,
                                                   tolerance: Double = 1e-4) -> [Int]? {

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -97,7 +97,7 @@ extension Face {
 extension ConstructionAxis {
     /// Angle between two construction axes, resolved against the given graph.
     /// Returns radians in [0, π].
-    public func angle(to other: ConstructionAxis, in graph: TopologyGraph) -> Double? {
+    public func angle(to other: ConstructionAxis, in graph: BRepGraph) -> Double? {
         guard case .success(let a) = graph.resolve(self),
               case .success(let b) = graph.resolve(other) else { return nil }
         return unsignedAngle(between: a.direction, and: b.direction)
@@ -107,7 +107,7 @@ extension ConstructionAxis {
 extension ConstructionPlane {
     /// Angle between two construction planes (angle between their normals).
     /// Returns radians in [0, π].
-    public func angle(to other: ConstructionPlane, in graph: TopologyGraph) -> Double? {
+    public func angle(to other: ConstructionPlane, in graph: BRepGraph) -> Double? {
         guard case .success(let a) = graph.resolve(self),
               case .success(let b) = graph.resolve(other) else { return nil }
         return unsignedAngle(between: a.zAxis, and: b.zAxis)

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -4964,7 +4964,7 @@ public struct ShapeHistoryRecord: Sendable {
 /// selection IDs across boolean / split mutations (e.g. OCCTMCP's
 /// `remap_selection`, parametric editors that want feature replay).
 public final class ShapeHistoryRef: @unchecked Sendable {
-    // internal, not fileprivate: TopologyGraph.add(_:absorbing:inputRoots:operationName:)
+    // internal, not fileprivate: BRepGraph.add(_:absorbing:inputRoots:operationName:)
     // in BRepGraph.swift needs it to synthesize a BRepTools_History (issue #290).
     let handle: OCCTBooleanHistoryRef
 
@@ -12305,7 +12305,7 @@ public final class Polygon2D: @unchecked Sendable {
 
 /// A `Poly_Triangulation` — a 3D mesh defined by node positions and triangle vertex indices.
 ///
-/// Used as input to `TopologyGraph.createTriangulationRep(_:)` when populating the cached
+/// Used as input to `BRepGraph.createTriangulationRep(_:)` when populating the cached
 /// mesh tier of a graph (`BRepGraph_MeshCache`). Triangle indices are 0-based on the Swift
 /// boundary; the bridge handles the OCCT 1-based conversion internally.
 public final class Triangulation: @unchecked Sendable {

--- a/Sources/OCCTSwift/Sketch.swift
+++ b/Sources/OCCTSwift/Sketch.swift
@@ -99,11 +99,11 @@ extension Sketch {
     ///
     /// - Parameters:
     ///   - context: The construction context that registered `hostPlane`.
-    ///   - graph: A TopologyGraph against which to resolve the host plane's recipe.
+    ///   - graph: A BRepGraph against which to resolve the host plane's recipe.
     /// - Returns: A closed Wire on the resolved plane, or nil if the host plane
     ///   fails to resolve or no profile elements exist.
     public func buildProfile(in context: ConstructionContext,
-                             graph: TopologyGraph) -> Wire? {
+                             graph: BRepGraph) -> Wire? {
         let profileElements = elements.filter { !$0.isConstruction }
         guard !profileElements.isEmpty else { return nil }
 

--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -19,7 +19,7 @@ import Foundation
 public indirect enum TopologyRef: Sendable, Hashable {
     /// Direct reference by current `(kind, index)`. Escape hatch — use sparingly;
     /// it bypasses recipe resolution and breaks on any graph mutation.
-    case literal(TopologyGraph.NodeRef)
+    case literal(BRepGraph.NodeRef)
 
     /// The Nth node of `kind` that appears as a replacement in a history record
     /// tagged with `operationName`. Deterministic order: (sequenceNumber,
@@ -31,7 +31,7 @@ public indirect enum TopologyRef: Sendable, Hashable {
     /// disable forward-walk entirely and get the node as originally created —
     /// rarely what you want, but useful for history inspection.
     case createdBy(operationName: String,
-                   kind: TopologyGraph.NodeKind,
+                   kind: BRepGraph.NodeKind,
                    occurrence: Int = 0,
                    leafOccurrence: Int? = 0)
 
@@ -42,7 +42,7 @@ public indirect enum TopologyRef: Sendable, Hashable {
     /// unmodified parents; for mutated parents the order is whatever the graph
     /// reports post-mutation.
     case containedIn(parent: TopologyRef,
-                     kind: TopologyGraph.NodeKind,
+                     kind: BRepGraph.NodeKind,
                      occurrence: Int = 0)
 
     /// The Nth replacement produced by the operation that split `original` into
@@ -52,20 +52,20 @@ public indirect enum TopologyRef: Sendable, Hashable {
 
 public enum TopologyResolutionError: Error, Sendable, Hashable {
     case ancestorMissing(TopologyRef)
-    case kindMismatch(expected: TopologyGraph.NodeKind, found: TopologyGraph.NodeKind)
+    case kindMismatch(expected: BRepGraph.NodeKind, found: BRepGraph.NodeKind)
     case occurrenceOutOfRange(TopologyRef, available: Int, requested: Int)
     case operationNotFound(String)
     case noCurrentDescendant(TopologyRef)
     case invalid(TopologyRef)
 }
 
-extension TopologyGraph.NodeRef {
+extension BRepGraph.NodeRef {
     /// Sentinel for recording pure creations (no meaningful ancestor).
     /// Matches OCCT's default-constructed `BRepGraph_NodeId` — kind .solid, index -1.
-    public static let sentinel = TopologyGraph.NodeRef(kind: .solid, index: -1)
+    public static let sentinel = BRepGraph.NodeRef(kind: .solid, index: -1)
 }
 
-extension TopologyGraph {
+extension BRepGraph {
     /// Resolve a `TopologyRef` recipe against the graph's current state.
     ///
     /// Recipes are evaluated lazily — `resolve` performs the lookup every call,

--- a/Tests/OCCTBRepGraphTests/GraphHistoryAbsorbTests.swift
+++ b/Tests/OCCTBRepGraphTests/GraphHistoryAbsorbTests.swift
@@ -14,10 +14,10 @@ struct GraphHistoryAbsorbTests {
     /// The reporter's scenario, assembled once.
     struct Cut {
         let base: Shape
-        let graph: TopologyGraph
-        let root: TopologyGraph.NodeRef
+        let graph: BRepGraph
+        let root: BRepGraph.NodeRef
         /// The top face's node, pinned before the cut.
-        let pinnedTop: TopologyGraph.NodeRef
+        let pinnedTop: BRepGraph.NodeRef
         let result: Shape
         let history: ShapeHistoryRef
     }
@@ -25,7 +25,7 @@ struct GraphHistoryAbsorbTests {
     static func makeCut() -> Cut? {
         guard let base = Shape.box(origin: SIMD3<Double>(0, 0, 0),
                                    width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: base),
+              let graph = BRepGraph(shape: base),
               let rootNode = graph.findNode(for: base) else { return nil }
 
         let faces = base.faces()
@@ -41,14 +41,14 @@ struct GraphHistoryAbsorbTests {
 
         return Cut(base: base,
                    graph: graph,
-                   root: TopologyGraph.NodeRef(kind: rootNode.kind, index: rootNode.index),
-                   pinnedTop: TopologyGraph.NodeRef(kind: topNode.kind, index: topNode.index),
+                   root: BRepGraph.NodeRef(kind: rootNode.kind, index: rootNode.index),
+                   pinnedTop: BRepGraph.NodeRef(kind: topNode.kind, index: topNode.index),
                    result: result,
                    history: history)
     }
 
     /// Area of the face a node reconstructs to.
-    static func faceArea(_ graph: TopologyGraph, _ node: TopologyGraph.NodeRef) -> Double? {
+    static func faceArea(_ graph: BRepGraph, _ node: BRepGraph.NodeRef) -> Double? {
         guard let shape = graph.shape(nodeKind: node.kind, nodeIndex: node.index) else { return nil }
         let areas = shape.measure().faceAreas
         guard !areas.isEmpty else { return nil }
@@ -163,7 +163,7 @@ struct GraphHistoryAbsorbTests {
               let bottomNode = c.graph.findNode(for: bottomFace) else {
             Issue.record("bottom face lookup failed"); return
         }
-        let bottom = TopologyGraph.NodeRef(kind: bottomNode.kind, index: bottomNode.index)
+        let bottom = BRepGraph.NodeRef(kind: bottomNode.kind, index: bottomNode.index)
 
         #expect(!c.graph.historyIsDeleted(bottom),
                 "an untouched face must not be reported as deleted")

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -16,12 +16,12 @@ extension SIMD3 where Scalar == Double {
 
 // MARK: - BRepGraph Tests (v0.129.0)
 
-@Suite("TopologyGraph Build")
-struct TopologyGraphBuildTests {
+@Suite("BRepGraph Build")
+struct BRepGraphBuildTests {
     @Test func buildFromBox() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             #expect(graph != nil)
             if let graph {
                 #expect(graph.faceCount == 6)
@@ -39,7 +39,7 @@ struct TopologyGraphBuildTests {
     @Test func buildParallel() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box, parallel: true)
+            let graph = BRepGraph(shape: box, parallel: true)
             #expect(graph != nil)
             if let graph {
                 #expect(graph.faceCount == 6)
@@ -50,7 +50,7 @@ struct TopologyGraphBuildTests {
     @Test func buildFromSphere() {
         let sphere = Shape.sphere(radius: 5)
         if let sphere {
-            let graph = TopologyGraph(shape: sphere)
+            let graph = BRepGraph(shape: sphere)
             if let graph {
                 #expect(graph.faceCount > 0)
                 #expect(graph.edgeCount >= 0)
@@ -65,7 +65,7 @@ struct TopologyGraphBuildTests {
         if let box, let cyl {
             let fused = box + cyl
             if let fused {
-                let graph = TopologyGraph(shape: fused)
+                let graph = BRepGraph(shape: fused)
                 if let graph {
                     #expect(graph.faceCount > 6)
                     #expect(graph.isValid)
@@ -75,12 +75,12 @@ struct TopologyGraphBuildTests {
     }
 }
 
-@Suite("TopologyGraph Counts")
-struct TopologyGraphCountTests {
+@Suite("BRepGraph Counts")
+struct BRepGraphCountTests {
     @Test func activeCounts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.activeFaceCount == 6)
                 #expect(graph.activeEdgeCount == 12)
@@ -92,7 +92,7 @@ struct TopologyGraphCountTests {
     @Test func geometryCounts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.surfaceCount == 6)
                 #expect(graph.curve3DCount == 12)
@@ -104,7 +104,7 @@ struct TopologyGraphCountTests {
     @Test func coedgeCounts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.coedgeCount == 24)
             }
@@ -112,12 +112,12 @@ struct TopologyGraphCountTests {
     }
 }
 
-@Suite("TopologyGraph Face Queries")
-struct TopologyGraphFaceQueryTests {
+@Suite("BRepGraph Face Queries")
+struct BRepGraphFaceQueryTests {
     @Test func faceAdjacency() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let adj = graph.adjacentFaces(of: 0)
                 #expect(adj.count == 4)
@@ -128,7 +128,7 @@ struct TopologyGraphFaceQueryTests {
     @Test func sharedEdges() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let adj = graph.adjacentFaces(of: 0)
                 if adj.count > 0 {
@@ -142,7 +142,7 @@ struct TopologyGraphFaceQueryTests {
     @Test func outerWire() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let wire = graph.outerWire(of: 0)
                 #expect(wire >= 0)
@@ -151,12 +151,12 @@ struct TopologyGraphFaceQueryTests {
     }
 }
 
-@Suite("TopologyGraph Edge Queries")
-struct TopologyGraphEdgeQueryTests {
+@Suite("BRepGraph Edge Queries")
+struct BRepGraphEdgeQueryTests {
     @Test func edgeFaceCount() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let nbFaces = graph.faceCount(of: 0)
                 #expect(nbFaces == 2)
@@ -167,7 +167,7 @@ struct TopologyGraphEdgeQueryTests {
     @Test func edgeFaces() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let faces = graph.faces(of: 0)
                 #expect(faces.count == 2)
@@ -178,7 +178,7 @@ struct TopologyGraphEdgeQueryTests {
     @Test func noBoundaryEdges() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     #expect(!graph.isBoundaryEdge(i))
@@ -190,7 +190,7 @@ struct TopologyGraphEdgeQueryTests {
     @Test func allManifoldEdges() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     #expect(graph.isManifoldEdge(i))
@@ -202,7 +202,7 @@ struct TopologyGraphEdgeQueryTests {
     @Test func edgeAdjacency() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let adj = graph.adjacentEdges(of: 0)
                 #expect(adj.count > 0)
@@ -211,12 +211,12 @@ struct TopologyGraphEdgeQueryTests {
     }
 }
 
-@Suite("TopologyGraph Vertex Queries")
-struct TopologyGraphVertexQueryTests {
+@Suite("BRepGraph Vertex Queries")
+struct BRepGraphVertexQueryTests {
     @Test func vertexEdges() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let edges = graph.edges(of: 0)
                 #expect(edges.count == 3)
@@ -225,12 +225,12 @@ struct TopologyGraphVertexQueryTests {
     }
 }
 
-@Suite("TopologyGraph Explorers")
-struct TopologyGraphExplorerTests {
+@Suite("BRepGraph Explorers")
+struct BRepGraphExplorerTests {
     @Test func childExplorer() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // OCCT 8.0 reshaped root iteration to Products only — wrap the
                 // box's solid root in a Product to expose it as a graph root.
@@ -248,7 +248,7 @@ struct TopologyGraphExplorerTests {
     @Test func parentExplorer() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let parents = graph.parentCount(nodeKind: .face, nodeIndex: 0)
                 #expect(parents > 0)
@@ -257,12 +257,12 @@ struct TopologyGraphExplorerTests {
     }
 }
 
-@Suite("TopologyGraph Validate")
-struct TopologyGraphValidateTests {
+@Suite("BRepGraph Validate")
+struct BRepGraphValidateTests {
     @Test func boxIsValid() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.isValid)
                 let result = graph.validate()
@@ -273,12 +273,12 @@ struct TopologyGraphValidateTests {
     }
 }
 
-@Suite("TopologyGraph Compact")
-struct TopologyGraphCompactTests {
+@Suite("BRepGraph Compact")
+struct BRepGraphCompactTests {
     @Test func compactBox() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let result = graph.compact()
                 #expect(result.nodesAfter > 0)
@@ -287,12 +287,12 @@ struct TopologyGraphCompactTests {
     }
 }
 
-@Suite("TopologyGraph Deduplicate")
-struct TopologyGraphDeduplicateTests {
+@Suite("BRepGraph Deduplicate")
+struct BRepGraphDeduplicateTests {
     @Test func deduplicateBox() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let result = graph.deduplicate()
                 #expect(result.canonicalSurfaces == 6)
@@ -302,12 +302,12 @@ struct TopologyGraphDeduplicateTests {
     }
 }
 
-@Suite("TopologyGraph Stats")
-struct TopologyGraphStatsTests {
+@Suite("BRepGraph Stats")
+struct BRepGraphStatsTests {
     @Test func boxStats() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let s = graph.stats
                 #expect(s.faces == 6)
@@ -325,12 +325,12 @@ struct TopologyGraphStatsTests {
     }
 }
 
-@Suite("TopologyGraph Node Status")
-struct TopologyGraphNodeStatusTests {
+@Suite("BRepGraph Node Status")
+struct BRepGraphNodeStatusTests {
     @Test func noRemovedNodes() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.faceCount {
                     #expect(!graph.isRemoved(nodeKind: .face, nodeIndex: i))
@@ -340,12 +340,12 @@ struct TopologyGraphNodeStatusTests {
     }
 }
 
-@Suite("TopologyGraph Root Nodes")
-struct TopologyGraphRootNodeTests {
+@Suite("BRepGraph Root Nodes")
+struct BRepGraphRootNodeTests {
     @Test func hasRoots() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // OCCT 8.0 reshaped root iteration to Products only — wrap the
                 // box's solid root in a Product to expose it as a graph root.
@@ -358,14 +358,14 @@ struct TopologyGraphRootNodeTests {
     }
 }
 
-// MARK: - TopologyGraph Extended Tests (v0.133.0)
+// MARK: - BRepGraph Extended Tests (v0.133.0)
 
-@Suite("TopologyGraph Shape Reconstruction")
-struct TopologyGraphShapeReconstructionTests {
+@Suite("BRepGraph Shape Reconstruction")
+struct BRepGraphShapeReconstructionTests {
     @Test func reconstructFace() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let face = graph.shape(nodeKind: .face, nodeIndex: 0)
                 #expect(face != nil)
@@ -376,7 +376,7 @@ struct TopologyGraphShapeReconstructionTests {
     @Test func reconstructSolid() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let solid = graph.shape(nodeKind: .solid, nodeIndex: 0)
                 #expect(solid != nil)
@@ -387,7 +387,7 @@ struct TopologyGraphShapeReconstructionTests {
     @Test func findNode() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let found = graph.hasNode(for: box)
                 #expect(found)
@@ -401,7 +401,7 @@ struct TopologyGraphShapeReconstructionTests {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         let sphere = Shape.sphere(radius: 5)
         if let box, let sphere {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(!graph.hasNode(for: sphere))
             }
@@ -409,12 +409,12 @@ struct TopologyGraphShapeReconstructionTests {
     }
 }
 
-@Suite("TopologyGraph Vertex Geometry")
-struct TopologyGraphVertexGeometryTests {
+@Suite("BRepGraph Vertex Geometry")
+struct BRepGraphVertexGeometryTests {
     @Test func vertexPoint() {
         let box = Shape.box(width: 10, height: 20, depth: 30)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let pt = graph.vertexPoint(0)
                 // Vertex should be a finite point
@@ -428,7 +428,7 @@ struct TopologyGraphVertexGeometryTests {
     @Test func vertexTolerance() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let tol = graph.vertexTolerance(0)
                 #expect(tol > 0)
@@ -438,12 +438,12 @@ struct TopologyGraphVertexGeometryTests {
     }
 }
 
-@Suite("TopologyGraph Edge Geometry")
-struct TopologyGraphEdgeGeometryTests {
+@Suite("BRepGraph Edge Geometry")
+struct BRepGraphEdgeGeometryTests {
     @Test func edgeTolerance() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let tol = graph.edgeTolerance(0)
                 #expect(tol > 0)
@@ -454,7 +454,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeNotDegenerated() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     #expect(!graph.isEdgeDegenerated(i))
@@ -466,7 +466,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeSameParameter() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     #expect(graph.isEdgeSameParameter(i))
@@ -478,7 +478,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeSameRange() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     #expect(graph.isEdgeSameRange(i))
@@ -490,7 +490,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeRange() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let range = graph.edgeRange(0)
                 #expect(range.first < range.last)
@@ -501,7 +501,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeHasCurve() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     #expect(graph.edgeHasCurve(i))
@@ -513,7 +513,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeMaxContinuity() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let cont = graph.edgeMaxContinuity(0)
                 #expect(cont >= 0)
@@ -524,7 +524,7 @@ struct TopologyGraphEdgeGeometryTests {
     @Test func edgeNotClosedOnFace() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box edges are not seam edges
                 let faces = graph.faces(of: 0)
@@ -536,12 +536,12 @@ struct TopologyGraphEdgeGeometryTests {
     }
 }
 
-@Suite("TopologyGraph Face Geometry")
-struct TopologyGraphFaceGeometryTests {
+@Suite("BRepGraph Face Geometry")
+struct BRepGraphFaceGeometryTests {
     @Test func faceTolerance() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let tol = graph.faceTolerance(0)
                 #expect(tol > 0)
@@ -552,7 +552,7 @@ struct TopologyGraphFaceGeometryTests {
     @Test func faceHasSurface() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.faceCount {
                     #expect(graph.faceHasSurface(i))
@@ -564,7 +564,7 @@ struct TopologyGraphFaceGeometryTests {
     @Test func faceNaturalRestriction() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Just check it returns a bool without crashing
                 let _ = graph.isFaceNaturalRestriction(0)
@@ -575,7 +575,7 @@ struct TopologyGraphFaceGeometryTests {
     @Test func faceHasTriangulation() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box may or may not have triangulation depending on meshing
                 let _ = graph.faceHasTriangulation(0)
@@ -584,12 +584,12 @@ struct TopologyGraphFaceGeometryTests {
     }
 }
 
-@Suite("TopologyGraph Wire Extended")
-struct TopologyGraphWireExtendedTests {
+@Suite("BRepGraph Wire Extended")
+struct BRepGraphWireExtendedTests {
     @Test func wireIsClosed() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.wireCount {
                     #expect(graph.isWireClosed(i))
@@ -601,7 +601,7 @@ struct TopologyGraphWireExtendedTests {
     @Test func wireCoEdgeCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let count = graph.wireCoEdgeCount(0)
                 #expect(count == 4) // box face has 4 edges
@@ -612,7 +612,7 @@ struct TopologyGraphWireExtendedTests {
     @Test func wireFaces() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let faceCount = graph.wireFaceCount(0)
                 #expect(faceCount == 1)
@@ -623,12 +623,12 @@ struct TopologyGraphWireExtendedTests {
     }
 }
 
-@Suite("TopologyGraph CoEdge Queries")
-struct TopologyGraphCoEdgeQueryTests {
+@Suite("BRepGraph CoEdge Queries")
+struct BRepGraphCoEdgeQueryTests {
     @Test func coedgeEdge() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let edgeIdx = graph.coedgeEdge(0)
                 #expect(edgeIdx >= 0)
@@ -640,7 +640,7 @@ struct TopologyGraphCoEdgeQueryTests {
     @Test func coedgeFace() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let faceIdx = graph.coedgeFace(0)
                 #expect(faceIdx >= 0)
@@ -652,7 +652,7 @@ struct TopologyGraphCoEdgeQueryTests {
     @Test func coedgeSeamPairNilForBox() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box edges are not seam edges, so no seam pairs
                 let pair = graph.coedgeSeamPair(0)
@@ -664,7 +664,7 @@ struct TopologyGraphCoEdgeQueryTests {
     @Test func coedgeSeamPairForSphere() {
         let sphere = Shape.sphere(radius: 5)
         if let sphere {
-            let graph = TopologyGraph(shape: sphere)
+            let graph = BRepGraph(shape: sphere)
             if let graph {
                 // Sphere has seam edges; find a coedge with a seam pair
                 var foundSeam = false
@@ -683,7 +683,7 @@ struct TopologyGraphCoEdgeQueryTests {
     @Test func coedgeHasPCurve() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box coedges should have PCurves
                 var hasPCurve = false
@@ -701,7 +701,7 @@ struct TopologyGraphCoEdgeQueryTests {
     @Test func coedgeRange() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 if graph.coedgeHasPCurve(0) {
                     let range = graph.coedgeRange(0)
@@ -712,12 +712,12 @@ struct TopologyGraphCoEdgeQueryTests {
     }
 }
 
-@Suite("TopologyGraph Shell Queries")
-struct TopologyGraphShellQueryTests {
+@Suite("BRepGraph Shell Queries")
+struct BRepGraphShellQueryTests {
     @Test func shellSolids() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let count = graph.shellSolidCount(0)
                 #expect(count == 1)
@@ -729,12 +729,12 @@ struct TopologyGraphShellQueryTests {
     }
 }
 
-@Suite("TopologyGraph Solid Queries")
-struct TopologyGraphSolidQueryTests {
+@Suite("BRepGraph Solid Queries")
+struct BRepGraphSolidQueryTests {
     @Test func solidCompSolidCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let count = graph.solidCompSolidCount(0)
                 #expect(count == 0) // standalone solid, not in comp-solid
@@ -743,12 +743,12 @@ struct TopologyGraphSolidQueryTests {
     }
 }
 
-@Suite("TopologyGraph History")
-struct TopologyGraphHistoryTests {
+@Suite("BRepGraph History")
+struct BRepGraphHistoryTests {
     @Test func historyDefaults() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.isHistoryEnabled)
                 #expect(graph.historyRecordCount == 0)
@@ -759,7 +759,7 @@ struct TopologyGraphHistoryTests {
     @Test func historyToggle() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 graph.isHistoryEnabled = false
                 #expect(!graph.isHistoryEnabled)
@@ -772,7 +772,7 @@ struct TopologyGraphHistoryTests {
     @Test func historyClear() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 graph.clearHistory()
                 #expect(graph.historyRecordCount == 0)
@@ -781,12 +781,12 @@ struct TopologyGraphHistoryTests {
     }
 }
 
-@Suite("TopologyGraph Poly Counts")
-struct TopologyGraphPolyCountTests {
+@Suite("BRepGraph Poly Counts")
+struct BRepGraphPolyCountTests {
     @Test func polyCounts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Poly counts are >= 0 (may be 0 if not meshed)
                 #expect(graph.triangulationCount >= 0)
@@ -796,12 +796,12 @@ struct TopologyGraphPolyCountTests {
     }
 }
 
-@Suite("TopologyGraph Active Geometry")
-struct TopologyGraphActiveGeometryTests {
+@Suite("BRepGraph Active Geometry")
+struct BRepGraphActiveGeometryTests {
     @Test func activeGeometryCounts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.activeSurfaceCount == 6)
                 #expect(graph.activeCurve3DCount == 12)
@@ -811,12 +811,12 @@ struct TopologyGraphActiveGeometryTests {
     }
 }
 
-@Suite("TopologyGraph SameDomain")
-struct TopologyGraphSameDomainTests {
+@Suite("BRepGraph SameDomain")
+struct BRepGraphSameDomainTests {
     @Test func boxNoSameDomain() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box faces are all distinct, no same-domain
                 let sd = graph.sameDomainFaces(of: 0)
@@ -826,12 +826,12 @@ struct TopologyGraphSameDomainTests {
     }
 }
 
-@Suite("TopologyGraph Copy")
-struct TopologyGraphCopyTests {
+@Suite("BRepGraph Copy")
+struct BRepGraphCopyTests {
     @Test func deepCopy() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let copy = graph.copy()
                 #expect(copy != nil)
@@ -847,7 +847,7 @@ struct TopologyGraphCopyTests {
     @Test func lightCopy() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let copy = graph.copy(copyGeometry: false)
                 #expect(copy != nil)
@@ -861,7 +861,7 @@ struct TopologyGraphCopyTests {
     @Test func copyFace() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let faceCopy = graph.copyFace(0)
                 #expect(faceCopy != nil)
@@ -873,12 +873,12 @@ struct TopologyGraphCopyTests {
     }
 }
 
-@Suite("TopologyGraph Transform")
-struct TopologyGraphTransformTests {
+@Suite("BRepGraph Transform")
+struct BRepGraphTransformTests {
     @Test func translateGraph() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let translated = graph.translated(dx: 100, dy: 200, dz: 300)
                 #expect(translated != nil)
@@ -900,7 +900,7 @@ struct TopologyGraphTransformTests {
     @Test func translateLightCopy() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 let translated = graph.translated(dx: 10, dy: 0, dz: 0, copyGeometry: false)
                 #expect(translated != nil)
@@ -914,12 +914,12 @@ struct TopologyGraphTransformTests {
 
 // MARK: - BRepGraph Assembly & Refs (v0.134.0)
 
-@Suite("TopologyGraph Products")
-struct TopologyGraphProductTests {
+@Suite("BRepGraph Products")
+struct BRepGraphProductTests {
     @Test func productCountForPrimitive() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Simple shapes have 1 product (the shape itself as a part)
                 #expect(graph.productCount >= 0)
@@ -940,7 +940,7 @@ struct TopologyGraphProductTests {
     @Test func productQueriesOnSphere() {
         let sphere = Shape.sphere(radius: 5)
         if let sphere {
-            let graph = TopologyGraph(shape: sphere)
+            let graph = BRepGraph(shape: sphere)
             if let graph {
                 #expect(graph.productCount >= 0)
                 #expect(graph.occurrenceCount == 0)
@@ -953,12 +953,12 @@ struct TopologyGraphProductTests {
     }
 }
 
-@Suite("TopologyGraph Occurrences")
-struct TopologyGraphOccurrenceTests {
+@Suite("BRepGraph Occurrences")
+struct BRepGraphOccurrenceTests {
     @Test func occurrenceCountForPrimitive() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.occurrenceCount == 0)
             }
@@ -966,12 +966,12 @@ struct TopologyGraphOccurrenceTests {
     }
 }
 
-@Suite("TopologyGraph Ref Counts")
-struct TopologyGraphRefCountTests {
+@Suite("BRepGraph Ref Counts")
+struct BRepGraphRefCountTests {
     @Test func refCountsForBox() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box has shells, faces, wires, coedges, vertices refs
                 #expect(graph.shellRefCount >= 1)
@@ -989,7 +989,7 @@ struct TopologyGraphRefCountTests {
     @Test func refCountsConsistency() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Face ref count should be >= face definition count
                 #expect(graph.faceRefCount >= graph.faceCount)
@@ -1000,12 +1000,12 @@ struct TopologyGraphRefCountTests {
     }
 }
 
-@Suite("TopologyGraph Ref Entry Queries")
-struct TopologyGraphRefEntryTests {
+@Suite("BRepGraph Ref Entry Queries")
+struct BRepGraphRefEntryTests {
     @Test func refChildNode() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Check face ref 0 child node
                 if graph.faceRefCount > 0 {
@@ -1024,7 +1024,7 @@ struct TopologyGraphRefEntryTests {
     @Test func refNotRemoved() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 if graph.faceRefCount > 0 {
                     #expect(!graph.isRefRemoved(.face, refIndex: 0))
@@ -1039,7 +1039,7 @@ struct TopologyGraphRefEntryTests {
     @Test func refOrientation() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 if graph.faceRefCount > 0 {
                     let ori = graph.refOrientation(.face, refIndex: 0)
@@ -1051,12 +1051,12 @@ struct TopologyGraphRefEntryTests {
     }
 }
 
-@Suite("TopologyGraph Face Def Details")
-struct TopologyGraphFaceDefTests {
+@Suite("BRepGraph Face Def Details")
+struct BRepGraphFaceDefTests {
     @Test func faceWireCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Each face of a box has exactly 1 wire (the outer wire)
                 for i in 0..<graph.faceCount {
@@ -1069,7 +1069,7 @@ struct TopologyGraphFaceDefTests {
     @Test func faceVertexRefCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box faces normally have no isolated vertices
                 for i in 0..<graph.faceCount {
@@ -1080,12 +1080,12 @@ struct TopologyGraphFaceDefTests {
     }
 }
 
-@Suite("TopologyGraph Edge Def Details")
-struct TopologyGraphEdgeDefTests {
+@Suite("BRepGraph Edge Def Details")
+struct BRepGraphEdgeDefTests {
     @Test func edgeStartEndVertex() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     let start = graph.edgeStartVertex(i)
@@ -1106,7 +1106,7 @@ struct TopologyGraphEdgeDefTests {
     @Test func edgeIsClosedOnBox() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box edges are NOT closed (they are line segments)
                 for i in 0..<graph.edgeCount {
@@ -1119,7 +1119,7 @@ struct TopologyGraphEdgeDefTests {
     @Test func edgeClosedConsistency() {
         let sphere = Shape.sphere(radius: 5)
         if let sphere {
-            let graph = TopologyGraph(shape: sphere)
+            let graph = BRepGraph(shape: sphere)
             if let graph {
                 // For any closed edge, start == end vertex
                 for i in 0..<graph.edgeCount {
@@ -1138,12 +1138,12 @@ struct TopologyGraphEdgeDefTests {
     }
 }
 
-@Suite("TopologyGraph Edge Wires CoEdges")
-struct TopologyGraphEdgeWiresCoEdgesTests {
+@Suite("BRepGraph Edge Wires CoEdges")
+struct BRepGraphEdgeWiresCoEdgesTests {
     @Test func edgeWires() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     let wires = graph.edgeWires(i)
@@ -1160,7 +1160,7 @@ struct TopologyGraphEdgeWiresCoEdgesTests {
     @Test func edgeCoEdges() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.edgeCount {
                     let coedges = graph.edgeCoEdges(i)
@@ -1177,7 +1177,7 @@ struct TopologyGraphEdgeWiresCoEdgesTests {
     @Test func edgeFindCoEdge() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // For each edge, find a coedge on one of its faces
                 for i in 0..<graph.edgeCount {
@@ -1195,12 +1195,12 @@ struct TopologyGraphEdgeWiresCoEdgesTests {
     }
 }
 
-@Suite("TopologyGraph Face Shells")
-struct TopologyGraphFaceShellTests {
+@Suite("BRepGraph Face Shells")
+struct BRepGraphFaceShellTests {
     @Test func faceShells() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.faceCount {
                     let count = graph.faceShellCount(i)
@@ -1218,7 +1218,7 @@ struct TopologyGraphFaceShellTests {
     @Test func faceCompoundCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box faces are not in compounds
                 for i in 0..<graph.faceCount {
@@ -1229,12 +1229,12 @@ struct TopologyGraphFaceShellTests {
     }
 }
 
-@Suite("TopologyGraph Shell Extended")
-struct TopologyGraphShellExtendedTests {
+@Suite("BRepGraph Shell Extended")
+struct BRepGraphShellExtendedTests {
     @Test func shellCompoundCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.shellCount {
                     #expect(graph.shellCompoundCount(i) == 0)
@@ -1246,7 +1246,7 @@ struct TopologyGraphShellExtendedTests {
     @Test func shellIsClosed() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Box shell should be closed
                 #expect(graph.shellCount >= 1)
@@ -1258,12 +1258,12 @@ struct TopologyGraphShellExtendedTests {
     }
 }
 
-@Suite("TopologyGraph Solid Extended")
-struct TopologyGraphSolidExtendedTests {
+@Suite("BRepGraph Solid Extended")
+struct BRepGraphSolidExtendedTests {
     @Test func solidCompoundCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 for i in 0..<graph.solidCount {
                     #expect(graph.solidCompoundCount(i) == 0)
@@ -1273,12 +1273,12 @@ struct TopologyGraphSolidExtendedTests {
     }
 }
 
-@Suite("TopologyGraph CompSolid Count")
-struct TopologyGraphCompSolidCountTests {
+@Suite("BRepGraph CompSolid Count")
+struct BRepGraphCompSolidCountTests {
     @Test func compSolidCount() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.compSolidCount == 0)
             }
@@ -1286,8 +1286,8 @@ struct TopologyGraphCompSolidCountTests {
     }
 }
 
-@Suite("TopologyGraph Compound Queries")
-struct TopologyGraphCompoundTests {
+@Suite("BRepGraph Compound Queries")
+struct BRepGraphCompoundTests {
     @Test func compoundQueriesOnCompound() {
         // Create a compound shape by fusing two boxes
         let box1 = Shape.box(width: 10, height: 10, depth: 10)
@@ -1295,7 +1295,7 @@ struct TopologyGraphCompoundTests {
         if let box1, let box2 {
             let compound = Shape.compound([box1, box2])
             if let compound {
-                let graph = TopologyGraph(shape: compound)
+                let graph = BRepGraph(shape: compound)
                 if let graph {
                     #expect(graph.compoundCount >= 1)
                     if graph.compoundCount > 0 {
@@ -1313,11 +1313,11 @@ struct TopologyGraphCompoundTests {
 
 // MARK: - BRepGraph Builder (v0.135.0)
 
-@Suite("TopologyGraph Builder AddVertex")
-struct TopologyGraphBuilderAddVertexTests {
+@Suite("BRepGraph Builder AddVertex")
+struct BRepGraphBuilderAddVertexTests {
     @Test func addVertexToGraph() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origVertexCount = graph.vertexCount
                 if let vidx = graph.addVertex(x: 5.0, y: 5.0, z: 5.0, tolerance: 1e-7) {
                     #expect(vidx >= 0)
@@ -1334,7 +1334,7 @@ struct TopologyGraphBuilderAddVertexTests {
 
     @Test func addMultipleVertices() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let orig = graph.vertexCount
                 let v1 = graph.addVertex(x: 0, y: 0, z: 0, tolerance: 0.01)
                 let v2 = graph.addVertex(x: 1, y: 2, z: 3, tolerance: 0.02)
@@ -1346,11 +1346,11 @@ struct TopologyGraphBuilderAddVertexTests {
     }
 }
 
-@Suite("TopologyGraph Builder AddShell")
-struct TopologyGraphBuilderAddShellTests {
+@Suite("BRepGraph Builder AddShell")
+struct BRepGraphBuilderAddShellTests {
     @Test func addEmptyShell() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origShellCount = graph.shellCount
                 if let sidx = graph.addShell() {
                     #expect(sidx >= 0)
@@ -1361,11 +1361,11 @@ struct TopologyGraphBuilderAddShellTests {
     }
 }
 
-@Suite("TopologyGraph Builder AddSolid")
-struct TopologyGraphBuilderAddSolidTests {
+@Suite("BRepGraph Builder AddSolid")
+struct BRepGraphBuilderAddSolidTests {
     @Test func addEmptySolid() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origSolidCount = graph.solidCount
                 if let sidx = graph.addSolid() {
                     #expect(sidx >= 0)
@@ -1376,11 +1376,11 @@ struct TopologyGraphBuilderAddSolidTests {
     }
 }
 
-@Suite("TopologyGraph Builder AddFaceToShell")
-struct TopologyGraphBuilderAddFaceToShellTests {
+@Suite("BRepGraph Builder AddFaceToShell")
+struct BRepGraphBuilderAddFaceToShellTests {
     @Test func linkFaceToShell() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 // Add a new shell, then link existing face 0 to it
                 if let shellIdx = graph.addShell() {
                     let refIdx = graph.addFaceToShell(shellIndex: shellIdx, faceIndex: 0, orientation: 0)
@@ -1391,11 +1391,11 @@ struct TopologyGraphBuilderAddFaceToShellTests {
     }
 }
 
-@Suite("TopologyGraph Builder AddShellToSolid")
-struct TopologyGraphBuilderAddShellToSolidTests {
+@Suite("BRepGraph Builder AddShellToSolid")
+struct BRepGraphBuilderAddShellToSolidTests {
     @Test func linkShellToSolid() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 if let solidIdx = graph.addSolid(), let shellIdx = graph.addShell() {
                     let refIdx = graph.addShellToSolid(solidIndex: solidIdx, shellIndex: shellIdx, orientation: 0)
                     #expect(refIdx != nil)
@@ -1405,14 +1405,14 @@ struct TopologyGraphBuilderAddShellToSolidTests {
     }
 }
 
-@Suite("TopologyGraph Builder AddCompound")
-struct TopologyGraphBuilderAddCompoundTests {
+@Suite("BRepGraph Builder AddCompound")
+struct BRepGraphBuilderAddCompoundTests {
     @Test func addCompoundFromSolids() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origCompoundCount = graph.compoundCount
                 if graph.solidCount > 0 {
-                    let children: [(kind: TopologyGraph.NodeKind, index: Int)] = [
+                    let children: [(kind: BRepGraph.NodeKind, index: Int)] = [
                         (.solid, 0)
                     ]
                     if let cidx = graph.addCompound(children: children) {
@@ -1425,11 +1425,11 @@ struct TopologyGraphBuilderAddCompoundTests {
     }
 }
 
-@Suite("TopologyGraph Builder AddCompSolid")
-struct TopologyGraphBuilderAddCompSolidTests {
+@Suite("BRepGraph Builder AddCompSolid")
+struct BRepGraphBuilderAddCompSolidTests {
     @Test func addCompSolidFromSolids() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origCS = graph.compSolidCount
                 if graph.solidCount > 0 {
                     if let csIdx = graph.addCompSolid(solidIndices: [0]) {
@@ -1442,11 +1442,11 @@ struct TopologyGraphBuilderAddCompSolidTests {
     }
 }
 
-@Suite("TopologyGraph Builder RemoveNode")
-struct TopologyGraphBuilderRemoveNodeTests {
+@Suite("BRepGraph Builder RemoveNode")
+struct BRepGraphBuilderRemoveNodeTests {
     @Test func removeVertex() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 if graph.vertexCount > 0 {
                     let vIdx = graph.vertexCount - 1
                     #expect(!graph.isRemoved(nodeKind: .vertex, nodeIndex: vIdx))
@@ -1459,7 +1459,7 @@ struct TopologyGraphBuilderRemoveNodeTests {
 
     @Test func removeSubgraph() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 if graph.faceCount > 0 {
                     let fIdx = graph.faceCount - 1
                     graph.removeSubgraph(nodeKind: .face, nodeIndex: fIdx)
@@ -1470,11 +1470,11 @@ struct TopologyGraphBuilderRemoveNodeTests {
     }
 }
 
-@Suite("TopologyGraph Builder AppendShape")
-struct TopologyGraphBuilderAppendShapeTests {
+@Suite("BRepGraph Builder AppendShape")
+struct BRepGraphBuilderAppendShapeTests {
     @Test func appendFlattenedShape() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origFaces = graph.faceCount
                 if let sphere = Shape.sphere(radius: 5) {
                     graph.appendFlattenedShape(sphere)
@@ -1486,7 +1486,7 @@ struct TopologyGraphBuilderAppendShapeTests {
 
     @Test func appendFullShape() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let origFaces = graph.faceCount
                 if let cylinder = Shape.cylinder(radius: 3, height: 8) {
                     graph.appendFullShape(cylinder)
@@ -1497,11 +1497,11 @@ struct TopologyGraphBuilderAppendShapeTests {
     }
 }
 
-@Suite("TopologyGraph Builder Deferred")
-struct TopologyGraphBuilderDeferredTests {
+@Suite("BRepGraph Builder Deferred")
+struct BRepGraphBuilderDeferredTests {
     @Test func deferredModeToggle() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 #expect(!graph.isDeferredMode)
                 graph.beginDeferredInvalidation()
                 #expect(graph.isDeferredMode)
@@ -1513,7 +1513,7 @@ struct TopologyGraphBuilderDeferredTests {
 
     @Test func deferredModeWithMutations() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 graph.beginDeferredInvalidation()
                 _ = graph.addVertex(x: 1, y: 2, z: 3, tolerance: 0.001)
                 _ = graph.addVertex(x: 4, y: 5, z: 6, tolerance: 0.001)
@@ -1525,11 +1525,11 @@ struct TopologyGraphBuilderDeferredTests {
     }
 }
 
-@Suite("TopologyGraph Builder CommitMutation")
-struct TopologyGraphBuilderCommitMutationTests {
+@Suite("BRepGraph Builder CommitMutation")
+struct BRepGraphBuilderCommitMutationTests {
     @Test func commitAfterAdd() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 _ = graph.addVertex(x: 0, y: 0, z: 0, tolerance: 0.01)
                 graph.commitMutation()
                 // Should not crash
@@ -1539,11 +1539,11 @@ struct TopologyGraphBuilderCommitMutationTests {
     }
 }
 
-@Suite("TopologyGraph Builder RemoveRef")
-struct TopologyGraphBuilderRemoveRefTests {
+@Suite("BRepGraph Builder RemoveRef")
+struct BRepGraphBuilderRemoveRefTests {
     @Test func removeShellRef() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 if graph.shellRefCount > 0 {
                     let removed = graph.removeRef(refKind: .shell, refIndex: 0)
                     // Should succeed or gracefully fail
@@ -1554,13 +1554,13 @@ struct TopologyGraphBuilderRemoveRefTests {
     }
 }
 
-@Suite("TopologyGraph Builder ClearMesh")
-struct TopologyGraphBuilderClearMeshTests {
+@Suite("BRepGraph Builder ClearMesh")
+struct BRepGraphBuilderClearMeshTests {
     @Test func clearFaceMesh() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             // Mesh the shape first
             let _ = box.mesh(linearDeflection: 0.1)
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 if graph.faceCount > 0 {
                     // Should not crash
                     graph.clearFaceMesh(faceIndex: 0)
@@ -1572,7 +1572,7 @@ struct TopologyGraphBuilderClearMeshTests {
     @Test func clearEdgePolygon3D() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             let _ = box.mesh(linearDeflection: 0.1)
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 if graph.edgeCount > 0 {
                     // Should not crash
                     graph.clearEdgePolygon3D(edgeIndex: 0)
@@ -1582,11 +1582,11 @@ struct TopologyGraphBuilderClearMeshTests {
     }
 }
 
-@Suite("TopologyGraph Builder ValidateMutation")
-struct TopologyGraphBuilderValidateMutationTests {
+@Suite("BRepGraph Builder ValidateMutation")
+struct BRepGraphBuilderValidateMutationTests {
     @Test func validateCleanGraph() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 // A freshly built graph should have valid mutation boundary
                 let valid = graph.validateMutation()
                 #expect(valid)
@@ -1596,7 +1596,7 @@ struct TopologyGraphBuilderValidateMutationTests {
 
     @Test func validateAfterAddVertex() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 _ = graph.addVertex(x: 0, y: 0, z: 0, tolerance: 0.01)
                 graph.commitMutation()
                 let valid = graph.validateMutation()
@@ -1606,13 +1606,13 @@ struct TopologyGraphBuilderValidateMutationTests {
     }
 }
 
-// MARK: - TopologyGraph UV Grid Sampling (v0.136.0)
+// MARK: - BRepGraph UV Grid Sampling (v0.136.0)
 
-@Suite("TopologyGraph UV Grid")
-struct TopologyGraphUVGridTests {
+@Suite("BRepGraph UV Grid")
+struct BRepGraphUVGridTests {
     @Test func sampleBoxFace() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 5, vSamples: 5)
                 #expect(sample != nil)
                 if let sample {
@@ -1638,7 +1638,7 @@ struct TopologyGraphUVGridTests {
 
     @Test func sampleSphereFace() {
         if let sphere = Shape.sphere(radius: 5) {
-            if let graph = TopologyGraph(shape: sphere) {
+            if let graph = BRepGraph(shape: sphere) {
                 if graph.faceCount > 0 {
                     let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 4, vSamples: 4)
                     if let sample {
@@ -1657,7 +1657,7 @@ struct TopologyGraphUVGridTests {
 
     @Test func sampleSinglePoint() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 1, vSamples: 1)
                 #expect(sample != nil)
                 if let sample {
@@ -1669,7 +1669,7 @@ struct TopologyGraphUVGridTests {
 
     @Test func sampleInvalidFace() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let sample = graph.sampleFaceUVGrid(faceIndex: 999, uSamples: 5, vSamples: 5)
                 #expect(sample == nil)
             }
@@ -1678,7 +1678,7 @@ struct TopologyGraphUVGridTests {
 
     @Test func sampleZeroCounts() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 0, vSamples: 5)
                 #expect(sample == nil)
             }
@@ -1686,11 +1686,11 @@ struct TopologyGraphUVGridTests {
     }
 }
 
-@Suite("TopologyGraph Edge Sampling")
-struct TopologyGraphEdgeSamplingTests {
+@Suite("BRepGraph Edge Sampling")
+struct BRepGraphEdgeSamplingTests {
     @Test func sampleBoxEdge() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 // Find an edge with a curve
                 var sampledEdge = -1
                 for i in 0..<graph.edgeCount {
@@ -1718,7 +1718,7 @@ struct TopologyGraphEdgeSamplingTests {
 
     @Test func sampleSinglePoint() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 for i in 0..<graph.edgeCount {
                     if graph.edgeHasCurve(i) {
                         let points = graph.sampleEdgeCurve(edgeIndex: i, count: 1)
@@ -1732,7 +1732,7 @@ struct TopologyGraphEdgeSamplingTests {
 
     @Test func sampleEdgeWithoutCurve() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 // Test with invalid index
                 let points = graph.sampleEdgeCurve(edgeIndex: 999, count: 10)
                 #expect(points.isEmpty)
@@ -1742,7 +1742,7 @@ struct TopologyGraphEdgeSamplingTests {
 
     @Test func sampleZeroCount() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            if let graph = TopologyGraph(shape: box) {
+            if let graph = BRepGraph(shape: box) {
                 let points = graph.sampleEdgeCurve(edgeIndex: 0, count: 0)
                 #expect(points.isEmpty)
             }
@@ -1751,7 +1751,7 @@ struct TopologyGraphEdgeSamplingTests {
 
     @Test func sampleSphereEdge() {
         if let sphere = Shape.sphere(radius: 5) {
-            if let graph = TopologyGraph(shape: sphere) {
+            if let graph = BRepGraph(shape: sphere) {
                 for i in 0..<graph.edgeCount {
                     if graph.edgeHasCurve(i) {
                         let points = graph.sampleEdgeCurve(edgeIndex: i, count: 20)
@@ -1776,14 +1776,14 @@ struct BRepGraphHistoryReadbackTests {
     @Test("Recorded 1-to-1 modification survives roundtrip through the API")
     func oneToOneReadback() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let orig = TopologyGraph.NodeRef(kind: .face, index: 0)
-        let repl = TopologyGraph.NodeRef(kind: .face, index: 42)
+        let orig = BRepGraph.NodeRef(kind: .face, index: 0)
+        let repl = BRepGraph.NodeRef(kind: .face, index: 42)
         graph.recordHistory(operationName: "TestFillet", original: orig, replacements: [repl])
 
         #expect(graph.historyRecordCount == 1)
@@ -1798,16 +1798,16 @@ struct BRepGraphHistoryReadbackTests {
     @Test("Split (1-to-N) mapping round-trips")
     func splitMapping() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let orig = TopologyGraph.NodeRef(kind: .edge, index: 3)
-        let a = TopologyGraph.NodeRef(kind: .edge, index: 100)
-        let b = TopologyGraph.NodeRef(kind: .edge, index: 101)
-        let c = TopologyGraph.NodeRef(kind: .edge, index: 102)
+        let orig = BRepGraph.NodeRef(kind: .edge, index: 3)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 100)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 101)
+        let c = BRepGraph.NodeRef(kind: .edge, index: 102)
         graph.recordHistory(operationName: "SplitEdge", original: orig, replacements: [a, b, c])
 
         let rec = graph.historyRecord(at: 0)
@@ -1817,13 +1817,13 @@ struct BRepGraphHistoryReadbackTests {
     @Test("Deletion (1-to-0) round-trips")
     func deletionMapping() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let orig = TopologyGraph.NodeRef(kind: .face, index: 5)
+        let orig = BRepGraph.NodeRef(kind: .face, index: 5)
         graph.recordHistory(operationName: "RemoveFace", original: orig, replacements: [])
 
         let rec = graph.historyRecord(at: 0)
@@ -1833,17 +1833,17 @@ struct BRepGraphHistoryReadbackTests {
     @Test("FindDerived walks forward through chained records")
     func findDerivedWalksForward() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
         // orig → [a] → [b, c]
-        let orig = TopologyGraph.NodeRef(kind: .edge, index: 1)
-        let a = TopologyGraph.NodeRef(kind: .edge, index: 10)
-        let b = TopologyGraph.NodeRef(kind: .edge, index: 20)
-        let c = TopologyGraph.NodeRef(kind: .edge, index: 21)
+        let orig = BRepGraph.NodeRef(kind: .edge, index: 1)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 10)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 20)
+        let c = BRepGraph.NodeRef(kind: .edge, index: 21)
         graph.recordHistory(operationName: "Op1", original: orig, replacements: [a])
         graph.recordHistory(operationName: "Op2", original: a, replacements: [b, c])
 
@@ -1858,16 +1858,16 @@ struct BRepGraphHistoryReadbackTests {
     @Test("hasHistoryRecord: true for nodes named in any record's mapping; false otherwise")
     func hasHistoryRecordDistinguishesNamedFromUntouched() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let modified = TopologyGraph.NodeRef(kind: .face, index: 0)
-        let replaced = TopologyGraph.NodeRef(kind: .face, index: 100)
-        let deleted = TopologyGraph.NodeRef(kind: .face, index: 1)
-        let untouched = TopologyGraph.NodeRef(kind: .face, index: 2)
+        let modified = BRepGraph.NodeRef(kind: .face, index: 0)
+        let replaced = BRepGraph.NodeRef(kind: .face, index: 100)
+        let deleted = BRepGraph.NodeRef(kind: .face, index: 1)
+        let untouched = BRepGraph.NodeRef(kind: .face, index: 2)
 
         graph.recordHistory(operationName: "ModifyFace", original: modified, replacements: [replaced])
         graph.recordHistory(operationName: "DeleteFace", original: deleted, replacements: [])
@@ -1880,16 +1880,16 @@ struct BRepGraphHistoryReadbackTests {
     @Test("findDerivedOrSelf: returns derivatives, [] for deleted, [original] for untouched")
     func findDerivedOrSelfDisambiguates() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let modified = TopologyGraph.NodeRef(kind: .face, index: 0)
-        let replaced = TopologyGraph.NodeRef(kind: .face, index: 100)
-        let deleted = TopologyGraph.NodeRef(kind: .face, index: 1)
-        let untouched = TopologyGraph.NodeRef(kind: .face, index: 2)
+        let modified = BRepGraph.NodeRef(kind: .face, index: 0)
+        let replaced = BRepGraph.NodeRef(kind: .face, index: 100)
+        let deleted = BRepGraph.NodeRef(kind: .face, index: 1)
+        let untouched = BRepGraph.NodeRef(kind: .face, index: 2)
 
         graph.recordHistory(operationName: "ModifyFace", original: modified, replacements: [replaced])
         graph.recordHistory(operationName: "DeleteFace", original: deleted, replacements: [])
@@ -1912,17 +1912,17 @@ struct BRepGraphHistoryReadbackTests {
     @Test("findDerivedOrSelf preserves findDerived semantics for chained records")
     func findDerivedOrSelfMatchesFindDerivedWhenNonEmpty() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
         // orig → [a] → [b, c]
-        let orig = TopologyGraph.NodeRef(kind: .edge, index: 1)
-        let a = TopologyGraph.NodeRef(kind: .edge, index: 10)
-        let b = TopologyGraph.NodeRef(kind: .edge, index: 20)
-        let c = TopologyGraph.NodeRef(kind: .edge, index: 21)
+        let orig = BRepGraph.NodeRef(kind: .edge, index: 1)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 10)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 20)
+        let c = BRepGraph.NodeRef(kind: .edge, index: 21)
         graph.recordHistory(operationName: "Op1", original: orig, replacements: [a])
         graph.recordHistory(operationName: "Op2", original: a, replacements: [b, c])
 
@@ -1936,15 +1936,15 @@ struct BRepGraphHistoryReadbackTests {
     @Test("FindOriginal walks backwards")
     func findOriginalWalksBackward() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let orig = TopologyGraph.NodeRef(kind: .face, index: 7)
-        let mid = TopologyGraph.NodeRef(kind: .face, index: 70)
-        let leaf = TopologyGraph.NodeRef(kind: .face, index: 700)
+        let orig = BRepGraph.NodeRef(kind: .face, index: 7)
+        let mid = BRepGraph.NodeRef(kind: .face, index: 70)
+        let leaf = BRepGraph.NodeRef(kind: .face, index: 700)
         graph.recordHistory(operationName: "A", original: orig, replacements: [mid])
         graph.recordHistory(operationName: "B", original: mid, replacements: [leaf])
 
@@ -1954,13 +1954,13 @@ struct BRepGraphHistoryReadbackTests {
     @Test("Unrecorded node findOriginal returns itself")
     func findOriginalPassthrough() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
-        let node = TopologyGraph.NodeRef(kind: .face, index: 3)
+        let node = BRepGraph.NodeRef(kind: .face, index: 3)
         #expect(graph.findOriginal(of: node) == node)
     }
 }
@@ -1972,10 +1972,10 @@ struct TopologyRefResolverTests {
     @Test("Literal reference to a valid node resolves to itself")
     func literalValid() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
-        let node = TopologyGraph.NodeRef(kind: .face, index: 2)
+        let node = BRepGraph.NodeRef(kind: .face, index: 2)
         let result = graph.resolve(.literal(node))
         switch result {
         case .success(let r): #expect(r == node)
@@ -1986,7 +1986,7 @@ struct TopologyRefResolverTests {
     @Test("Literal reference to an invalid node fails")
     func literalInvalid() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let result = graph.resolve(.literal(.sentinel))
@@ -1998,12 +1998,12 @@ struct TopologyRefResolverTests {
     @Test("createdBy resolves to the recorded replacement")
     func createdByBasic() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
-        let newFace = TopologyGraph.NodeRef(kind: .face, index: 100)
+        let newFace = BRepGraph.NodeRef(kind: .face, index: 100)
         graph.recordHistory(operationName: "Extrude_1",
                              original: .sentinel,
                              replacements: [newFace])
@@ -2017,7 +2017,7 @@ struct TopologyRefResolverTests {
     @Test("createdBy with unknown operation fails with operationNotFound")
     func createdByMissingOp() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
@@ -2033,12 +2033,12 @@ struct TopologyRefResolverTests {
     @Test("createdBy with occurrence out of range fails cleanly")
     func createdByOutOfRange() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
-        let only = TopologyGraph.NodeRef(kind: .face, index: 100)
+        let only = BRepGraph.NodeRef(kind: .face, index: 100)
         graph.recordHistory(operationName: "Op", original: .sentinel, replacements: [only])
         let result = graph.resolve(.createdBy(operationName: "Op", kind: .face, occurrence: 5))
         if case .failure(.occurrenceOutOfRange(_, let available, let requested)) = result {
@@ -2052,14 +2052,14 @@ struct TopologyRefResolverTests {
     @Test("createdBy walks forward through subsequent history to currentForm")
     func createdByForwardWalk() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
         // op1 creates face 10; op2 modifies face 10 → face 11.
-        let created = TopologyGraph.NodeRef(kind: .face, index: 10)
-        let current = TopologyGraph.NodeRef(kind: .face, index: 11)
+        let created = BRepGraph.NodeRef(kind: .face, index: 10)
+        let current = BRepGraph.NodeRef(kind: .face, index: 11)
         graph.recordHistory(operationName: "Create", original: .sentinel, replacements: [created])
         graph.recordHistory(operationName: "Modify", original: created, replacements: [current])
         // Asking for "face created by Create" should give the CURRENT form (face 11),
@@ -2074,14 +2074,14 @@ struct TopologyRefResolverTests {
     @Test("splitOf picks the Nth replacement of a split original")
     func splitOf() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
-        let orig = TopologyGraph.NodeRef(kind: .edge, index: 3)
-        let a = TopologyGraph.NodeRef(kind: .edge, index: 30)
-        let b = TopologyGraph.NodeRef(kind: .edge, index: 31)
+        let orig = BRepGraph.NodeRef(kind: .edge, index: 3)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 30)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 31)
         graph.recordHistory(operationName: "SplitEdge", original: orig, replacements: [a, b])
         let result = graph.resolve(.splitOf(original: .literal(orig), occurrence: 1))
         switch result {
@@ -2093,7 +2093,7 @@ struct TopologyRefResolverTests {
     @Test("Ancestor resolution failure propagates")
     func ancestorMissing() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
@@ -2115,7 +2115,7 @@ struct ConstructionPlaneTests {
     @Test("Absolute plane resolves to specified origin+normal")
     func absolutePlane() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let plane = ConstructionPlane.absolute(origin: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1))
@@ -2130,7 +2130,7 @@ struct ConstructionPlaneTests {
     @Test("offsetFromFace produces a parallel plane at the offset")
     func offsetFromFace() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         // Pick any face; the exact normal is produced from the UV midpoint.
@@ -2149,7 +2149,7 @@ struct ConstructionPlaneTests {
     @Test("byThreePoints returns a valid plane through three vertices")
     func byThreePoints() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let v0 = TopologyRef.literal(.init(kind: .vertex, index: 0))
@@ -2166,7 +2166,7 @@ struct ConstructionPlaneTests {
     @Test("byThreePoints on collinear points fails with degenerate")
     func collinearPointsDegenerate() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let v = TopologyRef.literal(.init(kind: .vertex, index: 0))
@@ -2180,7 +2180,7 @@ struct ConstructionPlaneTests {
     @Test("normalToEdge produces plane perpendicular to edge tangent")
     func normalToEdge() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let edgeRef = TopologyRef.literal(.init(kind: .edge, index: 0))
@@ -2199,7 +2199,7 @@ struct ConstructionAxisTests {
     @Test("alongEdge produces edge start + unit direction")
     func alongEdge() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let edge = TopologyRef.literal(.init(kind: .edge, index: 0))
@@ -2213,7 +2213,7 @@ struct ConstructionAxisTests {
     @Test("throughPoints on coincident vertices fails with degenerate")
     func coincidentPointsDegenerate() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let v = TopologyRef.literal(.init(kind: .vertex, index: 0))
@@ -2225,7 +2225,7 @@ struct ConstructionAxisTests {
     @Test("intersectionOfPlanes on parallel planes fails with degenerate")
     func parallelIntersectionDegenerate() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let a = ConstructionPlane.absolute(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1))
@@ -2241,7 +2241,7 @@ struct ConstructionPointTests {
     @Test("atVertex returns the vertex's 3D point")
     func atVertex() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let v = TopologyRef.literal(.init(kind: .vertex, index: 0))
@@ -2256,7 +2256,7 @@ struct ConstructionPointTests {
     @Test("midpointOfEdge lies between endpoints")
     func midpointOfEdge() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let edge = TopologyRef.literal(.init(kind: .edge, index: 0))
@@ -2270,7 +2270,7 @@ struct ConstructionPointTests {
     @Test("intersectionOfAxisAndPlane for axis parallel to plane fails")
     func parallelIntersectionFails() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let plane = ConstructionPlane.absolute(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1))
@@ -2283,7 +2283,7 @@ struct ConstructionPointTests {
     @Test("intersectionOfAxisAndPlane computes correct intersection")
     func intersectionCorrect() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let plane = ConstructionPlane.absolute(origin: SIMD3(0, 0, 10), normal: SIMD3(0, 0, 1))
@@ -2303,7 +2303,7 @@ struct ContainedInTests {
     @Test("Face contained in a box solid resolves")
     func faceInSolid() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let solid = TopologyRef.literal(.init(kind: .solid, index: 0))
@@ -2318,7 +2318,7 @@ struct ContainedInTests {
     @Test("Occurrence out of range in containedIn")
     func faceInSolidOOB() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let solid = TopologyRef.literal(.init(kind: .solid, index: 0))
@@ -2331,14 +2331,14 @@ struct ContainedInTests {
 
 // MARK: - Durable Identity (UID / RefUID / ItemUID) — OCCT 8.0.0p1
 
-@Suite("TopologyGraph Durable UID")
-struct TopologyGraphDurableUIDTests {
+@Suite("BRepGraph Durable UID")
+struct BRepGraphDurableUIDTests {
     // Face kind ordinal in BRepGraph_NodeId::Kind is 2.
     private let faceKind = 2
 
     @Test func nodeUIDRoundTrip() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        guard let graph = TopologyGraph(shape: box) else { return }
+        guard let graph = BRepGraph(shape: box) else { return }
         #expect(graph.faceCount == 6)
 
         // Every face should yield a valid UID that round-trips back to the same node.
@@ -2364,8 +2364,8 @@ struct TopologyGraphDurableUIDTests {
     @Test func uidFromAnotherGraphDoesNotResolve() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let cyl = Shape.cylinder(radius: 3, height: 7),
-              let boxGraph = TopologyGraph(shape: box),
-              let cylGraph = TopologyGraph(shape: cyl) else { return }
+              let boxGraph = BRepGraph(shape: box),
+              let cylGraph = BRepGraph(shape: cyl) else { return }
 
         guard let boxFaceUID = boxGraph.uid(ofNodeKind: faceKind, index: 2) else {
             Issue.record("box face 2 had no UID"); return
@@ -2384,8 +2384,8 @@ struct TopologyGraphDurableUIDTests {
     /// geometry. This is the case a consumer is most likely to assume works.
     @Test func uidDoesNotCrossIdenticallyBuiltGraphs() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let a = TopologyGraph(shape: box),
-              let b = TopologyGraph(shape: box) else { return }
+              let a = BRepGraph(shape: box),
+              let b = BRepGraph(shape: box) else { return }
         #expect(a.instanceID != b.instanceID)
         guard let uid = a.uid(ofNodeKind: faceKind, index: 1) else { return }
         #expect(b.node(forUID: uid) == nil)
@@ -2394,7 +2394,7 @@ struct TopologyGraphDurableUIDTests {
 
     /// Mean sampled position + normal — a signature that actually distinguishes a box's faces.
     /// (A single grid corner does not: adjacent faces share corners.)
-    private func faceSignature(_ g: TopologyGraph, _ i: Int,
+    private func faceSignature(_ g: BRepGraph, _ i: Int,
                                shift: SIMD3<Double> = .zero) -> String? {
         guard let s = g.sampleFaceUVGrid(faceIndex: i, uSamples: 3, vSamples: 3),
               !s.positions.isEmpty, !s.normals.isEmpty else { return nil }
@@ -2413,7 +2413,7 @@ struct TopologyGraphDurableUIDTests {
     /// the GraphGUID into the target. Guards the #295 provenance check against over-rejecting.
     @Test func uidSurvivesAFullCopyAndNamesTheSameFace() {
         guard let box = Shape.box(width: 10, height: 20, depth: 30),
-              let graph = TopologyGraph(shape: box),
+              let graph = BRepGraph(shape: box),
               let copy = graph.copy() else { return }
         #expect(copy.instanceID == graph.instanceID)   // a copy is the same identity
         #expect(copy.faceCount == graph.faceCount)
@@ -2436,7 +2436,7 @@ struct TopologyGraphDurableUIDTests {
     @Test func uidSurvivesATranslationAndNamesTheSameFace() {
         let d = SIMD3<Double>(100, 200, 300)
         guard let box = Shape.box(width: 10, height: 20, depth: 30),
-              let graph = TopologyGraph(shape: box),
+              let graph = BRepGraph(shape: box),
               let moved = graph.translated(dx: d.x, dy: d.y, dz: d.z) else { return }
         #expect(moved.instanceID == graph.instanceID)
         for i in 0..<graph.faceCount {
@@ -2454,7 +2454,7 @@ struct TopologyGraphDurableUIDTests {
     /// face. The extracted graph gets a fresh identity, so it now returns nil.
     @Test func uidDoesNotCrossACopiedOutFace() {
         guard let box = Shape.box(width: 10, height: 20, depth: 30),
-              let graph = TopologyGraph(shape: box),
+              let graph = BRepGraph(shape: box),
               let lifted = graph.copyFace(3) else { return }
         #expect(lifted.instanceID != graph.instanceID)
         #expect(lifted.faceCount == 1)
@@ -2472,14 +2472,14 @@ struct TopologyGraphDurableUIDTests {
     /// tests the counter path rather than being rejected on provenance first.
     @Test func outOfRangeCounterDoesNotResolve() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        guard let graph = TopologyGraph(shape: box) else { return }
+        guard let graph = BRepGraph(shape: box) else { return }
 
-        let bogus = TopologyGraph.GraphUID(kind: faceKind, counter: 999_999, graphID: graph.instanceID)
+        let bogus = BRepGraph.GraphUID(kind: faceKind, counter: 999_999, graphID: graph.instanceID)
         #expect(!graph.contains(uid: bogus))
         #expect(graph.node(forUID: bogus) == nil)
 
         // The invalid sentinel (counter 0) is never valid.
-        let invalid = TopologyGraph.GraphUID(kind: faceKind, counter: 0, graphID: graph.instanceID)
+        let invalid = BRepGraph.GraphUID(kind: faceKind, counter: 0, graphID: graph.instanceID)
         #expect(!invalid.isValid)
         #expect(!graph.contains(uid: invalid))
     }
@@ -2488,10 +2488,10 @@ struct TopologyGraphDurableUIDTests {
     /// even when its counter names a real node in the graph asked.
     @Test func unstampedUIDResolvesNowhere() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        guard let graph = TopologyGraph(shape: box) else { return }
+        guard let graph = BRepGraph(shape: box) else { return }
         guard let real = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
 
-        let unstamped = TopologyGraph.GraphUID(kind: real.kind, counter: real.counter, graphID: 0)
+        let unstamped = BRepGraph.GraphUID(kind: real.kind, counter: real.counter, graphID: 0)
         #expect(unstamped.isValid)              // the counter is a real one...
         #expect(graph.node(forUID: unstamped) == nil)   // ...but it names no graph
         #expect(!graph.contains(uid: unstamped))
@@ -2501,7 +2501,7 @@ struct TopologyGraphDurableUIDTests {
     /// graph that minted it. Guards against the #295 provenance check over-rejecting.
     @Test func uidSurvivesCompactionOfItsOwnGraph() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box),
+              let graph = BRepGraph(shape: box),
               let uid = graph.uid(ofNodeKind: faceKind, index: 3) else { return }
         let idBefore = graph.instanceID
         graph.compact()
@@ -2514,17 +2514,17 @@ struct TopologyGraphDurableUIDTests {
     /// as an unstamped UID rather than a decode failure.
     @Test func uidCodableCarriesProvenance() throws {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box),
+              let graph = BRepGraph(shape: box),
               let uid = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
 
-        let round = try JSONDecoder().decode(TopologyGraph.GraphUID.self,
+        let round = try JSONDecoder().decode(BRepGraph.GraphUID.self,
                                              from: try JSONEncoder().encode(uid))
         #expect(round == uid)
         #expect(round.graphID == graph.instanceID)
         #expect(graph.node(forUID: round) != nil)
 
         let legacy = Data(#"{"kind":2,"counter":1}"#.utf8)
-        let decoded = try JSONDecoder().decode(TopologyGraph.GraphUID.self, from: legacy)
+        let decoded = try JSONDecoder().decode(BRepGraph.GraphUID.self, from: legacy)
         #expect(decoded.graphID == 0)
         #expect(graph.node(forUID: decoded) == nil)
     }
@@ -2534,8 +2534,8 @@ struct TopologyGraphDurableUIDTests {
     @Test func refAndItemUIDsDoNotCrossGraphs() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let cyl = Shape.cylinder(radius: 3, height: 7),
-              let boxGraph = TopologyGraph(shape: box),
-              let cylGraph = TopologyGraph(shape: cyl) else { return }
+              let boxGraph = BRepGraph(shape: box),
+              let cylGraph = BRepGraph(shape: cyl) else { return }
 
         // Ref kind 1 == Face reference entry.
         if let refUID = boxGraph.uid(ofRefKind: 1, index: 0) {
@@ -2559,11 +2559,11 @@ struct TopologyGraphDurableUIDTests {
     @available(*, deprecated, message: "Exercises the deprecated `generation` on purpose.")
     @Test func generationIsAlwaysOne() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else { return }
+              let graph = BRepGraph(shape: box) else { return }
         #expect(graph.generation == 1)          // Clear()-at-build stamps generation 1 (#303)
         graph.compact()
         #expect(graph.generation == 1)          // compaction preserves identity
-        if let other = TopologyGraph(shape: box) {
+        if let other = BRepGraph(shape: box) {
             #expect(other.generation == 1)      // a second graph: same 1, hence useless as identity
             #expect(other.instanceID != graph.instanceID)
         }
@@ -2575,7 +2575,7 @@ struct TopologyGraphDurableUIDTests {
 
     @Test func itemUIDOfNode() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        guard let graph = TopologyGraph(shape: box) else { return }
+        guard let graph = BRepGraph(shape: box) else { return }
         guard graph.faceCount > 0 else { return }
 
         if let item = graph.itemUID(ofNodeKind: faceKind, index: 0) {
@@ -2598,12 +2598,12 @@ struct TopologyGraphDurableUIDTests {
 // (BRepGraph_LayerTopoSupplement): a freshly built (clean) box graph has none until one is
 // attached via faceAddVertex / edgeAddInternalVertex. The returned value is a layer-local
 // attachment uid (not a core ref index); removal is by that uid.
-@Suite("TopologyGraph Supplement Vertices")
-struct TopologyGraphSupplementVertexTests {
+@Suite("BRepGraph Supplement Vertices")
+struct BRepGraphSupplementVertexTests {
     @Test func faceDirectVertexAttachCountRemove() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         guard let box else { Issue.record("box build failed"); return }
-        let graph = TopologyGraph(shape: box)
+        let graph = BRepGraph(shape: box)
         guard let graph else { Issue.record("graph build failed"); return }
 
         // Clean box: no face-direct vertices until we add one.
@@ -2628,7 +2628,7 @@ struct TopologyGraphSupplementVertexTests {
     @Test func edgeInternalVertexAttach() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         guard let box else { Issue.record("box build failed"); return }
-        let graph = TopologyGraph(shape: box)
+        let graph = BRepGraph(shape: box)
         guard let graph else { Issue.record("graph build failed"); return }
 
         // Attaching an edge-internal vertex returns a non-nil layer-local uid.
@@ -2642,7 +2642,7 @@ struct TopologyGraphSupplementVertexTests {
     @Test func boxFacesNotNaturalRestriction() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         guard let box else { Issue.record("box build failed"); return }
-        let graph = TopologyGraph(shape: box)
+        let graph = BRepGraph(shape: box)
         guard let graph else { Issue.record("graph build failed"); return }
         for i in 0..<graph.faceCount {
             #expect(graph.isFaceNaturalRestriction(i) == false)

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -3700,7 +3700,7 @@ struct EditorViewV162Tests {
     func coedgeGeometricSetters() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.coedgeCount > 0, graph.edgeCount > 0, graph.faceCount > 1 {
                 graph.setCoEdgeUVBox(0, u1: 0, v1: 0, u2: 1, v2: 1)
                 // OCCT 8.0.0 GA replaced per-coedge SetContinuity / SetSeamContinuity /
@@ -3716,9 +3716,9 @@ struct EditorViewV162Tests {
     func identityLocationSetters() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
-                let m = TopologyGraph.identityLocationMatrix
+                let m = BRepGraph.identityLocationMatrix
                 #expect(m.count == 12)
                 if graph.faceRefCount > 0 { graph.setFaceRefLocalLocation(0, matrix: m) }
                 if graph.shellRefCount > 0 { graph.setShellRefLocalLocation(0, matrix: m) }
@@ -3739,7 +3739,7 @@ struct EditorViewV162Tests {
         }
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.faceCount > 0 {
                 guard let triRepId = graph.createTriangulationRep(tri) else {
                     Issue.record("createTriangulationRep nil"); return
@@ -3867,7 +3867,7 @@ struct SketchArcCircleTests {
     @Test("buildProfile with arc yields a wire")
     func buildProfileWithArc() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else { Issue.record("graph nil"); return }
+              let graph = BRepGraph(shape: box) else { Issue.record("graph nil"); return }
         let ctx = ConstructionContext()
         let planeID = ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
         var sketch = Sketch(hostPlane: planeID)

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -1209,7 +1209,7 @@ struct EditorViewV164Tests {
     func cachedFaceMeshInspectionOnFreshGraph() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.faceCount > 0 {
                 #expect(graph.cachedFaceMeshIsPresent(0) == false)
                 #expect(graph.cachedFaceMeshTriRepCount(0) == 0)
@@ -1227,7 +1227,7 @@ struct EditorViewV164Tests {
         }
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.faceCount > 0,
                let triRepId = graph.createTriangulationRep(tri) {
                 graph.appendCachedTriangulation(faceIndex: 0, triRepId: triRepId)
@@ -1244,7 +1244,7 @@ struct EditorViewV164Tests {
     func cachedEdgeCoEdgeAbsent() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.cachedEdgeMeshIsPresent(0) == false)
                 #expect(graph.cachedEdgeMeshPolygon3DRepId(0) == nil)
@@ -1262,7 +1262,7 @@ struct EditorViewProductOpsTests {
     func createAndLinkProducts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // Empty product: an assembly node, no direct topology.
                 guard let parentProduct = graph.createEmptyProduct() else {
@@ -1274,7 +1274,7 @@ struct EditorViewProductOpsTests {
                 guard let childProduct = graph.linkProductToTopology(
                     shapeRootKind: 0,        // Solid
                     shapeRootIndex: 0,
-                    placement: TopologyGraph.identityLocationMatrix) else {
+                    placement: BRepGraph.identityLocationMatrix) else {
                     Issue.record("linkProductToTopology nil"); return
                 }
                 #expect(childProduct >= 0)
@@ -1284,7 +1284,7 @@ struct EditorViewProductOpsTests {
                 if let linked = graph.linkProducts(
                     parentProductIndex: parentProduct,
                     referencedProductIndex: childProduct,
-                    placement: TopologyGraph.identityLocationMatrix) {
+                    placement: BRepGraph.identityLocationMatrix) {
                     #expect(linked.occurrenceIndex >= 0)
                     #expect(linked.occurrenceRefIndex >= 0)
                 }
@@ -1296,7 +1296,7 @@ struct EditorViewProductOpsTests {
     func removeOpsSafe() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.productRemoveOccurrence(99999, occurrenceRefIndex: 99999) == false)
                 #expect(graph.productRemoveShapeRoot(99999) == false)
@@ -1311,7 +1311,7 @@ struct EditorViewAddRemoveTests {
     func addOpsSafe() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // These return nil on invalid topology (a closed box already wires its own
                 // structure), but the bridge must not crash.
@@ -1329,7 +1329,7 @@ struct EditorViewAddRemoveTests {
     func removeOpsSafe() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 #expect(graph.edgeRemoveVertex(0, vertexRefIndex: 99999) == false)
                 #expect(graph.edgeReplaceVertex(0, oldVertexRefIndex: 99999, newVertexIndex: 0) == nil)
@@ -1352,7 +1352,7 @@ struct EditorViewAddRemoveTests {
         // Box has 12 edges, 8 vertices, 6 faces, 6 wires, 1 shell, 1 solid; ids 0..N-1 are valid.
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.edgeCount > 0, graph.faceCount > 0, graph.shellCount > 0, graph.solidCount > 0 {
                 graph.setEdgeCurve3DRepId(0, curve3DRepId: 0)
                 graph.setEdgePolygon3DRepId(0, polygon3DRepId: 0)
@@ -1376,7 +1376,7 @@ struct EditorViewSettersTests {
     func vertexFieldSetters() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.vertexCount > 0 {
                 graph.setVertexPoint(0, x: 1.5, y: 2.5, z: 3.5)
                 let p = graph.vertexPoint(0)
@@ -1394,7 +1394,7 @@ struct EditorViewSettersTests {
     func edgeFieldSetters() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.edgeCount > 0 {
                 graph.setEdgeTolerance(0, tolerance: 0.001)
                 #expect(abs(graph.edgeTolerance(0) - 0.001) < 1e-12)
@@ -1427,7 +1427,7 @@ struct EditorViewSettersTests {
     func faceFieldSetters() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph, graph.faceCount > 0 {
                 graph.setFaceTolerance(0, tolerance: 0.005)
                 #expect(abs(graph.faceTolerance(0) - 0.005) < 1e-12)
@@ -1442,7 +1442,7 @@ struct EditorViewSettersTests {
     func auxiliarySetters() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // The box has wires/shells; coedges are derived per-face. Setters are no-ops on
                 // invalid ids (try/catch in bridge) so the calls below are always safe.

--- a/Tests/OCCTMeshTests/OCCTMeshTests.swift
+++ b/Tests/OCCTMeshTests/OCCTMeshTests.swift
@@ -871,7 +871,7 @@ struct MeshCacheWriteTests {
         }
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 guard let repId = graph.createTriangulationRep(tri) else {
                     Issue.record("createTriangulationRep nil"); return
@@ -895,7 +895,7 @@ struct MeshCacheWriteTests {
         }
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 guard let repId = graph.createPolygon3DRep(poly) else {
                     Issue.record("createPolygon3DRep nil"); return
@@ -915,7 +915,7 @@ struct MeshViewCountsTests {
     func meshCountsZeroOnFreshGraph() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // No mesh has been computed yet; all counts should be 0 (or at least non-negative).
                 #expect(graph.polygon2DCount >= 0)
@@ -937,7 +937,7 @@ struct MeshViewCountsTests {
     func meshRepIdsAbsentBeforeMeshing() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let box {
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // No incremental mesh has run; cache and persistent tiers are empty.
                 #expect(graph.meshFaceActiveTriangulationRepId(0) == nil)
@@ -953,7 +953,7 @@ struct MeshViewCountsTests {
         if let box {
             // Generate triangulation via incremental mesher.
             _ = box.mesh(linearDeflection: 0.5, angularDeflection: 0.5)
-            let graph = TopologyGraph(shape: box)
+            let graph = BRepGraph(shape: box)
             if let graph {
                 // After meshing, persistent triangulation tier should report nonzero.
                 #expect(graph.triangulationCount + graph.polygon3DCount >= 0)

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -78,7 +78,7 @@ struct ConstructionContextTests {
     @Test("Resolve entities against a graph")
     func resolveAgainstGraph() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let ctx = ConstructionContext()
@@ -93,7 +93,7 @@ struct ConstructionContextTests {
     @Test("allBroken detects unregistered references")
     func allBrokenDetection() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let ctx = ConstructionContext()
@@ -136,7 +136,7 @@ struct SketchBuildProfileTests {
     @Test("Profile excludes construction elements")
     func excludesConstruction() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let ctx = ConstructionContext()
@@ -158,7 +158,7 @@ struct SketchBuildProfileTests {
     @Test("buildProfile returns nil if no profile elements present")
     func emptyProfileNil() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let ctx = ConstructionContext()
@@ -172,7 +172,7 @@ struct SketchBuildProfileTests {
     @Test("buildProfile returns nil when host plane is unresolvable")
     func brokenHostPlane() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let ctx = ConstructionContext()
@@ -244,7 +244,7 @@ struct AngleHelperTests {
     @Test("ConstructionAxis angle between resolved axes")
     func constructionAxisAngle() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let xAxis = ConstructionAxis.absolute(origin: .zero, direction: SIMD3(1, 0, 0))
@@ -257,7 +257,7 @@ struct AngleHelperTests {
     @Test("ConstructionPlane angle between normals")
     func constructionPlaneAngle() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         let xy = ConstructionPlane.absolute(origin: .zero, normal: SIMD3(0, 0, 1))
@@ -275,16 +275,16 @@ struct MultiLeafCreatedByTests {
     @Test("leafOccurrence picks among split descendants")
     func leafOccurrencePicksNth() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
 
         // Create → op1, then split into two leaves via op2.
-        let seed = TopologyGraph.NodeRef(kind: .face, index: 1)
-        let leaf1 = TopologyGraph.NodeRef(kind: .face, index: 11)
-        let leaf2 = TopologyGraph.NodeRef(kind: .face, index: 22)
+        let seed = BRepGraph.NodeRef(kind: .face, index: 1)
+        let leaf1 = BRepGraph.NodeRef(kind: .face, index: 11)
+        let leaf2 = BRepGraph.NodeRef(kind: .face, index: 22)
         graph.recordHistory(operationName: "Op1", original: .sentinel, replacements: [seed])
         graph.recordHistory(operationName: "Op2", original: seed, replacements: [leaf1, leaf2])
 
@@ -303,14 +303,14 @@ struct MultiLeafCreatedByTests {
     @Test("currentForms returns both leaves of a split")
     func currentFormsReturnsAll() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
-        let seed = TopologyGraph.NodeRef(kind: .edge, index: 3)
-        let a = TopologyGraph.NodeRef(kind: .edge, index: 30)
-        let b = TopologyGraph.NodeRef(kind: .edge, index: 31)
+        let seed = BRepGraph.NodeRef(kind: .edge, index: 3)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 30)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 31)
         graph.recordHistory(operationName: "Split", original: seed, replacements: [a, b])
         let leaves = Set(graph.currentForms(of: seed))
         #expect(leaves.isSuperset(of: [a, b]))
@@ -319,13 +319,13 @@ struct MultiLeafCreatedByTests {
     @Test("leafOccurrence: nil returns seed without forward-walk")
     func leafOccurrenceNil() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
         graph.isHistoryEnabled = true
         graph.clearHistory()
-        let seed = TopologyGraph.NodeRef(kind: .face, index: 1)
-        let leaf = TopologyGraph.NodeRef(kind: .face, index: 11)
+        let seed = BRepGraph.NodeRef(kind: .face, index: 1)
+        let leaf = BRepGraph.NodeRef(kind: .face, index: 11)
         graph.recordHistory(operationName: "Op", original: .sentinel, replacements: [seed])
         graph.recordHistory(operationName: "Mod", original: seed, replacements: [leaf])
         let result = graph.resolve(.createdBy(operationName: "Op", kind: .face, leafOccurrence: nil))
@@ -356,7 +356,7 @@ struct ConstructionLayerTests {
     func materializeAll() {
         guard let doc = Document.create(),
               let box = Shape.box(width: 10, height: 10, depth: 10),
-              let graph = TopologyGraph(shape: box) else {
+              let graph = BRepGraph(shape: box) else {
             Issue.record("setup nil"); return
         }
         let ctx = doc.constructionContext

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -6429,11 +6429,11 @@ struct SewQuiltHealFullHistoryTests {
         #expect(r1.isDeleted == r2.isDeleted)
     }
 
-    @Test("A sew's history can be absorbed into a TopologyGraph (issue #290 integration)")
+    @Test("A sew's history can be absorbed into a BRepGraph (issue #290 integration)")
     func sewHistoryAbsorbsIntoGraph() {
         let (face1, face2) = Self.touchingFaces()
         guard let compound = Shape.compound([face1, face2]),
-              let graph = TopologyGraph(shape: compound),
+              let graph = BRepGraph(shape: compound),
               let root = graph.findNode(for: compound) else {
             Issue.record("graph setup failed")
             return
@@ -6444,7 +6444,7 @@ struct SewQuiltHealFullHistoryTests {
         }
         #expect(graph.historyRecordCount == 0)
         let added = graph.add(r.result, absorbing: r.history,
-                              inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+                              inputRoots: [BRepGraph.NodeRef(kind: root.kind, index: root.index)],
                               operationName: "sew")
         #expect(added != nil, "add(absorbing:) should succeed for a sew's synthesized history")
         #expect(graph.historyRecordCount > 0, "absorb should have written history records")
@@ -6551,10 +6551,10 @@ struct TransformPatternFullHistoryTests {
         }
     }
 
-    @Test("A translate's history can be absorbed into a TopologyGraph (issue #290 integration)")
+    @Test("A translate's history can be absorbed into a BRepGraph (issue #290 integration)")
     func translateHistoryAbsorbsIntoGraph() {
         let box = Shape.box(width: 10, height: 10, depth: 10)!
-        guard let graph = TopologyGraph(shape: box),
+        guard let graph = BRepGraph(shape: box),
               let root = graph.findNode(for: box) else {
             Issue.record("graph setup failed")
             return
@@ -6565,7 +6565,7 @@ struct TransformPatternFullHistoryTests {
         }
         #expect(graph.historyRecordCount == 0)
         let added = graph.add(r.result, absorbing: r.history,
-                              inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+                              inputRoots: [BRepGraph.NodeRef(kind: root.kind, index: root.index)],
                               operationName: "translate")
         #expect(added != nil, "add(absorbing:) should succeed for a translate's synthesized history")
         #expect(graph.historyRecordCount > 0, "absorb should have written history records")
@@ -6585,10 +6585,10 @@ struct TransformPatternFullHistoryTests {
         #expect(r == nil)
     }
 
-    @Test("A linear pattern's history can be absorbed into a TopologyGraph (issue #290 integration)")
+    @Test("A linear pattern's history can be absorbed into a BRepGraph (issue #290 integration)")
     func linearPatternHistoryAbsorbsIntoGraph() {
         let hole = Shape.cylinder(radius: 3, height: 10)!
-        guard let graph = TopologyGraph(shape: hole),
+        guard let graph = BRepGraph(shape: hole),
               let root = graph.findNode(for: hole) else {
             Issue.record("graph setup failed")
             return
@@ -6599,7 +6599,7 @@ struct TransformPatternFullHistoryTests {
         }
         #expect(graph.historyRecordCount == 0)
         let added = graph.add(r.result, absorbing: r.history,
-                              inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+                              inputRoots: [BRepGraph.NodeRef(kind: root.kind, index: root.index)],
                               operationName: "linearPattern")
         #expect(added != nil, "add(absorbing:) should succeed for a pattern's synthesized history")
         #expect(graph.historyRecordCount > 0, "absorb should have written history records")

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -4255,19 +4255,19 @@ struct DocumentGDTTests {
     }
 }
 
-// MARK: - TopologyGraph attribute store + Codable snapshot (#168)
+// MARK: - BRepGraph attribute store + Codable snapshot (#168)
 
-@Suite("TopologyGraph Attributes")
-struct TopologyGraphAttributeTests {
+@Suite("BRepGraph Attributes")
+struct BRepGraphAttributeTests {
 
     /// Attach mixed attribute types to face/edge/vertex nodes and read them back.
     @Test func attachAndReadMixedAttributes() {
         guard let box = Shape.box(width: 10, height: 20, depth: 30),
-              let graph = TopologyGraph(shape: box) else { return }
+              let graph = BRepGraph(shape: box) else { return }
 
-        let faceNode = TopologyGraph.NodeRef(kind: .face, index: 0)
-        let edgeNode = TopologyGraph.NodeRef(kind: .edge, index: 0)
-        let vertexNode = TopologyGraph.NodeRef(kind: .vertex, index: 0)
+        let faceNode = BRepGraph.NodeRef(kind: .face, index: 0)
+        let edgeNode = BRepGraph.NodeRef(kind: .edge, index: 0)
+        let vertexNode = BRepGraph.NodeRef(kind: .vertex, index: 0)
 
         graph.setAttribute("residualRMS", .double(0.042), for: faceNode)
         graph.setAttribute("surfaceType", .string("plane"), for: faceNode)
@@ -4287,8 +4287,8 @@ struct TopologyGraphAttributeTests {
     /// Clearing the last attribute on a node drops the node entry entirely.
     @Test func clearingLastAttributeDropsNode() {
         guard let box = Shape.box(width: 5, height: 5, depth: 5),
-              let graph = TopologyGraph(shape: box) else { return }
-        let node = TopologyGraph.NodeRef(kind: .face, index: 1)
+              let graph = BRepGraph(shape: box) else { return }
+        let node = BRepGraph.NodeRef(kind: .face, index: 1)
         graph.setAttribute("a", .int(1), for: node)
         graph.setAttribute("b", .int(2), for: node)
         #expect(graph.attributes.annotatedNodeCount == 1)
@@ -4303,11 +4303,11 @@ struct TopologyGraphAttributeTests {
     /// on the correct node.
     @Test func snapshotJSONRoundTrip() throws {
         guard let box = Shape.box(width: 12, height: 8, depth: 4),
-              let graph = TopologyGraph(shape: box) else { return }
+              let graph = BRepGraph(shape: box) else { return }
 
-        let f0 = TopologyGraph.NodeRef(kind: .face, index: 0)
-        let f3 = TopologyGraph.NodeRef(kind: .face, index: 3)
-        let v2 = TopologyGraph.NodeRef(kind: .vertex, index: 2)
+        let f0 = BRepGraph.NodeRef(kind: .face, index: 0)
+        let f3 = BRepGraph.NodeRef(kind: .face, index: 3)
+        let v2 = BRepGraph.NodeRef(kind: .vertex, index: 2)
         graph.setAttribute("residualRMS", .double(0.001), for: f0)
         graph.setAttribute("decision", .string("human"), for: f3)
         graph.setAttribute("mirror", .bool(true), for: f3)
@@ -4316,7 +4316,7 @@ struct TopologyGraphAttributeTests {
         let snap = try graph.snapshot()
         let data = try JSONEncoder().encode(snap)
         let decoded = try JSONDecoder().decode(GraphSnapshot.self, from: data)
-        let restored = try TopologyGraph(snapshot: decoded)
+        let restored = try BRepGraph(snapshot: decoded)
 
         #expect(restored.faceCount == graph.faceCount)
         #expect(restored.vertexCount == graph.vertexCount)
@@ -4331,9 +4331,9 @@ struct TopologyGraphAttributeTests {
     /// the contract for diffable, versionable snapshots.
     @Test func encodingIsDeterministic() throws {
         guard let box = Shape.box(width: 3, height: 3, depth: 3),
-              let graph = TopologyGraph(shape: box) else { return }
+              let graph = BRepGraph(shape: box) else { return }
         for i in 0..<graph.faceCount {
-            graph.setAttribute("idx", .int(i), for: TopologyGraph.NodeRef(kind: .face, index: i))
+            graph.setAttribute("idx", .int(i), for: BRepGraph.NodeRef(kind: .face, index: i))
         }
         let encoder = GraphSnapshot.canonicalEncoder()
         let a = try encoder.encode(graph.attributes)
@@ -4345,10 +4345,10 @@ struct TopologyGraphAttributeTests {
     /// snapshot round-trip relies on. Verify a node index resolves to the same geometry.
     @Test func nodeIndexingDeterministicAcrossRebuild() {
         guard let box = Shape.box(width: 10, height: 20, depth: 30),
-              let g1 = TopologyGraph(shape: box),
+              let g1 = BRepGraph(shape: box),
               let brep = box.toBREPString(),
               let box2 = Shape.fromBREPString(brep),
-              let g2 = TopologyGraph(shape: box2) else { return }
+              let g2 = BRepGraph(shape: box2) else { return }
 
         #expect(g1.faceCount == g2.faceCount)
         #expect(g1.edgeCount == g2.edgeCount)
@@ -4371,7 +4371,7 @@ struct TopologyGraphAttributeTests {
         let future = GraphSnapshot(brep: brep, attributes: NodeAttributeStore(),
                                    formatVersion: GraphSnapshot.currentFormatVersion + 1)
         #expect(throws: GraphSnapshotError.self) {
-            _ = try TopologyGraph(snapshot: future)
+            _ = try BRepGraph(snapshot: future)
         }
     }
 
@@ -4379,7 +4379,7 @@ struct TopologyGraphAttributeTests {
     @Test func invalidBREPThrows() {
         let bad = GraphSnapshot(brep: "not a brep", attributes: NodeAttributeStore())
         #expect(throws: GraphSnapshotError.self) {
-            _ = try TopologyGraph(snapshot: bad)
+            _ = try BRepGraph(snapshot: bad)
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,33 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.14.0
+## Current: v1.15.0
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #323 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.0 (July 2026) — `TopologyGraph` renamed to `BRepGraph` (closes #333)
+
+**MINOR — additive; old name still works.** `TopologyGraph` read as too close to OCCT's own `TopoDS_*`
+family (`TopoDS_Shape`, `TopoDS_Face`, ...) on a skim, without signaling that it specifically wraps the
+BRepGraph durable-identity engine. Renamed to `BRepGraph`, matching both the C++ package it wraps and
+this file's own name (`BRepGraph.swift`).
+
+```swift
+@available(*, deprecated, renamed: "BRepGraph")
+public typealias TopologyGraph = BRepGraph
+```
+
+Existing code compiles unchanged (with a deprecation warning) under the old name. New code should use
+`BRepGraph`. The typealias stays until a later release drops it per the usual deprecation policy — no
+removal date set yet.
+
+Docs move alongside the rename: `docs/reference/TopologyGraph*.md` → `BRepGraph*.md`,
+`docs/guides/cookbook/topology-graph*.md` → `brep-graph*.md`. The `Tests/OCCTTopologyGraphTests` target
+is renamed to `Tests/OCCTBRepGraphTests` (internal only, no consumer-visible effect).
 
 ### v1.14.0 (July 2026) — feat: `*WithFullHistory` parity for translate/rotate/scale/mirror/patterns (#331)
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -37,7 +37,7 @@ A minor bump is for additive change. Two routes:
 
 1. **xcframework rebuild against a new OCCT minor / patch / RC.** OCCT ships a stability patch, a bug-fix release, an RC, or a beta — we rebuild the xcframework, the binary URL+checksum in `Package.swift` updates, consumers re-download. This is treated as MINOR because the binary swap is a meaningful "new functionality" event even when the Swift API surface is identical.
 
-2. **Additive new public Swift API.** A new `Shape.foo()` method, a new `Wire.bar` static factory, a new `TopologyGraph.baz` field, a new `FeatureSpec` case — anything that adds to the surface without removing or changing what's there. Existing callers are unaffected; new callers can opt in.
+2. **Additive new public Swift API.** A new `Shape.foo()` method, a new `Wire.bar` static factory, a new `BRepGraph.baz` field, a new `FeatureSpec` case — anything that adds to the surface without removing or changing what's there. Existing callers are unaffected; new callers can opt in.
 
 Either case bumps minor. A release that does both (e.g. rebuilds against new OCCT *and* adds a new wrapped operation that the rebuild made available) is one minor bump, not two.
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -57,7 +57,7 @@ This page exists so you don't have to guess which dep to add.
 │  ┌─────────────────────────────────────────────────────────────────┐   │
 │  │ OCCTSwift                                                       │   │
 │  │ Swift wrapper for OCCT — shapes, curves, surfaces, OCAF,        │   │
-│  │ TopologyGraph, drawing/projection, ML-friendly samplers.        │   │
+│  │ BRepGraph, drawing/projection, ML-friendly samplers.            │   │
 │  │ Bundles a pre-built OCCT 8.0.0 GA xcframework (arm64,           │   │
 │  │ macOS / iOS / visionOS / tvOS).                                 │   │
 │  └─────────────────────────────────────────────────────────────────┘   │
@@ -91,7 +91,7 @@ You want the full visualization stack:
 You want **OCCTSwiftScripts**. It ships:
 
 - `occtkit` — a CLI binary with verbs like `compose`, `reconstruct`, `drawing-export`, `metrics`, `simplify-mesh`, `render-preview`, `xcaf`. Ready to drive from a Makefile or a server-side parametric pipeline.
-- `ScriptHarness` library — JSON-driven manifest format you can embed in your own tools, with topology-graph descriptors for downstream watchers.
+- `ScriptHarness` library — JSON-driven manifest format you can embed in your own tools, with brep-graph descriptors for downstream watchers.
 
 Scripts depends on the full ecosystem (kernel + IO + Mesh + Tools + AIS + Viewport for `render-preview`). If your use case is purely batch and you don't need preview rendering, depend on the lower-tier packages directly instead.
 
@@ -105,7 +105,7 @@ If you can't depend on Swift (e.g. you're writing a C plugin for a host applicat
 
 ### Engineering-drawing ML pipelines
 
-`OCCTSwift` itself ships `TopologyGraph` for graph-based topology representation, plus UV-grid samplers and curve samplers for ML feature extraction. Combined with `OCCTSwiftIO.exportForML()` (extension on `TopologyGraph` lifted from the kernel in v0.171.0), you can produce flat / COO-format adjacency tensors for GNN / UV-Net / BRepNet pipelines.
+`OCCTSwift` itself ships `BRepGraph` for graph-based topology representation, plus UV-grid samplers and curve samplers for ML feature extraction. Combined with `OCCTSwiftIO.exportForML()` (extension on `BRepGraph` lifted from the kernel in v0.171.0), you can produce flat / COO-format adjacency tensors for GNN / UV-Net / BRepNet pipelines.
 
 For trained model artifacts and CoreML wrappers:
 
@@ -130,7 +130,7 @@ All public packages graduated to **SemVer-stable v1.0.0** alongside OCCTSwift v1
 
 ## Notable v1.0.x patches
 
-- **OCCTSwift v1.0.1** — `TopologyGraph.NodeKind` extended to cover `Product` / `Occurrence` raw values; without this, `rootNodes` silently returned `[]` for any graph with assembly roots.
+- **OCCTSwift v1.0.1** — `BRepGraph.NodeKind` extended to cover `Product` / `Occurrence` raw values; without this, `rootNodes` silently returned `[]` for any graph with assembly roots.
 - **OCCTSwift v1.0.2** — per-input boolean history surface (`unionWithFullHistory` / `subtractedWithFullHistory` / `intersectionWithFullHistory` / `splitWithFullHistory`), used by selection-remapping consumers (e.g. OCCTMCP's `remap_selection`) to walk selection IDs across boolean / split mutations exactly instead of falling back to a centroid-distance heuristic.
 - **OCCTSwift v1.0.3** — extends per-input history to modification ops (`filletedWithFullHistory` / `chamferedWithFullHistory` / `shelledWithFullHistory` / `defeaturedWithFullHistory`) and threads it through `FeatureReconstructor.BuildResult.histories[featureID]`. Closes the long-running #165 selection-survival epic.
 - **OCCTSwift v1.0.4** — wires `applyFillet` / `applyChamfer` through the Tier 2 history variants and implements chamfer's `.nearPoint` / `.onFeature` selectors that were stubbed before. After this, every `FeatureSpec` kind (boolean / hole / additive / fillet / chamfer) populates `BuildResult.histories[id]` for specs with non-nil ids — closes #166.
@@ -138,8 +138,8 @@ All public packages graduated to **SemVer-stable v1.0.0** alongside OCCTSwift v1
 - **OCCTSwiftViewport v1.0.3** — fixes an **uncatchable** crash (`fatalError`, not a thrown error) on body load: `NormalSmoothing.quantize(_:)` overflowed `Int32` for any mesh vertex beyond ±21,474.8 model units (or `NaN`/`±inf`). Now clamps non-finite/out-of-range coords before the trapping conversion. Closes Viewport [#30](https://github.com/gsdali/OCCTSwiftViewport/issues/30).
 - **OCCTSwiftViewport v1.0.4** — packaging fix: the demo target's dependency on `OCCTSwiftTools` (which depends back on Viewport) formed a package cycle that broke standalone `swift build`. The demo moved to `Examples/MetalDemo`; **the published Viewport package now has zero external dependencies** (its library never used the kernel or Tools). No library API change — fully compatible with v1.0.3. Closes Viewport [#32](https://github.com/gsdali/OCCTSwiftViewport/pull/32).
 - **OCCTSwiftTools v1.1.0** — first MINOR bump under the [cohort SemVer policy](SEMVER.md). `PointConverter.pointsToBody` now wires `pointRadius` and `perPointColors` through to the new `ViewportBody` fields and stamps `primitiveKind = .point`. Companion follow-up to Viewport v1.0.2.
-- **OCCTSwift v1.1.0** — `TopologyGraph.findDerivedOrSelf(of:)` and `hasHistoryRecord(for:)` disambiguate untouched-vs-deleted nodes that both returned `[]` from `findDerived` (closes #167). Direct unblocker for OCCTMCP `remap_selection`'s history path.
-- **OCCTSwift v1.2.0** — `TopologyGraph` per-node attribute store (`attributes` / `AttrValue` / `NodeAttributeStore`) + Codable `GraphSnapshot` round-trip (closes #168). Pure Swift sidecar, no bridge change; nodes can now carry arbitrary typed metadata (fit residual, provenance, mesh-region sets) and a session serializes deterministically. Foundation for the OCCTReconstruct mesh-to-solid pipeline and OCCTMCP's planned `reconstruct_*` graph read/write tools ([OCCTMCP #33](https://github.com/gsdali/OCCTMCP/issues/33)).
+- **OCCTSwift v1.1.0** — `BRepGraph.findDerivedOrSelf(of:)` and `hasHistoryRecord(for:)` disambiguate untouched-vs-deleted nodes that both returned `[]` from `findDerived` (closes #167). Direct unblocker for OCCTMCP `remap_selection`'s history path.
+- **OCCTSwift v1.2.0** — `BRepGraph` per-node attribute store (`attributes` / `AttrValue` / `NodeAttributeStore`) + Codable `GraphSnapshot` round-trip (closes #168). Pure Swift sidecar, no bridge change; nodes can now carry arbitrary typed metadata (fit residual, provenance, mesh-region sets) and a session serializes deterministically. Foundation for the OCCTReconstruct mesh-to-solid pipeline and OCCTMCP's planned `reconstruct_*` graph read/write tools ([OCCTMCP #33](https://github.com/gsdali/OCCTMCP/issues/33)).
 - **OCCTSwiftTools v1.0.1** — `PointConverter.pointsToBody(_:)` for rendering point clouds without sphere-compound triangulation. Renderer-side support for drawing the points as visible primitives is tracked at [OCCTSwiftViewport#28](https://github.com/gsdali/OCCTSwiftViewport/issues/28).
 - **OCCTMCP v1.2.0** — full `apply_feature` history surface (consumes OCCTSwift v1.0.4's per-input histories) plus visible point clouds end-to-end (Viewport v1.0.2 + Tools v1.1.0).
 - **OCCTMCP v1.3.0** — `find_correspondences` tool (closes OCCTMCP #24) for matching topology across model variants, with a history-path fix.

--- a/docs/guides/cookbook/brep-graph-uids.md
+++ b/docs/guides/cookbook/brep-graph-uids.md
@@ -1,20 +1,20 @@
 ---
 title: "BREP Graph: Durable Identity & UIDs"
-parent: Topology Graph
+parent: BRep Graph
 grand_parent: Cookbook
 nav_order: 1
 ---
 
 # BREP Graph: Durable Identity & UIDs
 
-A `TopologyGraph` gives every node (solid, shell, face, wire, edge, vertex, and the reference and
+A `BRepGraph` gives every node (solid, shell, face, wire, edge, vertex, and the reference and
 product entries around them) an identity that survives mutation of that graph. This page is about how
 that identity works: the three UID flavours, how they are minted and resolved, and the one rule that
 trips people up most, which is that a **UID belongs to the exact graph instance that minted it** and
 resolves nowhere else.
 
 For general graph queries (counts, adjacency, shared edges) and a lighter tour of identity, start with
-[Topology Graph](topology-graph.md). This page goes deep on the identity model.
+[BRep Graph](brep-graph.md). This page goes deep on the identity model.
 
 ## Why indices are not enough
 
@@ -24,9 +24,9 @@ different face tomorrow.
 
 ```swift
 let box = Shape.box(width: 10, height: 10, depth: 10)!
-let graph = TopologyGraph(shape: box)!
+let graph = BRepGraph(shape: box)!
 
-let faceKind = Int(TopologyGraph.NodeKind.face.rawValue)   // 2
+let faceKind = Int(BRepGraph.NodeKind.face.rawValue)   // 2
 let uid = graph.uid(ofNodeKind: faceKind, index: 3)!       // pin face 3 by identity
 
 graph.compact()                                            // vectors renumber
@@ -63,7 +63,7 @@ guard let uid = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
 
 // Resolve: durable UID  ->  (kind, index) as of now
 if let node = graph.node(forUID: uid) {
-    let ref = TopologyGraph.NodeRef(kind: TopologyGraph.NodeKind(rawValue: Int32(node.kind))!,
+    let ref = BRepGraph.NodeRef(kind: BRepGraph.NodeKind(rawValue: Int32(node.kind))!,
                                     index: node.index)
     // ... query with ref ...
 }
@@ -91,11 +91,11 @@ minting graph's `instanceID` in its `graphID` field, and the resolvers reject a 
 anywhere else.
 
 ```swift
-let boxGraph = TopologyGraph(shape: box)!
+let boxGraph = BRepGraph(shape: box)!
 let faceUID  = boxGraph.uid(ofNodeKind: faceKind, index: 0)!
 print(faceUID.graphID == boxGraph.instanceID)   // true: this graph minted it
 
-let cyl = TopologyGraph(shape: Shape.cylinder(radius: 3, height: 7)!)!
+let cyl = BRepGraph(shape: Shape.cylinder(radius: 3, height: 7)!)!
 print(cyl.node(forUID: faceUID))                // nil, not a wrong face
 print(cyl.contains(uid: faceUID))               // false
 ```
@@ -129,7 +129,7 @@ survive.
 | `copy(copyGeometry:)` | **inherited** | carry over; name the same nodes |
 | `translated(dx:dy:dz:copyGeometry:)` | **inherited** | carry over |
 | `copyFace(_:copyGeometry:)` | **new instance** | old UIDs resolve nowhere; mint fresh ones |
-| rebuild `TopologyGraph(shape:)` | **new instance** | old UIDs void |
+| rebuild `BRepGraph(shape:)` | **new instance** | old UIDs void |
 
 `copy()` and `translated()` inherit the identity because the kernel copies the graph wholesale: it
 transplants the UID counter space itself, so a copy genuinely *is* the same identity and every UID
@@ -171,7 +171,7 @@ let saved = (kind: faceKind, index: 3)
 let brep  = box.toBREPString()!
 
 // Load: rebuild the graph from the shape, then re-mint the UID.
-let reloaded = TopologyGraph(shape: Shape.fromBREPString(brep)!)!
+let reloaded = BRepGraph(shape: Shape.fromBREPString(brep)!)!
 let freshUID = reloaded.uid(ofNodeKind: saved.kind, index: saved.index)
 ```
 
@@ -196,13 +196,13 @@ The graph can absorb an operation's history so a selection re-resolves through i
 the operation's input, hand it the result and its history, then resolve the pinned node forward:
 
 ```swift
-let graph  = TopologyGraph(shape: base)!
+let graph  = BRepGraph(shape: base)!
 let root   = graph.findNode(for: base)!
 let pinned = /* the node you picked, as a NodeRef */
 
 let (result, history) = base.subtractedWithFullHistory(tool)!
 graph.add(result, absorbing: history,
-          inputRoots: [TopologyGraph.NodeRef(kind: root.kind, index: root.index)],
+          inputRoots: [BRepGraph.NodeRef(kind: root.kind, index: root.index)],
           operationName: "cut")
 
 graph.currentForms(of: pinned)      // what the pinned node became after the cut
@@ -210,7 +210,7 @@ graph.currentForms(of: pinned)      // what the pinned node became after the cut
 
 Because that path keeps everything inside one graph instance, the `NodeRef`s and UIDs you already hold
 stay valid: there is no second graph to look them up in. See
-[Topology Graph](topology-graph.md#tracking-nodes-through-operations-history) for the history API
+[BRep Graph](brep-graph.md#tracking-nodes-through-operations-history) for the history API
 (`add(_:absorbing:inputRoots:operationName:)`, `currentForms(of:)`, `recordHistory`,
 `findDerivedOrSelf`, `historyIsDeleted`), and issue
 [#290](https://github.com/SecondMouseAU/OCCTSwift/issues/290) for the design.
@@ -230,7 +230,7 @@ do not expect a UID to mean anything in a different graph.
 
 ## See also
 
-- [Topology Graph](topology-graph.md) for graph construction, queries, adjacency, and the history API.
+- [BRep Graph](brep-graph.md) for graph construction, queries, adjacency, and the history API.
 - [XCAF Assemblies](xcaf-assemblies.md) for identity *across* shapes (the product tree) rather than
   within one shape.
 - API mapping: [`../../API_REFERENCE.md`](../../API_REFERENCE.md).

--- a/docs/guides/cookbook/brep-graph.md
+++ b/docs/guides/cookbook/brep-graph.md
@@ -1,14 +1,14 @@
 ---
-title: Topology Graph
+title: BRep Graph
 parent: Cookbook
 nav_order: 9
 has_children: true
 ---
 
-# Topology Graph
+# BRep Graph
 
 A `Shape` is a B-Rep — a graph of solids, shells, faces, wires, edges and vertices wired together by
-incidence. `TopologyGraph` exposes that graph for **queries** (counts, adjacency, shared edges), gives
+incidence. `BRepGraph` exposes that graph for **queries** (counts, adjacency, shared edges), gives
 every node an identity that survives mutation of that graph, and can absorb an operation's **history**
 so a selection survives the operation too — useful for selection and analysis.
 
@@ -16,7 +16,7 @@ so a selection survives the operation too — useful for selection and analysis.
 
 ```swift
 let box = Shape.box(width: 10, height: 10, depth: 10)!
-guard let graph = TopologyGraph(shape: box) else { return }   // parallel: false by default
+guard let graph = BRepGraph(shape: box) else { return }   // parallel: false by default
 ```
 
 ## Count nodes by kind
@@ -58,13 +58,13 @@ graph.sameDomainFaces(of: 0)
 
 This section is the short tour. For the full model (the three UID flavours, the one-graph-instance
 scope rule and provenance, what preserves identity versus mints a new one, and persistence) see
-[BREP Graph: Durable Identity & UIDs](topology-graph-uids.md).
+[BREP Graph: Durable Identity & UIDs](brep-graph-uids.md).
 
 A node **index** is not stable — it shifts when topology is added or removed. For a reference that
 survives mutation, use a `GraphUID` (`kind` + a never-reused `counter`):
 
 ```swift
-let faceKind = Int(TopologyGraph.NodeKind.face.rawValue)
+let faceKind = Int(BRepGraph.NodeKind.face.rawValue)
 guard let uid = graph.uid(ofNodeKind: faceKind, index: 0) else { return }
 uid.isValid                       // counter > 0
 graph.contains(uid: uid)          // still present?
@@ -78,7 +78,7 @@ a UID from another graph would name an unrelated node; each UID carries the mint
 `instanceID` as `graphID`, and the resolvers return `nil` rather than a wrong node:
 
 ```swift
-let other = TopologyGraph(shape: Shape.cylinder(radius: 3, height: 7)!)!
+let other = BRepGraph(shape: Shape.cylinder(radius: 3, height: 7)!)!
 other.node(forUID: uid)      // nil — uid belongs to `graph`, not to `other`
 other.contains(uid: uid)     // false
 ```
@@ -110,7 +110,7 @@ after rebuilding:
 // save:  the shape, plus the node address you care about
 let saved = (kind: faceKind, index: 3)
 // load:  rebuild, then re-mint
-let reloaded = TopologyGraph(shape: Shape.fromBREPString(brep)!)!
+let reloaded = BRepGraph(shape: Shape.fromBREPString(brep)!)!
 let uid = reloaded.uid(ofNodeKind: saved.kind, index: saved.index)
 ```
 
@@ -132,8 +132,8 @@ The graph can record how nodes map through an operation (e.g. a fillet replacing
 selection can be re-resolved afterward:
 
 ```swift
-let orig = TopologyGraph.NodeRef(kind: .face, index: 0)
-let repl = TopologyGraph.NodeRef(kind: .face, index: 42)
+let orig = BRepGraph.NodeRef(kind: .face, index: 0)
+let repl = BRepGraph.NodeRef(kind: .face, index: 42)
 graph.recordHistory(operationName: "Fillet", original: orig, replacements: [repl])
 
 graph.findDerived(of: orig)          // [repl]    — what it became
@@ -147,7 +147,7 @@ remapping a selection, since an empty `findDerived` is ambiguous on its own.
 
 ## See also
 
-- [BREP Graph: Durable Identity & UIDs](topology-graph-uids.md): the deep dive on `GraphUID` / `GraphRefUID` / `GraphItemUID`, the one-graph-instance scope rule, and persistence.
+- [BREP Graph: Durable Identity & UIDs](brep-graph-uids.md): the deep dive on `GraphUID` / `GraphRefUID` / `GraphItemUID`, the one-graph-instance scope rule, and persistence.
 - [XCAF Assemblies](xcaf-assemblies.md) — structure *across* shapes (the product tree), vs. structure *within* one shape here.
 - [Healing & Validity](healing-and-validity.md) — `sameDomainFaces` pairs with `unified()` after booleans.
 - API mapping: [`../../API_REFERENCE.md`](../../API_REFERENCE.md)

--- a/docs/guides/cookbook/index.md
+++ b/docs/guides/cookbook/index.md
@@ -55,8 +55,8 @@ using the static PNG as the loading poster. Code → figure → 3D model all com
 - [Healing & Validity](healing-and-validity.md) — `isValid` / `isValidSolid` / `isSelfIntersecting`, `analyze`, `orientedForward`, and the repair ops (`healed` / `fixed` / `unified` / `sewn`).
 - [Meshing & Export](meshing-and-export.md) — `mesh` (deflection), the `Mesh` type, `mesh.toShape`, and STL / OBJ / STEP / IGES / BREP / glTF export + import.
 - [XCAF Assemblies](xcaf-assemblies.md) — `Document` trees, components & instancing, names / colors / materials, and structured STEP / GLB round-trip.
-- [Topology Graph](topology-graph.md) — `TopologyGraph` node counts, adjacency & shared edges, per-graph UIDs, and history tracking through operations.
-  - [BREP Graph: Durable Identity & UIDs](topology-graph-uids.md): the deep dive on identity. The three UID flavours, minting and resolving, the one-graph-instance scope rule (#295), what preserves identity versus mints a new one, and persistence.
+- [BRep Graph](brep-graph.md) — `BRepGraph` node counts, adjacency & shared edges, per-graph UIDs, and history tracking through operations.
+  - [BREP Graph: Durable Identity & UIDs](brep-graph-uids.md): the deep dive on identity. The three UID flavours, minting and resolving, the one-graph-instance scope rule (#295), what preserves identity versus mints a new one, and persistence.
 - [Gordon Surfaces](gordon-surfaces.md) — skin a surface through a network of profile + guide curves (`Surface.gordon` / `gordonReport`), with build diagnostics.
 - [Surfaces from Points](surfaces-from-points.md) — fit a B-spline through a grid (`fromPointGrid`) or a scattered cloud (`plateThrough`), and deform-to-targets (`nlPlateDeformed`).
 - [Working with Meshes](working-with-meshes.md) — the `Mesh` type: build from arrays, inspect, mesh-level booleans, triangle↔face picking, `toShape`, and SceneKit / RealityKit / Metal interop.

--- a/docs/guides/cookbook/xcaf-assemblies.md
+++ b/docs/guides/cookbook/xcaf-assemblies.md
@@ -108,5 +108,5 @@ plain [Exporter](meshing-and-export.md).
 ## See also
 
 - [Meshing & Export](meshing-and-export.md) — single-shape export and the file formats.
-- [Topology Graph](topology-graph.md) — structure *within* one shape (faces/edges), vs. the assembly tree across shapes.
+- [BRep Graph](brep-graph.md) — structure *within* one shape (faces/edges), vs. the assembly tree across shapes.
 - API mapping: [`../../API_REFERENCE.md`](../../API_REFERENCE.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ figure (interactive 3D where it helps). The **[Cookbook index](guides/cookbook/)
 [Healing & Validity](guides/cookbook/healing-and-validity.md) ·
 [Meshing & Export](guides/cookbook/meshing-and-export.md) ·
 [XCAF Assemblies](guides/cookbook/xcaf-assemblies.md) ·
-[Topology Graph](guides/cookbook/topology-graph.md) ·
+[BRep Graph](guides/cookbook/brep-graph.md) ·
 [Gordon Surfaces](guides/cookbook/gordon-surfaces.md) ·
 [Surfaces from Points](guides/cookbook/surfaces-from-points.md) ·
 [Working with Meshes](guides/cookbook/working-with-meshes.md)

--- a/docs/reference/BRepGraph-Attributes.md
+++ b/docs/reference/BRepGraph-Attributes.md
@@ -1,21 +1,21 @@
 ---
-title: TopologyGraph — Attributes, Snapshots & References
+title: BRepGraph — Attributes, Snapshots & References
 parent: API Reference
 ---
 
-# TopologyGraph — Attributes, Snapshots & References
+# BRepGraph — Attributes, Snapshots & References
 
-These are the pure-Swift value types that sit alongside `TopologyGraph`: a typed attribute store (`NodeAttributeStore`) that attaches arbitrary metadata to graph nodes, a `GraphSnapshot` that serializes attributes and the source shape for round-trip persistence, and `TopologyRef` — a recipe-based identity scheme that survives graph mutations. No C++ bridge code is involved in these types. See the main **TopologyGraph** page (coming) for the graph structure, node counts, adjacency queries, and history primitives (`NodeRef`, `HistoryRecord`, `NodeKind`) that these types build on.
+These are the pure-Swift value types that sit alongside `BRepGraph`: a typed attribute store (`NodeAttributeStore`) that attaches arbitrary metadata to graph nodes, a `GraphSnapshot` that serializes attributes and the source shape for round-trip persistence, and `TopologyRef` — a recipe-based identity scheme that survives graph mutations. No C++ bridge code is involved in these types. See the main **BRepGraph** page (coming) for the graph structure, node counts, adjacency queries, and history primitives (`NodeRef`, `HistoryRecord`, `NodeKind`) that these types build on.
 
 ## Topics
 
-- [AttrValue](#attrvalue) · [NodeAttributeStore](#nodeattributestore) · [NodeAttributeStore — Codable](#nodeattributestore--codable) · [GraphSnapshot](#graphsnapshot) · [GraphSnapshotError](#graphsnapshoterror) · [Snapshot / Restore on TopologyGraph](#snapshot--restore-on-topologygraph) · [TopologyRef](#topologyref) · [NodeRef.sentinel](#noderefsentinel) · [TopologyResolutionError](#topologyresolutionerror) · [resolve on TopologyGraph](#resolve-on-topologygraph) · [currentForms on TopologyGraph](#currentforms-on-topologygraph)
+- [AttrValue](#attrvalue) · [NodeAttributeStore](#nodeattributestore) · [NodeAttributeStore — Codable](#nodeattributestore--codable) · [GraphSnapshot](#graphsnapshot) · [GraphSnapshotError](#graphsnapshoterror) · [Snapshot / Restore on BRepGraph](#snapshot--restore-on-brepgraph) · [TopologyRef](#topologyref) · [NodeRef.sentinel](#noderefsentinel) · [TopologyResolutionError](#topologyresolutionerror) · [resolve on BRepGraph](#resolve-on-brepgraph) · [currentForms on BRepGraph](#currentforms-on-brepgraph)
 
 ---
 
 ## AttrValue
 
-`TopologyGraph.AttrValue` is a closed, `Codable` union of the scalar and array types you can attach to a node. The closed set keeps snapshot round-trips lossless — no open extension point means no unknown cases when deserializing.
+`BRepGraph.AttrValue` is a closed, `Codable` union of the scalar and array types you can attach to a node. The closed set keeps snapshot round-trips lossless — no open extension point means no unknown cases when deserializing.
 
 ```swift
 public enum AttrValue: Codable, Hashable, Sendable {
@@ -88,7 +88,7 @@ public var doublesValue: [Double]? { get }
 
 - **Example:**
   ```swift
-  let attr: TopologyGraph.AttrValue = .doubles([0.12, 0.34, 0.56])
+  let attr: BRepGraph.AttrValue = .doubles([0.12, 0.34, 0.56])
   if let params = attr.doublesValue {
       print("params:", params)
   }
@@ -98,7 +98,7 @@ public var doublesValue: [Double]? { get }
 
 ## NodeAttributeStore
 
-`NodeAttributeStore` is a per-node attribute bag keyed by `TopologyGraph.NodeRef`. Keys are caller-namespaced strings (e.g. `"reconstruct.residualRMS"`). The store is `Codable`, `Sendable`, and `Equatable`; its Codable encoding is a sorted array of entries — see [NodeAttributeStore — Codable](#nodeattributestore--codable).
+`NodeAttributeStore` is a per-node attribute bag keyed by `BRepGraph.NodeRef`. Keys are caller-namespaced strings (e.g. `"reconstruct.residualRMS"`). The store is `Codable`, `Sendable`, and `Equatable`; its Codable encoding is a sorted array of entries — see [NodeAttributeStore — Codable](#nodeattributestore--codable).
 
 ```swift
 public struct NodeAttributeStore: Codable, Sendable, Equatable
@@ -109,7 +109,7 @@ public struct NodeAttributeStore: Codable, Sendable, Equatable
 Create a store, optionally pre-populated.
 
 ```swift
-public init(storage: [TopologyGraph.NodeRef: [String: TopologyGraph.AttrValue]] = [:])
+public init(storage: [BRepGraph.NodeRef: [String: BRepGraph.AttrValue]] = [:])
 ```
 
 - **Parameters:** `storage` — initial contents; defaults to empty.
@@ -125,7 +125,7 @@ public init(storage: [TopologyGraph.NodeRef: [String: TopologyGraph.AttrValue]] 
 The raw dictionary backing the store.
 
 ```swift
-public private(set) var storage: [TopologyGraph.NodeRef: [String: TopologyGraph.AttrValue]]
+public private(set) var storage: [BRepGraph.NodeRef: [String: BRepGraph.AttrValue]]
 ```
 
 Direct mutation is not exposed; use the subscript and the mutating helpers below.
@@ -137,14 +137,14 @@ Direct mutation is not exposed; use the subscript and the mutating helpers below
 All attributes on a node — get returns an empty dictionary when no attributes are set; set with an empty dictionary removes the node entry entirely.
 
 ```swift
-public subscript(node: TopologyGraph.NodeRef) -> [String: TopologyGraph.AttrValue] { get set }
+public subscript(node: BRepGraph.NodeRef) -> [String: BRepGraph.AttrValue] { get set }
 ```
 
 - **Parameters:** `node` — the node whose attribute dictionary to read or replace.
 - **Example:**
   ```swift
   var store = NodeAttributeStore()
-  let ref = TopologyGraph.NodeRef(kind: .face, index: 0)
+  let ref = BRepGraph.NodeRef(kind: .face, index: 0)
   store[ref] = ["region": .int(3)]
   print(store[ref]["region"]?.intValue ?? -1)  // 3
   ```
@@ -156,7 +156,7 @@ public subscript(node: TopologyGraph.NodeRef) -> [String: TopologyGraph.AttrValu
 Read one attribute by key, or `nil` if unset.
 
 ```swift
-public func value(_ key: String, for node: TopologyGraph.NodeRef) -> TopologyGraph.AttrValue?
+public func value(_ key: String, for node: BRepGraph.NodeRef) -> BRepGraph.AttrValue?
 ```
 
 - **Parameters:** `key` — attribute name; `node` — the node to query.
@@ -169,7 +169,7 @@ public func value(_ key: String, for node: TopologyGraph.NodeRef) -> TopologyGra
 Set one attribute on a node.
 
 ```swift
-public mutating func set(_ key: String, _ value: TopologyGraph.AttrValue, for node: TopologyGraph.NodeRef)
+public mutating func set(_ key: String, _ value: BRepGraph.AttrValue, for node: BRepGraph.NodeRef)
 ```
 
 - **Parameters:** `key` — attribute name; `value` — value to store; `node` — the target node.
@@ -181,7 +181,7 @@ public mutating func set(_ key: String, _ value: TopologyGraph.AttrValue, for no
 Remove one attribute. Drops the node entry entirely once its last attribute is cleared.
 
 ```swift
-public mutating func clear(_ key: String, for node: TopologyGraph.NodeRef)
+public mutating func clear(_ key: String, for node: BRepGraph.NodeRef)
 ```
 
 - **Parameters:** `key` — attribute name to remove; `node` — the target node.
@@ -193,7 +193,7 @@ public mutating func clear(_ key: String, for node: TopologyGraph.NodeRef)
 Remove every attribute on a node.
 
 ```swift
-public mutating func removeAll(for node: TopologyGraph.NodeRef)
+public mutating func removeAll(for node: BRepGraph.NodeRef)
 ```
 
 - **Parameters:** `node` — the node whose entire attribute dictionary should be dropped.
@@ -211,8 +211,8 @@ public var annotatedNodeCount: Int { get }
 - **Example:**
   ```swift
   var store = NodeAttributeStore()
-  let face0 = TopologyGraph.NodeRef(kind: .face, index: 0)
-  let face1 = TopologyGraph.NodeRef(kind: .face, index: 1)
+  let face0 = BRepGraph.NodeRef(kind: .face, index: 0)
+  let face1 = BRepGraph.NodeRef(kind: .face, index: 1)
   store.set("tag", .string("critical"), for: face0)
   store.set("rms", .double(0.002), for: face1)
   print(store.annotatedNodeCount)  // 2
@@ -246,7 +246,7 @@ public func encode(to encoder: Encoder) throws
 
 ## GraphSnapshot
 
-`GraphSnapshot` bundles everything needed to persist a `TopologyGraph` session: the source shape as a BREP string (which is sufficient to re-derive the graph structure), plus the attribute store. The graph topology is NOT stored — it is reconstructed from `brep` on `TopologyGraph.init(snapshot:)`, relying on the fact that `TopologyGraph.init(shape:)` produces identical node indexing for the same BREP.
+`GraphSnapshot` bundles everything needed to persist a `BRepGraph` session: the source shape as a BREP string (which is sufficient to re-derive the graph structure), plus the attribute store. The graph topology is NOT stored — it is reconstructed from `brep` on `BRepGraph.init(snapshot:)`, relying on the fact that `BRepGraph.init(shape:)` produces identical node indexing for the same BREP.
 
 ```swift
 public struct GraphSnapshot: Codable, Sendable, Equatable
@@ -320,7 +320,7 @@ Sets `outputFormatting` to `[.sortedKeys]`. Combined with `NodeAttributeStore`'s
 - **Returns:** A configured `JSONEncoder`.
 - **Example:**
   ```swift
-  guard let graph = TopologyGraph(shape: myShape) else { return }
+  guard let graph = BRepGraph(shape: myShape) else { return }
   let snap = try graph.snapshot()
   let data = try GraphSnapshot.canonicalEncoder().encode(snap)
   try data.write(to: snapshotURL)
@@ -330,7 +330,7 @@ Sets `outputFormatting` to `[.sortedKeys]`. Combined with `NodeAttributeStore`'s
 
 ## GraphSnapshotError
 
-Errors raised while snapshotting or rebuilding a `TopologyGraph`.
+Errors raised while snapshotting or rebuilding a `BRepGraph`.
 
 ```swift
 public enum GraphSnapshotError: Error, Equatable, Sendable
@@ -378,9 +378,9 @@ case unsupportedFormatVersion(Int)
 
 ---
 
-## Snapshot / Restore on TopologyGraph
+## Snapshot / Restore on BRepGraph
 
-### `TopologyGraph.attribute(_:for:)`
+### `BRepGraph.attribute(_:for:)`
 
 Read one attribute on a node, or `nil` if unset.
 
@@ -400,7 +400,7 @@ public func attribute(_ key: String, for node: NodeRef) -> AttrValue?
 
 ---
 
-### `TopologyGraph.setAttribute(_:_:for:)`
+### `BRepGraph.setAttribute(_:_:for:)`
 
 Set one attribute on a node.
 
@@ -417,7 +417,7 @@ public func setAttribute(_ key: String, _ value: AttrValue, for node: NodeRef)
 
 ---
 
-### `TopologyGraph.snapshot()`
+### `BRepGraph.snapshot()`
 
 Export the attribute store and source shape for persistence or transport.
 
@@ -431,7 +431,7 @@ public func snapshot() throws -> GraphSnapshot
 
 ---
 
-### `TopologyGraph.init(snapshot:)`
+### `BRepGraph.init(snapshot:)`
 
 Rebuild a graph from a snapshot: deserialize the BREP, rebuild the graph (non-parallel for deterministic node indexing), and reattach the attributes.
 
@@ -449,14 +449,14 @@ public convenience init(snapshot: GraphSnapshot) throws
 - **Example:**
   ```swift
   // Round-trip
-  guard let graph = TopologyGraph(shape: myShape) else { return }
+  guard let graph = BRepGraph(shape: myShape) else { return }
   graph.setAttribute("quality", .string("high"), for: someRef)
   let snap = try graph.snapshot()
   let data = try GraphSnapshot.canonicalEncoder().encode(snap)
 
   // Later...
   let snap2 = try JSONDecoder().decode(GraphSnapshot.self, from: data)
-  let graph2 = try TopologyGraph(snapshot: snap2)
+  let graph2 = try BRepGraph(snapshot: snap2)
   let quality = graph2.attribute("quality", for: someRef)
   // quality == .string("high")
   ```
@@ -465,7 +465,7 @@ public convenience init(snapshot: GraphSnapshot) throws
 
 ## TopologyRef
 
-`TopologyRef` is a recipe-based topology identity (OCCTSwift #72, Phase 1). OCCT node indices (`BRepGraph NodeId`) are unstable across mutations — after a fillet, split, or Boolean operation, the same index may point to a different entity or nothing at all. `TopologyRef` encodes *how to find* an entity rather than *where it is now*, and `TopologyGraph.resolve(_:)` evaluates the recipe against the current graph state on demand.
+`TopologyRef` is a recipe-based topology identity (OCCTSwift #72, Phase 1). OCCT node indices (`BRepGraph NodeId`) are unstable across mutations — after a fillet, split, or Boolean operation, the same index may point to a different entity or nothing at all. `TopologyRef` encodes *how to find* an entity rather than *where it is now*, and `BRepGraph.resolve(_:)` evaluates the recipe against the current graph state on demand.
 
 The design follows Onshape's FeatureScript query system (`qCreatedBy`, `qContainedIn`, etc.) and the Shapr3D / Onshape consensus: when a recipe can't resolve, return an error rather than silently guessing.
 
@@ -480,7 +480,7 @@ public indirect enum TopologyRef: Sendable, Hashable
 Direct reference by current `(kind, index)` — an escape hatch that bypasses recipe resolution.
 
 ```swift
-case literal(TopologyGraph.NodeRef)
+case literal(BRepGraph.NodeRef)
 ```
 
 Use sparingly. A literal ref breaks the moment any mutation changes node indexing. Prefer `.createdBy` or `.containedIn` for any ref that must survive mutations.
@@ -493,7 +493,7 @@ The Nth node of `kind` that appears as a replacement in a history record tagged 
 
 ```swift
 case createdBy(operationName: String,
-               kind: TopologyGraph.NodeKind,
+               kind: BRepGraph.NodeKind,
                occurrence: Int = 0,
                leafOccurrence: Int? = 0)
 ```
@@ -521,7 +521,7 @@ The Nth descendant of `kind` contained within `parent`.
 
 ```swift
 case containedIn(parent: TopologyRef,
-                 kind: TopologyGraph.NodeKind,
+                 kind: BRepGraph.NodeKind,
                  occurrence: Int = 0)
 ```
 
@@ -558,7 +558,7 @@ Typical use: picking one of two halves after an edge or face split.
   ```swift
   // Second half of an edge that was split
   let halfEdge = TopologyRef.splitOf(
-      original: .literal(TopologyGraph.NodeRef(kind: .edge, index: 5)),
+      original: .literal(BRepGraph.NodeRef(kind: .edge, index: 5)),
       occurrence: 1
   )
   ```
@@ -570,7 +570,7 @@ Typical use: picking one of two halves after an edge or face split.
 A sentinel `NodeRef` for recording pure creations that have no meaningful ancestor.
 
 ```swift
-public static let sentinel = TopologyGraph.NodeRef(kind: .solid, index: -1)
+public static let sentinel = BRepGraph.NodeRef(kind: .solid, index: -1)
 ```
 
 Matches OCCT's default-constructed `BRepGraph_NodeId` (kind `.solid`, index `-1`). `isValid` is `false` on the sentinel.
@@ -579,7 +579,7 @@ Matches OCCT's default-constructed `BRepGraph_NodeId` (kind `.solid`, index `-1`
 
 ## TopologyResolutionError
 
-Errors returned from `TopologyGraph.resolve(_:)` when a recipe cannot be evaluated.
+Errors returned from `BRepGraph.resolve(_:)` when a recipe cannot be evaluated.
 
 ```swift
 public enum TopologyResolutionError: Error, Sendable, Hashable
@@ -600,7 +600,7 @@ case ancestorMissing(TopologyRef)
 A resolved node has a different `NodeKind` than expected.
 
 ```swift
-case kindMismatch(expected: TopologyGraph.NodeKind, found: TopologyGraph.NodeKind)
+case kindMismatch(expected: BRepGraph.NodeKind, found: BRepGraph.NodeKind)
 ```
 
 ---
@@ -647,9 +647,9 @@ case invalid(TopologyRef)
 
 ---
 
-## resolve on TopologyGraph
+## resolve on BRepGraph
 
-### `TopologyGraph.resolve(_:)`
+### `BRepGraph.resolve(_:)`
 
 Resolve a `TopologyRef` recipe against the graph's current state.
 
@@ -661,12 +661,12 @@ Recipes are evaluated lazily — `resolve` performs the full lookup on every cal
 
 - **Parameters:** `ref` — the recipe to evaluate.
 - **Returns:** `.success(NodeRef)` when the entity can be found; `.failure(TopologyResolutionError)` when it cannot.
-- **Note:** Pure Swift — no bridge call. The evaluation walks `historyRecords` and `childIndices` (a public helper on `TopologyGraph` defined in `ConstructionEntity.swift`).
+- **Note:** Pure Swift — no bridge call. The evaluation walks `historyRecords` and `childIndices` (a public helper on `BRepGraph` defined in `ConstructionEntity.swift`).
 - **Example:**
   ```swift
-  guard let graph = TopologyGraph(shape: myShape) else { return }
+  guard let graph = BRepGraph(shape: myShape) else { return }
   let ref = TopologyRef.containedIn(
-      parent: .literal(TopologyGraph.NodeRef(kind: .solid, index: 0)),
+      parent: .literal(BRepGraph.NodeRef(kind: .solid, index: 0)),
       kind: .face,
       occurrence: 0
   )
@@ -680,9 +680,9 @@ Recipes are evaluated lazily — `resolve` performs the full lookup on every cal
 
 ---
 
-## currentForms on TopologyGraph
+## currentForms on BRepGraph
 
-### `TopologyGraph.currentForms(of:)`
+### `BRepGraph.currentForms(of:)`
 
 All current (live-leaf) descendants of `node`, in deterministic order.
 
@@ -697,7 +697,7 @@ A descendant is "live" when it does not appear as an original in any subsequent 
 - **Note:** Used internally by `.createdBy` resolution when `leafOccurrence` is non-nil. Callers can use it directly to enumerate all current forms of a node that may have been split by subsequent operations.
 - **Example:**
   ```swift
-  let seed = TopologyGraph.NodeRef(kind: .face, index: 2)
+  let seed = BRepGraph.NodeRef(kind: .face, index: 2)
   let leaves = graph.currentForms(of: seed)
   if leaves.isEmpty {
       print("Face 2 has not been split")

--- a/docs/reference/BRepGraph-Builders.md
+++ b/docs/reference/BRepGraph-Builders.md
@@ -1,13 +1,13 @@
 ---
-title: TopologyGraph — Builders & Editor Mutation
+title: BRepGraph — Builders & Editor Mutation
 parent: API Reference
 ---
 
-# TopologyGraph — Builders & Editor Mutation
+# BRepGraph — Builders & Editor Mutation
 
-This page covers the **mutation surface** of `TopologyGraph` — every query and builder method from
+This page covers the **mutation surface** of `BRepGraph` — every query and builder method from
 the `// MARK: Edge/Face/Shell/Solid Additional Queries`, `CompSolid Count`, `Builder:` and
-`EditorView` sections (source lines 1093–1621). See the main **TopologyGraph** page for
+`EditorView` sections (source lines 1093–1621). See the main **BRepGraph** page for
 construction, traversal, and the core query API.
 
 ## Topics
@@ -31,7 +31,7 @@ public func edgeWires(_ edgeIndex: Int) -> [Int]
 - **OCCT:** `BRepGraph_EditorView` (graph topo layer — wire-membership reverse lookup).
 - **Example:**
   ```swift
-  let graph = TopologyGraph(shape: solid)
+  let graph = BRepGraph(shape: solid)
   let wires = graph.edgeWires(0)
   print("edge 0 belongs to \(wires.count) wire(s)")
   ```

--- a/docs/reference/BRepGraph-Detail-History.md
+++ b/docs/reference/BRepGraph-Detail-History.md
@@ -1,11 +1,11 @@
 ---
-title: TopologyGraph — Topology Detail, History & Mesh
+title: BRepGraph — Topology Detail, History & Mesh
 parent: API Reference
 ---
 
-# TopologyGraph — Topology Detail, History & Mesh
+# BRepGraph — Topology Detail, History & Mesh
 
-This page covers the detail-query, history, mesh-storage, assembly, and structural reference members of `TopologyGraph`. For the core construction, counts, adjacency, geometry, and serialization API see [TopologyGraph](TopologyGraph.md).
+This page covers the detail-query, history, mesh-storage, assembly, and structural reference members of `BRepGraph`. For the core construction, counts, adjacency, geometry, and serialization API see [BRepGraph](BRepGraph.md).
 
 ## Topics
 
@@ -218,7 +218,7 @@ public func clearHistory()
 
 ### `NodeRef`
 
-A `(kind, index)` pair identifying a node within a `TopologyGraph`.
+A `(kind, index)` pair identifying a node within a `BRepGraph`.
 
 ```swift
 public struct NodeRef: Sendable, Hashable, Codable {
@@ -450,7 +450,7 @@ that minted it ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
 - **Example:** cut a channel across a box's top face and keep hold of the face.
   ```swift
   let base = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
-  let graph = TopologyGraph(shape: base)!
+  let graph = BRepGraph(shape: base)!
   let rootNode = graph.findNode(for: base)!
   let root = NodeRef(kind: rootNode.kind, index: rootNode.index)
 
@@ -882,11 +882,11 @@ public func sameDomainFaces(of faceIndex: Int) -> [Int]
 Creates a deep copy of the graph.
 
 ```swift
-public func copy(copyGeometry: Bool = true) -> TopologyGraph?
+public func copy(copyGeometry: Bool = true) -> BRepGraph?
 ```
 
 - **Parameters:** `copyGeometry` — when `true` (default), geometry handles are also copied; when `false`, the new graph shares geometry with the original.
-- **Returns:** New `TopologyGraph`, or `nil` on failure.
+- **Returns:** New `BRepGraph`, or `nil` on failure.
 - **OCCT:** `OCCTBRepGraphCopy`.
 - **Example:**
   ```swift
@@ -902,13 +902,13 @@ public func copy(copyGeometry: Bool = true) -> TopologyGraph?
 Creates a new graph containing only the sub-graph of a single face.
 
 ```swift
-public func copyFace(_ faceIndex: Int, copyGeometry: Bool = true) -> TopologyGraph?
+public func copyFace(_ faceIndex: Int, copyGeometry: Bool = true) -> BRepGraph?
 ```
 
 - **Parameters:**
   - `faceIndex` — 0-based index of the face to extract.
   - `copyGeometry` — whether to copy geometry handles (default: `true`).
-- **Returns:** New `TopologyGraph` for the face sub-graph, or `nil` on failure.
+- **Returns:** New `BRepGraph` for the face sub-graph, or `nil` on failure.
 - **OCCT:** `OCCTBRepGraphCopyFace`.
 - **Example:**
   ```swift
@@ -924,13 +924,13 @@ public func copyFace(_ faceIndex: Int, copyGeometry: Bool = true) -> TopologyGra
 Returns a new graph translated by `(dx, dy, dz)`.
 
 ```swift
-public func translated(dx: Double, dy: Double, dz: Double, copyGeometry: Bool = true) -> TopologyGraph?
+public func translated(dx: Double, dy: Double, dz: Double, copyGeometry: Bool = true) -> BRepGraph?
 ```
 
 - **Parameters:**
   - `dx`, `dy`, `dz` — translation components in model units.
   - `copyGeometry` — whether to copy geometry handles (default: `true`).
-- **Returns:** Translated `TopologyGraph`, or `nil` on failure.
+- **Returns:** Translated `BRepGraph`, or `nil` on failure.
 - **OCCT:** `OCCTBRepGraphTransformTranslation`.
 - **Example:**
   ```swift
@@ -1091,7 +1091,7 @@ public var rootProductIndices: [Int] { get }
 
 ## Reference Counts
 
-`TopologyGraph` stores topology as definition nodes (face, edge, …) and typed reference entries that link parent nodes to child nodes with orientation. The counts below reflect the size of each reference table.
+`BRepGraph` stores topology as definition nodes (face, edge, …) and typed reference entries that link parent nodes to child nodes with orientation. The counts below reflect the size of each reference table.
 
 ### `RefKind`
 

--- a/docs/reference/BRepGraph-Editor-Identity.md
+++ b/docs/reference/BRepGraph-Editor-Identity.md
@@ -1,11 +1,11 @@
 ---
-title: TopologyGraph — Editor Geometry, Sampling & Durable Identity
+title: BRepGraph — Editor Geometry, Sampling & Durable Identity
 parent: API Reference
 ---
 
-# TopologyGraph — Editor Geometry, Sampling & Durable Identity
+# BRepGraph — Editor Geometry, Sampling & Durable Identity
 
-This page covers the final sections of `TopologyGraph` (source lines 1622–2055): geometric setters for the EditorView, assembly-building ProductOps, in-place RepOps swaps, MeshView cache inspection, UV-grid and edge-curve sampling, and the durable-identity UID/RefUID/ItemUID API. See the other **TopologyGraph — …** pages for the core read API, write helpers, and I/O.
+This page covers the final sections of `BRepGraph` (source lines 1622–2055): geometric setters for the EditorView, assembly-building ProductOps, in-place RepOps swaps, MeshView cache inspection, UV-grid and edge-curve sampling, and the durable-identity UID/RefUID/ItemUID API. See the other **BRepGraph — …** pages for the core read API, write helpers, and I/O.
 
 ## Topics
 
@@ -140,7 +140,7 @@ Set the local `TopLoc_Location` of a vertex reference entry.
 public func setVertexRefLocalLocation(_ vertexRefIndex: Int, matrix: [Double])
 ```
 
-`matrix` is a row-major 3×4 array (12 doubles) following the `gp_Trsf::SetValues` convention — rows are `[r00 r01 r02 tx | r10 r11 r12 ty | r20 r21 r22 tz]`. Use `TopologyGraph.identityLocationMatrix` for a no-op placement.
+`matrix` is a row-major 3×4 array (12 doubles) following the `gp_Trsf::SetValues` convention — rows are `[r00 r01 r02 tx | r10 r11 r12 ty | r20 r21 r22 tz]`. Use `BRepGraph.identityLocationMatrix` for a no-op placement.
 
 - **Parameters:** `vertexRefIndex` — per-kind vertex-ref index; `matrix` — 12-element row-major 3×4 transform.
 - **OCCT:** `TopLoc_Location` via `gp_Trsf::SetValues` (via `OCCTBRepGraphSetVertexRefLocalLocation`).
@@ -245,7 +245,7 @@ Returns `[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]` — a row-major identity with zer
 
 - **Example:**
   ```swift
-  graph.setFaceRefLocalLocation(0, matrix: TopologyGraph.identityLocationMatrix)
+  graph.setFaceRefLocalLocation(0, matrix: BRepGraph.identityLocationMatrix)
   ```
 
 ---
@@ -318,7 +318,7 @@ public func linkProducts(parentProductIndex: Int, referencedProductIndex: Int,
 - **Note:** Precondition: `placement.count == 12`.
 - **Example:**
   ```swift
-  let matrix = TopologyGraph.identityLocationMatrix
+  let matrix = BRepGraph.identityLocationMatrix
   if let result = graph.linkProducts(parentProductIndex: 0,
                                       referencedProductIndex: 1,
                                       placement: matrix) {
@@ -737,8 +737,8 @@ public func sampleEdgeCurve(edgeIndex: Int, count: Int) -> [SIMD3<Double>]
 A UID is meaningful only inside the graph that minted it. Every graph allocates counters from 1 independently, so the same `(kind, counter)` names some unrelated node in every other graph. Each UID therefore carries a `graphID` — the `instanceID` of the graph that minted it — and the resolvers reject a UID from anywhere else:
 
 ```swift
-let boxGraph = TopologyGraph(shape: box)!
-let cylGraph = TopologyGraph(shape: cylinder)!
+let boxGraph = BRepGraph(shape: box)!
+let cylGraph = BRepGraph(shape: cylinder)!
 
 let faceUID = boxGraph.uid(ofNodeKind: 2, index: 2)!   // a face of the BOX
 boxGraph.node(forUID: faceUID)      // Optional((kind: 2, index: 2))
@@ -757,7 +757,7 @@ Which operations carry identity across follows the kernel's own rule — whether
 | `copyFace()` | **fresh** — `CopyNode` lifts one face without the counter space | source UIDs return `nil` |
 | a new graph over any shape (incl. a rebuild of the same one) | fresh | source UIDs return `nil` |
 
-To carry a selection across a *modelling operation* rather than across mutations of one graph, absorb the operation's history — see [`add(_:absorbing:inputRoots:operationName:)`](TopologyGraph-Detail-History.md#add_absorbinginputrootsoperationname). To carry one across a save/load, store `(kind, index)` with the shape and re-mint after rebuilding — see [Topology Graph § UIDs and persistence](../guides/cookbook/topology-graph.md#uids-and-persistence).
+To carry a selection across a *modelling operation* rather than across mutations of one graph, absorb the operation's history — see [`add(_:absorbing:inputRoots:operationName:)`](BRepGraph-Detail-History.md#add_absorbinginputrootsoperationname). To carry one across a save/load, store `(kind, index)` with the shape and re-mint after rebuilding — see [BRep Graph § UIDs and persistence](../guides/cookbook/brep-graph.md#uids-and-persistence).
 
 > Before v1.12.0 UIDs carried no provenance, so a UID from an unrelated graph resolved to a plausible but wrong node instead of returning `nil`. `copyFace()` was affected the same way. ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295))
 
@@ -981,11 +981,11 @@ Identity here is the graph object, not the geometry: two graphs built from the s
 - **OCCT:** none — assigned by the bridge per `OCCTBRepGraph` (via `OCCTBRepGraphInstanceID`).
 - **Example:**
   ```swift
-  let graph = TopologyGraph(shape: box)!
+  let graph = BRepGraph(shape: box)!
   let uid = graph.uid(ofNodeKind: 2, index: 0)!
   print(uid.graphID == graph.instanceID)   // true — this graph minted it
 
-  let rebuilt = TopologyGraph(shape: box)!  // same shape, new instance
+  let rebuilt = BRepGraph(shape: box)!  // same shape, new instance
   print(rebuilt.instanceID == graph.instanceID)   // false
   print(rebuilt.node(forUID: uid))                // nil
   ```

--- a/docs/reference/BRepGraph.md
+++ b/docs/reference/BRepGraph.md
@@ -1,13 +1,13 @@
 ---
-title: TopologyGraph
+title: BRepGraph
 parent: API Reference
 ---
 
-# TopologyGraph
+# BRepGraph
 
-`TopologyGraph` is OCCTSwift's graph-based view of B-Rep topology, wrapping OCCT's `BRepGraph` package. It indexes all faces, edges, vertices, wires, shells, solids, coedges, and compounds of a `Shape` as flat integer-indexed entity vectors with O(1) cross-references, enabling cache-friendly traversal, fast adjacency queries, and parallel geometry extraction. Obtain one via `TopologyGraph(shape:)`.
+`BRepGraph` is OCCTSwift's graph-based view of B-Rep topology, wrapping OCCT's `BRepGraph` package. It indexes all faces, edges, vertices, wires, shells, solids, coedges, and compounds of a `Shape` as flat integer-indexed entity vectors with O(1) cross-references, enabling cache-friendly traversal, fast adjacency queries, and parallel geometry extraction. Obtain one via `BRepGraph(shape:)`.
 
-> **TopologyGraph is large — documented across several pages.** This is the core (construction, counts, topology queries, explorers, validate/compact/deduplicate, statistics, geometry readback); see the other **TopologyGraph — …** pages for topology detail/history/mesh, builders & editor mutation, editor geometry/sampling/durable-identity, and attributes/snapshots/references.
+> **BRepGraph is large — documented across several pages.** This is the core (construction, counts, topology queries, explorers, validate/compact/deduplicate, statistics, geometry readback); see the other **BRepGraph — …** pages for topology detail/history/mesh, builders & editor mutation, editor geometry/sampling/durable-identity, and attributes/snapshots/references.
 
 ## Topics
 
@@ -40,12 +40,12 @@ public init?(shape: Shape, parallel: Bool = false)
 Ingests the shape's full B-Rep topology into an indexed graph. Pass `parallel: true` to build using multi-threaded traversal (faster for large shapes; not safe to call concurrently with other graph ops).
 
 - **Parameters:** `shape` — the shape to analyze; `parallel` — whether to use parallel construction (default: `false`).
-- **Returns:** A fully built `TopologyGraph`, or `nil` if ingestion fails.
+- **Returns:** A fully built `BRepGraph`, or `nil` if ingestion fails.
 - **OCCT:** `BRepGraph::ShapesView::Add(shape, opts)` with `opts.Parallel` set accordingly.
 - **Example:**
   ```swift
   if let box = Shape.box(width: 10, height: 10, depth: 10),
-     let graph = TopologyGraph(shape: box) {
+     let graph = BRepGraph(shape: box) {
       print(graph.faceCount)   // 6
       print(graph.edgeCount)   // 12
       print(graph.vertexCount) // 8
@@ -272,7 +272,7 @@ public func adjacentFaces(of faceIndex: Int) -> [Int]
 - **Example:**
   ```swift
   if let box = Shape.box(width: 10, height: 10, depth: 10),
-     let graph = TopologyGraph(shape: box) {
+     let graph = BRepGraph(shape: box) {
       let neighbors = graph.adjacentFaces(of: 0)
       // neighbors has 4 entries for a box face
   }
@@ -509,14 +509,14 @@ public var rootNodes: [RootNode] { get }
 ```
 
 > **This is empty for a graph built from a `Shape`, and that is expected.** It enumerates
-> `BRepGraph::RootProductIds()` — assembly Products, not topology. `TopologyGraph(shape:)` builds with
+> `BRepGraph::RootProductIds()` — assembly Products, not topology. `BRepGraph(shape:)` builds with
 > `CreateAutoProduct: false` (no auto Product/Occurrence wrap), so such a graph has no products and
 > `rootNodes` returns `[]`. It is populated for graphs carrying assembly context.
 >
 > **For the topology root of a shape-built graph, use `findNode(for:)` on the shape itself:**
 >
 > ```swift
-> let graph = TopologyGraph(shape: base)!
+> let graph = BRepGraph(shape: base)!
 > let root = graph.findNode(for: base)     // e.g. (kind: .solid, index: 0)
 > ```
 >
@@ -525,7 +525,7 @@ public var rootNodes: [RootNode] { get }
 - **OCCT:** `BRepGraph::RootProductIds()`.
 - **Example:**
   ```swift
-  // Meaningful for assembly-context graphs; [] for TopologyGraph(shape:).
+  // Meaningful for assembly-context graphs; [] for BRepGraph(shape:).
   for root in graph.rootNodes {
       print("\(root.kind) at index \(root.index)")
   }
@@ -714,9 +714,9 @@ Reads all topology and geometry counts in a single call.
 - **Example:**
   ```swift
   if let box = Shape.box(width: 10, height: 10, depth: 10),
-     let graph = TopologyGraph(shape: box) {
+     let graph = BRepGraph(shape: box) {
       print(graph.stats)
-      // TopologyGraph.Stats(solids: 1, shells: 1, faces: 6, wires: 6, edges: 12, vertices: 8, ...)
+      // BRepGraph.Stats(solids: 1, shells: 1, faces: 6, wires: 6, edges: 12, vertices: 8, ...)
   }
   ```
 

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -5,11 +5,11 @@ parent: API Reference
 
 # Construction & Sketching
 
-The construction & sketching types implement Fusion 360-style parametric reference geometry and 2D profile creation. `ConstructionEntity` types carry _recipes_ (plane, axis, point definitions keyed on `TopologyRef`s) that are resolved against a live `TopologyGraph`; `ConstructionContext` is the document-level registry for those entities; `ConstructionLayer` bridges them to the XCAF document layer system for STEP persistence; `Sketch` hosts 2D curve elements on a plane and builds a 3D profile wire; and `Section2D` extends `Shape` to produce 2D contour drawings from planar section cuts.
+The construction & sketching types implement Fusion 360-style parametric reference geometry and 2D profile creation. `ConstructionEntity` types carry _recipes_ (plane, axis, point definitions keyed on `TopologyRef`s) that are resolved against a live `BRepGraph`; `ConstructionContext` is the document-level registry for those entities; `ConstructionLayer` bridges them to the XCAF document layer system for STEP persistence; `Sketch` hosts 2D curve elements on a plane and builds a 3D profile wire; and `Section2D` extends `Shape` to produce 2D contour drawings from planar section cuts.
 
 ## Topics
 
-- [Placement](#placement) · [ConstructionPlane](#constructionplane) · [ConstructionAxis](#constructionaxis) · [ConstructionPoint](#constructionpoint) · [ConstructionResolutionError](#constructionresolutionerror) · [TopologyGraph resolve extensions](#topologygraph-resolve-extensions) · [TopologyGraph.childIndices](#topologygraphchildindices) · [ConstructionContext](#constructioncontext) · [Document.constructionContext](#documentconstructioncontext) · [ConstructionLayer — Document extension](#constructionlayer--document-extension) · [ConstructionContext.materialize](#constructioncontextmaterialize) · [SketchElement](#sketchelement) · [Sketch](#sketch) · [Shape.section2D](#shapesection2d) · [Shape.SectionView](#shapesectionview)
+- [Placement](#placement) · [ConstructionPlane](#constructionplane) · [ConstructionAxis](#constructionaxis) · [ConstructionPoint](#constructionpoint) · [ConstructionResolutionError](#constructionresolutionerror) · [BRepGraph resolve extensions](#brepgraph-resolve-extensions) · [BRepGraph.childIndices](#brepgraphchildindices) · [ConstructionContext](#constructioncontext) · [Document.constructionContext](#documentconstructioncontext) · [ConstructionLayer — Document extension](#constructionlayer--document-extension) · [ConstructionContext.materialize](#constructioncontextmaterialize) · [SketchElement](#sketchelement) · [Sketch](#sketch) · [Shape.section2D](#shapesection2d) · [Shape.SectionView](#shapesectionview)
 
 ---
 
@@ -67,7 +67,7 @@ Picks a stable X axis using `worldUp × normal`; falls back to `worldY × normal
 
 ## ConstructionPlane
 
-A recipe for a construction plane. Each case carries its defining inputs as `TopologyRef`s (or absolute geometry) that are resolved against a `TopologyGraph` at use time, so the plane tracks model edits automatically.
+A recipe for a construction plane. Each case carries its defining inputs as `TopologyRef`s (or absolute geometry) that are resolved against a `BRepGraph` at use time, so the plane tracks model edits automatically.
 
 ### `ConstructionPlane.absolute(origin:normal:)`
 
@@ -170,7 +170,7 @@ case normalToEdge(edge: TopologyRef, t: Double)
 
 ## ConstructionAxis
 
-A recipe for a construction axis. Resolved to `(origin: SIMD3<Double>, direction: SIMD3<Double>)` against a `TopologyGraph`.
+A recipe for a construction axis. Resolved to `(origin: SIMD3<Double>, direction: SIMD3<Double>)` against a `BRepGraph`.
 
 ### `ConstructionAxis.absolute(origin:direction:)`
 
@@ -230,7 +230,7 @@ Fails with `.degenerate("planes are parallel")` when the cross product is near-z
 
 ## ConstructionPoint
 
-A recipe for a construction point. Resolved to `SIMD3<Double>` against a `TopologyGraph`.
+A recipe for a construction point. Resolved to `SIMD3<Double>` against a `BRepGraph`.
 
 ### `ConstructionPoint.absolute(_:)`
 
@@ -307,7 +307,7 @@ public enum ConstructionResolutionError: Error, Sendable {
     case topology(TopologyResolutionError)
     case notApplicable(String)
     case degenerate(String)
-    case missingGeometry(TopologyGraph.NodeRef)
+    case missingGeometry(BRepGraph.NodeRef)
 }
 ```
 
@@ -318,11 +318,11 @@ public enum ConstructionResolutionError: Error, Sendable {
 
 ---
 
-## TopologyGraph resolve extensions
+## BRepGraph resolve extensions
 
-`TopologyGraph` is extended in `ConstructionEntity.swift` to resolve the three construction entity types. These are the primary resolution entry points.
+`BRepGraph` is extended in `ConstructionEntity.swift` to resolve the three construction entity types. These are the primary resolution entry points.
 
-### `TopologyGraph.resolve(_:) for ConstructionPlane`
+### `BRepGraph.resolve(_:) for ConstructionPlane`
 
 Resolves a `ConstructionPlane` recipe against the current graph state.
 
@@ -342,7 +342,7 @@ public func resolve(_ plane: ConstructionPlane) -> Result<Placement, Constructio
 
 ---
 
-### `TopologyGraph.resolve(_:) for ConstructionAxis`
+### `BRepGraph.resolve(_:) for ConstructionAxis`
 
 Resolves a `ConstructionAxis` recipe against the current graph state.
 
@@ -361,7 +361,7 @@ public func resolve(_ axis: ConstructionAxis) -> Result<(origin: SIMD3<Double>, 
 
 ---
 
-### `TopologyGraph.resolve(_:) for ConstructionPoint`
+### `BRepGraph.resolve(_:) for ConstructionPoint`
 
 Resolves a `ConstructionPoint` recipe against the current graph state.
 
@@ -380,9 +380,9 @@ public func resolve(_ point: ConstructionPoint) -> Result<SIMD3<Double>, Constru
 
 ---
 
-## TopologyGraph.childIndices
+## BRepGraph.childIndices
 
-### `TopologyGraph.childIndices(rootKind:rootIndex:targetKind:)`
+### `BRepGraph.childIndices(rootKind:rootIndex:targetKind:)`
 
 Returns the indices of all descendant nodes of `targetKind` under a root node.
 
@@ -407,7 +407,7 @@ Complements `childCount(rootKind:rootIndex:targetKind:)` by giving the actual in
 
 ## ConstructionContext
 
-A document-level, thread-safe registry of named construction entities. Entities are stored by value under opaque typed IDs; they are resolved on demand against a `TopologyGraph`. Insertion order is preserved. Thread-safe via an internal `NSLock`.
+A document-level, thread-safe registry of named construction entities. Entities are stored by value under opaque typed IDs; they are resolved on demand against a `BRepGraph`. Insertion order is preserved. Thread-safe via an internal `NSLock`.
 
 > **Persistence note:** Construction entity _recipes_ live in Swift value storage only — they are not serialised into the XCAF/XDE shape tree. STEP round-trip preserves layer tags (see `ConstructionLayer`) but loses recipe structure. Serialise the `ConstructionContext` separately (e.g. as JSON via `Codable`) if recipe round-trip is required.
 
@@ -665,10 +665,10 @@ public func removeAll()
 Resolves a registered plane against a topology graph, returning a `Placement`.
 
 ```swift
-public func resolve(_ id: PlaneID, in graph: TopologyGraph) -> Result<Placement, ConstructionResolutionError>
+public func resolve(_ id: PlaneID, in graph: BRepGraph) -> Result<Placement, ConstructionResolutionError>
 ```
 
-Delegates to `TopologyGraph.resolve(_:)`. Returns `.failure(.notApplicable(...))` if `id` is not registered.
+Delegates to `BRepGraph.resolve(_:)`. Returns `.failure(.notApplicable(...))` if `id` is not registered.
 
 - **Parameters:**
   - `id` — the `PlaneID` to resolve.
@@ -690,7 +690,7 @@ Delegates to `TopologyGraph.resolve(_:)`. Returns `.failure(.notApplicable(...))
 Resolves a registered axis against a topology graph.
 
 ```swift
-public func resolve(_ id: AxisID, in graph: TopologyGraph) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError>
+public func resolve(_ id: AxisID, in graph: BRepGraph) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError>
 ```
 
 ---
@@ -700,7 +700,7 @@ public func resolve(_ id: AxisID, in graph: TopologyGraph) -> Result<(origin: SI
 Resolves a registered point against a topology graph.
 
 ```swift
-public func resolve(_ id: PointID, in graph: TopologyGraph) -> Result<SIMD3<Double>, ConstructionResolutionError>
+public func resolve(_ id: PointID, in graph: BRepGraph) -> Result<SIMD3<Double>, ConstructionResolutionError>
 ```
 
 ---
@@ -729,7 +729,7 @@ public struct BrokenEntities: Sendable {
 Inspects every registered entity against `graph` and returns those that fail resolution.
 
 ```swift
-public func allBroken(in graph: TopologyGraph) -> BrokenEntities
+public func allBroken(in graph: BRepGraph) -> BrokenEntities
 ```
 
 Useful in agent workflows after model edits to detect stale construction references before attempting a sketch build or section.
@@ -903,7 +903,7 @@ Materialises all registered construction entities as `TopoDS_Shape`s on the docu
 ```swift
 @discardableResult
 public func materialize(in document: Document,
-                        graph: TopologyGraph,
+                        graph: BRepGraph,
                         options: MaterializeOptions = MaterializeOptions()) -> MaterializationResult
 ```
 
@@ -1119,14 +1119,14 @@ Builds a 3D closed profile wire from the sketch's non-construction elements, pla
 
 ```swift
 public func buildProfile(in context: ConstructionContext,
-                         graph: TopologyGraph) -> Wire?
+                         graph: BRepGraph) -> Wire?
 ```
 
 Construction elements are filtered at this single site — upstream views (solver, editor) see the full element set. Each 2D point is lifted into 3D via `placement.origin + pt.x * placement.xAxis + pt.y * placement.yAxis`. The resulting polyline is closed automatically if the first and last 3D points are within 1e-9 of each other.
 
 - **Parameters:**
   - `context` — the `ConstructionContext` that registered `hostPlane`.
-  - `graph` — a `TopologyGraph` to resolve the host plane's recipe.
+  - `graph` — a `BRepGraph` to resolve the host plane's recipe.
 - **Returns:** A closed `Wire` on the resolved plane, or `nil` if the host plane fails to resolve, no profile elements exist, or fewer than 2 distinct 3D points result.
 - **OCCT:** Delegates to `Wire.polygon3D(_:closed:)` — `BRepBuilderAPI_MakePolygon`.
 - **Example:**

--- a/docs/reference/Measurement.md
+++ b/docs/reference/Measurement.md
@@ -221,11 +221,11 @@ Resolves each axis via `BRepGraph.resolve(_:)` to obtain its `direction` vector,
 - **OCCT:** Pure-Swift over `BRepGraph.resolve` + `unsignedAngle(between:and:)`.
 - **Example:**
   ```swift
-  let graph = shape.brepGraph()
-  let axes = graph.constructionAxes()
-  if axes.count >= 2,
-     let a = axes[0].angle(to: axes[1], in: graph) {
-      print(a * 180 / .pi)
+  let graph = BRepGraph(shape: shape)!
+  let axisA = ConstructionAxis.absolute(origin: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0))
+  let axisB = ConstructionAxis.absolute(origin: SIMD3(0, 0, 0), direction: SIMD3(0, 1, 0))
+  if let a = axisA.angle(to: axisB, in: graph) {
+      print(a * 180 / .pi)  // 90
   }
   ```
 
@@ -254,11 +254,11 @@ Resolves each plane via `BRepGraph.resolve(_:)` to obtain its `zAxis` vector, th
 - **OCCT:** Pure-Swift over `BRepGraph.resolve` + `unsignedAngle(between:and:)`.
 - **Example:**
   ```swift
-  let graph = shape.brepGraph()
-  let planes = graph.constructionPlanes()
-  if planes.count >= 2,
-     let a = planes[0].angle(to: planes[1], in: graph) {
-      print(a * 180 / .pi)
+  let graph = BRepGraph(shape: shape)!
+  let planeA = ConstructionPlane.absolute(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1))
+  let planeB = ConstructionPlane.absolute(origin: SIMD3(0, 0, 0), normal: SIMD3(1, 0, 0))
+  if let a = planeA.angle(to: planeB, in: graph) {
+      print(a * 180 / .pi)  // 90
   }
   ```
 

--- a/docs/reference/Measurement.md
+++ b/docs/reference/Measurement.md
@@ -209,19 +209,19 @@ Extension on `ConstructionAxis` (defined in `MeasurementHelpers.swift`).
 Angle between two construction axes, resolved against the given topology graph.
 
 ```swift
-public func angle(to other: ConstructionAxis, in graph: TopologyGraph) -> Double?
+public func angle(to other: ConstructionAxis, in graph: BRepGraph) -> Double?
 ```
 
-Resolves each axis via `TopologyGraph.resolve(_:)` to obtain its `direction` vector, then computes the unsigned angle between the directions.
+Resolves each axis via `BRepGraph.resolve(_:)` to obtain its `direction` vector, then computes the unsigned angle between the directions.
 
 - **Parameters:**
   - `other` — the axis to compare.
-  - `graph` — the `TopologyGraph` used to resolve both axis handles.
+  - `graph` — the `BRepGraph` used to resolve both axis handles.
 - **Returns:** Angle in radians in `[0, π]`, or `nil` if either axis fails to resolve.
-- **OCCT:** Pure-Swift over `TopologyGraph.resolve` + `unsignedAngle(between:and:)`.
+- **OCCT:** Pure-Swift over `BRepGraph.resolve` + `unsignedAngle(between:and:)`.
 - **Example:**
   ```swift
-  let graph = shape.topologyGraph()
+  let graph = shape.brepGraph()
   let axes = graph.constructionAxes()
   if axes.count >= 2,
      let a = axes[0].angle(to: axes[1], in: graph) {
@@ -242,19 +242,19 @@ Extension on `ConstructionPlane` (defined in `MeasurementHelpers.swift`).
 Angle between two construction planes (angle between their Z-axis normals).
 
 ```swift
-public func angle(to other: ConstructionPlane, in graph: TopologyGraph) -> Double?
+public func angle(to other: ConstructionPlane, in graph: BRepGraph) -> Double?
 ```
 
-Resolves each plane via `TopologyGraph.resolve(_:)` to obtain its `zAxis` vector, then computes the unsigned angle between them.
+Resolves each plane via `BRepGraph.resolve(_:)` to obtain its `zAxis` vector, then computes the unsigned angle between them.
 
 - **Parameters:**
   - `other` — the plane to compare.
-  - `graph` — the `TopologyGraph` used to resolve both plane handles.
+  - `graph` — the `BRepGraph` used to resolve both plane handles.
 - **Returns:** Angle in radians in `[0, π]`, or `nil` if either plane fails to resolve.
-- **OCCT:** Pure-Swift over `TopologyGraph.resolve` + `unsignedAngle(between:and:)`.
+- **OCCT:** Pure-Swift over `BRepGraph.resolve` + `unsignedAngle(between:and:)`.
 - **Example:**
   ```swift
-  let graph = shape.topologyGraph()
+  let graph = shape.brepGraph()
   let planes = graph.constructionPlanes()
   if planes.count >= 2,
      let a = planes[0].angle(to: planes[1], in: graph) {

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -104,7 +104,7 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 | Mesh | 34 | `Mesh.md` | ✅ done |
 | Exporter | 39 | `Exporter.md` | ✅ done |
 | Document | 1735 | `Document.md` + 12 (Persistence-IO, XCAF-Notes, OCAF-Attributes, Math-Bounds, Analysis-Builders, Geometry-Constructors, BSpline-Extrema, Math-Solvers, Mesh-Fixing, Transforms, Builders-Fillet, Completions) | ✅ done |
-| TopologyGraph (BRepGraph) | 375 | `TopologyGraph.md` + 4 (Detail-History, Builders, Editor-Identity, Attributes) | ✅ done |
+| BRepGraph | 375 | `BRepGraph.md` + 4 (Detail-History, Builders, Editor-Identity, Attributes) | ✅ done |
 | ThreadFeatures | 30 | `ThreadFeatures.md` | ✅ done |
 | DrawingAnnotation | 100 | `DrawingAnnotation.md` | ✅ done |
 | Drawing & Sheets (Drawing, DrawingSheet, DrawingStyle, DisplayDrawer) | 94 | `Drawing.md` | ✅ done |

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -1105,7 +1105,7 @@ public func copy() -> Polygon2D?
 
 ## Triangulation
 
-`Triangulation` wraps `Poly_Triangulation` — a 3D mesh defined by node positions and triangle vertex indices. Used as input to `TopologyGraph.createTriangulationRep(_:)` for populating the cached mesh tier of a graph. Triangle indices are 0-based on the Swift boundary; the bridge converts to OCCT's 1-based representation internally.
+`Triangulation` wraps `Poly_Triangulation` — a 3D mesh defined by node positions and triangle vertex indices. Used as input to `BRepGraph.createTriangulationRep(_:)` for populating the cached mesh tier of a graph. Triangle indices are 0-based on the Swift boundary; the bridge converts to OCCT's 1-based representation internally.
 
 ### `Triangulation.create(nodes:triangles:)`
 


### PR DESCRIPTION
## Summary

- Renames `TopologyGraph` → `BRepGraph`, matching the C++ package it wraps (`BRepGraph`) and its own source file (`BRepGraph.swift`). `TopologyGraph` read as too close to OCCT's own `TopoDS_*` family (`TopoDS_Shape`, `TopoDS_Face`, ...) without signaling that it specifically wraps the BRepGraph durable-identity engine.
- Adds a deprecated typealias so existing consumers keep compiling:
  ```swift
  @available(*, deprecated, renamed: "BRepGraph")
  public typealias TopologyGraph = BRepGraph
  ```
- Docs move alongside the rename: `docs/reference/TopologyGraph*.md` → `BRepGraph*.md`, `docs/guides/cookbook/topology-graph*.md` → `brep-graph*.md`. `docs/CHANGELOG.md`'s historical entries are left untouched (they describe the API as it was at the time); a new `v1.15.0` entry documents the rename.
- `Tests/OCCTTopologyGraphTests` → `Tests/OCCTBRepGraphTests` (internal only, no consumer-visible effect).

MINOR per this repo's [SemVer policy](docs/SEMVER.md) — additive, existing name still resolves.

## Ecosystem impact

Surveyed every downstream repo in the org (public + private) for real (non-comment) source references to `TopologyGraph`. Six public and three private repos have real usages (~260 call sites total across OCCTMCP, OCCTSwiftScripts, OCCTSwiftAIS, OCCTSwiftTools, OCCTSwiftIO, OCCTSwiftMesh, OCCTReconstruct, PadCAMEngine, swiftGCS); none build with `-Werror`, so the deprecated typealias keeps them compiling. Tracking issues are being filed in each so they can migrate off the deprecated name at their own pace — see #333 for the origin request.

Closes #333

## Test plan

- [x] `swift build` — clean, 0 errors, 0 warnings
- [x] `swift build --build-tests` — clean, 0 errors, only pre-existing unrelated warnings (`union(with:)`/`intersection(with:)` deprecations, dead-code in OCCTAnalysisTests/OCCTCurveTests)
- [x] `swift test --filter OCCTBRepGraphTests` — 170 tests / 63 suites pass
- [ ] Maintainer: cut `v1.15.0` tag after merge and re-index into `context` per the ecosystem release-discipline standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)