### PR TITLE
fix(#501): the orphaned quasi-uniform duplicate, and the buffer overflow it was hiding

### DIFF
--- a/Scripts/repro/501-quasiuniform-buffer-overflow/README.md
+++ b/Scripts/repro/501-quasiuniform-buffer-overflow/README.md
@@ -1,0 +1,129 @@
+# OCCTSwift#501 reproducer: GCPnts arc-length samplers overflow the caller's buffer
+
+Standalone reproducer for the heap write past the end of a caller-supplied buffer in four bridge
+functions that discretize a curve by arc length. Found while resolving #501's orphaned duplicate:
+the two spellings of quasi-uniform curve sampling disagreed about whether the output buffer needed a
+bound, and measuring which one was right showed that the one actually in service was wrong.
+
+## Root cause
+
+`GCPnts_UniformAbscissa::initialize` sizes its own parameter array at `theNbPoints + 5`:
+
+```cpp
+const int aSize = theNbPoints + 5;
+myParams = new NCollection_HArray1<double>(1, aSize);
+```
+
+and both fill helpers walk until they reach the end parameter *or* run out of array
+(`isNotDone = ... && (anIndex + 1 <= theParameters.Length())`), so `NbPoints()` is bounded by
+`nbPoints + 5`, not by `nbPoints`. `GCPnts_QuasiUniformAbscissa` inherits this for every curve that
+is neither Bezier nor BSpline, because it forwards to `GCPnts_UniformAbscissa` for those; only its
+Bezier/BSpline branch sets `myNbPoints = theNbPoints` outright.
+
+Four bridge functions were handed a buffer sized from the count the caller asked for and then filled
+it with `NbPoints()` values:
+
+| bridge function | buffer the caller allocates | Swift entry point |
+|---|---|---|
+| `OCCTCurve3DQuasiUniformAbscissa` | `count` doubles | `Curve3D.quasiUniformParameters(count:)` |
+| `OCCTCurve3DDrawUniform` | `pointCount * 3` doubles | `Curve3D.drawUniform(pointCount:)` |
+| `OCCTCurve2DDrawUniform` | `pointCount * 2` doubles | `Curve2D.drawUniform(pointCount:)` |
+| `sampleAdaptorUniform` | `count * 3` doubles | `CompCurve`/`EdgeCurve` `sampleUniform(count:)` |
+
+## Triggering geometry
+
+The overshoot is a rounding effect, so it needs a curve whose arc-length walk lands outside the
+sampler's epsilon of the end parameter. An **ellipse with major radius 1e6 and minor radius 1e-3**
+does it: the walk stops ~1.6e-8 in parameter short of `2*pi`, against an epsilon of
+`Resolution(1e-7)` which is about 1e-13 there, so the sampler takes one more step and snaps it to
+the end. 22 of the first 59 point counts overshoot by exactly one.
+
+Well-conditioned geometry does not reproduce it. A line, a circle at any radius from 1e-6 to 1e7, a
+5 x 2 ellipse, a hyperbola, a parabola, a 4-pole Bezier, a 2-pole Bezier, an 8-point BSpline fit, a
+40-point BSpline with uneven knots, a rational Bezier with weights from 1e-3 to 1e4, an offset of a
+circle, an offset of a BSpline and a trimmed circle were all measured across counts 2..200: zero
+excess. Which is why this survived from v0.31.0.
+
+## What the caller sees
+
+Not the same thing at every entry point, which is worth knowing when reading old bug reports:
+
+- `Curve3D.drawUniform(pointCount:)` and `Curve2D.drawUniform(pointCount:)` **trap**. Their wrappers
+  unpack the buffer by index using the count the bridge returned, so `pointCount + 1` reads past the
+  end of the Swift `Array` and hits its bounds check: `Fatal error: Index out of range`. Confirmed
+  by running the new tests against the unfixed bridge: the test process dies at
+  `ContiguousArrayBuffer.swift:692`.
+- `Curve3D.quasiUniformParameters(count:)` is silent. It returns `Array(params.prefix(n))`, and
+  `prefix` clamps to the array's own count, so the surplus never surfaces. Only the heap write
+  does.
+- `Edge.quasiUniformParameters(count:)` is silent and wrong: it clamps in the bridge, so it is
+  memory-safe, but it drops the end of the edge (below).
+
+## Clamping alone is not the fix
+
+The surplus point *is* the end of the curve: the walk's final step always sets the end parameter.
+Truncating the tail therefore leaves the distribution stopping short of the curve:
+
+```
+curve parameter range: [0, 6.2831853071795862]
+returned 5 params: 0  1.9106332362490186  4.3725520709305679  6.2831852916099189  6.2831853071795862
+                                                              ^ what a count-clamped caller sees
+                                                                as its last parameter, 1.56e-08
+                                                                short of the end
+```
+
+`OCCTGCPntsQuasiUniform` was the one member of the family that already clamped, and it had exactly
+this defect, silently, for every overshooting call. The fix keeps the first `capacity - 1` samples
+and the sampler's own last one, via `occtSamplerKept` / `occtSamplerIndex` in
+`Sources/OCCTBridge/src/OCCTBridge_Internal.h`.
+
+## The degenerate-count SIGSEGV next door
+
+Both samplers document `nbPoints >= 2` and enforce it with `Standard_ConstructionError_Raise_if`,
+which the pinned Release kernel compiles out (`No_Exception`, see #487). Measured with
+`nbPoints == 0`:
+
+| curve | `GCPnts_QuasiUniformAbscissa` | `GCPnts_UniformAbscissa` |
+|---|---|---|
+| line, circle | `IsDone()`, 1 point | `IsDone()`, 1 point |
+| ellipse | `IsDone()`, **5 points** | `IsDone()`, 5 points |
+| 4-pole Bezier | **SIGSEGV** | `IsDone()`, 5 points |
+| all-coincident-pole Bezier | **SIGSEGV** | not done |
+| 8-point BSpline fit | **SIGSEGV** | `IsDone()`, 5 points |
+
+The crash is the Bezier/BSpline branch building `new NCollection_HArray1<double>(1, 0)`, an empty
+range, and then calling `SetValue(1, theU1)` on it. That bounds check is a `Raise_if` too, so it is
+also compiled out, and the store lands out of bounds. Uncatchable, same class as #263/#310/#317/#318.
+
+No bridge entry point reached it: every quasi-uniform caller already rejected `nbPoints < 2` or
+`nbPoints <= 0`. But `OCCTUniformAbscissaByCount` and `OCCTUniformAbscissaByCountRange` had no count
+precondition at all, so `Shape.uniformAbscissa(pointCount: 0)` returned five bogus parameters for a
+request of zero. `occtValidSampleCount` is now applied at all of them.
+
+## Running it
+
+```bash
+clang++ -std=c++17 -ObjC++ -w -O0 \
+  -ISources/OCCTBridge/include -ISources/OCCTBridge/src \
+  -ILibraries/OCCT.xcframework/macos-arm64/Headers \
+  -LLibraries/OCCT.xcframework/macos-arm64 \
+  Scripts/repro/501-quasiuniform-buffer-overflow/repro_501.mm \
+  Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm \
+  Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ -o /tmp/repro_501
+/tmp/repro_501
+```
+
+It compiles the shipped `.mm` files, so it measures the real bridge functions rather than copies of
+them. Each call writes into a buffer followed by sentinel doubles; a changed sentinel is a real
+write past the end. Exit status is 1 while any call overflows.
+
+Before: 48 overflowing calls (16 counts x 3 functions), plus `OCCTGCPntsQuasiUniform` reporting a
+last parameter short of the edge's end on all 16.
+After: `PASS: 0 overflowing calls`, and the end parameter kept everywhere.
+
+## Not examined
+
+`OCCTUniformAbscissaByDistance` / `OCCTUniformAbscissaByDistanceRange` take an arc-length step rather
+than a count, so the clamp does not apply to them and they were left alone. Their behaviour on a
+zero or negative distance was not measured.

--- a/Scripts/repro/501-quasiuniform-buffer-overflow/repro_501.mm
+++ b/Scripts/repro/501-quasiuniform-buffer-overflow/repro_501.mm
@@ -1,0 +1,146 @@
+// OCCTSwift#501 reproducer: GCPnts arc-length samplers write past the caller's buffer.
+//
+// Every bridge function here is handed a buffer sized from the *requested* point count and then
+// fills it with `sampler.NbPoints()` values. GCPnts_UniformAbscissa sizes its own parameter array
+// at `nbPoints + 5` and lets the arc-length walk run to that array's length, so NbPoints() can come
+// back larger than the request, and GCPnts_QuasiUniformAbscissa forwards to it for every curve
+// that is neither Bezier nor BSpline.
+//
+// Each call below writes into a buffer followed by sentinel doubles; a changed sentinel is a real
+// heap write past the end. Section C covers the degenerate counts that OCCT's own `>= 2`
+// precondition is supposed to reject but cannot, because the Release kernel compiles
+// `Standard_ConstructionError_Raise_if` out (No_Exception).
+//
+// Build (from the repo root):
+//   clang++ -std=c++17 -ObjC++ -w -O0 \
+//     -ISources/OCCTBridge/include -ISources/OCCTBridge/src \
+//     -ILibraries/OCCT.xcframework/macos-arm64/Headers \
+//     -LLibraries/OCCT.xcframework/macos-arm64 \
+//     Scripts/repro/501-quasiuniform-buffer-overflow/repro_501.mm \
+//     Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm \
+//     Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ -o /tmp/repro_501
+//   /tmp/repro_501
+//
+// Exit status is 1 while any call still overflows, 0 once they all respect the buffer.
+
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <string>
+
+#include "OCCTBridge.h"
+#include "OCCTBridge_Internal.h"
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax22d.hxx>
+
+// A curve whose arc-length walk lands just short of the end parameter, so the sampler takes one
+// extra step and snaps to the end: major radius 1e6, minor radius 1e-3. The gap that triggers it
+// is ~1.6e-8 in parameter, far above the sampler's own epsilon (Resolution(1e-7) ~ 1e-13 here).
+static const double kMajor = 1e6;
+static const double kMinor = 1e-3;
+
+static const double kSentinel = -1234.5678;
+static int gFailures = 0;
+
+namespace {
+
+struct Guarded {
+    std::vector<double> buf;
+    int32_t             capacity;   // slots the caller is allowed to write
+
+    explicit Guarded(int32_t cap) : buf(cap + 8, kSentinel), capacity(cap) {
+        for (int32_t i = 0; i < cap; ++i) buf[i] = 0.0;
+    }
+    double* data() { return buf.data(); }
+    int clobbered() const {
+        int n = 0;
+        for (size_t i = capacity; i < buf.size(); ++i) if (buf[i] != kSentinel) ++n;
+        return n;
+    }
+};
+
+void report(const char* site, int32_t count, int32_t returned, int clobbered,
+            double lastWritten, double curveEnd) {
+    const bool overflowed = clobbered > 0;
+    const bool shortOfEnd = !overflowed && std::isfinite(curveEnd)
+                            && std::abs(lastWritten - curveEnd) > 1e-12;
+    if (overflowed) ++gFailures;
+    printf("  %-34s count=%-3d returned=%-3d guard=%d%s%s\n",
+           site, count, returned, clobbered,
+           overflowed ? "   OVERFLOW" : "",
+           shortOfEnd ? "   (last param short of the curve end)" : "");
+}
+
+}  // namespace
+
+int main() {
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
+    gp_Ax2   ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    gp_Ax22d ax2(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+
+    Handle(Geom_Ellipse)   e3 = new Geom_Ellipse(ax3, kMajor, kMinor);
+    Handle(Geom2d_Ellipse) e2 = new Geom2d_Ellipse(ax2, kMajor, kMinor);
+
+    OCCTCurve3D  curve3d(e3);
+    OCCTCurve2D  curve2d(e2);
+    OCCTEdge     edge(BRepBuilderAPI_MakeEdge(e3, 0.0, 2 * M_PI).Edge());
+    const double uEnd = 2 * M_PI;
+
+    // Counts measured to make the sampler overshoot on this ellipse.
+    const int counts[] = {4, 5, 8, 12, 14, 18, 20, 22, 25, 26, 31, 33, 34, 35, 39, 40};
+
+    printf("=== A. OCCTCurve3DQuasiUniformAbscissa: buffer holds `nbPoints` doubles ===\n");
+    for (int n : counts) {
+        Guarded g(n);
+        int32_t got = OCCTCurve3DQuasiUniformAbscissa(&curve3d, n, g.data());
+        report("OCCTCurve3DQuasiUniformAbscissa", n, got, g.clobbered(),
+               got > 0 ? g.buf[std::min(got, n) - 1] : 0.0, uEnd);
+    }
+
+    printf("\n=== B. OCCTCurve3DDrawUniform: buffer holds `pointCount * 3` doubles ===\n");
+    for (int n : counts) {
+        Guarded g(n * 3);
+        int32_t got = OCCTCurve3DDrawUniform(&curve3d, n, g.data());
+        report("OCCTCurve3DDrawUniform", n, got, g.clobbered(), NAN, NAN);
+    }
+
+    printf("\n=== C. OCCTCurve2DDrawUniform: buffer holds `pointCount * 2` doubles ===\n");
+    for (int n : counts) {
+        Guarded g(n * 2);
+        int32_t got = OCCTCurve2DDrawUniform(&curve2d, n, g.data());
+        report("OCCTCurve2DDrawUniform", n, got, g.clobbered(), NAN, NAN);
+    }
+
+    printf("\n=== D. OCCTGCPntsQuasiUniform: already clamps to maxParams ===\n");
+    for (int n : counts) {
+        Guarded g(n);
+        int32_t got = OCCTGCPntsQuasiUniform(&edge, n, g.data(), n);
+        report("OCCTGCPntsQuasiUniform", n, got, g.clobbered(),
+               got > 0 ? g.buf[got - 1] : 0.0, uEnd);
+    }
+
+    printf("\n=== E. degenerate counts (OCCT's own `>= 2` precondition is compiled out) ===\n");
+    printf("     GCPnts_QuasiUniformAbscissa(bezier_or_bspline, 0) SIGSEGVs inside OCCT on a\n"
+           "     (1, 0)-ranged NCollection_HArray1; every entry point must reject it itself.\n");
+    for (int n : {0, 1}) {
+        Guarded a(std::max(n, 1));
+        printf("  OCCTCurve3DQuasiUniformAbscissa    count=%d returned=%d\n", n,
+               OCCTCurve3DQuasiUniformAbscissa(&curve3d, n, a.data()));
+        Guarded b(std::max(n, 1) * 3);
+        printf("  OCCTCurve3DDrawUniform            count=%d returned=%d\n", n,
+               OCCTCurve3DDrawUniform(&curve3d, n, b.data()));
+        Guarded c(std::max(n, 1) * 2);
+        printf("  OCCTCurve2DDrawUniform            count=%d returned=%d\n", n,
+               OCCTCurve2DDrawUniform(&curve2d, n, c.data()));
+    }
+
+    printf("\n%s: %d overflowing call%s\n", gFailures ? "FAIL" : "PASS",
+           gFailures, gFailures == 1 ? "" : "s");
+    return gFailures ? 1 : 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -158,7 +158,7 @@
 // BRepFilletAPI_MakeFillet2d          → OCCTShapeFillet2D*, OCCTShapeChamfer2D*
 //
 // --- BRepGProp ---
-// BRepGProp                           → OCCTShapeVolume, OCCTShapeSurfaceArea, OCCTShapeGetCenterOfMass
+// BRepGProp                           → OCCTShapeGetVolume, OCCTShapeGetSurfaceArea, OCCTShapeGetCenterOfMass
 // BRepGProp_Face                      → OCCTFaceGProp*
 // BRepGProp_MeshCinert                → OCCTMeshCinert*
 // BRepGProp_MeshProps                 → OCCTMeshProps*
@@ -180,8 +180,9 @@
 //
 // --- BRepOffset ---
 // BRepOffset_Analyse                  → OCCTEdgeGetConvexity
+// BRepOffset_MakeSimpleOffset         → OCCTShapeSimpleOffset
 // BRepOffset_Offset                   → OCCTBRepOffsetFace
-// BRepOffset_SimpleOffset             → OCCTShapeSimpleOffset
+// BRepOffset_SimpleOffset             → OCCTBRepOffsetSimpleOffset
 //
 // --- BRepOffsetAPI ---
 // BRepOffsetAPI_DraftAngle            → OCCTShapeDraft
@@ -210,7 +211,7 @@
 // BRepPrimAPI_MakeWedge               → OCCTShapeCreateWedge
 //
 // --- BRepTools ---
-// BRepTools_Modifier                  → OCCTShapeNurbsConvertViaModifier, OCCTShapeSimpleOffset
+// BRepTools_Modifier                  → OCCTBRepToolsModifierNurbsConvert, OCCTBRepOffsetSimpleOffset, OCCTShapeCopyModification, OCCTShapeTrsfModification, OCCTShapeGTrsfModification, OCCTShapeDraftModification
 // BRepTools_ReShape                   → OCCTShapeReplaceSubShape*
 // BRepTools_Substitution              → OCCTShapeSubstituted
 // BRepTools_WireExplorer              → OCCTWireGetOrderedEdge*
@@ -229,6 +230,9 @@
 // Contap_ContAna                      → OCCTContapSphereDir, OCCTContapCylinderDir, OCCTContapSphereEye
 // Contap_Contour                      → OCCTContapContour*
 //
+// --- CPnts ---
+// CPnts_UniformDeflection             → OCCTCPntsUniformDeflection*
+//
 // --- GC ---
 // GC_MakeArcOfCircle                  → OCCTWireCreateArc, OCCTWireCreateArc3Points
 // GC_MakeCircle                       → OCCTWireCreateCircle
@@ -243,11 +247,12 @@
 // GC_MakeLine2d                       → OCCTGCE2dMakeLine* (bridge symbols retain GCE2d historical name)
 //
 // --- GCPnts ---
-// GCPnts_AbscissaPoint                → OCCTCurve2DParameterAtLength
-// GCPnts_QuasiUniformAbscissa         → OCCTCurve3DQuasiUniformParams
+// GCPnts_AbscissaPoint                → OCCTCurve3DArcLength*, OCCTCurve3DLength, OCCTCurve3DGetLength*, OCCTCurve3DParameterAtLength, OCCTCurve2DLength, OCCTCurve2DGetLength*, OCCTCurve2DParameterAtLength, OCCTEdgeArcLength*, OCCTEdgeParameterAt*, OCCTWireGetLength
+// GCPnts_QuasiUniformAbscissa         → OCCTCurve3DQuasiUniformAbscissa, OCCTGCPntsQuasiUniform
 // GCPnts_QuasiUniformDeflection       → OCCTCurve3DQuasiUniformDeflection
-// GCPnts_UniformAbscissa              → OCCTCPntsUniformDeflection*
-// GCPnts_UniformDeflection            → OCCTCPntsUniformDeflection*
+// GCPnts_TangentialDeflection         → OCCTGCPntsTangentialDeflection*, OCCTCurve3DDrawAdaptive, OCCTCurve2DDrawAdaptive
+// GCPnts_UniformAbscissa              → OCCTUniformAbscissaBy*, OCCTCurve3DDrawUniform, OCCTCurve2DDrawUniform, OCCTCompCurveSampleUniform, OCCTEdgeCurveSampleUniform
+// GCPnts_UniformDeflection            → OCCTCurve3DDrawDeflection, OCCTCurve2DDrawDeflection
 //
 // --- GccAna ---
 // GccAna_Circ2d2TanOn                 → OCCTGccAnaCirc2d2TanOn*
@@ -460,7 +465,7 @@
 // --- ShapeCustom ---
 // ShapeCustom_BSplineRestriction      → OCCTShapeBSplineRestriction*
 // ShapeCustom_Curve2d                 → OCCTCurve2DIsLinear, OCCTCurve2DConvertToLine, OCCTCurve2DSimplifyBSpline
-// ShapeCustom_DirectModification      → OCCTShapeDirectModification
+// ShapeCustom_DirectModification      → OCCTShapeCustomDirectModification
 // ShapeCustom_Surface                 → OCCTSurfaceConvertToAnalytical, OCCTSurfaceConvertToPeriodic, OCCTSurfaceConversionGap
 // ShapeCustom_SweptToElementary       → OCCTShapeSweptToElementary
 // ShapeCustom_TrsfModification        → OCCTShapeTrsfModificationScale
@@ -4322,9 +4327,11 @@ bool OCCTDocumentGetLengthUnit(OCCTDocumentRef doc, double* unitScale, char* uni
 
 /// Sample curve parameters using quasi-uniform abscissa distribution.
 /// @param curve The curve to sample
-/// @param nbPoints Desired number of sample points
+/// @param nbPoints Desired number of sample points; must be >= 2, else 0 is returned
 /// @param outParams Output array for parameter values (must hold nbPoints doubles)
-/// @return Actual number of parameters written, or 0 on failure
+/// @return Actual number of parameters written, never more than nbPoints, or 0 on failure.
+///         GCPnts can compute one or more points beyond the request; the surplus is dropped, but
+///         the last slot still gets the curve's last parameter so the result spans the curve (#501).
 int32_t OCCTCurve3DQuasiUniformAbscissa(OCCTCurve3DRef curve, int32_t nbPoints, double* outParams);
 
 
@@ -10194,17 +10201,19 @@ OCCTApproxSurfaceResult OCCTGeomConvertApproxSurface(OCCTSurfaceRef _Nonnull sur
 // MARK: - GCPnts_QuasiUniformAbscissa
 
 /// Compute quasi-uniform parameter distribution on an edge curve.
-/// Returns parameter count, fills params array.
+/// The Curve3D form of this is OCCTCurve3DQuasiUniformAbscissa (v0.31.0), not a second function
+/// here. The one that used to be, OCCTGCPntsQuasiUniformCurve, was a never-called re-wrap (#501).
+/// @param edge The edge to sample
+/// @param nbPoints Desired number of sample points; must be >= 2, else 0 is returned
+/// @param params Output array for parameter values (must hold maxParams doubles)
+/// @param maxParams Capacity of params. The sampler can report more points than nbPoints, so this
+///        is a real bound, not a formality; when it bites, the last slot still gets the edge's last
+///        parameter so the distribution spans the whole edge.
+/// @return Actual number of parameters written, or 0 on failure
 int32_t OCCTGCPntsQuasiUniform(OCCTEdgeRef _Nonnull edge,
                                 int32_t nbPoints,
                                 double* _Nonnull params,
                                 int32_t maxParams);
-
-/// Quasi-uniform sampling on a Curve3D.
-int32_t OCCTGCPntsQuasiUniformCurve(OCCTCurve3DRef _Nonnull curve,
-                                      int32_t nbPoints,
-                                      double* _Nonnull params,
-                                      int32_t maxParams);
 
 // MARK: - GCPnts_TangentialDeflection
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -821,14 +821,17 @@ int32_t OCCTCurve3DDrawAdaptive(OCCTCurve3DRef c,
 
 int32_t OCCTCurve3DDrawUniform(OCCTCurve3DRef c,
                                 int32_t pointCount, double* outXYZ) {
-    if (!c || c->curve.IsNull() || !outXYZ || pointCount <= 0) return 0;
+    // outXYZ holds pointCount triples, which is not what the sampler is bounded by. See
+    // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
+    if (!c || c->curve.IsNull() || !outXYZ || !occtValidSampleCount(pointCount)) return 0;
     try {
         GeomAdaptor_Curve adaptor(c->curve);
         GCPnts_UniformAbscissa sampler(adaptor, pointCount);
         if (!sampler.IsDone()) return 0;
-        int32_t n = sampler.NbPoints();
+        int32_t total = sampler.NbPoints();
+        int32_t n = occtSamplerKept(total, pointCount);
         for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(i + 1);
+            double u = sampler.Parameter(occtSamplerIndex(i, n, total));
             gp_Pnt p = adaptor.Value(u);
             outXYZ[i*3] = p.X();
             outXYZ[i*3+1] = p.Y();
@@ -1088,14 +1091,17 @@ int32_t OCCTCurve3DExtrema(OCCTCurve3DRef c1, OCCTCurve3DRef c2, OCCTCurveExtrem
 #include <GCPnts_QuasiUniformAbscissa.hxx>
 
 int32_t OCCTCurve3DQuasiUniformAbscissa(OCCTCurve3DRef curve, int32_t nbPoints, double* outParams) {
-    if (!curve || curve->curve.IsNull() || !outParams || nbPoints <= 0) return 0;
+    // outParams holds nbPoints doubles, which is not what the sampler is bounded by. See
+    // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
+    if (!curve || curve->curve.IsNull() || !outParams || !occtValidSampleCount(nbPoints)) return 0;
     try {
         GeomAdaptor_Curve adaptor(curve->curve);
         GCPnts_QuasiUniformAbscissa sampler(adaptor, nbPoints);
         if (!sampler.IsDone()) return 0;
-        int32_t n = sampler.NbPoints();
+        int32_t total = sampler.NbPoints();
+        int32_t n = occtSamplerKept(total, nbPoints);
         for (int32_t i = 0; i < n; i++) {
-            outParams[i] = sampler.Parameter(i + 1);
+            outParams[i] = sampler.Parameter(occtSamplerIndex(i, n, total));
         }
         return n;
     } catch (...) {
@@ -1656,14 +1662,17 @@ int32_t OCCTGCPntsQuasiUniform(OCCTEdgeRef _Nonnull edge,
                                 int32_t nbPoints,
                                 double* _Nonnull params,
                                 int32_t maxParams) {
-    if (!edge || nbPoints < 2) return 0;
+    if (!edge || !occtValidSampleCount(nbPoints)) return 0;
     try {
         BRepAdaptor_Curve curve(TopoDS::Edge(edge->edge));
         GCPnts_QuasiUniformAbscissa sampler(curve, nbPoints);
         if (!sampler.IsDone()) return 0;
-        int32_t count = std::min((int32_t)sampler.NbPoints(), maxParams);
+        // This one always clamped, but to the tail, so whenever the sampler overshot the result
+        // stopped short of the edge's last parameter. occtSamplerIndex keeps the end (#501).
+        int32_t total = sampler.NbPoints();
+        int32_t count = occtSamplerKept(total, maxParams);
         for (int32_t i = 0; i < count; i++) {
-            params[i] = sampler.Parameter(i + 1); // 1-based
+            params[i] = sampler.Parameter(occtSamplerIndex(i, count, total)); // 1-based
         }
         return count;
     } catch (...) {
@@ -1671,24 +1680,11 @@ int32_t OCCTGCPntsQuasiUniform(OCCTEdgeRef _Nonnull edge,
     }
 }
 
-int32_t OCCTGCPntsQuasiUniformCurve(OCCTCurve3DRef _Nonnull curve,
-                                      int32_t nbPoints,
-                                      double* _Nonnull params,
-                                      int32_t maxParams) {
-    if (!curve || nbPoints < 2) return 0;
-    try {
-        GeomAdaptor_Curve adaptor(curve->curve);
-        GCPnts_QuasiUniformAbscissa sampler(adaptor, nbPoints);
-        if (!sampler.IsDone()) return 0;
-        int32_t count = std::min((int32_t)sampler.NbPoints(), maxParams);
-        for (int32_t i = 0; i < count; i++) {
-            params[i] = sampler.Parameter(i + 1);
-        }
-        return count;
-    } catch (...) {
-        return 0;
-    }
-}
+// A second Curve3D-based spelling, OCCTGCPntsQuasiUniformCurve, lived here from v0.75 until #501.
+// It was byte-for-byte the same sampling as OCCTCurve3DQuasiUniformAbscissa (v0.31.0) and never
+// had a caller in Swift or in the tests; the cross-reference index that should have caught the
+// re-wrap named a function that does not exist. It is gone; its maxParams bound, the one thing the
+// older spelling lacked, is now folded into that spelling.
 
 // --- GCPnts_TangentialDeflection ---
 
@@ -3000,8 +2996,12 @@ OCCTCurve3DRef OCCTGCMakeHyperbola3Points(double x1, double y1, double z1,
 #include <GCPnts_UniformAbscissa.hxx>
 #include <BRepAdaptor_Curve.hxx>
 
+// These four are called twice by their Swift wrappers (once with params == nullptr to learn the
+// count, then again with a buffer of exactly that size), so the sampler's own overshoot is already
+// accounted for and there is nothing to clamp. The count preconditions still have to be applied
+// here: without them nbPoints == 0 reported IsDone() with five parameters (#501).
 int32_t OCCTUniformAbscissaByCount(OCCTShapeRef edge, int32_t nbPoints, double* params) {
-    if (!edge) return 0;
+    if (!edge || !occtValidSampleCount(nbPoints)) return 0;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
         GCPnts_UniformAbscissa ua(ac, nbPoints);
@@ -3034,7 +3034,7 @@ int32_t OCCTUniformAbscissaByDistance(OCCTShapeRef edge, double abscissa, double
 
 int32_t OCCTUniformAbscissaByCountRange(OCCTShapeRef edge, int32_t nbPoints,
                                          double u1, double u2, double* params) {
-    if (!edge) return 0;
+    if (!edge || !occtValidSampleCount(nbPoints)) return 0;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
         GCPnts_UniformAbscissa ua(ac, nbPoints, u1, u2);
@@ -5611,15 +5611,17 @@ static bool adaptorParamAtAbscissa(Adaptor3d_Curve& a, double s, double* outPara
 // N points spaced equally by arc length along the curve. outXYZ must hold count*3 doubles;
 // returns the number of points actually written.
 static int32_t sampleAdaptorUniform(Adaptor3d_Curve& a, int32_t count, double* outXYZ) {
-    if (count < 2 || !outXYZ) return 0;
+    if (!occtValidSampleCount(count) || !outXYZ) return 0;
     GCPnts_UniformAbscissa sampler(a, count);
     if (!sampler.IsDone()) return 0;
-    int32_t n = sampler.NbPoints();
-    for (int32_t i = 1; i <= n; ++i) {
-        gp_Pnt p = a.Value(sampler.Parameter(i));
-        outXYZ[(i - 1) * 3 + 0] = p.X();
-        outXYZ[(i - 1) * 3 + 1] = p.Y();
-        outXYZ[(i - 1) * 3 + 2] = p.Z();
+    // The sampler is not bounded by `count`. See occtSamplerKept/occtSamplerIndex (#501).
+    int32_t total = sampler.NbPoints();
+    int32_t n = occtSamplerKept(total, count);
+    for (int32_t i = 0; i < n; ++i) {
+        gp_Pnt p = a.Value(sampler.Parameter(occtSamplerIndex(i, n, total)));
+        outXYZ[i * 3 + 0] = p.X();
+        outXYZ[i * 3 + 1] = p.Y();
+        outXYZ[i * 3 + 2] = p.Z();
     }
     return n;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -5092,14 +5092,17 @@ int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef c, double angularDefl, double cho
 }
 
 int32_t OCCTCurve2DDrawUniform(OCCTCurve2DRef c, int32_t pointCount, double* outXY) {
-    if (!c || c->curve.IsNull() || !outXY || pointCount <= 0) return 0;
+    // outXY holds pointCount pairs, which is not what the sampler is bounded by. See
+    // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
+    if (!c || c->curve.IsNull() || !outXY || !occtValidSampleCount(pointCount)) return 0;
     try {
         Geom2dAdaptor_Curve adaptor(c->curve);
         GCPnts_UniformAbscissa sampler(adaptor, pointCount);
         if (!sampler.IsDone()) return 0;
-        int32_t n = sampler.NbPoints();
+        int32_t total = sampler.NbPoints();
+        int32_t n = occtSamplerKept(total, pointCount);
         for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(i + 1);
+            double u = sampler.Parameter(occtSamplerIndex(i, n, total));
             gp_Pnt2d p = adaptor.Value(u);
             outXY[i * 2] = p.X();
             outXY[i * 2 + 1] = p.Y();

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -658,6 +658,49 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
     return iu * vCount + iv;
 }
 
+// === #501: GCPnts arc-length samplers can return more points than were asked for ===
+//
+// GCPnts_UniformAbscissa::initialize sizes its own parameter array at `nbPoints + 5` and lets the
+// arc-length walk fill it as far as it runs, so NbPoints() is not bounded by the requested count.
+// GCPnts_QuasiUniformAbscissa inherits that for every curve which is neither Bezier nor BSpline,
+// because it forwards to GCPnts_UniformAbscissa for those.
+//
+// Measured on an ellipse with major radius 1e6 and minor radius 1e-3: the walk lands ~1.6e-8 in
+// parameter short of the end, which is far outside the sampler's own epsilon (Resolution(1e-7),
+// about 1e-13 there), so it takes one more step and snaps that step to the end parameter. 22 of 59
+// point counts overshoot by exactly one. Every bridge function here is handed a buffer sized from
+// the count the caller asked for, so writing NbPoints() values was a heap write past the end.
+// Scripts/repro/501-quasiuniform-buffer-overflow reproduces it against the shipped functions.
+//
+// Clamping alone is not enough: the surplus point *is* the curve's end parameter, so dropping the
+// tail drops the end of the curve. Keep the first `capacity - 1` samples and the sampler's own last
+// one, which is what OCCTGCPntsQuasiUniform (the only member of the family that already clamped)
+// was silently getting wrong.
+
+/// How many of a GCPnts sampler's `nbPoints` samples fit in a buffer of `capacity` slots.
+inline int32_t occtSamplerKept(int32_t nbPoints, int32_t capacity) {
+    return std::min(nbPoints, std::max(capacity, 0));
+}
+
+/// The 1-based sampler index feeding output slot `slot`, given `kept` of `nbPoints` samples fit.
+/// Identity while everything fits; otherwise the final slot takes the sampler's last point so a
+/// clamped distribution still spans the whole curve.
+inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints) {
+    return (slot == kept - 1) ? nbPoints : slot + 1;
+}
+
+/// The point-count precondition every GCPnts_UniformAbscissa / GCPnts_QuasiUniformAbscissa entry
+/// point has to apply itself. Both classes document (and `Raise_if`) `nbPoints >= 2`, but the
+/// pinned kernel is a Release build, where OCCT defines No_Exception and every `*_Raise_if`
+/// compiles to nothing (see #487). Below 2 the algorithms do not fail cleanly:
+/// GCPnts_QuasiUniformAbscissa(bezier_or_bspline, 0) builds an NCollection_HArray1 with the empty
+/// range (1, 0) and then writes element 1 of it, an out-of-bounds store that SIGSEGVs (measured on
+/// a 4-pole Bezier, an all-coincident-pole Bezier and an 8-point BSpline fit); on an ellipse the
+/// same call reports IsDone() with five points for a request of zero.
+inline bool occtValidSampleCount(int32_t nbPoints) {
+    return nbPoints >= 2;
+}
+
 // === #489: shared BRepFilletAPI_MakeFillet edge-list skeleton ===
 //
 // Three bridge functions fillet a caller-supplied list of edge indices and differ only in what

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -245,7 +245,18 @@ public final class Curve2D: @unchecked Sendable {
         return (0..<n).map { SIMD2(buffer[$0 * 2], buffer[$0 * 2 + 1]) }
     }
 
-    /// Discretize the curve with exactly `pointCount` uniformly-spaced-by-arc-length points.
+    /// Discretize the curve with at most `pointCount` uniformly-spaced-by-arc-length points.
+    ///
+    /// The first point is always the start of the curve and the last is always its end.
+    ///
+    /// ```swift
+    /// let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!
+    /// let pts = seg.drawUniform(pointCount: 11)
+    /// // pts[5] ≈ SIMD2(5, 0)
+    /// ```
+    ///
+    /// - Parameter pointCount: Desired number of output points; must be at least 2, else empty.
+    /// - Returns: Array of 2D points, never more than `pointCount` of them, or empty on failure
     public func drawUniform(pointCount: Int) -> [SIMD2<Double>] {
         var buffer = [Double](repeating: 0, count: pointCount * 2)
         let n = Int(OCCTCurve2DDrawUniform(handle, Int32(pointCount), &buffer))

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -542,7 +542,18 @@ public final class Curve3D: @unchecked Sendable {
         return unpackSIMD3(buffer, count: n)
     }
 
-    /// Uniform arc-length spacing discretization
+    /// Uniform arc-length spacing discretization.
+    ///
+    /// The first point is always the start of the curve and the last is always its end.
+    ///
+    /// ```swift
+    /// let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+    /// let pts = seg.drawUniform(pointCount: 11)
+    /// // pts[5] ≈ SIMD3(5, 0, 0)
+    /// ```
+    ///
+    /// - Parameter pointCount: Desired number of output points; must be at least 2, else empty.
+    /// - Returns: Array of 3D points, never more than `pointCount` of them, or empty on failure
     public func drawUniform(pointCount: Int) -> [SIMD3<Double>] {
         var buffer = [Double](repeating: 0, count: pointCount * 3)
         let n = Int(OCCTCurve3DDrawUniform(handle, Int32(pointCount), &buffer))
@@ -769,10 +780,21 @@ extension Curve3D {
     /// Sample parameter values at quasi-uniform arc-length intervals.
     ///
     /// Uses `GCPnts_QuasiUniformAbscissa` to distribute sample points
-    /// approximately evenly along the curve's arc length.
+    /// approximately evenly along the curve's arc length. The first parameter is always the start
+    /// of the curve's domain and the last is always its end.
     ///
-    /// - Parameter count: Desired number of sample points
-    /// - Returns: Array of parameter values, or empty array on failure
+    /// ```swift
+    /// if let c = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+    ///     let params = c.quasiUniformParameters(count: 8)
+    ///     #expect(params.count == 8)
+    ///     #expect(params.last == c.domain.upperBound)
+    /// }
+    /// ```
+    ///
+    /// - Parameter count: Desired number of sample points. Must be at least 2. OCCT's samplers
+    ///   document that precondition but cannot enforce it in a Release kernel, and below 2 they
+    ///   misbehave rather than fail, so anything smaller returns an empty array here.
+    /// - Returns: Array of parameter values, never more than `count` of them, or empty on failure
     public func quasiUniformParameters(count: Int) -> [Double] {
         var params = [Double](repeating: 0, count: count)
         let n = Int(OCCTCurve3DQuasiUniformAbscissa(handle, Int32(count), &params))

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -7922,6 +7922,10 @@ extension Curve2D {
 
 extension Shape {
     /// Uniformly sample an edge by point count. Returns parameter values.
+    ///
+    /// - Parameter pointCount: Desired number of samples; must be at least 2, else `nil`. OCCT's
+    ///   sampler documents that precondition but cannot enforce it in a Release kernel, and used to
+    ///   answer a request for zero with five parameters (#501).
     public func uniformAbscissa(pointCount: Int) -> [Double]? {
         let n = Int(OCCTUniformAbscissaByCount(handle, Int32(pointCount), nil))
         guard n > 0 else { return nil }
@@ -7940,6 +7944,8 @@ extension Shape {
     }
 
     /// Uniformly sample an edge by point count within parameter range.
+    ///
+    /// - Parameter pointCount: Desired number of samples; must be at least 2, else `nil` (#501).
     public func uniformAbscissa(pointCount: Int, u1: Double, u2: Double) -> [Double]? {
         let n = Int(OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, nil))
         guard n > 0 else { return nil }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -12073,6 +12073,18 @@ extension Surface {
 
 extension Edge {
     /// Compute quasi-uniform parameter distribution on this edge.
+    ///
+    /// The first parameter is always the start of the edge and the last is always its end.
+    ///
+    /// ```swift
+    /// if let edge = Shape.box(width: 10, height: 10, depth: 10)?.edges().first {
+    ///     let params = edge.quasiUniformParameters(count: 10)
+    ///     #expect(params.count == 10)
+    /// }
+    /// ```
+    ///
+    /// - Parameter count: Desired number of sample points; must be at least 2, else empty.
+    /// - Returns: Array of parameter values, never more than `count` of them, or empty on failure
     public func quasiUniformParameters(count: Int) -> [Double] {
         var params = [Double](repeating: 0, count: count)
         let n = OCCTGCPntsQuasiUniform(handle, Int32(count), &params, Int32(count))

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -1230,6 +1230,105 @@ struct QuasiUniformAbscissaTests {
     }
 }
 
+// MARK: - #501: GCPnts samplers can compute more points than were requested
+
+/// An ellipse whose arc-length walk lands ~1.6e-8 in parameter short of the end, so
+/// `GCPnts_UniformAbscissa` takes one extra step and snaps it to the end parameter. That surplus
+/// point used to be written past the end of the caller's buffer; clamping it away without keeping
+/// the sampler's last point would instead leave the distribution stopping short of the curve.
+private func overshootingEllipse() -> Curve3D? {
+    Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1), majorRadius: 1e6, minorRadius: 1e-3)
+}
+
+/// Counts measured to overshoot on that ellipse (22 of the first 59 do).
+private let overshootingCounts = [4, 5, 8, 12, 14, 18, 20, 22, 25, 26, 31, 33, 34, 35, 39, 40]
+
+@Suite("GCPnts sampler bounds (#501)")
+struct GCPntsSamplerBoundsTests {
+    @Test("Quasi-uniform sampling never exceeds the requested count")
+    func quasiUniformRespectsCount() {
+        guard let ellipse = overshootingEllipse() else {
+            Issue.record("could not build the high-aspect-ratio ellipse")
+            return
+        }
+        for count in overshootingCounts {
+            #expect(ellipse.quasiUniformParameters(count: count).count == count)
+        }
+    }
+
+    @Test("Quasi-uniform sampling still reaches the end of the curve when clamped")
+    func quasiUniformKeepsCurveEnd() {
+        guard let ellipse = overshootingEllipse() else { return }
+        let end = ellipse.domain.upperBound
+        for count in overshootingCounts {
+            let params = ellipse.quasiUniformParameters(count: count)
+            if let last = params.last {
+                #expect(abs(last - end) < 1e-12)
+            }
+        }
+    }
+
+    @Test("Quasi-uniform parameters stay ordered when clamped")
+    func quasiUniformStaysOrdered() {
+        guard let ellipse = overshootingEllipse() else { return }
+        for count in overshootingCounts {
+            let params = ellipse.quasiUniformParameters(count: count)
+            for i in 1..<params.count {
+                #expect(params[i] > params[i - 1])
+            }
+        }
+    }
+
+    @Test("Uniform discretization never exceeds the requested count and reaches the end")
+    func drawUniformRespectsCount() {
+        guard let ellipse = overshootingEllipse() else { return }
+        let endPoint = ellipse.point(at: ellipse.domain.upperBound)
+        for count in overshootingCounts {
+            let points = ellipse.drawUniform(pointCount: count)
+            #expect(points.count == count)
+            if let last = points.last {
+                #expect(distance(last, endPoint) < 1e-6)
+            }
+        }
+    }
+
+    /// OCCT documents `nbPoints >= 2` for both samplers but enforces it with a `Raise_if`, which
+    /// the Release kernel compiles out (No_Exception, #487). Below 2 the algorithms do not fail
+    /// cleanly: `GCPnts_QuasiUniformAbscissa(bezier_or_bspline, 0)` writes element 1 of an
+    /// empty `(1, 0)`-ranged array and SIGSEGVs, so every entry point rejects it itself.
+    @Test("Sample counts below two are rejected, not passed to OCCT")
+    func countsBelowTwoRejected() {
+        guard let ellipse = overshootingEllipse(),
+              let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
+              let bezier = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(1, 4, 0),
+                                                 SIMD3(4, -3, 1), SIMD3(6, 1, 0)])
+        else {
+            Issue.record("could not build the degenerate-count fixtures")
+            return
+        }
+        for curve in [ellipse, circle, bezier] {
+            for count in [0, 1] {
+                #expect(curve.quasiUniformParameters(count: count).isEmpty)
+                #expect(curve.drawUniform(pointCount: count).isEmpty)
+            }
+        }
+    }
+
+    @Test("Edge uniform abscissa rejects counts below two")
+    func edgeUniformAbscissaRejectsCountsBelowTwo() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let edge = box.subShapes(ofType: .edge).first
+        else {
+            Issue.record("could not build a box edge")
+            return
+        }
+        for count in [0, 1] {
+            #expect(edge.uniformAbscissa(pointCount: count) == nil)
+            #expect(edge.uniformAbscissa(pointCount: count, u1: 0, u2: 1) == nil)
+        }
+    }
+}
+
 @Suite("Quasi-Uniform Deflection Sampling")
 struct QuasiUniformDeflectionTests {
     @Test("Sample circle with deflection")

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -245,6 +245,35 @@ struct Curve2DTests {
         #expect(points.count == 32)
     }
 
+    /// #501: `GCPnts_UniformAbscissa` sizes its own array at `nbPoints + 5` and can report more
+    /// points than were asked for: one more, on a 1e6 x 1e-3 ellipse, for 22 of the first 59
+    /// counts. `outXY` only holds `pointCount` pairs, so the surplus used to be written past its
+    /// end; the surplus point is the curve's end parameter, so it is the last slot that keeps it.
+    @Test("Uniform draw stays within the requested count on an overshooting ellipse")
+    func uniformDrawRespectsCount() {
+        guard let ellipse = Curve2D.ellipse(center: .zero, majorRadius: 1e6, minorRadius: 1e-3)
+        else {
+            Issue.record("could not build the high-aspect-ratio ellipse")
+            return
+        }
+        let endPoint = ellipse.point(at: ellipse.domain.upperBound)
+        for count in [4, 5, 8, 12, 14, 18, 20, 22, 25, 26, 31, 33, 34, 35, 39, 40] {
+            let points = ellipse.drawUniform(pointCount: count)
+            #expect(points.count == count)
+            if let last = points.last {
+                #expect(distance(last, endPoint) < 1e-6)
+            }
+        }
+    }
+
+    @Test("Uniform draw rejects counts below two")
+    func uniformDrawRejectsCountsBelowTwo() {
+        let circle = Curve2D.circle(center: .zero, radius: 5)!
+        for count in [0, 1] {
+            #expect(circle.drawUniform(pointCount: count).isEmpty)
+        }
+    }
+
     @Test("Deflection draw produces points")
     func deflectionDraw() {
         let circle = Curve2D.circle(center: .zero, radius: 5)!

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -714,6 +714,73 @@ that still carried the feature the caller asked to remove, indistinguishable fro
 removal; the two index-addressed siblings already failed on it. `defeature(faces:tolerance:)` is
 deprecated (it forwards, and its tolerance was never read); calls that omit `tolerance:` were
 already reaching the tolerance-free path and are unaffected.
+#### Fix: four arc-length samplers wrote past the end of the caller's buffer (#501)
+
+`GCPnts_UniformAbscissa` sizes its own parameter array at `nbPoints + 5` and fills it as far as the
+arc-length walk runs, so `NbPoints()` is not bounded by the count that was asked for, and
+`GCPnts_QuasiUniformAbscissa` inherits that for every curve which is neither Bezier nor BSpline,
+because it forwards to `GCPnts_UniformAbscissa` for those. Four bridge functions were handed a
+buffer sized from the requested count and then filled it with `NbPoints()` values:
+`OCCTCurve3DQuasiUniformAbscissa` (`Curve3D.quasiUniformParameters(count:)`),
+`OCCTCurve3DDrawUniform` (`Curve3D.drawUniform(pointCount:)`), `OCCTCurve2DDrawUniform`
+(`Curve2D.drawUniform(pointCount:)`) and `sampleAdaptorUniform`
+(`CompCurve`/`EdgeCurve` `sampleUniform(count:)`).
+
+Reproduced against the shipped functions with sentinel-guarded buffers: on an ellipse with major
+radius 1e6 and minor radius 1e-3, 22 of the first 59 point counts overshoot by one, for **48
+overflowing calls** across the three curve entry points. The trigger is rounding: the walk stops
+~1.6e-8 in parameter short of the end against an epsilon of ~1e-13, so the sampler takes one more
+step. Well-conditioned geometry does not do it, which is why this survived from v0.31.0: a line, a
+circle at radii from 1e-6 to 1e7, a 5x2 ellipse, hyperbola, parabola, Bezier, BSpline, offset and
+trimmed curves were all clean across counts 2..200.
+
+The two `drawUniform` entry points did not corrupt memory quietly. They **crashed the process**.
+Their Swift wrappers unpack the buffer by index using the count the bridge returned, so a returned
+`pointCount + 1` reads three (or two) elements past the end of the Swift `Array` and hits its bounds
+check: `Fatal error: Index out of range`. `quasiUniformParameters` uses `prefix(n)`, which clamps,
+so there the only symptom was the heap write itself.
+
+Clamping alone would not have been the fix. The surplus point *is* the curve's end parameter, so
+truncating the tail leaves the distribution stopping short of the curve, which is precisely what
+`OCCTGCPntsQuasiUniform` (`Edge.quasiUniformParameters(count:)`), the one member of the family that
+already clamped, had been doing silently on every overshooting call. The shared
+`occtSamplerKept`/`occtSamplerIndex` helpers keep the first `capacity - 1` samples and the sampler's
+own last one.
+
+Also fixed: **`Shape.uniformAbscissa(pointCount: 0)` returned five parameters** instead of `nil`.
+Both samplers document `nbPoints >= 2` and enforce it with a `Raise_if`, which the Release kernel
+compiles out (`No_Exception`, #487), and `OCCTUniformAbscissaByCount`/`ByCountRange` had no count
+precondition of their own. Below 2 the algorithms misbehave rather than fail:
+`GCPnts_QuasiUniformAbscissa(bezier_or_bspline, 0)` builds an `NCollection_HArray1` over the empty
+range `(1, 0)` and writes element 1 of it: an uncatchable SIGSEGV, one missing guard away on three
+of the six entry points. `occtValidSampleCount` is now applied at all of them, so `count`/
+`pointCount` below 2 returns empty rather than reaching OCCT.
+
+Reproducer and the full measured tables: [`Scripts/repro/501-quasiuniform-buffer-overflow/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/501-quasiuniform-buffer-overflow).
+
+#### The orphaned duplicate the index was hiding, and eight corrected entries (#501)
+
+`OCCTBridge.h`'s index mapped `GCPnts_QuasiUniformAbscissa → OCCTCurve3DQuasiUniformParams`, a
+symbol that has never existed. Chasing the real one turned up two: `OCCTCurve3DQuasiUniformAbscissa`
+(v0.31.0) and `OCCTGCPntsQuasiUniformCurve` (v0.75), byte-for-byte the same sampling of the same
+`Curve3D` through the same two OCCT classes. The v0.75 one had no caller in Swift or in the tests
+and never had; it is removed. Its `maxParams` bound (the one thing the older spelling lacked, and
+the reason the older spelling was overflowing) is folded into the survivor. No Swift API changes:
+`OCCTGCPntsQuasiUniformCurve` was C-level only and never reachable.
+
+Index entries corrected alongside it: the whole `GCPnts` block (`UniformAbscissa` and
+`UniformDeflection` both pointed at `OCCTCPntsUniformDeflection*`, which wraps a **different OCCT
+class**, `CPnts_UniformDeflection`, now given its own entry; `AbscissaPoint` named one 2D function
+out of eleven; `TangentialDeflection` had no entry at all), `BRepGProp` (two of three symbols
+missing their `Get`), `ShapeCustom_DirectModification` (missing its `Custom`), and
+`BRepOffset_SimpleOffset`, which named `OCCTShapeSimpleOffset` (a function that wraps
+`BRepOffset_MakeSimpleOffset`, a different class, now indexed separately) while the real
+`OCCTBRepOffsetSimpleOffset` was absent. `Scripts/check-bridge-index.py` goes from 139 stale entries
+to 134; the remaining 134 are #510.
+
+Worth noting for #510: the two `GCPnts_Uniform*` entries **passed** the checker. It verifies that a
+named symbol exists, not that it wraps the class the entry claims, so a mis-attributed entry is
+invisible to it. 139 is a floor, not the count.
 
 #### One `BRepLib::BuildCurves3d` entry point, not three, and one default instead of two (#498)
 

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -407,15 +407,15 @@ Concentrates sample points where curvature is high and fewer where the curve is 
 
 ### `drawUniform(pointCount:)`
 
-Discretizes the curve at exactly `pointCount` uniformly-spaced arc-length points.
+Discretizes the curve at up to `pointCount` uniformly-spaced arc-length points. The first point is always the start of the curve and the last is always its end.
 
 ```swift
 public func drawUniform(pointCount: Int) -> [SIMD2<Double>]
 ```
 
-- **Parameters:** `pointCount` — desired number of output points.
-- **Returns:** Array of 2D points; empty on failure.
-- **OCCT:** `GCPnts_UniformAbscissa` (via `OCCTCurve2DDrawUniform`).
+- **Parameters:** `pointCount`, the desired number of output points. Must be at least 2; below that the result is empty (#501).
+- **Returns:** Array of 2D points, never more than `pointCount`; empty on failure.
+- **OCCT:** `GCPnts_UniformAbscissa` (via `OCCTCurve2DDrawUniform`). It sizes its own array at `pointCount + 5` and can report more points than requested on a poorly-conditioned curve; the surplus is dropped and the curve's end point kept (#501).
 - **Example:**
   ```swift
   let seg = Curve2D.segment(from: .zero, to: SIMD2(10, 0))!

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -496,11 +496,11 @@ Returns parameter values at quasi-uniform arc-length intervals.
 public func quasiUniformParameters(count: Int) -> [Double]
 ```
 
-Uses `GCPnts_QuasiUniformAbscissa` to space `count` parameters approximately evenly along the arc length of the curve. The result is suitable for passing to `evaluateGrid(_:)`.
+Uses `GCPnts_QuasiUniformAbscissa` to space `count` parameters approximately evenly along the arc length of the curve. The result is suitable for passing to `evaluateGrid(_:)`. The first parameter is always the start of the curve's domain and the last is always its end.
 
-- **Parameters:** `count` — desired number of sample parameters.
-- **Returns:** Array of parameter values of length up to `count`; empty on failure.
-- **OCCT:** `GCPnts_QuasiUniformAbscissa`.
+- **Parameters:** `count`, the desired number of sample parameters. Must be at least 2; below that the result is empty. OCCT documents the same precondition but enforces it with a `Raise_if`, which the pinned Release kernel compiles out, so the bridge applies it (#501).
+- **Returns:** Array of parameter values of length up to `count`, never more; empty on failure.
+- **OCCT:** `GCPnts_QuasiUniformAbscissa`. It can compute one point beyond the request on a poorly-conditioned curve (measured on a 1e6 x 1e-3 ellipse); the surplus is dropped, but the curve's end parameter is kept in the last slot rather than truncated away.
 - **Example:**
   ```swift
   if let c = Curve3D.bspline(points: myPoints) {

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -936,11 +936,11 @@ Discretizes the curve at uniform arc-length intervals.
 public func drawUniform(pointCount: Int) -> [SIMD3<Double>]
 ```
 
-All consecutive point pairs are separated by the same arc-length. Good for even distribution of sample points regardless of curvature.
+All consecutive point pairs are separated by the same arc-length. Good for even distribution of sample points regardless of curvature. The first point is always the start of the curve and the last is always its end.
 
-- **Parameters:** `pointCount` — desired number of output points.
-- **Returns:** Array of 3D points, or empty array on failure.
-- **OCCT:** `GCPnts_UniformAbscissa(adaptor, pointCount)`.
+- **Parameters:** `pointCount`, the desired number of output points. Must be at least 2; below that the result is empty (#501).
+- **Returns:** Array of 3D points, never more than `pointCount`, or empty array on failure.
+- **OCCT:** `GCPnts_UniformAbscissa(adaptor, pointCount)`. It sizes its own array at `pointCount + 5` and can report more points than requested on a poorly-conditioned curve; the surplus is dropped and the curve's end point kept (#501).
 - **Example:**
   ```swift
   let seg = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -73,7 +73,7 @@ Uniformly sample an edge by point count; returns parameter values.
 public func uniformAbscissa(pointCount: Int) -> [Double]?
 ```
 
-- **Parameters:** `pointCount` — number of sample points.
+- **Parameters:** `pointCount`, the number of sample points. Must be at least 2, else `nil`. OCCT documents that precondition but enforces it with a `Raise_if`, which the pinned Release kernel compiles out, so a request for zero used to come back with five parameters (#501).
 - **Returns:** Array of curve parameter values, or `nil` if the edge is invalid or sampling fails.
 - **OCCT:** `GCPnts_UniformAbscissa` (by number of points)
 - **Example:**
@@ -114,7 +114,7 @@ Uniformly sample an edge by point count within a parameter range.
 public func uniformAbscissa(pointCount: Int, u1: Double, u2: Double) -> [Double]?
 ```
 
-- **Parameters:** `pointCount` — number of points; `u1`, `u2` — parameter range on the underlying curve.
+- **Parameters:** `pointCount`, the number of points, at least 2 (else `nil`, see above); `u1`, `u2`, the parameter range on the underlying curve.
 - **Returns:** Array of parameter values, or `nil` on failure.
 - **OCCT:** `GCPnts_UniformAbscissa` (range variant, by count)
 - **Example:**

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -1112,11 +1112,12 @@ Computes a quasi-uniform parameter distribution along an edge.
 public func quasiUniformParameters(count: Int) -> [Double]
 ```
 
-The returned parameters are distributed so that the chord lengths between consecutive curve points are approximately equal.
+The returned parameters are distributed so that the chord lengths between consecutive curve points are approximately equal. The first is always the start of the edge and the last is always its end.
 
-- **Parameters:** `count` — desired number of parameter values.
+- **Parameters:** `count`, the desired number of parameter values. Must be at least 2; below that the result is empty (#501).
 - **Returns:** Array of curve parameters of length ≤ `count`.
-- **OCCT:** `GCPnts_QuasiUniformAbscissa` via `OCCTGCPntsQuasiUniform`.
+- **OCCT:** `GCPnts_QuasiUniformAbscissa` via `OCCTGCPntsQuasiUniform`. It can compute one point beyond the request on a poorly-conditioned curve; the surplus is dropped and the edge's end parameter kept. Before #501 the surplus was dropped along with the end parameter, so the distribution stopped short of the edge.
+- **Curve3D equivalent:** `Curve3D.quasiUniformParameters(count:)`, which goes through `OCCTCurve3DQuasiUniformAbscissa`. A second Curve3D-based bridge function, `OCCTGCPntsQuasiUniformCurve`, duplicated it from v0.75 with no caller and was removed in #501.
 - **Example:**
   ```swift
   let params = edge.quasiUniformParameters(count: 20)


### PR DESCRIPTION
Closes #501. Part of Pass 1b (#381) of the #377 duplication audit; targets `refactor/381-pass1b`, not `main`.

## What the issue asked for

`OCCTBridge.h`'s cross-reference index maps `GCPnts_QuasiUniformAbscissa` to `OCCTCurve3DQuasiUniformParams`, a symbol that has never existed, and hides an orphaned duplicate of the real wrap.

Both confirmed. Chasing the real function turned up two: `OCCTCurve3DQuasiUniformAbscissa` (v0.31.0) and `OCCTGCPntsQuasiUniformCurve` (v0.75), byte-for-byte the same sampling of the same `Curve3D` through the same two OCCT classes. The v0.75 one has no caller in Swift or in the tests and never had. It is removed.

## What measuring the duplicate turned up

The two spellings disagreed about exactly one thing: whether the output buffer needed a bound. The one in service did not have one, and that turned out to be a live heap buffer overflow.

`GCPnts_UniformAbscissa::initialize` sizes its own parameter array at `theNbPoints + 5` and lets the arc-length walk fill it as far as it runs, so `NbPoints()` is not bounded by the requested count. `GCPnts_QuasiUniformAbscissa` inherits that for every curve which is neither Bezier nor BSpline, because it forwards to `GCPnts_UniformAbscissa` for those.

Four bridge functions took a buffer sized from the requested count and wrote `NbPoints()` values into it:

| bridge function | buffer the caller allocates | Swift entry point |
|---|---|---|
| `OCCTCurve3DQuasiUniformAbscissa` | `count` doubles | `Curve3D.quasiUniformParameters(count:)` |
| `OCCTCurve3DDrawUniform` | `pointCount * 3` doubles | `Curve3D.drawUniform(pointCount:)` |
| `OCCTCurve2DDrawUniform` | `pointCount * 2` doubles | `Curve2D.drawUniform(pointCount:)` |
| `sampleAdaptorUniform` | `count * 3` doubles | `CompCurve`/`EdgeCurve` `sampleUniform(count:)` |

Measured with sentinel-guarded buffers against the shipped functions: on an ellipse with major radius 1e6 and minor radius 1e-3, 22 of the first 59 point counts overshoot by one, for **48 overflowing calls** across the three curve entry points. The trigger is rounding: the walk stops ~1.6e-8 in parameter short of the end, against an epsilon of ~1e-13 there, so the sampler takes one more step and snaps it to the end.

The two `drawUniform` wrappers unpack by index rather than `prefix`, so they did not corrupt memory quietly: they **trap**, with `Fatal error: Index out of range`.

Well-conditioned geometry does not reproduce it, which is why it survived from v0.31.0. A line, a circle at radii from 1e-6 to 1e7, a 5x2 ellipse, hyperbola, parabola, Bezier, BSpline, offset and trimmed curves were all clean across counts 2..200.

## Clamping alone would have been the wrong fix

The surplus point *is* the curve's end parameter, so truncating the tail leaves the distribution stopping short of the curve:

```
curve parameter range: [0, 6.2831853071795862]
returned 5 params: 0  1.9106332362490186  4.3725520709305679  6.2831852916099189  6.2831853071795862
                                                              ^ what a count-clamped caller sees,
                                                                1.56e-08 short of the end
```

`OCCTGCPntsQuasiUniform` was the one member of the family that already clamped, and it had exactly this defect, silently, on every overshooting call. Shared `occtSamplerKept`/`occtSamplerIndex` keep the first `capacity - 1` samples and the sampler's own last one.

## The degenerate-count guard next door

Both samplers document `nbPoints >= 2` and enforce it with a `Raise_if`, which the pinned Release kernel compiles out (`No_Exception`, #487). Below 2 they misbehave rather than fail:

| curve | `GCPnts_QuasiUniformAbscissa(c, 0)` | `GCPnts_UniformAbscissa(c, 0)` |
|---|---|---|
| line, circle | `IsDone()`, 1 point | `IsDone()`, 1 point |
| ellipse | `IsDone()`, **5 points** | `IsDone()`, 5 points |
| 4-pole Bezier | **SIGSEGV** | `IsDone()`, 5 points |
| all-coincident-pole Bezier | **SIGSEGV** | not done |
| 8-point BSpline fit | **SIGSEGV** | `IsDone()`, 5 points |

The crash is the Bezier/BSpline branch building `new NCollection_HArray1<double>(1, 0)`, an empty range, then calling `SetValue(1, theU1)` on it; that bounds check is a `Raise_if` too, so the store lands out of bounds. Uncatchable, same class as #263/#310/#317/#318. No quasi-uniform entry point reached it (all rejected `< 2` or `<= 0`), but `OCCTUniformAbscissaByCount`/`ByCountRange` had no count precondition at all, so `Shape.uniformAbscissa(pointCount: 0)` came back with five parameters for a request of zero. `occtValidSampleCount` is now applied at all six entry points.

## Index entries corrected

Beyond the flagged one: the whole `GCPnts` block, `BRepGProp`, `ShapeCustom_DirectModification`, `BRepOffset_SimpleOffset` and `BRepTools_Modifier`. `Scripts/check-bridge-index.py` goes from 134 stale to 131 on this base; the rest are #510.

**Worth noting for #510:** `GCPnts_UniformAbscissa` and `GCPnts_UniformDeflection` both pointed at `OCCTCPntsUniformDeflection*`, which wraps a *different OCCT class* (`CPnts_UniformDeflection`, now given its own entry), and both **passed** the checker. It verifies that a named symbol exists, not that it wraps the class the entry claims, so a mis-attributed entry is invisible to it. 139 is a floor, not the count.

## Behaviour changes

- `Curve3D.quasiUniformParameters(count:)`, `Curve3D.drawUniform(pointCount:)`, `Curve2D.drawUniform(pointCount:)`, `Edge.quasiUniformParameters(count:)` and `CompCurve`/`EdgeCurve.sampleUniform(count:)` return empty for a count below 2 (previously: 1 point on some curve types, nothing on others, and a hard crash one guard away).
- `Shape.uniformAbscissa(pointCount:)` and `(pointCount:u1:u2:)` return `nil` below 2 instead of five parameters.
- Where the sampler overshoots, results now end at the curve's last parameter instead of just short of it.

No Swift API is added or removed. `OCCTGCPntsQuasiUniformCurve` was C-level only and unreachable from Swift.

## Verification

- `Scripts/repro/501-quasiuniform-buffer-overflow/` compiles the shipped `.mm` files, so it measures the real functions. Before: 48 overflowing calls plus `OCCTGCPntsQuasiUniform` short of the end on all 16 counts. After: `PASS: 0 overflowing calls`.
- New tests run against the unfixed bridge first: the degenerate-count ones fail, and the overshoot ones kill the test process at `ContiguousArrayBuffer.swift:692`. They cover the defect rather than describing it.
- Full `swift test`: 4774 tests, 0 failures.
- Docs updated in the same change: `CHANGELOG`, the five affected `docs/reference/` pages, and `///` comments with runnable snippets on each changed public method.

## Not examined

`OCCTUniformAbscissaByDistance`/`ByDistanceRange` take an arc-length step rather than a count, so the clamp does not apply; their behaviour on a zero or negative distance was not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)