### PR TITLE
fix(#493): make Curve3D.interpolatePeriodic delegate instead of reimplementing

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -4471,20 +4471,15 @@ OCCTCurve3DRef OCCTInterpolateWithParameters(const double* points, int32_t count
     } catch (...) { return nullptr; }
 }
 
+// Exactly OCCTCurve3DInterpolate with the periodicity flag pinned. It used to be a second,
+// independent GeomAPI_Interpolate call site, which had already drifted: it rejected count < 3
+// where the general entry point rejects only count < 2, so the same 2-point input reached OCCT
+// through one and not the other, and it hardcoded the tolerance with no way to reach any other
+// value. Forwarding keeps the C ABI while leaving one implementation (#493, the 3D counterpart of
+// #412's fix on OCCTInterpolate2DPeriodic). Callers that need a tolerance other than the default
+// should call OCCTCurve3DInterpolate directly with closed = true.
 OCCTCurve3DRef OCCTInterpolatePeriodic(const double* points, int32_t count) {
-    if (!points || count < 3) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt) pts = new TColgp_HArray1OfPnt(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt(points[i*3], points[i*3+1], points[i*3+2]));
-        }
-        GeomAPI_Interpolate interp(pts, Standard_True, 1e-6);
-        interp.Perform();
-        if (interp.IsDone()) {
-            return (OCCTCurve3DRef)new OCCTCurve3D{interp.Curve()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+    return OCCTCurve3DInterpolate(points, count, true, 1e-6);
 }
 
 

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1786,13 +1786,32 @@ extension Curve3D {
     }
 
     /// Interpolate a periodic (closed) 3D BSpline through points.
-    public static func interpolatePeriodic(points: [SIMD3<Double>]) -> Curve3D? {
-        var flat = [Double]()
-        for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
-        guard let ref = flat.withUnsafeBufferPointer({ buf in
-            OCCTInterpolatePeriodic(buf.baseAddress!, Int32(points.count))
-        }) else { return nil }
-        return Curve3D(handle: ref)
+    ///
+    /// A spelling of `interpolate(points:closed:tolerance:)` with `closed: true`, and it
+    /// delegates to it: the two cannot produce different curves for the same input.
+    ///
+    /// - Parameters:
+    ///   - points: Points to interpolate. At least 2; the curve closes back to `points[0]`, so
+    ///     do not repeat the first point at the end.
+    ///   - tolerance: Interpolation tolerance. Defaults to `1e-6`, which is what this method used
+    ///     to hardcode with no way to change it (#493).
+    /// - Returns: The periodic curve, or `nil` if interpolation fails.
+    ///
+    /// ```swift
+    /// let loop = Curve3D.interpolatePeriodic(points: [
+    ///     SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(-1, 0, 0), SIMD3(0, -1, 0),
+    /// ])
+    /// #expect(loop?.isPeriodic == true)
+    ///
+    /// // Identical to spelling it out on the general factory:
+    /// let same = Curve3D.interpolate(points: [
+    ///     SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(-1, 0, 0), SIMD3(0, -1, 0),
+    /// ], closed: true)
+    /// #expect(loop?.domain == same?.domain)
+    /// ```
+    public static func interpolatePeriodic(points: [SIMD3<Double>],
+                                           tolerance: Double = 1e-6) -> Curve3D? {
+        interpolate(points: points, closed: true, tolerance: tolerance)
     }
 
     /// Approximate a 3D BSpline through points with degree and continuity control.

--- a/Tests/OCCTCurveTests/Issue493InterpolatePeriodicParityTests.swift
+++ b/Tests/OCCTCurveTests/Issue493InterpolatePeriodicParityTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// MARK: - #493: the two 3D periodic-interpolation entry points
+
+/// The same `GeomAPI_Interpolate` computation is reachable two ways:
+/// `Curve3D.interpolatePeriodic(points:tolerance:)` and
+/// `Curve3D.interpolate(points:closed:tolerance:)` with `closed: true`. They used to be two
+/// independent bridge call sites that had drifted apart in two ways. The periodic one rejected
+/// `count < 3` where the general one rejects only `count < 2`, and it hardcoded tolerance `1e-6`
+/// with no parameter path to reach any other value. This is the 3D counterpart of the 2D parity
+/// suite added for #412 (`Curve2DInterpolatePeriodicParityTests`), which was fixed on its own.
+@Suite("Curve3D periodic interpolation entry points agree (#493)")
+struct Curve3DInterpolatePeriodicParityTests {
+
+    private static let square: [SIMD3<Double>] = [
+        SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0),
+    ]
+
+    private func expectSameCurve(_ a: Curve3D?, _ b: Curve3D?,
+                                 _ comment: Comment? = nil) {
+        #expect(a != nil, comment)
+        #expect(b != nil, comment)
+        guard let a, let b else { return }
+        #expect(a.isClosed == b.isClosed, comment)
+        #expect(a.isPeriodic == b.isPeriodic, comment)
+        #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12, comment)
+        #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12, comment)
+        for t in stride(from: 0.0, through: 1.0, by: 0.1) {
+            let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
+            let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
+            let pa = a.point(at: ua), pb = b.point(at: ub)
+            #expect(abs(pa.x - pb.x) < 1e-9, comment)
+            #expect(abs(pa.y - pb.y) < 1e-9, comment)
+            #expect(abs(pa.z - pb.z) < 1e-9, comment)
+        }
+    }
+
+    @Test("Default tolerance: the two entry points produce the same curve")
+    func defaultToleranceMatches() {
+        expectSameCurve(Curve3D.interpolatePeriodic(points: Self.square),
+                        Curve3D.interpolate(points: Self.square, closed: true))
+    }
+
+    @Test("A non-default tolerance is now reachable through interpolatePeriodic")
+    func customToleranceIsReachable() {
+        for tolerance in [1e-3, 1e-4, 1e-8] {
+            expectSameCurve(Curve3D.interpolatePeriodic(points: Self.square, tolerance: tolerance),
+                            Curve3D.interpolate(points: Self.square, closed: true,
+                                                tolerance: tolerance),
+                            "tolerance=\(tolerance)")
+        }
+    }
+
+    /// The point-count floor the two had drifted apart on. OCCT accepts a 2-point periodic
+    /// interpolation (it produces a valid out-and-back loop), and the general entry point always
+    /// let it through; only the periodic wrapper rejected it at the bridge boundary.
+    @Test("A 2-point periodic interpolation is accepted by both entry points")
+    func twoPointFloorMatches() {
+        let two: [SIMD3<Double>] = [SIMD3(0, 0, 0), SIMD3(10, 0, 0)]
+        let periodic = Curve3D.interpolatePeriodic(points: two)
+        expectSameCurve(periodic, Curve3D.interpolate(points: two, closed: true))
+        if let c = periodic {
+            #expect(c.isClosed)
+            #expect(c.isPeriodic)
+        }
+    }
+
+    @Test("Both entry points reject a single point")
+    func singlePointRejectedByBoth() {
+        let one: [SIMD3<Double>] = [SIMD3(1, 2, 3)]
+        #expect(Curve3D.interpolatePeriodic(points: one) == nil)
+        #expect(Curve3D.interpolate(points: one, closed: true) == nil)
+    }
+
+    /// The tolerance is not merely accepted, it reaches `GeomAPI_Interpolate` and changes the
+    /// outcome: OCCT treats points closer together than the tolerance as coincident and refuses to
+    /// interpolate. With two points 1e-3 apart, the default 1e-6 interpolates and 1e-2 does not:
+    /// a distinction no caller could make before `interpolatePeriodic` gained the parameter.
+    @Test("The tolerance actually reaches OCCT, it is not just accepted and dropped")
+    func toleranceChangesTheOutcome() {
+        let nearCoincident: [SIMD3<Double>] = [
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10.001, 0, 0),
+        ]
+        #expect(Curve3D.interpolatePeriodic(points: nearCoincident) != nil)
+        #expect(Curve3D.interpolatePeriodic(points: nearCoincident, tolerance: 1e-9) != nil)
+        #expect(Curve3D.interpolatePeriodic(points: nearCoincident, tolerance: 1e-2) == nil)
+        // ... and the general entry point draws the line in the same place.
+        #expect(Curve3D.interpolate(points: nearCoincident, closed: true, tolerance: 1e-2) == nil)
+        #expect(Curve3D.interpolate(points: nearCoincident, closed: true, tolerance: 1e-9) != nil)
+    }
+
+    /// A non-planar loop, to make sure the shared path is not accidentally flattening z.
+    @Test("A non-planar loop agrees through both entry points")
+    func nonPlanarLoopMatches() {
+        let helixish: [SIMD3<Double>] = [
+            SIMD3(5, 0, 0), SIMD3(0, 5, 2), SIMD3(-5, 0, 4), SIMD3(0, -5, 2),
+        ]
+        expectSameCurve(Curve3D.interpolatePeriodic(points: helixish, tolerance: 1e-5),
+                        Curve3D.interpolate(points: helixish, closed: true, tolerance: 1e-5))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -550,6 +550,37 @@ in its request set — both entry points must still return the *same* surface th
 excludes it from the "reported error describes the returned surface" assertion, with a comment to
 drop that exclusion when #522 is fixed.
 
+#### `Curve3D.interpolatePeriodic` delegates instead of reimplementing, and gains `tolerance:` (#493)
+
+**Behaviour change.** `Curve3D.interpolatePeriodic(points:)` with exactly 2 points used to return
+`nil`; it now returns a valid out-and-back periodic loop. `OCCTInterpolatePeriodic` was a second,
+independent `GeomAPI_Interpolate` call site alongside `OCCTCurve3DInterpolate`, and the two had
+drifted: the periodic one rejected `count < 3` where the general one rejects only `count < 2`, so
+the same 2-point input reached OCCT through `interpolate(points:closed:tolerance:)` with
+`closed: true` and not through `interpolatePeriodic`. Confirmed by running it, not by inspection: the
+general entry point returns a closed, periodic curve over `0...20` for two points, and OCCT builds it
+without complaint.
+
+This is #412's fix, applied to the 3D sibling it never touched. The 2D pair was fixed in v1.17.0 and
+the 3D pair was left with the defect verbatim, including the fix comment's own description of it.
+`OCCTInterpolatePeriodic` is now `return OCCTCurve3DInterpolate(points, count, true, 1e-6);`. The C
+ABI is unchanged, and `Curve3D.interpolatePeriodic` delegates to
+`interpolate(points:closed:tolerance:)` rather than flattening its own buffer.
+
+Additive: `Curve3D.interpolatePeriodic(points:tolerance:)` gains a `tolerance:` parameter defaulted
+to the `1e-6` it used to hardcode, so the bare call is unchanged. The tolerance was previously
+unreachable, and it is not decorative: OCCT treats points closer together than the tolerance as
+coincident and refuses the interpolation, so with two points `1e-3` apart the default succeeds and
+`tolerance: 1e-2` returns `nil`. That case is now asserted rather than assumed.
+
+New `Curve3DInterpolatePeriodicParityTests` (`Tests/OCCTCurveTests`) ports the 2D suite #427 added
+(default-tolerance parity, tolerance reachability, the 2-point floor, single-point rejection) and
+adds the tolerance-changes-the-outcome case and a non-planar loop, which checks the shared path is
+not flattening z. The 2-point test was run against the unfixed code first and fails there, so it
+covers the defect rather than describing it. The only pre-existing coverage of the 3D function was a
+4-point square asserting `!= nil` (`Tests/OCCTMiscTests`) plus one use as a fixture for an unrelated
+test, which is why the drift survived #412.
+
 ---
 
 ## Release History

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -260,17 +260,20 @@ Controls the parameterization explicitly — each point is placed at the corresp
 
 ---
 
-### `Curve3D.interpolatePeriodic(points:)`
+### `Curve3D.interpolatePeriodic(points:tolerance:)`
 
 Interpolates a periodic (closed) BSpline through the given points.
 
 ```swift
-public static func interpolatePeriodic(points: [SIMD3<Double>]) -> Curve3D?
+public static func interpolatePeriodic(points: [SIMD3<Double>],
+                                       tolerance: Double = 1e-6) -> Curve3D?
 ```
 
 The resulting curve is periodic: it passes through all points and closes smoothly back to the first point without an explicit closing segment. The first and last points need not coincide.
 
-- **Parameters:** `points` — interpolation points (minimum 2, typically 3 or more for a non-degenerate loop).
+A spelling of [`interpolate(points:closed:tolerance:)`](Curve3D.md) with `closed: true`, and it delegates to it: the two cannot produce different curves for the same input. Before #493 it was a second, independent `GeomAPI_Interpolate` call site with the tolerance pinned at `1e-6` and unreachable, and with a stricter minimum point count (3, against the general entry point's 2) that the two had drifted into. This is the same fix #412 applied to `Curve2D.interpolatePeriodic`.
+
+- **Parameters:** `points`, interpolation points (minimum 2, typically 3 or more for a non-degenerate loop); `tolerance`, point coincidence tolerance. Points closer together than this are treated as coincident and the interpolation fails.
 - **Returns:** Periodic interpolated BSpline, or `nil` on failure.
 - **OCCT:** `GeomAPI_Interpolate(pts, Standard_True, tol)` + `Perform()`.
 - **Example:**
@@ -280,6 +283,12 @@ The resulting curve is periodic: it passes through all points and closes smoothl
   ]) {
       #expect(loop.isPeriodic)
   }
+
+  // Identical to spelling it out on the general factory:
+  let same = Curve3D.interpolate(points: [
+      SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(-1, 0, 0), SIMD3(0, -1, 0)
+  ], closed: true)
+  #expect(same?.isPeriodic == true)
   ```
 
 ---

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -420,7 +420,7 @@ public static func interpolate(points: [SIMD3<Double>], closed: Bool = false,
                                tolerance: Double = 1e-6) -> Curve3D?
 ```
 
-Unlike `bspline(poles:…)`, the curve passes exactly through every point. Use `closed: true` for a periodic loop.
+Unlike `bspline(poles:…)`, the curve passes exactly through every point. Use `closed: true` for a periodic loop: [`interpolatePeriodic(points:tolerance:)`](Curve3D-Construction.md) is a spelling of exactly that case and delegates here (#493).
 
 - **Parameters:** `points` — points the curve must pass through (minimum 2); `closed` — closed/periodic curve; `tolerance` — interpolation precision.
 - **Returns:** Interpolated BSpline curve, or `nil` on failure.


### PR DESCRIPTION
Part of Pass 1b of the #381 / #377 duplication audit. Targets `refactor/381-pass1b`, per #493.

## What was wrong

`OCCTInterpolatePeriodic` was a second, independent `GeomAPI_Interpolate` call site alongside `OCCTCurve3DInterpolate`, and the two had drifted in two ways:

1. **Point-count floor.** The periodic one rejected `count < 3`; the general one rejects only `count < 2`. So the same 2-point input reached OCCT through `Curve3D.interpolate(points:closed: true)` and not through `Curve3D.interpolatePeriodic(points:)`.
2. **Tolerance.** The periodic one hardcoded `1e-6` with no parameter path to reach any other value; the general one threads the caller's tolerance.

This is exactly what #412 / PR #427 fixed on the 2D sibling `OCCTInterpolate2DPeriodic`. The 3D counterpart was left with the defect verbatim, including the fix comment's own description of it.

Verified by running it rather than by inspection, before writing any fix:

```
PROBE periodic(2pts) = nil
PROBE general(2pts, closed) = curve
PROBE general isClosed=true isPeriodic=true domain=0.0...20.0
PROBE periodic(1pt) = nil
PROBE general(1pt) = nil
```

## The fix

Mirrors PR #427 exactly:

- `OCCTInterpolatePeriodic` is now `return OCCTCurve3DInterpolate(points, count, true, 1e-6);`. The C ABI is unchanged, so direct `OCCTBridge.h` consumers are unaffected.
- `Curve3D.interpolatePeriodic(points:tolerance:)` delegates to `interpolate(points:closed:tolerance:)` instead of flattening its own buffer, and gains a `tolerance:` parameter defaulted to the `1e-6` it used to hardcode. Additive: the bare call still compiles and behaves identically.

## Behaviour change

| call | before | now |
|---|---|---|
| `Curve3D.interpolatePeriodic(points: [p0, p1])` | `nil` (bridge floor `count < 3`) | a valid out-and-back periodic loop, matching `interpolate(points:closed: true)`, which has always allowed it |

Nothing else changes. 3-or-more-point input is unaffected, and a single point is still rejected by both entry points.

## Tests

New `Curve3DInterpolatePeriodicParityTests` (`Tests/OCCTCurveTests`) ports the four cases PR #427 added for 2D (default-tolerance parity, tolerance reachability, the 2-point floor, single-point rejection) and adds two:

- **The tolerance reaches OCCT and changes the outcome.** The ported reachability test is tautological once both spellings share one path, so this one measures the parameter instead: OCCT treats points closer together than the tolerance as coincident and refuses the interpolation, so with two points `1e-3` apart the default `1e-6` interpolates and `tolerance: 1e-2` returns `nil`. That distinction was unreachable before.
- **A non-planar loop**, which checks the shared path is not flattening z.

The 2-point test was run against the unfixed code first and fails there, so it covers the defect rather than describing it.

The only pre-existing coverage of the 3D function was a 4-point square asserting `!= nil` (`Tests/OCCTMiscTests`) plus one use as a fixture for an unrelated periodic-normalization test, which is why the drift survived #412.

Full `swift test`: **4696 tests, all pass**.

## Docs

- `docs/CHANGELOG.md`: entry under Pass 1b, including the behaviour change.
- `docs/reference/Curve3D-Construction.md`: the `interpolatePeriodic` entry retitled for the new signature, with the delegation and the tolerance semantics stated, plus a snippet showing it against the general factory.
- `docs/reference/Curve3D.md`: the reciprocal pointer on `interpolate(points:closed:tolerance:)`, matching what #412 added on the 2D pages.
- `///` doc comment on `Curve3D.interpolatePeriodic` with a runnable snippet.

Bridge-only and Swift-only: no kernel patch, no xcframework rebuild, nothing filed upstream.

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
