### PR TITLE
refactor(#422): unify EdgeCurve/WireCurve arc-length adaptor duplication

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -5663,9 +5663,68 @@ OCCTCurve3DRef OCCTGeomEvalAHTBezierCurveCreateRational(
     } catch (...) { return nullptr; }
 }
 
+// MARK: - Shared arc-length adaptor helpers (#211/#212/#422): generic over any Adaptor3d_Curve&
+//
+// BRepAdaptor_CompCurve (multi-edge wire) and BRepAdaptor_Curve (single edge) both derive from
+// Adaptor3d_Curve, so the entire arc-length API (length, native-parameter access, arc-length
+// lookup, uniform sampling) can be written once here and reused by both OCCTCompCurve* and
+// OCCTEdgeCurve* below — mirroring the pre-existing sampleAdaptorUniform() precedent, which this
+// unifies the other 5 operations to match. Callers keep their own try/catch + null-ref check
+// (matching sampleAdaptorUniform's own call sites) so a thrown Standard_Failure/StdFail_NotDone
+// can never cross the extern "C" boundary.
+#include <Adaptor3d_Curve.hxx>
+#include <GCPnts_AbscissaPoint.hxx>
+#include <GCPnts_UniformAbscissa.hxx>
+
+static double adaptorLength(Adaptor3d_Curve& a) {
+    return GCPnts_AbscissaPoint::Length(a);
+}
+
+static void adaptorParamRange(Adaptor3d_Curve& a, double* first, double* last) {
+    if (first) *first = a.FirstParameter();
+    if (last)  *last  = a.LastParameter();
+}
+
+static bool adaptorPointAtParam(Adaptor3d_Curve& a, double u, double* x, double* y, double* z) {
+    gp_Pnt p = a.Value(u);
+    if (x) *x = p.X(); if (y) *y = p.Y(); if (z) *z = p.Z();
+    return true;
+}
+
+static bool adaptorTangentAtParam(Adaptor3d_Curve& a, double u, double* x, double* y, double* z) {
+    gp_Pnt p; gp_Vec d1;
+    a.D1(u, p, d1);
+    if (d1.Magnitude() < 1e-12) return false;   // degenerate (e.g. cusp)
+    gp_Dir dir(d1);
+    if (x) *x = dir.X(); if (y) *y = dir.Y(); if (z) *z = dir.Z();
+    return true;
+}
+
+static bool adaptorParamAtAbscissa(Adaptor3d_Curve& a, double s, double* outParam) {
+    GCPnts_AbscissaPoint ap(a, s, a.FirstParameter());
+    if (!ap.IsDone()) return false;
+    if (outParam) *outParam = ap.Parameter();
+    return true;
+}
+
+// N points spaced equally by arc length along the curve. outXYZ must hold count*3 doubles;
+// returns the number of points actually written.
+static int32_t sampleAdaptorUniform(Adaptor3d_Curve& a, int32_t count, double* outXYZ) {
+    if (count < 2 || !outXYZ) return 0;
+    GCPnts_UniformAbscissa sampler(a, count);
+    if (!sampler.IsDone()) return 0;
+    int32_t n = sampler.NbPoints();
+    for (int32_t i = 1; i <= n; ++i) {
+        gp_Pnt p = a.Value(sampler.Parameter(i));
+        outXYZ[(i - 1) * 3 + 0] = p.X();
+        outXYZ[(i - 1) * 3 + 1] = p.Y();
+        outXYZ[(i - 1) * 3 + 2] = p.Z();
+    }
+    return n;
+}
+
 // MARK: - CompCurve adaptor (#211): a multi-edge wire as one arc-length-parameterized curve
 #include <BRepAdaptor_CompCurve.hxx>
-#include <GCPnts_AbscissaPoint.hxx>
 
 // Opaque handle: holds the adaptor by value (BRepAdaptor_CompCurve(const TopoDS_Wire&)).
 struct OCCTCompCurve {
@@ -5683,65 +5742,32 @@ void OCCTCompCurveRelease(OCCTCompCurveRef ref) { delete ref; }
 
 double OCCTCompCurveLength(OCCTCompCurveRef ref) {
     if (!ref) return -1.0;
-    try { return GCPnts_AbscissaPoint::Length(ref->adaptor); }
+    try { return adaptorLength(ref->adaptor); }
     catch (...) { return -1.0; }
 }
 
 void OCCTCompCurveParamRange(OCCTCompCurveRef ref, double* first, double* last) {
     if (!ref) return;
-    try {
-        if (first) *first = ref->adaptor.FirstParameter();
-        if (last)  *last  = ref->adaptor.LastParameter();
-    } catch (...) {}
+    try { adaptorParamRange(ref->adaptor, first, last); }
+    catch (...) {}
 }
 
 bool OCCTCompCurvePointAtParam(OCCTCompCurveRef ref, double u, double* x, double* y, double* z) {
     if (!ref) return false;
-    try {
-        gp_Pnt p = ref->adaptor.Value(u);
-        if (x) *x = p.X(); if (y) *y = p.Y(); if (z) *z = p.Z();
-        return true;
-    } catch (...) { return false; }
+    try { return adaptorPointAtParam(ref->adaptor, u, x, y, z); }
+    catch (...) { return false; }
 }
 
 bool OCCTCompCurveTangentAtParam(OCCTCompCurveRef ref, double u, double* x, double* y, double* z) {
     if (!ref) return false;
-    try {
-        gp_Pnt p; gp_Vec d1;
-        ref->adaptor.D1(u, p, d1);
-        if (d1.Magnitude() < 1e-12) return false;   // degenerate (e.g. cusp)
-        gp_Dir dir(d1);
-        if (x) *x = dir.X(); if (y) *y = dir.Y(); if (z) *z = dir.Z();
-        return true;
-    } catch (...) { return false; }
+    try { return adaptorTangentAtParam(ref->adaptor, u, x, y, z); }
+    catch (...) { return false; }
 }
 
 bool OCCTCompCurveParamAtAbscissa(OCCTCompCurveRef ref, double s, double* outParam) {
     if (!ref) return false;
-    try {
-        GCPnts_AbscissaPoint ap(ref->adaptor, s, ref->adaptor.FirstParameter());
-        if (!ap.IsDone()) return false;
-        if (outParam) *outParam = ap.Parameter();
-        return true;
-    } catch (...) { return false; }
-}
-
-// Shared: N points spaced equally by arc length along any 3D curve adaptor.
-// outXYZ must hold count*3 doubles; returns the number of points actually written.
-#include <Adaptor3d_Curve.hxx>
-#include <GCPnts_UniformAbscissa.hxx>
-static int32_t sampleAdaptorUniform(Adaptor3d_Curve& a, int32_t count, double* outXYZ) {
-    if (count < 2 || !outXYZ) return 0;
-    GCPnts_UniformAbscissa sampler(a, count);
-    if (!sampler.IsDone()) return 0;
-    int32_t n = sampler.NbPoints();
-    for (int32_t i = 1; i <= n; ++i) {
-        gp_Pnt p = a.Value(sampler.Parameter(i));
-        outXYZ[(i - 1) * 3 + 0] = p.X();
-        outXYZ[(i - 1) * 3 + 1] = p.Y();
-        outXYZ[(i - 1) * 3 + 2] = p.Z();
-    }
-    return n;
+    try { return adaptorParamAtAbscissa(ref->adaptor, s, outParam); }
+    catch (...) { return false; }
 }
 
 int32_t OCCTCompCurveSampleUniform(OCCTCompCurveRef ref, int32_t count, double* outXYZ) {
@@ -5768,47 +5794,32 @@ void OCCTEdgeCurveRelease(OCCTEdgeCurveRef ref) { delete ref; }
 
 double OCCTEdgeCurveLength(OCCTEdgeCurveRef ref) {
     if (!ref) return -1.0;
-    try { return GCPnts_AbscissaPoint::Length(ref->adaptor); }
+    try { return adaptorLength(ref->adaptor); }
     catch (...) { return -1.0; }
 }
 
 void OCCTEdgeCurveParamRange(OCCTEdgeCurveRef ref, double* first, double* last) {
     if (!ref) return;
-    try {
-        if (first) *first = ref->adaptor.FirstParameter();
-        if (last)  *last  = ref->adaptor.LastParameter();
-    } catch (...) {}
+    try { adaptorParamRange(ref->adaptor, first, last); }
+    catch (...) {}
 }
 
 bool OCCTEdgeCurvePointAtParam(OCCTEdgeCurveRef ref, double u, double* x, double* y, double* z) {
     if (!ref) return false;
-    try {
-        gp_Pnt p = ref->adaptor.Value(u);
-        if (x) *x = p.X(); if (y) *y = p.Y(); if (z) *z = p.Z();
-        return true;
-    } catch (...) { return false; }
+    try { return adaptorPointAtParam(ref->adaptor, u, x, y, z); }
+    catch (...) { return false; }
 }
 
 bool OCCTEdgeCurveTangentAtParam(OCCTEdgeCurveRef ref, double u, double* x, double* y, double* z) {
     if (!ref) return false;
-    try {
-        gp_Pnt p; gp_Vec d1;
-        ref->adaptor.D1(u, p, d1);
-        if (d1.Magnitude() < 1e-12) return false;
-        gp_Dir dir(d1);
-        if (x) *x = dir.X(); if (y) *y = dir.Y(); if (z) *z = dir.Z();
-        return true;
-    } catch (...) { return false; }
+    try { return adaptorTangentAtParam(ref->adaptor, u, x, y, z); }
+    catch (...) { return false; }
 }
 
 bool OCCTEdgeCurveParamAtAbscissa(OCCTEdgeCurveRef ref, double s, double* outParam) {
     if (!ref) return false;
-    try {
-        GCPnts_AbscissaPoint ap(ref->adaptor, s, ref->adaptor.FirstParameter());
-        if (!ap.IsDone()) return false;
-        if (outParam) *outParam = ap.Parameter();
-        return true;
-    } catch (...) { return false; }
+    try { return adaptorParamAtAbscissa(ref->adaptor, s, outParam); }
+    catch (...) { return false; }
 }
 
 int32_t OCCTEdgeCurveSampleUniform(OCCTEdgeCurveRef ref, int32_t count, double* outXYZ) {

--- a/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
+++ b/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Shared arc-length-adaptor interface implemented by ``EdgeCurve`` and ``WireCurve`` (#211/#212/#422).
+///
+/// Both types wrap a distinct OCCT curve adaptor behind a distinct bridge handle type
+/// (`BRepAdaptor_Curve` for a single edge, `BRepAdaptor_CompCurve` for a multi-edge wire), so they
+/// stay separate public classes — but once each type supplies its own native-parameter primitives
+/// (`length`, `point(atParameter:)`, `tangent(atParameter:)`, `parameter(atAbscissa:)`,
+/// `points(count:)`), the arc-length *composition* built on top of them (looking up a point/tangent
+/// by abscissa, converting a spacing into an evenly-divided sample count) is identical for both —
+/// this protocol's extension supplies that composition exactly once instead of per-type.
+///
+/// ```swift
+/// func firstQuarterPoint(of curve: some ArcLengthCurveAdaptor) -> SIMD3<Double>? {
+///     curve.point(atAbscissa: curve.length / 4)
+/// }
+/// ```
+public protocol ArcLengthCurveAdaptor: AnyObject {
+    /// Total arc length of the underlying curve.
+    var length: Double { get }
+
+    /// The native parameter range `[first, last]` (not arc length — use the `atAbscissa:`
+    /// methods for arc-length sampling).
+    var parameterRange: (first: Double, last: Double) { get }
+
+    /// Point at a native curve parameter `u` (within ``parameterRange``).
+    func point(atParameter u: Double) -> SIMD3<Double>?
+
+    /// Unit tangent (first derivative, normalized) at a native parameter `u`.
+    /// `nil` at a degenerate point (e.g. a cusp where the derivative vanishes).
+    func tangent(atParameter u: Double) -> SIMD3<Double>?
+
+    /// The native parameter at arc length `s` measured from the start of the curve.
+    func parameter(atAbscissa s: Double) -> Double?
+
+    /// `count` points spaced equally by arc length along the curve (`count >= 2`), including both
+    /// endpoints. One pass, cheaper than calling ``point(atAbscissa:)`` in a loop.
+    func points(count: Int) -> [SIMD3<Double>]
+}
+
+extension ArcLengthCurveAdaptor {
+    /// Point at arc length `s` from the start of the curve (0...``length``).
+    public func point(atAbscissa s: Double) -> SIMD3<Double>? {
+        guard let u = parameter(atAbscissa: s) else { return nil }
+        return point(atParameter: u)
+    }
+
+    /// Unit tangent at arc length `s` from the start of the curve.
+    public func tangent(atAbscissa s: Double) -> SIMD3<Double>? {
+        guard let u = parameter(atAbscissa: s) else { return nil }
+        return tangent(atParameter: u)
+    }
+
+    /// Points spaced approximately `spacing` apart along the curve (by arc length). The exact
+    /// step is adjusted so the samples divide the curve evenly end-to-end.
+    public func points(spacing: Double) -> [SIMD3<Double>] {
+        let len = length
+        guard spacing > 0, len > 0 else { return [] }
+        let count = max(2, Int((len / spacing).rounded()) + 1)
+        return points(count: count)
+    }
+}

--- a/Sources/OCCTSwift/EdgeCurve.swift
+++ b/Sources/OCCTSwift/EdgeCurve.swift
@@ -7,12 +7,15 @@ import OCCTBridge
 /// *native* parameter space; `EdgeCurve` adds the arc-length side — `length`,
 /// `point(atAbscissa:)`, evenly-spaced sampling — matching ``WireCurve`` for a single edge. (#211/#212)
 ///
+/// The arc-length composition (`point`/`tangent(atAbscissa:)`, `points(spacing:)`) is shared with
+/// ``WireCurve`` via ``ArcLengthCurveAdaptor``; see that protocol for the underlying primitives.
+///
 /// ```swift
 /// guard let ec = EdgeCurve(edge) else { return }
 /// let mids = ec.points(count: 11)        // 11 points equally spaced along the edge
 /// let half = ec.point(atAbscissa: ec.length / 2)
 /// ```
-public final class EdgeCurve: @unchecked Sendable {
+public final class EdgeCurve: ArcLengthCurveAdaptor, @unchecked Sendable {
     internal let ref: OCCTEdgeCurveRef
 
     /// Build an arc-length adaptor over `edge`. Returns `nil` if the edge is invalid (e.g.
@@ -55,18 +58,6 @@ public final class EdgeCurve: @unchecked Sendable {
         return u
     }
 
-    /// Point at arc length `s` from the start of the edge (0...``length``).
-    public func point(atAbscissa s: Double) -> SIMD3<Double>? {
-        guard let u = parameter(atAbscissa: s) else { return nil }
-        return point(atParameter: u)
-    }
-
-    /// Unit tangent at arc length `s` from the start of the edge.
-    public func tangent(atAbscissa s: Double) -> SIMD3<Double>? {
-        guard let u = parameter(atAbscissa: s) else { return nil }
-        return tangent(atParameter: u)
-    }
-
     /// `count` points spaced equally by arc length along the edge (`count >= 2`), endpoints included.
     public func points(count: Int) -> [SIMD3<Double>] {
         guard count >= 2 else { return [] }
@@ -75,11 +66,6 @@ public final class EdgeCurve: @unchecked Sendable {
         return (0..<n).map { SIMD3(buf[$0 * 3], buf[$0 * 3 + 1], buf[$0 * 3 + 2]) }
     }
 
-    /// Points spaced approximately `spacing` apart along the edge (by arc length).
-    public func points(spacing: Double) -> [SIMD3<Double>] {
-        let len = length
-        guard spacing > 0, len > 0 else { return [] }
-        let count = max(2, Int((len / spacing).rounded()) + 1)
-        return points(count: count)
-    }
+    // point(atAbscissa:), tangent(atAbscissa:), points(spacing:) are supplied by the
+    // ArcLengthCurveAdaptor extension — see that protocol.
 }

--- a/Sources/OCCTSwift/WireCurve.swift
+++ b/Sources/OCCTSwift/WireCurve.swift
@@ -8,6 +8,9 @@ import OCCTBridge
 /// Useful for placing loft cross-sections along a measured section wire, walking a
 /// prismatic outline at a fixed step, etc. (#211)
 ///
+/// The arc-length composition (`point`/`tangent(atAbscissa:)`, `points(spacing:)`) is shared with
+/// ``EdgeCurve`` via ``ArcLengthCurveAdaptor``; see that protocol for the underlying primitives.
+///
 /// ```swift
 /// guard let wc = WireCurve(sectionWire) else { return }
 /// let n = 20
@@ -15,7 +18,7 @@ import OCCTBridge
 ///     wc.point(atAbscissa: wc.length * Double(i) / Double(n))
 /// }   // n+1 points spaced equally along the wire
 /// ```
-public final class WireCurve: @unchecked Sendable {
+public final class WireCurve: ArcLengthCurveAdaptor, @unchecked Sendable {
     internal let ref: OCCTCompCurveRef
 
     /// Build an arc-length adaptor over `wire`. Returns `nil` if the wire is empty/invalid.
@@ -59,18 +62,6 @@ public final class WireCurve: @unchecked Sendable {
         return u
     }
 
-    /// Point at arc length `s` from the start of the wire (0...``length``).
-    public func point(atAbscissa s: Double) -> SIMD3<Double>? {
-        guard let u = parameter(atAbscissa: s) else { return nil }
-        return point(atParameter: u)
-    }
-
-    /// Unit tangent at arc length `s` from the start of the wire.
-    public func tangent(atAbscissa s: Double) -> SIMD3<Double>? {
-        guard let u = parameter(atAbscissa: s) else { return nil }
-        return tangent(atParameter: u)
-    }
-
     /// `count` points spaced **equally by arc length** along the wire (`count >= 2`),
     /// including both endpoints — `GCPnts_UniformAbscissa`. One pass, cheaper than calling
     /// ``point(atAbscissa:)`` in a loop.
@@ -81,12 +72,6 @@ public final class WireCurve: @unchecked Sendable {
         return (0..<n).map { SIMD3(buf[$0 * 3], buf[$0 * 3 + 1], buf[$0 * 3 + 2]) }
     }
 
-    /// Points spaced approximately `spacing` apart along the wire (by arc length). The exact
-    /// step is adjusted so the samples divide the wire evenly end-to-end.
-    public func points(spacing: Double) -> [SIMD3<Double>] {
-        let len = length
-        guard spacing > 0, len > 0 else { return [] }
-        let count = max(2, Int((len / spacing).rounded()) + 1)
-        return points(count: count)
-    }
+    // point(atAbscissa:), tangent(atAbscissa:), points(spacing:) are supplied by the
+    // ArcLengthCurveAdaptor extension — see that protocol.
 }

--- a/Tests/OCCTCurveTests/Issue211WireCurveTests.swift
+++ b/Tests/OCCTCurveTests/Issue211WireCurveTests.swift
@@ -61,6 +61,38 @@ struct Issue211WireCurve {
         }
         #expect(wc.points(count: 1).isEmpty)   // need >= 2
     }
+
+    // #422: parameterRange/point(atParameter:)/tangent(atParameter:) were previously only
+    // exercised indirectly, as internals of point/tangent(atAbscissa:).
+    @Test("parameterRange bounds match the wire's start/end via point(atParameter:)")
+    func parameterRangeMatchesEndpoints() {
+        guard let w = lWire(), let wc = WireCurve(w) else { #expect(Bool(false)); return }
+        let range = wc.parameterRange
+        #expect(range.first < range.last)
+        if let start = wc.point(atParameter: range.first) {
+            #expect(simd_distance(start, SIMD3(0, 0, 0)) < 1e-6)
+        } else { #expect(Bool(false), "point(atParameter: first) nil") }
+        if let end = wc.point(atParameter: range.last) {
+            #expect(simd_distance(end, SIMD3(10, 10, 0)) < 1e-6)
+        } else { #expect(Bool(false), "point(atParameter: last) nil") }
+        if let t = wc.tangent(atParameter: range.first) {
+            #expect(abs(simd_length(t) - 1.0) < 1e-6)
+        } else { #expect(Bool(false), "tangent(atParameter: first) nil") }
+    }
+
+    // #422: points(spacing:) was untested on both EdgeCurve and WireCurve.
+    @Test("points(spacing:) divides the wire evenly and includes both endpoints")
+    func pointsSpacing() {
+        guard let w = lWire(), let wc = WireCurve(w) else { #expect(Bool(false)); return }
+        let pts = wc.points(spacing: 4)   // length 20 -> 6 points, 4 apart
+        #expect(pts.count == 6)
+        if let first = pts.first, let last = pts.last {
+            #expect(simd_distance(first, SIMD3(0, 0, 0)) < 1e-6)
+            #expect(simd_distance(last, SIMD3(10, 10, 0)) < 1e-6)
+        }
+        #expect(wc.points(spacing: 0).isEmpty)          // spacing must be > 0
+        #expect(wc.points(spacing: -1).isEmpty)
+    }
 }
 
 // #211/#212: EdgeCurve — single-edge arc-length adaptor.
@@ -82,5 +114,47 @@ struct Issue211EdgeCurve {
         if let t = ec.tangent(atAbscissa: ec.length / 2) {
             #expect(abs(simd_length(t) - 1.0) < 1e-6)
         } else { #expect(Bool(false), "tangent nil") }
+    }
+
+    // #422: parity with WireCurve's count < 2 empty-array case (previously untested on EdgeCurve).
+    @Test("points(count:) below 2 returns an empty array")
+    func pointsCountBelowTwoIsEmpty() {
+        guard let e = anEdge(), let ec = EdgeCurve(e) else { #expect(Bool(false)); return }
+        #expect(ec.points(count: 1).isEmpty)
+        #expect(ec.points(count: 0).isEmpty)
+    }
+
+    // #422: parameterRange/point(atParameter:)/tangent(atParameter:) were previously only
+    // exercised indirectly, as internals of point/tangent(atAbscissa:).
+    @Test("parameterRange bounds match the edge's start/end via point(atParameter:)")
+    func parameterRangeMatchesEndpoints() {
+        guard let e = anEdge(), let ec = EdgeCurve(e) else { #expect(Bool(false)); return }
+        let range = ec.parameterRange
+        #expect(range.first < range.last)
+        guard let start = ec.point(atParameter: range.first),
+              let end = ec.point(atParameter: range.last),
+              let abscissaStart = ec.point(atAbscissa: 0),
+              let abscissaEnd = ec.point(atAbscissa: ec.length)
+        else { #expect(Bool(false), "point(atParameter:)/point(atAbscissa:) nil"); return }
+        #expect(simd_distance(start, abscissaStart) < 1e-6)
+        #expect(simd_distance(end, abscissaEnd) < 1e-6)
+        if let t = ec.tangent(atParameter: range.first) {
+            #expect(abs(simd_length(t) - 1.0) < 1e-6)
+        } else { #expect(Bool(false), "tangent(atParameter: first) nil") }
+    }
+
+    // #422: points(spacing:) was untested on both EdgeCurve and WireCurve.
+    @Test("points(spacing:) divides the edge evenly and includes both endpoints")
+    func pointsSpacing() {
+        guard let e = anEdge(), let ec = EdgeCurve(e) else { #expect(Bool(false)); return }
+        let pts = ec.points(spacing: 5)   // length 10 -> 3 points, 5 apart
+        #expect(pts.count == 3)
+        if pts.count == 3, let abscissaStart = ec.point(atAbscissa: 0), let abscissaEnd = ec.point(atAbscissa: ec.length) {
+            #expect(simd_distance(pts.first!, abscissaStart) < 1e-6)
+            #expect(simd_distance(pts.last!, abscissaEnd) < 1e-6)
+            #expect(abs(simd_distance(pts[0], pts[1]) - 5.0) < 1e-6)
+        }
+        #expect(ec.points(spacing: 0).isEmpty)          // spacing must be > 0
+        #expect(ec.points(spacing: -1).isEmpty)
     }
 }


### PR DESCRIPTION
## What & why

`EdgeCurve` (single edge, `BRepAdaptor_Curve`) and `WireCurve` (multi-edge wire, `BRepAdaptor_CompCurve`) duplicated the entire arc-length-adaptor API line-for-line on both the Swift and bridge sides — 9 members each, and 6 of 7 bridge functions (only `SampleUniform` was already shared via the pre-existing `sampleAdaptorUniform(Adaptor3d_Curve&, ...)` helper).

**Bridge (`Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`):** `Length`, `ParamRange`, `PointAtParam`, `TangentAtParam`, and `ParamAtAbscissa` are now generic `static` helpers taking `Adaptor3d_Curve&` (`adaptorLength`, `adaptorParamRange`, `adaptorPointAtParam`, `adaptorTangentAtParam`, `adaptorParamAtAbscissa`), following the exact pattern the file's own `sampleAdaptorUniform` already established. Both `struct OCCTCompCurve` and `struct OCCTEdgeCurve` are valid as `Adaptor3d_Curve&` since `BRepAdaptor_CompCurve`/`BRepAdaptor_Curve` both derive from it. Every public C entry point (`OCCTCompCurveLength`, `OCCTEdgeCurveLength`, etc.) is now a thin wrapper: null-check + `try`/`catch` (unchanged behavior) around a call into the shared helper. **No public C symbol names changed** — internal-implementation unification only, not an ABI change.

**Swift:** `EdgeCurve`/`WireCurve` stay as two distinct public classes (different bridge handle types, genuinely different OCCT adaptors) — not collapsed into one type. The issue itself doesn't mandate this either way, just diagnoses the duplication; keeping them separate is this PR's own call, made because each wraps a genuinely distinct bridge handle type (`OCCTEdgeCurveRef` vs `OCCTCompCurveRef`) and collapsing them would be a much larger, separate change. Instead, added a new public `ArcLengthCurveAdaptor` protocol (`Sources/OCCTSwift/ArcLengthCurveAdaptor.swift`) whose extension supplies `point(atAbscissa:)`, `tangent(atAbscissa:)`, and `points(spacing:)` — the 3 members that were pure composition over each type's own primitives, with zero per-type OCCT logic. Both classes now implement only the primitives (`length`, `parameterRange`, `point(atParameter:)`, `tangent(atParameter:)`, `parameter(atAbscissa:)`, `points(count:)` — each backed by its own distinct bridge call) and get the composed methods for free via protocol conformance.

## Checklist

- [x] Bridge-side duplication eliminated (6 of 7 functions now share one `Adaptor3d_Curve&` implementation; `SampleUniform` already did)
- [x] Swift-side duplication eliminated for the 3 pure-composition members via `ArcLengthCurveAdaptor`
- [x] Public C symbol names unchanged (verified via header diff — `OCCTBridge.h` untouched)
- [x] `EdgeCurve` gains the `count < 2` empty-array case for `points(count:)` (parity with `WireCurve`)
- [x] `points(spacing:)` tested on both `EdgeCurve` and `WireCurve` (previously untested on either)
- [x] `parameterRange` + `point(atParameter:)` + `tangent(atParameter:)` tested directly on both classes (previously only exercised indirectly as internals of `*(atAbscissa:)`)
- [x] `docs/CHANGELOG.md` not touched (per branch convention)

## Test results

- `swift build --target OCCTBridge` — clean
- `swift build --target OCCTCurveTests` — clean
- `swift test --filter "Issue211WireCurve"` (covers both `Issue211WireCurve` and `Issue211EdgeCurve` suites) — **11/11 passed**
- Full `swift test` — **4552 tests, 1 failure** (`RobustImportProgressTests` / "Shape.loadRobust interrupts repair, not just the transfer (#300)", `OCCTIOTests`). Unrelated to this change — it's a pre-existing, documented parallel-execution timing flake (the test's own inline comment explains two cancellation tests calibrating a deadline against a self-timed baseline can inflate each other's baseline when run concurrently). Re-ran `swift test --filter "RobustImportProgressTests"` in isolation immediately after: **3/3 passed**, confirming it's the known flake and not a regression from this PR (which only touches `EdgeCurve`/`WireCurve`/the Curve3D bridge's `CompCurve`/`EdgeCurve` section — nowhere near STEP import).

## Notes for the reviewer

- Bridge unification is complete — all 7 operations now share one `Adaptor3d_Curve&`-generic implementation.
- Swift unification is partial by design: this PR keeps `EdgeCurve`/`WireCurve` as separate types rather than collapsing them (they wrap genuinely distinct bridge handle types — `OCCTEdgeCurveRef` vs `OCCTCompCurveRef` — for a single edge vs. a multi-edge wire). The issue doesn't prescribe this — it diagnoses the duplication and leaves the fix approach open — but collapsing the two handle types is a materially bigger, riskier change than deduplicating their shared composition logic, so it's left out of scope here. I evaluated two approaches for sharing the Swift-side composition logic:
  1. An **internal** protocol/base with `public` extension methods — tested this in isolation first (see method below) and confirmed it does **not** work: Swift does not expose default implementations from an `internal`-visibility protocol's extension to callers outside the module, even when the extension methods are individually marked `public`. A consumer of `OCCTSwift` could see `point(atParameter:)` (a real member of the class) but not `point(atAbscissa:)` (only reachable through the internal protocol's extension) — this would have silently broken the public API for downstream consumers.
  2. A **public** protocol (`ArcLengthCurveAdaptor`) with `public` extension methods — verified end-to-end with a standalone two-module Swift compile (library + separate consumer module) before touching the real codebase, confirming the composed methods are correctly visible and callable cross-module. This is the approach shipped here, and it mirrors an existing precedent in this codebase (`ImportProgress`, a `public protocol ... AnyObject` with a defaulted extension method).
  - This unifies `point(atAbscissa:)`, `tangent(atAbscissa:)`, `points(spacing:)` (the only 3 members that were pure composition, i.e. built entirely from other primitives with no direct bridge call of their own). The other 6 members (`length`, `parameterRange`, `point(atParameter:)`, `tangent(atParameter:)`, `parameter(atAbscissa:)`, `points(count:)`) still have a small (2-6 line) per-type body because each calls its own distinct C bridge function — there's no further sharing possible on the Swift side without also merging `OCCTEdgeCurveRef`/`OCCTCompCurveRef` at the bridge-handle level, which this PR treats as out of scope (see note above — the issue doesn't mandate keeping them separate, this is a scoping call).
  - Net effect: the bridge-side OCCT-call duplication (the primary complaint - "differing only in the wrapped adaptor type") is fully gone. The Swift-side reduction is smaller in line count but removes 100% of what was actually *pure* duplication (identical composition logic with zero adaptor-specific code) while leaving the necessarily-per-type primitive calls in place.
- Per-issue scope: did **not** add this sampling API to `Curve3D` (flagged by the issue as a separate, out-of-scope concern).

Closes #422. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.
