### PR TITLE
fix(#418): unify BRepGraph's 12 count->buffer->fetch->map accessors

### DIFF
--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -55,6 +55,29 @@ public final class BRepGraph: @unchecked Sendable {
         OCCTBRepGraphRelease(handle)
     }
 
+    // MARK: - Internal Helpers
+
+    /// Shared count-then-fetch helper for the bridge's `...Count`/`...Indices` accessor pairs.
+    ///
+    /// Every adjacency/relation query (`adjacentFaces(of:)`, `sharedEdges(between:and:)`,
+    /// `edgeWires(_:)`, `rootProductIndices`, etc.) allocates an `Int32` buffer sized by a
+    /// prior count call, fills it via a bridge `...Indices` function, then maps back to
+    /// `[Int]`. `fetch` receives the buffer's base address to call the bridge function with.
+    ///
+    /// Guards `count <= 0`, not just `count == 0`: the underlying bridge `...Count` functions
+    /// derive their result via an unchecked narrowing `(int32_t)` cast from a `size_t`, so a
+    /// sufficiently large (theoretical) graph could produce a negative count. Without this
+    /// guard, `[Int32](repeating:count:)` would trap; with it, a negative count degrades to
+    /// `[]` like an empty result.
+    private func fetchIndices(count: Int, fetch: (UnsafeMutablePointer<Int32>) -> Void) -> [Int] {
+        guard count > 0 else { return [] }
+        var indices = [Int32](repeating: 0, count: count)
+        indices.withUnsafeMutableBufferPointer { buf in
+            fetch(buf.baseAddress!)
+        }
+        return indices.map { Int($0) }
+    }
+
     // MARK: - Topology Counts
 
     /// Total number of nodes in the graph (all entity kinds).
@@ -97,23 +120,17 @@ public final class BRepGraph: @unchecked Sendable {
     /// Indices of faces adjacent to a given face (sharing an edge).
     public func adjacentFaces(of faceIndex: Int) -> [Int] {
         let count = Int(OCCTBRepGraphFaceAdjacentCount(handle, Int32(faceIndex)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphFaceAdjacentIndices(handle, Int32(faceIndex), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphFaceAdjacentIndices(handle, Int32(faceIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     /// Indices of edges shared between two faces.
     public func sharedEdges(between faceA: Int, and faceB: Int) -> [Int] {
         let count = Int(OCCTBRepGraphFaceSharedEdgeCount(handle, Int32(faceA), Int32(faceB)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphFaceSharedEdgeIndices(handle, Int32(faceA), Int32(faceB), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphFaceSharedEdgeIndices(handle, Int32(faceA), Int32(faceB), buf)
         }
-        return indices.map { Int($0) }
     }
 
     /// Index of the outer wire of a face.
@@ -130,13 +147,9 @@ public final class BRepGraph: @unchecked Sendable {
 
     /// Indices of faces an edge belongs to.
     public func faces(of edgeIndex: Int) -> [Int] {
-        let count = faceCount(of: edgeIndex)
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphEdgeFaceIndices(handle, Int32(edgeIndex), buf.baseAddress!)
+        fetchIndices(count: faceCount(of: edgeIndex)) { buf in
+            OCCTBRepGraphEdgeFaceIndices(handle, Int32(edgeIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     /// Whether an edge is a boundary edge (belongs to only one face).
@@ -152,12 +165,9 @@ public final class BRepGraph: @unchecked Sendable {
     /// Indices of edges adjacent to a given edge (sharing a vertex).
     public func adjacentEdges(of edgeIndex: Int) -> [Int] {
         let count = Int(OCCTBRepGraphEdgeAdjacentCount(handle, Int32(edgeIndex)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphEdgeAdjacentIndices(handle, Int32(edgeIndex), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphEdgeAdjacentIndices(handle, Int32(edgeIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     // MARK: - Vertex Queries
@@ -165,12 +175,9 @@ public final class BRepGraph: @unchecked Sendable {
     /// Indices of edges connected to a vertex.
     public func edges(of vertexIndex: Int) -> [Int] {
         let count = Int(OCCTBRepGraphVertexEdgeCount(handle, Int32(vertexIndex)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphVertexEdgeIndices(handle, Int32(vertexIndex), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphVertexEdgeIndices(handle, Int32(vertexIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     // MARK: - Explorers
@@ -458,13 +465,9 @@ public final class BRepGraph: @unchecked Sendable {
 
     /// Indices of faces a wire belongs to.
     public func wireFaces(_ wireIndex: Int) -> [Int] {
-        let count = wireFaceCount(wireIndex)
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphWireFaceIndices(handle, Int32(wireIndex), buf.baseAddress!)
+        fetchIndices(count: wireFaceCount(wireIndex)) { buf in
+            OCCTBRepGraphWireFaceIndices(handle, Int32(wireIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     // MARK: - CoEdge Queries (v0.133.0)
@@ -506,13 +509,9 @@ public final class BRepGraph: @unchecked Sendable {
 
     /// Indices of solids a shell belongs to.
     public func shellSolids(_ shellIndex: Int) -> [Int] {
-        let count = shellSolidCount(shellIndex)
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphShellSolidIndices(handle, Int32(shellIndex), buf.baseAddress!)
+        fetchIndices(count: shellSolidCount(shellIndex)) { buf in
+            OCCTBRepGraphShellSolidIndices(handle, Int32(shellIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     // MARK: - Solid Queries (v0.133.0)
@@ -1012,12 +1011,9 @@ public final class BRepGraph: @unchecked Sendable {
     /// Indices of same-domain faces for a given face.
     public func sameDomainFaces(of faceIndex: Int) -> [Int] {
         let count = Int(OCCTBRepGraphFaceSameDomainCount(handle, Int32(faceIndex)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphFaceSameDomainIndices(handle, Int32(faceIndex), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphFaceSameDomainIndices(handle, Int32(faceIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     // MARK: - Copy and Transform (v0.133.0)
@@ -1097,13 +1093,9 @@ public final class BRepGraph: @unchecked Sendable {
 
     /// Indices of root products.
     public var rootProductIndices: [Int] {
-        let count = rootProductCount
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphRootProductIndices(handle, buf.baseAddress!)
+        fetchIndices(count: rootProductCount) { buf in
+            OCCTBRepGraphRootProductIndices(handle, buf)
         }
-        return indices.map { Int($0) }
     }
 
     // MARK: - Reference Counts (v0.134.0)
@@ -1226,23 +1218,17 @@ public final class BRepGraph: @unchecked Sendable {
     /// Indices of wires an edge belongs to.
     public func edgeWires(_ edgeIndex: Int) -> [Int] {
         let count = Int(OCCTBRepGraphEdgeWireCount(handle, Int32(edgeIndex)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphEdgeWireIndices(handle, Int32(edgeIndex), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphEdgeWireIndices(handle, Int32(edgeIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     /// Indices of coedges of an edge.
     public func edgeCoEdges(_ edgeIndex: Int) -> [Int] {
         let count = Int(OCCTBRepGraphEdgeCoEdgeCount(handle, Int32(edgeIndex)))
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphEdgeCoEdgeIndices(handle, Int32(edgeIndex), buf.baseAddress!)
+        return fetchIndices(count: count) { buf in
+            OCCTBRepGraphEdgeCoEdgeIndices(handle, Int32(edgeIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     /// Find the coedge index for an (edge, face) pair, or nil if not found.
@@ -1260,13 +1246,9 @@ public final class BRepGraph: @unchecked Sendable {
 
     /// Indices of shells a face belongs to.
     public func faceShells(_ faceIndex: Int) -> [Int] {
-        let count = faceShellCount(faceIndex)
-        if count == 0 { return [] }
-        var indices = [Int32](repeating: 0, count: count)
-        indices.withUnsafeMutableBufferPointer { buf in
-            OCCTBRepGraphFaceShellIndices(handle, Int32(faceIndex), buf.baseAddress!)
+        fetchIndices(count: faceShellCount(faceIndex)) { buf in
+            OCCTBRepGraphFaceShellIndices(handle, Int32(faceIndex), buf)
         }
-        return indices.map { Int($0) }
     }
 
     /// Number of compounds a face belongs to.

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -951,6 +951,25 @@ struct BRepGraphProductTests {
             }
         }
     }
+
+    // #418: rootProductIndices had zero test coverage anywhere; only its
+    // sibling rootProductCount was exercised (productCountForPrimitive above).
+    @Test func rootProductIndices() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)
+        if let box {
+            let graph = BRepGraph(shape: box)
+            if let graph {
+                let indices = graph.rootProductIndices
+                #expect(indices.count == graph.rootProductCount)
+                for index in indices {
+                    #expect(index >= 0)
+                    #expect(index < graph.productCount)
+                }
+                // Root product indices should be unique.
+                #expect(Set(indices).count == indices.count)
+            }
+        }
+    }
 }
 
 @Suite("BRepGraph Occurrences")


### PR DESCRIPTION
## What & why

`Sources/OCCTSwift/BRepGraph.swift` had 12 near-identical methods (`adjacentFaces(of:)`, `sharedEdges(between:and:)`, `faces(of edgeIndex:)`, `adjacentEdges(of:)`, `edges(of vertexIndex:)`, `wireFaces(_:)`, `shellSolids(_:)`, `sameDomainFaces(of:)`, `edgeWires(_:)`, `edgeCoEdges(_:)`, `faceShells(_:)`, and the computed var `rootProductIndices`) that each repeated the same shape: fetch a count, allocate an `Int32` buffer, fetch indices into it via `withUnsafeMutableBufferPointer`, map to `[Int]`. They also split 5-vs-7 on how they obtained the count (routed through a public `...Count` helper vs. inlining the bridge call directly), a silently-abandoned convention.

This PR routes all 12 through one new private helper:

```swift
private func fetchIndices(count: Int, fetch: (UnsafeMutablePointer<Int32>) -> Void) -> [Int] {
    guard count > 0 else { return [] }
    var indices = [Int32](repeating: 0, count: count)
    indices.withUnsafeMutableBufferPointer { buf in fetch(buf.baseAddress!) }
    return indices.map { Int($0) }
}
```

Each call site keeps its existing style for obtaining `count` (public helper vs. inline bridge call) — only the buffer-fill/map boilerplate is deduplicated, to minimize the diff and avoid inventing new public API surface.

**Fixes the negative-count trap**: the underlying bridge `...Count` functions derive their count via an unchecked narrowing `(int32_t)someCollection.size()` cast, so a sufficiently large graph could theoretically produce a negative `Int32`. Previously every one of the 12 sites guarded only `count == 0`, so a negative count would hit `[Int32](repeating: 0, count: count)` — a Swift runtime trap. The shared helper guards `count > 0`, so a negative count now degrades gracefully to `[]`.

Closes #418. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — added `rootProductIndices()` to `@Suite("BRepGraph Products")` in `Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`, which previously had zero coverage anywhere (only its sibling `rootProductCount` was tested). Asserts `indices.count == rootProductCount`, each index is in `[0, productCount)`, and indices are unique.

## Notes for the reviewer

- The count/fetch TOCTOU note from the issue (a concurrent graph mutation between the count-fetch and indices-fetch calls, under `BRepGraph`'s `@unchecked Sendable`) is real but pre-existing behavior common to all 12 sites, not introduced by this refactor. Fixing it properly would need a retry-with-larger-buffer pattern like `historyRecord(at:)`/`findDerived(of:)` already use elsewhere — a bigger change than this dedup. Left as-is per the issue's own scoping; worth a follow-up issue if it's ever observed in practice.
- Deliberately did not normalize the 5-vs-7 split on how each site sources its `count` (public helper vs. inline bridge call) — both styles now feed the same helper and produce identical behavior, so unifying that too felt like unrelated scope creep on top of the dedup.

## Test results

- `swift build --target OCCTBRepGraphTests`: clean (191.5s).
- `swift test --filter` across every suite touching one of the 12 methods (Face/Edge/Vertex Queries, Wire Extended, Shell Queries, SameDomain, Edge Wires CoEdges, Face Shells, Products): **22/22 passed** (9 suites), including the new `rootProductIndices()` test.
- Full `swift test`: **4548 tests in 1308 suites, 1 failure.** The 1 failure is `RobustImportProgressTests` (`Tests/OCCTIOTests/OCCTIOTests.swift:2175`, `@Suite("v1.11.2 Robust import progress (issue #300)", .serialized)`) — a pre-existing, documented timing flake unrelated to this change. The suite's own doc comment explains the mechanism: two cancellation tests each calibrate a deadline against a self-timed baseline import; under CPU contention (the machine had several other #377-audit worktrees running full suites concurrently) the baseline inflates enough that the deadline never fires. `.serialized` only protects the suite against itself, not against contention from concurrent processes outside the suite. Nothing in `BRepGraph.swift` or `OCCTIOTests` was touched by this PR.

