### PR TITLE
fix(#410): make Curve2D.interpolate(points:startTangent:endTangent:) reach tolerance

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -4047,24 +4047,14 @@ const char* OCCTCurve2DTypeName(OCCTCurve2DRef curve) {
 
 
 // MARK: - v0.115: 2D interpolate / PointsToBSpline / SplitAtContinuity / Trimmed / Length (re-routed from Curve3D)
+// Exactly OCCTCurve2DInterpolateWithTangents with tolerance pinned to the OCCT default. It used to
+// be a second, independent Geom2dAPI_Interpolate call site with the tolerance hardcoded and no way
+// to reach it. Forwarding keeps the C ABI while leaving one implementation (#410). Callers that
+// need a different tolerance should call OCCTCurve2DInterpolateWithTangents directly.
 OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points, int32_t count,
                                                double t1x, double t1y,
                                                double t2x, double t2y) {
-    if (!points || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i*2], points[i*2+1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, Standard_False, 1e-6);
-        gp_Vec2d v1(t1x, t1y), v2(t2x, t2y);
-        interp.Load(v1, v2);
-        interp.Perform();
-        if (interp.IsDone()) {
-            return (OCCTCurve2DRef)new OCCTCurve2D{interp.Curve()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+    return OCCTCurve2DInterpolateWithTangents(points, count, t1x, t1y, t2x, t2y, 1e-6);
 }
 
 // Exactly OCCTCurve2DInterpolate with the periodicity flag pinned. It used to be a second,

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -301,6 +301,9 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Interpolate through points with specified start and end tangents.
+    ///
+    /// `interpolate(points:startTangent:endTangent:tolerance:)` is a spelling of this with the
+    /// `points:` argument label, and delegates here.
     public static func interpolate(through points: [SIMD2<Double>],
                                    startTangent: SIMD2<Double>,
                                    endTangent: SIMD2<Double>,
@@ -2278,17 +2281,31 @@ extension Curve2D {
     // MARK: - v0.115.0: Interpolation expansion, trim, length
 
     /// Interpolate a 2D BSpline through points with endpoint tangents.
+    ///
+    /// A spelling of `interpolate(through:startTangent:endTangent:tolerance:)` with the `points:`
+    /// argument label, and it delegates to it — the two cannot produce different curves for the
+    /// same input.
+    ///
+    /// - Parameters:
+    ///   - points: Points to interpolate. At least 2.
+    ///   - startTangent: Tangent direction at the first point.
+    ///   - endTangent: Tangent direction at the last point.
+    ///   - tolerance: Interpolation tolerance. Defaults to `1e-6`, which is what this method used
+    ///     to hardcode with no way to change it (#410).
+    /// - Returns: The interpolated curve, or `nil` if interpolation fails.
+    ///
+    /// ```swift
+    /// let curve = Curve2D.interpolate(points: [SIMD2(0, 0), SIMD2(5, 5), SIMD2(10, 0)],
+    ///                                  startTangent: SIMD2(1, 1), endTangent: SIMD2(1, -1),
+    ///                                  tolerance: 1e-4)
+    /// #expect(curve != nil)
+    /// ```
     public static func interpolate(points: [SIMD2<Double>],
                                    startTangent: SIMD2<Double>,
-                                   endTangent: SIMD2<Double>) -> Curve2D? {
-        var flat = [Double]()
-        for p in points { flat.append(contentsOf: [p.x, p.y]) }
-        guard let ref = flat.withUnsafeBufferPointer({ buf in
-            OCCTInterpolate2DWithTangents(buf.baseAddress!, Int32(points.count),
-                                          startTangent.x, startTangent.y,
-                                          endTangent.x, endTangent.y)
-        }) else { return nil }
-        return Curve2D(handle: ref)
+                                   endTangent: SIMD2<Double>,
+                                   tolerance: Double = 1e-6) -> Curve2D? {
+        interpolate(through: points, startTangent: startTangent, endTangent: endTangent,
+                    tolerance: tolerance)
     }
 
     /// Interpolate a periodic (closed) 2D BSpline through points.

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4467,3 +4467,68 @@ struct Curve2DProjectionParityTests {
         #expect(start.distance(to: Self.segment) == 0)
     }
 }
+
+// MARK: - #410: interpolate(points:startTangent:endTangent:) gains the tolerance its sibling had
+
+/// `Curve2D.interpolate(points:startTangent:endTangent:)` and
+/// `Curve2D.interpolate(through:startTangent:endTangent:tolerance:)` wrap the same
+/// `Geom2dAPI_Interpolate` constructor with the same `Load()`/`Perform()`/`IsDone()`/`Curve()`
+/// sequence. As two independent implementations, the `points:` spelling had drifted: it hardcoded
+/// tolerance at `1e-6` with no parameter to change it. It now delegates.
+@Suite("Curve2D tangent interpolation entry points agree (#410)")
+struct Curve2DInterpolateTangentsParityTests {
+
+    private static let points: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(5, 5), SIMD2(10, 0)]
+    private static let startTangent = SIMD2<Double>(1, 1)
+    private static let endTangent = SIMD2<Double>(1, -1)
+
+    private func expectSameCurve(_ a: Curve2D?, _ b: Curve2D?,
+                                 _ comment: Comment? = nil) {
+        #expect(a != nil, comment)
+        #expect(b != nil, comment)
+        guard let a, let b else { return }
+        #expect(a.isClosed == b.isClosed, comment)
+        #expect(a.isPeriodic == b.isPeriodic, comment)
+        #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12, comment)
+        #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12, comment)
+        for t in stride(from: 0.0, through: 1.0, by: 0.1) {
+            let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
+            let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
+            let pa = a.point(at: ua), pb = b.point(at: ub)
+            #expect(abs(pa.x - pb.x) < 1e-9, comment)
+            #expect(abs(pa.y - pb.y) < 1e-9, comment)
+        }
+    }
+
+    @Test("Default tolerance: the two entry points produce the same curve")
+    func defaultToleranceMatches() {
+        expectSameCurve(
+            Curve2D.interpolate(points: Self.points, startTangent: Self.startTangent,
+                                endTangent: Self.endTangent),
+            Curve2D.interpolate(through: Self.points, startTangent: Self.startTangent,
+                                endTangent: Self.endTangent))
+    }
+
+    /// The capability gap #410 found: previously `interpolate(points:...)` had no way to reach
+    /// any tolerance other than the hardcoded `1e-6`.
+    @Test("A non-default tolerance is now reachable through interpolate(points:...)")
+    func customToleranceIsReachable() {
+        for tolerance in [1e-3, 1e-4, 1e-8] {
+            expectSameCurve(
+                Curve2D.interpolate(points: Self.points, startTangent: Self.startTangent,
+                                    endTangent: Self.endTangent, tolerance: tolerance),
+                Curve2D.interpolate(through: Self.points, startTangent: Self.startTangent,
+                                    endTangent: Self.endTangent, tolerance: tolerance),
+                "tolerance=\(tolerance)")
+        }
+    }
+
+    @Test("Both entry points reject a single point")
+    func singlePointRejectedByBoth() {
+        let one: [SIMD2<Double>] = [SIMD2(1, 2)]
+        #expect(Curve2D.interpolate(points: one, startTangent: Self.startTangent,
+                                    endTangent: Self.endTangent) == nil)
+        #expect(Curve2D.interpolate(through: one, startTangent: Self.startTangent,
+                                    endTangent: Self.endTangent) == nil)
+    }
+}

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -921,7 +921,7 @@ directly to this method, so existing call sites get a migration warning rather t
 
 ---
 
-### `interpolate(points:startTangent:endTangent:)`
+### `interpolate(points:startTangent:endTangent:tolerance:)`
 
 Interpolates a 2D BSpline through a sequence of points with prescribed endpoint tangents.
 
@@ -929,11 +929,17 @@ Interpolates a 2D BSpline through a sequence of points with prescribed endpoint 
 public static func interpolate(
     points: [SIMD2<Double>],
     startTangent: SIMD2<Double>,
-    endTangent: SIMD2<Double>
+    endTangent: SIMD2<Double>,
+    tolerance: Double = 1e-6
 ) -> Curve2D?
 ```
 
-- **Parameters:** `points` — interpolation points; `startTangent`/`endTangent` — tangent directions at the first and last point.
+A spelling of [`interpolate(through:startTangent:endTangent:tolerance:)`](Curve2D.md) with the
+`points:` argument label, and it delegates to it — the two cannot produce different curves for
+the same input. Before #410 it was a second, independent `Geom2dAPI_Interpolate` call site with
+the tolerance hardcoded at `1e-6` and no parameter to change it.
+
+- **Parameters:** `points` — interpolation points; `startTangent`/`endTangent` — tangent directions at the first and last point; `tolerance` — interpolation tolerance (default `1e-6`, matching the value this method used to hardcode).
 - **Returns:** Interpolated BSpline, or `nil` on failure.
 - **OCCT:** `Geom2dAPI_Interpolate` (with tangent constraints).
 - **Example:**

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -527,6 +527,9 @@ public static func interpolate(through points: [SIMD2<Double>],
                                tolerance: Double = 1e-6) -> Curve2D?
 ```
 
+[`interpolate(points:startTangent:endTangent:tolerance:)`](Curve2D-Analysis.md#interpolatepointsstarttangentendtangenttolerance)
+is a spelling of this with the `points:` argument label, and delegates here.
+
 - **Parameters:** `points` — interpolation points; `startTangent` — tangent at the first point; `endTangent` — tangent at the last point; `tolerance` — precision.
 - **Returns:** Interpolated BSpline, or `nil` on failure.
 - **OCCT:** `Geom2dAPI_Interpolate::Load(startTangent, endTangent)` + `Perform()`.


### PR DESCRIPTION
## What & why

`Curve2D.interpolate(points:startTangent:endTangent:)` and `Curve2D.interpolate(through:startTangent:endTangent:tolerance:)` wrap the same `Geom2dAPI_Interpolate` constructor with the same `Load()`/`Perform()`/`IsDone()`/`Curve()` sequence. As two independent implementations they had already drifted: the `through:` overload threads the caller's tolerance into the constructor, while the `points:` overload (added later, under the v0.115.0 section) hardcoded `1e-6` with no parameter to change it — a caller reaching for the more recently added overload silently lost tolerance control with no compiler warning and no doc cross-reference to the sibling that had it.

Both layers now have one implementation: the Swift `interpolate(points:startTangent:endTangent:)` gains a defaulted `tolerance:` parameter and delegates to `interpolate(through:startTangent:endTangent:tolerance:)`, and the bridge's `OCCTInterpolate2DWithTangents` forwards to `OCCTCurve2DInterpolateWithTangents` so direct C consumers of the bridge get the same behaviour rather than a second copy that can drift again.

Refs #410. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual verification)

New suite `Curve2DInterpolateTangentsParityTests` (`Tests/OCCTGeom2dTests`): default-tolerance equivalence between the two overloads, three non-default tolerances (previously unreachable through `points:`), and the single-point rejection both share. Prior coverage was as thin as the issue found: `interpolateWithTangents()` and `interpolate2DWithTangents()` both only asserted `curve != nil` at the default tolerance, and no test anywhere passed a custom tolerance to either overload.

## Notes for the reviewer

**Delegation is safe, checked rather than assumed.** For the shared test input the two implementations produced bit-identical curves before this change — same domain, same sampled points to 1e-9 — which is what you'd expect given they build the same `Geom2dAPI_Interpolate` the same way with only the tolerance literal differing.

**Verification that the bug was live:** reverting only the Swift/bridge changes (keeping the new test) fails to compile — `interpolate(points:...)` had no `tolerance:` parameter at all before this change, so the new test's non-default-tolerance case couldn't even be expressed against the old signature. That's the clearest possible confirmation of the issue's core claim: the tolerance knob was genuinely unreachable from that overload.

**Naming (`points:` vs `through:`):** the issue asked whether the two are pure duplicates by label only, worth consolidating to one. They are — same parameters, same order, only the external label differs — but per the precedent set by #411/#412 in this same file (keep both spellings, make the newer one delegate rather than remove it), I kept `points:` as a thin, source-compatible overload rather than removing it. Existing call sites (`Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift:3230`, `Tests/OCCTCurveTests/OCCTCurveTests.swift:2970`) use the bare 3-arg form with no `tolerance:`, so both keep compiling unchanged.

**Mirror fix:** #400 is the same duplication pattern in `Curve3D.swift` (a different type, fixed separately, not touched here). Once both land, `Curve2D` and `Curve3D` should read as the same shape to a Swift developer using either.

Full `swift test` (4515 tests, 1301 suites) — 1 pre-existing, unrelated failure: `"Shape.loadRobust interrupts repair, not just the transfer (#300)"`, the CPU-timing-sensitive cancellation test whose own source comment documents it as flaky under concurrent load.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one unit, and parallel child PRs each editing the same changelog header would conflict on every one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)