### PR TITLE
fix(#503): one pipe shell, and the sweep mode it was quietly discarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ OCCTSwift provides method-level coverage of all user-facing OCCT classes. Key ar
 
 | Category | Operations | Highlights |
 |----------|-----------|------------|
-| Primitives & Sweeps | 36 | box, cylinder, sphere, cone, torus, wedge, pipe, extrude, revolve, loft, thru-sections |
+| Primitives & Sweeps | 37 | box, cylinder, sphere, cone, torus, wedge, pipe, extrude, revolve, loft, thru-sections |
 | Booleans | 13 | union, subtract, intersect, section, split, cells builder, defeaturing |
 | Modifications | 33 | fillet (uniform/variable/evolving), chamfer, shell, offset, draft |
 | Wires & Edges | 56 | rectangle, circle, polygon, arc, BSpline, NURBS, helix, fillet2D, chamfer2D |

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -191,7 +191,10 @@
 //                                        (FillingSurface) — one implementation, #434
 // BRepOffsetAPI_MakeOffset            → OCCTShapeOffset*
 // BRepOffsetAPI_MakePipe              → OCCTShapePipe*
-// BRepOffsetAPI_MakePipeShell         → OCCTShapePipeShell*
+// BRepOffsetAPI_MakePipeShell         → OCCTShapeCreatePipeShellMultiSection (every
+//                                       Add() sweep, one profile or many),
+//                                       OCCTShapeCreatePipeShellWithLaw (SetLaw),
+//                                       OCCTPipeShell* (the incremental builder). #503
 // BRepOffsetAPI_MakeThickSolid        → OCCTShapeShell, OCCTShapeHollowed
 // BRepOffsetAPI_ThruSections          → OCCTShapeLoft*
 //
@@ -1594,45 +1597,26 @@ typedef enum {
     OCCTPipeModeAuxiliary = 3         // Guided by auxiliary curve
 } OCCTPipeMode;
 
-/// Create pipe shell with sweep mode
-/// @param spine Path wire for sweep
-/// @param profile Profile wire to sweep
-/// @param mode Sweep mode (Frenet, corrected Frenet, etc.)
-/// @param solid If true, create solid; if false, create shell
-/// @return Swept shape, or NULL on failure
-OCCTShapeRef OCCTShapeCreatePipeShell(OCCTWireRef spine, OCCTWireRef profile,
-                                       OCCTPipeMode mode, bool solid);
-
-/// Create pipe shell with fixed binormal direction
-/// @param spine Path wire for sweep
-/// @param profile Profile wire to sweep
-/// @param bnX, bnY, bnZ Fixed binormal direction
-/// @param solid If true, create solid; if false, create shell
-/// @return Swept shape, or NULL on failure
-OCCTShapeRef OCCTShapeCreatePipeShellWithBinormal(OCCTWireRef spine, OCCTWireRef profile,
-                                                   double bnX, double bnY, double bnZ, bool solid);
-
-/// Create pipe shell guided by auxiliary spine
-/// @param spine Main path wire
-/// @param profile Profile wire to sweep
-/// @param auxSpine Auxiliary spine for twist control
-/// @param solid If true, create solid; if false, create shell
-/// @return Swept shape, or NULL on failure
-OCCTShapeRef OCCTShapeCreatePipeShellWithAuxSpine(OCCTWireRef spine, OCCTWireRef profile,
-                                                   OCCTWireRef auxSpine, bool solid);
-
-/// Create a variable-section pipe shell from several profiles (issue #180).
+/// Create a pipe shell by sweeping one or more profiles along a spine (issues #180, #503).
 /// Adds each profile (positioned in 3D along the spine) to a single
-/// BRepOffsetAPI_MakePipeShell, producing a smooth swept solid/shell that
-/// interpolates between sections. Supports every orientation mode:
-///   - OCCTPipeModeFixedBinormal uses (bnX, bnY, bnZ)
-///   - OCCTPipeModeAuxiliary uses auxSpine (must be non-NULL for that mode)
+/// BRepOffsetAPI_MakePipeShell, producing a swept solid/shell that interpolates between
+/// sections. This is the only Add()-based pipe shell in the bridge: pass profileCount = 1
+/// for an ordinary single-profile sweep. It supersedes OCCTShapeCreatePipeShell,
+/// OCCTShapeCreatePipeShellWithBinormal, OCCTShapeCreatePipeShellWithAuxSpine and
+/// OCCTShapeCreatePipeShellWithTransition, which were this function with arguments nailed
+/// shut and which silently swept Frenet when asked for a mode they could not express (#503).
+/// Every orientation mode is honoured:
+///   - OCCTPipeModeFixedBinormal uses (bnX, bnY, bnZ), and fails the call rather than
+///     substituting another mode if that vector is zero-length
+///   - OCCTPipeModeAuxiliary uses auxSpine, and fails the call if it is NULL
 /// @param spine Path wire for sweep
 /// @param profiles Array of profile wires (length profileCount, all non-NULL)
 /// @param profileCount Number of profiles (>= 1)
 /// @param mode Sweep mode controlling profile orientation
 /// @param bnX, bnY, bnZ Fixed binormal (used only for OCCTPipeModeFixedBinormal)
 /// @param auxSpine Auxiliary spine (used only for OCCTPipeModeAuxiliary; else NULL)
+/// @param transitionMode Corner behaviour at spine discontinuities:
+///        0=Transformed (OCCT's own default), 1=RightCorner, 2=RoundCorner
 /// @param withContact If true, move each profile to touch the spine before sweeping
 /// @param withCorrection If true, rotate the profile to stay orthogonal to the spine
 /// @param solid If true, create solid; if false, create shell
@@ -1642,6 +1626,7 @@ OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
                                                   OCCTPipeMode mode,
                                                   double bnX, double bnY, double bnZ,
                                                   OCCTWireRef auxSpine,
+                                                  int32_t transitionMode,
                                                   bool withContact, bool withCorrection,
                                                   bool solid);
 
@@ -4587,20 +4572,6 @@ OCCTShapeRef OCCTShapeCreateEvolvedAdvanced(OCCTShapeRef spine, OCCTWireRef prof
                                              int32_t joinType, bool axeProf,
                                              bool solid, bool volume,
                                              double tolerance);
-
-
-// MARK: - Pipe Shell with Transition Mode (v0.33.0)
-
-/// Create a pipe shell with transition mode control.
-/// @param spine The spine wire
-/// @param profile The profile wire
-/// @param mode Sweep mode: 0=Frenet, 1=CorrectedFrenet
-/// @param transitionMode Transition: 0=Transformed, 1=RightCorner, 2=RoundCorner
-/// @param solid true to produce a solid
-/// @return Pipe shape, or NULL on failure
-OCCTShapeRef OCCTShapeCreatePipeShellWithTransition(OCCTWireRef spine, OCCTWireRef profile,
-                                                     int32_t mode, int32_t transitionMode,
-                                                     bool solid);
 
 
 // MARK: - Face from Surface with UV Bounds (v0.33.0)

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -450,149 +450,74 @@ OCCTShapeRef OCCTShapeRemoveFeatures(OCCTShapeRef shape, const int32_t* faceIndi
     }
 }
 
-OCCTShapeRef OCCTShapeCreatePipeShell(OCCTWireRef spine, OCCTWireRef profile,
-                                       OCCTPipeMode mode, bool solid) {
-    if (!spine || !profile) return nullptr;
+// MARK: - Pipe shell (BRepOffsetAPI_MakePipeShell)
+//
+// Every Add()-based pipe shell in this bridge is one call to
+// OCCTShapeCreatePipeShellMultiSection. The single-profile spellings that used to sit
+// here (OCCTShapeCreatePipeShell, ...WithBinormal, ...WithAuxSpine, ...WithTransition)
+// were that function with profileCount == 1 and some of its arguments nailed shut, and
+// two of them disagreed with it about what a mode means (#503).
 
-    try {
-        BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
-
-        // Set sweep mode
-        switch (mode) {
-            case OCCTPipeModeFrenet:
-                pipeShell.SetMode(Standard_False);  // Frenet
-                break;
-            case OCCTPipeModeCorrectedFrenet:
-                pipeShell.SetMode(Standard_True);   // Corrected Frenet
-                break;
-            case OCCTPipeModeFixedBinormal:
-            case OCCTPipeModeAuxiliary:
-                // These modes require additional parameters
-                // Use dedicated functions for them
-                pipeShell.SetMode(Standard_False);
-                break;
-        }
-
-        // Add profile
-        pipeShell.Add(profile->wire);
-
-        // Build the shell
-        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
-        pipeShell.Build();
-        if (!pipeShell.IsDone()) return nullptr;
-
-        TopoDS_Shape result = pipeShell.Shape();
-
-        // Make solid if requested
-        if (solid) {
-            pipeShell.MakeSolid();
-            if (pipeShell.IsDone()) {
-                result = pipeShell.Shape();
-            }
-        }
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
+// Apply an orientation mode. Returns false when the mode's own argument is missing;
+// a zero-length binormal throws out of gp_Dir and is caught by the caller.
+static bool occtPipeShellSetMode(BRepOffsetAPI_MakePipeShell& pipeShell, OCCTPipeMode mode,
+                                 double bnX, double bnY, double bnZ, OCCTWireRef auxSpine) {
+    switch (mode) {
+        case OCCTPipeModeFrenet:
+            pipeShell.SetMode(Standard_False);
+            return true;
+        case OCCTPipeModeCorrectedFrenet:
+            pipeShell.SetMode(Standard_True);
+            return true;
+        case OCCTPipeModeFixedBinormal:
+            pipeShell.SetMode(gp_Dir(bnX, bnY, bnZ));
+            return true;
+        case OCCTPipeModeAuxiliary:
+            if (!auxSpine) return false;
+            pipeShell.SetMode(auxSpine->wire, Standard_False);  // curvilinear equivalence = false
+            return true;
     }
+    return false;
 }
 
-OCCTShapeRef OCCTShapeCreatePipeShellWithBinormal(OCCTWireRef spine, OCCTWireRef profile,
-                                                   double bnX, double bnY, double bnZ, bool solid) {
-    if (!spine || !profile) return nullptr;
+// Build the configured shell and, when asked, close it into a solid. Holds the sole copy
+// of the build-history workaround that used to be pasted into all six entry points.
+static OCCTShapeRef occtPipeShellFinish(BRepOffsetAPI_MakePipeShell& pipeShell, bool solid) {
+    pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
+    pipeShell.Build();
+    if (!pipeShell.IsDone()) return nullptr;
 
-    try {
-        BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
-
-        // Set fixed binormal direction
-        gp_Dir binormal(bnX, bnY, bnZ);
-        pipeShell.SetMode(binormal);
-
-        // Add profile
-        pipeShell.Add(profile->wire);
-
-        // Build the shell
-        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
-        pipeShell.Build();
-        if (!pipeShell.IsDone()) return nullptr;
-
-        TopoDS_Shape result = pipeShell.Shape();
-
-        // Make solid if requested
-        if (solid) {
-            pipeShell.MakeSolid();
-            if (pipeShell.IsDone()) {
-                result = pipeShell.Shape();
-            }
+    TopoDS_Shape result = pipeShell.Shape();
+    if (solid) {
+        pipeShell.MakeSolid();
+        if (pipeShell.IsDone()) {
+            result = pipeShell.Shape();
         }
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
     }
-}
-
-OCCTShapeRef OCCTShapeCreatePipeShellWithAuxSpine(OCCTWireRef spine, OCCTWireRef profile,
-                                                   OCCTWireRef auxSpine, bool solid) {
-    if (!spine || !profile || !auxSpine) return nullptr;
-
-    try {
-        BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
-
-        // Set auxiliary spine for twist control
-        pipeShell.SetMode(auxSpine->wire, Standard_False);  // curvilinear equivalence = false
-
-        // Add profile
-        pipeShell.Add(profile->wire);
-
-        // Build the shell
-        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
-        pipeShell.Build();
-        if (!pipeShell.IsDone()) return nullptr;
-
-        TopoDS_Shape result = pipeShell.Shape();
-
-        // Make solid if requested
-        if (solid) {
-            pipeShell.MakeSolid();
-            if (pipeShell.IsDone()) {
-                result = pipeShell.Shape();
-            }
-        }
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+    return new OCCTShape(result);
 }
 
 // Multi-section pipe shell (#180): one MakePipeShell, several Add() calls.
+// Since #503 this is also the single-profile form, and the only Add()-based pipe shell.
 OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
                                                   const OCCTWireRef* profiles, int32_t profileCount,
                                                   OCCTPipeMode mode,
                                                   double bnX, double bnY, double bnZ,
                                                   OCCTWireRef auxSpine,
+                                                  int32_t transitionMode,
                                                   bool withContact, bool withCorrection,
                                                   bool solid) {
     if (!spine || !profiles || profileCount < 1) return nullptr;
-    if (mode == OCCTPipeModeAuxiliary && !auxSpine) return nullptr;
 
     try {
         BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
 
-        switch (mode) {
-            case OCCTPipeModeFrenet:
-                pipeShell.SetMode(Standard_False);
-                break;
-            case OCCTPipeModeCorrectedFrenet:
-                pipeShell.SetMode(Standard_True);
-                break;
-            case OCCTPipeModeFixedBinormal:
-                pipeShell.SetMode(gp_Dir(bnX, bnY, bnZ));
-                break;
-            case OCCTPipeModeAuxiliary:
-                pipeShell.SetMode(auxSpine->wire, Standard_False);
-                break;
+        if (!occtPipeShellSetMode(pipeShell, mode, bnX, bnY, bnZ, auxSpine)) return nullptr;
+
+        switch (transitionMode) {
+            case 1:  pipeShell.SetTransitionMode(BRepBuilderAPI_RightCorner); break;
+            case 2:  pipeShell.SetTransitionMode(BRepBuilderAPI_RoundCorner); break;
+            default: pipeShell.SetTransitionMode(BRepBuilderAPI_Transformed); break;
         }
 
         // Add every profile (variable cross-section).
@@ -603,18 +528,7 @@ OCCTShapeRef OCCTShapeCreatePipeShellMultiSection(OCCTWireRef spine,
                           withCorrection ? Standard_True : Standard_False);
         }
 
-        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
-        pipeShell.Build();
-        if (!pipeShell.IsDone()) return nullptr;
-
-        TopoDS_Shape result = pipeShell.Shape();
-        if (solid) {
-            pipeShell.MakeSolid();
-            if (pipeShell.IsDone()) {
-                result = pipeShell.Shape();
-            }
-        }
-        return new OCCTShape(result);
+        return occtPipeShellFinish(pipeShell, solid);
     } catch (...) {
         return nullptr;
     }
@@ -2138,47 +2052,6 @@ OCCTShapeRef OCCTShapeCreateEvolvedAdvanced(OCCTShapeRef spine, OCCTWireRef prof
         if (!evolved.IsDone()) return nullptr;
         TopoDS_Shape result = evolved.Shape();
         if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-// MARK: - Pipe Shell with Transition Mode (v0.33.0)
-
-#include <BRepBuilderAPI_TransitionMode.hxx>
-
-OCCTShapeRef OCCTShapeCreatePipeShellWithTransition(OCCTWireRef spine, OCCTWireRef profile,
-                                                     int32_t mode, int32_t transitionMode,
-                                                     bool solid) {
-    if (!spine || !profile) return nullptr;
-    try {
-        BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
-        // Set sweep mode
-        if (mode == 1) {
-            pipeShell.SetMode(Standard_True);   // Corrected Frenet
-        } else {
-            pipeShell.SetMode(Standard_False);  // Frenet
-        }
-        // Set transition mode
-        if (transitionMode == 1) {
-            pipeShell.SetTransitionMode(BRepBuilderAPI_RightCorner);
-        } else if (transitionMode == 2) {
-            pipeShell.SetTransitionMode(BRepBuilderAPI_RoundCorner);
-        } else {
-            pipeShell.SetTransitionMode(BRepBuilderAPI_Transformed);
-        }
-        pipeShell.Add(profile->wire);
-        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
-        pipeShell.Build();
-        if (!pipeShell.IsDone()) return nullptr;
-        TopoDS_Shape result = pipeShell.Shape();
-        if (solid) {
-            pipeShell.MakeSolid();
-            if (pipeShell.IsDone()) {
-                result = pipeShell.Shape();
-            }
-        }
         return new OCCTShape(result);
     } catch (...) {
         return nullptr;
@@ -4190,6 +4063,9 @@ OCCTLawFunctionRef OCCTLawCreateBSpline(const double* poles, int32_t poleCount,
     }
 }
 
+// The one pipe shell that is not an Add() sweep: SetLaw scales a single profile along the
+// spine, and OCCT's own header warns against combining the two. It shares the build tail
+// (and so the build-history workaround) with OCCTShapeCreatePipeShellMultiSection.
 OCCTShapeRef OCCTShapeCreatePipeShellWithLaw(OCCTWireRef spine,
                                               OCCTWireRef profile,
                                               OCCTLawFunctionRef law,
@@ -4199,18 +4075,7 @@ OCCTShapeRef OCCTShapeCreatePipeShellWithLaw(OCCTWireRef spine,
         BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
         pipeShell.SetMode(Standard_False); // Frenet
         pipeShell.SetLaw(profile->wire, law->law, Standard_False, Standard_False);
-        pipeShell.SetIsBuildHistory(false); // avoid SEGV on closed spine+profile (OCCT bug)
-        pipeShell.Build();
-        if (!pipeShell.IsDone()) return nullptr;
-
-        TopoDS_Shape result = pipeShell.Shape();
-        if (solid) {
-            pipeShell.MakeSolid();
-            if (pipeShell.IsDone()) {
-                result = pipeShell.Shape();
-            }
-        }
-        return new OCCTShape(result);
+        return occtPipeShellFinish(pipeShell, solid);
     } catch (...) {
         return nullptr;
     }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2753,36 +2753,53 @@ extension Shape {
 
     /// Create a pipe (sweep) with advanced sweep modes
     ///
-    /// Unlike the basic `pipe(profile:path:)`, this method provides control over
-    /// how the profile is oriented along the sweep path.
+    /// Unlike the basic `pipe(profile:path:)`, this method controls how the profile is
+    /// oriented along the sweep path, what happens at corners in the spine, and whether the
+    /// profile is repositioned onto the spine before sweeping.
+    ///
+    /// This is the single-profile form of
+    /// ``pipeShellMultiSection(spine:profiles:mode:transition:withContact:withCorrection:solid:)``
+    /// and runs the same code: one `BRepOffsetAPI_MakePipeShell` with one section added (#503).
+    ///
+    /// ```swift
+    /// let spine = Wire.bspline([SIMD3(0, 0, 0), SIMD3(10, 5, 0),
+    ///                           SIMD3(20, -5, 10), SIMD3(30, 0, 10)])!
+    /// let profile = Wire.rectangle(width: 5, height: 3)!
+    ///
+    /// // Frenet lets the section roll with the spine's torsion.
+    /// let rolled = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet)
+    ///
+    /// // A fixed binormal keeps it upright instead, which is a different solid.
+    /// let upright = Shape.pipeShell(spine: spine, profile: profile,
+    ///                               mode: .fixed(binormal: SIMD3(0, 0, 1)))
+    /// print(rolled?.volume ?? 0)    // 180.29
+    /// print(upright?.volume ?? 0)   // 150.00
+    /// ```
     ///
     /// - Parameters:
     ///   - spine: Path wire along which to sweep
     ///   - profile: Profile wire to sweep
-    ///   - mode: Sweep mode controlling profile orientation
+    ///   - mode: Sweep mode controlling profile orientation. A mode whose own argument is
+    ///     unusable (`.fixed(binormal:)` given a zero-length vector, or `.auxiliary(spine:)`
+    ///     given a spine OCCT rejects) returns nil rather than quietly sweeping some other
+    ///     mode, which is what the pre-#503 bridge did.
+    ///   - transition: How to handle transitions at spine corners
+    ///   - withContact: If true, the profile is moved to touch the spine before sweeping
+    ///   - withCorrection: If true, the profile is rotated to stay orthogonal to the spine
     ///   - solid: If true, create a solid; if false, create a shell
     /// - Returns: Swept shape, or nil on failure
     public static func pipeShell(
         spine: Wire,
         profile: Wire,
         mode: PipeSweepMode = .frenet,
+        transition: PipeTransitionMode = .transformed,
+        withContact: Bool = false,
+        withCorrection: Bool = false,
         solid: Bool = true
     ) -> Shape? {
-        let result: OCCTShapeRef?
-
-        switch mode {
-        case .frenet:
-            result = OCCTShapeCreatePipeShell(spine.handle, profile.handle, OCCTPipeModeFrenet, solid)
-        case .correctedFrenet:
-            result = OCCTShapeCreatePipeShell(spine.handle, profile.handle, OCCTPipeModeCorrectedFrenet, solid)
-        case .fixed(let binormal):
-            result = OCCTShapeCreatePipeShellWithBinormal(spine.handle, profile.handle, binormal.x, binormal.y, binormal.z, solid)
-        case .auxiliary(let auxSpine):
-            result = OCCTShapeCreatePipeShellWithAuxSpine(spine.handle, profile.handle, auxSpine.handle, solid)
-        }
-
-        guard let shapeRef = result else { return nil }
-        return Shape(handle: shapeRef)
+        pipeShellMultiSection(
+            spine: spine, profiles: [profile], mode: mode, transition: transition,
+            withContact: withContact, withCorrection: withCorrection, solid: solid)
     }
 
     /// Create a pipe shell with transition mode control.
@@ -2796,6 +2813,14 @@ extension Shape {
     ///   - transition: How to handle transitions at spine corners
     ///   - solid: If true, create a solid; if false, create a shell
     /// - Returns: Swept shape, or nil on failure
+    @available(*, deprecated,
+        renamed: "pipeShell(spine:profile:mode:transition:withContact:withCorrection:solid:)",
+        message: """
+            This spelling took a PipeSweepMode but could only express .frenet and \
+            .correctedFrenet: .fixed(binormal:) and .auxiliary(spine:) were silently swept \
+            as Frenet, returning a different solid from the one asked for. pipeShell now \
+            takes the same transition: argument and honours every mode (#503).
+            """)
     public static func pipeShellWithTransition(
         spine: Wire,
         profile: Wire,
@@ -2803,16 +2828,7 @@ extension Shape {
         transition: PipeTransitionMode = .transformed,
         solid: Bool = true
     ) -> Shape? {
-        let modeInt: Int32 = {
-            switch mode {
-            case .correctedFrenet: return 1
-            default: return 0
-            }
-        }()
-        guard let h = OCCTShapeCreatePipeShellWithTransition(
-            spine.handle, profile.handle, modeInt, transition.rawValue, solid
-        ) else { return nil }
-        return Shape(handle: h)
+        pipeShell(spine: spine, profile: profile, mode: mode, transition: transition, solid: solid)
     }
 
     // MARK: - Variable-Section Sweep (v0.21.0)
@@ -2833,20 +2849,35 @@ extension Shape {
         return Shape(handle: result)
     }
 
-    /// Sweep several profiles along a spine for a variable-section pipe shell.
+    /// Sweep one or more profiles along a spine for a variable-section pipe shell.
     ///
-    /// This is the multi-section form of ``pipeShell(spine:profile:mode:solid:)``: each
-    /// profile is positioned in 3D at its station along the spine, and OCCT interpolates a
-    /// smooth solid (or shell) that passes through every section. It supports the same
-    /// orientation modes — including ``PipeSweepMode/auxiliary(spine:)``, which keeps the
-    /// section oriented by a secondary curve (e.g. a thread rib that ramps from a runout to
-    /// full crest along a helix while staying radial to the axis).
+    /// Every `MakePipeShell` sweep in OCCTSwift is this call. Each profile is positioned in
+    /// 3D at its station along the spine, and OCCT interpolates a solid (or shell) that
+    /// passes through every section. It supports every orientation mode, including
+    /// ``PipeSweepMode/auxiliary(spine:)``, which keeps the section oriented by a secondary
+    /// curve (e.g. a thread rib that ramps from a runout to full crest along a helix while
+    /// staying radial to the axis). ``pipeShell(spine:profile:mode:transition:withContact:withCorrection:solid:)``
+    /// is this function with one profile (#503).
+    ///
+    /// ```swift
+    /// let spine = Wire.line(from: .zero, to: SIMD3(0, 0, 10))!
+    /// // Three coaxial circles: wide, narrow, wide. A vase.
+    /// let stations = [(0.0, 2.0), (5.0, 1.0), (10.0, 2.0)].compactMap {
+    ///     Wire.circle(origin: SIMD3(0, 0, $0.0), normal: SIMD3(0, 0, 1), radius: $0.1)
+    /// }
+    /// let vase = Shape.pipeShellMultiSection(spine: spine, profiles: stations, mode: .frenet)
+    /// print(vase?.volume ?? 0)   // 58.64
+    /// ```
     ///
     /// - Parameters:
     ///   - spine: Path wire along which to sweep.
     ///   - profiles: Profile wires, each positioned at its station along the spine. At least
     ///     one is required; two or more give a genuinely varying section.
     ///   - mode: Sweep mode controlling profile orientation (incl. `.auxiliary(spine:)`).
+    ///     A mode whose own argument is unusable returns nil rather than substituting
+    ///     another mode.
+    ///   - transition: How to handle transitions at spine corners. Reaches a multi-section
+    ///     sweep since #503; before that only the single-profile spelling could set it.
     ///   - withContact: If true, each profile is moved to touch the spine before sweeping.
     ///   - withCorrection: If true, each profile is rotated to stay orthogonal to the spine.
     ///   - solid: If true, create a solid; if false, a shell.
@@ -2855,6 +2886,7 @@ extension Shape {
         spine: Wire,
         profiles: [Wire],
         mode: PipeSweepMode = .frenet,
+        transition: PipeTransitionMode = .transformed,
         withContact: Bool = false,
         withCorrection: Bool = false,
         solid: Bool = true
@@ -2882,7 +2914,7 @@ extension Shape {
             OCCTShapeCreatePipeShellMultiSection(
                 spine.handle, buffer.baseAddress, Int32(profiles.count),
                 modeValue, binormal.x, binormal.y, binormal.z,
-                auxHandle, withContact, withCorrection, solid)
+                auxHandle, transition.rawValue, withContact, withCorrection, solid)
         }) else { return nil }
         return Shape(handle: result)
     }

--- a/Tests/OCCTModelingTests/Issue503PipeShellTests.swift
+++ b/Tests/OCCTModelingTests/Issue503PipeShellTests.swift
@@ -1,0 +1,238 @@
+// #503: every Add()-based pipe shell is one bridge function.
+//
+// Four bridge entry points used to build their own single-profile MakePipeShell, and two of
+// them could not express half the OCCTPipeMode enum they accepted: they swept Frenet instead
+// and returned a shape that looked like a success. These tests pin the unified contract:
+// a single-profile sweep is the multi-section sweep with one section, and a mode the caller
+// asked for is either honoured or refused, never quietly swapped.
+
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+@Suite("Pipe shell unification (#503)")
+struct Issue503PipeShellTests {
+
+    /// Curved enough that Frenet, corrected Frenet and a fixed binormal all disagree.
+    /// A straight spine will not do: with no torsion the modes coincide, which is how the
+    /// silent fall-through survived a test suite that only ever swept straight lines.
+    static func curvedSpine() -> Wire? {
+        Wire.bspline([SIMD3(0, 0, 0), SIMD3(10, 5, 0), SIMD3(20, -5, 10), SIMD3(30, 0, 10)])
+    }
+
+    /// An L-shaped spine, so the corner transition modes have a corner to act on.
+    static func corneredSpine() -> Wire? {
+        Wire.path([SIMD3(0, 0, 0), SIMD3(0, 0, 20), SIMD3(15, 0, 20)])
+    }
+
+    static func fingerprint(_ s: Shape?) -> (volume: Double, faces: Int)? {
+        guard let s, let v = s.volume else { return nil }
+        return (v, s.faces().count)
+    }
+
+    // MARK: - The unification invariant
+
+    @Test("a one-profile multi-section sweep is the single-profile sweep, in every mode")
+    func oneProfileMatchesTheMultiSectionForm() {
+        guard let curved = Self.curvedSpine(),
+              let straight = Wire.line(from: .zero, to: SIMD3(0, 0, 20)),
+              let aux = Wire.line(from: SIMD3(5, 0, 0), to: SIMD3(5, 8, 20)),
+              let rect = Wire.rectangle(width: 5, height: 3),
+              let circle = Wire.circle(radius: 2) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+
+        let cases: [(String, Wire, Wire, PipeSweepMode)] = [
+            ("frenet", curved, rect, .frenet),
+            ("correctedFrenet", curved, rect, .correctedFrenet),
+            ("fixed", curved, rect, .fixed(binormal: SIMD3(0, 0, 1))),
+            ("auxiliary", straight, circle, .auxiliary(spine: aux)),
+        ]
+
+        for (name, spine, profile, mode) in cases {
+            let single = Self.fingerprint(
+                Shape.pipeShell(spine: spine, profile: profile, mode: mode))
+            let multi = Self.fingerprint(
+                Shape.pipeShellMultiSection(spine: spine, profiles: [profile], mode: mode))
+            #expect(single != nil, "single-profile \(name) sweep failed")
+            #expect(multi != nil, "one-section \(name) sweep failed")
+            if let single, let multi {
+                #expect(single.volume.isApproximatelyEqual(to: multi.volume, tolerance: 1e-9),
+                        "\(name): \(single.volume) vs \(multi.volume)")
+                #expect(single.faces == multi.faces, "\(name) face count")
+            }
+        }
+    }
+
+    // MARK: - Modes are honoured, not substituted
+
+    @Test("a fixed binormal builds a different solid from Frenet on a curved spine")
+    func fixedBinormalDiffersFromFrenet() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        let frenet = Self.fingerprint(Shape.pipeShell(spine: spine, profile: profile, mode: .frenet))
+        let fixed = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile, mode: .fixed(binormal: SIMD3(0, 0, 1))))
+
+        if let frenet, let fixed {
+            #expect(frenet.volume.isApproximatelyEqual(to: 180.286724, tolerance: 1e-5))
+            #expect(fixed.volume.isApproximatelyEqual(to: 149.999816, tolerance: 1e-5))
+            #expect(!frenet.volume.isApproximatelyEqual(to: fixed.volume, tolerance: 1e-6))
+        } else {
+            Issue.record("Both sweeps must build")
+        }
+    }
+
+    /// The regression this issue actually fixes. Asking for a transition mode used to force
+    /// the sweep through a bridge function that understood only Frenet and corrected Frenet,
+    /// so `.fixed(binormal:)` came back as a Frenet sweep: same call, wrong solid, no nil.
+    @Test("asking for a corner transition does not downgrade the sweep mode")
+    func transitionModeKeepsTheRequestedSweepMode() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        let plain = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile,
+                            mode: .fixed(binormal: SIMD3(0, 0, 1))))
+        let withTransition = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile,
+                            mode: .fixed(binormal: SIMD3(0, 0, 1)), transition: .transformed))
+        let frenet = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile, mode: .frenet, transition: .transformed))
+
+        if let plain, let withTransition, let frenet {
+            // Transformed is OCCT's own default, so naming it changes nothing.
+            #expect(withTransition.volume.isApproximatelyEqual(to: plain.volume, tolerance: 1e-9))
+            // And the binormal is still in force, rather than having been dropped for Frenet.
+            #expect(!withTransition.volume.isApproximatelyEqual(to: frenet.volume, tolerance: 1e-6),
+                    "fixed-binormal sweep collapsed back to Frenet (\(withTransition.volume))")
+        } else {
+            Issue.record("All three sweeps must build")
+        }
+    }
+
+    @Test("the deprecated transition spelling forwards with its mode intact")
+    @available(*, deprecated, message: "Exercises the deprecated `pipeShellWithTransition` on purpose.")
+    func deprecatedTransitionSpellingForwards() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        let old = Self.fingerprint(
+            Shape.pipeShellWithTransition(spine: spine, profile: profile,
+                                          mode: .fixed(binormal: SIMD3(0, 0, 1))))
+        let new = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile,
+                            mode: .fixed(binormal: SIMD3(0, 0, 1))))
+        #expect(old != nil)
+        if let old, let new {
+            #expect(old.volume.isApproximatelyEqual(to: new.volume, tolerance: 1e-9))
+        }
+    }
+
+    @Test("a mode whose own argument is unusable returns nil instead of another mode's solid")
+    func unusableModeArgumentFails() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+              let straight = Wire.line(from: .zero, to: SIMD3(0, 0, 20)),
+              let circle = Wire.circle(radius: 2) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        // A zero-length binormal is not a direction, and is not silently Frenet either.
+        #expect(Shape.pipeShell(spine: spine, profile: profile,
+                                mode: .fixed(binormal: .zero)) == nil)
+        // An auxiliary spine OCCT cannot use fails the sweep rather than being ignored.
+        if let sameAsSpine = Wire.line(from: .zero, to: SIMD3(0, 0, 20)) {
+            #expect(Shape.pipeShell(spine: straight, profile: circle,
+                                    mode: .auxiliary(spine: sameAsSpine)) == nil)
+        }
+    }
+
+    // MARK: - Reach gained by the unification
+
+    @Test("an auxiliary spine steers a single-profile sweep")
+    func auxiliarySpineSteersOneProfile() {
+        guard let spine = Wire.line(from: .zero, to: SIMD3(0, 0, 20)),
+              let aux = Wire.line(from: SIMD3(5, 0, 0), to: SIMD3(5, 8, 20)),
+              let profile = Wire.circle(radius: 2) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        let steered = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile, mode: .auxiliary(spine: aux)))
+        let plain = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile, mode: .frenet))
+
+        #expect(steered != nil, "the single-profile auxiliary path must build")
+        if let steered, let plain {
+            #expect(steered.volume.isApproximatelyEqual(to: 251.327629, tolerance: 1e-5))
+            #expect(!steered.volume.isApproximatelyEqual(to: plain.volume, tolerance: 1e-9),
+                    "the auxiliary spine had no effect")
+        }
+    }
+
+    @Test("corner transitions reach a multi-section sweep")
+    func multiSectionHonoursCornerTransitions() {
+        guard let spine = Self.corneredSpine(),
+              let start = Wire.circle(origin: .zero, normal: SIMD3(0, 0, 1), radius: 2),
+              let end = Wire.circle(origin: SIMD3(15, 0, 20), normal: SIMD3(1, 0, 0), radius: 1) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        let profiles = [start, end]
+        let transformed = Self.fingerprint(
+            Shape.pipeShellMultiSection(spine: spine, profiles: profiles, transition: .transformed))
+        let rightCorner = Self.fingerprint(
+            Shape.pipeShellMultiSection(spine: spine, profiles: profiles, transition: .rightCorner))
+        let roundCorner = Self.fingerprint(
+            Shape.pipeShellMultiSection(spine: spine, profiles: profiles, transition: .roundCorner))
+
+        #expect(transformed != nil)
+        #expect(rightCorner != nil)
+        #expect(roundCorner != nil)
+        if let transformed, let rightCorner, let roundCorner {
+            #expect(!transformed.volume.isApproximatelyEqual(to: rightCorner.volume, tolerance: 1e-6),
+                    "rightCorner did not reach the multi-section sweep")
+            #expect(!rightCorner.volume.isApproximatelyEqual(to: roundCorner.volume, tolerance: 1e-6),
+                    "roundCorner did not reach the multi-section sweep")
+            // A rounded corner carries the extra face that rounds it.
+            #expect(roundCorner.faces > rightCorner.faces)
+        }
+    }
+
+    @Test("withContact and withCorrection reach a single-profile sweep")
+    func singleProfileHonoursContactAndCorrection() {
+        // A profile parked off the spine and tilted away from it, so both flags have work.
+        guard let spine = Wire.line(from: .zero, to: SIMD3(0, 0, 20)),
+              let profile = Wire.circle(origin: SIMD3(6, 0, 0), normal: SIMD3(1, 1, 2), radius: 2) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        let plain = Self.fingerprint(Shape.pipeShell(spine: spine, profile: profile))
+        let corrected = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile, withCorrection: true))
+        let contacted = Self.fingerprint(
+            Shape.pipeShell(spine: spine, profile: profile, withContact: true))
+
+        if let plain, let corrected, let contacted {
+            // Rotating the tilted section orthogonal to the spine sweeps a true cylinder:
+            // pi * 2^2 * 20. The tilted sweep is thinner.
+            #expect(corrected.volume.isApproximatelyEqual(to: 251.327412, tolerance: 1e-5))
+            #expect(!plain.volume.isApproximatelyEqual(to: corrected.volume, tolerance: 1e-6),
+                    "withCorrection had no effect")
+            // Contact translates the section onto the spine, which preserves the volume but
+            // not the solid, so compare where it lands rather than how big it is.
+            if let plainShape = Shape.pipeShell(spine: spine, profile: profile),
+               let contactedShape = Shape.pipeShell(spine: spine, profile: profile, withContact: true) {
+                #expect(!plainShape.bounds.min.x.isApproximatelyEqual(
+                            to: contactedShape.bounds.min.x, tolerance: 1e-6),
+                        "withContact had no effect")
+            }
+            #expect(contacted.volume > 0)
+        } else {
+            Issue.record("All three sweeps must build")
+        }
+    }
+}
+
+private extension Double {
+    func isApproximatelyEqual(to other: Double, tolerance: Double) -> Bool {
+        abs(self - other) <= tolerance * Swift.max(1.0, abs(self), abs(other))
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -1773,7 +1773,7 @@ struct PipeShellTransitionTests {
         let p3 = SIMD3<Double>(10, 10, 0)
         let spine = Wire.path([p1, p2, p3])!
         let profile = Wire.circle(radius: 1)!
-        let result = Shape.pipeShellWithTransition(
+        let result = Shape.pipeShell(
             spine: spine, profile: profile,
             transition: .transformed, solid: true
         )
@@ -1786,7 +1786,7 @@ struct PipeShellTransitionTests {
         // is perpendicular to the spine tangent (required for RightCorner)
         let spine = Wire.path([SIMD3(0,0,0), SIMD3(0,0,10), SIMD3(0,10,10)])!
         let profile = Wire.circle(radius: 2)!
-        let result = Shape.pipeShellWithTransition(
+        let result = Shape.pipeShell(
             spine: spine, profile: profile,
             transition: .rightCorner, solid: true
         )
@@ -1799,7 +1799,7 @@ struct PipeShellTransitionTests {
         // is perpendicular to the spine tangent (required for RoundCorner)
         let spine = Wire.path([SIMD3(0,0,0), SIMD3(0,0,10), SIMD3(0,10,10)])!
         let profile = Wire.circle(radius: 2)!
-        let result = Shape.pipeShellWithTransition(
+        let result = Shape.pipeShell(
             spine: spine, profile: profile,
             transition: .roundCorner, solid: true
         )
@@ -1807,6 +1807,7 @@ struct PipeShellTransitionTests {
     }
 
     @Test("Pipe transition with corrected Frenet mode")
+    @available(*, deprecated, message: "Exercises the deprecated `pipeShellWithTransition` on purpose.")
     func pipeCorrectedFrenetTransition() {
         // Simple straight spine — Frenet and CorrectedFrenet should behave the same
         guard let spine = Wire.line(from: SIMD3(0, 0, 0), to: SIMD3(0, 0, 10)) else { return }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,327** of the entry points (~78% of the `Total` below); the rest are real, callable,
+categorisation covering **3,328** of the entry points (~78% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -34,7 +34,7 @@ a map of the major areas, and the `Total` as the count.
 | Category | Count | Examples |
 |----------|-------|----------|
 | **Primitives** | 13 | box, cylinder, cylinder(at:), sphere, cone, torus, surface, wedge, halfSpace, vertex, shell(from surface), shell(from Surface), nonUniformScale |
-| **Sweeps** | 23 | pipe sweep, pipeShell, pipeShellWithTransition, pipeShellWithLaw, extrude, revolve, loft, loft(ruled+vertex), ruled, revolutionFromCurve, ruledShell, advancedEvolved, pipeSweep, compatibleWires, thruSectionsCreate, thruSectionsAddWire, thruSectionsAddVertex, thruSectionsSetSmoothing, thruSectionsSetMaxDegree, thruSectionsSetContinuity, thruSectionsBuild, thruSectionsShape, thruSectionsRelease |
+| **Sweeps** | 24 | pipe sweep, pipeShell, pipeShellMultiSection, pipeShellWithTransition (deprecated, #503), pipeShellWithLaw, extrude, revolve, loft, loft(ruled+vertex), ruled, revolutionFromCurve, ruledShell, advancedEvolved, pipeSweep, compatibleWires, thruSectionsCreate, thruSectionsAddWire, thruSectionsAddVertex, thruSectionsSetSmoothing, thruSectionsSetMaxDegree, thruSectionsSetContinuity, thruSectionsBuild, thruSectionsShape, thruSectionsRelease |
 | **Booleans** | 12 | union (+), subtract (-), intersect (&), section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory |
 | **Modifications** | 33 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
 | **Transforms** | 10 | translate, rotate, scale, mirror, mirrorAboutPoint, mirrorAboutAxis, scaleAboutPoint, translated(from:to:), transformed(matrix:), gTransformed(matrix:) |
@@ -1071,10 +1071,13 @@ aliases the input.
 |-----------|------------|
 | `Shape.evolvedAdvanced(spine:profile:joinType:axeProf:solid:volume:tolerance:)` | `BRepOffsetAPI_MakeEvolved` (full constructor) |
 
-#### Pipe Shell Transition (v0.33.0)
+#### Pipe Shell (v0.33.0, unified in #503)
+Every `Add()`-based pipe sweep is one bridge function, `OCCTShapeCreatePipeShellMultiSection`.
 | Swift API | OCCT Class |
 |-----------|------------|
-| `Shape.pipeShellWithTransition(spine:profile:mode:transition:solid:)` | `BRepOffsetAPI_MakePipeShell.SetTransitionMode` |
+| `Shape.pipeShell(spine:profile:mode:transition:withContact:withCorrection:solid:)` | `BRepOffsetAPI_MakePipeShell` (one section) |
+| `Shape.pipeShellMultiSection(spine:profiles:mode:transition:withContact:withCorrection:solid:)` | `BRepOffsetAPI_MakePipeShell` (`SetMode` + `Add` per section + `SetTransitionMode`) |
+| `Shape.pipeShellWithTransition(spine:profile:mode:transition:solid:)`, **deprecated**, forwards to `pipeShell` | `BRepOffsetAPI_MakePipeShell.SetTransitionMode` |
 
 #### Face from Surface (v0.33.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,48 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### One pipe shell, and the sweep mode it was quietly discarding (#503)
+
+Four bridge functions each built their own single-profile `BRepOffsetAPI_MakePipeShell`, and each
+was `OCCTShapeCreatePipeShellMultiSection` with `profileCount = 1` and some arguments nailed shut.
+Confirmed rather than assumed: OCCT's `Add(profile)` is `Add(profile, false, false)` by default
+argument, and the two spellings produce byte-identical BREP. All four are gone. Every `Add()`-based
+pipe sweep is now one function, and the workaround comment `SetIsBuildHistory(false) // avoid SEGV
+on closed spine+profile` went from six pasted copies to one.
+
+Two of the four accepted an `OCCTPipeMode` they could not express. Their mode switch had a case for
+`FixedBinormal` and `Auxiliary` that fell through to `SetMode(Standard_False)`, plain Frenet, and
+returned the resulting solid as a success. At the C level that branch was unreachable from Swift,
+but the same defect had already surfaced in the public API:
+`Shape.pipeShellWithTransition(mode: .fixed(binormal:))` swept Frenet. Measured on an S-curve spine
+with a 5×3 rectangular section: 180.287 requested as a fixed binormal, where the fixed binormal
+builds 149.999. **A straight spine will not show this**: with no torsion the modes coincide
+exactly, which is how it survived a suite that only ever swept straight lines and gentle arcs.
+
+A mode whose own argument is unusable now fails the call instead of substituting a different mode:
+`.fixed(binormal: .zero)` and an auxiliary spine OCCT rejects both return `nil`.
+
+Three things became reachable that were not, all of which change the output rather than being
+inert knobs:
+
+| control | was | measured effect |
+|---|---|---|
+| `transition:` on a multi-section sweep | single-profile only | 113.05 / 256.65 / 240.53 for transformed / rightCorner / roundCorner |
+| `withContact:` / `withCorrection:` on a single-profile sweep | multi-section only | correction re-orthogonalises a tilted section: 205.208 → 251.327 |
+| `.auxiliary(spine:)` with one profile | untested, no coverage anywhere | builds, and differs from Frenet |
+
+**API changes.** `Shape.pipeShell` gains `transition:`, `withContact:` and `withCorrection:`;
+`Shape.pipeShellMultiSection` gains `transition:`. All default to the previous behaviour, so no call
+site changes. `Shape.pipeShellWithTransition` is **deprecated** (it is now `pipeShell` with one
+argument set) and forwards, honouring every mode. `Shape.pipeShellWithLaw` keeps its own entry
+point, since `SetLaw` is not an `Add()` sweep and OCCT's header warns against combining the two; it
+shares the build tail.
+
+Verified by capturing every pipe-shell call path's volume, area and face count before the change and
+re-running after: every figure is identical except `pipeShellWithTransition(mode: .fixed(...))`,
+which moved to the value its non-transition sibling already produced. The new tests were also run
+against a deliberately reintroduced fall-through: 4 of 8 fail, naming the substituted mode.
+
 #### Breaking: the junction analysers now say what they measured, and stop reporting what they did not (#495)
 
 **Source-breaking, in one place:** `Curve3D.ContinuityAnalysis` and `Surface.ContinuityAnalysis`

--- a/docs/guides/cookbook/lofting-and-sweeps.md
+++ b/docs/guides/cookbook/lofting-and-sweeps.md
@@ -160,9 +160,12 @@ guard stations.count == 3,
 ```
 
 `mode:` controls how each section is framed as it travels the spine (`.frenet`, `.correctedFrenet`,
-`.fixed(binormal:)`, `.auxiliary(spine:)`); `withContact` / `withCorrection` move and re-orthogonalise
-the profiles onto the spine. To scale a *single* profile by a law along the spine instead of supplying
-many, use `Shape.pipeShellWithLaw(spine:profile:law:)` — see [Helices & Springs](helices.md).
+`.fixed(binormal:)`, `.auxiliary(spine:)`); `transition:` controls what happens at corners in the
+spine (`.transformed`, `.rightCorner`, `.roundCorner`); `withContact` / `withCorrection` move and
+re-orthogonalise the profiles onto the spine. `Shape.pipeShell(spine:profile:...)` is the same call
+with one profile and takes the same arguments (#503). To scale a *single* profile by a law along the
+spine instead of supplying many, use `Shape.pipeShellWithLaw(spine:profile:law:)`. See
+[Helices & Springs](helices.md).
 
 <table>
 <tr>

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1091,7 +1091,7 @@ Useful for simplifying imported geometry or removing small features before analy
 
 ## Advanced / Variable-Section Pipe Sweep
 
-### `Shape.pipeShell(spine:profile:mode:solid:)`
+### `Shape.pipeShell(spine:profile:mode:transition:withContact:withCorrection:solid:)`
 
 Creates a pipe sweep with advanced orientation mode control.
 
@@ -1100,17 +1100,31 @@ public static func pipeShell(
     spine: Wire,
     profile: Wire,
     mode: PipeSweepMode = .frenet,
+    transition: PipeTransitionMode = .transformed,
+    withContact: Bool = false,
+    withCorrection: Bool = false,
     solid: Bool = true
 ) -> Shape?
 ```
+
+Since #503 this is the single-profile form of
+[`pipeShellMultiSection`](#shapepipeshellmultisectionspineprofilesmodetransitionwithcontactwithcorrectionsolid)
+and runs the same code, so it reaches the corner-transition and profile-placement controls that
+used to be split across three other spellings.
 
 - **Parameters:**
   - `spine` — path wire.
   - `profile` — profile wire to sweep.
   - `mode` — sweep orientation mode (`.frenet`, `.correctedFrenet`, `.fixed(binormal:)`, `.auxiliary(spine:)`).
+    A mode whose own argument is unusable (a zero-length binormal, or an auxiliary spine OCCT
+    rejects) returns `nil`. It is never swapped for a different mode, which is what the
+    pre-#503 bridge did.
+  - `transition`: corner transition style at spine discontinuities.
+  - `withContact`: if `true`, the profile is moved to touch the spine before sweeping.
+  - `withCorrection`: if `true`, the profile is rotated to stay orthogonal to the spine.
   - `solid` — `true` = solid result; `false` = shell.
 - **Returns:** Swept shape, or `nil` on failure.
-- **OCCT:** `BRepOffsetAPI_MakePipeShell`.
+- **OCCT:** `BRepOffsetAPI_MakePipeShell` (via `OCCTShapeCreatePipeShellMultiSection`).
 - **Example:**
   ```swift
   let spine = Wire.helix(origin: .zero, axis: SIMD3(0,0,1), radius: 10, pitch: 5, turns: 3)!
@@ -1120,11 +1134,19 @@ public static func pipeShell(
 
 ---
 
-### `Shape.pipeShellWithTransition(spine:profile:mode:transition:solid:)`
+### `Shape.pipeShellWithTransition(spine:profile:mode:transition:solid:)` (deprecated)
 
-Creates a pipe sweep with both orientation mode and spine-corner transition control.
+**Deprecated since #503.** Use
+[`pipeShell(spine:profile:mode:transition:...)`](#shapepipeshellspineprofilemodetransitionwithcontactwithcorrectionsolid),
+which takes the same `transition:` argument.
+
+This spelling accepted a full `PipeSweepMode` but reached a bridge function that could only
+express `.frenet` and `.correctedFrenet`. `.fixed(binormal:)` and `.auxiliary(spine:)` were swept
+as Frenet: a different solid from the one requested, returned as a success. It now forwards to
+`pipeShell` and honours every mode.
 
 ```swift
+@available(*, deprecated, renamed: "pipeShell(spine:profile:mode:transition:withContact:withCorrection:solid:)")
 public static func pipeShellWithTransition(
     spine: Wire,
     profile: Wire,
@@ -1134,13 +1156,7 @@ public static func pipeShellWithTransition(
 ) -> Shape?
 ```
 
-- **Parameters:**
-  - `spine`, `profile` — as for `pipeShell`.
-  - `mode` — orientation mode (`.frenet` or `.correctedFrenet`; other modes fall back to Frenet).
-  - `transition` — corner transition style.
-  - `solid` — produce a solid when `true`.
-- **Returns:** Swept shape, or `nil` on failure.
-- **OCCT:** `BRepOffsetAPI_MakePipeShell`.
+- **OCCT:** `BRepOffsetAPI_MakePipeShell` (via `OCCTShapeCreatePipeShellMultiSection`).
 
 ---
 
@@ -1165,32 +1181,36 @@ The law value defines how the profile scales along the spine: 1.0 = no scaling, 
 
 ---
 
-### `Shape.pipeShellMultiSection(spine:profiles:mode:withContact:withCorrection:solid:)`
+### `Shape.pipeShellMultiSection(spine:profiles:mode:transition:withContact:withCorrection:solid:)`
 
-Sweeps multiple profiles along a spine for a variable-section result.
+Sweeps one or more profiles along a spine for a variable-section result.
 
 ```swift
 public static func pipeShellMultiSection(
     spine: Wire,
     profiles: [Wire],
     mode: PipeSweepMode = .frenet,
+    transition: PipeTransitionMode = .transformed,
     withContact: Bool = false,
     withCorrection: Bool = false,
     solid: Bool = true
 ) -> Shape?
 ```
 
-Each profile is positioned in 3D at its station along the spine, and OCCT interpolates a smooth solid that passes through every section. Supports all `PipeSweepMode` cases, including `.auxiliary(spine:)` for twist control.
+Each profile is positioned in 3D at its station along the spine, and OCCT interpolates a smooth solid that passes through every section. Supports all `PipeSweepMode` cases, including `.auxiliary(spine:)` for twist control. Every `MakePipeShell` sweep in OCCTSwift is this call; `pipeShell` is this function with one profile (#503).
 
 - **Parameters:**
   - `spine` — path wire.
   - `profiles` — section wires, each pre-positioned at its station (at least one required).
-  - `mode` — orientation mode.
+  - `mode`: orientation mode. A mode whose own argument is unusable returns `nil` rather than
+    being swapped for another mode.
+  - `transition`: corner transition style at spine discontinuities. Reaches a multi-section
+    sweep since #503; before that only the single-profile spelling could set it.
   - `withContact` — if `true`, each profile is moved to touch the spine.
   - `withCorrection` — if `true`, each profile is rotated to stay orthogonal to the spine.
   - `solid` — produce a solid when `true`.
 - **Returns:** Swept shape, or `nil` on failure.
-- **OCCT:** `BRepOffsetAPI_MakePipeShell` multi-profile form (via `OCCTShapeCreatePipeShellMultiSection`).
+- **OCCT:** `BRepOffsetAPI_MakePipeShell` (via `OCCTShapeCreatePipeShellMultiSection`).
 
 ---
 


### PR DESCRIPTION
Closes #503. Pass 1b of the #377 duplication audit, so this targets `refactor/381-pass1b`, not `main`.

## What the finding was, and what it turned out to be

The issue found three single-profile pipe-shell bridge functions that were `OCCTShapeCreatePipeShellMultiSection` with `profileCount = 1`, plus a fourth entry point (`...WithTransition`) sharing the same copy-pasted SEGV workaround. It also flagged a dead branch: `OCCTShapeCreatePipeShell`'s mode switch silently fell through `FixedBinormal`/`Auxiliary` to plain Frenet, unreachable today only because Swift routed those cases elsewhere.

**The dead branch was not dead.** The same defect was already live in the public Swift API one layer up: `Shape.pipeShellWithTransition` accepted a full `PipeSweepMode` but mapped it to an `Int32` that could only carry Frenet and corrected Frenet, so `.fixed(binormal:)` and `.auxiliary(spine:)` swept Frenet and returned the wrong solid as a success.

Measured on an S-curve spine with a 5x3 rectangular section:

| call | volume before | volume after |
|---|---|---|
| `pipeShell(mode: .fixed(0,0,1))` | 149.9998 | 149.9998 |
| `pipeShellWithTransition(mode: .fixed(0,0,1))` | **180.2867** (Frenet) | **149.9998** |
| `pipeShellWithTransition(mode: .frenet)` | 180.2867 | 180.2867 |

A straight spine will not show this. With no torsion the modes coincide exactly, which is how it survived a suite that only ever swept straight lines and gentle arcs. Same lesson as #430: probe both geometries.

## Changes

**Bridge.** `OCCTShapeCreatePipeShell`, `...WithBinormal`, `...WithAuxSpine` and `...WithTransition` are deleted. `OCCTShapeCreatePipeShellMultiSection` is the only `Add()`-based pipe shell and gains a `transitionMode` parameter. Two file-local helpers carry the shared skeleton: `occtPipeShellSetMode` (one orientation dispatch, which fails rather than substituting) and `occtPipeShellFinish` (build, solid, and the sole remaining copy of the `SetIsBuildHistory(false)` workaround, down from six). `OCCTShapeCreatePipeShellWithLaw` keeps its own entry point, since `SetLaw` is not an `Add()` sweep and OCCT's header warns against combining the two, but shares the build tail.

**Swift.** `Shape.pipeShell` gains `transition:`, `withContact:`, `withCorrection:` and delegates to `pipeShellMultiSection`. `Shape.pipeShellMultiSection` gains `transition:`. Every new parameter defaults to the previous behaviour, so no existing call site changes. `Shape.pipeShellWithTransition` is deprecated (it is now `pipeShell` with one argument set) and forwards, honouring every mode.

**Reach gained**, all measured rather than assumed inert:

| control | was | effect |
|---|---|---|
| `transition:` on a multi-section sweep | single-profile only | 113.05 / 256.65 / 240.53 for transformed / rightCorner / roundCorner |
| `withContact:` / `withCorrection:` on a single-profile sweep | multi-section only | correction re-orthogonalises a tilted section, 205.208 to 251.327 |
| `.auxiliary(spine:)` with one profile | no test anywhere | builds, and differs from Frenet |

A mode whose own argument is unusable now returns nil instead of another mode's solid: `.fixed(binormal: .zero)` and an auxiliary spine OCCT rejects both fail the call.

## Verification

- **Byte-for-byte before/after.** Every pipe-shell call path's volume, area and face count was recorded on the pre-change build and re-run after. Every figure is identical except `pipeShellWithTransition(mode: .fixed(...))`, which moved to the value its non-transition sibling already produced.
- **`Add(profile)` really is `Add(profile, false, false)`.** Ground-truth C++ against the pinned xcframework: identical BREP hash, not just an argument-default reading.
- **The new tests catch the old behaviour.** The fall-through was deliberately reintroduced in `occtPipeShellSetMode` and the suite re-run: 4 of 8 fail, naming the substituted mode. Restored and green.
- **Full suite:** 4768 tests, 1339 suites, passing. No new deprecation warnings (`@available` markers on the two tests that exercise the deprecated forwarder on purpose).

## Docs

`docs/CHANGELOG.md` (Unreleased), `docs/API_REFERENCE.md` (Sweeps row and the pipe-shell mapping table), `docs/reference/Shape-Features.md`, `docs/guides/cookbook/lofting-and-sweeps.md`, plus the bridge header's cross-reference index entry for `BRepOffsetAPI_MakePipeShell`, which named a symbol prefix rather than the functions. The reference page had documented the bug as intended behaviour ("other modes fall back to Frenet"); that is corrected.

`Sweeps` moved 23 to 24 because `pipeShellMultiSection` was never listed, so the illustrative category sum and the README row moved with it. The derived `Total` (4285) is unchanged and `Scripts/count-operations.py` still reports both files in sync.

**Noticed, not fixed:** `Shape.helicalSweep` is also missing from the `API_REFERENCE.md` category rows. Unrelated to this issue, so left alone rather than folded in silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)