### PR TITLE
fix(#419): dedup flat-buffer→[SIMD3] unpack, fix sampleFaceUVGrid count divergence

### DIFF
--- a/Sources/OCCTSwift/Annotation.swift
+++ b/Sources/OCCTSwift/Annotation.swift
@@ -287,9 +287,7 @@ public final class PointCloud: @unchecked Sendable {
         guard n > 0 else { return [] }
         var coords = [Double](repeating: 0, count: n * 3)
         let copied = OCCTPointCloudGetPoints(handle, &coords, Int32(n))
-        return (0..<Int(copied)).map { i in
-            SIMD3(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2])
-        }
+        return unpackSIMD3(coords, count: Int(copied))
     }
 
     /// Get all point colors (empty if uncolored)
@@ -299,9 +297,7 @@ public final class PointCloud: @unchecked Sendable {
         var cols = [Float](repeating: 0, count: n * 3)
         let copied = OCCTPointCloudGetColors(handle, &cols, Int32(n))
         guard copied > 0 else { return [] }
-        return (0..<Int(copied)).map { i in
-            SIMD3(cols[i * 3], cols[i * 3 + 1], cols[i * 3 + 2])
-        }
+        return unpackSIMD3(cols, count: Int(copied))
     }
 }
 

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -2021,20 +2021,19 @@ public final class BRepGraph: @unchecked Sendable {
 
         guard result > 0 else { return nil }
 
-        var positions = [SIMD3<Double>]()
-        positions.reserveCapacity(total)
-        var normals = [SIMD3<Double>]()
-        normals.reserveCapacity(total)
-        for i in 0..<total {
-            positions.append(SIMD3(posBuffer[i * 3], posBuffer[i * 3 + 1], posBuffer[i * 3 + 2]))
-            normals.append(SIMD3(nrmBuffer[i * 3], nrmBuffer[i * 3 + 1], nrmBuffer[i * 3 + 2]))
-        }
+        // Unpack only the actually-written count (`result`), not the requested `total` — today
+        // the bridge is all-or-nothing so the two coincide, but nothing should assume that stays
+        // true (see #419). Truncate the scalar buffers to match for the same reason: all four
+        // outputs must agree on how many samples are actually valid.
+        let written = Int(result)
+        let positions: [SIMD3<Double>] = unpackSIMD3(posBuffer, count: written)
+        let normals: [SIMD3<Double>] = unpackSIMD3(nrmBuffer, count: written)
 
         return FaceGridSample(
             positions: positions,
             normals: normals,
-            gaussianCurvatures: gaussBuffer,
-            meanCurvatures: meanBuffer,
+            gaussianCurvatures: Array(gaussBuffer.prefix(written)),
+            meanCurvatures: Array(meanBuffer.prefix(written)),
             uSamples: uSamples,
             vSamples: vSamples
         )
@@ -2054,12 +2053,7 @@ public final class BRepGraph: @unchecked Sendable {
             OCCTBRepGraphSampleEdgeCurve(handle, Int32(edgeIndex), Int32(count), buf.baseAddress!)
         }
         guard result > 0 else { return [] }
-        var points = [SIMD3<Double>]()
-        points.reserveCapacity(Int(result))
-        for i in 0..<Int(result) {
-            points.append(SIMD3(buffer[i * 3], buffer[i * 3 + 1], buffer[i * 3 + 2]))
-        }
-        return points
+        return unpackSIMD3(buffer, count: Int(result))
     }
 
     // MARK: - Durable Identity (UID / RefUID / ItemUID) — OCCT 8.0.0p1

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -334,7 +334,7 @@ public final class Curve3D: @unchecked Sendable {
         var buffer = [Double](repeating: 0, count: n * 3)
         let actual = Int(OCCTCurve3DGetPoles(handle, &buffer))
         guard actual > 0 else { return nil }
-        return (0..<actual).map { i in SIMD3(buffer[i*3], buffer[i*3+1], buffer[i*3+2]) }
+        return unpackSIMD3(buffer, count: actual)
     }
 
     /// Degree of BSpline/Bezier curve (-1 if not applicable)
@@ -479,14 +479,14 @@ public final class Curve3D: @unchecked Sendable {
         var buffer = [Double](repeating: 0, count: maxPoints * 3)
         let n = Int(OCCTCurve3DDrawAdaptive(handle, angularDeflection, chordalDeflection,
                                              &buffer, Int32(maxPoints)))
-        return (0..<n).map { SIMD3(buffer[$0*3], buffer[$0*3+1], buffer[$0*3+2]) }
+        return unpackSIMD3(buffer, count: n)
     }
 
     /// Uniform arc-length spacing discretization
     public func drawUniform(pointCount: Int) -> [SIMD3<Double>] {
         var buffer = [Double](repeating: 0, count: pointCount * 3)
         let n = Int(OCCTCurve3DDrawUniform(handle, Int32(pointCount), &buffer))
-        return (0..<n).map { SIMD3(buffer[$0*3], buffer[$0*3+1], buffer[$0*3+2]) }
+        return unpackSIMD3(buffer, count: n)
     }
 
     /// Chordal deflection discretization
@@ -494,7 +494,7 @@ public final class Curve3D: @unchecked Sendable {
                                maxPoints: Int = 4096) -> [SIMD3<Double>] {
         var buffer = [Double](repeating: 0, count: maxPoints * 3)
         let n = Int(OCCTCurve3DDrawDeflection(handle, deflection, &buffer, Int32(maxPoints)))
-        return (0..<n).map { SIMD3(buffer[$0*3], buffer[$0*3+1], buffer[$0*3+2]) }
+        return unpackSIMD3(buffer, count: n)
     }
 
     // MARK: - Local Properties
@@ -575,7 +575,7 @@ extension Curve3D {
         guard !parameters.isEmpty else { return [] }
         var outXYZ = [Double](repeating: 0, count: parameters.count * 3)
         let n = Int(OCCTCurve3DEvaluateGrid(handle, parameters, Int32(parameters.count), &outXYZ))
-        return (0..<n).map { i in SIMD3(outXYZ[i * 3], outXYZ[i * 3 + 1], outXYZ[i * 3 + 2]) }
+        return unpackSIMD3(outXYZ, count: n)
     }
 
     /// Evaluate the curve and its first derivative at multiple parameters in one call.
@@ -587,10 +587,9 @@ extension Curve3D {
         var outXYZ = [Double](repeating: 0, count: parameters.count * 3)
         var outDXDYDZ = [Double](repeating: 0, count: parameters.count * 3)
         let n = Int(OCCTCurve3DEvaluateGridD1(handle, parameters, Int32(parameters.count), &outXYZ, &outDXDYDZ))
-        return (0..<n).map { i in
-            (point: SIMD3(outXYZ[i * 3], outXYZ[i * 3 + 1], outXYZ[i * 3 + 2]),
-             tangent: SIMD3(outDXDYDZ[i * 3], outDXDYDZ[i * 3 + 1], outDXDYDZ[i * 3 + 2]))
-        }
+        let points: [SIMD3<Double>] = unpackSIMD3(outXYZ, count: n)
+        let tangents: [SIMD3<Double>] = unpackSIMD3(outDXDYDZ, count: n)
+        return zip(points, tangents).map { (point: $0, tangent: $1) }
     }
 
     /// Check if this curve is planar.
@@ -931,12 +930,7 @@ extension Curve3D {
     public func samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> [SIMD3<Double>] {
         var buffer = [Double](repeating: 0, count: maxPoints * 3)
         let count = OCCTCurve3DGetSamplePoints3D(handle, first, last, &buffer, Int32(maxPoints))
-        var points = [SIMD3<Double>]()
-        points.reserveCapacity(Int(count))
-        for i in 0..<Int(count) {
-            points.append(SIMD3(buffer[i*3], buffer[i*3+1], buffer[i*3+2]))
-        }
-        return points
+        return unpackSIMD3(buffer, count: Int(count))
     }
 
     // MARK: - v0.50.0: Arc construction, periodic conversion, splitting

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -6191,7 +6191,7 @@ public enum IntAna {
                                 torusAxis.x, torusAxis.y, torusAxis.z,
                                 majorRadius, minorRadius, buf.baseAddress!)
         }
-        return (0..<Int(n)).map { i in SIMD3(buffer[i*3], buffer[i*3+1], buffer[i*3+2]) }
+        return unpackSIMD3(buffer, count: Int(n))
     }
 }
 

--- a/Sources/OCCTSwift/SIMD3Unpacking.swift
+++ b/Sources/OCCTSwift/SIMD3Unpacking.swift
@@ -1,0 +1,43 @@
+//
+//  SIMD3Unpacking.swift
+//  OCCTSwift
+//
+//  Shared helper for the flat, tightly-packed (x0,y0,z0, x1,y1,z1, ...) buffer
+//  layout the bridge uses for every batch position/normal/pole/point query.
+//
+//  Driver: issue #419 (the #377/#380 duplication audit) — the 3-stride unpack
+//  expression `SIMD3(buf[i*3], buf[i*3+1], buf[i*3+2])` was reimplemented at
+//  dozens of call sites with no shared conversion point, and two of those
+//  copies (BRepGraph's `sampleFaceUVGrid`/`sampleEdgeCurve`) had already
+//  drifted on which count bounds the loop — one trusted the *requested*
+//  sample count, the other the *actual* count the bridge reported writing.
+//
+
+/// Unpacks a flat, tightly-packed `(x0,y0,z0, x1,y1,z1, ...)` buffer into `[SIMD3<Scalar>]`.
+///
+/// `count` is the number of `SIMD3` elements to read — always the *actual* number of valid
+/// entries in `buffer` (typically a bridge call's own returned/written count), never a
+/// requested or upper-bound count. Passing a requested count for a buffer a bridge call only
+/// partially filled would read stale or uninitialized entries past the true written range.
+///
+/// Works for any random-access, `Int`-indexed buffer of a SIMD-compatible scalar — a plain
+/// `[Double]`/`[Float]` array, or an `UnsafeBufferPointer`/`UnsafeMutableBufferPointer` obtained
+/// from `withUnsafe(Mutable)BufferPointer`.
+///
+/// ```swift
+/// let flat: [Double] = [1, 2, 3, 4, 5, 6]
+/// let points = unpackSIMD3(flat, count: 2)
+/// #expect(points == [SIMD3(1, 2, 3), SIMD3(4, 5, 6)])
+/// ```
+internal func unpackSIMD3<Buffer: RandomAccessCollection, Scalar>(
+    _ buffer: Buffer, count: Int
+) -> [SIMD3<Scalar>] where Buffer.Element == Scalar, Buffer.Index == Int, Scalar: SIMDScalar {
+    guard count > 0 else { return [] }
+    var result = [SIMD3<Scalar>]()
+    result.reserveCapacity(count)
+    for i in 0..<count {
+        let base = buffer.startIndex + i * 3
+        result.append(SIMD3(buffer[base], buffer[base + 1], buffer[base + 2]))
+    }
+    return result
+}

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -12815,14 +12815,8 @@ public func mergedMeshNodes(from shape: Shape,
 
     let nv = Int(nVerts)
     let nt = Int(triCount)
-    var verts = [SIMD3<Float>]()
-    verts.reserveCapacity(nv)
-    var norms = [SIMD3<Float>]()
-    norms.reserveCapacity(nv)
-    for i in 0..<nv {
-        verts.append(SIMD3(vertices[i*3], vertices[i*3+1], vertices[i*3+2]))
-        norms.append(SIMD3(normals[i*3], normals[i*3+1], normals[i*3+2]))
-    }
+    let verts: [SIMD3<Float>] = unpackSIMD3(vertices, count: nv)
+    let norms: [SIMD3<Float>] = unpackSIMD3(normals, count: nv)
     let idxSlice = Array(indices.prefix(nt * 3))
 
     return MergedMeshData(vertices: verts, normals: norms, indices: idxSlice,

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -532,12 +532,7 @@ public final class Surface: @unchecked Sendable {
         guard n == total else { return .empty }
 
         // Bridge buffer is already U-major (idx = u * vCount + v), matching SurfaceGrid's storage.
-        var points = [SIMD3<Double>]()
-        points.reserveCapacity(total)
-        for idx in 0..<total {
-            let base = idx * 3
-            points.append(SIMD3(buffer[base], buffer[base + 1], buffer[base + 2]))
-        }
+        let points: [SIMD3<Double>] = unpackSIMD3(buffer, count: total)
         return SurfaceGrid(uCount: uCount, vCount: vCount, points: points)
     }
 
@@ -2572,12 +2567,7 @@ extension Surface {
         guard uCount > 0 && vCount > 0 else { return [] }
         var flat = [Double](repeating: 0, count: uCount * vCount * 3)
         OCCTSurfaceBSplineGetPoles(handle, &flat)
-        var result = [SIMD3<Double>]()
-        result.reserveCapacity(uCount * vCount)
-        for i in stride(from: 0, to: flat.count, by: 3) {
-            result.append(SIMD3(flat[i], flat[i + 1], flat[i + 2]))
-        }
-        return result
+        return unpackSIMD3(flat, count: uCount * vCount)
     }
 
     /// Get parameter bounds for BSpline surface.
@@ -2653,12 +2643,7 @@ extension Surface {
         guard uCount > 0 && vCount > 0 else { return [] }
         var flat = [Double](repeating: 0, count: uCount * vCount * 3)
         OCCTSurfaceBezierGetPoles(handle, &flat)
-        var result = [SIMD3<Double>]()
-        result.reserveCapacity(uCount * vCount)
-        for i in stride(from: 0, to: flat.count, by: 3) {
-            result.append(SIMD3(flat[i], flat[i + 1], flat[i + 2]))
-        }
-        return result
+        return unpackSIMD3(flat, count: uCount * vCount)
     }
 
     /// Get all weights as flat array for Bezier surface. Returns nil if non-rational.

--- a/Sources/OCCTSwift/Wire.swift
+++ b/Sources/OCCTSwift/Wire.swift
@@ -1200,7 +1200,7 @@ extension Wire {
         guard OCCTWireExplorerGetEdge(handle, Int32(index), &buffer, Int32(limit), &pointCount)
         else { return nil }
         let n = Int(pointCount)
-        return (0..<n).map { i in SIMD3(buffer[i * 3], buffer[i * 3 + 1], buffer[i * 3 + 2]) }
+        return unpackSIMD3(buffer, count: n)
     }
 }
 

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -1769,6 +1769,52 @@ struct BRepGraphEdgeSamplingTests {
     }
 }
 
+// MARK: - unpackSIMD3 shared helper (#419)
+
+@Suite("unpackSIMD3 shared helper")
+struct UnpackSIMD3Tests {
+    @Test("Exact index-to-component mapping for a known flat buffer")
+    func exactMapping() {
+        let flat: [Double] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let points: [SIMD3<Double>] = unpackSIMD3(flat, count: 3)
+        #expect(points.count == 3)
+        #expect(points == [SIMD3(1, 2, 3), SIMD3(4, 5, 6), SIMD3(7, 8, 9)])
+    }
+
+    @Test("count: 0 returns an empty array")
+    func zeroCountIsEmpty() {
+        let flat: [Double] = [1, 2, 3]
+        let points: [SIMD3<Double>] = unpackSIMD3(flat, count: 0)
+        #expect(points.isEmpty)
+    }
+
+    @Test("Only reads the first `count` triples, never buffer entries past it")
+    func stopsAtActualCountNotBufferLength() {
+        // The whole point of #419: the caller passes the ACTUAL written count, and the
+        // helper must never read past it even though the backing buffer is larger —
+        // this is exactly the divergence that made sampleFaceUVGrid unsafe.
+        let flat: [Double] = [1, 2, 3, 999, 999, 999]
+        let points: [SIMD3<Double>] = unpackSIMD3(flat, count: 1)
+        #expect(points == [SIMD3(1, 2, 3)])
+    }
+
+    @Test("Works generically for a Float scalar buffer")
+    func floatScalarBuffer() {
+        let flat: [Float] = [1, 2, 3, 4, 5, 6]
+        let points: [SIMD3<Float>] = unpackSIMD3(flat, count: 2)
+        #expect(points == [SIMD3<Float>(1, 2, 3), SIMD3<Float>(4, 5, 6)])
+    }
+
+    @Test("Works for an UnsafeBufferPointer, not just a plain Array")
+    func unsafeBufferPointerBuffer() {
+        let flat: [Double] = [1, 2, 3, 4, 5, 6]
+        let points: [SIMD3<Double>] = flat.withUnsafeBufferPointer { buf in
+            unpackSIMD3(buf, count: 2)
+        }
+        #expect(points == [SIMD3(1, 2, 3), SIMD3(4, 5, 6)])
+    }
+}
+
 // MARK: - v0.141 / #72 Phase 0: BRepGraph history record readback
 
 @Suite("v0.141 BRepGraph history record readback")


### PR DESCRIPTION
## What & why

The 3-stride flat-array→`SIMD3<Double>` unpack expression `SIMD3(buf[i*3], buf[i*3+1], buf[i*3+2])` was reimplemented at dozens of call sites across `Sources/OCCTSwift/` with no shared conversion point. Two copies in `BRepGraph.swift` — `sampleFaceUVGrid` and `sampleEdgeCurve` — had already drifted on the one thing that matters for this pattern: which count bounds the loop. `sampleFaceUVGrid` iterated `0..<total` (the *requested* `uSamples * vSamples`), while `sampleEdgeCurve` iterated `0..<Int(result)` (the *actual* count the bridge reported writing). They only agreed because today's bridge functions are all-or-nothing; nothing pinned the two loops together, so a future bridge change to short-circuit (returning a partial count) would make `sampleFaceUVGrid` silently read stale/uninitialized buffer entries while `sampleEdgeCurve` stayed safe.

This PR:
1. Adds a shared, generic helper `unpackSIMD3(_:count:)` (`Sources/OCCTSwift/SIMD3Unpacking.swift`) — generic over any `RandomAccessCollection` with `Int` index and a `SIMDScalar` element, so it works for both `[Double]`/`[Float]` arrays and `UnsafeBufferPointer`.
2. Routes `sampleFaceUVGrid` and `sampleEdgeCurve` through it. **Critically**, `sampleFaceUVGrid` now unpacks the bridge's actual written count (`result`), not the requested `total` — eliminating the latent divergence, not just the duplication. `gaussianCurvatures`/`meanCurvatures` are now truncated to the same actual count for the same reason (all four outputs of `FaceGridSample` must agree on how many samples are valid).
3. Routes 8 other clean-fit sites through the same helper: `Annotation.swift` (`PointCloud.points`, `PointCloud.colors` — the latter is `SIMD3<Float>`, exercising the helper's generic scalar support), `Curve3D.swift` (`poles`, `drawAdaptive`, `drawUniform`, `drawDeflection`, `evaluateGrid`, `evaluateGridD1`, `samplePoints`), `Document.swift` (`IntAna.lineTorus`), `Surface.swift` (`drawMesh`, `bsplinePoles`, `bezierPoles`), `Wire.swift` (`orderedEdgePoints`), `Shape.swift` (`mergedMeshNodes`).
4. Adds a direct unit-test suite for the helper itself (`UnpackSIMD3Tests` in `Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`): exact index-to-component mapping, `count: 0`, the "never reads past the actual count" property that's the whole point of the fix, `Float` scalar support, and an `UnsafeBufferPointer` buffer.

Closes #419. Part of the #380 / #377 duplication audit — targets `refactor/377-segmented-audit`, not `main`.

## Checklist

- [x] New/changed behavior covered by a real test (`UnpackSIMD3Tests`, 5 tests)
- [x] Existing `BRepGraphUVGridTests` / `BRepGraphEdgeSamplingTests` still pass (all-or-nothing bridge behavior unchanged, so `written == total` in every existing test)
- [x] No force-unwraps inside `#expect`
- [x] `docs/CHANGELOG.md` untouched (per issue instructions)

## Test results

- `swift build --target OCCTSwift`: clean, no new warnings
- `swift test --filter "BRepGraphUVGridTests|BRepGraphEdgeSamplingTests|UnpackSIMD3Tests"`: 15/15 passed
- `swift test --filter "OCCTSurfaceTests|OCCTCurveTests|OCCTMeshTests|OCCTTopologyTests|OCCTAnalysisTests"` (covers all 6 "other" files touched): 1684/1684 passed
- Full `swift test`: **4552 tests in 1309 suites passed** (62.2s), 0 failures

## Notes for the reviewer

The issue named one representative line per "other" file, but every one of those had drifted (the issue was filed against an older revision) — e.g. `Shape.swift:12905` is now `OCCTCoherentTriangulationRemoveDegenerated`, unrelated to any unpack. I located the current equivalent site by content/purpose rather than by line number, and converted it plus any obviously-identical siblings in the immediate vicinity:

- **Annotation.swift** — both cited sites (`points`, `colors`) converted; lines matched exactly (291, 303), no drift.
- **Curve3D.swift** — converted 8 sites total (`poles`, the `drawAdaptive`/`drawUniform`/`drawDeflection` triplet, `evaluateGrid`, `evaluateGridD1`, `samplePoints`). More than the 2 originally cited, but this file is small/cohesive and every one of these is a byte-identical copy of the same bug-prone loop, so I converted the lot rather than leaving 6 near-duplicates of the ones I did fix.
- **Document.swift** — converted only `IntAna.lineTorus` (array-based, clean drop-in). Left `IntAna.linePlane`/`lineSphere`/`quadQuadResultFromC`/`Bezier.toBSpline`'s poles alone: they unpack via `withMemoryRebound`/`withUnsafeBytes` over a fixed-size C tuple, not a `[Double]`/`UnsafeBufferPointer` — a genuinely different consumption shape from what `unpackSIMD3` targets, and one of those sites (`linePlane`) has an unrelated pre-existing dead-code oddity (a discarded first computation immediately re-computed "properly") that's out of scope here.
- **Surface.swift** — converted `drawMesh`, `bsplinePoles`, `bezierPoles` (flat, single 0..<count loop). Left `drawGrid` (ragged per-line 2D output) and the 2D `poles` property (`[[SIMD3<Double>]]`, nested `u`/`v` indexing) alone — both produce nested/ragged structures, not a flat drop-in for `(buffer, count) -> [SIMD3]`.
- **Wire.swift** — the cited site (1203) matched exactly, converted.
- **Shape.swift** — converted `mergedMeshNodes` (closest current match to the cited line, and itself a two-buffer vertex+normal pair structurally identical to `sampleFaceUVGrid`'s bug shape). Shape.swift is ~13k lines and a broader grep turns up well over a dozen more instances of the identical pattern (`drawGrid`/mesh helpers throughout the file) — confirming the issue's own "dozens more times" note. Converting all of them is out of proportion to this issue's scope (1 cited site) and risk (13k-line file); left for a dedicated follow-up in the #377/#380 series, same as how #443 was split out from #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
