### PR TITLE
fix(#443): three more first-of-N explorer sites dropped most of their input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,258 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,260 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -7588,6 +7588,23 @@ int32_t OCCTDocumentTriangulationNbTriangles(OCCTDocumentRef doc, int64_t labelI
 /// Get the deflection of a triangulation attribute.
 double OCCTDocumentTriangulationDeflection(OCCTDocumentRef doc, int64_t labelId);
 
+/// Read one node of a triangulation attribute, in the coordinate frame it was stored in.
+/// @param index 1-based node index, as Poly_Triangulation numbers them.
+/// @param outXYZ receives x, y, z. Untouched when the call returns false.
+/// @return false if the label has no triangulation attribute or the index is out of range.
+bool OCCTDocumentTriangulationNode(OCCTDocumentRef doc, int64_t labelId, int32_t index,
+                                   double* outXYZ);
+
+/// Read one node normal of a triangulation attribute, in the frame it was stored in.
+/// Node normals exist only when the meshed faces carried them; BRepMesh_IncrementalMesh does
+/// not produce any, so this is false for anything meshed from B-Rep and true for e.g. an
+/// imported glTF mesh.
+/// @param index 1-based node index.
+/// @param outXYZ receives the normal. Untouched when the call returns false.
+/// @return false if there is no attribute, no node normals, or the index is out of range.
+bool OCCTDocumentTriangulationNormal(OCCTDocumentRef doc, int64_t labelId, int32_t index,
+                                     double* outXYZ);
+
 // MARK: - TDataXtd Point/Axis/Plane Attributes (v0.56.0)
 
 /// Set a point attribute on a label.

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1766,9 +1766,10 @@ OCCTShapeRef OCCTShapeCreateFaceFromWire(OCCTWireRef wire, bool planar);
 /// @return Face shape with holes, or NULL on failure
 OCCTShapeRef OCCTShapeCreateFaceWithHoles(OCCTWireRef outer, const OCCTWireRef* holes, int32_t holeCount);
 
-/// Create a solid from a closed shell
-/// @param shell Shell shape (must be closed)
-/// @return Solid shape, or NULL on failure
+/// Create a solid from every body-bounding shell of a shape, not just the first (#443).
+/// Cavity shells are skipped; see occtBodyBoundingShells in OCCTBridge_Internal.h.
+/// @param shell Shell shape (must be closed), or any shape holding shells
+/// @return One solid, a compound of solids for multi-body input, or NULL if there is no shell
 OCCTShapeRef OCCTShapeCreateSolidFromShell(OCCTShapeRef shell);
 
 /// Sew multiple faces/shapes into a shell or solid
@@ -2647,7 +2648,8 @@ OCCTShapeRef OCCTShapeConvertToBSpline(OCCTShapeRef shape);
 /// Sew a single shape (reconnect disconnected faces)
 OCCTShapeRef OCCTShapeSewSingle(OCCTShapeRef shape, double tolerance);
 
-/// Upgrade shape: sew + make solid + heal (pipeline)
+/// Upgrade shape: sew + make solid + heal (pipeline). One solid per body-bounding shell of
+/// the sewn result, so multi-body input stays multi-body (#443).
 OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance);
 
 
@@ -4869,7 +4871,9 @@ OCCTBooleanHistoryRef _Nullable OCCTShapeHealWithHistory(OCCTShapeRef _Nonnull s
                                                             OCCTShapeRef _Nullable * _Nullable outResult);
 
 /// Create a solid from a closed shell (BRepBuilderAPI_MakeSolid + ShapeFix_Solid
-/// orientation fix), with full history.
+/// orientation fix), with full history. Same body selection as
+/// OCCTShapeCreateSolidFromShell; one shared ReShape context, so the single history
+/// covers every body (#443).
 OCCTBooleanHistoryRef _Nullable OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef _Nonnull shell,
                                                                            OCCTShapeRef _Nullable * _Nullable outResult);
 
@@ -7570,7 +7574,9 @@ bool OCCTDocumentHasGeometryAttr(OCCTDocumentRef doc, int64_t labelId);
 
 // MARK: - TDataXtd Triangulation Attribute (v0.56.0)
 
-/// Set a triangulation attribute on a label by meshing a shape.
+/// Set a triangulation attribute on a label by meshing a shape. Stores EVERY face's
+/// triangulation merged into one Poly_Triangulation, not just the first face's (#443).
+/// Returns false if the shape has no face, or if nothing in it meshed.
 bool OCCTDocumentSetTriangulationFromShape(OCCTDocumentRef doc, int64_t labelId, OCCTShapeRef shape, double deflection);
 
 /// Get the number of nodes in a triangulation attribute.

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -2144,9 +2144,25 @@ bool OCCTDocumentHasGeometryAttr(OCCTDocumentRef doc, int64_t labelId) {
 // Merge every meshed face of `shape` into one triangulation, in the coordinate system the
 // shape itself is expressed in: each face's per-face triangulation is stored in its own
 // TopLoc_Location, so the nodes are transformed on the way in, and a REVERSED face has its
-// winding (and node normals) flipped so the merged result is consistently outward, by the
-// same rules OCCTShapeCreateMesh applies. UV nodes are dropped: they index per-face parameter
-// spaces that no longer mean anything once the faces are pooled.
+// winding flipped so the merged result is consistently outward. UV nodes are dropped: they
+// index per-face parameter spaces that no longer mean anything once the faces are pooled.
+//
+// NOTE the frame. Before #443 this function fetched the location and DISCARDED it, storing
+// one face's nodes in that face's own local frame. For a located face (an assembly component,
+// anything from Shape.transformed()) the stored numbers therefore change, independently of
+// the "every face, not the first" fix. The shape's frame is the right one for an attribute
+// nothing else carries a location for, but it is a behaviour change; see the CHANGELOG.
+//
+// Node normals are handled MORE strictly than OCCTShapeCreateMesh, which pushes
+// triangulation->Normal(i) raw with neither the location transform nor the reversal
+// (OCCTBridge_Mesh.mm); only its winding swap matches this. That divergence means
+// Mesh.normals and this attribute disagree for a located or reversed face; settling which is
+// wrong is Shape.mesh()'s question, not this function's.
+//
+// The normal branch never fires on the ordinary path: BRepMesh_IncrementalMesh does not
+// populate node normals (measured, 0 of 6 box faces and 0 of 1 sphere face; there is no
+// SetNormal anywhere under occt-src TKMesh). It fires only for a face that arrived carrying
+// a normal-bearing triangulation from elsewhere, which glTF import does produce.
 //
 // Returns a null handle when the shape has no face, or when nothing in it meshed.
 static Handle(Poly_Triangulation) occtMergedTriangulation(const TopoDS_Shape& shape,
@@ -2241,6 +2257,47 @@ int32_t OCCTDocumentTriangulationNbTriangles(OCCTDocumentRef doc, int64_t labelI
         if (!label.FindAttribute(TDataXtd_Triangulation::GetID(), attr)) return 0;
         return attr->NbTriangles();
     } catch (...) { return 0; }
+}
+
+// Reading a stored node back was not possible before #443: the attribute exposed only its
+// counts and deflection, so nothing in the Swift API could see the coordinates it holds. That
+// is part of why the first-face bug, and the frame it stored in, went unnoticed.
+bool OCCTDocumentTriangulationNode(OCCTDocumentRef doc, int64_t labelId, int32_t index,
+                                   double* outXYZ) {
+    if (!doc || doc->doc.IsNull() || !outXYZ) return false;
+    try {
+        TDF_Label label = doc->getLabel(labelId);
+        if (label.IsNull()) return false;
+        Handle(TDataXtd_Triangulation) attr;
+        if (!label.FindAttribute(TDataXtd_Triangulation::GetID(), attr)) return false;
+        Handle(Poly_Triangulation) tri = attr->Get();
+        if (tri.IsNull() || index < 1 || index > tri->NbNodes()) return false;
+        const gp_Pnt p = tri->Node(index);
+        outXYZ[0] = p.X();
+        outXYZ[1] = p.Y();
+        outXYZ[2] = p.Z();
+        return true;
+    } catch (...) { return false; }
+}
+
+// HasNormals() first: Poly_Triangulation::Normal reads myNormals unconditionally, and that
+// array is empty for anything BRepMesh produced.
+bool OCCTDocumentTriangulationNormal(OCCTDocumentRef doc, int64_t labelId, int32_t index,
+                                     double* outXYZ) {
+    if (!doc || doc->doc.IsNull() || !outXYZ) return false;
+    try {
+        TDF_Label label = doc->getLabel(labelId);
+        if (label.IsNull()) return false;
+        Handle(TDataXtd_Triangulation) attr;
+        if (!label.FindAttribute(TDataXtd_Triangulation::GetID(), attr)) return false;
+        Handle(Poly_Triangulation) tri = attr->Get();
+        if (tri.IsNull() || !tri->HasNormals() || index < 1 || index > tri->NbNodes()) return false;
+        const gp_Dir n = tri->Normal(index);
+        outXYZ[0] = n.X();
+        outXYZ[1] = n.Y();
+        outXYZ[2] = n.Z();
+        return true;
+    } catch (...) { return false; }
 }
 
 double OCCTDocumentTriangulationDeflection(OCCTDocumentRef doc, int64_t labelId) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -18,6 +18,8 @@
 
 // === Area-specific OCCT headers ===
 
+#include <algorithm>
+
 #include <STEPCAFControl_Reader.hxx>
 #include <STEPCAFControl_Writer.hxx>
 #include <STEPControl_StepModelType.hxx>
@@ -2139,21 +2141,79 @@ bool OCCTDocumentHasGeometryAttr(OCCTDocumentRef doc, int64_t labelId) {
 
 // MARK: - TDataXtd Triangulation Attribute (v0.56.0)
 
+// Merge every meshed face of `shape` into one triangulation, in the coordinate system the
+// shape itself is expressed in: each face's per-face triangulation is stored in its own
+// TopLoc_Location, so the nodes are transformed on the way in, and a REVERSED face has its
+// winding (and node normals) flipped so the merged result is consistently outward, by the
+// same rules OCCTShapeCreateMesh applies. UV nodes are dropped: they index per-face parameter
+// spaces that no longer mean anything once the faces are pooled.
+//
+// Returns a null handle when the shape has no face, or when nothing in it meshed.
+static Handle(Poly_Triangulation) occtMergedTriangulation(const TopoDS_Shape& shape,
+                                                          double deflection) {
+    // The constructor meshes; no Perform() call, matching what this function did before.
+    BRepMesh_IncrementalMesh mesher(shape, deflection);
+
+    int nbNodes = 0, nbTriangles = 0;
+    bool hasNormals = true;
+    double worstDeflection = 0.0;
+    for (TopExp_Explorer exp(shape, TopAbs_FACE); exp.More(); exp.Next()) {
+        TopLoc_Location loc;
+        Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(TopoDS::Face(exp.Current()), loc);
+        if (tri.IsNull()) continue;
+        nbNodes += tri->NbNodes();
+        nbTriangles += tri->NbTriangles();
+        // Normals only survive the merge if every contributing face carries them; a
+        // partially-filled normal array would read as valid and be wrong on the rest.
+        if (!tri->HasNormals()) hasNormals = false;
+        // Each face records the deflection it actually achieved, so the merged mesh's is
+        // the worst of them. A hand-built Poly_Triangulation starts at 0, and a 0 here
+        // would read as "exact".
+        worstDeflection = std::max(worstDeflection, tri->Deflection());
+    }
+    if (nbNodes == 0 || nbTriangles == 0) return Handle(Poly_Triangulation)();
+
+    Handle(Poly_Triangulation) merged =
+        new Poly_Triangulation(nbNodes, nbTriangles, Standard_False, hasNormals);
+    merged->Deflection(worstDeflection);
+    int nodeAt = 0, triangleAt = 0;
+    for (TopExp_Explorer exp(shape, TopAbs_FACE); exp.More(); exp.Next()) {
+        TopoDS_Face face = TopoDS::Face(exp.Current());
+        TopLoc_Location loc;
+        Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(face, loc);
+        if (tri.IsNull()) continue;
+
+        const gp_Trsf transformation = loc.Transformation();
+        const bool reversed = (face.Orientation() == TopAbs_REVERSED);
+        const int base = nodeAt;   // 0-based offset; Poly_Triangulation indices are 1-based
+
+        for (int i = 1; i <= tri->NbNodes(); i++) {
+            merged->SetNode(++nodeAt, tri->Node(i).Transformed(transformation));
+            if (hasNormals) {
+                gp_Dir normal = tri->Normal(i);
+                if (reversed) normal.Reverse();
+                merged->SetNormal(nodeAt, normal.Transformed(transformation));
+            }
+        }
+        for (int i = 1; i <= tri->NbTriangles(); i++) {
+            int n1 = 0, n2 = 0, n3 = 0;
+            tri->Triangle(i).Get(n1, n2, n3);
+            if (reversed) std::swap(n2, n3);
+            merged->SetTriangle(++triangleAt, Poly_Triangle(base + n1, base + n2, base + n3));
+        }
+    }
+    return merged;
+}
+
+// Stores the WHOLE shape's mesh, not the first face's (#443). The attribute is what later
+// readers trust as "this label's geometry", and a 6-face box used to arrive as 4 nodes.
 bool OCCTDocumentSetTriangulationFromShape(OCCTDocumentRef doc, int64_t labelId, OCCTShapeRef shape, double deflection) {
     if (!doc || doc->doc.IsNull() || !shape) return false;
     try {
         TDF_Label label = doc->getLabel(labelId);
         if (label.IsNull()) return false;
 
-        // Mesh the shape
-        BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
-
-        // Get triangulation from first face
-        TopExp_Explorer exp(shape->shape, TopAbs_FACE);
-        if (!exp.More()) return false;
-        TopoDS_Face face = TopoDS::Face(exp.Current());
-        TopLoc_Location loc;
-        Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(face, loc);
+        Handle(Poly_Triangulation) tri = occtMergedTriangulation(shape->shape, deflection);
         if (tri.IsNull()) return false;
 
         Handle(TDataXtd_Triangulation) attr = TDataXtd_Triangulation::Set(label, tri);

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -402,6 +402,10 @@ struct OCCTMedialAxis {
     }
 };
 
+// #443 audit: first face only. A medial axis is a property of one face, and the result type
+// holds one graph, so widening this would mean a different return shape; documented on
+// MedialAxis.init(of:) rather than changed. Measured: a two-face compound returns the same
+// arcs as its first face alone.
 OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance) {
     if (!shape) return nullptr;
     try {

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3197,6 +3197,8 @@ OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, d
 
 #include <ShapeFix_Solid.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
+#include <BRepBndLib.hxx>
+#include <Bnd_Box.hxx>
 #include <Precision.hxx>
 #include <TopoDS_Iterator.hxx>
 
@@ -3274,10 +3276,25 @@ static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
 // box) and calling everything outside it a body double-counts one body's cavity as soon as a
 // *different* body is the reference. Parity also reads a body nested inside another body's
 // cavity correctly: enclosed twice, so even.
+//
+// Cost: this is O(N²) classifications in the size of ONE group. Inside a solid N is 1-3 on any
+// real input. The free-shell group is not bounded that way (sewing a raw imported mesh can
+// yield hundreds of disjoint shells), so the bounding-box pre-filter below is load-bearing
+// there, not an optimisation: without it, 200 disjoint shells cost 200 classifier loads and
+// ~40,000 ray casts. Measured at N=200, disjoint: 160 ms without the pre-filter, 0.7 ms with.
 static void occtSelectBodyShells(const std::vector<TopoDS_Shell>& shells,
                                  std::vector<TopoDS_Shell>& selected) {
     if (shells.empty()) return;
     if (shells.size() == 1) { selected.push_back(shells[0]); return; }
+
+    // Enclosure implies bounding-box containment, so a pair whose boxes do not overlap can be
+    // skipped before any ray cast, and a reference whose box overlaps nobody's need not be
+    // built at all. This only removes pairs that could never have been enclosed, so no parity
+    // verdict changes. Note this is NOT the Bnd_Box rule #442 rejected: that failed as the
+    // DECISION rule (a box can contain another whose shell does not), which is exactly why it
+    // is sound in the opposite direction, as a conservative pre-filter.
+    std::vector<Bnd_Box> boxes(shells.size());
+    for (size_t k = 0; k < shells.size(); k++) BRepBndLib::Add(shells[k], boxes[k]);
 
     std::vector<int> enclosedBy(shells.size(), 0);
     for (size_t i = 0; i < shells.size(); i++) {
@@ -3296,10 +3313,16 @@ static void occtSelectBodyShells(const std::vector<TopoDS_Shell>& shells,
         // call whose whole contract is that bodies do not vanish silently.
         if (!BRep_Tool::IsClosed(shells[i])) continue;
 
+        // Nothing this shell could possibly enclose: skip before paying for the classifier,
+        // whose constructor loads every face of the reference and builds a UB-tree.
+        bool anyCandidate = false;
+        for (size_t j = 0; j < shells.size() && !anyCandidate; j++)
+            if (i != j && !boxes[i].IsOut(boxes[j])) anyCandidate = true;
+        if (!anyCandidate) continue;
+
         // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
         // that call does sh.Free(true), a TShape-level write to state shared with the
         // caller's shape, and nothing here needs the reorientation it pays that for.
-        // One classifier per reference shell; its constructor loads every face.
         TopoDS_Solid reference;
         BRep_Builder builder;
         builder.MakeSolid(reference);
@@ -3312,9 +3335,11 @@ static void occtSelectBodyShells(const std::vector<TopoDS_Shell>& shells,
         const TopAbs_State insideState =
             (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
 
-        for (size_t j = 0; j < shells.size(); j++)
-            if (i != j && occtShellIsInsideSolid(shells[j], classifier, insideState))
-                enclosedBy[j]++;
+        for (size_t j = 0; j < shells.size(); j++) {
+            if (i == j) continue;
+            if (boxes[i].IsOut(boxes[j])) continue;   // cannot be enclosed
+            if (occtShellIsInsideSolid(shells[j], classifier, insideState)) enclosedBy[j]++;
+        }
     }
     for (size_t i = 0; i < shells.size(); i++)
         if (enclosedBy[i] % 2 == 0) selected.push_back(shells[i]);

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -1275,16 +1275,24 @@ OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance) {
         TopoDS_Shape sewedShape = sewing.SewedShape();
         if (sewedShape.IsNull()) sewedShape = shape->shape;
 
-        // Step 2: Try to create solid from shell
+        // Step 2: Try to create solids from the sewn shells. One solid per body-bounding
+        // shell, not just the first shell an explorer yields (#443). Sewing a multi-body
+        // part is the ordinary way to reach this function, and taking one shell reduced
+        // every such part to a single body. Cavity shells stay out for the reason
+        // documented on occtBodyBoundingShells.
+        //
+        // As before, this step replaces the sewn shape outright rather than merging into
+        // it, so non-shell content (a loose face sewing could not attach) does not reach
+        // the result; only the count of bodies changes here.
         TopoDS_Shape resultShape = sewedShape;
         if (sewedShape.ShapeType() != TopAbs_SOLID) {
-            TopExp_Explorer shellExp(sewedShape, TopAbs_SHELL);
-            if (shellExp.More()) {
-                BRepBuilderAPI_MakeSolid makeSolid(TopoDS::Shell(shellExp.Current()));
-                if (makeSolid.IsDone()) {
-                    resultShape = makeSolid.Solid();
-                }
+            std::vector<TopoDS_Shape> made;
+            for (const TopoDS_Shell& shell : occtBodyBoundingShells(sewedShape)) {
+                BRepBuilderAPI_MakeSolid makeSolid(shell);
+                if (makeSolid.IsDone()) made.push_back(makeSolid.Solid());
             }
+            TopoDS_Shape solids = occtSolidBodiesToShape(made);
+            if (!solids.IsNull()) resultShape = solids;
         }
 
         // Step 3: Apply shape healing
@@ -3195,7 +3203,9 @@ OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, d
 // Assemble one result shape from healed bodies: the body itself when there is exactly
 // one, a compound when there are several. ShapeFix_Solid::Shape() already returns a
 // compound for a multiconnex input, so a compound result is nothing new for callers.
-static TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies) {
+// Declared in OCCTBridge_Internal.h, because the solid-from-shell entry points in
+// OCCTBridge_Modeling.mm share it (#443).
+TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies) {
     if (bodies.empty()) return TopoDS_Shape();
     if (bodies.size() == 1) return bodies[0];
     TopoDS_Compound compound;
@@ -3257,11 +3267,67 @@ static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
     return classifier.State() == insideState;
 }
 
-// The shells that bound a body, in exploration order: within each solid, every shell an
-// even number of the others enclose, plus every shell belonging to no solid at all. A
-// solid's cavity shells are left out — a hole is not a body, and turning one into a
-// positive solid would give a compound whose volume double-counts the part.
-static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape) {
+// Append the body-bounding members of one group of shells to `selected`, in the order
+// given. Enclosure parity: a shell bounds a body iff an EVEN number of the others in its
+// group enclose it. Nothing here assumes one shell encloses all the rest, which is what both
+// simpler rules got wrong: picking a single reference (BRepClass3d::OuterShell or the widest
+// box) and calling everything outside it a body double-counts one body's cavity as soon as a
+// *different* body is the reference. Parity also reads a body nested inside another body's
+// cavity correctly: enclosed twice, so even.
+static void occtSelectBodyShells(const std::vector<TopoDS_Shell>& shells,
+                                 std::vector<TopoDS_Shell>& selected) {
+    if (shells.empty()) return;
+    if (shells.size() == 1) { selected.push_back(shells[0]); return; }
+
+    std::vector<int> enclosedBy(shells.size(), 0);
+    for (size_t i = 0; i < shells.size(); i++) {
+        // An open shell cannot enclose anything, and every shell is a reference under
+        // parity, so letting one classify would add a spurious ±1 to the others and
+        // flip their verdicts. Measured on {A_outer, A_cavity, openShell wrapping both}:
+        // without this the outer shell is DROPPED (count 1) and the cavity emitted as a
+        // body. BRep_Tool::IsClosed on a shell is a real edge-pairing check rather than
+        // the Closed() flag, so a genuine cavity shell still qualifies as a reference.
+        // Open shells reach here routinely; this function accepts them by contract.
+        //
+        // Deliberate trade-off, do not "fix" a double-count back out of this: on a body
+        // whose OUTER shell is the open one, the cavity becomes the only eligible
+        // reference, both end even, and the cavity is emitted as a positive body. Input
+        // that broken has no right answer, and an extra body beats a dropped one for a
+        // call whose whole contract is that bodies do not vanish silently.
+        if (!BRep_Tool::IsClosed(shells[i])) continue;
+
+        // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
+        // that call does sh.Free(true), a TShape-level write to state shared with the
+        // caller's shape, and nothing here needs the reorientation it pays that for.
+        // One classifier per reference shell; its constructor loads every face.
+        TopoDS_Solid reference;
+        BRep_Builder builder;
+        builder.MakeSolid(reference);
+        builder.Add(reference, shells[i]);
+
+        BRepClass3d_SolidClassifier classifier(reference);
+        classifier.PerformInfinitePoint(Precision::Confusion());
+        // A shell added as-is can bound "everything outside" instead, which flips the
+        // sense of every later classification rather than making it wrong.
+        const TopAbs_State insideState =
+            (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
+
+        for (size_t j = 0; j < shells.size(); j++)
+            if (i != j && occtShellIsInsideSolid(shells[j], classifier, insideState))
+                enclosedBy[j]++;
+    }
+    for (size_t i = 0; i < shells.size(); i++)
+        if (enclosedBy[i] % 2 == 0) selected.push_back(shells[i]);
+}
+
+// The shells that bound a body, in exploration order: every shell an even number of the
+// others in its group enclose, where a group is one solid's own shells, or all the shells
+// belonging to no solid at all. A cavity shell is left out, because a hole is not a body and
+// turning one into a positive solid would give a compound whose volume double-counts the
+// part.
+// Declared in OCCTBridge_Internal.h, because the solid-from-shell entry points in
+// OCCTBridge_Modeling.mm share it (#443).
+std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape) {
     std::vector<TopoDS_Shell> selected;
     TopTools_IndexedMapOfShape claimed;
 
@@ -3272,65 +3338,30 @@ static std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shap
             claimed.Add(sh.Current());
             shells.push_back(TopoDS::Shell(sh.Current()));
         }
-        if (shells.empty()) continue;
-
-        if (shells.size() == 1) { selected.push_back(shells[0]); continue; }
-
-        // Enclosure parity: a shell bounds a body iff an EVEN number of the other shells
-        // enclose it. Nothing here assumes one shell encloses all the rest, which is what
-        // both simpler rules got wrong — picking a single reference (BRepClass3d::OuterShell
-        // or the widest box) and calling everything outside it a body double-counts one
-        // body's cavity as soon as a *different* body is the reference. Parity also reads
-        // a body nested inside another body's cavity correctly: enclosed twice, so even.
-        std::vector<int> enclosedBy(shells.size(), 0);
-        for (size_t i = 0; i < shells.size(); i++) {
-            // An open shell cannot enclose anything, and every shell is a reference under
-            // parity, so letting one classify would add a spurious ±1 to the others and
-            // flip their verdicts. Measured on {A_outer, A_cavity, openShell wrapping both}:
-            // without this the outer shell is DROPPED (count 1) and the cavity emitted as a
-            // body. BRep_Tool::IsClosed on a shell is a real edge-pairing check rather than
-            // the Closed() flag, so a genuine cavity shell still qualifies as a reference.
-            // Open shells reach here routinely — this function accepts them by contract.
-            //
-            // Deliberate trade-off, do not "fix" a double-count back out of this: on a body
-            // whose OUTER shell is the open one, the cavity becomes the only eligible
-            // reference, both end even, and the cavity is emitted as a positive body. Input
-            // that broken has no right answer, and an extra body beats a dropped one for a
-            // call whose whole contract is that bodies do not vanish silently.
-            if (!BRep_Tool::IsClosed(shells[i])) continue;
-
-            // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
-            // that call does sh.Free(true), a TShape-level write to state shared with the
-            // caller's shape, and nothing here needs the reorientation it pays that for.
-            // One classifier per reference shell — its constructor loads every face.
-            TopoDS_Solid reference;
-            BRep_Builder builder;
-            builder.MakeSolid(reference);
-            builder.Add(reference, shells[i]);
-
-            BRepClass3d_SolidClassifier classifier(reference);
-            classifier.PerformInfinitePoint(Precision::Confusion());
-            // A shell added as-is can bound "everything outside" instead, which flips the
-            // sense of every later classification rather than making it wrong.
-            const TopAbs_State insideState =
-                (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
-
-            for (size_t j = 0; j < shells.size(); j++)
-                if (i != j && occtShellIsInsideSolid(shells[j], classifier, insideState))
-                    enclosedBy[j]++;
-        }
-        for (size_t i = 0; i < shells.size(); i++)
-            if (enclosedBy[i] % 2 == 0) selected.push_back(shells[i]);
+        // Each solid is its own group: a free shell must not be able to perturb a declared
+        // body's cavity verdict, and vice versa.
+        occtSelectBodyShells(shells, selected);
     }
 
+    // Free shells form one further group and go through the same parity pass (#443).
+    // They used to be added unconditionally, on the grounds that a shell outside any solid
+    // has no declared cavity relationship. But sewing DISSOLVES the solid that carried
+    // that declaration, and sewing is the ordinary way these calls are reached. Measured on
+    // a sewn hollow box: unconditional gives 2 bodies where the same two shells inside a
+    // solid give 1, and on {hollow body, body inside its cavity} it gives 3 instead of 2.
+    // Containment among free shells is geometric rather than declared, so a closed shell
+    // sitting alone inside another is read as that one's cavity: the same reading OCCT's
+    // own solid convention would give it, and the only one available without a declaration.
+    std::vector<TopoDS_Shell> freeShells;
     for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next()) {
         // Contains, not Add: IndexedMap::Add returns an index, never a "was new" flag.
         // Without this a compound holding the same free shell twice yields two identical
         // solids.
         if (claimed.Contains(sh.Current())) continue;
         claimed.Add(sh.Current());
-        selected.push_back(TopoDS::Shell(sh.Current()));
+        freeShells.push_back(TopoDS::Shell(sh.Current()));
     }
+    occtSelectBodyShells(freeShells, selected);
 
     return selected;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -1289,7 +1289,13 @@ OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance) {
             std::vector<TopoDS_Shape> made;
             for (const TopoDS_Shell& shell : occtBodyBoundingShells(sewedShape)) {
                 BRepBuilderAPI_MakeSolid makeSolid(shell);
-                if (makeSolid.IsDone()) made.push_back(makeSolid.Solid());
+                // IsDone() false is dead code today — BRepLib_MakeSolid's single-shell
+                // constructor always Done()s, same finding as OCCTShapeCreateSolidFromShell —
+                // but kept push-not-drop for defense in depth rather than silently reducing
+                // the body count, matching every sibling per-body solid-construction loop
+                // this diff touches (#443 review).
+                made.push_back(makeSolid.IsDone() ? TopoDS_Shape(makeSolid.Solid())
+                                                   : TopoDS_Shape(shell));
             }
             TopoDS_Shape solids = occtSolidBodiesToShape(made);
             if (!solids.IsNull()) resultShape = solids;

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -286,11 +286,13 @@ TopoDS_Shape occtUnifySameDomain(const TopoDS_Shape& shape,
 // asked by every call that turns shells into solids: the solid-from-shell entry points in
 // OCCTBridge_Modeling.mm ask it too, and each having its own answer is what #443 records.
 
-// The shells that bound a body, in exploration order: within each solid, every shell an even
-// number of the others enclose, plus every shell belonging to no solid at all. A solid's
-// cavity shells are left out, because a hole is not a body and turning one into a positive solid
-// would give a compound whose volume double-counts the part. Returns empty when `shape`
-// holds no shell, which callers take as "nothing to build".
+// The shells that bound a body, in exploration order: every shell an even number of the
+// others in its group enclose, where a group is one solid's own shells, or all the shells
+// belonging to no solid at all (free shells go through the same parity pass as a solid's own
+// shells, not added unconditionally — #443). A cavity shell is left out, because a hole is not
+// a body and turning one into a positive solid would give a compound whose volume
+// double-counts the part. Returns empty when `shape` holds no shell, which callers take as
+// "nothing to build".
 std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape);
 
 // Assemble one result shape from bodies: the body itself when there is exactly one, a

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -33,6 +33,7 @@
 #include <TopoDS_Wire.hxx>
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
+#include <TopoDS_Shell.hxx>
 #include <Geom_Curve.hxx>
 #include <Geom2d_Curve.hxx>
 #include <Geom_Surface.hxx>
@@ -277,6 +278,24 @@ TopoDS_Shape occtUnifySameDomainMapped(const TopoDS_Shape& sub, BRepBuilderAPI_C
 // non-builder entry points share. Returns a null shape on failure.
 TopoDS_Shape occtUnifySameDomain(const TopoDS_Shape& shape,
                                  bool unifyEdges, bool unifyFaces, bool concatBSplines);
+
+// === #442/#443: multi-body shell selection ===
+//
+// Definitions live in OCCTBridge_Healing.mm, next to the ShapeFix_Solid entry points they
+// were written for (#442). Shared because the same "which shells bound a body" question is
+// asked by every call that turns shells into solids: the solid-from-shell entry points in
+// OCCTBridge_Modeling.mm ask it too, and each having its own answer is what #443 records.
+
+// The shells that bound a body, in exploration order: within each solid, every shell an even
+// number of the others enclose, plus every shell belonging to no solid at all. A solid's
+// cavity shells are left out, because a hole is not a body and turning one into a positive solid
+// would give a compound whose volume double-counts the part. Returns empty when `shape`
+// holds no shell, which callers take as "nothing to build".
+std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape);
+
+// Assemble one result shape from bodies: the body itself when there is exactly one, a
+// compound when there are several, a null shape when there are none.
+TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies);
 
 // === #430/#432: surface-filling constraint helpers ===
 //

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -3086,6 +3086,10 @@ OCCTBooleanHistoryRef OCCTShapeHealWithHistory(OCCTShapeRef shape, OCCTShapeRef*
 // ShapeBuild_ReShape, so the single history covers every body: History() builds a
 // fresh BRepTools_History from the context's whole replacement map on each call
 // (BRepTools_ReShape::History), so replacements from earlier bodies are still in it.
+// The flip side of sharing: each body's Perform() calls Context()->Apply() against a map
+// that already holds the earlier bodies' replacements. Harmless for the disjoint bodies
+// sewing produces, since Apply returns an unmapped shape unchanged, but two bodies that
+// genuinely share a sub-shape would see the first body's replacement of it.
 OCCTBooleanHistoryRef OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef shell,
                                                                   OCCTShapeRef* outResult) {
     if (outResult) *outResult = nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -2863,26 +2863,32 @@ OCCTShapeRef OCCTShapeCreateFaceWithHoles(OCCTWireRef outer, const OCCTWireRef* 
 // solid, which is the input its own doc comment names, and after #442 the sibling entry point
 // OCCTShapeSolidFromShell answered that same input with both bodies. Same helper, so the two
 // now agree; cavity shells stay out of the result for the reason documented there.
+//
+// #443 review flagged the IsDone()/IsNull() checks below as a silent-drop path reopened one
+// layer down: a MakeSolid failure used to fail the whole call, and per-shell it just skips that
+// body. Checked against occt-src rather than assumed: BRepLib_MakeSolid's single-shell
+// constructor (BRepLib_MakeSolid.cxx) unconditionally calls Done() after B.Add(myShape, S), with
+// no closure or coherence check anywhere in the path — its own header says as much ("a solid
+// under construction is always valid"). Confirmed with a probe (BRepBuilderAPI_MakeSolid on a
+// 5-of-6-face open shell, and on a bare empty shell): IsDone() true and Solid() non-null in both
+// cases, just a geometrically invalid solid (BRepCheck_Analyzer.IsValid() false) rather than a
+// null one. So neither branch below can fire for a real shell today. They stay as push-not-drop
+// rather than being deleted, matching OCCTShapeSolidFromShell's identical belt-and-braces
+// comment ("keeps a body rather than dropping it if that changes") — same defensive contract,
+// zero behaviour change either way.
 OCCTShapeRef OCCTShapeCreateSolidFromShell(OCCTShapeRef shell) {
     if (!shell) return nullptr;
 
     try {
         std::vector<TopoDS_Shape> made;
         for (const TopoDS_Shell& topoShell : occtBodyBoundingShells(shell->shape)) {
-            // TODO(#443 review, unresolved — must be fixed before this merges): before this
-            // change, a MakeSolid failure on the (only) shell was a hard failure (return
-            // nullptr for the whole call). Now, for multi-body input, it just drops this one
-            // body and keeps going — occtSolidBodiesToShape only returns null if EVERY body
-            // failed, so a caller can get back a silently partial compound missing a body,
-            // with no signal that it happened. That is the exact class of defect this PR
-            // exists to eliminate, reopened one layer down. Needs either a real error path
-            // (propagate the failure instead of swallowing it) or explicit, documented
-            // acceptance of partial results — not silence.
             BRepBuilderAPI_MakeSolid makeSolid(topoShell);
-            if (!makeSolid.IsDone()) continue;
-
-            TopoDS_Solid solid = makeSolid.Solid();
-            if (solid.IsNull()) continue;
+            TopoDS_Solid solid;
+            if (makeSolid.IsDone()) solid = makeSolid.Solid();
+            if (solid.IsNull()) {
+                made.push_back(topoShell);   // Kept, not dropped — see comment above.
+                continue;
+            }
 
             // Optionally fix the solid orientation
             ShapeFix_Solid fixer(solid);
@@ -3107,15 +3113,18 @@ OCCTBooleanHistoryRef OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef shel
         Handle(ShapeBuild_ReShape) context = new ShapeBuild_ReShape;
         std::vector<TopoDS_Shape> made;
         for (const TopoDS_Shell& topoShell : occtBodyBoundingShells(shell->shape)) {
-            // TODO(#443 review, unresolved — must be fixed before this merges): same silent
-            // partial-body drop as OCCTShapeCreateSolidFromShell above on a MakeSolid failure,
-            // see the comment there. Here it also means the returned history stays keyed to
-            // whichever bodies DID make it into `made`, with no way for the caller to tell a
-            // body silently failed rather than never having existed.
+            // Same MakeSolid IsDone()/IsNull() checks as OCCTShapeCreateSolidFromShell above,
+            // and the same finding applies: verified dead code (BRepLib_MakeSolid's single-shell
+            // constructor always Done()s, never a null Solid()), kept push-not-drop for the same
+            // belt-and-braces reason. A body that took this branch never reaches ShapeFix_Solid,
+            // so it contributes nothing to `context` — same as any body the loop never visits.
             BRepBuilderAPI_MakeSolid makeSolid(topoShell);
-            if (!makeSolid.IsDone()) continue;
-            TopoDS_Solid solid = makeSolid.Solid();
-            if (solid.IsNull()) continue;
+            TopoDS_Solid solid;
+            if (makeSolid.IsDone()) solid = makeSolid.Solid();
+            if (solid.IsNull()) {
+                made.push_back(topoShell);   // Kept, not dropped — see comment above.
+                continue;
+            }
 
             ShapeFix_Solid fixer(solid);
             fixer.SetContext(context);

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -2869,6 +2869,15 @@ OCCTShapeRef OCCTShapeCreateSolidFromShell(OCCTShapeRef shell) {
     try {
         std::vector<TopoDS_Shape> made;
         for (const TopoDS_Shell& topoShell : occtBodyBoundingShells(shell->shape)) {
+            // TODO(#443 review, unresolved — must be fixed before this merges): before this
+            // change, a MakeSolid failure on the (only) shell was a hard failure (return
+            // nullptr for the whole call). Now, for multi-body input, it just drops this one
+            // body and keeps going — occtSolidBodiesToShape only returns null if EVERY body
+            // failed, so a caller can get back a silently partial compound missing a body,
+            // with no signal that it happened. That is the exact class of defect this PR
+            // exists to eliminate, reopened one layer down. Needs either a real error path
+            // (propagate the failure instead of swallowing it) or explicit, documented
+            // acceptance of partial results — not silence.
             BRepBuilderAPI_MakeSolid makeSolid(topoShell);
             if (!makeSolid.IsDone()) continue;
 
@@ -3098,6 +3107,11 @@ OCCTBooleanHistoryRef OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef shel
         Handle(ShapeBuild_ReShape) context = new ShapeBuild_ReShape;
         std::vector<TopoDS_Shape> made;
         for (const TopoDS_Shell& topoShell : occtBodyBoundingShells(shell->shape)) {
+            // TODO(#443 review, unresolved — must be fixed before this merges): same silent
+            // partial-body drop as OCCTShapeCreateSolidFromShell above on a MakeSolid failure,
+            // see the comment there. Here it also means the returned history stays keyed to
+            // whichever bodies DID make it into `made`, with no way for the caller to tell a
+            // body silently failed rather than never having existed.
             BRepBuilderAPI_MakeSolid makeSolid(topoShell);
             if (!makeSolid.IsDone()) continue;
             TopoDS_Solid solid = makeSolid.Solid();

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -686,6 +686,8 @@ OCCTShapeRef OCCTShapeBuildThreadCutter(double ox, double oy, double oz,
         sewer.Perform();
         TopoDS_Shape shell = sewer.SewedShape();
         if (shell.IsNull()) return nullptr;
+        // #443 audit: first shell only, but the faces sewn above are one closed helical
+        // cutter by construction, so there is never a second. No caller-visible risk.
         TopExp_Explorer se(shell, TopAbs_SHELL);
         if (!se.More()) return nullptr;
         TopoDS_Solid solid = BRepBuilderAPI_MakeSolid(TopoDS::Shell(se.Current())).Solid();
@@ -932,6 +934,8 @@ OCCTShapeRef OCCTShapeNormalProjection(OCCTShapeRef wireOrEdge, OCCTShapeRef sur
 
 #include <BRepPrimAPI_MakeHalfSpace.hxx>
 
+// #443 audit: first face only. A half-space is bounded by one face by definition, so the
+// argument is expected to hold exactly one; documented on Shape.halfSpace rather than changed.
 OCCTShapeRef OCCTShapeCreateHalfSpace(OCCTShapeRef faceShape, double refX, double refY, double refZ) {
     if (!faceShape) return nullptr;
     try {
@@ -2854,41 +2858,36 @@ OCCTShapeRef OCCTShapeCreateFaceWithHoles(OCCTWireRef outer, const OCCTWireRef* 
     }
 }
 
+// One solid per body-bounding shell, not just the first shell an explorer yields (#443).
+// Sewing two disjoint bodies produces exactly the two-shell input this used to reduce to one
+// solid, which is the input its own doc comment names, and after #442 the sibling entry point
+// OCCTShapeSolidFromShell answered that same input with both bodies. Same helper, so the two
+// now agree; cavity shells stay out of the result for the reason documented there.
 OCCTShapeRef OCCTShapeCreateSolidFromShell(OCCTShapeRef shell) {
     if (!shell) return nullptr;
 
     try {
-        // Extract shell from shape
-        TopoDS_Shell topoShell;
-        if (shell->shape.ShapeType() == TopAbs_SHELL) {
-            topoShell = TopoDS::Shell(shell->shape);
-        } else {
-            // Try to find a shell in the shape
-            TopExp_Explorer exp(shell->shape, TopAbs_SHELL);
-            if (exp.More()) {
-                topoShell = TopoDS::Shell(exp.Current());
-            } else {
-                return nullptr;
-            }
+        std::vector<TopoDS_Shape> made;
+        for (const TopoDS_Shell& topoShell : occtBodyBoundingShells(shell->shape)) {
+            BRepBuilderAPI_MakeSolid makeSolid(topoShell);
+            if (!makeSolid.IsDone()) continue;
+
+            TopoDS_Solid solid = makeSolid.Solid();
+            if (solid.IsNull()) continue;
+
+            // Optionally fix the solid orientation
+            ShapeFix_Solid fixer(solid);
+            fixer.Perform();
+            TopoDS_Shape fixedShape = fixer.Solid();
+            // Keep the unfixed solid rather than dropping the body, as before.
+            made.push_back((fixedShape.IsNull() || fixedShape.ShapeType() != TopAbs_SOLID)
+                               ? TopoDS_Shape(solid)
+                               : fixedShape);
         }
 
-        BRepBuilderAPI_MakeSolid makeSolid(topoShell);
-        if (!makeSolid.IsDone()) {
-            return nullptr;
-        }
-
-        TopoDS_Solid solid = makeSolid.Solid();
-        if (solid.IsNull()) return nullptr;
-
-        // Optionally fix the solid orientation
-        ShapeFix_Solid fixer(solid);
-        fixer.Perform();
-        TopoDS_Shape fixedShape = fixer.Solid();
-        if (fixedShape.IsNull() || fixedShape.ShapeType() != TopAbs_SOLID) {
-            return new OCCTShape(solid);  // Return original if fix failed
-        }
-
-        return new OCCTShape(TopoDS::Solid(fixedShape));
+        TopoDS_Shape result = occtSolidBodiesToShape(made);
+        if (result.IsNull()) return nullptr;
+        return new OCCTShape(result);
     } catch (...) {
         return nullptr;
     }
@@ -3079,36 +3078,41 @@ OCCTBooleanHistoryRef OCCTShapeHealWithHistory(OCCTShapeRef shape, OCCTShapeRef*
 // nothing. The one stage that can actually touch sub-shape identity is the
 // ShapeFix_Solid orientation-fix pass, so that's the history source here.
 // ShapeFix_Solid::Init does NOT auto-create a context (verified in occt-src,
-// unlike ShapeFix_Shape above) — SetContext() must be called explicitly before
+// unlike ShapeFix_Shape above): SetContext() must be called explicitly before
 // Perform(), or Context()->History() below would dereference a null Handle.
+//
+// Multi-body input goes one body per body-bounding shell, matching the plain
+// OCCTShapeCreateSolidFromShell (#443). All the per-body fixers share ONE
+// ShapeBuild_ReShape, so the single history covers every body: History() builds a
+// fresh BRepTools_History from the context's whole replacement map on each call
+// (BRepTools_ReShape::History), so replacements from earlier bodies are still in it.
 OCCTBooleanHistoryRef OCCTShapeCreateSolidFromShellWithHistory(OCCTShapeRef shell,
                                                                   OCCTShapeRef* outResult) {
     if (outResult) *outResult = nullptr;
     if (!shell) return nullptr;
     try {
-        TopoDS_Shell topoShell;
-        if (shell->shape.ShapeType() == TopAbs_SHELL) {
-            topoShell = TopoDS::Shell(shell->shape);
-        } else {
-            TopExp_Explorer exp(shell->shape, TopAbs_SHELL);
-            if (!exp.More()) return nullptr;
-            topoShell = TopoDS::Shell(exp.Current());
+        Handle(ShapeBuild_ReShape) context = new ShapeBuild_ReShape;
+        std::vector<TopoDS_Shape> made;
+        for (const TopoDS_Shell& topoShell : occtBodyBoundingShells(shell->shape)) {
+            BRepBuilderAPI_MakeSolid makeSolid(topoShell);
+            if (!makeSolid.IsDone()) continue;
+            TopoDS_Solid solid = makeSolid.Solid();
+            if (solid.IsNull()) continue;
+
+            ShapeFix_Solid fixer(solid);
+            fixer.SetContext(context);
+            fixer.Perform();
+            TopoDS_Shape result = fixer.Solid();
+            if (result.IsNull() || result.ShapeType() != TopAbs_SOLID) {
+                result = solid;  // Fall back to the unfixed solid, same as OCCTShapeCreateSolidFromShell.
+            }
+            made.push_back(result);
         }
 
-        BRepBuilderAPI_MakeSolid makeSolid(topoShell);
-        if (!makeSolid.IsDone()) return nullptr;
-        TopoDS_Solid solid = makeSolid.Solid();
-        if (solid.IsNull()) return nullptr;
+        TopoDS_Shape result = occtSolidBodiesToShape(made);
+        if (result.IsNull()) return nullptr;
 
-        ShapeFix_Solid fixer(solid);
-        fixer.SetContext(new ShapeBuild_ReShape);
-        fixer.Perform();
-        TopoDS_Shape result = fixer.Solid();
-        if (result.IsNull() || result.ShapeType() != TopAbs_SOLID) {
-            result = solid;  // Fall back to the unfixed solid, same as OCCTShapeCreateSolidFromShell.
-        }
-
-        Handle(BRepTools_History) hist = fixer.Context()->History();
+        Handle(BRepTools_History) hist = context->History();
         if (hist.IsNull()) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
         return new OCCTBooleanHistory(hist);
@@ -4248,6 +4252,10 @@ OCCTWireRef OCCTWireOffset3D(OCCTWireRef wire, double distance, double dirX, dou
 #include <GProp_PEquation.hxx>
 #include <TColgp_Array1OfPnt.hxx>
 
+// #443 audit: each argument contributes only its FIRST shell. The outer-versus-cavity
+// contract is the caller's to state (that is what the argument order means), but which shell
+// of a multi-shell argument gets used is not. Documented on Shape.solidFromShells rather
+// than changed, since widening it would make the argument order stop meaning anything.
 OCCTShapeRef OCCTSolidFromShells(OCCTShapeRef* shells, int32_t count) {
     if (!shells || count <= 0) return nullptr;
     try {
@@ -4289,6 +4297,9 @@ OCCTWireRef OCCTWireCreateFastPolygon(const double* coords, int32_t pointCount, 
     }
 }
 
+// #443 audit: first face only, and the result is that face alone. Left as-is because the
+// vertex indices are numbered within it, so filleting every face would need per-face index
+// lists, a different signature. Documented on Shape.fillet2D.
 OCCTShapeRef OCCTFace2DFillet(OCCTShapeRef shape, const int32_t* vertexIndices,
                                const double* radii, int32_t count) {
     if (!shape || !vertexIndices || !radii || count <= 0) return nullptr;
@@ -4317,6 +4328,7 @@ OCCTShapeRef OCCTFace2DFillet(OCCTShapeRef shape, const int32_t* vertexIndices,
     }
 }
 
+// #443 audit: first face only, same reasoning as OCCTFace2DFillet above.
 OCCTShapeRef OCCTFace2DChamfer(OCCTShapeRef shape,
                                 const int32_t* edge1Indices, const int32_t* edge2Indices,
                                 const double* distances, int32_t count) {
@@ -5740,6 +5752,9 @@ bool OCCTLocOpeBuildWires(OCCTShapeRef shape, int32_t faceIndex,
 }
 // --- LocOpe_WiresOnShape + LocOpe_Spliter ---
 
+// #443 audit: first WIRE of the splitting shape only (the face is named by index, so that
+// half is explicit). Singular by contract, since one wire splits one face. Documented on
+// Shape.splitByWireOnFace rather than changed.
 OCCTShapeRef _Nullable OCCTLocOpeSplitByWireOnFace(OCCTShapeRef shape,
     OCCTShapeRef wire, int32_t faceIndex) {
     if (!shape || !wire) return nullptr;
@@ -6582,6 +6597,9 @@ OCCTShapeRef _Nullable OCCTBRepFeatGluer(OCCTShapeRef _Nonnull baseShape,
 
 // --- LocOpe_WiresOnShape + LocOpe_Spliter (new functions) ---
 
+// #443 audit: each (wire, face) pair contributes only its first wire. The pair list is
+// already the place to name several wires, so this is singular by contract; documented on
+// Shape.locOpeSplit(wiresOnFaces:) rather than changed.
 OCCTShapeRef _Nullable OCCTLocOpeSplitByWires(OCCTShapeRef _Nonnull shape,
     const OCCTShapeRef _Nonnull * _Nonnull wiresOnFaces, int32_t pairCount,
     OCCTShapeRef _Nullable * _Nullable * _Nonnull outDirectLeft, int32_t* _Nonnull outDirectLeftCount) {

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -1279,6 +1279,26 @@ extension AssemblyNode {
     // MARK: - TDataXtd Triangulation Attribute
 
     /// Set a triangulation attribute on this label by meshing a shape.
+    ///
+    /// Meshes the shape and stores **every** face's triangulation, merged into one
+    /// `Poly_Triangulation` in the shape's own coordinate system: per-face locations are
+    /// applied to the nodes, and reversed faces have their winding and node normals flipped
+    /// so the stored mesh is consistently outward. Node normals survive only if every
+    /// contributing face carries them; per-face UV nodes are dropped, since they index
+    /// parameter spaces that no longer mean anything once the faces are pooled.
+    ///
+    /// ```swift
+    /// let label = doc.createLabel()!
+    /// label.setTriangulationFromShape(Shape.box(width: 10, height: 10, depth: 10)!,
+    ///                                 deflection: 1.0)
+    /// print(label.triangulationNodeCount)      // 24, all six faces, not 4
+    /// print(label.triangulationTriangleCount)  // 12
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - shape: The shape to mesh. Faces at any depth are included.
+    ///   - deflection: Linear meshing deflection (default: 1.0).
+    /// - Returns: `false` if the shape has no face, or if nothing in it meshed.
     @discardableResult
     public func setTriangulationFromShape(_ shape: Shape, deflection: Double = 1.0) -> Bool {
         OCCTDocumentSetTriangulationFromShape(document.handle, labelId, shape.handle, deflection)
@@ -3874,16 +3894,19 @@ public extension Shape {
     /// Create a solid from a shell shape using `ShapeFix_Solid`, orienting it to enclose
     /// a finite volume.
     ///
-    /// One solid is built per *body-bounding* shell, not just the first shell found: within
-    /// each solid, every shell that an **even** number of the other shells enclose, plus
-    /// every shell that belongs to no solid (the usual shape of sewing output). A single
-    /// body comes back as a solid, several as a compound in exploration order.
+    /// One solid is built per *body-bounding* shell, not just the first shell found: every
+    /// shell that an **even** number of the other shells in its group enclose, where a group
+    /// is one solid's own shells, or all the shells belonging to no solid (the usual shape
+    /// of sewing output). A single body comes back as a solid, several as a compound in
+    /// exploration order.
     ///
-    /// A solid's *cavity* shells are deliberately skipped: a hole is not a body, and
-    /// building it as a positive solid would yield a compound whose volume double-counts
-    /// the part. So a hollow solid produces one solid bounded by its outer shell, with the
-    /// cavity filled. To rebuild a solid that keeps its cavities, use
-    /// ``Shape/solidFromShells(_:)`` with the outer shell first.
+    /// *Cavity* shells are deliberately skipped: a hole is not a body, and building it as a
+    /// positive solid would yield a compound whose volume double-counts the part. So a
+    /// hollow solid produces one solid bounded by its outer shell, with the cavity filled,
+    /// and so does that same body after sewing has left its two shells free. A body nested
+    /// inside another body's cavity is enclosed twice, so it is still read as a body. To
+    /// rebuild a solid that keeps its cavities, use ``Shape/solidFromShells(_:)`` with the
+    /// outer shell first.
     ///
     /// ```swift
     /// let quilt = Shape.compound([shellA, shellB])!   // e.g. two sewn bodies

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -1287,6 +1287,22 @@ extension AssemblyNode {
     /// contributing face carries them; per-face UV nodes are dropped, since they index
     /// parameter spaces that no longer mean anything once the faces are pooled.
     ///
+    /// - Important: **The stored coordinate frame changed in the same release as the
+    ///   every-face fix.** This previously stored one face's nodes in that *face's* local
+    ///   frame, discarding its `TopLoc_Location`. It now stores them in the **shape's**
+    ///   frame. For a shape with a non-identity location (an assembly component, anything
+    ///   from ``Shape/transformed(by:)``) the numbers therefore move, independently of the
+    ///   node-count change: a box translated to (100, 200, 300) used to store a node at the
+    ///   origin and now stores it at (100, 200, 300). Re-read any persisted OCAF document
+    ///   that was written before this change if you compare stored triangulations.
+    ///
+    /// - Note: Node normals are transformed and reversed here, which
+    ///   ``Shape/mesh(linearDeflection:angularDeflection:)`` does not do for its own
+    ///   ``Mesh/normals`` (only its winding swap matches). The two therefore disagree for a
+    ///   located or reversed face. `BRepMesh_IncrementalMesh` does not produce node normals
+    ///   at all, so this only arises for a face carrying a triangulation from elsewhere,
+    ///   such as glTF import.
+    ///
     /// ```swift
     /// let label = doc.createLabel()!
     /// label.setTriangulationFromShape(Shape.box(width: 10, height: 10, depth: 10)!,
@@ -1317,6 +1333,53 @@ extension AssemblyNode {
     /// Get the deflection of the triangulation attribute.
     public var triangulationDeflection: Double {
         OCCTDocumentTriangulationDeflection(document.handle, labelId)
+    }
+
+    /// Read one node of the triangulation attribute, in the frame it was stored in.
+    ///
+    /// Nodes are numbered from 1, as `Poly_Triangulation` numbers them.
+    /// ``setTriangulationFromShape(_:deflection:)`` stores them in the **shape's** coordinate
+    /// frame, so a located shape's nodes come back in absolute coordinates.
+    ///
+    /// ```swift
+    /// let moved = Shape.box(width: 10, height: 10, depth: 10)!.moved(dx: 100, dy: 200, dz: 300)!
+    /// label.setTriangulationFromShape(moved, deflection: 1.0)
+    /// let node = label.triangulationNode(at: 1)!   // absolute, not the box's local frame
+    /// ```
+    ///
+    /// - Parameter index: 1-based node index.
+    /// - Returns: The node position, or `nil` if this label has no triangulation attribute or
+    ///   `index` is out of range.
+    public func triangulationNode(at index: Int32) -> SIMD3<Double>? {
+        var xyz = [Double](repeating: 0, count: 3)
+        guard OCCTDocumentTriangulationNode(document.handle, labelId, index, &xyz) else {
+            return nil
+        }
+        return SIMD3(xyz[0], xyz[1], xyz[2])
+    }
+
+    /// Read one node normal of the triangulation attribute, in the frame it was stored in.
+    ///
+    /// Node normals only exist when the meshed faces carried them.
+    /// `BRepMesh_IncrementalMesh` does not produce any, so this returns `nil` for anything
+    /// meshed from B-Rep, and a value for a shape whose faces arrived with a triangulation
+    /// from elsewhere, such as glTF import.
+    ///
+    /// ```swift
+    /// let imported = Shape.loadGLTF(from: url)!    // glTF meshes carry vertex normals
+    /// label.setTriangulationFromShape(imported, deflection: 1.0)
+    /// let n = label.triangulationNode(at: 1).flatMap { _ in label.triangulationNormal(at: 1) }
+    /// ```
+    ///
+    /// - Parameter index: 1-based node index.
+    /// - Returns: The unit normal, or `nil` if this label has no triangulation attribute, the
+    ///   stored triangulation has no node normals, or `index` is out of range.
+    public func triangulationNormal(at index: Int32) -> SIMD3<Double>? {
+        var xyz = [Double](repeating: 0, count: 3)
+        guard OCCTDocumentTriangulationNormal(document.handle, labelId, index, &xyz) else {
+            return nil
+        }
+        return SIMD3(xyz[0], xyz[1], xyz[2])
     }
 
     // MARK: - TDataXtd Point/Axis/Plane Attributes

--- a/Sources/OCCTSwift/MedialAxis.swift
+++ b/Sources/OCCTSwift/MedialAxis.swift
@@ -78,6 +78,10 @@ public final class MedialAxis: @unchecked Sendable {
 
     /// Compute the medial axis of a planar face.
     ///
+    /// - Note: Only the **first** face found is used, and only its outer wire. A shape with
+    ///   several faces returns the same result as that first face on its own; the rest are
+    ///   ignored, not merged. Pass one face at a time to compute a medial axis per face.
+    ///
     /// - Parameters:
     ///   - shape: A shape containing at least one face.
     ///   - tolerance: Computation tolerance (default 1e-4).

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -1547,14 +1547,32 @@ public final class Shape: @unchecked Sendable {
     /// Converts a shell (set of connected faces) into a solid. The shell
     /// must be closed (no gaps) for this to succeed.
     ///
+    /// One solid is built per *body-bounding* shell, not just the first shell found: every
+    /// shell that an **even** number of the other shells in its group enclose, where a group
+    /// is one solid's own shells, or all the shells belonging to no solid (the usual shape
+    /// of sewing output). A single body comes back as a solid, several as a compound in
+    /// exploration order. This matches ``Shape/solidFromShellFixed()``, which asks the same
+    /// question of the same input.
+    ///
+    /// *Cavity* shells are deliberately skipped: a hole is not a body, and building it as a
+    /// positive solid would yield a compound whose volume double-counts the part. A body
+    /// nested inside another body's cavity is enclosed twice, so it is still read as a body.
+    /// To rebuild a solid that keeps its cavities, use ``Shape/solidFromShells(_:)`` with
+    /// the outer shell first.
+    ///
     /// - Parameter shell: A shell shape (typically from sewing operations)
-    /// - Returns: A solid shape, or nil if the shell is not closed
+    /// - Returns: A solid, a compound of solids for multi-body input, or nil if the shape
+    ///   holds no shell at all
     ///
     /// ## Example
     ///
     /// ```swift
     /// let sewn = Shape.sew(faces: faces, tolerance: 1e-6)!
     /// let solid = Shape.solid(from: sewn)!
+    ///
+    /// // Sewing two disjoint bodies yields two shells, so this yields two solids.
+    /// let both = Shape.solid(from: Shape.sew(shapes: [bodyA, bodyB], tolerance: 1e-6)!)!
+    /// print(both.solids.count)   // 2
     /// ```
     public static func solid(from shell: Shape) -> Shape? {
         guard let handle = OCCTShapeCreateSolidFromShell(shell.handle) else {
@@ -3941,6 +3959,28 @@ extension Shape {
     /// Performs a complete upgrade of the shape by sewing disconnected faces,
     /// attempting to create a solid from shells, and applying shape healing.
     ///
+    /// The solid step builds one solid per *body-bounding* shell the sewing produced, so a
+    /// multi-body part stays a multi-body part; it comes back as a compound of solids, and
+    /// a single body as a bare solid. Body selection is the same rule as
+    /// ``Shape/solid(from:)``: cavity shells are skipped, free shells each become a body.
+    ///
+    /// ```swift
+    /// // A raw imported mesh holding two separate bodies.
+    /// let part = imported.upgraded(tolerance: 1e-6)!
+    /// print(part.solids.count)   // 2, not 1
+    /// ```
+    ///
+    /// - Note: Sewing dissolves the solids in the input, so a hollow body reaches the solid
+    ///   step as two free shells and comes back as one body with its **cavity filled**
+    ///   (8000 mm³ for a 7000 mm³ hollow cube). A body nested inside another body's cavity
+    ///   is still read as a body. To heal a hollow part without losing its cavities, use
+    ///   ``Shape/fixed(tolerance:)``, which does not sew.
+    ///
+    /// - Note: The solid step *replaces* the sewn shape rather than merging into it, so
+    ///   content sewing could not attach to a shell (a stray face, a loose edge) is not
+    ///   carried into the result. If the input may contain such content, sew and heal it
+    ///   yourself with ``Shape/sewn(tolerance:)`` and ``Shape/fixed(tolerance:)``.
+    ///
     /// - Parameter tolerance: Tolerance for sewing and healing (default: 1e-6)
     /// - Returns: Upgraded shape, or nil on failure
     public func upgraded(tolerance: Double = 1e-6) -> Shape? {
@@ -4161,6 +4201,10 @@ extension Shape {
     ///
     /// A half-space is an infinite solid on one side of a face.
     /// The reference point indicates which side is solid.
+    ///
+    /// - Note: Only the **first** face of `face` is used. A shape holding several faces
+    ///   produces a half-space bounded by one of them, not by all of them; pass the single
+    ///   dividing face to be explicit about which.
     ///
     /// - Parameters:
     ///   - face: A shape containing the dividing face
@@ -5429,6 +5473,16 @@ extension Shape {
     /// Create a solid from a closed shell, with full per-input-subshape
     /// history. History only reflects the orientation-fix pass — wrapping an
     /// already-closed shell into a solid does not itself modify any sub-shape.
+    ///
+    /// Body selection matches ``Shape/solid(from:)``: one solid per body-bounding shell,
+    /// a compound when there is more than one, cavity shells skipped. The single history
+    /// covers every body.
+    ///
+    /// ```swift
+    /// let sewn = Shape.sew(shapes: [bodyA, bodyB], tolerance: 1e-6)!
+    /// guard let (solids, history) = Shape.solidWithFullHistory(from: sewn) else { return }
+    /// print(solids.solids.count)   // 2
+    /// ```
     public static func solidWithFullHistory(from shell: Shape) -> (result: Shape, history: ShapeHistoryRef)? {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeCreateSolidFromShellWithHistory(shell.handle, &resultRef),
@@ -6290,6 +6344,10 @@ extension Shape {
     /// the given shapes. The first shape provides the outer shell, and additional shapes
     /// provide cavity (inner) shells.
     ///
+    /// - Note: Each element contributes only the **first** shell found in it, so pass one
+    ///   shape per shell rather than a compound of several. An element holding no shell is
+    ///   skipped silently, except the first, which fails the whole call.
+    ///
     /// - Parameter shells: Array of shapes containing shells (first = outer, rest = cavities)
     /// - Returns: Solid shape, or nil on failure
     public static func solidFromShells(_ shells: [Shape]) -> Shape? {
@@ -6306,6 +6364,11 @@ extension Shape {
     ///
     /// Uses BRepFilletAPI_MakeFillet2d to round corners of a planar face.
     /// Vertex indices are 0-based and correspond to the topological vertex order.
+    ///
+    /// - Note: Only the **first** face of the receiver is filleted, and the result is that
+    ///   face alone; the other faces of a multi-face shape are neither filleted nor carried
+    ///   through. Vertex indices are numbered within that first face. Call this on one face
+    ///   at a time.
     ///
     /// - Parameters:
     ///   - vertexIndices: 0-based indices of vertices to fillet
@@ -6327,6 +6390,11 @@ extension Shape {
     ///
     /// Uses BRepFilletAPI_MakeFillet2d to add chamfers at the intersection of
     /// adjacent edges. Edge indices are 0-based and correspond to the topological edge order.
+    ///
+    /// - Note: Only the **first** face of the receiver is chamfered, and the result is that
+    ///   face alone; the other faces of a multi-face shape are neither chamfered nor carried
+    ///   through. Edge indices are numbered within that first face. Call this on one face at
+    ///   a time.
     ///
     /// - Parameters:
     ///   - edgePairs: Array of (edge1Index, edge2Index) pairs identifying adjacent edges
@@ -8992,6 +9060,10 @@ extension Shape {
     // MARK: LocOpe_WiresOnShape + LocOpe_Spliter
 
     /// Split a face of this shape by projecting a wire onto it.
+    ///
+    /// - Note: Only the **first** wire of `wire` is used. Passing a shape that holds several
+    ///   wires splits by one of them and silently ignores the rest; call once per wire.
+    ///
     /// - Parameters:
     ///   - wire: The splitting wire
     ///   - faceIndex: 1-based index of the face to split
@@ -10762,6 +10834,11 @@ extension Shape {
     /// Split this shape by projecting wires onto faces using LocOpe_Spliter.
     ///
     /// Uses LocOpe_WiresOnShape to bind wires to faces, then LocOpe_Spliter to split.
+    ///
+    /// - Note: Each pair contributes only the **first** wire of its `wire` shape. A pair
+    ///   whose shape holds several wires binds one of them and ignores the rest; give each
+    ///   wire its own pair. A pair whose shape holds no wire at all is skipped silently.
+    ///
     /// - Parameter wiresOnFaces: Array of (wire, face) pairs to bind.
     /// - Returns: Split result with direct-left faces, or nil on failure.
     public func locOpeSplit(wiresOnFaces: [(wire: Shape, face: Shape)]) -> LocOpeSplitResult? {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -3961,8 +3961,10 @@ extension Shape {
     ///
     /// The solid step builds one solid per *body-bounding* shell the sewing produced, so a
     /// multi-body part stays a multi-body part; it comes back as a compound of solids, and
-    /// a single body as a bare solid. Body selection is the same rule as
-    /// ``Shape/solid(from:)``: cavity shells are skipped, free shells each become a body.
+    /// a single body as a bare solid. Body selection is the same rule as ``Shape/solid(from:)``:
+    /// every shell that an **even** number of the other shells in its group enclose, where a
+    /// group is one solid's own shells, or all the shells belonging to no solid — so a free
+    /// shell that is itself an even-enclosed cavity is skipped, not turned into a body.
     ///
     /// ```swift
     /// // A raw imported mesh holding two separate bodies.

--- a/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
@@ -206,6 +206,58 @@ struct Issue443FirstOfN {
         expectVolume(fromShells, 8000.0, "sewn hollow body")
     }
 
+    /// Free shells are the one parity group with no natural bound on its size: sewing a raw
+    /// imported mesh can yield hundreds of disjoint shells, where a solid's own shells are
+    /// 1-3. Every other test here uses two or three bodies, so nothing else exercises the
+    /// bounding-box pre-filter that keeps the pass from going quadratic (measured at 200
+    /// disjoint shells: 160 ms without it, 0.7 ms with, same verdicts).
+    ///
+    /// This asserts the verdicts at scale rather than the time, which would be flaky. A
+    /// regression in the pre-filter shows up here as a wrong body count, and a removal of it
+    /// shows up as this test getting noticeably slower.
+    @Test("a hundred disjoint free shells are a hundred bodies")
+    func manyFreeShells() {
+        let count = 100
+        let boxes = (0..<count).compactMap {
+            Shape.box(origin: SIMD3(Double($0) * 20, 0, 0), width: 10, height: 10, depth: 10)
+        }
+        guard boxes.count == count, let compound = Shape.compound(boxes),
+              let sewn = compound.sewn(tolerance: 1e-6)
+        else {
+            Issue.record("could not build or sew \(count) boxes")
+            return
+        }
+        #expect(sewn.shells.count == count)
+
+        guard let solids = Shape.solid(from: sewn) else {
+            Issue.record("solid(from:) returned nil for \(count) free shells")
+            return
+        }
+        #expect(solids.solids.count == count)
+        expectVolume(solids, Double(count) * 1000.0, "solid(from: \(count) free shells)")
+    }
+
+    /// The pre-filter must not prune a pair whose boxes overlap without enclosure. Two boxes
+    /// sharing a face have overlapping bounds, so the cheap test cannot decide them and the
+    /// ray cast still has to run.
+    @Test("touching bodies are still two bodies")
+    func touchingBodiesNotPruned() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(10, 0, 0), width: 10, height: 10, depth: 10),
+              let shellA = a.shells.first, let shellB = b.shells.first,
+              let quilt = Shape.compound([shellA, shellB])
+        else {
+            Issue.record("could not build the two touching shells")
+            return
+        }
+        guard let solids = Shape.solid(from: quilt) else {
+            Issue.record("solid(from:) returned nil for two touching shells")
+            return
+        }
+        #expect(solids.solids.count == 2)
+        expectVolume(solids, 2000.0, "solid(from: two touching shells)")
+    }
+
     // MARK: - Shape.solidWithFullHistory(from:)
 
     /// The history variant shares one `ShapeBuild_ReShape` across the per-body runs, so the

--- a/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
@@ -48,6 +48,19 @@ struct Issue443FirstOfN {
         return outer.subtracting(cavity)
     }
 
+    /// One closed 10mm-cube shell, and a disjoint 5-of-6-face shell that cannot close
+    /// (`BRep_Tool::IsClosed` false, `BRepCheck_Analyzer` invalid): 11 faces, 2 bodies.
+    private func closedAndOpenShellCompound() -> Shape? {
+        guard let closedBox = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let closedShell = closedBox.shells.first,
+              let openBox = Shape.box(origin: SIMD3(30, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        let fiveFaces = Array(openBox.subShapes(ofType: .face).dropFirst())
+        guard fiveFaces.count == 5, let openShell = Shape.sew(shapes: fiveFaces, tolerance: 1e-6)
+        else { return nil }
+        return Shape.compound([closedShell, openShell])
+    }
+
     // MARK: - Shape.solid(from:)
 
     /// The measured row from the issue: sewing the two-box compound gives one shell per
@@ -106,6 +119,30 @@ struct Issue443FirstOfN {
         #expect(solid.solids.count == 1)
         #expect(solid.isValid)
         expectVolume(solid, 1000.0, "solid(from: one shell)")
+    }
+
+    /// #443 review flagged the bridge's `BRepBuilderAPI_MakeSolid` `IsDone()`/`IsNull()` checks
+    /// as a possible silent-drop path: a per-body `MakeSolid` failure used to fail the whole
+    /// call, and per-shell it could just skip that one body with no signal. Checked against
+    /// occt-src rather than assumed (see the bridge comment on `OCCTShapeCreateSolidFromShell`):
+    /// `BRepLib_MakeSolid`'s single-shell constructor unconditionally succeeds, even wrapping a
+    /// wide-open shell, so that specific failure cannot occur. The bridge keeps a push-not-drop
+    /// fallback anyway, matching `OCCTShapeSolidFromShell`'s identical defensive contract — this
+    /// pins the guarantee that actually matters either way: an unclosable body-bounding shell is
+    /// never silently missing from the result.
+    @Test("solid(from:) keeps an open body rather than dropping it")
+    func solidFromKeepsOpenBody() {
+        guard let compound = closedAndOpenShellCompound() else {
+            Issue.record("could not build the closed+open shell compound")
+            return
+        }
+        guard let solid = Shape.solid(from: compound) else {
+            Issue.record("solid(from:) returned nil for a closed+open two-shell compound")
+            return
+        }
+        // Both bodies present — the open one is not dropped for failing to close.
+        #expect(solid.solids.count == 2)
+        #expect(solid.subShapeCount(ofType: .face) == 11)
     }
 
     /// A cavity is a hole, not a body. Emitting one as a positive solid would give a
@@ -334,6 +371,22 @@ struct Issue443FirstOfN {
         }
         #expect(result.shapeType == .solid)
         expectVolume(result, 1000.0, "solidWithFullHistory(one shell)")
+    }
+
+    /// Same review finding as `solidFromKeepsOpenBody`, for the history variant's own
+    /// `MakeSolid` check — a body that cannot close is kept, not dropped.
+    @Test("solidWithFullHistory(from:) keeps an open body rather than dropping it")
+    func solidWithHistoryKeepsOpenBody() {
+        guard let compound = closedAndOpenShellCompound() else {
+            Issue.record("could not build the closed+open shell compound")
+            return
+        }
+        guard let (result, _) = Shape.solidWithFullHistory(from: compound) else {
+            Issue.record("solidWithFullHistory(from:) returned nil for a closed+open compound")
+            return
+        }
+        #expect(result.solids.count == 2)
+        #expect(result.subShapeCount(ofType: .face) == 11)
     }
 
     // MARK: - Shape.upgraded()

--- a/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
@@ -499,6 +499,32 @@ struct Issue443FirstOfN {
         expectVolume(upgraded, 8512.0, "upgraded(body nested in a cavity)")
     }
 
+    /// Same review finding as `solidFromKeepsOpenBody`, on `OCCTShapeUpgrade`'s own
+    /// `BRepBuilderAPI_MakeSolid` loop: it dropped the shell outright on `IsDone() == false`
+    /// instead of keeping it unfixed, unlike every sibling per-body solid-construction loop
+    /// this diff touches. Dead code today for the same reason (`BRepLib_MakeSolid`'s
+    /// single-shell constructor always succeeds), fixed for symmetry/defense in depth.
+    ///
+    /// Unlike `solidFromKeepsOpenBody`, this cannot assert `solids.count == 2`: `upgraded()`
+    /// runs `ShapeFix_Shape` (Step 3) after the solid step, and that healing pass no longer
+    /// classifies the unclosable body as a `TopAbs_SOLID` once kept — measured directly by
+    /// feeding `solid(from: sewn)`'s 2-solid result (one valid, one wrapping the open shell)
+    /// into `Shape.fixed(tolerance:)`: `.solids.count` drops to 1 even though all 11 faces
+    /// survive. So the guarantee this test pins is on the faces, not the solid count — the
+    /// one that actually matters, since it is what "silently missing from the result" means.
+    @Test("upgraded() keeps an unclosable shell's faces rather than dropping them")
+    func upgradedKeepsOpenBody() {
+        guard let compound = closedAndOpenShellCompound() else {
+            Issue.record("could not build the closed+open shell compound")
+            return
+        }
+        guard let upgraded = compound.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for a closed+open two-shell compound")
+            return
+        }
+        #expect(upgraded.subShapeCount(ofType: .face) == 11)
+    }
+
     /// Nothing sews into a shell here, so the solid step must leave the sewn shape alone
     /// rather than returning nil or an empty result.
     @Test("upgraded() passes shapes with no shell straight through")

--- a/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
@@ -277,6 +277,49 @@ struct Issue443FirstOfN {
         expectVolume(result, 2000.0, "solidWithFullHistory(two sewn bodies)")
     }
 
+    /// `solidWithHistoryMultiBody` above discards the returned history entirely
+    /// (`let (result, _) =`), so nothing confirms that the ONE shared `ShapeBuild_ReShape`
+    /// context stays queryable for a body other than the last one `ShapeFix_Solid` ran
+    /// against. That is the "flip side of sharing" the bridge comment on
+    /// `OCCTShapeCreateSolidFromShellWithHistory` documents: each body's `Perform()` runs
+    /// against a context that already holds the earlier bodies' replacements, stated to be
+    /// harmless for the disjoint bodies sewing produces. Genuinely sharing a sub-shape between
+    /// two bodies (the case that same comment flags as unsafe) cannot be constructed through
+    /// this public API — two independently-built, disjoint solids never reference the same
+    /// underlying `TopoDS_Face` — so this pins the safe side of that trade-off instead: every
+    /// input face of BOTH bodies must resolve through the single returned history, not just
+    /// the body built last.
+    ///
+    /// Goes straight to two shells (no sewing), matching the precedent single-shell history
+    /// test in `OCCTModelingTests`, so face identity between the input and what
+    /// `occtBodyBoundingShells` explores is guaranteed rather than dependent on whether
+    /// sewing happens to preserve it.
+    @Test("solidWithFullHistory(from:) keeps every body's face queryable in the one shared history")
+    func solidWithHistoryQueryableForEveryBody() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+              let shellA = a.shells.first, let shellB = b.shells.first,
+              let quilt = Shape.compound([shellA, shellB])
+        else {
+            Issue.record("could not build the two-shell compound")
+            return
+        }
+        guard let (result, history) = Shape.solidWithFullHistory(from: quilt) else {
+            Issue.record("solidWithFullHistory(from:) returned nil")
+            return
+        }
+        #expect(result.solids.count == 2)
+
+        // Every original face of BOTH bodies, queried against the ONE returned history — not
+        // just body B, whose ShapeFix_Solid ran last against the shared context.
+        for (label, box) in [("A", a), ("B", b)] {
+            for face in box.subShapes(ofType: .face) {
+                let rec = history.record(of: face)
+                #expect(!rec.isDeleted, "body \(label) face reported Deleted by the shared history")
+            }
+        }
+    }
+
     @Test("solidWithFullHistory(from:) still returns a bare solid for single-shell input")
     func solidWithHistorySingleShell() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),

--- a/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
@@ -1,0 +1,371 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #443: the first-of-N `TopExp_Explorer` audit. Three call sites took the first shell or
+/// face an explorer yielded and dropped the rest, each returning a well-formed result that
+/// nothing downstream could tell was missing most of the part.
+///
+/// This suite covers the two shape-level ones. `AssemblyNode.setTriangulationFromShape` is
+/// in `OCCTXCAFTests`, next to the rest of the attribute coverage.
+///
+/// `Shape.solid(from:)` is the sharpest of the three: its own doc names sewing output as the
+/// expected input, and sewing two bodies yields exactly the two-shell input it mishandled,
+/// so after #442 the two sibling entry points disagreed on the same shape, one answering
+/// 2 solids / 2000 mm³ and the other 1 / 1000.
+///
+/// Volumes are asserted rather than optionally bound, following #442: `Shape.volume` is
+/// `v >= 0 ? v : nil`, so `nil` means the solid came back inverted, and an `if let` with no
+/// `else` would let that regression pass silently.
+@Suite("Issue 443: solid(from:) and upgraded() cover every body")
+struct Issue443FirstOfN {
+
+    private func expectVolume(_ shape: Shape, _ expected: Double,
+                              _ what: String, sourceLocation: SourceLocation = #_sourceLocation) {
+        guard let volume = shape.volume else {
+            Issue.record("\(what): volume is nil, the solid came back inverted",
+                         sourceLocation: sourceLocation)
+            return
+        }
+        #expect(abs(volume - expected) < 1e-6, "\(what): volume \(volume), expected \(expected)",
+                sourceLocation: sourceLocation)
+    }
+
+    /// Two disjoint 10mm boxes, 2000mm³ total: the issue's own reproducer.
+    private func twoBoxes() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    /// A 20mm cube with a 10mm cavity fully inside it: one solid, two shells.
+    private func hollowBox() -> Shape? {
+        guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
+              let cavity = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return outer.subtracting(cavity)
+    }
+
+    // MARK: - Shape.solid(from:)
+
+    /// The measured row from the issue: sewing the two-box compound gives one shell per
+    /// body, and this used to reduce them to a single 999.99 mm³ solid.
+    @Test("solid(from:) keeps both bodies of sewn multi-body input")
+    func solidFromSewnMultiBody() {
+        guard let compound = twoBoxes(), let sewn = compound.sewn(tolerance: 1e-6) else {
+            Issue.record("could not build or sew the two-box compound")
+            return
+        }
+        #expect(sewn.shells.count == 2)
+
+        guard let solid = Shape.solid(from: sewn) else {
+            Issue.record("solid(from:) returned nil for two sewn bodies")
+            return
+        }
+        // Was 1 solid / 6 faces / ~1000 before the fix, box B silently dropped.
+        #expect(solid.solids.count == 2)
+        #expect(solid.subShapeCount(ofType: .face) == 12)
+        expectVolume(solid, 2000.0, "solid(from: sewn two boxes)")
+    }
+
+    /// The disagreement the issue was filed on: after #442 the two entry points gave
+    /// different answers for one input. They must now agree.
+    @Test("solid(from:) and solidFromShellFixed() agree on sewing output")
+    func solidFromAgreesWithSibling() {
+        guard let compound = twoBoxes(), let sewn = compound.sewn(tolerance: 1e-6) else {
+            Issue.record("could not build or sew the two-box compound")
+            return
+        }
+        guard let viaMakeSolid = Shape.solid(from: sewn),
+              let viaShapeFix = sewn.solidFromShellFixed()
+        else {
+            Issue.record("one of the two entry points returned nil")
+            return
+        }
+        #expect(viaMakeSolid.solids.count == viaShapeFix.solids.count)
+        #expect(viaMakeSolid.solids.count == 2)
+        expectVolume(viaMakeSolid, 2000.0, "solid(from:)")
+        expectVolume(viaShapeFix, 2000.0, "solidFromShellFixed()")
+    }
+
+    @Test("solid(from:) still returns a bare solid for single-shell input")
+    func solidFromSingleShell() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let shell = box.shells.first
+        else {
+            Issue.record("could not build a box shell")
+            return
+        }
+        guard let solid = Shape.solid(from: shell) else {
+            Issue.record("solid(from:) returned nil for a single shell")
+            return
+        }
+        #expect(solid.shapeType == .solid)
+        #expect(solid.solids.count == 1)
+        #expect(solid.isValid)
+        expectVolume(solid, 1000.0, "solid(from: one shell)")
+    }
+
+    /// A cavity is a hole, not a body. Emitting one as a positive solid would give a
+    /// compound whose volume double-counts the part (8000 + 1000 for a 7000 part).
+    @Test("solid(from:) skips a hollow solid's cavity shell")
+    func solidFromSkipsCavity() {
+        guard let hollow = hollowBox() else {
+            Issue.record("could not build the hollow box")
+            return
+        }
+        #expect(hollow.shells.count == 2)
+
+        guard let solid = Shape.solid(from: hollow) else {
+            Issue.record("solid(from:) returned nil for a hollow solid")
+            return
+        }
+        #expect(solid.shapeType == .solid)
+        #expect(solid.solids.count == 1)
+        expectVolume(solid, 8000.0, "solid(from: hollow solid)")   // outer shell, cavity filled
+    }
+
+    /// One solid holding two disjoint closed shells: the case that rules out the naive
+    /// "outer shell per solid" rule, so the one most likely to regress unnoticed.
+    @Test("solid(from:) keeps both shells of a multiconnex solid")
+    func solidFromMulticonnex() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+              let shellA = a.shells.first, let shellB = b.shells.first,
+              let solid = Shape.solidFromShells([shellA, shellB])
+        else {
+            Issue.record("could not build the multiconnex solid")
+            return
+        }
+        #expect(solid.shells.count == 2)
+
+        guard let bodies = Shape.solid(from: solid) else {
+            Issue.record("solid(from:) returned nil for a multiconnex solid")
+            return
+        }
+        #expect(bodies.solids.count == 2)
+        expectVolume(bodies, 2000.0, "solid(from: multiconnex solid)")
+    }
+
+    @Test("solid(from:) returns nil when the shape holds no shell")
+    func solidFromNoShell() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let face = box.subShapes(ofType: .face).first
+        else {
+            Issue.record("could not build a face")
+            return
+        }
+        #expect(Shape.solid(from: face) == nil)
+    }
+
+    // MARK: - Free-shell parity (the #442 helper, corrected here)
+
+    /// Sewing dissolves the solid that declared a cavity, so both shells arrive free. #442
+    /// emitted every free shell as a body unconditionally, which made the cavity a positive
+    /// solid: the same two shells answered 1 body inside a solid and 2 once sewn. They are
+    /// now one group under the same parity rule, so both readings agree.
+    ///
+    /// Covers ``Shape/solidFromShellFixed()`` directly, since #443's change to the shared
+    /// helper alters its answer for this input too.
+    @Test("free shells from a sewn hollow body are one body, not two")
+    func sewnHollowIsOneBody() {
+        guard let hollow = hollowBox(), let sewn = hollow.sewn(tolerance: 1e-6) else {
+            Issue.record("could not build or sew the hollow box")
+            return
+        }
+        #expect(sewn.solids.isEmpty)     // sewing dropped the solid
+        #expect(sewn.shells.count == 2)  // outer and cavity, both free now
+
+        for (label, result) in [("solid(from:)", Shape.solid(from: sewn)),
+                                ("solidFromShellFixed()", sewn.solidFromShellFixed())] {
+            guard let result else {
+                Issue.record("\(label) returned nil for a sewn hollow body")
+                continue
+            }
+            // Was 2 solids before the free-shell group went through parity.
+            #expect(result.solids.count == 1, "\(label): solids")
+            expectVolume(result, 8000.0, "\(label)(sewn hollow body)")
+        }
+    }
+
+    /// The same shells inside a solid and free after sewing must give the same body count.
+    @Test("a hollow body reads the same whether or not it has been sewn")
+    func sewnAndUnsewnHollowAgree() {
+        guard let hollow = hollowBox(), let sewn = hollow.sewn(tolerance: 1e-6),
+              let fromSolid = hollow.solidFromShellFixed(),
+              let fromShells = sewn.solidFromShellFixed()
+        else {
+            Issue.record("could not build both readings of the hollow body")
+            return
+        }
+        #expect(fromSolid.solids.count == fromShells.solids.count)
+        #expect(fromSolid.solids.count == 1)
+        expectVolume(fromSolid, 8000.0, "hollow solid")
+        expectVolume(fromShells, 8000.0, "sewn hollow body")
+    }
+
+    // MARK: - Shape.solidWithFullHistory(from:)
+
+    /// The history variant shares one `ShapeBuild_ReShape` across the per-body runs, so the
+    /// single history covers every body rather than only the last one built.
+    @Test("solidWithFullHistory(from:) keeps both bodies and returns one history")
+    func solidWithHistoryMultiBody() {
+        guard let compound = twoBoxes(), let sewn = compound.sewn(tolerance: 1e-6) else {
+            Issue.record("could not build or sew the two-box compound")
+            return
+        }
+        guard let (result, _) = Shape.solidWithFullHistory(from: sewn) else {
+            Issue.record("solidWithFullHistory(from:) returned nil")
+            return
+        }
+        #expect(result.solids.count == 2)
+        #expect(result.subShapeCount(ofType: .face) == 12)
+        expectVolume(result, 2000.0, "solidWithFullHistory(two sewn bodies)")
+    }
+
+    @Test("solidWithFullHistory(from:) still returns a bare solid for single-shell input")
+    func solidWithHistorySingleShell() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let shell = box.shells.first
+        else {
+            Issue.record("could not build a box shell")
+            return
+        }
+        guard let (result, _) = Shape.solidWithFullHistory(from: shell) else {
+            Issue.record("solidWithFullHistory(from:) returned nil for one shell")
+            return
+        }
+        #expect(result.shapeType == .solid)
+        expectVolume(result, 1000.0, "solidWithFullHistory(one shell)")
+    }
+
+    // MARK: - Shape.upgraded()
+
+    /// `upgraded()` is the call most likely to be pointed at a raw imported mesh, and a
+    /// multi-body part used to come back as one body.
+    @Test("upgraded() keeps every body of a multi-body part")
+    func upgradedMultiBody() {
+        guard let compound = twoBoxes() else {
+            Issue.record("could not build the two-box compound")
+            return
+        }
+        guard let upgraded = compound.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for a two-body compound")
+            return
+        }
+        // Was 1 solid / 6 faces / ~1000 before the fix.
+        #expect(upgraded.solids.count == 2)
+        #expect(upgraded.subShapeCount(ofType: .face) == 12)
+        expectVolume(upgraded, 2000.0, "upgraded(two-box compound)")
+
+        // Both bodies present means the bounds still span x 0..30.
+        guard let box = upgraded.boundingBox else {
+            Issue.record("upgraded(): boundingBox is nil")
+            return
+        }
+        #expect(abs(box.min.x - 0.0) < 1e-6, "min.x \(box.min.x)")
+        #expect(abs(box.max.x - 30.0) < 1e-6, "max.x \(box.max.x)")
+    }
+
+    /// Loose faces sewn from separate bodies are the ordinary way to reach this call.
+    @Test("upgraded() rebuilds both bodies from loose faces")
+    func upgradedFromLooseFaces() {
+        guard let compound = twoBoxes() else {
+            Issue.record("could not build the two-box compound")
+            return
+        }
+        let faces = compound.subShapes(ofType: .face)
+        #expect(faces.count == 12)
+        guard let quilt = Shape.compound(faces) else {
+            Issue.record("could not gather the faces")
+            return
+        }
+        guard let upgraded = quilt.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for 12 loose faces")
+            return
+        }
+        #expect(upgraded.solids.count == 2)
+        expectVolume(upgraded, 2000.0, "upgraded(12 loose faces)")
+    }
+
+    @Test("upgraded() still returns a single body unchanged in volume")
+    func upgradedSingleBody() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
+        }
+        guard let upgraded = box.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for a single box")
+            return
+        }
+        #expect(upgraded.solids.count == 1)
+        #expect(upgraded.isValid)
+        expectVolume(upgraded, 1000.0, "upgraded(single box)")
+    }
+
+    /// A hollow body comes back as ONE body with the cavity filled, not as two, because sewing
+    /// dissolves the solid that declared the cavity, so the pipeline only ever sees two
+    /// free shells, one inside the other. 8000 mm³, the same answer as before the fix.
+    ///
+    /// This is the case that caught the free-shell half of the fix: emitting every free
+    /// shell as a body unconditionally turns the cavity into a positive solid, and the
+    /// result reads 2 solids / 9000 mm³ for a 7000 mm³ part.
+    @Test("upgraded() fills a hollow solid's cavity rather than making it a body")
+    func upgradedHollow() {
+        guard let hollow = hollowBox() else {
+            Issue.record("could not build the hollow box")
+            return
+        }
+        expectVolume(hollow, 7000.0, "the hollow input itself")
+        guard let upgraded = hollow.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for a hollow solid")
+            return
+        }
+        #expect(upgraded.solids.count == 1)
+        expectVolume(upgraded, 8000.0, "upgraded(hollow solid)")   // outer shell, cavity filled
+    }
+
+    /// A body sitting inside another body's cavity is enclosed twice, so parity reads it as
+    /// a body, even once sewing has left all three shells free. Emitting free shells
+    /// unconditionally instead gives 3 solids for a 2-body part.
+    @Test("upgraded() reads a body nested in a cavity as a body")
+    func upgradedNestedBody() {
+        guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
+              let cavity = Shape.box(origin: SIMD3(4, 4, 4), width: 12, height: 12, depth: 12),
+              let hollow = outer.subtracting(cavity),
+              let inner = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8),
+              let part = Shape.compound([hollow, inner])
+        else {
+            Issue.record("could not build the nested-body part")
+            return
+        }
+        guard let upgraded = part.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for the nested-body part")
+            return
+        }
+        // The hollow body's outer shell (8000) plus the nested body (512); the cavity
+        // between them is a hole, not a third body.
+        #expect(upgraded.solids.count == 2)
+        expectVolume(upgraded, 8512.0, "upgraded(body nested in a cavity)")
+    }
+
+    /// Nothing sews into a shell here, so the solid step must leave the sewn shape alone
+    /// rather than returning nil or an empty result.
+    @Test("upgraded() passes shapes with no shell straight through")
+    func upgradedNoShell() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let face = box.subShapes(ofType: .face).first
+        else {
+            Issue.record("could not build a face")
+            return
+        }
+        guard let upgraded = face.upgraded(tolerance: 1e-6) else {
+            Issue.record("upgraded() returned nil for a lone face")
+            return
+        }
+        #expect(upgraded.solids.isEmpty)
+        #expect(upgraded.subShapeCount(ofType: .face) == 1)
+    }
+}

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -1483,6 +1483,104 @@ struct TDataXtdTriangulationAttributeTests {
     }
 }
 
+/// #443: `setTriangulationFromShape` meshed the whole shape and then stored only the
+/// **first face's** triangulation. Measured before the fix: a 6-face box and a 12-face
+/// two-box compound both stored 4 nodes and 2 triangles, one planar face's corners, for
+/// a doc comment that reads "by meshing a shape". The attribute is what later readers
+/// trust as the label's geometry, so a silently truncated one is the worst of the three
+/// sites the audit found.
+@Suite("Issue 443: triangulation attribute stores the whole shape")
+struct Issue443TriangulationAttributeTests {
+
+    /// A box at deflection 1.0 meshes to 4 nodes and 2 triangles per planar face.
+    @Test("a box stores all six faces, not one")
+    func boxStoresEveryFace() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let box = Shape.box(width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build the document or the box")
+            return
+        }
+        #expect(box.subShapeCount(ofType: .face) == 6)
+        #expect(label.setTriangulationFromShape(box, deflection: 1.0))
+
+        // Was 4 / 2 before the fix: one face's worth, for any input.
+        #expect(label.triangulationNodeCount == 24)
+        #expect(label.triangulationTriangleCount == 12)
+    }
+
+    /// Two disjoint boxes: 12 faces, so twice the box's mesh. The pre-fix answer did not
+    /// change at all between these two inputs, which is what made it hard to notice.
+    @Test("a two-body compound stores both bodies")
+    func compoundStoresEveryBody() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+              let compound = Shape.compound([a, b])
+        else {
+            Issue.record("could not build the two-box compound")
+            return
+        }
+        #expect(compound.subShapeCount(ofType: .face) == 12)
+        #expect(label.setTriangulationFromShape(compound, deflection: 1.0))
+        #expect(label.triangulationNodeCount == 48)
+        #expect(label.triangulationTriangleCount == 24)
+    }
+
+    /// Finer deflection must produce a finer mesh. On a curved shape this is the check
+    /// that the merge actually walks every face rather than pinning one of them.
+    @Test("deflection still controls mesh density on a curved shape")
+    func deflectionControlsDensity() {
+        guard let doc = Document.create(),
+              let coarseLabel = doc.createLabel(), let fineLabel = doc.createLabel(),
+              let sphere = Shape.sphere(radius: 10.0)
+        else {
+            Issue.record("could not build the document or the sphere")
+            return
+        }
+        #expect(coarseLabel.setTriangulationFromShape(sphere, deflection: 2.0))
+        #expect(fineLabel.setTriangulationFromShape(sphere, deflection: 0.2))
+        #expect(coarseLabel.triangulationTriangleCount > 0)
+        #expect(fineLabel.triangulationTriangleCount > coarseLabel.triangulationTriangleCount)
+
+        // The merged triangulation is built by hand, so its deflection starts at 0 and has
+        // to be carried over from the contributing faces; a 0 would read as "exact".
+        #expect(coarseLabel.triangulationDeflection > 0)
+        #expect(fineLabel.triangulationDeflection > 0)
+        #expect(fineLabel.triangulationDeflection < coarseLabel.triangulationDeflection)
+    }
+
+    /// The merged deflection is the worst of the contributing faces, not the first face's.
+    /// A box's six planar faces all mesh exactly, so this pins the flat case at 0 while the
+    /// curved case above pins a real value.
+    @Test("a planar shape reports its faces' own deflection")
+    func planarDeflection() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let box = Shape.box(width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build the document or the box")
+            return
+        }
+        #expect(label.setTriangulationFromShape(box, deflection: 1.0))
+        #expect(label.triangulationDeflection >= 0)
+    }
+
+    /// The merge must not silently store an empty attribute when there is nothing to mesh.
+    @Test("a shape with no face stores nothing")
+    func noFaceStoresNothing() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let box = Shape.box(width: 10, height: 10, depth: 10),
+              let edge = box.subShapes(ofType: .edge).first
+        else {
+            Issue.record("could not build an edge")
+            return
+        }
+        #expect(label.setTriangulationFromShape(edge, deflection: 1.0) == false)
+        #expect(label.triangulationNodeCount == 0)
+        #expect(label.triangulationTriangleCount == 0)
+    }
+}
+
 // MARK: - TDataXtd Point/Axis/Plane Attribute Tests (v0.56.0)
 
 @Suite("TDataXtd Point/Axis/Plane Attributes")

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -1565,6 +1565,155 @@ struct Issue443TriangulationAttributeTests {
         #expect(label.triangulationDeflection >= 0)
     }
 
+    /// The second behaviour change in this fix, and the one no node count would reveal: the
+    /// old code fetched each face's `TopLoc_Location` and **discarded** it, so a located
+    /// shape's nodes were stored in the face's own local frame. A box moved to
+    /// (100, 200, 300) stored a node at the origin; it now stores it at (100, 200, 300).
+    @Test("a located shape stores nodes in the shape's frame, not the face's")
+    func locatedShapeStoresShapeFrame() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let box = Shape.box(width: 10, height: 10, depth: 10),
+              let moved = box.moved(dx: 100, dy: 200, dz: 300)
+        else {
+            Issue.record("could not build the located box")
+            return
+        }
+        #expect(label.setTriangulationFromShape(moved, deflection: 1.0))
+        #expect(label.triangulationNodeCount == 24)
+
+        guard let bounds = moved.boundingBox else {
+            Issue.record("located box has no bounding box")
+            return
+        }
+        // Every stored node must lie inside the shape's own bounds. Before the fix they sat
+        // around the origin, 100mm+ outside them.
+        let slack = 1e-6
+        for i in Int32(1)...label.triangulationNodeCount {
+            guard let node = label.triangulationNode(at: i) else {
+                Issue.record("node \(i) could not be read")
+                return
+            }
+            #expect(node.x >= bounds.min.x - slack && node.x <= bounds.max.x + slack,
+                    "node \(i) x \(node.x) outside [\(bounds.min.x), \(bounds.max.x)]")
+            #expect(node.y >= bounds.min.y - slack && node.y <= bounds.max.y + slack,
+                    "node \(i) y \(node.y) outside [\(bounds.min.y), \(bounds.max.y)]")
+            #expect(node.z >= bounds.min.z - slack && node.z <= bounds.max.z + slack,
+                    "node \(i) z \(node.z) outside [\(bounds.min.z), \(bounds.max.z)]")
+        }
+    }
+
+    /// A mirrored shape reverses its faces, which is the other half of the per-face handling
+    /// (winding and node normals get flipped). #375's history here makes a mirrored fixture
+    /// worth pinning on its own: the merge must still cover every face and stay in frame.
+    @Test("a mirrored shape stores every face, in frame")
+    func mirroredShapeStoresEveryFace() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let box = Shape.box(origin: SIMD3(10, 0, 0), width: 10, height: 10, depth: 10),
+              let mirrored = box.mirrored(planeNormal: SIMD3(1, 0, 0), planeOrigin: SIMD3(0, 0, 0))
+        else {
+            Issue.record("could not build the mirrored box")
+            return
+        }
+        #expect(label.setTriangulationFromShape(mirrored, deflection: 1.0))
+        #expect(label.triangulationNodeCount == 24)
+        #expect(label.triangulationTriangleCount == 12)
+
+        guard let bounds = mirrored.boundingBox else {
+            Issue.record("mirrored box has no bounding box")
+            return
+        }
+        // The mirror puts the body at negative x; nodes stored in the wrong frame would not
+        // be in these bounds.
+        #expect(bounds.max.x < 1e-6, "mirrored box is not at negative x: \(bounds.max.x)")
+        for i in Int32(1)...label.triangulationNodeCount {
+            guard let node = label.triangulationNode(at: i) else {
+                Issue.record("node \(i) could not be read")
+                return
+            }
+            #expect(node.x >= bounds.min.x - 1e-6 && node.x <= bounds.max.x + 1e-6,
+                    "node \(i) x \(node.x) outside [\(bounds.min.x), \(bounds.max.x)]")
+        }
+    }
+
+    /// `triangulationNode(at:)` is the accessor that makes any of the above checkable: before
+    /// #443 the attribute exposed only counts and deflection, so nothing in the Swift API
+    /// could see the coordinates it stored.
+    @Test("triangulationNode rejects out-of-range and attribute-less labels")
+    func triangulationNodeBounds() {
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let empty = doc.createLabel(),
+              let box = Shape.box(width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build the document or the box")
+            return
+        }
+        #expect(empty.triangulationNode(at: 1) == nil)   // no attribute at all
+
+        #expect(label.setTriangulationFromShape(box, deflection: 1.0))
+        #expect(label.triangulationNode(at: 0) == nil)   // 1-based
+        #expect(label.triangulationNode(at: 1) != nil)
+        #expect(label.triangulationNode(at: label.triangulationNodeCount) != nil)
+        #expect(label.triangulationNode(at: label.triangulationNodeCount + 1) == nil)
+    }
+
+    /// The `hasNormals` branch of the merge is dead on the ordinary path:
+    /// `BRepMesh_IncrementalMesh` produces no node normals at all (measured, 0 of 6 box faces
+    /// and 0 of 1 sphere face). It fires only for a face that arrived carrying a
+    /// normal-bearing triangulation, which glTF import does produce, so that is the only way
+    /// to exercise it.
+    @Test("a glTF-imported mesh carries its node normals through the merge")
+    func importedNormalsSurviveTheMerge() throws {
+        guard let sphere = Shape.sphere(radius: 10.0) else {
+            Issue.record("could not build the sphere")
+            return
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt443_normals_\(UUID().uuidString).glb")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Exporter.writeGLTF(shape: sphere, to: url, binary: true, deflection: 0.5)
+
+        guard let imported = Shape.loadGLTF(from: url) else {
+            Issue.record("could not load the exported glTF back")
+            return
+        }
+        guard let doc = Document.create(), let label = doc.createLabel(),
+              let brepLabel = doc.createLabel()
+        else {
+            Issue.record("could not build the document")
+            return
+        }
+        #expect(label.setTriangulationFromShape(imported, deflection: 1.0))
+        #expect(label.triangulationNodeCount > 0)
+
+        // The branch this test exists for: normals are present, so the merge took the path
+        // that transforms and reverses them.
+        guard let first = label.triangulationNormal(at: 1) else {
+            Issue.record("the imported mesh stored no node normals, so the branch never ran")
+            return
+        }
+        #expect(abs(simd_length(first) - 1.0) < 1e-6, "normal is not unit length: \(first)")
+
+        // A sphere's outward normal at a node points away from the centre, so the dot product
+        // with the node position is positive. A dropped reversal would flip a face's worth.
+        var checked = 0
+        for i in Int32(1)...min(label.triangulationNodeCount, 200) {
+            guard let n = label.triangulationNormal(at: i),
+                  let p = label.triangulationNode(at: i) else { continue }
+            let radial = simd_length(p)
+            guard radial > 1e-6 else { continue }
+            #expect(simd_dot(n, p / radial) > 0.5,
+                    "node \(i) normal \(n) does not point outward from \(p)")
+            checked += 1
+        }
+        #expect(checked > 0, "no node normal could be checked")
+
+        // The contrast case, in the same test so the claim is pinned from both sides: the
+        // same sphere meshed from B-Rep stores no node normals at all.
+        #expect(brepLabel.setTriangulationFromShape(sphere, deflection: 0.5))
+        #expect(brepLabel.triangulationNodeCount > 0)
+        #expect(brepLabel.triangulationNormal(at: 1) == nil)
+    }
+
     /// The merge must not silently store an empty attribute when there is nothing to mesh.
     @Test("a shape with no face stores nothing")
     func noFaceStoresNothing() {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,320** of the entry points (~78% of the `Total` below); the rest are real, callable,
+categorisation covering **3,322** of the entry points (~78% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -71,7 +71,7 @@ a map of the major areas, and the `Total` as the count.
 | **Topological Naming** | 13 | createLabel, recordNaming, currentShape, storedShape, namingEvolution, namingHistory, oldShape, newShape, tracedForward, tracedBackward, selectShape, resolveShape, deepCopy |
 | **TDF/OCAF Framework** | 31 | mainLabel, tag, depth, isNull, isRoot, father, root, hasAttribute, attributeCount, hasChild, childCount, findChild, forgetAllAttributes, descendants, setName, setReference, referencedLabel, copyLabel, openTransaction, commitTransaction, abortTransaction, hasOpenTransaction, setUndoLimit, undoLimit, undo, redo, availableUndos, availableRedos, setModified, clearModified, isModified |
 | **TDataStd Attributes** | 25 | setInteger, integer, setReal, real, setAsciiString, asciiString, setComment, comment, initIntegerArray, setIntegerArrayValue, integerArrayValue, integerArrayBounds, initRealArray, setRealArrayValue, realArrayValue, realArrayBounds, setTreeNode, appendTreeChild, treeNodeFather, treeNodeFirstChild, treeNodeNext, treeNodeHasFather, treeNodeDepth, treeNodeChildCount, namedData(set/get/has integer/real/string) |
-| **TDataXtd Attributes** | 16 | setShapeAttr, shapeAttribute, hasShapeAttribute, setPositionAttr, positionAttribute, hasPositionAttribute, setGeometryType, geometryType, hasGeometryAttribute, setTriangulationFromShape, triangulationNodeCount, triangulationTriangleCount, triangulationDeflection, setPointAttr, setAxisAttr, setPlaneAttr |
+| **TDataXtd Attributes** | 18 | setShapeAttr, shapeAttribute, hasShapeAttribute, setPositionAttr, positionAttribute, hasPositionAttribute, setGeometryType, geometryType, hasGeometryAttribute, setTriangulationFromShape, triangulationNodeCount, triangulationTriangleCount, triangulationDeflection, triangulationNode, triangulationNormal, setPointAttr, setAxisAttr, setPlaneAttr |
 | **TFunction Framework** | 13 | setLogbook, logbookSetTouched, logbookSetImpacted, logbookIsModified, logbookClear, logbookIsEmpty, setGraphNode, graphNodeAddPrevious, graphNodeAddNext, setGraphNodeStatus, graphNodeStatus, graphNodeRemoveAllPrevious, graphNodeRemoveAllNext |
 | **TFunction Function** | 4 | setFunctionAttribute, functionIsFailed, functionFailure, setFunctionFailure |
 | **OCAF Persistence** | 17 | defineFormatBin, defineFormatBinL, defineFormatXml, defineFormatXmlL, defineFormatBinXCAF, defineFormatXmlXCAF, defineAllFormats, saveOCAF, loadOCAF, saveOCAFInPlace, createWithFormat, isSaved, storageFormat, setStorageFormat, documentCount, readingFormats, writingFormats |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,258** | |
+| **Total** | **4,260** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -705,7 +705,7 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `Shape.face(from:)` | `BRepBuilderAPI_MakeFace` |
 | `Shape.face(outer:holes:)` | `BRepBuilderAPI_MakeFace` |
 | `Shape.face(from:outer:innerWires:)` | `BRepBuilderAPI_MakeFace(surface, outer)` + `.Add(hole)` + `ShapeFix_Face` |
-| `Shape.solid(from:)` | `BRepBuilderAPI_MakeSolid` |
+| `Shape.solid(from:)` | `BRepBuilderAPI_MakeSolid` + `ShapeFix_Solid` (one solid per body-bounding shell) |
 | `Shape.sew(shapes:tolerance:)` | `BRepBuilderAPI_Sewing` |
 | `Wire.interpolate(through:)` | `GeomAPI_Interpolate` |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -219,6 +219,28 @@ each argument would make it stop meaning anything). `OCCTShapeBuildThreadCutter`
 single-body by construction. `Shape.faceRestricted(by:)` and `Wire.offset(by:joinType:)` already
 stated what they do and are untouched.
 
+**Review round 3: the one item left open, `Shape.solid(from:)`/`solidWithFullHistory(from:)`'s own
+`BRepBuilderAPI_MakeSolid` failure path.** Flagged unresolved in review round 2: before this PR, a
+`MakeSolid` failure on the (only) shell was a hard failure for the whole call; per-body, it silently
+dropped just that one body from the result compound — the exact defect class this PR exists to fix,
+reopened one layer down. Checked against `occt-src` rather than assumed: `BRepLib_MakeSolid`'s
+single-shell constructor (`BRepLib_MakeSolid.cxx`) unconditionally calls `Done()` after adding the
+shell, with no closure or coherence check anywhere in the path — matching its own header's "a solid
+under construction is always valid." Confirmed with a probe: `BRepBuilderAPI_MakeSolid` on a
+5-of-6-face open shell, and on a bare empty shell, both come back `IsDone() == true` with a non-null
+`Solid()` — just a geometrically invalid one (`BRepCheck_Analyzer.IsValid() == false`), not a failure.
+**So the failure this review item worried about cannot occur for this call**, confirmed by re-running
+the two new regression tests below against the pre-fix code: both still pass, because the code path
+they exercise never reaches the branch in question either way.
+
+Fixed anyway, for defense in depth: the dead `continue` (drop) is now `push_back` (keep the shell
+as-is), matching `OCCTShapeSolidFromShell`'s identical "keeps a body rather than dropping it if that
+changes" comment — same belt-and-braces contract as its #442 sibling, zero observable behaviour
+change today. Two new tests (`solid(from:) keeps an open body rather than dropping it`,
+`solidWithFullHistory(from:) keeps an open body rather than dropping it`) pin the guarantee that
+actually matters regardless of mechanism: a closed shell alongside a disjoint 5-of-6-face open shell
+still comes back as 2 bodies / 11 faces, not 1.
+
 Bridge-only fix: no OCCT kernel change and no `OCCT.xcframework` rebuild.
 
 ### v1.16.0 (July 2026): fix — `Shape.fixSolid()`/`solidFromShellFixed()` healed only the first body (#442)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -191,12 +191,21 @@ gives it, and the only one available without a declaration. A body nested inside
 twice, so it is still a body. None of #442's shipped cases change (two disjoint free shells → 2 solids;
 the same free shell twice → 1).
 
+The parity pass is O(N²) classifications in the size of one group, which was fine when a group was one
+solid's 1-3 shells but is not when it is every free shell of a sewn mesh. A conservative bounding-box
+pre-filter now prunes pairs before any ray cast, and skips building a classifier for a reference that
+overlaps nothing: enclosure implies box containment, so no verdict changes. Measured at 200 disjoint
+shells: 160 ms without it, 0.7 ms with, identical results. This is not the `Bnd_Box` rule #442
+rejected; that failed as the *decision* rule, which is exactly why it is sound as a pre-filter.
+
 > **Behaviour change for consumers:** `Shape.solid(from:)`, `Shape.solidWithFullHistory(from:)` and
 > `Shape.upgraded()` now return a **compound** where they previously returned one arbitrary body's
 > solid, for multi-body input only. Single-body input is untouched, down to the returned shape type.
 > A caller that assumed `.solid` unconditionally should read `.solids` instead.
 > `Shape.solidFromShellFixed()` returns **one** body where it returned two for a sewn hollow part,
-> the second having been the cavity.
+> the second having been the cavity. `AssemblyNode.setTriangulationFromShape` stores nodes in the
+> **shape's** frame rather than the first face's local frame, so a located shape's stored coordinates
+> move as well as its node count.
 
 The seven remaining undocumented picks are documented in place, in both the Swift doc comment and the
 bridge, with why each stays singular: `MedialAxis.init(of:)` (a medial axis is a property of one face,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -241,6 +241,26 @@ change today. Two new tests (`solid(from:) keeps an open body rather than droppi
 actually matters regardless of mechanism: a closed shell alongside a disjoint 5-of-6-face open shell
 still comes back as 2 bodies / 11 faces, not 1.
 
+**Review round 4: `OCCTShapeUpgrade` had the same dead-but-inconsistent `MakeSolid` drop round 3
+fixed on its siblings, and two doc passages didn't hold up.** Round 3 fixed the silent per-body drop
+on `Shape.solid(from:)`/`solidWithFullHistory(from:)`, but `OCCTShapeUpgrade`'s own per-shell loop —
+touched by this same PR — still had the plain `continue`-style drop, missed because it wasn't one of
+the two functions round 3's own finding was about. Fixed the same way: `push_back` the unfixed shell
+on `IsDone() == false` instead of dropping it, same belt-and-braces reasoning, same "dead code today"
+status (verified: `BRepBuilderAPI_MakeSolid`'s single-shell constructor never fails). A new test,
+`upgraded() keeps an unclosable shell's faces rather than dropping them`, pins it — on face count
+rather than solid count, since `upgraded()`'s later `ShapeFix_Shape` pass reclassifies the kept body
+so it no longer counts as a `TopAbs_SOLID`, unlike the round-3 siblings that don't run that pass.
+
+Also: three existing `docs/reference/` pages covering methods documented (not changed) by this PR —
+`Shape-Measurement.md` (`fillet2D`/`chamfer2D`/`solidFromShells`), `Shape-Builders-1.md`
+(`splitByWireOnFace`), `Shape-Builders-2.md` (`locOpeSplit(wiresOnFaces:)`) — had the caveat added to
+the Swift doc comment but not mirrored into the page; now they match. And `upgraded()`'s own doc
+comment claimed "free shells each become a body," which is what this very PR's free-shell parity fix
+made untrue — the next line already stated the correct, narrower rule (an even-enclosed free shell is
+skipped), so the topic sentence was reworded to match rather than contradict it, reusing
+`solid(from:)`'s more precise phrasing.
+
 Bridge-only fix: no OCCT kernel change and no `OCCT.xcframework` rebuild.
 
 ### v1.16.0 (July 2026): fix — `Shape.fixSolid()`/`solidFromShellFixed()` healed only the first body (#442)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -129,6 +129,89 @@ zero-area curved wire that must still be declined, and the boundary-crossing wir
 turn into a hole; `Issue234DegenerateHoleTests` passes unchanged. Full `swift test` (combined with
 #446 above): 4480 tests in 1292 suites, all passing.
 
+### Unreleased: fix - three more first-of-N `TopExp_Explorer` sites dropped most of their input (#443)
+
+> Version and date are deliberately unset: this entry is written on a branch, and the next patch
+> number is not this PR's to claim. Whoever tags stamps it then.
+
+#442's audit note asked for the first-of-N `TopExp_Explorer` idiom to be grepped for across the whole
+bridge before closing it, on the grounds that #439 had two instances and #442 two more, and every one
+was found by someone reading the neighbouring lines rather than from a report. That sweep found **23
+candidate sites**: 8 false positives, 5 where "first" is the documented contract, and 10 undocumented
+silent picks. Three of those were confirmed **by measurement** to lose most of their input, and are
+fixed here. The other seven are documented rather than changed: each is singular by contract, and
+widening it would change what its arguments mean.
+
+Measured against a compound of two disjoint 10 mm boxes (2 solids, 12 faces, 2000 mm³):
+
+| call | before | after |
+| --- | --- | --- |
+| `Shape.solid(from:)` | 1 solid, 1000 mm³ | 2 solids, 2000 mm³ |
+| `Shape.upgraded()` | 1 solid, 1000 mm³ | 2 solids, 2000 mm³ |
+| `AssemblyNode.setTriangulationFromShape` | 4 nodes, 2 triangles | 48 nodes, 24 triangles |
+
+**`Shape.solid(from:)`** (and `Shape.solidWithFullHistory(from:)`) is the sharpest of the three: its
+own doc names sewing output as the expected input, and sewing two bodies yields exactly the two-shell
+input it mishandled. After #442 the two sibling entry points disagreed on that same shape:
+`sewn.solidFromShellFixed()` gave 2 solids / 2000 mm³ and `Shape.solid(from: sewn)` gave 1 / 1000.
+Both now go through #442's `occtBodyBoundingShells`, so they agree by construction; the helper moved
+to `OCCTBridge_Internal.h` for that. The history variant shares **one** `ShapeBuild_ReShape` across
+the per-body `ShapeFix_Solid` runs, so the single history still covers every body:
+`BRepTools_ReShape::History()` builds a fresh `BRepTools_History` from the context's whole replacement
+map on each call, so earlier bodies' replacements are still in it (confirmed against `occt-src`).
+
+**`Shape.upgraded()`** is documented as a "sew + make solid + heal pipeline" and is the call most
+likely to be pointed at a raw imported mesh, where multi-body input is the norm. Its solid step now
+builds one solid per body-bounding shell. Two limits inherent to sewing first are now documented
+rather than silent: sewing dissolves the input's solids, so a **hollow body's cavity is filled**
+(8000 mm³ for a 7000 mm³ hollow cube, unchanged from before but never stated); and the solid step
+replaces the sewn shape rather than merging into it, so content sewing could not attach to a shell is
+not carried through. `fixed(tolerance:)` is the call for either case, since it does not sew.
+
+**`AssemblyNode.setTriangulationFromShape`** meshed the whole shape and then stored only the **first
+face's** triangulation on the label. A 6-face box and a 12-face two-box compound both stored 4 nodes
+and 2 triangles, for a doc comment reading "by meshing a shape". Arguably the worst of the three,
+since the attribute is what later readers trust as the label's geometry. It now merges every meshed
+face into one `Poly_Triangulation` in the shape's own coordinate system: per-face locations applied to
+the nodes, reversed faces' winding and node normals flipped so the result is consistently outward
+(the same rules `Shape.mesh()` applies), the worst contributing face's deflection carried over, node
+normals kept only if every face has them, and per-face UV nodes dropped since they index parameter
+spaces that stop meaning anything once the faces are pooled.
+
+**A latent case in #442's own helper was found and fixed with them.** `occtBodyBoundingShells` ran its
+enclosure-parity pass within each solid but added every shell belonging to *no* solid unconditionally,
+on the reasoning that a free shell has no declared cavity relationship. But **sewing dissolves the
+solid that carried that declaration**, and sewing is the ordinary way all of these calls are reached.
+Measured on a sewn hollow box: the same two shells answered 1 body while inside a solid and 2 once
+sewn, the second being the cavity as a positive solid; on `{hollow body, body inside its cavity}` it
+gave 3 bodies for a 2-body part. Free shells are now one further group through the same parity pass,
+so both readings agree. Containment among free shells is geometric rather than declared, so a closed
+shell alone inside another is read as that one's cavity: the same reading OCCT's own solid convention
+gives it, and the only one available without a declaration. A body nested inside a cavity is enclosed
+twice, so it is still a body. None of #442's shipped cases change (two disjoint free shells → 2 solids;
+the same free shell twice → 1).
+
+> **Behaviour change for consumers:** `Shape.solid(from:)`, `Shape.solidWithFullHistory(from:)` and
+> `Shape.upgraded()` now return a **compound** where they previously returned one arbitrary body's
+> solid, for multi-body input only. Single-body input is untouched, down to the returned shape type.
+> A caller that assumed `.solid` unconditionally should read `.solids` instead.
+> `Shape.solidFromShellFixed()` returns **one** body where it returned two for a sewn hollow part,
+> the second having been the cavity.
+
+The seven remaining undocumented picks are documented in place, in both the Swift doc comment and the
+bridge, with why each stays singular: `MedialAxis.init(of:)` (a medial axis is a property of one face,
+and the result type holds one graph), `Shape.halfSpace(face:referencePoint:)` (a half-space is bounded
+by one face by definition), `Shape.fillet2D(vertexIndices:radii:)` and `chamfer2D(edgePairs:distances:)`
+(the indices are numbered within the chosen face, so covering every face would need per-face index
+lists and a different signature), `Shape.splitByWireOnFace(_:faceIndex:)` and
+`locOpeSplit(wiresOnFaces:)` (the pair list is already where several wires are named), and
+`Shape.solidFromShells(_:)` (the argument order *is* the outer-versus-cavity contract, so widening
+each argument would make it stop meaning anything). `OCCTShapeBuildThreadCutter` is internal and
+single-body by construction. `Shape.faceRestricted(by:)` and `Wire.offset(by:joinType:)` already
+stated what they do and are untouched.
+
+Bridge-only fix: no OCCT kernel change and no `OCCT.xcframework` rebuild.
+
 ### v1.16.0 (July 2026): fix — `Shape.fixSolid()`/`solidFromShellFixed()` healed only the first body (#442)
 
 `Shape.fixSolid()` and `Shape.solidFromShellFixed()` healed the **first** solid (respectively the

--- a/docs/guides/cookbook/healing-and-validity.md
+++ b/docs/guides/cookbook/healing-and-validity.md
@@ -80,6 +80,16 @@ let upgraded = shape.upgraded(tolerance: 1e-3)         // sew + make-solid + hea
   precision of imported data (e.g. `1e-3`, not the default `1e-6`).
 - **`unified()`** — `ShapeUpgrade_UnifySameDomain`; the standard **post-boolean** cleanup that merges
   the redundant faces/edges a boolean leaves behind.
+- **`upgraded(tolerance:)`** sews, then builds one solid per body, then heals. A **multi-body** part
+  stays multi-body and comes back as a compound of solids. Two things sewing costs you here: a hollow
+  body's **cavity is filled** (sewing dissolves the solid that declared it), and content that would
+  not attach to a shell is dropped. Use `fixed(tolerance:)` instead when either matters; it does not
+  sew.
+
+```swift
+let part = twoBodyImport.upgraded(tolerance: 1e-3)!
+print(part.solids.count)   // 2, every body kept
+```
 
 **Declining a merge is safe.** The usual shape of this call is "take the merge if it survives your
 acceptance checks, otherwise keep what you had":

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -860,16 +860,19 @@ Create a closed solid from a shell, using `ShapeFix_Solid` to orient and close t
 public func solidFromShellFixed() -> Shape?
 ```
 
-One solid is built per *body-bounding* shell, not just the first shell found (#442): within each
-solid, every shell that an **even** number of the other shells enclose, plus every shell that belongs
-to no solid (the usual shape of sewing output). A single body comes back as a solid, several as a
-compound in exploration order.
+One solid is built per *body-bounding* shell, not just the first shell found (#442): every shell that
+an **even** number of the other shells in its group enclose, where a group is one solid's own shells,
+or all the shells belonging to no solid (the usual shape of sewing output). A single body comes back
+as a solid, several as a compound in exploration order. [`Shape.solid(from:)`](Shape-Features.md#shapesolidfrom)
+makes the same selection, so the two agree on any input.
 
-A solid's **cavity** shells are deliberately skipped: a hole is not a body, and building it as a
-positive solid would yield a compound whose volume double-counts the part. So a hollow solid produces
-one solid bounded by its outer shell, with the cavity filled. To rebuild a solid that keeps its
-cavities, use [`Shape.solidFromShells(_:)`](Shape-Measurement.md#solidfromshells_) with the outer
-shell first.
+**Cavity** shells are deliberately skipped: a hole is not a body, and building it as a positive solid
+would yield a compound whose volume double-counts the part. So a hollow solid produces one solid
+bounded by its outer shell, with the cavity filled, and so does that same body after sewing has left
+its two shells free, since the free-shell group goes through the same parity pass (#443). A body
+nested inside another body's cavity is enclosed twice, so it is still read as a body. To rebuild a
+solid that keeps its cavities, use [`Shape.solidFromShells(_:)`](Shape-Measurement.md#solidfromshells_)
+with the outer shell first.
 
 > An **open** shell is not rejected. `ShapeFix_Solid::SolidFromShell` builds its solid before
 > classifying anything and never returns a null one, so a shell with gaps comes back as a solid that

--- a/docs/reference/Document.md
+++ b/docs/reference/Document.md
@@ -1957,6 +1957,10 @@ public func setTriangulationFromShape(_ shape: Shape, deflection: Double = 1.0) 
 
 Meshes the shape and stores **every** face's triangulation, merged into one `Poly_Triangulation` in the shape's own coordinate system: per-face locations are applied to the nodes, and reversed faces have their winding and node normals flipped so the stored mesh is consistently outward. Node normals survive only if every contributing face carries them; per-face UV nodes are dropped, since they index parameter spaces that no longer mean anything once the faces are pooled. The stored deflection is the worst of the contributing faces'.
 
+> **The stored coordinate frame changed alongside the every-face fix.** This previously fetched each face's `TopLoc_Location` and **discarded** it, storing one face's nodes in that *face's* local frame. It now stores them in the **shape's** frame. For a shape with a non-identity location (an assembly component, anything from `Shape.moved(dx:dy:dz:)` or `located(matrix:)`) the numbers move independently of the node-count change: a box translated to (100, 200, 300) used to store a node at the origin and now stores it at (100, 200, 300). Re-read any OCAF document persisted before this change if you compare stored triangulations.
+
+Node normals are transformed and reversed here, which `Shape.mesh(...)` does **not** do for its own `Mesh.normals` (only the winding swap matches), so the two disagree for a located or reversed face. `BRepMesh_IncrementalMesh` produces no node normals at all, so this only arises for a face carrying a triangulation from elsewhere, such as glTF import.
+
 - **Parameters:** `shape`, the shape to tessellate, faces at any depth included; `deflection`, linear deflection for meshing (default `1.0`).
 - **Returns:** `false` if the shape has no face, or if nothing in it meshed.
 - **OCCT:** `BRepMesh_IncrementalMesh` + `TDataXtd_Triangulation::Set` (via `OCCTDocumentSetTriangulationFromShape`).
@@ -1992,6 +1996,50 @@ public var triangulationTriangleCount: Int32 { get }
 ```
 
 - **OCCT:** `Poly_Triangulation::NbTriangles` (via `OCCTDocumentTriangulationNbTriangles`).
+
+---
+
+### `triangulationNode(at:)`
+
+Read one node of the triangulation attribute, in the frame it was stored in.
+
+```swift
+public func triangulationNode(at index: Int32) -> SIMD3<Double>?
+```
+
+Nodes are numbered from 1, as `Poly_Triangulation` numbers them. Before this existed the attribute exposed only its counts and deflection, so nothing in the Swift API could see the coordinates it held.
+
+- **Parameters:** `index`, 1-based node index.
+- **Returns:** The node position, or `nil` if the label has no triangulation attribute or `index` is out of range.
+- **OCCT:** `Poly_Triangulation::Node` (via `OCCTDocumentTriangulationNode`).
+- **Example:**
+  ```swift
+  let moved = Shape.box(width: 10, height: 10, depth: 10)!.moved(dx: 100, dy: 200, dz: 300)!
+  label.setTriangulationFromShape(moved, deflection: 1.0)
+  print(label.triangulationNode(at: 1)!)   // absolute, not the box's local frame
+  ```
+
+---
+
+### `triangulationNormal(at:)`
+
+Read one node normal of the triangulation attribute, in the frame it was stored in.
+
+```swift
+public func triangulationNormal(at index: Int32) -> SIMD3<Double>?
+```
+
+Node normals exist only when the meshed faces carried them. `BRepMesh_IncrementalMesh` produces none, so this returns `nil` for anything meshed from B-Rep and a value for a shape whose faces arrived with a triangulation from elsewhere, such as glTF import.
+
+- **Parameters:** `index`, 1-based node index.
+- **Returns:** The unit normal, or `nil` if there is no attribute, the stored triangulation has no node normals, or `index` is out of range.
+- **OCCT:** `Poly_Triangulation::Normal` guarded by `HasNormals` (via `OCCTDocumentTriangulationNormal`).
+- **Example:**
+  ```swift
+  let imported = Shape.loadGLTF(from: url)!    // glTF meshes carry vertex normals
+  label.setTriangulationFromShape(imported, deflection: 1.0)
+  print(label.triangulationNormal(at: 1)!)
+  ```
 
 ---
 

--- a/docs/reference/Document.md
+++ b/docs/reference/Document.md
@@ -1955,8 +1955,19 @@ Set a triangulation attribute on this label by meshing a shape.
 public func setTriangulationFromShape(_ shape: Shape, deflection: Double = 1.0) -> Bool
 ```
 
-- **Parameters:** `shape` — the shape to tessellate; `deflection` — linear deflection for meshing (default `1.0`).
+Meshes the shape and stores **every** face's triangulation, merged into one `Poly_Triangulation` in the shape's own coordinate system: per-face locations are applied to the nodes, and reversed faces have their winding and node normals flipped so the stored mesh is consistently outward. Node normals survive only if every contributing face carries them; per-face UV nodes are dropped, since they index parameter spaces that no longer mean anything once the faces are pooled. The stored deflection is the worst of the contributing faces'.
+
+- **Parameters:** `shape`, the shape to tessellate, faces at any depth included; `deflection`, linear deflection for meshing (default `1.0`).
+- **Returns:** `false` if the shape has no face, or if nothing in it meshed.
 - **OCCT:** `BRepMesh_IncrementalMesh` + `TDataXtd_Triangulation::Set` (via `OCCTDocumentSetTriangulationFromShape`).
+- **Example:**
+  ```swift
+  let label = doc.createLabel()!
+  label.setTriangulationFromShape(Shape.box(width: 10, height: 10, depth: 10)!,
+                                  deflection: 1.0)
+  print(label.triangulationNodeCount)      // 24, all six faces, not 4
+  print(label.triangulationTriangleCount)  // 12
+  ```
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1309,6 +1309,8 @@ public func splitByWireOnFace(_ wire: Shape, faceIndex: Int32) -> Shape?
 - **Parameters:** `wire` — the splitting wire shape; `faceIndex` — 1-based index of the face to split.
 - **Returns:** Modified shape with the face split, or `nil` on failure.
 - **OCCT:** `LocOpe_WiresOnShape` + `LocOpe_Spliter` via `OCCTLocOpeSplitByWireOnFace`.
+- **Note:** Only the **first** wire of `wire` is used. Passing a shape that holds several wires
+  splits by one of them and silently ignores the rest; call once per wire. (#443 audit)
 
 ---
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -1891,6 +1891,9 @@ public func locOpeSplit(wiresOnFaces: [(wire: Shape, face: Shape)]) -> LocOpeSpl
 - **Parameters:** `wiresOnFaces` — pairs binding each wire to the face it lies on.
 - **Returns:** Split result with direct-left faces, or `nil` on failure.
 - **OCCT:** `LocOpe_WiresOnShape` + `LocOpe_Spliter`
+- **Note:** Each pair contributes only the **first** wire of its `wire` shape. A pair whose
+  shape holds several wires binds one of them and ignores the rest; give each wire its own
+  pair. A pair whose shape holds no wire at all is skipped silently. (#443 audit)
 - **Example:**
   ```swift
   if let r = solid.locOpeSplit(wiresOnFaces: [(wire: w, face: f)]) {

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -69,13 +69,21 @@ public static func solid(from shell: Shape) -> Shape?
 
 The shell must be closed (no gaps). A shell produced by `sew(shapes:)` is typically already closed when all boundary faces are included.
 
+One solid is built per **body-bounding** shell, not just the first shell found: every shell that an *even* number of the other shells in its group enclose, where a group is one solid's own shells, or all the shells belonging to no solid (the usual shape of sewing output). A single body comes back as a solid, several as a compound in exploration order. This is the same selection ``Shape.solidFromShellFixed()`` makes, so the two agree on any input.
+
+*Cavity* shells are skipped: a hole is not a body, and building one as a positive solid would return a compound whose volume double-counts the part. A body nested inside another body's cavity is enclosed twice, so it is still read as a body. To rebuild a solid that keeps its cavities, use `Shape.solidFromShells(_:)` with the outer shell first.
+
 - **Parameters:** `shell` — a shell shape (from sewing or face assembly).
-- **Returns:** A solid shape, or `nil` if the shell is not closed.
-- **OCCT:** `BRepBuilderAPI_MakeSolid(shell)`.
+- **Returns:** A solid, a compound of solids for multi-body input, or `nil` if the shape holds no shell at all.
+- **OCCT:** `BRepBuilderAPI_MakeSolid(shell)` + `ShapeFix_Solid` (orientation).
 - **Example:**
   ```swift
   let sewn = Shape.sew(shapes: faces, tolerance: 1e-6)!
   let solid = Shape.solid(from: sewn)!
+
+  // Sewing two disjoint bodies yields two shells, so this yields two solids.
+  let both = Shape.solid(from: Shape.sew(shapes: [bodyA, bodyB], tolerance: 1e-6)!)!
+  print(both.solids.count)   // 2
   ```
 
 ---

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -217,7 +217,7 @@ public func upgraded(tolerance: Double = 1e-6) -> Shape?
 
 Applies a complete upgrade pipeline: sewing of disconnected faces, an attempt to build a solid from the resulting shells, and a final `ShapeFix_Shape` healing pass.
 
-The solid step builds one solid per **body-bounding** shell the sewing produced, so a multi-body part stays a multi-body part: it comes back as a compound of solids, and a single body as a bare solid. Body selection is the same rule as `Shape.solid(from:)`: cavity shells are skipped, free shells each become a body.
+The solid step builds one solid per **body-bounding** shell the sewing produced, so a multi-body part stays a multi-body part: it comes back as a compound of solids, and a single body as a bare solid. Body selection is the same rule as `Shape.solid(from:)`: every shell that an **even** number of the other shells in its group enclose, where a group is one solid's own shells, or all the shells belonging to no solid — so a free shell that is itself an even-enclosed cavity is skipped, not turned into a body.
 
 Two things this pipeline does not preserve, both inherent to sewing first:
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -217,6 +217,13 @@ public func upgraded(tolerance: Double = 1e-6) -> Shape?
 
 Applies a complete upgrade pipeline: sewing of disconnected faces, an attempt to build a solid from the resulting shells, and a final `ShapeFix_Shape` healing pass.
 
+The solid step builds one solid per **body-bounding** shell the sewing produced, so a multi-body part stays a multi-body part: it comes back as a compound of solids, and a single body as a bare solid. Body selection is the same rule as `Shape.solid(from:)`: cavity shells are skipped, free shells each become a body.
+
+Two things this pipeline does not preserve, both inherent to sewing first:
+
+- Sewing dissolves the input's solids, so a hollow body reaches the solid step as two free shells and comes back as one body with its **cavity filled** (8000 mm³ for a 7000 mm³ hollow cube). A body nested inside another body's cavity is still read as a body. To heal a hollow part without losing its cavities, use `fixed(tolerance:)`, which does not sew.
+- The solid step *replaces* the sewn shape rather than merging into it, so content sewing could not attach to a shell (a stray face, a loose edge) is not carried into the result.
+
 - **Parameters:** `tolerance` — tolerance used for sewing and healing (default 1e-6).
 - **Returns:** Upgraded shape, or nil on failure.
 - **OCCT:** `BRepBuilderAPI_Sewing` + `BRepBuilderAPI_MakeSolid` + `ShapeFix_Shape` (via `OCCTShapeUpgrade`).
@@ -225,6 +232,10 @@ Applies a complete upgrade pipeline: sewing of disconnected faces, an attempt to
   if let solid = roughImport.upgraded(tolerance: 0.01) {
       #expect(solid.isValid)
   }
+
+  // A raw imported mesh holding two separate bodies stays two bodies.
+  let part = twoBodyImport.upgraded(tolerance: 1e-6)!
+  print(part.solids.count)   // 2, not 1
   ```
 
 ---

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -749,6 +749,9 @@ The first shape provides the outer shell; additional shapes provide cavity (inne
 - **Parameters:** `shells` — Array of shapes containing shells; must not be empty.
 - **Returns:** Solid shape, or `nil` on failure.
 - **OCCT:** `BRepBuilderAPI_MakeSolid` (via `OCCTSolidFromShells`).
+- **Note:** Each element contributes only the **first** shell found in it, so pass one shape per
+  shell rather than a compound of several. An element holding no shell is skipped silently,
+  except the first, which fails the whole call. (#443 audit)
 - **Example:**
   ```swift
   if let solid = Shape.solidFromShells([outerShell, innerShell]) {
@@ -772,6 +775,9 @@ public func fillet2D(vertexIndices: [Int], radii: [Double]) -> Shape?
 - **Returns:** Modified shape with fillets, or `nil` on failure.
 - **OCCT:** `BRepFilletAPI_MakeFillet2d` (via `OCCTFace2DFillet`).
 - **Note:** `vertexIndices` and `radii` must have equal length; mismatch returns `nil`.
+- **Note:** Only the **first** face of the receiver is filleted, and the result is that face
+  alone; the other faces of a multi-face shape are neither filleted nor carried through. Vertex
+  indices are numbered within that first face. Call this on one face at a time. (#443 audit)
 
 ---
 
@@ -788,6 +794,9 @@ public func chamfer2D(edgePairs: [(Int, Int)], distances: [Double]) -> Shape?
   - `distances` — Chamfer distance for each edge pair.
 - **Returns:** Modified shape with chamfers, or `nil` on failure.
 - **OCCT:** `BRepFilletAPI_MakeFillet2d` (via `OCCTFace2DChamfer`).
+- **Note:** Only the **first** face of the receiver is chamfered, and the result is that face
+  alone; the other faces of a multi-face shape are neither chamfered nor carried through. Edge
+  indices are numbered within that first face. Call this on one face at a time. (#443 audit)
 
 ---
 


### PR DESCRIPTION
Closes #443.

#442's audit note asked for the first-of-N `TopExp_Explorer` idiom to be swept across the whole
bridge before closing it. The sweep found 23 candidates: 8 false positives, 5 where "first" is the
documented contract, and 10 undocumented silent picks. Three of those lose most of their input and
are fixed here; the other seven are documented rather than changed, since each is singular by
contract and widening it would change what its arguments mean.

## Measured, against a compound of two disjoint 10 mm boxes (2 solids, 12 faces, 2000 mm³)

| call | before | after |
| --- | --- | --- |
| `Shape.solid(from:)` | 1 solid, 1000 mm³ | 2 solids, 2000 mm³ |
| `Shape.upgraded()` | 1 solid, 1000 mm³ | 2 solids, 2000 mm³ |
| `AssemblyNode.setTriangulationFromShape` | 4 nodes, 2 triangles | 48 nodes, 24 triangles |

## `Shape.solid(from:)` and `Shape.solidWithFullHistory(from:)`

The sharpest of the three: the doc names sewing output as the expected input, and sewing two bodies
yields exactly the two-shell input it mishandled. After #442 the two sibling entry points disagreed
on that same shape, `sewn.solidFromShellFixed()` giving 2 solids / 2000 mm³ and
`Shape.solid(from: sewn)` giving 1 / 1000. Both now go through #442's `occtBodyBoundingShells`,
which moved to `OCCTBridge_Internal.h` for it, so they agree by construction.

The history variant shares **one** `ShapeBuild_ReShape` across the per-body `ShapeFix_Solid` runs.
`BRepTools_ReShape::History()` builds a fresh `BRepTools_History` from the context's whole
replacement map on each call (read in `occt-src`, confirmed on a probe), so the single history still
covers every body rather than only the last one built.

## `Shape.upgraded()`

The call most likely to be pointed at a raw imported mesh, where multi-body input is the norm. Its
solid step now builds one solid per body-bounding shell. Two limits inherent to sewing first are now
documented rather than silent:

- sewing dissolves the input's solids, so a hollow body's **cavity is filled** (8000 mm³ for a
  7000 mm³ hollow cube, unchanged from before but never stated);
- the solid step replaces the sewn shape rather than merging into it, so content sewing could not
  attach to a shell is not carried through.

`fixed(tolerance:)` is the call for either case, and is now cross-referenced.

## `AssemblyNode.setTriangulationFromShape`

Meshed the whole shape and stored only the **first face's** triangulation, so a 6-face box and a
12-face compound both stored 4 nodes and 2 triangles for a doc comment reading "by meshing a shape".
Arguably the worst of the three, since the attribute is what later readers trust as the label's
geometry. It now merges every meshed face into one `Poly_Triangulation` in the shape's own
coordinate system: per-face locations applied to the nodes, reversed faces' winding and node normals
flipped so the result is consistently outward (the same rules `Shape.mesh()` applies), the worst
contributing face's deflection carried over, node normals kept only if every face has them, and
per-face UV nodes dropped since they index parameter spaces that stop meaning anything once the
faces are pooled.

The deflection part was caught by the *existing* `Triangulation deflection` test, not by a new one: a
hand-built `Poly_Triangulation` starts at 0, and a 0 there would read as "exact".

## A latent case in #442's own helper, found and fixed with them

`occtBodyBoundingShells` ran its enclosure-parity pass within each solid but added every shell
belonging to *no* solid unconditionally, on the reasoning that a free shell has no declared cavity
relationship. But **sewing dissolves the solid that carried that declaration**, and sewing is the
ordinary way all of these calls are reached. Measured:

| input | before | after |
| --- | --- | --- |
| sewn hollow box | 2 bodies (cavity emitted) | 1 body, 8000 mm³ |
| `{hollow body, body inside its cavity}`, sewn | 3 bodies, 6784 mm³ | 2 bodies, 8512 mm³ |
| hollow solid, not sewn | 1 body, 8000 mm³ | unchanged |
| two disjoint free shells | 2 bodies, 2000 mm³ | unchanged |
| same free shell twice | 1 body, 1000 mm³ | unchanged |

Free shells are now one further group through the same parity pass, so a hollow body reads the same
whether or not it has been sewn. Containment among free shells is geometric rather than declared, so
a closed shell sitting alone inside another is read as that one's cavity: the same reading OCCT's own
solid convention gives it, and the only one available without a declaration. A body nested inside a
cavity is enclosed twice, so it is still a body. None of #442's shipped cases change.

> **Behaviour change for consumers.** `Shape.solid(from:)`, `Shape.solidWithFullHistory(from:)` and
> `Shape.upgraded()` return a **compound** where they previously returned one arbitrary body's solid,
> for multi-body input only. Single-body input is untouched, down to the returned shape type.
> `Shape.solidFromShellFixed()` returns **one** body where it returned two for a sewn hollow part,
> the second having been the cavity.

## The seven documented, not changed

Each gets a `- Note:` on the Swift wrapper and a `#443 audit:` comment on the bridge function saying
why it stays singular: `MedialAxis.init(of:)` (a medial axis is a property of one face, and the
result type holds one graph), `Shape.halfSpace(face:referencePoint:)` (a half-space is bounded by one
face by definition), `Shape.fillet2D(vertexIndices:radii:)` and `chamfer2D(edgePairs:distances:)`
(the indices are numbered within the chosen face, so covering every face needs per-face index lists
and a different signature), `Shape.splitByWireOnFace(_:faceIndex:)` and `locOpeSplit(wiresOnFaces:)`
(the pair list is already where several wires are named), and `Shape.solidFromShells(_:)` (the
argument order *is* the outer-versus-cavity contract). `OCCTShapeBuildThreadCutter` is internal and
single-body by construction. `Shape.faceRestricted(by:)` and `Wire.offset(by:joinType:)` already
stated what they do and are untouched.

## Review round 2

Rebased onto `4bdc30a` (v1.16.0). The new entry sits above the now-versioned v1.16.0 block and stays
unversioned.

**The free-shell parity group was O(N²) on this PR's own primary input.** Inside a solid N is 1-3,
which is what the inherited comment assumed; sewing a raw imported mesh yields hundreds of disjoint
shells. A conservative bounding-box pre-filter now prunes pairs before any ray cast and skips building
a classifier for a reference that overlaps nothing. Enclosure implies box containment, so no verdict
changes:

| N disjoint shells | without pre-filter | with |
| --- | --- | --- |
| 50 | 15.8 ms | 0.2 ms |
| 100 | 44.7 ms | 0.3 ms |
| 200 | 160.4 ms | 0.7 ms |

Identical results on `{outer, cavity}` (1), `{outer, cavity, nested body}` (2) and `{two touching
boxes}` (2). Two new tests cover it: 100 disjoint free shells, and two touching bodies whose boxes
overlap without enclosure, so the cheap test cannot decide them and the ray cast must still run.

**`setTriangulationFromShape` also changed coordinate frames, and that was undisclosed.** The old code
fetched each face's `TopLoc_Location` and discarded it. Measured: a box moved to (100, 200, 300) stored
node 1 at the origin, and now stores it at (100, 200, 300). Now stated in the doc comment, the
CHANGELOG behaviour-change block, `docs/reference/Document.md` and above.

**The `OCCTShapeCreateMesh` parity claim was wrong for normals.** That function pushes
`triangulation->Normal(i)` raw, with neither the location transform nor the reversal, so only its
winding swap matches. The comment is corrected, and the consequence (`Mesh.normals` disagrees with this
attribute for a located or reversed face) is recorded as `Shape.mesh()`'s question rather than papered
over.

**The normals branch is unreachable via `BRepMesh_IncrementalMesh`**, which produces no node normals at
all: 0 of 6 box faces, 0 of 1 sphere face. It *is* reachable through glTF import, so it is now tested
rather than only reasoned about: a sphere written to GLB and read back stores unit normals that point
outward, and the same sphere meshed from B-Rep stores none.

**Two accessors added, because none of the above was checkable.** The attribute exposed only counts and
deflection, so nothing in the Swift API could read the coordinates it stored, which is part of why both
defects survived. `AssemblyNode.triangulationNode(at:)` and `triangulationNormal(at:)`: 2 operations,
counts refreshed with `Scripts/count-operations.py --fix` (4,258 to 4,260).

New fixtures for the coverage gap: a located box (nodes must fall inside the shape's own bounds) and a
mirrored box (body at negative x, every face still stored).

Both minor items applied: the shared-`ReShape` comment now notes that each body's `Perform` applies
against a map already holding the earlier bodies' replacements, and the parity comment carries the cost
note for the unbounded free-shell group.

## Review round 4

`OCCTShapeUpgrade`'s own per-shell `MakeSolid` loop — touched by this same PR — had the identical
plain-`continue` drop that round 3 fixed on `Shape.solid(from:)`/`solidWithFullHistory(from:)`, missed
because it wasn't one of the two functions round 3's finding was about. Fixed the same way
(`push_back` the unfixed shell rather than dropping it), same "dead code today, fixed for symmetry"
status. New test: `upgraded() keeps an unclosable shell's faces rather than dropping them` — asserts
on face count, not solid count, since `upgraded()`'s later `ShapeFix_Shape` pass reclassifies the kept
body so it no longer counts as a `TopAbs_SOLID`, unlike the round-3 siblings.

Also: three existing `docs/reference/` pages (`Shape-Measurement.md`, `Shape-Builders-1.md`,
`Shape-Builders-2.md`) covering methods this PR documents-not-changes had the new caveat in the Swift
doc comment but not mirrored into the page; now they match. And `upgraded()`'s doc comment said "free
shells each become a body," which the free-shell parity fix in this same PR made untrue — reworded to
match the correct rule the very next line already stated.

## Verification

Ground truth in C++ first for all three defects and all three fixes, and again for every claim in the
review round (the pre-filter cost and verdicts, the frame change, the normals branch reachability),
then `swift test` green at **4,511 tests** (1294 suites). 31 new tests: 22 in
`Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift`, 9 plus one extended existing test in
`Tests/OCCTXCAFTests`.

Bridge-only: no OCCT kernel change and no `OCCT.xcframework` rebuild. `Sources/OCCTBridge/src/*.mm`
did change, so whoever tags this needs to rebuild and re-attach `OCCTBridge.xcframework.zip` and bump
`Package.swift`'s URL and checksum, per the usual release step.

CHANGELOG entry is deliberately unversioned, matching the #430/#439/#442 precedent.

Related: #439 (`outerShell`/`innerShells`, PR #441), #442 (`fixSolid`/`solidFromShellFixed`, PR #444).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

