### PR TITLE
okf: a merge into refactor/381-pass1b is Code-Review, not Done

### DIFF
--- a/okf/policies/issue-tracking.md
+++ b/okf/policies/issue-tracking.md
@@ -19,9 +19,12 @@ Todo/In Progress/Done default: [OCCTSwift Refactor (#377)](https://github.com/or
 `refactor` + `phase:*` labels identify which issues belong to it.
 
 **Update `Status` at the same points the workflow already visits**, not as a separate later pass:
-opening a PR moves the card to `PR Review`, a review landing moves it to `Code-Review`, a merge moves
-it to `Done`. The project's own Workflows panel automates the one transition GitHub can do for you
-("Item closed" / "Pull request merged" → `Done`); turn both on per board.
+opening a PR moves the card to `PR Review`, a review landing moves it to `Code-Review`. **A merge
+into `refactor/381-pass1b` is not `Done`**: that branch is the initiative's own integration branch,
+not `main`, so a merged/closed issue stays at `Code-Review` until the initiative's branch itself
+reaches `main`. Do not wire the project's native "Item closed" / "Pull request merged" → `Done`
+Workflows here: both fire on the branch merge, not the eventual `main` merge, which is exactly the
+wrong event for this initiative's shape.
 
 **`Linked pull requests` will not populate for a PR based on anything but the repo's default branch**,
 including every `refactor/381-pass1b`-targeted PR in this project. That is GitHub platform behaviour,


### PR DESCRIPTION
Mirrors [ecosystem#28](https://github.com/SecondMouseAU/ecosystem/pull/28), correcting
[#528](https://github.com/SecondMouseAU/OCCTSwift/pull/528)'s own guidance.

## Why

Five #377 issues (#490, #491, #492, #493, #495) got moved to `Done` on the OCCTSwift Refactor
project board right after their PRs merged. Wrong in every case: those PRs merged into
`refactor/381-pass1b`, the initiative's own integration branch, not `main`. `Code-Review` (the
same status a posted-but-unlanded review uses) is the correct card state until the initiative's
branch itself reaches `main`. Fixed on the board already; this PR corrects the doc that gave the
wrong instruction.

## What changed

- `okf/policies/issue-tracking.md`: retracts "a merge moves it to `Done`" and the recommendation to
  wire the project's native Item closed / PR merged Workflows to `Done`, since both fire on the
  branch merge rather than the eventual `main` merge.