### PR TITLE
docs(#375): Shape.mesh()/Shape.loadSTL() winding guarantees (v1.15.19)

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -796,6 +796,21 @@ public final class Shape: @unchecked Sendable {
     ///      approximates the `Geom_OffsetSurface` with a plain B-spline, which smooths the cusps
     ///      the angular check is choking on. Measured on the #286 solid: 125 s / 526 k vertices —
     ///      faster, but it resamples the geometry, so treat it as a rescue path, not a default.
+    ///
+    /// - Note: **Triangle winding always reflects the shape's true topological orientation, not
+    ///   a naive read of a caller-applied transform.** This method reads each face's
+    ///   `TopoDS_Face::Orientation()` faithfully (reversing the triangulation's node order when
+    ///   `REVERSED`), so it's never "wrong" — but for a **valid, closed solid**, that orientation
+    ///   is *always* consistently outward, even after a mirror (negative-determinant transform):
+    ///   ``mirrored(planeNormal:planeOrigin:)`` doesn't naively re-tessellate flipped geometry —
+    ///   OCCT's `BRepBuilderAPI_Transform` compensates by flipping each face's orientation flag,
+    ///   preserving the invariant that a valid solid's faces classify consistently outward.
+    ///   Confirmed empirically (#375): a box and its mirror both mesh 12/12 triangles outward,
+    ///   with the identical FORWARD/REVERSED face split before and after. There is currently no
+    ///   way, via a valid `Shape`, to obtain a mesh whose winding reflects an applied mirror — a
+    ///   caller who needs deliberately caller-controlled (including "wrong-way") winding, e.g. to
+    ///   test orientation-sensitive downstream code, should build a ``Mesh`` directly via
+    ///   ``Mesh/init(vertices:normals:indices:)`` instead of going through a `Shape`.
     public func mesh(
         linearDeflection: Double = 0.1,
         angularDeflection: Double = 0.5
@@ -877,6 +892,8 @@ public final class Shape: @unchecked Sendable {
     ///
     /// - Parameter parameters: Enhanced mesh parameters
     /// - Returns: A `Mesh` with the specified quality settings
+    /// - Note: Same orientation guarantee as ``mesh(linearDeflection:angularDeflection:)`` — see
+    ///   its doc for details on why a valid solid's mesh is always consistently outward.
     public func mesh(parameters: MeshParameters) -> Mesh? {
         let bridgeParams = parameters.toBridge()
         guard let meshHandle = OCCTShapeCreateMeshWithParams(handle, bridgeParams) else { return nil }
@@ -1390,9 +1407,20 @@ public final class Shape: @unchecked Sendable {
 
     /// Load a shape from an STL file
     ///
+    /// Builds one planar `TopoDS_Face` per STL facet via OCCT's `StlAPI_Reader`
+    /// (`BRepBuilderAPI_MakeShapeOnMesh`); faces are unsewn — call ``sewn(tolerance:)`` or use
+    /// ``loadSTLRobust(from:sewingTolerance:)`` if you need a connected shell/solid.
+    ///
     /// - Parameter url: URL to the STL file (.stl)
     /// - Returns: Imported shape
     /// - Throws: ImportError if import fails
+    /// - Note: Each facet's vertex winding is preserved exactly, including a globally-reversed
+    ///   (but self-consistent) file — confirmed empirically (#375) by round-tripping a uniformly
+    ///   reversed-winding box through `loadSTL` + ``mesh(linearDeflection:angularDeflection:)``
+    ///   and finding all 12 triangles consistently inward, with zero shared-edge orientation
+    ///   conflicts. If a round-tripped mesh comes back with *locally* inconsistent winding (some
+    ///   faces inward, some outward), the input STL itself is locally inconsistent — this method
+    ///   doesn't introduce that defect, it faithfully reproduces one already in the file.
     public static func loadSTL(from url: URL) throws -> Shape {
         guard let handle = OCCTImportSTL(url.path) else {
             throw ImportError.importFailed("Failed to import STL file: \(url.lastPathComponent)")
@@ -1401,6 +1429,8 @@ public final class Shape: @unchecked Sendable {
     }
 
     /// Load a shape from an STL file path
+    ///
+    /// - Note: Same winding-fidelity guarantee as ``loadSTL(from:)`` — see its doc for details.
     public static func loadSTL(fromPath path: String) throws -> Shape {
         guard let handle = OCCTImportSTL(path) else {
             throw ImportError.importFailed("Failed to import STL file: \(path)")

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -288,6 +288,100 @@ struct STLImportTests {
     }
 }
 
+// MARK: - Issue #375: loadSTL winding fidelity
+
+// #375: reported that `Shape.loadSTL()` might not reliably preserve a globally-reversed (but
+// self-consistent) STL's winding — that a round trip could come back locally inconsistent
+// instead of cleanly globally inverted. Empirically confirmed NOT to be a bug (ground-truth
+// C++ test against `StlAPI_Reader` + `BRepMesh_IncrementalMesh` directly): winding is preserved
+// exactly, including a full uniform reversal. The "locally inconsistent" observation that
+// prompted the issue traced to a defect in the *reporting* test fixture's own STL-generation
+// helper (a copy-pasted, unmirrored top-face vertex order), not to OCCTSwift.
+@Suite("Issue #375 — Shape.loadSTL() preserves facet winding, including a global reversal")
+struct Issue375STLWindingTests {
+
+    /// A hand-written, watertight, unit-half-extent box STL: 6 quads (2 triangles each), every
+    /// face's own outward normal independently right-hand-rule-verified. `reversedGlobally`
+    /// flips every facet's vertex order uniformly (a self-consistent, globally-inverted file).
+    private func boxSTL(halfExtent e: Double, reversedGlobally: Bool) -> String {
+        typealias V = SIMD3<Double>
+        func quad(_ a: V, _ b: V, _ c: V, _ d: V) -> [(V, V, V)] {
+            let order = reversedGlobally ? [a, d, c, b] : [a, b, c, d]
+            return [(order[0], order[1], order[2]), (order[0], order[2], order[3])]
+        }
+        var tris: [(V, V, V)] = []
+        tris += quad(V(-e, -e, -e), V(-e, e, -e), V(e, e, -e), V(e, -e, -e))   // -Z
+        tris += quad(V(-e, -e, e), V(e, -e, e), V(e, e, e), V(-e, e, e))       // +Z
+        tris += quad(V(e, -e, -e), V(e, e, -e), V(e, e, e), V(e, -e, e))       // +X
+        tris += quad(V(-e, -e, -e), V(-e, -e, e), V(-e, e, e), V(-e, e, -e))   // -X
+        tris += quad(V(-e, e, -e), V(-e, e, e), V(e, e, e), V(e, e, -e))       // +Y
+        tris += quad(V(-e, -e, -e), V(e, -e, -e), V(e, -e, e), V(-e, -e, e))   // -Y
+
+        var out = "solid box\n"
+        for (a, b, c) in tris {
+            let n = simd_normalize(simd_cross(b - a, c - a))
+            out += "  facet normal \(n.x) \(n.y) \(n.z)\n    outer loop\n"
+            out += "      vertex \(a.x) \(a.y) \(a.z)\n"
+            out += "      vertex \(b.x) \(b.y) \(b.z)\n"
+            out += "      vertex \(c.x) \(c.y) \(c.z)\n"
+            out += "    endloop\n  endfacet\n"
+        }
+        out += "endsolid box\n"
+        return out
+    }
+
+    /// Fraction of `mesh`'s triangles whose (v1,v2,v3) winding faces away from `center` --
+    /// cross(v2-v1, v3-v1) points away from the center, the expected convention for a convex
+    /// solid's outward-facing mesh. 1.0 = fully outward, 0.0 = fully inward (a clean global
+    /// inversion), anything strictly between = locally inconsistent.
+    private func outwardFraction(of mesh: Mesh, center: SIMD3<Float>) -> Double {
+        let verts = mesh.vertices
+        let idx = mesh.indices
+        var outward = 0
+        var total = 0
+        var i = 0
+        while i + 2 < idx.count {
+            let p1 = verts[Int(idx[i])], p2 = verts[Int(idx[i + 1])], p3 = verts[Int(idx[i + 2])]
+            let normal = simd_cross(p2 - p1, p3 - p1)
+            if simd_dot(normal, p1 - center) > 0 { outward += 1 }
+            total += 1
+            i += 3
+        }
+        return Double(outward) / Double(total)
+    }
+
+    private func writeAndLoad(_ stl: String) throws -> Shape {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("stl")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try stl.write(to: tempURL, atomically: true, encoding: .utf8)
+        return try Shape.loadSTL(from: tempURL)
+    }
+
+    @Test("a normally-wound STL round-trips fully outward")
+    func normalWindingRoundTripsOutward() throws {
+        let shape = try writeAndLoad(boxSTL(halfExtent: 5, reversedGlobally: false))
+        let mesh = try #require(shape.mesh(linearDeflection: 0.5, angularDeflection: 0.5))
+        #expect(mesh.indices.count == 36, "expected exactly 12 triangles (6 faces x 2), got \(mesh.indices.count / 3)")
+        #expect(outwardFraction(of: mesh, center: .zero) == 1.0)
+    }
+
+    @Test("a globally reversed (but self-consistent) STL round-trips as a CLEAN global inversion, not local inconsistency")
+    func globallyReversedWindingRoundTripsInward() throws {
+        let shape = try writeAndLoad(boxSTL(halfExtent: 5, reversedGlobally: true))
+        let mesh = try #require(shape.mesh(linearDeflection: 0.5, angularDeflection: 0.5))
+        #expect(mesh.indices.count == 36, "expected exactly 12 triangles (6 faces x 2), got \(mesh.indices.count / 3)")
+
+        // "Locally inconsistent" (the #375 concern) would show up here as a fraction strictly
+        // between 0 and 1 -- some faces one way, some the other. A clean global inversion reads
+        // exactly 0.0 (fully inward, i.e. zero triangles facing outward).
+        let fraction = outwardFraction(of: mesh, center: .zero)
+        #expect(fraction == 0.0,
+                "expected a clean global inversion (0.0 outward), got \(fraction) -- a value strictly between 0 and 1 would mean the round trip introduced local inconsistency")
+    }
+}
+
 // MARK: - OBJ Import/Export Tests (v0.17.0)
 
 @Suite("OBJ Import Export Tests")

--- a/Tests/OCCTMeshTests/Issue375MeshWindingTests.swift
+++ b/Tests/OCCTMeshTests/Issue375MeshWindingTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #375: `Shape.mesh()` always emits consistently outward-facing triangles for a valid,
+// closed solid, even after a mirror transform (determinant -1). Empirically confirmed to be
+// intentional/correct OCCT behavior, not a bridge bug: `BRepBuilderAPI_Transform` compensates a
+// negative-determinant transform by flipping each face's `TopoDS_Face::Orientation()` flag, so a
+// valid solid's faces always classify consistently outward — the bridge's extraction (which
+// reads that flag faithfully) has nothing left to get "wrong". See `Shape.mesh()`'s doc comment
+// for the caller-controlled-winding workaround (`Mesh(vertices:normals:indices:)`).
+@Suite("Issue #375 — mesh() winding reflects true topological orientation, not a naive transform read")
+struct Issue375MeshWindingTests {
+
+    /// Returns the fraction of `mesh`'s triangles whose (v1,v2,v3) winding faces away from
+    /// `center` — i.e. cross(v2-v1, v3-v1) points away from the center, the expected convention
+    /// for a convex solid's outward-facing mesh.
+    private func outwardFraction(of mesh: Mesh, center: SIMD3<Float>) -> Double {
+        let verts = mesh.vertices
+        let idx = mesh.indices
+        guard !idx.isEmpty else { return .nan }
+        var outward = 0
+        var total = 0
+        var i = 0
+        while i + 2 < idx.count {
+            let p1 = verts[Int(idx[i])], p2 = verts[Int(idx[i + 1])], p3 = verts[Int(idx[i + 2])]
+            let normal = simd_cross(p2 - p1, p3 - p1)
+            if simd_dot(normal, p1 - center) > 0 { outward += 1 }
+            total += 1
+            i += 3
+        }
+        return Double(outward) / Double(total)
+    }
+
+    @Test("a mirrored valid solid still meshes 100% outward, matching the un-mirrored original")
+    func mirroredSolidMeshesConsistentlyOutward() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let mirrored = try #require(box.mirrored(planeNormal: SIMD3(0, 0, 1), planeOrigin: .zero))
+
+        let boxMesh = try #require(box.mesh(linearDeflection: 0.5, angularDeflection: 0.5))
+        let mirroredMesh = try #require(mirrored.mesh(linearDeflection: 0.5, angularDeflection: 0.5))
+
+        // Shape.box(width:height:depth:) is centered at the origin (both before and after a
+        // mirror through a plane containing the origin), so `.zero` is the outward reference
+        // center for both meshes.
+        let boxOutward = outwardFraction(of: boxMesh, center: .zero)
+        let mirroredOutward = outwardFraction(of: mirroredMesh, center: .zero)
+
+        #expect(boxOutward == 1.0, "expected the un-mirrored box to mesh fully outward, got \(boxOutward)")
+        #expect(mirroredOutward == 1.0,
+                "expected the mirrored box to STILL mesh fully outward (OCCT compensates the flip), got \(mirroredOutward)")
+    }
+
+    @Test("mesh(parameters:) has the same outward-normalization behavior as the deflection overload")
+    func meshParametersOverloadMatchesOutwardBehavior() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let mirrored = try #require(box.mirrored(planeNormal: SIMD3(1, 0, 0), planeOrigin: .zero))
+
+        let mirroredMesh = try #require(mirrored.mesh(parameters: .default))
+        let mirroredOutward = outwardFraction(of: mirroredMesh, center: .zero)
+
+        #expect(mirroredOutward == 1.0, "expected mesh(parameters:) to also read fully outward, got \(mirroredOutward)")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,56 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.18
+## Current: v1.15.19
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353, #374 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.19 (July 2026): docs + tests — `Shape.mesh()`/`Shape.loadSTL()` winding guarantees, retract the #375 "loses winding" concern (#375)
+
+**Not a bug — investigated and retracted, both parts.** #375 asked whether `Shape.mesh()`
+(always outward for a valid solid, even after a mirror) and `Shape.loadSTL()` (reportedly
+"locally inconsistent" after round-tripping a globally-reversed STL) were losing orientation
+information. Both were root-caused with a ground-truth C++ test against the pinned xcframework,
+independent of any Swift-side code.
+
+1. **`Shape.mesh()` outward-normalization is genuine, intentional OCCT behavior.** A
+   `BRepPrimAPI_MakeBox` box already has a mixed FORWARD/REVERSED face-orientation split (3/3)
+   baked into its topology; mirroring it (`gp_Trsf::SetMirror`, a negative-determinant
+   transform) through `BRepBuilderAPI_Transform` produces the **identical** 3/3 split, and both
+   the original and mirrored mesh read 12/12 triangles outward. OCCT compensates a mirror
+   transform by flipping face orientation flags, preserving the invariant that a valid solid's
+   faces always classify consistently outward — the bridge's existing
+   `face.Orientation() == TopAbs_REVERSED` check (already correct) has nothing left to get
+   "wrong". There is no way, via a valid `Shape`, to get caller-controlled/"wrong-way" winding —
+   that's what `Mesh(vertices:normals:indices:)` is for.
+
+2. **`Shape.loadSTL()` preserves facet winding exactly, including a full global reversal.** A
+   from-scratch, independently-verified box STL — both normally wound and uniformly, globally
+   reversed — round-trips through `StlAPI_Reader` (`BRepBuilderAPI_MakeShapeOnMesh`) +
+   `BRepMesh_IncrementalMesh` + the bridge's extraction as **fully consistent** in both cases (12/12
+   outward, then 12/12 inward; zero shared-edge orientation conflicts either way). **The "locally
+   inconsistent" result that prompted the issue traced to a bug in the reporting test's own STL
+   fixture generator** (a `quad()` helper that copy-pasted the bottom face's relative vertex
+   layout onto the top face without mirroring it, so the top face's own "non-reversed" baseline
+   was already backwards) — confirmed by reproducing that exact fixture's geometry and finding
+   the same defect independent of any `reversed` flag. Not an OCCTSwift bug; not filed upstream.
+
+**Docs:** `Shape.mesh(linearDeflection:angularDeflection:)`, `mesh(parameters:)`, and
+`loadSTL(from:)`/`loadSTL(fromPath:)` (`Sources/OCCTSwift/Shape.swift`) each gain a `- Note:`
+explaining the orientation guarantee, pointing at `Mesh(vertices:normals:indices:)` for
+caller-controlled winding.
+
+**Tests:** `Issue375MeshWindingTests` (`OCCTMeshTests`) — a mirrored box still meshes 100%
+outward, both `mesh()` overloads. `Issue375STLWindingTests` (`OCCTIOTests`) — a normally-wound
+box STL round-trips 100% outward; a globally-reversed box STL round-trips as a clean 100% inward
+(not a fraction strictly between 0 and 1, which would mean local inconsistency).
+
+Docs + tests only, no code behavior change, no binary change — reuses the v1.15.18 xcframework
+(the binaryTarget URL is unchanged).
 
 ### v1.15.18 (July 2026) — fix (kernel): Resource_Manager::Debug / Storage_Schema::ICurrentData() races (#374)
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1258,6 +1258,8 @@ public func mesh(
   3. **Raise `angularDeflection`** (it sets the `AngleInterior` threshold doing all the splitting), or raise `MinSize` via `mesh(parameters:)` so the backstop bites sooner.
   4. `withSurfacesAsBSpline(offset: true)` approximates the offset surface with a plain B-spline, smoothing the cusps the angular check chokes on: 125 s / 526 k verts on the #286 solid. It resamples the geometry, so it is a rescue path, not a default.
 
+- **Winding always reflects true topological orientation, not a naive transform read** ([#375](https://github.com/SecondMouseAU/OCCTSwift/issues/375)). This reads each face's `TopoDS_Face::Orientation()` faithfully — but for a **valid, closed solid**, that orientation is always consistently outward, even after a mirror (negative-determinant transform): `mirrored(planeNormal:planeOrigin:)` doesn't naively re-tessellate flipped geometry — OCCT's `BRepBuilderAPI_Transform` compensates by flipping each face's orientation flag. Confirmed empirically: a box and its mirror both mesh 12/12 triangles outward, with the identical FORWARD/REVERSED face split before and after. There is no way, via a valid `Shape`, to get caller-controlled ("wrong-way") winding — use `Mesh(vertices:normals:indices:)` directly for that.
+
 ---
 
 ### `meshWithProgress(linearDeflection:angularDeflection:progress:)`
@@ -1322,6 +1324,7 @@ Provides fine-grained control over tessellation quality, useful for CAM toolpath
   params.inParallel = true   // multi-threaded
   if let mesh = shape.mesh(parameters: params) { }
   ```
+- Same winding guarantee as [`mesh(linearDeflection:angularDeflection:)`](#meshlineardeflectionangulardeflection) above ([#375](https://github.com/SecondMouseAU/OCCTSwift/issues/375)).
 
 ---
 
@@ -1931,7 +1934,8 @@ public static func loadSTL(from url: URL) throws -> Shape
 - **Parameters:** `url` — URL to the `.stl` file.
 - **Returns:** Imported shape (a shell of triangulated faces).
 - **Throws:** `ImportError.importFailed` on failure.
-- **OCCT:** `StlAPI_Reader` (via `OCCTImportSTL`).
+- **OCCT:** `StlAPI_Reader` (via `OCCTImportSTL`). Builds one planar `TopoDS_Face` per STL facet (`BRepBuilderAPI_MakeShapeOnMesh`); faces are unsewn — call `sewn(tolerance:)` or use `loadSTLRobust(from:sewingTolerance:)` if you need a connected shell/solid.
+- **Winding is preserved exactly, including a global reversal** ([#375](https://github.com/SecondMouseAU/OCCTSwift/issues/375)). Each facet's vertex order is preserved exactly — confirmed empirically by round-tripping a uniformly reversed-winding box and finding all triangles consistently inward, with zero shared-edge orientation conflicts. If a round-tripped mesh comes back with *locally* inconsistent winding (some faces inward, some outward), the input STL itself is locally inconsistent — this method doesn't introduce that defect, it faithfully reproduces one already in the file.
 - **Example:**
   ```swift
   let mesh = try Shape.loadSTL(from: stlURL)
@@ -1948,6 +1952,7 @@ public static func loadSTL(fromPath path: String) throws -> Shape
 ```
 
 - **OCCT:** `StlAPI_Reader` (via `OCCTImportSTL`).
+- Same winding-fidelity guarantee as [`Shape.loadSTL(from:)`](#shapeloadstlfrom) above.
 
 ---
 


### PR DESCRIPTION
## Summary

Investigates and retracts both parts of #375:

1. **`Shape.mesh()` always emits outward winding for a valid solid, even after a mirror.** Confirmed intentional/correct OCCT behavior with a ground-truth C++ test: a box built via `BRepPrimAPI_MakeBox` already has a mixed FORWARD/REVERSED face-orientation split (3/3); mirroring it through `BRepBuilderAPI_Transform` (negative-determinant `gp_Trsf`) produces the *identical* 3/3 split, and both the original and mirrored mesh read 12/12 triangles outward. OCCT compensates a mirror transform by flipping face orientation flags to preserve the "valid solid classifies consistently outward" invariant — the bridge's existing `face.Orientation()` check has nothing left to get wrong.
2. **`Shape.loadSTL()` reportedly loses a globally-reversed STL's winding, coming back "locally inconsistent."** Also confirmed NOT a bug: a from-scratch, independently-verified box STL (both normally wound and uniformly globally reversed) round-trips through `StlAPI_Reader` + `BRepMesh_IncrementalMesh` + the bridge's extraction as fully consistent in both directions (12/12 outward, then 12/12 inward — a clean global inversion, zero shared-edge orientation conflicts). The "locally inconsistent" result that prompted the issue traced to a bug in the *reporting test's own STL fixture generator* (a `quad()` helper that copy-pasted the bottom face's vertex layout onto the top face without mirroring it) — reproduced independently and confirmed unrelated to OCCTSwift.

## Changes

- `Sources/OCCTSwift/Shape.swift`: doc notes on `mesh(linearDeflection:angularDeflection:)`, `mesh(parameters:)`, `loadSTL(from:)`, `loadSTL(fromPath:)` explaining the orientation guarantees, pointing at `Mesh(vertices:normals:indices:)` for caller-controlled winding.
- `docs/reference/Shape.md`: same notes mirrored into the per-type reference doc.
- `docs/CHANGELOG.md`: v1.15.19 entry (docs + tests only, no binary change).
- New regression tests: `Issue375MeshWindingTests` (`OCCTMeshTests`), `Issue375STLWindingTests` (`OCCTIOTests`).

## Test plan

- [x] `swift build` — zero errors
- [x] `swift test` — all 4432 tests pass (includes 4 new regression tests)
- [x] Ground-truth C++ repro against the pinned xcframework confirms both root causes independent of any Swift-side code

🤖 Generated with [Claude Code](https://claude.com/claude-code)