### PR TITLE
fix(#363): move naming scope to a per-Document field, not a shared instance — v1.15.14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,8 +79,8 @@ let occtBridgeTarget: Target = useBridgeLocalBinary
     // the OCCT.xcframework convention above.
     ? .binaryTarget(
         name: "OCCTBridge",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.13/OCCTBridge.xcframework.zip",
-        checksum: "67490e717cc9778e626a669b3044920a826dac7eb4272797ea7f0f21be16071f"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.14/OCCTBridge.xcframework.zip",
+        checksum: "64cfc4fb7b0351655285363df07d397d9218322af21f8eaec23ad520f510fadb"
     )
     : .target(
         name: "OCCTBridge",

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -6053,29 +6053,23 @@ void OCCTFunctionDriverTableClear() {
 }
 
 // MARK: - TNaming_Scope (v0.90.0)
-
-#include <TNaming_Scope.hxx>
-
-static TNaming_Scope& getDocNamingScope() {
-    static TNaming_Scope scope(true);
-    return scope;
-}
-
-// #361: getDocNamingScope() is one process-wide instance shared across every
-// OCCTDocument; its NCollection_Map<TDF_Label> myValid has no internal
-// synchronization, so every access below is serialized on docNamingScopeMutex().
-std::mutex& docNamingScopeMutex() {
-    static std::mutex mutex;
-    return mutex;
-}
+//
+// #363: naming scope lives on doc->namingScope (a per-OCCTDocument field, see
+// OCCTBridge_Internal.h) rather than one shared process-wide instance. #361's
+// docNamingScopeMutex() fix made concurrent access memory-safe but left the
+// underlying design bug intact: every document shared the same TNaming_Scope, so
+// one document's valid-label set could leak into another's regardless of locking.
+// A per-document field removes the sharing (and the need for a lock) instead of
+// just synchronizing access to it -- same principle as gkv311's upstream review of
+// #341's AutoNamingScope fix (OCCT#1388): state that was wrongly made global/shared
+// should be relocated to its actual owner, not locked in place.
 
 bool OCCTDocumentNamingScopeValid(OCCTDocumentRef doc, int64_t labelId) {
     if (!doc || doc->doc.IsNull()) return false;
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
-        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
-        getDocNamingScope().Valid(label);
+        doc->namingScope.Valid(label);
         return true;
     } catch (...) { return false; }
 }
@@ -6085,8 +6079,7 @@ bool OCCTDocumentNamingScopeValidChildren(OCCTDocumentRef doc, int64_t labelId, 
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
-        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
-        getDocNamingScope().ValidChildren(label, withRoot);
+        doc->namingScope.ValidChildren(label, withRoot);
         return true;
     } catch (...) { return false; }
 }
@@ -6096,8 +6089,7 @@ bool OCCTDocumentNamingScopeIsValid(OCCTDocumentRef doc, int64_t labelId) {
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
-        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
-        return getDocNamingScope().IsValid(label);
+        return doc->namingScope.IsValid(label);
     } catch (...) { return false; }
 }
 
@@ -6106,23 +6098,22 @@ bool OCCTDocumentNamingScopeUnvalid(OCCTDocumentRef doc, int64_t labelId) {
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
-        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
-        getDocNamingScope().Unvalid(label);
+        doc->namingScope.Unvalid(label);
         return true;
     } catch (...) { return false; }
 }
 
 void OCCTDocumentNamingScopeClear(OCCTDocumentRef doc) {
+    if (!doc || doc->doc.IsNull()) return;
     try {
-        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
-        getDocNamingScope().ClearValid();
+        doc->namingScope.ClearValid();
     } catch (...) {}
 }
 
 int32_t OCCTDocumentNamingScopeValidCount(OCCTDocumentRef doc) {
+    if (!doc || doc->doc.IsNull()) return 0;
     try {
-        std::lock_guard<std::mutex> scopeLock(docNamingScopeMutex());
-        return getDocNamingScope().GetValid().Extent();
+        return doc->namingScope.GetValid().Extent();
     } catch (...) { return 0; }
 }
 // MARK: - TNaming_Translator (v0.90.0)

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -47,6 +47,7 @@
 #include <XCAFDoc_ColorTool.hxx>
 #include <XCAFDoc_VisMaterialTool.hxx>
 #include <TDF_Label.hxx>
+#include <TNaming_Scope.hxx>
 
 // === Foundation struct definitions ===
 
@@ -94,6 +95,13 @@ struct OCCTDocument {
     Handle(XCAFDoc_ColorTool) colorTool;
     Handle(XCAFDoc_VisMaterialTool) materialTool;
     std::vector<TDF_Label> labels;  // Label registry (index = labelId)
+    // #363: per-document, not a shared process-wide static (see docNamingScopeMutex's
+    // old comment / issue #361) -- TNaming_Scope's own NCollection_Map<TDF_Label>
+    // myValid has no internal synchronization, and (independent of the race) sharing
+    // one instance across every document meant one document's valid-label set could
+    // leak into another's. Each OCCTDocument owns its own scope instead; the WithValid
+    // ctor arg matches the shared instance's prior behavior (map-defined scope).
+    TNaming_Scope namingScope{true};
 
     OCCTDocument() {
         app = XCAFApp_Application::GetApplication();
@@ -204,11 +212,10 @@ std::mutex& igesMutex();
 // OCCTDocumentSaveOCAF/OCCTDocumentSaveOCAFInPlace). Interim mitigation until a
 // kernel fix lands — matches the #298/#341 PR1→PR2 pattern.
 std::mutex& ocafStoreMutex();
-// #361: getDocNamingScope() shares one process-wide TNaming_Scope instance across
-// every OCCTDocument; its NCollection_Map<TDF_Label> myValid has no internal
-// synchronization, so two threads touching unrelated documents' naming scope race
-// on the shared map. Bridge-only (no OCCT source involved).
-std::mutex& docNamingScopeMutex();
+// #361/#363: naming-scope state moved to a per-OCCTDocument TNaming_Scope field
+// instead of one shared process-wide instance -- no lock needed, see OCCTDocument's
+// namingScope member above. (docNamingScopeMutex() existed briefly in v1.15.13 and
+// was removed once the shared-instance design itself was replaced.)
 // #361: g_fontList/g_fontListPopulated (OCCTBridge_Visualization.mm) are plain
 // globals with an unsynchronized check-then-act lazy-init, plus
 // OCCTFontMgrInitDatabase() can reassign both at any time from any thread.

--- a/Tests/OCCTThreadTests/Issue361SharedSingletonThreadSafetyTests.swift
+++ b/Tests/OCCTThreadTests/Issue361SharedSingletonThreadSafetyTests.swift
@@ -2,27 +2,63 @@ import Testing
 import Foundation
 @testable import OCCTSwift
 
-// Issue #361: two more process-global bridge singletons found scoping #342, both matching
-// the #341/#344/#353 shape (unsynchronized shared state, mutated by callers who have no
-// reason to expect they're touching anything shared).
+// Issue #361 (fixed further in #363): two more process-global bridge singletons found
+// scoping #342, both originally matching the #341/#344/#353 shape (unsynchronized shared
+// state, mutated by callers who have no reason to expect they're touching anything shared).
 //
-// A. getDocNamingScope() (OCCTBridge_Document.mm) returns one TNaming_Scope instance shared
-//    across every OCCTDocument. TNaming_Scope's own NCollection_Map<TDF_Label> myValid has no
-//    internal synchronization -- two threads calling namingScopeValid/IsValid/etc. on two
-//    unrelated documents race on that shared map. Fixed with docNamingScopeMutex(), held for
-//    the duration of every access.
+// A. getDocNamingScope() (OCCTBridge_Document.mm) originally returned one TNaming_Scope
+//    instance shared across every OCCTDocument. v1.15.13 (#361) made concurrent access to it
+//    memory-safe with docNamingScopeMutex() -- but that left the underlying design bug
+//    intact: every document shared the same TNaming_Scope, so document A's valid-label set
+//    could leak into document B's regardless of locking. Upstream reviewer gkv311's pushback
+//    on #341's analogous AutoNamingScope fix (OCCT#1388) prompted a second look: relocate the
+//    state to its actual owner instead of locking it in place. #363 moves naming scope onto a
+//    per-OCCTDocument field (doc->namingScope) -- no lock needed at all, since two threads
+//    working on two different Document instances no longer touch anything shared.
 //
 // B. Font_FontMgr's font-list cache (OCCTBridge_Visualization.mm): g_fontList/
 //    g_fontListPopulated is an unsynchronized check-then-act lazy-init, and
 //    FontManager.initDatabase() can reassign both at any time from any thread, racing an
 //    in-progress read in fontName(at:)/fontPath(at:)/fontHasAspect(at:). Fixed with
-//    fontListMutex(), held for the duration of every access (population and read).
+//    fontListMutex(), held for the duration of every access (population and read) -- this one
+//    stayed a mutex fix, since Font_FontMgr's system font registry is genuinely one
+//    process-wide resource by OCCT's own design, unlike TNaming_Scope above.
 //
-// Like #341/#359's equivalent suites, this is a basic exerciser through the Swift API --
-// confirms no deadlock and no functional regression -- not the authoritative verification for
-// a lock-coverage bug on a plain (non-recursive) std::mutex.
-@Suite("Issue #361 — shared singletons (TNaming_Scope, Font_FontMgr) are thread-safe")
+// Like #341/#359's equivalent suites, the concurrent tests below are basic exercisers through
+// the Swift API -- confirms no deadlock and no functional regression -- not the authoritative
+// verification for a lock-coverage bug. The isolation test IS authoritative for its specific
+// claim (two documents' naming scopes don't share state), since that's a deterministic,
+// single-threaded correctness property, not a race.
+@Suite("Issue #361/#363 — shared singletons (TNaming_Scope, Font_FontMgr) are thread-safe")
 struct Issue361SharedSingletonThreadSafetyTests {
+
+    @Test("Two documents' naming scopes are isolated (#363 — not just race-free, but not shared)")
+    func namingScopesAreIsolatedAcrossDocuments() throws {
+        let docA = try #require(Document.create())
+        let docB = try #require(Document.create())
+
+        let boxA = Shape.box(width: 5, height: 5, depth: 5)!
+        let boxB = Shape.box(width: 7, height: 7, depth: 7)!
+        let labelA = docA.addShape(boxA, makeAssembly: false)
+        let labelB = docB.addShape(boxB, makeAssembly: false)
+
+        docA.namingScopeValid(labelId: labelA)
+        docA.namingScopeValid(labelId: labelA)  // repeat marks are idempotent, not cumulative
+
+        #expect(docA.namingScopeValidCount == 1)
+        #expect(docB.namingScopeValidCount == 0,
+                "document B's valid count must not reflect document A's marks")
+        #expect(docA.namingScopeIsValid(labelId: labelA))
+        #expect(!docB.namingScopeIsValid(labelId: labelB))
+
+        docB.namingScopeValid(labelId: labelB)
+        #expect(docB.namingScopeValidCount == 1)
+
+        docA.namingScopeClear()
+        #expect(docA.namingScopeValidCount == 0)
+        #expect(docB.namingScopeValidCount == 1,
+                "clearing document A must not clear document B's scope")
+    }
 
     @Test("Concurrent naming-scope access across independent documents doesn't crash or deadlock")
     func concurrentNamingScopeAccessSucceeds() async throws {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,51 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.13
+## Current: v1.15.14
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.14 (July 2026) — fix (bridge): naming scope moved to a per-Document field instead of a shared instance + mutex (#363)
+
+Follow-up to #361, prompted by upstream reviewer feedback on #341's analogous fix
+([OCCT#1388](https://github.com/Open-Cascade-SAS/OCCT/pull/1388) review comment: "a mutex is not
+the right tool here... usage remains unprotected"). v1.15.13's `docNamingScopeMutex()` made
+concurrent access to the shared `TNaming_Scope` instance memory-safe, but left the underlying
+design bug in place: every `Document` still shared the *same* `TNaming_Scope`, so one document's
+valid-label set could leak into another's regardless of locking — a correctness bug, not just a
+race, that predates #361's fix.
+
+**Fix:** `TNaming_Scope` moved from a shared process-wide static to a field on `OCCTDocument`
+itself (`doc->namingScope`, `OCCTBridge_Internal.h`). No lock needed at all — two threads working
+on two different `Document` instances no longer touch anything shared. `docNamingScopeMutex()` was
+removed entirely; the six `OCCTDocumentNamingScope*` bridge functions now read/write
+`doc->namingScope` directly (two of the six, `OCCTDocumentNamingScopeClear`/`ValidCount`, gained a
+null-check on `doc` they'd never had — a symptom of the same bug, since the old implementation
+ignored the `doc` parameter entirely and touched the shared global instead).
+
+New test `namingScopesAreIsolatedAcrossDocuments` in `Issue361SharedSingletonThreadSafetyTests`
+directly verifies the correctness property (two documents' valid-label sets and counts stay
+independent) — a deterministic, single-threaded assertion, not a race-dependent exerciser. Full
+`swift test` (4427 tests) clean, both source and `OCCTSWIFT_BRIDGE_PREBUILT=1` build paths.
+
+`Font_FontMgr`'s font-list cache (`fontListMutex()`, also from #361) is unaffected — that mutex
+stays, since the system font registry is genuinely one process-wide resource by OCCT's own design,
+unlike `TNaming_Scope`. See `docs/thread-safety.md`'s updated section for the general lesson this
+draws: a mutex is the right tool only when state is *meant* to be shared; when it was wrongly made
+global in the first place, the fix is relocating ownership, not locking access to the wrong owner.
+
+**Binary release** — `OCCTBridge.xcframework` (the opt-in prebuilt bridge from #339) changed again,
+so `Package.swift`'s URL/checksum are bumped to this release. `OCCT.xcframework` is unchanged
+(still v1.15.11).
+
+Filed as a companion to [#363](https://github.com/SecondMouseAU/OCCTSwift/issues/363), which also
+tracks applying the same per-instance-override redesign to #341's upstream `AutoNamingScope` PR —
+that part is deliberately deferred: prototype + test locally first, then respond to the OCCT#1388
+review and update that PR, not the other way around.
 
 ### v1.15.13 (July 2026) — fix (bridge): two more unsynchronized process-global singletons — TNaming_Scope shared instance, Font_FontMgr font-list cache (#361)
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -174,18 +174,28 @@ Distinct from issue #280 (constructing a `STEPCAFControl_Reader` poisons subsequ
 writes) — that's a different, already-fixed mechanism confirmed *not* `Interface_Static`-related,
 resolved via an upstream kernel patch in v1.10.1.
 
-### Naming-scope validation and font enumeration thread safety (issue #361)
+### Naming-scope validation and font enumeration thread safety (issues #361, #363)
 
-Two more process-global bridge singletons, found scoping #342, both **safe to call concurrently**
-as of v1.15.13 — bridge-only fixes, no OCCT kernel change needed since the shared state lives in
-bridge-owned globals, not inside OCCT's own classes.
+Two more process-global bridge singletons, found scoping #342. Both are **safe to call
+concurrently** — bridge-only fixes, no OCCT kernel change needed since the shared state lives in
+bridge-owned globals, not inside OCCT's own classes — but they took different fixes, worth
+contrasting:
 
 - **`Document.namingScopeValid`/`namingScopeIsValid`/`namingScopeValidChildren`/`namingScopeUnvalid`/
-  `namingScopeClear`/`namingScopeValidCount`** all go through one process-wide `TNaming_Scope`
-  instance shared across every `Document`. `TNaming_Scope`'s own `NCollection_Map<TDF_Label>
-  myValid` has no internal synchronization, so two threads calling any of these on two *unrelated*
-  documents raced on that shared map. Fixed via `docNamingScopeMutex()` in
-  `OCCTBridge_Document.mm`, held for every access.
+  `namingScopeClear`/`namingScopeValidCount`** originally went through one process-wide
+  `TNaming_Scope` instance shared across every `Document`. v1.15.13 (#361) added a mutex
+  (`docNamingScopeMutex()`) around every access, which fixed the underlying race —
+  `TNaming_Scope`'s own `NCollection_Map<TDF_Label> myValid` has no internal synchronization — but
+  left a design bug in place: every `Document` still shared the *same* map, so one document's
+  valid-label set could leak into another's regardless of locking. Upstream reviewer feedback on
+  #341's analogous `AutoNamingScope` fix ([OCCT#1388](https://github.com/Open-Cascade-SAS/OCCT/pull/1388) —
+  "a mutex is not the right tool here... usage remains unprotected") prompted a second look:
+  **v1.15.14 (#363) moves naming scope onto a `TNaming_Scope` field on `OCCTDocument` itself** — no
+  lock needed at all, since two threads working on two different `Document` instances no longer
+  touch anything shared. `docNamingScopeMutex()` was removed. The general lesson: a mutex is the
+  right tool only when the state is *genuinely* meant to be one shared resource; when it was
+  wrongly made global/shared in the first place, the fix is relocating ownership to whatever object
+  actually owns the data, not locking access to the wrong owner.
 - **`FontManager`** (`fontCount`, `fontName`, `fontPath`, `fontHasAspect`, `initDatabase`) shares
   a process-global font-list cache with an unsynchronized check-then-act lazy-init, plus
   `initDatabase()` could reassign the cache at any time, racing an in-progress read. Fixed via


### PR DESCRIPTION
## Summary
- Follow-up to #361, prompted by upstream reviewer feedback on #341's analogous `AutoNamingScope` fix ([OCCT#1388](https://github.com/Open-Cascade-SAS/OCCT/pull/1388): "a mutex is not the right tool here... usage remains unprotected").
- v1.15.13's `docNamingScopeMutex()` made concurrent access to the shared `TNaming_Scope` instance memory-safe, but left a design bug in place: every `Document` still shared the *same* `TNaming_Scope`, so one document's valid-label set could leak into another's — a correctness bug, not just a race, that predates #361.
- **Fix:** `TNaming_Scope` moved from a shared process-wide static to a field on `OCCTDocument` itself (`doc->namingScope`). No lock needed at all — two threads working on two different `Document` instances no longer touch anything shared. `docNamingScopeMutex()` removed entirely.
- Two of the six `OCCTDocumentNamingScope*` functions (`Clear`/`ValidCount`) gained a null-check on `doc` they'd never had — a symptom of the same bug, since the old implementation ignored the `doc` parameter and touched the shared global instead.
- New test `namingScopesAreIsolatedAcrossDocuments` directly verifies the correctness property (deterministic, not race-dependent).
- `FontManager`'s `fontListMutex()` (also from #361) is unaffected — the system font registry is genuinely one process-wide resource by OCCT's own design, unlike `TNaming_Scope`. `docs/thread-safety.md` updated to contrast the two.
- `OCCTBridge.xcframework` rebuilt; `Package.swift` URL/checksum bumped to v1.15.14. `OCCT.xcframework` unchanged (still v1.15.11).

The same per-instance-override principle is queued for #341's upstream `AutoNamingScope` fix — tracked in #363 (this issue) but deliberately deferred: prototype + test locally first (separate PR), then respond to the OCCT#1388 review and update that PR.

## Test plan
- [x] `swift build` clean (source bridge)
- [x] `OCCTSWIFT_BRIDGE_PREBUILT=1 swift build` clean (prebuilt bridge)
- [x] New isolation test passes; concurrent exerciser still passes
- [x] Full `swift test` — 4427 tests / 1284 suites, clean (2 consecutive full runs)

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)