### PR TITLE
fix(#481): report every knot split, not the first hundred

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -9103,7 +9103,9 @@ void OCCTGeomFillNSectionsInfo(
 /// @param continuityOrder Continuity level to check (0=C0, 1=C1, 2=C2)
 /// @param outIndices Output array of split knot indices
 /// @param maxIndices Maximum number of indices to write
-/// @return Number of split knot indices written
+/// @return Number of split knot indices found (true count, even if writing was truncated
+///   by maxIndices), or -1 on failure. #481: was the written count, which capped callers
+///   at their first-pass buffer size; matches OCCTLawBSplineKnotSplitParams below.
 int32_t OCCTLawBSplineKnotSplitting(OCCTLawFunctionRef _Nonnull law,
     int32_t continuityOrder,
     int32_t* _Nonnull outIndices, int32_t maxIndices);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -549,27 +549,36 @@ bool occtDefeaturingFacesFromShapes(const OCCTShape* const* faces, int32_t faceC
 bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Shape& shape,
                           const TopTools_ListOfShape& facesToRemove, TopoDS_Shape& outResult);
 
-// === #403: shared BSpline knot-split-to-parameter conversion ===
+// === #403/#481: shared BSpline knot-splitting buffer contract ===
 //
-// Curve3D.continuityBreaks, LawFunction.knotSplitParameters, and Surface.knotSplitting
-// each wrap a different OCCT *KnotSplitting analyzer (GeomConvert_BSplineCurveKnotSplitting,
-// Law_BSplineKnotSplitting, GeomConvert_BSplineSurfaceKnotSplitting -- the last one calling
-// this twice, once per parametric direction) but all three reduce to the identical loop:
-// walk the N computed split points, convert each one's knot-table index to a real
-// parameter value, write up to maxParams of them, and report the true split count even
-// when writing was truncated (so a caller can always retry with a bigger buffer).
+// Curve3D.continuityBreaks, LawFunction.knotSplitting, LawFunction.knotSplitParameters and
+// Surface.knotSplitting each wrap a different OCCT *KnotSplitting analyzer
+// (GeomConvert_BSplineCurveKnotSplitting, Law_BSplineKnotSplitting, and
+// GeomConvert_BSplineSurfaceKnotSplitting, the last one calling this twice, once per
+// parametric direction) but all reduce to the identical loop: walk the N computed split
+// points, write up to maxOut of them into the caller's buffer, and report the TRUE split
+// count even when writing was truncated, so a caller that came up short can retry at the
+// size it was just told. #481: LawFunction.knotSplitting was the one that returned the
+// written count instead, silently capping itself at its Swift caller's first-pass buffer.
 //
-// splitIndexAt(i) returns the underlying knot-table index for split i (1-based, matching
-// every *KnotSplitting class's own SplitValue/USplitValue/VSplitValue numbering);
-// knotAt(index) converts that knot-table index to an actual parameter value.
+// valueAt(i) produces split i's value (1-based, matching every *KnotSplitting class's own
+// SplitValue/USplitValue/VSplitValue numbering).
+template <class T, class ValueAt>
+int32_t occtWriteKnotSplits(int32_t nbSplits, ValueAt valueAt, T* outValues, int32_t maxOut) {
+    int32_t count = std::min(nbSplits, maxOut);
+    for (int32_t i = 0; i < count; i++) {
+        outValues[i] = valueAt(i + 1);
+    }
+    return nbSplits;
+}
+
+// The parameter-valued form of the above: splitIndexAt(i) returns the underlying knot-table
+// index for split i, and knotAt(index) converts that index to an actual parameter value.
 template <class SplitIndexAt, class KnotAt>
 int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, KnotAt knotAt,
                                   double* outParams, int32_t maxParams) {
-    int32_t count = std::min(nbSplits, maxParams);
-    for (int32_t i = 0; i < count; i++) {
-        outParams[i] = knotAt(splitIndexAt(i + 1));
-    }
-    return nbSplits;
+    return occtWriteKnotSplits<double>(nbSplits,
+        [&](int32_t i) { return knotAt(splitIndexAt(i)); }, outParams, maxParams);
 }
 
 // === #399/#411/#487: conic dimension preconditions ===

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -5830,30 +5830,31 @@ OCCTShapeRef _Nullable OCCTBOPAlgoSection(const OCCTShapeRef _Nonnull * _Nonnull
 // MARK: - Law_BSplineKnotSplitting + Law_Composite (v0.68)
 // --- Law_BSplineKnotSplitting ---
 
+// #481: reports the true split count even when maxIndices truncated the write, and fails
+// with -1, matching OCCTLawBSplineKnotSplitParams below in both respects. The two wrap the
+// same analyzer over the same law, so a caller pairing them must be able to size a retry off
+// either one. Returning the written count instead capped LawFunction.knotSplitting at its
+// caller's first-pass buffer with nothing to signal that anything had been dropped.
 int32_t OCCTLawBSplineKnotSplitting(OCCTLawFunctionRef law,
     int32_t continuityOrder,
     int32_t* outIndices, int32_t maxIndices)
 {
+    if (!law || !outIndices || maxIndices <= 0) return -1;
     try {
         auto* wrapper = reinterpret_cast<OCCTLawFunction*>(law);
         // The law must be a BSpline-based law (Law_BSpFunc or similar)
         Handle(Law_BSpFunc) bspFunc = Handle(Law_BSpFunc)::DownCast(wrapper->law);
-        if (bspFunc.IsNull()) return 0;
+        if (bspFunc.IsNull()) return -1;
 
         Handle(Law_BSpline) bspl = bspFunc->Curve();
-        if (bspl.IsNull()) return 0;
+        if (bspl.IsNull()) return -1;
 
         Law_BSplineKnotSplitting splitter(bspl, continuityOrder);
-        int nb = splitter.NbSplits();
-        int count = std::min((int)maxIndices, nb);
-        NCollection_Array1<int> splits(1, nb);
-        splitter.Splitting(splits);
-        for (int i = 0; i < count; i++) {
-            outIndices[i] = (int32_t)splits(i + 1);
-        }
-        return (int32_t)count;
+        return occtWriteKnotSplits<int32_t>(splitter.NbSplits(),
+            [&](int32_t i) { return (int32_t)splitter.SplitValue(i); },
+            outIndices, maxIndices);
     } catch (...) {
-        return 0;
+        return -1;
     }
 }
 

--- a/Sources/OCCTSwift/LawFunction.swift
+++ b/Sources/OCCTSwift/LawFunction.swift
@@ -126,13 +126,34 @@ public final class LawFunction: @unchecked Sendable {
     /// `bounds`, since this API exposes no way to read that knot table back. See
     /// `knotSplitParameters(continuityOrder:)` for the actual parameter values (#403).
     ///
+    /// ```swift
+    /// let indices = law.knotSplitting(continuityOrder: 2)
+    /// let params  = law.knotSplitParameters(continuityOrder: 2)
+    /// // Same analyzer over the same law: indices[i] is the knot-table index of params[i],
+    /// // so the two always agree on count, however many splits the law has (#481).
+    /// ```
+    ///
     /// - Parameter continuityOrder: Continuity level (0=C0, 1=C1, 2=C2)
     /// - Returns: Array of knot indices where continuity breaks, or empty array
     public func knotSplitting(continuityOrder: Int = 2) -> [Int] {
-        let maxIndices: Int32 = 100
-        var indices = [Int32](repeating: 0, count: Int(maxIndices))
-        let count = OCCTLawBSplineKnotSplitting(handle, Int32(continuityOrder), &indices, maxIndices)
-        return (0..<Int(count)).map { Int(indices[$0]) }
+        // Same retry-on-truncation pattern as knotSplitParameters below: the bridge always
+        // reports the true split count even when it writes fewer, so one retry sized to
+        // that count is always enough. #481: this used to keep whatever fitted in a fixed
+        // 100-entry buffer, so a law with more splits than that reported exactly 100 and
+        // disagreed with its sibling about how many splits the law has.
+        func read(capacity: Int32) -> (count: Int32, indices: [Int32]) {
+            var indices = [Int32](repeating: 0, count: Int(capacity))
+            let count = OCCTLawBSplineKnotSplitting(handle, Int32(continuityOrder), &indices, capacity)
+            return (count, indices)
+        }
+
+        var (count, indices) = read(capacity: 100)
+        guard count >= 0 else { return [] }
+        if count > 100 {
+            (count, indices) = read(capacity: count)
+            guard count >= 0 else { return [] }
+        }
+        return indices.prefix(Int(count)).map(Int.init)
     }
 
     /// Parameter values (not raw knot indices) at which continuity drops below `continuityOrder`.

--- a/Tests/OCCTCurveTests/Issue481LawKnotSplittingTruncationTests.swift
+++ b/Tests/OCCTCurveTests/Issue481LawKnotSplittingTruncationTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #481: `LawFunction.knotSplitting` read into a fixed 100-entry buffer and returned however
+/// many the bridge had written, so a law with more than 100 splits silently reported exactly
+/// 100. Its sibling `knotSplitParameters` (same `Law_BSplineKnotSplitting` analyzer, same
+/// law, added alongside it in #403) reads the true count and retries at that size, so the
+/// two disagreed on how many splits the law has. Same defect and same fix as
+/// `Curve3D.continuityBreaks` (#398) and `Surface.knotSplitting` (#403).
+@Suite("LawFunction knot splitting truncation (#481)")
+struct Issue481LawKnotSplittingTruncationTests {
+
+    /// Degree-3 BSpline law whose every interior knot has multiplicity 3, so continuity there
+    /// is 3-3=0 and every knot is a split at C1 or above. `knotCount` knots in, `knotCount`
+    /// splits out, which is the cheapest way to push past the old 100-entry buffer.
+    private func lawWithSplits(knotCount: Int) -> LawFunction? {
+        let degree = 3
+        let knots = (0..<knotCount).map { Double($0) }
+        var mults = [Int32](repeating: 3, count: knotCount)
+        mults[0] = Int32(degree + 1)
+        mults[knotCount - 1] = Int32(degree + 1)
+        // Non-periodic BSpline: nbPoles == sum(multiplicities) - degree - 1.
+        let poleCount = Int(mults.reduce(0, +)) - degree - 1
+        let poles = (0..<poleCount).map { Double($0 % 7) }
+        return LawFunction.bspline(poles: poles, knots: knots, multiplicities: mults, degree: degree)
+    }
+
+    @Test("Index and parameter forms agree past the old 100-entry buffer")
+    func indexAndParameterCountsAgreeWhenLarge() {
+        guard let law = lawWithSplits(knotCount: 150) else {
+            Issue.record("could not build the test law")
+            return
+        }
+        let indices = law.knotSplitting(continuityOrder: 2)
+        let params = law.knotSplitParameters(continuityOrder: 2)
+
+        // The property the truncation broke: both wrap the same analyzer over the same law.
+        #expect(indices.count == params.count)
+        // And the law really does have more splits than the old fixed buffer could hold,
+        // so the agreement above is not vacuous.
+        #expect(indices.count > 100)
+        #expect(indices.count == 150)
+    }
+
+    @Test("Indices stay ascending and unique across the retry boundary")
+    func indicesAreAscendingBeyondTheBuffer() {
+        guard let law = lawWithSplits(knotCount: 150) else {
+            Issue.record("could not build the test law")
+            return
+        }
+        let indices = law.knotSplitting(continuityOrder: 2)
+        // A retry that re-read into a fresh buffer but kept a stale count, or that returned
+        // the first pass's contents, would show up as a repeat or a drop here.
+        #expect(zip(indices, indices.dropFirst()).allSatisfy { $0 < $1 })
+        // Every knot of this law is a split, so the indices run 1...knotCount: the last one
+        // is the law's last knot, not wherever the first pass happened to stop.
+        #expect(indices.first == 1)
+        #expect(indices.last == 150)
+    }
+
+    @Test("Indices below the buffer size are unchanged")
+    func smallLawIsUnaffected() {
+        guard let law = lawWithSplits(knotCount: 12) else {
+            Issue.record("could not build the test law")
+            return
+        }
+        let indices = law.knotSplitting(continuityOrder: 2)
+        let params = law.knotSplitParameters(continuityOrder: 2)
+        #expect(indices.count == 12)
+        #expect(indices.count == params.count)
+    }
+
+    @Test("Non-BSpline-based law still returns empty, not a crash")
+    func nonBSplineLawReturnsEmptyIndices() {
+        guard let law = LawFunction.linear(from: 0, to: 1) else {
+            Issue.record("could not build the test law")
+            return
+        }
+        #expect(law.knotSplitting(continuityOrder: 1).isEmpty)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1516,6 +1516,35 @@ and a "no law on constant edges" throw on the next.
 
 Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
 
+#### Fix: `LawFunction.knotSplitting` reported at most 100 splits, whatever the law had (#481)
+
+`LawFunction.knotSplitting(continuityOrder:)` read into a fixed 100-entry buffer and returned
+however many entries came back, so a law with more splits than that reported exactly 100 with
+nothing to say the rest had been dropped. Its sibling `knotSplitParameters(continuityOrder:)`,
+added alongside it in #403 over the same `Law_BSplineKnotSplitting` analyzer and the same law,
+reads the true count and retries at that size. The two therefore disagreed about how many splits
+a law has: measured on a degree-3 law with 150 knots of multiplicity 3, `knotSplitting` returned
+100 indices and `knotSplitParameters` returned 150 parameters.
+
+The issue's proposed fix, applying the sibling's read-then-retry in Swift, could not work on its
+own. `OCCTLawBSplineKnotSplitting` returned `min(maxIndices, nbSplits)`, the count it had
+*written*, so at a 100-entry first pass a truncated result is indistinguishable from a law with
+exactly 100 splits and there is nothing to size a retry from. The bridge function now reports the
+true split count even when the write was truncated, and fails with `-1`, matching
+`OCCTLawBSplineKnotSplitParams` in both respects. That is a **C-layer contract change**: a direct
+caller of the bridge that treated the return value as "entries written" now needs to clamp it, and
+one that treated `0` as failure now sees `-1`. `OCCTBridge` is not an SPM product, so no package
+outside this repo can be that caller.
+
+Both bridge functions now share one `occtWriteKnotSplits` helper, generalised from #403's
+`occtWriteKnotSplitParams` (which is now a thin wrapper over it), so the two cannot drift apart on
+their truncation contract again. This is the same defect and the same fix as
+`Curve3D.continuityBreaks` (#398, a fixed 256-entry buffer) and `Surface.knotSplitting` (#403).
+
+`Issue481LawKnotSplittingTruncationTests` (`Tests/OCCTCurveTests`), 4 tests, run against the
+unmodified bridge first: the count-agreement test failed at 100 versus 150, which is the property
+the truncation broke.
+
 ---
 
 ## Release History

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -793,11 +793,22 @@ public func knotSplitting(continuityOrder: Int = 2) -> [Int]
 
 Only works on BSpline-based law functions created via `bspline(poles:knots:multiplicities:degree:)`.
 Returns raw indices into the law's own knot table, not directly usable against `value(at:)` or
-`bounds` — see `knotSplitParameters(continuityOrder:)` for the parameter-value form.
+`bounds`; see `knotSplitParameters(continuityOrder:)` for the parameter-value form.
+
+Every split is returned, however many there are. **Before #481** the result was capped at 100:
+a law with more splits than that reported exactly 100, with nothing to say the rest had been
+dropped, so it disagreed with `knotSplitParameters(continuityOrder:)` (same analyzer, same law)
+about how many splits the law has.
 
 - **Parameters:** `continuityOrder` — continuity level to check (`0`=C0, `1`=C1, `2`=C2).
 - **Returns:** Array of knot indices where continuity breaks, or empty array if none or if the function is not BSpline-based.
-- **OCCT:** `Law_BSplineKnotSplitting`.
+- **OCCT:** `Law_BSplineKnotSplitting::NbSplits` / `SplitValue`.
+- **Example:**
+  ```swift
+  let indices = law.knotSplitting(continuityOrder: 2)
+  let params  = law.knotSplitParameters(continuityOrder: 2)
+  // indices[i] is the knot-table index of params[i], so the two always agree on count
+  ```
 
 ---
 


### PR DESCRIPTION
`LawFunction.knotSplitting(continuityOrder:)` read into a fixed 100-entry buffer and returned
however many entries came back, so a law with more splits than that reported exactly 100 with
nothing to say the rest had been dropped. Its sibling `knotSplitParameters(continuityOrder:)`,
added alongside it in #403 over the same `Law_BSplineKnotSplitting` analyzer and the same law,
reads the true count and retries at that size. The two therefore disagreed about how many splits
a law has: measured on a degree-3 law with 150 knots of multiplicity 3, `knotSplitting` returned
100 indices and `knotSplitParameters` returned 150 parameters.

## The issue's proposed fix could not work on its own

The issue says the bridge already reports the true count, so one Swift-side retry is sufficient.
It does not. `OCCTLawBSplineKnotSplitting` returned `min(maxIndices, nbSplits)`, the count it had
*written*, which is exactly what makes the truncation silent: at a 100-entry first pass, a
truncated result is indistinguishable from a law with exactly 100 splits, and there is nothing to
size a retry from. The sibling's retry works only because `OCCTLawBSplineKnotSplitParams` was
written the other way round.

So the fix is at both layers:

- **Bridge.** `OCCTLawBSplineKnotSplitting` now reports the true split count even when the write
  was truncated, and fails with `-1`, matching `OCCTLawBSplineKnotSplitParams` in both respects.
  It also gained the `!law || !outIndices || maxIndices <= 0` guard the sibling already had, and
  reads splits through `SplitValue(i)` rather than allocating an `NCollection_Array1` to hold all
  of them and then copying a prefix out.
- **Swift.** `knotSplitting` uses the same read-then-retry as `knotSplitParameters` five lines
  below it.

**C-layer contract change:** a direct caller of `OCCTLawBSplineKnotSplitting` that treated the
return value as "entries written" now needs to clamp it, and one that treated `0` as failure now
sees `-1`. `OCCTBridge` is not an SPM product, so no package outside this repo can be that caller;
the one in-repo caller is the Swift wrapper changed here.

## One helper, so they cannot drift again

Both functions now go through `occtWriteKnotSplits`, generalised from #403's
`occtWriteKnotSplitParams` (which is now a thin wrapper over it). The truncation contract lives in
one place for all four wrappers of an OCCT `*KnotSplitting` analyzer. This is the same defect and
the same fix as `Curve3D.continuityBreaks` (#398, a fixed 256-entry buffer) and
`Surface.knotSplitting` (#403).

## Tests

`Issue481LawKnotSplittingTruncationTests` (`Tests/OCCTCurveTests`), 4 tests, run against the
unmodified bridge first: the count-agreement test failed at 100 versus 150, which is the property
the truncation broke, and the two supporting assertions failed with it. After the fix all four
pass, and the post-fix `indices.last == 150` is what shows the retry really re-read the full set
rather than the first pass being padded.

The fixture is a degree-3 law whose every interior knot has multiplicity 3, so continuity there is
`3 - 3 = 0` and every knot is a split at C1 or above: `knotCount` knots in, `knotCount` splits out.
A 12-knot case pins that laws below the buffer size are unaffected, and the non-BSpline law still
returns empty rather than surfacing the new `-1`.

Full `swift test`: 4856 tests in 1347 suites, clean.

## Docs

`docs/CHANGELOG.md` (Pass 1b entry) and `docs/reference/GeometrySolvers.md`
(`knotSplitting(continuityOrder:)` now states that every split is returned, with the pairing
snippet). No operation-count or Swift-to-OCCT mapping change: nothing was added or removed.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
