### PR TITLE
fix(#408): unify Curve3D arc-length failure contract behind length/length(from:to:)

### DIFF
--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -399,13 +399,25 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Arc length of the full curve
+    /// Arc length of the full curve.
+    ///
+    /// This is the canonical, failure-distinguishing entry point: returns `nil` if the curve
+    /// is invalid or the underlying computation fails, rather than collapsing failure into a
+    /// numeric result. `totalArcLength` delegates to this and collapses failure back to `-1.0`
+    /// for source compatibility — prefer this property when you need to tell "failed" apart
+    /// from "genuinely zero".
     public var length: Double? {
         let l = OCCTCurve3DGetLength(handle)
         return l >= 0 ? l : nil
     }
 
-    /// Arc length between two parameters
+    /// Arc length between two parameters.
+    ///
+    /// This is the canonical, failure-distinguishing entry point: returns `nil` if the curve
+    /// is invalid or the underlying computation fails, rather than collapsing failure into a
+    /// numeric result. `arcLength(from:to:)` and `arcLengthBetween(_:_:)` both delegate to this
+    /// and collapse failure back to `-1.0` for source compatibility — prefer this method when
+    /// you need to tell "failed" apart from a genuine zero-length interval (e.g. `u1 == u2`).
     public func length(from u1: Double, to u2: Double) -> Double? {
         let l = OCCTCurve3DGetLengthBetween(handle, u1, u2)
         return l >= 0 ? l : nil
@@ -1681,8 +1693,14 @@ extension Curve3D {
     }
 
     /// Compute the arc length of this curve between parameters u1 and u2 (non-optional).
+    ///
+    /// Delegates to `length(from:to:)`, the failure-distinguishing entry point. Returns `-1.0`
+    /// if the underlying computation fails — arc length is otherwise always non-negative, so
+    /// this is an unambiguous failure sentinel, never confusable with a genuine zero-length
+    /// result (e.g. `u1 == u2`). Use `length(from:to:)` directly if you need an optional
+    /// rather than a sentinel value.
     public func arcLength(from u1: Double, to u2: Double) -> Double {
-        OCCTCurve3DLength(handle, u1, u2)
+        length(from: u1, to: u2) ?? -1.0
     }
 
     /// Find the parameter at a given arc length distance from a starting parameter.
@@ -1698,13 +1716,24 @@ extension Curve3D {
     }
 
     /// Total arc length of the curve within its domain.
+    ///
+    /// Delegates to `length`, the failure-distinguishing entry point. Returns `-1.0` if the
+    /// underlying computation fails — arc length is otherwise always non-negative, so this is
+    /// an unambiguous failure sentinel, never confusable with a genuine zero-length curve. Use
+    /// `length` directly if you need an optional rather than a sentinel value.
     public var totalArcLength: Double {
-        OCCTCurve3DArcLength(handle)
+        length ?? -1.0
     }
 
     /// Arc length between two parameters.
+    ///
+    /// Delegates to `length(from:to:)`, the failure-distinguishing entry point. Returns `-1.0`
+    /// if the underlying computation fails — arc length is otherwise always non-negative, so
+    /// this is an unambiguous failure sentinel, never confusable with a genuine zero-length
+    /// interval (e.g. `param1 == param2`). Use `length(from:to:)` directly if you need an
+    /// optional rather than a sentinel value.
     public func arcLengthBetween(_ param1: Double, _ param2: Double) -> Double {
-        OCCTCurve3DArcLengthBetween(handle, param1, param2)
+        length(from: param1, to: param2) ?? -1.0
     }
 
     /// Find the parameter of the closest point on this curve to a given point.

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -4153,3 +4153,68 @@ struct Curve3DInterpolateTangentToleranceParityTests {
         #expect(tighter != nil)
     }
 }
+
+@Suite("Curve3D arc-length failure vs. zero-length distinguishability (#408)")
+struct Curve3DArcLengthFailureParityTests {
+
+    @Test("A genuine zero-width interval reports exactly 0.0, not a failure sentinel")
+    func genuineZeroLengthIsZero() {
+        let line = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
+        if let line {
+            let d = line.domain
+            let mid = (d.lowerBound + d.upperBound) / 2
+            #expect(line.arcLength(from: mid, to: mid) == 0.0)
+            #expect(line.arcLengthBetween(mid, mid) == 0.0)
+            #expect(line.totalArcLength >= 0.0)
+            if let l = line.length(from: mid, to: mid) {
+                #expect(l == 0.0)
+            }
+        }
+    }
+
+    @Test("A genuinely failing computation is distinguishable from a real zero-length result")
+    func genuineFailureIsDistinguishableFromZero() {
+        let line = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
+        if let line {
+            let d = line.domain
+
+            // `length(from:to:)` is the canonical, failure-distinguishing entry point: a NaN
+            // bound makes the underlying OCCT abscissa computation produce NaN, which fails the
+            // `l >= 0` guard and reports nil -- a genuine computation failure, not a valid
+            // (let alone zero) length.
+            let canonical = line.length(from: d.lowerBound, to: .nan)
+            #expect(canonical == nil)
+
+            // The non-optional convenience accessors must collapse that same failure to an
+            // unambiguous sentinel (-1.0) rather than to 0.0, which would be indistinguishable
+            // from the genuine zero-length interval covered by genuineZeroLengthIsZero() above.
+            let arcLen = line.arcLength(from: d.lowerBound, to: .nan)
+            let arcLenBetween = line.arcLengthBetween(d.lowerBound, .nan)
+            #expect(arcLen == -1.0)
+            #expect(arcLenBetween == -1.0)
+            #expect(arcLen != 0.0)
+            #expect(arcLenBetween != 0.0)
+        }
+    }
+
+    @Test("totalArcLength and length agree on a valid curve (single source of truth)")
+    func totalArcLengthMatchesLength() {
+        let line = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
+        if let line, let expected = line.length {
+            #expect(line.totalArcLength == expected)
+        }
+    }
+
+    @Test("arcLength(from:to:) and length(from:to:) agree on a valid curve")
+    func arcLengthMatchesLengthBetween() {
+        let line = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
+        if let line {
+            let d = line.domain
+            let quarter = d.lowerBound + (d.upperBound - d.lowerBound) / 4
+            if let expected = line.length(from: d.lowerBound, to: quarter) {
+                #expect(line.arcLength(from: d.lowerBound, to: quarter) == expected)
+                #expect(line.arcLengthBetween(d.lowerBound, quarter) == expected)
+            }
+        }
+    }
+}

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -355,11 +355,14 @@ The arc length of this curve between two parameter values.
 public func arcLength(from u1: Double, to u2: Double) -> Double
 ```
 
-Non-optional; returns `0` if the curve is invalid or an exception occurs internally.
+Non-optional; delegates to `length(from:to:)` (the failure-distinguishing entry point on the
+main page) and returns `-1.0` if the curve is invalid or the computation fails. Arc length is
+otherwise always non-negative, so `-1.0` is unambiguous and never collides with a genuine
+zero-length result (e.g. `u1 == u2`). Use `length(from:to:)` directly if you need an optional.
 
 - **Parameters:** `u1` — start parameter; `u2` — end parameter (must satisfy `u1 ≤ u2`).
-- **Returns:** Arc length in model units.
-- **OCCT:** `GCPnts_AbscissaPoint::Length(GeomAdaptor_Curve(curve, u1, u2))`.
+- **Returns:** Arc length in model units, or `-1.0` on failure.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(GeomAdaptor_Curve(curve, u1, u2))` (via `length(from:to:)`).
 - **Example:**
   ```swift
   if let curve = Curve3D.interpolate(
@@ -405,10 +408,13 @@ The total arc length of the curve over its full domain.
 public var totalArcLength: Double { get }
 ```
 
-Integrates the curve from `domain.lowerBound` to `domain.upperBound`. Distinct from the `length` property on the main page (which returns `Double?`); this always returns a `Double` (0 on failure).
+Delegates to `length` (the failure-distinguishing entry point on the main page) and returns
+`-1.0` if the curve is invalid or the computation fails, rather than `Double?`. Arc length is
+otherwise always non-negative, so `-1.0` is unambiguous and never collides with a genuine
+zero-length curve. Use `length` directly if you need an optional.
 
-- **Returns:** Total arc length in model units.
-- **OCCT:** `GCPnts_AbscissaPoint::Length(GeomAdaptor_Curve(curve))`.
+- **Returns:** Total arc length in model units, or `-1.0` on failure.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(GeomAdaptor_Curve(curve))` (via `length`).
 - **Example:**
   ```swift
   let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 10)!
@@ -426,11 +432,13 @@ The arc length between two parameter values.
 public func arcLengthBetween(_ param1: Double, _ param2: Double) -> Double
 ```
 
-Like `arcLength(from:to:)` but with unlabelled parameters. Returns `0` on failure.
+Like `arcLength(from:to:)` but with unlabelled parameters. Delegates to `length(from:to:)` and
+returns `-1.0` on failure, never `0.0` (which would collide with a genuine zero-length interval,
+e.g. `param1 == param2`).
 
 - **Parameters:** `param1` — first parameter; `param2` — second parameter.
-- **Returns:** Arc length between the two parameters.
-- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor, param1, param2)`.
+- **Returns:** Arc length between the two parameters, or `-1.0` on failure.
+- **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor, param1, param2)` (via `length(from:to:)`).
 - **Example:**
   ```swift
   let line = Curve3D.segment(from: SIMD3(0,0,0), to: SIMD3(10,0,0))!

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -710,6 +710,10 @@ The total arc length of the curve over its full domain.
 public var length: Double? { get }
 ```
 
+This is the canonical, failure-distinguishing entry point for the whole-domain arc length:
+`totalArcLength` (see [Curve3D-Construction](Curve3D-Construction.md)) delegates to this and
+collapses `nil` to a `-1.0` sentinel for source compatibility.
+
 - **Returns:** Arc length in model units, or `nil` if measurement fails (e.g. infinite line with unbounded domain).
 - **OCCT:** `GCPnts_AbscissaPoint::Length(adaptor)`.
 - **Example:**
@@ -727,6 +731,11 @@ The arc length between two parameter values.
 ```swift
 public func length(from u1: Double, to u2: Double) -> Double?
 ```
+
+This is the canonical, failure-distinguishing entry point for a bounded-interval arc length:
+`arcLength(from:to:)` and `arcLengthBetween(_:_:)` (see
+[Curve3D-Construction](Curve3D-Construction.md)) both delegate to this and collapse `nil` to a
+`-1.0` sentinel for source compatibility.
 
 - **Parameters:** `u1` — start parameter; `u2` — end parameter.
 - **Returns:** Arc length, or `nil` on failure.


### PR DESCRIPTION
## What & why

`Curve3D` computed the same arc length through two parallel families with a diverging failure
contract. `length`/`length(from:to:)` are optional-returning and already correctly guard
`OCCTCurve3DGetLength`/`GetLengthBetween`'s `-1.0` failure sentinel (`l >= 0 ? l : nil`).
`totalArcLength`, `arcLength(from:to:)`, and `arcLengthBetween(_:_:)` called their own separate
bridge functions (`OCCTCurve3DArcLength`/`OCCTCurve3DLength`/`OCCTCurve3DArcLengthBetween`) and
returned a plain, non-optional `Double`, collapsing "the OCCT computation failed" and "the curve
genuinely has zero length between these parameters" into the identical `0.0` value — a caller
had no way to tell the two apart.

All three now delegate to `length`/`length(from:to:)` — the canonical, failure-distinguishing
entry points — and collapse only the resulting `nil` to an unambiguous `-1.0` sentinel. Arc
length is otherwise always non-negative, so `-1.0` can never collide with a genuine result,
unlike the `0.0` it replaces. This also retires the two duplicate bridge functions from the
Swift call path entirely (they remain declared in `OCCTBridge.h`/implemented in
`OCCTBridge_Curve3D.mm` for C-ABI stability, just unused by Swift now), and incidentally fixes
the same collapse for `NaN` inputs, which previously passed straight through as an uncheckable
`NaN` rather than a comparable sentinel.

Refs #408. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`,
not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification)

New suite `Curve3DArcLengthFailureParityTests` (`Tests/OCCTCurveTests`): a genuine zero-length
interval reports exactly `0.0` on all three accessors; a genuinely failing computation (a `NaN`
parameter, which makes the underlying OCCT abscissa integration produce `NaN`) reports the
`-1.0` sentinel and is asserted `!= 0.0`; and `totalArcLength`/`arcLength(from:to:)` are checked
to agree numerically with `length`/`length(from:to:)` on a normal curve.

## Notes for the reviewer

**Why delegation instead of dropping to `Double?` everywhere.** Converting
`totalArcLength`/`arcLength(from:to:)`/`arcLengthBetween(_:_:)` to optionals would be the
"correct" shape per this repo's own convention (fallible operations return optionals), but it's
a source-breaking signature change to three existing public non-optional methods. Delegating
internally to the already-optional `length`/`length(from:to:)` and re-collapsing to a sentinel
gets the same single source of truth and the same fixed failure contract without breaking any
existing caller — the same trade-off #401's PR (#424) made for `Surface.normal(u:v:)` on this
branch.

**Why `-1.0` and not some other sentinel.** It's already the exact convention `length`/
`length(from:to:)` use for the identical underlying bridge failure (`OCCTCurve3DGetLength`/
`GetLengthBetween` return `-1.0`, decoded via `l >= 0 ? l : nil`). Reusing it rather than
inventing a new one (e.g. `.infinity`, as #413's PR used for `Point2D.distance(to:)`) keeps one
failure convention for this type instead of two.

**A genuine "null curve" failure isn't reachable from the public API.** I looked for a way to
reproduce the issue's literal "null curve or caught exception" collapse through
`Curve3D`'s own factories and confirmed it can't happen: every bridge factory either returns a
live, non-null curve or `nullptr` (translated to Swift `nil` before a `Curve3D` ever exists), so
there's no way to hold a `Curve3D` instance wrapping invalid geometry. I verified this with
ground-truth C++ probes against the OCCT kernel directly (`GeomAdaptor_Curve`/
`CPnts_AbscissaPoint`/`GCPnts_AbscissaPoint` tolerate wildly out-of-domain and even reversed
parameters without throwing, for both analytic and BSpline curves) rather than assume it. The
regression test instead exercises a `NaN` parameter, which reaches the exact same `l >= 0`
guard and demonstrates the identical class of bug (a caller can't distinguish failure from a
real result) through a path that *is* reachable from the public API.

**Verification that the bug was live**: reverted only the `Curve3D.swift` delegation (kept the
new test) and re-ran the new suite — 2 issues, `arcLength(from:to:)`/`arcLengthBetween(_:_:)`
both returned `nan` instead of `-1.0` against a `NaN` input. Reapplied the fix, suite green
again.

**#409 is the mirror fix for `Curve2D`** (same bug class — `Curve2D.arcLength(from:to:)`
collapsing failure into `0.0` — being fixed in parallel by a separate PR against this same
branch). No file overlap between the two, but the design shape (delegate to the existing
optional-returning entry point, collapse to a reused negative sentinel rather than convert to
`Double?`) is intentionally the same so both types read as one consistent pattern once merged.

Also updated `docs/reference/Curve3D-Construction.md` and `docs/reference/Curve3D.md`, which
explicitly documented the old "returns 0 on failure" contract and didn't cross-reference the
canonical accessors.

Full `swift test`: 4516 tests, 1301 suites, all passing (89s), no flakes observed this run.

No `CHANGELOG.md` / version entry here deliberately — the audit branch merges to `main` as one
unit, and parallel child PRs each editing the same changelog header would conflict on every one.
