### PR TITLE
fix(#415): make Curve3D.arc(through:_:_:) a true alias of arcOfCircle

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -2880,9 +2880,6 @@ OCCTCurve3DRef OCCTCurve3DCreateCircle(double cx, double cy, double cz,
 OCCTCurve3DRef OCCTCurve3DCreateArcOfCircle(double p1x, double p1y, double p1z,
                                              double p2x, double p2y, double p2z,
                                              double p3x, double p3y, double p3z);
-OCCTCurve3DRef OCCTCurve3DCreateArc3Points(double p1x, double p1y, double p1z,
-                                            double pmx, double pmy, double pmz,
-                                            double p2x, double p2y, double p2z);
 OCCTCurve3DRef OCCTCurve3DCreateEllipse(double cx, double cy, double cz,
                                          double nx, double ny, double nz,
                                          double majorR, double minorR);

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -328,20 +328,6 @@ OCCTCurve3DRef OCCTCurve3DCreateArcOfCircle(double p1x, double p1y, double p1z,
     }
 }
 
-OCCTCurve3DRef OCCTCurve3DCreateArc3Points(double p1x, double p1y, double p1z,
-                                            double pmx, double pmy, double pmz,
-                                            double p2x, double p2y, double p2z) {
-    try {
-        GC_MakeArcOfCircle maker(gp_Pnt(p1x, p1y, p1z),
-                                  gp_Pnt(pmx, pmy, pmz),
-                                  gp_Pnt(p2x, p2y, p2z));
-        if (!maker.IsDone()) return nullptr;
-        return new OCCTCurve3D(maker.Value());
-    } catch (...) {
-        return nullptr;
-    }
-}
-
 OCCTCurve3DRef OCCTCurve3DCreateEllipse(double cx, double cy, double cz,
                                          double nx, double ny, double nz,
                                          double majorR, double minorR) {

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -125,12 +125,23 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Circular arc through three points (alias)
+    /// Circular arc through three points.
+    ///
+    /// A spelling of `arcOfCircle(start:interior:end:)` and delegates to it — the two cannot
+    /// produce different curves for the same input (#415).
+    ///
+    /// - Parameters:
+    ///   - p1: First endpoint (maps to `arcOfCircle`'s `start`).
+    ///   - pm: A point on the arc (maps to `arcOfCircle`'s `interior`).
+    ///   - p2: Second endpoint (maps to `arcOfCircle`'s `end`).
+    /// - Returns: Arc curve, or `nil` if the three points are collinear or coincident.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.arc(through: SIMD3(5, 0, 0), SIMD3(0, 5, 0), SIMD3(-5, 0, 0))
+    /// #expect(arc != nil)
+    /// ```
     public static func arc(through p1: SIMD3<Double>, _ pm: SIMD3<Double>, _ p2: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateArc3Points(p1.x, p1.y, p1.z,
-                                                   pm.x, pm.y, pm.z,
-                                                   p2.x, p2.y, p2.z) else { return nil }
-        return Curve3D(handle: h)
+        arcOfCircle(start: p1, interior: pm, end: p2)
     }
 
     /// Ellipse in a plane defined by center and normal.

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -4218,3 +4218,70 @@ struct Curve3DArcLengthFailureParityTests {
         }
     }
 }
+
+// MARK: - #415: arc(through:_:_:) delegates to arcOfCircle(start:interior:end:)
+
+/// `Curve3D.arc(through:_:_:)` was documented as an alias for `arcOfCircle(start:interior:end:)`
+/// but was actually a second, independently-maintained bridge entry point
+/// (`OCCTCurve3DCreateArc3Points`) wrapping the same `GC_MakeArcOfCircle` constructor with a
+/// structurally identical body. Nothing enforced the "alias" contract and `arc(through:_:_:)` had
+/// zero test coverage. It now delegates directly to `arcOfCircle(start:interior:end:)`; the
+/// redundant bridge function was removed.
+@Suite("Curve3D.arc(through:_:_:) is a true alias of arcOfCircle (#415)")
+struct Curve3DArcAliasParityTests {
+
+    private static let start = SIMD3<Double>(5, 0, 0)
+    private static let interior = SIMD3<Double>(0, 5, 0)
+    private static let end = SIMD3<Double>(-5, 0, 0)
+
+    @Test("arc(through:_:_:) produces a valid arc")
+    func arcThroughThreePoints() {
+        let arc = Curve3D.arc(through: Self.start, Self.interior, Self.end)
+        #expect(arc != nil)
+        if let arc {
+            #expect(!arc.isClosed)
+            let s = arc.startPoint
+            #expect(abs(s.x - Self.start.x) < 0.01)
+            #expect(abs(s.y - Self.start.y) < 0.01)
+            #expect(abs(s.z - Self.start.z) < 0.01)
+        }
+    }
+
+    @Test("arc(through:_:_:) and arcOfCircle(start:interior:end:) produce identical geometry")
+    func parityWithArcOfCircle() {
+        let viaArc = Curve3D.arc(through: Self.start, Self.interior, Self.end)
+        let viaArcOfCircle = Curve3D.arcOfCircle(start: Self.start, interior: Self.interior, end: Self.end)
+        #expect(viaArc != nil)
+        #expect(viaArcOfCircle != nil)
+        guard let a = viaArc, let b = viaArcOfCircle else { return }
+        #expect(a.isClosed == b.isClosed)
+        #expect(a.isPeriodic == b.isPeriodic)
+        #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12)
+        #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12)
+        for t in stride(from: 0.0, through: 1.0, by: 0.1) {
+            let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
+            let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
+            let pa = a.point(at: ua), pb = b.point(at: ub)
+            #expect(abs(pa.x - pb.x) < 1e-9)
+            #expect(abs(pa.y - pb.y) < 1e-9)
+            #expect(abs(pa.z - pb.z) < 1e-9)
+        }
+    }
+
+    @Test("Both entry points reject collinear points")
+    func collinearRejectedByBoth() {
+        let a = Curve3D.arc(through: SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(2, 0, 0))
+        let b = Curve3D.arcOfCircle(start: SIMD3(0, 0, 0), interior: SIMD3(1, 0, 0), end: SIMD3(2, 0, 0))
+        #expect(a == nil)
+        #expect(b == nil)
+    }
+
+    @Test("Both entry points reject coincident points")
+    func coincidentRejectedByBoth() {
+        let p = SIMD3<Double>(3, 4, 5)
+        let a = Curve3D.arc(through: p, p, p)
+        let b = Curve3D.arcOfCircle(start: p, interior: p, end: p)
+        #expect(a == nil)
+        #expect(b == nil)
+    }
+}

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -281,18 +281,19 @@ OCCT derives the centre and radius from the three points. The arc sweeps from `s
 
 ### `Curve3D.arc(through:_:_:)`
 
-Alias for `arcOfCircle(start:interior:end:)`.
+A spelling of [`arcOfCircle(start:interior:end:)`](#curve3darcofcirclestartinteriorend) and delegates to it — the two cannot produce different curves for the same input (#415).
 
 ```swift
 public static func arc(through p1: SIMD3<Double>, _ pm: SIMD3<Double>, _ p2: SIMD3<Double>) -> Curve3D?
 ```
 
-- **Parameters:** `p1` — first endpoint; `pm` — interior midpoint; `p2` — second endpoint.
+- **Parameters:** `p1` — first endpoint (maps to `arcOfCircle`'s `start`); `pm` — a point on the arc (maps to `interior`); `p2` — second endpoint (maps to `end`).
 - **Returns:** Arc curve, or `nil` if points are collinear or coincident.
-- **OCCT:** `GC_MakeArcOfCircle` → `Geom_TrimmedCurve`.
+- **OCCT:** `GC_MakeArcOfCircle` → `Geom_TrimmedCurve`, via `arcOfCircle(start:interior:end:)`.
 - **Example:**
   ```swift
   let arc = Curve3D.arc(through: SIMD3(5, 0, 0), SIMD3(0, 5, 0), SIMD3(-5, 0, 0))
+  #expect(arc != nil)
   ```
 
 ---


### PR DESCRIPTION
## What & why

`Curve3D.arc(through:_:_:)` was documented (`docs/reference/Curve3D.md`, in-source doc comment) as an alias for `arcOfCircle(start:interior:end:)`, but nothing in the code made that true structurally. It was a second, independently-maintained bridge entry point (`OCCTCurve3DCreateArc3Points`) that built its own `GC_MakeArcOfCircle` with a structurally identical body (same point order, same `IsDone()` guard, same `catch(...)`) to `OCCTCurve3DCreateArcOfCircle`. Any future fix applied to one (e.g. a collinear/coincident pre-check, a catch-clause change) had no mechanism forcing it onto the other — and `arc(through:_:_:)` had zero test coverage, so any such drift would go uncaught.

Fix (option (a) from the issue, the preferred one, matching the #412 "make X delegate instead of reimplementing" pattern — but going one step further since #415 explicitly calls for it): `arc(through:_:_:)` now calls `arcOfCircle(start:interior:end:)` directly in pure Swift. The now-redundant `OCCTCurve3DCreateArc3Points` bridge function and its header declaration are deleted outright — there was no other caller anywhere in the repo (`docs/`, `.mm`, `.h`, `.swift`) besides the one Swift wrapper being changed.

## Changes

- `Sources/OCCTSwift/Curve3D.swift`: `arc(through:_:_:)` delegates to `arcOfCircle(start:interior:end:)`; expanded doc comment with parameter mapping and a runnable snippet.
- `Sources/OCCTBridge/include/OCCTBridge.h`: removed `OCCTCurve3DCreateArc3Points` declaration.
- `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`: removed `OCCTCurve3DCreateArc3Points` implementation.
- `docs/reference/Curve3D.md`: `arc(through:_:_:)` entry now states and links the real delegation relationship instead of the unenforced "alias" claim.
- `Tests/OCCTCurveTests/OCCTCurveTests.swift`: new `Curve3DArcAliasParityTests` suite — direct coverage of `arc(through:_:_:)` (previously untested), a parity test sampling both entry points across their domain and asserting identical geometry, and coverage of the collinear/coincident rejection path on both.

## Checklist

- [x] New test coverage for the changed behavior (`Curve3DArcAliasParityTests`, 4 tests)
- [x] `swift build` clean (bridge + Swift)
- [x] Focused target: `swift build --target OCCTCurveTests` clean; `swift test --filter Curve3DArcAliasParityTests` — 4/4 pass
- [x] Full `swift test` — 4551 tests / 1309 suites, clean (one earlier run hit a single unrelated failure consistent with this repo's known ~1-in-10 parallel-run flake documented in `CLAUDE.md`; a second full run was 100% clean)
- [x] `docs/reference/Curve3D.md` updated to match the new contract
- [x] `docs/CHANGELOG.md` intentionally NOT touched (audit branch merges to main as one unit later)

## Notes for the reviewer

- No OCCT kernel/xcframework changes — this is a pure bridge + Swift + docs change, no `OCCTBridge.xcframework` rebuild needed (default `swift build` compiles the bridge from source; the prebuilt-bridge opt-in is unaffected since the removed symbol had no other callers).
- Confirmed via `grep -rn "OCCTCurve3DCreateArc3Points"` across the whole repo that the only references were the header decl, the `.mm` impl, and the one Swift call site being changed — safe to delete outright rather than keep as a forwarding shim.

Closes #415. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.