### PR TITLE
fix(#400): remove Curve3D.interpolate tangent overload that shadowed tolerance

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -17190,7 +17190,9 @@ OCCTShapeRef _Nullable OCCTShapeEmptyCopied(OCCTShapeRef _Nonnull shape);
 
 // --- GeomAPI_Interpolate expansion ---
 
-/// Interpolate 3D BSpline with endpoint tangents.
+/// Interpolate 3D BSpline with endpoint tangents. Forwards to
+/// OCCTCurve3DInterpolateWithTangents with a fixed 1e-6 tolerance; kept for
+/// existing C callers of this exact signature.
 OCCTCurve3DRef _Nullable OCCTInterpolateWithTangents(const double* _Nonnull points, int32_t count,
                                                        double t1x, double t1y, double t1z,
                                                        double t2x, double t2y, double t2z);

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -4552,21 +4552,7 @@ const char* OCCTCurve3DTypeName(OCCTCurve3DRef curve) {
 OCCTCurve3DRef OCCTInterpolateWithTangents(const double* points, int32_t count,
                                              double t1x, double t1y, double t1z,
                                              double t2x, double t2y, double t2z) {
-    if (!points || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt) pts = new TColgp_HArray1OfPnt(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt(points[i*3], points[i*3+1], points[i*3+2]));
-        }
-        GeomAPI_Interpolate interp(pts, Standard_False, 1e-6);
-        gp_Vec v1(t1x, t1y, t1z), v2(t2x, t2y, t2z);
-        interp.Load(v1, v2);
-        interp.Perform();
-        if (interp.IsDone()) {
-            return (OCCTCurve3DRef)new OCCTCurve3D{interp.Curve()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+    return OCCTCurve3DInterpolateWithTangents(points, count, t1x, t1y, t1z, t2x, t2y, t2z, 1e-6);
 }
 
 OCCTCurve3DRef OCCTInterpolateWithAllTangents(const double* points, int32_t count,

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -275,7 +275,24 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Interpolate through points with start/end tangent constraints
+    /// Interpolate a BSpline through points with constrained start/end tangents.
+    ///
+    /// - Parameters:
+    ///   - points: Points the curve must pass through (minimum 2).
+    ///   - startTangent: Tangent vector at the first point.
+    ///   - endTangent: Tangent vector at the last point.
+    ///   - tolerance: Interpolation precision; also the minimum allowed distance between
+    ///     consecutive points. Defaults to `1e-6` and is honored on every call, including
+    ///     the bare 3-argument form.
+    /// - Returns: Interpolated BSpline curve, or `nil` on failure.
+    ///
+    /// ```swift
+    /// let pts: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(5, 5, 5), SIMD3(10, 0, 0)]
+    /// let curve = Curve3D.interpolate(points: pts,
+    ///                                 startTangent: SIMD3(1, 1, 1),
+    ///                                 endTangent: SIMD3(1, -1, -1),
+    ///                                 tolerance: 1e-9)
+    /// ```
     public static func interpolate(points: [SIMD3<Double>],
                                    startTangent: SIMD3<Double>,
                                    endTangent: SIMD3<Double>,
@@ -1574,20 +1591,6 @@ extension Curve3D {
     public var lineProperties: LineProperties { LineProperties(handle: handle) }
 
     // MARK: - v0.115.0: Interpolation expansion, length, closest point
-
-    /// Interpolate a 3D BSpline through points with endpoint tangents.
-    public static func interpolate(points: [SIMD3<Double>],
-                                   startTangent: SIMD3<Double>,
-                                   endTangent: SIMD3<Double>) -> Curve3D? {
-        var flat = [Double]()
-        for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
-        guard let ref = flat.withUnsafeBufferPointer({ buf in
-            OCCTInterpolateWithTangents(buf.baseAddress!, Int32(points.count),
-                                        startTangent.x, startTangent.y, startTangent.z,
-                                        endTangent.x, endTangent.y, endTangent.z)
-        }) else { return nil }
-        return Curve3D(handle: ref)
-    }
 
     /// Interpolate a 3D BSpline with per-point tangent constraints.
     public static func interpolate(points: [SIMD3<Double>],

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -4100,3 +4100,56 @@ struct Curve3DConicFactoryParityTests {
         }
     }
 }
+
+/// `interpolate(points:startTangent:endTangent:)` used to be shadowed by a second, later-added
+/// overload of the same name that lacked a `tolerance` parameter entirely: Swift's overload
+/// resolution always prefers the exact-arity match, so the ordinary 3-argument call could never
+/// reach `interpolate(points:startTangent:endTangent:tolerance:)`'s `tolerance` knob. The
+/// duplicate overload (and its separate bridge implementation) is gone; there is now exactly one
+/// `interpolate(points:startTangent:endTangent:...)`, so the bare 3-argument call and an explicit
+/// `tolerance:` argument reach the same code path.
+@Suite("Curve3D.interpolate tangent-tolerance reachability (#400)")
+struct Curve3DInterpolateTangentToleranceParityTests {
+
+    private static let points: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(5, 5, 5), SIMD3(10, 0, 0)]
+    private static let startTangent = SIMD3<Double>(1, 1, 1)
+    private static let endTangent = SIMD3<Double>(1, -1, -1)
+
+    @Test("Bare 3-arg call matches an explicit default-tolerance call exactly")
+    func bareCallMatchesExplicitDefaultTolerance() {
+        let bare = Curve3D.interpolate(points: Self.points,
+                                       startTangent: Self.startTangent,
+                                       endTangent: Self.endTangent)
+        let explicitDefault = Curve3D.interpolate(points: Self.points,
+                                                   startTangent: Self.startTangent,
+                                                   endTangent: Self.endTangent,
+                                                   tolerance: 1e-6)
+        #expect(bare != nil)
+        #expect(explicitDefault != nil)
+        if let a = bare, let b = explicitDefault {
+            #expect(a.domain.lowerBound == b.domain.lowerBound)
+            #expect(a.domain.upperBound == b.domain.upperBound)
+            for t in stride(from: a.domain.lowerBound, through: a.domain.upperBound,
+                            by: (a.domain.upperBound - a.domain.lowerBound) / 8) {
+                #expect(simd_distance(a.point(at: t), b.point(at: t)) < 1e-12)
+            }
+        }
+    }
+
+    @Test("tolerance: is reachable and actually governs the minimum inter-point distance")
+    func toleranceParameterIsReachableAndEffective() {
+        // Two points 5e-7 apart: farther than 1e-9, but not farther than the 1e-6 default.
+        let closePoints: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(0, 0, 5e-7), SIMD3(10, 0, 0)]
+        let tan = SIMD3<Double>(1, 0, 0)
+
+        // Default tolerance (bare call): the two near-coincident points are too close, so
+        // GeomAPI_Interpolate's construction rejects them.
+        let bareDefault = Curve3D.interpolate(points: closePoints, startTangent: tan, endTangent: tan)
+        #expect(bareDefault == nil)
+
+        // A tighter explicit tolerance accepts the exact same points.
+        let tighter = Curve3D.interpolate(points: closePoints, startTangent: tan, endTangent: tan,
+                                          tolerance: 1e-9)
+        #expect(tighter != nil)
+    }
+}

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -194,33 +194,12 @@ public static func hyperbolaThreePoints(
 
 ## Interpolation Expansion, Length, Closest Point (v0.115.0)
 
-### `Curve3D.interpolate(points:startTangent:endTangent:)`
+### `Curve3D.interpolate(points:startTangent:endTangent:tolerance:)`
 
-Interpolates a BSpline through points with constrained endpoint tangents.
-
-```swift
-public static func interpolate(
-    points: [SIMD3<Double>],
-    startTangent: SIMD3<Double>,
-    endTangent: SIMD3<Double>
-) -> Curve3D?
-```
-
-Like `interpolate(points:closed:tolerance:)` but pins the tangent direction at the first and last interpolation points. Useful when the approach and departure directions are known (e.g. G1 join to adjacent geometry).
-
-- **Parameters:** `points` — interpolation points (minimum 2); `startTangent` — tangent at the first point; `endTangent` — tangent at the last point.
-- **Returns:** Interpolated BSpline, or `nil` on failure.
-- **OCCT:** `GeomAPI_Interpolate::Load(startTangent, endTangent)` + `Perform()`.
-- **Example:**
-  ```swift
-  if let curve = Curve3D.interpolate(
-      points: [SIMD3(0, 0, 0), SIMD3(5, 5, 0), SIMD3(10, 0, 0)],
-      startTangent: SIMD3(1, 0, 0),
-      endTangent: SIMD3(1, 0, 0)
-  ) {
-      let len = curve.totalArcLength
-  }
-  ```
+Interpolates a BSpline through points with constrained endpoint tangents. Fully documented on the
+main [Curve3D](Curve3D.md#curve3dinterpolatepointsstarttangentendtangenttolerance) page under
+"BSpline & Bezier", alongside the sibling `interpolate(points:closed:tolerance:)` — see that entry
+for the signature, parameters, OCCT mapping, and an example.
 
 ---
 


### PR DESCRIPTION
## What & why

`Curve3D.interpolate(points:startTangent:endTangent:tolerance:)` (tolerance defaulting to
`1e-6`, threaded through to `GeomAPI_Interpolate`) sat alongside a same-named, later-added
`interpolate(points:startTangent:endTangent:)` overload with no `tolerance` parameter at all.
Swift's overload resolution always prefers the exact-arity match, so the ordinary 3-argument
call site could never reach the tolerance-aware overload — the parameter was reachable only
by writing `tolerance:` at every call site, which no test in the repo did.

There is now exactly one `interpolate(points:startTangent:endTangent:...)` overload (tolerance
defaulting to `1e-6`, unchanged). The bridge's `OCCTInterpolateWithTangents` (the C function the
removed duplicate called) now forwards to `OCCTCurve3DInterpolateWithTangents` with `1e-6` instead
of reimplementing the same `GeomAPI_Interpolate`/`Load`/`Perform` sequence, so there is one real
implementation and existing direct callers of that exact C signature keep working.

Refs #400. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve3DInterpolateTangentToleranceParityTests` (`Tests/OCCTCurveTests`): the bare
3-argument call now matches an explicit `tolerance: 1e-6` call exactly (sampled across the curve
domain), and an explicit tighter `tolerance:` value measurably changes the outcome (accepts two
points 5e-7 apart that the 1e-6 default rejects with `Standard_ConstructionError`). Before this PR,
no test anywhere passed `tolerance:` to this overload at all — the 4th parameter was dead code from
the test suite's own perspective.

## Notes for the reviewer

**The two implementations were already numerically identical**, which the issue itself called out
("no numeric divergence exists yet ... an accident of both authors independently picking OCCT's own
common default"). I confirmed this empirically rather than assuming it: I reverted the source
changes (keeping only the new test), rebuilt, and ran the new suite against the pre-fix code —
**both tests still passed**. This is expected and consistent with the issue's framing: unlike
#412/#427's `Curve2D.interpolatePeriodic` (which had a genuinely different point-count floor, a
live behavioral bug), #400 was pure duplication with no observable divergence today — the risk was
entirely about future drift (any change to either literal/default would silently split behavior
between two same-named overloads) and about the parameter being unreachable via the natural call
in spirit, not literally uncallable. The regression tests lock in parity and prove the tolerance
knob is genuinely honored and reachable through the single remaining overload; they just can't
"fail-then-pass" the way a true behavioral fix's tests would, because there was no live behavioral
bug to flip.

**Why delete rather than add `tolerance:` to the newer overload**, as the issue's own suggested
direction floated: the two overloads share the exact same base name and parameter labels
(`points:startTangent:endTangent:`), so adding a defaulted `tolerance:` to the parameter-less one
would make its full signature byte-for-byte identical to the existing overload — an invalid
redeclaration, not something Swift allows regardless of differing bodies. Consolidating to one
overload was the only viable fix; I kept the older, already-documented one (`docs/reference/
Curve3D.md` already described only the tolerance-aware signature, matching the sibling
`interpolate(points:closed:tolerance:)` pattern the issue pointed to) and removed the newer
duplicate.

Full `swift test` (4514 tests, 1301 suites) clean. Focused `OCCTCurveTests` (320 tests) and
`OCCTMiscTests` (51 tests, includes the pre-existing `interpolateWithEndpointTangents` call site)
also clean.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and parallel child PRs each editing the same changelog header would conflict on every one.
