### PR TITLE
fix(#412): make Curve2D.interpolatePeriodic delegate instead of reimplementing

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -4059,20 +4059,14 @@ OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points, int32_t count
     } catch (...) { return nullptr; }
 }
 
+// Exactly OCCTCurve2DInterpolate with the periodicity flag pinned. It used to be a second,
+// independent Geom2dAPI_Interpolate call site, which had already drifted: it rejected count < 3
+// where the general entry point rejects only count < 2, so the same 2-point input reached OCCT
+// through one and not the other. Forwarding keeps the C ABI while leaving one implementation
+// (#412). Callers that need a tolerance other than the default should call
+// OCCTCurve2DInterpolate directly with closed = true.
 OCCTCurve2DRef OCCTInterpolate2DPeriodic(const double* points, int32_t count) {
-    if (!points || count < 3) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i*2], points[i*2+1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, Standard_True, 1e-6);
-        interp.Perform();
-        if (interp.IsDone()) {
-            return (OCCTCurve2DRef)new OCCTCurve2D{interp.Curve()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+    return OCCTCurve2DInterpolate(points, count, true, 1e-6);
 }
 // --- GeomAPI_PointsToBSpline expansion ---
 // Helper: map continuity int → GeomAbs_Shape (duplicate of Curve3D's mapContinuityV115, ODR-safe)

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -260,6 +260,23 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Interpolate a smooth B-spline curve through the given points.
+    ///
+    /// - Parameters:
+    ///   - points: Points to interpolate. At least 2.
+    ///   - closed: Pass `true` for a periodic loop that closes back to `points[0]` — do not repeat
+    ///     the first point at the end. `interpolatePeriodic(points:tolerance:)` is a spelling of
+    ///     this case and delegates here.
+    ///   - tolerance: Interpolation tolerance.
+    /// - Returns: The interpolated curve, or `nil` if interpolation fails.
+    ///
+    /// ```swift
+    /// let open = Curve2D.interpolate(through: [SIMD2(0, 0), SIMD2(5, 3), SIMD2(10, 0)])
+    /// #expect(open?.isPeriodic == false)
+    ///
+    /// let loop = Curve2D.interpolate(through: [SIMD2(0, 0), SIMD2(10, 0), SIMD2(5, 8)],
+    ///                                closed: true, tolerance: 1e-4)
+    /// #expect(loop?.isPeriodic == true)
+    /// ```
     public static func interpolate(through points: [SIMD2<Double>], closed: Bool = false,
                                    tolerance: Double = 1e-6) -> Curve2D? {
         let flat = points.flatMap { [$0.x, $0.y] }
@@ -2154,13 +2171,32 @@ extension Curve2D {
     }
 
     /// Interpolate a periodic (closed) 2D BSpline through points.
-    public static func interpolatePeriodic(points: [SIMD2<Double>]) -> Curve2D? {
-        var flat = [Double]()
-        for p in points { flat.append(contentsOf: [p.x, p.y]) }
-        guard let ref = flat.withUnsafeBufferPointer({ buf in
-            OCCTInterpolate2DPeriodic(buf.baseAddress!, Int32(points.count))
-        }) else { return nil }
-        return Curve2D(handle: ref)
+    ///
+    /// A spelling of `interpolate(through:closed:tolerance:)` with `closed: true`, and it
+    /// delegates to it — the two cannot produce different curves for the same input.
+    ///
+    /// - Parameters:
+    ///   - points: Points to interpolate. At least 2; the curve closes back to `points[0]`, so
+    ///     do not repeat the first point at the end.
+    ///   - tolerance: Interpolation tolerance. Defaults to `1e-6`, which is what this method used
+    ///     to hardcode with no way to change it (#412).
+    /// - Returns: The periodic curve, or `nil` if interpolation fails.
+    ///
+    /// ```swift
+    /// let loop = Curve2D.interpolatePeriodic(points: [
+    ///     SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 10), SIMD2(0, 10),
+    /// ])
+    /// #expect(loop?.isPeriodic == true)
+    ///
+    /// // Identical to spelling it out on the general factory:
+    /// let same = Curve2D.interpolate(through: [
+    ///     SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 10), SIMD2(0, 10),
+    /// ], closed: true)
+    /// #expect(loop?.domain == same?.domain)
+    /// ```
+    public static func interpolatePeriodic(points: [SIMD2<Double>],
+                                           tolerance: Double = 1e-6) -> Curve2D? {
+        interpolate(through: points, closed: true, tolerance: tolerance)
     }
 
     /// Approximate a 2D BSpline through points with degree and continuity control.

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4071,3 +4071,73 @@ struct Section2DTests {
         }
     }
 }
+
+// MARK: - #412: interpolatePeriodic is interpolate(closed: true)
+
+/// `Curve2D.interpolatePeriodic(points:)` and `Curve2D.interpolate(through:closed:tolerance:)`
+/// wrap the same `Geom2dAPI_Interpolate` constructor with the same `Perform()`/`IsDone()`/
+/// `Curve()` sequence. As two independent implementations they had already drifted: the periodic
+/// one pinned the tolerance at `1e-6` with no way to reach it, and rejected `count < 3` where the
+/// general one rejects only `count < 2`. It now delegates.
+@Suite("Curve2D periodic interpolation delegates (#412)")
+struct Curve2DInterpolatePeriodicParityTests {
+
+    private static let square: [SIMD2<Double>] = [
+        SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 10), SIMD2(0, 10),
+    ]
+
+    private func expectSameCurve(_ a: Curve2D?, _ b: Curve2D?,
+                                 _ comment: Comment? = nil) {
+        #expect(a != nil, comment)
+        #expect(b != nil, comment)
+        guard let a, let b else { return }
+        #expect(a.isClosed == b.isClosed, comment)
+        #expect(a.isPeriodic == b.isPeriodic, comment)
+        #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12, comment)
+        #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12, comment)
+        for t in stride(from: 0.0, through: 1.0, by: 0.1) {
+            let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
+            let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
+            let pa = a.point(at: ua), pb = b.point(at: ub)
+            #expect(abs(pa.x - pb.x) < 1e-9, comment)
+            #expect(abs(pa.y - pb.y) < 1e-9, comment)
+        }
+    }
+
+    @Test("Default tolerance: the two entry points produce the same curve")
+    func defaultToleranceMatches() {
+        expectSameCurve(Curve2D.interpolatePeriodic(points: Self.square),
+                        Curve2D.interpolate(through: Self.square, closed: true))
+    }
+
+    @Test("A non-default tolerance is now reachable through interpolatePeriodic")
+    func customToleranceIsReachable() {
+        for tolerance in [1e-3, 1e-4, 1e-8] {
+            expectSameCurve(Curve2D.interpolatePeriodic(points: Self.square, tolerance: tolerance),
+                            Curve2D.interpolate(through: Self.square, closed: true,
+                                                tolerance: tolerance),
+                            "tolerance=\(tolerance)")
+        }
+    }
+
+    /// The point-count floor the two had drifted apart on. OCCT accepts a 2-point periodic
+    /// interpolation — it produces a valid out-and-back loop — and the general entry point always
+    /// let it through; only the periodic wrapper rejected it at the bridge boundary.
+    @Test("A 2-point periodic interpolation is accepted by both entry points")
+    func twoPointFloorMatches() {
+        let two: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(10, 0)]
+        let periodic = Curve2D.interpolatePeriodic(points: two)
+        expectSameCurve(periodic, Curve2D.interpolate(through: two, closed: true))
+        if let c = periodic {
+            #expect(c.isClosed)
+            #expect(c.isPeriodic)
+        }
+    }
+
+    @Test("Both entry points reject a single point")
+    func singlePointRejectedByBoth() {
+        let one: [SIMD2<Double>] = [SIMD2(1, 2)]
+        #expect(Curve2D.interpolatePeriodic(points: one) == nil)
+        #expect(Curve2D.interpolate(through: one, closed: true) == nil)
+    }
+}

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -925,15 +925,18 @@ public static func interpolate(
 
 ---
 
-### `interpolatePeriodic(points:)`
+### `interpolatePeriodic(points:tolerance:)`
 
 Interpolates a closed (periodic) 2D BSpline through a sequence of points.
 
 ```swift
-public static func interpolatePeriodic(points: [SIMD2<Double>]) -> Curve2D?
+public static func interpolatePeriodic(points: [SIMD2<Double>],
+                                       tolerance: Double = 1e-6) -> Curve2D?
 ```
 
-- **Parameters:** `points` — interpolation points (do not repeat the first point at the end; the bridge closes the curve automatically).
+A spelling of [`interpolate(through:closed:tolerance:)`](Curve2D.md) with `closed: true`, and it delegates to it — the two cannot produce different curves for the same input. Before #412 it was a second, independent `Geom2dAPI_Interpolate` call site with the tolerance pinned at `1e-6` and unreachable, and with a stricter minimum point count (3, against the general entry point's 2) that the two had drifted into.
+
+- **Parameters:** `points` — interpolation points, minimum 2 (do not repeat the first point at the end; the curve closes automatically); `tolerance` — point coincidence tolerance.
 - **Returns:** Periodic BSpline, or `nil` on failure.
 - **OCCT:** `Geom2dAPI_Interpolate` (periodic).
 - **Example:**

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -500,7 +500,7 @@ public static func interpolate(through points: [SIMD2<Double>], closed: Bool = f
                                tolerance: Double = 1e-6) -> Curve2D?
 ```
 
-The curve passes exactly through every point. Use `closed: true` for a periodic loop.
+The curve passes exactly through every point. Use `closed: true` for a periodic loop — [`interpolatePeriodic(points:tolerance:)`](Curve2D-Analysis.md) is a spelling of exactly that case and delegates here (#412).
 
 - **Parameters:** `points` — interpolation points (minimum 2); `closed` — closed/periodic curve; `tolerance` — point coincidence tolerance.
 - **Returns:** Interpolated BSpline, or `nil` on failure.


### PR DESCRIPTION
## What & why

`Curve2D.interpolatePeriodic(points:)` and `Curve2D.interpolate(through:closed:tolerance:)` wrap
the same `Geom2dAPI_Interpolate` constructor with the same `Perform()`/`IsDone()`/`Curve()`
sequence. The former is exactly the latter with `closed: true`. Kept as two independent
implementations they had already drifted twice:

1. **Tolerance unreachable.** The general path threads the caller's tolerance through; the
   periodic path hardcoded `1e-6` with no parameter to change it.
2. **Point-count floor.** The general bridge function rejects `count < 2`, the periodic one
   rejected `count < 3` — so the same 2-point input reached OCCT through one entry point and was
   refused at the bridge boundary by the other.

Both layers now have one implementation: the Swift method delegates, and the bridge's
`OCCTInterpolate2DPeriodic` forwards to `OCCTCurve2DInterpolate` so direct C consumers of the
bridge get the same behaviour rather than a second copy that can drift again.

Refs #412. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve2DInterpolatePeriodicParityTests` (`Tests/OCCTGeom2dTests`): default-tolerance
equivalence, three non-default tolerances (previously unreachable), the 2-point floor, and the
1-point rejection both share. Worth noting how thin the prior coverage was — the issue found that
*no* existing test anywhere called `interpolate(through:closed: true)` with any tolerance, and
`interpolate2DPeriodic` only asserted `!= nil` on one square.

## Notes for the reviewer

**Two behaviour changes, both deliberate:**

`interpolatePeriodic` gains a defaulted `tolerance:` parameter. Source-compatible — existing call
sites keep compiling — and the default is exactly the value it used to hardcode.

`interpolatePeriodic(points:)` with 2 points now succeeds instead of returning `nil`. I unified on
the general entry point's floor rather than the stricter one, because OCCT genuinely accepts a
2-point periodic interpolation: it produces a valid out-and-back loop (verified — `isClosed`,
`isPeriodic`, domain `0...20` for a 10-unit segment, midpoint at the far end). The general
overload has always allowed this, so tightening instead would have removed working behaviour from
the more widely used of the two APIs to preserve an accident in the less used one.

**Delegation is safe, and this was checked rather than assumed.** For a 3-point input the two
implementations produced *bit-identical* curves before the change — same domain, same sampled
points to the last digit — which is what you would expect given they build the same
`Geom2dAPI_Interpolate` the same way. Every path except the two drifted ones is behaviour-
preserving.

**Docs** (the issue's third point): the two were documented on separate pages with no link
between them, while `Curve2D.md` already positioned `closed: true` as the recommended way to make
a periodic loop. Both pages now cross-reference, and the periodic page documents the new parameter
and the corrected minimum.

`Curve3D.interpolatePeriodic` has the same shape but is out of scope here — it is a different
type in a different audit finding.

Full `swift test` (4437 tests) clean. One unrelated intermittent failure appeared in one run —
`"Shape.loadRobust interrupts repair … (#300)"`, the CPU-timing-sensitive cancellation test whose
own source comment documents it as flaky; it also fails in isolation on occasion and passed on
re-run.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and six parallel child PRs each editing the same changelog header would conflict on every
one.

**Conflict note:** #411 and #413 also edit `OCCTBridge_Geom2d.mm` and `Curve2D.swift`, in
different regions. The changes are independent in substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)