### PR TITLE
fix(#556): guard the geometry handle at the 60 bridge functions that pass it to OCCT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ Opaque handle types (`OCCTShapeRef`, `OCCTWireRef`, `OCCTFaceRef`, `OCCTEdgeRef`
 3. **Swift wrapper** (appropriate `.swift` file): Add public method/static factory
 4. **Test**: Add `@Suite`/`@Test` to the matching `Tests/OCCT<Domain>Tests/` target (see "Test Layout")
 
+If the new function takes an `OCCTCurve3DRef` / `OCCTCurve2DRef` / `OCCTSurfaceRef`, guard the
+handle as well as the pointer: `if (!x || x->curve.IsNull()) return <the fallback the catch below
+uses>;`. Checking only the pointer says nothing about the handle, and 24 of the 35 OCCT entry
+points this bridge passes such a handle into dereference it unconditionally, which is an
+uncatchable signal, not something `catch (...)` can absorb (#478, #556). Run
+`python3 Scripts/check-null-handle-guards.py` to verify; it exits 1 on any unguarded site.
+
 ## Naming Conventions
 
 - Bridge functions: `OCCTShape...`, `OCCTWire...`, `OCCTFace...`, `OCCTEdge...`

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Verify that every bridge function guards the geometry Handle, not just the wrapper pointer.
+
+`OCCTCurve3DRef`, `OCCTCurve2DRef` and `OCCTSurfaceRef` are pointers to a wrapper struct whose
+only field is an OCCT `Handle`. Checking the pointer says nothing about the handle, and a null
+handle reaching OCCT is usually an unconditional dereference: `Scripts/repro/556-null-handle-guard-sweep`
+measures 24 of the 35 distinct OCCT entry points this bridge passes such a handle into as an
+uncatchable OS signal, which the enclosing `catch (...)` cannot intercept. So the opener has to
+test both:
+
+    if (!x || x->curve.IsNull()) return <the same fallback the catch below uses>;
+
+#478 fixed the 14 functions that dereferenced the handle themselves; #556 fixed the 60 that pass
+it to an OCCT API which dereferences it internally. This script is what keeps that at zero: it is
+the same walk that produced both lists, so a new function that checks only the pointer is reported
+the moment it is added.
+
+A `DownCast(x->curve)` is NOT a use: down-casting a null handle returns a null handle, and every
+such site in this bridge checks the cast result. Without that exclusion the walk reports several
+hundred false positives.
+
+Usage (from the repo root):
+
+    python3 Scripts/check-null-handle-guards.py          # report unguarded sites
+    python3 Scripts/check-null-handle-guards.py --quiet  # exit status only
+
+Exit status is 1 when any site is unguarded, so this can gate a commit.
+"""
+import glob
+import os
+import re
+import sys
+
+SRC_DIR = 'Sources/OCCTBridge/src'
+
+# wrapper parameter type -> the handle field it carries
+WRAPPERS = {
+    'OCCTCurve3DRef': 'curve',
+    'OCCTCurve2DRef': 'curve',
+    'OCCTSurfaceRef': 'surface',
+}
+
+# Sites deliberately left unguarded, with the reason. Keep this list empty-by-default: an entry
+# is a promise that every caller checks both the pointer and the handle.
+ALLOWED = {
+    # Returns Geom2dGcc_QualifiedCurve by value, so it has no null-safe fallback to return.
+    # All of its callers reject a null pointer and a null handle before calling.
+    ('OCCTBridge_Geom2d.mm', 'makeQualifiedCurve'),
+}
+
+FUNC = re.compile(r'^(?:static\s+)?[A-Za-z_][\w:<>,\s\*&]*?\b(\w+)\s*\(([^;{]*?)\)\s*\{', re.M | re.S)
+NOT_A_FUNCTION = {'if', 'for', 'while', 'switch', 'catch', 'return'}
+
+
+def strip_comments(text):
+    """Blank out comments and preserve every newline, so line numbers still line up."""
+    out, i, n = [], 0, len(text)
+    while i < n:
+        if text.startswith('//', i):
+            j = text.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif text.startswith('/*', i):
+            j = text.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append(''.join(c if c == '\n' else ' ' for c in text[i:j]))
+            i = j
+        elif text[i] == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == '\\':
+                    j += 1
+                j += 1
+            out.append(text[i:j + 1])
+            i = j + 1
+        else:
+            out.append(text[i])
+            i += 1
+    return ''.join(out)
+
+
+def functions(text):
+    """(name, params, body start, body end) for every function definition in the file."""
+    for m in FUNC.finditer(text):
+        name, params = m.group(1), m.group(2)
+        if name in NOT_A_FUNCTION:
+            continue
+        start = i = m.end() - 1
+        depth = 0
+        while i < len(text):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        yield name, params, start, i
+
+
+def wrapper_params(params):
+    """(name, handle field, whether it is an array) for each wrapper-typed parameter."""
+    out = []
+    for p in params.split(','):
+        p = p.strip()
+        for wrapper, field in WRAPPERS.items():
+            if not re.search(r'\b' + wrapper + r'\b', p):
+                continue
+            m = re.search(r'(\w+)\s*(\[\s*\])?\s*$', p)
+            if m and m.group(1) not in WRAPPERS:
+                tail = p[p.index(wrapper) + len(wrapper):]
+                out.append((m.group(1), field, '*' in tail or bool(m.group(2))))
+            break
+    return out
+
+
+def unguarded_sites():
+    """Every (file, line, function, parameter) whose handle reaches OCCT without an IsNull test."""
+    found = []
+    for path in sorted(glob.glob(os.path.join(SRC_DIR, '*.mm'))) + \
+            sorted(glob.glob(os.path.join(SRC_DIR, '*.h'))):
+        raw = open(path).read()
+        text = strip_comments(raw)
+        for name, params, body_start, body_end in functions(text):
+            body = text[body_start:body_end + 1]
+            for param, field, is_array in wrapper_params(params):
+                if is_array:
+                    use = re.compile(r'\b' + re.escape(param) + r'\s*\[[^\]]*\]\s*->\s*' + field + r'\b')
+                else:
+                    use = re.compile(r'\b' + re.escape(param) + r'\s*->\s*' + field + r'\b')
+                first_real, guarded = None, False
+                for u in use.finditer(body):
+                    after = body[u.end():u.end() + 40]
+                    before = body[max(0, u.start() - 80):u.start()]
+                    if re.match(r'\s*\.\s*IsNull\s*\(', after):
+                        guarded = True          # this occurrence IS the guard
+                        continue
+                    if re.search(r'DownCast\s*\(\s*$', before):
+                        continue                # null-safe: DownCast(null) returns null
+                    first_real = u
+                    break
+                if first_real is None or guarded:
+                    continue
+                if (os.path.basename(path), name) in ALLOWED:
+                    continue
+                line = text.count('\n', 0, body_start + first_real.start()) + 1
+                found.append((os.path.basename(path), line, name, param, field,
+                              raw.splitlines()[line - 1].strip()))
+    return found
+
+
+def main():
+    quiet = '--quiet' in sys.argv
+    sites = unguarded_sites()
+    if not sites:
+        if not quiet:
+            print('All bridge functions guard the geometry handle as well as the wrapper pointer.')
+        return 0
+    if not quiet:
+        print(f'{len(sites)} (function, argument) pair(s) reach OCCT with an unchecked handle:\n')
+        for f, line, func, param, field, src in sites:
+            print(f'  {f}:{line}  {func}({param})')
+            print(f'      {src}')
+            print(f'      want: if (!{param} || {param}->{field}.IsNull()) return <fallback>;')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Scripts/repro/556-null-handle-guard-sweep/README.md
+++ b/Scripts/repro/556-null-handle-guard-sweep/README.md
@@ -1,0 +1,94 @@
+# OCCTSwift#556 probe: what a null geometry `Handle` actually does at each OCCT entry point
+
+Ground truth for the defect class behind #556, against the pinned OCCT 8.0.0p1 kernel. It exists
+because #556's stated mechanism needed checking before 60 functions were edited on the strength of
+it, and the check changed the story in both directions: the issue's headline example is the mildest
+case in the whole set, and the class is far more dangerous than "latent" elsewhere.
+
+No fixture files needed: every case is a default-constructed (null) `Handle`.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/556-null-handle-guard-sweep/repro_556.mm -o /tmp/occt_556
+/tmp/occt_556
+```
+
+Each probe runs in a forked child, so a crash is reported rather than ending the run. A child that
+exits normally, or via `Standard_Failure`, is a case the bridge's own `catch (...)` already coped
+with before the fix. A child killed by a signal is a case it could not.
+
+## What it measures
+
+35 distinct OCCT entry points: every API that the 60 bridge functions #556 guards pass an
+`OCCTCurve3DRef` / `OCCTCurve2DRef` / `OCCTSurfaceRef`'s handle into.
+
+**24 of 35 crash with an uncatchable signal. 5 raise a catchable `Standard_Failure`. 6 return.**
+
+### The issue's headline example is one of the mild ones
+
+#556 leads with `Geom2dAdaptor_Curve`, and argues from
+`ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx:272`:
+
+> `Geom2dAdaptor_Curve::load` [...] has **no** null precondition at all: it goes straight to
+> `C->DynamicType()`. So this is not a `Standard_NullObject` raise that `No_Exception` compiled
+> out, it is an unconditional dereference in every build configuration.
+
+The premise is right and the conclusion is wrong, because lowercase `load` is private. Every caller
+(including both handle-taking constructors) reaches it through the public `Load`, which is
+header-inline at `Geom2dAdaptor_Curve.hxx:108-131` and opens with an unconditional,
+never-`No_Exception`-guarded check:
+
+```cpp
+void Load(const occ::handle<Geom2d_Curve>& theCurve)
+{
+  if (theCurve.IsNull())
+  {
+    throw Standard_NullObject();
+  }
+  load(theCurve, theCurve->FirstParameter(), theCurve->LastParameter());
+}
+```
+
+Measured: `Geom2dAdaptor_Curve(null)` and `Geom2dAdaptor_Curve(null, 0, 1)` both raise a catchable
+`Standard_Failure`, which every bridge caller's existing `catch (...)` already absorbed. Same for
+`GeomAdaptor_Curve`, `GCPnts_AbscissaPoint` and `GeomAPI_ExtremaSurfaceSurface`.
+
+### The cases that do crash
+
+| OCCT call | reached from | null handle |
+|---|---|---|
+| `new Geom_TrimmedCurve` | `OCCTCurve3DTrimmed` | SIGSEGV |
+| `new Geom_OffsetCurve` | `OCCTCurve3DCreateOffset` | SIGSEGV |
+| `new Geom_RectangularTrimmedSurface` | `OCCTSurfaceCreate{RectangularTrimmed,TrimmedInU,TrimmedInV}` | SIGSEGV |
+| `ShapeAnalysis_Curve::{Project,ValidateRange,GetSamplePoints,IsClosed,IsPeriodic}` | 5 `OCCTCurve3D*` fns | SIGSEGV |
+| `ShapeConstruct_Curve::{ConvertToBSpline,AdjustCurve,AdjustCurve2d}` | 4 `OCCTShapeConstruct*` fns | SIGSEGV |
+| `ShapeCustom_Curve2d::ConvertToLine2d` | `OCCTCurve2DConvertToLine` | SIGSEGV |
+| `Bisector_BisecAna::Perform` | both `OCCTBisectorBisecAna*` fns | SIGSEGV |
+| `BRepLib_MakeEdge2d` | `OCCTMakeEdge2dCurve{,Range}` | SIGSEGV |
+| `GeomConvert::CurveToBSplineCurve` | `OCCTSurfaceFillBSpline{2,4}Curves` | SIGSEGV |
+| `ShapeAnalysis_Surface::ValueOfUV` | 11 `OCCTSurface*` fns | SIGSEGV |
+| `GeomFill_Gordon::Init` | `OCCTGeomFillGordon{,Report}` | SIGSEGV |
+| `BRepAlgoAPI_Section` ctor / `Init1` | `OCCTShapeSectionWithSurface`, `OCCTSectionBuilderInit{1,2}Surface` | SIGSEGV |
+| `Geom2d_Curve->D0`, `Handle->FirstParameter` | `OCCTCurve2DPointAt`, `OCCTCurve3DSplitAt`, both `OCCTConcatenateCurves*` | SIGSEGV |
+
+`ShapeAnalysis_Surface` is worth singling out: **constructing** it from a null handle returns
+normally, and the crash lands at the first `ValueOfUV`/`HasSingularities` call. A probe that only
+constructed the object would have reported this whole 11-function family as safe.
+
+Per CLAUDE.md, `OCC_CATCH_SIGNALS` is inert in this build, so none of the 24 is recoverable
+in-process. The enclosing `catch (...)` is not a fallback for any of them.
+
+## What this does not show
+
+It does not show that any of these is reachable from Swift today. #478 classified all 228 sites
+that bind a handle into one of the three wrapper types and found none that can produce a wrapper
+carrying a null handle, so the class stays latent. What the measurement changes is the cost of
+weakening that invariant later: for 24 of these 35 entry points the first symptom is a SIGSEGV
+with no diagnostic trail, not a caught exception and a nil return.
+
+`Scripts/check-null-handle-guards.py` is what keeps the guard uniform from here.

--- a/Scripts/repro/556-null-handle-guard-sweep/repro_556.mm
+++ b/Scripts/repro/556-null-handle-guard-sweep/repro_556.mm
@@ -1,0 +1,207 @@
+// #556 ground truth, full sweep: for every distinct OCCT entry point the 60 guarded bridge
+// functions pass a geometry Handle into, does a null handle raise a catchable Standard_Failure
+// (which the bridge's existing catch(...) already absorbs) or an uncatchable OS signal?
+// Each probe runs in a forked child.
+#include <BRepAlgoAPI_Section.hxx>
+#include <BRepLib_MakeEdge2d.hxx>
+#include <BRep_Tool.hxx>
+#include <Bisector_BisecAna.hxx>
+#include <Draft_FaceInfo.hxx>
+#include <ExtremaPC_Curve.hxx>
+#include <GCPnts_AbscissaPoint.hxx>
+#include <GCPnts_TangentialDeflection.hxx>
+#include <GeomAPI_ExtremaSurfaceSurface.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <GeomConvert.hxx>
+#include <GeomConvert_CompCurveToBSplineCurve.hxx>
+#include <GeomFill_Gordon.hxx>
+#include <Geom_BoundedCurve.hxx>
+#include <Geom_OffsetCurve.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <Geom2dConvert_CompCurveToBSplineCurve.hxx>
+#include <Geom2d_BoundedCurve.hxx>
+#include <Geom2d_CartesianPoint.hxx>
+#include <Geom2d_TrimmedCurve.hxx>
+#include <ShapeAnalysis_Curve.hxx>
+#include <ShapeAnalysis_Surface.hxx>
+#include <ShapeConstruct_Curve.hxx>
+#include <ShapeConstruct_ProjectCurveOnSurface.hxx>
+#include <ShapeCustom_Curve.hxx>
+#include <ShapeCustom_Curve2d.hxx>
+#include <ShapeCustom_Surface.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Shape.hxx>
+#include <NCollection_Array1.hxx>
+#include <NCollection_Sequence.hxx>
+#include <Standard_Failure.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+
+#include <cstdio>
+#include <cstring>
+#include <functional>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int uncatchable = 0, catchable = 0, benign = 0;
+
+static void probe(const char* bridgeFn, const char* call, const std::function<void()>& body) {
+    fflush(stdout);
+    pid_t pid = fork();
+    if (pid == 0) {
+        try { body(); }
+        catch (Standard_Failure const&) { _exit(3); }
+        catch (...) { _exit(4); }
+        _exit(0);
+    }
+    int st = 0;
+    waitpid(pid, &st, 0);
+    const char* verdict;
+    bool crash = false;
+    if (WIFSIGNALED(st)) { verdict = "SIGNAL (uncatchable)"; crash = true; }
+    else if (WEXITSTATUS(st) == 3) { verdict = "Standard_Failure"; catchable++; }
+    else if (WEXITSTATUS(st) == 4) { verdict = "other exception"; catchable++; }
+    else { verdict = "returned"; benign++; }
+    if (crash) uncatchable++;
+    printf("  %-22s %-42s %s\n", bridgeFn, call, verdict);
+}
+
+int main() {
+    Handle(Geom_Curve) nc;
+    Handle(Geom2d_Curve) nc2;
+    Handle(Geom_Surface) ns;
+
+    printf("#556: null geometry Handle at every OCCT entry point the guarded bridge fns call\n");
+    printf("(OCCT 8.0.0p1. 'Standard_Failure'/'returned' = the pre-fix catch(...) already coped.)\n\n");
+    printf("  %-22s %-42s %s\n", "bridge function", "OCCT call", "result");
+    printf("  %-22s %-42s %s\n", "----------------------", "------------------------------------------", "------");
+
+    probe("Curve3DProjectPoint", "ShapeAnalysis_Curve::Project", [&] {
+        ShapeAnalysis_Curve s; gp_Pnt p; double t;
+        (void)s.Project(nc, gp_Pnt(0, 0, 0), 1e-7, p, t);
+    });
+    probe("Curve3DValidateRange", "ShapeAnalysis_Curve::ValidateRange", [&] {
+        ShapeAnalysis_Curve s; double f = 0, l = 1; (void)s.ValidateRange(nc, f, l, 1e-7);
+    });
+    probe("...GetSamplePoints3D", "ShapeAnalysis_Curve::GetSamplePoints", [&] {
+        ShapeAnalysis_Curve s; NCollection_Sequence<gp_Pnt> q;
+        (void)s.GetSamplePoints(nc, 0, 1, q);
+    });
+    probe("Curve3DIsClosedWithPreci", "ShapeAnalysis_Curve::IsClosed", [&] {
+        (void)ShapeAnalysis_Curve::IsClosed(nc, 1e-7);
+    });
+    probe("Curve3DIsPeriodicSA", "ShapeAnalysis_Curve::IsPeriodic", [&] {
+        (void)ShapeAnalysis_Curve::IsPeriodic(nc);
+    });
+    probe("Curve3DConvertToPeriodic", "ShapeCustom_Curve ctor", [&] { ShapeCustom_Curve c(nc); (void)c; });
+    probe("Curve3DSplitAt", "Handle(Geom_Curve)->FirstParameter", [&] {
+        Handle(Geom_Curve) c = nc; (void)c->FirstParameter();
+    });
+    probe("GCPntsTangential...", "GeomAdaptor_Curve ctor", [&] { GeomAdaptor_Curve a(nc); (void)a; });
+    probe("...ConvertToBSpline3D", "ShapeConstruct_Curve::ConvertToBSpline", [&] {
+        ShapeConstruct_Curve s; (void)s.ConvertToBSpline(nc, 0, 1, 1e-7);
+    });
+    probe("...AdjustCurve3D", "ShapeConstruct_Curve::AdjustCurve", [&] {
+        ShapeConstruct_Curve s; (void)s.AdjustCurve(nc, gp_Pnt(0, 0, 0), gp_Pnt(1, 1, 1));
+    });
+    probe("Curve3DCreateOffset", "new Geom_OffsetCurve", [&] {
+        Handle(Geom_OffsetCurve) o = new Geom_OffsetCurve(nc, 1.0, gp_Dir(0, 0, 1)); (void)o;
+    });
+    probe("Curve3DTrimmed", "new Geom_TrimmedCurve", [&] {
+        Handle(Geom_TrimmedCurve) t = new Geom_TrimmedCurve(nc, 0, 1); (void)t;
+    });
+    probe("ConcatenateCurves3D", "Geom_BoundedCurve::DownCast then deref", [&] {
+        Handle(Geom_BoundedCurve) b = Handle(Geom_BoundedCurve)::DownCast(nc);
+        if (b.IsNull()) (void)nc->FirstParameter();
+    });
+    probe("...ParameterAtLength", "GCPnts_AbscissaPoint(adaptor)", [&] {
+        GeomAdaptor_Curve a(nc); GCPnts_AbscissaPoint ap(a, 1.0, 0.0); (void)ap.IsDone();
+    });
+    probe("ExtremaPCCurve", "ExtremaPC_Curve ctor", [&] { ExtremaPC_Curve e(nc); (void)e; });
+
+    printf("\n");
+    probe("Curve2DConvertToLine", "ShapeCustom_Curve2d::ConvertToLine2d", [&] {
+        double a = 0, b = 0, d = 0;
+        (void)ShapeCustom_Curve2d::ConvertToLine2d(nc2, 0, 1, 1e-7, a, b, d);
+    });
+    probe("ApproxCurve2d / Gcc*", "Geom2dAdaptor_Curve ctor", [&] {
+        Geom2dAdaptor_Curve a(nc2); (void)a;
+    });
+    probe("ExtremaExtCC2d", "Geom2dAdaptor_Curve(c, first, last)", [&] {
+        Geom2dAdaptor_Curve a(nc2, 0, 1); (void)a;
+    });
+    probe("BisectorBisecAna...", "Bisector_BisecAna::Perform", [&] {
+        Handle(Bisector_BisecAna) b = new Bisector_BisecAna();
+        Handle(Geom2d_Point) p = new Geom2d_CartesianPoint(gp_Pnt2d(0, 0));
+        b->Perform(nc2, p, gp_Pnt2d(0, 0), gp_Vec2d(1, 0), gp_Vec2d(0, 1), 1.0, 1e-7);
+    });
+    probe("Curve2DPointAt", "Geom2d_Curve->D0", [&] { gp_Pnt2d p; nc2->D0(0.5, p); });
+    probe("...ConvertToBSpline2D", "ShapeConstruct_Curve::ConvertToBSpline(2d)", [&] {
+        ShapeConstruct_Curve s; (void)s.ConvertToBSpline(nc2, 0, 1, 1e-7);
+    });
+    probe("...AdjustCurve2D", "ShapeConstruct_Curve::AdjustCurve2d", [&] {
+        ShapeConstruct_Curve s; (void)s.AdjustCurve2d(nc2, gp_Pnt2d(0, 0), gp_Pnt2d(1, 1));
+    });
+    probe("ConcatenateCurves2D", "Geom2d_BoundedCurve::DownCast then deref", [&] {
+        Handle(Geom2d_BoundedCurve) b = Handle(Geom2d_BoundedCurve)::DownCast(nc2);
+        if (b.IsNull()) (void)nc2->FirstParameter();
+    });
+    probe("MakeEdge2dCurve", "BRepLib_MakeEdge2d ctor", [&] {
+        BRepLib_MakeEdge2d m(nc2); (void)m.IsDone();
+    });
+
+    printf("\n");
+    probe("SurfaceFillBSpline*", "GeomConvert::CurveToBSplineCurve", [&] {
+        (void)GeomConvert::CurveToBSplineCurve(nc);
+    });
+    probe("SurfaceExtrema", "GeomAPI_ExtremaSurfaceSurface", [&] {
+        GeomAPI_ExtremaSurfaceSurface e(ns, ns, 0, 1, 0, 1, 0, 1, 0, 1); (void)e.NbExtrema();
+    });
+    probe("SurfaceValueOfUV etc", "new ShapeAnalysis_Surface", [&] {
+        Handle(ShapeAnalysis_Surface) s = new ShapeAnalysis_Surface(ns);
+        (void)s->ValueOfUV(gp_Pnt(0, 0, 0), 1e-7);
+    });
+    probe("SurfaceConvertToPeriodic", "ShapeCustom_Surface::ConvertToPeriodic", [&] {
+        ShapeCustom_Surface c(ns); (void)c.ConvertToPeriodic(Standard_False);
+    });
+    probe("SurfaceCreate*Trimmed", "new Geom_RectangularTrimmedSurface", [&] {
+        Handle(Geom_RectangularTrimmedSurface) t = new Geom_RectangularTrimmedSurface(
+            ns, 0.0, 1.0, 0.0, 1.0, Standard_True, Standard_True); (void)t;
+    });
+    probe("GeomFillGordon", "GeomFill_Gordon::Init + Perform", [&] {
+        NCollection_Array1<occ::handle<Geom_Curve>> a(0, 1), b(0, 1);
+        a.SetValue(0, nc); a.SetValue(1, nc); b.SetValue(0, nc); b.SetValue(1, nc);
+        GeomFill_Gordon g; g.Init(a, b, 1e-7); g.Perform(); (void)g.IsDone();
+    });
+
+    printf("\n");
+    probe("DraftFaceInfoFromSurface", "Draft_FaceInfo ctor", [&] {
+        Draft_FaceInfo f(ns, false); (void)f;
+    });
+    probe("ShapeSectionWithSurface", "BRepAlgoAPI_Section(shape, surface)", [&] {
+        TopoDS_Shape empty;
+        BRepAlgoAPI_Section s(empty, ns); s.Build(); (void)s.IsDone();
+    });
+    probe("SectionBuilderInit1/2", "BRepAlgoAPI_Section::Init1", [&] {
+        BRepAlgoAPI_Section s; s.Init1(ns);
+    });
+    probe("ProjectCurveOnSurface", "ShapeConstruct_ProjectCurveOnSurface", [&] {
+        Handle(ShapeConstruct_ProjectCurveOnSurface) p = new ShapeConstruct_ProjectCurveOnSurface();
+        p->Init(ns, 1e-7);
+        Handle(Geom2d_Curve) out;
+        (void)p->Perform(nc, 0, 1, out);
+    });
+    probe("BRepToolCurveOnPlane", "BRep_Tool::CurveOnPlane", [&] {
+        TopoDS_Edge e; TopLoc_Location l; double f = 0, la = 0;
+        (void)BRep_Tool::CurveOnPlane(e, ns, l, f, la);
+    });
+
+    printf("\n%d uncatchable signal(s), %d catchable exception(s), %d returned normally.\n",
+           uncatchable, catchable, benign);
+    printf("Only the uncatchable ones were reachable crashes before the #556 guards; the rest were\n"
+           "already absorbed by each function's own catch (...).\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1211,6 +1211,7 @@ OCCTCurve3DRef OCCTCurve3DJoinCurves(const OCCTCurve3DRef* curves, int32_t count
     if (!curves || count < 1) return nullptr;
     try {
         // First curve initializes the joiner
+        if (!curves[0] || curves[0]->curve.IsNull()) return nullptr;
         Handle(Geom_BoundedCurve) first = Handle(Geom_BoundedCurve)::DownCast(curves[0]->curve);
         if (first.IsNull()) return nullptr;
 
@@ -1240,7 +1241,7 @@ OCCTCurve3DRef OCCTCurve3DJoinCurves(const OCCTCurve3DRef* curves, int32_t count
 OCCTCurveProjectResult OCCTCurve3DProjectPoint(OCCTCurve3DRef curve,
     double px, double py, double pz, double precision) {
     OCCTCurveProjectResult result = {};
-    if (!curve) return result;
+    if (!curve || curve->curve.IsNull()) return result;
     try {
         ShapeAnalysis_Curve sac;
         gp_Pnt proj;
@@ -1263,7 +1264,7 @@ OCCTCurveValidateRangeResult OCCTCurve3DValidateRange(OCCTCurve3DRef curve,
     result.first = first;
     result.last = last;
     result.wasAdjusted = false;
-    if (!curve) return result;
+    if (!curve || curve->curve.IsNull()) return result;
     try {
         ShapeAnalysis_Curve sac;
         double f = first, l = last;
@@ -1279,7 +1280,7 @@ OCCTCurveValidateRangeResult OCCTCurve3DValidateRange(OCCTCurve3DRef curve,
 
 int32_t OCCTCurve3DGetSamplePoints3D(OCCTCurve3DRef curve, double first, double last,
     double* outXYZ, int32_t maxPoints) {
-    if (!curve || !outXYZ || maxPoints <= 0) return 0;
+    if (!curve || curve->curve.IsNull() || !outXYZ || maxPoints <= 0) return 0;
     try {
         ShapeAnalysis_Curve sac;
         NCollection_Sequence<gp_Pnt> pts;
@@ -1343,7 +1344,7 @@ OCCTCurve3DRef OCCTCurve3DArcOfParabola(
 
 // MARK: - Curve3D ConvertToPeriodic / SplitAt (v0.50)
 OCCTCurve3DRef OCCTCurve3DConvertToPeriodic(OCCTCurve3DRef curve) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         ShapeCustom_Curve scc(curve->curve);
         Handle(Geom_Curve) periodic = scc.ConvertToPeriodic(Standard_False);
@@ -1358,7 +1359,7 @@ OCCTCurve3DRef OCCTCurve3DConvertToPeriodic(OCCTCurve3DRef curve) {
 
 bool OCCTCurve3DSplitAt(OCCTCurve3DRef curve, double splitParam,
     OCCTCurve3DRef* outCurve1, OCCTCurve3DRef* outCurve2) {
-    if (!curve || !outCurve1 || !outCurve2) return false;
+    if (!curve || curve->curve.IsNull() || !outCurve1 || !outCurve2) return false;
     *outCurve1 = nullptr;
     *outCurve2 = nullptr;
     try {
@@ -1731,7 +1732,7 @@ int32_t OCCTGCPntsTangentialDeflectionCurve(OCCTCurve3DRef _Nonnull curve,
                                              double* _Nonnull params,
                                              double* _Nullable coords,
                                              int32_t maxPoints) {
-    if (!curve) return 0;
+    if (!curve || curve->curve.IsNull()) return 0;
     try {
         GeomAdaptor_Curve adaptor(curve->curve);
         GCPnts_TangentialDeflection sampler(adaptor, angularDeflection, curvatureDeflection,
@@ -2003,7 +2004,7 @@ void OCCTAxis2PlacementSetXDirection(OCCTAxis2PlacementRef _Nonnull ref, double 
 
 OCCTCurve3DRef _Nullable OCCTShapeConstructConvertToBSpline3D(OCCTCurve3DRef _Nonnull curve,
                                                                 double first, double last, double precision) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         ShapeConstruct_Curve scc;
         Handle(Geom_BSplineCurve) bsp = scc.ConvertToBSpline(curve->curve, first, last, precision);
@@ -2018,7 +2019,7 @@ OCCTCurve3DRef _Nullable OCCTShapeConstructConvertToBSpline3D(OCCTCurve3DRef _No
 bool OCCTShapeConstructAdjustCurve3D(OCCTCurve3DRef _Nonnull curve,
                                       double p1x, double p1y, double p1z,
                                       double p2x, double p2y, double p2z) {
-    if (!curve) return false;
+    if (!curve || curve->curve.IsNull()) return false;
     try {
         ShapeConstruct_Curve scc;
         return scc.AdjustCurve(curve->curve, gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z));
@@ -2508,6 +2509,7 @@ OCCTGeomTransformRef OCCTGeomTransformInverted(OCCTGeomTransformRef transform) {
 OCCTCurve3DRef OCCTCurve3DCreateOffset(OCCTCurve3DRef basisCurve,
                                          double offset,
                                          double dirX, double dirY, double dirZ) {
+    if (!basisCurve || basisCurve->curve.IsNull()) return nullptr;
     try {
         Handle(Geom_OffsetCurve) oc = new Geom_OffsetCurve(
             basisCurve->curve, offset, gp_Dir(dirX, dirY, dirZ));
@@ -2784,14 +2786,14 @@ bool OCCTConvertCompBezier2dToBSpline2d(const double* poles, int32_t segCount, i
 // --- ShapeAnalysis_Curve static methods ---
 
 bool OCCTCurve3DIsClosedWithPreci(OCCTCurve3DRef curve, double preci) {
-    if (!curve) return false;
+    if (!curve || curve->curve.IsNull()) return false;
     try {
         return ShapeAnalysis_Curve::IsClosed(curve->curve, preci);
     } catch (...) { return false; }
 }
 
 bool OCCTCurve3DIsPeriodicSA(OCCTCurve3DRef curve) {
-    if (!curve) return false;
+    if (!curve || curve->curve.IsNull()) return false;
     try {
         return ShapeAnalysis_Curve::IsPeriodic(curve->curve);
     } catch (...) { return false; }
@@ -2813,6 +2815,7 @@ OCCTCurve3DRef OCCTCurve3DOffsetBasis(OCCTCurve3DRef curve) {
 // --- Geom_TrimmedCurve ---
 
 OCCTCurve3DRef OCCTCurve3DTrimmed(OCCTCurve3DRef basisCurve, double u1, double u2) {
+    if (!basisCurve || basisCurve->curve.IsNull()) return nullptr;
     try {
         Handle(Geom_TrimmedCurve) tc = new Geom_TrimmedCurve(basisCurve->curve, u1, u2);
         OCCTCurve3D* c = new OCCTCurve3D();
@@ -3092,6 +3095,7 @@ OCCTCurve3DRef OCCTConcatenateCurves3D(OCCTCurve3DRef* curves, int32_t count, do
     if (!curves || count <= 0) return nullptr;
     try {
         // First curve must be bounded — try to cast
+        if (!curves[0] || curves[0]->curve.IsNull()) return nullptr;
         Handle(Geom_BoundedCurve) first = Handle(Geom_BoundedCurve)::DownCast(curves[0]->curve);
         if (first.IsNull()) {
             // Try trimming the curve using its parameter range
@@ -3101,6 +3105,7 @@ OCCTCurve3DRef OCCTConcatenateCurves3D(OCCTCurve3DRef* curves, int32_t count, do
         }
         GeomConvert_CompCurveToBSplineCurve comp(first);
         for (int32_t i = 1; i < count; i++) {
+            if (!curves[i] || curves[i]->curve.IsNull()) return nullptr;
             Handle(Geom_BoundedCurve) bc = Handle(Geom_BoundedCurve)::DownCast(curves[i]->curve);
             if (bc.IsNull()) {
                 double f = curves[i]->curve->FirstParameter();
@@ -4641,7 +4646,7 @@ OCCTCurve3DRef OCCTCurve3DConcatenateG1(const OCCTCurve3DRef* curves, int32_t co
 
 
 double OCCTCurve3DParameterAtLength(OCCTCurve3DRef curve, double arcLength, double fromParam) {
-    if (!curve) return 0;
+    if (!curve || curve->curve.IsNull()) return 0;
     try {
         GeomAdaptor_Curve adaptor(curve->curve);
         GCPnts_AbscissaPoint ap(adaptor, arcLength, fromParam);
@@ -5336,7 +5341,7 @@ int32_t OCCTExtremaPCCurve(OCCTCurve3DRef curve,
                             double* outParams, double* outDistances,
                             double* outPx, double* outPy, double* outPz,
                             int32_t maxResults) {
-    if (!curve || !outParams || !outDistances || maxResults <= 0) return 0;
+    if (!curve || curve->curve.IsNull() || !outParams || !outDistances || maxResults <= 0) return 0;
     try {
         ExtremaPC_Curve extPC(curve->curve);
         if (!extPC.IsInitialized()) return 0;
@@ -5360,7 +5365,7 @@ int32_t OCCTExtremaPCCurveBounded(OCCTCurve3DRef curve,
                                    double* outParams, double* outDistances,
                                    double* outPx, double* outPy, double* outPz,
                                    int32_t maxResults) {
-    if (!curve || !outParams || !outDistances || maxResults <= 0) return 0;
+    if (!curve || curve->curve.IsNull() || !outParams || !outDistances || maxResults <= 0) return 0;
     try {
         ExtremaPC_Curve extPC(curve->curve, uMin, uMax);
         if (!extPC.IsInitialized()) return 0;
@@ -5380,7 +5385,7 @@ int32_t OCCTExtremaPCCurveBounded(OCCTCurve3DRef curve,
 
 double OCCTExtremaPCMinDistance(OCCTCurve3DRef curve,
                                 double px, double py, double pz) {
-    if (!curve) return -1.0;
+    if (!curve || curve->curve.IsNull()) return -1.0;
     try {
         ExtremaPC_Curve extPC(curve->curve);
         if (!extPC.IsInitialized()) return -1.0;

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -715,7 +715,7 @@ bool OCCTCurve2DIsLinear(OCCTCurve2DRef curve2D, double tolerance, double* devia
 OCCTCurve2DRef _Nullable OCCTCurve2DConvertToLine(OCCTCurve2DRef curve2D,
     double first, double last, double tolerance,
     double* newFirst, double* newLast, double* deviation) {
-    if (!curve2D || !newFirst || !newLast || !deviation) return nullptr;
+    if (!curve2D || curve2D->curve.IsNull() || !newFirst || !newLast || !deviation) return nullptr;
     try {
         Handle(Geom2d_Line) line = ShapeCustom_Curve2d::ConvertToLine2d(
             curve2D->curve, first, last, tolerance, *newFirst, *newLast, *deviation);
@@ -745,7 +745,7 @@ bool OCCTCurve2DSimplifyBSpline(OCCTCurve2DRef curve2D, double tolerance) {
 OCCTCurve2DRef _Nullable OCCTApproxCurve2d(OCCTCurve2DRef curve2D,
     double first, double last, double tolU, double tolV,
     int32_t maxDegree, int32_t maxSegments) {
-    if (!curve2D) return nullptr;
+    if (!curve2D || curve2D->curve.IsNull()) return nullptr;
     try {
         Handle(Adaptor2d_Curve2d) adaptor = new Geom2dAdaptor_Curve(curve2D->curve, first, last);
         Approx_Curve2d approx(adaptor, first, last, tolU, tolV, GeomAbs_C2, maxDegree, maxSegments);
@@ -772,6 +772,9 @@ static GccEnt_Position toGccPosition(int32_t q) {
     }
 }
 
+// #556: no guard here by design. The return type has no null-safe value to fall back to, so the
+// precondition lives in the callers: every one of them rejects a null pointer and a null handle
+// before calling. Keep that true when adding a caller: Geom2dAdaptor_Curve::load() dereferences.
 static Geom2dGcc_QualifiedCurve makeQualifiedCurve(OCCTCurve2DRef c, int32_t q) {
     Geom2dAdaptor_Curve adaptor(c->curve);
     return Geom2dGcc_QualifiedCurve(adaptor, toGccPosition(q));
@@ -1335,6 +1338,7 @@ int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef curve, int32_t qualifier,
                                  double lpx, double lpy, double ldx, double ldy,
                                  double tolerance, double angle,
                                  OCCTGccLineSolution* out, int32_t max) {
+    if (!curve || curve->curve.IsNull()) return 0;
     try {
         Geom2dAdaptor_Curve adaptor(curve->curve);
         Geom2dGcc_QualifiedCurve qc(adaptor, toGccPosition(qualifier));
@@ -1412,6 +1416,8 @@ int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef c1, int32_t q1,
                                   double tolerance,
                                   double initParam1, double initParam2, double initParamOn,
                                   OCCTGccCircleSolution* out, int32_t max) {
+    if (!c1 || !c2 || !onCurve) return 0;
+    if (c1->curve.IsNull() || c2->curve.IsNull() || onCurve->curve.IsNull()) return 0;
     try {
         Geom2dAdaptor_Curve ac1(c1->curve), ac2(c2->curve), aon(onCurve->curve);
         Geom2dGcc_QualifiedCurve qc1(ac1, toGccPosition(q1));
@@ -1435,6 +1441,7 @@ int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef curve, int32_t qualifier,
                                     OCCTCurve2DRef onCurve,
                                     double radius, double tolerance,
                                     OCCTGccCircleSolution* out, int32_t max) {
+    if (!curve || !onCurve || curve->curve.IsNull() || onCurve->curve.IsNull()) return 0;
     try {
         Geom2dAdaptor_Curve ac(curve->curve), aon(onCurve->curve);
         Geom2dGcc_QualifiedCurve qc(ac, toGccPosition(qualifier));
@@ -1631,6 +1638,7 @@ int32_t OCCTExtremaExtPElC2dLin(double px, double py,
 int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef c1, double first1, double last1,
                            OCCTCurve2DRef c2, double first2, double last2,
                            OCCTExtrema2dResult* out, int32_t max) {
+    if (!c1 || !c2 || c1->curve.IsNull() || c2->curve.IsNull()) return -1;
     try {
         Geom2dAdaptor_Curve ac1(c1->curve, first1, last1);
         Geom2dAdaptor_Curve ac2(c2->curve, first2, last2);
@@ -1658,6 +1666,7 @@ OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(
     double px, double py,
     double v1x, double v1y, double v2x, double v2y,
     double sense, double tolerance) {
+    if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull()) return nullptr;
     try {
         Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
         bisec->Perform(curve1->curve, curve2->curve,
@@ -1677,6 +1686,7 @@ OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(
     double px, double py,
     double v1x, double v1y, double v2x, double v2y,
     double sense, double tolerance) {
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         Handle(Geom2d_Point) geomPt = new Geom2d_CartesianPoint(gp_Pnt2d(ptx, pty));
         Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
@@ -2158,6 +2168,7 @@ int32_t OCCTLPropAnalyticCurInf(int32_t curveType, double first, double last,
 // --- Curve2D ↔ Point2D integration ---
 
 OCCTPoint2DRef _Nullable OCCTCurve2DPointAt(OCCTCurve2DRef _Nonnull curve, double t) {
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         gp_Pnt2d pt;
         curve->curve->D0(t, pt);
@@ -2458,7 +2469,7 @@ int32_t OCCTIntfSelfInterferencePolygon2d(
 // MARK: - ShapeConstruct Curve2D Convert + Adjust (v0.76)
 OCCTCurve2DRef _Nullable OCCTShapeConstructConvertToBSpline2D(OCCTCurve2DRef _Nonnull curve,
                                                                 double first, double last, double precision) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         ShapeConstruct_Curve scc;
         Handle(Geom2d_BSplineCurve) bsp = scc.ConvertToBSpline(curve->curve, first, last, precision);
@@ -2473,7 +2484,7 @@ OCCTCurve2DRef _Nullable OCCTShapeConstructConvertToBSpline2D(OCCTCurve2DRef _No
 bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
                                       double p1x, double p1y,
                                       double p2x, double p2y) {
-    if (!curve) return false;
+    if (!curve || curve->curve.IsNull()) return false;
     try {
         ShapeConstruct_Curve scc;
         return scc.AdjustCurve2d(curve->curve, gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
@@ -3260,6 +3271,7 @@ OCCTCurve2DRef OCCTCurve2DMakeParabolaDirectrixFocus(double dx, double dy,
 OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, double tolerance) {
     if (!curves || count <= 0) return nullptr;
     try {
+        if (!curves[0] || curves[0]->curve.IsNull()) return nullptr;
         Handle(Geom2d_BoundedCurve) first = Handle(Geom2d_BoundedCurve)::DownCast(curves[0]->curve);
         if (first.IsNull()) {
             double f = curves[0]->curve->FirstParameter();
@@ -3268,6 +3280,7 @@ OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, do
         }
         Geom2dConvert_CompCurveToBSplineCurve comp(first);
         for (int32_t i = 1; i < count; i++) {
+            if (!curves[i] || curves[i]->curve.IsNull()) return nullptr;
             Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curves[i]->curve);
             if (bc.IsNull()) {
                 double f = curves[i]->curve->FirstParameter();
@@ -3363,7 +3376,7 @@ OCCTShapeRef OCCTMakeEdge2dEllipseArc(double cx, double cy, double dx, double dy
 }
 
 OCCTShapeRef OCCTMakeEdge2dCurve(OCCTCurve2DRef curve) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         BRepLib_MakeEdge2d me(curve->curve);
         if (!me.IsDone()) return nullptr;
@@ -3374,7 +3387,7 @@ OCCTShapeRef OCCTMakeEdge2dCurve(OCCTCurve2DRef curve) {
 }
 
 OCCTShapeRef OCCTMakeEdge2dCurveRange(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve) return nullptr;
+    if (!curve || curve->curve.IsNull()) return nullptr;
     try {
         BRepLib_MakeEdge2d me(curve->curve, u1, u2);
         if (!me.IsDone()) return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -7695,7 +7695,7 @@ bool OCCTDraftEdgeInfoSetTangent(double dx, double dy, double dz) {
 }
 
 bool OCCTDraftFaceInfoFromSurface(OCCTSurfaceRef surface) {
-    if (!surface) return false;
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         Draft_FaceInfo fi(surface->surface, false);
         return true;
@@ -9750,7 +9750,7 @@ OCCTShapeRef OCCTShapeSectionWithPlane(OCCTShapeRef shape,
 }
 
 OCCTShapeRef OCCTShapeSectionWithSurface(OCCTShapeRef shape, OCCTSurfaceRef surface) {
-    if (!shape || !surface) return nullptr;
+    if (!shape || !surface || surface->surface.IsNull()) return nullptr;
     try {
         BRepAlgoAPI_Section section(shape->shape, surface->surface);
         section.Build();
@@ -9802,7 +9802,7 @@ void OCCTSectionBuilderInit1Plane(OCCTSectionBuilderRef builder,
 }
 
 void OCCTSectionBuilderInit1Surface(OCCTSectionBuilderRef builder, OCCTSurfaceRef surface) {
-    if (!builder || !surface) return;
+    if (!builder || !surface || surface->surface.IsNull()) return;
     try { builder->section.Init1(surface->surface); } catch (...) {}
 }
 
@@ -9821,7 +9821,7 @@ void OCCTSectionBuilderInit2Plane(OCCTSectionBuilderRef builder,
 }
 
 void OCCTSectionBuilderInit2Surface(OCCTSectionBuilderRef builder, OCCTSurfaceRef surface) {
-    if (!builder || !surface) return;
+    if (!builder || !surface || surface->surface.IsNull()) return;
     try { builder->section.Init2(surface->surface); } catch (...) {}
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
@@ -1006,7 +1006,7 @@ OCCTCurve2DRef _Nullable OCCTProjectCurveOnSurface(OCCTCurve3DRef _Nonnull curve
                                                      double firstParam,
                                                      double lastParam,
                                                      double precision) {
-    if (!curve || !surface) return nullptr;
+    if (!curve || !surface || curve->curve.IsNull() || surface->surface.IsNull()) return nullptr;
     try {
         Handle(ShapeConstruct_ProjectCurveOnSurface) projector =
             new ShapeConstruct_ProjectCurveOnSurface();

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -1435,7 +1435,7 @@ static Handle(Geom_BSplineCurve) toBSplineCurve(const Handle(Geom_Curve)& curve)
 
 OCCTSurfaceRef OCCTSurfaceFillBSpline2Curves(OCCTCurve3DRef curve1, OCCTCurve3DRef curve2,
                                                int32_t fillStyle) {
-    if (!curve1 || !curve2) return nullptr;
+    if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull()) return nullptr;
     try {
         Handle(Geom_BSplineCurve) c1 = toBSplineCurve(curve1->curve);
         Handle(Geom_BSplineCurve) c2 = toBSplineCurve(curve2->curve);
@@ -1458,6 +1458,8 @@ OCCTSurfaceRef OCCTSurfaceFillBSpline4Curves(OCCTCurve3DRef c1, OCCTCurve3DRef c
                                                OCCTCurve3DRef c3, OCCTCurve3DRef c4,
                                                int32_t fillStyle) {
     if (!c1 || !c2 || !c3 || !c4) return nullptr;
+    if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull() || c4->curve.IsNull())
+        return nullptr;
     try {
         Handle(Geom_BSplineCurve) bc1 = toBSplineCurve(c1->curve);
         Handle(Geom_BSplineCurve) bc2 = toBSplineCurve(c2->curve);
@@ -1497,6 +1499,7 @@ int32_t OCCTSurfaceExtrema(OCCTSurfaceRef s1, OCCTSurfaceRef s2,
                             double u2Min, double u2Max, double v2Min, double v2Max,
                             OCCTSurfaceExtremaResult* outResult) {
     if (!s1 || !s2 || !outResult) return 0;
+    if (s1->surface.IsNull() || s2->surface.IsNull()) return 0;
     try {
         GeomAPI_ExtremaSurfaceSurface extrema(
             s1->surface, s2->surface,
@@ -1637,7 +1640,7 @@ bool OCCTGeomFillConstrainedInfo(OCCTShapeRef face, OCCTConstrainedFillingInfo* 
 OCCTSurfaceUVResult OCCTSurfaceValueOfUV(OCCTSurfaceRef surface,
     double px, double py, double pz, double precision) {
     OCCTSurfaceUVResult result = {};
-    if (!surface) return result;
+    if (!surface || surface->surface.IsNull()) return result;
     try {
         Handle(ShapeAnalysis_Surface) sa = new ShapeAnalysis_Surface(surface->surface);
         gp_Pnt2d uv = sa->ValueOfUV(gp_Pnt(px, py, pz), precision);
@@ -1653,7 +1656,7 @@ OCCTSurfaceUVResult OCCTSurfaceValueOfUV(OCCTSurfaceRef surface,
 OCCTSurfaceUVResult OCCTSurfaceNextValueOfUV(OCCTSurfaceRef surface,
     double prevU, double prevV, double px, double py, double pz, double precision) {
     OCCTSurfaceUVResult result = {};
-    if (!surface) return result;
+    if (!surface || surface->surface.IsNull()) return result;
     try {
         Handle(ShapeAnalysis_Surface) sa = new ShapeAnalysis_Surface(surface->surface);
         gp_Pnt2d uv = sa->NextValueOfUV(gp_Pnt2d(prevU, prevV), gp_Pnt(px, py, pz), precision);
@@ -1872,7 +1875,7 @@ OCCTSurfaceRef OCCTSurfaceJoinBezierPatches(
 // MARK: - Surface ConvertToAnalytical (v0.50)
 OCCTSurfaceAnalyticalResult OCCTSurfaceConvertToAnalytical(OCCTSurfaceRef surface, double tolerance) {
     OCCTSurfaceAnalyticalResult result = {};
-    if (!surface) return result;
+    if (!surface || surface->surface.IsNull()) return result;
     try {
         ShapeCustom_Surface sc(surface->surface);
         Handle(Geom_Surface) recognized = sc.ConvertToAnalytical(tolerance, Standard_False);
@@ -2753,7 +2756,7 @@ bool OCCTGeomFillBoundWithSurfEvaluate(
 // --- ShapeCustom_Surface: ConvertToPeriodic, Gap ---
 
 OCCTSurfaceRef _Nullable OCCTSurfaceConvertToPeriodic(OCCTSurfaceRef _Nonnull surface) {
-    if (!surface) return nullptr;
+    if (!surface || surface->surface.IsNull()) return nullptr;
     try {
         ShapeCustom_Surface sc(surface->surface);
         Handle(Geom_Surface) periodic = sc.ConvertToPeriodic(Standard_False);
@@ -2767,7 +2770,7 @@ OCCTSurfaceRef _Nullable OCCTSurfaceConvertToPeriodic(OCCTSurfaceRef _Nonnull su
 }
 
 double OCCTSurfaceConversionGap(OCCTSurfaceRef _Nonnull surface) {
-    if (!surface) return -1.0;
+    if (!surface || surface->surface.IsNull()) return -1.0;
     try {
         ShapeCustom_Surface sc(surface->surface);
         // Trigger a conversion to populate gap
@@ -3342,6 +3345,7 @@ OCCTSurfaceRef _Nullable OCCTGceMakePlnFrom3Points(double p1x, double p1y, doubl
 OCCTSurfaceRef OCCTSurfaceCreateRectangularTrimmed(OCCTSurfaceRef basisSurface,
                                                      double u1, double u2,
                                                      double v1, double v2) {
+    if (!basisSurface || basisSurface->surface.IsNull()) return nullptr;
     try {
         Handle(Geom_RectangularTrimmedSurface) ts =
             new Geom_RectangularTrimmedSurface(basisSurface->surface, u1, u2, v1, v2);
@@ -3353,6 +3357,7 @@ OCCTSurfaceRef OCCTSurfaceCreateRectangularTrimmed(OCCTSurfaceRef basisSurface,
 
 OCCTSurfaceRef OCCTSurfaceCreateTrimmedInU(OCCTSurfaceRef basisSurface,
                                              double param1, double param2) {
+    if (!basisSurface || basisSurface->surface.IsNull()) return nullptr;
     try {
         Handle(Geom_RectangularTrimmedSurface) ts =
             new Geom_RectangularTrimmedSurface(basisSurface->surface, param1, param2, true);
@@ -3364,6 +3369,7 @@ OCCTSurfaceRef OCCTSurfaceCreateTrimmedInU(OCCTSurfaceRef basisSurface,
 
 OCCTSurfaceRef OCCTSurfaceCreateTrimmedInV(OCCTSurfaceRef basisSurface,
                                              double param1, double param2) {
+    if (!basisSurface || basisSurface->surface.IsNull()) return nullptr;
     try {
         Handle(Geom_RectangularTrimmedSurface) ts =
             new Geom_RectangularTrimmedSurface(basisSurface->surface, param1, param2, false);
@@ -3594,6 +3600,7 @@ OCCTSurfaceRef OCCTSurfaceOffsetBasis(OCCTSurfaceRef surface) {
 
 double OCCTSurfaceProjectPointUV(OCCTSurfaceRef surface, double px, double py, double pz,
                                    double preci, double* u, double* v) {
+    if (!surface || surface->surface.IsNull()) { *u = 0; *v = 0; return -1.0; }
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         gp_Pnt2d uv = sas->ValueOfUV(gp_Pnt(px, py, pz), preci);
@@ -3604,6 +3611,7 @@ double OCCTSurfaceProjectPointUV(OCCTSurfaceRef surface, double px, double py, d
 }
 
 bool OCCTSurfaceHasSingularities(OCCTSurfaceRef surface, double preci) {
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         return sas->HasSingularities(preci);
@@ -3611,6 +3619,7 @@ bool OCCTSurfaceHasSingularities(OCCTSurfaceRef surface, double preci) {
 }
 
 int32_t OCCTSurfaceNbSingularities(OCCTSurfaceRef surface, double preci) {
+    if (!surface || surface->surface.IsNull()) return 0;
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         return sas->NbSingularities(preci);
@@ -3618,6 +3627,7 @@ int32_t OCCTSurfaceNbSingularities(OCCTSurfaceRef surface, double preci) {
 }
 
 bool OCCTSurfaceIsUClosedSA(OCCTSurfaceRef surface, double preci) {
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         return sas->IsUClosed(preci);
@@ -3625,6 +3635,7 @@ bool OCCTSurfaceIsUClosedSA(OCCTSurfaceRef surface, double preci) {
 }
 
 bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci) {
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         return sas->IsVClosed(preci);
@@ -3644,6 +3655,7 @@ bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci) {
 /// 3D gap (very large on failure).
 double OCCTSurfaceUVFromIso(OCCTSurfaceRef surface, double px, double py, double pz,
                             double preci, double* u, double* v) {
+    if (!surface || surface->surface.IsNull()) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         double U = 0, V = 0;
@@ -3660,6 +3672,7 @@ bool OCCTSurfaceSingularityDetail(OCCTSurfaceRef surface, int32_t num, double* p
                                   double* px, double* py, double* pz,
                                   double* firstU, double* firstV, double* lastU, double* lastV,
                                   double* firstPar, double* lastPar, bool* uIsoDegenerate) {
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         gp_Pnt P3d; gp_Pnt2d f2, l2; double fp = 0, lp = 0; Standard_Boolean uiso = Standard_False;
@@ -3680,6 +3693,7 @@ bool OCCTSurfaceSingularityDetail(OCCTSurfaceRef surface, int32_t num, double* p
 bool OCCTSurfaceProjectDegenerated(OCCTSurfaceRef surface, double px, double py, double pz,
                                    double preci, double neighbourU, double neighbourV,
                                    double* ru, double* rv) {
+    if (!surface || surface->surface.IsNull()) return false;
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         gp_Pnt2d result;
@@ -3697,6 +3711,7 @@ bool OCCTSurfaceProjectDegenerated(OCCTSurfaceRef surface, double px, double py,
 double OCCTSurfaceProjectPointUVInDomain(OCCTSurfaceRef surface, double px, double py, double pz,
                                          double preci, double u1, double u2, double v1, double v2,
                                          double* u, double* v) {
+    if (!surface || surface->surface.IsNull()) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
     try {
         Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
         sas->SetDomain(u1, u2, v1, v2);
@@ -6383,12 +6398,12 @@ OCCTSurfaceRef OCCTGeomFillGordon(const OCCTCurve3DRef* profiles, int32_t profil
     try {
         NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
         for (int i = 0; i < profileCount; i++) {
-            if (!profiles[i]) return nullptr;
+            if (!profiles[i] || profiles[i]->curve.IsNull()) return nullptr;
             profs.SetValue(i, profiles[i]->curve);
         }
         NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
         for (int i = 0; i < guideCount; i++) {
-            if (!guides[i]) return nullptr;
+            if (!guides[i] || guides[i]->curve.IsNull()) return nullptr;
             gds.SetValue(i, guides[i]->curve);
         }
 
@@ -6465,12 +6480,12 @@ OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t 
     try {
         NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
         for (int i = 0; i < profileCount; i++) {
-            if (!profiles[i]) return nullptr;
+            if (!profiles[i] || profiles[i]->curve.IsNull()) return nullptr;
             profs.SetValue(i, profiles[i]->curve);
         }
         NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
         for (int i = 0; i < guideCount; i++) {
-            if (!guides[i]) return nullptr;
+            if (!guides[i] || guides[i]->curve.IsNull()) return nullptr;
             gds.SetValue(i, guides[i]->curve);
         }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1609,7 +1609,7 @@ OCCTCurveSurfaceInterRef _Nullable OCCTCurveSurfaceInterCreateCurve(
     OCCTShapeRef _Nonnull shape,
     OCCTCurve3DRef _Nonnull curve,
     double tolerance) {
-    if (!shape || !curve) return nullptr;
+    if (!shape || !curve || curve->curve.IsNull()) return nullptr;
     try {
         auto* ref = new OCCTCurveSurfaceInter();
         GeomAdaptor_Curve gac(curve->curve);
@@ -3806,7 +3806,7 @@ double OCCTBRepToolMaxTolerance(OCCTShapeRef shape, int32_t subShapeType) {
 
 OCCTCurve2DRef OCCTBRepToolCurveOnPlane(OCCTShapeRef edge, OCCTSurfaceRef surface,
                                          double* outFirst, double* outLast) {
-    if (!edge || !surface || !outFirst || !outLast) return nullptr;
+    if (!edge || !surface || surface->surface.IsNull() || !outFirst || !outLast) return nullptr;
     try {
         TopoDS_Edge e = TopoDS::Edge(edge->shape);
         TopLoc_Location loc;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -386,6 +386,73 @@ one-family drift fails the parity suite, while a defect inside the shared `build
 families identically and leaves the parity suite entirely green, failing only the geometry suite.
 A parity assertion stops being evidence the moment the thing it compares becomes shared.
 
+#### The other half of the null-handle sweep, and a checker so it stays swept (#556)
+
+#478 fixed the 14 bridge functions that guard the wrapper pointer and then **dereference** the
+`Handle` it carries. #556 is the class it deliberately left behind: functions that guard the wrapper
+and then **pass** the unchecked handle to an OCCT API which dereferences it internally.
+
+**60 functions, 73 (function, argument) pairs**, all now opening with
+`if (!x || x->handle.IsNull())`:
+
+| file | functions |
+|---|---|
+| `OCCTBridge_Surface.mm` | 22 |
+| `OCCTBridge_Curve3D.mm` | 17 |
+| `OCCTBridge_Geom2d.mm` | 14 |
+| `OCCTBridge_Modeling.mm` | 4 |
+| `OCCTBridge_Topology.mm` | 2 |
+| `OCCTBridge_ProjLib_NLPlate.mm` | 1 |
+
+The issue counted 49 functions across 5 files; the same walk, run again, finds 61 across 6.
+
+**The issue's headline example is a false positive, twice over.** #556 opens with
+`makeQualifiedCurve` (`Geom2dAdaptor_Curve adaptor(c->curve)`, "no guard at all"), and argues from
+`Geom2dAdaptor_Curve.cxx:272` that `load` "has **no** null precondition at all [...] it is an
+unconditional dereference in every build configuration". Lowercase `load` is private. Every caller
+reaches it through the public `Load`, header-inline at `Geom2dAdaptor_Curve.hxx:108`, which opens
+with a bare `if (theCurve.IsNull()) throw Standard_NullObject();`, not macro-guarded, so unlike the
+kernel's precompiled `.cxx` preconditions it is *not* compiled out by `No_Exception`, which only
+ever applied to the Release kernel build and never to bridge translation units. And all 12 of
+`makeQualifiedCurve`'s call sites, across 7 functions, already reject both the null pointer and the
+null handle before calling it. It is the one site in the whole sweep left unguarded, now with a
+comment saying why: its return type (`Geom2dGcc_QualifiedCurve`, by value) has no null-safe
+fallback, so the precondition has to live in the callers.
+
+**The class is worse than "latent" elsewhere, though.**
+[`Scripts/repro/556-null-handle-guard-sweep/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/556-null-handle-guard-sweep)
+drives a null handle into all **35** distinct OCCT entry points these 60 functions call, each in a
+forked child: **24 crash with an uncatchable signal**, 5 raise a catchable `Standard_Failure`, 6
+return normally. `Geom2dAdaptor_Curve` is in the mild group. `new Geom_TrimmedCurve`,
+`new Geom_OffsetCurve`, `new Geom_RectangularTrimmedSurface`, `ShapeAnalysis_Curve::IsPeriodic`,
+`BRepLib_MakeEdge2d`, `GeomConvert::CurveToBSplineCurve`, `BRepAlgoAPI_Section` and
+`ShapeConstruct_Curve::ConvertToBSpline` are not. `ShapeAnalysis_Surface` is the one to remember:
+constructing it from a null handle returns normally and the crash lands at the first `ValueOfUV`, so
+a probe that only constructed it would have cleared that entire 11-function family.
+
+**Three findings the issue's own reproduction recipe could not reach**, because it walks scalar
+parameters only:
+
+- `OCCTCurve2DPointAt` is a **dereference** site (`curve->curve->D0(t, pt)`, with no guard at all)
+  that #478's sweep missed outright. Fixed here rather than left for a third pass.
+- Five functions take an *array* of wrappers. `OCCTGeomFillGordon` and `OCCTGeomFillGordonReport`
+  checked `!profiles[i]` and passed the handle unchecked; `OCCTConcatenateCurves3D`,
+  `OCCTConcatenateCurves2D` and `OCCTCurve3DJoinCurves` checked `curves[i]` inside the loop but
+  never `curves[0]`, the element every one of them handles separately to seed the accumulator.
+- `OCCTBridge_ProjLib_NLPlate.mm` was not in the issue's file list at all.
+
+**The deliverable is the invariant, so it is now checked rather than remembered.**
+`Scripts/check-null-handle-guards.py` is the same walk that produced both #478's list and this one,
+committed alongside `check-bridge-index.py` and gating on exit status. Verified against two injected
+regressions: reverting one guard, and adding a new function that checks only the pointer. It reports
+both, and reports nothing on the fixed tree. `DownCast(x->handle)` is excluded as a use, since
+down-casting a null handle returns null and every such site checks the cast result. Without that
+exclusion the walk reports several hundred false positives.
+
+Still latent: #478's classification of all 228 wrapper-producing sites holds, so no bridge call can
+hand back a wrapper carrying a null handle today. What changed is the measured cost of weakening
+that invariant later.
+
 #### Fix: arc-length sampling aborted the process on a sample count it could not allocate (#479)
 
 `EdgeCurve`/`WireCurve` `points(spacing:)` derived its sample count from the caller's spacing with a


### PR DESCRIPTION
Closes #556

#478 fixed the 14 bridge functions that guard the wrapper pointer and then **dereference** the
`Handle` it carries. This is the class it deliberately left behind: functions that guard the wrapper
and then **pass** the unchecked handle to an OCCT API which dereferences it internally.

**60 functions, 73 (function, argument) pairs**, now opening with `if (!x || x->handle.IsNull())`:

| file | functions |
|---|---|
| `OCCTBridge_Surface.mm` | 22 |
| `OCCTBridge_Curve3D.mm` | 17 |
| `OCCTBridge_Geom2d.mm` | 14 |
| `OCCTBridge_Modeling.mm` | 4 |
| `OCCTBridge_Topology.mm` | 2 |
| `OCCTBridge_ProjLib_NLPlate.mm` | 1 |

## Three of the issue's claims did not survive re-measurement

Flagging these up front, since they are the parts of this PR worth actually reviewing rather than
skimming. The fix itself is mechanical.

**1. The headline example is a false positive, twice over.** #556 opens with `makeQualifiedCurve`
and argues from `Geom2dAdaptor_Curve.cxx:272` that `load` "has **no** null precondition at all
[...] it is an unconditional dereference in every build configuration". Lowercase `load` is
private. Every caller reaches it through the public `Load`, header-inline at
`Geom2dAdaptor_Curve.hxx:108`:

```cpp
void Load(const occ::handle<Geom2d_Curve>& theCurve)
{
  if (theCurve.IsNull())
  {
    throw Standard_NullObject();
  }
  load(theCurve, theCurve->FirstParameter(), theCurve->LastParameter());
}
```

That `throw` is not macro-guarded, so unlike the kernel's precompiled `.cxx` preconditions it is
not compiled out by `No_Exception`, which only ever applied to the Release kernel build
(`occt_defs_flags.cmake:227`) and never to bridge translation units. And all 12 of
`makeQualifiedCurve`'s call sites, across 7 functions, already reject both the null pointer and the
null handle. It is the one site in the sweep left unguarded, now carrying a comment saying why: its
return type (`Geom2dGcc_QualifiedCurve`, by value) has no null-safe fallback, so the precondition
has to live in the callers.

**2. The counts were low.** The issue counted 49 functions across 5 files. The same walk finds 61
across 6; `OCCTBridge_ProjLib_NLPlate.mm` was not in its file list at all.

**3. The class is more dangerous than the issue argued, just not where it pointed.**
[`Scripts/repro/556-null-handle-guard-sweep/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/556-handle-guard-sweep/Scripts/repro/556-null-handle-guard-sweep)
drives a null handle into all **35** distinct OCCT entry points these functions call, each in a
forked child so a crash is reported rather than ending the run:

**24 crash with an uncatchable signal. 5 raise a catchable `Standard_Failure`. 6 return normally.**

`Geom2dAdaptor_Curve` is in the mild group. `new Geom_TrimmedCurve`, `new Geom_OffsetCurve`,
`new Geom_RectangularTrimmedSurface`, `ShapeAnalysis_Curve::IsPeriodic`, `BRepLib_MakeEdge2d`,
`GeomConvert::CurveToBSplineCurve`, `BRepAlgoAPI_Section` and `ShapeConstruct_Curve::ConvertToBSpline`
are not. `ShapeAnalysis_Surface` is the one to remember: constructing it from a null handle returns
normally and the crash lands at the first `ValueOfUV`, so a probe that only constructed it would
have cleared that entire 11-function family as safe.

## Three findings the issue's own reproduction recipe could not reach

It walks scalar parameters only.

- **`OCCTCurve2DPointAt` is a dereference site** (`curve->curve->D0(t, pt)`, no guard at all) that
  #478's sweep missed outright. Fixed here rather than left for a third pass.
- **Five functions take an array of wrappers.** `OCCTGeomFillGordon` and `OCCTGeomFillGordonReport`
  checked `!profiles[i]` and passed the handle unchecked. `OCCTConcatenateCurves3D`,
  `OCCTConcatenateCurves2D` and `OCCTCurve3DJoinCurves` checked `curves[i]` inside the loop but
  never `curves[0]`, the element each of them handles separately to seed its accumulator.
- **`OCCTBridge_ProjLib_NLPlate.mm`** was missing from the issue's file list.

## The deliverable is the invariant, so it is checked rather than remembered

`Scripts/check-null-handle-guards.py` is the same walk that produced both #478's list and this one,
committed alongside `check-bridge-index.py` and gating on exit status. `CLAUDE.md`'s "Adding a New
Wrapped Operation" now points at both the guard and the checker.

Proven to catch regressions rather than merely pass, against two injected defects:

| injected | reported |
|---|---|
| revert one guard (`OCCTSurfaceCreateRectangularTrimmed`) | yes, exit 1 |
| add a new function checking only the pointer | yes, exit 1 |
| fixed tree | nothing, exit 0 |

`DownCast(x->handle)` is excluded as a use, since down-casting a null handle returns null and every
such site checks the cast result. Without that exclusion the walk reports several hundred false
positives.

## Scope

**Still latent.** #478's classification of all 228 wrapper-producing sites holds, so no bridge call
can hand back a wrapper carrying a null handle today. What changed is the measured cost of weakening
that invariant later: for 24 of these 35 entry points the first symptom is a SIGSEGV with no
diagnostic trail.

**Deliberately not fixed here:** several functions in the `Gcc` / `IntAna2d` families write to
`out[i]` without checking `out` or bounding `max`. Real, but a different invariant from the geometry
handle, and fixing only the three that this PR happens to touch would leave the family less
consistent than it is now.

**Not a kernel change**, so no `OCCT.xcframework` rebuild. `OCCTBridge.xcframework` is unaffected by
this PR (it is rebuilt on release, and `Sources/OCCTBridge/src/*.mm` changed here).

## Verification

- `swift build` clean
- `swift test`: **4910 tests in 1353 suites, all passing**
- `python3 Scripts/check-null-handle-guards.py`: clean, exit 0
- `python3 Scripts/count-operations.py`: 4299, matching README and API_REFERENCE (no API change)
- `python3 Scripts/check-bridge-index.py`: 128 stale, unchanged from the base branch (pre-existing,
  see #565)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
