### PR TITLE
Republish prebuilt OCCTBridge.xcframework for v1.16.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,8 +81,8 @@ let occtBridgeTarget: Target = useBridgeLocalBinary
     // the OCCT.xcframework convention above.
     ? .binaryTarget(
         name: "OCCTBridge",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.17/OCCTBridge.xcframework.zip",
-        checksum: "3aa5e5804418c90c691cf6c7a5138033350d4d3f16bf71eb41417867b6f093bc"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.16.1/OCCTBridge.xcframework.zip",
+        checksum: "0877e440eea7c26c72dbe20ec86101e369f944fd3a491b68a956c08f71c428d4"
     )
     : .target(
         name: "OCCTBridge",


### PR DESCRIPTION
## What & why

The `occtBridgeTarget` prebuilt `.binaryTarget` was still pinned to the v1.15.17 release asset — the exact release that first shipped the prebuilt path — even though v1.16.0 and v1.16.1 both edited `Sources/OCCTBridge/src/*.mm`. Consumers opting into `OCCTSWIFT_BRIDGE_PREBUILT=1` either hard-fail (v1.16.x source references the new `OCCTShapeOuterShells` symbol, absent from the stale binary) or silently link a bridge that predates the `Shape.fill` SIGSEGV fix, `faceAddHole` circular-hole fix, and `unify` input-mutation fix.

Rebuilt via `Scripts/build-occtbridge.sh` against current `main` (= v1.16.1), rezipped, recomputed the checksum, and bumped `url`/`checksum` in `Package.swift`.

Closes #451

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.

Not applicable here: no Swift source or bridge behavior changed in this PR — it only re-points the prebuilt binary asset at code that shipped (and was tested) in v1.16.0/v1.16.1. Verified manually: `OCCTSWIFT_BRIDGE_PREBUILT=1 swift build` now succeeds against the rebuilt binary (previously failed with a missing-symbol error).

## Notes for the reviewer

The release asset itself (`OCCTBridge.xcframework.zip`) still needs to be attached to the existing `v1.16.1` GitHub release for URL-resolving consumers (no local sibling checkout) to pick it up — doing that as a follow-up upload rather than bundling it in this PR since it's a binary, not a source diff.
