### PR TITLE
fix(#478): sweep the null-handle guard across all 14 sites, unify Curve2D's transform families

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -2814,6 +2814,10 @@ OCCTCurve3DRef OCCTCurve3DTrimmed(OCCTCurve3DRef basisCurve, double u1, double u
 }
 
 void OCCTCurve3DStartPoint(OCCTCurve3DRef curve, double* x, double* y, double* z) {
+    // #478: these two were the only pair in the family with no guard at all, not even the
+    // wrapper pointer. Zero out first so the guarded exit matches the catch below.
+    *x = 0; *y = 0; *z = 0;
+    if (!curve || curve->curve.IsNull()) return;
     try {
         gp_Pnt p = curve->curve->Value(curve->curve->FirstParameter());
         *x = p.X(); *y = p.Y(); *z = p.Z();
@@ -2821,6 +2825,8 @@ void OCCTCurve3DStartPoint(OCCTCurve3DRef curve, double* x, double* y, double* z
 }
 
 void OCCTCurve3DEndPoint(OCCTCurve3DRef curve, double* x, double* y, double* z) {
+    *x = 0; *y = 0; *z = 0;   // #478, as above
+    if (!curve || curve->curve.IsNull()) return;
     try {
         gp_Pnt p = curve->curve->Value(curve->curve->LastParameter());
         *x = p.X(); *y = p.Y(); *z = p.Z();
@@ -4048,7 +4054,7 @@ int32_t OCCTExtremaExtPElCParab(double px, double py, double pz,
 // MARK: - Curve3D Extras (v0.109.0)
 
 bool OCCTCurve3DReverse(OCCTCurve3DRef curve) {
-    if (!curve) return false;
+    if (!curve || curve->curve.IsNull()) return false;   // #478
     try {
         curve->curve->Reverse();
         return true;
@@ -4056,7 +4062,7 @@ bool OCCTCurve3DReverse(OCCTCurve3DRef curve) {
 }
 
 OCCTCurve3DRef OCCTCurve3DCopy(OCCTCurve3DRef curve) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;  // #478
     try {
         Handle(Geom_Curve) copy = Handle(Geom_Curve)::DownCast(curve->curve->Copy());
         if (copy.IsNull()) return nullptr;
@@ -4937,7 +4943,7 @@ bool OCCTCurve3DBSplineMovePointAndTangent(OCCTCurve3DRef curve, double u,
 // --- Curve3D queries ---
 
 double OCCTCurve3DPeriod(OCCTCurve3DRef curve) {
-    if (!curve) return 0.0;
+    if (!curve || curve->curve.IsNull()) return 0.0;   // #478
     try {
         if (!curve->curve->IsPeriodic()) return 0.0;
         return curve->curve->Period();
@@ -4945,12 +4951,12 @@ double OCCTCurve3DPeriod(OCCTCurve3DRef curve) {
 }
 
 double OCCTCurve3DFirstParameter(OCCTCurve3DRef curve) {
-    if (!curve) return 0.0;
+    if (!curve || curve->curve.IsNull()) return 0.0;   // #478
     try { return curve->curve->FirstParameter(); } catch (...) { return 0.0; }
 }
 
 double OCCTCurve3DLastParameter(OCCTCurve3DRef curve) {
-    if (!curve) return 0.0;
+    if (!curve || curve->curve.IsNull()) return 0.0;   // #478
     try { return curve->curve->LastParameter(); } catch (...) { return 0.0; }
 }
 // --- Geom_BezierCurve completions ---

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -3927,7 +3927,7 @@ int32_t OCCTConic2dLineCircleIntersect(double lpx, double lpy, double ldx, doubl
 // MARK: - Curve2D Extras (v0.109.0)
 
 bool OCCTCurve2DReverse(OCCTCurve2DRef curve) {
-    if (!curve) return false;
+    if (!curve || curve->curve.IsNull()) return false;   // #478
     try {
         curve->curve->Reverse();
         return true;
@@ -3935,7 +3935,7 @@ bool OCCTCurve2DReverse(OCCTCurve2DRef curve) {
 }
 
 OCCTCurve2DRef OCCTCurve2DCopy(OCCTCurve2DRef curve) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;  // #478
     try {
         Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
         if (copy.IsNull()) return nullptr;
@@ -4717,31 +4717,55 @@ bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve) {
         return true;
     } catch (...) { return false; }
 }
+// === #478: one gp_Trsf2d builder behind both Curve2D transform families ===
+//
+// Curve2D has the same two-family shape as Curve3D (#416) and Surface (#488): an in-place
+// mutating dispatcher (OCCTCurve2DTransform, taking a transformType selector) and an immutable
+// OCCTCurve2DTranslate/Rotate/Scale/MirrorAxis/MirrorPoint family that returns a transformed
+// copy. Both build the same five transformations; each family built them its own way, so the
+// two could drift, and had already drifted on the null guard below. They share this builder now,
+// mirroring buildTrsf3D in OCCTBridge_Curve3D.mm / OCCTBridge_Surface.mm.
+//
+// The scale case is the only one whose construction changes. The dispatcher used to compose it
+// by hand as SetScaleFactor(S) + SetTranslationPart(C * (1 - S)); gp_Trsf2d::SetScale(C, S) is
+// what the immutable family reached through Geom2d_Geometry::Scale, and what buildTrsf3D uses.
+// Verified equivalent before switching, over factors {2.5, 0.25, 1, -1, -3, 0, 1e-9, 1e9} x three
+// centres including (1e6, 1e-6): identical ScaleFactor(), identical TranslationPart(), identical
+// transformed coordinates, to the bit. The two disagree only on the internal gp_TrsfForm tag at
+// S = 1 (gp_Scale vs gp_Identity) and S = -1 (gp_Scale vs gp_PntMirror), which is a dispatch hint,
+// not a result: transforming a real BSpline curve through both gives identical poles.
+static bool buildTrsf2D(gp_Trsf2d& trsf, int32_t type,
+                         double p1, double p2, double p3, double p4) {
+    switch (type) {
+        case 0: // translation (dx, dy)
+            trsf.SetTranslation(gp_Vec2d(p1, p2));
+            return true;
+        case 1: // rotation (cx, cy, angle)
+            trsf.SetRotation(gp_Pnt2d(p1, p2), p3);
+            return true;
+        case 2: // scale (cx, cy, factor)
+            trsf.SetScale(gp_Pnt2d(p1, p2), p3);
+            return true;
+        case 3: // mirror point (px, py)
+            trsf.SetMirror(gp_Pnt2d(p1, p2));
+            return true;
+        case 4: // mirror axis (ox, oy, dx, dy)
+            trsf.SetMirror(gp_Ax2d(gp_Pnt2d(p1, p2), gp_Dir2d(p3, p4)));
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool OCCTCurve2DTransform(OCCTCurve2DRef curve, int32_t transformType,
                            double p1, double p2, double p3, double p4, double p5) {
-    if (!curve) return false;
+    // #478: the handle as well as the wrapper. Geom2d_Curve::Transform is a kernel virtual, so
+    // its Standard_NullObject precondition is compiled out of this No_Exception build and a null
+    // handle is a raw dereference; the enclosing catch cannot intercept the resulting signal.
+    if (!curve || curve->curve.IsNull()) return false;
     try {
         gp_Trsf2d trsf;
-        switch (transformType) {
-            case 0: // translation (dx, dy)
-                trsf.SetTranslation(gp_Vec2d(p1, p2));
-                break;
-            case 1: // rotation (cx, cy, angle)
-                trsf.SetRotation(gp_Pnt2d(p1, p2), p3);
-                break;
-            case 2: // scale (cx, cy, factor)
-                trsf.SetScaleFactor(p3);
-                trsf.SetTranslationPart(gp_Vec2d(p1 * (1.0 - p3), p2 * (1.0 - p3)));
-                break;
-            case 3: // mirror point (px, py)
-                trsf.SetMirror(gp_Pnt2d(p1, p2));
-                break;
-            case 4: // mirror axis (ox, oy, dx, dy)
-                trsf.SetMirror(gp_Ax2d(gp_Pnt2d(p1, p2), gp_Dir2d(p3, p4)));
-                break;
-            default:
-                return false;
-        }
+        if (!buildTrsf2D(trsf, transformType, p1, p2, p3, p4)) return false;
         curve->curve->Transform(trsf);
         return true;
     } catch (...) { return false; }
@@ -5356,12 +5380,17 @@ OCCTCurve2DRef OCCTCurve2DReversed(OCCTCurve2DRef c) {
     }
 }
 
+// #478: the five immutable transforms share buildTrsf2D with the in-place
+// OCCTCurve2DTransform dispatcher (defined above) rather than each building its own
+// transformation, so the two families cannot drift apart on the transform math.
+
 OCCTCurve2DRef OCCTCurve2DTranslate(OCCTCurve2DRef c, double dx, double dy) {
     if (!c || c->curve.IsNull()) return nullptr;
     try {
         Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Vec2d v(dx, dy);
-        copy->Translate(v);
+        gp_Trsf2d trsf;
+        if (!buildTrsf2D(trsf, 0, dx, dy, 0, 0)) return nullptr;
+        copy->Transform(trsf);
         return new OCCTCurve2D(copy);
     } catch (...) {
         return nullptr;
@@ -5372,8 +5401,9 @@ OCCTCurve2DRef OCCTCurve2DRotate(OCCTCurve2DRef c, double cx, double cy, double 
     if (!c || c->curve.IsNull()) return nullptr;
     try {
         Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Pnt2d center(cx, cy);
-        copy->Rotate(center, angle);
+        gp_Trsf2d trsf;
+        if (!buildTrsf2D(trsf, 1, cx, cy, angle, 0)) return nullptr;
+        copy->Transform(trsf);
         return new OCCTCurve2D(copy);
     } catch (...) {
         return nullptr;
@@ -5384,8 +5414,9 @@ OCCTCurve2DRef OCCTCurve2DScale(OCCTCurve2DRef c, double cx, double cy, double f
     if (!c || c->curve.IsNull()) return nullptr;
     try {
         Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Pnt2d center(cx, cy);
-        copy->Scale(center, factor);
+        gp_Trsf2d trsf;
+        if (!buildTrsf2D(trsf, 2, cx, cy, factor, 0)) return nullptr;
+        copy->Transform(trsf);
         return new OCCTCurve2D(copy);
     } catch (...) {
         return nullptr;
@@ -5397,8 +5428,9 @@ OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef c, double px, double py,
     if (!c || c->curve.IsNull()) return nullptr;
     try {
         Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Ax2d axis(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
-        copy->Mirror(axis);
+        gp_Trsf2d trsf;
+        if (!buildTrsf2D(trsf, 4, px, py, dx, dy)) return nullptr;
+        copy->Transform(trsf);
         return new OCCTCurve2D(copy);
     } catch (...) {
         return nullptr;
@@ -5409,8 +5441,9 @@ OCCTCurve2DRef OCCTCurve2DMirrorPoint(OCCTCurve2DRef c, double px, double py) {
     if (!c || c->curve.IsNull()) return nullptr;
     try {
         Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Pnt2d pt(px, py);
-        copy->Mirror(pt);
+        gp_Trsf2d trsf;
+        if (!buildTrsf2D(trsf, 3, px, py, 0, 0)) return nullptr;
+        copy->Transform(trsf);
         return new OCCTCurve2D(copy);
     } catch (...) {
         return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -4670,7 +4670,7 @@ void OCCTSurfaceBounds(OCCTSurfaceRef surface,
                         double* uMin, double* uMax,
                         double* vMin, double* vMax) {
     *uMin = 0; *uMax = 0; *vMin = 0; *vMax = 0;
-    if (!surface) return;
+    if (!surface || surface->surface.IsNull()) return;   // #478
     try {
         surface->surface->Bounds(*uMin, *uMax, *vMin, *vMax);
     } catch (...) {}
@@ -4682,7 +4682,7 @@ int32_t OCCTSurfaceContinuity(OCCTSurfaceRef surface) {
 }
 
 OCCTSurfaceRef OCCTSurfaceCopy(OCCTSurfaceRef surface) {
-    if (!surface) return nullptr;
+    if (!surface || surface->surface.IsNull()) return nullptr;   // #478
     try {
         Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(surface->surface->Copy());
         if (copy.IsNull()) return nullptr;
@@ -5483,7 +5483,7 @@ bool OCCTSurfaceBSplineSetPoleRow(OCCTSurfaceRef surface,
 // --- Surface queries ---
 
 double OCCTSurfaceUPeriod(OCCTSurfaceRef surface) {
-    if (!surface) return 0.0;
+    if (!surface || surface->surface.IsNull()) return 0.0;   // #478
     try {
         if (!surface->surface->IsUPeriodic()) return 0.0;
         return surface->surface->UPeriod();
@@ -5491,7 +5491,7 @@ double OCCTSurfaceUPeriod(OCCTSurfaceRef surface) {
 }
 
 double OCCTSurfaceVPeriod(OCCTSurfaceRef surface) {
-    if (!surface) return 0.0;
+    if (!surface || surface->surface.IsNull()) return 0.0;   // #478
     try {
         if (!surface->surface->IsVPeriodic()) return 0.0;
         return surface->surface->VPeriod();

--- a/Tests/OCCTGeom2dTests/Issue478Curve2DTransformParityTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue478Curve2DTransformParityTests.swift
@@ -1,0 +1,241 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #478: Curve2D has two transform families that never had a test asserting they agree:
+// the in-place `translate`/`rotate`/`scale`/`mirrorPoint`/`mirrorAxis` (one shared bridge
+// dispatcher, `OCCTCurve2DTransform`) and the immutable `translated`/`rotated`/`scaled`/
+// `mirrored` (five separate bridge functions returning a transformed copy). Each family built
+// its own transformation, and the two had already drifted on the null-handle guard. They now
+// share one `buildTrsf2D`, matching Curve3D (#416) and Surface (#488); these tests hold them
+// together.
+//
+// Two fixtures per case, because they exercise different kernel paths. A segment is a
+// `Geom2d_TrimmedCurve` over a `Geom2d_Line`, whose Transform moves an axis placement; a Bezier
+// transforms every pole. Only the second can expose a wrong translation part in the scale case,
+// which is the one construction that changed, so every scale case uses a non-origin centre.
+@Suite("Curve2D Transform Family Parity (#478)")
+struct Issue478Curve2DTransformParityTests {
+
+    private static func analytic() -> Curve2D? {
+        Curve2D.segment(from: SIMD2(3, -1), to: SIMD2(11, 4))
+    }
+
+    private static func poled() -> Curve2D? {
+        Curve2D.bezier(poles: [SIMD2(100, -37.5), SIMD2(140.25, 12), SIMD2(-8, 260.125)])
+    }
+
+    private func samples(_ curve: Curve2D, count: Int = 7) -> [SIMD2<Double>] {
+        let d = curve.domain
+        return (0..<count).map { i in
+            curve.point(at: d.lowerBound
+                        + (d.upperBound - d.lowerBound) * (Double(i) / Double(count - 1)))
+        }
+    }
+
+    private func assertSameGeometry(_ mutated: Curve2D, _ copied: Curve2D,
+                                    _ label: String, tolerance: Double = 1e-9) {
+        let a = samples(mutated), b = samples(copied)
+        #expect(a.count == b.count)
+        for (p, q) in zip(a, b) {
+            #expect(abs(p.x - q.x) < tolerance, "\(label): x \(p.x) vs \(q.x)")
+            #expect(abs(p.y - q.y) < tolerance, "\(label): y \(p.y) vs \(q.y)")
+        }
+    }
+
+    /// Runs one transform kind over both fixtures: take the immutable copy first, then mutate
+    /// the original in place, then compare. `apply` returns false only if the in-place call did.
+    private func checkParity(_ label: String,
+                             copy: (Curve2D) -> Curve2D?,
+                             mutate: (Curve2D) -> Bool) {
+        for (name, make) in [("analytic", Self.analytic), ("bezier", Self.poled)] {
+            guard let base = make() else {
+                Issue.record("\(label): could not build the \(name) fixture")
+                continue
+            }
+            guard let copied = copy(base) else {
+                Issue.record("\(label): the immutable \(name) call returned nil")
+                continue
+            }
+            #expect(mutate(base), "\(label): the in-place \(name) call failed")
+            assertSameGeometry(base, copied, "\(label)/\(name)")
+        }
+    }
+
+    @Test("translate vs translated(by:)")
+    func translateParity() {
+        checkParity("translate",
+                    copy: { $0.translated(by: SIMD2(3, -2.5)) },
+                    mutate: { $0.translate(dx: 3, dy: -2.5) })
+    }
+
+    @Test("rotate vs rotated(around:angle:)")
+    func rotateParity() {
+        let centre = SIMD2<Double>(7, 5)
+        checkParity("rotate",
+                    copy: { $0.rotated(around: centre, angle: .pi / 3) },
+                    mutate: { $0.rotate(center: centre, angle: .pi / 3) })
+    }
+
+    // The case whose gp_Trsf2d construction changed: the dispatcher used to compose
+    // SetScaleFactor + SetTranslationPart by hand where the immutable family reached
+    // gp_Trsf2d::SetScale. A centre away from the origin is what makes the two separable.
+    @Test("scale vs scaled(from:factor:) about a non-origin centre")
+    func scaleParity() {
+        let centre = SIMD2<Double>(12.5, -6.25)
+        checkParity("scale",
+                    copy: { $0.scaled(from: centre, factor: 2.5) },
+                    mutate: { $0.scale(center: centre, factor: 2.5) })
+    }
+
+    // Negative factors are where the two constructions tag the transformation differently
+    // (gp_Scale vs gp_PntMirror) while producing the same geometry.
+    @Test("scale parity holds for a negative factor")
+    func negativeScaleParity() {
+        let centre = SIMD2<Double>(12.5, -6.25)
+        checkParity("scale(-1)",
+                    copy: { $0.scaled(from: centre, factor: -1) },
+                    mutate: { $0.scale(center: centre, factor: -1) })
+    }
+
+    @Test("mirrorPoint vs mirrored(acrossPoint:)")
+    func mirrorPointParity() {
+        let point = SIMD2<Double>(4, 4)
+        checkParity("mirrorPoint",
+                    copy: { $0.mirrored(acrossPoint: point) },
+                    mutate: { $0.mirrorPoint(point) })
+    }
+
+    @Test("mirrorAxis vs mirrored(acrossLine:direction:)")
+    func mirrorAxisParity() {
+        let origin = SIMD2<Double>(0, 2)
+        let direction = SIMD2<Double>(1, 2)
+        checkParity("mirrorAxis",
+                    copy: { $0.mirrored(acrossLine: origin, direction: direction) },
+                    mutate: { $0.mirrorAxis(origin: origin, direction: direction) })
+    }
+}
+// buildTrsf2D's default branch (a selector outside 0...4) has no test: TransformType2D admits
+// only the five valid values, and test targets link OCCTSwift alone, so nothing here can call
+// OCCTCurve2DTransform with a raw selector.
+
+// Parity alone is not enough once the two families share one builder: a defect inside
+// buildTrsf2D moves both families identically, so a parity assertion still holds while the
+// geometry is wrong. Injecting "scale about the origin, ignoring the centre" into buildTrsf2D
+// leaves every test in the suite above green. These tests are the other half: each transform
+// checked against coordinates computed here, in Swift, with no bridge call in the expectation.
+@Suite("Curve2D Transform Absolute Geometry (#478)")
+struct Issue478Curve2DTransformGeometryTests {
+
+    private static let p0 = SIMD2<Double>(3, -1)
+    private static let p1 = SIMD2<Double>(11, 4)
+
+    private static func segment() -> Curve2D? { Curve2D.segment(from: p0, to: p1) }
+
+    /// Endpoints of the curve, read at its own domain bounds.
+    private func ends(_ curve: Curve2D) -> (SIMD2<Double>, SIMD2<Double>) {
+        let d = curve.domain
+        return (curve.point(at: d.lowerBound), curve.point(at: d.upperBound))
+    }
+
+    private func expectClose(_ got: SIMD2<Double>, _ want: SIMD2<Double>,
+                             _ label: String, tolerance: Double = 1e-9) {
+        #expect(abs(got.x - want.x) < tolerance, "\(label): x \(got.x) expected \(want.x)")
+        #expect(abs(got.y - want.y) < tolerance, "\(label): y \(got.y) expected \(want.y)")
+    }
+
+    /// Applies `expected` to both endpoints and checks the in-place and immutable families
+    /// against it independently, so a defect in the shared builder cannot hide behind parity.
+    private func checkAgainstOracle(_ label: String,
+                                    expected: (SIMD2<Double>) -> SIMD2<Double>,
+                                    copy: (Curve2D) -> Curve2D?,
+                                    mutate: (Curve2D) -> Bool) {
+        guard let mutated = Self.segment(), let source = Self.segment() else {
+            Issue.record("\(label): could not build the segment fixture")
+            return
+        }
+        guard let copied = copy(source) else {
+            Issue.record("\(label): the immutable call returned nil")
+            return
+        }
+        #expect(mutate(mutated), "\(label): the in-place call failed")
+
+        let (ma, mb) = ends(mutated)
+        let (ca, cb) = ends(copied)
+        expectClose(ma, expected(Self.p0), "\(label)/in-place start")
+        expectClose(mb, expected(Self.p1), "\(label)/in-place end")
+        expectClose(ca, expected(Self.p0), "\(label)/immutable start")
+        expectClose(cb, expected(Self.p1), "\(label)/immutable end")
+    }
+
+    @Test("translation moves both endpoints by the delta")
+    func translateGeometry() {
+        let delta = SIMD2<Double>(3, -2.5)
+        checkAgainstOracle("translate",
+                           expected: { $0 + delta },
+                           copy: { $0.translated(by: delta) },
+                           mutate: { $0.translate(dx: delta.x, dy: delta.y) })
+    }
+
+    @Test("rotation turns both endpoints about the centre")
+    func rotateGeometry() {
+        let centre = SIMD2<Double>(7, 5)
+        let angle = Double.pi / 3
+        checkAgainstOracle("rotate",
+                           expected: { p in
+                               let d = p - centre
+                               return SIMD2(centre.x + d.x * cos(angle) - d.y * sin(angle),
+                                            centre.y + d.x * sin(angle) + d.y * cos(angle))
+                           },
+                           copy: { $0.rotated(around: centre, angle: angle) },
+                           mutate: { $0.rotate(center: centre, angle: angle) })
+    }
+
+    // The construction that changed in #478. Scaling about a centre away from the origin is
+    // what separates a correct gp_Trsf2d from one that scales about (0, 0).
+    @Test("scale moves both endpoints away from the centre, not the origin")
+    func scaleGeometry() {
+        let centre = SIMD2<Double>(12.5, -6.25)
+        let factor = 2.5
+        checkAgainstOracle("scale",
+                           expected: { centre + (($0 - centre) * factor) },
+                           copy: { $0.scaled(from: centre, factor: factor) },
+                           mutate: { $0.scale(center: centre, factor: factor) })
+    }
+
+    @Test("a negative scale factor reflects through the centre")
+    func negativeScaleGeometry() {
+        let centre = SIMD2<Double>(12.5, -6.25)
+        checkAgainstOracle("scale(-1)",
+                           expected: { centre + (($0 - centre) * -1.0) },
+                           copy: { $0.scaled(from: centre, factor: -1) },
+                           mutate: { $0.scale(center: centre, factor: -1) })
+    }
+
+    @Test("point mirror reflects both endpoints through the point")
+    func mirrorPointGeometry() {
+        let point = SIMD2<Double>(4, 4)
+        checkAgainstOracle("mirrorPoint",
+                           expected: { (point * 2.0) - $0 },
+                           copy: { $0.mirrored(acrossPoint: point) },
+                           mutate: { $0.mirrorPoint(point) })
+    }
+
+    @Test("axis mirror reflects both endpoints across the line")
+    func mirrorAxisGeometry() {
+        let origin = SIMD2<Double>(0, 2)
+        let direction = SIMD2<Double>(1, 2)
+        let len = (direction.x * direction.x + direction.y * direction.y).squareRoot()
+        let unit = SIMD2<Double>(direction.x / len, direction.y / len)
+        checkAgainstOracle("mirrorAxis",
+                           expected: { p in
+                               let d = p - origin
+                               let along = d.x * unit.x + d.y * unit.y
+                               // reflection = 2 * projection onto the axis, minus the vector
+                               return origin + ((unit * (2 * along)) - d)
+                           },
+                           copy: { $0.mirrored(acrossLine: origin, direction: direction) },
+                           mutate: { $0.mirrorAxis(origin: origin, direction: direction) })
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -206,6 +206,70 @@ separately. The 3D equivalents are unsurveyed, as #514 noted.
 build with every guard stripped back out: the 10 rejection tests fail, and the 8 that pin valid
 input (including "a hyperbola may have minor > major" and the coefficient order) still pass.
 
+#### The null-handle guard, swept across the whole geometry-wrapper surface (#478)
+
+#416 added the missing `IsNull()` guard to `OCCTCurve3DTransform` and #488 to
+`OCCTSurfaceTransform`; #478 asked whether the same shape existed elsewhere rather than fixing a
+third site alone. It did, in **14 bridge functions**, found by walking every function that takes an
+`OCCTCurve3DRef` / `OCCTCurve2DRef` / `OCCTSurfaceRef` and dereferences the handle it carries:
+
+| file | functions |
+|---|---|
+| `OCCTBridge_Curve3D.mm` | `StartPoint`, `EndPoint`, `Reverse`, `Copy`, `Period`, `FirstParameter`, `LastParameter` |
+| `OCCTBridge_Geom2d.mm` | `Reverse`, `Copy`, `Transform` |
+| `OCCTBridge_Surface.mm` | `Bounds`, `Copy`, `UPeriod`, `VPeriod` |
+
+Each checked the wrapper pointer and then dereferenced the `Handle` inside it. Their own siblings,
+in the same files, check both. `OCCTCurve3DStartPoint` and `OCCTCurve3DEndPoint` had no guard at
+all, not even the wrapper. All 14 now open with `if (!x || x->handle.IsNull())`. These are
+uncatchable: the enclosing `catch (...)` cannot intercept a signal, and the kernel's own
+`Standard_NullObject` preconditions are compiled out of this `No_Exception` build.
+
+**Still latent, and now measured rather than assumed.** All **228** sites that bind a handle into an
+`OCCTCurve3D` / `OCCTCurve2D` / `OCCTSurface` wrapper were classified:
+
+| how the handle is obtained | sites |
+|---|---|
+| a local the same function already `IsNull()`-checked | 97 |
+| a maker result behind `IsDone()` | 58 |
+| `new Geom_*` / `new GeomEval_*` / `new Bisector_*` (never null) | 50 |
+| a `Copy()` / `Reversed()` down-cast | 18 |
+| OCCT contract, built from an input already checked | 5 |
+
+The last five are `GeomConvert_BSplineCurveToBezierCurve::Arc` (twice),
+`GeomConvert_CompCurveToBSplineCurve::BSplineCurve`, `Geom2dConvert_ApproxArcsSegments::GetResult`
+and `Geom_TrimmedCurve::BasisCurve`: each is constructed from a handle the caller checked, so none
+can return null there, but that rests on the class's contract rather than a check at the site. No
+bridge call hands back a wrapper carrying a null handle, so nothing here closes a reachable crash.
+The cost asymmetry is the argument: one condition against a SIGSEGV.
+
+The sweep also found a **second, larger class it does not fix**: 49 functions guard the wrapper and
+then pass the unchecked handle to an OCCT API that dereferences it internally, 28 of them without
+even the wrapper check (`Geom2dAdaptor_Curve adaptor(c->curve)`, `new Geom_TrimmedCurve(basis->curve,
+...)`, and so on). Same crash, one hop further out, equally latent. Filed separately rather than
+folded in here.
+
+**Curve2D's two transform families now share one `buildTrsf2D`**, which is why its dispatcher had
+drifted in the first place. It was the last of the three geometry types still duplicating the
+construction, after `Curve3D` (#416) and `Surface` (#488). The five immutable functions
+(`OCCTCurve2DTranslate`, `Rotate`, `Scale`, `MirrorAxis`, `MirrorPoint`) reached it through
+`Geom2d_Geometry`'s per-operation convenience methods while the in-place `OCCTCurve2DTransform`
+built its own `gp_Trsf2d`, composing the scale case by hand as
+`SetScaleFactor(S)` + `SetTranslationPart(C * (1 - S))` where the other family used
+`gp_Trsf2d::SetScale(C, S)`. Verified equivalent before switching, over factors
+`{2.5, 0.25, 1, -1, -3, 0, 1e-9, 1e9}` against three centres including `(1e6, 1e-6)`: identical
+scale factor, identical translation part, identical transformed coordinates, to the bit. They
+disagree only on the internal `gp_TrsfForm` tag at `S = 1` and `S = -1`, which is a dispatch hint,
+not a result.
+
+Two new suites in `Tests/OCCTGeom2dTests`, because one is not enough. `Issue478Curve2DTransform`
+`ParityTests` holds the two families together across all five kinds, on a segment and on a Bezier.
+`Issue478Curve2DTransformGeometryTests` checks each transform against coordinates computed in
+Swift, with no bridge call in the expectation. Both were run against injected defects: a
+one-family drift fails the parity suite, while a defect inside the shared `buildTrsf2D` moves both
+families identically and leaves the parity suite entirely green, failing only the geometry suite.
+A parity assertion stops being evidence the moment the thing it compares becomes shared.
+
 #### One pipe shell, and the sweep mode it was quietly discarding (#503)
 
 Four bridge functions each built their own single-profile `BRepOffsetAPI_MakePipeShell`, and each


### PR DESCRIPTION
Closes #478.

## What the issue asked for

#478's headline fix, the missing `IsNull()` guard on `OCCTSurfaceTransform`, **had already landed**
via #488 (PR #517) on this branch. What was left is the part the issue asked for and #488 did not
do: *"worth a sweep for the same shape across the other in-place dispatchers rather than fixing
this one site alone."*

## The sweep

Walked every bridge function taking an `OCCTCurve3DRef` / `OCCTCurve2DRef` / `OCCTSurfaceRef` and
dereferencing the handle it carries. **14 sites** guard the wrapper pointer and not the handle,
while their own siblings in the same file guard both:

| file | functions |
|---|---|
| `OCCTBridge_Curve3D.mm` | `StartPoint`, `EndPoint`, `Reverse`, `Copy`, `Period`, `FirstParameter`, `LastParameter` |
| `OCCTBridge_Geom2d.mm` | `Reverse`, `Copy`, `Transform` |
| `OCCTBridge_Surface.mm` | `Bounds`, `Copy`, `UPeriod`, `VPeriod` |

`OCCTCurve3DStartPoint` and `OCCTCurve3DEndPoint` had no guard at all, not even the wrapper. All 14
now open with `if (!x || x->handle.IsNull())`. These are uncatchable: `catch (...)` cannot intercept
a signal, and the kernel's own preconditions are compiled out of this `No_Exception` build.

## Still latent, and now measured rather than assumed

#478 filed this as latent on the grounds that no caller is *known* to produce a wrapper with a null
handle. Rather than take that on trust, all **228** sites that bind a handle into one of these
wrappers were classified:

| how the handle is obtained | sites |
|---|---|
| a local the same function already `IsNull()`-checked | 97 |
| a maker result behind `IsDone()` | 58 |
| `new Geom_*` / `new GeomEval_*` / `new Bisector_*` (never null) | 50 |
| a `Copy()` / `Reversed()` down-cast | 18 |
| OCCT contract, built from an input already checked | 5 |

No bridge call hands back a wrapper carrying a null handle. So this closes no reachable crash; the
argument is the cost asymmetry, one condition against a SIGSEGV.

## Curve2D's two transform families now share one builder

Which is why its dispatcher had drifted in the first place. `Curve2D` was the last of the three
geometry types still duplicating the transform construction, after `Curve3D` (#416) and `Surface`
(#488).

The scale case is the only one whose construction changes. The dispatcher composed it by hand as
`SetScaleFactor(S)` + `SetTranslationPart(C * (1 - S))`, where the immutable family reached
`gp_Trsf2d::SetScale(C, S)` through `Geom2d_Geometry::Scale`. Verified equivalent with a ground
truth C++ test before switching, over factors `{2.5, 0.25, 1, -1, -3, 0, 1e-9, 1e9}` against three
centres including `(1e6, 1e-6)`: identical `ScaleFactor()`, identical `TranslationPart()`, identical
transformed coordinates, to the bit. They differ only in the internal `gp_TrsfForm` tag at `S = 1`
and `S = -1`, which is a dispatch hint, not a result.

## Two test suites, because one is not enough

This is the part worth reading. `Issue478Curve2DTransformParityTests` holds the two families
together across all five transform kinds, on a segment and on a Bezier. `Issue478Curve2DTransform
GeometryTests` checks each transform against coordinates computed in Swift, with no bridge call in
the expectation.

Both were run against injected defects, and the result changed the design:

- a defect confined to **one** family (`OCCTCurve2DTranslate` given a wrong delta) fails the parity
  suite, 14 issues, and the geometry suite;
- a defect inside the **shared** `buildTrsf2D` (scale about the origin, ignoring the centre) leaves
  the parity suite **entirely green** and fails only the geometry suite.

A parity assertion stops being evidence the moment the thing it compares becomes shared. The parity
suite alone, which is the pattern #416 and #488 both used, would have shipped that defect. Worth
carrying back to those two suites in a follow-up.

## Also filed

The sweep turned up a second, larger class this PR does not fix: **49 functions** that guard the
wrapper and then pass the unchecked handle to an OCCT API which dereferences it internally, 28 of
them without even the wrapper check. `Geom2dAdaptor_Curve::load` in the pinned p1 source has no null
precondition at all, so that one is an unconditional dereference in every build configuration.
Filed as #556 rather than folded in here.

## Verification

- Ground truth C++ test against the pinned xcframework for the `gp_Trsf2d` equivalence: pass.
- The audit re-run after the fix reports 0 remaining sites.
- `swift test`: **4854 tests, all passing**.
- `Scripts/count-operations.py`: 4290, README and API_REFERENCE both matching (no public API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
