### PR TITLE
fix(#489): one skeleton behind the edge-list fillet family, one radius precondition

### DIFF
--- a/Scripts/repro/489-fillet-radius-validation/README.md
+++ b/Scripts/repro/489-fillet-radius-validation/README.md
@@ -1,0 +1,71 @@
+# OCCTSwift#489 ground truth: what `BRepFilletAPI_MakeFillet` does with an invalid radius
+
+Two standalone probes, run against the pinned `OCCT.xcframework` (8.0.0p1 + our carried patches),
+that establish what OCCT actually does when the radius handed to the edge-list fillet family is
+zero, negative or NaN. They are what the #489 fix is calibrated against: the finding assumed a bad
+radius reaching OCCT was the bug, and the measurement says otherwise.
+
+No fixture files: every case is a 10×10×10 box.
+
+## Compile and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/489-fillet-radius-validation/occt_489_add_radius.mm -o /tmp/occt_489_add_radius
+/tmp/occt_489_add_radius
+```
+
+Same recipe for `occt_489_setradius_and_bounds.mm`.
+
+## `occt_489_add_radius.mm`: the `Add(radius, edge)` path
+
+`OCCTShapeFilletEdges` and `OCCTShapeBlendEdges` both reach OCCT through
+`BRepFilletAPI_MakeFillet::Add(radius, edge)`.
+
+| input | measured |
+|---|---|
+| `Add(2.0, e)` | `IsDone=1`, volume 991.415927, `BRepCheck_Analyzer` valid |
+| `Add(0.0, e)` | `IsDone=0`, `NbFaultyContours=1` |
+| `Add(-5.0, e)` | `IsDone=0`, `NbFaultyContours=1` |
+| `Add(2.0, e1)` + `Add(0.0, e2)` | `IsDone=0`, `NbFaultyContours=1` |
+| `Add(2.0, e1)` + `Add(-5.0, e2)` | `IsDone=0`, `NbFaultyContours=1` |
+
+No throw, no crash, and no wrong shape. OCCT fails `IsDone()`, which the bridge already turned into
+`nullptr`, so a non-positive radius that reached OCCT was already reported as failure, and one bad
+radius already poisoned the whole batch. The precondition still belongs in the bridge (OCCT's own
+`*_Raise_if` checks are compiled out of this Release build by `No_Exception`, so nothing inside the
+library is load-bearing here), but it buys rejection *before* a full fillet build attempt rather
+than a different answer.
+
+## `occt_489_setradius_and_bounds.mm`: the law path, and the case that did escape
+
+| input | measured |
+|---|---|
+| no contour added at all | `Build()` throws `Standard_Failure`: "There are no suitable edges for chamfer or fillet" |
+| `Add(e)` + `SetRadius(0.0, …)` at both ends | `IsDone=0` |
+| `Add(e)` + `SetRadius(-5.0, …)` at both ends | `IsDone=0` |
+| `Add(NaN, e)` | `IsDone=0` |
+| one valid edge only | `IsDone=1`, volume 991.415927, valid |
+
+The last row is the observable defect. `OCCTShapeBlendEdges` bounds-checked each caller index and
+`continue`d past an out-of-range one *before* the radius was ever used, so
+`blendedEdges([(0, 2.0), (99999, -5.0)])` skipped the invalid pair, built from edge 0 alone, and
+returned a shape: success for a request that was never fully honoured. Every other invalid-radius
+combination already surfaced as `nil` by way of `IsDone=0`.
+
+The first row is why the bounds check can stay a skip rather than a rejection: when it skips
+everything, `Build()` throws and the bridge's `catch (...)` reports `nullptr` anyway.
+
+## Fix
+
+Bridge-only, no kernel patch, no xcframework rebuild. `occtShapeFilletEdgeList` in
+`Sources/OCCTBridge/src/OCCTBridge_Internal.h` is now the one skeleton behind
+`OCCTShapeFilletEdges`, `OCCTShapeFilletEdgesLinear` and `OCCTShapeBlendEdges`, and
+`occtValidFilletRadius` / `occtValidFilletRadii` are the one precondition all three apply.
+Regression tests: `Tests/OCCTModelingTests/Issue489FilletRadiusTests.swift`.
+
+Nothing filed upstream: `Add()` reporting failure through `IsDone()` is OCCT's documented
+`BRepBuilderAPI_MakeShape` contract, not a defect.

--- a/Scripts/repro/489-fillet-radius-validation/occt_489_add_radius.mm
+++ b/Scripts/repro/489-fillet-radius-validation/occt_489_add_radius.mm
@@ -1,0 +1,52 @@
+// OCCTSwift#489 ground truth: what BRepFilletAPI_MakeFillet::Add(r, edge) does for r == 0
+// and r < 0, uniform and mixed with a valid radius. See README.md in this directory.
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <Standard_Failure.hxx>
+#include <cstdio>
+
+static void report(const char* label, double r0, double r1, bool twoEdges) {
+    printf("--- %s (r0=%g%s) ---\n", label, r0, twoEdges ? ", r1 varies" : "");
+    try {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(box, TopAbs_EDGE, edgeMap);
+        BRepFilletAPI_MakeFillet fillet(box);
+        fillet.Add(r0, TopoDS::Edge(edgeMap(1)));
+        if (twoEdges) fillet.Add(r1, TopoDS::Edge(edgeMap(2)));
+        fillet.Build();
+        printf("  Build ok, IsDone=%d\n", (int)fillet.IsDone());
+        if (fillet.IsDone()) {
+            TopoDS_Shape res = fillet.Shape();
+            printf("  IsNull=%d\n", (int)res.IsNull());
+            if (!res.IsNull()) {
+                GProp_GProps props;
+                BRepGProp::VolumeProperties(res, props);
+                BRepCheck_Analyzer an(res);
+                printf("  volume=%.6f valid=%d\n", props.Mass(), (int)an.IsValid());
+            }
+        } else {
+            printf("  NbFaultyContours=%d\n", fillet.NbFaultyContours());
+        }
+    } catch (Standard_Failure& f) {
+        printf("  THREW Standard_Failure: %s\n", f.GetMessageString() ? f.GetMessageString() : "(none)");
+    } catch (...) {
+        printf("  THREW unknown\n");
+    }
+}
+
+int main() {
+    report("baseline positive", 2.0, 0, false);
+    report("zero radius", 0.0, 0, false);
+    report("negative radius", -5.0, 0, false);
+    report("mixed valid+zero", 2.0, 0.0, true);
+    report("mixed valid+negative", 2.0, -5.0, true);
+    printf("done\n");
+    return 0;
+}

--- a/Scripts/repro/489-fillet-radius-validation/occt_489_setradius_and_bounds.mm
+++ b/Scripts/repro/489-fillet-radius-validation/occt_489_setradius_and_bounds.mm
@@ -1,0 +1,89 @@
+// OCCTSwift#489 ground truth, part 2: (a) what Build() does when no contour was added at all,
+// (b) SetRadius with a non-positive radius (the radius-law path), (c) a NaN radius, and (d) the one
+// case that escaped OCCTShapeBlendEdges' missing precondition: a bad radius whose edge index was
+// out of range, so the bounds check dropped the pair and the batch built anyway.
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_Curve.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <Standard_Failure.hxx>
+#include <cmath>
+#include <cstdio>
+
+static TopoDS_Shape box() { return BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape(); }
+
+static void result(BRepFilletAPI_MakeFillet& fillet) {
+    fillet.Build();
+    printf("  IsDone=%d", (int)fillet.IsDone());
+    if (fillet.IsDone()) {
+        TopoDS_Shape res = fillet.Shape();
+        printf(" IsNull=%d", (int)res.IsNull());
+        if (!res.IsNull()) {
+            GProp_GProps props;
+            BRepGProp::VolumeProperties(res, props);
+            printf(" volume=%.6f valid=%d", props.Mass(), (int)BRepCheck_Analyzer(res).IsValid());
+        }
+    }
+    printf("\n");
+}
+
+int main() {
+    // (a) no contours added at all (every caller-supplied index out of range)
+    printf("--- zero contours ---\n");
+    try {
+        TopoDS_Shape s = box();
+        BRepFilletAPI_MakeFillet fillet(s);
+        printf("  NbContours=%d\n", fillet.NbContours());
+        result(fillet);
+    } catch (Standard_Failure& f) { printf("  THREW: %s\n", f.GetMessageString()); }
+
+    // (b) SetRadius with a non-positive radius (the FilletVariable / FilletEvolving path)
+    for (double r : {0.0, -5.0}) {
+        printf("--- SetRadius(%g, param, 1) ---\n", r);
+        try {
+            TopoDS_Shape s = box();
+            TopTools_IndexedMapOfShape edgeMap;
+            TopExp::MapShapes(s, TopAbs_EDGE, edgeMap);
+            TopoDS_Edge e = TopoDS::Edge(edgeMap(1));
+            BRepFilletAPI_MakeFillet fillet(s);
+            fillet.Add(e);
+            double first, last;
+            Handle(Geom_Curve) c = BRep_Tool::Curve(e, first, last);
+            fillet.SetRadius(r, first, 1);
+            fillet.SetRadius(r, last, 1);
+            result(fillet);
+        } catch (Standard_Failure& f) { printf("  THREW: %s\n", f.GetMessageString()); }
+    }
+
+    // (c) NaN radius through Add()
+    printf("--- Add(NaN, edge) ---\n");
+    try {
+        TopoDS_Shape s = box();
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(s, TopAbs_EDGE, edgeMap);
+        BRepFilletAPI_MakeFillet fillet(s);
+        fillet.Add(std::nan(""), TopoDS::Edge(edgeMap(1)));
+        result(fillet);
+    } catch (Standard_Failure& f) { printf("  THREW: %s\n", f.GetMessageString()); }
+
+    // (d) one valid edge added, the invalid-radius entry skipped because its index was
+    //     out of range, which today's OCCTShapeBlendEdges lets through.
+    printf("--- valid edge only (bad-radius entry skipped by bounds check) ---\n");
+    try {
+        TopoDS_Shape s = box();
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(s, TopAbs_EDGE, edgeMap);
+        BRepFilletAPI_MakeFillet fillet(s);
+        fillet.Add(2.0, TopoDS::Edge(edgeMap(1)));
+        result(fillet);
+    } catch (Standard_Failure& f) { printf("  THREW: %s\n", f.GetMessageString()); }
+
+    printf("done\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -123,7 +123,7 @@
 //
 // --- BRepFilletAPI ---
 // BRepFilletAPI_MakeChamfer           → OCCTShapeChamfer*
-// BRepFilletAPI_MakeFillet            → OCCTShapeFillet*
+// BRepFilletAPI_MakeFillet            → OCCTShapeFillet*, OCCTShapeBlendEdges, OCCTShapeFuseAndBlend, OCCTShapeCutAndBlend, OCCTFilletBuilder*
 // BRepFilletAPI_MakeFillet2d          → OCCTShapeFillet2D*, OCCTShapeChamfer2D*
 //
 // --- BRepGProp ---
@@ -1497,20 +1497,26 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType);
 // MARK: - Advanced Modeling (v0.8.0)
 
 /// Fillet specific edges with uniform radius
+///
+/// One of three entry points sharing occtShapeFilletEdgeList (OCCTBridge_Internal.h) with
+/// OCCTShapeFilletEdgesLinear and OCCTShapeBlendEdges: same edge map, same 0-based index bounds
+/// check (an out-of-range index is skipped), same positive-radius precondition. #489
 /// @param shape The shape to fillet
 /// @param edgeIndices Array of edge indices (0-based)
 /// @param edgeCount Number of edges to fillet
-/// @param radius Fillet radius
+/// @param radius Fillet radius; must be > 0, or the call fails without touching OCCT
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices,
                                    int32_t edgeCount, double radius);
 
 /// Fillet specific edges with linear radius interpolation
+///
+/// Shares occtShapeFilletEdgeList with OCCTShapeFilletEdges and OCCTShapeBlendEdges. #489
 /// @param shape The shape to fillet
 /// @param edgeIndices Array of edge indices (0-based)
 /// @param edgeCount Number of edges to fillet
-/// @param startRadius Radius at start of each edge
-/// @param endRadius Radius at end of each edge
+/// @param startRadius Radius at start of each edge; must be > 0
+/// @param endRadius Radius at end of each edge; must be > 0
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeIndices,
                                          int32_t edgeCount, double startRadius, double endRadius);
@@ -2248,9 +2254,14 @@ OCCTWireRef OCCTWireChamfer2D(OCCTWireRef wire, int32_t vertexIndex, double dist
 OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance);
 
 /// Blend multiple edges with individual radii
+///
+/// The per-edge member of the occtShapeFilletEdgeList family (OCCTBridge_Internal.h), alongside
+/// OCCTShapeFilletEdges and OCCTShapeFilletEdgesLinear. Implemented in OCCTBridge_Healing.mm
+/// while the other two are in OCCTBridge_Modeling.mm, which is how it came to be the one without
+/// a radius precondition. #489
 /// @param shape The shape to blend
-/// @param edgeIndices Array of edge indices
-/// @param radii Array of radii (one per edge)
+/// @param edgeIndices Array of edge indices (0-based; an out-of-range index is skipped)
+/// @param radii Array of radii (one per edge); every element must be > 0, or the whole call fails
 /// @param count Number of edges
 /// @return Blended shape, or NULL on failure
 OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
@@ -4811,6 +4822,9 @@ int32_t OCCTShapeCompoundChildren(OCCTShapeRef _Nonnull compound,
 // MARK: - Tier 2 modification ops with full per-input history (issue #165)
 
 /// Uniform-radius fillet on the given edges, with retained history.
+///
+/// `radius` must be > 0, and the edge loop is occtFilletAddEdges (OCCTBridge_Internal.h), shared
+/// with OCCTShapeFilletEdges: 0-based indices, an out-of-range one skipped. #489
 OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromFilletEdges(OCCTShapeRef _Nonnull shape,
                                                                   const int32_t* _Nonnull edgeIndices,
                                                                   int32_t count,
@@ -4819,6 +4833,8 @@ OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromFilletEdges(OCCTShapeRef _No
 
 /// Variable-radius fillet on a single edge (start radius linearly varies to end radius
 /// along the edge's parameter range), with retained history.
+///
+/// Both radii must be > 0, matching OCCTShapeFilletEdgesLinear. #489
 OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromFilletEdgeVariable(OCCTShapeRef _Nonnull shape,
                                                                          int32_t edgeIndex,
                                                                          double startRadius, double endRadius,

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -711,37 +711,18 @@ OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance) {
     }
 }
 
+// Shares occtShapeFilletEdgeList (OCCTBridge_Internal.h) with OCCTShapeFilletEdges and
+// OCCTShapeFilletEdgesLinear in OCCTBridge_Modeling.mm, supplying only the per-edge radius.
+// This is the entry point that had no radius precondition at all; see that helper. #489
 OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
                                   const int32_t* edgeIndices, const double* radii, int32_t count) {
-    if (!shape || !edgeIndices || !radii || count < 1) return nullptr;
+    if (!occtValidFilletRadii(radii, count)) return nullptr;
 
-    try {
-        // Get all edges from shape
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-
-        // Create fillet maker
-        BRepFilletAPI_MakeFillet fillet(shape->shape);
-
-        // Add each edge with its radius
-        for (int32_t i = 0; i < count; i++) {
-            int32_t idx = edgeIndices[i];
-            if (idx < 0 || idx >= edgeMap.Extent()) continue;
-
-            TopoDS_Edge edge = TopoDS::Edge(edgeMap(idx + 1));
-            fillet.Add(radii[i], edge);
-        }
-
-        fillet.Build();
-        if (!fillet.IsDone()) return nullptr;
-
-        TopoDS_Shape result = fillet.Shape();
-        if (result.IsNull()) return nullptr;
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+    return occtShapeFilletEdgeList(shape, edgeIndices, count,
+                                   [radii](BRepFilletAPI_MakeFillet& fillet,
+                                           const TopoDS_Edge& edge, int32_t entry) {
+        fillet.Add(radii[entry], edge);
+    });
 }
 
 // MARK: - Surface filling (#430/#434)

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -52,7 +52,13 @@
 #include <XCAFDoc_VisMaterialTool.hxx>
 #include <TDF_Label.hxx>
 #include <TNaming_Scope.hxx>
+// The last four serve the shared algorithm helpers at the bottom of this header
+// (occtFillingAddConstraint, occtShapeFilletEdgeList) rather than the structs above.
 #include <BRepOffsetAPI_MakeFilling.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
 
 // === Foundation struct definitions ===
 
@@ -453,6 +459,105 @@ inline bool occtValidHyperbolaRadii(double majorR, double minorR) {
 // axis of symmetry, which is gp_Parab2d's documented behaviour, not an error it reports.
 inline bool occtValidParabolaFocal(double focal) {
     return focal > 0;
+}
+
+// === #489: shared BRepFilletAPI_MakeFillet edge-list skeleton ===
+//
+// Three bridge functions fillet a caller-supplied list of edge indices and differ only in what
+// radius each of those edges gets: OCCTShapeFilletEdges (one radius for the whole list) and
+// OCCTShapeFilletEdgesLinear (a start and an end radius, applied per edge) in
+// OCCTBridge_Modeling.mm, and OCCTShapeBlendEdges (one radius per edge) in OCCTBridge_Healing.mm.
+// Everything either side of the per-edge Add (the null/count guard, the TopExp::MapShapes edge
+// map, the 0-based-to-1-based index translation and its bounds check, Build/IsDone/Shape, and the
+// catch(...) that turns any OCCT failure into nullptr) was written out three times.
+//
+// That is how the radius precondition came to be missing from one of them. Both fillet* functions
+// reject a non-positive radius before OCCT is touched; the blend function checked only that the
+// radii pointer was non-null, and never looked at a single element. Copies do not propagate a
+// guard added to one of them, which is the whole argument for one skeleton: the next piece of
+// hardening this family needs lands in one place, on all three call sites at once.
+//
+// The precondition belongs here in the bridge, for the same reason the conic predicates above do:
+// the pinned OCCT.xcframework is a Release build, so OCCT's own *_Raise_if preconditions are
+// compiled out by No_Exception and nothing inside the library will reject the value for us.
+// Measured against that kernel (Scripts/repro/489-fillet-radius-validation/):
+// BRepFilletAPI_MakeFillet::Add(r, edge) with r of 0, a negative r, or NaN neither throws nor
+// yields a wrong shape. It fails IsDone(), so wherever the bad radius did reach OCCT the result
+// was already nullptr. The case that escaped was a bad radius paired with an out-of-range edge
+// index: the bounds check dropped the pair, and the batch then built from the remaining edges and
+// reported success for a request that was never fully honoured.
+
+// A fillet radius has to be positive. Zero and negative both fail BRepFilletAPI_MakeFillet's own
+// Build(), so this rejects them before that work is done rather than after; NaN fails the same
+// comparison, since NaN > 0 is false.
+inline bool occtValidFilletRadius(double radius) {
+    return radius > 0;
+}
+
+// Every radius in a per-edge radius array, checked up front. One bad element rejects the whole
+// batch, matching the uniform-radius entry point: it rejects its single radius before looking at
+// any index, so a per-edge list cannot make its own validity depend on which indices resolve.
+inline bool occtValidFilletRadii(const double* radii, int32_t count) {
+    if (!radii || count < 1) return false;
+    for (int32_t i = 0; i < count; i++) {
+        if (!occtValidFilletRadius(radii[i])) return false;
+    }
+    return true;
+}
+
+// Add the edges named by `edgeIndices` (0-based, indexing `shape`'s own TopExp edge map) to
+// `fillet`, through whichever Add overload the caller's radius law needs.
+//
+// `addEdge(fillet, edge, entry)` is the only part that varies between the callers: `entry` is the
+// index into the caller's own arrays, so a per-edge radius list can read its own element. It is
+// called only for indices that resolve to a real edge.
+//
+// An out-of-range index is skipped rather than rejected, which is the behaviour every caller had
+// before they shared this loop. When that leaves no contour at all, the subsequent Build() throws
+// "There are no suitable edges for chamfer or fillet", so a caller's catch(...) still reports
+// failure; nothing here has to detect the empty case itself.
+//
+// Not folded into occtShapeFilletEdgeList below because OCCTShapeHistoryFromFilletEdges has to
+// keep its builder alive past the call, to hand back a BRepTools_History over it.
+//
+// Radius validation is the caller's, since the shapes it takes (one scalar, two scalars, an array,
+// a (parameter, radius) point list) have nothing in common but occtValidFilletRadius above.
+template <class AddEdge>
+void occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
+                        const int32_t* edgeIndices, int32_t edgeCount, AddEdge addEdge) {
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
+
+    for (int32_t i = 0; i < edgeCount; i++) {
+        int32_t idx = edgeIndices[i];
+        if (idx < 0 || idx >= edgeMap.Extent()) continue;
+        addEdge(fillet, TopoDS::Edge(edgeMap(idx + 1)), i);  // OCCT's map is 1-based
+    }
+}
+
+// occtFilletAddEdges plus the build-and-wrap half: the guard, the perform/check/result triad, and
+// the catch(...) that turns any OCCT failure into nullptr. This is the whole body of the three
+// edge-list fillet entry points bar their radius law.
+template <class AddEdge>
+OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
+                                     const int32_t* edgeIndices, int32_t edgeCount,
+                                     AddEdge addEdge) {
+    if (!shape || !edgeIndices || edgeCount < 1) return nullptr;
+
+    try {
+        BRepFilletAPI_MakeFillet fillet(shape->shape);
+        occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge);
+
+        fillet.Build();
+        if (!fillet.IsDone()) return nullptr;
+
+        TopoDS_Shape result = fillet.Shape();
+        if (result.IsNull()) return nullptr;
+
+        return new OCCTShape(result);
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -322,65 +322,32 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType) 
 
 // MARK: - Advanced Modeling (v0.8.0)
 
+// The three edge-list fillet entry points share occtShapeFilletEdgeList (OCCTBridge_Internal.h)
+// and supply only their own radius law; OCCTShapeBlendEdges, the per-edge one, lives in
+// OCCTBridge_Healing.mm. See that helper for why the radius precondition is the bridge's. #489
 OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices,
                                    int32_t edgeCount, double radius) {
-    if (!shape || !edgeIndices || edgeCount <= 0 || radius <= 0) return nullptr;
+    if (!occtValidFilletRadius(radius)) return nullptr;
 
-    try {
-        BRepFilletAPI_MakeFillet fillet(shape->shape);
-
-        // Build edge index map for lookup
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-
-        for (int32_t i = 0; i < edgeCount; i++) {
-            int32_t idx = edgeIndices[i];
-            if (idx >= 0 && idx < edgeMap.Extent()) {
-                TopoDS_Edge edge = TopoDS::Edge(edgeMap(idx + 1));  // OCCT is 1-based
-                fillet.Add(radius, edge);
-            }
-        }
-
-        fillet.Build();
-        if (!fillet.IsDone()) return nullptr;
-
-        return new OCCTShape(fillet.Shape());
-    } catch (...) {
-        return nullptr;
-    }
+    return occtShapeFilletEdgeList(shape, edgeIndices, edgeCount,
+                                   [radius](BRepFilletAPI_MakeFillet& fillet,
+                                            const TopoDS_Edge& edge, int32_t) {
+        fillet.Add(radius, edge);
+    });
 }
 
 OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeIndices,
                                          int32_t edgeCount, double startRadius, double endRadius) {
-    if (!shape || !edgeIndices || edgeCount <= 0) return nullptr;
-    if (startRadius <= 0 || endRadius <= 0) return nullptr;
+    if (!occtValidFilletRadius(startRadius) || !occtValidFilletRadius(endRadius)) return nullptr;
 
-    try {
-        BRepFilletAPI_MakeFillet fillet(shape->shape);
-
-        // Build edge index map for lookup
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-
-        for (int32_t i = 0; i < edgeCount; i++) {
-            int32_t idx = edgeIndices[i];
-            if (idx >= 0 && idx < edgeMap.Extent()) {
-                TopoDS_Edge edge = TopoDS::Edge(edgeMap(idx + 1));  // OCCT is 1-based
-                // Add edge with variable radius
-                fillet.Add(edge);
-                // Set radius variation along the edge
-                int contourIndex = fillet.NbContours();
-                fillet.SetRadius(startRadius, endRadius, contourIndex, 1);
-            }
-        }
-
-        fillet.Build();
-        if (!fillet.IsDone()) return nullptr;
-
-        return new OCCTShape(fillet.Shape());
-    } catch (...) {
-        return nullptr;
-    }
+    return occtShapeFilletEdgeList(shape, edgeIndices, edgeCount,
+                                   [startRadius, endRadius](BRepFilletAPI_MakeFillet& fillet,
+                                                            const TopoDS_Edge& edge, int32_t) {
+        // The radius-law overload takes no radius: add the edge as its own contour first, then
+        // vary the radius across that contour.
+        fillet.Add(edge);
+        fillet.SetRadius(startRadius, endRadius, fillet.NbContours(), 1);
+    });
 }
 
 OCCTShapeRef OCCTShapeDraft(OCCTShapeRef shape, const int32_t* faceIndices, int32_t faceCount,
@@ -1921,16 +1888,17 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdges(OCCTShapeRef shape,
                                                        double radius,
                                                        OCCTShapeRef* outResult) {
     if (outResult) *outResult = nullptr;
+    // Same family as OCCTShapeFilletEdges, so the same precondition and the same edge loop; it
+    // cannot use occtShapeFilletEdgeList itself because the builder outlives the call. #489
+    if (!occtValidFilletRadius(radius)) return nullptr;
     if (!shape || !edgeIndices || count < 1) return nullptr;
     try {
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
-        for (int32_t i = 0; i < count; i++) {
-            int32_t idx = edgeIndices[i] + 1; // 0-based to 1-based
-            if (idx < 1 || idx > edgeMap.Extent()) continue;
-            op->Add(radius, TopoDS::Edge(edgeMap(idx)));
-        }
+        occtFilletAddEdges(*op, shape->shape, edgeIndices, count,
+                           [radius](BRepFilletAPI_MakeFillet& fillet,
+                                    const TopoDS_Edge& edge, int32_t) {
+            fillet.Add(radius, edge);
+        });
         op->Build();
         if (!op->IsDone()) return nullptr;
         TopoDS_Shape result = op->Shape();
@@ -1945,6 +1913,8 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdgeVariable(OCCTShapeRef shape,
                                                               double startRadius, double endRadius,
                                                               OCCTShapeRef* outResult) {
     if (outResult) *outResult = nullptr;
+    // The single-edge sibling of OCCTShapeFilletEdgesLinear, and the same precondition. #489
+    if (!occtValidFilletRadius(startRadius) || !occtValidFilletRadius(endRadius)) return nullptr;
     if (!shape) return nullptr;
     try {
         TopTools_IndexedMapOfShape edgeMap;

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -3474,8 +3474,14 @@ extension Shape {
     /// Each edge can have its own fillet radius, allowing for more control
     /// than applying a uniform fillet to all edges.
     ///
-    /// - Parameter edgeRadii: Array of (edgeIndex, radius) pairs
-    /// - Returns: Filleted shape, or nil on failure
+    /// Every radius must be positive: one non-positive (or NaN) radius rejects the whole batch,
+    /// the same contract ``filleted(edges:radius:)`` and
+    /// ``filleted(edges:startRadius:endRadius:)`` apply to theirs. An out-of-range `edgeIndex` is
+    /// skipped, so the fillet is applied to whichever indices resolve on this shape.
+    ///
+    /// - Parameter edgeRadii: Array of (edgeIndex, radius) pairs; each radius must be > 0
+    /// - Returns: Filleted shape, or nil on failure, including an empty array, a non-positive
+    ///   radius anywhere in the array, or no index resolving to an edge of this shape
     ///
     /// ## Example
     ///
@@ -3486,9 +3492,12 @@ extension Shape {
     ///     (1, 2.0),  // Edge 1 gets 2mm fillet
     ///     (2, 0.5)   // Edge 2 gets 0.5mm fillet
     /// ])
+    ///
+    /// // Rejected: a radius of zero is not a fillet, so the batch returns nil
+    /// let invalid = shape.blendedEdges([(0, 1.0), (1, 0.0)])  // nil
     /// ```
     public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Shape? {
-        guard !edgeRadii.isEmpty else { return nil }
+        guard !edgeRadii.isEmpty, edgeRadii.allSatisfy({ $0.radius > 0 }) else { return nil }
 
         var indices = edgeRadii.map { Int32($0.edgeIndex) }
         var radii = edgeRadii.map { $0.radius }
@@ -5300,10 +5309,12 @@ extension Shape {
     /// shape and a `ShapeHistoryRef` queryable for `Modified` / `Generated` /
     /// `IsDeleted` per input sub-shape (e.g. a filleted edge → multiple
     /// generated fillet faces).
+    ///
+    /// `radius` must be positive, matching ``filleted(edges:radius:)``.
     public func filletedWithFullHistory(radius: Double, edges: [Int])
         -> (result: Shape, history: ShapeHistoryRef)?
     {
-        guard !edges.isEmpty else { return nil }
+        guard !edges.isEmpty, radius > 0 else { return nil }
         let edgeIndices = edges.map { Int32($0) }
         var resultRef: OCCTShapeRef?
         let h = edgeIndices.withUnsafeBufferPointer { buf in
@@ -5316,9 +5327,12 @@ extension Shape {
 
     /// Variable-radius fillet on a single edge: radius linearly varies from
     /// `startRadius` (at the edge's first parameter) to `endRadius` (at last).
+    ///
+    /// Both radii must be positive, matching ``filleted(edges:startRadius:endRadius:)``.
     public func filletedWithFullHistory(edge: Int, startRadius: Double, endRadius: Double)
         -> (result: Shape, history: ShapeHistoryRef)?
     {
+        guard startRadius > 0, endRadius > 0 else { return nil }
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeHistoryFromFilletEdgeVariable(handle, Int32(edge),
                                                                startRadius, endRadius,

--- a/Tests/OCCTModelingTests/Issue489FilletRadiusTests.swift
+++ b/Tests/OCCTModelingTests/Issue489FilletRadiusTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #489: the three `BRepFilletAPI_MakeFillet` edge-list entry points share one skeleton, so they
+/// share one radius precondition.
+///
+/// `Shape.blendedEdges(_:)` used to be the outlier: `filleted(edges:radius:)` and
+/// `filleted(edges:startRadius:endRadius:)` reject a non-positive radius before OCCT is called,
+/// while the per-edge variant checked only that the array was non-empty. Ground truth for the
+/// pinned kernel (`Scripts/repro/489-fillet-radius-validation/`): `BRepFilletAPI_MakeFillet::Add`
+/// neither throws nor produces a wrong shape for a radius of 0, a negative radius or NaN. It
+/// fails `IsDone()`, so a bad radius that reached OCCT already surfaced as `nil`. The gap was the
+/// pairing of a bad radius with an out-of-range edge index: the bounds check dropped that pair and
+/// the batch built successfully, filleting fewer edges than the caller asked for.
+@Suite("Fillet Edge-List Radius Validation (#489)")
+struct Issue489FilletRadiusTests {
+
+    // MARK: - Per-edge radii (Shape.blendedEdges)
+
+    @Test("Blend rejects a zero radius")
+    func blendZeroRadiusRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.blendedEdges([(0, 0.0)]) == nil)
+    }
+
+    @Test("Blend rejects a negative radius")
+    func blendNegativeRadiusRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.blendedEdges([(0, -5.0)]) == nil)
+    }
+
+    @Test("Blend rejects a NaN radius")
+    func blendNaNRadiusRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.blendedEdges([(0, Double.nan)]) == nil)
+    }
+
+    @Test("One bad radius rejects the whole blend batch")
+    func blendMixedRadiiRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.blendedEdges([(0, 2.0), (1, 0.0)]) == nil)
+        #expect(box.blendedEdges([(0, 2.0), (1, -3.0)]) == nil)
+    }
+
+    /// The one case where the missing guard was observable rather than merely redundant: the
+    /// bounds check skipped the (out-of-range index, bad radius) pair, so the batch built from the
+    /// remaining edge and reported success for a request that was never fully honoured.
+    @Test("A bad radius on an out-of-range index still rejects the batch")
+    func blendBadRadiusOnOutOfRangeIndexRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.edges().count < 99_999)
+        #expect(box.blendedEdges([(0, 2.0), (99_999, -5.0)]) == nil)
+    }
+
+    /// The bounds check itself is unchanged: an out-of-range index paired with a *valid* radius is
+    /// still skipped, and the batch still builds from whatever edges resolved.
+    @Test("An out-of-range index with a valid radius is still skipped, not rejected")
+    func blendOutOfRangeIndexStillSkipped() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let blended = box.blendedEdges([(0, 2.0), (99_999, 2.0)])
+        #expect(blended != nil)
+        if let blended { #expect(blended.isValid) }
+    }
+
+    // MARK: - Uniform radius (Shape.filleted(edges:radius:))
+
+    /// The sibling guard the per-edge variant was missing. It existed in source on both sides of
+    /// the FFI boundary but had no test, so nothing pinned it.
+    @Test("Uniform fillet rejects a non-positive radius")
+    func uniformNonPositiveRadiusRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let edges = Array(box.edges().prefix(2))
+        #expect(edges.count == 2)
+        #expect(box.filleted(edges: edges, radius: 0.0) == nil)
+        #expect(box.filleted(edges: edges, radius: -2.0) == nil)
+        #expect(box.filleted(edges: edges, radius: Double.nan) == nil)
+    }
+
+    // MARK: - Linear radius (Shape.filleted(edges:startRadius:endRadius:))
+
+    @Test("Linear fillet rejects a non-positive radius at either end")
+    func linearNonPositiveRadiusRejected() {
+        let box = Shape.box(width: 30, height: 10, depth: 10)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("Could not get edge 0")
+            return
+        }
+        #expect(box.filleted(edges: [edge], startRadius: 0.0, endRadius: 3.0) == nil)
+        #expect(box.filleted(edges: [edge], startRadius: 1.0, endRadius: 0.0) == nil)
+        #expect(box.filleted(edges: [edge], startRadius: -1.0, endRadius: 3.0) == nil)
+        #expect(box.filleted(edges: [edge], startRadius: 1.0, endRadius: -3.0) == nil)
+    }
+
+    // MARK: - History-retaining siblings (same loop, same precondition)
+
+    @Test("History fillet rejects a non-positive radius")
+    func historyUniformNonPositiveRadiusRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.filletedWithFullHistory(radius: 0.0, edges: [0]) == nil)
+        #expect(box.filletedWithFullHistory(radius: -2.0, edges: [0]) == nil)
+        #expect(box.filletedWithFullHistory(radius: Double.nan, edges: [0]) == nil)
+    }
+
+    @Test("History variable fillet rejects a non-positive radius at either end")
+    func historyLinearNonPositiveRadiusRejected() {
+        let box = Shape.box(width: 30, height: 10, depth: 10)!
+        #expect(box.filletedWithFullHistory(edge: 0, startRadius: 0.0, endRadius: 3.0) == nil)
+        #expect(box.filletedWithFullHistory(edge: 0, startRadius: 1.0, endRadius: 0.0) == nil)
+        #expect(box.filletedWithFullHistory(edge: 0, startRadius: -1.0, endRadius: 3.0) == nil)
+    }
+
+    /// The history entry point moved onto the shared edge loop, so a valid request must still build
+    /// and still report the input edge in its history.
+    @Test("History fillet still builds and still records the input edge")
+    func historyFilletStillBuilds() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let edges = box.subShapes(ofType: .edge)
+        #expect(!edges.isEmpty)
+
+        var built: (result: Shape, history: ShapeHistoryRef)?
+        var builtIndex = -1
+        for i in 0..<min(edges.count, 6) {
+            if let r = box.filletedWithFullHistory(radius: 1.0, edges: [i]) {
+                built = r
+                builtIndex = i
+                break
+            }
+        }
+        guard let r = built, builtIndex >= 0 else {
+            Issue.record("no edge accepted a uniform 1.0 fillet")
+            return
+        }
+        #expect(r.result.isValid)
+        if let volume = r.result.volume { #expect(volume < 8000.0) }
+
+        let rec = r.history.record(of: edges[builtIndex])
+        #expect(rec.modified.count + rec.generated.count > 0 || rec.isDeleted)
+    }
+
+    // MARK: - Geometry unchanged by the shared skeleton
+
+    /// Both entry points now run the same loop over the same edge map, so a per-edge radius list
+    /// where every radius is equal must produce exactly the shape the uniform entry point does.
+    @Test("Uniform radii through the per-edge path match the uniform path")
+    func perEdgeUniformRadiiMatchUniformPath() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let edges = Array(box.edges().prefix(3))
+        #expect(edges.count == 3)
+
+        let uniform = box.filleted(edges: edges, radius: 2.0)
+        let perEdge = box.blendedEdges(edges.map { (edgeIndex: $0.index, radius: 2.0) })
+
+        #expect(uniform != nil)
+        #expect(perEdge != nil)
+        if let uniform, let perEdge,
+           let uniformVolume = uniform.volume, let perEdgeVolume = perEdge.volume {
+            #expect(abs(uniformVolume - perEdgeVolume) < 1e-6)
+            #expect(uniformVolume < 8000.0)  // material actually removed
+        }
+    }
+
+    /// Distinct radii still reach OCCT individually rather than collapsing onto one value.
+    @Test("Distinct per-edge radii remove more material than the smallest one alone")
+    func distinctPerEdgeRadiiHonoured() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let edges = Array(box.edges().prefix(3))
+        #expect(edges.count == 3)
+
+        let allSmall = box.blendedEdges(edges.map { (edgeIndex: $0.index, radius: 1.0) })
+        let mixed = box.blendedEdges([
+            (edgeIndex: edges[0].index, radius: 1.0),
+            (edgeIndex: edges[1].index, radius: 3.0),
+            (edgeIndex: edges[2].index, radius: 2.0),
+        ])
+
+        #expect(allSmall != nil)
+        #expect(mixed != nil)
+        if let allSmall, let mixed,
+           let smallVolume = allSmall.volume, let mixedVolume = mixed.volume {
+            #expect(mixedVolume < smallVolume)
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -114,6 +114,67 @@ downstream algorithms self-reject: a zero-radius ellipse yields a 5-pole BSpline
 two of them have no nil channel to report a rejection through and each needs its own contract
 decision.
 
+#### One skeleton behind the three edge-list fillet entry points, and the radius precondition one of them never had (#489)
+
+**Behaviour change, one call shape.** `Shape.blendedEdges(_:)` now returns `nil` when any radius in
+the batch is non-positive or NaN, which is the contract `filleted(edges:radius:)` and
+`filleted(edges:startRadius:endRadius:)` already applied to theirs:
+
+| call | before | now |
+|---|---|---|
+| `blendedEdges([(0, 2.0), (99999, -5.0)])` | shape filleted on edge 0 only, reported as success | `nil` |
+| `blendedEdges([(0, 0.0)])` | `nil` | `nil` |
+| `blendedEdges([(0, -5.0)])` | `nil` | `nil` |
+| `blendedEdges([(0, 2.0), (1, 0.0)])` | `nil` | `nil` |
+
+Only the first row changes, and measuring that is what narrowed the finding: a non-positive radius
+that reached OCCT was already reported as failure, because `BRepFilletAPI_MakeFillet::Add(r, edge)`
+with `r` of 0, a negative `r`, or NaN does not throw and does not build a wrong shape, it fails
+`IsDone()` (ground truth in
+[`Scripts/repro/489-fillet-radius-validation/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/489-fillet-radius-validation)).
+The case that escaped was a bad radius paired with an out-of-range edge index: the bounds check
+dropped the pair before the radius was ever used, so the batch built from the remaining edges and
+reported success for a request that was never fully honoured. Valid input is unaffected, pinned by a
+test that a uniform per-edge radius list produces the same volume as the uniform entry point. An
+out-of-range index with a valid radius is still skipped, unchanged.
+
+`OCCTShapeFilletEdges` and `OCCTShapeFilletEdgesLinear` (`OCCTBridge_Modeling.mm`) and
+`OCCTShapeBlendEdges` (`OCCTBridge_Healing.mm`) were three hand-maintained copies of one loop:
+same `TopExp::MapShapes` edge map, same 0-based index bounds check, same `Build`/`IsDone`/`Shape`
+triad, same `catch (...)`, differing only in the radius each edge gets. That is how the guard came to
+exist in two of them and not the third. All three now share `occtShapeFilletEdgeList` and the
+`occtValidFilletRadius` / `occtValidFilletRadii` predicates in `OCCTBridge_Internal.h`, so the next
+piece of hardening this family needs lands once. `OCCTShapeFilletEdges` also picks up the null-result
+check the blend function already had.
+
+A fourth copy of the same loop turned up in `OCCTShapeHistoryFromFilletEdges`, which the finding did
+not name: it cannot use the full skeleton, because it keeps its builder alive to hand back a
+`BRepTools_History` over it, so the loop is split out as `occtFilletAddEdges` and shared at that
+level. It had no radius precondition either, nor does its single-edge sibling
+`OCCTShapeHistoryFromFilletEdgeVariable`; both now apply the same one, as do their Swift wrappers
+`Shape.filletedWithFullHistory(radius:edges:)` and
+`Shape.filletedWithFullHistory(edge:startRadius:endRadius:)`. No observable change for either: both
+take a single radius (or radius pair) that is either valid or rejected outright, with no per-element
+pairing for an index skip to hide.
+
+Bridge-only: no kernel patch, no xcframework rebuild, nothing filed upstream, since `Add()` reporting
+failure through `IsDone()` is OCCT's documented `BRepBuilderAPI_MakeShape` contract.
+
+The cross-reference index entry for `BRepFilletAPI_MakeFillet` named only the `OCCTShapeFillet*`
+prefix, so four of its call sites were unreachable from the index: `OCCTShapeBlendEdges` (the one this
+issue is about), `OCCTShapeFuseAndBlend`, `OCCTShapeCutAndBlend` and the `OCCTFilletBuilder*` family.
+That is the #484 failure mode again, an audit by symbol name finding fewer sites than exist, and it is
+how this family's copies stayed out of view. The entry now names all of them;
+`Scripts/check-bridge-index.py` still reports the same 139 pre-existing stale entries (#510), none of
+them new.
+
+Two family-level inconsistencies were found and deliberately left alone, filed as #520: the other two
+`BRepFilletAPI_MakeFillet` edge-list functions disagree with these three about what an edge index
+means and what an invalid one does. `OCCTShapeFilletEvolving` takes 1-based indices (documented as
+such on `EvolvingFilletEdge.edgeIndex`) and rejects an out-of-range one, and
+`OCCTShapeFilletVariable` takes a 0-based index and also rejects. Reconciling them changes public
+API behaviour and needs its own decision, not a drive-by in a dedup fix.
+
 ---
 
 ## Release History

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1011,8 +1011,12 @@ public func filleted(edges: [Edge], radius: Double) -> Shape?
 ```
 
 - **Parameters:** `edges` — edges to fillet (must have valid `index` values from this shape); `radius` — fillet radius (must be > 0).
-- **Returns:** Filleted shape, or `nil` on failure.
+- **Returns:** Filleted shape, or `nil` on failure, which includes a non-positive or NaN radius.
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeFilletEdges`).
+- **Notes:** shares one bridge implementation with
+  [`filleted(edges:startRadius:endRadius:)`](#filletededgesstartradiusendradius) and
+  [`blendedEdges(_:)`](#blendededges_), so all three apply the same positive-radius precondition and
+  the same skip-an-out-of-range-index behaviour (#489).
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)
@@ -1033,8 +1037,11 @@ public func filleted(edges: [Edge], startRadius: Double, endRadius: Double) -> S
 The radius varies linearly from `startRadius` at the start of each edge to `endRadius` at its end.
 
 - **Parameters:** `edges` — edges to fillet; `startRadius` — radius at edge start (> 0); `endRadius` — radius at edge end (> 0).
-- **Returns:** Filleted shape, or `nil` on failure.
+- **Returns:** Filleted shape, or `nil` on failure, which includes a non-positive or NaN radius at
+  either end.
 - **OCCT:** `BRepFilletAPI_MakeFillet` with law-driven radius (via `OCCTShapeFilletEdgesLinear`).
+- **Notes:** shares one bridge implementation with [`filleted(edges:radius:)`](#filletededgesradius)
+  and [`blendedEdges(_:)`](#blendededges_) (#489).
 
 ---
 
@@ -1566,9 +1573,14 @@ Applies fillets to multiple edges, each with its own radius.
 public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Shape?
 ```
 
-- **Parameters:** `edgeRadii` — array of `(edgeIndex, radius)` pairs.
-- **Returns:** Filleted shape with per-edge radii applied, or `nil` on failure.
+- **Parameters:** `edgeRadii` — array of `(edgeIndex, radius)` pairs. Every radius must be > 0.
+- **Returns:** Filleted shape with per-edge radii applied, or `nil` on failure, which includes an
+  empty array, a non-positive or NaN radius anywhere in it, and no index resolving to an edge of
+  this shape.
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeBlendEdges`).
+- **Notes:** one non-positive radius rejects the whole batch, the same contract
+  [`filleted(edges:radius:)`](#filletededgesradius) applies to its single radius (#489). An
+  out-of-range `edgeIndex` is skipped, so the fillet is applied to whichever indices resolve.
 - **Example:**
   ```swift
   let blended = shape.blendedEdges([
@@ -1576,6 +1588,9 @@ public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Sha
       (1, 2.0),
       (2, 0.5)
   ])
+
+  // Rejected: a radius of zero is not a fillet
+  let invalid = shape.blendedEdges([(0, 1.0), (1, 0.0)])  // nil
   ```
 
 ---

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -2070,9 +2070,10 @@ public func filletedWithFullHistory(radius: Double, edges: [Int])
 ```
 
 - **Parameters:**
-  - `radius` — fillet radius.
-  - `edges` — 0-based edge indices to fillet.
-- **Returns:** Result shape and history, or nil on failure or empty edge list.
+  - `radius` — fillet radius. Must be > 0.
+  - `edges` — 0-based edge indices to fillet. An index that does not resolve on this shape is skipped.
+- **Returns:** Result shape and history, or nil on failure, an empty edge list, or a non-positive
+  radius (#489).
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeHistoryFromFilletEdges`).
 - **Example:**
   ```swift
@@ -2094,9 +2095,10 @@ Radius varies linearly from `startRadius` (at the edge's first parameter) to `en
 
 - **Parameters:**
   - `edge` — 0-based edge index.
-  - `startRadius` — radius at the start of the edge.
-  - `endRadius` — radius at the end of the edge.
-- **Returns:** Result shape and history, or nil on failure.
+  - `startRadius` — radius at the start of the edge. Must be > 0.
+  - `endRadius` — radius at the end of the edge. Must be > 0.
+- **Returns:** Result shape and history, or nil on failure, or a non-positive radius at either
+  end (#489).
 - **OCCT:** `BRepFilletAPI_MakeFillet` variable-radius (via `OCCTShapeHistoryFromFilletEdgeVariable`).
 - **Example:**
   ```swift


### PR DESCRIPTION
## What & why

`OCCTShapeFilletEdges`, `OCCTShapeFilletEdgesLinear` and `OCCTShapeBlendEdges` were three
hand-maintained copies of one loop, differing only in the radius each edge gets, which is why the
positive-radius precondition existed in two of them and not the third. All three now share one
skeleton and one predicate, so the next piece of hardening this family needs lands once.

Targets `refactor/381-pass1b`, not `main`, per #377's ordering rule.

Closes #489

### The behaviour change

| call | before | now |
|---|---|---|
| `blendedEdges([(0, 2.0), (99999, -5.0)])` | shape filleted on edge 0 only, reported as success | `nil` |
| `blendedEdges([(0, 0.0)])` | `nil` | `nil` |
| `blendedEdges([(0, -5.0)])` | `nil` | `nil` |
| `blendedEdges([(0, Double.nan)])` | `nil` | `nil` |
| `blendedEdges([(0, 2.0), (1, 0.0)])` | `nil` | `nil` |
| `blendedEdges([(0, 2.0), (99999, 2.0)])` | shape filleted on edge 0 | shape filleted on edge 0 |

One row changes. Valid input is untouched, pinned by a test that a uniform per-edge radius list
produces the same volume as `filleted(edges:radius:)`, and by one that distinct radii still remove
more material than the smallest alone. Skipping an out-of-range index with a valid radius is
unchanged, also pinned.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification): `Issue489FilletRadiusTests` in `Tests/OCCTModelingTests/`, 13 tests.

## Notes for the reviewer

**One correction to the issue's finding, from measuring before coding** (the #380 lesson). The
finding says `Shape.blendedEdges([(0, 0.0)])` "reaches `BRepFilletAPI_MakeFillet::Add(0.0, edge)`
with no rejection anywhere in the stack". True as far as reaching the call goes, but the outcome was
already `nil`: `Add(r, edge)` with `r` of 0, a negative `r`, or NaN neither throws nor builds a wrong
shape, it fails `IsDone()`, which the bridge already turned into `nullptr`. Same for the `SetRadius`
law path. And when the bounds check skips *every* index, `Build()` throws "There are no suitable edges
for chamfer or fillet", so that case was already `nil` too.

**Exactly one call shape was observably wrong**, and it is not the one the finding names: a bad radius
paired with an out-of-range index. The bounds check `continue`d past the pair before the radius was
ever read, so the batch built from the remaining edges and reported success for a request that was
never fully honoured. Proven rather than assumed: the new suite was written first and run against
unmodified code, where 1 of 10 tests failed and the other 9 already passed. Ground truth tables for
both probes are in
[`Scripts/repro/489-fillet-radius-validation/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/489-fillet-edge-list-dedup/Scripts/repro/489-fillet-radius-validation).

That does not make the guard cosmetic. It rejects the batch before a full fillet build attempt rather
than after, and the precondition has to live in the bridge for the reason #487 established: the pinned
`OCCT.xcframework` is a Release build, so every `*_Raise_if` inside OCCT is compiled out by
`No_Exception` and nothing in the library is load-bearing.

**A fourth copy of the loop the issue does not name.** `OCCTShapeHistoryFromFilletEdges` runs the same
edge loop but keeps its builder alive to hand back a `BRepTools_History`, so it cannot use the full
skeleton. The loop is therefore split into `occtFilletAddEdges` (the loop) and
`occtShapeFilletEdgeList` (loop plus `Build`/`IsDone`/`Shape`/`catch`), and the history function shares
the former. It had no radius precondition either, nor does its single-edge sibling
`OCCTShapeHistoryFromFilletEdgeVariable`; both now apply the same one, as do their Swift wrappers
`filletedWithFullHistory(radius:edges:)` and `filletedWithFullHistory(edge:startRadius:endRadius:)`.
Neither can change observably: both take a single radius (or pair) that is either valid or rejected
outright, with no per-element pairing for an index skip to hide.

**Where the helpers live.** `OCCTBridge_Internal.h`, the established cross-TU home
(`occtFilling*` from #434, the conic predicates from #487), since the callers are in
`OCCTBridge_Modeling.mm` and `OCCTBridge_Healing.mm`. Templated on the Add step with a lambda,
matching `occtWriteKnotSplitParams`' precedent; that requires four OCCT includes in the header
(`BRepFilletAPI_MakeFillet`, `TopExp`, `TopoDS`, `TopTools_IndexedMapOfShape`), since a template body
needs them at definition point. `BRepOffsetAPI_MakeFilling.hxx` was already there for the same
reason. `OCCTShapeFilletEdges` also picks up the null-result check `OCCTShapeBlendEdges` already had.

**One index entry fixed, in Pass 1b's own remit.** `BRepFilletAPI_MakeFillet → OCCTShapeFillet*` hid
four of that class's call sites from any audit by symbol name: `OCCTShapeBlendEdges` (this issue's
subject), `OCCTShapeFuseAndBlend`, `OCCTShapeCutAndBlend` and the `OCCTFilletBuilder*` family. That is
the #484 failure mode, and it is part of why these copies stayed out of view.
`Scripts/check-bridge-index.py` reports the same 139 pre-existing stale entries before and after
(#510), none new.

**Two family-level inconsistencies found and deliberately not fixed, filed as #520.** The other two
`BRepFilletAPI_MakeFillet` edge-list functions disagree with these three: `OCCTShapeFilletEvolving`
takes 1-based indices (documented as such on `EvolvingFilletEdge.edgeIndex`) and
`OCCTShapeFilletVariable` takes 0-based, both reject an out-of-range index where the other three skip
it, and neither validates a radius element. Reconciling any of that changes public API behaviour
across five methods, which is not a drive-by in a dedup fix.

**Verification**

- Ground-truth probes compiled against the pinned xcframework per `CLAUDE.md`'s recipe, committed with
  their measured tables.
- Fix proven to live in the bridge, not in the new Swift guard: with the Swift-side `allSatisfy`
  temporarily removed, all 13 tests still pass. The Swift guard is defense in depth, matching the two
  sibling wrappers.
- `swift test`: 4655 tests in 1319 suites, clean.
- No kernel patch, no xcframework rebuild, nothing filed upstream.

**Docs.** `docs/CHANGELOG.md` (Unreleased, Pass 1b section), `docs/reference/Shape-Features.md` (all
three edge-list entries, with the shared-contract note and a rejected-input snippet),
`docs/reference/Shape-Healing.md` (both history entries), `///` doc comments on the changed Swift
methods, and the three bridge header declarations.
