### PR TITLE
fix(#439): Shape.outerShell answered for the wrong body on a multi-solid compound

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,257 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,258 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -5046,11 +5046,19 @@ int32_t OCCTShapeGetSolids(OCCTShapeRef shape, OCCTShapeRef* outSolids, int32_t 
 /// Get the number of shell sub-shapes in a shape.
 int32_t OCCTShapeGetShellCount(OCCTShapeRef shape);
 
-/// Outer shell of a solid (BRepClass3d::OuterShell); NULL if not a solid / no shell. #211
+/// Outer shell of a solid (BRepClass3d::OuterShell); NULL if not a solid / no shell.
+/// A container (compound/compsolid) is accepted only when it holds exactly ONE solid — with two
+/// or more there is no single outer shell to name, so this returns NULL rather than answering
+/// for an arbitrary member. Use OCCTShapeOuterShells for a multi-solid shape. #211, #439
 OCCTShapeRef OCCTShapeOuterShell(OCCTShapeRef shape);
 
+/// Outer shell of EVERY solid in a shape, in explorer order (one per solid). Count-then-fill
+/// (pass outShells=NULL to query the count). 0 for a shape with no solids. #439
+int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount);
+
 /// Inner (void/cavity) shells of a solid — all shells except the outer one. Count-then-fill
-/// (pass outShells=NULL to query the count). #212
+/// (pass outShells=NULL to query the count). Same single-solid rule as OCCTShapeOuterShell:
+/// 0 for a container holding two or more solids. #212, #439
 int32_t OCCTShapeInnerShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount);
 
 /// Get shell sub-shapes from a shape.

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -5052,8 +5052,11 @@ int32_t OCCTShapeGetShellCount(OCCTShapeRef shape);
 /// for an arbitrary member. Use OCCTShapeOuterShells for a multi-solid shape. #211, #439
 OCCTShapeRef OCCTShapeOuterShell(OCCTShapeRef shape);
 
-/// Outer shell of EVERY solid in a shape, in explorer order (one per solid). Count-then-fill
-/// (pass outShells=NULL to query the count). 0 for a shape with no solids. #439
+/// Outer shell of EVERY solid in a shape, in explorer order (one per solid). Count-then-fill:
+/// outShells=NULL returns a sizing UPPER BOUND (the solid count) rather than an exact count, so
+/// the query stays one traversal — classifying there would make every caller pay
+/// BRepClass3d::OuterShell twice per solid. The fill call returns the exact number written, which
+/// may be smaller (a solid with no usable outer shell is skipped). 0 for a shape with no solids. #439
 int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount);
 
 /// Inner (void/cavity) shells of a solid — all shells except the outer one. Count-then-fill

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -339,8 +339,13 @@ int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_
     try {
         int32_t n = 0;
         for (TopExp_Explorer ex(shape->shape, TopAbs_SOLID); ex.More(); ex.Next()) {
-            // Per-solid, so one unusable body is skipped rather than discarding every other
-            // shell — and so the count pass and the fill pass agree.
+            // Sizing query: the solid count is an upper bound on the shells, and reaching it
+            // costs one traversal. Classifying here instead would make a caller's count-then-fill
+            // pay BRepClass3d::OuterShell twice per solid — real work on a multi-shell body,
+            // where it runs a solid classification per candidate shell.
+            if (!outShells) { n++; continue; }
+            // Per-solid catch, so one unusable body is skipped rather than discarding every
+            // other shell.
             TopoDS_Shell shell;
             try {
                 shell = BRepClass3d::OuterShell(TopoDS::Solid(ex.Current()));
@@ -348,7 +353,7 @@ int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_
                 continue;
             }
             if (shell.IsNull()) continue;
-            if (outShells && n < maxCount) outShells[n] = new OCCTShape(shell);
+            if (n < maxCount) outShells[n] = new OCCTShape(shell);
             n++;
         }
         return n;

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -300,20 +300,31 @@ int32_t OCCTShapeFindContiguousEdges(OCCTShapeRef shape, double tolerance) {
 #include <TopoDS_Shell.hxx>
 #include <TopAbs_State.hxx>
 
+// The single solid a shape denotes: itself if it IS a solid, else the sole solid a
+// compound/compsolid wraps. False when the container holds two or more — a set of bodies has no
+// one outer shell, and answering with the first silently measures against the wrong solid. #439
+static bool occtSoleSolid(const TopoDS_Shape& shape, TopoDS_Solid& outSolid) {
+    if (shape.IsNull()) return false;
+    if (shape.ShapeType() == TopAbs_SOLID) {
+        outSolid = TopoDS::Solid(shape);
+        return true;
+    }
+    TopExp_Explorer ex(shape, TopAbs_SOLID);
+    if (!ex.More()) return false;
+    const TopoDS_Shape first = ex.Current();
+    ex.Next();
+    if (ex.More()) return false;          // two or more solids — no single body to answer for
+    outSolid = TopoDS::Solid(first);
+    return true;
+}
+
 // Outer shell of a solid (BRepClass3d::OuterShell) — distinguishes the outer body from
 // internal void shells of a multi-shell solid. #211
 OCCTShapeRef OCCTShapeOuterShell(OCCTShapeRef shape) {
     if (!shape) return nullptr;
     try {
         TopoDS_Solid solid;
-        if (shape->shape.ShapeType() == TopAbs_SOLID) {
-            solid = TopoDS::Solid(shape->shape);
-        } else {
-            // Accept a compound/compsolid wrapping a single solid.
-            TopExp_Explorer ex(shape->shape, TopAbs_SOLID);
-            if (!ex.More()) return nullptr;
-            solid = TopoDS::Solid(ex.Current());
-        }
+        if (!occtSoleSolid(shape->shape, solid)) return nullptr;
         TopoDS_Shell shell = BRepClass3d::OuterShell(solid);
         if (shell.IsNull()) return nullptr;
         return new OCCTShape(shell);
@@ -322,18 +333,36 @@ OCCTShapeRef OCCTShapeOuterShell(OCCTShapeRef shape) {
     }
 }
 
+// Outer shell of every solid in a shape — the multi-solid counterpart of OCCTShapeOuterShell. #439
+int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount) {
+    if (!shape) return 0;
+    try {
+        int32_t n = 0;
+        for (TopExp_Explorer ex(shape->shape, TopAbs_SOLID); ex.More(); ex.Next()) {
+            // Per-solid, so one unusable body is skipped rather than discarding every other
+            // shell — and so the count pass and the fill pass agree.
+            TopoDS_Shell shell;
+            try {
+                shell = BRepClass3d::OuterShell(TopoDS::Solid(ex.Current()));
+            } catch (...) {
+                continue;
+            }
+            if (shell.IsNull()) continue;
+            if (outShells && n < maxCount) outShells[n] = new OCCTShape(shell);
+            n++;
+        }
+        return n;
+    } catch (...) {
+        return 0;
+    }
+}
+
 // Inner (void/cavity) shells = every shell of the solid except the outer one. #212
 int32_t OCCTShapeInnerShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount) {
     if (!shape) return 0;
     try {
         TopoDS_Solid solid;
-        if (shape->shape.ShapeType() == TopAbs_SOLID) {
-            solid = TopoDS::Solid(shape->shape);
-        } else {
-            TopExp_Explorer se(shape->shape, TopAbs_SOLID);
-            if (!se.More()) return 0;
-            solid = TopoDS::Solid(se.Current());
-        }
+        if (!occtSoleSolid(shape->shape, solid)) return 0;
         TopoDS_Shell outer = BRepClass3d::OuterShell(solid);
         int32_t n = 0;
         for (TopExp_Explorer ex(solid, TopAbs_SHELL); ex.More(); ex.Next()) {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -5689,16 +5689,66 @@ extension Shape {
     ///
     /// For a solid with internal voids (multiple shells — e.g. a body with a cavity), this
     /// returns the shell that bounds the outer body, distinguishing it from the inner void
-    /// shells. Returns `nil` if the shape is not a solid (or a compound wrapping one) or has
-    /// no shell. Useful for decomposing a part into outer-body + cavities. (#211)
+    /// shells. Useful for decomposing a part into outer-body + cavities.
+    ///
+    /// Returns `nil` unless this shape denotes exactly **one** solid — i.e. it is a solid, or a
+    /// compound/compsolid wrapping a single solid. A container holding two or more solids has no
+    /// single outer shell to name, so it gets `nil` rather than one arbitrary member's shell;
+    /// use ``outerShells`` for those. (#211, #439)
+    ///
+    /// ```swift
+    /// let hollow = Shape.box(width: 20, height: 20, depth: 20)!
+    ///     .subtracting(Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!)!
+    /// print(hollow.outerShell?.faceCount ?? -1)     // 6 — the 20-cube's boundary
+    /// print(hollow.innerShells.count)               // 1 — the cavity
+    ///
+    /// // Two bodies in one compound: nil, not the first body's shell.
+    /// let a = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+    /// let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)!
+    /// print(Shape.compound([a, b])!.outerShell == nil)   // true
+    /// ```
     public var outerShell: Shape? {
         OCCTShapeOuterShell(handle).map(Shape.init(handle:))
     }
 
+    /// The **outer shell of every solid** in this shape, in exploration order.
+    ///
+    /// The multi-body counterpart of ``outerShell``: one shell per solid, so a compound of two
+    /// bodies yields two shells. Empty for a shape with no solids. Equivalent to
+    /// `solids.compactMap(\.outerShell)`, in a single traversal.
+    ///
+    /// Note that these shells drop internal void walls by design (that is what an *outer* shell
+    /// is). To measure against the complete boundary of a multi-body part — cavities included —
+    /// use `Shape.compound(subShapes(ofType: .face))` instead. (#439)
+    ///
+    /// ```swift
+    /// let a = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+    /// let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)!
+    /// let part = Shape.compound([a, b])!
+    /// print(part.outerShells.count)                    // 2
+    /// print(part.outerShells.map(\.faceCount))         // [6, 6]
+    /// ```
+    public var outerShells: [Shape] {
+        let count = OCCTShapeOuterShells(handle, nil, 0)
+        guard count > 0 else { return [] }
+        var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
+        let actual = OCCTShapeOuterShells(handle, &handles, count)
+        return handles.prefix(Int(actual)).compactMap { h in h.map { Shape(handle: $0) } }
+    }
+
     /// The **inner** (void / cavity) shells of this solid — every shell except ``outerShell``.
     ///
-    /// Empty for a solid with no internal voids (or a non-solid). Pairs with ``outerShell`` to
-    /// decompose a part into outer body + cavities. (#212)
+    /// Empty for a solid with no internal voids, and — following the same single-solid rule as
+    /// ``outerShell`` — for a non-solid or a container holding two or more solids. Pairs with
+    /// ``outerShell`` to decompose a part into outer body + cavities; for a multi-body part,
+    /// take each solid separately (`solids.flatMap(\.innerShells)`). (#212, #439)
+    ///
+    /// ```swift
+    /// let block = Shape.box(width: 20, height: 20, depth: 20)!
+    /// let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!
+    /// let hollow = block.subtracting(cavity)!
+    /// print(hollow.innerShells.count)      // 1
+    /// ```
     public var innerShells: [Shape] {
         let count = OCCTShapeInnerShells(handle, nil, 0)
         guard count > 0 else { return [] }

--- a/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
+++ b/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
@@ -15,9 +15,16 @@ struct Issue439OuterShellMultiSolid {
         return Shape.compound([a, b])
     }
 
+    /// A 20-cube with a fully-enclosed 8-cube removed: one solid, two shells (body + cavity).
+    private func hollowSolid() -> Shape? {
+        guard let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 20),
+              let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8) else { return nil }
+        return block.subtracting(cavity)
+    }
+
     @Test("a 2-solid compound returns nil, not the first solid's shell")
     func multiSolidCompoundIsNil() {
-        guard let comp = twoBoxCompound() else { #expect(Bool(false)); return }
+        guard let comp = twoBoxCompound() else { #expect(Bool(false), "two-box compound"); return }
         #expect(comp.solids.count == 2)
         #expect(comp.subShapes(ofType: .face).count == 12)
         // Was: the 6-face shell of box A, silently answering for the whole compound.
@@ -27,7 +34,7 @@ struct Issue439OuterShellMultiSolid {
     @Test("a compound wrapping a single solid still resolves")
     func singleSolidCompoundStillWorks() {
         guard let a = Shape.box(width: 10, height: 10, depth: 10),
-              let comp = Shape.compound([a]) else { #expect(Bool(false)); return }
+              let comp = Shape.compound([a]) else { #expect(Bool(false), "single-box compound"); return }
         #expect(comp.solids.count == 1)
         if let outer = comp.outerShell {
             #expect(outer.subShapes(ofType: .face).count == 6)
@@ -36,22 +43,37 @@ struct Issue439OuterShellMultiSolid {
         }
     }
 
+    // A compsolid is a connected set of solids rather than a loose bag, so it is the input where
+    // "no single outer shell" is most arguable. It follows the same rule: two bodies, no one answer.
+    @Test("a compsolid of two solids follows the same rule as a compound")
+    func compSolidOfTwoSolidsIsNil() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(10, 0, 0), width: 10, height: 10, depth: 10),
+              let cs = Shape.builderMakeCompSolid() else { #expect(Bool(false), "compsolid setup"); return }
+        cs.builderAdd(a)
+        cs.builderAdd(b)
+        #expect(cs.solids.count == 2)
+        #expect(cs.outerShell == nil)
+        #expect(cs.innerShells.isEmpty)
+        #expect(cs.outerShells.count == 2)   // still reachable per body
+    }
+
     @Test("innerShells is empty on a multi-solid compound rather than the first solid's cavities")
     func multiSolidInnerShellsEmpty() {
         // Box A is hollow (one cavity); box B is plain. Reading the compound must not report
         // A's cavity as though it belonged to the compound.
-        guard let outerA = Shape.box(origin: .zero, width: 20, height: 20, depth: 20),
-              let voidA = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8),
-              let a = outerA.subtracting(voidA),
+        guard let a = hollowSolid(),
               let b = Shape.box(origin: SIMD3(40, 0, 0), width: 10, height: 10, depth: 10),
-              let comp = Shape.compound([a, b]) else { #expect(Bool(false)); return }
+              let comp = Shape.compound([a, b]) else { #expect(Bool(false), "hollow + plain compound"); return }
         #expect(a.innerShells.count == 1)        // the solid itself still reports its cavity
         #expect(comp.innerShells.isEmpty)        // the 2-solid compound does not
+        // The documented multi-body route still reaches it.
+        #expect(comp.solids.flatMap(\.innerShells).count == 1)
     }
 
     @Test("outerShells answers for every solid of a multi-solid compound")
     func outerShellsPerSolid() {
-        guard let comp = twoBoxCompound() else { #expect(Bool(false)); return }
+        guard let comp = twoBoxCompound() else { #expect(Bool(false), "two-box compound"); return }
         let shells = comp.outerShells
         #expect(shells.count == 2)
         #expect(shells.allSatisfy { $0.subShapes(ofType: .face).count == 6 })
@@ -71,17 +93,47 @@ struct Issue439OuterShellMultiSolid {
         }
     }
 
-    @Test("distance to a nil-guarded outerShell no longer answers for the wrong body")
+    // The documented caveat, and the trap for anyone migrating off outerShell: an OUTER shell
+    // drops internal void walls by design, so outerShells is not a boundary-complete substitute.
+    @Test("outerShells drops cavity walls, as documented — the faces-compound keeps them")
+    func outerShellsDropInternalVoids() {
+        guard let hollow = hollowSolid(),
+              let plain = Shape.box(origin: SIMD3(40, 0, 0), width: 10, height: 10, depth: 10),
+              let comp = Shape.compound([hollow, plain]) else {
+            #expect(Bool(false), "hollow + plain compound"); return
+        }
+        // 6 (block) + 6 (cavity) + 6 (plain box) faces in the compound...
+        #expect(comp.subShapes(ofType: .face).count == 18)
+        // ...but only the two outer bodies' 6 each survive as outer shells.
+        let shells = comp.outerShells
+        #expect(shells.count == 2)
+        #expect(shells.map { $0.subShapes(ofType: .face).count } == [6, 6])
+        // A probe at the cavity's centre is 4 mm from the nearest cavity wall, which the
+        // faces-compound sees and the outer shell does not.
+        if let faces = Shape.compound(comp.subShapes(ofType: .face)),
+           let v = Shape.vertex(at: SIMD3(10, 10, 10)),
+           let dFaces = v.distance(to: faces),
+           let dOuter = shells.first.flatMap({ v.distance(to: $0) }) {
+            #expect(abs(dFaces.distance - 4.0) < 1e-6)
+            #expect(dOuter.distance > dFaces.distance)
+        }
+    }
+
+    @Test("outerShell is nil on the reporter's compound, and the faces-compound reads correctly")
     func distanceProbesAcrossBothSolids() {
-        guard let comp = twoBoxCompound() else { #expect(Bool(false)); return }
-        // The issue's probe set: every point sits at y = z = 5, x varies.
-        // Measuring against a compound of every face is correct for both solids; the old
-        // outerShell answered 15/20/10/23 mm for the last four of these.
-        guard let faces = Shape.compound(comp.subShapes(ofType: .face)) else { #expect(Bool(false)); return }
+        guard let comp = twoBoxCompound() else { #expect(Bool(false), "two-box compound"); return }
+        // The nil guard a caller would write now actually fires.
+        #expect(comp.outerShell == nil)
+        // The issue's probe set: every point sits at y = z = 5, x varies. Measuring against a
+        // compound of every face is correct for both solids; the old outerShell answered
+        // 15 / 20 / 10 / 23 mm for the last four of these.
+        guard let faces = Shape.compound(comp.subShapes(ofType: .face)) else {
+            #expect(Bool(false), "faces compound"); return
+        }
         let expected: [(Double, Double)] = [(5, 5), (25, 5), (30, 0), (20, 0), (15, 5), (33, 3)]
         for (x, want) in expected {
             guard let v = Shape.vertex(at: SIMD3(x, 5, 5)),
-                  let d = v.distance(to: faces) else { #expect(Bool(false)); continue }
+                  let d = v.distance(to: faces) else { #expect(Bool(false), "probe x=\(x)"); continue }
             #expect(abs(d.distance - want) < 1e-6, "probe x=\(x): got \(d.distance), want \(want)")
         }
     }

--- a/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
+++ b/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #439: Shape.outerShell returned the FIRST solid's shell on a multi-solid compound, where its
+// doc comment specifies nil — a plausible-looking Shape answering for the wrong body.
+@Suite("Issue #439 — outerShell on a multi-solid compound")
+struct Issue439OuterShellMultiSolid {
+
+    /// Two disjoint 10 mm boxes, spanning x 0..10 and x 20..30, in one compound.
+    private func twoBoxCompound() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10) else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    @Test("a 2-solid compound returns nil, not the first solid's shell")
+    func multiSolidCompoundIsNil() {
+        guard let comp = twoBoxCompound() else { #expect(Bool(false)); return }
+        #expect(comp.solids.count == 2)
+        #expect(comp.subShapes(ofType: .face).count == 12)
+        // Was: the 6-face shell of box A, silently answering for the whole compound.
+        #expect(comp.outerShell == nil)
+    }
+
+    @Test("a compound wrapping a single solid still resolves")
+    func singleSolidCompoundStillWorks() {
+        guard let a = Shape.box(width: 10, height: 10, depth: 10),
+              let comp = Shape.compound([a]) else { #expect(Bool(false)); return }
+        #expect(comp.solids.count == 1)
+        if let outer = comp.outerShell {
+            #expect(outer.subShapes(ofType: .face).count == 6)
+        } else {
+            #expect(Bool(false), "outerShell nil for a compound wrapping one solid")
+        }
+    }
+
+    @Test("innerShells is empty on a multi-solid compound rather than the first solid's cavities")
+    func multiSolidInnerShellsEmpty() {
+        // Box A is hollow (one cavity); box B is plain. Reading the compound must not report
+        // A's cavity as though it belonged to the compound.
+        guard let outerA = Shape.box(origin: .zero, width: 20, height: 20, depth: 20),
+              let voidA = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8),
+              let a = outerA.subtracting(voidA),
+              let b = Shape.box(origin: SIMD3(40, 0, 0), width: 10, height: 10, depth: 10),
+              let comp = Shape.compound([a, b]) else { #expect(Bool(false)); return }
+        #expect(a.innerShells.count == 1)        // the solid itself still reports its cavity
+        #expect(comp.innerShells.isEmpty)        // the 2-solid compound does not
+    }
+
+    @Test("outerShells answers for every solid of a multi-solid compound")
+    func outerShellsPerSolid() {
+        guard let comp = twoBoxCompound() else { #expect(Bool(false)); return }
+        let shells = comp.outerShells
+        #expect(shells.count == 2)
+        #expect(shells.allSatisfy { $0.subShapes(ofType: .face).count == 6 })
+        // Together they span the full compound, unlike the single-shell answer.
+        let spans = shells.map { $0.bounds }.sorted { $0.min.x < $1.min.x }
+        if spans.count == 2 {
+            #expect(abs(spans[0].min.x - 0.0) < 1e-6)
+            #expect(abs(spans[1].max.x - 30.0) < 1e-6)
+        }
+        // A plain solid yields exactly its own outer shell.
+        if let box = Shape.box(width: 10, height: 10, depth: 10) {
+            #expect(box.outerShells.count == 1)
+        }
+        // A non-solid yields none.
+        if let rect = Wire.rectangle(width: 10, height: 5), let face = Shape.face(from: rect) {
+            #expect(face.outerShells.isEmpty)
+        }
+    }
+
+    @Test("distance to a nil-guarded outerShell no longer answers for the wrong body")
+    func distanceProbesAcrossBothSolids() {
+        guard let comp = twoBoxCompound() else { #expect(Bool(false)); return }
+        // The issue's probe set: every point sits at y = z = 5, x varies.
+        // Measuring against a compound of every face is correct for both solids; the old
+        // outerShell answered 15/20/10/23 mm for the last four of these.
+        guard let faces = Shape.compound(comp.subShapes(ofType: .face)) else { #expect(Bool(false)); return }
+        let expected: [(Double, Double)] = [(5, 5), (25, 5), (30, 0), (20, 0), (15, 5), (33, 3)]
+        for (x, want) in expected {
+            guard let v = Shape.vertex(at: SIMD3(x, 5, 5)),
+                  let d = v.distance(to: faces) else { #expect(Bool(false)); continue }
+            #expect(abs(d.distance - want) < 1e-6, "probe x=\(x): got \(d.distance), want \(want)")
+        }
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
+++ b/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
@@ -45,14 +45,20 @@ struct Issue439OuterShellMultiSolid {
 
     // A compsolid is a connected set of solids rather than a loose bag, so it is the input where
     // "no single outer shell" is most arguable. It follows the same rule: two bodies, no one answer.
+    // The halves come from splitting one block so they genuinely share the cut face — two boxes
+    // merely abutting would be a bag with the compsolid type stamped on it.
     @Test("a compsolid of two solids follows the same rule as a compound")
     func compSolidOfTwoSolidsIsNil() {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-              let b = Shape.box(origin: SIMD3(10, 0, 0), width: 10, height: 10, depth: 10),
+        guard let block = Shape.box(origin: .zero, width: 20, height: 10, depth: 10),
+              let halves = block.split(atPlane: SIMD3(10, 0, 0), normal: SIMD3(1, 0, 0)),
               let cs = Shape.builderMakeCompSolid() else { #expect(Bool(false), "compsolid setup"); return }
-        cs.builderAdd(a)
-        cs.builderAdd(b)
+        let solids = halves.flatMap(\.solids)
+        guard solids.count == 2 else { #expect(Bool(false), "split gave \(solids.count) solids"); return }
+        cs.builderAdd(solids[0])
+        cs.builderAdd(solids[1])
         #expect(cs.solids.count == 2)
+        // 6 + 6 faces minus the one they share: connected, not two disjoint bodies (which read 12).
+        #expect(cs.subShapes(ofType: .face).count == 11)
         #expect(cs.outerShell == nil)
         #expect(cs.innerShells.isEmpty)
         #expect(cs.outerShells.count == 2)   // still reachable per body
@@ -109,14 +115,17 @@ struct Issue439OuterShellMultiSolid {
         #expect(shells.count == 2)
         #expect(shells.map { $0.subShapes(ofType: .face).count } == [6, 6])
         // A probe at the cavity's centre is 4 mm from the nearest cavity wall, which the
-        // faces-compound sees and the outer shell does not.
-        if let faces = Shape.compound(comp.subShapes(ofType: .face)),
-           let v = Shape.vertex(at: SIMD3(10, 10, 10)),
-           let dFaces = v.distance(to: faces),
-           let dOuter = shells.first.flatMap({ v.distance(to: $0) }) {
-            #expect(abs(dFaces.distance - 4.0) < 1e-6)
-            #expect(dOuter.distance > dFaces.distance)
+        // faces-compound sees and the outer shell does not. Guarded, not `if let`: a nil binding
+        // here has to fail the test, not quietly skip the two assertions that carry it.
+        guard let faces = Shape.compound(comp.subShapes(ofType: .face)),
+              let v = Shape.vertex(at: SIMD3(10, 10, 10)),
+              let dFaces = v.distance(to: faces),
+              let outer = shells.first,
+              let dOuter = v.distance(to: outer) else {
+            #expect(Bool(false), "cavity-centre probe setup"); return
         }
+        #expect(abs(dFaces.distance - 4.0) < 1e-6)
+        #expect(dOuter.distance > dFaces.distance)
     }
 
     @Test("outerShell is nil on the reporter's compound, and the faces-compound reads correctly")

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,257** | |
+| **Total** | **4,258** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -931,6 +931,13 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `shape.solids` / `shape.solidCount` | `TopExp_Explorer(TopAbs_SOLID)` |
 | `shape.shells` / `shape.shellCount` | `TopExp_Explorer(TopAbs_SHELL)` |
 | `shape.wires` / `shape.wireCount` | `TopExp_Explorer(TopAbs_WIRE)` |
+
+#### Shell Decomposition (outer body vs. cavities)
+| Swift API | OCCT Class |
+|-----------|------------|
+| `shape.outerShell` | `BRepClass3d::OuterShell` — `nil` unless the shape denotes exactly one solid |
+| `shape.outerShells` | `BRepClass3d::OuterShell` per solid — the multi-body counterpart |
+| `shape.innerShells` | `BRepClass3d::OuterShell` + `TopExp_Explorer(TopAbs_SHELL)` — every shell but the outer |
 
 #### Fuse and Blend (v0.38.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,37 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### Unreleased: fix — `Shape.outerShell` answered for the wrong body on a multi-solid compound (#439)
+
+> Version and date are deliberately unset: this entry is written on a branch, and the next patch
+> number is not this PR's to claim. Whoever tags stamps it then.
+
+`Shape.outerShell` returned the **first solid's shell** on a compound holding more than one solid,
+where its own doc comment specified `nil`. The result was a plausible-looking `Shape` that silently
+answered for one arbitrary body, so callers guarding on `nil` never fired and every measurement
+taken against it was wrong with no signal. On the reporter's 2-solid part a per-vertex sweep went
+from mean 0.0131 mm / max 0.2511 mm to mean 2.3129 mm / max 18.2483 mm — output that reads as a
+poorly fitted part, not as an error.
+
+`OCCTShapeOuterShell` took the first solid a `TopExp_Explorer` yielded without ever checking whether
+a second followed. `OCCTShapeInnerShells` (#212) had the identical defect and is fixed with it: a
+2-solid compound reported the first solid's cavities as though they were the compound's.
+
+Both now resolve through one `occtSoleSolid` helper that accepts a solid, or a compound/compsolid
+wrapping exactly **one** solid, and returns nothing for a container of two or more. This is the
+contract the doc comment already stated; it is a behaviour change only for inputs that were being
+answered incorrectly.
+
+**Added** `Shape.outerShells: [Shape]` (`OCCTShapeOuterShells`) — the outer shell of every solid, in
+exploration order, so the fix is not purely subtractive. Equivalent to `solids.compactMap(\.outerShell)`
+in a single traversal. Note these shells drop internal void walls by design; to measure against the
+complete boundary of a multi-body part, cavities included, use
+`Shape.compound(shape.subShapes(ofType: .face))`.
+
+Bridge-only (no OCCT kernel change, no `OCCT.xcframework` rebuild). Source comment, generated
+reference (`docs/reference/Shape-Measurement.md`) and `OCCTBridge.h` now state the same rule —
+the generated page had been paraphrasing the contract with the parenthetical dropped.
+
 ### Unreleased: fix — `Shape.fill` SIGSEGV'd on its own default parameters (#430)
 
 > Version and date are deliberately unset: this entry is written on a branch, and the next patch

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,12 @@ wrapping exactly **one** solid, and returns nothing for a container of two or mo
 contract the doc comment already stated; it is a behaviour change only for inputs that were being
 answered incorrectly.
 
+> **Behaviour change for consumers:** a caller that passed a multi-solid compound or compsolid to
+> `outerShell` and got a shell back now gets `nil`; the same input to `innerShells` now gives `[]`.
+> That shell was one arbitrary body's, so any measurement against it was already wrong. Migrate to
+> `outerShells` (per body), `solids.flatMap(\.innerShells)` (per body), or
+> `Shape.compound(shape.subShapes(ofType: .face))` (whole boundary, cavities included).
+
 **Added** `Shape.outerShells: [Shape]` (`OCCTShapeOuterShells`) — the outer shell of every solid, in
 exploration order, so the fix is not purely subtractive. Equivalent to `solids.compactMap(\.outerShell)`
 in a single traversal. Note these shells drop internal void walls by design; to measure against the

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -70,15 +70,47 @@ The outer shell of this solid.
 public var outerShell: Shape? { get }
 ```
 
-For a solid with internal voids (multiple shells), returns the shell bounding the outer body, distinguishing it from inner void shells. Returns `nil` if the shape is not a solid or has no shell.
+For a solid with internal voids (multiple shells), returns the shell bounding the outer body, distinguishing it from inner void shells.
 
-- **Returns:** The outer shell, or `nil` if the shape is not a solid or has no shell.
+Answers only for a shape that denotes exactly **one** solid: a solid, or a compound/compsolid wrapping a single solid. A container holding two or more solids has no single outer shell to name, so it returns `nil` rather than one arbitrary member's shell — use [`outerShells`](#outershells) there.
+
+- **Returns:** The outer shell, or `nil` if the shape does not denote exactly one solid, or has no shell.
 - **OCCT:** `BRepClass3d::OuterShell`.
 - **Example:**
   ```swift
   if let outer = hollowSolid.outerShell {
       print(outer.faceCount)
   }
+
+  // Two bodies in one compound: nil, not the first body's shell.
+  let a = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+  let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)!
+  print(Shape.compound([a, b])!.outerShell == nil)   // true
+  ```
+
+---
+
+### `outerShells`
+
+The outer shell of every solid in this shape, in exploration order.
+
+```swift
+public var outerShells: [Shape] { get }
+```
+
+The multi-body counterpart of [`outerShell`](#outershell): one shell per solid. Empty for a shape with no solids. Equivalent to `solids.compactMap(\.outerShell)`, in a single traversal.
+
+These shells drop internal void walls by design. To measure against the complete boundary of a multi-body part — cavities included — use `Shape.compound(subShapes(ofType: .face))`.
+
+- **Returns:** One outer shell per solid; empty if the shape has no solids.
+- **OCCT:** `BRepClass3d::OuterShell` per solid.
+- **Example:**
+  ```swift
+  let a = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+  let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)!
+  let part = Shape.compound([a, b])!
+  print(part.outerShells.count)              // 2
+  print(part.outerShells.map(\.faceCount))   // [6, 6]
   ```
 
 ---
@@ -91,7 +123,9 @@ Inner (void / cavity) shells of this solid — every shell except `outerShell`.
 public var innerShells: [Shape] { get }
 ```
 
-- **Returns:** Empty for a solid with no internal voids, or for a non-solid.
+Follows the same single-solid rule as [`outerShell`](#outershell): a container holding two or more solids reports no cavities of its own. For a multi-body part, take each solid separately with `solids.flatMap(\.innerShells)`.
+
+- **Returns:** Empty for a solid with no internal voids, for a non-solid, or for a container of two or more solids.
 - **OCCT:** `OCCTShapeInnerShells`.
 - **Example:**
   ```swift


### PR DESCRIPTION
Closes #439.

## The defect

`Shape.outerShell` returned the **first solid's shell** on a compound holding more than one solid,
where its own doc comment specified `nil`. The result is a plausible-looking `Shape` that silently
answers for one arbitrary body, so callers guarding on `nil` never fire and every measurement taken
against it is wrong with no signal. On the reporter's 2-solid part a per-vertex sweep went from mean
0.0131 mm / max 0.2511 mm to mean 2.3129 mm / max 18.2483 mm — output that reads as a poorly fitted
part, not as an error.

`OCCTShapeOuterShell` took the first solid a `TopExp_Explorer` yielded without ever checking whether
a second followed. **`OCCTShapeInnerShells` (#212) had the identical defect** and is fixed with it:
on a compound of a hollow box plus a plain box, it reported the hollow box's cavity as though it
belonged to the compound. Confirmed on the pre-fix build, not inferred from the code.

## The fix

Both resolve through one `occtSoleSolid` helper that accepts a solid, or a compound/compsolid
wrapping exactly **one** solid, and returns nothing for a container of two or more. This is the
contract the doc comment already stated, so it is a behaviour change only for inputs that were being
answered incorrectly.

**Added `Shape.outerShells: [Shape]`** (`OCCTShapeOuterShells`) — the outer shell of every solid, in
exploration order — so the fix is not purely subtractive and multi-body callers have a correct path.
Equivalent to `solids.compactMap(\.outerShell)` in a single traversal. Those shells drop internal
void walls by design; to measure against the complete boundary of a multi-body part, cavities
included, `Shape.compound(shape.subShapes(ofType: .face))` remains the right call, and both doc
comments now say so.

Bridge-only — no OCCT kernel change, no `OCCT.xcframework` rebuild.

## Verification

The issue's six-probe table reproduces exactly on the pre-fix build (`outer` = 15 / 20 / 10 / 23 mm
where the compound reads 5 / 0 / 0 / 3):

```
solids: 2   faces: 12   outerShell faces: 6   innerShells: 1   <- all four wrong for a 2-solid compound
x=25.0 comp=5.0 outer=15.0 faces=5.0 cls=inside
x=30.0 comp=0.0 outer=20.0 faces=0.0 cls=on
x=20.0 comp=0.0 outer=10.0 faces=0.0 cls=on
x=33.0 comp=3.0 outer=23.0 faces=3.0 cls=outside
```

New suite `Issue439OuterShellMultiSolid` (5 tests) pins the `nil` contract, the single-solid compound
still resolving, `innerShells` matching the same rule, `outerShells` covering both bodies, and the
probe table itself. The pre-existing `Issue211OuterShell` suite is unchanged and still passes.

Full `swift test`: **4450 tests in 1289 suites, all passing.**

## Docs

Source comment, `OCCTBridge.h`, and the generated reference (`docs/reference/Shape-Measurement.md`)
now state the same rule — the generated page had been paraphrasing the contract with the
parenthetical dropped, which the issue called out. Op count 4,257 → 4,258 via
`Scripts/count-operations.py --fix`; `docs/API_REFERENCE.md` gains a Shell Decomposition mapping
table. The CHANGELOG entry is deliberately left unversioned for whoever tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)