### PR TITLE
fix(#413): one projection path behind the four point-to-curve entry points

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -267,7 +267,8 @@
 // Geom2dAPI_ExtremaCurveCurve         → OCCTCurve2DExtrema, OCCTCurve2DCurvatureExtrema
 // Geom2dAPI_InterCurveCurve           → OCCTCurve2DIntersect, OCCTCurve2DSelfIntersect
 // Geom2dAPI_Interpolate               → OCCTCurve2DInterpolate*
-// Geom2dAPI_ProjectPointOnCurve       → OCCTPoint2DDistanceToCurve, OCCTCurve2DProjectPoint2D
+// Geom2dAPI_ProjectPointOnCurve       → OCCTCurve2DProjectPoint, OCCTCurve2DProjectPointAll,
+//                                        OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve
 //
 // --- Geom2dGcc ---
 // Geom2dGcc_Circ2d2TanOn              → OCCTGeom2dGccCirc2d2TanOn*
@@ -2437,7 +2438,13 @@ typedef struct {
     double x, y, parameter, distance;
 } OCCTCurve2DProjection;
 
+/// Project a point onto a curve, nearest solution only.
+/// @return Projection with `distance >= 0` on success; on failure `distance` is -1 and the
+///         other fields are zeroed. A curve can legitimately have no projection for a point
+///         (one beyond the ends of a bounded curve, or a circle's centre).
 OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef curve, double px, double py);
+/// Project a point onto a curve, all local-minimum solutions.
+/// @return Number of solutions written to `out` (0 if there are none).
 int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef curve, double px, double py,
                                    OCCTCurve2DProjection* out, int32_t max);
 
@@ -8667,6 +8674,9 @@ OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref,
 OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
     double ox, double oy, double dx, double dy);
 /// Distance from point to curve
+/// @return Minimum distance, or -1 when the point has no projection onto the curve (one beyond
+///         the ends of a bounded curve, or a circle's centre). Swift's Point2D.distance(to:)
+///         maps that to .infinity.
 double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve);
 /// Apply a Transform2D to a point, returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
@@ -8777,8 +8787,10 @@ OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1
     OCCTPoint2DRef _Nonnull p2);
 
 /// Project a Point2D onto a Curve2D, returns parameter at closest point
-/// @param outDistance Output: minimum distance
-/// @return parameter on curve, or 0 on failure
+/// @param outDistance Output: minimum distance, or -1 on failure — this is the failure signal
+/// @return parameter on curve, or NaN on failure. Do NOT test the return value against 0: 0 is a
+///         legitimate parameter on any curve whose domain includes it (projecting a segment's own
+///         start point onto it returns exactly 0). Test `outDistance < 0` instead.
 double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve, OCCTPoint2DRef _Nonnull point,
     double* _Nonnull outDistance);
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -111,6 +111,32 @@ static inline bool occtValidCircle2dRadius(double radius) {
     return radius > 0;
 }
 
+// One Geom2dAPI_ProjectPointOnCurve construction behind every entry point that wants the nearest
+// solution: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D and OCCTPoint2DDistanceToCurve.
+// They were three independent constructions of the same algorithm with three different
+// failure-signalling conventions bolted on separately (#413). It also gives the two that lacked
+// one an explicit null-handle guard rather than relying on catch(...) to absorb the dereference.
+//
+// Returns false when there is no projection at all — an ordinary outcome, not an error: a point
+// beyond the ends of a bounded curve, or the centre of a circle, has no extremum. Each caller
+// applies its own documented sentinel; none of them may report failure through the parameter,
+// since 0 is a legitimate parameter on any curve whose domain includes it.
+static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d& point,
+                                            gp_Pnt2d* outNearest, double* outParameter,
+                                            double* outDistance) {
+    if (!curve || curve->curve.IsNull()) return false;
+    try {
+        Geom2dAPI_ProjectPointOnCurve proj(point, curve->curve);
+        if (proj.NbPoints() == 0) return false;
+        if (outNearest) *outNearest = proj.NearestPoint();
+        if (outParameter) *outParameter = proj.LowerDistanceParameter();
+        if (outDistance) *outDistance = proj.LowerDistance();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 // MARK: - Batch Curve2D Evaluation (v0.28.0)
 
 #include <Geom2dGridEval_Curve.hxx>
@@ -1872,12 +1898,16 @@ OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
     } catch (...) { return nullptr; }
 }
 
+// Failure contract: returns a negative distance. Swift's Point2D.distance(to:) maps that to
+// .infinity rather than passing the sentinel through as if it were a real distance (#413).
 double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve) {
-    try {
-        Geom2dAPI_ProjectPointOnCurve proj(ref->point->Pnt2d(), curve->curve);
-        if (proj.NbPoints() == 0) return -1.0;
-        return proj.LowerDistance();
-    } catch (...) { return -1.0; }
+    if (!ref) return -1.0;
+    double distance = -1.0;
+    if (!occtNearestProjectionOnCurve2d(curve, ref->point->Pnt2d(), nullptr,
+                                        nullptr, &distance)) {
+        return -1.0;
+    }
+    return distance;
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
@@ -2175,14 +2205,19 @@ OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1
     } catch (...) { return nullptr; }
 }
 
+// Failure contract: *outDistance < 0, and NaN returned. The parameter cannot carry the failure
+// signal — 0 is a legitimate result (projecting a segment's own start point onto it returns
+// exactly 0), which is what the old "returns 0 on failure" contract conflated (#413).
 double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve, OCCTPoint2DRef _Nonnull point,
     double* _Nonnull outDistance) {
-    try {
-        Geom2dAPI_ProjectPointOnCurve proj(point->point->Pnt2d(), curve->curve);
-        if (proj.NbPoints() == 0) { *outDistance = -1.0; return 0.0; }
-        *outDistance = proj.LowerDistance();
-        return proj.LowerDistanceParameter();
-    } catch (...) { *outDistance = -1.0; return 0.0; }
+    if (!point) { *outDistance = -1.0; return std::numeric_limits<double>::quiet_NaN(); }
+    double parameter = 0.0;
+    if (!occtNearestProjectionOnCurve2d(curve, point->point->Pnt2d(), nullptr,
+                                        &parameter, outDistance)) {
+        *outDistance = -1.0;
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return parameter;
 }
 
 // MARK: - FairCurve Batten / MinimalVariation (v0.67)
@@ -5507,22 +5542,18 @@ int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef c, double tolerance,
 
 // Projection
 
+// Failure contract: distance < 0. The point/parameter fields are left zeroed and must not be
+// read when it is negative.
 OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef c, double px, double py) {
     OCCTCurve2DProjection result = {0, 0, 0, -1};
-    if (!c || c->curve.IsNull()) return result;
-    try {
-        gp_Pnt2d point(px, py);
-        Geom2dAPI_ProjectPointOnCurve proj(point, c->curve);
-        if (proj.NbPoints() == 0) return result;
-        gp_Pnt2d nearest = proj.NearestPoint();
-        result.x = nearest.X();
-        result.y = nearest.Y();
-        result.parameter = proj.LowerDistanceParameter();
-        result.distance = proj.LowerDistance();
-        return result;
-    } catch (...) {
+    gp_Pnt2d nearest;
+    if (!occtNearestProjectionOnCurve2d(c, gp_Pnt2d(px, py), &nearest,
+                                        &result.parameter, &result.distance)) {
         return result;
     }
+    result.x = nearest.X();
+    result.y = nearest.Y();
+    return result;
 }
 
 int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef c, double px, double py,

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -643,6 +643,21 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Project a point onto this curve, returning the nearest projection.
+    ///
+    /// - Parameter p: Point to project.
+    /// - Returns: The nearest projection, or `nil` if the point has no projection onto this curve
+    ///   — one beyond the ends of a bounded curve, or the centre of a circle.
+    ///
+    /// `project(_:)` (the `Point2D` overload) and `Point2D.distance(to:)` compute the same nearest
+    /// solution through the same shared bridge path, and agree on both the value and on when
+    /// there is no projection.
+    ///
+    /// ```swift
+    /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
+    /// let hit = segment.project(point: SIMD2(5, 3))
+    /// #expect(hit?.distance == 3)
+    /// #expect(segment.project(point: SIMD2(100, 0)) == nil)   // past the end
+    /// ```
     public func project(point p: SIMD2<Double>) -> Curve2DProjection? {
         let r = OCCTCurve2DProjectPoint(handle, p.x, p.y)
         guard r.distance >= 0 else { return nil }
@@ -1772,7 +1787,22 @@ extension Curve2D {
     }
 
     /// Project a `Point2D` onto this curve.
-    /// Returns `(parameter, distance)` or `nil` on failure.
+    ///
+    /// - Parameter point: Point to project.
+    /// - Returns: `(parameter, distance)` of the nearest solution, or `nil` if the point has no
+    ///   projection onto this curve.
+    ///
+    /// The same nearest-solution computation as `project(point:)`, returned without the projected
+    /// point itself. Note that a parameter of `0` is a perfectly ordinary success — projecting a
+    /// segment's own start point onto it returns exactly that — so `nil` is the only failure
+    /// signal.
+    ///
+    /// ```swift
+    /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
+    /// let start = Point2D(x: 0, y: 0)!
+    /// #expect(segment.project(start)?.parameter == 0)          // success, at parameter 0
+    /// #expect(segment.project(Point2D(x: 100, y: 0)!) == nil)  // no projection
+    /// ```
     public func project(_ point: Point2D) -> (parameter: Double, distance: Double)? {
         var dist: Double = 0
         let param = OCCTCurve2DProjectPoint2D(handle, point.handle, &dist)

--- a/Sources/OCCTSwift/Point2D.swift
+++ b/Sources/OCCTSwift/Point2D.swift
@@ -74,8 +74,27 @@ public final class Point2D: @unchecked Sendable {
     }
 
     /// Minimum distance from this point to a 2D curve.
+    ///
+    /// - Parameter curve: Curve to measure to.
+    /// - Returns: The distance to the nearest point of the curve, or `.infinity` if the point has
+    ///   no projection onto it at all.
+    ///
+    /// A point can legitimately have no projection: one beyond the ends of a bounded curve, or
+    /// the centre of a circle (equidistant from every point, so there is no local minimum). This
+    /// used to return the bridge's raw `-1` sentinel for that case, which any threshold test
+    /// (`distance < tolerance`) would read as "touching" — the opposite of the truth (#413).
+    ///
+    /// ```swift
+    /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
+    /// let above = Point2D(x: 5, y: 3)!
+    /// #expect(abs(above.distance(to: segment) - 3) < 1e-9)
+    ///
+    /// let pastTheEnd = Point2D(x: 100, y: 0)!
+    /// #expect(pastTheEnd.distance(to: segment) == .infinity)
+    /// ```
     public func distance(to curve: Curve2D) -> Double {
-        OCCTPoint2DDistanceToCurve(handle, curve.handle)
+        let d = OCCTPoint2DDistanceToCurve(handle, curve.handle)
+        return d < 0 ? .infinity : d
     }
 
     // MARK: - Transforms (return new Point2D)

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4178,3 +4178,94 @@ struct Curve2DInterpolatePeriodicParityTests {
         #expect(Curve2D.interpolate(through: one, closed: true) == nil)
     }
 }
+
+// MARK: - #413: the four point-to-curve projection entry points
+
+/// The same `Geom2dAPI_ProjectPointOnCurve` computation is reachable four ways:
+/// `Curve2D.project(point:)`, `Curve2D.allProjections(of:)`, `Curve2D.project(_ point: Point2D)`
+/// and `Point2D.distance(to:)`. They were four independent constructions with four different
+/// failure conventions bolted on separately — including one (`Point2D.distance(to:)`) that leaked
+/// the bridge's raw `-1` sentinel to callers as though it were a distance. They now share one
+/// bridge path and agree on both the values and on when there is no projection.
+@Suite("Curve2D projection entry points agree (#413)")
+struct Curve2DProjectionParityTests {
+
+    private static let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
+
+    @Test("All four entry points agree for an ordinary projection")
+    func successAgreesAcrossAllFour() {
+        let cases: [(Curve2D, SIMD2<Double>)] = [
+            (Self.segment, SIMD2(5, 3)),
+            (Self.segment, SIMD2(0.5, -2)),
+            (Curve2D.circle(center: .zero, radius: 5)!, SIMD2(10, 0)),
+            (Curve2D.circle(center: .zero, radius: 5)!, SIMD2(3, 4)),
+        ]
+        for (curve, p) in cases {
+            guard let point2D = Point2D(x: p.x, y: p.y) else { continue }
+            let comment: Comment = "\(p)"
+
+            let nearest = curve.project(point: p)
+            let asTuple = curve.project(point2D)
+            let distance = point2D.distance(to: curve)
+            let all = curve.allProjections(of: p)
+
+            #expect(nearest != nil, comment)
+            #expect(asTuple != nil, comment)
+            guard let nearest, let asTuple else { continue }
+
+            #expect(nearest.parameter == asTuple.parameter, comment)
+            #expect(nearest.distance == asTuple.distance, comment)
+            #expect(nearest.distance == distance, comment)
+
+            // The nearest solution must be the smallest of the full solution set.
+            #expect(!all.isEmpty, comment)
+            if let smallest = all.map(\.distance).min() {
+                #expect(abs(smallest - nearest.distance) < 1e-9, comment)
+            }
+        }
+    }
+
+    /// A point with no projection at all is an ordinary outcome, not an error: one beyond the
+    /// ends of a bounded curve, or a circle's centre (equidistant everywhere, so no local
+    /// minimum). All four entry points must report it, and none may report it as a distance a
+    /// threshold test would accept.
+    @Test("All four entry points agree when there is no projection")
+    func failureAgreesAcrossAllFour() {
+        let cases: [(Curve2D, SIMD2<Double>)] = [
+            (Self.segment, SIMD2(100, 0)),      // past the end
+            (Self.segment, SIMD2(-50, 3)),      // before the start
+            (Curve2D.circle(center: .zero, radius: 5)!, SIMD2(0, 0)),   // circle centre
+        ]
+        for (curve, p) in cases {
+            guard let point2D = Point2D(x: p.x, y: p.y) else { continue }
+            let comment: Comment = "\(p)"
+
+            #expect(curve.project(point: p) == nil, comment)
+            #expect(curve.project(point2D) == nil, comment)
+            #expect(curve.allProjections(of: p).isEmpty, comment)
+
+            // Not -1: a raw sentinel here reads as "touching" to any `distance < tolerance` test.
+            let distance = point2D.distance(to: curve)
+            #expect(distance == .infinity, comment)
+            #expect(distance > 0, comment)
+        }
+    }
+
+    /// Parameter 0 is a legitimate success value, which is why no entry point may signal failure
+    /// through the parameter alone. Projecting a segment's own start point onto it returns
+    /// exactly 0 at distance 0.
+    @Test("Parameter zero is a success, not a failure signal")
+    func parameterZeroIsASuccess() {
+        guard let start = Point2D(x: 0, y: 0) else { return }
+        let asTuple = Self.segment.project(start)
+        #expect(asTuple != nil)
+        if let asTuple {
+            #expect(asTuple.parameter == 0)
+            #expect(asTuple.distance == 0)
+        }
+        let nearest = Self.segment.project(point: SIMD2(0, 0))
+        #expect(nearest?.parameter == 0)
+        #expect(nearest?.distance == 0)
+        #expect(start.distance(to: Self.segment) == 0)
+    }
+}

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -335,8 +335,9 @@ public func project(point p: SIMD2<Double>) -> Curve2DProjection?
 ```
 
 - **Parameters:** `p` — 2D point to project.
-- **Returns:** Nearest `Curve2DProjection`, or `nil` on failure (negative distance sentinel from bridge).
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve`.
+- **Returns:** Nearest `Curve2DProjection`, or `nil` when the point has no projection onto the curve — one beyond the ends of a bounded curve, or a circle's centre. An ordinary outcome, not an error.
+- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (`NearestPoint`/`LowerDistanceParameter`/`LowerDistance`).
+- **Note:** `project(_:)` (the `Point2D` overload) and [`Point2D.distance(to:)`](Geometry2D.md) compute the same nearest solution through the same shared bridge path, so all three agree on the value and on when there is no projection (#413).
 - **Example:**
   ```swift
   if let circle = Curve2D.circle(center: .zero, radius: 5),
@@ -355,16 +356,19 @@ Projects a point onto this curve, returning all projection solutions.
 public func allProjections(of p: SIMD2<Double>) -> [Curve2DProjection]
 ```
 
-Capped at 64 results. Useful when there are multiple equidistant points (e.g. projecting the center onto a circle).
+Capped at 64 results. Useful when a point has several local-minimum projections — e.g. a point outside a circle projects to both the near and the far side.
 
 - **Parameters:** `p` — 2D point to project.
-- **Returns:** Array of `Curve2DProjection` values (may be empty).
+- **Returns:** Array of `Curve2DProjection` values, empty when there is no projection at all.
 - **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (all solutions).
 - **Example:**
   ```swift
   if let circle = Curve2D.circle(center: .zero, radius: 5) {
-      let projs = circle.allProjections(of: .zero)
-      // all points on the circle are equidistant
+      let projs = circle.allProjections(of: SIMD2(10, 0))
+      // 2 solutions: the near side and the far side
+
+      let none = circle.allProjections(of: .zero)
+      // empty — the centre is equidistant from every point, so there is no local minimum
   }
   ```
 
@@ -1427,8 +1431,9 @@ public func project(_ point: Point2D) -> (parameter: Double, distance: Double)?
 ```
 
 - **Parameters:** `point` — the `Point2D` to project.
-- **Returns:** `(parameter, distance)` tuple, or `nil` on failure (negative distance sentinel).
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve`.
+- **Returns:** `(parameter, distance)` tuple, or `nil` when the point has no projection onto the curve.
+- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (`LowerDistanceParameter`/`LowerDistance`).
+- **Note:** A `parameter` of `0` is an ordinary success — projecting a segment's own start point onto it returns exactly that — so `nil` is the only failure signal. The underlying bridge function used to return `0` on failure too, conflating the two (#413).
 - **Example:**
   ```swift
   if let circle = Curve2D.circle(center: .zero, radius: 5),

--- a/docs/reference/Geometry2D.md
+++ b/docs/reference/Geometry2D.md
@@ -233,11 +233,14 @@ Minimum distance from this point to a 2D curve.
 public func distance(to curve: Curve2D) -> Double
 ```
 
-Returns `-1.0` if the projection fails or the curve has no projection points.
+Returns `.infinity` when the point has no projection onto the curve at all — one beyond the ends of a bounded curve, or the centre of a circle (equidistant from every point, so there is no local minimum). This is an ordinary outcome, not an error.
+
+Before #413 this returned the bridge's raw `-1.0` sentinel for that case, which any threshold test (`distance < tolerance`) would read as "touching" — the opposite of the truth.
 
 - **Parameters:** `curve` — the 2D curve to measure against.
-- **Returns:** Minimum distance, or `-1.0` on failure.
+- **Returns:** Minimum distance, or `.infinity` if there is no projection.
 - **OCCT:** `Geom2dAPI_ProjectPointOnCurve::LowerDistance()`.
+- **Note:** Shares one bridge path with [`Curve2D.project(point:)`](Curve2D-Analysis.md) and `Curve2D.project(_:)`, so all three agree on the value and on when there is no projection (#413).
 - **Example:**
   ```swift
   if let p = Point2D(x: 5.0, y: 5.0),


### PR DESCRIPTION
## What & why

`Geom2dAPI_ProjectPointOnCurve` was constructed four separate times for the same computation —
`Curve2D.project(point:)`, `Curve2D.allProjections(of:)`, `Curve2D.project(_ point: Point2D)` and
`Point2D.distance(to:)` — each with its own failure convention bolted on independently, and two
of them with no null-handle guard at all. The three nearest-solution entry points now share
`occtNearestProjectionOnCurve2d`; `allProjections` keeps its own loop because it genuinely needs
every solution, not the nearest.

Two of the four conventions were actively wrong. Neither failure mode is exotic — **a point
beyond the ends of a bounded curve, or a circle's centre, has no projection at all**, which is an
ordinary outcome rather than an error:

| Entry point | Failure signal before | After |
|---|---|---|
| `Curve2D.project(point:)` | `distance = -1`, Swift guards it | unchanged |
| `Curve2D.allProjections(of:)` | empty array | unchanged |
| `Point2D.distance(to:)` | **raw `-1.0` returned to the caller as a distance** | `.infinity` |
| `Curve2D.project(_ point:)` | **C ABI returns parameter `0.0`** | `NaN`, doc corrected |

Refs #413. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve2DProjectionParityTests` (`Tests/OCCTGeom2dTests`): all four cross-checked against
each other on the same inputs for both success and no-projection, plus the parameter-0 case. Each
of the four had a test before; none compared them, and none exercised the failure path at all.

## Notes for the reviewer

**Why `Point2D.distance(to:)` returning `-1` mattered.** It is a plain `Double` API with no
optional, and `-1` is not an inert sentinel — the obvious caller check, `if distance < tolerance`,
**succeeds** on it. A point past the end of a segment would report as touching the segment. The
`.infinity` it now returns fails that test correctly, and still behaves sensibly under `min()` and
ordering. This is a behaviour change to a public method, deliberately: no caller can have been
relying on `-1` for anything except a bespoke negative check, and such a check still works
(`.infinity` is not `< 0`, and neither result is a real distance).

**Why the parameter could not carry the failure signal.** Verified concretely rather than argued:
projecting the segment `(0,0)→(10,0)`'s own start point onto it succeeds at **parameter 0.0,
distance 0.0**. The old header contract (`@return parameter on curve, or 0 on failure`) invited a
check that would call that success a failure. `NaN` cannot collide with any real parameter, and
the header now says to test `outDistance < 0`.

**Two stale artefacts of the duplication, both fixed:**

- `OCCTBridge.h:270`'s OCCT-class coverage index listed `Geom2dAPI_ProjectPointOnCurve →
  OCCTPoint2DDistanceToCurve, OCCTCurve2DProjectPoint2D`, omitting the other two. This is the
  issue's own evidence that keeping four copies in sync had already failed in practice.
- `docs/reference/Curve2D-Analysis.md` illustrated `allProjections(of:)` with "projecting the
  center onto a circle … all points on the circle are equidistant". It returns **zero** solutions
  for that input — equidistant means no local minimum. Replaced with a point outside the circle,
  which really does give two, and the empty case is documented as what the centre actually does.

Verified: reverting `OCCTBridge_Geom2d.mm` and `Point2D.swift` fails the new suite with 6 issues,
all on the `-1`-instead-of-`.infinity` path. Full `swift test` (4436 tests) clean.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and six parallel child PRs each editing the same changelog header would conflict on every
one.

**Conflict note:** #411 and #412 also edit `OCCTBridge_Geom2d.mm` and `Curve2D.swift`. #411 and
this PR both insert a helper at the same anchor near the top of `OCCTBridge_Geom2d.mm`, so expect
a small textual conflict there; the changes are independent in substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)