### PR TITLE
fix(#484): two upstream null-context SIGSEGVs patched, Face.fixed given a context, connectedFaces covered and de-first-of-N'd

### DIFF
--- a/Scripts/check-bridge-index.py
+++ b/Scripts/check-bridge-index.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Verify OCCTBridge.h's OCCT-class → bridge-symbol cross-reference index.
+
+The index at the top of `Sources/OCCTBridge/include/OCCTBridge.h` maps each wrapped
+OCCT class to the bridge symbols that wrap it. It is hand-maintained, so a rename
+leaves it pointing at a symbol that no longer exists — and since the index is the
+map people use to find every call site of an OCCT class, a stale entry hides real
+work. That is exactly how #484's unpatched fourth `ShapeFix_Face` call site was
+missed: the index named `OCCTShapeFixFace`, which exists nowhere, so a re-audit of
+`ShapeFix_Face` call sites by symbol name found nothing.
+
+A trailing `*` in an index entry means "family prefix": at least one real symbol
+must start with it.
+
+Usage (from the repo root):
+
+    python3 Scripts/check-bridge-index.py          # report stale entries
+    python3 Scripts/check-bridge-index.py --quiet  # exit status only
+
+Exit status is 1 when any entry is stale, so this can gate a commit.
+"""
+import os
+import re
+import sys
+
+HEADER = 'Sources/OCCTBridge/include/OCCTBridge.h'
+SRC_DIR = 'Sources/OCCTBridge/src'
+SYMBOL = re.compile(r'\bOCCT[A-Za-z0-9_]+')
+ENTRY = re.compile(r'^//\s+(\w+)\s+→\s+(.+?)\s*$')
+
+
+def index_entries(lines):
+    """(line number, OCCT class, bridge symbol) for every symbol named in the index."""
+    out = []
+    for i, line in enumerate(lines):
+        m = ENTRY.match(line)
+        if not m:
+            continue
+        cls, syms = m.group(1), re.sub(r'\(v[\d.]+\)', '', m.group(2))
+        for sym in re.split(r'[,/]', syms):
+            sym = sym.strip()
+            if re.fullmatch(r'OCCT\w+\*?', sym):
+                out.append((i + 1, cls, sym))
+    return out
+
+
+def real_symbols(lines):
+    """Every bridge symbol that actually exists.
+
+    The index lives in header comments, so comment lines are stripped first —
+    otherwise every entry trivially finds itself.
+    """
+    code = '\n'.join(l for l in lines if not l.lstrip().startswith('//'))
+    found = set(SYMBOL.findall(code))
+    for root, _dirs, files in os.walk(SRC_DIR):
+        for name in files:
+            if name.endswith(('.mm', '.h')):
+                with open(os.path.join(root, name), errors='replace') as f:
+                    found.update(SYMBOL.findall(f.read()))
+    return found
+
+
+def main():
+    quiet = '--quiet' in sys.argv
+    if not os.path.exists(HEADER):
+        print(f'{HEADER} not found — run from the repo root', file=sys.stderr)
+        return 2
+
+    with open(HEADER, errors='replace') as f:
+        lines = f.read().split('\n')
+    entries = index_entries(lines)
+    known = real_symbols(lines)
+
+    stale = []
+    for ln, cls, sym in entries:
+        if sym.endswith('*'):
+            if not any(k.startswith(sym[:-1]) for k in known):
+                stale.append((ln, cls, sym, 'no symbol starts with this prefix'))
+        elif sym not in known:
+            near = sorted(k for k in known if sym in k or k in sym)
+            hint = 'did you mean: ' + ', '.join(near[:3]) if near else 'no similar symbol'
+            stale.append((ln, cls, sym, hint))
+
+    if not quiet:
+        classes = len({c for _, c, _ in entries})
+        print(f'{len(entries)} index symbols across {classes} OCCT classes')
+        for ln, cls, sym, hint in stale:
+            print(f'  STALE {HEADER}:{ln}  {cls} → {sym}  ({hint})')
+        print(f'{len(stale)} stale')
+    return 1 if stale else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Scripts/patches/0017-null-reshape-context-ComposeShell-WireDivide-484.patch
+++ b/Scripts/patches/0017-null-reshape-context-ComposeShell-WireDivide-484.patch
@@ -55,7 +55,8 @@ shape is byte-identical before and after the patch (BREP dump hash and
 face/wire/edge/vertex counts compared for both surfaces and both classes), and
 the no-context path now produces that same result rather than crashing.
 
-Reported downstream and isolated at SecondMouseAU/OCCTSwift#484.
+Reported downstream and isolated at SecondMouseAU/OCCTSwift#484; filed upstream as
+Open-Cascade-SAS/OCCT#1409 (repro) / OCCT#1410 (fix).
 ---
  .../TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx        | 12 ++++++++++++
  .../TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx  |  6 ++++++

--- a/Scripts/patches/0017-null-reshape-context-ComposeShell-WireDivide-484.patch
+++ b/Scripts/patches/0017-null-reshape-context-ComposeShell-WireDivide-484.patch
@@ -1,0 +1,110 @@
+From: OCCTSwift ecosystem <noreply@secondmouse.au>
+Subject: [PATCH] Shape Healing - create a ReShape context when none is set in
+ ShapeFix_ComposeShell and ShapeUpgrade_WireDivide
+
+ShapeFix_ComposeShell::Perform(), ShapeFix_ComposeShell::SplitEdges() and
+ShapeUpgrade_WireDivide::Perform() dereference Context() unconditionally, so
+every call made without a prior SetContext() is an immediate null-handle
+dereference: an uncatchable SIGSEGV (Address 0), reproducible with nothing more
+exotic than a planar square face.
+
+    ShapeUpgrade_WireDivide wd;
+    wd.Init(wire, face);
+    wd.Perform();            // <- SIGSEGV, ShapeUpgrade_WireDivide.cxx:323
+
+    ShapeFix_ComposeShell cs;
+    cs.Init(grid, TopLoc_Location(), face, Precision::Confusion());
+    cs.Perform();            // <- SIGSEGV, via LoadWires, ShapeFix_ComposeShell.cxx:506
+
+Context() returns ShapeFix_Root::myContext, which the base constructor leaves
+null; it is only ever set by an explicit SetContext() call, and neither class'
+documentation nor Init() signature requires one. The two classes are the odd
+ones out in their own package: ShapeUpgrade_FaceDivide::Perform() -- the
+in-kernel driver of both, and the reason neither crash shows up in OCCT's own
+test suite -- opens with exactly the guard added here,
+
+    if (Context().IsNull())
+    {
+      SetContext(new ShapeBuild_ReShape);
+    }
+
+and then hands its context down (ShapeUpgrade_FaceDivide.cxx:185 for the
+compose shell, :238 for the wire divide), so both classes only ever run with a
+live context when reached that way. A caller that uses either class directly --
+the usage its public Init()/Perform() pair invites -- gets the crash.
+
+ShapeFix_Shape::Init, ShapeFix_Shell::Perform, ShapeFix_Solid::Perform,
+ShapeFix_FixSmallFace::Init, ShapeFix_SplitCommonVertex::Init,
+ShapeFix_Wireframe (both entry points), ShapeFix_Wire::FixGap3d/FixGap2d,
+ShapeFix_Face::FixMissingSeam and ShapeUpgrade_ShapeDivide::Perform all carry
+the same self-creating guard already; this patch adds it to the three public
+entry points that were missing it. ShapeFix_ComposeShell's remaining
+context-dereferencing methods (LoadWires, SplitWire, SplitByLine,
+MakeFacesOnPatch, DispatchWires) are all reached through Perform() or
+SplitEdges(), so guarding those two covers them.
+
+The same defect class was fixed for ShapeFix_Face::FixPeriodicDegenerated in
+Open-Cascade-SAS/OCCT#1378 / #1380.
+
+Validation (fast path, no full rebuild -- see Scripts/patches/README.md's #0001
+entry for the override-link technique): a plain 4-edge planar square face and an
+unbounded-cylinder face, run through both classes with no SetContext() call,
+SIGSEGV 100% of the time on stock V8_0_0_p1 and complete normally after this
+patch. With a context set -- the only path that worked before -- the resulting
+shape is byte-identical before and after the patch (BREP dump hash and
+face/wire/edge/vertex counts compared for both surfaces and both classes), and
+the no-context path now produces that same result rather than crashing.
+
+Reported downstream and isolated at SecondMouseAU/OCCTSwift#484.
+---
+ .../TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx        | 12 ++++++++++++
+ .../TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx  |  6 ++++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
+index 946ec8ff..51a875e5 100644
+--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
++++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
+@@ -205,6 +205,12 @@ void ShapeFix_ComposeShell::Init(const occ::handle<ShapeExtend_CompositeSurface>
+
+ bool ShapeFix_ComposeShell::Perform()
+ {
++  // Every Context() dereference below assumes a live context; SetContext() is optional
++  if (Context().IsNull())
++  {
++    SetContext(new ShapeBuild_ReShape);
++  }
++
+   myStatus           = ShapeExtend::EncodeStatus(ShapeExtend_OK);
+   myInvertEdgeStatus = false;
+
+@@ -258,6 +264,12 @@ bool ShapeFix_ComposeShell::Perform()
+
+ void ShapeFix_ComposeShell::SplitEdges()
+ {
++  // LoadWires()/SplitByGrid() below dereference Context(); SetContext() is optional
++  if (Context().IsNull())
++  {
++    SetContext(new ShapeBuild_ReShape);
++  }
++
+   myStatus = ShapeExtend::EncodeStatus(ShapeExtend_OK);
+
+   NCollection_Sequence<ShapeFix_WireSegment> seqw; // working data: wire segments
+diff --git a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
+index 7937581b..a7deaf8b 100644
+--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
++++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
+@@ -276,6 +276,12 @@ static void CorrectSplitValues(const occ::handle<NCollection_HSequence<double>>&
+
+ void ShapeUpgrade_WireDivide::Perform()
+ {
++  // Every Context() dereference below assumes a live context, as in the
++  // ShapeUpgrade_FaceDivide::Perform() that drives this class; SetContext() is optional
++  if (Context().IsNull())
++  {
++    SetContext(new ShapeBuild_ReShape);
++  }
+
+   myStatus = ShapeExtend::EncodeStatus(ShapeExtend_OK);
+

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -377,6 +377,6 @@ Both are the odd ones out in their own package. `ShapeUpgrade_FaceDivide::Perfor
 
 Both crashes were already closed **bridge-side**, before this patch existed: `OCCTShapeFixComposeShell` and `OCCTShapeUpgradeWireDivide` (`OCCTBridge_Healing.mm`) each call `SetContext(new ShapeBuild_ReShape())` with a comment naming the SIGSEGV. This patch fixes the kernel so those workarounds can eventually retire, and so the crash is closed for every other OCCT consumer following the documented `Init` + `Perform` usage.
 
-See [`Scripts/repro/484-null-reshape-context/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/484-null-reshape-context) for the reproducer and full writeup.
+See [`Scripts/repro/484-null-reshape-context/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/484-null-reshape-context) for the reproducer and full writeup. Filed upstream as [Open-Cascade-SAS/OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409) (repro) / [OCCT#1410](https://github.com/Open-Cascade-SAS/OCCT/pull/1410) (fix). Both defects are still present on upstream `master` (verified against `37dd5686` at filing time), and the PR branch's post-edit blobs hash identically to this patch's output, so the fix is the same on `master` as on our `V8_0_0_p1` pin.
 
 **Retire** once the bundled OCCT includes this fix.

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -362,3 +362,21 @@ See [`Scripts/repro/349-ocaf-driver-reentrancy/`](https://github.com/SecondMouse
 See [`Scripts/repro/353-cdm-metadata-lookup-table/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/353-cdm-metadata-lookup-table) for the reproducer and full writeup. Filed upstream as [Open-Cascade-SAS/OCCT#1396](https://github.com/Open-Cascade-SAS/OCCT/issues/1396) (repro) / [OCCT#1397](https://github.com/Open-Cascade-SAS/OCCT/pull/1397) (fix, CI green on all platforms).
 
 **Retire** once the bundled OCCT includes this fix.
+
+## 0017-null-reshape-context-ComposeShell-WireDivide-484.patch
+
+**Fixes two upstream OCCT crashes found while auditing the `ShapeFix_Face` call sites in [#484](https://github.com/SecondMouseAU/OCCTSwift/issues/484)** — the same defect class as `0005`/#317 (an unguarded null `ShapeBuild_ReShape` context dereference), in two classes that were never patched or filed.
+
+`ShapeFix_ComposeShell::Perform()`, `ShapeFix_ComposeShell::SplitEdges()` and `ShapeUpgrade_WireDivide::Perform()` dereference `Context()` unconditionally. `Context()` returns `ShapeFix_Root::myContext`, which the base constructor leaves **null** and only an explicit `SetContext()` ever fills — so the ordinary `Init(...)` + `Perform()` pair those classes' public API invites is an immediate null-handle dereference, an uncatchable SIGSEGV at Address 0. No exotic geometry needed: a plain 4-edge planar square face crashes both classes 100% of the time.
+
+Both are the odd ones out in their own package. `ShapeUpgrade_FaceDivide::Perform()` — the in-kernel driver of *both* classes, and the reason neither crash shows up in OCCT's own test suite — opens with exactly the guard this patch adds, then hands its context down to the compose shell (`ShapeUpgrade_FaceDivide.cxx:185`) and the wire divide (`:238`). Reached that way, neither class ever sees a null context. Reached directly, both crash. `ShapeFix_Shape::Init`, `ShapeFix_Shell::Perform`, `ShapeFix_Solid::Perform`, `ShapeFix_FixSmallFace::Init`, `ShapeFix_SplitCommonVertex::Init`, `ShapeFix_Wireframe` (both entry points), `ShapeFix_Wire::FixGap3d`/`FixGap2d`, `ShapeFix_Face::FixMissingSeam` and `ShapeUpgrade_ShapeDivide::Perform` all carry the same self-creating guard already.
+
+**Fix:** the guard OCCT itself uses in those ten places — `if (Context().IsNull()) { SetContext(new ShapeBuild_ReShape); }` — at the three public entry points missing it. `ShapeFix_ComposeShell`'s other context-dereferencing methods (`LoadWires`, `SplitWire`, `SplitByLine`, `MakeFacesOnPatch`, `DispatchWires`) are all reached through `Perform()` or `SplitEdges()`, so guarding those two covers them; they are also `const`, so they could not create a context themselves.
+
+**Validation** (fast path, no full rebuild — see the `#0001` entry above for the override-link technique): a 4-edge planar square face and an unbounded-cylinder face, run through both classes with no `SetContext()` call, SIGSEGV 100% of the time on stock `V8_0_0_p1` + patches `0001`–`0016` and complete normally after this patch. On the *with-context* path — the only one that worked before — the result is **byte-identical** before and after (BREP dump hash plus face/wire/edge/vertex counts compared for both surfaces and both classes), and the no-context path now produces that same result instead of crashing.
+
+Both crashes were already closed **bridge-side**, before this patch existed: `OCCTShapeFixComposeShell` and `OCCTShapeUpgradeWireDivide` (`OCCTBridge_Healing.mm`) each call `SetContext(new ShapeBuild_ReShape())` with a comment naming the SIGSEGV. This patch fixes the kernel so those workarounds can eventually retire, and so the crash is closed for every other OCCT consumer following the documented `Init` + `Perform` usage.
+
+See [`Scripts/repro/484-null-reshape-context/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/484-null-reshape-context) for the reproducer and full writeup.
+
+**Retire** once the bundled OCCT includes this fix.

--- a/Scripts/repro/484-null-reshape-context/README.md
+++ b/Scripts/repro/484-null-reshape-context/README.md
@@ -5,6 +5,9 @@ found while auditing every `ShapeFix_Face` call site in the bridge for #484. Sam
 [#317](https://github.com/SecondMouseAU/OCCTSwift/issues/317) (`Scripts/patches/0005-*`), in two
 classes that had never been patched or filed upstream.
 
+Filed upstream as [Open-Cascade-SAS/OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409)
+(repro) / [OCCT#1410](https://github.com/Open-Cascade-SAS/OCCT/pull/1410) (fix).
+
 No fixture file is needed: a plain 4-edge planar square face crashes both classes 100% of the time.
 
 ## Root cause

--- a/Scripts/repro/484-null-reshape-context/README.md
+++ b/Scripts/repro/484-null-reshape-context/README.md
@@ -1,0 +1,134 @@
+# OCCTSwift#484 reproducer — null `ShapeBuild_ReShape` context SIGSEGVs in `ShapeFix_ComposeShell` / `ShapeUpgrade_WireDivide`
+
+Standalone, deterministic reproducers for two uncatchable SIGSEGVs in OCCT's shape-healing family,
+found while auditing every `ShapeFix_Face` call site in the bridge for #484. Same defect class as
+[#317](https://github.com/SecondMouseAU/OCCTSwift/issues/317) (`Scripts/patches/0005-*`), in two
+classes that had never been patched or filed upstream.
+
+No fixture file is needed: a plain 4-edge planar square face crashes both classes 100% of the time.
+
+## Root cause
+
+`ShapeFix_Root::Context()` returns `myContext`, a `Handle(ShapeBuild_ReShape)` that the base
+constructor leaves **null**. Only an explicit `SetContext()` call ever fills it, and it is optional —
+nothing in either class' documentation, `Init()` signature or `Perform()` contract requires one.
+
+Three public entry points dereference it unconditionally:
+
+| Entry point | First unguarded dereference |
+|---|---|
+| `ShapeUpgrade_WireDivide::Perform()` | `ShapeUpgrade_WireDivide.cxx:323` — `Context()->Apply(ItW.Value(), TopAbs_SHAPE)`, the first statement of the per-edge loop |
+| `ShapeFix_ComposeShell::Perform()` | `ShapeFix_ComposeShell.cxx:506`, via `LoadWires()` — `Context()->Apply(iw.Value())` |
+| `ShapeFix_ComposeShell::SplitEdges()` | same `LoadWires()` dereference |
+
+So `Init(...)` followed by `Perform()` — the usage the public API invites — is an immediate
+null-handle dereference: Address 0, `EXC_BAD_ACCESS`, uncatchable in-process (a `catch (...)` on the
+bridge side cannot trap an OS signal).
+
+**Why this hid for so long.** Both classes are, in-kernel, only ever driven by
+`ShapeUpgrade_FaceDivide::Perform()`, which opens with
+
+```cpp
+if (Context().IsNull())
+{
+  SetContext(new ShapeBuild_ReShape);
+}
+```
+
+and then hands its context down — to the compose shell at `ShapeUpgrade_FaceDivide.cxx:185`, to the
+wire divide at `:238`. Reached that way, neither class ever sees a null context, so OCCT's own test
+suite never exercises the crash. Reached directly, both crash on the first call.
+
+Nine other classes in the same package already carry that self-creating guard:
+`ShapeFix_Shape::Init`, `ShapeFix_Shell::Perform`, `ShapeFix_Solid::Perform`,
+`ShapeFix_FixSmallFace::Init`, `ShapeFix_SplitCommonVertex::Init`, `ShapeFix_Wireframe` (both entry
+points), `ShapeFix_Wire::FixGap3d`/`FixGap2d`, `ShapeFix_Face::FixMissingSeam` and
+`ShapeUpgrade_ShapeDivide::Perform`. `ShapeFix_ComposeShell` and `ShapeUpgrade_WireDivide` are the
+odd ones out.
+
+## Fix
+
+`Scripts/patches/0017-null-reshape-context-ComposeShell-WireDivide-484.patch`: add that same guard to
+the three unguarded public entry points. `ShapeFix_ComposeShell`'s other context-dereferencing
+methods (`LoadWires`, `SplitWire`, `SplitByLine`, `MakeFacesOnPatch`, `DispatchWires`) are all
+reached through `Perform()` or `SplitEdges()`, so guarding those two covers them — and they are
+`const`, so they could not create a context themselves.
+
+## Reproducers
+
+### `repro_484_crash.mm` — the crash
+
+Runs each case in a `fork()`ed child so one SIGSEGV does not hide the others, and prints the
+terminating signal per case. Also covers `ShapeFix_Face::Perform` and the individual `ShapeFix_Wire`
+fixes with no context, to bound the blast radius (both are safe — see "Also checked" below).
+
+```bash
+clang++ -std=c++17 -ObjC++ -w -g \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/484-null-reshape-context/repro_484_crash.mm -o /tmp/repro_484_crash
+/tmp/repro_484_crash
+```
+
+Stock `V8_0_0_p1` + patches `0001`–`0016`:
+
+```
+ShapeFix_Face::Perform / intersecting wires    ctx=NO  : Perform=1 resultNull=0
+ShapeFix_Face::Perform / intersecting wires    ctx=yes : Perform=1 resultNull=0
+ShapeFix_Face::FixIntersectingWires direct     ctx=NO  : FixIntersectingWires=0
+ShapeFix_Face::FixIntersectingWires direct     ctx=yes : FixIntersectingWires=1
+ShapeUpgrade_WireDivide::Perform               ctx=NO  :   *** KILLED BY SIGNAL 11 ***
+ShapeUpgrade_WireDivide::Perform               ctx=yes : Perform done, wireNull=0
+ShapeFix_ComposeShell::Perform                 ctx=NO  :   *** KILLED BY SIGNAL 11 ***
+ShapeFix_ComposeShell::Perform                 ctx=yes : Perform=1 resultNull=0
+ShapeFix_Wire individual fixes                 ctx=NO  : reorder=0 conn=0 curves=0 ...
+ShapeFix_Wire individual fixes                 ctx=yes : reorder=0 conn=0 curves=0 ...
+```
+
+With patch `0017` both `ctx=NO` lines complete normally, matching their `ctx=yes` siblings.
+
+### `repro_484_equivalence.mm` — no behaviour change on the working path
+
+Prints a structural fingerprint (shape type, face/wire/edge/vertex counts, and a hash of the
+`BRepTools::Write` dump) of each result, for a planar and an unbounded-cylindrical face.
+
+Verified via the override-link technique (see `Scripts/patches/README.md`'s `#0001` entry): compile
+the two patched TUs standalone and link them *before* `libOCCT-macos.a`, so no full rebuild is
+needed.
+
+```bash
+SRC=Libraries/occt-src/src/ModelingAlgorithms/TKShHealing
+clang++ -std=c++17 -O2 -w -I Libraries/OCCT.xcframework/macos-arm64/Headers \
+  -c $SRC/ShapeFix/ShapeFix_ComposeShell.cxx -o /tmp/cs.o
+clang++ -std=c++17 -O2 -w -I Libraries/OCCT.xcframework/macos-arm64/Headers \
+  -c $SRC/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx -o /tmp/wd.o
+clang++ -std=c++17 -ObjC++ -w -g -I Libraries/OCCT.xcframework/macos-arm64/Headers \
+  Scripts/repro/484-null-reshape-context/repro_484_equivalence.mm /tmp/cs.o /tmp/wd.o \
+  -L Libraries/OCCT.xcframework/macos-arm64 -lOCCT-macos \
+  -framework Foundation -framework AppKit -lz -lc++ -o /tmp/repro_484_equiv_patched
+MMGT_OPT=0 /tmp/repro_484_equiv_patched
+```
+
+Result: the four `ctx=yes` fingerprints are **byte-identical** stock vs patched (`brep=` hashes and
+all counts match), and the four `ctx=NO` fingerprints — which SIGSEGV on stock — are identical to
+their `ctx=yes` counterparts after the patch. The guard only fires when there was no context, and in
+that case it produces exactly what an explicitly-provided context produces.
+
+## Also checked (not defects)
+
+Both were candidates in the same audit and came back clean, so the patch deliberately does not touch
+them:
+
+- **`ShapeFix_Face::Perform()` with no context** — safe. `FixPeriodicDegenerated` was the #317 site
+  and is already guarded by patch `0005`; `FixMissingSeam` self-creates a context;
+  `FixIntersectingWires` bails out early (`ShapeFix_IntersectionTool::FixIntersectingWires` opens
+  with `if (myContext.IsNull() || face.IsNull()) return false;`). It does **silently skip** fixes
+  that need a context, which is a correctness difference, not a crash — see #484's bridge-side fix
+  to `OCCTFaceFix`.
+- **`ShapeFix_Wire`'s individual fixes with no context** — safe. All 14 `UpdateWire()` call sites
+  guard, `FixGap3d`/`FixGap2d` self-create a context, and `FixEdgeCurves`' singularity-split branch
+  (`ShapeFix_Wire.cxx:817`) sits inside an `if (!Context().IsNull())` at `:676`.
+- **`ShapeUpgrade_RemoveInternalWires`** — safe. Both constructors call
+  `SetContext(new ShapeBuild_ReShape)` before anything else.
+- **`ShapeFix_Edge`** — safe. All 11 context dereferences are guarded.

--- a/Scripts/repro/484-null-reshape-context/repro_484_crash.mm
+++ b/Scripts/repro/484-null-reshape-context/repro_484_crash.mm
@@ -1,0 +1,229 @@
+// #484: null-ReShape-context dereferences in the OCCT healing family.
+//
+// #317 (Scripts/patches/0005) guarded ONE such site
+// (ShapeFix_Face::FixPeriodicDegenerated). This probe checks the siblings the
+// bridge currently papers over with a local SetContext() call, plus
+// ShapeFix_Face::Perform itself against a face with intersecting wires.
+//
+// Each case runs in a forked child, so a SIGSEGV in one still lets the rest run.
+#include <signal.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_Plane.hxx>
+#include <NCollection_HArray2.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeExtend_CompositeSurface.hxx>
+#include <ShapeFix_ComposeShell.hxx>
+#include <ShapeFix_Face.hxx>
+#include <ShapeFix_Wire.hxx>
+#include <ShapeUpgrade_WireDivide.hxx>
+#include <Standard_Failure.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Pln.hxx>
+
+// A planar face whose outer wire and inner wire cross each other.
+static TopoDS_Face intersectingWiresFace()
+{
+  BRepBuilderAPI_MakePolygon outer;
+  outer.Add(gp_Pnt(0, 0, 0));
+  outer.Add(gp_Pnt(10, 0, 0));
+  outer.Add(gp_Pnt(10, 10, 0));
+  outer.Add(gp_Pnt(0, 10, 0));
+  outer.Close();
+
+  BRepBuilderAPI_MakePolygon inner;
+  inner.Add(gp_Pnt(5, 5, 0));
+  inner.Add(gp_Pnt(15, 5, 0));
+  inner.Add(gp_Pnt(15, 8, 0));
+  inner.Add(gp_Pnt(5, 8, 0));
+  inner.Close();
+
+  Handle(Geom_Plane)      pln = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+  BRepBuilderAPI_MakeFace mf(pln, outer.Wire(), Standard_True);
+  if (!mf.IsDone())
+    return TopoDS_Face();
+  mf.Add(TopoDS::Wire(inner.Wire().Reversed()));
+  return mf.IsDone() ? mf.Face() : TopoDS_Face();
+}
+
+static TopoDS_Face squareFace()
+{
+  BRepBuilderAPI_MakePolygon p;
+  p.Add(gp_Pnt(0, 0, 0));
+  p.Add(gp_Pnt(10, 0, 0));
+  p.Add(gp_Pnt(10, 10, 0));
+  p.Add(gp_Pnt(0, 10, 0));
+  p.Close();
+  Handle(Geom_Plane)      pln = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+  BRepBuilderAPI_MakeFace mf(pln, p.Wire(), Standard_True);
+  return mf.IsDone() ? mf.Face() : TopoDS_Face();
+}
+
+// ---- cases -----------------------------------------------------------------
+
+static void caseFacePerformIntersectingWires(bool withContext)
+{
+  TopoDS_Face f = intersectingWiresFace();
+  if (f.IsNull())
+  {
+    printf("no face\n");
+    return;
+  }
+  ShapeFix_Face fixer(f);
+  if (withContext)
+    fixer.SetContext(new ShapeBuild_ReShape);
+  fixer.SetPrecision(1e-6);
+  fixer.FixWireMode()            = 1;
+  fixer.FixOrientationMode()     = 1;
+  fixer.FixAddNaturalBoundMode() = 1;
+  fixer.FixMissingSeamMode()     = 1;
+  fixer.FixSmallAreaWireMode()   = 1;
+  bool ok = fixer.Perform();
+  printf("Perform=%d resultNull=%d\n", (int)ok, (int)fixer.Face().IsNull());
+}
+
+static void caseFaceFixIntersectingWiresDirect(bool withContext)
+{
+  TopoDS_Face f = intersectingWiresFace();
+  if (f.IsNull())
+  {
+    printf("no face\n");
+    return;
+  }
+  ShapeFix_Face fixer(f);
+  if (withContext)
+    fixer.SetContext(new ShapeBuild_ReShape);
+  fixer.SetPrecision(1e-6);
+  bool ok = fixer.FixIntersectingWires();
+  printf("FixIntersectingWires=%d\n", (int)ok);
+}
+
+static void caseWireDivide(bool withContext)
+{
+  TopoDS_Face f = squareFace();
+  if (f.IsNull())
+  {
+    printf("no face\n");
+    return;
+  }
+  TopoDS_Wire w;
+  for (TopExp_Explorer ex(f, TopAbs_WIRE); ex.More(); ex.Next())
+  {
+    w = TopoDS::Wire(ex.Current());
+    break;
+  }
+  Handle(ShapeUpgrade_WireDivide) wd = new ShapeUpgrade_WireDivide();
+  if (withContext)
+    wd->SetContext(new ShapeBuild_ReShape);
+  wd->Init(w, f);
+  wd->Perform();
+  printf("Perform done, wireNull=%d\n", (int)wd->Wire().IsNull());
+}
+
+static void caseComposeShell(bool withContext)
+{
+  TopoDS_Face f = squareFace();
+  if (f.IsNull())
+  {
+    printf("no face\n");
+    return;
+  }
+  Handle(Geom_Surface) surf = BRep_Tool::Surface(f);
+  Handle(NCollection_HArray2<Handle(Geom_Surface)>) grid =
+    new NCollection_HArray2<Handle(Geom_Surface)>(1, 1, 1, 1);
+  grid->SetValue(1, 1, surf);
+  Handle(ShapeExtend_CompositeSurface) cs = new ShapeExtend_CompositeSurface(grid);
+
+  Handle(ShapeFix_ComposeShell) shell = new ShapeFix_ComposeShell();
+  if (withContext)
+    shell->SetContext(new ShapeBuild_ReShape);
+  shell->Init(cs, TopLoc_Location(), f, 1e-7);
+  bool ok = shell->Perform();
+  printf("Perform=%d resultNull=%d\n", (int)ok, (int)shell->Result().IsNull());
+}
+
+static void caseWireFixerNoContext(bool withContext)
+{
+  // The OCCTWireFixer* family: ShapeFix_Wire::Init + individual fixes, no context.
+  TopoDS_Face f = squareFace();
+  TopoDS_Wire w;
+  for (TopExp_Explorer ex(f, TopAbs_WIRE); ex.More(); ex.Next())
+  {
+    w = TopoDS::Wire(ex.Current());
+    break;
+  }
+  Handle(ShapeFix_Wire) fixer = new ShapeFix_Wire();
+  if (withContext)
+    fixer->SetContext(new ShapeBuild_ReShape);
+  fixer->Init(w, f, 1e-6);
+  bool a = fixer->FixReorder();
+  bool b = fixer->FixConnected();
+  bool c = fixer->FixEdgeCurves();
+  bool d = fixer->FixSelfIntersection();
+  bool e = fixer->FixLacking();
+  bool g = fixer->FixGaps3d();
+  bool h = fixer->FixGaps2d();
+  bool i = fixer->FixNotchedEdges();
+  printf("reorder=%d conn=%d curves=%d selfint=%d lack=%d gaps3d=%d gaps2d=%d notch=%d\n", a, b, c,
+         d, e, g, h, i);
+}
+
+// ---- driver ----------------------------------------------------------------
+
+typedef void (*CaseFn)(bool);
+
+static void run(const char* name, CaseFn fn, bool withContext)
+{
+  printf("%-46s ctx=%-3s : ", name, withContext ? "yes" : "NO");
+  fflush(stdout);
+  pid_t pid = fork();
+  if (pid == 0)
+  {
+    try
+    {
+      fn(withContext);
+    }
+    catch (const Standard_Failure& e)
+    {
+      printf("Standard_Failure: %s\n", e.GetMessageString() ? e.GetMessageString() : "?");
+    }
+    catch (...)
+    {
+      printf("unknown exception\n");
+    }
+    fflush(stdout);
+    _exit(0);
+  }
+  int st = 0;
+  waitpid(pid, &st, 0);
+  if (WIFSIGNALED(st))
+    printf("  *** KILLED BY SIGNAL %d (%s) ***\n", WTERMSIG(st), strsignal(WTERMSIG(st)));
+  fflush(stdout);
+}
+
+int main()
+{
+  run("ShapeFix_Face::Perform / intersecting wires", caseFacePerformIntersectingWires, false);
+  run("ShapeFix_Face::Perform / intersecting wires", caseFacePerformIntersectingWires, true);
+  run("ShapeFix_Face::FixIntersectingWires direct", caseFaceFixIntersectingWiresDirect, false);
+  run("ShapeFix_Face::FixIntersectingWires direct", caseFaceFixIntersectingWiresDirect, true);
+  run("ShapeUpgrade_WireDivide::Perform", caseWireDivide, false);
+  run("ShapeUpgrade_WireDivide::Perform", caseWireDivide, true);
+  run("ShapeFix_ComposeShell::Perform", caseComposeShell, false);
+  run("ShapeFix_ComposeShell::Perform", caseComposeShell, true);
+  run("ShapeFix_Wire individual fixes", caseWireFixerNoContext, false);
+  run("ShapeFix_Wire individual fixes", caseWireFixerNoContext, true);
+  printf("\nALL CASES ATTEMPTED\n");
+  return 0;
+}

--- a/Scripts/repro/484-null-reshape-context/repro_484_equivalence.mm
+++ b/Scripts/repro/484-null-reshape-context/repro_484_equivalence.mm
@@ -1,0 +1,117 @@
+// #484 equivalence probe: structural fingerprint of ShapeUpgrade_WireDivide and
+// ShapeFix_ComposeShell results, so stock-vs-patched output can be compared for
+// the WITH-context path (which the patch must not change), and so the
+// NO-context path can be checked to now produce the same result.
+#include <sstream>
+#include <stdio.h>
+#include <string>
+
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepTools.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <NCollection_HArray2.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeExtend_CompositeSurface.hxx>
+#include <ShapeFix_ComposeShell.hxx>
+#include <ShapeUpgrade_WireDivide.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Pln.hxx>
+
+static std::string fingerprint(const TopoDS_Shape& s)
+{
+  if (s.IsNull())
+    return "NULL";
+  std::ostringstream os;
+  os << "type=" << (int)s.ShapeType();
+  static const TopAbs_ShapeEnum kinds[] = {TopAbs_FACE, TopAbs_WIRE, TopAbs_EDGE, TopAbs_VERTEX};
+  for (TopAbs_ShapeEnum k : kinds)
+  {
+    int n = 0;
+    for (TopExp_Explorer ex(s, k); ex.More(); ex.Next())
+      n++;
+    os << " n" << (int)k << "=" << n;
+  }
+  std::ostringstream dump;
+  BRepTools::Write(s, dump);
+  // hash the BREP dump so any geometric difference shows up
+  std::hash<std::string> h;
+  os << " brep=" << std::hex << h(dump.str()) << " len=" << std::dec << dump.str().size();
+  return os.str();
+}
+
+static TopoDS_Face planarFace()
+{
+  BRepBuilderAPI_MakePolygon p;
+  p.Add(gp_Pnt(0, 0, 0));
+  p.Add(gp_Pnt(10, 0, 0));
+  p.Add(gp_Pnt(10, 10, 0));
+  p.Add(gp_Pnt(0, 10, 0));
+  p.Close();
+  Handle(Geom_Plane)      pln = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+  BRepBuilderAPI_MakeFace mf(pln, p.Wire(), Standard_True);
+  return mf.Face();
+}
+
+static TopoDS_Face cylindricalFace()
+{
+  gp_Ax3                          ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+  Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(ax, 3.0);
+  BRepBuilderAPI_MakeFace         mf(cyl, 0.0, 2.0 * M_PI, 0.0, 5.0, 1e-7);
+  return mf.Face();
+}
+
+static void wireDivide(const char* tag, const TopoDS_Face& f, bool withContext)
+{
+  TopoDS_Wire w;
+  for (TopExp_Explorer ex(f, TopAbs_WIRE); ex.More(); ex.Next())
+  {
+    w = TopoDS::Wire(ex.Current());
+    break;
+  }
+  Handle(ShapeUpgrade_WireDivide) wd = new ShapeUpgrade_WireDivide();
+  if (withContext)
+    wd->SetContext(new ShapeBuild_ReShape);
+  wd->Init(w, f);
+  wd->Perform();
+  printf("WireDivide   %-12s ctx=%-3s : %s\n", tag, withContext ? "yes" : "NO",
+         fingerprint(wd->Wire()).c_str());
+}
+
+static void composeShell(const char* tag, const TopoDS_Face& f, bool withContext)
+{
+  Handle(Geom_Surface)                              surf = BRep_Tool::Surface(f);
+  Handle(NCollection_HArray2<Handle(Geom_Surface)>) grid =
+    new NCollection_HArray2<Handle(Geom_Surface)>(1, 1, 1, 1);
+  grid->SetValue(1, 1, surf);
+  Handle(ShapeExtend_CompositeSurface) cs = new ShapeExtend_CompositeSurface(grid);
+
+  Handle(ShapeFix_ComposeShell) shell = new ShapeFix_ComposeShell();
+  if (withContext)
+    shell->SetContext(new ShapeBuild_ReShape);
+  shell->Init(cs, TopLoc_Location(), f, 1e-7);
+  bool ok = shell->Perform();
+  printf("ComposeShell %-12s ctx=%-3s : ok=%d %s\n", tag, withContext ? "yes" : "NO", (int)ok,
+         fingerprint(shell->Result()).c_str());
+}
+
+int main()
+{
+  setvbuf(stdout, nullptr, _IONBF, 0); // unbuffered: keep output when a case SIGSEGVs
+  TopoDS_Face planar = planarFace();
+  TopoDS_Face cyl    = cylindricalFace();
+  wireDivide("planar", planar, true);
+  wireDivide("cylindrical", cyl, true);
+  composeShell("planar", planar, true);
+  composeShell("cylindrical", cyl, true);
+  printf("---- no-context (crashes on stock) ----\n");
+  wireDivide("planar", planar, false);
+  wireDivide("cylindrical", cyl, false);
+  composeShell("planar", planar, false);
+  composeShell("cylindrical", cyl, false);
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -423,8 +423,8 @@
 //
 // --- ShapeFix ---
 // ShapeFix_Edge                       → OCCTShapeFixEdge*
-// ShapeFix_Face                       → OCCTShapeFixFace
-// ShapeFix_FaceConnect                → OCCTShapeFixConnect*
+// ShapeFix_Face                       → OCCTFaceFix, OCCTFaceFixer*, OCCTShapeCreateFaceFromSurfaceWire, OCCTShapeCreateFaceFromSurfaceWireWithHoles
+// ShapeFix_FaceConnect                → OCCTShapeFixFaceConnect
 // ShapeFix_FixSmallFace               → OCCTShapeFixSmallFaces
 // ShapeFix_FixSmallSolid              → OCCTShapeFixSmallSolid*
 // ShapeFix_Shape                      → OCCTShapeFix, OCCTShapeFixed*

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2189,8 +2189,15 @@ OCCTShapeRef OCCTShapeFixFaceConnect(OCCTShapeRef shape, double tolerance) {
             }
 
             TopoDS_Shell result = connector.Build(shell, tolerance, tolerance);
-            // Build() returns a null shell when it could not connect this one; keep the input
-            // shell rather than dropping it from a multi-shell result.
+            // Defensive, not reachable: read ShapeFix_FaceConnect::Build (occt-src) end to end --
+            // `result` starts as the input shell and is only ever reassigned via TopoDS::Shell() on
+            // a ReShape::Apply() result or a rebuilt shell, never a default-constructed TopoDS_Shell.
+            // Probed directly (Add() consecutive face pairs then Build(), matching this loop exactly)
+            // against a real connect, a no-Add() no-op, and a single-face shell: IsNull() is false in
+            // all three (#484). Kept for the same reason #443's equivalent branch was kept once its
+            // own "failure" was found to be dead code: the alternative is trusting an internal OCCT
+            // invariant to hold forever, and the cost of being wrong (silently dropping a shell from
+            // a multi-shell result) is worse than one unreachable branch.
             anyConnected = anyConnected || !result.IsNull();
             connected.push_back(result.IsNull() ? shell : (TopoDS_Shape)result);
         }

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -301,6 +301,11 @@ OCCTShapeRef OCCTFaceFix(OCCTFaceRef face, double tolerance) {
 
     try {
         Handle(ShapeFix_Face) fixer = new ShapeFix_Face(face->face);
+        // #317/#484: ShapeFix_Face's base constructor leaves Context() null, and the fixes that
+        // need one then silently no-op (or, on an unpatched kernel, null-deref in
+        // FixPeriodicDegenerated). This was the fourth ShapeFix_Face call site in the bridge and
+        // the only one the #317 pass missed. Give it a context, as the other three do.
+        fixer->SetContext(new ShapeBuild_ReShape);
         fixer->SetPrecision(tolerance);
 
         // Enable fixing modes
@@ -2146,38 +2151,55 @@ OCCTShapeRef OCCTShapeFixSplitCommonVertex(OCCTShapeRef shape) {
     }
 }
 
+// Connect adjacent faces in every shell of the input, not just the first one an explorer yields
+// (#484, same first-of-N family as #439/#442/#443). ShapeFix_FaceConnect::Build takes one shell,
+// so a multi-shell input has to be driven one shell at a time; the results are reassembled with
+// the shared helper, so a single-shell input still returns a bare shell and multi-shell input
+// returns a compound.
 OCCTShapeRef OCCTShapeFixFaceConnect(OCCTShapeRef shape, double tolerance) {
     if (!shape) return nullptr;
     try {
-        // Get shell from shape
-        TopoDS_Shell shell;
+        std::vector<TopoDS_Shape> shells;
         if (shape->shape.ShapeType() == TopAbs_SHELL) {
-            shell = TopoDS::Shell(shape->shape);
+            shells.push_back(shape->shape);
         } else {
             for (TopExp_Explorer exp(shape->shape, TopAbs_SHELL); exp.More(); exp.Next()) {
-                shell = TopoDS::Shell(exp.Current());
-                break;
+                shells.push_back(exp.Current());
             }
         }
-        if (shell.IsNull()) return nullptr;
+        if (shells.empty()) return nullptr;
 
-        // Get face pairs and connect them
-        ShapeFix_FaceConnect connector;
+        std::vector<TopoDS_Shape> connected;
+        bool anyConnected = false;
+        for (const TopoDS_Shape& shellShape : shells) {
+            TopoDS_Shell shell = TopoDS::Shell(shellShape);
 
-        // Collect all faces
-        std::vector<TopoDS_Face> faces;
-        for (TopExp_Explorer exp(shell, TopAbs_FACE); exp.More(); exp.Next()) {
-            faces.push_back(TopoDS::Face(exp.Current()));
+            // Get face pairs and connect them
+            ShapeFix_FaceConnect connector;
+
+            // Collect all faces
+            std::vector<TopoDS_Face> faces;
+            for (TopExp_Explorer exp(shell, TopAbs_FACE); exp.More(); exp.Next()) {
+                faces.push_back(TopoDS::Face(exp.Current()));
+            }
+
+            // Add adjacent face pairs
+            for (size_t i = 0; i + 1 < faces.size(); i++) {
+                connector.Add(faces[i], faces[i + 1]);
+            }
+
+            TopoDS_Shell result = connector.Build(shell, tolerance, tolerance);
+            // Build() returns a null shell when it could not connect this one; keep the input
+            // shell rather than dropping it from a multi-shell result.
+            anyConnected = anyConnected || !result.IsNull();
+            connected.push_back(result.IsNull() ? shell : (TopoDS_Shape)result);
         }
+        // Unchanged contract for the single-shell case: nil when nothing could be connected.
+        if (!anyConnected) return nullptr;
 
-        // Add adjacent face pairs
-        for (size_t i = 0; i + 1 < faces.size(); i++) {
-            connector.Add(faces[i], faces[i + 1]);
-        }
-
-        TopoDS_Shell result = connector.Build(shell, tolerance, tolerance);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
+        TopoDS_Shape out = occtSolidBodiesToShape(connected);
+        if (out.IsNull()) return nullptr;
+        return new OCCTShape(out);
     } catch (...) {
         return nullptr;
     }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -3304,6 +3304,11 @@ extension Face {
 
     /// Fix face problems such as incorrect wire orientation, missing seams, and surface parameters.
     ///
+    /// The underlying `ShapeFix_Face` is given a `ShapeBuild_ReShape` context up front (#484), so
+    /// the fixes that record replacements — a missing seam, or the degenerate apex edge a wire
+    /// belting a cone's full period needs — actually apply. Without one they silently no-op and the
+    /// face comes back unhealed.
+    ///
     /// - Parameter tolerance: Tolerance for fixing operations
     /// - Returns: Fixed face as a shape, or nil on failure
     ///
@@ -7499,10 +7504,28 @@ extension Shape {
 
     // MARK: - ShapeFix_FaceConnect
 
-    /// Connect adjacent faces in this shape's shell.
+    /// Connect adjacent faces in **every** shell of this shape (`ShapeFix_FaceConnect`).
     ///
-    /// - Parameter tolerance: Connection tolerance
-    /// - Returns: Fixed shape with connected faces, or nil on failure
+    /// A shape with several shells — a compound of two solids, say — has each shell connected
+    /// independently and the results reassembled: one shell in, one shell out; several in, a
+    /// compound out. Before #484 only the first shell an explorer yielded was processed and the
+    /// rest were silently dropped.
+    ///
+    /// - Parameter tolerance: Connection tolerance.
+    /// - Returns: The shape with connected faces, or nil when the input has no shell at all, or
+    ///   when no shell could be connected.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// // A compound of two disjoint boxes keeps both shells (12 faces, not 6)
+    /// let a = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let b = Shape.box(width: 6, height: 6, depth: 6)!.translated(by: SIMD3(40, 0, 0))!
+    /// let compound = Shape.compound([a, b])!
+    /// if let connected = compound.connectedFaces(tolerance: 1e-4) {
+    ///     print(connected.faces().count)   // 12
+    /// }
+    /// ```
     public func connectedFaces(tolerance: Double = 1e-4) -> Shape? {
         guard let ref = OCCTShapeFixFaceConnect(handle, tolerance) else { return nil }
         return Shape(handle: ref)

--- a/Tests/OCCTShapeHealingTests/Issue484ConnectedFacesTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue484ConnectedFacesTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #484: `Shape.connectedFaces(tolerance:)` (`ShapeFix_FaceConnect`, via
+/// `OCCTShapeFixFaceConnect`) had **zero** test coverage anywhere in `Tests/` — grepping
+/// `connectedFaces` repo-wide returned only its own declaration. The stale cross-reference index
+/// entry (`ShapeFix_FaceConnect → OCCTShapeFixConnect*`, a symbol family that does not exist) would
+/// not have led anyone to it either.
+///
+/// Writing the coverage surfaced a first-of-N defect of the same family as #439/#442/#443: the
+/// bridge took the **first** shell an explorer yielded and dropped every other one, so a two-shell
+/// compound came back as a single shell. Now every shell is processed and the results reassembled.
+@Suite("Issue #484 — Shape.connectedFaces coverage")
+struct Issue484ConnectedFacesTests {
+
+    @Test("connectedFaces on a box shell returns a shape with the same face count")
+    func boxShellRoundTrips() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box"); return
+        }
+        guard let connected = box.connectedFaces() else {
+            Issue.record("connectedFaces returned nil for a box"); return
+        }
+        #expect(connected.faces().count == box.faces().count)
+    }
+
+    @Test("connectedFaces accepts an explicit tolerance")
+    func explicitTolerance() {
+        guard let cyl = Shape.cylinder(radius: 4, height: 9) else {
+            Issue.record("cylinder"); return
+        }
+        for tol in [1e-6, 1e-4, 1e-2] {
+            guard let connected = cyl.connectedFaces(tolerance: tol) else {
+                Issue.record("connectedFaces returned nil at tolerance \(tol)"); continue
+            }
+            #expect(connected.faces().count == cyl.faces().count)
+        }
+    }
+
+    /// The first-of-N fix: two disjoint solids in one compound carry two shells, and both must
+    /// survive. Before the fix the second shell was silently dropped.
+    @Test("connectedFaces keeps every shell of a multi-shell compound")
+    func multiShellCompoundKeepsEveryShell() {
+        guard let a = Shape.box(width: 10, height: 10, depth: 10),
+              let b = Shape.box(width: 6, height: 6, depth: 6)?
+                  .translated(by: SIMD3(40, 0, 0)) else {
+            Issue.record("boxes"); return
+        }
+        guard let compound = Shape.compound([a, b]) else {
+            Issue.record("compound"); return
+        }
+        #expect(compound.faces().count == 12)
+
+        guard let connected = compound.connectedFaces() else {
+            Issue.record("connectedFaces returned nil for the compound"); return
+        }
+        // 12, not 6: both shells are processed, not just the first the explorer yields.
+        #expect(connected.faces().count == 12)
+    }
+
+    @Test("connectedFaces returns nil for a shape with no shell")
+    func noShellReturnsNil() {
+        guard let wire = Wire.rectangle(width: 5, height: 5),
+              let face = Shape.face(from: wire) else {
+            Issue.record("rectangle face"); return
+        }
+        // A lone face is not a shell, and ShapeFix_FaceConnect needs one.
+        #expect(face.connectedFaces() == nil)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue484ConnectedFacesTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue484ConnectedFacesTests.swift
@@ -11,6 +11,13 @@ import simd
 /// Writing the coverage surfaced a first-of-N defect of the same family as #439/#442/#443: the
 /// bridge took the **first** shell an explorer yielded and dropped every other one, so a two-shell
 /// compound came back as a single shell. Now every shell is processed and the results reassembled.
+///
+/// Review round (PR #511) found the box/cylinder cases above never exercise an actual connection:
+/// `BRepPrimAPI_MakeBox`/`MakeCylinder` already share edges between faces, so `ShapeFix_FaceConnect`
+/// has nothing to do on either input — the tests confirm no data is lost, not that connecting works.
+/// `genuinelyDisconnectedFacesGetConnected` below closes that gap with a shell assembled from two
+/// independently-built faces that share a geometric edge but not a topological one (`Shape.shellFromFaces`
+/// wraps `BRep_Builder::Add`, no sewing), so there is real work for `connectedFaces` to do.
 @Suite("Issue #484 — Shape.connectedFaces coverage")
 struct Issue484ConnectedFacesTests {
 
@@ -67,5 +74,41 @@ struct Issue484ConnectedFacesTests {
         }
         // A lone face is not a shell, and ShapeFix_FaceConnect needs one.
         #expect(face.connectedFaces() == nil)
+    }
+
+    /// Two abutting unit squares, each built from its own independent `Wire.polygon3D` — same
+    /// endpoints where they meet, but no shared `TopoDS_Edge`/`TopoDS_Vertex` between them.
+    /// `Shape.shellFromFaces` (`BRep_Builder::Add`, no sewing) wires them into one shell exactly as
+    /// found: 8 topologically-independent boundary edges, none shared. Ground-truthed directly
+    /// against `ShapeFix_FaceConnect::Add`/`Build` (matching the bridge's own call sequence) before
+    /// writing this: the shared boundary sews into one edge and the shell's total unique edge count
+    /// drops from 8 to 7 — `Shape.edgeCount`'s own method (`TopExp::MapShapes`, deduped).
+    @Test("connectedFaces sews a genuinely disconnected shared edge, not just preserves face count")
+    func genuinelyDisconnectedFacesGetConnected() {
+        let squareA: [SIMD3<Double>] = [
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0),
+        ]
+        let squareB: [SIMD3<Double>] = [
+            SIMD3(10, 0, 0), SIMD3(20, 0, 0), SIMD3(20, 10, 0), SIMD3(10, 10, 0),
+        ]
+        guard let wireA = Wire.polygon3D(squareA), let wireB = Wire.polygon3D(squareB) else {
+            Issue.record("polygon3D"); return
+        }
+        guard let faceA = Shape.face(from: wireA), let faceB = Shape.face(from: wireB) else {
+            Issue.record("face(from:)"); return
+        }
+        guard let shell = Shape.shellFromFaces([faceA, faceB]) else {
+            Issue.record("shellFromFaces"); return
+        }
+        // Confirms the fixture is what it claims to be: 8 independent boundary edges, not already
+        // sewn by construction.
+        #expect(shell.edgeCount == 8)
+
+        guard let connected = shell.connectedFaces() else {
+            Issue.record("connectedFaces returned nil"); return
+        }
+        #expect(connected.faces().count == 2)
+        // The real assertion: the two coincident boundary edges merged into one shared edge.
+        #expect(connected.edgeCount == 7)
     }
 }

--- a/Tests/OCCTShapeHealingTests/Issue484FaceFixContextTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue484FaceFixContextTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #484: `Face.fixed(tolerance:)` was the fourth `ShapeFix_Face` construction in the bridge
+/// and the only one the #317 pass missed — it built a bare `ShapeFix_Face` with no
+/// `SetContext(new ShapeBuild_ReShape)`, leaving it exposed to the #317 mechanism
+/// (`FixPeriodicDegenerated` null-dereferencing `Context()`) on any unpatched kernel, and silently
+/// skipping the context-dependent fixes on a patched one. The only #317 regression test
+/// (`Issue317PeriodicConicalSingleWireTests`) covers `Shape.face(from:boundary:)`, a different call
+/// site.
+///
+/// These tests pin both halves: the #317 crash shape now goes through `Face.fixed(tolerance:)`, and
+/// ordinary faces must be unaffected by the added context (the real risk of the change).
+@Suite("Issue #484 — Face.fixed(tolerance:) gets a ReShape context")
+struct Issue484FaceFixContextTests {
+
+    /// The #317 shape — a single closed periodic curve belting a cone's full period — driven through
+    /// the `Face.fixed(tolerance:)` call site rather than `Shape.face(from:boundary:)`.
+    @Test("Face.fixed on a periodic conical single-wire face survives and stays valid")
+    func periodicConicalFaceSurvivesFaceFix() {
+        let ringPoints: [SIMD3<Double>] = (0..<8).map { i in
+            let angle = 2 * Double.pi * Double(i) / 8
+            return SIMD3(0.14 * cos(angle), 4.0 + 0.14 * sin(angle), -9.6)
+        }
+        guard let curve = Curve3D.interpolate(points: ringPoints, closed: true) else {
+            Issue.record("interpolate"); return
+        }
+        guard let edgeShape = Shape.edgeFromCurve(curve), let edge = Edge(edgeShape) else {
+            Issue.record("edgeFromCurve"); return
+        }
+        guard let wire = Wire.wireFromEdges([edge]) else {
+            Issue.record("wireFromEdges"); return
+        }
+        guard let cone = Surface.cone(origin: SIMD3(0, 4.0, -9.1), axis: SIMD3(0, 0.09, -1.0),
+                                      radius: 0, semiAngle: 0.35) else {
+            Issue.record("cone"); return
+        }
+        guard let faceShape = Shape.face(from: cone, boundary: wire) else {
+            Issue.record("face(from:boundary:)"); return
+        }
+        guard let face = faceShape.faces().first else {
+            Issue.record("no face in the healed shape"); return
+        }
+
+        // The call site under test. Before the fix this ran with a null Context(), which is the
+        // #317 null-deref on any kernel without Scripts/patches/0005.
+        guard let fixed = face.fixed(tolerance: 1e-6) else {
+            Issue.record("Face.fixed returned nil"); return
+        }
+        #expect(fixed.isValid)
+        #expect(fixed.faces().count == 1)
+    }
+
+    /// A conical face whose sole wire belts the full period, built through
+    /// `Surface.toFace(uvBoundary:)` — the one face factory that applies no healing at all, so the
+    /// face reaches `Face.fixed(tolerance:)` in its raw state.
+    @Test("Face.fixed on an unhealed full-period conical UV face returns a face")
+    func unhealedPeriodicConicalUVFaceSurvivesFaceFix() {
+        guard let cone = Surface.cone(origin: SIMD3(0, 0, 0), axis: SIMD3(0, 0, 1),
+                                      radius: 2.0, semiAngle: 0.4636476) else {
+            Issue.record("cone"); return
+        }
+        let belt: [SIMD2<Double>] = (0..<8).map { SIMD2(2 * Double.pi * Double($0) / 8, 3.0) }
+        guard let faceShape = cone.toFace(uvBoundary: belt) else {
+            Issue.record("toFace(uvBoundary:)"); return
+        }
+        guard let face = faceShape.faces().first else {
+            Issue.record("no face"); return
+        }
+        // No validity claim: this input is degenerate by construction (one wire belting a cone's
+        // period, no apex edge). What matters is that the call completes and returns a face.
+        guard let fixed = face.fixed(tolerance: 1e-6) else {
+            Issue.record("Face.fixed returned nil"); return
+        }
+        #expect(fixed.faces().count == 1)
+    }
+
+    /// The context is added unconditionally, so the guard against regression is that ordinary,
+    /// already-well-formed faces come back unchanged and valid.
+    @Test("Face.fixed leaves well-formed box faces valid")
+    func wellFormedBoxFacesUnaffected() {
+        guard let box = Shape.box(width: 10, height: 20, depth: 30) else {
+            Issue.record("box"); return
+        }
+        let faces = box.faces()
+        #expect(faces.count == 6)
+        for face in faces {
+            guard let fixed = face.fixed(tolerance: 1e-6) else {
+                Issue.record("Face.fixed returned nil for a box face"); continue
+            }
+            #expect(fixed.isValid)
+            #expect(fixed.faces().count == 1)
+        }
+    }
+
+    /// Same guard for an analytic curved face, where a seam is involved.
+    @Test("Face.fixed leaves cylinder faces valid")
+    func cylinderFacesUnaffected() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 12) else {
+            Issue.record("cylinder"); return
+        }
+        for face in cyl.faces() {
+            guard let fixed = face.fixed(tolerance: 1e-6) else {
+                Issue.record("Face.fixed returned nil for a cylinder face"); continue
+            }
+            #expect(fixed.isValid)
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,62 @@ All notable changes to OCCTSwift.
 
 ---
 
+## Unreleased
+
+### Pass 1b of the #377 duplication audit
+
+#### Two upstream OCCT null-context SIGSEGVs, patched and filed (#484)
+
+Auditing every `ShapeFix_Face` call site turned up two unpatched, never-filed crashes of the same
+class as #317: `ShapeFix_ComposeShell::Perform()`, `ShapeFix_ComposeShell::SplitEdges()` and
+`ShapeUpgrade_WireDivide::Perform()` dereference their `ShapeBuild_ReShape` context
+unconditionally, and that context is null unless the caller made an optional `SetContext()` call. A
+plain 4-edge planar square face crashes both classes 100% of the time. Both are the odd ones out in
+their own package: `ShapeUpgrade_FaceDivide::Perform()`, their only in-kernel driver, self-creates a
+context and hands it down, and nine other healing classes carry the same guard.
+
+Carried as `Scripts/patches/0017-*` and filed upstream as
+[OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409) (repro) /
+[OCCT#1410](https://github.com/Open-Cascade-SAS/OCCT/pull/1410) (fix). Verified via the override-link
+technique: both no-context cases SIGSEGV before and complete after, and the with-context path is
+byte-identical before and after (BREP dump hash plus topology counts, planar and cylindrical). Takes
+effect at the next xcframework rebuild; nothing regresses in the interim because the bridge already
+sets a context at both call sites. Reproducer and writeup:
+[`Scripts/repro/484-null-reshape-context/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/484-null-reshape-context).
+
+#### `Face.fixed(tolerance:)` now heals what it claims to (#484)
+
+`OCCTFaceFix` was the fourth `ShapeFix_Face` construction in the bridge and the only one the #317
+pass missed — it built a bare fixer with no context, so the fixes that record replacements silently
+did nothing (and on any kernel without `Scripts/patches/0005` it was exposed to the #317 null-deref).
+On the raw #317 shape, no context yields a `BRepCheck`-invalid face with no apex edge; with a context
+it is valid. Well-formed faces are unaffected.
+
+#### `Shape.connectedFaces(tolerance:)`: every shell, not just the first (#484)
+
+The function had **zero** test coverage repo-wide. Writing it surfaced a first-of-N defect of the
+#439/#442/#443 family: only the first shell an explorer yielded was connected and the rest were
+dropped, so a compound of two boxes came back with 6 faces instead of 12. Every shell is now
+processed and the results reassembled through the shared `occtSolidBodiesToShape` helper — a
+single-shell input still returns a bare shell, and the nil-on-failure contract is unchanged.
+
+#### Two stale cross-reference index entries corrected (#484)
+
+`OCCTBridge.h`'s index mapped `ShapeFix_Face → OCCTShapeFixFace` and
+`ShapeFix_FaceConnect → OCCTShapeFixConnect*`. Neither symbol exists anywhere in the codebase, so
+anyone using the index to find every `ShapeFix_Face` call site for a #317-class re-audit got zero
+hits — which is how the unpatched fourth site above went unnoticed. They now name the real symbols:
+`OCCTFaceFix`, `OCCTFaceFixer*` and the two `OCCTShapeCreateFaceFromSurfaceWire*` functions; and
+`OCCTShapeFixFaceConnect`, a single function rather than a family.
+
+New `Scripts/check-bridge-index.py` checks every index entry against the real symbols and exits 1 on
+any mismatch. Its first run showed the two #484 entries are not isolated: **139 of the index's 418
+symbol references name symbols that exist nowhere in `Sources/`**. Filed as #510 rather than fixed
+here — each stale entry needs its real call site identified, and inventing a plausible name for a
+class that has no wrap would be worse than leaving the entry visibly broken.
+
+---
+
 ## Release History
 
 ### v1.17.0 (July 2026): pass 1a of the #377 duplication audit, and two source-breaking changes in a minor release


### PR DESCRIPTION
Closes #484.

Targets `refactor/381-pass1b` per #484's own instruction, not `main`.

The issue asked for two stale index entries, an unguarded `ShapeFix_Face` call site, and missing test coverage. Chasing the SIGSEGV claim first, as directed, turned up two genuinely unpatched upstream OCCT crashes, so that work leads.

## 1. Two upstream OCCT null-context SIGSEGVs — patched and filed

`ShapeFix_ComposeShell::Perform()`, `ShapeFix_ComposeShell::SplitEdges()` and `ShapeUpgrade_WireDivide::Perform()` dereference their `ShapeBuild_ReShape` context unconditionally. `ShapeFix_Root::Context()` is null unless the caller made an optional `SetContext()` call, so `Init(...)` + `Perform()` — the usage the public API invites — is a null-handle dereference. **A plain 4-edge planar square face crashes both classes 100% of the time** (Address 0, uncatchable in-process).

Both are the odd ones out in their own package: `ShapeUpgrade_FaceDivide::Perform()`, their only in-kernel driver and the reason neither crash appears in OCCT's own test suite, self-creates a context and hands it down; nine other healing classes carry the same guard.

- Carried as `Scripts/patches/0017-null-reshape-context-ComposeShell-WireDivide-484.patch`
- Filed upstream: [OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409) (repro) / [OCCT#1410](https://github.com/Open-Cascade-SAS/OCCT/pull/1410) (fix) — format + non-ASCII checks green, builds running
- Reproducers and writeup: `Scripts/repro/484-null-reshape-context/`

**Verified** with the override-link technique (patched TUs linked ahead of the stock archive, no full rebuild):

| | stock p1 + 0001–0016 | patched |
|---|---|---|
| `WireDivide::Perform()`, no context | SIGSEGV | completes |
| `ComposeShell::Perform()`, no context | SIGSEGV | completes |
| either, **with** a context | works | **byte-identical** result |

Equivalence is a BREP dump hash plus face/wire/edge/vertex counts, for a planar and an unbounded-cylindrical face, both classes. The no-context path now yields exactly what the with-context path yields.

**Takes effect at the next xcframework rebuild** — no rebuild in this PR, and nothing regresses in the interim: both bridge call sites already call `SetContext` (with comments naming the SIGSEGV). The patch fixes the kernel so those workarounds can retire and the crash is closed for every other OCCT consumer.

Also checked and clean, so deliberately untouched: `ShapeFix_Face::Perform` with no context (`FixPeriodicDegenerated` is patch `0005`, `FixMissingSeam` self-creates, `FixIntersectingWires` bails out early), `ShapeFix_Wire`'s individual fixes, `ShapeUpgrade_RemoveInternalWires`, `ShapeFix_Edge`.

## 2. `Face.fixed(tolerance:)` gets a context

`OCCTFaceFix` was the fourth `ShapeFix_Face` construction in the bridge and the only one the #317 pass missed. Measured on the raw #317 shape: with no context, `Perform()` returns a `BRepCheck`-**invalid** face (2 wires, no degenerate apex edge); with one, a valid face (1 wire, 4 edges). On a kernel without patch `0005` the same call is the #317 null-deref.

Scope note, since the issue frames this as a live crash: on **our** kernel it is a correctness bug, not a crash — patch `0005` closed the crash. And the invalid-vs-valid divergence is **not reachable through the current Swift surface**: every Swift face factory either heals with a context already (`Shape.face(from:boundary:)`) or produces a face that needs no context-dependent fix. `Surface.toFace(uvBoundary:)` looked like the way in, but its implicit closing segment wraps `u` backwards across the period, so `IsPeriodicConicalLoop` never matches. The fix is therefore consistency and defence-in-depth against an unpatched kernel — stated plainly rather than dressed up with a test that proves less than it appears to.

## 3. `Shape.connectedFaces(tolerance:)`: every shell, not just the first

The function had **zero** coverage repo-wide. Writing it surfaced a first-of-N defect of the #439/#442/#443 family: only the first shell an explorer yielded was connected, the rest silently dropped — a compound of two boxes came back with 6 faces instead of 12. Now every shell is processed and reassembled through the shared `occtSolidBodiesToShape` helper; a single-shell input still returns a bare shell, and the nil-on-failure contract is unchanged (nil when no shell connected). Verified red pre-fix: `(connected.faces().count → 6) == 12`.

## 4. The two stale index entries

`ShapeFix_Face → OCCTShapeFixFace` and `ShapeFix_FaceConnect → OCCTShapeFixConnect*` both name symbols that exist nowhere, which is exactly how the unpatched fourth call site above stayed hidden — a re-audit by index-named symbol returns zero hits. Now `OCCTFaceFix`, `OCCTFaceFixer*`, both `OCCTShapeCreateFaceFromSurfaceWire*` functions; and `OCCTShapeFixFaceConnect`.

New `Scripts/check-bridge-index.py` gates this mechanically. **Its first run shows the two entries are far from isolated: 139 of the index's 418 symbol references name symbols that exist nowhere in `Sources/`.** Filed as #510 rather than fixed here — each stale entry needs its real call site identified first, and inventing a plausible name for a class that has no wrap is worse than leaving the entry visibly broken.

## Tests

`Tests/OCCTShapeHealingTests/Issue484FaceFixContextTests.swift` (4) and `Issue484ConnectedFacesTests.swift` (4): the #317 crash shape through `Face.fixed(tolerance:)`, an unhealed full-period conical UV face, no-regression checks on box and cylinder faces, and `connectedFaces` coverage including the multi-shell case and the no-shell nil.

Full `swift test`: **4633 tests / 1317 suites, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
