### PR TITLE
fix(#406): align Surface.approximated defaults with Curve3D/Curve2D

### DIFF
--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -579,6 +579,12 @@ public final class Curve2D: @unchecked Sendable {
     ///   - continuity: Desired continuity (0=C0, 1=C1, 2=C2, 3=C3)
     ///   - maxSegments: Maximum number of B-spline segments
     ///   - maxDegree: Maximum polynomial degree
+    ///
+    /// Defaults (`tolerance: 1e-3`, `maxDegree: 8`) are shared with `Curve3D.approximated` and
+    /// `Surface.approximated` (#406) — all three wrap the same `GeomConvert_Approx*`/
+    /// `Geom2dConvert_ApproxCurve` family applied to a different OCCT geometry hierarchy, not
+    /// independent algorithms that would justify independently-tuned numeric defaults.
+    ///
     /// - Returns: Approximated BSpline curve, or `nil` on failure
     ///
     /// ```swift

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -445,7 +445,12 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Approximate the curve with a BSpline of specified continuity
+    /// Approximate the curve with a BSpline of specified continuity.
+    ///
+    /// Defaults (`tolerance: 1e-3`, `maxDegree: 8`) are shared with `Curve2D.approximated` and
+    /// `Surface.approximated` (#406) — all three wrap the same `GeomConvert_Approx*`/
+    /// `Geom2dConvert_ApproxCurve` family applied to a different OCCT geometry hierarchy, not
+    /// independent algorithms that would justify independently-tuned numeric defaults.
     public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
                              maxSegments: Int = 100, maxDegree: Int = 8) -> Curve3D? {
         guard let h = OCCTCurve3DApproximate(handle, tolerance, Int32(continuity),

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -419,9 +419,31 @@ public final class Surface: @unchecked Sendable {
         return Surface(handle: h)
     }
 
-    /// Approximate as a BSpline surface within tolerance
-    public func approximated(tolerance: Double = 0.01, continuity: Int = 2,
-                             maxSegments: Int = 100, maxDegree: Int = 10) -> Surface? {
+    /// Approximate as a BSpline surface within tolerance.
+    ///
+    /// - Parameters:
+    ///   - tolerance: Maximum approximation error
+    ///   - continuity: Desired continuity (0=C0, 1=C1, 2=C2, 3=C3)
+    ///   - maxSegments: Maximum number of B-spline segments
+    ///   - maxDegree: Maximum polynomial degree
+    ///
+    /// Defaults (`tolerance: 1e-3`, `maxDegree: 8`) match `Curve3D.approximated`/
+    /// `Curve2D.approximated` (#406): all three wrap the same `GeomConvert_Approx*`/
+    /// `Geom2dConvert_ApproxCurve` family applied to a different OCCT geometry hierarchy
+    /// (surface vs. 3D curve vs. 2D curve), not independent algorithms whose numeric defaults
+    /// should be tuned independently. Measured directly (analytic primitives — sphere, torus,
+    /// trimmed cylinder/cone — and a 40x40-point BSpline fit): the tighter tolerance and lower
+    /// degree succeed on every case tried, with no meaningful cost difference, so there was no
+    /// dimensional justification for the looser values this used to default to. An
+    /// infinite/unbounded surface must still be trimmed to a finite parameter domain before
+    /// calling this (see `trimmed(u1:u2:v1:v2:)`) — approximation does not do that for you.
+    ///
+    /// ```swift
+    /// let sphere = Surface.sphere(center: .zero, radius: 5)!
+    /// let bsp = sphere.approximated(tolerance: 1e-3, maxDegree: 8)
+    /// ```
+    public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
+                             maxSegments: Int = 100, maxDegree: Int = 8) -> Surface? {
         guard let h = OCCTSurfaceApproximate(handle, tolerance, Int32(continuity),
                                               Int32(maxSegments), Int32(maxDegree))
         else { return nil }

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -5646,4 +5646,78 @@ struct SurfaceApproximateDefaultsParityTests {
             #expect(cone.approximated() != nil)
         }
     }
+
+    /// Review follow-up on #406/PR #460: the suite above only exercises primitives (sphere,
+    /// torus, trimmed cylinder/cone) that have an *exact* BSpline conversion — easy cases for
+    /// `GeomConvert_ApproxSurface`. This test targets a genuinely non-analytic surface instead:
+    /// the offset of a free-form (point-grid-fit) BSpline surface, which has no closed-form
+    /// equivalent.
+    ///
+    /// Verified directly against the OCCT source before writing this (do not trust "offset
+    /// surfaces are hard" as a assumption): `Geom_OffsetSurface::Surface()` only computes an
+    /// exact equivalent for Plane/Cylindrical/Conical/Spherical/Toroidal bases
+    /// (`Geom_OffsetSurface.cxx:867-990`) — for those, `toBSpline()` succeeds exactly, so
+    /// offsetting a *primitive* (e.g. `sphere.offset(distance:)`) is actually still an easy case,
+    /// not a hard one, despite the doc comment's example suggesting otherwise. For an offset of a
+    /// BSpline base (this test), `Geom_OffsetSurface::Surface()` returns null, and
+    /// `GeomConvert::SurfaceToBSplineSurface` falls through to its own internal fallback — a
+    /// `GeomConvert_ApproxSurface` with hardcoded `Tol3d: 1e-4, MaxDegree: 14`
+    /// (`GeomConvert_1.cxx:934-961`) — so `toBSpline()` does *not* return `nil` here either; OCCT
+    /// silently approximates it for you, just with different, fixed parameters we don't control.
+    /// "Does `toBSpline()` return `nil`" therefore isn't a reliable signal of hardness for a
+    /// *bounded* composite surface in this OCCT version — what makes this surface genuinely
+    /// non-analytic is structural (no elementary-surface equivalent exists for its basis), not
+    /// that `toBSpline()` fails outright.
+    @Test("Non-analytic surface (offset of a BSpline base) still approximates at the new default")
+    func nonAnalyticOffsetSurfaceApproximates() {
+        var gridPoints: [SIMD3<Double>] = []
+        let uCount = 8, vCount = 8
+        for i in 0..<uCount {
+            for j in 0..<vCount {
+                let u = Double(i) / Double(uCount - 1) * 10.0
+                let v = Double(j) / Double(vCount - 1) * 10.0
+                let z = sin(u * 0.7) * cos(v * 0.7) * 1.5
+                gridPoints.append(SIMD3(u, v, z))
+            }
+        }
+        guard let base = Surface.fromPointGrid(points: gridPoints, uCount: uCount, vCount: vCount)
+        else {
+            Issue.record("fromPointGrid failed to build the base surface")
+            return
+        }
+        #expect(base.isBSpline)
+
+        guard let offsetSurface = base.offset(distance: 0.3) else {
+            Issue.record("offset(distance:) failed on the BSpline base")
+            return
+        }
+        #expect(offsetSurface.isOffsetSurface)
+
+        // The empirical claim from PR #460: the new tighter default (tolerance: 1e-3,
+        // maxDegree: 8) still succeeds here, not just on the easy analytic primitives above.
+        let approx = offsetSurface.approximated()
+        #expect(approx != nil)
+        if let approx = approx {
+            #expect(approx.uDegree <= 8)
+            #expect(approx.vDegree <= 8)
+
+            // Loose fidelity sanity check (not a tight tolerance bound: GeomConvert_ApproxSurface's
+            // HasResult() — what the bridge checks — is documented as true even when the result is
+            // "not NECESSARILY within the required tolerance", so asserting a bound near 1e-3 itself
+            // would assert something OCCT's own contract doesn't promise). This only needs to catch
+            // a gross regression (e.g. silently returning the un-offset base surface instead).
+            let domain = approx.domain
+            var maxDeviation = 0.0
+            for i in 0...4 {
+                for j in 0...4 {
+                    let u = domain.uMin + (domain.uMax - domain.uMin) * Double(i) / 4
+                    let v = domain.vMin + (domain.vMax - domain.vMin) * Double(j) / 4
+                    let approxPoint = approx.point(atU: u, v: v)
+                    let truePoint = offsetSurface.point(atU: u, v: v)
+                    maxDeviation = max(maxDeviation, simd_length(approxPoint - truePoint))
+                }
+            }
+            #expect(maxDeviation < 0.5)
+        }
+    }
 }

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -5591,3 +5591,59 @@ struct SurfaceCurvatureParityTests {
         }
     }
 }
+
+// MARK: - #406: Surface.approximated defaults now match Curve3D/Curve2D.approximated
+
+/// Before #406, `Surface.approximated`'s defaults (`tolerance: 0.01`, `maxDegree: 10`) silently
+/// diverged from `Curve3D.approximated`/`Curve2D.approximated` (`tolerance: 1e-3`, `maxDegree: 8`)
+/// with no documented rationale. Manual measurement against analytic primitives and a 40x40-point
+/// BSpline fit found no case where the tighter shared values fail or cost meaningfully more, so
+/// the divergence was drift rather than a deliberate accuracy/cost tradeoff — `Surface.approximated`
+/// now shares the same defaults.
+@Suite("Surface.approximated defaults match Curve3D/Curve2D (#406)")
+struct SurfaceApproximateDefaultsParityTests {
+
+    @Test("Default call succeeds and respects the shared maxDegree cap")
+    func defaultCallRespectsSharedMaxDegree() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        // No explicit tolerance/maxDegree: exercises the *default* values directly.
+        let approx = sphere.approximated()
+        #expect(approx != nil)
+        if let approx = approx {
+            #expect(approx.uDegree <= 8)
+            #expect(approx.vDegree <= 8)
+        }
+    }
+
+    @Test("Default call is equivalent to an explicit tolerance: 1e-3, maxDegree: 8 call")
+    func defaultCallMatchesExplicitSharedValues() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        let byDefault = sphere.approximated()
+        let explicit = sphere.approximated(tolerance: 1e-3, maxDegree: 8)
+        #expect(byDefault != nil)
+        #expect(explicit != nil)
+        if let a = byDefault, let b = explicit {
+            #expect(a.uDegree == b.uDegree)
+            #expect(a.vDegree == b.vDegree)
+        }
+    }
+
+    @Test("Tighter shared defaults still succeed on every primitive the old looser defaults handled")
+    func tighterDefaultsSucceedOnCommonSurfaces() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        #expect(sphere.approximated() != nil)
+
+        if let torus = Surface.torus(origin: .zero, axis: SIMD3(0, 0, 1),
+                                      majorRadius: 10, minorRadius: 3) {
+            #expect(torus.approximated() != nil)
+        }
+        if let cylinder = Surface.trimmedCylinder(origin: .zero, direction: SIMD3(0, 0, 1),
+                                                    radius: 5, height: 20) {
+            #expect(cylinder.approximated() != nil)
+        }
+        if let cone = Surface.trimmedCone(point1: SIMD3(0, 0, 0), point2: SIMD3(0, 0, 10),
+                                           r1: 5, r2: 2) {
+            #expect(cone.approximated() != nil)
+        }
+    }
+}

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -927,6 +927,10 @@ public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
 - **Parameters:** `tolerance` — maximum approximation error, applied over the whole curve; `continuity` — desired continuity order; `maxSegments` — maximum number of BSpline segments; `maxDegree` — maximum polynomial degree.
 - **Returns:** Approximated BSpline, or `nil` on failure.
 - **OCCT:** `Geom2dConvert_ApproxCurve` (via `OCCTCurve2DApproximate`).
+- **Note:** Defaults are shared with `Curve3D.approximated` and `Surface.approximated` (#406) —
+  all three wrap the same `GeomConvert_Approx*`/`Geom2dConvert_ApproxCurve` family applied to a
+  different OCCT geometry hierarchy, not independent algorithms that would justify
+  independently-tuned numeric defaults.
 - **Example:**
   ```swift
   let circle = Curve2D.circle(center: .zero, radius: 5)!

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -827,6 +827,10 @@ Useful for converting an analytical curve to a polynomial BSpline with controlle
 - **Parameters:** `tolerance` — approximation error; `continuity` — minimum continuity order; `maxSegments` — maximum number of BSpline spans; `maxDegree` — maximum polynomial degree.
 - **Returns:** Approximating BSpline, or `nil` on failure.
 - **OCCT:** `GeomConvert_ApproxCurve(curve, tolerance, continuity, maxSegments, maxDegree)`.
+- **Note:** Defaults are shared with `Curve2D.approximated` and `Surface.approximated` (#406) —
+  all three wrap the same `GeomConvert_Approx*`/`Geom2dConvert_ApproxCurve` family applied to a
+  different OCCT geometry hierarchy, not independent algorithms that would justify
+  independently-tuned numeric defaults.
 - **Example:**
   ```swift
   let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)!

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -673,8 +673,8 @@ Uses OCCT's exact conversion for analytic surfaces. Infinite surfaces must be tr
 Approximates this surface as a BSpline surface within a tolerance.
 
 ```swift
-public func approximated(tolerance: Double = 0.01, continuity: Int = 2,
-                          maxSegments: Int = 100, maxDegree: Int = 10) -> Surface?
+public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
+                          maxSegments: Int = 100, maxDegree: Int = 8) -> Surface?
 ```
 
 Useful when exact `toBSpline()` conversion is unavailable (e.g. offset or composite surfaces).
@@ -686,6 +686,12 @@ Useful when exact `toBSpline()` conversion is unavailable (e.g. offset or compos
   - `maxDegree` — maximum polynomial degree.
 - **Returns:** Approximated BSpline surface, or `nil` on failure.
 - **OCCT:** `GeomConvert_ApproxSurface`.
+- **Note:** Defaults match `Curve3D.approximated`/`Curve2D.approximated` (#406) — all three wrap
+  the same `GeomConvert_Approx*`/`Geom2dConvert_ApproxCurve` family applied to a different OCCT
+  geometry hierarchy, not independent algorithms whose numeric defaults should diverge. (Before
+  #406 this defaulted to `tolerance: 0.01, maxDegree: 10`, a 10x looser tolerance with no
+  documented reason; measurement found the tighter shared values succeed on every case tried,
+  with no meaningful cost difference.)
 - **Example:**
   ```swift
   let offset = sphere.offset(distance: 1)!


### PR DESCRIPTION
## What & why

`Surface.approximated(tolerance:continuity:maxSegments:maxDegree:)` defaulted to
`tolerance: 0.01, maxDegree: 10` while the otherwise-identical `Curve3D.approximated`/
`Curve2D.approximated` (same parameter shape, same bridge-call pattern) both default to
`tolerance: 1e-3, maxDegree: 8` — a 10x looser tolerance and a 2-degree-lower cap, with nothing in
the source, docs, or history explaining why the surface case would need to be different.

**Conclusion: the divergence was unjustified drift, not a deliberate accuracy/cost tradeoff.**
All three bridge functions (`OCCTSurfaceApproximate`, `OCCTCurve3DApproximate`,
`OCCTCurve2DApproximate`) are structurally identical — same continuity-enum switch, same
try/catch, same `HasResult()`/`IsDone()` gate — just calling `GeomConvert_ApproxSurface` vs.
`GeomConvert_ApproxCurve` vs. `Geom2dConvert_ApproxCurve`. Neither OCCT constructor has its own
default argument that would explain a difference; the Swift-side defaults are this wrapper's own
choice. I measured the tighter shared values directly against a sphere, torus, trimmed
cylinder/cone, and a 40x40-point BSpline fit (including a stress case at 40x40 with higher-frequency
noise): every case succeeded, with no meaningful performance difference (often marginally faster).
So `Surface.approximated` now shares `Curve3D`/`Curve2D`'s defaults, and all three doc comments
cross-reference each other and state this rationale explicitly, closing the "no documented
rationale" gap either way.

Refs #406. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `SurfaceApproximateDefaultsParityTests` (`Tests/OCCTSurfaceTests`): the *default* call
(no explicit `tolerance`/`maxDegree`) now behaves identically to an explicit
`tolerance: 1e-3, maxDegree: 8` call, respects the shared `maxDegree` cap, and still succeeds on
every primitive type the old looser defaults handled (sphere, torus, trimmed cylinder, trimmed
cone). Before this PR no test exercised `Surface.approximated()`'s bare defaults at all — every
existing call site passed an explicit `tolerance`.

## Notes for the reviewer

**Verification that the divergence was live and unforced:** reverting only `Surface.swift`'s
default values (keeping everything else) makes `sphere.approximated()` produce degree
`(10, 8)`/tolerance `0.01` instead of `(8, 8)`/`1e-3` — confirmed via a throwaway experiment in
`Sources/OCCTTest/main.swift` (not part of this diff) that ran both default sets against a sphere,
torus, trimmed cylinder, trimmed cone, and two BSpline point-grid fits (20x20 and a
higher-frequency 40x40). Every case succeeded under the tighter tolerance/lower degree, and timing
was equivalent or better in every case — the strongest evidence that "surface fitting is a harder
problem, so it needs looser defaults" doesn't hold up empirically for this bridge.

**Also updated:** `docs/reference/Surface.md`'s `approximated` section (defaults + a `Note` on the
shared rationale, since it previously reproduced the diverged `0.01`/`10` signature verbatim), and
matching `Note` additions to `docs/reference/Curve3D.md`/`docs/reference/Curve2D.md` (no default
change there, just closing the same documented-rationale gap the issue called out for all three
pages).

**Out of scope, left alone:** `docs/reference/Curve2D.md` already (pre-existing, unrelated)
mislabels the OCCT class as `Approx_Curve2d` when the bridge actually calls
`Geom2dConvert_ApproxCurve` — the issue itself flagged this as a separate, minor mismatch not
worth fixing here.

**Conflict note:** #407 (a separate parallel PR, different concern — the large tolerance gap
between `Curve2D`'s *two* `approximated` overloads, not this cross-type default drift) also edits
`Curve2D.swift`, near but not overlapping the lines this PR touches (the
`approximated(tolerance:continuity:maxSegments:maxDegree:)` overload only — the other overload at
`Curve2D.swift:~1148`, `approximated(first:last:toleranceU:toleranceV:maxDegree:maxSegments:)`, is
untouched here). Expect the two PRs to land close to each other in the same file; will need
rebasing/merge-order coordination by the reviewer.

Full `swift test` (4515 tests): 4514 passed, 1 known pre-existing flake
(`Shape.loadRobust interrupts repair, not just the transfer (#300)`, a CPU-timing-sensitive
cancellation test already called out as a flake unrelated to this change) — reran the focused
`OCCTSurfaceTests`/`OCCTCurveTests`/`OCCTGeom2dTests` suites clean on their own.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and parallel child PRs each editing the same changelog header would conflict on every one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)