### PR TITLE
fix(#494): one resolution behind every GeomLProp local-properties entry point

### DIFF
--- a/Scripts/repro/494-lprop-resolution/README.md
+++ b/Scripts/repro/494-lprop-resolution/README.md
@@ -1,0 +1,132 @@
+# OCCTSwift#494 probes — the `GeomLProp_*` `Resolution` argument
+
+Standalone, deterministic probes for the tolerance divergence #494 fixed, plus the `RealLast()`
+centre-of-curvature defect found while measuring it. No fixture files and no kernel patch: every
+case builds its geometry from a primitive.
+
+## What `Resolution` is
+
+`GeomLProp_SLProps` / `GeomLProp_CLProps` / `GeomLProp_CLProps2d` take a `Resolution` their headers
+describe as "the linear tolerance (it is used to test if a vector is null)". It is not a comparison
+or display tolerance. It decides whether a derivative at one `(u, v)` counts as null, and therefore
+whether the tangent, normal and curvature are reported as *existing* at that point:
+
+```cpp
+// LProp_CurveUtils.hxx, IsTangentDefined
+const double aTolSq = theLinTol * theLinTol;
+...
+if (aV.SquareMagnitude() > aTolSq) { theSigOrder = anOrder; theTanStatus = LProp_Defined; return true; }
+```
+
+Note the direction: a **smaller** resolution is the **more permissive** one. The `1e-10` the
+`Local*` family used to pass called derivatives significant that `Precision::Confusion()` (`1e-7`)
+calls null — three decades *more* willing to treat a degenerate point as well-conditioned. That is
+the opposite of how a tolerance usually reads, and it is why the drift survived #405's audit, whose
+own commit message describes the value it removed as "looser".
+
+For surfaces the resolution reaches `IsCurvatureDefined()` indirectly, via `IsNormalDefined()` and
+`IsTangentUDefined()`/`IsTangentVDefined()`, all three of which take `myLinTol`
+(`GeomLProp_SurfaceUtils.hxx`). `IsCurvatureDefined()` itself takes no tolerance argument, which is
+why grepping for it does not reveal the dependency.
+
+## Building
+
+```bash
+L=Libraries/OCCT.xcframework/macos-arm64
+clang++ -std=c++17 -ObjC++ -w -I"$L/Headers" -L"$L" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/494-lprop-resolution/occt_494_resolution_sweep.cpp -o /tmp/occt_494_sweep
+/tmp/occt_494_sweep
+```
+
+Same command for the other two files. In a git worktree `Libraries/` does not exist — point `L` at
+the main checkout's copy (see `docs/guides/building-occt.md`).
+
+## The three probes
+
+### `occt_494_resolution_sweep.cpp` — where the three values disagree
+
+Sweeps `1e-10`, `Precision::Confusion()` and `1e-6` over a cone approaching its apex, a cubic Bezier
+whose first two poles are a controlled distance apart, and a set of classic degeneracies. Output on
+OCCT 8.0.0p1:
+
+```
+=== SLProps: cone (semi-angle 30 deg, apex radius 0), u=0, varying v ===
+v            | 1e-10 (Local)                | Confusion                    | 1e-6 (LProp*)
+1e-09        | def K=-0        H=-8.66e+08  | UNDEFINED                    | UNDEFINED
+1e-08        | def K=-0        H=-8.66e+07  | UNDEFINED                    | UNDEFINED
+1e-07        | def K=-0        H=-8.66e+06  | UNDEFINED                    | UNDEFINED
+1e-06        | def K=-0        H=-8.66e+05  | def K=-0        H=-8.66e+05  | UNDEFINED
+1e-05        | def K=-0        H=-8.66e+04  | def K=-0        H=-8.66e+04  | def K=-0        H=-8.66e+04
+```
+
+Three sampled `v` values where the `Local*` family reported a defined mean curvature of up to
+`-8.7e8` and every canonical entry point reported the same point undefined. The curve half shows the
+same window as a curvature value: `6.7e19` from `1e-10` against `RealLast()` from
+`Precision::Confusion()`.
+
+It also confirms two things the fix depends on: well-conditioned geometry gives bit-identical values
+at all three resolutions (so converging them changes nothing away from a degeneracy), and the
+`SLProps` curvature accessors *raise* when `IsCurvatureDefined()` is false rather than returning
+zero (so the bridge's `isDefined` check is load-bearing, not belt-and-braces).
+
+### `occt_494_reallast_centre.cpp` — the `(nan, inf, nan)` centre of curvature
+
+At a cusp — first significant derivative of order 2, e.g. a Bezier whose first two poles coincide —
+OCCT returns `RealLast()` from `Curvature()` to mean *infinite* curvature. `IsTangentDefined()` is
+still true, and `RealLast()` passes any "is the curvature big enough to invert" test, so it used to
+flow into `CentreOfCurvature()`:
+
+```
+  d=1e-12    Confusion  tan=1 curv=1.798e+308  centre=(nan, inf, nan)   normal=THROW
+  d=1e-09    Confusion  tan=1 curv=1.798e+308  centre=(inf, inf, nan)   normal=THROW
+```
+
+The mechanism is upstream and independent of which resolution is passed — the probe shows it at all
+three. `LProp_CurveUtils::Curvature()` returns the sentinel on an early path:
+
+```cpp
+if (theSigOrder > 1)
+  return RealLast();                                  // theCurvature NOT assigned
+theCurvature = ComputeCurvature(theD1, theD2, theLinTol * theLinTol);
+```
+
+so `myCurvature` keeps its `= 0.0` initializer, and `CentreOfCurvature()`'s own guard
+(`if (std::abs(theProps.Curvature()) <= theLinTol) throw`) sees `RealLast()`, passes, and calls
+`ComputeCentreOfCurvature(..., theCurvature = 0.0, ...)`, which does `aNorm.Divide(0.0)`.
+`Normal()` was never exposed because it tests for the sentinel by name
+(`if (aCurvature == RealLast() || ...) throw`).
+
+The bridge now rejects the sentinel before either accessor, via
+`occtCurveCurvatureIsInvertible()` in `OCCTBridge_Internal.h`.
+
+### `occt_494_isumbilic_ulp.cpp` — `IsUmbilic()` is a one-ULP test
+
+Not part of the fix; it corrects a docs claim. `Surface.localCurvatureDirections(u:v:)` returns `nil`
+at umbilic points, and was documented as though that covered a sphere. OCCT's test is
+`|maxCurv - minCurv| < Epsilon(maxCurv)` — one ULP, not a geometric tolerance:
+
+```
+Sphere R=3 (analytically umbilic EVERYWHERE):
+  sphere  (u=0 v=0.3)  max=-0.33333333333333331 min=-0.33333333333333331 |diff|=0        umbilic=1
+  sphere  (u=0 v=1)    max=-0.33333333333333331 min=-0.33333333333333337 |diff|=5.55e-17 umbilic=0
+
+Plane (both principal curvatures exactly 0):
+  plane   (u=1 v=2)    max=0 min=0 |diff|=0 Epsilon=4.94e-324 umbilic=1
+```
+
+So an analytically-umbilic sphere is detected as umbilic only where the two computed curvatures
+round to the same `Double` — it depends on the radius and the parameter. A plane always qualifies.
+This is why the regression suite asserts the curvature-defined-but-no-directions asymmetry on a
+plane, where it is exact, rather than on a sphere, where it would be flaky.
+
+## What the fix was
+
+Bridge-only; no kernel patch, no `OCCT.xcframework` rebuild. All 28 `GeomLProp_*` constructions in
+the bridge now go through `occtSurfaceLocalProps` / `occtCurveLocalProps` / `occtCurve2dLocalProps`
+in `OCCTBridge_Internal.h`, which take their resolution from `occtLocalPropsResolution()`; every
+curvature inversion goes through `occtCurveCurvatureIsInvertible()`. Regression coverage is
+`LocalPropsParityTests` in `Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift`.
+
+The 19 `BRepLProp_SLProps`/`BRepLProp_CLProps` constructions still on a literal `1e-6` are
+[#529](https://github.com/SecondMouseAU/OCCTSwift/issues/529).

--- a/Scripts/repro/494-lprop-resolution/occt_494_isumbilic_ulp.cpp
+++ b/Scripts/repro/494-lprop-resolution/occt_494_isumbilic_ulp.cpp
@@ -1,0 +1,44 @@
+// #494: when does GeomLProp_SLProps::IsUmbilic() actually report true?
+// It tests |maxCurv - minCurv| < Epsilon(maxCurv) -- one ULP, not a geometric tolerance.
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_ToroidalSurface.hxx>
+#include <GeomLProp_SLProps.hxx>
+#include <Precision.hxx>
+#include <gp_Ax3.hxx>
+#include <cstdio>
+#include <cmath>
+
+static void report(const char* what, const Handle(Geom_Surface)& s, double u, double v) {
+    GeomLProp_SLProps p(s, u, v, 2, Precision::Confusion());
+    if (!p.IsCurvatureDefined()) { printf("  %-34s (u=%.3g v=%.3g) curvature UNDEFINED\n", what, u, v); return; }
+    double mx = p.MaxCurvature(), mn = p.MinCurvature();
+    bool umb = false;
+    try { umb = p.IsUmbilic(); } catch (...) { printf("  %-34s IsUmbilic threw\n", what); return; }
+    printf("  %-34s (u=%.3g v=%.3g) max=%.17g min=%.17g |diff|=%.3g Epsilon=%.3g umbilic=%d\n",
+           what, u, v, mx, mn, std::abs(mx - mn), std::abs(Epsilon(mx)), umb ? 1 : 0);
+}
+
+int main() {
+    Handle(Geom_SphericalSurface) sph = new Geom_SphericalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 3.0);
+    Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 5.0);
+    Handle(Geom_Plane) pln = new Geom_Plane(gp_Pnt(0,0,0), gp_Dir(0,0,1));
+    Handle(Geom_ToroidalSurface) tor = new Geom_ToroidalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 10.0, 3.0);
+
+    printf("Sphere R=3 (analytically umbilic EVERYWHERE):\n");
+    for (double v : {0.0, 0.3, 0.5, 1.0, -0.7}) report("sphere", sph, 0.0, v);
+    for (double u : {0.5, 1.3, 2.7}) report("sphere off-meridian", sph, u, 0.3);
+
+    printf("\nPlane (both principal curvatures exactly 0):\n");
+    for (double u : {0.0, 1.0, -4.0}) report("plane", pln, u, 2.0);
+
+    printf("\nCylinder R=5 (never umbilic):\n");
+    for (double v : {0.0, 1.0}) report("cylinder", cyl, 0.3, v);
+
+    printf("\nTorus (never umbilic):\n");
+    report("torus", tor, 0.3, 0.7);
+
+    printf("\nDONE\n");
+    return 0;
+}

--- a/Scripts/repro/494-lprop-resolution/occt_494_reallast_centre.cpp
+++ b/Scripts/repro/494-lprop-resolution/occt_494_reallast_centre.cpp
@@ -1,0 +1,74 @@
+// #494 follow-up probe: what do the centre-of-curvature / normal accessors actually produce in the
+// band where Curvature() returns RealLast() (significant derivative order > 1)?
+#include <Geom_BezierCurve.hxx>
+#include <GeomLProp_CLProps.hxx>
+#include <GeomLProp_SLProps.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Precision.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <gp_Ax3.hxx>
+#include <cstdio>
+#include <cmath>
+
+static const double TOLS[3] = {1e-10, Precision::Confusion(), 1e-6};
+static const char*  NAMES[3] = {"1e-10", "Confusion", "1e-6"};
+
+int main() {
+    printf("=== cubic Bezier, |D1(0)|=3d, u=0: full accessor behaviour ===\n");
+    const double ds[] = {0.0, 1e-12, 1e-10, 1e-9, 1e-8, 1e-7, 1e-6, 1e-3};
+    for (double d : ds) {
+        TColgp_Array1OfPnt poles(1, 4);
+        poles.SetValue(1, gp_Pnt(0, 0, 0));
+        poles.SetValue(2, gp_Pnt(d, 0, 0));
+        poles.SetValue(3, gp_Pnt(1, 1, 0));
+        poles.SetValue(4, gp_Pnt(2, 0, 0));
+        Handle(Geom_BezierCurve) bez = new Geom_BezierCurve(poles);
+        for (int t = 0; t < 3; ++t) {
+            GeomLProp_CLProps p(bez, 0.0, 2, TOLS[t]);
+            double curv = -1;
+            bool curvThrew = false;
+            try { curv = p.Curvature(); } catch (...) { curvThrew = true; }
+            char cen[96] = "THROW";
+            try {
+                gp_Pnt c;
+                p.CentreOfCurvature(c);
+                snprintf(cen, sizeof cen, "(%.4g, %.4g, %.4g)", c.X(), c.Y(), c.Z());
+            } catch (...) {}
+            char nrm[64] = "THROW";
+            try {
+                gp_Dir n; p.Normal(n);
+                snprintf(nrm, sizeof nrm, "(%.3g,%.3g,%.3g)", n.X(), n.Y(), n.Z());
+            } catch (...) {}
+            printf("  d=%-8.0e %-10s tan=%d curv=%-12.4g%s centre=%-30s normal=%s\n",
+                   d, NAMES[t], p.IsTangentDefined() ? 1 : 0, curv,
+                   curvThrew ? "(THREW)" : "       ", cen, nrm);
+        }
+        printf("\n");
+    }
+
+    printf("=== Is RealLast() curvature reachable from the *canonical* bridge gate? ===\n");
+    printf("RealLast() = %.4g ; Confusion = %.4g\n", RealLast(), Precision::Confusion());
+    printf("canonical gate 'curv < Confusion' rejects RealLast? %s\n",
+           (RealLast() < Precision::Confusion()) ? "yes" : "NO -> it proceeds");
+    printf("local gate 'curv > 1e-10' accepts RealLast? %s\n",
+           (RealLast() > 1e-10) ? "YES -> it proceeds" : "no");
+
+    // Surface: does an UNDEFINED curvature leave Max/Min/Mean/Gaussian readable at all?
+    printf("\n=== SLProps accessors when IsCurvatureDefined() is false (cone v=1e-8) ===\n");
+    Handle(Geom_ConicalSurface) cone =
+        new Geom_ConicalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), M_PI/6.0, 0.0);
+    for (int t = 0; t < 3; ++t) {
+        GeomLProp_SLProps p(cone, 0.0, 1e-8, 2, TOLS[t]);
+        bool def = p.IsCurvatureDefined();
+        char vals[128] = "n/a";
+        bool threw = false;
+        try {
+            snprintf(vals, sizeof vals, "K=%.4g H=%.4g max=%.4g min=%.4g",
+                     p.GaussianCurvature(), p.MeanCurvature(), p.MaxCurvature(), p.MinCurvature());
+        } catch (...) { threw = true; }
+        printf("  %-10s defined=%d  %s%s\n", NAMES[t], def ? 1 : 0,
+               threw ? "accessors THREW" : vals, threw ? "" : "");
+    }
+    printf("\nDONE\n");
+    return 0;
+}

--- a/Scripts/repro/494-lprop-resolution/occt_494_resolution_sweep.cpp
+++ b/Scripts/repro/494-lprop-resolution/occt_494_resolution_sweep.cpp
@@ -1,0 +1,156 @@
+// #494 ground truth: does the GeomLProp Resolution argument (1e-10 vs Precision::Confusion()
+// vs 1e-6) actually change what the Local* / canonical curvature entry points report?
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Line.hxx>
+#include <GeomLProp_SLProps.hxx>
+#include <GeomLProp_CLProps.hxx>
+#include <Precision.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <gp_Ax3.hxx>
+#include <Standard_Failure.hxx>
+#include <cstdio>
+#include <cmath>
+
+static const double TOLS[3] = {1e-10, Precision::Confusion(), 1e-6};
+static const char*  NAMES[3] = {"1e-10 (Local)", "Confusion", "1e-6 (LProp*)"};
+
+// --- Surface side: cone, sampled at V distances that straddle the tolerance band ---
+static void surfaceSweep() {
+    printf("\n=== SLProps: cone (semi-angle 30 deg, apex radius 0), u=0, varying v ===\n");
+    printf("%-12s | %-28s | %-28s | %-28s\n", "v", NAMES[0], NAMES[1], NAMES[2]);
+    Handle(Geom_ConicalSurface) cone =
+        new Geom_ConicalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), M_PI/6.0, 0.0);
+
+    const double vs[] = {0.0, 1e-12, 1e-10, 1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-2, 1.0};
+    for (double v : vs) {
+        printf("%-12.0e |", v);
+        for (int t = 0; t < 3; ++t) {
+            char cell[64];
+            try {
+                GeomLProp_SLProps p(cone, 0.0, v, 2, TOLS[t]);
+                if (p.IsCurvatureDefined()) {
+                    snprintf(cell, sizeof cell, "def K=%-9.3g H=%-9.3g", p.GaussianCurvature(), p.MeanCurvature());
+                } else {
+                    snprintf(cell, sizeof cell, "UNDEFINED");
+                }
+            } catch (Standard_Failure const& f) {
+                snprintf(cell, sizeof cell, "throw %s", f.GetMessageString());
+            } catch (...) { snprintf(cell, sizeof cell, "throw ..."); }
+            printf(" %-28s |", cell);
+        }
+        printf("\n");
+    }
+}
+
+// A "shrinking-lobe" Bezier: pole 1 sits distance d from pole 0, so |D1(0)| = 3d.
+static void curveSweep() {
+    printf("\n=== CLProps: cubic Bezier, |D1(0)| = 3*d, at u=0 ===\n");
+    printf("%-12s | %-34s | %-34s | %-34s\n", "d", NAMES[0], NAMES[1], NAMES[2]);
+    const double ds[] = {0.0, 1e-12, 1e-10, 1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-3, 1.0};
+    for (double d : ds) {
+        TColgp_Array1OfPnt poles(1, 4);
+        poles.SetValue(1, gp_Pnt(0, 0, 0));
+        poles.SetValue(2, gp_Pnt(d, 0, 0));
+        poles.SetValue(3, gp_Pnt(1, 1, 0));
+        poles.SetValue(4, gp_Pnt(2, 0, 0));
+        Handle(Geom_BezierCurve) bez = new Geom_BezierCurve(poles);
+        printf("%-12.0e |", d);
+        for (int t = 0; t < 3; ++t) {
+            char cell[80];
+            try {
+                GeomLProp_CLProps p(bez, 0.0, 2, TOLS[t]);
+                bool tanDef = p.IsTangentDefined();
+                // mirror OCCTCurve3DLocalCurvature: Curvature() with NO IsTangentDefined guard
+                char curv[32] = "-";
+                try { snprintf(curv, sizeof curv, "%.4g", p.Curvature()); }
+                catch (...) { snprintf(curv, sizeof curv, "THROW"); }
+                char cen[24] = "-";
+                try { gp_Pnt c; p.CentreOfCurvature(c); snprintf(cen, sizeof cen, "ok"); }
+                catch (...) { snprintf(cen, sizeof cen, "THROW"); }
+                snprintf(cell, sizeof cell, "tan=%d curv=%-10s centre=%s", tanDef ? 1 : 0, curv, cen);
+            } catch (...) { snprintf(cell, sizeof cell, "ctor threw"); }
+            printf(" %-34s |", cell);
+        }
+        printf("\n");
+    }
+}
+
+// Does the *value* of curvature change with Resolution on well-conditioned geometry?
+static void wellConditioned() {
+    printf("\n=== Well-conditioned sanity: values must be identical across all 3 tolerances ===\n");
+    Handle(Geom_Circle) circ = new Geom_Circle(gp_Ax2(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 5.0);
+    Handle(Geom_SphericalSurface) sph =
+        new Geom_SphericalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 3.0);
+    Handle(Geom_CylindricalSurface) cyl =
+        new Geom_CylindricalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 2.0);
+    for (int t = 0; t < 3; ++t) {
+        GeomLProp_CLProps pc(circ, 0.7, 2, TOLS[t]);
+        GeomLProp_SLProps ps(sph, 0.3, 0.4, 2, TOLS[t]);
+        GeomLProp_SLProps pcy(cyl, 0.3, 1.0, 2, TOLS[t]);
+        printf("  %-14s circle k=%.17g | sphere K=%.17g | cyl H=%.17g umbilic=%d\n",
+               NAMES[t], pc.Curvature(), ps.GaussianCurvature(), pcy.MeanCurvature(),
+               pcy.IsUmbilic() ? 1 : 0);
+    }
+    // A straight line: curvature 0, centre undefined at every tolerance
+    Handle(Geom_Line) line = new Geom_Line(gp_Pnt(0,0,0), gp_Dir(1,0,0));
+    for (int t = 0; t < 3; ++t) {
+        GeomLProp_CLProps p(line, 1.0, 2, TOLS[t]);
+        bool centreThrew = false;
+        try { gp_Pnt c; p.CentreOfCurvature(c); } catch (...) { centreThrew = true; }
+        bool normalThrew = false;
+        try { gp_Dir n; p.Normal(n); } catch (...) { normalThrew = true; }
+        printf("  %-14s line   tan=%d curv=%.17g centreThrew=%d normalThrew=%d\n",
+               NAMES[t], p.IsTangentDefined() ? 1 : 0, p.Curvature(), centreThrew, normalThrew);
+    }
+}
+
+// Cone apex exactly (what SurfaceCurvatureParityTests uses) + a sphere pole.
+static void degenerateSpots() {
+    printf("\n=== Classic degeneracies ===\n");
+    Handle(Geom_ConicalSurface) cone =
+        new Geom_ConicalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), M_PI/6.0, 5.0);
+    // apex is at v = -R/sin(angle) = -10
+    Handle(Geom_SphericalSurface) sph =
+        new Geom_SphericalSurface(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 3.0);
+    struct { const char* what; Handle(Geom_Surface) s; double u, v; } cases[] = {
+        {"cone apex (v=-10)", cone, 0.0, -10.0},
+        {"cone near apex (v=-10+1e-9)", cone, 0.0, -10.0 + 1e-9},
+        {"cone near apex (v=-10+1e-8)", cone, 0.0, -10.0 + 1e-8},
+        {"sphere north pole (v=pi/2)", sph, 0.0, M_PI/2.0},
+        {"sphere v=pi/2-1e-9", sph, 0.0, M_PI/2.0 - 1e-9},
+    };
+    for (auto& c : cases) {
+        printf("  %-30s |", c.what);
+        for (int t = 0; t < 3; ++t) {
+            char cell[48];
+            try {
+                GeomLProp_SLProps p(c.s, c.u, c.v, 2, TOLS[t]);
+                if (p.IsCurvatureDefined())
+                    snprintf(cell, sizeof cell, "def K=%.3g", p.GaussianCurvature());
+                else
+                    snprintf(cell, sizeof cell, "UNDEF");
+            } catch (...) { snprintf(cell, sizeof cell, "throw"); }
+            printf(" %-18s |", cell);
+        }
+        printf("\n");
+    }
+}
+
+int main() {
+    printf("Precision::Confusion() = %.17g\n", Precision::Confusion());
+#ifdef No_Exception
+    printf("No_Exception: DEFINED in this TU (LProp_NotDefined_Raise_if compiles out)\n");
+#else
+    printf("No_Exception: not defined in this TU (LProp_NotDefined_Raise_if is live)\n");
+#endif
+    surfaceSweep();
+    curveSweep();
+    wellConditioned();
+    degenerateSpots();
+    printf("\nDONE\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -8455,6 +8455,12 @@ typedef struct {
     double cx, cy, cz;       // center of curvature (0 if undefined)
     double curvature;        // curvature value
     bool tangentDefined;
+    // Whether nx/ny/nz and cx/cy/cz hold anything: the curvature has to be invertible into a
+    // radius, which rules out both zero (a straight stretch, or an inflection) and OCCT's
+    // RealLast() infinite-curvature sentinel at a cusp. Added in #494 so callers stop re-deriving
+    // it from `curvature` against a magic number of their own — the Swift wrapper used to test
+    // `curvature > 1e-10`, which was a copy of a bridge-side literal that no longer exists.
+    bool curvatureInvertible;
 } OCCTCurveLocalProps;
 
 OCCTCurveLocalProps OCCTGeomLPropCLProps(OCCTShapeRef edgeShape, double param);

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -2971,7 +2971,7 @@ int32_t OCCTBRepGraphSampleFaceUVGrid(OCCTBRepGraphRef g, int32_t faceIndex,
                 double u = uMin + iu * uStep;
                 int32_t idx = iv * uSamples + iu;
 
-                GeomLProp_SLProps props(surfHandle, u, v, 2, Precision::Confusion());
+                GeomLProp_SLProps props = occtSurfaceLocalProps(surfHandle, u, v, 2);
 
                 // Position
                 gp_Pnt pnt = props.Value();

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -865,8 +865,7 @@ int32_t OCCTCurve3DDrawDeflection(OCCTCurve3DRef c, double deflection,
 double OCCTCurve3DGetCurvature(OCCTCurve3DRef c, double u) {
     if (!c || c->curve.IsNull()) return 0.0;
     try {
-        GeomLProp_CLProps props(c->curve, 2, Precision::Confusion());
-        props.SetParameter(u);
+        GeomLProp_CLProps props = occtCurveLocalProps(c->curve, u, 2);
         if (!props.IsTangentDefined()) return 0.0;
         return props.Curvature();
     } catch (...) {
@@ -878,8 +877,7 @@ bool OCCTCurve3DGetTangent(OCCTCurve3DRef c, double u,
                             double* tx, double* ty, double* tz) {
     if (!c || c->curve.IsNull() || !tx || !ty || !tz) return false;
     try {
-        GeomLProp_CLProps props(c->curve, 1, Precision::Confusion());
-        props.SetParameter(u);
+        GeomLProp_CLProps props = occtCurveLocalProps(c->curve, u, 1);
         if (!props.IsTangentDefined()) return false;
         gp_Dir dir;
         props.Tangent(dir);
@@ -894,8 +892,7 @@ bool OCCTCurve3DGetNormal(OCCTCurve3DRef c, double u,
                            double* nx, double* ny, double* nz) {
     if (!c || c->curve.IsNull() || !nx || !ny || !nz) return false;
     try {
-        GeomLProp_CLProps props(c->curve, 2, Precision::Confusion());
-        props.SetParameter(u);
+        GeomLProp_CLProps props = occtCurveLocalProps(c->curve, u, 2);
         if (!props.IsTangentDefined()) return false;
         gp_Dir dir;
         props.Normal(dir);
@@ -910,10 +907,12 @@ bool OCCTCurve3DGetCenterOfCurvature(OCCTCurve3DRef c, double u,
                                       double* cx, double* cy, double* cz) {
     if (!c || c->curve.IsNull() || !cx || !cy || !cz) return false;
     try {
-        GeomLProp_CLProps props(c->curve, 2, Precision::Confusion());
-        props.SetParameter(u);
+        GeomLProp_CLProps props = occtCurveLocalProps(c->curve, u, 2);
         if (!props.IsTangentDefined()) return false;
-        if (props.Curvature() < Precision::Confusion()) return false;
+        // Rejects a cusp's RealLast() curvature as well as a straight stretch's zero; the plain
+        // "is it big enough" test this used to make let the sentinel through, and OCCT then handed
+        // back (nan, inf, nan) as a successfully computed centre (#494).
+        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
         gp_Pnt center;
         props.CentreOfCurvature(center);
         *cx = center.X(); *cy = center.Y(); *cz = center.Z();
@@ -4739,9 +4738,23 @@ OCCTCurve3DRef _Nullable OCCTHelixApproxToBSpline(double t1, double t2, double p
 // gp_Ax3
 
 // MARK: - v0.116: Curve3D Local Curvature/Tangent/Normal/CentreOfCurvature
+//
+// The same four GeomLProp_CLProps quantities as OCCTCurve3DGetCurvature / GetTangent / GetNormal /
+// GetCenterOfCurvature, in the isDefined-out-parameter shape the v0.116 Swift API wanted. All four
+// used to pass a hardcoded 1e-10 resolution instead of the shared one, so they disagreed with their
+// canonical counterparts about the same curve at the same parameter: on a cubic Bezier whose first
+// two poles sit 1e-8 apart, the 1e-10 props returned curvature 6.67e15 where the canonical props
+// returned RealLast(). They now build props through occtCurveLocalProps (#494).
 double OCCTCurve3DLocalCurvature(OCCTCurve3DRef _Nonnull curve, double u) {
+    if (curve->curve.IsNull()) return 0.0;
     try {
-        GeomLProp_CLProps props(curve->curve, u, 2, 1e-10);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve->curve, u, 2);
+        // Curvature() reads derivatives IsTangentDefined() is what establishes as meaningful. It
+        // does raise LProp_NotDefined itself, but only through LProp_NotDefined_Raise_if, which
+        // compiles out under No_Exception — defined for the OCCT build, not for this one. Asking
+        // first, as the canonical sibling does, does not depend on which side of that macro the
+        // code lands on.
+        if (!props.IsTangentDefined()) return 0.0;
         return props.Curvature();
     } catch (...) { return 0.0; }
 }
@@ -4749,8 +4762,12 @@ double OCCTCurve3DLocalCurvature(OCCTCurve3DRef _Nonnull curve, double u) {
 void OCCTCurve3DLocalTangent(OCCTCurve3DRef _Nonnull curve, double u,
                                double* _Nonnull tx, double* _Nonnull ty, double* _Nonnull tz,
                                bool* _Nonnull isDefined) {
+    if (curve->curve.IsNull()) {
+        *isDefined = false; *tx = 0; *ty = 0; *tz = 0;
+        return;
+    }
     try {
-        GeomLProp_CLProps props(curve->curve, u, 1, 1e-10);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve->curve, u, 1);
         *isDefined = props.IsTangentDefined();
         if (*isDefined) {
             gp_Dir d;
@@ -4765,8 +4782,12 @@ void OCCTCurve3DLocalTangent(OCCTCurve3DRef _Nonnull curve, double u,
 void OCCTCurve3DLocalNormal(OCCTCurve3DRef _Nonnull curve, double u,
                               double* _Nonnull nx, double* _Nonnull ny, double* _Nonnull nz,
                               bool* _Nonnull isDefined) {
+    if (curve->curve.IsNull()) {
+        *isDefined = false; *nx = 0; *ny = 0; *nz = 0;
+        return;
+    }
     try {
-        GeomLProp_CLProps props(curve->curve, u, 2, 1e-10);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve->curve, u, 2);
         *isDefined = props.IsTangentDefined();
         if (*isDefined) {
             gp_Dir n;
@@ -4781,10 +4802,16 @@ void OCCTCurve3DLocalNormal(OCCTCurve3DRef _Nonnull curve, double u,
 void OCCTCurve3DLocalCentreOfCurvature(OCCTCurve3DRef _Nonnull curve, double u,
                                          double* _Nonnull cx, double* _Nonnull cy, double* _Nonnull cz,
                                          bool* _Nonnull isDefined) {
+    if (curve->curve.IsNull()) {
+        *isDefined = false; *cx = 0; *cy = 0; *cz = 0;
+        return;
+    }
     try {
-        GeomLProp_CLProps props(curve->curve, u, 2, 1e-10);
-        double curv = props.Curvature();
-        if (curv > 1e-10 && props.IsTangentDefined()) {
+        GeomLProp_CLProps props = occtCurveLocalProps(curve->curve, u, 2);
+        // Two separate 1000x splits from the canonical sibling used to live on the next line: the
+        // props resolution (above) and this gate's own 1e-10 literal, which also let a cusp's
+        // RealLast() curvature through into a (nan, inf, nan) centre. Both now share one value.
+        if (props.IsTangentDefined() && occtCurveCurvatureIsInvertible(props.Curvature())) {
             gp_Pnt p;
             props.CentreOfCurvature(p);
             *cx = p.X(); *cy = p.Y(); *cz = p.Z();

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -5631,7 +5631,11 @@ OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves, int32_t co
 double OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u) {
     if (!c || c->curve.IsNull()) return 0.0;
     try {
-        GeomLProp_CLProps2d props(c->curve, u, 2, Precision::Confusion());
+        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+        // Curvature() is only meaningful once the tangent is established. It does raise otherwise,
+        // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception — defined
+        // for the OCCT build, not for this one. Matches OCCTCurve3DGetCurvature (#494).
+        if (!props.IsTangentDefined()) return 0.0;
         return props.Curvature();
     } catch (...) {
         return 0.0;
@@ -5641,9 +5645,10 @@ double OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u) {
 bool OCCTCurve2DGetNormal(OCCTCurve2DRef c, double u, double* nx, double* ny) {
     if (!c || c->curve.IsNull() || !nx || !ny) return false;
     try {
-        GeomLProp_CLProps2d props(c->curve, u, 2, Precision::Confusion());
+        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
         if (!props.IsTangentDefined()) return false;
-        if (props.Curvature() < Precision::Confusion()) return false;
+        // Rejects a cusp's RealLast() curvature as well as a straight stretch's zero (#494).
+        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
         gp_Dir2d n;
         props.Normal(n);
         *nx = n.X(); *ny = n.Y();
@@ -5656,7 +5661,7 @@ bool OCCTCurve2DGetNormal(OCCTCurve2DRef c, double u, double* nx, double* ny) {
 bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef c, double u, double* tx, double* ty) {
     if (!c || c->curve.IsNull() || !tx || !ty) return false;
     try {
-        GeomLProp_CLProps2d props(c->curve, u, 1, Precision::Confusion());
+        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 1);
         if (!props.IsTangentDefined()) return false;
         gp_Dir2d t;
         props.Tangent(t);
@@ -5670,9 +5675,10 @@ bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef c, double u, double* tx, double* ty
 bool OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef c, double u, double* cx, double* cy) {
     if (!c || c->curve.IsNull() || !cx || !cy) return false;
     try {
-        GeomLProp_CLProps2d props(c->curve, u, 2, Precision::Confusion());
+        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
         if (!props.IsTangentDefined()) return false;
-        if (props.Curvature() < Precision::Confusion()) return false;
+        // Rejects a cusp's RealLast() curvature, which used to reach CentreOfCurvature (#494).
+        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
         gp_Pnt2d center;
         props.CentreOfCurvature(center);
         *cx = center.X(); *cy = center.Y();

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -62,6 +62,11 @@
 #include <TopoDS.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TopTools_ListOfShape.hxx>
+// These four serve the local-properties helpers (occtSurfaceLocalProps and friends).
+#include <GeomLProp_SLProps.hxx>
+#include <GeomLProp_CLProps.hxx>
+#include <Precision.hxx>
+#include <cmath>
 
 // === Foundation struct definitions ===
 
@@ -888,6 +893,80 @@ inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int3
     TopTools_IndexedMapOfShape map;
     if (index >= occtMapSubShapes(shape, type, map)) return TopoDS_Shape();
     return map(index + 1);  // OCCT's indexed maps are 1-based
+}
+
+// === #405/#494: one resolution behind every GeomLProp_* local-property construction ===
+//
+// GeomLProp_SLProps / GeomLProp_CLProps / GeomLProp_CLProps2d each take a `Resolution` their own
+// headers document as "the linear tolerance (it is used to test if a vector is null)". It is not a
+// comparison or display tolerance: it decides whether a derivative at one (u, v) counts as null,
+// and so whether the tangent, normal and curvature are reported as existing at all. Two entry
+// points that pass different values disagree about the *existence* of curvature at the same point
+// on the same geometry, which is the defect #405 fixed for three Surface entry points and #494
+// finished for the rest.
+//
+// A *smaller* resolution is the more permissive one. The null test is
+// `derivative.SquareMagnitude() > resolution * resolution`, so the 1e-10 the Local* family used to
+// pass called a derivative significant that Precision::Confusion() calls null -- the opposite of
+// how a tolerance usually reads, which is why the drift survived #405's own audit.
+//
+// Measured before converging them (Scripts/repro/494-lprop-resolution/): on a cone approaching its
+// apex, 1e-10 reports curvature defined with mean curvature -8.66e7 at v = 1e-8 where
+// Precision::Confusion() reports it undefined; on a cubic Bezier whose first two poles sit 1e-8
+// apart, 1e-10 returns curvature 6.67e15 where Precision::Confusion() returns RealLast(). The
+// third value in play, the 1e-6 of OCCTGeomLPropCLProps/OCCTGeomLPropSLProps, was the same value
+// #405 removed from OCCTSurfaceCurvatures.
+//
+// The 19 BRepLProp_SLProps/BRepLProp_CLProps constructions elsewhere in the bridge still pass a
+// literal 1e-6. They are a different (adaptor-based) class family asking the same question of a
+// face rather than a surface, tracked separately -- this accessor is the value they should adopt.
+inline double occtLocalPropsResolution() { return Precision::Confusion(); }
+
+// Construct the local-properties object for a surface at (u, v), computing derivatives up to
+// `order` (1 for tangents and the normal, 2 for curvature). C++17 guarantees the returned prvalue
+// is constructed directly into the caller's variable, so nothing is copied or moved.
+inline GeomLProp_SLProps occtSurfaceLocalProps(const occ::handle<Geom_Surface>& surface,
+                                                double u, double v, int order) {
+    return GeomLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
+}
+
+// Curve counterpart. The parameter is bound here rather than through a later SetParameter() call,
+// which the two-step callers (construct, then SetParameter) get for free.
+inline GeomLProp_CLProps occtCurveLocalProps(const occ::handle<Geom_Curve>& curve,
+                                              double u, int order) {
+    return GeomLProp_CLProps(curve, u, order, occtLocalPropsResolution());
+}
+
+// 2D curve counterpart, over Geom2d_Curve.
+inline GeomLProp_CLProps2d occtCurve2dLocalProps(const occ::handle<Geom2d_Curve>& curve,
+                                                  double u, int order) {
+    return GeomLProp_CLProps2d(curve, u, order, occtLocalPropsResolution());
+}
+
+// Whether a curvature reported by GeomLProp_CLProps/CLProps2d can be turned into a radius, and so
+// into a normal direction or a centre of curvature.
+//
+// Two ways it cannot, and every bridge entry point that inverts a curvature has to reject both:
+//
+//   - Curvature at or below the resolution. A straight stretch of curve has no centre of
+//     curvature; OCCT's own CentreOfCurvature() throws LProp_NotDefined here.
+//
+//   - Curvature exactly RealLast(). OCCT returns that sentinel, meaning infinite curvature, when
+//     the first significant derivative has order > 1 -- a cusp, e.g. a Bezier whose first two
+//     poles coincide. IsTangentDefined() is still true there (the search falls through to D2), and
+//     RealLast() passes any "is the curvature big enough" test, so the sentinel used to flow
+//     straight into CentreOfCurvature(). That is worse than an exception: LProp_CurveUtils::
+//     Curvature() returns the sentinel *without* assigning the myCurvature field it normally sets,
+//     leaving it 0.0, so ComputeCentreOfCurvature divides the normal by zero and the caller gets
+//     (nan, inf, nan) reported as a successfully computed point. Measured on the same cusped
+//     Bezier. Normal() rejects the sentinel explicitly and throws, so it was never exposed there.
+//
+// Non-finite values cannot arise from OCCT's own arithmetic here, but are rejected too so that a
+// caller of this predicate never has to ask a second question about the value it approved.
+inline bool occtCurveCurvatureIsInvertible(double curvature) {
+    return std::isfinite(curvature)
+        && curvature != RealLast()
+        && std::abs(curvature) > occtLocalPropsResolution();
 }
 
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -116,7 +116,7 @@ bool OCCTFaceGetNormalAtUV(OCCTFaceRef face, double u, double v,
         Handle(Geom_Surface) surface = BRep_Tool::Surface(face->face);
         if (surface.IsNull()) return false;
 
-        GeomLProp_SLProps props(surface, u, v, 1, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surface, u, v, 1);
         if (!props.IsNormalDefined()) return false;
 
         gp_Dir normal = props.Normal();
@@ -141,7 +141,7 @@ bool OCCTFaceGetGaussianCurvature(OCCTFaceRef face, double u, double v,
         Handle(Geom_Surface) surface = BRep_Tool::Surface(face->face);
         if (surface.IsNull()) return false;
 
-        GeomLProp_SLProps props(surface, u, v, 2, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surface, u, v, 2);
         if (!props.IsCurvatureDefined()) return false;
 
         *curvature = props.GaussianCurvature();
@@ -159,7 +159,7 @@ bool OCCTFaceGetMeanCurvature(OCCTFaceRef face, double u, double v,
         Handle(Geom_Surface) surface = BRep_Tool::Surface(face->face);
         if (surface.IsNull()) return false;
 
-        GeomLProp_SLProps props(surface, u, v, 2, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surface, u, v, 2);
         if (!props.IsCurvatureDefined()) return false;
 
         *curvature = props.MeanCurvature();
@@ -180,7 +180,7 @@ bool OCCTFaceGetPrincipalCurvatures(OCCTFaceRef face, double u, double v,
         Handle(Geom_Surface) surface = BRep_Tool::Surface(face->face);
         if (surface.IsNull()) return false;
 
-        GeomLProp_SLProps props(surface, u, v, 2, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surface, u, v, 2);
         if (!props.IsCurvatureDefined()) return false;
 
         *k1 = props.MinCurvature();
@@ -334,8 +334,7 @@ bool OCCTEdgeGetCurvature3D(OCCTEdgeRef edge, double param, double* curvature) {
         Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
         if (curve.IsNull()) return false;
 
-        GeomLProp_CLProps props(curve, 2, Precision::Confusion());
-        props.SetParameter(param);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve, param, 2);
         if (!props.IsTangentDefined()) return false;
 
         *curvature = props.Curvature();
@@ -354,8 +353,7 @@ bool OCCTEdgeGetTangent3D(OCCTEdgeRef edge, double param,
         Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
         if (curve.IsNull()) return false;
 
-        GeomLProp_CLProps props(curve, 1, Precision::Confusion());
-        props.SetParameter(param);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve, param, 1);
         if (!props.IsTangentDefined()) return false;
 
         gp_Dir dir;
@@ -378,8 +376,7 @@ bool OCCTEdgeGetNormal3D(OCCTEdgeRef edge, double param,
         Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
         if (curve.IsNull()) return false;
 
-        GeomLProp_CLProps props(curve, 2, Precision::Confusion());
-        props.SetParameter(param);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve, param, 2);
         if (!props.IsTangentDefined()) return false;
 
         gp_Dir dir;
@@ -402,11 +399,12 @@ bool OCCTEdgeGetCenterOfCurvature3D(OCCTEdgeRef edge, double param,
         Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
         if (curve.IsNull()) return false;
 
-        GeomLProp_CLProps props(curve, 2, Precision::Confusion());
-        props.SetParameter(param);
+        GeomLProp_CLProps props = occtCurveLocalProps(curve, param, 2);
         if (!props.IsTangentDefined()) return false;
 
-        if (props.Curvature() < Precision::Confusion()) return false;
+        // Also rejects a cusp's RealLast() curvature, which the previous magnitude-only test let
+        // through into a (nan, inf, nan) centre reported as success (#494).
+        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
 
         gp_Pnt center;
         props.CentreOfCurvature(center);
@@ -1040,18 +1038,29 @@ OCCTCurveLocalProps OCCTGeomLPropCLProps(OCCTShapeRef edgeShape, double param) {
         Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, f, l);
         if (curve.IsNull()) return result;
 
-        GeomLProp_CLProps props(curve, param, 2, 1e-6);
+        // Was its own 1e-6 resolution, the third value the bridge passed to a GeomLProp_* props
+        // (Precision::Confusion() from the canonical Curve3D/Surface entry points, 1e-10 from the
+        // Local* family) and the same one #405 removed from OCCTSurfaceCurvatures — so this
+        // reported a different answer than Edge.curvature3D(at:) for the same edge and parameter.
+        GeomLProp_CLProps props = occtCurveLocalProps(curve, param, 2);
         gp_Pnt pt = props.Value();
         result.px = pt.X(); result.py = pt.Y(); result.pz = pt.Z();
-        result.curvature = props.Curvature();
+        // Asked before Curvature(), which is only meaningful once the tangent is established; the
+        // old order relied on Curvature() raising, and it raises through
+        // LProp_NotDefined_Raise_if, which compiles out under No_Exception.
         result.tangentDefined = props.IsTangentDefined();
 
         if (result.tangentDefined) {
+            result.curvature = props.Curvature();
+
             gp_Dir tangent;
             props.Tangent(tangent);
             result.tx = tangent.X(); result.ty = tangent.Y(); result.tz = tangent.Z();
 
-            if (result.curvature > 1e-10) {
+            // Rejects a cusp's RealLast() curvature too: Normal() raises on it, but
+            // CentreOfCurvature() does not, and used to yield (nan, inf, nan) (#494).
+            result.curvatureInvertible = occtCurveCurvatureIsInvertible(result.curvature);
+            if (result.curvatureInvertible) {
                 gp_Dir normal;
                 props.Normal(normal);
                 result.nx = normal.X(); result.ny = normal.Y(); result.nz = normal.Z();
@@ -1075,7 +1084,10 @@ OCCTSurfaceLocalProps OCCTGeomLPropSLProps(OCCTShapeRef faceShape, double u, dou
         Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
         if (surf.IsNull()) return result;
 
-        GeomLProp_SLProps props(surf, u, v, 2, 1e-6);
+        // Same 1e-6 drift as OCCTGeomLPropCLProps above: this disagreed with
+        // OCCTFaceGetGaussianCurvature/MeanCurvature/PrincipalCurvatures, which read the same
+        // quantities off the same surface through Precision::Confusion() props (#494).
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surf, u, v, 2);
         gp_Pnt pt = props.Value();
         result.px = pt.X(); result.py = pt.Y(); result.pz = pt.Z();
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -274,7 +274,7 @@ bool OCCTSurfaceGetNormal(OCCTSurfaceRef s, double u, double v,
                            double* nx, double* ny, double* nz) {
     if (!s || s->surface.IsNull() || !nx || !ny || !nz) return false;
     try {
-        GeomLProp_SLProps props(s->surface, u, v, 1, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 1);
         if (!props.IsNormalDefined()) return false;
         gp_Dir n = props.Normal();
         *nx = n.X(); *ny = n.Y(); *nz = n.Z();
@@ -824,14 +824,16 @@ int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
 // resolution argument — the linear tolerance IsCurvatureDefined() tests tangent vectors against
 // for nullity — is stated once. OCCTSurfaceCurvatures used to construct its own with a hardcoded
 // 1e-6, 10x looser than Precision::Confusion(), so the two APIs could disagree about whether
-// curvature is defined at all for the same surface and the same (u, v) (#405).
+// curvature is defined at all for the same surface and the same (u, v) (#405). The resolution
+// itself now comes from occtLocalPropsResolution(), shared with the Local* family that #405 left
+// on its own 1e-10 (#494).
 // Returns false (leaving the outputs untouched) where curvature is undefined; each caller
 // applies its own documented fallback.
 static bool occtSurfaceCurvaturePair(OCCTSurfaceRef s, double u, double v,
                                       double* gaussian, double* mean) {
     if (!s || s->surface.IsNull()) return false;
     try {
-        GeomLProp_SLProps props(s->surface, u, v, 2, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 2);
         if (!props.IsCurvatureDefined()) return false;
         if (gaussian) *gaussian = props.GaussianCurvature();
         if (mean) *mean = props.MeanCurvature();
@@ -860,7 +862,7 @@ bool OCCTSurfaceGetPrincipalCurvatures(OCCTSurfaceRef s, double u, double v,
     if (!s || s->surface.IsNull() || !kMin || !kMax ||
         !d1x || !d1y || !d1z || !d2x || !d2y || !d2z) return false;
     try {
-        GeomLProp_SLProps props(s->surface, u, v, 2, Precision::Confusion());
+        GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 2);
         if (!props.IsCurvatureDefined()) return false;
         *kMin = props.MinCurvature();
         *kMax = props.MaxCurvature();
@@ -5032,12 +5034,24 @@ OCCTSurfaceRef OCCTPointsToSurfaceBSpline(const double* points, int32_t uCount, 
 // --- GeomConvert utilities ---
 
 // MARK: - v0.116: Surface Local Curvatures + Curvature Directions
+//
+// These two report the same GeomLProp_SLProps quantities as OCCTSurfaceCurvatures /
+// OCCTSurfaceGetGaussianCurvature / OCCTSurfaceGetMeanCurvature / OCCTSurfaceGetPrincipalCurvatures
+// above, differing only in returning all four curvature scalars (or both directions) in one call.
+// They used to construct their props with a hardcoded 1e-10 rather than the shared resolution, so
+// they disagreed with every one of those siblings about whether curvature exists at all near a
+// degeneracy — reporting a defined mean curvature of -8.66e7 at a point on a cone the canonical
+// entry points called undefined. Both now build props through occtSurfaceLocalProps (#494).
 void OCCTSurfaceLocalCurvatures(OCCTSurfaceRef _Nonnull surface, double u, double v,
                                   double* _Nonnull gaussian, double* _Nonnull mean,
                                   double* _Nonnull maxCurvature, double* _Nonnull minCurvature,
                                   bool* _Nonnull isDefined) {
+    if (surface->surface.IsNull()) {
+        *isDefined = false; *gaussian = 0; *mean = 0; *maxCurvature = 0; *minCurvature = 0;
+        return;
+    }
     try {
-        GeomLProp_SLProps props(surface->surface, u, v, 2, 1e-10);
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surface->surface, u, v, 2);
         *isDefined = props.IsCurvatureDefined();
         if (*isDefined) {
             *gaussian = props.GaussianCurvature();
@@ -5054,8 +5068,14 @@ void OCCTSurfaceLocalCurvatureDirections(OCCTSurfaceRef _Nonnull surface, double
                                            double* _Nonnull maxDx, double* _Nonnull maxDy, double* _Nonnull maxDz,
                                            double* _Nonnull minDx, double* _Nonnull minDy, double* _Nonnull minDz,
                                            bool* _Nonnull isDefined) {
+    if (surface->surface.IsNull()) {
+        *isDefined = false;
+        *maxDx = 0; *maxDy = 0; *maxDz = 0;
+        *minDx = 0; *minDy = 0; *minDz = 0;
+        return;
+    }
     try {
-        GeomLProp_SLProps props(surface->surface, u, v, 2, 1e-10);
+        GeomLProp_SLProps props = occtSurfaceLocalProps(surface->surface, u, v, 2);
         *isDefined = props.IsCurvatureDefined() && !props.IsUmbilic();
         if (*isDefined) {
             gp_Dir maxD, minD;

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -13807,12 +13807,35 @@ public enum UnitsConversion {
 
 extension Curve3D {
 
-    /// Get the curvature at a parameter value using LProp3d_CLProps.
+    /// The curvature of the curve at a parameter value.
+    ///
+    /// Equivalent to ``Curve3D/curvature(at:)`` — same OCCT computation, same tolerance. The two
+    /// used to disagree near a degeneracy, because this one asked at a 1000x tighter resolution
+    /// (#494).
+    ///
+    /// - Parameter u: Curve parameter.
+    /// - Returns: Curvature (1/radius), `0` where the curve has no defined tangent, and
+    ///   `Double.greatestFiniteMagnitude` at a cusp, where OCCT reports curvature as infinite.
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    /// let k = circle.localCurvature(at: 0)   // 0.2, i.e. 1/5
+    /// ```
     public func localCurvature(at u: Double) -> Double {
         OCCTCurve3DLocalCurvature(handle, u)
     }
 
-    /// Get the tangent direction at a parameter value using LProp3d_CLProps.
+    /// The unit tangent direction at a parameter value.
+    ///
+    /// Equivalent to ``Curve3D/tangentDirection(at:)``.
+    ///
+    /// - Parameter u: Curve parameter.
+    /// - Returns: The unit tangent, or `nil` where every derivative up to order 3 is null.
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    /// if let t = circle.localTangent(at: 0) { print(t) }   // (0, 1, 0)
+    /// ```
     public func localTangent(at u: Double) -> SIMD3<Double>? {
         var tx = 0.0, ty = 0.0, tz = 0.0
         var isDefined = false
@@ -13820,7 +13843,20 @@ extension Curve3D {
         return isDefined ? SIMD3(tx, ty, tz) : nil
     }
 
-    /// Get the normal direction at a parameter value using LProp3d_CLProps.
+    /// The principal normal direction at a parameter value.
+    ///
+    /// Equivalent to ``Curve3D/normal(at:)``.
+    ///
+    /// - Parameter u: Curve parameter.
+    /// - Returns: The normal, or `nil` where the curvature is zero (a straight stretch, or an
+    ///   inflection) or infinite (a cusp) — a normal needs a curvature to point away from.
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    /// let n = circle.localNormal(at: 0)                    // points at the centre
+    /// let straight = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!
+    /// #expect(straight.localNormal(at: 0) == nil)          // no curvature, no normal
+    /// ```
     public func localNormal(at u: Double) -> SIMD3<Double>? {
         var nx = 0.0, ny = 0.0, nz = 0.0
         var isDefined = false
@@ -13828,7 +13864,19 @@ extension Curve3D {
         return isDefined ? SIMD3(nx, ny, nz) : nil
     }
 
-    /// Get the centre of curvature at a parameter value using LProp3d_CLProps.
+    /// The centre of the osculating circle at a parameter value.
+    ///
+    /// Equivalent to ``Curve3D/centerOfCurvature(at:)``.
+    ///
+    /// - Parameter u: Curve parameter.
+    /// - Returns: The centre of curvature, or `nil` where the curvature cannot be inverted into a
+    ///   radius: zero (straight or inflecting) or infinite (a cusp). Both cases used to return a
+    ///   point built from `NaN` and infinity rather than `nil` (#494).
+    ///
+    /// ```swift
+    /// let circle = Curve3D.circle(center: SIMD3(1, 2, 0), normal: SIMD3(0, 0, 1), radius: 5)!
+    /// let c = circle.localCentreOfCurvature(at: 0)   // (1, 2, 0), the circle's own centre
+    /// ```
     public func localCentreOfCurvature(at u: Double) -> SIMD3<Double>? {
         var cx = 0.0, cy = 0.0, cz = 0.0
         var isDefined = false
@@ -13849,7 +13897,30 @@ extension Surface {
         public let minCurvature: Double
     }
 
-    /// Get all curvatures at (u, v) using LProp3d_SLProps.
+    /// All four curvature scalars at a surface point, in one call.
+    ///
+    /// The same quantities ``Surface/curvatures(u:v:)``, ``Surface/gaussianCurvature(atU:v:)``,
+    /// ``Surface/meanCurvature(atU:v:)`` and ``Surface/principalCurvatures(atU:v:)`` report, and
+    /// now at the same tolerance — this used to ask at a 1000x tighter resolution, so it could
+    /// report curvature near a degeneracy that every one of those called undefined (#494).
+    ///
+    /// - Parameters:
+    ///   - u: Surface U parameter.
+    ///   - v: Surface V parameter.
+    /// - Returns: Gaussian, mean, max and min curvature, or `nil` where curvature is undefined —
+    ///   a cone's apex, a sphere's pole, or any point whose surface normal is not defined.
+    ///
+    /// ```swift
+    /// let sphere = Surface.sphere(center: .zero, radius: 10)!
+    /// if let c = sphere.localCurvatures(u: 0, v: 0.5) {
+    ///     print(c.gaussian)      // 1/R^2 = 0.01
+    ///     print(abs(c.mean))     // 1/R   = 0.1
+    /// }
+    ///
+    /// // A cone's apex has no defined curvature.
+    /// let cone = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 0, semiAngle: .pi / 6)!
+    /// #expect(cone.localCurvatures(u: 0, v: 0) == nil)
+    /// ```
     public func localCurvatures(u: Double, v: Double) -> LocalCurvatures? {
         var gaussian = 0.0, mean = 0.0, maxC = 0.0, minC = 0.0
         var isDefined = false
@@ -13864,8 +13935,38 @@ extension Surface {
         public let minDirection: SIMD3<Double>
     }
 
-    /// Get curvature directions at (u, v) using LProp3d_SLProps.
-    /// Returns nil for umbilic points (where curvature is constant).
+    /// The principal curvature directions at a surface point.
+    ///
+    /// Shares its tolerance with ``Surface/principalCurvatures(atU:v:)``, which reports the same
+    /// two directions alongside their curvatures; the two used to disagree about where curvature
+    /// exists at all (#494).
+    ///
+    /// - Parameters:
+    ///   - u: Surface U parameter.
+    ///   - v: Surface V parameter.
+    /// - Returns: The max- and min-curvature directions, or `nil` where curvature is undefined
+    ///   **or** the point is umbilic, since equal principal curvatures single out no pair of
+    ///   directions.
+    ///
+    /// Umbilic detection is OCCT's, and it is stricter than the geometry suggests: the two
+    /// principal curvatures must land within one ULP of each other. A plane qualifies (both are
+    /// exactly zero); an analytically-umbilic sphere qualifies only where the two computed values
+    /// round to the same `Double`, which varies with radius and parameter. Treat a non-`nil`
+    /// result on a sphere as normal, not as a bug.
+    ///
+    /// ```swift
+    /// // A cylinder is not umbilic: one direction follows the axis, the other wraps around it.
+    /// let cylinder = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5)!
+    /// if let d = cylinder.localCurvatureDirections(u: 0, v: 0) {
+    ///     print(d.maxDirection, d.minDirection)
+    /// }
+    ///
+    /// // A plane is umbilic everywhere, so it has directions nowhere — but its curvature is
+    /// // perfectly well defined (all four scalars are zero).
+    /// let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+    /// #expect(plane.localCurvatures(u: 1, v: 2) != nil)
+    /// #expect(plane.localCurvatureDirections(u: 1, v: 2) == nil)
+    /// ```
     public func localCurvatureDirections(u: Double, v: Double) -> CurvatureDirections? {
         var maxDx = 0.0, maxDy = 0.0, maxDz = 0.0
         var minDx = 0.0, minDy = 0.0, minDz = 0.0

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -9373,6 +9373,14 @@ public struct SurfaceLocalProperties: Sendable {
     public let minCurvature: Double
     public let meanCurvature: Double
     public let gaussianCurvature: Double
+    /// Whether the four curvature values above mean anything.
+    ///
+    /// They are all `0` where curvature is undefined — a cone's apex, a sphere's pole, any point
+    /// with no defined normal — which is indistinguishable from a genuinely flat point without
+    /// this flag. The bridge has always computed it; it was simply not carried through to Swift
+    /// until #494, which is why the per-scalar siblings (`Face.gaussianCurvature(atU:v:)` and
+    /// friends, all returning optionals) were the only way to tell the two apart.
+    public let curvatureDefined: Bool
     public let isUmbilic: Bool
 }
 
@@ -9495,10 +9503,11 @@ extension Shape {
         let point = SIMD3(r.px, r.py, r.pz)
         let tangent: SIMD3<Double>? = r.tangentDefined ?
             SIMD3(r.tx, r.ty, r.tz) : nil
-        let normal: SIMD3<Double>? = (r.tangentDefined && r.curvature > 1e-10) ?
-            SIMD3(r.nx, r.ny, r.nz) : nil
-        let center: SIMD3<Double>? = (r.tangentDefined && r.curvature > 1e-10) ?
-            SIMD3(r.cx, r.cy, r.cz) : nil
+        // #494: was `r.tangentDefined && r.curvature > 1e-10` here, a Swift-side copy of a
+        // bridge-side literal. The bridge now reports whether it filled these in, so the threshold
+        // lives in exactly one place and the two sides cannot drift apart.
+        let normal: SIMD3<Double>? = r.curvatureInvertible ? SIMD3(r.nx, r.ny, r.nz) : nil
+        let center: SIMD3<Double>? = r.curvatureInvertible ? SIMD3(r.cx, r.cy, r.cz) : nil
         return CurveLocalProperties(
             point: point, tangent: tangent, normal: normal,
             centerOfCurvature: center, curvature: r.curvature)
@@ -9519,7 +9528,7 @@ extension Shape {
             point: point, normal: normal, tangentU: tu, tangentV: tv,
             maxCurvature: r.maxCurvature, minCurvature: r.minCurvature,
             meanCurvature: r.meanCurvature, gaussianCurvature: r.gaussianCurvature,
-            isUmbilic: r.isUmbilic)
+            curvatureDefined: r.curvatureDefined, isUmbilic: r.isUmbilic)
     }
 
     // MARK: - BRepOffset_SimpleOffset

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -5180,6 +5180,374 @@ struct LProp3dSurfaceTests {
     }
 }
 
+// MARK: - #494: the Local* local-properties family agrees with its canonical siblings
+
+/// `Surface.localCurvatures`/`localCurvatureDirections` and `Curve3D.localCurvature`/`localTangent`/
+/// `localNormal`/`localCentreOfCurvature` read the same `GeomLProp_SLProps`/`GeomLProp_CLProps`
+/// quantities as `Surface.curvatures`/`gaussianCurvature`/`meanCurvature`/`principalCurvatures` and
+/// `Curve3D.curvature`/`tangentDirection`/`normal`/`centerOfCurvature`, differing only in shape:
+/// several scalars per call, and an optional rather than a zero fallback.
+///
+/// They used to construct their props with a hardcoded `1e-10` resolution where the canonical family
+/// passes `Precision::Confusion()` (`1e-7`) — three decades apart, and *more* permissive, since the
+/// null-derivative test is `SquareMagnitude() > resolution * resolution`. #405/PR #425 converged
+/// three Surface entry points onto the shared value but never inventoried this family, nor the
+/// Curve3D side at all. So for any point whose derivative magnitude landed between the two values
+/// the two halves disagreed about whether curvature exists: on the apex cone below, `localCurvatures`
+/// reported a defined mean curvature of about -8.7e7 at `v = 1e-8` where every canonical entry point
+/// reported the same point undefined.
+@Suite("Local* local-properties parity (#494)")
+struct LocalPropsParityTests {
+
+    /// A cone with `radius: 0`: the apex sits at `v = 0` and the tangent magnitude falls off
+    /// linearly with `v`, so sampling `v` sweeps smoothly through both resolutions' thresholds.
+    private static func apexCone() -> Surface {
+        Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 0, semiAngle: .pi / 6)!
+    }
+
+    /// A cubic Bezier whose first two poles sit `spacing` apart, so `|D1(0)| = 3 * spacing`.
+    /// At `spacing == 0` the point is a cusp: the first significant derivative has order 2.
+    private static func cuspBezier(spacing: Double) -> Curve3D {
+        Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(spacing, 0, 0),
+                               SIMD3(1, 1, 0), SIMD3(2, 0, 0)])!
+    }
+
+    // MARK: Surface
+
+    private func expectSurfaceAgreement(_ surface: Surface, u: Double, v: Double,
+                                        _ label: Comment) {
+        let local = surface.localCurvatures(u: u, v: v)
+        let principal = surface.principalCurvatures(atU: u, v: v)
+
+        // Definedness first: this is the disagreement the issue is about.
+        #expect((local != nil) == (principal != nil), label)
+
+        if let local, let principal {
+            #expect(local.maxCurvature == principal.kMax, label)
+            #expect(local.minCurvature == principal.kMin, label)
+            // ...and against the pair-returning and single-scalar entry points.
+            let pair = surface.curvatures(u: u, v: v)
+            #expect(local.gaussian == pair.gaussian, label)
+            #expect(local.mean == pair.mean, label)
+            #expect(local.gaussian == surface.gaussianCurvature(atU: u, v: v), label)
+            #expect(local.mean == surface.meanCurvature(atU: u, v: v), label)
+        }
+
+        // Directions carry an extra umbilic rejection, so only the implication holds.
+        if surface.localCurvatureDirections(u: u, v: v) != nil {
+            #expect(principal != nil, label)
+        }
+    }
+
+    @Test("Well-conditioned surface points agree")
+    func wellConditionedSurfacesAgree() {
+        let sphere = Surface.sphere(center: .zero, radius: 5)!
+        let cylinder = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 3)!
+        let cone = Self.apexCone()
+
+        for (u, v) in [(0.0, 0.3), (Double.pi / 3, 0.4), (1.2, -0.8)] {
+            expectSurfaceAgreement(sphere, u: u, v: v, "sphere u=\(u) v=\(v)")
+            expectSurfaceAgreement(cylinder, u: u, v: v, "cylinder u=\(u) v=\(v)")
+        }
+        for v in [10.0, 1.0, 0.01] {
+            expectSurfaceAgreement(cone, u: 0, v: v, "cone v=\(v)")
+        }
+
+        // Umbilic is not degenerate: curvature is well defined, there is just no distinguished pair
+        // of principal directions, so only the directions call returns nil. The one asymmetry
+        // between the two families that is by design rather than drift.
+        //
+        // Asserted on a plane, not a sphere. OCCT's IsUmbilic() is
+        // `|maxCurv - minCurv| < Epsilon(maxCurv)` — a one-ULP test, not a geometric tolerance. A
+        // plane's two principal curvatures are both exactly 0, so it always passes; an
+        // analytically-umbilic sphere passes only where the two values happen to round to the same
+        // double, which depends on the radius and the (u, v). Measured on a sphere of radius 3:
+        // umbilic at v = 0, 0.3, 0.5 and -0.7, but not at v = 1, where they differ by exactly one
+        // ULP (5.55e-17). Nothing in #494 changed this — IsUmbilic() takes no resolution — but it
+        // is why no test here asserts a sphere is detected as umbilic.
+        let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+        #expect(plane.localCurvatures(u: 1, v: 2) != nil)
+        #expect(plane.localCurvatureDirections(u: 1, v: 2) == nil)
+        #expect(cylinder.localCurvatureDirections(u: 0, v: 0.3) != nil)
+    }
+
+    /// The Surface regression proper. Every `v` here lands between `1e-10` and
+    /// `Precision::Confusion()`, so pre-fix `localCurvatures` returned a value and every canonical
+    /// entry point returned nil/zero for the identical point.
+    @Test("Inside the old 1e-10 window the two Surface families agree")
+    func surfaceToleranceWindowAgrees() {
+        let cone = Self.apexCone()
+        for v in [1e-9, 1e-8, 1e-7, 3e-7, 1e-6] {
+            expectSurfaceAgreement(cone, u: 0, v: v, "cone v=\(v)")
+        }
+
+        // The sphere pole approached from just inside: same window, different degeneracy.
+        let sphere = Surface.sphere(center: .zero, radius: 3)!
+        for delta in [1e-9, 1e-8, 1e-7] {
+            expectSurfaceAgreement(sphere, u: 0, v: .pi / 2 - delta, "sphere pole -\(delta)")
+        }
+    }
+
+    @Test("Genuinely degenerate surface points are undefined for both families")
+    func degenerateSurfacePointsAgree() {
+        let cone = Self.apexCone()
+        #expect(cone.localCurvatures(u: 0, v: 0) == nil)
+        #expect(cone.principalCurvatures(atU: 0, v: 0) == nil)
+        #expect(cone.localCurvatureDirections(u: 0, v: 0) == nil)
+
+        let sphere = Surface.sphere(center: .zero, radius: 3)!
+        for v in [Double.pi / 2, -.pi / 2] {
+            expectSurfaceAgreement(sphere, u: 0, v: v, "sphere pole v=\(v)")
+        }
+    }
+
+    // MARK: Curve3D
+
+    private func expectCurveAgreement(_ curve: Curve3D, at u: Double, _ label: Comment) {
+        #expect(curve.localCurvature(at: u) == curve.curvature(at: u), label)
+
+        let localTangent = curve.localTangent(at: u)
+        let tangent = curve.tangentDirection(at: u)
+        #expect((localTangent != nil) == (tangent != nil), label)
+        if let localTangent, let tangent { #expect(localTangent == tangent, label) }
+
+        let localNormal = curve.localNormal(at: u)
+        let normal = curve.normal(at: u)
+        #expect((localNormal != nil) == (normal != nil), label)
+        if let localNormal, let normal { #expect(localNormal == normal, label) }
+
+        let localCentre = curve.localCentreOfCurvature(at: u)
+        let centre = curve.centerOfCurvature(at: u)
+        #expect((localCentre != nil) == (centre != nil), label)
+        if let localCentre, let centre { #expect(localCentre == centre, label) }
+    }
+
+    @Test("Well-conditioned curve parameters agree")
+    func wellConditionedCurvesAgree() {
+        let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+        for u in [0.0, 0.7, Double.pi, 2.0] {
+            expectCurveAgreement(circle, at: u, "circle u=\(u)")
+        }
+
+        let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!
+        for u in [0.0, 1.0, -3.0] {
+            expectCurveAgreement(line, at: u, "line u=\(u)")
+        }
+
+        let bezier = Self.cuspBezier(spacing: 1.0)
+        for u in [0.0, 0.25, 0.5, 1.0] {
+            expectCurveAgreement(bezier, at: u, "bezier u=\(u)")
+        }
+    }
+
+    /// The Curve3D regression proper, the half #405 never looked at. Measured pre-fix at
+    /// `spacing = 1e-8`, all four pairs disagreed on the same curve at the same parameter:
+    ///
+    ///   - `localCurvature(at: 0)` returned about 6.7e15, `curvature(at: 0)` returned `RealLast()`
+    ///     (`Double.greatestFiniteMagnitude`) — 293 orders of magnitude apart.
+    ///   - `localTangent(at: 0)` returned `(1, 0, 0)`, `tangentDirection(at: 0)` returned
+    ///     `(0.707, 0.707, 0)`. Not a precision difference: the two resolutions disagree about
+    ///     which derivative is the first significant one, and OCCT derives the tangent from that
+    ///     one, so the reported direction is genuinely different.
+    ///   - `localNormal(at: 0)` returned a vector where `normal(at: 0)` returned nil.
+    ///   - `localCentreOfCurvature(at: 0)` returned `(0, 1.5e-16, 0)` where
+    ///     `centerOfCurvature(at: 0)` returned `(nan, inf, nan)`.
+    @Test("Inside the old 1e-10 window the two Curve3D families agree")
+    func curveToleranceWindowAgrees() {
+        for spacing in [1e-12, 1e-10, 1e-9, 1e-8, 1e-7, 1e-6, 1e-3] {
+            expectCurveAgreement(Self.cuspBezier(spacing: spacing), at: 0,
+                                 "cusp bezier spacing=\(spacing)")
+        }
+    }
+
+    // MARK: The 1e-6 pair
+
+    /// `Shape.curveLocalProps(at:)` and `surfaceLocalProps(u:v:)` were the third tolerance in play,
+    /// on `1e-6` — the same value #405 removed from `OCCTSurfaceCurvatures`. They report the same
+    /// quantities as `Edge`'s and `Face`'s per-scalar entry points, so they have to agree with them.
+    ///
+    /// `curveLocalProps` also carried a Swift-side copy of the old bridge threshold
+    /// (`r.curvature > 1e-10`) to decide whether the normal and centre had been filled in. The
+    /// bridge now reports that directly, so the two sides cannot disagree about it.
+    @Test("Shape.curveLocalProps agrees with Edge's per-scalar entry points")
+    func curveLocalPropsAgreesWithEdge() throws {
+        let cylinder = try #require(Shape.cylinder(radius: 10, height: 5))
+        let edgeShapes = cylinder.subShapes(ofType: .edge)
+        try #require(!edgeShapes.isEmpty)
+
+        for (i, edgeShape) in edgeShapes.enumerated() {
+            let edge = try #require(Edge(edgeShape))
+            for param in [0.0, 0.5, 1.0, 2.0] {
+                let props = edgeShape.curveLocalProps(at: param)
+                let label: Comment = "edge \(i) param=\(param)"
+
+                // Edge.curvature returns nil exactly where the tangent is undefined.
+                if let curvature = edge.curvature(at: param) {
+                    #expect(props.tangent != nil, label)
+                    #expect(props.curvature == curvature, label)
+                } else {
+                    #expect(props.tangent == nil, label)
+                }
+
+                if let tangent = props.tangent {
+                    #expect(edge.tangent(at: param) == tangent, label)
+                }
+                // The aggregate and per-scalar entry points must agree on definedness, which is
+                // what the 1e-6/1e-7 split used to break.
+                #expect((props.normal != nil) == (edge.normal(at: param) != nil), label)
+                #expect((props.centerOfCurvature != nil)
+                        == (edge.centerOfCurvature(at: param) != nil), label)
+                if let n = props.normal { #expect(edge.normal(at: param) == n, label) }
+                if let c = props.centerOfCurvature {
+                    #expect(edge.centerOfCurvature(at: param) == c, label)
+                    #expect(c.x.isFinite && c.y.isFinite && c.z.isFinite, label)
+                }
+            }
+        }
+    }
+
+    /// The discriminating half of the previous test: a cusped edge, where `curveLocalProps`'
+    /// `1e-6` resolution put it three decades away from `Edge`'s `Precision::Confusion()` — and
+    /// where the `RealLast()` sentinel reached `CentreOfCurvature()` through both.
+    @Test("Shape.curveLocalProps agrees with Edge on a cusped edge")
+    func curveLocalPropsAgreesOnCusp() throws {
+        for spacing in [0.0, 1e-12, 1e-9, 1e-8, 1e-7] {
+            let curve = Self.cuspBezier(spacing: spacing)
+            let edgeShape = try #require(Shape.edgeFromCurve(curve))
+            let edge = try #require(Edge(edgeShape))
+            let props = edgeShape.curveLocalProps(at: 0)
+            let label: Comment = "cusp edge spacing=\(spacing)"
+
+            #expect(props.curvature == (edge.curvature(at: 0) ?? 0), label)
+            #expect((props.normal != nil) == (edge.normal(at: 0) != nil), label)
+            #expect((props.centerOfCurvature != nil)
+                    == (edge.centerOfCurvature(at: 0) != nil), label)
+
+            // Where the curvature is OCCT's infinite sentinel there is no centre to report. Not
+            // every spacing here reaches that: from 1e-7 up the first derivative clears
+            // Precision::Confusion(), so the curvature is finite and a centre does exist — which
+            // is why this is keyed off the reported curvature rather than asserted for all.
+            if props.curvature == .greatestFiniteMagnitude {
+                #expect(props.centerOfCurvature == nil, label)
+                #expect(edge.centerOfCurvature(at: 0) == nil, label)
+                #expect(props.normal == nil, label)
+            }
+            for p in [props.centerOfCurvature, props.normal, props.tangent] {
+                if let p { #expect(p.x.isFinite && p.y.isFinite && p.z.isFinite, label) }
+            }
+        }
+    }
+
+    @Test("Shape.surfaceLocalProps agrees with Face's per-scalar entry points")
+    func surfaceLocalPropsAgreesWithFace() throws {
+        let cylinder = try #require(Shape.cylinder(radius: 10, height: 5))
+        let faceShapes = cylinder.subShapes(ofType: .face)
+        try #require(!faceShapes.isEmpty)
+
+        for (i, faceShape) in faceShapes.enumerated() {
+            let face = try #require(Face(faceShape))
+            for (u, v) in [(0.0, 0.0), (0.5, 1.0), (1.2, 2.0)] {
+                let props = faceShape.surfaceLocalProps(u: u, v: v)
+                let label: Comment = "face \(i) u=\(u) v=\(v)"
+
+                #expect((props.normal != nil) == (face.normal(atU: u, v: v) != nil), label)
+                #expect(props.gaussianCurvature == (face.gaussianCurvature(atU: u, v: v) ?? 0),
+                        label)
+                #expect(props.meanCurvature == (face.meanCurvature(atU: u, v: v) ?? 0), label)
+                if let principal = face.principalCurvatures(atU: u, v: v) {
+                    #expect(props.minCurvature == principal.kMin, label)
+                    #expect(props.maxCurvature == principal.kMax, label)
+                }
+            }
+        }
+    }
+
+    /// The discriminating half: a cone's lateral face sampled approaching its apex. `v` values in
+    /// the `(1e-7, 1e-6)` band are exactly where `surfaceLocalProps`' old `1e-6` called curvature
+    /// undefined and `Face`'s `Precision::Confusion()` entry points called it defined.
+    @Test("Shape.surfaceLocalProps agrees with Face approaching a cone apex")
+    func surfaceLocalPropsAgreesNearConeApex() throws {
+        let cone = try #require(Shape.cone(bottomRadius: 5, topRadius: 0, height: 10))
+        // The lateral face is the one whose curvature varies with v; a planar cap's does not.
+        for faceShape in cone.subShapes(ofType: .face) {
+            let face = try #require(Face(faceShape))
+            for v in [1e-8, 1e-7, 5e-7, 1e-6, 1e-5, 1e-3, 1.0] {
+                let props = faceShape.surfaceLocalProps(u: 0, v: v)
+                let label: Comment = "cone face v=\(v)"
+                #expect(props.gaussianCurvature == (face.gaussianCurvature(atU: 0, v: v) ?? 0),
+                        label)
+                #expect(props.meanCurvature == (face.meanCurvature(atU: 0, v: v) ?? 0), label)
+                #expect((face.principalCurvatures(atU: 0, v: v) != nil) == props.curvatureDefined,
+                        label)
+            }
+        }
+    }
+
+    // MARK: The RealLast() sentinel
+
+    /// A cusp makes OCCT's `Curvature()` return `RealLast()`, meaning infinite curvature. Every
+    /// bridge gate that inverted a curvature only asked whether it was *big enough*, which the
+    /// sentinel trivially passes — and `LProp_CurveUtils::Curvature()` returns it without assigning
+    /// the curvature field `CentreOfCurvature()` then divides by, so the caller got
+    /// `(nan, inf, nan)` reported as a successfully computed point. Both halves of the pair did it.
+    @Test("A cusp's infinite curvature yields no centre of curvature, not a NaN one")
+    func cuspCentreOfCurvatureIsUndefined() {
+        for spacing in [0.0, 1e-14, 1e-12, 1e-11] {
+            let curve = Self.cuspBezier(spacing: spacing)
+            let label: Comment = "cusp bezier spacing=\(spacing)"
+
+            // The sentinel really is what OCCT reports here — otherwise this test proves nothing.
+            #expect(curve.curvature(at: 0) == .greatestFiniteMagnitude, label)
+
+            #expect(curve.centerOfCurvature(at: 0) == nil, label)
+            #expect(curve.localCentreOfCurvature(at: 0) == nil, label)
+        }
+    }
+
+    /// The invariant behind the previous test, stated once for every local-properties entry point:
+    /// a returned value is a real number. `nil`/zero means "undefined"; NaN and infinity are never
+    /// answers.
+    @Test("No local-properties entry point returns a non-finite number")
+    func localPropsNeverReturnNonFinite() {
+        let curves: [(String, Curve3D)] = [
+            ("cusp d=0", Self.cuspBezier(spacing: 0)),
+            ("cusp d=1e-12", Self.cuspBezier(spacing: 1e-12)),
+            ("cusp d=1e-8", Self.cuspBezier(spacing: 1e-8)),
+            ("circle", Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!),
+            ("line", Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!),
+        ]
+        for (name, curve) in curves {
+            for u in [0.0, 1e-9, 0.5, 1.0] {
+                let label: Comment = "\(name) u=\(u)"
+                #expect(curve.curvature(at: u).isFinite, label)
+                #expect(curve.localCurvature(at: u).isFinite, label)
+                for p in [curve.centerOfCurvature(at: u), curve.localCentreOfCurvature(at: u),
+                          curve.normal(at: u), curve.localNormal(at: u),
+                          curve.tangentDirection(at: u), curve.localTangent(at: u)] {
+                    if let p { #expect(p.x.isFinite && p.y.isFinite && p.z.isFinite, label) }
+                }
+            }
+        }
+
+        let surfaces: [(String, Surface)] = [
+            ("apex cone", Self.apexCone()),
+            ("sphere", Surface.sphere(center: .zero, radius: 3)!),
+        ]
+        for (name, surface) in surfaces {
+            for v in [0.0, 1e-9, 1e-8, 1e-7, .pi / 2, 1.0] {
+                let label: Comment = "\(name) v=\(v)"
+                if let c = surface.localCurvatures(u: 0, v: v) {
+                    #expect(c.gaussian.isFinite && c.mean.isFinite, label)
+                    #expect(c.maxCurvature.isFinite && c.minCurvature.isFinite, label)
+                }
+                if let d = surface.localCurvatureDirections(u: 0, v: v) {
+                    #expect(d.maxDirection.x.isFinite && d.minDirection.x.isFinite, label)
+                }
+            }
+        }
+    }
+}
+
 // MARK: - v0.118.0 Tests
 
 @Suite("BRepBndLib")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -807,6 +807,102 @@ has 24 edge *occurrences* over 12 edges and 48 vertex occurrences over 8 vertice
 already reported 12; and `Shape.faces()` (still an explorer walk, see #541) can hand back a face
 `face(at:)` cannot address, because their indices came from different enumerations.
 
+#### One tolerance behind every local-properties entry point, and a cusp that returned NaN (#494)
+
+`GeomLProp_SLProps`/`GeomLProp_CLProps`/`GeomLProp_CLProps2d` take a `Resolution` argument their own
+headers describe as "the linear tolerance (it is used to test if a vector is null)". It is not a
+comparison tolerance: it decides whether a derivative counts as null, and so whether the tangent,
+normal and curvature exist at all at a point. The bridge passed **three different values** across 28
+construction sites — `Precision::Confusion()` (`1e-7`) from the canonical `Surface`/`Curve3D`/`Face`/
+`Edge`/`Curve2D` entry points, `1e-10` from the `Local*` family, and `1e-6` from
+`OCCTGeomLProp{CL,SL}Props`. #405/PR #425 fixed this for three `Surface` entry points; its audit was
+Surface-only and never inventoried the `Local*` family or the `Curve3D` side, so the same defect
+survived in the siblings. All 28 now construct through shared helpers in `OCCTBridge_Internal.h`
+(`occtLocalPropsResolution`, `occtSurfaceLocalProps`, `occtCurveLocalProps`,
+`occtCurve2dLocalProps`), so the value is stated once and no site can drift again.
+
+Note the direction, which #405's own framing had backwards for this case: a *smaller* resolution is
+the more **permissive** one, because the null test is
+`derivative.SquareMagnitude() > resolution * resolution`. The `Local*` family's `1e-10` was three
+decades more willing to call a degenerate point well-conditioned than the canonical family, not less.
+
+Measured divergences, all now gone. On a cubic Bezier whose first two poles sit `1e-8` apart, at
+`u = 0`:
+
+- `Curve3D.localCurvature(at:)` returned `6.7e15` where `curvature(at:)` returned
+  `Double.greatestFiniteMagnitude` (OCCT's infinite-curvature sentinel) — 293 orders of magnitude
+  apart.
+- `localTangent(at:)` returned `(1, 0, 0)` where `tangentDirection(at:)` returned
+  `(0.707, 0.707, 0)`. Not a precision difference: the two resolutions disagree about which
+  derivative is the first significant one, and OCCT derives the tangent from that one, so the two
+  reported genuinely different directions.
+- `localNormal(at:)` returned a vector where `normal(at:)` returned `nil`.
+
+On a cone with `radius: 0` at `v = 1e-8`, `Surface.localCurvatures(u:v:)` reported a defined mean
+curvature of `-8.66e7` at a point `curvatures(u:v:)`, `gaussianCurvature(atU:v:)`,
+`meanCurvature(atU:v:)` and `principalCurvatures(atU:v:)` all reported undefined. Same for a sphere
+approaching its pole. `Shape.curveLocalProperties`/`surfaceLocalProperties` (the `1e-6` pair)
+disagreed with `Edge.curvature3D(at:)` and `Face`'s curvature entry points the same way.
+
+**A separate live defect found while probing those gates**, affecting the canonical family too:
+OCCT returns `RealLast()` from `Curvature()` to mean *infinite* curvature, at a cusp — where the
+first significant derivative has order 2, e.g. a Bezier whose first two poles coincide.
+`IsTangentDefined()` is still true there, and the sentinel trivially passes any "is the curvature
+big enough to invert" test, so it flowed straight into `CentreOfCurvature()`. That is worse than an
+exception: `LProp_CurveUtils::Curvature()` returns the sentinel *without* assigning the curvature
+field `ComputeCentreOfCurvature` then divides by, leaving it `0.0`, so the caller got
+`(nan, inf, nan)` reported as a successfully computed point. `Curve3D.centerOfCurvature(at:)`,
+`localCentreOfCurvature(at:)`, `Curve2D.centerOfCurvature(at:)`, `Edge.centerOfCurvature3D(at:)` and
+`Shape.curveLocalProperties` were all affected; each now returns `nil`/no centre, via a shared
+`occtCurveCurvatureIsInvertible` predicate that rejects the sentinel as well as a below-resolution
+curvature. `Normal()` was never exposed — it rejects the sentinel explicitly and raises.
+
+Also hardened while in these functions: the six `Local*` bridge entry points dereferenced their
+`Geom_Curve`/`Geom_Surface` handle without a null check their canonical siblings all make (an
+uncatchable SIGSEGV in this Release kernel, where OCCT's own precondition is compiled out), and
+three functions called `Curvature()` before establishing `IsTangentDefined()`, relying on a raise
+that goes through `LProp_NotDefined_Raise_if` — live in the bridge's own translation units, compiled
+out inside the OCCT build. Neither is reachable through today's Swift API; both are now consistent
+with the rest of the family.
+
+New `LocalPropsParityTests` (`Tests/OCCTAnalysisTests`, 11 tests) asserts definedness *and* value
+agreement between each entry point and its counterpart across well-conditioned points, the old
+`1e-10`-vs-`1e-7` window, and genuinely degenerate points, plus the cusp regression and a blanket
+"no local-properties entry point ever returns a non-finite number" sweep. Each was run against the
+pre-fix bridge to check it discriminates the fix rather than merely passing alongside it: 5 fail
+there (both `1e-10` window tests, the cusp regression, the non-finite sweep, and the cusped-edge
+test that covers the `1e-6` pair), and 6 pass both before and after as intended controls. The
+issue's own review of existing coverage was accurate — no test anywhere compared a `Local*`
+function against its sibling, and none drove a degenerate parameter through one.
+
+Two API additions fell out of writing those tests, both exposing state the bridge already had:
+`OCCTCurveLocalProps` gains `curvatureInvertible`, because `Shape.curveLocalProps(at:)` decided
+whether its `normal`/`centerOfCurvature` were filled in by re-testing `curvature > 1e-10` in
+Swift — a copy of a bridge-side literal that no longer exists, and one that would have gone stale
+in the other direction after this change. `SurfaceLocalProperties` gains `curvatureDefined`, which
+the bridge struct has always carried but the Swift wrapper dropped: its four curvature values are
+non-optional and all zero where curvature is undefined, so a caller had no way to tell a cone's
+apex from a flat point. Both are additive; neither struct has a public memberwise initializer.
+
+One documentation correction fell out of writing the parity tests, unrelated to the tolerance:
+`Surface.localCurvatureDirections(u:v:)` was documented as returning `nil` "for umbilic points
+(where curvature is constant)", which reads as covering a sphere. OCCT's umbilic test is
+`|maxCurv - minCurv| < Epsilon(maxCurv)` — one ULP, not a geometric tolerance. A plane always
+qualifies (both curvatures are exactly zero), but an analytically-umbilic sphere qualifies only
+where the two computed values round to the same `Double`: on a sphere of radius 3 it does at
+`v = 0`, `0.3`, `0.5` and `-0.7` and does not at `v = 1`, where they differ by exactly one ULP.
+Nothing changed here — `IsUmbilic()` takes no resolution — but the docs now say what it does, and
+the test asserts the asymmetry on a plane rather than on a sphere, where it would be flaky.
+
+Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild. Probes and full writeup at
+[`Scripts/repro/494-lprop-resolution/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/494-lprop-resolution).
+
+Not changed, and tracked separately as
+[#529](https://github.com/SecondMouseAU/OCCTSwift/issues/529): 19 `BRepLProp_SLProps`/
+`BRepLProp_CLProps` constructions still pass a literal `1e-6`. They are a different, adaptor-based
+class family asking the same question of a face rather than a surface, and several feed face
+orientation decisions rather than curvature reporting, so they need their own validation.
+
 ---
 
 ## Release History

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -919,6 +919,12 @@ public static func dumpLengthUnit(_ unit: OCCTLengthUnit) -> String?
 
 Extensions on `Curve3D` wrapping `LProp3d_CLProps` for local differential properties.
 
+These four are alternative spellings of `Curve3D.curvature(at:)`, `tangentDirection(at:)`,
+`normal(at:)` and `centerOfCurvature(at:)` — same OCCT computation, same tolerance, differing only
+in shape. They are guaranteed to agree with their counterparts for the same curve at the same
+parameter; before #494 they asked at a hardcoded `1e-10` resolution against the canonical family's
+`Precision::Confusion()` (`1e-7`), and the two disagreed near a degeneracy.
+
 ### `Curve3D.localCurvature(at:)`
 
 Curvature of the curve at a parameter value.
@@ -928,7 +934,9 @@ public func localCurvature(at u: Double) -> Double
 ```
 
 - **Parameters:** `u` — curve parameter.
-- **Returns:** Signed curvature (1/radius).
+- **Returns:** Curvature (1/radius); `0` where the tangent is undefined, and
+  `Double.greatestFiniteMagnitude` at a cusp, where OCCT reports curvature as infinite.
+- **Equivalent to:** `Curve3D.curvature(at:)`.
 - **OCCT:** `OCCTCurve3DLocalCurvature` → `LProp3d_CLProps::Curvature`.
 
 ---
@@ -941,7 +949,8 @@ Tangent direction at a parameter value.
 public func localTangent(at u: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** Unit tangent vector, or `nil` if not defined (e.g. degenerate point).
+- **Returns:** Unit tangent vector, or `nil` where every derivative up to order 3 is null.
+- **Equivalent to:** `Curve3D.tangentDirection(at:)`.
 - **OCCT:** `OCCTCurve3DLocalTangent` → `LProp3d_CLProps::Tangent`.
 
 ---
@@ -954,7 +963,9 @@ Principal normal direction at a parameter value.
 public func localNormal(at u: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** Normal vector, or `nil` at inflection or zero-curvature points.
+- **Returns:** Normal vector, or `nil` where the curvature is zero (straight or inflecting) or
+  infinite (a cusp).
+- **Equivalent to:** `Curve3D.normal(at:)`.
 - **OCCT:** `OCCTCurve3DLocalNormal` → `LProp3d_CLProps::Normal`.
 
 ---
@@ -967,7 +978,10 @@ Centre of curvature at a parameter value.
 public func localCentreOfCurvature(at u: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** Centre of the osculating circle, or `nil` if not defined.
+- **Returns:** Centre of the osculating circle, or `nil` where the curvature cannot be inverted
+  into a radius: zero (straight or inflecting) or infinite (a cusp). Both used to return a point
+  built from `NaN` and infinity instead of `nil` (#494).
+- **Equivalent to:** `Curve3D.centerOfCurvature(at:)`.
 - **OCCT:** `OCCTCurve3DLocalCentreOfCurvature` → `LProp3d_CLProps::CentreOfCurvature`.
 
 ---
@@ -975,6 +989,13 @@ public func localCentreOfCurvature(at u: Double) -> SIMD3<Double>?
 ## Surface LProp3d Extensions
 
 Extensions on `Surface` wrapping `LProp3d_SLProps` for local surface differential properties.
+
+Both report quantities `Surface.curvatures(u:v:)`, `gaussianCurvature(atU:v:)`,
+`meanCurvature(atU:v:)` and `principalCurvatures(atU:v:)` also report, at the same tolerance since
+#494 — they previously asked at a hardcoded `1e-10` against those entry points'
+`Precision::Confusion()`, so they could report curvature at a point the rest called undefined. The
+one remaining asymmetry is by design: `localCurvatureDirections` also returns `nil` at umbilic
+points, where curvature is perfectly well defined but no principal direction is distinguished.
 
 ### `Surface.LocalCurvatures`
 
@@ -1000,7 +1021,10 @@ public func localCurvatures(u: Double, v: Double) -> LocalCurvatures?
 ```
 
 - **Parameters:** `u`, `v` — surface parameters.
-- **Returns:** Gaussian, mean, max and min curvatures, or `nil` if undefined.
+- **Returns:** Gaussian, mean, max and min curvatures, or `nil` where curvature is undefined — a
+  cone's apex, a sphere's pole, or any point with no defined surface normal.
+- **Agrees with:** `Surface.curvatures(u:v:)`, `gaussianCurvature(atU:v:)`,
+  `meanCurvature(atU:v:)`, `principalCurvatures(atU:v:)`.
 - **OCCT:** `OCCTSurfaceLocalCurvatures` → `LProp3d_SLProps`.
 
 ---
@@ -1026,7 +1050,13 @@ Principal curvature directions at a surface point.
 public func localCurvatureDirections(u: Double, v: Double) -> CurvatureDirections?
 ```
 
-- **Returns:** Max and min curvature directions, or `nil` at umbilic points.
+- **Returns:** Max and min curvature directions, or `nil` where curvature is undefined **or** the
+  point is umbilic. OCCT's umbilic test is one ULP wide (`|maxCurv - minCurv| < Epsilon(maxCurv)`),
+  not a geometric tolerance: a plane always qualifies, but an analytically-umbilic sphere qualifies
+  only where the two computed curvatures round to the same `Double` — so a non-`nil` result on a
+  sphere is expected, not a defect.
+- **Agrees with:** `Surface.principalCurvatures(atU:v:)`, which returns the same two directions
+  alongside their curvatures (and does not reject umbilic points).
 - **OCCT:** `OCCTSurfaceLocalCurvatureDirections` → `LProp3d_SLProps`.
 
 ---


### PR DESCRIPTION
Closes #494.

Part of Pass 1b of the #377 duplication audit (#381). Targets `refactor/381-pass1b`, not `main`.

## What the argument actually is

`GeomLProp_SLProps`/`GeomLProp_CLProps`/`GeomLProp_CLProps2d` take a `Resolution` their own headers
call "the linear tolerance (it is used to test if a vector is null)". It is not a comparison
tolerance — it decides whether a derivative counts as null, and so whether the tangent, normal and
curvature exist at all at a point. The bridge passed **three different values across 28
construction sites**:

| value | sites | who |
|---|---|---|
| `Precision::Confusion()` (`1e-7`) | 20 | canonical `Surface`/`Curve3D`/`Face`/`Edge`/`Curve2D` entry points |
| `1e-10` | 6 | the `Local*` family |
| `1e-6` | 2 | `OCCTGeomLProp{CL,SL}Props` |

#405/PR #425 fixed this for three `Surface` entry points; its audit was Surface-only, so the
`Local*` family and the whole `Curve3D` side were never inventoried and the defect survived in the
siblings. All 28 now construct through shared helpers in `OCCTBridge_Internal.h`.

**One correction to the issue's framing, and to #405's:** a *smaller* resolution is the more
**permissive** one. The null test is `derivative.SquareMagnitude() > resolution * resolution`
(`LProp_CurveUtils.hxx`), so `1e-10` called derivatives significant that `Precision::Confusion()`
calls null. The `Local*` family was three decades *more* willing to call a degenerate point
well-conditioned, not less. The issue already caught this; recording it here because #405's
"looser" wording is what made it easy to miss.

## Measured divergence

Probes in `Scripts/repro/494-lprop-resolution/`. On a cubic Bezier whose first two poles sit `1e-8`
apart, at `u = 0` — all four `Curve3D` pairs disagreed:

| | `local*` (`1e-10`) | canonical (`1e-7`) |
|---|---|---|
| curvature | `6.7e15` | `1.798e308` (`RealLast()`) |
| tangent | `(1, 0, 0)` | `(0.707, 0.707, 0)` |
| normal | a vector | `nil` |
| centre of curvature | `(0, 1.5e-16, 0)` | `(nan, inf, nan)` |

The tangent row is the one worth pausing on: not a precision difference. The two resolutions
disagree about *which derivative is the first significant one*, and OCCT derives the tangent
direction from that one, so the two entry points reported genuinely different directions for the
same curve at the same parameter.

On a cone with `radius: 0` at `v = 1e-8`, `Surface.localCurvatures(u:v:)` reported a defined mean
curvature of `-8.66e7` at a point `curvatures`, `gaussianCurvature`, `meanCurvature` and
`principalCurvatures` all called undefined. Same approaching a sphere's pole.

## A second, separate defect found while probing those gates

OCCT returns `RealLast()` from `Curvature()` to mean *infinite* curvature, at a cusp — where the
first significant derivative has order 2. `IsTangentDefined()` is still true there (the search
falls through to `D2`), and the sentinel trivially passes any "is the curvature big enough to
invert" test, so it flowed into `CentreOfCurvature()`. That is worse than an exception:
`LProp_CurveUtils::Curvature()` returns the sentinel *without* assigning the `myCurvature` field
`ComputeCentreOfCurvature` then divides by, leaving it `0.0` — so the caller got `(nan, inf, nan)`
reported as a successfully computed point.

This hit the **canonical** family too, not just `Local*`: `Curve3D.centerOfCurvature(at:)`,
`localCentreOfCurvature(at:)`, `Curve2D.centerOfCurvature(at:)`, `Edge.centerOfCurvature(at:)` and
`Shape.curveLocalProps(at:)`. All now return `nil`, via a shared `occtCurveCurvatureIsInvertible`
predicate that rejects the sentinel as well as a below-resolution curvature. `Normal()` was never
exposed — it checks for the sentinel explicitly and raises.

## Also in scope

- **Six `Local*` entry points dereferenced their `Geom_Curve`/`Geom_Surface` handle with no null
  check** their canonical siblings all make. An uncatchable SIGSEGV in this Release kernel, where
  OCCT's own `Standard_NullObject` precondition is compiled out. Not reachable through today's
  Swift API; now consistent with the rest of the family.
- **Three functions called `Curvature()` before establishing `IsTangentDefined()`**, relying on a
  raise that goes through `LProp_NotDefined_Raise_if`. Worth knowing: that macro is **live** in the
  bridge's own translation units (these classes are header-only templates in OCCT 8.0, so they
  instantiate here) and **compiled out** inside the OCCT build, which defines `No_Exception`. The
  behaviour was correct by accident; it now does not depend on which side of that macro the code
  lands on.

## API additions

Both expose state the bridge already computed:

- `OCCTCurveLocalProps.curvatureInvertible` — `Shape.curveLocalProps(at:)` decided whether its
  `normal`/`centerOfCurvature` were filled in by re-testing `curvature > 1e-10` **in Swift**, a copy
  of a bridge literal that no longer exists. Left alone it would have gone stale in the other
  direction and started reporting `(0, 0, 0)` as a normal.
- `SurfaceLocalProperties.curvatureDefined` — the bridge struct always had it; the Swift wrapper
  dropped it. Its four curvature values are non-optional and all zero where curvature is undefined,
  so a caller could not tell a cone's apex from a flat point.

Both additive; neither struct has a public memberwise initializer.

## Verification

- Full `swift test`: **4714 tests, 0 failures**, bridge compiled from source
  (`env -u OCCTSWIFT_BRIDGE_PREBUILT`).
- New `LocalPropsParityTests` (`Tests/OCCTAnalysisTests`, 11 tests): definedness **and** value
  agreement for every pair, across well-conditioned points, the old `1e-10`-vs-`1e-7` window, and
  genuinely degenerate points, plus the cusp regression and a blanket "no local-properties entry
  point ever returns a non-finite number" sweep.
- **Each new test was run against the pre-fix bridge** to confirm it discriminates the fix rather
  than passing alongside it: 5 fail there (both window tests, the cusp regression, the non-finite
  sweep, and the cusped-edge test covering the `1e-6` pair) and 6 pass both before and after as
  intended controls. The `1e-6` half was isolated separately by restoring only those two literals.
- `Scripts/check-bridge-index.py`: 139 stale, unchanged from the #510 baseline.
- No `OCCT.xcframework` rebuild needed — no kernel patch. `OCCTBridge.xcframework` does need one at
  release time since `Sources/OCCTBridge/src/*.mm` changed.

## Not done, tracked separately

19 `BRepLProp_SLProps`/`BRepLProp_CLProps` constructions still pass a literal `1e-6` — filed as
**#529**. Different, adaptor-based class family asking the same question of a face rather than a
surface, and 3 of the 19 feed *face orientation* decisions rather than curvature reporting, so they
need a before/after check against real geometry rather than this PR's parity assertions.

## Docs

`docs/CHANGELOG.md`, the six `///` blocks with runnable snippets on the changed Swift entry points,
and `docs/reference/Document-Transforms.md`. `docs/API_REFERENCE.md` op counts are unchanged — no
new operations, only a field on two result structs.

One documentation correction fell out, unrelated to the tolerance:
`Surface.localCurvatureDirections(u:v:)` was documented as returning `nil` "for umbilic points
(where curvature is constant)", which reads as covering a sphere. OCCT's umbilic test is
`|maxCurv - minCurv| < Epsilon(maxCurv)` — **one ULP**, not a geometric tolerance. A plane always
qualifies (both curvatures exactly zero); an analytically-umbilic sphere qualifies only where the
two computed values round to the same `Double`. Measured on radius 3: umbilic at `v = 0, 0.3, 0.5,
-0.7`, not at `v = 1`, where they differ by exactly one ULP. Nothing changed here — `IsUmbilic()`
takes no resolution — but the docs now say what it does, and the test asserts the asymmetry on a
plane rather than on a sphere, where it would be flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
