### PR TITLE
fix(#492): one analytical-conversion path per converter class, and a result that no longer aliases its input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,273 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,274 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/repro/492-analytical-conversion/README.md
+++ b/Scripts/repro/492-analytical-conversion/README.md
@@ -1,0 +1,90 @@
+# OCCTSwift#492 probe — what `GeomConvert_*ToAna*` actually hands back
+
+Ground truth for the two analytical-conversion converter classes, against the pinned OCCT 8.0.0p1
+kernel. It exists because #492's central claim — that a wrapper's "already analytical" guard
+compares the result handle against the input handle — could only be settled by measuring which
+converter, if either, ever returns the input handle.
+
+The answer is that both do something, and they do opposite things.
+
+No fixture files needed: every case builds its geometry from a primitive.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/492-analytical-conversion/occt_492_handle_identity.cpp -o /tmp/occt_492
+/tmp/occt_492
+```
+
+## What it measures
+
+### 1. `GeomConvert_CurveToAnaCurve` returns the input handle for an already-analytical curve
+
+```
+--- curve: Geom_Circle (already analytical)  (full range)
+    ok                     YES
+    same handle as input?  YES
+```
+
+Same for `Geom_Line`, and for both a full range and a sub-range. This is not incidental:
+`ComputeLine` (`GeomConvert_CurveToAnaCurve.cxx:186`) and `ComputeCircle` (`:296`) each down-cast
+the input and return it unchanged, with `Deviation = 0`.
+
+`Geom_TrimmedCurve` is a quieter version of the same thing — `ConvertToAnalytical` unwraps it to its
+basis curve before recognition, so the returned `Geom_Line` is the object the trim still holds.
+
+**Consequence in the bridge, before #492:** both curve wrappers handed that shared curve to Swift as
+a separate `Curve3D`, so the two objects aliased one `Geom_Curve`. `Curve3D.translate` is in-place,
+so transforming the "converted" curve moved the original. Measured through the public API:
+translating `Curve3D.circle(...).toAnalytical()` by 100 moved the source circle by exactly 100.
+Covered now by `AnalyticalConversionContractTests` in `Tests/OCCTCurveTests`, which fails by exactly
+that margin against the pre-#492 bridge.
+
+### 2. `GeomConvert_SurfToAnaSurf` never returns the input handle
+
+```
+--- surface: Geom_Plane (already analytical)
+    same handle as input?  no
+    result type            Geom_Plane
+    gap                    0
+```
+
+Also `no` for cylinder, sphere, a rectangular-trimmed plane and cylinder, an offset plane, and a
+BSpline fitted to a flat grid. Every branch allocates: the already-analytical branch returns
+`new Geom_Plane(aGAS.Plane())` and friends (`GeomConvert_SurfToAnaSurf.cxx:791-807`), and every
+other path assigns `newSurf[isurf]` from a freshly-built elementary surface.
+
+So `OCCTSurfaceToAnalytical`'s guard —
+
+```cpp
+// If the result is the same handle, it was already analytical or couldn't convert
+if (result == surface->surface) return nullptr;
+```
+
+— was dead code, and its comment was wrong twice over: an already-analytical surface converts (to a
+fresh, equal surface, gap 0), and a surface that "couldn't convert" comes back as a **null** handle,
+which the line above already caught.
+
+### 3. Failure and edge cases
+
+| Input | Result |
+|---|---|
+| Freeform BSpline surface | null handle, `Gap()` = -1 |
+| Freeform BSpline curve | `ok` = false, null handle, `Gap()` = -1 |
+| Bounded overload, inverted UV (`uMin > uMax`) | throws `Geom_BSplineSurface::Segment` |
+| BSpline circle, sub-range `[π/2, 3π/2]` | succeeds, reports `[0, 3.06]` — the *recognized* circle's parameterisation, not the input's |
+
+The inverted-UV throw is the only exception any of these paths raises, and it is a catchable
+`Standard_Failure`, not a signal.
+
+## What #492 changed
+
+`occtCurveToAnalytical` and `occtSurfaceToAnalytical` (`OCCTBridge_Internal.h`) are now the single
+path behind all three surviving bridge entry points. Both detach the result with `Copy()`, so the
+guarantee is the same for both classes and does not depend on which branch of which kernel version
+happened to allocate. The results are line/circle/ellipse and plane/cylinder/cone/sphere/torus, so
+the copy costs nothing.

--- a/Scripts/repro/492-analytical-conversion/occt_492_handle_identity.cpp
+++ b/Scripts/repro/492-analytical-conversion/occt_492_handle_identity.cpp
@@ -1,0 +1,212 @@
+// Ground truth for #492: what GeomConvert_CurveToAnaCurve / GeomConvert_SurfToAnaSurf
+// actually return, against the pinned OCCT 8.0.0p1 kernel.
+//
+// Questions:
+//  1. Can ConvertToAnalytical ever hand back the SAME handle it was given?
+//     (the `result == surface->surface` guard in OCCTSurfaceToAnalytical assumes it can)
+//  2. What comes back for an already-analytical input?
+//  3. What comes back for an unconvertible input — null, or the input?
+//  4. Gap()/newFirst/newLast on each path.
+
+#include <Geom_Plane.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Geom_OffsetSurface.hxx>
+#include <Geom_SurfaceOfLinearExtrusion.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <GeomConvert.hxx>
+#include <GeomConvert_CurveToAnaCurve.hxx>
+#include <GeomConvert_SurfToAnaSurf.hxx>
+#include <GeomAPI_PointsToBSpline.hxx>
+#include <GeomAPI_PointsToBSplineSurface.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <TColgp_Array2OfPnt.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Ax2.hxx>
+#include <cstdio>
+#include <cmath>
+
+static const char* yn(bool b) { return b ? "YES" : "no"; }
+
+static void probeSurface(const char* label, const Handle(Geom_Surface)& s, double tol) {
+    printf("--- surface: %s\n", label);
+    if (s.IsNull()) { printf("    input is null, skipped\n"); return; }
+    try {
+        GeomConvert_SurfToAnaSurf conv(s);
+        Handle(Geom_Surface) r = conv.ConvertToAnalytical(tol);
+        printf("    result null?           %s\n", yn(r.IsNull()));
+        if (!r.IsNull()) {
+            printf("    same handle as input?  %s\n", yn(r == s));
+            printf("    result type            %s\n", r->DynamicType()->Name());
+            printf("    gap                    %.6g\n", conv.Gap());
+        } else {
+            printf("    gap                    %.6g\n", conv.Gap());
+        }
+        printf("    IsCanonical(input)     %s\n", yn(GeomConvert_SurfToAnaSurf::IsCanonical(s)));
+    } catch (const Standard_Failure& e) {
+        printf("    THREW: %s\n", e.GetMessageString() ? e.GetMessageString() : "(no message)");
+    } catch (...) {
+        printf("    THREW: (unknown)\n");
+    }
+}
+
+static void probeSurfaceBounded(const char* label, const Handle(Geom_Surface)& s, double tol,
+                                double uMin, double uMax, double vMin, double vMax) {
+    printf("--- surface (bounded): %s  uv=[%.3g,%.3g]x[%.3g,%.3g]\n", label, uMin, uMax, vMin, vMax);
+    if (s.IsNull()) { printf("    input is null, skipped\n"); return; }
+    try {
+        GeomConvert_SurfToAnaSurf conv(s);
+        Handle(Geom_Surface) r = conv.ConvertToAnalytical(tol, uMin, uMax, vMin, vMax);
+        printf("    result null?           %s\n", yn(r.IsNull()));
+        if (!r.IsNull()) {
+            printf("    same handle as input?  %s\n", yn(r == s));
+            printf("    result type            %s\n", r->DynamicType()->Name());
+        }
+        printf("    gap                    %.6g\n", conv.Gap());
+    } catch (const Standard_Failure& e) {
+        printf("    THREW: %s\n", e.GetMessageString() ? e.GetMessageString() : "(no message)");
+    } catch (...) {
+        printf("    THREW: (unknown)\n");
+    }
+}
+
+static void probeCurve(const char* label, const Handle(Geom_Curve)& c, double tol,
+                       bool subRange) {
+    printf("--- curve: %s%s\n", label, subRange ? "  (sub-range: middle half)" : "  (full range)");
+    if (c.IsNull()) { printf("    input is null, skipped\n"); return; }
+    double f = c->FirstParameter(), l = c->LastParameter();
+    if (subRange) { double d = (l - f) * 0.25; f += d; l -= d; }
+    try {
+        GeomConvert_CurveToAnaCurve conv(c);
+        Handle(Geom_Curve) r;
+        double nf = -12345, nl = -12345;
+        bool ok = conv.ConvertToAnalytical(tol, r, f, l, nf, nl);
+        printf("    ok                     %s\n", yn(ok));
+        printf("    result null?           %s\n", yn(r.IsNull()));
+        if (!r.IsNull()) {
+            printf("    same handle as input?  %s\n", yn(r == c));
+            printf("    result type            %s\n", r->DynamicType()->Name());
+        }
+        printf("    in  F/L                %.6g / %.6g\n", f, l);
+        printf("    out newF/newL          %.6g / %.6g\n", nf, nl);
+        printf("    gap                    %.6g\n", conv.Gap());
+    } catch (const Standard_Failure& e) {
+        printf("    THREW: %s\n", e.GetMessageString() ? e.GetMessageString() : "(no message)");
+    } catch (...) {
+        printf("    THREW: (unknown)\n");
+    }
+}
+
+int main() {
+    const double tol = 1e-4;
+
+    printf("========== SURFACES ==========\n");
+
+    Handle(Geom_Plane) plane = new Geom_Plane(gp_Ax3(gp_Pnt(1, 2, 3), gp_Dir(0, 0, 1)));
+    probeSurface("Geom_Plane (already analytical)", plane, tol);
+
+    Handle(Geom_CylindricalSurface) cyl =
+        new Geom_CylindricalSurface(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 5.0);
+    probeSurface("Geom_CylindricalSurface (already analytical)", cyl, tol);
+
+    Handle(Geom_SphericalSurface) sph =
+        new Geom_SphericalSurface(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 3.0);
+    probeSurface("Geom_SphericalSurface (already analytical)", sph, tol);
+
+    // BSpline that IS a plane
+    {
+        TColgp_Array2OfPnt pts(1, 4, 1, 4);
+        for (int i = 1; i <= 4; ++i)
+            for (int j = 1; j <= 4; ++j)
+                pts.SetValue(i, j, gp_Pnt(i * 2.0, j * 2.0, 0.0));
+        GeomAPI_PointsToBSplineSurface maker(pts);
+        probeSurface("BSpline over a flat grid (convertible -> plane)", maker.Surface(), tol);
+    }
+
+    // BSpline that is NOT analytical (a saddle / freeform bump)
+    Handle(Geom_BSplineSurface) freeform;
+    {
+        TColgp_Array2OfPnt pts(1, 5, 1, 5);
+        for (int i = 1; i <= 5; ++i)
+            for (int j = 1; j <= 5; ++j) {
+                double x = i * 2.0, y = j * 2.0;
+                pts.SetValue(i, j, gp_Pnt(x, y, sin(x * 0.7) * cos(y * 1.3) * 4.0));
+            }
+        GeomAPI_PointsToBSplineSurface maker(pts);
+        freeform = maker.Surface();
+        probeSurface("BSpline freeform bumpy (NOT convertible)", freeform, tol);
+    }
+
+    // Trimmed / offset wrappers around an analytical surface
+    probeSurface("RectangularTrimmed(plane)",
+                 new Geom_RectangularTrimmedSurface(Handle(Geom_Surface)(plane), -10.0, 10.0, -10.0, 10.0, true, true), tol);
+    probeSurface("RectangularTrimmed(cylinder)",
+                 new Geom_RectangularTrimmedSurface(Handle(Geom_Surface)(cyl), 0.0, M_PI, -5.0, 5.0, true, true), tol);
+    probeSurface("Offset(plane, 2.0)", new Geom_OffsetSurface(plane, 2.0), tol);
+
+    printf("\n========== SURFACES (bounded overload) ==========\n");
+    probeSurfaceBounded("Geom_Plane (already analytical)", plane, tol, -10, 10, -10, 10);
+    probeSurfaceBounded("BSpline freeform bumpy", freeform, tol, 0, 1, 0, 1);
+    {
+        TColgp_Array2OfPnt pts(1, 4, 1, 4);
+        for (int i = 1; i <= 4; ++i)
+            for (int j = 1; j <= 4; ++j)
+                pts.SetValue(i, j, gp_Pnt(i * 2.0, j * 2.0, 0.0));
+        GeomAPI_PointsToBSplineSurface maker(pts);
+        Handle(Geom_Surface) flat = maker.Surface();
+        double u1, u2, v1, v2; flat->Bounds(u1, u2, v1, v2);
+        probeSurfaceBounded("BSpline flat, full bounds", flat, tol, u1, u2, v1, v2);
+        probeSurfaceBounded("BSpline flat, middle half", flat, tol,
+                            u1 + (u2 - u1) * 0.25, u2 - (u2 - u1) * 0.25,
+                            v1 + (v2 - v1) * 0.25, v2 - (v2 - v1) * 0.25);
+        probeSurfaceBounded("BSpline flat, INVERTED uv (uMin>uMax)", flat, tol, u2, u1, v2, v1);
+    }
+
+    printf("\n========== CURVES ==========\n");
+
+    Handle(Geom_Line) line = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 1, 0));
+    probeCurve("Geom_Line (already analytical, infinite range)", line, tol, false);
+    probeCurve("TrimmedCurve(line, 0..10)", new Geom_TrimmedCurve(line, 0, 10), tol, false);
+    probeCurve("TrimmedCurve(line, 0..10)", new Geom_TrimmedCurve(line, 0, 10), tol, true);
+
+    Handle(Geom_Circle) circ = new Geom_Circle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 4.0);
+    probeCurve("Geom_Circle (already analytical)", circ, tol, false);
+    probeCurve("Geom_Circle (already analytical)", circ, tol, true);
+
+    // BSpline that IS a circle
+    {
+        Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(circ);
+        probeCurve("BSpline over a circle (convertible)", bs, tol, false);
+        probeCurve("BSpline over a circle (convertible)", bs, tol, true);
+    }
+
+    // BSpline that IS a line
+    {
+        TColgp_Array1OfPnt pts(1, 5);
+        for (int i = 1; i <= 5; ++i) pts.SetValue(i, gp_Pnt(i * 1.0, i * 2.0, i * 3.0));
+        GeomAPI_PointsToBSpline maker(pts);
+        probeCurve("BSpline over collinear points (convertible -> line)", maker.Curve(), tol, false);
+    }
+
+    // Freeform BSpline: not analytical
+    {
+        TColgp_Array1OfPnt pts(1, 6);
+        pts.SetValue(1, gp_Pnt(0, 0, 0));
+        pts.SetValue(2, gp_Pnt(1, 3, 0));
+        pts.SetValue(3, gp_Pnt(2, -2, 1));
+        pts.SetValue(4, gp_Pnt(4, 5, -3));
+        pts.SetValue(5, gp_Pnt(6, 0, 2));
+        pts.SetValue(6, gp_Pnt(8, 4, 0));
+        GeomAPI_PointsToBSpline maker(pts);
+        probeCurve("BSpline freeform wiggle (NOT convertible)", maker.Curve(), tol, false);
+    }
+
+    printf("\n========== DONE ==========\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -295,6 +295,8 @@
 // --- GeomConvert ---
 // GeomConvert                         → OCCTCurve3DToBSpline, OCCTCurve3DToBezierSegments
 // GeomConvert_CompCurveToBSplineCurve → OCCTCurve3DJoined
+// GeomConvert_CurveToAnaCurve         → OCCTGeomConvertCurveToAnalytical, OCCTGeomConvertIsLinear
+// GeomConvert_SurfToAnaSurf           → OCCTGeomConvertSurfToAnalytical*, OCCTGeomConvertIsCanonical
 //
 // --- Convert ---
 // Convert_CompBezierCurvesToBSplineCurve   → OCCTConvertCompBezierToBSpline (v0.99.0)
@@ -4094,24 +4096,6 @@ int32_t OCCTSurfaceIntersect(OCCTSurfaceRef s1, OCCTSurfaceRef s2, double tolera
 /// @param surface The surface
 /// @return Minimum distance, or -1.0 on failure
 double OCCTCurve3DDistanceToSurface(OCCTCurve3DRef curve, OCCTSurfaceRef surface);
-
-
-// MARK: - Curve to Analytical (v0.30.0)
-
-/// Convert a curve to its analytical (canonical) form if possible.
-/// @param curve The input curve
-/// @param tolerance Conversion tolerance
-/// @return Analytical curve, or NULL if conversion is not possible
-OCCTCurve3DRef OCCTCurve3DToAnalytical(OCCTCurve3DRef curve, double tolerance);
-
-
-// MARK: - Surface to Analytical (v0.30.0)
-
-/// Convert a surface to its analytical (canonical) form if possible.
-/// @param surface The input surface
-/// @param tolerance Conversion tolerance
-/// @return Analytical surface, or NULL if conversion is not possible
-OCCTSurfaceRef OCCTSurfaceToAnalytical(OCCTSurfaceRef surface, double tolerance);
 
 
 // MARK: - Shape Contents (v0.30.0)
@@ -10466,14 +10450,19 @@ int OCCTSplitSurfaceArea(OCCTSurfaceRef _Nonnull surfaceRef, int nbParts, bool i
 
 /// Result struct for curve-to-analytical conversion.
 typedef struct {
-    OCCTCurve3DRef _Nullable curve;
-    double newFirst;
-    double newLast;
-    double gap;
+    OCCTCurve3DRef _Nullable curve;   ///< Owned by the caller; independent of the input curve
+    double newFirst;                  ///< Range start, in the RECOGNISED curve's parameterisation
+    double newLast;                   ///< Range end, in the RECOGNISED curve's parameterisation
+    double gap;                       ///< Max deviation from the input; exactly 0 when already analytical
     bool success;
 } OCCTCurveToAnaCurveResult;
 
-/// Convert a BSpline curve to an analytical curve (line, circle, ellipse).
+/// Convert a curve to an analytical curve (line, circle, ellipse) over [first, last].
+///
+/// The sole entry point for GeomConvert_CurveToAnaCurve; the v0.30.0 OCCTCurve3DToAnalytical, which
+/// hardcoded the curve's own range and dropped newFirst/newLast/gap, was retired into it (#492).
+/// An already-analytical input succeeds with gap 0 rather than being rejected, and the returned
+/// curve never aliases the input.
 OCCTCurveToAnaCurveResult OCCTGeomConvertCurveToAnalytical(OCCTCurve3DRef _Nonnull curveRef,
                                                              double tolerance, double first, double last);
 
@@ -10485,15 +10474,21 @@ bool OCCTGeomConvertIsLinear(const double* _Nonnull points, int count, double to
 
 /// Result struct for surface-to-analytical conversion.
 typedef struct {
-    OCCTSurfaceRef _Nullable surface;
-    double gap;
+    OCCTSurfaceRef _Nullable surface;  ///< Owned by the caller; independent of the input surface
+    double gap;                        ///< Max deviation from the input; exactly 0 when already analytical
     bool success;
 } OCCTSurfToAnaSurfResult;
 
-/// Convert a BSpline surface to an analytical surface (plane, cylinder, cone, sphere, torus).
+/// Convert a surface to an analytical surface (plane, cylinder, cone, sphere, torus).
+///
+/// The sole unbounded entry point for GeomConvert_SurfToAnaSurf; the v0.30.0
+/// OCCTSurfaceToAnalytical was retired into it (#492), along with its "if the result is the same
+/// handle it was already analytical" guard, which never fired -- every branch of
+/// ConvertToAnalytical allocates. An already-analytical input succeeds with gap 0.
 OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalytical(OCCTSurfaceRef _Nonnull surfaceRef, double tolerance);
 
-/// Convert with UV bounds.
+/// Convert, fitting only the [uMin, uMax] x [vMin, vMax] sub-patch. Inverted bounds fail (OCCT
+/// throws Geom_BSplineSurface::Segment, caught here) rather than being normalised.
 OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalyticalBounded(OCCTSurfaceRef _Nonnull surfaceRef,
                                                                   double tolerance,
                                                                   double uMin, double uMax,

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1050,27 +1050,6 @@ int32_t OCCTCurve3DExtrema(OCCTCurve3DRef c1, OCCTCurve3DRef c2, OCCTCurveExtrem
     }
 }
 
-// MARK: - Curve to Analytical (v0.30.0)
-
-#include <GeomConvert_CurveToAnaCurve.hxx>
-
-OCCTCurve3DRef OCCTCurve3DToAnalytical(OCCTCurve3DRef curve, double tolerance) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        GeomConvert_CurveToAnaCurve converter(curve->curve);
-        Handle(Geom_Curve) result;
-        double newFirst, newLast;
-        bool ok = converter.ConvertToAnalytical(tolerance, result,
-                                                 curve->curve->FirstParameter(),
-                                                 curve->curve->LastParameter(),
-                                                 newFirst, newLast);
-        if (!ok || result.IsNull()) return nullptr;
-        return new OCCTCurve3D(result);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
 // MARK: - Quasi-Uniform Curve Sampling (v0.31.0)
 
 #include <GCPnts_QuasiUniformAbscissa.hxx>
@@ -2179,26 +2158,20 @@ int OCCTSplitCurve3dContinuity(OCCTCurve3DRef _Nonnull curveRef, int criterion, 
     }
 }
 
-// MARK: - GeomConvert_CurveToAnaCurve (v0.78)
 // MARK: - GeomConvert_CurveToAnaCurve
 
 OCCTCurveToAnaCurveResult OCCTGeomConvertCurveToAnalytical(OCCTCurve3DRef _Nonnull curveRef,
                                                              double tolerance, double first, double last) {
     OCCTCurveToAnaCurveResult result = {nullptr, 0, 0, 0, false};
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve3D*>(curveRef)->curve;
-        GeomConvert_CurveToAnaCurve converter(curve);
-        Handle(Geom_Curve) resCurve;
-        double newF, newL;
-        bool ok = converter.ConvertToAnalytical(tolerance, resCurve, first, last, newF, newL);
-        if (ok && !resCurve.IsNull()) {
-            result.curve = reinterpret_cast<OCCTCurve3DRef>(new OCCTCurve3D{resCurve});
-            result.newFirst = newF;
-            result.newLast = newL;
-            result.gap = converter.Gap();
-            result.success = true;
-        }
-    } catch (...) {}
+    if (!curveRef) return result;
+    Handle(Geom_Curve) resCurve;
+    if (!occtCurveToAnalytical(reinterpret_cast<OCCTCurve3D*>(curveRef)->curve, tolerance,
+                               first, last, resCurve,
+                               result.newFirst, result.newLast, result.gap)) {
+        return result;
+    }
+    result.curve = reinterpret_cast<OCCTCurve3DRef>(new OCCTCurve3D{resCurve});
+    result.success = true;
     return result;
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -455,4 +455,96 @@ inline bool occtValidParabolaFocal(double focal) {
     return focal > 0;
 }
 
+// === #492: one analytical-conversion path per GeomConvert converter class ===
+//
+// GeomConvert_CurveToAnaCurve and GeomConvert_SurfToAnaSurf each had two independently-grown
+// wrapper families (v0.30.0 and v0.78) that made the identical OCCT call and then disagreed about
+// what to do with the answer: the older curve wrapper hardcoded the curve's own parameter range and
+// discarded newFirst/newLast/Gap(), and the older surface wrapper carried an "already analytical"
+// guard its younger sibling never grew. These two helpers are the single path all of them now take.
+//
+// The contract both entry points guarantee, and neither guaranteed before:
+//
+//   1. Success yields a NEW object that shares no state with the input. This is not decoration.
+//      GeomConvert_CurveToAnaCurve::ConvertToAnalytical hands back the *input handle itself* when
+//      the curve is already analytical -- ComputeLine and ComputeCircle both down-cast the input and
+//      return it (GeomConvert_CurveToAnaCurve.cxx:186, :296) -- and for a Geom_TrimmedCurve it
+//      returns the basis curve the trim still holds. Both wrappers then handed that shared curve to
+//      Swift as a separate Curve3D, so an in-place transform on the "converted" curve moved the
+//      original too. Measured, not theorised: translating the result of
+//      Curve3D.circle(...).toAnalytical() by 100 moved the source circle by exactly 100.
+//
+//      GeomConvert_SurfToAnaSurf never does this -- every branch allocates
+//      (GeomConvert_SurfToAnaSurf.cxx:791-807 for already-analytical input, and every newSurf[]
+//      assignment elsewhere), so the old same-handle guard was dead code against this kernel. It is
+//      still copied here, because "the current kernel happens to allocate" is exactly the assumption
+//      that let the two families drift apart in the first place. Both results are tiny analytic
+//      objects (line/circle/ellipse; plane/cylinder/cone/sphere/torus), so the copy is free.
+//
+//   2. Failure is one outcome, not three. A null input, an unrecognisable input and a thrown
+//      Standard_Failure (the bounded surface overload throws Geom_BSplineSurface::Segment on
+//      inverted UV bounds) all return false, leaving the out-parameters untouched.
+//
+// "Already analytical" is a success, not a rejection, on both sides -- a circle IS its analytical
+// form. Gap() reports 0 exactly for those, which is how a caller tells them apart.
+
+#include <GeomConvert_CurveToAnaCurve.hxx>
+#include <GeomConvert_SurfToAnaSurf.hxx>
+
+// Recognise `curve` over [first, last] as a line, circle or ellipse.
+//
+// outFirst/outLast come back in the RECOGNISED curve's own parameterisation, which is not the
+// input's: a BSpline circle asked about [pi/2, 3pi/2] reports [0, 3.06] on the Geom_Circle it
+// returns. Trimmed curves are unwrapped to their basis curve before recognition.
+inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve, double tolerance,
+                                  double first, double last,
+                                  occ::handle<Geom_Curve>& outCurve,
+                                  double& outFirst, double& outLast, double& outGap) {
+    if (curve.IsNull()) return false;
+    try {
+        GeomConvert_CurveToAnaCurve converter(curve);
+        occ::handle<Geom_Curve> result;
+        double newFirst = first, newLast = last;
+        if (!converter.ConvertToAnalytical(tolerance, result, first, last, newFirst, newLast)) {
+            return false;
+        }
+        if (result.IsNull()) return false;
+        occ::handle<Geom_Curve> detached = occ::handle<Geom_Curve>::DownCast(result->Copy());
+        if (detached.IsNull()) return false;
+        outCurve = detached;
+        outFirst = newFirst;
+        outLast = newLast;
+        outGap = converter.Gap();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Recognise `surface` as a plane, cylinder, cone, sphere or torus.
+//
+// uvBounds is either null, for the whole surface, or four doubles {uMin, uMax, vMin, vMax}
+// selecting the sub-patch to fit. Those are the two ConvertToAnalytical overloads; nothing else
+// differs between them.
+inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface, double tolerance,
+                                    const double* uvBounds,
+                                    occ::handle<Geom_Surface>& outSurface, double& outGap) {
+    if (surface.IsNull()) return false;
+    try {
+        GeomConvert_SurfToAnaSurf converter(surface);
+        occ::handle<Geom_Surface> result =
+            uvBounds ? converter.ConvertToAnalytical(tolerance, uvBounds[0], uvBounds[1],
+                                                     uvBounds[2], uvBounds[3])
+                     : converter.ConvertToAnalytical(tolerance);
+        if (result.IsNull()) return false;
+        occ::handle<Geom_Surface> detached = occ::handle<Geom_Surface>::DownCast(result->Copy());
+        if (detached.IsNull()) return false;
+        outSurface = detached;
+        outGap = converter.Gap();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -1045,24 +1045,6 @@ double OCCTCurve3DDistanceToSurface(OCCTCurve3DRef curve, OCCTSurfaceRef surface
     }
 }
 
-// MARK: - Surface to Analytical (v0.30.0)
-
-#include <GeomConvert_SurfToAnaSurf.hxx>
-
-OCCTSurfaceRef OCCTSurfaceToAnalytical(OCCTSurfaceRef surface, double tolerance) {
-    if (!surface || surface->surface.IsNull()) return nullptr;
-    try {
-        GeomConvert_SurfToAnaSurf converter(surface->surface);
-        Handle(Geom_Surface) result = converter.ConvertToAnalytical(tolerance);
-        if (result.IsNull()) return nullptr;
-        // If the result is the same handle, it was already analytical or couldn't convert
-        if (result == surface->surface) return nullptr;
-        return new OCCTSurface(result);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
 // MARK: - Canonical Recognition (v0.30.0)
 
 #include <ShapeAnalysis_CanonicalRecognition.hxx>
@@ -2807,40 +2789,33 @@ bool OCCTGeomLibPlanarSurfacePlane(OCCTSurfaceRef _Nonnull surfRef, double toler
     }
 }
 
-// MARK: - GeomConvert_SurfToAnaSurf (v0.78)
 // MARK: - GeomConvert_SurfToAnaSurf
 
-OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalytical(OCCTSurfaceRef _Nonnull surfaceRef, double tolerance) {
+// Package one occtSurfaceToAnalytical answer as the C result both entry points return.
+static OCCTSurfToAnaSurfResult occtSurfToAnaSurfResult(OCCTSurfaceRef _Nullable surfaceRef,
+                                                       double tolerance, const double* uvBounds) {
     OCCTSurfToAnaSurfResult result = {nullptr, 0, false};
-    try {
-        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
-        GeomConvert_SurfToAnaSurf converter(surface);
-        Handle(Geom_Surface) resSurf = converter.ConvertToAnalytical(tolerance);
-        if (!resSurf.IsNull()) {
-            result.surface = reinterpret_cast<OCCTSurfaceRef>(new OCCTSurface{resSurf});
-            result.gap = converter.Gap();
-            result.success = true;
-        }
-    } catch (...) {}
+    if (!surfaceRef) return result;
+    Handle(Geom_Surface) resSurf;
+    if (!occtSurfaceToAnalytical(reinterpret_cast<OCCTSurface*>(surfaceRef)->surface, tolerance,
+                                 uvBounds, resSurf, result.gap)) {
+        return result;
+    }
+    result.surface = reinterpret_cast<OCCTSurfaceRef>(new OCCTSurface{resSurf});
+    result.success = true;
     return result;
+}
+
+OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalytical(OCCTSurfaceRef _Nonnull surfaceRef, double tolerance) {
+    return occtSurfToAnaSurfResult(surfaceRef, tolerance, nullptr);
 }
 
 OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalyticalBounded(OCCTSurfaceRef _Nonnull surfaceRef,
                                                                   double tolerance,
                                                                   double uMin, double uMax,
                                                                   double vMin, double vMax) {
-    OCCTSurfToAnaSurfResult result = {nullptr, 0, false};
-    try {
-        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
-        GeomConvert_SurfToAnaSurf converter(surface);
-        Handle(Geom_Surface) resSurf = converter.ConvertToAnalytical(tolerance, uMin, uMax, vMin, vMax);
-        if (!resSurf.IsNull()) {
-            result.surface = reinterpret_cast<OCCTSurfaceRef>(new OCCTSurface{resSurf});
-            result.gap = converter.Gap();
-            result.success = true;
-        }
-    } catch (...) {}
-    return result;
+    const double uvBounds[4] = {uMin, uMax, vMin, vMax};
+    return occtSurfToAnaSurfResult(surfaceRef, tolerance, uvBounds);
 }
 
 bool OCCTGeomConvertIsCanonical(OCCTSurfaceRef _Nonnull surfaceRef) {

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -725,16 +725,26 @@ extension Curve3D {
         return d >= 0 ? d : nil
     }
 
-    /// Convert this freeform curve to an analytical curve if possible.
+    /// Convert this curve to an analytical curve if possible.
     ///
-    /// Recognizes if the curve is actually a line, circle, or ellipse
-    /// within the given tolerance and returns the analytical representation.
+    /// Recognizes if the curve is actually a line, circle, or ellipse within the given tolerance
+    /// and returns the analytical representation. A curve that is already analytical converts to an
+    /// equal, independent curve rather than being rejected.
+    ///
+    /// Examines the curve's whole domain. Use ``toAnalytical(tolerance:first:last:)`` to examine a
+    /// sub-range, or ``toAnalyticalWithGap(tolerance:)`` to also get the deviation.
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    /// if let analytical = circle.toBSpline()?.toAnalytical(tolerance: 1e-4) {
+    ///     print(analytical.curveKind)   // .circle
+    /// }
+    /// ```
     ///
     /// - Parameter tolerance: Recognition tolerance
     /// - Returns: The analytical curve, or nil if not recognizable
     public func toAnalytical(tolerance: Double = 1e-4) -> Curve3D? {
-        guard let h = OCCTCurve3DToAnalytical(handle, tolerance) else { return nil }
-        return Curve3D(handle: h)
+        toAnalyticalWithGap(tolerance: tolerance)?.curve
     }
 
     // MARK: - Quasi-Uniform Sampling (v0.31.0)

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -12526,14 +12526,39 @@ extension Surface {
 
 /// Result of converting a curve to its analytical form.
 public struct CurveToAnalyticalResult: Sendable {
+    /// The recognized curve. Independent of the curve it was recognized from.
     public let curve: Curve3D
+    /// Range start, expressed in `curve`'s own parameterization — not the input's.
     public let newFirst: Double
+    /// Range end, expressed in `curve`'s own parameterization — not the input's.
     public let newLast: Double
+    /// Maximum deviation from the input curve. Exactly `0` when the input was already analytical.
     public let gap: Double
 }
 
 extension Curve3D {
     /// Attempt to convert this curve to an analytical form (line, circle, ellipse).
+    ///
+    /// Recognition runs over `[first, last]` only, so a curve that is a circle along part of its
+    /// domain can be recognized there even when the whole domain is not. The result carries the
+    /// recognized curve's own parameterization: a BSpline circle examined over `[π/2, 3π/2]`
+    /// reports a range starting at 0 on the `Geom_Circle` it returns.
+    ///
+    /// ```swift
+    /// let bspline = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!.toBSpline()!
+    /// let domain = bspline.domain
+    /// if let r = bspline.toAnalytical(tolerance: 1e-4,
+    ///                                 first: domain.lowerBound,
+    ///                                 last: domain.upperBound) {
+    ///     print(r.curve.curveKind, r.gap)   // .circle, ~1e-15
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - tolerance: Recognition tolerance.
+    ///   - first: Start of the parameter range to examine.
+    ///   - last: End of the parameter range to examine.
+    /// - Returns: The recognized curve with its range and deviation, or nil if not recognizable.
     public func toAnalytical(tolerance: Double, first: Double, last: Double) -> CurveToAnalyticalResult? {
         let result = OCCTGeomConvertCurveToAnalytical(handle, tolerance, first, last)
         guard result.success, let curveRef = result.curve else { return nil }
@@ -12543,6 +12568,28 @@ extension Curve3D {
             newLast: result.newLast,
             gap: result.gap
         )
+    }
+
+    /// Attempt to convert this curve to an analytical form over its whole domain, reporting the
+    /// deviation.
+    ///
+    /// The full-range spelling of ``toAnalytical(tolerance:first:last:)``, and the curve counterpart
+    /// of ``Surface/toAnalyticalWithGap(tolerance:)``.
+    ///
+    /// ```swift
+    /// let bspline = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!.toBSpline()!
+    /// if let r = bspline.toAnalyticalWithGap(tolerance: 1e-4) {
+    ///     print(r.gap)   // how far the BSpline strayed from the circle
+    /// }
+    /// ```
+    ///
+    /// - Parameter tolerance: Recognition tolerance.
+    /// - Returns: The recognized curve with its range and deviation, or nil if not recognizable.
+    public func toAnalyticalWithGap(tolerance: Double = 1e-4) -> CurveToAnalyticalResult? {
+        let domain = self.domain
+        return toAnalytical(tolerance: tolerance,
+                            first: domain.lowerBound,
+                            last: domain.upperBound)
     }
 
     /// Check if a set of 3D points are collinear within tolerance.
@@ -12562,19 +12609,56 @@ extension Curve3D {
 
 /// Result of converting a surface to its analytical form.
 public struct SurfaceToAnalyticalResult: Sendable {
+    /// The recognized surface. Independent of the surface it was recognized from.
     public let surface: Surface
+    /// Maximum deviation from the input surface. Exactly `0` when the input was already analytical.
     public let gap: Double
 }
 
 extension Surface {
-    /// Attempt to convert this surface to an analytical form with detailed result.
+    /// Attempt to convert this surface to an analytical form, reporting the deviation.
+    ///
+    /// The detailed spelling of ``Surface/toAnalytical(tolerance:)``: same recognition, same
+    /// success and failure cases, plus the gap.
+    ///
+    /// ```swift
+    /// let bspline = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5)!
+    ///     .trimmed(u1: 0, u2: .pi, v1: -5, v2: 5)!.toBSpline()!
+    /// if let r = bspline.toAnalyticalWithGap(tolerance: 1e-4) {
+    ///     print(r.surface.surfaceKind, r.gap)   // .cylinder, ~1e-15
+    /// }
+    /// ```
+    ///
+    /// - Parameter tolerance: Recognition tolerance.
+    /// - Returns: The recognized surface with its deviation, or nil if not recognizable.
     public func toAnalyticalWithGap(tolerance: Double) -> SurfaceToAnalyticalResult? {
         let result = OCCTGeomConvertSurfToAnalytical(handle, tolerance)
         guard result.success, let surfRef = result.surface else { return nil }
         return SurfaceToAnalyticalResult(surface: Surface(handle: surfRef), gap: result.gap)
     }
 
-    /// Attempt to convert this surface to analytical form within UV bounds.
+    /// Attempt to convert a UV sub-patch of this surface to an analytical form.
+    ///
+    /// Fits only `[uMin, uMax] × [vMin, vMax]`, so a surface that is a cylinder over part of its
+    /// domain can be recognized there even when the whole domain is not. Inverted bounds
+    /// (`uMin > uMax`) are rejected rather than normalized.
+    ///
+    /// ```swift
+    /// let d = bsplineSurface.domain
+    /// if let r = bsplineSurface.toAnalyticalWithGap(tolerance: 1e-4,
+    ///                                               uMin: d.uMin, uMax: (d.uMin + d.uMax) / 2,
+    ///                                               vMin: d.vMin, vMax: d.vMax) {
+    ///     print(r.surface.surfaceKind)
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - tolerance: Recognition tolerance.
+    ///   - uMin: Lower U bound of the patch to fit.
+    ///   - uMax: Upper U bound of the patch to fit.
+    ///   - vMin: Lower V bound of the patch to fit.
+    ///   - vMax: Upper V bound of the patch to fit.
+    /// - Returns: The recognized surface with its deviation, or nil if not recognizable.
     public func toAnalyticalWithGap(tolerance: Double,
                                       uMin: Double, uMax: Double,
                                       vMin: Double, vMax: Double) -> SurfaceToAnalyticalResult? {

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -940,16 +940,26 @@ extension Surface {
         }
     }
 
-    /// Convert this freeform surface to an analytical surface if possible.
+    /// Convert this surface to an analytical surface if possible.
     ///
-    /// Recognizes if the surface is actually a plane, cylinder, cone,
-    /// sphere, or torus within the given tolerance.
+    /// Recognizes if the surface is actually a plane, cylinder, cone, sphere, or torus within the
+    /// given tolerance. A surface that is already analytical converts to an equal, independent
+    /// surface rather than being rejected.
+    ///
+    /// Use ``toAnalyticalWithGap(tolerance:)`` to also get the deviation, or
+    /// ``toAnalyticalWithGap(tolerance:uMin:uMax:vMin:vMax:)`` to fit only a sub-patch.
+    ///
+    /// ```swift
+    /// let cylinder = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5)!
+    /// if let analytical = cylinder.toBSpline()?.toAnalytical(tolerance: 1e-4) {
+    ///     print(analytical.surfaceKind)   // .cylinder
+    /// }
+    /// ```
     ///
     /// - Parameter tolerance: Recognition tolerance
     /// - Returns: The analytical surface, or nil if not recognizable
     public func toAnalytical(tolerance: Double = 1e-4) -> Surface? {
-        guard let h = OCCTSurfaceToAnalytical(handle, tolerance) else { return nil }
-        return Surface(handle: h)
+        toAnalyticalWithGap(tolerance: tolerance)?.surface
     }
 }
 

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -4428,3 +4428,273 @@ struct Curve3DArcAliasParityTests {
         #expect(b == nil)
     }
 }
+
+// MARK: - #492: one analytical-conversion contract per OCCT converter class
+
+/// Pins the contract shared by every `GeomConvert_CurveToAnaCurve` /
+/// `GeomConvert_SurfToAnaSurf` entry point, after #492 unified the two
+/// independently-grown wrapper families onto one path each.
+@Suite("Analytical conversion contract (#492)")
+struct AnalyticalConversionContractTests {
+
+    private static func dist(_ a: SIMD3<Double>, _ b: SIMD3<Double>) -> Double {
+        let d = a - b
+        return (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
+    }
+
+    /// A wiggly interpolated curve, recognizable as neither line, circle nor ellipse.
+    private static func freeformCurve() -> Curve3D? {
+        Curve3D.interpolate(points: [
+            SIMD3(0, 0, 0), SIMD3(1, 3, 0), SIMD3(2, -2, 1),
+            SIMD3(4, 5, -3), SIMD3(6, 0, 2), SIMD3(8, 4, 0),
+        ])
+    }
+
+    /// A bumpy Bezier patch, recognizable as none of the five analytical surfaces.
+    private static func freeformSurface() -> Surface? {
+        var poles: [[SIMD3<Double>]] = []
+        for i in 0..<4 {
+            var row: [SIMD3<Double>] = []
+            for j in 0..<4 {
+                let x = Double(i) * 2, y = Double(j) * 2
+                row.append(SIMD3(x, y, sin(x * 0.7) * cos(y * 1.3) * 4))
+            }
+            poles.append(row)
+        }
+        return Surface.bspline(poles: poles,
+                               knotsU: [0, 1], multiplicitiesU: [4, 4],
+                               knotsV: [0, 1], multiplicitiesV: [4, 4],
+                               degreeU: 3, degreeV: 3)
+    }
+
+    // MARK: Independence of the result
+
+    @Test("Curve result does not alias the input curve")
+    func curveResultIsIndependent() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
+              let analytical = circle.toAnalytical(tolerance: 1e-4) else {
+            Issue.record("circle did not convert")
+            return
+        }
+        let before = circle.point(at: 0)
+        #expect(analytical.translate(dx: 100, dy: 0, dz: 0))
+        let after = circle.point(at: 0)
+        #expect(Self.dist(before, after) < 1e-9)
+    }
+
+    @Test("Range-aware curve result does not alias the input curve")
+    func rangeAwareCurveResultIsIndependent() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) else {
+            Issue.record("circle not built")
+            return
+        }
+        let domain = circle.domain
+        guard let result = circle.toAnalytical(tolerance: 1e-4,
+                                               first: domain.lowerBound,
+                                               last: domain.upperBound) else {
+            Issue.record("circle did not convert")
+            return
+        }
+        let before = circle.point(at: 0)
+        #expect(result.curve.translate(dx: 100, dy: 0, dz: 0))
+        let after = circle.point(at: 0)
+        #expect(Self.dist(before, after) < 1e-9)
+    }
+
+    @Test("Surface result does not alias the input surface")
+    func surfaceResultIsIndependent() {
+        guard let plane = Surface.plane(origin: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1)),
+              let analytical = plane.toAnalytical(tolerance: 1e-4) else {
+            Issue.record("plane did not convert")
+            return
+        }
+        let before = plane.point(atU: 0, v: 0)
+        #expect(analytical.translate(dx: 100, dy: 0, dz: 0))
+        let after = plane.point(atU: 0, v: 0)
+        #expect(Self.dist(before, after) < 1e-9)
+    }
+
+    @Test("Gap-returning surface result does not alias the input surface")
+    func gapSurfaceResultIsIndependent() {
+        guard let plane = Surface.plane(origin: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1)),
+              let result = plane.toAnalyticalWithGap(tolerance: 1e-4) else {
+            Issue.record("plane did not convert")
+            return
+        }
+        let before = plane.point(atU: 0, v: 0)
+        #expect(result.surface.translate(dx: 100, dy: 0, dz: 0))
+        let after = plane.point(atU: 0, v: 0)
+        #expect(Self.dist(before, after) < 1e-9)
+    }
+
+    // MARK: Parity between the two spellings of each conversion
+
+    @Test("Both curve spellings agree over the curve's own range")
+    func curveSpellingsAgree() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
+              let trimmed = circle.trimmed(from: 0, to: .pi),
+              let bspline = trimmed.toBSpline() else {
+            Issue.record("BSpline circle not built")
+            return
+        }
+        let domain = bspline.domain
+        let plain = bspline.toAnalytical(tolerance: 1e-4)
+        let ranged = bspline.toAnalytical(tolerance: 1e-4,
+                                          first: domain.lowerBound,
+                                          last: domain.upperBound)
+        #expect((plain == nil) == (ranged == nil))
+        if let plain, let ranged {
+            for t in stride(from: 0.0, through: 1.0, by: 0.25) {
+                let u = ranged.newFirst + (ranged.newLast - ranged.newFirst) * t
+                #expect(Self.dist(plain.point(at: u), ranged.curve.point(at: u)) < 1e-9)
+            }
+        }
+    }
+
+    @Test("Full-range curve spelling agrees with the explicit-range spelling")
+    func fullRangeCurveSpellingAgrees() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
+              let trimmed = circle.trimmed(from: 0, to: .pi),
+              let bspline = trimmed.toBSpline(),
+              let freeform = Self.freeformCurve() else {
+            Issue.record("fixtures not built")
+            return
+        }
+        for curve in [bspline, freeform] {
+            let domain = curve.domain
+            let full = curve.toAnalyticalWithGap(tolerance: 1e-4)
+            let explicit = curve.toAnalytical(tolerance: 1e-4,
+                                              first: domain.lowerBound,
+                                              last: domain.upperBound)
+            #expect((full == nil) == (explicit == nil))
+            if let full, let explicit {
+                #expect(full.newFirst == explicit.newFirst)
+                #expect(full.newLast == explicit.newLast)
+                #expect(full.gap == explicit.gap)
+            }
+        }
+    }
+
+    @Test("Both surface spellings agree on success and on geometry")
+    func surfaceSpellingsAgree() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+              let trimmed = plane.trimmed(u1: -10, u2: 10, v1: -10, v2: 10),
+              let bspline = trimmed.toBSpline(),
+              let alreadyAnalytical = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5),
+              let freeform = Self.freeformSurface() else {
+            Issue.record("fixtures not built")
+            return
+        }
+        for surface in [bspline, alreadyAnalytical, freeform] {
+            let plain = surface.toAnalytical(tolerance: 1e-4)
+            let withGap = surface.toAnalyticalWithGap(tolerance: 1e-4)
+            #expect((plain == nil) == (withGap == nil))
+            if let plain, let withGap {
+                #expect(Self.dist(plain.point(atU: 0.3, v: 0.4),
+                                  withGap.surface.point(atU: 0.3, v: 0.4)) < 1e-9)
+            }
+        }
+    }
+
+    // MARK: Already-analytical inputs
+
+    @Test("Already-analytical inputs convert rather than being rejected")
+    func alreadyAnalyticalInputsConvert() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
+              let cylinder = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5) else {
+            Issue.record("fixtures not built")
+            return
+        }
+        #expect(circle.toAnalytical(tolerance: 1e-4) != nil)
+        #expect(cylinder.toAnalytical(tolerance: 1e-4) != nil)
+        if let result = cylinder.toAnalyticalWithGap(tolerance: 1e-4) {
+            #expect(result.gap == 0)
+        } else {
+            Issue.record("cylinder did not convert")
+        }
+    }
+
+    // MARK: Unrecognizable inputs
+
+    @Test("Freeform inputs are rejected by every spelling")
+    func freeformInputsAreRejected() {
+        guard let curve = Self.freeformCurve(), let surface = Self.freeformSurface() else {
+            Issue.record("fixtures not built")
+            return
+        }
+        let domain = curve.domain
+        #expect(curve.toAnalytical(tolerance: 1e-6) == nil)
+        #expect(curve.toAnalytical(tolerance: 1e-6,
+                                   first: domain.lowerBound,
+                                   last: domain.upperBound) == nil)
+        #expect(surface.toAnalytical(tolerance: 1e-6) == nil)
+        #expect(surface.toAnalyticalWithGap(tolerance: 1e-6) == nil)
+        #expect(surface.toAnalyticalWithGap(tolerance: 1e-6,
+                                            uMin: 0, uMax: 1, vMin: 0, vMax: 1) == nil)
+    }
+
+    // MARK: The UV-bounded overload (no coverage at all before #492)
+
+    @Test("UV-bounded conversion recognizes a plane over full bounds and over a sub-range")
+    func boundedConversionRecognizesPlane() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+              let trimmed = plane.trimmed(u1: -10, u2: 10, v1: -10, v2: 10),
+              let bspline = trimmed.toBSpline() else {
+            Issue.record("BSpline plane not built")
+            return
+        }
+        let d = bspline.domain
+        let full = bspline.toAnalyticalWithGap(tolerance: 1e-4,
+                                               uMin: d.uMin, uMax: d.uMax,
+                                               vMin: d.vMin, vMax: d.vMax)
+        #expect(full != nil)
+        #expect((full?.gap ?? 1) < 1e-3)
+
+        let uMid = (d.uMin + d.uMax) / 2, uQ = (d.uMax - d.uMin) / 4
+        let vMid = (d.vMin + d.vMax) / 2, vQ = (d.vMax - d.vMin) / 4
+        let sub = bspline.toAnalyticalWithGap(tolerance: 1e-4,
+                                              uMin: uMid - uQ, uMax: uMid + uQ,
+                                              vMin: vMid - vQ, vMax: vMid + vQ)
+        #expect(sub != nil)
+        #expect((sub?.gap ?? 1) < 1e-3)
+    }
+
+    @Test("UV-bounded conversion rejects inverted bounds instead of trapping")
+    func boundedConversionRejectsInvertedBounds() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+              let trimmed = plane.trimmed(u1: -10, u2: 10, v1: -10, v2: 10),
+              let bspline = trimmed.toBSpline() else {
+            Issue.record("BSpline plane not built")
+            return
+        }
+        let d = bspline.domain
+        #expect(bspline.toAnalyticalWithGap(tolerance: 1e-4,
+                                            uMin: d.uMax, uMax: d.uMin,
+                                            vMin: d.vMax, vMax: d.vMin) == nil)
+    }
+
+    // MARK: Sub-range curve conversion
+
+    @Test("Explicit sub-range reparameterizes the recognized curve")
+    func subRangeReparameterizesResult() {
+        guard let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
+              let bspline = circle.toBSpline() else {
+            Issue.record("BSpline circle not built")
+            return
+        }
+        let domain = bspline.domain
+        let quarter = (domain.upperBound - domain.lowerBound) / 4
+        guard let result = bspline.toAnalytical(tolerance: 1e-4,
+                                                first: domain.lowerBound + quarter,
+                                                last: domain.upperBound - quarter) else {
+            Issue.record("sub-range did not convert")
+            return
+        }
+        #expect(result.gap < 1e-3)
+        // The recognized circle carries its own parameterisation, not the input's.
+        #expect(result.newLast - result.newFirst > 0)
+        let mid = (result.newFirst + result.newLast) / 2
+        let onResult = result.curve.point(at: mid)
+        #expect(abs((onResult.x * onResult.x + onResult.y * onResult.y).squareRoot() - 5) < 1e-6)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -170,7 +170,7 @@ a map of the major areas, and the `Total` as the count.
 | **Approx SameParameter** | 1 | checkSameParameter (3D vs 2D on surface) |
 | **ShapeUpgrade CurveSplit** | 3 | splitByContinuity (3D/2D), convertToBezierSegments (2D) |
 | **ShapeUpgrade SurfaceSplit** | 3 | splitSurfaceByContinuity, splitByAngle, splitByArea |
-| **GeomConvert Recognition** | 5 | curveToAnalytical, arePointsLinear, surfToAnalyticalWithGap, surfToAnalyticalBounded, isCanonical |
+| **GeomConvert Recognition** | 6 | curveToAnalytical, curveToAnalyticalWithGap, arePointsLinear, surfToAnalyticalWithGap, surfToAnalyticalBounded, isCanonical |
 | **Geom2dConvert** | 1 | approxArcsAndSegments (approximate 2D curves as arcs/lines) |
 | **Poly_Polygon2D** | 5 | create, nodeCount, node, nodes, deflection |
 | **Poly_Polygon3D** | 8 | create, createWithParams, nodeCount, node, nodes, hasParameters, parameter, deflection |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,273** | |
+| **Total** | **4,274** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -846,10 +846,19 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `surface.intersections(with: otherSurface)` | `GeomAPI_IntSS` |
 
 #### Analytical Recognition (v0.30.0)
+
+Every `GeomConvert_CurveToAnaCurve` / `GeomConvert_SurfToAnaSurf` spelling reaches one bridge entry
+point per class (#492). An already-analytical input converts, with `gap == 0`; the result never
+aliases the input.
+
 | Swift API | OCCT Class |
 |-----------|------------|
 | `curve.toAnalytical(tolerance:)` | `GeomConvert_CurveToAnaCurve` |
+| `curve.toAnalytical(tolerance:first:last:)` | `GeomConvert_CurveToAnaCurve` |
+| `curve.toAnalyticalWithGap(tolerance:)` | `GeomConvert_CurveToAnaCurve` |
 | `surface.toAnalytical(tolerance:)` | `GeomConvert_SurfToAnaSurf` |
+| `surface.toAnalyticalWithGap(tolerance:)` | `GeomConvert_SurfToAnaSurf` |
+| `surface.toAnalyticalWithGap(tolerance:uMin:uMax:vMin:vMax:)` | `GeomConvert_SurfToAnaSurf` (bounded) |
 | `shape.recognizeCanonical(tolerance:)` | `ShapeAnalysis_CanonicalRecognition` |
 
 #### Shape Census & Edge Analysis (v0.30.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,45 @@ symbol references name symbols that exist nowhere in `Sources/`**. Filed as #510
 here — each stale entry needs its real call site identified, and inventing a plausible name for a
 class that has no wrap would be worse than leaving the entry visibly broken.
 
+#### Analytical conversion: one path per converter class, and the result no longer aliases its input (#492)
+
+`GeomConvert_CurveToAnaCurve` and `GeomConvert_SurfToAnaSurf` each had two wrapper families, added
+eight releases apart, making the identical OCCT call and then disagreeing about the answer. The
+v0.30.0 curve wrapper hardcoded the curve's own parameter range and discarded `newFirst`/`newLast`/
+`Gap()`; the v0.30.0 surface wrapper carried an "already analytical" guard its v0.78 sibling never
+grew. Five bridge functions now reach two shared helpers, `occtCurveToAnalytical` and
+`occtSurfaceToAnalytical` (`OCCTBridge_Internal.h`), and `OCCTCurve3DToAnalytical` /
+`OCCTSurfaceToAnalytical` are gone.
+
+**The behaviour fix, which the issue did not predict.** Probing both converters against the pinned
+kernel showed they do opposite things with an already-analytical input, and only one wrapper family
+had been written for either. `GeomConvert_SurfToAnaSurf` always allocates
+(`GeomConvert_SurfToAnaSurf.cxx:791-807`), so the surface guard was dead code. But
+`GeomConvert_CurveToAnaCurve` returns **the input handle itself** — `ComputeLine` and `ComputeCircle`
+down-cast the input and return it — and for a `Geom_TrimmedCurve` it returns the basis curve the trim
+still holds. Both curve wrappers handed that shared curve to Swift as a separate `Curve3D`, so the
+two aliased one `Geom_Curve` and `Curve3D.translate` is in-place: translating the result of
+`Curve3D.circle(...).toAnalytical()` by 100 moved the source circle by exactly 100. Both helpers now
+detach the result with `Copy()`, so the guarantee holds for both classes rather than depending on
+which branch of which kernel version happens to allocate. The results are line/circle/ellipse and
+plane/cylinder/cone/sphere/torus, so the copy costs nothing.
+
+The contract is now stated once and identical on both sides: an already-analytical input **converts**
+(`gap == 0` exactly) rather than being rejected, the result is independent of the input, and null
+input, unrecognisable input and OCCT's own throw (the bounded overload raises
+`Geom_BSplineSurface::Segment` on inverted UV bounds) are one failure outcome.
+
+New: `Curve3D.toAnalyticalWithGap(tolerance:)`, the full-range curve spelling that reports the gap —
+the counterpart of `Surface.toAnalyticalWithGap(tolerance:)`, previously missing, which is why
+getting a curve's gap meant switching wrapper families. No other public Swift signature changed.
+
+New `AnalyticalConversionContractTests` (`Tests/OCCTCurveTests`) pins all of it: 12 tests, of which
+the two aliasing cases fail by exactly 100.0 against the pre-#492 bridge. It also gives
+`toAnalyticalWithGap(tolerance:uMin:uMax:vMin:vMax:)` its first coverage of any kind. Probe and
+writeup: [`Scripts/repro/492-analytical-conversion/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/492-analytical-conversion).
+`GeomConvert_CurveToAnaCurve` and `GeomConvert_SurfToAnaSurf` also gained the cross-reference index
+entries they never had.
+
 #### The 2D conic factories reject degenerate dimensions, like their siblings already did (#487)
 
 **Behaviour change.** `Curve2D.ellipseFromCenterDir`, `Curve2D.hyperbolaFromCenterDir` and

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -896,6 +896,15 @@ public func splitByArea(parts: Int, intoSquares: Bool = false) -> SplitResult?
 
 Types and extensions for recognising and converting geometry to analytical (canonical) forms.
 
+Every spelling below reaches one bridge entry point per OCCT converter class, and they share one
+contract (#492):
+
+- **An already-analytical input converts.** A circle recognised as a circle is a success, not a
+  rejection, and reports `gap == 0` exactly. That is how you tell it apart from a fit.
+- **The result is independent of the input.** No returned curve or surface shares state with the
+  geometry it was recognised from, so an in-place transform on one never moves the other.
+- **Failure is one outcome.** An unrecognisable input, and bounds OCCT rejects, both return `nil`.
+
 ### `CurveToAnalyticalResult`
 
 Result of converting a 3D curve to its analytical form.
@@ -910,12 +919,61 @@ public struct CurveToAnalyticalResult: Sendable {
 ```
 
 `gap` is the maximum deviation between the original and the recognized analytical curve.
+`newFirst`/`newLast` are expressed in the **recognised** curve's own parameterisation, not the
+input's: a BSpline circle examined over `[π/2, 3π/2]` reports a range starting at 0 on the
+`Geom_Circle` it returns.
+
+---
+
+### `Curve3D.toAnalytical(tolerance:)`
+
+Attempts to convert this curve to an analytical form over its whole domain.
+
+```swift
+public func toAnalytical(tolerance: Double = 1e-4) -> Curve3D?
+```
+
+- **Parameters:** `tolerance` — recognition tolerance.
+- **Returns:** The recognised curve, or `nil` if no analytical form is recognised.
+- **OCCT:** `GeomConvert_CurveToAnaCurve` via `OCCTGeomConvertCurveToAnalytical`.
+- **Example:**
+  ```swift
+  let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+  if let analytical = circle.toBSpline()?.toAnalytical(tolerance: 1e-4) {
+      print(analytical.curveKind)   // .circle
+  }
+  ```
+
+---
+
+### `Curve3D.toAnalyticalWithGap(tolerance:)`
+
+Attempts to convert this curve to an analytical form over its whole domain, reporting the deviation.
+The full-range spelling of `toAnalytical(tolerance:first:last:)`, and the curve counterpart of
+`Surface.toAnalyticalWithGap(tolerance:)`.
+
+```swift
+public func toAnalyticalWithGap(tolerance: Double = 1e-4) -> CurveToAnalyticalResult?
+```
+
+- **Parameters:** `tolerance` — recognition tolerance.
+- **Returns:** `CurveToAnalyticalResult` with the recognised curve, its range and the gap, or `nil`.
+- **OCCT:** `GeomConvert_CurveToAnaCurve` via `OCCTGeomConvertCurveToAnalytical`.
+- **Example:**
+  ```swift
+  let bspline = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!.toBSpline()!
+  if let r = bspline.toAnalyticalWithGap(tolerance: 1e-4) {
+      print(r.gap)   // how far the BSpline strayed from the circle
+  }
+  ```
 
 ---
 
 ### `Curve3D.toAnalytical(tolerance:first:last:)`
 
-Attempts to convert this curve to an analytical form (line, circle, ellipse, etc.).
+Attempts to convert this curve to an analytical form (line, circle, ellipse, etc.) over a chosen
+parameter range, so a curve that is a circle along part of its domain can be recognised there even
+when the whole domain is not.
 
 ```swift
 public func toAnalytical(tolerance: Double, first: Double, last: Double) -> CurveToAnalyticalResult?
@@ -998,8 +1056,17 @@ public func toAnalyticalWithGap(tolerance: Double,
 ```
 
 - **Parameters:** `tolerance` — recognition tolerance; `uMin`, `uMax`, `vMin`, `vMax` — UV parameter bounds to consider.
-- **Returns:** `SurfaceToAnalyticalResult`, or `nil` on failure.
+- **Returns:** `SurfaceToAnalyticalResult`, or `nil` on failure. Inverted bounds (`uMin > uMax`) are rejected rather than normalised.
 - **OCCT:** `GeomConvert_SurfToAnaSurf` (bounded variant) via `OCCTGeomConvertSurfToAnalyticalBounded`.
+- **Example:**
+  ```swift
+  let d = bsplineSurface.domain
+  if let r = bsplineSurface.toAnalyticalWithGap(tolerance: 1e-4,
+                                                uMin: d.uMin, uMax: (d.uMin + d.uMax) / 2,
+                                                vMin: d.vMin, vMax: d.vMax) {
+      print(r.surface.surfaceKind)
+  }
+  ```
 
 ---
 


### PR DESCRIPTION
Closes #492. Targets `refactor/381-pass1b`, per #492's own branch rule (Pass 1b of #377).

## What changed

**Five bridge functions reach two shared helpers.** `occtCurveToAnalytical` and
`occtSurfaceToAnalytical` (`OCCTBridge_Internal.h`, the established cross-TU helper home) are now the
single path behind every `GeomConvert_CurveToAnaCurve` / `GeomConvert_SurfToAnaSurf` entry point.
`OCCTCurve3DToAnalytical` and `OCCTSurfaceToAnalytical` (the v0.30.0 copies) are deleted — a free
move, since `OCCTBridge` is not an SPM product, so no consumer reaches those C symbols.

**The behaviour fix, which the issue did not predict.** #492 flagged the surface wrapper's
`if (result == surface->surface) return nullptr` guard as dead code built on a false premise, and
worried that the v0.78 copy lacking it *could* diverge if a future kernel ever returned the input
handle. Probing both converters (`Scripts/repro/492-analytical-conversion/`) showed the two classes
do opposite things, and the guard had been written for the wrong one:

| | already-analytical input |
|---|---|
| `GeomConvert_SurfToAnaSurf` | always allocates (`GeomConvert_SurfToAnaSurf.cxx:791-807`) — guard is dead, confirmed for plane, cylinder, sphere, trimmed, offset, BSpline |
| `GeomConvert_CurveToAnaCurve` | **returns the input handle itself** — `ComputeLine` (`:186`) and `ComputeCircle` (`:296`) down-cast the input and return it; a `Geom_TrimmedCurve` yields the basis curve the trim still holds |

Neither curve wrapper had a guard, so both handed that shared curve to Swift as a separate `Curve3D`.
`Curve3D.translate` is in-place, so the aliasing is observable through the public API: translating the
result of `Curve3D.circle(...).toAnalytical()` by 100 moves the source circle by exactly 100.

Both helpers now detach the result with `Copy()`. The surface side does not need it against this
kernel; it is there anyway, because "the current kernel happens to allocate" is exactly the
assumption that let the two families drift apart. Results are line/circle/ellipse and
plane/cylinder/cone/sphere/torus, so the copy costs nothing.

**One contract, stated once, identical on both sides.** An already-analytical input *converts*
(`gap == 0` exactly) rather than being rejected — the old comment claimed the opposite and was wrong
twice over. The result is independent of the input. Null input, unrecognisable input and OCCT's own
throw (the bounded overload raises `Geom_BSplineSurface::Segment` on inverted UV bounds) are one
failure outcome. The two `_Nonnull` v0.78 functions also regained the null-ref guard their deleted
v0.30.0 siblings had.

**New: `Curve3D.toAnalyticalWithGap(tolerance:)`.** The full-range curve spelling that reports the
gap, counterpart of `Surface.toAnalyticalWithGap(tolerance:)`. Its absence is why getting a curve's
gap meant switching wrapper families. No other public Swift signature changed; both
`toAnalytical(tolerance:)` convenience methods now forward to the detailed spelling.

**Also:** the duplicated back-to-back `// MARK: - GeomConvert_*` lines in both `.mm` files, and the
cross-reference index entries `GeomConvert_CurveToAnaCurve` / `GeomConvert_SurfToAnaSurf`, which the
index never had — the #484/#489 failure mode where a missing entry hides call sites from any
audit-by-symbol-name.

## Tests

`AnalyticalConversionContractTests` (`Tests/OCCTCurveTests`), 12 tests, written and run against the
**unmodified** bridge first, per the #489 lesson:

- **2 failed pre-fix**, both aliasing cases, by exactly 100.0. They pass now.
- 10 passed pre-fix, which is the useful half of the measurement: `surfaceSpellingsAgree` and
  `alreadyAnalyticalInputsConvert` confirm the issue's item-2 reading — the surface guard is dead
  and the two surface spellings already agreed, so nothing observable changes there.
- `toAnalyticalWithGap(tolerance:uMin:uMax:vMin:vMax:)` gets its first coverage of any kind
  (#492 grepped `Tests/` and found none): full bounds, a sub-range, and inverted bounds.

## Verification

- `swift build`: clean.
- `swift test`: **4678 tests in 1323 suites pass.**
- `Scripts/check-bridge-index.py`: 139 stale, unchanged from the #484 baseline (#510); the two new
  entries resolve.
- `Scripts/count-operations.py --fix`: 4,273 → 4,274, the one net-new public API.
- Repro compiles and runs from its committed path.

## Not changed

- **No xcframework rebuild.** `Sources/OCCTBridge/src/*.mm` changed, which is release-time packaging
  — same as PR #511 and PR #517 on this branch. Note that `OCCTSWIFT_BRIDGE_PREBUILT=1` masks these
  edits entirely; unset it when running tests locally.
- **No kernel patch, nothing filed upstream.** `GeomConvert_CurveToAnaCurve` returning the input
  handle is documented behaviour of a recognition API, not a defect — the wrapper is what owed
  callers an independent object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)