### PR TITLE
fix(#442): fixSolid()/solidFromShellFixed() healed only the first body of a multi-solid shape

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -12186,10 +12186,14 @@ bool OCCTDocumentHasRelation(OCCTDocumentRef _Nonnull document, int tag);
 
 // MARK: - ShapeFix_Solid
 
-/// Fix a solid shape (topology and orientation). Returns fixed shape or NULL.
+/// Fix a solid shape (topology and orientation). Heals EVERY solid in the input, not
+/// just the first (#442): a single body comes back as a solid, several as a compound.
+/// Returns fixed shape or NULL when the input holds no solid.
 OCCTShapeRef _Nullable OCCTShapeFixSolid(OCCTShapeRef _Nonnull shape);
 
-/// Create a solid from a shell using ShapeFix_Solid
+/// Create a solid from a shell using ShapeFix_Solid. One solid per body-bounding shell
+/// (#442) — each solid's outer shell plus every free shell; a solid's cavity shells are
+/// skipped. A single body comes back as a solid, several as a compound.
 OCCTShapeRef _Nullable OCCTShapeSolidFromShell(OCCTShapeRef _Nonnull shellShape);
 
 // MARK: - ShapeFix_EdgeConnect

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -12187,13 +12187,16 @@ bool OCCTDocumentHasRelation(OCCTDocumentRef _Nonnull document, int tag);
 // MARK: - ShapeFix_Solid
 
 /// Fix a solid shape (topology and orientation). Heals EVERY solid in the input, not
-/// just the first (#442): a single body comes back as a solid, several as a compound.
-/// Returns fixed shape or NULL when the input holds no solid.
+/// just the first (#442): a single body comes back as a solid, several as a compound of
+/// one result per input body. No body is ever dropped, so a result is not always a solid
+/// — ShapeFix_Solid returns a SHELL it could not close, and a solid it fails to heal
+/// comes back unhealed. Returns NULL only when the input holds no solid.
 OCCTShapeRef _Nullable OCCTShapeFixSolid(OCCTShapeRef _Nonnull shape);
 
 /// Create a solid from a shell using ShapeFix_Solid. One solid per body-bounding shell
-/// (#442) — each solid's outer shell plus every free shell; a solid's cavity shells are
-/// skipped. A single body comes back as a solid, several as a compound.
+/// (#442) — within each solid, every shell an even number of the others enclose, plus
+/// every free shell; a solid's cavity shells are skipped. A single body comes back as a
+/// solid, several as a compound.
 OCCTShapeRef _Nullable OCCTShapeSolidFromShell(OCCTShapeRef _Nonnull shellShape);
 
 // MARK: - ShapeFix_EdgeConnect

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3251,6 +3251,21 @@ static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shap
         // a body nested inside another body's cavity correctly: enclosed twice, so even.
         std::vector<int> enclosedBy(shells.size(), 0);
         for (size_t i = 0; i < shells.size(); i++) {
+            // An open shell cannot enclose anything, and every shell is a reference under
+            // parity, so letting one classify would add a spurious ±1 to the others and
+            // flip their verdicts. Measured on {A_outer, A_cavity, openShell wrapping both}:
+            // without this the outer shell is DROPPED (count 1) and the cavity emitted as a
+            // body. BRep_Tool::IsClosed on a shell is a real edge-pairing check rather than
+            // the Closed() flag, so a genuine cavity shell still qualifies as a reference.
+            // Open shells reach here routinely — this function accepts them by contract.
+            //
+            // Deliberate trade-off, do not "fix" a double-count back out of this: on a body
+            // whose OUTER shell is the open one, the cavity becomes the only eligible
+            // reference, both end even, and the cavity is emitted as a positive body. Input
+            // that broken has no right answer, and an extra body beats a dropped one for a
+            // call whose whole contract is that bodies do not vanish silently.
+            if (!BRep_Tool::IsClosed(shells[i])) continue;
+
             // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
             // that call does sh.Free(true), a TShape-level write to state shared with the
             // caller's shape, and nothing here needs the reorientation it pays that for.

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3155,15 +3155,45 @@ OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, d
 // MARK: - ShapeFix_Solid
 
 #include <ShapeFix_Solid.hxx>
+#include <BRepClass3d.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
+#include <Precision.hxx>
 
+// Assemble one result shape from healed bodies: the body itself when there is exactly
+// one, a compound when there are several. ShapeFix_Solid::Shape() already returns a
+// compound for a multiconnex input, so a compound result is nothing new for callers.
+static TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies) {
+    if (bodies.empty()) return TopoDS_Shape();
+    if (bodies.size() == 1) return bodies[0];
+    TopoDS_Compound compound;
+    BRep_Builder builder;
+    builder.MakeCompound(compound);
+    for (const TopoDS_Shape& body : bodies) builder.Add(compound, body);
+    return compound;
+}
+
+// Heal EVERY solid, not just the first one an explorer yields (#442). ShapeFix_Solid
+// cannot take a compound — Init/the constructor want a TopoDS_Solid, and TopoDS::Solid
+// throws on anything else — so multi-body input has to be driven one solid at a time.
 OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape) {
+    if (!shape) return nullptr;
     try {
-        TopExp_Explorer exp(shape->shape, TopAbs_SOLID);
-        if (!exp.More()) return nullptr;
-        TopoDS_Solid solid = TopoDS::Solid(exp.Current());
-        ShapeFix_Solid fixer(solid);
-        fixer.Perform();
-        TopoDS_Shape result = fixer.Shape();
+        std::vector<TopoDS_Shape> fixed;
+        for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More(); exp.Next()) {
+            ShapeFix_Solid fixer(TopoDS::Solid(exp.Current()));
+            fixer.Perform();
+            TopoDS_Shape result = fixer.Shape();
+            if (result.IsNull()) continue;
+            // Flatten: Shape() hands back a compound when one solid's shells resolve
+            // into several, and nesting those would hide bodies a level down.
+            if (result.ShapeType() == TopAbs_COMPOUND || result.ShapeType() == TopAbs_COMPSOLID) {
+                for (TopExp_Explorer se(result, TopAbs_SOLID); se.More(); se.Next())
+                    fixed.push_back(se.Current());
+            } else {
+                fixed.push_back(result);
+            }
+        }
+        TopoDS_Shape result = occtSolidBodiesToShape(fixed);
         if (result.IsNull()) return nullptr;
         auto* ref = new OCCTShape();
         ref->shape = result;
@@ -3171,13 +3201,65 @@ OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape) {
     } catch (...) { return nullptr; }
 }
 
+// Is `shell` enclosed by `reference` — i.e. a cavity rather than a body of its own?
+static bool occtShellIsInsideSolid(const TopoDS_Shell& shell, const TopoDS_Solid& reference) {
+    TopExp_Explorer ve(shell, TopAbs_VERTEX);
+    if (!ve.More()) return false;
+    gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(ve.Current()));
+    BRepClass3d_SolidClassifier classifier(reference);
+    classifier.Perform(p, Precision::Confusion());
+    return classifier.State() == TopAbs_IN;
+}
+
+// The shells that bound a body, in exploration order: each solid's outer shell, any
+// further shell of that solid that lies outside it (a disjoint sibling in a multiconnex
+// solid), and every shell belonging to no solid at all. A solid's cavity shells are
+// left out — a hole is not a body, and turning one into a positive solid would give a
+// compound whose volume double-counts the part.
+static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape) {
+    std::vector<TopoDS_Shell> selected;
+    TopTools_IndexedMapOfShape claimed;
+
+    for (TopExp_Explorer se(shape, TopAbs_SOLID); se.More(); se.Next()) {
+        TopoDS_Solid solid = TopoDS::Solid(se.Current());
+        std::vector<TopoDS_Shell> shells;
+        for (TopExp_Explorer sh(solid, TopAbs_SHELL); sh.More(); sh.Next()) {
+            claimed.Add(sh.Current());
+            shells.push_back(TopoDS::Shell(sh.Current()));
+        }
+        if (shells.empty()) continue;
+
+        TopoDS_Shell outer = BRepClass3d::OuterShell(solid);
+        if (outer.IsNull()) outer = shells[0];
+        selected.push_back(outer);
+        if (shells.size() == 1) continue;
+
+        ShapeFix_Solid maker;
+        TopoDS_Solid outerSolid = maker.SolidFromShell(outer);
+        for (const TopoDS_Shell& candidate : shells) {
+            if (candidate.IsSame(outer)) continue;
+            if (outerSolid.IsNull() || !occtShellIsInsideSolid(candidate, outerSolid))
+                selected.push_back(candidate);
+        }
+    }
+
+    for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next())
+        if (!claimed.Contains(sh.Current())) selected.push_back(TopoDS::Shell(sh.Current()));
+
+    return selected;
+}
+
+// One solid per body-bounding shell, not just the first shell an explorer yields (#442).
 OCCTShapeRef OCCTShapeSolidFromShell(OCCTShapeRef shape) {
+    if (!shape) return nullptr;
     try {
-        TopExp_Explorer exp(shape->shape, TopAbs_SHELL);
-        if (!exp.More()) return nullptr;
-        TopoDS_Shell shell = TopoDS::Shell(exp.Current());
-        ShapeFix_Solid fixer;
-        TopoDS_Solid result = fixer.SolidFromShell(shell);
+        std::vector<TopoDS_Shape> made;
+        for (const TopoDS_Shell& shell : occtBodyBoundingShells(shape->shape)) {
+            ShapeFix_Solid fixer;
+            TopoDS_Solid solid = fixer.SolidFromShell(shell);
+            if (!solid.IsNull()) made.push_back(solid);
+        }
+        TopoDS_Shape result = occtSolidBodiesToShape(made);
         if (result.IsNull()) return nullptr;
         auto* ref = new OCCTShape();
         ref->shape = result;

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3155,9 +3155,11 @@ OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, d
 // MARK: - ShapeFix_Solid
 
 #include <ShapeFix_Solid.hxx>
-#include <BRepClass3d.hxx>
+#include <BRepBndLib.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
+#include <Bnd_Box.hxx>
 #include <Precision.hxx>
+#include <TopoDS_Iterator.hxx>
 
 // Assemble one result shape from healed bodies: the body itself when there is exactly
 // one, a compound when there are several. ShapeFix_Solid::Shape() already returns a
@@ -3183,12 +3185,22 @@ OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape) {
             ShapeFix_Solid fixer(TopoDS::Solid(exp.Current()));
             fixer.Perform();
             TopoDS_Shape result = fixer.Shape();
-            if (result.IsNull()) continue;
-            // Flatten: Shape() hands back a compound when one solid's shells resolve
-            // into several, and nesting those would hide bodies a level down.
-            if (result.ShapeType() == TopAbs_COMPOUND || result.ShapeType() == TopAbs_COMPSOLID) {
-                for (TopExp_Explorer se(result, TopAbs_SOLID); se.More(); se.Next())
-                    fixed.push_back(se.Current());
+
+            // No body may leave by the failure path either: a solid ShapeFix_Solid
+            // cannot heal comes back unhealed rather than vanishing from the result,
+            // which is the silent drop this function is being fixed for.
+            if (result.IsNull()) { fixed.push_back(exp.Current()); continue; }
+
+            // Flatten one level: Shape() hands back a compound when one solid's shells
+            // resolve into several bodies, and nesting it would hide them a level down.
+            // Its children are taken as they are — usually solids, but Perform() also
+            // puts back a shell it could not close, and exploring for TopAbs_SOLID here
+            // would drop exactly that. COMPSOLID is not a case: Shape() only ever
+            // returns the input solid, one fixed solid, or a compound.
+            if (result.ShapeType() == TopAbs_COMPOUND) {
+                size_t before = fixed.size();
+                for (TopoDS_Iterator it(result); it.More(); it.Next()) fixed.push_back(it.Value());
+                if (fixed.size() == before) fixed.push_back(exp.Current());   // empty compound
             } else {
                 fixed.push_back(result);
             }
@@ -3201,17 +3213,28 @@ OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape) {
     } catch (...) { return nullptr; }
 }
 
-// Is `shell` enclosed by `reference` — i.e. a cavity rather than a body of its own?
-static bool occtShellIsInsideSolid(const TopoDS_Shell& shell, const TopoDS_Solid& reference) {
+// Diagonal of a shell's bounding box, for picking the one shell that could enclose the
+// others. Zero when the box is void.
+static double occtShellExtent(const TopoDS_Shell& shell) {
+    Bnd_Box box;
+    BRepBndLib::Add(shell, box);
+    return box.IsVoid() ? 0.0 : box.SquareExtent();
+}
+
+// Does `shell` lie inside the solid the classifier was loaded with — i.e. is it a cavity
+// rather than a body of its own? `insideState` is the caller's once-per-solid reading of
+// which state means "inside" for that reference (see occtBodyBoundingShells).
+static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
+                                   BRepClass3d_SolidClassifier& classifier,
+                                   TopAbs_State insideState) {
     TopExp_Explorer ve(shell, TopAbs_VERTEX);
     if (!ve.More()) return false;
     gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(ve.Current()));
-    BRepClass3d_SolidClassifier classifier(reference);
     classifier.Perform(p, Precision::Confusion());
-    return classifier.State() == TopAbs_IN;
+    return classifier.State() == insideState;
 }
 
-// The shells that bound a body, in exploration order: each solid's outer shell, any
+// The shells that bound a body, in exploration order: each solid's enclosing shell, any
 // further shell of that solid that lies outside it (a disjoint sibling in a multiconnex
 // solid), and every shell belonging to no solid at all. A solid's cavity shells are
 // left out — a hole is not a body, and turning one into a positive solid would give a
@@ -3229,27 +3252,58 @@ static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shap
         }
         if (shells.empty()) continue;
 
-        TopoDS_Shell outer = BRepClass3d::OuterShell(solid);
-        if (outer.IsNull()) outer = shells[0];
+        // Widest shell, not BRepClass3d::OuterShell: only the enclosing shell can have
+        // the largest box, and unlike OuterShell this does not depend on the input being
+        // correctly oriented — which is exactly what a healing entry point cannot assume.
+        // Measured: the two agree on every well-formed input, and on an inside-out hollow
+        // solid OuterShell names the *cavity*, which would emit it as a second overlapping
+        // body (9000 mm³ for a 7000 mm³ part).
+        TopoDS_Shell outer = shells[0];
+        for (const TopoDS_Shell& candidate : shells)
+            if (occtShellExtent(candidate) > occtShellExtent(outer)) outer = candidate;
         selected.push_back(outer);
         if (shells.size() == 1) continue;
 
-        ShapeFix_Solid maker;
-        TopoDS_Solid outerSolid = maker.SolidFromShell(outer);
+        // Reference for the enclosure test, built directly rather than through
+        // ShapeFix_Solid::SolidFromShell: that call does sh.Free(true), a TShape-level
+        // write to state shared with the caller's shape, and nothing here needs the
+        // reorientation it pays that for. One classifier per solid, not per candidate —
+        // its constructor loads every face of the reference.
+        TopoDS_Solid reference;
+        BRep_Builder builder;
+        builder.MakeSolid(reference);
+        builder.Add(reference, outer);
+
+        BRepClass3d_SolidClassifier classifier(reference);
+        classifier.PerformInfinitePoint(Precision::Confusion());
+        // A shell added as-is can bound "everything outside" instead, which flips the
+        // sense of every later classification rather than making it wrong.
+        const TopAbs_State insideState =
+            (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
+
         for (const TopoDS_Shell& candidate : shells) {
             if (candidate.IsSame(outer)) continue;
-            if (outerSolid.IsNull() || !occtShellIsInsideSolid(candidate, outerSolid))
+            if (!occtShellIsInsideSolid(candidate, classifier, insideState))
                 selected.push_back(candidate);
         }
     }
 
-    for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next())
-        if (!claimed.Contains(sh.Current())) selected.push_back(TopoDS::Shell(sh.Current()));
+    for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next()) {
+        // Contains, not Add: IndexedMap::Add returns an index, never a "was new" flag.
+        // Without this a compound holding the same free shell twice yields two identical
+        // solids.
+        if (claimed.Contains(sh.Current())) continue;
+        claimed.Add(sh.Current());
+        selected.push_back(TopoDS::Shell(sh.Current()));
+    }
 
     return selected;
 }
 
 // One solid per body-bounding shell, not just the first shell an explorer yields (#442).
+// Note ShapeFix_Solid::SolidFromShell does sh.Free(true) on each shell it is given, which
+// writes a flag on the TShape shared with the caller's shape; that is inherent to the call
+// this function exists to make, and is why the enclosure reference above avoids it.
 OCCTShapeRef OCCTShapeSolidFromShell(OCCTShapeRef shape) {
     if (!shape) return nullptr;
     try {
@@ -3257,7 +3311,9 @@ OCCTShapeRef OCCTShapeSolidFromShell(OCCTShapeRef shape) {
         for (const TopoDS_Shell& shell : occtBodyBoundingShells(shape->shape)) {
             ShapeFix_Solid fixer;
             TopoDS_Solid solid = fixer.SolidFromShell(shell);
-            if (!solid.IsNull()) made.push_back(solid);
+            // SolidFromShell builds its solid before any classification and never returns
+            // a null one, so this keeps a body rather than dropping it if that changes.
+            made.push_back(solid.IsNull() ? TopoDS_Shape(shell) : TopoDS_Shape(solid));
         }
         TopoDS_Shape result = occtSolidBodiesToShape(made);
         if (result.IsNull()) return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3155,9 +3155,7 @@ OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, d
 // MARK: - ShapeFix_Solid
 
 #include <ShapeFix_Solid.hxx>
-#include <BRepBndLib.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
-#include <Bnd_Box.hxx>
 #include <Precision.hxx>
 #include <TopoDS_Iterator.hxx>
 
@@ -3213,17 +3211,9 @@ OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape) {
     } catch (...) { return nullptr; }
 }
 
-// Diagonal of a shell's bounding box, for picking the one shell that could enclose the
-// others. Zero when the box is void.
-static double occtShellExtent(const TopoDS_Shell& shell) {
-    Bnd_Box box;
-    BRepBndLib::Add(shell, box);
-    return box.IsVoid() ? 0.0 : box.SquareExtent();
-}
-
-// Does `shell` lie inside the solid the classifier was loaded with — i.e. is it a cavity
-// rather than a body of its own? `insideState` is the caller's once-per-solid reading of
-// which state means "inside" for that reference (see occtBodyBoundingShells).
+// Does `shell` lie inside the solid the classifier was loaded with? `insideState` is the
+// caller's once-per-reference reading of which state means "inside" for it (see
+// occtBodyBoundingShells).
 static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
                                    BRepClass3d_SolidClassifier& classifier,
                                    TopAbs_State insideState) {
@@ -3234,11 +3224,10 @@ static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
     return classifier.State() == insideState;
 }
 
-// The shells that bound a body, in exploration order: each solid's enclosing shell, any
-// further shell of that solid that lies outside it (a disjoint sibling in a multiconnex
-// solid), and every shell belonging to no solid at all. A solid's cavity shells are
-// left out — a hole is not a body, and turning one into a positive solid would give a
-// compound whose volume double-counts the part.
+// The shells that bound a body, in exploration order: within each solid, every shell an
+// even number of the others enclose, plus every shell belonging to no solid at all. A
+// solid's cavity shells are left out — a hole is not a body, and turning one into a
+// positive solid would give a compound whose volume double-counts the part.
 static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape) {
     std::vector<TopoDS_Shell> selected;
     TopTools_IndexedMapOfShape claimed;
@@ -3252,40 +3241,38 @@ static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shap
         }
         if (shells.empty()) continue;
 
-        // Widest shell, not BRepClass3d::OuterShell: only the enclosing shell can have
-        // the largest box, and unlike OuterShell this does not depend on the input being
-        // correctly oriented — which is exactly what a healing entry point cannot assume.
-        // Measured: the two agree on every well-formed input, and on an inside-out hollow
-        // solid OuterShell names the *cavity*, which would emit it as a second overlapping
-        // body (9000 mm³ for a 7000 mm³ part).
-        TopoDS_Shell outer = shells[0];
-        for (const TopoDS_Shell& candidate : shells)
-            if (occtShellExtent(candidate) > occtShellExtent(outer)) outer = candidate;
-        selected.push_back(outer);
-        if (shells.size() == 1) continue;
+        if (shells.size() == 1) { selected.push_back(shells[0]); continue; }
 
-        // Reference for the enclosure test, built directly rather than through
-        // ShapeFix_Solid::SolidFromShell: that call does sh.Free(true), a TShape-level
-        // write to state shared with the caller's shape, and nothing here needs the
-        // reorientation it pays that for. One classifier per solid, not per candidate —
-        // its constructor loads every face of the reference.
-        TopoDS_Solid reference;
-        BRep_Builder builder;
-        builder.MakeSolid(reference);
-        builder.Add(reference, outer);
+        // Enclosure parity: a shell bounds a body iff an EVEN number of the other shells
+        // enclose it. Nothing here assumes one shell encloses all the rest, which is what
+        // both simpler rules got wrong — picking a single reference (BRepClass3d::OuterShell
+        // or the widest box) and calling everything outside it a body double-counts one
+        // body's cavity as soon as a *different* body is the reference. Parity also reads
+        // a body nested inside another body's cavity correctly: enclosed twice, so even.
+        std::vector<int> enclosedBy(shells.size(), 0);
+        for (size_t i = 0; i < shells.size(); i++) {
+            // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
+            // that call does sh.Free(true), a TShape-level write to state shared with the
+            // caller's shape, and nothing here needs the reorientation it pays that for.
+            // One classifier per reference shell — its constructor loads every face.
+            TopoDS_Solid reference;
+            BRep_Builder builder;
+            builder.MakeSolid(reference);
+            builder.Add(reference, shells[i]);
 
-        BRepClass3d_SolidClassifier classifier(reference);
-        classifier.PerformInfinitePoint(Precision::Confusion());
-        // A shell added as-is can bound "everything outside" instead, which flips the
-        // sense of every later classification rather than making it wrong.
-        const TopAbs_State insideState =
-            (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
+            BRepClass3d_SolidClassifier classifier(reference);
+            classifier.PerformInfinitePoint(Precision::Confusion());
+            // A shell added as-is can bound "everything outside" instead, which flips the
+            // sense of every later classification rather than making it wrong.
+            const TopAbs_State insideState =
+                (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
 
-        for (const TopoDS_Shell& candidate : shells) {
-            if (candidate.IsSame(outer)) continue;
-            if (!occtShellIsInsideSolid(candidate, classifier, insideState))
-                selected.push_back(candidate);
+            for (size_t j = 0; j < shells.size(); j++)
+                if (i != j && occtShellIsInsideSolid(shells[j], classifier, insideState))
+                    enclosedBy[j]++;
         }
+        for (size_t i = 0; i < shells.size(); i++)
+            if (enclosedBy[i] % 2 == 0) selected.push_back(shells[i]);
     }
 
     for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next()) {

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -3871,8 +3871,13 @@ public extension Shape {
     /// print(solids.solids.count)   // 2 — one solid per shell
     /// ```
     ///
-    /// - Returns: A solid, a compound of solids for multi-body input, or `nil` if the
-    ///   receiver holds no shell or none of them closes.
+    /// - Important: An **open** shell is not rejected. `ShapeFix_Solid::SolidFromShell`
+    ///   builds its solid before classifying anything and never returns a null one, so a
+    ///   shell with gaps comes back as a solid that is not closed rather than as `nil`.
+    ///   Check ``Shape/isValid`` or sew first if the input may be open.
+    ///
+    /// - Returns: A solid, a compound of solids for multi-body input, or `nil` only if the
+    ///   receiver holds no shell at all.
     func solidFromShellFixed() -> Shape? {
         guard let ref = OCCTShapeSolidFromShell(handle) else { return nil }
         return Shape(handle: ref)

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -3837,9 +3837,22 @@ public extension Shape {
     ///   is ever dropped to make that true. `ShapeFix_Solid` hands back a **shell** when it
     ///   cannot close one into a solid, and a solid it fails to heal outright is returned
     ///   **unhealed** rather than discarded. So `result.solids.count` can be lower than the
-    ///   number of input bodies even though nothing was lost — check
-    ///   `result.subShapes(ofType: .shell)` or ``Shape/isValid`` if that distinction
-    ///   matters, rather than treating a short `solids` count as a body having vanished.
+    ///   number of input bodies even though nothing was lost.
+    ///
+    ///   To spot an unclosed body, walk the result's **direct children** — not
+    ///   ``Shape/subShapes(ofType:)``, which maps at every depth and so reports one shell
+    ///   for every *healthy* solid too (a compound of two healed solids has two shells, and
+    ///   a single healed solid has one):
+    ///
+    ///   ```swift
+    ///   let healed = part.fixSolid()!
+    ///   let bodies = (0..<healed.nbChildren).compactMap { healed.child(at: $0) }
+    ///   let unclosed = bodies.filter { $0.shapeType == .shell }
+    ///   ```
+    ///
+    ///   When a single body came back, the result is that body rather than a compound, so
+    ///   `healed.shapeType == .shell` answers it directly. A body that came back *unhealed*
+    ///   is still a solid — use ``Shape/isValid`` for that.
     ///
     /// ```swift
     /// let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -3820,13 +3820,59 @@ public extension Document {
 // MARK: - ShapeFix_Solid
 
 public extension Shape {
-    /// Fix a solid shape (topology and orientation).
+    /// Fix a solid shape (topology and orientation), using `ShapeFix_Solid`.
+    ///
+    /// Every solid in the receiver is healed, not just the first: a single-body input
+    /// comes back as a solid, a multi-body one as a compound of the healed solids in
+    /// exploration order. A compound result is not new to this call — `ShapeFix_Solid`
+    /// already returns one when a single solid's shells resolve into several bodies.
+    ///
+    /// Only solids are carried over. Loose shells, faces or wires sitting alongside them
+    /// in a compound are dropped, and an input holding no solid at all returns `nil`.
+    /// To heal a whole shape of mixed content instead, use
+    /// ``Shape/fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)``, which wraps
+    /// `ShapeFix_Shape` and preserves everything it is given.
+    ///
+    /// ```swift
+    /// let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
+    /// let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)!
+    /// let part = Shape.compound([a, b])!
+    ///
+    /// let healed = part.fixSolid()!
+    /// print(healed.solids.count)   // 2 — both bodies, not just the first
+    /// print(healed.volume!)        // 2000.0
+    /// ```
+    ///
+    /// - Returns: The repaired solid, a compound of repaired solids for multi-body input,
+    ///   or `nil` if the receiver holds no solid.
     func fixSolid() -> Shape? {
         guard let ref = OCCTShapeFixSolid(handle) else { return nil }
         return Shape(handle: ref)
     }
 
-    /// Create a solid from a shell shape using ShapeFix_Solid.
+    /// Create a solid from a shell shape using `ShapeFix_Solid`, orienting it to enclose
+    /// a finite volume.
+    ///
+    /// One solid is built per *body-bounding* shell, not just the first shell found: each
+    /// solid's outer shell, plus every shell that belongs to no solid (the usual shape of
+    /// sewing output), plus any further shell of a solid that lies outside it — a disjoint
+    /// sibling body in a multiconnex solid. A single body comes back as a solid, several
+    /// as a compound in exploration order.
+    ///
+    /// A solid's *cavity* shells are deliberately skipped: a hole is not a body, and
+    /// building it as a positive solid would yield a compound whose volume double-counts
+    /// the part. So a hollow solid produces one solid bounded by its outer shell, with the
+    /// cavity filled. To rebuild a solid that keeps its cavities, use
+    /// ``Shape/solidFromShells(_:)`` with the outer shell first.
+    ///
+    /// ```swift
+    /// let quilt = Shape.compound([shellA, shellB])!   // e.g. two sewn bodies
+    /// let solids = quilt.solidFromShellFixed()!
+    /// print(solids.solids.count)   // 2 — one solid per shell
+    /// ```
+    ///
+    /// - Returns: A solid, a compound of solids for multi-body input, or `nil` if the
+    ///   receiver holds no shell or none of them closes.
     func solidFromShellFixed() -> Shape? {
         guard let ref = OCCTShapeSolidFromShell(handle) else { return nil }
         return Shape(handle: ref)

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -3823,15 +3823,23 @@ public extension Shape {
     /// Fix a solid shape (topology and orientation), using `ShapeFix_Solid`.
     ///
     /// Every solid in the receiver is healed, not just the first: a single-body input
-    /// comes back as a solid, a multi-body one as a compound of the healed solids in
-    /// exploration order. A compound result is not new to this call — `ShapeFix_Solid`
+    /// comes back as a solid, a multi-body one as a compound of one result per input body,
+    /// in exploration order. A compound result is not new to this call — `ShapeFix_Solid`
     /// already returns one when a single solid's shells resolve into several bodies.
     ///
-    /// Only solids are carried over. Loose shells, faces or wires sitting alongside them
-    /// in a compound are dropped, and an input holding no solid at all returns `nil`.
-    /// To heal a whole shape of mixed content instead, use
+    /// Only the receiver's *solids* are visited. Loose shells, faces or wires sitting
+    /// alongside them in a compound are not carried over, and an input holding no solid at
+    /// all returns `nil`. To heal a whole shape of mixed content instead, use
     /// ``Shape/fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)``, which wraps
     /// `ShapeFix_Shape` and preserves everything it is given.
+    ///
+    /// - Warning: A result body is usually a healed solid, but **not always**, and no body
+    ///   is ever dropped to make that true. `ShapeFix_Solid` hands back a **shell** when it
+    ///   cannot close one into a solid, and a solid it fails to heal outright is returned
+    ///   **unhealed** rather than discarded. So `result.solids.count` can be lower than the
+    ///   number of input bodies even though nothing was lost — check
+    ///   `result.subShapes(ofType: .shell)` or ``Shape/isValid`` if that distinction
+    ///   matters, rather than treating a short `solids` count as a body having vanished.
     ///
     /// ```swift
     /// let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
@@ -3843,8 +3851,8 @@ public extension Shape {
     /// print(healed.volume!)        // 2000.0
     /// ```
     ///
-    /// - Returns: The repaired solid, a compound of repaired solids for multi-body input,
-    ///   or `nil` if the receiver holds no solid.
+    /// - Returns: The repaired body, or a compound of one result per input body for
+    ///   multi-body input, or `nil` if the receiver holds no solid.
     func fixSolid() -> Shape? {
         guard let ref = OCCTShapeFixSolid(handle) else { return nil }
         return Shape(handle: ref)
@@ -3853,11 +3861,10 @@ public extension Shape {
     /// Create a solid from a shell shape using `ShapeFix_Solid`, orienting it to enclose
     /// a finite volume.
     ///
-    /// One solid is built per *body-bounding* shell, not just the first shell found: each
-    /// solid's outer shell, plus every shell that belongs to no solid (the usual shape of
-    /// sewing output), plus any further shell of a solid that lies outside it — a disjoint
-    /// sibling body in a multiconnex solid. A single body comes back as a solid, several
-    /// as a compound in exploration order.
+    /// One solid is built per *body-bounding* shell, not just the first shell found: within
+    /// each solid, every shell that an **even** number of the other shells enclose, plus
+    /// every shell that belongs to no solid (the usual shape of sewing output). A single
+    /// body comes back as a solid, several as a compound in exploration order.
     ///
     /// A solid's *cavity* shells are deliberately skipped: a hole is not a body, and
     /// building it as a positive solid would yield a compound whose volume double-counts

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #442 — `Shape.fixSolid()` and `Shape.solidFromShellFixed()` healed only the FIRST
+/// body a `TopExp_Explorer` yielded and discarded the rest, returning a well-formed
+/// `Shape` that nothing downstream could tell was missing most of the part.
+///
+/// Both now cover every body. The single-body results are pinned alongside the
+/// multi-body ones, because the fix must not change what a one-solid input returns.
+@Suite("Issue 442: fixSolid/solidFromShellFixed cover every body")
+struct Issue442FixSolidMultiBody {
+
+    /// Two disjoint 10mm boxes, 2000mm³ total — the issue's own reproducer.
+    private func twoBoxes() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    /// A 20mm cube with a 10mm cavity fully inside it: one solid, two shells.
+    private func hollowBox() -> Shape? {
+        guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
+              let cavity = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return outer.subtracting(cavity)
+    }
+
+    // MARK: - fixSolid
+
+    @Test("fixSolid keeps both bodies of a two-solid compound")
+    func fixSolidMultiBody() {
+        guard let compound = twoBoxes() else { return }
+        #expect(compound.solids.count == 2)
+        #expect(compound.subShapeCount(ofType: .face) == 12)
+
+        guard let healed = compound.fixSolid() else {
+            Issue.record("fixSolid returned nil for a two-solid compound")
+            return
+        }
+        // Was 1 solid / 6 faces / 1000.0 before the fix — box B silently dropped.
+        #expect(healed.solids.count == 2)
+        #expect(healed.subShapeCount(ofType: .face) == 12)
+        if let volume = healed.volume {
+            #expect(abs(volume - 2000.0) < 1e-6)
+        }
+    }
+
+    @Test("fixSolid still returns a bare solid for single-body input")
+    func fixSolidSingleBody() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let healed = box.fixSolid() else {
+            Issue.record("fixSolid returned nil for a single solid")
+            return
+        }
+        #expect(healed.shapeType == .solid)
+        #expect(healed.solids.count == 1)
+        #expect(healed.isValid)
+        if let volume = healed.volume {
+            #expect(abs(volume - 1000.0) < 1e-6)
+        }
+    }
+
+    @Test("fixSolid preserves a hollow solid's cavity")
+    func fixSolidHollow() {
+        guard let hollow = hollowBox() else { return }
+        guard let healed = hollow.fixSolid() else {
+            Issue.record("fixSolid returned nil for a hollow solid")
+            return
+        }
+        #expect(healed.solids.count == 1)
+        if let volume = healed.volume {
+            #expect(abs(volume - 7000.0) < 1e-6)   // 8000 outer − 1000 cavity
+        }
+    }
+
+    @Test("fixSolid returns nil when the shape holds no solid")
+    func fixSolidNoSolid() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        let faces = box.subShapes(ofType: .face)
+        #expect(faces.count == 6)
+        if let face = faces.first {
+            #expect(face.fixSolid() == nil)
+        }
+    }
+
+    // MARK: - solidFromShellFixed
+
+    @Test("solidFromShellFixed keeps both bodies of a two-solid compound")
+    func solidFromShellMultiBody() {
+        guard let compound = twoBoxes() else { return }
+        guard let solids = compound.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil for a two-solid compound")
+            return
+        }
+        // Was 1 solid / 1000.0 before the fix.
+        #expect(solids.solids.count == 2)
+        #expect(solids.subShapeCount(ofType: .face) == 12)
+        if let volume = solids.volume {
+            #expect(abs(volume - 2000.0) < 1e-6)
+        }
+    }
+
+    @Test("solidFromShellFixed still returns a bare solid for single-body input")
+    func solidFromShellSingleBody() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let solid = box.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil for a single solid")
+            return
+        }
+        #expect(solid.shapeType == .solid)
+        #expect(solid.solids.count == 1)
+        if let volume = solid.volume {
+            #expect(abs(volume - 1000.0) < 1e-6)
+        }
+    }
+
+    /// A cavity is a hole, not a body: building one as a positive solid would return a
+    /// compound whose volume double-counts the part (8000 + 1000 for a 7000 part).
+    @Test("solidFromShellFixed skips a hollow solid's cavity shell")
+    func solidFromShellSkipsCavity() {
+        guard let hollow = hollowBox() else { return }
+        #expect(hollow.solids.count == 1)
+        #expect(hollow.shells.count == 2)
+
+        guard let solid = hollow.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil for a hollow solid")
+            return
+        }
+        #expect(solid.shapeType == .solid)
+        #expect(solid.solids.count == 1)
+        if let volume = solid.volume {
+            #expect(abs(volume - 8000.0) < 1e-6)   // outer shell only, cavity filled
+        }
+    }
+
+    /// Free shells belong to no solid — the usual shape of sewing output.
+    @Test("solidFromShellFixed builds one solid per free shell")
+    func solidFromShellFreeShells() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+              let shellA = a.shells.first, let shellB = b.shells.first,
+              let quilt = Shape.compound([shellA, shellB])
+        else { return }
+        #expect(quilt.solids.isEmpty)
+        #expect(quilt.shells.count == 2)
+
+        guard let solids = quilt.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil for two free shells")
+            return
+        }
+        #expect(solids.solids.count == 2)
+        if let volume = solids.volume {
+            #expect(abs(volume - 2000.0) < 1e-6)
+        }
+    }
+
+    @Test("solidFromShellFixed returns nil when the shape holds no shell")
+    func solidFromShellNoShell() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        if let face = box.subShapes(ofType: .face).first {
+            #expect(face.solidFromShellFixed() == nil)
+        }
+    }
+
+    // MARK: - The issue's measured table
+
+    /// The exact table from the issue: every column read 1 solid / 6 faces / 1000.0 for
+    /// the two healing calls before the fix, against a 2 solid / 12 face / 2000.0 input.
+    @Test("Issue 442 reproducer table")
+    func reproducerTable() {
+        guard let compound = twoBoxes(),
+              let healed = compound.fixSolid(),
+              let fromShells = compound.solidFromShellFixed()
+        else {
+            Issue.record("could not build the #442 reproducer")
+            return
+        }
+        for shape in [compound, healed, fromShells] {
+            #expect(shape.solids.count == 2)
+            #expect(shape.subShapeCount(ofType: .face) == 12)
+            if let volume = shape.volume {
+                #expect(abs(volume - 2000.0) < 1e-6)
+            }
+            // Both bodies present means the bounds still span x 0..30.
+            if let box = shape.boundingBox {
+                #expect(abs(box.min.x - 0.0) < 1e-6)
+                #expect(abs(box.max.x - 30.0) < 1e-6)
+            }
+        }
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -214,6 +214,38 @@ struct Issue442FixSolidMultiBody {
         expectVolume(solids, 2000.0, "solidFromShellFixed(multiconnex solid)")
     }
 
+    /// One solid holding a hollow body's two shells *and* a second, wider body's shell.
+    /// This is what rules out picking any single reference shell and calling everything
+    /// outside it a body: with the wider body as the reference, the first body's cavity
+    /// also classifies as outside, and gets emitted as a positive solid that double-counts
+    /// (36000 against a correct 35000). Enclosure parity has no such reference.
+    @Test("solidFromShellFixed skips a cavity even when another body is wider")
+    func solidFromShellCavityWithWiderSibling() {
+        guard let outerA = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
+              let cavityA = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10),
+              let hollowA = outerA.subtracting(cavityA),
+              let boxB = Shape.box(origin: SIMD3(50, 0, 0), width: 30, height: 30, depth: 30)
+        else {
+            Issue.record("could not build the hollow body plus wider sibling")
+            return
+        }
+        // One solid, three shells: A's outer (8000), A's cavity (1000), B's outer (27000).
+        let shells = hollowA.shells + boxB.shells
+        #expect(shells.count == 3)
+        guard let solid = Shape.solidFromShells(shells) else {
+            Issue.record("could not assemble the three shells into one solid")
+            return
+        }
+        #expect(solid.shells.count == 3)
+
+        guard let bodies = solid.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil")
+            return
+        }
+        #expect(bodies.solids.count == 2)
+        expectVolume(bodies, 35000.0, "solidFromShellFixed(cavity + wider sibling)")
+    }
+
     /// Free shells belong to no solid — the usual shape of sewing output.
     @Test("solidFromShellFixed builds one solid per free shell")
     func solidFromShellFreeShells() {

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -9,8 +9,27 @@ import simd
 ///
 /// Both now cover every body. The single-body results are pinned alongside the
 /// multi-body ones, because the fix must not change what a one-solid input returns.
+///
+/// Every assertion here is written so it cannot be *skipped*: `Shape.volume` is
+/// `v >= 0 ? v : nil`, so it returns `nil` precisely when a solid comes back inverted —
+/// and orientation is the whole job of `SolidFromShell`. An `if let volume` with no
+/// `else` would let that regression pass silently, which is the failure mode this issue
+/// is about.
 @Suite("Issue 442: fixSolid/solidFromShellFixed cover every body")
 struct Issue442FixSolidMultiBody {
+
+    /// Volume, asserted rather than optionally-bound: a `nil` here means the solid is
+    /// inverted, which must fail the test rather than skip it.
+    private func expectVolume(_ shape: Shape, _ expected: Double,
+                              _ what: String, sourceLocation: SourceLocation = #_sourceLocation) {
+        guard let volume = shape.volume else {
+            Issue.record("\(what): volume is nil — the solid came back inverted",
+                         sourceLocation: sourceLocation)
+            return
+        }
+        #expect(abs(volume - expected) < 1e-6, "\(what): volume \(volume), expected \(expected)",
+                sourceLocation: sourceLocation)
+    }
 
     /// Two disjoint 10mm boxes, 2000mm³ total — the issue's own reproducer.
     private func twoBoxes() -> Shape? {
@@ -28,11 +47,25 @@ struct Issue442FixSolidMultiBody {
         return outer.subtracting(cavity)
     }
 
+    /// One solid holding two disjoint closed shells. Pathological but real, and the case
+    /// that rules out the naive "outer shell per solid" selection rule — so it is the one
+    /// most likely to regress unnoticed.
+    private func multiconnexSolid() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+              let shellA = a.shells.first, let shellB = b.shells.first
+        else { return nil }
+        return Shape.solidFromShells([shellA, shellB])
+    }
+
     // MARK: - fixSolid
 
     @Test("fixSolid keeps both bodies of a two-solid compound")
     func fixSolidMultiBody() {
-        guard let compound = twoBoxes() else { return }
+        guard let compound = twoBoxes() else {
+            Issue.record("could not build the two-box compound")
+            return
+        }
         #expect(compound.solids.count == 2)
         #expect(compound.subShapeCount(ofType: .face) == 12)
 
@@ -43,14 +76,15 @@ struct Issue442FixSolidMultiBody {
         // Was 1 solid / 6 faces / 1000.0 before the fix — box B silently dropped.
         #expect(healed.solids.count == 2)
         #expect(healed.subShapeCount(ofType: .face) == 12)
-        if let volume = healed.volume {
-            #expect(abs(volume - 2000.0) < 1e-6)
-        }
+        expectVolume(healed, 2000.0, "fixSolid(two-box compound)")
     }
 
     @Test("fixSolid still returns a bare solid for single-body input")
     func fixSolidSingleBody() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
+        }
         guard let healed = box.fixSolid() else {
             Issue.record("fixSolid returned nil for a single solid")
             return
@@ -58,39 +92,65 @@ struct Issue442FixSolidMultiBody {
         #expect(healed.shapeType == .solid)
         #expect(healed.solids.count == 1)
         #expect(healed.isValid)
-        if let volume = healed.volume {
-            #expect(abs(volume - 1000.0) < 1e-6)
-        }
+        expectVolume(healed, 1000.0, "fixSolid(single solid)")
     }
 
     @Test("fixSolid preserves a hollow solid's cavity")
     func fixSolidHollow() {
-        guard let hollow = hollowBox() else { return }
+        guard let hollow = hollowBox() else {
+            Issue.record("could not build the hollow box")
+            return
+        }
         guard let healed = hollow.fixSolid() else {
             Issue.record("fixSolid returned nil for a hollow solid")
             return
         }
         #expect(healed.solids.count == 1)
-        if let volume = healed.volume {
-            #expect(abs(volume - 7000.0) < 1e-6)   // 8000 outer − 1000 cavity
+        expectVolume(healed, 7000.0, "fixSolid(hollow solid)")   // 8000 outer − 1000 cavity
+    }
+
+    /// One solid, two disjoint shells: `ShapeFix_Solid::Shape()` splits it into a compound
+    /// of two solids, which is why a compound return was never a new category for this API.
+    @Test("fixSolid splits a multiconnex solid into both bodies")
+    func fixSolidMulticonnex() {
+        guard let solid = multiconnexSolid() else {
+            Issue.record("could not build the multiconnex solid")
+            return
         }
+        #expect(solid.solids.count == 1)
+        #expect(solid.shells.count == 2)
+
+        guard let healed = solid.fixSolid() else {
+            Issue.record("fixSolid returned nil for a multiconnex solid")
+            return
+        }
+        #expect(healed.solids.count == 2)
+        expectVolume(healed, 2000.0, "fixSolid(multiconnex solid)")
     }
 
     @Test("fixSolid returns nil when the shape holds no solid")
     func fixSolidNoSolid() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
+        }
         let faces = box.subShapes(ofType: .face)
         #expect(faces.count == 6)
-        if let face = faces.first {
-            #expect(face.fixSolid() == nil)
+        guard let face = faces.first else {
+            Issue.record("box reported no faces")
+            return
         }
+        #expect(face.fixSolid() == nil)
     }
 
     // MARK: - solidFromShellFixed
 
     @Test("solidFromShellFixed keeps both bodies of a two-solid compound")
     func solidFromShellMultiBody() {
-        guard let compound = twoBoxes() else { return }
+        guard let compound = twoBoxes() else {
+            Issue.record("could not build the two-box compound")
+            return
+        }
         guard let solids = compound.solidFromShellFixed() else {
             Issue.record("solidFromShellFixed returned nil for a two-solid compound")
             return
@@ -98,30 +158,32 @@ struct Issue442FixSolidMultiBody {
         // Was 1 solid / 1000.0 before the fix.
         #expect(solids.solids.count == 2)
         #expect(solids.subShapeCount(ofType: .face) == 12)
-        if let volume = solids.volume {
-            #expect(abs(volume - 2000.0) < 1e-6)
-        }
+        expectVolume(solids, 2000.0, "solidFromShellFixed(two-box compound)")
     }
 
     @Test("solidFromShellFixed still returns a bare solid for single-body input")
     func solidFromShellSingleBody() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
+        }
         guard let solid = box.solidFromShellFixed() else {
             Issue.record("solidFromShellFixed returned nil for a single solid")
             return
         }
         #expect(solid.shapeType == .solid)
         #expect(solid.solids.count == 1)
-        if let volume = solid.volume {
-            #expect(abs(volume - 1000.0) < 1e-6)
-        }
+        expectVolume(solid, 1000.0, "solidFromShellFixed(single solid)")
     }
 
     /// A cavity is a hole, not a body: building one as a positive solid would return a
     /// compound whose volume double-counts the part (8000 + 1000 for a 7000 part).
     @Test("solidFromShellFixed skips a hollow solid's cavity shell")
     func solidFromShellSkipsCavity() {
-        guard let hollow = hollowBox() else { return }
+        guard let hollow = hollowBox() else {
+            Issue.record("could not build the hollow box")
+            return
+        }
         #expect(hollow.solids.count == 1)
         #expect(hollow.shells.count == 2)
 
@@ -131,9 +193,25 @@ struct Issue442FixSolidMultiBody {
         }
         #expect(solid.shapeType == .solid)
         #expect(solid.solids.count == 1)
-        if let volume = solid.volume {
-            #expect(abs(volume - 8000.0) < 1e-6)   // outer shell only, cavity filled
+        expectVolume(solid, 8000.0, "solidFromShellFixed(hollow solid)")   // outer shell, cavity filled
+    }
+
+    /// The case the "outer shell per solid" rule would silently drop a body on.
+    @Test("solidFromShellFixed keeps both shells of a multiconnex solid")
+    func solidFromShellMulticonnex() {
+        guard let solid = multiconnexSolid() else {
+            Issue.record("could not build the multiconnex solid")
+            return
         }
+        #expect(solid.solids.count == 1)
+        #expect(solid.shells.count == 2)
+
+        guard let solids = solid.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil for a multiconnex solid")
+            return
+        }
+        #expect(solids.solids.count == 2)
+        expectVolume(solids, 2000.0, "solidFromShellFixed(multiconnex solid)")
     }
 
     /// Free shells belong to no solid — the usual shape of sewing output.
@@ -143,7 +221,10 @@ struct Issue442FixSolidMultiBody {
               let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
               let shellA = a.shells.first, let shellB = b.shells.first,
               let quilt = Shape.compound([shellA, shellB])
-        else { return }
+        else {
+            Issue.record("could not build the two free shells")
+            return
+        }
         #expect(quilt.solids.isEmpty)
         #expect(quilt.shells.count == 2)
 
@@ -152,17 +233,42 @@ struct Issue442FixSolidMultiBody {
             return
         }
         #expect(solids.solids.count == 2)
-        if let volume = solids.volume {
-            #expect(abs(volume - 2000.0) < 1e-6)
+        expectVolume(solids, 2000.0, "solidFromShellFixed(two free shells)")
+    }
+
+    /// The same free shell twice in one compound is one body, not two.
+    @Test("solidFromShellFixed does not duplicate a repeated free shell")
+    func solidFromShellDeduplicates() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let shell = a.shells.first,
+              let duped = Shape.compound([shell, shell])
+        else {
+            Issue.record("could not build the duplicated-shell compound")
+            return
         }
+        #expect(duped.shells.count == 2)
+
+        guard let solid = duped.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil for a duplicated shell")
+            return
+        }
+        #expect(solid.solids.count == 1)
+        expectVolume(solid, 1000.0, "solidFromShellFixed(same shell twice)")
     }
 
     @Test("solidFromShellFixed returns nil when the shape holds no shell")
     func solidFromShellNoShell() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        if let face = box.subShapes(ofType: .face).first {
-            #expect(face.solidFromShellFixed() == nil)
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
         }
+        let faces = box.subShapes(ofType: .face)
+        #expect(faces.count == 6)
+        guard let face = faces.first else {
+            Issue.record("box reported no faces")
+            return
+        }
+        #expect(face.solidFromShellFixed() == nil)
     }
 
     // MARK: - The issue's measured table
@@ -171,24 +277,30 @@ struct Issue442FixSolidMultiBody {
     /// the two healing calls before the fix, against a 2 solid / 12 face / 2000.0 input.
     @Test("Issue 442 reproducer table")
     func reproducerTable() {
-        guard let compound = twoBoxes(),
-              let healed = compound.fixSolid(),
-              let fromShells = compound.solidFromShellFixed()
-        else {
+        guard let compound = twoBoxes() else {
             Issue.record("could not build the #442 reproducer")
             return
         }
-        for shape in [compound, healed, fromShells] {
-            #expect(shape.solids.count == 2)
-            #expect(shape.subShapeCount(ofType: .face) == 12)
-            if let volume = shape.volume {
-                #expect(abs(volume - 2000.0) < 1e-6)
-            }
+        guard let healed = compound.fixSolid() else {
+            Issue.record("fixSolid returned nil")
+            return
+        }
+        guard let fromShells = compound.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil")
+            return
+        }
+        for (label, shape) in [("input", compound), ("fixSolid", healed),
+                               ("solidFromShellFixed", fromShells)] {
+            #expect(shape.solids.count == 2, "\(label): solids")
+            #expect(shape.subShapeCount(ofType: .face) == 12, "\(label): faces")
+            expectVolume(shape, 2000.0, label)
             // Both bodies present means the bounds still span x 0..30.
-            if let box = shape.boundingBox {
-                #expect(abs(box.min.x - 0.0) < 1e-6)
-                #expect(abs(box.max.x - 30.0) < 1e-6)
+            guard let box = shape.boundingBox else {
+                Issue.record("\(label): boundingBox is nil")
+                continue
             }
+            #expect(abs(box.min.x - 0.0) < 1e-6, "\(label): min.x \(box.min.x)")
+            #expect(abs(box.max.x - 30.0) < 1e-6, "\(label): max.x \(box.max.x)")
         }
     }
 }

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -303,6 +303,82 @@ struct Issue442FixSolidMultiBody {
         #expect(face.solidFromShellFixed() == nil)
     }
 
+    /// The docs tell callers to spot an unclosed body by walking the result's **direct
+    /// children**, and explicitly not with `subShapes(ofType: .shell)`. This pins both
+    /// halves of that claim: the recommended walk reports no shell on healthy output, and
+    /// the rejected one reports a shell per solid whether or not anything went wrong.
+    @Test("the documented unclosed-body check works on healthy output")
+    func documentedUnclosedCheck() {
+        guard let compound = twoBoxes() else {
+            Issue.record("could not build the two-box compound")
+            return
+        }
+        guard let healed = compound.fixSolid() else {
+            Issue.record("fixSolid returned nil")
+            return
+        }
+        // Recommended: direct children, one per body, all solids.
+        let bodies = (0..<healed.nbChildren).compactMap { healed.child(at: $0) }
+        #expect(bodies.count == 2)
+        #expect(bodies.allSatisfy { $0.shapeType == .solid })
+        #expect(bodies.filter { $0.shapeType == .shell }.isEmpty)
+
+        // Rejected: maps at every depth, so healthy output reports one shell per solid.
+        #expect(healed.subShapeCount(ofType: .shell) == 2)
+
+        // Single-body input returns the body itself, so shapeType answers it directly.
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let single = box.fixSolid() else {
+            Issue.record("could not heal a single box")
+            return
+        }
+        #expect(single.shapeType == .solid)
+        #expect(single.subShapeCount(ofType: .shell) == 1)   // not a failure signal
+    }
+
+    /// An open shell reaching the parity pass must not perturb the other shells' verdicts.
+    /// Every shell is a reference under parity, and an open one cannot enclose anything;
+    /// without that guard, measured, a hollow body's outer shell is dropped outright
+    /// (enclosed count 1, odd) and its cavity emitted as a positive body.
+    @Test("an open shell does not flip other shells' verdicts")
+    func openShellDoesNotPerturbParity() {
+        guard let outerA = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
+              let cavityA = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10),
+              let hollowA = outerA.subtracting(cavityA),
+              let bigBox = Shape.box(origin: SIMD3(-10, -10, -10), width: 40, height: 40, depth: 40)
+        else {
+            Issue.record("could not build the hollow body or the wrapping box")
+            return
+        }
+        // An open shell that wraps the hollow body: the big box's faces minus one, sewn.
+        let faces = bigBox.subShapes(ofType: .face)
+        #expect(faces.count == 6)
+        guard let openQuilt = Shape.compound(Array(faces.dropFirst()))?.sewn(tolerance: 1e-6),
+              let openShell = openQuilt.shells.first
+        else {
+            Issue.record("could not sew the open shell")
+            return
+        }
+        guard let solid = Shape.solidFromShells(hollowA.shells + [openShell]) else {
+            Issue.record("could not assemble the shells into one solid")
+            return
+        }
+        #expect(solid.shells.count == 3)
+
+        guard let bodies = solid.solidFromShellFixed() else {
+            Issue.record("solidFromShellFixed returned nil")
+            return
+        }
+        // The hollow body's outer shell must still be a body, and its cavity must not be.
+        // Without the guard the outer shell is dropped and the cavity comes back instead,
+        // which shows up as the 8000 mm³ body going missing.
+        let volumes = bodies.solids.compactMap(\.volume)
+        #expect(volumes.contains { abs($0 - 8000.0) < 1e-6 },
+                "the hollow body's outer shell was dropped; volumes: \(volumes)")
+        #expect(!volumes.contains { abs($0 - 1000.0) < 1e-6 },
+                "the cavity was emitted as a positive body; volumes: \(volumes)")
+    }
+
     // MARK: - The issue's measured table
 
     /// The exact table from the issue: every column read 1 solid / 6 faces / 1000.0 for

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,13 +31,24 @@ driven one solid at a time. **A compound result is not a new return category:** 
 already hands one back when a single solid's shells resolve into several bodies, so callers that
 handled `fixSolid()` correctly for a multiconnex solid already handle this.
 
-`solidFromShellFixed()` builds one solid per **body-bounding** shell: each solid's outer shell, every
-shell belonging to no solid (the usual shape of sewing output), and any further shell of a solid that
-lies outside it — a disjoint sibling body in a multiconnex solid. A solid's *cavity* shells are
+`solidFromShellFixed()` builds one solid per **body-bounding** shell: each solid's enclosing shell,
+every shell belonging to no solid (the usual shape of sewing output), and any further shell of a solid
+that lies outside it — a disjoint sibling body in a multiconnex solid. A solid's *cavity* shells are
 skipped: a hole is not a body, and building one as a positive solid would return a compound whose
 volume double-counts the part (8000 + 1000 for a 7000 mm³ hollow box). Enclosure is decided with
 `BRepClass3d_SolidClassifier`, not by shell orientation — measured, both a hollow solid's outer and
 cavity shells are `FORWARD`, so orientation carries no signal here.
+
+The enclosing shell is picked by bounding-box extent rather than `BRepClass3d::OuterShell`: only the
+enclosing shell can have the largest box, and unlike `OuterShell` that does not depend on the input
+being correctly oriented, which a healing entry point cannot assume. Measured, the two agree on every
+well-formed input; on an **inside-out** hollow solid `OuterShell` names the *cavity*, which would emit
+it as a second overlapping body (9000 mm³ for a 7000 mm³ part).
+
+Neither call can drop a body by any path: a solid `ShapeFix_Solid` fails to heal comes back unhealed
+rather than vanishing, `Shape()`'s compound is flattened by direct children so a shell it could not
+close is kept rather than skipped by a `TopAbs_SOLID` explorer, and a compound holding the same free
+shell twice yields one solid, not two.
 
 > **Behaviour change for consumers:** these two calls now return a **compound** where they previously
 > returned one arbitrary body's solid, for multi-body input only. Single-body input is untouched, down
@@ -56,6 +67,12 @@ for callers with mixed content to preserve.
 `OCCTShapeFixSolid` also gains the `if (!shape) return nullptr;` guard its siblings in the file use.
 Not reachable through the Swift API, but a null deref is an uncatchable SIGSEGV rather than something
 the enclosing `try` would catch.
+
+**Documentation correction:** `solidFromShellFixed()` was previously described, before and after this
+change, as returning `nil` when a shell does not close. Reading `ShapeFix_Solid.cxx`, `SolidFromShell`
+does `B.MakeSolid(solid); B.Add(solid, sh);` unconditionally before any classification and returns
+that even on its exception path — it never returns a null solid and never rejects an open shell. The
+only `nil` is "no shells at all"; an open shell comes back as a solid that is not closed.
 
 Bridge-only (no OCCT kernel change, no `OCCT.xcframework` rebuild). Operation count is unchanged at
 4,258 — behaviour and documentation only. Source comments, `OCCTBridge.h` and the generated reference

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,14 @@ volume double-counts the part (8000 + 1000 for a 7000 mm³ hollow box). Enclosur
 cavity shells are `FORWARD`, so orientation carries no signal here; each reference is read once with
 `PerformInfinitePoint` so an inside-out shell flips the sense rather than the answer.
 
+An **open** shell is skipped in the reference role (`BRep_Tool::IsClosed`, which for a shell is a real
+edge-pairing check rather than the `Closed()` flag, so a genuine cavity shell still qualifies). Open
+shells reach this code by contract — the same call accepts them and returns them as unclosed solids —
+and under parity every shell is a reference, so one that cannot enclose anything would still add a
+spurious ±1 to the others. Measured on `{A_outer, A_cavity, openShell wrapping both}`: without the
+guard the outer shell is **dropped outright** (enclosed count 1, odd) and the cavity emitted as a
+positive body.
+
 Parity is used because **every rule that picks one reference shell and calls everything outside it a
 body is wrong on some real input**, and the two obvious choices fail on different ones. Measured, on
 one solid holding `{A_outer 8000, A_cavity 1000, B_outer 27000}`: picking the widest shell emits
@@ -58,8 +66,10 @@ shell twice yields one solid, not two.
 > **Reading the result of `fixSolid()`:** because no body is dropped, a result body is not always a
 > solid. `ShapeFix_Solid` hands back a shell it could not close, and a solid it fails to heal comes
 > back unhealed. `result.solids.count` can therefore be lower than the number of input bodies with
-> nothing lost — check `subShapes(ofType: .shell)` or `isValid` rather than reading a short `solids`
-> count as a body having vanished.
+> nothing lost. Spot an unclosed body by walking the result's **direct children**
+> (`child(at:)` over `nbChildren`) — **not** `subShapes(ofType: .shell)`, which maps at every depth
+> and so reports one shell per *healthy* solid as well, making it useless as a failure signal. A body
+> that came back unhealed is still a solid; use `isValid` for that.
 
 > **Behaviour change for consumers:** these two calls now return a **compound** where they previously
 > returned one arbitrary body's solid, for multi-body input only. Single-body input is untouched, down

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,52 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### Unreleased: fix — `Shape.fixSolid()`/`solidFromShellFixed()` healed only the first body (#442)
+
+> Version and date are deliberately unset: this entry is written on a branch, and the next patch
+> number is not this PR's to claim. Whoever tags stamps it then.
+
+`Shape.fixSolid()` and `Shape.solidFromShellFixed()` healed the **first** solid (respectively the
+first shell) a `TopExp_Explorer` yielded and discarded every other body without a signal. The return
+was a well-formed `Shape` that looked like a healed version of the input, so nothing downstream could
+tell that most of the part was gone: a 2000 mm³ two-box compound came back as a 1000 mm³ single solid.
+
+Both now cover every body. `ShapeFix_Solid` cannot be handed a compound — its constructor and `Init`
+take a `TopoDS_Solid`, and `TopoDS::Solid` throws on anything else — so multi-body input has to be
+driven one solid at a time. **A compound result is not a new return category:** `ShapeFix_Solid::Shape()`
+already hands one back when a single solid's shells resolve into several bodies, so callers that
+handled `fixSolid()` correctly for a multiconnex solid already handle this.
+
+`solidFromShellFixed()` builds one solid per **body-bounding** shell: each solid's outer shell, every
+shell belonging to no solid (the usual shape of sewing output), and any further shell of a solid that
+lies outside it — a disjoint sibling body in a multiconnex solid. A solid's *cavity* shells are
+skipped: a hole is not a body, and building one as a positive solid would return a compound whose
+volume double-counts the part (8000 + 1000 for a 7000 mm³ hollow box). Enclosure is decided with
+`BRepClass3d_SolidClassifier`, not by shell orientation — measured, both a hollow solid's outer and
+cavity shells are `FORWARD`, so orientation carries no signal here.
+
+> **Behaviour change for consumers:** these two calls now return a **compound** where they previously
+> returned one arbitrary body's solid, for multi-body input only. Single-body input is untouched, down
+> to the returned shape type. A caller that assumed `.solid` unconditionally should read `.solids`
+> instead; a caller that wants one specific body should pick it before healing.
+
+Unlike #439, no doc comment was being violated here — the Swift docs were one-liners that said nothing
+about multi-body input either way — so this is a design decision rather than a contract fix. Returning
+`nil` for multi-body input (what #439 did for `outerShell`) was rejected: `outerShell` answers a
+question about *one* body and has no meaningful answer for several, whereas refusing to heal a
+two-body part is a capability loss with no upside. `ShapeFix_Shape` was checked as the "call the other
+class" alternative the issue suggested — it does handle a multi-solid compound correctly (2 solids,
+2000 mm³) and is already wrapped as `Shape.fixed(tolerance:…)`, now cross-referenced from `fixSolid()`
+for callers with mixed content to preserve.
+
+`OCCTShapeFixSolid` also gains the `if (!shape) return nullptr;` guard its siblings in the file use.
+Not reachable through the Swift API, but a null deref is an uncatchable SIGSEGV rather than something
+the enclosing `try` would catch.
+
+Bridge-only (no OCCT kernel change, no `OCCT.xcframework` rebuild). Operation count is unchanged at
+4,258 — behaviour and documentation only. Source comments, `OCCTBridge.h` and the generated reference
+(`docs/reference/Document-OCAF-Attributes.md`) all state the same rule.
+
 ### Unreleased: fix — `Shape.outerShell` answered for the wrong body on a multi-solid compound (#439)
 
 > Version and date are deliberately unset: this entry is written on a branch, and the next patch

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,24 +31,35 @@ driven one solid at a time. **A compound result is not a new return category:** 
 already hands one back when a single solid's shells resolve into several bodies, so callers that
 handled `fixSolid()` correctly for a multiconnex solid already handle this.
 
-`solidFromShellFixed()` builds one solid per **body-bounding** shell: each solid's enclosing shell,
-every shell belonging to no solid (the usual shape of sewing output), and any further shell of a solid
-that lies outside it — a disjoint sibling body in a multiconnex solid. A solid's *cavity* shells are
-skipped: a hole is not a body, and building one as a positive solid would return a compound whose
+`solidFromShellFixed()` builds one solid per **body-bounding** shell, decided by **enclosure parity**:
+within each solid, a shell bounds a body iff an *even* number of the other shells enclose it, plus
+every shell belonging to no solid at all (the usual shape of sewing output). A solid's *cavity* shells
+are skipped: a hole is not a body, and building one as a positive solid would return a compound whose
 volume double-counts the part (8000 + 1000 for a 7000 mm³ hollow box). Enclosure is decided with
 `BRepClass3d_SolidClassifier`, not by shell orientation — measured, both a hollow solid's outer and
-cavity shells are `FORWARD`, so orientation carries no signal here.
+cavity shells are `FORWARD`, so orientation carries no signal here; each reference is read once with
+`PerformInfinitePoint` so an inside-out shell flips the sense rather than the answer.
 
-The enclosing shell is picked by bounding-box extent rather than `BRepClass3d::OuterShell`: only the
-enclosing shell can have the largest box, and unlike `OuterShell` that does not depend on the input
-being correctly oriented, which a healing entry point cannot assume. Measured, the two agree on every
-well-formed input; on an **inside-out** hollow solid `OuterShell` names the *cavity*, which would emit
-it as a second overlapping body (9000 mm³ for a 7000 mm³ part).
+Parity is used because **every rule that picks one reference shell and calls everything outside it a
+body is wrong on some real input**, and the two obvious choices fail on different ones. Measured, on
+one solid holding `{A_outer 8000, A_cavity 1000, B_outer 27000}`: picking the widest shell emits
+`A_cavity` as a positive body (36000 mm³ against a correct 35000), because it is outside *B*; picking
+`BRepClass3d::OuterShell` gets that case right but names the *cavity* on an inside-out hollow solid,
+emitting the true outer shell as a second overlapping body (9000 mm³ for a 7000 mm³ part). Parity
+assumes no single enclosing shell and needs no orientation, and it also reads a body nested inside
+another body's cavity correctly — enclosed twice, so even, so a body (8064 mm³, measured). It is
+O(N²) classifications in the shells of one solid, where N is 1-3 on any real input and 1 is free.
 
 Neither call can drop a body by any path: a solid `ShapeFix_Solid` fails to heal comes back unhealed
 rather than vanishing, `Shape()`'s compound is flattened by direct children so a shell it could not
 close is kept rather than skipped by a `TopAbs_SOLID` explorer, and a compound holding the same free
 shell twice yields one solid, not two.
+
+> **Reading the result of `fixSolid()`:** because no body is dropped, a result body is not always a
+> solid. `ShapeFix_Solid` hands back a shell it could not close, and a solid it fails to heal comes
+> back unhealed. `result.solids.count` can therefore be lower than the number of input bodies with
+> nothing lost — check `subShapes(ofType: .shell)` or `isValid` rather than reading a short `solids`
+> count as a body having vanished.
 
 > **Behaviour change for consumers:** these two calls now return a **compound** where they previously
 > returned one arbitrary body's solid, for multi-body input only. Single-body input is untouched, down

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -849,10 +849,15 @@ single body comes back as a solid, several as a compound in exploration order.
 A solid's **cavity** shells are deliberately skipped: a hole is not a body, and building it as a
 positive solid would yield a compound whose volume double-counts the part. So a hollow solid produces
 one solid bounded by its outer shell, with the cavity filled. To rebuild a solid that keeps its
-cavities, use [`Shape.solidFromShells(_:)`](Shape-Features.md) with the outer shell first.
+cavities, use [`Shape.solidFromShells(_:)`](Shape-Measurement.md#solidfromshells_) with the outer
+shell first.
 
-- **Returns:** A solid, a compound of solids for multi-body input, or `nil` if the receiver holds no
-  shell or none of them closes.
+> An **open** shell is not rejected. `ShapeFix_Solid::SolidFromShell` builds its solid before
+> classifying anything and never returns a null one, so a shell with gaps comes back as a solid that
+> is not closed rather than as `nil`. Check `isValid` or sew first if the input may be open.
+
+- **Returns:** A solid, a compound of solids for multi-body input, or `nil` only if the receiver
+  holds no shell at all.
 - **OCCT:** `ShapeFix_Solid::SolidFromShell`.
 - **Example:**
   ```swift

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -804,13 +804,31 @@ Fix topology and orientation problems in a solid shape.
 public func fixSolid() -> Shape?
 ```
 
-- **Returns:** The repaired solid, or `nil` on failure.
+**Every** solid in the receiver is healed, not just the first (#442): a single-body input comes back
+as a solid, a multi-body one as a compound of the healed solids in exploration order. A compound
+result is not new to this call — `ShapeFix_Solid` already returns one when a single solid's shells
+resolve into several bodies.
+
+Only solids are carried over. Loose shells, faces or wires sitting alongside them in a compound are
+dropped, and an input holding no solid at all returns `nil`. To heal a whole shape of mixed content
+instead, use [`fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`](Shape-Features.md#fixedtolerancefixsolidfixshellfixfacefixwire),
+which wraps `ShapeFix_Shape` and preserves everything it is given.
+
+- **Returns:** The repaired solid, a compound of repaired solids for multi-body input, or `nil` if
+  the receiver holds no solid.
 - **OCCT:** `ShapeFix_Solid::Perform`.
 - **Example:**
   ```swift
   if let solid = importedShape.fixSolid() {
       // solid.isValid == true
   }
+
+  // Multi-body input: both bodies are healed, not just the first.
+  let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
+  let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)!
+  let healed = Shape.compound([a, b])!.fixSolid()!
+  print(healed.solids.count)   // 2
+  print(healed.volume!)        // 2000.0
   ```
 
 ---
@@ -823,8 +841,26 @@ Create a closed solid from a shell, using `ShapeFix_Solid` to orient and close t
 public func solidFromShellFixed() -> Shape?
 ```
 
-- **Returns:** A solid shape, or `nil` if the shell cannot be closed.
+One solid is built per *body-bounding* shell, not just the first shell found (#442): each solid's
+outer shell, plus every shell that belongs to no solid (the usual shape of sewing output), plus any
+further shell of a solid that lies outside it — a disjoint sibling body in a multiconnex solid. A
+single body comes back as a solid, several as a compound in exploration order.
+
+A solid's **cavity** shells are deliberately skipped: a hole is not a body, and building it as a
+positive solid would yield a compound whose volume double-counts the part. So a hollow solid produces
+one solid bounded by its outer shell, with the cavity filled. To rebuild a solid that keeps its
+cavities, use [`Shape.solidFromShells(_:)`](Shape-Features.md) with the outer shell first.
+
+- **Returns:** A solid, a compound of solids for multi-body input, or `nil` if the receiver holds no
+  shell or none of them closes.
 - **OCCT:** `ShapeFix_Solid::SolidFromShell`.
+- **Example:**
+  ```swift
+  // Two sewn bodies in one compound — one solid per shell.
+  let quilt = Shape.compound([shellA, shellB])!
+  let solids = quilt.solidFromShellFixed()!
+  print(solids.solids.count)   // 2
+  ```
 
 ---
 

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -805,17 +805,24 @@ public func fixSolid() -> Shape?
 ```
 
 **Every** solid in the receiver is healed, not just the first (#442): a single-body input comes back
-as a solid, a multi-body one as a compound of the healed solids in exploration order. A compound
-result is not new to this call — `ShapeFix_Solid` already returns one when a single solid's shells
-resolve into several bodies.
+as a solid, a multi-body one as a compound of one result per input body, in exploration order. A
+compound result is not new to this call — `ShapeFix_Solid` already returns one when a single solid's
+shells resolve into several bodies.
 
-Only solids are carried over. Loose shells, faces or wires sitting alongside them in a compound are
-dropped, and an input holding no solid at all returns `nil`. To heal a whole shape of mixed content
-instead, use [`fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`](Shape-Features.md#fixedtolerancefixsolidfixshellfixfacefixwire),
+Only the receiver's **solids** are visited. Loose shells, faces or wires sitting alongside them in a
+compound are not carried over, and an input holding no solid at all returns `nil`. To heal a whole
+shape of mixed content instead, use [`fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`](Shape-Features.md#fixedtolerancefixsolidfixshellfixfacefixwire),
 which wraps `ShapeFix_Shape` and preserves everything it is given.
 
-- **Returns:** The repaired solid, a compound of repaired solids for multi-body input, or `nil` if
-  the receiver holds no solid.
+> **A result body is usually a healed solid, but not always** — and no body is ever dropped to make
+> that true. `ShapeFix_Solid` hands back a **shell** when it cannot close one into a solid, and a
+> solid it fails to heal outright is returned **unhealed** rather than discarded. So
+> `result.solids.count` can be lower than the number of input bodies even though nothing was lost;
+> check `result.subShapes(ofType: .shell)` or `isValid` if that distinction matters, rather than
+> reading a short `solids` count as a body having vanished.
+
+- **Returns:** The repaired body, a compound of one result per input body for multi-body input, or
+  `nil` if the receiver holds no solid.
 - **OCCT:** `ShapeFix_Solid::Perform`.
 - **Example:**
   ```swift
@@ -841,10 +848,10 @@ Create a closed solid from a shell, using `ShapeFix_Solid` to orient and close t
 public func solidFromShellFixed() -> Shape?
 ```
 
-One solid is built per *body-bounding* shell, not just the first shell found (#442): each solid's
-outer shell, plus every shell that belongs to no solid (the usual shape of sewing output), plus any
-further shell of a solid that lies outside it — a disjoint sibling body in a multiconnex solid. A
-single body comes back as a solid, several as a compound in exploration order.
+One solid is built per *body-bounding* shell, not just the first shell found (#442): within each
+solid, every shell that an **even** number of the other shells enclose, plus every shell that belongs
+to no solid (the usual shape of sewing output). A single body comes back as a solid, several as a
+compound in exploration order.
 
 A solid's **cavity** shells are deliberately skipped: a hole is not a body, and building it as a
 positive solid would yield a compound whose volume double-counts the part. So a hollow solid produces

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -817,9 +817,21 @@ which wraps `ShapeFix_Shape` and preserves everything it is given.
 > **A result body is usually a healed solid, but not always** — and no body is ever dropped to make
 > that true. `ShapeFix_Solid` hands back a **shell** when it cannot close one into a solid, and a
 > solid it fails to heal outright is returned **unhealed** rather than discarded. So
-> `result.solids.count` can be lower than the number of input bodies even though nothing was lost;
-> check `result.subShapes(ofType: .shell)` or `isValid` if that distinction matters, rather than
-> reading a short `solids` count as a body having vanished.
+> `result.solids.count` can be lower than the number of input bodies even though nothing was lost.
+
+To spot an unclosed body, walk the result's **direct children**. Do not use
+`subShapes(ofType: .shell)`: it maps at every depth, so it reports one shell for every *healthy*
+solid too — a compound of two healed solids has two shells, and a single healed solid has one.
+
+```swift
+let healed = part.fixSolid()!
+let bodies = (0..<healed.nbChildren).compactMap { healed.child(at: $0) }
+let unclosed = bodies.filter { $0.shapeType == .shell }
+```
+
+When a single body came back, the result is that body rather than a compound, so
+`healed.shapeType == .shell` answers it directly. A body that came back *unhealed* is still a solid —
+use `isValid` for that.
 
 - **Returns:** The repaired body, a compound of one result per input body for multi-body input, or
   `nil` if the receiver holds no solid.


### PR DESCRIPTION
Closes #442.

## The defect

`Shape.fixSolid()` and `Shape.solidFromShellFixed()` healed the **first** solid (respectively the
first shell) a `TopExp_Explorer` yielded and discarded every other body without a signal. The return
was a well-formed `Shape` that looked like a healed version of the input, so nothing downstream could
tell that most of the part was gone. The issue's own reproducer, on the pre-fix build:

| call | solids | faces | volume |
| --- | --- | --- | --- |
| input compound | 2 | 12 | 2000.0 |
| `fixSolid()` | 1 | 6 | **1000.0** |
| `solidFromShellFixed()` | 1 | 6 | **1000.0** |

## Settling the design question

#442 listed three defensible answers and did not pick one. Ground truth (`/tmp/occt_v442_test.mm`,
three programs against the pinned kernel) decided it:

- **`ShapeFix_Solid` cannot take a compound.** Its constructor and `Init` want a `TopoDS_Solid`, and
  `TopoDS::Solid` throws on anything else. So "call the other class" — the possibility the issue
  flagged as worth checking first — is not available for this tool; multi-body input has to be driven
  one solid at a time.
- **A compound result is not a new return category.** `ShapeFix_Solid::Shape()` already returns one
  when a single solid's shells resolve into several bodies (measured: one solid holding two disjoint
  shells comes back as a 2-solid compound). Callers that handled `fixSolid()` correctly before
  already handle this, which is what makes option 2 cheap.
- **`ShapeFix_Shape` does handle a multi-solid compound correctly** (2 solids, 2000 mm³) — it is
  already wrapped as `Shape.fixed(tolerance:…)`, and `fixSolid()` now cross-references it for callers
  with mixed content to preserve, since only solids survive `fixSolid()`.

Returning `nil` for multi-body input, which is what #439 did for `outerShell`, was rejected:
`outerShell` answers a question about *one* body and has no meaningful answer for several, whereas
refusing to heal a two-body part is a capability loss with no upside. That asymmetry is why #442 was
split out of #441 rather than folded into it.

## The shell-selection rule

`solidFromShellFixed()` builds one solid per **body-bounding** shell: each solid's outer shell, every
shell belonging to no solid (the usual shape of sewing output), and any further shell of a solid that
lies **outside** it — a disjoint sibling body in a multiconnex solid.

Two naive rules were measured and rejected before landing this one:

- *Every shell the explorer yields* turns a hollow solid's cavity into a second, overlapping positive
  body — a compound reading 9000 mm³ for a 7000 mm³ part.
- *Outer shell per solid* drops a body on a multiconnex solid, i.e. reintroduces the exact first-of-N
  defect this issue is about.

Cavity shells are therefore skipped, and enclosure is decided with `BRepClass3d_SolidClassifier`
rather than shell orientation — measured, **both** a hollow solid's outer and cavity shells are
`FORWARD`, so orientation carries no signal here. Ground truth over the whole input space:

```
single solid           in: shells=1 solids=1  ->  SOLID    1 solid   1000.0
bare shell             in: shells=1 solids=0  ->  SOLID    1 solid   1000.0
2-box compound         in: shells=2 solids=2  ->  COMPOUND 2 solids  2000.0
hollow solid           in: shells=2 solids=1  ->  SOLID    1 solid   8000.0   (cavity skipped)
multiconnex solid      in: shells=2 solids=1  ->  COMPOUND 2 solids  2000.0
2 free shells          in: shells=2 solids=0  ->  COMPOUND 2 solids  2000.0
solid + free shell     in: shells=2 solids=1  ->  COMPOUND 2 solids  2000.0
no shells at all       in: shells=0 solids=0  ->  NULL
```

## Behaviour change

Both calls now return a **compound** where they previously returned one arbitrary body's solid, for
multi-body input only. Single-body input is untouched, down to the returned shape type — pinned by
tests, not assumed. A caller that assumed `.solid` unconditionally should read `.solids`; a caller
that wants one specific body should pick it before healing.

Also fixed: `OCCTShapeFixSolid` gains the `if (!shape) return nullptr;` guard its siblings in the
file use (issue's secondary note). Not reachable through the Swift API, but a null deref is an
uncatchable SIGSEGV rather than something the enclosing `try` would catch.

## Verification

New suite `Issue442FixSolidMultiBody` (10 tests). **Four fail on the pre-fix bridge** with exactly
the issue's numbers — 1 solid / 6 faces / 1000.0 against a 2 solid / 12 face / 2000.0 input, bounds
stopping at x=10 instead of x=30 — confirmed by rebuilding against the pre-fix `OCCTBridge_Healing.mm`
and re-running. The other six pin the single-body, hollow-solid, free-shell and no-solid behaviour
that must **not** change.

Full `swift test`: **4462 tests in 1290 suites, all passing.**

Bridge-only — no OCCT kernel change, no `OCCT.xcframework` rebuild. Operation count unchanged at
4,258 (`Scripts/count-operations.py`): this is behaviour and documentation only.

## The audit note

#442 asked for the first-of-N idiom to be grepped for across the bridge before closing. Done, and
filed as **#443**: 23 candidate sites, 8 false positives, 5 where "first" is the documented contract,
10 undocumented silent picks. Three are confirmed by measurement to lose whole bodies —
`Shape.solid(from:)`, `Shape.upgraded()`, and `AssemblyNode.setTriangulationFromShape` (which stores
one face's triangulation for any input, measured at 4 nodes for both a 6-face box and a 12-face
compound). `Shape.solid(from:)` is the sharpest: its doc names sewing output as the expected input,
and after this PR the two sibling entry points disagree on it — `sewn.solidFromShellFixed()` gives
2 solids / 2000 mm³ where `Shape.solid(from: sewn)` gives 1 / 1000. Left out of this PR deliberately;
each is a separate contract decision, the same reason #442 was split out of #441.

## Docs

Swift doc comments (both now carry a runnable ```swift``` snippet), `OCCTBridge.h`, the generated
reference (`docs/reference/Document-OCAF-Attributes.md`) and `docs/CHANGELOG.md` all state the same
rule. The CHANGELOG entry is deliberately left unversioned for whoever tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
