### PR TITLE
refactor(#506): delete three orphaned arc-length bridge functions, which were not spare copies

### DIFF
--- a/Scripts/repro/506-arclength-adaptor-divergence/README.md
+++ b/Scripts/repro/506-arclength-adaptor-divergence/README.md
@@ -1,0 +1,94 @@
+# OCCTSwift#506 probe: pre-bounded adaptor vs range-taking `GCPnts_AbscissaPoint::Length`
+
+Ground truth for the two spellings of ranged arc length the bridge carried, against the pinned
+OCCT 8.0.0p1 kernel.
+
+#506 found three arc-length bridge functions left unreachable when #408 routed every Swift spelling
+through `OCCTCurve3DGetLength` / `OCCTCurve3DGetLengthBetween`. That reading is correct. The header
+comparison also suggests the orphans are exact copies, differing only in their failure sentinel. One
+of them is not: `OCCTCurve3DLength` measured through a **pre-bounded** `GeomAdaptor_Curve(c, u1, u2)`
+rather than passing the range to `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`. This probe asks
+what that constructor choice actually changes, which the headers do not say:
+
+1. **Do the two forms ever disagree, and on what input?** A duplicate that behaves identically is a
+   tidiness question. One that does not is a correctness question.
+2. **Which one clamps to the curve's domain?** #477's fix depends on clamping rather than
+   extrapolating past a BSpline's knots.
+3. **How does each treat a reversed range?** The 2D sibling documents itself as range-checked, and
+   #487 established that `No_Exception` voids OCCT-internal preconditions in this build, so the
+   documented raise needed confirming rather than reading.
+
+No fixture files needed: every case builds its geometry from a primitive or an interpolation.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/506-arclength-adaptor-divergence/occt_506_arclength_adaptor.mm -o /tmp/occt_506
+/tmp/occt_506
+```
+
+## What it does
+
+Part 1 measures both forms on the same input across in-domain, reversed, equal-parameter,
+out-of-domain, periodic-seam, unbounded and NaN ranges. The fixture is a 5-point interpolated
+BSpline with sharply varying speed (domain `[0, 325.974]`, length 360.986), the shape #477's accuracy
+work used, plus a circle and an unbounded line. Part 1g repeats the comparison for the 2D pair, where
+both spellings are still live. Part 2 follows up on the NaN row, asking whether the surviving form's
+NaN behaviour is the same for every curve type.
+
+## Result
+
+**The orphans were not exact copies. The pre-bounded form disagrees on four of eleven ranges.**
+
+| range | pre-bounded (deleted) | ranged (live) |
+|---|---|---|
+| in domain, forward | 173.76 | 173.76 |
+| in domain, full | 360.99 | 360.99 |
+| in domain, reversed | raises `Standard_Failure` | 173.76 |
+| equal parameters | 0 | 0 |
+| overshooting both ends by a domain width | **8489.78** | 360.99 |
+| wholly outside the domain | 1.34 | 0 |
+| periodic seam, full period, unbounded sub-range | agree | agree |
+| NaN upper bound | `nan` | 0 |
+
+- **Only the range-taking form clamps.** The pre-bounded constructor evaluates the BSpline's
+  polynomial past its knots: 8489.78 for a curve 360.99 long, and 1.34 for a range the curve does not
+  occupy at all, both reported as ordinary successes. This is the behaviour #477 removed from every
+  reachable path, preserved verbatim in the unreachable one.
+- **The reversed-range raise is real in this build.** `GeomAdaptor_Curve(c, 195.6, 32.6)` and the 2D
+  equivalents raise, so `No_Exception` does not void this particular precondition. The deleted
+  function's `catch (...) { return 0; }` turned that raise into `0`, which is the same value a
+  genuine zero-width interval reports, so a reversed range read as zero length.
+- **The two agree wherever the range is ordinary**, including across a periodic seam and on an
+  unbounded line, which is why nothing noticed for two releases.
+
+**The live form's NaN handling is curve-type dependent**, which part 1f's single row hinted at:
+
+| curve | NaN upper bound | NaN lower bound |
+|---|---|---|
+| segment (trimmed line) | `nan`, Swift reports `nil` | `nan`, Swift reports `nil` |
+| unbounded line | `nan`, Swift reports `nil` | not measured |
+| circle | `nan`, Swift reports `nil` | not measured |
+| BSpline | **0**, Swift reports a value | **360.99**, Swift reports a value |
+
+#408's distinguishability test uses `Curve3D.segment(from:to:)`, one of the types where NaN
+propagates, so it passes and says nothing about splines. Filed as #548.
+
+## What was done with it
+
+All three orphans deleted, with tombstone comments naming the surviving function. The four divergent
+ranges are pinned by `Tests/OCCTCurveTests/Issue506ArcLengthBridgeContractTests.swift`, verified by
+injection: restoring the pre-#408 wiring reproduces this probe's figures through the public Swift API
+(`0` against 173.76, 8489.78 against 360.99, 1.34 against 0), and rewiring `length(from:to:)` itself
+onto the pre-bounded form fails all four tests.
+
+Not an upstream defect: both `GeomAdaptor_Curve` constructors behave as documented, and choosing
+between them is the caller's job. Nothing to file or patch in the kernel.
+
+Two findings left for their own issues: the NaN dependence above (#548), and the 2D pair, where
+`Curve2D.arcLength(from:to:)` still reaches the pre-bounded form deliberately, so the 2D and 3D
+spellings of the same call now answer differently on a reversed range (#549).

--- a/Scripts/repro/506-arclength-adaptor-divergence/occt_506_arclength_adaptor.mm
+++ b/Scripts/repro/506-arclength-adaptor-divergence/occt_506_arclength_adaptor.mm
@@ -1,0 +1,135 @@
+// OCCTSwift#506 probe: pre-bounded GeomAdaptor_Curve(c, u1, u2) vs GCPnts_AbscissaPoint::Length(c, u1, u2)
+//
+// #506 deleted three orphaned Curve3D arc-length bridge functions. One of them,
+// OCCTCurve3DLength, measured through a pre-bounded adaptor rather than passing the range to
+// GCPnts_AbscissaPoint::Length. This asks whether the two forms ever disagree, and where.
+//
+// Part 2 asks a question raised by part 1's NaN row: is the live form's NaN handling the same for
+// every curve type? (It is not. Filed as #548.)
+//
+// Build and run from the repository root:
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/506-arclength-adaptor-divergence/occt_506_arclength_adaptor.mm -o /tmp/occt_506
+//   /tmp/occt_506
+
+#include <GCPnts_AbscissaPoint.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom2d_Circle.hxx>
+#include <GeomAPI_Interpolate.hxx>
+#include <TColgp_HArray1OfPnt.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Ax2d.hxx>
+#include <gp_Circ2d.hxx>
+#include <gp_Lin2d.hxx>
+#include <Standard_Failure.hxx>
+#include <stdio.h>
+
+// prebounded: what the deleted OCCTCurve3DLength did.
+// ranged: what the surviving OCCTCurve3DGetLengthBetween does.
+static void probe3d(const char* label, const Handle(Geom_Curve)& c, double u1, double u2) {
+    double a = -999, b = -999;
+    const char* ea = "-"; const char* eb = "-";
+    try { GeomAdaptor_Curve ac(c, u1, u2); a = GCPnts_AbscissaPoint::Length(ac); }
+    catch (Standard_Failure const&) { ea = "Standard_Failure"; }
+    catch (...) { ea = "other"; }
+    try { GeomAdaptor_Curve ac(c); b = GCPnts_AbscissaPoint::Length(ac, u1, u2); }
+    catch (Standard_Failure const&) { eb = "Standard_Failure"; }
+    catch (...) { eb = "other"; }
+    printf("%-46s u=[%g,%g]  prebounded=%.10g (%s)  ranged=%.10g (%s)  %s\n",
+           label, u1, u2, a, ea, b, eb,
+           (ea[0] == '-' && eb[0] == '-' && a == b) ? "SAME" : "DIFFER");
+}
+
+// The 2D pair, which #506 left alone: OCCTCurve2DLength is still the pre-bounded form and is
+// still reachable from Curve2D.arcLength(from:to:). Filed as #549.
+static void probe2d(const char* label, const Handle(Geom2d_Curve)& c, double u1, double u2) {
+    double a = -999, b = -999;
+    const char* ea = "-"; const char* eb = "-";
+    try { Geom2dAdaptor_Curve ac(c, u1, u2); a = GCPnts_AbscissaPoint::Length(ac); }
+    catch (Standard_Failure const&) { ea = "Standard_Failure"; }
+    catch (...) { ea = "other"; }
+    try { Geom2dAdaptor_Curve ac(c); b = GCPnts_AbscissaPoint::Length(ac, u1, u2); }
+    catch (Standard_Failure const&) { eb = "Standard_Failure"; }
+    catch (...) { eb = "other"; }
+    printf("%-46s u=[%g,%g]  prebounded=%.10g (%s)  ranged=%.10g (%s)  %s\n",
+           label, u1, u2, a, ea, b, eb,
+           (ea[0] == '-' && eb[0] == '-' && a == b) ? "SAME" : "DIFFER");
+}
+
+static void ranged(const char* label, const Handle(Geom_Curve)& c, double u1, double u2) {
+    double v = -999; const char* e = "-";
+    try { GeomAdaptor_Curve ac(c); v = GCPnts_AbscissaPoint::Length(ac, u1, u2); }
+    catch (Standard_Failure const&) { e = "Standard_Failure"; } catch (...) { e = "other"; }
+    printf("%-34s ranged=%-16.10g (%s)  Swift sees=%s\n", label, v, e,
+           (e[0] != '-') ? "n/a" : (v >= 0 ? "a value" : "nil"));
+}
+
+static Handle(Geom_Curve) multiSpanBSpline() {
+    Handle(TColgp_HArray1OfPnt) pts = new TColgp_HArray1OfPnt(1, 5);
+    pts->SetValue(1, gp_Pnt(0, 0, 0));
+    pts->SetValue(2, gp_Pnt(10, 40, 0));
+    pts->SetValue(3, gp_Pnt(20, 0, 0));
+    pts->SetValue(4, gp_Pnt(200, 5, 0));
+    pts->SetValue(5, gp_Pnt(210, 60, 30));
+    GeomAPI_Interpolate interp(pts, Standard_False, 1e-7);
+    interp.Perform();
+    return interp.Curve();
+}
+
+int main() {
+    Handle(Geom_Curve) bsp = multiSpanBSpline();
+    const double f = bsp->FirstParameter(), l = bsp->LastParameter();
+    printf("BSpline domain = [%g, %g]\n", f, l);
+
+    Handle(Geom_Curve) circ = new Geom_Circle(gp_Circ(gp_Ax2(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 5.0));
+    Handle(Geom_Curve) line = new Geom_Line(gp_Lin(gp_Pnt(0,0,0), gp_Dir(1,0,0)));
+    Handle(Geom_Curve) seg = new Geom_TrimmedCurve(line, 0.0, 10.0);
+
+    printf("\n== part 1a: 3D, in-domain sub-range ==\n");
+    probe3d("bspline in-domain", bsp, f + 0.1 * (l - f), f + 0.6 * (l - f));
+    probe3d("bspline full domain", bsp, f, l);
+    printf("\n== part 1b: 3D, reversed range ==\n");
+    probe3d("bspline reversed", bsp, f + 0.6 * (l - f), f + 0.1 * (l - f));
+    probe3d("circle reversed", circ, 2.0, 1.0);
+    printf("\n== part 1c: 3D, equal parameters ==\n");
+    probe3d("bspline equal", bsp, f + 0.3 * (l - f), f + 0.3 * (l - f));
+    printf("\n== part 1d: 3D, out of domain ==\n");
+    probe3d("bspline overshoot both ends", bsp, f - (l - f), l + (l - f));
+    probe3d("bspline wholly outside", bsp, l + 1.0, l + 2.0);
+    printf("\n== part 1e: 3D, periodic seam and unbounded ==\n");
+    probe3d("circle across seam", circ, 5.0, 7.0);
+    probe3d("circle full period", circ, 0.0, 6.283185307179586);
+    probe3d("unbounded line sub-range", line, -10.0, 10.0);
+    printf("\n== part 1f: 3D, NaN bound ==\n");
+    probe3d("bspline NaN upper", bsp, f, NAN);
+
+    Handle(Geom2d_Curve) c2 = new Geom2d_Circle(gp_Circ2d(gp_Ax2d(gp_Pnt2d(0,0), gp_Dir2d(1,0)), 5.0));
+    Handle(Geom2d_Curve) l2 = new Geom2d_Line(gp_Lin2d(gp_Pnt2d(0,0), gp_Dir2d(1,0)));
+    printf("\n== part 1g: the 2D pair, still both live (#549) ==\n");
+    probe2d("circle2d in-domain", c2, 1.0, 2.0);
+    probe2d("circle2d reversed", c2, 2.0, 1.0);
+    probe2d("line2d reversed", l2, 10.0, -10.0);
+
+    printf("\n== part 2: is the live form's NaN handling curve-type dependent? (#548) ==\n");
+    printf("NaN upper bound:\n");
+    ranged("segment (trimmed line)", seg, 0.0, NAN);
+    ranged("unbounded line", line, 0.0, NAN);
+    ranged("bspline", bsp, f, NAN);
+    ranged("circle", circ, 0.0, NAN);
+    printf("NaN lower bound:\n");
+    ranged("segment", seg, NAN, 10.0);
+    ranged("bspline", bsp, NAN, l);
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -17574,11 +17574,9 @@ double OCCTEdgeArcLength(OCCTShapeRef _Nonnull edge);
 /// Find parameter on a 3D curve at a given arc length from startParam.
 double OCCTCurve3DParameterAtLength(OCCTCurve3DRef _Nonnull curve, double arcLength, double fromParam);
 
-/// Compute total arc length of a 3D curve within its domain.
-double OCCTCurve3DArcLength(OCCTCurve3DRef _Nonnull curve);
-
-/// Compute arc length of a 3D curve between two parameters.
-double OCCTCurve3DArcLengthBetween(OCCTCurve3DRef _Nonnull curve, double param1, double param2);
+/// OCCTCurve3DArcLength and OCCTCurve3DArcLengthBetween were declared here: second spellings
+/// of OCCTCurve3DGetLength / OCCTCurve3DGetLengthBetween that returned 0 rather than -1.0 on
+/// failure. Removed by #506.
 
 /// Compute arc length between two parameters on an edge.
 double OCCTEdgeArcLengthBetween(OCCTShapeRef _Nonnull edge, double u1, double u2);
@@ -17645,8 +17643,9 @@ double OCCTShapeTotalEdgeLength(OCCTShapeRef _Nonnull shape);
 
 // --- Curve3D/2D additional (v0.115.0) ---
 
-/// Compute the length of a 3D curve between parameters u1 and u2.
-double OCCTCurve3DLength(OCCTCurve3DRef _Nonnull curve, double u1, double u2);
+/// OCCTCurve3DLength was declared here: a third spelling of OCCTCurve3DGetLengthBetween that
+/// measured through a pre-bounded GeomAdaptor_Curve, so it extrapolated past the curve's knots
+/// instead of clamping and read a reversed range as zero length. Removed by #506.
 
 /// OCCTCurve3DClosestParameter was declared here: a second spelling of the projection
 /// OCCTCurve3DNearestParameter now performs. Removed by #500.

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -4596,13 +4596,11 @@ OCCTCurve3DRef OCCTCurve3DConcatenateG1(const OCCTCurve3DRef* curves, int32_t co
 #include <GCPnts_AbscissaPoint.hxx>
 #include <GeomAdaptor_Curve.hxx>
 
-double OCCTCurve3DLength(OCCTCurve3DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        GeomAdaptor_Curve ac(curve->curve, u1, u2);
-        return GCPnts_AbscissaPoint::Length(ac);
-    } catch (...) { return 0; }
-}
+// OCCTCurve3DLength lived here: GCPnts_AbscissaPoint::Length over a pre-bounded
+// GeomAdaptor_Curve(curve, u1, u2), which raises on a reversed range (so the catch reported a
+// reversed range as zero length) and extrapolates past the curve's knots instead of clamping to
+// its domain. Removed by #506; Curve3D.arcLength(from:to:) has routed through
+// OCCTCurve3DGetLengthBetween, which does neither, since #408.
 
 // OCCTCurve3DClosestParameter lived here: the same projection as OCCTCurve3DNearestParameter,
 // differing only in reporting no-projection as 0 rather than FirstParameter(). Removed by #500;
@@ -4619,21 +4617,12 @@ double OCCTCurve3DParameterAtLength(OCCTCurve3DRef curve, double arcLength, doub
     } catch (...) { return 0; }
 }
 
-double OCCTCurve3DArcLength(OCCTCurve3DRef curve) {
-    if (!curve) return 0;
-    try {
-        GeomAdaptor_Curve adaptor(curve->curve);
-        return GCPnts_AbscissaPoint::Length(adaptor);
-    } catch (...) { return 0; }
-}
-
-double OCCTCurve3DArcLengthBetween(OCCTCurve3DRef curve, double param1, double param2) {
-    if (!curve) return 0;
-    try {
-        GeomAdaptor_Curve adaptor(curve->curve);
-        return GCPnts_AbscissaPoint::Length(adaptor, param1, param2);
-    } catch (...) { return 0; }
-}
+// OCCTCurve3DArcLength and OCCTCurve3DArcLengthBetween lived here: the same two
+// GCPnts_AbscissaPoint::Length calls OCCTCurve3DGetLength / OCCTCurve3DGetLengthBetween make,
+// differing only in returning 0 on failure (indistinguishable from a genuine zero-length result)
+// and in guarding the wrapper pointer without also guarding the curve handle it holds. Removed
+// by #506; Curve3D.totalArcLength and arcLengthBetween(_:_:) have routed through the -1.0
+// spellings since #408.
 
 // MARK: - v0.116: HelixGeom (BuilderHelix/Coil + HelixCurve eval/D1/D2 + ApproxToBSpline)
 #include <math_IntegerVector.hxx>

--- a/Tests/OCCTCurveTests/Issue506ArcLengthBridgeContractTests.swift
+++ b/Tests/OCCTCurveTests/Issue506ArcLengthBridgeContractTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// Cover for #506, which deleted three orphaned arc-length bridge functions
+/// (`OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween`, `OCCTCurve3DLength`) left unreachable
+/// when #408 routed every Swift spelling through `OCCTCurve3DGetLength` /
+/// `OCCTCurve3DGetLengthBetween`.
+///
+/// The deleted ranged function was not a redundant copy. It measured through a *pre-bounded*
+/// `GeomAdaptor_Curve(curve, u1, u2)` rather than passing the range to
+/// `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`, and the two forms disagree wherever the range
+/// is not an ordinary in-domain interval. Measured against the pinned kernel on the fixture below:
+///
+/// | range | pre-bounded (deleted) | ranged (live) |
+/// |---|---|---|
+/// | reversed, in domain | raises, reported as `0` | 173.76 |
+/// | overshooting both ends by a domain width | 8489.78 | 360.99 (the curve's own length) |
+/// | wholly outside the domain | 1.34 | 0 |
+///
+/// Nothing exercised any of that: the three functions had no Swift call site and no test, so a
+/// future caller rewiring onto one (or copying one as a template) would have reinherited both the
+/// `0`-means-failure collapse #408 fixed and the extrapolation #477 fixed, silently. These
+/// assertions pin the surviving behaviour on exactly the ranges where the two forms differ.
+@Suite("Curve3D ranged arc-length contract after the #506 bridge removal")
+struct Issue506ArcLengthBridgeContractTests {
+
+    /// Multi-span interpolated BSpline with sharply varying speed: the shape where the two
+    /// adaptor forms diverge most, and the shape a straight line or a single arc cannot detect.
+    private func multiSpanCurve() -> Curve3D? {
+        Curve3D.interpolate(points: [
+            SIMD3(0, 0, 0),
+            SIMD3(10, 40, 0),
+            SIMD3(20, 0, 0),
+            SIMD3(200, 5, 0),
+            SIMD3(210, 60, 30)
+        ])
+    }
+
+    /// Chord-sum reference, so the clamping assertions compare against the curve's real length
+    /// rather than against whatever the implementation returns for the whole domain.
+    private func polylineLength(_ c: Curve3D, from u1: Double, to u2: Double,
+                               segments: Int = 20_000) -> Double {
+        var total = 0.0
+        var prev = c.point(at: u1)
+        for i in 1...segments {
+            let u = u1 + (u2 - u1) * Double(i) / Double(segments)
+            let p = c.point(at: u)
+            let d = p - prev
+            total += (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
+            prev = p
+        }
+        return total
+    }
+
+    @Test("A reversed in-domain range measures the span, not zero")
+    func reversedRangeMeasuresTheSpan() {
+        guard let c = multiSpanCurve() else { return }
+        let d = c.domain
+        let lo = d.lowerBound + 0.1 * (d.upperBound - d.lowerBound)
+        let hi = d.lowerBound + 0.6 * (d.upperBound - d.lowerBound)
+
+        guard let forward = c.length(from: lo, to: hi),
+              let reversed = c.length(from: hi, to: lo) else {
+            Issue.record("both orderings must measure on a valid curve")
+            return
+        }
+
+        // The pre-bounded adaptor raised Standard_ConstructionError on u1 > u2 and the deleted
+        // function's catch turned that into 0, so a reversed range read as a zero-length interval.
+        #expect(reversed == forward)
+        #expect(reversed > 0)
+        #expect(abs(reversed - polylineLength(c, from: lo, to: hi)) < 0.01 * forward)
+    }
+
+    @Test("Parameters past both ends clamp to the domain instead of extrapolating")
+    func overshootingBothEndsClampsToTheDomain() {
+        guard let c = multiSpanCurve(), let whole = c.length else { return }
+        let d = c.domain
+        let span = d.upperBound - d.lowerBound
+
+        guard let overshot = c.length(from: d.lowerBound - span, to: d.upperBound + span) else {
+            Issue.record("an out-of-domain range must still measure")
+            return
+        }
+
+        // The pre-bounded adaptor evaluated the BSpline's polynomial past its knots: 8489.78
+        // against a curve 360.99 long, reported as an ordinary success.
+        #expect(overshot == whole)
+        #expect(abs(overshot - polylineLength(c, from: d.lowerBound, to: d.upperBound)) < 0.01 * whole)
+    }
+
+    @Test("A range wholly outside the domain measures zero")
+    func rangeOutsideTheDomainMeasuresZero() {
+        guard let c = multiSpanCurve() else { return }
+        let d = c.domain
+
+        // Clamping both bounds to upperBound leaves an empty interval. The pre-bounded adaptor
+        // extrapolated it instead, reporting 1.34 for a range the curve does not occupy.
+        #expect(c.length(from: d.upperBound + 1, to: d.upperBound + 2) == 0)
+    }
+
+    @Test("All three Swift spellings agree on the ranges that used to diverge")
+    func everySpellingAgreesOnDivergentRanges() {
+        guard let c = multiSpanCurve() else { return }
+        let d = c.domain
+        let span = d.upperBound - d.lowerBound
+        let cases: [(String, Double, Double)] = [
+            ("reversed", d.lowerBound + 0.6 * span, d.lowerBound + 0.1 * span),
+            ("overshoot both ends", d.lowerBound - span, d.upperBound + span),
+            ("wholly outside", d.upperBound + 1, d.upperBound + 2),
+            ("equal parameters", d.lowerBound + 0.3 * span, d.lowerBound + 0.3 * span)
+        ]
+
+        // #408 made these three spellings one computation. They shared no code before it: two
+        // reached the deleted functions and one reached the surviving pair.
+        for (label, u1, u2) in cases {
+            guard let canonical = c.length(from: u1, to: u2) else {
+                Issue.record("\(label): canonical spelling must measure")
+                continue
+            }
+            #expect(c.arcLength(from: u1, to: u2) == canonical, "\(label)")
+            #expect(c.arcLengthBetween(u1, u2) == canonical, "\(label)")
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,7 +46,8 @@ wherever the range is not an ordinary in-domain interval. Measured against the p
 
 So the "dead copy" still extrapolated a BSpline's polynomial past its knots, the behaviour #477
 removed from every reachable path, and still read a reversed range as zero length. One rewire or one
-copy-paste and both defects were back, with no test anywhere to catch it.
+copy-paste and both defects were back, with no test anywhere to catch it. Probe and full figures at
+[`Scripts/repro/506-arclength-adaptor-divergence/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/506-arclength-adaptor-divergence).
 
 New suite `Issue506ArcLengthBridgeContractTests` (`OCCTCurveTests`) pins the surviving behaviour on
 exactly the four ranges where the forms diverge, with the clamping assertions checked against a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,10 +60,10 @@ four tests.
 reports `nil` on a line, a segment and a circle, but on a BSpline `GCPnts_AbscissaPoint::Length`
 returns a plausible number (`0` for a NaN upper bound, the whole length for a NaN lower bound), so
 the failure-versus-zero distinction #408 established holds for the curve types its own tests use and
-not for BSplines. Separately, `Curve2D.arcLength(from:to:)` still measures through the 2D
+not for BSplines (#548). Separately, `Curve2D.arcLength(from:to:)` still measures through the 2D
 pre-bounded adaptor deliberately, documented as range-checked, so the 2D and 3D spellings of the same
-call now differ on a reversed range. Both are #408/#409 contract questions rather than duplication,
-so they are filed rather than folded in here.
+call now differ on a reversed range (#549). Both are #408/#409 contract questions rather than
+duplication, so they are filed rather than folded in here.
 
 #### One pipe shell, and the sweep mode it was quietly discarding (#503)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,54 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
+
+`OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed
+`totalArcLength`, `arcLength(from:to:)` and `arcLengthBetween(_:_:)` through `length` /
+`length(from:to:)`, which call `OCCTCurve3DGetLength` / `OCCTCurve3DGetLengthBetween`, leaving all
+three declared, compiled, and unreachable from Swift. #461 kept them "for C-ABI stability". That
+rationale does not survive contact with the packaging: `OCCTBridge` is a target, not a product, so
+nothing outside this package can link those symbols through SwiftPM. The layer's actual stability
+contract is now written down rather than asserted per PR, in
+[`docs/architecture/overview.md`](architecture/overview.md) under design decision 6.
+
+Keeping them was not free. Retaining an orphan freezes whatever contract it had when it was
+orphaned, and these three were frozen before two separate fixes. All three returned `0` on failure,
+the collapse of "the computation failed" into "the curve is genuinely zero length" that #408 fixed.
+`OCCTCurve3DLength` also measured through a pre-bounded `GeomAdaptor_Curve(curve, u1, u2)` instead
+of passing the range to `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`, and the two forms disagree
+wherever the range is not an ordinary in-domain interval. Measured against the pinned kernel on a
+5-point interpolated BSpline, 360.99 long:
+
+| range | pre-bounded (deleted) | ranged (live) |
+|---|---|---|
+| in domain, forward | 173.76 | 173.76 |
+| in domain, reversed | raises, reported as `0` | 173.76 |
+| overshooting both ends by a domain width | 8489.78 | 360.99 |
+| wholly outside the domain | 1.34 | 0 |
+| equal parameters, periodic seam, unbounded sub-range | agree | agree |
+
+So the "dead copy" still extrapolated a BSpline's polynomial past its knots, the behaviour #477
+removed from every reachable path, and still read a reversed range as zero length. One rewire or one
+copy-paste and both defects were back, with no test anywhere to catch it.
+
+New suite `Issue506ArcLengthBridgeContractTests` (`OCCTCurveTests`) pins the surviving behaviour on
+exactly the four ranges where the forms diverge, with the clamping assertions checked against a
+chord-sum reference rather than against the implementation's own answer for the whole domain. Proved
+against two injections rather than assumed: restoring the pre-#408 wiring fails the cross-spelling
+test on all three divergent ranges (0 against 173.76, 8489.78 against 360.99, 1.34 against 0), and
+rewiring `length(from:to:)` itself onto the pre-bounded form, the accidental-rewire case, fails all
+four tests.
+
+**Noticed, not fixed.** `length(from:to:)`'s NaN handling is curve-type dependent: a NaN bound
+reports `nil` on a line, a segment and a circle, but on a BSpline `GCPnts_AbscissaPoint::Length`
+returns a plausible number (`0` for a NaN upper bound, the whole length for a NaN lower bound), so
+the failure-versus-zero distinction #408 established holds for the curve types its own tests use and
+not for BSplines. Separately, `Curve2D.arcLength(from:to:)` still measures through the 2D
+pre-bounded adaptor deliberately, documented as range-checked, so the 2D and 3D spellings of the same
+call now differ on a reversed range. Both are #408/#409 contract questions rather than duplication,
+so they are filed rather than folded in here.
+
 #### One pipe shell, and the sweep mode it was quietly discarding (#503)
 
 Four bridge functions each built their own single-profile `BRepOffsetAPI_MakePipeShell`, and each
@@ -1343,6 +1391,9 @@ direct C consumers, but they are no longer reached from Swift: #408 routed `tota
 `arcLength(from:to:)` and `arcLengthBetween(_:_:)` through `length`/`length(from:to:)`, so every
 Swift spelling now lands on `OCCTCurve3DGetLength`/`OCCTCurve3DGetLengthBetween`. Nothing in
 `Sources/OCCTSwift` references the older three.
+(Superseded: all three were deleted outright by #506, which also found that `OCCTCurve3DLength`'s
+pre-bounded adaptor extrapolated past the knots rather than clamping, so it had not in fact
+inherited this entry's fix. See the #506 entry.)
 
 New suite `Issue477ArcLengthAccuracyTests` (`OCCTCurveTests`) pins all five Swift spellings against
 an independently computed reference (a Richardson-extrapolated polyline, not the implementation's
@@ -1501,6 +1552,8 @@ restored and `length`/`length(from:to:)` gain it as well. Note the consequence f
 `OCCTCurve3DArcLength`, `OCCTCurve3DLength` and `OCCTCurve3DArcLengthBetween` are no longer reached
 from Swift at all (nothing in `Sources/OCCTSwift` references them), though they remain exported for
 direct C consumers.
+(Superseded: #506 deleted all three. `OCCTBridge` is a target and not a product, so there were no
+direct C consumers to export them for.)
 
 #### Public Swift API
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -150,6 +150,27 @@ OCCT operations can fail (e.g., self-intersecting boolean). Current strategy:
 
 Future consideration: Swift `throws` for explicit error handling.
 
+### 6. The Bridge Is Internal: No Frozen C ABI
+
+`OCCTBridge` is a *target*, not a product. `Package.swift` declares exactly one product,
+`.library(name: "OCCTSwift")`, so no external package can `import OCCTBridge` or link its symbols
+through SwiftPM. The C surface in `OCCTBridge.h` therefore carries no compatibility promise of its
+own: renaming, merging, or deleting a bridge function is an internal refactor, and the only
+stability contract is the Swift API's, governed by [`SEMVER.md`](../SEMVER.md).
+
+Two practical consequences:
+
+- **A bridge function with no Swift caller is deleted, not retained.** "Keep it exported for C
+  consumers" is not a reason this repo recognises, because the packaging gives it no C consumers to
+  keep it for. Retaining one instead preserves whatever contract it had at the moment it was
+  orphaned, which is how #506 came to hold three arc-length functions that still returned `0` on
+  failure years after the Swift layer moved to a `-1.0` sentinel, and still extrapolated past a
+  curve's knots after #477 fixed that everywhere reachable.
+- **The published `OCCTBridge.xcframework` is a per-release artifact, not an ABI.** The
+  `OCCTSWIFT_BRIDGE_PREBUILT=1` path (see `Package.swift`) resolves a version-pinned URL, so the
+  binary and the headers of any one release stay self-consistent. That is reproducibility within a
+  release, not a promise across releases.
+
 ## Memory Management
 
 ### OCCT Handles


### PR DESCRIPTION
Closes #506. Pass 1b of the #377 duplication audit, so this targets `refactor/381-pass1b`, not `main`.

## The finding, confirmed

`OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` had no Swift call site and no test. #408 (PR #461) routed `totalArcLength`, `arcLength(from:to:)` and `arcLengthBetween(_:_:)` through `length` / `length(from:to:)`, which call `OCCTCurve3DGetLength` / `OCCTCurve3DGetLengthBetween`, and kept the three "for C-ABI stability".

That rationale does not hold. `Package.swift` declares exactly one product, `.library(name: "OCCTSwift")`; `OCCTBridge` is a target, so nothing outside this package can `import OCCTBridge` or link those symbols through SwiftPM. There were no C consumers to export them for.

## They were not spare copies

Retaining an orphan freezes whatever contract it had when it was orphaned. These three were frozen before two separate fixes.

All three returned `0` on failure, the collapse of "the computation failed" into "the curve is genuinely zero length" that #408 exists to fix. `OCCTCurve3DLength` additionally measured through a pre-bounded `GeomAdaptor_Curve(curve, u1, u2)` rather than passing the range to `GCPnts_AbscissaPoint::Length(adaptor, u1, u2)`. Ground-truth C++ against the pinned xcframework, on a 5-point interpolated BSpline 360.99 long:

| range | pre-bounded (deleted) | ranged (live) |
|---|---|---|
| in domain, forward | 173.76 | 173.76 |
| in domain, reversed | raises, reported as `0` | 173.76 |
| overshooting both ends by a domain width | **8489.78** | 360.99 |
| wholly outside the domain | 1.34 | 0 |
| equal parameters, periodic seam, unbounded sub-range | agree | agree |

So the "harmless leftover" still extrapolated a BSpline's polynomial past its knots, the behaviour #477 removed from every reachable path, and still read a reversed range as zero length. The identical figures come back through the public Swift API when the old wiring is restored, so this is the shipped behaviour of the code that was kept, not a property of the probe.

Probe and full figures at [`Scripts/repro/506-arclength-adaptor-divergence/`](https://github.com/SecondMouseAU/OCCTSwift/tree/refactor/506-drop-orphaned-arclength-bridge/Scripts/repro/506-arclength-adaptor-divergence).

## Changes

**Bridge.** All three declarations and implementations deleted, each replaced by a tombstone comment naming the surviving function and the issue, following the idiom #500 established in this branch. The `GCPnts_AbscissaPoint` / `GeomAdaptor_Curve` includes stay: `OCCTCurve3DParameterAtLength` still uses both.

**Docs.** `docs/architecture/overview.md` gains design decision 6, writing down what the bridge layer's stability contract actually is (target not product, no frozen C ABI, an orphan is deleted rather than retained, and the published `OCCTBridge.xcframework` is a per-release artifact rather than a promise across releases). The issue asked for this either way: the rationale had been asserted once in a PR body and nowhere else, so the next audit had to re-derive it by git archaeology. The two changelog sentences that said the three functions "remain exported for direct C consumers" are annotated as superseded rather than rewritten.

No public Swift API change, so `Scripts/count-operations.py` still reports 4287 in both files.

## Verification

- **Full suite:** 4797 tests, 1343 suites, passing.
- **New suite** `Issue506ArcLengthBridgeContractTests` (`OCCTCurveTests`) pins the surviving behaviour on the four ranges where the two adaptor forms diverge. The clamping assertions compare against a chord-sum reference, not against the implementation's own whole-domain answer.
- **Proved against two injections rather than assumed.** Restoring the pre-#408 wiring (the three functions back, the three accessors rewired to them) fails the cross-spelling test on all three divergent ranges, reporting exactly the probe's figures: `0.0` against `173.76`, `8489.78` against `360.99`, `1.34` against `0.0`. It also fails #408's own parity suite (`arcLen -> nan`). Rewiring `length(from:to:)` itself onto the pre-bounded form, which is the accidental-rewire case the issue describes, fails all four new tests.

## Noticed, not fixed

Filed rather than folded in, since both are #408/#409 contract questions rather than duplication:

- **`length(from:to:)`'s NaN handling is curve-type dependent** (#548). A NaN bound reports `nil` on a line, a segment and a circle, but on a BSpline `GCPnts_AbscissaPoint::Length` returns a plausible number: `0` for a NaN upper bound, the whole length for a NaN lower bound. #408's distinguishability test passes because it uses a segment.
- **`Curve2D.arcLength(from:to:)` and `Curve3D.arcLength(from:to:)` disagree on a reversed range** (#549). The 2D spelling still measures through the 2D pre-bounded adaptor deliberately and documents itself as range-checked (verified: it does raise in this build, so the doc is accurate); the 3D spelling measures the span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
