### PR TITLE
ci: add Tier 1 (CI) and Tier 2 (release verification) workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+# Fast per-PR/per-push gate. Deliberately does NOT rebuild OCCT from source (that's
+# kernel-rebuild.yml's job, ~30-60 min) — a clean checkout has no local Libraries/, so
+# Package.swift's binaryTarget resolves OCCT.xcframework from its pinned release URL and
+# verifies the checksum, which only costs a download. OCCTBridge compiles from source by
+# default (no OCCTSWIFT_BRIDGE_PREBUILT set) — that's the repo's own intended default, see
+# the comment above `useBridgePrebuilt` in Package.swift, and it's a couple of minutes, not
+# tens of minutes.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'refactor/**'
+  push:
+    branches:
+      - main
+      - 'refactor/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: swift build + test (macOS)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # README states Xcode 16.0+ / Swift 6.1+. latest-stable tracks forward as the
+          # runner image updates; pin to an explicit version here if that ever regresses.
+          xcode-version: latest-stable
+
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: swift build
+        run: swift build
+
+      - name: swift test
+        run: swift test
+
+  ios-simulator-build:
+    name: swift build (iOS Simulator, smoke)
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-ios-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-ios-
+
+      # Build-only: catches #if os(iOS) / platform-conditional breakage without the cost
+      # or flakiness of booting a simulator to run the full suite there too.
+      - name: xcodebuild for iOS Simulator
+        run: |
+          xcodebuild build \
+            -scheme OCCTSwift \
+            -destination 'generic/platform=iOS Simulator'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release verification
+
+# Confirms the binary pins in Package.swift (OCCT.xcframework + OCCTBridge.xcframework,
+# each a url:/checksum: pair) actually resolve and checksum-match a real release asset.
+# `swift build` on a clean checkout (no local Libraries/) is what does the real work here —
+# SwiftPM downloads each binaryTarget from its pinned URL and fails loudly on a checksum
+# mismatch or a 404, which is exactly the "forgot to bump both url and checksum" class of
+# mistake the comments in Package.swift already warn about by hand. `swift test` on top
+# confirms the tagged commit itself is genuinely healthy, not just that its binary pins
+# resolve.
+#
+# Triggered by the GitHub Release publish event rather than a raw tag push, since assets are
+# expected to be attached by the time a release is published. If an xcframework gets
+# rebuilt/republished as a follow-up fix after the release already published (this repo has
+# done that — see the v1.16.1 "Republish prebuilt OCCTBridge.xcframework" commit), re-run
+# this workflow manually via workflow_dispatch, selecting the tag as the ref, once the
+# replacement asset is uploaded.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  verify-binary-pins:
+    name: Verify binary pins + tagged build
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Show pinned binary targets
+        run: |
+          echo "Package.swift binaryTarget pins for this ref:"
+          grep -B1 -E 'url:|checksum:' Package.swift | grep -E 'releases/download|checksum:'
+
+      - name: swift build (forces binaryTarget download + checksum verification)
+        run: swift build
+
+      - name: swift test
+        run: swift test


### PR DESCRIPTION
## What & why

Zero automated CI exists on this repo today — no branch protection on `main`, and the one
existing workflow (`occt-parallel-crash-test.yml`) is `workflow_dispatch`-only, pinned to a
stale `V8_0_0_rc5`. Adds the Tier 1 + Tier 2 workflows from the OCCTSwift/ecosystem release
planning discussion.

**`ci.yml`** — per-PR/per-push gate (`main` and `refactor/**`, matching how this repo
actually routes PRs — e.g. #377's children target `refactor/377-segmented-audit`, not
`main`):
- `swift build` + `swift test` on macOS. Deliberately does **not** rebuild OCCT from source
  (that's a separate, future Tier 3 `kernel-rebuild.yml` job, ~30-60 min) — a clean checkout
  has no local `Libraries/`, so `Package.swift`'s `OCCT` binaryTarget resolves from its
  pinned release URL and SwiftPM verifies the checksum itself. `OCCTBridge` compiles from
  source by default (no `OCCTSWIFT_BRIDGE_PREBUILT` set), which is already this repo's
  intended default per the comment above `useBridgePrebuilt` in `Package.swift`.
- A second, build-only iOS Simulator leg to catch `#if os(iOS)` breakage cheaply, via
  `xcodebuild -scheme OCCTSwift -destination 'generic/platform=iOS Simulator'`.
- SwiftPM artifact caching keyed on `Package.swift`'s hash.

**`release.yml`** — on GitHub Release publish, re-runs the same binaryTarget resolution
against the tagged commit specifically. `swift build` forces both `OCCT` and `OCCTBridge`
binaryTargets to download and checksum-verify — exactly the "forgot to bump both url and
checksum" mistake the comments in `Package.swift` already warn about by hand. `swift test`
on top confirms the tagged commit is genuinely healthy, not just that its pins resolve.
Also runnable via `workflow_dispatch` (select the tag as the ref) for re-verifying after an
asset gets republished post-release, as `v1.16.1`'s "Republish prebuilt OCCTBridge.xcframework"
commit did.

Both workflows use `xcode-version: latest-stable` (README states Xcode 16.0+ / Swift 6.1+
required) — pin to an explicit version if the runner image ever regresses below that.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A, this PR adds CI infrastructure, not application behavior; the
      workflows are self-verifying (this PR's own CI run against itself is the test).

## Notes for the reviewer

- Both workflow files pass a YAML syntax check (`ruby -ryaml`) and the `release.yml`
  binary-pin grep step was dry-run against the current `Package.swift` — clean output for
  both `OCCT` and `OCCTBridge` pins.
- Recommend letting `ci.yml` prove green here and on a couple more PRs before turning on
  required status checks / branch protection on `main` — not retroactively blocking the
  already-in-review Pass 1a merge (#474) on a brand-new, unproven workflow.
- Tier 3 (`kernel-rebuild.yml` for OCCT-from-source rebuilds/patch validation,
  `tsan-nightly.yml` for `Scripts/tsan-stress.sh`) is intentionally not in this PR — lower
  urgency, separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)