### PR TITLE
fix(#508): the twelve bridge symbols that never said "OCCT"

### DIFF
--- a/Scripts/check-bridge-index.py
+++ b/Scripts/check-bridge-index.py
@@ -36,7 +36,13 @@ def index_entries(lines):
         m = ENTRY.match(line)
         if not m:
             continue
-        cls, syms = m.group(1), re.sub(r'\(v[\d.]+\)', '', m.group(2))
+        # Strip any parenthetical annotation, not just `(vX.Y.Z)`: a prose aside
+        # such as `OCCTFoo* (historical name)` otherwise leaves the symbol glued
+        # to the prose, failing the fullmatch below and silently skipping the
+        # entry. That is how #508's fabricated `OCCTGCE2dMakeLine*` survived the
+        # #510 sweep. The `)` is optional because an aside may wrap to the next
+        # line, which this line-at-a-time scan never sees.
+        cls, syms = m.group(1), re.sub(r'\([^)]*\)?', '', m.group(2))
         for sym in re.split(r'[,/]', syms):
             sym = sym.strip()
             if re.fullmatch(r'OCCT\w+\*?', sym):

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -244,7 +244,11 @@
 // GC_MakeTranslation                  → OCCTGCMakeTranslation
 //
 // --- GC 2D ---
-// GC_MakeLine2d                       → OCCTGCE2dMakeLine* (bridge symbols retain GCE2d historical name)
+// GC_MakeCircle2d                     → OCCTCurve2DMakeCircle*
+// GC_MakeEllipse2d                    → OCCTCurve2DMakeEllipse*
+// GC_MakeHyperbola2d                  → OCCTCurve2DMakeHyperbola*
+// GC_MakeLine2d                       → OCCTCurve2DMakeLine*
+// GC_MakeParabola2d                   → OCCTCurve2DMakeParabola*
 //
 // --- GCPnts ---
 // GCPnts_AbscissaPoint                → OCCTCurve3DArcLength*, OCCTCurve3DLength, OCCTCurve3DGetLength*, OCCTCurve3DParameterAtLength, OCCTCurve2DLength, OCCTCurve2DGetLength*, OCCTCurve2DParameterAtLength, OCCTEdgeArcLength*, OCCTEdgeParameterAt*, OCCTWireGetLength
@@ -6807,7 +6811,7 @@ typedef struct {
 OCCTSurfaceContinuitySplitResult OCCTSurfaceSplitByContinuity(OCCTSurfaceRef surface,
     int32_t criterion, double tolerance);
 
-// MARK: - v0.51.0: BRepLib makers, GC geometry, GCE2d, ChFi2d_AnaFilletAlgo
+// MARK: - v0.51.0: BRepLib makers, GC geometry, GC 2D, ChFi2d_AnaFilletAlgo
 
 // --- BRepLib_MakePolygon ---
 
@@ -14461,67 +14465,67 @@ OCCTCurve3DRef _Nullable OCCTGCMakeHyperbola3Points(double x1, double y1, double
 // MARK: - GC_MakeCircle2d (v0.105.0)
 
 /// Create a 2D circle from center and radius.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeCircleCenterRadius(double cx, double cy, double radius);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius);
 
 /// Create a 2D circle through 3 points.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeCircle3Points(double x1, double y1,
-                                                     double x2, double y2,
-                                                     double x3, double y3);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircle3Points(double x1, double y1,
+                                                      double x2, double y2,
+                                                      double x3, double y3);
 
 /// Create a 2D circle from center and point on circle.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeCircleCenterPoint(double cx, double cy, double px, double py);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py);
 
 /// Create a 2D circle parallel to existing circle at distance.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeCircleParallel(double cx, double cy,
-                                                      double dx, double dy,
-                                                      double radius, double dist);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleParallel(double cx, double cy,
+                                                       double dx, double dy,
+                                                       double radius, double dist);
 
 /// Create a 2D circle from axis and radius.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeCircleAxis(double cx, double cy,
-                                                  double dx, double dy,
-                                                  double radius);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleAxis(double cx, double cy,
+                                                   double dx, double dy,
+                                                   double radius);
 
 // MARK: - GC_MakeEllipse2d (v0.105.0)
 
 /// Create a 2D ellipse from axis and radii.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeEllipse(double cx, double cy,
-                                               double dx, double dy,
-                                               double major, double minor);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipse(double cx, double cy,
+                                                double dx, double dy,
+                                                double major, double minor);
 
 /// Create a 2D ellipse from 3 points (S1, S2, center).
-OCCTCurve2DRef _Nullable OCTGCE2dMakeEllipse3Points(double x1, double y1,
-                                                      double x2, double y2,
-                                                      double x3, double y3);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipse3Points(double x1, double y1,
+                                                       double x2, double y2,
+                                                       double x3, double y3);
 
 /// Create a 2D ellipse from full Ax22d and radii.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeEllipseAxis22d(double cx, double cy,
-                                                      double xdx, double xdy,
-                                                      double ydx, double ydy,
-                                                      double major, double minor);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipseAxis22d(double cx, double cy,
+                                                       double xdx, double xdy,
+                                                       double ydx, double ydy,
+                                                       double major, double minor);
 
 // MARK: - GC_MakeHyperbola2d (v0.105.0)
 
 /// Create a 2D hyperbola from axis and radii.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeHyperbola(double cx, double cy,
-                                                 double dx, double dy,
-                                                 double major, double minor);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeHyperbola(double cx, double cy,
+                                                  double dx, double dy,
+                                                  double major, double minor);
 
 /// Create a 2D hyperbola from 3 points (S1, S2, center).
-OCCTCurve2DRef _Nullable OCTGCE2dMakeHyperbola3Points(double x1, double y1,
-                                                        double x2, double y2,
-                                                        double x3, double y3);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeHyperbola3Points(double x1, double y1,
+                                                         double x2, double y2,
+                                                         double x3, double y3);
 
 // MARK: - GC_MakeParabola2d (v0.105.0)
 
 /// Create a 2D parabola from axis and focal distance.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeParabola(double cx, double cy,
-                                                double dx, double dy,
-                                                double focal);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeParabola(double cx, double cy,
+                                                 double dx, double dy,
+                                                 double focal);
 
 /// Create a 2D parabola from directrix and focus.
-OCCTCurve2DRef _Nullable OCTGCE2dMakeParabolaDirectrixFocus(double dx, double dy,
-                                                              double ddx, double ddy,
-                                                              double fx, double fy);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeParabolaDirectrixFocus(double dx, double dy,
+                                                               double ddx, double ddy,
+                                                               double fx, double fy);
 
 // MARK: - GCPnts_UniformAbscissa (v0.105.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -3092,7 +3092,7 @@ OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
 #include <gp_Ax22d.hxx>
 #include <gp_Circ2d.hxx>
 
-OCCTCurve2DRef OCTGCE2dMakeCircleCenterRadius(double cx, double cy, double radius) {
+OCCTCurve2DRef OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius) {
     try {
         GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), radius);
         if (!mc.IsDone()) return nullptr;
@@ -3102,9 +3102,9 @@ OCCTCurve2DRef OCTGCE2dMakeCircleCenterRadius(double cx, double cy, double radiu
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeCircle3Points(double x1, double y1,
-                                           double x2, double y2,
-                                           double x3, double y3) {
+OCCTCurve2DRef OCCTCurve2DMakeCircle3Points(double x1, double y1,
+                                            double x2, double y2,
+                                            double x3, double y3) {
     try {
         GC_MakeCircle2d mc(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
         if (!mc.IsDone()) return nullptr;
@@ -3114,7 +3114,7 @@ OCCTCurve2DRef OCTGCE2dMakeCircle3Points(double x1, double y1,
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeCircleCenterPoint(double cx, double cy, double px, double py) {
+OCCTCurve2DRef OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py) {
     try {
         GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), gp_Pnt2d(px, py));
         if (!mc.IsDone()) return nullptr;
@@ -3124,9 +3124,9 @@ OCCTCurve2DRef OCTGCE2dMakeCircleCenterPoint(double cx, double cy, double px, do
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeCircleParallel(double cx, double cy,
-                                            double dx, double dy,
-                                            double radius, double dist) {
+OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx, double cy,
+                                             double dx, double dy,
+                                             double radius, double dist) {
     try {
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
         GC_MakeCircle2d mc(circ, dist);
@@ -3137,9 +3137,9 @@ OCCTCurve2DRef OCTGCE2dMakeCircleParallel(double cx, double cy,
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeCircleAxis(double cx, double cy,
-                                        double dx, double dy,
-                                        double radius) {
+OCCTCurve2DRef OCCTCurve2DMakeCircleAxis(double cx, double cy,
+                                         double dx, double dy,
+                                         double radius) {
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         GC_MakeCircle2d mc(ax, radius);
@@ -3152,9 +3152,9 @@ OCCTCurve2DRef OCTGCE2dMakeCircleAxis(double cx, double cy,
 
 // MARK: - GC_MakeEllipse2d (v0.105.0)
 
-OCCTCurve2DRef OCTGCE2dMakeEllipse(double cx, double cy,
-                                     double dx, double dy,
-                                     double major, double minor) {
+OCCTCurve2DRef OCCTCurve2DMakeEllipse(double cx, double cy,
+                                      double dx, double dy,
+                                      double major, double minor) {
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         GC_MakeEllipse2d me(ax, major, minor);
@@ -3165,9 +3165,9 @@ OCCTCurve2DRef OCTGCE2dMakeEllipse(double cx, double cy,
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeEllipse3Points(double x1, double y1,
-                                            double x2, double y2,
-                                            double x3, double y3) {
+OCCTCurve2DRef OCCTCurve2DMakeEllipse3Points(double x1, double y1,
+                                             double x2, double y2,
+                                             double x3, double y3) {
     try {
         GC_MakeEllipse2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
         if (!me.IsDone()) return nullptr;
@@ -3177,10 +3177,10 @@ OCCTCurve2DRef OCTGCE2dMakeEllipse3Points(double x1, double y1,
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeEllipseAxis22d(double cx, double cy,
-                                            double xdx, double xdy,
-                                            double ydx, double ydy,
-                                            double major, double minor) {
+OCCTCurve2DRef OCCTCurve2DMakeEllipseAxis22d(double cx, double cy,
+                                             double xdx, double xdy,
+                                             double ydx, double ydy,
+                                             double major, double minor) {
     try {
         gp_Ax22d ax(gp_Pnt2d(cx, cy), gp_Dir2d(xdx, xdy), gp_Dir2d(ydx, ydy));
         GC_MakeEllipse2d me(ax, major, minor);
@@ -3193,9 +3193,9 @@ OCCTCurve2DRef OCTGCE2dMakeEllipseAxis22d(double cx, double cy,
 
 // MARK: - GC_MakeHyperbola2d (v0.105.0)
 
-OCCTCurve2DRef OCTGCE2dMakeHyperbola(double cx, double cy,
-                                       double dx, double dy,
-                                       double major, double minor) {
+OCCTCurve2DRef OCCTCurve2DMakeHyperbola(double cx, double cy,
+                                        double dx, double dy,
+                                        double major, double minor) {
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         GC_MakeHyperbola2d mh(ax, major, minor);
@@ -3206,9 +3206,9 @@ OCCTCurve2DRef OCTGCE2dMakeHyperbola(double cx, double cy,
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeHyperbola3Points(double x1, double y1,
-                                              double x2, double y2,
-                                              double x3, double y3) {
+OCCTCurve2DRef OCCTCurve2DMakeHyperbola3Points(double x1, double y1,
+                                               double x2, double y2,
+                                               double x3, double y3) {
     try {
         GC_MakeHyperbola2d mh(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
         if (!mh.IsDone()) return nullptr;
@@ -3220,9 +3220,9 @@ OCCTCurve2DRef OCTGCE2dMakeHyperbola3Points(double x1, double y1,
 
 // MARK: - GC_MakeParabola2d (v0.105.0)
 
-OCCTCurve2DRef OCTGCE2dMakeParabola(double cx, double cy,
-                                      double dx, double dy,
-                                      double focal) {
+OCCTCurve2DRef OCCTCurve2DMakeParabola(double cx, double cy,
+                                       double dx, double dy,
+                                       double focal) {
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         GC_MakeParabola2d mp(ax, focal, true);
@@ -3233,9 +3233,9 @@ OCCTCurve2DRef OCTGCE2dMakeParabola(double cx, double cy,
     } catch (...) { return nullptr; }
 }
 
-OCCTCurve2DRef OCTGCE2dMakeParabolaDirectrixFocus(double dx, double dy,
-                                                    double ddx, double ddy,
-                                                    double fx, double fy) {
+OCCTCurve2DRef OCCTCurve2DMakeParabolaDirectrixFocus(double dx, double dy,
+                                                     double ddx, double ddy,
+                                                     double fx, double fy) {
     try {
         gp_Ax2d directrix(gp_Pnt2d(dx, dy), gp_Dir2d(ddx, ddy));
         GC_MakeParabola2d mp(directrix, gp_Pnt2d(fx, fy));

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -7811,37 +7811,37 @@ extension Curve3D {
 extension Curve2D {
     /// Create a 2D circle from center and radius.
     public static func gceCircle(center: SIMD2<Double>, radius: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeCircleCenterRadius(center.x, center.y, radius) else { return nil }
+        guard let ref = OCCTCurve2DMakeCircleCenterRadius(center.x, center.y, radius) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D circle through 3 points.
     public static func gceCircle(p1: SIMD2<Double>, p2: SIMD2<Double>, p3: SIMD2<Double>) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeCircle3Points(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y) else { return nil }
+        guard let ref = OCCTCurve2DMakeCircle3Points(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D circle from center and point on circle.
     public static func gceCircle(center: SIMD2<Double>, pointOn: SIMD2<Double>) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeCircleCenterPoint(center.x, center.y, pointOn.x, pointOn.y) else { return nil }
+        guard let ref = OCCTCurve2DMakeCircleCenterPoint(center.x, center.y, pointOn.x, pointOn.y) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D circle parallel to existing circle at distance.
     public static func gceCircleParallel(center: SIMD2<Double>, direction: SIMD2<Double>,
                                           radius: Double, distance: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeCircleParallel(center.x, center.y,
-                                                     direction.x, direction.y,
-                                                     radius, distance) else { return nil }
+        guard let ref = OCCTCurve2DMakeCircleParallel(center.x, center.y,
+                                                      direction.x, direction.y,
+                                                      radius, distance) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D circle from axis and radius.
     public static func gceCircle(axisCenter: SIMD2<Double>, axisDirection: SIMD2<Double>,
                                   radius: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeCircleAxis(axisCenter.x, axisCenter.y,
-                                                 axisDirection.x, axisDirection.y,
-                                                 radius) else { return nil }
+        guard let ref = OCCTCurve2DMakeCircleAxis(axisCenter.x, axisCenter.y,
+                                                  axisDirection.x, axisDirection.y,
+                                                  radius) else { return nil }
         return Curve2D(handle: ref)
     }
 }
@@ -7852,15 +7852,15 @@ extension Curve2D {
     /// Create a 2D ellipse from axis and radii.
     public static func gceEllipse(center: SIMD2<Double>, xDirection: SIMD2<Double>,
                                    majorRadius: Double, minorRadius: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeEllipse(center.x, center.y,
-                                              xDirection.x, xDirection.y,
-                                              majorRadius, minorRadius) else { return nil }
+        guard let ref = OCCTCurve2DMakeEllipse(center.x, center.y,
+                                               xDirection.x, xDirection.y,
+                                               majorRadius, minorRadius) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D ellipse from 3 points (S1, S2, center).
     public static func gceEllipse(s1: SIMD2<Double>, s2: SIMD2<Double>, center: SIMD2<Double>) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeEllipse3Points(s1.x, s1.y, s2.x, s2.y,
+        guard let ref = OCCTCurve2DMakeEllipse3Points(s1.x, s1.y, s2.x, s2.y,
                                                       center.x, center.y) else { return nil }
         return Curve2D(handle: ref)
     }
@@ -7869,7 +7869,7 @@ extension Curve2D {
     public static func gceEllipse(center: SIMD2<Double>, xDirection: SIMD2<Double>,
                                    yDirection: SIMD2<Double>,
                                    majorRadius: Double, minorRadius: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeEllipseAxis22d(center.x, center.y,
+        guard let ref = OCCTCurve2DMakeEllipseAxis22d(center.x, center.y,
                                                       xDirection.x, xDirection.y,
                                                       yDirection.x, yDirection.y,
                                                       majorRadius, minorRadius) else { return nil }
@@ -7883,15 +7883,15 @@ extension Curve2D {
     /// Create a 2D hyperbola from axis and radii.
     public static func gceHyperbola(center: SIMD2<Double>, xDirection: SIMD2<Double>,
                                      majorRadius: Double, minorRadius: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeHyperbola(center.x, center.y,
-                                                xDirection.x, xDirection.y,
-                                                majorRadius, minorRadius) else { return nil }
+        guard let ref = OCCTCurve2DMakeHyperbola(center.x, center.y,
+                                                 xDirection.x, xDirection.y,
+                                                 majorRadius, minorRadius) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D hyperbola from 3 points (S1, S2, center).
     public static func gceHyperbola(s1: SIMD2<Double>, s2: SIMD2<Double>, center: SIMD2<Double>) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeHyperbola3Points(s1.x, s1.y, s2.x, s2.y,
+        guard let ref = OCCTCurve2DMakeHyperbola3Points(s1.x, s1.y, s2.x, s2.y,
                                                         center.x, center.y) else { return nil }
         return Curve2D(handle: ref)
     }
@@ -7903,17 +7903,17 @@ extension Curve2D {
     /// Create a 2D parabola from axis and focal distance.
     public static func gceParabola(center: SIMD2<Double>, direction: SIMD2<Double>,
                                     focalDistance: Double) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeParabola(center.x, center.y,
-                                               direction.x, direction.y, focalDistance) else { return nil }
+        guard let ref = OCCTCurve2DMakeParabola(center.x, center.y,
+                                                direction.x, direction.y, focalDistance) else { return nil }
         return Curve2D(handle: ref)
     }
 
     /// Create a 2D parabola from directrix and focus.
     public static func gceParabola(directrixPoint: SIMD2<Double>, directrixDirection: SIMD2<Double>,
                                     focus: SIMD2<Double>) -> Curve2D? {
-        guard let ref = OCTGCE2dMakeParabolaDirectrixFocus(directrixPoint.x, directrixPoint.y,
-                                                             directrixDirection.x, directrixDirection.y,
-                                                             focus.x, focus.y) else { return nil }
+        guard let ref = OCCTCurve2DMakeParabolaDirectrixFocus(directrixPoint.x, directrixPoint.y,
+                                                              directrixDirection.x, directrixDirection.y,
+                                                              focus.x, focus.y) else { return nil }
         return Curve2D(handle: ref)
     }
 }

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -2872,8 +2872,8 @@ struct TransformFactory2DTests {
     }
 }
 
-@Suite("GCE2d Conic Tests")
-struct GCE2dConicTests {
+@Suite("GC_Make*2d Conic Tests")
+struct GCMake2dConicTests {
 
     @Test func circle2dCenterRadius() {
         let c = Curve2D.gceCircle(center: SIMD2(0, 0), radius: 5)
@@ -2907,12 +2907,47 @@ struct GCE2dConicTests {
         }
     }
 
+    /// `GC_MakeCircle2d(gp_Circ2d, theDist)`: a positive signed distance yields a
+    /// concentric circle that *encloses* the source, so r grows by exactly theDist.
+    @Test func circle2dParallel() {
+        let c = Curve2D.gceCircleParallel(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                          radius: 5, distance: 2)
+        #expect(c != nil)
+        if let c = c {
+            #expect(abs(c.circleProperties.radius - 7) < 1e-9)
+            #expect(abs(c.circleProperties.center.x) < 1e-9)
+            #expect(abs(c.circleProperties.center.y) < 1e-9)
+        }
+    }
+
+    /// A negative distance shrinks instead: the result is enclosed by the source.
+    @Test func circle2dParallelInward() {
+        let c = Curve2D.gceCircleParallel(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                          radius: 5, distance: -2)
+        #expect(c != nil)
+        if let c = c {
+            #expect(abs(c.circleProperties.radius - 3) < 1e-9)
+        }
+    }
+
     @Test func ellipse2dFromAxis() {
         let e = Curve2D.gceEllipse(center: SIMD2(0, 0), xDirection: SIMD2(1, 0),
                                     majorRadius: 10, minorRadius: 5)
         #expect(e != nil)
         if let e = e {
             #expect(e.isClosed)
+        }
+    }
+
+    /// `GC_MakeEllipse2d(S1, S2, Center)`: S1 is the apex on the major axis, so the
+    /// major radius is |S1 - Center|; S2 fixes the minor radius off that axis.
+    @Test func ellipse2dFrom3Points() {
+        let e = Curve2D.gceEllipse(s1: SIMD2(10, 0), s2: SIMD2(0, 5), center: SIMD2(0, 0))
+        #expect(e != nil)
+        if let e = e {
+            #expect(e.isClosed)
+            #expect(abs(e.ellipseProperties.majorRadius - 10) < 1e-9)
+            #expect(abs(e.ellipseProperties.minorRadius - 5) < 1e-9)
         }
     }
 
@@ -2930,6 +2965,17 @@ struct GCE2dConicTests {
         let h = Curve2D.gceHyperbola(center: SIMD2(0, 0), xDirection: SIMD2(1, 0),
                                       majorRadius: 10, minorRadius: 5)
         #expect(h != nil)
+    }
+
+    /// `GC_MakeHyperbola2d(S1, S2, Center)`: S1 is the main-branch vertex on the
+    /// major axis; S2 is the conjugate-branch vertex giving the minor radius.
+    @Test func hyperbola2dFrom3Points() {
+        let h = Curve2D.gceHyperbola(s1: SIMD2(10, 0), s2: SIMD2(0, 5), center: SIMD2(0, 0))
+        #expect(h != nil)
+        if let h = h {
+            #expect(abs(h.hyperbolaProperties.majorRadius - 10) < 1e-9)
+            #expect(abs(h.hyperbolaProperties.minorRadius - 5) < 1e-9)
+        }
     }
 
     @Test func parabola2dFromAxis() {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -353,10 +353,10 @@ a map of the major areas, and the `Total` as the count.
 | **GC_MakeCircle** | 4 | circle from axis+radius, 3 points, center+normal, parallel |
 | **GC_MakeEllipse** | 3 | ellipse from axis+radii, 3 points, full Ax2 |
 | **GC_MakeHyperbola** | 2 | hyperbola from axis+radii, 3 points |
-| **GCE2d_MakeCircle** | 5 | 2D circle: center+radius, 3 points, center+point, parallel, axis |
-| **GCE2d_MakeEllipse** | 3 | 2D ellipse: axis+radii, 3 points, Ax22d |
-| **GCE2d_MakeHyperbola** | 2 | 2D hyperbola: axis+radii, 3 points |
-| **GCE2d_MakeParabola** | 2 | 2D parabola: axis+focal, directrix+focus |
+| **GC_MakeCircle2d** | 5 | 2D circle: center+radius, 3 points, center+point, parallel, axis |
+| **GC_MakeEllipse2d** | 3 | 2D ellipse: axis+radii, 3 points, Ax22d |
+| **GC_MakeHyperbola2d** | 2 | 2D hyperbola: axis+radii, 3 points |
+| **GC_MakeParabola2d** | 2 | 2D parabola: axis+focal, directrix+focus |
 | **GCPnts_UniformAbscissa** | 4 | uniform arc-length points by count/distance, full/subrange |
 | **GeomConvert_CompCurveToBSpline** | 1 | concatenate bounded 3D curves into BSpline |
 | **Geom2dConvert_CompCurveToBSpline** | 1 | concatenate bounded 2D curves into BSpline |
@@ -568,9 +568,9 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 #### 2D Parametric Curves
 | Swift API | OCCT Class |
 |-----------|------------|
-| `Curve2D.segment(from:to:)` | `GCE2d_MakeSegment` |
+| `Curve2D.segment(from:to:)` | `GC_MakeSegment2d` |
 | `Curve2D.circle(center:radius:)` | `Geom2d_Circle` |
-| `Curve2D.ellipse(...)` | `GCE2d_MakeEllipse` |
+| `Curve2D.ellipse(...)` | `Geom2d_Ellipse` |
 | `Curve2D.bspline(...)` | `Geom2d_BSplineCurve` |
 | `Curve2D.interpolate(through:)` | `Geom2dAPI_Interpolate` |
 | `curve.curvature(at:)` | `Geom2dLProp_CLProps2d` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,6 +105,45 @@ catches it.
 
 No behaviour changed.
 
+#### The 12 bridge symbols that never said "OCCT", and the index entry for a symbol that never existed (#508)
+
+Of ~1161 bridge function declarations, twelve began `OCT` rather than `OCCT` — the whole
+`GC_MakeCircle2d`/`Ellipse2d`/`Hyperbola2d`/`Parabola2d` family, consistently misspelled across the
+header, the `.mm`, and the Swift call site since v0.105.0. Nothing was broken; the mismatch was
+internally consistent end to end, which is exactly why it survived.
+
+The obvious fix was to insert the missing `C`. Instead the family is now `OCCTCurve2DMake*`,
+matching `OCCTCurve2DMakeLineThroughPoints`/`OCCTCurve2DMakeLineParallel` — the `GC_MakeLine2d`
+wrappers declared two lines away, the direct sibling of these four classes. The old name was a
+second inaccuracy layered on the first: `GCE2d` is a *different* OCCT package, and v0.156.0 already
+moved these implementations off it when OCCT 8.0.0 deprecated `GCE2d_X` into a `using` alias for
+`GC_X2d`. That release deliberately kept the C names for ABI reasons that no longer apply, so a
+grep for the package these functions were named after led away from the code, not to it.
+
+The header's cross-reference index carried a matching but distinct error: its one `GC 2D` entry
+read `GC_MakeLine2d → OCCTGCE2dMakeLine* (bridge symbols retain GCE2d historical name)`. That
+prefix has zero occurrences anywhere in the repo — it named neither the conic family nor the line
+functions it claimed to describe. All five `GC_Make*2d` families are now indexed under their real
+symbols.
+
+`Scripts/check-bridge-index.py`, written for #484/#510 to catch precisely this, could not see the
+entry: it stripped only a `(vX.Y.Z)` suffix, so the trailing prose aside left the symbol glued to
+the annotation and the entry was silently skipped rather than reported stale. It now strips any
+parenthetical, which also un-hides two further entries that were being skipped for the same reason
+(both resolve). The stale count is unchanged at 135 — the #510 backlog, untouched here.
+
+Documentation for this family named a *fourth* variant, `gce_MakeCirc2d`/`gce_MakeElips2d`/
+`gce_MakeHypr2d` — a real OCCT package, but not the one these twelve call. Corrected to the actual
+`GC_Make*2d` classes, along with two rows elsewhere in `API_REFERENCE.md` left stale by the same
+v0.156.0 migration (`Curve2D.segment` is `GC_MakeSegment2d`; `Curve2D.ellipse` constructs
+`Geom2d_Ellipse` directly and never went through `GCE2d_MakeEllipse`).
+
+Four tests close the coverage hole the audit found alongside the naming drift:
+`gceCircleParallel`, `gceEllipse(s1:s2:center:)` and `gceHyperbola(s1:s2:center:)` had no test at
+all. They assert measured geometry rather than non-nil, and were verified to fail against injected
+defects — a flipped parallel-offset sign, and swapped `S1`/`S2` apex points. No public Swift API
+changed; `OCCTBridge` is not an SPM product, so the C-layer rename reaches no consumer.
+
 #### One pipe shell, and the sweep mode it was quietly discarding (#503)
 
 Four bridge functions each built their own single-profile `BRepOffsetAPI_MakePipeShell`, and each

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -2188,7 +2188,7 @@ public static func gcHyperbola(s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIM
 
 ## GC_MakeCircle2d
 
-`Curve2D` factory methods backed by `gce_MakeCirc2d`.
+`Curve2D` factory methods backed by `GC_MakeCircle2d`.
 
 ### `Curve2D.gceCircle(center:radius:)`
 
@@ -2198,7 +2198,7 @@ Create a 2D circle from center and radius.
 public static func gceCircle(center: SIMD2<Double>, radius: Double) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeCirc2d` via `OCTGCE2dMakeCircleCenterRadius`.
+- **OCCT:** `GC_MakeCircle2d` via `OCCTCurve2DMakeCircleCenterRadius`.
 
 ---
 
@@ -2210,7 +2210,7 @@ Create a 2D circle through 3 points.
 public static func gceCircle(p1: SIMD2<Double>, p2: SIMD2<Double>, p3: SIMD2<Double>) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeCirc2d` (3 points) via `OCTGCE2dMakeCircle3Points`.
+- **OCCT:** `GC_MakeCircle2d` (3 points) via `OCCTCurve2DMakeCircle3Points`.
 
 ---
 
@@ -2222,7 +2222,7 @@ Create a 2D circle from center and a point on the circle.
 public static func gceCircle(center: SIMD2<Double>, pointOn: SIMD2<Double>) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeCirc2d` (center + point) via `OCTGCE2dMakeCircleCenterPoint`.
+- **OCCT:** `GC_MakeCircle2d` (center + point) via `OCCTCurve2DMakeCircleCenterPoint`.
 
 ---
 
@@ -2235,7 +2235,7 @@ public static func gceCircleParallel(center: SIMD2<Double>, direction: SIMD2<Dou
                                       radius: Double, distance: Double) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeCirc2d` (parallel) via `OCTGCE2dMakeCircleParallel`.
+- **OCCT:** `GC_MakeCircle2d` (parallel) via `OCCTCurve2DMakeCircleParallel`.
 
 ---
 
@@ -2248,7 +2248,7 @@ public static func gceCircle(axisCenter: SIMD2<Double>, axisDirection: SIMD2<Dou
                               radius: Double) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeCirc2d` (axis) via `OCTGCE2dMakeCircleAxis`.
+- **OCCT:** `GC_MakeCircle2d` (axis) via `OCCTCurve2DMakeCircleAxis`.
 - **Example:**
   ```swift
   if let c = Curve2D.gceCircle(center: SIMD2(0, 0), radius: 5) {
@@ -2260,7 +2260,7 @@ public static func gceCircle(axisCenter: SIMD2<Double>, axisDirection: SIMD2<Dou
 
 ## GC_MakeEllipse2d
 
-`Curve2D` factory methods backed by `gce_MakeElips2d`.
+`Curve2D` factory methods backed by `GC_MakeEllipse2d`.
 
 ### `Curve2D.gceEllipse(center:xDirection:majorRadius:minorRadius:)`
 
@@ -2271,7 +2271,7 @@ public static func gceEllipse(center: SIMD2<Double>, xDirection: SIMD2<Double>,
                                majorRadius: Double, minorRadius: Double) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeElips2d` via `OCTGCE2dMakeEllipse`.
+- **OCCT:** `GC_MakeEllipse2d` via `OCCTCurve2DMakeEllipse`.
 
 ---
 
@@ -2283,7 +2283,7 @@ Create a 2D ellipse from 3 points (S1, S2, center).
 public static func gceEllipse(s1: SIMD2<Double>, s2: SIMD2<Double>, center: SIMD2<Double>) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeElips2d` (3 points) via `OCTGCE2dMakeEllipse3Points`.
+- **OCCT:** `GC_MakeEllipse2d` (3 points) via `OCCTCurve2DMakeEllipse3Points`.
 
 ---
 
@@ -2298,13 +2298,13 @@ public static func gceEllipse(center: SIMD2<Double>, xDirection: SIMD2<Double>,
 ```
 
 - **Parameters:** `yDirection` — explicit Y-axis direction for the ellipse frame.
-- **OCCT:** `gce_MakeElips2d` (Ax22d) via `OCTGCE2dMakeEllipseAxis22d`.
+- **OCCT:** `GC_MakeEllipse2d` (Ax22d) via `OCCTCurve2DMakeEllipseAxis22d`.
 
 ---
 
 ## GC_MakeHyperbola2d
 
-`Curve2D` factory methods backed by `gce_MakeHypr2d`.
+`Curve2D` factory methods backed by `GC_MakeHyperbola2d`.
 
 ### `Curve2D.gceHyperbola(center:xDirection:majorRadius:minorRadius:)`
 
@@ -2315,7 +2315,7 @@ public static func gceHyperbola(center: SIMD2<Double>, xDirection: SIMD2<Double>
                                  majorRadius: Double, minorRadius: Double) -> Curve2D?
 ```
 
-- **OCCT:** `gce_MakeHypr2d` via `OCTGCE2dMakeHyperbola`.
+- **OCCT:** `GC_MakeHyperbola2d` via `OCCTCurve2DMakeHyperbola`.
 
 ---
 
@@ -2328,7 +2328,7 @@ public static func gceHyperbola(s1: SIMD2<Double>, s2: SIMD2<Double>, center: SI
 ```
 
 - **Parameters:** `s1`, `s2` — points on the hyperbola; `center` — hyperbola center.
-- **OCCT:** `gce_MakeHypr2d` (3 points) via `OCTGCE2dMakeHyperbola3Points`.
+- **OCCT:** `GC_MakeHyperbola2d` (3 points) via `OCCTCurve2DMakeHyperbola3Points`.
 - **Example:**
   ```swift
   if let h = Curve2D.gceHyperbola(center: .zero,

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -15,7 +15,7 @@ This page covers geometry construction and analysis utilities added across v0.10
 
 ## GC_MakeParabola2d
 
-Two-dimensional parabola constructors extending `Curve2D` via `GCE2d_MakeParabola`.
+Two-dimensional parabola constructors extending `Curve2D` via `GC_MakeParabola2d`.
 
 ### `Curve2D.gceParabola(center:direction:focalDistance:)`
 
@@ -28,7 +28,7 @@ public static func gceParabola(center: SIMD2<Double>, direction: SIMD2<Double>,
 
 - **Parameters:** `center` — origin of the parabola axis; `direction` — X-direction of the axis; `focalDistance` — distance from vertex to focus.
 - **Returns:** A `Curve2D` wrapping a `Geom2d_Parabola`, or `nil` if construction fails.
-- **OCCT:** `GCE2d_MakeParabola`
+- **OCCT:** `GC_MakeParabola2d`
 - **Example:**
   ```swift
   if let p = Curve2D.gceParabola(center: .zero, direction: SIMD2(1, 0), focalDistance: 2.0) {
@@ -49,7 +49,7 @@ public static func gceParabola(directrixPoint: SIMD2<Double>, directrixDirection
 
 - **Parameters:** `directrixPoint` — a point on the directrix; `directrixDirection` — direction of the directrix; `focus` — the focus point.
 - **Returns:** A `Curve2D` wrapping a `Geom2d_Parabola`, or `nil` on failure.
-- **OCCT:** `GCE2d_MakeParabola` (directrix-focus constructor)
+- **OCCT:** `GC_MakeParabola2d` (directrix-focus constructor)
 - **Example:**
   ```swift
   if let p = Curve2D.gceParabola(directrixPoint: SIMD2(-2, 0),


### PR DESCRIPTION
Part of the #381 Pass 1b duplication audit. Targets `refactor/381-pass1b`, not `main`.

## What was wrong

Two independent drifts, plus a third found while fixing them.

**1. Twelve `OCT`-prefixed symbols.** The `GC_MakeCircle2d`/`Ellipse2d`/`Hyperbola2d`/`Parabola2d` family began `OCT`, not `OCCT` — 12 of ~1161 bridge declarations, misspelled *consistently* across the header, the `.mm` and the Swift call site since v0.105.0. Nothing was broken; the mismatch was internally consistent end to end, which is exactly why it survived.

**2. An index entry for a symbol that never existed.** The header's cross-reference index had one `GC 2D` entry:

```
// GC_MakeLine2d  → OCCTGCE2dMakeLine* (bridge symbols retain GCE2d historical name)
```

`OCCTGCE2dMakeLine` has zero occurrences anywhere in the repo. It named neither the conic family nor the `GC_MakeLine2d` wrappers it claimed to describe (those are `OCCTCurve2DMakeLine*`).

**3. The checker built to catch this couldn't see it.** `Scripts/check-bridge-index.py` — written for #484/#510 for precisely this failure mode — stripped only a `(vX.Y.Z)` suffix before matching. The trailing prose aside left the symbol glued to the annotation, failed the `fullmatch`, and the entry was **silently skipped** rather than reported stale. That is how the fabricated prefix survived the #510 sweep.

## Why `OCCTCurve2DMake*` and not just adding the `C`

Inserting the missing `C` would have made the symbols `OCCTGCE2dMake*` — fixing the prefix while preserving a second inaccuracy. `GCE2d` is a *different* OCCT package, and `9821be1` (v0.156.0) already moved these implementations off it when OCCT 8.0.0 deprecated `GCE2d_X` into a `using` alias for `GC_X2d`. That release's message states the C names were kept deliberately, for ABI reasons that no longer apply. So a grep for the package these functions were named after led *away* from the code.

`OCCTCurve2DMake*` matches `OCCTCurve2DMakeLineThroughPoints`/`OCCTCurve2DMakeLineParallel` — the `GC_MakeLine2d` wrappers declared two lines away, the direct sibling of these four classes. One naming pattern for one OCCT family group, matching CLAUDE.md's `OCCT<Domain>...` rule and the `Curve2D` return type. No collisions.

The index now carries all five families under their real symbols:

```
// GC_MakeCircle2d     → OCCTCurve2DMakeCircle*
// GC_MakeEllipse2d    → OCCTCurve2DMakeEllipse*
// GC_MakeHyperbola2d  → OCCTCurve2DMakeHyperbola*
// GC_MakeLine2d       → OCCTCurve2DMakeLine*
// GC_MakeParabola2d   → OCCTCurve2DMakeParabola*
```

## Docs named a *fourth* variant

The reference pages attributed this family to `gce_MakeCirc2d`/`gce_MakeElips2d`/`gce_MakeHypr2d` — a real OCCT package, but not the one these twelve call. Corrected to the actual `GC_Make*2d` classes, along with two `API_REFERENCE.md` rows left stale by the same v0.156.0 migration (`Curve2D.segment` is `GC_MakeSegment2d`; `Curve2D.ellipse` constructs `Geom2d_Ellipse` directly and never went through `GCE2d_MakeEllipse`).

## Tests

The issue flagged 3 of the 12 call sites as having no coverage at all. Four tests added (`gceCircleParallel` gets both offset directions). They assert measured geometry rather than non-nil, with semantics read out of the pinned OCCT headers rather than assumed — `theDist > 0` encloses the source circle; `S1` is the apex on the major axis, `S2` fixes the conjugate radius.

Verified they actually catch a mis-wire by injecting defects into the bridge and re-running:

| Injected defect | Result |
|---|---|
| `GC_MakeCircle2d(circ, -dist)` | `circle2dParallel` r=3 not 7; `circle2dParallelInward` r=7 not 3 |
| `GC_MakeEllipse2d` S1↔S2 | `ellipse2dFrom3Points` nil (`gce_InvertRadius`) |
| `GC_MakeHyperbola2d` S1↔S2 | `hyperbola2dFrom3Points` major/minor swapped |

Reverted; suite green again.

The suite itself was `@Suite("GCE2d Conic Tests")` / `struct GCE2dConicTests`, named for the retired convention — now `GC_Make*2d Conic Tests` / `GCMake2dConicTests`. Nothing referenced the struct name outside its own file.

## Verification

- `swift build` clean.
- Full `swift test`: **4797 tests, 1342 suites, all pass.**
- `check-bridge-index.py`: the 5 new `GC 2D` entries all resolve. Stale count unchanged at **135** — un-hiding two previously-skipped entries added nothing, both resolve. The #510 backlog is untouched here.
- No public Swift API change. `OCCTBridge` is not an SPM product, so the C-layer rename reaches no consumer.

## Noted, not fixed

Six `docs/reference/Curve2D*.md` attributions to `GCE2d_MakeArcOf*`/`GCE2d_MakeSegment` are stale the same way (those bridge functions use `GC_MakeArcOf*2d`/`GC_MakeSegment2d`). Different family, outside this issue's twelve — worth its own pass over the v0.156.0 migration's doc fallout.

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)