### PR TITLE
fix(#402): collapse Curve2D curvature-extrema/inflection duplication onto one bridge computation

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -7249,24 +7249,6 @@ int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef c1, double first1, double last1,
                            OCCTCurve2DRef c2, double first2, double last2,
                            OCCTExtrema2dResult* out, int32_t max);
 
-// --- Geom2dLProp_NumericCurInf2d ---
-
-/// Curvature inflection/extremum point result
-typedef struct {
-    double parameter;
-    int32_t type;   ///< 0 = curvature minimum, 1 = curvature maximum, 2 = inflection
-} OCCTCurInfPoint;
-
-/// Find curvature extrema on a 2D curve.
-/// @return Number of extrema found
-int32_t OCCTGeom2dLPropCurExt(OCCTCurve2DRef curve,
-                              OCCTCurInfPoint* out, int32_t max);
-
-/// Find inflection points on a 2D curve.
-/// @return Number of inflection points found
-int32_t OCCTGeom2dLPropCurInf(OCCTCurve2DRef curve,
-                              OCCTCurInfPoint* out, int32_t max);
-
 // --- Bisector_BisecAna ---
 
 /// Compute analytical bisector between two 2D curves.

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -1029,9 +1029,6 @@ int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef curve, int32_t qualifier,
 #include <Extrema_ExtPElC2d.hxx>
 #include <Extrema_ExtCC2d.hxx>
 #include <Extrema_POnCurv2d.hxx>
-#include <GeomLProp_CurAndInf2d.hxx>
-#include <LProp_CurAndInf.hxx>
-#include <LProp_CIType.hxx>
 #include <Bisector_BisecAna.hxx>
 #include <GeomAbs_JoinType.hxx>
 #include <gp_Elips2d.hxx>
@@ -1645,40 +1642,6 @@ int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef c1, double first1, double last1,
         }
         return nb;
     } catch (...) { return -1; }
-}
-
-// --- GeomLProp_CurAndInf2d (was Geom2dLProp_NumericCurInf2d in RC4) ---
-int32_t OCCTGeom2dLPropCurExt(OCCTCurve2DRef curve,
-                              OCCTCurInfPoint* out, int32_t max) {
-    try {
-        GeomLProp_CurAndInf2d solver;
-        solver.PerformCurExt(curve->curve);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].parameter = solver.Parameter(i + 1);
-            LProp_CIType t = solver.Type(i + 1);
-            if (t == LProp_MinCur) out[i].type = 0;
-            else if (t == LProp_MaxCur) out[i].type = 1;
-            else out[i].type = 2;
-        }
-        return nb;
-    } catch (...) { return 0; }
-}
-
-int32_t OCCTGeom2dLPropCurInf(OCCTCurve2DRef curve,
-                              OCCTCurInfPoint* out, int32_t max) {
-    try {
-        GeomLProp_CurAndInf2d solver;
-        solver.PerformInf(curve->curve);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].parameter = solver.Parameter(i + 1);
-            out[i].type = 2;
-        }
-        return nb;
-    } catch (...) { return 0; }
 }
 
 // --- Bisector_BisecAna ---

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -1651,10 +1651,26 @@ public enum Extrema2d {
 // MARK: - Geom2dLProp: Curvature Inflection/Extrema
 
 /// Type of curvature feature point.
+///
+/// A same-cases, different-ordering vocabulary for `Curve2DSpecialPointType`, kept for
+/// callers of `curvatureExtremaDetailed()`/`inflectionPointsDetailed()`. Both are derived
+/// from a single `GeomLProp_CurAndInf2d` computation (`curvatureExtrema()`/`inflectionPoints()`);
+/// see `CurInfType.init(_:)` for the (test-pinned) mapping between the two.
 public enum CurInfType: Int32, Sendable {
     case curvatureMinimum = 0
     case curvatureMaximum = 1
     case inflection = 2
+}
+
+extension CurInfType {
+    /// Maps from the `Curve2DSpecialPointType` vocabulary used by the plain family.
+    public init(_ type: Curve2DSpecialPointType) {
+        switch type {
+        case .inflection: self = .inflection
+        case .minCurvature: self = .curvatureMinimum
+        case .maxCurvature: self = .curvatureMaximum
+        }
+    }
 }
 
 /// A curvature feature point on a 2D curve.
@@ -1668,28 +1684,18 @@ public struct CurInfPoint: Sendable {
 extension Curve2D {
     /// Find curvature extrema (min/max) on this 2D curve with type classification.
     ///
-    /// Uses Geom2dLProp_NumericCurInf2d to find parameters where
-    /// curvature is at a local minimum or maximum. Returns detailed
-    /// `CurInfPoint` objects distinguishing min vs max.
+    /// Delegates to `curvatureExtrema()` — the same `GeomLProp_CurAndInf2d` computation —
+    /// translating its results into the `CurInfPoint`/`CurInfType` vocabulary.
     public func curvatureExtremaDetailed() -> [CurInfPoint] {
-        var buffer = [OCCTCurInfPoint](repeating: OCCTCurInfPoint(), count: 64)
-        let n = Int(OCCTGeom2dLPropCurExt(handle, &buffer, 64))
-        return (0..<n).map {
-            CurInfPoint(parameter: buffer[$0].parameter,
-                       type: CurInfType(rawValue: buffer[$0].type) ?? .inflection)
-        }
+        curvatureExtrema().map { CurInfPoint(parameter: $0.parameter, type: CurInfType($0.type)) }
     }
 
     /// Find inflection points on this 2D curve with type information.
     ///
-    /// Similar to `inflectionPoints()` but returns detailed `CurInfPoint`
-    /// objects including the type classification.
+    /// Delegates to `inflectionPoints()` — the same `GeomLProp_CurAndInf2d` computation —
+    /// translating its results into the `CurInfPoint`/`CurInfType` vocabulary.
     public func inflectionPointsDetailed() -> [CurInfPoint] {
-        var buffer = [OCCTCurInfPoint](repeating: OCCTCurInfPoint(), count: 64)
-        let n = Int(OCCTGeom2dLPropCurInf(handle, &buffer, 64))
-        return (0..<n).map {
-            CurInfPoint(parameter: buffer[$0].parameter, type: .inflection)
-        }
+        inflectionPoints().map { CurInfPoint(parameter: $0, type: .inflection) }
     }
 }
 

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -1721,6 +1721,51 @@ struct ApproxCurve2DTests {
             #expect(inflections.count >= 0)
         }
     }
+
+    // #402: curvatureExtremaDetailed()/inflectionPointsDetailed() ("Detailed" family) and
+    // curvatureExtrema()/inflectionPoints() ("plain" family) both wrap GeomLProp_CurAndInf2d.
+    // CurInfType and Curve2DSpecialPointType number the same 3 cases differently; these pin
+    // the mapping between them and confirm both families agree on the same curve.
+
+    @Test("CurInfType mirrors Curve2DSpecialPointType case-for-case")
+    func curInfTypeMirrorsSpecialPointType() {
+        #expect(CurInfType(.inflection) == .inflection)
+        #expect(CurInfType(.minCurvature) == .curvatureMinimum)
+        #expect(CurInfType(.maxCurvature) == .curvatureMaximum)
+    }
+
+    @Test("curvatureExtremaDetailed() agrees with curvatureExtrema() on the same curve")
+    func curvatureExtremaFamiliesAgree() {
+        let ellipse = Curve2D.ellipse(center: .zero, majorRadius: 10, minorRadius: 5)
+        if let ellipse {
+            let plain = ellipse.curvatureExtrema()
+            let detailed = ellipse.curvatureExtremaDetailed()
+            #expect(plain.count == detailed.count)
+            #expect(plain.count >= 2)
+            for (p, d) in zip(plain, detailed) {
+                #expect(abs(p.parameter - d.parameter) < 1e-9)
+                #expect(CurInfType(p.type) == d.type)
+            }
+        }
+    }
+
+    @Test("inflectionPointsDetailed() agrees with inflectionPoints() on the same curve")
+    func inflectionPointFamiliesAgree() {
+        let points: [SIMD2<Double>] = [
+            SIMD2(0, 0), SIMD2(2, 5), SIMD2(5, -5), SIMD2(8, 0)
+        ]
+        let curve = Curve2D.interpolate(through: points)
+        if let curve {
+            let plain = curve.inflectionPoints()
+            let detailed = curve.inflectionPointsDetailed()
+            #expect(plain.count == detailed.count)
+            #expect(plain.count >= 1)
+            for (p, d) in zip(plain, detailed) {
+                #expect(abs(p - d.parameter) < 1e-9)
+                #expect(d.type == .inflection)
+            }
+        }
+    }
 }
 
 @Suite("Bisector_BisecAna") struct BisectorBisecAnaTests {

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -115,7 +115,7 @@ public func inflectionPoints() -> [Double]
 Capped internally at 256 results.
 
 - **Returns:** Array of parameter values at inflection points (may be empty).
-- **OCCT:** `Geom2dLProp_CLProps2d` inflection detection.
+- **OCCT:** `GeomLProp_CurAndInf2d::PerformInf`.
 - **Example:**
   ```swift
   if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
@@ -136,7 +136,7 @@ public func curvatureExtrema() -> [Curve2DSpecialPoint]
 Returns `Curve2DSpecialPoint` values with `.minCurvature` or `.maxCurvature` type classification. Capped at 256 results.
 
 - **Returns:** Array of special points (may be empty).
-- **OCCT:** `Geom2dLProp_CLProps2d` curvature extrema.
+- **OCCT:** `GeomLProp_CurAndInf2d::PerformCurExt`.
 - **Example:**
   ```swift
   if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
@@ -159,7 +159,7 @@ public func allSpecialPoints() -> [Curve2DSpecialPoint]
 Capped internally at 256 results.
 
 - **Returns:** Array of `Curve2DSpecialPoint` values (`.inflection`, `.minCurvature`, or `.maxCurvature`).
-- **OCCT:** `Geom2dLProp_CLProps2d`.
+- **OCCT:** `GeomLProp_CurAndInf2d::Perform`.
 - **Example:**
   ```swift
   if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
@@ -622,13 +622,18 @@ Capped at 32 results.
 
 ## Geom2dLProp: Curvature Inflection/Extrema
 
-Higher-resolution curvature feature detection via `Geom2dLProp_NumericCurInf2d`.
+`CurInfPoint`/`CurInfType` are an alternate vocabulary for the same `curvatureExtrema()`/
+`inflectionPoints()` results above — same `GeomLProp_CurAndInf2d` computation, no second
+solver run. `curvatureExtremaDetailed()`/`inflectionPointsDetailed()` delegate to those two
+functions and translate each `Curve2DSpecialPoint` into a `CurInfPoint` via `CurInfType.init(_:)`.
 
 ---
 
 ### `CurInfType`
 
-Enum classifying a curvature feature point.
+Enum classifying a curvature feature point. Numbers the same 3 cases as
+`Curve2DSpecialPointType` in a different order; `CurInfType.init(_:)` is the pinned mapping
+between them (see the `Geom2dLProp Curvature Analysis` test suite for the parity tests).
 
 ```swift
 public enum CurInfType: Int32, Sendable {
@@ -661,10 +666,12 @@ Finds local curvature extrema with min/max type classification.
 public func curvatureExtremaDetailed() -> [CurInfPoint]
 ```
 
-Unlike `curvatureExtrema()` (which returns `Curve2DSpecialPoint`), this returns `CurInfPoint` values using the `CurInfType` enum. Capped at 64 results.
+Unlike `curvatureExtrema()` (which returns `Curve2DSpecialPoint`), this returns `CurInfPoint`
+values using the `CurInfType` enum — the two share one underlying `GeomLProp_CurAndInf2d` call,
+so their parameter/count results always agree. Capped at 256 results (the shared function's cap).
 
 - **Returns:** Array of `CurInfPoint` with `.curvatureMinimum` or `.curvatureMaximum` type.
-- **OCCT:** `Geom2dLProp_NumericCurInf2d::PerformCurExt`.
+- **OCCT:** `GeomLProp_CurAndInf2d::PerformCurExt`, via `curvatureExtrema()`.
 - **Example:**
   ```swift
   if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {
@@ -684,10 +691,12 @@ Finds inflection points with type information.
 public func inflectionPointsDetailed() -> [CurInfPoint]
 ```
 
-Like `inflectionPoints()` but returns `CurInfPoint` values (all with `.inflection` type) rather than bare `Double` parameters. Capped at 64 results.
+Like `inflectionPoints()` but returns `CurInfPoint` values (all with `.inflection` type) rather
+than bare `Double` parameters — delegates directly to it, so results always match. Capped at
+256 results (the shared function's cap).
 
 - **Returns:** Array of `CurInfPoint` (all `.inflection`).
-- **OCCT:** `Geom2dLProp_NumericCurInf2d::PerformInf`.
+- **OCCT:** `GeomLProp_CurAndInf2d::PerformInf`, via `inflectionPoints()`.
 - **Example:**
   ```swift
   if let spline = Curve2D.interpolate(points: pts, startTangent: t1, endTangent: t2) {


### PR DESCRIPTION
## What & why

`Curve2D`'s "Detailed" family (`curvatureExtremaDetailed()`, `inflectionPointsDetailed()`,
`CurInfType`, `CurInfPoint`) and its "plain" family (`curvatureExtrema()`, `inflectionPoints()`,
`allSpecialPoints()`, `Curve2DSpecialPointType`, `Curve2DSpecialPoint`) each ran their own,
separately-instantiated `GeomLProp_CurAndInf2d` solver in the bridge — the same OCCT
computation, done twice, behind two structurally-identical C structs (`OCCTCurInfPoint` /
`OCCTCurve2DCurvePoint`, both `{double parameter; int32_t type;}`) whose `type` field used
different, incompatible orderings for the same three cases (inflection / min-curvature /
max-curvature). Nothing was actually misclassified today — each bridge function was
internally consistent with its own struct — but the identical wire shape with incompatible
raw-value semantics was exactly the landmine #398 warned this class of duplication creates:
one future "these two structs look the same, let's merge them" refactor and inflection points
silently become curvature extrema.

Removed the duplicate bridge functions (`OCCTGeom2dLPropCurExt`/`OCCTGeom2dLPropCurInf`) and
`OCCTCurInfPoint` entirely. `curvatureExtremaDetailed()`/`inflectionPointsDetailed()` now
delegate in Swift to `curvatureExtrema()`/`inflectionPoints()` — the same, now-single,
`GeomLProp_CurAndInf2d` call — and translate results via a new `CurInfType.init(_:)` that pins
the mapping between the two enums. Both public API surfaces are kept: `curvatureExtremaDetailed()`/
`inflectionPointsDetailed()` are established public API with their own test suite, and nothing
in the issue suggested downstream consumers don't use both, so delegation (rather than
deprecating one family) gets the single-computation property without any source break.

Also fixed: the doc comments and `docs/reference/Curve2D-Analysis.md` for both families cited
the wrong OCCT class — `Geom2dLProp_CLProps2d` (a different, per-point local-properties class
actually used by `curvature(at:)`/`normal(at:)`/etc.) for the plain family, and
`Geom2dLProp_NumericCurInf2d` (renamed upstream before this project's OCCT baseline — the
bridge's own code comment already noted the rename) for the Detailed family. Both now correctly
cite `GeomLProp_CurAndInf2d`.

Refs #402. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New tests in `Geom2dLPropTests` (`Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift`): a mapping-pin
test asserting `CurInfType.init(_:)`'s three cases directly, plus two families-agree tests
(ellipse curvature extrema, S-curve inflection points) asserting the plain and Detailed
functions return the same parameters, counts, and classifications for the same curve.

## Notes for the reviewer

**No live behavioral bug existed before this fix** — unlike some other #380 findings, both
families were already self-consistent with their own struct's encoding, so this is a
duplication/landmine fix, not a correctness fix. I verified the new mapping-pin test actually
has teeth rather than being vacuous: I temporarily swapped `CurInfType.init(_:)`'s
`.minCurvature`/`.maxCurvature` branches and reran `swift test --filter Geom2dLPropTests` — the
pinning test failed immediately (`CurInfType(.minCurvature) → .curvatureMaximum) ==
.curvatureMinimum`, etc.), while the two families-agree tests still passed (expected: both
sides of that comparison route through the same, now-shared, mapping function, so they can
never disagree with each other even if the mapping itself is wrong — the mapping-pin test is
the one that actually guards correctness). Reverted the swap before committing.

**Not folded in:** `OCCTLPropAnalyticCurInf` (`OCCTBridge_Geom2d.mm`, v0.64) shares the same
`0=Inflection,1=MinCur,2=MaxCur` output convention but is a hand-coded analytic-curve-type
shortcut (ellipse-only) that never actually calls `GeomLProp_CurAndInf2d` — a different
algorithm by design, not a third instance of this duplication, and out of scope for #402.

Full `swift test`: 4515 tests in 1300 suites, 1 failure — the pre-existing, CPU-timing-sensitive
`loadRobust` cancellation flake (issue #300, `v1.11.2 Robust import progress`), unrelated to this
change and already documented as a known flake. Focused `Geom2dLPropTests` and
`Curve2DLocalPropertiesTests` suites: all green.

No `CHANGELOG.md` entry deliberately — the audit branch merges to `main` as one unit, and
parallel child PRs editing the same header would conflict.
