### PR TITLE
fix(#404): unify drawMesh/evaluateGrid on a SurfaceGrid type

### DIFF
--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2,6 +2,46 @@ import Foundation
 import simd
 import OCCTBridge
 
+/// A 2D grid of points sampled over a surface's UV parameter space.
+///
+/// Returned by ``Surface/drawMesh(uCount:vCount:)`` and
+/// ``Surface/evaluateGrid(uParameters:vParameters:)``. Both share this type specifically so
+/// indexing is unambiguous: access is always `.at(u:v:)`, regardless of how each method lays out
+/// its own bridge buffer internally — there is no `[[SIMD3<Double>]]` nesting order left for a
+/// caller to get backwards between the two.
+///
+/// ```swift
+/// let grid = surface.drawMesh(uCount: 20, vCount: 10)
+/// let corner = grid.at(u: 0, v: 0)
+/// let opposite = grid.at(u: grid.uCount - 1, v: grid.vCount - 1)
+/// ```
+public struct SurfaceGrid: Sendable {
+    /// Number of samples in the U direction.
+    public let uCount: Int
+    /// Number of samples in the V direction.
+    public let vCount: Int
+    /// Flat storage, U-major: `points[u * vCount + v]`.
+    private let points: [SIMD3<Double>]
+
+    init(uCount: Int, vCount: Int, points: [SIMD3<Double>]) {
+        self.uCount = uCount
+        self.vCount = vCount
+        self.points = points
+    }
+
+    static let empty = SurfaceGrid(uCount: 0, vCount: 0, points: [])
+
+    /// Whether this grid has no points (returned when sampling fails).
+    public var isEmpty: Bool { points.isEmpty }
+
+    /// Point at the given U/V grid index.
+    public func at(u: Int, v: Int) -> SIMD3<Double> {
+        precondition(u >= 0 && u < uCount && v >= 0 && v < vCount,
+                      "SurfaceGrid.at(u: \(u), v: \(v)) out of range (uCount: \(uCount), vCount: \(vCount))")
+        return points[u * vCount + v]
+    }
+}
+
 /// A parametric surface backed by OpenCASCADE Handle(Geom_Surface).
 ///
 /// Wraps analytic surfaces (plane, cylinder, cone, sphere, torus),
@@ -455,26 +495,28 @@ public final class Surface: @unchecked Sendable {
         return result
     }
 
-    /// Sample a uniform mesh grid of points for Metal visualization
-    /// - Returns: 2D array [uIndex][vIndex] of surface points
-    public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> [[SIMD3<Double>]] {
+    /// Sample a uniform mesh grid of points for Metal visualization.
+    ///
+    /// - Returns: A ``SurfaceGrid`` indexed `.at(u:v:)`, or an empty grid if sampling fails.
+    ///
+    /// ```swift
+    /// let grid = surface.drawMesh(uCount: 30, vCount: 30)
+    /// let p = grid.at(u: 5, v: 3)
+    /// ```
+    public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid {
         let total = uCount * vCount
         var buffer = [Double](repeating: 0, count: total * 3)
         let n = Int(OCCTSurfaceDrawMesh(handle, Int32(uCount), Int32(vCount), &buffer))
-        guard n == total else { return [] }
+        guard n == total else { return .empty }
 
-        var grid = [[SIMD3<Double>]]()
-        grid.reserveCapacity(uCount)
-        for i in 0..<uCount {
-            var row = [SIMD3<Double>]()
-            row.reserveCapacity(vCount)
-            for j in 0..<vCount {
-                let idx = (i * vCount + j) * 3
-                row.append(SIMD3(buffer[idx], buffer[idx + 1], buffer[idx + 2]))
-            }
-            grid.append(row)
+        // Bridge buffer is already U-major (idx = u * vCount + v), matching SurfaceGrid's storage.
+        var points = [SIMD3<Double>]()
+        points.reserveCapacity(total)
+        for idx in 0..<total {
+            let base = idx * 3
+            points.append(SIMD3(buffer[base], buffer[base + 1], buffer[base + 2]))
         }
-        return grid
+        return SurfaceGrid(uCount: uCount, vCount: vCount, points: points)
     }
 
     // MARK: - Local Properties
@@ -784,31 +826,38 @@ public final class Surface: @unchecked Sendable {
 extension Surface {
     /// Evaluate the surface at a UV grid in one call.
     ///
-    /// Returns points in row-major order (u varies fastest).
-    ///
     /// - Parameters:
     ///   - uParameters: Array of U parameter values
     ///   - vParameters: Array of V parameter values
-    /// - Returns: 2D array of evaluated 3D points [v][u]
-    public func evaluateGrid(uParameters: [Double], vParameters: [Double]) -> [[SIMD3<Double>]] {
-        guard !uParameters.isEmpty, !vParameters.isEmpty else { return [] }
-        let total = uParameters.count * vParameters.count
+    /// - Returns: A ``SurfaceGrid`` indexed `.at(u:v:)`, or an empty grid if either input is
+    ///   empty or the evaluated count doesn't match `uParameters.count * vParameters.count`.
+    ///
+    /// ```swift
+    /// let grid = surface.evaluateGrid(uParameters: [0, 1, 2], vParameters: [0, 1])
+    /// let p = grid.at(u: 2, v: 0)
+    /// ```
+    public func evaluateGrid(uParameters: [Double], vParameters: [Double]) -> SurfaceGrid {
+        guard !uParameters.isEmpty, !vParameters.isEmpty else { return .empty }
+        let uCount = uParameters.count
+        let vCount = vParameters.count
+        let total = uCount * vCount
         var outXYZ = [Double](repeating: 0, count: total * 3)
         let n = Int(OCCTSurfaceEvaluateGrid(handle,
-                                             uParameters, Int32(uParameters.count),
-                                             vParameters, Int32(vParameters.count),
+                                             uParameters, Int32(uCount),
+                                             vParameters, Int32(vCount),
                                              &outXYZ))
-        guard n == total else { return [] }
-        var result = [[SIMD3<Double>]]()
-        for v in 0..<vParameters.count {
-            var row = [SIMD3<Double>]()
-            for u in 0..<uParameters.count {
-                let i = v * uParameters.count + u
-                row.append(SIMD3(outXYZ[i * 3], outXYZ[i * 3 + 1], outXYZ[i * 3 + 2]))
+        guard n == total else { return .empty }
+
+        // Bridge buffer is V-major (v varies slowest, per OCCTSurfaceEvaluateGrid's own doc
+        // comment); SurfaceGrid's storage is U-major, so transpose while unpacking.
+        var points = [SIMD3<Double>](repeating: SIMD3(0, 0, 0), count: total)
+        for v in 0..<vCount {
+            for u in 0..<uCount {
+                let bridgeIdx = (v * uCount + u) * 3
+                points[u * vCount + v] = SIMD3(outXYZ[bridgeIdx], outXYZ[bridgeIdx + 1], outXYZ[bridgeIdx + 2])
             }
-            result.append(row)
         }
-        return result
+        return SurfaceGrid(uCount: uCount, vCount: vCount, points: points)
     }
 }
 

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -861,8 +861,39 @@ struct SurfaceDrawTests {
     func drawMesh() {
         let sphere = Surface.sphere(center: .zero, radius: 5)!
         let mesh = sphere.drawMesh(uCount: 10, vCount: 10)
-        #expect(mesh.count == 10)
-        #expect(mesh[0].count == 10)
+        #expect(mesh.uCount == 10)
+        #expect(mesh.vCount == 10)
+        let p = mesh.at(u: 0, v: 0)
+        #expect(abs(simd_length(p) - 5.0) < 1e-6)
+    }
+
+    @Test("Draw mesh on an asymmetric grid indexes .at(u:v:) correctly")
+    func drawMeshAsymmetric() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        let uCount = 6, vCount = 4
+        let mesh = sphere.drawMesh(uCount: uCount, vCount: vCount)
+        #expect(mesh.uCount == uCount)
+        #expect(mesh.vCount == vCount)
+
+        // Recompute the same clamped domain the bridge samples (OCCTSurfaceDrawMesh), and cross
+        // check every grid point against the independent single-point evaluator. Before #404,
+        // drawMesh's own test used a symmetric 10x10 grid, which cannot distinguish [u][v] from
+        // [v][u] ordering — this asymmetric grid can.
+        var (uMin, uMax, vMin, vMax) = sphere.domain
+        if uMin < -1e6 { uMin = -100 }
+        if uMax > 1e6 { uMax = 100 }
+        if vMin < -1e6 { vMin = -100 }
+        if vMax > 1e6 { vMax = 100 }
+
+        for u in 0..<uCount {
+            let uParam = uMin + (uMax - uMin) * Double(u) / Double(uCount - 1)
+            for v in 0..<vCount {
+                let vParam = vMin + (vMax - vMin) * Double(v) / Double(vCount - 1)
+                let expected = sphere.point(atU: uParam, v: vParam)
+                let actual = mesh.at(u: u, v: v)
+                #expect(simd_length(actual - expected) < 1e-6)
+            }
+        }
     }
 }
 
@@ -1322,12 +1353,12 @@ struct BatchSurfaceTests {
         let uParams = [0.0, 1.0, 2.0]
         let vParams = [0.0, 1.0]
         let grid = plane.evaluateGrid(uParameters: uParams, vParameters: vParams)
-        #expect(grid.count == 2) // 2 rows (v)
-        #expect(grid[0].count == 3) // 3 columns (u)
+        #expect(grid.uCount == 3)
+        #expect(grid.vCount == 2)
         // All z should be 0 on the XY plane
-        for row in grid {
-            for pt in row {
-                #expect(abs(pt.z) < 1e-10)
+        for u in 0..<grid.uCount {
+            for v in 0..<grid.vCount {
+                #expect(abs(grid.at(u: u, v: v).z) < 1e-10)
             }
         }
     }
@@ -1338,13 +1369,66 @@ struct BatchSurfaceTests {
         let uParams = stride(from: 0.0, to: 2 * Double.pi, by: Double.pi / 4).map { $0 }
         let vParams = stride(from: -Double.pi / 2, to: Double.pi / 2, by: Double.pi / 4).map { $0 }
         let grid = sphere.evaluateGrid(uParameters: uParams, vParameters: vParams)
-        #expect(grid.count == vParams.count)
-        #expect(grid[0].count == uParams.count)
+        #expect(grid.uCount == uParams.count)
+        #expect(grid.vCount == vParams.count)
         // All points should be at distance 5 from origin
-        for row in grid {
-            for pt in row {
+        for u in 0..<grid.uCount {
+            for v in 0..<grid.vCount {
+                let pt = grid.at(u: u, v: v)
                 let dist = sqrt(pt.x * pt.x + pt.y * pt.y + pt.z * pt.z)
                 #expect(abs(dist - 5.0) < 1e-6)
+            }
+        }
+    }
+
+    @Test("evaluateGrid indexes each (u, v) at its own parameter, not transposed")
+    func evalGridAsymmetricMatchesDirectEvaluation() {
+        // #404: evaluateGrid used to return [vIndex][uIndex] while drawMesh returned
+        // [uIndex][vIndex] — a symmetric grid can't tell the two conventions apart, so use an
+        // asymmetric one and cross-check every sample against the independent point(atU:v:)
+        // evaluator.
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        let uParams = [0.0, 0.4, 1.1, 2.0, 3.5]
+        let vParams = [-1.2, 0.0, 1.2]
+        let grid = sphere.evaluateGrid(uParameters: uParams, vParameters: vParams)
+        #expect(grid.uCount == uParams.count)
+        #expect(grid.vCount == vParams.count)
+
+        for u in 0..<uParams.count {
+            for v in 0..<vParams.count {
+                let expected = sphere.point(atU: uParams[u], v: vParams[v])
+                let actual = grid.at(u: u, v: v)
+                #expect(simd_length(actual - expected) < 1e-6)
+            }
+        }
+    }
+
+    @Test("drawMesh and evaluateGrid agree at matching parameters")
+    func drawMeshAndEvaluateGridAgree() {
+        // #404: the two methods used opposite index conventions internally, but nothing at the
+        // type level distinguished them — a caller mixing them up would silently read transposed
+        // data. Now both return SurfaceGrid, sampled here at the same asymmetric (u, v) grid, so
+        // they must agree point-for-point under the same .at(u:v:) indexing.
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        let uCount = 5, vCount = 3
+        let meshGrid = sphere.drawMesh(uCount: uCount, vCount: vCount)
+
+        var (uMin, uMax, vMin, vMax) = sphere.domain
+        if uMin < -1e6 { uMin = -100 }
+        if uMax > 1e6 { uMax = 100 }
+        if vMin < -1e6 { vMin = -100 }
+        if vMax > 1e6 { vMax = 100 }
+        let uParams = (0..<uCount).map { uMin + (uMax - uMin) * Double($0) / Double(uCount - 1) }
+        let vParams = (0..<vCount).map { vMin + (vMax - vMin) * Double($0) / Double(vCount - 1) }
+        let evalGrid = sphere.evaluateGrid(uParameters: uParams, vParameters: vParams)
+
+        #expect(meshGrid.uCount == evalGrid.uCount)
+        #expect(meshGrid.vCount == evalGrid.vCount)
+        for u in 0..<uCount {
+            for v in 0..<vCount {
+                let fromMesh = meshGrid.at(u: u, v: v)
+                let fromEval = evalGrid.at(u: u, v: v)
+                #expect(simd_length(fromMesh - fromEval) < 1e-6)
             }
         }
     }

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -697,13 +697,18 @@ Returns all intersection points (tangent and transverse) up to an internal cap o
 Evaluates the surface at a grid of UV parameters in a single call.
 
 ```swift
-public func evaluateGrid(uParameters: [Double], vParameters: [Double]) -> [[SIMD3<Double>]]
+public func evaluateGrid(uParameters: [Double], vParameters: [Double]) -> SurfaceGrid
 ```
 
-Returns a 2D array indexed `[vIndex][uIndex]` — V is the outer index. This is significantly faster than individual `point(atU:v:)` calls when building a dense mesh or sampling a parameter grid.
+Returns a `SurfaceGrid` (see [Surface.md](Surface.md#surfacegrid)) indexed `.at(u:v:)` — the same
+type `drawMesh(uCount:vCount:)` returns, so the two can never disagree on index order the way
+their old raw `[[SIMD3<Double>]]` returns could ([#404](https://github.com/SecondMouseAU/OCCTSwift/issues/404)).
+This is significantly faster than individual `point(atU:v:)` calls when building a dense mesh or
+sampling a parameter grid.
 
 - **Parameters:** `uParameters` — array of U parameter values; `vParameters` — array of V parameter values.
-- **Returns:** 2D array of 3D positions of size `[vParameters.count][uParameters.count]`, or empty if either input is empty or the evaluated count mismatches.
+- **Returns:** A `SurfaceGrid` of size `uParameters.count × vParameters.count`, or an empty grid if
+  either input is empty or the evaluated count mismatches.
 - **OCCT:** `Geom_Surface::D0` called per grid point via the bridge buffer.
 - **Example:**
   ```swift
@@ -711,7 +716,7 @@ Returns a 2D array indexed `[vIndex][uIndex]` — V is the outer index. This is 
       let us = stride(from: 0.0, through: Double.pi * 2, by: 0.1).map { $0 }
       let vs = stride(from: -.pi / 2, through: .pi / 2, by: 0.1).map { $0 }
       let grid = srf.evaluateGrid(uParameters: us, vParameters: vs)
-      // grid[i][j] is the 3D point at (us[j], vs[i])
+      let p = grid.at(u: 2, v: 0)  // point at (us[2], vs[0])
   }
   ```
 - **Note:** Result is empty (not a partial result) if the internal buffer fill count does not match `uParameters.count × vParameters.count`.

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -808,23 +808,46 @@ Samples `uLineCount` U-iso lines and `vLineCount` V-iso lines, each discretised 
 
 ---
 
+### `SurfaceGrid`
+
+A 2D grid of points sampled over a surface's UV parameter space, returned by `drawMesh(uCount:vCount:)`
+and `evaluateGrid(uParameters:vParameters:)` (see [Surface-Analysis.md](Surface-Analysis.md)). Both
+methods share this one type specifically so indexing is unambiguous — access is always
+`.at(u:v:)`, regardless of how each method lays out its own bridge buffer internally. Before
+[#404](https://github.com/SecondMouseAU/OCCTSwift/issues/404), the two returned raw
+`[[SIMD3<Double>]]` with opposite nesting order (`[uIndex][vIndex]` vs `[vIndex][uIndex]`) and
+nothing at the type level stopped a caller from mixing them up.
+
+```swift
+public struct SurfaceGrid: Sendable {
+    public let uCount: Int
+    public let vCount: Int
+    public var isEmpty: Bool { get }
+    public func at(u: Int, v: Int) -> SIMD3<Double>
+}
+```
+
+- **`uCount`/`vCount`:** number of samples in each direction.
+- **`at(u:v:)`:** the point at that grid index. Traps if either index is out of range.
+- **`isEmpty`:** `true` for the grid returned when sampling fails.
+
+---
+
 ### `drawMesh(uCount:vCount:)`
 
 Samples a uniform mesh grid of points for Metal visualisation.
 
 ```swift
-public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> [[SIMD3<Double>]]
+public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid
 ```
 
-Returns a 2D array indexed `[uIndex][vIndex]` of evaluated surface points on a uniform UV grid.
-
 - **Parameters:** `uCount` — number of U sample points; `vCount` — number of V sample points.
-- **Returns:** 2D array of 3D points, or `[]` if sampling fails.
+- **Returns:** A `SurfaceGrid` indexed `.at(u:v:)`, or an empty grid if sampling fails.
 - **OCCT:** `Geom_Surface::D0` sampled on a uniform UV grid.
 - **Example:**
   ```swift
   let mesh = surface.drawMesh(uCount: 30, vCount: 30)
-  // mesh[i][j] is the surface point at the ith U and jth V sample
+  let p = mesh.at(u: 5, v: 3)
   ```
 
 ---


### PR DESCRIPTION
## What & why

`Surface.drawMesh(uCount:vCount:)` and `Surface.evaluateGrid(uParameters:vParameters:)` both
sample a UV grid into a nested array, but disagreed on nesting order: `drawMesh` returned
`[uIndex][vIndex]` (confirmed against its bridge buffer, U-major) while `evaluateGrid` returned
`[vIndex][uIndex]` (confirmed against `OCCTSurfaceEvaluateGrid`'s own doc comment, V-major). Both
sides were internally self-consistent, so there was no live bug — but nothing at the type level
stopped a caller used to one method's ordering from indexing the other the same way and silently
reading transposed U/V data. `drawMesh`'s only prior test used a symmetric 10x10 grid, which can't
distinguish the two conventions.

Checked every consumer in the OCCTSwift monorepo and every sibling ecosystem repo
(OCCTSwiftViewport, OCCTReconstruct, OCCTMCP, OCCTStudio) before choosing a fix: nothing outside
this repo's own tests calls `Surface.drawMesh` or `Surface.evaluateGrid` (the `evaluateGrid` calls
in OCCTSwiftViewport's gallery are all `Curve3D.evaluateGrid`, a different, unambiguous 1D-array
overload). With zero external call sites at risk, a wrapper type was a clean, contained change
rather than a large one.

Both methods now return a new `SurfaceGrid` struct (`uCount`, `vCount`, `.at(u:v:)`). Each keeps
its own bridge call and buffer layout internally — `drawMesh`'s buffer is already U-major and
copies straight across; `evaluateGrid`'s buffer is V-major and is transposed while unpacking — but
both converge on the same `.at(u:v:)` contract, so there is no more `[[SIMD3<Double>]]` nesting
order left to get backwards between the two.

Refs #404. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

`drawMeshAsymmetric` and `evalGridAsymmetricMatchesDirectEvaluation` sample an asymmetric grid
(`uCount != vCount`) and cross-check every point against the independent `point(atU:v:)`
evaluator — a case the old symmetric-grid tests could not have caught a transposition with.
`drawMeshAndEvaluateGridAgree` samples both methods at matching parameters on the same surface and
asserts they agree point-for-point under `.at(u:v:)`. The existing `drawMesh`/`evalGridPlane`/
`evalGridSphere` tests are updated to the new API, not replaced.

## Notes for the reviewer

**Why a wrapper type instead of a rename.** The issue offered a smaller alternative (rename to
`uMajor`/`vMajor`-style parameters, add a doc comment + runtime assertion) if a wrapper type was
too large a change. A rename only helps a reader who stops to check the name; it does not stop
`[[SIMD3<Double>]]` from being indexed either way by habit. Since no downstream consumer touches
either method's return value, replacing the nested array with `SurfaceGrid` costs nothing in
compatibility and removes the ambiguity outright — old code indexing `grid[i][j]` no longer
compiles at all, rather than silently continuing to compile with a swapped meaning.

**Storage layout.** `SurfaceGrid` stores U-major internally (`points[u * vCount + v]`); this only
affects transpose cost inside `evaluateGrid` (V-major bridge buffer) — callers only ever see
`.at(u:v:)` and never see the backing layout.

**Docs.** `docs/reference/Surface.md` gained a `SurfaceGrid` section (linked from
`Surface-Analysis.md`); both `drawMesh`/`evaluateGrid` entries there and the `///` doc comments in
`Surface.swift` were updated to the new signature and a `.at(u:v:)` example. Op-count tables in
`docs/API_REFERENCE.md`/`README.md` are untouched — this isn't a new-ops release.

Full `swift test`: 4515 tests / 1300 suites, all passed, no failures, no flakes observed in this
run.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and parallel child PRs each editing the same changelog header would conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)