### PR TITLE
fix(#502): one sub-shape enumeration, not one per accessor

### DIFF
--- a/Scripts/repro/502-subshape-traversal-dedup/README.md
+++ b/Scripts/repro/502-subshape-traversal-dedup/README.md
@@ -1,0 +1,91 @@
+# OCCTSwift#502 probe: `TopExp_Explorer` vs `TopExp::MapShapes` as sub-shape enumerators
+
+Ground truth for the two traversals the bridge used to answer one question, against the pinned
+OCCT 8.0.0p1 kernel.
+
+#502 found that `OCCTShapeGetSolids`/`GetShells`/`GetWires` drive a bare `TopExp_Explorer` while
+`OCCTShapeGetSubShapeCount`/`GetSubShapeByTypeIndex` build a `TopTools_IndexedMapOfShape` through
+`TopExp::MapShapes`, and that the second deduplicates while the first does not. That reading of the
+headers is correct. This probe asks the three things the headers cannot answer:
+
+1. **Do the counts actually diverge, and on what geometry?** A construction nobody writes is not a
+   defect worth changing an API over.
+2. **When they diverge, which occurrence does the map keep, and is anything lost beyond the count?**
+3. **Is the map path's order the explorer's order**, so that one implementation could serve both
+   without renumbering anyone's indices?
+
+No fixture files needed: every case builds its geometry from a primitive.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/502-subshape-traversal-dedup/occt_502_traversal_dedup.mm -o /tmp/occt_502
+/tmp/occt_502
+```
+
+## What it does
+
+Thirteen fixtures, each walked both ways for SOLID, SHELL, FACE, WIRE, EDGE and VERTEX. For every
+divergence it reports which occurrence was dropped and which surviving entry absorbed it, with
+`IsSame`'s three components (TShape, location, orientation) broken out, so "deduplicated" is
+attributed to a specific bit rather than assumed. It also checks whether the map's sequence is a
+prefix-preserving subsequence of the explorer's, and probes the argument domain of the generic
+type+index API (raw type values `0`, `1`, `8`, `9`, `-1`).
+
+The fixtures are grouped: shapes with no sharing (primitives, a hollow solid, two distinct bodies);
+the same sub-shape reachable twice (one shape compounded with itself, two placements of one body,
+a reversed copy, #502's own reused-shell case, one wire in two faces); sharing that arises from
+ordinary modelling rather than hand-built topology (a sewn stack, a compsolid, a folded shell).
+
+## Result
+
+**The divergence is real, and it is not the shape #502 implies.**
+
+- **For EDGE and VERTEX it is universal, not exceptional.** A plain 10mm box: 24 edge occurrences
+  over 12 edges, 48 vertex occurrences over 8 vertices. Every edge is visited once per adjacent
+  face. Every drop is attributed to orientation alone (`sameTShape=1 sameLocation=1
+  sameOrientation=0`), which is exactly what `IsSame` is documented to ignore.
+
+- **For SOLID, SHELL and WIRE, the three types the explorer-backed accessors covered, the two
+  agree on every ordinary shape**: box, sphere, cylinder, a hollow solid's two shells, a compound of
+  two distinct bodies, **two placements of one body** (2 vs 2, since `IsSame` compares the location, so
+  instancing survives deduplication), a sewn stack, a compsolid. They diverge exactly when one
+  sub-shape is reachable from two parents:
+
+  | fixture | explorer | map |
+  |---|---|---|
+  | `compound(box, THE SAME box)` | 2 solids | 1 |
+  | `compound(box, box.Reversed())` | 2 solids | 1 |
+  | `compound(solidFromShells(sh), solidFromShells(THE SAME sh))` | 2 shells | 1 (solids stay 2) |
+  | `compound(face(w), otherFace(THE SAME w))` | 2 wires | 1 |
+  | `shell(face, face.Reversed())` | 2 faces / 2 wires | 1 / 1 |
+
+- **Order is preserved in all thirteen fixtures, for all six types** (`order=same`). Reading
+  `TopExp.cxx:34-45` explains why it must be: the three-argument `TopExp::MapShapes` is *literally*
+  a `TopExp_Explorer` walk piped into the map. The two are not independent primitives: the
+  deduplicated sequence is the explorer's sequence with later repeats removed. That is what makes
+  one shared implementation possible with no index moving.
+
+- **The argument domain is benign.** Raw type `8` (`TopAbs_SHAPE`), `9` and `-1` all answer 0 on
+  both paths without throwing, so `ShapeType.unknown` (raw `-1`) was never crashing, but it was
+  reaching `static_cast<TopAbs_ShapeEnum>(-1)`, a value the enum has no name for. The shared helper
+  now range-checks instead, which keeps the same answer without the cast.
+
+- **A shape is its own sub-shape** when it is of the requested type, on both paths: a solid asked
+  for SOLID answers 1, a shell asked for SHELL answers 1. Neither path invents a COMPOUND for a box.
+
+## What was done with it
+
+Deduplicated is the answer this API already gave everywhere it mattered (`edgeCount` reported 12 for
+a box, not 24), so that is the answer all of it gives now. `occtMapSubShapes` in
+`OCCTBridge_Internal.h` is the one enumeration; the six `TopExp_Explorer` entry points behind
+`solids`/`shells`/`wires` are gone, as is `OCCTShapeGetEdgeCount`, an explorer count with no caller
+that disagreed with `OCCTShapeGetTotalEdgeCount`. Cross-checks live in
+`Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift`.
+
+Not an upstream defect (both OCCT primitives behave as documented), so nothing to file or patch.
+`Shape.faces()` is still an explorer walk and is filed separately as #541.

--- a/Scripts/repro/502-subshape-traversal-dedup/occt_502_traversal_dedup.mm
+++ b/Scripts/repro/502-subshape-traversal-dedup/occt_502_traversal_dedup.mm
@@ -1,0 +1,286 @@
+// #502 ground truth: TopExp_Explorer vs TopExp::MapShapes as sub-shape enumerators.
+//
+// The bridge enumerates sub-shapes two ways. OCCTShapeGetSolids/Shells/Wires drive a bare
+// TopExp_Explorer; OCCTShapeGetSubShapeCount/ByTypeIndex build a TopTools_IndexedMapOfShape
+// through TopExp::MapShapes. #502 asserts the two disagree because the map deduplicates.
+//
+// This probe asks three things the headers alone cannot answer:
+//
+//   1. Do the counts actually diverge, and on what geometry? A construction nobody writes is
+//      not a defect worth changing an API over.
+//   2. When they diverge, WHICH occurrence does the map keep, and is anything lost beyond
+//      the count (orientation, location)?
+//   3. Is the map path's order the explorer's order, so that one implementation could serve
+//      both without renumbering anyone's indices?
+//
+// No fixture files: every case builds its geometry from a primitive.
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <BRep_Builder.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_CompSolid.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Solid.hxx>
+#include <TopAbs.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Trsf.hxx>
+#include <gp_Vec.hxx>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// The two enumerators, transcribed from the bridge.
+// ---------------------------------------------------------------------------
+
+// OCCTShapeGetSolidCount / GetSolids / GetShellCount / GetShells / GetWireCount / GetWires
+static std::vector<TopoDS_Shape> explorerWalk(const TopoDS_Shape& s, TopAbs_ShapeEnum t) {
+    std::vector<TopoDS_Shape> out;
+    for (TopExp_Explorer ex(s, t); ex.More(); ex.Next()) out.push_back(ex.Current());
+    return out;
+}
+
+// OCCTShapeGetSubShapeCount / GetSubShapeByTypeIndex
+static std::vector<TopoDS_Shape> mapWalk(const TopoDS_Shape& s, TopAbs_ShapeEnum t) {
+    TopTools_IndexedMapOfShape m;
+    TopExp::MapShapes(s, t, m);
+    std::vector<TopoDS_Shape> out;
+    for (int i = 1; i <= m.Extent(); ++i) out.push_back(m(i));
+    return out;
+}
+
+static const char* typeName(TopAbs_ShapeEnum t) {
+    switch (t) {
+        case TopAbs_COMPOUND:  return "COMPOUND";
+        case TopAbs_COMPSOLID: return "COMPSOLID";
+        case TopAbs_SOLID:     return "SOLID";
+        case TopAbs_SHELL:     return "SHELL";
+        case TopAbs_FACE:      return "FACE";
+        case TopAbs_WIRE:      return "WIRE";
+        case TopAbs_EDGE:      return "EDGE";
+        case TopAbs_VERTEX:    return "VERTEX";
+        default:               return "SHAPE";
+    }
+}
+
+static const char* oriName(TopAbs_Orientation o) {
+    switch (o) {
+        case TopAbs_FORWARD:  return "FWD";
+        case TopAbs_REVERSED: return "REV";
+        case TopAbs_INTERNAL: return "INT";
+        default:              return "EXT";
+    }
+}
+
+// What the map dropped, and why it was allowed to: IsSame ignores orientation, IsEqual does not.
+static void reportDrops(const std::vector<TopoDS_Shape>& exp, const std::vector<TopoDS_Shape>& map) {
+    for (size_t i = 0; i < exp.size(); ++i) {
+        bool kept = false;
+        for (const TopoDS_Shape& k : map) {
+            if (k.IsEqual(exp[i])) { kept = true; break; }
+        }
+        if (kept) continue;
+        // Find the occurrence that absorbed it.
+        for (size_t j = 0; j < map.size(); ++j) {
+            if (!map[j].IsSame(exp[i])) continue;
+            printf("      dropped occurrence #%zu (%s) -> collapsed into index %zu (%s); "
+                   "sameTShape=1 sameLocation=%d sameOrientation=%d\n",
+                   i, oriName(exp[i].Orientation()), j, oriName(map[j].Orientation()),
+                   map[j].Location().IsEqual(exp[i].Location()) ? 1 : 0,
+                   map[j].Orientation() == exp[i].Orientation() ? 1 : 0);
+            break;
+        }
+    }
+}
+
+static void compare(const char* fixture, const TopoDS_Shape& s,
+                    const std::vector<TopAbs_ShapeEnum>& types) {
+    printf("  %s\n", fixture);
+    for (TopAbs_ShapeEnum t : types) {
+        std::vector<TopoDS_Shape> exp = explorerWalk(s, t);
+        std::vector<TopoDS_Shape> map = mapWalk(s, t);
+
+        // Is the map a prefix-preserving subsequence of the explorer walk? If it is, one
+        // traversal can serve both and no existing index moves.
+        bool orderPreserved = true;
+        size_t k = 0;
+        for (size_t i = 0; i < exp.size() && k < map.size(); ++i) {
+            if (map[k].IsEqual(exp[i])) ++k;
+        }
+        if (k != map.size()) orderPreserved = false;
+
+        printf("    %-9s explorer=%-3zu map=%-3zu %s  order=%s\n",
+               typeName(t), exp.size(), map.size(),
+               exp.size() == map.size() ? "agree " : "DIVERGE",
+               orderPreserved ? "same" : "RENUMBERED");
+        if (exp.size() != map.size()) reportDrops(exp, map);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+static TopoDS_Shape compoundOf(const std::vector<TopoDS_Shape>& members) {
+    TopoDS_Compound c;
+    BRep_Builder b;
+    b.MakeCompound(c);
+    for (const TopoDS_Shape& m : members) b.Add(c, m);
+    return c;
+}
+
+static TopoDS_Shape planarFace(double z, double side) {
+    BRepBuilderAPI_MakePolygon poly(gp_Pnt(0, 0, z), gp_Pnt(side, 0, z),
+                                    gp_Pnt(side, side, z), gp_Pnt(0, side, z), true);
+    return BRepBuilderAPI_MakeFace(poly.Wire()).Face();
+}
+
+int main() {
+    const std::vector<TopAbs_ShapeEnum> all = {TopAbs_SOLID, TopAbs_SHELL, TopAbs_FACE,
+                                               TopAbs_WIRE, TopAbs_EDGE, TopAbs_VERTEX};
+
+    printf("=== 1. Shapes with no sharing: the two paths must agree ===\n");
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+    compare("box(10,10,10)", box, all);
+    compare("sphere(r=5)", BRepPrimAPI_MakeSphere(5.0).Shape(), all);
+    compare("cylinder(r=3,h=8)", BRepPrimAPI_MakeCylinder(3.0, 8.0).Shape(), all);
+
+    // A hollow solid: two shells, one boundary + one cavity. Real geometry, real multi-shell.
+    TopoDS_Shape cavity = BRepPrimAPI_MakeBox(gp_Pnt(3, 3, 3), 4.0, 4.0, 4.0).Shape();
+    TopoDS_Shape hollow = BRepAlgoAPI_Cut(box, cavity).Shape();
+    compare("box minus inner box (hollow, 2 shells)", hollow, all);
+
+    // Two bodies far apart: distinct TShapes throughout.
+    TopoDS_Shape farBox = BRepPrimAPI_MakeBox(gp_Pnt(50, 0, 0), 10.0, 10.0, 10.0).Shape();
+    compare("compound(box, distinct box)", compoundOf({box, farBox}), all);
+
+    printf("\n=== 2. The same sub-shape reachable twice ===\n");
+
+    // (a) The identical solid added to one compound twice. Shape.compound([s, s]).
+    compare("compound(box, THE SAME box)", compoundOf({box, box}), all);
+
+    // (b) Two instances of one body at different locations (assembly instancing).
+    gp_Trsf move;
+    move.SetTranslation(gp_Vec(50, 0, 0));
+    compare("compound(box, box.Moved(+50x))", compoundOf({box, box.Moved(TopLoc_Location(move))}), all);
+
+    // (c) Same body, opposite orientation: differs only in a bit IsSame ignores.
+    compare("compound(box, box.Reversed())", compoundOf({box, box.Reversed()}), all);
+
+    // (d) The issue's own case: one shell handle reused across two solid constructions,
+    //     then both solids put in one compound (Issue442FixSolidMultiBodyTests pattern).
+    {
+        TopoDS_Shell shell;
+        for (TopExp_Explorer ex(box, TopAbs_SHELL); ex.More(); ex.Next()) {
+            shell = TopoDS::Shell(ex.Current());
+            break;
+        }
+        BRep_Builder b;
+        TopoDS_Solid s1, s2;
+        b.MakeSolid(s1);
+        b.Add(s1, shell);
+        b.MakeSolid(s2);
+        b.Add(s2, shell);  // the same shell, in a second solid
+        compare("compound(solidFromShells(sh), solidFromShells(THE SAME sh))",
+                compoundOf({s1, s2}), all);
+    }
+
+    // (e) One wire used to build two different faces: the WIRE case specifically.
+    {
+        BRepBuilderAPI_MakePolygon poly(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0),
+                                        gp_Pnt(10, 10, 0), gp_Pnt(0, 10, 0), true);
+        TopoDS_Wire w = poly.Wire();
+        TopoDS_Face f1 = BRepBuilderAPI_MakeFace(w).Face();
+        TopoDS_Face f2 = BRepBuilderAPI_MakeFace(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), w).Face();
+        compare("compound(face(w), otherFace(THE SAME w))", compoundOf({f1, f2}), all);
+    }
+
+    printf("\n=== 3. Sharing that arises from ordinary modelling, not hand-built topology ===\n");
+
+    // Two boxes sewn along a common plane: the shared face/edges/vertices are one TShape
+    // reachable from both sides.
+    {
+        TopoDS_Shape lower = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 0), 10.0, 10.0, 5.0).Shape();
+        TopoDS_Shape upper = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 5), 10.0, 10.0, 5.0).Shape();
+        BRepBuilderAPI_Sewing sewing(1e-6);
+        sewing.Add(lower);
+        sewing.Add(upper);
+        sewing.Perform();
+        compare("sewn(box, stacked box)", sewing.SewedShape(), all);
+    }
+
+    // A compsolid of two solids glued on a shared face.
+    {
+        TopoDS_Shape lower = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 0), 10.0, 10.0, 5.0).Shape();
+        TopoDS_Shape upper = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 5), 10.0, 10.0, 5.0).Shape();
+        TopoDS_CompSolid cs;
+        BRep_Builder b;
+        b.MakeCompSolid(cs);
+        for (TopExp_Explorer ex(lower, TopAbs_SOLID); ex.More(); ex.Next()) b.Add(cs, ex.Current());
+        for (TopExp_Explorer ex(upper, TopAbs_SOLID); ex.More(); ex.Next()) b.Add(cs, ex.Current());
+        compare("compsolid(lower, upper)", cs, all);
+    }
+
+    // A shell whose two faces share a wire? They cannot: a wire belongs to one face. But a
+    // face and its own reversed copy in one shell CAN, and that is what a self-folded sheet
+    // looks like after a bad sew.
+    {
+        TopoDS_Face f = TopoDS::Face(planarFace(0.0, 10.0));
+        TopoDS_Shell sh;
+        BRep_Builder b;
+        b.MakeShell(sh);
+        b.Add(sh, f);
+        b.Add(sh, f.Reversed());
+        compare("shell(face, face.Reversed())", sh, all);
+    }
+
+    printf("\n=== 4. Argument-domain edges of the generic type+index API ===\n");
+    // ShapeType has a `.unknown = -1` case and a `.compound = 0` case, both reachable from
+    // Swift as subShapeCount(ofType:). TopExp_Explorer's header says the type to find
+    // "cannot be SHAPE" (= 8). What do the paths do with each?
+    {
+        TopoDS_Shape c = compoundOf({box, farBox});
+        for (int raw : {0, 1, 8, 9, -1}) {
+            TopAbs_ShapeEnum t = static_cast<TopAbs_ShapeEnum>(raw);
+            int expCount = -1, mapCount = -1;
+            std::string expErr, mapErr;
+            try { expCount = static_cast<int>(explorerWalk(c, t).size()); }
+            catch (const Standard_Failure& f) { expErr = f.GetMessageString() ? f.GetMessageString() : "Standard_Failure"; }
+            catch (...) { expErr = "unknown throw"; }
+            try { mapCount = static_cast<int>(mapWalk(c, t).size()); }
+            catch (const Standard_Failure& f) { mapErr = f.GetMessageString() ? f.GetMessageString() : "Standard_Failure"; }
+            catch (...) { mapErr = "unknown throw"; }
+            printf("    raw type %-3d (%-9s) explorer=%-3d %-24s map=%-3d %s\n",
+                   raw, typeName(t), expCount, expErr.empty() ? "" : ("threw: " + expErr).c_str(),
+                   mapCount, mapErr.empty() ? "" : ("threw: " + mapErr).c_str());
+        }
+    }
+
+    printf("\n=== 5. Does either path ever yield the shape itself? ===\n");
+    // Matters for solidCount on a bare solid, and for shellCount on a bare shell.
+    {
+        TopoDS_Shape solid;
+        for (TopExp_Explorer ex(box, TopAbs_SOLID); ex.More(); ex.Next()) { solid = ex.Current(); break; }
+        printf("    solid, asked for SOLID:  explorer=%zu map=%zu\n",
+               explorerWalk(solid, TopAbs_SOLID).size(), mapWalk(solid, TopAbs_SOLID).size());
+        TopoDS_Shape shell;
+        for (TopExp_Explorer ex(box, TopAbs_SHELL); ex.More(); ex.Next()) { shell = ex.Current(); break; }
+        printf("    shell, asked for SHELL:  explorer=%zu map=%zu\n",
+               explorerWalk(shell, TopAbs_SHELL).size(), mapWalk(shell, TopAbs_SHELL).size());
+        printf("    box,   asked for COMPOUND: explorer=%zu map=%zu\n",
+               explorerWalk(box, TopAbs_COMPOUND).size(), mapWalk(box, TopAbs_COMPOUND).size());
+    }
+
+    printf("\ndone\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1128,7 +1128,8 @@ void OCCTShapeGetBounds(OCCTShapeRef shape, double* minX, double* minY, double* 
 // MARK: - Slicing
 
 OCCTShapeRef OCCTShapeSliceAtZ(OCCTShapeRef shape, double z);
-int32_t OCCTShapeGetEdgeCount(OCCTShapeRef shape);
+// OCCTShapeGetEdgeCount is gone: it was a TopExp_Explorer occurrence count with no caller, and it
+// disagreed with OCCTShapeGetTotalEdgeCount (24 vs 12 on a plain box). Use that one. #502
 int32_t OCCTShapeGetEdgePoints(OCCTShapeRef shape, int32_t edgeIndex, double* outPoints, int32_t maxPoints);
 int32_t OCCTShapeGetContourPoints(OCCTShapeRef shape, double* outPoints, int32_t maxPoints);
 
@@ -5116,20 +5117,13 @@ void OCCTOrientedBoundingBoxCorners(const OCCTOrientedBoundingBox* result, doubl
 OCCTShapeRef OCCTShapeCopy(OCCTShapeRef shape, bool copyGeom, bool copyMesh);
 
 
-// MARK: - Sub-Shape Extraction (v0.38.0)
-
-/// Get the number of solid sub-shapes in a shape.
-int32_t OCCTShapeGetSolidCount(OCCTShapeRef shape);
-
-/// Get solid sub-shapes from a shape.
-/// @param shape The shape to explore
-/// @param outSolids Output array for solid shape references
-/// @param maxCount Maximum number of solids to return
-/// @return Number of solids actually returned
-int32_t OCCTShapeGetSolids(OCCTShapeRef shape, OCCTShapeRef* outSolids, int32_t maxCount);
-
-/// Get the number of shell sub-shapes in a shape.
-int32_t OCCTShapeGetShellCount(OCCTShapeRef shape);
+// MARK: - Outer / Inner Shells (v0.38.0)
+//
+// Solid, shell and wire sub-shapes are no longer extracted here: OCCTShapeGetSolidCount/GetSolids,
+// GetShellCount/GetShells and GetWireCount/GetWires each walked a bare TopExp_Explorer, which
+// counts occurrences rather than distinct sub-shapes and so disagreed with the generic
+// OCCTShapeGetSubShapeCount/GetSubShapes/GetSubShapeByTypeIndex below on any shape whose
+// sub-shape is reachable from two parents. Use the generic family with type 2/3/5. #502
 
 /// Outer shell of a solid (BRepClass3d::OuterShell); NULL if not a solid / no shell.
 /// A container (compound/compsolid) is accepted only when it holds exactly ONE solid — with two
@@ -5148,23 +5142,6 @@ int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_
 /// (pass outShells=NULL to query the count). Same single-solid rule as OCCTShapeOuterShell:
 /// 0 for a container holding two or more solids. #212, #439
 int32_t OCCTShapeInnerShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount);
-
-/// Get shell sub-shapes from a shape.
-/// @param shape The shape to explore
-/// @param outShells Output array for shell shape references
-/// @param maxCount Maximum number of shells to return
-/// @return Number of shells actually returned
-int32_t OCCTShapeGetShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount);
-
-/// Get the number of wire sub-shapes in a shape.
-int32_t OCCTShapeGetWireCount(OCCTShapeRef shape);
-
-/// Get wire sub-shapes from a shape.
-/// @param shape The shape to explore
-/// @param outWires Output array for wire shape references (wrapped as OCCTShapeRef)
-/// @param maxCount Maximum number of wires to return
-/// @return Number of wires actually returned
-int32_t OCCTShapeGetWires(OCCTShapeRef shape, OCCTShapeRef* outWires, int32_t maxCount);
 
 
 // MARK: - Fuse and Blend (v0.38.0)
@@ -5533,12 +5510,29 @@ bool OCCTAnalyzePointCloud(const double* coords, int32_t pointCount,
                             double tolerance, OCCTPointCloudGeometry* outResult);
 
 // MARK: - Sub-Shape Extraction (fixes #36)
+//
+// The bridge's ONE sub-shape enumeration, for every topological type. Each entry is a distinct
+// sub-shape (TopoDS_Shape::IsSame: same TShape and location, orientation ignored), in
+// TopExp_Explorer order; a sub-shape reachable from two parents appears once, at the position of
+// its first visit. A shape is its own sub-shape when it is of the requested type. The fixed-type
+// counts elsewhere in this header (OCCTShapeGetFaceCount, OCCTShapeGetTotalEdgeCount,
+// OCCTShapeGetVertexCount, OCCTShapeUniqueSubShapeCount and its edge/face/vertex convenience
+// forms) all read this same enumeration. #502
 
 /// Count sub-shapes of a given topological type
 /// @param shape The parent shape
-/// @param type TopAbs_ShapeEnum value (0=COMPOUND..7=VERTEX)
-/// @return Number of sub-shapes of that type
+/// @param type TopAbs_ShapeEnum value (0=COMPOUND..7=VERTEX); out of range counts 0
+/// @return Number of distinct sub-shapes of that type
 int32_t OCCTShapeGetSubShapeCount(OCCTShapeRef shape, int32_t type);
+
+/// Get sub-shapes of a given topological type, in enumeration order
+/// @param shape The parent shape
+/// @param type TopAbs_ShapeEnum value (0=COMPOUND..7=VERTEX)
+/// @param outSubShapes Output array, caller-allocated (size it with OCCTShapeGetSubShapeCount)
+/// @param maxCount Capacity of outSubShapes
+/// @return Number of sub-shapes actually written
+int32_t OCCTShapeGetSubShapes(OCCTShapeRef shape, int32_t type,
+                              OCCTShapeRef* outSubShapes, int32_t maxCount);
 
 /// Get a sub-shape by type and 0-based index
 /// @param shape The parent shape

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -837,4 +837,57 @@ inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface, do
     }
 }
 
+// === #502: one sub-shape enumeration ===
+//
+// "Give me this shape's sub-shapes of type T" was implemented twice, on two different OCCT
+// primitives that answer differently:
+//
+//   * OCCTShapeGetSolidCount/GetSolids, GetShellCount/GetShells, GetWireCount/GetWires drove a
+//     bare TopExp_Explorer, which yields one entry per *occurrence* in the topology tree.
+//   * OCCTShapeGetSubShapeCount/GetSubShapeByTypeIndex (and OCCTShapeUniqueSubShapeCount, and the
+//     fixed-type counts for faces, edges and vertices) built a TopTools_IndexedMapOfShape through
+//     TopExp::MapShapes, which keeps one entry per *distinct* sub-shape.
+//
+// The gap is not cosmetic and not rare. TopTools_ShapeMapHasher's equality is
+// TopoDS_Shape::IsSame (same TShape and same location, orientation ignored), so the map drops
+// every repeat visit. Measured on the pinned kernel (Scripts/repro/502-subshape-traversal-dedup/):
+// a plain 10mm box has 24 edge occurrences over 12 edges and 48 vertex occurrences over 8
+// vertices, because each edge is reached once per adjacent face. For SOLID/SHELL/WIRE the two
+// agreed on every ordinary shape tried (primitives, a hollow solid's two shells, two distinct
+// bodies, two placements of one body, a sewn stack, a compsolid) and diverged exactly when one
+// sub-shape is reachable from two parents: one Shape compounded with itself (2 solids vs 1), one
+// shell handed to two solidFromShells calls (2 shells vs 1, #502's own example), one wire used to
+// build two faces (2 wires vs 1), a face and its own reverse in one shell (2 faces vs 1).
+//
+// Deduplicated is the answer this API gives everywhere else (a box has 12 edges, not 24), so that
+// is the answer all of it gives now. What made the choice cheap is that the two primitives
+// are not independent: TopExp::MapShapes(S, T, M) is literally a TopExp_Explorer walk piped into
+// the map (TopExp.cxx:34-45), so the deduplicated sequence is the explorer's sequence with later
+// repeats removed. Order is preserved, no index moves, and one traversal serves both spellings.
+
+/// THE sub-shape enumeration. Fills `outMap` with `shape`'s sub-shapes of TopAbs type `type`,
+/// in TopExp_Explorer order, one entry per distinct sub-shape (`TopoDS_Shape::IsSame`: same
+/// TShape and location, orientation ignored). Returns the number of entries.
+///
+/// `type` is the raw TopAbs_ShapeEnum ordinal as it arrives from Swift (0=COMPOUND..7=VERTEX);
+/// anything outside that range yields 0 rather than being cast to an enum it has no value in.
+/// Note that a shape IS its own sub-shape when it is of the requested type: a solid asked for
+/// SOLID answers 1.
+inline int32_t occtMapSubShapes(const TopoDS_Shape& shape, int32_t type,
+                                TopTools_IndexedMapOfShape& outMap) {
+    if (type < TopAbs_COMPOUND || type > TopAbs_VERTEX) return 0;
+    TopExp::MapShapes(shape, static_cast<TopAbs_ShapeEnum>(type), outMap);
+    return outMap.Extent();
+}
+
+/// The single sub-shape at 0-based `index` in the enumeration above, or a null TopoDS_Shape when
+/// the index is negative or past the end. Callers that want the whole set should map once and
+/// read the map, rather than calling this in a loop.
+inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int32_t index) {
+    if (index < 0) return TopoDS_Shape();
+    TopTools_IndexedMapOfShape map;
+    if (index >= occtMapSubShapes(shape, type, map)) return TopoDS_Shape();
+    return map(index + 1);  // OCCT's indexed maps are 1-based
+}
+
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -10754,18 +10754,6 @@ OCCTShapeRef OCCTShapeSliceAtZ(OCCTShapeRef shape, double z) {
     }
 }
 
-int32_t OCCTShapeGetEdgeCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
-
-    int32_t count = 0;
-    TopExp_Explorer explorer(shape->shape, TopAbs_EDGE);
-    while (explorer.More()) {
-        count++;
-        explorer.Next();
-    }
-    return count;
-}
-
 int32_t OCCTShapeGetEdgePoints(OCCTShapeRef shape, int32_t edgeIndex, double* outPoints, int32_t maxPoints) {
     if (!shape || !outPoints || maxPoints < 2 || edgeIndex < 0) return 0;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1861,32 +1861,22 @@ bool OCCTShapeIntersects(OCCTShapeRef shape1, OCCTShapeRef shape2, double tolera
     }
 }
 
-int32_t OCCTShapeGetVertexCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
+// The three vertex accessors below read the shared sub-shape enumeration (occtMapSubShapes,
+// OCCTBridge_Internal.h), so "a vertex" here means what it means everywhere else in the bridge:
+// one entry per distinct vertex, not one per occurrence in the topology tree (#502).
 
-    try {
-        // Use IndexedMapOfShape for unique vertices
-        TopTools_IndexedMapOfShape vertexMap;
-        TopExp::MapShapes(shape->shape, TopAbs_VERTEX, vertexMap);
-        return vertexMap.Extent();
-    } catch (...) {
-        return 0;
-    }
+int32_t OCCTShapeGetVertexCount(OCCTShapeRef shape) {
+    return OCCTShapeGetSubShapeCount(shape, TopAbs_VERTEX);
 }
 
 bool OCCTShapeGetVertexAt(OCCTShapeRef shape, int32_t index, double* outX, double* outY, double* outZ) {
-    if (!shape || !outX || !outY || !outZ || index < 0) return false;
+    if (!shape || !outX || !outY || !outZ) return false;
 
     try {
-        // Use IndexedMapOfShape for unique vertices
-        TopTools_IndexedMapOfShape vertexMap;
-        TopExp::MapShapes(shape->shape, TopAbs_VERTEX, vertexMap);
+        TopoDS_Shape vertex = occtSubShapeAt(shape->shape, TopAbs_VERTEX, index);
+        if (vertex.IsNull()) return false;
 
-        // IndexedMapOfShape uses 1-based indexing
-        if (index >= vertexMap.Extent()) return false;
-
-        TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(index + 1));
-        gp_Pnt point = BRep_Tool::Pnt(vertex);
+        gp_Pnt point = BRep_Tool::Pnt(TopoDS::Vertex(vertex));
         *outX = point.X();
         *outY = point.Y();
         *outZ = point.Z();
@@ -1900,15 +1890,10 @@ int32_t OCCTShapeGetVertices(OCCTShapeRef shape, double* outVertices) {
     if (!shape || !outVertices) return 0;
 
     try {
-        // Use IndexedMapOfShape for unique vertices
         TopTools_IndexedMapOfShape vertexMap;
-        TopExp::MapShapes(shape->shape, TopAbs_VERTEX, vertexMap);
-
-        int32_t count = vertexMap.Extent();
+        int32_t count = occtMapSubShapes(shape->shape, TopAbs_VERTEX, vertexMap);
         for (int32_t i = 0; i < count; i++) {
-            // IndexedMapOfShape uses 1-based indexing
-            TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(i + 1));
-            gp_Pnt point = BRep_Tool::Pnt(vertex);
+            gp_Pnt point = BRep_Tool::Pnt(TopoDS::Vertex(vertexMap(i + 1)));  // 1-based
 
             outVertices[i * 3] = point.X();
             outVertices[i * 3 + 1] = point.Y();

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -543,63 +543,7 @@ OCCTShapeRef OCCTShapeCopy(OCCTShapeRef shape, bool copyGeom, bool copyMesh) {
     }
 }
 
-// MARK: - Sub-Shape Extraction (v0.38.0)
-
-#include <TopExp_Explorer.hxx>
-
-int32_t OCCTShapeGetSolidCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More(); exp.Next()) {
-        count++;
-    }
-    return count;
-}
-
-int32_t OCCTShapeGetSolids(OCCTShapeRef shape, OCCTShapeRef* outSolids, int32_t maxCount) {
-    if (!shape || !outSolids || maxCount <= 0) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More() && count < maxCount; exp.Next()) {
-        outSolids[count++] = new OCCTShape(exp.Current());
-    }
-    return count;
-}
-
-int32_t OCCTShapeGetShellCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_SHELL); exp.More(); exp.Next()) {
-        count++;
-    }
-    return count;
-}
-
-int32_t OCCTShapeGetShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount) {
-    if (!shape || !outShells || maxCount <= 0) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_SHELL); exp.More() && count < maxCount; exp.Next()) {
-        outShells[count++] = new OCCTShape(exp.Current());
-    }
-    return count;
-}
-
-int32_t OCCTShapeGetWireCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_WIRE); exp.More(); exp.Next()) {
-        count++;
-    }
-    return count;
-}
-
-int32_t OCCTShapeGetWires(OCCTShapeRef shape, OCCTShapeRef* outWires, int32_t maxCount) {
-    if (!shape || !outWires || maxCount <= 0) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_WIRE); exp.More() && count < maxCount; exp.Next()) {
-        outWires[count++] = new OCCTShape(exp.Current());
-    }
-    return count;
-}
+#include <TopExp_Explorer.hxx>   // still used by the shell-classification and traversal helpers below
 
 // MARK: - Memory Management
 
@@ -997,25 +941,42 @@ bool OCCTShapeFindPlane(OCCTShapeRef shape, double tolerance,
     }
 }
 // MARK: - Sub-Shape Extraction (fixes #36)
+//
+// The only sub-shape enumeration in the bridge; see occtMapSubShapes in OCCTBridge_Internal.h for
+// what it counts and why the TopExp_Explorer spellings that used to sit alongside it are gone (#502).
 
 int32_t OCCTShapeGetSubShapeCount(OCCTShapeRef shape, int32_t type) {
     if (!shape) return 0;
     try {
         TopTools_IndexedMapOfShape map;
-        TopExp::MapShapes(shape->shape, static_cast<TopAbs_ShapeEnum>(type), map);
-        return map.Extent();
+        return occtMapSubShapes(shape->shape, type, map);
+    } catch (...) {
+        return 0;
+    }
+}
+
+int32_t OCCTShapeGetSubShapes(OCCTShapeRef shape, int32_t type,
+                              OCCTShapeRef* outSubShapes, int32_t maxCount) {
+    if (!shape || !outSubShapes || maxCount <= 0) return 0;
+    try {
+        TopTools_IndexedMapOfShape map;
+        int32_t total = occtMapSubShapes(shape->shape, type, map);
+        int32_t count = total < maxCount ? total : maxCount;
+        for (int32_t i = 0; i < count; i++) {
+            outSubShapes[i] = new OCCTShape(map(i + 1));  // OCCT's indexed maps are 1-based
+        }
+        return count;
     } catch (...) {
         return 0;
     }
 }
 
 OCCTShapeRef OCCTShapeGetSubShapeByTypeIndex(OCCTShapeRef shape, int32_t type, int32_t index) {
-    if (!shape || index < 0) return nullptr;
+    if (!shape) return nullptr;
     try {
-        TopTools_IndexedMapOfShape map;
-        TopExp::MapShapes(shape->shape, static_cast<TopAbs_ShapeEnum>(type), map);
-        if (index >= map.Extent()) return nullptr;
-        return new OCCTShape(map(index + 1)); // OCCT uses 1-based indexing
+        TopoDS_Shape sub = occtSubShapeAt(shape->shape, type, index);
+        if (sub.IsNull()) return nullptr;
+        return new OCCTShape(sub);
     } catch (...) {
         return nullptr;
     }
@@ -3095,13 +3056,10 @@ bool OCCTShapeIsClosed(OCCTShapeRef shape) {
 
 #include <TopTools_IndexedMapOfShape.hxx>
 
+// A second spelling of OCCTShapeGetSubShapeCount, kept for its Swift callers; the count itself is
+// computed in exactly one place (#502).
 int32_t OCCTShapeUniqueSubShapeCount(OCCTShapeRef shape, int32_t type) {
-    if (!shape) return 0;
-    try {
-        TopTools_IndexedMapOfShape map;
-        TopExp::MapShapes(shape->shape, (TopAbs_ShapeEnum)type, map);
-        return (int32_t)map.Extent();
-    } catch (...) { return 0; }
+    return OCCTShapeGetSubShapeCount(shape, type);
 }
 // --- Convenience unique counts ---
 
@@ -4218,28 +4176,16 @@ OCCTShapeRef OCCTShapeFromEdge(OCCTEdgeRef edgeRef) {
 // MARK: - Face Index Access (Issue #13)
 
 int32_t OCCTShapeGetFaceCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    
-    try {
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-        return faceMap.Extent();
-    } catch (...) {
-        return 0;
-    }
+    return OCCTShapeGetSubShapeCount(shape, TopAbs_FACE);
 }
 
 OCCTFaceRef OCCTShapeGetFaceAtIndex(OCCTShapeRef shape, int32_t index) {
-    if (!shape || index < 0) return nullptr;
-    
+    if (!shape) return nullptr;
+
     try {
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-        
-        if (index >= faceMap.Extent()) return nullptr;
-        
-        TopoDS_Face face = TopoDS::Face(faceMap(index + 1));  // OCCT is 1-based
-        return new OCCTFace(face);
+        TopoDS_Shape face = occtSubShapeAt(shape->shape, TopAbs_FACE, index);
+        if (face.IsNull()) return nullptr;
+        return new OCCTFace(TopoDS::Face(face));
     } catch (...) {
         return nullptr;
     }
@@ -4248,28 +4194,16 @@ OCCTFaceRef OCCTShapeGetFaceAtIndex(OCCTShapeRef shape, int32_t index) {
 // MARK: - Edge Access (Issue #14)
 
 int32_t OCCTShapeGetTotalEdgeCount(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    
-    try {
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-        return edgeMap.Extent();
-    } catch (...) {
-        return 0;
-    }
+    return OCCTShapeGetSubShapeCount(shape, TopAbs_EDGE);
 }
 
 OCCTEdgeRef OCCTShapeGetEdgeAtIndex(OCCTShapeRef shape, int32_t index) {
-    if (!shape || index < 0) return nullptr;
-    
+    if (!shape) return nullptr;
+
     try {
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-        
-        if (index >= edgeMap.Extent()) return nullptr;
-        
-        TopoDS_Edge edge = TopoDS::Edge(edgeMap(index + 1));  // OCCT is 1-based
-        return new OCCTEdge(edge);
+        TopoDS_Shape edge = occtSubShapeAt(shape->shape, TopAbs_EDGE, index);
+        if (edge.IsNull()) return nullptr;
+        return new OCCTEdge(TopoDS::Edge(edge));
     } catch (...) {
         return nullptr;
     }

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -12812,19 +12812,34 @@ extension Shape {
 }
 
 // --- Unique sub-shape counts ---
+//
+// Older spellings of the counts on `subShapeCount(ofType:)`, kept because they are public. The
+// "unique" in the name is not a distinction: every sub-shape count in this API reads the one
+// deduplicated enumeration, so these agree with `edgeCount`, `faceCount`, `vertexCount` and
+// `subShapeCount(ofType:)` by construction rather than by coincidence. (#502)
 
 extension Shape {
 
-    /// Number of unique edges in this shape.
+    /// Number of unique edges in this shape. Same value as ``edgeCount``.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.uniqueEdgeCount == box.edgeCount)   // true, 12 either way
+    /// ```
     public var uniqueEdgeCount: Int { Int(OCCTShapeUniqueEdgeCount(handle)) }
 
-    /// Number of unique faces in this shape.
+    /// Number of unique faces in this shape. Same value as ``faceCount``.
     public var uniqueFaceCount: Int { Int(OCCTShapeUniqueFaceCount(handle)) }
 
-    /// Number of unique vertices in this shape.
+    /// Number of unique vertices in this shape. Same value as ``vertexCount``.
     public var uniqueVertexCount: Int { Int(OCCTShapeUniqueVertexCount(handle)) }
 
-    /// Count unique sub-shapes of a specific type.
+    /// Count unique sub-shapes of a specific type. Same value as ``subShapeCount(ofType:)``.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.uniqueSubShapeCount(ofType: .wire))   // 6
+    /// ```
     public func uniqueSubShapeCount(ofType type: ShapeType) -> Int {
         Int(OCCTShapeUniqueSubShapeCount(handle, Int32(type.rawValue)))
     }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2077,18 +2077,49 @@ public final class Shape: @unchecked Sendable {
 
     // MARK: - Sub-Shape Extraction
 
-    /// Get the number of sub-shapes of a given topological type.
+    /// The number of **distinct** sub-shapes of a given topological type.
+    ///
+    /// This is the one sub-shape enumeration: ``solids``, ``shells``, ``wires``, ``faceCount``,
+    /// ``edgeCount`` and ``vertexCount`` all read the same one, so their answers agree with this
+    /// one by construction (#502).
+    ///
+    /// "Distinct" is `TopExp::MapShapes` over `TopoDS_Shape::IsSame`: same underlying geometry
+    /// *and* same placement, orientation ignored. Two consequences worth knowing:
+    ///
+    /// - A sub-shape reachable from more than one parent counts **once**. A box's 12 edges are
+    ///   each shared by two faces, so the count is 12, not the 24 edge-in-face occurrences a raw
+    ///   `TopExp_Explorer` walk yields.
+    /// - Two *placements* of one body count **twice**, because the location is part of the
+    ///   comparison. Instanced assemblies are not collapsed.
+    ///
+    /// A shape is its own sub-shape when it is of the requested type, so a solid reports one solid.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.subShapeCount(ofType: .face))    // 6
+    /// print(box.subShapeCount(ofType: .edge))    // 12
+    /// print(box.subShapeCount(ofType: .vertex))  // 8
+    /// print(box.subShapeCount(ofType: .solid))   // 1, the box itself
+    ///
+    /// // One body compounded with itself is one solid; two placements of it are two.
+    /// print(Shape.compound([box, box])!.subShapeCount(ofType: .solid))                       // 1
+    /// print(Shape.compound([box, box.translated(by: SIMD3(50, 0, 0))!])!
+    ///     .subShapeCount(ofType: .solid))                                                    // 2
+    /// ```
     ///
     /// - Parameter type: The topological type to count (e.g., `.face`, `.edge`, `.vertex`)
-    /// - Returns: Number of sub-shapes of that type
+    /// - Returns: Number of distinct sub-shapes of that type; 0 for `.unknown`
     public func subShapeCount(ofType type: ShapeType) -> Int {
         Int(OCCTShapeGetSubShapeCount(handle, Int32(type.rawValue)))
     }
 
-    /// Get a sub-shape by type and 0-based index.
+    /// A sub-shape by type and 0-based index, in the order ``subShapes(ofType:)`` returns.
     ///
-    /// Uses `TopExp::MapShapes` to enumerate sub-shapes of the given type,
-    /// then returns the one at the specified index as a `Shape` handle.
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.subShape(type: .face, index: 0)?.shapeType ?? .unknown)  // Face
+    /// print(box.subShape(type: .face, index: 6) == nil)                  // true, only 6 faces
+    /// ```
     ///
     /// - Parameters:
     ///   - type: The topological type (e.g., `.face`, `.edge`, `.vertex`)
@@ -2101,13 +2132,26 @@ public final class Shape: @unchecked Sendable {
         return Shape(handle: ref)
     }
 
-    /// Get all sub-shapes of a given topological type.
+    /// All **distinct** sub-shapes of a given topological type, in enumeration order.
+    ///
+    /// One walk to size the buffer and one to fill it, so this is much cheaper than reading
+    /// ``subShape(type:index:)`` in a loop, which re-walks the shape once per element. See
+    /// ``subShapeCount(ofType:)`` for what "distinct" excludes.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.subShapes(ofType: .face).count)   // 6
+    /// print(box.subShapes(ofType: .edge).count)   // 12
+    /// ```
     ///
     /// - Parameter type: The topological type (e.g., `.face`, `.edge`, `.vertex`)
     /// - Returns: Array of sub-shapes
     public func subShapes(ofType type: ShapeType) -> [Shape] {
-        let count = subShapeCount(ofType: type)
-        return (0..<count).compactMap { subShape(type: type, index: $0) }
+        let count = Int32(subShapeCount(ofType: type))
+        guard count > 0 else { return [] }
+        var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
+        let written = OCCTShapeGetSubShapes(handle, Int32(type.rawValue), &handles, count)
+        return handles.prefix(Int(written)).compactMap { h in h.map { Shape(handle: $0) } }
     }
 
     // MARK: - Bounds
@@ -5790,21 +5834,42 @@ extension Shape {
 
 extension Shape {
     /// Number of solid sub-shapes.
-    public var solidCount: Int { Int(OCCTShapeGetSolidCount(handle)) }
+    ///
+    /// A named spelling of `subShapeCount(ofType: .solid)`, reading the same enumeration, so
+    /// "distinct solid" means what it does there: one body reachable from two parents counts once,
+    /// two *placements* of it count twice. (#502)
+    ///
+    /// ```swift
+    /// let a = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+    /// let b = Shape.box(origin: SIMD3(50, 0, 0), width: 10, height: 10, depth: 10)!
+    /// print(Shape.compound([a, b])!.solidCount)   // 2
+    /// print(a.solidCount)                         // 1, a solid is its own sub-shape
+    /// ```
+    public var solidCount: Int { subShapeCount(ofType: .solid) }
 
-    /// Extract all solid sub-shapes.
-    public var solids: [Shape] {
-        let count = OCCTShapeGetSolidCount(handle)
-        guard count > 0 else { return [] }
-        var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
-        let actual = OCCTShapeGetSolids(handle, &handles, count)
-        return handles.prefix(Int(actual)).compactMap { h in
-            h.map { Shape(handle: $0) }
-        }
-    }
+    /// Extract all solid sub-shapes, in enumeration order.
+    ///
+    /// ```swift
+    /// let part = Shape.compound([
+    ///     Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!,
+    ///     Shape.box(origin: SIMD3(50, 0, 0), width: 4, height: 4, depth: 4)!,
+    /// ])!
+    /// print(part.solids.count)                       // 2
+    /// print(part.solids.map(\.volume))               // [1000.0, 64.0]
+    /// ```
+    public var solids: [Shape] { subShapes(ofType: .solid) }
 
     /// Number of shell sub-shapes.
-    public var shellCount: Int { Int(OCCTShapeGetShellCount(handle)) }
+    ///
+    /// A named spelling of `subShapeCount(ofType: .shell)`. A shell reused by two solids (the
+    /// shape `solidFromShells` produces when handed the same shell twice) is one shell. (#502)
+    ///
+    /// ```swift
+    /// let hollow = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
+    ///     .subtracting(Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!)!
+    /// print(hollow.shellCount)   // 2, the outer boundary and the cavity
+    /// ```
+    public var shellCount: Int { subShapeCount(ofType: .shell) }
 
     /// The **outer shell** of this solid (`BRepClass3d::OuterShell`).
     ///
@@ -5878,30 +5943,37 @@ extension Shape {
         return handles.prefix(Int(actual)).compactMap { h in h.map { Shape(handle: $0) } }
     }
 
-    /// Extract all shell sub-shapes.
-    public var shells: [Shape] {
-        let count = OCCTShapeGetShellCount(handle)
-        guard count > 0 else { return [] }
-        var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
-        let actual = OCCTShapeGetShells(handle, &handles, count)
-        return handles.prefix(Int(actual)).compactMap { h in
-            h.map { Shape(handle: $0) }
-        }
-    }
+    /// Extract all shell sub-shapes, in enumeration order.
+    ///
+    /// ```swift
+    /// let hollow = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
+    ///     .subtracting(Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!)!
+    /// print(hollow.shells.count)   // 2
+    /// ```
+    ///
+    /// To tell the boundary from the cavities, use ``outerShell`` / ``innerShells`` instead;
+    /// this is the plain enumeration and puts no meaning on the order.
+    public var shells: [Shape] { subShapes(ofType: .shell) }
 
     /// Number of wire sub-shapes.
-    public var wireCount: Int { Int(OCCTShapeGetWireCount(handle)) }
+    ///
+    /// A named spelling of `subShapeCount(ofType: .wire)`. A wire used to build two faces counts
+    /// once, since it is one wire seen from two parents. (#502)
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 5, depth: 3)!
+    /// print(box.wireCount)   // 6, one boundary wire per face
+    /// ```
+    public var wireCount: Int { subShapeCount(ofType: .wire) }
 
-    /// Extract all wire sub-shapes.
-    public var wires: [Shape] {
-        let count = OCCTShapeGetWireCount(handle)
-        guard count > 0 else { return [] }
-        var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
-        let actual = OCCTShapeGetWires(handle, &handles, count)
-        return handles.prefix(Int(actual)).compactMap { h in
-            h.map { Shape(handle: $0) }
-        }
-    }
+    /// Extract all wire sub-shapes, in enumeration order.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 5, depth: 3)!
+    /// print(box.wires.count)                       // 6
+    /// print(box.wires.compactMap(Wire.init).count)  // 6, as typed Wire objects
+    /// ```
+    public var wires: [Shape] { subShapes(ofType: .wire) }
 }
 
 // MARK: - Fuse and Blend (v0.38.0)

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -278,7 +278,10 @@ struct Issue442FixSolidMultiBody {
             Issue.record("could not build the duplicated-shell compound")
             return
         }
-        #expect(duped.shells.count == 2)
+        // Two children, one shell: the compound holds the same shell twice, and the sub-shape
+        // enumeration counts distinct shells, not occurrences (#502).
+        #expect(duped.nbChildren == 2)
+        #expect(duped.shells.count == 1)
 
         guard let solid = duped.solidFromShellFixed() else {
             Issue.record("solidFromShellFixed returned nil for a duplicated shell")

--- a/Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift
+++ b/Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift
@@ -1,0 +1,231 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #502: `solids`/`shells`/`wires` walked a bare `TopExp_Explorer`, which yields one entry per
+// *occurrence* in the topology tree; `subShapes(ofType:)` walked `TopExp::MapShapes`, which
+// deduplicates by `TopoDS_Shape::IsSame` (same TShape + same location, orientation ignored).
+// Two answers to one question, and nothing anywhere compared them.
+//
+// These tests fix the answer at the deduplicated one, for every type and both spellings, and
+// pin the two properties that make that choice safe: instances at different locations survive,
+// and the enumeration order does not change.
+
+@Suite("Sub-shape traversal is one enumeration (#502)")
+struct Issue502SubShapeTraversalTests {
+
+    // MARK: - The two spellings agree on ordinary geometry
+
+    /// Nothing here shares a sub-shape between two parents, so this passed before #502 too.
+    /// It is the control: it says the fix did not move the answer for shapes anyone actually has.
+    @Test("Typed and generic spellings agree on primitives")
+    func typedAndGenericAgreeOnPrimitives() {
+        let fixtures: [(String, Shape)] = [
+            ("box", Shape.box(width: 10, height: 5, depth: 3)!),
+            ("sphere", Shape.sphere(radius: 5)!),
+            ("cylinder", Shape.cylinder(radius: 3, height: 8)!),
+        ]
+        for (name, shape) in fixtures {
+            #expect(shape.solidCount == shape.subShapeCount(ofType: .solid), "\(name) solids")
+            #expect(shape.shellCount == shape.subShapeCount(ofType: .shell), "\(name) shells")
+            #expect(shape.wireCount == shape.subShapeCount(ofType: .wire), "\(name) wires")
+            #expect(shape.solids.count == shape.solidCount, "\(name) solids array")
+            #expect(shape.shells.count == shape.shellCount, "\(name) shells array")
+            #expect(shape.wires.count == shape.wireCount, "\(name) wires array")
+        }
+    }
+
+    @Test("Typed and generic spellings agree on a hollow solid's two shells")
+    func typedAndGenericAgreeOnHollowSolid() {
+        // `box(origin:)` is corner-anchored, so the cavity is strictly inside the block and the
+        // cut leaves a second, inner shell. (`box(width:height:depth:)` is centred on the
+        // origin, where the same cavity would break the surface instead.)
+        let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
+        let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!
+        guard let hollow = block.subtracting(cavity) else {
+            Issue.record("cut failed")
+            return
+        }
+        #expect(hollow.shellCount == 2)
+        #expect(hollow.shellCount == hollow.subShapeCount(ofType: .shell))
+        #expect(hollow.shells.count == hollow.subShapes(ofType: .shell).count)
+    }
+
+    // MARK: - The same sub-shape reachable twice
+
+    /// The plainest form: one `Shape` handed to `compound` twice. The explorer walk reported two
+    /// solids for one body at one location; the map walk reported one. Now both report one.
+    @Test("A body compounded with itself counts once")
+    func bodyCompoundedWithItselfCountsOnce() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let doubled = Shape.compound([box, box]) else {
+            Issue.record("compound failed")
+            return
+        }
+        #expect(doubled.solidCount == 1)
+        #expect(doubled.solids.count == 1)
+        #expect(doubled.solidCount == doubled.subShapeCount(ofType: .solid))
+        #expect(doubled.shellCount == doubled.subShapeCount(ofType: .shell))
+        #expect(doubled.wireCount == doubled.subShapeCount(ofType: .wire))
+    }
+
+    /// #502's own example: one shell handle reused across two `solidFromShells` calls. The two
+    /// solids are distinct objects, so the solid count stays 2; it is the shell that is one
+    /// shell, seen from two parents.
+    @Test("A shell reused by two solids counts once, and the solids still count twice")
+    func shellReusedByTwoSolidsCountsOnce() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let shell = box.shells.first,
+              let s1 = Shape.solidFromShells([shell]),
+              let s2 = Shape.solidFromShells([shell]),
+              let both = Shape.compound([s1, s2]) else {
+            Issue.record("could not build two solids over one shell")
+            return
+        }
+        #expect(both.solidCount == 2)
+        #expect(both.shellCount == 1)
+        #expect(both.shellCount == both.subShapeCount(ofType: .shell))
+        #expect(both.shells.count == both.subShapes(ofType: .shell).count)
+    }
+
+    /// The wire case, which needs two faces built over one wire, since a face's wire is otherwise
+    /// never shared with a second face.
+    @Test("A wire reused by two faces counts once")
+    func wireReusedByTwoFacesCountsOnce() {
+        guard let wire = Wire.rectangle(width: 10, height: 10),
+              let planar = Shape.face(from: wire),
+              let onPlane = Shape.face(from: Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!,
+                                       boundary: wire),
+              let both = Shape.compound([planar, onPlane]) else {
+            Issue.record("could not build two faces over one wire")
+            return
+        }
+        #expect(both.subShapeCount(ofType: .face) == 2)
+        #expect(both.wireCount == 1)
+        #expect(both.wireCount == both.subShapeCount(ofType: .wire))
+        #expect(both.wires.count == both.subShapes(ofType: .wire).count)
+    }
+
+    // MARK: - What deduplication must NOT collapse
+
+    /// Deduplication is by `IsSame`, which compares the location as well as the underlying
+    /// geometry. Two placements of one body are therefore two solids, not one; without this,
+    /// the fix would silently break every assembly that instances a part.
+    @Test("Two placements of one body count twice")
+    func twoPlacementsOfOneBodyCountTwice() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let moved = box.translated(by: SIMD3(50, 0, 0)),
+              let assembly = Shape.compound([box, moved]) else {
+            Issue.record("compound failed")
+            return
+        }
+        #expect(assembly.solidCount == 2)
+        #expect(assembly.solids.count == 2)
+        #expect(assembly.subShapeCount(ofType: .solid) == 2)
+        #expect(assembly.shellCount == 2)
+        #expect(assembly.wireCount == 12)
+    }
+
+    /// Two genuinely different bodies, so nothing to collapse.
+    @Test("Two distinct bodies count twice")
+    func twoDistinctBodiesCountTwice() {
+        let a = Shape.box(width: 10, height: 10, depth: 10)!
+        let b = Shape.box(origin: SIMD3(50, 0, 0), width: 4, height: 4, depth: 4)!
+        guard let compound = Shape.compound([a, b]) else {
+            Issue.record("compound failed")
+            return
+        }
+        #expect(compound.solidCount == 2)
+        #expect(compound.solids.count == 2)
+        #expect(compound.shellCount == 2)
+        #expect(compound.wireCount == 12)
+    }
+
+    // MARK: - One enumeration, so one order
+
+    /// `TopExp::MapShapes` is an explorer walk piped into an indexed map, so the deduplicated
+    /// sequence is the explorer's sequence with later repeats removed. Both spellings must
+    /// therefore hand back the same sub-shapes in the same order, element by element.
+    @Test("Both spellings enumerate in the same order")
+    func bothSpellingsEnumerateInTheSameOrder() {
+        let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
+        let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!
+        guard let hollow = block.subtracting(cavity),
+              let assembly = Shape.compound([hollow, hollow.translated(by: SIMD3(40, 0, 0))!]) else {
+            Issue.record("fixture failed")
+            return
+        }
+        for type in [ShapeType.solid, .shell, .wire] {
+            let typed: [Shape]
+            switch type {
+            case .solid: typed = assembly.solids
+            case .shell: typed = assembly.shells
+            default:     typed = assembly.wires
+            }
+            let generic = assembly.subShapes(ofType: type)
+            #expect(typed.count == generic.count, "\(type) count")
+            guard typed.count == generic.count else { continue }
+            for (i, pair) in zip(typed, generic).enumerated() {
+                #expect(pair.0.isSame(as: pair.1), "\(type) index \(i) differs between spellings")
+            }
+        }
+    }
+
+    /// The indexed accessor reads out of the same enumeration as the array accessor.
+    @Test("Indexed and array access return the same sub-shape")
+    func indexedAndArrayAccessMatch() {
+        let hollow = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
+            .subtracting(Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!)!
+        let shells = hollow.shells
+        #expect(shells.count == 2)
+        for i in 0..<shells.count {
+            guard let indexed = hollow.subShape(type: .shell, index: i) else {
+                Issue.record("no shell at \(i)")
+                continue
+            }
+            #expect(indexed.isSame(as: shells[i]))
+        }
+        #expect(hollow.subShape(type: .shell, index: shells.count) == nil)
+        #expect(hollow.subShape(type: .shell, index: -1) == nil)
+    }
+
+    // MARK: - The rest of the API already deduplicated, and still does
+
+    /// `edgeCount` / `vertexCount` / `faceCount` were already map-backed. Stated here because it
+    /// is the reason #502 resolves toward deduplication rather than away from it: a box has 12
+    /// edges, not the 24 edge *occurrences* an explorer walk yields.
+    @Test("A box has 12 edges and 8 vertices under every spelling")
+    func boxEdgeAndVertexCountsAreDeduplicated() {
+        let box = Shape.box(width: 10, height: 5, depth: 3)!
+        #expect(box.edgeCount == 12)
+        #expect(box.subShapeCount(ofType: .edge) == 12)
+        #expect(box.vertexCount == 8)
+        #expect(box.subShapeCount(ofType: .vertex) == 8)
+        #expect(box.subShapeCount(ofType: .face) == 6)
+    }
+
+    /// An out-of-domain `ShapeType` raw value reaches `TopAbs_ShapeEnum` as a cast; it must
+    /// answer 0 rather than throw or crash.
+    @Test("Unknown shape type counts zero")
+    func unknownShapeTypeCountsZero() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        #expect(box.subShapeCount(ofType: .unknown) == 0)
+        #expect(box.subShapes(ofType: .unknown).isEmpty)
+        #expect(box.subShape(type: .unknown, index: 0) == nil)
+        #expect(box.subShapeCount(ofType: .compound) == 0)
+    }
+
+    /// A shape with none of the requested type, on both spellings.
+    @Test("A vertex has no solids, shells or wires")
+    func vertexHasNoSolidsShellsOrWires() {
+        let vertex = Shape.vertex(at: SIMD3(0, 0, 0))!
+        #expect(vertex.solidCount == 0)
+        #expect(vertex.solids.isEmpty)
+        #expect(vertex.shellCount == 0)
+        #expect(vertex.shells.isEmpty)
+        #expect(vertex.wireCount == 0)
+        #expect(vertex.wires.isEmpty)
+        #expect(vertex.subShapeCount(ofType: .solid) == 0)
+        #expect(vertex.subShapes(ofType: .wire).isEmpty)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -936,11 +936,23 @@ aliases the input.
 | `shape.copy(copyGeometry:copyMesh:)` | `BRepBuilderAPI_Copy` |
 
 #### Sub-Shape Extraction (v0.38.0)
+
+One enumeration behind all of these: `TopExp::MapShapes` into a `TopTools_IndexedMapOfShape`, in
+`TopExp_Explorer` order, one entry per **distinct** sub-shape (`TopoDS_Shape::IsSame`: same
+geometry *and* placement, orientation ignored). A sub-shape reachable from two parents appears
+once; two placements of one body appear twice. (#502)
+
 | Swift API | OCCT Class |
 |-----------|------------|
-| `shape.solids` / `shape.solidCount` | `TopExp_Explorer(TopAbs_SOLID)` |
-| `shape.shells` / `shape.shellCount` | `TopExp_Explorer(TopAbs_SHELL)` |
-| `shape.wires` / `shape.wireCount` | `TopExp_Explorer(TopAbs_WIRE)` |
+| `shape.subShapeCount(ofType:)` / `shape.uniqueSubShapeCount(ofType:)` | `TopExp::MapShapes` |
+| `shape.subShape(type:index:)` / `shape.subShapes(ofType:)` | `TopExp::MapShapes` |
+| `shape.solids` / `shape.solidCount` | `TopExp::MapShapes(TopAbs_SOLID)` |
+| `shape.shells` / `shape.shellCount` | `TopExp::MapShapes(TopAbs_SHELL)` |
+| `shape.wires` / `shape.wireCount` | `TopExp::MapShapes(TopAbs_WIRE)` |
+| `shape.faceCount` / `shape.face(at:)` | `TopExp::MapShapes(TopAbs_FACE)` |
+| `shape.edgeCount` / `shape.edge(at:)` / `shape.edges()` | `TopExp::MapShapes(TopAbs_EDGE)` |
+| `shape.vertexCount` / `shape.vertices()` | `TopExp::MapShapes(TopAbs_VERTEX)` |
+| `shape.faces()` | `TopExp_Explorer(TopAbs_FACE)`: occurrences, not distinct faces (#541) |
 
 #### Shell Decomposition (outer body vs. cavities)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -766,6 +766,47 @@ actually works: an edge carrying only a pcurve on a cylinder. Run against the un
 the default-value and cross-wrapper-agreement tests fail there, so they cover the defect rather
 than describing it.
 
+#### One sub-shape enumeration, not one per accessor (#502)
+
+`Shape.solids`/`solidCount`, `shells`/`shellCount` and `wires`/`wireCount` walked a bare
+`TopExp_Explorer`, which yields one entry per **occurrence** in the topology tree.
+`subShapes(ofType:)`/`subShapeCount(ofType:)`, along with `faceCount`, `edgeCount`, `vertexCount`,
+`uniqueSubShapeCount(ofType:)` and the `face(at:)`/`edge(at:)` indexed accessors, built a
+`TopTools_IndexedMapOfShape` through `TopExp::MapShapes`, which keeps one entry per **distinct**
+sub-shape. Two answers to one question, in two hand-written traversals, with no test anywhere
+comparing them.
+
+The two are not independent primitives: `TopExp::MapShapes(S, T, M)` *is* a `TopExp_Explorer` walk
+piped into the map (`TopExp.cxx:34-45`), so the deduplicated sequence is the explorer's sequence
+with later repeats removed: same order, no index moved. Every sub-shape accessor in the bridge now
+reads one enumeration (`occtMapSubShapes`), and the six `TopExp_Explorer` entry points behind the
+typed accessors are gone, along with a seventh (`OCCTShapeGetEdgeCount`) that had no caller and
+disagreed with `OCCTShapeGetTotalEdgeCount` two declarations away.
+
+**Behaviour change, in the deduplicating direction.** `solidCount`/`shellCount`/`wireCount` and
+`solids`/`shells`/`wires` now count distinct sub-shapes. Measured against the pinned kernel
+([`Scripts/repro/502-subshape-traversal-dedup/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/502-subshape-traversal-dedup)),
+the old and new answers are identical for every ordinary shape tried (the primitives, a hollow
+solid's two shells, two distinct bodies, two *placements* of one body, a sewn stack, a compsolid),
+and differ only where one sub-shape is reachable from two parents:
+
+| shape | before | after |
+|---|---|---|
+| `Shape.compound([box, box])` (the same `Shape` twice) | 2 solids | 1 solid |
+| the same shell handed to two `solidFromShells` calls | 2 shells | 1 shell |
+| one wire used to build two faces | 2 wires | 1 wire |
+| a face and its own reverse in one shell | 2 faces | 1 face |
+
+Deduplication is by `TopoDS_Shape::IsSame`, which compares the **location** as well as the
+geometry, so two placements of one body are still two solids and instanced assemblies are not
+collapsed. It ignores orientation, so a sub-shape embedded forward in one parent and reversed in
+another is one sub-shape.
+
+Two illustrations of why this is the answer the whole API should have been giving: a plain 10mm box
+has 24 edge *occurrences* over 12 edges and 48 vertex occurrences over 8 vertices, and `edgeCount`
+already reported 12; and `Shape.faces()` (still an explorer walk, see #541) can hand back a face
+`face(at:)` cannot address, because their indices came from different enumerations.
+
 ---
 
 ## Release History

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -515,21 +515,32 @@ public struct ImportResult: Sendable {
 
 ## Sub-Shape Extraction
 
+This is the one sub-shape enumeration in the API. `solids`/`shells`/`wires`, `faceCount`,
+`edgeCount`, `vertexCount`, `face(at:)`, `edge(at:)` and `uniqueSubShapeCount(ofType:)` all read it,
+so their answers agree with these by construction (#502). Each entry is a **distinct** sub-shape,
+meaning `TopoDS_Shape::IsSame`: same underlying geometry *and* same placement, orientation ignored.
+
 ### `subShapeCount(ofType:)`
 
-Returns the number of sub-shapes of a given topological type.
+Returns the number of distinct sub-shapes of a given topological type.
 
 ```swift
 public func subShapeCount(ofType type: ShapeType) -> Int
 ```
 
 - **Parameters:** `type` — the topological type to count (e.g. `.face`, `.edge`, `.vertex`).
-- **Returns:** Count of sub-shapes of that type.
+- **Returns:** Count of distinct sub-shapes of that type; `0` for `.unknown`.
 - **OCCT:** `TopExp::MapShapes` (via `OCCTShapeGetSubShapeCount`).
+- **Note:** A sub-shape reachable from more than one parent counts once: a box has 12 edges, not
+  the 24 edge-in-face occurrences a raw `TopExp_Explorer` walk yields. Two *placements* of one body
+  count twice, since the location is part of the comparison.
 - **Example:**
   ```swift
-  let box = Shape.box(width: 10, height: 10, depth: 10)
-  print(box.subShapeCount(ofType: .face))  // 6
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.subShapeCount(ofType: .face))    // 6
+  print(box.subShapeCount(ofType: .edge))    // 12
+  print(box.subShapeCount(ofType: .vertex))  // 8
+  print(box.subShapeCount(ofType: .solid))   // 1, the box itself
   ```
 
 ---
@@ -553,15 +564,22 @@ Uses `TopExp::MapShapes` to enumerate sub-shapes of the given type.
 
 ### `subShapes(ofType:)`
 
-Returns all sub-shapes of a given topological type as an array.
+Returns all distinct sub-shapes of a given topological type as an array, in enumeration order.
 
 ```swift
 public func subShapes(ofType type: ShapeType) -> [Shape]
 ```
 
 - **Parameters:** `type` — topological type.
-- **Returns:** Array of all sub-shapes of that type (may be empty).
-- **OCCT:** Calls `subShapeCount` + `subShape(type:index:)` iteratively.
+- **Returns:** Array of all distinct sub-shapes of that type (may be empty).
+- **OCCT:** `TopExp::MapShapes` (via `OCCTShapeGetSubShapes`): one walk to size the buffer and one
+  to fill it, rather than one per element as reading `subShape(type:index:)` in a loop would cost.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.subShapes(ofType: .face).count)  // 6
+  print(box.subShapes(ofType: .edge).count)  // 12
+  ```
 
 ---
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -15,36 +15,46 @@ This page covers the measurement, decomposition, healing, and local-operation AP
 
 ## Sub-Shape Extraction (v0.38.0)
 
+Every accessor in this section, plus `subShapeCount(ofType:)`, `subShapes(ofType:)`, `faceCount`,
+`edgeCount` and `vertexCount` elsewhere, reads **one** enumeration: `TopExp::MapShapes` into a
+`TopTools_IndexedMapOfShape`, in `TopExp_Explorer` order, one entry per **distinct** sub-shape.
+"Distinct" is `TopoDS_Shape::IsSame`: same underlying geometry *and* same placement, orientation
+ignored. So a sub-shape reachable from two parents is counted once, while two *placements* of one
+body are counted twice (instanced assemblies are not collapsed). A shape is its own sub-shape when
+it is of the requested type. (#502)
+
 ### `solidCount`
 
-Number of solid sub-shapes in this shape.
+Number of distinct solid sub-shapes in this shape.
 
 ```swift
 public var solidCount: Int { get }
 ```
 
-- **OCCT:** `BRep_Builder` / `TopExp_Explorer` (via `OCCTShapeGetSolidCount`).
+- **OCCT:** `TopExp::MapShapes` with `TopAbs_SOLID` (via `OCCTShapeGetSubShapeCount`).
 - **Example:**
   ```swift
-  let box = Shape.box(dx: 10, dy: 10, dz: 10)!
-  print(box.solidCount)  // 1
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.solidCount)                             // 1, a solid is its own sub-shape
+  print(Shape.compound([box, box])!.solidCount)     // 1, one body, listed twice
+  print(Shape.compound([box, box.translated(by: SIMD3(50, 0, 0))!])!.solidCount)  // 2
   ```
 
 ---
 
 ### `solids`
 
-Extract all solid sub-shapes.
+Extract all distinct solid sub-shapes, in enumeration order.
 
 ```swift
 public var solids: [Shape] { get }
 ```
 
 - **Returns:** Array of solid sub-shapes; empty if none.
-- **OCCT:** `TopExp_Explorer` with `TopAbs_SOLID`.
+- **OCCT:** `TopExp::MapShapes` with `TopAbs_SOLID`.
 - **Example:**
   ```swift
-  let compound = Shape.compound([box1, box2])
+  let compound = Shape.compound([box1, box2])!
   let all = compound.solids  // [box1, box2]
   ```
 
@@ -52,13 +62,19 @@ public var solids: [Shape] { get }
 
 ### `shellCount`
 
-Number of shell sub-shapes.
+Number of distinct shell sub-shapes. A shell reused by two solids counts once.
 
 ```swift
 public var shellCount: Int { get }
 ```
 
-- **OCCT:** `OCCTShapeGetShellCount`.
+- **OCCT:** `TopExp::MapShapes` with `TopAbs_SHELL`.
+- **Example:**
+  ```swift
+  let hollow = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
+      .subtracting(Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!)!
+  print(hollow.shellCount)  // 2, the outer boundary and the cavity
+  ```
 
 ---
 
@@ -143,33 +159,44 @@ Extract all shell sub-shapes.
 public var shells: [Shape] { get }
 ```
 
-- **Returns:** Array of all shell sub-shapes (inner and outer).
-- **OCCT:** `TopExp_Explorer` with `TopAbs_SHELL` (via `OCCTShapeGetShells`).
+- **Returns:** Array of all shell sub-shapes (inner and outer), in enumeration order.
+- **OCCT:** `TopExp::MapShapes` with `TopAbs_SHELL`. Use `outerShell` / `innerShells` to tell the
+  boundary from the cavities; this accessor puts no meaning on the order.
 
 ---
 
 ### `wireCount`
 
-Number of wire sub-shapes.
+Number of distinct wire sub-shapes. A wire used to build two faces counts once.
 
 ```swift
 public var wireCount: Int { get }
 ```
 
-- **OCCT:** `OCCTShapeGetWireCount`.
+- **OCCT:** `TopExp::MapShapes` with `TopAbs_WIRE`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 5, depth: 3)!
+  print(box.wireCount)  // 6, one boundary wire per face
+  ```
 
 ---
 
 ### `wires`
 
-Extract all wire sub-shapes.
+Extract all distinct wire sub-shapes, in enumeration order.
 
 ```swift
 public var wires: [Shape] { get }
 ```
 
 - **Returns:** Array of wire sub-shapes; empty if none.
-- **OCCT:** `TopExp_Explorer` with `TopAbs_WIRE` (via `OCCTShapeGetWires`).
+- **OCCT:** `TopExp::MapShapes` with `TopAbs_WIRE`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 5, depth: 3)!
+  print(box.wires.compactMap(Wire.init).count)  // 6, as typed Wire objects
+  ```
 
 ---
 


### PR DESCRIPTION
Closes #502. Pass 1b of the #381 / #377 duplication audit, so this targets `refactor/381-pass1b`, not `main`.

## What the issue reported, and what measurement added

#502's reading of the headers is correct: `OCCTShapeGetSolids`/`GetShells`/`GetWires` drive a bare `TopExp_Explorer` (one entry per **occurrence** in the topology tree) while `OCCTShapeGetSubShapeCount`/`GetSubShapeByTypeIndex` build a `TopTools_IndexedMapOfShape` through `TopExp::MapShapes` (one entry per **distinct** sub-shape, `TopoDS_Shape::IsSame`). Two answers to one question, two hand-written traversals, and no test anywhere comparing them.

A 13-fixture probe against the pinned kernel ([`Scripts/repro/502-subshape-traversal-dedup/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/502-subshape-traversal-dedup)) settled the three things the headers cannot:

**1. The divergence is universal for EDGE and VERTEX, not exceptional.** A plain 10mm box has 24 edge occurrences over 12 edges and 48 vertex occurrences over 8 vertices, because each edge is reached once per adjacent face. Every drop is attributed to orientation alone, which is the bit `IsSame` is documented to ignore. This is what decided the direction of the fix: `edgeCount` already reported 12, and 12 is the answer a caller means.

**2. For SOLID/SHELL/WIRE the exposure is narrower than the issue implies.** The two agree on every ordinary shape tried: box, sphere, cylinder, a hollow solid's two shells, a compound of two distinct bodies, **two placements of one body** (2 vs 2, since `IsSame` compares the location, so instancing survives deduplication), a sewn stack, a compsolid. They diverge exactly where one sub-shape is reachable from two parents:

| fixture | explorer | map |
|---|---|---|
| `compound(box, THE SAME box)` | 2 solids | 1 |
| `compound(box, box.Reversed())` | 2 solids | 1 |
| the same shell handed to two `solidFromShells` calls | 2 shells | 1 (solids stay 2) |
| one wire used to build two faces | 2 wires | 1 |
| a face and its own reverse in one shell | 2 faces / 2 wires | 1 / 1 |

**3. The two primitives are not independent, which is what makes the unification free.** `TopExp::MapShapes(S, T, M)` is *literally* a `TopExp_Explorer` walk piped into the map (`TopExp.cxx:34-45`), so the deduplicated sequence is the explorer's sequence with later repeats removed. Order preserved in all 13 fixtures for all 6 types, so one traversal serves both spellings and no existing index moves.

Also measured: the argument domain is benign. Raw type `8`, `9` and `-1` all answer 0 on both paths without throwing, so `ShapeType.unknown` was never crashing, but it was reaching `static_cast<TopAbs_ShapeEnum>(-1)`, a value the enum has no name for. The shared helper range-checks instead, same answer without the cast.

## The change

`occtMapSubShapes` and `occtSubShapeAt` in `OCCTBridge_Internal.h` are the one enumeration. Everything that counts or addresses a sub-shape by `TopAbs` type now reads them:

- **Deleted:** `OCCTShapeGetSolidCount`/`GetSolids`, `GetShellCount`/`GetShells`, `GetWireCount`/`GetWires`. The Swift `solidCount`/`solids`/`shellCount`/`shells`/`wireCount`/`wires` are unchanged as API and now delegate to `subShapeCount(ofType:)`/`subShapes(ofType:)`.
- **Also deleted:** `OCCTShapeGetEdgeCount` (`OCCTBridge_Modeling.mm`), an explorer occurrence count with no Swift caller that disagreed with `OCCTShapeGetTotalEdgeCount` (24 vs 12 on a box).
- **Rerouted, no behaviour change:** `OCCTShapeGetFaceCount`, `GetFaceAtIndex`, `GetTotalEdgeCount`, `GetEdgeAtIndex`, `GetVertexCount`, `GetVertexAt`, `GetVertices`, `UniqueSubShapeCount`. Each had its own copy of the same four lines.
- **Added:** `OCCTShapeGetSubShapes` (batch fill), so `subShapes(ofType:)` costs one walk to size plus one to fill rather than one walk per element.

`OCCTBridge` is not an SPM product, so the deleted C declarations are not consumer-visible; no ecosystem repo references them (checked).

## Behaviour change

`solidCount`/`shellCount`/`wireCount` and `solids`/`shells`/`wires` count distinct sub-shapes. Per the table above, the answer only moves where one sub-shape is reachable from two parents; deduplication is by `IsSame`, so two placements of one body are still two solids.

One existing test needed updating: `Issue442FixSolidMultiBodyTests.solidFromShellDeduplicates` asserted `duped.shells.count == 2` as its own *input* precondition (its actual subject, `solidFromShellFixed` collapsing to one body, passes unchanged). It now states both facts: two children, one distinct shell.

Not source-breaking, so no `SEMVER.md` exception is needed.

## Tests

`Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift`, 12 tests. Written and run **before** the fix: the 3 divergence tests failed (11 expectations) and the 9 controls passed, so they demonstrably catch the defect rather than describing the new code. They cover the cross-checks that were missing entirely, both directions of what deduplication must and must not collapse, element-by-element order equality between the two spellings, and the `.unknown` argument domain.

Full suite green: 4772 tests, 1339 suites.

## Follow-up filed

**#541:** `Shape.faces()` is still a `TopExp_Explorer` walk while `faceCount`/`face(at:)` are map-backed, so on a shape with a doubled face `faces()` returns 2 entries and hands out `Face.index` values `face(at:)` answers `nil` for. Left out of this PR because `Face.index` is used as an addressing token elsewhere (`edgesInFace(at:)`, selection remapping), so the traversal swap is one line and the audit of its consumers is not. The sibling edge family is already consistent, which is what makes the face one an outlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
