### PR TITLE
fix(#554): the 3D conic sites that took a dimension and never checked it

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1137,6 +1137,7 @@ OCCTCurve3DRef OCCTCurve3DArcOfEllipse(double centerX, double centerY, double ce
                                          double majorRadius, double minorRadius,
                                          double angle1, double angle2, bool sense) {
     try {
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
         gp_Ax2 ax(gp_Pnt(centerX, centerY, centerZ), gp_Dir(normalX, normalY, normalZ));
         gp_Elips elips(ax, majorRadius, minorRadius);
         GC_MakeArcOfEllipse maker(elips, angle1, angle2, sense);
@@ -1153,6 +1154,9 @@ OCCTCurve3DRef OCCTCurve3DArcOfEllipsePoints(double centerX, double centerY, dou
                                                double p1X, double p1Y, double p1Z,
                                                double p2X, double p2Y, double p2Z, bool sense) {
     try {
+        // Not redundant with the IsDone() check below: a zero minor radius makes the two-point
+        // form's ElCLib::Parameter inversion NaN, and IsDone() still reports true (#554).
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
         gp_Ax2 ax(gp_Pnt(centerX, centerY, centerZ), gp_Dir(normalX, normalY, normalZ));
         gp_Elips elips(ax, majorRadius, minorRadius);
         GC_MakeArcOfEllipse maker(elips, gp_Pnt(p1X, p1Y, p1Z), gp_Pnt(p2X, p2Y, p2Z), sense);
@@ -1301,6 +1305,7 @@ OCCTCurve3DRef OCCTCurve3DArcOfHyperbola(
     double dirX, double dirY, double dirZ,
     double alpha1, double alpha2, bool sense) {
     try {
+        if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
         gp_Ax2 ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
         gp_Hypr hypr(ax, majorRadius, minorRadius);
         GC_MakeArcOfHyperbola maker(hypr, alpha1, alpha2, sense ? Standard_True : Standard_False);
@@ -1321,6 +1326,7 @@ OCCTCurve3DRef OCCTCurve3DArcOfParabola(
     double dirX, double dirY, double dirZ,
     double alpha1, double alpha2, bool sense) {
     try {
+        if (!occtValidParabolaFocal(focalDistance)) return nullptr;
         gp_Ax2 ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
         gp_Parab parab(ax, focalDistance);
         GC_MakeArcOfParabola maker(parab, alpha1, alpha2, sense ? Standard_True : Standard_False);
@@ -1390,6 +1396,7 @@ bool OCCTCurve3DSplitAt(OCCTCurve3DRef curve, double splitParam,
 OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipse(double cx, double cy, double cz,
     double dx, double dy, double dz, double majorRadius, double minorRadius) {
     try {
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(dx, dy, dz));
         GC_MakeEllipse me(ax, majorRadius, minorRadius);
         if (!me.IsDone()) return nullptr;
@@ -1422,6 +1429,7 @@ OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipseThreePoints(
 OCCTCurve3DRef _Nullable OCCTCurve3DMakeHyperbola(double cx, double cy, double cz,
     double dx, double dy, double dz, double majorRadius, double minorRadius) {
     try {
+        if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(dx, dy, dz));
         GC_MakeHyperbola mh(ax, majorRadius, minorRadius);
         if (!mh.IsDone()) return nullptr;
@@ -2918,6 +2926,7 @@ OCCTCurve3DRef OCCTGCMakeEllipse(double cx, double cy, double cz,
                                    double nx, double ny, double nz,
                                    double major, double minor) {
     try {
+        if (!occtValidEllipseRadii(major, minor)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         GC_MakeEllipse me(ax, major, minor);
         if (!me.IsDone()) return nullptr;
@@ -2944,6 +2953,7 @@ OCCTCurve3DRef OCCTGCMakeEllipseFromElips(double cx, double cy, double cz,
                                             double xdx, double xdy, double xdz,
                                             double major, double minor) {
     try {
+        if (!occtValidEllipseRadii(major, minor)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), gp_Dir(xdx, xdy, xdz));
         GC_MakeEllipse me(ax, major, minor);
         if (!me.IsDone()) return nullptr;
@@ -2959,6 +2969,7 @@ OCCTCurve3DRef OCCTGCMakeHyperbola(double cx, double cy, double cz,
                                      double nx, double ny, double nz,
                                      double major, double minor) {
     try {
+        if (!occtValidHyperbolaRadii(major, minor)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         GC_MakeHyperbola mh(ax, major, minor);
         if (!mh.IsDone()) return nullptr;
@@ -3385,6 +3396,7 @@ bool OCCTCurve3DCircleSetRadius(OCCTCurve3DRef curve, double radius) {
     try {
         Handle(Geom_Circle) c = Handle(Geom_Circle)::DownCast(curve->curve);
         if (c.IsNull()) return false;
+        if (!occtValidCircleRadius(radius)) return false;
         c->SetRadius(radius);
         return true;
     } catch (...) { return false; }
@@ -3459,6 +3471,9 @@ bool OCCTCurve3DEllipseSetMajorRadius(OCCTCurve3DRef curve, double r) {
     try {
         Handle(Geom_Ellipse) e = Handle(Geom_Ellipse)::DownCast(curve->curve);
         if (e.IsNull()) return false;
+        // The pair has to stay a valid ellipse, so the new value is judged against the radius
+        // already on the curve, not on its own (#554).
+        if (!occtValidEllipseRadii(r, e->MinorRadius())) return false;
         e->SetMajorRadius(r);
         return true;
     } catch (...) { return false; }
@@ -3469,6 +3484,7 @@ bool OCCTCurve3DEllipseSetMinorRadius(OCCTCurve3DRef curve, double r) {
     try {
         Handle(Geom_Ellipse) e = Handle(Geom_Ellipse)::DownCast(curve->curve);
         if (e.IsNull()) return false;
+        if (!occtValidEllipseRadii(e->MajorRadius(), r)) return false;
         e->SetMinorRadius(r);
         return true;
     } catch (...) { return false; }
@@ -3560,6 +3576,7 @@ bool OCCTCurve3DHyperbolaSetMajorRadius(OCCTCurve3DRef curve, double r) {
     try {
         Handle(Geom_Hyperbola) h = Handle(Geom_Hyperbola)::DownCast(curve->curve);
         if (h.IsNull()) return false;
+        if (!occtValidHyperbolaRadii(r, h->MinorRadius())) return false;
         h->SetMajorRadius(r);
         return true;
     } catch (...) { return false; }
@@ -3570,6 +3587,7 @@ bool OCCTCurve3DHyperbolaSetMinorRadius(OCCTCurve3DRef curve, double r) {
     try {
         Handle(Geom_Hyperbola) h = Handle(Geom_Hyperbola)::DownCast(curve->curve);
         if (h.IsNull()) return false;
+        if (!occtValidHyperbolaRadii(h->MajorRadius(), r)) return false;
         h->SetMinorRadius(r);
         return true;
     } catch (...) { return false; }
@@ -3632,6 +3650,7 @@ bool OCCTCurve3DParabolaSetFocal(OCCTCurve3DRef curve, double focal) {
     try {
         Handle(Geom_Parabola) p = Handle(Geom_Parabola)::DownCast(curve->curve);
         if (p.IsNull()) return false;
+        if (!occtValidParabolaFocal(focal)) return false;
         p->SetFocal(focal);
         return true;
     } catch (...) { return false; }
@@ -3851,6 +3870,9 @@ int32_t OCCTExtremaElCLinElips(double lpx, double lpy, double lpz, double ldx, d
                                 double tolerance,
                                 OCCTExtremaElResult* out, int32_t max) {
     try {
+        // A degenerate ellipse does not give a degenerate answer here, it gives a wrong one:
+        // Extrema_ExtElC reports IsParallel() against a (0, 0) ellipse (#554).
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return -1;
         gp_Lin l(gp_Pnt(lpx, lpy, lpz), gp_Dir(ldx, ldy, ldz));
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), gp_Dir(xdx, xdy, xdz));
         gp_Elips elips(ax, majorRadius, minorRadius);
@@ -4009,6 +4031,10 @@ int32_t OCCTExtremaExtPElCElips(double px, double py, double pz,
                                   double tolerance,
                                   OCCTExtremaElResult* out, int32_t max) {
     try {
+        // Extrema_ExtPElC reports NbExt() == 0 against a (0, 0) ellipse rather than the one
+        // extremum at its centre, so "no extrema" would be a wrong answer, not a degenerate
+        // one (#554).
+        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return -1;
         gp_Pnt p(px, py, pz);
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), gp_Dir(xdx, xdy, xdz));
         gp_Elips elips(ax, majorRadius, minorRadius);
@@ -4034,6 +4060,7 @@ int32_t OCCTExtremaExtPElCParab(double px, double py, double pz,
                                   double tolerance,
                                   OCCTExtremaElResult* out, int32_t max) {
     try {
+        if (!occtValidParabolaFocal(focal)) return -1;
         gp_Pnt p(px, py, pz);
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), gp_Dir(xdx, xdy, xdz));
         gp_Parab parab(ax, focal);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -604,39 +604,71 @@ int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, Kn
         [&](int32_t i) { return knotAt(splitIndexAt(i)); }, outParams, maxParams);
 }
 
-// === #399/#411/#487: conic dimension preconditions ===
+// === #399/#411/#487/#514/#554: conic dimension preconditions ===
 //
 // The dimensions a circle, ellipse, hyperbola or parabola needs in order to be that curve rather
 // than a degenerate stand-in for a point or a line. Not dimension-specific: whether the conic is
 // built in a plane or in space changes nothing about which radii describe one, so these four
 // predicates serve both the Curve3D and the Curve2D factories.
 //
-// Two families build each curve type from caller-supplied dimensions, and every one of them needs
-// the same answer: the direct family (OCCTCurve3DCreate*, OCCTCurve2DCreate*, including the ArcOf*
-// variants) constructing a Geom_* / Geom2d_* object outright, and the gce family (OCCTGceMake*,
-// OCCTGceMake*2d) going through a gce_Make* algorithm first.
+// Four routes reach a conic from caller-supplied dimensions, and every one of them needs the same
+// answer: the direct family (OCCTCurve3DCreate*, OCCTCurve2DCreate*, including the ArcOf* variants)
+// constructing a gp_* / Geom_* / Geom2d_* object outright, the gce family (OCCTGceMake*) and the GC
+// family (OCCTGCMake*, OCCTCurve3DMake*) going through an algorithm class first, and the setters
+// (OCCTCurve3D{Ellipse,Hyperbola,Parabola,Circle}Set*) rewriting one dimension of a live curve.
 //
-// They must be checked here, in the bridge, and not left to OCCT. Every OCCT precondition is
+// They must be checked here, in the bridge, and not left to OCCT. Most OCCT preconditions are
 // written as a *_Raise_if macro, and the pinned OCCT.xcframework is a Release build, where OCCT's
 // own BUILD_RELEASE_DISABLE_EXCEPTIONS (default ON) defines No_Exception and expands all of those
-// macros to nothing inside OCCT's translation units. So the checks OCCT documents in its headers do
-// not run in this build; measured consequences (#487):
+// macros to nothing inside OCCT's translation units. Which checks survive therefore depends on
+// *where the check is written*, and the three cases behave differently (measured, #487/#514/#554):
 //
-//   - gce_MakeElips2d(ax, 5, -3) reports gce_Done and yields a live Geom2d_Ellipse whose
-//     MinorRadius() is -3. Its own two checks (MajorRadius < 0, MajorRadius < MinorRadius) do not
-//     cover that input, and gp_Elips2d's check, which would, is compiled out.
-//   - gce_MakeHypr2d(ax, 0, 0, true) and gce_MakeParab2d(ax, 0) both succeed, as do the
-//     corresponding direct Geom2d_Hyperbola / Geom2d_Parabola constructors. OCCT accepts these
-//     through every route; rejecting them is entirely this bridge's contract.
+//   - A macro inside OCCT's own .cxx is gone. gce_MakeElips2d(ax, 5, -3) reports gce_Done and
+//     yields a live Geom2d_Ellipse whose MinorRadius() is -3; gce_MakeHypr2d(ax, 0, 0, true) and
+//     gce_MakeParab2d(ax, 0) both succeed. OCCT accepts these through every route.
+//   - A macro in a header the bridge includes still runs, because it is compiled in *our* TU.
+//     gp_Elips/gp_Hypr/gp_Parab (and their 2d counterparts) are constexpr in the header, so
+//     gp_Elips(ax, 5, -3), gp_Elips(ax, 3, 5), gp_Hypr(ax, -5, 3) and gp_Parab(ax, -2) all raise
+//     and the surrounding catch already turns them into a failure.
+//   - A hand-written `if (...) throw` is not a macro and survives everywhere. Geom_Ellipse's
+//     setters are spelled that way, so SetMinorRadius(-3) and SetMajorRadius below the current
+//     minor both raise from inside OCCT's TU.
+//
+// The residue those three leave is the same in every family: ZERO. It satisfies every check
+// written (`minor < 0 || major < minor` is false for (0, 0)), so it is the one degenerate input
+// that arrives intact by every route, and it is what these predicates exist to reject.
 //
 // A degenerate conic is not a harmless curve either: a zero-radius ellipse evaluates to its own
 // centre at every parameter while still reporting a [0, 2pi] range, so it reads as a curve
-// everywhere downstream and behaves as a point.
+// everywhere downstream and behaves as a point. The sharpest measured case is
+// GC_MakeArcOfEllipse's two-point form, where a zero minor radius makes the ElCLib::Parameter
+// inversion return NaN for both bounds: IsDone() still reports true, so the `if (!IsDone())` guard
+// a bridge function would normally rely on passes, and the caller receives a live curve whose
+// every evaluation is NaN.
 //
 // One definition each, because the alternative is what the audit found: #399 added these four to
 // OCCTBridge_Curve3D.mm, #411 added a byte-equivalent occtValidCircle2dRadius to
 // OCCTBridge_Geom2d.mm, and the 2D direct factories spelled the same conditions inline in six more
 // places, which is how the 2D gce factories came to be skipped by both passes.
+//
+// Whether a *query* taking these dimensions needs the same guard is decided per site by the test
+// #553 settled on: probe whether OCCT actually returns the degenerate answer. Being a read-only
+// query is not the criterion, since that is exactly where a wrong answer hides quietly.
+//
+// Guarded, because OCCT does not answer the degenerate question (#554):
+//
+//   - OCCTExtremaExtPElCElips / OCCTExtremaExtPElCParab: Extrema_ExtPElC reports NbExt() == 0
+//     against a (0, 0) ellipse rather than the one extremum at its centre.
+//   - OCCTExtremaElCLinElips: Extrema_ExtElC reports IsParallel() whatever the line does.
+//
+// Not guarded, because OCCT does answer it, and neither has a channel to report a rejection
+// through without widening its signature:
+//
+//   - OCCTElCLibValueOnEllipse evaluates the degenerate conic exactly as it is defined
+//     (ElCLib::Value(1.0, gp_Elips(ax, 5, 0)) is (2.70151, 0, 0), a point on the collapsed
+//     segment), and returns void.
+//   - The OCCTBndLib* conic entry points return the true bounding box of the degenerate curve
+//     (a tolerance-sized box at the centre for (0, 0)), and return void.
 
 // A circle needs a positive radius. Zero collapses it to its own centre.
 inline bool occtValidCircleRadius(double radius) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -8081,6 +8081,9 @@ OCCTShapeRef OCCTMakeEdgeFromEllipse(double cx, double cy, double cz,
                                       double nx, double ny, double nz,
                                       double major, double minor) {
     try {
+        // BRepBuilderAPI_MakeEdge reports IsDone() for every degenerate conic, so without this
+        // the caller gets a live edge carrying a curve that is really a point (#554).
+        if (!occtValidEllipseRadii(major, minor)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         gp_Elips elips(ax, major, minor);
         BRepBuilderAPI_MakeEdge me(elips);
@@ -8096,6 +8099,7 @@ OCCTShapeRef OCCTMakeEdgeFromEllipseArc(double cx, double cy, double cz,
                                           double major, double minor,
                                           double u1, double u2) {
     try {
+        if (!occtValidEllipseRadii(major, minor)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         gp_Elips elips(ax, major, minor);
         BRepBuilderAPI_MakeEdge me(elips, u1, u2);
@@ -8111,6 +8115,7 @@ OCCTShapeRef OCCTMakeEdgeFromHyperbolaArc(double cx, double cy, double cz,
                                             double major, double minor,
                                             double u1, double u2) {
     try {
+        if (!occtValidHyperbolaRadii(major, minor)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         gp_Hypr hypr(ax, major, minor);
         BRepBuilderAPI_MakeEdge me(hypr, u1, u2);
@@ -8125,6 +8130,7 @@ OCCTShapeRef OCCTMakeEdgeFromParabolaArc(double cx, double cy, double cz,
                                            double nx, double ny, double nz,
                                            double focal, double u1, double u2) {
     try {
+        if (!occtValidParabolaFocal(focal)) return nullptr;
         gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
         gp_Parab parab(ax, focal);
         BRepBuilderAPI_MakeEdge me(parab, u1, u2);

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -888,7 +888,22 @@ extension Curve3D {
     ///   - startAngle: Start angle in radians
     ///   - endAngle: End angle in radians
     ///   - counterclockwise: Arc direction (default: true)
-    /// - Returns: The elliptical arc curve, or nil on failure
+    /// - Returns: The elliptical arc curve, or `nil` on failure, including when the radii do not
+    ///   describe an ellipse.
+    ///
+    /// `majorRadius` and `minorRadius` must both be `> 0` with `minorRadius <= majorRadius`, the
+    /// same contract `ellipse(center:normal:majorRadius:minorRadius:)` enforces. A zero minor
+    /// radius is rejected rather than collapsed onto the major axis.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.arcOfEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                majorRadius: 10, minorRadius: 5,
+    ///                                startAngle: 0, endAngle: .pi)
+    /// #expect(arc != nil)
+    /// #expect(Curve3D.arcOfEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                              majorRadius: 10, minorRadius: 0,
+    ///                              startAngle: 0, endAngle: .pi) == nil)
+    /// ```
     public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
                                      majorRadius: Double, minorRadius: Double,
                                      startAngle: Double, endAngle: Double,
@@ -914,7 +929,23 @@ extension Curve3D {
     ///   - from: Start point (must lie on the ellipse)
     ///   - to: End point (must lie on the ellipse)
     ///   - counterclockwise: Arc direction (default: true)
-    /// - Returns: The elliptical arc curve, or nil on failure
+    /// - Returns: The elliptical arc curve, or `nil` on failure, including when the radii do not
+    ///   describe an ellipse.
+    ///
+    /// Same radius contract as the angular form. It matters more here: this form inverts each
+    /// point back to a parameter, and with a zero minor radius that inversion is `NaN`, which
+    /// OCCT reports as a *successful* construction. Before the radii were checked, this returned
+    /// a live curve whose parameter range and every evaluation were `NaN` (#554).
+    ///
+    /// ```swift
+    /// let arc = Curve3D.arcOfEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                majorRadius: 10, minorRadius: 5,
+    ///                                from: SIMD3(10, 0, 0), to: SIMD3(-10, 0, 0))
+    /// #expect(arc != nil)
+    /// #expect(Curve3D.arcOfEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                              majorRadius: 10, minorRadius: 0,
+    ///                              from: SIMD3(10, 0, 0), to: SIMD3(-10, 0, 0)) == nil)
+    /// ```
     public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
                                      majorRadius: Double, minorRadius: Double,
                                      from: SIMD3<Double>, to: SIMD3<Double>,
@@ -1042,7 +1073,18 @@ extension Curve3D {
     ///   - alpha1: Start parameter value
     ///   - alpha2: End parameter value
     ///   - sense: Direction of parameterization (true = natural)
-    /// - Returns: Trimmed curve representing the arc, or nil on failure
+    /// - Returns: Trimmed curve representing the arc, or `nil` on failure, including when either
+    ///   radius is `<= 0`.
+    ///
+    /// Both radii must be `> 0`. Unlike an ellipse there is no ordering constraint between them:
+    /// a minor radius larger than the major is an ordinary hyperbola.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.arcOfHyperbola(majorRadius: 8, minorRadius: 3, alpha1: 0, alpha2: 1)
+    /// #expect(arc != nil)
+    /// #expect(Curve3D.arcOfHyperbola(majorRadius: 8, minorRadius: 0,
+    ///                                alpha1: 0, alpha2: 1) == nil)
+    /// ```
     public static func arcOfHyperbola(
         center: SIMD3<Double> = .zero,
         direction: SIMD3<Double> = SIMD3(0, 0, 1),
@@ -1069,7 +1111,18 @@ extension Curve3D {
     ///   - alpha1: Start parameter value
     ///   - alpha2: End parameter value
     ///   - sense: Direction of parameterization (true = natural)
-    /// - Returns: Trimmed curve representing the arc, or nil on failure
+    /// - Returns: Trimmed curve representing the arc, or `nil` on failure, including when
+    ///   `focalDistance` is `<= 0`.
+    ///
+    /// `focalDistance` must be `> 0`. At zero the parabola degenerates to a straight line along
+    /// its own axis of symmetry, which is `gp_Parab`'s documented behaviour rather than an error
+    /// it reports, so the arc would build and read as a curve.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.arcOfParabola(focalDistance: 4, alpha1: 0, alpha2: 1)
+    /// #expect(arc != nil)
+    /// #expect(Curve3D.arcOfParabola(focalDistance: 0, alpha1: 0, alpha2: 1) == nil)
+    /// ```
     public static func arcOfParabola(
         center: SIMD3<Double> = .zero,
         direction: SIMD3<Double> = SIMD3(0, 0, 1),
@@ -1560,6 +1613,17 @@ extension Curve3D {
         public var radius: Double { OCCTCurve3DCircleRadius(handle) }
 
         /// Set the radius of the circle.
+        ///
+        /// - Parameter r: New radius. Must be `> 0`; zero collapses the circle onto its centre.
+        /// - Returns: `true` if the radius was written, `false` if the curve is not a circle or
+        ///   `r` is not a valid radius. On `false` the curve is left as it was.
+        ///
+        /// ```swift
+        /// if let c = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+        ///     #expect(c.circleProperties.setRadius(8) == true)
+        ///     #expect(c.circleProperties.setRadius(0) == false)
+        /// }
+        /// ```
         @discardableResult
         public func setRadius(_ r: Double) -> Bool { OCCTCurve3DCircleSetRadius(handle, r) }
 
@@ -1604,10 +1668,39 @@ extension Curve3D {
         public var minorRadius: Double { OCCTCurve3DEllipseMinorRadius(handle) }
 
         /// Set the major radius.
+        ///
+        /// - Parameter r: New major radius. Judged against the minor radius already on the
+        ///   curve, so it must be `> 0` and no smaller than the current `minorRadius`.
+        /// - Returns: `true` if the radius was written, `false` if the curve is not an ellipse or
+        ///   the pair would not describe one. On `false` the curve is left as it was.
+        ///
+        /// ```swift
+        /// if let e = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+        ///                            majorRadius: 10, minorRadius: 5) {
+        ///     #expect(e.ellipseProperties.setMajorRadius(12) == true)
+        ///     #expect(e.ellipseProperties.setMajorRadius(3) == false)  // below the minor
+        /// }
+        /// ```
         @discardableResult
         public func setMajorRadius(_ r: Double) -> Bool { OCCTCurve3DEllipseSetMajorRadius(handle, r) }
 
         /// Set the minor radius.
+        ///
+        /// - Parameter r: New minor radius. Judged against the major radius already on the curve,
+        ///   so it must be `> 0` and no larger than the current `majorRadius`.
+        /// - Returns: `true` if the radius was written, `false` if the curve is not an ellipse or
+        ///   the pair would not describe one. On `false` the curve is left as it was.
+        ///
+        /// Zero is rejected here as it is at construction: it would leave a live `Geom_Ellipse`
+        /// that evaluates onto its own major axis at every parameter.
+        ///
+        /// ```swift
+        /// if let e = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
+        ///                            majorRadius: 10, minorRadius: 5) {
+        ///     #expect(e.ellipseProperties.setMinorRadius(3) == true)
+        ///     #expect(e.ellipseProperties.setMinorRadius(0) == false)
+        /// }
+        /// ```
         @discardableResult
         public func setMinorRadius(_ r: Double) -> Bool { OCCTCurve3DEllipseSetMinorRadius(handle, r) }
 
@@ -1658,10 +1751,35 @@ extension Curve3D {
         public var minorRadius: Double { OCCTCurve3DHyperbolaMinorRadius(handle) }
 
         /// Set the major radius.
+        ///
+        /// - Parameter r: New major radius. Must be `> 0`. Unlike an ellipse there is no ordering
+        ///   constraint against the minor radius.
+        /// - Returns: `true` if the radius was written, `false` if the curve is not a hyperbola or
+        ///   `r` is not a valid radius. On `false` the curve is left as it was.
+        ///
+        /// ```swift
+        /// if let h = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+        ///                              majorRadius: 8, minorRadius: 3) {
+        ///     #expect(h.hyperbolaProperties.setMajorRadius(7) == true)
+        ///     #expect(h.hyperbolaProperties.setMajorRadius(0) == false)
+        /// }
+        /// ```
         @discardableResult
         public func setMajorRadius(_ r: Double) -> Bool { OCCTCurve3DHyperbolaSetMajorRadius(handle, r) }
 
         /// Set the minor radius.
+        ///
+        /// - Parameter r: New minor radius. Must be `> 0`; it may exceed the major radius.
+        /// - Returns: `true` if the radius was written, `false` if the curve is not a hyperbola or
+        ///   `r` is not a valid radius. On `false` the curve is left as it was.
+        ///
+        /// ```swift
+        /// if let h = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+        ///                              majorRadius: 8, minorRadius: 3) {
+        ///     #expect(h.hyperbolaProperties.setMinorRadius(4) == true)
+        ///     #expect(h.hyperbolaProperties.setMinorRadius(0) == false)
+        /// }
+        /// ```
         @discardableResult
         public func setMinorRadius(_ r: Double) -> Bool { OCCTCurve3DHyperbolaSetMinorRadius(handle, r) }
 
@@ -1699,6 +1817,18 @@ extension Curve3D {
         public var focal: Double { OCCTCurve3DParabolaFocal(handle) }
 
         /// Set the focal distance.
+        ///
+        /// - Parameter f: New focal distance. Must be `> 0`; at zero the parabola degenerates to
+        ///   a straight line along its own axis of symmetry.
+        /// - Returns: `true` if the value was written, `false` if the curve is not a parabola or
+        ///   `f` is not a valid focal distance. On `false` the curve is left as it was.
+        ///
+        /// ```swift
+        /// if let p = Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 4) {
+        ///     #expect(p.parabolaProperties.setFocal(5) == true)
+        ///     #expect(p.parabolaProperties.setFocal(0) == false)
+        /// }
+        /// ```
         @discardableResult
         public func setFocal(_ f: Double) -> Bool { OCCTCurve3DParabolaSetFocal(handle, f) }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -7805,6 +7805,25 @@ extension Curve3D {
 
 extension Curve3D {
     /// Create a 3D ellipse from axis and major/minor radii.
+    ///
+    /// - Parameters:
+    ///   - center: Ellipse centre.
+    ///   - normal: Normal of the plane the ellipse lies in.
+    ///   - majorRadius: Major radius. Must be `> 0`.
+    ///   - minorRadius: Minor radius. Must be `> 0` and no larger than `majorRadius`.
+    /// - Returns: The ellipse, or `nil` if the radii do not describe one.
+    ///
+    /// `GC_MakeEllipse` reports `!IsDone()` for negative and inverted radii on its own, but
+    /// accepts zero; the radii are checked here so every route to an ellipse enforces the same
+    /// contract as `Curve3D.ellipse(center:normal:majorRadius:minorRadius:)`.
+    ///
+    /// ```swift
+    /// let e = Curve3D.gcEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                           majorRadius: 10, minorRadius: 5)
+    /// #expect(e != nil)
+    /// #expect(Curve3D.gcEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                           majorRadius: 10, minorRadius: 0) == nil)
+    /// ```
     public static func gcEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
                                   majorRadius: Double, minorRadius: Double) -> Curve3D? {
         guard let ref = OCCTGCMakeEllipse(center.x, center.y, center.z,
@@ -7822,6 +7841,16 @@ extension Curve3D {
     }
 
     /// Create a 3D ellipse from full Ax2 (center + normal + X direction) and radii.
+    ///
+    /// Same radius contract as `gcEllipse(center:normal:majorRadius:minorRadius:)`; this overload
+    /// only adds control over where the major axis points.
+    ///
+    /// ```swift
+    /// let e = Curve3D.gcEllipse(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                           xDirection: SIMD3(1, 0, 0),
+    ///                           majorRadius: 10, minorRadius: 5)
+    /// #expect(e != nil)
+    /// ```
     public static func gcEllipse(center: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>,
                                   majorRadius: Double, minorRadius: Double) -> Curve3D? {
         guard let ref = OCCTGCMakeEllipseFromElips(center.x, center.y, center.z,
@@ -7836,6 +7865,21 @@ extension Curve3D {
 
 extension Curve3D {
     /// Create a 3D hyperbola from axis and major/minor radii.
+    ///
+    /// - Parameters:
+    ///   - center: Hyperbola centre.
+    ///   - normal: Normal of the plane the hyperbola lies in.
+    ///   - majorRadius: Major radius. Must be `> 0`.
+    ///   - minorRadius: Minor radius. Must be `> 0`. No ordering constraint against the major.
+    /// - Returns: The hyperbola, or `nil` if either radius is `<= 0`.
+    ///
+    /// ```swift
+    /// let h = Curve3D.gcHyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                             majorRadius: 8, minorRadius: 3)
+    /// #expect(h != nil)
+    /// #expect(Curve3D.gcHyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+    ///                             majorRadius: 0, minorRadius: 3) == nil)
+    /// ```
     public static func gcHyperbola(center: SIMD3<Double>, normal: SIMD3<Double>,
                                     majorRadius: Double, minorRadius: Double) -> Curve3D? {
         guard let ref = OCCTGCMakeHyperbola(center.x, center.y, center.z,
@@ -9936,6 +9980,18 @@ public enum ExtremaElC {
     }
 
     /// Distance between a 3D line and ellipse.
+    ///
+    /// `majorRadius` and `minorRadius` must describe an ellipse (both `> 0`, minor no larger than
+    /// major). A degenerate ellipse returns `[]`: measured, `Extrema_ExtElC` reports
+    /// `IsParallel()` against a zero-radius ellipse whatever the line does (#554).
+    ///
+    /// ```swift
+    /// let ex = ExtremaElC.lineToEllipse(linePoint: SIMD3(0, 0, 10), lineDir: SIMD3(1, 0, 1),
+    ///                                   center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                   xDir: SIMD3(1, 0, 0),
+    ///                                   majorRadius: 5, minorRadius: 3)
+    /// #expect(!ex.isEmpty)
+    /// ```
     public static func lineToEllipse(
         linePoint: SIMD3<Double>, lineDir: SIMD3<Double>,
         center: SIMD3<Double>, normal: SIMD3<Double>, xDir: SIMD3<Double>,
@@ -10159,6 +10215,19 @@ public enum ExtremaPointCurve {
     }
 
     /// Distance from a point to a 3D ellipse.
+    ///
+    /// `majorRadius` and `minorRadius` must describe an ellipse (both `> 0`, minor no larger than
+    /// major). A degenerate ellipse returns `[]`, because OCCT does not answer the degenerate
+    /// question here: measured, `Extrema_ExtPElC` reports no extrema at all against a zero-radius
+    /// ellipse rather than the one at its centre (#554).
+    ///
+    /// ```swift
+    /// let ex = ExtremaPointCurve.pointToEllipse(point: SIMD3(10, 0, 0),
+    ///                                           center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                           xDir: SIMD3(1, 0, 0),
+    ///                                           majorRadius: 5, minorRadius: 3)
+    /// #expect(ex.count == 2)
+    /// ```
     public static func pointToEllipse(
         point: SIMD3<Double>,
         center: SIMD3<Double>, normal: SIMD3<Double>, xDir: SIMD3<Double>,
@@ -10185,6 +10254,15 @@ public enum ExtremaPointCurve {
     }
 
     /// Distance from a point to a 3D parabola.
+    ///
+    /// `focal` must be `> 0`; a degenerate parabola returns `[]`.
+    ///
+    /// ```swift
+    /// let ex = ExtremaPointCurve.pointToParabola(point: SIMD3(10, 0, 0),
+    ///                                            center: .zero, normal: SIMD3(0, 0, 1),
+    ///                                            xDir: SIMD3(1, 0, 0), focal: 2)
+    /// #expect(!ex.isEmpty)
+    /// ```
     public static func pointToParabola(
         point: SIMD3<Double>,
         center: SIMD3<Double>, normal: SIMD3<Double>, xDir: SIMD3<Double>,
@@ -12046,6 +12124,22 @@ extension Surface {
 extension Shape {
 
     /// Create a full ellipse edge.
+    ///
+    /// - Parameters:
+    ///   - center: Ellipse centre.
+    ///   - normal: Normal of the plane the ellipse lies in.
+    ///   - majorRadius: Major radius. Must be `> 0`.
+    ///   - minorRadius: Minor radius. Must be `> 0` and no larger than `majorRadius`.
+    /// - Returns: The edge, or `nil` if the radii do not describe an ellipse.
+    ///
+    /// `BRepBuilderAPI_MakeEdge` reports `IsDone()` for a degenerate conic, so without the radius
+    /// check this returned a live edge carrying a curve that is really a point (#554).
+    ///
+    /// ```swift
+    /// let e = Shape.edgeFromEllipse(majorRadius: 10, minorRadius: 5)
+    /// #expect(e != nil)
+    /// #expect(Shape.edgeFromEllipse(majorRadius: 10, minorRadius: 0) == nil)
+    /// ```
     public static func edgeFromEllipse(center: SIMD3<Double> = .zero, normal: SIMD3<Double> = SIMD3(0,0,1),
                                         majorRadius: Double, minorRadius: Double) -> Shape? {
         guard let ref = OCCTMakeEdgeFromEllipse(center.x, center.y, center.z,
@@ -12055,6 +12149,14 @@ extension Shape {
     }
 
     /// Create an ellipse arc edge.
+    ///
+    /// Same radius contract as `edgeFromEllipse(center:normal:majorRadius:minorRadius:)`.
+    ///
+    /// ```swift
+    /// let e = Shape.edgeFromEllipseArc(majorRadius: 10, minorRadius: 5, u1: 0, u2: .pi)
+    /// #expect(e != nil)
+    /// #expect(Shape.edgeFromEllipseArc(majorRadius: 10, minorRadius: 0, u1: 0, u2: .pi) == nil)
+    /// ```
     public static func edgeFromEllipseArc(center: SIMD3<Double> = .zero, normal: SIMD3<Double> = SIMD3(0,0,1),
                                            majorRadius: Double, minorRadius: Double,
                                            u1: Double, u2: Double) -> Shape? {
@@ -12065,6 +12167,14 @@ extension Shape {
     }
 
     /// Create a hyperbola arc edge.
+    ///
+    /// Both radii must be `> 0`, with no ordering constraint between them.
+    ///
+    /// ```swift
+    /// let e = Shape.edgeFromHyperbolaArc(majorRadius: 8, minorRadius: 3, u1: 0, u2: 1)
+    /// #expect(e != nil)
+    /// #expect(Shape.edgeFromHyperbolaArc(majorRadius: 8, minorRadius: 0, u1: 0, u2: 1) == nil)
+    /// ```
     public static func edgeFromHyperbolaArc(center: SIMD3<Double> = .zero, normal: SIMD3<Double> = SIMD3(0,0,1),
                                              majorRadius: Double, minorRadius: Double,
                                              u1: Double, u2: Double) -> Shape? {
@@ -12075,6 +12185,14 @@ extension Shape {
     }
 
     /// Create a parabola arc edge.
+    ///
+    /// `focalLength` must be `> 0`; at zero the parabola is a straight line along its own axis.
+    ///
+    /// ```swift
+    /// let e = Shape.edgeFromParabolaArc(focalLength: 4, u1: 0, u2: 1)
+    /// #expect(e != nil)
+    /// #expect(Shape.edgeFromParabolaArc(focalLength: 0, u1: 0, u2: 1) == nil)
+    /// ```
     public static func edgeFromParabolaArc(center: SIMD3<Double> = .zero, normal: SIMD3<Double> = SIMD3(0,0,1),
                                             focalLength: Double, u1: Double, u2: Double) -> Shape? {
         guard let ref = OCCTMakeEdgeFromParabolaArc(center.x, center.y, center.z,

--- a/Tests/OCCTCurveTests/Issue554Conic3dDegenerateTests.swift
+++ b/Tests/OCCTCurveTests/Issue554Conic3dDegenerateTests.swift
@@ -1,0 +1,331 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #554: the 3D counterparts of #514. Every bridge site that builds a 3D conic from a
+/// caller-supplied dimension, or rewrites one on a live curve, and never checked it.
+///
+/// The gap is the same one #514 measured in 2D, and for the same reason. OCCT does reject the
+/// obviously-bad values, by three separate mechanisms that survive this build to three different
+/// degrees:
+///
+/// - `gp_Elips`/`gp_Hypr`/`gp_Parab` are `constexpr` in the header, so their
+///   `Standard_ConstructionError_Raise_if` runs in a bridge translation unit and negatives and
+///   inverted ellipse radii already raised.
+/// - `GC_MakeEllipse`/`GC_MakeHyperbola` compile inside OCCT, where `No_Exception` deletes that
+///   macro, but they carry their own status and report `!IsDone()` for the same inputs.
+/// - `Geom_Ellipse`'s setters use a hand-written `if (...) throw`, which is not a macro and so
+///   raises from inside OCCT's own translation unit too.
+///
+/// What all three let through is **zero**, which satisfies every check written
+/// (`minor < 0 || major < minor` is false for `(0, 0)`). These tests pin zero at every site, and
+/// keep the negative/ordering cases as controls so a future change that removes a guard on the
+/// theory that "OCCT already checks" fails here first.
+@Suite("Issue554 3D conic degenerate dimensions")
+struct Issue554Conic3dDegenerateTests {
+
+    private static let center = SIMD3<Double>(0, 0, 0)
+    private static let normal = SIMD3<Double>(0, 0, 1)
+    private static let xDir = SIMD3<Double>(1, 0, 0)
+
+    // MARK: - GC_MakeArcOf* (Curve3D.arcOf*)
+
+    @Test func arcOfEllipseRejectsZeroRadii() {
+        // Measured before the guard: both reported IsDone() and produced a live trimmed curve.
+        // (0, 0) evaluated to its own centre at every parameter; (5, 0) collapsed onto the
+        // major axis, running 5,0,0 -> 0,0,0 over [0, pi].
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 0, minorRadius: 0,
+                                     startAngle: 0, endAngle: .pi) == nil)
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 5, minorRadius: 0,
+                                     startAngle: 0, endAngle: .pi) == nil)
+    }
+
+    @Test func arcOfEllipseRejectsNegativeAndInvertedRadii() {
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 5, minorRadius: -3,
+                                     startAngle: 0, endAngle: .pi) == nil)
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 3, minorRadius: 5,
+                                     startAngle: 0, endAngle: .pi) == nil)
+    }
+
+    @Test func arcOfEllipseAcceptsValidRadii() {
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 5, minorRadius: 3,
+                                     startAngle: 0, endAngle: .pi) != nil)
+        // Equal radii are a circle, which gp_Elips documents as valid.
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 4, minorRadius: 4,
+                                     startAngle: 0, endAngle: .pi) != nil)
+    }
+
+    /// The sharpest case in the issue, and the reason `IsDone()` is not a sufficient guard.
+    @Test func arcOfEllipseThroughPointsRejectsZeroMinorRadius() {
+        // A zero minor radius makes the two-point form's ElCLib::Parameter inversion return NaN
+        // for both bounds (0/0 in its atan2), and GC_MakeArcOfEllipse still reports IsDone().
+        // Measured before the guard: a live Curve3D whose parameter range was [nan, nan] and
+        // whose every evaluation was NaN.
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 5, minorRadius: 0,
+                                     from: SIMD3(5, 0, 0), to: SIMD3(-5, 0, 0)) == nil)
+        #expect(Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                     majorRadius: 0, minorRadius: 0,
+                                     from: SIMD3(1, 0, 0), to: SIMD3(0, 1, 0)) == nil)
+    }
+
+    @Test func arcOfEllipseThroughPointsAcceptsValidRadiiAndIsNotNaN() {
+        // The control that pins the NaN above to the radius and not to the two-point form:
+        // the identical call on a healthy ellipse produces a finite parameter range.
+        let arc = Curve3D.arcOfEllipse(center: Self.center, normal: Self.normal,
+                                       majorRadius: 5, minorRadius: 3,
+                                       from: SIMD3(5, 0, 0), to: SIMD3(-5, 0, 0))
+        #expect(arc != nil)
+        if let arc {
+            #expect(arc.firstParameter.isFinite)
+            #expect(arc.lastParameter.isFinite)
+        }
+    }
+
+    @Test func arcOfHyperbolaRejectsZeroRadii() {
+        #expect(Curve3D.arcOfHyperbola(center: Self.center, direction: Self.normal,
+                                       majorRadius: 0, minorRadius: 0,
+                                       alpha1: 0, alpha2: 1) == nil)
+        #expect(Curve3D.arcOfHyperbola(center: Self.center, direction: Self.normal,
+                                       majorRadius: 5, minorRadius: 0,
+                                       alpha1: 0, alpha2: 1) == nil)
+        #expect(Curve3D.arcOfHyperbola(center: Self.center, direction: Self.normal,
+                                       majorRadius: 0, minorRadius: 5,
+                                       alpha1: 0, alpha2: 1) == nil)
+    }
+
+    @Test func arcOfHyperbolaAcceptsMinorLargerThanMajor() {
+        // A hyperbola puts no ordering on its radii; copying the ellipse rule would reject this.
+        #expect(Curve3D.arcOfHyperbola(center: Self.center, direction: Self.normal,
+                                       majorRadius: 3, minorRadius: 5,
+                                       alpha1: 0, alpha2: 1) != nil)
+    }
+
+    @Test func arcOfParabolaRejectsZeroFocalDistance() {
+        // Measured before the guard: focal 0 gave a live arc that is a straight line along the
+        // parabola's own axis of symmetry, which is what gp_Parab documents zero to mean.
+        #expect(Curve3D.arcOfParabola(center: Self.center, direction: Self.normal,
+                                      focalDistance: 0, alpha1: 0, alpha2: 1) == nil)
+    }
+
+    @Test func arcOfParabolaAcceptsPositiveFocalDistance() {
+        #expect(Curve3D.arcOfParabola(center: Self.center, direction: Self.normal,
+                                      focalDistance: 2, alpha1: 0, alpha2: 1) != nil)
+    }
+
+    // MARK: - GC_MakeEllipse / GC_MakeHyperbola (Curve3D.gc*)
+
+    @Test func gcEllipseRejectsZeroRadii() {
+        #expect(Curve3D.gcEllipse(center: Self.center, normal: Self.normal,
+                                  majorRadius: 0, minorRadius: 0) == nil)
+        #expect(Curve3D.gcEllipse(center: Self.center, normal: Self.normal,
+                                  majorRadius: 5, minorRadius: 0) == nil)
+        #expect(Curve3D.gcEllipse(center: Self.center, normal: Self.normal,
+                                  majorRadius: 5, minorRadius: 3) != nil)
+    }
+
+    @Test func gcEllipseFromFullAxisRejectsZeroRadii() {
+        #expect(Curve3D.gcEllipse(center: Self.center, normal: Self.normal, xDirection: Self.xDir,
+                                  majorRadius: 0, minorRadius: 0) == nil)
+        #expect(Curve3D.gcEllipse(center: Self.center, normal: Self.normal, xDirection: Self.xDir,
+                                  majorRadius: 5, minorRadius: 0) == nil)
+        #expect(Curve3D.gcEllipse(center: Self.center, normal: Self.normal, xDirection: Self.xDir,
+                                  majorRadius: 5, minorRadius: 3) != nil)
+    }
+
+    @Test func gcHyperbolaRejectsZeroRadii() {
+        #expect(Curve3D.gcHyperbola(center: Self.center, normal: Self.normal,
+                                    majorRadius: 0, minorRadius: 0) == nil)
+        #expect(Curve3D.gcHyperbola(center: Self.center, normal: Self.normal,
+                                    majorRadius: 0, minorRadius: 5) == nil)
+        #expect(Curve3D.gcHyperbola(center: Self.center, normal: Self.normal,
+                                    majorRadius: 5, minorRadius: 3) != nil)
+    }
+
+    /// Control for the two three-point forms, which are deliberately *not* guarded: they take no
+    /// dimension at all, and OCCT's own `GC_Make*` status already rejects a degenerate triple.
+    /// If that ever stops being true, this test is where it shows up.
+    @Test func gcThreePointFormsRejectDegeneratePointTriplesWithoutABridgeGuard() {
+        let origin = SIMD3<Double>(0, 0, 0)
+        #expect(Curve3D.gcEllipse(s1: origin, s2: origin, center: origin) == nil)
+        // S2 on the major axis leaves no minor radius to derive.
+        #expect(Curve3D.gcEllipse(s1: SIMD3(5, 0, 0), s2: SIMD3(2, 0, 0), center: origin) == nil)
+        #expect(Curve3D.gcHyperbola(s1: origin, s2: origin, center: origin) == nil)
+        // ... and the healthy triple still builds.
+        #expect(Curve3D.gcEllipse(s1: SIMD3(5, 0, 0), s2: SIMD3(0, 3, 0), center: origin) != nil)
+    }
+
+    // MARK: - BRepBuilderAPI_MakeEdge (Shape.edgeFrom*)
+
+    @Test func edgeFromEllipseRejectsZeroRadii() {
+        // BRepBuilderAPI_MakeEdge reported IsDone() for every degenerate conic below, so before
+        // the guard each of these returned a live edge carrying a curve that is really a point.
+        #expect(Shape.edgeFromEllipse(center: Self.center, normal: Self.normal,
+                                      majorRadius: 0, minorRadius: 0) == nil)
+        #expect(Shape.edgeFromEllipse(center: Self.center, normal: Self.normal,
+                                      majorRadius: 5, minorRadius: 0) == nil)
+        #expect(Shape.edgeFromEllipse(center: Self.center, normal: Self.normal,
+                                      majorRadius: 5, minorRadius: 3) != nil)
+    }
+
+    @Test func edgeFromEllipseArcRejectsZeroRadii() {
+        #expect(Shape.edgeFromEllipseArc(center: Self.center, normal: Self.normal,
+                                         majorRadius: 5, minorRadius: 0, u1: 0, u2: .pi) == nil)
+        #expect(Shape.edgeFromEllipseArc(center: Self.center, normal: Self.normal,
+                                         majorRadius: 5, minorRadius: 3, u1: 0, u2: .pi) != nil)
+    }
+
+    @Test func edgeFromHyperbolaArcRejectsZeroRadii() {
+        #expect(Shape.edgeFromHyperbolaArc(center: Self.center, normal: Self.normal,
+                                           majorRadius: 0, minorRadius: 0, u1: 0, u2: 1) == nil)
+        #expect(Shape.edgeFromHyperbolaArc(center: Self.center, normal: Self.normal,
+                                           majorRadius: 5, minorRadius: 0, u1: 0, u2: 1) == nil)
+        #expect(Shape.edgeFromHyperbolaArc(center: Self.center, normal: Self.normal,
+                                           majorRadius: 5, minorRadius: 3, u1: 0, u2: 1) != nil)
+    }
+
+    @Test func edgeFromParabolaArcRejectsZeroFocalLength() {
+        #expect(Shape.edgeFromParabolaArc(center: Self.center, normal: Self.normal,
+                                          focalLength: 0, u1: 0, u2: 1) == nil)
+        #expect(Shape.edgeFromParabolaArc(center: Self.center, normal: Self.normal,
+                                          focalLength: 2, u1: 0, u2: 1) != nil)
+    }
+
+    // MARK: - Extrema_ExtElC / Extrema_ExtPElC
+
+    /// These are solver inputs, which #553 excluded from the 2D pass on the grounds that a
+    /// degenerate conic can still be a meaningful question. Measured here, it is not: OCCT does
+    /// not answer the degenerate question, it answers a different one.
+    @Test func pointToEllipseRejectsZeroRadii() {
+        // Measured before the guard: NbExt() == 0 against a (0, 0) ellipse, so the caller was
+        // told "no extrema" rather than the one extremum at the centre.
+        #expect(ExtremaPointCurve.pointToEllipse(point: SIMD3(10, 0, 0),
+                                                 center: Self.center, normal: Self.normal,
+                                                 xDir: Self.xDir,
+                                                 majorRadius: 0, minorRadius: 0).isEmpty)
+        #expect(ExtremaPointCurve.pointToEllipse(point: SIMD3(10, 0, 0),
+                                                 center: Self.center, normal: Self.normal,
+                                                 xDir: Self.xDir,
+                                                 majorRadius: 5, minorRadius: 0).isEmpty)
+        // The healthy ellipse still answers, with the near and far extremum.
+        #expect(ExtremaPointCurve.pointToEllipse(point: SIMD3(10, 0, 0),
+                                                 center: Self.center, normal: Self.normal,
+                                                 xDir: Self.xDir,
+                                                 majorRadius: 5, minorRadius: 3).count == 2)
+    }
+
+    @Test func pointToParabolaRejectsZeroFocalDistance() {
+        #expect(ExtremaPointCurve.pointToParabola(point: SIMD3(10, 0, 0),
+                                                  center: Self.center, normal: Self.normal,
+                                                  xDir: Self.xDir, focal: 0).isEmpty)
+        #expect(!ExtremaPointCurve.pointToParabola(point: SIMD3(10, 0, 0),
+                                                   center: Self.center, normal: Self.normal,
+                                                   xDir: Self.xDir, focal: 2).isEmpty)
+    }
+
+    @Test func lineToEllipseRejectsZeroRadii() {
+        let linePoint = SIMD3<Double>(0, 0, 10)
+        let lineDir = SIMD3<Double>(1, 0, 1)
+        #expect(ExtremaElC.lineToEllipse(linePoint: linePoint, lineDir: lineDir,
+                                         center: Self.center, normal: Self.normal, xDir: Self.xDir,
+                                         majorRadius: 0, minorRadius: 0).isEmpty)
+        #expect(ExtremaElC.lineToEllipse(linePoint: linePoint, lineDir: lineDir,
+                                         center: Self.center, normal: Self.normal, xDir: Self.xDir,
+                                         majorRadius: 5, minorRadius: 0).isEmpty)
+        #expect(!ExtremaElC.lineToEllipse(linePoint: linePoint, lineDir: lineDir,
+                                          center: Self.center, normal: Self.normal, xDir: Self.xDir,
+                                          majorRadius: 5, minorRadius: 3).isEmpty)
+    }
+
+    // MARK: - Geom_* setters, which degrade a healthy curve in place
+
+    @Test func ellipseSetMinorRadiusRejectsZero() {
+        let e = Curve3D.ellipse(center: Self.center, normal: Self.normal,
+                                majorRadius: 5, minorRadius: 3)
+        #expect(e != nil)
+        guard let e else { return }
+        // Measured before the guard: accepted, leaving a live Geom_Ellipse with minorRadius 0
+        // that evaluates onto its own major axis.
+        #expect(e.ellipseProperties.setMinorRadius(0) == false)
+        #expect(e.ellipseProperties.minorRadius == 3)
+        #expect(e.ellipseProperties.setMinorRadius(2) == true)
+        #expect(e.ellipseProperties.minorRadius == 2)
+    }
+
+    @Test func ellipseSetMajorRadiusKeepsThePairValid() {
+        let e = Curve3D.ellipse(center: Self.center, normal: Self.normal,
+                                majorRadius: 5, minorRadius: 3)
+        #expect(e != nil)
+        guard let e else { return }
+        // Below the current minor radius, which Geom_Ellipse's own hand-written throw already
+        // rejected. Kept as a control on the new pairwise check.
+        #expect(e.ellipseProperties.setMajorRadius(1) == false)
+        #expect(e.ellipseProperties.setMajorRadius(0) == false)
+        #expect(e.ellipseProperties.majorRadius == 5)
+        #expect(e.ellipseProperties.setMajorRadius(9) == true)
+        #expect(e.ellipseProperties.majorRadius == 9)
+    }
+
+    @Test func hyperbolaSettersRejectZero() {
+        let h = Curve3D.hyperbola(center: Self.center, normal: Self.normal,
+                                  majorRadius: 5, minorRadius: 3)
+        #expect(h != nil)
+        guard let h else { return }
+        #expect(h.hyperbolaProperties.setMajorRadius(0) == false)
+        #expect(h.hyperbolaProperties.setMinorRadius(0) == false)
+        #expect(h.hyperbolaProperties.majorRadius == 5)
+        #expect(h.hyperbolaProperties.minorRadius == 3)
+        // No ordering constraint, so a minor above the major is still accepted.
+        #expect(h.hyperbolaProperties.setMinorRadius(8) == true)
+        #expect(h.hyperbolaProperties.minorRadius == 8)
+    }
+
+    @Test func parabolaSetFocalRejectsZero() {
+        let p = Curve3D.parabola(center: Self.center, normal: Self.normal, focal: 2)
+        #expect(p != nil)
+        guard let p else { return }
+        #expect(p.parabolaProperties.setFocal(0) == false)
+        #expect(p.parabolaProperties.focal == 2)
+        #expect(p.parabolaProperties.setFocal(6) == true)
+        #expect(p.parabolaProperties.focal == 6)
+    }
+
+    @Test func circleSetRadiusRejectsZero() {
+        let c = Curve3D.circle(center: Self.center, normal: Self.normal, radius: 5)
+        #expect(c != nil)
+        guard let c else { return }
+        #expect(c.circleProperties.setRadius(0) == false)
+        #expect(c.circleProperties.radius == 5)
+        #expect(c.circleProperties.setRadius(7) == true)
+        #expect(c.circleProperties.radius == 7)
+    }
+
+    // MARK: - The two families deliberately left alone
+
+    /// `BndLib` and `ElCLib` take the same dimensions and are deliberately not guarded: both are
+    /// pure queries that return the *correct* answer for the degenerate curve, and both are
+    /// `void` bridge functions with nowhere to report a rejection. Pinned so the exclusion is a
+    /// recorded decision rather than an oversight, and so a later pass that adds a guard here has
+    /// to change a test that says why it should not.
+    @Test func degenerateEllipseStillEvaluatesAndBoundsCorrectly() {
+        // ElCLib evaluates the collapsed ellipse exactly as gp_Elips defines it: a point on the
+        // major axis at 5*cos(1).
+        let p = ElCLib.valueOnEllipse(u: 1, center: Self.center, normal: Self.normal,
+                                      majorRadius: 5, minorRadius: 0)
+        #expect(abs(p.x - 5 * Foundation.cos(1.0)) < 1e-9)
+        #expect(abs(p.y) < 1e-12)
+
+        // BndLib returns the true box of the segment the collapsed ellipse traces.
+        let b = BndLib.ellipse(center: Self.center, normal: Self.normal, xDirection: Self.xDir,
+                               majorRadius: 5, minorRadius: 0)
+        #expect(abs(b.min.x - -5) < 1e-6)
+        #expect(abs(b.max.x - 5) < 1e-6)
+        #expect(abs(b.max.y) < 1e-6)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -206,6 +206,80 @@ separately. The 3D equivalents are unsurveyed, as #514 noted.
 build with every guard stripped back out: the 10 rejection tests fail, and the 8 that pin valid
 input (including "a hyperbola may have minor > major" and the coefficient order) still pass.
 
+#### The 3D conic sites that took a dimension and never checked it (#554)
+
+The 3D counterparts of #514, which surveyed only the 2D side. Twenty-two sites across
+`OCCTBridge_Curve3D.mm` and `OCCTBridge_Modeling.mm` build a 3D conic from a caller-supplied
+dimension, or rewrite one on a live curve, and none of them checked it. All twenty-two now use the
+same four shared predicates: 11 ellipse, 6 hyperbola, 4 parabola, 1 circle. #399's earlier pass
+covered the `Curve3D` *factories* only.
+
+**The census is wider than the issue's nine `gp_Elips` sites**, because three separate families
+have the same gap by three different mechanisms, and OCCT's own checks survive this build to three
+different degrees:
+
+| family | sites | what OCCT still rejects | what gets through |
+|---|---|---|---|
+| `gp_Elips`/`gp_Hypr`/`gp_Parab` constructed in a bridge TU | 11 | negatives and inverted ellipse radii: the constructor is `constexpr` in the header, so its `Standard_ConstructionError_Raise_if` runs here | zero |
+| `GC_MakeEllipse`/`GC_MakeHyperbola` | 5 | negatives and inverted radii, via the maker's own status (`!IsDone()`) rather than the macro, which `No_Exception` deletes inside OCCT | zero |
+| `Geom_Ellipse`/`Geom_Hyperbola`/`Geom_Parabola`/`Geom_Circle` setters | 6 | negatives, and an ellipse major below its own minor: these are a hand-written `if (...) throw`, not a macro, so `No_Exception` never touched them | zero |
+
+That third row refines #487's rule rather than restating it: `No_Exception` voids the *macro*, not
+every OCCT precondition. `Geom_Ellipse::SetMajorRadius` throws from inside OCCT's own translation
+unit because the check is spelled by hand.
+
+Zero satisfies every check any of the three writes (`minor < 0 || major < minor` is false for
+`(0, 0)`), which is why it is the one degenerate input that arrived intact by every route.
+
+**The sharpest case is `GC_MakeArcOfEllipse`'s two-point form**, where `IsDone()` is not merely
+insufficient but actively misleading. That form inverts each endpoint back to a parameter, which
+divides by the minor radius; at zero both bounds come back `NaN` and the maker still reports
+success. The `if (!maker.IsDone()) return nullptr` line the bridge relied on therefore passed, and
+`Curve3D.arcOfEllipse(…, from:to:)` returned a live curve whose parameter range was `[nan, nan]`
+and whose every evaluation was `NaN`. Measured against the pinned kernel, with the identical call
+on a healthy `(5, 3)` ellipse as the control:
+
+| radii | `IsDone()` | resulting parameter range |
+|---|---|---|
+| `(5, 3)` | true | `[0, 3.14159]` |
+| `(5, 0)` | true | `[nan, nan]` |
+| `(0, 0)` | true | `[nan, nan]` |
+
+**Every site was placed by asking #553's question, not by which OCCT class it calls.** #553 settled
+whether a degenerate conic can be a meaningful *query* rather than a broken construction, and
+answered it by probing whether OCCT actually returns the degenerate answer. Applied here the same
+question splits this family in two, and the split does not follow the "pure query" line it looks
+like it should:
+
+- **The three `Extrema` entry points are guarded**, because OCCT does not answer the degenerate
+  question: `Extrema_ExtPElC` reports `NbExt() == 0` against a `(0, 0)` ellipse rather than the one
+  extremum at its centre, and `Extrema_ExtElC` reports `IsParallel()` regardless of what the line
+  does. Same failure shape #553 measured across the `Gcc` families, and the same conclusion.
+- **`BndLib` and `ElCLib` are excluded**, because they do answer it. `ElCLib::Value(1.0,
+  gp_Elips(ax, 5, 0))` is `(2.70151, 0, 0)`, a point on the collapsed segment, which is exactly
+  what that curve is; `BndLib::Add` returns the true box of it. Both are also `void` with nowhere
+  to report a rejection, so guarding them would mean widening a signature in order to refuse an
+  input OCCT handles correctly.
+
+The second bullet is the one worth stating explicitly, because "it is only a query" is not the
+reason — #553 has already shown that a query can be exactly where the wrong answer hides.
+
+Also excluded, and pinned by a test so the exclusion stays deliberate: the four `GC_Make*`
+three-point forms. They take no dimension at all, and OCCT's own status already rejects a
+degenerate point triple (measured: coincident points, and an `S2` lying on the major axis, both
+report `!IsDone()`).
+
+No API signature changed, and nothing that used to succeed on valid input now fails. Every
+affected entry point already had somewhere to say no: `nil` for the 13 factory and edge builders,
+`false` for the 6 setters, and the existing `-1` error return for the 3 `Extrema` functions, which
+the Swift layer already maps to `[]`.
+
+26 tests in `Tests/OCCTCurveTests/Issue554Conic3dDegenerateTests.swift`. They were run against a
+build with every guard stripped back out: 19 fail, and the 7 that pass are exactly the controls —
+valid input still accepted, the negative and inverted cases OCCT already rejected, the three-point
+forms, the ellipse major setter that `Geom_Ellipse`'s own `throw` already covered, and the
+`BndLib`/`ElCLib` exclusion.
+
 #### The null-handle guard, swept across the whole geometry-wrapper surface (#478)
 
 #416 added the missing `IsNull()` guard to `OCCTCurve3DTransform` and #488 to

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -175,13 +175,17 @@ Mutates the circle's radius in place.
 public func setRadius(_ r: Double) -> Bool
 ```
 
-- **Parameters:** `r` — new radius (must be > 0).
-- **Returns:** `true` on success, `false` if the curve is not a circle or the value is invalid.
+- **Parameters:** `r`: new radius, must be `> 0`.
+- **Returns:** `true` if the radius was written, `false` if the curve is not a circle or `r` is not a valid radius. On `false` the curve is left exactly as it was.
 - **OCCT:** `Geom_Circle::SetRadius`.
 - **Example:**
   ```swift
   if let curve = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
-      curve.circleProperties.setRadius(8)
+      #expect(curve.circleProperties.setRadius(8) == true)
+
+      // Rejected, and the radius set above survives.
+      #expect(curve.circleProperties.setRadius(0) == false)
+      #expect(curve.circleProperties.radius == 8)
   }
   ```
 
@@ -340,14 +344,18 @@ Mutates the ellipse's major radius in place.
 public func setMajorRadius(_ r: Double) -> Bool
 ```
 
-- **Parameters:** `r` — new major radius (must be > minor radius per OCCT).
-- **Returns:** `true` on success, `false` if the curve is not an ellipse or the value is invalid.
+- **Parameters:** `r`: new major radius. Judged against the minor radius already on the curve, so it must be `> 0` and no smaller than the current `minorRadius`.
+- **Returns:** `true` if the radius was written, `false` if the curve is not an ellipse or the resulting pair would not describe one. On `false` the curve is left exactly as it was.
 - **OCCT:** `Geom_Ellipse::SetMajorRadius`.
 - **Example:**
   ```swift
   if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
                                   majorRadius: 10, minorRadius: 5) {
-      curve.ellipseProperties.setMajorRadius(12)
+      #expect(curve.ellipseProperties.setMajorRadius(12) == true)
+
+      // Below the current minor radius: no longer an ellipse.
+      #expect(curve.ellipseProperties.setMajorRadius(3) == false)
+      #expect(curve.ellipseProperties.majorRadius == 12)
   }
   ```
 
@@ -362,14 +370,18 @@ Mutates the ellipse's minor radius in place.
 public func setMinorRadius(_ r: Double) -> Bool
 ```
 
-- **Parameters:** `r` — new minor radius (must be < major radius per OCCT).
-- **Returns:** `true` on success, `false` if the curve is not an ellipse or the value is invalid.
+- **Parameters:** `r`: new minor radius. Judged against the major radius already on the curve, so it must be `> 0` and no larger than the current `majorRadius`.
+- **Returns:** `true` if the radius was written, `false` if the curve is not an ellipse or the resulting pair would not describe one. On `false` the curve is left exactly as it was.
 - **OCCT:** `Geom_Ellipse::SetMinorRadius`.
 - **Example:**
   ```swift
   if let curve = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
                                   majorRadius: 10, minorRadius: 5) {
-      curve.ellipseProperties.setMinorRadius(3)
+      #expect(curve.ellipseProperties.setMinorRadius(3) == true)
+
+      // Zero would leave a live ellipse evaluating onto its own major axis.
+      #expect(curve.ellipseProperties.setMinorRadius(0) == false)
+      #expect(curve.ellipseProperties.minorRadius == 3)
   }
   ```
 
@@ -570,14 +582,16 @@ Mutates the hyperbola's major radius in place.
 public func setMajorRadius(_ r: Double) -> Bool
 ```
 
-- **Parameters:** `r` — new major radius (must be > 0).
-- **Returns:** `true` on success, `false` if the curve is not a hyperbola or the value is invalid.
+- **Parameters:** `r`: new major radius, must be `> 0`. Unlike an ellipse there is no ordering constraint against the minor radius.
+- **Returns:** `true` if the radius was written, `false` if the curve is not a hyperbola or `r` is not a valid radius. On `false` the curve is left exactly as it was.
 - **OCCT:** `Geom_Hyperbola::SetMajorRadius`.
 - **Example:**
   ```swift
   if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
                                     majorRadius: 5, minorRadius: 3) {
-      curve.hyperbolaProperties.setMajorRadius(7)
+      #expect(curve.hyperbolaProperties.setMajorRadius(7) == true)
+      #expect(curve.hyperbolaProperties.setMajorRadius(0) == false)
+      #expect(curve.hyperbolaProperties.majorRadius == 7)
   }
   ```
 
@@ -592,14 +606,18 @@ Mutates the hyperbola's minor radius in place.
 public func setMinorRadius(_ r: Double) -> Bool
 ```
 
-- **Parameters:** `r` — new minor radius (must be > 0).
-- **Returns:** `true` on success, `false` if the curve is not a hyperbola or the value is invalid.
+- **Parameters:** `r`: new minor radius, must be `> 0`. It may exceed the major radius.
+- **Returns:** `true` if the radius was written, `false` if the curve is not a hyperbola or `r` is not a valid radius. On `false` the curve is left exactly as it was.
 - **OCCT:** `Geom_Hyperbola::SetMinorRadius`.
 - **Example:**
   ```swift
   if let curve = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
                                     majorRadius: 5, minorRadius: 3) {
-      curve.hyperbolaProperties.setMinorRadius(4)
+      #expect(curve.hyperbolaProperties.setMinorRadius(4) == true)
+
+      // A minor radius above the major is an ordinary hyperbola, so this is accepted.
+      #expect(curve.hyperbolaProperties.setMinorRadius(8) == true)
+      #expect(curve.hyperbolaProperties.setMinorRadius(0) == false)
   }
   ```
 
@@ -740,13 +758,15 @@ Mutates the parabola's focal distance in place.
 public func setFocal(_ f: Double) -> Bool
 ```
 
-- **Parameters:** `f` — new focal distance (must be > 0).
-- **Returns:** `true` on success, `false` if the curve is not a parabola or `f` is invalid.
+- **Parameters:** `f`: new focal distance, must be `> 0`. At zero the parabola degenerates to a straight line along its own axis of symmetry, which is `gp_Parab`'s documented behaviour rather than an error it reports.
+- **Returns:** `true` if the value was written, `false` if the curve is not a parabola or `f` is not a valid focal distance. On `false` the curve is left exactly as it was.
 - **OCCT:** `Geom_Parabola::SetFocal`.
 - **Example:**
   ```swift
-  if let curve = Curve3D.parabola(vertex: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
-      curve.parabolaProperties.setFocal(5)
+  if let curve = Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
+      #expect(curve.parabolaProperties.setFocal(5) == true)
+      #expect(curve.parabolaProperties.setFocal(0) == false)
+      #expect(curve.parabolaProperties.focal == 5)
   }
   ```
 

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -1007,8 +1007,8 @@ public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
 
 The major axis direction is determined by OCCT's `gp_Ax2` construction from `normal`. Angles are measured from the major axis in the ellipse plane.
 
-- **Parameters:** `center` — ellipse centre; `normal` — plane normal; `majorRadius` — semi-major axis; `minorRadius` — semi-minor axis; `startAngle`/`endAngle` — arc bounds in radians; `counterclockwise` — winding direction.
-- **Returns:** Elliptical arc curve, or `nil` on failure.
+- **Parameters:** `center`: ellipse centre; `normal`: plane normal; `majorRadius`: semi-major axis, must be `> 0`; `minorRadius`: semi-minor axis, must be `> 0` and no larger than `majorRadius`; `startAngle`/`endAngle`: arc bounds in radians; `counterclockwise`: winding direction.
+- **Returns:** Elliptical arc curve, or `nil` on failure, including when the radii do not describe an ellipse.
 - **OCCT:** `GC_MakeArcOfEllipse(elips, angle1, angle2, sense)` → `Geom_TrimmedCurve`.
 - **Example:**
   ```swift
@@ -1016,6 +1016,12 @@ The major axis direction is determined by OCCT's `gp_Ax2` construction from `nor
       center: .zero, normal: SIMD3(0, 0, 1),
       majorRadius: 10, minorRadius: 5,
       startAngle: 0, endAngle: .pi)
+
+  // A zero minor radius would otherwise build an arc that evaluates onto the major axis.
+  #expect(Curve3D.arcOfEllipse(
+      center: .zero, normal: SIMD3(0, 0, 1),
+      majorRadius: 10, minorRadius: 0,
+      startAngle: 0, endAngle: .pi) == nil)
   ```
 
 ---
@@ -1033,8 +1039,8 @@ public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
 
 Both `from` and `to` must lie on the ellipse (within tolerance). Use this form when angles are not known but the endpoint coordinates are.
 
-- **Parameters:** `center` — ellipse centre; `normal` — plane normal; `majorRadius`/`minorRadius` — ellipse radii; `from` — start point on the ellipse; `to` — end point on the ellipse; `counterclockwise` — winding direction.
-- **Returns:** Elliptical arc curve, or `nil` if points do not lie on the ellipse or construction fails.
+- **Parameters:** `center`: ellipse centre; `normal`: plane normal; `majorRadius`/`minorRadius`: ellipse radii, both `> 0` with minor no larger than major; `from`: start point on the ellipse; `to`: end point on the ellipse; `counterclockwise`: winding direction.
+- **Returns:** Elliptical arc curve, or `nil` if the radii do not describe an ellipse, the points do not lie on it, or construction fails.
 - **OCCT:** `GC_MakeArcOfEllipse(elips, from, to, sense)` → `Geom_TrimmedCurve`.
 - **Example:**
   ```swift
@@ -1043,6 +1049,18 @@ Both `from` and `to` must lie on the ellipse (within tolerance). Use this form w
       majorRadius: 10, minorRadius: 5,
       from: SIMD3(10, 0, 0), to: SIMD3(-10, 0, 0))
   ```
+
+The radius check matters more in this form than in the angular one. Converting each endpoint back to
+a parameter divides by the minor radius, so at zero both bounds come back `NaN` — and OCCT reports
+that construction as *done*. Before #554 this returned a live curve whose parameter range and every
+evaluation were `NaN`:
+
+```swift
+#expect(Curve3D.arcOfEllipse(
+    center: .zero, normal: SIMD3(0, 0, 1),
+    majorRadius: 10, minorRadius: 0,
+    from: SIMD3(10, 0, 0), to: SIMD3(-10, 0, 0)) == nil)
+```
 
 ---
 


### PR DESCRIPTION
Closes #554.

The 3D counterparts of #514. Twenty-two bridge sites build a 3D conic from a caller-supplied
dimension, or rewrite one on a live curve, and none of them checked it. All twenty-two now use the
four shared predicates #487 converged on in `OCCTBridge_Internal.h`.

## The census is wider than the issue's nine sites, and the extra ones are a different mechanism

The issue listed nine `gp_Elips` constructions. Re-censusing on the current base (the line numbers
had moved) turned up two more families with the same gap reached a different way, plus the
hyperbola and parabola siblings sitting one line from the ellipses the issue named. Fixing only the
ellipses would have left the identical defect immediately adjacent, which is how #514 records the
2D `gce` factories came to be skipped by two separate passes.

| family | sites | what OCCT still rejects | what gets through |
|---|---|---|---|
| `gp_Elips`/`gp_Hypr`/`gp_Parab` built in a bridge TU | 11 | negatives, inverted ellipse radii — the constructor is `constexpr` in the header so its `Standard_ConstructionError_Raise_if` runs here | **zero** |
| `GC_MakeEllipse`/`GC_MakeHyperbola` | 5 | negatives, inverted radii — via the maker's own status, not the macro, which `No_Exception` deletes inside OCCT | **zero** |
| `Geom_*` setters | 6 | negatives, and an ellipse major below its own minor — these are a hand-written `if (...) throw`, never a macro, so `No_Exception` never touched them | **zero** |

That third row is a refinement of #487's rule worth keeping: `No_Exception` voids the *macro*, not
every OCCT precondition. `Geom_Ellipse::SetMajorRadius` throws from inside OCCT's own translation
unit because it is spelled by hand.

Zero satisfies every check any of the three writes (`minor < 0 || major < minor` is false for
`(0, 0)`), which is why it is the one degenerate input that arrived intact by every route.

## The sharpest case: `IsDone()` is not merely insufficient, it is misleading

`GC_MakeArcOfEllipse`'s two-point form inverts each endpoint back to a parameter, which divides by
the minor radius. At zero both bounds come back `NaN` — and the maker reports success, so the
`if (!maker.IsDone()) return nullptr` line the bridge relied on passed. `Curve3D.arcOfEllipse(…,
from:to:)` returned a live curve whose parameter range was `[nan, nan]` and whose every evaluation
was `NaN`. Measured against the pinned kernel, with the identical call on a healthy ellipse as the
control:

| radii | `IsDone()` | resulting parameter range |
|---|---|---|
| `(5, 3)` | true | `[0, 3.14159]` |
| `(5, 0)` | true | `[nan, nan]` |
| `(0, 0)` | true | `[nan, nan]` |

## What is deliberately not guarded, and why

The issue asked to check the return channel on `OCCTElCLibValueOnEllipse` before assuming the
one-liner applied. It does not apply — but "no channel" turned out not to be the deciding factor.

Each query site was placed by the test #553 settled on (probe whether OCCT actually returns the
degenerate answer), not by which class it calls. That splits this family in two, and the split does
*not* follow the "it's only a read-only query" line it looks like it should:

- **The three `Extrema` entry points are guarded**, because OCCT does not answer the degenerate
  question. `Extrema_ExtPElC` reports `NbExt() == 0` against a `(0, 0)` ellipse rather than the one
  extremum at its centre, and `Extrema_ExtElC` reports `IsParallel()` regardless of what the line
  does. Same failure shape #553 measured across the `Gcc` families, same conclusion.
- **`BndLib` and `ElCLib` are excluded**, because they do answer it. `ElCLib::Value(1.0,
  gp_Elips(ax, 5, 0))` is `(2.70151, 0, 0)`, a point on the collapsed segment, which is exactly
  what that curve is; `BndLib::Add` returns its true box. Both are also `void`, so guarding them
  would mean widening a signature in order to refuse an input OCCT handles correctly.
- **The four `GC_Make*` three-point forms** take no dimension at all, and OCCT's own status already
  rejects a degenerate point triple (measured: coincident points, and an `S2` on the major axis,
  both report `!IsDone()`). Pinned by a test so the exclusion stays deliberate.

(#553 also independently corroborates the mechanism table above from the 2D side: status returns
survive `No_Exception`, only the `*_Raise_if` macros are deleted.)

## Not a breaking change

No signature changed and nothing that used to succeed on valid input now fails. Every affected
entry point already had somewhere to say no: `nil` for the 13 factory and edge builders, `false`
for the 6 setters, and the existing `-1` error return for the 3 `Extrema` functions, which the
Swift layer already maps to `[]`. Operation counts are unchanged (4299).

## Verification

- 26 new tests in `Tests/OCCTCurveTests/Issue554Conic3dDegenerateTests.swift`.
- Run against a build with every guard stripped back out: **19 fail**, and the 7 that pass are
  exactly the controls — valid input still accepted, the negative and inverted cases OCCT already
  rejected, the three-point forms, the ellipse major setter `Geom_Ellipse`'s own `throw` already
  covered, and the `BndLib`/`ElCLib` exclusion.
- Full `swift test` clean: 4950 tests, 4 consecutive runs. A fifth run (an earlier build of the
  same tree) reported 2 assertion failures, and the detail was lost to output truncation on my
  side; it has not recurred in any run since, and another worktree was running the full suite
  concurrently, which is the documented shape of this repo's parallel fixture flakes. Flagging it
  rather than calling it clean, since I cannot name the two tests.
- Ground truth for every claim above came from four C++ probes compiled against the pinned
  xcframework, not from reading headers.

## One thing found and not acted on

`OCCTCurve3DMakeEllipse` and `OCCTCurve3DMakeHyperbola` (v0.51) are byte-equivalent duplicates of
`OCCTGCMakeEllipse` / `OCCTGCMakeHyperbola` (v0.105) and have no Swift caller. Both pairs are
guarded here so neither can drift, but two spellings of one factory is exactly the shape #377 is
auditing, and deleting the orphans is a separate change from adding a precondition. Happy to file
it if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
