### PR TITLE
fix(#488): unify Surface's two transform families onto one buildTrsf3D, add the missing null guard

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -470,6 +470,13 @@ OCCTSurfaceRef OCCTSurfaceCreateBSpline(const double* poles,
 
 // Operations
 
+// Shared gp_Trsf builder (defined below, near OCCTSurfaceTransform); forward-declared here so
+// the immutable translate/rotate/scale/mirror* family can reuse the same transform-construction
+// logic as the in-place OCCTSurfaceTransform dispatcher instead of duplicating it.
+static bool buildTrsf3D(gp_Trsf& trsf, int32_t type,
+                          double p1, double p2, double p3,
+                          double p4, double p5, double p6, double p7);
+
 OCCTSurfaceRef OCCTSurfaceTrim(OCCTSurfaceRef s,
                                 double u1, double u2, double v1, double v2) {
     if (!s || s->surface.IsNull()) return nullptr;
@@ -499,7 +506,7 @@ OCCTSurfaceRef OCCTSurfaceTranslate(OCCTSurfaceRef s,
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
         gp_Trsf trsf;
-        trsf.SetTranslation(gp_Vec(dx, dy, dz));
+        if (!buildTrsf3D(trsf, 0, dx, dy, dz, 0, 0, 0, 0)) return nullptr;
         copy->Transform(trsf);
         return new OCCTSurface(copy);
     } catch (...) {
@@ -515,7 +522,7 @@ OCCTSurfaceRef OCCTSurfaceRotate(OCCTSurfaceRef s,
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
         gp_Trsf trsf;
-        trsf.SetRotation(gp_Ax1(gp_Pnt(axOx, axOy, axOz), gp_Dir(axDx, axDy, axDz)), angle);
+        if (!buildTrsf3D(trsf, 1, axOx, axOy, axOz, axDx, axDy, axDz, angle)) return nullptr;
         copy->Transform(trsf);
         return new OCCTSurface(copy);
     } catch (...) {
@@ -529,7 +536,7 @@ OCCTSurfaceRef OCCTSurfaceScale(OCCTSurfaceRef s,
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
         gp_Trsf trsf;
-        trsf.SetScale(gp_Pnt(cx, cy, cz), factor);
+        if (!buildTrsf3D(trsf, 2, cx, cy, cz, factor, 0, 0, 0)) return nullptr;
         copy->Transform(trsf);
         return new OCCTSurface(copy);
     } catch (...) {
@@ -544,7 +551,7 @@ OCCTSurfaceRef OCCTSurfaceMirrorPlane(OCCTSurfaceRef s,
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
         gp_Trsf trsf;
-        trsf.SetMirror(gp_Ax2(gp_Pnt(px, py, pz), gp_Dir(nx, ny, nz)));
+        if (!buildTrsf3D(trsf, 5, px, py, pz, nx, ny, nz, 0)) return nullptr;
         copy->Transform(trsf);
         return new OCCTSurface(copy);
     } catch (...) {
@@ -558,7 +565,7 @@ OCCTSurfaceRef OCCTSurfaceMirrorPoint(OCCTSurfaceRef s,
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
         gp_Trsf trsf;
-        trsf.SetMirror(gp_Pnt(px, py, pz));
+        if (!buildTrsf3D(trsf, 3, px, py, pz, 0, 0, 0, 0)) return nullptr;
         copy->Transform(trsf);
         return new OCCTSurface(copy);
     } catch (...) {
@@ -573,7 +580,7 @@ OCCTSurfaceRef OCCTSurfaceMirrorAxis(OCCTSurfaceRef s,
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
         gp_Trsf trsf;
-        trsf.SetMirror(gp_Ax1(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz)));
+        if (!buildTrsf3D(trsf, 4, px, py, pz, dx, dy, dz, 0)) return nullptr;
         copy->Transform(trsf);
         return new OCCTSurface(copy);
     } catch (...) {
@@ -6051,6 +6058,10 @@ bool OCCTSurfaceBezierSetPoleRowWeights(OCCTSurfaceRef surface, int32_t uIndex,
         return true;
     } catch (...) { return false; }
 }
+// --- Geometry Transform (in-place) ---
+
+// Shared by the in-place dispatcher below and by the immutable
+// OCCTSurfaceTranslate/Rotate/Scale/Mirror* family (forward-declared near the top of this file).
 static bool buildTrsf3D(gp_Trsf& trsf, int32_t type,
                           double p1, double p2, double p3,
                           double p4, double p5, double p6, double p7) {
@@ -6081,7 +6092,7 @@ static bool buildTrsf3D(gp_Trsf& trsf, int32_t type,
 bool OCCTSurfaceTransform(OCCTSurfaceRef surface, int32_t transformType,
                            double p1, double p2, double p3,
                            double p4, double p5, double p6, double p7) {
-    if (!surface) return false;
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         gp_Trsf trsf;
         if (!buildTrsf3D(trsf, transformType, p1, p2, p3, p4, p5, p6, p7)) return false;

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -3036,15 +3036,21 @@ struct SurfaceTransformTests {
 
     @Test("Transform BezierSurface values")
     func transformBezierSurface() {
-        // Create a Bezier surface and verify transform changes values
-        let surf = Surface.bezierFill(
-            Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0))!,
-            Curve3D.line(through: SIMD3(0, 10, 0), direction: SIMD3(1, 0, 0))!
-        )
-        if let s = surf {
-            let ok = s.translate(dx: 0, dy: 0, dz: 100)
-            #expect(ok)
+        // bezierFill down-casts its inputs to Geom_BezierCurve and returns nil for anything else, so
+        // the boundaries must be real Bezier curves. This test used to pass Curve3D.line, got nil
+        // back, and skipped its whole body via `if let` without ever calling translate (#488).
+        guard let c1 = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(5, 0, 3), SIMD3(10, 0, 0)]),
+              let c2 = Curve3D.bezier(poles: [SIMD3(0, 10, 0), SIMD3(5, 10, 3), SIMD3(10, 10, 0)]),
+              let s = Surface.bezierFill(c1, c2) else {
+            Issue.record("bezierFill setup nil")
+            return
         }
+        let before = s.point(atU: 0.5, v: 0.5)
+        #expect(s.translate(dx: 0, dy: 0, dz: 100))
+        let after = s.point(atU: 0.5, v: 0.5)
+        #expect(abs(after.x - before.x) < 1e-9)
+        #expect(abs(after.y - before.y) < 1e-9)
+        #expect(abs(after.z - before.z - 100) < 1e-9)
     }
 }
 

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -5883,3 +5883,177 @@ struct SurfaceApproximateDefaultsParityTests {
         }
     }
 }
+
+// MARK: - #488: Surface transform family parity
+
+/// `Surface` exposes every transform twice: an immutable copy-returning family
+/// (`translated`/`rotated`/`scaled`/`mirrored*`, backed by six separate bridge functions) and an
+/// in-place family (`translate`/`rotate`/`scale`/`mirrorPoint`/`mirrorAxis`/`mirrorPlane`, all
+/// backed by the single `OCCTSurfaceTransform` dispatcher). Both now build their `gp_Trsf` through
+/// one shared `buildTrsf3D`, so they must produce identical geometry for identical input. Before
+/// #488 the switch existed seven times over and nothing checked the copies agreed. Mirrors
+/// `Curve3DTransformFamilyParityTests`, added for the same fix on `Curve3D` (#416).
+///
+/// For each pair: take one immutable copy BEFORE mutating the original in place, apply the same
+/// transform to both, then compare a UV grid of evaluated points.
+@Suite("Surface Transform Family Parity (#488)")
+struct SurfaceTransformFamilyParityTests {
+
+    /// Bounded on both parameters, so sampling its own domain is well defined
+    /// (a plane's or cylinder's domain runs to ±1e100 and cannot be gridded).
+    private func sphere() -> Surface {
+        Surface.sphere(center: SIMD3(1, 2, 3), radius: 4)!
+    }
+
+    private func points(on surface: Surface, steps: Int = 4) -> [SIMD3<Double>] {
+        let d = surface.domain
+        var result: [SIMD3<Double>] = []
+        for i in 0...steps {
+            for j in 0...steps {
+                let u = d.uMin + (d.uMax - d.uMin) * Double(i) / Double(steps)
+                let v = d.vMin + (d.vMax - d.vMin) * Double(j) / Double(steps)
+                result.append(surface.point(atU: u, v: v))
+            }
+        }
+        return result
+    }
+
+    private func assertMatch(_ a: Surface, _ b: Surface, tolerance: Double = 1e-9) {
+        let pa = points(on: a)
+        let pb = points(on: b)
+        #expect(pa.count == pb.count)
+        for (p, q) in zip(pa, pb) {
+            #expect(abs(p.x - q.x) < tolerance)
+            #expect(abs(p.y - q.y) < tolerance)
+            #expect(abs(p.z - q.z) < tolerance)
+        }
+    }
+
+    @Test("translate vs translated(by:)")
+    func translateParity() {
+        let base = sphere()
+        let copy = base.translated(by: SIMD3(3, -2, 1.5))
+        let ok = base.translate(dx: 3, dy: -2, dz: 1.5)
+        #expect(ok)
+        #expect(copy != nil)
+        if let copy = copy {
+            assertMatch(base, copy)
+        }
+    }
+
+    @Test("rotate vs rotated(axisOrigin:axisDirection:angle:)")
+    func rotateParity() {
+        let base = sphere()
+        let axisOrigin = SIMD3<Double>(0, 0, 0)
+        let axisDirection = SIMD3<Double>(0, 0, 1)
+        let angle = Double.pi / 3
+        let copy = base.rotated(axisOrigin: axisOrigin, axisDirection: axisDirection, angle: angle)
+        let ok = base.rotate(axisOrigin: axisOrigin, axisDirection: axisDirection, angle: angle)
+        #expect(ok)
+        #expect(copy != nil)
+        if let copy = copy {
+            assertMatch(base, copy)
+        }
+    }
+
+    @Test("scale vs scaled(center:factor:)")
+    func scaleParity() {
+        let base = sphere()
+        let center = SIMD3<Double>(0, 0, 0)
+        let copy = base.scaled(center: center, factor: 2.5)
+        let ok = base.scale(center: center, factor: 2.5)
+        #expect(ok)
+        #expect(copy != nil)
+        if let copy = copy {
+            assertMatch(base, copy)
+        }
+    }
+
+    @Test("mirrorPoint vs mirrored(acrossPoint:)")
+    func mirrorPointParity() {
+        let base = sphere()
+        let point = SIMD3<Double>(1, 1, 1)
+        let copy = base.mirrored(acrossPoint: point)
+        let ok = base.mirrorPoint(point)
+        #expect(ok)
+        #expect(copy != nil)
+        if let copy = copy {
+            assertMatch(base, copy)
+        }
+    }
+
+    @Test("mirrorAxis vs mirrored(acrossAxis:direction:)")
+    func mirrorAxisParity() {
+        let base = sphere()
+        let origin = SIMD3<Double>(0, 0, 0)
+        let direction = SIMD3<Double>(1, 0, 0)
+        let copy = base.mirrored(acrossAxis: origin, direction: direction)
+        let ok = base.mirrorAxis(origin: origin, direction: direction)
+        #expect(ok)
+        #expect(copy != nil)
+        if let copy = copy {
+            assertMatch(base, copy)
+        }
+    }
+
+    @Test("mirrorPlane vs mirrored(planeOrigin:planeNormal:)")
+    func mirrorPlaneParity() {
+        let base = sphere()
+        let origin = SIMD3<Double>(0, 0, 0)
+        let normal = SIMD3<Double>(0, 0, 1)
+        let copy = base.mirrored(planeOrigin: origin, planeNormal: normal)
+        let ok = base.mirrorPlane(origin: origin, normal: normal)
+        #expect(ok)
+        #expect(copy != nil)
+        if let copy = copy {
+            assertMatch(base, copy)
+        }
+    }
+
+    /// The analytic cases above all exercise `Geom_ElementarySurface::Transform`, which just moves an
+    /// axis placement. A Bezier surface takes a different override that transforms every pole, so it
+    /// is the case most likely to expose a divergence between the two families' `gp_Trsf` values.
+    @Test("Bezier surface: both families agree across all six transform kinds")
+    func bezierParityAcrossAllKinds() {
+        // bezierFill down-casts its inputs to Geom_BezierCurve and returns nil for anything else,
+        // so these have to be real Bezier curves. A Curve3D.line or .segment yields nil.
+        func bezier() -> Surface? {
+            guard let c1 = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(5, 0, 3), SIMD3(10, 0, 0)]),
+                  let c2 = Curve3D.bezier(poles: [SIMD3(0, 10, 5), SIMD3(5, 10, 8), SIMD3(10, 10, 5)])
+            else { return nil }
+            return Surface.bezierFill(c1, c2)
+        }
+
+        guard let translateBase = bezier(), let rotateBase = bezier(),
+              let scaleBase = bezier(), let mirrorPointBase = bezier(),
+              let mirrorAxisBase = bezier(), let mirrorPlaneBase = bezier() else {
+            Issue.record("bezierFill returned nil")
+            return
+        }
+
+        let translateCopy = translateBase.translated(by: SIMD3(3, -2, 1.5))
+        #expect(translateBase.translate(dx: 3, dy: -2, dz: 1.5))
+        if let c = translateCopy { assertMatch(translateBase, c) }
+
+        let rotateCopy = rotateBase.rotated(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1),
+                                            angle: .pi / 3)
+        #expect(rotateBase.rotate(axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1), angle: .pi / 3))
+        if let c = rotateCopy { assertMatch(rotateBase, c) }
+
+        let scaleCopy = scaleBase.scaled(center: .zero, factor: 2.5)
+        #expect(scaleBase.scale(center: .zero, factor: 2.5))
+        if let c = scaleCopy { assertMatch(scaleBase, c) }
+
+        let mirrorPointCopy = mirrorPointBase.mirrored(acrossPoint: SIMD3(1, 1, 1))
+        #expect(mirrorPointBase.mirrorPoint(SIMD3(1, 1, 1)))
+        if let c = mirrorPointCopy { assertMatch(mirrorPointBase, c) }
+
+        let mirrorAxisCopy = mirrorAxisBase.mirrored(acrossAxis: .zero, direction: SIMD3(1, 0, 0))
+        #expect(mirrorAxisBase.mirrorAxis(origin: .zero, direction: SIMD3(1, 0, 0)))
+        if let c = mirrorAxisCopy { assertMatch(mirrorAxisBase, c) }
+
+        let mirrorPlaneCopy = mirrorPlaneBase.mirrored(planeOrigin: .zero, planeNormal: SIMD3(0, 0, 1))
+        #expect(mirrorPlaneBase.mirrorPlane(origin: .zero, normal: SIMD3(0, 0, 1)))
+        if let c = mirrorPlaneCopy { assertMatch(mirrorPlaneBase, c) }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,35 @@ symbol references name symbols that exist nowhere in `Sources/`**. Filed as #510
 here — each stale entry needs its real call site identified, and inventing a plausible name for a
 class that has no wrap would be worse than leaving the entry visibly broken.
 
+#### `Surface`'s two transform families now share one `gp_Trsf` builder (#488)
+
+`OCCTBridge_Surface.mm` carried the same `gp_Trsf`-construction switch seven times: once inline in
+each of the six immutable functions (`OCCTSurfaceTranslate`, `Rotate`, `Scale`, `MirrorPlane`,
+`MirrorPoint`, `MirrorAxis`) and once more as a standalone `buildTrsf3D` that only the in-place
+`OCCTSurfaceTransform` dispatcher used. All seven now route through the one `buildTrsf3D`, matching
+what #416 did for `Curve3D`, which that issue explicitly flagged for `Surface` and never applied.
+
+The triplication had already caused a divergence. `OCCTSurfaceTransform` guarded only
+`if (!surface)` and then dereferenced `surface->surface` unconditionally, while all six of its
+siblings in the same file check `s->surface.IsNull()` first. That is the identical gap #416 fixed on
+`OCCTCurve3DTransform`. It now guards both. No live path reaches it with a null internal handle
+today (every call site null-checks the OCCT maker result before assigning), so this is a latent
+crash closed, not an observed one; a null `Handle` deref here would be an uncatchable SIGSEGV per the
+#345 precedent, not a caught C++ exception.
+
+New `SurfaceTransformFamilyParityTests` (`Tests/OCCTSurfaceTests`) asserts the two families produce
+identical geometry for identical input across all six transform kinds, on a sphere and on a Bezier
+surface. The Bezier case matters because the analytic surfaces all take
+`Geom_ElementarySurface::Transform`, which just moves an axis placement, while a Bezier transforms
+every pole. Nothing had checked the two families agreed before, for `Surface` or, until #416, for
+`Curve3D`.
+
+Writing that suite turned up a dead test: `SurfaceTransformTests.transformBezierSurface`
+(`Tests/OCCTMathTests`) built its surface from `Curve3D.line`, but `OCCTSurfaceBezierFill2`
+down-casts its inputs to `Geom_BezierCurve` and returns `nullptr` for anything else, so the test got
+`nil` back and skipped its entire body through `if let` without ever calling `translate`. It now uses
+real Bezier boundaries and asserts the surface actually moved.
+
 ---
 
 ## Release History


### PR DESCRIPTION
Closes #488. Targets `refactor/381-pass1b`, per #488's own branch rule (Pass 1b of #377).

This is the follow-up #416 explicitly scoped out and flagged: *"a second, textually-identical but separately-defined `static bool buildTrsf3D(...)` exists for `Surface`... same duplication shape one type over, not itself part of this finding but worth folding into the same fix if unifying `buildTrsf3D`."* That folding never happened.

## What changed

**1. Seven copies of the `gp_Trsf` switch collapse to one.** `OCCTBridge_Surface.mm` hand-rolled the same transform construction inline in each of the six immutable functions (`OCCTSurfaceTranslate`, `Rotate`, `Scale`, `MirrorPlane`, `MirrorPoint`, `MirrorAxis`) and once more as a standalone `buildTrsf3D` that only the in-place `OCCTSurfaceTransform` dispatcher used. All seven now route through the one `buildTrsf3D`, forward-declared at the top of the Operations section exactly the way `OCCTBridge_Curve3D.mm:557` does it after #416.

**2. The already-diverged null guard, closed.** `OCCTSurfaceTransform` guarded only `if (!surface)` and then dereferenced `surface->surface` unconditionally, while all six of its siblings in the same file check `s->surface.IsNull()` first. That is the identical gap #416 fixed on `OCCTCurve3DTransform` (`c73a26e`). It now guards both.

No live path reaches it with a null internal handle today: `OCCTSurface`'s default ctor leaves `surface` null and the "default-construct then assign" idiom is used at ~20 sites in this file, but every one null-checks the OCCT maker result before assigning. So this closes a latent crash, not an observed one. It matters because a null `Handle` deref here would be an uncatchable SIGSEGV per the #345 precedent, not a caught C++ exception, and the guard was written six times on one side of the duplication and never carried to the other.

**3. `SurfaceTransformFamilyParityTests`** (`Tests/OCCTSurfaceTests`), mirroring `Curve3DTransformFamilyParityTests`. Nothing anywhere asserted the two families agree. Each test takes an immutable copy before mutating the original in place, applies the same transform to both, then compares a 5x5 UV grid of evaluated points at 1e-9.

Six analytic cases on a sphere, plus a seventh on a Bezier surface across all six kinds. The Bezier case is the one that earns its keep: the analytic surfaces all take `Geom_ElementarySurface::Transform`, which just moves an axis placement, while a Bezier takes an override that transforms every pole, so it is where a divergence between the two families' `gp_Trsf` values would actually show.

Sphere rather than plane throughout because a plane's or cylinder's `domain` runs to ±1e100 and cannot be gridded.

**4. A dead test, revived.** Writing the Bezier case surfaced that `SurfaceTransformTests.transformBezierSurface` (`Tests/OCCTMathTests`, one of the tests #488 enumerates as the mutating family's coverage) built its surface from `Curve3D.line`. `OCCTSurfaceBezierFill2` down-casts its inputs to `Geom_BezierCurve` and returns `nullptr` for anything else, so the test got `nil` back and skipped its entire body through `if let` without ever calling `translate`. It now uses real Bezier boundaries and asserts the surface actually moved by the requested amount.

## Not changed

- **`OCCTBridge.h`'s two declaration blocks** (`:3045-3061` and `:19700-19709`). The two families are declared in different sections of the header, which is header organisation rather than logic duplication; #488's own prescribed fix (items 1-4) does not ask for it, and moving declarations is #395's territory.
- **No public Swift API change.** All twelve wrappers keep their signatures and behaviour. No op-count or API_REFERENCE change.
- **No xcframework rebuild.** `Sources/OCCTBridge/src/*.mm` changed, which is release-time packaging, same as PR #511 on this branch.

## Verification

- `swift build`: clean.
- `swift test`: 4641 tests in 1318 suites pass.
- `swift test --filter "SurfaceTransformTests|SurfaceOperationsTests|SurfaceTransformFamilyParityTests"`: 22/22 pass after the final edits.
- `Scripts/check-bridge-index.py`: 139 stale, unchanged from the base commit. Pre-existing and tracked as #510; this PR does not touch `OCCTBridge.h`.

Docs: `docs/CHANGELOG.md` gains a Pass 1b subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)