### PR TITLE
fix(#553): one radius contract for the 2D solvers, decided per family by measurement

### DIFF
--- a/Scripts/repro/553-gcc-zero-radius-circle/README.md
+++ b/Scripts/repro/553-gcc-zero-radius-circle/README.md
@@ -1,0 +1,99 @@
+# OCCTSwift#553 probe — a zero-radius circle handed to the 2D solvers
+
+`occt_553_probe.mm` measures what every 2D solver family in `OCCTBridge_Geom2d.mm` does when one of
+its circle arguments has radius 0, and compares that against OCCT's own point overload of the same
+query. It is a measurement, not a crash reproducer: nothing here crashes, and that is the point.
+Every one of these calls returns something that reads as an answer.
+
+No fixture files and no kernel patch. Build and run:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/553-gcc-zero-radius-circle/occt_553_probe.mm -o /tmp/occt_553_probe
+/tmp/occt_553_probe
+```
+
+## The question
+
+#514 guarded the 2D conic *construction* sites and deliberately stopped there. About 25 more sites
+in the same file build a `gp_Circ2d` from caller-supplied doubles, but those circles are inputs to a
+tangency, bisector, intersection or extrema solver rather than geometry being returned. A
+zero-radius circle handed to such a solver is geometrically a point, and several of these solvers
+have a documented, meaningful answer for a point argument. Rejecting it outright would remove a
+query some callers might legitimately be making — unlike the construction sites, where a zero-radius
+circle can only produce a degenerate result.
+
+So the decision had to be made per family, on measurement.
+
+## What the probe found
+
+Negative was never the gap. `gp_Circ2d`'s constructor is `constexpr` in the header, so its
+`Standard_ConstructionError_Raise_if(theRadius < 0.0, ...)` **does** run in a bridge translation
+unit — the same finding #514 made for `gp_Elips2d`, confirmed again here — and the existing
+`catch (...)` already turns a negative radius into an empty result. `GC_MakeCircle2d` rejects a
+negative radius through `gce_NegativeRadius`, a status rather than a macro, so `No_Exception` does
+not void that either. **The gap is exactly zero.**
+
+And no family answers the point question:
+
+| family | zero-radius argument gives | the point overload gives |
+|---|---|---|
+| `GccAna_Circ2dBisec` | 4 solutions, each duplicated. With **both** radii 0: a line plus two hyperbolas of **major radius 0** | `GccAna_CircPnt2dBisec` gives 2; `GccAna_Pnt2dBisec` gives the perpendicular bisector line |
+| `GccAna_CircPnt2dBisec` | 2 hyperbolas of **major radius 0** | `GccAna_Pnt2dBisec` gives a **line** — the returned *type* is wrong, not just duplicated |
+| `GccAna_CircLin2dBisec` | the point overload's parabola, twice | `GccAna_LinPnt2dBisec` gives it once |
+| `GccAna_Lin2dTanPar` | the point overload's line, twice | the `gp_Pnt2d` overload gives it once |
+| `GccAna_Lin2dTanPer` | the point overload's line, twice | the `gp_Pnt2d` overload gives it once |
+| `GccAna_Lin2d2Tan` | the point overload's line, twice | the point/point overload gives it once |
+| `GccAna_Circ2d3Tan`, 3 circles | 8 solutions: the point overload's 4, each twice | 4, all tangency residuals < 1e-14 |
+| `GccAna_Circ2d3Tan`, 2 circles + point | 4 solutions holding 2 distinct circles | — |
+| `GccAna_Circ2d3Tan`, 1 circle + 2 points | **0 solutions** | the all-points overload finds the circumscribed circle |
+| `Extrema_ExtPElC2d` | **0 extrema** | — |
+| `Extrema_ExtElC2d` | the right distance, twice | — |
+| `IntAna2d_AnaIntersection` | the right point, with `ParamOnSecond()` **NaN** | — |
+
+The duplication has a cause worth recording: tangency to a circle of radius 0 satisfies the
+enclosing and the outside case simultaneously, so the solver enumerates each solution once per
+qualifier. The two hyperbolas of major radius 0 are the same degenerate conic
+`occtValidHyperbolaRadii` refuses to construct on the other side of this same file, so the bisector
+families were handing back curves the construction API would not accept.
+
+Every one of those families already has a point entry point wrapped in `OCCTBridge_Geom2d.mm`
+(`OCCTGccAnaPnt2dBisec`, `OCCTGccAnaLinPnt2dBisec`, `OCCTGccAnaLin2dTanParPt`,
+`OCCTGccAnaLin2dTanPerPtLin`, `OCCTGccAnaCirc2d3TanPoints`, `OCCTGccAnaLin2d2TanPntPnt`, and the
+mixed circle/point overloads). Naming a point as a point already has a spelling, and a degenerate
+circle is not it. So: **guard, in every family** — a decision reached per family, which happened to
+converge.
+
+## Two more radius contracts in the same file
+
+The probe also covers the other two things a caller can mean by "radius" here.
+
+**The radius of the circle the solver must find.** `GccAna_Circ2d2TanRad` and
+`GccAna_Circ2dTanOnRad` asked for radius 0 return solution circles of radius 0. Three bridge entry
+points already rejected that inline (`OCCTGccCircle2d2TanRad`, `OCCTGccCircle2dTanPtRad`,
+`OCCTGccCircle2d2PtRad`); four siblings did not.
+
+**A circle this file is asked to build.** Four sites #514 did not reach.
+`BRepBuilderAPI_MakeEdge2d` reports `IsDone()` for a zero-radius arc and returns a zero-length edge
+with both vertices at the centre. `GC_MakeCircle2d(ax, 0)` succeeds with `gce_Done`. And the
+parallel constructor takes the *absolute value* of `radius + dist` rather than refusing an offset
+that reaches or passes the centre:
+
+```
+GC_MakeCircle2d(r=5, dist=-5)   IsDone(), radius 0
+GC_MakeCircle2d(r=5, dist=-6)   IsDone(), radius 1     <-- not the circle asked for
+```
+
+so `OCCTCurve2DMakeCircleParallel` checks the offset as well as the radius.
+
+## Deliberately not changed
+
+`extractBisecSolution` has a `case` for each of `GccInt_Lin`/`Cir`/`Ell`/`Hpr`/`Par` and a `default`
+that writes `(0, 0)`, so a `GccInt_Pnt` solution would lose its coordinates. Section 13 of the probe
+looks for one: identical circles, concentric circles, externally and internally tangent circles,
+crossing circles, a point on the circle, a point at the centre. None of them produces a `GccInt_Pnt`,
+and neither does any zero-radius case in sections 1–3. Left alone rather than fixed speculatively —
+it is a `default` branch with no measured way to reach it, not an observed defect.

--- a/Scripts/repro/553-gcc-zero-radius-circle/occt_553_probe.mm
+++ b/Scripts/repro/553-gcc-zero-radius-circle/occt_553_probe.mm
@@ -1,0 +1,732 @@
+// OCCTSwift #553 probe: what every 2D solver family does with a zero-radius circle argument.
+//
+// The question the issue poses: a zero-radius circle handed to a tangency / bisector / intersection
+// solver is geometrically a point, and several of these solvers have a documented point overload.
+// So does OCCT answer the point question when it is handed a degenerate circle, or does it answer
+// nothing, or does it answer garbage? The decision (guard, or document "radius 0 means point") has
+// to be per family, and it has to be measured.
+//
+// For every family this runs three cases:
+//   control  a valid circle, so the family is known to work at all with these arguments
+//   zero     the same circle with radius 0
+//   point    OCCT's own point overload of the same query, same centre, where one exists
+// and then checks the zero case's solutions against what the point reading would require.
+//
+// Build:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/553-gcc-zero-radius-circle/occt_553_probe.mm -o /tmp/occt_553_probe
+//   /tmp/occt_553_probe
+
+#include <gp_Pnt2d.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Lin2d.hxx>
+#include <gp_Circ2d.hxx>
+#include <gp_Ax2d.hxx>
+#include <gp_Ax22d.hxx>
+#include <gp_Elips2d.hxx>
+#include <gp_Hypr2d.hxx>
+#include <gp_Parab2d.hxx>
+
+#include <GccAna_Circ2dBisec.hxx>
+#include <GccAna_CircLin2dBisec.hxx>
+#include <GccAna_CircPnt2dBisec.hxx>
+#include <GccAna_Pnt2dBisec.hxx>
+#include <GccAna_LinPnt2dBisec.hxx>
+#include <GccAna_Lin2dTanPar.hxx>
+#include <GccAna_Lin2dTanPer.hxx>
+#include <GccAna_Lin2d2Tan.hxx>
+#include <GccAna_Circ2d3Tan.hxx>
+#include <GccAna_Circ2d2TanRad.hxx>
+#include <GccAna_Circ2dTanOnRad.hxx>
+#include <GccEnt_QualifiedCirc.hxx>
+#include <GccEnt_QualifiedLin.hxx>
+#include <GccInt_Bisec.hxx>
+#include <GccInt_IType.hxx>
+
+#include <IntAna2d_AnaIntersection.hxx>
+#include <IntAna2d_IntPoint.hxx>
+#include <Extrema_ExtElC2d.hxx>
+#include <Extrema_ExtPElC2d.hxx>
+#include <Extrema_POnCurv2d.hxx>
+
+#include <GC_MakeCircle2d.hxx>
+#include <BRepBuilderAPI_MakeEdge2d.hxx>
+#include <BRep_Tool.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopExp.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <Geom2d_Circle.hxx>
+#include <GProp_GProps.hxx>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+static int gFailures = 0;
+
+static void head(const char* title) {
+    printf("\n============================================================\n%s\n"
+           "============================================================\n", title);
+}
+
+static const char* bisecTypeName(GccInt_IType t) {
+    switch (t) {
+        case GccInt_Lin: return "Line";
+        case GccInt_Cir: return "Circle";
+        case GccInt_Ell: return "Ellipse";
+        case GccInt_Par: return "Parabola";
+        case GccInt_Hpr: return "Hyperbola";
+        case GccInt_Pnt: return "Point";
+    }
+    return "?";
+}
+
+// A one-line description of a bisector solution, plus whether the bridge's own extractor
+// (OCCTBridge_Geom2d.mm extractBisecSolution) can carry it. That extractor has a case for
+// Lin/Cir/Ell/Hpr/Par and a default that zeroes everything, so GccInt_Pnt loses its coordinates.
+static std::string describeBisec(const Handle(GccInt_Bisec)& b, bool* outBridgeLosesIt) {
+    char buf[256];
+    GccInt_IType t = b->ArcType();
+    *outBridgeLosesIt = (t == GccInt_Pnt);
+    switch (t) {
+        case GccInt_Lin: {
+            gp_Lin2d l = b->Line();
+            snprintf(buf, sizeof buf, "Line      at (%.4f, %.4f) dir (%.4f, %.4f)",
+                     l.Location().X(), l.Location().Y(), l.Direction().X(), l.Direction().Y());
+            break;
+        }
+        case GccInt_Cir: {
+            gp_Circ2d c = b->Circle();
+            snprintf(buf, sizeof buf, "Circle    at (%.4f, %.4f) r %.4f",
+                     c.Location().X(), c.Location().Y(), c.Radius());
+            break;
+        }
+        case GccInt_Ell: {
+            gp_Elips2d e = b->Ellipse();
+            snprintf(buf, sizeof buf, "Ellipse   at (%.4f, %.4f) major %.4f minor %.4f",
+                     e.Location().X(), e.Location().Y(), e.MajorRadius(), e.MinorRadius());
+            break;
+        }
+        case GccInt_Hpr: {
+            gp_Hypr2d h = b->Hyperbola();
+            snprintf(buf, sizeof buf, "Hyperbola at (%.4f, %.4f) major %.4f minor %.4f",
+                     h.Location().X(), h.Location().Y(), h.MajorRadius(), h.MinorRadius());
+            break;
+        }
+        case GccInt_Par: {
+            gp_Parab2d p = b->Parabola();
+            snprintf(buf, sizeof buf, "Parabola  at (%.4f, %.4f) focal %.4f",
+                     p.Location().X(), p.Location().Y(), p.Focal());
+            break;
+        }
+        case GccInt_Pnt: {
+            gp_Pnt2d p = b->Point();
+            snprintf(buf, sizeof buf, "Point     at (%.4f, %.4f)", p.X(), p.Y());
+            break;
+        }
+        default:
+            snprintf(buf, sizeof buf, "unknown");
+    }
+    return std::string(buf);
+}
+
+template <class Solver>
+static void dumpBisec(const char* label, Solver& s) {
+    if (!s.IsDone()) { printf("  %-22s IsDone() false\n", label); return; }
+    int n = s.NbSolutions();
+    printf("  %-22s IsDone() true, %d solution(s)\n", label, n);
+    for (int i = 1; i <= n; i++) {
+        bool lost = false;
+        std::string d = describeBisec(s.ThisSolution(i), &lost);
+        printf("      [%d] %s%s\n", i, d.c_str(), lost ? "   <-- bridge writes (0,0)" : "");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. GccAna_Circ2dBisec  (bridge: OCCTGccAnaCirc2dBisec)
+//    Point overloads in the same family: GccAna_CircPnt2dBisec, GccAna_Pnt2dBisec.
+// ---------------------------------------------------------------------------
+static void probeCirc2dBisec() {
+    head("1. GccAna_Circ2dBisec - bisector of two circles");
+    gp_Pnt2d c1(0, 0), c2(10, 0);
+    gp_Circ2d big1(gp_Ax22d(c1, gp_Dir2d(1, 0)), 3.0);
+    gp_Circ2d big2(gp_Ax22d(c2, gp_Dir2d(1, 0)), 2.0);
+    gp_Circ2d zero1(gp_Ax22d(c1, gp_Dir2d(1, 0)), 0.0);
+    gp_Circ2d zero2(gp_Ax22d(c2, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_Circ2dBisec control(big1, big2);         dumpBisec("control r=3, r=2", control);
+    GccAna_Circ2dBisec oneZero(zero1, big2);        dumpBisec("first r=0", oneZero);
+    GccAna_Circ2dBisec bothZero(zero1, zero2);      dumpBisec("both r=0", bothZero);
+
+    GccAna_CircPnt2dBisec pointOverload(big2, c1);  dumpBisec("point overload", pointOverload);
+    GccAna_Pnt2dBisec twoPoints(c1, c2);
+    printf("  %-22s IsDone() %s, HasSolution() %s\n", "two-point overload",
+           twoPoints.IsDone() ? "true" : "false",
+           twoPoints.IsDone() && twoPoints.HasSolution() ? "true" : "false");
+    if (twoPoints.IsDone() && twoPoints.HasSolution()) {
+        gp_Lin2d l = twoPoints.ThisSolution();
+        printf("      [1] Line      at (%.4f, %.4f) dir (%.4f, %.4f)\n",
+               l.Location().X(), l.Location().Y(), l.Direction().X(), l.Direction().Y());
+    }
+    printf("  NOTE the r=0 answer is a *conic* bisector, the point overload's is a hyperbola branch;\n"
+           "       the two-point overload gives the perpendicular bisector line.\n");
+}
+
+// ---------------------------------------------------------------------------
+// 2. GccAna_CircLin2dBisec  (bridge: OCCTGccAnaCircLin2dBisec)
+//    Point overload: GccAna_LinPnt2dBisec.
+// ---------------------------------------------------------------------------
+static void probeCircLin2dBisec() {
+    head("2. GccAna_CircLin2dBisec - bisector of a circle and a line");
+    gp_Pnt2d c(0, 5);
+    gp_Lin2d line(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+    gp_Circ2d big(gp_Ax22d(c, gp_Dir2d(1, 0)), 2.0);
+    gp_Circ2d zero(gp_Ax22d(c, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_CircLin2dBisec control(big, line);   dumpBisec("control r=2", control);
+    GccAna_CircLin2dBisec degen(zero, line);    dumpBisec("r=0", degen);
+
+    GccAna_LinPnt2dBisec pointOverload(line, c);
+    printf("  %-22s IsDone() %s (one solution)\n", "point overload",
+           pointOverload.IsDone() ? "true" : "false");
+    if (pointOverload.IsDone()) {
+        bool lost = false;
+        printf("      [1] %s\n", describeBisec(pointOverload.ThisSolution(), &lost).c_str());
+    }
+    printf("  NOTE a point/line bisector is one parabola. Compare with the r=0 answer above.\n");
+}
+
+// ---------------------------------------------------------------------------
+// 3. GccAna_CircPnt2dBisec  (bridge: OCCTGccAnaCircPnt2dBisec)
+//    Point overload: GccAna_Pnt2dBisec.
+// ---------------------------------------------------------------------------
+static void probeCircPnt2dBisec() {
+    head("3. GccAna_CircPnt2dBisec - bisector of a circle and a point");
+    gp_Pnt2d c(0, 0), p(6, 0);
+    gp_Circ2d big(gp_Ax22d(c, gp_Dir2d(1, 0)), 2.0);
+    gp_Circ2d zero(gp_Ax22d(c, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_CircPnt2dBisec control(big, p);  dumpBisec("control r=2", control);
+    GccAna_CircPnt2dBisec degen(zero, p);   dumpBisec("r=0", degen);
+
+    GccAna_Pnt2dBisec pointOverload(c, p);
+    printf("  %-22s IsDone() %s, HasSolution() %s\n", "point overload",
+           pointOverload.IsDone() ? "true" : "false",
+           pointOverload.IsDone() && pointOverload.HasSolution() ? "true" : "false");
+    if (pointOverload.IsDone() && pointOverload.HasSolution()) {
+        gp_Lin2d l = pointOverload.ThisSolution();
+        printf("      [1] Line      at (%.4f, %.4f) dir (%.4f, %.4f)\n",
+               l.Location().X(), l.Location().Y(), l.Direction().X(), l.Direction().Y());
+    }
+    printf("  NOTE the point/point answer is the perpendicular bisector at x = 3.\n");
+}
+
+// ---------------------------------------------------------------------------
+// 4/5. GccAna_Lin2dTanPar / GccAna_Lin2dTanPer with a qualified circle
+//      (bridge: OCCTGccAnaLin2dTanParCirc, OCCTGccAnaLin2dTanPerCircLin)
+//      Both have a gp_Pnt2d overload taking the point directly.
+// ---------------------------------------------------------------------------
+static double distPointToLine(const gp_Pnt2d& p, const gp_Lin2d& l) {
+    gp_Pnt2d o = l.Location();
+    gp_Dir2d d = l.Direction();
+    double vx = p.X() - o.X(), vy = p.Y() - o.Y();
+    return std::fabs(vx * d.Y() - vy * d.X());
+}
+
+static void probeLin2dTanPar() {
+    head("4. GccAna_Lin2dTanPar - line tangent to a circle, parallel to a line");
+    gp_Pnt2d c(0, 0);
+    gp_Lin2d ref(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+    gp_Circ2d big(gp_Ax22d(c, gp_Dir2d(1, 0)), 4.0);
+    gp_Circ2d zero(gp_Ax22d(c, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_Lin2dTanPar control(GccEnt_QualifiedCirc(big, GccEnt_unqualified), ref);
+    printf("  control r=4          IsDone() %s, %d solution(s)\n",
+           control.IsDone() ? "true" : "false", control.IsDone() ? control.NbSolutions() : 0);
+    for (int i = 1; control.IsDone() && i <= control.NbSolutions(); i++) {
+        gp_Lin2d s = control.ThisSolution(i);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to centre %.6f (want 4)\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(),
+               distPointToLine(c, s));
+    }
+
+    GccAna_Lin2dTanPar degen(GccEnt_QualifiedCirc(zero, GccEnt_unqualified), ref);
+    printf("  r=0                  IsDone() %s, %d solution(s)\n",
+           degen.IsDone() ? "true" : "false", degen.IsDone() ? degen.NbSolutions() : 0);
+    for (int i = 1; degen.IsDone() && i <= degen.NbSolutions(); i++) {
+        gp_Lin2d s = degen.ThisSolution(i);
+        double d = distPointToLine(c, s);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to centre %.6f (point reading wants 0)%s\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(), d,
+               d < 1e-9 ? "" : "   <-- NOT through the centre");
+    }
+
+    GccAna_Lin2dTanPar pointOverload(c, ref);
+    printf("  point overload       IsDone() %s, %d solution(s)\n",
+           pointOverload.IsDone() ? "true" : "false",
+           pointOverload.IsDone() ? pointOverload.NbSolutions() : 0);
+    for (int i = 1; pointOverload.IsDone() && i <= pointOverload.NbSolutions(); i++) {
+        gp_Lin2d s = pointOverload.ThisSolution(i);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to point %.6f\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(),
+               distPointToLine(c, s));
+    }
+}
+
+static void probeLin2dTanPer() {
+    head("5. GccAna_Lin2dTanPer - line tangent to a circle, perpendicular to a line");
+    gp_Pnt2d c(0, 0);
+    gp_Lin2d ref(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+    gp_Circ2d big(gp_Ax22d(c, gp_Dir2d(1, 0)), 4.0);
+    gp_Circ2d zero(gp_Ax22d(c, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_Lin2dTanPer control(GccEnt_QualifiedCirc(big, GccEnt_unqualified), ref);
+    printf("  control r=4          IsDone() %s, %d solution(s)\n",
+           control.IsDone() ? "true" : "false", control.IsDone() ? control.NbSolutions() : 0);
+    for (int i = 1; control.IsDone() && i <= control.NbSolutions(); i++) {
+        gp_Lin2d s = control.ThisSolution(i);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to centre %.6f (want 4)\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(),
+               distPointToLine(c, s));
+    }
+
+    GccAna_Lin2dTanPer degen(GccEnt_QualifiedCirc(zero, GccEnt_unqualified), ref);
+    printf("  r=0                  IsDone() %s, %d solution(s)\n",
+           degen.IsDone() ? "true" : "false", degen.IsDone() ? degen.NbSolutions() : 0);
+    for (int i = 1; degen.IsDone() && i <= degen.NbSolutions(); i++) {
+        gp_Lin2d s = degen.ThisSolution(i);
+        double d = distPointToLine(c, s);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to centre %.6f (point reading wants 0)%s\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(), d,
+               d < 1e-9 ? "" : "   <-- NOT through the centre");
+    }
+
+    GccAna_Lin2dTanPer pointOverload(c, ref);
+    printf("  point overload       IsDone() %s, %d solution(s)\n",
+           pointOverload.IsDone() ? "true" : "false",
+           pointOverload.IsDone() ? pointOverload.NbSolutions() : 0);
+    for (int i = 1; pointOverload.IsDone() && i <= pointOverload.NbSolutions(); i++) {
+        gp_Lin2d s = pointOverload.ThisSolution(i);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to point %.6f\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(),
+               distPointToLine(c, s));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. GccAna_Circ2d3Tan - circle tangent to three circles / two circles + point / circle + 2 points
+//    (bridge: OCCTGccAnaCirc2d3TanCircles, OCCTGccAnaCirc2d2CirclesPoint,
+//             OCCTGccAnaCirc2dCircle2Points)
+//    OCCT ships every mixed overload, including the all-points one.
+// ---------------------------------------------------------------------------
+static void reportCirc3Tan(const char* label, GccAna_Circ2d3Tan& s,
+                           const gp_Pnt2d* checkCentre, double checkRadius) {
+    printf("  %-24s IsDone() %s, %d solution(s)\n", label,
+           s.IsDone() ? "true" : "false", s.IsDone() ? s.NbSolutions() : 0);
+    for (int i = 1; s.IsDone() && i <= s.NbSolutions(); i++) {
+        gp_Circ2d sol = s.ThisSolution(i);
+        printf("      [%d] centre (%.6f, %.6f) r %.6f", i,
+               sol.Location().X(), sol.Location().Y(), sol.Radius());
+        if (checkCentre) {
+            // Tangency to a circle of radius R: |d - r| == R (outer) or d + R == r (enclosing).
+            // At R = 0 both collapse to "the solution passes through the point": |d - r| == 0.
+            double dx = sol.Location().X() - checkCentre->X();
+            double dy = sol.Location().Y() - checkCentre->Y();
+            double d = std::sqrt(dx * dx + dy * dy);
+            double err = std::fabs(std::fabs(d - sol.Radius()) - checkRadius);
+            printf("   tangency residual %.3e%s", err, err < 1e-7 ? "" : "   <-- NOT tangent");
+        }
+        printf("\n");
+    }
+}
+
+static void probeCirc2d3Tan() {
+    head("6. GccAna_Circ2d3Tan - circle tangent to three circles");
+    gp_Pnt2d a(0, 0), b(10, 0), c(5, 8);
+    gp_Circ2d ca(gp_Ax2d(a, gp_Dir2d(1, 0)), 2.0);
+    gp_Circ2d cb(gp_Ax2d(b, gp_Dir2d(1, 0)), 2.0);
+    gp_Circ2d cc(gp_Ax2d(c, gp_Dir2d(1, 0)), 2.0);
+    gp_Circ2d za(gp_Ax2d(a, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_Circ2d3Tan control(GccEnt_QualifiedCirc(ca, GccEnt_unqualified),
+                              GccEnt_QualifiedCirc(cb, GccEnt_unqualified),
+                              GccEnt_QualifiedCirc(cc, GccEnt_unqualified), 1e-7);
+    reportCirc3Tan("control r=2,2,2", control, &a, 2.0);
+
+    GccAna_Circ2d3Tan oneZero(GccEnt_QualifiedCirc(za, GccEnt_unqualified),
+                              GccEnt_QualifiedCirc(cb, GccEnt_unqualified),
+                              GccEnt_QualifiedCirc(cc, GccEnt_unqualified), 1e-7);
+    reportCirc3Tan("first r=0 (vs point a)", oneZero, &a, 0.0);
+
+    GccAna_Circ2d3Tan pointOverload(GccEnt_QualifiedCirc(cb, GccEnt_unqualified),
+                                    GccEnt_QualifiedCirc(cc, GccEnt_unqualified),
+                                    a, 1e-7);
+    reportCirc3Tan("point overload", pointOverload, &a, 0.0);
+
+    printf("\n  --- two circles + a point (bridge OCCTGccAnaCirc2d2CirclesPoint) ---\n");
+    GccAna_Circ2d3Tan twoZero(GccEnt_QualifiedCirc(za, GccEnt_unqualified),
+                              GccEnt_QualifiedCirc(cb, GccEnt_unqualified),
+                              c, 1e-7);
+    reportCirc3Tan("first r=0", twoZero, &a, 0.0);
+
+    printf("\n  --- one circle + two points (bridge OCCTGccAnaCirc2dCircle2Points) ---\n");
+    GccAna_Circ2d3Tan oneZeroTwoPts(GccEnt_QualifiedCirc(za, GccEnt_unqualified), b, c, 1e-7);
+    reportCirc3Tan("r=0", oneZeroTwoPts, &a, 0.0);
+    GccAna_Circ2d3Tan allPoints(a, b, c, 1e-7);
+    reportCirc3Tan("all-points overload", allPoints, &a, 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// 7. GccAna_Lin2d2Tan - line tangent to a circle and through a point
+//    (bridge: OCCTGccAnaLin2d2TanCircPnt). Point overload: (pnt1, pnt2, tol).
+// ---------------------------------------------------------------------------
+static void probeLin2d2Tan() {
+    head("7. GccAna_Lin2d2Tan - line tangent to a circle, through a point");
+    gp_Pnt2d c(0, 0), p(10, 0);
+    gp_Circ2d big(gp_Ax2d(c, gp_Dir2d(1, 0)), 3.0);
+    gp_Circ2d zero(gp_Ax2d(c, gp_Dir2d(1, 0)), 0.0);
+
+    GccAna_Lin2d2Tan control(GccEnt_QualifiedCirc(big, GccEnt_unqualified), p, 1e-7);
+    printf("  control r=3          IsDone() %s, %d solution(s)\n",
+           control.IsDone() ? "true" : "false", control.IsDone() ? control.NbSolutions() : 0);
+    for (int i = 1; control.IsDone() && i <= control.NbSolutions(); i++) {
+        gp_Lin2d s = control.ThisSolution(i);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to centre %.6f (want 3)\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(),
+               distPointToLine(c, s));
+    }
+
+    GccAna_Lin2d2Tan degen(GccEnt_QualifiedCirc(zero, GccEnt_unqualified), p, 1e-7);
+    printf("  r=0                  IsDone() %s, %d solution(s)\n",
+           degen.IsDone() ? "true" : "false", degen.IsDone() ? degen.NbSolutions() : 0);
+    for (int i = 1; degen.IsDone() && i <= degen.NbSolutions(); i++) {
+        gp_Lin2d s = degen.ThisSolution(i);
+        double d = distPointToLine(c, s);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)  dist to centre %.6f%s\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y(), d,
+               d < 1e-9 ? "   (through the centre, matches the point reading)" : "   <-- NOT through the centre");
+    }
+
+    GccAna_Lin2d2Tan pointOverload(c, p, 1e-7);
+    printf("  point overload       IsDone() %s, %d solution(s)\n",
+           pointOverload.IsDone() ? "true" : "false",
+           pointOverload.IsDone() ? pointOverload.NbSolutions() : 0);
+    for (int i = 1; pointOverload.IsDone() && i <= pointOverload.NbSolutions(); i++) {
+        gp_Lin2d s = pointOverload.ThisSolution(i);
+        printf("      [%d] at (%.4f, %.4f) dir (%.4f, %.4f)\n",
+               i, s.Location().X(), s.Location().Y(), s.Direction().X(), s.Direction().Y());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8. IntAna2d_AnaIntersection - line/circle and circle/circle
+//    (bridge: OCCTIntAna2dLinCirc, OCCTIntAna2dCircCirc). No point overload exists:
+//    "does this point lie on that curve" is not an intersection query OCCT offers here.
+// ---------------------------------------------------------------------------
+static void reportIntAna(const char* label, IntAna2d_AnaIntersection& inter) {
+    printf("  %-30s IsDone() %s, IsEmpty() %s", label,
+           inter.IsDone() ? "true" : "false",
+           inter.IsDone() && inter.IsEmpty() ? "true" : "false");
+    if (!inter.IsDone()) { printf("\n"); return; }
+    if (inter.IsEmpty()) { printf(", 0 point(s)\n"); return; }
+    printf(", %d point(s), IdenticalElements() %s\n", inter.NbPoints(),
+           inter.IdenticalElements() ? "true" : "false");
+    for (int i = 1; i <= inter.NbPoints(); i++) {
+        const IntAna2d_IntPoint& pt = inter.Point(i);
+        printf("      [%d] (%.6f, %.6f) param1 %.6f param2 %.6f\n", i,
+               pt.Value().X(), pt.Value().Y(), pt.ParamOnFirst(),
+               pt.SecondIsImplicit() ? 0.0 : pt.ParamOnSecond());
+    }
+}
+
+static void probeIntAna2d() {
+    head("8. IntAna2d_AnaIntersection - line/circle and circle/circle");
+    gp_Lin2d onCentre(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));     // passes through (0,0)
+    gp_Lin2d offCentre(gp_Pnt2d(0, 1), gp_Dir2d(1, 0));    // misses (0,0)
+    gp_Circ2d big(gp_Ax22d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 3.0);
+    gp_Circ2d zero(gp_Ax22d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 0.0);
+    gp_Circ2d other(gp_Ax22d(gp_Pnt2d(3, 0), gp_Dir2d(1, 0)), 3.0);  // passes through (0,0)
+    gp_Circ2d far(gp_Ax22d(gp_Pnt2d(20, 0), gp_Dir2d(1, 0)), 3.0);   // does not
+
+    IntAna2d_AnaIntersection a(onCentre, big);      reportIntAna("control line x circle r=3", a);
+    IntAna2d_AnaIntersection b(onCentre, zero);     reportIntAna("line THROUGH the r=0 centre", b);
+    IntAna2d_AnaIntersection c(offCentre, zero);    reportIntAna("line MISSING the r=0 centre", c);
+    IntAna2d_AnaIntersection d(zero, other);        reportIntAna("r=0 x circle THROUGH centre", d);
+    IntAna2d_AnaIntersection e(zero, far);          reportIntAna("r=0 x circle missing centre", e);
+    IntAna2d_AnaIntersection f(zero, zero);         reportIntAna("r=0 x the same r=0", f);
+    printf("  NOTE the point reading wants exactly one intersection when the point lies on the other\n"
+           "       element and none when it does not.\n");
+}
+
+// ---------------------------------------------------------------------------
+// 9. Extrema_ExtElC2d / Extrema_ExtPElC2d against a zero-radius circle
+//    (bridge: OCCTExtremaExtElC2dLinCirc, OCCTExtremaExtPElC2dCirc)
+// ---------------------------------------------------------------------------
+static void probeExtrema() {
+    head("9. Extrema_ExtElC2d (line/circle) and Extrema_ExtPElC2d (point/circle)");
+    gp_Lin2d line(gp_Pnt2d(0, 10), gp_Dir2d(1, 0));
+    gp_Circ2d big(gp_Ax22d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 3.0);
+    gp_Circ2d zero(gp_Ax22d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 0.0);
+
+    {
+        Extrema_ExtElC2d ext(line, big, 1e-7);
+        printf("  line x circle r=3    IsDone() %s, %d extremum/a\n",
+               ext.IsDone() ? "true" : "false", ext.IsDone() ? ext.NbExt() : 0);
+        for (int i = 1; ext.IsDone() && i <= ext.NbExt(); i++)
+            printf("      [%d] sqDist %.6f (want 49 and 169)\n", i, ext.SquareDistance(i));
+    }
+    {
+        bool threw = false;
+        try {
+            Extrema_ExtElC2d ext(line, zero, 1e-7);
+            printf("  line x circle r=0    IsDone() %s, %d extremum/a\n",
+                   ext.IsDone() ? "true" : "false", ext.IsDone() ? ext.NbExt() : 0);
+            for (int i = 1; ext.IsDone() && i <= ext.NbExt(); i++) {
+                double sq = ext.SquareDistance(i);
+                printf("      [%d] sqDist %.6f%s (point reading wants 100)\n", i, sq,
+                       std::isnan(sq) ? "   <-- NaN" : "");
+            }
+        } catch (...) { threw = true; }
+        if (threw) printf("  line x circle r=0    threw\n");
+    }
+    {
+        Extrema_ExtPElC2d ext(gp_Pnt2d(0, 10), big, 1e-7, 0, 2 * M_PI);
+        printf("  point x circle r=3   IsDone() %s, %d extremum/a\n",
+               ext.IsDone() ? "true" : "false", ext.IsDone() ? ext.NbExt() : 0);
+        for (int i = 1; ext.IsDone() && i <= ext.NbExt(); i++)
+            printf("      [%d] sqDist %.6f (want 49 and 169)\n", i, ext.SquareDistance(i));
+    }
+    {
+        bool threw = false;
+        try {
+            Extrema_ExtPElC2d ext(gp_Pnt2d(0, 10), zero, 1e-7, 0, 2 * M_PI);
+            printf("  point x circle r=0   IsDone() %s, %d extremum/a\n",
+                   ext.IsDone() ? "true" : "false", ext.IsDone() ? ext.NbExt() : 0);
+            for (int i = 1; ext.IsDone() && i <= ext.NbExt(); i++) {
+                double sq = ext.SquareDistance(i);
+                printf("      [%d] sqDist %.6f%s (point reading wants 100)\n", i, sq,
+                       std::isnan(sq) ? "   <-- NaN" : "");
+            }
+        } catch (...) { threw = true; }
+        if (threw) printf("  point x circle r=0   threw\n");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 10. The producers: a zero-radius circle turned into an edge or a curve.
+//     (bridge: OCCTMakeEdge2dFromCircle, OCCTCurve2DMakeCircleParallel,
+//              OCCTCurve2DMakeCircleAxis, OCCTCurve2DMakeCircleCenterRadius)
+//     These return geometry, so #514's decision already applies; the question is only
+//     whether OCCT itself refuses them.
+// ---------------------------------------------------------------------------
+static void probeProducers() {
+    head("10. Producers - a zero-radius circle asked for as geometry");
+    gp_Ax2d ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+
+    {
+        gp_Circ2d zero(ax, 0.0);
+        BRepBuilderAPI_MakeEdge2d me(zero, 0, M_PI);
+        printf("  MakeEdge2d arc r=0        IsDone() %s\n", me.IsDone() ? "true" : "false");
+        if (me.IsDone()) {
+            TopoDS_Edge e = me.Edge();
+            TopoDS_Vertex v1, v2;
+            TopExp::Vertices(e, v1, v2);
+            gp_Pnt p1 = BRep_Tool::Pnt(v1), p2 = BRep_Tool::Pnt(v2);
+            printf("      vertices (%.4f, %.4f, %.4f) and (%.4f, %.4f, %.4f) - %s\n",
+                   p1.X(), p1.Y(), p1.Z(), p2.X(), p2.Y(), p2.Z(),
+                   p1.Distance(p2) < 1e-12 ? "coincident, a zero-length edge" : "distinct");
+        }
+    }
+    {
+        GC_MakeCircle2d mc(ax, 0.0);
+        printf("  GC_MakeCircle2d(ax, 0)    IsDone() %s, status %d\n",
+               mc.IsDone() ? "true" : "false", (int)mc.Status());
+        if (mc.IsDone()) printf("      radius %.6f\n", mc.Value()->Radius());
+    }
+    {
+        GC_MakeCircle2d mc(ax, -1.0);
+        printf("  GC_MakeCircle2d(ax, -1)   IsDone() %s, status %d (2 == NegativeRadius)\n",
+               mc.IsDone() ? "true" : "false", (int)mc.Status());
+        if (mc.IsDone()) printf("      radius %.6f   <-- a negative radius was accepted\n",
+                                mc.Value()->Radius());
+    }
+    {
+        gp_Circ2d base(ax, 5.0);
+        GC_MakeCircle2d mc(base, -5.0);   // parallel at distance -5: collapses to radius 0
+        printf("  GC_MakeCircle2d(r=5, -5)  IsDone() %s, status %d\n",
+               mc.IsDone() ? "true" : "false", (int)mc.Status());
+        if (mc.IsDone()) printf("      radius %.6f   <-- the offset collapsed the circle\n",
+                                mc.Value()->Radius());
+    }
+    {
+        gp_Circ2d base(ax, 5.0);
+        GC_MakeCircle2d mc(base, -6.0);   // parallel past the centre
+        printf("  GC_MakeCircle2d(r=5, -6)  IsDone() %s, status %d (2 == NegativeRadius)\n",
+               mc.IsDone() ? "true" : "false", (int)mc.Status());
+        if (mc.IsDone()) printf("      radius %.6f\n", mc.Value()->Radius());
+    }
+    {
+        gp_Circ2d zero(ax, 0.0);
+        GC_MakeCircle2d mc(zero, 3.0);    // parallel to a degenerate circle
+        printf("  GC_MakeCircle2d(r=0, +3)  IsDone() %s, status %d\n",
+               mc.IsDone() ? "true" : "false", (int)mc.Status());
+        if (mc.IsDone()) printf("      radius %.6f\n", mc.Value()->Radius());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 11. Negative radius: does gp_Circ2d's own precondition run in this translation unit?
+//     #514 measured that gp_Elips2d's does, because the constructor is constexpr in the
+//     header rather than compiled inside OCCT under No_Exception. gp_Circ2d should behave
+//     the same, which would mean the only gap is exactly zero.
+// ---------------------------------------------------------------------------
+static void probeNegative() {
+    head("11. gp_Circ2d(-1) - does the header's own precondition run here?");
+    bool threw = false;
+    double r = -999;
+    try {
+        gp_Circ2d bad(gp_Ax2d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), -1.0);
+        r = bad.Radius();
+    } catch (...) { threw = true; }
+    if (threw) {
+        printf("  gp_Circ2d(ax, -1)         threw  <-- negative is already rejected, gap is only zero\n");
+    } else {
+        printf("  gp_Circ2d(ax, -1)         accepted, Radius() %.4f   <-- negative also needs guarding\n", r);
+        gFailures++;
+    }
+    threw = false;
+    try {
+        gp_Circ2d zero(gp_Ax2d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 0.0);
+        r = zero.Radius();
+    } catch (...) { threw = true; }
+    printf("  gp_Circ2d(ax, 0)          %s\n",
+           threw ? "threw" : "accepted, this is the gap");
+}
+
+// ---------------------------------------------------------------------------
+// 12. The other radius in this file: the radius of the circle the solver is asked to
+//     CONSTRUCT, not one it is given. GccAna_Circ2d2TanRad and GccAna_Circ2dTanOnRad take it.
+//     Three bridge entry points already reject radius <= 0 outright (OCCTGccCircle2d2TanRad,
+//     OCCTGccCircle2dTanPtRad, OCCTGccCircle2d2PtRad); four siblings do not
+//     (OCCTGccAnaCirc2dTanOnRadLin, OCCTGeom2dGccCirc2dTanOnRad,
+//     OCCTGccAnaCirc2d2TanRadLineLin, OCCTGccAnaCirc2d2TanRadPntPnt).
+// ---------------------------------------------------------------------------
+static void probeRequestedRadius() {
+    head("12. A requested SOLUTION radius of 0 - GccAna_Circ2d2TanRad / Circ2dTanOnRad");
+    gp_Lin2d l1(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+    gp_Lin2d l2(gp_Pnt2d(0, 0), gp_Dir2d(0, 1));
+    gp_Lin2d onLine(gp_Pnt2d(0, 0), gp_Dir2d(1, 1));
+
+    for (double r : {2.0, 0.0, -1.0}) {
+        bool threw = false;
+        try {
+            GccAna_Circ2d2TanRad s(GccEnt_QualifiedLin(l1, GccEnt_unqualified),
+                                   GccEnt_QualifiedLin(l2, GccEnt_unqualified), r, 1e-7);
+            printf("  2TanRad(lin, lin, r=%-5.1f) IsDone() %s, %d solution(s)", r,
+                   s.IsDone() ? "true" : "false", s.IsDone() ? s.NbSolutions() : 0);
+            if (s.IsDone() && s.NbSolutions() > 0)
+                printf(", first r %.6f%s", s.ThisSolution(1).Radius(),
+                       s.ThisSolution(1).Radius() > 0 ? "" : "   <-- a degenerate solution circle");
+            printf("\n");
+        } catch (...) { threw = true; }
+        if (threw) printf("  2TanRad(lin, lin, r=%-5.1f) threw\n", r);
+    }
+    for (double r : {2.0, 0.0, -1.0}) {
+        bool threw = false;
+        try {
+            GccAna_Circ2d2TanRad s(gp_Pnt2d(0, 0), gp_Pnt2d(4, 0), r, 1e-7);
+            printf("  2TanRad(pnt, pnt, r=%-5.1f) IsDone() %s, %d solution(s)", r,
+                   s.IsDone() ? "true" : "false", s.IsDone() ? s.NbSolutions() : 0);
+            if (s.IsDone() && s.NbSolutions() > 0)
+                printf(", first r %.6f", s.ThisSolution(1).Radius());
+            printf("\n");
+        } catch (...) { threw = true; }
+        if (threw) printf("  2TanRad(pnt, pnt, r=%-5.1f) threw\n", r);
+    }
+    for (double r : {2.0, 0.0, -1.0}) {
+        bool threw = false;
+        try {
+            GccAna_Circ2dTanOnRad s(GccEnt_QualifiedLin(l1, GccEnt_unqualified), onLine, r, 1e-7);
+            printf("  TanOnRad(lin, on, r=%-5.1f) IsDone() %s, %d solution(s)", r,
+                   s.IsDone() ? "true" : "false", s.IsDone() ? s.NbSolutions() : 0);
+            if (s.IsDone() && s.NbSolutions() > 0)
+                printf(", first r %.6f%s", s.ThisSolution(1).Radius(),
+                       s.ThisSolution(1).Radius() > 0 ? "" : "   <-- a degenerate solution circle");
+            printf("\n");
+        } catch (...) { threw = true; }
+        if (threw) printf("  TanOnRad(lin, on, r=%-5.1f) threw\n", r);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 13. Is a GccInt_Pnt bisector solution reachable from VALID circles? The bridge's
+//     extractBisecSolution has no case for it and its default branch writes (0, 0), so if a
+//     point solution can come out of a well-formed pair the coordinates are lost with no
+//     zero-radius circle involved anywhere.
+// ---------------------------------------------------------------------------
+static void probePointBisec() {
+    head("13. GccInt_Pnt from valid circles - is the dropped case reachable?");
+    struct Case { const char* what; gp_Circ2d a, b; };
+    gp_Dir2d x(1, 0);
+    Case cases[] = {
+        {"identical circles",   gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 3.0),
+                                gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 3.0)},
+        {"concentric r=3, r=1", gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 3.0),
+                                gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 1.0)},
+        {"externally tangent",  gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 2.0),
+                                gp_Circ2d(gp_Ax22d(gp_Pnt2d(5, 0), x), 3.0)},
+        {"internally tangent",  gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 5.0),
+                                gp_Circ2d(gp_Ax22d(gp_Pnt2d(2, 0), x), 3.0)},
+        {"crossing",            gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 3.0),
+                                gp_Circ2d(gp_Ax22d(gp_Pnt2d(4, 0), x), 3.0)},
+    };
+    for (const Case& c : cases) {
+        GccAna_Circ2dBisec s(c.a, c.b);
+        printf("  %-22s IsDone() %s, %d solution(s)\n", c.what,
+               s.IsDone() ? "true" : "false", s.IsDone() ? s.NbSolutions() : 0);
+        for (int i = 1; s.IsDone() && i <= s.NbSolutions(); i++) {
+            bool lost = false;
+            std::string d = describeBisec(s.ThisSolution(i), &lost);
+            printf("      [%d] %s%s\n", i, d.c_str(), lost ? "   <-- bridge writes (0,0)" : "");
+        }
+    }
+    // The circle/point and circle/line families can produce one too.
+    GccAna_CircPnt2dBisec onCircle(gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 3.0), gp_Pnt2d(3, 0));
+    printf("  %-22s IsDone() %s, %d solution(s)\n", "point ON the circle",
+           onCircle.IsDone() ? "true" : "false", onCircle.IsDone() ? onCircle.NbSolutions() : 0);
+    for (int i = 1; onCircle.IsDone() && i <= onCircle.NbSolutions(); i++) {
+        bool lost = false;
+        std::string d = describeBisec(onCircle.ThisSolution(i), &lost);
+        printf("      [%d] %s%s\n", i, d.c_str(), lost ? "   <-- bridge writes (0,0)" : "");
+    }
+    GccAna_CircPnt2dBisec atCentre(gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), x), 3.0), gp_Pnt2d(0, 0));
+    printf("  %-22s IsDone() %s, %d solution(s)\n", "point AT the centre",
+           atCentre.IsDone() ? "true" : "false", atCentre.IsDone() ? atCentre.NbSolutions() : 0);
+    for (int i = 1; atCentre.IsDone() && i <= atCentre.NbSolutions(); i++) {
+        bool lost = false;
+        std::string d = describeBisec(atCentre.ThisSolution(i), &lost);
+        printf("      [%d] %s%s\n", i, d.c_str(), lost ? "   <-- bridge writes (0,0)" : "");
+    }
+}
+
+int main() {
+    printf("OCCTSwift #553 - zero-radius circle arguments to the 2D solver families\n");
+    probeNegative();
+    probeCirc2dBisec();
+    probeCircLin2dBisec();
+    probeCircPnt2dBisec();
+    probeLin2dTanPar();
+    probeLin2dTanPer();
+    probeCirc2d3Tan();
+    probeLin2d2Tan();
+    probeIntAna2d();
+    probeExtrema();
+    probeProducers();
+    probeRequestedRadius();
+    probePointBisec();
+    printf("\ndone\n");
+    return 0;
+}

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -107,6 +107,59 @@
 // live in OCCTBridge_Internal.h. #411 introduced a 2D-suffixed copy of the circle one here, which
 // is how the 2D ellipse/hyperbola/parabola factories ended up skipped by both #411 and #399's
 // otherwise-identical pass over the 3D side; #487 converged them.
+//
+// #553: the same predicate now covers the solver entry points too. A circle reaches this file's
+// solvers as a centre and a radius, and there are three separate things a caller can mean by that
+// radius, which had three different contracts:
+//
+//   1. a circle the solver is GIVEN            unchecked at 13 entry points
+//   2. the radius of the circle it must FIND   checked at 3 entry points, unchecked at 4 siblings
+//   3. a circle this file is asked to BUILD    checked at 6 entry points (#514), unchecked at 4
+//
+// Negative is not the gap: gp_Circ2d's constructor is constexpr in the header, so its
+// Standard_ConstructionError_Raise_if does run in a bridge translation unit (the same finding as
+// #514's, measured again for gp_Circ2d) and the existing catch already turns it into an empty
+// result. GC_MakeCircle2d rejects a negative radius through gce_NegativeRadius, a status rather
+// than a macro, so No_Exception does not void it either. The gap is exactly zero.
+//
+// Case 1 is the one the issue held open, because a zero-radius circle handed to a tangency solver
+// is geometrically a point and several of these solvers have a documented answer for a point. The
+// probe in Scripts/repro/553-gcc-zero-radius-circle ran every family against a zero-radius
+// argument and against OCCT's own point overload of the same query. No family answers the point
+// question:
+//
+//   GccAna_Circ2dBisec        4 solutions where the point overload gives 2, each duplicated; with
+//                             both radii 0, two of the three solutions are hyperbolas of major
+//                             radius 0, which occtValidHyperbolaRadii rejects on construction
+//   GccAna_CircPnt2dBisec     2 hyperbolas of major radius 0; the point/point answer is a LINE,
+//                             so the returned type is wrong, not merely duplicated
+//   GccAna_CircLin2dBisec     the point overload's parabola, twice
+//   GccAna_Lin2dTanPar/Per    the point overload's single line, twice
+//   GccAna_Lin2d2Tan          the point overload's single line, twice
+//   GccAna_Circ2d3Tan         3 circles: the point overload's 4 solutions, each twice.
+//                             2 circles + a point: 2 distinct solutions padded to 4.
+//                             1 circle + 2 points: 0 solutions, where the all-points overload
+//                             finds the circumscribed circle - the answer is lost outright
+//   Extrema_ExtPElC2d         0 extrema; the distance the point reading asks for is lost
+//   Extrema_ExtElC2d          the right distance, twice
+//   IntAna2d_AnaIntersection  the right point, with ParamOnSecond() NaN, which the bridge writes
+//                             straight into the caller's param2
+//
+// Every one of those families already has a point entry point in this same file
+// (OCCTGccAnaPnt2dBisec, OCCTGccAnaLinPnt2dBisec, OCCTGccAnaLin2dTanParPt,
+// OCCTGccAnaLin2dTanPerPtLin, OCCTGccAnaCirc2d3TanPoints, OCCTGccAnaLin2d2TanPntPnt and the mixed
+// circle/point overloads), so the decision costs the caller no query: asking about a point has a
+// spelling, and a degenerate circle is not it. Guard, per family, on the same evidence.
+//
+// Case 2 was already decided, just not everywhere: OCCTGccCircle2d2TanRad, OCCTGccCircle2dTanPtRad
+// and OCCTGccCircle2d2PtRad each spelled `radius <= 0` inline. A requested radius of 0 makes
+// GccAna_Circ2d2TanRad and GccAna_Circ2dTanOnRad hand back solution circles of radius 0, which is
+// the degenerate geometry #514 refused to return. All seven now share one predicate.
+//
+// Case 3 is #514's decision applied to the four sites it did not reach. One of them,
+// OCCTCurve2DMakeCircleParallel, needs the offset checked as well as the radius: measured, a
+// radius-5 circle offset by -5 yields radius 0 and by -6 yields radius 1, so GC_MakeCircle2d takes
+// the absolute value rather than refusing an offset that passes through the centre.
 
 // One Geom2dAPI_ProjectPointOnCurve construction behind every entry point that wants the nearest
 // solution: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve and
@@ -865,7 +918,7 @@ int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef c1, int32_t q1,
                                OCCTGccCircleSolution* out, int32_t max) {
     if (!c1 || !c2 || !out || max <= 0) return 0;
     if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    if (radius <= 0) return 0;
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
         Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
@@ -890,7 +943,7 @@ int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef curve, int32_t qualifier,
                                 double radius, double tolerance,
                                 OCCTGccCircleSolution* out, int32_t max) {
     if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    if (radius <= 0) return 0;
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
         Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
@@ -913,7 +966,7 @@ int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef curve, int32_t qualifier,
 int32_t OCCTGccCircle2d2PtRad(double p1x, double p1y, double p2x, double p2y,
                               double radius, double tolerance,
                               OCCTGccCircleSolution* out, int32_t max) {
-    if (!out || max <= 0 || radius <= 0) return 0;
+    if (!out || max <= 0 || !occtValidCircleRadius(radius)) return 0;
     try {
         Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
         Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
@@ -1167,6 +1220,7 @@ bool OCCTGccAnaLinPnt2dBisec(double lpx, double lpy, double ldx, double ldy,
 int32_t OCCTGccAnaCirc2dBisec(double c1x, double c1y, double c1r,
                               double c2x, double c2y, double c2r,
                               OCCTBisecSolution* out, int32_t max) {
+    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
     try {
         gp_Circ2d circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
         gp_Circ2d circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
@@ -1185,6 +1239,7 @@ int32_t OCCTGccAnaCirc2dBisec(double c1x, double c1y, double c1r,
 int32_t OCCTGccAnaCircLin2dBisec(double cx, double cy, double cr,
                                  double lpx, double lpy, double ldx, double ldy,
                                  OCCTBisecSolution* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return 0;
     try {
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
         gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
@@ -1203,6 +1258,7 @@ int32_t OCCTGccAnaCircLin2dBisec(double cx, double cy, double cr,
 int32_t OCCTGccAnaCircPnt2dBisec(double cx, double cy, double cr,
                                  double px, double py,
                                  OCCTBisecSolution* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return 0;
     try {
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
         GccAna_CircPnt2dBisec bisec(circ, gp_Pnt2d(px, py));
@@ -1242,6 +1298,7 @@ int32_t OCCTGccAnaLin2dTanParPt(double px, double py,
 int32_t OCCTGccAnaLin2dTanParCirc(double cx, double cy, double cr, int32_t qualifier,
                                   double lpx, double lpy, double ldx, double ldy,
                                   OCCTGccLineSolution* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return 0;
     try {
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
         gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
@@ -1289,6 +1346,7 @@ int32_t OCCTGccAnaLin2dTanPerPtLin(double px, double py,
 int32_t OCCTGccAnaLin2dTanPerCircLin(double cx, double cy, double cr, int32_t qualifier,
                                      double lpx, double lpy, double ldx, double ldy,
                                      OCCTGccLineSolution* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return 0;
     try {
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
         gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
@@ -1391,6 +1449,7 @@ int32_t OCCTGccAnaCirc2dTanOnRadLin(double lpx, double lpy, double ldx, double l
                                     double onPx, double onPy, double onDx, double onDy,
                                     double radius, double tolerance,
                                     OCCTGccCircleSolution* out, int32_t max) {
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         gp_Lin2d l1(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
         gp_Lin2d onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
@@ -1442,6 +1501,7 @@ int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef curve, int32_t qualifier,
                                     double radius, double tolerance,
                                     OCCTGccCircleSolution* out, int32_t max) {
     if (!curve || !onCurve || curve->curve.IsNull() || onCurve->curve.IsNull()) return 0;
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         Geom2dAdaptor_Curve ac(curve->curve), aon(onCurve->curve);
         Geom2dGcc_QualifiedCurve qc(ac, toGccPosition(qualifier));
@@ -1484,6 +1544,7 @@ int32_t OCCTIntAna2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
 int32_t OCCTIntAna2dLinCirc(double lpx, double lpy, double ldx, double ldy,
                             double cx, double cy, double cr,
                             OCCTIntAna2dPoint* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return 0;
     try {
         gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
@@ -1505,6 +1566,7 @@ int32_t OCCTIntAna2dLinCirc(double lpx, double lpy, double ldx, double ldy,
 int32_t OCCTIntAna2dCircCirc(double c1x, double c1y, double c1r,
                              double c2x, double c2y, double c2r,
                              OCCTIntAna2dPoint* out, int32_t max) {
+    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
     try {
         gp_Circ2d circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
         gp_Circ2d circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
@@ -1565,6 +1627,7 @@ int32_t OCCTExtremaExtElC2dLinCirc(double lpx, double lpy, double ldx, double ld
                                    double cx, double cy, double cr,
                                    double tolerance,
                                    OCCTExtrema2dResult* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return -1;
     try {
         gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
@@ -1591,6 +1654,7 @@ int32_t OCCTExtremaExtPElC2dCirc(double px, double py,
                                  double cx, double cy, double cr,
                                  double tolerance,
                                  OCCTExtrema2dResult* out, int32_t max) {
+    if (!occtValidCircleRadius(cr)) return -1;
     try {
         gp_Pnt2d pt(px, py);
         gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
@@ -1770,6 +1834,7 @@ OCCTShapeRef _Nullable OCCTMakeEdge2dFromPoints(double x1, double y1, double x2,
 OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(
     double cx, double cy, double dx, double dy,
     double radius, double p1, double p2) {
+    if (!occtValidCircleRadius(radius)) return nullptr;
     try {
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
         BRepBuilderAPI_MakeEdge2d me(circ, p1, p2);
@@ -2328,6 +2393,8 @@ int32_t OCCTGccAnaCirc2d3TanCircles(
     double tolerance,
     OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
 {
+    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)
+        || !occtValidCircleRadius(c3r)) return 0;
     try {
         gp_Circ2d circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
         gp_Circ2d circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
@@ -2349,6 +2416,7 @@ int32_t OCCTGccAnaCirc2d2CirclesPoint(
     double px, double py, double tolerance,
     OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
 {
+    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
     try {
         gp_Circ2d circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
         gp_Circ2d circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
@@ -2367,6 +2435,7 @@ int32_t OCCTGccAnaCirc2dCircle2Points(
     double p1x, double p1y, double p2x, double p2y, double tolerance,
     OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
 {
+    if (!occtValidCircleRadius(cr)) return 0;
     try {
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
         GccAna_Circ2d3Tan solver(
@@ -2631,6 +2700,7 @@ int OCCTGccAnaCirc2d2TanRadLineLin(double l1px, double l1py, double l1dx, double
                                      double l2px, double l2py, double l2dx, double l2dy,
                                      double radius, double tolerance,
                                      OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
         gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
@@ -2658,6 +2728,7 @@ int OCCTGccAnaCirc2d2TanRadLineLin(double l1px, double l1py, double l1dx, double
 int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x, double p1y, double p2x, double p2y,
                                     double radius, double tolerance,
                                     OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         GccAna_Circ2d2TanRad solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), radius, tolerance);
         if (!solver.IsDone()) return 0;
@@ -2755,6 +2826,7 @@ int OCCTGccAnaLin2d2TanPntPnt(double p1x, double p1y, double p2x, double p2y,
 int OCCTGccAnaLin2d2TanCircPnt(double cx, double cy, double radius,
                                  double px, double py, double tolerance,
                                  OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions) {
+    if (!occtValidCircleRadius(radius)) return 0;
     try {
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
         GccEnt_QualifiedCirc qc(circ, GccEnt_unqualified);
@@ -3110,6 +3182,7 @@ OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
 #include <gp_Circ2d.hxx>
 
 OCCTCurve2DRef OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius) {
+    if (!occtValidCircleRadius(radius)) return nullptr;
     try {
         GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), radius);
         if (!mc.IsDone()) return nullptr;
@@ -3144,6 +3217,11 @@ OCCTCurve2DRef OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px,
 OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx, double cy,
                                              double dx, double dy,
                                              double radius, double dist) {
+    // The offset is checked as well as the radius. GC_MakeCircle2d takes the absolute value of
+    // radius + dist rather than refusing an offset that reaches or passes the centre: measured
+    // (#553), radius 5 offset by -5 gives radius 0 and by -6 gives radius 1, a circle inside the
+    // base rather than the one the caller asked for.
+    if (!occtValidCircleRadius(radius) || !occtValidCircleRadius(radius + dist)) return nullptr;
     try {
         gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
         GC_MakeCircle2d mc(circ, dist);
@@ -3157,6 +3235,7 @@ OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx, double cy,
 OCCTCurve2DRef OCCTCurve2DMakeCircleAxis(double cx, double cy,
                                          double dx, double dy,
                                          double radius) {
+    if (!occtValidCircleRadius(radius)) return nullptr;
     try {
         gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
         GC_MakeCircle2d mc(ax, radius);

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -1390,6 +1390,24 @@ public enum GccAnaBisector {
     /// Bisectors between two circles.
     ///
     /// Returns curves equidistant from both circles (up to 4 solutions).
+    ///
+    /// Both radii must be positive. A radius of zero describes a point rather than a circle, and
+    /// the solver does not answer the point question when it is given one: measured (#553), it
+    /// returns each solution twice, and with both radii zero two of the three solutions are
+    /// hyperbolas of major radius zero, a conic this API refuses to construct. Ask about points
+    /// through ``ofPoints(_:_:)`` or ``ofCircleAndPoint(center:radius:point:)`` instead. A
+    /// non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let bisectors = GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: 3,
+    ///                                          center2: SIMD2(10, 0), radius2: 2)
+    /// print(bisectors.count)   // 4
+    ///
+    /// // A point is not a zero-radius circle here:
+    /// GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: 0,
+    ///                          center2: SIMD2(10, 0), radius2: 2)   // []
+    /// GccAnaBisector.ofPoints(SIMD2(0, 0), SIMD2(10, 0))            // the perpendicular bisector
+    /// ```
     public static func ofCircles(
         center1: SIMD2<Double>, radius1: Double,
         center2: SIMD2<Double>, radius2: Double
@@ -1407,6 +1425,17 @@ public enum GccAnaBisector {
     }
 
     /// Bisectors between a circle and a line.
+    ///
+    /// The radius must be positive. With a radius of zero the solver returns the point/line
+    /// parabola twice rather than once (#553); ask about a point through
+    /// ``ofLineAndPoint(linePoint:lineDir:point:)``. A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let bisectors = GccAnaBisector.ofCircleAndLine(center: SIMD2(0, 5), radius: 2,
+    ///                                                linePoint: SIMD2(0, 0),
+    ///                                                lineDir: SIMD2(1, 0))
+    /// print(bisectors.count)   // 2 parabolas
+    /// ```
     public static func ofCircleAndLine(
         center: SIMD2<Double>, radius: Double,
         linePoint: SIMD2<Double>, lineDir: SIMD2<Double>
@@ -1424,6 +1453,17 @@ public enum GccAnaBisector {
     }
 
     /// Bisectors between a circle and a point.
+    ///
+    /// The radius must be positive. This is the family where a zero radius is furthest from the
+    /// point reading: measured (#553), it returns two hyperbolas of major radius zero, where the
+    /// bisector of two points is a straight line. Use ``ofPoints(_:_:)`` for that. A non-positive
+    /// radius returns an empty array.
+    ///
+    /// ```swift
+    /// let bisectors = GccAnaBisector.ofCircleAndPoint(center: SIMD2(0, 0), radius: 2,
+    ///                                                 point: SIMD2(6, 0))
+    /// print(bisectors.count)   // 2 hyperbola branches
+    /// ```
     public static func ofCircleAndPoint(
         center: SIMD2<Double>, radius: Double,
         point: SIMD2<Double>
@@ -1461,6 +1501,18 @@ extension Curve2DGcc {
     }
 
     /// Lines tangent to a circle, parallel to a reference line.
+    ///
+    /// `circleRadius` must be positive. With a radius of zero the solver returns the single line
+    /// through the centre twice (#553); ``lineParallelThrough(point:parallelTo:lineDir:)`` is the
+    /// entry point for that question and returns it once. A non-positive radius returns an empty
+    /// array.
+    ///
+    /// ```swift
+    /// let tangents = Curve2DGcc.linesTangentParallel(circleCenter: SIMD2(0, 0), circleRadius: 4,
+    ///                                                parallelTo: SIMD2(0, 0),
+    ///                                                lineDir: SIMD2(1, 0))
+    /// print(tangents.count)   // 2, at y = 4 and y = -4
+    /// ```
     public static func linesTangentParallel(
         circleCenter: SIMD2<Double>, circleRadius: Double,
         qualifier: Curve2DQualifier = .unqualified,
@@ -1493,6 +1545,19 @@ extension Curve2DGcc {
     }
 
     /// Lines tangent to a circle, perpendicular to a reference line.
+    ///
+    /// `circleRadius` must be positive. With a radius of zero the solver returns the single line
+    /// through the centre twice (#553); use
+    /// ``linePerpendicularThrough(point:perpendicularTo:lineDir:)`` for the point question. A
+    /// non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let tangents = Curve2DGcc.linesTangentPerpendicular(circleCenter: SIMD2(0, 0),
+    ///                                                     circleRadius: 4,
+    ///                                                     perpendicularTo: SIMD2(0, 0),
+    ///                                                     lineDir: SIMD2(1, 0))
+    /// print(tangents.count)   // 2, at x = 4 and x = -4
+    /// ```
     public static func linesTangentPerpendicular(
         circleCenter: SIMD2<Double>, circleRadius: Double,
         qualifier: Curve2DQualifier = .unqualified,
@@ -1565,6 +1630,17 @@ extension Curve2DGcc {
     }
 
     /// Circles tangent to a line, center on a line, with given radius.
+    ///
+    /// `radius` is the radius of the circles to find, and it must be positive. Asked for zero the
+    /// solver obliges and returns solution circles of radius zero (#553), which is a point rather
+    /// than the circle the caller asked for. A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let circles = Curve2DGcc.circlesTangentToLineOnLineWithRadius(
+    ///     linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+    ///     centerOnPoint: SIMD2(0, 0), centerOnDir: SIMD2(1, 1), radius: 2)
+    /// print(circles.map(\.radius))   // every solution has radius 2
+    /// ```
     public static func circlesTangentToLineOnLineWithRadius(
         linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
         qualifier: Curve2DQualifier = .unqualified,
@@ -1605,6 +1681,15 @@ extension Curve2DGcc {
     }
 
     /// Circles tangent to a curve, center on a curve, with given radius (Geom2dGcc).
+    ///
+    /// `radius` is the radius of the circles to find, and it must be positive; zero would ask for
+    /// a solution circle that is a point (#553). A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// guard let line = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0)),
+    ///       let centerOn = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 1)) else { return }
+    /// let circles = Curve2DGcc.circlesTangentOnCurveWithRadius(line, centerOn: centerOn, radius: 2)
+    /// ```
     public static func circlesTangentOnCurveWithRadius(
         _ curve: Curve2D, _ qualifier: Curve2DQualifier = .unqualified,
         centerOn: Curve2D,
@@ -1653,6 +1738,17 @@ public enum IntAna2d {
     }
 
     /// Intersect a 2D line and circle.
+    ///
+    /// `circleRadius` must be positive. A zero-radius circle is a point, and asking whether a
+    /// point lies on a line is not an intersection query: measured (#553), OCCT answers with the
+    /// centre and a `param2` of NaN, since a point has no parameter on a circle that is not
+    /// there. A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let hits = IntAna2d.intersectLineCircle(linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+    ///                                         circleCenter: SIMD2(0, 0), circleRadius: 3)
+    /// print(hits.map(\.point))   // (3, 0) and (-3, 0)
+    /// ```
     public static func intersectLineCircle(
         linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
         circleCenter: SIMD2<Double>, circleRadius: Double
@@ -1668,6 +1764,17 @@ public enum IntAna2d {
     }
 
     /// Intersect two 2D circles.
+    ///
+    /// Both radii must be positive, for the same reason as
+    /// ``intersectLineCircle(linePoint:lineDir:circleCenter:circleRadius:)``: a zero radius makes
+    /// the argument a point, not a curve to intersect (#553). A non-positive radius returns an
+    /// empty array.
+    ///
+    /// ```swift
+    /// let hits = IntAna2d.intersectCircles(center1: SIMD2(0, 0), radius1: 3,
+    ///                                      center2: SIMD2(4, 0), radius2: 3)
+    /// print(hits.count)   // 2
+    /// ```
     public static func intersectCircles(
         center1: SIMD2<Double>, radius1: Double,
         center2: SIMD2<Double>, radius2: Double
@@ -1728,6 +1835,18 @@ public enum Extrema2d {
     }
 
     /// Distance between a 2D line and circle.
+    ///
+    /// `circleRadius` must be positive. With a radius of zero the extrema come back correct but
+    /// duplicated (#553); ``distanceFromPointToLine(point:linePoint:lineDir:)`` answers the point
+    /// question directly. A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let extrema = Extrema2d.distanceBetweenLineAndCircle(linePoint: SIMD2(0, 10),
+    ///                                                      lineDir: SIMD2(1, 0),
+    ///                                                      circleCenter: SIMD2(0, 0),
+    ///                                                      circleRadius: 3)
+    /// print(extrema.map(\.distance))   // 7 and 13
+    /// ```
     public static func distanceBetweenLineAndCircle(
         linePoint: SIMD2<Double>, lineDir: SIMD2<Double>,
         circleCenter: SIMD2<Double>, circleRadius: Double,
@@ -1747,6 +1866,17 @@ public enum Extrema2d {
     }
 
     /// Closest/farthest points on a 2D circle from a point.
+    ///
+    /// `circleRadius` must be positive. This is the family where a zero radius loses the answer
+    /// outright: measured (#553), OCCT reports no extremum at all rather than the distance to the
+    /// centre. A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let extrema = Extrema2d.distanceFromPointToCircle(point: SIMD2(0, 10),
+    ///                                                   circleCenter: SIMD2(0, 0),
+    ///                                                   circleRadius: 3)
+    /// print(extrema.map(\.distance))   // 7 and 13
+    /// ```
     public static func distanceFromPointToCircle(
         point: SIMD2<Double>,
         circleCenter: SIMD2<Double>, circleRadius: Double,

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -9186,6 +9186,15 @@ extension Shape {
     }
 
     /// Create a 2D edge from a circle arc with parameter bounds.
+    ///
+    /// `radius` must be positive. `BRepBuilderAPI_MakeEdge2d` reports success for a zero radius
+    /// and hands back a zero-length edge with both vertices at the centre (#553), so the radius is
+    /// checked before OCCT sees it. A non-positive radius returns nil.
+    ///
+    /// ```swift
+    /// let arc = Shape.edge2dFromCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+    ///                                  radius: 3, p1: 0, p2: .pi)
+    /// ```
     public static func edge2dFromCircle(
         center: SIMD2<Double>,
         direction: SIMD2<Double>,
@@ -10465,6 +10474,21 @@ extension Shape {
     }
 
     /// Find circles tangent to 3 circles.
+    ///
+    /// Every radius must be positive. A zero-radius argument is a point, and OCCT does not answer
+    /// the point question when it is given one: measured (#553), it returns each solution twice,
+    /// because tangency to a circle of radius zero satisfies both the enclosing and the outside
+    /// case at once. Use ``circleTangent2CirclesPoint(c1Center:c1Radius:c2Center:c2Radius:point:tolerance:)``,
+    /// ``circleTangentCircle2Points(circleCenter:circleRadius:p1:p2:tolerance:)`` or
+    /// ``circleThrough3Points(p1:p2:p3:tolerance:)`` to name a point as a point. A non-positive
+    /// radius returns an empty array.
+    ///
+    /// ```swift
+    /// let circles = Shape.circleTangent3Circles(c1Center: SIMD2(0, 0), c1Radius: 2,
+    ///                                           c2Center: SIMD2(10, 0), c2Radius: 2,
+    ///                                           c3Center: SIMD2(5, 8), c3Radius: 2)
+    /// print(circles.count)   // 8
+    /// ```
     public static func circleTangent3Circles(
         c1Center: SIMD2<Double>, c1Radius: Double,
         c2Center: SIMD2<Double>, c2Radius: Double,
@@ -10482,6 +10506,16 @@ extension Shape {
     }
 
     /// Find circles tangent to 2 circles through 1 point.
+    ///
+    /// Both radii must be positive. With a zero radius the solution set comes back padded with
+    /// repeats (#553): measured, four solutions holding two distinct circles. A non-positive
+    /// radius returns an empty array.
+    ///
+    /// ```swift
+    /// let circles = Shape.circleTangent2CirclesPoint(c1Center: SIMD2(0, 0), c1Radius: 2,
+    ///                                                c2Center: SIMD2(10, 0), c2Radius: 2,
+    ///                                                point: SIMD2(5, 8))
+    /// ```
     public static func circleTangent2CirclesPoint(
         c1Center: SIMD2<Double>, c1Radius: Double,
         c2Center: SIMD2<Double>, c2Radius: Double,
@@ -10497,6 +10531,16 @@ extension Shape {
     }
 
     /// Find circles tangent to 1 circle through 2 points.
+    ///
+    /// `circleRadius` must be positive. This is the case where reading a zero-radius circle as a
+    /// point fails outright: measured (#553), the solver finds nothing at all, where
+    /// ``circleThrough3Points(p1:p2:p3:tolerance:)`` on the same three positions finds the circle
+    /// through them. A non-positive radius returns an empty array.
+    ///
+    /// ```swift
+    /// let circles = Shape.circleTangentCircle2Points(circleCenter: SIMD2(0, 0), circleRadius: 2,
+    ///                                                p1: SIMD2(10, 0), p2: SIMD2(5, 8))
+    /// ```
     public static func circleTangentCircle2Points(
         circleCenter: SIMD2<Double>, circleRadius: Double,
         p1: SIMD2<Double>, p2: SIMD2<Double>, tolerance: Double = 1e-6
@@ -12630,6 +12674,16 @@ public struct Circle2DSolution: Sendable {
 }
 
 /// Find circles tangent to two lines with given radius.
+///
+/// `radius` is the radius of the circles to find, and it must be positive. Asked for zero,
+/// `GccAna_Circ2d2TanRad` obliges and returns solution circles of radius zero (#553). A
+/// non-positive radius returns an empty array.
+///
+/// ```swift
+/// let circles = circlesTangentToLines(SIMD2(0, 0), SIMD2(1, 0),
+///                                     SIMD2(0, 0), SIMD2(0, 1), radius: 2)
+/// print(circles.count)   // 4, one per quadrant
+/// ```
 public func circlesTangentToLines(_ l1Origin: SIMD2<Double>, _ l1Direction: SIMD2<Double>,
                                    _ l2Origin: SIMD2<Double>, _ l2Direction: SIMD2<Double>,
                                    radius: Double, tolerance: Double = 1e-6) -> [Circle2DSolution] {
@@ -12646,6 +12700,14 @@ public func circlesTangentToLines(_ l1Origin: SIMD2<Double>, _ l1Direction: SIMD
 }
 
 /// Find circles through two points with given radius.
+///
+/// `radius` is the radius of the circles to find, and it must be positive; zero would ask for a
+/// solution circle that is a point (#553). A non-positive radius returns an empty array, as does a
+/// radius too small to reach both points.
+///
+/// ```swift
+/// let circles = circlesThroughPointsWithRadius(SIMD2(0, 0), SIMD2(4, 0), radius: 3)
+/// ```
 public func circlesThroughPointsWithRadius(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
                                             radius: Double, tolerance: Double = 1e-6) -> [Circle2DSolution] {
     var solutions = [OCCTCircle2DSolution](repeating: OCCTCircle2DSolution(), count: 8)
@@ -12708,6 +12770,16 @@ public func lineThroughPoints(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>,
 }
 
 /// Find lines tangent to a circle through a point.
+///
+/// `circleRadius` must be positive. With a radius of zero the solver returns the single line
+/// through the centre twice (#553); ``Curve2DGcc/linesTangentToPoint(_:_:)`` and the point/point
+/// entry points answer that question once. A non-positive radius returns an empty array.
+///
+/// ```swift
+/// let tangents = linesTangentToCircleThroughPoint(circleCenter: SIMD2(0, 0), circleRadius: 3,
+///                                                 point: SIMD2(10, 0))
+/// print(tangents.count)   // 2
+/// ```
 public func linesTangentToCircleThroughPoint(circleCenter: SIMD2<Double>, circleRadius: Double,
                                               point: SIMD2<Double>,
                                               tolerance: Double = 1e-6) -> [Line2DSolution] {

--- a/Tests/OCCTGeom2dTests/Issue553GccZeroRadiusTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue553GccZeroRadiusTests.swift
@@ -1,0 +1,279 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #553: the 2D solver entry points that take a circle as a centre and a radius.
+///
+/// Split out of #514, which guarded the conic *construction* sites and stopped there because a
+/// zero-radius circle handed to a tangency solver is geometrically a point, and several of these
+/// solvers have a documented answer for a point argument. The probe in
+/// `Scripts/repro/553-gcc-zero-radius-circle` ran every family against a zero-radius argument and
+/// against OCCT's own point overload of the same query. None of them answers the point question:
+/// the answer comes back duplicated, or as a conic this bridge's own construction guards reject,
+/// or with a NaN parameter, or not at all. Every family already has a point entry point in the
+/// same API, so rejecting the degenerate circle costs the caller no query.
+///
+/// Each rejection test names the measured wrong answer it replaces, and each family also pins a
+/// valid case so the guard cannot be silently over-broad.
+@Suite("Issue553 zero-radius circle solver arguments")
+struct Issue553GccZeroRadiusTests {
+
+    // MARK: - GccAna bisectors
+
+    /// Measured: 4 solutions where the point overload gives 2, each one duplicated. With both
+    /// radii 0, two of the three solutions are hyperbolas of major radius 0, which is exactly the
+    /// degenerate conic `occtValidHyperbolaRadii` refuses to construct.
+    @Test func circleBisectorRejectsZeroRadius() {
+        #expect(GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: 0,
+                                         center2: SIMD2(10, 0), radius2: 2).isEmpty)
+        #expect(GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: 3,
+                                         center2: SIMD2(10, 0), radius2: 0).isEmpty)
+        #expect(GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: 0,
+                                         center2: SIMD2(10, 0), radius2: 0).isEmpty)
+    }
+
+    @Test func circleBisectorAcceptsValidRadii() {
+        let solutions = GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: 3,
+                                                 center2: SIMD2(10, 0), radius2: 2)
+        #expect(solutions.count == 4)
+    }
+
+    /// The point/point question has its own entry point, and it answers correctly where the
+    /// zero-radius circle does not: measured, `ofCircleAndPoint` with radius 0 returns two
+    /// hyperbolas of major radius 0, while the perpendicular bisector is a line at x = 3.
+    @Test func pointBisectorAnswersWhatZeroRadiusCannot() {
+        #expect(GccAnaBisector.ofCircleAndPoint(center: SIMD2(0, 0), radius: 0,
+                                                point: SIMD2(6, 0)).isEmpty)
+        if let line = GccAnaBisector.ofPoints(SIMD2(0, 0), SIMD2(6, 0)) {
+            #expect(abs(line.point.x - 3) < 1e-9)
+            #expect(abs(line.direction.x) < 1e-9)
+        } else {
+            Issue.record("the two-point bisector should have a solution")
+        }
+    }
+
+    @Test func circlePointBisectorAcceptsValidRadius() {
+        #expect(GccAnaBisector.ofCircleAndPoint(center: SIMD2(0, 0), radius: 2,
+                                                point: SIMD2(6, 0)).count == 2)
+    }
+
+    /// Measured: the point overload's single parabola, returned twice.
+    @Test func circleLineBisectorRejectsZeroRadius() {
+        #expect(GccAnaBisector.ofCircleAndLine(center: SIMD2(0, 5), radius: 0,
+                                               linePoint: SIMD2(0, 0),
+                                               lineDir: SIMD2(1, 0)).isEmpty)
+        #expect(GccAnaBisector.ofCircleAndLine(center: SIMD2(0, 5), radius: 2,
+                                               linePoint: SIMD2(0, 0),
+                                               lineDir: SIMD2(1, 0)).count == 2)
+    }
+
+    // MARK: - GccAna tangent lines
+
+    /// Measured: the point overload's single line, returned twice.
+    @Test func tangentParallelLinesRejectZeroRadius() {
+        #expect(Curve2DGcc.linesTangentParallel(circleCenter: SIMD2(0, 0), circleRadius: 0,
+                                                parallelTo: SIMD2(0, 0),
+                                                lineDir: SIMD2(1, 0)).isEmpty)
+        #expect(Curve2DGcc.linesTangentParallel(circleCenter: SIMD2(0, 0), circleRadius: 4,
+                                                parallelTo: SIMD2(0, 0),
+                                                lineDir: SIMD2(1, 0)).count == 2)
+    }
+
+    @Test func tangentPerpendicularLinesRejectZeroRadius() {
+        #expect(Curve2DGcc.linesTangentPerpendicular(circleCenter: SIMD2(0, 0), circleRadius: 0,
+                                                     perpendicularTo: SIMD2(0, 0),
+                                                     lineDir: SIMD2(1, 0)).isEmpty)
+        #expect(Curve2DGcc.linesTangentPerpendicular(circleCenter: SIMD2(0, 0), circleRadius: 4,
+                                                     perpendicularTo: SIMD2(0, 0),
+                                                     lineDir: SIMD2(1, 0)).count == 2)
+    }
+
+    /// Measured: the line through the centre, returned twice, where `linesTangentToPoint`'s own
+    /// entry point returns it once.
+    @Test func tangentLineThroughPointRejectsZeroRadius() {
+        #expect(linesTangentToCircleThroughPoint(circleCenter: SIMD2(0, 0), circleRadius: 0,
+                                                 point: SIMD2(10, 0)).isEmpty)
+        #expect(linesTangentToCircleThroughPoint(circleCenter: SIMD2(0, 0), circleRadius: 3,
+                                                 point: SIMD2(10, 0)).count == 2)
+    }
+
+    // MARK: - GccAna_Circ2d3Tan
+
+    /// Measured: 8 solutions where the point overload gives 4, each one duplicated.
+    @Test func circleTangentToThreeCirclesRejectsZeroRadius() {
+        #expect(Shape.circleTangent3Circles(c1Center: SIMD2(0, 0), c1Radius: 0,
+                                            c2Center: SIMD2(10, 0), c2Radius: 2,
+                                            c3Center: SIMD2(5, 8), c3Radius: 2).isEmpty)
+        #expect(Shape.circleTangent3Circles(c1Center: SIMD2(0, 0), c1Radius: 2,
+                                            c2Center: SIMD2(10, 0), c2Radius: 2,
+                                            c3Center: SIMD2(5, 8), c3Radius: 2).count == 8)
+    }
+
+    /// Measured: 4 solutions holding only 2 distinct circles, one of them repeated three times.
+    @Test func circleTangentToTwoCirclesAndPointRejectsZeroRadius() {
+        #expect(Shape.circleTangent2CirclesPoint(c1Center: SIMD2(0, 0), c1Radius: 0,
+                                                 c2Center: SIMD2(10, 0), c2Radius: 2,
+                                                 point: SIMD2(5, 8)).isEmpty)
+        #expect(!Shape.circleTangent2CirclesPoint(c1Center: SIMD2(0, 0), c1Radius: 2,
+                                                  c2Center: SIMD2(10, 0), c2Radius: 2,
+                                                  point: SIMD2(5, 8)).isEmpty)
+    }
+
+    /// The sharpest case measured: with a zero-radius circle the solver finds nothing at all,
+    /// while the all-points entry point finds the circle circumscribing the same three positions.
+    /// Reading the degenerate circle as a point would have to produce that circle; it produces
+    /// an empty set instead.
+    ///
+    /// This is one of two tests here that cannot discriminate: because OCCT's own wrong answer is
+    /// already an empty set, the assertion holds with or without the guard. Verified by running
+    /// the suite against a build with the zero rejection removed, where 16 of these 22 tests fail
+    /// and this one does not. It is kept because it pins the contract, not because it catches a
+    /// regression in it.
+    @Test func circleTangentToCircleAndTwoPointsRejectsZeroRadius() {
+        #expect(Shape.circleTangentCircle2Points(circleCenter: SIMD2(0, 0), circleRadius: 0,
+                                                 p1: SIMD2(10, 0), p2: SIMD2(5, 8)).isEmpty)
+        #expect(!Shape.circleTangentCircle2Points(circleCenter: SIMD2(0, 0), circleRadius: 2,
+                                                  p1: SIMD2(10, 0), p2: SIMD2(5, 8)).isEmpty)
+    }
+
+    // MARK: - IntAna2d
+
+    /// Measured: the intersection point is right, but `ParamOnSecond()` on a zero-radius circle is
+    /// NaN and the bridge writes it straight into `param2`.
+    @Test func lineCircleIntersectionRejectsZeroRadius() {
+        #expect(IntAna2d.intersectLineCircle(linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+                                             circleCenter: SIMD2(0, 0), circleRadius: 0).isEmpty)
+        let valid = IntAna2d.intersectLineCircle(linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+                                                 circleCenter: SIMD2(0, 0), circleRadius: 3)
+        #expect(valid.count == 2)
+        #expect(valid.allSatisfy { !$0.param2.isNaN })
+    }
+
+    @Test func circleCircleIntersectionRejectsZeroRadius() {
+        #expect(IntAna2d.intersectCircles(center1: SIMD2(0, 0), radius1: 0,
+                                          center2: SIMD2(3, 0), radius2: 3).isEmpty)
+        #expect(IntAna2d.intersectCircles(center1: SIMD2(0, 0), radius1: 3,
+                                          center2: SIMD2(4, 0), radius2: 3).count == 2)
+    }
+
+    // MARK: - Extrema 2D
+
+    /// Measured: the right distance, returned twice.
+    @Test func lineCircleExtremaRejectZeroRadius() {
+        #expect(Extrema2d.distanceBetweenLineAndCircle(linePoint: SIMD2(0, 10),
+                                                       lineDir: SIMD2(1, 0),
+                                                       circleCenter: SIMD2(0, 0),
+                                                       circleRadius: 0).isEmpty)
+        #expect(Extrema2d.distanceBetweenLineAndCircle(linePoint: SIMD2(0, 10),
+                                                       lineDir: SIMD2(1, 0),
+                                                       circleCenter: SIMD2(0, 0),
+                                                       circleRadius: 3).count == 2)
+    }
+
+    /// Measured: no extremum at all, so the distance the point reading asks for is lost outright.
+    /// The other of the two non-discriminating tests, for the same reason as
+    /// ``circleTangentToCircleAndTwoPointsRejectsZeroRadius()``: OCCT already returns nothing here,
+    /// so only the valid-radius half of this test can fail.
+    @Test func pointCircleExtremaRejectZeroRadius() {
+        #expect(Extrema2d.distanceFromPointToCircle(point: SIMD2(0, 10),
+                                                    circleCenter: SIMD2(0, 0),
+                                                    circleRadius: 0).isEmpty)
+        #expect(Extrema2d.distanceFromPointToCircle(point: SIMD2(0, 10),
+                                                    circleCenter: SIMD2(0, 0),
+                                                    circleRadius: 3).count == 2)
+    }
+
+    // MARK: - The requested solution radius
+
+    /// A radius of 0 here does not describe an argument, it asks the solver to find a circle that
+    /// is a point. Measured, `GccAna_Circ2d2TanRad` and `GccAna_Circ2dTanOnRad` oblige and hand
+    /// back solution circles of radius 0. Three sibling entry points already rejected it inline;
+    /// these four were the ones that did not.
+    @Test func requestedRadiusOfZeroIsRejected() {
+        #expect(circlesTangentToLines(SIMD2(0, 0), SIMD2(1, 0),
+                                      SIMD2(0, 0), SIMD2(0, 1), radius: 0).isEmpty)
+        #expect(circlesThroughPointsWithRadius(SIMD2(0, 0), SIMD2(4, 0), radius: 0).isEmpty)
+        #expect(Curve2DGcc.circlesTangentToLineOnLineWithRadius(
+            linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+            centerOnPoint: SIMD2(0, 0), centerOnDir: SIMD2(1, 1), radius: 0).isEmpty)
+    }
+
+    @Test func requestedRadiusOfZeroIsRejectedOnCurves() {
+        guard let line = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0)),
+              let centerOn = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 1)) else {
+            Issue.record("could not build the two 2D lines")
+            return
+        }
+        #expect(Curve2DGcc.circlesTangentOnCurveWithRadius(line, centerOn: centerOn,
+                                                           radius: 0).isEmpty)
+    }
+
+    @Test func requestedRadiusAcceptsValidValues() {
+        #expect(circlesTangentToLines(SIMD2(0, 0), SIMD2(1, 0),
+                                      SIMD2(0, 0), SIMD2(0, 1), radius: 2).count == 4)
+        #expect(!circlesThroughPointsWithRadius(SIMD2(0, 0), SIMD2(4, 0), radius: 3).isEmpty)
+        #expect(!Curve2DGcc.circlesTangentToLineOnLineWithRadius(
+            linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0),
+            centerOnPoint: SIMD2(0, 0), centerOnDir: SIMD2(1, 1), radius: 2).isEmpty)
+    }
+
+    // MARK: - The producers #514 did not reach
+
+    /// Measured: `BRepBuilderAPI_MakeEdge2d` reports `IsDone()` for a zero-radius arc and hands
+    /// back a zero-length edge with both vertices at the centre, the same shape of answer #514
+    /// refused for `OCCTMakeEdge2dFullCircle`.
+    @Test func circleEdgeRejectsZeroRadius() {
+        #expect(Shape.edge2dFromCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       radius: 0, p1: 0, p2: .pi) == nil)
+        #expect(Shape.edge2dFromCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       radius: 3, p1: 0, p2: .pi) != nil)
+    }
+
+    /// `GC_MakeCircle2d` rejects a negative radius through `gce_NegativeRadius` but accepts 0.
+    @Test func gceCircleFactoriesRejectZeroRadius() {
+        #expect(Curve2D.gceCircle(center: SIMD2(0, 0), radius: 0) == nil)
+        #expect(Curve2D.gceCircle(center: SIMD2(0, 0), radius: 3) != nil)
+        #expect(Curve2D.gceCircle(axisCenter: SIMD2(0, 0), axisDirection: SIMD2(1, 0),
+                                  radius: 0) == nil)
+        #expect(Curve2D.gceCircle(axisCenter: SIMD2(0, 0), axisDirection: SIMD2(1, 0),
+                                  radius: 3) != nil)
+    }
+
+    /// The parallel factory needs the offset checked as well as the radius. Measured, radius 5
+    /// offset by -5 gives radius 0 and by -6 gives radius 1: `GC_MakeCircle2d` takes the absolute
+    /// value rather than refusing an offset that reaches or passes the centre, so a caller asking
+    /// for a circle 6 units inside a radius-5 one silently gets a radius-1 circle.
+    @Test func parallelCircleRejectsCollapsingOffset() {
+        #expect(Curve2D.gceCircleParallel(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                          radius: 0, distance: 3) == nil)
+        #expect(Curve2D.gceCircleParallel(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                          radius: 5, distance: -5) == nil)
+        #expect(Curve2D.gceCircleParallel(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                          radius: 5, distance: -6) == nil)
+        if let c = Curve2D.gceCircleParallel(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                             radius: 5, distance: -2) {
+            #expect(abs(c.circleProperties.radius - 3) < 1e-9)
+        } else {
+            Issue.record("an offset that stays inside the base circle should still build")
+        }
+    }
+
+    // MARK: - Negative radius was never the gap
+
+    /// `gp_Circ2d`'s constructor is `constexpr` in the header, so its
+    /// `Standard_ConstructionError_Raise_if` runs in a bridge translation unit and the existing
+    /// catch already turned a negative radius into an empty result. These pin that the new guards
+    /// did not change what a negative radius does, only what zero does.
+    @Test func negativeRadiusWasAlreadyRejected() {
+        #expect(GccAnaBisector.ofCircles(center1: SIMD2(0, 0), radius1: -1,
+                                         center2: SIMD2(10, 0), radius2: 2).isEmpty)
+        #expect(IntAna2d.intersectCircles(center1: SIMD2(0, 0), radius1: -1,
+                                          center2: SIMD2(3, 0), radius2: 3).isEmpty)
+        #expect(Extrema2d.distanceFromPointToCircle(point: SIMD2(0, 10),
+                                                    circleCenter: SIMD2(0, 0),
+                                                    circleRadius: -1).isEmpty)
+        #expect(Curve2D.gceCircle(center: SIMD2(0, 0), radius: -1) == nil)
+        #expect(Shape.edge2dFromCircle(center: SIMD2(0, 0), direction: SIMD2(1, 0),
+                                       radius: -1, p1: 0, p2: .pi) == nil)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -186,6 +186,79 @@ all. They assert measured geometry rather than non-nil, and were verified to fai
 defects — a flipped parallel-offset sign, and swapped `S1`/`S2` apex points. No public Swift API
 changed; `OCCTBridge` is not an SPM product, so the C-layer rename reaches no consumer.
 
+#### The 2D solvers' circle radius: measured per family, guarded in all of them (#553)
+
+The last unresolved part of the 2D circle-radius family, split out of #514. About 25 sites in
+`OCCTBridge_Geom2d.mm` build a `gp_Circ2d` from caller-supplied doubles as an **input** to a
+tangency, bisector, intersection or extrema solver rather than as geometry being returned. #514
+stopped there on purpose: a zero-radius circle handed to such a solver is geometrically a point, and
+several of them have a documented answer for a point argument, so guarding blindly could have
+removed a query some callers were legitimately making.
+
+So it was measured, per family, against OCCT's own point overload of the same query. The probe is at
+[`Scripts/repro/553-gcc-zero-radius-circle/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/553-gcc-zero-radius-circle).
+**No family answers the point question:**
+
+| family | a zero-radius argument gives | OCCT's own point overload gives |
+|---|---|---|
+| `GccAna_Circ2dBisec` | 4 solutions, each duplicated; with **both** radii 0, two of the three are hyperbolas of **major radius 0** | `GccAna_CircPnt2dBisec` gives 2; `GccAna_Pnt2dBisec` gives the perpendicular bisector line |
+| `GccAna_CircPnt2dBisec` | 2 hyperbolas of **major radius 0** | a **line** — so the returned *type* is wrong, not merely duplicated |
+| `GccAna_CircLin2dBisec` | the point overload's parabola, twice | it once |
+| `GccAna_Lin2dTanPar` / `Lin2dTanPer` | the point overload's line, twice | it once |
+| `GccAna_Lin2d2Tan` | the point overload's line, twice | it once |
+| `GccAna_Circ2d3Tan`, three circles | 8 solutions: the point overload's 4, each twice | 4, tangency residuals < 1e-14 |
+| `GccAna_Circ2d3Tan`, one circle + two points | **0 solutions** | the circle circumscribing the three positions |
+| `Extrema_ExtPElC2d` | **0 extrema** — the distance is lost outright | — |
+| `Extrema_ExtElC2d` | the right distance, twice | — |
+| `IntAna2d_AnaIntersection` | the right point, with `ParamOnSecond()` **NaN**, written straight into the caller's `param2` | — |
+
+The duplication has a cause worth recording: tangency to a circle of radius 0 satisfies the
+enclosing and the outside qualifier at once, so the solver enumerates each solution twice. And the
+hyperbolas of major radius 0 are the same degenerate conic `occtValidHyperbolaRadii` refuses to
+construct on the other side of this file, so the bisector families were handing back curves the
+construction API would not accept.
+
+Every one of those families already has a point entry point in the same API — `GccAnaBisector.ofPoints`,
+`ofLineAndPoint`, `Curve2DGcc.lineParallelThrough`, `linePerpendicularThrough`,
+`Shape.circleThrough3Points`, the point/point line solvers, and the mixed circle/point overloads.
+Naming a point as a point already has a spelling, and a degenerate circle is not it. **Guard, in
+every family** — a decision reached per family, which converged.
+
+**Negative was never the gap.** `gp_Circ2d`'s constructor is `constexpr` in the header, so its
+`Standard_ConstructionError_Raise_if(theRadius < 0.0, …)` does run in a bridge translation unit —
+the same finding #514 made for `gp_Elips2d` — and the existing `catch` already turned it into an
+empty result. `GC_MakeCircle2d` reports `gce_NegativeRadius`, a status rather than a macro, so
+`No_Exception` does not void that either. The new guards change what **zero** does, nothing else.
+
+Two more radius contracts in the same file were converged onto the same predicate while the family
+was open:
+
+- **The radius of the circle a solver must find.** `OCCTGccCircle2d2TanRad`,
+  `OCCTGccCircle2dTanPtRad` and `OCCTGccCircle2d2PtRad` each spelled `radius <= 0` inline; four
+  siblings did not check at all. Measured, `GccAna_Circ2d2TanRad` and `GccAna_Circ2dTanOnRad` asked
+  for radius 0 return solution circles of radius 0. All seven now share `occtValidCircleRadius`.
+- **Four producer sites #514 did not reach.** `BRepBuilderAPI_MakeEdge2d` reports `IsDone()` for a
+  zero-radius arc and returns a zero-length edge with both vertices at the centre;
+  `GC_MakeCircle2d(ax, 0)` succeeds. `Curve2D.gceCircleParallel` needed the offset checked as well:
+  measured, `GC_MakeCircle2d` takes the **absolute value** of `radius + dist`, so radius 5 offset by
+  -5 gives radius 0 and by -6 gives radius 1 — a circle the caller did not ask for, not a refusal.
+
+Every affected Swift entry point now documents its radius contract with a runnable snippet; none of
+them mentioned it before. A rejected radius returns an empty array (or `nil` for the producers),
+which is what these entry points already returned for "no solutions", so no call site has to move.
+
+22 tests in `Tests/OCCTGeom2dTests/Issue553GccZeroRadiusTests.swift`, run against a build with the
+zero rejection removed: **16 fail**, and the 6 that do not are the four valid-input controls, the
+negative-radius test, and the two cases where OCCT's own wrong answer is itself an empty set
+(`circleTangentCircle2Points` and `distanceFromPointToCircle`), which no assertion can discriminate.
+Both are noted as such in the test file.
+
+Not changed: `extractBisecSolution`'s `default` branch writes `(0, 0)` for a `GccInt_Pnt` solution
+instead of its coordinates. Section 13 of the probe hunts for one — identical, concentric,
+externally tangent, internally tangent and crossing circles, a point on the circle, a point at the
+centre — and none of them, nor any zero-radius case, produces one. Left alone rather than fixed
+speculatively.
+
 #### The nine 2D conic sites that took a dimension and never checked it (#514)
 
 Split out of #487, which fixed the three `gce_Make*2d` factories and converged the four conic

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -540,6 +540,9 @@ public static func distanceBetweenLineAndCircle(
 
 - **Returns:** Array of extrema results (min and/or max distance points; may be empty on failure).
 - **OCCT:** `Extrema_ExtElC2d` (line–circle).
+- **Note:** `circleRadius` must be positive (#553). With a radius of zero the extrema come back
+  correct but duplicated; `distanceFromPointToLine(point:linePoint:lineDir:)` answers the point
+  question directly. A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let extrema = Extrema2d.distanceBetweenLineAndCircle(
@@ -563,6 +566,9 @@ public static func distanceFromPointToCircle(
 
 - **Returns:** Array of up to 2 results (min and max distance to the circle).
 - **OCCT:** `Extrema_ExtPElC2d` (point–circle).
+- **Note:** `circleRadius` must be positive (#553). This is the family where a zero radius loses
+  the answer outright: measured, OCCT reports no extremum at all rather than the distance to the
+  centre. A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let extrema = Extrema2d.distanceFromPointToCircle(
@@ -772,6 +778,9 @@ Returns 0, 1 (tangent), or 2 intersection points.
 
 - **Returns:** Array of 0–2 `Intersection2DPoint` values.
 - **OCCT:** `IntAna2d_AnaIntersection` (line–circle).
+- **Note:** `circleRadius` must be positive (#553). A zero-radius circle is a point, and whether a
+  point lies on a line is not an intersection query: measured, OCCT answers with the centre and a
+  `param2` of NaN. A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let pts = IntAna2d.intersectLineCircle(
@@ -797,6 +806,8 @@ Returns 0 (disjoint or concentric), 1 (tangent), or 2 intersection points.
 
 - **Returns:** Array of 0–2 `Intersection2DPoint` values.
 - **OCCT:** `IntAna2d_AnaIntersection` (circle–circle).
+- **Note:** both radii must be positive, for the same reason as `intersectLineCircle` (#553). A
+  non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let pts = IntAna2d.intersectCircles(

--- a/docs/reference/Curve2D-Constraint-Solvers.md
+++ b/docs/reference/Curve2D-Constraint-Solvers.md
@@ -613,6 +613,12 @@ public static func ofCircles(
 - **Parameters:** `center1`, `radius1` — first circle; `center2`, `radius2` — second circle.
 - **Returns:** Array of up to 4 bisector curves.
 - **OCCT:** `GccAna_Circ2dBisec`.
+- **Note:** both radii must be positive (#553). A radius of zero describes a point, and this solver
+  does not answer the point question when it is given one: measured, it returns each solution twice,
+  and with both radii zero two of the three solutions are hyperbolas of major radius zero, a conic
+  this API refuses to construct. Use `ofPoints(_:_:)` or `ofCircleAndPoint(center:radius:point:)`.
+  A non-positive radius returns an empty array; a negative one always did, through `gp_Circ2d`'s own
+  header check.
 - **Example:**
   ```swift
   let bisectors = GccAnaBisector.ofCircles(
@@ -637,6 +643,9 @@ public static func ofCircleAndLine(
 - **Parameters:** `center`, `radius` — the circle; `linePoint`, `lineDir` — point and direction of the line.
 - **Returns:** Array of bisector curve solutions.
 - **OCCT:** `GccAna_CircLin2dBisec`.
+- **Note:** the radius must be positive (#553). With a radius of zero the solver returns the
+  point/line parabola twice rather than once; `ofLineAndPoint(linePoint:lineDir:point:)` is the
+  entry point for that question. A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let bisectors = GccAnaBisector.ofCircleAndLine(
@@ -660,6 +669,10 @@ public static func ofCircleAndPoint(
 - **Parameters:** `center`, `radius` — the circle; `point` — the fixed point.
 - **Returns:** Array of bisector curve solutions.
 - **OCCT:** `GccAna_CircPnt2dBisec`.
+- **Note:** the radius must be positive (#553). This is the family where a zero radius is furthest
+  from the point reading: measured, it returns two hyperbolas of major radius zero, where the
+  bisector of two points is a straight line. Use `ofPoints(_:_:)` for that. A non-positive radius
+  returns an empty array.
 - **Example:**
   ```swift
   let bisectors = GccAnaBisector.ofCircleAndPoint(
@@ -710,6 +723,9 @@ public static func linesTangentParallel(
 - **Parameters:** `circleCenter`, `circleRadius` — the circle; `qualifier` — qualifier; `linePoint`, `lineDir` — reference line direction.
 - **Returns:** Array of parallel tangent lines (0 or 2 solutions).
 - **OCCT:** `GccAna_Lin2dTanPar`.
+- **Note:** `circleRadius` must be positive (#553). With a radius of zero the solver returns the
+  single line through the centre twice; `lineParallelThrough(point:parallelTo:lineDir:)` answers
+  that question and returns it once. A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let lines = Curve2DGcc.linesTangentParallel(
@@ -757,6 +773,10 @@ public static func linesTangentPerpendicular(
 - **Parameters:** `circleCenter`, `circleRadius` — the circle; `qualifier` — qualifier; `linePoint`, `lineDir` — reference line direction.
 - **Returns:** Array of perpendicular tangent lines.
 - **OCCT:** `GccAna_Lin2dTanPer`.
+- **Note:** `circleRadius` must be positive (#553). With a radius of zero the solver returns the
+  single line through the centre twice; use
+  `linePerpendicularThrough(point:perpendicularTo:lineDir:)` for the point question. A non-positive
+  radius returns an empty array.
 - **Example:**
   ```swift
   let lines = Curve2DGcc.linesTangentPerpendicular(
@@ -865,6 +885,9 @@ public static func circlesTangentToLineOnLineWithRadius(
 - **Parameters:** `linePoint`, `lineDir` — tangent line; `qualifier` — qualifier; `centerOnPoint`, `centerOnDir` — center-constraint line; `radius` — fixed radius; `tolerance` — tolerance.
 - **Returns:** Array of circle solutions.
 - **OCCT:** `GccAna_Circ2dTanOnRad`.
+- **Note:** `radius` is the radius of the circles to find, and it must be positive (#553). Asked
+  for zero, `GccAna_Circ2dTanOnRad` obliges and returns solution circles of radius zero. A
+  non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let circles = Curve2DGcc.circlesTangentToLineOnLineWithRadius(
@@ -923,6 +946,8 @@ public static func circlesTangentOnCurveWithRadius(
 - **Parameters:** `curve` — tangent curve; `qualifier` — qualifier; `centerOn` — center-constraint curve; `radius` — fixed radius; `tolerance` — tolerance.
 - **Returns:** Array of circle solutions.
 - **OCCT:** `Geom2dGcc_Circ2dTanOnRad`.
+- **Note:** `radius` is the radius of the circles to find, and it must be positive; zero would ask
+  for a solution circle that is a point (#553). A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let spine = Curve2D.interpolate(

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -2199,6 +2199,9 @@ public static func gceCircle(center: SIMD2<Double>, radius: Double) -> Curve2D?
 ```
 
 - **OCCT:** `GC_MakeCircle2d` via `OCCTCurve2DMakeCircleCenterRadius`.
+- **Note:** `radius` must be positive (#553). `GC_MakeCircle2d` reports `gce_NegativeRadius` for a
+  negative radius but succeeds for zero, returning a circle that behaves as its own centre. A
+  non-positive radius returns nil.
 
 ---
 
@@ -2236,6 +2239,10 @@ public static func gceCircleParallel(center: SIMD2<Double>, direction: SIMD2<Dou
 ```
 
 - **OCCT:** `GC_MakeCircle2d` (parallel) via `OCCTCurve2DMakeCircleParallel`.
+- **Note:** `radius` must be positive, and so must `radius + distance` (#553). `GC_MakeCircle2d`
+  takes the absolute value rather than refusing an offset that reaches or passes the centre:
+  measured, radius 5 offset by -5 gives radius 0 and by -6 gives radius 1, a circle inside the base
+  rather than the one asked for. Either violation returns nil.
 
 ---
 
@@ -2249,6 +2256,7 @@ public static func gceCircle(axisCenter: SIMD2<Double>, axisDirection: SIMD2<Dou
 ```
 
 - **OCCT:** `GC_MakeCircle2d` (axis) via `OCCTCurve2DMakeCircleAxis`.
+- **Note:** `radius` must be positive (#553); a non-positive radius returns nil.
 - **Example:**
   ```swift
   if let c = Curve2D.gceCircle(center: SIMD2(0, 0), radius: 5) {

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1213,6 +1213,9 @@ public static func edge2dFromCircle(
 - **Parameters:** `center` — 2D circle centre; `direction` — orientation; `radius` — radius; `p1`, `p2` — angular bounds.
 - **Returns:** 2D edge shape, or `nil` on failure.
 - **OCCT:** `BRepBuilderAPI_MakeEdge2d(gp_Circ2d, p1, p2)` via `OCCTMakeEdge2dFromCircle`.
+- **Note:** `radius` must be positive (#553). `BRepBuilderAPI_MakeEdge2d` reports success for a
+  zero radius and hands back a zero-length edge with both vertices at the centre, so the radius is
+  checked before OCCT sees it. A non-positive radius returns nil.
 
 ---
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -1230,6 +1230,11 @@ public static func circleTangent3Circles(
 
 - **Returns:** Array of up to 8 solution circles.
 - **OCCT:** `GccAna_Circ2d3Tan` (3 circles)
+- **Note:** every radius must be positive (#553). A zero-radius argument is a point, and the solver
+  does not answer the point question when it is given one: measured, it returns each solution twice,
+  because tangency to a circle of radius zero satisfies the enclosing and the outside qualifier at
+  once. Use `circleTangent2CirclesPoint`, `circleTangentCircle2Points` or `circleThrough3Points` to
+  name a point as a point. A non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let sols = Shape.circleTangent3Circles(
@@ -1253,6 +1258,8 @@ public static func circleTangent2CirclesPoint(
 ```
 
 - **OCCT:** `GccAna_Circ2d3Tan` (2 circles + point)
+- **Note:** both radii must be positive (#553). With a zero radius the solution set comes back
+  padded with repeats: measured, four solutions holding two distinct circles.
 - **Example:**
   ```swift
   let sols = Shape.circleTangent2CirclesPoint(
@@ -1275,6 +1282,9 @@ public static func circleTangentCircle2Points(
 ```
 
 - **OCCT:** `GccAna_Circ2d3Tan` (circle + 2 points)
+- **Note:** `circleRadius` must be positive (#553). This is the case where reading a zero-radius
+  circle as a point fails outright: measured, the solver finds nothing at all, where
+  `circleThrough3Points` on the same three positions finds the circle through them.
 - **Example:**
   ```swift
   let sols = Shape.circleTangentCircle2Points(

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -476,6 +476,9 @@ public func circlesTangentToLines(_ l1Origin: SIMD2<Double>, _ l1Direction: SIMD
 - **Parameters:** `l1Origin`, `l1Direction` — first line (point + direction); `l2Origin`, `l2Direction` — second line; `radius` — required circle radius; `tolerance` — geometric tolerance.
 - **Returns:** Array of up to four `Circle2DSolution` values (may be empty if no solution exists).
 - **OCCT:** `GccAna_Circ2d2TanRad` (Lin+Lin variant) via `OCCTGccAnaCirc2d2TanRadLineLin`.
+- **Note:** `radius` is the radius of the circles to find, and it must be positive (#553). Asked
+  for zero, `GccAna_Circ2d2TanRad` obliges and returns solution circles of radius zero. A
+  non-positive radius returns an empty array.
 - **Example:**
   ```swift
   let circles = circlesTangentToLines(SIMD2(0,0), SIMD2(1,0),
@@ -498,6 +501,9 @@ public func circlesThroughPointsWithRadius(_ p1: SIMD2<Double>, _ p2: SIMD2<Doub
 - **Parameters:** `p1`, `p2` — two points to pass through; `radius` — required circle radius; `tolerance` — geometric tolerance.
 - **Returns:** Array of up to two `Circle2DSolution` values.
 - **OCCT:** `GccAna_Circ2d2TanRad` (Pnt+Pnt variant) via `OCCTGccAnaCirc2d2TanRadPntPnt`.
+- **Note:** `radius` is the radius of the circles to find, and it must be positive; zero would ask
+  for a solution circle that is a point (#553). A non-positive radius returns an empty array, as
+  does a radius too small to reach both points.
 - **Example:**
   ```swift
   let circles = circlesThroughPointsWithRadius(SIMD2(-3, 0), SIMD2(3, 0), radius: 5)
@@ -606,6 +612,8 @@ public func linesTangentToCircleThroughPoint(circleCenter: SIMD2<Double>,
 - **Parameters:** `circleCenter`, `circleRadius` — the circle; `point` — point the line must pass through; `tolerance` — geometric tolerance.
 - **Returns:** Array of up to two `Line2DSolution` values (one if the point lies on the circle).
 - **OCCT:** `GccAna_Lin2d2Tan` (Circ+Pnt variant) via `OCCTGccAnaLin2d2TanCircPnt`.
+- **Note:** `circleRadius` must be positive (#553). With a radius of zero the solver returns the
+  single line through the centre twice; the point/point entry points answer that question once.
 - **Example:**
   ```swift
   let tangents = linesTangentToCircleThroughPoint(circleCenter: .zero,


### PR DESCRIPTION
Split out of #514, the last unresolved part of the 2D circle-radius family.

About 25 sites in `OCCTBridge_Geom2d.mm` build a `gp_Circ2d` from caller-supplied doubles as an
**input** to a tangency, bisector, intersection or extrema solver rather than as geometry being
returned. #514 stopped there on purpose: a zero-radius circle handed to such a solver is
geometrically a point, several of them have a documented answer for a point argument, and guarding
blindly could have removed a query some callers were legitimately making.

So it was measured, per family, against OCCT's own point overload of the same query. The probe is in
[`Scripts/repro/553-gcc-zero-radius-circle/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/553-geom2dgcc-circle-radius/Scripts/repro/553-gcc-zero-radius-circle).

## No family answers the point question

| family | a zero-radius argument gives | OCCT's own point overload gives |
|---|---|---|
| `GccAna_Circ2dBisec` | 4 solutions, each duplicated; with **both** radii 0, two of the three are hyperbolas of **major radius 0** | `GccAna_CircPnt2dBisec` gives 2; `GccAna_Pnt2dBisec` gives the perpendicular bisector line |
| `GccAna_CircPnt2dBisec` | 2 hyperbolas of **major radius 0** | a **line** — the returned *type* is wrong, not merely duplicated |
| `GccAna_CircLin2dBisec` | the point overload's parabola, twice | it once |
| `GccAna_Lin2dTanPar` / `Lin2dTanPer` | the point overload's line, twice | it once |
| `GccAna_Lin2d2Tan` | the point overload's line, twice | it once |
| `GccAna_Circ2d3Tan`, three circles | 8 solutions: the point overload's 4, each twice | 4, tangency residuals < 1e-14 |
| `GccAna_Circ2d3Tan`, one circle + two points | **0 solutions** | the circle circumscribing the three positions |
| `Extrema_ExtPElC2d` | **0 extrema** — the distance is lost outright | — |
| `Extrema_ExtElC2d` | the right distance, twice | — |
| `IntAna2d_AnaIntersection` | the right point, with `ParamOnSecond()` **NaN**, written straight into the caller's `param2` | — |

The duplication has a cause worth recording: tangency to a circle of radius 0 satisfies the
enclosing and the outside qualifier at once, so the solver enumerates each solution twice. And the
hyperbolas of major radius 0 are the same degenerate conic `occtValidHyperbolaRadii` refuses to
construct on the other side of this file, so the bisector families were handing back curves the
construction API would not accept.

Every one of those families already has a point entry point in the same API — `GccAnaBisector.ofPoints`,
`ofLineAndPoint`, `Curve2DGcc.lineParallelThrough`, `linePerpendicularThrough`,
`Shape.circleThrough3Points`, the point/point line solvers, the mixed circle/point overloads. Naming
a point as a point already has a spelling, and a degenerate circle is not it. **Guard, in every
family** — a decision reached per family, which converged.

## Negative was never the gap

`gp_Circ2d`'s constructor is `constexpr` in the header, so its
`Standard_ConstructionError_Raise_if(theRadius < 0.0, …)` **does** run in a bridge translation unit —
the same finding #514 made for `gp_Elips2d`, measured again here — and the existing `catch` already
turned it into an empty result. `GC_MakeCircle2d` reports `gce_NegativeRadius`, a status rather than
a macro, so `No_Exception` does not void that either. These guards change what **zero** does,
nothing else.

## Two more radius contracts in the same file

- **The radius of the circle a solver must find.** `OCCTGccCircle2d2TanRad`,
  `OCCTGccCircle2dTanPtRad` and `OCCTGccCircle2d2PtRad` each spelled `radius <= 0` inline; four
  siblings did not check at all. Measured, `GccAna_Circ2d2TanRad` and `GccAna_Circ2dTanOnRad` asked
  for radius 0 hand back solution circles of radius 0. All seven now share `occtValidCircleRadius`.
- **Four producer sites #514 did not reach.** `BRepBuilderAPI_MakeEdge2d` reports `IsDone()` for a
  zero-radius arc and returns a zero-length edge with both vertices at the centre;
  `GC_MakeCircle2d(ax, 0)` succeeds. `Curve2D.gceCircleParallel` needed the offset checked as well:
  `GC_MakeCircle2d` takes the **absolute value** of `radius + dist`, so radius 5 offset by -5 gives
  radius 0 and by -6 gives radius 1 — a circle the caller did not ask for, not a refusal.

## Contract and docs

A rejected radius returns an empty array (`nil` for the producers), which is what these entry points
already returned for "no solutions", so **no call site has to move and no signature changed**. Every
affected Swift entry point now documents its radius contract with a runnable snippet; none of them
mentioned it before, which was point 3 of the issue.

## Verification

22 tests in `Tests/OCCTGeom2dTests/Issue553GccZeroRadiusTests.swift`, run against a build with the
zero rejection removed: **16 fail**. The 6 that do not are the four valid-input controls, the
negative-radius test, and the two cases where OCCT's own wrong answer is itself an empty set
(`circleTangentCircle2Points`, `distanceFromPointToCircle`), which no assertion can discriminate;
both are noted as such in the test file. Full suite green, **4936 tests**.

## Deliberately not changed

`extractBisecSolution`'s `default` branch writes `(0, 0)` for a `GccInt_Pnt` solution instead of its
coordinates. Section 13 of the probe hunts for one — identical, concentric, externally tangent,
internally tangent and crossing circles, a point on the circle, a point at the centre — and none of
them, nor any zero-radius case, produces one. Left alone rather than fixed speculatively.

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)