### PR TITLE
okf: add issue-tracking policy doc

### DIFF
--- a/okf/index.md
+++ b/okf/index.md
@@ -48,3 +48,4 @@ See [`references/`](references/index.md) — OpenCASCADE upstream and licensing 
 - [No em-dashes, banned words in prose](policies/writing-style.md)
 - [Search before building](policies/search-before-building.md)
 - [Upstream OCCT PRs follow OCCT's house style](policies/upstream-occt-style.md)
+- [Issue labels and project-board tracking](policies/issue-tracking.md)

--- a/okf/policies/issue-tracking.md
+++ b/okf/policies/issue-tracking.md
@@ -1,0 +1,22 @@
+---
+type: policy
+title: Issue labels and project-board tracking
+description: Every issue carries a type:* and priority:* label, enforced by CI; multi-phase initiatives get a dedicated project board. See Issue tracking.
+tags: [policy, issues, labels, project-board, triage]
+timestamp: 2026-07-29
+---
+
+# Issue labels and project-board tracking
+
+Every issue carries a `type:*` label and a `priority:*` label. `.github/workflows/require-issue-labels.yml`
+enforces this: a non-blocking sticky comment names whichever is missing, including on blank issues that
+bypass `.github/ISSUE_TEMPLATE/`, whose own templates already apply the correct `type:*` on arrival.
+
+Multi-phase initiatives (the #377 duplication audit, 46 issues across 13 phases) get a dedicated
+GitHub Project scoped to that initiative's own issues, with a `Status` field matching its real
+workflow stages (Backlog, In Progress, PR Review, Code-Review, Ready, Done) rather than the generic
+Todo/In Progress/Done default: [OCCTSwift Refactor (#377)](https://github.com/orgs/SecondMouseAU/projects/2).
+`refactor` + `phase:*` labels identify which issues belong to it.
+
+For the full rule and rationale, follow the authoritative **Issue tracking** section in
+[OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md).


### PR DESCRIPTION
## Summary
- Adds `okf/policies/issue-tracking.md`, the 5th mandatory `okf/` policy per [ecosystem#27](https://github.com/SecondMouseAU/ecosystem/pull/27) (adding the corresponding "Issue tracking" section to `OKF-STANDARD.md`).
- Links it from `okf/index.md` alongside the other four.

Documents the pattern applied to this repo's own #377 duplication audit: `type:*`/`priority:*` labels enforced by [#471](https://github.com/SecondMouseAU/OCCTSwift/pull/471), and the 46 `refactor`-labeled issues tracked on their own [dedicated project board](https://github.com/orgs/SecondMouseAU/projects/2) rather than the shared org-wide Control Tower.

## Test plan
- [ ] Confirm `okf/index.md` renders the new policy link correctly
- [ ] Merge alongside (or after) ecosystem#27, since this doc points at that PR's OKF-STANDARD.md section