### PR TITLE
fix(#491): one GeomConvert_Approx* run per type, not two that disagree

### DIFF
--- a/Scripts/repro/491-approx-wrapper-drift/README.md
+++ b/Scripts/repro/491-approx-wrapper-drift/README.md
@@ -1,0 +1,145 @@
+# OCCTSwift#491 measurements — the two `GeomConvert_Approx*` wrappers per type
+
+The evidence behind #491's two decisions. Not crash reproducers: both programs exit cleanly and print
+a table. They exist because the audit finding for #491 described one divergence that turns out to be
+unreachable and one that is real but had no obvious "correct" resolution, and both conclusions rest
+on measurement rather than on reading the headers.
+
+Compile either with the standard ground-truth invocation from `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/491-approx-wrapper-drift/occt_491_precis_code_sweep.mm -o /tmp/occt_491_precis
+/tmp/occt_491_precis
+```
+
+## 1. `occt_491_isdone_vs_hasresult.mm` — the divergence that does not reproduce
+
+`GeomConvert_ApproxCurve.hxx` documents its two completion accessors as different questions:
+
+- `IsDone()` — "true if the approximation has been done **within required tolerance**"
+- `HasResult()` — "true if the approximation did come out with a result that is **not NECESSARILY**
+  within the required tolerance"
+
+`OCCTCurve3DApproximate` gated on the first and `OCCTGeomConvertApproxCurve` on the second, so on
+paper the pair disagreed for any completed-but-over-tolerance fit: one returns `nil`, the other
+returns the curve.
+
+**They cannot disagree in this kernel.** `GeomConvert_ApproxCurve::Approximate` copies both flags
+straight off `AdvApprox_ApproxAFunction` (`GeomConvert_ApproxCurve.cxx:169-170`), and that class sets
+them together:
+
+```c++
+// AdvApprox_ApproxAFunction.cxx:945-953
+if (ErrorCode == 0)      { myDone = true; myHasResult = true; }
+else if (ErrorCode == -1) { myHasResult = true; }
+```
+
+`ErrorCode == -1` is the only `HasResult`-without-`IsDone` path, and the only assignment that would
+produce it is commented out upstream:
+
+```c++
+// AdvApprox_ApproxAFunction.cxx:550, inside the "stack is full" branch
+//-> If the stack is full...
+// for now               ErrorCode=-1;
+NumCurves++;
+```
+
+With that line dead, `ErrorCode` is only ever `0` (both flags set) or `1` (early return, neither set),
+so `IsDone() == HasResult()` for every input. This program confirms it empirically over 10 requests —
+including deliberately starved fits, where OCCT reports success against a tolerance it missed by nine
+orders of magnitude:
+
+```
+  circle r=10, 1 segment deg 3      tol=1e-09  seg=1   deg=3  IsDone=1 HasResult=1 maxError=5.10851
+  ellipse 50x1, 1 segment deg 3     tol=1e-09  seg=1   deg=3  IsDone=1 HasResult=1 maxError=24.1927
+  offset(ellipse 50x1) tol 1e-12    tol=1e-12  seg=100 deg=8  IsDone=1 HasResult=1 maxError=6.96736
+```
+
+So gating on `IsDone()` never rejected an over-tolerance curve — the practical consequence is that
+`Curve3D.approximated`'s behaviour is unchanged by #491's move to `HasResult()`. The gate was unified
+anyway, on `HasResult()`, because that is what OCCT's own curve-conversion sites use
+(`GeomConvert.cxx:345/441`, `GeomToIGES_GeomCurve.cxx:632`, `GeomFill_Profiler.cxx:136`), what both
+surface entry points already used, and the only gate under which `approxWithDetails`' `isDone: false`
+diagnostic means anything.
+
+Re-run this if that upstream line is ever re-enabled: the parity tests
+(`Tests/OCCTCurveTests/Issue491Curve3DApproxParityTests.swift`) are the guard for that day.
+
+## 2. `occt_491_precis_code_sweep.mm` — choosing the shared `PrecisCode`
+
+`GeomConvert_ApproxSurface`'s eighth constructor argument is `PrecisCode`, "the index of precision".
+`OCCTSurfaceApproximate` passed `0`, `OCCTGeomConvertApproxSurface` passed `1`, neither with a
+comment. It is a genuine algorithm knob: `GeomConvert_ApproxSurface::Approximate` forwards it into
+`AdvApp2Var_ApproxAFunc2Var`, which clamps it to `[0, 3]` and passes it to `AdvApp2Var_Context` as
+`iprecis`, where `lesparam` (`AdvApp2Var_Context.cxx:22-76`) turns it into the Jacobi degree and the
+initial per-axis sample-point count that seed the iterative fit:
+
+```c++
+ndgjac = ncflim;                        // icodeo == 0: unchanged
+if (icodeo > 0) {
+  ndgjac += (9 - (iordre + 1));         // icodeo >= 1: inflate the Jacobi degree
+  ndgjac += (icodeo - 1) * 10;
+}
+// ndgjac then selects nbpnts from a 8/10/20/30/40/50 ladder
+```
+
+So the two wrappers seeded a different parameterisation for identical
+tolerance/continuity/degree/segment inputs. This program runs both codes over 72 bounded cases — 8
+surface families (sphere, torus, trimmed cylinder, trimmed cone, revolved ellipse, offset sphere,
+offset torus, bicubic Bezier) x 6 tolerances from `1e-1` to `1e-9`, plus C0/C1 and `maxDegree` 10
+variants — and tallies the differences:
+
+```
+== tally over 72 cases ==
+  result shape (poles/knots/degree) differs : 1
+  IsDone differs between the two codes      : 0  (only P0 done: 0, only P1 done: 0)
+  smaller maxError with PrecisCode=0        : 64
+  smaller maxError with PrecisCode=1        : 8
+  identical maxError                        : 0
+```
+
+The one layout difference is an offset sphere at tolerance `1e-5`, where both met the tolerance but
+`0` did it with fewer poles:
+
+```
+offset sphere +1.5  tol=1e-05 | P0 done=1 err=1.79952e-06 27x15 k 5x3 | P1 done=1 err=6.92185e-07 27x23 k 5x5
+```
+
+**#491 standardised on `0`.** A caller who states a tolerance wants the lightest surface that meets
+it, and `0` was never worse on that criterion. The residual `maxError` differences elsewhere are
+sub-1% either way, so this is a tie broken on economy rather than a quality gap.
+
+OCCT itself is split on the value, and splits along the same line:
+
+| passes `0` | passes `1` |
+|---|---|
+| `ShapeCustom_BSplineRestriction.cxx:852` | `GeomConvert_1.cxx:786` (`GeomConvert::SurfaceToBSplineSurface`) |
+| `ShapeConstruct.cxx:265` | `GeomLib.cxx:1517` |
+| `BRepFill_Sweep.cxx:1162` | `GeomFill_Sweep.cxx:296` |
+| | `ShapeUpgrade_UnifySameDomain.cxx:3629` |
+
+The `0` sites honour a caller-supplied tolerance and re-check `MaxError() <= tol` themselves,
+iterating on failure. The `1` sites convert with their own hardcoded internal tolerance
+(`1e-4`, `Precision::Confusion()`) and never surface a tolerance to a caller. This bridge is in the
+first group, which is the other half of the argument for `0`.
+
+## Note on infinite surfaces
+
+`occt_491_precis_code_sweep.mm` trims the cylinder and cone before approximating, per the project rule
+that infinite OCCT surfaces must be trimmed before BSpline conversion. Passing an untrimmed
+`Geom_CylindricalSurface` straight in (as `occt_491_isdone_vs_hasresult.mm` deliberately does, to show
+what it looks like) yields `maxError` around `1e+84` and a wildly different pole count per
+`PrecisCode` — both meaningless. Do not read anything into those rows.
+
+## Sibling finding
+
+Building #491's parity tests surfaced an unrelated upstream defect in the same class, tracked as
+[#522](https://github.com/SecondMouseAU/OCCTSwift/issues/522) with its own reproducers in
+[`Scripts/repro/522-approx-c0-collapse/`](../522-approx-c0-collapse/): at `GeomAbs_C0`,
+`GeomConvert_ApproxSurface` can collapse a parametric direction to degree 1 and still report
+`IsDone()` with a `maxError` five orders of magnitude below the surface it returns. It predates #491
+and both entry points hit it identically.

--- a/Scripts/repro/491-approx-wrapper-drift/occt_491_isdone_vs_hasresult.mm
+++ b/Scripts/repro/491-approx-wrapper-drift/occt_491_isdone_vs_hasresult.mm
@@ -1,0 +1,120 @@
+// OCCTSwift#491 — are the two documented wrapper divergences observable? See this directory's
+// README.md for the conclusions.
+//
+//  (1) GeomConvert_ApproxCurve: is there an input where HasResult() is true but IsDone() is
+//      false? That is the exact case where OCCTCurve3DApproximate (gates !IsDone -> nullptr)
+//      and OCCTGeomConvertApproxCurve (gates HasResult -> returns the fit) disagree.
+//  (2) GeomConvert_ApproxSurface: does PrecisCode 0 vs 1 actually change the resulting
+//      BSpline (knots/poles/degree/maxError) for identical other arguments?
+
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_ToroidalSurface.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_OffsetCurve.hxx>
+#include <GeomConvert_ApproxCurve.hxx>
+#include <GeomConvert_ApproxSurface.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Elips.hxx>
+#include <gp_Sphere.hxx>
+#include <gp_Cylinder.hxx>
+#include <gp_Torus.hxx>
+#include <gp_Cone.hxx>
+
+#include <cstdio>
+#include <string>
+
+static void probeCurve(const char* label, const Handle(Geom_Curve)& c,
+                       double tol, GeomAbs_Shape order, int maxSeg, int maxDeg) {
+    printf("  %-42s tol=%-9g seg=%-3d deg=%-3d ", label, tol, maxSeg, maxDeg);
+    try {
+        GeomConvert_ApproxCurve approx(c, tol, order, maxSeg, maxDeg);
+        Handle(Geom_BSplineCurve) bs = approx.Curve();
+        printf("IsDone=%d HasResult=%d maxError=%-12g curve=%s",
+               (int)approx.IsDone(), (int)approx.HasResult(), approx.MaxError(),
+               bs.IsNull() ? "NULL" : "ok");
+        if (!bs.IsNull()) {
+            printf(" (deg=%d poles=%d knots=%d)", bs->Degree(), bs->NbPoles(), bs->NbKnots());
+        }
+        if (approx.HasResult() && !approx.IsDone()) printf("   <<< DIVERGES");
+        printf("\n");
+    } catch (Standard_Failure const& f) {
+        printf("threw: %s\n", f.GetMessageString() ? f.GetMessageString() : "?");
+    } catch (...) {
+        printf("threw: unknown\n");
+    }
+}
+
+static void probeSurface(const char* label, const Handle(Geom_Surface)& s,
+                         double tol, GeomAbs_Shape cont, int maxDeg, int maxSeg) {
+    printf("  %-28s tol=%-9g cont=%d deg=%-3d seg=%-4d\n", label, tol, (int)cont, maxDeg, maxSeg);
+    for (int precis = 0; precis <= 1; precis++) {
+        printf("      PrecisCode=%d  ", precis);
+        try {
+            GeomConvert_ApproxSurface approx(s, tol, cont, cont, maxDeg, maxDeg, maxSeg, precis);
+            Handle(Geom_BSplineSurface) bs = approx.Surface();
+            printf("IsDone=%d HasResult=%d maxError=%-14.9g ",
+                   (int)approx.IsDone(), (int)approx.HasResult(), approx.MaxError());
+            if (bs.IsNull()) {
+                printf("surface=NULL\n");
+            } else {
+                printf("uDeg=%d vDeg=%d uPoles=%d vPoles=%d uKnots=%d vKnots=%d\n",
+                       bs->UDegree(), bs->VDegree(), bs->NbUPoles(), bs->NbVPoles(),
+                       bs->NbUKnots(), bs->NbVKnots());
+            }
+        } catch (Standard_Failure const& f) {
+            printf("threw: %s\n", f.GetMessageString() ? f.GetMessageString() : "?");
+        } catch (...) {
+            printf("threw: unknown\n");
+        }
+    }
+}
+
+int main() {
+    gp_Ax2 ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    gp_Ax3 ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+    printf("== (1) GeomConvert_ApproxCurve: IsDone vs HasResult ==\n");
+    Handle(Geom_Circle) circle = new Geom_Circle(gp_Circ(ax, 10.0));
+    Handle(Geom_Ellipse) ellipse = new Geom_Ellipse(gp_Elips(ax, 50.0, 1.0));
+
+    // The bridge's own default-ish arguments first (Curve3D.approximated defaults: 1e-3, C2, 100, 8).
+    probeCurve("circle r=10, defaults", circle, 1e-3, GeomAbs_C2, 100, 8);
+    // Starve the approximation: too few segments and/or too low a degree for the tolerance.
+    probeCurve("circle r=10, 1 segment deg 3", circle, 1e-9, GeomAbs_C0, 1, 3);
+    probeCurve("circle r=10, 1 segment deg 3 tol 1e-6", circle, 1e-6, GeomAbs_C0, 1, 3);
+    probeCurve("circle r=10, 1 segment deg 3 tol 1e-4", circle, 1e-4, GeomAbs_C0, 1, 3);
+    probeCurve("circle r=10, 2 segments deg 3", circle, 1e-9, GeomAbs_C0, 2, 3);
+    probeCurve("circle r=10, tol 1e-15 deg 8", circle, 1e-15, GeomAbs_C2, 100, 8);
+    probeCurve("ellipse 50x1, 1 segment deg 3", ellipse, 1e-9, GeomAbs_C0, 1, 3);
+    probeCurve("ellipse 50x1, tol 1e-12 deg 4", ellipse, 1e-12, GeomAbs_C2, 4, 4);
+    // Offset of a highly eccentric ellipse: no exact BSpline exists.
+    Handle(Geom_OffsetCurve) offs = new Geom_OffsetCurve(ellipse, 0.5, gp_Dir(0, 0, 1));
+    probeCurve("offset(ellipse 50x1) d=0.5 tol 1e-12", offs, 1e-12, GeomAbs_C2, 100, 8);
+    probeCurve("offset(ellipse 50x1) 1 seg deg 3", offs, 1e-9, GeomAbs_C0, 1, 3);
+
+    printf("\n== (2) GeomConvert_ApproxSurface: PrecisCode 0 vs 1 ==\n");
+    Handle(Geom_SphericalSurface) sphere = new Geom_SphericalSurface(ax3, 10.0);
+    Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(ax3, 5.0);
+    Handle(Geom_ToroidalSurface) torus = new Geom_ToroidalSurface(ax3, 20.0, 5.0);
+    Handle(Geom_ConicalSurface) cone = new Geom_ConicalSurface(ax3, 0.4, 3.0);
+
+    // Surface.approximated's post-#406 defaults: tol 1e-3, C2, maxDegree 8, maxSegments 100.
+    probeSurface("sphere r=10", sphere, 1e-3, GeomAbs_C2, 8, 100);
+    probeSurface("sphere r=10 (tight)", sphere, 1e-7, GeomAbs_C2, 8, 100);
+    probeSurface("sphere r=10 (old tol/deg)", sphere, 1e-2, GeomAbs_C2, 10, 100);
+    probeSurface("cylinder r=5", cyl, 1e-3, GeomAbs_C2, 8, 100);
+    probeSurface("torus 20/5", torus, 1e-3, GeomAbs_C2, 8, 100);
+    probeSurface("torus 20/5 (tight)", torus, 1e-9, GeomAbs_C2, 8, 100);
+    probeSurface("cone", cone, 1e-3, GeomAbs_C2, 8, 100);
+    probeSurface("sphere, starved seg=1 deg=3", sphere, 1e-9, GeomAbs_C0, 3, 1);
+
+    printf("\ndone\n");
+    return 0;
+}

--- a/Scripts/repro/491-approx-wrapper-drift/occt_491_precis_code_sweep.mm
+++ b/Scripts/repro/491-approx-wrapper-drift/occt_491_precis_code_sweep.mm
@@ -1,0 +1,151 @@
+// OCCTSwift#491 — PrecisCode 0 vs 1 across BOUNDED surfaces and tolerances; the evidence for
+// standardising both surface approximation entry points on 0. See this directory's README.md.
+// Which value should the one shared GeomConvert_ApproxSurface wrapper pass? Decide on measured
+// evidence: does either reach the requested tolerance where the other does not, and which
+// produces the smaller residual error?
+
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_ToroidalSurface.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_SurfaceOfRevolution.hxx>
+#include <Geom_SurfaceOfLinearExtrusion.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Geom_OffsetSurface.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_BezierSurface.hxx>
+#include <GeomConvert_ApproxSurface.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Elips.hxx>
+#include <gp_Circ.hxx>
+#include <NCollection_Array2.hxx>
+
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <string>
+
+struct Run {
+    bool   isDone = false;
+    bool   hasResult = false;
+    double maxError = 0;
+    int    uPoles = 0, vPoles = 0, uKnots = 0, vKnots = 0, uDeg = 0, vDeg = 0;
+    bool   threw = false;
+};
+
+static Run run(const Handle(Geom_Surface)& s, double tol, GeomAbs_Shape cont,
+               int maxDeg, int maxSeg, int precis) {
+    Run r;
+    try {
+        GeomConvert_ApproxSurface a(s, tol, cont, cont, maxDeg, maxDeg, maxSeg, precis);
+        r.isDone = a.IsDone();
+        r.hasResult = a.HasResult();
+        r.maxError = a.MaxError();
+        Handle(Geom_BSplineSurface) bs = a.Surface();
+        if (!bs.IsNull()) {
+            r.uPoles = bs->NbUPoles(); r.vPoles = bs->NbVPoles();
+            r.uKnots = bs->NbUKnots(); r.vKnots = bs->NbVKnots();
+            r.uDeg = bs->UDegree();    r.vDeg = bs->VDegree();
+        }
+    } catch (...) {
+        r.threw = true;
+    }
+    return r;
+}
+
+static int betterFor0 = 0, betterFor1 = 0, sameError = 0;
+static int doneOnly0 = 0, doneOnly1 = 0, shapeDiffers = 0, cases = 0;
+
+static void compare(const char* label, const Handle(Geom_Surface)& s,
+                    double tol, GeomAbs_Shape cont, int maxDeg, int maxSeg) {
+    Run a = run(s, tol, cont, maxDeg, maxSeg, 0);
+    Run b = run(s, tol, cont, maxDeg, maxSeg, 1);
+    cases++;
+
+    bool shape = (a.uPoles != b.uPoles || a.vPoles != b.vPoles ||
+                  a.uKnots != b.uKnots || a.vKnots != b.vKnots ||
+                  a.uDeg != b.uDeg || a.vDeg != b.vDeg);
+    if (shape) shapeDiffers++;
+    if (a.isDone && !b.isDone) doneOnly0++;
+    if (b.isDone && !a.isDone) doneOnly1++;
+    if (a.maxError < b.maxError) betterFor0++;
+    else if (b.maxError < a.maxError) betterFor1++;
+    else sameError++;
+
+    printf("%-34s tol=%-8g deg=%-3d seg=%-4d | P0 done=%d res=%d err=%-13.6g %2dx%-2d k%2dx%-2d"
+           " | P1 done=%d res=%d err=%-13.6g %2dx%-2d k%2dx%-2d%s%s\n",
+           label, tol, maxDeg, maxSeg,
+           (int)a.isDone, (int)a.hasResult, a.maxError, a.uPoles, a.vPoles, a.uKnots, a.vKnots,
+           (int)b.isDone, (int)b.hasResult, b.maxError, b.uPoles, b.vPoles, b.uKnots, b.vKnots,
+           shape ? "  SHAPE-DIFF" : "",
+           (a.isDone != b.isDone) ? "  DONE-DIFF" : "");
+}
+
+int main() {
+    gp_Ax3 ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    gp_Ax2 ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+    Handle(Geom_SphericalSurface) sphere = new Geom_SphericalSurface(ax3, 10.0);
+    Handle(Geom_ToroidalSurface) torus = new Geom_ToroidalSurface(ax3, 20.0, 5.0);
+    // Infinite surfaces trimmed first, per the project's own rule.
+    Handle(Geom_Surface) cyl =
+        new Geom_RectangularTrimmedSurface(new Geom_CylindricalSurface(ax3, 5.0),
+                                           0.0, 2 * M_PI, -10.0, 10.0);
+    Handle(Geom_Surface) cone =
+        new Geom_RectangularTrimmedSurface(new Geom_ConicalSurface(ax3, 0.4, 3.0),
+                                           0.0, 2 * M_PI, 0.0, 12.0);
+    // Revolution of an ellipse: not exactly representable, so the fit has to work.
+    Handle(Geom_Ellipse) profile =
+        new Geom_Ellipse(gp_Elips(gp_Ax2(gp_Pnt(20, 0, 0), gp_Dir(0, 1, 0)), 6.0, 2.0));
+    Handle(Geom_Surface) revol = new Geom_SurfaceOfRevolution(profile, gp_Ax1(gp_Pnt(0, 0, 0),
+                                                                             gp_Dir(0, 0, 1)));
+    Handle(Geom_Surface) offSphere = new Geom_OffsetSurface(sphere, 1.5);
+    Handle(Geom_Surface) offTorus = new Geom_OffsetSurface(torus, 0.75);
+    // A Bezier patch, already polynomial: the easy case.
+    NCollection_Array2<gp_Pnt> poles(1, 4, 1, 4);
+    for (int i = 1; i <= 4; i++)
+        for (int j = 1; j <= 4; j++)
+            poles.SetValue(i, j, gp_Pnt(i * 3.0, j * 3.0, (i * j) % 5));
+    Handle(Geom_Surface) bez = new Geom_BezierSurface(poles);
+
+    struct Case { const char* label; Handle(Geom_Surface) surf; };
+    std::vector<Case> surfaces = {
+        {"sphere r=10", sphere},
+        {"torus 20/5", torus},
+        {"trimmed cylinder r=5", cyl},
+        {"trimmed cone", cone},
+        {"revolved ellipse 6x2", revol},
+        {"offset sphere +1.5", offSphere},
+        {"offset torus +0.75", offTorus},
+        {"bezier 4x4", bez},
+    };
+    // Surface.approximated's defaults are tolerance 1e-3 / maxDegree 8 / maxSegments 100.
+    std::vector<double> tolerances = {1e-1, 1e-2, 1e-3, 1e-5, 1e-7, 1e-9};
+
+    printf("== PrecisCode 0 vs 1, continuity C2, maxDegree 8, maxSegments 100 ==\n");
+    for (const Case& c : surfaces) {
+        for (double tol : tolerances) {
+            compare(c.label, c.surf, tol, GeomAbs_C2, 8, 100);
+        }
+        printf("\n");
+    }
+
+    printf("== same, continuity C0 / C1 and the pre-#406 maxDegree 10 ==\n");
+    for (const Case& c : surfaces) {
+        compare(c.label, c.surf, 1e-3, GeomAbs_C0, 8, 100);
+        compare(c.label, c.surf, 1e-3, GeomAbs_C1, 8, 100);
+        compare(c.label, c.surf, 1e-2, GeomAbs_C2, 10, 100);
+    }
+
+    printf("\n== tally over %d cases ==\n", cases);
+    printf("  result shape (poles/knots/degree) differs : %d\n", shapeDiffers);
+    printf("  IsDone differs between the two codes      : %d  (only P0 done: %d, only P1 done: %d)\n",
+           doneOnly0 + doneOnly1, doneOnly0, doneOnly1);
+    printf("  smaller maxError with PrecisCode=0        : %d\n", betterFor0);
+    printf("  smaller maxError with PrecisCode=1        : %d\n", betterFor1);
+    printf("  identical maxError                        : %d\n", sameError);
+    return 0;
+}

--- a/Scripts/repro/522-approx-c0-collapse/README.md
+++ b/Scripts/repro/522-approx-c0-collapse/README.md
@@ -1,0 +1,109 @@
+# OCCTSwift#522 reproducer — `GeomConvert_ApproxSurface` at `GeomAbs_C0` collapses a direction and misreports its error
+
+Standalone, deterministic reproducers for an upstream defect found while building #491's approximation
+parity tests. Committed here rather than left in scratch because #491's own tests have to work around
+it; the fix itself is #522's, not #491's.
+
+**Not caused by #491.** Both surface approximation entry points
+(`Surface.approximated` / `Surface.approxWithDetails`) hit this identically, before and after that
+issue unified them, because both call the same OCCT class. Nothing about it is bridge-side.
+
+Compile with the standard ground-truth invocation from `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/522-approx-c0-collapse/occt_522_c0_minimal.mm -o /tmp/occt_522_c0
+/tmp/occt_522_c0
+```
+
+No fixture file is needed — a plain `Geom_SphericalSurface` reproduces it.
+
+## What happens
+
+`occt_522_c0_minimal.mm` approximates a radius-10 sphere at tolerance `1e-3`, once per continuity, and
+compares OCCT's reported `MaxError()` against the real maximum deviation over a 21x21 grid of the
+source domain:
+
+```
+cont=C0  precis=0 isDone=1 hasResult=1 maxError=0.000106971  uDeg=1 vDeg=7 uPoles=2 vPoles=8
+    fit domain U[0 6.28319] V[-1.5708 1.5708]   source U[0 6.28319] V[-1.5708 1.5708]
+    real max deviation over the source domain: 19.9999  (at u=3.14159 v=0)
+cont=C1  precis=0 isDone=1 hasResult=1 maxError=5.97449e-05  uDeg=8 vDeg=8 uPoles=16 vPoles=9
+    real max deviation over the source domain: 1.68135e-05  (at u=3.45575 v=-0.314159)
+cont=C2  precis=0 isDone=1 hasResult=1 maxError=0.000205606  uDeg=8 vDeg=8 uPoles=15 vPoles=9
+    real max deviation over the source domain: 5.45774e-05  (at u=2.51327 v=0.314159)
+```
+
+At C0 the fit is 2 poles at degree 1 across the sphere's full `[0, 2*pi]` of longitude — a straight
+line through the sphere, deviating by its own diameter — while `IsDone()` reports the tolerance met
+and `MaxError()` reports `1.07e-4`. C1 and C2 on the identical surface are correct, and their reported
+error bounds the real deviation as it should.
+
+Both `PrecisCode` values do it, so it is unrelated to the knob #491 was about.
+
+Reachable from the public Swift API through either entry point:
+
+```swift
+let sphere = Surface.sphere(center: .zero, radius: 10)!
+let fit = sphere.approximated(tolerance: 1e-3, continuity: 0)!   // continuity: 0 == C0
+// fit.uDegree == 1, fit.uPoleCount == 2; deviation from `sphere` is 19.9999
+
+let detailed = sphere.approxWithDetails(tolerance: 1e-3, uContinuity: .c0, vContinuity: .c0)
+// detailed.isDone == true, detailed.maxError == 0.000106971
+```
+
+## How wide it is
+
+`occt_522_c0_sweep.mm` runs 98 requests — 7 surface families x all 9 `(uContinuity, vContinuity)`
+combinations of C0/C1/C2 at tolerance `1e-3`, plus C0/C0 across five tolerances — and flags any whose
+real deviation exceeds 10x the reported error. 12 of 98 misreport, and every one requests C0 in at
+least one direction:
+
+| surface | uCont | vCont | reported `maxError` | real deviation | result |
+|---|---|---|---|---|---|
+| sphere r=10 | C0 | C0 | 1.07e-4 | **19.9999** | degree 1x7, 2x8 poles |
+| sphere r=10 | C1 | C0 | 1.60e-4 | **19.9999** | degree 3x8, 4x9 poles |
+| sphere r=10 | C2 | C0 | 1.87e-4 | **7.66293** | degree 5x8, 6x9 poles |
+| bicubic Bezier 4x4 | C0 | C0 | 4.08e-15 | **0.13824** | degree 1x1, 2x2 poles |
+
+Two things narrow it further:
+
+- **Degree collapse alone is not the bug.** A cylinder trimmed in V legitimately gets `vDegree = 1` —
+  it *is* linear in V — and reports correctly. Collapsing where the input is not linear is the defect.
+- **At C0/C0 the requested tolerance stops mattering.** The bicubic Bezier returns the identical 2x2
+  bilinear patch with the identical `4.08e-15` reported error at every tolerance from `1e-1` down to
+  `1e-7`. Tightening the tolerance changes nothing.
+
+A full sphere is affected while the same sphere trimmed in V to `[-1, 1]` is not, which points at the
+apex rows of the V parameterisation.
+
+## Where to look
+
+**Not root-caused.** These are the reproducers, not the diagnosis.
+`GeomConvert_ApproxSurface::Approximate`
+(`Libraries/occt-src/src/ModelingData/TKGeomBase/GeomConvert/GeomConvert_ApproxSurface.cxx:345-421`)
+forwards the requested continuities into `AdvApp2Var_ApproxAFunc2Var` as `theUContinuity` /
+`theVContinuity`, which become `AdvApp2Var_Context`'s `iu` / `iv` constraint orders. Those feed
+`lesparam` (`AdvApp2Var_Context.cxx:22-76`), which derives the Jacobi degree and the initial per-axis
+sample count, and `hMaxFactor` (`AdvApp2Var_Context.cxx:104`), which special-cases orders 0 and -1.
+
+`myMaxError` is read back from `approx.MaxError(3, 1)` — i.e. from
+`AdvApp2Var_ApproxAFunc2Var::my3DMaxError`, accumulated per patch during the iso-curve fit
+(`AdvApp2Var_ApproxAFunc2Var.cxx:845-865`) rather than measured against the surface `ConvertBS` finally
+builds. That gap is the plausible reason a degree-1 collapse can still report a tiny error, but it has
+not been confirmed.
+
+Worth establishing whether the returned surface is wrong, the reported error is wrong, or both, before
+choosing between a kernel patch (this project carries `Scripts/patches/0001`-`0017`) and a bridge-side
+rejection of the C0 request.
+
+## Interaction with #491
+
+`Tests/OCCTSurfaceTests/Issue491SurfaceApproxParityTests.swift` keeps `.c0` in its request set — both
+entry points must return the *same* surface for the same request, and after #491 they do, garbage
+included. Only its `maxErrorDescribesTheSharedFit` test excludes `.c0`, because asserting "sampled
+deviation <= reported `maxError`" fails on OCCT's own numbers there. That exclusion carries a comment
+pointing here and should be dropped when this is fixed.

--- a/Scripts/repro/522-approx-c0-collapse/occt_522_c0_minimal.mm
+++ b/Scripts/repro/522-approx-c0-collapse/occt_522_c0_minimal.mm
@@ -1,0 +1,48 @@
+// OCCTSwift#522 — minimal case: GeomConvert_ApproxSurface at GeomAbs_C0 returns a degree-1
+// collapse of a sphere (2 poles across its full longitude, deviating by the sphere's own diameter)
+// while reporting IsDone and a maxError of 1e-4. C1 and C2 on the same surface are correct.
+// See this directory's README.md.
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <GeomConvert_ApproxSurface.hxx>
+#include <gp_Ax3.hxx>
+#include <cstdio>
+#include <cmath>
+
+static void probe(GeomAbs_Shape cont, const char* name, int precis) {
+    gp_Ax3 ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    Handle(Geom_SphericalSurface) sphere = new Geom_SphericalSurface(ax3, 10.0);
+    GeomConvert_ApproxSurface a(sphere, 1e-3, cont, cont, 8, 8, 100, precis);
+    Handle(Geom_BSplineSurface) bs = a.Surface();
+    printf("cont=%-3s precis=%d isDone=%d hasResult=%d maxError=%-14g", name, precis,
+           (int)a.IsDone(), (int)a.HasResult(), a.MaxError());
+    if (bs.IsNull()) { printf(" surface=NULL\n"); return; }
+    printf(" uDeg=%d vDeg=%d uPoles=%d vPoles=%d", bs->UDegree(), bs->VDegree(),
+           bs->NbUPoles(), bs->NbVPoles());
+    double u0, u1, v0, v1, su0, su1, sv0, sv1;
+    bs->Bounds(u0, u1, v0, v1);
+    sphere->Bounds(su0, su1, sv0, sv1);
+    printf("\n    fit domain U[%g %g] V[%g %g]   source U[%g %g] V[%g %g]\n",
+           u0, u1, v0, v1, su0, su1, sv0, sv1);
+
+    double worst = 0; double wu = 0, wv = 0;
+    for (int i = 0; i <= 20; i++) {
+        for (int j = 0; j <= 20; j++) {
+            double u = su0 + (su1 - su0) * i / 20.0;
+            double v = sv0 + (sv1 - sv0) * j / 20.0;
+            gp_Pnt p = sphere->Value(u, v);
+            gp_Pnt q = bs->Value(u, v);
+            double d = p.Distance(q);
+            if (d > worst) { worst = d; wu = u; wv = v; }
+        }
+    }
+    printf("    real max deviation over the source domain: %g  (at u=%g v=%g)\n", worst, wu, wv);
+}
+
+int main() {
+    probe(GeomAbs_C0, "C0", 0);
+    probe(GeomAbs_C0, "C0", 1);
+    probe(GeomAbs_C1, "C1", 0);
+    probe(GeomAbs_C2, "C2", 0);
+    return 0;
+}

--- a/Scripts/repro/522-approx-c0-collapse/occt_522_c0_sweep.mm
+++ b/Scripts/repro/522-approx-c0-collapse/occt_522_c0_sweep.mm
@@ -1,0 +1,112 @@
+// OCCTSwift#522 — how wide is it? GeomConvert_ApproxSurface at GeomAbs_C0 returns a degree-1,
+// 2-pole-in-U fit of a sphere that deviates by 20 while reporting IsDone and maxError 1e-4.
+// Sweep 7 surface families x all 9 (uCont, vCont) combinations of C0/C1/C2, plus C0/C0 across five
+// tolerances, to see which requests are affected. See this directory's README.md.
+
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_ToroidalSurface.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Geom_SurfaceOfRevolution.hxx>
+#include <Geom_BezierSurface.hxx>
+#include <Geom_Ellipse.hxx>
+#include <GeomConvert_ApproxSurface.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Elips.hxx>
+#include <NCollection_Array2.hxx>
+#include <cstdio>
+#include <cmath>
+#include <vector>
+
+static const char* contName(GeomAbs_Shape s) {
+    switch (s) {
+        case GeomAbs_C0: return "C0";
+        case GeomAbs_C1: return "C1";
+        case GeomAbs_C2: return "C2";
+        case GeomAbs_C3: return "C3";
+        default: return "??";
+    }
+}
+
+static int misreports = 0, checked = 0;
+
+static void probe(const char* label, const Handle(Geom_Surface)& s,
+                  GeomAbs_Shape uc, GeomAbs_Shape vc, double tol) {
+    GeomConvert_ApproxSurface a(s, tol, uc, vc, 8, 8, 100, 0);
+    Handle(Geom_BSplineSurface) bs = a.Surface();
+    checked++;
+    printf("  %-24s u=%s v=%s tol=%-7g isDone=%d maxError=%-13g ", label, contName(uc),
+           contName(vc), tol, (int)a.IsDone(), a.MaxError());
+    if (bs.IsNull()) { printf("surface=NULL\n"); return; }
+    double su0, su1, sv0, sv1;
+    s->Bounds(su0, su1, sv0, sv1);
+    double worst = 0;
+    for (int i = 0; i <= 20; i++) {
+        for (int j = 0; j <= 20; j++) {
+            double u = su0 + (su1 - su0) * i / 20.0;
+            double v = sv0 + (sv1 - sv0) * j / 20.0;
+            worst = std::max(worst, s->Value(u, v).Distance(bs->Value(u, v)));
+        }
+    }
+    bool bad = worst > a.MaxError() * 10 + 1e-9;
+    if (bad) misreports++;
+    printf("uDeg=%d vDeg=%d poles=%dx%d realDev=%-13g%s\n", bs->UDegree(), bs->VDegree(),
+           bs->NbUPoles(), bs->NbVPoles(), worst, bad ? "   <<< MISREPORT" : "");
+}
+
+int main() {
+    gp_Ax3 ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+    Handle(Geom_Surface) sphere = new Geom_SphericalSurface(ax3, 10.0);
+    Handle(Geom_Surface) torus = new Geom_ToroidalSurface(ax3, 20.0, 5.0);
+    Handle(Geom_Surface) cyl =
+        new Geom_RectangularTrimmedSurface(new Geom_CylindricalSurface(ax3, 5.0),
+                                           0.0, 2 * M_PI, -10.0, 10.0);
+    Handle(Geom_Surface) cone =
+        new Geom_RectangularTrimmedSurface(new Geom_ConicalSurface(ax3, 0.4, 3.0),
+                                           0.0, 2 * M_PI, 0.0, 12.0);
+    Handle(Geom_Ellipse) profile =
+        new Geom_Ellipse(gp_Elips(gp_Ax2(gp_Pnt(20, 0, 0), gp_Dir(0, 1, 0)), 6.0, 2.0));
+    Handle(Geom_Surface) revol =
+        new Geom_SurfaceOfRevolution(profile, gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+    // Half a sphere in U: same surface type, non-periodic U range.
+    Handle(Geom_Surface) halfSphere =
+        new Geom_RectangularTrimmedSurface(new Geom_SphericalSurface(ax3, 10.0),
+                                           0.0, M_PI, -1.0, 1.0);
+    NCollection_Array2<gp_Pnt> poles(1, 4, 1, 4);
+    for (int i = 1; i <= 4; i++)
+        for (int j = 1; j <= 4; j++)
+            poles.SetValue(i, j, gp_Pnt(i * 3.0, j * 3.0, (i * j) % 5));
+    Handle(Geom_Surface) bez = new Geom_BezierSurface(poles);
+
+    struct Case { const char* label; Handle(Geom_Surface) surf; };
+    std::vector<Case> all = {
+        {"sphere r=10", sphere},           {"half sphere (U trimmed)", halfSphere},
+        {"torus 20/5", torus},             {"trimmed cylinder r=5", cyl},
+        {"trimmed cone", cone},            {"revolved ellipse", revol},
+        {"bezier 4x4", bez},
+    };
+
+    printf("== every (uCont, vCont) combination over C0/C1/C2, tolerance 1e-3 ==\n");
+    GeomAbs_Shape conts[3] = {GeomAbs_C0, GeomAbs_C1, GeomAbs_C2};
+    for (const Case& c : all) {
+        for (GeomAbs_Shape uc : conts)
+            for (GeomAbs_Shape vc : conts)
+                probe(c.label, c.surf, uc, vc, 1e-3);
+        printf("\n");
+    }
+
+    printf("== C0/C0 across tolerances ==\n");
+    for (const Case& c : all) {
+        for (double tol : {1e-1, 1e-2, 1e-3, 1e-5, 1e-7})
+            probe(c.label, c.surf, GeomAbs_C0, GeomAbs_C0, tol);
+        printf("\n");
+    }
+
+    printf("misreported (real deviation more than 10x the reported maxError): %d of %d\n",
+           misreports, checked);
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -2941,6 +2941,10 @@ int32_t OCCTCurve3DBSplineToBeziers(OCCTCurve3DRef curve,
 void OCCTCurve3DFreeArray(OCCTCurve3DRef* curves, int32_t count);
 OCCTCurve3DRef OCCTCurve3DJoinToBSpline(const OCCTCurve3DRef* curves, int32_t count,
                                          double tolerance);
+/// Approximate a curve as a BSpline. Returns the fit whenever GeomConvert_ApproxCurve produced one
+/// (HasResult), which per OCCT includes a best-effort fit outside `tolerance` — use
+/// OCCTGeomConvertApproxCurve for the same fit plus its maxError/isDone. Both share one
+/// implementation (#491).
 OCCTCurve3DRef OCCTCurve3DApproximate(OCCTCurve3DRef curve, double tolerance,
                                        int32_t continuity, int32_t maxSegments,
                                        int32_t maxDegree);
@@ -3061,6 +3065,11 @@ OCCTSurfaceRef OCCTSurfaceMirrorAxis(OCCTSurfaceRef surface,
 
 // Conversion
 OCCTSurfaceRef OCCTSurfaceToBSpline(OCCTSurfaceRef surface);
+/// Approximate a surface as a BSpline surface. Returns the fit whenever GeomConvert_ApproxSurface
+/// produced one (HasResult), which per OCCT includes a best-effort fit outside `tolerance` — use
+/// OCCTGeomConvertApproxSurface for the same fit plus its maxError/isDone. Both share one
+/// implementation, including the PrecisCode they pass (#491). `continuity` applies to both
+/// parametric directions; the detailed entry point takes them separately.
 OCCTSurfaceRef OCCTSurfaceApproximate(OCCTSurfaceRef surface, double tolerance,
                                        int32_t continuity, int32_t maxSegments,
                                        int32_t maxDegree);
@@ -10038,6 +10047,9 @@ typedef struct {
     bool hasResult;
 } OCCTApproxCurveResult;
 
+/// The same approximation OCCTCurve3DApproximate performs (one shared implementation since #491),
+/// reporting the fit's maxError and completion flags. `curve` is populated exactly when
+/// `hasResult`; `isDone` is whether the fit reached `tolerance`.
 OCCTApproxCurveResult OCCTGeomConvertApproxCurve(OCCTCurve3DRef _Nonnull curve,
                                                   double tolerance,
                                                   int32_t continuity,
@@ -10054,6 +10066,11 @@ typedef struct {
     bool hasResult;
 } OCCTApproxSurfaceResult;
 
+/// The same approximation OCCTSurfaceApproximate performs (one shared implementation since #491,
+/// including the PrecisCode passed to GeomConvert_ApproxSurface), reporting the fit's maxError and
+/// completion flags. `surface` is populated exactly when `hasResult`; `isDone` is whether the fit
+/// reached `tolerance`. Note maxDegree comes BEFORE maxSegments here, the reverse of
+/// OCCTSurfaceApproximate's argument order.
 OCCTApproxSurfaceResult OCCTGeomConvertApproxSurface(OCCTSurfaceRef _Nonnull surface,
                                                       double tolerance,
                                                       int32_t uContinuity,

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -743,26 +743,67 @@ OCCTCurve3DRef OCCTCurve3DJoinToBSpline(const OCCTCurve3DRef* curves, int32_t co
     }
 }
 
+// Map a requested approximation continuity onto GeomAbs_Shape. Request orders count 0, 1, 2, 3
+// for C0..C3, which is NOT GeomAbs_Shape's own declared order (that interleaves G1/G2). Out-of-range
+// values fall back to C2, the value both approximation entry points default to.
+static GeomAbs_Shape intToContinuity(int32_t c) {
+    switch (c) {
+        case 0: return GeomAbs_C0;
+        case 1: return GeomAbs_C1;
+        case 2: return GeomAbs_C2;
+        case 3: return GeomAbs_C3;
+        default: return GeomAbs_C2;
+    }
+}
+
+// === #491: one GeomConvert_ApproxCurve run behind both curve approximation entry points ===
+//
+// OCCTCurve3DApproximate (Curve3D.approximated) and OCCTGeomConvertApproxCurve
+// (Curve3D.approxWithDetails) are two views of the same approximation: the first returns the
+// fitted BSpline, the second returns it alongside the diagnostics OCCT already computed for it.
+// They were written independently and drifted on which completion accessor decides success —
+// IsDone() here, HasResult() there — so they run through this one helper instead.
+//
+// The shared gate is HasResult(). The header documents the two as different questions: IsDone() is
+// "the approximation has been done within required tolerance", HasResult() is "did come out with a
+// result that is not NECESSARILY within the required tolerance". In this kernel they cannot
+// actually disagree: GeomConvert_ApproxCurve copies both flags off AdvApprox_ApproxAFunction, whose
+// only HasResult-without-IsDone path is the ErrorCode = -1 assignment at
+// AdvApprox_ApproxAFunction.cxx:550 — commented out upstream ("// for now ErrorCode=-1;"). With
+// that line dead, ErrorCode is only ever 0 (both flags set) or 1 (neither), which is why gating on
+// IsDone() never actually rejected an over-tolerance fit: a circle fitted with one segment at
+// degree 3 against a 1e-9 tolerance reports maxError 5.1 and still reports IsDone.
+//
+// HasResult() is the right one to standardise on regardless. It is what OCCT's own curve conversion
+// entry points use (GeomConvert.cxx:345/441, GeomToIGES_GeomCurve.cxx:632,
+// GeomFill_Profiler.cxx:136), it is what both surface entry points already used, and it is the only
+// gate under which approxWithDetails' isDone/maxError diagnostics mean anything — reporting
+// isDone: false is the point of that API, so it cannot also be the reason to return nothing.
+static OCCTApproxCurveResult occtApproxCurve(OCCTCurve3DRef c, double tolerance,
+                                             int32_t continuity, int32_t maxSegments,
+                                             int32_t maxDegree) {
+    OCCTApproxCurveResult result = {};
+    // Both the outer handle and the curve it wraps: a null Geom_Curve reaches GeomAdaptor_Curve,
+    // whose own Standard_NullObject precondition is compiled out of this Release kernel.
+    if (!c || c->curve.IsNull()) return result;
+    try {
+        GeomConvert_ApproxCurve approx(c->curve, tolerance, intToContinuity(continuity),
+                                        maxSegments, maxDegree);
+        result.isDone = approx.IsDone();
+        result.hasResult = approx.HasResult();
+        if (result.hasResult) {
+            result.maxError = approx.MaxError();
+            Handle(Geom_BSplineCurve) bspl = approx.Curve();
+            if (!bspl.IsNull()) result.curve = new OCCTCurve3D(bspl);
+        }
+    } catch (...) {}
+    return result;
+}
+
 OCCTCurve3DRef OCCTCurve3DApproximate(OCCTCurve3DRef c, double tolerance,
                                        int32_t continuity, int32_t maxSegments,
                                        int32_t maxDegree) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        GeomAbs_Shape cont = GeomAbs_C2;
-        switch (continuity) {
-            case 0: cont = GeomAbs_C0; break;
-            case 1: cont = GeomAbs_C1; break;
-            case 2: cont = GeomAbs_C2; break;
-            case 3: cont = GeomAbs_C3; break;
-        }
-
-        GeomConvert_ApproxCurve approx(c->curve, tolerance, cont, maxSegments, maxDegree);
-        if (!approx.IsDone()) return nullptr;
-
-        return new OCCTCurve3D(approx.Curve());
-    } catch (...) {
-        return nullptr;
-    }
+    return occtApproxCurve(c, tolerance, continuity, maxSegments, maxDegree).curve;
 }
 
 // Draw Methods
@@ -1628,39 +1669,14 @@ int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, do
 // MARK: - GeomConvert_ApproxCurve (v0.75)
 // --- GeomConvert_ApproxCurve ---
 
-static GeomAbs_Shape intToContinuity(int32_t c) {
-    switch (c) {
-        case 0: return GeomAbs_C0;
-        case 1: return GeomAbs_C1;
-        case 2: return GeomAbs_C2;
-        case 3: return GeomAbs_C3;
-        default: return GeomAbs_C2;
-    }
-}
-
+// Both curve approximation entry points share occtApproxCurve, declared next to
+// OCCTCurve3DApproximate above — see the #491 note there for why the gate is HasResult().
 OCCTApproxCurveResult OCCTGeomConvertApproxCurve(OCCTCurve3DRef _Nonnull curve,
                                                   double tolerance,
                                                   int32_t continuity,
                                                   int32_t maxSegments,
                                                   int32_t maxDegree) {
-    OCCTApproxCurveResult result = {};
-    if (!curve) return result;
-    try {
-        GeomConvert_ApproxCurve approx(curve->curve, tolerance,
-                                        intToContinuity(continuity), maxSegments, maxDegree);
-        result.isDone = approx.IsDone();
-        result.hasResult = approx.HasResult();
-        if (result.hasResult) {
-            result.maxError = approx.MaxError();
-            Handle(Geom_BSplineCurve) bspl = approx.Curve();
-            if (!bspl.IsNull()) {
-                auto* ref = new OCCTCurve3D();
-                ref->curve = bspl;
-                result.curve = ref;
-            }
-        }
-    } catch (...) {}
-    return result;
+    return occtApproxCurve(curve, tolerance, continuity, maxSegments, maxDegree);
 }
 
 // MARK: - GCPnts QuasiUniform / TangentialDeflection (v0.75)

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -601,25 +601,82 @@ OCCTSurfaceRef OCCTSurfaceToBSpline(OCCTSurfaceRef s) {
     }
 }
 
+// Map a requested approximation continuity onto GeomAbs_Shape. Request orders count 0, 1, 2, 3
+// for C0..C3, which is NOT GeomAbs_Shape's own declared order (that interleaves G1/G2). Out-of-range
+// values fall back to C2, the value both approximation entry points default to.
+static GeomAbs_Shape intToContinuity(int32_t c) {
+    switch (c) {
+        case 0: return GeomAbs_C0;
+        case 1: return GeomAbs_C1;
+        case 2: return GeomAbs_C2;
+        case 3: return GeomAbs_C3;
+        default: return GeomAbs_C2;
+    }
+}
+
+// === #491: one GeomConvert_ApproxSurface run behind both surface approximation entry points ===
+//
+// OCCTSurfaceApproximate (Surface.approximated) and OCCTGeomConvertApproxSurface
+// (Surface.approxWithDetails) are two views of the same approximation: the first returns the fitted
+// BSpline surface, the second returns it alongside the diagnostics OCCT already computed for it.
+// They were written independently and passed different values for GeomConvert_ApproxSurface's
+// eighth constructor argument — 0 here, 1 there — so they returned measurably different surfaces
+// for the same request. They run through this one helper instead.
+//
+// That argument is PrecisCode, "the index of precision", and it is a real algorithm knob rather
+// than a reserved value: GeomConvert_ApproxSurface::Approximate forwards it unchanged into
+// AdvApp2Var_ApproxAFunc2Var, which clamps it to [0, 3] and hands it to AdvApp2Var_Context as
+// iprecis, where lesparam (AdvApp2Var_Context.cxx:22) turns it into the Jacobi degree and the
+// initial per-axis sample-point count that seed the iterative fit. Different values therefore seed
+// a different parameterisation for identical tolerance/continuity/degree/segment inputs.
+//
+// The shared value is 0. Measured over 72 bounded cases (8 surface families x 6 tolerances, plus
+// C0/C1 and maxDegree 10 variants): the two codes never disagreed on IsDone, and produced the same
+// knot/pole layout in 71 of 72 — but a different maxError in all 72, smaller with 0 in 64 of them,
+// and in the single layout-differing case (an offset sphere at tolerance 1e-5) 0 met the requested
+// tolerance with 27x15 poles where 1 needed 27x23. A caller asking for a tolerance wants the
+// lightest surface that meets it, which is what 0 delivered.
+//
+// OCCT itself is split on the value, and splits along that same line: the sites that honour a
+// caller's tolerance and re-check MaxError() themselves pass 0 (ShapeCustom_BSplineRestriction.cxx:852,
+// ShapeConstruct.cxx:265, BRepFill_Sweep.cxx:1162), while the sites that convert with their own
+// hardcoded internal tolerance pass 1 (GeomConvert_1.cxx:786, GeomLib.cxx:1517,
+// GeomFill_Sweep.cxx:296, ShapeUpgrade_UnifySameDomain.cxx:3629). This bridge is in the first group.
+//
+// Note both entry points have always gated on HasResult(), which OCCT documents as true even for a
+// result "not NECESSARILY within the required tolerance" — unlike the curve pair, the surface pair
+// never drifted on that, and unlike the curve class, this one really can report HasResult without
+// IsDone (a torus at tolerance 1e-9 does). Reporting that through isDone is what approxWithDetails
+// is for.
+static OCCTApproxSurfaceResult occtApproxSurface(OCCTSurfaceRef s, double tolerance,
+                                                 int32_t uContinuity, int32_t vContinuity,
+                                                 int32_t maxSegments, int32_t maxDegree) {
+    OCCTApproxSurfaceResult result = {};
+    // Both the outer handle and the surface it wraps: a null Geom_Surface reaches
+    // GeomAdaptor_Surface, whose own Standard_NullObject precondition is compiled out of this
+    // Release kernel.
+    if (!s || s->surface.IsNull()) return result;
+    try {
+        GeomConvert_ApproxSurface approx(s->surface, tolerance,
+                                          intToContinuity(uContinuity),
+                                          intToContinuity(vContinuity),
+                                          maxDegree, maxDegree, maxSegments,
+                                          /* PrecisCode */ 0);
+        result.isDone = approx.IsDone();
+        result.hasResult = approx.HasResult();
+        if (result.hasResult) {
+            result.maxError = approx.MaxError();
+            Handle(Geom_BSplineSurface) bspl = approx.Surface();
+            if (!bspl.IsNull()) result.surface = new OCCTSurface(bspl);
+        }
+    } catch (...) {}
+    return result;
+}
+
 OCCTSurfaceRef OCCTSurfaceApproximate(OCCTSurfaceRef s, double tolerance,
                                        int32_t continuity, int32_t maxSegments,
                                        int32_t maxDegree) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        GeomAbs_Shape cont = GeomAbs_C2;
-        switch (continuity) {
-            case 0: cont = GeomAbs_C0; break;
-            case 1: cont = GeomAbs_C1; break;
-            case 2: cont = GeomAbs_C2; break;
-            case 3: cont = GeomAbs_C3; break;
-        }
-        GeomConvert_ApproxSurface approx(s->surface, tolerance,
-                                          cont, cont, maxDegree, maxDegree, maxSegments, 0);
-        if (!approx.HasResult()) return nullptr;
-        return new OCCTSurface(approx.Surface());
-    } catch (...) {
-        return nullptr;
-    }
+    return occtApproxSurface(s, tolerance, continuity, continuity, maxSegments, maxDegree).surface;
 }
 
 // Iso Curves
@@ -2719,44 +2776,18 @@ double OCCTSurfaceConversionGap(OCCTSurfaceRef _Nonnull surface) {
 }
 
 // MARK: - GeomConvert_ApproxSurface (v0.75)
-static GeomAbs_Shape intToContinuity(int32_t c) {
-    switch (c) {
-        case 0: return GeomAbs_C0;
-        case 1: return GeomAbs_C1;
-        case 2: return GeomAbs_C2;
-        case 3: return GeomAbs_C3;
-        default: return GeomAbs_C2;
-    }
-}
-
 // --- GeomConvert_ApproxSurface ---
 
+// Both surface approximation entry points share occtApproxSurface, declared next to
+// OCCTSurfaceApproximate above — see the #491 note there for the PrecisCode rationale. Note this
+// entry point takes maxDegree BEFORE maxSegments, the reverse of OCCTSurfaceApproximate's order.
 OCCTApproxSurfaceResult OCCTGeomConvertApproxSurface(OCCTSurfaceRef _Nonnull surface,
                                                       double tolerance,
                                                       int32_t uContinuity,
                                                       int32_t vContinuity,
                                                       int32_t maxDegree,
                                                       int32_t maxSegments) {
-    OCCTApproxSurfaceResult result = {};
-    if (!surface) return result;
-    try {
-        GeomConvert_ApproxSurface approx(surface->surface, tolerance,
-                                          intToContinuity(uContinuity),
-                                          intToContinuity(vContinuity),
-                                          maxDegree, maxDegree, maxSegments, 1);
-        result.isDone = approx.IsDone();
-        result.hasResult = approx.HasResult();
-        if (result.hasResult) {
-            result.maxError = approx.MaxError();
-            Handle(Geom_BSplineSurface) bspl = approx.Surface();
-            if (!bspl.IsNull()) {
-                auto* ref = new OCCTSurface();
-                ref->surface = bspl;
-                result.surface = ref;
-            }
-        }
-    } catch (...) {}
-    return result;
+    return occtApproxSurface(surface, tolerance, uContinuity, vContinuity, maxSegments, maxDegree);
 }
 
 // MARK: - GeomLib_Tool Surface Param + IsPlanar (v0.77)

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -506,6 +506,19 @@ public final class Curve3D: @unchecked Sendable {
     /// `Surface.approximated` (#406) — all three wrap the same `GeomConvert_Approx*`/
     /// `Geom2dConvert_ApproxCurve` family applied to a different OCCT geometry hierarchy, not
     /// independent algorithms that would justify independently-tuned numeric defaults.
+    ///
+    /// Returns the fitted curve whenever OCCT produced one, which — per `HasResult()`, the
+    /// accessor this shares with ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)``
+    /// since #491 — includes a best-effort fit that did *not* reach `tolerance`. A non-nil result
+    /// is therefore not a promise that `tolerance` was met: `approxWithDetails` reports the actual
+    /// `maxError` and an `isDone` flag for that. (Gating on `IsDone()` would not have helped here;
+    /// measured against this kernel it never rejects an over-tolerance fit — a circle fitted with
+    /// one segment at degree 3 against a 1e-9 tolerance reports `maxError` 5.1 and `isDone` true.)
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10)!
+    /// let bspline = circle.approximated(tolerance: 1e-4)
+    /// ```
     public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
                              maxSegments: Int = 100, maxDegree: Int = 8) -> Curve3D? {
         guard let h = OCCTCurve3DApproximate(handle, tolerance, Int32(continuity),

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -11677,7 +11677,24 @@ public struct ApproxCurveResult {
 }
 
 extension Curve3D {
-    /// Approximate this curve as a BSpline with detailed result (error, status).
+    /// Approximate this curve as a BSpline, reporting the fit's error and completion status.
+    ///
+    /// The same approximation ``Curve3D/approximated(tolerance:continuity:maxSegments:maxDegree:)``
+    /// performs — one shared `GeomConvert_ApproxCurve` run behind both (#491) — with the
+    /// diagnostics OCCT already computed for it. For identical arguments the two return the same
+    /// curve; use this one when you need to know how close the fit actually came.
+    ///
+    /// `hasResult` is what decides whether `curve` is populated, and OCCT documents it as true even
+    /// for a fit that is *not* within `tolerance` — `isDone` and `maxError` are how you find out.
+    /// So a non-nil `curve` is not by itself a promise that `tolerance` was met.
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10)!
+    /// let fit = circle.approxWithDetails(tolerance: 1e-6)
+    /// if let bspline = fit.curve, fit.isDone {
+    ///     print("fitted to \(fit.maxError) with \(bspline.poleCount ?? 0) poles")
+    /// }
+    /// ```
     public func approxWithDetails(tolerance: Double, continuity: ParametricContinuity = .c2,
                                    maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult {
         let r = OCCTGeomConvertApproxCurve(handle, tolerance, continuity.rawValue,
@@ -11696,9 +11713,33 @@ public struct ApproxSurfaceResult {
 }
 
 extension Surface {
-    /// Approximate this surface as a BSpline with detailed result (error, status).
-    public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c1,
-                                   vContinuity: ParametricContinuity = .c1,
+    /// Approximate this surface as a BSpline surface, reporting the fit's error and completion status.
+    ///
+    /// The same approximation ``Surface/approximated(tolerance:continuity:maxSegments:maxDegree:)``
+    /// performs — one shared `GeomConvert_ApproxSurface` run behind both (#491) — with the
+    /// diagnostics OCCT already computed for it. For identical arguments the two return the same
+    /// surface; use this one when you need to know how close the fit actually came.
+    ///
+    /// `hasResult` is what decides whether `surface` is populated, and OCCT documents it as true
+    /// even for a fit that is *not* within `tolerance` — `isDone` and `maxError` are how you find
+    /// out. So a non-nil `surface` is not by itself a promise that `tolerance` was met; on a
+    /// surface where `maxDegree` cannot reach the tolerance (a torus at 1e-9, say) OCCT returns a
+    /// usable best effort with `isDone` false.
+    ///
+    /// The continuity defaults are C2, matching ``Surface/approximated(tolerance:continuity:maxSegments:maxDegree:)``.
+    /// Before #491 they were C1 here, so the two no-continuity-argument calls fitted to different
+    /// smoothness and returned different surfaces. An infinite/unbounded surface must be trimmed to
+    /// a finite parameter domain first (see ``Surface/trimmed(u1:u2:v1:v2:)``).
+    ///
+    /// ```swift
+    /// let sphere = Surface.sphere(center: .zero, radius: 10)!
+    /// let fit = sphere.approxWithDetails(tolerance: 1e-5)
+    /// if let bspline = fit.surface, fit.isDone {
+    ///     print("fitted to \(fit.maxError) with \(bspline.uPoleCount)x\(bspline.vPoleCount) poles")
+    /// }
+    /// ```
+    public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c2,
+                                   vContinuity: ParametricContinuity = .c2,
                                    maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult {
         let r = OCCTGeomConvertApproxSurface(handle, tolerance, uContinuity.rawValue,
                                               vContinuity.rawValue, Int32(maxDegree), Int32(maxSegments))

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -481,6 +481,14 @@ public final class Surface: @unchecked Sendable {
     /// infinite/unbounded surface must still be trimmed to a finite parameter domain before
     /// calling this (see `trimmed(u1:u2:v1:v2:)`) — approximation does not do that for you.
     ///
+    /// Returns the fitted surface whenever OCCT produced one, which — per `HasResult()` — includes
+    /// a best-effort fit that did *not* reach `tolerance`. A non-nil result is therefore not a
+    /// promise that `tolerance` was met; on a surface where `maxDegree` cannot reach it (a torus at
+    /// 1e-9, say) OCCT returns a usable surface anyway.
+    /// ``Surface/approxWithDetails(tolerance:uContinuity:vContinuity:maxDegree:maxSegments:)``
+    /// runs the identical approximation (one shared `GeomConvert_ApproxSurface` behind both since
+    /// #491) and reports the actual `maxError` plus an `isDone` flag.
+    ///
     /// ```swift
     /// let sphere = Surface.sphere(center: .zero, radius: 5)!
     /// let bsp = sphere.approximated(tolerance: 1e-3, maxDegree: 8)

--- a/Tests/OCCTCurveTests/Issue491Curve3DApproxParityTests.swift
+++ b/Tests/OCCTCurveTests/Issue491Curve3DApproxParityTests.swift
@@ -1,0 +1,227 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// `Curve3D` wraps `GeomConvert_ApproxCurve` twice: ``Curve3D/approximated(tolerance:continuity:maxSegments:maxDegree:)``
+/// returns the fitted BSpline, and ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)``
+/// returns the same fit alongside the diagnostics OCCT already computed for it. Both go through
+/// one shared bridge helper as of #491, so for identical inputs they must agree on whether the
+/// approximation succeeded and hand back the same curve — the second differing from the first
+/// only by carrying `maxError`/`isDone`/`hasResult`.
+///
+/// Before #491 the two bridge functions gated their result on different accessors:
+/// `OCCTCurve3DApproximate` on `IsDone()`, `OCCTGeomConvertApproxCurve` on `HasResult()`. The
+/// header documents those as different questions ("within required tolerance" vs "a result that
+/// is not NECESSARILY within the required tolerance"), so on paper the pair could disagree for a
+/// completed-but-over-tolerance fit.
+///
+/// Measured against the pinned kernel, they cannot: `GeomConvert_ApproxCurve` copies both flags
+/// straight off `AdvApprox_ApproxAFunction`, whose only `HasResult && !IsDone` path is the
+/// `ErrorCode = -1` assignment at `AdvApprox_ApproxAFunction.cxx:550` — commented out upstream
+/// ("// for now ErrorCode=-1;"). With that line dead, `ErrorCode` is only ever 0 (both flags set)
+/// or 1 (neither set), so the two accessors are equal for every input. The starved-fit cases
+/// below confirm it empirically: a circle fitted with one segment at degree 3 against a 1e-9
+/// tolerance reports `maxError` around 5.1 and still reports `isDone`.
+///
+/// So these tests pin a contract that the pre-#491 code happened to satisfy by accident. They are
+/// the guard for the day that upstream line is re-enabled, at which point the shared `HasResult()`
+/// gate keeps the pair together instead of splitting it.
+@Suite("Curve3D approximation parity: approximated vs approxWithDetails (#491)")
+struct Issue491Curve3DApproxParityTests {
+
+    /// One approximation request, run through both entry points.
+    private struct Request {
+        let label: String
+        let curve: Curve3D
+        let tolerance: Double
+        let continuity: ParametricContinuity
+        let maxSegments: Int
+        let maxDegree: Int
+    }
+
+    private func requests() -> [Request] {
+        var result: [Request] = []
+
+        if let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10) {
+            // The defaults both entry points declare.
+            result.append(Request(label: "circle r=10, shared defaults", curve: circle,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            // Starved: one segment at degree 3 cannot reach 1e-9 on a circle. This is the case
+            // the IsDone/HasResult split was supposed to separate.
+            result.append(Request(label: "circle r=10, 1 segment degree 3, tol 1e-9", curve: circle,
+                                  tolerance: 1e-9, continuity: .c0, maxSegments: 1, maxDegree: 3))
+            result.append(Request(label: "circle r=10, 2 segments degree 3, tol 1e-9", curve: circle,
+                                  tolerance: 1e-9, continuity: .c0, maxSegments: 2, maxDegree: 3))
+            // Unreachable tolerance with generous budget: fills the segment stack instead.
+            result.append(Request(label: "circle r=10, tol 1e-15", curve: circle,
+                                  tolerance: 1e-15, continuity: .c2, maxSegments: 100, maxDegree: 8))
+        }
+        if let ellipse = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                         majorRadius: 50, minorRadius: 1) {
+            result.append(Request(label: "ellipse 50x1, shared defaults", curve: ellipse,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            result.append(Request(label: "ellipse 50x1, 1 segment degree 3", curve: ellipse,
+                                  tolerance: 1e-9, continuity: .c0, maxSegments: 1, maxDegree: 3))
+            result.append(Request(label: "ellipse 50x1, degree 4 in 4 segments", curve: ellipse,
+                                  tolerance: 1e-12, continuity: .c2, maxSegments: 4, maxDegree: 4))
+        }
+        if let line = Curve3D.line(through: SIMD3(1, 2, 3), direction: SIMD3(1, 1, 0)),
+           let segment = line.trimmed(from: 0, to: 10) {
+            result.append(Request(label: "line segment", curve: segment,
+                                  tolerance: 1e-6, continuity: .c1, maxSegments: 10, maxDegree: 3))
+        }
+        return result
+    }
+
+    /// `maxSegments` and `maxDegree` are two adjacent `int32_t` both entry points forward to the one
+    /// shared helper. Unlike the surface pair they are declared in the same order on both sides, so
+    /// no re-ordering happens here — but a request whose two values are interchangeable could not
+    /// catch a swap either way, so this pins that they are order-sensitive and that both entry points
+    /// read them the same way.
+    ///
+    /// It deliberately does not assert `degree <= maxDegree`: OCCT does not treat `MaxDegree` as a
+    /// hard cap (`maxDegree: 4` on this ellipse comes back degree 5 — `lesparam` keeps "a reserve
+    /// coefficient"), and it does so identically through both entry points.
+    @Test("maxSegments and maxDegree are order-sensitive, and both entry points agree on the order")
+    func maxDegreeIsNotSwappedWithMaxSegments() {
+        guard let ellipse = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+                                            majorRadius: 50, minorRadius: 1) else {
+            Issue.record("ellipse fixture failed")
+            return
+        }
+        let asRequested = ellipse.approximated(tolerance: 1e-6, continuity: 2,
+                                               maxSegments: 40, maxDegree: 5)
+        let swapped = ellipse.approximated(tolerance: 1e-6, continuity: 2,
+                                           maxSegments: 5, maxDegree: 40)
+        #expect(asRequested != nil)
+        #expect(swapped != nil)
+        if let a = asRequested, let b = swapped {
+            #expect(a.degree != b.degree || a.poleCount != b.poleCount,
+                    "maxSegments/maxDegree are interchangeable on this input, so no test here can detect a swap: \(a.degree)/\(a.poleCount ?? -1) vs \(b.degree)/\(b.poleCount ?? -1)")
+        }
+
+        let detailed = ellipse.approxWithDetails(tolerance: 1e-6, continuity: .c2,
+                                                 maxSegments: 40, maxDegree: 5)
+        if let a = asRequested, let withDetails = detailed.curve {
+            #expect(a.degree == withDetails.degree)
+            #expect(a.poleCount == withDetails.poleCount)
+        } else {
+            Issue.record("one entry point returned no curve for maxSegments 40 / maxDegree 5")
+        }
+    }
+
+    private func sampled(_ curve: Curve3D, steps: Int = 12) -> [SIMD3<Double>] {
+        let domain = curve.domain
+        return (0...steps).map { i in
+            curve.point(at: domain.lowerBound
+                            + (domain.upperBound - domain.lowerBound) * Double(i) / Double(steps))
+        }
+    }
+
+    @Test("Both entry points succeed, or neither does, on the same request")
+    func successAgrees() {
+        let all = requests()
+        #expect(!all.isEmpty, "no request could be constructed — the fixtures themselves failed")
+
+        for request in all {
+            let plain = request.curve.approximated(tolerance: request.tolerance,
+                                                   continuity: Int(request.continuity.rawValue),
+                                                   maxSegments: request.maxSegments,
+                                                   maxDegree: request.maxDegree)
+            let detailed = request.curve.approxWithDetails(tolerance: request.tolerance,
+                                                           continuity: request.continuity,
+                                                           maxSegments: request.maxSegments,
+                                                           maxDegree: request.maxDegree)
+            #expect((plain != nil) == (detailed.curve != nil),
+                    "\(request.label): approximated \(plain == nil ? "nil" : "curve") but approxWithDetails \(detailed.curve == nil ? "nil" : "curve")")
+            #expect((plain != nil) == detailed.hasResult,
+                    "\(request.label): approximated \(plain == nil ? "nil" : "curve") but hasResult = \(detailed.hasResult)")
+        }
+    }
+
+    @Test("Both entry points return the same fitted curve")
+    func geometryMatches() {
+        for request in requests() {
+            let plain = request.curve.approximated(tolerance: request.tolerance,
+                                                   continuity: Int(request.continuity.rawValue),
+                                                   maxSegments: request.maxSegments,
+                                                   maxDegree: request.maxDegree)
+            let detailed = request.curve.approxWithDetails(tolerance: request.tolerance,
+                                                           continuity: request.continuity,
+                                                           maxSegments: request.maxSegments,
+                                                           maxDegree: request.maxDegree)
+            guard let plain = plain, let withDetails = detailed.curve else { continue }
+
+            #expect(plain.degree == withDetails.degree, "\(request.label): degree differs")
+            #expect(plain.poleCount == withDetails.poleCount, "\(request.label): pole count differs")
+
+            let a = sampled(plain)
+            let b = sampled(withDetails)
+            #expect(a.count == b.count)
+            if a.count == b.count {
+                var maxGap = 0.0
+                for (pa, pb) in zip(a, b) { maxGap = max(maxGap, simd_length(pa - pb)) }
+                #expect(maxGap < 1e-12, "\(request.label): sampled points differ by \(maxGap)")
+            }
+        }
+    }
+
+    @Test("maxError describes the curve both entry points return")
+    func maxErrorDescribesTheSharedFit() {
+        for request in requests() {
+            let detailed = request.curve.approxWithDetails(tolerance: request.tolerance,
+                                                           continuity: request.continuity,
+                                                           maxSegments: request.maxSegments,
+                                                           maxDegree: request.maxDegree)
+            guard let fit = detailed.curve else { continue }
+
+            // Sample deviation is a lower bound on the true maximum, so it must not exceed the
+            // reported maxError by more than the slack a coarse sampling allows.
+            let domain = request.curve.domain
+            var deviation = 0.0
+            for i in 0...40 {
+                let t = domain.lowerBound
+                    + (domain.upperBound - domain.lowerBound) * Double(i) / 40.0
+                deviation = max(deviation, simd_length(request.curve.point(at: t) - fit.point(at: t)))
+            }
+            #expect(deviation <= detailed.maxError + 1e-6,
+                    "\(request.label): sampled deviation \(deviation) exceeds reported maxError \(detailed.maxError)")
+        }
+    }
+
+    /// The completion flags come from one `GeomConvert_ApproxCurve` run, so a `hasResult` without
+    /// a curve (or the reverse) would mean the bridge dropped the fit on the floor.
+    @Test("hasResult and the returned curve agree")
+    func hasResultMatchesTheCurve() {
+        for request in requests() {
+            let detailed = request.curve.approxWithDetails(tolerance: request.tolerance,
+                                                           continuity: request.continuity,
+                                                           maxSegments: request.maxSegments,
+                                                           maxDegree: request.maxDegree)
+            #expect(detailed.hasResult == (detailed.curve != nil), "\(request.label)")
+            // isDone implies hasResult in either direction the kernel can report.
+            if detailed.isDone { #expect(detailed.hasResult, "\(request.label)") }
+        }
+    }
+
+    /// Documents the starved case that motivated the audit finding: OCCT reports the fit as done
+    /// even though its error is nine orders of magnitude past the requested tolerance, which is
+    /// why gating on `IsDone()` never actually rejected an over-tolerance curve.
+    @Test("An over-tolerance fit is still returned, with its real error reported")
+    func overToleranceFitIsReturnedNotDropped() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10) else {
+            Issue.record("circle fixture failed")
+            return
+        }
+        let detailed = circle.approxWithDetails(tolerance: 1e-9, continuity: .c0,
+                                                maxSegments: 1, maxDegree: 3)
+        #expect(detailed.hasResult)
+        #expect(detailed.curve != nil)
+        #expect(detailed.maxError > 1e-9, "a one-segment cubic cannot fit a circle to 1e-9")
+
+        #expect(circle.approximated(tolerance: 1e-9, continuity: 0,
+                                    maxSegments: 1, maxDegree: 3) != nil,
+                "approximated must return the same fit approxWithDetails reports")
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue491SurfaceApproxParityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue491SurfaceApproxParityTests.swift
@@ -1,0 +1,311 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// `Surface` wraps `GeomConvert_ApproxSurface` twice: ``Surface/approximated(tolerance:continuity:maxSegments:maxDegree:)``
+/// returns the fitted BSpline surface, and ``Surface/approxWithDetails(tolerance:uContinuity:vContinuity:maxDegree:maxSegments:)``
+/// returns the same fit alongside the diagnostics OCCT already computed for it. Both go through
+/// one shared bridge helper as of #491, so for identical inputs they must produce the same
+/// surface — the second differing from the first only by carrying `maxError`/`isDone`/`hasResult`.
+///
+/// Before #491 they produced *different* surfaces, for two independent reasons:
+///
+///  1. `OCCTSurfaceApproximate` passed `PrecisCode = 0` as `GeomConvert_ApproxSurface`'s eighth
+///     constructor argument; `OCCTGeomConvertApproxSurface` passed `1`. That argument is a real
+///     algorithm knob, not a reserved value: it reaches `AdvApp2Var_Context`'s `iprecis`, which
+///     `lesparam` (`AdvApp2Var_Context.cxx:22`) turns into the Jacobi degree and the initial
+///     per-axis sample-point count seeding the iterative fit. Measured over 72 bounded cases
+///     (8 surface families x 6 tolerances, plus C0/C1 and maxDegree 10 variants), the two codes
+///     never disagreed on `IsDone` and produced the same knot/pole layout in 71 of 72 — but a
+///     different `maxError` in all 72, and in the one layout-differing case (an offset sphere at
+///     tolerance 1e-5) `0` met the tolerance with 27x15 poles where `1` used 27x23.
+///  2. The two Swift entry points defaulted to different continuity: `.approximated` to C2,
+///     `.approxWithDetails` to C1 in both directions. So the no-continuity-argument calls fitted
+///     to different smoothness requirements.
+///
+/// Neither divergence had any test coverage in either direction before this suite.
+@Suite("Surface approximation parity: approximated vs approxWithDetails (#491)")
+struct Issue491SurfaceApproxParityTests {
+
+    /// One approximation request, run through both entry points.
+    private struct Request {
+        let label: String
+        let surface: Surface
+        let tolerance: Double
+        let continuity: ParametricContinuity
+        let maxSegments: Int
+        let maxDegree: Int
+    }
+
+    /// Bounded in both parameters, so the fit can be sampled over its own domain. An infinite
+    /// surface has to be trimmed before approximation anyway (both entry points document that).
+    private func requests() -> [Request] {
+        var result: [Request] = []
+
+        if let sphere = Surface.sphere(center: .zero, radius: 10) {
+            result.append(Request(label: "sphere r=10, shared defaults", surface: sphere,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            result.append(Request(label: "sphere r=10, tol 1e-5", surface: sphere,
+                                  tolerance: 1e-5, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            // Past what maxDegree 8 can reach: IsDone false, HasResult true.
+            result.append(Request(label: "sphere r=10, tol 1e-9", surface: sphere,
+                                  tolerance: 1e-9, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            result.append(Request(label: "sphere r=10, C0", surface: sphere,
+                                  tolerance: 1e-3, continuity: .c0, maxSegments: 100, maxDegree: 8))
+            result.append(Request(label: "sphere r=10, C1", surface: sphere,
+                                  tolerance: 1e-3, continuity: .c1, maxSegments: 100, maxDegree: 8))
+            // The offset of a primitive is the case where PrecisCode 0 and 1 chose different
+            // knot layouts, so it is the sharpest check that both now run the same fit.
+            if let offsetSphere = sphere.offset(distance: 1.5) {
+                result.append(Request(label: "offset sphere +1.5, tol 1e-5", surface: offsetSphere,
+                                      tolerance: 1e-5, continuity: .c2,
+                                      maxSegments: 100, maxDegree: 8))
+                result.append(Request(label: "offset sphere +1.5, shared defaults",
+                                      surface: offsetSphere, tolerance: 1e-3, continuity: .c2,
+                                      maxSegments: 100, maxDegree: 8))
+            }
+        }
+        if let torus = Surface.torus(origin: .zero, axis: SIMD3(0, 0, 1),
+                                     majorRadius: 20, minorRadius: 5) {
+            result.append(Request(label: "torus 20/5, shared defaults", surface: torus,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            result.append(Request(label: "torus 20/5, tol 1e-9", surface: torus,
+                                  tolerance: 1e-9, continuity: .c2, maxSegments: 100, maxDegree: 8))
+        }
+        if let cylinder = Surface.trimmedCylinder(origin: .zero, direction: SIMD3(0, 0, 1),
+                                                  radius: 5, height: 20) {
+            result.append(Request(label: "trimmed cylinder r=5", surface: cylinder,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 100, maxDegree: 8))
+        }
+        if let cone = Surface.trimmedCone(point1: SIMD3(0, 0, 0), point2: SIMD3(0, 0, 12),
+                                          r1: 5, r2: 2) {
+            result.append(Request(label: "trimmed cone", surface: cone,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 100, maxDegree: 8))
+            // maxSegments and maxDegree far apart and not interchangeable. The two entry points
+            // declare them in opposite orders (`maxSegments:maxDegree:` on .approximated,
+            // `maxDegree:maxSegments:` on .approxWithDetails) and the bridge has to re-order them
+            // for the shared helper, so a request where the two values are equal — as every other
+            // one here is — would not notice a swap.
+            result.append(Request(label: "trimmed cone, degree 4 in 20 segments", surface: cone,
+                                  tolerance: 1e-3, continuity: .c2, maxSegments: 20, maxDegree: 4))
+        }
+        return result
+    }
+
+    private func sampled(_ surface: Surface, steps: Int = 6) -> [SIMD3<Double>] {
+        let d = surface.domain
+        var result: [SIMD3<Double>] = []
+        for i in 0...steps {
+            for j in 0...steps {
+                let u = d.uMin + (d.uMax - d.uMin) * Double(i) / Double(steps)
+                let v = d.vMin + (d.vMax - d.vMin) * Double(j) / Double(steps)
+                result.append(surface.point(atU: u, v: v))
+            }
+        }
+        return result
+    }
+
+    @Test("Both entry points succeed, or neither does, on the same request")
+    func successAgrees() {
+        let all = requests()
+        #expect(!all.isEmpty, "no request could be constructed — the fixtures themselves failed")
+
+        for request in all {
+            let plain = request.surface.approximated(tolerance: request.tolerance,
+                                                     continuity: Int(request.continuity.rawValue),
+                                                     maxSegments: request.maxSegments,
+                                                     maxDegree: request.maxDegree)
+            let detailed = request.surface.approxWithDetails(tolerance: request.tolerance,
+                                                            uContinuity: request.continuity,
+                                                            vContinuity: request.continuity,
+                                                            maxDegree: request.maxDegree,
+                                                            maxSegments: request.maxSegments)
+            #expect((plain != nil) == (detailed.surface != nil),
+                    "\(request.label): approximated \(plain == nil ? "nil" : "surface") but approxWithDetails \(detailed.surface == nil ? "nil" : "surface")")
+            #expect((plain != nil) == detailed.hasResult,
+                    "\(request.label): approximated \(plain == nil ? "nil" : "surface") but hasResult = \(detailed.hasResult)")
+        }
+    }
+
+    /// The PrecisCode drift: same tolerance, continuity, degree and segment budget through both
+    /// entry points had to give the same BSpline, and did not.
+    @Test("Both entry points return the same fitted surface")
+    func geometryMatches() {
+        for request in requests() {
+            let plain = request.surface.approximated(tolerance: request.tolerance,
+                                                     continuity: Int(request.continuity.rawValue),
+                                                     maxSegments: request.maxSegments,
+                                                     maxDegree: request.maxDegree)
+            let detailed = request.surface.approxWithDetails(tolerance: request.tolerance,
+                                                            uContinuity: request.continuity,
+                                                            vContinuity: request.continuity,
+                                                            maxDegree: request.maxDegree,
+                                                            maxSegments: request.maxSegments)
+            guard let plain = plain, let withDetails = detailed.surface else { continue }
+
+            #expect(plain.uDegree == withDetails.uDegree, "\(request.label): uDegree differs")
+            #expect(plain.vDegree == withDetails.vDegree, "\(request.label): vDegree differs")
+            #expect(plain.uPoleCount == withDetails.uPoleCount,
+                    "\(request.label): uPoleCount \(plain.uPoleCount) vs \(withDetails.uPoleCount)")
+            #expect(plain.vPoleCount == withDetails.vPoleCount,
+                    "\(request.label): vPoleCount \(plain.vPoleCount) vs \(withDetails.vPoleCount)")
+
+            let a = sampled(plain)
+            let b = sampled(withDetails)
+            #expect(a.count == b.count)
+            if a.count == b.count {
+                var maxGap = 0.0
+                for (pa, pb) in zip(a, b) { maxGap = max(maxGap, simd_length(pa - pb)) }
+                #expect(maxGap < 1e-12, "\(request.label): sampled points differ by \(maxGap)")
+            }
+        }
+    }
+
+    /// The default-continuity drift: `.approximated` defaulted to C2 and `.approxWithDetails` to
+    /// C1, so the two no-continuity-argument calls fitted to different smoothness.
+    @Test("The two entry points share their default continuity")
+    func defaultContinuityMatches() {
+        guard let sphere = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture failed")
+            return
+        }
+        let plain = sphere.approximated(tolerance: 1e-3)
+        let detailed = sphere.approxWithDetails(tolerance: 1e-3)
+        #expect(plain != nil)
+        #expect(detailed.surface != nil)
+        guard let plain = plain, let withDetails = detailed.surface else { return }
+
+        #expect(plain.uDegree == withDetails.uDegree)
+        #expect(plain.vDegree == withDetails.vDegree)
+        #expect(plain.uPoleCount == withDetails.uPoleCount,
+                "default-continuity call: uPoleCount \(plain.uPoleCount) vs \(withDetails.uPoleCount)")
+        #expect(plain.vPoleCount == withDetails.vPoleCount,
+                "default-continuity call: vPoleCount \(plain.vPoleCount) vs \(withDetails.vPoleCount)")
+
+        // And the explicit C2 call — the shared default — must reproduce it exactly.
+        let explicit = sphere.approxWithDetails(tolerance: 1e-3, uContinuity: .c2, vContinuity: .c2)
+        if let explicitSurface = explicit.surface {
+            #expect(explicitSurface.uPoleCount == withDetails.uPoleCount)
+            #expect(explicitSurface.vPoleCount == withDetails.vPoleCount)
+            #expect(abs(explicit.maxError - detailed.maxError) < 1e-15)
+        }
+    }
+
+    /// `.c0` requests are excluded: `GeomConvert_ApproxSurface` at `GeomAbs_C0` can collapse a
+    /// direction to degree 1 and still report a `maxError` five orders of magnitude below the
+    /// surface it returns (a full sphere at C0 comes back as a straight line across its own
+    /// longitude, deviating by 19.9999, reported as 1.07e-4 with `isDone` true). That is an
+    /// upstream defect, tracked as #522 — it predates #491, both entry points hit it identically,
+    /// and unifying them neither causes nor fixes it. C0 stays in the *parity* requests above,
+    /// because both entry points must still return the same surface for the same request; only
+    /// this "the reported error describes the returned surface" property fails there. Drop the
+    /// exclusion when #522 is fixed.
+    @Test("maxError describes the surface both entry points return")
+    func maxErrorDescribesTheSharedFit() {
+        for request in requests() where request.continuity != .c0 {
+            let detailed = request.surface.approxWithDetails(tolerance: request.tolerance,
+                                                            uContinuity: request.continuity,
+                                                            vContinuity: request.continuity,
+                                                            maxDegree: request.maxDegree,
+                                                            maxSegments: request.maxSegments)
+            guard let fit = detailed.surface else { continue }
+
+            // Sample deviation is a lower bound on the true maximum, so it must not exceed the
+            // reported maxError by more than the slack a coarse sampling allows.
+            let d = request.surface.domain
+            var deviation = 0.0
+            for i in 0...10 {
+                for j in 0...10 {
+                    let u = d.uMin + (d.uMax - d.uMin) * Double(i) / 10.0
+                    let v = d.vMin + (d.vMax - d.vMin) * Double(j) / 10.0
+                    deviation = max(deviation,
+                                    simd_length(request.surface.point(atU: u, v: v)
+                                                - fit.point(atU: u, v: v)))
+                }
+            }
+            #expect(deviation <= detailed.maxError + 1e-6,
+                    "\(request.label): sampled deviation \(deviation) exceeds reported maxError \(detailed.maxError)")
+        }
+    }
+
+    /// Both surface entry points have always gated on `HasResult()`, which OCCT documents as true
+    /// even for a fit that is not within the requested tolerance. That leniency is the contract,
+    /// and it is why `approxWithDetails` exists: `isDone` is how a caller finds out.
+    @Test("An over-tolerance fit is returned by both, with isDone false")
+    func overToleranceFitIsReturnedNotDropped() {
+        guard let torus = Surface.torus(origin: .zero, axis: SIMD3(0, 0, 1),
+                                        majorRadius: 20, minorRadius: 5) else {
+            Issue.record("torus fixture failed")
+            return
+        }
+        let detailed = torus.approxWithDetails(tolerance: 1e-9, uContinuity: .c2, vContinuity: .c2,
+                                               maxDegree: 8, maxSegments: 100)
+        #expect(detailed.hasResult)
+        #expect(!detailed.isDone, "maxDegree 8 cannot fit a torus to 1e-9")
+        #expect(detailed.maxError > 1e-9)
+        #expect(detailed.surface != nil)
+
+        #expect(torus.approximated(tolerance: 1e-9, continuity: 2,
+                                   maxSegments: 100, maxDegree: 8) != nil,
+                "approximated must return the same fit approxWithDetails reports")
+    }
+
+    /// `maxDegree` and `maxSegments` are two adjacent `int32_t` the bridge has to **re-order**: the
+    /// two entry points declare them in opposite orders (`maxSegments:maxDegree:` on `.approximated`,
+    /// `maxDegree:maxSegments:` on `.approxWithDetails`) and the shared helper takes one order. A
+    /// silent swap in either path is the obvious way for this refactor to go wrong.
+    ///
+    /// `geometryMatches` above covers it for the `degree 4 in 20 segments` request, but only if the
+    /// two values are actually distinguishable — swapping interchangeable arguments proves nothing.
+    /// So this asserts the pair is order-sensitive first, then that both entry points landed on the
+    /// same side of it.
+    ///
+    /// It deliberately does not assert `uDegree <= maxDegree`: OCCT does not treat `MaxDegU`/`MaxDegV`
+    /// as a hard cap. Measured on this cone, `maxDegree: 4` comes back degree 5 (`lesparam` keeps
+    /// "a reserve coefficient"), through both entry points alike.
+    @Test("maxDegree and maxSegments are order-sensitive, and both entry points agree on the order")
+    func maxDegreeIsNotSwappedWithMaxSegments() {
+        guard let cone = Surface.trimmedCone(point1: SIMD3(0, 0, 0), point2: SIMD3(0, 0, 12),
+                                             r1: 5, r2: 2) else {
+            Issue.record("cone fixture failed")
+            return
+        }
+        // Exchanging the two must change the result — otherwise the parity check below is vacuous.
+        let asRequested = cone.approximated(tolerance: 1e-3, continuity: 2,
+                                            maxSegments: 20, maxDegree: 4)
+        let swapped = cone.approximated(tolerance: 1e-3, continuity: 2,
+                                        maxSegments: 4, maxDegree: 20)
+        #expect(asRequested != nil)
+        #expect(swapped != nil)
+        if let a = asRequested, let b = swapped {
+            #expect(a.uDegree != b.uDegree || a.uPoleCount != b.uPoleCount,
+                    "maxSegments/maxDegree are interchangeable on this input, so no test here can detect a swap: \(a.uDegree)/\(a.uPoleCount) vs \(b.uDegree)/\(b.uPoleCount)")
+        }
+
+        // Both entry points must land on the unswapped reading.
+        let detailed = cone.approxWithDetails(tolerance: 1e-3, uContinuity: .c2, vContinuity: .c2,
+                                              maxDegree: 4, maxSegments: 20)
+        if let a = asRequested, let withDetails = detailed.surface {
+            #expect(a.uDegree == withDetails.uDegree)
+            #expect(a.vDegree == withDetails.vDegree)
+            #expect(a.uPoleCount == withDetails.uPoleCount)
+            #expect(a.vPoleCount == withDetails.vPoleCount)
+        } else {
+            Issue.record("one entry point returned no surface for maxDegree 4 / maxSegments 20")
+        }
+    }
+
+    @Test("hasResult and the returned surface agree")
+    func hasResultMatchesTheSurface() {
+        for request in requests() {
+            let detailed = request.surface.approxWithDetails(tolerance: request.tolerance,
+                                                            uContinuity: request.continuity,
+                                                            vContinuity: request.continuity,
+                                                            maxDegree: request.maxDegree,
+                                                            maxSegments: request.maxSegments)
+            #expect(detailed.hasResult == (detailed.surface != nil), "\(request.label)")
+            if detailed.isDone { #expect(detailed.hasResult, "\(request.label)") }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -201,6 +201,73 @@ down-casts its inputs to `Geom_BezierCurve` and returns `nullptr` for anything e
 `nil` back and skipped its entire body through `if let` without ever calling `translate`. It now uses
 real Bezier boundaries and asserts the surface actually moved.
 
+#### One `GeomConvert_Approx*` run per type, not two that disagree (#491)
+
+`Curve3D` and `Surface` each wrapped the same OCCT approximation class twice — `approximated`
+returning the fitted BSpline, `approxWithDetails` returning it plus OCCT's own diagnostics — and each
+pair had drifted. Both now run through one shared bridge helper per type, so the detailed entry point
+differs from the plain one only by carrying `maxError`/`isDone`/`hasResult`.
+
+Three divergences resolved, plus one that turned out to be paper-only:
+
+- **`Surface`: `PrecisCode` 0 vs 1.** `OCCTSurfaceApproximate` passed `0` as
+  `GeomConvert_ApproxSurface`'s eighth constructor argument and `OCCTGeomConvertApproxSurface` passed
+  `1`, with no comment either side. It is a real algorithm knob, not a reserved value: it reaches
+  `AdvApp2Var_Context`'s `iprecis`, where `lesparam` turns it into the Jacobi degree and the initial
+  per-axis sample count that seed the fit. Both now pass `0`. Chosen on measurement over 72 bounded
+  cases (8 surface families x 6 tolerances, plus C0/C1 and `maxDegree` 10 variants): the two codes
+  never disagreed on `IsDone` and produced the same knot/pole layout in 71 of 72, but a different
+  `maxError` in all 72 — smaller with `0` in 64 of them — and in the one layout-differing case (an
+  offset sphere at tolerance `1e-5`) `0` met the requested tolerance with 27x15 poles where `1`
+  needed 27x23. A caller who states a tolerance wants the lightest surface that meets it. OCCT itself
+  splits along that same line: its tolerance-honouring conversion loops pass `0`
+  (`ShapeCustom_BSplineRestriction`, `ShapeConstruct`, `BRepFill_Sweep`), its fixed-internal-tolerance
+  conversions pass `1` (`GeomConvert_1`, `GeomLib`, `GeomFill_Sweep`, `ShapeUpgrade_UnifySameDomain`).
+- **`Surface`: default continuity C2 vs C1.** `Surface.approxWithDetails` defaulted `uContinuity` and
+  `vContinuity` to `.c1` while `Surface.approximated` defaulted to C2, so the two
+  no-continuity-argument calls fitted to different smoothness and returned different surfaces (15 vs
+  16 U poles on a sphere at `1e-3`). Both now default to C2.
+- **Both: the null-handle guard.** `OCCTGeomConvertApproxCurve`/`Surface` checked only the outer
+  wrapper pointer, while their plain counterparts also checked the OCCT handle inside it. A null
+  `Geom_Curve`/`Geom_Surface` reaching `GeomAdaptor_*` is an uncatchable SIGSEGV in this Release
+  kernel, where OCCT's own `Standard_NullObject` precondition is compiled out. Both now check both.
+- **`Curve3D`: `IsDone()` vs `HasResult()` — the audit's headline claim, and it does not reproduce.**
+  The header documents these as different questions, so `OCCTCurve3DApproximate`'s `IsDone()` gate
+  looked like it would reject a completed-but-over-tolerance fit that `OCCTGeomConvertApproxCurve`'s
+  `HasResult()` gate returns. It cannot: `GeomConvert_ApproxCurve` copies both flags off
+  `AdvApprox_ApproxAFunction`, whose only `HasResult`-without-`IsDone` path is an `ErrorCode = -1`
+  assignment upstream has commented out (`AdvApprox_ApproxAFunction.cxx:550`, `// for now
+  ErrorCode=-1;`). With that line dead the two accessors are equal for every input, which is why
+  gating on `IsDone()` never actually rejected anything — a circle fitted with one segment at degree
+  3 against a `1e-9` tolerance reports `maxError` 5.1 and `isDone` true. The gate is unified on
+  `HasResult()` anyway: it is what OCCT's own curve-conversion sites use (`GeomConvert.cxx`,
+  `GeomToIGES_GeomCurve.cxx`, `GeomFill_Profiler.cxx`), what both surface entry points already used,
+  and the only gate under which `approxWithDetails`' `isDone: false` diagnostic means anything.
+
+So `Curve3D.approximated` is unchanged in behaviour and `Surface.approximated` is unchanged in
+output; what changes observably is `Surface.approxWithDetails`, which now returns the same surface
+`Surface.approximated` does instead of a slightly different one. Neither divergence had any test
+coverage in either direction — no test anywhere called both entry points on the same input. New
+`Issue491Curve3DApproxParityTests` (`Tests/OCCTCurveTests`) and `Issue491SurfaceApproxParityTests`
+(`Tests/OCCTSurfaceTests`) assert success, geometry, pole/degree counts and reported `maxError` agree
+across both entry points on 9 curve and 12 surface requests spanning the starved, over-tolerance and
+unreachable-tolerance cases.
+
+Each `.mm` also had two copies of the request-side `int32_t` → `GeomAbs_Shape` mapping (a `static
+intToContinuity` for the detailed entry point, the identical `switch` spelled inline in the plain
+one); each file now has one. The wider census of that conversion across the bridge is #513's, not
+this issue's.
+
+Building the parity tests surfaced an unrelated upstream defect, filed as
+[#522](https://github.com/SecondMouseAU/OCCTSwift/issues/522): `GeomConvert_ApproxSurface` asked for
+`GeomAbs_C0` can collapse a direction to degree 1 and return a surface deviating by the input's own
+diameter while reporting `IsDone()` and a `maxError` five orders of magnitude too small (a full
+sphere at C0 comes back as a straight line across its longitude). It predates #491, both entry points
+hit it identically, and unifying them neither causes nor fixes it. The surface parity suite keeps C0
+in its request set — both entry points must still return the *same* surface there, and they do — but
+excludes it from the "reported error describes the returned surface" assertion, with a comment to
+drop that exclusion when #522 is fixed.
+
 ---
 
 ## Release History

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -841,19 +841,63 @@ public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
                          maxSegments: Int = 100, maxDegree: Int = 8) -> Curve3D?
 ```
 
-Useful for converting an analytical curve to a polynomial BSpline with controlled accuracy. `continuity` maps to `GeomAbs_Shape`: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2.
+Useful for converting an analytical curve to a polynomial BSpline with controlled accuracy.
+`continuity` is a **request order** counting `0=C0, 1=C1, 2=C2, 3=C3` — not a raw `GeomAbs_Shape`
+ordinal (that enum interleaves the geometric classes: `C0=0, G1=1, C1=2, G2=3, C2=4`). Values
+outside `0...3` fall back to C2.
 
 - **Parameters:** `tolerance` — approximation error; `continuity` — minimum continuity order; `maxSegments` — maximum number of BSpline spans; `maxDegree` — maximum polynomial degree.
-- **Returns:** Approximating BSpline, or `nil` on failure.
-- **OCCT:** `GeomConvert_ApproxCurve(curve, tolerance, continuity, maxSegments, maxDegree)`.
+- **Returns:** Approximating BSpline, or `nil` when OCCT produced no fit at all.
+- **OCCT:** `GeomConvert_ApproxCurve(curve, tolerance, continuity, maxSegments, maxDegree)`, gated on `HasResult()`.
 - **Note:** Defaults are shared with `Curve2D.approximated` and `Surface.approximated` (#406) —
   all three wrap the same `GeomConvert_Approx*`/`Geom2dConvert_ApproxCurve` family applied to a
   different OCCT geometry hierarchy, not independent algorithms that would justify
   independently-tuned numeric defaults.
+- **Note:** A non-`nil` result is **not** a promise that `tolerance` was met. This gates on OCCT's
+  `HasResult()`, which is documented as true for a fit that is "not NECESSARILY within the required
+  tolerance" — the same accessor
+  [`approxWithDetails`](#approxwithdetailstolerancecontinuitymaxsegmentsmaxdegree) uses, since #491
+  put one shared implementation behind both. Use `approxWithDetails` when you need the actual
+  `maxError`. (Gating on `IsDone()` instead, as this used to, would not have helped: measured
+  against this kernel it never rejects an over-tolerance fit — a circle fitted with one segment at
+  degree 3 against a `1e-9` tolerance reports `maxError` 5.1 and `isDone` true.)
 - **Example:**
   ```swift
   let circle = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)!
   let approx = circle.approximated(tolerance: 0.01, continuity: 2)
+  ```
+
+---
+
+### `approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)`
+
+The same approximation as [`approximated`](#approximatedtolerancecontinuitymaxsegmentsmaxdegree),
+reporting the fit's error and completion status.
+
+```swift
+public func approxWithDetails(tolerance: Double, continuity: ParametricContinuity = .c2,
+                              maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult
+```
+
+One shared `GeomConvert_ApproxCurve` run backs both entry points (#491), so for identical arguments
+they return the same curve — this one just also carries the diagnostics OCCT already computed.
+
+- **Returns:** `ApproxCurveResult(curve:maxError:isDone:hasResult:)`. `curve` is populated exactly
+  when `hasResult`; `isDone` is whether the fit reached `tolerance`; `maxError` is the greatest
+  distance between the source curve and the fit.
+- **OCCT:** `GeomConvert_ApproxCurve` — `Curve()`, `MaxError()`, `IsDone()`, `HasResult()`.
+- **Note:** `isDone` and `hasResult` are always equal in the pinned kernel. `GeomConvert_ApproxCurve`
+  copies both off `AdvApprox_ApproxAFunction`, whose only `HasResult`-without-`IsDone` path is an
+  `ErrorCode = -1` assignment that upstream has commented out
+  (`AdvApprox_ApproxAFunction.cxx:550`). Read `maxError` against your own tolerance rather than
+  trusting `isDone` to mean "within tolerance".
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10)!
+  let fit = circle.approxWithDetails(tolerance: 1e-6)
+  if let bspline = fit.curve, fit.maxError <= 1e-6 {
+      print("fitted with \(bspline.poleCount ?? 0) poles")
+  }
   ```
 
 ---

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -724,21 +724,65 @@ Useful when exact `toBSpline()` conversion is unavailable (e.g. offset or compos
 
 - **Parameters:**
   - `tolerance` — maximum approximation deviation.
-  - `continuity` — desired continuity order (0=C0, 1=C1, 2=C2).
+  - `continuity` — desired continuity order, applied to **both** parametric directions
+    (`0=C0, 1=C1, 2=C2, 3=C3`; a request order, not a raw `GeomAbs_Shape` ordinal). Values outside
+    `0...3` fall back to C2.
   - `maxSegments` — maximum number of BSpline segments.
   - `maxDegree` — maximum polynomial degree.
-- **Returns:** Approximated BSpline surface, or `nil` on failure.
-- **OCCT:** `GeomConvert_ApproxSurface`.
+- **Returns:** Approximated BSpline surface, or `nil` when OCCT produced no fit at all.
+- **OCCT:** `GeomConvert_ApproxSurface`, gated on `HasResult()`, with `PrecisCode = 0`.
 - **Note:** Defaults match `Curve3D.approximated`/`Curve2D.approximated` (#406) — all three wrap
   the same `GeomConvert_Approx*`/`Geom2dConvert_ApproxCurve` family applied to a different OCCT
   geometry hierarchy, not independent algorithms whose numeric defaults should diverge. (Before
   #406 this defaulted to `tolerance: 0.01, maxDegree: 10`, a 10x looser tolerance with no
   documented reason; measurement found the tighter shared values succeed on every case tried,
   with no meaningful cost difference.)
+- **Note:** A non-`nil` result is **not** a promise that `tolerance` was met. This gates on OCCT's
+  `HasResult()`, documented as true for a fit that is "not NECESSARILY within the required
+  tolerance" — on a surface `maxDegree` cannot fit (a torus at `1e-9`) OCCT returns a usable best
+  effort anyway. [`approxWithDetails`](#approxwithdetailstoleranceucontinuityvcontinuitymaxdegreemaxsegments)
+  runs the identical approximation and reports the actual `maxError`.
 - **Example:**
   ```swift
   let offset = sphere.offset(distance: 1)!
   let bsp = offset.approximated(tolerance: 0.001)
+  ```
+
+---
+
+### `approxWithDetails(tolerance:uContinuity:vContinuity:maxDegree:maxSegments:)`
+
+The same approximation as [`approximated`](#approximatedtolerancecontinuitymaxsegmentsmaxdegree),
+reporting the fit's error and completion status, with the two parametric directions requested
+separately.
+
+```swift
+public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c2,
+                              vContinuity: ParametricContinuity = .c2,
+                              maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult
+```
+
+One shared `GeomConvert_ApproxSurface` run backs both entry points (#491), so for identical
+arguments they return the same surface — this one just also carries the diagnostics OCCT already
+computed. Note `maxDegree` precedes `maxSegments` here, the reverse of `approximated`'s order.
+
+- **Returns:** `ApproxSurfaceResult(surface:maxError:isDone:hasResult:)`. `surface` is populated
+  exactly when `hasResult`; `isDone` is whether the fit reached `tolerance`; `maxError` is the
+  greatest distance between the source surface and the fit.
+- **OCCT:** `GeomConvert_ApproxSurface` — `Surface()`, `MaxError()`, `IsDone()`, `HasResult()`.
+- **Note:** Before #491 the continuity defaults here were C1, and this entry point passed
+  `PrecisCode = 1` to `GeomConvert_ApproxSurface` where `approximated` passed `0`, so the two
+  returned measurably different surfaces for the same request. Both now default to C2 and pass `0`.
+- **Note:** `maxError` is not trustworthy for a `.c0` request — see
+  [#522](https://github.com/SecondMouseAU/OCCTSwift/issues/522), an upstream defect where a C0 fit
+  can collapse a direction to degree 1 and still report an error five orders of magnitude too small.
+- **Example:**
+  ```swift
+  let sphere = Surface.sphere(center: .zero, radius: 10)!
+  let fit = sphere.approxWithDetails(tolerance: 1e-5)
+  if let bspline = fit.surface, fit.isDone {
+      print("fitted to \(fit.maxError) with \(bspline.uPoleCount)x\(bspline.vPoleCount) poles")
+  }
   ```
 
 ---


### PR DESCRIPTION
Closes #491. Targets `refactor/381-pass1b` per #377's ordering rule.

`Curve3D` and `Surface` each wrapped the same OCCT approximation class twice — `approximated`
returning the fitted BSpline, `approxWithDetails` returning it plus OCCT's own diagnostics — and each
pair had drifted. Both now run through one shared bridge helper per type, so the detailed entry point
differs from the plain one only by carrying `maxError`/`isDone`/`hasResult`.

## What changed, and why each way

**`Surface`: `PrecisCode` 0 vs 1** — the real divergence. `OCCTSurfaceApproximate` passed `0` as
`GeomConvert_ApproxSurface`'s eighth constructor argument and `OCCTGeomConvertApproxSurface` passed
`1`, neither with a comment. It is a genuine algorithm knob, not a reserved value: it reaches
`AdvApp2Var_Context`'s `iprecis`, where `lesparam` turns it into the Jacobi degree and the initial
per-axis sample count that seed the iterative fit.

**Both now pass `0`**, decided on measurement rather than on which wrapper was "first"
([the sweep is committed](../tree/fix/491-approx-dedup/Scripts/repro/491-approx-wrapper-drift), 72
bounded cases — 8 surface families x 6 tolerances, plus C0/C1 and `maxDegree` 10 variants):

```
result shape (poles/knots/degree) differs : 1
IsDone differs between the two codes      : 0
smaller maxError with PrecisCode=0        : 64
smaller maxError with PrecisCode=1        : 8
```

The single layout difference is an offset sphere at tolerance `1e-5`, where both met the tolerance but
`0` did it with 27x15 poles against `1`'s 27x23. A caller who states a tolerance wants the lightest
surface that meets it, and `0` was never worse on that criterion. OCCT itself is split on the value
and splits along the same line: its tolerance-honouring conversion loops pass `0`
(`ShapeCustom_BSplineRestriction`, `ShapeConstruct`, `BRepFill_Sweep`), its
fixed-internal-tolerance conversions pass `1` (`GeomConvert_1`, `GeomLib`, `GeomFill_Sweep`,
`ShapeUpgrade_UnifySameDomain`). This bridge is in the first group.

**`Surface`: default continuity** — `approxWithDetails` defaulted both directions to `.c1` while
`approximated` defaulted to C2, so the two no-continuity-argument calls fitted to different smoothness
and returned different surfaces (15 vs 16 U poles on a sphere at `1e-3`). Both now default to C2.
Without this the issue's stated goal is not met, so it is in scope even though #491 does not name it.

**Both: the null-handle guard** — the detailed entry points checked only the outer wrapper pointer
while their plain counterparts also checked the OCCT handle inside it. A null
`Geom_Curve`/`Geom_Surface` reaching `GeomAdaptor_*` is an uncatchable SIGSEGV in this Release kernel,
where OCCT's own `Standard_NullObject` precondition is compiled out (#487's finding). Latent, not
observed — no current call site can produce it.

## The issue's headline claim does not reproduce

#491 leads on `Curve3D`'s `IsDone()`-vs-`HasResult()` gate producing "divergence in observable
behavior: one returns `nil`, the other returns a usable BSpline plus diagnostics". **It cannot, in
this kernel.** `GeomConvert_ApproxCurve` copies both flags straight off `AdvApprox_ApproxAFunction`,
which sets them together, and the only `HasResult`-without-`IsDone` path is an assignment upstream has
commented out:

```c++
// AdvApprox_ApproxAFunction.cxx:550, the "stack is full" branch
// for now               ErrorCode=-1;
```

With that line dead `ErrorCode` is only ever `0` (both flags set) or `1` (neither), so the two
accessors are equal for every input — which is why gating on `IsDone()` never actually rejected an
over-tolerance fit. Measured: a circle fitted with one segment at degree 3 against a `1e-9` tolerance
reports `maxError` **5.1** and `isDone` **true**. The claim came from the header's doc comments, which
do describe two different questions; the implementation does not honour that distinction.

The gate is unified on `HasResult()` anyway — it is what OCCT's own curve-conversion sites use
(`GeomConvert.cxx:345/441`, `GeomToIGES_GeomCurve.cxx:632`, `GeomFill_Profiler.cxx:136`), what both
surface entry points already used, what `Curve2D.approximated` already used, and the only gate under
which `approxWithDetails`' `isDone: false` diagnostic means anything. All five wrappers of the
`*Convert_Approx*` family now gate the same way.

## Net observable effect

`Curve3D.approximated` is unchanged in behaviour and `Surface.approximated` is unchanged in output.
What changes observably is `Surface.approxWithDetails`, which now returns the same surface
`Surface.approximated` does instead of a slightly different one, and defaults to C2 rather than C1.

## Tests

No test anywhere called both entry points on the same input — the drift was uncovered in both
directions. New `Issue491Curve3DApproxParityTests` and `Issue491SurfaceApproxParityTests` assert
success, geometry, pole/degree counts and reported `maxError` agree across both entry points on 9 curve
and 12 surface requests, spanning the starved, over-tolerance and unreachable-tolerance cases.

Run against the unmodified bridge first: the curve suite passed (confirming the claim above) and the
surface suite failed on 14 assertions. Both green after.

The suites also pin `maxDegree`/`maxSegments` order-sensitivity, because the two entry points declare
those two adjacent `int32_t` in **opposite** orders and the bridge has to re-order them for the shared
helper — the obvious way for this refactor to break silently. Verified by injecting the swap: 4 tests
across 3 suites fail loudly. (That test does *not* assert `degree <= maxDegree`; OCCT does not treat
it as a hard cap — `maxDegree: 4` comes back degree 5, identically through both entry points.)

## Sibling finding filed: #522

Building the surface parity suite surfaced an unrelated upstream defect, filed as #522 with its own
reproducers in `Scripts/repro/522-approx-c0-collapse/`: `GeomConvert_ApproxSurface` asked for
`GeomAbs_C0` can collapse a direction to degree 1 and return a surface deviating by the input's own
diameter while reporting `IsDone()` and a `maxError` five orders of magnitude too small — a full sphere
at C0 comes back as a straight line across its longitude, real deviation 19.9999, reported 1.07e-4.
12 of 98 swept requests misreport, all of them requesting C0 in at least one direction. It predates
this PR, both entry points hit it identically, and unifying them neither causes nor fixes it. The
parity suite keeps C0 in its request set (both entry points must still return the *same* surface
there, and they do) but excludes it from the "reported error describes the returned surface"
assertion, with a comment to drop that when #522 is fixed.

## Also in scope, and deliberately out

Each `.mm` carried two copies of the request-side `int32_t` → `GeomAbs_Shape` mapping — a `static
intToContinuity` for the detailed entry point and the identical `switch` spelled inline in the plain
one. Each file now has one. The bridge-wide census of that conversion is **#513's**, which is
scheduled after this refactor, so nothing here reaches across files.

Left alone deliberately, flagged rather than fixed:

- The **Swift argument order** for `maxDegree`/`maxSegments` still differs between the two entry points
  on `Surface`, and the continuity parameter is still `Int` on `.approximated` but
  `ParametricContinuity` on `.approxWithDetails`. Both are source-breaking public API changes needing
  deprecation shims, and the continuity-vocabulary question belongs to #398/#436.
- Both `.approxWithDetails` extensions still live in `Shape.swift` rather than `Curve3D.swift` /
  `Surface.swift`, as #491 notes. Moving them is churn with no behaviour change; #395's `OCCTBridge.h`
  breakout is the natural place.

## Verification

`swift build` clean. Full `swift test`: **4679 tests green** on two runs of this code. A third and
fourth run each hit one failure in `v1.11.2 Robust import progress (issue #300)` — a different test
and a different failure mode each time (once the `elapsed < full * 0.95` timing bound, once
`.importFailed` on `occt300_robust_repair.step`). That suite writes three **hardcoded, non-unique**
temp paths (`occt300_robust_heal.igs`, `occt300_robust_repair.step`, `occt300_robust_nil.step`), which
is the pre-existing parallel-collision flake class `CLAUDE.md` already documents; it passes 3/3 in
isolation and nothing in the IGES/STEP import path calls any of the four functions this PR touches.
Not fixed here.

All four committed reproducers compile and reproduce the numbers quoted in their READMEs.
