### PR TITLE
feat(scripts): ThreadSanitizer gate for concurrency-touching changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,8 @@ Package.resolved
 # OCCT build artifacts and large binaries
 # Users must run Scripts/build-occt.sh to generate these
 Libraries/occt-src/
-Libraries/occt-build-ios/
-Libraries/occt-build-sim/
-Libraries/occt-build-macos/
-Libraries/occt-install-ios/
-Libraries/occt-install-sim/
-Libraries/occt-install-macos/
+Libraries/occt-build-*/
+Libraries/occt-install-*/
 Libraries/OCCT.xcframework/
 Libraries/*.a
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ swift build --target OCCTThreadTests # Focused compile: just one domain's tests 
 swift test                           # Run all tests (~3900 tests across per-domain targets)
 swift test --filter "Issue187"       # Run suites whose struct name matches (matches the type, not @Suite title)
 swift run OCCTTest                   # Run test executable
+Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concurrency-touching changes (see docs/thread-safety.md)
 ```
 
 ### Compile a Ground Truth C++ Test

--- a/Scripts/tsan-stress.sh
+++ b/Scripts/tsan-stress.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+#
+# ThreadSanitizer gate for concurrency-touching changes.
+#
+# Formalizes the TSan protocol used to find and fix issues #298, #319, #341, #344
+# and #349: a minimal-module ThreadSanitizer build of the pinned OCCT (with all
+# carried patches applied) plus the standalone C++ stress harnesses in
+# Scripts/repro/, run with race detection on. See docs/thread-safety.md
+# ("ThreadSanitizer gate") for when running this is required.
+#
+# Usage:
+#   Scripts/tsan-stress.sh build    One-time: build the TSan-instrumented OCCT
+#                                   into Libraries/occt-install-tsan (~15-30 min)
+#   Scripts/tsan-stress.sh run     Compile + run every gate scenario under TSan
+#   Scripts/tsan-stress.sh swift   swift test --sanitize=thread on the
+#                                   concurrency-focused suites (wrapper-only
+#                                   coverage; see docs/thread-safety.md)
+#   Scripts/tsan-stress.sh all     build (if needed) + run + swift
+#
+# Environment:
+#   JOBS          parallel build jobs (default: hw.ncpu)
+#   SWIFT_FILTER  override the test filter used by the swift mode
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LIBRARIES_DIR="$PROJECT_DIR/Libraries"
+SRC_DIR="$LIBRARIES_DIR/occt-src"
+BUILD_DIR="$LIBRARIES_DIR/occt-build-tsan"
+INSTALL_DIR="$LIBRARIES_DIR/occt-install-tsan"
+SUPP_FILE="$SCRIPT_DIR/tsan.supp"
+JOBS="${JOBS:-$(sysctl -n hw.ncpu)}"
+
+# ---------------------------------------------------------------------------
+# Gate scenario matrix.
+#
+# One line per scenario: "<source relative to Scripts/repro>|<program args>".
+# The token @SCRATCH is replaced with a per-run scratch directory.
+#
+# POLICY: when a change introduces a new concurrent usage pattern (a new
+# subsystem wrapped for parallel use, a serialization mutex removed, a new
+# concurrent path through the bridge), add a scenario here, either a new mode
+# in an existing harness or a new standalone harness under Scripts/repro/.
+#
+# Only DOCUMENTED-SAFE usage patterns belong here (independent shapes,
+# unique file paths). Deliberately adversarial modes that exercise
+# documented-unsafe usage (341's shared_adaptor_cache, obj_roundtrip_shared)
+# are excluded: they are expected to race and gate nothing.
+# ---------------------------------------------------------------------------
+SCENARIOS=(
+  "341-meshcaf/occt_341_stress.cpp|create_fillet_boolean 8 30"
+  "341-meshcaf/occt_341_stress.cpp|mesh_independent 8 30"
+  "341-meshcaf/occt_341_stress.cpp|obj_roundtrip_unique 8 25 @SCRATCH"
+  "344-cdf-directory/occt_344_newdoc_only.cpp|8 50"
+  "344-cdf-directory/occt_344_barrier.cpp|8 50"
+  "344-cdf-directory/occt_344_stress.cpp|8 25 @SCRATCH"
+  "349-ocaf-driver-reentrancy/occt_349_barrier.cpp|8 50 @SCRATCH"
+)
+
+MACOS_SDK=$(xcrun --sdk macosx --show-sdk-path)
+CXX=$(xcrun --find clang++)
+
+apply_patches() {
+    # Same idempotent loop as build-occt.sh: carried patches must be in the
+    # instrumented kernel too, otherwise the gate re-reports every fixed race.
+    if compgen -G "$SCRIPT_DIR/patches/*.patch" > /dev/null; then
+        echo ">>> Applying carried OCCT patches to occt-src..."
+        for p in "$SCRIPT_DIR"/patches/*.patch; do
+            if git -C "$SRC_DIR" apply --reverse --check "$p" 2>/dev/null; then
+                echo "    already applied: $(basename "$p")"
+            elif git -C "$SRC_DIR" apply --check "$p" 2>/dev/null; then
+                git -C "$SRC_DIR" apply "$p"
+                echo "    applied: $(basename "$p")"
+            else
+                echo "    ERROR: cannot apply $(basename "$p") cleanly" >&2
+                exit 1
+            fi
+        done
+    fi
+}
+
+do_build() {
+    if [ ! -d "$SRC_DIR" ]; then
+        echo "ERROR: $SRC_DIR not found. Run Scripts/build-occt.sh once first (it clones the pinned OCCT source)." >&2
+        exit 1
+    fi
+    apply_patches
+
+    # Minimal-module config, mirroring the proven #298/#341/#344/#349 protocol
+    # builds (Libraries/occt-build-tsan344/349): FoundationClasses + ModelingData
+    # + ModelingAlgorithms + DataExchange. Toolkits those modules depend on
+    # (TKLCAF/TKCDF etc.) are built by OCCT's own dependency resolution.
+    echo ">>> Configuring TSan OCCT build ($BUILD_DIR)..."
+    cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
+        -DBUILD_LIBRARY_TYPE=Static \
+        -DBUILD_MODULE_ApplicationFramework=OFF \
+        -DBUILD_MODULE_DataExchange=ON \
+        -DBUILD_MODULE_Draw=OFF \
+        -DBUILD_MODULE_FoundationClasses=ON \
+        -DBUILD_MODULE_ModelingAlgorithms=ON \
+        -DBUILD_MODULE_ModelingData=ON \
+        -DBUILD_MODULE_Visualization=OFF \
+        -DUSE_FREETYPE=OFF -DUSE_FREEIMAGE=OFF -DUSE_TBB=OFF \
+        -DUSE_VTK=OFF -DUSE_OPENGL=OFF -DUSE_GLES2=OFF \
+        -DUSE_DRACO=OFF -DUSE_FFMPEG=OFF -DUSE_OPENVR=OFF \
+        -DUSE_XLIB=OFF -DUSE_TCL=OFF -DUSE_RAPIDJSON=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_CXX_COMPILER="$CXX" \
+        -DCMAKE_CXX_FLAGS="-arch arm64 -isysroot $MACOS_SDK -mmacosx-version-min=12.0 -fsanitize=thread -g" \
+        -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
+    echo ">>> Building (this takes a while)..."
+    cmake --build "$BUILD_DIR" --parallel "$JOBS"
+    cmake --install "$BUILD_DIR"
+    echo ">>> TSan OCCT installed at $INSTALL_DIR"
+}
+
+do_run() {
+    if [ ! -d "$INSTALL_DIR/lib" ]; then
+        echo "ERROR: no TSan OCCT install at $INSTALL_DIR. Run: Scripts/tsan-stress.sh build" >&2
+        exit 1
+    fi
+    local inc="$INSTALL_DIR/include/opencascade"
+    [ -d "$inc" ] || inc="$INSTALL_DIR/include"
+    local libs
+    libs=$(ls "$INSTALL_DIR"/lib/libTK*.a | xargs -n1 basename | sed 's/^lib//;s/\.a$//;s/^/-l/')
+
+    local results scratch
+    results=$(mktemp -d /tmp/occt-tsan-results.XXXXXX)
+    scratch=$(mktemp -d /tmp/occt-tsan-scratch.XXXXXX)
+    echo ">>> TSan gate: logs in $results"
+
+    local failures=0 total=0
+    for entry in "${SCENARIOS[@]}"; do
+        local src="${entry%%|*}"
+        local args="${entry#*|}"
+        args="${args//@SCRATCH/$scratch}"
+        local src_path="$SCRIPT_DIR/repro/$src"
+        local bin="$results/$(basename "${src%.cpp}")"
+
+        # results dir is fresh per run, so "binary exists" means "already
+        # compiled this run" (macOS /bin/bash is 3.2: no associative arrays)
+        if [ ! -x "$bin" ]; then
+            echo ">>> Compiling $src"
+            "$CXX" -std=c++17 -fsanitize=thread -g -O1 -w \
+                -I"$inc" -L"$INSTALL_DIR/lib" \
+                "$src_path" -o "$bin" \
+                $libs -lz -lc++ -framework Foundation
+        fi
+
+        total=$((total + 1))
+        local log="$results/$(basename "${src%.cpp}").$(echo "$args" | tr ' /' '__').log"
+        echo ">>> RUN  $(basename "$bin") $args"
+        local status=0
+        MMGT_OPT=0 \
+        TSAN_OPTIONS="halt_on_error=0:exitcode=66:suppressions=$SUPP_FILE" \
+            "$bin" $args > "$log" 2>&1 || status=$?
+
+        local races
+        races=$(grep -c "WARNING: ThreadSanitizer" "$log" || true)
+        if [ "$status" -eq 0 ] && [ "$races" -eq 0 ]; then
+            echo "     PASS (0 races)"
+        else
+            echo "     FAIL (exit $status, $races race warnings): $log"
+            failures=$((failures + 1))
+        fi
+    done
+
+    echo ""
+    echo ">>> TSan gate: $((total - failures))/$total scenarios clean"
+    if [ "$failures" -gt 0 ]; then
+        echo ">>> FAILED. Inspect the logs above. A race that is confirmed benign or is an"
+        echo ">>> already-filed open kernel finding may be added to Scripts/tsan.supp, with"
+        echo ">>> an issue link and removal condition (see the policy in that file)."
+        exit 1
+    fi
+}
+
+do_swift() {
+    # Wrapper-only coverage: SwiftPM instruments the Swift + OCCTBridge sources,
+    # but the prebuilt OCCT.xcframework is NOT instrumented, so races entirely
+    # inside the kernel are invisible here. Kernel coverage comes from do_run.
+    local filter="${SWIFT_FILTER:-Thread|Stress|Concurren|Parallel}"
+    echo ">>> swift test --sanitize=thread --filter \"$filter\""
+    (cd "$PROJECT_DIR" && swift test --sanitize=thread --filter "$filter")
+}
+
+case "${1:-}" in
+    build) do_build ;;
+    run)   do_run ;;
+    swift) do_swift ;;
+    all)
+        [ -d "$INSTALL_DIR/lib" ] || do_build
+        do_run
+        do_swift
+        ;;
+    *)
+        sed -n '2,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+        exit 2
+        ;;
+esac

--- a/Scripts/tsan.supp
+++ b/Scripts/tsan.supp
@@ -1,0 +1,31 @@
+# ThreadSanitizer suppressions for the TSan gate (Scripts/tsan-stress.sh).
+#
+# POLICY: every entry needs (a) a reason, (b) an issue link, and (c) a removal
+# condition. Two kinds of entry are allowed:
+#   1. Confirmed-benign races we have reviewed and chosen not to fix.
+#   2. Known OPEN kernel findings already filed and tracked, suppressed so the
+#      gate stays green for NEW code while the fix is in flight. These MUST be
+#      removed when the fix lands (the gate itself then verifies the fix).
+# Anything else is a gate failure: fix it or file it first.
+
+# --- 1. Confirmed benign ----------------------------------------------------
+
+# Lazy one-time init of the BOPAlgo message table. Racy per TSan, harmless in
+# effect; known since the #298 investigation (patches/README.md, patch 0003).
+# Remove if upstream ever guards it.
+race:BOPAlgo_InitMessages
+
+# OCCT's default console messenger writes progress text from multiple threads
+# with no locking. Interleaved console output only; documented in
+# Scripts/repro/341-meshcaf/README.md. Remove if upstream ever locks it.
+race:Message_PrinterOStream
+
+# --- 2. Open kernel findings, filed and tracked -----------------------------
+
+# CDM_Application::myMetaDataLookUpTable is an unsynchronized NCollection map
+# shared by every thread using one TDocStd_Application; surfaced by the #349
+# fix (same fix-one-race-exposes-the-next pattern as #344). Filed as
+# SecondMouseAU/OCCTSwift#353. REMOVE when the #353 kernel patch is carried.
+race:CDM_MetaData
+race:CDM_Application
+race:CDF_FWOSDriver::CreateMetaData

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -151,6 +151,61 @@ investigation, tracked separately in #349. Plain shape-format I/O (STEP/IGES/BRE
 glTF) is unaffected — this only covers the three OCAF (`.bcaf`/`.xcaf`-style binary/XML
 document) persistence entry points.
 
+## ThreadSanitizer gate for concurrency-touching changes
+
+Every thread-safety kernel bug this project has found and fixed (#298, #341, #344, #349)
+was pinned down by the same protocol: a minimal-module ThreadSanitizer build of the pinned
+OCCT with all carried patches applied, plus a small standalone C++ stress harness for the
+suspect usage pattern. `Scripts/tsan-stress.sh` formalizes that protocol as a routine gate,
+because upstream OCCT runs no sanitizers in its CI at all: races we do not catch here are
+caught by nobody.
+
+### When running it is required
+
+Run `Scripts/tsan-stress.sh run` (plus `swift`) before merging any change that:
+
+1. adds or widens a concurrent path through the bridge (a new operation callable in
+   parallel, a new async/worker entry point);
+2. wraps a new OCCT subsystem that callers are expected to use from multiple threads;
+3. removes or relaxes a serialization mutex (`OCCTSerial`, `meshCafMutex`,
+   `ocafStoreMutex`, or any successor); or
+4. adds or updates a carried kernel patch that touches shared state.
+
+If the change introduces a genuinely new concurrent usage pattern, also add a gate
+scenario: either a new mode in an existing harness under `Scripts/repro/` or a new
+standalone harness, and register it in the `SCENARIOS` matrix at the top of
+`Scripts/tsan-stress.sh`. The existing harnesses (`341-meshcaf`, `344-cdf-directory`,
+`349-ocaf-driver-reentrancy`) are the templates.
+
+### Commands
+
+```bash
+Scripts/tsan-stress.sh build   # one-time: TSan-instrumented OCCT into Libraries/occt-install-tsan
+Scripts/tsan-stress.sh run     # compile + run every gate scenario; fails on unsuppressed races
+Scripts/tsan-stress.sh swift   # swift test --sanitize=thread on the concurrency-focused suites
+Scripts/tsan-stress.sh all     # build if needed, then run + swift
+```
+
+### Coverage model
+
+- `run` is the kernel gate: the harnesses link the instrumented OCCT directly, so races
+  wholly inside kernel code are visible. This is the mode that found `STATIC_SOLIDINDEX`
+  (#298), `theAutoNaming` (#341), the CDF singleton family (#344) and the storage-driver
+  scratch state (#349).
+- `swift` instruments the Swift and OCCTBridge sources only; the prebuilt
+  `OCCT.xcframework` is not instrumented, so kernel-internal races are invisible there.
+  It exists to catch wrapper-level races (bridge caches, Swift concurrency misuse), not
+  kernel ones.
+
+### Suppressions
+
+`Scripts/tsan.supp` may contain only (a) confirmed-benign races reviewed and documented,
+or (b) already-filed open kernel findings, each with an issue link and a removal
+condition (current example: the `CDM_Application` metadata-map race, #353, suppressed
+until its patch is carried so the gate stays green for new code). An unsuppressed race is
+a gate failure: fix it or file it first. When a suppressed finding's fix lands, remove
+the suppression; the gate then verifies the fix.
+
 ## Performance
 
 The mutex overhead is ~1µs per lock/unlock. Typical OCCT operations take 0.1ms-10s. The serialization cost is negligible for all practical workflows.


### PR DESCRIPTION
## Summary

Formalizes the TSan protocol that found and validated #298 / #341 / #344 / #349 as a routine, repeatable gate, so new concurrency-touching code is checked the same way the carried thread-safety patches were.

- **`Scripts/tsan-stress.sh`**
  - `build`: one-time minimal-module ThreadSanitizer OCCT build (same proven config as the occt-build-tsan344/349 protocol builds, carried patches applied so fixed races do not re-report) into `Libraries/occt-install-tsan`.
  - `run`: compiles the standalone stress harnesses in `Scripts/repro/` and executes a gate scenario matrix (7 scenarios across `341-meshcaf`, `344-cdf-directory`, `349-ocaf-driver-reentrancy`; documented-safe usage patterns only). Fails on any unsuppressed race or crash.
  - `swift`: `swift test --sanitize=thread` on the concurrency-focused suites (wrapper-only coverage; the prebuilt xcframework is uninstrumented, and the doc says so).
- **`Scripts/tsan.supp`**: curated suppressions under a strict policy: confirmed-benign (`BOPAlgo_InitMessages`, `Message_PrinterOStream`) or filed-and-open kernel findings (#353, suppressed with a removal condition so the gate stays green for new code while the fix is in flight).
- **`docs/thread-safety.md`**: new "ThreadSanitizer gate" section defining when the gate is required (new concurrent bridge paths, newly parallel-wrapped subsystems, mutex removals, new thread-safety kernel patches) and the rule that a new concurrent usage pattern must add a scenario to the matrix.
- **`CLAUDE.md`**: one-line pointer in Build & Test Commands.
- **`.gitignore`**: `occt-build-*/` / `occt-install-*/` globs replace the per-directory entries, covering the TSan/ASan/debug build trees.

Context: the ecosystem-level OCCT kernel bug deep dive (2026-07) found that upstream OCCT CI runs no sanitizers at all, so races this gate does not catch are caught by nobody.

No linked issue to close; this implements a standing action from the deep-dive review rather than fixing a defect.

## Validation

- `bash -n` clean; runs on stock macOS `/bin/bash` 3.2 (no associative arrays).
- Usage output and the no-install guard path exercised.
- The `build` step (15-30 min kernel build) was not run in this PR's environment; first `run` on a dev machine prompts for it. The scenario matrix and compile/link lines mirror the commands already documented and used in `Scripts/repro/341-meshcaf/README.md` and the #344/#349 investigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)