### PR TITLE
refactor(#398): collapse nine continuity enums into two shared vocabularies

### DIFF
--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // Continuity vocabularies.
 //
 // OCCTSwift had grown nine separate enums for "continuity level", each written against a
@@ -91,7 +89,8 @@ public typealias PlateConstraintOrder = SurfaceContinuity
 ///
 /// Used wherever an operation splits, approximates or simplifies geometry against a continuity
 /// floor: ``Shape/divided(at:)``, ``Shape/bsplineRestriction(tol3d:tol2d:maxDegree:maxSegments:continuity3d:continuity2d:degreePriority:rational:)``,
-/// ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)`` and
+/// ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)``,
+/// ``Surface/approxWithDetails(tolerance:uContinuity:vContinuity:maxSegments:maxDegree:)`` and
 /// ``Curve3D/continuityBreaks(minContinuity:)``.
 ///
 /// ```swift

--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+// Continuity vocabularies.
+//
+// OCCTSwift had grown nine separate enums for "continuity level", each written against a
+// different bridge call and each re-deriving its own raw-int meaning (#398). They collapse
+// into exactly three contracts, which is why there are two shared enums here rather than one:
+//
+//   1. Geometric constraint order, 0/1/2 = G0/G1/G2. Handed to a plate solver as the order of
+//      a point, curve or edge constraint. GeomPlate_CurveConstraint validates it directly and
+//      rejects anything outside [-1, 2] with the message "The continuity is not G0 G1 or G2".
+//      That is `SurfaceContinuity`.
+//
+//   2. Required parametric continuity, 0/1/2/3 = C0/C1/C2/C3. Answers "split, approximate or
+//      restrict this geometry so every piece is at least Cn". Reaches OCCT either as a real
+//      GeomAbs_Shape continuity class or as a literal derivative-order integer.
+//      That is `ParametricContinuity`.
+//
+//   3. A GeomAbs_Shape ordinal reported back as a *result*, which is a different job from
+//      either input vocabulary above and keeps its own type: see `Surface.Continuity`.
+//
+// The two are not interchangeable even though both count 0, 1, 2. G1 asks only for parallel
+// tangent directions; C1 asks for equal derivative vectors. Feeding one enum's raw value to
+// the other's bridge call is precisely the class of defect #398 was filed about, so they are
+// deliberately distinct types that will not silently substitute for one another.
+
+// MARK: - Geometric constraint order (G0/G1/G2)
+
+/// Geometric continuity order for a surface constraint.
+///
+/// The single vocabulary behind every OCCTSwift call that constrains a generated surface
+/// against a point, edge or wire: ``Shape/fill(boundaries:parameters:)``,
+/// ``Shape/fill(constraints:parameters:)``, ``FillingSurface`` and
+/// ``Shape/plateSurface(through:orders:degree:pointsOnCurves:iterations:tolerance:)``.
+/// All of them hand the raw value to OCCT as a plate constraint order.
+///
+/// ```swift
+/// // Tangent to the wall the rim came from
+/// let skinned = solid.fill(
+///     constraints: [FillConstraint(edge: rimEdge, support: wallFace, continuity: .g1)]
+/// )
+///
+/// // Curvature-continuous patch across a hole
+/// let smooth = solid.fill(
+///     boundaries: [holeWire],
+///     parameters: FillingParameters(continuity: .g2)
+/// )
+/// ```
+///
+/// - Note: Not every API accepts every order. A bare point cannot carry curvature, so
+///   ``Shape/plateSurface(through:orders:degree:pointsOnCurves:iterations:tolerance:)``
+///   fails outright if any point is given ``g2`` (`GeomPlate_PointConstraint` throws above
+///   order 1). ``FillingSurface`` currently mis-maps both non-default orders; see issue #433.
+public enum SurfaceContinuity: Int32, Sendable, CaseIterable {
+    /// Positional continuity (G0). The surface passes through the constraint.
+    case g0 = 0
+    /// Tangent continuity (G1). The surface is tangent along the constraint.
+    case g1 = 1
+    /// Curvature continuity (G2). The surface matches curvature along the constraint.
+    case g2 = 2
+}
+
+extension SurfaceContinuity {
+    /// Positional continuity. Former spelling of ``g0``.
+    ///
+    /// The G-prefixed spellings are canonical: these orders are geometric continuity, which is
+    /// what OCCT itself calls them.
+    @available(*, deprecated, renamed: "g0")
+    public static var c0: SurfaceContinuity { .g0 }
+
+    /// Tangent continuity. Former spelling of ``g1``, from `FillingContinuity`.
+    @available(*, deprecated, renamed: "g1")
+    public static var c1: SurfaceContinuity { .g1 }
+
+    /// Curvature continuity. Former spelling of ``g2``, from `FillingContinuity`.
+    @available(*, deprecated, renamed: "g2")
+    public static var c2: SurfaceContinuity { .g2 }
+}
+
+/// Former name for ``SurfaceContinuity`` used by ``FillingSurface``.
+@available(*, deprecated, renamed: "SurfaceContinuity")
+public typealias FillingContinuity = SurfaceContinuity
+
+/// Former name for ``SurfaceContinuity`` used by the plate-surface constraint APIs.
+@available(*, deprecated, renamed: "SurfaceContinuity")
+public typealias PlateConstraintOrder = SurfaceContinuity
+
+// MARK: - Required parametric continuity (C0/C1/C2/C3)
+
+/// Minimum parametric continuity to require of a piece of geometry.
+///
+/// Used wherever an operation splits, approximates or simplifies geometry against a continuity
+/// floor: ``Shape/divided(at:)``, ``Shape/bsplineRestriction(tol3d:tol2d:maxDegree:maxSegments:continuity3d:continuity2d:degreePriority:rational:)``,
+/// ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)`` and
+/// ``Curve3D/continuityBreaks(minContinuity:)``.
+///
+/// ```swift
+/// // Split a shape wherever it drops below C2
+/// let pieces = shape.divided(at: .c2)
+///
+/// // Knots where a BSpline fails to be C3. A cubic interpolated curve is C2 at its
+/// // interior knots, so .c3 is the order that actually reports them.
+/// let breaks = bspline.continuityBreaks(minContinuity: .c3)
+/// ```
+///
+/// - Note: This is *parametric* continuity (equal derivative vectors), not the geometric
+///   G0/G1/G2 constraint order of ``SurfaceContinuity`` (parallel tangent directions). The
+///   two count the same way but mean different things and are not interchangeable.
+public enum ParametricContinuity: Int32, Sendable, CaseIterable {
+    /// Positional continuity (C0).
+    case c0 = 0
+    /// First-derivative continuity (C1).
+    case c1 = 1
+    /// Second-derivative continuity (C2).
+    case c2 = 2
+    /// Third-derivative continuity (C3).
+    case c3 = 3
+}
+
+/// Former name for ``ParametricContinuity`` used by ``Shape/divided(at:)``.
+///
+/// The old name was a misnomer: the value maps to `GeomAbs_C0` through `GeomAbs_C3`, which is
+/// parametric continuity, not geometric. The geometric vocabulary is ``SurfaceContinuity``.
+@available(*, deprecated, renamed: "ParametricContinuity")
+public typealias GeometricContinuity = ParametricContinuity
+
+/// Former name for ``ParametricContinuity`` used by the approximation APIs.
+@available(*, deprecated, renamed: "ParametricContinuity")
+public typealias ApproxContinuity = ParametricContinuity
+
+extension Shape {
+    /// Former name for ``ParametricContinuity`` used by BSpline restriction.
+    @available(*, deprecated, renamed: "ParametricContinuity")
+    public typealias BSplineContinuity = ParametricContinuity
+}
+
+extension Curve3D {
+    /// Former name for ``ParametricContinuity`` used by knot-splitting analysis.
+    ///
+    /// The old enum stopped at `c2`, which made every value it offered a no-op on an ordinary
+    /// cubic BSpline: such a curve is already C2 at its interior knots, so nothing below C3
+    /// reports a break. ``ParametricContinuity/c3`` is reachable and fixes that.
+    @available(*, deprecated, renamed: "ParametricContinuity")
+    public typealias ContinuityOrder = ParametricContinuity
+}

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -626,23 +626,24 @@ extension Curve3D {
 
     // MARK: - BSpline Knot Splitting (v0.40.0)
 
-    /// Continuity order for knot splitting analysis
-    public enum ContinuityOrder: Int32 {
-        /// C0 continuity (positional)
-        case c0 = 0
-        /// C1 continuity (tangent)
-        case c1 = 1
-        /// C2 continuity (curvature)
-        case c2 = 2
-    }
+    // Continuity order for knot splitting is `ParametricContinuity` (Continuity.swift); the
+    // nested `ContinuityOrder` copy declared here is now a deprecated alias of it. See #398.
 
     /// Find parameter values where continuity drops below a specified level
     ///
-    /// Only works on BSpline curves. Returns knot parameters where the curve's
-    /// internal continuity is less than the requested order.
+    /// Only works on BSpline curves. Returns the knot parameters bounding arcs that are at
+    /// least `minContinuity`, which always includes the curve's own first and last knots.
+    ///
+    /// ```swift
+    /// // A cubic interpolated BSpline is already C2 at its interior knots, so nothing
+    /// // below C3 reports anything beyond the two end knots.
+    /// let ends   = bspline.continuityBreaks(minContinuity: .c2)  // [first, last]
+    /// let breaks = bspline.continuityBreaks(minContinuity: .c3)  // + interior knots
+    /// ```
+    ///
     /// - Parameter minContinuity: Minimum continuity to require
     /// - Returns: Array of parameter values at continuity breaks, or nil if not a BSpline
-    public func continuityBreaks(minContinuity: ContinuityOrder = .c1) -> [Double]? {
+    public func continuityBreaks(minContinuity: ParametricContinuity = .c1) -> [Double]? {
         let maxParams: Int32 = 256
         var params = [Double](repeating: 0, count: Int(maxParams))
         let count = OCCTCurve3DBSplineKnotSplits(handle, minContinuity.rawValue, &params, maxParams)

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -629,10 +629,12 @@ extension Curve3D {
     // Continuity order for knot splitting is `ParametricContinuity` (Continuity.swift); the
     // nested `ContinuityOrder` copy declared here is now a deprecated alias of it. See #398.
 
-    /// Find parameter values where continuity drops below a specified level
+    /// Knot parameters at which to split a BSpline so every arc is at least `minContinuity`
     ///
-    /// Only works on BSpline curves. Returns the knot parameters bounding arcs that are at
-    /// least `minContinuity`, which always includes the curve's own first and last knots.
+    /// Only works on BSpline curves. The result is a set of *split* parameters, not a set of
+    /// defects: the curve's own first and last knots are always included, so a curve that never
+    /// drops below `minContinuity` returns exactly those two rather than an empty array. Any
+    /// further entries are interior knots where the curve really is less continuous than asked.
     ///
     /// ```swift
     /// // A cubic interpolated BSpline is already C2 at its interior knots, so nothing
@@ -641,13 +643,27 @@ extension Curve3D {
     /// let breaks = bspline.continuityBreaks(minContinuity: .c3)  // + interior knots
     /// ```
     ///
-    /// - Parameter minContinuity: Minimum continuity to require
-    /// - Returns: Array of parameter values at continuity breaks, or nil if not a BSpline
+    /// - Parameter minContinuity: Minimum continuity to require of each resulting arc
+    /// - Returns: Split parameters in ascending order, bounded by the curve's end knots, or
+    ///   nil if the curve is not a BSpline
     public func continuityBreaks(minContinuity: ParametricContinuity = .c1) -> [Double]? {
-        let maxParams: Int32 = 256
-        var params = [Double](repeating: 0, count: Int(maxParams))
-        let count = OCCTCurve3DBSplineKnotSplits(handle, minContinuity.rawValue, &params, maxParams)
+        // The bridge returns the true split count even when it writes fewer, so one retry at
+        // that count is always enough. Worth doing since #398: the old c0...c2 range could not
+        // report interior knots at all on an ordinary cubic, and .c3 can, which brought a fixed
+        // 256-entry buffer within reach of real imported geometry.
+        func read(capacity: Int32) -> (count: Int32, params: [Double]) {
+            var params = [Double](repeating: 0, count: Int(capacity))
+            let count = OCCTCurve3DBSplineKnotSplits(handle, minContinuity.rawValue,
+                                                     &params, capacity)
+            return (count, params)
+        }
+
+        var (count, params) = read(capacity: 256)
         guard count >= 0 else { return nil }
+        if count > 256 {
+            (count, params) = read(capacity: count)
+            guard count >= 0 else { return nil }
+        }
         return Array(params.prefix(Int(count)))
     }
 

--- a/Sources/OCCTSwift/FillingSurface.swift
+++ b/Sources/OCCTSwift/FillingSurface.swift
@@ -2,15 +2,8 @@ import Foundation
 import simd
 import OCCTBridge
 
-/// Continuity order for filling surface constraints
-public enum FillingContinuity: Int32, Sendable {
-    /// Positional continuity (G0) — surface passes through the constraint
-    case c0 = 0
-    /// Tangent continuity (C1) — surface is tangent along the constraint
-    case c1 = 1
-    /// Curvature continuity (C2) — surface has curvature continuity along the constraint
-    case c2 = 2
-}
+// Continuity order for filling constraints is `SurfaceContinuity` (Continuity.swift); the
+// `FillingContinuity` copy this file used to declare is now a deprecated alias of it. See #398.
 
 /// Builder for N-sided surface filling using BRepFill_Filling.
 ///
@@ -21,10 +14,10 @@ public enum FillingContinuity: Int32, Sendable {
 /// ```swift
 /// let edges = box.edges()
 /// let filling = FillingSurface()
-/// filling.add(edge: edges[0], continuity: .c0)
-/// filling.add(edge: edges[1], continuity: .c0)
-/// filling.add(edge: edges[2], continuity: .c0)
-/// filling.add(edge: edges[3], continuity: .c0)
+/// filling.add(edge: edges[0], continuity: .g0)
+/// filling.add(edge: edges[1], continuity: .g0)
+/// filling.add(edge: edges[2], continuity: .g0)
+/// filling.add(edge: edges[3], continuity: .g0)
 /// filling.add(point: SIMD3(5, 5, 3))  // surface passes through this point
 /// let face = filling.build()
 /// ```
@@ -53,10 +46,15 @@ public final class FillingSurface: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - edge: Edge to add as boundary constraint
-    ///   - continuity: Continuity order at this edge (default .c0)
-    /// - Returns: true if the edge was added successfully
+    ///   - continuity: Continuity order at this edge (default .g0)
+    /// - Returns: true if the edge was added successfully, which says nothing about whether
+    ///   the order is usable: `BRepFill_Filling::Add` only appends, so a bad order surfaces
+    ///   later as a nil ``build()`` that takes every other constraint with it.
+    /// - Warning: Only ``SurfaceContinuity/g0`` currently behaves as documented here. This
+    ///   call still hand-maps the other two orders to the wrong OCCT values (`.g1` requests
+    ///   curvature, `.g2` requests an order every constraint class rejects). Tracked as #433.
     @discardableResult
-    public func add(edge: Edge, continuity: FillingContinuity = .c0) -> Bool {
+    public func add(edge: Edge, continuity: SurfaceContinuity = .g0) -> Bool {
         OCCTFillingAddEdge(handle, edge.handle, continuity.rawValue)
     }
 
@@ -66,10 +64,11 @@ public final class FillingSurface: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - freeEdge: Edge to add as a free constraint
-    ///   - continuity: Continuity order at this edge (default .c0)
+    ///   - continuity: Continuity order at this edge (default .g0)
     /// - Returns: true if the edge was added successfully
+    /// - Warning: Carries the same #433 order mis-mapping as ``add(edge:continuity:)``.
     @discardableResult
-    public func add(freeEdge edge: Edge, continuity: FillingContinuity = .c0) -> Bool {
+    public func add(freeEdge edge: Edge, continuity: SurfaceContinuity = .g0) -> Bool {
         OCCTFillingAddFreeEdge(handle, edge.handle, continuity.rawValue)
     }
 

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -3289,25 +3289,8 @@ extension Face {
 
 // MARK: - Advanced Blends & Surface Filling (v0.14.0)
 
-/// Continuity specification for surface filling operations
-public enum SurfaceContinuity: Int32 {
-    /// Positional continuity (surfaces touch)
-    case c0 = 0
-    /// Tangent continuity (smooth transition)
-    case g1 = 1
-    /// Curvature continuity (very smooth)
-    case g2 = 2
-}
-
-/// Constraint order for advanced plate surface construction (v0.23.0)
-public enum PlateConstraintOrder: Int32 {
-    /// Position only — surface must pass through the point
-    case g0 = 0
-    /// Position + tangent — surface must be tangent-continuous
-    case g1 = 1
-    /// Position + tangent + curvature — surface must be curvature-continuous
-    case g2 = 2
-}
+// `SurfaceContinuity` (formerly declared here, alongside a second `PlateConstraintOrder` copy
+// of the same vocabulary) now lives in Continuity.swift. See #398.
 
 /// One edge constraint for ``Shape/fill(constraints:parameters:)``.
 ///
@@ -3321,10 +3304,10 @@ public enum PlateConstraintOrder: Int32 {
 /// let tangent = FillConstraint(edge: rimEdge, support: wallFace, continuity: .g1)
 ///
 /// // Pass through this edge, but let it float otherwise
-/// let positional = FillConstraint(edge: freeEdge, continuity: .c0)
+/// let positional = FillConstraint(edge: freeEdge, continuity: .g0)
 ///
 /// // Pull the surface through an interior edge without it bounding the face
-/// let interior = FillConstraint(edge: ridgeEdge, continuity: .c0, isBoundary: false)
+/// let interior = FillConstraint(edge: ridgeEdge, continuity: .g0, isBoundary: false)
 /// ```
 public struct FillConstraint {
     /// Edge the filled surface must satisfy
@@ -3514,7 +3497,7 @@ extension Shape {
     /// // Free-standing wires have no surface to be tangent to, so fill positionally.
     /// let patch = Shape.fill(
     ///     boundaries: [wire1, wire2, wire3, wire4],
-    ///     parameters: FillingParameters(continuity: .c0)
+    ///     parameters: FillingParameters(continuity: .g0)
     /// )
     /// ```
     public static func fill(
@@ -3604,7 +3587,7 @@ extension Shape {
     ///
     /// let patch = Shape.fill(constraints: [
     ///     FillConstraint(edge: rim, support: wall, continuity: .g2),
-    ///     FillConstraint(edge: freeEdge, continuity: .c0)
+    ///     FillConstraint(edge: freeEdge, continuity: .g0)
     /// ])
     /// ```
     public static func fill(
@@ -3749,7 +3732,7 @@ extension Shape {
     /// - Returns: Surface face, or nil on failure
     public static func plateSurface(
         through points: [SIMD3<Double>],
-        orders: [PlateConstraintOrder],
+        orders: [SurfaceContinuity],
         degree: Int = 3,
         pointsOnCurves: Int = 15,
         iterations: Int = 2,
@@ -3786,8 +3769,8 @@ extension Shape {
     ///   - tolerance: Approximation tolerance (default 0.01)
     /// - Returns: Surface face, or nil on failure
     public static func plateSurface(
-        pointConstraints points: [(point: SIMD3<Double>, order: PlateConstraintOrder)],
-        curveConstraints curves: [(wire: Wire, order: PlateConstraintOrder)],
+        pointConstraints points: [(point: SIMD3<Double>, order: SurfaceContinuity)],
+        curveConstraints curves: [(wire: Wire, order: SurfaceContinuity)],
         degree: Int = 3,
         tolerance: Double = 0.01
     ) -> Shape? {
@@ -3829,13 +3812,9 @@ extension Shape {
 
 // MARK: - Advanced Healing (v0.17.0)
 
-/// Target geometric continuity for shape divide operations
-public enum GeometricContinuity: Int32, Sendable {
-    case c0 = 0
-    case c1 = 1
-    case c2 = 2
-    case c3 = 3
-}
+// The enum formerly declared here as `GeometricContinuity` was a misnomer: it maps to
+// GeomAbs_C0...C3, so it is parametric continuity. It is now `ParametricContinuity` in
+// Continuity.swift, shared with the other APIs that take a continuity floor. See #398.
 
 extension Shape {
 
@@ -3843,7 +3822,7 @@ extension Shape {
     ///
     /// - Parameter continuity: Target continuity level
     /// - Returns: Divided shape, or nil on failure
-    public func divided(at continuity: GeometricContinuity) -> Shape? {
+    public func divided(at continuity: ParametricContinuity) -> Shape? {
         guard let handle = OCCTShapeDivide(self.handle, continuity.rawValue) else { return nil }
         return Shape(handle: handle)
     }
@@ -7684,10 +7663,9 @@ extension Shape {
 
     // MARK: - ShapeCustom
 
-    /// Continuity for BSpline restriction
-    public enum BSplineContinuity: Int32, Sendable {
-        case c0 = 0, c1 = 1, c2 = 2, c3 = 3
-    }
+    // Continuity for BSpline restriction is `ParametricContinuity` (Continuity.swift); the
+    // nested `BSplineContinuity` copy this file used to declare is now a deprecated alias
+    // of it. See #398.
 
     /// Simplify BSpline surfaces and curves by restricting degree and segment count.
     ///
@@ -7706,7 +7684,7 @@ extension Shape {
     public func bsplineRestriction(
         tol3d: Double = 0.01, tol2d: Double = 0.01,
         maxDegree: Int = 8, maxSegments: Int = 100,
-        continuity3d: BSplineContinuity = .c1, continuity2d: BSplineContinuity = .c1,
+        continuity3d: ParametricContinuity = .c1, continuity2d: ParametricContinuity = .c1,
         degreePriority: Bool = true, rational: Bool = false
     ) -> Shape? {
         guard let ref = OCCTShapeCustomBSplineRestriction(
@@ -11513,10 +11491,8 @@ extension Shape {
 
 // MARK: - GeomConvert_ApproxCurve/Surface
 
-/// Continuity level for approximation.
-public enum ApproxContinuity: Int32 {
-    case c0 = 0, c1 = 1, c2 = 2, c3 = 3
-}
+// Continuity level for approximation is `ParametricContinuity` (Continuity.swift); the
+// `ApproxContinuity` copy this file used to declare is now a deprecated alias of it. See #398.
 
 /// Result of curve approximation as BSpline.
 public struct ApproxCurveResult {
@@ -11528,7 +11504,7 @@ public struct ApproxCurveResult {
 
 extension Curve3D {
     /// Approximate this curve as a BSpline with detailed result (error, status).
-    public func approxWithDetails(tolerance: Double, continuity: ApproxContinuity = .c2,
+    public func approxWithDetails(tolerance: Double, continuity: ParametricContinuity = .c2,
                                    maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult {
         let r = OCCTGeomConvertApproxCurve(handle, tolerance, continuity.rawValue,
                                             Int32(maxSegments), Int32(maxDegree))
@@ -11547,8 +11523,8 @@ public struct ApproxSurfaceResult {
 
 extension Surface {
     /// Approximate this surface as a BSpline with detailed result (error, status).
-    public func approxWithDetails(tolerance: Double, uContinuity: ApproxContinuity = .c1,
-                                   vContinuity: ApproxContinuity = .c1,
+    public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c1,
+                                   vContinuity: ParametricContinuity = .c1,
                                    maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult {
         let r = OCCTGeomConvertApproxSurface(handle, tolerance, uContinuity.rawValue,
                                               vContinuity.rawValue, Int32(maxDegree), Int32(maxSegments))

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -7534,8 +7534,14 @@ extension Shape {
 
     // MARK: - ShapeUpgrade_ShapeDivideContinuity
 
-    /// Continuity level for shape division
-    public enum ContinuityLevel: Int32, Sendable {
+    /// Continuity level for shape division.
+    ///
+    /// Deliberately kept separate from ``ParametricContinuity`` (#398): this is a strict
+    /// superset, and `cn`, `g1` and `g2` are accepted only by
+    /// ``dividedByContinuity(criterion:tolerance:)``. Every other continuity-floor call site
+    /// silently defaults an unrecognised value, so widening them to this type would trade a
+    /// compile error for a wrong answer.
+    public enum ContinuityLevel: Int32, Sendable, CaseIterable {
         case c0 = 0, c1 = 1, c2 = 2, c3 = 3, cn = 4, g1 = 5, g2 = 6
     }
 

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -34,6 +34,11 @@ public final class Surface: @unchecked Sendable {
     }
 
     /// Surface continuity class, derived from GeomAbs_Shape.
+    ///
+    /// - Note: This reports a surface's *measured* continuity, and its raw values are
+    ///   `GeomAbs_Shape`'s own ordinals, which are not a 0/1/2 order. Do not confuse it with
+    ///   the top-level ``SurfaceContinuity``, one dot away, which is the G0/G1/G2 order you
+    ///   *request* of a filling or plate constraint. See #398 for the full census.
     public enum Continuity: Int32, Sendable, CaseIterable {
         case c0 = 0, g1 = 1, c1 = 2, g2 = 3, c2 = 4, c3 = 5, cN = 6
     }

--- a/Tests/OCCTCurveTests/Issue398KnotSplittingTests.swift
+++ b/Tests/OCCTCurveTests/Issue398KnotSplittingTests.swift
@@ -39,6 +39,35 @@ struct Issue398KnotSplittingTests {
         }
     }
 
+    @Test("More than 256 splits are returned in full, not silently truncated")
+    func largeSplitCountSurvivesTheBuffer() {
+        // continuityBreaks used a fixed 256-entry buffer while the bridge returns the true,
+        // unclamped split count, so anything past the 256th was dropped without a signal. The
+        // old c0...c2 range could not report interior knots at all on a cubic, which kept that
+        // out of reach; .c3 can, so this now needs the retry path. 400 points is comfortably
+        // past the old ceiling.
+        let points: [SIMD3<Double>] = (0..<400).map { i in
+            let t = Double(i) / 399.0 * 12.0 * .pi
+            return SIMD3(Double(i) * 0.25, sin(t) * 5.0, cos(t * 0.5) * 2.0)
+        }
+        guard let bspline = Curve3D.interpolate(points: points)?.toBSpline() else {
+            Issue.record("could not build the 400-point BSpline")
+            return
+        }
+
+        guard let splits = bspline.continuityBreaks(minContinuity: .c3) else {
+            Issue.record("continuityBreaks returned nil for a BSpline")
+            return
+        }
+        #expect(splits.count > 256)
+        // The retry must return the whole set, not a second truncated window.
+        #expect(splits.count == splits.sorted().count)
+        #expect(splits == splits.sorted())
+        // Ascending and strictly so: these are distinct knot values, which is the ordering
+        // guarantee the `- Returns:` line promises.
+        #expect(zip(splits, splits.dropFirst()).allSatisfy { $0 < $1 })
+    }
+
     @Test("Requesting more continuity never reports fewer split parameters")
     func higherOrdersAreMonotonic() {
         guard let bspline = cubicWithInteriorKnots() else {

--- a/Tests/OCCTCurveTests/Issue398KnotSplittingTests.swift
+++ b/Tests/OCCTCurveTests/Issue398KnotSplittingTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #398: `Curve3D.ContinuityOrder` stopped at `c2`, which made every order it could express a
+/// no-op for the query it exists to answer. Sharing `ParametricContinuity` with the other
+/// continuity-floor APIs makes `.c3` reachable, and `.c3` is the order that actually finds
+/// interior breaks on an ordinary cubic.
+@Suite("BSpline knot splitting continuity range (#398)")
+struct Issue398KnotSplittingTests {
+
+    /// A cubic BSpline interpolated through points that force interior knots.
+    private func cubicWithInteriorKnots() -> Curve3D? {
+        let points: [SIMD3<Double>] = [
+            SIMD3(0, 0, 0), SIMD3(10, 5, 0), SIMD3(20, -5, 0), SIMD3(30, 5, 0),
+            SIMD3(40, -5, 0), SIMD3(50, 5, 0), SIMD3(60, -3, 0), SIMD3(70, 0, 0),
+        ]
+        return Curve3D.interpolate(points: points)?.toBSpline()
+    }
+
+    @Test("Third-derivative order is reachable and reports interior knots")
+    func thirdDerivativeOrderReportsInteriorKnots() {
+        guard let bspline = cubicWithInteriorKnots() else {
+            Issue.record("could not build the test BSpline")
+            return
+        }
+
+        // Interior knots of a cubic interpolation have multiplicity 1, so the curve is already
+        // C2 there. Nothing below C3 has anything to report beyond the two end knots, which is
+        // why the old c0...c2 range could never answer this question.
+        let atC2 = bspline.continuityBreaks(minContinuity: .c2)
+        let atC3 = bspline.continuityBreaks(minContinuity: .c3)
+
+        #expect(atC2 != nil)
+        #expect(atC3 != nil)
+        if let atC2, let atC3 {
+            #expect(atC2.count == 2)
+            #expect(atC3.count > atC2.count)
+        }
+    }
+
+    @Test("Requesting more continuity never reports fewer split parameters")
+    func higherOrdersAreMonotonic() {
+        guard let bspline = cubicWithInteriorKnots() else {
+            Issue.record("could not build the test BSpline")
+            return
+        }
+        let counts = ParametricContinuity.allCases.compactMap {
+            bspline.continuityBreaks(minContinuity: $0)?.count
+        }
+        #expect(counts.count == ParametricContinuity.allCases.count)
+        #expect(counts == counts.sorted())
+        // Every order at least brackets the curve with its own end knots.
+        #expect(counts.allSatisfy { $0 >= 2 })
+    }
+}

--- a/Tests/OCCTCurveTests/Issue398KnotSplittingTests.swift
+++ b/Tests/OCCTCurveTests/Issue398KnotSplittingTests.swift
@@ -60,11 +60,19 @@ struct Issue398KnotSplittingTests {
             return
         }
         #expect(splits.count > 256)
-        // The retry must return the whole set, not a second truncated window.
-        #expect(splits.count == splits.sorted().count)
-        #expect(splits == splits.sorted())
-        // Ascending and strictly so: these are distinct knot values, which is the ordering
-        // guarantee the `- Returns:` line promises.
+
+        // The retry must return the whole set, not a second truncated window. Count alone
+        // cannot tell those apart; the end parameters can, since a truncated result stops
+        // short of the curve's final knot. This also pins the `- Returns:` promise that the
+        // result is bounded by the curve's own end knots.
+        let domain = bspline.domain
+        if let first = splits.first, let last = splits.last {
+            #expect(abs(first - domain.lowerBound) < 1e-9)
+            #expect(abs(last - domain.upperBound) < 1e-9)
+        }
+
+        // Strictly ascending: these are distinct knot values, which is the other half of the
+        // ordering guarantee that same line promises.
         #expect(zip(splits, splits.dropFirst()).allSatisfy { $0 < $1 })
     }
 

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -1182,7 +1182,7 @@ struct BSplineKnotSplittingTests {
             #expect(bspline != nil)
             if let bspline {
                 // C0 breaks — should at least have first and last
-                let c0Breaks = bspline.continuityBreaks(minContinuity: Curve3D.ContinuityOrder.c0)
+                let c0Breaks = bspline.continuityBreaks(minContinuity: ParametricContinuity.c0)
                 #expect(c0Breaks != nil)
                 if let c0Breaks {
                     #expect(c0Breaks.count >= 2) // At minimum first/last knot

--- a/Tests/OCCTSurfaceTests/Issue398ContinuityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue398ContinuityTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #398: the continuity vocabularies collapsed from nine enums to two shared ones plus two
+/// retained specials. These pin the raw values (the unification must not move a single one),
+/// the deprecated spellings, and the one order that OCCT refuses outright.
+@Suite("Continuity vocabulary (#398)")
+struct Issue398ContinuityTests {
+
+    // MARK: - Raw values
+
+    @Test("Geometric orders keep their plate-order raw values")
+    func geometricOrdersKeepRawValues() {
+        // These are handed to OCCT as a plate constraint order, which GeomPlate_CurveConstraint
+        // validates against [-1, 2]. Renaming .c0 to .g0 must not have moved anything.
+        #expect(SurfaceContinuity.g0.rawValue == 0)
+        #expect(SurfaceContinuity.g1.rawValue == 1)
+        #expect(SurfaceContinuity.g2.rawValue == 2)
+        #expect(SurfaceContinuity.allCases.count == 3)
+    }
+
+    @Test("Parametric orders keep their GeomAbs_C0...C3 raw values")
+    func parametricOrdersKeepRawValues() {
+        #expect(ParametricContinuity.c0.rawValue == 0)
+        #expect(ParametricContinuity.c1.rawValue == 1)
+        #expect(ParametricContinuity.c2.rawValue == 2)
+        #expect(ParametricContinuity.c3.rawValue == 3)
+        #expect(ParametricContinuity.allCases.count == 4)
+    }
+
+    @Test("Surface.Continuity still mirrors the real GeomAbs_Shape ordinals")
+    func surfaceContinuityMirrorsGeomAbsShape() {
+        // Deliberately NOT folded into either shared enum: this one is a result type whose
+        // raw values are GeomAbs_Shape's own ordinals, which are not a 0/1/2 order at all.
+        #expect(Surface.Continuity.c0.rawValue == 0)
+        #expect(Surface.Continuity.g1.rawValue == 1)
+        #expect(Surface.Continuity.c1.rawValue == 2)
+        #expect(Surface.Continuity.g2.rawValue == 3)
+        #expect(Surface.Continuity.c2.rawValue == 4)
+        #expect(Surface.Continuity.c3.rawValue == 5)
+        #expect(Surface.Continuity.cN.rawValue == 6)
+    }
+
+    // MARK: - Source compatibility
+
+    @available(*, deprecated, message: "exercises the deprecated spellings on purpose")
+    @Test("Retired names and spellings still resolve to the same values")
+    func retiredSpellingsStillResolve() {
+        #expect(FillingContinuity.g0 == SurfaceContinuity.g0)
+        #expect(PlateConstraintOrder.g1 == SurfaceContinuity.g1)
+        #expect(SurfaceContinuity.c0 == SurfaceContinuity.g0)
+        #expect(SurfaceContinuity.c1 == SurfaceContinuity.g1)
+        #expect(SurfaceContinuity.c2 == SurfaceContinuity.g2)
+
+        #expect(GeometricContinuity.c2 == ParametricContinuity.c2)
+        #expect(ApproxContinuity.c3 == ParametricContinuity.c3)
+        #expect(Shape.BSplineContinuity.c1 == ParametricContinuity.c1)
+        #expect(Curve3D.ContinuityOrder.c0 == ParametricContinuity.c0)
+    }
+
+    // MARK: - Orders OCCT will not accept
+
+    @Test("Plate point constraints reject curvature order")
+    func plateThroughPointsRejectsCurvatureOrder() {
+        // GeomPlate_PointConstraint throws above order 1: a bare point carries no curvature
+        // to match. The throw takes down the whole build, not just that one constraint, so
+        // .g2 here is always nil however good the point set is.
+        let points: [SIMD3<Double>] = [
+            SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2),
+            SIMD3(0, 10, 1), SIMD3(5, 5, 3)
+        ]
+        let curvature = Shape.plateSurface(through: points,
+                                           orders: Array(repeating: .g2, count: points.count))
+        #expect(curvature == nil)
+
+        // The orders that do work, for contrast.
+        let positional = Shape.plateSurface(through: points,
+                                            orders: Array(repeating: .g0, count: points.count))
+        #expect(positional != nil)
+        let tangent = Shape.plateSurface(through: points,
+                                         orders: Array(repeating: .g1, count: points.count))
+        #expect(tangent != nil)
+    }
+
+    @Test("A single curvature point poisons an otherwise valid order list")
+    func plateThroughPointsRejectsMixedCurvatureOrder() {
+        let points: [SIMD3<Double>] = [
+            SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2),
+            SIMD3(0, 10, 1), SIMD3(5, 5, 3)
+        ]
+        var orders: [SurfaceContinuity] = Array(repeating: .g0, count: points.count)
+        orders[2] = .g2
+        #expect(Shape.plateSurface(through: points, orders: orders) == nil)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue398ContinuityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue398ContinuityTests.swift
@@ -29,6 +29,21 @@ struct Issue398ContinuityTests {
         #expect(ParametricContinuity.allCases.count == 4)
     }
 
+    @Test("The two vocabularies are distinct types, not aliases of each other")
+    func vocabulariesAreNotSubstitutable() {
+        // The property this whole refactor exists to guarantee is compile-time: a G0/G1/G2
+        // constraint order must never be passable where a C0...C3 continuity floor is wanted,
+        // or vice versa. That cannot be asserted directly, but collapsing one into a typealias
+        // of the other is the realistic way it would be lost, and this catches exactly that.
+        #expect(ObjectIdentifier(SurfaceContinuity.self) != ObjectIdentifier(ParametricContinuity.self))
+        #expect(ObjectIdentifier(SurfaceContinuity.self) != ObjectIdentifier(Surface.Continuity.self))
+        #expect(ObjectIdentifier(ParametricContinuity.self) != ObjectIdentifier(Shape.ContinuityLevel.self))
+
+        // They agree on 0/1/2 numerically, which is precisely why the type distinction is
+        // load-bearing: a raw-value mix-up would be silent.
+        #expect(SurfaceContinuity.g1.rawValue == ParametricContinuity.c1.rawValue)
+    }
+
     @Test("Surface.Continuity still mirrors the real GeomAbs_Shape ordinals")
     func surfaceContinuityMirrorsGeomAbsShape() {
         // Deliberately NOT folded into either shared enum: this one is a result type whose
@@ -61,6 +76,8 @@ struct Issue398ContinuityTests {
 
     // MARK: - Orders OCCT will not accept
 
+    // NOTE: both tests below pin a BUG, not desired behaviour. Flip the `== nil` expectations
+    // when #437 lands and .g2 either clamps or is rejected up front.
     @Test("Plate point constraints reject curvature order")
     func plateThroughPointsRejectsCurvatureOrder() {
         // GeomPlate_PointConstraint throws above order 1: a bare point carries no curvature

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -49,7 +49,7 @@ struct SurfaceFillingTests {
         // succeed with all boundary configurations. This tests the API.
         let surface = Shape.fill(
             boundaries: [boundary],
-            parameters: FillingParameters(continuity: .c0)
+            parameters: FillingParameters(continuity: .g0)
         )
 
         // The operation may or may not succeed depending on OCCT's
@@ -72,7 +72,7 @@ struct SurfaceFillingTests {
         }
 
         let params = FillingParameters(
-            continuity: .c0,
+            continuity: .g0,
             tolerance: 1e-3,
             maxDegree: 8,
             maxSegments: 9
@@ -148,7 +148,7 @@ struct FillingSupportFaceTests {
         }
 
         let flat = Shape.fill(boundaries: [rim],
-                              parameters: FillingParameters(continuity: .c0))
+                              parameters: FillingParameters(continuity: .g0))
         let tangent = Shape.fill(boundaries: [rim], supportedBy: bowl,
                                  parameters: FillingParameters(continuity: .g1))
 
@@ -272,7 +272,7 @@ struct FillingSupportFaceTests {
         }
 
         let boundaryOnly = Shape.fill(constraints: [
-            FillConstraint(edge: rim, continuity: .c0)
+            FillConstraint(edge: rim, continuity: .g0)
         ])
 
         // A line well above the rim plane, spanning the opening. As an internal (non-bounding)
@@ -285,8 +285,8 @@ struct FillingSupportFaceTests {
         }
 
         let withInterior = Shape.fill(constraints: [
-            FillConstraint(edge: rim, continuity: .c0),
-            FillConstraint(edge: interior, continuity: .c0, isBoundary: false)
+            FillConstraint(edge: rim, continuity: .g0),
+            FillConstraint(edge: interior, continuity: .g0, isBoundary: false)
         ])
 
         guard let boundaryOnly = boundaryOnly, let withInterior = withInterior else {
@@ -310,7 +310,7 @@ struct FillingSupportFaceTests {
         let tangent = Shape.fill(boundaries: [square],
                                  parameters: FillingParameters(continuity: .g1))
         let positional = Shape.fill(boundaries: [square],
-                                    parameters: FillingParameters(continuity: .c0))
+                                    parameters: FillingParameters(continuity: .g0))
 
         #expect(tangent == nil)
         #expect(positional != nil)
@@ -369,7 +369,7 @@ struct FillingSupportFaceTests {
         // because SetApproxParam was never called — so the cap did nothing and the result came
         // back degree 8. Second site of #431.
         let filling = FillingSurface(maxDegree: 3)
-        #expect(filling.add(edge: rim, continuity: .c1))
+        #expect(filling.add(edge: rim, continuity: .g1))
 
         guard let surface = filling.build()?.faceSurfaceGeom() else {
             Issue.record("FillingSurface should build a face with an extractable surface")
@@ -394,7 +394,7 @@ struct FillingSupportFaceTests {
         // requests curvature, .c2 lands out of range and is dropped) — that is #433, because
         // correcting it changes documented public behavior.
         let filling = FillingSurface()
-        let added = filling.add(edge: rim, continuity: .c1)
+        let added = filling.add(edge: rim, continuity: .g1)
         #expect(added)
 
         let face = filling.build()
@@ -472,7 +472,7 @@ struct PlateSurfaceTests {
         // succeed depending on OCCT's GeomPlate algorithm
         let surface = Shape.plateSurface(
             constrainedBy: [curve1, curve2],
-            continuity: .c0,
+            continuity: .g0,
             tolerance: 1.0
         )
 
@@ -1012,7 +1012,7 @@ struct SurfaceCurveProjectionTests {
 
 // MARK: - Advanced Plate Surfaces Tests (v0.23.0)
 
-@Suite("Advanced Plate Surface Tests", .disabled("Plate surface operations cause segfault in OCCT — pre-existing issue"))
+@Suite("Advanced Plate Surface Tests")
 struct AdvancedPlateSurfaceTests {
 
     @Test("Plate surface with G0 constraint orders")
@@ -1021,7 +1021,7 @@ struct AdvancedPlateSurfaceTests {
             SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2),
             SIMD3(0, 10, 1), SIMD3(5, 5, 3)
         ]
-        let orders: [PlateConstraintOrder] = [.g0, .g0, .g0, .g0, .g0]
+        let orders: [SurfaceContinuity] = [.g0, .g0, .g0, .g0, .g0]
         let shape = Shape.plateSurface(through: points, orders: orders)
         #expect(shape != nil)
         if let s = shape {
@@ -1035,7 +1035,7 @@ struct AdvancedPlateSurfaceTests {
             SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0),
             SIMD3(0, 10, 0), SIMD3(5, 5, 2)
         ]
-        let orders: [PlateConstraintOrder] = [.g0, .g1, .g0, .g1, .g0]
+        let orders: [SurfaceContinuity] = [.g0, .g1, .g0, .g1, .g0]
         let shape = Shape.plateSurface(through: points, orders: orders)
         #expect(shape != nil)
     }
@@ -1047,7 +1047,7 @@ struct AdvancedPlateSurfaceTests {
             SIMD3(0, 5, 1), SIMD3(5, 5, 3), SIMD3(10, 5, 1),
             SIMD3(0, 10, 0), SIMD3(5, 10, 1), SIMD3(10, 10, 0)
         ]
-        let orders: [PlateConstraintOrder] = Array(repeating: .g0, count: 9)
+        let orders: [SurfaceContinuity] = Array(repeating: .g0, count: 9)
         let shape = Shape.plateSurface(
             through: points, orders: orders,
             degree: 4, pointsOnCurves: 20, iterations: 3, tolerance: 0.001
@@ -1058,7 +1058,7 @@ struct AdvancedPlateSurfaceTests {
     @Test("Plate surface rejects mismatched point/order counts")
     func platePointsMismatch() {
         let points: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0)]
-        let orders: [PlateConstraintOrder] = [.g0, .g0]  // Too few
+        let orders: [SurfaceContinuity] = [.g0, .g0]  // Too few
         let shape = Shape.plateSurface(through: points, orders: orders)
         #expect(shape == nil)
     }
@@ -1066,14 +1066,14 @@ struct AdvancedPlateSurfaceTests {
     @Test("Plate surface rejects fewer than 3 points")
     func platePointsTooFew() {
         let points: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(1, 0, 0)]
-        let orders: [PlateConstraintOrder] = [.g0, .g0]
+        let orders: [SurfaceContinuity] = [.g0, .g0]
         let shape = Shape.plateSurface(through: points, orders: orders)
         #expect(shape == nil)
     }
 
     @Test("Mixed plate surface with points and curves")
     func plateMixedPointsAndCurves() {
-        let pointConstraints: [(point: SIMD3<Double>, order: PlateConstraintOrder)] = [
+        let pointConstraints: [(point: SIMD3<Double>, order: SurfaceContinuity)] = [
             (point: SIMD3(5, 5, 3), order: .g0),
             (point: SIMD3(2, 8, 1), order: .g0)
         ]
@@ -1087,7 +1087,7 @@ struct AdvancedPlateSurfaceTests {
             return
         }
 
-        let curveConstraints: [(wire: Wire, order: PlateConstraintOrder)] = [
+        let curveConstraints: [(wire: Wire, order: SurfaceContinuity)] = [
             (wire: w, order: .g0)
         ]
 
@@ -1100,13 +1100,13 @@ struct AdvancedPlateSurfaceTests {
 
     @Test("Mixed plate surface with points only")
     func plateMixedPointsOnly() {
-        let pointConstraints: [(point: SIMD3<Double>, order: PlateConstraintOrder)] = [
+        let pointConstraints: [(point: SIMD3<Double>, order: SurfaceContinuity)] = [
             (point: SIMD3(0, 0, 0), order: .g0),
             (point: SIMD3(10, 0, 1), order: .g0),
             (point: SIMD3(10, 10, 2), order: .g0),
             (point: SIMD3(0, 10, 1), order: .g0)
         ]
-        let curveConstraints: [(wire: Wire, order: PlateConstraintOrder)] = []
+        let curveConstraints: [(wire: Wire, order: SurfaceContinuity)] = []
 
         let shape = Shape.plateSurface(
             pointConstraints: pointConstraints,
@@ -1121,7 +1121,7 @@ struct AdvancedPlateSurfaceTests {
             SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0),
             SIMD3(0, 10, 0), SIMD3(5, 5, 5)
         ]
-        let orders: [PlateConstraintOrder] = Array(repeating: .g0, count: 5)
+        let orders: [SurfaceContinuity] = Array(repeating: .g0, count: 5)
         let shape = Shape.plateSurface(through: points, orders: orders)
         #expect(shape != nil)
         if let s = shape {
@@ -1890,7 +1890,7 @@ struct FillingSurfaceTests {
 
         let filling = FillingSurface()
         for edge in edges {
-            #expect(filling.add(edge: edge, continuity: .c0))
+            #expect(filling.add(edge: edge, continuity: .g0))
         }
 
         let result = filling.build()
@@ -1904,7 +1904,7 @@ struct FillingSurfaceTests {
 
         let filling = FillingSurface()
         for edge in edges {
-            filling.add(edge: edge, continuity: .c0)
+            filling.add(edge: edge, continuity: .g0)
         }
         let _ = filling.build()
 
@@ -1921,7 +1921,7 @@ struct FillingSurfaceTests {
 
         let filling = FillingSurface()
         for edge in edges {
-            filling.add(edge: edge, continuity: .c0)
+            filling.add(edge: edge, continuity: .g0)
         }
         // Add interior point above the plane
         filling.add(point: SIMD3(5, 5, 3))
@@ -1937,7 +1937,7 @@ struct FillingSurfaceTests {
 
         let filling = FillingSurface()
         for edge in edges {
-            filling.add(edge: edge, continuity: .c0)
+            filling.add(edge: edge, continuity: .g0)
         }
         let _ = filling.build()
 
@@ -1955,9 +1955,9 @@ struct FillingSurfaceTests {
         let filling = FillingSurface()
         // Add 3 boundary edges and 1 free edge
         for i in 0..<3 {
-            filling.add(edge: edges[i], continuity: .c0)
+            filling.add(edge: edges[i], continuity: .g0)
         }
-        filling.add(freeEdge: edges[3], continuity: .c0)
+        filling.add(freeEdge: edges[3], continuity: .g0)
 
         let result = filling.build()
         #expect(result != nil)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,62 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### Unreleased: refactor — nine continuity enums collapsed to two shared vocabularies (#398)
+
+> Version and date deliberately unset; whoever tags stamps them.
+
+OCCTSwift had grown **nine** separate "continuity level" enums, each written against one bridge
+call and each re-deriving its own raw-int meaning. Verified against the pinned kernel, they turn
+out to express exactly **three** contracts, not one:
+
+| contract | what OCCT receives | enums that expressed it |
+|---|---|---|
+| geometric constraint order, `0/1/2 = G0/G1/G2` | a plate constraint order; `GeomPlate_CurveConstraint` rejects outside `[-1, 2]` with "The continuity is not G0 G1 or G2" | `SurfaceContinuity`, `PlateConstraintOrder`, `FillingContinuity` |
+| required parametric continuity, `0…3 = C0…C3` | a `GeomAbs_Shape` continuity class, or a literal derivative-order integer | `GeometricContinuity`, `ApproxContinuity`, `Shape.BSplineContinuity`, `Curve3D.ContinuityOrder` |
+| a `GeomAbs_Shape` ordinal reported back | nothing; it is a *result* | `Surface.Continuity` |
+
+Collapsed to `SurfaceContinuity` (`.g0` / `.g1` / `.g2`) and a new `ParametricContinuity`
+(`.c0` … `.c3`). `Surface.Continuity` is retained as a result type, and `Shape.ContinuityLevel`
+is retained as a strict superset (it adds `cn`, `g1`, `g2` cases that only
+`dividedByContinuity(criterion:tolerance:)` accepts).
+
+**No raw value moved, and no bridge code changed, so no call's behaviour changed.** Every retired
+name and spelling remains as a deprecated alias, so existing source still compiles:
+
+```swift
+@available(*, deprecated, renamed: "SurfaceContinuity")
+public typealias FillingContinuity = SurfaceContinuity      // and PlateConstraintOrder
+@available(*, deprecated, renamed: "ParametricContinuity")
+public typealias GeometricContinuity = ParametricContinuity // and ApproxContinuity,
+                                                            // Shape.BSplineContinuity,
+                                                            // Curve3D.ContinuityOrder
+```
+
+`SurfaceContinuity.c0` / `.c1` / `.c2` also survive as deprecated aliases of `.g0` / `.g1` /
+`.g2`. The one source-compatibility caveat: an *exhaustive* `switch` over one of these enums now
+needs a `default`, since the old spellings are static properties rather than cases.
+
+Two live defects surfaced while verifying the mappings the issue had assumed correct. Both are
+pre-existing, both are now pinned by tests, and neither is fixed here:
+
+- **`Shape.plateSurface(through:orders:)` can never accept `.g2`.** A bare point carries no
+  curvature to match, so `GeomPlate_PointConstraint` throws above order 1 (the header's "Order is
+  not 0 or -1" doc is itself wrong; 1 is accepted). The throw fails the whole call, so a single
+  `.g2` in an otherwise valid order list returns `nil`.
+- **`Curve3D.ContinuityOrder`'s cap at `.c2` made every order it offered a no-op.**
+  `GeomConvert_BSplineCurveKnotSplitting` splits where `degree - multiplicity < ContinuityRange`,
+  and a cubic interpolation is already C2 at its interior knots. Measured: ranges 0, 1 and 2 all
+  return just the two end knots; range 3 returns five parameters. Sharing `ParametricContinuity`
+  makes `.c3` reachable, which fixes this as a side effect.
+
+Also re-enabled `AdvancedPlateSurfaceTests`, disabled since v0.23.0 under the claim "Plate surface
+operations cause segfault in OCCT". A C++ replica of that exact bridge path shows no segfault at
+orders 0 or 1, and the suite is 8/8 clean over repeated runs. Same pattern as the #341
+re-enablement: the claim was never characterised and does not hold up.
+
+Docs: `naming-conventions.md` carried `GeometricContinuity.c0, .c1, .g1` as its worked example,
+an enum/case combination that never existed.
+
 ### Unreleased: fix — `Shape.fill` SIGSEGV'd on its own default parameters (#430)
 
 > Version and date are deliberately unset: this entry is written on a branch, and the next patch

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
-### Unreleased: refactor, nine continuity enums collapsed to two shared vocabularies (#398)
+### Unreleased: refactor — nine continuity enums collapsed to two shared vocabularies (#398)
 
 > Version and date deliberately unset; whoever tags stamps them.
 
@@ -79,7 +79,7 @@ re-enablement: the claim was never characterised and does not hold up.
 Docs: `naming-conventions.md` carried `GeometricContinuity.c0, .c1, .g1` as its worked example,
 an enum/case combination that never existed.
 
-### Unreleased: fix, `Shape.fill` SIGSEGV'd on its own default parameters (#430)
+### Unreleased: fix — `Shape.fill` SIGSEGV'd on its own default parameters (#430)
 
 > Version and date are deliberately unset: this entry is written on a branch, and the next patch
 > number is not this PR's to claim. Whoever tags stamps it then. (Two open PRs both predicted

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,9 +34,12 @@ Collapsed to `SurfaceContinuity` (`.g0` / `.g1` / `.g2`) and a new `ParametricCo
 is retained as a strict superset (it adds `cn`, `g1`, `g2` cases that only
 `dividedByContinuity(criterion:tolerance:)` accepts).
 
-**No raw value moved, and no bridge code changed, so no existing call's behaviour changed.** (The
-one deliberate widening is `.c3` becoming reachable for `continuityBreaks`, below.) Every retired
-name and spelling remains as a deprecated alias, so existing source still compiles:
+**No raw value moved, and no bridge code changed, so no existing call's behaviour changed.** Two
+deliberate widenings, both in `Curve3D.continuityBreaks(minContinuity:)`: `.c3` becomes reachable
+(below), and results past the 256th are no longer silently dropped. The latter is the only new
+executable code in this PR, and the more consequential of the two for imported geometry, which is
+where split counts get large. Every retired name and spelling remains as a deprecated alias, so
+existing source still compiles:
 
 ```swift
 @available(*, deprecated, renamed: "SurfaceContinuity")
@@ -76,7 +79,7 @@ re-enablement: the claim was never characterised and does not hold up.
 Docs: `naming-conventions.md` carried `GeometricContinuity.c0, .c1, .g1` as its worked example,
 an enum/case combination that never existed.
 
-### Unreleased: fix — `Shape.fill` SIGSEGV'd on its own default parameters (#430)
+### Unreleased: fix, `Shape.fill` SIGSEGV'd on its own default parameters (#430)
 
 > Version and date are deliberately unset: this entry is written on a branch, and the next patch
 > number is not this PR's to claim. Whoever tags stamps it then. (Two open PRs both predicted

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
-### Unreleased: refactor — nine continuity enums collapsed to two shared vocabularies (#398)
+### Unreleased: refactor, nine continuity enums collapsed to two shared vocabularies (#398)
 
 > Version and date deliberately unset; whoever tags stamps them.
 
@@ -34,7 +34,8 @@ Collapsed to `SurfaceContinuity` (`.g0` / `.g1` / `.g2`) and a new `ParametricCo
 is retained as a strict superset (it adds `cn`, `g1`, `g2` cases that only
 `dividedByContinuity(criterion:tolerance:)` accepts).
 
-**No raw value moved, and no bridge code changed, so no call's behaviour changed.** Every retired
+**No raw value moved, and no bridge code changed, so no existing call's behaviour changed.** (The
+one deliberate widening is `.c3` becoming reachable for `continuityBreaks`, below.) Every retired
 name and spelling remains as a deprecated alias, so existing source still compiles:
 
 ```swift
@@ -47,8 +48,12 @@ public typealias GeometricContinuity = ParametricContinuity // and ApproxContinu
 ```
 
 `SurfaceContinuity.c0` / `.c1` / `.c2` also survive as deprecated aliases of `.g0` / `.g1` /
-`.g2`. The one source-compatibility caveat: an *exhaustive* `switch` over one of these enums now
-needs a `default`, since the old spellings are static properties rather than cases.
+`.g2`. Two source-compatibility caveats, both fixed by adding a `default`:
+
+- An *exhaustive* `switch` over any of these enums now needs one, because the old spellings are
+  static properties rather than cases.
+- `Curve3D.ContinuityOrder` also *widens* from three cases to four, so even a switch written with
+  the correct `.c0` / `.c1` / `.c2` spellings stops being exhaustive.
 
 Two live defects surfaced while verifying the mappings the issue had assumed correct. Both are
 pre-existing, both are now pinned by tests, and neither is fixed here:

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -97,7 +97,8 @@ OCCTSwift uses Swift-style dot-syntax with lowercase cases:
 
 ```swift
 ShapeType.solid, .face, .edge, .vertex
-GeometricContinuity.c0, .c1, .g1
+ParametricContinuity.c0, .c1, .c2
+SurfaceContinuity.g0, .g1, .g2
 ```
 
 ## Properties vs Query Methods

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -77,15 +77,21 @@ public var degree: Int { get }
 
 ### `ContinuityOrder`
 
-Continuity level used for knot-splitting analysis.
+> **Deprecated in #398.** `ContinuityOrder` was one of several copies of the same
+> continuity-floor vocabulary and is now a typealias of
+> [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity).
 
 ```swift
-public enum ContinuityOrder: Int32 {
-    case c0 = 0   // positional
-    case c1 = 1   // tangent
-    case c2 = 2   // curvature
-}
+@available(*, deprecated, renamed: "ParametricContinuity")
+public typealias ContinuityOrder = ParametricContinuity
 ```
+
+The old enum stopped at `.c2`, which made **every order it could express a no-op** for the
+query it exists to answer: `GeomConvert_BSplineCurveKnotSplitting` splits where
+`degree - multiplicity < ContinuityRange`, and an ordinary cubic interpolation has interior
+knots of multiplicity 1, so it is already C2 there. Measured on a degree-3 interpolated BSpline,
+ranges 0, 1 and 2 all return just the two end knots; range 3 returns five parameters.
+`ParametricContinuity.c3` is reachable and fixes that. OCCT itself accepts any range `>= 0`.
 
 Pass to `continuityBreaks(minContinuity:)` to specify the minimum required continuity across knots.
 
@@ -96,7 +102,7 @@ Pass to `continuityBreaks(minContinuity:)` to specify the minimum required conti
 Parameter values where the B-spline's internal continuity drops below the specified level.
 
 ```swift
-public func continuityBreaks(minContinuity: ContinuityOrder = .c1) -> [Double]?
+public func continuityBreaks(minContinuity: ParametricContinuity = .c1) -> [Double]?
 ```
 
 Only works on `Geom_BSplineCurve`. Returns knot parameters where the curve's continuity is strictly less than `minContinuity`. Useful for splitting a composite B-spline into smooth segments.

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -99,16 +99,16 @@ Pass to `continuityBreaks(minContinuity:)` to specify the minimum required conti
 
 ### `continuityBreaks(minContinuity:)`
 
-Parameter values where the B-spline's internal continuity drops below the specified level.
+Knot parameters at which to split the B-spline so that every resulting arc is at least `minContinuity`.
 
 ```swift
 public func continuityBreaks(minContinuity: ParametricContinuity = .c1) -> [Double]?
 ```
 
-Only works on `Geom_BSplineCurve`. Returns knot parameters where the curve's continuity is strictly less than `minContinuity`. Useful for splitting a composite B-spline into smooth segments.
+Only works on `Geom_BSplineCurve`. The result is a set of *split* parameters, not a set of defects: the curve's own first and last knots are always included, so a curve that never drops below `minContinuity` returns exactly those two rather than an empty array. Any further entries are interior knots where the curve really is less continuous than asked. Useful for splitting a composite B-spline into smooth segments.
 
-- **Parameters:** `minContinuity` — minimum continuity to require (default `.c1`).
-- **Returns:** Array of parameter values at continuity breaks (up to 256), or `nil` if the curve is not a B-spline.
+- **Parameters:** `minContinuity` — minimum continuity to require of each resulting arc (default `.c1`).
+- **Returns:** Split parameters in ascending order, bounded by the curve's end knots, or `nil` if the curve is not a B-spline.
 - **OCCT:** `GeomConvert_BSplineCurveKnotSplitting::NbSplits` / `SplitValue`, resolved via `Geom_BSplineCurve::Knot`.
 - **Example:**
   ```swift

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -396,15 +396,20 @@ Builder for N-sided surface filling using `BRepFill_Filling`. Creates a smooth s
 
 ### `FillingContinuity`
 
-Continuity order for filling surface constraints.
+> **Deprecated in #398.** `FillingContinuity` was one of three copies of the same geometric
+> constraint-order vocabulary and is now a typealias of
+> [`SurfaceContinuity`](Shape-Features.md#surfacecontinuity) (`.g0` / `.g1` / `.g2`). The
+> `.c0` / `.c1` / `.c2` spellings still resolve, as deprecated aliases. No raw value moved.
 
 ```swift
-public enum FillingContinuity: Int32, Sendable {
-    case c0 = 0   // Positional continuity (G0)
-    case c1 = 1   // Tangent continuity (C1)
-    case c2 = 2   // Curvature continuity (C2)
-}
+@available(*, deprecated, renamed: "SurfaceContinuity")
+public typealias FillingContinuity = SurfaceContinuity
 ```
+
+> **Only `.g0` currently behaves as documented here.** `OCCTFillingAddEdge` still hand-maps the
+> other two orders to the wrong OCCT values: `.g1` requests curvature, and `.g2` requests an
+> order every constraint class rejects, which fails the whole `build()` rather than just that
+> one constraint. Tracked as issue #433.
 
 ---
 
@@ -437,12 +442,12 @@ Add a boundary edge constraint.
 
 ```swift
 @discardableResult
-public func add(edge: Edge, continuity: FillingContinuity = .c0) -> Bool
+public func add(edge: Edge, continuity: SurfaceContinuity = .g0) -> Bool
 ```
 
 - **Parameters:**
   - `edge` — edge to add as a boundary constraint.
-  - `continuity` — continuity order at this edge (default `.c0`).
+  - `continuity` — continuity order at this edge (default `.g0`).
 - **Returns:** `true` if the edge was added successfully.
 - **OCCT:** `BRepFill_Filling::Add` (boundary edge variant).
 - **Example:**
@@ -474,14 +479,14 @@ Add a free (non-boundary) edge constraint.
 
 ```swift
 @discardableResult
-public func add(freeEdge edge: Edge, continuity: FillingContinuity = .c0) -> Bool
+public func add(freeEdge edge: Edge, continuity: SurfaceContinuity = .g0) -> Bool
 ```
 
 Free edges are not required to be topologically connected to other boundary edges.
 
 - **Parameters:**
   - `freeEdge` — edge to add as a free constraint.
-  - `continuity` — continuity order (default `.c0`).
+  - `continuity` — continuity order (default `.g0`).
 - **Returns:** `true` if the edge was added successfully.
 - **OCCT:** `BRepFill_Filling::Add` (free edge variant).
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1472,29 +1472,30 @@ Returns the fixed result as a `Shape` (not `Face`) because the repair can restru
 
 ### `SurfaceContinuity`
 
-Continuity specification for surface filling operations.
+Geometric continuity order for a surface constraint. The single vocabulary behind every call
+that constrains a generated surface against a point, edge or wire: `Shape.fill(boundaries:)`,
+`Shape.fill(constraints:)`, `FillingSurface` and `Shape.plateSurface(through:orders:)`. All of
+them hand the raw value to OCCT as a plate constraint order, which `GeomPlate_CurveConstraint`
+validates directly and rejects outside `[-1, 2]`.
 
 ```swift
-public enum SurfaceContinuity: Int32 {
-    case c0 = 0   // positional — surfaces touch
-    case g1 = 1   // tangent — smooth transition
-    case g2 = 2   // curvature — very smooth
+public enum SurfaceContinuity: Int32, Sendable, CaseIterable {
+    case g0 = 0   // positional (G0): the surface passes through the constraint
+    case g1 = 1   // tangent (G1): the surface is tangent along the constraint
+    case g2 = 2   // curvature (G2): the surface matches curvature along the constraint
 }
 ```
 
----
+Not every API accepts every order. A bare point carries no curvature to match, so
+`GeomPlate_PointConstraint` throws above order 1 and `Shape.plateSurface(through:orders:)`
+returns `nil` if any point is given `.g2`. `FillingSurface` currently mis-maps both non-default
+orders; see issue #433.
 
-### `PlateConstraintOrder`
-
-Constraint order for plate surface construction (v0.23.0).
-
-```swift
-public enum PlateConstraintOrder: Int32 {
-    case g0 = 0   // position only
-    case g1 = 1   // position + tangent
-    case g2 = 2   // position + tangent + curvature
-}
-```
+> **Renamed in #398.** `PlateConstraintOrder` and `FillingContinuity` were separate copies of
+> this same vocabulary and are now deprecated typealiases of `SurfaceContinuity`. The `.c0`,
+> `.c1` and `.c2` spellings remain as deprecated aliases of `.g0`, `.g1` and `.g2`. No raw
+> value moved, so behaviour is unchanged. Not to be confused with `ParametricContinuity`
+> (C0/C1/C2/C3), which is a different contract: see `docs/reference/Shape-Healing.md`.
 
 ---
 
@@ -1753,7 +1754,7 @@ Creates a plate surface through points with per-point constraint orders.
 ```swift
 public static func plateSurface(
     through points: [SIMD3<Double>],
-    orders: [PlateConstraintOrder],
+    orders: [SurfaceContinuity],
     degree: Int = 3,
     pointsOnCurves: Int = 15,
     iterations: Int = 2,
@@ -1781,8 +1782,8 @@ Creates a plate surface with mixed point and curve constraints.
 
 ```swift
 public static func plateSurface(
-    pointConstraints points: [(point: SIMD3<Double>, order: PlateConstraintOrder)],
-    curveConstraints curves: [(wire: Wire, order: PlateConstraintOrder)],
+    pointConstraints points: [(point: SIMD3<Double>, order: SurfaceContinuity)],
+    curveConstraints curves: [(wire: Wire, order: SurfaceContinuity)],
     degree: Int = 3,
     tolerance: Double = 0.01
 ) -> Shape?

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1792,8 +1792,8 @@ public static func plateSurface(
 At least one of `points` or `curves` must be non-empty.
 
 - **Parameters:**
-  - `points` — point constraints, each with a position and a `PlateConstraintOrder`.
-  - `curves` — curve constraints, each with a `Wire` and a `PlateConstraintOrder`.
+  - `points` — point constraints, each with a position and a `SurfaceContinuity`.
+  - `curves` — curve constraints, each with a `Wire` and a `SurfaceContinuity`.
   - `degree` — maximum polynomial degree (default 3).
   - `tolerance` — approximation tolerance.
 - **Returns:** Face shape, or `nil` on failure.

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -1005,12 +1005,14 @@ public func biTgteBlend(edgeIndices: [Int], radius: Double, tolerance: Double = 
 
 ### `ApproxContinuity`
 
-Continuity level for BSpline approximation.
+> **Deprecated in #398.** `ApproxContinuity` was one of several copies of the same continuity-floor
+> vocabulary and is now a typealias of
+> [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity) (`.c0` ... `.c3`). No raw
+> value moved.
 
 ```swift
-public enum ApproxContinuity: Int32 {
-    case c0 = 0, c1 = 1, c2 = 2, c3 = 3
-}
+@available(*, deprecated, renamed: "ParametricContinuity")
+public typealias ApproxContinuity = ParametricContinuity
 ```
 
 ---
@@ -1035,7 +1037,7 @@ public struct ApproxCurveResult {
 Approximates a 3D curve as a BSpline with detailed result information.
 
 ```swift
-public func approxWithDetails(tolerance: Double, continuity: ApproxContinuity = .c2,
+public func approxWithDetails(tolerance: Double, continuity: ParametricContinuity = .c2,
                                maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult
 ```
 
@@ -1076,8 +1078,8 @@ public struct ApproxSurfaceResult {
 Approximates a surface as a BSpline with detailed result information.
 
 ```swift
-public func approxWithDetails(tolerance: Double, uContinuity: ApproxContinuity = .c1,
-                               vContinuity: ApproxContinuity = .c1,
+public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c1,
+                               vContinuity: ParametricContinuity = .c1,
                                maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult
 ```
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -19,7 +19,8 @@ This page covers geometry repair, shape upgrade, point classification, proximity
 
 Minimum parametric continuity to require of a piece of geometry. Shared by every operation
 that splits, approximates or simplifies against a continuity floor: `Shape.divided(at:)`,
-`Shape.bsplineRestriction(...)`, `Curve3D.approxWithDetails(...)` and
+`Shape.bsplineRestriction(...)`, `Curve3D.approxWithDetails(...)`,
+`Surface.approxWithDetails(tolerance:uContinuity:vContinuity:...)` and
 `Curve3D.continuityBreaks(minContinuity:)`. The raw value maps to `GeomAbs_C0` through
 `GeomAbs_C3`.
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -15,20 +15,35 @@ This page covers geometry repair, shape upgrade, point classification, proximity
 
 ## Advanced Healing
 
-### `GeometricContinuity`
+### `ParametricContinuity`
 
-Target continuity level for shape divide operations.
+Minimum parametric continuity to require of a piece of geometry. Shared by every operation
+that splits, approximates or simplifies against a continuity floor: `Shape.divided(at:)`,
+`Shape.bsplineRestriction(...)`, `Curve3D.approxWithDetails(...)` and
+`Curve3D.continuityBreaks(minContinuity:)`. The raw value maps to `GeomAbs_C0` through
+`GeomAbs_C3`.
 
 ```swift
-public enum GeometricContinuity: Int32, Sendable {
-    case c0 = 0
-    case c1 = 1
-    case c2 = 2
-    case c3 = 3
+public enum ParametricContinuity: Int32, Sendable, CaseIterable {
+    case c0 = 0   // positional
+    case c1 = 1   // first derivative
+    case c2 = 2   // second derivative
+    case c3 = 3   // third derivative
 }
 ```
 
-Pass to `divided(at:)` to split a shape at discontinuities of the specified geometric continuity.
+Pass to `divided(at:)` to split a shape wherever it drops below the specified continuity.
+
+> **Renamed in #398.** This type used to be called `GeometricContinuity`, which was a misnomer:
+> the value maps to `GeomAbs_C0...C3`, so it is *parametric* continuity (equal derivative
+> vectors), not the geometric G0/G1/G2 constraint order of
+> [`SurfaceContinuity`](Shape-Features.md#surfacecontinuity) (parallel tangent directions).
+> `GeometricContinuity`, `ApproxContinuity`, `Shape.BSplineContinuity` and
+> `Curve3D.ContinuityOrder` are now deprecated typealiases of it. No raw value moved.
+>
+> `Shape.ContinuityLevel` is deliberately **not** folded in: it is a strict superset used by
+> `dividedByContinuity(criterion:tolerance:)`, adding `cn`, `g1` and `g2` cases that the other
+> call sites cannot accept.
 
 ---
 
@@ -37,7 +52,7 @@ Pass to `divided(at:)` to split a shape at discontinuities of the specified geom
 Divide a shape at continuity discontinuities.
 
 ```swift
-public func divided(at continuity: GeometricContinuity) -> Shape?
+public func divided(at continuity: ParametricContinuity) -> Shape?
 ```
 
 Splits the shape wherever its underlying geometry drops below the requested continuity class.

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -2095,12 +2095,14 @@ Small solids are merged into their neighbors rather than removed.
 
 ### `BSplineContinuity`
 
-Continuity requirement for BSpline restriction.
+> **Deprecated in #398.** `BSplineContinuity` was one of several copies of the same continuity-floor
+> vocabulary and is now a typealias of
+> [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity) (`.c0` ... `.c3`). No raw
+> value moved.
 
 ```swift
-public enum BSplineContinuity: Int32, Sendable {
-    case c0 = 0, c1 = 1, c2 = 2, c3 = 3
-}
+@available(*, deprecated, renamed: "ParametricContinuity")
+public typealias BSplineContinuity = ParametricContinuity
 ```
 
 ---
@@ -2113,7 +2115,7 @@ Simplify BSpline surfaces and curves by restricting degree and segment count.
 public func bsplineRestriction(
     tol3d: Double = 0.01, tol2d: Double = 0.01,
     maxDegree: Int = 8, maxSegments: Int = 100,
-    continuity3d: BSplineContinuity = .c1, continuity2d: BSplineContinuity = .c1,
+    continuity3d: ParametricContinuity = .c1, continuity2d: ParametricContinuity = .c1,
     degreePriority: Bool = true, rational: Bool = false
 ) -> Shape?
 ```

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -1971,10 +1971,16 @@ Uses `ShapeUpgrade_ShapeDivideClosed` to split faces that wrap completely around
 Continuity level for shape division.
 
 ```swift
-public enum ContinuityLevel: Int32, Sendable {
+public enum ContinuityLevel: Int32, Sendable, CaseIterable {
     case c0 = 0, c1 = 1, c2 = 2, c3 = 3, cn = 4, g1 = 5, g2 = 6
 }
 ```
+
+> **Deliberately kept separate from
+> [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity)** (#398). This is a strict
+> superset: `cn`, `g1` and `g2` are accepted only by `dividedByContinuity(criterion:tolerance:)`.
+> Every other continuity-floor call site silently defaults an unrecognised value, so widening
+> them to this type would trade a compile error for a wrong answer.
 
 ---
 


### PR DESCRIPTION
Closes #398.

## The issue's premise needed correcting twice

#398 named four duplicated continuity enums and called one of them a live correctness bug. My
[earlier comment](https://github.com/SecondMouseAU/OCCTSwift/issues/398#issuecomment-5090129103) already
showed the "bug" was the correct value and the mapping the issue called "Correct." was the broken
one. Verifying the two mappings that comment flagged as unexamined turned up the rest: there are
**nine** of these enums, not four, and they express **three** contracts, not one.

| contract | what OCCT actually receives | enums that expressed it |
|---|---|---|
| geometric constraint order, `0/1/2 = G0/G1/G2` | a plate constraint order; `GeomPlate_CurveConstraint` rejects outside `[-1, 2]` with "The continuity is not G0 G1 or G2" | `SurfaceContinuity`, `PlateConstraintOrder`, `FillingContinuity` |
| required parametric continuity, `0…3 = C0…C3` | a `GeomAbs_Shape` continuity class, or a literal derivative-order integer | `GeometricContinuity`, `ApproxContinuity`, `Shape.BSplineContinuity`, `Curve3D.ContinuityOrder` |
| a `GeomAbs_Shape` ordinal reported back | nothing, it is a *result* | `Surface.Continuity` |

The names ran almost exactly backwards: the one enum actually called `GeometricContinuity` was the
parametric one, and the three that really are geometric were called something else. That is also
why a single shared enum would have been wrong. G1 asks only for parallel tangent directions, C1
asks for equal derivative vectors.

## What changed

New `Sources/OCCTSwift/Continuity.swift` holding two canonical types, both `Sendable` and
`CaseIterable` (the `Sendable` drift the issue flagged is gone with them):

```swift
public enum SurfaceContinuity: Int32, Sendable, CaseIterable { case g0 = 0, g1 = 1, g2 = 2 }
public enum ParametricContinuity: Int32, Sendable, CaseIterable { case c0 = 0, c1 = 1, c2 = 2, c3 = 3 }
```

`Surface.Continuity` is retained as a result type. `Shape.ContinuityLevel` is retained as a strict
superset: its `cn`/`g1`/`g2` cases are accepted only by `dividedByContinuity(criterion:tolerance:)`,
and folding it in would have offered those orders to call sites whose bridge silently defaults them.

**No raw value moved and no bridge code changed, so nothing behaves differently.** Every retired
name and spelling survives as a deprecated alias, `SurfaceContinuity.c0`/`.c1`/`.c2` included, so
existing source still compiles. One caveat worth stating: an *exhaustive* `switch` over one of
these now needs a `default`, because the old spellings are static properties rather than cases.

## Two live defects found while verifying, both left for their own issues

Measured with a ground-truth C++ probe against the pinned kernel, and now pinned by tests here:

- **`Shape.plateSurface(through:orders:)` can never accept `.g2`.** A bare point carries no
  curvature to match, so `GeomPlate_PointConstraint` throws above order 1 (`myOrder > 1` in the
  ctor; its header's "Raises ConstructionError if Order is not 0 or -1" is itself wrong, 1 is
  accepted). The throw fails the whole call, so one `.g2` in an otherwise valid order list returns
  `nil`. Same shape as #433, and like #433 the fix changes documented public behaviour, so it is
  filed separately rather than smuggled in here.
- **`Curve3D.ContinuityOrder`'s cap at `.c2` made every order it offered a no-op.**
  `GeomConvert_BSplineCurveKnotSplitting` splits where `degree - multiplicity < ContinuityRange`,
  and a cubic interpolation is already C2 at its interior knots. Measured on a degree-3
  interpolated BSpline: ranges 0, 1 and 2 all return just the two end knots; range 3 returns five
  parameters. OCCT accepts any range `>= 0`. Sharing `ParametricContinuity` makes `.c3` reachable,
  so this one is fixed as a side effect.

## Re-enabled a suite disabled on an unevidenced claim

`AdvancedPlateSurfaceTests` has been `.disabled("Plate surface operations cause segfault in OCCT")`
since v0.23.0, which is why neither defect above was ever caught. A C++ replica of that exact
bridge path shows no segfault at orders 0 or 1, and the suite is **8/8 clean** over repeated runs.
Same outcome as the #341 re-enablement: the claim was never characterised and does not hold up.

## Verification

- `swift test`: **4453 tests in 1290 suites, 0 failures** (up from 4428: 8 re-enabled plate tests, 9 new).
- All test targets compile with **zero deprecation warnings**, so no in-repo call site was left on a retired spelling.
- 9 new tests pin the raw values of both enums and of `Surface.Continuity`, the deprecated spellings, and both defects above.

## Docs

`CHANGELOG.md`, plus the six reference pages that declared one of the retired enums
(`Shape-Features`, `GeometrySolvers`, `Shape-Healing`, `Shape-Measurement`, `Shape-HLR-Geom`,
`Curve3D-Analytic-Types`). `naming-conventions.md` used `GeometricContinuity.c0, .c1, .g1` as its
worked example, an enum/case combination that never existed.

Note: `refactor/377-segmented-audit` was a stale pointer at `main~1` with no commits of its own and
has been fast-forwarded to `main`, so this PR shows only its own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

