### PR TITLE
fix(#558): the sampling family is 28 entry points, not 14, and each needs its own contract

### DIFF
--- a/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
+++ b/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
@@ -54,21 +54,19 @@ extension ArcLengthCurveAdaptor {
         return tangent(atParameter: u)
     }
 
-    /// The largest sample count either adaptor will produce: 10 million points.
+    /// The largest sample count either adaptor will produce: ``Sampling/maximumSampleCount``.
     ///
     /// Both ``points(count:)`` and ``points(spacing:)`` return an empty array rather than
-    /// attempting a larger request. The number is a ceiling on the *allocation*, not on what is
-    /// useful: one sample costs 24 bytes in the bridge's packed buffer plus 32 in the returned
-    /// array, so the ceiling itself is already about 625 MB resident and, measured on a two-edge
-    /// wire, about 45 seconds of sampling. It is also two orders of magnitude below the `int32_t`
-    /// the bridge takes its count in.
+    /// attempting a larger request. Declared here by #479 for these two types and now shared with
+    /// the other 26 sampling entry points that had the same defect (#558); this stays as the
+    /// spelling the adaptors' own documentation uses.
     ///
     /// ```swift
     /// let wc = WireCurve(wire)!
     /// wc.points(spacing: 1e-9).isEmpty      // true: implies 1e11 points, past the ceiling
     /// wc.points(count: WireCurve.maximumSampleCount + 1).isEmpty   // true
     /// ```
-    public static var maximumSampleCount: Int { 10_000_000 }
+    public static var maximumSampleCount: Int { Sampling.maximumSampleCount }
 
     /// Points spaced approximately `spacing` apart along the curve (by arc length). The exact
     /// step is adjusted so the samples divide the curve evenly end-to-end.
@@ -111,7 +109,7 @@ extension ArcLengthCurveAdaptor {
         count: Int,
         _ sample: (Int32, UnsafeMutablePointer<Double>) -> Int32
     ) -> [SIMD3<Double>] {
-        guard count >= 2, count <= Self.maximumSampleCount else { return [] }
+        guard let count = Sampling.requested(count) else { return [] }
         var buffer = [Double](repeating: 0, count: count * 3)
         let written = Int(sample(Int32(count), &buffer))
         return unpackSIMD3(buffer, count: written)

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -1986,10 +1986,13 @@ public final class BRepGraph: @unchecked Sendable {
     ///   - faceIndex: Face definition index.
     ///   - uSamples: Number of samples in U direction (must be >= 1).
     ///   - vSamples: Number of samples in V direction (must be >= 1).
-    /// - Returns: Grid sample data, or nil if face has no surface or sampling fails.
+    /// - Returns: Grid sample data, or nil if face has no surface, sampling fails, or the grid
+    ///   cannot be served: the bound is on the **product**, which must not exceed
+    ///   ``Sampling/maximumSampleCount`` (#558). This sampler fills four buffers per point
+    ///   (position, normal, Gaussian and mean curvature), so it reaches the ceiling's memory cost
+    ///   sooner than the point-only samplers do.
     public func sampleFaceUVGrid(faceIndex: Int, uSamples: Int, vSamples: Int) -> FaceGridSample? {
-        guard uSamples >= 1, vSamples >= 1 else { return nil }
-        let total = uSamples * vSamples
+        guard let total = Sampling.gridTotal(uSamples, vSamples) else { return nil }
         var posBuffer = [Double](repeating: 0, count: total * 3)
         var nrmBuffer = [Double](repeating: 0, count: total * 3)
         var gaussBuffer = [Double](repeating: 0, count: total)
@@ -2034,10 +2037,11 @@ public final class BRepGraph: @unchecked Sendable {
     /// Sample evenly-spaced points along an edge curve.
     /// - Parameters:
     ///   - edgeIndex: Edge definition index.
-    ///   - count: Number of points to sample (must be >= 1).
+    ///   - count: Number of points to sample, honoured within `1...`
+    ///     ``Sampling/maximumSampleCount``; outside that range the result is empty (#558).
     /// - Returns: Array of 3D points along the edge, empty if edge has no curve.
     public func sampleEdgeCurve(edgeIndex: Int, count: Int) -> [SIMD3<Double>] {
-        guard count >= 1 else { return [] }
+        guard let count = Sampling.requested(count, atLeast: 1) else { return [] }
         var buffer = [Double](repeating: 0, count: count * 3)
         let result = buffer.withUnsafeMutableBufferPointer { buf in
             OCCTBRepGraphSampleEdgeCurve(handle, Int32(edgeIndex), Int32(count), buf.baseAddress!)

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -234,14 +234,19 @@ public final class Curve2D: @unchecked Sendable {
     /// - Parameters:
     ///   - angularDeflection: Maximum angular deflection in radians (default 0.1)
     ///   - chordalDeflection: Maximum chordal deflection (default 0.01)
-    ///   - maxPoints: Maximum number of output points (default 4096)
+    ///   - maxPoints: Output *capacity* (default 4096), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#558). The deflection
+    ///     criteria decide the actual point count, so clamping an unservable capacity returns the
+    ///     same points rather than a coarser sampling.
     /// - Returns: Array of 2D points approximating the curve
     public func drawAdaptive(angularDeflection: Double = 0.1,
                              chordalDeflection: Double = 0.01,
                              maxPoints: Int = 4096) -> [SIMD2<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 2)
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 2)
         let n = Int(OCCTCurve2DDrawAdaptive(handle, angularDeflection, chordalDeflection,
-                                            &buffer, Int32(maxPoints)))
+                                            &buffer, Int32(capacity)))
         return (0..<n).map { SIMD2(buffer[$0 * 2], buffer[$0 * 2 + 1]) }
     }
 
@@ -255,19 +260,29 @@ public final class Curve2D: @unchecked Sendable {
     /// // pts[5] ≈ SIMD2(5, 0)
     /// ```
     ///
-    /// - Parameter pointCount: Desired number of output points; must be at least 2, else empty.
+    /// - Parameter pointCount: Desired number of output points, honoured within `2...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty. This is a
+    ///   *request*, so a count past the ceiling fails visibly rather than coming back coarser
+    ///   than what was asked for (#558). Before that bound the documented "at least 2, else
+    ///   empty" was only true of counts down to 0: a negative aborted the process.
     /// - Returns: Array of 2D points, never more than `pointCount` of them, or empty on failure
     public func drawUniform(pointCount: Int) -> [SIMD2<Double>] {
+        guard let pointCount = Sampling.requested(pointCount) else { return [] }
         var buffer = [Double](repeating: 0, count: pointCount * 2)
         let n = Int(OCCTCurve2DDrawUniform(handle, Int32(pointCount), &buffer))
         return (0..<n).map { SIMD2(buffer[$0 * 2], buffer[$0 * 2 + 1]) }
     }
 
     /// Discretize the curve with a maximum chordal deflection.
+    ///
+    /// - Parameter maxPoints: Output *capacity* (default 4096), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#558).
     public func drawDeflection(deflection: Double = 0.01,
                                maxPoints: Int = 4096) -> [SIMD2<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 2)
-        let n = Int(OCCTCurve2DDrawDeflection(handle, deflection, &buffer, Int32(maxPoints)))
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 2)
+        let n = Int(OCCTCurve2DDrawDeflection(handle, deflection, &buffer, Int32(capacity)))
         return (0..<n).map { SIMD2(buffer[$0 * 2], buffer[$0 * 2 + 1]) }
     }
 

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -532,13 +532,20 @@ public final class Curve3D: @unchecked Sendable {
 
     // MARK: - Draw (Discretization for Metal)
 
-    /// Adaptive discretization using angular and chordal deflection criteria
+    /// Adaptive discretization using angular and chordal deflection criteria.
+    ///
+    /// - Parameter maxPoints: Output *capacity*, clamped into `0...`
+    ///   ``Sampling/maximumSampleCount`` (#558). The deflection criteria decide the actual point
+    ///   count; `maxPoints` only truncates, so clamping an unservable capacity returns the same
+    ///   points rather than a coarser sampling. A capacity of 0 or less returns empty.
     public func drawAdaptive(angularDeflection: Double = 0.1,
                              chordalDeflection: Double = 0.01,
                              maxPoints: Int = 4096) -> [SIMD3<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 3)
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 3)
         let n = Int(OCCTCurve3DDrawAdaptive(handle, angularDeflection, chordalDeflection,
-                                             &buffer, Int32(maxPoints)))
+                                             &buffer, Int32(capacity)))
         return unpackSIMD3(buffer, count: n)
     }
 
@@ -552,19 +559,29 @@ public final class Curve3D: @unchecked Sendable {
     /// // pts[5] ≈ SIMD3(5, 0, 0)
     /// ```
     ///
-    /// - Parameter pointCount: Desired number of output points; must be at least 2, else empty.
+    /// - Parameter pointCount: Desired number of output points, honoured within `2...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty. This is a
+    ///   *request*, so a count past the ceiling fails visibly rather than coming back coarser
+    ///   than what was asked for (#558). Before that bound the documented "at least 2, else
+    ///   empty" was only true of counts down to 0: a negative aborted the process.
     /// - Returns: Array of 3D points, never more than `pointCount` of them, or empty on failure
     public func drawUniform(pointCount: Int) -> [SIMD3<Double>] {
+        guard let pointCount = Sampling.requested(pointCount) else { return [] }
         var buffer = [Double](repeating: 0, count: pointCount * 3)
         let n = Int(OCCTCurve3DDrawUniform(handle, Int32(pointCount), &buffer))
         return unpackSIMD3(buffer, count: n)
     }
 
-    /// Chordal deflection discretization
+    /// Chordal deflection discretization.
+    ///
+    /// - Parameter maxPoints: Output *capacity*, clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#558).
     public func drawDeflection(deflection: Double = 0.01,
                                maxPoints: Int = 4096) -> [SIMD3<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 3)
-        let n = Int(OCCTCurve3DDrawDeflection(handle, deflection, &buffer, Int32(maxPoints)))
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 3)
+        let n = Int(OCCTCurve3DDrawDeflection(handle, deflection, &buffer, Int32(capacity)))
         return unpackSIMD3(buffer, count: n)
     }
 
@@ -791,11 +808,15 @@ extension Curve3D {
     /// }
     /// ```
     ///
-    /// - Parameter count: Desired number of sample points. Must be at least 2. OCCT's samplers
-    ///   document that precondition but cannot enforce it in a Release kernel, and below 2 they
-    ///   misbehave rather than fail, so anything smaller returns an empty array here.
+    /// - Parameter count: Desired number of sample points, honoured within `2...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty. OCCT's samplers
+    ///   document the lower bound but cannot enforce it in a Release kernel, and below 2 they
+    ///   misbehave rather than fail; the upper bound is this layer's, since `count` sizes a Swift
+    ///   allocation and is cast to the bridge's `int32_t`, and both ends used to abort the
+    ///   process (#558).
     /// - Returns: Array of parameter values, never more than `count` of them, or empty on failure
     public func quasiUniformParameters(count: Int) -> [Double] {
+        guard let count = Sampling.requested(count) else { return [] }
         var params = [Double](repeating: 0, count: count)
         let n = Int(OCCTCurve3DQuasiUniformAbscissa(handle, Int32(count), &params))
         return Array(params.prefix(n))
@@ -809,14 +830,15 @@ extension Curve3D {
     ///
     /// - Parameters:
     ///   - deflection: Maximum allowed chord deviation
-    ///   - maxPoints: Maximum number of points to return
+    ///   - maxPoints: Output *capacity*, clamped into `0`...``Sampling/maximumSampleCount``;
+    ///     0 or less returns empty (#558). The deflection decides the actual point count.
     /// - Returns: Array of 3D points, or empty array on failure
     public func quasiUniformDeflectionPoints(deflection: Double, maxPoints: Int = 500) -> [SIMD3<Double>] {
-        var xyz = [Double](repeating: 0, count: maxPoints * 3)
-        let n = Int(OCCTCurve3DQuasiUniformDeflection(handle, deflection, &xyz, Int32(maxPoints)))
-        return (0..<n).map { i in
-            SIMD3<Double>(xyz[i*3], xyz[i*3+1], xyz[i*3+2])
-        }
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var xyz = [Double](repeating: 0, count: capacity * 3)
+        let n = Int(OCCTCurve3DQuasiUniformDeflection(handle, deflection, &xyz, Int32(capacity)))
+        return unpackSIMD3(xyz, count: n)
     }
 
     // MARK: - BSpline Knot Splitting (v0.40.0)
@@ -1053,11 +1075,14 @@ extension Curve3D {
     /// - Parameters:
     ///   - first: Start parameter
     ///   - last: End parameter
-    ///   - maxPoints: Maximum number of points to return (default: 1000)
+    ///   - maxPoints: Output *capacity* (default: 1000), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#558).
     /// - Returns: Array of 3D sample points
     public func samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> [SIMD3<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 3)
-        let count = OCCTCurve3DGetSamplePoints3D(handle, first, last, &buffer, Int32(maxPoints))
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 3)
+        let count = OCCTCurve3DGetSamplePoints3D(handle, first, last, &buffer, Int32(capacity))
         return unpackSIMD3(buffer, count: Int(count))
     }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -8038,10 +8038,13 @@ extension Curve2D {
 extension Shape {
     /// Uniformly sample an edge by point count. Returns parameter values.
     ///
-    /// - Parameter pointCount: Desired number of samples; must be at least 2, else `nil`. OCCT's
-    ///   sampler documents that precondition but cannot enforce it in a Release kernel, and used to
-    ///   answer a request for zero with five parameters (#501).
+    /// - Parameter pointCount: Desired number of samples, honoured within `2...`
+    ///   ``Sampling/maximumSampleCount``, else `nil`. OCCT's sampler documents the lower bound but
+    ///   cannot enforce it in a Release kernel, and used to answer a request for zero with five
+    ///   parameters (#501); the upper bound is this layer's, since `pointCount` is cast to the
+    ///   bridge's `int32_t` and used to abort the process past it (#558).
     public func uniformAbscissa(pointCount: Int) -> [Double]? {
+        guard let pointCount = Sampling.requested(pointCount) else { return nil }
         let n = Int(OCCTUniformAbscissaByCount(handle, Int32(pointCount), nil))
         guard n > 0 else { return nil }
         var params = [Double](repeating: 0, count: n)
@@ -8060,8 +8063,10 @@ extension Shape {
 
     /// Uniformly sample an edge by point count within parameter range.
     ///
-    /// - Parameter pointCount: Desired number of samples; must be at least 2, else `nil` (#501).
+    /// - Parameter pointCount: Desired number of samples, honoured within `2...`
+    ///   ``Sampling/maximumSampleCount``, else `nil` (#501, #558).
     public func uniformAbscissa(pointCount: Int, u1: Double, u2: Double) -> [Double]? {
+        guard let pointCount = Sampling.requested(pointCount) else { return nil }
         let n = Int(OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, nil))
         guard n > 0 else { return nil }
         var params = [Double](repeating: 0, count: n)
@@ -8465,10 +8470,14 @@ extension QuadricIntersection {
     }
 
     /// Sample points along a cone-sphere intersection curve.
+    ///
+    /// - Parameter sampleCount: Desired number of samples, honoured within `1...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty (#558).
     public static func coneSpherePoints(semiAngle: Double, refRadius: Double,
                                          sphereCenter: SIMD3<Double>, sphereRadius: Double,
                                          tolerance: Double = 1e-6,
                                          curveIndex: Int, sampleCount: Int) -> [SIMD3<Double>] {
+        guard let sampleCount = Sampling.requested(sampleCount, atLeast: 1) else { return [] }
         var xs = [Double](repeating: 0, count: sampleCount)
         var ys = [Double](repeating: 0, count: sampleCount)
         var zs = [Double](repeating: 0, count: sampleCount)

--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -180,12 +180,25 @@ public final class Edge: @unchecked Sendable {
     // MARK: - Sampling
 
     /// Get points along the edge curve
-    /// - Parameter count: Number of points to generate (default: automatic based on length)
+    /// - Parameter count: Number of points to generate (default: automatic based on length),
+    ///   honoured within `2`...``Sampling/maximumSampleCount``; outside that range the result
+    ///   is empty (#558). The automatic default is bounded too: a long enough edge implies more
+    ///   points at 0.5mm spacing than the ceiling can serve.
     /// - Returns: Array of 3D points along the edge
     public func points(count: Int? = nil) -> [SIMD3<Double>] {
-        let pointCount = count ?? max(2, Int(length / 0.5) + 1)  // ~0.5mm spacing default
-        guard pointCount >= 2 else { return [] }
-        
+        let requested: Int
+        if let count {
+            requested = count
+        } else {
+            // ~0.5mm spacing default. Derive in Double: `Int(_:)` on a Double past Int.max is a
+            // trap rather than an error, and `length` is geometry-supplied, so the implied count
+            // is not bounded a priori (#558). A NaN length fails this guard too.
+            let implied = (length / 0.5).rounded(.down) + 1
+            guard implied <= Double(Sampling.maximumSampleCount) else { return [] }
+            requested = max(2, Int(implied))
+        }
+        guard let pointCount = Sampling.requested(requested) else { return [] }
+
         var buffer = [Double](repeating: 0, count: pointCount * 3)
         let actualCount = OCCTEdgeGetPoints(handle, Int32(pointCount), &buffer)
         

--- a/Sources/OCCTSwift/MedialAxis.swift
+++ b/Sources/OCCTSwift/MedialAxis.swift
@@ -185,9 +185,18 @@ public final class MedialAxis: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - index: 1-based arc index.
-    ///   - maxPoints: Maximum number of sample points (default 32).
+    ///   - maxPoints: Desired number of sample points (default 32), honoured within `2...`
+    ///     ``Sampling/maximumSampleCount``; outside that range the result is empty (#558).
+    ///
+    ///     The name says capacity but the contract is a *request*: the bridge samples the arc's
+    ///     parameter range at exactly `maxPoints` evenly-spaced values rather than letting a
+    ///     deflection criterion pick the count, so it always returns exactly this many points
+    ///     (and nothing at all below 2). That is why an unservable count is rejected here rather
+    ///     than clamped the way the genuinely adaptive samplers clamp theirs — clamping this one
+    ///     would hand back a different, coarser sampling than the caller asked for.
     /// - Returns: Array of 2D points along the arc, or empty on error.
     public func drawArc(at index: Int, maxPoints: Int = 32) -> [SIMD2<Double>] {
+        guard let maxPoints = Sampling.requested(maxPoints) else { return [] }
         var xy = [Double](repeating: 0, count: maxPoints * 2)
         let count = OCCTMedialAxisDrawArc(handle, Int32(index), &xy, Int32(maxPoints))
         return (0..<Int(count)).map { i in
@@ -197,11 +206,18 @@ public final class MedialAxis: @unchecked Sendable {
 
     /// Sample points along all bisector arcs.
     ///
-    /// - Parameter maxPointsPerArc: Maximum points per arc (default 32).
+    /// - Parameter maxPointsPerArc: Points requested per arc (default 32), at least 2 — the same
+    ///   fill-exactly request ``drawArc(at:maxPoints:)`` takes, not a capacity. The bound is on
+    ///   the **total**: `arcCount * maxPointsPerArc` must not exceed
+    ///   ``Sampling/maximumSampleCount``, else the result is empty (#558). Checking
+    ///   `maxPointsPerArc` on its own is not redundant, since a negative count on a graph with no
+    ///   arcs multiplies to a plausible total.
     /// - Returns: Array of polylines, one per arc.
     public func drawAll(maxPointsPerArc: Int = 32) -> [[SIMD2<Double>]] {
-        let totalMax = arcCount * maxPointsPerArc
-        guard totalMax > 0 else { return [] }
+        guard maxPointsPerArc >= 2,
+              let totalMax = Sampling.gridTotal(arcCount, maxPointsPerArc, atLeast: 0),
+              totalMax > 0
+        else { return [] }
         var xy = [Double](repeating: 0, count: totalMax * 2)
         var lineStarts = [Int32](repeating: 0, count: arcCount)
         var lineLengths = [Int32](repeating: 0, count: arcCount)

--- a/Sources/OCCTSwift/Sampling.swift
+++ b/Sources/OCCTSwift/Sampling.swift
@@ -1,0 +1,85 @@
+//
+//  Sampling.swift
+//  OCCTSwift
+//
+//  The one ceiling every sampling entry point measures a caller-supplied count
+//  against, plus the three decisions that ceiling can drive.
+//
+//  Driver: issue #558 (split out of #479). A sampling count arrives from the
+//  caller, sizes a Swift allocation, and is then cast to the `int32_t` the
+//  bridge takes its count in. Both ends abort the process rather than failing:
+//  `[Double](repeating:count:)` traps on a negative, and `Int32(_:)` traps past
+//  `Int32.max`. #479 bounded two such entry points and declared the ceiling on
+//  `ArcLengthCurveAdaptor`; measuring the rest of the family found 28, so the
+//  ceiling moves here where all of them can see it.
+//
+
+/// The shared bound on how many samples any one call to this library will produce.
+public enum Sampling {
+    /// The largest sample count any sampling entry point will produce: 10 million points.
+    ///
+    /// Measured, not round (#479): sampling costs about 4.5 µs per point, and one sample costs
+    /// 24 bytes in the bridge's packed `(x,y,z)` buffer plus 32 in the returned array, so the
+    /// ceiling itself is already about 625 MB resident and 45 seconds of work. It is also two
+    /// orders of magnitude below the `int32_t` the bridge takes its count in, which is where the
+    /// process used to abort instead.
+    ///
+    /// ```swift
+    /// let curve = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+    /// curve.drawUniform(pointCount: Sampling.maximumSampleCount + 1).isEmpty   // true
+    /// curve.drawAdaptive(maxPoints: Sampling.maximumSampleCount + 1)           // clamped, not empty
+    /// ```
+    public static let maximumSampleCount = 10_000_000
+
+    /// A caller's *request* for exactly this many samples: honoured in full or not at all.
+    ///
+    /// Returns `nil` when the count is below `minimum` or above ``maximumSampleCount``, which
+    /// every caller turns into its own documented empty value. There is no clamping: a request
+    /// the ceiling cannot honour has to fail visibly, because coming back silently coarser than
+    /// what was asked for is the defect #501 found in the one sampler that did clamp a request.
+    ///
+    /// - Parameters:
+    ///   - count: The caller's requested sample count.
+    ///   - minimum: The entry point's own documented lower bound, usually OCCT's `>= 2` (which a
+    ///     Release kernel compiles its precondition out of, #501) and occasionally `>= 1`.
+    internal static func requested(_ count: Int, atLeast minimum: Int = 2) -> Int? {
+        guard count >= minimum, count <= maximumSampleCount else { return nil }
+        return count
+    }
+
+    /// A caller's *capacity* for at most this many samples: clamped into `0...`
+    /// ``maximumSampleCount``.
+    ///
+    /// Unlike ``requested(_:atLeast:)`` this clamps rather than rejects, because a capacity does
+    /// not decide the answer. An adaptive sampler picks its own point count from a deflection
+    /// tolerance and uses the capacity only to truncate, so lowering an unservable capacity to
+    /// the ceiling returns the *same* points the caller would have got — there is nothing to
+    /// coarsen. A capacity below zero is not a smaller capacity, it is no capacity: it clamps to
+    /// 0, and every caller returns its documented empty value rather than calling the bridge with
+    /// a zero-length buffer.
+    internal static func capacity(_ maxPoints: Int) -> Int {
+        min(max(maxPoints, 0), maximumSampleCount)
+    }
+
+    /// A grid *request* of `factors` samples per direction: bounds the **product**, and each
+    /// factor on its own.
+    ///
+    /// Returns the total sample count, or `nil` if any factor is below `minimum` or the product
+    /// exceeds ``maximumSampleCount``. Checking the factors individually is not redundant with
+    /// checking the product: two negative factors multiply to a perfectly plausible positive
+    /// total, which is exactly why `Surface.drawMesh(uCount: -1, vCount: -1)` used to look
+    /// well-behaved while `drawMesh(uCount: -1, vCount: 3)` aborted the process (#558). The
+    /// multiplication is overflow-checked for the same reason: `Int` wraps into a trap of its own
+    /// well before the ceiling is reached.
+    internal static func gridTotal(_ factors: Int..., atLeast minimum: Int = 1) -> Int? {
+        var total = 1
+        for factor in factors {
+            guard factor >= minimum else { return nil }
+            let (product, overflowed) = total.multipliedReportingOverflow(by: factor)
+            guard !overflowed else { return nil }
+            total = product
+        }
+        guard total <= maximumSampleCount else { return nil }
+        return total
+    }
+}

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -913,16 +913,19 @@ public final class Shape: @unchecked Sendable {
     /// - Parameters:
     ///   - index: Edge index (0-based)
     ///   - deflection: Maximum chord deviation
-    ///   - maxPoints: Maximum number of points to return
+    ///   - maxPoints: Output *capacity*, clamped into `0`...``Sampling/maximumSampleCount``;
+    ///     a capacity of 0 or less returns nil (#558). The deflection decides the actual point count.
     /// - Returns: Array of 3D points along the edge, or nil if edge not found
     public func edgePolyline(
         at index: Int,
         deflection: Double = 0.1,
         maxPoints: Int = 1000
     ) -> [SIMD3<Double>]? {
-        var points = [Double](repeating: 0, count: maxPoints * 3)
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return nil }
+        var points = [Double](repeating: 0, count: capacity * 3)
         let numPoints = points.withUnsafeMutableBufferPointer { buffer in
-            OCCTShapeGetEdgePolyline(handle, Int32(index), deflection, buffer.baseAddress, Int32(maxPoints))
+            OCCTShapeGetEdgePolyline(handle, Int32(index), deflection, buffer.baseAddress, Int32(capacity))
         }
 
         guard numPoints > 0 else { return nil }
@@ -976,7 +979,10 @@ public final class Shape: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - deflection: Maximum chord deviation
-    ///   - maxPointsPerEdge: Maximum points per edge
+    ///   - maxPointsPerEdge: Per-edge output *capacity*, honoured within `2...`
+    ///     ``Sampling/maximumSampleCount``; outside that range the result is empty (#558). This
+    ///     one keeps its existing lower bound of 2 rather than clamping to 0, since it is also
+    ///     passed straight to the bridge's bulk pass.
     /// - Returns: `(edgeIndex, points)` pairs, ascending by `edgeIndex`, one per
     ///   successfully discretized edge
     public func allEdgePolylinesIndexed(
@@ -993,7 +999,7 @@ public final class Shape: @unchecked Sendable {
         // One bulk pass: the bridge builds the edge map once. Looping `edgePolyline(at:)`
         // instead rebuilds it per call, making this O(edges²) — 20 s for a 12k-edge shell,
         // and unusable on mesh-scale shapes (issue #275).
-        guard maxPointsPerEdge >= 2,
+        guard let maxPointsPerEdge = Sampling.requested(maxPointsPerEdge),
               let polys = OCCTShapeComputeAllEdgePolylines(handle, deflection, Int32(maxPointsPerEdge))
         else { return [] }
         defer { OCCTEdgePolylinesRelease(polys) }
@@ -2264,11 +2270,14 @@ public final class Shape: @unchecked Sendable {
     ///
     /// Points are sampled uniformly along the edge curve from start to end.
     /// - Parameter index: The edge index (0 to edgeCount-1)
-    /// - Parameter maxPoints: Maximum points to return (capped at 20 internally for performance)
+    /// - Parameter maxPoints: Output *capacity* (capped at 20 internally for performance), clamped
+    ///   into `0`...``Sampling/maximumSampleCount``; 0 or less returns empty (#558)
     /// - Returns: Array of 3D points along the edge curve
     public func edgePoints(at index: Int, maxPoints: Int = 20) -> [SIMD3<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 3)
-        let count = OCCTShapeGetEdgePoints(handle, Int32(index), &buffer, Int32(maxPoints))
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 3)
+        let count = OCCTShapeGetEdgePoints(handle, Int32(index), &buffer, Int32(capacity))
         var points: [SIMD3<Double>] = []
         for i in 0..<Int(count) {
             points.append(SIMD3(buffer[i*3], buffer[i*3+1], buffer[i*3+2]))
@@ -2282,11 +2291,14 @@ public final class Shape: @unchecked Sendable {
     /// For curved edges, use `edgePoints(at:maxPoints:)` to get curve samples.
     /// This is suitable for simple polygon contours from Z-plane slices.
     ///
-    /// - Parameter maxPoints: Maximum number of points to return
+    /// - Parameter maxPoints: Output *capacity*, clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#558)
     /// - Returns: Array of 3D points (one per edge start vertex)
     public func contourPoints(maxPoints: Int = 1000) -> [SIMD3<Double>] {
-        var buffer = [Double](repeating: 0, count: maxPoints * 3)
-        let count = OCCTShapeGetContourPoints(handle, &buffer, Int32(maxPoints))
+        let capacity = Sampling.capacity(maxPoints)
+        guard capacity > 0 else { return [] }
+        var buffer = [Double](repeating: 0, count: capacity * 3)
+        let count = OCCTShapeGetContourPoints(handle, &buffer, Int32(capacity))
         var points: [SIMD3<Double>] = []
         for i in 0..<Int(count) {
             points.append(SIMD3(buffer[i*3], buffer[i*3+1], buffer[i*3+2]))
@@ -9838,18 +9850,24 @@ extension Shape {
 
     // MARK: - GeomFill_CoonsAlgPatch
 
-    /// Evaluate Coons algorithmic patch from 4 boundary edges
+    /// Evaluate Coons algorithmic patch from 4 boundary edges.
+    ///
+    /// - Parameters:
+    ///   - evalU: Evaluations in U, at least 1.
+    ///   - evalV: Evaluations in V, at least 1.
+    /// - Returns: The evaluated grid, or nil if the patch is degenerate or the grid cannot be
+    ///   served: the bound is on the **product**, which must not exceed
+    ///   ``Sampling/maximumSampleCount`` (#558).
     public static func coonsAlgPatch(
         edge1: Shape, edge2: Shape, edge3: Shape, edge4: Shape,
         evalU: Int = 10, evalV: Int = 10
     ) -> [SIMD3<Double>]? {
-        var outPoints = [Double](repeating: 0, count: evalU * evalV * 3)
+        guard let total = Sampling.gridTotal(evalU, evalV) else { return nil }
+        var outPoints = [Double](repeating: 0, count: total * 3)
         OCCTGeomFillCoonsAlgPatchEval(
             edge1.handle, edge2.handle, edge3.handle, edge4.handle,
             Int32(evalU), Int32(evalV), &outPoints)
-        let points = (0..<evalU * evalV).map { i in
-            SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
-        }
+        let points: [SIMD3<Double>] = unpackSIMD3(outPoints, count: total)
         // Check if any non-zero points
         guard points.contains(where: { simd_length($0) > 1e-10 }) else { return nil }
         return points
@@ -9902,22 +9920,26 @@ extension Shape {
 
     // MARK: - Adaptor3d_IsoCurve
 
-    /// Evaluate points along a U-iso curve on a face at given U parameter
+    /// Evaluate points along a U-iso curve on a face at given U parameter.
+    ///
+    /// - Parameter count: Desired number of evaluations, honoured within `1...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty (#558).
     public func uIsoCurvePoints(u: Double, count: Int = 20) -> [SIMD3<Double>] {
+        guard let count = Sampling.requested(count, atLeast: 1) else { return [] }
         var outPoints = [Double](repeating: 0, count: count * 3)
         OCCTAdaptor3dIsoCurveEval(handle, 0, u, Int32(count), &outPoints)
-        return (0..<count).map { i in
-            SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
-        }
+        return unpackSIMD3(outPoints, count: count)
     }
 
-    /// Evaluate points along a V-iso curve on a face at given V parameter
+    /// Evaluate points along a V-iso curve on a face at given V parameter.
+    ///
+    /// - Parameter count: Desired number of evaluations, honoured within `1...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty (#558).
     public func vIsoCurvePoints(v: Double, count: Int = 20) -> [SIMD3<Double>] {
+        guard let count = Sampling.requested(count, atLeast: 1) else { return [] }
         var outPoints = [Double](repeating: 0, count: count * 3)
         OCCTAdaptor3dIsoCurveEval(handle, 1, v, Int32(count), &outPoints)
-        return (0..<count).map { i in
-            SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
-        }
+        return unpackSIMD3(outPoints, count: count)
     }
 
     /// Extract a U-iso curve from a face as an edge
@@ -12278,9 +12300,13 @@ extension Edge {
     /// }
     /// ```
     ///
-    /// - Parameter count: Desired number of sample points; must be at least 2, else empty.
+    /// - Parameter count: Desired number of sample points, honoured within `2...`
+    ///   ``Sampling/maximumSampleCount``; outside that range the result is empty (#558). Shares
+    ///   the contract of ``Curve3D/quasiUniformParameters(count:)``, which wraps the same
+    ///   `GCPnts_QuasiUniformAbscissa` for the standalone-curve case.
     /// - Returns: Array of parameter values, never more than `count` of them, or empty on failure
     public func quasiUniformParameters(count: Int) -> [Double] {
+        guard let count = Sampling.requested(count) else { return [] }
         var params = [Double](repeating: 0, count: count)
         let n = OCCTGCPntsQuasiUniform(handle, Int32(count), &params, Int32(count))
         return Array(params.prefix(Int(n)))

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -594,14 +594,25 @@ public final class Surface: @unchecked Sendable {
 
     /// Draw iso-parameter grid lines for Metal visualization
     /// - Parameters:
-    ///   - uLineCount: Number of U-iso lines
-    ///   - vLineCount: Number of V-iso lines
-    ///   - pointsPerLine: Points per iso line
-    /// - Returns: Array of polylines, each a [SIMD3<Double>]
+    ///   - uLineCount: Number of U-iso lines, at least 0.
+    ///   - vLineCount: Number of V-iso lines, at least 0.
+    ///   - pointsPerLine: Points per iso line, at least 1.
+    /// - Returns: Array of polylines, each a [SIMD3<Double>], or empty if the grid cannot be
+    ///   served. The bound is on the total: `(uLineCount + vLineCount) * pointsPerLine` must not
+    ///   exceed ``Sampling/maximumSampleCount`` (#558). Each factor is also checked on its own,
+    ///   since a negative line count used to abort the process unless the other count happened to
+    ///   outweigh it.
     public func drawGrid(uLineCount: Int = 10, vLineCount: Int = 10,
                          pointsPerLine: Int = 50) -> [[SIMD3<Double>]] {
+        // Bound each line count before adding: the sum is what sizes `lineLengths`, and two counts
+        // near `Int.max` overflow the addition itself into a trap before any ceiling is consulted.
+        guard uLineCount >= 0, uLineCount <= Sampling.maximumSampleCount,
+              vLineCount >= 0, vLineCount <= Sampling.maximumSampleCount
+        else { return [] }
         let maxLines = uLineCount + vLineCount
-        let maxPoints = maxLines * pointsPerLine
+        guard let maxPoints = Sampling.gridTotal(maxLines, pointsPerLine, atLeast: 0),
+              maxPoints > 0
+        else { return [] }
         var buffer = [Double](repeating: 0, count: maxPoints * 3)
         var lineLengths = [Int32](repeating: 0, count: maxLines)
 
@@ -630,14 +641,22 @@ public final class Surface: @unchecked Sendable {
 
     /// Sample a uniform mesh grid of points for Metal visualization.
     ///
-    /// - Returns: A ``SurfaceGrid`` indexed `.at(u:v:)`, or an empty grid if sampling fails.
+    /// - Parameters:
+    ///   - uCount: Samples in U, at least 1.
+    ///   - vCount: Samples in V, at least 1.
+    /// - Returns: A ``SurfaceGrid`` indexed `.at(u:v:)`, or an empty grid if sampling fails or the
+    ///   grid cannot be served. The bound is on the **product**: `uCount * vCount` must not exceed
+    ///   ``Sampling/maximumSampleCount`` (#558). Each factor is also checked on its own, which is
+    ///   not redundant — two negative counts multiply to a plausible positive total, so
+    ///   `drawMesh(uCount: -1, vCount: -1)` used to look well-behaved while
+    ///   `drawMesh(uCount: -1, vCount: 3)` aborted the process.
     ///
     /// ```swift
     /// let grid = surface.drawMesh(uCount: 30, vCount: 30)
     /// let p = grid.at(u: 5, v: 3)
     /// ```
     public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid {
-        let total = uCount * vCount
+        guard let total = Sampling.gridTotal(uCount, vCount) else { return .empty }
         var buffer = [Double](repeating: 0, count: total * 3)
         let n = Int(OCCTSurfaceDrawMesh(handle, Int32(uCount), Int32(vCount), &buffer))
         guard n == total else { return .empty }

--- a/Sources/OCCTSwift/Wire.swift
+++ b/Sources/OCCTSwift/Wire.swift
@@ -1182,13 +1182,16 @@ extension Wire {
     ///
     /// - Parameters:
     ///   - index: 0-based edge index in traversal order
-    ///   - maxPoints: Maximum points to return (default: all points)
+    ///   - maxPoints: Output *capacity* (default: all points), honoured within `1...`
+    ///     ``Sampling/maximumSampleCount``; outside that range the result is nil (#558). This one
+    ///     keeps its existing lower bound of 1 rather than clamping to 0, since 0 already meant
+    ///     nil here.
     /// - Returns: Array of 3D points along the edge, or nil if index is out of range
     public func orderedEdgePoints(at index: Int, maxPoints: Int? = nil) -> [SIMD3<Double>]? {
         guard index >= 0 else { return nil }
         let limit: Int
         if let maxPoints {
-            guard maxPoints > 0 else { return nil }
+            guard maxPoints > 0, maxPoints <= Sampling.maximumSampleCount else { return nil }
             limit = maxPoints
         } else {
             let count = orderedEdgePointCount(at: index)

--- a/Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift
+++ b/Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift
@@ -1,0 +1,319 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #558: the sampling entry points #479 did not reach. A caller-supplied count sizes a Swift
+// allocation and is then cast to the `int32_t` the bridge takes its count in, so both ends abort
+// the process rather than failing: `[Double](repeating:count:)` traps on a negative and
+// `Int32(_:)` traps past `Int32.max`.
+//
+// Measured before the fix, one case per process (a trap takes the whole harness down, so each
+// absurd input needs its own run) against `refactor/381-pass1b`. 28 public entry points, not the
+// 14 the issue's own census named: `Edge.quasiUniformParameters`, `Curve3D.samplePoints`,
+// `Surface.drawGrid`, four more on `Shape`, `Wire.orderedEdgePoints`, both `MedialAxis` drawers
+// and `QuadricIntersection.coneSpherePoints` have the same shape and were missed. Every one of
+// the 28 trapped (or ground on an unservable allocation past 30 s) at `Int32.max + 1`, and 20 of
+// them trapped on a negative.
+//
+// These tests can run in-process precisely because the fix is what makes them able to: before it,
+// every #expect below would have aborted the test harness rather than failing.
+//
+// Two measurement notes that changed the fix:
+//
+//  - The issue recorded `Surface.drawMesh` as returning `.empty` for a negative count. It does,
+//    but only when the negative goes to *both* factors: `(-1) * (-1)` is a plausible positive
+//    total. `drawMesh(uCount: -1, vCount: 3)` aborted the process. Hence each factor is checked
+//    on its own, not just the product.
+//  - `MedialAxis.drawArc`'s parameter is named `maxPoints` but the bridge does `numPoints =
+//    maxPoints` and fills the buffer exactly, so it is a *request*, not a capacity. Clamping it
+//    would have handed back a coarser sampling than asked for; it rejects instead.
+// The emptiness assertions below compare `.count == 0` rather than reading `.isEmpty`. Swift
+// Testing prints the captured sub-expression on failure, and the sub-expression here is a sampling
+// call: a regression that returns 10 million points would print all 10 million of them. Measured
+// while injecting a deliberate bug to check these tests catch it — the run wrote over 5 GB before
+// it was killed. Comparing the count keeps a future failure to one integer. (#479 hit the same
+// hazard at 880 MB.)
+@Suite("Issue #558: every sampling entry point bounds the count a caller can supply", .serialized)
+struct Issue558SamplingCountBounds {
+
+    // `Int32.max + 1`, the first count provably past the bridge's own count type. Not the
+    // interesting threshold — anything above ~1e8 is unallocatable — just the cheapest to prove.
+    private static let pastInt32 = Int(Int32.max) + 1
+    private static let pastCeiling = Sampling.maximumSampleCount + 1
+
+    private func box() -> Shape { Shape.box(width: 10, height: 10, depth: 10)! }
+    private func segment3D() -> Curve3D { Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))! }
+    private func segment2D() -> Curve2D { Curve2D.segment(from: .zero, to: SIMD2(10, 0))! }
+    private func plane() -> Surface {
+        Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!.trimmed(u1: 0, u2: 10, v1: 0, v2: 10)!
+    }
+
+    // MARK: - The shared ceiling
+
+    @Test("the ceiling is declared once and the #479 spelling still resolves to it")
+    func ceilingIsShared() {
+        #expect(Sampling.maximumSampleCount == 10_000_000)
+        #expect(EdgeCurve.maximumSampleCount == Sampling.maximumSampleCount)
+        #expect(WireCurve.maximumSampleCount == Sampling.maximumSampleCount)
+    }
+
+    @Test("a request is honoured exactly or not at all")
+    func requestedContract() {
+        #expect(Sampling.requested(2) == 2)
+        #expect(Sampling.requested(Sampling.maximumSampleCount) == Sampling.maximumSampleCount)
+        #expect(Sampling.requested(1) == nil)                       // below the default minimum
+        #expect(Sampling.requested(1, atLeast: 1) == 1)             // ... unless the site allows it
+        #expect(Sampling.requested(0) == nil)
+        #expect(Sampling.requested(-1) == nil)
+        #expect(Sampling.requested(Self.pastCeiling) == nil)        // no clamping: rejected
+        #expect(Sampling.requested(Self.pastInt32) == nil)
+        #expect(Sampling.requested(Int.max) == nil)
+    }
+
+    @Test("a capacity is clamped into 0...ceiling rather than rejected")
+    func capacityContract() {
+        #expect(Sampling.capacity(4096) == 4096)
+        #expect(Sampling.capacity(Sampling.maximumSampleCount) == Sampling.maximumSampleCount)
+        #expect(Sampling.capacity(Self.pastCeiling) == Sampling.maximumSampleCount)
+        #expect(Sampling.capacity(Self.pastInt32) == Sampling.maximumSampleCount)
+        #expect(Sampling.capacity(Int.max) == Sampling.maximumSampleCount)
+        #expect(Sampling.capacity(0) == 0)
+        #expect(Sampling.capacity(-1) == 0)                         // no capacity, not a small one
+        #expect(Sampling.capacity(Int.min) == 0)
+    }
+
+    @Test("a grid bounds the product and each factor, and cannot overflow into one")
+    func gridTotalContract() {
+        #expect(Sampling.gridTotal(20, 20) == 400)
+        #expect(Sampling.gridTotal(1000, 10_000) == 10_000_000)     // exactly the ceiling
+        #expect(Sampling.gridTotal(1000, 10_001) == nil)            // one past it
+        // The measured hole: two negatives multiply to a plausible positive total.
+        #expect(Sampling.gridTotal(-1, -1) == nil)
+        #expect(Sampling.gridTotal(-1, 3) == nil)
+        #expect(Sampling.gridTotal(3, -1) == nil)
+        // Overflow is reported, not trapped on.
+        #expect(Sampling.gridTotal(Int.max, Int.max) == nil)
+        #expect(Sampling.gridTotal(Self.pastInt32, Self.pastInt32) == nil)
+        // `atLeast: 0` admits an empty grid without admitting a negative one.
+        #expect(Sampling.gridTotal(0, 50, atLeast: 0) == 0)
+        #expect(Sampling.gridTotal(-1, 50, atLeast: 0) == nil)
+    }
+
+    // MARK: - Requests: empty/nil outside 2...ceiling, exact inside it
+
+    @Test("Curve3D request samplers reject a count they cannot serve")
+    func curve3DRequests() {
+        let c = segment3D()
+        #expect(c.drawUniform(pointCount: 11).count == 11)
+        #expect(c.quasiUniformParameters(count: 8).count == 8)
+        for n in [-1, 0, 1, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(c.drawUniform(pointCount: n).count == 0, "drawUniform(\(n))")
+            #expect(c.quasiUniformParameters(count: n).count == 0, "quasiUniformParameters(\(n))")
+        }
+    }
+
+    @Test("Curve2D.drawUniform rejects a count it cannot serve")
+    func curve2DRequests() {
+        let c = segment2D()
+        #expect(c.drawUniform(pointCount: 11).count == 11)
+        for n in [-1, 0, 1, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(c.drawUniform(pointCount: n).count == 0, "drawUniform(\(n))")
+        }
+    }
+
+    @Test("Edge request samplers reject a count they cannot serve")
+    func edgeRequests() {
+        guard let e = box().edges().first else { #expect(Bool(false)); return }
+        #expect(e.points(count: 7).count == 7)
+        #expect(e.quasiUniformParameters(count: 9).count == 9)
+        for n in [-1, 0, 1, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(e.points(count: n).count == 0, "points(\(n))")
+            #expect(e.quasiUniformParameters(count: n).count == 0, "quasiUniformParameters(\(n))")
+        }
+        // The automatic default still produces its ~0.5mm-spaced samples.
+        #expect(e.points().count > 2)
+    }
+
+    @Test("Shape.uniformAbscissa rejects a count it cannot serve, both overloads")
+    func uniformAbscissaRequests() {
+        guard let edge = box().subShapes(ofType: .edge).first else { #expect(Bool(false)); return }
+        #expect(edge.uniformAbscissa(pointCount: 5)?.count == 5)
+        for n in [-1, 0, 1, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(edge.uniformAbscissa(pointCount: n) == nil, "uniformAbscissa(\(n))")
+            #expect(edge.uniformAbscissa(pointCount: n, u1: 0, u2: 1) == nil,
+                    "uniformAbscissa(\(n), u1:u2:)")
+        }
+    }
+
+    @Test("Shape iso-curve evaluators reject a count they cannot serve")
+    func isoCurveRequests() {
+        guard let face = box().subShapes(ofType: .face).first else { #expect(Bool(false)); return }
+        #expect(face.uIsoCurvePoints(u: 0.5, count: 12).count == 12)
+        #expect(face.vIsoCurvePoints(v: 0.5, count: 12).count == 12)
+        for n in [-1, 0, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(face.uIsoCurvePoints(u: 0.5, count: n).count == 0, "uIsoCurvePoints(\(n))")
+            #expect(face.vIsoCurvePoints(v: 0.5, count: n).count == 0, "vIsoCurvePoints(\(n))")
+        }
+    }
+
+    @Test("BRepGraph.sampleEdgeCurve rejects a count it cannot serve")
+    func graphEdgeSampleRequest() {
+        guard let graph = BRepGraph(shape: box()) else { #expect(Bool(false)); return }
+        #expect(graph.sampleEdgeCurve(edgeIndex: 0, count: 6).count == 6)
+        for n in [-1, 0, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(graph.sampleEdgeCurve(edgeIndex: 0, count: n).count == 0, "sampleEdgeCurve(\(n))")
+        }
+    }
+
+    @Test("Shape.allEdgePolylines keeps its own lower bound and gains the ceiling")
+    func allEdgePolylinesRequest() {
+        let b = box()
+        #expect(!b.allEdgePolylines(maxPointsPerEdge: 10).isEmpty)
+        for n in [-1, 0, 1, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(b.allEdgePolylines(maxPointsPerEdge: n).count == 0, "allEdgePolylines(\(n))")
+        }
+    }
+
+    @Test("MedialAxis fills its buffer exactly, so its maxPoints is a request, not a capacity")
+    func medialAxisRequests() {
+        guard let wire = Wire.rectangle(width: 10, height: 10),
+              let face = Shape.face(from: wire),
+              let ma = MedialAxis(of: face)
+        else { #expect(Bool(false)); return }
+        // Exactly the requested count, which is what makes clamping the wrong answer here.
+        #expect(ma.drawArc(at: 1, maxPoints: 32).count == 32)
+        #expect(ma.drawArc(at: 1, maxPoints: 64).count == 64)
+        for n in [-1, 0, 1, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(ma.drawArc(at: 1, maxPoints: n).count == 0, "drawArc(\(n))")
+            #expect(ma.drawAll(maxPointsPerArc: n).count == 0, "drawAll(\(n))")
+        }
+    }
+
+    @Test("QuadricIntersection.coneSpherePoints rejects a count it cannot serve")
+    func coneSphereRequest() {
+        for n in [-1, 0, Self.pastCeiling, Self.pastInt32, Int.max] {
+            let pts = QuadricIntersection.coneSpherePoints(
+                semiAngle: 0.5, refRadius: 5, sphereCenter: SIMD3(0, 0, 5), sphereRadius: 3,
+                curveIndex: 0, sampleCount: n)
+            #expect(pts.count == 0, "coneSpherePoints(\(n))")
+        }
+    }
+
+    // MARK: - Capacities: clamped, so an absurd capacity still returns the real answer
+
+    @Test("an adaptive sampler's capacity is clamped, not rejected: the answer is unchanged")
+    func adaptiveCapacitiesAreClamped() {
+        let c3 = segment3D(), c2 = segment2D()
+        // A straight segment is two points however much room it is offered. The point of clamping
+        // rather than rejecting: the caller gets the correct sampling, not an empty array.
+        let baseline3D = c3.drawAdaptive(maxPoints: 4096).count
+        #expect(baseline3D == c3.drawAdaptive(maxPoints: Self.pastInt32).count)
+        #expect(baseline3D == c3.drawDeflection(maxPoints: Self.pastInt32).count)
+        #expect(c3.samplePoints(first: 0, last: 10, maxPoints: 1000).count
+                == c3.samplePoints(first: 0, last: 10, maxPoints: Self.pastInt32).count)
+        #expect(!c3.quasiUniformDeflectionPoints(deflection: 0.1, maxPoints: Self.pastInt32).isEmpty)
+
+        let baseline2D = c2.drawAdaptive(maxPoints: 4096).count
+        #expect(baseline2D == c2.drawAdaptive(maxPoints: Self.pastInt32).count)
+        #expect(baseline2D == c2.drawDeflection(maxPoints: Self.pastInt32).count)
+    }
+
+    @Test("a capacity of zero or less yields the entry point's own empty value")
+    func nonPositiveCapacitiesAreEmpty() {
+        let c3 = segment3D(), c2 = segment2D(), b = box()
+        for n in [-1, 0, Int.min] {
+            #expect(c3.drawAdaptive(maxPoints: n).count == 0, "3D drawAdaptive(\(n))")
+            #expect(c3.drawDeflection(maxPoints: n).count == 0, "3D drawDeflection(\(n))")
+            #expect(c3.samplePoints(first: 0, last: 10, maxPoints: n).count == 0, "samplePoints(\(n))")
+            #expect(c3.quasiUniformDeflectionPoints(deflection: 0.1, maxPoints: n).count == 0,
+                    "quasiUniformDeflectionPoints(\(n))")
+            #expect(c2.drawAdaptive(maxPoints: n).count == 0, "2D drawAdaptive(\(n))")
+            #expect(c2.drawDeflection(maxPoints: n).count == 0, "2D drawDeflection(\(n))")
+            #expect(b.edgePolyline(at: 0, maxPoints: n) == nil, "edgePolyline(\(n))")
+            #expect(b.edgePoints(at: 0, maxPoints: n).count == 0, "edgePoints(\(n))")
+            #expect(b.contourPoints(maxPoints: n).count == 0, "contourPoints(\(n))")
+        }
+    }
+
+    @Test("Shape's own capacity samplers clamp and still answer")
+    func shapeCapacitiesAreClamped() {
+        let b = box()
+        #expect(b.edgePolyline(at: 0, maxPoints: Self.pastInt32) != nil)
+        // Both of these are bounded by the shape, not by the capacity: the bridge caps edgePoints
+        // at 20 internally, and contourPoints emits one point per edge.
+        #expect(b.edgePoints(at: 0, maxPoints: Self.pastInt32).count
+                == b.edgePoints(at: 0, maxPoints: 20).count)
+        #expect(b.contourPoints(maxPoints: Self.pastInt32).count
+                == b.contourPoints(maxPoints: 1000).count)
+    }
+
+    @Test("Wire.orderedEdgePoints keeps nil for zero and gains it for the ceiling")
+    func orderedEdgePointsCapacity() {
+        guard let w = Wire.rectangle(width: 10, height: 10) else { #expect(Bool(false)); return }
+        #expect(w.orderedEdgePoints(at: 0, maxPoints: 5) != nil)
+        #expect(w.orderedEdgePoints(at: 0) != nil)              // the derived, no-capacity path
+        for n in [-1, 0, Self.pastCeiling, Self.pastInt32, Int.max] {
+            #expect(w.orderedEdgePoints(at: 0, maxPoints: n) == nil, "orderedEdgePoints(\(n))")
+        }
+    }
+
+    // MARK: - Grids: the bound is on the product, and on each factor
+
+    @Test("Surface.drawMesh bounds the product, and each factor on its own")
+    func drawMeshGrid() {
+        let s = plane()
+        #expect(!s.drawMesh(uCount: 20, vCount: 20).isEmpty)
+        // Exactly the ceiling is refused only past it, not at it — but 1e7 points is 45 s of
+        // sampling, so the boundary itself is checked on `Sampling.gridTotal` above, not here.
+        #expect(s.drawMesh(uCount: 5000, vCount: 2001).uCount == 0)     // 10,005,000: past the ceiling
+        // The measured hole: two negatives used to multiply to a plausible positive total, so
+        // this pair looked well-behaved while the mixed-sign pairs below aborted the process.
+        #expect(s.drawMesh(uCount: -1, vCount: -1).uCount == 0)
+        #expect(s.drawMesh(uCount: -1, vCount: 3).uCount == 0)
+        #expect(s.drawMesh(uCount: 3, vCount: -1).uCount == 0)
+        #expect(s.drawMesh(uCount: 0, vCount: 3).uCount == 0)
+        #expect(s.drawMesh(uCount: Self.pastInt32, vCount: 3).uCount == 0)
+        #expect(s.drawMesh(uCount: Int.max, vCount: Int.max).uCount == 0)
+    }
+
+    @Test("Surface.drawGrid bounds the total, and each line count on its own")
+    func drawGridTotal() {
+        let s = plane()
+        #expect(!s.drawGrid(uLineCount: 4, vLineCount: 4, pointsPerLine: 10).isEmpty)
+        #expect(s.drawGrid(uLineCount: 4, vLineCount: 4, pointsPerLine: 2_000_000).count == 0)
+        #expect(s.drawGrid(uLineCount: -1, vLineCount: -1, pointsPerLine: 10).count == 0)
+        #expect(s.drawGrid(uLineCount: -1, vLineCount: 4, pointsPerLine: 10).count == 0)
+        #expect(s.drawGrid(uLineCount: 4, vLineCount: 4, pointsPerLine: -1).count == 0)
+        // Both line counts near Int.max used to overflow the addition itself, before any ceiling.
+        #expect(s.drawGrid(uLineCount: Int.max, vLineCount: Int.max, pointsPerLine: 10).count == 0)
+        #expect(s.drawGrid(uLineCount: Self.pastInt32, vLineCount: 0, pointsPerLine: 10).count == 0)
+    }
+
+    @Test("BRepGraph.sampleFaceUVGrid bounds the product, and each factor on its own")
+    func faceUVGrid() {
+        guard let graph = BRepGraph(shape: box()) else { #expect(Bool(false)); return }
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 5, vSamples: 4) != nil)
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 5000, vSamples: 2001) == nil)
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: -1, vSamples: -1) == nil)
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: -1, vSamples: 3) == nil)
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 0, vSamples: 3) == nil)
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: Self.pastInt32, vSamples: 3) == nil)
+        #expect(graph.sampleFaceUVGrid(faceIndex: 0, uSamples: Int.max, vSamples: Int.max) == nil)
+    }
+
+    @Test("Shape.coonsAlgPatch bounds the product, and each factor on its own")
+    func coonsPatchGrid() {
+        guard let e = box().subShapes(ofType: .edge).first else { #expect(Bool(false)); return }
+        // Four copies of one edge is a degenerate patch, so the result is nil either way; what is
+        // under test is that an absurd grid returns rather than aborting the process.
+        #expect(Shape.coonsAlgPatch(edge1: e, edge2: e, edge3: e, edge4: e,
+                                    evalU: -1, evalV: -1) == nil)
+        #expect(Shape.coonsAlgPatch(edge1: e, edge2: e, edge3: e, edge4: e,
+                                    evalU: -1, evalV: 3) == nil)
+        #expect(Shape.coonsAlgPatch(edge1: e, edge2: e, edge3: e, edge4: e,
+                                    evalU: 5000, evalV: 2001) == nil)
+        #expect(Shape.coonsAlgPatch(edge1: e, edge2: e, edge3: e, edge4: e,
+                                    evalU: Int.max, evalV: Int.max) == nil)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -227,6 +227,62 @@ tests); the only fallout was one existing test whose helper subtracted 1 from
 Not an upstream defect — both OCCT primitives behave exactly as documented, and the kernel is not
 involved in the base convention at all. No kernel patch, no xcframework rebuild.
 
+#### Every sampling entry point now bounds the count a caller can supply (#558)
+
+#479 bounded two entry points and recorded that "the same shape is live at fourteen other sampling
+entry points". Measuring the family before fixing it found **twenty-eight**, not fourteen: a caller
+supplies a count, it sizes a Swift allocation, and it is then cast to the `int32_t` the bridge takes
+its count in. `[Double](repeating:count:)` traps on a negative and `Int32(_:)` traps past
+`Int32.max`, so both ends abort the process rather than returning the documented empty value.
+
+Measured one case per process, since a trap takes the whole harness down with it. Every one of the
+28 either trapped or ground on an unservable allocation past 30 s at `Int(Int32.max) + 1`, and 20 of
+them trapped on `-1`. The fourteen the issue did not name are `Edge.quasiUniformParameters(count:)`
+(the same method, on the same `GCPnts_QuasiUniformAbscissa`, as the `Curve3D` one that *was* named),
+`Curve3D.samplePoints(first:last:maxPoints:)`, `Surface.drawGrid(uLineCount:vLineCount:pointsPerLine:)`,
+`Shape`'s `edgePolyline`, `allEdgePolylines`, `edgePoints`, `contourPoints`, `uIsoCurvePoints`,
+`vIsoCurvePoints` and `coonsAlgPatch`, `Wire.orderedEdgePoints(at:maxPoints:)`, both `MedialAxis`
+drawers, and `QuadricIntersection.coneSpherePoints`.
+
+The ceiling moves out of `ArcLengthCurveAdaptor` into **`Sampling.maximumSampleCount`**, still
+10,000,000 and still the measured number #479 justified. `EdgeCurve.maximumSampleCount` /
+`WireCurve.maximumSampleCount` keep working and resolve to it, so nothing #479 shipped breaks.
+
+The bound is not one rule, because the parameters do not mean one thing:
+
+| kind | parameter | decision | why |
+|---|---|---|---|
+| **request** | `count`, `pointCount`, `sampleCount` | rejected outside `2...ceiling` (empty / `nil`) | the caller asked for exactly this many; returning fewer is the silent-coarsening defect #501 found |
+| **capacity** | `maxPoints` on an adaptive sampler | clamped into `0...ceiling` | the deflection criterion decides the count and the capacity only truncates, so clamping returns the *same* points, not coarser ones |
+| **grid** | `uCount`×`vCount`, `evalU`×`evalV`, `(uLineCount + vLineCount)`×`pointsPerLine` | the **product** is bounded, and each factor checked on its own | see below |
+
+Two things the measurement changed about the fix as the issue specified it:
+
+- **The issue recorded `Surface.drawMesh` as returning `.empty` for a negative count. It does, but
+  only when the negative goes to both factors.** `(-1) * (-1)` is `1`, a perfectly plausible total,
+  so the allocation succeeds and the bridge rejects the counts on its own. `drawMesh(uCount: -1,
+  vCount: 3)` is `-3` and aborts the process. Bounding only the product would have left that live,
+  so each factor is checked individually as well. Confirmed by injection: with the per-factor check
+  removed, the new suite aborts with `Fatal error: Can't construct Array with count < 0` at exactly
+  that case. The same masking applies to `Surface.drawGrid` and `MedialAxis.drawAll`.
+- **`MedialAxis.drawArc`'s parameter is named `maxPoints`, but it is a request.** The bridge does
+  `numPoints = maxPoints` and fills the buffer exactly, so it returns precisely the count asked for
+  (and nothing at all below 2), unlike the genuinely adaptive samplers that share the name. It was
+  written as a capacity first; the verification sweep caught it returning a full 10,000,000 points
+  for a clamped absurd input, which is the coarsening the clamp was supposed to be immune to. It
+  rejects instead.
+
+The multiplications are overflow-checked rather than assumed in range: `Int` wraps into a trap of
+its own well before the ceiling is reached, and `drawGrid`'s two line counts are bounded before
+being added for the same reason.
+
+Regression suite: `Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift`, 21 tests. They run
+in-process only because the fix is what lets them: before it, every assertion in them would have
+aborted the test harness rather than failing. They compare `.count == 0` rather than reading
+`.isEmpty` because Swift Testing prints the captured sub-expression on failure, and a regression
+returning 10 million points would print all 10 million (measured at over 5 GB while injecting a
+deliberate bug to confirm the suite catches it; #479 hit the same hazard at 880 MB).
+
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 
 `OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed
@@ -737,6 +793,12 @@ itself, despite documenting "must be at least 2, else empty". Measured one case 
 assumed. Filed as #558 rather than widened into this fix: `maxPoints` on an adaptive algorithm is a
 capacity rather than a request, and `uSamples`/`vSamples` bound a product, so those need a contract
 decision per parameter rather than this one's ceiling applied uniformly.
+
+> **Corrected by #558**: the family is twenty-eight entry points, not fourteen — this census missed
+> half of it, including `Edge.quasiUniformParameters(count:)`, the same method on the same OCCT
+> class as the `Curve3D` one it did name. The `drawMesh` row of its table is also wrong: a negative
+> count only survives when it is passed to *both* factors, where the two negatives multiply to a
+> plausible positive total. See the #558 entry above.
 
 #### The knot-splitting continuity cap, on the four fifths of the family #398 did not reach (#480)
 

--- a/docs/reference/BRepGraph-Editor-Identity.md
+++ b/docs/reference/BRepGraph-Editor-Identity.md
@@ -695,7 +695,9 @@ public func sampleFaceUVGrid(faceIndex: Int, uSamples: Int, vSamples: Int) -> Fa
   - `faceIndex` — face definition index.
   - `uSamples` — number of samples in U direction (must be ≥ 1).
   - `vSamples` — number of samples in V direction (must be ≥ 1).
-- **Returns:** `FaceGridSample` with `uSamples × vSamples` entries, or `nil` if the face has no surface or sampling fails.
+
+  The bound is on the **product**: `uSamples * vSamples` must not exceed `Sampling.maximumSampleCount` (10,000,000), and each factor is checked on its own, since two negatives multiply to a plausible positive total (#558). This sampler fills four buffers per point (position, normal, Gaussian and mean curvature), so it reaches the ceiling's memory cost sooner than the point-only samplers do.
+- **Returns:** `FaceGridSample` with `uSamples × vSamples` entries, or `nil` if the face has no surface, sampling fails, or the grid cannot be served.
 - **OCCT:** `GeomLProp_SLProps` (position, normal, curvature evaluation) via `OCCTBRepGraphSampleFaceUVGrid`.
 - **Example:**
   ```swift
@@ -724,7 +726,7 @@ public func sampleEdgeCurve(edgeIndex: Int, count: Int) -> [SIMD3<Double>]
 
 - **Parameters:**
   - `edgeIndex` — edge definition index.
-  - `count` — number of points to sample (must be ≥ 1).
+  - `count` — number of points to sample, a *request* honoured within `1...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#558).
 - **Returns:** Array of 3D points along the edge curve, in parameter order; empty if the edge has no curve or sampling fails.
 - **OCCT:** `GeomAdaptor_Curve` (via `OCCTBRepGraphSampleEdgeCurve`).
 - **Example:**

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -393,7 +393,7 @@ public func drawAdaptive(angularDeflection: Double = 0.1,
 
 Concentrates sample points where curvature is high and fewer where the curve is straight, producing an efficient polyline for Metal rendering.
 
-- **Parameters:** `angularDeflection` — maximum angle between consecutive tangents (radians); `chordalDeflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Parameters:** `angularDeflection` — maximum angle between consecutive tangents (radians); `chordalDeflection` — maximum chord-to-curve deviation; `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558). The deflection criteria decide the actual point count.
 - **Returns:** Array of 2D points along the curve; empty on failure.
 - **OCCT:** `GCPnts_TangentialDeflection` (via `OCCTCurve2DDrawAdaptive`).
 - **Example:**
@@ -413,7 +413,7 @@ Discretizes the curve at up to `pointCount` uniformly-spaced arc-length points. 
 public func drawUniform(pointCount: Int) -> [SIMD2<Double>]
 ```
 
-- **Parameters:** `pointCount`, the desired number of output points. Must be at least 2; below that the result is empty (#501).
+- **Parameters:** `pointCount`, the desired number of output points — a *request*, honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#501, #558). Not clamped: a count past the ceiling fails visibly rather than coming back coarser than what was asked for. Before #558 a negative aborted the process rather than returning empty.
 - **Returns:** Array of 2D points, never more than `pointCount`; empty on failure.
 - **OCCT:** `GCPnts_UniformAbscissa` (via `OCCTCurve2DDrawUniform`). It sizes its own array at `pointCount + 5` and can report more points than requested on a poorly-conditioned curve; the surplus is dropped and the curve's end point kept (#501).
 - **Example:**
@@ -434,7 +434,7 @@ public func drawDeflection(deflection: Double = 0.01,
                            maxPoints: Int = 4096) -> [SIMD2<Double>]
 ```
 
-- **Parameters:** `deflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Parameters:** `deflection` — maximum chord-to-curve deviation; `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558).
 - **Returns:** Array of 2D points; empty on failure.
 - **OCCT:** `GCPnts_UniformDeflection` (via `OCCTCurve2DDrawDeflection`).
 - **Example:**

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -498,7 +498,7 @@ public func quasiUniformParameters(count: Int) -> [Double]
 
 Uses `GCPnts_QuasiUniformAbscissa` to space `count` parameters approximately evenly along the arc length of the curve. The result is suitable for passing to `evaluateGrid(_:)`. The first parameter is always the start of the curve's domain and the last is always its end.
 
-- **Parameters:** `count`, the desired number of sample parameters. Must be at least 2; below that the result is empty. OCCT documents the same precondition but enforces it with a `Raise_if`, which the pinned Release kernel compiles out, so the bridge applies it (#501).
+- **Parameters:** `count`, the desired number of sample parameters — a *request*, honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty. OCCT documents the lower bound but enforces it with a `Raise_if`, which the pinned Release kernel compiles out, so this layer applies it (#501); the upper bound is this layer's too, since `count` sizes a Swift allocation and is cast to the bridge's `int32_t`, and both ends used to abort the process (#558).
 - **Returns:** Array of parameter values of length up to `count`, never more; empty on failure.
 - **OCCT:** `GCPnts_QuasiUniformAbscissa`. It can compute one point beyond the request on a poorly-conditioned curve (measured on a 1e6 x 1e-3 ellipse); the surplus is dropped, but the curve's end parameter is kept in the last slot rather than truncated away.
 - **Example:**
@@ -521,7 +521,7 @@ public func quasiUniformDeflectionPoints(deflection: Double, maxPoints: Int = 50
 
 Uses `GCPnts_QuasiUniformDeflection`. Tighter curves produce more points; straighter segments produce fewer. The result is suitable for polygon rendering.
 
-- **Parameters:** `deflection` — maximum allowed chord deviation from the curve; `maxPoints` — upper bound on returned points (default 500).
+- **Parameters:** `deflection` — maximum allowed chord deviation from the curve; `maxPoints` — output *capacity* (default 500), clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558). The deflection decides the actual point count.
 - **Returns:** Array of 3D points (may be empty on failure).
 - **OCCT:** `GCPnts_QuasiUniformDeflection`.
 - **Example:**
@@ -654,7 +654,7 @@ public func samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> 
 
 Uses `ShapeAnalysis_Curve::GetSamplePoints`. The distribution is chosen internally by OCCT for good geometric coverage, not strict arc-length uniformity. For uniform spacing see `quasiUniformParameters(count:)`.
 
-- **Parameters:** `first` — start parameter; `last` — end parameter; `maxPoints` — upper bound on returned points (default 1000).
+- **Parameters:** `first` — start parameter; `last` — end parameter; `maxPoints` — output *capacity* (default 1000), clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558).
 - **Returns:** Array of 3D sample points (may be empty on failure).
 - **OCCT:** `ShapeAnalysis_Curve::GetSamplePoints`.
 - **Example:**

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -916,7 +916,7 @@ public func drawAdaptive(angularDeflection: Double = 0.1,
 
 Concentrates sample points where the curve bends sharply, producing an efficient polyline for Metal rendering. Returns an empty array if the curve cannot be discretized.
 
-- **Parameters:** `angularDeflection` — maximum angle between consecutive tangents (radians); `chordalDeflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Parameters:** `angularDeflection` — maximum angle between consecutive tangents (radians); `chordalDeflection` — maximum chord-to-curve deviation; `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558). The deflection criteria decide the actual point count.
 - **Returns:** Array of 3D points along the curve; never force-unwrap.
 - **OCCT:** `GCPnts_TangentialDeflection(adaptor, angularDefl, chordalDefl)`.
 - **Example:**
@@ -938,7 +938,7 @@ public func drawUniform(pointCount: Int) -> [SIMD3<Double>]
 
 All consecutive point pairs are separated by the same arc-length. Good for even distribution of sample points regardless of curvature. The first point is always the start of the curve and the last is always its end.
 
-- **Parameters:** `pointCount`, the desired number of output points. Must be at least 2; below that the result is empty (#501).
+- **Parameters:** `pointCount`, the desired number of output points — a *request*, honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#501, #558). Not clamped: a count past the ceiling fails visibly rather than coming back coarser than what was asked for. Before #558 a negative aborted the process rather than returning empty.
 - **Returns:** Array of 3D points, never more than `pointCount`, or empty array on failure.
 - **OCCT:** `GCPnts_UniformAbscissa(adaptor, pointCount)`. It sizes its own array at `pointCount + 5` and can report more points than requested on a poorly-conditioned curve; the surplus is dropped and the curve's end point kept (#501).
 - **Example:**
@@ -959,7 +959,7 @@ public func drawDeflection(deflection: Double = 0.01,
                            maxPoints: Int = 4096) -> [SIMD3<Double>]
 ```
 
-- **Parameters:** `deflection` — maximum chord-to-curve deviation; `maxPoints` — buffer size limit.
+- **Parameters:** `deflection` — maximum chord-to-curve deviation; `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558).
 - **Returns:** Array of 3D points; empty on failure.
 - **OCCT:** `GCPnts_UniformDeflection(adaptor, deflection)`.
 - **Example:**

--- a/docs/reference/CurveAdaptors.md
+++ b/docs/reference/CurveAdaptors.md
@@ -5,11 +5,11 @@ parent: API Reference
 
 # Curve Adaptors & Wire Ordering
 
-`WireCurve` and `EdgeCurve` wrap `BRepAdaptor_CompCurve` and `BRepAdaptor_Curve` respectively, exposing arc-length parameterization and uniform sampling over a multi-edge wire or a single edge. `WireOrder` wraps `ShapeAnalysis_WireOrder` to determine the connection order and required reversals for a set of disconnected edges.
+`WireCurve` and `EdgeCurve` wrap `BRepAdaptor_CompCurve` and `BRepAdaptor_Curve` respectively, exposing arc-length parameterization and uniform sampling over a multi-edge wire or a single edge. `WireOrder` wraps `ShapeAnalysis_WireOrder` to determine the connection order and required reversals for a set of disconnected edges. `Sampling` holds the one sample-count ceiling every sampling entry point in the package measures against.
 
 ## Topics
 
-- [WireCurve](#wirecurve) · [EdgeCurve](#edgecurve) · [WireOrder](#wireorder)
+- [WireCurve](#wirecurve) · [EdgeCurve](#edgecurve) · [WireOrder](#wireorder) · [Sampling](#sampling)
 
 ---
 
@@ -233,8 +233,10 @@ Pure-Swift: derives the sample count from `length / spacing` and delegates to `p
 
 The largest sample count either adaptor will produce: 10 million points. Shared by `WireCurve` and `EdgeCurve`, since it is declared once on `ArcLengthCurveAdaptor`.
 
+Since #558 the number itself lives on `Sampling.maximumSampleCount`, where the other 26 sampling entry points that had the same defect can see it; both spellings below resolve to it and stay the ones these two types' own documentation uses.
+
 ```swift
-public static var maximumSampleCount: Int  // 10_000_000
+public static var maximumSampleCount: Int  // 10_000_000, == Sampling.maximumSampleCount
 ```
 
 `count` sizes a Swift allocation and is then cast to the `int32_t` the bridge takes its count in, so an unbounded count is a process abort rather than a failed call: before #479 a `points(spacing:)` small enough to imply 10<sup>11</sup> points asked for a ~2.4 TB array, and one small enough to overflow `Int` trapped in the conversion itself. Both entry points now return `[]` above the ceiling instead, with no clamping: a request the ceiling cannot honour fails visibly rather than coming back silently coarser than what was asked for.
@@ -465,7 +467,7 @@ Pure-Swift: derives the sample count from `length / spacing` and delegates to `p
 
 ### `maximumSampleCount`
 
-The same ceiling `WireCurve` applies; see [maximumSampleCount](#maximumsamplecount) above. It is declared once on `ArcLengthCurveAdaptor`, so `EdgeCurve.maximumSampleCount == WireCurve.maximumSampleCount`.
+The same ceiling `WireCurve` applies; see [maximumSampleCount](#maximumsamplecount) above. It is declared once on `ArcLengthCurveAdaptor` and, since #558, forwards to `Sampling.maximumSampleCount`, so `EdgeCurve.maximumSampleCount == WireCurve.maximumSampleCount == Sampling.maximumSampleCount`.
 
 ```swift
 public static var maximumSampleCount: Int  // 10_000_000
@@ -620,4 +622,47 @@ Extracts edge endpoint coordinates from the wire via the bridge (up to 1000 edge
   if let wo = WireOrder.analyze(wire: wire) {
       print(wo.status)       // .closed or .open depending on wire
   }
+  ```
+
+---
+
+## Sampling
+
+The one ceiling every sampling entry point in the package measures a caller-supplied count against. Not a curve-adaptor type — it lives on this page because this is where the ceiling's rationale is written down, and `WireCurve`/`EdgeCurve` were the first two types to get it (#479) before the other 26 followed (#558).
+
+```swift
+public enum Sampling
+```
+
+---
+
+### `maximumSampleCount`
+
+The largest sample count any sampling entry point will produce: 10 million points.
+
+```swift
+public static let maximumSampleCount = 10_000_000
+```
+
+A sampling count arrives from the caller, sizes a Swift allocation, and is then cast to the `int32_t` the bridge takes its count in. Both ends abort the process rather than failing a call: `[Double](repeating:count:)` traps on a negative and `Int32(_:)` traps past `Int32.max`. Before #479/#558 that was live at 28 public entry points across `Curve3D`, `Curve2D`, `Edge`, `Surface`, `Shape`, `Wire`, `BRepGraph`, `MedialAxis` and `QuadricIntersection`.
+
+The number is measured, not round: sampling costs about 4.5 µs per point, and one sample costs 24 bytes in the bridge's packed buffer plus 32 in the returned array, so the ceiling itself is already about 625 MB resident and 45 seconds of work. It is also two orders of magnitude below the `int32_t` the bridge counts in. See [the `WireCurve` discussion](#maximumsamplecount) for the full cost curve.
+
+**The ceiling drives three different decisions, because the parameters do not mean one thing:**
+
+| kind | parameter | behaviour |
+|---|---|---|
+| **request** | `count`, `pointCount`, `sampleCount` | Rejected outside `2...maximumSampleCount` (empty / `nil`). Never clamped — the caller asked for exactly this many, and returning fewer is the silent-coarsening defect [#501](https://github.com/SecondMouseAU/OCCTSwift/issues/501) found. |
+| **capacity** | `maxPoints` on an adaptive sampler | Clamped into `0...maximumSampleCount`. The deflection criterion decides the point count and the capacity only truncates, so clamping returns the *same* points. A capacity of 0 or less yields the entry point's own empty value. |
+| **grid** | `uCount`×`vCount`, `evalU`×`evalV`, `(uLineCount + vLineCount)`×`pointsPerLine` | The **product** is bounded, and each factor checked on its own — two negatives multiply to a plausible positive total, which is why `drawMesh(uCount: -1, vCount: -1)` looked well-behaved while `drawMesh(uCount: -1, vCount: 3)` aborted the process. Multiplications are overflow-checked. |
+
+The parameter's *name* does not settle which it is: `MedialAxis.drawArc(at:maxPoints:)` says capacity but fills its buffer exactly, so it is a request.
+
+- **Example:**
+  ```swift
+  let curve = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
+
+  curve.drawUniform(pointCount: Sampling.maximumSampleCount + 1).isEmpty   // true: a request, rejected
+  curve.drawAdaptive(maxPoints: Sampling.maximumSampleCount + 1).count     // 2: a capacity, clamped
+  curve.drawUniform(pointCount: Int(Int32.max) + 1).isEmpty                // true, no trap
   ```

--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -463,7 +463,7 @@ public func points(count: Int? = nil) -> [SIMD3<Double>]
 
 When `count` is `nil`, automatically computes a point count at approximately 0.5 model-unit spacing (`max(2, Int(length / 0.5) + 1)`). Points are evenly spaced in the OCCT parameter domain (not arc-length).
 
-- **Parameters:** `count` — number of points to generate; `nil` = automatic.
+- **Parameters:** `count` — number of points to generate; `nil` = automatic (~0.5 mm spacing). A *request*: honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#558). The automatic default is bounded the same way, since a long enough edge implies more points at 0.5 mm than the ceiling can serve.
 - **Returns:** Array of 3D points; empty on failure or for degenerate edges.
 - **OCCT:** `BRepAdaptor_Curve::Value` — samples at uniformly-spaced parameter values.
 - **Example:**

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -629,7 +629,7 @@ public func drawArc(at index: Int, maxPoints: Int = 32) -> [SIMD2<Double>]
 
 Evaluates the arc's bisector curve (`BRepMAT2d_BisectingLocus::GeomBis`) at uniformly spaced parameters. Infinite curve parameters are clamped to ±1000.
 
-- **Parameters:** `index` — 1-based arc index; `maxPoints` — maximum number of sample points (default 32).
+- **Parameters:** `index` — 1-based arc index; `maxPoints` — sample points *requested* (default 32), honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#558). The name says capacity but the contract is a request: the bridge samples the arc at exactly `maxPoints` evenly-spaced parameters and always returns that many, so an unservable count is rejected rather than clamped — clamping would hand back a coarser sampling than asked for.
 - **Returns:** Array of 2D points along the arc; empty on error.
 - **OCCT:** `MAT_Graph::Arc` + `BRepMAT2d_BisectingLocus::GeomBis` + `Geom2d_TrimmedCurve::Value`.
 - **Example:**
@@ -652,7 +652,7 @@ public func drawAll(maxPointsPerArc: Int = 32) -> [[SIMD2<Double>]]
 
 Calls `OCCTMedialAxisDrawAll` which fills a flat XY buffer and per-arc start/length arrays in one pass. More efficient than calling `drawArc(at:)` in a loop.
 
-- **Parameters:** `maxPointsPerArc` — maximum sample points per arc (default 32).
+- **Parameters:** `maxPointsPerArc` — sample points *requested* per arc (default 32), at least 2. The bound is on the total: `arcCount * maxPointsPerArc` must not exceed `Sampling.maximumSampleCount` (10,000,000), else the result is empty; `maxPointsPerArc` is checked on its own too, since a negative count on a graph with no arcs multiplies to a plausible total (#558).
 - **Returns:** Array of polylines, one per arc; empty if `arcCount == 0`.
 - **OCCT:** `BRepMAT2d_BisectingLocus::GeomBis` (per arc) + `Geom2d_TrimmedCurve::Value`.
 - **Example:**

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -121,6 +121,6 @@ Coverage tracker — update as pages land. (Counts = public decls in the source 
 | Sheet Metal (SheetMetal, SheetLayout) | 39 | `SheetMetal.md` | ✅ done |
 | Bill of Materials & Selection (BillOfMaterials, Selector, Selection) | 48 | `Selection.md` | ✅ done |
 | Date & Period (Date, Period) | 33 | `DateTime.md` | ✅ done |
-| Curve Adaptors & Wire Ordering (WireCurve, EdgeCurve, WireOrder) | 32 | `CurveAdaptors.md` | ✅ done |
+| Curve Adaptors, Wire Ordering & Sampling Bounds (WireCurve, EdgeCurve, WireOrder, Sampling) | 33 | `CurveAdaptors.md` | ✅ done |
 | Geometry Solvers & Builders (BSplineApproxInterp, PlateSolver, FillingSurface, LawFunction, PolynomialSolver, KDTree) | 60 | `GeometrySolvers.md` | ✅ done |
 | Concurrency & Progress (OCCTSerial, ImportProgress) | 6 | `Concurrency.md` | ✅ done |

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -125,7 +125,7 @@ Evaluate sample points along a U-iso curve on a face.
 public func uIsoCurvePoints(u: Double, count: Int = 20) -> [SIMD3<Double>]
 ```
 
-- **Parameters:** `u` — U parameter value. `count` — number of sample points.
+- **Parameters:** `u` — U parameter value. `count` — number of sample points, a *request* honoured within `1...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#558).
 - **Returns:** Array of 3D points along the iso curve.
 - **OCCT:** `Adaptor3d_IsoCurve` (iso kind 0 = U)
 - **Example:**
@@ -143,7 +143,7 @@ Evaluate sample points along a V-iso curve on a face.
 public func vIsoCurvePoints(v: Double, count: Int = 20) -> [SIMD3<Double>]
 ```
 
-- **Parameters:** `v` — V parameter value. `count` — number of sample points.
+- **Parameters:** `v` — V parameter value. `count` — number of sample points, a *request* honoured within `1...Sampling.maximumSampleCount` (10,000,000); outside that range the result is empty (#558).
 - **Returns:** Array of 3D points along the iso curve.
 - **OCCT:** `Adaptor3d_IsoCurve` (iso kind 1 = V)
 - **Example:**

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -692,7 +692,7 @@ public func edgePoints(at index: Int, maxPoints: Int = 20) -> [SIMD3<Double>]
 
 Points are uniformly sampled from start to end of the edge curve.
 
-- **Parameters:** `index` — edge index (0 to `subShapeCount(ofType: .edge) − 1`); `maxPoints` — maximum points to return (capped at 20 internally).
+- **Parameters:** `index` — edge index (0 to `subShapeCount(ofType: .edge) − 1`); `maxPoints` — output *capacity* (capped at 20 internally), clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558).
 - **Returns:** Array of 3D points along the edge curve.
 - **OCCT:** `BRep_Tool::Curve` + `GCPnts_UniformParameter` (via `OCCTShapeGetEdgePoints`).
 
@@ -708,7 +708,7 @@ public func contourPoints(maxPoints: Int = 1000) -> [SIMD3<Double>]
 
 Returns edge **start** vertices only, not intermediate curve samples. For curved edges use `edgePoints(at:maxPoints:)` instead. Suitable for simple polygon contours from Z-plane slices.
 
-- **Parameters:** `maxPoints` — maximum number of points to return.
+- **Parameters:** `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns empty (#558).
 - **Returns:** Array of 3D points (one per edge start vertex).
 - **OCCT:** `TopExp_Explorer` over `TopAbs_EDGE` (via `OCCTShapeGetContourPoints`).
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1347,7 +1347,7 @@ Adaptively samples points along a B-Rep edge using curvature-based deflection co
 - **Parameters:**
   - `index` — edge index (0-based).
   - `deflection` — maximum chord deviation.
-  - `maxPoints` — maximum number of points to return.
+  - `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns `nil` (#558). The deflection decides the actual point count.
 - **Returns:** Array of 3D points along the edge, or `nil` if the edge is not found.
 - **OCCT:** `GCPnts_TangentialDeflection` / `BRep_Tool::Curve` (via `OCCTShapeGetEdgePolyline`).
 - **Example:**
@@ -1376,7 +1376,7 @@ Discretises every edge in a single bridge pass, building the shape's edge map on
 
 - **Parameters:**
   - `deflection` — maximum chord deviation per edge.
-  - `maxPointsPerEdge` — maximum points per edge (values below 2 return `[]`).
+  - `maxPointsPerEdge` — per-edge capacity, honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is `[]` (#558).
 - **Returns:** Array of polylines, one per edge. Edges that fail discretisation (including degenerate ones) are skipped — the result is **dense**, so a polyline's position does not reliably equal its edge index; use [`allEdgePolylinesIndexed`](#alledgepolylinesindexeddeflectionmaxpointsperedge) when that mapping matters.
 - **OCCT:** `BRepLib::BuildCurves3d` + `GCPnts_TangentialDeflection` (via `OCCTBRepLibBuildCurves3dForShape` and `OCCTShapeComputeAllEdgePolylines`).
 - **Performance:** Prefer this over a `for i in 0..<shape.edgeCount { shape.edgePolyline(at: i) }` loop. `edgePolyline(at:)` rebuilds the edge map on every call, so that loop is O(edges²) — 15 s for a 12k-edge shape, versus 0.02 s here ([#275](https://github.com/SecondMouseAU/OCCTSwift/issues/275)).

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -890,8 +890,8 @@ public func drawGrid(uLineCount: Int = 10, vLineCount: Int = 10,
 
 Samples `uLineCount` U-iso lines and `vLineCount` V-iso lines, each discretised to `pointsPerLine` 3D points. Infinite surfaces are clamped to ±100 before sampling.
 
-- **Parameters:** `uLineCount` — number of U iso-lines; `vLineCount` — number of V iso-lines; `pointsPerLine` — points per iso-line.
-- **Returns:** Array of polylines (one per iso-line), empty if the surface is null.
+- **Parameters:** `uLineCount` — number of U iso-lines, at least 0; `vLineCount` — number of V iso-lines, at least 0; `pointsPerLine` — points per iso-line, at least 1.
+- **Returns:** Array of polylines (one per iso-line), empty if the surface is null or the grid cannot be served. The bound is on the total: `(uLineCount + vLineCount) * pointsPerLine` must not exceed `Sampling.maximumSampleCount` (10,000,000), and each factor is checked on its own, since a negative line count used to abort the process unless the other count happened to outweigh it (#558).
 - **OCCT:** `Geom_Surface::Bounds` + `Geom_Surface::D0` via `OCCTSurfaceDrawGrid`.
 - **Example:**
   ```swift
@@ -969,8 +969,8 @@ Samples a uniform mesh grid of points for Metal visualisation.
 public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid
 ```
 
-- **Parameters:** `uCount` — number of U sample points; `vCount` — number of V sample points.
-- **Returns:** A `SurfaceGrid` indexed `.at(u:v:)`, or an empty grid if sampling fails.
+- **Parameters:** `uCount` — number of U sample points, at least 1; `vCount` — number of V sample points, at least 1.
+- **Returns:** A `SurfaceGrid` indexed `.at(u:v:)`, or an empty grid if sampling fails or the grid cannot be served. The bound is on the **product**: `uCount * vCount` must not exceed `Sampling.maximumSampleCount` (10,000,000). Each factor is also checked on its own, which is not redundant — two negative counts multiply to a plausible positive total, so `drawMesh(uCount: -1, vCount: -1)` used to look well-behaved while `drawMesh(uCount: -1, vCount: 3)` aborted the process (#558).
 - **OCCT:** `Geom_Surface::D0` sampled on a uniform UV grid.
 - **Example:**
   ```swift

--- a/docs/reference/Wire.md
+++ b/docs/reference/Wire.md
@@ -965,7 +965,7 @@ public func orderedEdgePoints(at index: Int, maxPoints: Int? = nil) -> [SIMD3<Do
 
 When `maxPoints` is `nil`, allocates a buffer sized to all discretised points (no truncation). When provided, limits the returned array to `maxPoints` elements.
 
-- **Parameters:** `index` — 0-based edge index; `maxPoints` — optional upper limit on returned points.
+- **Parameters:** `index` — 0-based edge index; `maxPoints` — optional output capacity, honoured within `1...Sampling.maximumSampleCount` (10,000,000); outside that range the result is `nil` (#558).
 - **Returns:** Array of 3D points along the edge, or `nil` if the index is out of range or the edge is degenerate.
 - **OCCT:** `BRepTools_WireExplorer` + `BRepAdaptor_Curve` + `GCPnts_TangentialDeflection`.
 - **Example:**
@@ -1016,7 +1016,7 @@ public func allEdgePolylines(
 
 Convenience wrapper: converts to `Shape`, then calls `shape.allEdgePolylines(deflection:maxPointsPerEdge:)`.
 
-- **Parameters:** `deflection` — maximum chord deviation; `maxPointsPerEdge` — maximum points per edge.
+- **Parameters:** `deflection` — maximum chord deviation; `maxPointsPerEdge` — per-edge capacity, honoured within `2...Sampling.maximumSampleCount` (10,000,000); outside that range the result is `[]` (#558).
 - **Returns:** Array of polylines (one per edge), or `[]` on failure.
 - **OCCT:** Delegates to `Shape.allEdgePolylines`.
 - **Example:**
@@ -1040,7 +1040,7 @@ public func edgePolyline(
 
 Convenience wrapper: converts to `Shape`, then calls `shape.edgePolyline(at:deflection:maxPoints:)`.
 
-- **Parameters:** `index` — 0-based edge index; `deflection` — chord deviation; `maxPoints` — point limit.
+- **Parameters:** `index` — 0-based edge index; `deflection` — chord deviation; `maxPoints` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000), so an unservable capacity returns the same points rather than a coarser sampling; 0 or less returns `nil` (#558).
 - **Returns:** Polyline for the edge, or `nil` if index is out of range.
 - **OCCT:** Delegates to `Shape.edgePolyline`.
 - **Example:**


### PR DESCRIPTION
Split out of #479, which bounded `EdgeCurve`/`WireCurve` and recorded that "the same shape is live at fourteen other sampling entry points".

## The census was half of it

A caller supplies a count, it sizes a Swift allocation, and it is then cast to the `int32_t` the bridge takes its count in. `[Double](repeating:count:)` traps on a negative and `Int32(_:)` traps past `Int32.max` — both abort the process rather than returning the documented empty value.

Measured one case per process before touching anything (a trap takes the whole harness down). **The family is 28, not 14.** Every one either trapped or ground on an unservable allocation past 30 s at `Int(Int32.max) + 1`; 20 of them trapped on `-1`.

The fourteen the issue missed: `Edge.quasiUniformParameters(count:)` — the same method, on the same `GCPnts_QuasiUniformAbscissa`, as the `Curve3D` one it *did* name — plus `Curve3D.samplePoints`, `Surface.drawGrid`, `Shape`'s `edgePolyline` / `allEdgePolylines` / `edgePoints` / `contourPoints` / `uIsoCurvePoints` / `vIsoCurvePoints` / `coonsAlgPatch`, `Wire.orderedEdgePoints`, both `MedialAxis` drawers, and `QuadricIntersection.coneSpherePoints`.

## A decision per parameter, and a shared ceiling

The ceiling moves out of `ArcLengthCurveAdaptor` into **`Sampling.maximumSampleCount`** — still the 10,000,000 #479 measured. `EdgeCurve`/`WireCurve.maximumSampleCount` keep working and forward to it, so nothing #479 shipped breaks.

| kind | parameter | decision | why |
|---|---|---|---|
| **request** | `count`, `pointCount`, `sampleCount` | rejected outside `2...ceiling` | the caller asked for exactly this many; returning fewer is the silent-coarsening defect #501 found |
| **capacity** | `maxPoints` on an adaptive sampler | clamped into `0...ceiling` | the deflection criterion decides the count and the capacity only truncates, so clamping returns the **same** points |
| **grid** | `uCount`×`vCount`, `evalU`×`evalV`, `(uLineCount + vLineCount)`×`pointsPerLine` | the **product** bounded, and each factor on its own | see below |

Measured after the fix: an absurd *capacity* now returns the real answer (2 points for a straight segment, 20 for `edgePoints`, 24 for `contourPoints`) rather than trapping; an absurd *request* returns empty.

## Two things the measurement changed about the fix as specified

- **The issue's `drawMesh` row is wrong.** It records `.empty` for a negative count, which holds only when the negative goes to *both* factors — `(-1) * (-1)` is a plausible positive total. `drawMesh(uCount: -1, vCount: 3)` aborted the process. So each factor is checked individually, not just the product. Confirmed by injection: with the per-factor check removed the new suite aborts with `Fatal error: Can't construct Array with count < 0` at exactly that case. Same masking in `drawGrid` and `MedialAxis.drawAll`.
- **`MedialAxis.drawArc`'s `maxPoints` is a request, not a capacity.** The bridge does `numPoints = maxPoints` and fills the buffer exactly. It was written as a capacity first; the verification sweep caught it returning a full 10,000,000 points for a clamped absurd input — precisely the coarsening the clamp was supposed to be immune to. It rejects instead. The parameter's *name* does not settle which contract it has.

## Tests

21 tests in `Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift`. They run in-process only because the fix is what lets them: before it, every assertion would have aborted the harness rather than failing.

Both halves injected to prove they catch it — clamping a request, and dropping the per-factor grid check (which crashed the run outright).

They compare `.count == 0` rather than reading `.isEmpty`, because Swift Testing prints the captured sub-expression on failure and a regression returning 10 million points prints all 10 million — measured at over 5 GB during the injection. #479 hit the same hazard at 880 MB.

## Docs

- `docs/CHANGELOG.md`: new entry; the #479 entry is corrected where it says fourteen and where its table calls a negative `drawMesh` count safe.
- Every affected reference page states the bound and which contract applies (`Curve2D`, `Curve3D`, `Curve3D-Analysis`, `Edge`, `Surface`, `Shape`, `Shape-Features`, `Shape-Builders-2`, `Wire`, `BRepGraph-Editor-Identity`, `FeatureRecognition`).
- `Sampling` documented on `CurveAdaptors.md`, where the ceiling's rationale already lived.

## Verification

- `swift build` clean (the one `unhandled file` warning is pre-existing on the base branch — verified by stashing).
- `swift test`: **4931 tests, 1354 suites, all pass.**
- `Scripts/count-operations.py`: 4299 ✓ unchanged — a `public let` is data, not an entry point, per the script's own rule.

Closes #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)