### PR TITLE
docs+test(#336): chained *WithFullHistory absorb — not a bug, close the test-coverage gap

### DIFF
--- a/Tests/OCCTBRepGraphTests/Issue336ChainedHistoryTests.swift
+++ b/Tests/OCCTBRepGraphTests/Issue336ChainedHistoryTests.swift
@@ -1,0 +1,141 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #336: a reported "second `*WithFullHistory` op chained onto a prior op's
+/// output absorbs zero records" turned out not to be a bug in
+/// `add(_:absorbing:inputRoots:operationName:)` at all. The reporter's repro
+/// used `Shape.box(width:height:depth:)`, which is documented as **centered
+/// at the origin** (see its doc comment and `OCCTShapeCreateBox`), not
+/// corner-anchored like raw OCCT's `BRepPrimAPI_MakeBox(w,h,d)`. That made the
+/// first "corner" tool land fully *inside* the box and the second "opposite
+/// corner" tool land entirely *outside* it (bounding boxes don't even
+/// overlap) — so the second cut was a genuine geometric no-op, and zero
+/// absorbed records was the correct answer.
+///
+/// Verified two ways: (1) probing the raw `ShapeHistoryRef` directly against
+/// `out1.faces()` — bypassing the graph entirely — showed the same zero
+/// modified/generated/deleted records, so the boolean's own history
+/// construction was never in question. (2) `out1.volume == out2.volume`
+/// confirms the second cut changed nothing geometrically.
+///
+/// What WAS missing: no existing test chained two `*WithFullHistory` ops
+/// end-to-end (second op fed from the first op's live, Compound-wrapped
+/// output) or passed a non-root node as `inputRoots` — every
+/// `GraphHistoryAbsorbTests` case only does a single hop rooted at the
+/// graph's own top-level node. These tests close that gap.
+@Suite("Chained WithFullHistory absorb (#336)")
+struct Issue336ChainedHistoryTests {
+
+    /// Same shape and box-centering as the issue, but with tool placements
+    /// that actually clip real corners — proving the chain absorbs correctly
+    /// once the geometry genuinely intersects.
+    @Test("two chained WithFullHistory cuts both absorb real records")
+    func chainedCutsAbsorbAcrossTwoHops() {
+        // Shape.box(width:height:depth:) is centered at the origin:
+        // [-5,5] x [-10,10] x [-15,15].
+        guard let box = Shape.box(width: 10, height: 20, depth: 30),
+              let graph = BRepGraph(shape: box),
+              let root0Raw = graph.findNode(for: box) else {
+            Issue.record("box/graph setup failed"); return
+        }
+        let root0 = BRepGraph.NodeRef(kind: root0Raw.kind, index: root0Raw.index)
+
+        // Corner-anchored tool clipping the (5, 10, 15) corner.
+        guard let tool1 = Shape.box(origin: SIMD3(4, 9, 14), width: 3, height: 3, depth: 3),
+              let (out1, hist1) = box.subtractedWithFullHistory(tool1) else {
+            Issue.record("hop1 subtract failed"); return
+        }
+
+        let before1 = graph.historyRecordCount
+        let added1 = graph.add(out1, absorbing: hist1, inputRoots: [root0], operationName: "hop1")
+        #expect(added1 != nil, "hop1 add should return the result's topology root")
+        #expect(graph.historyRecordCount > before1,
+                "hop1 should absorb real records — tool1 genuinely clips a corner of the box")
+
+        guard let out1Solid = out1.subShapes(ofType: .solid).first,
+              let root1Raw = graph.findNode(for: out1Solid) else {
+            Issue.record("out1Solid/root1 lookup failed"); return
+        }
+        let root1 = BRepGraph.NodeRef(kind: root1Raw.kind, index: root1Raw.index)
+
+        // Corner-anchored tool clipping the OPPOSITE (-5, -10, -15) corner of
+        // the ORIGINAL box — which remains a real corner of out1, since hop1
+        // only touched the (5, 10, 15) corner.
+        guard let tool2 = Shape.box(origin: SIMD3(-6, -11, -16), width: 3, height: 3, depth: 3),
+              let (out2, hist2) = out1.subtractedWithFullHistory(tool2) else {
+            Issue.record("hop2 subtract failed"); return
+        }
+        if let v1 = out1.volume, let v2 = out2.volume {
+            #expect(v2 < v1, "hop2's tool genuinely overlaps out1, so its volume must shrink")
+        } else {
+            Issue.record("volume() failed for out1/out2")
+        }
+
+        // This is the exact call the issue reported as broken — chaining a
+        // second *WithFullHistory op onto the first op's live output, using a
+        // non-root NodeId (root1) as inputRoots.
+        let before2 = graph.historyRecordCount
+        let added2 = graph.add(out2, absorbing: hist2, inputRoots: [root1], operationName: "hop2")
+        #expect(added2 != nil, "hop2 add should return the result's topology root")
+        #expect(graph.historyRecordCount > before2,
+                "hop2 should absorb real records once its tool genuinely clips a corner of out1")
+        #expect(graph.hasHistoryRecord(for: root1),
+                "root1 should carry a history record after a real chained cut touched it")
+    }
+
+    /// The issue's exact repro, kept as a permanent regression guard: when the
+    /// second tool's bounding box does not overlap the first cut's result at
+    /// all, absorbing zero records is correct, not a bug. If a future change
+    /// to the boolean bridge or the absorb path ever makes this non-zero
+    /// (or, worse, silently "recovers" nonexistent history), this test should
+    /// catch it.
+    @Test("a genuinely non-intersecting second cut absorbs nothing, correctly")
+    func nonIntersectingSecondCutAbsorbsNothing() throws {
+        let brepURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue336-\(UUID().uuidString).brep")
+        defer { try? FileManager.default.removeItem(at: brepURL) }
+
+        guard let box = Shape.box(width: 10, height: 20, depth: 30) else {
+            Issue.record("box failed"); return
+        }
+        try Exporter.writeBREP(shape: box, to: brepURL)
+        let loaded = try Shape.loadBREP(from: brepURL)
+
+        guard let graph = BRepGraph(shape: loaded),
+              let root0Raw = graph.findNode(for: loaded) else {
+            Issue.record("graph/root0 setup failed"); return
+        }
+        let root0 = BRepGraph.NodeRef(kind: root0Raw.kind, index: root0Raw.index)
+
+        // Fully INSIDE the centered box — an interior cavity cut, not a
+        // corner clip, but still a real geometric change.
+        guard let tool1 = Shape.box(width: 3, height: 3, depth: 3)?.translated(by: SIMD3(-1, -1, -1)),
+              let (out1, hist1) = loaded.subtractedWithFullHistory(tool1) else {
+            Issue.record("hop1 subtract failed"); return
+        }
+        _ = graph.add(out1, absorbing: hist1, inputRoots: [root0], operationName: "hop1")
+
+        guard let out1Solid = out1.subShapes(ofType: .solid).first,
+              let root1Raw = graph.findNode(for: out1Solid) else {
+            Issue.record("out1Solid/root1 lookup failed"); return
+        }
+        let root1 = BRepGraph.NodeRef(kind: root1Raw.kind, index: root1Raw.index)
+
+        // Entirely outside out1's [-5,5] x [-10,10] x [-15,15] bounds.
+        guard let tool2 = Shape.box(width: 3, height: 3, depth: 3)?.translated(by: SIMD3(8, 18, 28)),
+              let (out2, hist2) = out1.subtractedWithFullHistory(tool2) else {
+            Issue.record("hop2 subtract failed"); return
+        }
+        #expect(out1.volume == out2.volume, "a non-intersecting tool must leave the volume unchanged")
+
+        let before2 = graph.historyRecordCount
+        let added2 = graph.add(out2, absorbing: hist2, inputRoots: [root1], operationName: "hop2")
+        #expect(added2 != nil, "add() itself still succeeds — there is simply nothing to absorb")
+        #expect(graph.historyRecordCount == before2,
+                "no geometry changed, so no records should be absorbed")
+        #expect(!graph.hasHistoryRecord(for: root1))
+        #expect(graph.findDerivedOrSelf(of: root1) == [root1],
+                "untouched by a real op, root1 should resolve to itself")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,40 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.1
+## Current: v1.15.2
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.2 (July 2026): docs + tests — chaining `*WithFullHistory` ops across a `BRepGraph`, retract the #336 "absorbs zero records" report (#336)
+
+**Not a bug — investigated and retracted.** #336 reported that a second `*WithFullHistory` boolean op
+chained onto a prior op's live output absorbed zero history records into `add(_:absorbing:inputRoots:
+operationName:)`. Verified two independent ways: probing the raw `ShapeHistoryRef` directly against the
+first op's output faces (bypassing the graph and `CollectHistoryInputs`/`Absorb` entirely) showed the
+same zero records, and `out1.volume == out2.volume` confirmed the second cut changed nothing
+geometrically. **Root cause: the reporter's tool placement, not the absorb path.**
+`Shape.box(width:height:depth:)` is centered at the origin (documented on the API itself), not
+corner-anchored like raw OCCT's `BRepPrimAPI_MakeBox(w,h,d)`. The repro's first "corner" tool landed
+fully *inside* the box (an interior-cavity cut) and its second "opposite corner" tool landed entirely
+*outside* the box's actual bounds — the two shapes' bounding boxes don't even overlap — so the second
+cut was a genuine geometric no-op. Zero absorbed records was the correct answer.
+
+**Real gap found and closed: test coverage.** No existing test chained two `*WithFullHistory` ops
+end-to-end (second op fed from the first op's live, `Compound`-wrapped output) or passed a non-root
+`NodeRef` as `inputRoots` — every `GraphHistoryAbsorbTests` case only did a single hop rooted at the
+graph's own top-level node. New `Issue336ChainedHistoryTests` (`OCCTBRepGraphTests`) covers both: a
+genuine two-hop chain (opposite real corners) absorbing records at each hop, and a permanent regression
+guard for the reporter's exact non-intersecting geometry asserting the zero-record result stays correct.
+
+- **Docs:** `docs/reference/BRepGraph-Detail-History.md` gains a "Chaining multiple operations" section
+  with a runnable multi-hop snippet and the box-centering gotcha, right where `add(_:absorbing:...)` is
+  documented.
+- Docs only, no code or binary change — reuses the v1.15.1 xcframework (the binaryTarget URL is
+  unchanged).
 
 ### v1.15.1 (July 2026) — fix: `isSelfIntersecting(hardTimeout:)` can now actually interrupt a stuck self-interference search (#319)
 

--- a/docs/reference/BRepGraph-Detail-History.md
+++ b/docs/reference/BRepGraph-Detail-History.md
@@ -476,6 +476,34 @@ that minted it ([#295](https://github.com/SecondMouseAU/OCCTSwift/issues/295)).
 > faces, because `FindDerived` unions Modified and Generated descendants transitively. When you want
 > the faces a face became, filter on `.kind == .face`.
 
+#### Chaining multiple operations
+
+`inputRoots` is not limited to the graph's own top-level root — pass any `NodeRef` already in the
+graph, including one you just got back from a prior `add(_:absorbing:...)` call, to chain a second
+`*WithFullHistory` op onto the first op's live output ([#336](https://github.com/SecondMouseAU/OCCTSwift/issues/336)):
+
+```swift
+let (out1, hist1) = base.subtractedWithFullHistory(tool1)!
+graph.add(out1, absorbing: hist1, inputRoots: [root], operationName: "hop1")
+
+// Drill down to a trackable (solid) root for the next hop — a boolean result
+// is always a Compound wrapping its solid(s).
+let out1Solid = out1.subShapes(ofType: .solid).first!
+let root1Raw = graph.findNode(for: out1Solid)!
+let root1 = NodeRef(kind: root1Raw.kind, index: root1Raw.index)
+
+let (out2, hist2) = out1.subtractedWithFullHistory(tool2)!
+graph.add(out2, absorbing: hist2, inputRoots: [root1], operationName: "hop2")
+```
+
+> **Zero absorbed records means the tool didn't touch anything — check the geometry, not the API.**
+> `add(_:absorbing:...)` absorbs whatever the operation's own `BRepTools_History` reports; if a tool's
+> bounding box doesn't overlap the shape it's cutting, that history is legitimately empty. This is the
+> whole story behind #336: `Shape.box(width:height:depth:)` is centered at the origin (see its doc
+> comment), not corner-anchored like raw OCCT's `BRepPrimAPI_MakeBox(w,h,d)` — a tool built from it and
+> translated as if the box's corner were at the origin can end up nowhere near the shape you meant to
+> cut. Compare `out1.volume` / `out2.volume` (or bounding boxes) before suspecting the absorb path.
+
 ### `historyIsDeleted(_:)`
 
 True if a recorded operation consumed `node`, leaving it no image in the result.


### PR DESCRIPTION
## Summary

Closes #336 as **not a bug**, with evidence, plus the test-coverage gap that let it go undetected.

- **Investigated empirically**, not just by reading source: reproduced the issue's exact scenario, then probed the raw `ShapeHistoryRef` directly against `out1.faces()` — bypassing `BRepGraph` entirely — and got the *same* zero records. `out1.volume == out2.volume` confirmed the second cut was a genuine geometric no-op. So the bug (if any) could not be in `BRepGraph.add`/`CollectHistoryInputs`/`Absorb`.
- **Root cause:** `Shape.box(width:height:depth:)` is centered at the origin (already documented on the API: "Create a box centered at origin", and in the bridge: `OCCTShapeCreateBox` does `gp_Pnt origin(-width/2, -height/2, -depth/2)`), not corner-anchored like raw OCCT's `BRepPrimAPI_MakeBox(w,h,d)`. The issue's `tool1` (meant to clip a corner) landed fully *inside* the box, and `tool2` (meant to clip the opposite corner) landed entirely *outside* the box's actual bounds — the two shapes' bounding boxes don't even overlap. Zero absorbed records was the correct answer.
- **Confirmed the absorb mechanism itself works:** re-ran the same two-hop chain with tools that genuinely clip real opposite corners of the box (via the corner-anchored `Shape.box(origin:width:height:depth:)`) — both hops absorbed real records, `hasHistoryRecord(for:)` was true, and volume shrank as expected.
- **Real gap found and closed:** no existing test chained two `*WithFullHistory` ops end-to-end (second op fed from the first op's live, `Compound`-wrapped output) or passed a non-root `NodeRef` as `inputRoots` — every `GraphHistoryAbsorbTests` case only does a single hop rooted at the graph's own top-level node.

## Changes

- `Tests/OCCTBRepGraphTests/Issue336ChainedHistoryTests.swift` (new): a genuine two-hop chain proving multi-hop `add(_:absorbing:...)` works, and a permanent regression guard on the original non-intersecting geometry so "zero records" doesn't regress into "wrong records" later.
- `docs/reference/BRepGraph-Detail-History.md`: new "Chaining multiple operations" section with a runnable multi-hop snippet and the box-centering gotcha, right where `add(_:absorbing:...)` is documented.
- `docs/CHANGELOG.md`: v1.15.2 entry (docs + tests only — no code or binary change; reuses the v1.15.1 xcframework).

**No production code changes** — bridge, kernel, and public Swift API are untouched.

## Test plan

- [x] `swift build --target OCCTBRepGraphTests` — clean
- [x] `swift test --filter Issue336ChainedHistoryTests` — 2/2 pass
- [x] `swift test --filter GraphHistoryAbsorbTests` — 6/6 pass (no regressions)
- [x] `swift test --filter OCCTBRepGraphTests` (full domain target) — 172/172 pass
- [x] `swift build` (full package) — clean
- [x] Independent adversarial review pass (separate agent, hand-verified the geometry arithmetic and re-checked the original issue text) — no defects found

🤖 Generated with [Claude Code](https://claude.com/claude-code)