### PR TITLE
fix(#487): one conic dimension precondition, reaching the 2D gce factories too

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -251,27 +251,14 @@ void OCCTCurve3DD2(OCCTCurve3DRef c, double u,
 
 // Primitive Curves
 
-// Conic dimension preconditions, shared by the two factory families that build the
-// same four curve types: OCCTCurve3DCreate{Circle,Ellipse,Parabola,Hyperbola} (direct
+// Conic dimension preconditions (occtValidCircleRadius, occtValidEllipseRadii,
+// occtValidHyperbolaRadii, occtValidParabolaFocal) are shared by the two factory families that
+// build the same four curve types: OCCTCurve3DCreate{Circle,Ellipse,Parabola,Hyperbola} (direct
 // Geom_* construction) and OCCTGceMake{CircFromCenterNormal,Elips,Hypr,Parab} (gce_Make*
-// construction). The gce_Make* algorithms only reject strictly-negative dimensions, so
-// before #399 they silently produced degenerate zero-radius/zero-focal curves where the
-// direct family returned null for the identical input. One definition, both families.
-static inline bool occtValidCircleRadius(double radius) {
-    return radius > 0;
-}
-
-static inline bool occtValidEllipseRadii(double majorR, double minorR) {
-    return majorR > 0 && minorR > 0 && minorR <= majorR;
-}
-
-static inline bool occtValidHyperbolaRadii(double majorR, double minorR) {
-    return majorR > 0 && minorR > 0;
-}
-
-static inline bool occtValidParabolaFocal(double focal) {
-    return focal > 0;
-}
+// construction). #399 defined them here; #487 moved them to OCCTBridge_Internal.h once the 2D
+// factories in OCCTBridge_Geom2d.mm turned out to need the same four predicates, and its own
+// copy of one of them had already drifted out of reach of two of the passes that should have
+// applied it.
 
 OCCTCurve3DRef OCCTCurve3DCreateLine(double px, double py, double pz,
                                       double dx, double dy, double dz) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -102,14 +102,11 @@
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
 
-// Radius precondition for the 2D circle factories. Curve2D builds a circle from a centre and a
-// radius through two entry points — OCCTCurve2DCreateCircle (direct Geom2d_Circle construction)
-// and OCCTGceMakeCirc2dFromCenterRadius (gce_MakeCirc2d) — and gce_MakeCirc2d accepts
-// Radius >= 0, so before #411 the gce path returned a live, degenerate zero-radius circle where
-// the direct path returned null for the identical input. One definition, both entry points.
-static inline bool occtValidCircle2dRadius(double radius) {
-    return radius > 0;
-}
+// The conic dimension preconditions this file's factories share with Curve3D's
+// (occtValidCircleRadius, occtValidEllipseRadii, occtValidHyperbolaRadii, occtValidParabolaFocal)
+// live in OCCTBridge_Internal.h. #411 introduced a 2D-suffixed copy of the circle one here, which
+// is how the 2D ellipse/hyperbola/parabola factories ended up skipped by both #411 and #399's
+// otherwise-identical pass over the 3D side; #487 converged them.
 
 // One Geom2dAPI_ProjectPointOnCurve construction behind every entry point that wants the nearest
 // solution: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D and OCCTPoint2DDistanceToCurve.
@@ -2883,7 +2880,7 @@ OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef curve1, d
 // MARK: - gce_Make Circ2d / Lin2d / Elips2d / Hypr2d / Parab2d (v0.80)
 OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius) {
     try {
-        if (!occtValidCircle2dRadius(radius)) return nullptr;
+        if (!occtValidCircleRadius(radius)) return nullptr;
         gce_MakeCirc2d mc(gp_Pnt2d(cx, cy), radius);
         if (!mc.IsDone()) return nullptr;
         Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
@@ -2925,6 +2922,7 @@ OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx, double cy,
                                              double dirX, double dirY,
                                              double majorRadius, double minorRadius) {
     try {
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
         gce_MakeElips2d me(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius);
         if (!me.IsDone()) return nullptr;
         Handle(Geom2d_Ellipse) elips = new Geom2d_Ellipse(me.Value());
@@ -2936,6 +2934,7 @@ OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx, double cy,
                                              double dirX, double dirY,
                                              double majorRadius, double minorRadius) {
     try {
+        if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
         gce_MakeHypr2d mh(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius, true);
         if (!mh.IsDone()) return nullptr;
         Handle(Geom2d_Hyperbola) hypr = new Geom2d_Hyperbola(mh.Value());
@@ -2947,6 +2946,7 @@ OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
                                               double dirX, double dirY,
                                               double focal) {
     try {
+        if (!occtValidParabolaFocal(focal)) return nullptr;
         gce_MakeParab2d mp(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), focal);
         if (!mp.IsDone()) return nullptr;
         Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(mp.Value());
@@ -5021,7 +5021,7 @@ OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, doub
 
 OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius) {
     try {
-        if (!occtValidCircle2dRadius(radius)) return nullptr;
+        if (!occtValidCircleRadius(radius)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Ax2d axis(center, gp_Dir2d(1, 0));
         Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
@@ -5034,7 +5034,7 @@ OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius) {
 OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx, double cy, double radius,
                                             double startAngle, double endAngle) {
     try {
-        if (!occtValidCircle2dRadius(radius)) return nullptr;
+        if (!occtValidCircleRadius(radius)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Ax2d axis(center, gp_Dir2d(1, 0));
         Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
@@ -5063,7 +5063,7 @@ OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x, double p1y,
 OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx, double cy,
                                         double majorR, double minorR, double rotation) {
     try {
-        if (majorR <= 0 || minorR <= 0 || minorR > majorR) return nullptr;
+        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Dir2d majorDir(cos(rotation), sin(rotation));
         gp_Ax22d axes(center, majorDir);
@@ -5079,7 +5079,7 @@ OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx, double cy,
                                              double rotation,
                                              double startAngle, double endAngle) {
     try {
-        if (majorR <= 0 || minorR <= 0 || minorR > majorR) return nullptr;
+        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Dir2d majorDir(cos(rotation), sin(rotation));
         gp_Ax22d axes(center, majorDir);
@@ -5094,7 +5094,7 @@ OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx, double cy,
 OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy,
                                          double dx, double dy, double focal) {
     try {
-        if (focal <= 0) return nullptr;
+        if (!occtValidParabolaFocal(focal)) return nullptr;
         gp_Pnt2d mirrorP(fx - dx * focal, fy - dy * focal);
         gp_Dir2d dir(dx, dy);
         gp_Ax2d axis(mirrorP, dir);
@@ -5109,7 +5109,7 @@ OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx, double cy,
                                           double majorR, double minorR,
                                           double rotation) {
     try {
-        if (majorR <= 0 || minorR <= 0) return nullptr;
+        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Dir2d majorDir(cos(rotation), sin(rotation));
         gp_Ax22d axes(center, majorDir);
@@ -5810,7 +5810,7 @@ OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx, double cy,
                                                double rotation,
                                                double startAngle, double endAngle) {
     try {
-        if (majorR <= 0 || minorR <= 0) return nullptr;
+        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
         gp_Pnt2d center(cx, cy);
         gp_Dir2d majorDir(cos(rotation), sin(rotation));
         gp_Ax22d axes(center, majorDir);
@@ -5826,7 +5826,7 @@ OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx, double fy,
                                               double dx, double dy, double focal,
                                               double startParam, double endParam) {
     try {
-        if (focal <= 0) return nullptr;
+        if (!occtValidParabolaFocal(focal)) return nullptr;
         gp_Pnt2d mirrorP(fx - dx * focal, fy - dy * focal);
         gp_Dir2d dir(dx, dy);
         gp_Ax2d axis(mirrorP, dir);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -398,4 +398,61 @@ int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, Kn
     return nbSplits;
 }
 
+// === #399/#411/#487: conic dimension preconditions ===
+//
+// The dimensions a circle, ellipse, hyperbola or parabola needs in order to be that curve rather
+// than a degenerate stand-in for a point or a line. Not dimension-specific: whether the conic is
+// built in a plane or in space changes nothing about which radii describe one, so these four
+// predicates serve both the Curve3D and the Curve2D factories.
+//
+// Two families build each curve type from caller-supplied dimensions, and every one of them needs
+// the same answer: the direct family (OCCTCurve3DCreate*, OCCTCurve2DCreate*, including the ArcOf*
+// variants) constructing a Geom_* / Geom2d_* object outright, and the gce family (OCCTGceMake*,
+// OCCTGceMake*2d) going through a gce_Make* algorithm first.
+//
+// They must be checked here, in the bridge, and not left to OCCT. Every OCCT precondition is
+// written as a *_Raise_if macro, and the pinned OCCT.xcframework is a Release build, where OCCT's
+// own BUILD_RELEASE_DISABLE_EXCEPTIONS (default ON) defines No_Exception and expands all of those
+// macros to nothing inside OCCT's translation units. So the checks OCCT documents in its headers do
+// not run in this build; measured consequences (#487):
+//
+//   - gce_MakeElips2d(ax, 5, -3) reports gce_Done and yields a live Geom2d_Ellipse whose
+//     MinorRadius() is -3. Its own two checks (MajorRadius < 0, MajorRadius < MinorRadius) do not
+//     cover that input, and gp_Elips2d's check, which would, is compiled out.
+//   - gce_MakeHypr2d(ax, 0, 0, true) and gce_MakeParab2d(ax, 0) both succeed, as do the
+//     corresponding direct Geom2d_Hyperbola / Geom2d_Parabola constructors. OCCT accepts these
+//     through every route; rejecting them is entirely this bridge's contract.
+//
+// A degenerate conic is not a harmless curve either: a zero-radius ellipse evaluates to its own
+// centre at every parameter while still reporting a [0, 2pi] range, so it reads as a curve
+// everywhere downstream and behaves as a point.
+//
+// One definition each, because the alternative is what the audit found: #399 added these four to
+// OCCTBridge_Curve3D.mm, #411 added a byte-equivalent occtValidCircle2dRadius to
+// OCCTBridge_Geom2d.mm, and the 2D direct factories spelled the same conditions inline in six more
+// places, which is how the 2D gce factories came to be skipped by both passes.
+
+// A circle needs a positive radius. Zero collapses it to its own centre.
+inline bool occtValidCircleRadius(double radius) {
+    return radius > 0;
+}
+
+// An ellipse needs both radii positive, and the minor no larger than the major, which is the
+// orientation OCCT's own gp_Elips2d/gp_Elips invariant requires.
+inline bool occtValidEllipseRadii(double majorR, double minorR) {
+    return majorR > 0 && minorR > 0 && minorR <= majorR;
+}
+
+// A hyperbola needs both radii positive. Unlike an ellipse it puts no ordering on them: a minor
+// radius larger than the major is an ordinary hyperbola, not an inverted one.
+inline bool occtValidHyperbolaRadii(double majorR, double minorR) {
+    return majorR > 0 && minorR > 0;
+}
+
+// A parabola needs a positive focal length. At zero it degenerates to a line parallel to its own
+// axis of symmetry, which is gp_Parab2d's documented behaviour, not an error it reports.
+inline bool occtValidParabolaFocal(double focal) {
+    return focal > 0;
+}
+
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -147,11 +147,21 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Create a full ellipse.
+    ///
     /// - Parameters:
     ///   - center: Center point
-    ///   - majorRadius: Semi-major axis length (must be >= minorRadius)
-    ///   - minorRadius: Semi-minor axis length
+    ///   - majorRadius: Semi-major axis length. Must be `> 0` and `>= minorRadius`.
+    ///   - minorRadius: Semi-minor axis length. Must be `> 0`.
     ///   - rotation: Rotation of the major axis from the X axis (radians)
+    /// - Returns: The ellipse, or `nil` if either radius is not positive or `minorRadius` exceeds
+    ///   `majorRadius`.
+    ///
+    /// ```swift
+    /// let e = Curve2D.ellipse(center: .zero, majorRadius: 10, minorRadius: 5)
+    /// #expect(e != nil)
+    /// #expect(Curve2D.ellipse(center: .zero, majorRadius: 0, minorRadius: 0) == nil)
+    /// #expect(Curve2D.ellipse(center: .zero, majorRadius: 5, minorRadius: 10) == nil)
+    /// ```
     public static func ellipse(center: SIMD2<Double>, majorRadius: Double,
                                minorRadius: Double, rotation: Double = 0) -> Curve2D? {
         guard let h = OCCTCurve2DCreateEllipse(center.x, center.y,
@@ -170,10 +180,19 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Create a parabola.
+    ///
     /// - Parameters:
     ///   - focus: Focus point of the parabola
     ///   - direction: Axis direction (from vertex toward focus)
-    ///   - focalLength: Distance from vertex to focus
+    ///   - focalLength: Distance from vertex to focus. Must be `> 0`; at zero the parabola
+    ///     degenerates into a line parallel to its own axis.
+    /// - Returns: The parabola, or `nil` if `focalLength <= 0`.
+    ///
+    /// ```swift
+    /// let p = Curve2D.parabola(focus: .zero, direction: SIMD2(1, 0), focalLength: 1)
+    /// #expect(p != nil)
+    /// #expect(Curve2D.parabola(focus: .zero, direction: SIMD2(1, 0), focalLength: 0) == nil)
+    /// ```
     public static func parabola(focus: SIMD2<Double>, direction: SIMD2<Double>,
                                 focalLength: Double) -> Curve2D? {
         guard let h = OCCTCurve2DCreateParabola(focus.x, focus.y,
@@ -183,6 +202,23 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Create a hyperbola.
+    ///
+    /// Unlike an ellipse, a hyperbola puts no ordering on its radii: a minor radius larger than the
+    /// major one is an ordinary hyperbola and is accepted.
+    ///
+    /// - Parameters:
+    ///   - center: Center point
+    ///   - majorRadius: Semi-major axis length. Must be `> 0`.
+    ///   - minorRadius: Semi-minor axis length. Must be `> 0`.
+    ///   - rotation: Rotation of the major axis from the X axis (radians)
+    /// - Returns: The hyperbola, or `nil` if either radius is not positive.
+    ///
+    /// ```swift
+    /// let h = Curve2D.hyperbola(center: .zero, majorRadius: 5, minorRadius: 3)
+    /// #expect(h != nil)
+    /// #expect(Curve2D.hyperbola(center: .zero, majorRadius: 3, minorRadius: 5) != nil)
+    /// #expect(Curve2D.hyperbola(center: .zero, majorRadius: 0, minorRadius: 0) == nil)
+    /// ```
     public static func hyperbola(center: SIMD2<Double>, majorRadius: Double,
                                  minorRadius: Double, rotation: Double = 0) -> Curve2D? {
         guard let h = OCCTCurve2DCreateHyperbola(center.x, center.y,
@@ -1989,8 +2025,8 @@ extension Curve2D {
 
     /// Create a 2D circle from center + radius (`gce_MakeCirc2d`).
     ///
-    /// Geometrically identical to `circle(center:radius:)` — both produce a `Geom2d_Circle` on
-    /// the same X-axis-oriented frame — and, since #411, enforces the same radius contract.
+    /// Geometrically identical to `circle(center:radius:)` (both produce a `Geom2d_Circle` on the
+    /// same X-axis-oriented frame) and, since #411, enforces the same radius contract.
     ///
     /// - Parameters:
     ///   - center: Circle centre.
@@ -2029,7 +2065,30 @@ extension Curve2D {
         return Curve2D(handle: h)
     }
 
-    /// Create a 2D ellipse (gce_MakeElips2d)
+    /// Create a 2D ellipse from centre, major-axis direction and radii (`gce_MakeElips2d`).
+    ///
+    /// Geometrically identical to `ellipse(center:majorRadius:minorRadius:rotation:)`, which takes
+    /// the major-axis direction as a rotation angle instead of a vector, and since #487 enforces the
+    /// same radius contract.
+    ///
+    /// - Parameters:
+    ///   - center: Ellipse centre.
+    ///   - direction: Major-axis direction.
+    ///   - majorRadius: Semi-major axis length. Must be `> 0` and `>= minorRadius`.
+    ///   - minorRadius: Semi-minor axis length. Must be `> 0`.
+    /// - Returns: The ellipse, or `nil` if either radius is not positive or `minorRadius` exceeds
+    ///   `majorRadius`.
+    ///
+    /// ```swift
+    /// let e = Curve2D.ellipseFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+    ///                                      majorRadius: 8, minorRadius: 4)
+    /// #expect(e != nil)
+    /// // Same rejections as the direct factory: no degenerate ellipse, no negative minor radius.
+    /// #expect(Curve2D.ellipseFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+    ///                                      majorRadius: 0, minorRadius: 0) == nil)
+    /// #expect(Curve2D.ellipseFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+    ///                                      majorRadius: 5, minorRadius: -3) == nil)
+    /// ```
     public static func ellipseFromCenterDir(center: SIMD2<Double>, direction: SIMD2<Double>,
                                             majorRadius: Double,
                                             minorRadius: Double) -> Curve2D? {
@@ -2038,7 +2097,33 @@ extension Curve2D {
         return Curve2D(handle: h)
     }
 
-    /// Create a 2D hyperbola (gce_MakeHypr2d)
+    /// Create a 2D hyperbola from centre, major-axis direction and radii (`gce_MakeHypr2d`).
+    ///
+    /// Geometrically identical to `hyperbola(center:majorRadius:minorRadius:rotation:)`, which takes
+    /// the major-axis direction as a rotation angle instead of a vector, and since #487 enforces the
+    /// same radius contract.
+    ///
+    /// Unlike an ellipse, a hyperbola puts no ordering on its radii: a minor radius larger than the
+    /// major one is an ordinary hyperbola and is accepted.
+    ///
+    /// - Parameters:
+    ///   - center: Hyperbola centre.
+    ///   - direction: Major-axis direction.
+    ///   - majorRadius: Semi-major axis length. Must be `> 0`.
+    ///   - minorRadius: Semi-minor axis length. Must be `> 0`.
+    /// - Returns: The hyperbola, or `nil` if either radius is not positive.
+    ///
+    /// ```swift
+    /// let h = Curve2D.hyperbolaFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+    ///                                        majorRadius: 6, minorRadius: 3)
+    /// #expect(h != nil)
+    /// // Minor larger than major is a valid hyperbola, unlike for an ellipse.
+    /// #expect(Curve2D.hyperbolaFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+    ///                                        majorRadius: 3, minorRadius: 6) != nil)
+    /// // Same rejection as the direct factory: no degenerate zero-radius hyperbola.
+    /// #expect(Curve2D.hyperbolaFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+    ///                                        majorRadius: 0, minorRadius: 0) == nil)
+    /// ```
     public static func hyperbolaFromCenterDir(center: SIMD2<Double>, direction: SIMD2<Double>,
                                               majorRadius: Double,
                                               minorRadius: Double) -> Curve2D? {
@@ -2047,7 +2132,26 @@ extension Curve2D {
         return Curve2D(handle: h)
     }
 
-    /// Create a 2D parabola (gce_MakeParab2d)
+    /// Create a 2D parabola from a point on its axis of symmetry, that axis' direction, and the
+    /// focal length (`gce_MakeParab2d`).
+    ///
+    /// `center` is the parabola's vertex, so this places the curve the same way
+    /// `parabola(focus:direction:focalLength:)` does once that factory has stepped back from the
+    /// focus to the vertex. Since #487 both enforce the same focal-length contract.
+    ///
+    /// - Parameters:
+    ///   - center: Vertex of the parabola.
+    ///   - direction: Direction of the axis of symmetry.
+    ///   - focal: Distance from vertex to focus. Must be `> 0`; at zero the parabola degenerates
+    ///     into a line parallel to its own axis.
+    /// - Returns: The parabola, or `nil` if `focal <= 0`.
+    ///
+    /// ```swift
+    /// let p = Curve2D.parabolaFromCenterDir(center: .zero, direction: SIMD2(1, 0), focal: 3)
+    /// #expect(p != nil)
+    /// // Same rejection as the direct factory: a zero focal length is a line, not a parabola.
+    /// #expect(Curve2D.parabolaFromCenterDir(center: .zero, direction: SIMD2(1, 0), focal: 0) == nil)
+    /// ```
     public static func parabolaFromCenterDir(center: SIMD2<Double>, direction: SIMD2<Double>,
                                              focal: Double) -> Curve2D? {
         guard let h = OCCTGceMakeParab2d(center.x, center.y, direction.x, direction.y,

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4307,6 +4307,133 @@ struct Curve2DCircleFactoryParityTests {
     }
 }
 
+// MARK: - #487: Curve2D's two ellipse/hyperbola/parabola factory families
+
+/// The three remaining `Curve2D` conic types exist twice over, exactly as the circle did before
+/// #411 and as the four 3D conics did before #399: a direct family building a `Geom2d_*` object
+/// from a `gp_Ax22d`, and a `*FromCenterDir` family routing through OCCT's `gce_Make*2d`
+/// algorithms. The two are geometrically identical, but only the direct family carried a dimension
+/// precondition, so the gce family returned live degenerate curves for input its sibling rejected.
+///
+/// The preconditions have to live in the bridge rather than be left to OCCT. Measured against the
+/// pinned xcframework, `gce_MakeHypr2d(ax, 0, 0, true)` and `gce_MakeParab2d(ax, 0)` both report
+/// `gce_Done`, as do the corresponding `Geom2d_Hyperbola`/`Geom2d_Parabola` constructors: OCCT
+/// accepts these through every route. `gce_MakeElips2d(ax, 5, -3)` goes further and yields an
+/// ellipse reporting `MinorRadius() == -3`, because its own two checks do not cover that input and
+/// `gp_Elips2d`'s check, which does, is compiled out of the Release-built kernel by OCCT's
+/// `No_Exception`. So there is no OCCT-side contract to inherit here, only one to impose.
+@Suite("Curve2D conic factories agree (#487)")
+struct Curve2DConicFactoryParityTests {
+
+    private static let center = SIMD2<Double>(3, -4)
+    private static let xDir = SIMD2<Double>(1, 0)
+
+    @Test("Ellipse: both families reject zero, negative and inverted radii")
+    func ellipseDegenerateRadiiParity() {
+        let rejected: [(Double, Double)] = [(0, 0), (8, 0), (0, 4), (8, -4), (-8, 4), (4, 8)]
+        for (major, minor) in rejected {
+            #expect(Curve2D.ellipse(center: Self.center,
+                                    majorRadius: major, minorRadius: minor) == nil)
+            #expect(Curve2D.ellipseFromCenterDir(center: Self.center, direction: Self.xDir,
+                                                 majorRadius: major, minorRadius: minor) == nil)
+        }
+    }
+
+    @Test("Hyperbola: both families reject a zero or negative radius")
+    func hyperbolaDegenerateRadiiParity() {
+        let rejected: [(Double, Double)] = [(0, 0), (6, 0), (0, 3), (6, -3), (-6, 3)]
+        for (major, minor) in rejected {
+            #expect(Curve2D.hyperbola(center: Self.center,
+                                      majorRadius: major, minorRadius: minor) == nil)
+            #expect(Curve2D.hyperbolaFromCenterDir(center: Self.center, direction: Self.xDir,
+                                                   majorRadius: major, minorRadius: minor) == nil)
+        }
+    }
+
+    @Test("Parabola: both families reject zero and negative focal length")
+    func parabolaDegenerateFocalParity() {
+        for focal in [0.0, -1.0, -3.0] {
+            #expect(Curve2D.parabola(focus: Self.center, direction: Self.xDir,
+                                     focalLength: focal) == nil)
+            #expect(Curve2D.parabolaFromCenterDir(center: Self.center, direction: Self.xDir,
+                                                  focal: focal) == nil)
+        }
+    }
+
+    @Test("Hyperbola: a minor radius larger than the major is accepted by both families")
+    func hyperbolaMinorLargerThanMajorAcceptedByBoth() {
+        // A hyperbola puts no ordering on its radii, unlike an ellipse. Pinned so the shared
+        // precondition is not tightened into the ellipse's rule by a later pass.
+        #expect(Curve2D.hyperbola(center: Self.center, majorRadius: 3, minorRadius: 6) != nil)
+        #expect(Curve2D.hyperbolaFromCenterDir(center: Self.center, direction: Self.xDir,
+                                               majorRadius: 3, minorRadius: 6) != nil)
+    }
+
+    @Test("Ellipse: equal radii are accepted by both families")
+    func ellipseEqualRadiiAcceptedByBoth() {
+        // gp_Elips2d documents MajorRadius == MinorRadius as valid, so the shared precondition
+        // must reject only minor > major, not minor >= major.
+        #expect(Curve2D.ellipse(center: Self.center, majorRadius: 5, minorRadius: 5) != nil)
+        #expect(Curve2D.ellipseFromCenterDir(center: Self.center, direction: Self.xDir,
+                                             majorRadius: 5, minorRadius: 5) != nil)
+    }
+
+    @Test("Valid ellipse radii still build the identical curve in both families")
+    func validEllipseProducesMatchingGeometry() {
+        let direct = Curve2D.ellipse(center: Self.center, majorRadius: 8, minorRadius: 4)
+        let gce = Curve2D.ellipseFromCenterDir(center: Self.center, direction: Self.xDir,
+                                               majorRadius: 8, minorRadius: 4)
+        #expect(direct != nil)
+        #expect(gce != nil)
+        guard let a = direct, let b = gce else { return }
+
+        #expect(a.isClosed == b.isClosed)
+        #expect(a.isPeriodic == b.isPeriodic)
+        for t in stride(from: 0.0, to: 2 * .pi, by: .pi / 6) {
+            let pa = a.point(at: t), pb = b.point(at: t)
+            #expect(abs(pa.x - pb.x) < 1e-9)
+            #expect(abs(pa.y - pb.y) < 1e-9)
+        }
+    }
+
+    @Test("Valid hyperbola radii still build the identical curve in both families")
+    func validHyperbolaProducesMatchingGeometry() {
+        let direct = Curve2D.hyperbola(center: Self.center, majorRadius: 6, minorRadius: 3)
+        let gce = Curve2D.hyperbolaFromCenterDir(center: Self.center, direction: Self.xDir,
+                                                 majorRadius: 6, minorRadius: 3)
+        #expect(direct != nil)
+        #expect(gce != nil)
+        guard let a = direct, let b = gce else { return }
+
+        for t in stride(from: -1.0, through: 1.0, by: 0.25) {
+            let pa = a.point(at: t), pb = b.point(at: t)
+            #expect(abs(pa.x - pb.x) < 1e-9)
+            #expect(abs(pa.y - pb.y) < 1e-9)
+        }
+    }
+
+    @Test("Valid focal length still builds the identical parabola in both families")
+    func validParabolaProducesMatchingGeometry() {
+        // The two factories locate the curve from different points: parabolaFromCenterDir takes
+        // the vertex (gce_MakeParab2d's MirrorAxis location), parabola takes the focus and steps
+        // back along the axis to reach it. Same curve once the focus is placed accordingly.
+        let focal = 3.0
+        let vertex = Self.center
+        let focus = vertex + Self.xDir * focal
+        let direct = Curve2D.parabola(focus: focus, direction: Self.xDir, focalLength: focal)
+        let gce = Curve2D.parabolaFromCenterDir(center: vertex, direction: Self.xDir, focal: focal)
+        #expect(direct != nil)
+        #expect(gce != nil)
+        guard let a = direct, let b = gce else { return }
+
+        for t in stride(from: -2.0, through: 2.0, by: 0.5) {
+            let pa = a.point(at: t), pb = b.point(at: t)
+            #expect(abs(pa.x - pb.x) < 1e-9)
+            #expect(abs(pa.y - pb.y) < 1e-9)
+        }
+    }
+}
+
 // MARK: - #412: interpolatePeriodic is interpolate(closed: true)
 
 /// `Curve2D.interpolatePeriodic(points:)` and `Curve2D.interpolate(through:closed:tolerance:)`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,53 @@ symbol references name symbols that exist nowhere in `Sources/`**. Filed as #510
 here — each stale entry needs its real call site identified, and inventing a plausible name for a
 class that has no wrap would be worse than leaving the entry visibly broken.
 
+#### The 2D conic factories reject degenerate dimensions, like their siblings already did (#487)
+
+**Behaviour change.** `Curve2D.ellipseFromCenterDir`, `Curve2D.hyperbolaFromCenterDir` and
+`Curve2D.parabolaFromCenterDir` now return `nil` for dimensions that cannot describe the curve they
+name, matching the direct factories (`Curve2D.ellipse`, `Curve2D.hyperbola`, `Curve2D.parabola`) they
+are geometrically identical to. Previously they had no precondition at all and returned a live,
+degenerate curve:
+
+| call | before | now |
+|---|---|---|
+| `ellipseFromCenterDir(majorRadius: 0, minorRadius: 0)` | ellipse whose every point is its centre | `nil` |
+| `ellipseFromCenterDir(majorRadius: 8, minorRadius: 0)` | ellipse with a zero minor radius | `nil` |
+| `ellipseFromCenterDir(majorRadius: 5, minorRadius: -3)` | ellipse reporting `MinorRadius() == -3` | `nil` |
+| `hyperbolaFromCenterDir(majorRadius: 0, minorRadius: 0)` | degenerate hyperbola | `nil` |
+| `hyperbolaFromCenterDir(majorRadius: 6, minorRadius: 0)` | degenerate hyperbola | `nil` |
+| `parabolaFromCenterDir(focal: 0)` | parabola collapsed to a line | `nil` |
+
+Valid input is unaffected: both families still build the same curve, verified pointwise. Equal
+ellipse radii stay valid, and a hyperbola with its minor radius larger than its major stays valid,
+since neither is degenerate.
+
+This is the same gap #399 closed for the four 3D conics and #411 closed for the 2D circle. Neither
+pass reached the 2D ellipse, hyperbola or parabola, because the predicate had been copied rather than
+shared: #399 left four `static inline` helpers in `OCCTBridge_Curve3D.mm`, #411 added a
+byte-equivalent fifth (`occtValidCircle2dRadius`) in `OCCTBridge_Geom2d.mm`, and the 2D direct
+factories spelled the same conditions inline in six more places. All twelve now call one of four
+definitions in `OCCTBridge_Internal.h`. A conic's radii do not depend on whether it lives in a plane
+or in space, so there is nothing for a 2D copy to say differently.
+
+Worth recording for future audits of this kind: **no precondition inside the OCCT library is
+load-bearing in this build.** Every one is written as a `*_Raise_if` macro, and the pinned
+`OCCT.xcframework` is a Release build, where OCCT's own `BUILD_RELEASE_DISABLE_EXCEPTIONS` (default
+ON) defines `No_Exception` and expands all of them to nothing inside OCCT's translation units. That
+is why `gce_MakeElips2d(ax, 5, -3)` reports `gce_Done`: its own two checks do not cover that input,
+and `gp_Elips2d`'s check, which does, is not compiled. The bridge's `.mm` files are built without
+that macro, so the identical constructor called from the bridge does throw. For the hyperbola and
+parabola cases the divergence was never an OCCT accept/reject asymmetry at all: OCCT accepts
+`(0, 0)` and `focal == 0` through both routes, and rejecting them is entirely this bridge's contract.
+
+Six more `OCCTBridge_Geom2d.mm` sites build a 2D conic from caller dimensions with no precondition
+(`OCCTConvertEllipseToBSpline2D`, `OCCTConvertHyperbolaToBSpline2D`, `OCCTConvertParabolaToBSpline2D`,
+`OCCTMakeEdge2dEllipse`, `OCCTMakeEdge2dEllipseArc`, `OCCTConic2dFromEllipse`) and none of their
+downstream algorithms self-reject: a zero-radius ellipse yields a 5-pole BSpline, an edge reporting
+`IsDone()`, and six zero conic coefficients respectively. Filed as #514 rather than swept in here;
+two of them have no nil channel to report a rejection through and each needs its own contract
+decision.
+
 ---
 
 ## Release History

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1209,9 +1209,10 @@ public static func ellipseFromCenterDir(
 ) -> Curve2D?
 ```
 
-- **Parameters:** `center` — center point; `direction` — unit direction of the major axis; `majorRadius`/`minorRadius` — semi-axes.
-- **Returns:** `Curve2D` (ellipse), or `nil` if radii are non-positive.
+- **Parameters:** `center` — center point; `direction` — unit direction of the major axis; `majorRadius`/`minorRadius` — semi-axes (both must be > 0, and `minorRadius` no larger than `majorRadius`).
+- **Returns:** `Curve2D` (ellipse), or `nil` if either radius is non-positive or `minorRadius` exceeds `majorRadius`.
 - **OCCT:** `gce_MakeElips2d`.
+- **Note:** Geometrically identical to [`ellipse(center:majorRadius:minorRadius:rotation:)`](Curve2D.md), which takes the major-axis direction as a rotation angle, and since #487 enforces the same radius precondition. This page documented the rejection before #487, but only the direct factory performed it: `gce_MakeElips2d` accepted zero radii and, for `majorRadius: 5, minorRadius: -3`, returned an ellipse reporting a minor radius of -3. Equal radii remain valid.
 - **Example:**
   ```swift
   if let e = Curve2D.ellipseFromCenterDir(
@@ -1219,6 +1220,9 @@ public static func ellipseFromCenterDir(
       majorRadius: 5, minorRadius: 3) {
       print(e.ellipseProperties.majorRadius)
   }
+  // Degenerate dimensions are rejected, matching the direct factory.
+  Curve2D.ellipseFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+                               majorRadius: 0, minorRadius: 0)  // nil
   ```
 
 ---
@@ -1234,9 +1238,10 @@ public static func hyperbolaFromCenterDir(
 ) -> Curve2D?
 ```
 
-- **Parameters:** `center` — center; `direction` — unit direction of the real axis; `majorRadius`/`minorRadius` — real and imaginary semi-axes.
-- **Returns:** `Curve2D` (hyperbola), or `nil` on failure.
+- **Parameters:** `center` — center; `direction` — unit direction of the real axis; `majorRadius`/`minorRadius` — real and imaginary semi-axes (both must be > 0, in either order).
+- **Returns:** `Curve2D` (hyperbola), or `nil` if either radius is non-positive.
 - **OCCT:** `gce_MakeHypr2d`.
+- **Note:** Geometrically identical to [`hyperbola(center:majorRadius:minorRadius:rotation:)`](Curve2D.md), which takes the real-axis direction as a rotation angle, and since #487 enforces the same radius precondition. OCCT itself accepts zero radii through both routes, so the rejection is the bridge's contract, not OCCT's. Unlike an ellipse, a hyperbola puts no ordering on its radii: a minor radius larger than the major is an ordinary hyperbola and is accepted.
 - **Example:**
   ```swift
   if let h = Curve2D.hyperbolaFromCenterDir(
@@ -1244,6 +1249,9 @@ public static func hyperbolaFromCenterDir(
       majorRadius: 4, minorRadius: 3) {
       print(h.hyperbolaProperties.eccentricity)
   }
+  // Degenerate dimensions are rejected, matching the direct factory.
+  Curve2D.hyperbolaFromCenterDir(center: .zero, direction: SIMD2(1, 0),
+                                 majorRadius: 6, minorRadius: 0)  // nil
   ```
 
 ---
@@ -1259,15 +1267,18 @@ public static func parabolaFromCenterDir(
 ) -> Curve2D?
 ```
 
-- **Parameters:** `center` — vertex of the parabola; `direction` — axis direction; `focal` — focal distance.
-- **Returns:** `Curve2D` (parabola), or `nil` on failure.
+- **Parameters:** `center` — vertex of the parabola; `direction` — axis direction; `focal` — focal distance (must be > 0).
+- **Returns:** `Curve2D` (parabola), or `nil` if `focal ≤ 0`.
 - **OCCT:** `gce_MakeParab2d`.
+- **Note:** Places the same curve as [`parabola(focus:direction:focalLength:)`](Curve2D.md) once that factory's `focus` is set to `center + direction * focal`, and since #487 enforces the same focal-length precondition. OCCT itself accepts `focal == 0` through both routes (`gp_Parab2d` documents the result as a line parallel to the axis of symmetry), so the rejection is the bridge's contract, not OCCT's.
 - **Example:**
   ```swift
   if let p = Curve2D.parabolaFromCenterDir(
       center: .zero, direction: SIMD2(1, 0), focal: 2) {
       print(p.parabolaProperties.focal)  // 2.0
   }
+  // A zero focal length is a line, not a parabola.
+  Curve2D.parabolaFromCenterDir(center: .zero, direction: SIMD2(1, 0), focal: 0)  // nil
   ```
 
 ---

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -304,12 +304,14 @@ public static func ellipse(center: SIMD2<Double>, majorRadius: Double,
                            minorRadius: Double, rotation: Double = 0) -> Curve2D?
 ```
 
-- **Parameters:** `center` — ellipse centre; `majorRadius` — semi-major axis (must be ≥ `minorRadius`); `minorRadius` — semi-minor axis; `rotation` — rotation of the major axis from the X axis in radians (default 0).
-- **Returns:** Full ellipse curve, or `nil` on failure.
+- **Parameters:** `center` — ellipse centre; `majorRadius` — semi-major axis (must be > 0 and ≥ `minorRadius`); `minorRadius` — semi-minor axis (must be > 0); `rotation` — rotation of the major axis from the X axis in radians (default 0).
+- **Returns:** Full ellipse curve, or `nil` if either radius is ≤ 0 or `minorRadius` exceeds `majorRadius`. Equal radii are valid.
 - **OCCT:** `Geom2d_Ellipse(gp_Elips2d(...))`.
+- **See also:** [`ellipseFromCenterDir(center:direction:majorRadius:minorRadius:)`](Curve2D-Analysis.md) builds the identical ellipse through OCCT's `gce_MakeElips2d` algorithm and enforces the same radius contract (#487).
 - **Example:**
   ```swift
   let ellipse = Curve2D.ellipse(center: .zero, majorRadius: 10, minorRadius: 5)!
+  Curve2D.ellipse(center: .zero, majorRadius: 5, minorRadius: 10)  // nil, minor exceeds major
   ```
 
 ---
@@ -347,9 +349,11 @@ public static func parabola(focus: SIMD2<Double>, direction: SIMD2<Double>,
 - **Parameters:** `focus` — focus point; `direction` — axis direction from vertex toward focus; `focalLength` — distance from vertex to focus (must be > 0).
 - **Returns:** Parabola curve, or `nil` if `focalLength ≤ 0`.
 - **OCCT:** `Geom2d_Parabola(gp_Parab2d(...))`.
+- **See also:** [`parabolaFromCenterDir(center:direction:focal:)`](Curve2D-Analysis.md) places the same curve through OCCT's `gce_MakeParab2d` algorithm, taking the vertex rather than the focus, and enforces the same focal-length contract (#487).
 - **Example:**
   ```swift
   let par = Curve2D.parabola(focus: SIMD2(0, 2), direction: SIMD2(0, 1), focalLength: 2)
+  Curve2D.parabola(focus: .zero, direction: SIMD2(0, 1), focalLength: 0)  // nil, a line
   ```
 
 ---
@@ -363,12 +367,14 @@ public static func hyperbola(center: SIMD2<Double>, majorRadius: Double,
                              minorRadius: Double, rotation: Double = 0) -> Curve2D?
 ```
 
-- **Parameters:** `center` — hyperbola centre; `majorRadius` — real semi-axis; `minorRadius` — imaginary semi-axis (both must be > 0); `rotation` — major-axis rotation in radians (default 0).
-- **Returns:** Hyperbola curve, or `nil` on failure.
+- **Parameters:** `center` — hyperbola centre; `majorRadius` — real semi-axis; `minorRadius` — imaginary semi-axis (both must be > 0, in either order); `rotation` — major-axis rotation in radians (default 0).
+- **Returns:** Hyperbola curve, or `nil` if either radius is ≤ 0. Unlike an ellipse, a minor radius larger than the major is valid.
 - **OCCT:** `Geom2d_Hyperbola(gp_Hypr2d(...))`.
+- **See also:** [`hyperbolaFromCenterDir(center:direction:majorRadius:minorRadius:)`](Curve2D-Analysis.md) builds the identical hyperbola through OCCT's `gce_MakeHypr2d` algorithm and enforces the same radius contract (#487).
 - **Example:**
   ```swift
   let hyp = Curve2D.hyperbola(center: .zero, majorRadius: 3, minorRadius: 2)
+  Curve2D.hyperbola(center: .zero, majorRadius: 2, minorRadius: 3)  // valid, not inverted
   ```
 
 ---


### PR DESCRIPTION
## What & why

`Curve2D.ellipseFromCenterDir`, `Curve2D.hyperbolaFromCenterDir` and
`Curve2D.parabolaFromCenterDir` had no dimension precondition at all and returned live degenerate
curves for input their geometrically identical direct siblings reject. All three now enforce the same
contract, and the predicate that expresses it exists once instead of twelve times.

Targets `refactor/381-pass1b`, not `main`, per #377's ordering rule.

Closes #487

### The behaviour change

| call | before | now |
|---|---|---|
| `ellipseFromCenterDir(majorRadius: 0, minorRadius: 0)` | ellipse whose every point is its centre | `nil` |
| `ellipseFromCenterDir(majorRadius: 8, minorRadius: 0)` | ellipse with a zero minor radius | `nil` |
| `ellipseFromCenterDir(majorRadius: 5, minorRadius: -3)` | ellipse reporting `MinorRadius() == -3` | `nil` |
| `hyperbolaFromCenterDir(majorRadius: 0, minorRadius: 0)` | degenerate hyperbola | `nil` |
| `hyperbolaFromCenterDir(majorRadius: 6, minorRadius: 0)` | degenerate hyperbola | `nil` |
| `parabolaFromCenterDir(focal: 0)` | parabola collapsed to a line | `nil` |

Valid input is untouched: both families still build the same curve, checked pointwise. Equal ellipse
radii stay valid, and a hyperbola whose minor radius exceeds its major stays valid, since neither is
degenerate; both are pinned by their own test so a later pass cannot tighten the shared predicate
into the wrong shape.

### Why it was missed twice

The predicate had been copied rather than shared. #399 (PR #423) added four `static inline` helpers
to `OCCTBridge_Curve3D.mm`; #411 added a byte-equivalent fifth (`occtValidCircle2dRadius`) to
`OCCTBridge_Geom2d.mm`; the 2D direct factories spelled the same conditions inline in six more
places. So two passes over "the conic factories" both stopped one file short of the 2D ellipse,
hyperbola and parabola. Adding three more 2D-suffixed copies (which is what the issue proposed) would
have left twelve spellings of four predicates in a duplication-audit fix, so the four definitions
moved to `OCCTBridge_Internal.h` and all twelve call sites now use them. A conic's radii do not
depend on whether it lives in a plane or in space.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification): `Curve2DConicFactoryParityTests` in `Tests/OCCTGeom2dTests/`, 8 tests.

## Notes for the reviewer

**Three corrections to the issue's pre-written finding**, all from measuring before coding (the #380
lesson that three of Pass 1a's seven findings had a materially wrong claim). The measured tables are
in [the triage comment](https://github.com/SecondMouseAU/OCCTSwift/issues/487#issuecomment-5125025755).

1. **`gce_MakeElips2d` does not merely accept zero, it accepts a negative minor radius.**
   `(5, -3)` returns `gce_Done` and an ellipse reporting `MinorRadius() == -3`. The finding predicted,
   by analogy with the audited 3D sibling, that only the zero boundary diverged.

2. **For hyperbola and parabola there was no OCCT accept/reject asymmetry to inherit.** OCCT accepts
   `(0, 0)` and `focal == 0` through both routes. What rejected them was our own guard in the direct
   functions, so the fix is "apply the bridge's own contract at both entry points", not "make gce
   match OCCT".

3. **The family is nine functions, not three.** The other six are filed as #514.

**The mechanism behind correction 1 is worth knowing for any future audit of this kind: no
precondition inside the OCCT library is load-bearing in this build.** Every OCCT precondition is a
`*_Raise_if` macro, and the pinned `OCCT.xcframework` is a Release build, where OCCT's own
`BUILD_RELEASE_DISABLE_EXCEPTIONS` (default ON) defines `No_Exception` and expands all of them to
nothing inside OCCT's translation units. `gce_MakeElips2d.cxx` checks only `MajorRadius < 0` and
`MajorRadius < MinorRadius`, neither of which covers `(5, -3)`, then hands the values to
`gp_Elips2d`, whose own `Standard_ConstructionError_Raise_if(theMinorRadius < 0.0 || ...)` does cover
it and is not compiled. Our bridge `.mm` files are built without that macro, so the identical
constructor called from the bridge does throw, which is why the direct family looked like it was
inheriting an OCCT contract when it was imposing one.

**Verification**

- Ground-truth probe against the pinned xcframework across the full dimension boundary of all three
  types plus the six deferred sites, compiled per `CLAUDE.md`'s recipe.
- Bug proven live, not just fixed: with only the three new guards reverted, the new suite fails 7
  expectations (3 ellipse, 3 hyperbola, 1 parabola, matching the ground-truth table exactly) while
  every geometry-agreement test still passes, which is what shows the fix changes rejection and not
  geometry.
- `swift test`: 4642 tests in 1318 suites, clean.
- `Scripts/check-bridge-index.py`: 139 stale entries before and after, so nothing new (those 139 are
  pre-existing on this branch and tracked as #510). No public bridge symbol was renamed; the five
  removed helpers were file-local.

**No kernel patch and no xcframework rebuild.** This is not an OCCT defect: the `No_Exception`
behaviour is OCCT's documented Release-build choice, and `gce_MakeElips2d`'s own header states the two
checks it performs. Nothing filed upstream.

**Docs.** `docs/reference/Curve2D-Analysis.md` already documented the ellipse rejection that only the
direct factory performed, the same stale-claim shape #411 recorded for the circle; it is now true.
Added the contract to all six factories on both pages plus `See also` cross-references between each
pair, and `///` doc comments with fenced `swift` snippets on all six Swift methods per the context7
convention.
