### PR TITLE
fix(#499): one path parser, not two that disagree on what an extension is

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,287 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,288 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/repro/499-path-parsing-divergence/README.md
+++ b/Scripts/repro/499-path-parsing-divergence/README.md
@@ -1,0 +1,79 @@
+# OCCTSwift#499 probe: `TDocStd_PathParser` vs `OSD_Path`
+
+Ground-truth measurement of the two OCCT path-parsing classes OCCTSwift wrapped behind two
+identically-named Swift enums (`PathParser` and `OSDPath`). Not a crash reproducer: it prints what
+each class returns for 19 inputs so the divergence can be read off rather than argued about.
+
+No fixtures, no kernel patch, no OCCTSwift build. It links the pinned xcframework directly.
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/499-path-parsing-divergence/occt_499_path_divergence.mm -o /tmp/occt_499_probe
+/tmp/occt_499_probe
+```
+
+It mirrors the bridge exactly on both sides: `TCollection_ExtendedString` in and
+`TCollection_AsciiString` out for `TDocStd_PathParser` (what `OCCTPathParser*` did), plain
+`TCollection_AsciiString` for `OSD_Path` (what `OCCTOSDPath*` does).
+
+## What it shows
+
+**The reported divergence, confirmed.** The extension differs by its leading dot, because the two
+classes split at different offsets:
+
+- `OSD_Path.cxx:254-257` (`UnixExtract`): `pos = name.SearchFromEnd("."); ext = name.Split(pos - 1);`
+  splits one character *before* the dot, so the dot stays on the extension.
+- `TDocStd_PathParser.cxx:30-33` (`Parse()`): `myExtension = temp.Split(PointPosition);` splits *at*
+  the dot, so the dot is discarded.
+
+**A larger divergence the issue did not mention.** `OSD_Path::Trek()` is OCCT's portable directory
+syntax, not a filesystem path: `UnixExtract` runs `trek.ChangeAll('/', '|')` and rewrites `..` as
+`^`. So `/home/user/model.step` gives `"|home|user|"` where `TDocStd_PathParser` gives
+`"/home/user"`. `OSDPath.trek` had no test of any kind and a doc comment reading only "Get the
+directory trek from a path".
+
+**Four cases where `TDocStd_PathParser` is wrong, not just differently formatted.**
+
+| input | `TDocStd_PathParser` | `OSD_Path` |
+|---|---|---|
+| `/home/user/model` | trek `""`, name `""`, ext `""` | trek `\|home\|user\|`, name `model`, ext `""` |
+| `/home/user/.config` | throws `TCollection_ExtendedString::Split index` | name `""`, ext `.config` |
+| `.` | throws `TCollection_ExtendedString::Split index` | ext `.` |
+| `/home/a.b/model` | trek `/home`, name `a`, ext `b/model` | trek `\|home\|a.b\|`, name `model`, ext `""` |
+
+`Parse()` returns early at `TDocStd_PathParser.cxx:35-38` when the path holds no dot, leaving name
+and trek at their empty defaults. When the basename *starts* with a dot, the second `Split` is
+handed an index equal to the remaining length and throws; the bridge's `catch (...)` turned that
+into `nil`. And the dot search runs over the whole path with no separator awareness, so a dot in a
+directory name is read as the start of the file's extension.
+
+**The issue's non-ASCII prediction, inverted.** #499 expected `OSD_Path` to raise the
+`ConstructionError` its header documents for characters outside `' '...'~'` (`OSD_Path.hxx:43-46`),
+making every `OSDPath` method return `nil` for a non-ASCII path, while `TDocStd_PathParser`'s
+`TCollection_ExtendedString` handled it. Both halves are wrong:
+
+- `OSD_Path.cxx` contains no `Standard_ConstructionError` throw at all. The header includes the
+  class and documents the constraint; nothing enforces it. `/home/üser/mødel.step` parses cleanly.
+- `TDocStd_PathParser` returned `mÃ¸del` for that same path, from the bridge side:
+  `TCollection_ExtendedString(const char* theString, bool theIsMultiByte = false)` defaults to
+  *false*, so UTF-8 bytes were copied one per `ExtCharacter` and re-encoded as UTF-8 on the way back
+  through `TCollection_AsciiString`.
+
+**`OSD_Path::IsValid` accepts everything tried**, including the empty string, so `OSDPath.isValid`
+is a system-type syntax check and not a "can I open this" test. Its doc comment now says so.
+
+## Outcome
+
+Fixed bridge-side, no kernel patch and no xcframework rebuild. `OCCTPathParserTrek`/`Name`/
+`Extension`/`FreeString` are deleted, `TDocStd_PathParser` is no longer wrapped, and Swift
+`PathParser` is a deprecated forwarder onto `OSDPath`. Regression coverage lives in
+`Tests/OCCTFoundationTests/PathParsingContractTests.swift`, which cross-checks the two spellings
+against each other and pins each case in the table above. 8 of its 15 original tests failed against
+the unmodified bridge.
+
+Neither `TDocStd_PathParser` defect is filed upstream. `TDocStd_PathParser` is OCAF-internal, used
+by OCCT only on document paths it constructed itself, and OCCT has `OSD_Path` for general path
+parsing; the fix for a consumer is to not use it, which is what this issue did.

--- a/Scripts/repro/499-path-parsing-divergence/occt_499_path_divergence.mm
+++ b/Scripts/repro/499-path-parsing-divergence/occt_499_path_divergence.mm
@@ -1,0 +1,100 @@
+// Ground-truth probe for OCCTSwift #499: measure how TDocStd_PathParser and OSD_Path
+// actually disagree, across a full input matrix. No assumptions: print everything.
+#include <TDocStd_PathParser.hxx>
+#include <TCollection_ExtendedString.hxx>
+#include <TCollection_AsciiString.hxx>
+#include <OSD_Path.hxx>
+#include <Standard_Failure.hxx>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static std::string q(const TCollection_AsciiString& s) {
+    return std::string("\"") + s.ToCString() + "\"";
+}
+
+// Mirror the bridge: ExtendedString in, AsciiString out.
+static void pathParser(const char* p, std::string& trek, std::string& name, std::string& ext, std::string& err) {
+    try {
+        TCollection_ExtendedString e(p);
+        TDocStd_PathParser parser(e);
+        trek = q(TCollection_AsciiString(parser.Trek()));
+        name = q(TCollection_AsciiString(parser.Name()));
+        ext  = q(TCollection_AsciiString(parser.Extension()));
+        err  = "";
+    } catch (Standard_Failure const& f) {
+        trek = name = ext = "-"; err = std::string("THROW:") + f.GetMessageString();
+    } catch (...) { trek = name = ext = "-"; err = "THROW:unknown"; }
+}
+
+static void osdPath(const char* p, std::string& trek, std::string& name, std::string& ext,
+                    std::string& sys, std::string& err) {
+    try {
+        TCollection_AsciiString a(p);
+        OSD_Path o(a);
+        trek = q(o.Trek());
+        name = q(o.Name());
+        ext  = q(o.Extension());
+        TCollection_AsciiString s; o.SystemName(s);
+        sys  = q(s);
+        err  = "";
+    } catch (Standard_Failure const& f) {
+        trek = name = ext = sys = "-"; err = std::string("THROW:") + f.GetMessageString();
+    } catch (...) { trek = name = ext = sys = "-"; err = "THROW:unknown"; }
+}
+
+static void statics(const char* p) {
+    std::string valid = "?", unixp = "?", rel = "?", abs = "?", folder = "?", file = "?";
+    try { valid = OSD_Path::IsValid(TCollection_AsciiString(p)) ? "Y" : "n"; } catch (...) { valid = "T"; }
+    try { unixp = OSD_Path::IsUnixPath(p) ? "Y" : "n"; } catch (...) { unixp = "T"; }
+    try { rel   = OSD_Path::IsRelativePath(p) ? "Y" : "n"; } catch (...) { rel = "T"; }
+    try { abs   = OSD_Path::IsAbsolutePath(p) ? "Y" : "n"; } catch (...) { abs = "T"; }
+    try {
+        TCollection_AsciiString f, g;
+        OSD_Path::FolderAndFileFromPath(TCollection_AsciiString(p), f, g);
+        folder = q(f); file = q(g);
+    } catch (...) { folder = file = "THROW"; }
+    printf("    statics : IsValid=%s IsUnix=%s IsRel=%s IsAbs=%s  FolderAndFile=%s / %s\n",
+           valid.c_str(), unixp.c_str(), rel.c_str(), abs.c_str(), folder.c_str(), file.c_str());
+}
+
+int main() {
+    std::vector<std::pair<const char*, const char*>> cases = {
+        {"absolute + ext",          "/home/user/model.step"},
+        {"bare filename + ext",     "model.step"},
+        {"absolute, NO ext",        "/home/user/model"},
+        {"bare filename, NO ext",   "model"},
+        {"explicit relative",       "./sub/f.txt"},
+        {"parent relative",         "../up/f.txt"},
+        {"multi-dot",               "/home/user/archive.tar.gz"},
+        {"dotfile bare",            ".gitignore"},
+        {"dotfile in dir",          "/home/user/.config"},
+        {"empty string",            ""},
+        {"trailing slash (dir)",    "/home/user/"},
+        {"dot in DIR, none on file","/home/a.b/model"},
+        {"spaces",                  "/home/my docs/a file.step"},
+        {"windows-style",           "C:\\Users\\me\\model.step"},
+        {"non-ASCII (accented)",    "/home/\xc3\xbcser/m" "\xc3\xb8" "del.step"},
+        {"non-ASCII (CJK)",         "/home/user/" "\xe6\xa8\xa1" "\xe5\x9e\x8b" ".step"},
+        {"root only",               "/"},
+        {"just a dot",              "."},
+        {"tilde",                   "~/model.step"},
+    };
+
+    printf("OCCT path-parsing divergence probe (#499)\n");
+    printf("=========================================\n\n");
+    for (auto& c : cases) {
+        printf("[%s]  input=\"%s\"\n", c.first, c.second);
+        std::string pt, pn, pe, perr;
+        pathParser(c.second, pt, pn, pe, perr);
+        printf("    PathParser: trek=%-16s name=%-14s ext=%-10s %s\n",
+               pt.c_str(), pn.c_str(), pe.c_str(), perr.c_str());
+        std::string ot, on, oe, os, oerr;
+        osdPath(c.second, ot, on, oe, os, oerr);
+        printf("    OSDPath   : trek=%-16s name=%-14s ext=%-10s sys=%s %s\n",
+               ot.c_str(), on.c_str(), oe.c_str(), os.c_str(), oerr.c_str());
+        statics(c.second);
+        printf("\n");
+    }
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -427,6 +427,11 @@
 // NLPlate_HPG0G2Constraint            → OCCTNLPlateG0G2
 // NLPlate_HPG0G3Constraint            → OCCTNLPlateG0G3
 //
+// --- OSD ---
+// OSD_Environment                     → OCCTEnvironment*
+// OSD_Path                            → OCCTOSDPath* (the only path-parsing family; #499 deleted
+//                                       the TDocStd_PathParser one that duplicated it)
+//
 // --- Plate ---
 // Plate_Plate                         → OCCTPlate*
 // Plate_PinpointConstraint            → OCCTPlateLoadPinpoint
@@ -12753,23 +12758,6 @@ bool OCCTDocumentDataSetIsEmpty(OCCTDocumentRef _Nonnull doc, int64_t labelId);
 int32_t OCCTDocumentChildIDCount(OCCTDocumentRef _Nonnull doc, int64_t labelId,
                                   const char* _Nonnull guidString, bool allLevels);
 
-// MARK: - TDocStd_PathParser (v0.90.0)
-
-/// Parse a file path and return the directory (trek) component.
-/// Caller must free the returned string.
-const char* _Nullable OCCTPathParserTrek(const char* _Nonnull path);
-
-/// Parse a file path and return the filename (without extension).
-/// Caller must free the returned string.
-const char* _Nullable OCCTPathParserName(const char* _Nonnull path);
-
-/// Parse a file path and return the file extension.
-/// Caller must free the returned string.
-const char* _Nullable OCCTPathParserExtension(const char* _Nonnull path);
-
-/// Free a string returned by OCCTPathParser* functions.
-void OCCTPathParserFreeString(const char* _Nullable str);
-
 // MARK: - TFunction_DriverTable (v0.90.0)
 
 /// Check if a function driver with the given GUID is registered.
@@ -13526,14 +13514,22 @@ bool OCCTBRepAlgoImageIsImage(OCCTBRepAlgoImageRef _Nonnull img, OCCTShapeRef _N
 void OCCTBRepAlgoImageClear(OCCTBRepAlgoImageRef _Nonnull img);
 
 // MARK: - OSD_Path (v0.96.0)
+//
+// The single path-parsing family in the bridge. The TDocStd_PathParser family that used to sit
+// alongside it (OCCTPathParserTrek/Name/Extension, v0.90.0) was deleted in #499: it answered the
+// same questions in a different string format, and TDocStd_PathParser::Parse() is wrong outright
+// for an extension-less path, a dotfile inside a directory, and a dot in a directory name.
 
-/// Parse a path and return the filename (without extension). Caller must free.
+/// Parse a path and return the filename (without directory or extension). Caller must free.
 const char* _Nullable OCCTOSDPathName(const char* _Nonnull path);
 
-/// Parse a path and return the file extension (with dot). Caller must free.
+/// Parse a path and return the file extension, leading dot included ("/a/b.step" -> ".step").
+/// Caller must free.
 const char* _Nullable OCCTOSDPathExtension(const char* _Nonnull path);
 
-/// Parse a path and return the directory trek. Caller must free.
+/// Parse a path and return the directory in OCCT's *portable* trek syntax, where "/" becomes "|"
+/// and ".." becomes "^" ("/home/user/m.step" -> "|home|user|"). This is not a filesystem path;
+/// for that, use OCCTOSDPathFolderAndFile. Caller must free.
 const char* _Nullable OCCTOSDPathTrek(const char* _Nonnull path);
 
 /// Get the system name (full path). Caller must free.

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -6100,7 +6100,8 @@ bool OCCTDocumentDataSetIsEmpty(OCCTDocumentRef doc, int64_t labelId) {
     } catch (...) { return true; }
 }
 
-// MARK: - v0.90: TDF_ChildIDIterator + TDocStd_PathParser + TFunction_DriverTable + TNaming_Scope/Translator + TDataXtd_Placement/Presentation + XCAFDoc_AssemblyIterator/DimTol
+// MARK: - v0.90: TDF_ChildIDIterator + TFunction_DriverTable + TNaming_Scope/Translator + TDataXtd_Placement/Presentation + XCAFDoc_AssemblyIterator/DimTol
+// (TDocStd_PathParser was wrapped here too until #499 folded it into the OSD_Path family in OCCTBridge_IO.mm)
 // MARK: - TDF_ChildIDIterator (v0.90.0)
 
 #include <TDF_ChildIDIterator.hxx>
@@ -6118,41 +6119,6 @@ int32_t OCCTDocumentChildIDCount(OCCTDocumentRef doc, int64_t labelId,
         }
         return count;
     } catch (...) { return 0; }
-}
-
-// MARK: - TDocStd_PathParser (v0.90.0)
-
-#include <TDocStd_PathParser.hxx>
-
-const char* OCCTPathParserTrek(const char* path) {
-    try {
-        TCollection_ExtendedString epath(path);
-        TDocStd_PathParser parser(epath);
-        TCollection_AsciiString astr(parser.Trek());
-        return strdup(astr.ToCString());
-    } catch (...) { return nullptr; }
-}
-
-const char* OCCTPathParserName(const char* path) {
-    try {
-        TCollection_ExtendedString epath(path);
-        TDocStd_PathParser parser(epath);
-        TCollection_AsciiString astr(parser.Name());
-        return strdup(astr.ToCString());
-    } catch (...) { return nullptr; }
-}
-
-const char* OCCTPathParserExtension(const char* path) {
-    try {
-        TCollection_ExtendedString epath(path);
-        TDocStd_PathParser parser(epath);
-        TCollection_AsciiString astr(parser.Extension());
-        return strdup(astr.ToCString());
-    } catch (...) { return nullptr; }
-}
-
-void OCCTPathParserFreeString(const char* str) {
-    if (str) free((void*)str);
 }
 
 // MARK: - TFunction_DriverTable (v0.90.0)

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -1968,41 +1968,44 @@ void OCCTEnvironmentFreeString(const char* str) {
 
 #include <OSD_Path.hxx>
 
-const char* OCCTOSDPathName(const char* path) {
+// Every OCCTOSDPath* string accessor differs only in which component it reads back, so they share
+// one construction, one strdup and one failure outcome (nullptr). #499 folded the parallel
+// TDocStd_PathParser family into this one; OSD_Path is the workhorse the rest of the bridge already
+// uses, and it parses the cases TDocStd_PathParser::Parse() got wrong (extension-less paths,
+// dotfiles inside a directory, a dot in a directory name).
+namespace {
+enum class OSDPathComponent { Name, Extension, Trek, SystemName };
+
+const char* osdPathComponent(const char* path, OSDPathComponent which) {
     try {
         TCollection_AsciiString apath(path);
         OSD_Path p(apath);
-        TCollection_AsciiString name = p.Name();
-        return strdup(name.ToCString());
+        TCollection_AsciiString result;
+        switch (which) {
+            case OSDPathComponent::Name:       result = p.Name(); break;
+            case OSDPathComponent::Extension:  result = p.Extension(); break;
+            case OSDPathComponent::Trek:       result = p.Trek(); break;
+            case OSDPathComponent::SystemName: p.SystemName(result); break;
+        }
+        return strdup(result.ToCString());
     } catch (...) { return nullptr; }
+}
+}  // namespace
+
+const char* OCCTOSDPathName(const char* path) {
+    return osdPathComponent(path, OSDPathComponent::Name);
 }
 
 const char* OCCTOSDPathExtension(const char* path) {
-    try {
-        TCollection_AsciiString apath(path);
-        OSD_Path p(apath);
-        TCollection_AsciiString ext = p.Extension();
-        return strdup(ext.ToCString());
-    } catch (...) { return nullptr; }
+    return osdPathComponent(path, OSDPathComponent::Extension);
 }
 
 const char* OCCTOSDPathTrek(const char* path) {
-    try {
-        TCollection_AsciiString apath(path);
-        OSD_Path p(apath);
-        TCollection_AsciiString trek = p.Trek();
-        return strdup(trek.ToCString());
-    } catch (...) { return nullptr; }
+    return osdPathComponent(path, OSDPathComponent::Trek);
 }
 
 const char* OCCTOSDPathSystemName(const char* path) {
-    try {
-        TCollection_AsciiString apath(path);
-        OSD_Path p(apath);
-        TCollection_AsciiString sysName;
-        p.SystemName(sysName);
-        return strdup(sysName.ToCString());
-    } catch (...) { return nullptr; }
+    return osdPathComponent(path, OSDPathComponent::SystemName);
 }
 
 void OCCTOSDPathFolderAndFile(const char* path, const char** outFolder, const char** outFile) {

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -4697,30 +4697,46 @@ extension Document {
     }
 }
 
-// MARK: - TDocStd_PathParser (v0.90.0)
+// MARK: - TDocStd_PathParser (v0.90.0, folded into OSDPath in #499)
 
-/// Utility for parsing file paths into components.
+/// Deprecated spelling of ``OSDPath``.
+///
+/// This used to wrap `TDocStd_PathParser`, OCAF's internal path splitter, while ``OSDPath``
+/// wrapped `OSD_Path`: two OCCT classes answering the same questions in different string
+/// formats behind identically-named methods. Every method here now forwards to ``OSDPath``,
+/// which both settles the format and fixes four cases `TDocStd_PathParser::Parse()` got wrong:
+/// it left *both* name and directory empty for a path with no extension, threw (surfacing as
+/// `nil`) for a dotfile inside a directory, read a dot in a *directory* name as the start of the
+/// file's extension, and mangled non-ASCII paths.
+///
+/// ```swift
+/// // Before: "step", "/home/user", nil, "a"
+/// // Now:    ".step", "/home/user/", ".config", "model"
+/// OSDPath.fileExtension("/home/user/model.step")   // ".step"
+/// OSDPath.folder("/home/user/model.step")          // "/home/user/"
+/// OSDPath.fileExtension("/home/user/.config")      // ".config"
+/// OSDPath.name("/home/a.b/model")                  // "model"
+/// ```
 public enum PathParser {
 
-    /// Parse a file path and return the directory (trek) component.
+    /// Parse a file path and return the directory.
+    @available(*, deprecated, renamed: "OSDPath.folder(_:)",
+               message: "Forwards to OSDPath.folder(_:), which keeps the trailing separator (\"/home/user/\", not \"/home/user\") and returns a directory for extension-less paths instead of an empty string.")
     public static func trek(_ path: String) -> String? {
-        guard let ptr = OCCTPathParserTrek(path) else { return nil }
-        defer { OCCTPathParserFreeString(ptr) }
-        return String(cString: ptr)
+        OSDPath.folder(path)
     }
 
-    /// Parse a file path and return the filename (without extension).
+    /// Parse a file path and return the filename (without directory or extension).
+    @available(*, deprecated, renamed: "OSDPath.name(_:)")
     public static func name(_ path: String) -> String? {
-        guard let ptr = OCCTPathParserName(path) else { return nil }
-        defer { OCCTPathParserFreeString(ptr) }
-        return String(cString: ptr)
+        OSDPath.name(path)
     }
 
     /// Parse a file path and return the file extension.
+    @available(*, deprecated, renamed: "OSDPath.fileExtension(_:)",
+               message: "Forwards to OSDPath.fileExtension(_:), which includes the leading dot (\".step\", not \"step\").")
     public static func fileExtension(_ path: String) -> String? {
-        guard let ptr = OCCTPathParserExtension(path) else { return nil }
-        defer { OCCTPathParserFreeString(ptr) }
-        return String(cString: ptr)
+        OSDPath.fileExtension(path)
     }
 }
 
@@ -5982,38 +5998,93 @@ public final class ShapeImage: @unchecked Sendable {
 
 // MARK: - OSD_Path (v0.96.0)
 
-/// File path parsing and manipulation utilities.
+/// File path parsing and manipulation utilities, wrapping OCCT's `OSD_Path`.
+///
+/// The single path-parsing surface in OCCTSwift since #499. The `TDocStd_PathParser`-backed
+/// ``PathParser`` is now a deprecated forwarder onto this type.
+///
+/// Parsing is pure string syntax: nothing here touches the filesystem, and no method requires
+/// the path to exist.
+///
+/// ```swift
+/// OSDPath.name("/home/user/model.step")          // "model"
+/// OSDPath.fileExtension("/home/user/model.step") // ".step"  (leading dot, unlike URL.pathExtension)
+/// OSDPath.folder("/home/user/model.step")        // "/home/user/"
+/// OSDPath.isAbsolute("/home/user/model.step")    // true
+/// ```
 public enum OSDPath {
 
-    /// Get the filename (without extension) from a path.
+    /// Get the filename, without directory or extension, from a path.
+    ///
+    /// A basename that is entirely extension yields an empty name:
+    /// `OSDPath.name("/home/user/.config")` is `""`, not `".config"`.
+    ///
+    /// ```swift
+    /// OSDPath.name("/home/user/model.step")       // "model"
+    /// OSDPath.name("/home/user/archive.tar.gz")   // "archive.tar"  (last dot wins)
+    /// OSDPath.name("/home/user/model")            // "model"
+    /// ```
     public static func name(_ path: String) -> String? {
         guard let ptr = OCCTOSDPathName(path) else { return nil }
         defer { OCCTOSDPathFreeString(ptr) }
         return String(cString: ptr)
     }
 
-    /// Get the file extension (with dot) from a path.
+    /// Get the file extension, **leading dot included**, from a path.
+    ///
+    /// Note the dot: this differs from Foundation's `URL.pathExtension`, which strips it.
+    /// A path with no extension gives `""`, and only the last dot in the *basename* counts:
+    /// a dot in a directory name never starts an extension.
+    ///
+    /// ```swift
+    /// OSDPath.fileExtension("/home/user/model.step")     // ".step"
+    /// OSDPath.fileExtension("/home/user/archive.tar.gz") // ".gz"
+    /// OSDPath.fileExtension("/home/user/model")          // ""
+    /// OSDPath.fileExtension("/home/a.b/model")           // ""
+    /// ```
     public static func fileExtension(_ path: String) -> String? {
         guard let ptr = OCCTOSDPathExtension(path) else { return nil }
         defer { OCCTOSDPathFreeString(ptr) }
         return String(cString: ptr)
     }
 
-    /// Get the directory trek from a path.
+    /// Get the directory in OCCT's **portable trek syntax**, where `/` becomes `|` and `..`
+    /// becomes `^`.
+    ///
+    /// This is `OSD_Path`'s system-independent directory representation, not a filesystem
+    /// path, so do not hand it to `FileManager`. Use ``folder(_:)`` for a usable directory.
+    ///
+    /// ```swift
+    /// OSDPath.trek("/home/user/model.step")  // "|home|user|"
+    /// OSDPath.trek("../up/f.txt")            // "^|up|"
+    /// OSDPath.folder("/home/user/model.step")  // "/home/user/"  <- what you usually want
+    /// ```
     public static func trek(_ path: String) -> String? {
         guard let ptr = OCCTOSDPathTrek(path) else { return nil }
         defer { OCCTOSDPathFreeString(ptr) }
         return String(cString: ptr)
     }
 
-    /// Get the system-formatted path.
+    /// Get the path re-rendered in the running system's own syntax.
+    ///
+    /// ```swift
+    /// OSDPath.systemName("/home/user/model.step")  // "/home/user/model.step"
+    /// ```
     public static func systemName(_ path: String) -> String? {
         guard let ptr = OCCTOSDPathSystemName(path) else { return nil }
         defer { OCCTOSDPathFreeString(ptr) }
         return String(cString: ptr)
     }
 
-    /// Split path into folder and filename.
+    /// Split a path into its directory and its full filename, at the last separator.
+    ///
+    /// Unlike ``trek(_:)``, the folder is a real path: it keeps its trailing separator, and a
+    /// path with no directory part gives `""`.
+    ///
+    /// ```swift
+    /// OSDPath.folderAndFile("/home/user/model.step")  // ("/home/user/", "model.step")
+    /// OSDPath.folderAndFile("model.step")             // ("", "model.step")
+    /// ```
     public static func folderAndFile(_ path: String) -> (folder: String, file: String)? {
         var folderPtr: UnsafePointer<CChar>?
         var filePtr: UnsafePointer<CChar>?
@@ -6023,16 +6094,51 @@ public enum OSDPath {
         return (String(cString: fp), String(cString: flp))
     }
 
-    /// Check if path is valid.
+    /// Get the directory part of a path, as a real path with its trailing separator.
+    ///
+    /// The filesystem-usable counterpart of ``trek(_:)``.
+    ///
+    /// ```swift
+    /// OSDPath.folder("/home/user/model.step")  // "/home/user/"
+    /// OSDPath.folder("/home/user/model")       // "/home/user/"
+    /// OSDPath.folder("model.step")             // ""
+    /// ```
+    public static func folder(_ path: String) -> String? {
+        folderAndFile(path)?.folder
+    }
+
+    /// Check whether a path parses under the running system's syntax.
+    ///
+    /// A syntax check only. It does not test whether the path exists, and in practice
+    /// `OSD_Path` accepts anything a Unix system could name, including the empty string.
+    ///
+    /// ```swift
+    /// OSDPath.isValid("/tmp/test.txt")  // true
+    /// ```
     public static func isValid(_ path: String) -> Bool { OCCTOSDPathIsValid(path) }
 
-    /// Check if path is a Unix path.
+    /// Check if path is an absolute Unix path (leading `/`).
+    ///
+    /// ```swift
+    /// OSDPath.isUnixPath("/home/user/model.step")  // true
+    /// OSDPath.isUnixPath("model.step")             // false
+    /// ```
     public static func isUnixPath(_ path: String) -> Bool { OCCTOSDPathIsUnixPath(path) }
 
-    /// Check if path is relative.
+    /// Check if path is relative. Pure syntax, no filesystem access.
+    ///
+    /// ```swift
+    /// OSDPath.isRelative("./sub/f.txt")  // true
+    /// ```
     public static func isRelative(_ path: String) -> Bool { OCCTOSDPathIsRelative(path) }
 
-    /// Check if path is absolute.
+    /// Check if path is absolute. Pure syntax, no filesystem access.
+    ///
+    /// Recognises Unix, DOS, UNC and remote-protocol spellings.
+    ///
+    /// ```swift
+    /// OSDPath.isAbsolute("/home/user/model.step")  // true
+    /// ```
     public static func isAbsolute(_ path: String) -> Bool { OCCTOSDPathIsAbsolute(path) }
 }
 

--- a/Tests/OCCTFoundationTests/PathParsingContractTests.swift
+++ b/Tests/OCCTFoundationTests/PathParsingContractTests.swift
@@ -1,0 +1,158 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// One path-parsing contract, pinned across both public spellings (#499).
+///
+/// `PathParser` and `OSDPath` used to wrap two different OCCT classes, `TDocStd_PathParser` and
+/// `OSD_Path`, behind identically-named methods that answered the same question differently.
+/// These tests pin the single contract both spellings now share, and cover the four cases where
+/// `TDocStd_PathParser` was measurably wrong rather than merely differently formatted.
+@Suite("Path Parsing Contract (#499)")
+struct PathParsingContractTests {
+
+    // MARK: - The two spellings agree
+
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func bothSpellingsReportTheSameExtension() {
+        for path in ["/home/user/model.step", "model.step", "/home/user/archive.tar.gz",
+                     "/home/user/model", "./sub/f.txt"] {
+            #expect(PathParser.fileExtension(path) == OSDPath.fileExtension(path),
+                    "extension disagreement for \(path)")
+        }
+    }
+
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func bothSpellingsReportTheSameName() {
+        for path in ["/home/user/model.step", "model.step", "/home/user/archive.tar.gz",
+                     "/home/user/model", "./sub/f.txt"] {
+            #expect(PathParser.name(path) == OSDPath.name(path),
+                    "name disagreement for \(path)")
+        }
+    }
+
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func bothSpellingsReportTheSameDirectory() {
+        for path in ["/home/user/model.step", "model.step", "./sub/f.txt", "/home/user/model"] {
+            #expect(PathParser.trek(path) == OSDPath.folderAndFile(path)?.folder,
+                    "directory disagreement for \(path)")
+        }
+    }
+
+    // MARK: - The four TDocStd_PathParser defects, by case
+
+    /// `TDocStd_PathParser::Parse()` returns early when the path has no dot, leaving *both*
+    /// name and trek empty, so an extension-less path used to parse to nothing at all.
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func extensionlessPathStillHasANameAndDirectory() {
+        #expect(PathParser.name("/home/user/model") == "model")
+        #expect(PathParser.trek("/home/user/model") == "/home/user/")
+        #expect(PathParser.fileExtension("/home/user/model") == "")
+    }
+
+    /// A basename that begins with a dot drove `Parse()` into a `Split` past the end of the
+    /// string; the bridge's `catch (...)` turned that into `nil` from every accessor.
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func dotfileInsideADirectoryParses() {
+        #expect(PathParser.fileExtension("/home/user/.config") == ".config")
+        #expect(PathParser.name("/home/user/.config") == "")
+        #expect(PathParser.trek("/home/user/.config") == "/home/user/")
+    }
+
+    /// `Parse()` searched the whole path for the last dot with no awareness of the separator,
+    /// so a dot in a *directory* name was read as the start of the file's extension.
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func dotInADirectoryNameIsNotAnExtension() {
+        #expect(PathParser.fileExtension("/home/a.b/model") == "")
+        #expect(PathParser.name("/home/a.b/model") == "model")
+        #expect(PathParser.trek("/home/a.b/model") == "/home/a.b/")
+    }
+
+    /// The `TCollection_ExtendedString(const char*)` the bridge built defaults to
+    /// `theIsMultiByte = false`, so UTF-8 input round-tripped back out as mojibake.
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func nonASCIIPathSurvivesParsing() {
+        #expect(PathParser.name("/home/üser/mødel.step") == "mødel")
+        #expect(PathParser.name("/home/user/模型.step") == "模型")
+        #expect(OSDPath.name("/home/üser/mødel.step") == "mødel")
+        #expect(OSDPath.name("/home/user/模型.step") == "模型")
+    }
+
+    // MARK: - OSD_Path's own contract, unchanged
+
+    @Test func extensionKeepsItsLeadingDot() {
+        #expect(OSDPath.fileExtension("/home/user/model.step") == ".step")
+        #expect(OSDPath.fileExtension("/home/user/archive.tar.gz") == ".gz")
+        #expect(OSDPath.fileExtension("/home/user/model") == "")
+    }
+
+    @Test func nameDropsBothDirectoryAndExtension() {
+        #expect(OSDPath.name("/home/user/model.step") == "model")
+        #expect(OSDPath.name("/home/user/archive.tar.gz") == "archive.tar")
+    }
+
+    /// `OSD_Path::Trek()` is OCCT's *portable* directory syntax, not a filesystem path:
+    /// `/` becomes `|` and `..` becomes `^`. This is the one accessor whose result must not
+    /// be handed to `FileManager`.
+    @Test func trekIsPortableSyntaxNotAFilesystemPath() {
+        #expect(OSDPath.trek("/home/user/model.step") == "|home|user|")
+        #expect(OSDPath.trek("../up/f.txt") == "^|up|")
+        #expect(OSDPath.trek("model.step") == "")
+    }
+
+    @Test func folderAndFileSplitOnTheLastSeparator() {
+        let result = OSDPath.folderAndFile("/home/user/model.step")
+        #expect(result?.folder == "/home/user/")
+        #expect(result?.file == "model.step")
+    }
+
+    /// `folder(_:)` is the filesystem-usable directory accessor `trek(_:)` is not.
+    @Test func folderIsARealPathUnlikeTrek() {
+        #expect(OSDPath.folder("/home/user/model.step") == "/home/user/")
+        #expect(OSDPath.folder("/home/user/model") == "/home/user/")
+        #expect(OSDPath.folder("./sub/f.txt") == "./sub/")
+        #expect(OSDPath.folder("model.step") == "")
+        #expect(OSDPath.folder("/home/user/model.step") != OSDPath.trek("/home/user/model.step"))
+    }
+
+    /// A folder joined back onto its file reproduces the input, which is the property the
+    /// portable trek cannot offer.
+    @Test func folderAndFileRecomposeTheInput() {
+        for path in ["/home/user/model.step", "./sub/f.txt", "model.step", "/home/a.b/model"] {
+            let split = OSDPath.folderAndFile(path)
+            #expect((split.map { $0.folder + $0.file }) == path, "recompose failed for \(path)")
+        }
+    }
+
+    @Test func systemNameRoundTripsTheInput() {
+        #expect(OSDPath.systemName("/home/user/model.step") == "/home/user/model.step")
+        #expect(OSDPath.systemName("./sub/f.txt") == "./sub/f.txt")
+    }
+
+    @Test func absoluteAndRelativeAreSyntaxOnly() {
+        #expect(OSDPath.isAbsolute("/home/user/model.step"))
+        #expect(OSDPath.isRelative("./sub/f.txt"))
+        #expect(OSDPath.isRelative("model.step"))
+        #expect(OSDPath.isUnixPath("/home/user/model.step"))
+        #expect(!OSDPath.isUnixPath("model.step"))
+    }
+
+    /// Measured, not assumed: `OSD_Path::IsValid` accepts every string tried, including the
+    /// empty one. It is a system-type syntax check, not a "can I open this" test.
+    @Test func validityCheckAcceptsAnythingParsable() {
+        #expect(OSDPath.isValid("/tmp/test.txt"))
+        #expect(OSDPath.isValid(""))
+        #expect(OSDPath.isValid("/home/üser/mødel.step"))
+    }
+
+    // MARK: - Degenerate input is one outcome, not two
+
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
+    @Test func degenerateInputsAgreeAcrossSpellings() {
+        for path in ["", "/", ".", "/home/user/"] {
+            #expect(PathParser.name(path) == OSDPath.name(path), "name disagreement for \"\(path)\"")
+            #expect(PathParser.fileExtension(path) == OSDPath.fileExtension(path),
+                    "extension disagreement for \"\(path)\"")
+        }
+    }
+}

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -3776,23 +3776,26 @@ struct TDFChildIDIteratorTests {
     }
 }
 
+/// `PathParser` stopped wrapping `TDocStd_PathParser` in #499 and now forwards to `OSDPath`.
+/// These pin the forwarding; the shared contract itself lives in `PathParsingContractTests`
+/// (`OCCTFoundationTests`).
 @Suite("TDocStd PathParser Tests")
 struct TDocStdPathParserTests {
 
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
     @Test func parsePath() {
-        let trek = PathParser.trek("/home/user/docs/model.step")
-        #expect(trek != nil)
-        if let trek { #expect(trek.contains("home")) }
+        #expect(PathParser.trek("/home/user/docs/model.step") == "/home/user/docs/")
     }
 
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
     @Test func parseName() {
-        let name = PathParser.name("model.step")
-        #expect(name == "model")
+        #expect(PathParser.name("model.step") == "model")
     }
 
+    /// The forwarded extension keeps its leading dot; this used to assert `"step"`.
+    @available(*, deprecated, message: "Exercises the deprecated PathParser forwarders on purpose.")
     @Test func parseExtension() {
-        let ext = PathParser.fileExtension("model.step")
-        #expect(ext == "step")
+        #expect(PathParser.fileExtension("model.step") == ".step")
     }
 }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -263,7 +263,7 @@ a map of the major areas, and the `Total` as the count.
 | **TDF_AttributeIterator** | 1 | attributeCount |
 | **TDF_DataSet** | 1 | dataSetIsEmpty |
 | **TDF_ChildIDIterator** | 1 | childIDCount |
-| **TDocStd_PathParser** | 3 | trek, name, fileExtension |
+| **TDocStd_PathParser** | 3 | trek, name, fileExtension (all deprecated #499; `PathParser` now forwards to `OSDPath`; `TDocStd_PathParser` is no longer wrapped) |
 | **TFunction_DriverTable** | 2 | hasDriver, clear |
 | **TNaming_Scope** | 6 | valid, validChildren, isValid, unvalid, clear, validCount |
 | **TNaming_Translator** | 2 | translatorCopy, isSame |
@@ -305,7 +305,7 @@ a map of the major areas, and the `Total` as the count.
 | **ShapeFix_IntersectionTool** | 1 | fixIntersectingWires |
 | **XCAFDoc_AssemblyItemRef** | 7 | setAssemblyItemRef, assemblyItemRefPath, setSubshape, getSubshape, hasExtra, clearExtra, isOrphan |
 | **BRepAlgo_Image** | 5 | create, setRoot, bind, hasImage, isImage, clear |
-| **OSD_Path** | 9 | name, fileExtension, trek, systemName, folderAndFile, isValid, isUnixPath, isRelative, isAbsolute |
+| **OSD_Path** | 10 | name, fileExtension, trek, systemName, folderAndFile, folder, isValid, isUnixPath, isRelative, isAbsolute |
 | **BRepClass_FClassifier** | 1 | classifyPoint2D |
 | **BRepAlgo_Loop** | 1 | buildLoops |
 | **Bnd_BoundSortBox** | 2 | create, compare |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,287** | |
+| **Total** | **4,288** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -903,6 +903,54 @@ Not changed, and tracked separately as
 class family asking the same question of a face rather than a surface, and several feed face
 orientation decisions rather than curvature reporting, so they need their own validation.
 
+#### One path parser, not two that disagree on what an extension is (#499)
+
+`PathParser` wrapped `TDocStd_PathParser` and `OSDPath` wrapped `OSD_Path`: two OCCT classes
+answering the same questions behind identically-named Swift methods, each with its own test pinning
+its own format and neither comparing itself to the other. `PathParser` now forwards to `OSDPath`,
+whose bridge family is the single path-parsing implementation; `TDocStd_PathParser` is no longer
+wrapped, and its four bridge functions are deleted.
+
+**Silent behaviour change, in two places**, prompted by a deprecation warning at every call site
+rather than a compile error. [`SEMVER.md`](SEMVER.md#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499)
+records the exception:
+
+```swift
+PathParser.fileExtension("model.step")     // was "step"        now ".step"
+PathParser.trek("/home/user/model.step")   // was "/home/user"  now "/home/user/"
+```
+
+The formats were the *reported* divergence. Measuring both classes across 19 inputs
+([`Scripts/repro/499-path-parsing-divergence/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/499-path-parsing-divergence))
+found four cases where `TDocStd_PathParser` was not differently formatted but wrong, all of which
+the forwarding fixes:
+
+| input | `PathParser`, before | now (= `OSDPath`) |
+|---|---|---|
+| `/home/user/model` | name `""`, directory `""` (`Parse()` returns early when there is no dot) | name `"model"`, directory `"/home/user/"` |
+| `/home/user/.config` | `nil` from every accessor (`Split` past the end of the string, caught by the bridge) | ext `".config"`, directory `"/home/user/"` |
+| `/home/a.b/model` | name `"a"`, ext `"b/model"` (the last dot anywhere wins, separators ignored) | name `"model"`, ext `""` |
+| `/home/üser/mødel.step` | name `"mÃ¸del"` | name `"mødel"` |
+
+The issue predicted the opposite of that last row: that `OSD_Path`'s documented
+`ConstructionError` for characters outside `' '...'~'` would make every `OSDPath` method return
+`nil` for a non-ASCII path, while `TDocStd_PathParser`'s `TCollection_ExtendedString` handled it.
+`OSD_Path.cxx` never throws that error (the header documents a constraint the implementation does
+not enforce), and the mangling was on the `TDocStd_PathParser` side, in the bridge:
+`TCollection_ExtendedString(const char*)` defaults to `theIsMultiByte = false`, so UTF-8 input was
+read one byte per character and re-encoded on the way out.
+
+**`OSDPath.trek(_:)` is not a filesystem path.** `OSD_Path::Trek()` returns OCCT's portable
+directory syntax, where `/` becomes `|` and `..` becomes `^`. `/home/user/m.step` gives
+`"|home|user|"`, and `../up/f.txt` gives `"^|up|"`. The Swift doc comment said only "Get the
+directory trek from a path", and the method had no test of any kind. It now says what it returns and
+points at the new **`OSDPath.folder(_:)`**, which gives the real directory (`"/home/user/"`) and is
+what `PathParser.trek` forwards to. `folder`/`file` recompose to the input; `trek` never could.
+
+Also: `OSD_Path` and `OSD_Environment` gained the cross-reference index entries neither ever had,
+and the four `OCCTOSDPath*` string accessors, four copies of construct-read-`strdup`, share one
+helper.
+
 ---
 
 ## Release History

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,7 +17,7 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with two recorded exceptions: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places, and [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one.
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with three recorded exceptions: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places, [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, and [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return without breaking the build.
 
 ## Rules
 
@@ -64,6 +64,22 @@ It is a compile error at every call site, never silent. The exception was taken 
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with before/after code, and to be named in the release notes.
 
 Also in #495, and *not* breaking: `continuityWith`'s `order:` parameter and `Shape.continuityOfFaces` both changed type, and both kept a deprecated overload with the old signature.
+
+#### Recorded exception: Unreleased, `PathParser` forwards to `OSDPath` (#499)
+
+**Two behaviour changes, and unlike the two exceptions above these are *not* compile errors.** Recorded here before the tag is cut:
+
+| Break | Issue | What a caller does |
+|---|---|---|
+| `PathParser.fileExtension(_:)` returns `".step"`, not `"step"` | #499 | Drop the caller's own dot, or strip the leading `.` |
+| `PathParser.trek(_:)` returns `"/home/user/"`, not `"/home/user"` | #499 | Nothing, if the result is joined with a separator; otherwise trim the trailing `/` |
+
+Both spellings still compile and still return a value; the deprecation attribute on each method raises a warning at every call site naming the exact format change, and `renamed:` points at the `OSDPath` method that now does the work. The exception was taken because:
+
+- The disagreement *is* the bug. `PathParser.fileExtension` and `OSDPath.fileExtension` answered the same question in two formats, each pinned by its own test, neither compared to the other. Keeping both formats (by having `PathParser` strip what `OSDPath` returns) would have deduplicated the implementation while preserving the divergence the issue was filed about.
+- The same forwarding fixes four cases where `TDocStd_PathParser` was wrong rather than differently formatted: an extension-less path parsed to an empty name *and* empty directory, a dotfile inside a directory returned `nil` from every accessor, a dot in a directory name was read as the file's extension, and non-ASCII paths came back mangled. Those four are ordinary PATCH-class fixes ("a method that returned `nil` when it shouldn't"); only the two formats above are a break.
+- A warning, not an error, is the weaker prompt, stated plainly here rather than claimed otherwise. It is what the API allows: Swift cannot overload on return *value*, only on type, so there is no spelling in which the old format survives alongside the new one.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with before/after code, and to be named in the release notes.
 
 ### MINOR — `x.y.0`
 


### PR DESCRIPTION
Closes #499. Targets `refactor/381-pass1b`, per #499's own branch rule (Pass 1b of #377).

## What changed

**One path-parsing implementation.** `PathParser` wrapped `TDocStd_PathParser` and `OSDPath`
wrapped `OSD_Path`: two OCCT classes answering the same questions behind identically-named Swift
methods, each with its own test pinning its own format and neither compared to the other. Every
`PathParser` method now forwards to `OSDPath`. `TDocStd_PathParser` is no longer wrapped and
`OCCTPathParserTrek`/`Name`/`Extension`/`FreeString` are deleted, a free move since `OCCTBridge`
is not an SPM product, so no consumer reaches those C symbols.

`OSD_Path` was the right survivor on its merits, not just because it is the workhorse the rest of
the bridge already uses (STEP/IGES/STL export, `OCCTOSDFile`, `OCCTBridge_Mesh.mm`). Measuring both
classes across 19 inputs before writing any code
([`Scripts/repro/499-path-parsing-divergence/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/499-path-parsing-divergence))
found four cases where `TDocStd_PathParser` is not differently formatted but wrong:

| input | `PathParser`, before | now (= `OSDPath`) |
|---|---|---|
| `/home/user/model` | name `""`, directory `""` | name `"model"`, directory `"/home/user/"` |
| `/home/user/.config` | `nil` from every accessor | ext `".config"`, directory `"/home/user/"` |
| `/home/a.b/model` | name `"a"`, ext `"b/model"` | name `"model"`, ext `""` |
| `/home/üser/mødel.step` | name `"mÃ¸del"` | name `"mødel"` |

`Parse()` returns early when the path holds no dot, leaving name *and* trek at their empty
defaults. When the basename starts with a dot, its second `Split` is handed an index equal to the
remaining length and throws, which the bridge's `catch (...)` turned into `nil`. And the dot search
runs over the whole path with no separator awareness, so a dot in a directory name is read as the
start of the file's extension.

## Where the issue's premise was wrong

**The non-ASCII prediction is inverted.** #499's "second, deeper divergence" expected `OSD_Path`'s
documented `ConstructionError` for characters outside `' '...'~'` (`OSD_Path.hxx:43-46`) to make
every `OSDPath` method return `nil` for a non-ASCII path, while `TDocStd_PathParser`'s
`TCollection_ExtendedString` handled it. Both halves are wrong:

- `OSD_Path.cxx` contains no `Standard_ConstructionError` throw at all. It includes the header and
  documents the constraint; nothing enforces it. `/home/üser/mødel.step` parses cleanly.
- `TDocStd_PathParser` is the side that mangled it, and from the bridge:
  `TCollection_ExtendedString(const char*, bool theIsMultiByte = false)` defaults to *false*, so
  UTF-8 was read one byte per `ExtCharacter` and re-encoded on the way back out.

## A larger divergence the issue did not mention

**`OSDPath.trek(_:)` is not a filesystem path.** `OSD_Path::Trek()` returns OCCT's portable
directory syntax: `UnixExtract` runs `trek.ChangeAll('/', '|')` and rewrites `..` as `^`, so
`/home/user/model.step` gives `"|home|user|"` where `TDocStd_PathParser` gave `"/home/user"`. The
Swift doc comment said only "Get the directory trek from a path", and the method had **no test of
any kind** (#499 confirms `trek`, `systemName` and `isUnixPath` had none). It now documents the
syntax and points at the new **`OSDPath.folder(_:)`**, which returns the real directory and is what
`PathParser.trek` forwards to. `folder`/`file` recompose to the input; `trek` never could.

## The break, and why it was taken

Two silent behaviour changes, prompted by a deprecation warning at every call site rather than a
compile error. [`SEMVER.md`](../blob/refactor/381-pass1b/docs/SEMVER.md) records the exception:

```swift
PathParser.fileExtension("model.step")     // was "step"        now ".step"
PathParser.trek("/home/user/model.step")   // was "/home/user"  now "/home/user/"
```

The alternative, having `PathParser` strip the dot and the trailing slash off what `OSDPath`
returns, would have deduplicated the implementation while preserving the exact divergence the issue
was filed about. `OSDPath`'s format is the one that is tested, documented and OCCT-faithful, so it
wins; a caller who wants Foundation's convention gets told about the difference, which the doc
comment now states next to `URL.pathExtension`.

## Tests

`PathParsingContractTests` (`Tests/OCCTFoundationTests`), 17 tests, written and run against the
**unmodified** bridge first, per the #489 lesson:

- **8 of the original 15 failed pre-fix** (21 expectation failures), covering every row of the
  table above plus the three cross-spelling agreement tests.
- The 7 that passed are the `OSD_Path`-side regression guards, which is the useful half of the
  measurement: nothing about `OSDPath`'s own answers changed.
- `trek` gets its first coverage of any kind, pinning the `|`/`^` syntax so it cannot quietly turn
  into a path; `systemName` and `isUnixPath` get theirs too.
- `validityCheckAcceptsAnythingParsable` records what was measured rather than assumed:
  `OSD_Path::IsValid` accepted every string tried, including the empty one.

`TDocStdPathParserTests` (`OCCTXCAFTests`) stays where a `PathParser` user would look for it,
updated to the forwarded format, with the suite's `parseExtension` now asserting `".step"` where it
asserted `"step"`.

Full `swift test`: 4765 tests, 1337 suites, green. `swift build` warning-free.

## Also

- `OSD_Path` and `OSD_Environment` gained cross-reference index entries, neither of which the index
  ever had, the same #484/#489 failure mode where a missing entry hides call sites from any
  audit-by-symbol-name.
- The four `OCCTOSDPath*` string accessors were four copies of construct-read-`strdup`; they share
  one helper now.
- Not filed upstream. `TDocStd_PathParser` is OCAF-internal, used by OCCT only on document paths it
  built itself, and OCCT already ships `OSD_Path` for general parsing. The fix for a consumer is to
  not use it, which is what this PR does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
