### PR TITLE
okf: keep project Status current, note Linked PRs won't populate off-default-branch

### DIFF
--- a/okf/policies/issue-tracking.md
+++ b/okf/policies/issue-tracking.md
@@ -1,9 +1,9 @@
 ---
 type: policy
 title: Issue labels and project-board tracking
-description: Every issue carries a type:* and priority:* label, enforced by CI; multi-phase initiatives get a dedicated project board. See Issue tracking.
+description: Every issue carries a type:* and priority:* label, enforced by CI; multi-phase initiatives get a dedicated project board kept current at each workflow step. See Issue tracking.
 tags: [policy, issues, labels, project-board, triage]
-timestamp: 2026-07-29
+timestamp: 2026-07-30
 ---
 
 # Issue labels and project-board tracking
@@ -17,6 +17,16 @@ GitHub Project scoped to that initiative's own issues, with a `Status` field mat
 workflow stages (Backlog, In Progress, PR Review, Code-Review, Ready, Done) rather than the generic
 Todo/In Progress/Done default: [OCCTSwift Refactor (#377)](https://github.com/orgs/SecondMouseAU/projects/2).
 `refactor` + `phase:*` labels identify which issues belong to it.
+
+**Update `Status` at the same points the workflow already visits**, not as a separate later pass:
+opening a PR moves the card to `PR Review`, a review landing moves it to `Code-Review`, a merge moves
+it to `Done`. The project's own Workflows panel automates the one transition GitHub can do for you
+("Item closed" / "Pull request merged" → `Done`); turn both on per board.
+
+**`Linked pull requests` will not populate for a PR based on anything but the repo's default branch**,
+including every `refactor/381-pass1b`-targeted PR in this project. That is GitHub platform behaviour,
+not a bug to chase; the issue's own manual close naming the PR (see the repo's release process) is
+the real source of truth for that link until the initiative's branch reaches `main`.
 
 For the full rule and rationale, follow the authoritative **Issue tracking** section in
 [OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md).


### PR DESCRIPTION
Mirrors [ecosystem#27](https://github.com/SecondMouseAU/ecosystem/pull/27)'s addition to
`OKF-STANDARD.md`'s Issue tracking section.

## Why

Six issues (#484-#489) merged and closed against `refactor/381-pass1b` while sitting untouched on
the [OCCTSwift Refactor project board](https://github.com/orgs/SecondMouseAU/projects/2), still
showing `PR Review`/`Code-Review` instead of `Done`. Nothing in the workflow prompted a `Status`
update once the PR merged.

Also, while fixing that board, confirmed via `closingIssuesReferences` on the GraphQL API that
`Linked pull requests` never populates for a PR based on anything but the repo's default branch:
every PR into `refactor/381-pass1b` (#511, #515, #521, each with a correctly-formed `Closes #N`)
returns an empty array, while PRs into `main` populate it normally. Worth documenting so nobody
spends time chasing it as a PR-description bug.

## What changed

- `okf/policies/issue-tracking.md`: added the two points above, pointing to `OKF-STANDARD.md` for
  the full rationale (unchanged pattern for this file).

## Also done as part of this cleanup (not in this diff, GitHub-side only)

- #520 linked as a sub-issue of #381 (had `phase:1b` already, was missing the sub-issue link).
- #522 labelled `refactor` + `phase:backlog` (a #491-adjacent finding, not itself a duplication
  finding, so not `phase:1b`/not a sub-issue of #381 — matches #513's precedent) and added to the
  project board.
- Project board `Status` corrected for #484-#491, #510, #513, #520, #522 to match reality.