### PR TITLE
fix(#504): one free-bounds analyser, and the double-perform() bug the second one hid

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,290 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,293 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -450,7 +450,11 @@
 // ShapeAnalysis_Curve                 → OCCTCurve3DProjectPoint, OCCTCurve3DValidateRange,
 //                                        OCCTCurve3DGetSamplePoints3D, OCCTCurve3DIsClosedWithPreci,
 //                                        OCCTCurve3DIsPeriodicSA
-// ShapeAnalysis_FreeBoundsProperties  → OCCTShapeFreeBoundsAnalysis*
+// ShapeAnalysis_FreeBounds            → OCCTShapeFreeBounds, OCCTShapeFreeBoundsClosedCount,
+//                                        OCCTShapeFreeBoundsClosed, OCCTShapeFreeBoundsOpen
+// ShapeAnalysis_FreeBoundsProperties  → OCCTFreeBoundsProps* (one family since #504; the stateless
+//                                        OCCTFreeBounds* family was a second wrapping of the same
+//                                        class and is gone)
 // ShapeAnalysis_Surface               → OCCTSurfaceUVProject*
 // ShapeAnalysis_TransferParametersProj → OCCTShapeAnalysisTransferParam*
 // ShapeAnalysis_WireOrder             → OCCTWireAnalyze
@@ -6484,56 +6488,14 @@ OCCTShapeRef _Nullable OCCTShapeCustomBSplineRestriction(OCCTShapeRef shape,
     int32_t continuity3d, int32_t continuity2d, bool degreePriority, bool rational);
 
 // --- ShapeAnalysis_FreeBoundsProperties ---
-
-/// Free bounds analysis result (summary)
-typedef struct {
-    int32_t totalFreeBounds;
-    int32_t closedFreeBounds;
-    int32_t openFreeBounds;
-} OCCTFreeBoundsResult;
-
-/// Analyze free bounds of a shape.
-/// @param shape Shape to analyze
-/// @param tolerance Sewing tolerance for finding free bounds
-/// @return Analysis result with bound counts
-OCCTFreeBoundsResult OCCTFreeBoundsAnalyze(OCCTShapeRef shape, double tolerance);
-
-/// Individual free bound properties
-typedef struct {
-    double area;
-    double perimeter;
-    double ratio;       // Area / (perimeter * perimeter)
-    double width;       // Average width
-    int32_t notchCount;
-} OCCTFreeBoundInfo;
-
-/// Get properties of a closed free bound.
-/// @param shape Shape previously analyzed
-/// @param tolerance Same tolerance used in analysis
-/// @param index 0-based index of the closed free bound
-/// @return Properties of the specified closed free bound
-OCCTFreeBoundInfo OCCTFreeBoundsGetClosedBoundInfo(OCCTShapeRef shape, double tolerance, int32_t index);
-
-/// Get properties of an open free bound.
-/// @param shape Shape previously analyzed
-/// @param tolerance Same tolerance used in analysis
-/// @param index 0-based index of the open free bound
-/// @return Properties of the specified open free bound
-OCCTFreeBoundInfo OCCTFreeBoundsGetOpenBoundInfo(OCCTShapeRef shape, double tolerance, int32_t index);
-
-/// Get the wire of a closed free bound as a shape.
-/// @param shape Shape previously analyzed
-/// @param tolerance Same tolerance used in analysis
-/// @param index 0-based index of the closed free bound
-/// @return Wire shape, or NULL on failure
-OCCTShapeRef _Nullable OCCTFreeBoundsGetClosedBoundWire(OCCTShapeRef shape, double tolerance, int32_t index);
-
-/// Get the wire of an open free bound as a shape.
-/// @param shape Shape previously analyzed
-/// @param tolerance Same tolerance used in analysis
-/// @param index 0-based index of the open free bound
-/// @return Wire shape, or NULL on failure
-OCCTShapeRef _Nullable OCCTFreeBoundsGetOpenBoundWire(OCCTShapeRef shape, double tolerance, int32_t index);
+//
+// OCCTFreeBoundsAnalyze, OCCTFreeBoundsGetClosedBoundInfo, OCCTFreeBoundsGetOpenBoundInfo,
+// OCCTFreeBoundsGetClosedBoundWire and OCCTFreeBoundsGetOpenBoundWire were declared here.
+// Each rebuilt a whole ShapeAnalysis_FreeBoundsProperties and re-ran Perform() from scratch,
+// so a per-bound report cost one full free-bound search per bound; each also took a 0-based
+// index while the later OCCTFreeBoundsProps* family, wrapping the identical OCCT class, took a
+// 1-based one. Removed by #504: the one family, and the two structs that were declared here,
+// are with the v0.114.0 block (search OCCTFreeBoundsPropsCreate).
 
 // --- ShapeAnalysis_Surface expansion ---
 
@@ -17137,48 +17099,78 @@ typedef struct {
 /// Get extended shape contents analysis.
 OCCTShapeContentsExtended OCCTShapeGetContentsExtended(OCCTShapeRef _Nonnull shape);
 
-// --- ShapeAnalysis_FreeBoundsProperties (handle-based) ---
+// --- ShapeAnalysis_FreeBoundsProperties ---
+//
+// The one wrapping of this class since #504, which removed the stateless OCCTFreeBounds* family
+// declared in the v0.49.0 block. Every index below is 0-based and range-checked here.
+//
+// A free bound is a boundary contour of the shape: a chain of edges each used by exactly one
+// face, closed into a loop where it can be. Contours that close are "closed" bounds, the rest
+// "open". Note that the sewing-based search backing this class closes essentially
+// everything it finds, so the open sequence is usually empty (#504).
 
 typedef struct OCCTFreeBoundsProps* OCCTFreeBoundsPropsRef;
 
-/// Create a FreeBoundsProperties analyzer.
+/// Which of an analysis' two result sequences an accessor addresses.
+typedef enum {
+    OCCTFreeBoundClosed = 0,
+    OCCTFreeBoundOpen = 1
+} OCCTFreeBoundKind;
+
+/// Free bounds analysis result (summary)
+typedef struct {
+    int32_t totalFreeBounds;    // closedFreeBounds + openFreeBounds, per OCCT's own NbFreeBounds()
+    int32_t closedFreeBounds;
+    int32_t openFreeBounds;
+} OCCTFreeBoundsResult;
+
+/// Individual free bound properties
+typedef struct {
+    double area;
+    double perimeter;
+    // Aspect ratio: contour length divided by contour width, so 1 for a square-ish bound and 10
+    // for a 100x10 one. NOT area/perimeter^2, which is what this field claimed before #504.
+    // OCCT solves it from area and perimeter and leaves BOTH this and width at 0 when that solve
+    // has no real root, which an exactly square bound hits by one ulp, since it sits precisely on
+    // the boundary of the two branches. 0 here means "not solvable", not "degenerate contour".
+    double ratio;
+    double width;       // Average width, on the same 0-means-unsolved contract as ratio
+    int32_t notchCount; // Narrow 'V'-like sub-contours found on this bound
+} OCCTFreeBoundInfo;
+
+/// Create a free bounds analyzer over a shape. The shape should be a compound or shell of faces;
+/// a lone face has no free bounds, because the search runs over the shape's direct children.
+/// @param tolerance Sewing tolerance used to chain free edges into contours. A tolerance of 0 (or
+///        below) selects a different algorithm inside OCCT: the free edges are taken from the
+///        shape's already-shared topology instead of from a sewing pass.
 OCCTFreeBoundsPropsRef _Nullable OCCTFreeBoundsPropsCreate(OCCTShapeRef _Nonnull shape, double tolerance);
 
-/// Release a FreeBoundsProperties analyzer.
+/// Release a free bounds analyzer.
 void OCCTFreeBoundsPropsRelease(OCCTFreeBoundsPropsRef _Nonnull props);
 
-/// Perform the analysis.
+/// Run the analysis, if it has not already run, and report whether results are available.
+///
+/// Idempotent: OCCT's own Perform() appends to its result sequences without clearing them, so
+/// calling it twice doubles every count (#504). Calling this is optional: the accessors below
+/// run it on demand.
 bool OCCTFreeBoundsPropsPerform(OCCTFreeBoundsPropsRef _Nonnull props);
 
-/// Number of closed free bounds.
-int32_t OCCTFreeBoundsPropsNbClosedFreeBounds(OCCTFreeBoundsPropsRef _Nonnull props);
+/// Number of closed, open and total free bounds.
+OCCTFreeBoundsResult OCCTFreeBoundsPropsCounts(OCCTFreeBoundsPropsRef _Nonnull props);
 
-/// Number of open free bounds.
-int32_t OCCTFreeBoundsPropsNbOpenFreeBounds(OCCTFreeBoundsPropsRef _Nonnull props);
+/// Get the properties of one free bound.
+/// @param kind Which sequence to index
+/// @param index 0-based index within that sequence
+/// @return true on success; false, with *outInfo untouched, when index is out of range
+bool OCCTFreeBoundsPropsInfo(OCCTFreeBoundsPropsRef _Nonnull props, OCCTFreeBoundKind kind,
+                             int32_t index, OCCTFreeBoundInfo* _Nonnull outInfo);
 
-/// Get area of closed free bound by 1-based index.
-double OCCTFreeBoundsPropsClosedArea(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get perimeter of closed free bound by 1-based index.
-double OCCTFreeBoundsPropsClosedPerimeter(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get ratio (length/width) of closed free bound by 1-based index.
-double OCCTFreeBoundsPropsClosedRatio(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get width of closed free bound by 1-based index.
-double OCCTFreeBoundsPropsClosedWidth(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get wire of closed free bound by 1-based index.
-OCCTShapeRef _Nullable OCCTFreeBoundsPropsClosedWire(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get area of open free bound by 1-based index.
-double OCCTFreeBoundsPropsOpenArea(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get perimeter of open free bound by 1-based index.
-double OCCTFreeBoundsPropsOpenPerimeter(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
-
-/// Get wire of open free bound by 1-based index.
-OCCTShapeRef _Nullable OCCTFreeBoundsPropsOpenWire(OCCTFreeBoundsPropsRef _Nonnull props, int32_t index);
+/// Get the contour wire of one free bound, as a shape.
+/// @param kind Which sequence to index
+/// @param index 0-based index within that sequence
+/// @return Wire shape, or NULL when index is out of range
+OCCTShapeRef _Nullable OCCTFreeBoundsPropsWire(OCCTFreeBoundsPropsRef _Nonnull props,
+                                               OCCTFreeBoundKind kind, int32_t index);
 
 // --- BRepBuilderAPI_MakeWire (incremental) ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2330,94 +2330,11 @@ OCCTShapeRef OCCTShapeCustomBSplineRestriction(OCCTShapeRef shape,
 }
 
 // MARK: - ShapeAnalysis_FreeBoundsProperties (v0.49)
-// --- ShapeAnalysis_FreeBoundsProperties ---
-
-OCCTFreeBoundsResult OCCTFreeBoundsAnalyze(OCCTShapeRef shape, double tolerance) {
-    OCCTFreeBoundsResult result = {};
-    if (!shape) return result;
-    try {
-        ShapeAnalysis_FreeBoundsProperties fbp(shape->shape, tolerance);
-        if (!fbp.Perform()) return result;
-        result.totalFreeBounds = fbp.NbFreeBounds();
-        result.closedFreeBounds = fbp.NbClosedFreeBounds();
-        result.openFreeBounds = fbp.NbOpenFreeBounds();
-        return result;
-    } catch (...) {
-        return result;
-    }
-}
-
-OCCTFreeBoundInfo OCCTFreeBoundsGetClosedBoundInfo(OCCTShapeRef shape, double tolerance, int32_t index) {
-    OCCTFreeBoundInfo result = {};
-    if (!shape) return result;
-    try {
-        ShapeAnalysis_FreeBoundsProperties fbp(shape->shape, tolerance);
-        if (!fbp.Perform()) return result;
-        if (index < 0 || index >= fbp.NbClosedFreeBounds()) return result;
-        Handle(ShapeAnalysis_FreeBoundData) fbd = fbp.ClosedFreeBound(index + 1); // 1-indexed
-        if (fbd.IsNull()) return result;
-        result.area = fbd->Area();
-        result.perimeter = fbd->Perimeter();
-        result.ratio = fbd->Ratio();
-        result.width = fbd->Width();
-        result.notchCount = fbd->NbNotches();
-        return result;
-    } catch (...) {
-        return result;
-    }
-}
-
-OCCTFreeBoundInfo OCCTFreeBoundsGetOpenBoundInfo(OCCTShapeRef shape, double tolerance, int32_t index) {
-    OCCTFreeBoundInfo result = {};
-    if (!shape) return result;
-    try {
-        ShapeAnalysis_FreeBoundsProperties fbp(shape->shape, tolerance);
-        if (!fbp.Perform()) return result;
-        if (index < 0 || index >= fbp.NbOpenFreeBounds()) return result;
-        Handle(ShapeAnalysis_FreeBoundData) fbd = fbp.OpenFreeBound(index + 1); // 1-indexed
-        if (fbd.IsNull()) return result;
-        result.area = fbd->Area();
-        result.perimeter = fbd->Perimeter();
-        result.ratio = fbd->Ratio();
-        result.width = fbd->Width();
-        result.notchCount = fbd->NbNotches();
-        return result;
-    } catch (...) {
-        return result;
-    }
-}
-
-OCCTShapeRef OCCTFreeBoundsGetClosedBoundWire(OCCTShapeRef shape, double tolerance, int32_t index) {
-    if (!shape) return nullptr;
-    try {
-        ShapeAnalysis_FreeBoundsProperties fbp(shape->shape, tolerance);
-        if (!fbp.Perform()) return nullptr;
-        if (index < 0 || index >= fbp.NbClosedFreeBounds()) return nullptr;
-        Handle(ShapeAnalysis_FreeBoundData) fbd = fbp.ClosedFreeBound(index + 1);
-        if (fbd.IsNull()) return nullptr;
-        TopoDS_Wire wire = fbd->FreeBound();
-        if (wire.IsNull()) return nullptr;
-        return new OCCTShape(wire);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-OCCTShapeRef OCCTFreeBoundsGetOpenBoundWire(OCCTShapeRef shape, double tolerance, int32_t index) {
-    if (!shape) return nullptr;
-    try {
-        ShapeAnalysis_FreeBoundsProperties fbp(shape->shape, tolerance);
-        if (!fbp.Perform()) return nullptr;
-        if (index < 0 || index >= fbp.NbOpenFreeBounds()) return nullptr;
-        Handle(ShapeAnalysis_FreeBoundData) fbd = fbp.OpenFreeBound(index + 1);
-        if (fbd.IsNull()) return nullptr;
-        TopoDS_Wire wire = fbd->FreeBound();
-        if (wire.IsNull()) return nullptr;
-        return new OCCTShape(wire);
-    } catch (...) {
-        return nullptr;
-    }
-}
+//
+// OCCTFreeBoundsAnalyze, OCCTFreeBoundsGetClosedBoundInfo, OCCTFreeBoundsGetOpenBoundInfo,
+// OCCTFreeBoundsGetClosedBoundWire and OCCTFreeBoundsGetOpenBoundWire were implemented here,
+// each constructing its own ShapeAnalysis_FreeBoundsProperties and calling Perform() again.
+// Removed by #504; the one implementation is with the v0.114 block below.
 
 // MARK: - ShapeAnalysis_WireVertex (v0.50)
 OCCTWireVertexResult OCCTShapeWireVertexAnalysis(OCCTShapeRef wire, double precision) {
@@ -4521,12 +4438,53 @@ OCCTShapeContentsExtended OCCTShapeGetContentsExtended(OCCTShapeRef shape) {
     } catch (...) {}
     return result;
 }
-// --- ShapeAnalysis_FreeBoundsProperties (handle-based) ---
+// --- ShapeAnalysis_FreeBoundsProperties ---
+//
+// The one wrapping of this class since #504. See OCCTBridge.h for the contract; the two things
+// that shape this code are both OCCT behaviours measured against the pinned kernel:
+//
+//   Perform() appends to myClosedFreeBounds/myOpenFreeBounds and never clears them, and Init()
+//   does not clear them either; only the constructors allocate them. So a second Perform() on
+//   one instance doubles every count, a third triples it. `performed` therefore latches, and
+//   nothing here calls Perform() again.
+//
+//   Perform() itself returns DispatchBounds() | CheckNotches() | CheckContours(), and
+//   CheckNotches() returns true unconditionally, so it is true even for a shape with no free
+//   bounds at all, and even for one that was never loaded, contradicting its own documented
+//   "False if fail or no free bounds are found". IsLoaded() is the real signal, so that is what
+//   is checked here.
 
 struct OCCTFreeBoundsProps {
     ShapeAnalysis_FreeBoundsProperties fbp;
     bool performed;
 };
+
+// Run the analysis once. Returns whether results can be read.
+static bool occtFreeBoundsPerformed(OCCTFreeBoundsPropsRef props) {
+    if (!props) return false;
+    if (props->performed) return true;
+    try {
+        if (!props->fbp.IsLoaded()) return false;
+        props->fbp.Perform();
+        props->performed = true;
+        return true;
+    } catch (...) { return false; }
+}
+
+// Resolve a 0-based index within one of the two sequences, range-checked here rather than left
+// to NCollection_Sequence::Value's own throw: that check is compiled into this TU, so it does
+// fire, but it costs an exception per out-of-range read and cannot distinguish "no such bound"
+// from a genuine OCCT failure.
+static Handle(ShapeAnalysis_FreeBoundData) occtFreeBound(OCCTFreeBoundsPropsRef props,
+                                                          OCCTFreeBoundKind kind, int32_t index) {
+    if (!occtFreeBoundsPerformed(props) || index < 0) return nullptr;
+    const bool closed = (kind == OCCTFreeBoundClosed);
+    try {
+        if (index >= (closed ? props->fbp.NbClosedFreeBounds() : props->fbp.NbOpenFreeBounds()))
+            return nullptr;
+        return closed ? props->fbp.ClosedFreeBound(index + 1) : props->fbp.OpenFreeBound(index + 1);
+    } catch (...) { return nullptr; }
+}
 
 OCCTFreeBoundsPropsRef OCCTFreeBoundsPropsCreate(OCCTShapeRef shape, double tolerance) {
     if (!shape) return nullptr;
@@ -4543,99 +4501,44 @@ void OCCTFreeBoundsPropsRelease(OCCTFreeBoundsPropsRef props) {
 }
 
 bool OCCTFreeBoundsPropsPerform(OCCTFreeBoundsPropsRef props) {
-    if (!props) return false;
+    return occtFreeBoundsPerformed(props);
+}
+
+OCCTFreeBoundsResult OCCTFreeBoundsPropsCounts(OCCTFreeBoundsPropsRef props) {
+    OCCTFreeBoundsResult result = {};
+    if (!occtFreeBoundsPerformed(props)) return result;
     try {
-        bool ok = props->fbp.Perform();
-        props->performed = ok;
-        return ok;
+        result.totalFreeBounds = (int32_t)props->fbp.NbFreeBounds();
+        result.closedFreeBounds = (int32_t)props->fbp.NbClosedFreeBounds();
+        result.openFreeBounds = (int32_t)props->fbp.NbOpenFreeBounds();
+    } catch (...) { return OCCTFreeBoundsResult{}; }
+    return result;
+}
+
+bool OCCTFreeBoundsPropsInfo(OCCTFreeBoundsPropsRef props, OCCTFreeBoundKind kind,
+                             int32_t index, OCCTFreeBoundInfo* outInfo) {
+    Handle(ShapeAnalysis_FreeBoundData) fbd = occtFreeBound(props, kind, index);
+    if (fbd.IsNull()) return false;
+    try {
+        OCCTFreeBoundInfo info = {};
+        info.area = fbd->Area();
+        info.perimeter = fbd->Perimeter();
+        info.ratio = fbd->Ratio();
+        info.width = fbd->Width();
+        info.notchCount = (int32_t)fbd->NbNotches();
+        *outInfo = info;
+        return true;
     } catch (...) { return false; }
 }
 
-int32_t OCCTFreeBoundsPropsNbClosedFreeBounds(OCCTFreeBoundsPropsRef props) {
-    if (!props || !props->performed) return 0;
-    try { return (int32_t)props->fbp.NbClosedFreeBounds(); }
-    catch (...) { return 0; }
-}
-
-int32_t OCCTFreeBoundsPropsNbOpenFreeBounds(OCCTFreeBoundsPropsRef props) {
-    if (!props || !props->performed) return 0;
-    try { return (int32_t)props->fbp.NbOpenFreeBounds(); }
-    catch (...) { return 0; }
-}
-
-double OCCTFreeBoundsPropsClosedArea(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return 0;
+OCCTShapeRef OCCTFreeBoundsPropsWire(OCCTFreeBoundsPropsRef props,
+                                     OCCTFreeBoundKind kind, int32_t index) {
+    Handle(ShapeAnalysis_FreeBoundData) fbd = occtFreeBound(props, kind, index);
+    if (fbd.IsNull()) return nullptr;
     try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.ClosedFreeBound(index);
-        if (fbd.IsNull()) return 0;
-        return fbd->Area();
-    } catch (...) { return 0; }
-}
-
-double OCCTFreeBoundsPropsClosedPerimeter(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return 0;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.ClosedFreeBound(index);
-        if (fbd.IsNull()) return 0;
-        return fbd->Perimeter();
-    } catch (...) { return 0; }
-}
-
-double OCCTFreeBoundsPropsClosedRatio(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return 0;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.ClosedFreeBound(index);
-        if (fbd.IsNull()) return 0;
-        return fbd->Ratio();
-    } catch (...) { return 0; }
-}
-
-double OCCTFreeBoundsPropsClosedWidth(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return 0;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.ClosedFreeBound(index);
-        if (fbd.IsNull()) return 0;
-        return fbd->Width();
-    } catch (...) { return 0; }
-}
-
-OCCTShapeRef OCCTFreeBoundsPropsClosedWire(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return nullptr;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.ClosedFreeBound(index);
-        if (fbd.IsNull()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = fbd->FreeBound();
-        return ref;
-    } catch (...) { return nullptr; }
-}
-
-double OCCTFreeBoundsPropsOpenArea(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return 0;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.OpenFreeBound(index);
-        if (fbd.IsNull()) return 0;
-        return fbd->Area();
-    } catch (...) { return 0; }
-}
-
-double OCCTFreeBoundsPropsOpenPerimeter(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return 0;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.OpenFreeBound(index);
-        if (fbd.IsNull()) return 0;
-        return fbd->Perimeter();
-    } catch (...) { return 0; }
-}
-
-OCCTShapeRef OCCTFreeBoundsPropsOpenWire(OCCTFreeBoundsPropsRef props, int32_t index) {
-    if (!props || !props->performed) return nullptr;
-    try {
-        Handle(ShapeAnalysis_FreeBoundData) fbd = props->fbp.OpenFreeBound(index);
-        if (fbd.IsNull()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = fbd->FreeBound();
-        return ref;
+        TopoDS_Wire wire = fbd->FreeBound();
+        if (wire.IsNull()) return nullptr;
+        return new OCCTShape(wire);
     } catch (...) { return nullptr; }
 }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -12562,13 +12562,48 @@ extension Shape {
     }
 }
 
-// --- ShapeAnalysis_FreeBoundsProperties (handle-based) ---
+// --- ShapeAnalysis_FreeBoundsProperties ---
 
 /// Persistent free bounds properties analyzer.
+///
+/// A free bound is a boundary contour of the shape: a chain of edges each used by exactly one
+/// face, closed into a loop where it can be. The analysis runs once, and every query below is
+/// answered from that one result, which is the difference between this and `Shape`'s
+/// `freeBoundsAnalysis(tolerance:)` family, where each call analyses the shape again.
+///
+/// ```swift
+/// // A box shell with one face removed: its free boundary is the square hole.
+/// let opened = Shape.compound(box.subShapes(ofType: .face).dropLast())!
+/// let props = FreeBoundsProperties(shape: opened, tolerance: 1e-3)!
+///
+/// for i in 0..<props.closedCount {
+///     let bound = props.info(.closed, at: i)!
+///     print(bound.area, bound.perimeter, bound.notchCount)
+///     let wire = props.wire(.closed, at: i)
+/// }
+/// ```
+///
+/// The shape needs to be a compound or shell of faces: the search runs over its direct children,
+/// so a lone face reports no free bounds. In practice the sewing pass closes essentially every
+/// contour it finds, so ``openCount`` is usually 0.
 public final class FreeBoundsProperties: @unchecked Sendable {
     private let ref: OCCTFreeBoundsPropsRef
 
+    /// Which of the analysis' two result sequences a query addresses.
+    public enum BoundKind: Sendable {
+        /// Contours that close into a loop.
+        case closed
+        /// Contours that do not.
+        case open
+
+        fileprivate var occt: OCCTFreeBoundKind { self == .closed ? OCCTFreeBoundClosed : OCCTFreeBoundOpen }
+    }
+
     /// Create a free bounds properties analyzer.
+    ///
+    /// - Parameter tolerance: Sewing tolerance used to chain free edges into contours. 0 or below
+    ///   selects a different OCCT algorithm, taking free edges from the shape's already-shared
+    ///   topology instead of from a sewing pass.
     public init?(shape: Shape, tolerance: Double = 1e-7) {
         guard let r = OCCTFreeBoundsPropsCreate(shape.handle, tolerance) else { return nil }
         self.ref = r
@@ -12578,59 +12613,69 @@ public final class FreeBoundsProperties: @unchecked Sendable {
         OCCTFreeBoundsPropsRelease(ref)
     }
 
-    /// Perform analysis.
+    /// Run the analysis, if it has not already run, and report whether results are available.
+    ///
+    /// Calling this is optional: every query below runs it on demand. It is also idempotent, so a
+    /// second call is a no-op, not a second analysis.
     @discardableResult
     public func perform() -> Bool {
         OCCTFreeBoundsPropsPerform(ref)
     }
 
     /// Number of closed free bounds.
-    public var closedCount: Int { Int(OCCTFreeBoundsPropsNbClosedFreeBounds(ref)) }
+    public var closedCount: Int { Int(OCCTFreeBoundsPropsCounts(ref).closedFreeBounds) }
 
     /// Number of open free bounds.
-    public var openCount: Int { Int(OCCTFreeBoundsPropsNbOpenFreeBounds(ref)) }
+    public var openCount: Int { Int(OCCTFreeBoundsPropsCounts(ref).openFreeBounds) }
 
-    /// Get area of a closed free bound (0-based index).
-    public func closedArea(at index: Int) -> Double {
-        OCCTFreeBoundsPropsClosedArea(ref, Int32(index + 1))
+    /// Total number of free bounds, closed and open.
+    public var totalCount: Int { Int(OCCTFreeBoundsPropsCounts(ref).totalFreeBounds) }
+
+    /// Get every property of one free bound (0-based index), or nil if the index is out of range.
+    public func info(_ kind: BoundKind, at index: Int) -> Shape.FreeBoundInfo? {
+        var out = OCCTFreeBoundInfo()
+        guard OCCTFreeBoundsPropsInfo(ref, kind.occt, Int32(index), &out) else { return nil }
+        return Shape.FreeBoundInfo(
+            area: out.area, perimeter: out.perimeter,
+            ratio: out.ratio, width: out.width,
+            notchCount: Int(out.notchCount)
+        )
     }
 
-    /// Get perimeter of a closed free bound (0-based index).
-    public func closedPerimeter(at index: Int) -> Double {
-        OCCTFreeBoundsPropsClosedPerimeter(ref, Int32(index + 1))
+    /// Get the contour wire of one free bound (0-based index), or nil if the index is out of range.
+    public func wire(_ kind: BoundKind, at index: Int) -> Shape? {
+        guard let w = OCCTFreeBoundsPropsWire(ref, kind.occt, Int32(index)) else { return nil }
+        return Shape(handle: w)
     }
 
-    /// Get ratio (length/width) of a closed free bound (0-based index).
-    public func closedRatio(at index: Int) -> Double {
-        OCCTFreeBoundsPropsClosedRatio(ref, Int32(index + 1))
-    }
+    /// Get area of a closed free bound (0-based index), or 0 if the index is out of range.
+    public func closedArea(at index: Int) -> Double { info(.closed, at: index)?.area ?? 0 }
 
-    /// Get width of a closed free bound (0-based index).
-    public func closedWidth(at index: Int) -> Double {
-        OCCTFreeBoundsPropsClosedWidth(ref, Int32(index + 1))
-    }
+    /// Get perimeter of a closed free bound (0-based index), or 0 if the index is out of range.
+    public func closedPerimeter(at index: Int) -> Double { info(.closed, at: index)?.perimeter ?? 0 }
+
+    /// Get aspect ratio of a closed free bound (0-based index), or 0 if the index is out of range.
+    ///
+    /// See ``Shape/FreeBoundInfo/ratio``. 0 is also what OCCT reports for a bound whose ratio it
+    /// cannot solve, an exactly square one among them.
+    public func closedRatio(at index: Int) -> Double { info(.closed, at: index)?.ratio ?? 0 }
+
+    /// Get width of a closed free bound (0-based index), or 0 if the index is out of range.
+    ///
+    /// Carries the same "0 means unsolved" caveat as ``closedRatio(at:)``.
+    public func closedWidth(at index: Int) -> Double { info(.closed, at: index)?.width ?? 0 }
 
     /// Get wire of a closed free bound (0-based index).
-    public func closedWire(at index: Int) -> Shape? {
-        guard let ref = OCCTFreeBoundsPropsClosedWire(ref, Int32(index + 1)) else { return nil }
-        return Shape(handle: ref)
-    }
+    public func closedWire(at index: Int) -> Shape? { wire(.closed, at: index) }
 
-    /// Get area of an open free bound (0-based index).
-    public func openArea(at index: Int) -> Double {
-        OCCTFreeBoundsPropsOpenArea(ref, Int32(index + 1))
-    }
+    /// Get area of an open free bound (0-based index), or 0 if the index is out of range.
+    public func openArea(at index: Int) -> Double { info(.open, at: index)?.area ?? 0 }
 
-    /// Get perimeter of an open free bound (0-based index).
-    public func openPerimeter(at index: Int) -> Double {
-        OCCTFreeBoundsPropsOpenPerimeter(ref, Int32(index + 1))
-    }
+    /// Get perimeter of an open free bound (0-based index), or 0 if the index is out of range.
+    public func openPerimeter(at index: Int) -> Double { info(.open, at: index)?.perimeter ?? 0 }
 
     /// Get wire of an open free bound (0-based index).
-    public func openWire(at index: Int) -> Shape? {
-        guard let ref = OCCTFreeBoundsPropsOpenWire(ref, Int32(index + 1)) else { return nil }
-        return Shape(handle: ref)
-    }
+    public func openWire(at index: Int) -> Shape? { wire(.open, at: index) }
 }
 
 // --- BRepBuilderAPI_MakeWire (incremental) ---

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -8038,11 +8038,17 @@ extension Shape {
         public let area: Double
         /// Perimeter length
         public let perimeter: Double
-        /// Aspect ratio (area / perimeter^2)
+        /// Aspect ratio: contour length divided by contour width. 1 for a square-ish bound, 10 for
+        /// a 100×10 one.
+        ///
+        /// OCCT solves this from `area` and `perimeter` and leaves both this and ``width`` at 0
+        /// when that solve has no real root, which an exactly square bound hits by one ulp, since
+        /// it sits precisely on the boundary between the two branches. So 0 means "not solvable
+        /// here", not "degenerate contour"; `area` and `perimeter` are still good in that case.
         public let ratio: Double
-        /// Average width
+        /// Average width, on the same "0 means unsolved" contract as ``ratio``
         public let width: Double
-        /// Number of notches
+        /// Number of notches (narrow 'V'-like sub-contours) found on the bound
         public let notchCount: Int
     }
 
@@ -8058,50 +8064,66 @@ extension Shape {
 
     /// Analyze free bounds (boundary wires) of this shape.
     ///
-    /// Free bounds are edges that belong to only one face. Uses
-    /// ShapeAnalysis_FreeBoundsProperties to find and classify them.
+    /// Free bounds are chains of edges that belong to only one face, closed into contours where
+    /// they can be. Uses `ShapeAnalysis_FreeBoundsProperties` to find and classify them.
     ///
-    /// - Parameter tolerance: Sewing tolerance for finding free bounds
+    /// The shape needs to be a compound or shell of faces: the search runs over its direct
+    /// children, so a lone face reports no free bounds at all. In practice the sewing pass closes
+    /// essentially every contour it finds, so ``FreeBoundsAnalysis/openCount`` is usually 0.
+    ///
+    /// Each of the five `…FreeBound…` methods here runs its own analysis. To read several bounds
+    /// of one shape, build a ``FreeBoundsProperties`` instead: it analyses once and answers every
+    /// query from that one result.
+    ///
+    /// ```swift
+    /// let opened = Shape.compound(box.subShapes(ofType: .face).dropLast())!
+    /// let analysis = opened.freeBoundsAnalysis(tolerance: 1e-3)
+    /// print(analysis.closedCount)  // 1, the contour around the missing face
+    ///
+    /// if let bound = opened.closedFreeBoundInfo(tolerance: 1e-3, index: 0) {
+    ///     print(bound.area, bound.perimeter)
+    /// }
+    /// ```
+    ///
+    /// - Parameter tolerance: Sewing tolerance used to chain free edges into contours. 0 or below
+    ///   selects a different OCCT algorithm, taking free edges from the shape's already-shared
+    ///   topology instead of from a sewing pass.
     /// - Returns: Analysis summary with bound counts
     public func freeBoundsAnalysis(tolerance: Double) -> FreeBoundsAnalysis {
-        let result = OCCTFreeBoundsAnalyze(handle, tolerance)
+        guard let props = FreeBoundsProperties(shape: self, tolerance: tolerance) else {
+            return FreeBoundsAnalysis(totalCount: 0, closedCount: 0, openCount: 0)
+        }
         return FreeBoundsAnalysis(
-            totalCount: Int(result.totalFreeBounds),
-            closedCount: Int(result.closedFreeBounds),
-            openCount: Int(result.openFreeBounds)
+            totalCount: props.totalCount,
+            closedCount: props.closedCount,
+            openCount: props.openCount
         )
     }
 
     /// Get properties of a closed free bound.
+    ///
+    /// See ``freeBoundsAnalysis(tolerance:)`` for what the tolerance selects, and
+    /// ``FreeBoundsProperties`` for reading several bounds without re-analysing each time.
     ///
     /// - Parameters:
     ///   - tolerance: Same tolerance used for analysis
     ///   - index: 0-based index of the closed free bound
     /// - Returns: Properties of the bound, or nil if index is out of range
     public func closedFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo? {
-        let result = OCCTFreeBoundsGetClosedBoundInfo(handle, tolerance, Int32(index))
-        guard result.perimeter > 0 else { return nil }
-        return FreeBoundInfo(
-            area: result.area, perimeter: result.perimeter,
-            ratio: result.ratio, width: result.width,
-            notchCount: Int(result.notchCount)
-        )
+        FreeBoundsProperties(shape: self, tolerance: tolerance)?.info(.closed, at: index)
     }
 
     /// Get properties of an open free bound.
+    ///
+    /// See ``freeBoundsAnalysis(tolerance:)`` for what the tolerance selects, and
+    /// ``FreeBoundsProperties`` for reading several bounds without re-analysing each time.
     ///
     /// - Parameters:
     ///   - tolerance: Same tolerance used for analysis
     ///   - index: 0-based index of the open free bound
     /// - Returns: Properties of the bound, or nil if index is out of range
     public func openFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo? {
-        let result = OCCTFreeBoundsGetOpenBoundInfo(handle, tolerance, Int32(index))
-        guard result.perimeter > 0 else { return nil }
-        return FreeBoundInfo(
-            area: result.area, perimeter: result.perimeter,
-            ratio: result.ratio, width: result.width,
-            notchCount: Int(result.notchCount)
-        )
+        FreeBoundsProperties(shape: self, tolerance: tolerance)?.info(.open, at: index)
     }
 
     /// Get the wire shape of a closed free bound.
@@ -8111,8 +8133,7 @@ extension Shape {
     ///   - index: 0-based index of the closed free bound
     /// - Returns: Wire as a Shape, or nil if index is out of range
     public func closedFreeBoundWire(tolerance: Double, index: Int) -> Shape? {
-        guard let ref = OCCTFreeBoundsGetClosedBoundWire(handle, tolerance, Int32(index)) else { return nil }
-        return Shape(handle: ref)
+        FreeBoundsProperties(shape: self, tolerance: tolerance)?.wire(.closed, at: index)
     }
 
     /// Get the wire shape of an open free bound.
@@ -8122,8 +8143,7 @@ extension Shape {
     ///   - index: 0-based index of the open free bound
     /// - Returns: Wire as a Shape, or nil if index is out of range
     public func openFreeBoundWire(tolerance: Double, index: Int) -> Shape? {
-        guard let ref = OCCTFreeBoundsGetOpenBoundWire(handle, tolerance, Int32(index)) else { return nil }
-        return Shape(handle: ref)
+        FreeBoundsProperties(shape: self, tolerance: tolerance)?.wire(.open, at: index)
     }
 
     // MARK: - v0.50.0: Polyhedral distance, history tracking, wire vertex analysis, nearest plane

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -5058,6 +5058,114 @@ struct FreeBoundsPropsTests {
             }
         }
     }
+
+    // Two stacked rectangles: two disjoint closed free bounds, no open ones.
+    private func twoRects(_ w: Double, _ h: Double) -> Shape {
+        let lower = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(w, 0, 0), SIMD3(w, h, 0), SIMD3(0, h, 0)
+        ])!)!
+        let upper = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 5), SIMD3(w, 0, 5), SIMD3(w, h, 5), SIMD3(0, h, 5)
+        ])!)!
+        return Shape.compound([lower, upper])!
+    }
+
+    // #504: OCCT's own Perform() appends to its result sequences and never clears them, and
+    // Init() does not clear them either; only the constructors allocate them. Two calls used
+    // to double every count, three to triple it, and perform() is public and @discardableResult.
+    // The bridge latches it now.
+    @Test func performIsIdempotent() throws {
+        let props = try #require(FreeBoundsProperties(shape: twoRects(10, 10), tolerance: 0.01))
+        #expect(props.perform())
+        let once = props.closedCount
+        #expect(once == 2)
+
+        #expect(props.perform())
+        #expect(props.perform())
+        #expect(props.closedCount == once)
+        #expect(props.openCount == 0)
+        #expect(props.totalCount == once)
+    }
+
+    // #504: the accessors used to return 0 until perform() had been called, so forgetting it
+    // read as "this shape has no free bounds". They run the analysis on demand now.
+    @Test func accessorsRunTheAnalysisOnDemand() throws {
+        let props = try #require(FreeBoundsProperties(shape: twoRects(10, 10), tolerance: 0.01))
+        #expect(props.closedCount == 2)          // no perform() call at all
+        #expect(props.info(.closed, at: 0) != nil)
+        #expect(props.wire(.closed, at: 0) != nil)
+    }
+
+    // #504: the C layer took a 1-based index here and a 0-based one in the family Shape used,
+    // and neither range-checked it, so an out-of-range read reached NCollection_Sequence::Value
+    // and came back as 0 from the catch-all. Both are 0-based and checked now.
+    @Test func indexOutOfRange() throws {
+        let props = try #require(FreeBoundsProperties(shape: twoRects(10, 10), tolerance: 0.01))
+        #expect(props.info(.closed, at: 1) != nil)
+
+        for bad in [props.closedCount, props.closedCount + 5, -1] {
+            #expect(props.info(.closed, at: bad) == nil)
+            #expect(props.wire(.closed, at: bad) == nil)
+            #expect(props.closedArea(at: bad) == 0)
+            #expect(props.closedPerimeter(at: bad) == 0)
+        }
+        // The open sequence is empty for every fixture reachable through this API.
+        #expect(props.openCount == 0)
+        #expect(props.info(.open, at: 0) == nil)
+        #expect(props.wire(.open, at: 0) == nil)
+        #expect(props.openArea(at: 0) == 0)
+        #expect(props.openPerimeter(at: 0) == 0)
+        #expect(props.openWire(at: 0) == nil)
+    }
+
+    // #504: closedRatio/closedWidth had no coverage. `ratio` is the contour's length/width
+    // aspect ratio, NOT area/perimeter^2, which is what the bridge header and Shape.FreeBoundInfo
+    // both claimed. A 20x10 bound is 2, and area/perimeter^2 would be 0.0556.
+    @Test func ratioAndWidthAreAnAspectRatio() throws {
+        let props = try #require(FreeBoundsProperties(shape: twoRects(20, 10), tolerance: 0.01))
+        let bound = try #require(props.info(.closed, at: 0))
+        #expect(abs(bound.area - 200.0) < 0.5)
+        #expect(abs(bound.perimeter - 60.0) < 0.5)
+        #expect(abs(bound.ratio - 2.0) < 0.01)
+        #expect(abs(bound.width - 10.0) < 0.05)
+        #expect(bound.notchCount == 0)
+
+        #expect(props.closedArea(at: 0) == bound.area)
+        #expect(props.closedPerimeter(at: 0) == bound.perimeter)
+        #expect(props.closedRatio(at: 0) == bound.ratio)
+        #expect(props.closedWidth(at: 0) == bound.width)
+    }
+
+    // #504: OCCT solves ratio and width from area and perimeter, and a square bound sits exactly
+    // on the boundary between the two branches of that solve: one ulp the wrong way and there is
+    // no real root, so both come back 0 while area and perimeter stay correct. Pinned because it
+    // makes a square the one fixture that must not be used to test ratio or width.
+    @Test func squareBoundReportsNoRatioOrWidth() throws {
+        let props = try #require(FreeBoundsProperties(shape: twoRects(10, 10), tolerance: 0.01))
+        let bound = try #require(props.info(.closed, at: 0))
+        #expect(abs(bound.area - 100.0) < 0.5)
+        #expect(abs(bound.perimeter - 40.0) < 0.5)
+        #expect(bound.ratio == 0)
+        #expect(bound.width == 0)
+    }
+
+    // #504: notchCount was only reachable through Shape's family, which is gone; it is part of
+    // info(_:at:) now. A narrow V cut into the contour is what OCCT counts as a notch.
+    @Test func notchesAreCounted() throws {
+        let notched = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0),
+            SIMD3(5.05, 10, 0), SIMD3(5.0, 1, 0), SIMD3(4.95, 10, 0),
+            SIMD3(0, 10, 0)
+        ])!)!
+        let plain = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 5), SIMD3(10, 0, 5), SIMD3(10, 10, 5), SIMD3(0, 10, 5)
+        ])!)!
+        let props = try #require(FreeBoundsProperties(shape: Shape.compound([notched, plain])!,
+                                                      tolerance: 0.01))
+        let counts = (0..<props.closedCount).compactMap { props.info(.closed, at: $0)?.notchCount }
+        #expect(counts.contains(1))   // the slit
+        #expect(counts.contains(0))   // the plain square
+    }
 }
 
 @Suite("v0.114.0 - Mass Properties")

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -764,6 +764,82 @@ struct FreeBoundsPropertiesTests {
             }
         }
     }
+
+    // Two stacked 10x10 faces: two disjoint closed free bounds, no open ones.
+    private func twoFaces() -> Shape {
+        let lower = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)
+        ])!)!
+        let upper = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 5), SIMD3(10, 0, 5), SIMD3(10, 10, 5), SIMD3(0, 10, 5)
+        ])!)!
+        return Shape.compound([lower, upper])!
+    }
+
+    // #504: the four indexed accessors used to report "no such bound" by returning a zeroed
+    // struct, which Shape.swift read as `perimeter > 0`. A bound whose perimeter really is 0
+    // would have been indistinguishable, and the wire accessors had no signal at all beyond a
+    // throw from inside OCCT. The index is now range-checked in the bridge.
+    @Test("Free bound index out of range is nil, not a zeroed result")
+    func freeBoundIndexOutOfRange() throws {
+        let compound = twoFaces()
+        let analysis = compound.freeBoundsAnalysis(tolerance: 0.01)
+        #expect(analysis.closedCount == 2)
+        #expect(analysis.totalCount == analysis.closedCount + analysis.openCount)
+
+        #expect(compound.closedFreeBoundInfo(tolerance: 0.01, index: 1) != nil)
+        #expect(compound.closedFreeBoundWire(tolerance: 0.01, index: 1) != nil)
+
+        for bad in [analysis.closedCount, analysis.closedCount + 5, -1] {
+            #expect(compound.closedFreeBoundInfo(tolerance: 0.01, index: bad) == nil)
+            #expect(compound.closedFreeBoundWire(tolerance: 0.01, index: bad) == nil)
+        }
+    }
+
+    // #504: the open side of this family had no coverage at all. The sewing-based free-edge
+    // search closes essentially every contour it finds, so an open bound is not reachable
+    // through this entry point. What is worth pinning is that asking for one is a clean nil.
+    @Test("Open free bound accessors on a shape with no open bounds")
+    func openFreeBoundsAbsent() throws {
+        let compound = twoFaces()
+        #expect(compound.freeBoundsAnalysis(tolerance: 0.01).openCount == 0)
+        #expect(compound.openFreeBoundInfo(tolerance: 0.01, index: 0) == nil)
+        #expect(compound.openFreeBoundWire(tolerance: 0.01, index: 0) == nil)
+    }
+
+    // #504: the search runs over the shape's direct children, so a bare face offers its wires,
+    // not itself, and finds nothing. Every fixture in this suite is a compound for that reason.
+    @Test("A lone face has no free bounds")
+    func loneFaceHasNoFreeBounds() throws {
+        let face = Shape.face(from: Wire.polygon3D([
+            SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)
+        ])!)!
+        let analysis = face.freeBoundsAnalysis(tolerance: 0.01)
+        #expect(analysis.totalCount == 0)
+        #expect(analysis.closedCount == 0)
+        #expect(analysis.openCount == 0)
+    }
+
+    // #504: Shape's five methods and FreeBoundsProperties were two independent wrappings of one
+    // OCCT class, with opposite index-base conventions in the C layer. They share one now, so
+    // the same bound read either way has to come back identical.
+    @Test("Shape and FreeBoundsProperties report the same bound")
+    func shapeAndPropertiesAgree() throws {
+        let compound = twoFaces()
+        let props = try #require(FreeBoundsProperties(shape: compound, tolerance: 0.01))
+
+        #expect(props.closedCount == compound.freeBoundsAnalysis(tolerance: 0.01).closedCount)
+
+        for i in 0..<props.closedCount {
+            let viaShape = try #require(compound.closedFreeBoundInfo(tolerance: 0.01, index: i))
+            let viaProps = try #require(props.info(.closed, at: i))
+            #expect(viaShape.area == viaProps.area)
+            #expect(viaShape.perimeter == viaProps.perimeter)
+            #expect(viaShape.ratio == viaProps.ratio)
+            #expect(viaShape.width == viaProps.width)
+            #expect(viaShape.notchCount == viaProps.notchCount)
+        }
+    }
 }
 
 @Suite("ShapeAnalysis Surface ValueOfUV Tests")

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,328** of the entry points (~78% of the `Total` below); the rest are real, callable,
+categorisation covering **3,330** of the entry points (~78% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,290** | |
+| **Total** | **4,293** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -181,6 +181,67 @@ that do; and `ShapeAnalysis_Curve` named three functions that do not exist under
 
 Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
 
+#### One free-bounds analyser, and the double-`perform()` bug the second one hid (#504)
+
+`ShapeAnalysis_FreeBoundsProperties` was wrapped twice. The v0.49.0 family behind `Shape`'s five
+`…FreeBound…` methods rebuilt the whole analyser and re-ran `Perform()` on every single call, so
+a per-bound report cost one full free-bound search *per bound*; the v0.114.0 family behind
+`FreeBoundsProperties` analysed once and answered every query from that result. The two also took
+opposite index bases in the C layer, 0-based on one side and 1-based on the other for the same
+conceptual parameter, with neither declaration saying the other existed. Both Swift wrappers
+compensated correctly, so nothing was visibly broken; a third caller written against either C
+function by analogy with the other would have been off by one with no diagnostic.
+
+Consolidating them turned up a real bug that only the newer family could reach. OCCT's `Perform()`
+*appends* to its two result sequences and never clears them, and `Init()` does not clear them
+either; only the constructors allocate them. `FreeBoundsProperties.perform()` is public and
+`@discardableResult`, so calling it twice doubled every count and every notch:
+
+```swift
+let props = FreeBoundsProperties(shape: opened, tolerance: 1e-3)!
+props.perform(); props.closedCount   // 2
+props.perform(); props.closedCount   // 4   (before #504)
+props.perform(); props.closedCount   // 6
+```
+
+The stateless family could not hit it, because each of its calls built a fresh analyser. It is
+latched in the bridge now, and `perform()` is optional as well as idempotent: every accessor runs
+the analysis on demand, so forgetting it no longer reads as "this shape has no free bounds".
+
+**Not source-breaking.** `Shape.freeBoundsAnalysis(tolerance:)`, `closedFreeBoundInfo`,
+`openFreeBoundInfo`, `closedFreeBoundWire` and `openFreeBoundWire` keep their signatures and now
+run on the shared analyser. `FreeBoundsProperties` keeps all eight of its accessors and gains
+`totalCount`, `info(_:at:)` and `wire(_:at:)`, which take a `BoundKind` (`.closed` / `.open`) and
+give the open side the `ratio`, `width` and `notchCount` only the closed side used to expose.
+
+An out-of-range index is now a real answer rather than a guess. `Shape`'s info methods used to
+infer it from `perimeter > 0`, so a genuine zero-perimeter bound would have read as "no such
+bound", and the `FreeBoundsProperties` accessors did not range-check at all, letting the index reach
+`NCollection_Sequence::Value` and come back 0 from a catch-all. Both are checked in the bridge
+against the sequence length, and both report it as `nil` (or `0`, for the `Double` accessors).
+
+Two OCCT behaviours are documented and pinned by tests, having been found while measuring this:
+
+- **`ratio` is an aspect ratio**, contour length over contour width: 2 for a 20×10 bound. Both
+  `OCCTBridge.h` and `Shape.FreeBoundInfo` called it `area / perimeter²`, which for that bound is
+  0.0556. OCCT solves it from the area and the perimeter, and leaves *both* `ratio` and `width` at
+  0 when that solve has no real root, which an exactly **square** bound hits by one ulp, sitting
+  precisely on the branch boundary. So 0 means "not solvable", not "degenerate contour", and a
+  square is the one fixture that must not be used to test either field.
+- **`Perform()` is not a success signal.** It returns
+  `DispatchBounds() | CheckNotches() | CheckContours()`, and `CheckNotches()` returns `true`
+  unconditionally, so it is `true` for a shape with no free bounds at all and for one that was
+  never loaded, the opposite of its documented "False if fail or no free bounds are found".
+  `IsLoaded()` is what the bridge checks instead.
+
+The C family is 18 functions down to 6. `OCCTBridge.h`'s cross-reference index entry for the class
+named `OCCTShapeFreeBoundsAnalysis*`, a prefix that has never existed anywhere in the codebase; it
+names the real family now. `ShapeAnalysis_FreeBounds` (the similarly-named sibling class behind
+`Shape.freeBoundsClosedWires` and friends, easy to conflate and genuinely different) gains the
+index entry it never had.
+
+Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
+
 #### One continuity decoder per vocabulary, not nineteen (#490)
 
 Continuity reached OCCT as a plain integer through 19 separate decoders: seven independently-named

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2358,7 +2358,32 @@ Persistent free-bounds analysis wrapping `ShapeAnalysis_FreeBoundsProperties`.
 public final class FreeBoundsProperties: @unchecked Sendable
 ```
 
-Computes area, perimeter, ratio, and width for each free (open and closed) boundary loop in a shape.
+A free bound is a boundary contour of the shape: a chain of edges each used by exactly one face,
+closed into a loop where it can be. The analysis computes area, perimeter, aspect ratio, width and
+notch count for each one.
+
+The analysis runs once and every query is answered from that one result, which is the difference between
+this and `Shape`'s `freeBoundsAnalysis(tolerance:)` family, which analyses the shape again per
+call. Both have run on this one implementation since #504.
+
+The shape needs to be a compound or shell of faces: the search runs over its direct children, so a
+lone face reports no free bounds. In practice the sewing pass closes essentially every contour it
+finds, so `openCount` is usually 0.
+
+```swift
+// A box shell with one face removed: its free boundary is the square hole.
+let faces = Shape.box(width: 10, height: 10, depth: 10)!.subShapes(ofType: .face)
+let opened = Shape.compound(Array(faces.dropLast()))!
+
+let props = FreeBoundsProperties(shape: opened, tolerance: 1e-3)!
+print(props.closedCount, props.openCount, props.totalCount)   // 1 0 1
+
+for i in 0..<props.closedCount {
+    let bound = props.info(.closed, at: i)!
+    print(bound.area, bound.perimeter, bound.notchCount)      // 100.0 40.0 0
+    let wire = props.wire(.closed, at: i)
+}
+```
 
 ---
 
@@ -2370,6 +2395,9 @@ Create a free-bounds properties analyser.
 public init?(shape: Shape, tolerance: Double = 1e-7)
 ```
 
+- **Parameters:** `tolerance`, the sewing tolerance used to chain free edges into contours. 0 or below
+  selects a different OCCT algorithm, taking free edges from the shape's already-shared topology
+  instead of from a sewing pass.
 - **Returns:** The analyser, or `nil` on failure.
 - **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsCreate`).
 
@@ -2377,14 +2405,30 @@ public init?(shape: Shape, tolerance: Double = 1e-7)
 
 ### `FreeBoundsProperties.perform()`
 
-Perform the analysis.
+Run the analysis, if it has not already run, and report whether results are available.
 
 ```swift
 @discardableResult
 public func perform() -> Bool
 ```
 
-- **OCCT:** `ShapeAnalysis_FreeBoundsProperties::Perform`.
+Calling this is optional (every query below runs it on demand) and idempotent. Both matter:
+OCCT's own `Perform()` appends to its result sequences without clearing them, so calling it twice
+used to double every count (#504), and the accessors used to report 0 until it had been called.
+
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties::Perform`. Note that OCCT's return value is not a
+  success signal. It is `true` even for a shape with no free bounds and for one never loaded, so
+  this reports `IsLoaded()` instead.
+
+---
+
+### `FreeBoundsProperties.BoundKind`
+
+Which of the analysis' two result sequences a query addresses.
+
+```swift
+public enum BoundKind: Sendable { case closed, open }
+```
 
 ---
 
@@ -2408,9 +2452,57 @@ public var openCount: Int { get }
 
 ---
 
+### `FreeBoundsProperties.totalCount`
+
+Total number of free bounds, closed and open.
+
+```swift
+public var totalCount: Int { get }
+```
+
+---
+
+### `FreeBoundsProperties.info(_:at:)`
+
+Every property of one free bound (0-based index), or `nil` if the index is out of range.
+
+```swift
+public func info(_ kind: BoundKind, at index: Int) -> Shape.FreeBoundInfo?
+```
+
+`Shape.FreeBoundInfo` carries `area`, `perimeter`, `ratio`, `width` and `notchCount`. `ratio` is an
+aspect ratio: contour length over contour width, so 2 for a 20×10 bound, **not** `area / perimeter²`.
+OCCT solves it from the area and perimeter and leaves both `ratio` and `width` at 0 when that solve
+has no real root, which an exactly square bound hits by one ulp: 0 there means "not solvable", not
+"degenerate contour".
+
+```swift
+let props = FreeBoundsProperties(shape: twoStackedRects, tolerance: 0.01)!
+let bound = props.info(.closed, at: 0)!      // a 20x10 contour
+print(bound.ratio, bound.width)              // 2.0 10.0
+props.info(.closed, at: props.closedCount)   // nil, out of range
+```
+
+- **OCCT:** `ShapeAnalysis_FreeBoundData::Area`/`Perimeter`/`Ratio`/`Width`/`NbNotches`
+  (via `OCCTFreeBoundsPropsInfo`).
+
+---
+
+### `FreeBoundsProperties.wire(_:at:)`
+
+Contour wire of one free bound (0-based index), or `nil` if the index is out of range.
+
+```swift
+public func wire(_ kind: BoundKind, at index: Int) -> Shape?
+```
+
+- **OCCT:** `ShapeAnalysis_FreeBoundData::FreeBound` (via `OCCTFreeBoundsPropsWire`).
+
+---
+
 ### `FreeBoundsProperties.closedArea(at:)`
 
-Area enclosed by the `i`-th closed free bound (0-based).
+Area enclosed by the `i`-th closed free bound (0-based), or 0 if the index is out of range.
 
 ```swift
 public func closedArea(at index: Int) -> Double
@@ -2420,7 +2512,7 @@ public func closedArea(at index: Int) -> Double
 
 ### `FreeBoundsProperties.closedPerimeter(at:)`
 
-Perimeter of the `i`-th closed free bound (0-based).
+Perimeter of the `i`-th closed free bound (0-based), or 0 if the index is out of range.
 
 ```swift
 public func closedPerimeter(at index: Int) -> Double
@@ -2430,7 +2522,8 @@ public func closedPerimeter(at index: Int) -> Double
 
 ### `FreeBoundsProperties.closedRatio(at:)`
 
-Length-to-width ratio of the `i`-th closed free bound (0-based).
+Length-to-width aspect ratio of the `i`-th closed free bound (0-based), or 0 if the index is out of
+range. See `info(_:at:)`. 0 is also what OCCT reports for a bound whose ratio it cannot solve.
 
 ```swift
 public func closedRatio(at index: Int) -> Double
@@ -2440,7 +2533,8 @@ public func closedRatio(at index: Int) -> Double
 
 ### `FreeBoundsProperties.closedWidth(at:)`
 
-Width of the `i`-th closed free bound (0-based).
+Width of the `i`-th closed free bound (0-based), on the same "0 means unsolved" contract as
+`closedRatio(at:)`.
 
 ```swift
 public func closedWidth(at index: Int) -> Double
@@ -2460,7 +2554,7 @@ public func closedWire(at index: Int) -> Shape?
 
 ### `FreeBoundsProperties.openArea(at:)`
 
-Swept area of the `i`-th open free bound (0-based).
+Swept area of the `i`-th open free bound (0-based), or 0 if the index is out of range.
 
 ```swift
 public func openArea(at index: Int) -> Double
@@ -2470,7 +2564,7 @@ public func openArea(at index: Int) -> Double
 
 ### `FreeBoundsProperties.openPerimeter(at:)`
 
-Length of the `i`-th open free bound (0-based).
+Length of the `i`-th open free bound (0-based), or 0 if the index is out of range.
 
 ```swift
 public func openPerimeter(at index: Int) -> Double
@@ -2490,8 +2584,7 @@ public func openWire(at index: Int) -> Shape?
   ```swift
   let shell = Shape.box(width: 10, height: 10, depth: 10)!  // closed — 0 free bounds
   if let fp = FreeBoundsProperties(shape: shell) {
-      _ = fp.perform()
-      print("closed:", fp.closedCount, "open:", fp.openCount)
+      print("closed:", fp.closedCount, "open:", fp.openCount)   // closed: 0 open: 0
   }
   ```
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -2226,7 +2226,14 @@ public struct FreeBoundInfo: Sendable {
 }
 ```
 
-- `ratio` — `area / perimeter²` (shape factor).
+- `ratio`, an aspect ratio: contour length over contour width, so 2 for a 20×10 bound. **Not**
+  `area / perimeter²`, which is what this field's documentation claimed before #504 (0.0556 for
+  that same bound). OCCT solves it from `area` and `perimeter` and leaves *both* `ratio` and
+  `width` at 0 when that solve has no real root, which an exactly square bound hits by one ulp,
+  sitting precisely on the boundary between the two branches. So 0 means "not solvable here", not
+  "degenerate contour"; `area` and `perimeter` are still good in that case.
+- `width`, the average contour width, on the same "0 means unsolved" contract as `ratio`.
+- `notchCount`, the narrow 'V'-like sub-contours found on the bound.
 
 ---
 
@@ -2252,15 +2259,31 @@ Analyze free bounds (boundary wires) of this shape.
 public func freeBoundsAnalysis(tolerance: Double) -> FreeBoundsAnalysis
 ```
 
-Free bounds are edges that belong to only one face.
+A free bound is a chain of edges that belong to only one face, closed into a contour where it can
+be. The shape needs to be a compound or shell of faces: the search runs over its direct children,
+so a lone face reports no free bounds. In practice the sewing pass closes essentially every contour
+it finds, so `openCount` is usually 0.
 
-- **Parameters:** `tolerance` — Sewing tolerance for finding free bounds.
-- **Returns:** Analysis summary with closed and open bound counts.
-- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsAnalyze`).
+Each of the five `…FreeBound…` methods here runs its own analysis. To read several bounds of one
+shape, build a `FreeBoundsProperties` instead: it analyses once and answers every query from that
+one result. Both have run on the same implementation since #504.
+
+- **Parameters:** `tolerance`, the sewing tolerance used to chain free edges into contours. 0 or below
+  selects a different OCCT algorithm, taking free edges from the shape's already-shared topology
+  instead of from a sewing pass.
+- **Returns:** Analysis summary with total, closed and open bound counts.
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsCounts`).
 - **Example:**
   ```swift
-  let fb = shell.freeBoundsAnalysis(tolerance: 1e-6)
-  print("open: \(fb.openCount), closed: \(fb.closedCount)")
+  let faces = Shape.box(width: 10, height: 10, depth: 10)!.subShapes(ofType: .face)
+  let opened = Shape.compound(Array(faces.dropLast()))!   // free boundary = the square hole
+
+  let fb = opened.freeBoundsAnalysis(tolerance: 1e-3)
+  print("open: \(fb.openCount), closed: \(fb.closedCount)")   // open: 0, closed: 1
+
+  if let bound = opened.closedFreeBoundInfo(tolerance: 1e-3, index: 0) {
+      print(bound.area, bound.perimeter)                        // 100.0 40.0
+  }
   ```
 
 ---
@@ -2277,7 +2300,7 @@ public func closedFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo?
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the closed free bound.
 - **Returns:** Properties, or `nil` if the index is out of range.
-- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetClosedBoundInfo`).
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsInfo`).
 
 ---
 
@@ -2293,7 +2316,7 @@ public func openFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo?
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the open free bound.
 - **Returns:** Properties, or `nil` if the index is out of range.
-- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetOpenBoundInfo`).
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsInfo`).
 
 ---
 
@@ -2309,7 +2332,7 @@ public func closedFreeBoundWire(tolerance: Double, index: Int) -> Shape?
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the closed free bound.
 - **Returns:** Wire as a `Shape`, or `nil` if the index is out of range.
-- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetClosedBoundWire`).
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsWire`).
 
 ---
 
@@ -2325,4 +2348,4 @@ public func openFreeBoundWire(tolerance: Double, index: Int) -> Shape?
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the open free bound.
 - **Returns:** Wire as a `Shape`, or `nil` if the index is out of range.
-- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsGetOpenBoundWire`).
+- **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsWire`).


### PR DESCRIPTION
Part of Pass 1b of the #377 duplication audit (#381). Targets `refactor/381-pass1b`, not `main`.

## What was duplicated

`ShapeAnalysis_FreeBoundsProperties` was wrapped twice, exactly as the issue describes:

- the v0.49.0 stateless family (`OCCTFreeBoundsAnalyze` + 4 indexed accessors) behind `Shape`'s five `…FreeBound…` methods, which rebuilt the whole analyser and re-ran `Perform()` on **every call**;
- the v0.114.0 handle-based family (13 functions) behind `FreeBoundsProperties`, which analysed once and answered every query from that result.

They also took opposite index bases in the C layer, 0-based on one side and 1-based on the other for the same conceptual parameter, with neither declaration mentioning the other. Both Swift wrappers compensated correctly, so nothing was visibly broken; a third caller written against either C function by analogy with the other would have been off by one with no diagnostic.

## The bug consolidation found

Only the newer family could reach it. OCCT's `Perform()` **appends** to its two result sequences and never clears them, and `Init()` does not clear them either; only the constructors allocate them. `FreeBoundsProperties.perform()` is public and `@discardableResult`:

```swift
let props = FreeBoundsProperties(shape: opened, tolerance: 1e-3)!
props.perform(); props.closedCount   // 2
props.perform(); props.closedCount   // 4   (before this PR)
props.perform(); props.closedCount   // 6
```

The stateless family could not hit it, because each of its calls built a fresh analyser. It is latched in the bridge now, and `perform()` is optional as well as idempotent: every accessor runs the analysis on demand, so forgetting it no longer reads as "this shape has no free bounds".

Out-of-range indices are answered rather than guessed at. `Shape`'s info methods inferred it from `perimeter > 0`, which a genuine zero-perimeter bound would have tripped, and the `FreeBoundsProperties` accessors did not range-check at all, letting the index reach `NCollection_Sequence::Value` and come back `0` from a catch-all. Both are checked against the sequence length in the bridge.

## Two OCCT behaviours measured, documented and pinned

- **`ratio` is an aspect ratio**, contour length over contour width (2 for a 20×10 bound). Both `OCCTBridge.h` and `Shape.FreeBoundInfo` called it `area / perimeter²`, which for that bound is 0.0556. OCCT solves it from area and perimeter and leaves *both* `ratio` and `width` at 0 when that solve has no real root, which an exactly **square** bound hits by one ulp, sitting precisely on the branch boundary. A square is therefore the one fixture that must not be used to test either field.
- **`Perform()` is not a success signal.** It returns `DispatchBounds() | CheckNotches() | CheckContours()`, and `CheckNotches()` returns `true` unconditionally, so it is `true` for a shape with no free bounds at all and for one that was never loaded, the opposite of its documented "False if fail or no free bounds are found". `IsLoaded()` is what the bridge checks instead.

## The open side

The issue flags zero test coverage on the open bounds of both families. That is not neglect: **an open free bound is not reachable through this entry point.** 13 distinct topologies were probed against the pinned kernel (disjoint faces, T-junctions, vertex contacts, partial-edge contacts, free wires and free edges in the compound, shells, a half sphere, a cylinder, oversized tolerances, and both of the two tolerance modes) and every one closed every contour it found. The sewing-based free-edge search that backs this class closes essentially everything. The new tests pin what is reachable: that asking for one is a clean `nil`, on both entry points.

Also measured and now documented: a **lone face has no free bounds at all** (the search runs over the shape's direct children, so a bare face offers its wires), which is why every fixture in these suites is a compound, and a `tolerance` of 0 or below selects a **different algorithm** inside OCCT (shared topology instead of a sewing pass). Neither was stated anywhere.

## Changes

**Bridge: 18 functions down to 6.** `OCCTFreeBoundsPropsCounts` / `Info` / `Wire` replace the thirteen per-property accessors and the five stateless ones. `kind` is an `OCCTFreeBoundKind` (`OCCTFreeBoundClosed` / `OCCTFreeBoundOpen`), `index` is 0-based everywhere, both structs moved next to the family they belong to, and tombstone comments sit where the removed declarations were.

**Swift: not source-breaking.** `Shape`'s five methods keep their signatures and run on the shared analyser. `FreeBoundsProperties` keeps all eight of its accessors and gains `totalCount`, `info(_:at:)` and `wire(_:at:)`, which take a `BoundKind` and give the open side the `ratio`, `width` and `notchCount` only the closed side used to expose.

**Index:** the cross-reference entry named `OCCTShapeFreeBoundsAnalysis*`, a prefix that has never existed anywhere in the codebase. It names the real family now. `ShapeAnalysis_FreeBounds`, the similarly-named sibling class behind `Shape.freeBoundsClosedWires` and friends that the issue flags as easy to conflate, gains the index entry it never had. Stale entries 136 → 135.

## Verification

Both regressions were injected back into the bridge to prove the tests catch them:

- restoring the un-latched `Perform()`: 5 tests fail, including `performIsIdempotent` (counts 2 → 4 → 10 → 14) and `notchesAreCounted`;
- restoring the un-checked 1-based index: 6 tests fail, including two that pre-date this PR.

9 new tests across the two existing suites, covering everything the issue listed as uncovered plus the new contracts. Full `swift test`, 4776 tests, clean.

Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)