### PR TITLE
fix(#378): Edge.circleProperties returned nil for every full-circle edge (v1.15.20)

### DIFF
--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -141,17 +141,21 @@ extension Edge {
     public var circleProperties: CircleProperties? {
         guard curveType == .circle else { return nil }
         guard let bounds = parameterBounds else { return nil }
+        let range = bounds.last - bounds.first
+        let full = abs(range - 2 * .pi) < 1e-6
         // For a Geom_Circle parameterisation, start/end parameters are the angles.
         // The point at parameter 0 is on the +X axis of the circle's local frame;
-        // we recover centre and radius from three sampled points.
+        // we recover centre and radius from three sampled points. A full circle
+        // is periodic, so point(at: bounds.last) coincides with point(at: bounds.first)
+        // to floating-point precision — sample interior thirds instead so all
+        // three points are distinct.
         let sample1Param = bounds.first
-        let sample2Param = bounds.first + (bounds.last - bounds.first) * 0.5
-        let sample3Param = bounds.last
+        let sample2Param = bounds.first + range * (full ? 1.0 / 3.0 : 0.5)
+        let sample3Param = bounds.first + range * (full ? 2.0 / 3.0 : 1.0)
         guard let p1 = point(at: sample1Param),
               let p2 = point(at: sample2Param),
               let p3 = point(at: sample3Param) else { return nil }
         guard let (center, radius, axis) = circleThroughThreePoints(p1, p2, p3) else { return nil }
-        let full = abs((bounds.last - bounds.first) - 2 * .pi) < 1e-6
         return CircleProperties(center: center, radius: radius, axis: axis,
                                  isFullCircle: full,
                                  startAngle: bounds.first,

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -3836,6 +3836,26 @@ struct CirclePropertyTests {
         let p3 = SIMD3<Double>(2, 0, 0)
         #expect(circleThroughThreePoints(p1, p2, p3) == nil)
     }
+
+    @Test("Edge.circleProperties recovers a full-circle cap edge (#378)")
+    func edgeCirclePropertiesFullCircle() {
+        guard let cyl = Shape.cylinder(radius: 3, height: 8) else {
+            Issue.record("cyl nil"); return
+        }
+        var foundCircle = false
+        for edge in cyl.edges() where edge.isCircle {
+            guard let bounds = edge.parameterBounds else { continue }
+            #expect(abs((bounds.last - bounds.first) - 2 * .pi) < 1e-6)
+            if let props = edge.circleProperties {
+                #expect(abs(props.radius - 3.0) < 1e-6)
+                #expect(props.isFullCircle)
+                foundCircle = true
+            } else {
+                Issue.record("circleProperties nil for full-circle edge")
+            }
+        }
+        #expect(foundCircle)
+    }
 }
 
 // MARK: - v0.143 D2: Arc/circle in Sketch.buildProfile

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,32 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.19
+## Current: v1.15.20
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353, #374 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.20 (July 2026): fix — `Edge.circleProperties` returned `nil` for every full-circle edge (#378)
+
+`Edge.circleProperties` (`MeasurementHelpers.swift`) fits a circle through three points sampled
+at `[parameterBounds.first, mid, parameterBounds.last]`. For a full circle the underlying curve
+is periodic and `parameterBounds` is `(0, 2π)`, so `point(at: parameterBounds.last)` evaluates to
+the same point as `point(at: parameterBounds.first)` (identical to ~1e-16) — the three-point fit
+then received two coincident points and returned `nil` for every full-circle edge: a drilled
+hole, a bore, a plain cylinder's cap boundary. Partial arcs (`first != last`) were unaffected.
+
+**Fixed:** when `parameterBounds` spans a full `2π` (periodic curve), sample the third point at
+2/3 of the range instead of at `bounds.last`, and the second point at 1/3 instead of the
+midpoint — all three samples land at distinct, non-wrapping parameters. Partial-arc sampling
+(midpoint + `bounds.last`) is unchanged. No public API surface change — same signature, same
+`nil`-for-non-circular-edges contract — so this is a patch per `docs/SEMVER.md`.
+
+**Tests:** `edgeCirclePropertiesFullCircle` (`v0.143 Circle property extraction` suite,
+`OCCTCurveTests`) — a cylinder's two full-circle cap edges now yield non-nil `circleProperties`
+with the correct radius and `isFullCircle == true`; confirmed it fails against the pre-fix code.
 
 ### v1.15.19 (July 2026): docs + tests — `Shape.mesh()`/`Shape.loadSTL()` winding guarantees, retract the #375 "loses winding" concern (#375)
 


### PR DESCRIPTION
## What & why

`Edge.circleProperties` (`MeasurementHelpers.swift`) fits a circle through three points sampled
at `[parameterBounds.first, mid, parameterBounds.last]`. For a full circle the underlying curve
is periodic and `parameterBounds` is `(0, 2π)`, so `point(at: parameterBounds.last)` evaluates to
the same point as `point(at: parameterBounds.first)` (identical to ~1e-16). The three-point fit
then received two coincident points and returned `nil` — for every full-circle edge: a drilled
hole, a bore, a plain cylinder's cap boundary. Partial arcs (`first != last`) were unaffected.

Fix: when `parameterBounds` spans a full `2π` (periodic curve), sample the second/third points at
1/3 and 2/3 of the range instead of the midpoint and `bounds.last` — all three samples land at
distinct, non-wrapping parameters. Partial-arc sampling is unchanged. No public API surface
change, so this is a patch release (v1.15.19 → v1.15.20) per `docs/SEMVER.md`.

Closes #378

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.

## Notes for the reviewer

New regression test `edgeCirclePropertiesFullCircle` (`v0.143 Circle property extraction` suite,
`OCCTCurveTests`) reproduces the issue's exact repro (a cylinder's cap edges) and was confirmed
to fail against the pre-fix code before being confirmed passing against the fix. Full `swift test`
(4433 tests) passes. No xcframework / bridge rebuild needed — pure Swift-side fix.