### PR TITLE
fix(#420): unify cone/cylinder-from-points Surface factories

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -10931,17 +10931,14 @@ OCCTCurve3DRef _Nullable OCCTGceMakeCircFromCenterNormal(double cx, double cy, d
                                                           double nx, double ny, double nz,
                                                           double radius);
 
-// --- gce_MakeCone ---
-/// Create a conical surface from 2 points (axis) + 2 radii
-OCCTSurfaceRef _Nullable OCCTGceMakeCone(double p1x, double p1y, double p1z,
-                                          double p2x, double p2y, double p2z,
-                                          double radius1, double radius2);
-
-// --- gce_MakeCylinder ---
-/// Create a cylindrical surface from 3 points (P1-P2 axis, P3 radius)
-OCCTSurfaceRef _Nullable OCCTGceMakeCylinderFrom3Points(double p1x, double p1y, double p1z,
-                                                         double p2x, double p2y, double p2z,
-                                                         double p3x, double p3y, double p3z);
+// --- gce_MakeCone / gce_MakeCylinder ---
+// Note (#420): conical/cylindrical surface-from-points construction is unified
+// on OCCTSurfaceConicalFromPointsRadii / OCCTSurfaceCylindricalFromPoints
+// (GC_MakeConicalSurface / GC_MakeCylindricalSurface, which return the
+// Handle(Geom_*) directly). The gce_MakeCone / gce_MakeCylinder-backed bridge
+// functions that previously duplicated this path were removed; the Swift
+// `Surface.coneFrom2PointsRadii`/`cylinderFrom3Points` entry points now call
+// through to `conicalSurface`/`cylindricalSurface`.
 
 // --- gce_MakeLin ---
 /// Create a line from 2 points

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -84,8 +84,6 @@
 #include <Extrema_ExtPS.hxx>
 #include <Extrema_ExtSS.hxx>
 #include <Extrema_POnSurf.hxx>
-#include <gce_MakeCone.hxx>
-#include <gce_MakeCylinder.hxx>
 #include <gce_MakePln.hxx>
 #include <Convert_CylinderToBSplineSurface.hxx>
 #include <Convert_ConeToBSplineSurface.hxx>
@@ -3249,28 +3247,13 @@ OCCTExtremaPointPair OCCTExtremaExtSSPoint(OCCTSurfaceRef surface1, OCCTSurfaceR
     return result;
 }
 
-// MARK: - gce_Make Cone / Cylinder / Pln (v0.80)
-OCCTSurfaceRef _Nullable OCCTGceMakeCone(double p1x, double p1y, double p1z,
-                                          double p2x, double p2y, double p2z,
-                                          double radius1, double radius2) {
-    try {
-        gce_MakeCone mc(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), radius1, radius2);
-        if (!mc.IsDone()) return nullptr;
-        Handle(Geom_ConicalSurface) cone = new Geom_ConicalSurface(mc.Value().Position(), mc.Value().SemiAngle(), mc.Value().RefRadius());
-        return (OCCTSurfaceRef)new OCCTSurface{cone};
-    } catch (...) { return nullptr; }
-}
-
-OCCTSurfaceRef _Nullable OCCTGceMakeCylinderFrom3Points(double p1x, double p1y, double p1z,
-                                                         double p2x, double p2y, double p2z,
-                                                         double p3x, double p3y, double p3z) {
-    try {
-        gce_MakeCylinder mc(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), gp_Pnt(p3x, p3y, p3z));
-        if (!mc.IsDone()) return nullptr;
-        Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(mc.Value().Position(), mc.Value().Radius());
-        return (OCCTSurfaceRef)new OCCTSurface{cyl};
-    } catch (...) { return nullptr; }
-}
+// MARK: - gce_Make Pln (v0.80)
+// Note (#420): OCCTGceMakeCone / OCCTGceMakeCylinderFrom3Points used to live here,
+// duplicating OCCTSurfaceConicalFromPointsRadii / OCCTSurfaceCylindricalFromPoints
+// (same points-and-radii inputs) via a separate gce_MakeCone/gce_MakeCylinder ->
+// gp_Cone/gp_Cylinder -> Geom_ConicalSurface/Geom_CylindricalSurface round-trip.
+// Removed in favor of the single GC_MakeConicalSurface/GC_MakeCylindricalSurface
+// path; see Surface.coneFrom2PointsRadii/cylinderFrom3Points in Surface.swift.
 OCCTSurfaceRef _Nullable OCCTGceMakePlnFromEquation(double a, double b, double c, double d) {
     try {
         gce_MakePln mp(a, b, c, d);

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2082,21 +2082,40 @@ extension Surface {
                                         point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
     }
 
-    /// Create a conical surface from 2 points (axis) + 2 radii (gce_MakeCone)
+    /// Create a conical surface from 2 points (axis) + 2 radii.
+    ///
+    /// Equivalent to ``conicalSurface(point1:point2:r1:r2:)`` — same underlying
+    /// `GC_MakeConicalSurface` construction, kept as a separate entry point for
+    /// API discoverability under the "gce_Make"-style naming used elsewhere in
+    /// this file. Previously this used an independent `gce_MakeCone` construction
+    /// path; unified onto `GC_MakeConicalSurface` to avoid maintaining two
+    /// implementations of the same operation (#420).
+    ///
+    /// ```swift
+    /// let cone = Surface.coneFrom2PointsRadii(
+    ///     p1: SIMD3(0, 0, 0), p2: SIMD3(0, 0, 10), radius1: 5.0, radius2: 2.0)
+    /// ```
     public static func coneFrom2PointsRadii(p1: SIMD3<Double>, p2: SIMD3<Double>,
                                             radius1: Double, radius2: Double) -> Surface? {
-        guard let h = OCCTGceMakeCone(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z,
-                                       radius1, radius2) else { return nil }
-        return Surface(handle: h)
+        conicalSurface(point1: p1, point2: p2, r1: radius1, r2: radius2)
     }
 
-    /// Create a cylindrical surface from 3 points (gce_MakeCylinder)
+    /// Create a cylindrical surface from 3 points.
+    ///
+    /// Equivalent to ``cylindricalSurface(point1:point2:point3:)`` — same underlying
+    /// `GC_MakeCylindricalSurface` construction, kept as a separate entry point for
+    /// API discoverability under the "gce_Make"-style naming used elsewhere in
+    /// this file. Previously this used an independent `gce_MakeCylinder` construction
+    /// path; unified onto `GC_MakeCylindricalSurface` to avoid maintaining two
+    /// implementations of the same operation (#420).
+    ///
+    /// ```swift
+    /// let cyl = Surface.cylinderFrom3Points(
+    ///     p1: SIMD3(0, 0, 0), p2: SIMD3(0, 0, 10), p3: SIMD3(5, 0, 5))
+    /// ```
     public static func cylinderFrom3Points(p1: SIMD3<Double>, p2: SIMD3<Double>,
                                            p3: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTGceMakeCylinderFrom3Points(p1.x, p1.y, p1.z,
-                                                      p2.x, p2.y, p2.z,
-                                                      p3.x, p3.y, p3.z) else { return nil }
-        return Surface(handle: h)
+        cylindricalSurface(point1: p1, point2: p2, point3: p3)
     }
 
     /// Create a plane from equation Ax+By+Cz+D=0 (gce_MakePln)

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -910,21 +910,56 @@ struct GceMakeCircTests {
 
 @Suite("gce_MakeCone Tests")
 struct GceMakeConeTests {
-    @Test func coneFrom2PointsRadii() {
-        if let cone = Surface.coneFrom2PointsRadii(p1: SIMD3(0,0,0), p2: SIMD3(0,0,10),
-                                                    radius1: 5.0, radius2: 2.0) {
-            #expect(Bool(true)) // Construction succeeded
-        }
+    @Test func coneFrom2PointsRadii() throws {
+        let cone = try #require(Surface.coneFrom2PointsRadii(
+            p1: SIMD3(0, 0, 0), p2: SIMD3(0, 0, 10),
+            radius1: 5.0, radius2: 2.0))
+        #expect(cone.handle != nil)
+    }
+
+    // #420: coneFrom2PointsRadii and conicalSurface(point1:point2:r1:r2:) now
+    // share one implementation (GC_MakeConicalSurface) — assert they still
+    // produce geometrically equivalent cones for the same inputs.
+    @Test func parityWithConicalSurface() throws {
+        let p1 = SIMD3(0.0, 0.0, 0.0)
+        let p2 = SIMD3(0.0, 0.0, 10.0)
+        let radius1 = 5.0
+        let radius2 = 2.0
+
+        let viaGce = try #require(Surface.coneFrom2PointsRadii(
+            p1: p1, p2: p2, radius1: radius1, radius2: radius2))
+        let viaGC = try #require(Surface.conicalSurface(
+            point1: p1, point2: p2, r1: radius1, r2: radius2))
+
+        #expect(abs(viaGce.coneProperties.semiAngle - viaGC.coneProperties.semiAngle) < 1e-9)
+        #expect(abs(viaGce.coneProperties.refRadius - viaGC.coneProperties.refRadius) < 1e-9)
+        #expect(simd_length(viaGce.coneProperties.axis.position - viaGC.coneProperties.axis.position) < 1e-9)
+        #expect(simd_length(viaGce.coneProperties.axis.direction - viaGC.coneProperties.axis.direction) < 1e-9)
     }
 }
 
 @Suite("gce_MakeCylinder Tests")
 struct GceMakeCylinderTests {
-    @Test func cylinderFrom3Points() {
-        if let cyl = Surface.cylinderFrom3Points(p1: SIMD3(0,0,0), p2: SIMD3(0,0,10),
-                                                  p3: SIMD3(3,0,0)) {
-            #expect(Bool(true))
-        }
+    @Test func cylinderFrom3Points() throws {
+        let cyl = try #require(Surface.cylinderFrom3Points(
+            p1: SIMD3(0, 0, 0), p2: SIMD3(0, 0, 10), p3: SIMD3(3, 0, 0)))
+        #expect(cyl.handle != nil)
+    }
+
+    // #420: cylinderFrom3Points and cylindricalSurface(point1:point2:point3:) now
+    // share one implementation (GC_MakeCylindricalSurface) — assert they still
+    // produce geometrically equivalent cylinders for the same inputs.
+    @Test func parityWithCylindricalSurface() throws {
+        let p1 = SIMD3(0.0, 0.0, 0.0)
+        let p2 = SIMD3(0.0, 0.0, 10.0)
+        let p3 = SIMD3(3.0, 0.0, 0.0)
+
+        let viaGce = try #require(Surface.cylinderFrom3Points(p1: p1, p2: p2, p3: p3))
+        let viaGC = try #require(Surface.cylindricalSurface(point1: p1, point2: p2, point3: p3))
+
+        #expect(abs(viaGce.cylinderProperties.radius - viaGC.cylinderProperties.radius) < 1e-9)
+        #expect(simd_length(viaGce.cylinderProperties.axis.position - viaGC.cylinderProperties.axis.position) < 1e-9)
+        #expect(simd_length(viaGce.cylinderProperties.axis.direction - viaGC.cylinderProperties.axis.direction) < 1e-9)
     }
 }
 

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -1113,7 +1113,10 @@ public func extremaSSPoint(other: Surface, index: Int) -> Curve3D.ExtremaPointPa
 
 ### `Surface.coneFrom2PointsRadii(p1:p2:radius1:radius2:)`
 
-Creates a conical surface from 2 axis points and 2 radii using the `gce_MakeCone` factory.
+Creates a conical surface from 2 axis points and 2 radii. Equivalent to
+`conicalSurface(point1:point2:r1:r2:)` — as of #420 both call the same
+`GC_MakeConicalSurface` construction, kept as a separate `gce_Make`-style
+entry point.
 
 ```swift
 public static func coneFrom2PointsRadii(
@@ -1126,7 +1129,7 @@ public static func coneFrom2PointsRadii(
 
 - **Parameters:** `p1`, `p2` — axis points; `radius1` — radius at `p1`; `radius2` — radius at `p2`.
 - **Returns:** Conical surface, or `nil` on failure.
-- **OCCT:** `gce_MakeCone(gp_Pnt, gp_Pnt, Standard_Real, Standard_Real)`.
+- **OCCT:** `GC_MakeConicalSurface(gp_Pnt, gp_Pnt, Standard_Real, Standard_Real)`.
 - **Example:**
   ```swift
   if let cone = Surface.coneFrom2PointsRadii(
@@ -1140,7 +1143,10 @@ public static func coneFrom2PointsRadii(
 
 ### `Surface.cylinderFrom3Points(p1:p2:p3:)`
 
-Creates a cylindrical surface from 3 points using the `gce_MakeCylinder` factory.
+Creates a cylindrical surface from 3 points. Equivalent to
+`cylindricalSurface(point1:point2:point3:)` — as of #420 both call the same
+`GC_MakeCylindricalSurface` construction, kept as a separate `gce_Make`-style
+entry point.
 
 ```swift
 public static func cylinderFrom3Points(
@@ -1154,7 +1160,7 @@ The axis passes through `p1` and `p2`; `p3` defines the radius (its distance to 
 
 - **Parameters:** `p1`, `p2` — axis points; `p3` — radius-defining point.
 - **Returns:** Cylindrical surface, or `nil` on failure.
-- **OCCT:** `gce_MakeCylinder(gp_Pnt, gp_Pnt, gp_Pnt)`.
+- **OCCT:** `GC_MakeCylindricalSurface(gp_Pnt, gp_Pnt, gp_Pnt)`.
 - **Example:**
   ```swift
   if let cyl = Surface.cylinderFrom3Points(


### PR DESCRIPTION
## What & why

`Surface.coneFrom2PointsRadii(p1:p2:radius1:radius2:)` / `Surface.cylinderFrom3Points(p1:p2:p3:)`
duplicated `Surface.conicalSurface(point1:point2:r1:r2:)` / `Surface.cylindricalSurface(point1:point2:point3:)`
(same params, same intent, added one release earlier) via two independent OCCT construction
paths: the `gce_Make*`-backed pair went `gce_MakeCone`/`gce_MakeCylinder` → `gp_Cone`/`gp_Cylinder`
value type → manually reconstructed `new Geom_ConicalSurface(...)`/`new Geom_CylindricalSurface(...)`,
while the `GC_Make*`-backed pair returns the `Handle(Geom_ConicalSurface)`/`Handle(Geom_CylindricalSurface)`
straight from `GC_MakeConicalSurface`/`GC_MakeCylindricalSurface`. Two independently-maintained
implementations of the same operation, with test coverage that made the divergence risk concrete:
the `gce_Make*` tests used `if let x = ... { #expect(Bool(true)) }` with no `else`/`Issue.record`,
so they passed unconditionally even if construction silently returned `nil`.

Fix, in line with the issue's preferred approach:
- `Surface.coneFrom2PointsRadii`/`cylinderFrom3Points` (`Sources/OCCTSwift/Surface.swift`) now
  delegate directly to `conicalSurface(point1:point2:r1:r2:)`/`cylindricalSurface(point1:point2:point3:)`.
  Both public functions keep their existing signatures and behavior — this only changes which OCCT
  construction path backs them.
- The now-unreachable `OCCTGceMakeCone`/`OCCTGceMakeCylinderFrom3Points` bridge functions were
  removed from `Sources/OCCTBridge/include/OCCTBridge.h` and `Sources/OCCTBridge/src/OCCTBridge_Surface.mm`
  (along with their now-unused `gce_MakeCone.hxx`/`gce_MakeCylinder.hxx` includes), leaving one real
  construction path per shape (`OCCTSurfaceConicalFromPointsRadii`/`OCCTSurfaceCylindricalFromPoints`,
  `GC_MakeConicalSurface`/`GC_MakeCylindricalSurface`).
- `Tests/OCCTMathTests/OCCTMathTests.swift`: `GceMakeConeTests.coneFrom2PointsRadii` and
  `GceMakeCylinderTests.cylinderFrom3Points` now use `try #require(...)` + a real assertion (matching
  the sibling `ConicalSurfaceTests`/`CylindricalSurfaceTests` pattern), so a regression actually fails
  the test instead of passing unconditionally.
- Added `GceMakeConeTests.parityWithConicalSurface` and `GceMakeCylinderTests.parityWithCylindricalSurface`,
  which construct a cone/cylinder through both public entry points for the same inputs and assert the
  resulting `coneProperties`/`cylinderProperties` (semi-angle, ref radius / radius, axis position +
  direction) match. This is a regression guard on the delegation itself (parameter order/meaning),
  not just proof both paths currently agree.
- `docs/reference/Surface-Advanced.md`: updated the `OCCT:` line for both entries from `gce_MakeCone`/
  `gce_MakeCylinder` to `GC_MakeConicalSurface`/`GC_MakeCylindricalSurface` to match the new
  implementation, and noted the two APIs are now equivalent.

Closes #420. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.

## Checklist

- [x] `coneFrom2PointsRadii`/`cylinderFrom3Points` public signatures unchanged
- [x] Weak `if let ... { #expect(Bool(true)) }` tests replaced with `try #require(...)` + real assertions
- [x] New parity tests cross-checking both entry points' geometric output
- [x] `swift build --target OCCTMathTests` — clean
- [x] `swift test --filter "GceMakeConeTests|GceMakeCylinderTests|ConicalSurfaceTests|CylindricalSurfaceTests"` — 16/16 pass, 0 failures
- [x] Full `swift test` — **4549 tests in 1308 suites, all passed** (372s), 0 failures

## Notes for the reviewer

- Verified parameter order/meaning is identical between the two OCCT construction paths before
  deleting the `gce_Make*` bridge functions (both bridge implementations passed `p1`, `p2`, `r1`/`r2`
  (cone) or `p1`, `p2`, `p3` (cylinder) through unchanged, in the same order, to their respective OCCT
  constructors) — this is a pure implementation unification, not a behavior change.
- Went with full removal of the `OCCTGceMakeCone`/`OCCTGceMakeCylinderFrom3Points` bridge functions
  (rather than having one call the other's C++ logic internally) since nothing outside
  `Surface.swift` referenced them and the public Swift API tolerates it — this leaves exactly one
  bridge function per shape instead of one calling through to another.
- Sibling issue #421 (plane factories) and #414 (mirror overloads) also touch `Surface.swift` in
  different regions of the file — no functional overlap expected, just proximity within the same file.
