### PR TITLE
fix(#514): the nine 2D conic sites that took a dimension and never checked it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,295 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,298 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -13399,6 +13399,7 @@ void OCCTEnvironmentFreeString(const char* _Nullable str);
 // MARK: - Convert_EllipseToBSplineCurve (v0.95.0)
 
 /// Convert a 2D ellipse arc to a BSpline curve.
+/// Requires 0 < minorRadius <= majorRadius (#514); returns NULL otherwise.
 OCCTCurve2DRef _Nullable OCCTConvertEllipseToBSpline2D(double cx, double cy,
                                                          double majorRadius, double minorRadius,
                                                          double u1, double u2);
@@ -13406,6 +13407,7 @@ OCCTCurve2DRef _Nullable OCCTConvertEllipseToBSpline2D(double cx, double cy,
 // MARK: - Convert_HyperbolaToBSplineCurve (v0.95.0)
 
 /// Convert a 2D hyperbola arc to a BSpline curve.
+/// Requires both radii > 0, in either order (#514); returns NULL otherwise.
 OCCTCurve2DRef _Nullable OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
                                                            double majorRadius, double minorRadius,
                                                            double u1, double u2);
@@ -13413,6 +13415,7 @@ OCCTCurve2DRef _Nullable OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
 // MARK: - Convert_ParabolaToBSplineCurve (v0.95.0)
 
 /// Convert a 2D parabola arc to a BSpline curve.
+/// Requires focal > 0 (#514): at focal 0 the conversion succeeds with NaN poles.
 OCCTCurve2DRef _Nullable OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal,
                                                           double u1, double u2);
 
@@ -14908,15 +14911,18 @@ OCCTSurfaceRef _Nullable OCCTGCMakeTrimmedCylinder3Pts(double x1, double y1, dou
 
 // MARK: - BRepLib_MakeEdge2d extensions (v0.106.0)
 
-/// Create a 2D edge from a full circle.
+/// Create a 2D edge from a full circle. Requires radius > 0 (#514).
 OCCTShapeRef _Nullable OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy,
                                                   double radius);
 
-/// Create a 2D edge from an ellipse.
+/// Create a 2D edge from an ellipse. Requires 0 < minor <= major (#514):
+/// BRepLib_MakeEdge2d reports IsDone() for a degenerate ellipse and builds a zero-length or
+/// doubled-back edge from it.
 OCCTShapeRef _Nullable OCCTMakeEdge2dEllipse(double cx, double cy, double dx, double dy,
                                                double major, double minor);
 
 /// Create a 2D edge from an ellipse arc with parameter range.
+/// Requires 0 < minor <= major (#514).
 OCCTShapeRef _Nullable OCCTMakeEdge2dEllipseArc(double cx, double cy, double dx, double dy,
                                                   double major, double minor, double u1, double u2);
 
@@ -15971,20 +15977,27 @@ bool OCCTTrigRootsInfinite(double A, double B, double C, double D, double E,
 
 // MARK: - IntAna2d_Conic (v0.109.0)
 
-/// Get 6 conic coefficients from a 2D circle: A*x^2 + B*x*y + C*y^2 + D*x + E*y + F = 0.
-void OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
+/// Get 6 conic coefficients from a 2D circle: A*x^2 + B*y^2 + 2C*x*y + 2D*x + 2E*y + F = 0.
+/// Requires radius > 0 (#514). The coefficients are zeroed and false returned otherwise.
+/// @return true when the coefficients were computed.
+bool OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
                             double* _Nonnull coeffs);
 
-/// Get 6 conic coefficients from a 2D line.
-void OCCTConic2dFromLine(double px, double py, double dx, double dy,
+/// Get 6 conic coefficients from a 2D line, in the same order as OCCTConic2dFromCircle.
+/// @return true when the coefficients were computed (false for a zero direction).
+bool OCCTConic2dFromLine(double px, double py, double dx, double dy,
                           double* _Nonnull coeffs);
 
-/// Get 6 conic coefficients from a 2D ellipse.
-void OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
+/// Get 6 conic coefficients from a 2D ellipse, in the same order as OCCTConic2dFromCircle.
+/// Requires 0 < minorRadius <= majorRadius (#514): all-zero coefficients are the equation
+/// 0 = 0, which holds everywhere, so a degenerate ellipse cannot be reported through them.
+/// @return true when the coefficients were computed.
+bool OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
                              double majorRadius, double minorRadius,
                              double* _Nonnull coeffs);
 
 /// Intersect a 2D line with a 2D circle conic. Returns intersection points.
+/// Requires radius > 0 (#514).
 /// @return Number of intersection points (-1 on error)
 int32_t OCCTConic2dLineCircleIntersect(double lpx, double lpy, double ldx, double ldy,
                                         double cx, double cy, double cdx, double cdy, double radius,

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -3025,6 +3025,7 @@ static OCCTCurve2DRef buildCurve2DFromConic(const Convert_ConicToBSplineCurve& c
 OCCTCurve2DRef OCCTConvertEllipseToBSpline2D(double cx, double cy,
                                                double majorRadius, double minorRadius,
                                                double u1, double u2) {
+    if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
     try {
         gp_Elips2d e(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), majorRadius, minorRadius);
         Convert_EllipseToBSplineCurve conv(e, u1, u2);
@@ -3035,6 +3036,7 @@ OCCTCurve2DRef OCCTConvertEllipseToBSpline2D(double cx, double cy,
 OCCTCurve2DRef OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
                                                  double majorRadius, double minorRadius,
                                                  double u1, double u2) {
+    if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
     try {
         gp_Hypr2d h(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), majorRadius, minorRadius);
         Convert_HyperbolaToBSplineCurve conv(h, u1, u2);
@@ -3044,6 +3046,9 @@ OCCTCurve2DRef OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
 
 OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal,
                                                 double u1, double u2) {
+    // Measured (#514): focal 0 does not fail here, it produces a 3-pole degree-2 BSpline whose
+    // poles are NaN, so everything downstream of it evaluates to NaN.
+    if (!occtValidParabolaFocal(focal)) return nullptr;
     try {
         gp_Parab2d p(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), focal);
         Convert_ParabolaToBSplineCurve conv(p, u1, u2);
@@ -3058,6 +3063,7 @@ OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal
 
 OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
                                               double u1, double u2) {
+    if (!occtValidCircleRadius(radius)) return nullptr;
     try {
         gp_Circ2d circle(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
         Convert_CircleToBSplineCurve conv(circle, u1, u2);
@@ -3310,8 +3316,13 @@ void OCCTBSplineCurve2dKnotSplitValues(OCCTCurve2DRef curve, int32_t continuity,
 #include <BRepLib_MakeEdge2d.hxx>
 #include <gp_Elips2d.hxx>
 
+// BRepLib_MakeEdge2d reports IsDone() for a degenerate conic rather than refusing it: measured
+// (#514), a zero-radius ellipse yields a zero-length edge with both vertices at the centre, and a
+// zero minor radius yields a segment doubled back along the major axis. Neither is an edge the
+// caller asked for, so the dimensions are checked before OCCT sees them.
 OCCTShapeRef OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy,
                                        double radius) {
+    if (!occtValidCircleRadius(radius)) return nullptr;
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         gp_Circ2d circ(ax, radius);
@@ -3325,6 +3336,7 @@ OCCTShapeRef OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy
 
 OCCTShapeRef OCCTMakeEdge2dEllipse(double cx, double cy, double dx, double dy,
                                     double major, double minor) {
+    if (!occtValidEllipseRadii(major, minor)) return nullptr;
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         gp_Elips2d elips(ax, major, minor);
@@ -3338,6 +3350,7 @@ OCCTShapeRef OCCTMakeEdge2dEllipse(double cx, double cy, double dx, double dy,
 
 OCCTShapeRef OCCTMakeEdge2dEllipseArc(double cx, double cy, double dx, double dy,
                                        double major, double minor, double u1, double u2) {
+    if (!occtValidEllipseRadii(major, minor)) return nullptr;
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         gp_Elips2d elips(ax, major, minor);
@@ -3838,52 +3851,63 @@ OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve) {
 #include <gp_Circ2d.hxx>
 #include <gp_Elips2d.hxx>
 
-void OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
+// The three OCCTConic2dFrom* entry points share one failure encoding: the six coefficients are
+// zeroed and false returned. Zeroing alone could not carry it: 0 = 0 holds at every point of the
+// plane, so an all-zero result reads as a conic rather than as no answer, and a degenerate ellipse
+// produced exactly that (#514).
+static bool occtConic2dCoefficients(const IntAna2d_Conic& conic, double* coeffs) {
+    double A, B, C, D, E, F;
+    conic.Coefficients(A, B, C, D, E, F);
+    coeffs[0] = A; coeffs[1] = B; coeffs[2] = C;
+    coeffs[3] = D; coeffs[4] = E; coeffs[5] = F;
+    return true;
+}
+
+static bool occtConic2dFailed(double* coeffs) {
+    for (int i = 0; i < 6; i++) coeffs[i] = 0;
+    return false;
+}
+
+bool OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
                             double* coeffs) {
+    if (!occtValidCircleRadius(radius)) return occtConic2dFailed(coeffs);
     try {
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        IntAna2d_Conic conic(circ);
-        double A, B, C, D, E, F;
-        conic.Coefficients(A, B, C, D, E, F);
-        coeffs[0] = A; coeffs[1] = B; coeffs[2] = C;
-        coeffs[3] = D; coeffs[4] = E; coeffs[5] = F;
+        return occtConic2dCoefficients(IntAna2d_Conic(circ), coeffs);
     } catch (...) {
-        for (int i = 0; i < 6; i++) coeffs[i] = 0;
+        return occtConic2dFailed(coeffs);
     }
 }
 
-void OCCTConic2dFromLine(double px, double py, double dx, double dy,
+bool OCCTConic2dFromLine(double px, double py, double dx, double dy,
                           double* coeffs) {
     try {
         gp_Lin2d line(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
-        IntAna2d_Conic conic(line);
-        double A, B, C, D, E, F;
-        conic.Coefficients(A, B, C, D, E, F);
-        coeffs[0] = A; coeffs[1] = B; coeffs[2] = C;
-        coeffs[3] = D; coeffs[4] = E; coeffs[5] = F;
+        return occtConic2dCoefficients(IntAna2d_Conic(line), coeffs);
     } catch (...) {
-        for (int i = 0; i < 6; i++) coeffs[i] = 0;
+        return occtConic2dFailed(coeffs);
     }
 }
 
-void OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
+bool OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
                              double majorRadius, double minorRadius,
                              double* coeffs) {
+    if (!occtValidEllipseRadii(majorRadius, minorRadius)) return occtConic2dFailed(coeffs);
     try {
         gp_Elips2d elips(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), majorRadius, minorRadius);
-        IntAna2d_Conic conic(elips);
-        double A, B, C, D, E, F;
-        conic.Coefficients(A, B, C, D, E, F);
-        coeffs[0] = A; coeffs[1] = B; coeffs[2] = C;
-        coeffs[3] = D; coeffs[4] = E; coeffs[5] = F;
+        return occtConic2dCoefficients(IntAna2d_Conic(elips), coeffs);
     } catch (...) {
-        for (int i = 0; i < 6; i++) coeffs[i] = 0;
+        return occtConic2dFailed(coeffs);
     }
 }
 
 int32_t OCCTConic2dLineCircleIntersect(double lpx, double lpy, double ldx, double ldy,
                                         double cx, double cy, double cdx, double cdy, double radius,
                                         double* xs, double* ys, int32_t max) {
+    // Same circle contract as OCCTConic2dFromCircle above: intersecting against a radius-0 circle
+    // is a point-on-line test, not an intersection, and asking it here would be the one place in
+    // this block that still accepted a degenerate circle.
+    if (!occtValidCircleRadius(radius)) return -1;
     try {
         gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(cdx, cdy)), radius);

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -5756,6 +5756,15 @@ public enum MathJacobi {
 extension Curve2D {
 
     /// Convert a 2D circle arc to a BSpline curve.
+    ///
+    /// - Parameter radius: circle radius. Must be greater than zero.
+    /// - Returns: the converted curve, or `nil` if the circle is degenerate.
+    ///
+    /// ```swift
+    /// if let c = Curve2D.fromCircleArc(centerX: 0, centerY: 0, radius: 5, u1: 0, u2: .pi) {
+    ///     print(c.degree)
+    /// }
+    /// ```
     public static func fromCircleArc(centerX: Double, centerY: Double, radius: Double,
                                       u1: Double, u2: Double) -> Curve2D? {
         guard let ref = OCCTConvertCircleToBSpline2D(centerX, centerY, radius, u1, u2) else { return nil }
@@ -5804,6 +5813,20 @@ public enum Environment {
 extension Curve2D {
 
     /// Convert a 2D ellipse arc to a BSpline curve.
+    ///
+    /// - Parameters:
+    ///   - majorRadius: semi-major axis. Must be greater than zero.
+    ///   - minorRadius: semi-minor axis. Must be greater than zero and no larger than
+    ///     `majorRadius`; equal radii are a circle and are valid.
+    /// - Returns: the converted curve, or `nil` if the ellipse is degenerate.
+    ///
+    /// ```swift
+    /// if let c = Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+    ///                                   majorRadius: 20, minorRadius: 10,
+    ///                                   u1: 0, u2: .pi) {
+    ///     print(c.degree)
+    /// }
+    /// ```
     public static func fromEllipseArc(centerX: Double, centerY: Double,
                                        majorRadius: Double, minorRadius: Double,
                                        u1: Double, u2: Double) -> Curve2D? {
@@ -5812,6 +5835,20 @@ extension Curve2D {
     }
 
     /// Convert a 2D hyperbola arc to a BSpline curve.
+    ///
+    /// - Parameters:
+    ///   - majorRadius: major radius. Must be greater than zero.
+    ///   - minorRadius: minor radius. Must be greater than zero. A hyperbola puts no ordering on
+    ///     its radii, so a minor radius larger than the major is an ordinary hyperbola.
+    /// - Returns: the converted curve, or `nil` if the hyperbola is degenerate.
+    ///
+    /// ```swift
+    /// if let c = Curve2D.fromHyperbolaArc(centerX: 0, centerY: 0,
+    ///                                     majorRadius: 10, minorRadius: 5,
+    ///                                     u1: -1, u2: 1) {
+    ///     print(c.degree)
+    /// }
+    /// ```
     public static func fromHyperbolaArc(centerX: Double, centerY: Double,
                                          majorRadius: Double, minorRadius: Double,
                                          u1: Double, u2: Double) -> Curve2D? {
@@ -5820,6 +5857,16 @@ extension Curve2D {
     }
 
     /// Convert a 2D parabola arc to a BSpline curve.
+    ///
+    /// - Parameter focal: focal length. Must be greater than zero: OCCT converts a focal length of
+    ///   zero without complaint, into a curve whose poles are all NaN.
+    /// - Returns: the converted curve, or `nil` if the parabola is degenerate.
+    ///
+    /// ```swift
+    /// if let c = Curve2D.fromParabolaArc(centerX: 0, centerY: 0, focal: 5, u1: -2, u2: 2) {
+    ///     print(c.degree)
+    /// }
+    /// ```
     public static func fromParabolaArc(centerX: Double, centerY: Double, focal: Double,
                                         u1: Double, u2: Double) -> Curve2D? {
         guard let ref = OCCTConvertParabolaToBSpline2D(centerX, centerY, focal, u1, u2) else { return nil }
@@ -8640,6 +8687,15 @@ extension Surface {
 
 extension Shape {
     /// Create a 2D edge from a full circle.
+    ///
+    /// - Parameter radius: circle radius. Must be greater than zero.
+    /// - Returns: the edge, or `nil` if the circle is degenerate.
+    ///
+    /// ```swift
+    /// if let e = Shape.edge2dFullCircle(center: .zero, direction: SIMD2(1, 0), radius: 5) {
+    ///     print(e.edges().count)   // 1
+    /// }
+    /// ```
     public static func edge2dFullCircle(center: SIMD2<Double>, direction: SIMD2<Double>,
                                          radius: Double) -> Shape? {
         guard let h = OCCTMakeEdge2dFullCircle(center.x, center.y,
@@ -8649,6 +8705,20 @@ extension Shape {
     }
 
     /// Create a 2D edge from an ellipse.
+    ///
+    /// - Parameters:
+    ///   - majorRadius: semi-major axis. Must be greater than zero.
+    ///   - minorRadius: semi-minor axis. Must be greater than zero and no larger than
+    ///     `majorRadius`; equal radii are a circle and are valid.
+    /// - Returns: the edge, or `nil` if the ellipse is degenerate. OCCT builds a zero-length edge
+    ///   from a zero-radius ellipse, and a doubled-back segment from a zero minor radius.
+    ///
+    /// ```swift
+    /// if let e = Shape.edge2dEllipse(center: .zero, direction: SIMD2(1, 0),
+    ///                                majorRadius: 5, minorRadius: 3) {
+    ///     print(e.edges().count)   // 1
+    /// }
+    /// ```
     public static func edge2dEllipse(center: SIMD2<Double>, direction: SIMD2<Double>,
                                       majorRadius: Double, minorRadius: Double) -> Shape? {
         guard let h = OCCTMakeEdge2dEllipse(center.x, center.y,
@@ -8658,6 +8728,19 @@ extension Shape {
     }
 
     /// Create a 2D edge from an ellipse arc.
+    ///
+    /// - Parameters:
+    ///   - majorRadius: semi-major axis. Must be greater than zero.
+    ///   - minorRadius: semi-minor axis. Must be greater than zero and no larger than
+    ///     `majorRadius`; equal radii are a circle and are valid.
+    /// - Returns: the edge, or `nil` if the ellipse is degenerate.
+    ///
+    /// ```swift
+    /// if let e = Shape.edge2dEllipseArc(center: .zero, direction: SIMD2(1, 0),
+    ///                                   majorRadius: 5, minorRadius: 3, u1: 0, u2: .pi) {
+    ///     print(e.edges().count)   // 1
+    /// }
+    /// ```
     public static func edge2dEllipseArc(center: SIMD2<Double>, direction: SIMD2<Double>,
                                          majorRadius: Double, minorRadius: Double,
                                          u1: Double, u2: Double) -> Shape? {
@@ -10258,43 +10341,144 @@ public enum TrigRoots {
 // MARK: - IntAna2d_Conic (v0.109.0)
 
 /// 2D conic section coefficient representation.
+///
+/// The coefficients are OCCT's, in OCCT's order: the conic is the point set satisfying
+/// `a·x² + b·y² + 2c·x·y + 2d·x + 2e·y + f = 0`. Note that `b` is the `y²` coefficient and `c`
+/// the `x·y` one, and that the cross and linear terms carry a factor of 2.
+///
+/// ```swift
+/// // The circle of radius 5 about the origin: x² + y² - 25 = 0
+/// if let c = Conic2D.circle(center: .zero, direction: SIMD2(1, 0), radius: 5) {
+///     print(c.a, c.b, c.c, c.f)   // 1.0 1.0 0.0 -25.0
+/// }
+/// ```
 public struct Conic2D: Sendable {
-    /// Coefficients A, B, C, D, E, F of A*x^2 + B*x*y + C*y^2 + D*x + E*y + F = 0.
+    /// Coefficients a, b, c, d, e, f of `a*x^2 + b*y^2 + 2c*x*y + 2d*x + 2e*y + f = 0`.
     public let a, b, c, d, e, f: Double
 
+    /// The implicit conic of a 2D circle, or `nil` if the circle is degenerate.
+    ///
+    /// - Parameters:
+    ///   - center: circle centre.
+    ///   - direction: local X axis direction. Must be non-zero.
+    ///   - radius: circle radius. Must be greater than zero.
+    /// - Returns: the six implicit coefficients, or `nil` when a dimension is degenerate.
+    ///
+    /// ```swift
+    /// if let c = Conic2D.circle(center: .zero, direction: SIMD2(1, 0), radius: 3) {
+    ///     print(c.a, c.b, c.f)   // 1.0 1.0 -9.0
+    /// }
+    /// ```
+    public static func circle(
+        center: SIMD2<Double>, direction: SIMD2<Double>, radius: Double
+    ) -> Conic2D? {
+        var coeffs = [Double](repeating: 0, count: 6)
+        guard OCCTConic2dFromCircle(center.x, center.y, direction.x, direction.y,
+                                     radius, &coeffs) else { return nil }
+        return Conic2D(a: coeffs[0], b: coeffs[1], c: coeffs[2],
+                        d: coeffs[3], e: coeffs[4], f: coeffs[5])
+    }
+
+    /// The implicit conic of a 2D line, or `nil` if the direction is degenerate.
+    ///
+    /// - Parameters:
+    ///   - point: any point on the line.
+    ///   - direction: line direction. Must be non-zero.
+    /// - Returns: the six implicit coefficients, or `nil` for a zero direction.
+    ///
+    /// ```swift
+    /// if let l = Conic2D.line(point: .zero, direction: SIMD2(1, 0)) {
+    ///     print(l.e)   // non-zero: the y term of the line y = 0
+    /// }
+    /// ```
+    public static func line(
+        point: SIMD2<Double>, direction: SIMD2<Double>
+    ) -> Conic2D? {
+        var coeffs = [Double](repeating: 0, count: 6)
+        guard OCCTConic2dFromLine(point.x, point.y, direction.x, direction.y,
+                                   &coeffs) else { return nil }
+        return Conic2D(a: coeffs[0], b: coeffs[1], c: coeffs[2],
+                        d: coeffs[3], e: coeffs[4], f: coeffs[5])
+    }
+
+    /// The implicit conic of a 2D ellipse, or `nil` if the ellipse is degenerate.
+    ///
+    /// - Parameters:
+    ///   - center: ellipse centre.
+    ///   - direction: local X axis, along the major radius. Must be non-zero.
+    ///   - majorRadius: semi-major axis. Must be greater than zero.
+    ///   - minorRadius: semi-minor axis. Must be greater than zero and no larger than
+    ///     `majorRadius`; equal radii are a circle and are valid.
+    /// - Returns: the six implicit coefficients, or `nil` when a dimension is degenerate.
+    ///
+    /// ```swift
+    /// if let e = Conic2D.ellipse(center: .zero, direction: SIMD2(1, 0),
+    ///                            majorRadius: 5, minorRadius: 3) {
+    ///     print(e.a, e.b, e.f)   // 0.04 0.111... -1.0  (x²/25 + y²/9 - 1 = 0)
+    /// }
+    /// ```
+    public static func ellipse(
+        center: SIMD2<Double>, direction: SIMD2<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Conic2D? {
+        var coeffs = [Double](repeating: 0, count: 6)
+        guard OCCTConic2dFromEllipse(center.x, center.y, direction.x, direction.y,
+                                      majorRadius, minorRadius, &coeffs) else { return nil }
+        return Conic2D(a: coeffs[0], b: coeffs[1], c: coeffs[2],
+                        d: coeffs[3], e: coeffs[4], f: coeffs[5])
+    }
+
     /// Create from a 2D circle.
+    ///
+    /// Returns an all-zero `Conic2D` when the circle is degenerate, which no real conic ever is.
+    /// Use ``circle(center:direction:radius:)``, which returns `nil` instead.
+    @available(*, deprecated, renamed: "circle(center:direction:radius:)")
     public static func fromCircle(
         center: SIMD2<Double>, direction: SIMD2<Double>, radius: Double
     ) -> Conic2D {
-        var coeffs = [Double](repeating: 0, count: 6)
-        OCCTConic2dFromCircle(center.x, center.y, direction.x, direction.y, radius, &coeffs)
-        return Conic2D(a: coeffs[0], b: coeffs[1], c: coeffs[2],
-                        d: coeffs[3], e: coeffs[4], f: coeffs[5])
+        circle(center: center, direction: direction, radius: radius) ?? .degenerate
     }
 
     /// Create from a 2D line.
+    ///
+    /// Returns an all-zero `Conic2D` when the direction is degenerate, which no real conic ever
+    /// is. Use ``line(point:direction:)``, which returns `nil` instead.
+    @available(*, deprecated, renamed: "line(point:direction:)")
     public static func fromLine(
         point: SIMD2<Double>, direction: SIMD2<Double>
     ) -> Conic2D {
-        var coeffs = [Double](repeating: 0, count: 6)
-        OCCTConic2dFromLine(point.x, point.y, direction.x, direction.y, &coeffs)
-        return Conic2D(a: coeffs[0], b: coeffs[1], c: coeffs[2],
-                        d: coeffs[3], e: coeffs[4], f: coeffs[5])
+        line(point: point, direction: direction) ?? .degenerate
     }
 
     /// Create from a 2D ellipse.
+    ///
+    /// Returns an all-zero `Conic2D` when the ellipse is degenerate, which no real conic ever is.
+    /// Use ``ellipse(center:direction:majorRadius:minorRadius:)``, which returns `nil` instead.
+    @available(*, deprecated, renamed: "ellipse(center:direction:majorRadius:minorRadius:)")
     public static func fromEllipse(
         center: SIMD2<Double>, direction: SIMD2<Double>,
         majorRadius: Double, minorRadius: Double
     ) -> Conic2D {
-        var coeffs = [Double](repeating: 0, count: 6)
-        OCCTConic2dFromEllipse(center.x, center.y, direction.x, direction.y,
-                                majorRadius, minorRadius, &coeffs)
-        return Conic2D(a: coeffs[0], b: coeffs[1], c: coeffs[2],
-                        d: coeffs[3], e: coeffs[4], f: coeffs[5])
+        ellipse(center: center, direction: direction,
+                majorRadius: majorRadius, minorRadius: minorRadius) ?? .degenerate
     }
 
-    /// Intersect a 2D line with a 2D circle. Returns intersection points.
+    /// The all-zero coefficients the deprecated `from*` spellings return on failure. The equation
+    /// `0 = 0` holds at every point of the plane, so this describes no conic at all.
+    private static let degenerate = Conic2D(a: 0, b: 0, c: 0, d: 0, e: 0, f: 0)
+
+    /// Intersect a 2D line with a 2D circle.
+    ///
+    /// - Parameter radius: circle radius. Must be greater than zero; a radius of zero is a
+    ///   point-on-line test, not an intersection, and returns an empty array.
+    /// - Returns: 0, 1, or 2 intersection points.
+    ///
+    /// ```swift
+    /// let pts = Conic2D.lineCircleIntersection(
+    ///     linePoint: SIMD2(-5, 0), lineDir: SIMD2(1, 0),
+    ///     circleCenter: .zero, circleDir: SIMD2(1, 0), radius: 3)
+    /// // pts.count == 2 → [-3, 0] and [3, 0]
+    /// ```
     public static func lineCircleIntersection(
         linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
         circleCenter: SIMD2<Double>, circleDir: SIMD2<Double>, radius: Double

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -4679,25 +4679,33 @@ struct ExtremaExtPElSTorusTests {
 @Suite("IntAna2d_Conic")
 struct Conic2DTests {
     @Test func fromCircle() {
-        let c = Conic2D.fromCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0), radius: 5)
-        // Circle: x^2 + y^2 - 25 = 0 => A=1(x^2), B=1(y^2), C=0(xy), D=0(x), E=0(y), F=-25
-        #expect(abs(c.a - 1) < 1e-6)
-        #expect(abs(c.b - 1) < 1e-6)
-        #expect(abs(c.f + 25) < 1e-6)
+        let c = Conic2D.circle(center: SIMD2(0, 0), direction: SIMD2(1, 0), radius: 5)
+        // Circle: x^2 + y^2 - 25 = 0 => a=1(x^2), b=1(y^2), c=0(xy), d=0(x), e=0(y), f=-25
+        if let c {
+            #expect(abs(c.a - 1) < 1e-6)
+            #expect(abs(c.b - 1) < 1e-6)
+            #expect(abs(c.f + 25) < 1e-6)
+        } else {
+            Issue.record("circle conic should build")
+        }
     }
 
     @Test func fromLine() {
-        let c = Conic2D.fromLine(point: SIMD2(0, 0), direction: SIMD2(1, 0))
-        // y = 0 line: 0*x + 0*xy + 0*y^2 + 0*x + 1*y + 0 = 0 (varies by normalization)
-        // Just check it doesn't crash and produces non-zero coefficients
-        let hasNonZero = abs(c.a) + abs(c.b) + abs(c.c) + abs(c.d) + abs(c.e) + abs(c.f)
-        #expect(hasNonZero > 0)
+        let c = Conic2D.line(point: SIMD2(0, 0), direction: SIMD2(1, 0))
+        // y = 0 line: the linear terms carry it; the exact normalization is OCCT's.
+        if let c {
+            let hasNonZero = abs(c.a) + abs(c.b) + abs(c.c) + abs(c.d) + abs(c.e) + abs(c.f)
+            #expect(hasNonZero > 0)
+        } else {
+            Issue.record("line conic should build")
+        }
     }
 
     @Test func fromEllipse() {
-        let c = Conic2D.fromEllipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
-                                      majorRadius: 5, minorRadius: 3)
-        #expect(c.a > 0 || c.c > 0) // some non-zero coefficient
+        let c = Conic2D.ellipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                majorRadius: 5, minorRadius: 3)
+        #expect(c != nil)
+        if let c { #expect(c.a > 0 || c.b > 0) }
     }
 
     @Test func lineCircleIntersection() {

--- a/Tests/OCCTGeom2dTests/Issue514Conic2dDegenerateTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue514Conic2dDegenerateTests.swift
@@ -1,0 +1,173 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #514: the nine 2D conic construction sites that build a conic from caller-supplied
+/// dimensions. Before this pass every one of them accepted a zero dimension and returned
+/// something that reads as geometry and behaves as a point, a segment, or NaN.
+///
+/// The negative and ordering cases are covered too, because the issue's premise was that these
+/// sites had "no precondition at all". They do: `gp_Elips2d`/`gp_Hypr2d`/`gp_Parab2d`'s own
+/// `Standard_ConstructionError_Raise_if` is `constexpr` in the header, so unlike a call made from
+/// inside OCCT (where `No_Exception` deletes it) it does run in a bridge translation unit. What it
+/// never covered is zero, which is the whole of the real gap.
+@Suite("Issue514 2D conic degenerate dimensions")
+struct Issue514Conic2dDegenerateTests {
+
+    // MARK: - Convert_*ToBSplineCurve (Curve2D.from*Arc)
+
+    @Test func ellipseArcRejectsZeroRadii() {
+        #expect(Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+                                       majorRadius: 0, minorRadius: 0, u1: 0, u2: .pi) == nil)
+        // Zero minor alone collapses the ellipse onto its own major axis: measured, the
+        // conversion succeeded and produced a degree-2 BSpline running 5,0 -> 0,0 -> -5,0.
+        #expect(Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+                                       majorRadius: 5, minorRadius: 0, u1: 0, u2: .pi) == nil)
+    }
+
+    @Test func ellipseArcRejectsNegativeAndInvertedRadii() {
+        #expect(Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+                                       majorRadius: 5, minorRadius: -3, u1: 0, u2: .pi) == nil)
+        #expect(Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+                                       majorRadius: 3, minorRadius: 5, u1: 0, u2: .pi) == nil)
+    }
+
+    @Test func ellipseArcAcceptsValidRadii() {
+        #expect(Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+                                       majorRadius: 5, minorRadius: 3, u1: 0, u2: .pi) != nil)
+        // Equal radii are a circle, which gp_Elips2d documents as valid.
+        #expect(Curve2D.fromEllipseArc(centerX: 0, centerY: 0,
+                                       majorRadius: 4, minorRadius: 4, u1: 0, u2: .pi) != nil)
+    }
+
+    @Test func hyperbolaArcRejectsZeroRadii() {
+        #expect(Curve2D.fromHyperbolaArc(centerX: 0, centerY: 0,
+                                         majorRadius: 0, minorRadius: 0, u1: 0, u2: 1) == nil)
+        #expect(Curve2D.fromHyperbolaArc(centerX: 0, centerY: 0,
+                                         majorRadius: 5, minorRadius: 0, u1: 0, u2: 1) == nil)
+        #expect(Curve2D.fromHyperbolaArc(centerX: 0, centerY: 0,
+                                         majorRadius: 0, minorRadius: 3, u1: 0, u2: 1) == nil)
+    }
+
+    @Test func hyperbolaArcAcceptsMinorLargerThanMajor() {
+        // A hyperbola puts no ordering on its radii: minor > major is an ordinary hyperbola.
+        // Copying the ellipse rule here would reject it.
+        #expect(Curve2D.fromHyperbolaArc(centerX: 0, centerY: 0,
+                                         majorRadius: 3, minorRadius: 5, u1: 0, u2: 1) != nil)
+    }
+
+    @Test func parabolaArcRejectsZeroFocal() {
+        // Worst of the nine: measured, focal 0 produced a 3-pole degree-2 BSpline whose poles
+        // are NaN, so every downstream evaluation of it is NaN too.
+        #expect(Curve2D.fromParabolaArc(centerX: 0, centerY: 0, focal: 0, u1: 0, u2: 1) == nil)
+    }
+
+    @Test func parabolaArcAcceptsPositiveFocal() {
+        #expect(Curve2D.fromParabolaArc(centerX: 0, centerY: 0, focal: 2, u1: 0, u2: 1) != nil)
+    }
+
+    @Test func circleArcRejectsZeroRadius() {
+        #expect(Curve2D.fromCircleArc(centerX: 0, centerY: 0, radius: 0, u1: 0, u2: .pi) == nil)
+        #expect(Curve2D.fromCircleArc(centerX: 0, centerY: 0, radius: 3, u1: 0, u2: .pi) != nil)
+    }
+
+    // MARK: - BRepLib_MakeEdge2d (Shape.edge2d*)
+
+    @Test func edge2dEllipseRejectsZeroRadii() {
+        // BRepLib_MakeEdge2d reports IsDone() for both of these. Measured: the first builds a
+        // zero-length edge with both vertices at the centre, the second a doubled-back segment.
+        #expect(Shape.edge2dEllipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                    majorRadius: 0, minorRadius: 0) == nil)
+        #expect(Shape.edge2dEllipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                    majorRadius: 5, minorRadius: 0) == nil)
+    }
+
+    @Test func edge2dEllipseArcRejectsZeroRadii() {
+        #expect(Shape.edge2dEllipseArc(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       majorRadius: 0, minorRadius: 0, u1: 0, u2: .pi) == nil)
+        #expect(Shape.edge2dEllipseArc(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       majorRadius: 5, minorRadius: 0, u1: 0, u2: .pi) == nil)
+    }
+
+    @Test func edge2dFullCircleRejectsZeroRadius() {
+        #expect(Shape.edge2dFullCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       radius: 0) == nil)
+    }
+
+    @Test func edge2dConstructorsAcceptValidDimensions() {
+        #expect(Shape.edge2dEllipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                    majorRadius: 5, minorRadius: 3) != nil)
+        #expect(Shape.edge2dEllipseArc(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       majorRadius: 5, minorRadius: 3, u1: 0, u2: .pi) != nil)
+        #expect(Shape.edge2dFullCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       radius: 5) != nil)
+    }
+
+    // MARK: - IntAna2d_Conic (Conic2D)
+
+    @Test func conicEllipseRejectsZeroRadii() {
+        // All six coefficients came back 0, which is the equation 0 = 0: satisfied by every
+        // point in the plane, and indistinguishable from the value the catch block writes.
+        #expect(Conic2D.ellipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                majorRadius: 0, minorRadius: 0) == nil)
+        #expect(Conic2D.ellipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                majorRadius: 5, minorRadius: 0) == nil)
+    }
+
+    @Test func conicCircleRejectsZeroRadius() {
+        #expect(Conic2D.circle(center: SIMD2(0, 0), direction: SIMD2(1, 0), radius: 0) == nil)
+    }
+
+    @Test func conicRejectsZeroDirection() {
+        // gp_Dir2d(0, 0) throws; before the nil channel existed this returned the same all-zero
+        // struct as a degenerate ellipse did.
+        #expect(Conic2D.circle(center: SIMD2(0, 0), direction: SIMD2(0, 0), radius: 5) == nil)
+        #expect(Conic2D.line(point: SIMD2(0, 0), direction: SIMD2(0, 0)) == nil)
+        #expect(Conic2D.ellipse(center: SIMD2(0, 0), direction: SIMD2(0, 0),
+                                majorRadius: 5, minorRadius: 3) == nil)
+    }
+
+    /// The coefficient order is OCCT's: `A·x² + B·y² + 2C·xy + 2D·x + 2E·y + F = 0`. The Swift
+    /// doc comment used to name a different equation (`A·x² + B·xy + C·y² + …`), which puts the
+    /// xy term in `b` and the y² term in `c`, so a caller reading it built the wrong conic.
+    @Test func conicCoefficientOrderIsOCCTs() {
+        guard let c = Conic2D.circle(center: SIMD2(0, 0), direction: SIMD2(1, 0), radius: 5) else {
+            Issue.record("circle conic should build")
+            return
+        }
+        // x² + y² - 25 = 0
+        #expect(abs(c.a - 1) < 1e-9)
+        #expect(abs(c.b - 1) < 1e-9)   // y², not xy
+        #expect(abs(c.c) < 1e-9)       // xy, not y²
+        #expect(abs(c.f + 25) < 1e-9)
+
+        guard let e = Conic2D.ellipse(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                      majorRadius: 5, minorRadius: 3) else {
+            Issue.record("ellipse conic should build")
+            return
+        }
+        // x²/25 + y²/9 - 1 = 0
+        #expect(abs(e.a - 1.0 / 25.0) < 1e-9)
+        #expect(abs(e.b - 1.0 / 9.0) < 1e-9)
+        #expect(abs(e.c) < 1e-9)
+        #expect(abs(e.f + 1) < 1e-9)
+    }
+
+    @Test func conicLineIsUnchangedForValidInput() {
+        guard let l = Conic2D.line(point: SIMD2(0, 0), direction: SIMD2(1, 0)) else {
+            Issue.record("line conic should build")
+            return
+        }
+        let magnitude = abs(l.a) + abs(l.b) + abs(l.c) + abs(l.d) + abs(l.e) + abs(l.f)
+        #expect(magnitude > 0)
+    }
+
+    @Test func lineCircleIntersectionRejectsZeroRadius() {
+        #expect(Conic2D.lineCircleIntersection(
+            linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+            circleCenter: SIMD2(0, 0), circleDir: SIMD2(1, 0), radius: 0).isEmpty)
+        #expect(Conic2D.lineCircleIntersection(
+            linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+            circleCenter: SIMD2(0, 0), circleDir: SIMD2(1, 0), radius: 5).count == 2)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -418,7 +418,7 @@ a map of the major areas, and the `Total` as the count.
 | **Extrema_ExtPElC** | 4 | pointToLine, pointToCircle, pointToEllipse, pointToParabola |
 | **Extrema_ExtPElS** | 5 | pointToPlane, pointToSphere, pointToCylinder, pointToCone, pointToTorus |
 | **math_TrigonometricFunctionRoots** | 2 | solve, hasInfiniteRoots |
-| **IntAna2d_Conic** | 4 | fromCircle, fromLine, fromEllipse, lineCircleIntersection |
+| **IntAna2d_Conic** | 7 | circle, line, ellipse, lineCircleIntersection, + deprecated fromCircle / fromLine / fromEllipse |
 | **BRepAlgo_NormalProjection** | 5 | create, release, add, build, result |
 | **OSD_Disk** | 4 | size, freeSpace, isValid, name |
 | **OSD_SharedLibrary** | 5 | create, release, open, close, name |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,295** | |
+| **Total** | **4,298** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -144,6 +144,68 @@ all. They assert measured geometry rather than non-nil, and were verified to fai
 defects — a flipped parallel-offset sign, and swapped `S1`/`S2` apex points. No public Swift API
 changed; `OCCTBridge` is not an SPM product, so the C-layer rename reaches no consumer.
 
+#### The nine 2D conic sites that took a dimension and never checked it (#514)
+
+Split out of #487, which fixed the three `gce_Make*2d` factories and converged the four conic
+dimension predicates onto one definition. The rest of the 2D family builds a conic from
+caller-supplied dimensions at nine more places, and none of them checked. All nine now use the
+same shared predicates: `occtValidCircleRadius`, `occtValidEllipseRadii`, `occtValidHyperbolaRadii`,
+`occtValidParabolaFocal`.
+
+**The gap was the zero boundary specifically, not "no precondition at all".** The issue's premise
+was that `gp_Elips2d`'s own `Standard_ConstructionError_Raise_if` is compiled out. That is true of a
+call made from **inside** OCCT, where `No_Exception` is defined, and it is what #487 measured for
+`gce_MakeElips2d`. These nine sites construct the `gp_*2d` themselves, in a bridge translation unit,
+where the constructor is `constexpr` in the header and the check does run: `gp_Elips2d(ax, 5, -3)`,
+`(3, 5)` and `gp_Parab2d(ax, -2)` all raise today and are already caught. What the check never
+covered is zero, which every downstream algorithm then accepts:
+
+| construction | measured result on the degenerate input |
+|---|---|
+| `Convert_EllipseToBSplineCurve`, radii `(0, 0)` | 5 poles, degree 2, evaluates to the centre at every parameter |
+| `Convert_EllipseToBSplineCurve`, radii `(5, 0)` | collapses onto the major axis: `(5,0) → (0,0) → (-5,0)` |
+| `Convert_HyperbolaToBSplineCurve`, radii `(5, 0)` | a straight ray |
+| `Convert_ParabolaToBSplineCurve`, focal `0` | 3 poles, degree 2, **every pole NaN** |
+| `BRepLib_MakeEdge2d`, ellipse `(0, 0)` | `IsDone()`, zero-length edge, both vertices at the centre |
+| `BRepLib_MakeEdge2d`, ellipse `(5, 0)` | `IsDone()`, a segment doubled back along the major axis |
+| `IntAna2d_Conic`, ellipse `(0, 0)` | all six coefficients 0 |
+
+**`Conic2D` gains a way to say the conic does not exist.** All-zero coefficients cannot carry it:
+the equation `0 = 0` holds at every point of the plane, so they read as a conic, and they were also
+what the `catch` block already wrote. The three bridge functions return `bool`; in Swift there are
+three new factories that return `Conic2D?`:
+
+```swift
+// new
+if let e = Conic2D.ellipse(center: .zero, direction: SIMD2(1, 0),
+                           majorRadius: 5, minorRadius: 3) { … }
+
+// old spelling, still compiles, now deprecated
+let e = Conic2D.fromEllipse(center: .zero, direction: SIMD2(1, 0),
+                            majorRadius: 5, minorRadius: 3)
+```
+
+`fromCircle` / `fromLine` / `fromEllipse` are `@available(*, deprecated, renamed:)` and forward,
+returning the all-zero struct where the new spelling returns `nil`. **Not a breaking change**: no
+existing call site has to move, and no signature changed.
+
+`Conic2D`'s documented equation was wrong. It named `a·x² + b·x·y + c·y² + d·x + e·y + f = 0`;
+OCCT's `IntAna2d_Conic::Coefficients` returns `a·x² + b·y² + 2c·x·y + 2d·x + 2e·y + f = 0`, so `b`
+is the `y²` term and `c` the cross term, and the cross and linear terms carry a factor of 2. A
+caller who built a conic from the documented order got a different curve. The values themselves
+never changed; a regression test now pins the order against a radius-5 circle (`1, 1, 0, 0, 0, -25`).
+
+Scope: the three circle siblings sitting in the same three code blocks
+(`OCCTMakeEdge2dFullCircle`, `OCCTConvertCircleToBSpline2D`, `OCCTConic2dFromCircle`) are included,
+along with `OCCTConic2dLineCircleIntersect`, which shares the same `gp_Circ2d` construction and
+would otherwise have been the one entry point in its own block still accepting radius 0. The ~25
+remaining 2D circle sites are `Geom2dGcc` tangency-solver *inputs*, a different question, filed
+separately. The 3D equivalents are unsurveyed, as #514 noted.
+
+18 tests in `Tests/OCCTGeom2dTests/Issue514Conic2dDegenerateTests.swift`. They were run against a
+build with every guard stripped back out: the 10 rejection tests fail, and the 8 that pin valid
+input (including "a hyperbola may have minor > major" and the coefficient order) still pass.
+
 #### One pipe shell, and the sweep mode it was quietly discarding (#503)
 
 Four bridge functions each built their own single-profile `BRepOffsetAPI_MakePipeShell`, and each

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -1706,8 +1706,8 @@ public static func edge2dFullCircle(center: SIMD2<Double>, direction: SIMD2<Doub
                                      radius: Double) -> Shape?
 ```
 
-- **Parameters:** `center` — circle center in 2D; `direction` — X-axis direction; `radius` — radius.
-- **Returns:** A `Shape` wrapping a closed `TopoDS_Edge` in 2D, or `nil` on failure.
+- **Parameters:** `center`: circle center in 2D; `direction`: X-axis direction; `radius`: radius, must be greater than zero.
+- **Returns:** A `Shape` wrapping a closed `TopoDS_Edge` in 2D, or `nil` on failure or a degenerate radius.
 - **OCCT:** `BRepLib_MakeEdge2d` (circle overload)
 - **Example:**
   ```swift
@@ -1725,8 +1725,8 @@ public static func edge2dEllipse(center: SIMD2<Double>, direction: SIMD2<Double>
                                   majorRadius: Double, minorRadius: Double) -> Shape?
 ```
 
-- **Parameters:** `center` — center in 2D; `direction` — major-axis direction; `majorRadius`, `minorRadius` — semi-axes.
-- **Returns:** A closed 2D edge, or `nil` on failure.
+- **Parameters:** `center`: center in 2D; `direction`: major-axis direction; `majorRadius`, `minorRadius`: semi-axes, both greater than zero with `minorRadius <= majorRadius`. Equal radii are a circle and are valid.
+- **Returns:** A closed 2D edge, or `nil` on failure or a degenerate ellipse. `BRepLib_MakeEdge2d` itself reports `IsDone()` for one: a zero-radius ellipse builds a zero-length edge with both vertices at the centre, and a zero minor radius builds a segment doubled back along the major axis (#514).
 - **OCCT:** `BRepLib_MakeEdge2d` (ellipse overload)
 - **Example:**
   ```swift
@@ -1746,8 +1746,8 @@ public static func edge2dEllipseArc(center: SIMD2<Double>, direction: SIMD2<Doub
                                      u1: Double, u2: Double) -> Shape?
 ```
 
-- **Parameters:** `center`, `direction`, `majorRadius`, `minorRadius` — ellipse definition; `u1`, `u2` — parameter range (radians).
-- **Returns:** A 2D edge arc, or `nil` on failure.
+- **Parameters:** `center`, `direction`, `majorRadius`, `minorRadius`: ellipse definition, both radii greater than zero with `minorRadius <= majorRadius`; `u1`, `u2`: parameter range (radians).
+- **Returns:** A 2D edge arc, or `nil` on failure or a degenerate ellipse.
 - **OCCT:** `BRepLib_MakeEdge2d` (ellipse-arc overload)
 - **Example:**
   ```swift

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -1345,8 +1345,8 @@ public static func fromCircleArc(centerX: Double, centerY: Double, radius: Doubl
                                   u1: Double, u2: Double) -> Curve2D?
 ```
 
-- **Parameters:** `centerX`, `centerY` — arc centre; `radius` — circle radius; `u1`, `u2` — start and end parameter (in radians).
-- **Returns:** The BSpline representation, or `nil` on failure.
+- **Parameters:** `centerX`, `centerY`: arc centre; `radius`: circle radius, must be greater than zero; `u1`, `u2`: start and end parameter (in radians).
+- **Returns:** The BSpline representation, or `nil` on failure or a degenerate radius.
 - **OCCT:** `Convert_CircleToBSplineCurve` (via `OCCTConvertCircleToBSpline2D`).
 - **Example:**
   ```swift
@@ -1386,6 +1386,11 @@ public static func fromSphere(origin: SIMD3<Double>, axis: SIMD3<Double>, radius
 
 Extensions on `Curve2D` for exact BSpline representations of 2D conics.
 
+Every one of these returns `nil` for a degenerate dimension. None of the `Convert_*` algorithms
+refuses one on its own: measured (#514), a zero-radius ellipse converts to a degree-2 curve that
+evaluates to its own centre at every parameter, and a zero focal length converts to a curve whose
+poles are all NaN.
+
 ### `Curve2D.fromEllipseArc(centerX:centerY:majorRadius:minorRadius:u1:u2:)`
 
 Convert a 2D ellipse arc to a BSpline curve.
@@ -1396,8 +1401,8 @@ public static func fromEllipseArc(centerX: Double, centerY: Double,
                                    u1: Double, u2: Double) -> Curve2D?
 ```
 
-- **Parameters:** `centerX`, `centerY` — ellipse centre; `majorRadius`, `minorRadius` — semi-axes; `u1`, `u2` — parameter range.
-- **Returns:** BSpline curve, or `nil` on failure.
+- **Parameters:** `centerX`, `centerY`: ellipse centre; `majorRadius`, `minorRadius`: semi-axes, both greater than zero with `minorRadius <= majorRadius` (equal radii are a circle and are valid); `u1`, `u2`: parameter range.
+- **Returns:** BSpline curve, or `nil` on failure or a degenerate ellipse.
 - **OCCT:** `Convert_EllipseToBSplineCurve` (via `OCCTConvertEllipseToBSpline2D`).
 - **Example:**
   ```swift
@@ -1418,7 +1423,15 @@ public static func fromHyperbolaArc(centerX: Double, centerY: Double,
                                      u1: Double, u2: Double) -> Curve2D?
 ```
 
+- **Parameters:** `majorRadius`, `minorRadius`: both greater than zero, in either order. A hyperbola puts no ordering on its radii, so a minor radius larger than the major is an ordinary hyperbola, not an inverted one.
+- **Returns:** BSpline curve, or `nil` on failure or a degenerate hyperbola.
 - **OCCT:** `Convert_HyperbolaToBSplineCurve` (via `OCCTConvertHyperbolaToBSpline2D`).
+- **Example:**
+  ```swift
+  if let h = Curve2D.fromHyperbolaArc(centerX: 0, centerY: 0,
+                                       majorRadius: 10, minorRadius: 5,
+                                       u1: -1, u2: 1) { }
+  ```
 
 ---
 
@@ -1431,8 +1444,13 @@ public static func fromParabolaArc(centerX: Double, centerY: Double, focal: Doub
                                     u1: Double, u2: Double) -> Curve2D?
 ```
 
-- **Parameters:** `focal` — focal distance of the parabola.
+- **Parameters:** `focal`: focal distance of the parabola, must be greater than zero.
+- **Returns:** BSpline curve, or `nil` on failure or a zero focal length, which OCCT converts into a curve with NaN poles rather than rejecting.
 - **OCCT:** `Convert_ParabolaToBSplineCurve` (via `OCCTConvertParabolaToBSpline2D`).
+- **Example:**
+  ```swift
+  if let p = Curve2D.fromParabolaArc(centerX: 0, centerY: 0, focal: 5, u1: -2, u2: 2) { }
+  ```
 
 ---
 

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -18,12 +18,12 @@ This page covers `Document.swift` lines 9930-11279: 2D conic utilities, normal p
 ## IntAna2d\_Conic — 2D Conics
 
 `Conic2D` is a value type holding the six implicit coefficients of a 2D conic
-`A·x² + B·x·y + C·y² + D·x + E·y + F = 0`, plus static factories and a line-circle
+`a·x² + b·y² + 2c·x·y + 2d·x + 2e·y + f = 0`, plus static factories and a line-circle
 intersection query. Wraps `IntAna2d_Conic` / `IntAna2d_AnaIntersection`.
 
 ### `Conic2D`
 
-Coefficients of a 2D implicit conic `A·x² + B·x·y + C·y² + D·x + E·y + F = 0`.
+Coefficients of a 2D implicit conic `a·x² + b·y² + 2c·x·y + 2d·x + 2e·y + f = 0`.
 
 ```swift
 public struct Conic2D: Sendable {
@@ -31,68 +31,105 @@ public struct Conic2D: Sendable {
 }
 ```
 
----
+The coefficients are OCCT's, in OCCT's order: the conic is the point set satisfying
 
-### `Conic2D.fromCircle(center:direction:radius:)`
-
-Create `Conic2D` coefficients from a 2D circle.
-
-```swift
-public static func fromCircle(
-    center: SIMD2<Double>, direction: SIMD2<Double>, radius: Double
-) -> Conic2D
+```
+a·x² + b·y² + 2c·x·y + 2d·x + 2e·y + f = 0
 ```
 
-- **Parameters:** `center` — circle centre; `direction` — local X axis direction; `radius` — circle radius.
-- **Returns:** `Conic2D` with the six implicit coefficients.
+`b` is the `y²` coefficient and `c` the `x·y` one, and the cross and linear terms carry a factor
+of 2. (Through v1.17.0 the doc comment named `a·x² + b·x·y + c·y² + d·x + e·y + f = 0`, which swaps
+the roles of `b` and `c` and drops the factor; the values themselves never changed. #514)
+
+Every factory returns `nil` rather than a conic when a dimension is degenerate. There is no
+in-band way to say it: all-zero coefficients are the equation `0 = 0`, which holds at every point
+of the plane, so they read as a conic rather than as no answer.
+
+---
+
+### `Conic2D.circle(center:direction:radius:)`
+
+The implicit conic of a 2D circle.
+
+```swift
+public static func circle(
+    center: SIMD2<Double>, direction: SIMD2<Double>, radius: Double
+) -> Conic2D?
+```
+
+- **Parameters:** `center`: circle centre; `direction`: local X axis direction, must be non-zero; `radius`: circle radius, must be greater than zero.
+- **Returns:** the six implicit coefficients, or `nil` when a dimension is degenerate.
 - **OCCT:** `IntAna2d_Conic` (circle constructor) via `OCCTConic2dFromCircle`.
 - **Example:**
   ```swift
-  let c = Conic2D.fromCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0), radius: 3)
-  // c.a == 1, c.c == 1, c.f == -9  (approximate unit-circle form scaled by r²)
+  if let c = Conic2D.circle(center: SIMD2(0, 0), direction: SIMD2(1, 0), radius: 3) {
+      print(c.a, c.b, c.f)   // 1.0 1.0 -9.0   (x² + y² - 9 = 0)
+  }
   ```
 
 ---
 
-### `Conic2D.fromLine(point:direction:)`
+### `Conic2D.line(point:direction:)`
 
-Create `Conic2D` coefficients from a 2D line.
+The implicit conic of a 2D line.
 
 ```swift
-public static func fromLine(
+public static func line(
     point: SIMD2<Double>, direction: SIMD2<Double>
-) -> Conic2D
+) -> Conic2D?
 ```
 
-- **Parameters:** `point` — any point on the line; `direction` — line direction vector.
-- **Returns:** `Conic2D` whose non-zero linear coefficients describe the line.
+- **Parameters:** `point`: any point on the line; `direction`: line direction vector, must be non-zero.
+- **Returns:** the coefficients, whose non-zero linear terms describe the line, or `nil` for a zero direction.
 - **OCCT:** `IntAna2d_Conic` (line constructor) via `OCCTConic2dFromLine`.
 - **Example:**
   ```swift
-  let l = Conic2D.fromLine(point: .zero, direction: SIMD2(1, 0))
+  if let l = Conic2D.line(point: .zero, direction: SIMD2(1, 0)) {
+      print(l.e)   // non-zero: the y term of the line y = 0
+  }
   ```
 
 ---
 
-### `Conic2D.fromEllipse(center:direction:majorRadius:minorRadius:)`
+### `Conic2D.ellipse(center:direction:majorRadius:minorRadius:)`
 
-Create `Conic2D` coefficients from a 2D ellipse.
+The implicit conic of a 2D ellipse.
 
 ```swift
-public static func fromEllipse(
+public static func ellipse(
     center: SIMD2<Double>, direction: SIMD2<Double>,
     majorRadius: Double, minorRadius: Double
-) -> Conic2D
+) -> Conic2D?
 ```
 
-- **Parameters:** `center` — ellipse centre; `direction` — local X axis; `majorRadius` / `minorRadius` — semi-axes.
-- **Returns:** `Conic2D` with the six implicit conic coefficients.
+- **Parameters:** `center`: ellipse centre; `direction`: local X axis, must be non-zero; `majorRadius` / `minorRadius`: semi-axes, both greater than zero with `minorRadius <= majorRadius`. Equal radii are a circle and are valid.
+- **Returns:** the six implicit conic coefficients, or `nil` when a dimension is degenerate.
 - **OCCT:** `IntAna2d_Conic` (ellipse constructor) via `OCCTConic2dFromEllipse`.
 - **Example:**
   ```swift
-  let e = Conic2D.fromEllipse(center: .zero, direction: SIMD2(1, 0),
-                               majorRadius: 5, minorRadius: 3)
+  if let e = Conic2D.ellipse(center: .zero, direction: SIMD2(1, 0),
+                             majorRadius: 5, minorRadius: 3) {
+      print(e.a, e.b, e.f)   // 0.04 0.111… -1.0   (x²/25 + y²/9 - 1 = 0)
+  }
   ```
+
+---
+
+### Deprecated: `Conic2D.fromCircle` / `fromLine` / `fromEllipse`
+
+The three original spellings return a non-optional `Conic2D`, so their only way to report a
+degenerate input is the all-zero struct, which describes no conic. They remain, deprecated,
+forwarding to the factories above and returning all zeros where those return `nil`.
+
+```swift
+// before
+let e = Conic2D.fromEllipse(center: .zero, direction: SIMD2(1, 0),
+                            majorRadius: 5, minorRadius: 3)
+
+// after
+if let e = Conic2D.ellipse(center: .zero, direction: SIMD2(1, 0),
+                           majorRadius: 5, minorRadius: 3) { … }
+```
 
 ---
 
@@ -107,6 +144,7 @@ public static func lineCircleIntersection(
 ) -> [SIMD2<Double>]
 ```
 
+- **Parameters:** `radius` must be greater than zero. Intersecting against a radius-0 circle is a point-on-line test, not an intersection, and returns an empty array.
 - **Returns:** 0, 1, or 2 intersection points. Empty array when the line misses the circle.
 - **OCCT:** `IntAna2d_AnaIntersection` via `OCCTConic2dLineCircleIntersect`.
 - **Example:**


### PR DESCRIPTION
Closes #514.

Split out of #487, which fixed the three `gce_Make*2d` conic factories and converged the four conic
dimension predicates onto one definition in `OCCTBridge_Internal.h`. The rest of the 2D family
builds a conic from caller-supplied dimensions at nine more places in `OCCTBridge_Geom2d.mm`, and
none of them checked. All nine now use the same shared predicates.

## One correction to the issue's premise

The issue held that these sites have "no precondition at all", because `gp_Elips2d`'s own
`Standard_ConstructionError_Raise_if` is compiled out under `No_Exception`. That is true of a call
made from **inside** OCCT, and it is exactly what #487 measured for `gce_MakeElips2d`. These nine
sites construct the `gp_*2d` themselves, in a bridge translation unit, where the constructor is
`constexpr` in the header and the check does run. Measured:

| input | result today |
|---|---|
| `gp_Elips2d(ax, 5, -3)` | raises, already caught, already `nullptr` |
| `gp_Elips2d(ax, 3, 5)` | raises |
| `gp_Hypr2d(ax, -5, 3)` | raises |
| `gp_Parab2d(ax, -2)` | raises |

So the real gap is the zero boundary specifically, which `gp`'s check has never covered (`minor < 0
|| major < minor` passes `(0, 0)`), and which no downstream algorithm rejects either:

| construction | measured result on the degenerate input |
|---|---|
| `Convert_EllipseToBSplineCurve`, radii `(0, 0)` | 5 poles, degree 2, evaluates to the centre at every parameter |
| `Convert_EllipseToBSplineCurve`, radii `(5, 0)` | collapses onto the major axis: `(5,0) -> (0,0) -> (-5,0)` |
| `Convert_HyperbolaToBSplineCurve`, radii `(5, 0)` | a straight ray |
| `Convert_ParabolaToBSplineCurve`, focal `0` | 3 poles, degree 2, **every pole NaN** |
| `BRepLib_MakeEdge2d`, ellipse `(0, 0)` | `IsDone()`, zero-length edge, both vertices at the centre |
| `BRepLib_MakeEdge2d`, ellipse `(5, 0)` | `IsDone()`, a segment doubled back along the major axis |
| `IntAna2d_Conic`, ellipse `(0, 0)` | all six coefficients 0 |

## `Conic2D` gains a way to say the conic does not exist

`OCCTConic2dFromEllipse` returns void and writes six coefficients, zeroed in its `catch`, so it had
no channel for a rejection. All-zero coefficients cannot be that channel: `0 = 0` holds at every
point of the plane, so they read as a conic rather than as no answer, and they were already what a
throw wrote.

The three `OCCTConic2dFrom*` functions now return `bool`. In Swift:

```swift
// new
if let e = Conic2D.ellipse(center: .zero, direction: SIMD2(1, 0),
                           majorRadius: 5, minorRadius: 3) { … }

// old spelling, still compiles, now deprecated and forwarding
let e = Conic2D.fromEllipse(center: .zero, direction: SIMD2(1, 0),
                            majorRadius: 5, minorRadius: 3)
```

`fromCircle` / `fromLine` / `fromEllipse` are `@available(*, deprecated, renamed:)` and return the
all-zero struct where the new spelling returns `nil`. **Not a breaking change**: no existing call
site has to move, no signature changed, no SEMVER exception needed.

## The documented coefficient order was wrong

`Conic2D` documented `a·x² + b·x·y + c·y² + d·x + e·y + f = 0`. OCCT's
`IntAna2d_Conic::Coefficients` returns `a·x² + b·y² + 2c·x·y + 2d·x + 2e·y + f = 0`: `b` is the `y²`
term and `c` the cross term, and the cross and linear terms carry a factor of 2. Confirmed against
the header and by measurement (radius-5 circle gives `1, 1, 0, 0, 0, -25`, which is `x² + y² - 25`,
not `x² + xy - 25`). A caller building a conic from the documented order got a different curve. The
values themselves never changed, so this is a docs fix plus a test that pins the order.

## Scope

Included beyond the six sites the issue names, after asking:

- The three circle siblings sitting in the same three code blocks: `OCCTMakeEdge2dFullCircle`,
  `OCCTConvertCircleToBSpline2D`, `OCCTConic2dFromCircle`. Leaving them would have shipped
  `edge2dEllipse(0, 0)` rejected next to `edge2dFullCircle(radius: 0)` accepted, in one block.
- `OCCTConic2dLineCircleIntersect`, which shares the same `gp_Circ2d` construction and would
  otherwise be the one entry point in its own block still accepting radius 0.

Deliberately not included, filed as follow-ups: the ~25 remaining 2D circle sites, which are
`Geom2dGcc` tangency-solver **inputs** rather than conic constructions, and the 3D counterparts the
issue flagged as unsurveyed (`OCCTCurve3DArcOfEllipse`, `OCCTMakeEdgeFromEllipse` / `Arc` and
siblings in `OCCTBridge_Spatial.mm` are all unguarded, confirmed by grep during this pass).

## Verification

- 18 new tests, `Tests/OCCTGeom2dTests/Issue514Conic2dDegenerateTests.swift`.
- **The tests were run against a build with every guard stripped back out**: the 10 rejection tests
  fail, and the 8 that pin valid input still pass, including "a hyperbola may have minor > major"
  (no ordering rule, unlike an ellipse) and the coefficient order.
- Full `swift test`: 4811 tests, 1343 suites, green.
- `Scripts/count-operations.py --fix`: 4,287 -> 4,290.
- `Scripts/check-bridge-index.py`: 135 stale, all pre-existing (#510). The index block is untouched
  by this PR, and no bridge symbol was renamed or added.

## Docs

`docs/CHANGELOG.md`, `docs/API_REFERENCE.md` (`IntAna2d_Conic` row and Total), `README.md`
headline, `docs/reference/Document-Math-Solvers.md` (rewritten `Conic2D` section),
`docs/reference/Document-Math-Bounds.md`, `docs/reference/Document-Geometry-Constructors.md`, and
`///` doc comments with runnable ```swift``` snippets on every changed public entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
