### PR TITLE
fix(#421): unify Surface's four overlapping plane factories

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -288,16 +288,14 @@ bool OCCTSurfaceGetNormal(OCCTSurfaceRef s, double u, double v,
 
 // Analytic Surfaces
 
+// Exactly OCCTSurfacePlaneFromPointNormal (GC_MakePlane), a second, independent point+normal
+// plane constructor. Both throw/catch identically for a degenerate normal (ground-truthed for
+// #421: GC_MakePlane's point+normal overload adds no check beyond gp_Dir's own construction-time
+// validity), so forwarding is behaviour-preserving. Keeps the C ABI while leaving one
+// implementation.
 OCCTSurfaceRef OCCTSurfaceCreatePlane(double px, double py, double pz,
                                        double nx, double ny, double nz) {
-    try {
-        gp_Pnt origin(px, py, pz);
-        gp_Dir normal(nx, ny, nz);
-        Handle(Geom_Plane) plane = new Geom_Plane(origin, normal);
-        return new OCCTSurface(plane);
-    } catch (...) {
-        return nullptr;
-    }
+    return OCCTSurfacePlaneFromPointNormal(px, py, pz, nx, ny, nz);
 }
 
 OCCTSurfaceRef OCCTSurfaceCreateCylinder(double px, double py, double pz,
@@ -3280,15 +3278,14 @@ OCCTSurfaceRef _Nullable OCCTGceMakePlnFromEquation(double a, double b, double c
     } catch (...) { return nullptr; }
 }
 
+// Exactly OCCTSurfacePlaneFromPoints (GC_MakePlane), a second, independent 3-point plane
+// constructor. Ground-truthed for #421 (control, collinear, collinear-uneven, and both
+// coincident-point cases): GC_MakePlane and gce_MakePln's 3-point overloads agree on every case
+// tested, so forwarding is behaviour-preserving. Keeps the C ABI while leaving one implementation.
 OCCTSurfaceRef _Nullable OCCTGceMakePlnFrom3Points(double p1x, double p1y, double p1z,
                                                     double p2x, double p2y, double p2z,
                                                     double p3x, double p3y, double p3z) {
-    try {
-        gce_MakePln mp(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), gp_Pnt(p3x, p3y, p3z));
-        if (!mp.IsDone()) return nullptr;
-        Handle(Geom_Plane) plane = new Geom_Plane(mp.Value());
-        return (OCCTSurfaceRef)new OCCTSurface{plane};
-    } catch (...) { return nullptr; }
+    return OCCTSurfacePlaneFromPoints(p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z);
 }
 
 // MARK: - Geom_RectangularTrimmedSurface handle (v0.86)

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -187,12 +187,22 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Analytic Surfaces
 
-    /// Create an infinite plane from a point and normal direction
+    /// Create an infinite plane from a point and normal direction.
+    ///
+    /// A spelling of `planeFromPointNormal(point:normal:)` with unlabeled positional arguments,
+    /// and it delegates to it — the two cannot produce different planes for the same input (#421).
+    ///
+    /// - Parameters:
+    ///   - origin: A point on the plane
+    ///   - normal: Normal direction of the plane
+    /// - Returns: Plane surface, or nil if `normal` has zero (or near-zero) length
+    ///
+    /// ```swift
+    /// let ground = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))
+    /// #expect(ground != nil)
+    /// ```
     public static func plane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTSurfaceCreatePlane(origin.x, origin.y, origin.z,
-                                              normal.x, normal.y, normal.z)
-        else { return nil }
-        return Surface(handle: h)
+        planeFromPointNormal(point: origin, normal: normal)
     }
 
     /// Create a cylindrical surface
@@ -1428,13 +1438,27 @@ extension Surface {
         return Surface(handle: ref)
     }
 
-    /// Create a plane surface through three points.
+    /// Create a plane surface through three points, via `GC_MakePlane`.
+    ///
+    /// `planeFrom3Points(p1:p2:p3:)` is a labeled-argument spelling of the same construction
+    /// (`gce_MakePln` instead of `GC_MakePlane`) and delegates here — ground-truthed for #421,
+    /// the two OCCT algorithm classes agree on every case tested (well-separated, collinear, and
+    /// coincident points), so there is only one implementation.
     ///
     /// - Parameters:
     ///   - point1: First point
     ///   - point2: Second point
     ///   - point3: Third point
-    /// - Returns: Plane surface, or nil if points are collinear
+    /// - Returns: Plane surface, or nil if points are collinear (including coincident)
+    ///
+    /// ```swift
+    /// let base = Surface.planeFromPoints(SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0))
+    /// #expect(base != nil)
+    ///
+    /// // Collinear points fail construction:
+    /// let degenerate = Surface.planeFromPoints(SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(2, 0, 0))
+    /// #expect(degenerate == nil)
+    /// ```
     public static func planeFromPoints(
         _ point1: SIMD3<Double>,
         _ point2: SIMD3<Double>,
@@ -1447,12 +1471,20 @@ extension Surface {
         return Surface(handle: ref)
     }
 
-    /// Create a plane surface from a point and normal direction.
+    /// Create a plane surface from a point and normal direction, via `GC_MakePlane`.
+    ///
+    /// `plane(origin:normal:)` is an unlabeled-positional spelling of the same construction and
+    /// delegates here.
     ///
     /// - Parameters:
     ///   - point: A point on the plane
     ///   - normal: Normal direction of the plane
-    /// - Returns: Plane surface, or nil on failure
+    /// - Returns: Plane surface, or nil if `normal` has zero (or near-zero) length
+    ///
+    /// ```swift
+    /// let sheet = Surface.planeFromPointNormal(point: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1))
+    /// #expect(sheet != nil)
+    /// ```
     public static func planeFromPointNormal(
         point: SIMD3<Double>,
         normal: SIMD3<Double>
@@ -2105,13 +2137,25 @@ extension Surface {
         return Surface(handle: h)
     }
 
-    /// Create a plane from 3 points (gce_MakePln)
+    /// Create a plane from 3 points.
+    ///
+    /// A labeled-argument spelling of `planeFromPoints(_:_:_:)` (`gce_MakePln` instead of
+    /// `GC_MakePlane`), and it delegates to it — the two cannot produce different planes for the
+    /// same input (#421).
+    ///
+    /// - Parameters:
+    ///   - p1: First point
+    ///   - p2: Second point
+    ///   - p3: Third point
+    /// - Returns: Plane surface, or nil if points are collinear (including coincident)
+    ///
+    /// ```swift
+    /// let base = Surface.planeFrom3Points(p1: SIMD3(0, 0, 0), p2: SIMD3(1, 0, 0), p3: SIMD3(0, 1, 0))
+    /// #expect(base != nil)
+    /// ```
     public static func planeFrom3Points(p1: SIMD3<Double>, p2: SIMD3<Double>,
                                         p3: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTGceMakePlnFrom3Points(p1.x, p1.y, p1.z,
-                                                 p2.x, p2.y, p2.z,
-                                                 p3.x, p3.y, p3.z) else { return nil }
-        return Surface(handle: h)
+        planeFromPoints(p1, p2, p3)
     }
 
     /// Serialize surfaces to string via GeomTools_SurfaceSet

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -3069,3 +3069,101 @@ struct DrawingCompositionTests {
         #expect(counts.lines + counts.polylines > 0)
     }
 }
+
+// MARK: - #421: plane factories are unified (delegate, not reimplement)
+
+/// Four plane factories used to be four independent OCCT call paths for two operations:
+/// `planeFromPoints`/`planeFrom3Points` (3-point) and `plane(origin:normal:)`/
+/// `planeFromPointNormal` (point+normal). A ground-truth C++ test against the pinned OCCT headers
+/// (`GC_MakePlane`, `gce_MakePln`) confirmed the two 3-point algorithm classes agree on every case
+/// tried — well-separated points, collinear-but-distinct points (both evenly and unevenly
+/// spaced), one coincident pair, and all three points coincident — and that `GC_MakePlane`'s
+/// point+normal overload adds no check beyond `gp_Dir`'s own zero-length guard, matching the raw
+/// `Geom_Plane` constructor exactly. `planeFrom3Points`/`plane(origin:normal:)` now delegate to
+/// `planeFromPoints`/`planeFromPointNormal` instead of calling `gce_MakePln`/`new Geom_Plane`
+/// independently, so this coverage is a regression guard, not a live bug fix. None of these four
+/// degenerate-input cases had any test coverage before #421.
+@Suite("Surface plane factory parity (#421)")
+struct PlaneFactoryParityTests {
+
+    private func expectSamePlane(_ a: Surface?, _ b: Surface?, _ comment: Comment? = nil) {
+        #expect(a != nil, comment)
+        #expect(b != nil, comment)
+        guard let a, let b else { return }
+        let pa = a.point(atU: 0, v: 0)
+        let pb = b.point(atU: 0, v: 0)
+        #expect(abs(pa.x - pb.x) < 1e-9, comment)
+        #expect(abs(pa.y - pb.y) < 1e-9, comment)
+        #expect(abs(pa.z - pb.z) < 1e-9, comment)
+        let na = a.normal(atU: 0, v: 0)
+        let nb = b.normal(atU: 0, v: 0)
+        #expect(na != nil, comment)
+        #expect(nb != nil, comment)
+        if let na, let nb {
+            // Plane normals may point in opposite senses depending on point winding /
+            // algorithm internals; compare direction up to sign.
+            let dot = na.x * nb.x + na.y * nb.y + na.z * nb.z
+            #expect(abs(abs(dot) - 1.0) < 1e-9, comment)
+        }
+    }
+
+    // MARK: 3-point pair: planeFromPoints (GC_MakePlane, canonical) vs planeFrom3Points (delegates)
+
+    @Test("Well-separated points: both entry points agree")
+    func threePointControlMatches() {
+        let p1 = SIMD3<Double>(0, 0, 0), p2 = SIMD3<Double>(10, 0, 0), p3 = SIMD3<Double>(0, 10, 0)
+        expectSamePlane(Surface.planeFromPoints(p1, p2, p3),
+                        Surface.planeFrom3Points(p1: p1, p2: p2, p3: p3))
+    }
+
+    @Test("Collinear-but-distinct points: both entry points return nil")
+    func threePointCollinearRejectedByBoth() {
+        let p1 = SIMD3<Double>(0, 0, 0), p2 = SIMD3<Double>(1, 0, 0), p3 = SIMD3<Double>(2, 0, 0)
+        #expect(Surface.planeFromPoints(p1, p2, p3) == nil)
+        #expect(Surface.planeFrom3Points(p1: p1, p2: p2, p3: p3) == nil)
+    }
+
+    @Test("Collinear, unevenly spaced points: both entry points return nil")
+    func threePointCollinearUnevenRejectedByBoth() {
+        let p1 = SIMD3<Double>(0, 0, 0), p2 = SIMD3<Double>(0.3, 0, 0), p3 = SIMD3<Double>(5, 0, 0)
+        #expect(Surface.planeFromPoints(p1, p2, p3) == nil)
+        #expect(Surface.planeFrom3Points(p1: p1, p2: p2, p3: p3) == nil)
+    }
+
+    @Test("Two coincident points: both entry points return nil")
+    func threePointTwoCoincidentRejectedByBoth() {
+        let p1 = SIMD3<Double>(1, 1, 1), p2 = SIMD3<Double>(1, 1, 1), p3 = SIMD3<Double>(0, 1, 0)
+        #expect(Surface.planeFromPoints(p1, p2, p3) == nil)
+        #expect(Surface.planeFrom3Points(p1: p1, p2: p2, p3: p3) == nil)
+    }
+
+    @Test("All three points coincident: both entry points return nil")
+    func threePointAllCoincidentRejectedByBoth() {
+        let p = SIMD3<Double>(2, 2, 2)
+        #expect(Surface.planeFromPoints(p, p, p) == nil)
+        #expect(Surface.planeFrom3Points(p1: p, p2: p, p3: p) == nil)
+    }
+
+    // MARK: Point+normal pair: planeFromPointNormal (GC_MakePlane, canonical) vs plane (delegates)
+
+    @Test("Valid normal: both entry points agree")
+    func pointNormalControlMatches() {
+        let origin = SIMD3<Double>(5, 5, 5), normal = SIMD3<Double>(1, 1, 1)
+        expectSamePlane(Surface.planeFromPointNormal(point: origin, normal: normal),
+                        Surface.plane(origin: origin, normal: normal))
+    }
+
+    @Test("Zero-length normal: both entry points return nil")
+    func pointNormalZeroLengthRejectedByBoth() {
+        let origin = SIMD3<Double>(0, 0, 0), zero = SIMD3<Double>(0, 0, 0)
+        #expect(Surface.planeFromPointNormal(point: origin, normal: zero) == nil)
+        #expect(Surface.plane(origin: origin, normal: zero) == nil)
+    }
+
+    @Test("Near-zero-length normal: both entry points return nil")
+    func pointNormalNearZeroLengthRejectedByBoth() {
+        let origin = SIMD3<Double>(0, 0, 0), tiny = SIMD3<Double>(1e-300, 0, 0)
+        #expect(Surface.planeFromPointNormal(point: origin, normal: tiny) == nil)
+        #expect(Surface.plane(origin: origin, normal: tiny) == nil)
+    }
+}

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -462,7 +462,11 @@ the axis.
 
 ### `Surface.planeFromPoints(_:_:_:)`
 
-Creates a plane surface through three points.
+Creates a plane surface through three points. Canonical implementation for the 3-point
+constructor pair — `planeFrom3Points(p1:p2:p3:)` (below) is a labeled-argument spelling and
+delegates here (#421); a ground-truth check against the pinned OCCT headers confirmed
+`GC_MakePlane` and `gce_MakePln`'s 3-point overloads agree on every case tried (well-separated,
+collinear, and coincident points).
 
 ```swift
 public static func planeFromPoints(
@@ -473,8 +477,8 @@ public static func planeFromPoints(
 ```
 
 - **Parameters:** `point1`, `point2`, `point3` — three non-collinear points.
-- **Returns:** Plane surface, or `nil` if points are collinear.
-- **OCCT:** `Geom_Plane` from `gp_Pln` (three-point constructor).
+- **Returns:** Plane surface, or `nil` if points are collinear (including coincident).
+- **OCCT:** `GC_MakePlane(gp_Pnt, gp_Pnt, gp_Pnt)`.
 - **Example:**
   ```swift
   if let plane = Surface.planeFromPoints(
@@ -488,7 +492,9 @@ public static func planeFromPoints(
 
 ### `Surface.planeFromPointNormal(point:normal:)`
 
-Creates a plane surface from a point and normal direction.
+Creates a plane surface from a point and normal direction. Canonical implementation for the
+point+normal constructor pair — [`Surface.plane(origin:normal:)`](Surface.md) is an
+unlabeled-positional spelling and delegates here (#421).
 
 ```swift
 public static func planeFromPointNormal(
@@ -498,8 +504,8 @@ public static func planeFromPointNormal(
 ```
 
 - **Parameters:** `point` — a point on the plane; `normal` — plane normal direction.
-- **Returns:** Plane surface, or `nil` on failure.
-- **OCCT:** `Geom_Plane` from `gp_Pln(gp_Pnt, gp_Dir)`.
+- **Returns:** Plane surface, or `nil` if `normal` has zero (or near-zero) length.
+- **OCCT:** `GC_MakePlane(gp_Pnt, gp_Dir)`.
 - **Example:**
   ```swift
   if let plane = Surface.planeFromPointNormal(
@@ -1191,7 +1197,8 @@ public static func planeFromEquation(
 
 ### `Surface.planeFrom3Points(p1:p2:p3:)`
 
-Creates a plane surface from 3 points using the `gce_MakePln` factory.
+Creates a plane surface from 3 points. A labeled-argument spelling of `planeFromPoints(_:_:_:)`
+(above) and delegates to it (#421).
 
 ```swift
 public static func planeFrom3Points(
@@ -1202,8 +1209,8 @@ public static func planeFrom3Points(
 ```
 
 - **Parameters:** `p1`, `p2`, `p3` — three non-collinear points.
-- **Returns:** Plane surface, or `nil` if points are collinear.
-- **OCCT:** `gce_MakePln(gp_Pnt, gp_Pnt, gp_Pnt)`.
+- **Returns:** Plane surface, or `nil` if points are collinear (including coincident).
+- **OCCT:** `GC_MakePlane(gp_Pnt, gp_Pnt, gp_Pnt)` (via `planeFromPoints`).
 - **Example:**
   ```swift
   if let plane = Surface.planeFrom3Points(

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -310,9 +310,11 @@ public static func plane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Surfac
 
 The surface is infinite in both U and V. Trim it with `trimmed(u1:u2:v1:v2:)` or convert to a face with `toFace(uRange:vRange:)` before use in B-Rep operations.
 
+An unlabeled-positional spelling of [`planeFromPointNormal(point:normal:)`](Surface-Advanced.md) and delegates to it (#421) — the two cannot produce different planes for the same input.
+
 - **Parameters:** `origin` — a point on the plane; `normal` — outward normal direction.
-- **Returns:** `Geom_Plane` surface, or `nil` if `normal` is zero-length.
-- **OCCT:** `Geom_Plane(gp_Pnt, gp_Dir)`.
+- **Returns:** `Geom_Plane` surface, or `nil` if `normal` has zero (or near-zero) length.
+- **OCCT:** `GC_MakePlane(gp_Pnt, gp_Dir)`.
 - **Example:**
   ```swift
   let floor = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))


### PR DESCRIPTION
## What & why

`Surface.swift` had two duplicate pairs of plane-construction factories:

1. **3-point plane**: `planeFromPoints(_:_:_:)` (wraps `GC_MakePlane`) vs `planeFrom3Points(p1:p2:p3:)` (wraps `gce_MakePln`) — identical `(SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)` input, both produce a `Handle(Geom_Plane)`.
2. **Point+normal plane**: `plane(origin:normal:)` (raw `new Geom_Plane(origin, normal)`, no OCCT "Make" class) vs `planeFromPointNormal(point:normal:)` (wraps `GC_MakePlane`) — identical `(point, normal)` input.

Kept the `GC_MakePlane`-backed factory in each pair as canonical (more precise per its own header docs) and made the other member of each pair **delegate instead of reimplementing**, mirroring #412's pattern:

- `plane(origin:normal:)` now calls `planeFromPointNormal(point:normal:)`.
- `planeFrom3Points(p1:p2:p3:)` now calls `planeFromPoints(_:_:_:)`.

Both the Swift layer and the bridge C layer delegate — `OCCTSurfaceCreatePlane` forwards to `OCCTSurfacePlaneFromPointNormal`, and `OCCTGceMakePlnFrom3Points` forwards to `OCCTSurfacePlaneFromPoints` — so direct C consumers get the same behaviour without a second implementation to drift.

Also aligned all four doc comments on the same nil-condition wording (borrowing `planeFromPoints`'s original "nil if points are collinear" phrasing, extended to note coincident points too) and added a runnable `swift` snippet to each, per the project's context7-harvesting convention. Updated `docs/reference/Surface.md` and `docs/reference/Surface-Advanced.md` to match (OCCT class attribution corrected to `GC_MakePlane` for the now-canonical pair, delegation noted on both sides).

Left the call-site ergonomics difference (`planeFromPoints(_:_:_:)`'s unlabeled positional args vs `planeFrom3Points(p1:p2:p3:)`'s labeled args) as-is — not a disruptive public API rename, just a spelling difference now backed by one implementation. Could be a follow-up if it's ever worth unifying the naming convention itself.

Closes #421. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.

## Ground-truth finding (collinear-points question)

The issue flagged this as unconfirmed and asked for a ground-truth check before writing tests. Compiled a standalone `.mm` test (per `CLAUDE.md`'s "Compile a Ground Truth C++ Test" section) against the pinned OCCT headers/library, exercising both `GC_MakePlane(gp_Pnt,gp_Pnt,gp_Pnt)` and `gce_MakePln(gp_Pnt,gp_Pnt,gp_Pnt)` directly:

| Input | `GC_MakePlane` IsDone | `gce_MakePln` IsDone |
|---|---|---|
| well-separated (control) | 1 | 1 |
| collinear, evenly spaced | 0 | 0 |
| collinear, unevenly spaced | 0 | 0 |
| two points coincident | 0 | 0 |
| all three coincident | 0 | 0 |

**No divergence on any case tried** — the two classes agree exactly, despite the two overloads' header comments naming slightly different failure conditions in prose ("confused/collinear" vs "confused" only, with collinear covered by a note on a *different* overload). Also confirmed the point+normal pair's originally-suspected divergence doesn't exist either: `GC_MakePlane(gp_Pnt,gp_Dir)` and a raw `new Geom_Plane(point, normal)` both throw identically for a zero-length normal (`gp_Dir`'s own construction-time check), and both accept a `1e-20`-magnitude normal (not below `gp::Resolution()`) while both reject `1e-300` (its square underflows to exactly `0.0` in a `double`, so `gp_Dir` sees a zero-norm vector). This grounded the choice to delegate rather than trying to preserve two behaviors that were never actually different.

## Checklist

- [x] `swift build --target OCCTMathTests` — clean (only pre-existing, unrelated warnings)
- [x] `swift test --filter PlaneFactoryParityTests` — 8/8 new tests pass
- [x] `swift test --filter PlaneConstructionTests` (existing `GC_MakePlane` suite) — 2/2 pass, no regression
- [x] `swift test --filter GceMakePlnTests` (existing `gce_MakePln` suite) — 2/2 pass, no regression
- [x] Full `swift test` — 4555 tests, 1 pre-existing failure unrelated to this change (`Shape.loadRobust interrupts repair, not just the transfer (#300)`, a documented timing-calibration flake under concurrent CPU contention — its own doc comment explains the mechanism; nothing plane/Surface-related). All 8 new `PlaneFactoryParityTests` passed within the full run as well.
- [x] New/changed behavior covered by real tests: collinear-but-distinct 3 points, unevenly-spaced collinear, two/three coincident points, zero-length normal, near-zero-length (sub-representable) normal, plus parity assertions (same evaluated origin + normal direction) for valid input on both spellings of each pair.
- [x] Docs updated in the same PR (`docs/reference/Surface.md`, `docs/reference/Surface-Advanced.md`) — no `docs/CHANGELOG.md` touch per instructions.

## Notes for the reviewer

- The original audit's specific claim (a degenerate-normal divergence between `plane(origin:normal:)` and `planeFromPointNormal`) did not hold — both already threw/caught identically. This PR is consolidation + closing a real test gap, not a live-bug fix, consistent with what the issue itself flagged.
- Canonical-vs-delegate choice: `GC_MakePlane`-backed factories won both pairs, per the issue's own suggested tie-break (their header docs are the more precise of the two classes' docs) — this was a design choice, not something the ground truth forced, since behavior was proven identical either way.
- Did not touch the existing weak-assertion tests in `PlaneConstructionTests`/`GceMakePlnTests` (`GceMakePlnTests.planeFrom3Points()` in particular has the `if let plane = ... { #expect(Bool(true)) }` pattern flagged in the issue) — left them as smoke tests alongside the new, stronger `PlaneFactoryParityTests` suite rather than rewriting call sites out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
