### PR TITLE
fix(#403): align knot-splitting triage across Curve3D/Surface/LawFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,258 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,262 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -6632,8 +6632,16 @@ typedef struct {
 /// @param surface BSpline surface to analyze
 /// @param uContinuity Desired U continuity (0=C0, 1=C1, 2=C2)
 /// @param vContinuity Desired V continuity (0=C0, 1=C1, 2=C2)
+/// @param outUParams Pre-allocated array for U split parameter values (may be NULL)
+/// @param maxUParams Capacity of outUParams
+/// @param outVParams Pre-allocated array for V split parameter values (may be NULL)
+/// @param maxVParams Capacity of outVParams
+/// @return Split counts; nbUSplits/nbVSplits are the true counts even when writing
+///   was truncated by maxUParams/maxVParams, so a caller can retry with a bigger buffer
 OCCTSurfaceKnotSplitResult OCCTSurfaceKnotSplitting(OCCTSurfaceRef surface,
-    int32_t uContinuity, int32_t vContinuity);
+    int32_t uContinuity, int32_t vContinuity,
+    double* outUParams, int32_t maxUParams,
+    double* outVParams, int32_t maxVParams);
 
 /// Join an array of Bezier surface patches into a single BSpline surface.
 /// @param patches Array of surface handles (row-major, nRows x nCols)
@@ -8988,6 +8996,18 @@ void OCCTGeomFillNSectionsInfo(
 int32_t OCCTLawBSplineKnotSplitting(OCCTLawFunctionRef _Nonnull law,
     int32_t continuityOrder,
     int32_t* _Nonnull outIndices, int32_t maxIndices);
+
+/// Find PARAMETER values (not knot-table indices) where a BSpline law drops below
+/// given continuity -- the law-function analogue of OCCTCurve3DBSplineKnotSplits. #403.
+/// @param law BSpline law function handle
+/// @param continuityOrder Continuity level to check (0=C0, 1=C1, 2=C2)
+/// @param outParams Pre-allocated array for break parameter values
+/// @param maxParams Maximum number of parameters to return
+/// @return Number of break parameters found (true count, even if writing was truncated
+///   by maxParams), or -1 on failure
+int32_t OCCTLawBSplineKnotSplitParams(OCCTLawFunctionRef _Nonnull law,
+    int32_t continuityOrder,
+    double* _Nonnull outParams, int32_t maxParams);
 
 // --- Law_Composite ---
 /// Create a composite law from multiple sub-laws stitched together.

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -19,6 +19,7 @@
 #ifndef OCCTBridge_Internal_h
 #define OCCTBridge_Internal_h
 
+#include <algorithm>
 #include <mutex>
 #include <vector>
 
@@ -357,6 +358,29 @@ bool occtFillingAddConstraint(Filler& filling,
     }
     filling.Add(edge, order, isBound);
     return true;
+}
+
+// === #403: shared BSpline knot-split-to-parameter conversion ===
+//
+// Curve3D.continuityBreaks, LawFunction.knotSplitParameters, and Surface.knotSplitting
+// each wrap a different OCCT *KnotSplitting analyzer (GeomConvert_BSplineCurveKnotSplitting,
+// Law_BSplineKnotSplitting, GeomConvert_BSplineSurfaceKnotSplitting -- the last one calling
+// this twice, once per parametric direction) but all three reduce to the identical loop:
+// walk the N computed split points, convert each one's knot-table index to a real
+// parameter value, write up to maxParams of them, and report the true split count even
+// when writing was truncated (so a caller can always retry with a bigger buffer).
+//
+// splitIndexAt(i) returns the underlying knot-table index for split i (1-based, matching
+// every *KnotSplitting class's own SplitValue/USplitValue/VSplitValue numbering);
+// knotAt(index) converts that knot-table index to an actual parameter value.
+template <class SplitIndexAt, class KnotAt>
+int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, KnotAt knotAt,
+                                  double* outParams, int32_t maxParams) {
+    int32_t count = std::min(nbSplits, maxParams);
+    for (int32_t i = 0; i < count; i++) {
+        outParams[i] = knotAt(splitIndexAt(i + 1));
+    }
+    return nbSplits;
 }
 
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -5935,6 +5935,31 @@ int32_t OCCTLawBSplineKnotSplitting(OCCTLawFunctionRef law,
     }
 }
 
+// #403: same analyzer as above, but converts each split's knot-table index to an actual
+// parameter value via Law_BSpline::Knot() -- raw indices are otherwise uninterpretable
+// since the public API exposes no way to read the law's own knot vector.
+int32_t OCCTLawBSplineKnotSplitParams(OCCTLawFunctionRef law, int32_t continuityOrder,
+    double* outParams, int32_t maxParams)
+{
+    if (!law || !outParams || maxParams <= 0) return -1;
+    try {
+        auto* wrapper = reinterpret_cast<OCCTLawFunction*>(law);
+        Handle(Law_BSpFunc) bspFunc = Handle(Law_BSpFunc)::DownCast(wrapper->law);
+        if (bspFunc.IsNull()) return -1;
+
+        Handle(Law_BSpline) bspl = bspFunc->Curve();
+        if (bspl.IsNull()) return -1;
+
+        Law_BSplineKnotSplitting splitter(bspl, continuityOrder);
+        return occtWriteKnotSplitParams(splitter.NbSplits(),
+            [&](int32_t i) { return splitter.SplitValue(i); },
+            [&](int32_t idx) { return bspl->Knot(idx); },
+            outParams, maxParams);
+    } catch (...) {
+        return -1;
+    }
+}
+
 // --- Law_Composite ---
 
 OCCTLawFunctionRef OCCTLawComposite(const OCCTLawFunctionRef* lawRefs,

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -1702,8 +1702,14 @@ OCCTSurfaceRef OCCTSurfaceTrimmedCylinder(
 }
 
 // MARK: - Surface KnotSplitting / JoinBezierPatches (v0.50)
+// #403: also fills the U/V split PARAMETER buffers (not just the counts) -- the
+// underlying GeomConvert_BSplineSurfaceKnotSplitting analyzer always computed
+// USplitValue/VSplitValue, this just wasn't surfaced. outUParams/outVParams may be
+// null (or their max 0) to skip writing either direction.
 OCCTSurfaceKnotSplitResult OCCTSurfaceKnotSplitting(OCCTSurfaceRef surface,
-    int32_t uContinuity, int32_t vContinuity) {
+    int32_t uContinuity, int32_t vContinuity,
+    double* outUParams, int32_t maxUParams,
+    double* outVParams, int32_t maxVParams) {
     OCCTSurfaceKnotSplitResult result = {};
     if (!surface) return result;
     try {
@@ -1712,6 +1718,18 @@ OCCTSurfaceKnotSplitResult OCCTSurfaceKnotSplitting(OCCTSurfaceRef surface,
         GeomConvert_BSplineSurfaceKnotSplitting splitter(bsurf, uContinuity, vContinuity);
         result.nbUSplits = splitter.NbUSplits();
         result.nbVSplits = splitter.NbVSplits();
+        if (outUParams && maxUParams > 0) {
+            occtWriteKnotSplitParams(result.nbUSplits,
+                [&](int32_t i) { return splitter.USplitValue(i); },
+                [&](int32_t idx) { return bsurf->UKnot(idx); },
+                outUParams, maxUParams);
+        }
+        if (outVParams && maxVParams > 0) {
+            occtWriteKnotSplitParams(result.nbVSplits,
+                [&](int32_t i) { return splitter.VSplitValue(i); },
+                [&](int32_t idx) { return bsurf->VKnot(idx); },
+                outVParams, maxVParams);
+        }
     } catch (...) {}
     return result;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -896,14 +896,10 @@ int32_t OCCTCurve3DBSplineKnotSplits(OCCTCurve3DRef curve3D, int32_t continuityO
         if (bspline.IsNull()) return -1;
 
         GeomConvert_BSplineCurveKnotSplitting splitter(bspline, continuityOrder);
-        int32_t nbSplits = splitter.NbSplits();
-        int32_t count = std::min(nbSplits, maxParams);
-
-        for (int32_t i = 0; i < count; i++) {
-            int32_t knotIndex = splitter.SplitValue(i + 1);
-            outParams[i] = bspline->Knot(knotIndex);
-        }
-        return nbSplits;
+        return occtWriteKnotSplitParams(splitter.NbSplits(),
+            [&](int32_t i) { return splitter.SplitValue(i); },
+            [&](int32_t idx) { return bspline->Knot(idx); },
+            outParams, maxParams);
     } catch (...) {
         return -1;
     }

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -706,6 +706,12 @@ extension Curve3D {
     /// drops below `minContinuity` returns exactly those two rather than an empty array. Any
     /// further entries are interior knots where the curve really is less continuous than asked.
     ///
+    /// A curve's discontinuities are inherently 1D, so parameter values are the natural (and
+    /// only sensible) shape here -- unlike `Surface.knotSplitting` (2D, per-direction counts
+    /// *and* parameters) or `LawFunction.knotSplitting`/`knotSplitParameters` (1D, but split
+    /// across two methods for backward compatibility). See #403 for why these three siblings
+    /// return different shapes.
+    ///
     /// ```swift
     /// // A cubic interpolated BSpline is already C2 at its interior knots, so nothing
     /// // below C3 reports anything beyond the two end knots.

--- a/Sources/OCCTSwift/LawFunction.swift
+++ b/Sources/OCCTSwift/LawFunction.swift
@@ -121,7 +121,10 @@ public final class LawFunction: @unchecked Sendable {
 
     /// Find knot indices where a BSpline law drops below given continuity.
     ///
-    /// Only works on BSpline-based law functions.
+    /// Only works on BSpline-based law functions. Returns raw indices into the underlying
+    /// `Law_BSpline`'s own knot table -- not directly usable against `value(at:)` or
+    /// `bounds`, since this API exposes no way to read that knot table back. See
+    /// `knotSplitParameters(continuityOrder:)` for the actual parameter values (#403).
     ///
     /// - Parameter continuityOrder: Continuity level (0=C0, 1=C1, 2=C2)
     /// - Returns: Array of knot indices where continuity breaks, or empty array
@@ -130,5 +133,40 @@ public final class LawFunction: @unchecked Sendable {
         var indices = [Int32](repeating: 0, count: Int(maxIndices))
         let count = OCCTLawBSplineKnotSplitting(handle, Int32(continuityOrder), &indices, maxIndices)
         return (0..<Int(count)).map { Int(indices[$0]) }
+    }
+
+    /// Parameter values (not raw knot indices) at which continuity drops below `continuityOrder`.
+    ///
+    /// The law-function analogue of `Curve3D.continuityBreaks`: a law's discontinuities,
+    /// like a curve's, are inherently 1D, so parameter values (directly usable with
+    /// `value(at:)`, and bounded by `bounds`) are the natural shape here too -- unlike
+    /// `knotSplitting(continuityOrder:)`'s raw indices, which the public API otherwise
+    /// exposes no way to interpret. Added alongside `Surface.knotSplitting`'s new parameter
+    /// fields in #403: same "cheap to compute, previously dropped" gap.
+    ///
+    /// ```swift
+    /// let breaks = law.knotSplitParameters(continuityOrder: 2)
+    /// // breaks are real parameters within law.bounds, usable e.g. as sweep split points
+    /// ```
+    ///
+    /// - Parameter continuityOrder: Continuity level (0=C0, 1=C1, 2=C2)
+    /// - Returns: Split parameters in ascending order, or empty array if not a BSpline-based law
+    public func knotSplitParameters(continuityOrder: Int = 2) -> [Double] {
+        // Same retry-on-truncation pattern as Curve3D.continuityBreaks: the bridge always
+        // reports the true split count even when it writes fewer, so one retry sized to
+        // that count is always enough.
+        func read(capacity: Int32) -> (count: Int32, params: [Double]) {
+            var params = [Double](repeating: 0, count: Int(capacity))
+            let count = OCCTLawBSplineKnotSplitParams(handle, Int32(continuityOrder), &params, capacity)
+            return (count, params)
+        }
+
+        var (count, params) = read(capacity: 100)
+        guard count >= 0 else { return [] }
+        if count > 100 {
+            (count, params) = read(capacity: count)
+            guard count >= 0 else { return [] }
+        }
+        return Array(params.prefix(Int(count)))
     }
 }

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1435,23 +1435,65 @@ extension Surface {
     }
 
     /// Result of BSpline surface knot splitting analysis.
+    ///
+    /// `uSplitParams`/`vSplitParams` are the actual parameter values (from the surface's
+    /// own U/V knot vectors) at which those splits occur -- the 2D, per-direction analogue
+    /// of `Curve3D.continuityBreaks`'s 1D split parameters. Added in #403: the counts alone
+    /// made this strictly weaker than its curve/law siblings even though the underlying
+    /// analyzer (`GeomConvert_BSplineSurfaceKnotSplitting`) always computed the locations
+    /// too, via `USplitValue`/`VSplitValue`, this just wasn't surfaced.
     public struct KnotSplitResult {
         /// Number of U split indices needed for the requested continuity
         public let uSplitCount: Int
         /// Number of V split indices needed for the requested continuity
         public let vSplitCount: Int
+        /// U parameter values (ascending, bounded by the surface's own U range) at each split
+        public let uSplitParams: [Double]
+        /// V parameter values (ascending, bounded by the surface's own V range) at each split
+        public let vSplitParams: [Double]
     }
 
     /// Analyze where a BSpline surface would need to be split to achieve
     /// a given continuity level.
     ///
+    /// A surface's discontinuities are inherently 2D -- U and V are independent parametric
+    /// directions, each with its own knot vector -- so this reports counts *and* parameter
+    /// locations per direction, unlike `Curve3D.continuityBreaks` (one 1D parameter list).
+    ///
+    /// ```swift
+    /// let result = bsplineSurface.knotSplitting(uContinuity: 0, vContinuity: 0)
+    /// // result.uSplitParams / result.vSplitParams are real U/V parameters, usable to
+    /// // split the surface into same-continuity patches (e.g. via GeomConvert).
+    /// ```
+    ///
     /// - Parameters:
     ///   - uContinuity: Desired U continuity (0=C0, 1=C1, 2=C2)
     ///   - vContinuity: Desired V continuity (0=C0, 1=C1, 2=C2)
-    /// - Returns: Number of U and V splits needed
+    /// - Returns: Split counts plus the actual U/V parameter values, or all-empty/zero for
+    ///   a non-BSpline surface
     public func knotSplitting(uContinuity: Int = 1, vContinuity: Int = 1) -> KnotSplitResult {
-        let result = OCCTSurfaceKnotSplitting(handle, Int32(uContinuity), Int32(vContinuity))
-        return KnotSplitResult(uSplitCount: Int(result.nbUSplits), vSplitCount: Int(result.nbVSplits))
+        // Same retry-on-truncation pattern as Curve3D.continuityBreaks: the bridge always
+        // reports the true split counts even when it writes fewer, so one retry sized to
+        // those counts is always enough.
+        func read(uCapacity: Int32, vCapacity: Int32) -> (OCCTSurfaceKnotSplitResult, [Double], [Double]) {
+            var uParams = [Double](repeating: 0, count: Int(uCapacity))
+            var vParams = [Double](repeating: 0, count: Int(vCapacity))
+            let result = OCCTSurfaceKnotSplitting(handle, Int32(uContinuity), Int32(vContinuity),
+                                                   &uParams, uCapacity, &vParams, vCapacity)
+            return (result, uParams, vParams)
+        }
+
+        var (result, uParams, vParams) = read(uCapacity: 64, vCapacity: 64)
+        if result.nbUSplits > 64 || result.nbVSplits > 64 {
+            (result, uParams, vParams) = read(uCapacity: max(result.nbUSplits, 1),
+                                               vCapacity: max(result.nbVSplits, 1))
+        }
+        return KnotSplitResult(
+            uSplitCount: Int(result.nbUSplits),
+            vSplitCount: Int(result.nbVSplits),
+            uSplitParams: Array(uParams.prefix(Int(result.nbUSplits))),
+            vSplitParams: Array(vParams.prefix(Int(result.nbVSplits)))
+        )
     }
 
     /// Join an array of Bezier surface patches into a single BSpline surface.

--- a/Tests/OCCTCurveTests/Issue403LawKnotSplitParamsTests.swift
+++ b/Tests/OCCTCurveTests/Issue403LawKnotSplitParamsTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #403: `LawFunction.knotSplitting` only ever returned raw knot-table indices, which the
+/// public API otherwise exposes no way to interpret (there is no accessor for a law's own
+/// knot vector). `knotSplitParameters` adds the actual parameter-value form -- the same
+/// conversion `Curve3D.continuityBreaks` already does for curves -- as an additive sibling
+/// method, so the pre-existing `knotSplitting` signature is untouched.
+@Suite("LawFunction knot splitting parameters (#403)")
+struct Issue403LawKnotSplitParamsTests {
+
+    /// Degree-3 BSpline law with an interior knot (0.5) of multiplicity 2, so it is only
+    /// C1 there -- a genuine continuity break at C2, distinct from the two end knots.
+    private func lawWithInteriorBreak() -> LawFunction? {
+        LawFunction.bspline(
+            poles: [1.0, 3.0, 2.0, 5.0, 4.0, 6.0],
+            knots: [0.0, 0.5, 1.0],
+            multiplicities: [4, 2, 4],
+            degree: 3)
+    }
+
+    @Test("Parameter count matches the sibling index method")
+    func countMatchesIndexMethod() {
+        guard let law = lawWithInteriorBreak() else {
+            Issue.record("could not build the test law")
+            return
+        }
+        let indices = law.knotSplitting(continuityOrder: 2)
+        let params = law.knotSplitParameters(continuityOrder: 2)
+        // Same underlying Law_BSplineKnotSplitting analyzer -- must agree on how many
+        // splits there are, even though one returns indices and the other parameters.
+        #expect(indices.count == params.count)
+        #expect(params.count >= 2)
+    }
+
+    @Test("Parameters are ascending and bracketed by the law's own bounds")
+    func parametersMatchBounds() {
+        guard let law = lawWithInteriorBreak() else {
+            Issue.record("could not build the test law")
+            return
+        }
+        let params = law.knotSplitParameters(continuityOrder: 2)
+        let bounds = law.bounds
+
+        if let first = params.first, let last = params.last {
+            #expect(abs(first - bounds.lowerBound) < 1e-9)
+            #expect(abs(last - bounds.upperBound) < 1e-9)
+        }
+        #expect(zip(params, params.dropFirst()).allSatisfy { $0 < $1 })
+        #expect(params.allSatisfy { bounds.contains($0) })
+    }
+
+    @Test("Interior break at the multiplicity-2 knot is reported")
+    func interiorBreakReported() {
+        guard let law = lawWithInteriorBreak() else {
+            Issue.record("could not build the test law")
+            return
+        }
+        // Degree 3, multiplicity 2 at the interior knot => continuity there is 3-2=1, so
+        // asking for C2 must surface it as a break, in addition to the two end knots.
+        let params = law.knotSplitParameters(continuityOrder: 2)
+        #expect(params.contains { abs($0 - 0.5) < 1e-9 })
+    }
+
+    @Test("Non-BSpline-based law returns empty, not a crash")
+    func nonBSplineLawReturnsEmpty() {
+        guard let law = LawFunction.linear(from: 0, to: 1) else {
+            Issue.record("could not build the test law")
+            return
+        }
+        #expect(law.knotSplitParameters(continuityOrder: 1).isEmpty)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue403SurfaceKnotSplitParamsTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue403SurfaceKnotSplitParamsTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #403: `Surface.knotSplitting` used to report only `uSplitCount`/`vSplitCount` even though
+/// the underlying `GeomConvert_BSplineSurfaceKnotSplitting` analyzer always computed the split
+/// *locations* too (`USplitValue`/`VSplitValue`) -- strictly weaker than its `Curve3D`/
+/// `LawFunction` siblings, which both surface real parameter values. `uSplitParams`/
+/// `vSplitParams` are additive fields on `KnotSplitResult`, so the existing count fields and
+/// the function's signature are unchanged.
+@Suite("Surface knot splitting parameters (#403)")
+struct Issue403SurfaceKnotSplitParamsTests {
+
+    /// Trimmed cylinder converted to BSpline -- bounded, so the conversion succeeds, and
+    /// periodic in U, which guarantees more than the two bracketing splits in that direction.
+    private func bsplineCylinder() throws -> Surface {
+        let trimCyl = try #require(Surface.trimmedCylinder(radius: 5.0, height: 10.0))
+        return try #require(trimCyl.toBSpline())
+    }
+
+    @Test("Param array lengths match their own counts")
+    func paramCountsMatchSplitCounts() throws {
+        let bspline = try bsplineCylinder()
+        let result = bspline.knotSplitting(uContinuity: 0, vContinuity: 0)
+
+        #expect(result.uSplitParams.count == result.uSplitCount)
+        #expect(result.vSplitParams.count == result.vSplitCount)
+        #expect(result.uSplitCount >= 1)
+        #expect(result.vSplitCount >= 1)
+    }
+
+    @Test("Params are ascending and bracketed by the surface's own U/V domain")
+    func paramsMatchDomain() throws {
+        let bspline = try bsplineCylinder()
+        let result = bspline.knotSplitting(uContinuity: 0, vContinuity: 0)
+        let domain = bspline.domain
+
+        if let uFirst = result.uSplitParams.first, let uLast = result.uSplitParams.last {
+            #expect(abs(uFirst - domain.uMin) < 1e-6)
+            #expect(abs(uLast - domain.uMax) < 1e-6)
+        }
+        if let vFirst = result.vSplitParams.first, let vLast = result.vSplitParams.last {
+            #expect(abs(vFirst - domain.vMin) < 1e-6)
+            #expect(abs(vLast - domain.vMax) < 1e-6)
+        }
+        #expect(zip(result.uSplitParams, result.uSplitParams.dropFirst()).allSatisfy { $0 < $1 })
+        #expect(zip(result.vSplitParams, result.vSplitParams.dropFirst()).allSatisfy { $0 < $1 })
+    }
+
+    @Test("Non-BSpline surface returns empty params, not a crash")
+    func nonBSplineSurfaceReturnsEmpty() throws {
+        let plane = try #require(Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)))
+        let result = plane.knotSplitting(uContinuity: 0, vContinuity: 0)
+        #expect(result.uSplitCount == 0)
+        #expect(result.vSplitCount == 0)
+        #expect(result.uSplitParams.isEmpty)
+        #expect(result.vSplitParams.isEmpty)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,320** of the entry points (~78% of the `Total` below); the rest are real, callable,
+categorisation covering **3,321** of the entry points (~78% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -133,7 +133,7 @@ a map of the major areas, and the `Total` as the count.
 | **TopTrans** | 4 | surfaceTransition, surfaceTransitionWithCurvature, curveTransition, curveTransitionWithCurvature |
 | **GeomFill Trihedrons** | 7 | draftTrihedron, discreteTrihedron, correctedFrenet, frenetTrihedron, fixedTrihedron, constantBiNormalTrihedron, darbouxTrihedron |
 | **GeomFill NSections** | 2 | nSections, nSectionsInfo |
-| **Law Extensions** | 2 | composite, knotSplitting |
+| **Law Extensions** | 3 | composite, knotSplitting, knotSplitParameters |
 | **GccAna Circ2d3Tan** | 6 | circleThrough3Points, circleTangent3Lines, circleTangent3Circles, circleTangent2CirclesPoint, circleTangentCircle2Points, circleTangent2LinesPoint |
 | **Polygon Interference** | 2 | polygonInterference, polygonSelfInterference |
 | **ChFi2d Edge Operations** | 2 | chamfer2dEdges, fillet2dEdges |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,258** | |
+| **Total** | **4,262** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -748,10 +748,36 @@ public func knotSplitting(continuityOrder: Int = 2) -> [Int]
 ```
 
 Only works on BSpline-based law functions created via `bspline(poles:knots:multiplicities:degree:)`.
+Returns raw indices into the law's own knot table, not directly usable against `value(at:)` or
+`bounds` — see `knotSplitParameters(continuityOrder:)` for the parameter-value form.
 
 - **Parameters:** `continuityOrder` — continuity level to check (`0`=C0, `1`=C1, `2`=C2).
 - **Returns:** Array of knot indices where continuity breaks, or empty array if none or if the function is not BSpline-based.
 - **OCCT:** `Law_BSplineKnotSplitting`.
+
+---
+
+#### `knotSplitParameters(continuityOrder:)`
+
+Find parameter values (not raw knot indices) where a BSpline law drops below given continuity —
+the law-function analogue of `Curve3D.continuityBreaks`.
+
+```swift
+public func knotSplitParameters(continuityOrder: Int = 2) -> [Double]
+```
+
+Only works on BSpline-based law functions created via `bspline(poles:knots:multiplicities:degree:)`.
+Unlike `knotSplitting(continuityOrder:)`'s raw indices, these are real parameter values, directly
+usable with `value(at:)` and bounded by `bounds`.
+
+- **Parameters:** `continuityOrder` — continuity level to check (`0`=C0, `1`=C1, `2`=C2).
+- **Returns:** Split parameters in ascending order, or empty array if none or if the function is not BSpline-based.
+- **OCCT:** `Law_BSplineKnotSplitting`.
+- **Example:**
+  ```swift
+  let breaks = law.knotSplitParameters(continuityOrder: 2)
+  // breaks are real parameters within law.bounds, usable e.g. as sweep split points
+  ```
 
 ---
 

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -575,16 +575,18 @@ Analyses where a BSpline surface would need to be split to achieve a given conti
 public func knotSplitting(uContinuity: Int = 1, vContinuity: Int = 1) -> KnotSplitResult
 ```
 
-Returns the number of U and V splits needed; does not modify the surface.
+Returns the number of U and V splits needed, plus the actual U/V parameter values at each
+split; does not modify the surface.
 
 - **Parameters:** `uContinuity` — desired U continuity (0=C0, 1=C1, 2=C2); `vContinuity` — desired V continuity.
-- **Returns:** `KnotSplitResult` with `uSplitCount` and `vSplitCount`.
+- **Returns:** `KnotSplitResult` with `uSplitCount`/`vSplitCount` and `uSplitParams`/`vSplitParams`
+  (ascending, bounded by the surface's own U/V domain).
 - **OCCT:** `BSplSLib::KnotSplitting`.
 - **Example:**
   ```swift
   let result = surf.knotSplitting(uContinuity: 2, vContinuity: 2)
-  print("U splits needed:", result.uSplitCount)
-  print("V splits needed:", result.vSplitCount)
+  print("U splits needed:", result.uSplitCount, result.uSplitParams)
+  print("V splits needed:", result.vSplitCount, result.vSplitParams)
   ```
 
 ---


### PR DESCRIPTION
## What & why

`Curve3D.continuityBreaks`, `Surface.knotSplitting`, and `LawFunction.knotSplitting` all wrap the
same OCCT "find where a BSpline drops below a requested continuity" analyzer family
(`GeomConvert_BSplineCurveKnotSplitting` / `GeomConvert_BSplineSurfaceKnotSplitting` /
`Law_BSplineKnotSplitting`), but returned three incompatible shapes: real parameters, bare
counts, and raw knot-table indices.

**Triage conclusion: two of the three divergences are by design, one was a real gap.**
A curve's discontinuities are inherently 1D, so `Curve3D.continuityBreaks` returning parameters
is already correct and needed no change. A surface's are inherently 2D (U and V are independent),
so per-direction counts *and* locations is the right shape there too -- but `Surface.knotSplitting`
was dropping the locations even though the underlying `GeomConvert_BSplineSurfaceKnotSplitting`
analyzer always computes them (`USplitValue`/`VSplitValue`), for no reason. Same story for
`LawFunction.knotSplitting`: its raw knot-table indices are uninterpretable through the public
API (there's no accessor for a law's own knot vector), while `Law_BSpline::Knot(index)` -- the
same conversion `Curve3D` already does -- was sitting right there unused.

**Fix**: additive only, no existing signature changed.
- `Surface.KnotSplitResult` gains `uSplitParams`/`vSplitParams: [Double]` alongside the existing
  counts.
- `LawFunction` gains a new sibling method, `knotSplitParameters(continuityOrder:) -> [Double]`;
  the existing `knotSplitting(continuityOrder:) -> [Int]` is untouched for callers who already
  depend on raw indices.
- `Curve3D.continuityBreaks` is unchanged functionally; its doc comment now states the rationale
  so this doesn't reopen as a bug report.
- The three bridge implementations' identical "walk N split points, convert each to a real
  parameter, write up to a buffer, report the true count" loop is now one shared C++ template,
  `occtWriteKnotSplitParams` (`OCCTBridge_Internal.h`), used by all three call sites (and twice,
  once per direction, inside the surface one) instead of being hand-duplicated three times.

Refs #403. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

Two new suites, one per affected test target:
- `Tests/OCCTSurfaceTests/Issue403SurfaceKnotSplitParamsTests.swift` -- param/count length parity,
  ascending order, domain-bracketing, and a non-BSpline surface returning empty (not a crash).
- `Tests/OCCTCurveTests/Issue403LawKnotSplitParamsTests.swift` -- count parity between
  `knotSplitting`/`knotSplitParameters`, ascending order, bounds-bracketing, the known interior
  break at a multiplicity-2 knot, and a non-BSpline-based law returning empty.

## Notes for the reviewer

**Why not fully unify into one shared return type?** The parent issue's own framing is right:
a curve is 1D, a surface is 2D-per-direction, a law is 1D-on-its-own-domain. Forcing all three
into one struct would either lose the surface's U/V split or invent a fake "direction" for the
curve/law cases. What *was* wrong was two of the three quietly dropping data their own OCCT
backing class already computed for free -- that's the part this PR fixes.

**Why keep `LawFunction.knotSplitting`'s raw-index return instead of converting it in place?**
Changing its return type from `[Int]` to something richer would break existing callers (there's
a pre-existing test asserting `.count` on it as an array). Adding a sibling method keeps that
signature exactly as it was, per the issue's own "add fields/parameters rather than removing"
guidance -- there's no struct here to add a field to, so a new method is the additive
equivalent.

**Conflict risk**: touches `Sources/OCCTBridge/include/OCCTBridge.h` and three `.mm` files plus
three `Sources/OCCTSwift/*.swift` files; no overlap expected with the other in-flight #380 child
PRs based on their stated scopes.

Full `swift build` clean. Full `swift test`: 4519 tests in 1302 suites, 1 failure -- the known,
pre-existing `Shape.loadRobust` CPU-timing-sensitive cancellation flake (`OCCTIOTests.swift:2303`,
explicitly called out as an unrelated, ignorable flake), not touched by this change. The two
new `#403` suites and every other suite pass.

No `CHANGELOG.md` entry deliberately -- the audit branch merges to `main` as one unit, and
parallel child PRs each editing the same header would conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
