### PR TITLE
refactor(#536): one defeaturing operation, not one per OCCT layer

### DIFF
--- a/Scripts/repro/536-defeature-removefeatures-unify/README.md
+++ b/Scripts/repro/536-defeature-removefeatures-unify/README.md
@@ -1,0 +1,141 @@
+# OCCTSwift#536 probe — are `BRepAlgoAPI_Defeaturing` and `BOPAlgo_RemoveFeatures` one operation?
+
+Ground truth for collapsing the bridge's two shape-addressed "remove these faces" wrappers onto one,
+against the pinned OCCT 8.0.0p1 kernel.
+
+`Shape.defeature(faces:)` reached `OCCTShapeDefeature` → `BRepAlgoAPI_Defeaturing`, and
+`Shape.removeFeatures(faces:)` reached `OCCTBOPAlgoRemoveFeatures` → `BOPAlgo_RemoveFeatures`. Same
+argument types, same return type, different names, no cross-reference between them. Reading
+`BRepAlgoAPI_Defeaturing.cxx` says they should be the same operation — its `Build()` is a forwarder
+to a `BOPAlgo_RemoveFeatures` member — but the question a deprecation has to answer is not "do they
+agree on a box", it is "is there **any** input on which they can differ".
+
+They cannot. Every case agrees, BREP byte for byte, including the ones where the algorithm refuses.
+
+No fixture files needed: every case builds its geometry from a primitive.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/536-defeature-removefeatures-unify/occt_536_defeature_vs_removefeatures.mm \
+  -o /tmp/occt_536
+/tmp/occt_536
+```
+
+Exit status is 1 if any case diverges.
+
+## What it does
+
+Each path is driven exactly the way its bridge wrapper drove it, down to the completion test — the
+`BRepAlgoAPI` wrapper checked `IsDone()`, the `BOPAlgo` one checked `HasErrors()` — and the results
+are compared as full BREP serialisations rather than as volumes, so a difference in
+parameterisation that leaves the volume alone still counts.
+
+Three places a difference could hide are measured, not assumed:
+
+1. **The option defaults each path inherits.** `Build()` forwards a history flag and a parallel flag;
+   if the two classes defaulted them differently, every unconfigured call would already be two
+   different operations.
+2. **Ordinary removals**, across features of different kinds: a fillet (every face of the fixture in
+   turn, so the refusals are covered too), a through hole, a boss, and two holes removed at once.
+3. **The requests that are not ordinary**, where two independently maintained wrappers are likeliest
+   to have drifted: no faces at all, a face belonging to a different shape, a mixed request, an
+   input that is not a solid, the same face requested twice.
+
+## Result
+
+```
+option defaults (nothing set on either):
+  history filling : defeaturing=1 removeFeatures=1  same
+  parallel mode   : defeaturing=0 removeFeatures=0  same
+
+ordinary removals:
+  20mm box, remove fillet face               defeature[done=1 shape=1 vol=8000.000000000 faces= 6]  removeFeatures[ok=1 shape=1 vol=8000.000000000 faces= 6]  IDENTICAL BREP
+  20mm box, remove face 1 of 7               defeature[done=1 shape=1 vol=7982.831853072 faces= 7]  removeFeatures[ok=1 shape=1 vol=7982.831853072 faces= 7]  IDENTICAL BREP
+  20mm box, remove face 2 of 7               defeature[done=1 shape=1 vol=7982.831853072 faces= 7]  removeFeatures[ok=1 shape=1 vol=7982.831853072 faces= 7]  IDENTICAL BREP
+  20mm box, remove face 3 of 7               defeature[done=1 shape=1 vol=8000.000000000 faces= 6]  removeFeatures[ok=1 shape=1 vol=8000.000000000 faces= 6]  IDENTICAL BREP
+  20mm box, remove face 4 of 7               defeature[done=1 shape=1 vol=7982.831853072 faces= 7]  removeFeatures[ok=1 shape=1 vol=7982.831853072 faces= 7]  IDENTICAL BREP
+  20mm box, remove face 5 of 7               defeature[done=1 shape=1 vol=7982.831853072 faces= 7]  removeFeatures[ok=1 shape=1 vol=7982.831853072 faces= 7]  IDENTICAL BREP
+  20mm box, remove face 6 of 7               defeature[done=1 shape=1 vol=7982.831853072 faces= 7]  removeFeatures[ok=1 shape=1 vol=7982.831853072 faces= 7]  IDENTICAL BREP
+  20mm box, remove face 7 of 7               defeature[done=1 shape=1 vol=7982.831853072 faces= 7]  removeFeatures[ok=1 shape=1 vol=7982.831853072 faces= 7]  IDENTICAL BREP
+  box with through hole, remove hole         defeature[done=1 shape=1 vol=8000.000000000 faces= 6]  removeFeatures[ok=1 shape=1 vol=8000.000000000 faces= 6]  IDENTICAL BREP
+  box with boss, remove boss faces           defeature[done=1 shape=1 vol=8301.592894745 faces= 8]  removeFeatures[ok=1 shape=1 vol=8301.592894745 faces= 8]  IDENTICAL BREP
+  two holes, both removed at once            defeature[done=1 shape=1 vol=27000.000000000 faces= 6]  removeFeatures[ok=1 shape=1 vol=27000.000000000 faces= 6]  IDENTICAL BREP
+
+non-ordinary requests:
+  no faces requested                         defeature[done=0 ...]  removeFeatures[ok=0 ...]  IDENTICAL BREP
+  face from a different shape                defeature[done=0 ...]  removeFeatures[ok=0 ...]  IDENTICAL BREP
+  one real face plus one foreign             defeature[done=1 shape=1 vol=8000.000000000 faces= 6]  removeFeatures[ok=1 shape=1 vol=8000.000000000 faces= 6]  IDENTICAL BREP
+  input is a face, not a solid               defeature[done=0 ...]  removeFeatures[ok=0 ...]  IDENTICAL BREP
+  the same face requested twice              defeature[done=1 shape=1 vol=8000.000000000 faces= 6]  removeFeatures[ok=1 shape=1 vol=8000.000000000 faces= 6]  IDENTICAL BREP
+
+VERDICT: every case agrees, BREP byte for byte -- one operation under two names
+```
+
+Note that the two completion tests never disagree either: `Build()` calls `Done()` only after
+checking `HasErrors()` on the merged report, so `IsDone()` and `!HasErrors()` answer the same
+question one layer apart, exactly as the algorithms do.
+
+## Why
+
+`BRepAlgoAPI_Defeaturing::Build`
+(`src/ModelingAlgorithms/TKBO/BRepAlgoAPI/BRepAlgoAPI_Defeaturing.cxx`, 30 lines) is the whole of the
+outer class's contribution:
+
+```cpp
+myFeatureRemovalTool.SetShape(myInputShape);
+myFeatureRemovalTool.AddFacesToRemove(myFacesToRemove);
+myFeatureRemovalTool.SetToFillHistory(myFillHistory);
+myFeatureRemovalTool.SetRunParallel(myRunParallel);
+myFeatureRemovalTool.Perform(theRange);
+GetReport()->Merge(myFeatureRemovalTool.GetReport());
+if (HasErrors()) return;
+Done();
+myShape = myFeatureRemovalTool.Shape();
+```
+
+`myFeatureRemovalTool` is a `BOPAlgo_RemoveFeatures` member; `Modified`, `Generated`, `IsDeleted`,
+`HasModified`, `HasGenerated`, `HasDeleted` and `History` are all one-line delegations to it. Both
+forwarded flags default the same way on both classes (`myFillHistory(true)` in each constructor,
+`myRunParallel(false)` inherited from `BOPAlgo_Options`), which is what the first section of the
+probe checks — so an unconfigured `BRepAlgoAPI_Defeaturing` and an unconfigured
+`BOPAlgo_RemoveFeatures` are the same object with the same settings.
+
+There is no defect here and nothing to file: the outer class is doing what an API-level wrapper is
+for. The duplication was ours — the bridge wrapped both layers of one algorithm and gave each its
+own Swift name.
+
+## What else this measured
+
+Two things about the surviving entry point's contract, neither of them a difference between the two
+paths (both behave identically on all of it), and neither previously written down.
+
+**A face that is not part of the input is dropped, not refused.** The header says so
+("those that do not belong will be ignored") and the probe confirms it: a request mixing one real
+face with one foreign face succeeds, removes the real one, and emits **no warning of any kind**. A
+request of nothing but foreign faces fails, because nothing is left to remove. So the shape-addressed
+form is more forgiving than the index-addressed `withoutFeatures(faces:)`, which since #497 fails the
+whole call on one bad index. Membership is by identity: a face measured off a separately built but
+identical fixture is foreign (`done=0`).
+
+**What a "face to remove" is allowed to be.** `AddFaceToRemove` takes a `TopoDS_Shape` and its own
+documentation calls it "the shape to extract the faces for removal", so the argument need not be a
+face:
+
+```
+  the fillet face, as found                done=1 volume=8000.000000000 faces=6
+  the same face, orientation reversed      done=1 volume=8000.000000000 faces=6
+  a compound containing the fillet face    done=1 volume=8000.000000000 faces=6
+  the entire input solid                   done=1 volume=7982.831853072 faces=7   (a no-op success)
+  an edge (contains no face)               done=0 volume=0.000000000 faces=0
+```
+
+This is why #536 did not go on to give the shape-addressed form the index-addressed form's stricter
+membership rule. Enforcing "every requested face must belong to this shape" means first deciding
+what to do with the compounds, shells and whole solids the kernel accepts as face carriers, which is
+its own design question with its own measurement matrix, not a line of validation. Recorded here and
+in `defeature(faces:)`'s own documentation, and filed separately.

--- a/Scripts/repro/536-defeature-removefeatures-unify/occt_536_defeature_vs_removefeatures.mm
+++ b/Scripts/repro/536-defeature-removefeatures-unify/occt_536_defeature_vs_removefeatures.mm
@@ -1,0 +1,394 @@
+// #536 ground truth: are BRepAlgoAPI_Defeaturing and BOPAlgo_RemoveFeatures one operation?
+//
+// The bridge wraps both: OCCTShapeDefeature drives BRepAlgoAPI_Defeaturing, OCCTBOPAlgoRemoveFeatures
+// drives BOPAlgo_RemoveFeatures, and Swift spells them defeature(faces:) and removeFeatures(faces:).
+// BRepAlgoAPI_Defeaturing::Build is a forwarder -- it hands its input shape, its faces, its history
+// flag and its parallel flag to a BOPAlgo_RemoveFeatures member and takes that member's result. So
+// the question is not "do they agree on a box", it is "is there ANY input on which they can differ".
+//
+// This probe drives each one exactly the way its bridge wrapper does, over a matrix of fixtures and
+// face selections, and compares the full BREP serialisation rather than scalars -- volume and face
+// count would not notice a differently-parameterised surface.
+//
+// It also measures the three places a difference could hide:
+//   1. the option defaults each path inherits (history filling, parallel mode),
+//   2. the completion test each bridge wrapper uses (IsDone() vs !HasErrors()),
+//   3. the requests that are not ordinary: no faces, a face from another shape, an unremovable face.
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepAlgoAPI_Defeaturing.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
+#include <BOPAlgo_RemoveFeatures.hxx>
+#include <BRepTools.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopTools_ListOfShape.hxx>
+#include <TopoDS.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_Surface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <gp_Ax2.hxx>
+#include <TopoDS_Compound.hxx>
+#include <BRep_Builder.hxx>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <cstdio>
+
+static double volumeOf(const TopoDS_Shape& s) {
+    if (s.IsNull()) return 0.0;
+    GProp_GProps props;
+    BRepGProp::VolumeProperties(s, props);
+    return props.Mass();
+}
+
+static int faceCount(const TopoDS_Shape& s) {
+    if (s.IsNull()) return 0;
+    TopTools_IndexedMapOfShape m;
+    TopExp::MapShapes(s, TopAbs_FACE, m);
+    return m.Extent();
+}
+
+// The full BREP text: any difference in geometry, parameterisation or topology order shows here.
+static std::string brepOf(const TopoDS_Shape& s) {
+    if (s.IsNull()) return "<null>";
+    std::ostringstream os;
+    BRepTools::Write(s, os);
+    return os.str();
+}
+
+// --- The two bridge wrappers, transcribed ---
+//
+// OCCTShapeDefeature (OCCTBridge_Modeling.mm), via occtDefeaturePerform: SetShape, AddFacesToRemove,
+// Build, IsDone, then a null check on the result.
+struct Outcome {
+    bool         accepted = false;   // what the wrapper's own check answered
+    TopoDS_Shape shape;
+    std::string  brep = "<not run>";
+    bool         returnsShape = false;  // what the Swift caller would see: non-nil
+};
+
+static Outcome runDefeaturing(const TopoDS_Shape& shape, const TopTools_ListOfShape& faces) {
+    Outcome o;
+    BRepAlgoAPI_Defeaturing df;
+    df.SetShape(shape);
+    df.AddFacesToRemove(faces);
+    df.Build();
+    o.accepted = df.IsDone();
+    if (!o.accepted) return o;
+    o.shape = df.Shape();
+    o.returnsShape = !o.shape.IsNull();
+    o.brep = brepOf(o.shape);
+    return o;
+}
+
+// OCCTBOPAlgoRemoveFeatures (OCCTBridge_Modeling.mm): SetShape, AddFaceToRemove per face, Perform,
+// !HasErrors, then a null check on the result.
+static Outcome runRemoveFeatures(const TopoDS_Shape& shape, const TopTools_ListOfShape& faces) {
+    Outcome o;
+    BOPAlgo_RemoveFeatures rf;
+    rf.SetShape(shape);
+    for (TopTools_ListOfShape::Iterator it(faces); it.More(); it.Next())
+        rf.AddFaceToRemove(it.Value());
+    rf.Perform();
+    o.accepted = !rf.HasErrors();
+    if (!o.accepted) return o;
+    o.shape = rf.Shape();
+    o.returnsShape = !o.shape.IsNull();
+    o.brep = brepOf(o.shape);
+    return o;
+}
+
+static int failures = 0;
+
+static void compare(const char* label, const TopoDS_Shape& shape, const TopTools_ListOfShape& faces) {
+    Outcome d = runDefeaturing(shape, faces);
+    Outcome r = runRemoveFeatures(shape, faces);
+
+    const bool sameAccept = (d.accepted == r.accepted);
+    const bool sameReturn = (d.returnsShape == r.returnsShape);
+    const bool sameBrep   = (d.brep == r.brep);
+    const bool agree      = sameAccept && sameReturn && sameBrep;
+    if (!agree) failures++;
+
+    printf("  %-42s defeature[done=%d shape=%d vol=%.9f faces=%2d]  "
+           "removeFeatures[ok=%d shape=%d vol=%.9f faces=%2d]  %s\n",
+           label,
+           d.accepted, d.returnsShape, volumeOf(d.shape), faceCount(d.shape),
+           r.accepted, r.returnsShape, volumeOf(r.shape), faceCount(r.shape),
+           agree ? "IDENTICAL BREP" : (sameAccept && sameReturn ? "*** BREP DIFFERS ***"
+                                                                : "*** OUTCOME DIFFERS ***"));
+}
+
+static TopoDS_Shape filletedBox(double size, double radius) {
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(size, size, size).Shape();
+    BRepFilletAPI_MakeFillet fillet(box);
+    TopExp_Explorer ex(box, TopAbs_EDGE);
+    fillet.Add(radius, TopoDS::Edge(ex.Current()));
+    fillet.Build();
+    if (!fillet.IsDone()) return TopoDS_Shape();
+    return fillet.Shape();
+}
+
+static TopoDS_Face firstCylindricalFace(const TopoDS_Shape& s) {
+    for (TopExp_Explorer fe(s, TopAbs_FACE); fe.More(); fe.Next()) {
+        TopoDS_Face f = TopoDS::Face(fe.Current());
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(f);
+        if (!surf.IsNull() && surf->IsKind(STANDARD_TYPE(Geom_CylindricalSurface))) return f;
+    }
+    return TopoDS_Face();
+}
+
+static TopTools_ListOfShape oneFace(const TopoDS_Shape& f) {
+    TopTools_ListOfShape l;
+    l.Append(f);
+    return l;
+}
+
+int main() {
+    printf("=== #536: BRepAlgoAPI_Defeaturing vs BOPAlgo_RemoveFeatures ===\n\n");
+
+    // ------------------------------------------------------------------
+    // 1. The options each path inherits, before any geometry is involved.
+    //    BRepAlgoAPI_Defeaturing::Build forwards exactly these two to its BOPAlgo member; if the
+    //    defaults differed, every unconfigured call would already be two different operations.
+    // ------------------------------------------------------------------
+    {
+        BRepAlgoAPI_Defeaturing df;
+        BOPAlgo_RemoveFeatures rf;
+        printf("option defaults (nothing set on either):\n");
+        printf("  history filling : defeaturing=%d removeFeatures=%d  %s\n",
+               df.HasHistory(), rf.HasHistory(),
+               df.HasHistory() == rf.HasHistory() ? "same" : "*** DIFFER ***");
+        printf("  parallel mode   : defeaturing=%d removeFeatures=%d  %s\n",
+               df.RunParallel(), rf.RunParallel(),
+               df.RunParallel() == rf.RunParallel() ? "same" : "*** DIFFER ***");
+        if (df.HasHistory() != rf.HasHistory() || df.RunParallel() != rf.RunParallel()) failures++;
+        printf("\n");
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Ordinary removals, over fixtures whose features differ in kind.
+    // ------------------------------------------------------------------
+    printf("ordinary removals:\n");
+
+    // 2a. The issue's fixture: a 20mm box, one 2mm fillet, remove the fillet face.
+    TopoDS_Shape f20 = filletedBox(20.0, 2.0);
+    if (f20.IsNull()) { printf("FAIL: fixture (filleted 20mm box)\n"); return 1; }
+    TopoDS_Face fillet20 = firstCylindricalFace(f20);
+    if (fillet20.IsNull()) { printf("FAIL: fixture (no fillet face)\n"); return 1; }
+    compare("20mm box, remove fillet face", f20, oneFace(fillet20));
+
+    // 2b. Every face of the filleted box in turn -- including the five planar ones the algorithm
+    //     will refuse, so the refusal path is measured on both as well.
+    {
+        TopTools_IndexedMapOfShape faces;
+        TopExp::MapShapes(f20, TopAbs_FACE, faces);
+        for (int i = 1; i <= faces.Extent(); i++) {
+            char label[64];
+            snprintf(label, sizeof(label), "20mm box, remove face %d of %d", i, faces.Extent());
+            compare(label, f20, oneFace(faces(i)));
+        }
+    }
+
+    // 2c. A through hole: remove the cylindrical face, the textbook defeaturing case.
+    {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(20.0, 20.0, 20.0).Shape();
+        TopoDS_Shape drill = BRepPrimAPI_MakeCylinder(gp_Ax2(gp_Pnt(10, 10, -1), gp_Dir(0, 0, 1)),
+                                                      3.0, 22.0).Shape();
+        BRepAlgoAPI_Cut cut(box, drill);
+        cut.Build();
+        if (cut.IsDone()) {
+            TopoDS_Shape holed = cut.Shape();
+            TopoDS_Face hole = firstCylindricalFace(holed);
+            if (!hole.IsNull()) compare("box with through hole, remove hole", holed, oneFace(hole));
+        }
+    }
+
+    // 2d. A boss: remove all the faces the fuse added, as one multi-face request.
+    {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(20.0, 20.0, 20.0).Shape();
+        TopoDS_Shape boss = BRepPrimAPI_MakeCylinder(gp_Ax2(gp_Pnt(10, 10, 20), gp_Dir(0, 0, 1)),
+                                                     4.0, 6.0).Shape();
+        BRepAlgoAPI_Fuse fuse(box, boss);
+        fuse.Build();
+        if (fuse.IsDone()) {
+            TopoDS_Shape bossed = fuse.Shape();
+            TopTools_ListOfShape bossFaces;
+            for (TopExp_Explorer fe(bossed, TopAbs_FACE); fe.More(); fe.Next()) {
+                TopoDS_Face f = TopoDS::Face(fe.Current());
+                Handle(Geom_Surface) surf = BRep_Tool::Surface(f);
+                if (!surf.IsNull() && surf->IsKind(STANDARD_TYPE(Geom_CylindricalSurface)))
+                    bossFaces.Append(f);
+            }
+            if (!bossFaces.IsEmpty())
+                compare("box with boss, remove boss faces", bossed, bossFaces);
+        }
+    }
+
+    // 2e. Two features in one request, on one shape.
+    {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(30.0, 30.0, 30.0).Shape();
+        TopoDS_Shape d1 = BRepPrimAPI_MakeCylinder(gp_Ax2(gp_Pnt(8, 8, -1), gp_Dir(0, 0, 1)),
+                                                   3.0, 32.0).Shape();
+        TopoDS_Shape d2 = BRepPrimAPI_MakeCylinder(gp_Ax2(gp_Pnt(22, 22, -1), gp_Dir(0, 0, 1)),
+                                                   3.0, 32.0).Shape();
+        BRepAlgoAPI_Cut c1(box, d1);
+        c1.Build();
+        if (c1.IsDone()) {
+            BRepAlgoAPI_Cut c2(c1.Shape(), d2);
+            c2.Build();
+            if (c2.IsDone()) {
+                TopoDS_Shape twoHoles = c2.Shape();
+                TopTools_ListOfShape holes;
+                for (TopExp_Explorer fe(twoHoles, TopAbs_FACE); fe.More(); fe.Next()) {
+                    TopoDS_Face f = TopoDS::Face(fe.Current());
+                    Handle(Geom_Surface) surf = BRep_Tool::Surface(f);
+                    if (!surf.IsNull() && surf->IsKind(STANDARD_TYPE(Geom_CylindricalSurface)))
+                        holes.Append(f);
+                }
+                if (holes.Extent() >= 2) compare("two holes, both removed at once", twoHoles, holes);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 3. The requests that are not ordinary. These are where two independently maintained
+    //    wrappers are most likely to have drifted, so they matter more than the happy path.
+    // ------------------------------------------------------------------
+    printf("\nnon-ordinary requests:\n");
+
+    // 3a. No faces at all. The bridge rejects this before reaching either algorithm, but what the
+    //     algorithms themselves do decides whether that rejection is a bridge policy or a kernel one.
+    {
+        TopTools_ListOfShape none;
+        compare("no faces requested", f20, none);
+    }
+
+    // 3b. A face that belongs to a different shape. BRepAlgoAPI_Defeaturing.hxx says faces that do
+    //     not belong "will be ignored" -- measured here, on both paths, because a request that
+    //     removes nothing and reports success is a contract worth stating out loud.
+    {
+        TopoDS_Shape other = filletedBox(11.0, 1.5);
+        TopoDS_Face foreign = firstCylindricalFace(other);
+        if (!foreign.IsNull()) compare("face from a different shape", f20, oneFace(foreign));
+    }
+
+    // 3c. A face that belongs, mixed with one that does not.
+    {
+        TopoDS_Shape other = filletedBox(11.0, 1.5);
+        TopoDS_Face foreign = firstCylindricalFace(other);
+        if (!foreign.IsNull()) {
+            TopTools_ListOfShape mixed;
+            mixed.Append(fillet20);
+            mixed.Append(foreign);
+            compare("one real face plus one foreign", f20, mixed);
+        }
+    }
+
+    // 3d. A shape type the algorithm does not accept: only SOLID/COMPSOLID/COMPOUND-of-solids are
+    //     supported, so a bare face must be refused -- by both, the same way.
+    {
+        TopoDS_Shape justAFace = fillet20;
+        compare("input is a face, not a solid", justAFace, oneFace(fillet20));
+    }
+
+    // 3e. The same face twice in one request.
+    {
+        TopTools_ListOfShape twice;
+        twice.Append(fillet20);
+        twice.Append(fillet20);
+        compare("the same face requested twice", f20, twice);
+    }
+
+    // ------------------------------------------------------------------
+    // 4. What the shape-addressed form does with a face that is not part of the input, when the
+    //    request also contains one that is. Both paths agree (section 3c), so this is not a
+    //    divergence between them -- it is the surviving entry point's own contract, and #497 made
+    //    the index-addressed sibling fail exactly this request.
+    // ------------------------------------------------------------------
+    printf("\nthe foreign face in a mixed request:\n");
+    {
+        TopoDS_Shape other = filletedBox(11.0, 1.5);
+        TopoDS_Face foreign = firstCylindricalFace(other);
+        TopTools_ListOfShape mixed;
+        mixed.Append(fillet20);
+        mixed.Append(foreign);
+
+        BRepAlgoAPI_Defeaturing df;
+        df.SetShape(f20);
+        df.AddFacesToRemove(mixed);
+        df.Build();
+        printf("  done=%d  warnings=%d  volume=%.9f (8000 = the fillet went, nothing else did)\n",
+               df.IsDone(), df.HasWarnings(), volumeOf(df.Shape()));
+        if (df.HasWarnings()) {
+            Standard_SStream ss;
+            df.DumpWarnings(ss);
+            printf("  warning text: %s", ss.str().c_str());
+        } else {
+            printf("  no warning of any kind: the unusable face is dropped in silence\n");
+        }
+    }
+
+    // A face that is geometrically identical but a distinct TShape -- what a membership check
+    // would have to treat as foreign, so worth knowing whether the kernel accepts it today.
+    {
+        TopoDS_Shape twin = filletedBox(20.0, 2.0);
+        TopoDS_Face twinFillet = firstCylindricalFace(twin);
+        BRepAlgoAPI_Defeaturing df;
+        df.SetShape(f20);
+        df.AddFaceToRemove(twinFillet);
+        df.Build();
+        printf("  same geometry, different TShape (a twin fixture's fillet face): done=%d volume=%.9f\n",
+               df.IsDone(), volumeOf(df.Shape()));
+    }
+
+    // What "a face to remove" is allowed to be. AddFaceToRemove takes a TopoDS_Shape and its own
+    // doc calls it "the shape to extract the faces for removal", so the argument is not necessarily
+    // a face -- any membership precondition has to know what it would be rejecting.
+    printf("\nwhat the request is allowed to contain:\n");
+    {
+        struct Case { const char* label; TopoDS_Shape requested; };
+        std::vector<Case> cases;
+
+        cases.push_back({"the fillet face, as found", fillet20});
+        cases.push_back({"the same face, orientation reversed", fillet20.Reversed()});
+
+        // A compound wrapping the fillet face: a caller holding a selection, not a single face.
+        {
+            TopoDS_Compound comp;
+            BRep_Builder b;
+            b.MakeCompound(comp);
+            b.Add(comp, fillet20);
+            cases.push_back({"a compound containing the fillet face", comp});
+        }
+        // The whole input solid: every face at once.
+        cases.push_back({"the entire input solid", f20});
+        // An edge of the fillet face: a shape with no faces in it at all.
+        {
+            TopExp_Explorer ee(fillet20, TopAbs_EDGE);
+            if (ee.More()) cases.push_back({"an edge (contains no face)", ee.Current()});
+        }
+
+        for (const Case& c : cases) {
+            BRepAlgoAPI_Defeaturing df;
+            df.SetShape(f20);
+            df.AddFaceToRemove(c.requested);
+            df.Build();
+            printf("  %-40s done=%d volume=%.9f faces=%d\n",
+                   c.label, df.IsDone(), volumeOf(df.Shape()), faceCount(df.Shape()));
+        }
+    }
+
+    printf("\nVERDICT: %s\n",
+           failures == 0
+             ? "every case agrees, BREP byte for byte -- one operation under two names"
+             : "*** the two paths diverge somewhere: see the marked rows ***");
+    return failures == 0 ? 0 : 1;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -82,7 +82,10 @@
 // BOPAlgo_MakeConnected               → OCCTShapeMakeConnected
 // BOPAlgo_MakePeriodic                → OCCTShapeMakePeriodic, OCCTShapeRepeat
 // BOPAlgo_MakerVolume                 → OCCTShapeMakeVolume
-// BOPAlgo_RemoveFeatures              → OCCTBOPAlgoRemoveFeatures
+// BOPAlgo_RemoveFeatures              → OCCTShapeDefeature, OCCTShapeRemoveFeatures,
+//                                       OCCTShapeHistoryFromDefeature, OCCTShapeRemoveSmallFaces
+//                                       (reached through BRepAlgoAPI_Defeaturing, a forwarder to
+//                                       it; #536 deleted the direct wrap that duplicated them)
 // BOPAlgo_Section                     → OCCTBOPAlgoSection
 // BOPAlgo_ShellSplitter               → OCCTBOPAlgoShellSplitter
 // BOPAlgo_Splitter                    → OCCTBOPAlgoSplit
@@ -8706,14 +8709,9 @@ double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape, OCCTShapeRef faceS
 
 // MARK: - v0.65.0: Shape Processing Completions + Boolean Completions
 
-// --- BOPAlgo_RemoveFeatures ---
-/// Remove features (faces) from a solid shape.
-/// @param shape Input solid shape
-/// @param facesToRemove Array of face shapes to remove
-/// @param faceCount Number of faces to remove
-/// @return Result shape with features removed, or NULL on failure
-OCCTShapeRef _Nullable OCCTBOPAlgoRemoveFeatures(OCCTShapeRef shape,
-    const OCCTShapeRef _Nonnull * _Nonnull facesToRemove, int32_t faceCount);
+// OCCTBOPAlgoRemoveFeatures was declared here. It drove BOPAlgo_RemoveFeatures directly, which is
+// the algorithm BRepAlgoAPI_Defeaturing forwards to — so it was OCCTShapeDefeature one OCCT layer
+// down, with the same forwarded option defaults. #536
 
 // --- BOPAlgo_Section ---
 /// Compute section (intersection curves/vertices) between shapes.

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2553,7 +2553,6 @@ double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape, OCCTShapeRef faceS
 // v0.65.0: Shape Processing Completions + Boolean Completions
 // ============================================================
 
-#include <BOPAlgo_RemoveFeatures.hxx>
 #include <BOPAlgo_Section.hxx>
 #include <BOPAlgo_BuilderFace.hxx>
 #include <BOPAlgo_BuilderSolid.hxx>

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -76,7 +76,6 @@
 #include <BRepLib_MakeEdge.hxx>
 #include <BRepLib_MakeFace.hxx>
 #include <BRepLib_MakeShell.hxx>
-#include <BOPAlgo_RemoveFeatures.hxx>
 #include <BOPAlgo_Section.hxx>
 #include <BRepFeat_Builder.hxx>
 #include <Law_BSplineKnotSplitting.hxx>
@@ -5766,26 +5765,12 @@ OCCTShapeRef _Nullable OCCTBRepOffsetOffsetFace(OCCTShapeRef faceShape, double o
 }
 
 // MARK: - BOPAlgo RemoveFeatures (v0.64)
-// --- BOPAlgo_RemoveFeatures ---
-
-OCCTShapeRef _Nullable OCCTBOPAlgoRemoveFeatures(OCCTShapeRef shape,
-    const OCCTShapeRef _Nonnull * _Nonnull facesToRemove, int32_t faceCount) {
-    if (!shape || faceCount <= 0) return nullptr;
-    try {
-        BOPAlgo_RemoveFeatures remover;
-        remover.SetShape(shape->shape);
-        for (int32_t i = 0; i < faceCount; i++) {
-            if (facesToRemove[i]) {
-                remover.AddFaceToRemove(facesToRemove[i]->shape);
-            }
-        }
-        remover.Perform();
-        if (remover.HasErrors()) return nullptr;
-        TopoDS_Shape result = remover.Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
-}
+// OCCTBOPAlgoRemoveFeatures lived here. It was OCCTShapeDefeature one OCCT layer down:
+// BRepAlgoAPI_Defeaturing::Build forwards its shape, its faces, its history flag and its parallel
+// flag to a BOPAlgo_RemoveFeatures member and returns that member's result, and both paths took the
+// same defaults for the two forwarded flags. Measured identical, BREP byte for byte, on every case
+// including the refusals — see Scripts/repro/536-defeature-removefeatures-unify/. Both Swift
+// spellings now reach OCCTShapeDefeature. #536
 
 // MARK: - BOPAlgo Section (v0.64)
 // --- BOPAlgo_Section ---

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -14673,11 +14673,20 @@ extension Shape {
     /// The canonical defeaturing call. `withoutFeatures(faces:)` is the same operation addressing
     /// its faces by index instead of by shape, and `defeaturedWithFullHistory(faces:)` is the same
     /// operation again with the removal history retained; all three run one shared
-    /// `BRepAlgoAPI_Defeaturing` path in the bridge.
+    /// `BRepAlgoAPI_Defeaturing` path in the bridge. `removeFeatures(faces:)` was a fourth spelling
+    /// of this call, reaching the same algorithm one OCCT layer down, and is deprecated in favour
+    /// of this one (#536).
     ///
     /// Returns `nil` when `faces` is empty, and when the operation itself fails — defeaturing
     /// cannot always reconnect the surrounding topology, so a `nil` here is an ordinary outcome,
     /// not necessarily a caller error.
+    ///
+    /// A face that is not part of this shape cannot be removed from it. OCCT drops such a face
+    /// from the request and carries on with the rest, so a request that mixes real faces with
+    /// foreign ones succeeds and removes only the real ones; a request of nothing but foreign
+    /// faces fails. Membership is by identity, not by geometry: the same face measured off an
+    /// identically-built shape is foreign. The index-addressed `withoutFeatures(faces:)` is
+    /// stricter — since #497 one bad index fails the whole call.
     ///
     /// ```swift
     /// let box = Shape.box(width: 20, height: 20, depth: 20)!

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -9972,17 +9972,30 @@ extension Shape {
 
     /// Remove features (faces) from a solid shape.
     ///
-    /// Uses BOPAlgo_RemoveFeatures to remove specified faces (e.g., fillets, holes)
-    /// from a solid, healing the resulting shape.
+    /// Deprecated: this is ``defeature(faces:)`` under a second name, and always was.
+    /// `BRepAlgoAPI_Defeaturing`, which `defeature(faces:)` drives, is an API wrapper over
+    /// `BOPAlgo_RemoveFeatures`: its `Build()` hands the shape, the faces, the history flag and the
+    /// parallel flag to a `BOPAlgo_RemoveFeatures` member and takes that member's result. The two
+    /// spellings therefore drove one algorithm object, one of them through an extra layer, and the
+    /// defaults they inherited for those forwarded flags are the same.
+    ///
+    /// Measured rather than argued, over every face of a filleted box, a through hole, a boss, a
+    /// two-hole solid, and the requests that fail (no faces, a face from another shape, an input
+    /// that is not a solid): identical results, BREP byte for byte, in every case — see
+    /// `Scripts/repro/536-defeature-removefeatures-unify/`. Nothing about the result changes when
+    /// you switch.
+    ///
+    /// ```swift
+    /// let old = shape.removeFeatures(faces: filletFaces)
+    /// let new = shape.defeature(faces: filletFaces)   // the same shape, exactly
+    /// ```
     ///
     /// - Parameter faces: Array of face shapes to remove
     /// - Returns: Shape with features removed, or nil on failure
+    @available(*, deprecated, renamed: "defeature(faces:)",
+               message: "the same BRepAlgoAPI_Defeaturing operation one OCCT layer down. Use defeature(faces:).")
     public func removeFeatures(faces: [Shape]) -> Shape? {
-        let handles = faces.map { $0.handle as OCCTShapeRef }
-        guard let ref = handles.withUnsafeBufferPointer({ buf in
-            OCCTBOPAlgoRemoveFeatures(handle, buf.baseAddress!, Int32(buf.count))
-        }) else { return nil }
-        return Shape(handle: ref)
+        defeature(faces: faces)
     }
 
     // MARK: - BOPAlgo_Section

--- a/Tests/OCCTModelingTests/Issue536DefeaturingSpellingsTests.swift
+++ b/Tests/OCCTModelingTests/Issue536DefeaturingSpellingsTests.swift
@@ -1,0 +1,224 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #536 — `removeFeatures(faces:)` and `defeature(faces:)` were the same operation under two names,
+/// one OCCT layer apart: `BRepAlgoAPI_Defeaturing::Build` hands its shape, its faces, its history
+/// flag and its parallel flag to a `BOPAlgo_RemoveFeatures` member and returns that member's result.
+/// The deprecated spelling now forwards to the surviving one.
+///
+/// What these pin down:
+///  - the forwarder answers exactly what `defeature(faces:)` answers, on features of several kinds
+///    and on the requests that fail — not "both non-nil", the same geometry;
+///  - the whole defeaturing family still agrees with itself across all four spellings;
+///  - the face-membership contract the shape-addressed form actually has, which is not the
+///    index-addressed form's contract and was written down nowhere before.
+///
+/// Ground truth for every claim here (BREP byte-for-byte comparison of the two OCCT paths over a
+/// matrix of fixtures, including the refusals): `Scripts/repro/536-defeature-removefeatures-unify/`.
+@Suite("Issue 536: one defeaturing operation, not two")
+struct Issue536DefeaturingSpellingsTests {
+
+    /// A box with one filleted edge, and the indices of the faces the fillet added.
+    private static func filletedBox(size: Double = 20, radius: Double = 2) -> (shape: Shape, filletFaces: [Int])? {
+        guard let box = Shape.box(width: size, height: size, depth: size),
+              let filleted = box.filleted(radius: radius) else { return nil }
+        let faceCount = filleted.faces().count
+        guard faceCount > 6 else { return nil }
+        return (filleted, Array(6..<faceCount))
+    }
+
+    /// A 20mm box with a through hole drilled along Z.
+    private static func drilledBox() -> Shape? {
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let drill = Shape.cylinder(radius: 3, height: 40)?.translated(by: SIMD3(0, 0, -20))
+        else { return nil }
+        return box.subtracting(drill)
+    }
+
+    /// A 20mm box with a cylindrical boss fused onto its top.
+    private static func bossedBox() -> Shape? {
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let boss = Shape.cylinder(radius: 4, height: 6)?.translated(by: SIMD3(0, 0, 10))
+        else { return nil }
+        return box.union(boss)
+    }
+
+    /// Two results are the same removal, not merely two successes.
+    private func expectSameRemoval(_ a: Shape?, _ b: Shape?, _ what: String) {
+        #expect((a == nil) == (b == nil), "\(what): one spelling answered nil and the other did not")
+        guard let a, let b else { return }
+        #expect(a.faces().count == b.faces().count, "\(what): different face counts")
+        if let va = a.volume, let vb = b.volume {
+            #expect(abs(va - vb) < 1e-9, "\(what): volumes differ by \(abs(va - vb))")
+        }
+        if let sa = a.surfaceArea, let sb = b.surfaceArea {
+            #expect(abs(sa - sb) < 1e-9, "\(what): areas differ by \(abs(sa - sb))")
+        }
+    }
+
+    /// Every face of `shape` removed on its own, then the first two together, then all of them:
+    /// both spellings, compared each time. Removals that fail count — a forwarder that diverges
+    /// only where the algorithm refuses would slip past any happy-path check.
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    private func expectSpellingsAgree(on shape: Shape, _ fixture: String) {
+        let faces = shape.subShapes(ofType: .face)
+        #expect(!faces.isEmpty, "\(fixture): fixture has no faces")
+
+        for (i, face) in faces.enumerated() {
+            expectSameRemoval(shape.removeFeatures(faces: [face]),
+                              shape.defeature(faces: [face]),
+                              "\(fixture), face \(i) of \(faces.count)")
+        }
+
+        if faces.count >= 2 {
+            let pair = Array(faces.prefix(2))
+            expectSameRemoval(shape.removeFeatures(faces: pair),
+                              shape.defeature(faces: pair),
+                              "\(fixture), first two faces at once")
+        }
+
+        expectSameRemoval(shape.removeFeatures(faces: faces),
+                          shape.defeature(faces: faces),
+                          "\(fixture), every face at once")
+    }
+
+    // MARK: - The two spellings are one operation
+
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("removeFeatures(faces:) answers what defeature(faces:) answers, on a fillet")
+    func spellingsAgreeOnFillet() {
+        guard let (filleted, _) = Self.filletedBox() else {
+            #expect(Bool(false), "fixture: filleted box")
+            return
+        }
+        expectSpellingsAgree(on: filleted, "filleted box")
+    }
+
+    /// Features that are not fillets: a hole is a face the algorithm removes by closing the gap,
+    /// a boss is one it removes by cutting material away.
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("the spellings agree on a through hole and on a boss")
+    func spellingsAgreeOnOtherFeatures() {
+        guard let holed = Self.drilledBox() else {
+            #expect(Bool(false), "fixture: box with a through hole")
+            return
+        }
+        expectSpellingsAgree(on: holed, "box with through hole")
+
+        guard let bossed = Self.bossedBox() else {
+            #expect(Bool(false), "fixture: box with a boss")
+            return
+        }
+        expectSpellingsAgree(on: bossed, "box with boss")
+    }
+
+    /// The requests neither spelling can satisfy. Both must refuse, and refuse alike.
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("the spellings agree on the requests that fail")
+    func spellingsAgreeOnRefusals() {
+        guard let (filleted, filletIndices) = Self.filletedBox(),
+              let target = filletIndices.first,
+              let other = Shape.box(width: 11, height: 11, depth: 11) else {
+            #expect(Bool(false), "fixture: filleted box and a second shape")
+            return
+        }
+
+        // No faces at all.
+        #expect(filleted.removeFeatures(faces: []) == nil)
+        #expect(filleted.defeature(faces: []) == nil)
+
+        // Faces belonging to a different shape: nothing in the request can be removed.
+        let foreign = other.subShapes(ofType: .face)
+        #expect(!foreign.isEmpty)
+        expectSameRemoval(filleted.removeFeatures(faces: [foreign[0]]),
+                          filleted.defeature(faces: [foreign[0]]),
+                          "a face from another shape")
+
+        // An input that is not a solid: only SOLID, COMPSOLID and COMPOUND-of-solids are supported.
+        let aFace = filleted.subShapes(ofType: .face)[target]
+        expectSameRemoval(aFace.removeFeatures(faces: [aFace]),
+                          aFace.defeature(faces: [aFace]),
+                          "a face as the input shape")
+    }
+
+    // MARK: - The family still agrees with itself
+
+    /// All four spellings of "remove this face" on one fixture: by shape (surviving and deprecated),
+    /// by index, and by index with history. #497 unified the last three; this adds the fourth.
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("all four spellings of the same removal produce the same shape")
+    func wholeFamilyAgrees() {
+        guard let (filleted, filletIndices) = Self.filletedBox(),
+              let target = filletIndices.first else {
+            #expect(Bool(false), "fixture: filleted box")
+            return
+        }
+
+        let face = filleted.subShapes(ofType: .face)[target]
+        let byShape = filleted.defeature(faces: [face])
+        #expect(byShape != nil, "defeaturing a fillet face should succeed on this fixture")
+
+        expectSameRemoval(byShape, filleted.removeFeatures(faces: [face]), "deprecated spelling")
+        expectSameRemoval(byShape, filleted.withoutFeatures(faces: [filleted.faces()[target]]), "by index")
+        expectSameRemoval(byShape, filleted.defeaturedWithFullHistory(faces: [target])?.result, "with history")
+    }
+
+    // MARK: - What the surviving contract actually is
+
+    /// The shape-addressed form's membership rule, measured rather than assumed: OCCT drops a face
+    /// that is not part of the input and carries on with the rest, so a mixed request succeeds and
+    /// removes only what it could. The index-addressed spelling fails the whole call instead
+    /// (#497), and that difference is now documented on `defeature(faces:)` rather than latent.
+    @Test("a foreign face is dropped from a mixed request, not failed")
+    func foreignFaceInMixedRequest() {
+        guard let (filleted, filletIndices) = Self.filletedBox(),
+              let target = filletIndices.first,
+              let other = Shape.box(width: 11, height: 11, depth: 11) else {
+            #expect(Bool(false), "fixture: filleted box and a second shape")
+            return
+        }
+
+        let face = filleted.subShapes(ofType: .face)[target]
+        let foreign = other.subShapes(ofType: .face)[0]
+
+        guard let alone = filleted.defeature(faces: [face]), let aloneVolume = alone.volume else {
+            #expect(Bool(false), "defeaturing a fillet face should succeed on this fixture")
+            return
+        }
+
+        // The real face still goes; the foreign one is neither removed nor fatal.
+        if let mixed = filleted.defeature(faces: [face, foreign]) {
+            #expect(mixed.faces().count == alone.faces().count)
+            if let v = mixed.volume {
+                #expect(abs(v - aloneVolume) < 1e-9, "the foreign face changed the result")
+            }
+        } else {
+            #expect(Bool(false), "a mixed request should still remove the face that belongs")
+        }
+
+        // Nothing but foreign faces has nothing to remove, and fails.
+        #expect(filleted.defeature(faces: [foreign]) == nil)
+    }
+
+    /// Membership is identity, not geometry. Two separately built but identical filleted boxes do
+    /// not share faces, so one's face is foreign to the other — the same rule the kernel applies.
+    @Test("an identically-built shape's face is still foreign")
+    func membershipIsIdentityNotGeometry() {
+        guard let (a, filletIndices) = Self.filletedBox(),
+              let (b, _) = Self.filletedBox(),
+              let target = filletIndices.first else {
+            #expect(Bool(false), "fixture: two identically built filleted boxes")
+            return
+        }
+
+        // Same construction, same dimensions, same face at the same position.
+        #expect(a.faces().count == b.faces().count)
+        let twinFace = b.subShapes(ofType: .face)[target]
+
+        #expect(a.defeature(faces: [twinFace]) == nil,
+                "a twin fixture's face is not this shape's face")
+        // ... while this shape's own face at that position works.
+        #expect(a.defeature(faces: [a.subShapes(ofType: .face)[target]]) != nil)
+    }
+}

--- a/Tests/OCCTModelingTests/OCCTModelingTests.swift
+++ b/Tests/OCCTModelingTests/OCCTModelingTests.swift
@@ -2922,6 +2922,10 @@ struct BRepOffsetOffsetFaceTests {
 
 // MARK: - BOPAlgo_RemoveFeatures
 
+// These used to call removeFeatures(faces:), which drove BOPAlgo_RemoveFeatures directly. It is now
+// a deprecated forwarder to defeature(faces:), the same algorithm through BRepAlgoAPI_Defeaturing,
+// so they call the survivor. Issue536DefeaturingSpellingsTests holds the forwarder itself to
+// account. #536
 @Suite("BOPAlgo RemoveFeatures")
 struct BOPAlgoRemoveFeaturesTests {
     @Test("Remove fillet from box")
@@ -2933,7 +2937,7 @@ struct BOPAlgoRemoveFeaturesTests {
             // Fillet adds faces, try removing the last face
             guard filletedFaces.count > 6 else { return }
             let lastFace = filletedFaces[filletedFaces.count - 1]
-            if let result = filleted.removeFeatures(faces: [lastFace]) {
+            if let result = filleted.defeature(faces: [lastFace]) {
                 #expect(result.isValid)
                 let resultFaces = result.subShapes(ofType: .face)
                 #expect(resultFaces.count <= filletedFaces.count)
@@ -2944,7 +2948,7 @@ struct BOPAlgoRemoveFeaturesTests {
     @Test("Remove features returns nil for empty faces")
     func removeFeaturesEmptyFaces() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
-        let result = box.removeFeatures(faces: [])
+        let result = box.defeature(faces: [])
         #expect(result == nil)
     }
 
@@ -2955,7 +2959,7 @@ struct BOPAlgoRemoveFeaturesTests {
         guard !faces.isEmpty else { return }
         // Removing a face from a box may or may not succeed
         // depending on topology — just verify it doesn't crash
-        let _ = box.removeFeatures(faces: [faces[0]])
+        let _ = box.defeature(faces: [faces[0]])
     }
 }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -88,7 +88,7 @@ a map of the major areas, and the `Total` as the count.
 | **Shape History** | 1 | History (create, addModified, addGenerated, remove, isRemoved, hasModified, hasGenerated, hasRemoved, modifiedCount, generatedCount) |
 | **Contour Analysis** | 3 | contourSphereDir, contourCylinderDir, contourSphereEye |
 | **IntCurvesFace** | 1 | intersectLine (line-face intersection) |
-| **BOPAlgo Utilities** | 17 | split (splitter), CellsBuilder (create, addAll, removeAll, removeInternalBoundaries, result), analyzeBoolean, removeFeatures, section(instance), section(static), buildFaces, buildSolids, splitShell, edgesToWires, wiresToFaces, makeWire |
+| **BOPAlgo Utilities** | 17 | split (splitter), CellsBuilder (create, addAll, removeAll, removeInternalBoundaries, result), analyzeBoolean, removeFeatures (deprecated — `defeature(faces:)` one OCCT layer down, #536), section(instance), section(static), buildFaces, buildSolids, splitShell, edgesToWires, wiresToFaces, makeWire |
 | **IntTools** | 6 | edgeEdgeIntersection, edgeFaceIntersection, faceFaceIntersection, classifyPoint2d, isHole, beanFaceIntersect |
 | **BOPTools** | 4 | normalOnEdge, pointInFace, isEmpty, isOpenShell |
 | **PCurve / BRepAdaptor** | 3 | pcurveParams, pcurveValue, approxCurveOnSurface |
@@ -471,7 +471,7 @@ a map of the major areas, and the `Total` as the count.
 | **BRepBndLib** | 3 | boundingBox, boundingBoxOptimal, orientedBoundingBoxDetailed |
 | **ShapeAnalysis Tolerance** | 3 | toleranceValue, toleranceOverCount, toleranceInRangeCount |
 | **Boolean Validation** | 2 | isBooleanValid, isBooleanValidWith |
-| **Defeaturing** | 2 | defeature(faces:), defeature(faces:tolerance:) (deprecated — the tolerance was never read, #497) |
+| **Defeaturing** | 2 | defeature(faces:) (also the target of the deprecated removeFeatures, #536), defeature(faces:tolerance:) (deprecated — the tolerance was never read, #497) |
 | **Polynomial Conversion** | 1 | polynomialToPoles |
 | **Transform Extras** | 4 | transformed(byMatrix:), isTransformNegative, displacement, transformation |
 | **TopExp Extras** | 1 | commonVertex |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -342,6 +342,57 @@ New suite `Issue539NearestPointOnCurveTests` (`OCCTCurveTests`), 12 tests. Prove
 assumed: reinstating the two original implementations fails 9 of the 12, and the 3 that still pass
 are exactly the three asserting what was meant to stay the same.
 
+#### One defeaturing operation, not one per OCCT layer (#536)
+
+`Shape.removeFeatures(faces:)` and `Shape.defeature(faces:)` took the same arguments, returned the
+same type, and neither doc comment mentioned the other. They were the same operation: `defeature`
+drove `BRepAlgoAPI_Defeaturing`, `removeFeatures` drove `BOPAlgo_RemoveFeatures`, and
+`BRepAlgoAPI_Defeaturing::Build` is a 30-line forwarder that hands its shape, its faces, its history
+flag and its parallel flag to a `BOPAlgo_RemoveFeatures` member and returns that member's result —
+with `Modified`, `Generated`, `IsDeleted`, `HasModified`, `HasGenerated`, `HasDeleted` and `History`
+all one-line delegations to the same member. The bridge had wrapped both layers of one algorithm and
+given each its own Swift name. This is the sixth spelling of the operation #497 consolidated, left
+out of that pass because it reached a different OCCT class.
+
+**Measured, not read off the source.** A deprecation has to answer "is there any input on which they
+can differ", not "do they agree on a box", so both paths were driven exactly the way their bridge
+wrappers drove them — including the different completion tests, `IsDone()` against `!HasErrors()` —
+over every face of a filleted box in turn, a through hole, a boss, two holes at once, and the
+requests that fail (no faces, a face from another shape, a mixed request, an input that is not a
+solid, the same face twice). Identical in every case, compared as full BREP serialisations rather
+than volumes. The option defaults the forwarding depends on match too (`myFillHistory` true on both
+constructors, `myRunParallel` false from the shared `BOPAlgo_Options` base), which is what made the
+two unconfigured objects the same object. Probe and full output at
+[`Scripts/repro/536-defeature-removefeatures-unify/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/536-defeature-removefeatures-unify).
+
+`defeature(faces:)` survives — it is the class OCCT documents for application use, it is where the
+history-carrying sibling already lives, and since #497 it shares one bridge skeleton with the rest of
+the family. `removeFeatures(faces:)` is deprecated and forwards to it, with a `renamed:` fix-it.
+`OCCTBOPAlgoRemoveFeatures` is deleted rather than kept for a future caller: `OCCTBridge` is a
+target, not a product, so nothing outside this package can link it, and #506 measured what keeping an
+orphan costs — it freezes whatever contract it had, and this one had drifted already, silently
+skipping a null entry in the faces array where the surviving path fails the call. That particular
+drift was not reachable from Swift, since `[Shape]` has no null elements; it is what an orphaned copy
+looks like after one side gets a fix, which is the argument against keeping it.
+
+**Not fixed, and now written down.** A face that is not part of the input is dropped from the request
+rather than refused: a request mixing one real face with one foreign face succeeds, removes the real
+one, and emits no warning at all, while a request of nothing but foreign faces fails because nothing
+is left to remove. That is more forgiving than the index-addressed `withoutFeatures(faces:)`, which
+since #497 fails the whole call on one bad index. Making the two agree is not a line of validation:
+`AddFaceToRemove` takes a `TopoDS_Shape` and its own documentation calls it "the shape to extract the
+faces for removal", and the kernel duly accepts a compound, a shell or the whole input solid as a
+face carrier — measured. Deciding what a membership rule does with those is its own question, so it
+is filed separately; the behaviour is documented on `defeature(faces:)` in the meantime, along with
+the fact that membership is identity, not geometry (a face measured off a separately built but
+identical shape is foreign).
+
+New suite `Issue536DefeaturingSpellingsTests` (`OCCTModelingTests`) compares the two spellings face
+by face on three fixtures, pins all four spellings of one removal against each other, and pins the
+membership contract above. Proved against three injections rather than assumed: a forwarder that
+returns its input unchanged, one that drops the last requested face, and a `defeature` that reports
+failure as the input shape each fail the tests that cover them, and only those.
+
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 
 `OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1384,8 +1384,16 @@ public func defeature(faces: [Shape]) -> Shape?
   }
   ```
 
-**The rest of the family.** Four Swift spellings reach the same `BRepAlgoAPI_Defeaturing`
-operation, over one shared bridge path (#497):
+**Faces that are not part of this shape.** A face can only be removed from the shape it belongs to.
+OCCT drops a foreign face from the request and carries on with the rest, so a request mixing real
+faces with foreign ones succeeds and removes only the real ones, while a request of nothing but
+foreign faces fails. Membership is by identity, not geometry: the same face measured off an
+identically-built shape is foreign. The index-addressed `withoutFeatures(faces:)` is stricter —
+since #497 one bad index fails the whole call. Measured in
+[`Scripts/repro/536-defeature-removefeatures-unify/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/536-defeature-removefeatures-unify).
+
+**The rest of the family.** Five Swift spellings reach the same `BRepAlgoAPI_Defeaturing`
+operation, over one shared bridge path (#497, #536):
 
 | Call | Addresses faces as | Notes |
 |------|--------------------|-------|
@@ -1393,10 +1401,14 @@ operation, over one shared bridge path (#497):
 | [`withoutFeatures(faces:)`](Shape-Features.md#withoutfeaturesfaces) | `[Face]` (by index) | same operation |
 | `defeaturedWithFullHistory(faces:)` | `[Int]` (indices) | also returns the removal history |
 | [`withoutSmallFaces(minArea:)`](Shape-Features.md) | picks its own | every face below an area threshold |
+| [`removeFeatures(faces:)`](Shape-Builders-2.md#removefeaturesfaces--deprecated-536) | `[Shape]` | deprecated: this call, reached one OCCT layer down |
 
 `defeature(faces:tolerance:)` is deprecated and forwards here: `BRepAlgoAPI_Defeaturing` has no
 fuzzy tolerance to set, and never had — see
 [`Scripts/repro/497-defeaturing-fuzzy-inert/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/497-defeaturing-fuzzy-inert).
+`removeFeatures(faces:)` is deprecated too, and forwards here as well: it drove
+`BOPAlgo_RemoveFeatures` directly, which is the algorithm `BRepAlgoAPI_Defeaturing::Build` forwards
+to (#536).
 
 ---
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -229,21 +229,30 @@ public func transferParameterFromFace(_ param: Double, face: Shape) -> Double
 
 ## BOPAlgo\_RemoveFeatures
 
-### `removeFeatures(faces:)`
+### `removeFeatures(faces:)` — deprecated (#536)
 
-Remove features (faces) from a solid shape, healing the result.
+Remove features (faces) from a solid shape, healing the result. **Deprecated:** this is
+[`defeature(faces:)`](Document-Transforms.md#shapedefeaturefaces) under a second name.
+`BRepAlgoAPI_Defeaturing`, which
+`defeature(faces:)` drives, is an API wrapper over `BOPAlgo_RemoveFeatures`: its `Build()` hands the
+shape, the faces, the history flag and the parallel flag to a `BOPAlgo_RemoveFeatures` member and
+returns that member's result, and both spellings took the same defaults for the two forwarded flags.
+Measured identical, BREP byte for byte, on every case including the refusals — see
+[`Scripts/repro/536-defeature-removefeatures-unify/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/536-defeature-removefeatures-unify).
+It now forwards; nothing about the result changes when you switch.
 
 ```swift
+@available(*, deprecated, renamed: "defeature(faces:)")
 public func removeFeatures(faces: [Shape]) -> Shape?
 ```
 
 - **Parameters:** `faces` — array of face shapes to remove (e.g. fillets, boss faces, holes).
 - **Returns:** Healed shape with features removed, or `nil` on failure.
-- **OCCT:** `BOPAlgo_RemoveFeatures`
+- **OCCT:** `BRepAlgoAPI_Defeaturing`, which forwards to `BOPAlgo_RemoveFeatures`
 - **Example:**
   ```swift
   let faces = solid.subShapes(ofType: .face)
-  if let cleaned = solid.removeFeatures(faces: [faces[2]]) { }
+  if let cleaned = solid.defeature(faces: [faces[2]]) { }
   ```
 
 ---


### PR DESCRIPTION
Closes #536. Pass 1b of the #381 / #377 duplication audit; based on `refactor/381-pass1b`.

`Shape.removeFeatures(faces:)` and `Shape.defeature(faces:)` took the same arguments, returned the
same type, and neither doc comment mentioned the other. They were the same operation, one OCCT layer
apart: `defeature` drove `BRepAlgoAPI_Defeaturing`, `removeFeatures` drove `BOPAlgo_RemoveFeatures`,
and `BRepAlgoAPI_Defeaturing::Build` is a 30-line forwarder that hands its shape, its faces, its
history flag and its parallel flag to a `BOPAlgo_RemoveFeatures` member and returns that member's
result — with `Modified`, `Generated`, `IsDeleted`, `HasModified`, `HasGenerated`, `HasDeleted` and
`History` all one-line delegations to the same member. The bridge had wrapped both layers of one
algorithm and given each its own Swift name.

## Measured, not read off the source

A deprecation has to answer "is there **any** input on which they can differ", not "do they agree on
a box". Both paths were driven exactly the way their bridge wrappers drove them — including the
different completion tests, `IsDone()` against `!HasErrors()` — and compared as full BREP
serialisations rather than volumes, so a difference in parameterisation that leaves the volume alone
still counts:

```
option defaults (nothing set on either):
  history filling : defeaturing=1 removeFeatures=1  same
  parallel mode   : defeaturing=0 removeFeatures=0  same

ordinary removals:
  20mm box, remove fillet face          defeature[done=1 vol=8000.000000000 faces=6]  removeFeatures[ok=1 vol=8000.000000000 faces=6]  IDENTICAL BREP
  20mm box, remove face 1..7 of 7       (all seven)                                                                                   IDENTICAL BREP
  box with through hole, remove hole    defeature[done=1 vol=8000.000000000 faces=6]  removeFeatures[ok=1 vol=8000.000000000 faces=6]  IDENTICAL BREP
  box with boss, remove boss faces      defeature[done=1 vol=8301.592894745 faces=8]  removeFeatures[ok=1 vol=8301.592894745 faces=8]  IDENTICAL BREP
  two holes, both removed at once       defeature[done=1 vol=27000.00000000 faces=6]  removeFeatures[ok=1 vol=27000.00000000 faces=6]  IDENTICAL BREP

non-ordinary requests:
  no faces requested                    defeature[done=0]  removeFeatures[ok=0]                                                        IDENTICAL BREP
  face from a different shape           defeature[done=0]  removeFeatures[ok=0]                                                        IDENTICAL BREP
  one real face plus one foreign        defeature[done=1 vol=8000.000000000 faces=6]  removeFeatures[ok=1 vol=8000.000000000 faces=6]  IDENTICAL BREP
  input is a face, not a solid          defeature[done=0]  removeFeatures[ok=0]                                                        IDENTICAL BREP
  the same face requested twice         defeature[done=1 vol=8000.000000000 faces=6]  removeFeatures[ok=1 vol=8000.000000000 faces=6]  IDENTICAL BREP
```

The option defaults matter because they are what the forwarding depends on: `myFillHistory(true)` in
both constructors, `myRunParallel(false)` from the shared `BOPAlgo_Options` base, so an unconfigured
`BRepAlgoAPI_Defeaturing` and an unconfigured `BOPAlgo_RemoveFeatures` are the same object with the
same settings. Probe, full output and the source walk-through:
[`Scripts/repro/536-defeature-removefeatures-unify/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/536-defeature-removefeatures-unify/Scripts/repro/536-defeature-removefeatures-unify).

## The change

- `defeature(faces:)` survives — the class OCCT documents for application use, where the
  history-carrying sibling already lives, and since #497 the one sharing a bridge skeleton with the
  rest of the family.
- `removeFeatures(faces:)` is deprecated with a `renamed:` fix-it and forwards to it.
- `OCCTBOPAlgoRemoveFeatures` is deleted rather than kept for a future caller: `OCCTBridge` is a
  target, not a product, so nothing outside this package can link it, and #506 measured what keeping
  an orphan costs. This one had drifted already — it silently skipped a null entry in the faces
  array where the surviving path fails the call. Not reachable from Swift (`[Shape]` has no null
  elements), which is exactly what an orphaned copy looks like after one side gets a fix.
- No behaviour change for any caller: the forwarder returns what the deleted path returned.

## Noticed, documented, filed rather than fixed (#578)

A face that is not part of the input is **dropped from the request, not refused**: a request mixing
one real face with one foreign face succeeds, removes the real one, and emits no warning at all,
while a request of nothing but foreign faces fails because nothing is left to remove. That is more
forgiving than the index-addressed `withoutFeatures(faces:)`, which since #497 fails the whole call
on one bad index — the same failure mode #497 named, on the entry point this PR makes canonical.

It is not fixed here because "every requested face must belong to this shape" is not the precondition
it looks like. `AddFaceToRemove` takes a `TopoDS_Shape` and its own documentation calls it "the shape
to extract the faces for removal", and the kernel duly accepts more than a face — measured:

```
  the fillet face, as found                done=1 volume=8000.000000000 faces=6
  the same face, orientation reversed      done=1 volume=8000.000000000 faces=6
  a compound containing the fillet face    done=1 volume=8000.000000000 faces=6
  the entire input solid                   done=1 volume=7982.831853072 faces=7   (a no-op success)
  an edge (contains no face)               done=0 volume=0.000000000 faces=0
```

A membership rule has to decide what it does with those carriers first, which is its own design
question with its own matrix. Filed as #578; the behaviour is documented on `defeature(faces:)` and
pinned by tests in the meantime, along with the fact that membership is identity, not geometry (a
face measured off a separately built but identical shape is foreign).

## Tests

New suite `Issue536DefeaturingSpellingsTests` (`OCCTModelingTests`, 6 tests): the two spellings
compared face by face on a filleted box, a drilled box and a bossed box, plus multi-face and
all-face requests; the refusals; all four spellings of one removal against each other; and the
membership contract above.

Proved against three injections rather than assumed — each fails the tests that cover it, and only
those:

| Injection | Caught by |
|---|---|
| forwarder returns its input unchanged | the three equivalence tests + the refusal test |
| forwarder drops the last requested face | the three equivalence tests (45 issues) |
| `defeature` reports failure as the input shape | both contract tests + the refusal test |

Full suite green: 4930 tests in 1358 suites. `Scripts/check-bridge-index.py` clean for this entry
(the 128 pre-existing stale entries are #510/#565's). `Scripts/count-operations.py` unchanged at
4299 — a deprecated entry point is still an entry point.

## Docs

`docs/CHANGELOG.md` (Unreleased), `docs/API_REFERENCE.md` (both affected rows),
`docs/reference/Document-Transforms.md` (the family table, now five spellings, plus the membership
contract), `docs/reference/Shape-Builders-2.md` (the deprecated entry), and the `///` comments on
both Swift calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
