### PR TITLE
fix(#497): one defeaturing skeleton, and the fuzzy tolerance that never existed

### DIFF
--- a/Scripts/repro/497-defeaturing-fuzzy-inert/README.md
+++ b/Scripts/repro/497-defeaturing-fuzzy-inert/README.md
@@ -1,0 +1,100 @@
+# OCCTSwift#497 probe — does `BRepAlgoAPI_Defeaturing` honour a fuzzy tolerance?
+
+Ground truth for the one behavioural difference between the bridge's two shape-addressed
+defeaturing wrappers, against the pinned OCCT 8.0.0p1 kernel.
+
+#497 found three wrappers of `BRepAlgoAPI_Defeaturing` in `OCCTBridge.h`, and reported that the
+duplication was actively harmful because it "hides a working feature (fuzzy tolerance) behind an
+overload-resolution trap": `OCCTDefeatureWithTolerance` called `SetFuzzyValue`, `OCCTShapeDefeature`
+did not, and Swift's overload resolution sent every `shape.defeature(faces:)` call site to the
+second one. The trap half is real and was confirmed against the package itself. This probe asks the
+other half: what does the caller lose by landing on the wrapper without the `SetFuzzyValue` call?
+
+Nothing. The fuzzy value is stored and never read.
+
+No fixture files needed: every case builds its geometry from a primitive.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/497-defeaturing-fuzzy-inert/occt_497_defeaturing_fuzzy.mm -o /tmp/occt_497
+/tmp/occt_497
+```
+
+## What it does
+
+A 10mm box with one 2mm fillet; the fillet face is removed by `BRepAlgoAPI_Defeaturing` at fuzzy
+values from `1e-7` to `100`, and the full BREP serialisation of each result is compared against the
+first. A serialisation comparison rather than a volume comparison, so that a geometric difference
+too small to move the volume still counts as a difference.
+
+A null result means nothing on its own — the tolerances might simply be too small to bite. So the
+same magnitudes are also run through `BRepAlgoAPI_Cut`, a BOP that does honour the fuzzy value, as
+a control.
+
+## Result
+
+```
+input: volume=991.415926536 faces=7
+  fuzzy=0        stored=1e-07      volume=1000.000000000 faces=6 brep=IDENTICAL
+  fuzzy=1e-07    stored=1e-07      volume=1000.000000000 faces=6 brep=IDENTICAL
+  fuzzy=0.01     stored=0.01       volume=1000.000000000 faces=6 brep=IDENTICAL
+  fuzzy=1        stored=1          volume=1000.000000000 faces=6 brep=IDENTICAL
+  fuzzy=10       stored=10         volume=1000.000000000 faces=6 brep=IDENTICAL
+  fuzzy=100      stored=100        volume=1000.000000000 faces=6 brep=IDENTICAL
+
+Defeaturing: fuzzy value made NO difference at any magnitude
+
+control (BRepAlgoAPI_Cut, an honouring BOP):
+  fuzzy=0        stored=1e-07      volume=874.336293856 faces=7 brep=IDENTICAL
+  fuzzy=1e-07    stored=1e-07      volume=874.336293856 faces=7 brep=IDENTICAL
+  fuzzy=0.01     stored=0.01       volume=874.336293856 faces=7 brep=IDENTICAL
+  fuzzy=1        stored=1          volume=857.581133037 faces=7 brep=DIFFERENT
+  fuzzy=10       stored=10         volume=0.000000000 faces=0 brep=DIFFERENT
+  fuzzy=100      stored=100        volume=-20.943951024 faces=2 brep=DIFFERENT
+
+Cut: fuzzy value changed the result (control valid)
+```
+
+`FuzzyValue()` echoes back whatever was set, so the value really is reaching the object — it is the
+algorithm that never consults it. The control confirms the magnitudes bite: at `fuzzy=10` the same
+box cut by the same cylinder collapses to an empty shape.
+
+## Why
+
+`BRepAlgoAPI_Defeaturing::Build`
+(`src/ModelingAlgorithms/TKBO/BRepAlgoAPI/BRepAlgoAPI_Defeaturing.cxx`) forwards exactly four things
+to the `BOPAlgo_RemoveFeatures` that does the work:
+
+```cpp
+myFeatureRemovalTool.SetShape(myInputShape);
+myFeatureRemovalTool.AddFacesToRemove(myFacesToRemove);
+myFeatureRemovalTool.SetToFillHistory(myFillHistory);
+myFeatureRemovalTool.SetRunParallel(myRunParallel);
+```
+
+`myFuzzyValue` is not among them, and `BOPAlgo_RemoveFeatures.cxx` contains no reference to a fuzzy
+value at all — the general-fuse, trimming and volume-maker sub-algorithms it drives are each given
+`SetRunParallel` and nothing else. `SetFuzzyValue` writes a field on the `BOPAlgo_Options` base
+class that this algorithm's `Build()` never reads.
+
+This is not an upstream defect: `BRepAlgoAPI_Defeaturing.hxx` documents it, in the class comment
+listing the supported options.
+
+> Please note that the other options of the base class are not supported here and will have no
+> effect.
+
+So there is nothing to file upstream, and nothing to patch. The wrapper that offered the tolerance
+was `OCCTShapeDefeature` under a different name, and was deleted; the Swift overload that took one
+is deprecated and forwards.
+
+## What this changed about the fix
+
+#497's framing was that consolidating the wrappers required care because one of them carried a
+feature the other lacked. Measured, the two are interchangeable, so the consolidation is unconditional
+— and the finding inverts: the duplication's real cost was not a hidden feature but an advertised
+parameter that never worked, kept alive by the copy that had one.

--- a/Scripts/repro/497-defeaturing-fuzzy-inert/occt_497_defeaturing_fuzzy.mm
+++ b/Scripts/repro/497-defeaturing-fuzzy-inert/occt_497_defeaturing_fuzzy.mm
@@ -1,0 +1,126 @@
+// #497 ground truth: does BRepAlgoAPI_Defeaturing honour SetFuzzyValue?
+//
+// The bridge has two shape-based defeaturing wrappers whose ONLY difference is that one
+// calls SetFuzzyValue(fuzzyTol). This test asks whether that call does anything at all.
+//
+// Control: BRepAlgoAPI_Cut, a BOP that genuinely honours the fuzzy value, on the same
+// magnitudes -- so a null result for Defeaturing means "ignored", not "too small to matter".
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepAlgoAPI_Defeaturing.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepTools.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopExp.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_Surface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <gp_Ax2.hxx>
+#include <sstream>
+#include <string>
+#include <cstdio>
+
+static double volumeOf(const TopoDS_Shape& s) {
+    GProp_GProps props;
+    BRepGProp::VolumeProperties(s, props);
+    return props.Mass();
+}
+
+static int faceCount(const TopoDS_Shape& s) {
+    TopTools_IndexedMapOfShape m;
+    TopExp::MapShapes(s, TopAbs_FACE, m);
+    return m.Extent();
+}
+
+// A full BREP serialisation: catches any geometric difference the scalars would miss.
+static std::string brepOf(const TopoDS_Shape& s) {
+    std::ostringstream os;
+    BRepTools::Write(s, os);
+    return os.str();
+}
+
+int main() {
+    // --- Build a 10mm box with one filleted edge; the fillet face is the "feature". ---
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+    BRepFilletAPI_MakeFillet fillet(box);
+    TopExp_Explorer ex(box, TopAbs_EDGE);
+    fillet.Add(2.0, TopoDS::Edge(ex.Current()));
+    fillet.Build();
+    if (!fillet.IsDone()) { printf("FAIL: fillet\n"); return 1; }
+    TopoDS_Shape filleted = fillet.Shape();
+
+    // The fillet face is the only cylindrical one.
+    TopoDS_Face featureFace;
+    for (TopExp_Explorer fe(filleted, TopAbs_FACE); fe.More(); fe.Next()) {
+        TopoDS_Face f = TopoDS::Face(fe.Current());
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(f);
+        if (!surf.IsNull() && surf->IsKind(STANDARD_TYPE(Geom_CylindricalSurface))) {
+            featureFace = f;
+            break;
+        }
+    }
+    if (featureFace.IsNull()) { printf("FAIL: no fillet face found\n"); return 1; }
+
+    printf("input: volume=%.9f faces=%d\n", volumeOf(filleted), faceCount(filleted));
+
+    // --- Defeature the same face at wildly different fuzzy values. ---
+    // 10.0 is the box's whole edge length: any algorithm that honoured a fuzzy value of
+    // that magnitude could not possibly return the same shape as one at 0.
+    const double fuzz[] = { 0.0, 1e-7, 0.01, 1.0, 10.0, 100.0 };
+    std::string baseline;
+    bool allIdentical = true;
+
+    for (double f : fuzz) {
+        BRepAlgoAPI_Defeaturing df;
+        df.SetShape(filleted);
+        df.AddFaceToRemove(featureFace);
+        if (f > 0) df.SetFuzzyValue(f);
+        df.Build();
+        if (!df.IsDone()) { printf("  fuzzy=%-8g NOT DONE\n", f); allIdentical = false; continue; }
+        TopoDS_Shape r = df.Shape();
+        std::string brep = brepOf(r);
+        if (baseline.empty()) baseline = brep;
+        bool same = (brep == baseline);
+        allIdentical = allIdentical && same;
+        printf("  fuzzy=%-8g stored=%-10g volume=%.9f faces=%d brep=%s\n",
+               f, df.FuzzyValue(), volumeOf(r), faceCount(r), same ? "IDENTICAL" : "DIFFERENT");
+    }
+
+    printf("\nDefeaturing: fuzzy value %s\n",
+           allIdentical ? "made NO difference at any magnitude" : "changed the result");
+
+    // --- Control: BRepAlgoAPI_Cut on the same magnitudes. ---
+    // A fuzzy value this large visibly perturbs an algorithm that honours it.
+    printf("\ncontrol (BRepAlgoAPI_Cut, an honouring BOP):\n");
+    TopoDS_Shape tool = BRepPrimAPI_MakeCylinder(gp_Ax2(gp_Pnt(5, 5, -1), gp_Dir(0, 0, 1)),
+                                                 2.0, 12.0).Shape();
+    std::string cutBaseline;
+    bool cutAllIdentical = true;
+    for (double f : fuzz) {
+        BRepAlgoAPI_Cut cut(box, tool);
+        cut.SetFuzzyValue(f > 0 ? f : 0.0);
+        cut.Build();
+        if (!cut.IsDone()) { printf("  fuzzy=%-8g NOT DONE\n", f); continue; }
+        TopoDS_Shape r = cut.Shape();
+        std::string brep = brepOf(r);
+        if (cutBaseline.empty()) cutBaseline = brep;
+        bool same = (brep == cutBaseline);
+        cutAllIdentical = cutAllIdentical && same;
+        printf("  fuzzy=%-8g stored=%-10g volume=%.9f faces=%d brep=%s\n",
+               f, cut.FuzzyValue(), volumeOf(r), faceCount(r), same ? "IDENTICAL" : "DIFFERENT");
+    }
+    printf("\nCut: fuzzy value %s\n",
+           cutAllIdentical ? "made no difference (control INVALID)" : "changed the result (control valid)");
+
+    printf("\nVERDICT: %s\n",
+           (allIdentical && !cutAllIdentical)
+             ? "SetFuzzyValue is INERT on BRepAlgoAPI_Defeaturing (control proves the magnitudes bite)"
+             : "inconclusive");
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -86,7 +86,8 @@
 // BRepAlgoAPI_Check                   → OCCTShapeBooleanCheck
 // BRepAlgoAPI_Common                  → OCCTShapeIntersect
 // BRepAlgoAPI_Cut                     → OCCTShapeSubtract
-// BRepAlgoAPI_Defeaturing             → OCCTShapeRemoveFeatures
+// BRepAlgoAPI_Defeaturing             → OCCTShapeRemoveFeatures, OCCTShapeDefeature,
+//                                       OCCTShapeHistoryFromDefeature, OCCTShapeRemoveSmallFaces
 // BRepAlgoAPI_Fuse                    → OCCTShapeUnion
 // BRepAlgoAPI_Section                 → OCCTShapeSection, OCCTShapeSliceAtZ, OCCTSectionBuilder*
 // BRepAlgoAPI_Splitter                → OCCTShapeSplit
@@ -1557,11 +1558,15 @@ OCCTShapeRef OCCTShapeDraft(OCCTShapeRef shape, const int32_t* faceIndices, int3
                             double planeX, double planeY, double planeZ,
                             double planeNx, double planeNy, double planeNz);
 
-/// Remove features (faces) from shape using defeaturing
+/// Remove features (faces) from shape using defeaturing (BRepAlgoAPI_Defeaturing).
+/// The shape-addressed form is OCCTShapeDefeature; for the same operation with history see
+/// OCCTShapeHistoryFromDefeature. All of them share one skeleton — see the defeaturing block in
+/// OCCTBridge_Internal.h. #497
 /// @param shape The shape to modify
-/// @param faceIndices Array of face indices to remove (0-based)
+/// @param faceIndices Array of face indices to remove (0-based, into the shape's own face map)
 /// @param faceCount Number of faces to remove
-/// @return Shape with features removed, or NULL on failure
+/// @return Shape with features removed, or NULL on failure — including when faceCount is 0 or an
+///         index is out of range, which since #497 fails the call rather than being skipped
 OCCTShapeRef OCCTShapeRemoveFeatures(OCCTShapeRef shape, const int32_t* faceIndices, int32_t faceCount);
 
 /// Pipe sweep mode for advanced sweeps
@@ -1977,10 +1982,14 @@ OCCTShapeRef OCCTShapeUnifySameDomain(OCCTShapeRef shape,
                                        bool unifyEdges, bool unifyFaces,
                                        bool concatBSplines);
 
-/// Remove internal wires (holes) smaller than area threshold
+/// Remove faces smaller than an area threshold, by defeaturing (BRepAlgoAPI_Defeaturing).
+/// Picks the faces itself rather than taking a list, but is otherwise the same operation as
+/// OCCTShapeRemoveFeatures / OCCTShapeDefeature. (It removes faces, not "internal wires (holes)"
+/// as this comment claimed before #497.)
 /// @param shape The shape to clean
-/// @param minArea Minimum area threshold for holes
-/// @return Cleaned shape, or NULL on failure
+/// @param minArea Minimum face area to keep
+/// @return Cleaned shape — the input unchanged when no face is below the threshold — or NULL on
+///         failure
 OCCTShapeRef OCCTShapeRemoveSmallFaces(OCCTShapeRef shape, double minArea);
 
 /// Simplify shape by removing small features
@@ -4912,6 +4921,8 @@ OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromShell(OCCTShapeRef _Nonnull 
                                                             OCCTShapeRef _Nullable * _Nullable outResult);
 
 /// Defeature: remove given faces by smoothing surrounding topology, with retained history.
+/// The same BRepAlgoAPI_Defeaturing operation as OCCTShapeRemoveFeatures / OCCTShapeDefeature,
+/// keeping the builder alive to answer history queries. #497
 OCCTBooleanHistoryRef _Nullable OCCTShapeHistoryFromDefeature(OCCTShapeRef _Nonnull shape,
                                                                 const int32_t* _Nonnull faceIndices,
                                                                 int32_t faceCount,
@@ -17390,11 +17401,9 @@ OCCTShapeRef _Nullable OCCTBooleanCutWithHistory(OCCTShapeRef _Nonnull s1, OCCTS
                                                     bool* _Nonnull hasModified,
                                                     bool* _Nonnull hasGenerated);
 
-/// Defeature (remove faces) with fuzzy tolerance.
-OCCTShapeRef _Nullable OCCTDefeatureWithTolerance(OCCTShapeRef _Nonnull shape,
-                                                    const OCCTShapeRef _Nonnull * _Nonnull facesToRemove,
-                                                    int32_t count, double fuzzyTol);
-
+// OCCTDefeatureWithTolerance was declared here. BRepAlgoAPI_Defeaturing has no fuzzy tolerance to
+// set — Build() forwards neither the value nor anything else from BOPAlgo_Options to the algorithm
+// that does the work — so it was OCCTShapeDefeature under another name. #497
 // --- BRepOffsetAPI_ThruSections builder ---
 
 typedef void* OCCTThruSectionsRef;
@@ -18060,7 +18069,11 @@ bool OCCTShapeBooleanCheckPair(OCCTShapeRef _Nonnull shape1, OCCTShapeRef _Nonnu
 
 // MARK: - BRepAlgoAPI_Defeaturing (v0.118.0)
 
-/// Remove faces (features) from a solid shape. facesArray contains face shapes to remove.
+/// Remove faces (features) from a solid shape, addressing the faces as shapes.
+/// Fails (NULL) on an empty request or a null face, rather than removing a subset of what was
+/// asked for. The index-addressed form is OCCTShapeRemoveFeatures; for the same operation with
+/// history see OCCTShapeHistoryFromDefeature. All of them share one skeleton — see the
+/// defeaturing block in OCCTBridge_Internal.h. #497
 OCCTShapeRef _Nullable OCCTShapeDefeature(OCCTShapeRef _Nonnull shape,
                                            const OCCTShapeRef _Nonnull * _Nonnull faces, int32_t faceCount);
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -433,18 +433,11 @@ OCCTShapeRef OCCTShapeRemoveSmallFaces(OCCTShapeRef shape, double minArea) {
             return new OCCTShape(shape->shape);
         }
 
-        // Use defeaturing to remove small faces
-        BRepAlgoAPI_Defeaturing defeaturer;
-        defeaturer.SetShape(shape->shape);
-        defeaturer.AddFacesToRemove(facesToRemove);
-        defeaturer.Build();
-
-        if (!defeaturer.IsDone()) {
-            return nullptr;
-        }
-
-        TopoDS_Shape result = defeaturer.Shape();
-        if (result.IsNull()) return nullptr;
+        // Use defeaturing to remove small faces. This entry point picks the faces itself, so it
+        // needs no face-resolution helper, but it runs the same skeleton as the rest. #497
+        BRepAlgoAPI_Defeaturing defeaturing;
+        TopoDS_Shape result;
+        if (!occtDefeaturePerform(defeaturing, shape->shape, facesToRemove, result)) return nullptr;
 
         return new OCCTShape(result);
     } catch (...) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -53,13 +53,15 @@
 #include <XCAFDoc_VisMaterialTool.hxx>
 #include <TDF_Label.hxx>
 #include <TNaming_Scope.hxx>
-// The last four serve the shared algorithm helpers at the bottom of this header
-// (occtFillingAddConstraint, occtShapeFilletEdgeList) rather than the structs above.
+// The last five serve the shared algorithm helpers at the bottom of this header
+// (occtFillingAddConstraint, occtShapeFilletEdgeList, occtDefeaturePerform) rather than the
+// structs above.
 #include <BRepOffsetAPI_MakeFilling.hxx>
 #include <BRepFilletAPI_MakeFillet.hxx>
 #include <TopExp.hxx>
 #include <TopoDS.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
+#include <TopTools_ListOfShape.hxx>
 
 // === Foundation struct definitions ===
 
@@ -465,6 +467,49 @@ bool occtFillingAddConstraint(BRepOffsetAPI_MakeFilling& filling,
                               OCCTFillingSupport kind,
                               GeomAbs_Shape order,
                               bool isBound);
+
+// === #497: one BRepAlgoAPI_Defeaturing skeleton ===
+//
+// Four entry points remove faces with BRepAlgoAPI_Defeaturing: OCCTShapeRemoveFeatures and
+// OCCTShapeDefeature (the plain index- and shape-addressed forms), OCCTShapeHistoryFromDefeature
+// (same operation, keeping the builder alive for its history), and OCCTShapeRemoveSmallFaces
+// (OCCTBridge_Healing.mm, which picks the faces itself by area). They had four independent copies
+// of the same SetShape/AddFaceToRemove/Build/IsDone sequence, and the copies had drifted apart on
+// every precondition: one silently skipped an out-of-range face index while another failed the
+// call, one dereferenced its faces array without a null check, and only two of them checked the
+// result shape for null. Definitions live in OCCTBridge_Modeling.mm.
+//
+// A fifth wrapper, OCCTDefeatureWithTolerance, was deleted rather than folded in. It differed from
+// OCCTShapeDefeature only by calling SetFuzzyValue, and that call does nothing:
+// BRepAlgoAPI_Defeaturing::Build forwards exactly myInputShape, myFacesToRemove, myFillHistory and
+// myRunParallel to the BOPAlgo_RemoveFeatures that does the work, so the fuzzy value inherited from
+// BOPAlgo_Options is stored and never read — as BRepAlgoAPI_Defeaturing.hxx says outright ("the
+// other options of the base class are not supported here and will have no effect"). Measured, not
+// assumed: identical BREP output for fuzzy values from 1e-7 to 100 on a 10mm box, against a
+// BRepAlgoAPI_Cut control that those same magnitudes visibly wreck. See
+// Scripts/repro/497-defeaturing-fuzzy-inert/.
+class BRepAlgoAPI_Defeaturing;
+
+// Resolve caller-supplied face indices — 0-based, into the shape's own TopExp face map — to the
+// faces themselves. Returns false, adding nothing, when the request is empty or names an index the
+// shape does not have. Failing an out-of-range index is the contract the majority of the callers
+// already had: quietly dropping it (the pre-#497 OCCTShapeRemoveFeatures behaviour) hands back a
+// shape that still carries the feature the caller asked to remove, with nothing to distinguish it
+// from a successful removal.
+bool occtDefeaturingFacesByIndex(const TopoDS_Shape& shape, const int32_t* faceIndices,
+                                 int32_t faceCount, TopTools_ListOfShape& outFaces);
+
+// The same resolution for faces addressed as shape handles. Returns false when the request is
+// empty, the array itself is null, or any element is null — a null element used to be dereferenced
+// unchecked by OCCTShapeDefeature, which no try/catch could have saved.
+bool occtDefeaturingFacesFromShapes(const OCCTShape* const* faces, int32_t faceCount,
+                                    TopTools_ListOfShape& outFaces);
+
+// Run `defeaturing` over `shape`, removing `facesToRemove`. The builder is the caller's, because
+// OCCTShapeHistoryFromDefeature has to outlive this call to read its history. Returns false unless
+// the operation is done AND produced a non-null shape.
+bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Shape& shape,
+                          const TopTools_ListOfShape& facesToRemove, TopoDS_Shape& outResult);
 
 // === #403: shared BSpline knot-split-to-parameter conversion ===
 //

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -388,29 +388,63 @@ OCCTShapeRef OCCTShapeDraft(OCCTShapeRef shape, const int32_t* faceIndices, int3
     }
 }
 
+// MARK: - Defeaturing (BRepAlgoAPI_Defeaturing)
+
+// The shared skeleton behind every defeaturing entry point, here and in OCCTBridge_Healing.mm.
+// See OCCTBridge_Internal.h for what the four copies this replaces disagreed about, and for why
+// the fuzzy-tolerance wrapper that used to be the fifth is gone rather than folded in. #497
+
+bool occtDefeaturingFacesByIndex(const TopoDS_Shape& shape, const int32_t* faceIndices,
+                                 int32_t faceCount, TopTools_ListOfShape& outFaces) {
+    if (faceIndices == nullptr || faceCount < 1) return false;
+
+    TopTools_IndexedMapOfShape faceMap;
+    TopExp::MapShapes(shape, TopAbs_FACE, faceMap);
+
+    for (int32_t i = 0; i < faceCount; i++) {
+        int32_t idx = faceIndices[i];
+        if (idx < 0 || idx >= faceMap.Extent()) return false;
+        outFaces.Append(faceMap(idx + 1));
+    }
+    return true;
+}
+
+bool occtDefeaturingFacesFromShapes(const OCCTShape* const* faces, int32_t faceCount,
+                                    TopTools_ListOfShape& outFaces) {
+    if (faces == nullptr || faceCount < 1) return false;
+
+    for (int32_t i = 0; i < faceCount; i++) {
+        if (faces[i] == nullptr) return false;
+        outFaces.Append(faces[i]->shape);
+    }
+    return true;
+}
+
+bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Shape& shape,
+                          const TopTools_ListOfShape& facesToRemove, TopoDS_Shape& outResult) {
+    defeaturing.SetShape(shape);
+    defeaturing.AddFacesToRemove(facesToRemove);
+    defeaturing.Build();
+    if (!defeaturing.IsDone()) return false;
+
+    outResult = defeaturing.Shape();
+    return !outResult.IsNull();
+}
+
 OCCTShapeRef OCCTShapeRemoveFeatures(OCCTShapeRef shape, const int32_t* faceIndices, int32_t faceCount) {
-    if (!shape || !faceIndices || faceCount <= 0) return nullptr;
+    if (!shape) return nullptr;
 
     try {
-        BRepAlgoAPI_Defeaturing defeature;
-        defeature.SetShape(shape->shape);
-
-        // Build face index map
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-
-        for (int32_t i = 0; i < faceCount; i++) {
-            int32_t idx = faceIndices[i];
-            if (idx >= 0 && idx < faceMap.Extent()) {
-                TopoDS_Face face = TopoDS::Face(faceMap(idx + 1));
-                defeature.AddFaceToRemove(face);
-            }
+        TopTools_ListOfShape facesToRemove;
+        if (!occtDefeaturingFacesByIndex(shape->shape, faceIndices, faceCount, facesToRemove)) {
+            return nullptr;
         }
 
-        defeature.Build();
-        if (!defeature.IsDone()) return nullptr;
+        BRepAlgoAPI_Defeaturing defeaturing;
+        TopoDS_Shape result;
+        if (!occtDefeaturePerform(defeaturing, shape->shape, facesToRemove, result)) return nullptr;
 
-        return new OCCTShape(defeature.Shape());
+        return new OCCTShape(result);
     } catch (...) {
         return nullptr;
     }
@@ -1993,23 +2027,17 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromDefeature(OCCTShapeRef shape,
                                                      const int32_t* faceIndices, int32_t faceCount,
                                                      OCCTShapeRef* outResult) {
     if (outResult) *outResult = nullptr;
-    if (!shape || !faceIndices || faceCount < 1) return nullptr;
+    if (!shape) return nullptr;
     try {
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
         TopTools_ListOfShape facesToRemove;
-        for (int32_t i = 0; i < faceCount; ++i) {
-            int32_t idx = faceIndices[i] + 1;
-            if (idx < 1 || idx > faceMap.Extent()) return nullptr;
-            facesToRemove.Append(faceMap(idx));
+        if (!occtDefeaturingFacesByIndex(shape->shape, faceIndices, faceCount, facesToRemove)) {
+            return nullptr;
         }
+        // The builder outlives this call — OCCTBooleanHistory reads its history — so it is held by
+        // pointer here rather than on the stack, but it is the same skeleton. #497
         std::unique_ptr<BRepAlgoAPI_Defeaturing> op(new BRepAlgoAPI_Defeaturing());
-        op->SetShape(shape->shape);
-        op->AddFacesToRemove(facesToRemove);
-        op->Build();
-        if (!op->IsDone()) return nullptr;
-        TopoDS_Shape result = op->Shape();
-        if (result.IsNull()) return nullptr;
+        TopoDS_Shape result;
+        if (!occtDefeaturePerform(*op, shape->shape, facesToRemove, result)) return nullptr;
         if (outResult) *outResult = new OCCTShape(result);
         return new OCCTBooleanHistory(std::move(op), occtArgList(shape->shape));
     } catch (...) { return nullptr; }
@@ -8711,23 +8739,9 @@ OCCTShapeRef OCCTBooleanCutWithHistory(OCCTShapeRef s1, OCCTShapeRef s2, double 
     } catch (...) { return nullptr; }
 }
 
-OCCTShapeRef OCCTDefeatureWithTolerance(OCCTShapeRef shape, const OCCTShapeRef* facesToRemove,
-                                          int32_t count, double fuzzyTol) {
-    if (!shape || !facesToRemove || count < 1) return nullptr;
-    try {
-        BRepAlgoAPI_Defeaturing def;
-        def.SetShape(shape->shape);
-        for (int i = 0; i < count; i++) {
-            if (facesToRemove[i]) def.AddFaceToRemove(facesToRemove[i]->shape);
-        }
-        if (fuzzyTol > 0) def.SetFuzzyValue(fuzzyTol);
-        def.Build();
-        if (def.IsDone()) {
-            return new OCCTShape{def.Shape()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
-}
+// OCCTDefeatureWithTolerance lived here. It was OCCTShapeDefeature plus a SetFuzzyValue call that
+// BRepAlgoAPI_Defeaturing never reads, so it removed exactly the same faces the same way; both
+// Swift spellings now reach OCCTShapeDefeature. See OCCTBridge_Internal.h's defeaturing block. #497
 // --- ThruSections builder ---
 
 struct OCCTThruSections {
@@ -8931,23 +8945,20 @@ OCCTShapeRef OCCTUnifySameDomainShape(OCCTUnifySameDomainRef ref) {
 }
 
 // MARK: - v0.118: Defeature + Sewing nbMultipleEdges
+// The shape-addressed defeaturing entry point, and since #497 the only one: it absorbed
+// OCCTDefeatureWithTolerance, whose fuzzy tolerance BRepAlgoAPI_Defeaturing discards.
 OCCTShapeRef OCCTShapeDefeature(OCCTShapeRef shape,
                                  const OCCTShapeRef* faces, int32_t faceCount) {
+    if (!shape) return nullptr;
     try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        BRepAlgoAPI_Defeaturing df;
-        df.SetShape(s->shape);
-        for (int32_t i = 0; i < faceCount; i++) {
-            auto* f = static_cast<OCCTShape*>(faces[i]);
-            df.AddFaceToRemove(f->shape);
-        }
-        df.Build();
-        if (df.IsDone() && !df.Shape().IsNull()) {
-            auto* result = new OCCTShape();
-            result->shape = df.Shape();
-            return result;
-        }
-        return nullptr;
+        TopTools_ListOfShape facesToRemove;
+        if (!occtDefeaturingFacesFromShapes(faces, faceCount, facesToRemove)) return nullptr;
+
+        BRepAlgoAPI_Defeaturing defeaturing;
+        TopoDS_Shape result;
+        if (!occtDefeaturePerform(defeaturing, shape->shape, facesToRemove, result)) return nullptr;
+
+        return new OCCTShape(result);
     } catch (...) { return nullptr; }
 }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -14004,6 +14004,29 @@ extension Shape {
 
 extension Shape {
     /// Remove feature faces from a solid shape (e.g., fillets, holes).
+    ///
+    /// The canonical defeaturing call. `withoutFeatures(faces:)` is the same operation addressing
+    /// its faces by index instead of by shape, and `defeaturedWithFullHistory(faces:)` is the same
+    /// operation again with the removal history retained; all three run one shared
+    /// `BRepAlgoAPI_Defeaturing` path in the bridge.
+    ///
+    /// Returns `nil` when `faces` is empty, and when the operation itself fails — defeaturing
+    /// cannot always reconnect the surrounding topology, so a `nil` here is an ordinary outcome,
+    /// not necessarily a caller error.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 20, height: 20, depth: 20)!
+    /// let filleted = box.filleted(radius: 2.0)!
+    ///
+    /// // The fillet added faces beyond the box's own six; remove one of them again.
+    /// let filletFaces = Array(filleted.subShapes(ofType: .face).dropFirst(6).prefix(1))
+    /// if let plain = filleted.defeature(faces: filletFaces) {
+    ///     print(plain.volume ?? 0)   // back to 8000.0, the unfilleted box
+    /// }
+    /// ```
+    ///
+    /// - Parameter faces: The faces to remove, as shapes belonging to this shape.
+    /// - Returns: The defeatured shape, or `nil` on failure.
     public func defeature(faces: [Shape]) -> Shape? {
         let faceHandles = faces.map { $0.handle as OCCTShapeRef? }
         return faceHandles.withUnsafeBufferPointer { buf -> Shape? in

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2710,8 +2710,24 @@ extension Shape {
     /// gaps by extending adjacent faces. Useful for simplifying geometry for
     /// analysis or removing small features.
     ///
+    /// `defeature(faces:)` is the same operation addressing its faces as shapes rather than by
+    /// index; both run one shared `BRepAlgoAPI_Defeaturing` path in the bridge.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 20, height: 20, depth: 20)!
+    /// let filleted = box.filleted(radius: 2.0)!
+    ///
+    /// // Faces past the box's own six were added by the fillet.
+    /// let filletFaces = Array(filleted.faces().dropFirst(6).prefix(1))
+    /// if let plain = filleted.withoutFeatures(faces: filletFaces) {
+    ///     print(plain.volume ?? 0)   // back to 8000.0, the unfilleted box
+    /// }
+    /// ```
+    ///
     /// - Parameter faces: Faces to remove (must have valid indices from this shape)
-    /// - Returns: Shape with features removed, or nil on failure
+    /// - Returns: Shape with features removed, or nil on failure — including when a face's index
+    ///   does not belong to this shape. Such an index used to be skipped, which returned a shape
+    ///   that still carried the feature and looked no different from a successful removal (#497).
     public func withoutFeatures(faces: [Face]) -> Shape? {
         guard !faces.isEmpty else { return nil }
 
@@ -13719,13 +13735,31 @@ extension Shape {
                                      hasDeleted: hasDel, hasModified: hasMod, hasGenerated: hasGen)
     }
 
-    /// Remove faces from a shape with fuzzy tolerance (defeaturing).
-    public func defeature(faces: [Shape], tolerance: Double = 0) -> Shape? {
-        let faceRefs = faces.map { $0.handle as OCCTShapeRef }
-        guard let ref = faceRefs.withUnsafeBufferPointer({ buf in
-            OCCTDefeatureWithTolerance(handle, buf.baseAddress!, Int32(faces.count), tolerance)
-        }) else { return nil }
-        return Shape(handle: ref)
+    /// Remove faces from a shape, ignoring `tolerance` (defeaturing).
+    ///
+    /// `BRepAlgoAPI_Defeaturing` has no fuzzy tolerance to set. Its `Build()` hands the input
+    /// shape, the faces to remove, the history flag and the parallel flag to the
+    /// `BOPAlgo_RemoveFeatures` that does the work, and nothing else — the fuzzy value inherited
+    /// from `BOPAlgo_Options` is stored and never read, which its own header states outright
+    /// ("the other options of the base class are not supported here and will have no effect").
+    /// So this has always returned exactly what `defeature(faces:)` returns, at every tolerance.
+    ///
+    /// Call ``defeature(faces:)`` instead. Nothing about the result changes.
+    ///
+    /// ```swift
+    /// // Before: the tolerance argument was silently discarded.
+    /// let old = shape.defeature(faces: filletFaces, tolerance: 0.01)
+    /// // After: same shape, no false promise.
+    /// let new = shape.defeature(faces: filletFaces)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - faces: The faces to remove, as shapes belonging to this shape.
+    ///   - tolerance: Ignored. Kept so existing call sites still compile.
+    /// - Returns: The defeatured shape, or `nil` on failure.
+    @available(*, deprecated, message: "tolerance is ignored — BRepAlgoAPI_Defeaturing has no fuzzy value. Use defeature(faces:).")
+    public func defeature(faces: [Shape], tolerance: Double) -> Shape? {
+        defeature(faces: faces)
     }
 
     // --- Triangulation queries ---

--- a/Tests/OCCTModelingTests/Issue497DefeaturingTests.swift
+++ b/Tests/OCCTModelingTests/Issue497DefeaturingTests.swift
@@ -1,0 +1,163 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #497 — the BRepAlgoAPI_Defeaturing family, after the four bridge copies were folded onto one
+/// skeleton and the fifth (`OCCTDefeatureWithTolerance`) was deleted.
+///
+/// What these pin down:
+///  - the two Swift spellings of "remove these faces" agree, geometrically and exactly;
+///  - the fuzzy tolerance the deleted wrapper offered never did anything, at any magnitude —
+///    measured upstream in Scripts/repro/497-defeaturing-fuzzy-inert/ and asserted here so the
+///    day OCCT starts honouring it is the day this suite fails;
+///  - an out-of-range face index fails the call instead of being quietly dropped.
+@Suite("Issue 497: BRepAlgoAPI_Defeaturing family")
+struct Issue497DefeaturingTests {
+
+    /// A 20mm box with one edge filleted, plus the fillet's own faces.
+    /// Fillet faces are the ones the box did not have: a box has 6, `filleted` has more.
+    private static func filletedBox() -> (shape: Shape, filletFaceIndices: [Int])? {
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let filleted = box.filleted(radius: 2.0) else { return nil }
+        let faceCount = filleted.faces().count
+        guard faceCount > 6 else { return nil }
+        return (filleted, Array(6..<faceCount))
+    }
+
+    // MARK: - The two spellings agree
+
+    @Test("withoutFeatures(faces:) and defeature(faces:) remove the same face identically")
+    func indexAndShapeAddressingAgree() {
+        guard let (filleted, filletIndices) = Self.filletedBox(),
+              let target = filletIndices.first else {
+            #expect(Bool(false), "fixture: filleted box with fillet faces")
+            return
+        }
+
+        let byIndex = filleted.withoutFeatures(faces: [filleted.faces()[target]])
+        let byShape = filleted.defeature(faces: [filleted.subShapes(ofType: .face)[target]])
+
+        // Both paths must reach a result, or neither: they are the same OCCT operation.
+        #expect((byIndex == nil) == (byShape == nil))
+
+        if let a = byIndex, let b = byShape {
+            #expect(a.isValid)
+            #expect(b.isValid)
+            if let va = a.volume, let vb = b.volume {
+                #expect(abs(va - vb) < 1e-9)
+            }
+            #expect(a.faces().count == b.faces().count)
+        }
+    }
+
+    @Test("defeaturedWithFullHistory(faces:) produces the same shape as the plain call")
+    func historyVariantAgrees() {
+        guard let (filleted, filletIndices) = Self.filletedBox(),
+              let target = filletIndices.first else {
+            #expect(Bool(false), "fixture: filleted box with fillet faces")
+            return
+        }
+
+        let plain = filleted.withoutFeatures(faces: [filleted.faces()[target]])
+        let withHistory = filleted.defeaturedWithFullHistory(faces: [target])
+
+        #expect((plain == nil) == (withHistory == nil))
+
+        if let a = plain, let b = withHistory {
+            if let va = a.volume, let vb = b.result.volume {
+                #expect(abs(va - vb) < 1e-9)
+            }
+            #expect(a.faces().count == b.result.faces().count)
+        }
+    }
+
+    // MARK: - The tolerance that never was
+
+    /// `BRepAlgoAPI_Defeaturing::Build` forwards the input shape, the faces, the history flag and
+    /// the parallel flag to `BOPAlgo_RemoveFeatures`, and nothing else — the fuzzy value from
+    /// `BOPAlgo_Options` is stored and never read. A value of 10.0 on a 20mm box would visibly
+    /// wreck any BOP that honoured it (a `BRepAlgoAPI_Cut` control at these magnitudes returns an
+    /// empty or negative-volume shape); here it must change nothing at all.
+    @available(*, deprecated, message: "exercises the deprecated tolerance overload on purpose")
+    @Test("tolerance is inert at every magnitude")
+    func toleranceIsInert() {
+        guard let (filleted, filletIndices) = Self.filletedBox(),
+              let target = filletIndices.first else {
+            #expect(Bool(false), "fixture: filleted box with fillet faces")
+            return
+        }
+        let face = filleted.subShapes(ofType: .face)[target]
+
+        guard let baseline = filleted.defeature(faces: [face]), let baseVolume = baseline.volume else {
+            #expect(Bool(false), "defeaturing a fillet face should succeed on this fixture")
+            return
+        }
+        let baseFaceCount = baseline.faces().count
+
+        for tolerance in [0.0, 1e-7, 0.01, 1.0, 10.0, 100.0] {
+            let result = filleted.defeature(faces: [face], tolerance: tolerance)
+            #expect(result != nil, "tolerance \(tolerance) changed whether defeaturing succeeded")
+            if let r = result {
+                if let v = r.volume {
+                    #expect(abs(v - baseVolume) < 1e-9, "tolerance \(tolerance) changed the volume")
+                }
+                #expect(r.faces().count == baseFaceCount, "tolerance \(tolerance) changed the face count")
+            }
+        }
+    }
+
+    // MARK: - Preconditions, now shared
+
+    @Test("an out-of-range face index fails the call instead of being skipped")
+    func outOfRangeIndexFails() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let (filleted, filletIndices) = Self.filletedBox(),
+              let strayIndex = filletIndices.last else {
+            #expect(Bool(false), "fixture: box and filleted box")
+            return
+        }
+
+        let realFaces = box.faces()
+        #expect(realFaces.count == 6)
+
+        // A face of the filleted box, whose index is past the end of the plain box's six. Before
+        // #497 the bridge dropped it and reported success on a shape nothing had been removed from.
+        let stray = filleted.faces()[strayIndex]
+        #expect(stray.index >= realFaces.count)
+
+        #expect(box.withoutFeatures(faces: [stray]) == nil)
+        // Mixing a valid index with an invalid one fails too — a partial removal is not a result.
+        #expect(box.withoutFeatures(faces: [realFaces[0], stray]) == nil)
+        // The history-carrying spelling has always failed here; it still does.
+        #expect(box.defeaturedWithFullHistory(faces: [stray.index]) == nil)
+    }
+
+    @Test("an empty face list fails every spelling")
+    func emptyRequestFails() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            #expect(Bool(false), "fixture: box")
+            return
+        }
+
+        #expect(box.withoutFeatures(faces: []) == nil)
+        #expect(box.defeature(faces: []) == nil)
+        #expect(box.defeaturedWithFullHistory(faces: []) == nil)
+    }
+
+    /// `withoutSmallFaces` picks its own faces and shares only the run half of the skeleton;
+    /// a threshold below every face's area must leave the shape alone.
+    @Test("withoutSmallFaces returns the input when nothing is small enough")
+    func withoutSmallFacesKeepsEverything() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            #expect(Bool(false), "fixture: box")
+            return
+        }
+
+        if let result = box.withoutSmallFaces(minArea: 1e-6) {
+            #expect(result.faces().count == 6)
+            if let v = result.volume {
+                #expect(abs(v - 1000.0) < 1e-6)
+            }
+        }
+    }
+}

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -3997,6 +3997,8 @@ struct BooleanExpansionTests {
         }
     }
 
+    // The tolerance argument this test used to pass is gone: BRepAlgoAPI_Defeaturing never read
+    // it, so the overload that took one is deprecated. Issue497DefeaturingTests covers that. #497
     @Test func defeature() {
         if let box = Shape.box(width: 20, height: 20, depth: 20) {
             let filleted = box.filleted(radius: 2.0)
@@ -4006,9 +4008,15 @@ struct BooleanExpansionTests {
                 if faces.count > 6 {
                     // Pick the extra faces (fillets)
                     let filletFaces = Array(faces.suffix(from: 6).prefix(2))
-                    let result = f.defeature(faces: filletFaces, tolerance: 0.01)
+                    let result = f.defeature(faces: filletFaces)
                     // Defeaturing may or may not succeed on filleted box
-                    let _ = result
+                    if let r = result {
+                        #expect(r.isValid)
+                        // Removing fillet faces can only add material back.
+                        if let before = f.volume, let after = r.volume {
+                            #expect(after >= before - 1e-9)
+                        }
+                    }
                 }
             }
         }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -35,7 +35,7 @@ a map of the major areas, and the `Total` as the count.
 |----------|-------|----------|
 | **Primitives** | 13 | box, cylinder, cylinder(at:), sphere, cone, torus, surface, wedge, halfSpace, vertex, shell(from surface), shell(from Surface), nonUniformScale |
 | **Sweeps** | 23 | pipe sweep, pipeShell, pipeShellWithTransition, pipeShellWithLaw, extrude, revolve, loft, loft(ruled+vertex), ruled, revolutionFromCurve, ruledShell, advancedEvolved, pipeSweep, compatibleWires, thruSectionsCreate, thruSectionsAddWire, thruSectionsAddVertex, thruSectionsSetSmoothing, thruSectionsSetMaxDegree, thruSectionsSetContinuity, thruSectionsBuild, thruSectionsShape, thruSectionsRelease |
-| **Booleans** | 13 | union (+), subtract (-), intersect (&), section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory, defeatureWithTolerance |
+| **Booleans** | 12 | union (+), subtract (-), intersect (&), section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory |
 | **Modifications** | 33 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
 | **Transforms** | 10 | translate, rotate, scale, mirror, mirrorAboutPoint, mirrorAboutAxis, scaleAboutPoint, translated(from:to:), transformed(matrix:), gTransformed(matrix:) |
 | **Wires** | 31 | rectangle, circle, polygon, polygon3D, line, arc, bspline, nurbs, path, join, offset, offset3D, interpolate, fillet2D, filletAll2D, chamfer2D, chamferAll2D, helix, helixTapered, orderedEdgeCount, orderedEdgePoints, orderedEdgePointCount, analyze, wireFromEdges, edges, allEdgePolylines, allEdgePolylinesIndexed, edgePolyline, bounds |
@@ -471,7 +471,7 @@ a map of the major areas, and the `Total` as the count.
 | **BRepBndLib** | 3 | boundingBox, boundingBoxOptimal, orientedBoundingBoxDetailed |
 | **ShapeAnalysis Tolerance** | 3 | toleranceValue, toleranceOverCount, toleranceInRangeCount |
 | **Boolean Validation** | 2 | isBooleanValid, isBooleanValidWith |
-| **Defeaturing** | 1 | defeature(faces:) |
+| **Defeaturing** | 2 | defeature(faces:), defeature(faces:tolerance:) (deprecated — the tolerance was never read, #497) |
 | **Polynomial Conversion** | 1 | polynomialToPoles |
 | **Transform Extras** | 4 | transformed(byMatrix:), isTransformNegative, displacement, transformation |
 | **TopExp Extras** | 1 | commonVertex |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -481,6 +481,45 @@ in its request set — both entry points must still return the *same* surface th
 excludes it from the "reported error describes the returned surface" assertion, with a comment to
 drop that exclusion when #522 is fixed.
 
+#### One defeaturing skeleton, and the fuzzy tolerance that never existed (#497)
+
+Five bridge functions ran `BRepAlgoAPI_Defeaturing`, each with its own copy of the same
+`SetShape`/`AddFaceToRemove`/`Build`/`IsDone` sequence, and the copies had drifted apart on every
+precondition: one silently skipped an out-of-range face index while another failed the call, one
+dereferenced its faces array with no null check (a crash no `catch (...)` could have caught), and
+only two checked the result shape for null. `OCCTBridge.h`'s own cross-reference index listed one of
+the five, so a maintainer using the index to find the existing wrap would have found a third of it.
+
+Two of the five were the same function twice: `OCCTShapeDefeature` (v0.118.0) and
+`OCCTDefeatureWithTolerance` (v0.114.0) differed only in that the older one called `SetFuzzyValue`.
+On the Swift side both were spelled `defeature(faces:)`-callable — `defeature(faces:)` and
+`defeature(faces:tolerance: Double = 0)` — and Swift's overload resolution sends a call site that
+omits `tolerance:` to the exact-arity overload every time, so the fuzzy path was unreachable without
+naming the argument. Confirmed against this package, not argued from the rules: deprecating one
+overload and rebuilding showed the existing test at `OCCTModelingTests.swift:4134` binding to it.
+
+**The tolerance it was hiding does nothing.** `BRepAlgoAPI_Defeaturing::Build` forwards the input
+shape, the faces to remove, the history flag and the parallel flag to the `BOPAlgo_RemoveFeatures`
+that does the work, and nothing else; the fuzzy value inherited from `BOPAlgo_Options` is stored,
+readable back through `FuzzyValue()`, and never consulted. Its own header says so in the class
+comment ("the other options of the base class are not supported here and will have no effect").
+Measured as well as read: identical BREP output at every fuzzy value from `1e-7` to `100`, against a
+`BRepAlgoAPI_Cut` control that the same magnitudes collapse to an empty shape — see
+[`Scripts/repro/497-defeaturing-fuzzy-inert/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/497-defeaturing-fuzzy-inert).
+Not an upstream defect, so nothing to file or patch; the wrapper was `OCCTShapeDefeature` under
+another name and is gone.
+
+The four remaining entry points — `withoutFeatures(faces:)`, `defeature(faces:)`,
+`defeaturedWithFullHistory(faces:)` and `withoutSmallFaces(minArea:)` — now share one skeleton and
+one set of preconditions, and the index names all four.
+
+**Behaviour change.** A face index that does not belong to the shape now fails
+`withoutFeatures(faces:)` instead of being dropped from the request. Dropping it returned a shape
+that still carried the feature the caller asked to remove, indistinguishable from a successful
+removal; the two index-addressed siblings already failed on it. `defeature(faces:tolerance:)` is
+deprecated (it forwards, and its tolerance was never read); calls that omit `tolerance:` were
+already reaching the tolerance-free path and are unaffected.
+
 ---
 
 ## Release History

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1338,14 +1338,14 @@ public func isBooleanValidWith(
 
 ### `Shape.defeature(faces:)`
 
-Remove feature faces (fillets, holes, pockets) from a solid shape.
+Remove feature faces (fillets, holes, pockets) from a solid shape. The canonical defeaturing call.
 
 ```swift
 public func defeature(faces: [Shape]) -> Shape?
 ```
 
 - **Parameters:** `faces` — the face shapes to remove as features.
-- **Returns:** Defeatured shape, or `nil` on failure.
+- **Returns:** Defeatured shape, or `nil` on failure — including when `faces` is empty.
 - **OCCT:** `OCCTShapeDefeature` → `BRepAlgoAPI_Defeaturing`.
 - **Example:**
   ```swift
@@ -1353,6 +1353,20 @@ public func defeature(faces: [Shape]) -> Shape?
       // fillets removed
   }
   ```
+
+**The rest of the family.** Four Swift spellings reach the same `BRepAlgoAPI_Defeaturing`
+operation, over one shared bridge path (#497):
+
+| Call | Addresses faces as | Notes |
+|------|--------------------|-------|
+| `defeature(faces:)` | `[Shape]` | this one |
+| [`withoutFeatures(faces:)`](Shape-Features.md#withoutfeaturesfaces) | `[Face]` (by index) | same operation |
+| `defeaturedWithFullHistory(faces:)` | `[Int]` (indices) | also returns the removal history |
+| [`withoutSmallFaces(minArea:)`](Shape-Features.md) | picks its own | every face below an area threshold |
+
+`defeature(faces:tolerance:)` is deprecated and forwards here: `BRepAlgoAPI_Defeaturing` has no
+fuzzy tolerance to set, and never had — see
+[`Scripts/repro/497-defeaturing-fuzzy-inert/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/497-defeaturing-fuzzy-inert).
 
 ---
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1006,17 +1006,28 @@ public func subtractedWithHistory(_ tool: Shape, tolerance: Double = 0) -> Boole
 
 ---
 
-### `defeature(faces:tolerance:)`
+### `defeature(faces:tolerance:)` — deprecated
 
-Removes specified faces from the shape (defeaturing).
+Removes specified faces from the shape (defeaturing), ignoring `tolerance`.
 
 ```swift
-public func defeature(faces: [Shape], tolerance: Double = 0) -> Shape?
+@available(*, deprecated, message: "tolerance is ignored — BRepAlgoAPI_Defeaturing has no fuzzy value. Use defeature(faces:).")
+public func defeature(faces: [Shape], tolerance: Double) -> Shape?
 ```
 
-- **Parameters:** `faces` — the face shapes to remove. `tolerance` — fuzzy tolerance; default `0`.
-- **Returns:** The defeatured `Shape`, or `nil` on failure.
+- **Parameters:** `faces` — the face shapes to remove. `tolerance` — ignored, kept so existing call
+  sites still compile.
+- **Returns:** The defeatured `Shape`, or `nil` on failure. Identical to
+  [`defeature(faces:)`](Document-Transforms.md#shapedefeaturefaces) at every tolerance.
 - **OCCT:** `BRepAlgoAPI_Defeaturing`.
+
+`BRepAlgoAPI_Defeaturing::Build` hands the input shape, the faces to remove, the history flag and
+the parallel flag to the `BOPAlgo_RemoveFeatures` that does the work, and nothing else; the fuzzy
+value inherited from `BOPAlgo_Options` is stored and never read, as its own header states ("the
+other options of the base class are not supported here and will have no effect"). Measured across
+tolerances from `1e-7` to `100` against a `BRepAlgoAPI_Cut` control in
+[`Scripts/repro/497-defeaturing-fuzzy-inert/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/497-defeaturing-fuzzy-inert)
+(#497). Use `defeature(faces:)`.
 
 ---
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1079,8 +1079,13 @@ public func withoutFeatures(faces: [Face]) -> Shape?
 Useful for simplifying imported geometry or removing small features before analysis.
 
 - **Parameters:** `faces` — faces to remove (must have valid `index` values from this shape).
-- **Returns:** Shape with features removed, or `nil` on failure.
-- **OCCT:** `BOPAlgo_Defeaturing` (via `OCCTShapeRemoveFeatures`).
+- **Returns:** Shape with features removed, or `nil` on failure — including when a face's index does
+  not belong to this shape. Such an index used to be skipped, which returned a shape that still
+  carried the feature and looked no different from a successful removal (#497).
+- **OCCT:** `BRepAlgoAPI_Defeaturing` (via `OCCTShapeRemoveFeatures`). Corrected here: this row
+  previously named `BOPAlgo_Defeaturing`, which is not an OCCT class.
+- **See also:** [`defeature(faces:)`](Document-Transforms.md#shapedefeaturefaces), the same
+  operation addressing its faces as shapes, and the rest of the defeaturing family listed there.
 
 ---
 


### PR DESCRIPTION
Part of Pass 1b of the #381 / #377 duplication audit. Targets `refactor/381-pass1b`, not `main`.

## What #497 reported, and what measurement changed

#497 found three `BRepAlgoAPI_Defeaturing` wrappers in `OCCTBridge.h` and argued the duplication was
actively harmful because it "hides a working feature (fuzzy tolerance) behind an overload-resolution
trap". Both halves were checked before any code was written.

**The trap is real**, and confirmed against this package rather than a standalone snippet: marking
`Document.swift`'s `defeature(faces:)` deprecated and rebuilding showed the existing test at
`OCCTModelingTests.swift:4134` binding to it, so `shape.defeature(faces:)` never reached the
tolerance-carrying overload.

**The feature it hides does not exist.** `BRepAlgoAPI_Defeaturing::Build` forwards exactly four
things to the `BOPAlgo_RemoveFeatures` that does the work:

```cpp
myFeatureRemovalTool.SetShape(myInputShape);
myFeatureRemovalTool.AddFacesToRemove(myFacesToRemove);
myFeatureRemovalTool.SetToFillHistory(myFillHistory);
myFeatureRemovalTool.SetRunParallel(myRunParallel);
```

`myFuzzyValue` is not among them, and `BOPAlgo_RemoveFeatures.cxx` contains no reference to a fuzzy
value at all. The class comment in `BRepAlgoAPI_Defeaturing.hxx` says so directly: *"the other
options of the base class are not supported here and will have no effect."*

Measured as well as read — identical BREP serialisation at every fuzzy value from `1e-7` to `100`,
with a `BRepAlgoAPI_Cut` control on the same magnitudes to prove they bite:

```
  fuzzy=0        stored=1e-07      volume=1000.000000000 faces=6 brep=IDENTICAL
  fuzzy=10       stored=10         volume=1000.000000000 faces=6 brep=IDENTICAL
  fuzzy=100      stored=100        volume=1000.000000000 faces=6 brep=IDENTICAL
control (BRepAlgoAPI_Cut, an honouring BOP):
  fuzzy=10       stored=10         volume=0.000000000 faces=0 brep=DIFFERENT
```

`FuzzyValue()` echoes back whatever was set, so the value reaches the object — the algorithm never
consults it. Full probe and writeup: [`Scripts/repro/497-defeaturing-fuzzy-inert/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/497-defeaturing-fuzzy-inert).

So the finding inverts: the duplication's cost was not a hidden feature but an advertised parameter
that never worked, kept alive by the copy that had one. Nothing to file upstream, nothing to patch.

## The sprawl was five, not three

The audit listed three; `OCCTShapeHistoryFromDefeature` and `OCCTShapeRemoveSmallFaces`
(`OCCTBridge_Healing.mm`) run the same algorithm too. All of them had their own copy of the same
sequence, and the copies had drifted:

| | out-of-range index | null face pointer | null result checked |
|---|---|---|---|
| `OCCTShapeRemoveFeatures` | silently skipped | n/a | no |
| `OCCTDefeatureWithTolerance` | n/a | skipped | no |
| `OCCTShapeDefeature` | n/a | **dereferenced** | yes |
| `OCCTShapeHistoryFromDefeature` | failed the call | n/a | yes |
| `OCCTShapeRemoveSmallFaces` | n/a | n/a | yes |

`OCCTShapeDefeature`'s unchecked dereference was a null deref, not a C++ exception, so its own
`catch (...)` could not have saved it.

## The fix

Three helpers in `OCCTBridge_Internal.h` (defined in `OCCTBridge_Modeling.mm`): index→faces
resolution, shapes→faces resolution, and the configure/run/check sequence. The builder stays the
caller's, so `OCCTShapeHistoryFromDefeature` can still outlive the call to read its history.

`OCCTDefeatureWithTolerance` is deleted (`OCCTBridge` is not an SPM product). Swift keeps one
implementation, `defeature(faces:)`; `defeature(faces:tolerance:)` is deprecated and forwards, with
the default value dropped from `tolerance` so no ambiguity remains at any call site. Existing calls
compile either way.

The header's cross-reference index now names all four wrappers instead of one, and
`OCCTShapeRemoveSmallFaces`'s doc comment no longer claims it removes "internal wires (holes)".

## Behaviour change

A face index that does not belong to the shape now fails `withoutFeatures(faces:)` instead of being
dropped from the request. Dropping it returned a shape that still carried the feature the caller
asked to remove, indistinguishable from a successful removal; the two index-addressed siblings
already failed on it.

## Tests

New `Tests/OCCTModelingTests/Issue497DefeaturingTests.swift` (6 tests): the index- and shape-addressed
spellings agree exactly, the history variant agrees, the tolerance is inert at six magnitudes (a
canary — it fails the day OCCT starts honouring it), out-of-range and empty requests fail, and
`withoutSmallFaces` leaves a shape alone when nothing is small enough.

The out-of-range test was proved to catch the regression: re-injecting the old silent-skip in
`occtDefeaturingFacesByIndex` fails it, reverting passes it.

The two pre-existing defeaturing tests asserted nothing (`let _ = result`); the one that passed
`tolerance: 0.01` now calls the non-deprecated form and checks the result.

## Verification

- Full `swift test`: **4735 tests, 1334 suites, all passing**
- Warning-free build; `Scripts/count-operations.py` totals unchanged (4278); `Scripts/check-bridge-index.py` stale count unchanged (139, all pre-existing #510)

## Follow-ups (not in scope here)

- `Shape.removeFeatures(faces: [Shape])` wraps `BOPAlgo_RemoveFeatures` — the *same* algorithm one
  layer down, with the same argument types and a different name. A sixth spelling of this operation,
  but a different OCCT class, so outside this issue's stated sites.
- `Shape.faces()` numbers faces in `TopExp_Explorer` order while the defeaturing bridge resolves them
  through `TopExp::MapShapes`. They coincide for an ordinary solid and diverge where a face appears
  more than once. Pre-existing; this change makes a beyond-range index fail loudly rather than
  silently.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)