### PR TITLE
fix(#361): TNaming_Scope shared instance + Font_FontMgr font-list cache races — v1.15.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,8 +79,8 @@ let occtBridgeTarget: Target = useBridgeLocalBinary
     // the OCCT.xcframework convention above.
     ? .binaryTarget(
         name: "OCCTBridge",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.12/OCCTBridge.xcframework.zip",
-        checksum: "6a53ec32f781916edf0c6ef6b68090bc1804d63dcc90d767953aebfcc165fa8d"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.13/OCCTBridge.xcframework.zip",
+        checksum: "67490e717cc9778e626a669b3044920a826dac7eb4272797ea7f0f21be16071f"
     )
     : .target(
         name: "OCCTBridge",

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -6061,11 +6061,20 @@ static TNaming_Scope& getDocNamingScope() {
     return scope;
 }
 
+// #361: getDocNamingScope() is one process-wide instance shared across every
+// OCCTDocument; its NCollection_Map<TDF_Label> myValid has no internal
+// synchronization, so every access below is serialized on docNamingScopeMutex().
+std::mutex& docNamingScopeMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
 bool OCCTDocumentNamingScopeValid(OCCTDocumentRef doc, int64_t labelId) {
     if (!doc || doc->doc.IsNull()) return false;
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
+        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
         getDocNamingScope().Valid(label);
         return true;
     } catch (...) { return false; }
@@ -6076,6 +6085,7 @@ bool OCCTDocumentNamingScopeValidChildren(OCCTDocumentRef doc, int64_t labelId, 
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
+        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
         getDocNamingScope().ValidChildren(label, withRoot);
         return true;
     } catch (...) { return false; }
@@ -6086,6 +6096,7 @@ bool OCCTDocumentNamingScopeIsValid(OCCTDocumentRef doc, int64_t labelId) {
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
+        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
         return getDocNamingScope().IsValid(label);
     } catch (...) { return false; }
 }
@@ -6095,6 +6106,7 @@ bool OCCTDocumentNamingScopeUnvalid(OCCTDocumentRef doc, int64_t labelId) {
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
+        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
         getDocNamingScope().Unvalid(label);
         return true;
     } catch (...) { return false; }
@@ -6102,12 +6114,14 @@ bool OCCTDocumentNamingScopeUnvalid(OCCTDocumentRef doc, int64_t labelId) {
 
 void OCCTDocumentNamingScopeClear(OCCTDocumentRef doc) {
     try {
+        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
         getDocNamingScope().ClearValid();
     } catch (...) {}
 }
 
 int32_t OCCTDocumentNamingScopeValidCount(OCCTDocumentRef doc) {
     try {
+        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
         return getDocNamingScope().GetValid().Extent();
     } catch (...) { return 0; }
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -204,6 +204,16 @@ std::mutex& igesMutex();
 // OCCTDocumentSaveOCAF/OCCTDocumentSaveOCAFInPlace). Interim mitigation until a
 // kernel fix lands — matches the #298/#341 PR1→PR2 pattern.
 std::mutex& ocafStoreMutex();
+// #361: getDocNamingScope() shares one process-wide TNaming_Scope instance across
+// every OCCTDocument; its NCollection_Map<TDF_Label> myValid has no internal
+// synchronization, so two threads touching unrelated documents' naming scope race
+// on the shared map. Bridge-only (no OCCT source involved).
+std::mutex& docNamingScopeMutex();
+// #361: g_fontList/g_fontListPopulated (OCCTBridge_Visualization.mm) are plain
+// globals with an unsynchronized check-then-act lazy-init, plus
+// OCCTFontMgrInitDatabase() can reassign both at any time from any thread.
+// Bridge-only (no OCCT source involved).
+std::mutex& fontListMutex();
 
 // === OCCT signal handling ===
 //

--- a/Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
@@ -1787,7 +1787,16 @@ bool OCCTDateIsLeap(int year) {
 static NCollection_List<Handle(Font_SystemFont)> g_fontList;
 static bool g_fontListPopulated = false;
 
-static void ensureFontList() {
+// #361: g_fontList/g_fontListPopulated are shared process-wide with no internal
+// synchronization, and OCCTFontMgrInitDatabase() can reassign both at any time —
+// every access below (population and read) is serialized on fontListMutex().
+std::mutex& fontListMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+// Caller must hold fontListMutex().
+static void ensureFontListLocked() {
     if (!g_fontListPopulated) {
         Handle(Font_FontMgr) mgr = Font_FontMgr::GetInstance();
         mgr->InitFontDataBase();
@@ -1798,6 +1807,7 @@ static void ensureFontList() {
 
 void OCCTFontMgrInitDatabase(void) {
     try {
+        std::lock_guard<std::mutex> fontLock(fontListMutex());
         Handle(Font_FontMgr) mgr = Font_FontMgr::GetInstance();
         mgr->InitFontDataBase();
         g_fontList = mgr->GetAvailableFonts();
@@ -1807,14 +1817,16 @@ void OCCTFontMgrInitDatabase(void) {
 
 int OCCTFontMgrFontCount(void) {
     try {
-        ensureFontList();
+        std::lock_guard<std::mutex> fontLock(fontListMutex());
+        ensureFontListLocked();
         return static_cast<int>(g_fontList.Size());
     } catch (...) { return 0; }
 }
 
 const char *_Nullable OCCTFontMgrFontName(int index) {
     try {
-        ensureFontList();
+        std::lock_guard<std::mutex> fontLock(fontListMutex());
+        ensureFontListLocked();
         int i = 0;
         for (auto it = g_fontList.cbegin(); it != g_fontList.cend(); ++it, ++i) {
             if (i == index) {
@@ -1831,7 +1843,8 @@ const char *_Nullable OCCTFontMgrFontName(int index) {
 
 const char *_Nullable OCCTFontMgrFontPath(int index, int aspect) {
     try {
-        ensureFontList();
+        std::lock_guard<std::mutex> fontLock(fontListMutex());
+        ensureFontListLocked();
         if (aspect < 0 || aspect > 3) return nullptr;
         Font_FontAspect fa = (Font_FontAspect)aspect;
         int i = 0;
@@ -1851,7 +1864,8 @@ const char *_Nullable OCCTFontMgrFontPath(int index, int aspect) {
 
 bool OCCTFontMgrFontHasAspect(int index, int aspect) {
     try {
-        ensureFontList();
+        std::lock_guard<std::mutex> fontLock(fontListMutex());
+        ensureFontListLocked();
         if (aspect < 0 || aspect > 3) return false;
         Font_FontAspect fa = (Font_FontAspect)aspect;
         int i = 0;

--- a/Tests/OCCTThreadTests/Issue361SharedSingletonThreadSafetyTests.swift
+++ b/Tests/OCCTThreadTests/Issue361SharedSingletonThreadSafetyTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// Issue #361: two more process-global bridge singletons found scoping #342, both matching
+// the #341/#344/#353 shape (unsynchronized shared state, mutated by callers who have no
+// reason to expect they're touching anything shared).
+//
+// A. getDocNamingScope() (OCCTBridge_Document.mm) returns one TNaming_Scope instance shared
+//    across every OCCTDocument. TNaming_Scope's own NCollection_Map<TDF_Label> myValid has no
+//    internal synchronization -- two threads calling namingScopeValid/IsValid/etc. on two
+//    unrelated documents race on that shared map. Fixed with docNamingScopeMutex(), held for
+//    the duration of every access.
+//
+// B. Font_FontMgr's font-list cache (OCCTBridge_Visualization.mm): g_fontList/
+//    g_fontListPopulated is an unsynchronized check-then-act lazy-init, and
+//    FontManager.initDatabase() can reassign both at any time from any thread, racing an
+//    in-progress read in fontName(at:)/fontPath(at:)/fontHasAspect(at:). Fixed with
+//    fontListMutex(), held for the duration of every access (population and read).
+//
+// Like #341/#359's equivalent suites, this is a basic exerciser through the Swift API --
+// confirms no deadlock and no functional regression -- not the authoritative verification for
+// a lock-coverage bug on a plain (non-recursive) std::mutex.
+@Suite("Issue #361 — shared singletons (TNaming_Scope, Font_FontMgr) are thread-safe")
+struct Issue361SharedSingletonThreadSafetyTests {
+
+    @Test("Concurrent naming-scope access across independent documents doesn't crash or deadlock")
+    func concurrentNamingScopeAccessSucceeds() async throws {
+        struct Outcome: Sendable {
+            var failures = 0
+        }
+
+        let agg = await withTaskGroup(of: Outcome.self) { group -> Outcome in
+            for _ in 0..<8 {
+                group.addTask {
+                    var o = Outcome()
+                    for _ in 0..<20 {
+                        guard let doc = Document.create() else { o.failures += 1; continue }
+                        let box = Shape.box(width: 5, height: 5, depth: 5)!
+                        let labelId = doc.addShape(box, makeAssembly: false)
+
+                        doc.namingScopeValid(labelId: labelId)
+                        _ = doc.namingScopeIsValid(labelId: labelId)
+                        doc.namingScopeValidChildren(labelId: labelId)
+                        _ = doc.namingScopeValidCount
+                        doc.namingScopeUnvalid(labelId: labelId)
+                        doc.namingScopeClear()
+                    }
+                    return o
+                }
+            }
+            var total = Outcome()
+            for await o in group { total.failures += o.failures }
+            return total
+        }
+
+        #expect(agg.failures == 0, "concurrent document creation failed (expected 0 of 160)")
+    }
+
+    @Test("Concurrent font-database init + queries don't crash or deadlock")
+    func concurrentFontQueriesSucceed() async throws {
+        await withTaskGroup(of: Void.self) { group in
+            for taskIndex in 0..<8 {
+                group.addTask {
+                    for i in 0..<10 {
+                        if (taskIndex + i) % 3 == 0 {
+                            FontManager.initDatabase()
+                        }
+                        let count = FontManager.fontCount
+                        if count > 0 {
+                            let idx = i % count
+                            _ = FontManager.fontName(at: idx)
+                            _ = FontManager.fontPath(at: idx)
+                            _ = FontManager.fontHasAspect(at: idx, aspect: .regular)
+                        }
+                    }
+                }
+            }
+        }
+        // No #expect needed beyond "didn't crash/deadlock" -- font availability is
+        // environment-dependent (headless CI may have zero system fonts registered).
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,41 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.12
+## Current: v1.15.13
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.13 (July 2026) — fix (bridge): two more unsynchronized process-global singletons — TNaming_Scope shared instance, Font_FontMgr font-list cache (#361)
+
+Found continuing the #342 (bridge-level thread-handling contract) scoping pass that produced #359 —
+an earlier survey flagged two `needs-investigation` spots as high-confidence pattern matches for the
+#341/#344/#353 shape; verified both directly this release before fixing.
+
+- **`getDocNamingScope()`** (`OCCTBridge_Document.mm`) returns one process-wide `TNaming_Scope`
+  instance shared across every `OCCTDocument`. Construction is safe (C++11 magic statics), but
+  `TNaming_Scope`'s own `NCollection_Map<TDF_Label> myValid` has no internal synchronization —
+  two threads calling `namingScopeValid`/`IsValid`/`ValidChildren`/`Unvalid`/`ClearValid`/
+  `ValidCount` on two *unrelated* documents race on that shared map.
+- **`Font_FontMgr`'s font-list cache** (`OCCTBridge_Visualization.mm`): `g_fontList`/
+  `g_fontListPopulated` is a classic unsynchronized check-then-act lazy-init, and the public
+  `OCCTFontMgrInitDatabase()` can reassign both at any time from any thread, racing an
+  in-progress iteration in any of the read-side functions.
+
+**Fix:** bridge-only, matching the established #341/#344/#353 pattern — a dedicated
+`std::mutex` per shared resource (`docNamingScopeMutex()`, `fontListMutex()`), held for the
+duration of every access. No OCCT kernel change needed since both races are in bridge-owned
+static state, not inside OCCT's own classes. New regression suite
+`Issue361SharedSingletonThreadSafetyTests` (`Tests/OCCTThreadTests/`) — a basic exerciser, not the
+authoritative verification, same honesty caveat as #341/#359's equivalent suites. Full `swift test`
+(4426 tests) clean, both source and `OCCTSWIFT_BRIDGE_PREBUILT=1` build paths.
+
+**Binary release** — `OCCTBridge.xcframework` (the opt-in prebuilt bridge from #339) changed again,
+so `Package.swift`'s URL/checksum are bumped to this release. `OCCT.xcframework` is unchanged
+(still v1.15.11, no kernel patch this release).
 
 ### v1.15.12 (July 2026) — fix (bridge): STEP import + 3 later-added STEP writers missing the DE mutex — #181-B's fix didn't fully hold (#359)
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -174,6 +174,23 @@ Distinct from issue #280 (constructing a `STEPCAFControl_Reader` poisons subsequ
 writes) — that's a different, already-fixed mechanism confirmed *not* `Interface_Static`-related,
 resolved via an upstream kernel patch in v1.10.1.
 
+### Naming-scope validation and font enumeration thread safety (issue #361)
+
+Two more process-global bridge singletons, found scoping #342, both **safe to call concurrently**
+as of v1.15.13 — bridge-only fixes, no OCCT kernel change needed since the shared state lives in
+bridge-owned globals, not inside OCCT's own classes.
+
+- **`Document.namingScopeValid`/`namingScopeIsValid`/`namingScopeValidChildren`/`namingScopeUnvalid`/
+  `namingScopeClear`/`namingScopeValidCount`** all go through one process-wide `TNaming_Scope`
+  instance shared across every `Document`. `TNaming_Scope`'s own `NCollection_Map<TDF_Label>
+  myValid` has no internal synchronization, so two threads calling any of these on two *unrelated*
+  documents raced on that shared map. Fixed via `docNamingScopeMutex()` in
+  `OCCTBridge_Document.mm`, held for every access.
+- **`FontManager`** (`fontCount`, `fontName`, `fontPath`, `fontHasAspect`, `initDatabase`) shares
+  a process-global font-list cache with an unsynchronized check-then-act lazy-init, plus
+  `initDatabase()` could reassign the cache at any time, racing an in-progress read. Fixed via
+  `fontListMutex()` in `OCCTBridge_Visualization.mm`, held for every access (population and read).
+
 ## ThreadSanitizer gate for concurrency-touching changes
 
 Every thread-safety kernel bug this project has found and fixed (#298, #341, #344, #349)


### PR DESCRIPTION
## Summary
- Found continuing the #342 (bridge-level thread-handling contract) scoping pass that produced #359. Two more process-global bridge singletons, both matching the #341/#344/#353 shape (unsynchronized state shared across unrelated callers).
- **`getDocNamingScope()`** (`OCCTBridge_Document.mm`): one process-wide `TNaming_Scope` instance shared across every `OCCTDocument`. Construction is safe (C++11 magic statics), but `TNaming_Scope`'s own `NCollection_Map<TDF_Label> myValid` has zero internal synchronization — two threads calling `namingScopeValid`/`IsValid`/`ValidChildren`/`Unvalid`/`ClearValid`/`ValidCount` on two *unrelated* documents race on that shared map.
- **`Font_FontMgr`'s font-list cache** (`OCCTBridge_Visualization.mm`): `g_fontList`/`g_fontListPopulated` is an unsynchronized check-then-act lazy-init, and the public `OCCTFontMgrInitDatabase()` can reassign both at any time from any thread, racing an in-progress read.
- Fix: bridge-only, matching the established convention — `docNamingScopeMutex()`/`fontListMutex()`, held for every access. No OCCT kernel change (both races are in bridge-owned static state).
- New regression suite `Issue361SharedSingletonThreadSafetyTests` (`Tests/OCCTThreadTests/`).
- `OCCTBridge.xcframework` (opt-in prebuilt, #339) rebuilt; `Package.swift` URL/checksum bumped to v1.15.13. `OCCT.xcframework` unchanged (still v1.15.11).
- Docs: `docs/CHANGELOG.md` (v1.15.13 entry), `docs/thread-safety.md` (new section).

## Test plan
- [x] `swift build` clean (source bridge)
- [x] `OCCTSWIFT_BRIDGE_PREBUILT=1 swift build` clean (prebuilt bridge)
- [x] New `Issue361SharedSingletonThreadSafetyTests` suite passes on both build paths
- [x] Full `swift test` — 4426 tests / 1284 suites, clean

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)