### PR TITLE
fix(#411): unify the radius precondition behind Curve2D's two circle factories

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -102,6 +102,15 @@
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
 
+// Radius precondition for the 2D circle factories. Curve2D builds a circle from a centre and a
+// radius through two entry points — OCCTCurve2DCreateCircle (direct Geom2d_Circle construction)
+// and OCCTGceMakeCirc2dFromCenterRadius (gce_MakeCirc2d) — and gce_MakeCirc2d accepts
+// Radius >= 0, so before #411 the gce path returned a live, degenerate zero-radius circle where
+// the direct path returned null for the identical input. One definition, both entry points.
+static inline bool occtValidCircle2dRadius(double radius) {
+    return radius > 0;
+}
+
 // MARK: - Batch Curve2D Evaluation (v0.28.0)
 
 #include <Geom2dGridEval_Curve.hxx>
@@ -2872,6 +2881,7 @@ OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef curve1, d
 // MARK: - gce_Make Circ2d / Lin2d / Elips2d / Hypr2d / Parab2d (v0.80)
 OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius) {
     try {
+        if (!occtValidCircle2dRadius(radius)) return nullptr;
         gce_MakeCirc2d mc(gp_Pnt2d(cx, cy), radius);
         if (!mc.IsDone()) return nullptr;
         Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
@@ -5023,7 +5033,7 @@ OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, doub
 
 OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius) {
     try {
-        if (radius <= 0) return nullptr;
+        if (!occtValidCircle2dRadius(radius)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Ax2d axis(center, gp_Dir2d(1, 0));
         Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
@@ -5036,7 +5046,7 @@ OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius) {
 OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx, double cy, double radius,
                                             double startAngle, double endAngle) {
     try {
-        if (radius <= 0) return nullptr;
+        if (!occtValidCircle2dRadius(radius)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Ax2d axis(center, gp_Dir2d(1, 0));
         Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -111,6 +111,20 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Create a full circle.
+    ///
+    /// - Parameters:
+    ///   - center: Circle centre.
+    ///   - radius: Circle radius. Must be `> 0`; zero and negative radii return `nil`.
+    /// - Returns: The circle, or `nil` if `radius <= 0`.
+    ///
+    /// `circleFromCenterRadius(center:radius:)` builds the identical circle through OCCT's
+    /// `gce_MakeCirc2d` algorithm and enforces the same radius contract.
+    ///
+    /// ```swift
+    /// let c = Curve2D.circle(center: .zero, radius: 5)
+    /// #expect(c?.isPeriodic == true)
+    /// #expect(Curve2D.circle(center: .zero, radius: 0) == nil)
+    /// ```
     public static func circle(center: SIMD2<Double>, radius: Double) -> Curve2D? {
         guard let h = OCCTCurve2DCreateCircle(center.x, center.y, radius) else { return nil }
         return Curve2D(handle: h)
@@ -1858,7 +1872,22 @@ extension Curve2D {
                                     point2: SIMD2(r.x2, r.y2), param2: r.param2)
     }
 
-    /// Create a 2D circle from center + radius (gce_MakeCirc2d)
+    /// Create a 2D circle from center + radius (`gce_MakeCirc2d`).
+    ///
+    /// Geometrically identical to `circle(center:radius:)` — both produce a `Geom2d_Circle` on
+    /// the same X-axis-oriented frame — and, since #411, enforces the same radius contract.
+    ///
+    /// - Parameters:
+    ///   - center: Circle centre.
+    ///   - radius: Circle radius. Must be `> 0`; zero and negative radii return `nil`.
+    /// - Returns: The circle, or `nil` if `radius <= 0`.
+    ///
+    /// ```swift
+    /// let c = Curve2D.circleFromCenterRadius(center: .zero, radius: 5)
+    /// #expect(c != nil)
+    /// // Same rejection as the direct factory: no degenerate zero-radius circle.
+    /// #expect(Curve2D.circleFromCenterRadius(center: .zero, radius: 0) == nil)
+    /// ```
     public static func circleFromCenterRadius(center: SIMD2<Double>,
                                               radius: Double) -> Curve2D? {
         guard let h = OCCTGceMakeCirc2dFromCenterRadius(center.x, center.y, radius) else { return nil }

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4071,3 +4071,40 @@ struct Section2DTests {
         }
     }
 }
+
+// MARK: - #411: Curve2D's two centre+radius circle factories
+
+/// `Curve2D.circle(center:radius:)` builds a `Geom2d_Circle` directly;
+/// `Curve2D.circleFromCenterRadius(center:radius:)` routes through OCCT's `gce_MakeCirc2d`.
+/// Same purpose, same signature, same resulting circle — but `gce_MakeCirc2d` accepts
+/// `Radius >= 0`, so the gce factory used to return a live degenerate zero-radius curve where
+/// the direct factory returned `nil`. Both now share one radius precondition.
+@Suite("Curve2D circle factories agree (#411)")
+struct Curve2DCircleFactoryParityTests {
+
+    @Test("Both factories reject zero and negative radius")
+    func degenerateRadiusParity() {
+        for radius in [0.0, -1.0, -5.0] {
+            #expect(Curve2D.circle(center: .zero, radius: radius) == nil)
+            #expect(Curve2D.circleFromCenterRadius(center: .zero, radius: radius) == nil)
+        }
+    }
+
+    @Test("Both factories build the identical circle for a valid radius")
+    func validRadiusProducesMatchingGeometry() {
+        let center = SIMD2<Double>(3, -4)
+        let direct = Curve2D.circle(center: center, radius: 5)
+        let gce = Curve2D.circleFromCenterRadius(center: center, radius: 5)
+        #expect(direct != nil)
+        #expect(gce != nil)
+        guard let a = direct, let b = gce else { return }
+
+        #expect(a.isClosed == b.isClosed)
+        #expect(a.isPeriodic == b.isPeriodic)
+        for t in stride(from: 0.0, to: 2 * .pi, by: .pi / 6) {
+            let pa = a.point(at: t), pb = b.point(at: t)
+            #expect(abs(pa.x - pb.x) < 1e-9)
+            #expect(abs(pa.y - pb.y) < 1e-9)
+        }
+    }
+}

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1082,9 +1082,10 @@ Creates a 2D circle from a center point and radius using `gce_MakeCirc2d`.
 public static func circleFromCenterRadius(center: SIMD2<Double>, radius: Double) -> Curve2D?
 ```
 
-- **Parameters:** `center` — center point; `radius` — radius.
-- **Returns:** `Curve2D` (circle), or `nil` on failure (e.g. radius ≤ 0).
+- **Parameters:** `center` — center point; `radius` — radius (must be > 0).
+- **Returns:** `Curve2D` (circle), or `nil` if `radius ≤ 0`.
 - **OCCT:** `gce_MakeCirc2d` (center + radius constructor).
+- **Note:** Geometrically identical to [`circle(center:radius:)`](Curve2D.md), and enforces the same radius precondition. `gce_MakeCirc2d` itself accepts `Radius >= 0`, so the bridge adds the zero check to keep the two factories in agreement — before #411 this page documented the `radius ≤ 0` rejection that only the direct factory actually performed.
 - **Example:**
   ```swift
   if let c = Curve2D.circleFromCenterRadius(center: SIMD2(1, 2), radius: 4) {

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -245,6 +245,7 @@ The circle is periodic with period `2π`. U=0 starts on the positive X axis of t
 - **Parameters:** `center` — circle centre; `radius` — circle radius (must be > 0).
 - **Returns:** Full circle curve, or `nil` if `radius ≤ 0`.
 - **OCCT:** `Geom2d_Circle(gp_Circ2d(...))`.
+- **See also:** [`circleFromCenterRadius(center:radius:)`](Curve2D-Analysis.md) builds the identical circle through OCCT's `gce_MakeCirc2d` algorithm and enforces the same `radius > 0` contract (#411).
 - **Example:**
   ```swift
   let circle = Curve2D.circle(center: .zero, radius: 5)!


### PR DESCRIPTION
## What & why

`Curve2D` has two public, same-signature, same-purpose static factories for a circle from a
centre and radius. `circle(center:radius:)` constructs `Geom2d_Circle` directly and rejects
`radius <= 0`. `circleFromCenterRadius(center:radius:)` routes through `gce_MakeCirc2d`, which
accepts `Radius >= 0` — so at radius exactly `0` it returned a live, degenerate zero-radius curve
where its sibling returned `nil`. Negative radii were already rejected by both, so the drift was
specifically the zero boundary.

Both now share `occtValidCircle2dRadius` in `OCCTBridge_Geom2d.mm`, along with
`OCCTCurve2DCreateArcOfCircle`, which guards the same quantity in the same file.

Refs #411. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve2DCircleFactoryParityTests` (`Tests/OCCTGeom2dTests`): both factories reject the
same degenerate radii, and for a valid radius both are sampled around the circle and asserted to
agree to 1e-9. `circleFromCenterRadius` previously had three call sites in the whole test suite,
all at positive radii.

## Notes for the reviewer

**The docs already promised the contract the code didn't implement.**
`docs/reference/Curve2D-Analysis.md` documented `circleFromCenterRadius` as returning `nil` "on
failure (e.g. radius ≤ 0)". That was simply false before this change. It settles which way to
unify: the stricter contract is the one both the direct factory and the published documentation
already claimed, so this is the code catching up rather than a behaviour change anyone was
relying on.

**Verification that the bug was live:** reverting only `OCCTBridge_Geom2d.mm` fails the new suite
on the radius-0 case and only that case — which independently confirms the issue's finding that
negative radii were already consistent (`gce_MakeCirc2d` sets `gce_NegativeRadius` for
`Radius < 0`).

Full `swift test` (4435 tests) clean.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and six parallel child PRs each editing the same changelog header would conflict on every
one.

**Conflict note:** #412 and #413 also edit `OCCTBridge_Geom2d.mm` and `Curve2D.swift`, in
different regions. The changes are independent in substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)