### PR TITLE
fix(#520): one edge-index contract and one radius law for all five fillet entry points

### DIFF
--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -45,6 +45,12 @@ INIT = re.compile(r'^\s*public\s+(?:convenience\s+)?init[?!]?\s*\(')
 # or `public var x = 0` has no brace and is data, not an entry point.
 CVAR = re.compile(r'^\s*public\s+(?:static\s+)?var\s+([A-Za-z_][A-Za-z0-9_]*)\b[^=]*\{')
 SUBS = re.compile(r'^\s*public\s+(?:static\s+)?subscript\s*\(')
+# An @available(..., unavailable, ...) attribute: the declaration below it is a retired spelling
+# kept only so an old call site fails to build with an explanation, so it is not an entry point.
+# A `deprecated` one still is — it can still be called. Only the attribute's opening line is
+# matched, which is where `unavailable` sits; a multi-line `message:` body below it matches none
+# of the declaration patterns above (#520).
+UNAVAILABLE = re.compile(r'^\s*@available\s*\([^)]*\bunavailable\b')
 # reference docs use both ### and #### for entry points
 DOC_HEADING = re.compile(r'^#{3,4} `([^`]+)`')
 
@@ -80,22 +86,33 @@ def count_entry_points():
         rel = os.path.relpath(f, ROOT)
         stack = []      # [(type_name, brace_depth_at_open)]
         depth = 0
+        unavailable = False   # an @available(*, unavailable) seen; it applies to the next decl
         for i, line in enumerate(open(f, encoding="utf-8", errors="replace"), 1):
             code = re.sub(r'//.*', '', line)   # crude line-comment strip for brace counting
             enc = _enclosing_type(stack)
+            if UNAVAILABLE.match(line):
+                unavailable = True
             m = FUNC.match(line)
             if m:
-                breakdown["func"] += 1
-                ops.setdefault((enc, m.group(1)), (rel, i))
+                if not unavailable:
+                    breakdown["func"] += 1
+                    ops.setdefault((enc, m.group(1)), (rel, i))
+                unavailable = False
             elif INIT.match(line):
-                breakdown["init"] += 1
+                if not unavailable:
+                    breakdown["init"] += 1
+                unavailable = False
             else:
                 m = CVAR.match(line)
                 if m:
-                    breakdown["computed var"] += 1
-                    ops.setdefault((enc, m.group(1)), (rel, i))
+                    if not unavailable:
+                        breakdown["computed var"] += 1
+                        ops.setdefault((enc, m.group(1)), (rel, i))
+                    unavailable = False
                 elif SUBS.match(line):
-                    breakdown["subscript"] += 1
+                    if not unavailable:
+                        breakdown["subscript"] += 1
+                    unavailable = False
 
             # maintain the enclosing-type stack
             td = TYPE_DECL.match(line)

--- a/Scripts/repro/520-fillet-edge-index-contracts/README.md
+++ b/Scripts/repro/520-fillet-edge-index-contracts/README.md
@@ -1,0 +1,107 @@
+# OCCTSwift#520 ground truth: the radius law `BRepFilletAPI_MakeFillet` was never given
+
+Two standalone probes, run against the pinned `OCCT.xcframework` (8.0.0p1 + our carried patches).
+They establish what OCCT does with the calls the two radius-law fillet entry points were making,
+and what its `SetRadius(UandR, …)` overload does with a profile no one validates. They are what the
+#520 fix is calibrated against: the issue asked three contract questions and the measurement
+answered a fourth nobody had asked.
+
+No fixture files: every case is a box.
+
+## Compile and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/520-fillet-edge-index-contracts/occt_520_variable_radius_law.mm \
+  -o /tmp/occt_520_variable_radius_law
+/tmp/occt_520_variable_radius_law     # ends in a SIGSEGV; that is the last case
+```
+
+The second probe crashes in two of its cases, so each runs in its own process:
+
+```bash
+clang++ … Scripts/repro/520-fillet-edge-index-contracts/occt_520_radius_law_crash.mm \
+  -o /tmp/occt_520_radius_law_crash
+for c in no-radius radius-dropped zero-radius negative-radius all-radii-zero \
+         params-out-of-range-2pt params-out-of-range-3pt params-equivalent-3pt \
+         params-degenerate-3pt params-descending-3pt single-point; do
+  /tmp/occt_520_radius_law_crash "$c"; echo "  exit=$?"
+done
+```
+
+## `occt_520_variable_radius_law.mm`: the overload `OCCTShapeFilletVariable` was calling
+
+The bridge wrote, once per profile point:
+
+```cpp
+double param = first + params[i] * (last - first);   // a curve parameter
+fillet.SetRadius(radii[i], param, 1);                // "1 is the contour index"
+```
+
+`BRepFilletAPI_MakeFillet` has no `(Real, Real, Integer)` overload. The viable candidate is
+`SetRadius(const double Radius, const int IC, const int IinC)`, so `param` was truncated to an `int`
+and used as the **contour** index, and `1` was the edge-within-contour index. The comment was wrong
+about which argument it was naming, and the call was wrong about what it was setting.
+
+| profile on a 20mm box, edge 0 | measured |
+|---|---|
+| bridge: `SetRadius(r, param, 1)` per point | volume 7995.707963 |
+| OCCT: `SetRadius(UandR, 1, 1)` | volume 7981.047467 |
+| reference: constant 1.0 | volume **7995.707963** |
+| reference: constant 3.0 | volume 7961.371669 |
+
+The bridge result is bit-identical to the constant-1.0 reference. Same on a 30mm box with a 3-point
+profile: bridge 26993.561945, constant-1.0 26993.561945, the requested profile 26947.284023. The
+"variable radius" fillet was a constant one.
+
+Why that particular constant, and why it was a crash waiting to happen, is the third section. A box
+edge's curve range is `[0, side]`, so `[(0, 1.0), (1, 3.0)]` truncated to contour indices 0 and 20:
+
+| call on a 20mm box with 1 contour | measured |
+|---|---|
+| `SetRadius(2.0, IC=0, IinC=1)` | volume 7982.831853 — same as `IC=1`, i.e. it took effect |
+| `SetRadius(2.0, IC=1, IinC=1)` | volume 7982.831853 |
+| `SetRadius(2.0, IC=20, IinC=1)` | dropped, then **SIGSEGV** in `Build()` |
+
+`ChFi3d_FilBuilder::SetRadius` guards only `IC <= NbElements()`, with no lower bound (the same
+one-sided check #505 found). `IC=0` passes it and reaches `Value(0)` on a 1-based sequence, which on
+this build happened to read contour 1 — so the first profile point landed as a constant radius. A
+large `IC` fails the check and is dropped silently, which is what made the last point a no-op.
+
+## `occt_520_radius_law_crash.mm`: the contour that never gets a radius, and the profile contract
+
+| case | measured |
+|---|---|
+| `no-radius` — `Add(edge)`, no `SetRadius` at all | **SIGSEGV** (exit 139) |
+| `radius-dropped` — the one `SetRadius` dropped by `IC <= NbElements()` | **SIGSEGV** (exit 139) |
+| `zero-radius` — profile `[(0, 1.0), (1, 0.0)]` | `IsDone=1`, volume 7998.480894, valid |
+| `negative-radius` — profile `[(0, 1.0), (1, -3.0)]` | `IsDone=1`, volume 7999.471533, **`BRepCheck_Analyzer` invalid** |
+| `all-radii-zero` | `IsDone=0` |
+| `params-out-of-range-2pt` — X of 99 and -3 | volume 7981.047467, identical to X of 0 and 1 |
+| `params-out-of-range-3pt` — X of -5, 0, 7 | volume 7963.730821 |
+| `params-equivalent-3pt` — X of 0, 0.4166…, 1 | volume 7963.730821, identical to the row above |
+| `params-degenerate-3pt` — X all 0.5 | `IsDone=0` (the renormalisation divides by zero) |
+| `params-descending-3pt` — X of 1, 0.5, 0 | volume 7960.426609, a different shape from the ascending profile |
+| `single-point` | volume 7982.831853, i.e. a constant radius |
+
+Three things follow, and they are what `occtFilletSetRadiusProfile` enforces:
+
+1. **A contour must receive a radius.** Nothing downstream reports the omission; `Build()` crashes,
+   uncatchably. Every path that calls `Add(edge)` has to reach a successful `SetRadius` or return
+   before `Build()`.
+2. **A non-positive radius in a profile is not caught by OCCT.** This is the opposite of what #489
+   measured for `Add(radius, edge)`, where a bad radius merely fails `IsDone()`. Here it reports
+   success and hands back an invalid shape, so the bridge-side precondition is the only thing
+   between that shape and a caller.
+3. **`[0, 1]` is a caller-facing contract, not an OCCT-enforced one.** OCCT ignores the parameters
+   entirely for 1 or 2 points and renormalises 3 or more, so an out-of-range profile is silently
+   *reinterpreted* rather than rejected — `[(-5, 1), (0, 4), (7, 1)]` puts its peak at 41.7% of the
+   contour instead of at the start. Equal parameters divide by zero and descending ones reverse the
+   law. All three are rejected rather than reinterpreted.
+
+The same renormalisation is why a profile always spans the whole edge: it cannot fillet part of one
+and leave the rest alone, and only the *relative* spacing of interior points survives. That is
+documented on both Swift entry points rather than being left for a caller to discover.

--- a/Scripts/repro/520-fillet-edge-index-contracts/occt_520_radius_law_crash.mm
+++ b/Scripts/repro/520-fillet-edge-index-contracts/occt_520_radius_law_crash.mm
@@ -1,0 +1,149 @@
+// OCCTSwift#520 ground truth, part 2: what BRepFilletAPI_MakeFillet::Build() does when a contour
+// added by the radius-law overload Add(edge) never receives a radius, and what the documented
+// UandR overload does with parameters and radii the bridge never checks.
+//
+// Part 1 (occt_520_variable_radius_law.mm) ends in a SIGSEGV, so each case here runs in its own
+// process: pass the case name as argv[1]. `run.sh` runs them all and reports each exit status.
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <TColgp_Array1OfPnt2d.hxx>
+#include <Standard_Failure.hxx>
+#include <cstdio>
+#include <cstring>
+
+static TopoDS_Shape box(double side) { return BRepPrimAPI_MakeBox(side, side, side).Shape(); }
+
+static TopoDS_Edge firstEdge(const TopoDS_Shape& s) {
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(s, TopAbs_EDGE, edgeMap);
+    return TopoDS::Edge(edgeMap(1));
+}
+
+static void result(BRepFilletAPI_MakeFillet& fillet) {
+    try {
+        fillet.Build();
+        printf("  IsDone=%d", (int)fillet.IsDone());
+        if (fillet.IsDone()) {
+            TopoDS_Shape res = fillet.Shape();
+            printf(" IsNull=%d", (int)res.IsNull());
+            if (!res.IsNull()) {
+                GProp_GProps props;
+                BRepGProp::VolumeProperties(res, props);
+                printf(" volume=%.6f valid=%d", props.Mass(), (int)BRepCheck_Analyzer(res).IsValid());
+            }
+        }
+        printf("\n");
+    } catch (Standard_Failure& f) {
+        printf("  THREW: %s\n", f.GetMessageString());
+    }
+}
+
+// Add(edge) with a UandR profile, the overload OCCTShapeFilletEvolving uses.
+static void withProfile(int count, const double* params, const double* radii) {
+    TopoDS_Shape s = box(20.0);
+    BRepFilletAPI_MakeFillet fillet(s);
+    fillet.Add(firstEdge(s));
+    TColgp_Array1OfPnt2d UandR(1, count);
+    for (int i = 0; i < count; i++) UandR.SetValue(i + 1, gp_Pnt2d(params[i], radii[i]));
+    try {
+        fillet.SetRadius(UandR, 1, 1);
+    } catch (Standard_Failure& f) {
+        printf("  SetRadius THREW: %s\n", f.GetMessageString());
+        return;
+    }
+    result(fillet);
+}
+
+int main(int argc, const char** argv) {
+    setvbuf(stdout, NULL, _IONBF, 0);
+    const char* which = argc > 1 ? argv[1] : "";
+    printf("[%s]\n", which);
+
+    // --- the contour that never gets a radius ---
+
+    // Add(edge) and nothing else. This is what OCCTShapeFilletEvolving produces for an edge whose
+    // radiusPoints array is empty (pointCounts[i] == 0 takes neither of its two branches).
+    if (!strcmp(which, "no-radius")) {
+        TopoDS_Shape s = box(20.0);
+        BRepFilletAPI_MakeFillet fillet(s);
+        fillet.Add(firstEdge(s));
+        printf("  NbContours=%d, no SetRadius call at all\n", fillet.NbContours());
+        result(fillet);
+    }
+
+    // Every SetRadius dropped because the truncated contour index exceeded NbElements(). This is
+    // what OCCTShapeFilletVariable produces for any edge whose curve parameter range does not
+    // start at 0 (the box edges all start at 0, which is why its tests pass).
+    if (!strcmp(which, "radius-dropped")) {
+        TopoDS_Shape s = box(20.0);
+        BRepFilletAPI_MakeFillet fillet(s);
+        fillet.Add(firstEdge(s));
+        printf("  NbContours=%d, SetRadius(2.0, IC=20, IinC=1) is dropped by IC <= NbElements()\n",
+               fillet.NbContours());
+        fillet.SetRadius(2.0, 20, 1);
+        result(fillet);
+    }
+
+    // --- the UandR profile the bridge never validates ---
+
+    // A non-positive radius in the profile.
+    if (!strcmp(which, "zero-radius")) {
+        const double params[] = {0.0, 1.0};
+        const double radii[]  = {1.0, 0.0};
+        withProfile(2, params, radii);
+    }
+    if (!strcmp(which, "negative-radius")) {
+        const double params[] = {0.0, 1.0};
+        const double radii[]  = {1.0, -3.0};
+        withProfile(2, params, radii);
+    }
+    if (!strcmp(which, "all-radii-zero")) {
+        const double params[] = {0.0, 0.5, 1.0};
+        const double radii[]  = {0.0, 0.0, 0.0};
+        withProfile(3, params, radii);
+    }
+
+    // Parameters outside the [0,1] both OCCT's header and Shape.filletedVariable's doc comment
+    // promise. OCCT renormalises with Ucur = (Ucur - Uf) / (Ul - Uf) for 3+ points, and ignores
+    // X entirely for 1 or 2 points, so these are the cases that say how much [0,1] is worth.
+    if (!strcmp(which, "params-out-of-range-2pt")) {
+        const double params[] = {99.0, -3.0};   // X ignored: the 2-point shortcut reads Y only
+        const double radii[]  = {1.0, 3.0};
+        withProfile(2, params, radii);
+    }
+    if (!strcmp(which, "params-out-of-range-3pt")) {
+        const double params[] = {-5.0, 0.0, 7.0};   // renormalised to 0, 0.4166.., 1
+        const double radii[]  = {1.0, 4.0, 1.0};
+        withProfile(3, params, radii);
+    }
+    if (!strcmp(which, "params-equivalent-3pt")) {
+        const double params[] = {0.0, 0.416666666666667, 1.0};   // the renormalised equivalent
+        const double radii[]  = {1.0, 4.0, 1.0};
+        withProfile(3, params, radii);
+    }
+    // All three parameters equal: Ul - Uf == 0, so the renormalisation divides by zero.
+    if (!strcmp(which, "params-degenerate-3pt")) {
+        const double params[] = {0.5, 0.5, 0.5};
+        const double radii[]  = {1.0, 4.0, 1.0};
+        withProfile(3, params, radii);
+    }
+    // Descending parameters: Ul - Uf < 0, so the renormalisation flips the profile.
+    if (!strcmp(which, "params-descending-3pt")) {
+        const double params[] = {1.0, 0.5, 0.0};
+        const double radii[]  = {1.0, 4.0, 2.0};
+        withProfile(3, params, radii);
+    }
+    // A single point: the X is ignored and the radius is constant.
+    if (!strcmp(which, "single-point")) {
+        const double params[] = {0.5};
+        const double radii[]  = {2.0};
+        withProfile(1, params, radii);
+    }
+    return 0;
+}

--- a/Scripts/repro/520-fillet-edge-index-contracts/occt_520_variable_radius_law.mm
+++ b/Scripts/repro/520-fillet-edge-index-contracts/occt_520_variable_radius_law.mm
@@ -1,0 +1,141 @@
+// OCCTSwift#520 ground truth, part 1: which SetRadius overload OCCTShapeFilletVariable actually
+// calls.
+//
+// The bridge writes, once per profile point:
+//
+//     double param = first + params[i] * (last - first);   // a curve parameter
+//     fillet.SetRadius(radii[i], param, 1);                // "1 is the contour index"
+//
+// BRepFilletAPI_MakeFillet has no (Real, Real, Integer) overload. The viable candidate is
+// SetRadius(const double Radius, const int IC, const int IinC), so `param` is silently truncated
+// to an int and used as the *contour* index, and `1` is the edge-within-contour index. This probe
+// measures what that does, against a call that passes the profile the way OCCT documents it
+// (a TColgp_Array1OfPnt2d of (relative parameter, radius) pairs).
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_Curve.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <TColgp_Array1OfPnt2d.hxx>
+#include <Standard_Failure.hxx>
+#include <cstdio>
+
+static TopoDS_Shape box(double side) { return BRepPrimAPI_MakeBox(side, side, side).Shape(); }
+
+static TopoDS_Edge firstEdge(const TopoDS_Shape& s) {
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(s, TopAbs_EDGE, edgeMap);
+    return TopoDS::Edge(edgeMap(1));  // bridge edgeIndex 0
+}
+
+static void result(const char* label, BRepFilletAPI_MakeFillet& fillet) {
+    printf("%-46s", label);
+    try {
+        fillet.Build();
+        printf(" IsDone=%d", (int)fillet.IsDone());
+        if (fillet.IsDone()) {
+            TopoDS_Shape res = fillet.Shape();
+            printf(" IsNull=%d", (int)res.IsNull());
+            if (!res.IsNull()) {
+                GProp_GProps props;
+                BRepGProp::VolumeProperties(res, props);
+                printf(" volume=%.6f valid=%d", props.Mass(), (int)BRepCheck_Analyzer(res).IsValid());
+            }
+        }
+        printf("\n");
+    } catch (Standard_Failure& f) {
+        printf(" THREW: %s\n", f.GetMessageString());
+    }
+}
+
+// Exactly what OCCTShapeFilletVariable does today.
+static void asBridgeDoesIt(const char* label, double side,
+                           const double* params, const double* radii, int count) {
+    TopoDS_Shape s = box(side);
+    TopoDS_Edge e = firstEdge(s);
+    BRepFilletAPI_MakeFillet fillet(s);
+    fillet.Add(e);
+
+    double first, last;
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(e, first, last);
+    printf("  edge parameter range [%g, %g], NbContours=%d\n", first, last, fillet.NbContours());
+    for (int i = 0; i < count; i++) {
+        double param = first + params[i] * (last - first);
+        printf("    SetRadius(%g, %g -> IC=%d, IinC=1)\n", radii[i], param, (int)param);
+        fillet.SetRadius(radii[i], param, 1);
+    }
+    result(label, fillet);
+}
+
+// The same profile, passed the way BRepFilletAPI_MakeFillet documents it.
+static void asOCCTDocumentsIt(const char* label, double side,
+                              const double* params, const double* radii, int count) {
+    TopoDS_Shape s = box(side);
+    BRepFilletAPI_MakeFillet fillet(s);
+    fillet.Add(firstEdge(s));
+
+    TColgp_Array1OfPnt2d UandR(1, count);
+    for (int i = 0; i < count; i++) UandR.SetValue(i + 1, gp_Pnt2d(params[i], radii[i]));
+    fillet.SetRadius(UandR, 1, 1);
+    result(label, fillet);
+}
+
+static void constantRadius(const char* label, double side, double radius) {
+    TopoDS_Shape s = box(side);
+    BRepFilletAPI_MakeFillet fillet(s);
+    fillet.Add(radius, firstEdge(s));
+    result(label, fillet);
+}
+
+int main() {
+    // Unbuffered: one of these cases crashes, and a buffered stdout loses everything printed
+    // before it.
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    // Case 1: the two-point profile from Shape.filletedVariable's own doc comment and test.
+    {
+        const double params[] = {0.0, 1.0};
+        const double radii[]  = {1.0, 3.0};
+        printf("=== profile [(0.0, 1.0), (1.0, 3.0)] on a 20mm box, edge 0 ===\n");
+        asBridgeDoesIt("  bridge: SetRadius(r, param, 1)", 20.0, params, radii, 2);
+        asOCCTDocumentsIt("  OCCT:   SetRadius(UandR, 1, 1)", 20.0, params, radii, 2);
+        constantRadius("  reference: constant 1.0", 20.0, 1.0);
+        constantRadius("  reference: constant 3.0", 20.0, 3.0);
+    }
+
+    // Case 2: three points, so the two-point shortcut inside OCCT's UandR overload is not taken.
+    {
+        const double params[] = {0.0, 0.5, 1.0};
+        const double radii[]  = {1.0, 4.0, 1.0};
+        printf("\n=== profile [(0.0, 1.0), (0.5, 4.0), (1.0, 1.0)] on a 30mm box, edge 0 ===\n");
+        asBridgeDoesIt("  bridge: SetRadius(r, param, 1)", 30.0, params, radii, 3);
+        asOCCTDocumentsIt("  OCCT:   SetRadius(UandR, 1, 1)", 30.0, params, radii, 3);
+        constantRadius("  reference: constant 1.0", 30.0, 1.0);
+        constantRadius("  reference: constant 4.0", 30.0, 4.0);
+    }
+
+    // Case 3: which of the bridge's two truncated contour indices, if either, is the one that
+    // takes effect. ChFi3d_FilBuilder::SetRadius guards only `IC <= NbElements()`, so IC=0 passes
+    // that check and reaches Value(0) on a 1-based sequence, while a large IC is dropped silently.
+    printf("\n=== the two truncated contour indices in isolation (20mm box, 1 contour) ===\n");
+    for (int ic : {0, 1, 20}) {
+        TopoDS_Shape s = box(20.0);
+        BRepFilletAPI_MakeFillet fillet(s);
+        fillet.Add(firstEdge(s));
+        char label[80];
+        snprintf(label, sizeof(label), "  SetRadius(2.0, IC=%d, IinC=1)", ic);
+        try {
+            fillet.SetRadius(2.0, ic, 1);
+        } catch (Standard_Failure& f) {
+            printf("%-46s SetRadius THREW: %s\n", label, f.GetMessageString());
+            continue;
+        }
+        result(label, fillet);
+    }
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1630,9 +1630,10 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType);
 ///
 /// One of three entry points sharing occtShapeFilletEdgeList (OCCTBridge_Internal.h) with
 /// OCCTShapeFilletEdgesLinear and OCCTShapeBlendEdges: same edge map, same 0-based index bounds
-/// check (an out-of-range index is skipped), same positive-radius precondition. #489
+/// check, same positive-radius precondition. #489
 /// @param shape The shape to fillet
-/// @param edgeIndices Array of edge indices (0-based)
+/// @param edgeIndices Array of edge indices (0-based; an index naming no edge of `shape` rejects
+///   the whole call, #520)
 /// @param edgeCount Number of edges to fillet
 /// @param radius Fillet radius; must be > 0, or the call fails without touching OCCT
 /// @return Filleted shape, or NULL on failure
@@ -1643,7 +1644,8 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
 ///
 /// Shares occtShapeFilletEdgeList with OCCTShapeFilletEdges and OCCTShapeBlendEdges. #489
 /// @param shape The shape to fillet
-/// @param edgeIndices Array of edge indices (0-based)
+/// @param edgeIndices Array of edge indices (0-based; an index naming no edge of `shape` rejects
+///   the whole call, #520)
 /// @param edgeCount Number of edges to fillet
 /// @param startRadius Radius at start of each edge; must be > 0
 /// @param endRadius Radius at end of each edge; must be > 0
@@ -2350,11 +2352,17 @@ void OCCTZLayerSettingsGetOrigin(OCCTZLayerSettingsRef settings, double* x, doub
 // MARK: - Advanced Blends & Surface Filling (v0.14.0)
 
 /// Apply variable radius fillet to a specific edge
+///
+/// One of the two radius-law entry points, with OCCTShapeFilletEvolving: both resolve their edges
+/// through occtFilletAddEdges and apply their profile through occtFilletSetRadiusProfile
+/// (OCCTBridge_Internal.h), which is where the profile contract is documented and enforced. #520
 /// @param shape The shape to fillet
-/// @param edgeIndex Index of the edge to fillet
-/// @param radii Array of radius values along the edge
-/// @param params Array of parameter values (0-1) where radii apply
-/// @param count Number of radius/parameter pairs
+/// @param edgeIndex Index of the edge to fillet (0-based; an index naming no edge of `shape`
+///   rejects the call)
+/// @param radii Array of radius values along the edge; every element must be > 0
+/// @param params Array of relative parameters where those radii apply; each must lie in [0, 1] and
+///   they must strictly increase
+/// @param count Number of radius/parameter pairs; at least 2
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
                                       const double* radii, const double* params, int32_t count);
@@ -2393,7 +2401,8 @@ OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance);
 /// while the other two are in OCCTBridge_Modeling.mm, which is how it came to be the one without
 /// a radius precondition. #489
 /// @param shape The shape to blend
-/// @param edgeIndices Array of edge indices (0-based; an out-of-range index is skipped)
+/// @param edgeIndices Array of edge indices (0-based; an index naming no edge of `shape` rejects
+///   the whole call, #520)
 /// @param radii Array of radii (one per edge); every element must be > 0, or the whole call fails
 /// @param count Number of edges
 /// @return Blended shape, or NULL on failure
@@ -5273,11 +5282,18 @@ typedef struct {
 } OCCTFilletRadiusPoint;
 
 /// Apply evolving-radius fillets to multiple edges simultaneously.
+///
+/// The multi-edge radius-law entry point, sharing occtFilletAddEdges with the other four fillet
+/// edge-list functions and occtFilletSetRadiusProfile with OCCTShapeFilletVariable
+/// (OCCTBridge_Internal.h). Its indices were 1-based until #520 made the family agree.
 /// @param shape The shape
-/// @param edgeIndices Array of 1-based edge indices
+/// @param edgeIndices Array of edge indices (0-based since #520; an index naming no edge of
+///   `shape` rejects the whole call)
 /// @param edgeCount Number of edges
-/// @param radiusPoints Array of parameter-radius pairs per edge (flattened: edge0[rp0,rp1,...], edge1[rp0,...], ...)
-/// @param pointCounts Array of how many radius points per edge
+/// @param radiusPoints Array of parameter-radius pairs per edge (flattened: edge0[rp0,rp1,...], edge1[rp0,...], ...);
+///   every radius must be > 0, and each edge's parameters must lie in [0, 1] and strictly increase
+/// @param pointCounts Array of how many radius points per edge; fewer than 1 for any edge rejects
+///   the call, since a contour with no radius SIGSEGVs in Build()
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
                                       const int32_t* edgeIndices, int32_t edgeCount,

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -469,35 +469,32 @@ OCCTShapeRef OCCTShapeSimplify(OCCTShapeRef shape, double tolerance) {
 
 // MARK: - Advanced Blends & Surface Filling (v0.14.0)
 
+// The single-edge member of the radius-law pair, sharing occtFilletAddEdges (the edge lookup and
+// its bounds check) and occtFilletSetRadiusProfile (the law itself) with OCCTShapeFilletEvolving in
+// OCCTBridge_Modeling.mm. See OCCTBridge_Internal.h for what OCCT does with a profile.
+//
+// This used to map each relative parameter onto the edge's own curve parameter range and pass the
+// result to SetRadius(radii[i], param, 1). BRepFilletAPI_MakeFillet has no (Real, Real, Integer)
+// overload: `param` was truncated to an int and taken as the *contour* index, so the profile was
+// never applied. What the caller got was a constant radius, whichever profile point happened to
+// truncate to a live contour index — and, for any edge whose parameter range does not start at 0,
+// no radius at all, which SIGSEGVs in Build(). Both measured in
+// Scripts/repro/520-fillet-edge-index-contracts/. #520
 OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
                                       const double* radii, const double* params, int32_t count) {
-    if (!shape || !radii || !params || count < 2 || edgeIndex < 0) return nullptr;
+    if (!shape || !radii || !params || count < 2) return nullptr;
 
     try {
-        // Get the edge at the specified index
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-
-        if (edgeIndex >= edgeMap.Extent()) return nullptr;
-
-        TopoDS_Edge edge = TopoDS::Edge(edgeMap(edgeIndex + 1));  // OCCT uses 1-based indexing
-
-        // Create fillet maker
         BRepFilletAPI_MakeFillet fillet(shape->shape);
+        if (!occtFilletAddEdges(fillet, shape->shape, &edgeIndex, 1,
+                                [](BRepFilletAPI_MakeFillet& f, const TopoDS_Edge& edge, int32_t) {
+            f.Add(edge);  // the radius-law overload: the profile below supplies the radius
+        })) return nullptr;
 
-        // Add edge with variable radius
-        fillet.Add(edge);
-
-        // Get the edge length for parameter mapping
-        double first, last;
-        Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
-        if (curve.IsNull()) return nullptr;
-
-        // Set radius at each parameter point
-        for (int32_t i = 0; i < count; i++) {
-            double param = first + params[i] * (last - first);  // Map 0-1 to curve parameter range
-            fillet.SetRadius(radii[i], param, 1);  // 1 is the contour index
-        }
+        if (!occtFilletSetRadiusProfile(fillet, fillet.NbContours(), count,
+                                        [radii, params](int32_t i) {
+            return gp_Pnt2d(params[i], radii[i]);
+        })) return nullptr;
 
         fillet.Build();
         if (!fillet.IsDone()) return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -69,6 +69,8 @@
 #include <TopoDS.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TopTools_ListOfShape.hxx>
+#include <TColgp_Array1OfPnt2d.hxx>
+#include <gp_Pnt2d.hxx>
 // These four serve the local-properties helpers (occtSurfaceLocalProps and friends).
 #include <GeomLProp_SLProps.hxx>
 #include <GeomLProp_CLProps.hxx>
@@ -810,16 +812,19 @@ inline bool occtValidFilletRadii(const double* radii, int32_t count) {
 }
 
 // Add the edges named by `edgeIndices` (0-based, indexing `shape`'s own TopExp edge map) to
-// `fillet`, through whichever Add overload the caller's radius law needs.
+// `fillet`, through whichever Add overload the caller's radius law needs. Returns false, having
+// added nothing further, when an index does not name an edge of `shape`.
 //
 // `addEdge(fillet, edge, entry)` is the only part that varies between the callers: `entry` is the
 // index into the caller's own arrays, so a per-edge radius list can read its own element. It is
 // called only for indices that resolve to a real edge.
 //
-// An out-of-range index is skipped rather than rejected, which is the behaviour every caller had
-// before they shared this loop. When that leaves no contour at all, the subsequent Build() throws
-// "There are no suitable edges for chamfer or fillet", so a caller's catch(...) still reports
-// failure; nothing here has to detect the empty case itself.
+// #520 made an out-of-range index reject the call. It used to be skipped here, so a batch with one
+// bad index filleted the rest and reported success: a request honoured in part, presented as
+// honoured in full, the same defect class as #439/#442/#443. The two radius-law entry points
+// (OCCTShapeFilletVariable, OCCTShapeFilletEvolving) already rejected, so this is what makes all
+// five agree. A caller who wants best-effort can filter its own indices; a caller who cannot tell
+// a partial result from a complete one had no way back.
 //
 // Not folded into occtShapeFilletEdgeList below because OCCTShapeHistoryFromFilletEdges has to
 // keep its builder alive past the call, to hand back a BRepTools_History over it.
@@ -827,16 +832,70 @@ inline bool occtValidFilletRadii(const double* radii, int32_t count) {
 // Radius validation is the caller's, since the shapes it takes (one scalar, two scalars, an array,
 // a (parameter, radius) point list) have nothing in common but occtValidFilletRadius above.
 template <class AddEdge>
-void occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
+bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
                         const int32_t* edgeIndices, int32_t edgeCount, AddEdge addEdge) {
     TopTools_IndexedMapOfShape edgeMap;
     TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
 
     for (int32_t i = 0; i < edgeCount; i++) {
         int32_t idx = edgeIndices[i];
-        if (idx < 0 || idx >= edgeMap.Extent()) continue;
+        if (idx < 0 || idx >= edgeMap.Extent()) return false;
         addEdge(fillet, TopoDS::Edge(edgeMap(idx + 1)), i);  // OCCT's map is 1-based
     }
+    return true;
+}
+
+// === #520: the radius law, for the two entry points that take one ===
+//
+// A contour added by the law-taking Add(edge) overload carries no radius of its own, and
+// BRepFilletAPI_MakeFillet::Build() **SIGSEGVs** on a contour that never receives one — an OS
+// signal, so no catch(...) on this side of the bridge can turn it into nullptr. Every path that
+// calls Add(edge) therefore has to reach a successful SetRadius, or return before Build().
+// Measured in Scripts/repro/520-fillet-edge-index-contracts/ (`no-radius`, `radius-dropped`).
+//
+// Applying the law is one SetRadius(UandR, contour, 1) call, which is what makes the validation
+// below worth sharing. OCCT's own contract for that array (BRepFilletAPI_MakeFillet.hxx):
+//
+//   - X is a *relative* parameter on the contour, between 0 and 1; Y is the radius there.
+//   - With 1 point the X is ignored and the radius is constant; with 2 the X values are ignored
+//     too and only the endpoint radii are used; with 3 or more OCCT renormalises via
+//     (U - Uf) / (Ul - Uf), so the profile always spans the whole contour whatever the caller
+//     wrote, and only the *relative* placement of the interior points survives.
+//
+// So the [0,1] range is not load-bearing inside OCCT, and that is exactly why it is checked here:
+// a profile written outside it is silently reinterpreted rather than rejected, e.g.
+// [(-5, 1), (0, 4), (7, 1)] puts its peak at 41.7% of the contour rather than at the start. The
+// two degenerate orderings are worse than reinterpreted: equal parameters divide by zero, and
+// descending ones reverse the law the caller wrote (measured: 7960.426609 against 7963.730821 for
+// the ascending equivalent).
+//
+// Unlike the Add(radius, edge) path #489 measured, a non-positive radius here is not caught by
+// OCCT at all: a profile containing -3.0 reports IsDone() == 1 and hands back a shape
+// BRepCheck_Analyzer rejects. This predicate is the only thing standing between that and a caller.
+//
+// `pointAt(i)` returns the i-th point as a gp_Pnt2d(relative parameter, radius); the two callers
+// hold their profiles in different layouts (parallel arrays, and an array of OCCTFilletRadiusPoint)
+// and neither is worth copying to share this.
+template <class PointAt>
+bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, int32_t contourIndex,
+                                int32_t pointCount, PointAt pointAt) {
+    if (pointCount < 1) return false;
+
+    TColgp_Array1OfPnt2d UandR(1, pointCount);
+    double previous = 0;
+    for (int32_t i = 0; i < pointCount; i++) {
+        gp_Pnt2d point = pointAt(i);
+        if (!occtValidFilletRadius(point.Y())) return false;
+        // Written as a positive test so NaN, which compares false against everything, is rejected
+        // by the same expression rather than needing its own.
+        if (!(point.X() >= 0.0 && point.X() <= 1.0)) return false;
+        if (i > 0 && !(point.X() > previous)) return false;
+        previous = point.X();
+        UandR.SetValue(i + 1, point);
+    }
+
+    fillet.SetRadius(UandR, contourIndex, 1);
+    return true;
 }
 
 // occtFilletAddEdges plus the build-and-wrap half: the guard, the perform/check/result triad, and
@@ -850,7 +909,9 @@ OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
 
     try {
         BRepFilletAPI_MakeFillet fillet(shape->shape);
-        occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge);
+        if (!occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge)) {
+            return nullptr;
+        }
 
         fillet.Build();
         if (!fillet.IsDone()) return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -1842,11 +1842,11 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdges(OCCTShapeRef shape,
     if (!shape || !edgeIndices || count < 1) return nullptr;
     try {
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
-        occtFilletAddEdges(*op, shape->shape, edgeIndices, count,
-                           [radius](BRepFilletAPI_MakeFillet& fillet,
-                                    const TopoDS_Edge& edge, int32_t) {
+        if (!occtFilletAddEdges(*op, shape->shape, edgeIndices, count,
+                                [radius](BRepFilletAPI_MakeFillet& fillet,
+                                         const TopoDS_Edge& edge, int32_t) {
             fillet.Add(radius, edge);
-        });
+        })) return nullptr;
         op->Build();
         if (!op->IsDone()) return nullptr;
         TopoDS_Shape result = op->Shape();
@@ -2353,44 +2353,45 @@ OCCTShapeRef OCCTShapeCutAndBlend(OCCTShapeRef shape1, OCCTShapeRef shape2, doub
 
 // MARK: - Multi-Edge Evolving Fillet (v0.38.0)
 
+// The multi-edge member of the radius-law pair. It shares occtFilletAddEdges with the other four
+// entry points and occtFilletSetRadiusProfile with OCCTShapeFilletVariable (OCCTBridge_Healing.mm).
+//
+// Two contract changes, #520. `edgeIndices` is 0-based, as it is for every sibling; it was the one
+// 1-based edge index in the family. And a per-edge point count below 1 is now rejected: it used to
+// take neither branch, leaving a contour with no radius at all, which SIGSEGVs in Build() rather
+// than failing IsDone(). Reachable from Swift as EvolvingFilletEdge(edge:radiusPoints: []).
 OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
                                       const int32_t* edgeIndices, int32_t edgeCount,
                                       const OCCTFilletRadiusPoint* radiusPoints,
                                       const int32_t* pointCounts) {
     if (!shape || !edgeIndices || edgeCount <= 0 || !radiusPoints || !pointCounts) return nullptr;
     try {
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
-
         BRepFilletAPI_MakeFillet fillet(shape->shape);
 
-        int rpOffset = 0;
-        for (int32_t i = 0; i < edgeCount; i++) {
-            int32_t edgeIdx = edgeIndices[i];
-            if (edgeIdx < 1 || edgeIdx > edgeMap.Extent()) return nullptr;
-            const TopoDS_Edge& edge = TopoDS::Edge(edgeMap(edgeIdx));
-
-            fillet.Add(edge);
-            int contourIndex = fillet.NbContours();
-
-            int32_t nPts = pointCounts[i];
-            if (nPts >= 2) {
-                // Build array of (parameter, radius) pairs
-                TColgp_Array1OfPnt2d UandR(1, nPts);
-                for (int32_t j = 0; j < nPts; j++) {
-                    UandR.SetValue(j + 1, gp_Pnt2d(radiusPoints[rpOffset + j].parameter,
-                                                     radiusPoints[rpOffset + j].radius));
-                }
-                fillet.SetRadius(UandR, contourIndex, 1);
-            } else if (nPts == 1) {
-                fillet.SetRadius(radiusPoints[rpOffset].radius, contourIndex, 1);
-            }
-            rpOffset += nPts;
-        }
+        // The profile of edge i starts where the profiles of edges 0..i-1 end, so the offset walks
+        // forward with the loop inside occtFilletAddEdges rather than being indexable from `entry`.
+        int32_t offset = 0;
+        bool profilesOk = true;
+        bool indicesOk = occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount,
+                                            [&](BRepFilletAPI_MakeFillet& f,
+                                                const TopoDS_Edge& edge, int32_t entry) {
+            if (!profilesOk) return;
+            f.Add(edge);
+            const OCCTFilletRadiusPoint* points = radiusPoints + offset;
+            profilesOk = occtFilletSetRadiusProfile(f, f.NbContours(), pointCounts[entry],
+                                                    [points](int32_t j) {
+                return gp_Pnt2d(points[j].parameter, points[j].radius);
+            });
+            offset += pointCounts[entry];
+        });
+        if (!indicesOk || !profilesOk) return nullptr;
 
         fillet.Build();
         if (!fillet.IsDone()) return nullptr;
-        return new OCCTShape(fillet.Shape());
+
+        TopoDS_Shape result = fillet.Shape();
+        if (result.IsNull()) return nullptr;
+        return new OCCTShape(result);
     } catch (...) {
         return nullptr;
     }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2676,10 +2676,18 @@ extension Shape {
 
     /// Fillet specific edges with uniform radius
     ///
+    /// Every edge must belong to this shape: only ``Edge/index`` is carried across, so an edge
+    /// whose index names nothing here rejects the whole call rather than being skipped.
+    ///
+    /// ```swift
+    /// let bracket = Shape.box(width: 40, height: 20, depth: 10)!
+    /// let rounded = bracket.filleted(edges: bracket.concaveEdges(), radius: 2)
+    /// ```
+    ///
     /// - Parameters:
     ///   - edges: Edges to fillet (must have valid indices from this shape)
-    ///   - radius: Fillet radius
-    /// - Returns: Filleted shape, or nil on failure
+    ///   - radius: Fillet radius; must be > 0
+    /// - Returns: Filleted shape, or nil on failure, including an edge that is not this shape's
     public func filleted(edges: [Edge], radius: Double) -> Shape? {
         guard !edges.isEmpty, radius > 0 else { return nil }
 
@@ -2701,11 +2709,19 @@ extension Shape {
 
     /// Fillet specific edges with linear radius interpolation
     ///
+    /// Every edge must belong to this shape, on the same all-or-nothing basis as
+    /// ``filleted(edges:radius:)``.
+    ///
+    /// ```swift
+    /// let bar = Shape.box(width: 40, height: 20, depth: 10)!
+    /// let tapered = bar.filleted(edges: [bar.edges()[0]], startRadius: 1, endRadius: 3)
+    /// ```
+    ///
     /// - Parameters:
     ///   - edges: Edges to fillet (must have valid indices from this shape)
-    ///   - startRadius: Radius at start of each edge
-    ///   - endRadius: Radius at end of each edge
-    /// - Returns: Filleted shape, or nil on failure
+    ///   - startRadius: Radius at start of each edge; must be > 0
+    ///   - endRadius: Radius at end of each edge; must be > 0
+    /// - Returns: Filleted shape, or nil on failure, including an edge that is not this shape's
     public func filleted(edges: [Edge], startRadius: Double, endRadius: Double) -> Shape? {
         guard !edges.isEmpty, startRadius > 0, endRadius > 0 else { return nil }
 
@@ -3540,9 +3556,13 @@ extension Shape {
     /// The radius varies along the edge according to the given radius/parameter pairs.
     /// Parameters are normalized from 0.0 (start of edge) to 1.0 (end of edge).
     ///
+    /// Every radius must be positive, the parameters must lie in `0...1` and strictly increase, and
+    /// `edgeIndex` must name an edge of this shape; otherwise the call returns `nil`.
+    ///
     /// - Parameters:
-    ///   - edgeIndex: Index of the edge to fillet
-    ///   - radiusProfile: Array of (parameter, radius) pairs defining the radius along the edge
+    ///   - edgeIndex: 0-based index of the edge to fillet, as reported by ``Edge/index``
+    ///   - radiusProfile: Array of (parameter, radius) pairs defining the radius along the edge;
+    ///     at least two
     /// - Returns: Filleted shape, or nil on failure
     ///
     /// ## Example
@@ -3559,7 +3579,18 @@ extension Shape {
     ///     edgeIndex: 0,
     ///     radiusProfile: [(0.0, 1.0), (0.5, 2.0), (1.0, 1.0)]
     /// )
+    ///
+    /// // Rejected: a descending parameter would silently reverse the law
+    /// let invalid = shape.filletedVariable(
+    ///     edgeIndex: 0,
+    ///     radiusProfile: [(1.0, 1.0), (0.0, 3.0)]
+    /// )  // nil
     /// ```
+    ///
+    /// > Note: OCCT stretches the profile across the whole edge, so it cannot fillet part of one
+    /// > and leave the rest alone. With exactly two points the parameters are ignored and only the
+    /// > endpoint radii are used; with three or more only the *relative* spacing of the interior
+    /// > points survives, because OCCT renormalises the first parameter to 0 and the last to 1.
     public func filletedVariable(
         edgeIndex: Int,
         radiusProfile: [(parameter: Double, radius: Double)]
@@ -3590,12 +3621,13 @@ extension Shape {
     ///
     /// Every radius must be positive: one non-positive (or NaN) radius rejects the whole batch,
     /// the same contract ``filleted(edges:radius:)`` and
-    /// ``filleted(edges:startRadius:endRadius:)`` apply to theirs. An out-of-range `edgeIndex` is
-    /// skipped, so the fillet is applied to whichever indices resolve on this shape.
+    /// ``filleted(edges:startRadius:endRadius:)`` apply to theirs. Every index must name an edge of
+    /// this shape, on the same all-or-nothing basis: one that does not rejects the batch rather
+    /// than being skipped, so a result is never a partial fillet reported as a complete one.
     ///
-    /// - Parameter edgeRadii: Array of (edgeIndex, radius) pairs; each radius must be > 0
+    /// - Parameter edgeRadii: Array of (0-based edgeIndex, radius) pairs; each radius must be > 0
     /// - Returns: Filleted shape, or nil on failure, including an empty array, a non-positive
-    ///   radius anywhere in the array, or no index resolving to an edge of this shape
+    ///   radius anywhere in the array, or an index that names no edge of this shape
     ///
     /// ## Example
     ///
@@ -3609,6 +3641,9 @@ extension Shape {
     ///
     /// // Rejected: a radius of zero is not a fillet, so the batch returns nil
     /// let invalid = shape.blendedEdges([(0, 1.0), (1, 0.0)])  // nil
+    ///
+    /// // Rejected: 99_999 names no edge, so the batch returns nil rather than filleting edge 0
+    /// let outOfRange = shape.blendedEdges([(0, 1.0), (99_999, 2.0)])  // nil
     /// ```
     public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Shape? {
         guard !edgeRadii.isEmpty, edgeRadii.allSatisfy({ $0.radius > 0 }) else { return nil }
@@ -6024,12 +6059,54 @@ extension Shape {
 // MARK: - Multi-Edge Evolving Fillet (v0.38.0)
 
 /// Describes an evolving radius along an edge for filleting.
+///
+/// The radius follows the `radiusPoints` law, whose parameters are *relative*: 0.0 is the start of
+/// the edge and 1.0 its end, the same convention ``Shape/filletedVariable(edgeIndex:radiusProfile:)``
+/// uses. Every radius must be positive, and the parameters must lie in `0...1` and strictly
+/// increase, or ``Shape/filletEvolving(_:)`` returns `nil`.
+///
+/// ```swift
+/// let box = Shape.box(width: 20, height: 20, depth: 20)!
+/// let spec = EvolvingFilletEdge(edge: box.edges()[0],
+///                               radiusPoints: [(0.0, 1.0), (1.0, 3.0)])
+/// let tapered = box.filletEvolving([spec])
+/// ```
+///
+/// > Note: OCCT stretches the law across the whole edge. With one or two points the parameters are
+/// > ignored entirely (a single point is a constant radius); with three or more only the *relative*
+/// > spacing of the interior points survives, because OCCT renormalises the first parameter to 0
+/// > and the last to 1. A profile cannot fillet part of an edge and leave the rest alone.
 public struct EvolvingFilletEdge: Sendable {
-    /// 1-based edge index.
+    /// 0-based index of the edge to fillet, as reported by ``Edge/index``.
+    ///
+    /// This was 1-based before v1.16.2, the one edge index in the fillet family that was. It now
+    /// matches ``Edge/index``, ``Shape/filletedVariable(edgeIndex:radiusProfile:)`` and
+    /// ``Shape/blendedEdges(_:)``.
     public var edgeIndex: Int
     /// Array of (parameter, radius) pairs defining the radius evolution along the edge.
     public var radiusPoints: [(parameter: Double, radius: Double)]
 
+    /// Fillet `edge` with an evolving radius.
+    ///
+    /// - Parameters:
+    ///   - edge: The edge to fillet; it must belong to the shape being filleted, since only its
+    ///     ``Edge/index`` is carried across.
+    ///   - radiusPoints: The radius law, as (relative parameter, radius) pairs.
+    public init(edge: Edge, radiusPoints: [(parameter: Double, radius: Double)]) {
+        self.edgeIndex = edge.index
+        self.radiusPoints = radiusPoints
+    }
+
+    /// Unavailable: this initializer took a **1-based** edge index, and `edgeIndex` is now 0-based.
+    ///
+    /// Passing the same numbers to a 0-based API would fillet the neighbouring edge without any
+    /// diagnostic, so the spelling was retired rather than reinterpreted. Build the spec from the
+    /// `Edge` itself — `EvolvingFilletEdge(edge: shape.edges()[0], radiusPoints: …)` — or, if you
+    /// only hold an index, construct from any edge and assign ``edgeIndex`` (0-based).
+    @available(*, unavailable, message: """
+        edgeIndex was 1-based and is now 0-based (#520). Use init(edge:radiusPoints:) with the Edge \
+        itself, or assign the 0-based edgeIndex property, after re-checking the index you pass.
+        """)
     public init(edgeIndex: Int, radiusPoints: [(parameter: Double, radius: Double)]) {
         self.edgeIndex = edgeIndex
         self.radiusPoints = radiusPoints
@@ -6038,6 +6115,19 @@ public struct EvolvingFilletEdge: Sendable {
 
 extension Shape {
     /// Apply evolving-radius fillets to multiple edges simultaneously.
+    ///
+    /// Every edge is filleted or none is: an `edgeIndex` naming no edge of this shape returns `nil`
+    /// rather than filleting the rest, and so does any radius that is not positive, any parameter
+    /// outside `0...1`, any non-increasing parameter sequence, and an empty `radiusPoints`.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 20, height: 20, depth: 20)!
+    /// let edges = box.edges()
+    /// let filleted = box.filletEvolving([
+    ///     EvolvingFilletEdge(edge: edges[0], radiusPoints: [(0.0, 1.0), (1.0, 3.0)]),
+    ///     EvolvingFilletEdge(edge: edges[2], radiusPoints: [(0.0, 1.0), (0.5, 4.0), (1.0, 1.0)]),
+    /// ])
+    /// ```
     ///
     /// - Parameter edges: Array of edge specifications with radius evolution.
     /// - Returns: Filleted shape, or nil on failure.

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6079,7 +6079,7 @@ extension Shape {
 public struct EvolvingFilletEdge: Sendable {
     /// 0-based index of the edge to fillet, as reported by ``Edge/index``.
     ///
-    /// This was 1-based before v1.16.2, the one edge index in the fillet family that was. It now
+    /// This was 1-based until #520, the one edge index in the fillet family that was. It now
     /// matches ``Edge/index``, ``Shape/filletedVariable(edgeIndex:radiusProfile:)`` and
     /// ``Shape/blendedEdges(_:)``.
     public var edgeIndex: Int

--- a/Tests/OCCTModelingTests/Issue489FilletRadiusTests.swift
+++ b/Tests/OCCTModelingTests/Issue489FilletRadiusTests.swift
@@ -53,14 +53,15 @@ struct Issue489FilletRadiusTests {
         #expect(box.blendedEdges([(0, 2.0), (99_999, -5.0)]) == nil)
     }
 
-    /// The bounds check itself is unchanged: an out-of-range index paired with a *valid* radius is
-    /// still skipped, and the batch still builds from whatever edges resolved.
-    @Test("An out-of-range index with a valid radius is still skipped, not rejected")
-    func blendOutOfRangeIndexStillSkipped() {
+    /// #489 left the bounds check itself alone, so an out-of-range index paired with a *valid*
+    /// radius was still skipped and the batch still built from whatever edges resolved. #520
+    /// settled that question the other way for all five entry points in this family: a partial
+    /// fillet reported as a complete one is the defect, not the convenience. Pinned in
+    /// `Issue520FilletContractTests`; kept here so the pair of #489 cases still reads as a pair.
+    @Test("An out-of-range index rejects the batch whatever its radius")
+    func blendOutOfRangeIndexRejected() {
         let box = Shape.box(width: 20, height: 20, depth: 20)!
-        let blended = box.blendedEdges([(0, 2.0), (99_999, 2.0)])
-        #expect(blended != nil)
-        if let blended { #expect(blended.isValid) }
+        #expect(box.blendedEdges([(0, 2.0), (99_999, 2.0)]) == nil)
     }
 
     // MARK: - Uniform radius (Shape.filleted(edges:radius:))

--- a/Tests/OCCTModelingTests/Issue520FilletContractTests.swift
+++ b/Tests/OCCTModelingTests/Issue520FilletContractTests.swift
@@ -1,0 +1,306 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #520: the five `BRepFilletAPI_MakeFillet` edge-list entry points now agree on what an edge index
+/// means, on what an unresolvable one does, and on what a radius law may contain.
+///
+/// Ground truth for the pinned kernel is in `Scripts/repro/520-fillet-edge-index-contracts/`. Three
+/// measurements shaped this suite:
+///
+/// 1. `SetRadius(radius, param, 1)` has no `(Real, Real, Integer)` overload, so the curve parameter
+///    `OCCTShapeFilletVariable` computed was truncated to an `int` and used as the *contour* index.
+///    A 20mm box filleted with `[(0, 1.0), (1, 3.0)]` measured 7995.707963, which is exactly the
+///    constant-1.0 result; the profile OCCT was asked for gives 7981.047467.
+/// 2. A contour added by `Add(edge)` that never receives a radius makes `Build()` SIGSEGV — not a
+///    `Standard_Failure`, so no `catch (...)` in the bridge can turn it into `nil`.
+/// 3. A negative radius inside a `UandR` profile does *not* fail `IsDone()` the way
+///    `Add(radius, edge)` does (#489). It reports success and hands back a shape
+///    `BRepCheck_Analyzer` rejects.
+@Suite("Fillet Edge-Index And Radius-Law Contracts (#520)")
+struct Issue520FilletContractTests {
+
+    // MARK: - The radius law is applied, not silently collapsed to a constant
+
+    /// The headline defect: `filletedVariable` produced the constant-radius shape for the first
+    /// profile point and discarded the rest.
+    @Test("A variable profile removes more material than its smallest radius alone")
+    func variableProfileIsNotConstant() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+
+        let tapered = box.filletedVariable(edgeIndex: 0, radiusProfile: [(0.0, 1.0), (1.0, 3.0)])
+        let constantSmall = box.filleted(edges: [edge], radius: 1.0)
+        let constantLarge = box.filleted(edges: [edge], radius: 3.0)
+
+        #expect(tapered != nil)
+        #expect(constantSmall != nil)
+        #expect(constantLarge != nil)
+        guard let taperedVolume = tapered?.volume,
+              let smallVolume = constantSmall?.volume,
+              let largeVolume = constantLarge?.volume else {
+            Issue.record("a fillet produced no volume")
+            return
+        }
+        // A radius growing 1 -> 3 along the edge removes strictly more than a constant 1 and
+        // strictly less than a constant 3. Before the fix the first of these was an equality.
+        #expect(taperedVolume < smallVolume)
+        #expect(taperedVolume > largeVolume)
+    }
+
+    /// Three points, so OCCT's two-point shortcut is not taken and the interior point matters.
+    @Test("An interior profile point changes the result")
+    func variableProfileInteriorPointHonoured() {
+        let box = Shape.box(width: 30, height: 30, depth: 30)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+
+        let bulged = box.filletedVariable(edgeIndex: 0,
+                                          radiusProfile: [(0.0, 1.0), (0.5, 4.0), (1.0, 1.0)])
+        let constantSmall = box.filleted(edges: [edge], radius: 1.0)
+
+        #expect(bulged != nil)
+        guard let bulgedVolume = bulged?.volume, let smallVolume = constantSmall?.volume else {
+            Issue.record("a fillet produced no volume")
+            return
+        }
+        #expect(bulgedVolume < smallVolume)
+    }
+
+    /// The two radius-law entry points reach the same OCCT overload with the same profile, so the
+    /// same request must give the same shape through either one.
+    @Test("Both radius-law entry points agree on the same profile")
+    func radiusLawEntryPointsAgree() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+
+        let viaVariable = box.filletedVariable(edgeIndex: 0,
+                                               radiusProfile: [(0.0, 1.0), (1.0, 3.0)])
+        let viaEvolving = box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(0.0, 1.0), (1.0, 3.0)])
+        ])
+
+        #expect(viaVariable != nil)
+        #expect(viaEvolving != nil)
+        if let a = viaVariable?.volume, let b = viaEvolving?.volume {
+            #expect(abs(a - b) < 1e-6)
+        }
+    }
+
+    // MARK: - Index base (item 1): 0-based everywhere
+
+    /// A single-point radius law is a constant radius, so filleting edge *i* through the evolving
+    /// entry point must produce exactly what filleting edge *i* through the per-edge one does.
+    /// While `EvolvingFilletEdge` was 1-based this comparison was off by one edge.
+    @Test("The evolving entry point fillets the same edge the per-edge one does")
+    func evolvingUsesTheSameEdgeIndexAsBlend() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+
+        let viaBlend = box.blendedEdges([(edgeIndex: 0, radius: 2.0)])
+        let viaEvolving = box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(0.5, 2.0)])
+        ])
+
+        #expect(viaBlend != nil)
+        #expect(viaEvolving != nil)
+        if let a = viaBlend?.volume, let b = viaEvolving?.volume {
+            #expect(abs(a - b) < 1e-6)
+        }
+    }
+
+    /// Index 0 is a real edge now. Under the 1-based contract it named nothing and the call failed.
+    @Test("Edge index 0 is accepted by the evolving entry point")
+    func evolvingAcceptsIndexZero() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+        #expect(edge.index == 0)
+        #expect(box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(0.0, 1.0), (1.0, 2.0)])
+        ]) != nil)
+    }
+
+    // MARK: - An unresolvable index rejects the call (item 2)
+
+    @Test("Per-edge blend rejects an out-of-range index")
+    func blendRejectsOutOfRangeIndex() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.edges().count < 99_999)
+        #expect(box.blendedEdges([(0, 2.0), (99_999, 2.0)]) == nil)
+        #expect(box.blendedEdges([(-1, 2.0)]) == nil)
+    }
+
+    /// `filleted(edges:radius:)` takes `Edge` objects, so the way to hand it an index that does not
+    /// resolve is to pass an edge belonging to a different, larger shape.
+    @Test("Uniform fillet rejects an edge that is not this shape's")
+    func uniformFilletRejectsForeignEdge() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let cut = box.subtracting(Shape.box(width: 20, height: 20, depth: 20)!
+            .translated(by: SIMD3(10, 10, 10))!)
+        guard let cut, cut.edges().count > box.edges().count else {
+            Issue.record("cut did not produce more edges than the box")
+            return
+        }
+        guard let ownEdge = box.edge(at: 0),
+              let foreignEdge = cut.edge(at: cut.edges().count - 1) else {
+            Issue.record("could not select edges")
+            return
+        }
+        #expect(foreignEdge.index >= box.edges().count)
+        #expect(box.filleted(edges: [ownEdge, foreignEdge], radius: 1.0) == nil)
+        #expect(box.filleted(edges: [ownEdge, foreignEdge],
+                             startRadius: 1.0, endRadius: 2.0) == nil)
+    }
+
+    @Test("History fillet rejects an out-of-range index")
+    func historyFilletRejectsOutOfRangeIndex() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.filletedWithFullHistory(radius: 1.0, edges: [0, 99_999]) == nil)
+    }
+
+    @Test("Both radius-law entry points reject an out-of-range index")
+    func radiusLawEntryPointsRejectOutOfRangeIndex() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+        #expect(box.filletedVariable(edgeIndex: 99_999,
+                                     radiusProfile: [(0.0, 1.0), (1.0, 2.0)]) == nil)
+        #expect(box.filletedVariable(edgeIndex: -1,
+                                     radiusProfile: [(0.0, 1.0), (1.0, 2.0)]) == nil)
+
+        var outOfRange = EvolvingFilletEdge(edge: edge, radiusPoints: [(0.0, 1.0), (1.0, 2.0)])
+        outOfRange.edgeIndex = 99_999
+        #expect(box.filletEvolving([outOfRange]) == nil)
+    }
+
+    // MARK: - Radius validation on the radius-law entry points (item 3)
+
+    @Test("Variable fillet rejects a non-positive radius anywhere in the profile")
+    func variableRejectsNonPositiveRadius() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        #expect(box.filletedVariable(edgeIndex: 0, radiusProfile: [(0.0, 1.0), (1.0, 0.0)]) == nil)
+        #expect(box.filletedVariable(edgeIndex: 0, radiusProfile: [(0.0, 1.0), (1.0, -3.0)]) == nil)
+        #expect(box.filletedVariable(edgeIndex: 0,
+                                     radiusProfile: [(0.0, Double.nan), (1.0, 2.0)]) == nil)
+    }
+
+    /// The measurement that makes this more than hygiene: through the profile overload a negative
+    /// radius reported `IsDone() == 1` and handed back a shape `BRepCheck_Analyzer` rejects, so the
+    /// caller received an invalid shape presented as success.
+    @Test("Evolving fillet rejects a non-positive radius anywhere in the profile")
+    func evolvingRejectsNonPositiveRadius() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+        #expect(box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(0.0, 1.0), (1.0, -3.0)])
+        ]) == nil)
+        #expect(box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(0.0, 1.0), (1.0, 0.0)])
+        ]) == nil)
+        #expect(box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(0.0, Double.nan), (1.0, 2.0)])
+        ]) == nil)
+    }
+
+    // MARK: - Parameter validation on the radius-law entry points (item 3)
+
+    @Test("A profile parameter outside 0...1 rejects the call")
+    func parametersOutsideUnitRangeRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+        #expect(box.filletedVariable(edgeIndex: 0,
+                                     radiusProfile: [(-5.0, 1.0), (1.0, 3.0)]) == nil)
+        #expect(box.filletedVariable(edgeIndex: 0,
+                                     radiusProfile: [(0.0, 1.0), (7.0, 3.0)]) == nil)
+        #expect(box.filletedVariable(edgeIndex: 0,
+                                     radiusProfile: [(Double.nan, 1.0), (1.0, 3.0)]) == nil)
+        #expect(box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(-5.0, 1.0), (0.0, 4.0), (7.0, 1.0)])
+        ]) == nil)
+    }
+
+    /// OCCT renormalises a 3+ point profile with `(U - Uf) / (Ul - Uf)`, which divides by zero when
+    /// every parameter is equal and silently reverses the law when they descend. Neither is what
+    /// the caller wrote, so both are rejected.
+    @Test("Profile parameters must strictly increase")
+    func nonIncreasingParametersRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+        #expect(box.filletedVariable(edgeIndex: 0,
+                                     radiusProfile: [(0.5, 1.0), (0.5, 4.0), (0.5, 1.0)]) == nil)
+        #expect(box.filletedVariable(edgeIndex: 0,
+                                     radiusProfile: [(1.0, 1.0), (0.5, 4.0), (0.0, 2.0)]) == nil)
+        #expect(box.filletEvolving([
+            EvolvingFilletEdge(edge: edge, radiusPoints: [(1.0, 1.0), (0.0, 3.0)])
+        ]) == nil)
+    }
+
+    // MARK: - Contours that never receive a radius (the SIGSEGV paths)
+
+    /// An empty radius law left the contour without one, and `Build()` then SIGSEGV'd. The crash is
+    /// an OS signal, so the bridge's `catch (...)` never saw it: this test used to take the whole
+    /// test process down rather than fail.
+    @Test("An empty radius law is rejected rather than crashing the build")
+    func emptyRadiusLawRejected() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        guard let edge = box.edge(at: 0) else {
+            Issue.record("no edge 0")
+            return
+        }
+        #expect(box.filletEvolving([EvolvingFilletEdge(edge: edge, radiusPoints: [])]) == nil)
+        #expect(box.filletEvolving([]) == nil)
+    }
+
+    /// The other route to a radius-less contour: `filletedVariable` mapped its parameters onto the
+    /// edge's own curve range and passed them where OCCT wanted a contour index, so every
+    /// `SetRadius` was dropped for any edge whose range does not start at 0. Box edges all start at
+    /// 0, which is why this went unnoticed; the edges a boolean cut produces do not.
+    @Test("A variable fillet on a re-parameterised edge does not crash")
+    func variableFilletOnReparameterisedEdge() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let offset = Shape.box(width: 20, height: 20, depth: 20)!.translated(by: SIMD3(10, 10, 10))!
+        guard let cut = box.subtracting(offset) else {
+            Issue.record("cut failed")
+            return
+        }
+        // Edge 8 of this cut measured a curve range of [5, 15]; scan rather than hard-code it,
+        // since edge ordering is not guaranteed.
+        var checked = 0
+        for edge in cut.edges() {
+            guard let range = edge.parameterBounds, range.first != 0 else { continue }
+            checked += 1
+            // Whatever OCCT makes of this edge, the call must return rather than SIGSEGV, and any
+            // shape it hands back must be a real one.
+            if let filleted = cut.filletedVariable(edgeIndex: edge.index,
+                                                   radiusProfile: [(0.0, 0.5), (1.0, 1.0)]) {
+                #expect(filleted.isValid)
+            }
+        }
+        #expect(checked > 0, "no re-parameterised edge in the cut result")
+    }
+}

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -2197,12 +2197,12 @@ struct EvolvingFilletTests {
         let box = Shape.box(width: 40, height: 40, depth: 40)!
         // Try multiple edges until one succeeds (edge ordering can vary)
         var result: Shape? = nil
-        for idx in 0..<box.edges().count {
-            let edge = EvolvingFilletEdge(edgeIndex: idx, radiusPoints: [
+        for edge in box.edges() {
+            let spec = EvolvingFilletEdge(edge: edge, radiusPoints: [
                 (parameter: 0.0, radius: 1.0),
                 (parameter: 1.0, radius: 2.0)
             ])
-            result = box.filletEvolving([edge])
+            result = box.filletEvolving([spec])
             if result != nil { break }
         }
         #expect(result != nil)
@@ -2213,25 +2213,25 @@ struct EvolvingFilletTests {
     func multiEdgeEvolving() {
         let box = Shape.box(width: 40, height: 40, depth: 40)!
         // Find two edges that work
-        var workingEdges: [Int] = []
-        for idx in 0..<box.edges().count {
-            let edge = EvolvingFilletEdge(edgeIndex: idx, radiusPoints: [
+        var workingEdges: [Edge] = []
+        for edge in box.edges() {
+            let spec = EvolvingFilletEdge(edge: edge, radiusPoints: [
                 (parameter: 0.0, radius: 1.0),
                 (parameter: 1.0, radius: 1.0)
             ])
-            if box.filletEvolving([edge]) != nil {
-                workingEdges.append(idx)
+            if box.filletEvolving([spec]) != nil {
+                workingEdges.append(edge)
                 if workingEdges.count >= 2 { break }
             }
         }
         guard workingEdges.count >= 2 else { return }
-        let edges = workingEdges.map { idx in
-            EvolvingFilletEdge(edgeIndex: idx, radiusPoints: [
+        let specs = workingEdges.map { edge in
+            EvolvingFilletEdge(edge: edge, radiusPoints: [
                 (parameter: 0.0, radius: 1.0),
                 (parameter: 1.0, radius: 1.5)
             ])
         }
-        let result = box.filletEvolving(edges)
+        let result = box.filletEvolving(specs)
         #expect(result != nil)
         if let r = result { #expect(r.isValid) }
     }
@@ -2240,12 +2240,12 @@ struct EvolvingFilletTests {
     func constantRadiusViaEvolving() {
         let box = Shape.box(width: 40, height: 40, depth: 40)!
         var result: Shape? = nil
-        for idx in 0..<box.edges().count {
-            let edge = EvolvingFilletEdge(edgeIndex: idx, radiusPoints: [
+        for edge in box.edges() {
+            let spec = EvolvingFilletEdge(edge: edge, radiusPoints: [
                 (parameter: 0.0, radius: 2.0),
                 (parameter: 1.0, radius: 2.0)
             ])
-            result = box.filletEvolving([edge])
+            result = box.filletEvolving([spec])
             if result != nil { break }
         }
         #expect(result != nil)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,86 @@ not that it wraps the class the entry files it under. A mis-attributed entry tha
 symbol from a neighbouring class is still invisible, and it misleads exactly the way a fabricated one
 does.
 
+#### One edge-index contract and one radius law for all five fillet entry points (#520)
+
+The five `BRepFilletAPI_MakeFillet` edge-list functions disagreed on what an edge index means, on
+what an unresolvable one does, and two validated no radius at all. Settling those three questions
+turned up two defects the issue did not know were there.
+
+**`filletedVariable` never applied its radius profile.** It mapped each relative parameter onto the
+edge's own curve parameter range and called `SetRadius(radii[i], param, 1)`. There is no
+`(Real, Real, Integer)` overload of `SetRadius`, so `param` was truncated to an `int` and taken as
+the *contour* index; the profile was discarded and the caller got a constant radius. Measured on a
+20mm box, edge 0:
+
+| call | before | now |
+|---|---|---|
+| `filletedVariable(edgeIndex: 0, radiusProfile: [(0, 1.0), (1, 3.0)])` | volume 7995.707963, **exactly** the constant-1.0 result | 7981.047467, the profile OCCT was asked for |
+| `filletedVariable(edgeIndex: 0, radiusProfile: [(0, 1.0), (0.5, 4.0), (1, 1.0)])` (30mm box) | 26993.561945, exactly the constant-1.0 result | 26947.284023 |
+
+**Two live SIGSEGV paths.** A contour added by the law-taking `Add(edge)` overload that never
+receives a radius crashes `Build()`. It is an OS signal, so the bridge's `catch (...)` never saw it
+and no `nil` could come back. Both routes were reachable from Swift: `filletEvolving` with an empty
+`radiusPoints` (the old code took neither of its two branches for a count of 0), and
+`filletedVariable` on any edge whose curve parameter range does not start at 0, where every
+truncated contour index exceeded `NbElements()` and every `SetRadius` was silently dropped. Box
+edges all start at 0, which is why the existing tests never saw it; the edges a boolean cut
+produces do not (6 of the 21 edges of one box cut by another).
+
+Both radius-law entry points now resolve their edges through `occtFilletAddEdges` and apply their
+profile through the new `occtFilletSetRadiusProfile` (`OCCTBridge_Internal.h`), the same
+`SetRadius(UandR, contour, 1)` call `OCCTShapeHistoryFromFilletEdgeVariable` was already making
+correctly two functions away. So the same profile now gives the same shape through either entry
+point, which is pinned by a test.
+
+**Three contract changes.**
+
+*Radius and parameter validation on the two radius-law functions.* Neither inspected a single
+element before. This is not the redundant guard #489 measured for `Add(radius, edge)`: through the
+profile overload a negative radius is not caught by OCCT at all, reporting `IsDone() == 1` and
+handing back a shape `BRepCheck_Analyzer` rejects. The parameters are checked against the `[0, 1]`
+contract both doc comments already stated, and required to strictly increase, because OCCT
+renormalises a 3+ point profile with `(U - Uf) / (Ul - Uf)`: equal parameters divide by zero, and
+descending ones silently reverse the law (7960.426609 against 7963.730821 for the ascending
+equivalent).
+
+*An index that names no edge of the shape rejects the call.* Three of the five skipped it and
+reported success, filleting fewer edges than the caller asked for — a request honoured in part,
+presented as honoured in full, the same defect class as #439/#442/#443. The other two already
+rejected, so this is what makes the family agree.
+
+| call | before | now |
+|---|---|---|
+| `blendedEdges([(0, 2.0), (99999, 2.0)])` | edge 0 filleted, reported as success | `nil` |
+| `filleted(edges: [ownEdge, edgeOfAnotherShape], radius: 1.0)` | `ownEdge` filleted, reported as success | `nil` |
+| `filletedWithFullHistory(radius: 1.0, edges: [0, 99999])` | edge 0 filleted, reported as success | `nil` |
+
+*`EvolvingFilletEdge.edgeIndex` is 0-based*, matching `Edge.index` and every sibling; it was the
+one 1-based edge index in the family. Reinterpreting the same numbers would have quietly filleted
+the neighbouring edge for every existing caller, so the old spelling is
+`@available(*, unavailable)` instead: `init(edgeIndex:radiusPoints:)` fails to build with a message
+naming the base change, and `init(edge:radiusPoints:)` takes the `Edge` itself, the idiom
+`filleted(edges:radius:)` already uses. The four call sites in this repo's own tests failed exactly
+that way and were migrated.
+
+Ground truth for all of the above is in
+[`Scripts/repro/520-fillet-edge-index-contracts/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/520-fillet-edge-index-contracts).
+The new `Issue520FilletContractTests` suite was run against unmodified code first (#489's lesson):
+10 of its 13 then-runnable cases failed, 1 took the test process down with a SIGSEGV, and 2 passed —
+one of those for the wrong reason, since a 0-based index was out of range under the 1-based
+contract. Each guard was then re-checked by injecting the mistake back: the index guard fails 3
+tests, the radius guard 2, the parameter guards 2, the empty-law guard SIGSEGVs 3 runs out of 3, and
+restoring the truncating loop both fails the profile test and SIGSEGVs the re-parameterised-edge
+test.
+
+Bridge-only: no kernel patch, no xcframework rebuild, nothing filed upstream — passing a `double`
+where OCCT's signature takes an `int` is our defect, not OCCT's. `Scripts/count-operations.py` now
+skips `@available(*, unavailable)` declarations, which are retired spellings rather than entry
+points; the total stays 4295. The skip-an-out-of-range-index idiom survives outside this family, in
+`OCCTShapeHistoryFromChamferEdges`, `OCCTShapeOffsetPerFace` and the 2D fillet/chamfer vertex
+functions; those are a separate family and are left for their own issue rather than widened into
+this one.
+
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 
 `OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1042,12 +1042,15 @@ public func filleted(edges: [Edge], radius: Double) -> Shape?
 ```
 
 - **Parameters:** `edges` — edges to fillet (must have valid `index` values from this shape); `radius` — fillet radius (must be > 0).
-- **Returns:** Filleted shape, or `nil` on failure, which includes a non-positive or NaN radius.
+- **Returns:** Filleted shape, or `nil` on failure, which includes a non-positive or NaN radius and
+  an edge whose `index` names no edge of this shape.
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeFilletEdges`).
 - **Notes:** shares one bridge implementation with
   [`filleted(edges:startRadius:endRadius:)`](#filletededgesstartradiusendradius) and
-  [`blendedEdges(_:)`](#blendededges_), so all three apply the same positive-radius precondition and
-  the same skip-an-out-of-range-index behaviour (#489).
+  [`blendedEdges(_:)`](#blendededges_), so all three apply the same positive-radius precondition
+  (#489) and the same all-or-nothing index contract (#520): an edge that does not resolve rejects
+  the call rather than being skipped, so a result is never a partial fillet reported as a complete
+  one.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)
@@ -1072,7 +1075,8 @@ The radius varies linearly from `startRadius` at the start of each edge to `endR
   either end.
 - **OCCT:** `BRepFilletAPI_MakeFillet` with law-driven radius (via `OCCTShapeFilletEdgesLinear`).
 - **Notes:** shares one bridge implementation with [`filleted(edges:radius:)`](#filletededgesradius)
-  and [`blendedEdges(_:)`](#blendededges_) (#489).
+  and [`blendedEdges(_:)`](#blendededges_) (#489), including their all-or-nothing index contract
+  (#520).
 
 ---
 
@@ -1605,9 +1609,18 @@ public func filletedVariable(
 
 Parameters are normalised from 0.0 (start) to 1.0 (end). At least two profile points are required.
 
-- **Parameters:** `edgeIndex` — index of the edge to fillet; `radiusProfile` — array of `(parameter, radius)` pairs (minimum 2).
-- **Returns:** Filleted shape, or `nil` on failure.
+- **Parameters:** `edgeIndex` — 0-based index of the edge to fillet, as reported by `Edge.index`;
+  `radiusProfile` — array of `(parameter, radius)` pairs (minimum 2).
+- **Returns:** Filleted shape, or `nil` on failure, which includes an `edgeIndex` naming no edge of
+  this shape, a non-positive or NaN radius anywhere in the profile, a parameter outside `0...1`,
+  and a non-increasing parameter sequence (#520).
 - **OCCT:** `BRepFilletAPI_MakeFillet` with law-driven radius (via `OCCTShapeFilletVariable`).
+- **Notes:** the profile is applied through `SetRadius(UandR, contour, 1)`, the same OCCT overload
+  [`filletEvolving(_:)`](Shape-Measurement#filletevolving_) uses, so the same profile gives the
+  same shape through either entry point. **Until #520 the profile was never applied at all**: the
+  bridge mapped each relative parameter onto the edge's own curve range and passed it where OCCT
+  wanted a contour index, which truncated it to an `int`, so the result was a constant radius (and,
+  for an edge whose parameter range does not start at 0, a `SIGSEGV`).
 - **Example:**
   ```swift
   // Radius varies from 1 mm at start to 3 mm at end
@@ -1615,7 +1628,18 @@ Parameters are normalised from 0.0 (start) to 1.0 (end). At least two profile po
       edgeIndex: 0,
       radiusProfile: [(0.0, 1.0), (1.0, 3.0)]
   )
+
+  // Rejected: a descending parameter would silently reverse the law
+  let invalid = shape.filletedVariable(
+      edgeIndex: 0,
+      radiusProfile: [(1.0, 1.0), (0.0, 3.0)]
+  )  // nil
   ```
+
+> OCCT stretches the profile across the whole edge, so it cannot fillet part of one and leave the
+> rest alone. With exactly two points the parameters are ignored and only the endpoint radii are
+> used; with three or more only the *relative* spacing of the interior points survives, because
+> OCCT renormalises the first parameter to 0 and the last to 1.
 
 ---
 
@@ -1629,14 +1653,14 @@ Applies fillets to multiple edges, each with its own radius.
 public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Shape?
 ```
 
-- **Parameters:** `edgeRadii` — array of `(edgeIndex, radius)` pairs. Every radius must be > 0.
+- **Parameters:** `edgeRadii` — array of `(0-based edgeIndex, radius)` pairs. Every radius must be > 0.
 - **Returns:** Filleted shape with per-edge radii applied, or `nil` on failure, which includes an
-  empty array, a non-positive or NaN radius anywhere in it, and no index resolving to an edge of
-  this shape.
+  empty array, a non-positive or NaN radius anywhere in it, and an index that names no edge of this
+  shape.
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeBlendEdges`).
 - **Notes:** one non-positive radius rejects the whole batch, the same contract
-  [`filleted(edges:radius:)`](#filletededgesradius) applies to its single radius (#489). An
-  out-of-range `edgeIndex` is skipped, so the fillet is applied to whichever indices resolve.
+  [`filleted(edges:radius:)`](#filletededgesradius) applies to its single radius (#489), and one
+  index that does not resolve rejects it too rather than being skipped (#520).
 - **Example:**
   ```swift
   let blended = shape.blendedEdges([
@@ -1647,6 +1671,9 @@ public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Sha
 
   // Rejected: a radius of zero is not a fillet
   let invalid = shape.blendedEdges([(0, 1.0), (1, 0.0)])  // nil
+
+  // Rejected: 99_999 names no edge, so the batch fails rather than filleting edge 0
+  let outOfRange = shape.blendedEdges([(0, 1.0), (99_999, 2.0)])  // nil
   ```
 
 ---

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -250,12 +250,23 @@ Describes an evolving radius along an edge for filleting.
 public struct EvolvingFilletEdge: Sendable {
     public var edgeIndex: Int
     public var radiusPoints: [(parameter: Double, radius: Double)]
-    public init(edgeIndex: Int, radiusPoints: [(parameter: Double, radius: Double)])
+    public init(edge: Edge, radiusPoints: [(parameter: Double, radius: Double)])
 }
 ```
 
-- `edgeIndex` — 1-based edge index.
-- `radiusPoints` — Array of `(parameter, radius)` pairs defining the radius evolution along the edge.
+- `edgeIndex` — 0-based edge index, as reported by `Edge.index`. **This was 1-based until #520**,
+  the one edge index in the fillet family that was; `init(edgeIndex:radiusPoints:)` is now
+  `unavailable` rather than silently reinterpreted, so an old call site fails to build with an
+  explanation instead of quietly filleting the neighbouring edge. Build the spec from the `Edge`
+  itself, or assign `edgeIndex` after re-checking the index you pass.
+- `radiusPoints` — Array of `(parameter, radius)` pairs defining the radius evolution along the
+  edge. Parameters are relative: `0.0` is the start of the edge, `1.0` its end. Every radius must
+  be positive, and the parameters must lie in `0...1` and strictly increase.
+
+> OCCT stretches the law across the whole edge, so a profile cannot fillet part of one and leave
+> the rest alone. With one or two points the parameters are ignored entirely (a single point is a
+> constant radius); with three or more only the *relative* spacing of the interior points survives,
+> because OCCT renormalises the first parameter to 0 and the last to 1.
 
 ---
 
@@ -268,11 +279,14 @@ public func filletEvolving(_ edges: [EvolvingFilletEdge]) -> Shape?
 ```
 
 - **Parameters:** `edges` — Array of edge specifications with radius evolution; must not be empty.
-- **Returns:** Filleted shape, or `nil` on failure.
+- **Returns:** Filleted shape, or `nil` on failure. Every edge is filleted or none is: an
+  `edgeIndex` naming no edge of this shape returns `nil` rather than filleting the rest, and so
+  does a non-positive radius, a parameter outside `0...1`, a non-increasing parameter sequence, or
+  an empty `radiusPoints` (#520).
 - **OCCT:** `BRepFilletAPI_MakeFillet` with evolving law (via `OCCTShapeFilletEvolving`).
 - **Example:**
   ```swift
-  let spec = EvolvingFilletEdge(edgeIndex: 1, radiusPoints: [(0.0, 1.0), (1.0, 3.0)])
+  let spec = EvolvingFilletEdge(edge: box.edges()[0], radiusPoints: [(0.0, 1.0), (1.0, 3.0)])
   if let filled = box.filletEvolving([spec]) {
       print(filled.isValid)
   }


### PR DESCRIPTION
Closes #520

The five `BRepFilletAPI_MakeFillet` edge-list functions disagreed on what an edge index means, on
what an unresolvable one does, and two validated no radius at all. Settling those three questions
turned up two defects the issue did not know were there.

## `filletedVariable` never applied its radius profile

It mapped each relative parameter onto the edge's own curve range and called
`SetRadius(radii[i], param, 1)`. There is no `(Real, Real, Integer)` overload of `SetRadius`, so
`param` was truncated to an `int` and taken as the **contour** index (`1` was the
edge-within-contour index, not the contour index its comment claimed). Measured on a 20mm box,
edge 0:

| call | before | now |
|---|---|---|
| `radiusProfile: [(0, 1.0), (1, 3.0)]` | 7995.707963, **bit-identical** to the constant-1.0 result | 7981.047467, the profile OCCT was asked for |
| `radiusProfile: [(0, 1.0), (0.5, 4.0), (1, 1.0)]` (30mm box) | 26993.561945, again the constant-1.0 result | 26947.284023 |

## Two live SIGSEGV paths

A contour added by the law-taking `Add(edge)` overload that never receives a radius crashes
`Build()`. It is an OS signal, so the bridge's `catch (...)` never saw it. Both routes were
reachable from Swift:

- `filletEvolving` with an empty `radiusPoints` — a count of 0 took neither of the old code's two
  branches.
- `filletedVariable` on any edge whose curve parameter range does not start at 0 — every truncated
  contour index then exceeded `NbElements()` and every `SetRadius` was dropped. Box edges all start
  at 0, which is why the existing tests never saw it; 6 of the 21 edges of one box cut by another
  do not.

Both radius-law entry points now resolve their edges through `occtFilletAddEdges` and apply their
profile through the new `occtFilletSetRadiusProfile`, the same `SetRadius(UandR, contour, 1)` call
`OCCTShapeHistoryFromFilletEdgeVariable` was already making correctly two functions away. The same
profile now gives the same shape through either entry point, pinned by a test.

## The three contract questions the issue asked

**Item 3 — radius and parameter validation.** Not the redundant guard #489 measured: through the
profile overload a negative radius is not caught by OCCT at all, reporting `IsDone() == 1` and
handing back a shape `BRepCheck_Analyzer` rejects. Parameters are now held to the `[0, 1]` both doc
comments already stated, and required to strictly increase, because OCCT renormalises a 3+ point
profile with `(U - Uf) / (Ul - Uf)`: equal parameters divide by zero, descending ones silently
reverse the law (7960.426609 against 7963.730821 for the ascending equivalent).

**Item 2 — an unresolvable index rejects the call** (your call on the issue). Three of the five
skipped it and reported success; the other two already rejected.

| call | before | now |
|---|---|---|
| `blendedEdges([(0, 2.0), (99999, 2.0)])` | edge 0 filleted, reported as success | `nil` |
| `filleted(edges: [ownEdge, edgeOfAnotherShape], radius: 1.0)` | `ownEdge` filleted, reported as success | `nil` |
| `filletedWithFullHistory(radius: 1.0, edges: [0, 99999])` | edge 0 filleted, reported as success | `nil` |

**Item 1 — `EvolvingFilletEdge.edgeIndex` is 0-based**, made loud rather than silent (your call).
`init(edgeIndex:radiusPoints:)` is `@available(*, unavailable)` with a message naming the base
change, and `init(edge:radiusPoints:)` takes the `Edge` itself. The four call sites in this repo's
own tests failed exactly that way and were migrated, which is the mechanism working.

## Verification

Ground truth in [`Scripts/repro/520-fillet-edge-index-contracts/`](../tree/fix/520-fillet-edge-index-contracts/Scripts/repro/520-fillet-edge-index-contracts).

`Issue520FilletContractTests` was run against unmodified code first (#489's lesson): **10 of 13
then-runnable cases failed, 1 took the test process down with a SIGSEGV, 2 passed** — one of those
for the wrong reason, since a 0-based index was out of range under the 1-based contract.

Each guard was then re-checked by injecting the mistake back:

| injection | result |
|---|---|
| index reject → skip | 3 tests fail |
| radius guard removed | 2 tests fail |
| parameter range + ordering guards removed | 2 tests fail |
| empty radius law tolerated | SIGSEGV, 3 runs of 3 |
| truncating `SetRadius` loop restored | profile test fails; re-parameterised-edge test SIGSEGVs |

Full `swift test`: **4889 tests, all passing**. `Scripts/count-operations.py` clean at 4295 — it now
skips `@available(*, unavailable)` declarations, which are retired spellings rather than entry
points a caller can reach.

Bridge-only: no kernel patch, no xcframework rebuild, nothing filed upstream, since passing a
`double` where OCCT's signature takes an `int` is our defect and not OCCT's.

**Left for its own issue rather than widened into this one:** the skip-an-out-of-range-index idiom
survives outside this family, in `OCCTShapeHistoryFromChamferEdges`, `OCCTShapeOffsetPerFace` and
the 2D fillet/chamfer vertex functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)