### PR TITLE
fix(#495): make the junction analysers report what they measured, and stop reporting what they did not

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,278 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,285 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -18,10 +18,11 @@
 
 // MARK: - Continuity vocabularies
 //
-// Continuity crosses this boundary as a plain integer, and there are exactly three vocabularies
-// it can be speaking. Every declaration below that takes one names which (#490); the decoders
-// live in one place, OCCTBridge_Internal.h, so a value cannot mean different things in different
-// functions the way it did before #490 (see #433 for the bug that shipped from exactly that).
+// Continuity crosses this boundary as a plain integer, and there are exactly three request
+// vocabularies it can be speaking, plus one it is reported back in. Every declaration below that
+// takes or returns one names which (#490/#495); the decoders live in one place,
+// OCCTBridge_Internal.h, so a value cannot mean different things in different functions the way
+// it did before #490 (see #433 for the bug that shipped from exactly that).
 //
 //   Surface continuity — geometric constraint order handed to a plate solver.
 //     0=G0, 1=G1, 2=G2. Swift: `SurfaceContinuity`. Saturates at 2.
@@ -33,8 +34,17 @@
 //     above C2, while the Split*Continuity and PointsToBSpline families take the whole range.
 //
 //   Analysis order — a GeomAbs_Shape class named by its own ordinal.
-//     0=C0, 1=G1, 2=C1, 3=G2, 4=C2. Used in both directions by the LocalAnalysis_* junction
-//     analysers. Saturates at 4: those classes implement no predicate above C2/G2.
+//     0=C0, 1=G1, 2=C1, 3=G2, 4=C2. What the LocalAnalysis_* junction analysers are asked to
+//     check. Saturates at 4: those classes implement no predicate above C2/G2. It selects the
+//     analysis, it is not just a ceiling — each order computes only its own branch (C0; C0+G1;
+//     C0+C1; C0+G1+G2; C0+C1+C2), so a class the order does not cover is never measured and its
+//     predicate answers true from an uninitialised member. occtAnalysisMeasuredMask names the
+//     covered set and the *Flags functions report it. #495.
+//
+//   Measured class — a GeomAbs_Shape ordinal reported back as a *result*, 0=C0, 1=G1, 2=C1,
+//     3=G2, 4=C2, 5=C3, 6=CN. Swift: `ContinuityClass`. The full seven-value form, unlike the
+//     analysis order above, which shares the numbering but stops at 4. Spoken by
+//     OCCTCurve3D/2D/SurfaceGetContinuity (#485) and OCCTBRepLibContinuityOfFaces.
 //
 // MARK: - OCCT Class Cross-Reference Index
 //
@@ -8940,16 +8950,21 @@ OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double p1x, double p1y, d
 /// @param u1 Parameter on first curve
 /// @param curve2 Second curve
 /// @param u2 Parameter on second curve
-/// @param order Requested analysis order: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2
-/// @param outStatus Output: continuity status (0=C0, 1=G1, 2=C1, 3=G2, 4=C2)
+/// @param order Analysis order — see "Continuity vocabularies" at the top of this header.
+///   Selects which predicates get computed, so it is not merely a strictness ceiling: an order
+///   the caller does not ask for is never measured (#495).
+/// @param outStatus Output: the *effective* analysis order, i.e. `order` after saturation.
+///   `LocalAnalysis_*::ContinuityStatus()` returns the order it was constructed with verbatim,
+///   so this is the request echoed back and never a measurement — the measurement is the flags
+///   bitmask below.
 /// @param outC0Value Output: C0 distance
-/// @param outG1Angle Output: G1 angle (radians)
-/// @param outC1Angle Output: C1 angle
-/// @param outC1Ratio Output: C1 ratio
-/// @param outC2Angle Output: C2 angle
-/// @param outC2Ratio Output: C2 ratio
-/// @param outG2Angle Output: G2 angle
-/// @param outG2CurvatureVariation Output: G2 curvature variation
+/// @param outG1Angle Output: G1 angle (radians), or -1 if not measured at this order or not met
+/// @param outC1Angle Output: C1 angle, or -1
+/// @param outC1Ratio Output: C1 ratio, or -1
+/// @param outC2Angle Output: C2 angle, or -1
+/// @param outC2Ratio Output: C2 ratio, or -1
+/// @param outG2Angle Output: G2 angle, or -1
+/// @param outG2CurvatureVariation Output: G2 curvature variation, or -1
 /// @return true if analysis succeeded
 bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
     OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order,
@@ -8960,9 +8975,15 @@ bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
     double* _Nonnull outG2Angle, double* _Nonnull outG2CurvatureVariation);
 
 /// Check boolean continuity flags for curve continuity analysis.
-/// @return Bitmask: bit 0=IsC0, bit 1=IsG1, bit 2=IsC1, bit 3=IsG2, bit 4=IsC2
+/// @param outMeasured Output: bitmask of the classes this order actually measured. Only the
+///   requested order's branch is computed; an unmeasured predicate reads a zero-initialised
+///   member and answers true regardless of the geometry, so the returned flags are masked to
+///   this set and a caller must consult it to tell "false" from "never asked" (#495).
+/// @return Bitmask: bit 0=IsC0, bit 1=IsG1, bit 2=IsC1, bit 3=IsG2, bit 4=IsC2, masked to
+///   `outMeasured`
 int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, double u1,
-    OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order);
+    OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order,
+    int32_t* _Nonnull outMeasured);
 
 // --- LocalAnalysis_SurfaceContinuity ---
 
@@ -8973,12 +8994,14 @@ int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, do
 /// @param surface2 Second surface
 /// @param u2 U parameter on second surface
 /// @param v2 V parameter on second surface
-/// @param order Requested analysis order: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2
-/// @param outStatus Output: continuity status
+/// @param order Analysis order — same vocabulary and same measured-set semantics as
+///   OCCTLocalAnalysisCurveContinuity above.
+/// @param outStatus Output: the *effective* analysis order (the request after saturation, echoed
+///   back by `ContinuityStatus()`), never a measurement.
 /// @param outC0Value Output: C0 distance
-/// @param outG1Angle Output: G1 angle
-/// @param outC1UAngle Output: C1 U angle
-/// @param outC1VAngle Output: C1 V angle
+/// @param outG1Angle Output: G1 angle, or -1 if not measured at this order or not met
+/// @param outC1UAngle Output: C1 U angle, or -1
+/// @param outC1VAngle Output: C1 V angle, or -1
 /// @return true if analysis succeeded
 bool OCCTLocalAnalysisSurfaceContinuity(OCCTSurfaceRef _Nonnull surface1, double u1, double v1,
     OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order,
@@ -8987,9 +9010,13 @@ bool OCCTLocalAnalysisSurfaceContinuity(OCCTSurfaceRef _Nonnull surface1, double
     double* _Nonnull outC1UAngle, double* _Nonnull outC1VAngle);
 
 /// Check boolean continuity flags for surface continuity analysis.
-/// @return Bitmask: bit 0=IsC0, bit 1=IsG1, bit 2=IsC1, bit 3=IsG2, bit 4=IsC2
+/// @param outMeasured Output: bitmask of the classes this order actually measured — see
+///   OCCTLocalAnalysisCurveContinuityFlags for why the caller needs it.
+/// @return Bitmask: bit 0=IsC0, bit 1=IsG1, bit 2=IsC1, bit 3=IsG2, bit 4=IsC2, masked to
+///   `outMeasured`
 int32_t OCCTLocalAnalysisSurfaceContinuityFlags(OCCTSurfaceRef _Nonnull surface1, double u1, double v1,
-    OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order);
+    OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order,
+    int32_t* _Nonnull outMeasured);
 
 // --- TopTrans_SurfaceTransition ---
 
@@ -18853,7 +18880,13 @@ bool OCCTBRepLibEnsureNormalConsistency(OCCTShapeRef _Nonnull shape, double maxA
 void OCCTBRepLibUpdateDeflection(OCCTShapeRef _Nonnull shape);
 
 /// Get the continuity of the surface across an edge between two faces.
-/// Returns GeomAbs_Shape: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=CN, -1=error.
+/// Returns a raw GeomAbs_Shape ordinal — the measured-class vocabulary, so 0=C0, 1=G1, 2=C1,
+/// 3=G2, 4=C2, 6=CN, and -1 for a null argument or a throw. Six of the seven ordinals are
+/// reachable: `BRepLib::ContinuityOfFaces` never returns C3 (5), and CN is 6, not 5 — a seam
+/// edge on an elementary surface takes an early `return GeomAbs_CN`, and so does any elementary
+/// pair that measures C2. (This comment used to say "5=CN", which is neither the ordinal of CN
+/// nor a value this function can return; the implementation casts the enum straight through, so
+/// there was never a lookup table for it to be describing. #495.)
 int32_t OCCTBRepLibContinuityOfFaces(OCCTShapeRef _Nonnull edge,
                                       OCCTShapeRef _Nonnull face1, OCCTShapeRef _Nonnull face2,
                                       double tolerance);

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1570,13 +1570,18 @@ OCCTShapeRef _Nullable OCCTApproxCurvilinearParameter(OCCTShapeRef edgeShape,
 // MARK: - LocalAnalysis_CurveContinuity (v0.67)
 // --- LocalAnalysis_CurveContinuity ---
 
-// The order in and the status out are both GeomAbs_Shape ordinals; occtGeomAbsFromAnalysisOrder /
-// occtAnalysisOrderFromGeomAbs (OCCTBridge_Internal.h) are the shared pair. #490 retired the
-// local orderToShape/shapeToOrder copies here and the identical pair in OCCTBridge_Surface.mm.
+// The order in and the effective order out are both GeomAbs_Shape ordinals;
+// occtGeomAbsFromAnalysisOrder / occtAnalysisOrderFromGeomAbs (OCCTBridge_Internal.h) are the
+// shared pair. #490 retired the local orderToShape/shapeToOrder copies here and the identical
+// pair in OCCTBridge_Surface.mm.
+//
+// Only the requested order's own branch is computed, so every output is gated on
+// occtAnalysisMeasuredMask as well as on the predicate itself — an unmeasured predicate answers
+// true from a zero-initialised member, and its angle/ratio answers 0.0 to match. #495.
 
 bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
     OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order,
-    int32_t* _Nonnull outStatus,
+    int32_t* _Nonnull outEffectiveOrder,
     double* _Nonnull outC0Value, double* _Nonnull outG1Angle,
     double* _Nonnull outC1Angle, double* _Nonnull outC1Ratio,
     double* _Nonnull outC2Angle, double* _Nonnull outC2Ratio,
@@ -1585,29 +1590,40 @@ bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
         auto c1 = (OCCTCurve3D*)curve1;
         auto c2 = (OCCTCurve3D*)curve2;
 
-        LocalAnalysis_CurveContinuity cc(c1->curve, u1, c2->curve, u2, occtGeomAbsFromAnalysisOrder(order));
+        const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
+        const int32_t measured = occtAnalysisMeasuredMask(effective);
+
+        LocalAnalysis_CurveContinuity cc(c1->curve, u1, c2->curve, u2, effective);
         if (!cc.IsDone()) return false;
 
-        *outStatus = occtAnalysisOrderFromGeomAbs(cc.ContinuityStatus());
+        // ContinuityStatus() returns the order the analyser was constructed with, verbatim — it
+        // is the request echoed back, not a measurement. Reported as the *effective* order so a
+        // caller can see where a saturated request landed.
+        *outEffectiveOrder = occtAnalysisOrderFromGeomAbs(cc.ContinuityStatus());
         *outC0Value = cc.C0Value();
-        *outG1Angle = cc.IsG1() ? cc.G1Angle() : -1.0;
-        *outC1Angle = cc.IsC1() ? cc.C1Angle() : -1.0;
-        *outC1Ratio = cc.IsC1() ? cc.C1Ratio() : -1.0;
-        *outC2Angle = cc.IsC2() ? cc.C2Angle() : -1.0;
-        *outC2Ratio = cc.IsC2() ? cc.C2Ratio() : -1.0;
-        *outG2Angle = cc.IsG2() ? cc.G2Angle() : -1.0;
-        *outG2CurvatureVariation = cc.IsG2() ? cc.G2CurvatureVariation() : -1.0;
+        *outG1Angle = ((measured & 0x02) && cc.IsG1()) ? cc.G1Angle() : -1.0;
+        *outC1Angle = ((measured & 0x04) && cc.IsC1()) ? cc.C1Angle() : -1.0;
+        *outC1Ratio = ((measured & 0x04) && cc.IsC1()) ? cc.C1Ratio() : -1.0;
+        *outC2Angle = ((measured & 0x10) && cc.IsC2()) ? cc.C2Angle() : -1.0;
+        *outC2Ratio = ((measured & 0x10) && cc.IsC2()) ? cc.C2Ratio() : -1.0;
+        *outG2Angle = ((measured & 0x08) && cc.IsG2()) ? cc.G2Angle() : -1.0;
+        *outG2CurvatureVariation = ((measured & 0x08) && cc.IsG2()) ? cc.G2CurvatureVariation() : -1.0;
         return true;
     } catch (...) { return false; }
 }
 
 int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, double u1,
-    OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order) {
+    OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order,
+    int32_t* _Nonnull outMeasured) {
+    *outMeasured = 0;
     try {
         auto c1 = (OCCTCurve3D*)curve1;
         auto c2 = (OCCTCurve3D*)curve2;
 
-        LocalAnalysis_CurveContinuity cc(c1->curve, u1, c2->curve, u2, occtGeomAbsFromAnalysisOrder(order));
+        const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
+        const int32_t measured = occtAnalysisMeasuredMask(effective);
+
+        LocalAnalysis_CurveContinuity cc(c1->curve, u1, c2->curve, u2, effective);
         if (!cc.IsDone()) return 0;
 
         int32_t flags = 0;
@@ -1616,7 +1632,8 @@ int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, do
         if (cc.IsC1()) flags |= 4;
         if (cc.IsG2()) flags |= 8;
         if (cc.IsC2()) flags |= 16;
-        return flags;
+        *outMeasured = measured;
+        return flags & measured;
     } catch (...) { return 0; }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -399,6 +399,32 @@ inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape) {
     }
 }
 
+// Which of the five analysis predicates an analysis order actually computes. Bit layout matches
+// the OCCTLocalAnalysis*ContinuityFlags bitmask: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2.
+//
+// LocalAnalysis_CurveContinuity and LocalAnalysis_SurfaceContinuity run exactly one branch of a
+// switch on the order they were constructed with, and only that branch's quantities are ever
+// computed. Every other predicate then reads a member still at its 0.0 initialiser and compares
+// it against a tolerance, so its Is*() returns true whatever the geometry does: a sharp
+// 90-degree corner analysed at order C0 reports IsC2() == true, and C2Angle() answers 0.0 (a
+// perfect match) to go with it. The five branches are cumulative only along their own ladder,
+// and no order computes all five — not even the C2 default, which never touches G1 or G2.
+//
+// Callers mask against this so an unmeasured class is reported as "not asked" rather than as a
+// false positive. #495; OCCT's own header says as much ("the constructor computes the quantities
+// which are necessary to check the continuity in the following cases"), just not in a form any
+// caller can act on.
+inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order) {
+    switch (order) {
+        case GeomAbs_C0: return 0x01;                      // C0
+        case GeomAbs_G1: return 0x01 | 0x02;               // C0, G1
+        case GeomAbs_C1: return 0x01 | 0x04;               // C0, C1
+        case GeomAbs_G2: return 0x01 | 0x02 | 0x08;        // C0, G1, G2
+        case GeomAbs_C2: return 0x01 | 0x04 | 0x10;        // C0, C1, C2
+        default:         return 0x01;                      // unreachable: the order saturates
+    }
+}
+
 // === #430/#432/#434: surface-filling helpers ===
 //
 // Shared by both filling entry points — OCCTShapeFill* (OCCTBridge_Healing.mm) and OCCTFilling*

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -2450,41 +2450,50 @@ OCCTShapeRef _Nullable OCCTAdaptor3dIsoCurveEdge(OCCTShapeRef faceShape, int iso
 }
 
 // MARK: - LocalAnalysis_SurfaceContinuity (v0.67)
-// Order in / status out are GeomAbs_Shape ordinals — the same shared pair the curve analyser in
-// OCCTBridge_Curve3D.mm uses; see occtGeomAbsFromAnalysisOrder in OCCTBridge_Internal.h (#490).
+// Order in / effective order out are GeomAbs_Shape ordinals — the same shared pair the curve
+// analyser in OCCTBridge_Curve3D.mm uses; see occtGeomAbsFromAnalysisOrder in
+// OCCTBridge_Internal.h (#490). Outputs are gated on occtAnalysisMeasuredMask for the same
+// reason they are there: only the requested order's branch is ever computed (#495).
 
 // --- LocalAnalysis_SurfaceContinuity ---
 
 bool OCCTLocalAnalysisSurfaceContinuity(OCCTSurfaceRef _Nonnull surface1, double u1, double v1,
     OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order,
-    int32_t* _Nonnull outStatus,
+    int32_t* _Nonnull outEffectiveOrder,
     double* _Nonnull outC0Value, double* _Nonnull outG1Angle,
     double* _Nonnull outC1UAngle, double* _Nonnull outC1VAngle) {
     try {
         auto s1 = (OCCTSurface*)surface1;
         auto s2 = (OCCTSurface*)surface2;
 
-        LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2,
-                                            occtGeomAbsFromAnalysisOrder(order));
+        const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
+        const int32_t measured = occtAnalysisMeasuredMask(effective);
+
+        LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2, effective);
         if (!sc.IsDone()) return false;
 
-        *outStatus = occtAnalysisOrderFromGeomAbs(sc.ContinuityStatus());
+        // The request echoed back, same as the curve analyser — see the note there.
+        *outEffectiveOrder = occtAnalysisOrderFromGeomAbs(sc.ContinuityStatus());
         *outC0Value = sc.C0Value();
-        *outG1Angle = sc.IsG1() ? sc.G1Angle() : -1.0;
-        *outC1UAngle = sc.IsC1() ? sc.C1UAngle() : -1.0;
-        *outC1VAngle = sc.IsC1() ? sc.C1VAngle() : -1.0;
+        *outG1Angle = ((measured & 0x02) && sc.IsG1()) ? sc.G1Angle() : -1.0;
+        *outC1UAngle = ((measured & 0x04) && sc.IsC1()) ? sc.C1UAngle() : -1.0;
+        *outC1VAngle = ((measured & 0x04) && sc.IsC1()) ? sc.C1VAngle() : -1.0;
         return true;
     } catch (...) { return false; }
 }
 
 int32_t OCCTLocalAnalysisSurfaceContinuityFlags(OCCTSurfaceRef _Nonnull surface1, double u1, double v1,
-    OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order) {
+    OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order,
+    int32_t* _Nonnull outMeasured) {
+    *outMeasured = 0;
     try {
         auto s1 = (OCCTSurface*)surface1;
         auto s2 = (OCCTSurface*)surface2;
 
-        LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2,
-                                            occtGeomAbsFromAnalysisOrder(order));
+        const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
+        const int32_t measured = occtAnalysisMeasuredMask(effective);
+
+        LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2, effective);
         if (!sc.IsDone()) return 0;
 
         int32_t flags = 0;
@@ -2493,7 +2502,8 @@ int32_t OCCTLocalAnalysisSurfaceContinuityFlags(OCCTSurfaceRef _Nonnull surface1
         if (sc.IsC1()) flags |= 4;
         if (sc.IsG2()) flags |= 8;
         if (sc.IsC2()) flags |= 16;
-        return flags;
+        *outMeasured = measured;
+        return flags & measured;
     } catch (...) { return 0; }
 }
 

--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -256,3 +256,17 @@ extension ContinuityClass {
         return order >= Int(required.rawValue)
     }
 }
+
+extension ContinuityClass {
+    /// The bit this class occupies in the bridge's junction-analysis bitmasks.
+    ///
+    /// The bridge numbers those bits by `GeomAbs_Shape` ordinal — bit 0 is C0, bit 1 is G1, and
+    /// so on — which is this enum's own raw value, so the two need no lookup table between them.
+    /// ``c3`` and ``cN`` have bits here for completeness; `LocalAnalysis_*` never sets them.
+    var analysisFlagBit: Int { 1 << Int(rawValue) }
+
+    /// Decode one of those bitmasks back into the classes it names.
+    static func set(fromAnalysisMask mask: Int32) -> Set<ContinuityClass> {
+        Set(allCases.filter { Int(mask) & $0.analysisFlagBit != 0 })
+    }
+}

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1128,65 +1128,134 @@ extension Curve3D {
 
     /// Result of curve continuity analysis at a junction point.
     public struct ContinuityAnalysis: Sendable {
-        /// Continuity status as GeomAbs_Shape value (0=C0, 1=G1, 2=C1, 3=G2, 4=C2)
-        public let status: Int
+        /// The order the junction was actually analysed at: the requested ``ContinuityClass``
+        /// after saturation at ``ContinuityClass/c2``.
+        ///
+        /// This is the request, not a finding. `LocalAnalysis_CurveContinuity::ContinuityStatus()`
+        /// returns the order it was constructed with verbatim, so the only thing it can tell you
+        /// is where a saturated request landed. The findings are ``measured`` and ``holds(_:)``.
+        public let order: ContinuityClass
+        /// The continuity classes this ``order`` actually measured.
+        ///
+        /// Each order computes only its own branch — `.c0` measures C0; `.g1` measures C0 and G1;
+        /// `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2.
+        /// No order measures all five, not even the `.c2` default, which never looks at G1 or G2.
+        public let measured: Set<ContinuityClass>
         /// Distance between curve endpoints at junction
         public let c0Value: Double
-        /// Angle between tangents (radians)
+        /// Angle between tangents (radians), or -1 if G1 was not measured or does not hold
         public let g1Angle: Double
-        /// Angle between first derivatives
+        /// Angle between first derivatives, or -1
         public let c1Angle: Double
-        /// Ratio of first derivative magnitudes
+        /// Ratio of first derivative magnitudes, or -1
         public let c1Ratio: Double
-        /// Angle between second derivatives
+        /// Angle between second derivatives, or -1
         public let c2Angle: Double
-        /// Ratio of second derivative magnitudes
+        /// Ratio of second derivative magnitudes, or -1
         public let c2Ratio: Double
-        /// Angle between osculating planes
+        /// Angle between osculating planes, or -1
         public let g2Angle: Double
-        /// Variation of curvature at junction
+        /// Variation of curvature at junction, or -1
         public let g2CurvatureVariation: Double
-        /// Bitmask: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2
+        /// Bitmask of the classes that hold: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2.
+        ///
+        /// Only ever sets bits for classes in ``measured``, so a clear bit means "does not hold
+        /// *or* was not measured". Prefer ``holds(_:)``, which separates the two.
         public let flags: Int
 
-        /// Whether the junction is positionally continuous (C0)
-        public var isC0: Bool { flags & 1 != 0 }
-        /// Whether the junction is geometrically tangent-continuous (G1)
-        public var isG1: Bool { flags & 2 != 0 }
-        /// Whether the junction is parametrically tangent-continuous (C1)
-        public var isC1: Bool { flags & 4 != 0 }
-        /// Whether the junction is geometrically curvature-continuous (G2)
-        public var isG2: Bool { flags & 8 != 0 }
-        /// Whether the junction is parametrically curvature-continuous (C2)
-        public var isC2: Bool { flags & 16 != 0 }
+        /// Whether `continuity` holds at the junction, or `nil` if this ``order`` never measured
+        /// it.
+        ///
+        /// ```swift
+        /// let a = corner.continuityWith(other, u1: e1, u2: s2, order: .c1)!
+        /// a.holds(.c1)   // false — measured, and the junction is not C1
+        /// a.holds(.g1)   // nil   — order .c1 never computes G1
+        /// ```
+        public func holds(_ continuity: ContinuityClass) -> Bool? {
+            guard measured.contains(continuity) else { return nil }
+            return flags & continuity.analysisFlagBit != 0
+        }
+
+        /// Whether the junction is positionally continuous (C0). Always measured.
+        public var isC0: Bool? { holds(.c0) }
+        /// Whether the junction is geometrically tangent-continuous (G1), or nil if ``order``
+        /// did not measure G1 (only `.g1` and `.g2` do).
+        public var isG1: Bool? { holds(.g1) }
+        /// Whether the junction is parametrically tangent-continuous (C1), or nil if ``order``
+        /// did not measure C1 (only `.c1` and `.c2` do).
+        public var isC1: Bool? { holds(.c1) }
+        /// Whether the junction is geometrically curvature-continuous (G2), or nil if ``order``
+        /// was not `.g2`.
+        public var isG2: Bool? { holds(.g2) }
+        /// Whether the junction is parametrically curvature-continuous (C2), or nil if ``order``
+        /// was not `.c2`.
+        public var isC2: Bool? { holds(.c2) }
+
+        /// The effective analysis order as a raw `GeomAbs_Shape` ordinal. Former spelling of
+        /// ``order``.
+        ///
+        /// Named as though it reported a measurement; it never did. See ``order``.
+        @available(*, deprecated, renamed: "order")
+        public var status: Int { Int(order.rawValue) }
     }
 
     /// Analyze continuity between this curve at parameter `u1` and another curve at `u2`.
+    ///
+    /// ```swift
+    /// // Is this junction tangent-continuous? Ask for G1 — the .c2 default never measures it.
+    /// let a = leftArc.continuityWith(rightArc, u1: leftArc.domain.upperBound,
+    ///                                u2: rightArc.domain.lowerBound, order: .g1)
+    /// if a?.holds(.g1) == true { print("tangent, angle \(a!.g1Angle)") }
+    /// ```
     ///
     /// - Parameters:
     ///   - u1: Parameter on this curve
     ///   - other: Second curve
     ///   - u2: Parameter on second curve
-    ///   - order: Continuity class to check, as a `GeomAbs_Shape` ordinal (0=C0, 1=G1, 2=C1,
-    ///     3=G2, 4=C2) — the same encoding `ContinuityAnalysis.status` reports back. C2 is the
-    ///     ceiling: `LocalAnalysis_*` implements no predicate above C2/G2, and asking for more
-    ///     leaves every predicate reporting true, so anything above 4 is read as 4.
+    ///   - order: Which continuity class to measure. This selects the analysis, not just a
+    ///     ceiling: `LocalAnalysis_CurveContinuity` computes one branch of a switch, so the
+    ///     classes outside it are never measured and ``ContinuityAnalysis/holds(_:)`` reports
+    ///     `nil` for them. `.c2` is the strictest question the class can answer — it implements
+    ///     no predicate above C2/G2 — so `.c3` and `.cN` saturate to `.c2`, which
+    ///     ``ContinuityAnalysis/order`` reports back.
     /// - Returns: Continuity analysis result, or nil on failure
-    public func continuityWith(_ other: Curve3D, u1: Double, u2: Double, order: Int = 4) -> ContinuityAnalysis? {
-        var outStatus: Int32 = 0
+    public func continuityWith(_ other: Curve3D, u1: Double, u2: Double,
+                               order: ContinuityClass = .c2) -> ContinuityAnalysis? {
+        continuityAnalysis(with: other, u1: u1, u2: u2, rawOrder: order.rawValue)
+    }
+
+    /// Analyze continuity, with the order given as a raw `GeomAbs_Shape` ordinal.
+    ///
+    /// The untyped spelling is what let a caller pass `5`, `-1` or a raw value borrowed from an
+    /// unrelated continuity enum and be clamped without saying so. Pass a ``ContinuityClass``;
+    /// ``ContinuityAnalysis/order`` then reports where a saturated request landed.
+    @available(*, deprecated, message: "Pass a ContinuityClass (.c0/.g1/.c1/.g2/.c2) instead of a raw GeomAbs_Shape ordinal.")
+    public func continuityWith(_ other: Curve3D, u1: Double, u2: Double,
+                               order: Int) -> ContinuityAnalysis? {
+        continuityAnalysis(with: other, u1: u1, u2: u2, rawOrder: Int32(clamping: order))
+    }
+
+    // Both overloads land here, and neither reproduces the saturation rule: the bridge's
+    // occtGeomAbsFromAnalysisOrder owns it and reports the order it settled on.
+    private func continuityAnalysis(with other: Curve3D, u1: Double, u2: Double,
+                                    rawOrder: Int32) -> ContinuityAnalysis? {
+        var outEffectiveOrder: Int32 = 0
         var outC0: Double = 0, outG1: Double = 0
         var outC1A: Double = 0, outC1R: Double = 0
         var outC2A: Double = 0, outC2R: Double = 0
         var outG2A: Double = 0, outG2CV: Double = 0
         let ok = OCCTLocalAnalysisCurveContinuity(
-            handle, u1, other.handle, u2, Int32(order),
-            &outStatus, &outC0, &outG1, &outC1A, &outC1R,
+            handle, u1, other.handle, u2, rawOrder,
+            &outEffectiveOrder, &outC0, &outG1, &outC1A, &outC1R,
             &outC2A, &outC2R, &outG2A, &outG2CV)
         guard ok else { return nil }
+        var outMeasured: Int32 = 0
         let flags = Int(OCCTLocalAnalysisCurveContinuityFlags(
-            handle, u1, other.handle, u2, Int32(order)))
+            handle, u1, other.handle, u2, rawOrder, &outMeasured))
         return ContinuityAnalysis(
-            status: Int(outStatus), c0Value: outC0, g1Angle: outG1,
+            order: ContinuityClass(rawValue: outEffectiveOrder) ?? .c2,
+            measured: ContinuityClass.set(fromAnalysisMask: outMeasured),
+            c0Value: outC0, g1Angle: outG1,
             c1Angle: outC1A, c1Ratio: outC1R,
             c2Angle: outC2A, c2Ratio: outC2R,
             g2Angle: outG2A, g2CurvatureVariation: outG2CV,

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -15475,8 +15475,37 @@ extension Shape {
         OCCTBRepLibUpdateDeflection(handle)
     }
 
-    /// Get the continuity of the surface across an edge between two faces.
-    /// Returns GeomAbs_Shape: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=CN, -1=error.
+    /// The continuity of the surface across an edge between two faces.
+    ///
+    /// A sharp join reports ``ContinuityClass/c0``, a fillet's tangent join
+    /// ``ContinuityClass/g1``, and a seam edge on an elementary surface (a cylinder's or
+    /// sphere's) ``ContinuityClass/cN`` — `BRepLib::ContinuityOfFaces` short-circuits to CN for
+    /// those, and promotes any elementary pair that measures C2 to CN as well. ``ContinuityClass/c3``
+    /// is the one class it never returns.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let faces = box.faces(), edges = box.edges()
+    /// Shape.continuityClassOfFaces(edge: edges[0], face1: faces[0], face2: faces[1])  // .c0
+    /// ```
+    ///
+    /// - Returns: The measured class, or nil if the arguments are not an edge and two faces that
+    ///   share it (OCCT throwing, or a null handle).
+    public static func continuityClassOfFaces(edge: Shape, face1: Shape, face2: Shape,
+                                              tolerance: Double = 1e-6) -> ContinuityClass? {
+        ContinuityClass(rawValue:
+            OCCTBRepLibContinuityOfFaces(edge.handle, face1.handle, face2.handle, tolerance))
+    }
+
+    /// The continuity across an edge, as a raw `GeomAbs_Shape` ordinal (-1 on failure).
+    ///
+    /// This spelling's doc comment claimed `5=CN` for years. It is wrong twice over: CN is
+    /// ordinal 6, and 5 (C3) is a value `BRepLib::ContinuityOfFaces` cannot return at all. The
+    /// function itself was always right — it casts the enum straight through — so a caller who
+    /// matched `5` for "smooth" never matched anything, and one who received `6` had no
+    /// documented meaning for it. ``continuityClassOfFaces(edge:face1:face2:tolerance:)`` returns
+    /// the same measurement as a ``ContinuityClass``, where the ordinals cannot be misread. #495.
+    @available(*, deprecated, renamed: "continuityClassOfFaces(edge:face1:face2:tolerance:)")
     public static func continuityOfFaces(edge: Shape, face1: Shape, face2: Shape,
                                           tolerance: Double = 1e-6) -> Int {
         Int(OCCTBRepLibContinuityOfFaces(edge.handle, face1.handle, face2.handle, tolerance))

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1805,33 +1805,80 @@ extension Surface {
     // MARK: - LocalAnalysis
 
     /// Result of surface continuity analysis at a junction point.
+    ///
+    /// The curve-side twin of this type is ``Curve3D/ContinuityAnalysis``; both wrap a
+    /// `LocalAnalysis_*Continuity` and carry the same measured-set contract.
     public struct ContinuityAnalysis: Sendable {
-        /// Continuity status as GeomAbs_Shape value
-        public let status: Int
+        /// The order the junction was actually analysed at: the requested ``ContinuityClass``
+        /// after saturation at ``ContinuityClass/c2``.
+        ///
+        /// This is the request, not a finding —
+        /// `LocalAnalysis_SurfaceContinuity::ContinuityStatus()` returns the order it was
+        /// constructed with verbatim. The findings are ``measured`` and ``holds(_:)``.
+        public let order: ContinuityClass
+        /// The continuity classes this ``order`` actually measured.
+        ///
+        /// Each order computes only its own branch — `.c0` measures C0; `.g1` measures C0 and G1;
+        /// `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2.
+        /// No order measures all five, not even the `.c2` default, which never looks at G1 or G2.
+        public let measured: Set<ContinuityClass>
         /// Distance between surface points at junction
         public let c0Value: Double
-        /// Angle between normals (radians)
+        /// Angle between normals (radians), or -1 if G1 was not measured or does not hold
         public let g1Angle: Double
-        /// Angle between U-derivatives
+        /// Angle between U-derivatives, or -1
         public let c1UAngle: Double
-        /// Angle between V-derivatives
+        /// Angle between V-derivatives, or -1
         public let c1VAngle: Double
-        /// Bitmask: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2
+        /// Bitmask of the classes that hold: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2.
+        ///
+        /// Only ever sets bits for classes in ``measured``, so a clear bit means "does not hold
+        /// *or* was not measured". Prefer ``holds(_:)``, which separates the two.
         public let flags: Int
 
-        /// Whether the junction is positionally continuous (C0)
-        public var isC0: Bool { flags & 1 != 0 }
-        /// Whether the junction is geometrically tangent-continuous (G1)
-        public var isG1: Bool { flags & 2 != 0 }
-        /// Whether the junction is parametrically tangent-continuous (C1)
-        public var isC1: Bool { flags & 4 != 0 }
-        /// Whether the junction is geometrically curvature-continuous (G2)
-        public var isG2: Bool { flags & 8 != 0 }
-        /// Whether the junction is parametrically curvature-continuous (C2)
-        public var isC2: Bool { flags & 16 != 0 }
+        /// Whether `continuity` holds at the junction, or `nil` if this ``order`` never measured
+        /// it.
+        ///
+        /// ```swift
+        /// let a = plane.continuityWith(cylinder, u1: 0, v1: 0, u2: 0, v2: 0, order: .g2)!
+        /// a.holds(.g2)   // measured — .g2 computes C0, G1 and G2
+        /// a.holds(.c2)   // nil — .g2 never computes C2
+        /// ```
+        public func holds(_ continuity: ContinuityClass) -> Bool? {
+            guard measured.contains(continuity) else { return nil }
+            return flags & continuity.analysisFlagBit != 0
+        }
+
+        /// Whether the junction is positionally continuous (C0). Always measured.
+        public var isC0: Bool? { holds(.c0) }
+        /// Whether the junction is geometrically tangent-continuous (G1), or nil if ``order``
+        /// did not measure G1 (only `.g1` and `.g2` do).
+        public var isG1: Bool? { holds(.g1) }
+        /// Whether the junction is parametrically tangent-continuous (C1), or nil if ``order``
+        /// did not measure C1 (only `.c1` and `.c2` do).
+        public var isC1: Bool? { holds(.c1) }
+        /// Whether the junction is geometrically curvature-continuous (G2), or nil if ``order``
+        /// was not `.g2`.
+        public var isG2: Bool? { holds(.g2) }
+        /// Whether the junction is parametrically curvature-continuous (C2), or nil if ``order``
+        /// was not `.c2`.
+        public var isC2: Bool? { holds(.c2) }
+
+        /// The effective analysis order as a raw `GeomAbs_Shape` ordinal. Former spelling of
+        /// ``order``.
+        ///
+        /// Named as though it reported a measurement; it never did. See ``order``.
+        @available(*, deprecated, renamed: "order")
+        public var status: Int { Int(order.rawValue) }
     }
 
     /// Analyze continuity between this surface at (u1, v1) and another surface at (u2, v2).
+    ///
+    /// ```swift
+    /// // Do these two patches meet tangentially? Ask for G1 — the .c2 default never measures it.
+    /// let a = patchA.continuityWith(patchB, u1: 1, v1: 0.5, u2: 0, v2: 0.5, order: .g1)
+    /// if a?.holds(.g1) == true { print("tangent, normals differ by \(a!.g1Angle) rad") }
+    /// ```
     ///
     /// - Parameters:
     ///   - u1: U parameter on this surface
@@ -1839,23 +1886,47 @@ extension Surface {
     ///   - other: Second surface
     ///   - u2: U parameter on second surface
     ///   - v2: V parameter on second surface
-    ///   - order: Continuity class to check, as a `GeomAbs_Shape` ordinal (0=C0, 1=G1, 2=C1,
-    ///     3=G2, 4=C2) — the same encoding `ContinuityAnalysis.status` reports back. C2 is the
-    ///     ceiling: `LocalAnalysis_*` implements no predicate above C2/G2, and asking for more
-    ///     leaves every predicate reporting true, so anything above 4 is read as 4.
+    ///   - order: Which continuity class to measure. This selects the analysis, not just a
+    ///     ceiling: `LocalAnalysis_SurfaceContinuity` computes one branch of a switch, so the
+    ///     classes outside it are never measured and ``ContinuityAnalysis/holds(_:)`` reports
+    ///     `nil` for them. `.c2` is the strictest question the class can answer, so `.c3` and
+    ///     `.cN` saturate to it, which ``ContinuityAnalysis/order`` reports back.
     /// - Returns: Continuity analysis result, or nil on failure
-    public func continuityWith(_ other: Surface, u1: Double, v1: Double, u2: Double, v2: Double, order: Int = 4) -> ContinuityAnalysis? {
-        var outStatus: Int32 = 0
+    public func continuityWith(_ other: Surface, u1: Double, v1: Double, u2: Double, v2: Double,
+                               order: ContinuityClass = .c2) -> ContinuityAnalysis? {
+        continuityAnalysis(with: other, u1: u1, v1: v1, u2: u2, v2: v2, rawOrder: order.rawValue)
+    }
+
+    /// Analyze continuity, with the order given as a raw `GeomAbs_Shape` ordinal.
+    ///
+    /// The untyped spelling is what let a caller pass `5`, `-1` or a raw value borrowed from an
+    /// unrelated continuity enum and be clamped without saying so. Pass a ``ContinuityClass``;
+    /// ``ContinuityAnalysis/order`` then reports where a saturated request landed.
+    @available(*, deprecated, message: "Pass a ContinuityClass (.c0/.g1/.c1/.g2/.c2) instead of a raw GeomAbs_Shape ordinal.")
+    public func continuityWith(_ other: Surface, u1: Double, v1: Double, u2: Double, v2: Double,
+                               order: Int) -> ContinuityAnalysis? {
+        continuityAnalysis(with: other, u1: u1, v1: v1, u2: u2, v2: v2,
+                           rawOrder: Int32(clamping: order))
+    }
+
+    // Both overloads land here, and neither reproduces the saturation rule: the bridge's
+    // occtGeomAbsFromAnalysisOrder owns it and reports the order it settled on.
+    private func continuityAnalysis(with other: Surface, u1: Double, v1: Double,
+                                    u2: Double, v2: Double, rawOrder: Int32) -> ContinuityAnalysis? {
+        var outEffectiveOrder: Int32 = 0
         var outC0: Double = 0, outG1: Double = 0
         var outC1U: Double = 0, outC1V: Double = 0
         let ok = OCCTLocalAnalysisSurfaceContinuity(
-            handle, u1, v1, other.handle, u2, v2, Int32(order),
-            &outStatus, &outC0, &outG1, &outC1U, &outC1V)
+            handle, u1, v1, other.handle, u2, v2, rawOrder,
+            &outEffectiveOrder, &outC0, &outG1, &outC1U, &outC1V)
         guard ok else { return nil }
+        var outMeasured: Int32 = 0
         let flags = Int(OCCTLocalAnalysisSurfaceContinuityFlags(
-            handle, u1, v1, other.handle, u2, v2, Int32(order)))
+            handle, u1, v1, other.handle, u2, v2, rawOrder, &outMeasured))
         return ContinuityAnalysis(
-            status: Int(outStatus), c0Value: outC0, g1Angle: outG1,
+            order: ContinuityClass(rawValue: outEffectiveOrder) ?? .c2,
+            measured: ContinuityClass.set(fromAnalysisMask: outMeasured),
+            c0Value: outC0, g1Angle: outG1,
             c1UAngle: outC1U, c1VAngle: outC1V, flags: flags)
     }
 

--- a/Tests/OCCTCurveTests/Issue490ContinuityDecoderTests.swift
+++ b/Tests/OCCTCurveTests/Issue490ContinuityDecoderTests.swift
@@ -81,18 +81,18 @@ struct Issue490CurveContinuityTests {
         else { return }
 
         let atC2 = try #require(c1.continuityWith(c2, u1: c1.domain.upperBound,
-                                                  u2: c2.domain.lowerBound, order: 4))
+                                                  u2: c2.domain.lowerBound, order: .c2))
         // LocalAnalysis_CurveContinuity implements no predicate above C2/G2: asking for C3 or CN
         // leaves every predicate reporting true, i.e. the analysis becomes meaningless. So the
         // shared decoder reads anything above 4 as 4 instead of passing it through.
         let beyond = try #require(c1.continuityWith(c2, u1: c1.domain.upperBound,
-                                                    u2: c2.domain.lowerBound, order: 9))
-        #expect(atC2.status == beyond.status)
+                                                    u2: c2.domain.lowerBound, order: .cN))
+        #expect(atC2.order == beyond.order)
+        #expect(atC2.measured == beyond.measured)
         #expect(atC2.flags == beyond.flags)
 
-        // The status comes back in the same ordinal vocabulary the order went in as.
-        #expect(atC2.status >= 0)
-        #expect(atC2.status <= 4)
+        // The effective order comes back in the same ordinal vocabulary the request went in as.
+        #expect(atC2.order == .c2)
     }
 
     @Test("each analysis order below the ceiling asks a different question")
@@ -101,13 +101,15 @@ struct Issue490CurveContinuityTests {
               let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)])
         else { return }
 
-        // 0=C0, 1=G1, 2=C1, 3=G2, 4=C2 — the GeomAbs_Shape ordinals, which is what makes the
-        // reported status directly comparable to the requested order.
-        for order in 0...4 {
+        // The order is echoed back verbatim, so what makes each one a *different question* is the
+        // set of classes it measures — see Issue495CurveAnalysisOrderTests for that half.
+        for order in [ContinuityClass.c0, .g1, .c1, .g2, .c2] {
             let analysis = try #require(c1.continuityWith(c2, u1: c1.domain.upperBound,
                                                           u2: c2.domain.lowerBound, order: order))
-            #expect(analysis.status == order,
+            #expect(analysis.order == order,
                     "order \(order) should be reported back in the same encoding")
+            #expect(analysis.measured.contains(order),
+                    "the requested class is always among the measured ones")
         }
     }
 }

--- a/Tests/OCCTCurveTests/Issue495AnalysisOrderTests.swift
+++ b/Tests/OCCTCurveTests/Issue495AnalysisOrderTests.swift
@@ -1,0 +1,165 @@
+import Testing
+@testable import OCCTSwift
+
+// #495: what LocalAnalysis_CurveContinuity actually measures, and what it only appears to.
+//
+// The analyser runs one branch of a switch on the order it was constructed with, and only that
+// branch's quantities are computed. Every other predicate then compares a member still at its 0.0
+// initialiser against a tolerance and returns true whatever the geometry does — so before this
+// fix a sharp 90-degree corner analysed at order C0 reported isC2 == true, with c2Angle == 0.0 (a
+// perfect match) to go with it. No order covers all five classes: not even the .c2 default, which
+// never looks at G1 or G2, which is why `smoothJunctionIsG1` used to pass without measuring
+// anything.
+//
+// ContinuityStatus() is a separate half of the same problem: it returns the order it was
+// constructed with, verbatim. It was surfaced as `status` and documented as a result.
+
+@Suite("Issue #495: analysis order selects what is measured")
+struct Issue495CurveAnalysisOrderTests {
+
+    /// Two arcs meeting at (5,0,0) at a sharp angle. Only C0 holds.
+    private func sharpCorner() -> (Curve3D, Curve3D)? {
+        guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 0.5, 0), SIMD3(5, 0, 0)]),
+              let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)])
+        else { return nil }
+        return (c1, c2)
+    }
+
+    /// Two arcs meeting smoothly at (5,0,0).
+    private func smoothJunction() -> (Curve3D, Curve3D)? {
+        guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0)]),
+              let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)])
+        else { return nil }
+        return (c1, c2)
+    }
+
+    private func analyse(_ pair: (Curve3D, Curve3D),
+                         _ order: ContinuityClass) -> Curve3D.ContinuityAnalysis? {
+        pair.0.continuityWith(pair.1, u1: pair.0.domain.upperBound,
+                              u2: pair.1.domain.lowerBound, order: order)
+    }
+
+    @Test("each order measures exactly its own branch, and no order measures all five")
+    func measuredSetPerOrder() throws {
+        let pair = try #require(sharpCorner())
+        let expected: [ContinuityClass: Set<ContinuityClass>] = [
+            .c0: [.c0],
+            .g1: [.c0, .g1],
+            .c1: [.c0, .c1],
+            .g2: [.c0, .g1, .g2],
+            .c2: [.c0, .c1, .c2],
+        ]
+        for (order, want) in expected {
+            let a = try #require(analyse(pair, order), "order \(order) should analyse")
+            #expect(a.measured == want, "order \(order) measured \(a.measured)")
+            #expect(a.measured.count < 5, "no order covers all five classes")
+        }
+    }
+
+    @Test("a class the order never computed reports nil, not a false positive")
+    func unmeasuredClassesReportNil() throws {
+        let pair = try #require(sharpCorner())
+
+        // The regression. At order .c0 the analyser computes the C0 distance and nothing else,
+        // so IsG1()/IsC1()/IsG2()/IsC2() all answered true off their 0.0 initialisers.
+        let atC0 = try #require(analyse(pair, .c0))
+        #expect(atC0.holds(.c0) == true)
+        #expect(atC0.holds(.g1) == nil)
+        #expect(atC0.holds(.c1) == nil)
+        #expect(atC0.holds(.g2) == nil)
+        #expect(atC0.holds(.c2) == nil)
+        #expect(atC0.isC2 == nil, "a sharp corner analysed at C0 used to report isC2 == true")
+
+        // The parametric and geometric branches do not cover each other, in either direction.
+        let atC1 = try #require(analyse(pair, .c1))
+        #expect(atC1.holds(.c1) == false, "measured, and the corner is not C1")
+        #expect(atC1.holds(.g1) == nil, "order .c1 never computes G1")
+
+        let atG1 = try #require(analyse(pair, .g1))
+        #expect(atG1.holds(.g1) == false, "measured, and the corner is not G1")
+        #expect(atG1.holds(.c1) == nil, "order .g1 never computes C1")
+    }
+
+    @Test("the default order does not measure tangency")
+    func defaultOrderDoesNotMeasureG1() throws {
+        let pair = try #require(smoothJunction())
+        let atDefault = try #require(analyse(pair, .c2))
+        #expect(atDefault.measured == [.c0, .c1, .c2])
+        #expect(atDefault.holds(.g1) == nil,
+                "the .c2 default computes C0/C1/C2 only — G1 has to be asked for")
+
+        // Ask for it and the same junction answers properly.
+        let atG1 = try #require(analyse(pair, .g1))
+        #expect(atG1.holds(.g1) == true)
+        #expect(atG1.g1Angle >= 0)
+    }
+
+    @Test("metrics for an unmeasured class are withheld, not reported as a perfect match")
+    func unmeasuredMetricsAreWithheld() throws {
+        let pair = try #require(sharpCorner())
+        let atC0 = try #require(analyse(pair, .c0))
+
+        // These read straight off the uninitialised members before the fix: 0.0 radians of
+        // deviation, i.e. an ideal junction, for a 90-degree corner nothing had looked at.
+        #expect(atC0.g1Angle == -1)
+        #expect(atC0.c1Angle == -1)
+        #expect(atC0.c1Ratio == -1)
+        #expect(atC0.c2Angle == -1)
+        #expect(atC0.c2Ratio == -1)
+        #expect(atC0.g2Angle == -1)
+        #expect(atC0.g2CurvatureVariation == -1)
+
+        // C0 itself is measured at every order, and this junction does meet.
+        #expect(atC0.c0Value < 1e-6)
+    }
+
+    @Test("the flags bitmask never claims a bit outside the measured set")
+    func flagsStayInsideMeasured() throws {
+        let pair = try #require(smoothJunction())
+        for order in [ContinuityClass.c0, .g1, .c1, .g2, .c2] {
+            guard let a = analyse(pair, order) else { continue }
+            var measuredMask = 0
+            for c in a.measured { measuredMask |= c.analysisFlagBit }
+            #expect(a.flags & ~measuredMask == 0,
+                    "order \(order) set flags \(a.flags) outside measured \(a.measured)")
+        }
+    }
+
+    @Test("order reports the request after saturation, not a measurement")
+    func orderReportsTheEffectiveRequest() throws {
+        let pair = try #require(sharpCorner())
+
+        for order in [ContinuityClass.c0, .g1, .c1] {
+            let a = try #require(analyse(pair, order))
+            #expect(a.order == order, "\(order) is inside the analyser's vocabulary")
+        }
+
+        // C2 is the strictest question LocalAnalysis_* can answer, so .c3/.cN saturate to it —
+        // and `order` is how a caller finds out that happened.
+        for beyond in [ContinuityClass.c3, .cN] {
+            let a = try #require(analyse(pair, beyond))
+            #expect(a.order == .c2, "\(beyond) should saturate to .c2")
+            #expect(a.measured == [.c0, .c1, .c2])
+        }
+    }
+
+    @Test("the deprecated Int spelling decodes to the same analysis")
+    @available(*, deprecated, message: "exercises the deprecated Int order on purpose")
+    func deprecatedIntOverloadAgrees() throws {
+        let pair = try #require(sharpCorner())
+        let typed = try #require(analyse(pair, .c1))
+        let raw = try #require(pair.0.continuityWith(pair.1, u1: pair.0.domain.upperBound,
+                                                     u2: pair.1.domain.lowerBound, order: 2))
+        #expect(raw.order == typed.order)
+        #expect(raw.measured == typed.measured)
+        #expect(raw.flags == typed.flags)
+
+        // Out-of-range integers saturate in the bridge, and `order` says where they landed.
+        let clamped = try #require(pair.0.continuityWith(pair.1, u1: pair.0.domain.upperBound,
+                                                         u2: pair.1.domain.lowerBound, order: 99))
+        #expect(clamped.order == .c2)
+        let negative = try #require(pair.0.continuityWith(pair.1, u1: pair.0.domain.upperBound,
+                                                          u2: pair.1.domain.lowerBound, order: -3))
+        #expect(negative.order == .c0)
+    }
+}

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -1875,7 +1875,7 @@ struct LocalAnalysisCurveContinuityTests {
             SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)
         ]) else { return }
         if let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
-            #expect(analysis.isC0)
+            #expect(analysis.isC0 == true)
             #expect(analysis.c0Value < 1e-6)
         }
     }
@@ -1887,8 +1887,12 @@ struct LocalAnalysisCurveContinuityTests {
         guard let c2 = Curve3D.fit(points: [
             SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)
         ]) else { return }
-        if let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
-            #expect(analysis.isG1)
+        // G1 has to be requested: the `.c2` default computes C0/C1/C2 and never looks at
+        // tangency, so this assertion used to pass off an uninitialised member rather than a
+        // measurement (#495).
+        if let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound,
+                                            u2: c2.domain.lowerBound, order: .g1) {
+            #expect(analysis.isG1 == true)
             #expect(analysis.g1Angle >= 0)
         }
     }
@@ -1902,7 +1906,7 @@ struct LocalAnalysisCurveContinuityTests {
             SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)
         ]) else { return }
         if let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
-            #expect(analysis.isC0)
+            #expect(analysis.isC0 == true)
         }
     }
 
@@ -1914,7 +1918,9 @@ struct LocalAnalysisCurveContinuityTests {
             SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)
         ]) else { return }
         if let a = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
-            #expect(a.status >= 0)
+            // `order` is the request echoed back, so pinning it to the default is all it can
+            // tell us; the measurement is `c1Ratio`, which the default order does compute.
+            #expect(a.order == .c2)
             #expect(a.c1Ratio > 0)
         }
     }

--- a/Tests/OCCTSurfaceTests/Issue495AnalysisOrderTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue495AnalysisOrderTests.swift
@@ -1,0 +1,123 @@
+import Testing
+@testable import OCCTSwift
+
+// #495, surface side. Same defect and same fix as the curve analyser — see
+// Tests/OCCTCurveTests/Issue495AnalysisOrderTests.swift for the mechanism.
+//
+// Two wrinkles specific to LocalAnalysis_SurfaceContinuity, both measured against the pinned
+// kernel and pinned here so they are not rediscovered:
+//
+//   * Its predicates all gate on IsC0(), so when C0 itself fails the spurious trues were masked
+//     by accident. They were not masked when C0 held, which is the ordinary case for two patches
+//     that meet — which is when a caller is actually asking.
+//   * The `.c2` branch needs a non-zero *second* derivative in both U and V on both surfaces, or
+//     it reports NullSecondDerivative and the whole analysis is not done. A plane has none in
+//     either direction and a cylinder has none along its axis, so the `.c2` default answers nil
+//     for both. A sphere is curved in both directions and is the fixture that reaches C2.
+
+@Suite("Issue #495: surface analysis order selects what is measured")
+struct Issue495SurfaceAnalysisOrderTests {
+
+    private func identicalSpheres() -> (Surface, Surface)? {
+        guard let s1 = Surface.sphere(center: .zero, radius: 5),
+              let s2 = Surface.sphere(center: .zero, radius: 5) else { return nil }
+        return (s1, s2)
+    }
+
+    private func perpendicularPlanes() -> (Surface, Surface)? {
+        guard let s1 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+              let s2 = Surface.plane(origin: .zero, normal: SIMD3(0, 1, 0)) else { return nil }
+        return (s1, s2)
+    }
+
+    private func analyse(_ pair: (Surface, Surface), _ order: ContinuityClass,
+                         at uv: (Double, Double) = (0.5, 0.5)) -> Surface.ContinuityAnalysis? {
+        pair.0.continuityWith(pair.1, u1: uv.0, v1: uv.1, u2: uv.0, v2: uv.1, order: order)
+    }
+
+    @Test("each order measures exactly its own branch")
+    func measuredSetPerOrder() throws {
+        let pair = try #require(identicalSpheres())
+        let expected: [ContinuityClass: Set<ContinuityClass>] = [
+            .c0: [.c0],
+            .g1: [.c0, .g1],
+            .c1: [.c0, .c1],
+            .g2: [.c0, .g1, .g2],
+            .c2: [.c0, .c1, .c2],
+        ]
+        for (order, want) in expected {
+            let a = try #require(analyse(pair, order), "order \(order) should analyse")
+            #expect(a.measured == want, "order \(order) measured \(a.measured)")
+            #expect(a.measured.count < 5, "no order covers all five classes")
+        }
+    }
+
+    @Test("two planes at right angles do not report continuity they were never asked for")
+    func unmeasuredClassesReportNil() throws {
+        let pair = try #require(perpendicularPlanes())
+
+        // The two planes touch at the origin, so C0 holds and the IsC0() gate lets the spurious
+        // trues through: at order .c0 this used to report isG1/isC1/isG2/isC2 all true for a
+        // 90-degree crease.
+        let atC0 = try #require(analyse(pair, .c0, at: (0, 0)))
+        #expect(atC0.holds(.c0) == true)
+        #expect(atC0.holds(.g1) == nil)
+        #expect(atC0.holds(.c2) == nil)
+        #expect(atC0.isG2 == nil)
+        #expect(atC0.g1Angle == -1, "an unmeasured G1 used to answer 0.0 radians")
+
+        // Measured, and correctly false.
+        let atG1 = try #require(analyse(pair, .g1, at: (0, 0)))
+        #expect(atG1.holds(.g1) == false)
+        #expect(atG1.holds(.c1) == nil, "order .g1 never computes C1")
+    }
+
+    @Test("the default order does not measure tangency")
+    func defaultOrderDoesNotMeasureG1() throws {
+        let pair = try #require(identicalSpheres())
+        let atDefault = try #require(analyse(pair, .c2))
+        #expect(atDefault.measured == [.c0, .c1, .c2])
+        #expect(atDefault.holds(.g1) == nil)
+
+        let atG1 = try #require(analyse(pair, .g1))
+        #expect(atG1.holds(.g1) == true, "identical spheres are tangent-continuous when asked")
+    }
+
+    @Test("order reports the request after saturation")
+    func orderReportsTheEffectiveRequest() throws {
+        let pair = try #require(identicalSpheres())
+        let atG2 = try #require(analyse(pair, .g2))
+        #expect(atG2.order == .g2)
+        let beyond = try #require(analyse(pair, .cN))
+        #expect(beyond.order == .c2)
+        #expect(beyond.measured == [.c0, .c1, .c2])
+    }
+
+    @Test("the flags bitmask never claims a bit outside the measured set")
+    func flagsStayInsideMeasured() throws {
+        let pair = try #require(identicalSpheres())
+        for order in [ContinuityClass.c0, .g1, .c1, .g2, .c2] {
+            guard let a = analyse(pair, order) else { continue }
+            var measuredMask = 0
+            for c in a.measured { measuredMask |= c.analysisFlagBit }
+            #expect(a.flags & ~measuredMask == 0,
+                    "order \(order) set flags \(a.flags) outside measured \(a.measured)")
+        }
+    }
+
+    @Test("the .c2 default cannot analyse a surface with no second derivative")
+    func c2NeedsCurvatureInBothDirections() throws {
+        // Not a regression — an OCCT precondition (LocalAnalysis_NullSecondDerivative) that the
+        // default order walks straight into for the two most common elementary surfaces. Ask for
+        // .c1 or .g1 on planar or ruled geometry.
+        let planes = try #require(perpendicularPlanes())
+        #expect(analyse(planes, .c2, at: (0, 0)) == nil, "a plane has no second derivative")
+        #expect(analyse(planes, .c1, at: (0, 0)) != nil, "C1 only needs the first derivative")
+
+        let cyl = try #require(Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5))
+        let cyl2 = try #require(Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5))
+        #expect(cyl.continuityWith(cyl2, u1: 0.5, v1: 1, u2: 0.5, v2: 1, order: .c2) == nil,
+                "a cylinder is straight along its axis, so D2V is null")
+        #expect(cyl.continuityWith(cyl2, u1: 0.5, v1: 1, u2: 0.5, v2: 1, order: .g2) != nil)
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -2560,27 +2560,32 @@ struct LocalAnalysisSurfaceContinuityTests {
     @Test func identicalPlanes() {
         guard let s1 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
               let s2 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else { return }
-        if let analysis = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0) {
-            #expect(analysis.isC0)
-            #expect(analysis.isG1)
-            #expect(analysis.c0Value < 1e-6)
-        }
+        // Planes have no second derivative, so the `.c2` default is NullSecondDerivative and
+        // answers nil — these three suites used to assert nothing at all (#495). `.c1` is the
+        // strictest order a plane can be analysed at.
+        let analysis = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0, order: .c1)
+        #expect(analysis?.isC0 == true)
+        #expect((analysis?.c0Value ?? .infinity) < 1e-6)
+
+        // Tangency is a separate question: neither `.c1` nor the `.c2` default computes G1.
+        let tangency = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0, order: .g1)
+        #expect(tangency?.isG1 == true)
     }
 
     @Test func planeVsCylinder() {
         guard let s1 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
               let s2 = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5.0) else { return }
-        if let analysis = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0) {
-            #expect(analysis.status >= 0)
-        }
+        let analysis = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0, order: .c1)
+        #expect(analysis?.order == .c1)
+        // The two surfaces are 5 units apart at these parameters, so not even C0 holds.
+        #expect(analysis?.isC0 == false)
     }
 
     @Test func surfaceContinuityFlags() {
         guard let s1 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
               let s2 = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else { return }
-        if let analysis = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0) {
-            #expect(analysis.flags > 0)
-        }
+        let analysis = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0, order: .c1)
+        #expect((analysis?.flags ?? 0) > 0)
     }
 }
 

--- a/Tests/OCCTTopologyTests/Issue495FaceContinuityTests.swift
+++ b/Tests/OCCTTopologyTests/Issue495FaceContinuityTests.swift
@@ -1,0 +1,111 @@
+import Testing
+@testable import OCCTSwift
+
+// #495: `Shape.continuityOfFaces` documented its own return values wrong.
+//
+// The comment on both the bridge declaration and the Swift wrapper read
+// "0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=CN, -1=error". Two things are wrong with it: CN is ordinal 6,
+// not 5, and 5 (C3) is a value `BRepLib::ContinuityOfFaces` cannot return at all. The function
+// itself was always right — it casts the GeomAbs_Shape straight through with no lookup table — so
+// the comment was describing a mapping that did not exist. A caller matching 5 for "smooth" never
+// matched anything; one receiving 6 had no documented meaning for it.
+//
+// These tests pin the real domain against measured geometry.
+
+@Suite("Issue #495: continuity across an edge reports a real GeomAbs_Shape class")
+struct Issue495FaceContinuityTests {
+
+    /// Every (edge, faceA, faceB) triple in `shape` where exactly two faces share the edge.
+    private func sharedEdgeTriples(in shape: Shape) -> [(Shape, Shape, Shape)] {
+        let faces = shape.subShapes(ofType: .face)
+        return shape.subShapes(ofType: .edge).compactMap { edge in
+            let adjacent = shape.adjacentFaces(forEdge: edge)   // 1-based
+            guard adjacent.count == 2,
+                  let a = adjacent.first, let b = adjacent.last,
+                  a >= 1, a <= faces.count, b >= 1, b <= faces.count
+            else { return nil }
+            return (edge, faces[a - 1], faces[b - 1])
+        }
+    }
+
+    @Test("a sharp planar join is C0")
+    func boxEdgeIsC0() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let triples = sharedEdgeTriples(in: box)
+        try #require(!triples.isEmpty, "no shared edge found to check")
+        for (edge, f1, f2) in triples {
+            #expect(Shape.continuityClassOfFaces(edge: edge, face1: f1, face2: f2) == .c0,
+                    "a box's faces meet at a right angle")
+        }
+    }
+
+    @Test("a fillet's tangent join is G1 — ordinal 1, and a real measurement")
+    func filletedEdgeIsG1() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let filleted = try #require(box.filleted(radius: 3))
+
+        let classes = sharedEdgeTriples(in: filleted).map {
+            Shape.continuityClassOfFaces(edge: $0.0, face1: $0.1, face2: $0.2)
+        }
+        #expect(classes.contains(.g1),
+                "a filleted box should have tangent joins where the blend meets a wall")
+    }
+
+    @Test("a seam on an elementary surface is CN — ordinal 6, which the old comment called 5")
+    func seamOnElementarySurfaceIsCN() throws {
+        // BRepLib::ContinuityOfFaces short-circuits to GeomAbs_CN when the two faces are the same
+        // face and the surface is elementary, which is the seam case. This is the return value the
+        // docs mislabelled, and the only way to reach an ordinal above 4 here.
+        #expect(ContinuityClass.cN.rawValue == 6, "CN is ordinal 6 — the old comment said 5")
+
+        let cylinder = try #require(Shape.cylinder(radius: 5, height: 10))
+        var sawCN = false
+        for face in cylinder.subShapes(ofType: .face) {
+            for edge in face.subShapes(ofType: .edge) {
+                if Shape.continuityClassOfFaces(edge: edge, face1: face, face2: face) == .cN {
+                    sawCN = true
+                }
+            }
+        }
+        #expect(sawCN, "a cylinder's own faces are elementary, so a self-pair reports CN")
+    }
+
+    @Test("C3 is never reported, so the ordinal the old comment used is unreachable")
+    func c3IsNeverReported() throws {
+        #expect(ContinuityClass.c3.rawValue == 5)
+
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let filleted = try #require(box.filleted(radius: 2))
+        let cylinder = try #require(Shape.cylinder(radius: 4, height: 8))
+        let sphere = try #require(Shape.sphere(radius: 5))
+
+        for shape in [box, filleted, cylinder, sphere] {
+            for (edge, f1, f2) in sharedEdgeTriples(in: shape) {
+                #expect(Shape.continuityClassOfFaces(edge: edge, face1: f1, face2: f2) != .c3,
+                        "BRepLib::ContinuityOfFaces has no path that returns C3")
+            }
+        }
+    }
+
+    @Test("a null argument reports nil rather than a continuity class")
+    func failureIsNil() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let triple = try #require(sharedEdgeTriples(in: box).first)
+
+        // -1 is the bridge's failure code, and it is not a ContinuityClass raw value, so it
+        // decodes to nil instead of being read as a class. Passing a vertex where a face belongs
+        // makes TopoDS::Face throw, which is the -1 path.
+        let vertex = try #require(box.subShapes(ofType: .vertex).first)
+        #expect(Shape.continuityClassOfFaces(edge: triple.0, face1: vertex, face2: triple.2) == nil)
+    }
+
+    @Test("the deprecated Int spelling returns the same ordinal")
+    @available(*, deprecated, message: "exercises the deprecated Int-returning spelling on purpose")
+    func deprecatedIntSpellingAgrees() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let (edge, f1, f2) = try #require(sharedEdgeTriples(in: box).first)
+        let raw = Shape.continuityOfFaces(edge: edge, face1: f1, face2: f2)
+        let typed = Shape.continuityClassOfFaces(edge: edge, face1: f1, face2: f2)
+        #expect(Int32(raw) == typed?.rawValue)
+    }
+}

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -4392,16 +4392,18 @@ struct BRepLibExtendedTests {
     }
 
     @Test("Continuity of faces")
-    func continuityOfFaces() {
+    func continuityAcrossASharedEdge() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let b = box {
             let faces = b.subShapes(ofType: .face)
             let edges = b.subShapes(ofType: .edge)
             if faces.count >= 2, edges.count > 0 {
-                // Try to find a shared edge between two faces
-                let cont = Shape.continuityOfFaces(edge: edges[0], face1: faces[0], face2: faces[1])
-                // -1 means error (edge may not be shared); >= 0 is valid
-                #expect(cont >= -1)
+                // Try to find a shared edge between two faces. Whatever comes back must be a
+                // class the vocabulary actually has — the old `>= -1` was true of every Int
+                // (#495); Issue495FaceContinuityTests pins the values per geometry.
+                let cont = Shape.continuityClassOfFaces(edge: edges[0],
+                                                        face1: faces[0], face2: faces[1])
+                #expect(cont == nil || ContinuityClass.allCases.contains(cont!))
             }
         }
     }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,278** | |
+| **Total** | **4,285** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,75 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### Breaking: the junction analysers now say what they measured, and stop reporting what they did not (#495)
+
+**Source-breaking, in one place:** `Curve3D.ContinuityAnalysis` and `Surface.ContinuityAnalysis`
+expose `isC0`/`isG1`/`isC1`/`isG2`/`isC2` as `Bool?` rather than `Bool`. `nil` means "the order you
+asked for never measured this class". [`SEMVER.md`](SEMVER.md#recorded-exception-v1170-2026-07-29)
+records the exception; a shim is impossible, because Swift does not overload a property on its type.
+
+`LocalAnalysis_CurveContinuity` and `LocalAnalysis_SurfaceContinuity` run exactly one branch of a
+switch on the order they are constructed with, and only that branch's quantities are ever computed.
+Every other predicate then compared a member still at its `0.0` initialiser against a tolerance and
+answered `true` whatever the geometry did. A sharp 90° corner analysed at order C0 reported
+`isC2 == true`, with `c2Angle == 0.0` — a perfect second-derivative match — to go with it. The five
+branches are cumulative only along their own ladder, and **no order measures all five**, not even
+the `.c2` default, which never looks at G1 or G2:
+
+| order | measures |
+|---|---|
+| `.c0` | C0 |
+| `.g1` | C0, G1 |
+| `.c1` | C0, C1 |
+| `.g2` | C0, G1, G2 |
+| `.c2` | C0, C1, C2 |
+
+```swift
+// Before — compiles, and lies. The .c2 default never computes G1.
+if analysis.isG1 { … }
+
+// After — ask for what you want measured, and nil says when you did not.
+let a = c1.continuityWith(c2, u1: e1, u2: s2, order: .g1)!
+a.holds(.g1)   // Optional(true)
+a.holds(.c1)   // nil — .g1 does not measure C1
+a.measured     // [.c0, .g1]
+```
+
+The angle and ratio outputs are gated the same way: an unmeasured class now reports `-1` (the
+"not applicable" value those fields already used) instead of `0.0`. `flags` is masked to the
+measured set, and `measured`/`holds(_:)` are the new way to read it.
+
+Three more things fell out of the same audit, none of them source-breaking:
+
+- **`ContinuityAnalysis.status` was never a measurement.** `ContinuityStatus()` returns the order
+  the analyser was constructed with, verbatim. It is now `order: ContinuityClass`, documented as
+  the request after saturation, which is the one thing it can honestly report; `status` remains as
+  a deprecated `Int` shim. Every test that touched it asserted `status >= 0`, which is why the echo
+  went unnoticed.
+- **`order:` is typed.** `Curve3D.continuityWith` and `Surface.continuityWith` took a raw
+  `Int = 4`, the last two continuity parameters #398/PR#436 did not reach — a caller could pass
+  `5`, `-1` or a value borrowed from an unrelated continuity enum and be clamped without being
+  told. Both now take a `ContinuityClass = .c2`, with a deprecated `Int` overload that decodes
+  identically.
+- **`Shape.continuityOfFaces` documented its own return values wrong.** Its comment said
+  `5=CN`; CN is ordinal 6, and 5 (C3) is a value `BRepLib::ContinuityOfFaces` cannot return at all.
+  The function was always right — it casts the enum straight through, so there was no lookup table
+  for the comment to be describing — but a caller matching `5` for "smooth" never matched anything,
+  and one receiving `6` had no documented meaning for it. Same wrong string had been copied into
+  the bridge header and the Swift doc comment.
+  `continuityClassOfFaces(edge:face1:face2:tolerance:) -> ContinuityClass?` is the typed
+  replacement; the `Int` spelling is deprecated, not changed.
+
+Measured, not inferred: a box edge reports `.c0`, a filleted box's blend joins report `.g1`, a
+cylinder seam reports `.cN` (ordinal 6), and `.c3` appears nowhere. Also pinned by test, since the
+default order walks straight into it: the `.c2` branch needs a non-zero second derivative in both
+parametric directions, so `Surface.continuityWith` at the default returns `nil` for a plane (none in
+either direction) and for a cylinder (none along its axis) — ask for `.c1` or `.g1` on planar or
+ruled geometry. Six pre-existing tests across three targets asserted nothing at all because of
+these two facts together, and now assert the measurements.
+
+Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
+
 #### One continuity decoder per vocabulary, not nineteen (#490)
 
 Continuity reached OCCT as a plain integer through 19 separate decoders: seven independently-named

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,7 +17,7 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with one recorded exception: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with two recorded exceptions: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places, and [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one.
 
 ## Rules
 
@@ -47,6 +47,23 @@ Both are compile errors, never silent. The decision was to take the exception ra
 - Both are named at the top of [`CHANGELOG.md`](CHANGELOG.md)'s v1.17.0 entry with before/after code, and in the GitHub release notes.
 
 This exception does not amend the rule. A breaking change still triggers a major bump by default; taking an exception requires the same treatment given here, which is naming every break with a migration, in the release notes and in this file, before the tag is cut.
+
+#### Recorded exception: Unreleased — junction-analysis flags become optional (#495)
+
+**One source break, taken under the same terms as v1.17.0 above and recorded here before the tag is cut:**
+
+| Break | Issue | What a caller does |
+|---|---|---|
+| `Curve3D.ContinuityAnalysis` / `Surface.ContinuityAnalysis` expose `isC0`/`isG1`/`isC1`/`isG2`/`isC2` as `Bool?`, not `Bool` | #495 | Compare explicitly (`if a.isG1 == true`), or use `holds(_:)`. Then check the *order*: the value was only ever meaningful for the classes that order measured, and `nil` is now how the API says so |
+
+It is a compile error at every call site, never silent. The exception was taken because:
+
+- It cannot be shimmed. Swift does not overload a property on its type, so the old `Bool` spelling cannot coexist with the new one under the same name — the alternative was leaving five public properties that report `true` for a class nothing measured (a sharp 90° corner reported `isC2 == true`), which is a silent wrong answer, exactly what a SemVer promise is not meant to protect.
+- The compile error is the migration prompt. A caller reading `isG1` at the default `.c2` order was reading an uninitialised member; being made to write `== true` is the moment they find out the order has to ask for G1.
+- The major version stays reserved for OCCT 9.0.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with before/after code, and to be named in the release notes.
+
+Also in #495, and *not* breaking: `continuityWith`'s `order:` parameter and `Shape.continuityOfFaces` both changed type, and both kept a deprecated overload with the old signature.
 
 ### MINOR — `x.y.0`
 

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -140,7 +140,8 @@ Struct returned by `continuityWith(_:u1:u2:order:)`.
 
 ```swift
 public struct ContinuityAnalysis: Sendable {
-    public let status: Int
+    public let order: ContinuityClass
+    public let measured: Set<ContinuityClass>
     public let c0Value: Double
     public let g1Angle: Double
     public let c1Angle: Double
@@ -150,22 +151,27 @@ public struct ContinuityAnalysis: Sendable {
     public let g2Angle: Double
     public let g2CurvatureVariation: Double
     public let flags: Int
-    public var isC0: Bool { flags & 1  != 0 }
-    public var isG1: Bool { flags & 2  != 0 }
-    public var isC1: Bool { flags & 4  != 0 }
-    public var isG2: Bool { flags & 8  != 0 }
-    public var isC2: Bool { flags & 16 != 0 }
+    public func holds(_ continuity: ContinuityClass) -> Bool?
+    public var isC0: Bool? { holds(.c0) }
+    public var isG1: Bool? { holds(.g1) }
+    public var isC1: Bool? { holds(.c1) }
+    public var isG2: Bool? { holds(.g2) }
+    public var isC2: Bool? { holds(.c2) }
 }
 ```
 
-- `status` — raw `GeomAbs_Shape` continuity code (0=C0, 1=G1, 2=C1, 3=G2, 4=C2).
+- `order` — the class the junction was analysed at, i.e. the request after saturation. `LocalAnalysis_CurveContinuity::ContinuityStatus()` echoes its constructor argument, so this is never a finding; it exists to tell you where a saturated request landed.
+- `measured` — the classes this `order` actually evaluated. Each order runs one branch: `.c0` measures C0; `.g1` measures C0 and G1; `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2. **No order measures all five.**
 - `c0Value` — positional gap distance at the junction.
-- `g1Angle` — angle between tangent directions (radians).
-- `c1Angle` / `c1Ratio` — angle and magnitude ratio between first derivatives.
-- `c2Angle` / `c2Ratio` — angle and magnitude ratio between second derivatives.
-- `g2Angle` — angle between osculating planes.
-- `g2CurvatureVariation` — curvature variation at the junction.
-- `flags` — bitmask encoding continuity levels; decoded by computed boolean helpers `isC0` … `isC2`.
+- `g1Angle` — angle between tangent directions (radians), or `-1` if G1 was not measured or does not hold.
+- `c1Angle` / `c1Ratio` — angle and magnitude ratio between first derivatives, or `-1`.
+- `c2Angle` / `c2Ratio` — angle and magnitude ratio between second derivatives, or `-1`.
+- `g2Angle` — angle between osculating planes, or `-1`.
+- `g2CurvatureVariation` — curvature variation at the junction, or `-1`.
+- `flags` — bitmask (bit 0 = C0 … bit 4 = C2), masked to `measured`.
+- `holds(_:)` returns `nil` for a class outside `measured`, which is what separates "does not hold" from "never asked". Prefer it to `flags`.
+
+> Before #495 the `is*` helpers were non-optional and read straight off the bitmask, so a class the order never computed answered `true` from an uninitialised member — a 90° corner analysed at `.c0` reported `isC2 == true`, with `c2Angle == 0.0` alongside it.
 
 ---
 
@@ -174,18 +180,23 @@ public struct ContinuityAnalysis: Sendable {
 Analyses the continuity between this curve at parameter `u1` and another curve at parameter `u2`.
 
 ```swift
-public func continuityWith(_ other: Curve3D, u1: Double, u2: Double, order: Int = 4) -> ContinuityAnalysis?
+public func continuityWith(_ other: Curve3D, u1: Double, u2: Double,
+                           order: ContinuityClass = .c2) -> ContinuityAnalysis?
 ```
 
-`order` controls the maximum continuity level tested: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2 (default). Use at shared endpoints when assembling curves that are expected to meet smoothly.
+`order` **selects** the analysis rather than capping it — see `measured` above. `.c2` is the strictest class `LocalAnalysis_CurveContinuity` implements, so `.c3` and `.cN` saturate to it.
 
-- **Parameters:** `other` — the second curve; `u1` — parameter on this curve; `u2` — parameter on `other`; `order` — highest order to test (0–4, default 4).
-- **Returns:** `ContinuityAnalysis`, or `nil` if `LocalAnalysis_CurveContinuity` fails (e.g. degenerate tangent, invalid order).
+- **Parameters:** `other` — the second curve; `u1` — parameter on this curve; `u2` — parameter on `other`; `order` — the class to measure (default `.c2`).
+- **Returns:** `ContinuityAnalysis`, or `nil` if `LocalAnalysis_CurveContinuity` fails.
 - **OCCT:** `LocalAnalysis_CurveContinuity`.
+- **Note:** the `.c2` and `.g2` branches need a non-zero second derivative on both curves, so a straight line cannot be analysed above `.c1`/`.g1`.
 - **Example:**
   ```swift
-  if let ca = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
-      print(ca.isG1, ca.g1Angle)
+  // Tangency is its own question: the .c2 default never computes G1.
+  if let ca = c1.continuityWith(c2, u1: c1.domain.upperBound,
+                                u2: c2.domain.lowerBound, order: .g1) {
+      print(ca.holds(.g1), ca.g1Angle)
+      print(ca.holds(.c1))            // nil — .g1 does not measure C1
   }
   ```
 

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -444,23 +444,29 @@ public func updateDeflection()
 
 ---
 
-### `Shape.continuityOfFaces(edge:face1:face2:tolerance:)`
+### `Shape.continuityClassOfFaces(edge:face1:face2:tolerance:)`
 
 Get the geometric continuity of the surface across an edge shared by two faces.
 
 ```swift
-public static func continuityOfFaces(edge: Shape, face1: Shape, face2: Shape,
-                                      tolerance: Double = 1e-6) -> Int
+public static func continuityClassOfFaces(edge: Shape, face1: Shape, face2: Shape,
+                                          tolerance: Double = 1e-6) -> ContinuityClass?
 ```
 
 - **Parameters:** `edge` — the shared edge; `face1`, `face2` — the two faces; `tolerance` — comparison tolerance.
-- **Returns:** `GeomAbs_Shape` integer: 0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=CN, -1=error.
+- **Returns:** the measured `ContinuityClass`, or `nil` on failure (null handle, or OCCT throwing).
 - **OCCT:** `BRepLib::ContinuityOfFaces`.
+- **Domain:** six of the seven classes are reachable — `.c0` for a sharp join, `.g1` for a fillet's tangent join, and `.cN` for a seam on an elementary surface (or any elementary pair measuring C2, which OCCT promotes). `.c3` is never returned.
 - **Example:**
   ```swift
-  let c = Shape.continuityOfFaces(edge: e, face1: f1, face2: f2)
-  // c == 2 means C1 continuity
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let faces = box.subShapes(ofType: .face), edges = box.subShapes(ofType: .edge)
+  Shape.continuityClassOfFaces(edge: edges[0], face1: faces[0], face2: faces[1])  // .c0
   ```
+
+> **Deprecated:** `continuityOfFaces(edge:face1:face2:tolerance:) -> Int` returns the same
+> measurement as a raw ordinal. Its doc comment claimed `5=CN`, which is wrong twice over — CN is
+> ordinal 6, and 5 (C3) is a value this function cannot return. #495.
 
 ---
 

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -678,20 +678,22 @@ public func continuityWith(
     _ other: Surface,
     u1: Double, v1: Double,
     u2: Double, v2: Double,
-    order: Int = 4
+    order: ContinuityClass = .c2
 ) -> ContinuityAnalysis?
 ```
 
-Returns C0, G1, C1, G2, C2 status in a single call. The `ContinuityAnalysis` struct exposes
-both raw angular values and Boolean convenience flags (`isC0`, `isG1`, `isC1`, `isG2`, `isC2`).
+`order` selects which classes are measured, not just a ceiling — one branch of
+`LocalAnalysis_SurfaceContinuity` runs per call, and `ContinuityAnalysis.holds(_:)` reports `nil`
+for anything outside it. See [Surface-Analysis](Surface-Analysis.md#continuityanalysis) for the
+per-order measured sets and the `.c2`/second-derivative caveat.
 
-- **Parameters:** `other` — second surface; `u1`, `v1` — UV parameters on this surface; `u2`, `v2` — UV parameters on `other`; `order` — maximum order to check (0=C0 … 4=C2).
+- **Parameters:** `other` — second surface; `u1`, `v1` — UV parameters on this surface; `u2`, `v2` — UV parameters on `other`; `order` — the class to measure (default `.c2`).
 - **Returns:** `ContinuityAnalysis`, or `nil` if analysis fails.
 - **OCCT:** `LocalAnalysis_SurfaceContinuity`.
 - **Example:**
   ```swift
-  if let ca = surf1.continuityWith(surf2, u1: 1.0, v1: 0.5, u2: 0.0, v2: 0.5) {
-      #expect(ca.isG1)
+  if let ca = surf1.continuityWith(surf2, u1: 1.0, v1: 0.5, u2: 0.0, v2: 0.5, order: .g1) {
+      #expect(ca.holds(.g1) == true)
       print("C0 gap:", ca.c0Value, "G1 angle:", ca.g1Angle)
   }
   ```

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -118,26 +118,31 @@ Struct returned by `continuityWith(_:u1:v1:u2:v2:order:)`.
 
 ```swift
 public struct ContinuityAnalysis: Sendable {
-    public let status: Int
+    public let order: ContinuityClass
+    public let measured: Set<ContinuityClass>
     public let c0Value: Double
     public let g1Angle: Double
     public let c1UAngle: Double
     public let c1VAngle: Double
     public let flags: Int
-    public var isC0: Bool { flags & 1  != 0 }
-    public var isG1: Bool { flags & 2  != 0 }
-    public var isC1: Bool { flags & 4  != 0 }
-    public var isG2: Bool { flags & 8  != 0 }
-    public var isC2: Bool { flags & 16 != 0 }
+    public func holds(_ continuity: ContinuityClass) -> Bool?
+    public var isC0: Bool? { holds(.c0) }
+    public var isG1: Bool? { holds(.g1) }
+    public var isC1: Bool? { holds(.c1) }
+    public var isG2: Bool? { holds(.g2) }
+    public var isC2: Bool? { holds(.c2) }
 }
 ```
 
-- `status` — raw `GeomAbs_Shape` continuity status code.
+- `order` — the class the junction was analysed at, i.e. the request after saturation. `LocalAnalysis_SurfaceContinuity::ContinuityStatus()` echoes its constructor argument, so this is never a finding; it exists to tell you where a saturated request landed.
+- `measured` — the classes this `order` actually evaluated. Each order runs one branch: `.c0` measures C0; `.g1` measures C0 and G1; `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2. **No order measures all five.**
 - `c0Value` — positional gap distance at the junction.
-- `g1Angle` — angle between surface normals at the junction (radians).
-- `c1UAngle` / `c1VAngle` — angles between first derivatives in U and V directions.
-- `flags` — bitmask: bit 0 = C0, bit 1 = G1, bit 2 = C1, bit 3 = G2, bit 4 = C2.
-- Computed boolean helpers `isC0` … `isC2` decode the bitmask.
+- `g1Angle` — angle between surface normals at the junction (radians), or `-1` if G1 was not measured or does not hold.
+- `c1UAngle` / `c1VAngle` — angles between first derivatives in U and V directions, or `-1`.
+- `flags` — bitmask: bit 0 = C0, bit 1 = G1, bit 2 = C1, bit 3 = G2, bit 4 = C2, masked to `measured`.
+- `holds(_:)` returns `nil` for a class outside `measured`, which is what separates "does not hold" from "never asked". Prefer it to `flags`.
+
+> Before #495 the `is*` helpers were non-optional and read straight off the bitmask, so a class the order never computed answered `true` from an uninitialised member — a 90° crease analysed at `.c0` reported `isC2 == true`, with `c2Angle == 0.0` alongside it.
 
 ---
 
@@ -150,25 +155,22 @@ public func continuityWith(
     _ other: Surface,
     u1: Double, v1: Double,
     u2: Double, v2: Double,
-    order: Int = 4
+    order: ContinuityClass = .c2
 ) -> ContinuityAnalysis?
 ```
 
-`order` controls the maximum continuity level tested: 0 = C0, 1 = G1, 2 = C1, 3 = G2, 4 = C2. Use this to verify that two adjacent surface patches meet smoothly at a shared seam.
+`order` **selects** the analysis rather than capping it — see `measured` above. `.c2` is the strictest class `LocalAnalysis_SurfaceContinuity` implements, so `.c3` and `.cN` saturate to it.
 
-- **Parameters:** `other` — the second surface; `u1`/`v1` — parameters on this surface; `u2`/`v2` — parameters on `other`; `order` — maximum order to check (0–4, default 4).
-- **Returns:** `ContinuityAnalysis`, or `nil` if `LocalAnalysis_SurfaceContinuity` fails (e.g. degenerate point, invalid order).
+- **Parameters:** `other` — the second surface; `u1`/`v1` — parameters on this surface; `u2`/`v2` — parameters on `other`; `order` — the class to measure (default `.c2`).
+- **Returns:** `ContinuityAnalysis`, or `nil` if `LocalAnalysis_SurfaceContinuity` fails.
 - **OCCT:** `LocalAnalysis_SurfaceContinuity`.
+- **Note:** the `.c2` branch needs a non-zero second derivative in both U and V on both surfaces. A plane has none in either direction and a cylinder has none along its axis, so the default order returns `nil` for both — ask for `.c1` or `.g1` on planar or ruled geometry.
 - **Example:**
   ```swift
-  if let a = ContinuityAnalysis(
-         s1.continuityWith(s2, u1: u1, v1: v1, u2: u2, v2: v2)
-     ) {
-      print(a.isG1, a.g1Angle)
-  }
-  // safe unwrap form:
-  if let ca = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0) {
-      print(ca.isC1)
+  // Tangency is its own question: the .c2 default never computes G1.
+  if let a = s1.continuityWith(s2, u1: 0, v1: 0, u2: 0, v2: 0, order: .g1) {
+      print(a.holds(.g1), a.g1Angle)   // Optional(true), 0.0
+      print(a.holds(.c1))              // nil — .g1 does not measure C1
   }
   ```
 


### PR DESCRIPTION
Closes #495.

> **Stacked on #523 (#490).** #490 had already collapsed the three divergent C++ conversion helpers #495 names (`orderToShape`/`shapeToOrder` ×2, `continuityFromInt78`) into the shared decoders in `OCCTBridge_Internal.h`, and rewrote most of the drifted header comments. This PR therefore targets `fix/490-continuity-mapper-consolidation`, not `refactor/381-pass1b` — **retarget to `refactor/381-pass1b` once #523 merges.** What was left of #495 after #490 is the Swift-side typing, the one header comment #490 did not reach, and two live defects underneath both.

## What #490 left, and what probing it found

The typing half of #495 was straightforward. Probing it (ground-truth C++ against the pinned kernel, plus reading `LocalAnalysis_*.cxx`) turned up two defects the untyped contract had been hiding.

### 1. The `is*` flags report classes nothing measured

`LocalAnalysis_CurveContinuity` and `LocalAnalysis_SurfaceContinuity` run exactly one branch of a `switch` on the order they are constructed with, and only that branch's quantities are ever computed. Every other predicate then compares a member still at its `0.0` initialiser against a tolerance, so its `Is*()` returns `true` whatever the geometry does — and the matching angle answers `0.0`, a perfect junction.

Measured, on a sharp 90° corner:

```
order C0  -> C0=1 G1=1 C1=1 G2=1 C2=1     <- four of these are fiction
order G1  -> C0=1 G1=0 C1=1 G2=0 C2=1     <- G1 real, C1/C2 fiction
order C1  -> C0=1 G1=1 C1=0 G2=1 C2=0     <- C1 real, G1/G2 fiction
```

The branches are cumulative only along their own ladder, and **no order measures all five** — not even the `.c2` default, which never looks at G1 or G2. That is why `smoothJunctionIsG1`, which asserted `analysis.isG1` at the default order, had been passing without measuring anything.

`occtAnalysisMeasuredMask` (in `OCCTBridge_Internal.h`, beside #490's decoders) names the covered set per order; both bridge entry points gate every output on it and report it back. Swift-side, `holds(_:)` returns `nil` outside `measured`, the `is*` helpers become `Bool?`, and an unmeasured angle/ratio reports `-1` instead of `0.0`.

```swift
let a = c1.continuityWith(c2, u1: e1, u2: s2, order: .c1)!
a.holds(.c1)   // false — measured, and the corner is not C1
a.holds(.g1)   // nil   — order .c1 never computes G1
a.measured     // [.c0, .c1]
```

### 2. `ContinuityAnalysis.status` was never a measurement

`ContinuityStatus()` returns `myTypeCont`, which is the constructor's `Order` argument verbatim. It is the request echoed back. It is now `order: ContinuityClass`, documented as the request *after saturation* — the one thing it can honestly report — with `status` kept as a deprecated `Int` shim. Every test that read it asserted `status >= 0`, which is how the echo went unnoticed.

### 3. `Shape.continuityOfFaces` documented its own returns wrong

The comment said `0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=CN, -1=error`. CN is ordinal **6**, and 5 (C3) is a value `BRepLib::ContinuityOfFaces` cannot return at all — the function casts the enum straight through, so there was no lookup table for the comment to be describing. A caller matching `5` for "smooth" never matched anything; one receiving `6` had no documented meaning for it. The same wrong string sat in the bridge header and the Swift doc comment.

Measured domain, pinned by test: box edge → `.c0`, filleted box blend joins → `.g1`, cylinder seam → `.cN` (6), `.c3` nowhere. `continuityClassOfFaces(...) -> ContinuityClass?` is the typed replacement; the `Int` spelling is deprecated, not changed.

### And the typing #495 actually asked for

`Curve3D.continuityWith` / `Surface.continuityWith` took a raw `Int = 4` — the last two continuity parameters #398/PR#436 never reached. Both now take `ContinuityClass = .c2`, with a deprecated `Int` overload. Neither overload reproduces the saturation rule: they both hand the raw value to the bridge, which owns it and reports where it landed via `order`.

## Source compatibility

One break: `isC0`/`isG1`/`isC1`/`isG2`/`isC2` become `Bool?`. Unshimmable — Swift does not overload a property on its type — so the alternative was leaving five public properties that answer `true` for a class nothing measured. Recorded in `SEMVER.md` under the v1.17.0 precedent, with the migration. Everything else in this PR is additive plus deprecations.

## Also found

The `.c2` branch needs a non-zero second derivative in **both** parametric directions on both surfaces, so `Surface.continuityWith` at the default order returns `nil` for a plane (none in either direction) and for a cylinder (none along its axis). Not a regression — an OCCT precondition the default walks straight into. Pinned by test rather than left to be rediscovered; a sphere is the fixture that reaches C2.

Between that and defect 1, **six pre-existing tests across three targets asserted nothing at all**. They now assert the measurements.

`Scripts/count-operations.py` also showed the base branch one operation short of its derived total (4,277 vs the stated 4,276) before this PR touched anything; `--fix` reconciles it along with this PR's +7.

## Verification

- Ground truth first (`/tmp`-equivalent scratchpad probe, compiled against the pinned xcframework): the three tables above are measured output, not inference.
- **Injected the pre-fix behaviour to prove the new tests catch it** — removing the mask from both `.mm` files fails 18 expectations across 4 tests, with exactly the right signatures: `a.flags & ~measuredMask → 30` at order `.c0` (bits G1/C1/G2/C2 all set), and `atC0.g1Angle → 0.0` where `-1` is expected. Restored and re-verified clean.
- Full `swift test` (`env -u OCCTSWIFT_BRIDGE_PREBUILT`): **4723 tests, all pass**.
- `Scripts/check-bridge-index.py`: 139 stale, unchanged from #484's documented baseline.
- No warnings in any touched file (targets rebuilt from clean, since incremental builds hide them).

Docs updated in the same commit: `CHANGELOG.md`, `SEMVER.md`, `docs/reference/{Curve3D-Analysis,Surface-Analysis,Surface-Advanced,Document-Completions}.md`, `README.md` + `API_REFERENCE.md` totals, and the bridge header's "Continuity vocabularies" block (which gains the measured-result vocabulary it was missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)