### PR TITLE
fix(#409): Curve2D.arcLength(from:to:) returns nil on failure, not 0.0

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -17478,7 +17478,8 @@ double OCCTCurve3DClosestParameter(OCCTCurve3DRef _Nonnull curve, double px, dou
 /// Create a trimmed copy of a 2D curve between parameters u1 and u2.
 OCCTCurve2DRef _Nullable OCCTCurve2DTrimmed(OCCTCurve2DRef _Nonnull curve, double u1, double u2);
 
-/// Compute the length of a 2D curve between parameters u1 and u2.
+/// Compute the length of a 2D curve between parameters u1 and u2 (u1 must not exceed u2).
+/// Returns -1.0 on failure (null curve, reversed range, or any other computation error).
 double OCCTCurve2DLength(OCCTCurve2DRef _Nonnull curve, double u1, double u2);
 
 // --- Surface additional (v0.115.0) ---

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -4126,14 +4126,16 @@ OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2) {
 
 #include <Geom2dAdaptor_Curve.hxx>
 
+// Range-checked: Geom2dAdaptor_Curve's (curve,u1,u2) constructor raises
+// Standard_ConstructionError if u1 > u2, unlike OCCTCurve2DGetLengthBetween's
+// unrestricted adaptor, which tolerates either order.
 double OCCTCurve2DLength(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return 0;
+    if (!curve || curve->curve.IsNull()) return -1.0;
     try {
         Geom2dAdaptor_Curve ac(curve->curve, u1, u2);
         return GCPnts_AbscissaPoint::Length(ac);
-    } catch (...) { return 0; }
+    } catch (...) { return -1.0; }
 }
-// --- Curve3D Arc Length (GCPnts_AbscissaPoint) ---
 
 // MARK: - v0.116: gp_GTrsf2d + gp_Mat2d
 void OCCTGTrsf2dAffinity(double axPx, double axPy, double axDx, double axDy, double ratio,

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -2354,13 +2354,17 @@ extension Curve2D {
         return Curve2D(handle: ref)
     }
 
-    /// Compute the arc length of this curve between parameters `u1` and `u2`. Unlike
-    /// `length(from:to:)`, `u1` must not exceed `u2`. Returns `nil` on failure (a reversed
-    /// range, a released curve, or any other computation error) rather than a sentinel `0.0`
-    /// that could be mistaken for a genuine zero-length segment.
-    public func arcLength(from u1: Double, to u2: Double) -> Double? {
+    /// Compute the arc length of this curve between parameters `u1` and `u2` (non-optional).
+    ///
+    /// Unlike `length(from:to:)`, `u1` must not exceed `u2` — the underlying computation uses a
+    /// range-checked adaptor that fails on a reversed range. Returns `-1.0` on failure (a
+    /// reversed range, a released curve, or any other computation error) — arc length is
+    /// otherwise always non-negative, so this is an unambiguous failure sentinel, never
+    /// confusable with a genuine zero-length segment (e.g. `u1 == u2`). Use `length(from:to:)`
+    /// directly if you need an optional rather than a sentinel value (and order tolerance).
+    public func arcLength(from u1: Double, to u2: Double) -> Double {
         let l = OCCTCurve2DLength(handle, u1, u2)
-        return l >= 0 ? l : nil
+        return l >= 0 ? l : -1.0
     }
 
     /// Split this curve at C1 discontinuities.

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -450,7 +450,10 @@ public final class Curve2D: @unchecked Sendable {
         return l >= 0 ? l : nil
     }
 
-    /// Arc length between two parameter values.
+    /// Arc length between two parameter values. Unlike `arcLength(from:to:)`, `u1` may be
+    /// greater than `u2` (order doesn't affect the result). Returns `nil` on failure (e.g. a
+    /// released curve), never a sentinel value that could be mistaken for a real zero-length
+    /// segment.
     public func length(from u1: Double, to u2: Double) -> Double? {
         let l = OCCTCurve2DGetLengthBetween(handle, u1, u2)
         return l >= 0 ? l : nil
@@ -2351,9 +2354,13 @@ extension Curve2D {
         return Curve2D(handle: ref)
     }
 
-    /// Compute the arc length of this curve between parameters u1 and u2 (non-optional).
-    public func arcLength(from u1: Double, to u2: Double) -> Double {
-        OCCTCurve2DLength(handle, u1, u2)
+    /// Compute the arc length of this curve between parameters `u1` and `u2`. Unlike
+    /// `length(from:to:)`, `u1` must not exceed `u2`. Returns `nil` on failure (a reversed
+    /// range, a released curve, or any other computation error) rather than a sentinel `0.0`
+    /// that could be mistaken for a genuine zero-length segment.
+    public func arcLength(from u1: Double, to u2: Double) -> Double? {
+        let l = OCCTCurve2DLength(handle, u1, u2)
+        return l >= 0 ? l : nil
     }
 
     /// Split this curve at C1 discontinuities.

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -2972,7 +2972,11 @@ struct CurveLengthTests {
                                             endTangent: SIMD2(1, -1)) {
             let domain = curve.domain
             let len = curve.arcLength(from: domain.lowerBound, to: domain.upperBound)
-            #expect(len > 0)
+            if let len {
+                #expect(len > 0)
+            } else {
+                Issue.record("arcLength(from:to:) unexpectedly failed for a forward-ordered range")
+            }
         }
     }
 }

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -2972,11 +2972,7 @@ struct CurveLengthTests {
                                             endTangent: SIMD2(1, -1)) {
             let domain = curve.domain
             let len = curve.arcLength(from: domain.lowerBound, to: domain.upperBound)
-            if let len {
-                #expect(len > 0)
-            } else {
-                Issue.record("arcLength(from:to:) unexpectedly failed for a forward-ordered range")
-            }
+            #expect(len > 0)
         }
     }
 }

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4541,26 +4541,28 @@ struct Curve2DInterpolateTangentsParityTests {
 /// `Standard_ConstructionError` when `u1 > u2`), while `length(from:to:)` builds an unrestricted
 /// adaptor and calls the `Length(adaptor, u1, u2)` overload, which tolerates either order. That
 /// is a genuine behavioral difference, not just a cosmetic one, so `arcLength(from:to:)` keeps
-/// its own bridge call rather than delegating to `length(from:to:)`. Both used to collapse this
-/// (and any other computation failure) into a sentinel `0.0`/`-1.0` with no way for a caller to
-/// tell it apart from a legitimate zero-length result; both now return `nil` on failure.
+/// its own bridge call rather than delegating to `length(from:to:)`. `arcLength(from:to:)` stays
+/// non-optional (matching #408's `Curve3D.arcLength(from:to:)` shape, to avoid a source-breaking
+/// signature change) but now collapses failure to an unambiguous `-1.0` sentinel instead of
+/// `0.0`, which could be mistaken for a legitimate zero-length result; `length(from:to:)` is the
+/// optional, failure-distinguishing sibling for callers who need `nil` rather than a sentinel.
 @Suite("Curve2D.arcLength(from:to:) distinguishes failure from zero (#409)")
 struct Curve2DArcLengthFailureTests {
 
     private static let bezier = Curve2D.bezier(poles: [SIMD2(0, 0), SIMD2(5, 5), SIMD2(10, 0)])!
 
-    @Test("A reversed range is a genuine failure, not a zero-length result")
+    @Test("A reversed range is a genuine failure, reported as -1.0, not 0.0")
     func reversedRangeFails() {
-        #expect(Self.bezier.arcLength(from: 0.8, to: 0.2) == nil)
+        let len = Self.bezier.arcLength(from: 0.8, to: 0.2)
+        #expect(len == -1.0)
+        #expect(len != 0.0)
     }
 
-    @Test("Equal bounds are a genuine zero-length result, not a failure")
+    @Test("Equal bounds are a genuine zero-length result, not the failure sentinel")
     func equalBoundsAreGenuinelyZero() {
         let len = Self.bezier.arcLength(from: 0.3, to: 0.3)
-        #expect(len != nil)
-        if let len {
-            #expect(abs(len) < 1e-9)
-        }
+        #expect(abs(len) < 1e-9)
+        #expect(len != -1.0)
     }
 
     @Test("length(from:to:) tolerates the same reversed range arcLength(from:to:) rejects")

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4532,3 +4532,45 @@ struct Curve2DInterpolateTangentsParityTests {
                                     endTangent: Self.endTangent) == nil)
     }
 }
+
+// MARK: - #409: arcLength(from:to:) no longer collapses failure into 0.0
+
+/// `arcLength(from:to:)` and `length(from:to:)` both wrap `GCPnts_AbscissaPoint::Length` over
+/// a `Geom2dAdaptor_Curve`, but via different construction idioms: `arcLength(from:to:)` builds
+/// a range-checked adaptor (`Geom2dAdaptor_Curve(curve, u1, u2)`, which raises
+/// `Standard_ConstructionError` when `u1 > u2`), while `length(from:to:)` builds an unrestricted
+/// adaptor and calls the `Length(adaptor, u1, u2)` overload, which tolerates either order. That
+/// is a genuine behavioral difference, not just a cosmetic one, so `arcLength(from:to:)` keeps
+/// its own bridge call rather than delegating to `length(from:to:)`. Both used to collapse this
+/// (and any other computation failure) into a sentinel `0.0`/`-1.0` with no way for a caller to
+/// tell it apart from a legitimate zero-length result; both now return `nil` on failure.
+@Suite("Curve2D.arcLength(from:to:) distinguishes failure from zero (#409)")
+struct Curve2DArcLengthFailureTests {
+
+    private static let bezier = Curve2D.bezier(poles: [SIMD2(0, 0), SIMD2(5, 5), SIMD2(10, 0)])!
+
+    @Test("A reversed range is a genuine failure, not a zero-length result")
+    func reversedRangeFails() {
+        #expect(Self.bezier.arcLength(from: 0.8, to: 0.2) == nil)
+    }
+
+    @Test("Equal bounds are a genuine zero-length result, not a failure")
+    func equalBoundsAreGenuinelyZero() {
+        let len = Self.bezier.arcLength(from: 0.3, to: 0.3)
+        #expect(len != nil)
+        if let len {
+            #expect(abs(len) < 1e-9)
+        }
+    }
+
+    @Test("length(from:to:) tolerates the same reversed range arcLength(from:to:) rejects")
+    func lengthToleratesReversedRange() {
+        let forward = Self.bezier.length(from: 0.2, to: 0.8)
+        let reversed = Self.bezier.length(from: 0.8, to: 0.2)
+        #expect(forward != nil)
+        #expect(reversed != nil)
+        if let forward, let reversed {
+            #expect(abs(forward - reversed) < 1e-9)
+        }
+    }
+}

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1009,17 +1009,21 @@ public static func approximate(
 
 ### `arcLength(from:to:)`
 
-Computes the arc length of this curve between two parameter values. `u1` must not exceed `u2` —
-unlike `length(from:to:)`, which tolerates either order — since this entry point is backed by
-`Geom2dAdaptor_Curve`'s range-checked constructor.
+Computes the arc length of this curve between two parameter values (non-optional). `u1` must not
+exceed `u2` — unlike `length(from:to:)`, which tolerates either order — since this entry point is
+backed by `Geom2dAdaptor_Curve`'s range-checked constructor. Unlike `Curve3D.arcLength(from:to:)`,
+this does not delegate to `length(from:to:)`: the two use genuinely different adaptor
+constructions (range-checked vs. unrestricted), so collapsing them onto one call would silently
+drop the order validation.
 
 ```swift
-public func arcLength(from u1: Double, to u2: Double) -> Double?
+public func arcLength(from u1: Double, to u2: Double) -> Double
 ```
 
 - **Parameters:** `u1`/`u2` — parameter range, with `u1 ≤ u2`.
-- **Returns:** Arc length value, or `nil` on failure (e.g. a reversed range) — never a sentinel
-  `0.0` that could be mistaken for a genuine zero-length segment.
+- **Returns:** Arc length value, or `-1.0` on failure (e.g. a reversed range) — arc length is
+  otherwise always non-negative, so `-1.0` is unambiguous and never collides with a genuine
+  zero-length result (e.g. `u1 == u2`). Use `length(from:to:)` directly if you need an optional.
 - **OCCT:** `Geom2dAdaptor_Curve(curve, u1, u2)` + `GCPnts_AbscissaPoint::Length(adaptor)`.
 - **Example:**
   ```swift

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1009,15 +1009,18 @@ public static func approximate(
 
 ### `arcLength(from:to:)`
 
-Computes the arc length of this curve between two parameter values.
+Computes the arc length of this curve between two parameter values. `u1` must not exceed `u2` —
+unlike `length(from:to:)`, which tolerates either order — since this entry point is backed by
+`Geom2dAdaptor_Curve`'s range-checked constructor.
 
 ```swift
-public func arcLength(from u1: Double, to u2: Double) -> Double
+public func arcLength(from u1: Double, to u2: Double) -> Double?
 ```
 
-- **Parameters:** `u1`/`u2` — parameter range.
-- **Returns:** Arc length value (always non-negative when `u1 ≤ u2`).
-- **OCCT:** `GeomAdaptor_Curve` + `GCPnts_AbscissaPoint::Length`.
+- **Parameters:** `u1`/`u2` — parameter range, with `u1 ≤ u2`.
+- **Returns:** Arc length value, or `nil` on failure (e.g. a reversed range) — never a sentinel
+  `0.0` that could be mistaken for a genuine zero-length segment.
+- **OCCT:** `Geom2dAdaptor_Curve(curve, u1, u2)` + `GCPnts_AbscissaPoint::Length(adaptor)`.
 - **Example:**
   ```swift
   if let circle = Curve2D.circle(center: .zero, radius: 5) {

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -824,14 +824,16 @@ public var length: Double? { get }
 
 ### `length(from:to:)`
 
-Arc length between two parameter values.
+Arc length between two parameter values. Unlike `arcLength(from:to:)`, `u1` may be greater than
+`u2` — order doesn't affect the result, since this entry point builds an unrestricted adaptor
+rather than a range-checked one.
 
 ```swift
 public func length(from u1: Double, to u2: Double) -> Double?
 ```
 
-- **Parameters:** `u1` — start parameter; `u2` — end parameter.
-- **Returns:** Arc length, or `nil` on failure.
+- **Parameters:** `u1` — start parameter; `u2` — end parameter (either order).
+- **Returns:** Arc length, or `nil` on failure — never a sentinel value.
 - **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`.
 - **Example:**
   ```swift


### PR DESCRIPTION
## What & why

`Curve2D` exposes the same arc-length computation twice. `length(from:to:)` (backed by
`OCCTCurve2DGetLengthBetween`) already returns `Double?`, mapping a `-1.0` bridge sentinel to
`nil` on failure. `arcLength(from:to:)` (backed by `OCCTCurve2DLength`) returned a plain,
non-optional `Double`, mapping the exact same failure conditions to a sentinel `0.0` — silently
indistinguishable from a curve whose arc length is genuinely zero.

Reading both bridge implementations directly (not just the auditor's "cosmetic duplication"
summary) turned up a real, previously-undocumented divergence beyond the sentinel: `arcLength`'s
bridge call constructs a range-checked `Geom2dAdaptor_Curve(curve, u1, u2)`, which raises
`Standard_ConstructionError` when `u1 > u2`; `length`'s bridge call builds an *unrestricted*
adaptor and calls the `Length(adaptor, u1, u2)` overload, which tolerates either order and
returns the same magnitude regardless (verified with a ground-truth C++ probe against the pinned
xcframework). So the two functions are not fully redundant — `arcLength` enforces an ordering
contract `length` does not — and consolidating them onto one call would silently change that
contract. `OCCTCurve2DLength` keeps its own bridge call; only its failure sentinel changes, from
`0` to `-1.0`, matching every other length-reporting bridge function in this file.

Refs #409. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve2DArcLengthFailureTests` (`Tests/OCCTGeom2dTests`): a reversed range
(`u1 > u2`) is a genuine failure (reported as `-1.0`, not `0.0`), an equal-bounds range is a
genuine zero-length result (not the failure sentinel), and `length(from:to:)` is shown tolerating
the exact reversed range `arcLength(from:to:)` rejects. The existing happy-path test
(`curve2DArcLength`, `Tests/OCCTCurveTests`) is unchanged — `arcLength(from:to:)` keeps its
original non-optional signature (see "Update after review" below).

## Notes for the reviewer

**Verified the bug was live**, not just theoretically reachable: temporarily reverting only the
bridge sentinel (`-1.0` back to `0`) and re-running the new suite reproduces the exact failure —
`arcLength(from: 0.8, to: 0.2) → 0.0` where `nil` was expected — then restored.

**Why not delegate `arcLength` to `length`.** That was my first instinct reading the issue (both
ultimately call `GCPnts_AbscissaPoint::Length` over a `Geom2dAdaptor_Curve`), but a ground-truth
probe against the real xcframework showed `length(from:to:)`'s unrestricted-adaptor idiom
happily computes a positive length for a reversed range — it does not fail at all for the input
that makes `arcLength(from:to:)` fail. Delegating would have silently dropped `arcLength`'s order
validation rather than just fixing its sentinel. Keeping the bridge calls separate, with a shared
failure contract (`nil`), preserves both computations' actual behavior.

**Relationship to #408 (now #461, merged).** #461 is the mirror fix for `Curve3D`
(`totalArcLength`, `arcLength(from:to:)`, `arcLengthBetween`). It deliberately kept those three
non-optional and collapsed failure to a `-1.0` sentinel, specifically to avoid a source-breaking
signature change. This PR originally converted `Curve2D.arcLength(from:to:)` to `Double?` instead
— a real inconsistency, corrected below after review. `Curve2D.length`/`length(from:to:)` remain
the optional, failure-distinguishing entry points on both types; `arcLength(from:to:)` stays a
non-optional `-1.0`-sentinel convenience wrapper on both types, though (unlike `Curve3D`)
`Curve2D`'s wrapper keeps its own bridge call rather than delegating to `length(from:to:)`, per
the ordering-contract divergence above.

Full `swift test` (4515 tests) clean except one pre-existing flake documented in
`CLAUDE.md`/the test's own source comment: `"Shape.loadRobust interrupts repair, not just the
transfer (#300)"`, a CPU-timing-sensitive cancellation test that fails only when running beside
its IGES sibling under parallel load — unrelated to this change.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and parallel child PRs editing the same changelog header would conflict on every one.

## Update after review

Per [review feedback](https://github.com/SecondMouseAU/OCCTSwift/pull/458#pullrequestreview-4802255752):
reworked `arcLength(from:to:)` to stay **non-optional**, matching `Curve3D.arcLength(from:to:)`'s
shape from #461 exactly — the `Double?` return type was a MAJOR-triggering breaking change
(`docs/SEMVER.md`) and broke parity with the already-merged mirror fix. It now returns `-1.0` on
failure instead of the original `0.0`. The range-check-divergence finding (this PR's real
contribution) is unchanged: `arcLength(from:to:)` still keeps its own bridge call rather than
delegating to `length(from:to:)`, since the two use genuinely different adaptor constructions
(range-checked vs. unrestricted) and delegating would silently drop the order validation. Updated
the new test suite and `docs/reference/Curve2D-Analysis.md` to match; reverted the happy-path test
in `Tests/OCCTCurveTests` to its original (pre-PR) form since the signature no longer changed.
Rebased onto the current `refactor/377-segmented-audit` (picks up #461) so the diff is directly
comparable. `swift test --filter OCCTGeom2dTests` (398 tests) and `swift test --filter
OCCTCurveTests` (328 tests) both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
