### PR TITLE
fix(#482): a refused FillingSurface.add now fails build(), matching Shape.fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,266 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,270 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -5608,6 +5608,9 @@ OCCTFillingRef OCCTFillingCreate(int32_t degree, int32_t nbPtsOnCur, int32_t max
 void OCCTFillingRelease(OCCTFillingRef filling);
 
 /// Add a boundary edge constraint, deriving the continuity reference from the edge's own pcurve.
+///
+/// With no nominated support face to validate, this only refuses a constraint OCCT itself throws
+/// on. A refusal is sticky either way; see OCCTFillingBuild.
 /// @param filling Filling handle
 /// @param edge Edge to add as constraint
 /// @param continuity Continuity order: 0=position, 1=tangency, 2=curvature (see OCCTFillingParams)
@@ -5626,6 +5629,7 @@ bool OCCTFillingAddFreeEdge(OCCTFillingRef filling, OCCTEdgeRef edge, int32_t co
 /// `support` is used or the constraint fails: if it carries no pcurve for `edge` it cannot
 /// serve as the continuity reference, matching OCCTShapeFillConstraints' per-constraint
 /// contract. Pass NULL to derive the reference from the edge itself, same as OCCTFillingAddEdge.
+/// A refusal is sticky; see OCCTFillingBuild.
 /// @param filling Filling handle
 /// @param edge Edge to add as constraint
 /// @param support Face to be continuous with, or NULL to derive one from the edge
@@ -5640,7 +5644,21 @@ bool OCCTFillingAddEdgeWithSupport(OCCTFillingRef filling, OCCTEdgeRef edge,
 /// @return true if point was added
 bool OCCTFillingAddPoint(OCCTFillingRef filling, double x, double y, double z);
 
+/// Number of OCCTFillingAdd* calls this builder refused (#482).
+///
+/// A refused constraint is one that is NOT in the builder, so it distinguishes a poisoned
+/// OCCTFillingBuild from an ordinary fitting failure. Only ever increases; a later successful
+/// Add does not clear it.
+/// @param filling Filling handle
+/// @return Refusal count, or 0 for a NULL handle
+int32_t OCCTFillingRefusedConstraintCount(OCCTFillingRef filling);
+
 /// Build the filling surface.
+///
+/// Fails immediately, without attempting the build, if any OCCTFillingAdd* was refused (#482).
+/// Fitting a surface to the constraints that did make it in would answer a different question
+/// than the caller asked. Matches OCCTShapeFillConstraints, which returns NULL on the same
+/// refusal. Use OCCTFillingRefusedConstraintCount to tell the two failures apart.
 /// @param filling Filling handle
 /// @return true if build succeeded
 bool OCCTFillingBuild(OCCTFillingRef filling);

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -4403,7 +4403,18 @@ OCCTShapeRef OCCTFace2DChamfer(OCCTShapeRef shape,
 // history for free.
 struct OCCTFilling {
     BRepOffsetAPI_MakeFilling filler;
+    // #482: how many Add* calls were refused. A refused constraint is one that is NOT in
+    // `filler`. Building over the rest would answer a different question than the caller
+    // asked, so the refusal is sticky and OCCTFillingBuild fails on it. See the note there.
+    int32_t refusedCount = 0;
 };
+
+// Record a refused constraint and report the refusal to the caller, in one expression.
+// Refusing with a null handle is not recordable, so it is only reported.
+static bool OCCTFillingRefuse(OCCTFillingRef filling) {
+    if (filling) filling->refusedCount++;
+    return false;
+}
 
 OCCTFillingRef OCCTFillingCreate(int32_t degree, int32_t nbPtsOnCur, int32_t maxDegree,
                                   int32_t maxSegments, double tolerance3d) {
@@ -4433,46 +4444,52 @@ void OCCTFillingRelease(OCCTFillingRef filling) {
 // true here says nothing about the constraint's validity — a bad order still only surfaces as a
 // nil Build() later.
 bool OCCTFillingAddEdge(OCCTFillingRef filling, OCCTEdgeRef edge, int32_t continuity) {
-    if (!filling || !edge) return false;
+    if (!filling) return false;
+    if (!edge) return OCCTFillingRefuse(filling);
     try {
         occtFillingAddConstraint(filling->filler, edge->edge, TopoDS_Face(),
                                  OCCTFillingSupport::Inferred,
                                  occtFillingContinuityToGeomAbs(continuity), /*isBound=*/true);
         return true;
     } catch (...) {
-        return false;
+        return OCCTFillingRefuse(filling);
     }
 }
 
 bool OCCTFillingAddFreeEdge(OCCTFillingRef filling, OCCTEdgeRef edge, int32_t continuity) {
-    if (!filling || !edge) return false;
+    if (!filling) return false;
+    if (!edge) return OCCTFillingRefuse(filling);
     try {
         occtFillingAddConstraint(filling->filler, edge->edge, TopoDS_Face(),
                                  OCCTFillingSupport::Inferred,
                                  occtFillingContinuityToGeomAbs(continuity), /*isBound=*/false);
         return true;
     } catch (...) {
-        return false;
+        return OCCTFillingRefuse(filling);
     }
 }
 
 // #434: gives FillingSurface the same explicit-support-face capability
 // Shape.fill(constraints:)/FillConstraint already has. A face named here is Nominated: if it
-// cannot carry `edge`'s continuity, the constraint is not added and the caller should treat the
-// whole fill as failed, matching OCCTShapeFillConstraints' per-constraint contract.
+// cannot carry `edge`'s continuity, the constraint is not added and the whole fill fails,
+// matching OCCTShapeFillConstraints, which returns NULL on that same refusal (#482).
 bool OCCTFillingAddEdgeWithSupport(OCCTFillingRef filling, OCCTEdgeRef edge,
                                     OCCTFaceRef support, int32_t continuity) {
-    if (!filling || !edge) return false;
+    if (!filling) return false;
+    if (!edge) return OCCTFillingRefuse(filling);
     try {
         TopoDS_Face supportFace;
         if (support) supportFace = support->face;
-        return occtFillingAddConstraint(filling->filler, edge->edge, supportFace,
-                                        support ? OCCTFillingSupport::Nominated
-                                                : OCCTFillingSupport::Inferred,
-                                        occtFillingContinuityToGeomAbs(continuity),
-                                        /*isBound=*/true);
+        if (!occtFillingAddConstraint(filling->filler, edge->edge, supportFace,
+                                      support ? OCCTFillingSupport::Nominated
+                                              : OCCTFillingSupport::Inferred,
+                                      occtFillingContinuityToGeomAbs(continuity),
+                                      /*isBound=*/true)) {
+            return OCCTFillingRefuse(filling);
+        }
+        return true;
     } catch (...) {
-        return false;
+        return OCCTFillingRefuse(filling);
     }
 }
 
@@ -4482,12 +4499,25 @@ bool OCCTFillingAddPoint(OCCTFillingRef filling, double x, double y, double z) {
         filling->filler.Add(gp_Pnt(x, y, z));
         return true;
     } catch (...) {
-        return false;
+        return OCCTFillingRefuse(filling);
     }
 }
 
+int32_t OCCTFillingRefusedConstraintCount(OCCTFillingRef filling) {
+    return filling ? filling->refusedCount : 0;
+}
+
+// #482: a refused Add* fails the build outright rather than fitting a surface to whatever did
+// make it in. The one-shot entry point has always behaved this way: OCCTShapeFillConstraints
+// returns NULL the moment occtFillingAddConstraint refuses a nominated support face. The
+// incremental one carried on, so the same geometry answered differently depending on which API
+// the caller reached for, and the difference was a plausible-looking face that neither passed
+// through nor was bounded by the constraint the caller cared most about.
+//
+// Build() is not attempted at all, so IsDone() stays false and the face/error accessors keep
+// reporting "not built" rather than describing a surface no caller asked for.
 bool OCCTFillingBuild(OCCTFillingRef filling) {
-    if (!filling) return false;
+    if (!filling || filling->refusedCount > 0) return false;
     try {
         filling->filler.Build();
         return filling->filler.IsDone();

--- a/Sources/OCCTSwift/FillingSurface.swift
+++ b/Sources/OCCTSwift/FillingSurface.swift
@@ -12,9 +12,9 @@ import OCCTBridge
 /// connect multiple surface boundaries.
 ///
 /// Shares its bridge implementation with ``Shape/fill(boundaries:parameters:)`` and
-/// ``Shape/fill(constraints:parameters:)`` (#434); this is the incremental, stateful form —
-/// build up constraints one call at a time and inspect per-build error introspection —
-/// where those are one-shot convenience calls over an array.
+/// ``Shape/fill(constraints:parameters:)`` (#434); this is the incremental, stateful form
+/// (build up constraints one call at a time and inspect per-build error introspection), where
+/// those are one-shot convenience calls over an array.
 ///
 /// ```swift
 /// let edges = box.edges()
@@ -26,6 +26,29 @@ import OCCTBridge
 /// filling.add(point: SIMD3(5, 5, 3))  // surface passes through this point
 /// let face = filling.build()
 /// ```
+///
+/// ## Refused constraints
+///
+/// An `add` that returns `false` did not add its constraint, and that refusal is *sticky*:
+/// ``build()`` then returns nil however many other constraints succeeded, rather than fitting a
+/// surface to a subset the caller never asked for (#482). This is what
+/// ``Shape/fill(constraints:parameters:)`` has always done for the same input; ``build()``
+/// used to succeed here instead. Since every `add` is `@discardableResult`, the refusal is
+/// reported whether or not the return value was read. Check ``hasRefusedConstraint`` to tell a
+/// poisoned build from an ordinary fitting failure.
+///
+/// ```swift
+/// let filling = FillingSurface()
+/// filling.add(edge: e1, continuity: .g0)
+/// filling.add(edge: rim, support: importedWall, continuity: .g1)  // false: no pcurve there
+///
+/// filling.hasRefusedConstraint   // true
+/// filling.build()                // nil, not a face fitted to e1 alone
+/// ```
+///
+/// To attempt a constraint speculatively and carry on regardless, use
+/// ``add(edge:continuity:)``, which derives the continuity reference from the edge itself and
+/// so has nothing to refuse.
 public final class FillingSurface: @unchecked Sendable {
     private let handle: OCCTFillingRef
 
@@ -56,6 +79,8 @@ public final class FillingSurface: @unchecked Sendable {
     /// - Returns: true if the edge was added successfully, which says nothing about whether
     ///   the order is usable: `BRepOffsetAPI_MakeFilling::Add` only appends, so a bad order
     ///   surfaces later as a nil ``build()`` that takes every other constraint with it.
+    ///   With no support face to validate, this overload only refuses a constraint OCCT itself
+    ///   throws on; see ``hasRefusedConstraint`` for what a refusal costs.
     @discardableResult
     public func add(edge: Edge, continuity: SurfaceContinuity = .g0) -> Bool {
         OCCTFillingAddEdge(handle, edge.handle, continuity.rawValue)
@@ -67,7 +92,11 @@ public final class FillingSurface: @unchecked Sendable {
     /// constraint fails, rather than silently falling back to another surface. Use
     /// ``add(edge:continuity:)`` to accept whichever surface the edge itself resolves instead.
     ///
-    /// - Note: `support` is only meaningful above `.g0` — a positional constraint has nothing
+    /// The failure is not confined to this call. A refusal here poisons ``build()``, which then
+    /// returns nil whatever else succeeded: the same answer
+    /// ``Shape/fill(constraints:parameters:)`` gives for the same input (#482).
+    ///
+    /// - Note: `support` is only meaningful above `.g0`: a positional constraint has nothing
     ///   to be tangent or curvature-continuous *with*, so at `.g0` it is never read, matching
     ///   ``FillConstraint``, whose `continuity` also defaults to `.g1` rather than `.g0` for
     ///   this reason.
@@ -77,7 +106,9 @@ public final class FillingSurface: @unchecked Sendable {
     ///   - support: Face to be continuous with. Used or the constraint fails: if it carries no
     ///     pcurve for `edge` it cannot serve as the continuity reference.
     ///   - continuity: Continuity order at this edge (default .g1)
-    /// - Returns: true if the edge was added successfully
+    /// - Returns: true if the edge was added successfully. False means the constraint is not in
+    ///   the builder and ``build()`` will return nil; ``hasRefusedConstraint`` reports the same
+    ///   thing later, for callers who discarded this result.
     @discardableResult
     public func add(edge: Edge, support: Face, continuity: SurfaceContinuity = .g1) -> Bool {
         OCCTFillingAddEdgeWithSupport(handle, edge.handle, support.handle, continuity.rawValue)
@@ -107,7 +138,14 @@ public final class FillingSurface: @unchecked Sendable {
 
     /// Build the filling surface and return the resulting shape.
     ///
-    /// - Returns: The filled face as a Shape, or nil if building failed
+    /// Returns nil without attempting the build if any `add` was refused (#482). Fitting a
+    /// surface to the constraints that did make it in would answer a different question than
+    /// the one the caller posed, so the refusal takes the whole build with it, matching
+    /// ``Shape/fill(constraints:parameters:)``. Check ``hasRefusedConstraint`` to tell that
+    /// case apart from a fit that was attempted and failed.
+    ///
+    /// - Returns: The filled face as a Shape, or nil if a constraint was refused or the fit
+    ///   failed
     public func build() -> Shape? {
         guard OCCTFillingBuild(handle) else { return nil }
         guard let ref = OCCTFillingGetFace(handle) else { return nil }
@@ -115,8 +153,44 @@ public final class FillingSurface: @unchecked Sendable {
     }
 
     /// Whether the filling surface has been successfully built.
+    ///
+    /// Stays false after a refused `add`, since ``build()`` never attempts the fit in that case.
     public var isDone: Bool {
         OCCTFillingIsDone(handle)
+    }
+
+    /// Number of `add` calls this builder refused (#482).
+    ///
+    /// A refused constraint is one that is *not* in the builder: a nominated `support` face
+    /// carrying no pcurve for its edge, or a constraint OCCT threw on. Only ever increases: a
+    /// later successful `add` does not clear it, because the refused constraint is still
+    /// missing from the surface that would be fitted.
+    ///
+    /// ```swift
+    /// let filling = FillingSurface()
+    /// filling.add(edge: rim, support: importedWall, continuity: .g1)
+    ///
+    /// if filling.refusedConstraintCount > 0 {
+    ///     // build() will return nil; the wall carries no pcurve for the rim
+    /// }
+    /// ```
+    public var refusedConstraintCount: Int {
+        Int(OCCTFillingRefusedConstraintCount(handle))
+    }
+
+    /// Whether any `add` was refused, which makes ``build()`` return nil (#482).
+    ///
+    /// The one signal that separates "a constraint never made it in" from "the fit was
+    /// attempted and failed". Both return nil from ``build()``.
+    ///
+    /// ```swift
+    /// guard let face = filling.build() else {
+    ///     print(filling.hasRefusedConstraint ? "a constraint was refused" : "the fit failed")
+    ///     return
+    /// }
+    /// ```
+    public var hasRefusedConstraint: Bool {
+        refusedConstraintCount > 0
     }
 
     /// Positional (G0) error of the built surface.

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -486,6 +486,80 @@ struct FillingSupportFaceTests {
         let rejecting = FillingSurface()
         #expect(!rejecting.add(edge: rim, support: strangerFace))
     }
+
+    @Test("A refused add poisons build(), matching Shape.fill(constraints:) (#482)")
+    func fillingSurfaceRefusedConstraintPoisonsBuild() {
+        guard let bowl = bowl(), let rim = rimEdge(of: bowl) else {
+            Issue.record("Failed to build the truncated-sphere fixture")
+            return
+        }
+        guard let unrelated = Shape.sphere(at: SIMD3(100, 0, 0), direction: SIMD3(0, 0, 1),
+                                           radius: 3, angle1: -.pi / 2, angle2: .pi / 4),
+              let strangerFace = unrelated.faces().first else {
+            Issue.record("Failed to create the unrelated support face")
+            return
+        }
+
+        // Control: the rim alone builds. Without this the poisoned build() below would pass
+        // for the wrong reason: a fill that was never going to succeed anyway.
+        let control = FillingSurface()
+        #expect(control.add(edge: rim, continuity: .g0))
+        #expect(control.build() != nil)
+        #expect(!control.hasRefusedConstraint)
+        #expect(control.refusedConstraintCount == 0)
+
+        // Same buildable constraint, plus one the builder refuses: the stranger face carries no
+        // pcurve for the rim, so that constraint is never added. Before #482 build() went ahead
+        // and fitted a surface to whatever did make it in: here, a face bounded by the rim with
+        // no tangency at all, silently answering a question the caller did not ask. The refusal
+        // is now sticky.
+        let poisoned = FillingSurface()
+        #expect(poisoned.add(edge: rim, continuity: .g0))
+        #expect(!poisoned.add(edge: rim, support: strangerFace, continuity: .g1))
+        #expect(poisoned.hasRefusedConstraint)
+        #expect(poisoned.refusedConstraintCount == 1)
+        #expect(poisoned.build() == nil)
+        // Build() is not attempted at all, so nothing downstream reports a result either.
+        #expect(!poisoned.isDone)
+        #expect(poisoned.g0Error == nil)
+
+        // The same geometry through the other entry point has always returned nil. That the two
+        // now agree is the point of the change.
+        #expect(Shape.fill(constraints: [
+            FillConstraint(edge: rim, continuity: .g0, isBoundary: true),
+            FillConstraint(edge: rim, support: strangerFace, continuity: .g1)
+        ]) == nil)
+    }
+
+    @Test("Refusals accumulate and stay sticky across later successful adds (#482)")
+    func fillingSurfaceRefusalIsStickyAndCounted() {
+        guard let bowl = bowl(), let rim = rimEdge(of: bowl) else {
+            Issue.record("Failed to build the truncated-sphere fixture")
+            return
+        }
+        guard let wall = rim.adjacentFaces(in: bowl)?.0 else {
+            Issue.record("The rim should have an adjacent face to be tangent to")
+            return
+        }
+        guard let unrelated = Shape.sphere(at: SIMD3(100, 0, 0), direction: SIMD3(0, 0, 1),
+                                           radius: 3, angle1: -.pi / 2, angle2: .pi / 4),
+              let strangerFace = unrelated.faces().first else {
+            Issue.record("Failed to create the unrelated support face")
+            return
+        }
+
+        let filling = FillingSurface()
+        #expect(!filling.add(edge: rim, support: strangerFace, continuity: .g1))
+        #expect(!filling.add(edge: rim, support: strangerFace, continuity: .g2))
+        #expect(filling.refusedConstraintCount == 2)
+
+        // A later add that succeeds (with the face that genuinely does carry the rim's pcurve,
+        // so this one would build on its own) does not clear the earlier refusals.
+        #expect(filling.add(edge: rim, support: wall, continuity: .g1))
+        #expect(filling.refusedConstraintCount == 2)
+        #expect(filling.hasRefusedConstraint)
+        #expect(filling.build() == nil)
+    }
 }
 
 @Suite("Plate Surface Tests", .disabled("Plate surface operations cause segfault in OCCT — pre-existing issue"))

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,321** of the entry points (~78% of the `Total` below); the rest are real, callable,
+categorisation covering **3,323** of the entry points (~78% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,266** | |
+| **Total** | **4,270** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -890,6 +890,8 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `Shape.fill(boundaries:parameters:)` | `BRepOffsetAPI_MakeFilling` |
 | `Shape.fill(boundaries:supportedBy:parameters:)` | `BRepOffsetAPI_MakeFilling::Add(edge, face, order)` |
 | `Shape.fill(constraints:parameters:)` | `BRepOffsetAPI_MakeFilling::Add(edge, face, order, isBound)` |
+| `FillingSurface.refusedConstraintCount` | bridge state: constraints *not* passed to `BRepOffsetAPI_MakeFilling::Add` (#482) |
+| `FillingSurface.hasRefusedConstraint` | bridge state: constraints *not* passed to `BRepOffsetAPI_MakeFilling::Add` (#482) |
 
 #### Shape Healing (v0.31.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,64 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### Unreleased: fix, a refused `FillingSurface.add` still let `build()` return a face (#482)
+
+> Version and date deliberately unset; whoever tags stamps them.
+
+#434 converged `FillingSurface` and `Shape.fill(constraints:)` onto one builder and one shared
+`occtFillingAddConstraint`, but left them disagreeing about what a *refused* constraint means, and
+the disagreement favoured the wrong outcome on the incremental API.
+
+`occtFillingAddConstraint` refuses a constraint when a **nominated** support face carries no pcurve
+for its edge, which is routine on imported or sewn shapes. It does not call `Add`, so that
+constraint simply does not exist. `Shape.fill(constraints:)` has always treated that as fatal and
+returned nil. `FillingSurface.add(edge:support:continuity:)` returned `false` and left the builder
+usable, so `build()` went on to fit a surface to whatever constraints did make it in. Since every
+`add` is `@discardableResult`, ignoring the signal was the default at the call site:
+
+```swift
+let f = FillingSurface()
+f.add(edge: e1, continuity: .g0)
+f.add(edge: rim, support: importedWall, continuity: .g1)   // false, silently dropped
+let face = f.build()                                       // succeeded
+```
+
+That face was fitted to `e1` alone. It neither passed through nor was bounded by `rim`, the edge
+the caller cared most about, and it reported a healthy G0 error (measured 2.8e-05 on the
+truncated-sphere fixture) while doing so: a plausible wrong answer, not a visible failure. The
+same geometry through `Shape.fill(constraints:)` returned nil.
+
+The refusal is now **sticky**: the builder records it, and `build()` returns nil however many other
+constraints succeeded, without attempting the fit at all, so `isDone` stays false and the face and
+error accessors keep reporting "not built" rather than describing a surface no caller asked for.
+The two entry points now answer the same for the same input, which is what the #434 convergence was
+for. `@discardableResult` becomes harmless: the refusal is reported whether or not the return value
+was read.
+
+New: `FillingSurface.refusedConstraintCount` and `FillingSurface.hasRefusedConstraint`, which
+separate "a constraint never made it in" from "the fit was attempted and failed". Both return nil
+from `build()`:
+
+```swift
+guard let face = filling.build() else {
+    print(filling.hasRefusedConstraint ? "a constraint was refused" : "the fit failed")
+    return
+}
+```
+
+**Source-compatible, behaviour-breaking.** No signature changed, but a caller who was relying on
+`build()` succeeding after a refused `add` now gets nil. To attempt a constraint speculatively and
+carry on, use `add(edge:continuity:)`, which derives the continuity reference from the edge itself
+and so has nothing to refuse.
+
+Two doc comments promised this behaviour before anything enforced it: `add(edge:support:)`'s "used
+or the constraint fails" and `OCCTFillingAddEdgeWithSupport`'s "the caller should treat the whole
+fill as failed". Both are now true.
+
+Also fixed: the derived operation total in `README.md` / `docs/API_REFERENCE.md` was 4,266 against a
+derived 4,268 before this change, a pre-existing two-entry-point drift unrelated to #482.
+`Scripts/count-operations.py --fix` takes it to 4,270, of which two are the properties above.
+
 ### Unreleased: chore, every build of this package emitted an unhandled-file warning (#440)
 
 > Version and date deliberately unset; whoever tags stamps them.

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -402,6 +402,31 @@ stateful form (build up constraints one call at a time, inspect per-build error 
 the `Shape.fill` overloads are one-shot convenience calls over an array of boundaries or
 constraints.
 
+### Refused constraints
+
+An `add` that returns `false` did not add its constraint, and that refusal is *sticky*: `build()`
+then returns nil however many other constraints succeeded, rather than fitting a surface to a
+subset the caller never asked for (#482). This is what `Shape.fill(constraints:parameters:)` has
+always done for the same input; `build()` used to succeed here instead, returning a plausible face
+that neither passed through nor was bounded by the refused constraint's edge.
+
+Since every `add` is `@discardableResult`, the refusal is recorded whether or not the return value
+was read. [`hasRefusedConstraint`](#hasrefusedconstraint) separates it from an ordinary fitting
+failure. Both return nil from `build()`.
+
+```swift
+let filling = FillingSurface()
+filling.add(edge: e1, continuity: .g0)
+filling.add(edge: rim, support: importedWall, continuity: .g1)  // false: no pcurve there
+
+filling.hasRefusedConstraint   // true
+filling.build()                // nil, not a face fitted to e1 alone
+```
+
+To attempt a constraint speculatively and carry on regardless, use
+[`add(edge:continuity:)`](#addedgecontinuity), which derives the continuity reference from the edge
+itself and so has nothing to refuse.
+
 ### `FillingContinuity`
 
 > **Deprecated in #398.** `FillingContinuity` was one of three copies of the same geometric
@@ -453,7 +478,8 @@ public func add(edge: Edge, continuity: SurfaceContinuity = .g0) -> Bool
   - `continuity` — continuity order at this edge (default `.g0`).
 - **Returns:** `true` if the edge was added successfully. This says nothing about whether the
   order is usable: `Add` only appends, so a bad order surfaces later as a `nil` `build()` that
-  takes every other constraint with it.
+  takes every other constraint with it. With no support face to validate, this overload only
+  refuses a constraint OCCT itself throws on; see [Refused constraints](#refused-constraints).
 - **OCCT:** `BRepOffsetAPI_MakeFilling::Add` (boundary edge variant), via the same
   `occtFillingContinuityToGeomAbs` order mapping `Shape.fill` uses — see
   [Shape-Features](Shape-Features.md#surface-filling) for why `.g1` is not `GeomAbs_G1` and `.g2`
@@ -482,6 +508,10 @@ Mirrors `FillConstraint`'s support-face semantics: a face named here is used or 
 fails, rather than silently falling back to another surface. Use `add(edge:continuity:)` to
 accept whichever surface the edge itself resolves instead.
 
+The failure is not confined to this call. A refusal here poisons `build()`, which then returns nil
+whatever else succeeded: the same answer `Shape.fill(constraints:parameters:)` gives for the same
+input (#482). See [Refused constraints](#refused-constraints).
+
 `support` is only meaningful above `.g0` — a positional constraint has nothing to be tangent or
 curvature-continuous *with*, so at `.g0` it is never read. `continuity` defaults to `.g1` rather
 than `.g0` for this reason, matching `FillConstraint`'s own default.
@@ -491,7 +521,8 @@ than `.g0` for this reason, matching `FillConstraint`'s own default.
   - `support` — face to be continuous with. Used or the constraint fails: if it carries no
     pcurve for `edge` it cannot serve as the continuity reference.
   - `continuity` — continuity order at this edge (default `.g1`).
-- **Returns:** `true` if the edge was added successfully.
+- **Returns:** `true` if the edge was added successfully. `false` means the constraint is not in
+  the builder and `build()` will return nil.
 - **OCCT:** `BRepOffsetAPI_MakeFilling::Add` (edge + support face variant).
 - **Example:**
   ```swift
@@ -544,7 +575,12 @@ Build the filling surface and return the resulting shape.
 public func build() -> Shape?
 ```
 
-- **Returns:** The filled face as a `Shape`, or `nil` if building failed.
+Returns nil without attempting the build if any `add` was refused (#482). Fitting a surface to the
+constraints that did make it in would answer a different question than the one the caller posed, so
+the refusal takes the whole build with it, matching `Shape.fill(constraints:parameters:)`.
+
+- **Returns:** The filled face as a `Shape`, or `nil` if a constraint was refused or the fit failed.
+  [`hasRefusedConstraint`](#hasrefusedconstraint) tells the two apart.
 - **OCCT:** `BRepOffsetAPI_MakeFilling::Build`, `BRepOffsetAPI_MakeFilling::Shape`.
 - **Example:**
   ```swift
@@ -568,7 +604,57 @@ Whether the filling surface has been successfully built.
 public var isDone: Bool { get }
 ```
 
+- Stays `false` after a refused `add`, since `build()` never attempts the fit in that case.
 - **OCCT:** `BRepOffsetAPI_MakeFilling::IsDone`.
+
+---
+
+### `refusedConstraintCount`
+
+Number of `add` calls this builder refused (#482).
+
+```swift
+public var refusedConstraintCount: Int { get }
+```
+
+A refused constraint is one that is *not* in the builder: a nominated `support` face carrying no
+pcurve for its edge, or a constraint OCCT threw on. Only ever increases: a later successful `add`
+does not clear it, because the refused constraint is still missing from the surface that would be
+fitted.
+
+- **OCCT:** none. Bridge state, counting constraints never passed to
+  `BRepOffsetAPI_MakeFilling::Add`.
+- **Example:**
+  ```swift
+  let filling = FillingSurface()
+  filling.add(edge: rim, support: importedWall, continuity: .g1)
+
+  if filling.refusedConstraintCount > 0 {
+      // build() will return nil; the wall carries no pcurve for the rim
+  }
+  ```
+
+---
+
+### `hasRefusedConstraint`
+
+Whether any `add` was refused, which makes `build()` return nil (#482).
+
+```swift
+public var hasRefusedConstraint: Bool { get }
+```
+
+The one signal that separates "a constraint never made it in" from "the fit was attempted and
+failed". Both return nil from `build()`.
+
+- **OCCT:** none. Bridge state: `refusedConstraintCount > 0`.
+- **Example:**
+  ```swift
+  guard let face = filling.build() else {
+      print(filling.hasRefusedConstraint ? "a constraint was refused" : "the fit failed")
+      return
+  }
+  ```
 
 ---
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -122,5 +122,5 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 | Bill of Materials & Selection (BillOfMaterials, Selector, Selection) | 48 | `Selection.md` | ✅ done |
 | Date & Period (Date, Period) | 33 | `DateTime.md` | ✅ done |
 | Curve Adaptors & Wire Ordering (WireCurve, EdgeCurve, WireOrder) | 31 | `CurveAdaptors.md` | ✅ done |
-| Geometry Solvers & Builders (BSplineApproxInterp, PlateSolver, FillingSurface, LawFunction, PolynomialSolver, KDTree) | 60 | `GeometrySolvers.md` | ✅ done |
+| Geometry Solvers & Builders (BSplineApproxInterp, PlateSolver, FillingSurface, LawFunction, PolynomialSolver, KDTree) | 62 | `GeometrySolvers.md` | ✅ done |
 | Concurrency & Progress (OCCTSerial, ImportProgress) | 6 | `Concurrency.md` | ✅ done |


### PR DESCRIPTION
Resolves the decision in #482 as **option 1 plus the introspection slice of option 3**: the refusal
is sticky, and it is inspectable.

## The divergence

#434 converged `FillingSurface` and `Shape.fill(constraints:)` onto one builder and one shared
`occtFillingAddConstraint`, but left them disagreeing about what a *refused* constraint means.

`occtFillingAddConstraint` refuses a constraint when a **nominated** support face carries no pcurve
for its edge, which is routine on imported or sewn shapes. It does not call `Add`, so that
constraint simply does not exist.

| | refused constraint |
|---|---|
| `Shape.fill(constraints:)` | returns nil |
| `FillingSurface.add(...)` (before) | returns `false`, `build()` succeeds anyway |

Since every `add` is `@discardableResult`, ignoring the signal was the default at the call site:

```swift
let f = FillingSurface()
f.add(edge: e1, continuity: .g0)
f.add(edge: rim, support: importedWall, continuity: .g1)   // false, silently dropped
let face = f.build()                                       // succeeded
```

That face was fitted to `e1` alone. It neither passed through nor was bounded by `rim`, the edge
the caller cared most about, and it reported a healthy G0 error (measured **2.8e-05** on the
truncated-sphere fixture) while doing so: a plausible wrong answer, not a visible failure.

## The change

The refusal is now sticky. `OCCTFilling` records it, and `OCCTFillingBuild` fails **without
attempting the build at all**, so `IsDone` stays false and the face and error accessors keep
reporting "not built" rather than describing a surface no caller asked for. The two entry points
now answer the same for the same input, which is what the #434 convergence was for.
`@discardableResult` becomes harmless: the refusal is recorded whether or not the return value was
read.

New: `FillingSurface.refusedConstraintCount` and `FillingSurface.hasRefusedConstraint` (bridge
`OCCTFillingRefusedConstraintCount`), which separate "a constraint never made it in" from "the fit
was attempted and failed", both of which return nil from `build()`:

```swift
guard let face = filling.build() else {
    print(filling.hasRefusedConstraint ? "a constraint was refused" : "the fit failed")
    return
}
```

**Source-compatible, behaviour-breaking.** No signature changed, but a caller who was relying on
`build()` succeeding after a refused `add` now gets nil. To attempt a constraint speculatively and
carry on, use `add(edge:continuity:)`, which derives the continuity reference from the edge itself
and so has nothing to refuse. That is the option-1 cost the issue named, and it is already served
by the other overload.

Two doc comments promised this behaviour before anything enforced it: `add(edge:support:)`'s "used
or the constraint fails" and `OCCTFillingAddEdgeWithSupport`'s "the caller should treat the whole
fill as failed". Both are now true.

## Verification

- Two new cases in `OCCTSurfaceTests`' `FillingSupportFaceTests`, one covering the poisoned build
  (with a control proving the same constraints build fine on their own, so the nil is not vacuous)
  and one covering accumulation and stickiness across a later successful `add`.
- **Both proven sensitive**: the pre-#482 `build()` was injected back into the bridge and the tests
  fail on it (4 expectation failures, including `isDone == true` and `g0Error == 2.77e-05`, which
  is where the measurement above comes from). Restored and re-verified.
- Full suite green: **4627 tests**, built from bridge source with `OCCTSWIFT_BRIDGE_PREBUILT`
  unset, so the `.mm`/`.h` changes were actually compiled.

## Docs

CHANGELOG entry, a "Refused constraints" section plus the two new property pages in
`docs/reference/GeometrySolvers.md`, `API_REFERENCE.md` mapping rows.
`Scripts/count-operations.py --fix` takes the derived total to **4,270**; two of the four are the
new properties, the other two were a pre-existing drift on `main` (recorded 4,266 against a derived
4,268 before this change).

The prebuilt `OCCTBridge.xcframework` URL and checksum are untouched: `Sources/OCCTBridge/src/*.mm`
changed, so it needs rebuilding, but that belongs to the release commit that tags it.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)