### PR TITLE
fix(#500): one nearest-parameter projection per dimension, and a way to say there isn't one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,285 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,287 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -299,7 +299,8 @@
 // Geom2dAPI_InterCurveCurve           → OCCTCurve2DIntersect, OCCTCurve2DSelfIntersect
 // Geom2dAPI_Interpolate               → OCCTCurve2DInterpolate*
 // Geom2dAPI_ProjectPointOnCurve       → OCCTCurve2DProjectPoint, OCCTCurve2DProjectPointAll,
-//                                        OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve
+//                                        OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve,
+//                                        OCCTCurve2DNearestParameter
 //
 // --- Geom2dGcc ---
 // Geom2dGcc_Circ2d2TanOn              → OCCTGeom2dGccCirc2d2TanOn*
@@ -320,7 +321,10 @@
 // GeomAPI_IntSS                       → OCCTSurfaceSurfaceIntersect
 // GeomAPI_PointsToBSpline             → OCCTCurve3DFit
 // GeomAPI_PointsToBSplineSurface      → OCCTSurfacePlateThrough, OCCTSurfaceNLPlateG0
-// GeomAPI_ProjectPointOnCurve         → OCCTCurve3DProjectPoint
+// GeomAPI_ProjectPointOnCurve         → OCCTCurve3DNearestParameter, OCCTExtremaLocateOnCurve,
+//                                        OCCTExtremaPointCurve, OCCTProjOnCurve*,
+//                                        OCCTEdgeProjectPoint
+//                                        (NOT OCCTCurve3DProjectPoint; see ShapeAnalysis_Curve)
 // GeomAPI_ProjectPointOnSurf          → OCCTSurfaceProjectPoint, OCCTFaceProject*
 //
 // --- GeomConvert ---
@@ -430,7 +434,9 @@
 // ProjLib_ComputeApproxOnPolarSurface → OCCTProjLibProjectOntoPolarSurface
 //
 // --- ShapeAnalysis ---
-// ShapeAnalysis_Curve                 → OCCTCurveRangeValid*, OCCTCurveSamplePoints, OCCTCurveProjectPoint
+// ShapeAnalysis_Curve                 → OCCTCurve3DProjectPoint, OCCTCurve3DValidateRange,
+//                                        OCCTCurve3DGetSamplePoints3D, OCCTCurve3DIsClosedWithPreci,
+//                                        OCCTCurve3DIsPeriodicSA
 // ShapeAnalysis_FreeBoundsProperties  → OCCTShapeFreeBoundsAnalysis*
 // ShapeAnalysis_Surface               → OCCTSurfaceUVProject*
 // ShapeAnalysis_TransferParametersProj → OCCTShapeAnalysisTransferParam*
@@ -16647,18 +16653,28 @@ bool OCCTShapeLimitMaxTolerance(OCCTShapeRef _Nonnull shape, double maxTol);
 /// Get the curve type enum (GeomAbs_CurveType: 0=Line..7=OtherCurve).
 int32_t OCCTCurve3DCurveType(OCCTCurve3DRef _Nonnull curve);
 
-/// Find parameter on curve nearest to a 3D point.
-double OCCTCurve3DParameterAtPoint(OCCTCurve3DRef _Nonnull curve,
-                                   double x, double y, double z);
+/// Find the parameter on a 3D curve nearest to a 3D point, over the curve's whole range.
+///
+/// Returns false and leaves *outParameter untouched when the point has no projection at all:
+/// one beyond the ends of a bounded curve, or a circle's centre. That is an ordinary outcome, not
+/// an error, and it cannot be signalled through the parameter: every double is a legitimate
+/// parameter on some curve. Replaces OCCTCurve3DParameterAtPoint and OCCTCurve3DClosestParameter,
+/// which ran the identical projection and disagreed about the no-projection case (#500).
+bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve, double x, double y, double z,
+                                 double* _Nonnull outParameter);
 
 // --- Curve2D extras ---
 
 /// Get the 2D curve type enum.
 int32_t OCCTCurve2DCurveType(OCCTCurve2DRef _Nonnull curve);
 
-/// Find parameter on 2D curve nearest to a 2D point.
-double OCCTCurve2DParameterAtPoint(OCCTCurve2DRef _Nonnull curve,
-                                   double x, double y);
+/// Find the parameter on a 2D curve nearest to a 2D point, over the curve's whole range.
+///
+/// Returns false and leaves *outParameter untouched when the point has no projection at all,
+/// on the same contract as the other Geom2dAPI_ProjectPointOnCurve entry points (#413, #500).
+/// Replaces OCCTCurve2DParameterAtPoint, which reported that case as FirstParameter().
+bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve, double x, double y,
+                                 double* _Nonnull outParameter);
 
 // --- Surface extras ---
 
@@ -17624,8 +17640,8 @@ double OCCTShapeTotalEdgeLength(OCCTShapeRef _Nonnull shape);
 /// Compute the length of a 3D curve between parameters u1 and u2.
 double OCCTCurve3DLength(OCCTCurve3DRef _Nonnull curve, double u1, double u2);
 
-/// Find the closest point on a 3D curve to a given point. Returns parameter.
-double OCCTCurve3DClosestParameter(OCCTCurve3DRef _Nonnull curve, double px, double py, double pz);
+/// OCCTCurve3DClosestParameter was declared here: a second spelling of the projection
+/// OCCTCurve3DNearestParameter now performs. Removed by #500.
 
 /// Create a trimmed copy of a 2D curve between parameters u1 and u2.
 OCCTCurve2DRef _Nullable OCCTCurve2DTrimmed(OCCTCurve2DRef _Nonnull curve, double u1, double u2);

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -4144,14 +4144,43 @@ int32_t OCCTCurve3DCurveType(OCCTCurve3DRef curve) {
     } catch (...) { return 7; }
 }
 
-double OCCTCurve3DParameterAtPoint(OCCTCurve3DRef curve,
-                                   double x, double y, double z) {
-    if (!curve || curve->curve.IsNull()) return 0;
+// The 3D counterpart of OCCTBridge_Geom2d.mm's occtNearestProjectionOnCurve2d, which #413 gave the
+// 2D side and #500 found the 3D side had never had: one GeomAPI_ProjectPointOnCurve construction
+// behind every entry point that wants the nearest solution over the curve's whole range:
+// OCCTCurve3DNearestParameter and OCCTExtremaLocateOnCurve's full-range fallback.
+//
+// Returns false when there is no projection at all, an ordinary outcome rather than an error: a point
+// beyond the ends of a bounded curve, or the centre of a circle, has no extremum. Failure may not
+// be reported through the parameter, since every double is a legitimate parameter on some curve.
+//
+// Not routed through here, and why: OCCTExtremaLocateOnCurve's primary search and
+// OCCTEdgeProjectPoint (OCCTBridge_Properties.mm) pass an explicit parameter window;
+// OCCTExtremaPointCurve and OCCTProjOnCurve* need every extremum, not the nearest;
+// OCCTCurve3DProjectPoint runs ShapeAnalysis_Curve::Project, a different algorithm with a
+// different contract, adjusting to the curve ends rather than reporting no projection.
+static bool occtNearestProjectionOnCurve3d(OCCTCurve3DRef curve, const gp_Pnt& point,
+                                           gp_Pnt* outNearest, double* outParameter,
+                                           double* outDistance) {
+    if (!curve || curve->curve.IsNull()) return false;
     try {
-        GeomAPI_ProjectPointOnCurve proj(gp_Pnt(x, y, z), curve->curve);
-        if (proj.NbPoints() < 1) return curve->curve->FirstParameter();
-        return proj.LowerDistanceParameter();
-    } catch (...) { return 0; }
+        GeomAPI_ProjectPointOnCurve proj(point, curve->curve);
+        if (proj.NbPoints() == 0) return false;
+        if (outNearest) *outNearest = proj.NearestPoint();
+        if (outParameter) *outParameter = proj.LowerDistanceParameter();
+        if (outDistance) *outDistance = proj.LowerDistance();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Failure contract: returns false, leaving *outParameter untouched. This replaces two functions
+// that computed the identical projection and disagreed about how to report its absence:
+// OCCTCurve3DParameterAtPoint returned curve->FirstParameter(), OCCTCurve3DClosestParameter
+// returned 0, which is not even in the domain of a curve trimmed to, say, [3, 8] (#500).
+bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve, double x, double y, double z,
+                                 double* _Nonnull outParameter) {
+    return occtNearestProjectionOnCurve3d(curve, gp_Pnt(x, y, z), nullptr, outParameter, nullptr);
 }
 // --- Extrema extras ---
 
@@ -4170,11 +4199,8 @@ bool OCCTExtremaLocateOnCurve(OCCTCurve3DRef curve,
         GeomAPI_ProjectPointOnCurve proj(gp_Pnt(px, py, pz), curve->curve, lo, hi);
         if (proj.NbPoints() < 1) {
             // Fallback to full range
-            GeomAPI_ProjectPointOnCurve projFull(gp_Pnt(px, py, pz), curve->curve);
-            if (projFull.NbPoints() < 1) return false;
-            *param = projFull.LowerDistanceParameter();
-            *distance = projFull.LowerDistance();
-            return true;
+            return occtNearestProjectionOnCurve3d(curve, gp_Pnt(px, py, pz), nullptr,
+                                                  param, distance);
         }
         *param = proj.LowerDistanceParameter();
         *distance = proj.LowerDistance();
@@ -4579,16 +4605,9 @@ double OCCTCurve3DLength(OCCTCurve3DRef curve, double u1, double u2) {
     } catch (...) { return 0; }
 }
 
-double OCCTCurve3DClosestParameter(OCCTCurve3DRef curve, double px, double py, double pz) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        GeomAPI_ProjectPointOnCurve proj(gp_Pnt(px, py, pz), curve->curve);
-        if (proj.NbPoints() > 0) {
-            return proj.LowerDistanceParameter();
-        }
-        return 0;
-    } catch (...) { return 0; }
-}
+// OCCTCurve3DClosestParameter lived here: the same projection as OCCTCurve3DNearestParameter,
+// differing only in reporting no-projection as 0 rather than FirstParameter(). Removed by #500;
+// Curve3D.closestParameter(to:) now shares the one implementation.
 
 
 double OCCTCurve3DParameterAtLength(OCCTCurve3DRef curve, double arcLength, double fromParam) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -109,15 +109,19 @@
 // otherwise-identical pass over the 3D side; #487 converged them.
 
 // One Geom2dAPI_ProjectPointOnCurve construction behind every entry point that wants the nearest
-// solution: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D and OCCTPoint2DDistanceToCurve.
-// They were three independent constructions of the same algorithm with three different
-// failure-signalling conventions bolted on separately (#413). It also gives the two that lacked
-// one an explicit null-handle guard rather than relying on catch(...) to absorb the dereference.
+// solution: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve and
+// OCCTCurve2DNearestParameter. They were four independent constructions of the same algorithm with
+// four different failure-signalling conventions bolted on separately (#413 unified the first
+// three, #500 the fourth). It also gives those that lacked one an explicit null-handle guard
+// rather than relying on catch(...) to absorb the dereference.
 //
 // Returns false when there is no projection at all — an ordinary outcome, not an error: a point
 // beyond the ends of a bounded curve, or the centre of a circle, has no extremum. Each caller
 // applies its own documented sentinel; none of them may report failure through the parameter,
 // since 0 is a legitimate parameter on any curve whose domain includes it.
+//
+// OCCTCurve2DProjectPointAll is the multi-solution sibling: it needs every extremum rather than
+// the nearest one, so it constructs its own and is not routed through here.
 static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d& point,
                                             gp_Pnt2d* outNearest, double* outParameter,
                                             double* outDistance) {
@@ -3971,14 +3975,13 @@ int32_t OCCTCurve2DCurveType(OCCTCurve2DRef curve) {
     } catch (...) { return 7; }
 }
 
-double OCCTCurve2DParameterAtPoint(OCCTCurve2DRef curve,
-                                   double x, double y) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        Geom2dAPI_ProjectPointOnCurve proj(gp_Pnt2d(x, y), curve->curve);
-        if (proj.NbPoints() < 1) return curve->curve->FirstParameter();
-        return proj.LowerDistanceParameter();
-    } catch (...) { return 0; }
+// Failure contract: returns false, leaving *outParameter untouched. This replaces
+// OCCTCurve2DParameterAtPoint, which reported "no projection" as curve->FirstParameter(): a real
+// parameter in the curve's own domain, indistinguishable from a genuine result, and right or
+// maximally wrong depending only on which end the point fell off (#500).
+bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve, double x, double y,
+                                 double* _Nonnull outParameter) {
+    return occtNearestProjectionOnCurve2d(curve, gp_Pnt2d(x, y), nullptr, outParameter, nullptr);
 }
 
 // MARK: - v0.114: Curve2D isBounded + DN + type-name

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -712,7 +712,7 @@ public final class Curve2D: @unchecked Sendable {
     ///
     /// - Parameter p: Point to project.
     /// - Returns: The nearest projection, or `nil` if the point has no projection onto this curve
-    ///   — one beyond the ends of a bounded curve, or the centre of a circle.
+    ///     one beyond the ends of a bounded curve, or the centre of a circle.
     ///
     /// `project(_:)` (the `Point2D` overload) and `Point2D.distance(to:)` compute the same nearest
     /// solution through the same shared bridge path, and agree on both the value and on when
@@ -728,6 +728,34 @@ public final class Curve2D: @unchecked Sendable {
         let r = OCCTCurve2DProjectPoint(handle, p.x, p.y)
         guard r.distance >= 0 else { return nil }
         return Curve2DProjection(point: SIMD2(r.x, r.y), parameter: r.parameter, distance: r.distance)
+    }
+
+    /// The parameter of the point on this curve nearest to `point`.
+    ///
+    /// - Parameter point: Point to project.
+    /// - Returns: The nearest parameter, or `nil` if the point has no projection onto this curve
+    ///     one beyond the ends of a bounded curve, or the centre of a circle.
+    ///
+    /// The scalar form of `project(point:)`, computed by the same shared bridge path and agreeing
+    /// with it, with `Point2D.distance(to:)` and with `allProjections(of:)` on exactly when there
+    /// is no projection.
+    ///
+    /// `nil` is the only answer that says so, which is why this replaces the deprecated
+    /// `parameterAtPoint(_:)`: no `Double` can carry the signal. `0` is a legitimate parameter on
+    /// any curve whose domain includes it, and so is every other value.
+    ///
+    /// ```swift
+    /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
+    /// #expect(segment.nearestParameter(to: SIMD2(5, 3)) == 5)
+    /// #expect(segment.nearestParameter(to: SIMD2(100, 0)) == nil)   // past the end
+    ///
+    /// let circle = Curve2D.circle(center: .zero, radius: 5)!
+    /// #expect(circle.nearestParameter(to: .zero) == nil)            // equidistant everywhere
+    /// ```
+    public func nearestParameter(to point: SIMD2<Double>) -> Double? {
+        var parameter = 0.0
+        guard OCCTCurve2DNearestParameter(handle, point.x, point.y, &parameter) else { return nil }
+        return parameter
     }
 
     /// Project a point onto this curve, returning all projections.

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1895,9 +1895,44 @@ extension Curve3D {
         length(from: param1, to: param2) ?? -1.0
     }
 
+    /// The parameter of the point on this curve nearest to `point`.
+    ///
+    /// - Parameter point: Point to project.
+    /// - Returns: The nearest parameter, or `nil` if the point has no projection onto this curve
+    ///     one beyond the ends of a bounded curve, or the centre of a circle.
+    ///
+    /// `nil` is the only answer that says so: no `Double` can carry the signal, because
+    /// every value is a legitimate parameter on some curve. This is the 3D counterpart of
+    /// `Curve2D.nearestParameter(to:)`, and it replaces both `closestParameter(to:)` and
+    /// `parameterAtPoint(_:)`, which ran the identical projection and disagreed about how to
+    /// report its absence.
+    ///
+    /// Contrast `projectPoint(_:precision:)`, which runs a different OCCT algorithm
+    /// (`ShapeAnalysis_Curve::Project`) that always answers, adjusting to the curve's ends rather
+    /// than reporting that there is no projection.
+    ///
+    /// ```swift
+    /// let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!
+    /// let segment = line.trimmed(from: 3, to: 8)!
+    /// #expect(segment.nearestParameter(to: SIMD3(5, 2, 0)) == 5)
+    /// #expect(segment.nearestParameter(to: SIMD3(100, 0, 0)) == nil)   // past the end
+    /// ```
+    public func nearestParameter(to point: SIMD3<Double>) -> Double? {
+        var parameter = 0.0
+        guard OCCTCurve3DNearestParameter(handle, point.x, point.y, point.z, &parameter) else {
+            return nil
+        }
+        return parameter
+    }
+
     /// Find the parameter of the closest point on this curve to a given point.
+    @available(*, deprecated, message: """
+        Returns .nan when there is no projection, where it used to return 0, a value that is not \
+        even in the domain of a curve trimmed to, say, [3, 8]. Use nearestParameter(to:), which \
+        returns nil.
+        """)
     public func closestParameter(to point: SIMD3<Double>) -> Double {
-        OCCTCurve3DClosestParameter(handle, point.x, point.y, point.z)
+        nearestParameter(to: point) ?? .nan
     }
 
     /// Split this curve at C1 discontinuities.

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -11640,8 +11640,13 @@ extension Curve3D {
     }
 
     /// Find parameter on curve nearest to a 3D point.
+    @available(*, deprecated, message: """
+        Returns .nan when there is no projection, where it used to return the curve's \
+        firstParameter, a real parameter in its own domain, right or maximally wrong depending \
+        only on which end the point fell off. Use nearestParameter(to:), which returns nil.
+        """)
     public func parameterAtPoint(_ point: SIMD3<Double>) -> Double {
-        OCCTCurve3DParameterAtPoint(handle, point.x, point.y, point.z)
+        nearestParameter(to: point) ?? .nan
     }
 }
 
@@ -11655,8 +11660,13 @@ extension Curve2D {
     }
 
     /// Find parameter on 2D curve nearest to a 2D point.
+    @available(*, deprecated, message: """
+        Returns .nan when there is no projection, where it used to return the curve's \
+        firstParameter, a real parameter in its own domain, right or maximally wrong depending \
+        only on which end the point fell off. Use nearestParameter(to:), which returns nil.
+        """)
     public func parameterAtPoint(_ point: SIMD2<Double>) -> Double {
-        OCCTCurve2DParameterAtPoint(handle, point.x, point.y)
+        nearestParameter(to: point) ?? .nan
     }
 }
 

--- a/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
+++ b/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// MARK: - #500: the 3D side of the point-to-curve projection family
+
+/// #413 gave the 2D side one `Geom2dAPI_ProjectPointOnCurve` construction behind every entry point
+/// that wants the nearest solution. The 3D side never got the equivalent: `Curve3D.parameterAtPoint`
+/// and `Curve3D.closestParameter(to:)` each built their own `GeomAPI_ProjectPointOnCurve`, ran the
+/// identical computation, and then disagreed about how to report that there wasn't one — the first
+/// answering with the curve's `firstParameter`, the second with `0`.
+///
+/// The disagreement is invisible on the curves the old tests used, which is how it survived: both
+/// answer `0` whenever `firstParameter` happens to be `0`, as it is for a line, a circle, and a
+/// segment built from two points. It takes a curve trimmed to a domain that does not start at zero
+/// to separate them — and then `closestParameter`'s `0` is not merely ambiguous, it is outside the
+/// curve's own domain.
+@Suite("Curve3D nearest-parameter entry points agree (#500)")
+struct Issue500Curve3DNearestParameterTests {
+
+    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`.
+    private static func trimmedSegment() -> Curve3D? {
+        Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
+    }
+
+    @Test("An ordinary projection returns the real parameter")
+    func ordinaryProjection() throws {
+        let curve = try #require(Self.trimmedSegment())
+        #expect(curve.domain == 3...8)
+        #expect(curve.nearestParameter(to: SIMD3(5, 2, 0)) == 5)
+        #expect(curve.nearestParameter(to: SIMD3(3, 4, 0)) == 3)     // the start point itself
+        #expect(curve.nearestParameter(to: SIMD3(8, -1, 0)) == 8)    // the end point itself
+    }
+
+    /// A point beyond the ends of a bounded curve has no extremum, so no projection. This is the
+    /// case the two old spellings answered differently, and neither answer was reportable.
+    @Test("No projection is nil, not a parameter from either old convention")
+    func noProjectionIsNil() throws {
+        let curve = try #require(Self.trimmedSegment())
+        for p in [SIMD3<Double>(100, 0, 0), SIMD3(0, 0, 0), SIMD3(-50, 3, 0)] {
+            #expect(curve.nearestParameter(to: p) == nil, "\(p)")
+        }
+    }
+
+    /// A circle's centre is equidistant from every point on it, so there is no local minimum to
+    /// find. The 2D parity suite uses the same case (#413).
+    @Test("A circle's centre has no projection")
+    func circleCentreHasNoProjection() throws {
+        let circle = try #require(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5))
+        #expect(circle.nearestParameter(to: .zero) == nil)
+        #expect(circle.nearestParameter(to: SIMD3(3, 4, 0)) != nil)   // on the circle: fine
+    }
+
+    /// Both deprecated spellings now route through the one implementation, so they agree with each
+    /// other and with `nearestParameter(to:)` — including on the no-projection case, where they
+    /// report `.nan`. `.nan` is the only `Double` that is not a legitimate parameter on some curve.
+    @Test("The two deprecated spellings agree with each other and with nearestParameter")
+    @available(*, deprecated, message: "exercises the deprecated spellings on purpose")
+    func deprecatedSpellingsAgree() throws {
+        let curve = try #require(Self.trimmedSegment())
+
+        // Where there is a projection, all three give the same real parameter.
+        #expect(curve.nearestParameter(to: SIMD3(5, 2, 0)) == 5)
+        #expect(curve.parameterAtPoint(SIMD3(5, 2, 0)) == 5)
+        #expect(curve.closestParameter(to: SIMD3(5, 2, 0)) == 5)
+
+        // Where there is none, the scalar spellings say so instead of inventing a parameter.
+        // Before #500: parameterAtPoint returned 3 (firstParameter) and closestParameter
+        // returned 0 — a value not even inside this curve's [3, 8] domain.
+        for p in [SIMD3<Double>(100, 0, 0), SIMD3(0, 0, 0)] {
+            #expect(curve.nearestParameter(to: p) == nil, "\(p)")
+            #expect(curve.parameterAtPoint(p).isNaN, "\(p)")
+            #expect(curve.closestParameter(to: p).isNaN, "\(p)")
+        }
+    }
+
+    /// `projectPoint(_:precision:)` is deliberately *not* part of this family: it runs
+    /// `ShapeAnalysis_Curve::Project`, which adjusts to the curve's ends rather than reporting that
+    /// there is no projection, and so always answers. Pinned here so a later pass does not
+    /// "unify" two entry points that genuinely compute different things.
+    @Test("projectPoint runs a different algorithm and keeps its own contract")
+    func projectPointIsADifferentAlgorithm() throws {
+        let curve = try #require(Self.trimmedSegment())
+        let p = SIMD3<Double>(100, 0, 0)
+
+        #expect(curve.nearestParameter(to: p) == nil)
+
+        // It answers where nearestParameter does not. Its answer is *not* clamped to [3, 8]:
+        // measured against the pinned kernel, it reports the point as lying on the curve's
+        // underlying unbounded line. Recorded as-is; see the note in the #500 PR.
+        let projected = curve.projectPoint(p)
+        #expect(projected.parameter == 100)
+        #expect(projected.distance == 0)
+    }
+}

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -2922,10 +2922,11 @@ struct Curve3DExtrasV112Tests {
         }
     }
 
-    @Test func parameterAtPoint() {
+    @Test func nearestParameterOnLine() {
         if let line = Curve3D.line(through: SIMD3(0,0,0), direction: SIMD3(1,0,0)) {
-            let param = line.parameterAtPoint(SIMD3(5, 0, 0))
-            #expect(abs(param - 5.0) < 0.1)
+            let param = line.nearestParameter(to: SIMD3(5, 0, 0))
+            #expect(param != nil)
+            if let param { #expect(abs(param - 5.0) < 0.1) }
         }
     }
 }
@@ -3185,9 +3186,10 @@ struct CurveLengthTests {
 
     @Test func curve3DClosestParameter() {
         if let line = Curve3D.line(through: SIMD3(0,0,0), direction: SIMD3(1,0,0)) {
-            let param = line.closestParameter(to: SIMD3(5, 3, 0))
+            let param = line.nearestParameter(to: SIMD3(5, 3, 0))
             // For a line along X, closest to (5,3,0) should be near param=5
-            #expect(abs(param - 5.0) < 0.1)
+            #expect(param != nil)
+            if let param { #expect(abs(param - 5.0) < 0.1) }
         }
     }
 

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -3490,10 +3490,11 @@ struct Curve2DExtrasV112Tests {
         }
     }
 
-    @Test func parameterAtPoint() {
+    @Test func nearestParameterOnLine() {
         if let line = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0)) {
-            let param = line.parameterAtPoint(SIMD2(5, 0))
-            #expect(abs(param - 5.0) < 0.1)
+            let param = line.nearestParameter(to: SIMD2(5, 0))
+            #expect(param != nil)
+            if let param { #expect(abs(param - 5.0) < 0.1) }
         }
     }
 }
@@ -4583,21 +4584,23 @@ struct Curve2DInterpolatePeriodicParityTests {
     }
 }
 
-// MARK: - #413: the four point-to-curve projection entry points
+// MARK: - #413/#500: the five point-to-curve projection entry points
 
-/// The same `Geom2dAPI_ProjectPointOnCurve` computation is reachable four ways:
-/// `Curve2D.project(point:)`, `Curve2D.allProjections(of:)`, `Curve2D.project(_ point: Point2D)`
-/// and `Point2D.distance(to:)`. They were four independent constructions with four different
-/// failure conventions bolted on separately — including one (`Point2D.distance(to:)`) that leaked
-/// the bridge's raw `-1` sentinel to callers as though it were a distance. They now share one
-/// bridge path and agree on both the values and on when there is no projection.
+/// The same `Geom2dAPI_ProjectPointOnCurve` computation is reachable five ways:
+/// `Curve2D.project(point:)`, `Curve2D.allProjections(of:)`, `Curve2D.project(_ point: Point2D)`,
+/// `Point2D.distance(to:)` and `Curve2D.nearestParameter(to:)`. They were five independent
+/// constructions with five different failure conventions bolted on separately, including one
+/// (`Point2D.distance(to:)`) that leaked the bridge's raw `-1` sentinel to callers as though it
+/// were a distance, and one (`Curve2D.parameterAtPoint(_:)`, now deprecated) that #413 missed
+/// entirely and that answered with the curve's own `firstParameter`. They now share one bridge
+/// path and agree on both the values and on when there is no projection.
 @Suite("Curve2D projection entry points agree (#413)")
 struct Curve2DProjectionParityTests {
 
     private static let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
 
-    @Test("All four entry points agree for an ordinary projection")
-    func successAgreesAcrossAllFour() {
+    @Test("All five entry points agree for an ordinary projection")
+    func successAgreesAcrossAllFive() {
         let cases: [(Curve2D, SIMD2<Double>)] = [
             (Self.segment, SIMD2(5, 3)),
             (Self.segment, SIMD2(0.5, -2)),
@@ -4612,14 +4615,17 @@ struct Curve2DProjectionParityTests {
             let asTuple = curve.project(point2D)
             let distance = point2D.distance(to: curve)
             let all = curve.allProjections(of: p)
+            let scalar = curve.nearestParameter(to: p)
 
             #expect(nearest != nil, comment)
             #expect(asTuple != nil, comment)
+            #expect(scalar != nil, comment)
             guard let nearest, let asTuple else { continue }
 
             #expect(nearest.parameter == asTuple.parameter, comment)
             #expect(nearest.distance == asTuple.distance, comment)
             #expect(nearest.distance == distance, comment)
+            #expect(scalar == nearest.parameter, comment)
 
             // The nearest solution must be the smallest of the full solution set.
             #expect(!all.isEmpty, comment)
@@ -4631,10 +4637,10 @@ struct Curve2DProjectionParityTests {
 
     /// A point with no projection at all is an ordinary outcome, not an error: one beyond the
     /// ends of a bounded curve, or a circle's centre (equidistant everywhere, so no local
-    /// minimum). All four entry points must report it, and none may report it as a distance a
-    /// threshold test would accept.
-    @Test("All four entry points agree when there is no projection")
-    func failureAgreesAcrossAllFour() {
+    /// minimum). All five entry points must report it, and none may report it as a distance a
+    /// threshold test would accept, or as a parameter a caller could mistake for a real one.
+    @Test("All five entry points agree when there is no projection")
+    func failureAgreesAcrossAllFive() {
         let cases: [(Curve2D, SIMD2<Double>)] = [
             (Self.segment, SIMD2(100, 0)),      // past the end
             (Self.segment, SIMD2(-50, 3)),      // before the start
@@ -4647,6 +4653,7 @@ struct Curve2DProjectionParityTests {
             #expect(curve.project(point: p) == nil, comment)
             #expect(curve.project(point2D) == nil, comment)
             #expect(curve.allProjections(of: p).isEmpty, comment)
+            #expect(curve.nearestParameter(to: p) == nil, comment)
 
             // Not -1: a raw sentinel here reads as "touching" to any `distance < tolerance` test.
             let distance = point2D.distance(to: curve)
@@ -4671,6 +4678,32 @@ struct Curve2DProjectionParityTests {
         #expect(nearest?.parameter == 0)
         #expect(nearest?.distance == 0)
         #expect(start.distance(to: Self.segment) == 0)
+        #expect(Self.segment.nearestParameter(to: SIMD2(0, 0)) == 0)
+    }
+
+    /// The fifth entry point, which #413 missed. `parameterAtPoint(_:)` answered a no-projection
+    /// with `firstParameter`: right by luck when the point fell off the start, and the far end of
+    /// the curve when it fell off the finish. Neither is distinguishable from a real result, so
+    /// the scalar spelling had to become optional; the deprecated one now says `.nan` instead.
+    @Test("The deprecated scalar spelling no longer answers with a real parameter")
+    @available(*, deprecated, message: "exercises the deprecated parameterAtPoint on purpose")
+    func deprecatedScalarSpellingReportsNaN() {
+        // A domain that does not start at 0, so `firstParameter` is visibly not a default.
+        guard let line = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0)),
+              let trimmed = line.trimmed(from: 3, to: 8) else { return }
+        #expect(trimmed.domain == 3...8)
+
+        // Fell off the far end: `firstParameter` (3) was the worst answer available.
+        #expect(trimmed.nearestParameter(to: SIMD2(100, 0)) == nil)
+        #expect(trimmed.parameterAtPoint(SIMD2(100, 0)).isNaN)
+
+        // Fell off the start: `firstParameter` (3) was the right point for the wrong reason.
+        #expect(trimmed.nearestParameter(to: SIMD2(0, 0)) == nil)
+        #expect(trimmed.parameterAtPoint(SIMD2(0, 0)).isNaN)
+
+        // A real projection still returns the real parameter through both spellings.
+        #expect(trimmed.nearestParameter(to: SIMD2(5, 2)) == 5)
+        #expect(trimmed.parameterAtPoint(SIMD2(5, 2)) == 5)
     }
 }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -440,7 +440,7 @@ a map of the major areas, and the `Total` as the count.
 | **Shape Location/Orientation** | 9 | child, isLocked, setLocked, located, getLocation, setLocation, oriented, compounded, empty |
 | **Wire/Face Construction** | 8 | wireFromEdges, makeCompound, makeShell, isCompound, isSolid, isShell, isFace, isEdge |
 | **BRepCheck Extended** | 8 | checkFaceStatus, checkEdgeStatus, checkVertexStatus, maxTolerance, minTolerance, avgTolerance, fixTolerance, limitMaxTolerance |
-| **Curve3D/2D Type & Projection** | 5 | curveType (3D), parameterAtPoint (3D), curveType (2D), parameterAtPoint (2D), surfaceGetType |
+| **Curve3D/2D Type & Projection** | 5 | curveType (3D), nearestParameter (3D), curveType (2D), nearestParameter (2D), surfaceGetType |
 | **Extrema Extras** | 4 | locateOnCurve, locateOnSurface, pointCurve, pointSurface |
 | **MakeEdge Completions** | 12 | edgeFromEllipse, edgeFromEllipseArc, edgeFromHyperbolaArc, edgeFromParabolaArc, edgeFromCurve, edgeFromCurveParams, edgeFromCurvePoints, edgeOnSurface, edgeOnSurfaceParams, edgeVertex1, edgeVertex2, edgeError |
 | **ProjectionOnCurve** | 8 | create, release, nbPoints, point, parameter, distance, lowerDistance, lowerParam |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,285** | |
+| **Total** | **4,287** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -86,6 +86,59 @@ these two facts together, and now assert the measurements.
 
 Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
 
+#### The point-to-curve projection family finally has one answer for "there isn't one" (#500)
+
+`Curve2D.parameterAtPoint(_:)` was a fifth `Geom2dAPI_ProjectPointOnCurve` construction that #413's
+unification never reached, and it had invented a third failure convention, worse than either of
+the two #413 replaced. Where a point has no projection at all (one beyond the ends of a bounded
+curve, or a circle's centre, which is equidistant from every point on it), it returned the curve's
+own `firstParameter`: a real parameter inside the curve's own domain, indistinguishable from a
+genuine result. Whether that was right depended only on which end you fell off.
+
+The 3D side turned out to be worse, and the audit's own "adjacent, systemic" note undersold it.
+`Curve3D.parameterAtPoint(_:)` and `Curve3D.closestParameter(to:)` are two public spellings of the
+same computation, each with its own `GeomAPI_ProjectPointOnCurve`, and they *disagree*: one answers
+`firstParameter`, the other `0`. On a curve trimmed to `[3, 8]`, `0` is not even in the domain.
+Both old tests used a curve starting at parameter 0, where the two answers coincide, which is how
+the disagreement survived. There was no shared 3D helper at all: the 2D side got one in #413, the
+3D side never did.
+
+```swift
+let seg = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!.trimmed(from: 3, to: 8)!
+
+// Before: same question, three answers, none of them sayable as "no projection".
+seg.parameterAtPoint(SIMD3(100, 0, 0))     // 3.0  the far end of the curve
+seg.closestParameter(to: SIMD3(100, 0, 0)) // 0.0  outside the domain entirely
+
+// After.
+seg.nearestParameter(to: SIMD3(100, 0, 0)) // nil
+seg.nearestParameter(to: SIMD3(5, 2, 0))   // 5.0
+```
+
+**Not source-breaking.** `Curve2D.nearestParameter(to:)` and `Curve3D.nearestParameter(to:)` are
+new and return `Double?`; all three old spellings remain as deprecated shims. Their *behaviour*
+changes in the no-projection case only: they now return `.nan`, the one `Double` that is not a
+legitimate parameter on some curve, instead of three different plausible-looking values. Code that
+was reading a real answer reads the same real answer.
+
+Bridge-side, `OCCTCurve2DParameterAtPoint` now routes through `occtNearestProjectionOnCurve2d`
+(five entry points, one construction), and the 3D side gains the `occtNearestProjectionOnCurve3d`
+it never had, shared by `OCCTCurve3DNearestParameter` and `OCCTExtremaLocateOnCurve`'s full-range
+fallback. `OCCTCurve3DClosestParameter` is gone.
+
+`Curve3D.projectPoint(_:precision:)` is deliberately *not* folded in: it runs
+`ShapeAnalysis_Curve::Project`, a different algorithm that always answers by adjusting to the
+curve's ends. A test now pins that distinction so a later pass does not "unify" two things that
+genuinely compute differently.
+
+Three cross-reference index entries in `OCCTBridge.h` were corrected along the way. The staleness
+the audit blamed for the miss was real, and worse than reported. `Geom2dAPI_ProjectPointOnCurve`
+listed four of its five entry points; `GeomAPI_ProjectPointOnCurve` listed exactly one function,
+which does not use it (`OCCTCurve3DProjectPoint` calls `ShapeAnalysis_Curve`), and none of the five
+that do; and `ShapeAnalysis_Curve` named three functions that do not exist under those names.
+
+Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
+
 #### One continuity decoder per vocabulary, not nineteen (#490)
 
 Continuity reached OCCT as a plain integer through 19 separate decoders: seven independently-named

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -458,26 +458,40 @@ e.g. `param1 == param2`).
 
 ---
 
-### `closestParameter(to:)`
+### `nearestParameter(to:)`
 
-Finds the parameter of the closest point on this curve to a given 3D point.
+Finds the parameter of the nearest point on this curve to a given 3D point.
 
 ```swift
-public func closestParameter(to point: SIMD3<Double>) -> Double
+public func nearestParameter(to point: SIMD3<Double>) -> Double?
 ```
 
-Uses a projection; returns `0` if projection finds no points or an exception occurs.
-
 - **Parameters:** `point` — the query point in 3D space.
-- **Returns:** Parameter `u` such that `self.point(at: u)` is the nearest point on the curve to `point`.
+- **Returns:** Parameter `u` such that `self.point(at: u)` is the nearest point on the curve to
+  `point`, or `nil` if the point has no projection at all: one beyond the ends of a bounded
+  curve, or the centre of a circle, which is equidistant from every point on it. `nil` is the
+  only answer that says so: every `Double` is a legitimate parameter on some curve.
 - **OCCT:** `GeomAPI_ProjectPointOnCurve::LowerDistanceParameter`.
 - **Example:**
   ```swift
   if let line = Curve3D.line(through: .zero, direction: SIMD3(1,0,0)) {
-      let param = line.closestParameter(to: SIMD3(5, 3, 0))
-      #expect(abs(param - 5.0) < 0.1)
+      let param = line.nearestParameter(to: SIMD3(5, 3, 0))
+      #expect(param.map { abs($0 - 5.0) < 0.1 } == true)
+  }
+
+  // A curve trimmed to [3, 8]: a point past the end has no projection.
+  if let seg = Curve3D.line(through: .zero, direction: SIMD3(1,0,0))?.trimmed(from: 3, to: 8) {
+      #expect(seg.nearestParameter(to: SIMD3(100, 0, 0)) == nil)
   }
   ```
+
+Contrast [`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision), which runs a
+different OCCT algorithm (`ShapeAnalysis_Curve::Project`) that always answers, adjusting to the
+curve's ends rather than reporting that there is no projection.
+
+`closestParameter(to:)` is the deprecated spelling of this method. It returns `.nan` where this
+one returns `nil`; before #500 it returned `0`, which is not even inside the domain of a curve
+trimmed to `[3, 8]`.
 
 ---
 

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -775,17 +775,22 @@ Returns: `0` = Line, `1` = Circle, `2` = Ellipse, `3` = Hyperbola, `4` = Parabol
 
 ---
 
-### `Curve3D.parameterAtPoint(_:)`
+### `Curve3D.nearestParameter(to:)`
 
 Find the curve parameter nearest to a 3D point.
 
 ```swift
-public func parameterAtPoint(_ point: SIMD3<Double>) -> Double
+public func nearestParameter(to point: SIMD3<Double>) -> Double?
 ```
 
 - **Parameters:** `point` — the 3D query point.
-- **Returns:** The nearest parameter `u` on the curve.
-- **OCCT:** `GeomAPI_ProjectPointOnCurve` (via `OCCTCurve3DParameterAtPoint`).
+- **Returns:** The nearest parameter `u` on the curve, or `nil` if the point has no projection at
+  all: one beyond the ends of a bounded curve, or the centre of a circle.
+- **OCCT:** `GeomAPI_ProjectPointOnCurve` (via `OCCTCurve3DNearestParameter`).
+
+Replaces `parameterAtPoint(_:)` and
+[`closestParameter(to:)`](Curve3D-Construction.md#nearestparameterto), both deprecated: they ran
+the identical projection and disagreed about the no-projection case (#500).
 
 ---
 
@@ -803,15 +808,21 @@ Returns same codes as `Curve3D.curveType` but for `Geom2d_Curve`.
 
 ---
 
-### `Curve2D.parameterAtPoint(_:)`
+### `Curve2D.nearestParameter(to:)`
 
 Find the 2D curve parameter nearest to a 2D point.
 
 ```swift
-public func parameterAtPoint(_ point: SIMD2<Double>) -> Double
+public func nearestParameter(to point: SIMD2<Double>) -> Double?
 ```
 
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (via `OCCTCurve2DParameterAtPoint`).
+- **Returns:** The nearest parameter, or `nil` if the point has no projection at all. Agrees with
+  `Curve2D.project(point:)`, `Curve2D.allProjections(of:)`, `Curve2D.project(_:)` and
+  `Point2D.distance(to:)` on exactly when that is (#413, #500).
+- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (via `OCCTCurve2DNearestParameter`).
+
+Replaces `parameterAtPoint(_:)`, deprecated: it reported the no-projection case as the curve's
+own `firstParameter`.
 
 ---
 


### PR DESCRIPTION
Closes #500.

## What was wrong

`Curve2D.parameterAtPoint(_:)` is a fifth `Geom2dAPI_ProjectPointOnCurve` construction that #413's unification never reached. On a point with no projection at all (one beyond the ends of a bounded curve, or a circle's centre, equidistant from every point on it) it returned the curve's own `firstParameter`: a real parameter inside the curve's own domain, indistinguishable from a genuine result. That is a third failure convention, and a worse one than either of the two #413 replaced.

The 3D side turned out worse than the issue's "adjacent, systemic" framing suggested. `Curve3D.parameterAtPoint(_:)` and `Curve3D.closestParameter(to:)` are two public spellings of the same computation, each building its own `GeomAPI_ProjectPointOnCurve`, and they *disagree* about the no-projection case: one answers `firstParameter`, the other `0`.

```swift
let seg = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!.trimmed(from: 3, to: 8)!

// Before: same question, three answers, none of them sayable as "no projection".
seg.parameterAtPoint(SIMD3(100, 0, 0))     // 3.0, the far end of the curve
seg.closestParameter(to: SIMD3(100, 0, 0)) // 0.0, outside the domain entirely

// After.
seg.nearestParameter(to: SIMD3(100, 0, 0)) // nil
seg.nearestParameter(to: SIMD3(5, 2, 0))   // 5.0
```

Both old tests used curves whose domain starts at parameter 0, where the two answers coincide. That is how a disagreement between two public methods survived. There was no shared 3D helper at all: the 2D side got one in #413, the 3D side never did.

## Measured first

Ground truth against the pinned xcframework, before any code changed:

| case | `NbPoints()` | old `parameterAtPoint` | old `closestParameter` |
|---|---|---|---|
| segment `[3,8]`, point `(100,0,0)` past the end | 0 | 3.0 | 0.0 |
| segment `[3,8]`, point `(0,0,0)` before the start | 0 | 3.0 | 0.0 |
| segment `[3,8]`, point `(5,2,0)` | 1 | 5.0 | 5.0 |
| circle r=5, its own centre | 0 | 0.0 | 0.0 |

The sharpest case is a point just off the *start*: the true nearest point genuinely is `firstParameter`, and OCCT still reports `NbPoints() == 0` because there is no perpendicular foot, only an endpoint minimum. So the old fallback was right by luck at one end and maximally wrong at the other, with nothing to tell the two apart.

## What changed

**Bridge.** `OCCTCurve2DNearestParameter` routes through `occtNearestProjectionOnCurve2d`: five entry points, one construction. The 3D side gains `occtNearestProjectionOnCurve3d`, mirroring it, shared by `OCCTCurve3DNearestParameter` and `OCCTExtremaLocateOnCurve`'s full-range fallback. `OCCTCurve3DClosestParameter` is deleted, `OCCTCurve2DParameterAtPoint` and `OCCTCurve3DParameterAtPoint` are replaced.

**Swift.** `Curve2D.nearestParameter(to:)` and `Curve3D.nearestParameter(to:)` return `Double?`. All three old spellings remain as deprecated shims. **Not source-breaking**, so no `SEMVER.md` exception is needed. Their behaviour changes in the no-projection case only: `.nan`, the one `Double` that is not a legitimate parameter on some curve, in place of three different plausible-looking values. Code reading a real answer reads the same real answer.

**Deliberately not folded in.** `Curve3D.projectPoint(_:precision:)` runs `ShapeAnalysis_Curve::Project`, a different algorithm that always answers by adjusting to the curve's ends. A test pins that distinction so a later pass does not "unify" two things that genuinely compute differently.

**Cross-reference index.** The staleness the audit blamed for the miss was real, and worse than reported. Three entries in `OCCTBridge.h` corrected:

- `Geom2dAPI_ProjectPointOnCurve` listed four of its five entry points (the miss itself).
- `GeomAPI_ProjectPointOnCurve` listed exactly one function, `OCCTCurve3DProjectPoint`, which does not use it (it calls `ShapeAnalysis_Curve`), and none of the five that do.
- `ShapeAnalysis_Curve` named three functions that do not exist under those names (`OCCTCurveRangeValid*`, `OCCTCurveSamplePoints`, `OCCTCurveProjectPoint`).

## Verification

- New suite `Issue500Curve3DNearestParameterTests` (5 tests); `Curve2DProjectionParityTests` extended from four entry points to five.
- **The tests were proved to catch it**: reintroducing the pre-#500 fallback in both bridge functions fails 6 of the new/extended tests, every failure on a no-projection assertion. Restored and re-run clean.
- Full `swift test`: 4760 tests, 1338 suites, all passing.

## Found along the way, not fixed here

`Curve3D.projectPoint(_:precision:)` ignores a trimmed curve's parameter range, including when the range is passed explicitly (the 7-argument `ShapeAnalysis_Curve::Project` overload documents itself as *extending* the range). On the `[3,8]` segment above it reports the point `(100,0,0)` at parameter 100, distance 0, as though the point lies on the curve; its true distance is 92. `OCCTEdgeProjectPoint` passes a range and behaves the same way. Different function, different OCCT class, out of scope here; the current behaviour is pinned by test in this PR and I will file it separately.

Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)