### PR TITLE
fix(#539): the closest point on a curve is now on the curve

### DIFF
--- a/Scripts/repro/539-nearest-point-on-curve/580-repair-options.mm
+++ b/Scripts/repro/539-nearest-point-on-curve/580-repair-options.mm
@@ -1,0 +1,112 @@
+// #580: the two routes compared on the same 189 combinations -- repair inside BRepExtrema_ExtPC
+// (extrema + TrimmedSquareDistances) vs reuse of #539's occtNearestPointOnCurveRange.
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_Line.hxx>
+#include <GeomAPI_PointsToBSpline.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <ShapeAnalysis_Curve.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepExtrema_ExtPC.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRep_Tool.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <Precision.hxx>
+#include <gp_Ax2.hxx>
+
+// Verbatim shape of the shipped #539 helper.
+static bool nearestOnRange(const Handle(Geom_Curve)& curve, const gp_Pnt& point,
+                           double first, double last, double precision, double* outDistance) {
+  if (curve.IsNull()) return false;
+  const bool ff = !Precision::IsInfinite(first), lf = !Precision::IsInfinite(last);
+  double bestD = RealLast(); bool found = false;
+  auto consider = [&](double t) {
+    if (ff && t < first) return;
+    if (lf && t > last) return;
+    gp_Pnt c; try { c = curve->Value(t); } catch (...) { return; }
+    double d = point.Distance(c);
+    if (d < bestD) { bestD = d; found = true; }
+  };
+  double sp = 0, sd = RealLast(); bool haveS = false;
+  try { ShapeAnalysis_Curve a; gp_Pnt pr; sd = a.Project(curve, point, precision, pr, sp); haveS = true; consider(sp); } catch (...) {}
+  try { GeomAPI_ProjectPointOnCurve pc(point, curve, first, last);
+        for (int i = 1; i <= pc.NbPoints(); i++) consider(pc.Parameter(i)); } catch (...) {}
+  if (ff) consider(first);
+  if (lf) consider(last);
+  if (!found) { if (!haveS) return false; bestD = sd; }
+  *outDistance = bestD;
+  return true;
+}
+
+static double truthOf(const TopoDS_Edge& e, const gp_Pnt& p) {
+  BRepAdaptor_Curve ad(e);
+  double f = ad.FirstParameter(), l = ad.LastParameter(), best = 1e300;
+  for (int i = 0; i <= 400000; i++)
+    best = fmin(best, p.Distance(ad.Value(f + (l - f) * i / 400000.0)));
+  return best;
+}
+
+static int okExt = 0, okHelper = 0, total = 0;
+
+static void run(const TopoDS_Edge& e, const gp_Pnt& p, int ei) {
+  TopoDS_Vertex v = BRepBuilderAPI_MakeVertex(p);
+  BRepExtrema_ExtPC ext(v, e);
+  double minAll = 1e300;
+  if (ext.IsDone() && ext.NbExt() >= 1)
+    for (int i = 1; i <= ext.NbExt(); i++) minAll = fmin(minAll, sqrt(ext.SquareDistance(i)));
+  double d1 = -1, d2 = -1; gp_Pnt p1, p2;
+  ext.TrimmedSquareDistances(d1, d2, p1, p2);
+  double viaExt = fmin(minAll, fmin(sqrt(fmax(d1, 0.0)), sqrt(fmax(d2, 0.0))));
+
+  double first, last;
+  Handle(Geom_Curve) c = BRep_Tool::Curve(e, first, last);
+  double viaHelper = -1;
+  bool got = nearestOnRange(c, p, first, last, Precision::Confusion(), &viaHelper);
+
+  double t = truthOf(e, p);
+  auto near = [&](double a) { return fabs(a - t) <= 1e-5 * (1 + t); };
+  total++;
+  if (near(viaExt)) okExt++; else printf("  ExtPC route MISS  edge#%d pt(%.4g,%.4g,%.4g): %.8g vs truth %.8g\n", ei, p.X(), p.Y(), p.Z(), viaExt, t);
+  if (got && near(viaHelper)) okHelper++; else printf("  #539 helper MISS  edge#%d pt(%.4g,%.4g,%.4g): %.8g vs truth %.8g\n", ei, p.X(), p.Y(), p.Z(), viaHelper, t);
+}
+
+int main() {
+  gp_Ax2 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
+  Handle(Geom_Circle) circ = new Geom_Circle(ax, 5);
+  Handle(Geom_Line) line = new Geom_Line(gp_Pnt(0,0,0), gp_Dir(1,0,0));
+  TColgp_Array1OfPnt pts(1, 5);
+  pts.SetValue(1, gp_Pnt(0,0,0)); pts.SetValue(2, gp_Pnt(1,2,0));
+  pts.SetValue(3, gp_Pnt(3,3,0)); pts.SetValue(4, gp_Pnt(5,1,0));
+  pts.SetValue(5, gp_Pnt(7,0,0));
+  std::vector<TopoDS_Edge> edges = {
+    BRepBuilderAPI_MakeEdge(line, 3.0, 8.0),
+    BRepBuilderAPI_MakeEdge(circ, 0.0, M_PI),
+    BRepBuilderAPI_MakeEdge(circ, 0.0, M_PI / 2),
+    BRepBuilderAPI_MakeEdge(circ, 5.5, 7.0),
+    BRepBuilderAPI_MakeEdge(circ),
+    BRepBuilderAPI_MakeEdge(new Geom_Ellipse(ax, 8, 4), 0.0, M_PI),
+    BRepBuilderAPI_MakeEdge(GeomAPI_PointsToBSpline(pts).Curve()),
+  };
+  std::vector<gp_Pnt> queries;
+  for (int i = 0; i < 12; i++) {
+    double a = 2 * M_PI * i / 12.0;
+    queries.push_back(gp_Pnt(6 * cos(a), 6 * sin(a), 0));
+    queries.push_back(gp_Pnt(2 * cos(a), 2 * sin(a), 0));
+  }
+  queries.push_back(gp_Pnt(0, 0, 0));
+  queries.push_back(gp_Pnt(100, 0, 0));
+  queries.push_back(gp_Pnt(0, 0, 4));
+
+  for (size_t ei = 0; ei < edges.size(); ei++) for (auto& q : queries) run(edges[ei], q, (int)ei);
+
+  printf("\n%d combinations\n", total);
+  printf("  repair inside BRepExtrema_ExtPC (extrema + TrimmedSquareDistances) : %d\n", okExt);
+  printf("  reuse #539's occtNearestPointOnCurveRange                          : %d\n", okHelper);
+  return 0;
+}

--- a/Scripts/repro/539-nearest-point-on-curve/README.md
+++ b/Scripts/repro/539-nearest-point-on-curve/README.md
@@ -27,6 +27,7 @@ the returned parameter into the domain is the fix. These probes ask what the hea
 | `periodic-and-types.mm` | (2), (3), and whether the `Edge` path reports a maximum as the nearest point |
 | `sweep.mm` | the 51-case matrix: both current implementations and the proposed one against a dense brute-force reference |
 | `extpc-sibling.mm` | whether `BRepExtrema_ExtPC` (`Shape.pointEdgeExtrema`) shares the defect — it does, filed as #580 |
+| `580-repair-options.mm` | scores #580's repair options over 189 edge/point combinations, so that issue ships with its own answer rather than an open question |
 
 ## Build and run
 
@@ -81,6 +82,27 @@ curve's own domain:
 | minimum over both plus the range's ends (shipped) | **51 / 51** |
 
 The 26 the `Edge` path missed split into 9 wrong numbers and 17 refusals to answer.
+
+## The sibling entry point (#580)
+
+`Shape.pointEdgeExtrema` (`BRepExtrema_ExtPC`) makes the same promise and has the same defect, but
+was left out of #539 because fixing it needs a decision about its `solutionCount` field.
+`580-repair-options.mm` measures that decision rather than leaving it open. Over 189 edge/point
+combinations:
+
+| candidate set | correct distances |
+|---|---|
+| all extrema, `nil` when `IsDone()` is false (today) | 101 correct, 34 wrong, 54 `nil` |
+| extrema flagged `IsMin` only, no ends | 101 |
+| all extrema + the two ends (`TrimmedSquareDistances`) | 188 |
+| #539's `occtNearestPointOnCurveRange` | **189** |
+
+Two findings worth carrying: `BRepExtrema_ExtPC::TrimmedSquareDistances` is valid **even when
+`IsDone()` is false**, so the ends are always available; and filtering the extrema to `IsMin` ones
+**without** adding the ends scores exactly what today scores, so the obvious-looking fix is a no-op.
+The 188/189 miss is `Extrema_ExtPC` failing to converge on a BSpline where
+`GeomAPI_ProjectPointOnCurve` succeeds, which is why the recommendation is to reuse the helper below
+rather than repair in place.
 
 ## What shipped
 

--- a/Scripts/repro/539-nearest-point-on-curve/README.md
+++ b/Scripts/repro/539-nearest-point-on-curve/README.md
@@ -1,0 +1,90 @@
+# OCCTSwift#539 probe: what "the closest point on a curve" costs when you ask one OCCT class
+
+Ground truth for the two point-to-curve projection entry points the bridge carried, against the
+pinned OCCT 8.0.0p1 kernel. No fixture files: every case builds its geometry from a primitive or an
+interpolation.
+
+`Curve3D.projectPoint(_:precision:)` (`ShapeAnalysis_Curve::Project`) and `Edge.project(point:)`
+(`GeomAPI_ProjectPointOnCurve`, ranged) both promise the closest point on the curve. #539 reports
+the first returning distance 0 for a point 92 units off a trimmed segment, and asks whether clamping
+the returned parameter into the domain is the fix. These probes ask what the headers do not say:
+
+1. **Does the range extension the issue names have a workaround?** `ShapeAnalysis_Curve`'s
+   7-argument overload takes `cf`/`cl`, and its `AdjustToEnds` flag defaults to `true` and reads like
+   it might already be doing this. Both needed measuring rather than reading.
+2. **Which curve types does it bite?** The defect is invisible on the BSplines the existing tests
+   used, so "which types take the range-ignoring path" decides how wide the blast radius is.
+3. **Is a parameter clamp safe on a periodic basis?** A clamp is only correct if a parameter outside
+   `[first, last]` is genuinely outside the curve — not merely the wrong periodic representative of
+   a point that is on it.
+4. **Is the sibling entry point exposed the same way?** #539 says `OCCTEdgeProjectPoint` "is exposed
+   to the same extension behaviour. Not separately measured yet."
+
+## Files
+
+| file | what it answers |
+|---|---|
+| `periodic-and-types.mm` | (2), (3), and whether the `Edge` path reports a maximum as the nearest point |
+| `sweep.mm` | the 51-case matrix: both current implementations and the proposed one against a dense brute-force reference |
+| `extpc-sibling.mm` | whether `BRepExtrema_ExtPC` (`Shape.pointEdgeExtrema`) shares the defect — it does, filed as #580 |
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/539-nearest-point-on-curve/sweep.mm -o /tmp/occt_539_sweep
+/tmp/occt_539_sweep
+```
+
+## What it found
+
+**(1) There is no workaround inside `ShapeAnalysis_Curve`.** The ranged overload and the no-range
+overload return byte-identical answers on every case, and `AdjustToEnds` changes nothing either way.
+The 7-argument overload's own header says why: *"The range [cf, cl] is extended with help of
+Adaptor3d on the basis of 3d precision `preci`."* Extension is the documented behaviour.
+
+**(2) The defect is confined to analytic bases, which is why it hid.** A `Geom_TrimmedCurve` over a
+BSpline or Bezier respects its range and adjusts to the end correctly; over a line, circle, ellipse,
+parabola or hyperbola it solves on the basis curve and reports a parameter outside the domain. The
+pre-#539 tests used lines and full circles queried from in-range points, where the two agree.
+
+**(3) A clamp is safe on a periodic basis, and the reason is not obvious.** `Geom_TrimmedCurve`
+normalises its own domain — trimming a circle to `[-1, 1]` reports `[5.283, 7.283]` — and `Project`
+returns the periodic representative nearest that domain, not an arbitrary one. Over ten
+seam-crossing and beyond-one-period queries, the plain clamp matched brute force exactly every time.
+So no period-aware normalisation is needed, and none was written.
+
+**(4) The sibling has a different defect, not the same one.** `GeomAPI_ProjectPointOnCurve` honours
+the edge's range — it never extends it — but it returns *extrema*, not minima. On a half circle the
+only extremum in range can be the far side, reported as `LowerDistance` (11, where the nearest point
+is 7.81 away), and it finds nothing at all when the nearest point is an end, so every point past the
+end of a straight edge came back as no answer.
+
+**And the finding that changed the fix.** On a parabola over `[0, 2]` queried from `(20, 0, 0)`, and
+a hyperbola over `[0, 1]` from `(30, 0, 0)`, the one extremum inside the domain is a *maximum*. Both
+implementations answered with it — 20 and 27, where the truth is 19.60 and 25.48 — with a parameter
+that is not out of range at all. The clamp #539 proposed would not have touched either.
+
+## The matrix
+
+`sweep.mm`, 51 curve/point combinations over line, circle, ellipse, parabola, hyperbola, Bezier,
+BSpline and offset curves, trimmed and untrimmed, each against a dense brute-force sample of the
+curve's own domain:
+
+| implementation | correct distances |
+|---|---|
+| `ShapeAnalysis_Curve::Project` (was `Curve3D.projectPoint`) | 37 / 51 |
+| `GeomAPI_ProjectPointOnCurve`, ranged (was `Edge.project`) | 25 / 51 |
+| minimum over both plus the range's ends (shipped) | **51 / 51** |
+
+The 26 the `Edge` path missed split into 9 wrong numbers and 17 refusals to answer.
+
+## What shipped
+
+`occtNearestPointOnCurveRange` (`Sources/OCCTBridge/src/OCCTBridge_Internal.h`), behind both entry
+points. It takes the minimum over three candidate sources — `ShapeAnalysis_Curve`'s answer where it
+landed inside the range, every in-range `GeomAPI` extremum, and the range's own ends — because no
+one of the three is correct alone. Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild.

--- a/Scripts/repro/539-nearest-point-on-curve/extpc-sibling.mm
+++ b/Scripts/repro/539-nearest-point-on-curve/extpc-sibling.mm
@@ -1,0 +1,40 @@
+// Does BRepExtrema_ExtPC (Shape.pointEdgeExtrema) share the "extremum is not the nearest" defect?
+#include <cstdio>
+#include <cmath>
+#include <Geom_Circle.hxx>
+#include <Geom_Line.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepExtrema_ExtPC.hxx>
+#include <BRepExtrema_DistShapeShape.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Ax2.hxx>
+int main() {
+  Handle(Geom_Circle) circ = new Geom_Circle(gp_Ax2(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 5);
+  TopoDS_Edge arc = BRepBuilderAPI_MakeEdge(circ, 0.0, M_PI);
+  Handle(Geom_Line) line = new Geom_Line(gp_Pnt(0,0,0), gp_Dir(1,0,0));
+  TopoDS_Edge seg = BRepBuilderAPI_MakeEdge(line, 3.0, 8.0);
+  struct C { const char* n; TopoDS_Edge e; gp_Pnt p; double truth; };
+  C cs[] = {
+    {"half arc [0,pi] r=5", arc, gp_Pnt(0,-6,0), 7.81025},
+    {"half arc [0,pi] r=5", arc, gp_Pnt(3,-4,0), 4.47214},
+    {"seg [3,8]",           seg, gp_Pnt(100,0,0), 92.0},
+    {"seg [3,8]",           seg, gp_Pnt(0,0,0),   3.0},
+  };
+  for (auto& c : cs) {
+    TopoDS_Vertex v = BRepBuilderAPI_MakeVertex(c.p);
+    BRepExtrema_ExtPC ext(v, c.e);
+    double best = -1;
+    if (ext.IsDone() && ext.NbExt() >= 1) {
+      best = sqrt(ext.SquareDistance(1));
+      for (int i = 2; i <= ext.NbExt(); i++) best = fmin(best, sqrt(ext.SquareDistance(i)));
+    }
+    BRepExtrema_DistShapeShape dss(v, c.e);
+    printf("%-22s pt(%.3g,%.3g,%.3g)  ExtPC: NbExt=%d dist=%-10.6g %s | DistShapeShape=%-10.6g | truth=%.6g\n",
+           c.n, c.p.X(), c.p.Y(), c.p.Z(), ext.IsDone() ? ext.NbExt() : -1, best,
+           (ext.IsDone() && ext.NbExt() >= 1 && fabs(best - c.truth) < 1e-4) ? "ok " : "BAD/none",
+           dss.IsDone() ? dss.Value() : -1.0, c.truth);
+  }
+  return 0;
+}

--- a/Scripts/repro/539-nearest-point-on-curve/periodic-and-types.mm
+++ b/Scripts/repro/539-nearest-point-on-curve/periodic-and-types.mm
@@ -1,0 +1,131 @@
+// #539 probe 2: (1) can Project return an out-of-domain periodic representative when an
+// in-domain one exists? (2) which curve types take the range-ignoring analytic path?
+// (3) does the Edge path (GeomAPI, ranged) report a maximum as "nearest"?
+#include <cstdio>
+#include <cmath>
+#include <Geom_Line.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_Parabola.hxx>
+#include <Geom_Hyperbola.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_OffsetCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <GeomAPI_PointsToBSpline.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <ShapeAnalysis_Curve.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRep_Tool.hxx>
+#include <TopoDS_Edge.hxx>
+#include <gp_Ax2.hxx>
+
+static void line1(const char* tag, const Handle(Geom_Curve)& c, const gp_Pnt& p) {
+  ShapeAnalysis_Curve sac;
+  gp_Pnt proj; double param = -999;
+  double d = sac.Project(c, p, 1e-6, proj, param, true);
+  double f = c->FirstParameter(), l = c->LastParameter();
+  double cl = param < f ? f : (param > l ? l : param);
+  gp_Pnt pc = c->Value(cl);
+  // truth
+  const int N = 1000001; double best = 1e300, bestT = f;
+  for (int i = 0; i < N; i++) {
+    double t = f + (l - f) * i / (N - 1);
+    double dd = p.Distance(c->Value(t));
+    if (dd < best) { best = dd; bestT = t; }
+  }
+  printf("  %-26s domain[%.4g,%.4g] raw(param=%.6g dist=%.6g) clamped(param=%.6g dist=%.6g) truth(param=%.6g dist=%.6g)%s\n",
+         tag, f, l, param, d, cl, p.Distance(pc), bestT, best,
+         fabs(p.Distance(pc) - best) < 1e-6 ? "" : "   <-- CLAMP WRONG");
+}
+
+int main() {
+  printf("=== 1. periodic wrap: does Project ever return an out-of-domain representative\n");
+  printf("       when an in-domain one exists? ===\n");
+  {
+    Handle(Geom_Circle) circ = new Geom_Circle(gp_Ax2(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 5);
+    // domain straddling the seam negatively: [-1, 1]
+    Handle(Geom_Curve) arc = new Geom_TrimmedCurve(circ, -1.0, 1.0);
+    printf("  arc trimmed [-1, 1] (IsPeriodic=%d)\n", (int)arc->IsPeriodic());
+    for (double ang : {6.0, 5.5, 0.5, 2.0, 3.2}) {
+      char tag[80]; snprintf(tag, sizeof tag, "query angle %.2f", ang);
+      line1(tag, arc, gp_Pnt(6*cos(ang), 6*sin(ang), 0));
+    }
+    // domain wholly beyond one period: [7, 9]  (== angles 0.717 .. 2.717)
+    Handle(Geom_Curve) arc2 = new Geom_TrimmedCurve(circ, 7.0, 9.0);
+    printf("  arc trimmed [7, 9]\n");
+    for (double ang : {1.5, 0.717, 2.717, 4.5, 6.0}) {
+      char tag[80]; snprintf(tag, sizeof tag, "query angle %.2f", ang);
+      line1(tag, arc2, gp_Pnt(6*cos(ang), 6*sin(ang), 0));
+    }
+  }
+
+  printf("\n=== 2. which curve types ignore the trim range? ===\n");
+  {
+    gp_Ax2 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
+    struct Case { const char* name; Handle(Geom_Curve) basis; double a, b; gp_Pnt q; };
+    Handle(Geom_Curve) bez;
+    {
+      TColgp_Array1OfPnt poles(1, 4);
+      poles.SetValue(1, gp_Pnt(0,0,0)); poles.SetValue(2, gp_Pnt(1,3,0));
+      poles.SetValue(3, gp_Pnt(4,3,0)); poles.SetValue(4, gp_Pnt(6,0,0));
+      bez = new Geom_BezierCurve(poles);
+    }
+    TColgp_Array1OfPnt pts(1, 5);
+    pts.SetValue(1, gp_Pnt(0,0,0)); pts.SetValue(2, gp_Pnt(1,2,0));
+    pts.SetValue(3, gp_Pnt(3,3,0)); pts.SetValue(4, gp_Pnt(5,1,0));
+    pts.SetValue(5, gp_Pnt(7,0,0));
+    Handle(Geom_Curve) bspl = GeomAPI_PointsToBSpline(pts).Curve();
+
+    Case cases[] = {
+      {"line [3,8]",      new Geom_Line(gp_Pnt(0,0,0), gp_Dir(1,0,0)), 3, 8,            gp_Pnt(100, 0, 0)},
+      {"circle [0,pi]",   new Geom_Circle(ax, 5),                      0, M_PI,         gp_Pnt(0, -6, 0)},
+      {"ellipse [0,pi]",  new Geom_Ellipse(ax, 8, 4),                  0, M_PI,         gp_Pnt(0, -6, 0)},
+      {"parabola [0,2]",  new Geom_Parabola(ax, 2.0),                  0, 2,            gp_Pnt(20, 0, 0)},
+      {"hyperbola [0,1]", new Geom_Hyperbola(ax, 3, 2),                0, 1,            gp_Pnt(30, 0, 0)},
+      {"bezier [.4,.6]",  bez,                                         0.4, 0.6,        gp_Pnt(6, 0, 0)},
+      {"bspline [.4,.6]", bspl,                                        0.4, 0.6,        gp_Pnt(7, 0, 0)},
+    };
+    for (auto& c : cases) {
+      Handle(Geom_Curve) t = new Geom_TrimmedCurve(Handle(Geom_BoundedCurve)::DownCast(c.basis).IsNull()
+                                                   ? c.basis : c.basis, c.a, c.b);
+      GeomAdaptor_Curve ad(t);
+      char tag[80]; snprintf(tag, sizeof tag, "%s", c.name);
+      line1(tag, t, c.q);
+    }
+    // offset curve over a trimmed line
+    Handle(Geom_Curve) baseSeg = new Geom_TrimmedCurve(new Geom_Line(gp_Pnt(0,0,0), gp_Dir(1,0,0)), 3, 8);
+    Handle(Geom_Curve) off = new Geom_OffsetCurve(baseSeg, 2.0, gp_Dir(0,0,1));
+    line1("offset(line) [3,8]", off, gp_Pnt(100, 0, 0));
+  }
+
+  printf("\n=== 3. Edge path (GeomAPI ranged): does it report a maximum as nearest? ===\n");
+  {
+    Handle(Geom_Circle) circ = new Geom_Circle(gp_Ax2(gp_Pnt(0,0,0), gp_Dir(0,0,1)), 5);
+    TopoDS_Edge e = BRepBuilderAPI_MakeEdge(circ, 0.0, M_PI);
+    double first, last;
+    Handle(Geom_Curve) c = BRep_Tool::Curve(e, first, last);
+    printf("  half-circle edge, BRep_Tool first=%.4g last=%.4g\n", first, last);
+    for (gp_Pnt p : {gp_Pnt(0,-6,0), gp_Pnt(0,6,0), gp_Pnt(0,-1,0)}) {
+      GeomAPI_ProjectPointOnCurve proj(p, c, first, last);
+      double truthBest = 1e300, truthT = first;
+      for (int i = 0; i <= 1000000; i++) {
+        double t = first + (last - first) * i / 1000000.0;
+        double d = p.Distance(c->Value(t));
+        if (d < truthBest) { truthBest = d; truthT = t; }
+      }
+      if (proj.NbPoints() == 0) {
+        printf("    (%.4g,%.4g,%.4g): NbPoints=0 -> isValid=false;   truth param=%.6g dist=%.6g\n",
+               p.X(), p.Y(), p.Z(), truthT, truthBest);
+      } else {
+        printf("    (%.4g,%.4g,%.4g): NbPoints=%d param=%.6g dist=%.6g;   truth param=%.6g dist=%.6g%s\n",
+               p.X(), p.Y(), p.Z(), proj.NbPoints(), proj.LowerDistanceParameter(), proj.LowerDistance(),
+               truthT, truthBest,
+               fabs(proj.LowerDistance() - truthBest) < 1e-6 ? "" : "   <-- NOT the nearest");
+      }
+    }
+  }
+  printf("\ndone\n");
+  return 0;
+}

--- a/Scripts/repro/539-nearest-point-on-curve/sweep.mm
+++ b/Scripts/repro/539-nearest-point-on-curve/sweep.mm
@@ -1,0 +1,187 @@
+// #539 sweep: current Curve3D path (ShapeAnalysis_Curve::Project) vs current Edge path
+// (GeomAPI ranged) vs the proposed candidate-minimum, all against brute-force truth.
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <Geom_Line.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_Parabola.hxx>
+#include <Geom_Hyperbola.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_OffsetCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <GeomAPI_PointsToBSpline.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <ShapeAnalysis_Curve.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <Precision.hxx>
+#include <gp_Ax2.hxx>
+
+struct Ans { double param, dist; bool valid; };
+
+// --- current Curve3D path -------------------------------------------------
+static Ans currentCurve3D(const Handle(Geom_Curve)& c, const gp_Pnt& p) {
+  ShapeAnalysis_Curve sac; gp_Pnt proj; double param = 0;
+  double d = sac.Project(c, p, 1e-6, proj, param, true);
+  return {param, d, true};
+}
+
+// --- current Edge path ----------------------------------------------------
+static Ans currentEdge(const Handle(Geom_Curve)& c, const gp_Pnt& p) {
+  double f = c->FirstParameter(), l = c->LastParameter();
+  try {
+    GeomAPI_ProjectPointOnCurve proj(p, c, f, l);
+    if (proj.NbPoints() == 0) return {0, 0, false};
+    return {proj.LowerDistanceParameter(), proj.LowerDistance(), true};
+  } catch (...) { return {0, 0, false}; }
+}
+
+// --- proposed: candidate minimum over [f, l] ------------------------------
+// Mirrors what the bridge would do.
+static Ans proposed(const Handle(Geom_Curve)& c, const gp_Pnt& p, double preci) {
+  double f = c->FirstParameter(), l = c->LastParameter();
+  bool fFinite = !Precision::IsInfinite(f), lFinite = !Precision::IsInfinite(l);
+
+  double bestT = 0, bestD = RealLast();
+  bool have = false;
+  auto consider = [&](double t) {
+    if (fFinite && t < f) return;
+    if (lFinite && t > l) return;
+    gp_Pnt pt;
+    try { pt = c->Value(t); } catch (...) { return; }
+    double d = p.Distance(pt);
+    if (d < bestD) { bestD = d; bestT = t; have = true; }
+  };
+
+  // 1. whatever ShapeAnalysis_Curve found, if it landed inside the domain
+  ShapeAnalysis_Curve sac; gp_Pnt sproj; double sparam = 0;
+  double sdist = sac.Project(c, p, preci, sproj, sparam, true);
+  consider(sparam);
+
+  // 2. every extremum GeomAPI finds inside the domain
+  try {
+    GeomAPI_ProjectPointOnCurve pc(p, c, f, l);
+    for (int i = 1; i <= pc.NbPoints(); i++) consider(pc.Parameter(i));
+  } catch (...) {}
+
+  // 3. the domain's own ends, where they are finite
+  if (fFinite) consider(f);
+  if (lFinite) consider(l);
+
+  if (!have) return {sparam, sdist, true};   // unbounded and no extremum: keep the old answer
+  return {bestT, bestD, true};
+}
+
+// --- truth ----------------------------------------------------------------
+static Ans truth(const Handle(Geom_Curve)& c, const gp_Pnt& p) {
+  double f = c->FirstParameter(), l = c->LastParameter();
+  if (Precision::IsInfinite(f) || Precision::IsInfinite(l)) return {0, 0, false};
+  const int N = 400001; double best = RealLast(), bestT = f;
+  for (int i = 0; i < N; i++) {
+    double t = f + (l - f) * i / (N - 1);
+    double d = p.Distance(c->Value(t));
+    if (d < best) { best = d; bestT = t; }
+  }
+  // polish
+  double step = (l - f) / (N - 1);
+  for (int it = 0; it < 60; it++) {
+    double a = fmax(f, bestT - step), b = fmin(l, bestT + step);
+    for (int i = 0; i <= 100; i++) {
+      double t = a + (b - a) * i / 100.0;
+      double d = p.Distance(c->Value(t));
+      if (d < best) { best = d; bestT = t; }
+    }
+    step *= 0.3;
+  }
+  return {bestT, best, true};
+}
+
+static int nCur3D = 0, nEdge = 0, nProp = 0, nTot = 0;
+
+static void run(const std::string& name, const Handle(Geom_Curve)& c, const std::vector<gp_Pnt>& qs) {
+  printf("\n%s   domain [%.6g, %.6g]\n", name.c_str(), c->FirstParameter(), c->LastParameter());
+  for (auto& p : qs) {
+    Ans a = currentCurve3D(c, p), b = currentEdge(c, p), d = proposed(c, p, 1e-6), t = truth(c, p);
+    if (!t.valid) { printf("  (%.3g,%.3g,%.3g) unbounded, truth skipped\n", p.X(), p.Y(), p.Z()); continue; }
+    nTot++;
+    bool okA = fabs(a.dist - t.dist) <= 1e-6 * (1 + t.dist);
+    bool okB = b.valid && fabs(b.dist - t.dist) <= 1e-6 * (1 + t.dist);
+    bool okD = fabs(d.dist - t.dist) <= 1e-6 * (1 + t.dist);
+    if (okA) nCur3D++;
+    if (okB) nEdge++;
+    if (okD) nProp++;
+    printf("  (%7.3g,%7.3g,%7.3g) truth %10.6g | Curve3D %10.6g %s | Edge %10s %s | proposed %10.6g %s\n",
+           p.X(), p.Y(), p.Z(), t.dist,
+           a.dist, okA ? "ok " : "BAD",
+           b.valid ? (std::to_string(b.dist).substr(0,10)).c_str() : "nil",
+           okB ? "ok " : (b.valid ? "BAD" : "nil"),
+           d.dist, okD ? "ok " : "BAD");
+  }
+}
+
+int main() {
+  gp_Ax2 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
+  Handle(Geom_Line) line = new Geom_Line(gp_Pnt(0,0,0), gp_Dir(1,0,0));
+  Handle(Geom_Circle) circ = new Geom_Circle(ax, 5);
+
+  TColgp_Array1OfPnt pts(1, 5);
+  pts.SetValue(1, gp_Pnt(0,0,0)); pts.SetValue(2, gp_Pnt(1,2,0));
+  pts.SetValue(3, gp_Pnt(3,3,0)); pts.SetValue(4, gp_Pnt(5,1,0));
+  pts.SetValue(5, gp_Pnt(7,0,0));
+  Handle(Geom_BSplineCurve) bspl = GeomAPI_PointsToBSpline(pts).Curve();
+
+  TColgp_Array1OfPnt poles(1, 4);
+  poles.SetValue(1, gp_Pnt(0,0,0)); poles.SetValue(2, gp_Pnt(1,3,0));
+  poles.SetValue(3, gp_Pnt(4,3,0)); poles.SetValue(4, gp_Pnt(6,0,0));
+  Handle(Geom_BezierCurve) bez = new Geom_BezierCurve(poles);
+
+  run("trimmed line [3,8]", new Geom_TrimmedCurve(line, 3, 8),
+      {gp_Pnt(100,0,0), gp_Pnt(0,0,0), gp_Pnt(5,2,0), gp_Pnt(-50,3,0), gp_Pnt(3,4,0), gp_Pnt(8,-1,0), gp_Pnt(8.001,0,0)});
+
+  run("half arc [0,pi] r=5", new Geom_TrimmedCurve(circ, 0, M_PI),
+      {gp_Pnt(0,-6,0), gp_Pnt(0,6,0), gp_Pnt(0,0,0), gp_Pnt(6,0,0), gp_Pnt(-6,0,0), gp_Pnt(3,-4,0), gp_Pnt(0,-1,0)});
+
+  run("quarter arc [0,pi/2] r=5", new Geom_TrimmedCurve(circ, 0, M_PI/2),
+      {gp_Pnt(0,-6,0), gp_Pnt(-6,0,0), gp_Pnt(4,4,0), gp_Pnt(0,0,0)});
+
+  run("seam arc [5.5,7.0] r=5", new Geom_TrimmedCurve(circ, 5.5, 7.0),
+      {gp_Pnt(6*cos(0.3), 6*sin(0.3), 0), gp_Pnt(6*cos(3.0), 6*sin(3.0), 0), gp_Pnt(0,0,0)});
+
+  run("full circle r=5", circ,
+      {gp_Pnt(0,0,0), gp_Pnt(6,0,0), gp_Pnt(0,-9,0), gp_Pnt(0,0,4)});
+
+  run("ellipse arc [0,pi] a=8 b=4", new Geom_TrimmedCurve(new Geom_Ellipse(ax, 8, 4), 0, M_PI),
+      {gp_Pnt(0,-6,0), gp_Pnt(0,6,0), gp_Pnt(9,0,0), gp_Pnt(0,0,0)});
+
+  run("parabola [0,2] f=2", new Geom_TrimmedCurve(new Geom_Parabola(ax, 2.0), 0, 2),
+      {gp_Pnt(20,0,0), gp_Pnt(0,3,0), gp_Pnt(-5,1,0), gp_Pnt(1,1,0)});
+
+  run("hyperbola [0,1] 3/2", new Geom_TrimmedCurve(new Geom_Hyperbola(ax, 3, 2), 0, 1),
+      {gp_Pnt(30,0,0), gp_Pnt(0,5,0), gp_Pnt(4,1,0)});
+
+  run("bezier [0.4,0.6]", new Geom_TrimmedCurve(bez, 0.4, 0.6),
+      {gp_Pnt(6,0,0), gp_Pnt(0,0,0), gp_Pnt(3,5,0)});
+
+  run("bspline full", bspl,
+      {gp_Pnt(7,0,0), gp_Pnt(3,5,0), gp_Pnt(-3,0,0)});
+
+  run("bspline [0.4,0.6]", new Geom_TrimmedCurve(bspl, 0.4*(bspl->LastParameter()-bspl->FirstParameter())+bspl->FirstParameter(),
+                                                  0.6*(bspl->LastParameter()-bspl->FirstParameter())+bspl->FirstParameter()),
+      {gp_Pnt(7,0,0), gp_Pnt(0,0,0), gp_Pnt(3,5,0)});
+
+  run("offset(trimmed line) [3,8] d=2",
+      new Geom_OffsetCurve(new Geom_TrimmedCurve(line, 3, 8), 2.0, gp_Dir(0,0,1)),
+      {gp_Pnt(100,0,0), gp_Pnt(0,0,0), gp_Pnt(5,5,0)});
+
+  run("offset(arc) [0,pi] d=1",
+      new Geom_OffsetCurve(new Geom_TrimmedCurve(circ, 0, M_PI), 1.0, gp_Dir(0,0,1)),
+      {gp_Pnt(0,-9,0), gp_Pnt(0,9,0), gp_Pnt(0,0,0)});
+
+  printf("\n=========================================================\n");
+  printf("correct distances: Curve3D(now) %d/%d   Edge(now) %d/%d   proposed %d/%d\n",
+         nCur3D, nTot, nEdge, nTot, nProp, nTot);
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -349,8 +349,11 @@
 //                                        (NOT OCCTSurfacePlateThrough; see GeomPlate)
 // GeomAPI_ProjectPointOnCurve         → OCCTCurve3DNearestParameter, OCCTExtremaLocateOnCurve,
 //                                       OCCTExtremaPointCurve, OCCTProjOnCurve*,
-//                                       OCCTEdgeProjectPoint
-//                                       (NOT OCCTCurve3DProjectPoint; see ShapeAnalysis_Curve)
+//                                       OCCTEdgeProjectPoint, OCCTCurve3DProjectPoint
+//                                       (the last two only as one of the three candidate sources
+//                                       occtNearestPointOnCurveRange takes a minimum over; see
+//                                       ShapeAnalysis_Curve for the other, and #539 for why
+//                                       neither class answers correctly on its own)
 // GeomAPI_ProjectPointOnSurf          → OCCTSurfaceProjectPoint, OCCTFaceProject*
 //
 // --- GeomConvert ---
@@ -476,7 +479,10 @@
 // --- ShapeAnalysis ---
 // ShapeAnalysis_Curve                 → OCCTCurve3DProjectPoint, OCCTCurve3DValidateRange,
 //                                       OCCTCurve3DGetSamplePoints3D, OCCTCurve3DIsClosedWithPreci,
-//                                       OCCTCurve3DIsPeriodicSA
+//                                       OCCTCurve3DIsPeriodicSA, OCCTEdgeProjectPoint
+//                                       (the two projection entry points reach ::Project through
+//                                       occtNearestPointOnCurveRange, which does not trust its
+//                                       answer alone; see GeomAPI_ProjectPointOnCurve)
 // ShapeAnalysis_FreeBounds            → OCCTShapeFreeBounds, OCCTShapeFreeBoundsClosedCount,
 //                                       OCCTShapeFreeBoundsClosed, OCCTShapeFreeBoundsOpen
 // ShapeAnalysis_FreeBoundsProperties  → OCCTFreeBoundsProps* (one family since #504; the stateless
@@ -2942,12 +2948,14 @@ int32_t OCCTFaceProjectPointAll(OCCTFaceRef face,
 /// Projection result for point-on-curve
 typedef struct {
     double px, py, pz;   // closest 3D point on curve
-    double parameter;     // curve parameter
+    double parameter;     // curve parameter, always within the edge's own range
     double distance;      // distance from original point
-    bool isValid;
+    bool isValid;         // false only for an edge with no 3D curve
 } OCCTCurveProjectionResult;
 
-/// Project point onto edge curve (closest point)
+/// Project point onto edge curve, giving the closest point over the edge's own parameter range.
+/// Where the point has no perpendicular foot on the edge, the closest point is one of its ends
+/// (#539). Shares OCCTCurve3DProjectPoint's implementation.
 OCCTCurveProjectionResult OCCTEdgeProjectPoint(OCCTEdgeRef edge,
                                                 double px, double py, double pz);
 
@@ -6627,11 +6635,13 @@ OCCTSurfaceUVResult OCCTSurfaceNextValueOfUV(OCCTSurfaceRef surface,
 /// Curve point projection result
 typedef struct {
     double distance;            // Distance from original point to projection
-    double parameter;           // Parameter on curve at closest point
+    double parameter;           // Parameter on curve at closest point, always within its domain
     double projX, projY, projZ; // Projected point coordinates
 } OCCTCurveProjectResult;
 
-/// Project a point onto a 3D curve.
+/// Project a point onto a 3D curve, giving the closest point over the curve's own domain.
+/// Where the point has no perpendicular foot on the curve, the closest point is one of its ends
+/// (#539). Shares OCCTEdgeProjectPoint's implementation.
 /// @param curve Curve to project onto
 /// @param px,py,pz Point to project
 /// @param precision Projection precision

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1238,15 +1238,24 @@ OCCTCurve3DRef OCCTCurve3DJoinCurves(const OCCTCurve3DRef* curves, int32_t count
 // MARK: - Curve3D Projection / Validate / Sample (v0.49)
 // --- ShapeAnalysis_Curve expansion ---
 
+// The nearest point over the curve's own domain, not over its basis curve (#539). Before, this was
+// a bare ShapeAnalysis_Curve::Project, which on a segment trimmed to [3, 8] reported (100, 0, 0) at
+// parameter 100, distance 0 -- so a `distance < tolerance` proximity test read a point 92 units
+// away as lying on the curve. See occtNearestPointOnCurveRange for what each of its three candidate
+// sources contributes and why none of them suffices alone.
 OCCTCurveProjectResult OCCTCurve3DProjectPoint(OCCTCurve3DRef curve,
     double px, double py, double pz, double precision) {
     OCCTCurveProjectResult result = {};
     if (!curve || curve->curve.IsNull()) return result;
     try {
-        ShapeAnalysis_Curve sac;
         gp_Pnt proj;
-        double param;
-        double dist = sac.Project(curve->curve, gp_Pnt(px, py, pz), precision, proj, param);
+        double param = 0.0, dist = 0.0;
+        if (!occtNearestPointOnCurveRange(curve->curve, gp_Pnt(px, py, pz),
+                                          curve->curve->FirstParameter(),
+                                          curve->curve->LastParameter(),
+                                          precision, &proj, &param, &dist)) {
+            return result;
+        }
         result.distance = dist;
         result.parameter = param;
         result.projX = proj.X();

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1208,6 +1208,123 @@ inline bool occtCurveCurvatureIsInvertible(double curvature) {
         && std::abs(curvature) > occtLocalPropsResolution();
 }
 
+// === #539: the nearest point on a curve, over the range the caller actually has ===
+//
+// For every bridge entry point that promises the CLOSEST point on a bounded curve, rather than the
+// closest of whatever an OCCT search happened to find. No single OCCT call answers this correctly,
+// which is why the two entry points that asked it had picked one each and were wrong in different
+// ways:
+//
+//   ShapeAnalysis_Curve::Project answers on any curve, but on an analytic basis (line, circle,
+//     ellipse) it solves on the basis curve and reports a parameter outside [first, last] as though
+//     it were on the curve. A segment trimmed to [3, 8] calls (100, 0, 0) distance 0; a point on
+//     the full circle but off the arc reads as distance 0 too. Passing the range does not help --
+//     the 7-argument overload documents itself as EXTENDING the range, and measured identically.
+//     Its AdjustToEnds flag, which reads like it might already cover this, changed no measured
+//     answer either way.
+//
+//   GeomAPI_ProjectPointOnCurve honours the range, but returns extrema, not minima: on a half
+//     circle the only extremum in range can be the FAR side, reported as LowerDistance (11 where
+//     the truth is 7.81), and it finds nothing at all whenever the nearest point is an end.
+//
+//   The ends themselves are the answer whenever the nearest point is not a perpendicular foot --
+//     the ordinary case for a point beyond a trimmed curve, and the one neither call covers.
+//
+// Taking the minimum over all three is correct on all 51 curve/point combinations measured for
+// #539 (line, circle, ellipse, parabola, hyperbola, Bezier, BSpline and offset curves, trimmed and
+// not), where ShapeAnalysis_Curve alone was right on 37 and GeomAPI alone on 25. The two it fixes
+// beyond the trimmed-range defect the issue named: a parabola or hyperbola whose only in-range
+// extremum is a MAXIMUM (both calls answered 20 and 27 where the truth was 19.6 and 25.5), and any
+// arc queried from outside its own span.
+//
+// Periodic bases need no special handling here, and deliberately get none. Geom_TrimmedCurve
+// normalises its own domain (trimming a circle to [-1, 1] reports [5.28, 7.28]) and Project returns
+// the periodic representative nearest that domain, so a parameter landing outside it is genuinely
+// outside the curve -- verified over ten seam-crossing and beyond-one-period cases, every one of
+// which the plain clamp below answered exactly.
+//
+// `first`/`last` are passed in rather than read off the curve because the two callers disagree
+// about where the range lives: a Curve3D carries its own, while an edge's range comes from
+// BRep_Tool::Curve and usually bounds an unbounded basis curve.
+//
+// Returns false only when there is nothing to answer with -- a null curve, or a curve on which
+// every candidate failed to evaluate. An unbounded curve with no extremum keeps the
+// ShapeAnalysis_Curve answer, so callers that always answered still always answer.
+
+#include <ShapeAnalysis_Curve.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+
+inline bool occtNearestPointOnCurveRange(const occ::handle<Geom_Curve>& curve, const gp_Pnt& point,
+                                         double first, double last, double precision,
+                                         gp_Pnt* outPoint, double* outParameter,
+                                         double* outDistance) {
+    if (curve.IsNull()) return false;
+
+    const bool firstFinite = !Precision::IsInfinite(first);
+    const bool lastFinite = !Precision::IsInfinite(last);
+
+    double bestParam = 0.0, bestDistance = RealLast();
+    gp_Pnt bestPoint;
+    bool found = false;
+
+    // A candidate parameter counts only if it lies in the range AND the curve can be evaluated
+    // there; everything else about it is decided by the distance it produces.
+    auto consider = [&](double param) {
+        if (firstFinite && param < first) return;
+        if (lastFinite && param > last) return;
+        gp_Pnt candidate;
+        try {
+            candidate = curve->Value(param);
+        } catch (...) {
+            return;
+        }
+        double distance = point.Distance(candidate);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestParam = param;
+            bestPoint = candidate;
+            found = true;
+        }
+    };
+
+    // 1. ShapeAnalysis_Curve's answer, kept when it landed inside the range.
+    gp_Pnt analysisPoint;
+    double analysisParam = 0.0, analysisDistance = RealLast();
+    bool haveAnalysis = false;
+    try {
+        ShapeAnalysis_Curve analyzer;
+        analysisDistance = analyzer.Project(curve, point, precision, analysisPoint, analysisParam);
+        haveAnalysis = true;
+        consider(analysisParam);
+    } catch (...) {
+        // Leave it to the other two sources.
+    }
+
+    // 2. Every extremum inside the range, since the nearest one is not always the first.
+    try {
+        GeomAPI_ProjectPointOnCurve projector(point, curve, first, last);
+        for (int i = 1; i <= projector.NbPoints(); i++) consider(projector.Parameter(i));
+    } catch (...) {
+        // Same.
+    }
+
+    // 3. The ends, where they are real parameters rather than OCCT's infinity sentinel.
+    if (firstFinite) consider(first);
+    if (lastFinite) consider(last);
+
+    if (!found) {
+        if (!haveAnalysis) return false;
+        bestParam = analysisParam;
+        bestDistance = analysisDistance;
+        bestPoint = analysisPoint;
+    }
+
+    if (outPoint) *outPoint = bestPoint;
+    if (outParameter) *outParameter = bestParam;
+    if (outDistance) *outDistance = bestDistance;
+    return true;
+}
+
 // === #496: the drilling preconditions, and one BRepFeat_MakeCylindricalHole skeleton ===
 //
 // OCCTSwift drills round holes two ways, and the audit read the older one as a crude

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -555,6 +555,13 @@ int32_t OCCTFaceProjectPointAll(OCCTFaceRef face,
     }
 }
 
+// Shares OCCTCurve3DProjectPoint's nearest-point-on-a-range implementation since #539. The defect
+// here was the other half of that one: a bare GeomAPI_ProjectPointOnCurve honours the edge's range
+// but reports extrema rather than minima, so it answered 11 for the point (0, -6, 0) against a
+// half-circle edge whose nearest point is 7.81 away, and declined to answer at all -- isValid
+// false, surfacing as nil -- whenever the nearest point was an end rather than a perpendicular
+// foot, which is every point beyond the end of a straight edge. isValid now means what the header
+// says it means: false only for an edge with no 3D curve to project onto.
 OCCTCurveProjectionResult OCCTEdgeProjectPoint(OCCTEdgeRef edge,
                                                 double px, double py, double pz) {
     OCCTCurveProjectionResult result = {};
@@ -566,15 +573,15 @@ OCCTCurveProjectionResult OCCTEdgeProjectPoint(OCCTEdgeRef edge,
         Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, first, last);
         if (curve.IsNull()) return result;
 
-        GeomAPI_ProjectPointOnCurve proj(gp_Pnt(px, py, pz), curve, first, last);
-        if (proj.NbPoints() == 0) return result;
-
-        gp_Pnt nearest = proj.NearestPoint();
+        gp_Pnt nearest;
+        if (!occtNearestPointOnCurveRange(curve, gp_Pnt(px, py, pz), first, last,
+                                          Precision::Confusion(),
+                                          &nearest, &result.parameter, &result.distance)) {
+            return result;
+        }
         result.px = nearest.X();
         result.py = nearest.Y();
         result.pz = nearest.Z();
-        result.parameter = proj.LowerDistanceParameter();
-        result.distance = proj.LowerDistance();
         result.isValid = true;
         return result;
     } catch (...) {

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1017,9 +1017,29 @@ extension Curve3D {
         public let point: SIMD3<Double>
     }
 
-    /// Project a point onto this curve to find the closest point.
+    /// Project a point onto this curve to find the closest point on it.
     ///
-    /// Uses ShapeAnalysis_Curve::Project.
+    /// The answer is always inside this curve's own ``domain``, and always the true nearest point:
+    /// where the point has no perpendicular foot on the curve — anything past the end of a trimmed
+    /// curve, or off to one side of an arc — the nearest point is an end, and that is what comes
+    /// back. Unlike ``nearestParameter(to:)``, this always answers.
+    ///
+    /// ```swift
+    /// let segment = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!
+    ///     .trimmed(from: 3, to: 8)!
+    ///
+    /// let inside = segment.projectPoint(SIMD3(5, 2, 0))
+    /// #expect(inside.parameter == 5)         // the perpendicular foot
+    /// #expect(inside.distance == 2)
+    ///
+    /// let beyond = segment.projectPoint(SIMD3(100, 0, 0))
+    /// #expect(beyond.parameter == 8)         // the end of the curve, not of its basis line
+    /// #expect(beyond.distance == 92)
+    /// ```
+    ///
+    /// Before #539 this projected onto the curve's *underlying basis* curve, so the point above came
+    /// back at parameter 100, distance 0 — a `distance < tolerance` proximity test read a point 92
+    /// units away as lying on the curve.
     ///
     /// - Parameters:
     ///   - point: 3D point to project
@@ -1036,8 +1056,17 @@ extension Curve3D {
 
     /// Shortest distance from a 3D point to this curve.
     ///
-    /// Convenience one-liner around `projectPoint(_:)` when you only need the
-    /// scalar distance and don't care about the projected point or parameter.
+    /// Convenience one-liner around ``projectPoint(_:precision:)`` when you only need the scalar
+    /// distance and don't care about the projected point or parameter, so it measures to the same
+    /// nearest point: over this curve's own ``domain``, ends included.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    ///     .trimmed(from: 0, to: .pi)!
+    ///
+    /// // On the full circle, but not on this half of it: 4.47 from the arc's start.
+    /// #expect(abs(arc.distance(to: SIMD3(3, -4, 0)) - 4.47214) < 1e-5)
+    /// ```
     public func distance(to point: SIMD3<Double>, precision: Double = 1e-6) -> Double {
         projectPoint(point, precision: precision).distance
     }

--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -143,7 +143,25 @@ public final class Edge: @unchecked Sendable {
         return torsion
     }
 
-    /// Project a 3D point onto this edge's curve (closest point)
+    /// Project a 3D point onto this edge's curve, giving the closest point on the edge.
+    ///
+    /// The answer is always inside the edge's own parameter range (``parameterBounds``), and always
+    /// the true nearest point: where the point has no perpendicular foot on the edge, the nearest
+    /// point is one of its ends, and that is what comes back.
+    ///
+    /// ```swift
+    /// let edge = Wire.line(from: SIMD3(3, 0, 0), to: SIMD3(8, 0, 0))!.edges()[0]
+    ///
+    /// let beyond = edge.project(point: SIMD3(100, 0, 0))!
+    /// #expect(beyond.point == SIMD3(8, 0, 0))   // the end of the edge
+    /// #expect(beyond.distance == 92)
+    /// ```
+    ///
+    /// Before #539 this returned `nil` for that point, because the underlying extrema search finds
+    /// no perpendicular foot there, and on an arc it could report the *far* side of the arc as the
+    /// nearest point.
+    ///
+    /// - Returns: The closest point, or nil for an edge with no 3D curve to project onto.
     public func project(point: SIMD3<Double>) -> CurveProjection? {
         let result = OCCTEdgeProjectPoint(handle, point.x, point.y, point.z)
         guard result.isValid else { return nil }
@@ -154,8 +172,11 @@ public final class Edge: @unchecked Sendable {
         )
     }
 
-    /// Shortest distance from a 3D point to this edge. Returns nil if the
-    /// projection fails (e.g. degenerate edge).
+    /// Shortest distance from a 3D point to this edge.
+    ///
+    /// A one-liner over ``project(point:)``, so it measures to the same nearest point: over the
+    /// edge's own parameter range, ends included. Returns nil only for an edge with no 3D curve
+    /// (typically a pcurve-only edge from a loft or sweep before `BuildCurves3d`).
     public func distance(to point: SIMD3<Double>) -> Double? {
         project(point: point)?.distance
     }

--- a/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
+++ b/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
@@ -74,10 +74,15 @@ struct Issue500Curve3DNearestParameterTests {
         }
     }
 
-    /// `projectPoint(_:precision:)` is deliberately *not* part of this family: it runs
-    /// `ShapeAnalysis_Curve::Project`, which adjusts to the curve's ends rather than reporting that
-    /// there is no projection, and so always answers. Pinned here so a later pass does not
-    /// "unify" two entry points that genuinely compute different things.
+    /// `projectPoint(_:precision:)` is deliberately *not* part of this family, and asks a different
+    /// question: the nearest point on the curve, which exists for every point, rather than the
+    /// nearest *perpendicular foot*, which does not. Pinned here so a later pass does not "unify"
+    /// two entry points that genuinely compute different things.
+    ///
+    /// When #500 shipped, its answer here was parameter 100, distance 0 — it projected onto the
+    /// curve's underlying unbounded line, recorded as-is rather than asserted correct. #539 fixed
+    /// that: the answer is now the curve's own end. The contracts still differ, but only in whether
+    /// a point with no perpendicular foot gets an answer, not in whether the answer is true.
     @Test("projectPoint runs a different algorithm and keeps its own contract")
     func projectPointIsADifferentAlgorithm() throws {
         let curve = try #require(Self.trimmedSegment())
@@ -85,11 +90,9 @@ struct Issue500Curve3DNearestParameterTests {
 
         #expect(curve.nearestParameter(to: p) == nil)
 
-        // It answers where nearestParameter does not. Its answer is *not* clamped to [3, 8]:
-        // measured against the pinned kernel, it reports the point as lying on the curve's
-        // underlying unbounded line. Recorded as-is; see the note in the #500 PR.
+        // It answers where nearestParameter does not, with the end of the curve (#539).
         let projected = curve.projectPoint(p)
-        #expect(projected.parameter == 100)
-        #expect(projected.distance == 0)
+        #expect(projected.parameter == 8)
+        #expect(projected.distance == 92)
     }
 }

--- a/Tests/OCCTCurveTests/Issue539NearestPointOnCurveTests.swift
+++ b/Tests/OCCTCurveTests/Issue539NearestPointOnCurveTests.swift
@@ -1,0 +1,252 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// MARK: - #539: the closest point on the curve you actually have
+
+/// `Curve3D.projectPoint(_:precision:)` and `Edge.project(point:)` both promise the closest point,
+/// and neither delivered it. They had picked a different OCCT call each, and each call is wrong in
+/// its own way about a curve with ends:
+///
+/// - `ShapeAnalysis_Curve::Project`, behind the `Curve3D` side, solves on the *basis* curve for an
+///   analytic type and reports a parameter outside the domain as though it were on the curve. A
+///   segment trimmed to `[3, 8]` called `(100, 0, 0)` distance **0** — 92 units off the curve — and
+///   a point on the full circle but off an arc read as distance 0 too. Passing the range explicitly
+///   changed nothing: the 7-argument overload documents itself as *extending* the range.
+///
+/// - `GeomAPI_ProjectPointOnCurve`, behind the `Edge` side, honours the range but returns extrema
+///   rather than minima. On a half circle the only extremum in range can be the far side, reported
+///   as `LowerDistance`, and it finds nothing at all whenever the nearest point is an end — so a
+///   point beyond the end of a straight edge came back `nil`.
+///
+/// Both now take the minimum over three candidate sources: whatever `ShapeAnalysis_Curve` found if
+/// it landed inside the range, every extremum inside the range, and the ends themselves. Measured
+/// correct on all 51 curve/point combinations swept for #539, against a dense brute-force sample.
+///
+/// A `distance < tolerance` proximity test was the caller this broke: every case below used to read
+/// as "the point lies on the curve" or as no answer at all.
+@Suite("The nearest point is on the curve, not on its basis (#539)")
+struct Issue539NearestPointOnCurveTests {
+
+    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`. The basis is an
+    /// unbounded `Geom_Line`, which is what the old implementation answered about.
+    private static func trimmedSegment() -> Curve3D? {
+        Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
+    }
+
+    /// Half of a circle of radius 5 in the XY plane, domain `[0, pi]`.
+    private static func halfArc() -> Curve3D? {
+        Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)?.trimmed(from: 0, to: .pi)
+    }
+
+    // MARK: The trimmed-range defect the issue was filed on
+
+    @Test("A point past the end projects to the end, not onto the basis line")
+    func pastTheEndProjectsToTheEnd() throws {
+        let curve = try #require(Self.trimmedSegment())
+        #expect(curve.domain == 3...8)
+
+        // Was: parameter 100, distance 0.
+        let beyond = curve.projectPoint(SIMD3(100, 0, 0))
+        #expect(abs(beyond.parameter - 8) < 1e-9)
+        #expect(abs(beyond.distance - 92) < 1e-9)
+        #expect(simd_distance(beyond.point, SIMD3(8, 0, 0)) < 1e-9)
+
+        // Was: parameter 0, distance 0. Parameter 0 is not even inside this curve's domain.
+        let before = curve.projectPoint(.zero)
+        #expect(abs(before.parameter - 3) < 1e-9)
+        #expect(abs(before.distance - 3) < 1e-9)
+        #expect(simd_distance(before.point, SIMD3(3, 0, 0)) < 1e-9)
+
+        // Off to one side and past the start: the answer is the start point, not the perpendicular
+        // foot at parameter -50. Was: distance 3.
+        let offAxis = curve.projectPoint(SIMD3(-50, 3, 0))
+        #expect(abs(offAxis.parameter - 3) < 1e-9)
+        #expect(abs(offAxis.distance - (53 * 53 + 9).squareRoot()) < 1e-9)
+    }
+
+    /// The failure is not confined to points far away: a hair past the end used to read as exactly
+    /// on the curve, which is the reading a proximity test acts on.
+    @Test("A point just past the end is that far past it, not on the curve")
+    func justPastTheEnd() throws {
+        let curve = try #require(Self.trimmedSegment())
+        let projected = curve.projectPoint(SIMD3(8.001, 0, 0))
+        #expect(abs(projected.distance - 0.001) < 1e-9)   // was 0
+        #expect(abs(projected.parameter - 8) < 1e-9)
+    }
+
+    /// An arc has the same defect in a form that needs no trimming to a strange domain to hit: any
+    /// point on the underlying circle but outside the arc's own span read as distance 0.
+    @Test("A point on the circle but off the arc is not on the arc")
+    func onTheCircleButOffTheArc() throws {
+        let arc = try #require(Self.halfArc())
+
+        // (3, -4, 0) is exactly on the radius-5 circle, and exactly not on the upper half of it.
+        // Was: distance 1.6e-15, i.e. reported as lying on the arc.
+        let onCircle = arc.projectPoint(SIMD3(3, -4, 0))
+        // The nearest point on the arc is its start, (5, 0, 0): sqrt(2^2 + 4^2) = 4.47214.
+        #expect(abs(onCircle.distance - (2 * 2 + 4 * 4).squareRoot()) < 1e-6)
+        #expect(abs(onCircle.parameter) < 1e-6)
+
+        // Below the arc entirely: the nearest point is an end, 7.81 away. Was: distance 1, the
+        // distance to the far half of the circle.
+        let below = arc.projectPoint(SIMD3(0, -6, 0))
+        #expect(abs(below.distance - (25.0 + 36.0).squareRoot()) < 1e-6)        // 7.81025
+    }
+
+    // MARK: The in-range maximum, which no clamp would have fixed
+
+    /// On a parabola or hyperbola the one extremum inside the domain can be a *maximum*, so both
+    /// old implementations answered with the worst point in range rather than the best. Nothing
+    /// about the parameter is out of range here — this is why the fix takes a minimum over
+    /// candidates rather than clamping the parameter into the domain.
+    @Test("An in-range extremum that is a maximum does not win")
+    func inRangeMaximumDoesNotWin() throws {
+        // P(u) = (u^2/8, u, 0) over [0, 2]; from (20, 0, 0) the vertex at u=0 is a local maximum.
+        let parabola = try #require(Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1),
+                                                     focal: 2))
+        let arc = try #require(parabola.trimmed(from: 0, to: 2))
+        let projected = arc.projectPoint(SIMD3(20, 0, 0))
+        #expect(abs(projected.distance - 19.6023) < 1e-3)   // was 20, the distance to the vertex
+        #expect(abs(projected.parameter - 2) < 1e-6)
+
+        let hyperbola = try #require(Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
+                                                       majorRadius: 3, minorRadius: 2))
+        let branch = try #require(hyperbola.trimmed(from: 0, to: 1))
+        let far = branch.projectPoint(SIMD3(30, 0, 0))
+        #expect(abs(far.distance - 25.4794) < 1e-3)         // was 27
+    }
+
+    // MARK: What deliberately did not change
+
+    /// An ordinary projection onto a point that has a perpendicular foot inside the domain is the
+    /// case every pre-#539 test used, and it answers exactly as it did.
+    @Test("An ordinary in-range projection is unchanged")
+    func ordinaryProjectionUnchanged() throws {
+        let curve = try #require(Self.trimmedSegment())
+        let projected = curve.projectPoint(SIMD3(5, 2, 0))
+        #expect(abs(projected.parameter - 5) < 1e-9)
+        #expect(abs(projected.distance - 2) < 1e-9)
+        #expect(simd_distance(projected.point, SIMD3(5, 0, 0)) < 1e-9)
+
+        let arc = try #require(Self.halfArc())
+        let above = arc.projectPoint(SIMD3(0, 6, 0))
+        #expect(abs(above.distance - 1) < 1e-6)
+        #expect(abs(above.parameter - .pi / 2) < 1e-6)
+    }
+
+    /// A circle's centre has no perpendicular foot at all — `nearestParameter(to:)` reports `nil`
+    /// for it (#500). `projectPoint` still answers, and the radius it answers with was already
+    /// right, because the whole domain is in range.
+    @Test("A closed curve, and a point with no perpendicular foot, still answer")
+    func closedCurveStillAnswers() throws {
+        let circle = try #require(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5))
+        #expect(circle.nearestParameter(to: .zero) == nil)
+
+        let centre = circle.projectPoint(.zero)
+        #expect(abs(centre.distance - 5) < 1e-9)
+        #expect(abs(simd_length(centre.point) - 5) < 1e-9)
+
+        let outside = circle.projectPoint(SIMD3(6, 0, 0))
+        #expect(abs(outside.distance - 1) < 1e-9)
+    }
+
+    /// An unbounded curve has no ends to fall back on, and OCCT reports its domain as +/-2e100.
+    /// Those sentinels must not be evaluated as candidate parameters.
+    @Test("An unbounded curve projects as it always did")
+    func unboundedCurveUnchanged() throws {
+        let line = try #require(Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)))
+        let projected = line.projectPoint(SIMD3(100, 7, 0))
+        #expect(abs(projected.parameter - 100) < 1e-9)
+        #expect(abs(projected.distance - 7) < 1e-9)
+        #expect(simd_distance(projected.point, SIMD3(100, 0, 0)) < 1e-9)
+    }
+
+    /// `distance(to:)` is a one-liner over `projectPoint`, so it inherits the fix rather than
+    /// needing one of its own. Pinned because it is the spelling a proximity test reaches for.
+    @Test("Curve3D.distance inherits the corrected projection")
+    func curveDistanceInheritsTheFix() throws {
+        let curve = try #require(Self.trimmedSegment())
+        #expect(abs(curve.distance(to: SIMD3(100, 0, 0)) - 92) < 1e-9)   // was 0
+        #expect(abs(curve.distance(to: .zero) - 3) < 1e-9)               // was 0
+        #expect(abs(curve.distance(to: SIMD3(5, 2, 0)) - 2) < 1e-9)      // unchanged
+    }
+
+    // MARK: The Edge half, which had the same promise and the other defect
+
+    private static func straightEdge() throws -> Edge {
+        let wire = try #require(Wire.line(from: SIMD3(3, 0, 0), to: SIMD3(8, 0, 0)))
+        return try #require(wire.edges().first)
+    }
+
+    private static func arcEdge() throws -> Edge {
+        let wire = try #require(Wire.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi))
+        return try #require(wire.edges().first)
+    }
+
+    /// `Edge.project(point:)` used to return `nil` here — `isValid` false — because there is no
+    /// perpendicular foot. Its own documentation reserves `nil` for an edge with no 3D curve.
+    @Test("A point past the end of an edge gets the end, not nil")
+    func edgePastTheEndIsNotNil() throws {
+        let edge = try Self.straightEdge()
+
+        let beyond = try #require(edge.project(point: SIMD3(100, 0, 0)))
+        #expect(abs(beyond.distance - 92) < 1e-9)
+        #expect(simd_distance(beyond.point, SIMD3(8, 0, 0)) < 1e-9)
+
+        let before = try #require(edge.project(point: .zero))
+        #expect(abs(before.distance - 3) < 1e-9)
+        #expect(simd_distance(before.point, SIMD3(3, 0, 0)) < 1e-9)
+
+        // The one-liner over it stops returning nil for the same reason.
+        #expect(abs(try #require(edge.distance(to: SIMD3(100, 0, 0))) - 92) < 1e-9)
+    }
+
+    /// The extremum an edge-ranged `GeomAPI_ProjectPointOnCurve` finds on a half circle is the far
+    /// side of it, and it was reported as the nearest point.
+    @Test("An edge reports its nearest point, not its farthest extremum")
+    func edgeReportsNearestNotFarthest() throws {
+        let edge = try Self.arcEdge()
+
+        let below = try #require(edge.project(point: SIMD3(0, -6, 0)))
+        #expect(abs(below.distance - (25.0 + 36.0).squareRoot()) < 1e-6)   // 7.81025, was 11
+
+        let insideBelow = try #require(edge.project(point: SIMD3(0, -1, 0)))
+        #expect(abs(insideBelow.distance - (25.0 + 1.0).squareRoot()) < 1e-6)   // 5.09902, was 6
+
+        // Still right where it was right.
+        let above = try #require(edge.project(point: SIMD3(0, 6, 0)))
+        #expect(abs(above.distance - 1) < 1e-6)
+    }
+
+    /// The two entry points promise the same thing about the same geometry, so they answer the same
+    /// number. Before #539 they disagreed on every case above, in opposite directions.
+    @Test("Curve3D and Edge agree on the same geometry")
+    func curveAndEdgeAgree() throws {
+        let edge = try Self.arcEdge()
+        let arc = try #require(Self.halfArc())
+
+        for point in [SIMD3<Double>(0, -6, 0), SIMD3(0, 6, 0), SIMD3(3, -4, 0),
+                      SIMD3(0, -1, 0), SIMD3(6, 0, 0), .zero] {
+            let viaEdge = try #require(edge.project(point: point), "\(point)")
+            let viaCurve = arc.projectPoint(point)
+            #expect(abs(viaEdge.distance - viaCurve.distance) < 1e-6, "\(point)")
+            #expect(simd_distance(viaEdge.point, viaCurve.point) < 1e-6, "\(point)")
+        }
+    }
+
+    /// An edge with no 3D curve is the one case `nil` is still for. Nothing in this suite's
+    /// geometry produces one, so the contract is stated rather than exercised here; the closest
+    /// available check is that every edge that does have a curve now answers.
+    @Test("Every edge with a 3D curve answers")
+    func everyEdgeWithACurveAnswers() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let probe = SIMD3<Double>(100, 100, 100)
+        for edge in box.edges() {
+            let projected = edge.project(point: probe)
+            #expect(projected != nil)
+            if let projected { #expect(projected.distance > 0) }
+        }
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -624,7 +624,7 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `edge.parameterBounds` / `edge.curveType` | `BRep_Tool` / `GeomAdaptor_Curve` |
 | `edge.point(at:)` / `edge.tangent(at:)` / `edge.normal(at:)` | `GeomLProp_CLProps` |
 | `edge.curvature(at:)` / `edge.centerOfCurvature(at:)` / `edge.torsion(at:)` | `GeomLProp_CLProps` |
-| `edge.project(point:)` | `GeomAPI_ProjectPointOnCurve` |
+| `edge.project(point:)` / `edge.distance(to:)` — and `curve3d.projectPoint(_:precision:)` / `curve3d.distance(to:precision:)`, one shared implementation since #539 | `ShapeAnalysis_Curve::Project` + `GeomAPI_ProjectPointOnCurve`, minimised together with the range's ends |
 
 #### Shape Proximity (v0.18.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -333,7 +333,10 @@ pins the distinction, updated here to the corrected answer it recorded as-is.
 entry point documented as finding "the closest point on the edge" with the same defect: 11 for the
 half-circle query above, and `IsDone()` false for both trimmed-segment queries. It is left alone
 because fixing it means first deciding what its `solutionCount`, which is the extrema count it
-deliberately exposes, should say when the answer is an end. Filed as #580.
+deliberately exposes, should say when the answer is an end. Filed as #580 — with that decision
+measured rather than left open: `solutionCount` keeps its meaning (OCCT models the ends separately
+from the extrema, via `BRepExtrema_ExtPC::TrimmedSquareDistances`), the `nil` guard is what changes,
+and routing through this PR's shared helper scores 189/189 against the in-place repair's 188/189.
 
 New suite `Issue539NearestPointOnCurveTests` (`OCCTCurveTests`), 12 tests. Proved rather than
 assumed: reinstating the two original implementations fails 9 of the 12, and the 3 that still pass

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -283,6 +283,62 @@ aborted the test harness rather than failing. They compare `.count == 0` rather 
 returning 10 million points would print all 10 million (measured at over 5 GB while injecting a
 deliberate bug to confirm the suite catches it; #479 hit the same hazard at 880 MB).
 
+#### The closest point on a curve is now on the curve (#539)
+
+`Curve3D.projectPoint(_:precision:)`, `Curve3D.distance(to:precision:)`, `Edge.project(point:)` and
+`Edge.distance(to:)` all promise the closest point, and none of them delivered it. They had picked a
+different OCCT call each, and each call is wrong in its own way about a curve that has ends:
+
+| | `ShapeAnalysis_Curve::Project` (was behind `Curve3D`) | `GeomAPI_ProjectPointOnCurve`, ranged (was behind `Edge`) |
+|---|---|---|
+| segment trimmed to `[3, 8]`, point `(100, 0, 0)` | parameter 100, **distance 0** | no answer (`nil`) |
+| half circle r=5, point `(0, -6, 0)` | **distance 1** (the far half) | **distance 11** (the far side) |
+| point on the full circle, off the arc | **distance 1.6e-15** | **distance 10** |
+| parabola over `[0, 2]`, point `(20, 0, 0)` | **distance 20** (the vertex) | **distance 20** |
+
+Truth for those four rows: 92, 7.81, 4.47, 19.60. A `distance < tolerance` proximity test read the
+first three as "the point lies on the curve".
+
+Three distinct defects, not one. `ShapeAnalysis_Curve::Project` solves on the *basis* curve for an
+analytic type, so a parameter outside the domain comes back as though it were on the curve — passing
+the range does not help, the 7-argument overload documents itself as *extending* it, and its
+`AdjustToEnds` flag changed no measured answer either way. `GeomAPI_ProjectPointOnCurve` honours the
+range but returns extrema rather than minima, so the only extremum in range can be a maximum, and it
+finds nothing at all when the nearest point is an end. And on a parabola or hyperbola both answered
+with the worst point in range — the defect a parameter clamp, which is what the issue proposed,
+would not have touched.
+
+Both entry points now share one `occtNearestPointOnCurveRange`, which takes the minimum over three
+candidate sources: `ShapeAnalysis_Curve`'s answer where it landed inside the range, every extremum
+`GeomAPI` finds inside the range, and the range's own ends. Correct on all 51 curve/point
+combinations swept against a dense brute-force reference (line, circle, ellipse, parabola,
+hyperbola, Bezier, BSpline and offset curves, trimmed and not), where `ShapeAnalysis_Curve` alone
+was right on 37 and `GeomAPI` alone on 25. Periodic bases need no special handling and get none:
+`Geom_TrimmedCurve` normalises its own domain and `Project` returns the representative nearest it,
+verified over ten seam-crossing and beyond-one-period cases.
+
+**Behaviour changes for callers.** `Edge.project(point:)` and `Edge.distance(to:)` stop returning
+`nil` for a point with no perpendicular foot — every one of a box's twelve edges used to answer
+`nil` for a corner probe outside the box. `nil` now means what the documentation always said it
+meant: an edge with no 3D curve. Ordinary in-range projections, unbounded curves and closed curves
+are unchanged, which is why no pre-existing test moved: every one of them queried a point that has a
+perpendicular foot.
+
+`Curve3D.nearestParameter(to:)` (#500) is deliberately untouched and still reports `nil` for the
+points above. The two are different questions — the nearest point, which exists for every query
+point, versus the nearest perpendicular foot, which does not — and `Issue500Curve3DNearestParameterTests`
+pins the distinction, updated here to the corrected answer it recorded as-is.
+
+**Measured, not fixed.** `Shape.pointEdgeExtrema(point:edgeIndex:)` (`BRepExtrema_ExtPC`) is a third
+entry point documented as finding "the closest point on the edge" with the same defect: 11 for the
+half-circle query above, and `IsDone()` false for both trimmed-segment queries. It is left alone
+because fixing it means first deciding what its `solutionCount`, which is the extrema count it
+deliberately exposes, should say when the answer is an end. Filed as #580.
+
+New suite `Issue539NearestPointOnCurveTests` (`OCCTCurveTests`), 12 tests. Proved rather than
+assumed: reinstating the two original implementations fails 9 of the 12, and the 3 that still pass
+are exactly the three asserting what was meant to stay the same.
+
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 
 `OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -566,11 +566,13 @@ Projects a 3D point onto this curve to find the closest point.
 public func projectPoint(_ point: SIMD3<Double>, precision: Double = 1e-6) -> PointProjection
 ```
 
-Uses `ShapeAnalysis_Curve::Project`. Always returns a result (never `nil`); a non-zero `distance` indicates the query point was not on the curve.
+Always returns a result (never `nil`); a non-zero `distance` indicates the query point was not on the curve.
+
+The answer is always inside the curve's own `domain`, and always the true nearest point. Where the query point has no perpendicular foot on the curve — anything past the end of a trimmed curve, or off to one side of an arc — the nearest point is an end, and that is what comes back. Contrast [`nearestParameter(to:)`](Curve3D-Construction.md#nearestparameterto), which reports `nil` for exactly those points instead.
 
 - **Parameters:** `point` — 3D point to project; `precision` — projection precision (default `1e-6`).
 - **Returns:** `PointProjection` with distance, parameter, and closest curve point.
-- **OCCT:** `ShapeAnalysis_Curve::Project`.
+- **OCCT:** `ShapeAnalysis_Curve::Project` and `GeomAPI_ProjectPointOnCurve`, minimised together with the domain's ends — no one of the three is correct alone (#539).
 - **Example:**
   ```swift
   if let c = Curve3D.line(from: .zero, to: SIMD3(10, 0, 0)) {
@@ -578,7 +580,19 @@ Uses `ShapeAnalysis_Curve::Project`. Always returns a result (never `nil`); a no
       print(proj.point)     // ≈ SIMD3(5, 0, 0)
       print(proj.distance)  // ≈ 3.0
   }
+
+  // Past the end of a trimmed curve: the end, not the basis line.
+  if let seg = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8) {
+      let proj = seg.projectPoint(SIMD3(100, 0, 0))
+      print(proj.parameter)  // 8.0
+      print(proj.distance)   // 92.0
+  }
   ```
+
+> **Before #539** this projected onto the curve's *underlying basis* curve, so
+> the trimmed-segment case above reported parameter `100`, distance `0` — a `distance < tolerance`
+> proximity test read a point 92 units away as lying on the curve. A point on a full circle but
+> outside an arc's own span read as distance 0 for the same reason.
 
 ---
 
@@ -590,11 +604,11 @@ Returns the shortest distance from a 3D point to this curve.
 public func distance(to point: SIMD3<Double>, precision: Double = 1e-6) -> Double
 ```
 
-Convenience wrapper over `projectPoint(_:precision:)` when only the scalar distance is needed.
+Convenience wrapper over `projectPoint(_:precision:)` when only the scalar distance is needed, so it measures to the same nearest point: over the curve's own `domain`, ends included.
 
 - **Parameters:** `point` — query point; `precision` — projection precision (default `1e-6`).
 - **Returns:** Shortest distance from `point` to the curve.
-- **OCCT:** Delegates to `ShapeAnalysis_Curve::Project` via `projectPoint(_:precision:)`.
+- **OCCT:** Delegates to `projectPoint(_:precision:)`, and inherits its #539 fix.
 - **Example:**
   ```swift
   if let c = Curve3D.line(from: .zero, to: SIMD3(10, 0, 0)) {

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -485,9 +485,10 @@ public func nearestParameter(to point: SIMD3<Double>) -> Double?
   }
   ```
 
-Contrast [`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision), which runs a
-different OCCT algorithm (`ShapeAnalysis_Curve::Project`) that always answers, adjusting to the
-curve's ends rather than reporting that there is no projection.
+Contrast [`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision), which asks a
+different question and so always answers: the nearest point on the curve, which exists for every
+query point, rather than the nearest perpendicular foot, which does not. For the trimmed segment
+above it reports the curve's end, parameter `8` at distance `92` (#539).
 
 `closestParameter(to:)` is the deprecated spelling of this method. It returns `.nan` where this
 one returns `nil`; before #500 it returned `0`, which is not even inside the domain of a curve

--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -386,11 +386,11 @@ Projects a 3D point onto this edge's curve, returning the closest point.
 public func project(point: SIMD3<Double>) -> CurveProjection?
 ```
 
-Uses OCCT's `GeomAPI_ProjectPointOnCurve` bounded to the edge's parameter range, ensuring the projected point lies within the edge bounds.
+The answer is always inside the edge's own parameter range (`parameterBounds`), and always the true nearest point. Where the query point has no perpendicular foot on the edge, the nearest point is one of its ends, and that is what comes back.
 
 - **Parameters:** `point` — query point in 3D space.
-- **Returns:** `CurveProjection` with the closest point, its parameter, and the distance; or `nil` if the edge has no curve or projection fails.
-- **OCCT:** `BRep_Tool::Curve` + `GeomAPI_ProjectPointOnCurve`.
+- **Returns:** `CurveProjection` with the closest point, its parameter, and the distance; or `nil` only for an edge with no 3D curve to project onto.
+- **OCCT:** `BRep_Tool::Curve`, then `ShapeAnalysis_Curve::Project` and `GeomAPI_ProjectPointOnCurve` minimised together with the range's ends — no one of the three is correct alone (#539). Shares `Curve3D.projectPoint(_:precision:)`'s implementation.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!
@@ -401,23 +401,35 @@ Uses OCCT's `GeomAPI_ProjectPointOnCurve` bounded to the edge's parameter range,
           print(proj.distance)  // ≈ √3
       }
   }
+
+  // Past the end: the end of the edge, rather than nil.
+  let edge = Wire.line(from: SIMD3(3, 0, 0), to: SIMD3(8, 0, 0))!.edges()[0]
+  if let proj = edge.project(point: SIMD3(100, 0, 0)) {
+      print(proj.point)     // SIMD3(8, 0, 0)
+      print(proj.distance)  // 92.0
+  }
   ```
+
+> **Before #539** the bare `GeomAPI_ProjectPointOnCurve` behind this returned extrema
+> rather than minima, which cost it two ways: it returned `nil` whenever the nearest point was an
+> end rather than a perpendicular foot (the case above), and on an arc it could report the *far*
+> side as the nearest point — 11 for a query whose nearest point on a half circle is 7.81 away.
 
 ---
 
 ### `distance(to:)`
 
-The shortest distance from a 3D point to this edge. Returns `nil` if the projection fails.
+The shortest distance from a 3D point to this edge.
 
 ```swift
 public func distance(to point: SIMD3<Double>) -> Double?
 ```
 
-Pure-Swift convenience — delegates to `project(point:)?.distance`.
+Pure-Swift convenience — delegates to `project(point:)?.distance`, so it measures to the same nearest point: over the edge's own parameter range, ends included.
 
 - **Parameters:** `point` — query point.
-- **Returns:** Distance to the nearest point on the edge, or `nil` on failure.
-- **OCCT:** Delegates to `project(point:)` → `GeomAPI_ProjectPointOnCurve`.
+- **Returns:** Distance to the nearest point on the edge, or `nil` only for an edge with no 3D curve.
+- **OCCT:** Delegates to `project(point:)`, and inherits its #539 fix.
 - **Example:**
   ```swift
   if let d = edge.distance(to: SIMD3(5, 5, 5)) {


### PR DESCRIPTION
Closes #539. Pass 1b of the #381 / #377 duplication audit, stacked on `refactor/381-pass1b`.

## What was wrong

Four public entry points promise the closest point on a curve, and none of them delivered it. They
had picked a different OCCT call each, and each call is wrong in its own way about a curve that has
ends:

| | `ShapeAnalysis_Curve::Project`<br>(was behind `Curve3D`) | `GeomAPI_ProjectPointOnCurve`, ranged<br>(was behind `Edge`) | truth |
|---|---|---|---|
| segment trimmed to `[3, 8]`, point `(100, 0, 0)` | parameter 100, **distance 0** | no answer (`nil`) | 92 |
| half circle r=5, point `(0, -6, 0)` | **1** (the far half) | **11** (the far side) | 7.81 |
| point on the full circle, off the arc | **1.6e-15** | **10** | 4.47 |
| parabola over `[0, 2]`, point `(20, 0, 0)` | **20** (the vertex) | **20** | 19.60 |

A `distance < tolerance` proximity test read the first three rows as "the point lies on the curve".

## What the measurement changed about the fix

The issue named one defect — the trimmed range — and proposed clamping the returned parameter into
the domain, "subject to measuring what clamping does ... and to `ShapeAnalysis_Curve`'s `AdjustToEnds`
flag, which defaults to `true` and may already be intended to do some of this". Measuring all of
that ([`Scripts/repro/539-nearest-point-on-curve/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/539-projectpoint-trimmed-range/Scripts/repro/539-nearest-point-on-curve)) moved three things:

- **`AdjustToEnds` does nothing here**, and neither does the ranged overload. Byte-identical answers
  on every case, either way. The 7-argument overload's header already says so: the range is
  *extended*, not honoured.
- **A clamp would not have been enough.** Row 4 is a *maximum* that lies inside the domain: on a
  parabola and a hyperbola the single in-range extremum is the worst point in range, and its
  parameter needs no clamping. Both implementations answered with it. So the fix takes a minimum
  over candidates rather than clamping the one candidate it is handed.
- **The `Edge` half has a different defect than the issue alleged.** It says `OCCTEdgeProjectPoint`
  "is exposed to the same extension behaviour. Not separately measured yet." Measured, it is not:
  `GeomAPI_ProjectPointOnCurve` never extends the range. It returns *extrema*, so it reports the far
  side of an arc as nearest and declines to answer whenever the nearest point is an end.

One thing the measurement ruled *out*, which is why there is no code for it: **periodic bases need
no special handling.** `Geom_TrimmedCurve` normalises its own domain (trimming a circle to `[-1, 1]`
reports `[5.283, 7.283]`) and `Project` returns the periodic representative nearest that domain, so
a parameter outside it is genuinely outside the curve. Ten seam-crossing and beyond-one-period
queries, every one answered exactly by the plain clamp.

## The fix

One `occtNearestPointOnCurveRange` (`OCCTBridge_Internal.h`) behind both entry points, minimising
over three candidate sources — `ShapeAnalysis_Curve`'s answer where it landed inside the range,
every in-range `GeomAPI` extremum, and the range's own ends — because no one of the three is correct
alone. The range is passed in rather than read off the curve, since a `Curve3D` carries its own
while an edge's comes from `BRep_Tool::Curve` and usually bounds an unbounded basis curve.

51 curve/point combinations against a dense brute-force reference — line, circle, ellipse, parabola,
hyperbola, Bezier, BSpline and offset curves, trimmed and untrimmed:

| implementation | correct distances |
|---|---|
| `ShapeAnalysis_Curve::Project` (was `Curve3D.projectPoint`) | 37 / 51 |
| `GeomAPI_ProjectPointOnCurve`, ranged (was `Edge.project`) | 25 / 51 |
| this PR | **51 / 51** |

Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild.

## Behaviour changes for callers

- `Edge.project(point:)` and `Edge.distance(to:)` **stop returning `nil`** for a point with no
  perpendicular foot. All twelve of a box's edges used to answer `nil` for a corner probe outside
  the box. `nil` now means what the header always said it meant: an edge with no 3D curve.
- Every distance in the table above changes to the true one.
- Ordinary in-range projections, unbounded curves and closed curves are unchanged — which is why no
  pre-existing test moved. Every one of them queries a point that has a perpendicular foot.

`Curve3D.nearestParameter(to:)` (#500, merged into this branch a day ago) is deliberately untouched
and still reports `nil` for these points. The two ask different questions — the nearest point, which
exists for every query point, versus the nearest perpendicular foot, which does not.
`Issue500Curve3DNearestParameterTests.projectPointIsADifferentAlgorithm` pins that distinction and
is updated here: it had recorded `projectPoint`'s parameter-100-distance-0 answer as-is rather than
asserting it correct, precisely so this issue would have a test to update rather than a gap to find.

## Measured, not fixed — filed as #580, with its answer

`Shape.pointEdgeExtrema(point:edgeIndex:)` (`BRepExtrema_ExtPC`) is a third entry point documented as
finding "the closest point on the edge", with the same defect: 11 for the half-circle query above,
and `IsDone()` false for both trimmed-segment queries. It is not fixed here, because fixing it means
deciding what its `solutionCount` — the extrema count it deliberately exposes, and which its `nil`
guard keys off — should say when the answer is an end.

That decision is now **measured into the issue** rather than left open
(`Scripts/repro/539-nearest-point-on-curve/580-repair-options.mm`, 189 edge/point combinations):

| candidate set | correct distances, of 189 |
|---|---|
| all extrema, `nil` when `IsDone()` is false (**today**) | 101 correct, 34 answered wrongly, 54 `nil` |
| extrema flagged `IsMin` only, no ends | 101 |
| all extrema + the two ends (`TrimmedSquareDistances`) | 188 |
| **this PR's `occtNearestPointOnCurveRange`** | **189** |

`solutionCount` turns out not to need changing: OCCT models the extrema and the ends as two
different things on the same object — `BRepExtrema_ExtPC` exposes `TrimmedSquareDistances` alongside
`NbExt()` — so "number of extrema found" stays correct, and the ends were simply never consulted.
What changes is the `nil` guard. Three findings that save the implementer a round trip:
`TrimmedSquareDistances` is valid **even when `IsDone()` is false**; filtering the extrema to
`IsMin` ones **without** adding the ends scores exactly what today scores, so the obvious-looking
fix is a no-op; and the 188/189 miss is `Extrema_ExtPC` failing to converge on a BSpline where
`GeomAPI_ProjectPointOnCurve` succeeds — which is why the recommendation is to reuse this PR's
helper rather than repair in place.

## Verification

- New suite `Issue539NearestPointOnCurveTests` (`OCCTCurveTests`), 12 tests.
- **Proved rather than assumed:** reinstating the two original implementations fails **9 of the 12**,
  and the 3 that still pass are exactly the three asserting what was meant to stay the same
  (ordinary in-range projection, closed curve, unbounded curve).
- Full `swift test` green: **4936 tests in 1358 suites**.
- `Scripts/check-bridge-index.py`: 128 stale before this change, 128 after, none of them mine
  (that backlog is #510 / #564, in flight against the same base).

## Docs

`docs/CHANGELOG.md`, `docs/API_REFERENCE.md`, `docs/reference/Curve3D-Analysis.md`,
`docs/reference/Curve3D-Construction.md`, `docs/reference/Edge.md`, the `///` comments on all four
entry points (each with a runnable ```swift snippet), the `OCCTBridge.h` declarations, and both
sides of its class cross-reference index — `GeomAPI_ProjectPointOnCurve` no longer says "NOT
OCCTCurve3DProjectPoint", because it now is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

