### PR TITLE
Enforce type:*/priority:* labels on new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a crash, incorrect result, or unexpected behavior
-labels: ["bug"]
+labels: ["type:bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Request a new OCCT operation, API improvement, or integration
-labels: ["enhancement"]
+labels: ["type:feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/require-issue-labels.yml
+++ b/.github/workflows/require-issue-labels.yml
@@ -1,0 +1,62 @@
+name: Require Issue Labels
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for type:* and priority:* labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- require-issue-labels -->';
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const hasType = labels.some(l => l.startsWith('type:'));
+            const hasPriority = labels.some(l => l.startsWith('priority:'));
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.data.find(c => c.body.includes(marker));
+
+            if (hasType && hasPriority) {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: `${marker}\nLabeled — thanks!`,
+                });
+              }
+              return;
+            }
+
+            const missing = [];
+            if (!hasType) missing.push('a `type:*` label (e.g. `type:bug`, `type:feature`, `type:chore`, `type:epic`, `type:spike`, `type:docs`)');
+            if (!hasPriority) missing.push('a `priority:*` label (`priority:P0`–`priority:P3`)');
+
+            const body = `${marker}\nThis issue is missing ${missing.join(' and ')}. Please add the appropriate label so it shows up correctly in triage.`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary
- Fix `bug_report.yml`/`feature_request.yml` to apply `type:bug`/`type:feature` instead of the legacy `bug`/`enhancement` labels — the templates were stale against the `type:*` taxonomy already in use on recent issues.
- Add `require-issue-labels.yml`: on `issues: [opened, labeled, unlabeled, reopened]`, posts (and updates in place) a sticky comment naming any missing `type:*`/`priority:*` label. Non-blocking — issues have no merge gate — and covers blank/free-form issues that bypass the templates entirely (`blank_issues_enabled: true`).

Follow-up to the label taxonomy pass applied across all 51 open issues (refactor/phase labels for the #377 duplication-audit lineage, type/priority for the rest).

## Test plan
- [ ] Open a blank issue with no labels, confirm the bot comments listing both missing labels
- [ ] Add `type:bug` only, confirm the comment updates to note only `priority:*` is missing
- [ ] Add `priority:P2`, confirm the comment updates to "Labeled — thanks!"
- [ ] Open a Bug Report / Feature Request via template, confirm it lands with `type:bug` / `type:feature` pre-applied