### PR TITLE
fix(#399): unify the conic preconditions shared by Curve3D's two factory families

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -251,6 +251,28 @@ void OCCTCurve3DD2(OCCTCurve3DRef c, double u,
 
 // Primitive Curves
 
+// Conic dimension preconditions, shared by the two factory families that build the
+// same four curve types: OCCTCurve3DCreate{Circle,Ellipse,Parabola,Hyperbola} (direct
+// Geom_* construction) and OCCTGceMake{CircFromCenterNormal,Elips,Hypr,Parab} (gce_Make*
+// construction). The gce_Make* algorithms only reject strictly-negative dimensions, so
+// before #399 they silently produced degenerate zero-radius/zero-focal curves where the
+// direct family returned null for the identical input. One definition, both families.
+static inline bool occtValidCircleRadius(double radius) {
+    return radius > 0;
+}
+
+static inline bool occtValidEllipseRadii(double majorR, double minorR) {
+    return majorR > 0 && minorR > 0 && minorR <= majorR;
+}
+
+static inline bool occtValidHyperbolaRadii(double majorR, double minorR) {
+    return majorR > 0 && minorR > 0;
+}
+
+static inline bool occtValidParabolaFocal(double focal) {
+    return focal > 0;
+}
+
 OCCTCurve3DRef OCCTCurve3DCreateLine(double px, double py, double pz,
                                       double dx, double dy, double dz) {
     try {
@@ -281,7 +303,7 @@ OCCTCurve3DRef OCCTCurve3DCreateCircle(double cx, double cy, double cz,
                                         double nx, double ny, double nz,
                                         double radius) {
     try {
-        if (radius <= 0) return nullptr;
+        if (!occtValidCircleRadius(radius)) return nullptr;
         gp_Pnt center(cx, cy, cz);
         gp_Dir normal(nx, ny, nz);
         gp_Ax2 axis(center, normal);
@@ -324,7 +346,7 @@ OCCTCurve3DRef OCCTCurve3DCreateEllipse(double cx, double cy, double cz,
                                          double nx, double ny, double nz,
                                          double majorR, double minorR) {
     try {
-        if (majorR <= 0 || minorR <= 0 || minorR > majorR) return nullptr;
+        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
         gp_Ax2 axis(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         Handle(Geom_Ellipse) ellipse = new Geom_Ellipse(axis, majorR, minorR);
         return new OCCTCurve3D(ellipse);
@@ -337,7 +359,7 @@ OCCTCurve3DRef OCCTCurve3DCreateParabola(double cx, double cy, double cz,
                                           double nx, double ny, double nz,
                                           double focal) {
     try {
-        if (focal <= 0) return nullptr;
+        if (!occtValidParabolaFocal(focal)) return nullptr;
         gp_Ax2 axis(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         Handle(Geom_Parabola) parabola = new Geom_Parabola(axis, focal);
         return new OCCTCurve3D(parabola);
@@ -350,7 +372,7 @@ OCCTCurve3DRef OCCTCurve3DCreateHyperbola(double cx, double cy, double cz,
                                            double nx, double ny, double nz,
                                            double majorR, double minorR) {
     try {
-        if (majorR <= 0 || minorR <= 0) return nullptr;
+        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
         gp_Ax2 axis(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         Handle(Geom_Hyperbola) hyp = new Geom_Hyperbola(axis, majorR, minorR);
         return new OCCTCurve3D(hyp);
@@ -2349,6 +2371,7 @@ OCCTCurve3DRef _Nullable OCCTGceMakeCircFromCenterNormal(double cx, double cy, d
                                                           double nx, double ny, double nz,
                                                           double radius) {
     try {
+        if (!occtValidCircleRadius(radius)) return nullptr;
         gce_MakeCirc mc(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), radius);
         if (!mc.IsDone()) return nullptr;
         Handle(Geom_Circle) circ = new Geom_Circle(mc.Value());
@@ -2380,6 +2403,7 @@ OCCTCurve3DRef _Nullable OCCTGceMakeElips(double cx, double cy, double cz,
                                            double nx, double ny, double nz,
                                            double majorRadius, double minorRadius) {
     try {
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
         gce_MakeElips me(gp_Ax2(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), majorRadius, minorRadius);
         if (!me.IsDone()) return nullptr;
         Handle(Geom_Ellipse) elips = new Geom_Ellipse(me.Value());
@@ -2391,6 +2415,7 @@ OCCTCurve3DRef _Nullable OCCTGceMakeHypr(double cx, double cy, double cz,
                                           double nx, double ny, double nz,
                                           double majorRadius, double minorRadius) {
     try {
+        if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
         gce_MakeHypr mh(gp_Ax2(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), majorRadius, minorRadius);
         if (!mh.IsDone()) return nullptr;
         Handle(Geom_Hyperbola) hypr = new Geom_Hyperbola(mh.Value());
@@ -2402,6 +2427,7 @@ OCCTCurve3DRef _Nullable OCCTGceMakeParab(double cx, double cy, double cz,
                                            double nx, double ny, double nz,
                                            double focal) {
     try {
+        if (!occtValidParabolaFocal(focal)) return nullptr;
         gce_MakeParab mp(gp_Ax2(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), focal);
         if (!mp.IsDone()) return nullptr;
         Handle(Geom_Parabola) parab = new Geom_Parabola(mp.Value());

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -94,7 +94,22 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Full circle in a plane defined by center and normal
+    /// Full circle in a plane defined by center and normal.
+    ///
+    /// - Parameters:
+    ///   - center: Circle centre.
+    ///   - normal: Normal of the plane the circle lies in.
+    ///   - radius: Circle radius. Must be `> 0`; zero and negative radii return `nil`.
+    /// - Returns: The circle, or `nil` if `radius <= 0`.
+    ///
+    /// `circleFromCenterNormal(center:normal:radius:)` builds the identical circle through
+    /// OCCT's `gce_MakeCirc` algorithm and enforces the same radius contract.
+    ///
+    /// ```swift
+    /// let c = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)
+    /// #expect(c != nil)
+    /// #expect(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 0) == nil)
+    /// ```
     public static func circle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double) -> Curve3D? {
         guard let h = OCCTCurve3DCreateCircle(center.x, center.y, center.z,
                                                normal.x, normal.y, normal.z,
@@ -118,7 +133,28 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Ellipse in a plane defined by center and normal
+    /// Ellipse in a plane defined by center and normal.
+    ///
+    /// - Parameters:
+    ///   - center: Ellipse centre.
+    ///   - normal: Normal of the plane the ellipse lies in.
+    ///   - majorRadius: Major radius. Must be `> 0` and `>= minorRadius`.
+    ///   - minorRadius: Minor radius. Must be `> 0`.
+    /// - Returns: The ellipse, or `nil` if the radii violate that contract.
+    ///
+    /// `ellipseFromCenterNormal(center:normal:majorRadius:minorRadius:)` builds the identical
+    /// ellipse through OCCT's `gce_MakeElips` algorithm and enforces the same radius contract.
+    ///
+    /// ```swift
+    /// let e = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                         majorRadius: 10, minorRadius: 5)
+    /// #expect(e != nil)
+    /// // minor > major, and a zero minor radius, are both rejected
+    /// #expect(Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                         majorRadius: 5, minorRadius: 10) == nil)
+    /// #expect(Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                         majorRadius: 10, minorRadius: 0) == nil)
+    /// ```
     public static func ellipse(center: SIMD3<Double>, normal: SIMD3<Double>,
                                majorRadius: Double, minorRadius: Double) -> Curve3D? {
         guard let h = OCCTCurve3DCreateEllipse(center.x, center.y, center.z,
@@ -127,7 +163,22 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Parabola in a plane defined by center/normal with given focal length
+    /// Parabola in a plane defined by center/normal with given focal length.
+    ///
+    /// - Parameters:
+    ///   - center: Parabola apex.
+    ///   - normal: Normal of the plane the parabola lies in.
+    ///   - focal: Focal length. Must be `> 0`; zero and negative focal lengths return `nil`.
+    /// - Returns: The parabola, or `nil` if `focal <= 0`.
+    ///
+    /// `parabolaFromCenterNormal(center:normal:focal:)` builds the identical parabola through
+    /// OCCT's `gce_MakeParab` algorithm and enforces the same focal-length contract.
+    ///
+    /// ```swift
+    /// let p = Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 4)
+    /// #expect(p != nil)
+    /// #expect(Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 0) == nil)
+    /// ```
     public static func parabola(center: SIMD3<Double>, normal: SIMD3<Double>,
                                 focal: Double) -> Curve3D? {
         guard let h = OCCTCurve3DCreateParabola(center.x, center.y, center.z,
@@ -136,7 +187,26 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Hyperbola in a plane defined by center/normal
+    /// Hyperbola in a plane defined by center/normal.
+    ///
+    /// - Parameters:
+    ///   - center: Hyperbola centre.
+    ///   - normal: Normal of the plane the hyperbola lies in.
+    ///   - majorRadius: Major radius. Must be `> 0`.
+    ///   - minorRadius: Minor radius. Must be `> 0`. There is no ordering constraint between
+    ///     the two, unlike `ellipse(center:normal:majorRadius:minorRadius:)`.
+    /// - Returns: The hyperbola, or `nil` if either radius is `<= 0`.
+    ///
+    /// `hyperbolaFromCenterNormal(center:normal:majorRadius:minorRadius:)` builds the identical
+    /// hyperbola through OCCT's `gce_MakeHypr` algorithm and enforces the same radius contract.
+    ///
+    /// ```swift
+    /// let h = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                           majorRadius: 8, minorRadius: 3)
+    /// #expect(h != nil)
+    /// #expect(Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                           majorRadius: 0, minorRadius: 3) == nil)
+    /// ```
     public static func hyperbola(center: SIMD3<Double>, normal: SIMD3<Double>,
                                  majorRadius: Double, minorRadius: Double) -> Curve3D? {
         guard let h = OCCTCurve3DCreateHyperbola(center.x, center.y, center.z,
@@ -1130,7 +1200,24 @@ extension Curve3D {
         return Curve3D(handle: h)
     }
 
-    /// Create a circle from center, normal, and radius (gce_MakeCirc)
+    /// Create a circle from center, normal, and radius (`gce_MakeCirc`).
+    ///
+    /// Geometrically identical to `circle(center:normal:radius:)` — `gce_MakeCirc` builds the
+    /// same `gp_Ax2(center, normal)` frame — and, since #399, enforces the same radius contract.
+    ///
+    /// - Parameters:
+    ///   - center: Circle centre.
+    ///   - normal: Normal of the plane the circle lies in.
+    ///   - radius: Circle radius. Must be `> 0`; zero and negative radii return `nil`.
+    /// - Returns: The circle, or `nil` if `radius <= 0`.
+    ///
+    /// ```swift
+    /// let c = Curve3D.circleFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1), radius: 7)
+    /// #expect(c != nil)
+    /// // Same rejection as the direct factory: no degenerate zero-radius circle.
+    /// #expect(Curve3D.circleFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                        radius: 0) == nil)
+    /// ```
     public static func circleFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
                                               radius: Double) -> Curve3D? {
         guard let h = OCCTGceMakeCircFromCenterNormal(center.x, center.y, center.z,
@@ -1154,7 +1241,25 @@ extension Curve3D {
         return SIMD3(x, y, z)
     }
 
-    /// Create an ellipse (gce_MakeElips)
+    /// Create an ellipse (`gce_MakeElips`).
+    ///
+    /// Geometrically identical to `ellipse(center:normal:majorRadius:minorRadius:)` and, since
+    /// #399, enforces the same radius contract.
+    ///
+    /// - Parameters:
+    ///   - center: Ellipse centre.
+    ///   - normal: Normal of the plane the ellipse lies in.
+    ///   - majorRadius: Major radius. Must be `> 0` and `>= minorRadius`.
+    ///   - minorRadius: Minor radius. Must be `> 0`.
+    /// - Returns: The ellipse, or `nil` if the radii violate that contract.
+    ///
+    /// ```swift
+    /// let e = Curve3D.ellipseFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                         majorRadius: 10, minorRadius: 5)
+    /// #expect(e != nil)
+    /// #expect(Curve3D.ellipseFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                         majorRadius: 10, minorRadius: 0) == nil)
+    /// ```
     public static func ellipseFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
                                                majorRadius: Double,
                                                minorRadius: Double) -> Curve3D? {
@@ -1164,7 +1269,25 @@ extension Curve3D {
         return Curve3D(handle: h)
     }
 
-    /// Create a hyperbola (gce_MakeHypr)
+    /// Create a hyperbola (`gce_MakeHypr`).
+    ///
+    /// Geometrically identical to `hyperbola(center:normal:majorRadius:minorRadius:)` and, since
+    /// #399, enforces the same radius contract.
+    ///
+    /// - Parameters:
+    ///   - center: Hyperbola centre.
+    ///   - normal: Normal of the plane the hyperbola lies in.
+    ///   - majorRadius: Major radius. Must be `> 0`.
+    ///   - minorRadius: Minor radius. Must be `> 0`.
+    /// - Returns: The hyperbola, or `nil` if either radius is `<= 0`.
+    ///
+    /// ```swift
+    /// let h = Curve3D.hyperbolaFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                           majorRadius: 8, minorRadius: 3)
+    /// #expect(h != nil)
+    /// #expect(Curve3D.hyperbolaFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                           majorRadius: 8, minorRadius: 0) == nil)
+    /// ```
     public static func hyperbolaFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
                                                  majorRadius: Double,
                                                  minorRadius: Double) -> Curve3D? {
@@ -1174,7 +1297,23 @@ extension Curve3D {
         return Curve3D(handle: h)
     }
 
-    /// Create a parabola (gce_MakeParab)
+    /// Create a parabola (`gce_MakeParab`).
+    ///
+    /// Geometrically identical to `parabola(center:normal:focal:)` and, since #399, enforces the
+    /// same focal-length contract.
+    ///
+    /// - Parameters:
+    ///   - center: Parabola apex.
+    ///   - normal: Normal of the plane the parabola lies in.
+    ///   - focal: Focal length. Must be `> 0`; zero and negative focal lengths return `nil`.
+    /// - Returns: The parabola, or `nil` if `focal <= 0`.
+    ///
+    /// ```swift
+    /// let p = Curve3D.parabolaFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1), focal: 4)
+    /// #expect(p != nil)
+    /// #expect(Curve3D.parabolaFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                          focal: 0) == nil)
+    /// ```
     public static func parabolaFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
                                                 focal: Double) -> Curve3D? {
         guard let h = OCCTGceMakeParab(center.x, center.y, center.z,

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -3992,3 +3992,111 @@ struct CuttingPlaneLineTests {
         #expect(counts.texts >= 2)
     }
 }
+
+// MARK: - #399: direct vs gce_Make* conic factory families
+
+/// The four `Curve3D` conic factories exist twice: a direct family that builds `Geom_*` objects
+/// straight from a `gp_Ax2`, and a `*FromCenterNormal` family that routes through OCCT's
+/// `gce_Make*` algorithms. The two are geometrically identical (`gce_Make*` builds the same
+/// `gp_Ax2(center, normal)` frame), but the `gce_Make*` algorithms only reject strictly-negative
+/// dimensions, so the gce family used to return a degenerate zero-radius/zero-focal curve where
+/// the direct family returned `nil`. Both families now share one set of preconditions.
+@Suite("Curve3D conic factory families agree (#399)")
+struct Curve3DConicFactoryParityTests {
+
+    private static let center = SIMD3<Double>(1, 2, 3)
+    private static let normal = SIMD3<Double>(0, 0, 1)
+
+    @Test("Circle: both families reject zero and negative radius")
+    func circleDegenerateRadiusParity() {
+        for radius in [0.0, -1.0] {
+            #expect(Curve3D.circle(center: Self.center, normal: Self.normal, radius: radius) == nil)
+            #expect(Curve3D.circleFromCenterNormal(center: Self.center, normal: Self.normal,
+                                                   radius: radius) == nil)
+        }
+    }
+
+    @Test("Ellipse: both families reject zero radii and inverted radii")
+    func ellipseDegenerateRadiiParity() {
+        let rejected: [(Double, Double)] = [(10, 0), (0, 0), (5, 10), (10, -1)]
+        for (major, minor) in rejected {
+            #expect(Curve3D.ellipse(center: Self.center, normal: Self.normal,
+                                    majorRadius: major, minorRadius: minor) == nil)
+            #expect(Curve3D.ellipseFromCenterNormal(center: Self.center, normal: Self.normal,
+                                                    majorRadius: major, minorRadius: minor) == nil)
+        }
+    }
+
+    @Test("Hyperbola: both families reject a zero or negative radius")
+    func hyperbolaDegenerateRadiiParity() {
+        let rejected: [(Double, Double)] = [(0, 3), (8, 0), (0, 0), (-8, 3)]
+        for (major, minor) in rejected {
+            #expect(Curve3D.hyperbola(center: Self.center, normal: Self.normal,
+                                      majorRadius: major, minorRadius: minor) == nil)
+            #expect(Curve3D.hyperbolaFromCenterNormal(center: Self.center, normal: Self.normal,
+                                                      majorRadius: major,
+                                                      minorRadius: minor) == nil)
+        }
+    }
+
+    @Test("Parabola: both families reject zero and negative focal length")
+    func parabolaDegenerateFocalParity() {
+        for focal in [0.0, -1.0] {
+            #expect(Curve3D.parabola(center: Self.center, normal: Self.normal, focal: focal) == nil)
+            #expect(Curve3D.parabolaFromCenterNormal(center: Self.center, normal: Self.normal,
+                                                     focal: focal) == nil)
+        }
+    }
+
+    @Test("Valid inputs still build the identical curve in both families")
+    func validInputsProduceMatchingGeometry() {
+        // Circle
+        let c1 = Curve3D.circle(center: Self.center, normal: Self.normal, radius: 7)
+        let c2 = Curve3D.circleFromCenterNormal(center: Self.center, normal: Self.normal, radius: 7)
+        #expect(c1 != nil)
+        #expect(c2 != nil)
+        if let a = c1, let b = c2 {
+            for t in stride(from: 0.0, to: 2 * .pi, by: .pi / 4) {
+                let pa = a.point(at: t), pb = b.point(at: t)
+                #expect(simd_distance(pa, pb) < 1e-9)
+            }
+        }
+
+        // Ellipse
+        let e1 = Curve3D.ellipse(center: Self.center, normal: Self.normal,
+                                 majorRadius: 10, minorRadius: 5)
+        let e2 = Curve3D.ellipseFromCenterNormal(center: Self.center, normal: Self.normal,
+                                                 majorRadius: 10, minorRadius: 5)
+        #expect(e1 != nil)
+        #expect(e2 != nil)
+        if let a = e1, let b = e2 {
+            for t in stride(from: 0.0, to: 2 * .pi, by: .pi / 4) {
+                #expect(simd_distance(a.point(at: t), b.point(at: t)) < 1e-9)
+            }
+        }
+
+        // Hyperbola
+        let h1 = Curve3D.hyperbola(center: Self.center, normal: Self.normal,
+                                   majorRadius: 8, minorRadius: 3)
+        let h2 = Curve3D.hyperbolaFromCenterNormal(center: Self.center, normal: Self.normal,
+                                                   majorRadius: 8, minorRadius: 3)
+        #expect(h1 != nil)
+        #expect(h2 != nil)
+        if let a = h1, let b = h2 {
+            for t in stride(from: -1.0, through: 1.0, by: 0.25) {
+                #expect(simd_distance(a.point(at: t), b.point(at: t)) < 1e-9)
+            }
+        }
+
+        // Parabola
+        let p1 = Curve3D.parabola(center: Self.center, normal: Self.normal, focal: 4)
+        let p2 = Curve3D.parabolaFromCenterNormal(center: Self.center, normal: Self.normal, focal: 4)
+        #expect(p1 != nil)
+        #expect(p2 != nil)
+        if let a = p1, let b = p2 {
+            for t in stride(from: -2.0, through: 2.0, by: 0.5) {
+                #expect(simd_distance(a.point(at: t), b.point(at: t)) < 1e-9)
+            }
+        }
+    }
+}

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -932,8 +932,9 @@ public static func circleFromCenterNormal(
 ```
 
 - **Parameters:** `center` — center of the circle; `normal` — plane normal; `radius` — circle radius.
-- **Returns:** A `Geom_Circle`, or `nil` on failure (e.g. zero normal or radius).
+- **Returns:** A `Geom_Circle`, or `nil` on failure (zero normal, or `radius <= 0`).
 - **OCCT:** `gce_MakeCirc` (center + normal + radius constructor).
+- **Note:** Geometrically identical to [`circle(center:normal:radius:)`](Curve3D.md), which builds the same `gp_Ax2(center, normal)` frame directly. Both enforce the same `radius > 0` precondition — `gce_MakeCirc` itself only rejects a strictly-negative radius, so the bridge adds the zero check to keep the two factories in agreement (#399).
 - **Example:**
   ```swift
   if let c = Curve3D.circleFromCenterNormal(
@@ -1003,8 +1004,9 @@ public static func ellipseFromCenterNormal(
 ```
 
 - **Parameters:** `center` — center of the ellipse; `normal` — plane normal; `majorRadius` — semi-major axis length; `minorRadius` — semi-minor axis length (must be ≤ `majorRadius`).
-- **Returns:** A `Geom_Ellipse`, or `nil` on failure.
+- **Returns:** A `Geom_Ellipse`, or `nil` on failure (either radius `<= 0`, or `minorRadius > majorRadius`).
 - **OCCT:** `gce_MakeElips`.
+- **Note:** Geometrically identical to [`ellipse(center:normal:majorRadius:minorRadius:)`](Curve3D.md), and enforces the same radius preconditions — `gce_MakeElips` itself accepts a zero minor radius, so the bridge adds the zero check to keep the two factories in agreement (#399).
 - **Example:**
   ```swift
   if let e = Curve3D.ellipseFromCenterNormal(
@@ -1030,8 +1032,9 @@ public static func hyperbolaFromCenterNormal(
 ```
 
 - **Parameters:** `center` — center; `normal` — plane normal; `majorRadius` — semi-transverse axis; `minorRadius` — semi-conjugate axis.
-- **Returns:** A `Geom_Hyperbola`, or `nil` on failure.
+- **Returns:** A `Geom_Hyperbola`, or `nil` on failure (either radius `<= 0`).
 - **OCCT:** `gce_MakeHypr`.
+- **Note:** Geometrically identical to [`hyperbola(center:normal:majorRadius:minorRadius:)`](Curve3D.md), and enforces the same radius preconditions — `gce_MakeHypr` itself accepts a zero radius, so the bridge adds the zero check to keep the two factories in agreement (#399).
 - **Example:**
   ```swift
   if let h = Curve3D.hyperbolaFromCenterNormal(
@@ -1054,8 +1057,9 @@ public static func parabolaFromCenterNormal(
 ```
 
 - **Parameters:** `center` — vertex (apex) of the parabola; `normal` — plane normal; `focal` — focal distance (distance from vertex to focus).
-- **Returns:** A `Geom_Parabola`, or `nil` on failure.
+- **Returns:** A `Geom_Parabola`, or `nil` on failure (`focal <= 0`).
 - **OCCT:** `gce_MakeParab`.
+- **Note:** Geometrically identical to [`parabola(center:normal:focal:)`](Curve3D.md), and enforces the same focal-length precondition — `gce_MakeParab` itself accepts a zero focal length, so the bridge adds the zero check to keep the two factories in agreement (#399).
 - **Example:**
   ```swift
   if let p = Curve3D.parabolaFromCenterNormal(

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -249,6 +249,7 @@ The circle is periodic with period `2π`. The X axis of the local frame is deter
 - **Parameters:** `center` — circle centre; `normal` — plane normal; `radius` — circle radius (must be > 0).
 - **Returns:** Full circle curve, or `nil` if `radius ≤ 0` or `normal` is zero.
 - **OCCT:** `Geom_Circle(gp_Ax2(...), radius)`.
+- **See also:** [`circleFromCenterNormal(center:normal:radius:)`](Curve3D-Analysis.md) builds the identical circle through OCCT's `gce_MakeCirc` algorithm and enforces the same `radius > 0` contract (#399). The same pairing exists for `ellipse`/`ellipseFromCenterNormal`, `hyperbola`/`hyperbolaFromCenterNormal` and `parabola`/`parabolaFromCenterNormal`.
 - **Example:**
   ```swift
   let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!


### PR DESCRIPTION
## What & why

`Curve3D` builds four conic types through two parallel factory families with identical
signatures: a direct one (`circle`/`ellipse`/`parabola`/`hyperbola`, which constructs `Geom_*`
objects from a hand-built `gp_Ax2`) and a `*FromCenterNormal` one routed through OCCT's
`gce_Make*` algorithms. They are geometrically identical — `gce_MakeCirc(P, N, R)` builds the
very same `gp_Ax2(P, N)` frame — but only the direct family ever got explicit dimension guards.

The `gce_Make*` algorithms reject only *strictly negative* dimensions, so all four pairs
disagreed at the zero boundary. `Curve3D.circle(radius: 0)` returns `nil`;
`Curve3D.circleFromCenterNormal(radius: 0)` returned a live, degenerate zero-radius curve. Same
for `ellipseFromCenterNormal(minorRadius: 0)`, `hyperbolaFromCenterNormal` with either radius 0,
and `parabolaFromCenterNormal(focal: 0)`.

Both families now route through one set of preconditions in `OCCTBridge_Curve3D.mm`
(`occtValidCircleRadius`, `occtValidEllipseRadii`, `occtValidHyperbolaRadii`,
`occtValidParabolaFocal`), so the contract is stated once and cannot drift apart again.

Refs #399. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve3DConicFactoryParityTests` (`Tests/OCCTCurveTests`) cross-checks each pair at the
boundary in both directions: all four pairs reject the same degenerate inputs, and for valid
inputs both families are sampled along the curve and asserted to agree to 1e-9. It also closes
the direct family's own gaps the issue flagged — there was no zero-rejection test for
`hyperbola` or `parabola` at all.

## Notes for the reviewer

**The auditor's original claim needed correcting, and the issue body already records this**: the
finding said the two families disagreed on inverted ellipse radii (`majorRadius < minorRadius`).
They do not — `gce_MakeElips` rejects that itself with `gce_InvertRadius`. The real, verified
divergence is the zero boundary, and it affected all four pairs rather than just the ellipse.

**Verification that the bug was live**, not just theoretically reachable: reverting only
`OCCTBridge_Curve3D.mm` and re-running the new suite fails with 7 issues — circle 1, ellipse 2,
hyperbola 3, parabola 1. That distribution is itself the confirmation of the correction above:
the inverted-radii and negative-radii cases in the same test tables pass *before* the fix, so
only the zero cases were ever divergent.

**Why guards rather than delegation.** Having the gce family call the direct bridge functions
would also give one code path, but it would make the documented `gce_Make*` provenance false
(`docs/API_REFERENCE.md` maps these to the gce factories) and would silently change which OCCT
algorithm runs. Sharing the precondition helpers fixes the drift where it actually lived, keeps
both OCCT paths intact, and also fixes any direct C consumer of the bridge functions.

**Unified on the stricter contract** (reject zero) rather than the looser one: a zero-radius
circle or zero-focal parabola is a degenerate curve with no useful downstream behaviour, and the
direct family's `nil` is the already-documented and already-tested contract.

Full `swift test` (4438 tests) clean. One unrelated intermittent failure appeared in one of three
runs — `"Shape.loadRobust interrupts repair, not just the transfer (#300)"`, the CPU-timing-
sensitive cancellation test whose own source comment documents it as flaky under parallel
execution — and passed in the other two.

No `CHANGELOG.md` / version entry here deliberately: the audit branch merges to `main` as one
unit, and six parallel child PRs each editing the same changelog header would conflict on every
one. The release entry lands with the branch merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)