### PR TITLE
fix(#541): one meaning for a face index, and the wrong face it was naming

### DIFF
--- a/Scripts/repro/541-face-index-contract/README.md
+++ b/Scripts/repro/541-face-index-contract/README.md
@@ -1,0 +1,113 @@
+# OCCTSwift#541 probe: what a "face index" addresses
+
+Ground truth for the three ways the bridge answered "which face is index `i`", against the pinned
+OCCT 8.0.0p1 kernel.
+
+#502 established the kernel fact this builds on: `TopExp::MapShapes(S, T, M)` is *literally* a
+`TopExp_Explorer` walk piped into an indexed map (`TopExp.cxx:34-45`), so the map's sequence is the
+explorer's sequence with later repeats removed. #502 converged the sub-shape accessors onto the map
+but deliberately left the `Face` family alone, because a face index is an addressing token the Swift
+API hands out (`Face.index`, written from `Shape.faces()`) and takes back (`drafted(faces:)`,
+`shelled(openFaces:)`, `withoutFeatures(faces:)`, and ~30 more).
+
+The three schemes in the bridge before this fix:
+
+| scheme | enumeration | base | entry points |
+|---|---|---|---|
+| **A** | `TopExp_Explorer`, one entry per *occurrence* | 0 | `OCCTShapeGetFaces` (which writes `Face.index`) + 13 index consumers |
+| **B** | `TopExp::MapShapes`, one entry per *distinct* face | 0 | `OCCTShapeGetFaceCount` / `GetFaceAtIndex` + ~16 index consumers |
+| **C** | `TopExp::MapShapes` | **1** | `OCCTShapeOffsetPerFace`, `OCCTLocOpeBuildWires`, `OCCTLocOpeSplitByWireOnFace`, the `Poly_Connect` mesh family, and the `OCCTEdgeAdjacentFaces` / `OCCTVertexAdjacentEdges` index *outputs* |
+
+## The four questions the headers cannot answer
+
+1. **Does the A/B divergence arise from ordinary modelling, or only from hand-built topology?**
+   #502's face-divergent fixture was a hand-assembled shell of a face and its own reverse, and #541
+   reproduces with `Shape.compound([face, face])`. A construction nobody writes is not worth moving
+   an index over.
+2. **When A and B diverge, from which index onwards?**
+3. **Do A and B ever address *different* faces at an index both accept, or does A merely run
+   longer?** These are different defects: silently operating on the wrong face vs. returning nil.
+4. **Is the map's order the explorer's order on the shapes the fix must not disturb**, so
+   converging A onto B moves no index on any shape without a shared face?
+
+No fixture files: every case builds its geometry from a primitive.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/541-face-index-contract/occt_541_face_index_contract.mm -o /tmp/occt_541
+/tmp/occt_541
+```
+
+## Result
+
+**The divergence is not a hand-built curiosity. One ordinary modelling operation produces it, and
+on that shape the two schemes name different faces rather than one merely running longer.**
+
+Fifteen fixtures, five divergent:
+
+| fixture | provenance | explorer | map |
+|---|---|---|---|
+| box / cylinder / sphere / torus | ordinary | 6 / 3 / 1 / 1 | same |
+| hollow solid (cut) | ordinary | 12 | 12 |
+| fuse of two touching boxes | ordinary | 10 | 10 |
+| common of two overlapping boxes | ordinary | 6 | 6 |
+| compsolid of two separately-cut halves | ordinary | 12 | 12 |
+| **box split by a plane (one splitter run)** | **ordinary** | **12** | **11** |
+| sewn two-face sheet | ordinary | 2 | 2 |
+| `compound(face, THE SAME face)` | hand-built | 2 | 1 |
+| `shell(face, face.Reversed())` | hand-built | 2 | 1 |
+| `compound(box, THE SAME box)` | hand-built | 12 | 6 |
+| `compound(box, box.Moved())` | hand-built | 12 | 12 |
+| `compound(box, one of its own faces)` | hand-built | 7 | 6 |
+
+- **`BRepAlgoAPI_Splitter` is the ordinary case.** One splitter run cutting a box with a plane
+  yields two solids that *share* the single cut face, so the explorer visits it once per solid. This
+  is what an assembly split, a slice or an imprint produces. Note the control directly above it: two
+  halves cut by two *separate* `Common` calls and assembled into a compsolid do **not** diverge (12
+  vs 12), because each half got its own copy of the wall. Sharing comes from one operation producing
+  both parents, not from the assembly.
+
+- **On the split box the schemes name different faces from index 10 onwards** — the trailing
+  duplicate is not at the end of the explorer's walk, so every index after it is shifted. A caller
+  holding `Face.index == 10` from `faces()` and passing it to `drafted(faces:)`,
+  `withoutFeatures(faces:)` or `shelled(openFaces:)` (all map-backed) drafts, deletes or opens **a
+  different face than the one it selected**, with no error. On the four hand-built fixtures the
+  duplicate *is* last, so there A merely runs longer and the surplus indices are the ones
+  `face(at:)` answers nil for — #541's reported symptom, which turns out to be the milder half of
+  the defect.
+
+- **Order is preserved on all ten agreeing fixtures**, face-by-face and not merely by count. So
+  converging `faces()` onto the map moves no index on any shape that does not share a face, which is
+  every shape the existing tests build.
+
+- **`compound(box, box.Moved())` does not collapse** (12 vs 12). `IsSame` compares the location, so
+  instancing survives deduplication; the map is not merging placements.
+
+- **C is B shifted by one.** Measured on a box: `C(1)` is identical to `B(0)`, `C(6)` to `B(5)`,
+  `C(0)` is never a face and `B(5)` is reachable through C only as `C(6)`. A caller holding a
+  0-based `Face.index` and calling a C-scheme entry point addresses **the face before the one it
+  named**, and can never name the last face at all.
+
+- **`ShapeAnalysis_ShapeContents` is a fourth answer, and a fifth.** `Shape.contents`'s `NbFaces`
+  tracks the explorer exactly (occurrences). Its `NbSharedFaces` sibling — surfaced through
+  `Shape.contentsExtended()` — is a *third* dedup rule: it strips the location before adding to its
+  map (`ShapeAnalysis_ShapeContents.cxx:167`, `face.Location(TopLoc_Location())`), so unlike
+  `IsSame` it also collapses two placements of one face. On `compound(box, box.Moved())` the three
+  read 12 / 12 / **6**. Neither column is `faceCount`'s answer on every fixture, which is why
+  `contents` is documented as a complexity metric rather than converged.
+
+## What was done with it
+
+One enumeration and one base for every face index in the API: `occtMapSubShapes` / `occtSubShapeAt`
+(`OCCTBridge_Internal.h`, added in #502), 0-based. `OCCTShapeGetFaces` reads it, the fourteen
+explorer-backed consumers read it, and the 1-based entry points and index outputs were moved to
+0-based to match `Face.index`. Cross-checks live in
+`Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift`, alongside #502's.
+
+Not an upstream defect — both OCCT primitives behave exactly as documented, and the kernel is not
+involved in the base convention at all. Nothing to file or patch upstream.

--- a/Scripts/repro/541-face-index-contract/occt_541_face_index_contract.mm
+++ b/Scripts/repro/541-face-index-contract/occt_541_face_index_contract.mm
@@ -1,0 +1,385 @@
+// #541 ground truth: what a "face index" addresses, on the pinned OCCT 8.0.0p1 kernel.
+//
+// #502 established that TopExp::MapShapes is a TopExp_Explorer walk piped into an
+// IndexedMap, so the map's sequence is the explorer's sequence with later repeats removed.
+// #541 is about the consequence for FACE indices specifically, which #502 left alone because
+// they are an addressing token the Swift API hands out and takes back.
+//
+// The bridge answers "which face is index i" three different ways:
+//
+//   A. explorer walk, 0-based   -- OCCTShapeGetFaces (Shape.faces(), which writes Face.index),
+//                                  and 14 face-index consumers
+//   B. MapShapes, 0-based       -- OCCTShapeGetFaceCount / GetFaceAtIndex (Shape.faceCount,
+//                                  Shape.face(at:)), and ~16 face-index consumers
+//   C. MapShapes, 1-based       -- OCCTShapeOffsetPerFace, OCCTLocOpeBuildWires,
+//                                  OCCTLocOpeSplitByWireOnFace, the Poly_Connect mesh family,
+//                                  and the OCCTEdgeAdjacentFaces / OCCTVertexAdjacentEdges
+//                                  index *outputs*
+//
+// This probe asks the four things the headers cannot answer:
+//
+//   1. Does the A/B divergence arise from ORDINARY modelling, or only from hand-built
+//      topology? #502's face-divergent fixture was a hand-assembled shell of a face and its
+//      own reverse. If a compsolid or a glued boolean shares a face, the defect is routine.
+//   2. When A and B diverge, from which index onwards do they disagree? An index that only
+//      moves past the duplicate is a much narrower break than one that shifts everything.
+//   3. Do A and B ever address DIFFERENT faces at an index both accept, or does A merely run
+//      longer? These are different defects: silently operating on the wrong face vs.
+//      returning nil.
+//   4. Is the map's face order the explorer's order for the ordinary shapes the fix has to
+//      not disturb, so that converging A onto B moves no index on any shape anyone has?
+//
+// No fixture files: every case builds its geometry from a primitive.
+
+#include <ShapeAnalysis_ShapeContents.hxx>
+#include <BRepAlgoAPI_Common.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
+#include <BRepAlgoAPI_Splitter.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepPrimAPI_MakeTorus.hxx>
+#include <BRep_Builder.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_CompSolid.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Solid.hxx>
+#include <TopTools_ListOfShape.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Trsf.hxx>
+#include <gp_Vec.hxx>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// The three addressing schemes, transcribed from the bridge.
+// ---------------------------------------------------------------------------
+
+// A: OCCTShapeGetFaces -- a bare explorer walk, one entry per occurrence, 0-based.
+static std::vector<TopoDS_Shape> schemeA(const TopoDS_Shape& s) {
+    std::vector<TopoDS_Shape> out;
+    for (TopExp_Explorer e(s, TopAbs_FACE); e.More(); e.Next()) out.push_back(e.Current());
+    return out;
+}
+
+// B: OCCTShapeGetFaceAtIndex -- occtSubShapeAt, one entry per distinct face, 0-based.
+static std::vector<TopoDS_Shape> schemeB(const TopoDS_Shape& s) {
+    TopTools_IndexedMapOfShape m;
+    TopExp::MapShapes(s, TopAbs_FACE, m);
+    std::vector<TopoDS_Shape> out;
+    for (int i = 1; i <= m.Extent(); i++) out.push_back(m(i));
+    return out;
+}
+
+// C is B shifted by one; it addresses the same set, so it is measured as an offset rather
+// than walked separately.
+
+// IsSame ignores orientation; IsEqual does not. Both are reported so "the same face" is
+// attributed to a specific bit rather than assumed.
+static const char* sameness(const TopoDS_Shape& a, const TopoDS_Shape& b) {
+    if (a.IsEqual(b)) return "identical";
+    if (a.IsSame(b))  return "same-but-reversed";
+    return "DIFFERENT";
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    std::string name;
+    std::string provenance;   // "ordinary" = produced by a modelling op, "hand-built" = assembled
+    TopoDS_Shape shape;
+};
+
+static TopoDS_Shape box(double dx, double dy, double dz, double ox = 0, double oy = 0, double oz = 0) {
+    return BRepPrimAPI_MakeBox(gp_Pnt(ox, oy, oz), dx, dy, dz).Shape();
+}
+
+static TopoDS_Shape firstFace(const TopoDS_Shape& s) {
+    TopExp_Explorer e(s, TopAbs_FACE);
+    return e.More() ? e.Current() : TopoDS_Shape();
+}
+
+static std::vector<Fixture> buildFixtures() {
+    std::vector<Fixture> f;
+
+    // --- Ordinary modelling: no face is reachable twice, so A and B must agree. ---
+    f.push_back({"box", "ordinary", box(10, 10, 10)});
+    f.push_back({"cylinder", "ordinary", BRepPrimAPI_MakeCylinder(5, 10).Shape()});
+    f.push_back({"sphere", "ordinary", BRepPrimAPI_MakeSphere(5).Shape()});
+    f.push_back({"torus", "ordinary", BRepPrimAPI_MakeTorus(10, 3).Shape()});
+
+    // A hollow solid: two shells, twelve faces, nothing shared.
+    {
+        TopoDS_Shape outer = box(20, 20, 20);
+        TopoDS_Shape inner = box(8, 8, 8, 6, 6, 6);
+        f.push_back({"hollow solid (cut)", "ordinary", BRepAlgoAPI_Cut(outer, inner).Shape()});
+    }
+
+    // Booleans of two touching boxes. The interface face is the interesting one: does the
+    // result share one face between two solids, or duplicate it?
+    {
+        TopoDS_Shape a = box(10, 10, 10);
+        TopoDS_Shape b = box(10, 10, 10, 10, 0, 0);
+        f.push_back({"fuse of two touching boxes", "ordinary", BRepAlgoAPI_Fuse(a, b).Shape()});
+        f.push_back({"common of two overlapping boxes", "ordinary",
+                     BRepAlgoAPI_Common(box(10, 10, 10), box(10, 10, 10, 5, 0, 0)).Shape()});
+    }
+
+    // Two halves cut from a common block and assembled into a compsolid. Each Common ran
+    // separately, so the wall is two coincident faces rather than one shared one -- the
+    // control for the fixture below.
+    {
+        TopoDS_Shape whole = box(20, 10, 10);
+        TopoDS_Shape left  = BRepAlgoAPI_Common(whole, box(10, 10, 10)).Shape();
+        TopoDS_Shape right = BRepAlgoAPI_Common(whole, box(10, 10, 10, 10, 0, 0)).Shape();
+        TopoDS_CompSolid cs;
+        BRep_Builder bb;
+        bb.MakeCompSolid(cs);
+        for (TopExp_Explorer e(left, TopAbs_SOLID); e.More(); e.Next())  bb.Add(cs, e.Current());
+        for (TopExp_Explorer e(right, TopAbs_SOLID); e.More(); e.Next()) bb.Add(cs, e.Current());
+        f.push_back({"compsolid of two separately-cut halves", "ordinary", cs});
+    }
+
+    // The real ordinary-modelling candidate: ONE splitter run cuts a box with a plane, so
+    // both resulting solids share the single cut face. This is what an assembly split, a
+    // slicing operation or an imprint produces -- nobody hand-builds it.
+    {
+        TopoDS_Shape target = box(20, 10, 10);
+        TopoDS_Shape tool = BRepBuilderAPI_MakeFace(
+            gp_Pln(gp_Pnt(10, 0, 0), gp_Dir(1, 0, 0)), -50, 50, -50, 50).Face();
+        BRepAlgoAPI_Splitter splitter;
+        TopTools_ListOfShape args, tools;
+        args.Append(target);
+        tools.Append(tool);
+        splitter.SetArguments(args);
+        splitter.SetTools(tools);
+        splitter.Build();
+        if (splitter.IsDone()) {
+            f.push_back({"box split by a plane (one splitter run)", "ordinary", splitter.Shape()});
+        }
+    }
+
+    // A sewn stack: two independently-built faces sewn along a shared edge.
+    {
+        BRepBuilderAPI_MakePolygon p1(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0), gp_Pnt(10, 10, 0),
+                                      gp_Pnt(0, 10, 0), true);
+        BRepBuilderAPI_MakePolygon p2(gp_Pnt(10, 0, 0), gp_Pnt(20, 0, 0), gp_Pnt(20, 10, 0),
+                                      gp_Pnt(10, 10, 0), true);
+        BRepBuilderAPI_Sewing sew(1e-6);
+        sew.Add(BRepBuilderAPI_MakeFace(p1.Wire()).Face());
+        sew.Add(BRepBuilderAPI_MakeFace(p2.Wire()).Face());
+        sew.Perform();
+        f.push_back({"sewn two-face sheet", "ordinary", sew.SewedShape()});
+    }
+
+    // --- Constructions that put one face in two places. ---
+
+    // #541's own minimal reproduction: Shape.compound([face, face]).
+    {
+        TopoDS_Shape fc = firstFace(box(10, 10, 10));
+        TopoDS_Compound c;
+        BRep_Builder bb;
+        bb.MakeCompound(c);
+        bb.Add(c, fc);
+        bb.Add(c, fc);
+        f.push_back({"compound(face, THE SAME face)", "hand-built", c});
+    }
+
+    // The same face and its own reverse -- what a self-folded sheet looks like after a bad
+    // sew. IsSame ignores orientation, so the map keeps one.
+    {
+        TopoDS_Shape fc = firstFace(box(10, 10, 10));
+        TopoDS_Shell sh;
+        BRep_Builder bb;
+        bb.MakeShell(sh);
+        bb.Add(sh, fc);
+        bb.Add(sh, fc.Reversed());
+        f.push_back({"shell(face, face.Reversed())", "hand-built", sh});
+    }
+
+    // One whole solid compounded with itself: every one of its faces is reachable twice.
+    {
+        TopoDS_Shape b = box(10, 10, 10);
+        TopoDS_Compound c;
+        BRep_Builder bb;
+        bb.MakeCompound(c);
+        bb.Add(c, b);
+        bb.Add(c, b);
+        f.push_back({"compound(box, THE SAME box)", "hand-built", c});
+    }
+
+    // A solid compounded with a MOVED copy of itself. IsSame compares the location, so this
+    // must NOT collapse -- the control that says the map is not merging instances.
+    {
+        TopoDS_Shape b = box(10, 10, 10);
+        gp_Trsf t;
+        t.SetTranslation(gp_Vec(50, 0, 0));
+        TopoDS_Compound c;
+        BRep_Builder bb;
+        bb.MakeCompound(c);
+        bb.Add(c, b);
+        bb.Add(c, b.Moved(TopLoc_Location(t)));
+        f.push_back({"compound(box, box.Moved())", "hand-built", c});
+    }
+
+    // One face used by two different parents in one compound: a face and a shell that
+    // contains it.
+    {
+        TopoDS_Shape b = box(10, 10, 10);
+        TopoDS_Shape fc = firstFace(b);
+        TopoDS_Compound c;
+        BRep_Builder bb;
+        bb.MakeCompound(c);
+        bb.Add(c, b);
+        bb.Add(c, fc);
+        f.push_back({"compound(box, one of its own faces)", "hand-built", c});
+    }
+
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+int main() {
+    printf("#541 face-index contract probe -- OCCT 8.0.0p1 (pinned)\n");
+    printf("========================================================\n\n");
+
+    auto fixtures = buildFixtures();
+
+    printf("%-38s %-11s %9s %9s  %s\n", "fixture", "provenance", "explorer", "map", "verdict");
+    printf("%-38s %-11s %9s %9s  %s\n", "--------------------------------------",
+           "-----------", "--------", "---", "-------");
+
+    int divergent = 0;
+    std::vector<const Fixture*> divergentFixtures;
+    std::vector<std::pair<size_t, size_t>> divergentCounts;
+
+    for (const auto& fx : fixtures) {
+        auto a = schemeA(fx.shape);
+        auto b = schemeB(fx.shape);
+        bool same = (a.size() == b.size());
+        printf("%-38s %-11s %9zu %9zu  %s\n", fx.name.c_str(), fx.provenance.c_str(),
+               a.size(), b.size(), same ? "agree" : "DIVERGE");
+        if (!same) {
+            divergent++;
+            divergentFixtures.push_back(&fx);
+            divergentCounts.push_back({a.size(), b.size()});
+        }
+    }
+
+    printf("\n%d of %zu fixtures diverge.\n\n", divergent, fixtures.size());
+
+    // ---- Q2/Q3: where do they start disagreeing, and do they ever name different faces? ----
+    printf("Per-index addressing on the divergent fixtures\n");
+    printf("----------------------------------------------\n");
+    printf("For each index both schemes accept, is it the same face?\n\n");
+
+    for (size_t k = 0; k < divergentFixtures.size(); k++) {
+        const Fixture& fx = *divergentFixtures[k];
+        auto a = schemeA(fx.shape);
+        auto b = schemeB(fx.shape);
+        printf("  %s  (explorer %zu, map %zu)\n", fx.name.c_str(), a.size(), b.size());
+
+        size_t shared = a.size() < b.size() ? a.size() : b.size();
+        int firstMismatch = -1;
+        for (size_t i = 0; i < shared; i++) {
+            const char* s = sameness(a[i], b[i]);
+            bool bad = (std::string(s) == "DIFFERENT");
+            if (bad && firstMismatch < 0) firstMismatch = (int)i;
+            printf("     index %2zu: %s%s\n", i, s, bad ? "   <-- wrong face" : "");
+        }
+        for (size_t i = shared; i < a.size(); i++) {
+            printf("     index %2zu: explorer has a face here, map does not"
+                   "  <-- Face.index that face(at:) answers nil for\n", i);
+        }
+        if (firstMismatch < 0) {
+            printf("     => every shared index names the same face; the explorer merely runs "
+                   "%zu entries longer\n", a.size() - b.size());
+        } else {
+            printf("     => the two schemes name DIFFERENT faces from index %d onwards\n",
+                   firstMismatch);
+        }
+        printf("\n");
+    }
+
+    // ---- Q4: order preservation on the shapes the fix must not disturb ----
+    printf("Order check on the agreeing fixtures\n");
+    printf("------------------------------------\n");
+    printf("Converging faces() onto the map must move no index on any shape that does not\n");
+    printf("share a face. Each index is compared face-by-face, not just by count.\n\n");
+
+    int orderBreaks = 0;
+    for (const auto& fx : fixtures) {
+        auto a = schemeA(fx.shape);
+        auto b = schemeB(fx.shape);
+        if (a.size() != b.size()) continue;
+        bool ok = true;
+        for (size_t i = 0; i < a.size(); i++) {
+            if (!a[i].IsEqual(b[i])) { ok = false; break; }
+        }
+        if (!ok) orderBreaks++;
+        printf("  %-38s %s\n", fx.name.c_str(),
+               ok ? "identical at every index" : "ORDER DIFFERS");
+    }
+    printf("\n%d order break(s) across the agreeing fixtures.\n\n", orderBreaks);
+
+    // ---- The 1-based schemes ----
+    printf("The 1-based scheme (C)\n");
+    printf("----------------------\n");
+    printf("C indexes the same map as B, from 1. So on any shape, C(i) == B(i-1), C(0) is\n");
+    printf("never a face, and B's last index is unreachable through C. Measured on the box:\n\n");
+    {
+        TopoDS_Shape probeBox = box(10, 10, 10);
+        auto b = schemeB(probeBox);
+        TopTools_IndexedMapOfShape m;
+        TopExp::MapShapes(probeBox, TopAbs_FACE, m);
+        printf("     face count: %d\n", m.Extent());
+        printf("     C(0)      : out of range -- rejected, or silently skipped\n");
+        printf("     C(1)      : %s as B(0)\n", sameness(m(1), b[0]));
+        printf("     C(%d)      : %s as B(%zu)  <-- C's last valid index\n",
+               m.Extent(), sameness(m(m.Extent()), b[b.size() - 1]), b.size() - 1);
+        printf("     B(%zu)      : reachable through C only as C(%zu)\n",
+               b.size() - 1, b.size());
+        printf("\n     A caller holding Face.index (0-based) and calling a C-scheme entry\n"
+               "     point addresses the face BEFORE the one it named, and can never name\n"
+               "     the last face at all.\n");
+    }
+
+    // ---- The third counting mechanism ----
+    printf("\nShapeAnalysis_ShapeContents, the third census\n");
+    printf("---------------------------------------------\n");
+    printf("Shape.contents does not read either scheme above. Which of its two face numbers,\n");
+    printf("if either, is the one faceCount reports?\n\n");
+    printf("%-38s %9s %9s %9s %9s\n", "fixture", "explorer", "map", "NbFaces", "NbShared");
+    for (const auto& fx : fixtures) {
+        ShapeAnalysis_ShapeContents sc;
+        sc.Perform(fx.shape);
+        printf("%-38s %9zu %9zu %9d %9d\n", fx.name.c_str(),
+               schemeA(fx.shape).size(), schemeB(fx.shape).size(),
+               sc.NbFaces(), sc.NbSharedFaces());
+    }
+    printf("\n  NbFaces tracks the explorer (occurrences). NbSharedFaces is a THIRD rule: it\n"
+           "  strips the location before adding to its map (ShapeAnalysis_ShapeContents.cxx:167,\n"
+           "  `face.Location(TopLoc_Location())`), so unlike IsSame it also collapses two\n"
+           "  placements of one face. Neither column is faceCount's answer on every fixture.\n");
+
+    printf("\ndone.\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1333,7 +1333,12 @@ int32_t OCCTShapeRaycast(
     int32_t maxHits
 );
 
-/// Get total number of faces in a shape
+/// Get total number of faces in a shape.
+///
+/// #541: this count, OCCTShapeGetFaceAtIndex, OCCTShapeGetFaces and every entry point in this
+/// header that takes a face index all read ONE enumeration: TopExp::MapShapes, one entry per
+/// distinct face (TopoDS_Shape::IsSame -- same TShape and location, orientation ignored),
+/// addressed 0-based. A face index is meaningful only against the shape it came from.
 int32_t OCCTShapeGetFaceCount(OCCTShapeRef shape);
 
 /// Get face by index (0-based)
@@ -2169,7 +2174,7 @@ typedef struct {
     double depth;
     double pointX, pointY, pointZ;
     int32_t subShapeType;   // TopAbs_ShapeEnum: 7=VERTEX, 6=EDGE, 5=WIRE, 4=FACE, 8=SHAPE
-    int32_t subShapeIndex;  // 1-based index of sub-shape within parent, 0 if whole shape
+    int32_t subShapeIndex;  // 0-based index of sub-shape within parent, -1 if whole shape (#541)
 } OCCTPickResult;
 
 OCCTSelectorRef OCCTSelectorCreate(void);
@@ -5306,7 +5311,8 @@ OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
 /// Offset a shape with per-face variable distances.
 /// @param shape The shape to offset
 /// @param defaultOffset Default offset distance for all faces
-/// @param faceIndices Array of 1-based face indices with custom offsets
+/// @param faceIndices Array of 0-based face indices with custom offsets; an index outside
+///        0..<faceCount fails the call rather than being skipped (#541)
 /// @param faceOffsets Array of offset values for those faces
 /// @param faceCount Number of custom face offsets
 /// @param tolerance Offset tolerance
@@ -8422,7 +8428,7 @@ OCCTShapeRef _Nullable OCCTShapeCustomTrsfModificationScale(OCCTShapeRef shape, 
 
 /// Build wires from loose edges of a shape.
 /// @param shape The shape whose edges to build into wires
-/// @param faceIndex 1-based face index to get edges from (0 = all edges)
+/// @param faceIndex 0-based face index to get edges from (negative = every edge of the shape)
 /// @param outWires Output array of wire shapes — caller must release each
 /// @param outCount Number of wires built
 /// @return true on success
@@ -8435,7 +8441,7 @@ bool OCCTLocOpeBuildWires(OCCTShapeRef shape, int32_t faceIndex,
 /// Split a shape by projecting a wire onto a face and splitting along it.
 /// @param shape The shape to split
 /// @param wire The splitting wire
-/// @param faceIndex 1-based index of the face to split
+/// @param faceIndex 0-based index of the face to split
 /// @return The split shape, or NULL on failure
 OCCTShapeRef _Nullable OCCTLocOpeSplitByWireOnFace(OCCTShapeRef shape,
     OCCTShapeRef wire, int32_t faceIndex);
@@ -14235,11 +14241,14 @@ int32_t OCCTEdgeFaceAdjacency(OCCTShapeRef _Nonnull shape, int32_t* _Nullable ad
 int32_t OCCTVertexEdgeAdjacency(OCCTShapeRef _Nonnull shape, int32_t* _Nullable adjacentEdgeCounts);
 
 /// Get adjacent faces for a specific edge within a shape. Returns count of faces found.
-/// faceIndices is an output array of face indices (1-based, into indexed map). Caller allocates (max 64).
+/// faceIndices is an output array of 0-based face indices, addressable with
+/// OCCTShapeGetFaceAtIndex. Caller allocates (max 64).
 int32_t OCCTEdgeAdjacentFaces(OCCTShapeRef _Nonnull shape, OCCTShapeRef _Nonnull edge,
                               int32_t* _Nonnull faceIndices, int32_t maxFaces);
 
 /// Get adjacent edges for a specific vertex within a shape. Returns count of edges found.
+/// edgeIndices is an output array of 0-based edge indices, addressable with
+/// OCCTShapeGetEdgeAtIndex. Caller allocates (max 64).
 int32_t OCCTVertexAdjacentEdges(OCCTShapeRef _Nonnull shape, OCCTShapeRef _Nonnull vertex,
                                 int32_t* _Nonnull edgeIndices, int32_t maxEdges);
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -1987,15 +1987,11 @@ bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape, int32_t subShapeType, 
     try {
         BRepCheck_Analyzer analyzer(parentShape->shape, true);
 
-        TopAbs_ShapeEnum type = (TopAbs_ShapeEnum)subShapeType;
-        int idx = 0;
-        for (TopExp_Explorer exp(parentShape->shape, type); exp.More(); exp.Next()) {
-            if (idx == subShapeIndex) {
-                return analyzer.IsValid(exp.Current());
-            }
-            idx++;
-        }
-        return false;
+        // #541: the shared enumeration, so this names the same sub-shape every other
+        // type+index entry point does.
+        TopoDS_Shape sub = occtSubShapeAt(parentShape->shape, subShapeType, subShapeIndex);
+        if (sub.IsNull()) return false;
+        return analyzer.IsValid(sub);
     } catch (...) {
         return false;
     }
@@ -3507,15 +3503,12 @@ bool OCCTShapeFixEdgeProjAux(OCCTShapeRef shape, int32_t faceIndex, int32_t edge
                               double precision, double* outFirst, double* outLast) {
     if (!shape) return false;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return false;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return false;
 
-        TopExp_Explorer edgeExp(face, TopAbs_EDGE);
-        for (int i = 0; i < edgeIndex && edgeExp.More(); i++) edgeExp.Next();
-        if (!edgeExp.More()) return false;
-        TopoDS_Edge edge = TopoDS::Edge(edgeExp.Current());
+        // The edge index is into the face's own edge enumeration, read the same way.
+        TopoDS_Edge edge = occtEdgeAt(face, edgeIndex);
+        if (edge.IsNull()) return false;
 
         Handle(ShapeFix_EdgeProjAux) aux = new ShapeFix_EdgeProjAux(face, edge);
         aux->Compute(precision);
@@ -3533,10 +3526,8 @@ int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef shape, int32_t faceIndex,
                                     OCCTShapeRef* outFaces, int32_t maxFaces) {
     if (!shape) return -1;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return -1;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return -1;
 
         BRepAlgo_FaceRestrictor restrictor;
         restrictor.Init(face, false, true);
@@ -3572,10 +3563,8 @@ int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef shape, int32_t faceIndex,
 bool OCCTShapeFixIntersectingWires(OCCTShapeRef shape, int32_t faceIndex, double precision) {
     if (!shape) return false;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return false;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return false;
 
         Handle(ShapeBuild_ReShape) ctx = new ShapeBuild_ReShape();
         ShapeFix_IntersectionTool tool(ctx, precision, 1.0);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1097,6 +1097,43 @@ inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int3
     return map(index + 1);  // OCCT's indexed maps are 1-based
 }
 
+// === #541: one meaning for a face index ===
+//
+// A face index crossing this bridge is a 0-based position in the enumeration above -- the one
+// Shape.faces(), Shape.faceCount and Shape.face(at:) all read. Before #541 it was three things:
+// OCCTShapeGetFaces walked a bare TopExp_Explorer (one entry per *occurrence*, so the index it
+// wrote into Face.index could name a face no other entry point had), fourteen consumers walked
+// their own explorer to match it, and a handful read the deduplicated map 1-based, so a Face.index
+// addressed the face before the one it named and could never name the last face at all.
+//
+// Measured on the pinned kernel (Scripts/repro/541-face-index-contract/): the explorer/map
+// divergence is not a hand-built curiosity. One BRepAlgoAPI_Splitter run cutting a box with a
+// plane leaves two solids sharing the single cut face -- 12 occurrences over 11 distinct faces --
+// and the duplicate is not last, so from index 10 onwards the two schemes named *different* faces.
+// A caller holding Face.index from faces() drafted, deleted or opened a face it had not selected.
+// On the ten fixtures that share no face the two orders are identical face-by-face, so converging
+// them moved no index on any shape without a shared sub-shape.
+//
+// Use these two rather than open-coding an explorer walk or a map lookup: a null return means
+// "no such index", which is the only failure they have.
+
+/// The face at 0-based `index` in `shape`'s face enumeration, or a null face when the index is
+/// negative, past the end, or names a sub-shape that is not a face.
+inline TopoDS_Face occtFaceAt(const TopoDS_Shape& shape, int32_t index) {
+    TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_FACE, index);
+    if (sub.IsNull() || sub.ShapeType() != TopAbs_FACE) return TopoDS_Face();
+    return TopoDS::Face(sub);
+}
+
+/// The edge at 0-based `index` in `shape`'s edge enumeration, or a null edge when the index is
+/// negative, past the end, or names a sub-shape that is not an edge. `shape` is often a single
+/// face, whose edges are enumerated the same way.
+inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index) {
+    TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_EDGE, index);
+    if (sub.IsNull() || sub.ShapeType() != TopAbs_EDGE) return TopoDS_Edge();
+    return TopoDS::Edge(sub);
+}
+
 // === #405/#494: one resolution behind every GeomLProp_* local-property construction ===
 //
 // GeomLProp_SLProps / GeomLProp_CLProps / GeomLProp_CLProps2d each take a `Resolution` their own

--- a/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
@@ -1571,11 +1571,14 @@ OCCTShapeRef OCCTShapeReadSTL(const char* filePath) {
 // MARK: - v0.102: Poly_Connect Mesh Adjacency
 // MARK: - Poly_Connect Mesh Adjacency (v0.102.0)
 
+// #541: the FACE index is 0-based, like Face.index and every other face index in the API. It was
+// 1-based, so the caller had no way to name face 0 -- and nothing in the Swift API produces a
+// 1-based face index to feed it. The triangle and node indices these functions take stay 1-based:
+// those address Poly_Triangulation's own arrays, not a shape's faces, and the triangle indices
+// they hand back (Poly_Connect::Triangles/Triangle) are 1-based too.
 static Handle(Poly_Triangulation) _getFaceTriangulation(OCCTShapeRef shape, int32_t faceIndex) {
-    NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> faceMap;
-    TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-    if (faceIndex < 1 || faceIndex > faceMap.Extent()) return nullptr;
-    TopoDS_Face face = TopoDS::Face(faceMap(faceIndex));
+    TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+    if (face.IsNull()) return nullptr;
     TopLoc_Location loc;
     return BRep_Tool::Triangulation(face, loc);
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -2417,9 +2417,14 @@ OCCTShapeRef OCCTShapeOffsetPerFace(OCCTShapeRef shape, double defaultOffset,
         offset.Initialize(shape->shape, defaultOffset, tolerance,
                           BRepOffset_Skin, false, false, jt);
 
+        // #541: 0-based, matching Face.index and every sibling here. It was 1-based, so a
+        // Face.index offset the face before the one it named and index 0 was silently dropped.
+        // Out of range is a caller error rather than something to skip: skipping returned a
+        // shape offset by the default everywhere, indistinguishable from a successful run
+        // (the same failure #497 fixed for defeaturing).
         for (int32_t i = 0; i < faceCount; i++) {
-            int32_t idx = faceIndices[i];
-            if (idx < 1 || idx > faceMap.Extent()) continue;
+            int32_t idx = faceIndices[i] + 1;
+            if (idx < 1 || idx > faceMap.Extent()) return nullptr;
             const TopoDS_Face& face = TopoDS::Face(faceMap(idx));
             offset.SetOffsetOnFace(face, faceOffsets[i]);
         }
@@ -4576,16 +4581,8 @@ OCCTShapeRef OCCTLocOpeSplitShapeByWire(OCCTShapeRef shape, int32_t faceIndex, O
     try {
         LocOpe_SplitShape splitter(shape->shape);
 
-        // Find the target face
-        TopoDS_Face face;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex) {
-                face = TopoDS::Face(exp.Current());
-                break;
-            }
-            idx++;
-        }
+        // #541: the shared face enumeration, so this names the face face(at:) names.
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
         if (face.IsNull()) return nullptr;
 
         // Extract wire
@@ -4688,16 +4685,8 @@ OCCTShapeRef OCCTLocOpeSplitDrafts(OCCTShapeRef shape, int32_t faceIndex, OCCTSh
         LocOpe_SplitDrafts splitDrafts;
         splitDrafts.Init(shape->shape);
 
-        // Find the target face
-        TopoDS_Face face;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex) {
-                face = TopoDS::Face(exp.Current());
-                break;
-            }
-            idx++;
-        }
+        // #541: the shared face enumeration, so this names the face face(at:) names.
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
         if (face.IsNull()) return nullptr;
 
         // Extract wire
@@ -4748,16 +4737,8 @@ int32_t OCCTLocOpeFindEdgesInFace(OCCTShapeRef shape, int32_t faceIndex,
                                    OCCTShapeRef* outEdges, int32_t maxEdges) {
     if (!shape || !outEdges || maxEdges <= 0) return 0;
     try {
-        // Find the target face
-        TopoDS_Face face;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex) {
-                face = TopoDS::Face(exp.Current());
-                break;
-            }
-            idx++;
-        }
+        // #541: the shared face enumeration, so this names the face face(at:) names.
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
         if (face.IsNull()) return 0;
 
         LocOpe_FindEdgesInFace finder;
@@ -5629,12 +5610,13 @@ bool OCCTLocOpeBuildWires(OCCTShapeRef shape, int32_t faceIndex,
     int32_t* outCount) {
     if (!shape) return false;
     try {
+        // #541: the face index is 0-based, like Face.index. The "every edge of the shape"
+        // sentinel used to be 0, which collided with the first face's own index and made that
+        // face unaddressable; it is now any negative value.
         NCollection_List<TopoDS_Shape> edges;
-        if (faceIndex > 0) {
-            TopTools_IndexedMapOfShape faceMap;
-            TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-            if (faceIndex > faceMap.Extent()) return false;
-            TopoDS_Face face = TopoDS::Face(faceMap(faceIndex));
+        if (faceIndex >= 0) {
+            TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+            if (face.IsNull()) return false;
             TopExp_Explorer exp(face, TopAbs_EDGE);
             for (; exp.More(); exp.Next()) edges.Append(exp.Current());
         } else {
@@ -5667,10 +5649,9 @@ OCCTShapeRef _Nullable OCCTLocOpeSplitByWireOnFace(OCCTShapeRef shape,
     OCCTShapeRef wire, int32_t faceIndex) {
     if (!shape || !wire) return nullptr;
     try {
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-        if (faceIndex < 1 || faceIndex > faceMap.Extent()) return nullptr;
-        TopoDS_Face face = TopoDS::Face(faceMap(faceIndex));
+        // #541: 0-based, matching Face.index. It was 1-based, so face 0 was unaddressable.
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return nullptr;
 
         TopoDS_Wire w;
         if (wire->shape.ShapeType() == TopAbs_WIRE) {
@@ -7359,10 +7340,8 @@ void OCCTBRepAlgoImageClear(OCCTBRepAlgoImageRef img) {
 int32_t OCCTShapeBuildLoops(OCCTShapeRef shape, int32_t faceIndex) {
     if (!shape) return -1;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return -1;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return -1;
 
         BRepAlgo_Loop loop;
         loop.Init(face);
@@ -7385,10 +7364,8 @@ OCCTShapeRef OCCTShapeDraftModification(OCCTShapeRef shape, int32_t faceIndex,
                               double planeNX, double planeNY, double planeNZ) {
     if (!shape) return nullptr;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return nullptr;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return nullptr;
 
         Handle(Draft_Modification) draft = new Draft_Modification(shape->shape);
         draft->Add(face, gp_Dir(dirX, dirY, dirZ), angle,

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1317,10 +1317,8 @@ OCCTVinertGKResult OCCTBRepGPropVinertGK(OCCTShapeRef _Nonnull faceRef,
 int32_t OCCTShapeFaceDomainEdgeCount(OCCTShapeRef shape, int32_t faceIndex) {
     if (!shape) return 0;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return 0;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return 0;
 
         BRepGProp_Domain domain(face);
         int count = 0;

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1158,13 +1158,7 @@ OCCTPointFaceExtremaResult OCCTBRepExtremaExtPF(double px, double py, double pz,
     OCCTPointFaceExtremaResult result = {};
     if (!shape) return result;
     try {
-        // Find face
-        TopoDS_Face face;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex) { face = TopoDS::Face(exp.Current()); break; }
-            idx++;
-        }
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
         if (face.IsNull()) return result;
 
         TopoDS_Vertex vertex = BRepBuilderAPI_MakeVertex(gp_Pnt(px, py, pz));
@@ -1189,18 +1183,8 @@ OCCTFaceFaceExtremaResult OCCTBRepExtremaExtFF(OCCTShapeRef shape1, int32_t face
     OCCTFaceFaceExtremaResult result = {};
     if (!shape1 || !shape2) return result;
     try {
-        // Find faces
-        TopoDS_Face f1, f2;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape1->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex1) { f1 = TopoDS::Face(exp.Current()); break; }
-            idx++;
-        }
-        idx = 0;
-        for (TopExp_Explorer exp(shape2->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex2) { f2 = TopoDS::Face(exp.Current()); break; }
-            idx++;
-        }
+        TopoDS_Face f1 = occtFaceAt(shape1->shape, faceIndex1);
+        TopoDS_Face f2 = occtFaceAt(shape2->shape, faceIndex2);
         if (f1.IsNull() || f2.IsNull()) return result;
 
         BRepExtrema_ExtFF extFF(f1, f2);
@@ -1268,20 +1252,10 @@ OCCTEdgeFaceExtremaResult OCCTBRepExtremaExtCF(OCCTShapeRef shape1, int32_t edge
     OCCTEdgeFaceExtremaResult result = {};
     if (!shape1 || !shape2) return result;
     try {
-        TopoDS_Edge edge;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape1->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            if (idx == edgeIndex) { edge = TopoDS::Edge(exp.Current()); break; }
-            idx++;
-        }
+        TopoDS_Edge edge = occtEdgeAt(shape1->shape, edgeIndex);
         if (edge.IsNull()) return result;
 
-        TopoDS_Face face;
-        idx = 0;
-        for (TopExp_Explorer exp(shape2->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            if (idx == faceIndex) { face = TopoDS::Face(exp.Current()); break; }
-            idx++;
-        }
+        TopoDS_Face face = occtFaceAt(shape2->shape, faceIndex);
         if (face.IsNull()) return result;
 
         BRepExtrema_ExtCF ext(edge, face);
@@ -1796,10 +1770,8 @@ int32_t OCCTShapeClassifyPoint2D(OCCTShapeRef shape, int32_t faceIndex,
                                    double u, double v, double tolerance) {
     if (!shape) return 3;
     try {
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        for (int i = 0; i < faceIndex && faceExp.More(); i++) faceExp.Next();
-        if (!faceExp.More()) return 3;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+        if (face.IsNull()) return 3;
 
         BRepClass_FaceExplorer explorer(face);
         BRepClass_FClassifier classifier(explorer, gp_Pnt2d(u, v), tolerance);
@@ -2032,7 +2004,9 @@ int32_t OCCTEdgeAdjacentFaces(OCCTShapeRef shape, OCCTShapeRef edge,
         int32_t count = 0;
         for (auto it = faces.cbegin(); it != faces.cend() && count < maxFaces; ++it) {
             int fi = faceMap.FindIndex(*it);
-            if (fi > 0) faceIndices[count++] = (int32_t)fi;
+            // #541: FindIndex is 1-based; these indices address the same enumeration
+            // OCCTShapeGetFaceAtIndex reads 0-based, so they are reported 0-based too.
+            if (fi > 0) faceIndices[count++] = (int32_t)(fi - 1);
         }
         return count;
     } catch (...) { return 0; }
@@ -2052,7 +2026,8 @@ int32_t OCCTVertexAdjacentEdges(OCCTShapeRef shape, OCCTShapeRef vertex,
         int32_t count = 0;
         for (auto it = edges.cbegin(); it != edges.cend() && count < maxEdges; ++it) {
             int ei = edgeMap.FindIndex(*it);
-            if (ei > 0) edgeIndices[count++] = (int32_t)ei;
+            // #541: 0-based, matching OCCTShapeGetEdgeAtIndex. See OCCTEdgeAdjacentFaces.
+            if (ei > 0) edgeIndices[count++] = (int32_t)(ei - 1);
         }
         return count;
     } catch (...) { return 0; }
@@ -3915,28 +3890,25 @@ bool OCCTBRepToolSetUVPoints(OCCTShapeRef edge, OCCTShapeRef face,
 #include <BRepAdaptor_Curve.hxx>
 #include <GeomAbs_SurfaceType.hxx>
 
+// #541: this drove its own TopExp_Explorer, one entry per occurrence, while
+// OCCTShapeGetFaceCount/GetFaceAtIndex read the deduplicated map. Since Swift writes the array
+// position here into Face.index and hands it back to ~30 index-taking entry points, the two
+// enumerations had to be one. Reads occtMapSubShapes now, like every other face accessor.
 OCCTFaceRef* OCCTShapeGetFaces(OCCTShapeRef shape, int32_t* outCount) {
     if (!shape || !outCount) return nullptr;
     *outCount = 0;
 
     try {
-        // First, count faces
-        std::vector<TopoDS_Face> faces;
-        TopExp_Explorer explorer(shape->shape, TopAbs_FACE);
-        while (explorer.More()) {
-            faces.push_back(TopoDS::Face(explorer.Current()));
-            explorer.Next();
+        TopTools_IndexedMapOfShape faceMap;
+        int32_t count = occtMapSubShapes(shape->shape, TopAbs_FACE, faceMap);
+        if (count == 0) return nullptr;
+
+        OCCTFaceRef* result = new OCCTFaceRef[count];
+        for (int32_t i = 0; i < count; i++) {
+            result[i] = new OCCTFace(TopoDS::Face(faceMap(i + 1)));
         }
 
-        if (faces.empty()) return nullptr;
-
-        // Allocate array
-        OCCTFaceRef* result = new OCCTFaceRef[faces.size()];
-        for (size_t i = 0; i < faces.size(); i++) {
-            result[i] = new OCCTFace(faces[i]);
-        }
-
-        *outCount = static_cast<int32_t>(faces.size());
+        *outCount = count;
         return result;
     } catch (...) {
         return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
@@ -737,7 +737,7 @@ static int32_t OCCTSelectorCollectResults(OCCTSelectorRef sel, OCCTPickResult* o
 
         // Extract sub-shape information from BRepOwner
         out[count].subShapeType = static_cast<int32_t>(TopAbs_SHAPE);
-        out[count].subShapeIndex = 0;
+        out[count].subShapeIndex = -1;
 
         Handle(StdSelect_BRepOwner) brepOwner =
             Handle(StdSelect_BRepOwner)::DownCast(owner);
@@ -745,12 +745,15 @@ static int32_t OCCTSelectorCollectResults(OCCTSelectorRef sel, OCCTPickResult* o
             const TopoDS_Shape& subShape = brepOwner->Shape();
             out[count].subShapeType = static_cast<int32_t>(subShape.ShapeType());
 
-            // Find 1-based index of sub-shape within parent shape
+            // #541: a picked sub-shape's index is 0-based, so it can be handed straight to
+            // OCCTShapeGetFaceAtIndex / GetSubShapeByTypeIndex. It used to be 1-based with 0
+            // meaning "the whole shape", which both misaddressed every pick by one and made
+            // the sentinel indistinguishable from a hit on sub-shape 0; the sentinel is -1 now.
             if (brepOwner->ComesFromDecomposition()) {
                 TopTools_IndexedMapOfShape map;
                 TopExp::MapShapes(selectable->Shape(), subShape.ShapeType(), map);
                 int idx = map.FindIndex(subShape);
-                out[count].subShapeIndex = (idx > 0) ? idx : 0;
+                out[count].subShapeIndex = (idx > 0) ? idx - 1 : -1;
             }
         }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -7186,14 +7186,29 @@ extension Shape {
         return counts.map { Int($0) }
     }
 
-    /// Get 1-based face indices adjacent to a specific edge within this shape.
+    /// The 0-based indices of the faces adjacent to `edge` within this shape.
+    ///
+    /// The indices address the same enumeration ``Shape/face(at:)`` reads, so they can be handed
+    /// straight to it. They used to be 1-based, which named the face before the intended one and
+    /// could never name face 0 (#541).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let edge = box.subShapes(ofType: .edge).first!
+    /// for i in box.adjacentFaces(forEdge: edge) {
+    ///     print(box.face(at: i)!.area())   // the two faces meeting at that edge
+    /// }
+    /// ```
     public func adjacentFaces(forEdge edge: Shape) -> [Int] {
         var indices = [Int32](repeating: 0, count: 64)
         let count = Int(OCCTEdgeAdjacentFaces(handle, edge.handle, &indices, 64))
         return indices.prefix(count).map { Int($0) }
     }
 
-    /// Get 1-based edge indices adjacent to a specific vertex within this shape.
+    /// The 0-based indices of the edges meeting `vertex` within this shape.
+    ///
+    /// The indices address the same enumeration ``Shape/subShape(type:index:)`` reads for
+    /// `.edge`. They used to be 1-based (#541).
     public func adjacentEdges(forVertex vertex: Shape) -> [Int] {
         var indices = [Int32](repeating: 0, count: 64)
         let count = Int(OCCTVertexAdjacentEdges(handle, vertex.handle, &indices, 64))
@@ -7206,7 +7221,11 @@ extension Shape {
 extension Shape {
 
     /// Get adjacent triangles for a triangle in a meshed face.
-    /// faceIndex and triangleIndex are 1-based. Returns (adj1, adj2, adj3), 0 means no neighbor.
+    /// The three triangles adjacent to one triangle of a face's triangulation.
+    ///
+    /// `faceIndex` is 0-based, like ``Face/index`` and every other face index in this API (#541).
+    /// `triangleIndex` and the returned neighbour indices are `Poly_Triangulation`'s own 1-based
+    /// triangle numbers; 0 means no neighbour on that side.
     public func meshTriangleAdjacency(faceIndex: Int, triangleIndex: Int) -> (Int, Int, Int)? {
         var a1: Int32 = 0, a2: Int32 = 0, a3: Int32 = 0
         guard OCCTMeshTriangleAdjacency(handle, Int32(faceIndex), Int32(triangleIndex), &a1, &a2, &a3) else {
@@ -7215,13 +7234,18 @@ extension Shape {
         return (Int(a1), Int(a2), Int(a3))
     }
 
-    /// Get a triangle index containing a given node. faceIndex and nodeIndex are 1-based.
+    /// A triangle containing the given node of a face's triangulation.
+    ///
+    /// `faceIndex` is 0-based (#541); `nodeIndex` and the returned triangle index are
+    /// `Poly_Triangulation`'s own 1-based numbers.
     public func meshNodeTriangle(faceIndex: Int, nodeIndex: Int) -> Int? {
         let idx = Int(OCCTMeshNodeTriangle(handle, Int32(faceIndex), Int32(nodeIndex)))
         return idx > 0 ? idx : nil
     }
 
     /// Count triangles sharing a node (triangle fan count).
+    ///
+    /// `faceIndex` is 0-based (#541); `nodeIndex` is `Poly_Triangulation`'s own 1-based number.
     public func meshNodeTriangleCount(faceIndex: Int, nodeIndex: Int) -> Int {
         Int(OCCTMeshNodeTriangleCount(handle, Int32(faceIndex), Int32(nodeIndex)))
     }

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -6,7 +6,11 @@ import OCCTBridge
 public final class Face: @unchecked Sendable {
     internal let handle: OCCTFaceRef
 
-    /// Index of this face within the parent shape (-1 if standalone)
+    /// This face's 0-based position in its parent shape's face enumeration, or -1 when the face
+    /// was not produced from a parent.
+    ///
+    /// The same token ``Shape/face(at:)`` takes, and the one every face-index-taking method on
+    /// `Shape` expects. It is only meaningful against the shape it came from.
     public let index: Int
 
     internal init(handle: OCCTFaceRef, index: Int = -1) {
@@ -236,7 +240,23 @@ public final class Face: @unchecked Sendable {
 // MARK: - Shape Extension for Face Analysis
 
 extension Shape {
-    /// Get all faces from the solid
+    /// Every distinct face of this shape, in enumeration order.
+    ///
+    /// Each returned ``Face`` carries its own ``Face/index``, which is its position here and the
+    /// token ``Shape/face(at:)``, ``Shape/drafted(faces:direction:angle:neutralPlane:)``,
+    /// ``Shape/shelled(thickness:openFaces:)`` and ``Shape/withoutFeatures(faces:)`` all address.
+    ///
+    /// This is the enumeration ``Shape/faceCount`` counts. Before #541 it was a separate walk that
+    /// yielded one entry per *occurrence* in the topology tree, so a face reachable from two
+    /// parents appeared twice and the surplus indices named faces nothing else could address.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let top = box.faces().filter { $0.isUpwardFacing() }
+    /// if let hollow = box.shelled(thickness: 1.0, openFaces: top) {
+    ///     print(hollow.faceCount)   // the open box
+    /// }
+    /// ```
     public func faces() -> [Face] {
         var count: Int32 = 0
         guard let faceArray = OCCTShapeGetFaces(handle, &count) else {

--- a/Sources/OCCTSwift/Selection.swift
+++ b/Sources/OCCTSwift/Selection.swift
@@ -93,14 +93,40 @@ extension Shape {
 // MARK: - Shape Face Index Access Extension
 
 extension Shape {
-    /// Get total number of faces in the shape
+    /// The number of distinct faces in this shape.
+    ///
+    /// This is the same enumeration ``faces()`` walks and ``face(at:)`` indexes: one entry per
+    /// distinct face, in `TopExp_Explorer` order, addressed from 0. A face reachable from two
+    /// parents — the wall shared by both halves of a split solid, say — counts once.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.faceCount)                     // 6
+    /// print(box.faces().count)                 // 6, the same enumeration
+    /// print(box.subShapeCount(ofType: .face))  // 6, the generic spelling
+    /// ```
     public var faceCount: Int {
         Int(OCCTShapeGetFaceCount(handle))
     }
-    
-    /// Get face by index (0-based)
-    /// - Parameter index: The face index
-    /// - Returns: Face at the given index, or nil if index is out of bounds
+
+    /// The face at a 0-based index in this shape's face enumeration.
+    ///
+    /// The index is the one ``Face/index`` carries, and the one every face-index-taking method on
+    /// `Shape` expects. It is meaningful only against the shape it came from: an index taken from
+    /// one shape and used on another names an unrelated face, or nothing at all.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// for face in box.faces() {
+    ///     // Every index faces() hands out is addressable here, and names the same face.
+    ///     let again = box.face(at: face.index)!
+    ///     print(face.index, again.area())
+    /// }
+    /// print(box.face(at: box.faceCount) as Any)   // nil — one past the end
+    /// ```
+    ///
+    /// - Parameter index: The face index, in `0..<faceCount`.
+    /// - Returns: Face at the given index, or nil if the index is out of bounds.
     public func face(at index: Int) -> Face? {
         guard let faceHandle = OCCTShapeGetFaceAtIndex(handle, Int32(index)) else {
             return nil

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -56,8 +56,12 @@ public final class Selector: @unchecked Sendable {
         /// The type of sub-shape that was hit.
         public let subShapeType: SubShapeType
 
-        /// 1-based index of the sub-shape within its parent shape.
-        /// Zero if the whole shape was selected (mode 0).
+        /// 0-based index of the sub-shape within its parent shape, addressable with
+        /// ``Shape/face(at:)`` or ``Shape/subShape(type:index:)``.
+        ///
+        /// `-1` when the whole shape was selected (mode 0). It used to be 1-based with `0` as
+        /// that sentinel, so a picked sub-shape's index named the one before it and the sentinel
+        /// was indistinguishable from a hit on sub-shape 0 (#541).
         public let subShapeIndex: Int32
     }
 

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -4577,6 +4577,10 @@ extension Shape {
 // MARK: - Shape Contents (v0.30.0)
 
 /// Census of sub-shape counts in a shape.
+///
+/// These are **occurrence** counts, not the distinct-sub-shape counts ``Shape/faceCount``,
+/// ``Shape/edgeCount`` and ``Shape/subShapeCount(ofType:)`` report. See ``Shape/contents`` for
+/// what that difference means and when the two disagree.
 public struct ShapeContents: Sendable {
     public let solids: Int
     public let shells: Int
@@ -4590,10 +4594,34 @@ public struct ShapeContents: Sendable {
 }
 
 extension Shape {
-    /// Get a census of sub-shape counts in this shape.
+    /// A census of sub-shape *occurrences* in this shape, from `ShapeAnalysis_ShapeContents`.
     ///
-    /// Reports topology complexity metrics: counts of solids, shells,
-    /// faces, wires, edges, vertices, and free (unconnected) elements.
+    /// This is a complexity metric, not the addressable sub-shape enumeration. It counts one
+    /// entry per visit in the topology tree, so a sub-shape reachable from two parents is
+    /// counted twice, and every edge of a box is counted once per adjacent face:
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.edgeCount)          // 12 — the distinct edges, and the addressable ones
+    /// print(box.contents.edges)     // 24 — one per (face, edge) visit
+    /// print(box.faceCount)          // 6
+    /// print(box.contents.faces)     // 6 — a box shares no face, so these agree
+    /// ```
+    ///
+    /// **None of these numbers is an index bound.** `0..<contents.faces` overruns
+    /// ``face(at:)`` on any shape with a shared face; use ``faceCount``.
+    ///
+    /// There is a third count in play, and it is a third rule again:
+    /// ``contentsExtended()``'s `nbSharedFaces` and friends deduplicate with the location
+    /// *discarded*, so unlike ``faceCount`` — which follows `TopoDS_Shape::IsSame` and keeps
+    /// placements apart — they also collapse two instances of one body. Measured on the pinned
+    /// kernel (`Scripts/repro/541-face-index-contract/`), on a compound of a box with a
+    /// ``moved(dx:dy:dz:)`` copy of itself: `faceCount` 12, `contents.faces` 12,
+    /// `nbSharedFaces` 6. (``translated(by:)`` does not make an instance — it rebuilds through
+    /// `BRepBuilderAPI_Transform`, so the copy shares nothing and all three read 12.)
+    ///
+    /// - Returns: Counts of solids, shells, faces, wires, edges, vertices, and free
+    ///   (unconnected) elements.
     public var contents: ShapeContents {
         let c = OCCTShapeGetContents(handle)
         return ShapeContents(
@@ -6156,7 +6184,10 @@ extension Shape {
     ///
     /// - Parameters:
     ///   - defaultOffset: Default offset distance for all faces.
-    ///   - faceOffsets: Dictionary mapping 1-based face indices to custom offset distances.
+    ///   - faceOffsets: Dictionary mapping 0-based face indices — as ``face(at:)`` and
+    ///     ``Face/index`` use — to custom offset distances. An index outside `0..<faceCount`
+    ///     fails the call; it used to be skipped, which returned a shape offset by the default
+    ///     everywhere and looked exactly like success (#541).
     ///   - tolerance: Offset tolerance (default: 1e-3).
     ///   - joinType: Join type for offset gaps (default: .arc).
     /// - Returns: Offset shape, or nil on failure.
@@ -9339,9 +9370,18 @@ extension Shape {
 
     // MARK: LocOpe_BuildWires
 
-    /// Build wires from the edges of a face.
-    /// - Parameter faceIndex: 1-based face index (0 = all edges)
-    public func buildWires(faceIndex: Int32 = 0) -> [Shape]? {
+    /// Build wires from the edges of one face, or of the whole shape.
+    ///
+    /// - Parameter faceIndex: 0-based face index, as ``face(at:)`` and ``Face/index`` use.
+    ///   Any negative value means every edge of the shape. The sentinel used to be `0`, which
+    ///   collided with the first face's own index and left that face unaddressable (#541).
+    ///
+    /// ```swift
+    /// let box = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+    /// let allEdges = box.buildWires(faceIndex: -1)!   // every edge of the box
+    /// let firstFace = box.buildWires(faceIndex: 0)!   // just face 0's edges
+    /// ```
+    public func buildWires(faceIndex: Int32 = -1) -> [Shape]? {
         var outWires: UnsafeMutablePointer<OCCTShapeRef?>?
         var outCount: Int32 = 0
         guard OCCTLocOpeBuildWires(handle, faceIndex, &outWires, &outCount) else { return nil }
@@ -9365,7 +9405,8 @@ extension Shape {
     ///
     /// - Parameters:
     ///   - wire: The splitting wire
-    ///   - faceIndex: 1-based index of the face to split
+    ///   - faceIndex: 0-based index of the face to split, as ``face(at:)`` and ``Face/index``
+    ///     use. It was 1-based, so face 0 could not be named at all (#541).
     public func splitByWireOnFace(_ wire: Shape, faceIndex: Int32) -> Shape? {
         guard let h = OCCTLocOpeSplitByWireOnFace(handle, wire.handle, faceIndex) else { return nil }
         return Shape(handle: h)

--- a/Tests/OCCTTopologyTests/Issue495FaceContinuityTests.swift
+++ b/Tests/OCCTTopologyTests/Issue495FaceContinuityTests.swift
@@ -16,15 +16,19 @@ import Testing
 struct Issue495FaceContinuityTests {
 
     /// Every (edge, faceA, faceB) triple in `shape` where exactly two faces share the edge.
+    ///
+    /// `adjacentFaces(forEdge:)` returns 0-based indices into the same enumeration
+    /// `subShapes(ofType: .face)` walks, so they index it directly. They were 1-based until #541,
+    /// which is why this helper used to subtract one.
     private func sharedEdgeTriples(in shape: Shape) -> [(Shape, Shape, Shape)] {
         let faces = shape.subShapes(ofType: .face)
         return shape.subShapes(ofType: .edge).compactMap { edge in
-            let adjacent = shape.adjacentFaces(forEdge: edge)   // 1-based
+            let adjacent = shape.adjacentFaces(forEdge: edge)
             guard adjacent.count == 2,
                   let a = adjacent.first, let b = adjacent.last,
-                  a >= 1, a <= faces.count, b >= 1, b <= faces.count
+                  a >= 0, a < faces.count, b >= 0, b < faces.count
             else { return nil }
-            return (edge, faces[a - 1], faces[b - 1])
+            return (edge, faces[a], faces[b])
         }
     }
 

--- a/Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift
@@ -1,0 +1,320 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #541: a face index meant three different things.
+//
+//   A. `Shape.faces()` walked a bare `TopExp_Explorer`, one entry per *occurrence* in the
+//      topology tree, and wrote the array position into `Face.index`.
+//   B. `Shape.faceCount` / `Shape.face(at:)` — and most of the ~30 entry points that take a face
+//      index — read `TopExp::MapShapes`, one entry per *distinct* face (`TopoDS_Shape::IsSame`).
+//   C. A handful read the same map 1-based, so a 0-based `Face.index` addressed the face before
+//      the one it named and could never name the last face at all.
+//
+// Measured on the pinned kernel (`Scripts/repro/541-face-index-contract/`): the A/B divergence is
+// not a hand-built curiosity. One `BRepAlgoAPI_Splitter` run cutting a box with a plane leaves two
+// solids sharing the single cut face — 12 occurrences over 11 distinct faces — and the duplicate
+// is not last, so from index 10 onwards the two schemes name *different* faces. A caller holding
+// `Face.index` from `faces()` drafted, deleted or opened a face it had not selected.
+//
+// These tests fix all three on one enumeration: `occtMapSubShapes`, 0-based.
+
+@Suite("A face index means one thing (#541)")
+struct Issue541FaceIndexContractTests {
+
+    // MARK: - Fixtures
+
+    /// Two solids that share one face, from one ordinary modelling operation.
+    ///
+    /// `split(by:)` hands back the pieces separately; re-compounding them preserves the sharing,
+    /// because both came out of the same BOP and reference the same cut face. Returns nil rather
+    /// than recording an issue so callers can skip cleanly if the kernel stops sharing.
+    static func splitBoxCompound() -> Shape? {
+        guard let block = Shape.box(origin: .zero, width: 20, height: 10, depth: 10),
+              let plate = Shape.face(from: Wire.rectangle(width: 60, height: 60)!),
+              let upright = plate.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2),
+              let knife = upright.translated(by: SIMD3(10, 0, 0)),
+              let pieces = block.split(by: knife),
+              pieces.count == 2,
+              let compound = Shape.compound(pieces)
+        else { return nil }
+        return compound
+    }
+
+    /// #541's stated minimal reproduction: the same face handed to `compound` twice.
+    static func doubledFaceCompound() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let face = box.subShapes(ofType: .face).first
+        else { return nil }
+        return Shape.compound([face, face])
+    }
+
+    // MARK: - The three spellings agree
+
+    /// The headline: `faces()` handed out `Face.index` values `face(at:)` answered nil for.
+    @Test("faces() hands out only indices face(at:) can address")
+    func facesArrayIndicesAreAddressable() {
+        guard let duped = Self.doubledFaceCompound() else {
+            Issue.record("could not build the doubled-face compound")
+            return
+        }
+        #expect(duped.faces().count == duped.faceCount)
+        #expect(duped.faceCount == duped.subShapeCount(ofType: .face))
+        for face in duped.faces() {
+            #expect(duped.face(at: face.index) != nil,
+                    "faces() handed out index \(face.index), which face(at:) cannot address")
+        }
+    }
+
+    /// The half the issue did not report, and the more serious one: on a shape whose duplicate is
+    /// not the last occurrence, the two schemes named *different* faces at the same index.
+    @Test("faces() and face(at:) name the same face at every index")
+    func facesArrayAndIndexedAccessNameTheSameFace() {
+        guard let split = Self.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+        let array = split.faces()
+        #expect(array.count == split.faceCount)
+
+        for face in array {
+            guard let indexed = split.face(at: face.index) else {
+                Issue.record("face(at: \(face.index)) is nil for an index faces() handed out")
+                continue
+            }
+            guard let a = Shape.fromFace(face), let b = Shape.fromFace(indexed) else {
+                Issue.record("could not wrap face \(face.index) as a Shape")
+                continue
+            }
+            #expect(a.isSame(as: b),
+                    "faces()[\(face.index)] and face(at: \(face.index)) are different faces")
+        }
+    }
+
+    /// `subShape(type:index:)` is the generic spelling of the same enumeration; it must not be a
+    /// fourth answer.
+    @Test("The generic sub-shape spelling agrees with the face spellings")
+    func genericSpellingAgrees() {
+        guard let split = Self.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+        #expect(split.faceCount == split.subShapeCount(ofType: .face))
+        for i in 0..<split.faceCount {
+            guard let viaFace = split.face(at: i).flatMap(Shape.fromFace),
+                  let viaGeneric = split.subShape(type: .face, index: i) else {
+                Issue.record("index \(i) unreachable through one of the two spellings")
+                continue
+            }
+            #expect(viaFace.isSame(as: viaGeneric), "spellings disagree at index \(i)")
+        }
+    }
+
+    /// The control: on shapes that share no face — which is every shape the rest of the suite
+    /// builds — converging the enumerations moves nothing.
+    @Test("Ordinary shapes are unaffected")
+    func ordinaryShapesUnaffected() {
+        let fixtures: [(String, Shape)] = [
+            ("box", Shape.box(width: 10, height: 5, depth: 3)!),
+            ("cylinder", Shape.cylinder(radius: 3, height: 8)!),
+            ("sphere", Shape.sphere(radius: 5)!),
+        ]
+        for (name, shape) in fixtures {
+            #expect(shape.faces().count == shape.faceCount, "\(name) count")
+            for face in shape.faces() {
+                guard let indexed = shape.face(at: face.index),
+                      let a = Shape.fromFace(face), let b = Shape.fromFace(indexed) else {
+                    Issue.record("\(name): index \(face.index) unreachable")
+                    continue
+                }
+                #expect(a.isSame(as: b), "\(name): index \(face.index) moved")
+            }
+        }
+        #expect(Shape.box(width: 10, height: 10, depth: 10)!.faceCount == 6)
+    }
+
+    // MARK: - Face indices are 0-based everywhere
+
+    /// `adjacentFaces(forEdge:)` returned 1-based indices into the same map every other face
+    /// accessor reads 0-based. Feeding one straight to `face(at:)` named the wrong face, and the
+    /// face at index 0 could never be returned at all.
+    @Test("adjacentFaces(forEdge:) returns indices face(at:) can use")
+    func adjacentFaceIndicesAreZeroBased() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let edges = box.subShapes(ofType: .edge)
+        guard let edge = edges.first else {
+            Issue.record("box has no edges")
+            return
+        }
+        let indices = box.adjacentFaces(forEdge: edge)
+        #expect(indices.count == 2, "a box edge borders two faces")
+
+        for i in indices {
+            #expect(i >= 0 && i < box.faceCount, "index \(i) is outside 0..<\(box.faceCount)")
+            guard let face = box.face(at: i).flatMap(Shape.fromFace) else {
+                Issue.record("face(at: \(i)) is nil for an index adjacentFaces returned")
+                continue
+            }
+            // The named face must actually contain the edge it was named for.
+            let contains = face.subShapes(ofType: .edge).contains { $0.isSame(as: edge) }
+            #expect(contains, "face \(i) does not border the edge it was returned for")
+        }
+    }
+
+    /// The sibling accessor, same defect, same map.
+    @Test("adjacentEdges(forVertex:) returns indices edge(at:) can use")
+    func adjacentEdgeIndicesAreZeroBased() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let vertex = box.subShapes(ofType: .vertex).first else {
+            Issue.record("box has no vertices")
+            return
+        }
+        let indices = box.adjacentEdges(forVertex: vertex)
+        #expect(indices.count == 3, "a box corner meets three edges")
+
+        for i in indices {
+            #expect(i >= 0 && i < box.edgeCount, "index \(i) is outside 0..<\(box.edgeCount)")
+            guard let edge = box.subShape(type: .edge, index: i) else {
+                Issue.record("edge index \(i) unreachable")
+                continue
+            }
+            let contains = edge.subShapes(ofType: .vertex).contains { $0.isSame(as: vertex) }
+            #expect(contains, "edge \(i) does not meet the vertex it was returned for")
+        }
+    }
+
+    /// `splitByWireOnFace` took a 1-based index, so its accepted domain was `1...faceCount`
+    /// rather than `0..<faceCount`: `Face.index == 0` was rejected outright, and an index equal
+    /// to `faceCount` — past the end of every other spelling — was accepted.
+    ///
+    /// The domain is the discriminator here rather than the resulting geometry: `LocOpe_Spliter`
+    /// binds the wire across the whole shape, so the split itself succeeds at any index it
+    /// accepts.
+    @Test("splitByWireOnFace accepts 0..<faceCount, not 1...faceCount")
+    func splitByWireOnFaceIsZeroBased() {
+        guard let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 5),
+              let square = Wire.rectangle(width: 6, height: 6),
+              let flat = Shape.fromWire(square),
+              let wireShape = flat.translated(by: SIMD3(10, 10, 5))
+        else {
+            Issue.record("could not build the split fixture")
+            return
+        }
+        // Index 0 is a real face, not the rejected sentinel it used to be.
+        #expect(block.face(at: 0) != nil)
+        #expect(block.splitByWireOnFace(wireShape, faceIndex: 0) != nil,
+                "face 0 is unaddressable, so the index is still 1-based")
+        // One past the end must be rejected, as it is for face(at:).
+        #expect(block.face(at: block.faceCount) == nil)
+        #expect(block.splitByWireOnFace(wireShape, faceIndex: Int32(block.faceCount)) == nil,
+                "an index past the last face was accepted")
+        #expect(block.splitByWireOnFace(wireShape, faceIndex: -1) == nil)
+    }
+
+    /// `buildWires(faceIndex:)` used 0 as "all edges of the shape", which collides with the
+    /// 0-based index of the first face. The sentinel is now `-1`, so every face is addressable.
+    @Test("buildWires addresses face 0, and -1 still means every edge")
+    func buildWiresSentinelDoesNotCollideWithFaceZero() {
+        let box = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+
+        guard let allEdges = box.buildWires(faceIndex: -1) else {
+            Issue.record("buildWires(-1) failed")
+            return
+        }
+        guard let faceZero = box.buildWires(faceIndex: 0) else {
+            Issue.record("buildWires(0) failed — face 0 is not addressable")
+            return
+        }
+        // One face's edges cannot be the whole box's edges.
+        #expect(!allEdges.isEmpty)
+        #expect(!faceZero.isEmpty)
+        let allEdgeCount = allEdges.reduce(0) { $0 + $1.edgeCount }
+        let faceZeroEdgeCount = faceZero.reduce(0) { $0 + $1.edgeCount }
+        #expect(faceZeroEdgeCount < allEdgeCount,
+                "buildWires(0) returned the whole shape's edges, so 0 was still the sentinel")
+    }
+
+    // MARK: - The index consumers read the same enumeration
+
+    /// A sample of the entry points that walked their own explorer. Each is asked about the same
+    /// index and must answer about the face `face(at:)` names.
+    ///
+    /// Edge *counts* cannot discriminate here — every face of a split box is a four-edged planar
+    /// quad — so the check is edge *identity*: the edges `edgesInFace(at:)` reports must be the
+    /// very edges of the face at that index.
+    @Test("Index consumers answer about the face face(at:) names")
+    func indexConsumersAgreeWithFaceAt() {
+        guard let split = Self.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+        for i in 0..<split.faceCount {
+            guard let face = split.face(at: i).flatMap(Shape.fromFace) else {
+                Issue.record("face(at: \(i)) is nil below faceCount")
+                continue
+            }
+            let own = face.subShapes(ofType: .edge)
+            #expect(split.faceDomainEdgeCount(faceIndex: i) == own.count,
+                    "faceDomainEdgeCount disagrees about face \(i)")
+
+            let reported = split.edgesInFace(at: i)
+            #expect(reported.count == own.count, "edgesInFace(at: \(i)) has the wrong edge count")
+            for edge in reported {
+                guard let asShape = Shape.fromEdge(edge) else { continue }
+                #expect(own.contains { $0.isSame(as: asShape) },
+                        "edgesInFace(at: \(i)) returned an edge that is not on face \(i)")
+            }
+        }
+    }
+
+    // MARK: - Shape.contents is a different question, and stays one
+
+    /// `Shape.contents` is the third census, and #541 leaves it counting what it counts —
+    /// occurrences — rather than converging it. These pin the contract its docs now state, so
+    /// "a complexity metric, not an index bound" does not quietly become untrue.
+    @Test("Shape.contents counts occurrences, not addressable sub-shapes")
+    func contentsCountsOccurrences() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        // A box shares no face, so the two agree there.
+        #expect(box.contents.faces == box.faceCount)
+        // Every edge is visited once per adjacent face, so these must NOT agree.
+        #expect(box.edgeCount == 12)
+        #expect(box.contents.edges == 24)
+        #expect(box.vertexCount == 8)
+        #expect(box.contents.vertices == 48)
+    }
+
+    /// The third dedup rule: `nbSharedFaces` discards the location, so it collapses instances
+    /// that `faceCount` — which follows `IsSame` — keeps apart.
+    ///
+    /// The fixture has to be `moved(dx:dy:dz:)`, which only sets a `TopLoc_Location` and so
+    /// yields a true instance. `translated(by:)` rebuilds the shape through
+    /// `BRepBuilderAPI_Transform`, whose result shares no `TShape` with its input — all three
+    /// counts then read 12 and the distinction under test disappears.
+    @Test("contentsExtended's shared counts collapse instances that faceCount keeps")
+    func sharedCountsDiscardLocation() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let moved = box.moved(dx: 50, dy: 0, dz: 0),
+              let pair = Shape.compound([box, moved])
+        else {
+            Issue.record("could not build the instanced compound")
+            return
+        }
+        #expect(pair.faceCount == 12, "IsSame compares the location, so instances stay distinct")
+        #expect(pair.contents.faces == 12)
+        #expect(pair.contentsExtended().nbSharedFaces == 6,
+                "the shared counts strip the location, so the two placements collapse")
+    }
+
+    /// Past the end must be nil or empty on every spelling, not the last face or a crash.
+    @Test("Out-of-range face indices are rejected consistently")
+    func outOfRangeIndicesRejected() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let past = box.faceCount
+        #expect(box.face(at: past) == nil)
+        #expect(box.face(at: -1) == nil)
+        #expect(box.subShape(type: .face, index: past) == nil)
+        #expect(box.faceDomainEdgeCount(faceIndex: past) <= 0)
+        #expect(box.edgesInFace(at: past).isEmpty)
+    }
+}

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -705,7 +705,9 @@ struct SelectorSubShapeTests {
         if !results.isEmpty {
             #expect(results[0].shapeId == 1)
             #expect(results[0].subShapeType == .face)
-            #expect(results[0].subShapeIndex > 0)
+            // #541: 0-based, so the first face is 0 rather than the "whole shape" sentinel.
+            #expect(results[0].subShapeIndex >= 0)
+            #expect(box.face(at: Int(results[0].subShapeIndex)) != nil)
         }
     }
 
@@ -731,7 +733,9 @@ struct SelectorSubShapeTests {
         // Just verify no crash and correct sub-shape type if hit
         if !results.isEmpty {
             #expect(results[0].subShapeType == .edge)
-            #expect(results[0].subShapeIndex > 0)
+            // #541: 0-based, addressable against the shape the pick came from.
+            #expect(results[0].subShapeIndex >= 0)
+            #expect(box.subShape(type: .edge, index: Int(results[0].subShapeIndex)) != nil)
         }
     }
 
@@ -742,7 +746,7 @@ struct SelectorSubShapeTests {
         #expect(selector.pixelTolerance == 5)
     }
 
-    @Test("Shape mode pick returns shape sub-shape type with index 0")
+    @Test("Shape mode pick returns the whole-shape sentinel, not an index")
     func shapeModePick() {
         let box = Shape.box(width: 10, height: 10, depth: 10)!
         let cam = makeCamera()
@@ -757,8 +761,8 @@ struct SelectorSubShapeTests {
         )
 
         if !results.isEmpty {
-            // In shape mode, subShapeIndex should be 0 (whole shape)
-            #expect(results[0].subShapeIndex == 0)
+            // #541: the "whole shape" sentinel is -1, since 0 is now a real sub-shape index.
+            #expect(results[0].subShapeIndex == -1)
         }
     }
 }
@@ -1021,9 +1025,11 @@ struct ShapeContentsTests {
         #expect(c.solids == 1)
         #expect(c.shells == 1)
         #expect(c.faces == 6)
-        // ShapeAnalysis counts topology references, not unique shapes
-        #expect(c.edges > 0)
-        #expect(c.vertices > 0)
+        // #541: ShapeAnalysis_ShapeContents counts *occurrences*, not distinct sub-shapes, so
+        // these are not edgeCount/vertexCount and are not index bounds. A box's every edge is
+        // visited once per adjacent face. Pinned exactly in Issue541FaceIndexContractTests.
+        #expect(c.edges == 24)
+        #expect(c.vertices == 48)
     }
 
     @Test("Cylinder contents")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -139,6 +139,94 @@ points; the total stays 4295. The skip-an-out-of-range-index idiom survives outs
 functions; those are a separate family and are left for their own issue rather than widened into
 this one.
 
+#### Breaking: one meaning for a face index (#541)
+
+A face index in this API is now one thing: **a 0-based position in the enumeration
+`Shape.faces()`, `Shape.faceCount` and `Shape.face(at:)` all read** — `TopExp::MapShapes`, one
+entry per distinct face (`TopoDS_Shape::IsSame`). It used to be three things, and the three
+disagreed.
+
+`Shape.faces()` drove its own bare `TopExp_Explorer`, one entry per **occurrence** in the topology
+tree, and wrote the array position into `Face.index`. `faceCount` / `face(at:)` and most
+index-taking entry points read the deduplicated map. A handful read that map **1-based**.
+
+This is the case #502 (Pass 1b's sub-shape traversal fix) deliberately left, because face indices
+are an addressing token the API hands out and takes back, and auditing every consumer is not a
+one-line change.
+
+**The defect was worse than #541 reported.** Measured on the pinned kernel
+([`Scripts/repro/541-face-index-contract/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/541-face-index-contract)),
+fifteen fixtures walked both ways. The issue's reproduction is a hand-built
+`Shape.compound([face, face])`, but **one ordinary modelling operation produces the divergence**: a
+single `BRepAlgoAPI_Splitter` run cutting a box with a plane leaves two solids sharing the one cut
+face — 12 occurrences over 11 distinct faces. And because that duplicate is not the last
+occurrence, every index after it is shifted:
+
+| index | `faces()` | `face(at:)` |
+|---|---|---|
+| 0–9 | the same face | the same face |
+| **10** | **one face** | **a different face** |
+| 11 | a face | `nil` |
+
+So a caller selecting a face from `faces()` and handing it to `drafted(faces:)`,
+`shelled(openFaces:)` or `withoutFeatures(faces:)` — all map-backed — drafted, opened or deleted **a
+face it had not selected**, with no error. #541's reported symptom (`face(at:)` returning `nil` for
+an index `faces()` handed out) turns out to be the milder half.
+
+The control matters as much: across the ten fixtures that share no face — primitives, a hollow
+solid, both booleans, a compsolid, a sewn sheet, two placements of one body — the two enumerations
+are **identical at every index**, compared face-by-face rather than by count. Converging them moves
+nothing on any shape that does not share a sub-shape.
+
+**What changed.** `OCCTShapeGetFaces` reads `occtMapSubShapes`. The fourteen entry points that
+walked their own explorer to resolve an index (`OCCTShapeClassifyPoint2D`,
+`OCCTShapeFaceDomainEdgeCount`, `OCCTShapeBuildLoops`, `OCCTShapeDraftModification`, the three
+`BRepExtrema_Ext*F` extrema, the three `LocOpe` splitters, three `ShapeFix`/`BRepAlgo` healers and
+`OCCTBRepCheckSubShapeValid`) read `occtFaceAt` / `occtEdgeAt` / `occtSubShapeAt` instead. The
+1-based entry points and index outputs moved to 0-based. Two new helpers in
+`OCCTBridge_Internal.h` carry the contract in one place.
+
+**Six silent behaviour changes**, each recorded in [`SEMVER.md`](SEMVER.md) with its migration:
+
+```swift
+// faces() no longer double-counts a shared face
+let pieces = block.split(by: knife)!            // one splitter run
+let assembly = Shape.compound(pieces)!
+assembly.faces().count      // was 12, now 11 — and now equal to assembly.faceCount
+assembly.faces().allSatisfy { assembly.face(at: $0.index) != nil }   // was false, now true
+
+// adjacency indices are 0-based, so they index face(at:) directly
+for i in box.adjacentFaces(forEdge: edge) {
+    box.face(at: i)!        // was box.face(at: i - 1)
+}
+
+// the buildWires sentinel moved off 0, which is a real face
+box.buildWires(faceIndex: -1)   // every edge of the shape (was 0)
+box.buildWires(faceIndex: 0)    // face 0's edges (was rejected)
+```
+
+Also 0-based now: `splitByWireOnFace(_:faceIndex:)`, `offsetPerFace`'s `faceOffsets` keys (where an
+out-of-range key now fails the call instead of being silently skipped — the same silent-success
+failure #497 fixed for defeaturing), `EvolvingFilletEdge.edgeIndex` (the one fillet/chamfer entry
+point in the file that was 1-based), the `Poly_Connect` mesh family's `faceIndex` (their triangle
+and node indices stay `Poly_Triangulation`-native 1-based, as do the triangle indices they return),
+and `Selector.PickResult.subShapeIndex`, whose "whole shape" sentinel moved from `0` to `-1`.
+
+**`Shape.contents` was left counting what it counts, and is now documented as doing so.**
+`ShapeAnalysis_ShapeContents` is a fourth answer and a fifth: `NbFaces` tracks the explorer, while
+`contentsExtended()`'s `nbSharedFaces` strips the location before deduplicating, so unlike `IsSame`
+it also collapses two placements of one face. On a compound of a box with a `moved(dx:dy:dz:)` copy
+of itself the three read 12 / 12 / 6. It answers a different question — a complexity metric — and
+its docs now say so, with the warning that none of its numbers is an index bound.
+
+Regression tests in `Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift`; run against the
+unfixed bridge, seven of the ten failed and the three controls passed. Full suite green (4880
+tests); the only fallout was one existing test whose helper subtracted 1 from
+`adjacentFaces(forEdge:)`, and the selector tests that asserted the old sentinel.
+
+Not an upstream defect — both OCCT primitives behave exactly as documented, and the kernel is not
+involved in the base convention at all. No kernel patch, no xcframework rebuild.
+
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 
 `OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,7 +17,7 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with three recorded exceptions: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places, [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, and [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return without breaking the build.
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with four recorded exceptions: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places, [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return without breaking the build, and [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one, also without breaking the build.
 
 ## Rules
 
@@ -80,6 +80,26 @@ Both spellings still compile and still return a value; the deprecation attribute
 - The same forwarding fixes four cases where `TDocStd_PathParser` was wrong rather than differently formatted: an extension-less path parsed to an empty name *and* empty directory, a dotfile inside a directory returned `nil` from every accessor, a dot in a directory name was read as the file's extension, and non-ASCII paths came back mangled. Those four are ordinary PATCH-class fixes ("a method that returned `nil` when it shouldn't"); only the two formats above are a break.
 - A warning, not an error, is the weaker prompt, stated plainly here rather than claimed otherwise. It is what the API allows: Swift cannot overload on return *value*, only on type, so there is no spelling in which the old format survives alongside the new one.
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with before/after code, and to be named in the release notes.
+
+#### Recorded exception: Unreleased, one meaning for a face index (#541)
+
+**Six silent behaviour changes, none a compile error.** Every one moves an index toward the single contract now stated on `Shape.faceCount`: a sub-shape index into a shape is a 0-based position in the enumeration `faces()` / `faceCount` / `face(at:)` all read. Recorded here before the tag is cut:
+
+| Break | What a caller does |
+|---|---|
+| `Shape.faces()` returns one entry per *distinct* face, not per occurrence | Nothing on any shape that shares no face. On one that does — the result of a split, an imprint, a compound of a shape with itself — the array is shorter and the surplus `Face.index` values are gone. They named faces `face(at:)` could not address, and past the duplicate they named the *wrong* face |
+| `adjacentFaces(forEdge:)` / `adjacentEdges(forVertex:)` return 0-based indices | Drop the caller's own `- 1`. A caller who never subtracted was reading the neighbouring sub-shape |
+| `splitByWireOnFace(_:faceIndex:)` takes 0-based, so its domain is `0..<faceCount` not `1...faceCount` | Subtract 1 from a hand-written index |
+| `buildWires(faceIndex:)` takes 0-based; the "every edge" sentinel is any negative value, was `0` | Nothing if the default is used — it changed from `0` to `-1` and still means every edge. A caller passing `0` explicitly now gets face 0's edges |
+| `offsetPerFace(defaultOffset:faceOffsets:)` keys are 0-based, and an out-of-range key fails the call instead of being skipped | Subtract 1 from hand-written keys. A call that silently ignored a bad key now returns `nil` |
+| `EvolvingFilletEdge.edgeIndex` is 0-based; `Selector.PickResult.subShapeIndex` is 0-based with `-1`, not `0`, for the whole shape; `meshTriangleAdjacency`/`meshNodeTriangle`/`meshNodeTriangleCount` take a 0-based `faceIndex` (their triangle and node indices stay `Poly_Triangulation`-native 1-based, as do the triangle indices they return) | Subtract 1 from hand-written indices; compare `subShapeIndex` against `-1` rather than `0` |
+
+The exception was taken because:
+
+- **The disagreement is the bug, and it was not only cosmetic.** Measured on the pinned kernel (`Scripts/repro/541-face-index-contract/`): one `BRepAlgoAPI_Splitter` run cutting a box with a plane leaves 12 face occurrences over 11 distinct faces, and because the duplicate is not last, `faces()` and `face(at:)` named **different faces** from index 10 onwards. A caller selecting a face from `faces()` and passing it to `drafted(faces:)`, `shelled(openFaces:)` or `withoutFeatures(faces:)` — all map-backed — operated on a face it had not selected, with no error. Preserving any of the old conventions would have preserved that.
+- **There is no spelling in which both survive.** These are index *values*, not types or names, so Swift cannot overload on them and a deprecation attribute has nothing to attach to. The alternative to changing them is documenting that five different meanings of "face index" coexist and leaving callers to track which is which per method.
+- **On every shape that shares no sub-shape, nothing moves.** The probe checks the enumeration order face-by-face rather than by count across ten such fixtures: identical at every index. The `faces()` change is invisible to a caller whose shapes are primitives, booleans, sewn sheets or compsolids.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release notes.
 
 ### MINOR — `x.y.0`
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -946,28 +946,39 @@ public func vertexEdgeAdjacency() -> [Int]
 
 ### `adjacentFaces(forEdge:)`
 
-Get 1-based face indices adjacent to a specific edge within this shape.
+Get the 0-based indices of the faces adjacent to a specific edge within this shape.
 
 ```swift
 public func adjacentFaces(forEdge edge: Shape) -> [Int]
 ```
 
 - **Parameters:** `edge` — the edge shape to query adjacency for.
-- **Returns:** Array of 1-based face indices (up to 64).
+- **Returns:** Array of 0-based face indices (up to 64), addressable with `face(at:)`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let edge = box.subShapes(ofType: .edge).first!
+  for i in box.adjacentFaces(forEdge: edge) {
+      print(box.face(at: i)!.area())   // the two faces meeting at that edge
+  }
+  ```
+- **Note:** These were 1-based until #541, which named the face before the intended one and could
+  never name face 0. Drop any `- 1` a caller was applying.
 - **OCCT:** `TopExp` adjacency map via `OCCTEdgeAdjacentFaces`.
 
 ---
 
 ### `adjacentEdges(forVertex:)`
 
-Get 1-based edge indices adjacent to a specific vertex within this shape.
+Get the 0-based indices of the edges meeting a specific vertex within this shape.
 
 ```swift
 public func adjacentEdges(forVertex vertex: Shape) -> [Int]
 ```
 
 - **Parameters:** `vertex` — the vertex shape to query adjacency for.
-- **Returns:** Array of 1-based edge indices (up to 64).
+- **Returns:** Array of 0-based edge indices (up to 64), addressable with
+  `subShape(type: .edge, index:)`. These were 1-based until #541.
 - **OCCT:** `TopExp` adjacency map via `OCCTVertexAdjacentEdges`.
 - **Example:**
   ```swift
@@ -983,15 +994,17 @@ public func adjacentEdges(forVertex vertex: Shape) -> [Int]
 
 ### `meshTriangleAdjacency(faceIndex:triangleIndex:)`
 
-Get adjacent triangles for a triangle in a meshed face. Indices are 1-based; `0` means no neighbour.
+Get adjacent triangles for a triangle in a meshed face. Triangle indices are 1-based; `0` means
+no neighbour.
 
 ```swift
 public func meshTriangleAdjacency(faceIndex: Int, triangleIndex: Int) -> (Int, Int, Int)?
 ```
 
 - **Parameters:**
-  - `faceIndex` — 1-based face index.
-  - `triangleIndex` — 1-based triangle index within the face.
+  - `faceIndex` — 0-based face index, as `Face.index` and `face(at:)` use (#541).
+  - `triangleIndex` — 1-based triangle index within the face, as `Poly_Triangulation` numbers
+    them. The returned neighbour indices are 1-based for the same reason.
 - **Returns:** Tuple `(adj1, adj2, adj3)` of adjacent triangle indices, or `nil` if not found.
 - **OCCT:** `Poly_Connect` via `OCCTMeshTriangleAdjacency`.
 
@@ -1006,8 +1019,8 @@ public func meshNodeTriangle(faceIndex: Int, nodeIndex: Int) -> Int?
 ```
 
 - **Parameters:**
-  - `faceIndex` — 1-based face index.
-  - `nodeIndex` — 1-based node index.
+  - `faceIndex` — 0-based face index (#541).
+  - `nodeIndex` — 1-based node index, as `Poly_Triangulation` numbers them.
 - **Returns:** 1-based triangle index, or `nil` if not found.
 - **OCCT:** `Poly_Connect` via `OCCTMeshNodeTriangle`.
 
@@ -1022,8 +1035,8 @@ public func meshNodeTriangleCount(faceIndex: Int, nodeIndex: Int) -> Int
 ```
 
 - **Parameters:**
-  - `faceIndex` — 1-based face index.
-  - `nodeIndex` — 1-based node index.
+  - `faceIndex` — 0-based face index (#541).
+  - `nodeIndex` — 1-based node index, as `Poly_Triangulation` numbers them.
 - **Returns:** Number of triangles in the fan around this node.
 - **OCCT:** `Poly_Connect` via `OCCTMeshNodeTriangleCount`.
 

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -41,13 +41,19 @@ Inverse of `Shape.fromFace(_:)`. Use when you have a face-typed `Shape` (e.g. fr
 
 ### `index`
 
-Index of this face within the parent shape from which it was extracted (`-1` if standalone).
+This face's 0-based position in its parent shape's face enumeration (`-1` if standalone).
 
 ```swift
 public let index: Int
 ```
 
-Set automatically when a `Face` is created via `Shape.faces()`; faces constructed via `Face(_ shape:)` get index `-1`.
+Set automatically when a `Face` is created via `Shape.faces()` or `Shape.face(at:)`; faces
+constructed via `Face(_ shape:)` get index `-1`.
+
+This is the addressing token every face-index-taking method on `Shape` expects — `face(at:)`,
+`drafted(faces:…)`, `shelled(thickness:openFaces:)`, `withoutFeatures(faces:)`,
+`edgesInFace(at:)` and the rest. It is only meaningful against the shape it came from: an index
+taken from one shape and used on another names an unrelated face, or nothing at all. (#541)
 
 - **Example:**
   ```swift
@@ -570,15 +576,26 @@ Returns all face sub-shapes of the solid as typed `Face` objects.
 public func faces() -> [Face]
 ```
 
-Each returned `Face` carries its ordinal `index` within the traversal order. Returns an empty array if the shape has no faces or `TopExp_Explorer` fails.
+Each returned `Face` carries its position as ``Face.index``. This is the same enumeration
+`Shape.faceCount` counts and `Shape.face(at:)` indexes: one entry per **distinct** face, in
+`TopExp_Explorer` order. A face reachable from two parents — the wall shared by both halves of a
+split solid, say — appears once. Returns an empty array if the shape has no faces.
 
-- **OCCT:** `TopExp_Explorer(shape, TopAbs_FACE)` — iterates all `TopoDS_Face` sub-shapes.
+- **OCCT:** `TopExp::MapShapes(shape, TopAbs_FACE, …)` via the bridge's shared sub-shape
+  enumeration.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!
   let faces = box.faces()
   #expect(faces.count == 6)
+  #expect(faces.count == box.faceCount)
+  // Every index handed out here is addressable, and names the same face.
+  #expect(faces.allSatisfy { box.face(at: $0.index) != nil })
   ```
+- **Note:** Until #541 this was a separate walk yielding one entry per *occurrence* in the topology
+  tree, so on a shape with a shared face it was longer than `faceCount`, its surplus indices named
+  faces `face(at:)` could not address, and past the duplicate it named a *different* face than
+  every index-taking method resolved.
 
 ---
 

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -392,13 +392,21 @@ Total number of face sub-shapes in the shape.
 public var faceCount: Int { get }
 ```
 
-- **Returns:** Count of `TopoDS_Face` sub-shapes; 0 on error or if the shape has no faces.
+This is the same enumeration `Shape.faces()` walks and `Shape.face(at:)` indexes: one entry per
+**distinct** face (`TopoDS_Shape::IsSame` — same TShape and location, orientation ignored), in
+`TopExp_Explorer` order, addressed from 0. A face reachable from two parents counts once.
+
+- **Returns:** Count of distinct `TopoDS_Face` sub-shapes; 0 on error or if the shape has none.
 - **OCCT:** `TopExp::MapShapes(shape, TopAbs_FACE, faceMap)` → `faceMap.Extent()`.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!
-  print(box.faceCount)  // 6
+  print(box.faceCount)                     // 6
+  print(box.faces().count)                 // 6, the same enumeration
+  print(box.subShapeCount(ofType: .face))  // 6, the generic spelling
   ```
+- **Note:** `contents.faces` is a different number — it counts *occurrences* and is not an index
+  bound. See `Shape.contents`. (#541)
 
 ---
 
@@ -410,9 +418,12 @@ Returns the face at a 0-based index within the shape's indexed face map.
 public func face(at index: Int) -> Face?
 ```
 
-The index corresponds to `TopTools_IndexedMapOfShape` ordering, matching the `faceIndex` field returned by `RayHit`.
+The index is the one `Face.index` carries, the `faceIndex` field `RayHit` returns, and the one
+every face-index-taking method on `Shape` expects. It is meaningful only against the shape it came
+from: an index taken from one shape and used on another names an unrelated face, or nothing at all.
+(#541)
 
-- **Parameters:** `index` — 0-based face index.
+- **Parameters:** `index` — 0-based face index, in `0..<faceCount`.
 - **Returns:** `Face` at the given index, or `nil` if `index` is out of bounds or the shape is null.
 - **OCCT:** `TopExp::MapShapes` + `TopoDS::Face(faceMap(index + 1))` (OCCT maps are 1-based internally).
 - **Example:**
@@ -512,7 +523,10 @@ public struct PickResult: Sendable {
 - `depth` — distance from the camera to the hit.
 - `point` — 3D world-space point where the pick ray intersected the sensitive primitive.
 - `subShapeType` — topology type of the sub-shape hit (e.g. `.face`, `.edge`).
-- `subShapeIndex` — 1-based index of the hit sub-shape within its parent shape; 0 when the whole shape is selected (mode 0).
+- `subShapeIndex` — 0-based index of the hit sub-shape within its parent shape, addressable with
+  `face(at:)` or `subShape(type:index:)`; `-1` when the whole shape is selected (mode 0). This was
+  1-based with `0` as that sentinel until #541, which named the sub-shape before the one hit and
+  made the sentinel indistinguishable from a hit on sub-shape 0.
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1289,14 +1289,23 @@ Unlike the basic `scaled(by:)` transform, this propagates tolerance updates corr
 
 ### `buildWires(faceIndex:)`
 
-Build wires from the edges of a face.
+Build wires from the edges of one face, or of the whole shape.
 
 ```swift
-public func buildWires(faceIndex: Int32 = 0) -> [Shape]?
+public func buildWires(faceIndex: Int32 = -1) -> [Shape]?
 ```
 
-- **Parameters:** `faceIndex` — 1-based face index (`0` = all edges).
+- **Parameters:** `faceIndex` — 0-based face index, as `Face.index` and `face(at:)` use. Any
+  negative value means every edge of the shape.
 - **Returns:** Array of wire shapes, or `nil` on failure.
+- **Example:**
+  ```swift
+  let box = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
+  let allEdges = box.buildWires(faceIndex: -1)!   // every edge of the box
+  let firstFace = box.buildWires(faceIndex: 0)!   // just face 0's edges
+  ```
+- **Note:** #541 moved this off 1-based and moved the "all edges" sentinel from `0`, which
+  collided with the first face's own index and left that face unaddressable.
 - **OCCT:** `LocOpe_BuildWires` via `OCCTLocOpeBuildWires`.
 
 ---
@@ -1309,7 +1318,9 @@ Split a face of this shape by projecting a wire onto it.
 public func splitByWireOnFace(_ wire: Shape, faceIndex: Int32) -> Shape?
 ```
 
-- **Parameters:** `wire` — the splitting wire shape; `faceIndex` — 1-based index of the face to split.
+- **Parameters:** `wire` — the splitting wire shape; `faceIndex` — 0-based index of the face to
+  split, as `Face.index` and `face(at:)` use. It was 1-based until #541, so face 0 could not be
+  named at all and the accepted domain was `1...faceCount` rather than `0..<faceCount`.
 - **Returns:** Modified shape with the face split, or `nil` on failure.
 - **OCCT:** `LocOpe_WiresOnShape` + `LocOpe_Spliter` via `OCCTLocOpeSplitByWireOnFace`.
 - **Note:** Only the **first** wire of `wire` is used. Passing a shape that holds several wires

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -903,21 +903,33 @@ public struct ShapeContents: Sendable {
 
 ### `contents`
 
-Get a census of sub-shape counts in this shape.
+A census of sub-shape **occurrences** in this shape.
 
 ```swift
 public var contents: ShapeContents { get }
 ```
 
-Reports topology complexity metrics: counts of solids, shells, faces, wires, edges, vertices, and free (unconnected) elements.
+A complexity metric, not the addressable sub-shape enumeration. It counts one entry per visit in
+the topology tree, so a sub-shape reachable from two parents is counted twice, and every edge of a
+box is counted once per adjacent face.
 
-- **Returns:** A `ShapeContents` struct populated from `BRepTools` traversal.
-- **OCCT:** `BRepTools` iteration (via `OCCTShapeGetContents`).
+- **Returns:** A `ShapeContents` struct: counts of solids, shells, faces, wires, edges, vertices,
+  and free (unconnected) elements.
+- **OCCT:** `ShapeAnalysis_ShapeContents` (via `OCCTShapeGetContents`).
 - **Example:**
   ```swift
-  let c = solid.contents
-  print("faces: \(c.faces), freeEdges: \(c.freeEdges)")
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.edgeCount)        // 12 — the distinct edges, and the addressable ones
+  print(box.contents.edges)   // 24 — one per (face, edge) visit
+  print(box.faceCount)        // 6
+  print(box.contents.faces)   // 6 — a box shares no face, so these agree
   ```
+- **Note:** **None of these numbers is an index bound.** `0..<contents.faces` overruns `face(at:)`
+  on any shape with a shared face; use `faceCount`. There is a third count again in
+  `contentsExtended()`: its `nbSharedFaces` deduplicates with the location *discarded*, so unlike
+  `faceCount` — which follows `TopoDS_Shape::IsSame` and keeps placements apart — it also collapses
+  two instances of one body. Measured on a compound of a box with a `moved(dx:dy:dz:)` copy of
+  itself: `faceCount` 12, `contents.faces` 12, `nbSharedFaces` 6. (#541)
 
 ---
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -309,7 +309,8 @@ public func offsetPerFace(defaultOffset: Double,
 
 - **Parameters:**
   - `defaultOffset` — Default offset distance applied to all faces not listed in `faceOffsets`.
-  - `faceOffsets` — Dictionary mapping 1-based face indices to custom offset distances.
+  - `faceOffsets` — Dictionary mapping 0-based face indices — as `Face.index` and `face(at:)` use —
+    to custom offset distances. A key outside `0..<faceCount` fails the call.
   - `tolerance` — Offset tolerance.
   - `joinType` — Join strategy for offset gaps (`.arc` or `.intersection`).
 - **Returns:** Offset shape, or `nil` on failure.
@@ -317,10 +318,13 @@ public func offsetPerFace(defaultOffset: Double,
 - **Example:**
   ```swift
   if let result = solid.offsetPerFace(defaultOffset: 1.0,
-                                       faceOffsets: [1: 2.0, 3: 0.5]) {
+                                       faceOffsets: [0: 2.0, 2: 0.5]) {
       print(result.isValid)
   }
   ```
+- **Note:** #541 moved the keys off 1-based, and made an out-of-range key fail the call. It used to
+  be skipped, which returned a shape offset by the default everywhere and looked exactly like a
+  successful run — the same silent success #497 fixed for defeaturing.
 
 ---
 


### PR DESCRIPTION
Closes #541

A face index in this API is now one thing: **a 0-based position in the enumeration `Shape.faces()`, `Shape.faceCount` and `Shape.face(at:)` all read** — `TopExp::MapShapes`, one entry per distinct face. It used to be three things, and the three disagreed.

## What the probe found that the issue did not

The issue's reproduction is a hand-built `Shape.compound([face, face])`, which reads as a curiosity. It isn't one. [`Scripts/repro/541-face-index-contract/`](../tree/fix/541-faces-enumeration/Scripts/repro/541-face-index-contract) walks fifteen fixtures both ways, and **one ordinary modelling operation produces the divergence**: a single `BRepAlgoAPI_Splitter` run cutting a box with a plane leaves two solids sharing the one cut face — 12 occurrences over 11 distinct faces.

And because that duplicate is *not* the last occurrence, every index after it shifts:

| index | `faces()` | `face(at:)` |
|---|---|---|
| 0–9 | the same face | the same face |
| **10** | **one face** | **a different face** |
| 11 | a face | `nil` |

So a caller selecting a face from `faces()` and handing it to `drafted(faces:)`, `shelled(openFaces:)` or `withoutFeatures(faces:)` — all map-backed — drafted, opened or deleted **a face it had not selected**, with no error. #541's reported symptom (`face(at:)` returning `nil` for an index `faces()` handed out) turns out to be the milder half.

The control matters as much: across the ten fixtures that share no face — primitives, a hollow solid, both booleans, a compsolid, a sewn sheet, two placements of one body — the two enumerations are **identical at every index**, compared face-by-face rather than by count. Converging them moves nothing on any shape that does not share a sub-shape. Note also the compsolid built from two *separately* cut halves does **not** diverge: sharing comes from one operation producing both parents, not from the assembly.

## The census was wider than the issue's two sites

Beyond `OCCTShapeGetFaces`, three groups:

- **Fourteen entry points walked their own explorer** to resolve an index, so they matched `faces()` and not `face(at:)`: `OCCTShapeClassifyPoint2D`, `OCCTShapeFaceDomainEdgeCount`, `OCCTShapeBuildLoops`, `OCCTShapeDraftModification`, the three `BRepExtrema_Ext*F` extrema, the three `LocOpe` splitters, three `ShapeFix`/`BRepAlgo` healers, and `OCCTBRepCheckSubShapeValid`.
- **A handful read the deduplicated map 1-based**, so a `Face.index` addressed the face *before* the one it named and could never name the last face at all.
- **Two index *outputs* were 1-based too** — `OCCTEdgeAdjacentFaces` / `OCCTVertexAdjacentEdges` — plus `Selector.PickResult.subShapeIndex`, whose `0` doubled as the "whole shape" sentinel.

Most of the map-backed sites turned out to be correctly 0-based already (they do `+ 1` before the range check); `OCCTShapeFilletEvolving` was the one fillet/chamfer entry point in its file that wasn't.

## What changed

`OCCTShapeGetFaces` reads `occtMapSubShapes`. The fourteen explorer walks read new `occtFaceAt` / `occtEdgeAt` helpers beside `occtSubShapeAt` in `OCCTBridge_Internal.h`, which carry the contract in one place. The 1-based inputs and outputs moved to 0-based.

**Six silent behaviour changes**, each with a migration in [`docs/SEMVER.md`](../blob/fix/541-faces-enumeration/docs/SEMVER.md) as a recorded exception:

```swift
// faces() no longer double-counts a shared face
let assembly = Shape.compound(block.split(by: knife)!)!
assembly.faces().count      // was 12, now 11 — and now equal to assembly.faceCount
assembly.faces().allSatisfy { assembly.face(at: $0.index) != nil }   // was false, now true

// adjacency indices are 0-based, so they index face(at:) directly
for i in box.adjacentFaces(forEdge: edge) { box.face(at: i)! }   // was box.face(at: i - 1)

// the buildWires sentinel moved off 0, which is a real face
box.buildWires(faceIndex: -1)   // every edge of the shape (was 0)
box.buildWires(faceIndex: 0)    // face 0's edges (was rejected outright)
```

Also 0-based: `splitByWireOnFace`, `offsetPerFace`'s `faceOffsets` keys (where an out-of-range key now fails the call instead of being silently skipped — the same silent success #497 fixed for defeaturing), `EvolvingFilletEdge.edgeIndex`, the `Poly_Connect` mesh family's `faceIndex` (their triangle and node indices stay `Poly_Triangulation`-native 1-based, as do the triangle indices they *return*), and `Selector.PickResult.subShapeIndex`, whose whole-shape sentinel moved from `0` to `-1`.

## `Shape.contents`, the issue's second scope item

Left counting what it counts, and now documented as doing so. `ShapeAnalysis_ShapeContents` is a fourth answer *and* a fifth: `NbFaces` tracks the explorer, while `contentsExtended()`'s `nbSharedFaces` strips the location before deduplicating (`ShapeAnalysis_ShapeContents.cxx:167`), so unlike `IsSame` it also collapses two placements of one face. On a compound of a box with a `moved(dx:dy:dz:)` copy of itself the three read 12 / 12 / 6. It answers a different question — a complexity metric — so its docs now say so, with the warning that **none of its numbers is an index bound**. Both properties are pinned by tests rather than left as prose.

## Verification

- New tests in `Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift`. Run against the unfixed bridge first: **seven of the ten failed, and the three controls passed** — including the split-box case asserting `faces()[10]` and `face(at: 10)` are the same face.
- Full suite green: **4882 tests, 1350 suites**. The only fallout was one existing test helper that subtracted 1 from `adjacentFaces(forEdge:)` (it compensated for the old convention as its own input precondition), and the selector tests asserting the old `0` sentinel — both updated.
- Not a concurrency change, so no TSan gate.

## Not in scope, worth a follow-up

`OCCTShapeHistoryFromChamferEdges` silently `continue`s past an out-of-range edge index rather than failing — the same silent-success shape as `offsetPerFace`'s old behaviour and #497's defeaturing bug. Its *base* is already correct, so it is untouched here rather than smuggled in.

## Upstream

Nothing to file. Both OCCT primitives behave exactly as documented, and the kernel is not involved in the base convention at all. No kernel patch, no xcframework rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
