### PR TITLE
fix(#505): one edge type for FilletBuilder's radius laws, and the precondition none of them checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,293 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,295 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/repro/505-filletbuilder-edge-type/README.md
+++ b/Scripts/repro/505-filletbuilder-edge-type/README.md
@@ -1,0 +1,94 @@
+# OCCTSwift#505 ground truth: `BRepFilletAPI_MakeFillet`'s edge-keyed radius laws
+
+Two standalone probes, run against the pinned `OCCT.xcframework` (8.0.0p1 + our carried patches),
+behind the #505 fix. The finding was a bridge type inconsistency: `GetBounds` and `GetLaw` took an
+`OCCTShapeRef` while `SetLaw` took an `OCCTEdgeRef`, though all three OCCT functions take a
+`const TopoDS_Edge&`. The first probe establishes that the two argument routes are the same argument,
+so unifying them is behaviour-preserving. The second measures what all three do when the
+(contour, edge) pair does not name anything, which is what made the unified path worth guarding.
+
+No fixture files: every case is a 10x10x10 box.
+
+## Compile and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/505-filletbuilder-edge-type/occt_505_edge_vs_shape.mm -o /tmp/occt_505_edge_vs_shape
+/tmp/occt_505_edge_vs_shape
+```
+
+Same recipe for `occt_505_contour_membership.mm`. Neither translation unit defines `No_Exception`,
+which is how `Sources/OCCTBridge` is compiled too (`Package.swift` defines only `OCCT_AVAILABLE` and
+`OCCT_NO_DEPRECATED`), so anything the probes see about an inline header check holds in the bridge.
+
+## `occt_505_edge_vs_shape.mm`: are the two routes the same argument?
+
+Route A hands the accessor a `TopoDS_Edge` directly, which is what `OCCTEdgeRef` holds. Route B
+copies it into a `TopoDS_Shape` and downcasts it back with `TopoDS::Edge`, which is what
+`OCCTShapeRef` held plus what the old `GetBounds`/`GetLaw` implementations did to it.
+
+| measured | route A | route B |
+|---|---|---|
+| `GetBounds(1, e)` | `true`, `[-5, 15]` | `true`, `[-5, 15]` |
+| `GetLaw(1, e)` handle | `0x…060` | `0x…060` (same object) |
+| `IsSame` / `IsEqual` vs the original edge | n/a | both `1` |
+
+Identical, down to the returned `Handle(Law_Function)` being the same object, so the type change
+carries no behaviour with it. Two smaller measurements from the same probe:
+
+- `TopoDS::Edge(aFace)` throws `Standard_TypeMismatch`. Its `Standard_TypeMismatch_Raise_if` is
+  compiled out only where `No_Exception` is defined, and the bridge is not one of those places, so
+  the old `OCCTShapeRef` spelling really did fail at runtime rather than reinterpreting the memory.
+- `TopoDS::Edge(aNullShape)` does **not** throw: that check reads `ShapeType()` only when the shape
+  is non-null.
+
+## `occt_505_contour_membership.mm`: what the accessors do with a pair that names nothing
+
+All three reach `ChFiDS_FilSpine::ChangeLaw(E)`, which resolves the edge with
+`ChFiDS_Spine::Index(E)`, a linear `IsSame` search that returns **0** for an edge the contour does
+not hold, and then uses that index regardless: `ElSpine(0)` -> `FirstParameter(0)` ->
+`abscissa->Value(0 - 1)`. That access has no live bounds check in this Release build, and neither
+does `ChFi3d_FilBuilder`'s own `Value(IC)`.
+
+| case | measured |
+|---|---|
+| two contours, `GetBounds(1, edgeOfContour2)` | `true`, contour **1**'s bounds and law (`0.5 → 2.0`) |
+| two contours, `GetBounds(2, edgeOfContour1)` | `true`, contour **2**'s bounds and law (`1.0 → 3.0`) |
+| `GetBounds(1, edgeInNoContour)` | `true`, contour 1's answer; `Contour(e)` says `0` |
+| `SetLaw(1, edgeInNoContour, law)` | silently overwrites **contour 1's** law (read back as `4.0`) |
+| `GetBounds(0, e)` / `GetBounds(-1, e)` | `true`, contour 1's answer |
+| `GetBounds(2, e)` / `GetBounds(99, e)` with one contour | `false` (the upper bound *is* checked) |
+| before `Build()` | throws `ChFiDS_FilSpine::ChangeLaw : the limits are not up-to-date` |
+| constant-radius contour | throws `ChFiDS_FilSpine::ChangeLaw : no law on constant edges` |
+
+So the edge argument stops mattering the moment `Index()` answers 0, and only the *low* side of the
+contour range leaks. The two throws are the two legitimate "there is no law" answers, and both were
+already reported as `false`/`nullptr` by the bridge's `catch (...)`.
+
+`Contour(E)` is the same `IsSame` walk over the same spines, so it decides exactly the question
+`Index(E)` is about to ask, and `Add()` populates it rather than `Build()`, so it is valid before and
+after a build. That is the guard `occtFilletContourHoldsEdge` applies.
+
+**The wrong answer is not deterministic**, which is what an out-of-bounds read buys: the same
+unguarded call sometimes returns another contour's law and sometimes throws
+`no law on constant edges`, because `IsConstant(0)` compares whatever `abscissa->Value(-1)` happens
+to read against the contour's radii. Measured on the Swift suite with the guard removed: every run
+of `Tests/OCCTModelingTests/Issue505FilletBuilderEdgeTypeTests.swift` failed, but with 11 to 18
+recorded issues across five runs.
+
+### Two more things the same probe pins about `SetLaw`
+
+- **`Simulate(IC)` is the way to reach a law before building.** It performs the spine split
+  `ChangeLaw` requires, after which `GetBounds` reports the spine's own `[0, 10]` rather than the
+  post-build `[-5, 15]`, and `SetLaw` is accepted.
+- **`SetLaw` does not reach the geometry.** `GetLaw` reads the new law back, but a `Build()` after it
+  reports `IsDone() == 1` and hands back a shape whose volume is exactly 1000.0, the *unfilleted*
+  box, and `HasResult()` is 0. Setting the law before the first build (via `Simulate`) then building
+  gives 996.144988, the volume the original `Add(0.5, 2.0)` law produces, not the 980.685835 that
+  the law just set (a flat 3.0) would. So the law that `SetLaw` writes is recorded and readable, and
+  discarded by the builder either way. `FilletBuilder.setLaw`'s doc comment says so; nothing in the
+  bridge or the Swift wrapper can change it, and it is upstream behaviour rather than something #505
+  set out to fix.

--- a/Scripts/repro/505-filletbuilder-edge-type/occt_505_contour_membership.mm
+++ b/Scripts/repro/505-filletbuilder-edge-type/occt_505_contour_membership.mm
@@ -1,0 +1,379 @@
+// OCCTSwift#505 ground truth, probe 2: what BRepFilletAPI_MakeFillet's three edge-keyed accessors
+// do when the edge is not the one they were asked about.
+//
+// GetBounds/GetLaw/SetLaw all reach ChFiDS_FilSpine::ChangeLaw(E), which resolves the edge with
+// ChFiDS_Spine::Index(E) and returns 0 for an edge the contour does not contain. Every use of that
+// index downstream (FirstParameter(IE) -> abscissa->Value(IE - 1)) is unchecked, because OCCT's own
+// *_Raise_if bounds checks are compiled out of the pinned Release build. This probe measures the
+// consequence, plus the two documented throws (before Build, and on a constant contour).
+//
+// Each case runs in a forked child, so a case that dies by signal still leaves the rest measurable.
+//
+// Compile:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/505-filletbuilder-edge-type/occt_505_contour_membership.mm \
+//     -o /tmp/occt_505_contour_membership
+
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepGProp.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <GProp_GProps.hxx>
+#include <Law_Function.hxx>
+#include <Law_Linear.hxx>
+#include <Standard_Failure.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Shape.hxx>
+
+#include <cstdio>
+#include <functional>
+#include <sys/wait.h>
+#include <typeinfo>
+#include <unistd.h>
+
+static TopoDS_Shape makeBox()
+{
+  return BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+}
+
+static void collectEdges(const TopoDS_Shape& theShape, TopoDS_Edge theEdges[], const int theCount)
+{
+  TopExp_Explorer anExp(theShape, TopAbs_EDGE);
+  for (int i = 0; i < theCount && anExp.More(); anExp.Next(), ++i)
+  {
+    theEdges[i] = TopoDS::Edge(anExp.Current());
+  }
+}
+
+static double volumeOf(const TopoDS_Shape& theShape)
+{
+  GProp_GProps aProps;
+  BRepGProp::VolumeProperties(theShape, aProps);
+  return aProps.Mass();
+}
+
+// Runs one case in a child process and reports how it ended.
+static void runCase(const char* theName, const std::function<void()>& theBody)
+{
+  fflush(stdout);
+  const pid_t aPid = fork();
+  if (aPid == 0)
+  {
+    try
+    {
+      theBody();
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("  threw %s: %s\n",
+             typeid(aFail).name(),
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+    catch (...)
+    {
+      printf("  threw a non-Standard_Failure exception\n");
+    }
+    fflush(stdout);
+    _exit(0);
+  }
+  int aStatus = 0;
+  waitpid(aPid, &aStatus, 0);
+  if (WIFSIGNALED(aStatus))
+  {
+    printf("  [%s] died by signal %d\n", theName, WTERMSIG(aStatus));
+  }
+  else
+  {
+    printf("  [%s] exited %d\n", theName, WEXITSTATUS(aStatus));
+  }
+}
+
+int main()
+{
+  // ---- case 1: two contours, ask contour 1 about contour 2's edge --------------------------
+  printf("case 1: GetBounds/GetLaw for an edge belonging to a different contour\n");
+  runCase("cross-contour read", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdges[0]); // contour 1
+    aFillet.Add(1.0, 3.0, anEdges[2]); // contour 2
+    aFillet.Build();
+    printf("  IsDone=%d NbContours=%d Contour(e0)=%d Contour(e2)=%d\n",
+           (int)aFillet.IsDone(),
+           aFillet.NbContours(),
+           aFillet.Contour(anEdges[0]),
+           aFillet.Contour(anEdges[2]));
+
+    for (int aC = 1; aC <= 2; ++aC)
+    {
+      for (int anE = 0; anE < 3; anE += 2)
+      {
+        double aF = -1.0, aL = -1.0;
+        const bool anOk = aFillet.GetBounds(aC, anEdges[anE], aF, aL);
+        occ::handle<Law_Function> aLaw = aFillet.GetLaw(aC, anEdges[anE]);
+        printf("  GetBounds(%d, e%d)=%d [%.9f, %.9f]  law=%p  law(first)=%.9f law(last)=%.9f\n",
+               aC,
+               anE,
+               (int)anOk,
+               aF,
+               aL,
+               (void*)aLaw.get(),
+               aLaw.IsNull() ? -1.0 : aLaw->Value(aF),
+               aLaw.IsNull() ? -1.0 : aLaw->Value(aL));
+      }
+    }
+  });
+
+  // ---- case 2: an edge in no contour at all -------------------------------------------------
+  printf("case 2: GetBounds/GetLaw for an edge in no contour (Index(E) == 0)\n");
+  runCase("orphan read", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdges[0]);
+    aFillet.Build();
+    printf("  Contour(e1)=%d (0 means no contour holds it)\n", aFillet.Contour(anEdges[1]));
+
+    double     aF = -1.0, aL = -1.0;
+    const bool anOk = aFillet.GetBounds(1, anEdges[1], aF, aL);
+    printf("  GetBounds(1, e1)=%d [%.9f, %.9f]\n", (int)anOk, aF, aL);
+    occ::handle<Law_Function> aLaw = aFillet.GetLaw(1, anEdges[1]);
+    printf("  GetLaw(1, e1)=%p\n", (void*)aLaw.get());
+  });
+
+  // ---- case 3: SetLaw for an edge in no contour ---------------------------------------------
+  printf("case 3: SetLaw for an edge in no contour (writes through the same index)\n");
+  runCase("orphan write", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdges[0]);
+    aFillet.Build();
+
+    double aF = 0.0, aL = 1.0;
+    aFillet.GetBounds(1, anEdges[0], aF, aL);
+    occ::handle<Law_Linear> aLaw = new Law_Linear();
+    aLaw->Set(aF, 4.0, aL, 4.0);
+
+    printf("  SetLaw(1, e1 /* not in any contour */, law) ...\n");
+    fflush(stdout);
+    aFillet.SetLaw(1, anEdges[1], aLaw);
+    printf("  returned\n");
+
+    occ::handle<Law_Function> aBack = aFillet.GetLaw(1, anEdges[0]);
+    printf("  GetLaw(1, e0) after the foreign SetLaw: %p value(first)=%.9f\n",
+           (void*)aBack.get(),
+           aBack.IsNull() ? -1.0 : aBack->Value(aF));
+  });
+
+  // ---- case 4: before Build -----------------------------------------------------------------
+  printf("case 4: the same three calls before Build\n");
+  runCase("pre-build", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdges[0]);
+
+    double aF = -1.0, aL = -1.0;
+    try
+    {
+      const bool anOk = aFillet.GetBounds(1, anEdges[0], aF, aL);
+      printf("  GetBounds before Build=%d\n", (int)anOk);
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("  GetBounds before Build threw: %s\n",
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+  });
+
+  // ---- case 5: a constant-radius contour ----------------------------------------------------
+  printf("case 5: the same three calls on a constant-radius contour\n");
+  runCase("constant contour", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(1.0, anEdges[0]);
+    aFillet.Build();
+    printf("  IsDone=%d IsConstant(1)=%d\n", (int)aFillet.IsDone(), (int)aFillet.IsConstant(1));
+
+    double aF = -1.0, aL = -1.0;
+    try
+    {
+      const bool anOk = aFillet.GetBounds(1, anEdges[0], aF, aL);
+      printf("  GetBounds on constant contour=%d [%.9f, %.9f]\n", (int)anOk, aF, aL);
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("  GetBounds on constant contour threw: %s\n",
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+    try
+    {
+      occ::handle<Law_Function> aLaw = aFillet.GetLaw(1, anEdges[0]);
+      printf("  GetLaw on constant contour=%p\n", (void*)aLaw.get());
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("  GetLaw on constant contour threw: %s\n",
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+  });
+
+  // ---- case 6: does SetLaw change the built result? -----------------------------------------
+  printf("case 6: SetLaw on the right edge, then rebuild\n");
+  for (const double aNewRadius : {3.0, 1.0, 0.2})
+  {
+    runCase("setlaw effect", [aNewRadius] {
+      const TopoDS_Shape aBox = makeBox();
+      TopoDS_Edge        anEdges[4];
+      collectEdges(aBox, anEdges, 4);
+
+      BRepFilletAPI_MakeFillet aFillet(aBox);
+      aFillet.Add(0.5, 2.0, anEdges[0]);
+      aFillet.Build();
+      const double aBefore = volumeOf(aFillet.Shape());
+
+      double aF = 0.0, aL = 1.0;
+      aFillet.GetBounds(1, anEdges[0], aF, aL);
+      occ::handle<Law_Linear> aLaw = new Law_Linear();
+      aLaw->Set(aF, aNewRadius, aL, aNewRadius);
+      aFillet.SetLaw(1, anEdges[0], aLaw);
+
+      occ::handle<Law_Function> aBack = aFillet.GetLaw(1, anEdges[0]);
+      printf("  radius law %.1f: read back value(first)=%.9f value(last)=%.9f\n",
+             aNewRadius,
+             aBack.IsNull() ? -1.0 : aBack->Value(aF),
+             aBack.IsNull() ? -1.0 : aBack->Value(aL));
+
+      aFillet.Build();
+      printf("  rebuild: IsDone=%d HasResult=%d volume before=%.6f after=%.6f changed=%d\n",
+             (int)aFillet.IsDone(),
+             (int)aFillet.HasResult(),
+             aBefore,
+             aFillet.HasResult() ? volumeOf(aFillet.Shape()) : -1.0,
+             (int)(aFillet.HasResult() && std::abs(aBefore - volumeOf(aFillet.Shape())) > 1e-6));
+    });
+  }
+
+  // ---- case 7: is there an order in which SetLaw reaches the geometry? ----------------------
+  // ChangeLaw needs SplitDone(), which Build() sets, so SetLaw cannot precede the first Build.
+  // Simulate(IC) performs the same spine split without building the surfaces, so try it as the
+  // way in.
+  printf("case 7: Simulate, SetLaw, then Build\n");
+  runCase("simulate then setlaw", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aReference(aBox);
+    aReference.Add(3.0, anEdges[0]);
+    aReference.Build();
+    printf("  reference Add(3.0) volume=%.6f\n",
+           aReference.IsDone() ? volumeOf(aReference.Shape()) : -1.0);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdges[0]);
+    try
+    {
+      aFillet.Simulate(1);
+      printf("  Simulate(1) ok, NbSurf=%d\n", aFillet.NbSurf(1));
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("  Simulate(1) threw: %s\n", aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+
+    double aF = 0.0, aL = 1.0;
+    try
+    {
+      const bool anOk = aFillet.GetBounds(1, anEdges[0], aF, aL);
+      printf("  GetBounds after Simulate=%d [%.9f, %.9f]\n", (int)anOk, aF, aL);
+      occ::handle<Law_Linear> aLaw = new Law_Linear();
+      aLaw->Set(aF, 3.0, aL, 3.0);
+      aFillet.SetLaw(1, anEdges[0], aLaw);
+      printf("  SetLaw after Simulate ok\n");
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("  GetBounds/SetLaw after Simulate threw: %s\n",
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+      return;
+    }
+
+    aFillet.Build();
+    printf("  Build after SetLaw: IsDone=%d volume=%.6f\n",
+           (int)aFillet.IsDone(),
+           aFillet.IsDone() ? volumeOf(aFillet.Shape()) : -1.0);
+  });
+
+  // ---- case 8: what Shape() is after the second Build ---------------------------------------
+  printf("case 8: the shape a post-SetLaw rebuild hands back\n");
+  runCase("rebuilt shape identity", [] {
+    const TopoDS_Shape aBox = makeBox();
+    TopoDS_Edge        anEdges[4];
+    collectEdges(aBox, anEdges, 4);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdges[0]);
+    aFillet.Build();
+    const TopoDS_Shape aFilleted = aFillet.Shape();
+    printf("  first build : volume=%.6f IsSame(box)=%d\n",
+           volumeOf(aFilleted),
+           (int)aFilleted.IsSame(aBox));
+
+    double aF = 0.0, aL = 1.0;
+    aFillet.GetBounds(1, anEdges[0], aF, aL);
+    occ::handle<Law_Linear> aLaw = new Law_Linear();
+    aLaw->Set(aF, 3.0, aL, 3.0);
+    aFillet.SetLaw(1, anEdges[0], aLaw);
+    aFillet.Build();
+    const TopoDS_Shape aRebuilt = aFillet.Shape();
+    printf("  second build: volume=%.6f IsSame(box)=%d IsSame(first)=%d IsDone=%d\n",
+           volumeOf(aRebuilt),
+           (int)aRebuilt.IsSame(aBox),
+           (int)aRebuilt.IsSame(aFilleted),
+           (int)aFillet.IsDone());
+  });
+
+  // ---- case 9: out-of-range contour indices --------------------------------------------------
+  // ChFi3d_FilBuilder::GetBounds guards IC <= NbElements() but not IC >= 1, and Value(IC) has no
+  // live bounds check either.
+  printf("case 9: out-of-range contour indices\n");
+  for (const int aContour : {0, -1, 2, 99})
+  {
+    runCase("contour index", [aContour] {
+      const TopoDS_Shape aBox = makeBox();
+      TopoDS_Edge        anEdges[4];
+      collectEdges(aBox, anEdges, 4);
+
+      BRepFilletAPI_MakeFillet aFillet(aBox);
+      aFillet.Add(0.5, 2.0, anEdges[0]);
+      aFillet.Build();
+
+      double aF = -1.0, aL = -1.0;
+      printf("  GetBounds(%d, e0) ...\n", aContour);
+      fflush(stdout);
+      const bool anOk = aFillet.GetBounds(aContour, anEdges[0], aF, aL);
+      printf("  GetBounds(%d, e0)=%d [%.9f, %.9f]\n", aContour, (int)anOk, aF, aL);
+    });
+  }
+
+  printf("done\n");
+  return 0;
+}

--- a/Scripts/repro/505-filletbuilder-edge-type/occt_505_edge_vs_shape.mm
+++ b/Scripts/repro/505-filletbuilder-edge-type/occt_505_edge_vs_shape.mm
@@ -1,0 +1,171 @@
+// OCCTSwift#505 ground truth, probe 1: is a TopoDS_Edge reached through a TopoDS_Shape copy the
+// same argument, as far as BRepFilletAPI_MakeFillet's three edge-keyed accessors are concerned?
+//
+// The bridge hands GetBounds/GetLaw an OCCTShapeRef (generic TopoDS_Shape, downcast with
+// TopoDS::Edge at the call site) and SetLaw an OCCTEdgeRef (a TopoDS_Edge already). All three OCCT
+// functions take const TopoDS_Edge&. This probe measures whether the two routes are observably
+// equivalent, and what the downcast route does when the shape is not an edge.
+//
+// Compile:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/505-filletbuilder-edge-type/occt_505_edge_vs_shape.mm -o /tmp/occt_505_edge_vs_shape
+
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <Law_Function.hxx>
+#include <Standard_Failure.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+
+#include <cstdio>
+#include <typeinfo>
+
+static TopoDS_Shape makeBox()
+{
+  return BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+}
+
+static TopoDS_Edge firstEdge(const TopoDS_Shape& theShape)
+{
+  TopExp_Explorer anExp(theShape, TopAbs_EDGE);
+  return TopoDS::Edge(anExp.Current());
+}
+
+static TopoDS_Face firstFace(const TopoDS_Shape& theShape)
+{
+  TopExp_Explorer anExp(theShape, TopAbs_FACE);
+  return TopoDS::Face(anExp.Current());
+}
+
+int main()
+{
+  // ---- case 1: the two argument routes, on a built evolving-radius contour -----------------
+  {
+    const TopoDS_Shape aBox  = makeBox();
+    const TopoDS_Edge  anEdge = firstEdge(aBox);
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdge);
+    aFillet.Build();
+    printf("case 1: IsDone=%d NbContours=%d\n", (int)aFillet.IsDone(), aFillet.NbContours());
+
+    // route A: the TopoDS_Edge itself, which is what OCCTEdgeRef holds (SetLaw's route)
+    double aFirstA = -1.0, aLastA = -1.0;
+    const bool anOkA = aFillet.GetBounds(1, anEdge, aFirstA, aLastA);
+    occ::handle<Law_Function> aLawA = aFillet.GetLaw(1, anEdge);
+
+    // route B: a TopoDS_Shape copy, downcast back with TopoDS::Edge, which is what OCCTShapeRef
+    // holds plus what the GetBounds/GetLaw bridge implementations do to it
+    const TopoDS_Shape aShapeCopy = anEdge;
+    const TopoDS_Edge& anEdgeB    = TopoDS::Edge(aShapeCopy);
+    double             aFirstB = -1.0, aLastB = -1.0;
+    const bool         anOkB = aFillet.GetBounds(1, anEdgeB, aFirstB, aLastB);
+    occ::handle<Law_Function> aLawB = aFillet.GetLaw(1, anEdgeB);
+
+    printf("  route A (TopoDS_Edge)       : GetBounds=%d [%.9f, %.9f] GetLaw=%p\n",
+           (int)anOkA,
+           aFirstA,
+           aLastA,
+           (void*)aLawA.get());
+    printf("  route B (Shape -> downcast) : GetBounds=%d [%.9f, %.9f] GetLaw=%p\n",
+           (int)anOkB,
+           aFirstB,
+           aLastB,
+           (void*)aLawB.get());
+    printf("  identical: bounds=%d lawHandle=%d IsSame=%d IsEqual=%d\n",
+           (int)(anOkA == anOkB && aFirstA == aFirstB && aLastA == aLastB),
+           (int)(aLawA.get() == aLawB.get()),
+           (int)anEdge.IsSame(anEdgeB),
+           (int)anEdge.IsEqual(anEdgeB));
+
+    if (!aLawA.IsNull())
+    {
+      double aLF = 0.0, aLL = 0.0;
+      aLawA->Bounds(aLF, aLL);
+      printf("  law A: bounds [%.9f, %.9f] value(first)=%.9f value(last)=%.9f\n",
+             aLF,
+             aLL,
+             aLawA->Value(aLF),
+             aLawA->Value(aLL));
+    }
+  }
+
+  // ---- case 2: an edge that belongs to no contour ------------------------------------------
+  {
+    const TopoDS_Shape aBox = makeBox();
+    TopExp_Explorer     anExp(aBox, TopAbs_EDGE);
+    const TopoDS_Edge   anEdge0 = TopoDS::Edge(anExp.Current());
+    anExp.Next();
+    const TopoDS_Edge anEdge1 = TopoDS::Edge(anExp.Current());
+
+    BRepFilletAPI_MakeFillet aFillet(aBox);
+    aFillet.Add(0.5, 2.0, anEdge0);
+    aFillet.Build();
+
+    double aF = -1.0, aL = -1.0;
+    bool   anOk = false;
+    try
+    {
+      anOk = aFillet.GetBounds(1, anEdge1, aF, aL);
+      printf("case 2: foreign edge GetBounds=%d [%.9f, %.9f]\n", (int)anOk, aF, aL);
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("case 2: foreign edge GetBounds threw %s: %s\n",
+             typeid(aFail).name(),
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+    try
+    {
+      occ::handle<Law_Function> aLaw = aFillet.GetLaw(1, anEdge1);
+      printf("case 2: foreign edge GetLaw=%p\n", (void*)aLaw.get());
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("case 2: foreign edge GetLaw threw %s: %s\n",
+             typeid(aFail).name(),
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+  }
+
+  // ---- case 3: what the downcast does with a non-edge shape --------------------------------
+  // This translation unit does not define No_Exception, which is how Sources/OCCTBridge is
+  // compiled too (Package.swift defines only OCCT_AVAILABLE and OCCT_NO_DEPRECATED), so the
+  // Standard_TypeMismatch_Raise_if inside the inline TopoDS::Edge is live here.
+  {
+    const TopoDS_Shape aBox  = makeBox();
+    const TopoDS_Face  aFace = firstFace(aBox);
+    try
+    {
+      const TopoDS_Edge& aBogus = TopoDS::Edge(aFace);
+      printf("case 3: TopoDS::Edge(face) did NOT throw, ShapeType=%d\n", (int)aBogus.ShapeType());
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("case 3: TopoDS::Edge(face) threw %s: %s\n",
+             typeid(aFail).name(),
+             aFail.GetMessageString() ? aFail.GetMessageString() : "");
+    }
+
+    // A null shape is not rejected by that check at all (it tests ShapeType only when non-null).
+    const TopoDS_Shape aNull;
+    try
+    {
+      const TopoDS_Edge& aNullEdge = TopoDS::Edge(aNull);
+      printf("case 3: TopoDS::Edge(null shape) did NOT throw, IsNull=%d\n", (int)aNullEdge.IsNull());
+    }
+    catch (const Standard_Failure& aFail)
+    {
+      printf("case 3: TopoDS::Edge(null shape) threw %s\n", typeid(aFail).name());
+    }
+  }
+
+  printf("done\n");
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -19701,18 +19701,30 @@ bool OCCTSurfaceBezierSetPoleRowWeights(OCCTSurfaceRef _Nonnull surface, int32_t
 int32_t OCCTDocumentColorToolGetAllColors(OCCTDocumentRef _Nonnull doc,
                                            int64_t* _Nullable * _Nonnull outLabelIds);
 
-// --- FilletBuilder history queries ---
+// --- FilletBuilder radius laws, keyed by contour edge ---
+//
+// These three take an OCCTEdgeRef because the OCCT functions behind them take a const TopoDS_Edge&,
+// and all three resolve that edge the same way. They reject a contour index outside
+// [1, NbContours()] and an edge the named contour does not hold, which OCCT does not; see
+// occtFilletContourHoldsEdge in OCCTBridge_Internal.h for what happens without that (#505).
+//
+// The three below them (Generated/Modified/IsDeleted) take an OCCTShapeRef because their OCCT
+// counterparts take a const TopoDS_Shape&: any sub-shape of the input can be asked about, not just
+// an edge.
 
-/// Get the parameter bounds of a fillet on a contour edge. Returns false if not found.
+/// Get the parameter bounds of the radius law on a contour edge. Returns false in four cases:
+/// contourIndex outside [1, NbContours()], an edge the contour does not hold, a contour whose spine
+/// has not been split yet (before Build or Simulate), or a constant radius, which OCCT represents as
+/// no law rather than a flat one.
 bool OCCTFilletBuilderGetBounds(OCCTFilletBuilderRef _Nonnull builder,
-                                 int32_t contourIndex, OCCTShapeRef _Nonnull edge,
+                                 int32_t contourIndex, OCCTEdgeRef _Nonnull edge,
                                  double* _Nonnull outFirst, double* _Nonnull outLast);
 
-/// Get the law function for a fillet edge on a contour. Returns NULL if not available.
+/// Get the radius law on a contour edge. Returns NULL in the same four cases as GetBounds.
 OCCTLawFunctionRef _Nullable OCCTFilletBuilderGetLaw(OCCTFilletBuilderRef _Nonnull builder,
-                                                      int32_t contourIndex, OCCTShapeRef _Nonnull edge);
+                                                      int32_t contourIndex, OCCTEdgeRef _Nonnull edge);
 
-/// Set a law function for a fillet edge on a contour.
+/// Set the radius law on a contour edge. Returns false in the same four cases as GetBounds.
 bool OCCTFilletBuilderSetLaw(OCCTFilletBuilderRef _Nonnull builder,
                               int32_t contourIndex, OCCTEdgeRef _Nonnull edge,
                               OCCTLawFunctionRef _Nonnull law);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -800,6 +800,33 @@ OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
     }
 }
 
+// === #505: the precondition BRepFilletAPI_MakeFillet's edge-keyed radius laws never check ===
+//
+// GetBounds, GetLaw and SetLaw each take a (contour index, TopoDS_Edge) pair and each resolve it
+// through ChFiDS_FilSpine::ChangeLaw(E), which asks ChFiDS_Spine::Index(E) where the edge sits in
+// that contour's spine. Index returns 0 for an edge the spine does not hold, and ChangeLaw then uses
+// it anyway: ElSpine(0) -> FirstParameter(0) -> abscissa->Value(-1). Neither that access nor
+// ChFi3d_FilBuilder's own Value(IC) has a live bounds check, because OCCT's *_Raise_if macros are
+// compiled out of the pinned Release build. So nothing anywhere rejects the request; it just answers
+// about whatever the out-of-range index lands on. Measured on a 10x10x10 box
+// (Scripts/repro/505-filletbuilder-edge-type/):
+//
+//   - Two contours, GetBounds(1, edgeOfContour2): returns true, with contour 1's bounds and contour
+//     1's law. The edge argument stops mattering the moment Index() answers 0.
+//   - GetBounds(1, edgeInNoContour): same, true with contour 1's law.
+//   - SetLaw(1, edgeInNoContour, law): overwrites contour 1's law and reports nothing.
+//   - GetBounds(0, e) and GetBounds(-1, e): true, again with contour 1's answer. The upper bound is
+//     checked upstream (IC <= NbElements()), so 2 and 99 do return false; only the low side leaks.
+//
+// Contour(E) is the same TopoDS_Shape::IsSame walk over the same spines that Index(E) is about to
+// do, so it decides exactly this question, and it is populated by Add() rather than by Build(),
+// which means it is equally valid before and after the fillet is built.
+inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
+                                       int32_t contourIndex, const TopoDS_Edge& edge) {
+    if (contourIndex < 1 || contourIndex > fillet.NbContours()) return false;
+    return fillet.Contour(edge) == contourIndex;
+}
+
 // === #492: one analytical-conversion path per GeomConvert converter class ===
 //
 // GeomConvert_CurveToAnaCurve and GeomConvert_SurfToAnaSurf each had two independently-grown

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -9285,21 +9285,29 @@ bool OCCTDocumentShapeToolIsSimpleShape(OCCTDocumentRef doc, int64_t labelId) {
     } catch (...) { return false; }
 }
 
+// The three edge-keyed radius laws. All three take the same (contour index, edge) pair, all three
+// hand it to an OCCT function declared as (const Standard_Integer, const TopoDS_Edge&), and all
+// three have to reject a pair OCCT itself will use out of range: see occtFilletContourHoldsEdge in
+// OCCTBridge_Internal.h for the measurements. GetBounds and GetLaw used to take an OCCTShapeRef and
+// downcast it with TopoDS::Edge, which cost them a throw-on-non-edge that the caller could only
+// discover at runtime, and left every caller holding an Edge (the type addEdge, removeEdge,
+// setRadius and contour all take) converting it to a Shape and back (#505).
+
 bool OCCTFilletBuilderGetBounds(OCCTFilletBuilderRef builder, int32_t contourIndex,
-                                 OCCTShapeRef edge, double* outFirst, double* outLast) {
+                                 OCCTEdgeRef edge, double* outFirst, double* outLast) {
     if (!builder || !edge || !outFirst || !outLast) return false;
     try {
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        return builder->fillet.GetBounds(contourIndex, e, *outFirst, *outLast);
+        if (!occtFilletContourHoldsEdge(builder->fillet, contourIndex, edge->edge)) return false;
+        return builder->fillet.GetBounds(contourIndex, edge->edge, *outFirst, *outLast);
     } catch (...) { return false; }
 }
 
 OCCTLawFunctionRef OCCTFilletBuilderGetLaw(OCCTFilletBuilderRef builder, int32_t contourIndex,
-                                            OCCTShapeRef edge) {
+                                            OCCTEdgeRef edge) {
     if (!builder || !edge) return nullptr;
     try {
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        Handle(Law_Function) law = builder->fillet.GetLaw(contourIndex, e);
+        if (!occtFilletContourHoldsEdge(builder->fillet, contourIndex, edge->edge)) return nullptr;
+        Handle(Law_Function) law = builder->fillet.GetLaw(contourIndex, edge->edge);
         if (law.IsNull()) return nullptr;
         return new OCCTLawFunction(law);
     } catch (...) { return nullptr; }
@@ -9309,6 +9317,7 @@ bool OCCTFilletBuilderSetLaw(OCCTFilletBuilderRef builder, int32_t contourIndex,
                               OCCTEdgeRef edge, OCCTLawFunctionRef law) {
     if (!builder || !edge || !law) return false;
     try {
+        if (!occtFilletContourHoldsEdge(builder->fillet, contourIndex, edge->edge)) return false;
         builder->fillet.SetLaw(contourIndex, edge->edge, law->law);
         return true;
     } catch (...) { return false; }

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -16400,35 +16400,105 @@ extension Document {
 
 extension FilletBuilder {
 
-    /// Get the parameter bounds of a fillet on a contour edge.
+    /// Parameter bounds of the radius law on one edge of a contour.
+    ///
+    /// The range is the contour's own spine parameterisation, not the edge's: it runs past the
+    /// edge's ends once the fillet is built, because the blend surface extends beyond the edge it
+    /// was asked for.
+    ///
+    /// Returns `nil` when there is no law to measure, which covers four cases:
+    /// `contour` is outside `1...contourCount`; the contour does not hold `edge` (an edge from
+    /// another contour counts, and used to be answered about anyway, #505); the contour's spine has
+    /// not been split yet, which `build()` and ``FilletBuilder/simulate(contour:)`` both do; or the
+    /// radius is constant along the contour, which OCCT represents as no law rather than a flat one.
+    ///
     /// - Parameters:
     ///   - contour: Contour index (1-based)
-    ///   - edge: The edge in the contour
-    /// - Returns: Parameter range (first, last), or nil if not found
-    public func getBounds(contour: Int, edge: Shape) -> (first: Double, last: Double)? {
+    ///   - edge: An edge the contour holds
+    /// - Returns: Parameter range `(first, last)`, or `nil`
+    ///
+    /// ```swift
+    /// let builder = FilletBuilder(shape: box)!
+    /// let edge = box.edges()[0]
+    /// builder.addEdge(edge, radius1: 0.5, radius2: 2.0)   // evolving: there is a law
+    /// _ = builder.build()
+    /// if let bounds = builder.getBounds(contour: 1, edge: edge) {
+    ///     print(bounds.first, bounds.last)
+    /// }
+    /// ```
+    public func getBounds(contour: Int, edge: Edge) -> (first: Double, last: Double)? {
         var first = 0.0, last = 0.0
         guard OCCTFilletBuilderGetBounds(handle, Int32(contour), edge.handle, &first, &last) else { return nil }
         return (first, last)
     }
 
-    /// Get the law function for a fillet edge on a contour.
+    /// The radius law on one edge of a contour.
+    ///
+    /// Returns `nil` in the same four cases as ``FilletBuilder/getBounds(contour:edge:)``. In
+    /// particular a constant-radius contour has no law, so ask ``FilletBuilder/isConstant(contour:)``
+    /// first if the radius did not come from ``FilletBuilder/addEdge(_:radius1:radius2:)``.
+    ///
     /// - Parameters:
     ///   - contour: Contour index (1-based)
-    ///   - edge: The edge in the contour
-    /// - Returns: The law function, or nil if not available
-    public func getLaw(contour: Int, edge: Shape) -> LawFunction? {
+    ///   - edge: An edge the contour holds
+    /// - Returns: The law function, or `nil`
+    ///
+    /// ```swift
+    /// if let law = builder.getLaw(contour: 1, edge: edge) {
+    ///     print(law.value(at: law.bounds.lowerBound))   // 0.5, the radius at the start
+    /// }
+    /// ```
+    public func getLaw(contour: Int, edge: Edge) -> LawFunction? {
         guard let ref = OCCTFilletBuilderGetLaw(handle, Int32(contour), edge.handle) else { return nil }
         return LawFunction(handle: ref)
     }
 
-    /// Set a law function for a fillet edge on a contour.
+    /// Set the radius law on one edge of a contour.
+    ///
+    /// Rejected, returning `false`, in the same four cases as
+    /// ``FilletBuilder/getBounds(contour:edge:)``: no such contour, an edge the contour does not
+    /// hold, no spine split yet, or a constant-radius contour.
+    ///
+    /// The law is what ``FilletBuilder/getLaw(contour:edge:)`` reads back afterwards. It does not
+    /// reach the geometry: measured against the pinned kernel, a `build()` after this call reports
+    /// success and hands back the *unfilleted* input shape
+    /// (`Scripts/repro/505-filletbuilder-edge-type/`), so treat this as editing the builder's
+    /// recorded law rather than as a way to reshape an already-built fillet.
+    ///
     /// - Parameters:
     ///   - contour: Contour index (1-based)
-    ///   - edge: The edge
-    ///   - law: The law function to use
+    ///   - edge: An edge the contour holds
+    ///   - law: The radius law, over the range ``FilletBuilder/getBounds(contour:edge:)`` reports
+    /// - Returns: `true` if the law was set
+    ///
+    /// ```swift
+    /// let bounds = builder.getBounds(contour: 1, edge: edge)!
+    /// let law = LawFunction.linear(from: 4, to: 4, parameterRange: bounds.first...bounds.last)!
+    /// builder.setLaw(contour: 1, edge: edge, law: law)
+    /// builder.getLaw(contour: 1, edge: edge)?.value(at: bounds.first)   // 4.0
+    /// ```
     @discardableResult
     public func setLaw(contour: Int, edge: Edge, law: LawFunction) -> Bool {
         OCCTFilletBuilderSetLaw(handle, Int32(contour), edge.handle, law.handle)
+    }
+
+    /// The `Shape`-typed spelling of ``FilletBuilder/getBounds(contour:edge:)``.
+    ///
+    /// `BRepFilletAPI_MakeFillet::GetBounds` takes a `TopoDS_Edge`, so a `Shape` only ever reached
+    /// it through a downcast, and every caller holding an `Edge` (the type `addEdge`, `removeEdge`,
+    /// `setRadius` and `contour(for:)` all take) had to convert it and back again (#505).
+    @available(*, deprecated, message: "Pass the Edge itself. Convert a Shape with Edge(_:) if that is what you hold.")
+    public func getBounds(contour: Int, edge: Shape) -> (first: Double, last: Double)? {
+        guard let edge = Edge(edge) else { return nil }
+        return getBounds(contour: contour, edge: edge)
+    }
+
+    /// The `Shape`-typed spelling of ``FilletBuilder/getLaw(contour:edge:)``, deprecated for the same
+    /// reason as the `Shape`-typed `getBounds` above it.
+    @available(*, deprecated, message: "Pass the Edge itself. Convert a Shape with Edge(_:) if that is what you hold.")
+    public func getLaw(contour: Int, edge: Shape) -> LawFunction? {
+        guard let edge = Edge(edge) else { return nil }
+        return getLaw(contour: contour, edge: edge)
     }
 
     /// Get shapes generated from an input shape by the fillet operation.

--- a/Tests/OCCTModelingTests/Issue505FilletBuilderEdgeTypeTests.swift
+++ b/Tests/OCCTModelingTests/Issue505FilletBuilderEdgeTypeTests.swift
@@ -1,0 +1,201 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// MARK: - #505: FilletBuilder's radius laws are keyed by an Edge, and check that they are
+
+/// `BRepFilletAPI_MakeFillet::GetBounds`, `GetLaw` and `SetLaw` all take a `const TopoDS_Edge&`, but
+/// the bridge used to hand the first two a generic `OCCTShapeRef` and only the third an
+/// `OCCTEdgeRef`. Every caller therefore held the wrong type for two of the three: `addEdge`,
+/// `removeEdge`, `setRadius` and `contour(for:)` all speak `Edge`, so reading a law meant converting
+/// that `Edge` to a `Shape` and back again to write one.
+///
+/// Fixing the type surfaced what the three share underneath: `ChFiDS_FilSpine::ChangeLaw(E)` resolves
+/// the edge with `ChFiDS_Spine::Index(E)`, which answers `0` for an edge the contour does not hold,
+/// and then indexes the spine's abscissa array with `0 - 1`. OCCT's bounds check there is compiled
+/// out of the pinned Release build, so nothing rejected the request: measured on a box, asking
+/// contour 1 about contour 2's edge returned contour *1*'s law and reported success, and `SetLaw`
+/// with an edge in no contour at all overwrote contour 1's law instead
+/// (`Scripts/repro/505-filletbuilder-edge-type/`). The bridge now rejects those pairs.
+@Suite("FilletBuilder radius laws are keyed by an edge (#505)")
+struct Issue505FilletBuilderEdgeTypeTests {
+
+    private static func box() -> Shape? {
+        Shape.box(width: 10, height: 10, depth: 10)
+    }
+
+    /// A contour whose radius evolves has a law; a constant one does not (see
+    /// ``constantRadiusContourHasNoLaw``), so every case that needs a law starts here.
+    private static func builtEvolvingContour() throws -> (builder: FilletBuilder, edge: Edge, box: Shape) {
+        let box = try #require(Self.box())
+        let builder = try #require(FilletBuilder(shape: box))
+        let edge = try #require(box.edges().first)
+        #expect(builder.addEdge(edge, radius1: 0.5, radius2: 2.0))
+        #expect(builder.build() != nil)
+        #expect(builder.contour(for: edge) == 1)
+        return (builder, edge, box)
+    }
+
+    /// The round trip the type split made impossible to write with one value: read the law's range,
+    /// build a law over it, set it, read it back. All four calls take the same `Edge`.
+    @Test("One Edge value threads through getBounds, setLaw and getLaw")
+    func oneEdgeValueThroughAllThree() throws {
+        let (builder, edge, _) = try Self.builtEvolvingContour()
+
+        let bounds = try #require(builder.getBounds(contour: 1, edge: edge))
+        #expect(bounds.first < bounds.last)
+
+        let before = try #require(builder.getLaw(contour: 1, edge: edge))
+        #expect(abs(before.value(at: bounds.first) - 0.5) < 1e-9)
+        #expect(abs(before.value(at: bounds.last) - 2.0) < 1e-9)
+
+        let replacement = try #require(LawFunction.linear(from: 4, to: 4,
+                                                          parameterRange: bounds.first...bounds.last))
+        #expect(builder.setLaw(contour: 1, edge: edge, law: replacement))
+
+        let after = try #require(builder.getLaw(contour: 1, edge: edge))
+        #expect(abs(after.value(at: bounds.first) - 4.0) < 1e-9)
+        #expect(abs(after.value(at: bounds.last) - 4.0) < 1e-9)
+    }
+
+    /// The guard, on the read side: contour 1 knows nothing about contour 2's edge. Before #505 both
+    /// calls answered with contour 1's own bounds and law, and reported success while doing it.
+    @Test("An edge from another contour is rejected, not answered about")
+    func edgeFromAnotherContourIsRejected() throws {
+        let box = try #require(Self.box())
+        let builder = try #require(FilletBuilder(shape: box))
+        let edges = box.edges()
+        #expect(edges.count == 12)
+        let first = try #require(edges.first)
+        let other = try #require(edges.last)
+
+        #expect(builder.addEdge(first, radius1: 0.5, radius2: 2.0))
+        #expect(builder.addEdge(other, radius1: 1.0, radius2: 3.0))
+        #expect(builder.build() != nil)
+        #expect(builder.contourCount == 2)
+
+        let firstContour = builder.contour(for: first)
+        let otherContour = builder.contour(for: other)
+        #expect(firstContour != 0)
+        #expect(otherContour != 0)
+        #expect(firstContour != otherContour)
+
+        // Each contour answers about its own edge...
+        #expect(builder.getBounds(contour: firstContour, edge: first) != nil)
+        #expect(builder.getLaw(contour: otherContour, edge: other) != nil)
+
+        // ...and about no other.
+        #expect(builder.getBounds(contour: firstContour, edge: other) == nil)
+        #expect(builder.getLaw(contour: firstContour, edge: other) == nil)
+        #expect(builder.getBounds(contour: otherContour, edge: first) == nil)
+        #expect(builder.getLaw(contour: otherContour, edge: first) == nil)
+    }
+
+    /// The guard on the write side, which is the one that did damage: `SetLaw` with an edge the
+    /// contour does not hold used to overwrite that contour's law and report nothing.
+    @Test("setLaw with an edge the contour does not hold leaves the contour's law alone")
+    func setLawWithForeignEdgeChangesNothing() throws {
+        let (builder, edge, box) = try Self.builtEvolvingContour()
+        let foreign = try #require(box.edges().last)
+        #expect(builder.contour(for: foreign) == 0)   // in no contour at all
+
+        let bounds = try #require(builder.getBounds(contour: 1, edge: edge))
+        let intruder = try #require(LawFunction.linear(from: 4, to: 4,
+                                                       parameterRange: bounds.first...bounds.last))
+        #expect(builder.setLaw(contour: 1, edge: foreign, law: intruder) == false)
+
+        // Contour 1 still reports the radii it was added with.
+        let law = try #require(builder.getLaw(contour: 1, edge: edge))
+        #expect(abs(law.value(at: bounds.first) - 0.5) < 1e-9)
+        #expect(abs(law.value(at: bounds.last) - 2.0) < 1e-9)
+
+        // And the foreign edge is not readable either.
+        #expect(builder.getBounds(contour: 1, edge: foreign) == nil)
+        #expect(builder.getLaw(contour: 1, edge: foreign) == nil)
+    }
+
+    /// OCCT checks the top of the contour range (`IC <= NbElements()`) but not the bottom, so `0`
+    /// and `-1` used to answer about contour 1.
+    @Test("A contour index outside 1...contourCount is rejected at both ends")
+    func contourIndexOutsideRangeIsRejected() throws {
+        let (builder, edge, _) = try Self.builtEvolvingContour()
+        #expect(builder.contourCount == 1)
+
+        let bounds = try #require(builder.getBounds(contour: 1, edge: edge))
+        let law = try #require(LawFunction.linear(from: 4, to: 4,
+                                                  parameterRange: bounds.first...bounds.last))
+
+        for contour in [0, -1, 2, 99] {
+            #expect(builder.getBounds(contour: contour, edge: edge) == nil, "contour \(contour)")
+            #expect(builder.getLaw(contour: contour, edge: edge) == nil, "contour \(contour)")
+            #expect(builder.setLaw(contour: contour, edge: edge, law: law) == false, "contour \(contour)")
+        }
+
+        // The law contour 1 holds is still its own.
+        let unchanged = try #require(builder.getLaw(contour: 1, edge: edge))
+        #expect(abs(unchanged.value(at: bounds.first) - 0.5) < 1e-9)
+    }
+
+    /// A constant radius is not stored as a flat law: `ChFiDS_FilSpine::ChangeLaw` throws
+    /// "no law on constant edges" for it, which all three calls report as no law.
+    @Test("A constant-radius contour has no law to read or replace")
+    func constantRadiusContourHasNoLaw() throws {
+        let box = try #require(Self.box())
+        let builder = try #require(FilletBuilder(shape: box))
+        let edge = try #require(box.edges().first)
+        #expect(builder.addEdge(edge, radius: 1.0))
+        #expect(builder.build() != nil)
+        #expect(builder.isConstant(contour: 1))
+
+        #expect(builder.getBounds(contour: 1, edge: edge) == nil)
+        #expect(builder.getLaw(contour: 1, edge: edge) == nil)
+        let law = try #require(LawFunction.linear(from: 2, to: 3, parameterRange: 0...10))
+        #expect(builder.setLaw(contour: 1, edge: edge, law: law) == false)
+    }
+
+    /// The law exists only once the contour's spine has been split, which `build()` does and
+    /// `simulate(contour:)` also does without building the blend surfaces. Note that the range
+    /// differs between the two: after `simulate` it is the spine's own `[0, 10]`, and after `build`
+    /// it runs past both ends of the edge.
+    @Test("The law is unreachable before build, and reachable after simulate")
+    func lawNeedsASpineSplit() throws {
+        let box = try #require(Self.box())
+        let builder = try #require(FilletBuilder(shape: box))
+        let edge = try #require(box.edges().first)
+        #expect(builder.addEdge(edge, radius1: 0.5, radius2: 2.0))
+
+        #expect(builder.getBounds(contour: 1, edge: edge) == nil)
+        #expect(builder.getLaw(contour: 1, edge: edge) == nil)
+
+        builder.simulate(contour: 1)
+        let simulated = try #require(builder.getBounds(contour: 1, edge: edge))
+        #expect(simulated.first < simulated.last)
+        #expect(builder.getLaw(contour: 1, edge: edge) != nil)
+
+        #expect(builder.build() != nil)
+        let built = try #require(builder.getBounds(contour: 1, edge: edge))
+        #expect(built.first <= simulated.first)
+        #expect(built.last >= simulated.last)
+    }
+
+    /// The deprecated `Shape`-typed spellings route through the `Edge` ones, so they agree with them,
+    /// and a `Shape` that is not an edge is `nil` rather than a downcast throw swallowed by the
+    /// bridge.
+    @Test("The deprecated Shape spellings agree with the Edge ones")
+    @available(*, deprecated, message: "exercises the deprecated spellings on purpose")
+    func deprecatedShapeSpellingsAgree() throws {
+        let (builder, edge, box) = try Self.builtEvolvingContour()
+        let edgeShape = try #require(Shape.fromEdge(edge))
+
+        let viaEdge = try #require(builder.getBounds(contour: 1, edge: edge))
+        let viaShape = try #require(builder.getBounds(contour: 1, edge: edgeShape))
+        #expect(viaEdge == viaShape)
+
+        let lawViaShape = try #require(builder.getLaw(contour: 1, edge: edgeShape))
+        #expect(abs(lawViaShape.value(at: viaEdge.first) - 0.5) < 1e-9)
+
+        // The box itself is a solid, not an edge.
+        #expect(builder.getBounds(contour: 1, edge: box) == nil)
+        #expect(builder.getLaw(contour: 1, edge: box) == nil)
+    }
+}

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -5101,40 +5101,27 @@ struct FilletBuilderCompletionsTests {
 struct FilletBuilderHistoryTests {
 
     @Test("FilletBuilder GetBounds for evolving radius")
-    func getBounds() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        guard let builder = FilletBuilder(shape: box) else { return }
+    func getBoundsForEvolvingRadius() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let builder = try #require(FilletBuilder(shape: box))
         let edges = box.edges()
-        guard !edges.isEmpty else { return }
-        // Use evolving radius to avoid constant-edge law crash
-        let added = builder.addEdge(edges[0], radius1: 0.5, radius2: 2.0)
-        if added {
-            if let _ = builder.build() {
-                // getBounds takes a Shape, convert edge to shape
-                if let edgeShape = Shape.fromEdge(edges[0]) {
-                    if let bounds = builder.getBounds(contour: 1, edge: edgeShape) {
-                        #expect(bounds.first < bounds.last)
-                    }
-                }
-            }
-        }
+        let edge = try #require(edges.first)
+        // An evolving radius, because a constant one has no law to bound (#505).
+        #expect(builder.addEdge(edge, radius1: 0.5, radius2: 2.0))
+        #expect(builder.build() != nil)
+        let bounds = try #require(builder.getBounds(contour: 1, edge: edge))
+        #expect(bounds.first < bounds.last)
     }
 
     @Test("FilletBuilder GetLaw for evolving radius")
-    func getLaw() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        guard let builder = FilletBuilder(shape: box) else { return }
+    func getLawForEvolvingRadius() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let builder = try #require(FilletBuilder(shape: box))
         let edges = box.edges()
-        guard !edges.isEmpty else { return }
-        let added = builder.addEdge(edges[0], radius1: 0.5, radius2: 2.0)
-        if added {
-            if let _ = builder.build() {
-                if let edgeShape = Shape.fromEdge(edges[0]) {
-                    let law = builder.getLaw(contour: 1, edge: edgeShape)
-                    #expect(law != nil)
-                }
-            }
-        }
+        let edge = try #require(edges.first)
+        #expect(builder.addEdge(edge, radius1: 0.5, radius2: 2.0))
+        #expect(builder.build() != nil)
+        #expect(builder.getLaw(contour: 1, edge: edge) != nil)
     }
 
     @Test("FilletBuilder Generated from edge")

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,293** | |
+| **Total** | **4,295** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1153,6 +1153,72 @@ only ever see `PerformBlind`'s a priori `HoleTooLong` check, never `Validate()`'
 two are independent computations that could in principle disagree right at the boundary. Measured:
 they agree, closing the gap rather than finding a live divergence.
 
+#### `FilletBuilder`'s three radius laws are keyed by an edge, and now check that they are (#505)
+
+**Behaviour change, and it is a bug fix.** `FilletBuilder.getBounds(contour:edge:)`,
+`getLaw(contour:edge:)` and `setLaw(contour:edge:law:)` used to answer about a `(contour, edge)` pair
+that names nothing: a contour index of `0`, an edge from a *different* contour, an edge in no
+contour at all. They now return `nil` / `false` for those.
+
+**Not source-breaking.** `getBounds` and `getLaw` gain an `edge: Edge` spelling, and the `edge: Shape`
+one they had is deprecated and forwards to it.
+
+The audit finding was a type inconsistency: `OCCTFilletBuilderSetLaw` took an `OCCTEdgeRef` while its
+two siblings took an `OCCTShapeRef`, so two of the three had to downcast with `TopoDS::Edge` while the
+third did not, and a caller holding an `Edge` (the type `addEdge`, `removeEdge`, `setRadius` and
+`contour(for:)` all take) had to convert it to a `Shape` to read a law and hand back the original to
+write one. The pre-existing test carried the round trip and a comment about it. All three OCCT
+functions take a `const TopoDS_Edge&`, so `SetLaw` was the one that had it right and the framing of
+the finding (four functions in the doc group agree, `SetLaw` is the outlier) counted the wrong
+majority: `Generated`/`Modified`/`IsDeleted` sit in the same group and genuinely take a
+`const TopoDS_Shape&`, since any sub-shape can be asked about. They keep `OCCTShapeRef`.
+
+Making the three identical is what surfaced the real defect. They all resolve the edge through
+`ChFiDS_FilSpine::ChangeLaw(E)`, which asks `ChFiDS_Spine::Index(E)` for the edge's position in the
+contour's spine, gets `0` for an edge that spine does not hold, and uses it anyway:
+`ElSpine(0)` → `FirstParameter(0)` → `abscissa->Value(0 - 1)`. That read has no live bounds check,
+because OCCT's `*_Raise_if` macros are compiled out of the pinned Release build, and neither does
+`ChFi3d_FilBuilder`'s own `Value(IC)`. Measured on a 10×10×10 box
+([`Scripts/repro/505-filletbuilder-edge-type/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/505-filletbuilder-edge-type)):
+
+```swift
+// Two contours. Before #505, every one of these answered, and reported success.
+builder.getBounds(contour: 1, edge: edgeOfContour2)   // (-5, 15) and contour 1's law
+builder.getBounds(contour: 1, edge: edgeInNoContour)  // (-5, 15), same
+builder.getBounds(contour: 0, edge: edgeOfContour1)   // (-5, 15), same
+builder.setLaw(contour: 1, edge: edgeInNoContour, law: law)   // true, and it overwrote contour 1's law
+
+// After: nil, nil, nil, false.
+```
+
+Only the low side of the contour range leaked, since OCCT does check `IC <= NbElements()`, so `2` and `99`
+already returned `false`. `Contour(E)` is the same `IsSame` walk over the same spines that `Index(E)`
+is about to do, so it decides exactly this question, and `Add()` rather than `Build()` populates it,
+which makes it valid before a build as well as after. One helper,
+`occtFilletContourHoldsEdge`, applies it to all three.
+
+Three things the same measurements pin, now documented on the API for the first time:
+
+- **A constant-radius contour has no law.** OCCT throws "no law on constant edges" rather than
+  handing back a flat one, so all three report no law. The old test's comment called this a "crash";
+  it is a `Standard_DomainError`, and the bridge's `catch (...)` already turned it into `nil`.
+- **The law needs a spine split.** Before `build()` there is nothing to read, and
+  `simulate(contour:)` is the other way to get one. After it the range is the spine's own `[0, 10]`
+  rather than the post-build `[-5, 15]`, which runs past both ends of the edge.
+- **`setLaw` does not reach the geometry.** `getLaw` reads the new law back, but a `build()` after it
+  reports `IsDone() == 1` and hands back the *unfilleted* input shape, and setting the law before the
+  first build (via `simulate`) then building produces the volume the original `addEdge` radii give,
+  not the one the new law asks for. Upstream behaviour; the doc comment says so.
+
+`setLaw` had no test at all before this: the one function of the three whose type was right was also
+the uncovered one. `Issue505FilletBuilderEdgeTypeTests` (`Tests/OCCTModelingTests`) covers all three
+through a single `Edge` value, the round trip that used to need a conversion each way. Run with the
+guard removed, the suite fails every time, but with 11 to 18 recorded issues across five runs: the
+unguarded answer is whatever the out-of-bounds read finds, so it is another contour's law on one run
+and a "no law on constant edges" throw on the next.
+
+Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
+
 ---
 
 ## Release History

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -1822,60 +1822,94 @@ public func colorToolGetAllColors() -> [Int64]
 
 Extensions on `FilletBuilder` added in v0.127.0.
 
+All three are keyed by an `(contour index, edge)` pair, take the `Edge` type the rest of
+`FilletBuilder` speaks, and answer "there is no law" the same way (`nil`, or `false` for `setLaw`)
+in the same four cases (#505):
+
+| rejected because | detail |
+|---|---|
+| no such contour | `contour` outside `1...contourCount`. OCCT checks only the upper end. |
+| the contour does not hold `edge` | including an edge in no contour at all, and an edge from a *different* contour. |
+| the spine is not split yet | before `build()`, or before `simulate(contour:)`. |
+| the radius is constant | OCCT stores a constant radius as no law rather than as a flat one; ask `isConstant(contour:)`. |
+
 ### `FilletBuilder.getBounds(contour:edge:)`
 
-Get the parameter bounds of a fillet on a contour edge.
+Parameter bounds of the radius law on one edge of a contour, in the contour's own spine
+parameterisation. After `build()` the range runs past both ends of the edge, because the blend
+surface does.
 
 ```swift
-public func getBounds(contour: Int, edge: Shape) -> (first: Double, last: Double)?
+public func getBounds(contour: Int, edge: Edge) -> (first: Double, last: Double)?
 ```
 
-- **Parameters:** `contour` — 1-based contour index; `edge` — the edge within the contour.
-- **Returns:** `(first, last)` parameter range, or `nil` if not found.
-- **OCCT:** `BRepFilletAPI_MakeFillet::Bounds`.
+- **Parameters:** `contour` is a 1-based contour index; `edge` is an edge the contour holds.
+- **Returns:** `(first, last)` parameter range, or `nil` (see the table above).
+- **OCCT:** `BRepFilletAPI_MakeFillet::GetBounds`.
 - **Example:**
   ```swift
-  if let bounds = fillet.getBounds(contour: 1, edge: edge) {
+  let builder = FilletBuilder(shape: box)!
+  let edge = box.edges()[0]
+  builder.addEdge(edge, radius1: 0.5, radius2: 2.0)   // evolving: there is a law
+  _ = builder.build()
+  if let bounds = builder.getBounds(contour: 1, edge: edge) {
       print(bounds.first, bounds.last)
   }
   ```
+
+The `edge: Shape` spelling is deprecated: OCCT's own parameter is a `TopoDS_Edge`, so a `Shape` only
+ever reached it through a downcast. Convert with `Edge(_:)` if a `Shape` is what you hold.
 
 ---
 
 ### `FilletBuilder.getLaw(contour:edge:)`
 
-Get the law function controlling the fillet radius on an edge within a contour.
+The law function controlling the fillet radius on one edge of a contour.
 
 ```swift
-public func getLaw(contour: Int, edge: Shape) -> LawFunction?
+public func getLaw(contour: Int, edge: Edge) -> LawFunction?
 ```
 
-- **Parameters:** `contour` — 1-based contour index; `edge` — the edge.
-- **Returns:** A `LawFunction`, or `nil` if not available.
+- **Parameters:** `contour` is a 1-based contour index; `edge` is an edge the contour holds.
+- **Returns:** A `LawFunction`, or `nil` (see the table above).
 - **OCCT:** `BRepFilletAPI_MakeFillet::GetLaw`.
 - **Example:**
   ```swift
-  if let law = fillet.getLaw(contour: 1, edge: edge) { ... }
+  if let law = builder.getLaw(contour: 1, edge: edge) {
+      print(law.value(at: law.bounds.lowerBound))   // 0.5, the radius at the start
+  }
   ```
+
+The `edge: Shape` spelling is deprecated, as for `getBounds`.
 
 ---
 
 ### `FilletBuilder.setLaw(contour:edge:law:)`
 
-Assign a law function to control the fillet radius along an edge.
+Assign the law function controlling the fillet radius along one edge of a contour.
 
 ```swift
 @discardableResult
 public func setLaw(contour: Int, edge: Edge, law: LawFunction) -> Bool
 ```
 
-- **Parameters:** `contour` — 1-based contour index; `edge` — the target edge; `law` — the radius law.
-- **Returns:** `true` if set successfully.
+- **Parameters:** `contour` is a 1-based contour index; `edge` is an edge the contour holds; `law` is
+  the radius law, over the range `getBounds(contour:edge:)` reports.
+- **Returns:** `true` if the law was set, `false` in the four cases above.
 - **OCCT:** `BRepFilletAPI_MakeFillet::SetLaw`.
 - **Example:**
   ```swift
-  fillet.setLaw(contour: 1, edge: myEdge, law: radiusLaw)
+  let bounds = builder.getBounds(contour: 1, edge: edge)!
+  let law = LawFunction.linear(from: 4, to: 4, parameterRange: bounds.first...bounds.last)!
+  builder.setLaw(contour: 1, edge: edge, law: law)
+  builder.getLaw(contour: 1, edge: edge)?.value(at: bounds.first)   // 4.0
   ```
+
+`getLaw` reads the new law back, but it does not reach the geometry: measured against the pinned
+kernel, a `build()` after this call reports success and hands back the *unfilleted* input shape, and
+setting the law before the first build (via `simulate(contour:)`) then building produces the volume
+the original `addEdge` radii give, not the one this law asks for
+(`Scripts/repro/505-filletbuilder-edge-type/`). Treat it as editing the builder's recorded law.
 
 ---
 


### PR DESCRIPTION
## What

`OCCTFilletBuilderSetLaw` took an `OCCTEdgeRef` while its two siblings, `OCCTFilletBuilderGetBounds`
and `OCCTFilletBuilderGetLaw`, took an `OCCTShapeRef`. All three OCCT functions are declared
`(const Standard_Integer, const TopoDS_Edge&)`, so `SetLaw` is the one that had it right, and the two
`Shape`-typed ones now take an `OCCTEdgeRef` too.

The issue's framing counted the wrong majority (four of five in the doc group take `OCCTShapeRef`):
`Generated`/`Modified`/`IsDeleted` sit in that group and genuinely take a `const TopoDS_Shape&`, since
any sub-shape of the input can be asked about. They keep `OCCTShapeRef`.

The cost was not stylistic. Every caller holds an `Edge`, the type `addEdge`, `removeEdge`,
`setRadius` and `contour(for:)` all take, and had to convert it to a `Shape` to read a law and hand
back the original `Edge` to write one. The pre-existing test carried that round trip and an inline
comment about it.

## The defect making the three identical surfaced

All three resolve the edge through `ChFiDS_FilSpine::ChangeLaw(E)`, which asks
`ChFiDS_Spine::Index(E)` where the edge sits in the contour's spine, gets `0` for an edge that spine
does not hold, and then uses it anyway: `ElSpine(0)` -> `FirstParameter(0)` -> `abscissa->Value(-1)`.
That read has no live bounds check, because OCCT's `*_Raise_if` macros are compiled out of the pinned
Release build, and neither does `ChFi3d_FilBuilder`'s own `Value(IC)`.

Measured on a 10x10x10 box, before changing anything
([`Scripts/repro/505-filletbuilder-edge-type/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/505-filletbuilder-edge-type/Scripts/repro/505-filletbuilder-edge-type)):

| case | before | after |
|---|---|---|
| two contours, `getBounds(contour: 1, edge: edgeOfContour2)` | `(-5, 15)` and contour **1**'s law | `nil` |
| `getBounds(contour: 1, edge: edgeInNoContour)` | `(-5, 15)`, same | `nil` |
| `getBounds(contour: 0, ...)` / `getBounds(contour: -1, ...)` | `(-5, 15)`, same | `nil` |
| `setLaw(contour: 1, edge: edgeInNoContour, law:)` | `true`, and it overwrote contour 1's law | `false` |
| `getBounds(contour: 2, ...)` with one contour | `nil` already (OCCT checks `IC <= NbElements()`) | `nil` |

`Contour(E)` is the same `IsSame` walk over the same spines that `Index(E)` is about to do, so it
decides exactly this question, and `Add()` populates it rather than `Build()`, so it holds before a
build as well as after. One helper, `occtFilletContourHoldsEdge`, applies it to all three.

The probe also confirms the type change carries no behaviour: a `TopoDS_Edge` and the same edge copied
into a `TopoDS_Shape` and downcast back are the same argument, down to `GetLaw` returning the
identical `Handle(Law_Function)`.

## Also documented for the first time

- **A constant-radius contour has no law.** OCCT throws "no law on constant edges" rather than handing
  back a flat one. The old test's comment called this a "crash"; it is a `Standard_DomainError` the
  bridge's `catch (...)` already turned into `nil`.
- **The law needs a spine split.** Nothing to read before `build()`, and `simulate(contour:)` is the
  other way to get one. The range differs between them: `[0, 10]` after `simulate`, `[-5, 15]` after
  `build`, which runs past both ends of the edge.
- **`setLaw` does not reach the geometry.** `getLaw` reads the new law back, but a `build()` after it
  reports success and hands back the *unfilleted* input shape, and setting the law before the first
  build then building produces the volume the original `addEdge` radii give. Upstream behaviour.

## Compatibility

- **Behaviour change**, and it is the fix: the pairs in the table now answer `nil` / `false`.
- **Not source-breaking.** `getBounds` and `getLaw` gain an `edge: Edge` spelling; the `edge: Shape`
  one is deprecated and forwards through `Edge(_:)`, which is `nil` for a non-edge `Shape` (the same
  outcome the swallowed `TopoDS::Edge` throw produced). No ecosystem repo calls any of the three.
- The C signature change is free: `OCCTBridge` is not an SPM product.

## Tests

`setLaw` had no coverage at all before this, the one function of the three whose type was right.
`Tests/OCCTModelingTests/Issue505FilletBuilderEdgeTypeTests.swift` covers all three through a single
`Edge` value, plus the contour-membership guard, the contour-index range, the constant-radius case and
the deprecated spellings. The two pre-existing tests lose their `Shape.fromEdge` round trip and their
nested `if let`s, which had made every assertion skippable.

Run with the guard removed, the suite fails every run, but with 11 to 18 recorded issues across five
runs: the unguarded answer is whatever the out-of-bounds read finds, so it is another contour's law on
one run and a "no law on constant edges" throw on the next.

Full `swift test`: **4780 tests pass**. Bridge and Swift only, no kernel patch, no `OCCT.xcframework`
rebuild.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
