### PR TITLE
fix(#359): STEP import + 3 later STEP writers missing the DE mutex — v1.15.12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,8 +79,8 @@ let occtBridgeTarget: Target = useBridgeLocalBinary
     // the OCCT.xcframework convention above.
     ? .binaryTarget(
         name: "OCCTBridge",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.7/OCCTBridge.xcframework.zip",
-        checksum: "b4bc05e7669b5edc7dbc1a8642c53940f81699eb5938aaeb1719c999a60e611a"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.12/OCCTBridge.xcframework.zip",
+        checksum: "6a53ec32f781916edf0c6ef6b68090bc1804d63dcc90d767953aebfcc165fa8d"
     )
     : .target(
         name: "OCCTBridge",

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -87,6 +87,8 @@ OCCTDocumentRef OCCTDocumentCreate(void) {
 OCCTDocumentRef OCCTDocumentLoadSTEP(const char* path) {
     if (!path) return nullptr;
 
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     OCCTDocument* document = nullptr;
     try {
         document = new OCCTDocument();

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -139,6 +139,8 @@ bool OCCTExportSTEP(OCCTShapeRef shape, const char* path) {
 bool OCCTExportSTEPWithName(OCCTShapeRef shape, const char* path, const char* name) {
     if (!shape || !path) return false;
 
+    // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> deLock(igesMutex());
     try {
         // Use a scoped block to ensure all OCCT objects are destroyed before return
         bool success = false;
@@ -260,6 +262,8 @@ OCCTShapeRef OCCTImportSTEPProgress(const char* path,
                                       bool* outCancelled) {
     clearCancelOut(outCancelled);
     if (!path) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         IFSelect_ReturnStatus status = reader.ReadFile(path);
@@ -281,6 +285,8 @@ OCCTShapeRef OCCTImportSTEPRobustProgress(const char* path,
                                             bool* outCancelled) {
     clearCancelOut(outCancelled);
     if (!path) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         Interface_Static::SetIVal("read.precision.mode", 0);
@@ -346,6 +352,8 @@ OCCTShapeRef OCCTImportSTEPWithUnitProgress(const char* path, double unitInMeter
                                               bool* outCancelled) {
     clearCancelOut(outCancelled);
     if (!path) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         reader.SetSystemLengthUnit(unitInMeters);
@@ -427,6 +435,8 @@ OCCTDocumentRef OCCTDocumentLoadSTEPProgress(const char* path,
                                                bool* outCancelled) {
     clearCancelOut(outCancelled);
     if (!path) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     OCCTDocument* document = nullptr;
     try {
         document = new OCCTDocument();
@@ -507,6 +517,8 @@ bool OCCTExportSTEPWithModeProgress(OCCTShapeRef shape, const char* path, int32_
                                       const OCCTImportProgress* ctx, bool* outCancelled) {
     clearCancelOut(outCancelled);
     if (!shape || !path) return false;
+    // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> deLock(igesMutex());
     try {
         STEPControl_Writer writer;
         Interface_Static::SetCVal("write.step.schema", "AP214");
@@ -571,6 +583,8 @@ OCCTDocumentRef OCCTDocumentLoadSTEPWithModesProgress(const char* path,
                                                         bool* outCancelled) {
     clearCancelOut(outCancelled);
     if (!path) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     OCCTDocument* document = nullptr;
     try {
         document = new OCCTDocument();
@@ -606,6 +620,8 @@ OCCTDocumentRef OCCTDocumentLoadSTEPWithModesProgress(const char* path,
 OCCTShapeRef OCCTImportSTEP(const char* path) {
     if (!path) return nullptr;
 
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         IFSelect_ReturnStatus status = reader.ReadFile(path);
@@ -647,6 +663,8 @@ bool OCCTShapeIsValidSolid(OCCTShapeRef shape) {
 OCCTShapeRef OCCTImportSTEPRobust(const char* path) {
     if (!path) return nullptr;
 
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
 
@@ -715,6 +733,8 @@ OCCTSTEPImportResult OCCTImportSTEPWithDiagnostics(const char* path) {
     OCCTSTEPImportResult result = {nullptr, -1, -1, false, false, false, 0};
     if (!path) return result;
 
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
 
@@ -781,6 +801,8 @@ OCCTSTEPImportResult OCCTImportSTEPWithDiagnostics(const char* path) {
 
 bool OCCTStepTidyOptimize(const char* inputPath, const char* outputPath) {
     if (!inputPath || !outputPath) return false;
+    // Serialize all DE reads/writes: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> deLock(igesMutex());
     try {
         STEPControl_Reader reader;
         if (reader.ReadFile(inputPath) != IFSelect_RetDone) return false;
@@ -1022,6 +1044,8 @@ bool OCCTExportSTEPCleanDuplicates(OCCTShapeRef shape, const char* path, int32_t
 
 int32_t OCCTSTEPReaderNbRoots(const char* path) {
     if (!path) return 0;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         IFSelect_ReturnStatus status = reader.ReadFile(path);
@@ -1032,6 +1056,8 @@ int32_t OCCTSTEPReaderNbRoots(const char* path) {
 
 OCCTShapeRef OCCTImportSTEPRoot(const char* path, int32_t rootIndex) {
     if (!path || rootIndex < 1) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         IFSelect_ReturnStatus status = reader.ReadFile(path);
@@ -1047,6 +1073,8 @@ OCCTShapeRef OCCTImportSTEPRoot(const char* path, int32_t rootIndex) {
 
 OCCTShapeRef OCCTImportSTEPWithUnit(const char* path, double unitInMeters) {
     if (!path) return nullptr;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         reader.SetSystemLengthUnit(unitInMeters);
@@ -1061,6 +1089,8 @@ OCCTShapeRef OCCTImportSTEPWithUnit(const char* path, double unitInMeters) {
 
 int32_t OCCTSTEPReaderNbShapes(const char* path) {
     if (!path) return 0;
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     try {
         STEPControl_Reader reader;
         IFSelect_ReturnStatus status = reader.ReadFile(path);
@@ -1077,6 +1107,8 @@ OCCTDocumentRef OCCTDocumentLoadSTEPWithModes(const char* path,
     bool propsMode, bool gdtMode, bool matMode) {
     if (!path) return nullptr;
 
+    // Serialize all DE reads: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> igesLock(igesMutex());
     OCCTDocument* document = nullptr;
     try {
         document = new OCCTDocument();
@@ -1121,6 +1153,8 @@ bool OCCTDocumentWriteSTEPWithModes(OCCTDocumentRef doc, const char* path,
     bool dimTolMode, bool materialMode) {
     if (!doc || !path || doc->doc.IsNull()) return false;
 
+    // Serialize all DE writes: STEP/IGES share Interface_Static globals (#181-B, #359).
+    std::lock_guard<std::mutex> deLock(igesMutex());
     try {
         STEPCAFControl_Writer writer;
         writer.SetColorMode(colorMode);

--- a/Tests/OCCTThreadTests/Issue359STEPThreadSafetyTests.swift
+++ b/Tests/OCCTThreadTests/Issue359STEPThreadSafetyTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// Issue #359: #181-B (fixed by PR #184) serialized STEP/IGES *writers* on a shared
+// igesMutex(), since STEPControl/STEPCAFControl/IGESControl readers and writers all
+// touch OCCT's process-global Interface_Static parameter table. That fix never
+// covered STEP *import* (the original #181-B report was specifically about
+// concurrent writeSTEP), and 3 STEP writer entry points added afterward
+// (OCCTExportSTEPWithName, OCCTExportSTEPWithModeProgress, OCCTDocumentWriteSTEPWithModes)
+// never picked up the lock either. Found while scoping #342 (bridge-level
+// thread-handling contract) by auditing every function touching
+// STEPControl_Reader/Writer or STEPCAFControl_Reader/Writer for igesMutex()
+// coverage -- 18 functions were missing it. Fixed by adding igesMutex() to all 18,
+// matching the existing #181-B convention (bridge-only, no kernel change).
+//
+// Like #341's equivalent suite, this is a basic regression exerciser through the
+// Swift API, not the authoritative verification -- a std::mutex-guarded critical
+// section either serializes correctly or doesn't; it isn't the kind of race that
+// reliably manifests as an observable Swift-level failure at modest concurrency
+// without sanitizer instrumentation. Mixing concurrent imports and exports here at
+// least confirms the fix doesn't deadlock (all 18 sites lock a single
+// non-recursive std::mutex with no nested acquisition) and doesn't regress
+// ordinary round-trip correctness.
+@Suite("Issue #359 — concurrent STEP import/export is thread-safe (igesMutex)")
+struct Issue359STEPThreadSafetyTests {
+
+    @Test("Concurrent STEP import + export round-trips all succeed with a non-empty shape")
+    func concurrentSTEPRoundTripsSucceed() async throws {
+        struct Outcome: Sendable {
+            var writeFailed = 0, readFailed = 0, emptyShape = 0
+        }
+
+        let agg = await withTaskGroup(of: Outcome.self) { group -> Outcome in
+            for taskIndex in 0..<8 {
+                group.addTask {
+                    var o = Outcome()
+                    for i in 0..<15 {
+                        let box = Shape.box(width: 10, height: 20, depth: 30)!
+                        let path = NSTemporaryDirectory() + "occt359_step_\(taskIndex)_\(i).step"
+                        let url = URL(fileURLWithPath: path)
+                        defer { try? FileManager.default.removeItem(at: url) }
+
+                        do {
+                            try Exporter.writeSTEP(shape: box, to: url, modelType: .asIs)
+                        } catch {
+                            o.writeFailed += 1
+                            continue
+                        }
+
+                        guard let loaded = try? Shape.load(from: url) else {
+                            o.readFailed += 1
+                            continue
+                        }
+                        if loaded.subShapeCount(ofType: .face) == 0 { o.emptyShape += 1 }
+                    }
+                    return o
+                }
+            }
+            var total = Outcome()
+            for await o in group {
+                total.writeFailed += o.writeFailed
+                total.readFailed += o.readFailed
+                total.emptyShape += o.emptyShape
+            }
+            return total
+        }
+
+        #expect(agg.writeFailed == 0, "concurrent STEP writes failed (expected 0 of 120)")
+        #expect(agg.readFailed == 0, "concurrent STEP reads failed (expected 0 of 120)")
+        #expect(agg.emptyShape == 0, "concurrent STEP reads produced an empty shape (expected 0 of 120)")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,45 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.11
+## Current: v1.15.12
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.12 (July 2026) — fix (bridge): STEP import + 3 later-added STEP writers missing the DE mutex — #181-B's fix didn't fully hold (#359)
+
+Found while scoping #342 (bridge-level thread-handling contract). #181-B (fixed by PR #184) found
+that `STEPControl`/`STEPCAFControl`/`IGESControl` readers and writers share OCCT's process-global
+`Interface_Static` parameter table, and serialized every STEP/IGES *writer* entry point on a shared
+`igesMutex()` — the closing comment claimed this "serializes *all* of them." Auditing every function
+in `OCCTBridge_IO.mm`/`OCCTBridge_Document.mm` that constructs a `STEPControl_Reader`/`Writer` or
+`STEPCAFControl_Reader`/`Writer`, or calls `Interface_Static::Set*` directly, found that claim didn't
+hold: **18 functions were missing `igesMutex()`** — every STEP import function (all added after PR
+#184, across the "v0.58.0 STEP Full Coverage" and "v0.168.0 Progress" batches; the original #181-B
+report was specifically about concurrent writes, so import was never in scope), plus 3 STEP export
+functions added after PR #184 shipped (`OCCTExportSTEPWithName`, `OCCTExportSTEPWithModeProgress`,
+`OCCTDocumentWriteSTEPWithModes`).
+
+**Fix:** added `igesMutex()` to all 18 sites, matching the existing `#181-B` convention. Bridge-only,
+no kernel change, no `OCCT.xcframework` rebuild. New regression suite
+`Issue359STEPThreadSafetyTests` (`Tests/OCCTThreadTests/`) exercises concurrent STEP import/export
+through the Swift API — like #341's equivalent suite, this is a basic exerciser (confirms no deadlock
+and no round-trip regression), not the authoritative verification; a missing-lock bug on a
+non-recursive `std::mutex` doesn't reliably manifest as an observable Swift-level failure at modest
+concurrency. Full `swift test` (4424 tests) clean, both source and `OCCTSWIFT_BRIDGE_PREBUILT=1`
+build paths.
+
+Not the same issue as #280 (constructing a `STEPCAFControl_Reader` poisons subsequent STEP writes) —
+confirmed during triage that #280 is a different, already-fixed mechanism (not `Interface_Static`-
+related, resolved via a kernel patch in v1.10.1).
+
+**Binary release** — `OCCTBridge.xcframework` (the opt-in prebuilt bridge from #339) changed, so
+`Package.swift`'s URL/checksum are bumped to this release; consumers building with
+`OCCTSWIFT_BRIDGE_PREBUILT=1` need the new release asset. `OCCT.xcframework` is unchanged (still
+v1.15.11, no kernel patch this release).
 
 ### v1.15.11 (July 2026) — fix (kernel): CDM_Application::myMetaDataLookUpTable + CDM_MetaData field races under concurrent document save/close (#353)
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -151,6 +151,29 @@ investigation, tracked separately in #349. Plain shape-format I/O (STEP/IGES/BRE
 glTF) is unaffected — this only covers the three OCAF (`.bcaf`/`.xcaf`-style binary/XML
 document) persistence entry points.
 
+### STEP/IGES data-exchange thread safety (issues #181, #359)
+
+Every STEP and IGES import/export call is **safe to call concurrently** as of v1.15.12 — no
+lock needed on your side. `STEPControl`/`STEPCAFControl`/`IGESControl` readers and writers all
+read and write OCCT's process-global `Interface_Static` parameter table
+([Open-Cascade-SAS/OCCT#1179](https://github.com/Open-Cascade-SAS/OCCT/issues/1179)), so the
+bridge serializes every data-exchange (DE) call on a single shared mutex (`igesMutex()` in
+`OCCTBridge_IO.mm`). This is a wrapper-level fix, not an OCCT kernel patch — OCCT's own DE
+readers/writers aren't thread-safe by design, same as issue #298's original framing.
+
+- **#181-B** (fixed via PR #184) found this for concurrent `writeSTEP`: two STEP writes on
+  different threads SIGSEGV'd inside `STEPCAFControl_Writer`/`STEPControl_Writer` at once. The
+  fix serialized the STEP/IGES *writer* entry points that existed at the time.
+- **#359** found the same lock never covered STEP *import* at all (the #181-B report was
+  specifically about writes), and 3 writer entry points added after PR #184 shipped
+  (`OCCTExportSTEPWithName`, `OCCTExportSTEPWithModeProgress`, `OCCTDocumentWriteSTEPWithModes`)
+  never picked up the lock either — 18 functions total. Fixed by extending `igesMutex()`
+  coverage to all 18, matching the existing convention.
+
+Distinct from issue #280 (constructing a `STEPCAFControl_Reader` poisons subsequent STEP
+writes) — that's a different, already-fixed mechanism confirmed *not* `Interface_Static`-related,
+resolved via an upstream kernel patch in v1.10.1.
+
 ## ThreadSanitizer gate for concurrency-touching changes
 
 Every thread-safety kernel bug this project has found and fixed (#298, #341, #344, #349)


### PR DESCRIPTION
## Summary
- #181-B (PR #184) serialized STEP/IGES *writers* on `igesMutex()` since `STEPControl`/`STEPCAFControl`/`IGESControl` readers and writers all share OCCT's process-global `Interface_Static` parameter table — the closing comment claimed the fix "serializes *all* of them."
- That claim didn't hold. Audited every function in `OCCTBridge_IO.mm`/`OCCTBridge_Document.mm` touching `STEPControl_Reader`/`Writer` or `STEPCAFControl_Reader`/`Writer`, or calling `Interface_Static::Set*` directly: **18 functions were missing `igesMutex()`** — every STEP import function (never in scope for the original concurrent-*write*STEP report; all added after PR #184), plus 3 STEP export functions added afterward (`OCCTExportSTEPWithName`, `OCCTExportSTEPWithModeProgress`, `OCCTDocumentWriteSTEPWithModes`).
- Fix: add `igesMutex()` to all 18 sites, matching the existing convention. Bridge-only, no kernel change.
- New regression suite `Issue359STEPThreadSafetyTests` (`Tests/OCCTThreadTests/`) — like #341's equivalent, a basic exerciser (confirms no deadlock / no round-trip regression), not the authoritative verification for a lock-coverage bug.
- Checked #280 (STEP read "poisoning" later STEP writes) during triage — confirmed unrelated: different, already-fixed mechanism, not `Interface_Static`-related.
- `OCCTBridge.xcframework` (opt-in prebuilt, #339) rebuilt; `Package.swift` URL/checksum bumped to v1.15.12. `OCCT.xcframework` unchanged (still v1.15.11).
- Docs: `docs/CHANGELOG.md` (v1.15.12 entry), `docs/thread-safety.md` (new "STEP/IGES data-exchange thread safety" section).

## Test plan
- [x] `swift build` clean (source bridge)
- [x] `OCCTSWIFT_BRIDGE_PREBUILT=1 swift build` clean (prebuilt bridge)
- [x] New `Issue359STEPThreadSafetyTests` suite passes on both build paths
- [x] Full `swift test` — 4424 tests / 1283 suites, clean

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)