### PR TITLE
fix(#480): one continuity vocabulary for the whole knot-splitting family, and the order it could not spell

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -2582,6 +2582,8 @@ OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx, double fy,
 // Conversion Extras
 OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef curve, double tolerance,
                                       int32_t continuity, int32_t maxSegments, int32_t maxDegree);
+// `continuity` is a ContinuityRange (a literal derivative order, splitting where
+// `degree - multiplicity < continuity`), not a GeomAbs_Shape. See the #480 note in OCCTBridge_Internal.h.
 int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef curve, int32_t continuity,
                                           int32_t* outKnotIndices, int32_t max);
 int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef curve, double tolerance,
@@ -5421,7 +5423,10 @@ int32_t OCCTSurfaceBSplineToBezierPatches(OCCTSurfaceRef surface,
 
 /// Find continuity break parameters in a BSpline curve
 /// @param curve3D BSpline curve reference
-/// @param continuityOrder Minimum continuity to require (0=C0, 1=C1, 2=C2)
+/// @param continuityOrder Minimum continuity to require, as a literal derivative order: a knot
+///   splits when `degree - multiplicity < continuityOrder`. Useful domain 0...degree, saturating
+///   there: a cubic with simple interior knots needs 3. See the #480 note in
+///   OCCTBridge_Internal.h. A negative order throws, which surfaces here as -1
 /// @param outParams Pre-allocated array for break parameters
 /// @param maxParams Maximum number of parameters to return
 /// @return Number of break parameters found, or -1 on failure
@@ -6717,8 +6722,10 @@ typedef struct {
 
 /// Analyze BSpline surface knot splitting at a given continuity level.
 /// @param surface BSpline surface to analyze
-/// @param uContinuity Desired U continuity (0=C0, 1=C1, 2=C2)
-/// @param vContinuity Desired V continuity (0=C0, 1=C1, 2=C2)
+/// @param uContinuity Desired U continuity, as a literal derivative order: a knot splits when
+///   `degree - multiplicity < uContinuity`. Useful domain 0...U degree, saturating there: a
+///   cubic with simple interior knots needs 3. See the #480 note in OCCTBridge_Internal.h
+/// @param vContinuity Desired V continuity, same contract against the V degree and knots
 /// @param outUParams Pre-allocated array for U split parameter values (may be NULL)
 /// @param maxUParams Capacity of outUParams
 /// @param outVParams Pre-allocated array for V split parameter values (may be NULL)
@@ -9100,7 +9107,10 @@ void OCCTGeomFillNSectionsInfo(
 // --- Law_BSplineKnotSplitting ---
 /// Find knot indices where a BSpline law drops below given continuity.
 /// @param law BSpline law function handle
-/// @param continuityOrder Continuity level to check (0=C0, 1=C1, 2=C2)
+/// @param continuityOrder Continuity level to check, as a literal derivative order: a knot
+///   splits when `degree - multiplicity < continuityOrder`. Useful domain 0...degree, saturating
+///   there: a cubic with simple interior knots needs 3. See the #480 note in
+///   OCCTBridge_Internal.h
 /// @param outIndices Output array of split knot indices
 /// @param maxIndices Maximum number of indices to write
 /// @return Number of split knot indices found (true count, even if writing was truncated
@@ -9113,7 +9123,8 @@ int32_t OCCTLawBSplineKnotSplitting(OCCTLawFunctionRef _Nonnull law,
 /// Find PARAMETER values (not knot-table indices) where a BSpline law drops below
 /// given continuity -- the law-function analogue of OCCTCurve3DBSplineKnotSplits. #403.
 /// @param law BSpline law function handle
-/// @param continuityOrder Continuity level to check (0=C0, 1=C1, 2=C2)
+/// @param continuityOrder Continuity level to check, same contract as
+///   OCCTLawBSplineKnotSplitting above
 /// @param outParams Pre-allocated array for break parameter values
 /// @param maxParams Maximum number of parameters to return
 /// @return Number of break parameters found (true count, even if writing was truncated
@@ -14565,6 +14576,10 @@ OCCTCurve2DRef _Nullable OCCTConcatenateCurves2D(OCCTCurve2DRef _Nonnull * _Nonn
                                                    int32_t count, double tolerance);
 
 // MARK: - GeomConvert_BSplineSurfaceKnotSplitting (v0.105.0)
+//
+// `continuity` throughout this section is the same ContinuityRange as OCCTSurfaceKnotSplitting
+// takes: a literal derivative order, splitting where `degree - multiplicity < continuity`, with
+// useful domain 0...degree. See the #480 note in OCCTBridge_Internal.h.
 
 /// Get number of U-direction knot splits for a BSpline surface at given continuity.
 int32_t OCCTBSplineSurfaceKnotSplitsU(OCCTSurfaceRef _Nonnull surface, int32_t continuity);
@@ -14577,6 +14592,9 @@ void OCCTBSplineSurfaceKnotSplitValues(OCCTSurfaceRef _Nonnull surface, int32_t 
                                         int32_t* _Nonnull uSplits, int32_t* _Nonnull vSplits);
 
 // MARK: - Geom2dConvert_BSplineCurveKnotSplitting (v0.105.0)
+//
+// Same ContinuityRange contract again: Geom2dConvert_BSplineCurveKnotSplitting runs the
+// identical algorithm on a 2D curve. See the #480 note in OCCTBridge_Internal.h.
 
 /// Get number of knot splits for a 2D BSpline curve at given continuity.
 int32_t OCCTBSplineCurve2dKnotSplits(OCCTCurve2DRef _Nonnull curve, int32_t continuity);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -549,6 +549,29 @@ bool occtDefeaturingFacesFromShapes(const OCCTShape* const* faces, int32_t faceC
 bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Shape& shape,
                           const TopTools_ListOfShape& facesToRemove, TopoDS_Shape& outResult);
 
+// === #480: what a knot-splitting `continuity` argument actually means ===
+//
+// Four OCCT analyzers split a BSpline at knots: GeomConvert_BSplineCurveKnotSplitting,
+// Geom2dConvert_BSplineCurveKnotSplitting, GeomConvert_BSplineSurfaceKnotSplitting (once per
+// parametric direction) and Law_BSplineKnotSplitting. All four run a byte-for-byte identical
+// algorithm, so every bridge function below shares one contract, measured against the pinned
+// kernel on 3D curves, 2D curves, laws and surfaces (identical counts in all four):
+//
+//   - The argument is a `ContinuityRange`: a literal derivative order, not a GeomAbs_Shape.
+//     It must reach OCCT as the raw integer the caller asked for. Decoding it to a GeomAbs_Shape
+//     first would be silently wrong, since GeomAbs_C3 is ordinal 5 and would split at knots the
+//     caller never asked about.
+//   - A knot splits when `degree - multiplicity(knot) < ContinuityRange`. Range 0 short-circuits
+//     to the two bracketing knots, and so does any range the whole curve already satisfies.
+//   - So the useful domain is 0...degree and it saturates there: on a cubic with simple interior
+//     knots, ranges 0, 1 and 2 all return just the two bracketing knots and range 3 returns every
+//     knot; on a degree-5 curve nothing below 5 reaches a simple interior knot. That cap is the
+//     defect #398 found on curves and #480 fixed across the rest of the family: the Swift range
+//     was documented as 0...2, which on ordinary cubic geometry is every value that does nothing.
+//   - A negative range throws Standard_RangeError. That one is an explicit `throw`, not a
+//     *_Raise_if macro, so unlike most OCCT preconditions it survives this kernel's No_Exception
+//     build (verified) and reaches the catch(...) in each bridge function below.
+//
 // === #403/#481: shared BSpline knot-splitting buffer contract ===
 //
 // Curve3D.continuityBreaks, LawFunction.knotSplitting, LawFunction.knotSplitParameters and

--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -92,8 +92,12 @@ public typealias PlateConstraintOrder = SurfaceContinuity
 /// Used wherever an operation splits, approximates or simplifies geometry against a continuity
 /// floor: ``Shape/divided(at:)``, ``Shape/bsplineRestriction(tol3d:tol2d:maxDegree:maxSegments:continuity3d:continuity2d:degreePriority:rational:)``,
 /// ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)``,
-/// ``Surface/approxWithDetails(tolerance:uContinuity:vContinuity:maxSegments:maxDegree:)`` and
-/// ``Curve3D/continuityBreaks(minContinuity:)``.
+/// ``Surface/approxWithDetails(tolerance:uContinuity:vContinuity:maxSegments:maxDegree:)``, and
+/// the whole BSpline knot-splitting family: ``Curve3D/continuityBreaks(minContinuity:)``,
+/// ``Curve2D/splitIndicesAtDiscontinuities(continuity:)``,
+/// ``Surface/knotSplitting(uContinuity:vContinuity:)``,
+/// ``LawFunction/knotSplitting(continuityOrder:)`` and
+/// ``LawFunction/knotSplitParameters(continuityOrder:)``.
 ///
 /// ```swift
 /// // Split a shape wherever it drops below C2
@@ -107,6 +111,12 @@ public typealias PlateConstraintOrder = SurfaceContinuity
 /// - Note: This is *parametric* continuity (equal derivative vectors), not the geometric
 ///   G0/G1/G2 constraint order of ``SurfaceContinuity`` (parallel tangent directions). The
 ///   two count the same way but mean different things and are not interchangeable.
+///
+/// - Note: What the strict end of the ladder can express depends on the consumer. The
+///   knot-splitting family reads the value as a literal derivative order against the geometry's
+///   own degree, so ``c3`` is exact for a cubic but is the strictest question askable of a
+///   degree-4-or-higher BSpline; the approximation family rejects anything above ``c2``
+///   outright. Each API's own doc states its measured domain (#480, #490).
 public enum ParametricContinuity: Int32, Sendable, CaseIterable {
     /// Positional continuity (C0).
     case c0 = 0

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -654,11 +654,26 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Find knot indices where a B-spline has continuity discontinuities.
-    /// - Parameter continuity: The desired continuity level to check (0=C0, 1=C1, etc.)
+    ///
+    /// Indices are 1-based into the curve's own knot table, so `bsplineKnot(index:)` turns
+    /// each one into a parameter. The first and last knots are always included, so a curve
+    /// that never drops below `continuity` reports exactly those two.
+    ///
+    /// ```swift
+    /// // A cubic 2D BSpline with simple interior knots is already C2 there, so .c3 is the
+    /// // order that reports its interior knots.
+    /// let indices = curve.splitIndicesAtDiscontinuities(continuity: .c3)
+    /// let params = indices?.map { curve.bsplineKnot(index: $0) }
+    /// ```
+    ///
+    /// - Parameter continuity: Minimum continuity to require of each arc. This is a derivative
+    ///   order, and `Geom2dConvert_BSplineCurveKnotSplitting` splits a knot only when
+    ///   `degree - multiplicity < continuity`, so the meaningful range is 0...degree and it
+    ///   saturates there (#480).
     /// - Returns: Array of knot indices where the curve drops below the requested continuity, or nil if not a B-spline.
-    public func splitIndicesAtDiscontinuities(continuity: Int = 1) -> [Int]? {
+    public func splitIndicesAtDiscontinuities(continuity: ParametricContinuity = .c1) -> [Int]? {
         var buffer = [Int32](repeating: 0, count: 256)
-        let n = Int(OCCTCurve2DSplitAtDiscontinuities(handle, Int32(continuity), &buffer, 256))
+        let n = Int(OCCTCurve2DSplitAtDiscontinuities(handle, continuity.rawValue, &buffer, 256))
         guard n > 0 else { return nil }
         return (0..<n).map { Int(buffer[$0]) }
     }

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -844,7 +844,12 @@ extension Curve3D {
     /// let breaks = bspline.continuityBreaks(minContinuity: .c3)  // + interior knots
     /// ```
     ///
-    /// - Parameter minContinuity: Minimum continuity to require of each resulting arc
+    /// - Parameter minContinuity: Minimum continuity to require of each resulting arc. This is a
+    ///   derivative order, and `GeomConvert_BSplineCurveKnotSplitting` splits a knot only when
+    ///   `degree - multiplicity < minContinuity`, so the meaningful range is 0...degree and it
+    ///   saturates there. On a degree-4-or-higher curve ``ParametricContinuity/c3`` is the
+    ///   strictest question this vocabulary can ask; `toBezierSegments()` is the dedicated API
+    ///   for the every-knot split at the far end of that ladder (#480).
     /// - Returns: Split parameters in ascending order, bounded by the curve's end knots, or
     ///   nil if the curve is not a BSpline
     public func continuityBreaks(minContinuity: ParametricContinuity = .c1) -> [Double]? {

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -8037,24 +8037,38 @@ extension Curve2D {
 
 // MARK: - GeomConvert_BSplineSurfaceKnotSplitting (v0.105.0)
 
+// `continuity` throughout both sections below is the same derivative-order ContinuityRange
+// `Surface.knotSplitting` documents: a knot splits only when `degree - multiplicity <
+// continuity`, so the meaningful range is 0...degree and it saturates there. These five
+// entry points drive the same two OCCT analyzers as `Surface.knotSplitting` and
+// `Curve2D.splitIndicesAtDiscontinuities` and differ only in what they return. #480.
+
 extension Surface {
     /// Get number of U-direction knot splits for a BSpline surface at given continuity.
-    public func bsplineKnotSplitsU(continuity: Int) -> Int {
-        Int(OCCTBSplineSurfaceKnotSplitsU(handle, Int32(continuity)))
+    ///
+    /// Same count as `knotSplitting(uContinuity:vContinuity:)`'s `uSplitCount`.
+    public func bsplineKnotSplitsU(continuity: ParametricContinuity) -> Int {
+        Int(OCCTBSplineSurfaceKnotSplitsU(handle, continuity.rawValue))
     }
 
     /// Get number of V-direction knot splits for a BSpline surface at given continuity.
-    public func bsplineKnotSplitsV(continuity: Int) -> Int {
-        Int(OCCTBSplineSurfaceKnotSplitsV(handle, Int32(continuity)))
+    ///
+    /// Same count as `knotSplitting(uContinuity:vContinuity:)`'s `vSplitCount`.
+    public func bsplineKnotSplitsV(continuity: ParametricContinuity) -> Int {
+        Int(OCCTBSplineSurfaceKnotSplitsV(handle, continuity.rawValue))
     }
 
     /// Get U and V knot split index arrays.
-    public func bsplineKnotSplitValues(continuity: Int) -> (uSplits: [Int32], vSplits: [Int32]) {
+    ///
+    /// Indices are 1-based into the surface's own U/V knot tables; `bsplineUKnot(index:)` and
+    /// `bsplineVKnot(index:)` turn them into parameters, which is what
+    /// `knotSplitting(uContinuity:vContinuity:)` returns directly.
+    public func bsplineKnotSplitValues(continuity: ParametricContinuity) -> (uSplits: [Int32], vSplits: [Int32]) {
         let nu = bsplineKnotSplitsU(continuity: continuity)
         let nv = bsplineKnotSplitsV(continuity: continuity)
         var uSplits = [Int32](repeating: 0, count: max(nu, 1))
         var vSplits = [Int32](repeating: 0, count: max(nv, 1))
-        OCCTBSplineSurfaceKnotSplitValues(handle, Int32(continuity), &uSplits, &vSplits)
+        OCCTBSplineSurfaceKnotSplitValues(handle, continuity.rawValue, &uSplits, &vSplits)
         return (Array(uSplits.prefix(nu)), Array(vSplits.prefix(nv)))
     }
 }
@@ -8063,16 +8077,21 @@ extension Surface {
 
 extension Curve2D {
     /// Get number of knot splits for a 2D BSpline curve at given continuity.
-    public func bsplineKnotSplits(continuity: Int) -> Int {
-        Int(OCCTBSplineCurve2dKnotSplits(handle, Int32(continuity)))
+    ///
+    /// Same count as `splitIndicesAtDiscontinuities(continuity:)`'s array length.
+    public func bsplineKnotSplits(continuity: ParametricContinuity) -> Int {
+        Int(OCCTBSplineCurve2dKnotSplits(handle, continuity.rawValue))
     }
 
     /// Get knot split indices for a 2D BSpline curve at given continuity.
-    public func bsplineKnotSplitValues(continuity: Int) -> [Int32] {
+    ///
+    /// The same indices `splitIndicesAtDiscontinuities(continuity:)` returns, as `[Int32]`
+    /// and empty rather than `nil` for a non-BSpline curve.
+    public func bsplineKnotSplitValues(continuity: ParametricContinuity) -> [Int32] {
         let n = bsplineKnotSplits(continuity: continuity)
         guard n > 0 else { return [] }
         var splits = [Int32](repeating: 0, count: n)
-        OCCTBSplineCurve2dKnotSplitValues(handle, Int32(continuity), &splits)
+        OCCTBSplineCurve2dKnotSplitValues(handle, continuity.rawValue, &splits)
         return splits
     }
 }

--- a/Sources/OCCTSwift/LawFunction.swift
+++ b/Sources/OCCTSwift/LawFunction.swift
@@ -127,15 +127,19 @@ public final class LawFunction: @unchecked Sendable {
     /// `knotSplitParameters(continuityOrder:)` for the actual parameter values (#403).
     ///
     /// ```swift
-    /// let indices = law.knotSplitting(continuityOrder: 2)
-    /// let params  = law.knotSplitParameters(continuityOrder: 2)
+    /// let indices = law.knotSplitting(continuityOrder: .c2)
+    /// let params  = law.knotSplitParameters(continuityOrder: .c2)
     /// // Same analyzer over the same law: indices[i] is the knot-table index of params[i],
     /// // so the two always agree on count, however many splits the law has (#481).
     /// ```
     ///
-    /// - Parameter continuityOrder: Continuity level (0=C0, 1=C1, 2=C2)
+    /// - Parameter continuityOrder: Minimum continuity to require of each arc. This is a
+    ///   derivative order, and `Law_BSplineKnotSplitting` splits a knot only when
+    ///   `degree - multiplicity < continuityOrder`, so the meaningful range is 0...degree and it
+    ///   saturates there: a cubic law with simple interior knots is already C2 at every
+    ///   interior knot, and only ``ParametricContinuity/c3`` reports them (#480).
     /// - Returns: Array of knot indices where continuity breaks, or empty array
-    public func knotSplitting(continuityOrder: Int = 2) -> [Int] {
+    public func knotSplitting(continuityOrder: ParametricContinuity = .c1) -> [Int] {
         // Same retry-on-truncation pattern as knotSplitParameters below: the bridge always
         // reports the true split count even when it writes fewer, so one retry sized to
         // that count is always enough. #481: this used to keep whatever fitted in a fixed
@@ -143,7 +147,7 @@ public final class LawFunction: @unchecked Sendable {
         // disagreed with its sibling about how many splits the law has.
         func read(capacity: Int32) -> (count: Int32, indices: [Int32]) {
             var indices = [Int32](repeating: 0, count: Int(capacity))
-            let count = OCCTLawBSplineKnotSplitting(handle, Int32(continuityOrder), &indices, capacity)
+            let count = OCCTLawBSplineKnotSplitting(handle, continuityOrder.rawValue, &indices, capacity)
             return (count, indices)
         }
 
@@ -166,19 +170,22 @@ public final class LawFunction: @unchecked Sendable {
     /// fields in #403: same "cheap to compute, previously dropped" gap.
     ///
     /// ```swift
-    /// let breaks = law.knotSplitParameters(continuityOrder: 2)
+    /// // A cubic law with simple interior knots is already C2 there, so .c3 is the order
+    /// // that reports its interior knots; anything below returns just the two end knots.
+    /// let breaks = law.knotSplitParameters(continuityOrder: .c3)
     /// // breaks are real parameters within law.bounds, usable e.g. as sweep split points
     /// ```
     ///
-    /// - Parameter continuityOrder: Continuity level (0=C0, 1=C1, 2=C2)
+    /// - Parameter continuityOrder: Minimum continuity to require of each arc, same derivative
+    ///   order contract as `knotSplitting(continuityOrder:)` (#480)
     /// - Returns: Split parameters in ascending order, or empty array if not a BSpline-based law
-    public func knotSplitParameters(continuityOrder: Int = 2) -> [Double] {
+    public func knotSplitParameters(continuityOrder: ParametricContinuity = .c1) -> [Double] {
         // Same retry-on-truncation pattern as Curve3D.continuityBreaks: the bridge always
         // reports the true split count even when it writes fewer, so one retry sized to
         // that count is always enough.
         func read(capacity: Int32) -> (count: Int32, params: [Double]) {
             var params = [Double](repeating: 0, count: Int(capacity))
-            let count = OCCTLawBSplineKnotSplitParams(handle, Int32(continuityOrder), &params, capacity)
+            let count = OCCTLawBSplineKnotSplitParams(handle, continuityOrder.rawValue, &params, capacity)
             return (count, params)
         }
 

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1700,25 +1700,41 @@ extension Surface {
     /// directions, each with its own knot vector -- so this reports counts *and* parameter
     /// locations per direction, unlike `Curve3D.continuityBreaks` (one 1D parameter list).
     ///
+    /// The result is a set of *split* parameters, not a set of defects: each direction's own
+    /// first and last knots are always included, so a direction that never drops below the
+    /// requested continuity reports exactly those two rather than nothing.
+    ///
     /// ```swift
-    /// let result = bsplineSurface.knotSplitting(uContinuity: 0, vContinuity: 0)
-    /// // result.uSplitParams / result.vSplitParams are real U/V parameters, usable to
-    /// // split the surface into same-continuity patches (e.g. via GeomConvert).
+    /// // Where does the surface actually kink?
+    /// let kinks = bsplineSurface.knotSplitting()
+    ///
+    /// // A bicubic surface with simple interior knots is already C2 at every interior knot,
+    /// // so .c3 is the order that reports them (.c0, .c1 and .c2 return only the bounds).
+    /// let all = bsplineSurface.knotSplitting(uContinuity: .c3, vContinuity: .c3)
+    /// // all.uSplitParams / all.vSplitParams are real U/V parameters, usable to split the
+    /// // surface into same-continuity patches.
     /// ```
     ///
     /// - Parameters:
-    ///   - uContinuity: Desired U continuity (0=C0, 1=C1, 2=C2)
-    ///   - vContinuity: Desired V continuity (0=C0, 1=C1, 2=C2)
+    ///   - uContinuity: Minimum continuity to require of each U patch. This is a derivative
+    ///     order, and `GeomConvert_BSplineSurfaceKnotSplitting` splits a knot only when
+    ///     `U degree - multiplicity < uContinuity`, so the meaningful range is 0...U degree and
+    ///     it saturates there. On a degree-4-or-higher surface ``ParametricContinuity/c3`` is
+    ///     the strictest question this vocabulary can ask; `toBezierPatches()` is the dedicated
+    ///     API for the every-knot split at the far end of that ladder (#480).
+    ///   - vContinuity: Minimum continuity to require of each V patch, against the V degree
+    ///     and V knots
     /// - Returns: Split counts plus the actual U/V parameter values, or all-empty/zero for
     ///   a non-BSpline surface
-    public func knotSplitting(uContinuity: Int = 1, vContinuity: Int = 1) -> KnotSplitResult {
+    public func knotSplitting(uContinuity: ParametricContinuity = .c1,
+                              vContinuity: ParametricContinuity = .c1) -> KnotSplitResult {
         // Same retry-on-truncation pattern as Curve3D.continuityBreaks: the bridge always
         // reports the true split counts even when it writes fewer, so one retry sized to
         // those counts is always enough.
         func read(uCapacity: Int32, vCapacity: Int32) -> (OCCTSurfaceKnotSplitResult, [Double], [Double]) {
             var uParams = [Double](repeating: 0, count: Int(uCapacity))
             var vParams = [Double](repeating: 0, count: Int(vCapacity))
-            let result = OCCTSurfaceKnotSplitting(handle, Int32(uContinuity), Int32(vContinuity),
+            let result = OCCTSurfaceKnotSplitting(handle, uContinuity.rawValue, vContinuity.rawValue,
                                                    &uParams, uCapacity, &vParams, vCapacity)
             return (result, uParams, vParams)
         }

--- a/Tests/OCCTCurveTests/Issue403LawKnotSplitParamsTests.swift
+++ b/Tests/OCCTCurveTests/Issue403LawKnotSplitParamsTests.swift
@@ -26,8 +26,8 @@ struct Issue403LawKnotSplitParamsTests {
             Issue.record("could not build the test law")
             return
         }
-        let indices = law.knotSplitting(continuityOrder: 2)
-        let params = law.knotSplitParameters(continuityOrder: 2)
+        let indices = law.knotSplitting(continuityOrder: .c2)
+        let params = law.knotSplitParameters(continuityOrder: .c2)
         // Same underlying Law_BSplineKnotSplitting analyzer -- must agree on how many
         // splits there are, even though one returns indices and the other parameters.
         #expect(indices.count == params.count)
@@ -40,7 +40,7 @@ struct Issue403LawKnotSplitParamsTests {
             Issue.record("could not build the test law")
             return
         }
-        let params = law.knotSplitParameters(continuityOrder: 2)
+        let params = law.knotSplitParameters(continuityOrder: .c2)
         let bounds = law.bounds
 
         if let first = params.first, let last = params.last {
@@ -59,7 +59,7 @@ struct Issue403LawKnotSplitParamsTests {
         }
         // Degree 3, multiplicity 2 at the interior knot => continuity there is 3-2=1, so
         // asking for C2 must surface it as a break, in addition to the two end knots.
-        let params = law.knotSplitParameters(continuityOrder: 2)
+        let params = law.knotSplitParameters(continuityOrder: .c2)
         #expect(params.contains { abs($0 - 0.5) < 1e-9 })
     }
 
@@ -69,6 +69,6 @@ struct Issue403LawKnotSplitParamsTests {
             Issue.record("could not build the test law")
             return
         }
-        #expect(law.knotSplitParameters(continuityOrder: 1).isEmpty)
+        #expect(law.knotSplitParameters(continuityOrder: .c1).isEmpty)
     }
 }

--- a/Tests/OCCTCurveTests/Issue480LawKnotSplitContinuityTests.swift
+++ b/Tests/OCCTCurveTests/Issue480LawKnotSplitContinuityTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #480: `LawFunction.knotSplitting`/`knotSplitParameters` took a raw `Int` documented as
+/// "0=C0, 1=C1, 2=C2" and defaulted to 2. `Law_BSplineKnotSplitting` runs the same algorithm as
+/// the curve and surface analyzers (a knot splits only when `degree - multiplicity <
+/// ContinuityRange`), so on a cubic law with simple interior knots every value the doc offered
+/// returned just the two end knots. `ParametricContinuity` makes `.c3`, the order that actually
+/// reports them, spellable.
+@Suite("Law knot-splitting continuity range (#480)")
+struct Issue480LawKnotSplitContinuityTests {
+
+    /// A BSpline law of the given degree with `interiorKnots` interior knots at multiplicity 1,
+    /// except knot `bumpAt` (1-based), which gets `bumpMult`.
+    private func bsplineLaw(degree: Int, interiorKnots: Int,
+                            bumpAt: Int = 0, bumpMult: Int = 1) -> LawFunction? {
+        var knots: [Double] = [0]
+        var mults: [Int32] = [Int32(degree + 1)]
+        for i in 1...interiorKnots {
+            knots.append(Double(i))
+            mults.append(Int32(i == bumpAt ? bumpMult : 1))
+        }
+        knots.append(Double(interiorKnots + 1))
+        mults.append(Int32(degree + 1))
+
+        let nPoles = Int(mults.reduce(0, +)) - degree - 1
+        let poles = (0..<nPoles).map { Double($0 % 4) * 1.5 }
+        return LawFunction.bspline(poles: poles, knots: knots, multiplicities: mults, degree: degree)
+    }
+
+    @Test("A cubic law with simple interior knots reports interior splits only at .c3")
+    func cubicSimpleKnotsNeedC3() throws {
+        let law = try #require(bsplineLaw(degree: 3, interiorKnots: 4))
+
+        for continuity: ParametricContinuity in [.c0, .c1, .c2] {
+            #expect(law.knotSplitParameters(continuityOrder: continuity) == [0, 5],
+                    "params at \(continuity)")
+            #expect(law.knotSplitting(continuityOrder: continuity).count == 2,
+                    "indices at \(continuity)")
+        }
+
+        #expect(law.knotSplitParameters(continuityOrder: .c3) == [0, 1, 2, 3, 4, 5])
+        #expect(law.knotSplitting(continuityOrder: .c3).count == 6)
+    }
+
+    @Test("The .c1 default reports a real kink")
+    func defaultFindsGenuineKink() throws {
+        // Multiplicity 3 on a cubic leaves continuity 0 at that knot.
+        let law = try #require(bsplineLaw(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3))
+        #expect(law.knotSplitParameters() == [0, 2, 5])
+        #expect(law.knotSplitParameters(continuityOrder: .c0) == [0, 5])
+    }
+
+    @Test("Indices and parameters describe the same splits")
+    func indicesAndParametersAgree() throws {
+        let law = try #require(bsplineLaw(degree: 3, interiorKnots: 4))
+        // Same analyzer, so the two spellings must always agree on how many splits there are.
+        for continuity in ParametricContinuity.allCases {
+            #expect(law.knotSplitting(continuityOrder: continuity).count
+                    == law.knotSplitParameters(continuityOrder: continuity).count,
+                    "at \(continuity)")
+        }
+    }
+}

--- a/Tests/OCCTCurveTests/Issue481LawKnotSplittingTruncationTests.swift
+++ b/Tests/OCCTCurveTests/Issue481LawKnotSplittingTruncationTests.swift
@@ -32,8 +32,8 @@ struct Issue481LawKnotSplittingTruncationTests {
             Issue.record("could not build the test law")
             return
         }
-        let indices = law.knotSplitting(continuityOrder: 2)
-        let params = law.knotSplitParameters(continuityOrder: 2)
+        let indices = law.knotSplitting(continuityOrder: .c2)
+        let params = law.knotSplitParameters(continuityOrder: .c2)
 
         // The property the truncation broke: both wrap the same analyzer over the same law.
         #expect(indices.count == params.count)
@@ -49,7 +49,7 @@ struct Issue481LawKnotSplittingTruncationTests {
             Issue.record("could not build the test law")
             return
         }
-        let indices = law.knotSplitting(continuityOrder: 2)
+        let indices = law.knotSplitting(continuityOrder: .c2)
         // A retry that re-read into a fresh buffer but kept a stale count, or that returned
         // the first pass's contents, would show up as a repeat or a drop here.
         #expect(zip(indices, indices.dropFirst()).allSatisfy { $0 < $1 })
@@ -65,8 +65,8 @@ struct Issue481LawKnotSplittingTruncationTests {
             Issue.record("could not build the test law")
             return
         }
-        let indices = law.knotSplitting(continuityOrder: 2)
-        let params = law.knotSplitParameters(continuityOrder: 2)
+        let indices = law.knotSplitting(continuityOrder: .c2)
+        let params = law.knotSplitParameters(continuityOrder: .c2)
         #expect(indices.count == 12)
         #expect(indices.count == params.count)
     }
@@ -77,6 +77,6 @@ struct Issue481LawKnotSplittingTruncationTests {
             Issue.record("could not build the test law")
             return
         }
-        #expect(law.knotSplitting(continuityOrder: 1).isEmpty)
+        #expect(law.knotSplitting(continuityOrder: .c1).isEmpty)
     }
 }

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -2068,7 +2068,7 @@ struct LawCompositeTests {
             knots: [0.0, 0.5, 1.0],
             multiplicities: [4, 2, 4],
             degree: 3) else { return }
-        let splits = law.knotSplitting(continuityOrder: 2)
+        let splits = law.knotSplitting(continuityOrder: .c2)
         #expect(splits.count >= 2)
     }
 }

--- a/Tests/OCCTGeom2dTests/Issue480Curve2DKnotSplitContinuityTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue480Curve2DKnotSplitContinuityTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #480: the 2D sibling of the knot-splitting family.
+/// `Curve2D.splitIndicesAtDiscontinuities` and the `bsplineKnotSplits`/`bsplineKnotSplitValues`
+/// pair all drive `Geom2dConvert_BSplineCurveKnotSplitting`, which runs the identical algorithm
+/// to its 3D, surface and law counterparts: a knot splits only when
+/// `degree - multiplicity < ContinuityRange`. All three took a raw `Int` documented as starting
+/// at C0 and stopping at C2, the range that does nothing on ordinary cubic geometry.
+@Suite("Curve2D knot-splitting continuity range (#480)")
+struct Issue480Curve2DKnotSplitContinuityTests {
+
+    /// A 2D BSpline of the given degree with `interiorKnots` interior knots at multiplicity 1,
+    /// except knot `bumpAt` (1-based), which gets `bumpMult`.
+    private func bsplineCurve(degree: Int, interiorKnots: Int,
+                              bumpAt: Int = 0, bumpMult: Int = 1) -> Curve2D? {
+        var knots: [Double] = [0]
+        var mults: [Int32] = [Int32(degree + 1)]
+        for i in 1...interiorKnots {
+            knots.append(Double(i))
+            mults.append(Int32(i == bumpAt ? bumpMult : 1))
+        }
+        knots.append(Double(interiorKnots + 1))
+        mults.append(Int32(degree + 1))
+
+        let nPoles = Int(mults.reduce(0, +)) - degree - 1
+        let poles = (0..<nPoles).map { SIMD2<Double>(Double($0), Double($0 % 3)) }
+        return Curve2D.bspline(poles: poles, knots: knots, multiplicities: mults, degree: degree)
+    }
+
+    @Test("A cubic 2D BSpline with simple interior knots reports interior splits only at .c3")
+    func cubicSimpleKnotsNeedC3() throws {
+        let curve = try #require(bsplineCurve(degree: 3, interiorKnots: 4))
+
+        for continuity: ParametricContinuity in [.c0, .c1, .c2] {
+            #expect(curve.splitIndicesAtDiscontinuities(continuity: continuity) == [1, 6],
+                    "indices at \(continuity)")
+        }
+
+        // Knot indices are 1-based into the curve's own knot table, which here is 0...5.
+        let atC3 = try #require(curve.splitIndicesAtDiscontinuities(continuity: .c3))
+        #expect(atC3 == [1, 2, 3, 4, 5, 6])
+        #expect(atC3.map { curve.bsplineKnot(index: $0) } == [0, 1, 2, 3, 4, 5])
+    }
+
+    @Test("The .c1 default reports a real kink")
+    func defaultFindsGenuineKink() throws {
+        let curve = try #require(bsplineCurve(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3))
+        let defaulted = try #require(curve.splitIndicesAtDiscontinuities())
+        #expect(defaulted.map { curve.bsplineKnot(index: $0) } == [0, 2, 5])
+        #expect(curve.splitIndicesAtDiscontinuities(continuity: .c0) == [1, 6])
+    }
+
+    @Test("The v0.105 count/values spellings agree with the canonical one")
+    func alternateSpellingsAgree() throws {
+        let curve = try #require(bsplineCurve(degree: 3, interiorKnots: 4))
+        for continuity in ParametricContinuity.allCases {
+            let canonical = curve.splitIndicesAtDiscontinuities(continuity: continuity) ?? []
+            #expect(curve.bsplineKnotSplits(continuity: continuity) == canonical.count,
+                    "count at \(continuity)")
+            #expect(curve.bsplineKnotSplitValues(continuity: continuity) == canonical.map(Int32.init),
+                    "values at \(continuity)")
+        }
+    }
+}

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -769,7 +769,7 @@ struct Curve2DConvertExtrasTests {
         let joined = Curve2D.join([seg1, seg2])
         #expect(joined != nil)
         if let joined = joined {
-            let indices = joined.splitIndicesAtDiscontinuities(continuity: 2)
+            let indices = joined.splitIndicesAtDiscontinuities(continuity: .c2)
             // May or may not find C2 discontinuities depending on join method
             #expect(indices != nil)
         }
@@ -2996,10 +2996,10 @@ struct BSplineCurve2dKnotSplitTests {
     @Test func knotSplits() {
         // Create a 2D BSpline curve from interpolation
         if let c = Curve2D.interpolate(through: [SIMD2(0, 0), SIMD2(1, 1), SIMD2(2, 0), SIMD2(3, 1)]) {
-            let n = c.bsplineKnotSplits(continuity: 0)
+            let n = c.bsplineKnotSplits(continuity: .c0)
             #expect(n >= 0)
             if n > 0 {
-                let vals = c.bsplineKnotSplitValues(continuity: 0)
+                let vals = c.bsplineKnotSplitValues(continuity: .c0)
                 #expect(vals.count == n)
             }
         }

--- a/Tests/OCCTSurfaceTests/Issue403SurfaceKnotSplitParamsTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue403SurfaceKnotSplitParamsTests.swift
@@ -21,7 +21,7 @@ struct Issue403SurfaceKnotSplitParamsTests {
     @Test("Param array lengths match their own counts")
     func paramCountsMatchSplitCounts() throws {
         let bspline = try bsplineCylinder()
-        let result = bspline.knotSplitting(uContinuity: 0, vContinuity: 0)
+        let result = bspline.knotSplitting(uContinuity: .c0, vContinuity: .c0)
 
         #expect(result.uSplitParams.count == result.uSplitCount)
         #expect(result.vSplitParams.count == result.vSplitCount)
@@ -32,7 +32,7 @@ struct Issue403SurfaceKnotSplitParamsTests {
     @Test("Params are ascending and bracketed by the surface's own U/V domain")
     func paramsMatchDomain() throws {
         let bspline = try bsplineCylinder()
-        let result = bspline.knotSplitting(uContinuity: 0, vContinuity: 0)
+        let result = bspline.knotSplitting(uContinuity: .c0, vContinuity: .c0)
         let domain = bspline.domain
 
         if let uFirst = result.uSplitParams.first, let uLast = result.uSplitParams.last {
@@ -50,7 +50,7 @@ struct Issue403SurfaceKnotSplitParamsTests {
     @Test("Non-BSpline surface returns empty params, not a crash")
     func nonBSplineSurfaceReturnsEmpty() throws {
         let plane = try #require(Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)))
-        let result = plane.knotSplitting(uContinuity: 0, vContinuity: 0)
+        let result = plane.knotSplitting(uContinuity: .c0, vContinuity: .c0)
         #expect(result.uSplitCount == 0)
         #expect(result.vSplitCount == 0)
         #expect(result.uSplitParams.isEmpty)

--- a/Tests/OCCTSurfaceTests/Issue480SurfaceKnotSplitContinuityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue480SurfaceKnotSplitContinuityTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #480: `Surface.knotSplitting` took a raw `Int` documented as "0=C0, 1=C1, 2=C2", which on
+/// ordinary bicubic geometry is a list of every value that does nothing.
+/// `GeomConvert_BSplineSurfaceKnotSplitting` splits a knot only when
+/// `degree - multiplicity < ContinuityRange`, so a cubic with simple interior knots is already
+/// C2 there and ranges 0, 1 and 2 all return just the two bracketing knots. #398 established
+/// this on curves and widened `Curve3D.continuityBreaks` to `ParametricContinuity`, whose `.c3`
+/// is reachable; the surface and law siblings kept the old cap.
+///
+/// These cases pin the measured contract rather than the signature: the counts below would also
+/// catch the opposite mistake of routing the enum through a GeomAbs_Shape decoder first, since
+/// `GeomAbs_C2` is ordinal 4 and would split at every knot where `.c2` must split at none.
+@Suite("Surface knot-splitting continuity range (#480)")
+struct Issue480SurfaceKnotSplitContinuityTests {
+
+    /// A BSpline surface of the given degree in both directions, with `interiorKnots` interior
+    /// knots at multiplicity 1, except knot `bumpAt` (1-based), which gets `bumpMult`.
+    private func bsplineSurface(degree: Int, interiorKnots: Int,
+                                bumpAt: Int = 0, bumpMult: Int = 1) -> Surface? {
+        var knots: [Double] = [0]
+        var mults: [Int32] = [Int32(degree + 1)]
+        for i in 1...interiorKnots {
+            knots.append(Double(i))
+            mults.append(Int32(i == bumpAt ? bumpMult : 1))
+        }
+        knots.append(Double(interiorKnots + 1))
+        mults.append(Int32(degree + 1))
+
+        let nPoles = Int(mults.reduce(0, +)) - degree - 1
+        let poles = (0..<nPoles).map { u in
+            (0..<nPoles).map { v in
+                SIMD3<Double>(Double(u), Double(v), Double((u + v) % 3) * 0.5)
+            }
+        }
+        return Surface.bspline(poles: poles,
+                               knotsU: knots, multiplicitiesU: mults,
+                               knotsV: knots, multiplicitiesV: mults,
+                               degreeU: degree, degreeV: degree)
+    }
+
+    @Test("A bicubic surface with simple interior knots reports interior splits only at .c3")
+    func cubicSimpleKnotsNeedC3() throws {
+        let surface = try #require(bsplineSurface(degree: 3, interiorKnots: 4))
+        let bounds = surface.domain
+
+        // .c0/.c1/.c2: the surface is already C2 at every interior knot, so the only splits
+        // are the two curves bounding each direction.
+        for continuity: ParametricContinuity in [.c0, .c1, .c2] {
+            let result = surface.knotSplitting(uContinuity: continuity, vContinuity: continuity)
+            #expect(result.uSplitCount == 2, "u splits at \(continuity)")
+            #expect(result.vSplitCount == 2, "v splits at \(continuity)")
+            #expect(result.uSplitParams == [bounds.uMin, bounds.uMax])
+            #expect(result.vSplitParams == [bounds.vMin, bounds.vMax])
+        }
+
+        // .c3 is the order that reaches a simple knot on a cubic: 4 interior + 2 bounds.
+        let atC3 = surface.knotSplitting(uContinuity: .c3, vContinuity: .c3)
+        #expect(atC3.uSplitCount == 6)
+        #expect(atC3.vSplitCount == 6)
+        #expect(atC3.uSplitParams == [0, 1, 2, 3, 4, 5])
+        #expect(atC3.vSplitParams == [0, 1, 2, 3, 4, 5])
+    }
+
+    @Test("The .c1 default reports a real kink, which is why it stays the default")
+    func defaultFindsGenuineKink() throws {
+        // Multiplicity 3 on a cubic leaves continuity 3-3 = 0 at that knot: a genuine kink.
+        let surface = try #require(bsplineSurface(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3))
+
+        let defaulted = surface.knotSplitting()
+        #expect(defaulted.uSplitParams == [0, 2, 5])
+        #expect(defaulted.vSplitParams == [0, 2, 5])
+
+        // .c0 asks only for position, which the kink still satisfies.
+        #expect(surface.knotSplitting(uContinuity: .c0, vContinuity: .c0).uSplitCount == 2)
+        // .c3 still reports every interior knot, kink or not. That is a Bezier decomposition,
+        // not a discontinuity report, which is why .c3 is not the default.
+        #expect(surface.knotSplitting(uContinuity: .c3, vContinuity: .c3).uSplitCount == 6)
+    }
+
+    @Test("Each direction is asked independently")
+    func directionsAreIndependent() throws {
+        let surface = try #require(bsplineSurface(degree: 3, interiorKnots: 4))
+        let mixed = surface.knotSplitting(uContinuity: .c3, vContinuity: .c1)
+        #expect(mixed.uSplitCount == 6)
+        #expect(mixed.vSplitCount == 2)
+    }
+
+    @Test("On a degree-5 surface .c3 is the strictest question this vocabulary can ask")
+    func degreeFivePlusIsCappedAtC3() throws {
+        // Documents the measured reach limit rather than asserting it is desirable: a degree-5
+        // surface with simple interior knots is C4 there, so every order the enum can spell
+        // answers "already continuous enough". `toBezierPatches()` is the every-knot split.
+        let surface = try #require(bsplineSurface(degree: 5, interiorKnots: 4))
+        for continuity in ParametricContinuity.allCases {
+            #expect(surface.knotSplitting(uContinuity: continuity, vContinuity: continuity).uSplitCount == 2,
+                    "u splits at \(continuity)")
+        }
+        #expect(surface.toBezierPatches().count == 25)
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -2308,7 +2308,7 @@ struct SurfaceKnotSplittingTests {
         // Use trimmed cylinder (bounded) so it can convert to BSpline
         let trimCyl = try #require(Surface.trimmedCylinder(radius: 5.0, height: 10.0))
         let bspline = try #require(trimCyl.toBSpline())
-        let result = bspline.knotSplitting(uContinuity: 0, vContinuity: 0)
+        let result = bspline.knotSplitting(uContinuity: .c0, vContinuity: .c0)
         #expect(result.uSplitCount >= 1)
         #expect(result.vSplitCount >= 1)
     }
@@ -3360,7 +3360,7 @@ struct BSplineSurfaceKnotSplitTests {
         // Create a sphere surface and convert to BSpline
         if let sphere = Surface.sphere(center: .zero, radius: 5) {
             if let bsp = sphere.toBSpline() {
-                let n = bsp.bsplineKnotSplitsU(continuity: 0)
+                let n = bsp.bsplineKnotSplitsU(continuity: .c0)
                 #expect(n >= 0)
             }
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -314,6 +314,59 @@ assumed. Filed as #558 rather than widened into this fix: `maxPoints` on an adap
 capacity rather than a request, and `uSamples`/`vSamples` bound a product, so those need a contract
 decision per parameter rather than this one's ceiling applied uniformly.
 
+#### The knot-splitting continuity cap, on the four fifths of the family #398 did not reach (#480)
+
+#398 established that a knot-splitting continuity documented as `0=C0, 1=C1, 2=C2` lists every
+value that does nothing on ordinary cubic geometry: the analyzers split a knot only when
+`degree - multiplicity < ContinuityRange`, and a cubic with simple interior knots is already C2
+there. It widened `Curve3D.continuityBreaks` to `ParametricContinuity`, whose `.c3` is reachable.
+The rest of the family kept the cap, and a census by OCCT class rather than by the issue's site
+list found more of it than the issue named: **four** analyzers, **nine** public Swift entry points,
+eight still typed `Int` and still documenting the range that does nothing.
+
+All of them now take `ParametricContinuity`:
+
+| API | was | now |
+|---|---|---|
+| `Surface.knotSplitting(uContinuity:vContinuity:)` | `Int = 1, Int = 1` | `.c1, .c1` |
+| `LawFunction.knotSplitting(continuityOrder:)` | `Int = 2` | `.c1` |
+| `LawFunction.knotSplitParameters(continuityOrder:)` | `Int = 2` | `.c1` |
+| `Curve2D.splitIndicesAtDiscontinuities(continuity:)` | `Int = 1` | `.c1` |
+| `Surface.bsplineKnotSplitsU/V(continuity:)`, `Surface.bsplineKnotSplitValues(continuity:)` | `Int` | `ParametricContinuity` |
+| `Curve2D.bsplineKnotSplits(continuity:)`, `Curve2D.bsplineKnotSplitValues(continuity:)` | `Int` | `ParametricContinuity` |
+
+**Source-breaking:** callers passing integer literals need the spelled case (`0` → `.c0`). That is
+the point: the raw `Int` is what let a documented range consisting entirely of no-ops go unnoticed
+for five releases.
+
+The defaults were revisited and deliberately left at `.c1`, now uniform across the family (the two
+law methods moved from 2). Measured on a cubic with four interior knots: at `.c1` a
+multiplicity-3 knot (a genuine kink) is reported and nothing else is; at `.c3` *every* interior
+knot is reported, which is a Bezier decomposition rather than a discontinuity report. So `.c1`
+answers "where does this actually kink", which is the question a default should answer, and the
+fix for the issue is that `.c3` is now spellable, not that it is now the default.
+
+Also measured, and now documented rather than left implicit: all four analyzers
+(`GeomConvert_BSplineCurveKnotSplitting`, `Geom2dConvert_BSplineCurveKnotSplitting`,
+`GeomConvert_BSplineSurfaceKnotSplitting`, `Law_BSplineKnotSplitting`) run a byte-identical
+algorithm and agree on every count; the useful domain is `0...degree` and saturates there, so on a
+degree-5 BSpline nothing below `.c5` reaches a simple interior knot and `.c3` is the strictest
+question this vocabulary can ask (`toBezierSegments()`/`toBezierPatches()` is the dedicated API for
+the every-knot split at the far end of that ladder); and a negative range throws
+`Standard_RangeError` through an explicit `throw` rather than a `*_Raise_if` macro, so unlike most
+OCCT preconditions it survives this kernel's `No_Exception` build and reaches the bridge's
+`catch(...)`.
+
+Two doc corrections found on the way: `Surface.knotSplitting` was attributed to
+`BSplSLib::KnotSplitting`, which is not what it calls, and the bridge header still documented the
+`0=C0, 1=C1, 2=C2` range on `OCCTCurve3DBSplineKnotSplits`, the one function #398 had already
+fixed on the Swift side.
+
+New tests pin the measured contract in all three affected domains rather than the signature, so
+they also catch the opposite mistake of decoding the enum to a `GeomAbs_Shape` first: `GeomAbs_C2`
+is ordinal 4, which would split at every knot where `.c2` must split at none. Both mistakes were
+injected and confirmed to fail the new cases.
+
 #### One pipe shell, and the sweep mode it was quietly discarding (#503)
 
 Four bridge functions each built their own single-profile `BRepOffsetAPI_MakePipeShell`, and each

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -955,16 +955,25 @@ public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
 Finds knot indices where a BSpline has continuity discontinuities.
 
 ```swift
-public func splitIndicesAtDiscontinuities(continuity: Int = 1) -> [Int]?
+public func splitIndicesAtDiscontinuities(continuity: ParametricContinuity = .c1) -> [Int]?
 ```
 
-- **Parameters:** `continuity` — desired continuity level to check (0=C0, 1=C1, etc.).
+Indices are 1-based into the curve's own knot table, so `bsplineKnot(index:)` turns each one into
+a parameter. The first and last knots are always included, so a curve that never drops below
+`continuity` reports exactly those two.
+
+- **Parameters:** `continuity`: minimum continuity to require of each arc.
 - **Returns:** Array of knot indices where continuity drops below the requested level, or `nil` if not a BSpline or no discontinuities found.
-- **OCCT:** `Geom2d_BSplineCurve` knot analysis (via `OCCTCurve2DSplitAtDiscontinuities`).
+- **OCCT:** `Geom2dConvert_BSplineCurveKnotSplitting` (via `OCCTCurve2DSplitAtDiscontinuities`).
+- **Continuity range (#480):** the continuity is a *derivative order*, and a knot splits only when
+  `degree - multiplicity < continuity`, so the meaningful range is `0...degree` and it saturates
+  there. A cubic with simple interior knots is already C2 there, which means `.c0`, `.c1` and `.c2`
+  all report just the two end knots and `.c3` is the order that reports the interior ones.
 - **Example:**
   ```swift
   if let bsp = Curve2D.bspline(poles: [...], knots: [...], multiplicities: [...], degree: 3) {
-      let indices = bsp.splitIndicesAtDiscontinuities(continuity: 1)
+      let indices = bsp.splitIndicesAtDiscontinuities(continuity: .c3)
+      let params = indices?.map { bsp.bsplineKnot(index: $0) }
   }
   ```
 

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -91,7 +91,11 @@ query it exists to answer: `GeomConvert_BSplineCurveKnotSplitting` splits where
 `degree - multiplicity < ContinuityRange`, and an ordinary cubic interpolation has interior
 knots of multiplicity 1, so it is already C2 there. Measured on a degree-3 interpolated BSpline,
 ranges 0, 1 and 2 all return just the two end knots; range 3 returns five parameters.
-`ParametricContinuity.c3` is reachable and fixes that. OCCT itself accepts any range `>= 0`.
+`ParametricContinuity.c3` is reachable and fixes that. OCCT itself accepts any range `>= 0` and
+saturates at the curve's own degree, so on a degree-4-or-higher BSpline `.c3` is the strictest
+question this vocabulary can ask; `toBezierSegments()` is the dedicated API for the every-knot
+split at the far end of that ladder. The same cap and the same fix apply to the surface, law and
+2D-curve siblings (#480).
 
 Pass to `continuityBreaks(minContinuity:)` to specify the minimum required continuity across knots.
 

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -196,56 +196,67 @@ public static func concatenate(_ curves: [Curve2D], tolerance: Double = 1e-4) ->
 
 Extensions on `Surface` wrapping `GeomConvert_BSplineSurfaceKnotSplitting`.
 
+`continuity` throughout this section and the next is a `ParametricContinuity` read as a *derivative
+order*: a knot splits only when `degree - multiplicity < continuity`, so the meaningful range is
+`0...degree` and it saturates there. A cubic with simple interior knots is already C2 at every
+interior knot, which means `.c0`, `.c1` and `.c2` all report just the two bracketing knots and
+`.c3` is the order that reports the interior ones (#480). These five entry points drive the same
+two analyzers as [`Surface.knotSplitting`](Surface-Advanced.md) and
+[`Curve2D.splitIndicesAtDiscontinuities`](Curve2D.md), differing only in what they return.
+
 ### `Surface.bsplineKnotSplitsU(continuity:)`
 
-Number of U-direction knot split points required to achieve the specified continuity.
+Number of U-direction knot split points required to achieve the specified continuity. Same count
+as `knotSplitting(uContinuity:vContinuity:)`'s `uSplitCount`.
 
 ```swift
-public func bsplineKnotSplitsU(continuity: Int) -> Int
+public func bsplineKnotSplitsU(continuity: ParametricContinuity) -> Int
 ```
 
-- **Parameters:** `continuity` — desired continuity order (0 = C0, 1 = C1, …).
+- **Parameters:** `continuity`: minimum continuity to require of each U patch.
 - **Returns:** Count of U split indices.
 - **OCCT:** `GeomConvert_BSplineSurfaceKnotSplitting::NbUSplits`
 - **Example:**
   ```swift
-  let n = bsplineSurf.bsplineKnotSplitsU(continuity: 1)
+  let n = bsplineSurf.bsplineKnotSplitsU(continuity: .c3)
   ```
 
 ---
 
 ### `Surface.bsplineKnotSplitsV(continuity:)`
 
-Number of V-direction knot split points required to achieve the specified continuity.
+Number of V-direction knot split points required to achieve the specified continuity. Same count
+as `knotSplitting(uContinuity:vContinuity:)`'s `vSplitCount`.
 
 ```swift
-public func bsplineKnotSplitsV(continuity: Int) -> Int
+public func bsplineKnotSplitsV(continuity: ParametricContinuity) -> Int
 ```
 
-- **Parameters:** `continuity` — desired continuity order.
+- **Parameters:** `continuity`: minimum continuity to require of each V patch.
 - **Returns:** Count of V split indices.
 - **OCCT:** `GeomConvert_BSplineSurfaceKnotSplitting::NbVSplits`
 - **Example:**
   ```swift
-  let n = bsplineSurf.bsplineKnotSplitsV(continuity: 1)
+  let n = bsplineSurf.bsplineKnotSplitsV(continuity: .c3)
   ```
 
 ---
 
 ### `Surface.bsplineKnotSplitValues(continuity:)`
 
-Retrieve both U and V knot-split index arrays.
+Retrieve both U and V knot-split index arrays. `bsplineUKnot(index:)` and `bsplineVKnot(index:)`
+turn them into parameters, which is what `knotSplitting(uContinuity:vContinuity:)` returns directly.
 
 ```swift
-public func bsplineKnotSplitValues(continuity: Int) -> (uSplits: [Int32], vSplits: [Int32])
+public func bsplineKnotSplitValues(continuity: ParametricContinuity) -> (uSplits: [Int32], vSplits: [Int32])
 ```
 
-- **Parameters:** `continuity` — desired continuity order.
+- **Parameters:** `continuity`: minimum continuity to require of each patch.
 - **Returns:** Tuple of U-split and V-split knot index arrays (1-based OCCT knot indices).
 - **OCCT:** `GeomConvert_BSplineSurfaceKnotSplitting::Splitting`
 - **Example:**
   ```swift
-  let (uIdx, vIdx) = bsplineSurf.bsplineKnotSplitValues(continuity: 1)
+  let (uIdx, vIdx) = bsplineSurf.bsplineKnotSplitValues(continuity: .c3)
   ```
 
 ---
@@ -257,35 +268,38 @@ Extensions on `Curve2D` wrapping `Geom2dConvert_BSplineCurveKnotSplitting`.
 ### `Curve2D.bsplineKnotSplits(continuity:)`
 
 Number of knot split points required to achieve the specified continuity for a 2D BSpline curve.
+Same count as `splitIndicesAtDiscontinuities(continuity:)`'s array length.
 
 ```swift
-public func bsplineKnotSplits(continuity: Int) -> Int
+public func bsplineKnotSplits(continuity: ParametricContinuity) -> Int
 ```
 
-- **Parameters:** `continuity` — desired continuity order.
+- **Parameters:** `continuity`: minimum continuity to require of each arc.
 - **Returns:** Count of split indices.
 - **OCCT:** `Geom2dConvert_BSplineCurveKnotSplitting::NbSplits`
 - **Example:**
   ```swift
-  let n = curve2d.bsplineKnotSplits(continuity: 1)
+  let n = curve2d.bsplineKnotSplits(continuity: .c3)
   ```
 
 ---
 
 ### `Curve2D.bsplineKnotSplitValues(continuity:)`
 
-Retrieve the knot-split index array for a 2D BSpline curve.
+Retrieve the knot-split index array for a 2D BSpline curve. The same indices
+`splitIndicesAtDiscontinuities(continuity:)` returns, as `[Int32]` and empty rather than `nil`
+for a non-BSpline curve.
 
 ```swift
-public func bsplineKnotSplitValues(continuity: Int) -> [Int32]
+public func bsplineKnotSplitValues(continuity: ParametricContinuity) -> [Int32]
 ```
 
-- **Parameters:** `continuity` — desired continuity order.
+- **Parameters:** `continuity`: minimum continuity to require of each arc.
 - **Returns:** Array of knot split indices, or empty if none.
 - **OCCT:** `Geom2dConvert_BSplineCurveKnotSplitting::Splitting`
 - **Example:**
   ```swift
-  let splits = curve2d.bsplineKnotSplitValues(continuity: 2)
+  let splits = curve2d.bsplineKnotSplitValues(continuity: .c3)
   ```
 
 ---

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -788,7 +788,7 @@ public static func composite(laws: [LawFunction],
 Find knot indices where a BSpline law drops below given continuity.
 
 ```swift
-public func knotSplitting(continuityOrder: Int = 2) -> [Int]
+public func knotSplitting(continuityOrder: ParametricContinuity = .c1) -> [Int]
 ```
 
 Only works on BSpline-based law functions created via `bspline(poles:knots:multiplicities:degree:)`.
@@ -800,13 +800,18 @@ a law with more splits than that reported exactly 100, with nothing to say the r
 dropped, so it disagreed with `knotSplitParameters(continuityOrder:)` (same analyzer, same law)
 about how many splits the law has.
 
-- **Parameters:** `continuityOrder` — continuity level to check (`0`=C0, `1`=C1, `2`=C2).
+- **Parameters:** `continuityOrder`: minimum continuity to require of each arc.
 - **Returns:** Array of knot indices where continuity breaks, or empty array if none or if the function is not BSpline-based.
 - **OCCT:** `Law_BSplineKnotSplitting::NbSplits` / `SplitValue`.
+- **Continuity range (#480):** the order is a *derivative order*, and a knot splits only when
+  `degree - multiplicity < continuityOrder`, so the meaningful range is `0...degree` and it
+  saturates there. A cubic law with simple interior knots is already C2 there, which means `.c0`,
+  `.c1` and `.c2` all report just the two end knots and `.c3` is the order that reports the
+  interior ones.
 - **Example:**
   ```swift
-  let indices = law.knotSplitting(continuityOrder: 2)
-  let params  = law.knotSplitParameters(continuityOrder: 2)
+  let indices = law.knotSplitting(continuityOrder: .c2)
+  let params  = law.knotSplitParameters(continuityOrder: .c2)
   // indices[i] is the knot-table index of params[i], so the two always agree on count
   ```
 
@@ -818,19 +823,22 @@ Find parameter values (not raw knot indices) where a BSpline law drops below giv
 the law-function analogue of `Curve3D.continuityBreaks`.
 
 ```swift
-public func knotSplitParameters(continuityOrder: Int = 2) -> [Double]
+public func knotSplitParameters(continuityOrder: ParametricContinuity = .c1) -> [Double]
 ```
 
 Only works on BSpline-based law functions created via `bspline(poles:knots:multiplicities:degree:)`.
 Unlike `knotSplitting(continuityOrder:)`'s raw indices, these are real parameter values, directly
 usable with `value(at:)` and bounded by `bounds`.
 
-- **Parameters:** `continuityOrder` — continuity level to check (`0`=C0, `1`=C1, `2`=C2).
+- **Parameters:** `continuityOrder`: minimum continuity to require of each arc, same derivative-order
+  contract as `knotSplitting(continuityOrder:)` above (#480).
 - **Returns:** Split parameters in ascending order, or empty array if none or if the function is not BSpline-based.
 - **OCCT:** `Law_BSplineKnotSplitting`.
 - **Example:**
   ```swift
-  let breaks = law.knotSplitParameters(continuityOrder: 2)
+  // A cubic law with simple interior knots is already C2 there, so .c3 is the order that
+  // reports its interior knots; anything below returns just the two end knots.
+  let breaks = law.knotSplitParameters(continuityOrder: .c3)
   // breaks are real parameters within law.bounds, usable e.g. as sweep split points
   ```
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -20,9 +20,16 @@ This page covers geometry repair, shape upgrade, point classification, proximity
 Minimum parametric continuity to require of a piece of geometry. Shared by every operation
 that splits, approximates or simplifies against a continuity floor: `Shape.divided(at:)`,
 `Shape.bsplineRestriction(...)`, `Curve3D.approxWithDetails(...)`,
-`Surface.approxWithDetails(tolerance:uContinuity:vContinuity:...)` and
-`Curve3D.continuityBreaks(minContinuity:)`. The raw value maps to `GeomAbs_C0` through
-`GeomAbs_C3`.
+`Surface.approxWithDetails(tolerance:uContinuity:vContinuity:...)` and the whole BSpline
+knot-splitting family: `Curve3D.continuityBreaks(minContinuity:)`,
+`Curve2D.splitIndicesAtDiscontinuities(continuity:)`,
+`Surface.knotSplitting(uContinuity:vContinuity:)`, `LawFunction.knotSplitting(continuityOrder:)`
+and `LawFunction.knotSplitParameters(continuityOrder:)`.
+
+What the value becomes depends on the consumer. Most decode it to a `GeomAbs_Shape` (`GeomAbs_C0`
+through `GeomAbs_C3`); the knot-splitting family instead passes it to OCCT as a literal derivative
+order against the geometry's own degree, so `.c3` is exact for a cubic but is the strictest question
+askable of a degree-4-or-higher BSpline (#480). Each API's own page states its measured domain.
 
 ```swift
 public enum ParametricContinuity: Int32, Sendable, CaseIterable {

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -578,19 +578,36 @@ public static func trimmedCylinder(
 Analyses where a BSpline surface would need to be split to achieve a given continuity level.
 
 ```swift
-public func knotSplitting(uContinuity: Int = 1, vContinuity: Int = 1) -> KnotSplitResult
+public func knotSplitting(
+    uContinuity: ParametricContinuity = .c1,
+    vContinuity: ParametricContinuity = .c1
+) -> KnotSplitResult
 ```
 
 Returns the number of U and V splits needed, plus the actual U/V parameter values at each
-split; does not modify the surface.
+split; does not modify the surface. Each direction's own first and last knots are always
+included, so a direction that never drops below the requested continuity reports exactly those
+two rather than nothing.
 
-- **Parameters:** `uContinuity` — desired U continuity (0=C0, 1=C1, 2=C2); `vContinuity` — desired V continuity.
+- **Parameters:** `uContinuity`: minimum continuity to require of each U patch; `vContinuity`:
+  the same against the V degree and V knots.
 - **Returns:** `KnotSplitResult` with `uSplitCount`/`vSplitCount` and `uSplitParams`/`vSplitParams`
   (ascending, bounded by the surface's own U/V domain).
-- **OCCT:** `BSplSLib::KnotSplitting`.
+- **OCCT:** `GeomConvert_BSplineSurfaceKnotSplitting`.
+- **Continuity range (#480):** the continuity is a *derivative order*, and a knot splits only when
+  `degree - multiplicity < continuity`. So the meaningful range is `0...degree` and it saturates
+  there. A bicubic surface with simple interior knots is already C2 at every interior knot, which
+  means `.c0`, `.c1` and `.c2` all report just the two bounding curves per direction and `.c3` is
+  the order that reports the interior ones. On a degree-4-or-higher surface `.c3` is the strictest
+  question this vocabulary can ask; [`toBezierPatches()`](Surface.md) is the dedicated API for the
+  every-knot split at the far end of that ladder.
 - **Example:**
   ```swift
-  let result = surf.knotSplitting(uContinuity: 2, vContinuity: 2)
+  // Where does the surface actually kink? (multiplicity == degree)
+  let kinks = surf.knotSplitting()
+
+  // Every interior knot of a bicubic surface.
+  let result = surf.knotSplitting(uContinuity: .c3, vContinuity: .c3)
   print("U splits needed:", result.uSplitCount, result.uSplitParams)
   print("V splits needed:", result.vSplitCount, result.vSplitParams)
   ```


### PR DESCRIPTION
Closes #480.

## The defect

#398 established that a knot-splitting continuity documented as `0=C0, 1=C1, 2=C2` lists every
value that does nothing on ordinary cubic geometry. It widened `Curve3D.continuityBreaks` to
`ParametricContinuity`, whose `.c3` is reachable. The rest of the family kept the cap.

## The census

By OCCT class rather than by the issue's site list, which found more than the issue named:
**four** analyzers, **nine** public Swift entry points, eight still typed `Int`.

| Swift entry point | OCCT analyzer | was | now |
|---|---|---|---|
| `Curve3D.continuityBreaks(minContinuity:)` | `GeomConvert_BSplineCurveKnotSplitting` | `.c1` (#398) | unchanged |
| `Surface.knotSplitting(uContinuity:vContinuity:)` | `GeomConvert_BSplineSurfaceKnotSplitting` | `Int = 1, Int = 1` | `.c1, .c1` |
| `Surface.bsplineKnotSplitsU/V(continuity:)`, `Surface.bsplineKnotSplitValues(continuity:)` | same | `Int` | `ParametricContinuity` |
| `Curve2D.splitIndicesAtDiscontinuities(continuity:)` | `Geom2dConvert_BSplineCurveKnotSplitting` | `Int = 1` | `.c1` |
| `Curve2D.bsplineKnotSplits(continuity:)`, `Curve2D.bsplineKnotSplitValues(continuity:)` | same | `Int` | `ParametricContinuity` |
| `LawFunction.knotSplitting(continuityOrder:)` | `Law_BSplineKnotSplitting` | `Int = 2` | `.c1` |
| `LawFunction.knotSplitParameters(continuityOrder:)` | same | `Int = 2` | `.c1` |

**Source-breaking:** callers passing integer literals need the spelled case (`0` becomes `.c0`).
That is the point. The raw `Int` is what let a documented range consisting entirely of no-ops go
unnoticed for five releases.

## Measured, not assumed

Ground-truth C++ against the pinned kernel, all four analyzers, degrees 2/3/5, ranges -1 to 7
(`NbSplits`, 4 interior knots):

| geometry | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|---|
| degree 3, simple interior knots | 2 | 2 | 2 | **6** | 6 | 6 | 6 |
| degree 3, one knot at multiplicity 2 | 2 | 2 | **3** | 6 | 6 | 6 | 6 |
| degree 3, one knot at multiplicity 3 (a kink) | 2 | **3** | 3 | 6 | 6 | 6 | 6 |
| degree 5, simple interior knots | 2 | 2 | 2 | 2 | 2 | **6** | 6 |

All four analyzers return identical counts at every cell, so the family really is one contract.
Three consequences, now documented in one shared note in `OCCTBridge_Internal.h` instead of
restated wrongly in nine places:

- The argument is a literal derivative order, **not** a `GeomAbs_Shape`. Decoding it first would
  be silently wrong: `GeomAbs_C3` is ordinal 5.
- The useful domain is `0...degree` and saturates there, so `.c3` is the strictest question this
  vocabulary can ask of a degree-4-or-higher BSpline. `toBezierSegments()`/`toBezierPatches()` is
  the dedicated API for the every-knot split at the far end of that ladder.
- A negative range throws `Standard_RangeError` through an explicit `throw`, not a `*_Raise_if`
  macro, so unlike most OCCT preconditions it survives this kernel's `No_Exception` build and
  reaches the bridge's `catch(...)`.

## The one checkbox I did not implement as written

The issue asks for a case "asserting the **default call** finds the interior splits", which implies
moving the default to `.c3`. The defaults were revisited and deliberately left at `.c1`, now
uniform across the family (the two law methods moved from 2), because the measurement above says
`.c3` is the wrong default: on a cubic it reports *every* interior knot, which is a Bezier
decomposition, not a discontinuity report. `.c1` reports genuine kinks and nothing else, which is
the question a default should answer, and it matches what `Curve3D.continuityBreaks` already
shipped. A C2 knot is not a discontinuity when you asked for C1, so the old default was not hiding
anything; the reachable `.c3` is the fix.

## Also found

- `Surface.knotSplitting` was documented as `BSplSLib::KnotSplitting`, which is not what it calls.
- The bridge header still carried the `0=C0, 1=C1, 2=C2` range on `OCCTCurve3DBSplineKnotSplits`,
  the one function #398 had already fixed on the Swift side.

## Verification

New suites in the three affected domains pin the measured contract rather than the signature, so
they also catch the opposite mistake of decoding to `GeomAbs_Shape` first. Both mistakes were
injected and confirmed to fail:

- capping the range at 2 (the #480 defect): 3 surface tests fail, `.c3` reports 2 splits instead of 6
- decoding `.c2` to `GeomAbs_C2` (ordinal 4): the 2D tests fail, `.c2` reports every knot instead of none

`swift build` clean, full `swift test` 4862 tests pass, operation counts unchanged
(4293, README and API_REFERENCE agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)