### PR TITLE
fix(#401): route Surface.normal(u:v:) through the same degeneracy test as normal(atU:v:)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -4967,20 +4967,17 @@ const char* OCCTSurfaceTypeName(OCCTSurfaceRef surface) {
 // MARK: - v0.115: Surface additional (Normal + Curvatures)
 // --- Surface additional (new in v0.115.0) ---
 
+// Non-optional-return counterpart of OCCTSurfaceGetNormal. It keeps its own contract — a
+// zero vector where the normal is undefined, since the Swift wrapper returns a plain
+// SIMD3 — but delegates the computation so the two entry points cannot disagree about
+// *where* the normal is undefined. It used to hand-roll D1 + gp_Vec::Crossed against a
+// literal 1e-15 magnitude epsilon, which classified degeneracy differently from
+// GeomLProp_SLProps::IsNormalDefined() near a singularity (#401).
 void OCCTSurfaceNormal(OCCTSurfaceRef surface, double u, double v,
                          double* nx, double* ny, double* nz) {
+    if (!nx || !ny || !nz) return;
     *nx = *ny = *nz = 0;
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        gp_Pnt p;
-        gp_Vec d1u, d1v;
-        surface->surface->D1(u, v, p, d1u, d1v);
-        gp_Vec normal = d1u.Crossed(d1v);
-        if (normal.Magnitude() > 1e-15) {
-            normal.Normalize();
-            *nx = normal.X(); *ny = normal.Y(); *nz = normal.Z();
-        }
-    } catch (...) {}
+    OCCTSurfaceGetNormal(surface, u, v, nx, ny, nz);
 }
 
 #include <GeomLProp_SLProps.hxx>

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -4980,8 +4980,6 @@ void OCCTSurfaceNormal(OCCTSurfaceRef surface, double u, double v,
     OCCTSurfaceGetNormal(surface, u, v, nx, ny, nz);
 }
 
-#include <GeomLProp_SLProps.hxx>
-
 void OCCTSurfaceCurvatures(OCCTSurfaceRef surface, double u, double v,
                              double* gaussian, double* mean) {
     *gaussian = *mean = 0;

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2223,7 +2223,33 @@ extension Surface {
         return Surface(handle: ref)
     }
 
-    /// Compute the surface normal at (u, v).
+    /// Compute the surface normal at (u, v), returning the zero vector where it is undefined.
+    ///
+    /// This is the non-optional counterpart of `normal(atU:v:)`. Both evaluate the same
+    /// `GeomLProp_SLProps` normal and use the same degeneracy test, so they always agree on
+    /// *where* the normal exists — they differ only in how they report its absence: this method
+    /// returns `SIMD3(0, 0, 0)`, `normal(atU:v:)` returns `nil`. Prefer `normal(atU:v:)` when you
+    /// need to tell "undefined" apart from a genuine result.
+    ///
+    /// - Parameters:
+    ///   - u: U parameter.
+    ///   - v: V parameter.
+    /// - Returns: The unit normal, or `SIMD3(0, 0, 0)` at a singular point (a sphere pole, a cone
+    ///   apex) where the tangent plane is degenerate.
+    ///
+    /// ```swift
+    /// let sphere = Surface.sphere(center: .zero, radius: 5)!
+    /// let n = sphere.normal(u: 0, v: .pi / 4)     // unit length
+    /// #expect(abs(simd_length(n) - 1) < 1e-9)
+    ///
+    /// // A cone apex is a genuine singularity: zero vector here, nil from normal(atU:v:).
+    /// let cone = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 0, semiAngle: .pi / 6)!
+    /// #expect(simd_length(cone.normal(u: 0, v: 0)) < 1e-12)
+    /// #expect(cone.normal(atU: 0, v: 0) == nil)
+    /// ```
+    ///
+    /// > A sphere pole (`v = ±π/2`) is *not* one of these points — `GeomLProp_SLProps` still
+    /// > resolves a normal there, and both methods return it.
     public func normal(u: Double, v: Double) -> SIMD3<Double> {
         var nx = 0.0, ny = 0.0, nz = 0.0
         OCCTSurfaceNormal(handle, u, v, &nx, &ny, &nz)

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -5334,3 +5334,88 @@ struct GeomFillGordonReportTests {
     }
 }
 
+// MARK: - #401: the two Surface normal entry points
+
+/// `Surface` exposes the same normal twice: `normal(atU:v:)` returns an optional and reports an
+/// undefined normal as `nil`, `normal(u:v:)` returns a plain vector and reports it as
+/// `SIMD3(0, 0, 0)`. That difference in *reporting* is intentional. What was not intentional is
+/// that they used to disagree about *where* the normal is undefined: `normal(u:v:)` hand-rolled
+/// `D1` + a cross product against a literal `1e-15` magnitude epsilon instead of asking
+/// `GeomLProp_SLProps::IsNormalDefined()`, so near a singularity each could call the point
+/// degenerate when the other did not.
+@Suite("Surface normal entry points agree (#401)")
+struct SurfaceNormalParityTests {
+
+    /// A cone with `radius: 0` at the origin has its apex exactly at `v = 0`.
+    private static func apexCone() -> Surface {
+        Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 0, semiAngle: .pi / 6)!
+    }
+
+    @Test("Regular points: both entry points return the same unit normal")
+    func regularPointsAgree() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+        let cone = Self.apexCone()
+
+        let samples: [(Surface, Double, Double)] = [
+            (sphere, 0, 0), (sphere, .pi / 3, .pi / 4), (sphere, 1.2, -0.8),
+            (plane, 0, 0), (plane, 3, -7),
+            (cone, 0, 5), (cone, .pi / 2, -5),
+        ]
+        for (surface, u, v) in samples {
+            let optional = surface.normal(atU: u, v: v)
+            let plain = surface.normal(u: u, v: v)
+            #expect(optional != nil)
+            if let n = optional {
+                #expect(simd_distance(n, plain) < 1e-12)
+                #expect(abs(simd_length(plain) - 1) < 1e-9)
+            }
+        }
+    }
+
+    @Test("Cone apex: nil from the optional entry point, zero vector from the plain one")
+    func coneApexIsUndefinedInBoth() {
+        let cone = Self.apexCone()
+        #expect(cone.normal(atU: 0, v: 0) == nil)
+        #expect(simd_length(cone.normal(u: 0, v: 0)) < 1e-12)
+    }
+
+    /// Regression for the divergence window the hand-rolled epsilon created. Arbitrarily close to
+    /// (but not at) the apex the cross product `d1u × d1v` underflows the old literal `1e-15`
+    /// magnitude test, so `normal(u:v:)` returned a spurious zero vector — while OCCT's own
+    /// `IsNormalDefined()` resolves a perfectly good normal there, the same one every other point
+    /// on that generatrix has.
+    @Test("Near-apex: a defined normal is no longer reported as a zero vector")
+    func nearApexNormalIsNotSpuriouslyZero() {
+        let cone = Self.apexCone()
+        let v = 1e-16                       // |d1u x d1v| ≈ 5e-17, under the old 1e-15 epsilon
+
+        let (_, d1u, d1v) = cone.d1(atU: 0, v: v)
+        #expect(simd_length(simd_cross(d1u, d1v)) < 1e-15)   // the window really is entered
+
+        let optional = cone.normal(atU: 0, v: v)
+        let plain = cone.normal(u: 0, v: v)
+        #expect(optional != nil)                             // OCCT says the normal exists
+        #expect(abs(simd_length(plain) - 1) < 1e-9)          // ... and so does normal(u:v:) now
+        if let n = optional {
+            #expect(simd_distance(n, plain) < 1e-12)
+        }
+        // Same normal as a well-conditioned point on the same generatrix.
+        #expect(simd_distance(plain, cone.normal(u: 0, v: 5)) < 1e-9)
+    }
+
+    /// A sphere pole is a parameterisation singularity but not a normal singularity: OCCT still
+    /// resolves the tangent plane there. Pinned because the finding assumed otherwise.
+    @Test("Sphere pole is not a normal singularity")
+    func spherePoleStillHasANormal() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        for v in [Double.pi / 2, -Double.pi / 2] {
+            let optional = sphere.normal(atU: 0, v: v)
+            #expect(optional != nil)
+            if let n = optional {
+                #expect(simd_distance(n, sphere.normal(u: 0, v: v)) < 1e-12)
+                #expect(abs(abs(n.z) - 1) < 1e-9)
+            }
+        }
+    }
+}

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -287,7 +287,8 @@ public func normal(atU u: Double, v: Double) -> SIMD3<Double>?
 
 - **Parameters:** `u` — U parameter; `v` — V parameter.
 - **Returns:** Unit normal vector, or `nil` at singular points where the tangent plane is degenerate.
-- **OCCT:** `GeomLProp_SLProps::Normal`.
+- **OCCT:** `GeomLProp_SLProps::Normal` (order 1, `Precision::Confusion()`), gated on `IsNormalDefined()`.
+- **See also:** [`normal(u:v:)`](#normaluv) — same computation and same degeneracy test, but returns the zero vector instead of `nil` where the normal is undefined (#401).
 - **Example:**
   ```swift
   if let n = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!.normal(atU: 0, v: 0) {
@@ -1248,11 +1249,21 @@ Computes the surface normal at (u, v).
 public func normal(u: Double, v: Double) -> SIMD3<Double>
 ```
 
-Always returns a vector; at singular points the result may be the zero vector. Prefer the optional-returning `normal(atU:v:)` (from the Evaluation section) when singularity detection matters.
+Always returns a vector; where the normal is undefined the result is the zero vector. Prefer the optional-returning `normal(atU:v:)` (from the Evaluation section) when you need to tell "undefined" apart from a genuine result.
+
+Both entry points evaluate the same `GeomLProp_SLProps` normal and gate on the same `IsNormalDefined()` test, so they always agree on *where* the normal exists — they differ only in how the absence is reported (`nil` vs. the zero vector). Before #401 this method hand-rolled `Geom_Surface::D1` plus a cross product against a literal `1e-15` magnitude epsilon, which classified degeneracy differently: arbitrarily close to a cone apex it returned a spurious zero vector for a normal OCCT resolves perfectly well.
+
+A cone apex is a genuine singularity for this test; a sphere pole (`v = ±π/2`) is not — OCCT still resolves the tangent plane there.
 
 - **Parameters:** `u` — U parameter; `v` — V parameter.
-- **Returns:** Surface normal vector at (u, v).
-- **OCCT:** `GeomLProp_SLProps::Normal`.
+- **Returns:** Unit surface normal at (u, v), or `SIMD3(0, 0, 0)` where the normal is undefined.
+- **OCCT:** `GeomLProp_SLProps::Normal` (via the shared `OCCTSurfaceGetNormal` bridge path).
+- **Example:**
+  ```swift
+  let cone = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 0, semiAngle: .pi / 6)!
+  #expect(simd_length(cone.normal(u: 0, v: 0)) < 1e-12)   // apex: undefined
+  #expect(cone.normal(atU: 0, v: 0) == nil)               // ... reported as nil here
+  ```
 
 ---
 


### PR DESCRIPTION
## What & why

`Surface` exposes the same normal twice. `normal(atU:v:)` asks OCCT — `GeomLProp_SLProps`, gated
on `IsNormalDefined()` — and returns `nil` where the tangent plane is degenerate. `normal(u:v:)`
returns a plain `SIMD3` and reports the same condition as `SIMD3(0, 0, 0)`. That difference in
*reporting* is intentional and already documented.

What was not intentional is that the two disagreed about **where** the normal is undefined.
`normal(u:v:)` hand-rolled `Geom_Surface::D1` + `gp_Vec::Crossed` and tested the cross product
against a literal `1e-15` magnitude epsilon that has no relation to the `Precision::Confusion()`
its sibling uses. `OCCTSurfaceNormal` now delegates to `OCCTSurfaceGetNormal` and zeroes its
outputs when that reports undefined, so one computation and one degeneracy test back both entry
points. The public signature and the zero-vector contract are unchanged.

Refs #401. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `SurfaceNormalParityTests` (`Tests/OCCTSurfaceTests`): regular-point agreement across
sphere/plane/cone, the true singular case, the near-singular regression, and the sphere pole.
Before this PR *no* test evaluated either method at or near a singularity in either direction.

## Notes for the reviewer

Two things the finding got wrong, both worth knowing before review:

**1. The divergence runs the opposite way.** The finding predicted `normal(u:v:)` would silently
return zero where `normal(atU:v:)` returns `nil`. Measured on a cone apexed at the origin:

| v | \|d1u × d1v\| | old `normal(u:v:)` | `normal(atU:v:)` |
|---|---|---|---|
| 1e-12 | 5e-13 | unit normal | defined |
| **1e-16** | **5e-17** | **(0,0,0)** | **defined** |
| 0 (apex) | 0 | (0,0,0) | `nil` |

At the true apex the two already agreed. The real failure was at `v = 1e-16`, where the old
epsilon fired on a normal OCCT resolves perfectly well — a false *"undefined"*, not a silent zero
standing in for one. The new near-apex test pins exactly that point, and asserts the recovered
normal matches a well-conditioned point on the same generatrix.

**2. A sphere pole is not a singularity here.** The finding suggested `v = ±π/2` on a sphere as
the case to test. It is a parameterisation singularity but not a normal singularity — OCCT
resolves the tangent plane there and both methods return `(0,0,±1)`. A test pins that so the next
reader does not go looking for a bug in it.

**Docs.** The finding was right that `docs/reference/Surface.md:1255` attributed `normal(u:v:)` to
`GeomLProp_SLProps::Normal` when the code used nothing of the sort. That attribution is now
accurate rather than aspirational, and both entries cross-reference each other with the
singular/non-singular examples above.

**Why not make `normal(u:v:)` optional-returning.** That would be the cleaner API, but it is a
source-breaking change to a public method for a repo that ships semver releases, and the
zero-vector contract is deliberate and documented. The defect worth fixing was the disagreement,
not the signature.

Verified: reverting only `OCCTBridge_Surface.mm` fails the near-apex test with 3 issues. Full
`swift test` (4437 tests) clean.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and six parallel child PRs each editing the same changelog header would conflict on every
one.

**Conflict note:** #405 also edits `OCCTBridge_Surface.mm`, in the adjacent `v0.115` block. If
both land, expect a small textual conflict there; the changes are independent in substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)