### PR TITLE
fix(#367): Shape.fuseAll(_:) SetRunParallel(true) caused data corruption — v1.15.16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,8 +80,8 @@ let occtBridgeTarget: Target = useBridgeLocalBinary
     // the OCCT.xcframework convention above.
     ? .binaryTarget(
         name: "OCCTBridge",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.15/OCCTBridge.xcframework.zip",
-        checksum: "d71474602d126178c056ee09e241d8c2c2dd2f58ab8eb1c9db763de61a39a824"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.16/OCCTBridge.xcframework.zip",
+        checksum: "d5ad8b4cc6c6cdc45e081d6146433cd821af4b8ae6806418dbd545d7601ba9e2"
     )
     : .target(
         name: "OCCTBridge",

--- a/Scripts/repro/342-boolean-ops/occt_342_boolean_stress.cpp
+++ b/Scripts/repro/342-boolean-ops/occt_342_boolean_stress.cpp
@@ -1,0 +1,211 @@
+// Stress harness for #342 (bridge-level thread-handling contract): are ordinary boolean
+// operations (BRepAlgoAPI_Fuse/Cut/Common, as wrapped by OCCTShapeUnion/Subtract/Intersect)
+// safe to run concurrently on independent shapes? Never TSan'd before -- #298 already showed
+// "independent shapes are safe" is not a safe assumption to make by inspection for this
+// engine family (fillet/chamfer's legacy TopOpeBRepBuild engine hid a severe silent-corruption
+// race), so this checks the modern BOPAlgo engine plain Fuse/Cut/Common goes through
+// independently, rather than assuming it inherited #298's fix or was never affected.
+//
+// Two independent signals, matching the #298 methodology: TSan race reports, AND a
+// correctness check against a single-threaded baseline (volume/face-count) -- a race that
+// produces a wrong-but-plausible result without a crash would pass "no crash" but fail this.
+//
+// Usage: occt_342_boolean_stress <scenario> <threads> <iterations>
+//   scenarios: fuse | cut | common | mixed | fuse_multi_parallel
+
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+#include <BRepAlgoAPI_BuilderAlgo.hxx>
+#include <BRepAlgoAPI_Common.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
+#include <BRepGProp.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <GProp_GProps.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_ListOfShape.hxx>
+#include <TopoDS_Shape.hxx>
+
+std::atomic<long> gOps{0};
+std::atomic<long> gErrors{0};
+std::atomic<long> gWrongResult{0}; // diverged from the single-threaded baseline
+
+static void note(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+}
+
+// Canonical overlap: box(10,10,10) + sphere(center (5,5,5), r=6), same shapes #298's own
+// harness used -- an already-exercised, known-good pair, not a fresh unvalidated fixture.
+static TopoDS_Shape makeBox() { return BRepPrimAPI_MakeBox(10, 10, 10).Shape(); }
+static TopoDS_Shape makeSphere() { return BRepPrimAPI_MakeSphere(gp_Pnt(5, 5, 5), 6).Shape(); }
+
+static int faceCount(const TopoDS_Shape& s) {
+    int n = 0;
+    for (TopExp_Explorer exp(s, TopAbs_FACE); exp.More(); exp.Next()) ++n;
+    return n;
+}
+
+static double volumeOf(const TopoDS_Shape& s) {
+    GProp_GProps props;
+    BRepGProp::VolumeProperties(s, props);
+    return props.Mass();
+}
+
+// Baselines computed once, single-threaded, before any thread starts.
+static double gFuseBaselineVolume = 0;
+static int    gFuseBaselineFaces  = 0;
+static double gCutBaselineVolume  = 0;
+static int    gCutBaselineFaces   = 0;
+static double gCommonBaselineVolume = 0;
+static int    gCommonBaselineFaces  = 0;
+
+static void computeBaselines() {
+    {
+        BRepAlgoAPI_Fuse op(makeBox(), makeSphere());
+        op.Build();
+        gFuseBaselineVolume = volumeOf(op.Shape());
+        gFuseBaselineFaces  = faceCount(op.Shape());
+    }
+    {
+        BRepAlgoAPI_Cut op(makeBox(), makeSphere());
+        op.Build();
+        gCutBaselineVolume = volumeOf(op.Shape());
+        gCutBaselineFaces  = faceCount(op.Shape());
+    }
+    {
+        BRepAlgoAPI_Common op(makeBox(), makeSphere());
+        op.Build();
+        gCommonBaselineVolume = volumeOf(op.Shape());
+        gCommonBaselineFaces  = faceCount(op.Shape());
+    }
+    note("baselines: fuse vol=%.6f faces=%d | cut vol=%.6f faces=%d | common vol=%.6f faces=%d",
+         gFuseBaselineVolume, gFuseBaselineFaces, gCutBaselineVolume, gCutBaselineFaces,
+         gCommonBaselineVolume, gCommonBaselineFaces);
+}
+
+static bool closeEnough(double a, double b) { return std::fabs(a - b) < 1e-6 * std::max(1.0, std::fabs(b)); }
+
+void runFuse(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        BRepAlgoAPI_Fuse op(makeBox(), makeSphere());
+        op.Build();
+        if (!op.IsDone()) { gErrors++; note("[fuse %d] not done", id); continue; }
+        TopoDS_Shape result = op.Shape();
+        if (!closeEnough(volumeOf(result), gFuseBaselineVolume) || faceCount(result) != gFuseBaselineFaces) {
+            gWrongResult++;
+            note("[fuse %d] diverged: vol=%.6f faces=%d (expected vol=%.6f faces=%d)", id,
+                 volumeOf(result), faceCount(result), gFuseBaselineVolume, gFuseBaselineFaces);
+        }
+        gOps++;
+    }
+}
+
+void runCut(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        BRepAlgoAPI_Cut op(makeBox(), makeSphere());
+        op.Build();
+        if (!op.IsDone()) { gErrors++; note("[cut %d] not done", id); continue; }
+        TopoDS_Shape result = op.Shape();
+        if (!closeEnough(volumeOf(result), gCutBaselineVolume) || faceCount(result) != gCutBaselineFaces) {
+            gWrongResult++;
+            note("[cut %d] diverged: vol=%.6f faces=%d (expected vol=%.6f faces=%d)", id,
+                 volumeOf(result), faceCount(result), gCutBaselineVolume, gCutBaselineFaces);
+        }
+        gOps++;
+    }
+}
+
+void runCommon(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        BRepAlgoAPI_Common op(makeBox(), makeSphere());
+        op.Build();
+        if (!op.IsDone()) { gErrors++; note("[common %d] not done", id); continue; }
+        TopoDS_Shape result = op.Shape();
+        if (!closeEnough(volumeOf(result), gCommonBaselineVolume) || faceCount(result) != gCommonBaselineFaces) {
+            gWrongResult++;
+            note("[common %d] diverged: vol=%.6f faces=%d (expected vol=%.6f faces=%d)", id,
+                 volumeOf(result), faceCount(result), gCommonBaselineVolume, gCommonBaselineFaces);
+        }
+        gOps++;
+    }
+}
+
+// Half the threads fuse, a third cut, the rest common -- a realistic mixed workload rather
+// than N threads all doing the exact same op (which could mask interference that only shows
+// up when different BOPAlgo code paths run concurrently).
+void runMixed(int id, int iterations) {
+    switch (id % 3) {
+        case 0: runFuse(id, iterations); break;
+        case 1: runCut(id, iterations); break;
+        default: runCommon(id, iterations); break;
+    }
+}
+
+// OCCTShapeFuseMulti's own pattern: SetRunParallel(true) -- internal parallelism -- run
+// concurrently across threads too, so N threads each spawn their own internal worker pool
+// simultaneously. Tests oversubscription/interference, not just plain concurrent calls.
+void runFuseMultiParallel(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        TopTools_ListOfShape args;
+        args.Append(makeBox());
+        args.Append(makeSphere());
+        BRepAlgoAPI_BuilderAlgo builder;
+        builder.SetArguments(args);
+        builder.SetRunParallel(Standard_True);
+        builder.Build();
+        if (!builder.IsDone()) { gErrors++; note("[fuse_multi %d] not done", id); continue; }
+        TopoDS_Shape result = builder.Shape();
+        if (!closeEnough(volumeOf(result), gFuseBaselineVolume) || faceCount(result) != gFuseBaselineFaces) {
+            gWrongResult++;
+            note("[fuse_multi %d] diverged: vol=%.6f faces=%d (expected vol=%.6f faces=%d)", id,
+                 volumeOf(result), faceCount(result), gFuseBaselineVolume, gFuseBaselineFaces);
+        }
+        gOps++;
+    }
+}
+
+int main(int argc, char** argv) {
+    std::string scenario = argc > 1 ? argv[1] : "mixed";
+    int threads = argc > 2 ? atoi(argv[2]) : 8;
+    int iterations = argc > 3 ? atoi(argv[3]) : 50;
+
+    note("scenario=%s threads=%d iterations=%d", scenario.c_str(), threads, iterations);
+    computeBaselines();
+
+    std::vector<std::thread> pool;
+    auto t0 = std::chrono::steady_clock::now();
+
+    if (scenario == "fuse") {
+        for (int i = 0; i < threads; ++i) pool.emplace_back(runFuse, i, iterations);
+    } else if (scenario == "cut") {
+        for (int i = 0; i < threads; ++i) pool.emplace_back(runCut, i, iterations);
+    } else if (scenario == "common") {
+        for (int i = 0; i < threads; ++i) pool.emplace_back(runCommon, i, iterations);
+    } else if (scenario == "mixed") {
+        for (int i = 0; i < threads; ++i) pool.emplace_back(runMixed, i, iterations);
+    } else if (scenario == "fuse_multi_parallel") {
+        for (int i = 0; i < threads; ++i) pool.emplace_back(runFuseMultiParallel, i, iterations);
+    } else {
+        note("unknown scenario: %s", scenario.c_str());
+        return 2;
+    }
+
+    for (auto& t : pool) t.join();
+
+    auto t1 = std::chrono::steady_clock::now();
+    double secs = std::chrono::duration<double>(t1 - t0).count();
+    note("done: ops=%ld errors=%ld wrongResult=%ld elapsed=%.2fs", gOps.load(), gErrors.load(),
+         gWrongResult.load(), secs);
+    return (gErrors.load() > 0 || gWrongResult.load() > 0) ? 1 : 0;
+}

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -1563,7 +1563,11 @@ OCCTShapeRef OCCTShapeFuseMulti(const OCCTShapeRef* shapes, int32_t count) {
         }
         BRepAlgoAPI_BuilderAlgo builder;
         builder.SetArguments(arguments);
-        builder.SetRunParallel(Standard_True);
+        // #367: SetRunParallel(true) here caused silent data corruption (100%
+        // wrong results, 237 TSan races) whenever two concurrent top-level
+        // callers both requested internal parallelism -- their work items
+        // cross-contaminated on the shared OSD_ThreadPool::DefaultPool. Left
+        // at the safe serial default.
         builder.Build();
         if (!builder.IsDone()) return nullptr;
         TopoDS_Shape result = builder.Shape();

--- a/Tests/OCCTThreadTests/Issue367FuseMultiThreadSafetyTests.swift
+++ b/Tests/OCCTThreadTests/Issue367FuseMultiThreadSafetyTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// Issue #367: OCCTShapeFuseMulti (Shape.fuseAll(_:)) set builder.SetRunParallel(true)
+// unconditionally. Concurrent top-level BRepAlgoAPI_BuilderAlgo::Build() calls each requesting
+// internal parallelism submit work to the same process-wide OSD_ThreadPool::DefaultPool(), and
+// worker threads end up processing data belonging to the wrong caller's operation -- not a rare
+// race, but 100% reproducible data corruption under a pure-C++ TSan stress harness (400/400
+// concurrent operations produced 27 faces instead of the correct 13; 237 TSan race reports
+// across TopoDS_Builder::Add, TopExp_Explorer, BRep_Tool::Range, BOPTools_AlgoTools::MakeSplitEdge).
+// Fixed by dropping SetRunParallel(true) entirely -- OCCT's safe serial default.
+//
+// Same honesty caveat as this project's other thread-safety regression suites: a missing-lock /
+// wrong-parallelism-flag bug doesn't reliably reproduce as an observable Swift-level failure at
+// modest concurrency without sanitizer instrumentation. The authoritative reproducer is
+// Scripts/repro/342-boolean-ops/occt_342_boolean_stress.cpp (fuse_multi_parallel scenario),
+// which DID reliably reproduce it (100% of runs) before the fix. This suite is a basic exerciser
+// confirming the fixed code path still produces correct, consistent results under concurrency.
+@Suite("Issue #367 — Shape.fuseAll concurrent calls produce correct results (SetRunParallel removed)")
+struct Issue367FuseMultiThreadSafetyTests {
+
+    @Test("Concurrent fuseAll calls all match the single-threaded baseline face count")
+    func concurrentFuseAllMatchesBaseline() async throws {
+        let baselineBox = Shape.box(width: 10, height: 10, depth: 10)!
+        let baselineSphere = Shape.sphere(center: SIMD3(5, 5, 5), radius: 6)!
+        let baseline = try #require(Shape.fuseAll([baselineBox, baselineSphere]))
+        let baselineFaceCount = baseline.subShapeCount(ofType: .face)
+
+        struct Outcome: Sendable {
+            var failures = 0
+            var wrongFaceCounts = 0
+        }
+
+        let agg = await withTaskGroup(of: Outcome.self) { group -> Outcome in
+            for _ in 0..<8 {
+                group.addTask {
+                    var o = Outcome()
+                    for _ in 0..<50 {
+                        let box = Shape.box(width: 10, height: 10, depth: 10)!
+                        let sphere = Shape.sphere(center: SIMD3(5, 5, 5), radius: 6)!
+                        guard let result = Shape.fuseAll([box, sphere]) else {
+                            o.failures += 1
+                            continue
+                        }
+                        if result.subShapeCount(ofType: .face) != baselineFaceCount {
+                            o.wrongFaceCounts += 1
+                        }
+                    }
+                    return o
+                }
+            }
+            var total = Outcome()
+            for await o in group {
+                total.failures += o.failures
+                total.wrongFaceCounts += o.wrongFaceCounts
+            }
+            return total
+        }
+
+        #expect(agg.failures == 0, "concurrent fuseAll calls failed (expected 0 of 400)")
+        #expect(agg.wrongFaceCounts == 0,
+                "concurrent fuseAll produced a face count diverging from the single-threaded baseline (\(baselineFaceCount)) — the #367 corruption")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,46 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.15
+## Current: v1.15.16
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.16 (July 2026) — fix (bridge): Shape.fuseAll(_:) internal parallelism caused data corruption under concurrent calls (#367)
+
+Found continuing #342's classification pass. `OCCTShapeFuseMulti` (backs `Shape.fuseAll(_:)`) was
+the only bridge call site that set `builder.SetRunParallel(true)` — internal OCCT parallelism for
+a single call. Under concurrent load this was actively unsafe, not just an oversubscription
+concern as #342 originally framed it: two threads' top-level `Build()` calls, each requesting
+internal parallelism, submit work to the same process-wide `OSD_ThreadPool::DefaultPool()`, and
+worker threads from one caller's dispatch can end up processing another caller's data.
+
+**Evidence** (`Scripts/repro/342-boolean-ops/occt_342_boolean_stress.cpp`,
+`fuse_multi_parallel` scenario): 8 threads × 50 iterations, **400/400 concurrent operations
+produced wrong results** — 27 faces instead of the correct 13 (volume matched almost exactly,
+consistent with duplicated/torn geometry rather than floating-point imprecision) — plus 237
+ThreadSanitizer race reports across foundational topology code (`TopoDS_Builder::Add`,
+`TopExp_Explorer`, `BRep_Tool::Range`, `BOPTools_AlgoTools::MakeSplitEdge`). By contrast, the
+plain (non-parallel) boolean ops — `Shape.union(with:)`/`.subtracting(_:)`/`.intersecting(_:)`,
+none of which ever set `SetRunParallel` — are clean: 2000 concurrent mixed operations, 0 errors,
+0 wrong results, 0 races.
+
+**Fix:** dropped `SetRunParallel(true)` entirely — `Shape.fuseAll(_:)` now runs on OCCT's safe
+serial default. Removes the trigger rather than locking around a known-corrupting path. New
+regression suite `Issue367FuseMultiThreadSafetyTests`. Full `swift test` (4428 tests) clean.
+
+**Not fixed here:** the underlying mechanism looks like a genuine `OSD_ThreadPool`/
+`BOPTools_Parallel` concurrency bug in OCCT's own shared-pool dispatch — more foundational than
+anything else found in this project's TSan series (#298/#341/#344/#349/#353/#361 were all
+specific static/global variables in narrower classes). Root-causing it properly is tracked as a
+follow-up investigation in #367, out of scope for this release.
+
+**Binary release** — `OCCTBridge.xcframework` (the opt-in prebuilt bridge from #339) changed, so
+`Package.swift`'s URL/checksum are bumped to this release. `OCCT.xcframework` is unchanged (still
+v1.15.15) — this is a bridge-only fix, no kernel patch.
 
 ### v1.15.15 (July 2026) — fix (kernel): #341's AutoNamingScope revised to a per-instance override after upstream review (#363)
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -210,6 +210,32 @@ contrasting:
   `initDatabase()` could reassign the cache at any time, racing an in-progress read. Fixed via
   `fontListMutex()` in `OCCTBridge_Visualization.mm`, held for every access (population and read).
 
+### `Shape.fuseAll(_:)` internal parallelism (issue #367)
+
+`Shape.fuseAll(_:)` is **safe to call concurrently** as of v1.15.16. It previously set
+`builder.SetRunParallel(true)` on its `BRepAlgoAPI_BuilderAlgo` — internal OCCT parallelism for a
+single call, not multiple independent calls. Under concurrent load this was actively unsafe: two
+threads' top-level `Build()` calls, each requesting internal parallelism, submit work to the same
+process-wide `OSD_ThreadPool::DefaultPool()`, and worker threads from one caller's dispatch can end
+up processing another caller's data. Confirmed via TSan stress
+(`Scripts/repro/342-boolean-ops/`, `fuse_multi_parallel` scenario): **100% of concurrent runs
+produced wrong results** (27 faces instead of the correct 13), plus 237 race reports across
+foundational topology code (`TopoDS_Builder::Add`, `TopExp_Explorer`, `BRep_Tool::Range`,
+`BOPTools_AlgoTools::MakeSplitEdge`) — not a rare interleaving, a reliably reproducible one.
+
+**Fixed** by dropping `SetRunParallel(true)` entirely — `Shape.fuseAll(_:)` now runs on OCCT's safe
+serial default, same as `Shape.union(with:)`/`.subtracting(_:)`/`.intersecting(_:)` (which never
+set it and were already confirmed clean under the same stress: 2000 concurrent mixed operations,
+zero errors, zero wrong results, zero races). This is the only bridge call site that ever set
+`SetRunParallel(true)` — grepped exhaustively across `Sources/OCCTBridge/src/*.mm`.
+
+This is a distinct, more severe finding than a missing lock on bridge-owned state (#359/#361/#363):
+it points at `OSD_ThreadPool`/`BOPTools_Parallel` — OCCT's own shared-pool parallel-dispatch
+infrastructure — potentially not being safe for concurrent independent top-level callers at all,
+not just this one call site. Root-causing that properly is tracked as a follow-up investigation in
+#367, out of scope for this release; removing the trigger was the correct immediate fix regardless
+of what the eventual root cause turns out to be.
+
 ## ThreadSanitizer gate for concurrency-touching changes
 
 Every thread-safety kernel bug this project has found and fixed (#298, #341, #344, #349)


### PR DESCRIPTION
## Summary
- Found continuing #342's classification pass. `OCCTShapeFuseMulti` (backs `Shape.fuseAll(_:)`) was the only bridge call site setting `builder.SetRunParallel(true)`. Concurrent top-level `Build()` calls, each requesting internal parallelism, submit work to the same process-wide `OSD_ThreadPool::DefaultPool()` — worker threads from one caller's dispatch can end up processing another caller's data.
- **Evidence** (`Scripts/repro/342-boolean-ops/occt_342_boolean_stress.cpp`, `fuse_multi_parallel` scenario): 8 threads × 50 iterations, **400/400 concurrent operations produced wrong results** (27 faces instead of the correct 13), plus 237 TSan race reports across `TopoDS_Builder::Add`, `TopExp_Explorer`, `BRep_Tool::Range`, `BOPTools_AlgoTools::MakeSplitEdge`. By contrast, the plain (non-parallel) boolean ops — union/subtract/intersect, none of which ever set `SetRunParallel` — are clean: 2000 concurrent mixed operations, 0 errors, 0 wrong results, 0 races.
- **Fix:** dropped `SetRunParallel(true)` entirely — `Shape.fuseAll(_:)` now runs on OCCT's safe serial default. New regression suite `Issue367FuseMultiThreadSafetyTests`.
- **Not fixed here:** the underlying mechanism looks like a genuine `OSD_ThreadPool`/`BOPTools_Parallel` concurrency bug in OCCT's own shared-pool dispatch — more foundational than anything else found in this project's TSan series so far. Tracked as a follow-up investigation in #367.
- `OCCTBridge.xcframework` rebuilt; `Package.swift` URL/checksum bumped to v1.15.16. `OCCT.xcframework` unchanged (still v1.15.15) — bridge-only fix, no kernel patch.
- Docs: `docs/CHANGELOG.md`, `docs/thread-safety.md`.

## Test plan
- [x] `swift build` clean (source bridge)
- [x] `OCCTSWIFT_BRIDGE_PREBUILT=1 swift build` clean (prebuilt bridge)
- [x] New `Issue367FuseMultiThreadSafetyTests` suite passes on both build paths
- [x] Full `swift test` — 4428 tests / 1285 suites, clean

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)