### PR TITLE
fix(#417): add BRepGraph.contains(uid: GraphItemUID)

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -21090,6 +21090,10 @@ bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef _Nonnull graph,
                               int32_t* _Nonnull outDomain, int32_t* _Nonnull outKind,
                               int32_t* _Nonnull outIndex);
 
+/// True if an item UID (domain, kind, counter) exists in this graph generation.
+bool OCCTBRepGraphHasItemUID(OCCTBRepGraphRef _Nonnull graph,
+                              int32_t domain, int32_t kind, uint32_t counter);
+
 /// Return the current graph generation counter.
 ///
 /// NOTE: always 1 in practice. OCCT advances it only from BRepGraph::Clear(); this bridge

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -3417,6 +3417,16 @@ bool OCCTBRepGraphItemFromUID(OCCTBRepGraphRef graph,
     } catch (...) { return false; }
 }
 
+bool OCCTBRepGraphHasItemUID(OCCTBRepGraphRef graph, int32_t domain, int32_t kind, uint32_t counter) {
+    if (!graph) return false;
+    try {
+        BRepGraph_ItemUID uid = (domain == (int32_t)BRepGraph_ItemUID::Domain::Reference)
+            ? BRepGraph_ItemUID::Reference(refKindFromRawOrdinal(kind), (size_t)counter)
+            : BRepGraph_ItemUID::Node(kindFromInt(kind), (size_t)counter);
+        return graph->graph.UIDs().Has(uid);
+    } catch (...) { return false; }
+}
+
 uint32_t OCCTBRepGraphGeneration(OCCTBRepGraphRef graph) {
     if (!graph) return 0;
     try { return graph->graph.UIDs().Generation(); } catch (...) { return 0; }

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -2300,6 +2300,12 @@ public final class BRepGraph: @unchecked Sendable {
         return (Int(domain), Int(itemKind), Int(index))
     }
 
+    /// True if this graph minted the ItemUID and the item it names still exists here.
+    public func contains(uid: GraphItemUID) -> Bool {
+        guard uid.graphID == instanceID else { return false }
+        return OCCTBRepGraphHasItemUID(handle, Int32(uid.domain), Int32(uid.kind), uid.counter)
+    }
+
     /// Identifies this graph instance for as long as it lives.
     ///
     /// Unique among every graph this process builds, and — because the sequence starts at a random

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2547,6 +2547,8 @@ struct BRepGraphDurableUIDTests {
         if let itemUID = boxGraph.itemUID(ofNodeKind: faceKind, index: 2) {
             #expect(boxGraph.item(forUID: itemUID) != nil)
             #expect(cylGraph.item(forUID: itemUID) == nil)
+            #expect(boxGraph.contains(uid: itemUID))
+            #expect(!cylGraph.contains(uid: itemUID))
         }
     }
 


### PR DESCRIPTION
## What & why

`GraphUID` and `GraphRefUID` both have `contains(uid:)` (`BRepGraph.swift:2251`/`:2278`), backed by
`OCCTBRepGraphHasNodeUID`/`OCCTBRepGraphHasRefUID`. `GraphItemUID` was missing the same method
entirely — there was no `OCCTBRepGraphHasItemUID` bridge function at all, even though the
underlying OCCT method exists and is declared right alongside the other two `Has()` overloads:
`BRepGraph_UIDsView::Has(const BRepGraph_ItemUID&)` in
`Libraries/OCCT.xcframework/macos-arm64/Headers/BRepGraph_UIDsView.hxx:78` (verified against the
pinned 8.0.0p1 header before coding). Callers who wanted item-UID membership had to fall back to
`item(forUID:) != nil` instead of the symmetric `graph.contains(uid: itemUID)` the other two
durable-ID types offer.

This adds the missing method, following the existing triplet pattern exactly:

- `OCCTBRepGraphHasItemUID` declared in `Sources/OCCTBridge/include/OCCTBridge.h`, implemented in
  `Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm` — mirrors `OCCTBRepGraphItemFromUID`'s
  domain-based `BRepGraph_ItemUID::Node(...)`/`BRepGraph_ItemUID::Reference(...)` construction,
  then calls `BRepGraph_UIDsView::Has(...)`.
- `BRepGraph.contains(uid: GraphItemUID)` added to `Sources/OCCTSwift/BRepGraph.swift`, mirroring
  `contains(uid: GraphUID)`/`contains(uid: GraphRefUID)` exactly (provenance check against
  `instanceID`, then the bridge call).

No unification of the three near-identical UID types is attempted here — that's a bigger, riskier
refactor intentionally deferred to a follow-up; this PR fixes the one confirmed, real defect (the
missing method) surgically.

Closes #417. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.

## Checklist

- [x] New behavior is covered by a test in the same PR: extended `refAndItemUIDsDoNotCrossGraphs`
      (`Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`) with a same-graph-true /
      different-graph-false assertion for `GraphItemUID.contains(uid:)`, following the existing
      pattern used for `GraphRefUID` in the same test.

## Notes for the reviewer

- Scope deliberately kept minimal per the issue: just the missing `contains(uid:)` method + bridge
  function + test. The issue's bonus/optional ask (parity `isValid`/sentinel/provenance/`Codable`
  tests for `GraphRefUID`/`GraphItemUID`, matching `GraphUID`'s existing coverage) was left for a
  follow-up rather than risk scope creep on this PR.
- Test results:
  - `swift build --target OCCTBRepGraphTests`: clean.
  - `swift test --filter OCCTBRepGraphTests`: 172/172 pass, including the extended
    `refAndItemUIDsDoNotCrossGraphs` test exercising the new `contains(uid: GraphItemUID)`.
  - Full `swift test`: 4547 tests, 2 failures — both pre-existing, timing-sensitive, unrelated to
    this change: `allEdgePolylines scales linearly, not quadratically, in edge count`
    (`OCCTTopologyTests`, a CPU-timing cost-ratio benchmark; passes cleanly in isolation) and
    `Shape.loadIGESRobust interrupts healing, not just the transfer (#300)`
    (`OCCTIOTests`/`RobustImportProgressTests`, a self-calibrating deadline test whose own doc
    comment already documents it can flip "beside" other CPU load). This run happened alongside
    ~15 other concurrent `swift test` processes from sibling worktree agents on the same machine
    (the #411-422 duplication-audit batch), which is exactly the contention both tests' own
    comments call out as their failure mode. Neither touches `BRepGraph`/`GraphItemUID`.
- No sibling-issue overlap observed: #418/#419 touch `BRepGraph.swift`/`OCCTBridge_BRepGraph.mm`
  in the adjacency-accessor/UV-grid-unpack regions, not the UID types this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)