### PR TITLE
fix(scripts): pass -isysroot when compiling TSan gate harnesses

### DIFF
--- a/Scripts/tsan-stress.sh
+++ b/Scripts/tsan-stress.sh
@@ -143,6 +143,7 @@ do_run() {
         if [ ! -x "$bin" ]; then
             echo ">>> Compiling $src"
             "$CXX" -std=c++17 -fsanitize=thread -g -O1 -w \
+                -isysroot "$MACOS_SDK" \
                 -I"$inc" -L"$INSTALL_DIR/lib" \
                 "$src_path" -o "$bin" \
                 $libs -lz -lc++ -framework Foundation


### PR DESCRIPTION
Without it, clang++ from xcrun cannot find libc++ headers (fatal error:
'atomic' file not found) on machines without a default SDKROOT. The
kernel build already received the sysroot via its cmake flags; the
harness compile line did not.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
