### PR TITLE
fix(#398): Shape.fill silently downgraded g2 continuity (v1.15.21)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -46,6 +46,7 @@
 #include <BRepGProp.hxx>
 #include <BRepOffsetAPI_MakeFilling.hxx>
 #include <BRepTools.hxx>
+#include <Standard_ErrorHandler.hxx>   // OCC_CATCH_SIGNALS (issue #175)
 
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_Curve.hxx>
@@ -699,11 +700,30 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
     }
 }
 
+// Maps the Swift-side `Shape.SurfaceContinuity` raw value (c0 = 0, g1 = 1,
+// g2 = 2) to the matching `GeomAbs_Shape` enumerator. `GeomAbs_Shape`'s own
+// ordinals are NOT 0/1/2 for these three cases (GeomAbs_C0=0, GeomAbs_G1=1,
+// GeomAbs_C1=2, GeomAbs_G2=3, ...), so a raw `static_cast<GeomAbs_Shape>(...)`
+// silently turns a requested g2 (curvature) into GeomAbs_C1 (a plain
+// first-derivative tangency, not curvature-matched); see issue #398.
+static GeomAbs_Shape surfaceContinuityToGeomAbs(int32_t val) {
+    switch (val) {
+        case 0: return GeomAbs_C0;
+        case 1: return GeomAbs_G1;
+        case 2: return GeomAbs_G2;
+        default: return GeomAbs_C0;
+    }
+}
+
 OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries, int32_t wireCount,
                             OCCTFillingParams params) {
     if (!boundaries || wireCount < 1) return nullptr;
 
+    occtEnsureSignals();
     try {
+        OCC_CATCH_SIGNALS
+        GeomAbs_Shape continuity = surfaceContinuityToGeomAbs(params.continuity);
+
         // Create filling operation
         BRepOffsetAPI_MakeFilling filling(
             params.maxDegree > 0 ? params.maxDegree : 8,
@@ -712,7 +732,7 @@ OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries, int32_t wireCount,
             false,  // Anisotropie
             params.tolerance > 0 ? params.tolerance : 1e-4,
             params.tolerance > 0 ? params.tolerance : 1e-3,
-            static_cast<GeomAbs_Shape>(params.continuity)  // Continuity
+            continuity  // Continuity
         );
 
         // Add boundary constraints
@@ -722,7 +742,7 @@ OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries, int32_t wireCount,
             // Add each edge from the wire as a constraint
             for (TopExp_Explorer exp(boundaries[i]->wire, TopAbs_EDGE); exp.More(); exp.Next()) {
                 TopoDS_Edge edge = TopoDS::Edge(exp.Current());
-                filling.Add(edge, static_cast<GeomAbs_Shape>(params.continuity));
+                filling.Add(edge, continuity);
             }
         }
 

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -92,6 +92,104 @@ struct SurfaceFillingTests {
 
         #expect(surface == nil)
     }
+
+    /// `.g1`/`.g2` on a boundary with no face association can never satisfy
+    /// `GeomAbs_G1`/`GeomAbs_G2` (both require "the first face of the edge"
+    /// to compute tangency/curvature against): OCCT documents this as a
+    /// `ConstructionError`, which `OCCTShapeFill` catches and turns into
+    /// `nil`. Confirms `.g1` still behaves per that contract post-fix.
+    @Test("Fill with g1 continuity, no face association, fails safely")
+    func fillG1NoFaceAssociation() {
+        guard let boundary = Wire.rectangle(width: 10, height: 10) else {
+            Issue.record("Failed to create boundary wire")
+            return
+        }
+        let surface = Shape.fill(boundaries: [boundary], parameters: FillingParameters(continuity: .g1))
+        #expect(surface == nil)
+    }
+
+    /// Regression test for #398: `OCCTShapeFill` cast `params.continuity`
+    /// (the `SurfaceContinuity` raw value: c0=0, g1=1, g2=2) directly to
+    /// `GeomAbs_Shape` via `static_cast`. `GeomAbs_Shape`'s own ordinals are
+    /// C0=0, G1=1, C1=2, G2=3, ... so `.g2` silently asked OCCT for
+    /// `GeomAbs_C1` (plain first-derivative continuity, no curvature-match
+    /// obligation) instead of `GeomAbs_G2` (curvature continuity).
+    ///
+    /// Exercising `.g2` against a boundary that actually has curvature to
+    /// match (as opposed to the flat, freestanding boundaries above, which
+    /// can't tell C1 from G2 since both are trivially satisfied by a flat
+    /// patch) requires a boundary edge with "a first face": an edge
+    /// borrowed from an existing curved face, not a fresh standalone wire.
+    /// That code path (`BRepOffsetAPI_MakeFilling::Add` with an order other
+    /// than `GeomAbs_C0`, against a curved support surface) has a
+    /// **separate, pre-existing OCCT engine crash** in this OCCT build,
+    /// the same class of issue already tracked for the disabled "Plate
+    /// Surface Tests" / "NLPlate Deformation Tests" suites below. That crash
+    /// reproduces identically for plain `.g1` (which the #398 cast bug never
+    /// touched: it was already correctly mapped pre-fix), so it is orthogonal
+    /// to this bug and out of scope to fix here.
+    ///
+    /// What *is* in scope, and what this test actually proves: `OCCTShapeFill`
+    /// didn't have OCCT's own signal-to-exception guard
+    /// (`OCC_CATCH_SIGNALS`, issue #175, used by ~5 sibling bridge functions)
+    /// installed, so that pre-existing engine crash took the whole process
+    /// down instead of failing gracefully, which made it impossible to
+    /// safely exercise `.g2` against real curved geometry at all, let alone
+    /// notice the cast bug. Empirically (verified by temporarily reverting
+    /// the mapping and rebuilding):
+    ///   - pre-fix, `.g2` (-> `GeomAbs_C1`) against this exact curved
+    ///     boundary hits an *unrecoverable* crash: `OCC_CATCH_SIGNALS`
+    ///     does NOT save it, so it takes the whole test process down.
+    ///   - post-fix, `.g2` (-> `GeomAbs_G2`, the documented, "recognized"
+    ///     order for this API) hits a *recoverable* failure that
+    ///     `OCC_CATCH_SIGNALS` catches cleanly, and `OCCTShapeFill` returns
+    ///     `nil` exactly like any other caught `ConstructionError`.
+    /// So reaching the `#expect` below at all (instead of the whole test
+    /// binary aborting with SIGSEGV) *is* the regression check: this test
+    /// would have crashed the process pre-fix and passes clean post-fix.
+    @Test("Fill with g2 continuity against a curved boundary fails safely, not fatally (#398)")
+    func fillG2CurvedBoundaryDoesNotCrash() {
+        let radius = 10.0
+        let height = 20.0
+
+        // Bare cylindrical lateral surface: revolve a straight profile edge
+        // 360° around Z. No caps are added, so the top rim edge belongs to
+        // exactly one face (the curved wall) -- unambiguous "first face of
+        // the edge" for BRepOffsetAPI_MakeFilling's continuity constraint,
+        // and genuinely curved (unlike a flat rectangle/polygon boundary).
+        guard let profile = Wire.line(from: SIMD3(radius, 0, 0), to: SIMD3(radius, 0, height)) else {
+            Issue.record("Failed to create revolution profile")
+            return
+        }
+        guard let lateral = Shape.revolve(profile: profile, axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1)) else {
+            Issue.record("Failed to revolve cylinder wall")
+            return
+        }
+
+        // Isolate the top rim (z == height) from the bottom rim (z == 0).
+        guard let topEdge = lateral.edges().first(where: { edge in
+            guard edge.isCircle, let props = edge.circleProperties else { return false }
+            return abs(props.center.z - height) < 1e-6
+        }) else {
+            Issue.record("Could not find top rim edge")
+            return
+        }
+        guard let topWire = Wire.wireFromEdges([topEdge]) else {
+            Issue.record("Failed to build wire from top rim edge")
+            return
+        }
+
+        // Sanity check the boundary/geometry itself is usable: a plain C0
+        // fill (unaffected by #398, no face-association requirement) must
+        // succeed on this exact wire.
+        let c0Result = Shape.fill(boundaries: [topWire], parameters: FillingParameters(continuity: .c0))
+        #expect(c0Result != nil)
+
+        // The regression check. See the doc comment above: this line would
+        // have taken the whole test process down with SIGSEGV pre-fix.
+        let g2Result = Shape.fill(boundaries: [topWire], parameters: FillingParameters(continuity: .g2))
+        #expect(g2Result == nil)
+    }
 }
 
 @Suite("Plate Surface Tests", .disabled("Plate surface operations cause segfault in OCCT — pre-existing issue"))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,44 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v1.15.20
+## Current: v1.15.21
 
 **macOS / iOS (device + simulator) | OCCT 8.0.0p1 (+ #263, #280, #298, #310, #317, #318, #319, #323, #341, #344, #348, #349, #353, #374 kernel patches)**
 
 ---
 
 ## Release History
+
+### v1.15.21 (July 2026): fix: `Shape.fill` silently downgraded `.g2` continuity to first-derivative tangency (#398)
+
+`OCCTShapeFill` (`OCCTBridge_Healing.mm`) passed the Swift-side `SurfaceContinuity` raw value
+(`c0 = 0`, `g1 = 1`, `g2 = 2`) straight to `static_cast<GeomAbs_Shape>(...)` at both the
+`BRepOffsetAPI_MakeFilling` constructor and its per-edge `Add(edge, order)` call. `GeomAbs_Shape`'s
+own ordinals are not a plain 0/1/2 sequence (`GeomAbs_C0=0, GeomAbs_G1=1, GeomAbs_C1=2,
+GeomAbs_G2=3, ...`), so `static_cast<GeomAbs_Shape>(2)` landed on `GeomAbs_C1` (first-derivative
+continuity) instead of `GeomAbs_G2` (curvature continuity). `.c0`/`.g1` happened to land correctly
+by coincidence of alignment; only `.g2` was wrong. `Shape.fill(..., parameters:
+FillingParameters(continuity: .g2))` silently asked OCCT for weaker continuity than requested and
+documented (`docs/reference/Shape-Features.md`'s own doc comment says "curvature, very smooth"),
+with no test exercising `.g1`/`.g2` through `Shape.fill` to catch it.
+
+**Fixed:** both call sites now go through an explicit `surfaceContinuityToGeomAbs(int32_t)` mapping
+(0 to `GeomAbs_C0`, 1 to `GeomAbs_G1`, 2 to `GeomAbs_G2`) instead of a raw cast. Also added the
+signal-to-exception guard used by ~5 sibling bridge functions (`OCC_CATCH_SIGNALS` plus
+`occtEnsureSignals()`, issue #175) to `OCCTShapeFill`, which didn't have it: `BRepOffsetAPI_MakeFilling`
+has a separate, pre-existing OCCT engine crash when asked for non-`C0` continuity against a curved
+support surface (same class of issue as the already-disabled "Plate Surface Tests" suite). Without
+the guard, that crash took the whole process down instead of failing gracefully, which made it
+impossible to safely exercise `.g2` against real curved geometry at all. No public API surface
+change, same signatures, same `nil`-on-failure contract, so this is a patch per `docs/SEMVER.md`.
+
+**Tests:** `fillG2CurvedBoundaryDoesNotCrash` (`Surface Filling Tests` suite, `OCCTSurfaceTests`)
+fills a boundary edge borrowed from a curved (cylindrical) face, where `.c0` continuity succeeds
+but `.g2` continuity, verified empirically by temporarily reverting the mapping and rebuilding,
+crashed the whole test process pre-fix (`GeomAbs_C1` hits an unrecoverable path in this OCCT build)
+and now fails safely with `nil` post-fix (`GeomAbs_G2` is caught by the new `OCC_CATCH_SIGNALS`
+guard); reaching the final assertion at all is the regression check. `fillG1NoFaceAssociation`
+confirms `.g1` is unaffected and still fails safely without a face-associated boundary.
 
 ### v1.15.20 (July 2026): fix — `Edge.circleProperties` returned `nil` for every full-circle edge (#378)
 


### PR DESCRIPTION
## What & why

`OCCTShapeFill` cast the Swift-side `SurfaceContinuity` raw value (`c0=0, g1=1, g2=2`) directly to `GeomAbs_Shape` via `static_cast`, at both the `BRepOffsetAPI_MakeFilling` constructor and its per-edge `Add(edge, order)` call. `GeomAbs_Shape`'s own ordinals aren't a plain 0/1/2 sequence (`GeomAbs_C0=0, GeomAbs_G1=1, GeomAbs_C1=2, GeomAbs_G2=3, ...`), so `static_cast<GeomAbs_Shape>(2)` landed on `GeomAbs_C1` (first-derivative tangency) instead of `GeomAbs_G2` (curvature continuity). `.c0`/`.g1` happened to land correctly by coincidence of ordinal alignment; only `.g2` was wrong, so `Shape.fill(..., parameters: FillingParameters(continuity: .g2))` silently asked OCCT for weaker continuity than requested and documented, with no test in place to catch it.

Fixed both call sites with an explicit `surfaceContinuityToGeomAbs(int32_t)` mapping instead of a raw cast. Also added the `OCC_CATCH_SIGNALS`/`occtEnsureSignals()` guard (issue #175) that ~5 sibling bridge functions already use, since it was missing from `OCCTShapeFill`: `BRepOffsetAPI_MakeFilling` has a separate, pre-existing OCCT engine crash when asked for non-C0 continuity against a curved support surface (same class of issue as the disabled "Plate Surface Tests"/"NLPlate Deformation Tests" suites), and without the guard that crash took the whole process down instead of failing gracefully. That made it impossible to safely exercise `.g2` against real curved geometry at all, so this was a necessary addition to write a real regression test for the cast bug. No public API surface change, so this is a patch per `docs/SEMVER.md` (v1.15.20 to v1.15.21).

Closes #398

**Deviation from the audit branch queue:** this bypasses the `refactor/377-segmented-audit` branch queue and branches directly off `main` because it's a confirmed live correctness bug being fast-tracked ahead of the rest of the #380 audit pass, pending human review before any release.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397) for the ecosystem-wide test-coverage standard this is piloting.

## Notes for the reviewer

- This branches off `main`, not `refactor/377-segmented-audit` (see deviation note above).
- `Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift`: `fillG2CurvedBoundaryDoesNotCrash` is the core regression test. It doesn't do a live curvature-matching comparison; empirically (verified by temporarily reverting the mapping and rebuilding), `BRepOffsetAPI_MakeFilling` has an unrelated, pre-existing OCCT engine crash when given non-C0 continuity against ANY curved support surface in this OCCT build (reproduces identically for plain `.g1`, which the #398 bug never touched), so a real curvature comparison isn't reachable. What is reachable and load-bearing: pre-fix, `.g2` (-> `GeomAbs_C1`) against a curved boundary hits an *unrecoverable* crash that takes the whole process down even with the new `OCC_CATCH_SIGNALS` guard in place; post-fix, `.g2` (-> `GeomAbs_G2`) hits a *recoverable* failure that the guard catches cleanly, and the function returns `nil`. So reaching the test's final assertion at all (instead of the process aborting with SIGSEGV) is the regression check. Full reasoning is in the test's doc comment.
- `fillG1NoFaceAssociation` is a lighter companion test confirming `.g1` (unaffected by this bug) still behaves per OCCT's documented contract.
- `docs/reference/Shape-Features.md` already documents `.g2` correctly as curvature continuity; confirmed no change needed there.
- `swift build` is clean and `swift test --filter OCCTSurfaceTests` passes (390/390 tests) on this branch.
- Release/tag/merge is intentionally left for the user to do after review; this PR is not to be merged, tagged, or released by an agent.