### PR TITLE
fix(#529): one resolution behind the adaptor-backed local properties, and the raycast normal it was erasing

### DIFF
--- a/Scripts/repro/529-breplprop-resolution/README.md
+++ b/Scripts/repro/529-breplprop-resolution/README.md
@@ -1,0 +1,172 @@
+# OCCTSwift#529 probes — the `BRepLProp_*` `Resolution` argument
+
+Standalone, deterministic probes for the tolerance divergence #529 fixed, the curvature-inversion
+defect it widened, and the two decisions the change does *not* move. Everything but the last probe
+builds its geometry from a primitive; the decision sweep optionally takes `.brep` files on the
+command line.
+
+Companion to [`../494-lprop-resolution/`](../494-lprop-resolution), which measured the same argument
+on the `Geom_`-handle side.
+
+## `BRepLProp_SLProps` is `GeomLProp_SLProps`
+
+The issue's stated reason for deferring this half of #494 was that `BRepLProp_*` is "a different
+class family" whose factories "are not reusable as written". Reading the pinned headers first says
+otherwise. `BRepLProp_SLProps.hxx` in OCCT 8.0.0p1, in full, minus the licence block:
+
+```cpp
+#include <BRepAdaptor_Surface.hxx>
+#include <GeomLProp_SLProps.hxx>
+
+//! Alias for surface local properties using BRepAdaptor_Surface.
+using BRepLProp_SLProps = GeomLProp_SLPropsBase<BRepAdaptor_Surface>;
+```
+
+and `GeomLProp_SLProps.hxx` ends with
+
+```cpp
+using GeomLProp_SLProps = GeomLProp_SLPropsBase<occ::handle<Geom_Surface>>;
+```
+
+Same for the curve pair. One header-only template, two instantiations, one argument apart. So the
+`Resolution` means exactly what #494 measured it to mean, and the factories differ only in the type
+they take.
+
+## Building
+
+```bash
+L=Libraries/OCCT.xcframework/macos-arm64
+clang++ -std=c++17 -ObjC++ -w -I"$L/Headers" -L"$L" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/529-breplprop-resolution/occt_529_adaptor_sweep.cpp -o /tmp/occt_529_sweep
+/tmp/occt_529_sweep
+```
+
+Same command for the other three. In a git worktree `Libraries/` does not exist — point `L` at the
+main checkout's copy, or symlink it (see `docs/guides/building-occt.md`).
+
+## The four probes
+
+### `occt_529_adaptor_sweep.cpp` — where `1e-6` and `Precision::Confusion()` disagree
+
+Sweeps both values over a cone face approaching its apex, a sphere face approaching its pole, and a
+family of cubic Bezier edges whose first two poles sit a controlled distance apart, and prints the
+`GeomLProp_*` answer at `Precision::Confusion()` alongside as the reference. Output on 8.0.0p1:
+
+```
+=== SLProps on a FACE: cone (semi-angle 30 deg, apex radius 0), u=0 ===
+v         | BRepLProp @ 1e-6 (today)    | BRepLProp @ Confusion (fix) | GeomLProp @ Confusion
+1e-05     | def H=-8.66e+04   K=-0      | def H=-8.66e+04   K=-0      | def H=-8.66e+04   K=-0
+3e-06     | def H=-2.887e+05  K=-0      | def H=-2.887e+05  K=-0      | def H=-2.887e+05  K=-0
+1.5e-06   | UNDEFINED (normal def)      | def H=-5.774e+05  K=-0      | def H=-5.774e+05  K=-0
+1e-06     | UNDEFINED (normal def)      | def H=-8.66e+05   K=-0      | def H=-8.66e+05   K=-0
+3e-07     | UNDEFINED (normal def)      | def H=-2.887e+06  K=-0      | def H=-2.887e+06  K=-0
+1e-07     | UNDEFINED (normal def)      | UNDEFINED (normal def)      | UNDEFINED (normal def)
+0         | UNDEFINED (normal undef)    | UNDEFINED (normal undef)    | UNDEFINED (normal undef)
+```
+
+Note the `(normal def)` on every row but the last: the curvature is what the resolution decides here,
+not the normal. That distinction is what the third probe is about.
+
+Two things this probe also settles:
+
+- **The adaptor and the raw handle agree exactly on an analytic surface, and to about one ULP on a
+  Bezier or BSpline curve.** `GeomAdaptor_Curve` evaluates a Bezier through a cache the handle does
+  not use, so the same curvature comes out as `0.67461923686773151` through the adaptor and
+  `0.6746192368677314` through the handle. Parity assertions have to compare definedness exactly and
+  values relatively.
+- **A cusped edge answers `RealLast()` at both resolutions**, so the sentinel is not something the
+  resolution change removes. It needs its own gate — the next probe.
+
+### `occt_529_edge_inversion.cpp` — the `(nan, inf, nan)` centre of curvature
+
+`LProp_CurveUtils::Curvature()` returns `RealLast()` when the first significant derivative has order
+> 1, on a path that never assigns the `myCurvature` field. `Normal()` rejects the sentinel by name;
+`CentreOfCurvature()` tests only `|Curvature()| <= resolution`, which `RealLast()` passes, then
+divides by the unassigned field. So the failure mode is not an exception, it is a point that is not
+a point, returned as a success. #494 found this on the `Geom_` side; the same template does it here.
+
+The resolution decides how wide the window is. At `u = 0`, by pole spacing:
+
+| spacing | at `1e-6` | at `Precision::Confusion()` |
+|---|---|---|
+| 1e-3, 1e-5, 1e-6 | real centre | real centre |
+| 3e-7 | `(nan, inf, nan)` | real centre `(0, 1.35e-13, 0)` |
+| 1e-7 | `(inf, inf, nan)` | real centre `(2.80e-30, 1.5e-14, 0)` |
+| 1e-8, 1e-9, 1e-12 | `(nan, inf, nan)` | `(nan, inf, nan)` |
+| 0 | throws (`gp_Vec::Normalize() - vector has zero norm`) | throws |
+
+So tightening the resolution closes one decade of it and `occtCurveCurvatureIsInvertible` closes the
+rest. Only the exactly-coincident case was ever safe, and only by accident: the throw is absorbed by
+the bridge's `catch (...)` into `(0, 0, 0)`.
+
+### `occt_529_face_normal_decisions.cpp` — the change that is inert, measured rather than assumed
+
+`OCCTFaceGetNormal` evaluates the normal at the parametric midpoint of a face and reports it
+(`Face.normal`), and `isHorizontal` / `isUpwardFacing` / `isDownwardFacing` / `isVertical` are all
+predicates over that one normal. This probe compares definedness, direction and the resulting
+horizontal/upward classification at both resolutions, for every face of every shape it is given.
+
+```
+box 10x20x30              faces=6    definedness -/+ = 0/0  direction changed = 0  horizontal 2->2  upward 1->1
+cone r1=5 r2=0 h=12       faces=2    definedness -/+ = 0/0  direction changed = 0  horizontal 1->1  upward 0->0
+half sphere (pole at v mid) faces=2  definedness -/+ = 0/0  direction changed = 0  horizontal 1->1  upward 0->0
+filleted box (r=1.5)      faces=26   definedness -/+ = 0/0  direction changed = 0  horizontal 2->2  upward 1->1
+unify-crash-mmd-kiha10-body5.brep faces=662  definedness -/+ = 0/0  direction changed = 0  horizontal 18->18  upward 9->9
+extrusion skewed by 1e-06 rad  faces=1  definedness -/+ = 0/1 ...   <-- CHANGED
+extrusion skewed by 5e-07 rad  faces=1  definedness -/+ = 0/1 ...   <-- CHANGED
+```
+
+The mechanism behind the zeros, from `CSLib.cxx`:
+
+```cpp
+if (aD1UMag <= gp::Resolution() && aD1VMag <= gp::Resolution())  theStatus = CSLib_D1IsNull;
+...
+const double aSin2 = aD1UxD1V.SquareMagnitude() / (aD1UMag * aD1VMag);
+if (aSin2 < theSinTol * theSinTol)                               theStatus = CSLib_D1uIsParallelD1v;
+```
+
+The nullity tests use `gp::Resolution()`, a fixed ~1e-300 epsilon, **not** the caller's value. The
+caller's value is a *sine* tolerance on the angle between the two parametric directions, and that
+test is scale-invariant. So a surface whose derivatives merely shrink — a cone at its apex, a sphere
+at its pole — keeps a defined normal all the way down, and the resolution never enters. Only a
+nearly *singular parameterisation* is affected, which is what the skewed extrusion constructs: a
+line extruded along a direction 5e-7 radians off its own.
+
+This is also why the curvature sites move and the normal sites do not. `IsCurvatureDefined()` goes
+through `IsTangentUDefined()` / `IsTangentVDefined()`, which are absolute
+`SquareMagnitude() > tol * tol` tests.
+
+**Probe artefact worth recording**: an earlier version compared directions with
+`gp_Dir::IsEqual(other, 0.0)` and reported 384 of the 662 fixture faces as changed. `gp_Dir::Angle`
+returns ~1.5e-17 rather than 0 for two *bit-identical* directions whenever the dot product rounds
+just below 1 and it takes the `asin(CrossMagnitude)` branch — comparing two props objects built at
+the same resolution shows the same 1.5e-17. The probe now compares components exactly.
+
+### `occt_529_raycast_tolerance.cpp` — the one site that took its resolution from the caller
+
+`OCCTShapeRaycast` passed its `tolerance` parameter to `IntCurvesFace_ShapeIntersector::Load`, where
+it is an intersection distance, *and* to `BRepLProp_SLProps`, where it is the sine tolerance above.
+`Shape.raycast`'s default is `0.001`. A sine tolerance is dimensionless and saturates at 1:
+
+```
+=== sphere r=5, ray straight down the Z axis ===
+loadTol=0.001  resolution=0.001  hits=2   hit1 normal (6.123e-17, 0, 1)   hit2 normal (6.123e-17, 0, -1)
+loadTol=0.9    resolution=0.9    hits=2   hit1 normal (6.123e-17, 0, 1)   hit2 normal (6.123e-17, 0, -1)
+loadTol=1      resolution=1      hits=2   hit1 normal UNDEFINED -> reported as (0, 0, 1)   hit2 normal UNDEFINED -> ...
+loadTol=2      resolution=2      hits=2   hit1 normal UNDEFINED -> reported as (0, 0, 1)   hit2 normal UNDEFINED -> ...
+
+=== box 10x10x10, ray straight down ===
+loadTol=1      resolution=1      hits=2   hit1 normal (0, 0, 1)   hit2 normal (-0, -0, -1)
+loadTol=5      resolution=5      hits=2   hit1 normal UNDEFINED -> reported as (0, 0, 1)   hit2 normal UNDEFINED -> ...
+
+=== the same hits, resolution decoupled from the load tolerance ===
+loadTol=5      resolution=1e-07  hits=2   hit1 normal (0, 0, 1)   hit2 normal (-0, -0, -1)
+```
+
+The box surviving `resolution=1` where the sphere does not is the boundary being exact: a plane's
+`aSin2` is exactly 1, and the test is `<`, not `<=`.
+
+The fallback makes it worse than a missing answer. `RayHit.normal` is `(0, 0, 1)` when the normal is
+undefined, so at `tolerance: 5.0` a box's *downward* face reported an upward normal. `RayHit` now
+carries `normalDefined` alongside it.

--- a/Scripts/repro/529-breplprop-resolution/occt_529_adaptor_sweep.cpp
+++ b/Scripts/repro/529-breplprop-resolution/occt_529_adaptor_sweep.cpp
@@ -1,0 +1,207 @@
+// OCCTSwift#529 — does the Resolution argument change what the *adaptor-based* local-property
+// classes report, and do they agree with their Geom_* counterparts once the value matches?
+//
+// BRepLProp_SLProps / BRepLProp_CLProps are, in OCCT 8.0, plain aliases for the same header-only
+// templates GeomLProp_SLProps / GeomLProp_CLProps use, differing only in the adaptor they read
+// through (BRepAdaptor_Surface / BRepAdaptor_Curve instead of a Geom_ handle). So the Resolution
+// means exactly what #494 measured it to mean; this probe checks that it is observable through the
+// adaptor, and that the two halves land on the same answer at the same value.
+//
+// Build:
+//   L=Libraries/OCCT.xcframework/macos-arm64
+//   clang++ -std=c++17 -ObjC++ -w -I"$L/Headers" -L"$L" -lOCCT-macos \
+//     -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/529-breplprop-resolution/occt_529_adaptor_sweep.cpp -o /tmp/occt_529_sweep
+
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepLProp_CLProps.hxx>
+#include <BRepLProp_SLProps.hxx>
+#include <BRep_Tool.hxx>
+#include <GeomLProp_CLProps.hxx>
+#include <GeomLProp_SLProps.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Precision.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+static const double kOld = 1e-6;                     // what the 18 bridge sites pass today
+static const double kNew = Precision::Confusion();   // 1e-7, occtLocalPropsResolution()
+
+// ---------------------------------------------------------------------------------------------
+// Geometry
+
+static TopoDS_Face apexConeFace()
+{
+  // Semi-angle 30 deg, apex radius 0: the apex sits at v = 0 and |dS/du| falls off linearly with v,
+  // so sweeping v walks smoothly through both resolutions' null-vector thresholds.
+  gp_Ax3 axis(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+  occ::handle<Geom_ConicalSurface> cone = new Geom_ConicalSurface(axis, M_PI / 6.0, 0.0);
+  return BRepBuilderAPI_MakeFace(cone, 0.0, 2 * M_PI, -1.0, 10.0, Precision::Confusion()).Face();
+}
+
+static TopoDS_Face sphereFace(double radius)
+{
+  gp_Ax3 axis(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+  occ::handle<Geom_SphericalSurface> sphere = new Geom_SphericalSurface(axis, radius);
+  return BRepBuilderAPI_MakeFace(sphere, 0.0, 2 * M_PI, -M_PI / 2, M_PI / 2, Precision::Confusion())
+      .Face();
+}
+
+// A cubic Bezier whose first two poles sit `spacing` apart, so |D1(0)| = 3 * spacing. At spacing 0
+// the start is a cusp: the first significant derivative has order 2 and OCCT reports RealLast()
+// curvature there.
+static TopoDS_Edge cuspBezierEdge(double spacing)
+{
+  TColgp_Array1OfPnt poles(1, 4);
+  poles(1) = gp_Pnt(0, 0, 0);
+  poles(2) = gp_Pnt(spacing, 0, 0);
+  poles(3) = gp_Pnt(1, 1, 0);
+  poles(4) = gp_Pnt(2, 0, 0);
+  occ::handle<Geom_BezierCurve> bez = new Geom_BezierCurve(poles);
+  return BRepBuilderAPI_MakeEdge(bez).Edge();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Reporting helpers
+
+struct SurfaceAnswer
+{
+  bool normalDefined = false;
+  bool curvatureDefined = false;
+  double mean = 0.0;
+  double gaussian = 0.0;
+};
+
+template <typename Props>
+static SurfaceAnswer readSurface(Props& p)
+{
+  SurfaceAnswer a;
+  a.normalDefined = p.IsNormalDefined();
+  a.curvatureDefined = p.IsCurvatureDefined();
+  if (a.curvatureDefined)
+  {
+    a.mean = p.MeanCurvature();
+    a.gaussian = p.GaussianCurvature();
+  }
+  return a;
+}
+
+static std::string describe(const SurfaceAnswer& a)
+{
+  char buf[128];
+  if (!a.curvatureDefined)
+  {
+    std::snprintf(buf, sizeof(buf), "UNDEFINED (normal %s)", a.normalDefined ? "def" : "undef");
+    return buf;
+  }
+  std::snprintf(buf, sizeof(buf), "def H=%-12.4g K=%-12.4g", a.mean, a.gaussian);
+  return buf;
+}
+
+static bool sameSurface(const SurfaceAnswer& x, const SurfaceAnswer& y)
+{
+  if (x.normalDefined != y.normalDefined || x.curvatureDefined != y.curvatureDefined) return false;
+  if (!x.curvatureDefined) return true;
+  return x.mean == y.mean && x.gaussian == y.gaussian;
+}
+
+// ---------------------------------------------------------------------------------------------
+
+static void surfaceSweep(const char* title, const TopoDS_Face& face, double u,
+                         const double* vs, int nvs)
+{
+  std::printf("\n=== %s ===\n", title);
+  std::printf("%-14s | %-34s | %-34s | %s\n", "v", "BRepLProp @ 1e-6 (today)",
+              "BRepLProp @ Confusion (fix)", "GeomLProp @ Confusion (canonical)");
+
+  occ::handle<Geom_Surface> surf = BRep_Tool::Surface(face);
+  for (int i = 0; i < nvs; ++i)
+  {
+    const double v = vs[i];
+    BRepAdaptor_Surface adaptor(face);
+    BRepLProp_SLProps oldProps(adaptor, u, v, 2, kOld);
+    BRepLProp_SLProps newProps(adaptor, u, v, 2, kNew);
+    GeomLProp_SLProps geomProps(surf, u, v, 2, kNew);
+
+    SurfaceAnswer o = readSurface(oldProps);
+    SurfaceAnswer n = readSurface(newProps);
+    SurfaceAnswer g = readSurface(geomProps);
+
+    std::printf("%-14.6g | %-34s | %-34s | %s%s\n", v, describe(o).c_str(), describe(n).c_str(),
+                describe(g).c_str(),
+                sameSurface(n, g) ? "" : "   <-- adaptor/geom MISMATCH at same resolution");
+    if (!sameSurface(o, n)) std::printf("%-14s | ^ resolution changes the answer here\n", "");
+  }
+}
+
+static void curveSweep(const char* title, const TopoDS_Edge& edge, const double* us, int nus)
+{
+  std::printf("\n=== %s ===\n", title);
+  std::printf("%-14s | %-30s | %-30s | %s\n", "u", "BRepLProp @ 1e-6 (today)",
+              "BRepLProp @ Confusion (fix)", "GeomLProp @ Confusion");
+
+  double f = 0, l = 0;
+  occ::handle<Geom_Curve> curve = BRep_Tool::Curve(edge, f, l);
+
+  for (int i = 0; i < nus; ++i)
+  {
+    const double u = us[i];
+    BRepAdaptor_Curve adaptor(edge);
+    BRepLProp_CLProps oldProps(adaptor, u, 2, kOld);
+    BRepLProp_CLProps newProps(adaptor, u, 2, kNew);
+    GeomLProp_CLProps geomProps(curve, u, 2, kNew);
+
+    const bool oTan = oldProps.IsTangentDefined();
+    const bool nTan = newProps.IsTangentDefined();
+    const bool gTan = geomProps.IsTangentDefined();
+    const double oCur = oldProps.Curvature();
+    const double nCur = newProps.Curvature();
+    const double gCur = geomProps.Curvature();
+
+    char ob[64], nb[64], gb[64];
+    std::snprintf(ob, sizeof(ob), "%s k=%-12.6g", oTan ? "tan  " : "NOTAN", oCur);
+    std::snprintf(nb, sizeof(nb), "%s k=%-12.6g", nTan ? "tan  " : "NOTAN", nCur);
+    std::snprintf(gb, sizeof(gb), "%s k=%-12.6g", gTan ? "tan  " : "NOTAN", gCur);
+    std::printf("%-14.6g | %-30s | %-30s | %s%s\n", u, ob, nb, gb,
+                (nTan == gTan && nCur == gCur) ? "" : "   <-- adaptor/geom MISMATCH");
+    if (oTan != nTan || oCur != nCur)
+      std::printf("%-14s | ^ resolution changes the answer here\n", "");
+  }
+}
+
+int main()
+{
+  std::printf("OCCT resolution values: 1e-6 (bridge today) vs Precision::Confusion() = %g\n", kNew);
+
+  const double coneVs[] = {10.0, 1.0, 1e-2, 1e-5, 3e-6, 1.5e-6, 1e-6, 3e-7, 1e-7, 1e-8, 0.0};
+  surfaceSweep("SLProps on a FACE: cone (semi-angle 30 deg, apex radius 0), u=0", apexConeFace(),
+               0.0, coneVs, sizeof(coneVs) / sizeof(coneVs[0]));
+
+  const double poleVs[] = {M_PI / 2 - 1e-3, M_PI / 2 - 1e-5, M_PI / 2 - 1e-6,
+                           M_PI / 2 - 1e-7, M_PI / 2 - 1e-8, M_PI / 2};
+  surfaceSweep("SLProps on a FACE: sphere r=3 approaching the north pole, u=0", sphereFace(3.0),
+               0.0, poleVs, sizeof(poleVs) / sizeof(poleVs[0]));
+
+  const double us[] = {0.0, 1e-9, 1e-8, 1e-7, 0.5};
+  for (double spacing : {0.0, 1e-8, 1e-7, 3e-7, 1e-6, 1e-5})
+  {
+    char title[160];
+    std::snprintf(title, sizeof(title),
+                  "CLProps on an EDGE: cubic Bezier, first two poles %g apart (|D1(0)| = %g)",
+                  spacing, 3 * spacing);
+    curveSweep(title, cuspBezierEdge(spacing), us, sizeof(us) / sizeof(us[0]));
+  }
+
+  return 0;
+}

--- a/Scripts/repro/529-breplprop-resolution/occt_529_edge_inversion.cpp
+++ b/Scripts/repro/529-breplprop-resolution/occt_529_edge_inversion.cpp
@@ -1,0 +1,116 @@
+// OCCTSwift#529 — the curvature-inversion exposure on the adaptor side.
+//
+// #494 found that GeomLProp_CLProps::Curvature() returns RealLast() to mean "infinite curvature" at
+// a cusp, on a path that never assigns the myCurvature field CentreOfCurvature() then divides by --
+// so the centre comes back (nan, inf, nan) reported as a success. BRepLProp_CLProps is the same
+// template, so every bridge site that inverts a curvature through it has the same exposure. This
+// probe measures what the three inverting operations do on the two degeneracies, through the
+// adaptor.
+//
+// Build:
+//   L=Libraries/OCCT.xcframework/macos-arm64
+//   clang++ -std=c++17 -ObjC++ -w -I"$L/Headers" -L"$L" -lOCCT-macos \
+//     -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/529-breplprop-resolution/occt_529_edge_inversion.cpp -o /tmp/occt_529_inv
+
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepLProp_CLProps.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Precision.hxx>
+#include <Standard_Failure.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <TopoDS_Edge.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cmath>
+#include <cstdio>
+
+static TopoDS_Edge bezierEdge(double spacing)
+{
+  TColgp_Array1OfPnt poles(1, 4);
+  poles(1) = gp_Pnt(0, 0, 0);
+  poles(2) = gp_Pnt(spacing, 0, 0);
+  poles(3) = gp_Pnt(1, 1, 0);
+  poles(4) = gp_Pnt(2, 0, 0);
+  return BRepBuilderAPI_MakeEdge(new Geom_BezierCurve(poles)).Edge();
+}
+
+static TopoDS_Edge lineEdge()
+{
+  return BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Edge();
+}
+
+// What OCCTEdgeLPropCentreOfCurvature / OCCTEdgeLPropNormal do today: construct, ask, and let
+// catch (...) turn any throw into the zero-initialised out-parameters.
+static void report(const char* label, const TopoDS_Edge& edge, double u, double resolution)
+{
+  BRepAdaptor_Curve ac(edge);
+  BRepLProp_CLProps props(ac, u, 2, resolution);
+
+  const bool tangentDefined = props.IsTangentDefined();
+  const double k = props.Curvature();
+
+  std::printf("%-42s u=%-6g res=%-9g tangent=%-5s curvature=%-14.6g%s\n", label, u, resolution,
+              tangentDefined ? "yes" : "no", k, k == RealLast() ? "  (RealLast sentinel)" : "");
+
+  // Centre of curvature, as the bridge asks for it.
+  try
+  {
+    gp_Pnt centre;
+    props.CentreOfCurvature(centre);
+    const bool finite = std::isfinite(centre.X()) && std::isfinite(centre.Y())
+                        && std::isfinite(centre.Z());
+    std::printf("%-42s   CentreOfCurvature -> (%g, %g, %g)%s\n", "", centre.X(), centre.Y(),
+                centre.Z(), finite ? "" : "   <-- NOT A POINT, returned as success");
+  }
+  catch (const Standard_Failure& e)
+  {
+    std::printf("%-42s   CentreOfCurvature -> threw Standard_Failure (bridge reports (0,0,0)): %s\n",
+                "", e.GetMessageString());
+  }
+
+  // Normal.
+  try
+  {
+    gp_Dir n;
+    props.Normal(n);
+    std::printf("%-42s   Normal            -> (%g, %g, %g)\n", "", n.X(), n.Y(), n.Z());
+  }
+  catch (const Standard_Failure& e)
+  {
+    std::printf("%-42s   Normal            -> threw Standard_Failure (bridge reports (0,0,0)): %s\n",
+                "", e.GetMessageString());
+  }
+}
+
+int main()
+{
+  std::printf("RealLast() = %g, Precision::Confusion() = %g\n\n", RealLast(),
+              Precision::Confusion());
+
+  // The spacing sweep is the point: an *exactly* coincident pair of poles makes D1 exactly zero and
+  // CentreOfCurvature throws, which the bridge's catch (...) already absorbs. A *nearly* coincident
+  // pair is the dangerous one -- OCCT still answers RealLast() from Curvature(), but the division
+  // that follows produces a non-point instead of throwing, and the bridge reports it as a result.
+  // Which spacings land in that window is decided by the resolution, which is what #529 is about.
+  std::printf("=== how a near-cusp inverts, by pole spacing and resolution (u = 0) ===\n");
+  for (double spacing : {0.0, 1e-12, 1e-9, 1e-8, 3e-7, 1e-7, 1e-6, 1e-5, 1e-3})
+  {
+    char label[64];
+    for (double res : {1e-6, Precision::Confusion()})
+    {
+      std::snprintf(label, sizeof(label), "Bezier poles %g apart", spacing);
+      report(label, bezierEdge(spacing), 0.0, res);
+    }
+    std::printf("\n");
+  }
+
+  std::printf("=== the two cases that are degenerate at any resolution ===\n");
+  for (double res : {1e-6, Precision::Confusion()})
+  {
+    report("line (no centre of curvature)", lineEdge(), 5.0, res);
+    report("Bezier mid-span (well conditioned)", bezierEdge(1.0), 0.5, res);
+  }
+  return 0;
+}

--- a/Scripts/repro/529-breplprop-resolution/occt_529_face_normal_decisions.cpp
+++ b/Scripts/repro/529-breplprop-resolution/occt_529_face_normal_decisions.cpp
@@ -1,0 +1,233 @@
+// OCCTSwift#529 — what the resolution change does to a *decision*, not to a reported value.
+//
+// OCCTFaceGetNormal evaluates the surface normal at the parametric midpoint of a face and reports
+// it (Face.normal), and Face.isHorizontal / isUpwardFacing / isDownwardFacing / isVertical are all
+// predicates over that one normal. Tightening the resolution from 1e-6 to Precision::Confusion()
+// can only make IsNormalDefined() *more* permissive (the null test is
+// SquareMagnitude() > resolution^2, and CSLib::Normal's parallelism test is
+// |D1u ^ D1v| > sinTol * |D1u| * |D1v|), so a face can only move from "no normal" to "a normal",
+// never the other way, and the direction it reports when defined does not depend on the resolution
+// at all. This probe measures that claim over real shapes rather than asserting it: for every face
+// of every shape it compares definedness and direction at both values.
+//
+// Build:
+//   L=Libraries/OCCT.xcframework/macos-arm64
+//   clang++ -std=c++17 -ObjC++ -w -I"$L/Headers" -L"$L" -lOCCT-macos \
+//     -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/529-breplprop-resolution/occt_529_face_normal_decisions.cpp \
+//     -o /tmp/occt_529_decisions
+//   /tmp/occt_529_decisions [extra.brep ...]
+
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepLProp_SLProps.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCone.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepPrimAPI_MakeTorus.hxx>
+#include <BRepTools.hxx>
+#include <BRep_Builder.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_SurfaceOfLinearExtrusion.hxx>
+#include <Precision.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+static const double kOld = 1e-6;
+static const double kNew = Precision::Confusion();
+
+struct Decision
+{
+  bool defined = false;
+  gp_Dir normal;
+};
+
+// Exactly what OCCTFaceGetNormal does, with the resolution as a parameter.
+static Decision faceNormal(const TopoDS_Face& face, double resolution)
+{
+  Decision d;
+  try
+  {
+    BRepAdaptor_Surface adaptor(face);
+    const double uMid = (adaptor.FirstUParameter() + adaptor.LastUParameter()) / 2.0;
+    const double vMid = (adaptor.FirstVParameter() + adaptor.LastVParameter()) / 2.0;
+    BRepLProp_SLProps props(adaptor, uMid, vMid, 1, resolution);
+    if (!props.IsNormalDefined()) return d;
+    gp_Dir n = props.Normal();
+    if (face.Orientation() == TopAbs_REVERSED) n.Reverse();
+    d.defined = true;
+    d.normal = n;
+  }
+  catch (...)
+  {
+  }
+  return d;
+}
+
+// Face.isHorizontal / isUpwardFacing, at their Swift default tolerance.
+static bool isHorizontal(const Decision& d, double tol = 0.01)
+{
+  return d.defined && std::abs(d.normal.Z()) > std::cos(tol);
+}
+static bool isUpward(const Decision& d, double tol = 0.01)
+{
+  return d.defined && d.normal.Z() > std::cos(tol);
+}
+
+// Component-wise, not gp_Dir::IsEqual(other, 0.0): IsEqual measures the angle, and gp_Dir::Angle
+// returns ~1.5e-17 rather than 0 for two *bit-identical* directions whenever the dot product
+// rounds just below 1 and it takes the asin(CrossMagnitude) branch. Comparing two props objects
+// built at the same resolution shows the same 1.5e-17, so an angular test at tolerance 0 reports a
+// difference that is not there. The question here is whether the resolution perturbs the reported
+// direction at all, so ask for exact equality of the numbers actually handed to the caller.
+static bool sameDirection(const gp_Dir& a, const gp_Dir& b)
+{
+  return a.X() == b.X() && a.Y() == b.Y() && a.Z() == b.Z();
+}
+
+static void compare(const char* name, const TopoDS_Shape& shape)
+{
+  if (shape.IsNull())
+  {
+    std::printf("%-34s SKIPPED (null shape)\n", name);
+    return;
+  }
+
+  int faces = 0, flippedToDefined = 0, flippedToUndefined = 0, directionChanged = 0;
+  int horizOld = 0, horizNew = 0, upOld = 0, upNew = 0;
+  std::vector<std::string> notes;
+
+  int index = 0;
+  for (TopExp_Explorer exp(shape, TopAbs_FACE); exp.More(); exp.Next(), ++index)
+  {
+    const TopoDS_Face face = TopoDS::Face(exp.Current());
+    ++faces;
+
+    const Decision o = faceNormal(face, kOld);
+    const Decision n = faceNormal(face, kNew);
+
+    if (!o.defined && n.defined) ++flippedToDefined;
+    if (o.defined && !n.defined) ++flippedToUndefined;
+    if (o.defined && n.defined && !sameDirection(o.normal, n.normal)) ++directionChanged;
+
+    horizOld += isHorizontal(o) ? 1 : 0;
+    horizNew += isHorizontal(n) ? 1 : 0;
+    upOld += isUpward(o) ? 1 : 0;
+    upNew += isUpward(n) ? 1 : 0;
+
+    if (o.defined != n.defined || (o.defined && n.defined && !sameDirection(o.normal, n.normal)))
+    {
+      char buf[220];
+      std::snprintf(buf, sizeof(buf),
+                    "      face %d: 1e-6 %s -> Confusion %s%s", index,
+                    o.defined ? "defined" : "UNDEFINED", n.defined ? "defined" : "UNDEFINED",
+                    n.defined ? "" : "");
+      std::string line = buf;
+      if (n.defined)
+      {
+        std::snprintf(buf, sizeof(buf), " normal (%.6g, %.6g, %.6g)", n.normal.X(), n.normal.Y(),
+                      n.normal.Z());
+        line += buf;
+      }
+      notes.push_back(line);
+    }
+  }
+
+  std::printf("%-34s faces=%-4d  definedness -/+ = %d/%d  direction changed = %d  "
+              "horizontal %d->%d  upward %d->%d%s\n",
+              name, faces, flippedToUndefined, flippedToDefined, directionChanged, horizOld,
+              horizNew, upOld, upNew,
+              (flippedToDefined || flippedToUndefined || directionChanged) ? "   <-- CHANGED" : "");
+  for (const std::string& note : notes) std::printf("%s\n", note.c_str());
+}
+
+int main(int argc, char** argv)
+{
+  std::printf("Face-normal decisions at the parametric midpoint: 1e-6 (today) vs "
+              "Precision::Confusion() = %g\n\n",
+              kNew);
+
+  compare("box 10x20x30", BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape());
+  compare("cylinder r=5 h=20", BRepPrimAPI_MakeCylinder(5.0, 20.0).Shape());
+  compare("sphere r=7", BRepPrimAPI_MakeSphere(7.0).Shape());
+  compare("cone r1=5 r2=0 h=12 (apex)", BRepPrimAPI_MakeCone(5.0, 0.0, 12.0).Shape());
+  compare("cone r1=5 r2=2 h=12 (frustum)", BRepPrimAPI_MakeCone(5.0, 2.0, 12.0).Shape());
+  compare("torus R=10 r=3", BRepPrimAPI_MakeTorus(10.0, 3.0).Shape());
+  compare("half sphere (pole at v mid)", BRepPrimAPI_MakeSphere(7.0, 0.0, M_PI / 2).Shape());
+
+  // A bare conical face whose v range straddles the apex, so the *midpoint* is the degenerate
+  // point rather than an edge of the domain -- the case where a midpoint-sampling entry point is
+  // most likely to see the resolution at all.
+  {
+    gp_Ax3 axis(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    occ::handle<Geom_ConicalSurface> cone = new Geom_ConicalSurface(axis, M_PI / 6.0, 0.0);
+    compare("conical face, v in [-1e-6, 1e-6]",
+            BRepBuilderAPI_MakeFace(cone, 0.0, 2 * M_PI, -1e-6, 1e-6, Precision::Confusion())
+                .Face());
+    compare("conical face, v in [-3e-7, 3e-7]",
+            BRepBuilderAPI_MakeFace(cone, 0.0, 2 * M_PI, -3e-7, 3e-7, Precision::Confusion())
+                .Face());
+    compare("conical face, v in [-1e-8, 1e-8]",
+            BRepBuilderAPI_MakeFace(cone, 0.0, 2 * M_PI, -1e-8, 1e-8, Precision::Confusion())
+                .Face());
+  }
+
+  // The one shape of surface where the resolution *does* reach IsNormalDefined(). CSLib::Normal
+  // tests the two first derivatives for nullity against gp::Resolution() (a fixed ~1e-300 epsilon)
+  // and uses the caller's value only as a SINE tolerance on the angle between them:
+  //
+  //     aSin2 = |D1u ^ D1v|^2 / (|D1u|^2 |D1v|^2);  if (aSin2 < theSinTol^2) -> D1uIsParallelD1v
+  //
+  // That test is scale-invariant, so a surface whose derivatives merely shrink (a cone at its apex,
+  // a sphere at its pole) keeps a defined normal all the way down. Only a surface whose two
+  // parametric directions become nearly *parallel* is affected. An extrusion of a line along a
+  // direction a hair off the line's own is exactly that, with the angle dialled to order.
+  for (double angle : {1e-5, 3e-6, 1e-6, 5e-7, 1e-7, 1e-8})
+  {
+    occ::handle<Geom_Line> line = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+    gp_Dir extrusion(std::cos(angle), std::sin(angle), 0.0);
+    occ::handle<Geom_SurfaceOfLinearExtrusion> surf =
+        new Geom_SurfaceOfLinearExtrusion(line, extrusion);
+    char label[64];
+    std::snprintf(label, sizeof(label), "extrusion skewed by %g rad", angle);
+    compare(label,
+            BRepBuilderAPI_MakeFace(surf, 0.0, 10.0, 0.0, 10.0, Precision::Confusion()).Face());
+  }
+
+  // A filleted box: many BSpline/torus-patch faces, the closest thing to production geometry that
+  // builds from primitives.
+  {
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape();
+    BRepFilletAPI_MakeFillet fillet(box);
+    for (TopExp_Explorer exp(box, TopAbs_EDGE); exp.More(); exp.Next())
+      fillet.Add(1.5, TopoDS::Edge(exp.Current()));
+    fillet.Build();
+    compare("filleted box (r=1.5, all edges)", fillet.IsDone() ? fillet.Shape() : TopoDS_Shape());
+  }
+
+  // Any .brep passed on the command line, so the real fixtures can be swept too.
+  for (int i = 1; i < argc; ++i)
+  {
+    TopoDS_Shape shape;
+    BRep_Builder builder;
+    if (!BRepTools::Read(shape, argv[i], builder))
+    {
+      std::printf("%-34s SKIPPED (unreadable)\n", argv[i]);
+      continue;
+    }
+    compare(argv[i], shape);
+  }
+
+  return 0;
+}

--- a/Scripts/repro/529-breplprop-resolution/occt_529_raycast_tolerance.cpp
+++ b/Scripts/repro/529-breplprop-resolution/occt_529_raycast_tolerance.cpp
@@ -1,0 +1,97 @@
+// OCCTSwift#529 — the one BRepLProp site that does not hardcode a resolution, and what it takes
+// instead.
+//
+// OCCTShapeRaycast (Sources/OCCTBridge/src/OCCTBridge_Spatial.mm) forwards its `tolerance`
+// parameter twice: to IntCurvesFace_ShapeIntersector::Load, where it is the intersection tolerance
+// it is documented as, and to BRepLProp_SLProps, where it becomes the Resolution -- the sine
+// tolerance CSLib::Normal tests the two parametric directions for parallelism with. Those are
+// different quantities, and Shape.raycast's default is 0.001, four decades looser than the
+// Precision::Confusion() every other local-property site uses.
+//
+// The consequence is not a rounding difference. A sine tolerance is dimensionless and capped: once
+// the caller passes a value >= 1, `aSin2 < theSinTol * theSinTol` is true for every possible pair
+// of derivatives, so *every* hit reports an undefined normal and RayHit.normal falls back to
+// (0, 0, 1) -- a plausible-looking unit vector, pointing up, for every face of every shape.
+//
+// Build:
+//   L=Libraries/OCCT.xcframework/macos-arm64
+//   clang++ -std=c++17 -ObjC++ -w -I"$L/Headers" -L"$L" -lOCCT-macos \
+//     -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/529-breplprop-resolution/occt_529_raycast_tolerance.cpp -o /tmp/occt_529_ray
+
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepLProp_SLProps.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <IntCurvesFace_ShapeIntersector.hxx>
+#include <Precision.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cstdio>
+
+// OCCTShapeRaycast's normal, as it stands today: the caller's intersection tolerance doubles as the
+// local-property resolution. `resolution` is passed separately here so the same hit can be read
+// both ways.
+static void castRay(const char* label, const TopoDS_Shape& shape, const gp_Lin& ray,
+                    double loadTolerance, double resolution)
+{
+  IntCurvesFace_ShapeIntersector intersector;
+  intersector.Load(shape, loadTolerance);
+  intersector.Perform(ray, -1e10, 1e10);
+
+  std::printf("%-28s loadTol=%-8g resolution=%-10g hits=%d", label, loadTolerance, resolution,
+              intersector.NbPnt());
+  for (int i = 1; i <= intersector.NbPnt(); ++i)
+  {
+    BRepAdaptor_Surface adaptor(intersector.Face(i));
+    BRepLProp_SLProps props(adaptor, intersector.UParameter(i), intersector.VParameter(i), 1,
+                            resolution);
+    if (props.IsNormalDefined())
+    {
+      gp_Dir n = props.Normal();
+      if (intersector.Face(i).Orientation() == TopAbs_REVERSED) n.Reverse();
+      std::printf("   hit%d normal (%.4g, %.4g, %.4g)", i, n.X(), n.Y(), n.Z());
+    }
+    else
+    {
+      std::printf("   hit%d normal UNDEFINED -> reported as (0, 0, 1)", i);
+    }
+  }
+  std::printf("\n");
+}
+
+int main()
+{
+  std::printf("A sine tolerance is dimensionless: CSLib::Normal rejects the normal when\n"
+              "|D1u ^ D1v|^2 / (|D1u|^2 |D1v|^2) < resolution^2, so resolution >= 1 rejects every\n"
+              "normal there is. Precision::Confusion() = %g.\n\n",
+              Precision::Confusion());
+
+  const TopoDS_Shape sphere = BRepPrimAPI_MakeSphere(gp_Pnt(0, 0, 0), 5.0).Shape();
+  const gp_Lin down(gp_Pnt(0, 0, 20), gp_Dir(0, 0, -1));
+  const gp_Lin sideways(gp_Pnt(-20, 0, 0), gp_Dir(1, 0, 0));
+
+  std::printf("=== sphere r=5, ray straight down the Z axis ===\n");
+  for (double t : {Precision::Confusion(), 0.001, 0.1, 0.9, 1.0, 2.0})
+    castRay("sphere / down", sphere, down, t, t);
+
+  std::printf("\n=== sphere r=5, ray along +X (normals point sideways) ===\n");
+  for (double t : {0.001, 1.0})
+    castRay("sphere / sideways", sphere, sideways, t, t);
+
+  std::printf("\n=== box 10x10x10, ray straight down ===\n");
+  const TopoDS_Shape box = BRepPrimAPI_MakeBox(gp_Pnt(-5, -5, -5), 10.0, 10.0, 10.0).Shape();
+  for (double t : {0.001, 1.0, 5.0})
+    castRay("box / down", box, down, t, t);
+
+  std::printf("\n=== the same hits, resolution decoupled from the load tolerance ===\n");
+  for (double t : {0.001, 1.0, 5.0})
+    castRay("box / down (fixed res)", box, down, t, Precision::Confusion());
+
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1300,29 +1300,21 @@ bool OCCTFaceIsPlanar(OCCTFaceRef face);
 /// @return true if face is horizontal and Z was computed, false otherwise
 bool OCCTFaceGetZLevel(OCCTFaceRef face, double* outZ);
 
-/// Get horizontal faces from a shape (faces with normals pointing up or down)
-/// @param shape The shape to search
-/// @param tolerance Angle tolerance in radians (e.g., 0.01 for ~0.5 degrees)
-/// @param outCount Output: number of faces returned
-/// @return Array of face references for horizontal faces only
-OCCTFaceRef* OCCTShapeGetHorizontalFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount);
-
-/// Get upward-facing horizontal faces (potential pocket floors)
-/// @param shape The shape to search
-/// @param tolerance Angle tolerance in radians
-/// @param outCount Output: number of faces returned
-/// @return Array of face references for upward-facing horizontal faces
-OCCTFaceRef* OCCTShapeGetUpwardFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount);
+/// OCCTShapeGetHorizontalFaces and OCCTShapeGetUpwardFaces were declared here: second copies of
+/// the Face.isHorizontal / Face.isUpwardFacing predicates over the same midpoint normal
+/// OCCTFaceGetNormal returns, which Shape.horizontalFaces / Shape.upwardFaces use instead. Neither
+/// was called from anywhere. Removed by #529.
 
 // MARK: - Ray Casting & Selection (Issues #12, #13, #14)
 
 /// Ray hit result structure
 typedef struct {
     double point[3];        // 3D intersection point
-    double normal[3];       // Surface normal at hit
+    double normal[3];       // Surface normal at hit, (0,0,1) when normalDefined is false
     int32_t faceIndex;      // Index of hit face
     double distance;        // Distance from ray origin
     double uv[2];           // UV parameters on surface
+    bool normalDefined;     // False at a singular point, where `normal` is the (0,0,1) fallback
 } OCCTRayHit;
 
 /// Cast ray against shape and return all intersections
@@ -16455,28 +16447,39 @@ bool OCCTMathNewtonFuncSetRoot(int32_t nVars, int32_t nEqs,
 // (Curve3D/Curve2D.gridEvalD0/D1, Surface.gridEvalD0/D1) forward to the v0.29.0 family.
 
 // MARK: - BRepLProp_CLProps (v0.111.0)
+//
+// Every function in this section and the SLProps one below builds its props through
+// occtEdgeLocalProps / occtFaceLocalProps, so it asks whether a quantity exists at the same
+// resolution as the GeomLProp_*-backed OCCTEdgeGet*3D / OCCTFaceGet* entry points (#529).
 
 /// Get point on edge at parameter using local properties.
-void OCCTEdgeLPropValue(OCCTShapeRef _Nonnull edge, double param,
+/// Returns true if the point was computed, false for a null edge or a parameter the edge's curve
+/// cannot be evaluated at.
+bool OCCTEdgeLPropValue(OCCTShapeRef _Nonnull edge, double param,
                           double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
 
 /// Get tangent direction on edge at parameter. Returns true if tangent is defined.
 bool OCCTEdgeLPropTangent(OCCTShapeRef _Nonnull edge, double param,
                             double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
 
-/// Get curvature on edge at parameter.
+/// Get curvature on edge at parameter. Returns 0 where the tangent is undefined, and OCCT's
+/// RealLast() where the curvature is infinite (a cusp), matching OCCTEdgeGetCurvature3D.
 double OCCTEdgeLPropCurvature(OCCTShapeRef _Nonnull edge, double param);
 
 /// Get normal direction on edge at parameter.
-void OCCTEdgeLPropNormal(OCCTShapeRef _Nonnull edge, double param,
+/// Returns false where there is no normal to report: an undefined tangent, or a curvature that
+/// cannot be inverted (null on a straight stretch, RealLast() at a cusp).
+bool OCCTEdgeLPropNormal(OCCTShapeRef _Nonnull edge, double param,
                            double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
 
 /// Get centre of curvature on edge at parameter.
-void OCCTEdgeLPropCentreOfCurvature(OCCTShapeRef _Nonnull edge, double param,
+/// Returns false under the same conditions as OCCTEdgeLPropNormal. In particular a near-cusp used
+/// to be reported as a successfully computed point of (nan, inf, nan) (#529, and #494 before it).
+bool OCCTEdgeLPropCentreOfCurvature(OCCTShapeRef _Nonnull edge, double param,
                                        double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
 
-/// Get first derivative on edge at parameter.
-void OCCTEdgeLPropD1(OCCTShapeRef _Nonnull edge, double param,
+/// Get first derivative on edge at parameter. Returns true if it was computed.
+bool OCCTEdgeLPropD1(OCCTShapeRef _Nonnull edge, double param,
                        double* _Nonnull d1x, double* _Nonnull d1y, double* _Nonnull d1z);
 
 // MARK: - BRepLProp_SLProps (v0.111.0)

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -74,6 +74,8 @@
 // These four serve the local-properties helpers (occtSurfaceLocalProps and friends).
 #include <GeomLProp_SLProps.hxx>
 #include <GeomLProp_CLProps.hxx>
+#include <BRepLProp_SLProps.hxx>
+#include <BRepLProp_CLProps.hxx>
 #include <Precision.hxx>
 #include <cmath>
 
@@ -1156,9 +1158,11 @@ inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index) {
 // third value in play, the 1e-6 of OCCTGeomLPropCLProps/OCCTGeomLPropSLProps, was the same value
 // #405 removed from OCCTSurfaceCurvatures.
 //
-// The 19 BRepLProp_SLProps/BRepLProp_CLProps constructions elsewhere in the bridge still pass a
-// literal 1e-6. They are a different (adaptor-based) class family asking the same question of a
-// face rather than a surface, tracked separately -- this accessor is the value they should adopt.
+// #529 finished the job on the adaptor side. BRepLProp_SLProps and BRepLProp_CLProps are not a
+// different class family at all: in OCCT 8.0 they are `using` aliases for the very templates
+// GeomLProp_SLProps/GeomLProp_CLProps alias, instantiated over BRepAdaptor_Surface/BRepAdaptor_Curve
+// instead of a Geom_ handle (BRepLProp_SLProps.hxx is nine lines long). Same Resolution, same
+// meaning, so the same value -- see occtFaceLocalProps/occtEdgeLocalProps below.
 inline double occtLocalPropsResolution() { return Precision::Confusion(); }
 
 // Construct the local-properties object for a surface at (u, v), computing derivatives up to
@@ -1180,6 +1184,30 @@ inline GeomLProp_CLProps occtCurveLocalProps(const occ::handle<Geom_Curve>& curv
 inline GeomLProp_CLProps2d occtCurve2dLocalProps(const occ::handle<Geom2d_Curve>& curve,
                                                   double u, int order) {
     return GeomLProp_CLProps2d(curve, u, order, occtLocalPropsResolution());
+}
+
+// The topological counterparts (#529). A face and the surface under it are the same geometry asked
+// the same question, so OCCTFaceLPropMeanCurvature and OCCTFaceGetMeanCurvature have to agree about
+// whether the curvature exists at a given (u, v); the adaptor these read through changes how the
+// derivatives are fetched, not what counts as a null one.
+//
+// Measured on the pinned kernel (Scripts/repro/529-breplprop-resolution/), the two values disagree
+// exactly where the derivative magnitude falls between them: on a cone face approaching its apex,
+// 1e-6 reports the curvature undefined at v = 1e-6 where every Geom_-side entry point reports mean
+// curvature -8.66e5, and the disagreement runs down to v = 3e-7.
+//
+// The adaptor is the caller's, not built here: every one of these call sites needs it for something
+// else too -- its parameter bounds, or a second props object at a different order.
+inline BRepLProp_SLProps occtFaceLocalProps(const BRepAdaptor_Surface& surface,
+                                             double u, double v, int order) {
+    return BRepLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
+}
+
+// Edge counterpart, over BRepAdaptor_Curve. As with occtCurveLocalProps the parameter is bound in
+// the constructor rather than through a later SetParameter() call.
+inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve,
+                                             double u, int order) {
+    return BRepLProp_CLProps(curve, u, order, occtLocalPropsResolution());
 }
 
 // Whether a curvature reported by GeomLProp_CLProps/CLProps2d can be turned into a radius, and so

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1486,18 +1486,26 @@ void OCCTGPropBarycentre(const double* points, int32_t count,
 }
 
 // MARK: - v0.111: BRepLProp_CLProps + SLProps
+//
+// #529: every construction below goes through occtEdgeLocalProps / occtFaceLocalProps, so these
+// fifteen entry points ask "does this quantity exist here" at the same resolution as the
+// GeomLProp_*-backed entry points a few hundred lines above, which #494 converged. They used to
+// pass a literal 1e-6, a decade looser, and a decade is where the disagreement lives: measured on a
+// cone face, OCCTFaceLPropMeanCurvature returned 0 at v = 1e-6 while OCCTFaceGetMeanCurvature
+// returned -8.66e5 for the same point of the same face.
+//
 // MARK: - BRepLProp_CLProps (v0.111.0)
 
-void OCCTEdgeLPropValue(OCCTShapeRef edge, double param, double* x, double* y, double* z) {
+bool OCCTEdgeLPropValue(OCCTShapeRef edge, double param, double* x, double* y, double* z) {
     *x = 0; *y = 0; *z = 0;
-    if (!edge) return;
+    if (!edge) return false;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
-        BRepLProp_CLProps props(ac, 2, 1e-6);
-        props.SetParameter(param);
+        BRepLProp_CLProps props = occtEdgeLocalProps(ac, param, 2);
         gp_Pnt p = props.Value();
         *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+        return true;
+    } catch (...) { return false; }
 }
 
 bool OCCTEdgeLPropTangent(OCCTShapeRef edge, double param, double* dx, double* dy, double* dz) {
@@ -1505,8 +1513,7 @@ bool OCCTEdgeLPropTangent(OCCTShapeRef edge, double param, double* dx, double* d
     if (!edge) return false;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
-        BRepLProp_CLProps props(ac, 2, 1e-6);
-        props.SetParameter(param);
+        BRepLProp_CLProps props = occtEdgeLocalProps(ac, param, 2);
         if (!props.IsTangentDefined()) return false;
         gp_Dir tan;
         props.Tangent(tan);
@@ -1519,48 +1526,60 @@ double OCCTEdgeLPropCurvature(OCCTShapeRef edge, double param) {
     if (!edge) return 0.0;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
-        BRepLProp_CLProps props(ac, 2, 1e-6);
-        props.SetParameter(param);
+        BRepLProp_CLProps props = occtEdgeLocalProps(ac, param, 2);
+        if (!props.IsTangentDefined()) return 0.0;
         return props.Curvature();
     } catch (...) { return 0.0; }
 }
 
-void OCCTEdgeLPropNormal(OCCTShapeRef edge, double param, double* dx, double* dy, double* dz) {
+bool OCCTEdgeLPropNormal(OCCTShapeRef edge, double param, double* dx, double* dy, double* dz) {
     *dx = 0; *dy = 0; *dz = 0;
-    if (!edge) return;
+    if (!edge) return false;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
-        BRepLProp_CLProps props(ac, 2, 1e-6);
-        props.SetParameter(param);
+        BRepLProp_CLProps props = occtEdgeLocalProps(ac, param, 2);
+        if (!props.IsTangentDefined()) return false;
+        // The same gate OCCTEdgeGetNormal3D's neighbour uses. Normal() rejects both a null and a
+        // RealLast() curvature itself, by throwing, so this only replaces an exception with a
+        // return -- but it is the predicate that makes the answer reportable rather than absorbed.
+        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
         gp_Dir n;
         props.Normal(n);
         *dx = n.X(); *dy = n.Y(); *dz = n.Z();
-    } catch (...) {}
+        return true;
+    } catch (...) { return false; }
 }
 
-void OCCTEdgeLPropCentreOfCurvature(OCCTShapeRef edge, double param, double* x, double* y, double* z) {
+bool OCCTEdgeLPropCentreOfCurvature(OCCTShapeRef edge, double param, double* x, double* y, double* z) {
     *x = 0; *y = 0; *z = 0;
-    if (!edge) return;
+    if (!edge) return false;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
-        BRepLProp_CLProps props(ac, 2, 1e-6);
-        props.SetParameter(param);
+        BRepLProp_CLProps props = occtEdgeLocalProps(ac, param, 2);
+        if (!props.IsTangentDefined()) return false;
+        // Unlike Normal(), CentreOfCurvature() does *not* reject the RealLast() sentinel: it tests
+        // only |Curvature()| <= resolution, which RealLast() passes, and then divides by the
+        // myCurvature field the sentinel path never assigned. So a near-cusp used to come back as a
+        // point of (nan, inf, nan) -- measured, on a Bezier whose first two poles sit 1e-8 apart.
+        // #494 found this on the Geom_ side; it is the same template.
+        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
         gp_Pnt p;
         props.CentreOfCurvature(p);
         *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+        return true;
+    } catch (...) { return false; }
 }
 
-void OCCTEdgeLPropD1(OCCTShapeRef edge, double param, double* d1x, double* d1y, double* d1z) {
+bool OCCTEdgeLPropD1(OCCTShapeRef edge, double param, double* d1x, double* d1y, double* d1z) {
     *d1x = 0; *d1y = 0; *d1z = 0;
-    if (!edge) return;
+    if (!edge) return false;
     try {
         BRepAdaptor_Curve ac(TopoDS::Edge(edge->shape));
-        BRepLProp_CLProps props(ac, 1, 1e-6);
-        props.SetParameter(param);
+        BRepLProp_CLProps props = occtEdgeLocalProps(ac, param, 1);
         const gp_Vec& d1 = props.D1();
         *d1x = d1.X(); *d1y = d1.Y(); *d1z = d1.Z();
-    } catch (...) {}
+        return true;
+    } catch (...) { return false; }
 }
 
 // MARK: - BRepLProp_SLProps (v0.111.0)
@@ -1570,7 +1589,7 @@ void OCCTFaceLPropValue(OCCTShapeRef face, double u, double v, double* x, double
     if (!face) return;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         gp_Pnt p = props.Value();
         *x = p.X(); *y = p.Y(); *z = p.Z();
     } catch (...) {}
@@ -1581,7 +1600,7 @@ bool OCCTFaceLPropNormal(OCCTShapeRef face, double u, double v, double* dx, doub
     if (!face) return false;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsNormalDefined()) return false;
         gp_Dir n = props.Normal();
         *dx = n.X(); *dy = n.Y(); *dz = n.Z();
@@ -1593,7 +1612,7 @@ double OCCTFaceLPropMaxCurvature(OCCTShapeRef face, double u, double v) {
     if (!face) return 0.0;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsCurvatureDefined()) return 0.0;
         return props.MaxCurvature();
     } catch (...) { return 0.0; }
@@ -1603,7 +1622,7 @@ double OCCTFaceLPropMinCurvature(OCCTShapeRef face, double u, double v) {
     if (!face) return 0.0;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsCurvatureDefined()) return 0.0;
         return props.MinCurvature();
     } catch (...) { return 0.0; }
@@ -1613,7 +1632,7 @@ double OCCTFaceLPropMeanCurvature(OCCTShapeRef face, double u, double v) {
     if (!face) return 0.0;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsCurvatureDefined()) return 0.0;
         return props.MeanCurvature();
     } catch (...) { return 0.0; }
@@ -1623,7 +1642,7 @@ double OCCTFaceLPropGaussianCurvature(OCCTShapeRef face, double u, double v) {
     if (!face) return 0.0;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsCurvatureDefined()) return 0.0;
         return props.GaussianCurvature();
     } catch (...) { return 0.0; }
@@ -1633,7 +1652,7 @@ bool OCCTFaceLPropIsUmbilic(OCCTShapeRef face, double u, double v) {
     if (!face) return false;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsCurvatureDefined()) return false;
         return props.IsUmbilic();
     } catch (...) { return false; }
@@ -1644,7 +1663,7 @@ bool OCCTFaceLPropTangentU(OCCTShapeRef face, double u, double v, double* dx, do
     if (!face) return false;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsTangentUDefined()) return false;
         gp_Dir tan;
         props.TangentU(tan);
@@ -1658,7 +1677,7 @@ bool OCCTFaceLPropTangentV(OCCTShapeRef face, double u, double v, double* dx, do
     if (!face) return false;
     try {
         BRepAdaptor_Surface as(TopoDS::Face(face->shape));
-        BRepLProp_SLProps props(as, u, v, 2, 1e-6);
+        BRepLProp_SLProps props = occtFaceLocalProps(as, u, v, 2);
         if (!props.IsTangentVDefined()) return false;
         gp_Dir tan;
         props.TangentV(tan);

--- a/Sources/OCCTBridge/src/OCCTBridge_Spatial.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Spatial.mm
@@ -2538,10 +2538,18 @@ int32_t OCCTShapeRaycast(
             double u = intersector.UParameter(i);
             double v = intersector.VParameter(i);
             
-            // Get surface normal at intersection point
+            // Get surface normal at intersection point.
+            //
+            // #529: this used to pass `tolerance` -- the caller's *intersection* tolerance, which
+            // IntCurvesFace_ShapeIntersector::Load takes as a distance -- as the props Resolution,
+            // which CSLib::Normal takes as a SINE tolerance on the angle between the two parametric
+            // directions. A sine tolerance is dimensionless and saturates: measured on the pinned
+            // kernel, raycast(tolerance: 1.0) reported every hit on a sphere as having no normal,
+            // and at 5.0 a box's downward face came back pointing up, because the fallback below is
+            // (0, 0, 1). The intersection tolerance now stops at Load, where it belongs.
             BRepAdaptor_Surface adaptor(hitFace);
-            BRepLProp_SLProps props(adaptor, u, v, 1, tolerance);
-            
+            BRepLProp_SLProps props = occtFaceLocalProps(adaptor, u, v, 1);
+
             OCCTRayHit& hit = outHits[hitCount];
             hit.point[0] = pt.X();
             hit.point[1] = pt.Y();
@@ -2551,6 +2559,8 @@ int32_t OCCTShapeRaycast(
             hit.uv[0] = u;
             hit.uv[1] = v;
             
+            // A hit on a genuinely singular point of a surface still has no normal, and the (0,0,1)
+            // fallback is indistinguishable from a real upward normal, so say which one it is.
             if (props.IsNormalDefined()) {
                 gp_Dir normal = props.Normal();
                 if (hitFace.Orientation() == TopAbs_REVERSED) {
@@ -2559,10 +2569,12 @@ int32_t OCCTShapeRaycast(
                 hit.normal[0] = normal.X();
                 hit.normal[1] = normal.Y();
                 hit.normal[2] = normal.Z();
+                hit.normalDefined = true;
             } else {
                 hit.normal[0] = 0;
                 hit.normal[1] = 0;
                 hit.normal[2] = 1;
+                hit.normalDefined = false;
             }
             
             hitCount++;

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3950,8 +3950,10 @@ bool OCCTFaceGetNormal(OCCTFaceRef face, double* outNx, double* outNy, double* o
         double uMid = (uMin + uMax) / 2.0;
         double vMid = (vMin + vMax) / 2.0;
 
-        // Get surface properties at center
-        BRepLProp_SLProps props(adaptor, uMid, vMid, 1, 1e-6);
+        // Get surface properties at center. Shares its resolution with OCCTFaceGetNormalAtUV, which
+        // answers the same question about the same face at a caller-chosen (u, v) rather than the
+        // parametric midpoint (#529).
+        BRepLProp_SLProps props = occtFaceLocalProps(adaptor, uMid, vMid, 1);
         if (!props.IsNormalDefined()) return false;
 
         gp_Dir normal = props.Normal();
@@ -4035,98 +4037,12 @@ bool OCCTFaceGetZLevel(OCCTFaceRef face, double* outZ) {
     }
 }
 
-OCCTFaceRef* OCCTShapeGetHorizontalFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount) {
-    if (!shape || !outCount) return nullptr;
-    *outCount = 0;
-
-    try {
-        std::vector<TopoDS_Face> horizontalFaces;
-
-        TopExp_Explorer explorer(shape->shape, TopAbs_FACE);
-        while (explorer.More()) {
-            TopoDS_Face face = TopoDS::Face(explorer.Current());
-
-            // Get normal at face center
-            BRepAdaptor_Surface adaptor(face);
-            double uMid = (adaptor.FirstUParameter() + adaptor.LastUParameter()) / 2.0;
-            double vMid = (adaptor.FirstVParameter() + adaptor.LastVParameter()) / 2.0;
-
-            BRepLProp_SLProps props(adaptor, uMid, vMid, 1, 1e-6);
-            if (props.IsNormalDefined()) {
-                gp_Dir normal = props.Normal();
-                if (face.Orientation() == TopAbs_REVERSED) {
-                    normal.Reverse();
-                }
-
-                // Check if horizontal (normal is nearly parallel to Z axis)
-                double angleToZ = std::abs(normal.Z());
-                if (angleToZ > std::cos(tolerance)) {
-                    horizontalFaces.push_back(face);
-                }
-            }
-
-            explorer.Next();
-        }
-
-        if (horizontalFaces.empty()) return nullptr;
-
-        OCCTFaceRef* result = new OCCTFaceRef[horizontalFaces.size()];
-        for (size_t i = 0; i < horizontalFaces.size(); i++) {
-            result[i] = new OCCTFace(horizontalFaces[i]);
-        }
-
-        *outCount = static_cast<int32_t>(horizontalFaces.size());
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-OCCTFaceRef* OCCTShapeGetUpwardFaces(OCCTShapeRef shape, double tolerance, int32_t* outCount) {
-    if (!shape || !outCount) return nullptr;
-    *outCount = 0;
-
-    try {
-        std::vector<TopoDS_Face> upwardFaces;
-
-        TopExp_Explorer explorer(shape->shape, TopAbs_FACE);
-        while (explorer.More()) {
-            TopoDS_Face face = TopoDS::Face(explorer.Current());
-
-            // Get normal at face center
-            BRepAdaptor_Surface adaptor(face);
-            double uMid = (adaptor.FirstUParameter() + adaptor.LastUParameter()) / 2.0;
-            double vMid = (adaptor.FirstVParameter() + adaptor.LastVParameter()) / 2.0;
-
-            BRepLProp_SLProps props(adaptor, uMid, vMid, 1, 1e-6);
-            if (props.IsNormalDefined()) {
-                gp_Dir normal = props.Normal();
-                if (face.Orientation() == TopAbs_REVERSED) {
-                    normal.Reverse();
-                }
-
-                // Check if upward-facing (normal Z > 0 and nearly vertical)
-                if (normal.Z() > std::cos(tolerance)) {
-                    upwardFaces.push_back(face);
-                }
-            }
-
-            explorer.Next();
-        }
-
-        if (upwardFaces.empty()) return nullptr;
-
-        OCCTFaceRef* result = new OCCTFaceRef[upwardFaces.size()];
-        for (size_t i = 0; i < upwardFaces.size(); i++) {
-            result[i] = new OCCTFace(upwardFaces[i]);
-        }
-
-        *outCount = static_cast<int32_t>(upwardFaces.size());
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
-}
+// OCCTShapeGetHorizontalFaces and OCCTShapeGetUpwardFaces were implemented here: second copies
+// of Face.isHorizontal / Face.isUpwardFacing (|n.Z| > cos(tolerance) and n.Z > cos(tolerance) over
+// the midpoint normal OCCTFaceGetNormal already returns), declared, compiled, and reachable from
+// nothing. Shape.horizontalFaces / Shape.upwardFaces filter faces() through those two Face
+// predicates and never called either. Removed by #529, which would otherwise have had to converge
+// their resolution too -- an orphan keeps whatever contract it had when it was orphaned.
 
 // MARK: - Edge Structure
 // OCCTEdge is now defined in OCCTBridge_Internal.h.

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -11389,14 +11389,30 @@ extension PolynomialSolver {
 }
 
 // MARK: - BRepLProp Edge Extensions (v0.111.0)
+//
+// These read an edge through a `BRepAdaptor_Curve`, where `Curve3D.localCurvature` and friends read
+// the curve underneath directly. Since #529 both spellings decide whether a quantity exists at the
+// same resolution (`Precision::Confusion()`), so they agree about definedness at every parameter of
+// every edge; they still differ in the last bits of the values themselves, because the adaptor
+// evaluates a Bezier or BSpline through a cache the raw handle does not use.
 
 extension Shape {
 
-    /// Get point on an edge at parameter using local properties (BRepLProp_CLProps).
+    /// Point on an edge at `param`, through the edge's own adaptor (`BRepLProp_CLProps`).
+    ///
+    /// Returns nil for a parameter the edge cannot be evaluated at. Before #529 it returned
+    /// `(0, 0, 0)` there, wrapped in a non-nil optional.
+    ///
+    /// ```swift
+    /// let edge = Shape.box(width: 10, height: 10, depth: 10)!.subShapes(ofType: .edge)[0]
+    /// if let p = edge.edgeLPropValue(at: 5.0) {
+    ///     print("point at t=5: \(p)")
+    /// }
+    /// ```
     public func edgeLPropValue(at param: Double) -> SIMD3<Double>? {
         var x = 0.0, y = 0.0, z = 0.0
-        OCCTEdgeLPropValue(handle, param, &x, &y, &z)
-        return SIMD3(x, y, z)
+        let ok = OCCTEdgeLPropValue(handle, param, &x, &y, &z)
+        return ok ? SIMD3(x, y, z) : nil
     }
 
     /// Get tangent direction on an edge at parameter. Returns nil if tangent is undefined.
@@ -11406,30 +11422,61 @@ extension Shape {
         return ok ? SIMD3(dx, dy, dz) : nil
     }
 
-    /// Get curvature on an edge at parameter using local properties.
+    /// Curvature on an edge at `param`, through the edge's own adaptor.
+    ///
+    /// Returns 0 where the tangent is undefined, and `Double.greatestFiniteMagnitude` (OCCT's
+    /// `RealLast()`, meaning infinite curvature) at a cusp — the same two sentinels
+    /// ``Curve3D/curvature(at:)`` reports for the curve underneath.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 4)!
+    /// let edge = Shape.edgeFromCurve(arc)!
+    /// let k = edge.edgeCurvatureLP(at: 0.5)   // 0.25, the reciprocal of the radius
+    /// ```
     public func edgeCurvatureLP(at param: Double) -> Double {
         return OCCTEdgeLPropCurvature(handle, param)
     }
 
-    /// Get normal direction on an edge at parameter.
-    public func edgeNormalLP(at param: Double) -> SIMD3<Double> {
+    /// Normal direction on an edge at `param`.
+    ///
+    /// Returns nil where the curvature cannot be inverted into a direction: a straight stretch has
+    /// no normal, and neither does a cusp. Before #529 both cases returned `(0, 0, 0)`, which is
+    /// not a direction.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 4)!
+    /// let edge = Shape.edgeFromCurve(arc)!
+    /// if let n = edge.edgeNormalLP(at: 0) { print("points at the centre: \(n)") }
+    /// ```
+    public func edgeNormalLP(at param: Double) -> SIMD3<Double>? {
         var dx = 0.0, dy = 0.0, dz = 0.0
-        OCCTEdgeLPropNormal(handle, param, &dx, &dy, &dz)
-        return SIMD3(dx, dy, dz)
+        let ok = OCCTEdgeLPropNormal(handle, param, &dx, &dy, &dz)
+        return ok ? SIMD3(dx, dy, dz) : nil
     }
 
-    /// Get centre of curvature on an edge at parameter.
-    public func edgeCentreOfCurvature(at param: Double) -> SIMD3<Double> {
+    /// Centre of curvature on an edge at `param` — the centre of the circle that osculates the edge
+    /// there.
+    ///
+    /// Returns nil wherever there is no such circle, on the same terms as ``edgeNormalLP(at:)``.
+    /// Before #529 a near-cusp returned `(nan, inf, nan)` as though it were a point.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.circle(center: SIMD3(1, 2, 0), normal: SIMD3(0, 0, 1), radius: 4)!
+    /// let edge = Shape.edgeFromCurve(arc)!
+    /// if let c = edge.edgeCentreOfCurvature(at: 0) { print(c) }   // ~ (1, 2, 0)
+    /// ```
+    public func edgeCentreOfCurvature(at param: Double) -> SIMD3<Double>? {
         var x = 0.0, y = 0.0, z = 0.0
-        OCCTEdgeLPropCentreOfCurvature(handle, param, &x, &y, &z)
-        return SIMD3(x, y, z)
+        let ok = OCCTEdgeLPropCentreOfCurvature(handle, param, &x, &y, &z)
+        return ok ? SIMD3(x, y, z) : nil
     }
 
-    /// Get first derivative on an edge at parameter.
-    public func edgeLPropD1(at param: Double) -> SIMD3<Double> {
+    /// First derivative on an edge at `param`. Returns nil for a parameter the edge cannot be
+    /// evaluated at.
+    public func edgeLPropD1(at param: Double) -> SIMD3<Double>? {
         var d1x = 0.0, d1y = 0.0, d1z = 0.0
-        OCCTEdgeLPropD1(handle, param, &d1x, &d1y, &d1z)
-        return SIMD3(d1x, d1y, d1z)
+        let ok = OCCTEdgeLPropD1(handle, param, &d1x, &d1y, &d1z)
+        return ok ? SIMD3(d1x, d1y, d1z) : nil
     }
 }
 

--- a/Sources/OCCTSwift/Selection.swift
+++ b/Sources/OCCTSwift/Selection.swift
@@ -8,28 +8,48 @@ import OCCTBridge
 public struct RayHit: Sendable {
     /// 3D point where ray intersects surface
     public let point: SIMD3<Double>
-    
-    /// Surface normal at intersection point
+
+    /// Surface normal at intersection point.
+    ///
+    /// `(0, 0, 1)` where the surface has no normal at the hit point — check ``normalDefined``
+    /// rather than reading an upward normal as a fact about the geometry.
     public let normal: SIMD3<Double>
-    
+
     /// Index of the face that was hit (0-based)
     public let faceIndex: Int
-    
+
     /// Distance from ray origin to intersection point
     public let distance: Double
-    
+
     /// UV parameters on the surface at intersection
     public let uv: SIMD2<Double>
+
+    /// Whether ``normal`` is the surface's own normal or the `(0, 0, 1)` fallback.
+    ///
+    /// False only at a genuinely singular point of the surface. Until #529 it was also false
+    /// whenever `tolerance` was raised past about 1, because the intersection tolerance doubled as
+    /// the local-property resolution, where it is a dimensionless sine tolerance.
+    public let normalDefined: Bool
 }
 
 // MARK: - Shape Ray Casting Extension
 
 extension Shape {
     /// Cast a ray against the shape and find all intersections
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)
+    /// for hit in box.raycast(origin: SIMD3(0, 0, 20), direction: SIMD3(0, 0, -1)) {
+    ///     print("\(hit.distance) away, normal \(hit.normalDefined ? "\(hit.normal)" : "undefined")")
+    /// }
+    /// ```
+    ///
     /// - Parameters:
     ///   - origin: Starting point of the ray
     ///   - direction: Direction of the ray (will be normalized)
-    ///   - tolerance: Intersection tolerance (default: 0.001)
+    ///   - tolerance: Intersection tolerance (default: 0.001). Since #529 this bounds the
+    ///     intersection only; the surface normal reported for each hit is computed at the same
+    ///     resolution as every other local-property call, so raising it no longer erases normals.
     ///   - maxHits: Maximum number of hits to return (default: 100)
     /// - Returns: Array of ray hits sorted by distance
     public func raycast(
@@ -65,7 +85,8 @@ extension Shape {
                 normal: SIMD3(hit.normal.0, hit.normal.1, hit.normal.2),
                 faceIndex: Int(hit.faceIndex),
                 distance: hit.distance,
-                uv: SIMD2(hit.uv.0, hit.uv.1)
+                uv: SIMD2(hit.uv.0, hit.uv.1),
+                normalDefined: hit.normalDefined
             ))
         }
         

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -6190,7 +6190,8 @@ struct AdaptorLocalPropsParityTests {
                 continue
             }
             // Non-zero is what makes this discriminating: the adaptor family reports 0 both for
-            // "flat here" and for "undefined here", so a zero expectation would pass pre-fix too.
+            // "flat here" and for "undefined here" (#583), so a zero expectation would pass pre-fix
+            // too.
             #expect(mean != 0, label)
             expectClose(shape.faceLPropMeanCurvature(u: 0, v: v), mean, label)
             expectClose(shape.faceLPropGaussianCurvature(u: 0, v: v), gaussian, label)
@@ -6227,7 +6228,8 @@ struct AdaptorLocalPropsParityTests {
                 for (u, v) in [(0.3, 0.2), (1.1, -0.4), (2.0, 0.9)] {
                     let label: Comment = "\(name) u=\(u) v=\(v)"
                     let mean = face.meanCurvature(atU: u, v: v)
-                    // Definedness has to match; the adaptor family spells "undefined" as 0.
+                    // Definedness has to match; the adaptor family spells "undefined" as 0, so this
+                    // half can only be asserted one way until #583 makes it optional.
                     if let mean {
                         expectClose(faceShape.faceLPropMeanCurvature(u: u, v: v), mean, label)
                     }

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -4767,9 +4767,10 @@ struct BRepLPropEdgeTests {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             let edges = box.subShapes(ofType: .edge)
             if edges.count > 0 {
-                let d1 = edges[0].edgeLPropD1(at: 0.5)
-                let len = sqrt(d1.x * d1.x + d1.y * d1.y + d1.z * d1.z)
-                #expect(len > 0.0)
+                if let d1 = edges[0].edgeLPropD1(at: 0.5) {
+                    let len = sqrt(d1.x * d1.x + d1.y * d1.y + d1.z * d1.z)
+                    #expect(len > 0.0)
+                }
             }
         }
     }
@@ -6117,5 +6118,331 @@ struct ShapeMeasurementsTests {
             }
         }
         #expect(capCount == 2, "cylinder has 2 circular caps, found \(capCount)")
+    }
+}
+
+// MARK: - #529: the adaptor-backed local-properties family agrees with the Geom_-backed one
+
+/// `Shape.faceLProp*` / `Shape.edge*LP` read a face or an edge through a `BRepAdaptor_Surface` /
+/// `BRepAdaptor_Curve`; `Face.meanCurvature(atU:v:)` / `Edge.curvature(at:)` and their siblings read
+/// the surface or curve underneath directly. In OCCT 8.0 both go through the *same* header-only
+/// templates — `BRepLProp_SLProps` is a nine-line `using` alias for the template
+/// `GeomLProp_SLProps` also aliases — so the `Resolution` they pass means the same thing, and two
+/// entry points passing different values disagree about whether a quantity exists at all.
+///
+/// #494 converged all 28 `GeomLProp_*` constructions onto `Precision::Confusion()` and left the 18
+/// `BRepLProp_*` ones on a literal `1e-6`, a decade looser. Measured on the pinned kernel, that
+/// decade is exactly where they disagreed: on a cone face approaching its apex,
+/// `faceLPropMeanCurvature` returned 0 (undefined) at `v = 1e-6` where `Face.meanCurvature` returned
+/// -8.66e5 for the same point of the same face, and the disagreement ran down to `v = 3e-7`.
+///
+/// Probes: `Scripts/repro/529-breplprop-resolution/`.
+@Suite("BRepLProp/GeomLProp local-properties parity (#529)")
+struct AdaptorLocalPropsParityTests {
+
+    /// A cone with `radius: 0` — the apex sits at `v = 0`, and |dS/du| falls off linearly with `v`,
+    /// so sweeping `v` walks smoothly through both resolutions' thresholds. The face keeps the apex
+    /// out of its own `v` range so the sampled points are all interior.
+    private static func apexConeFace() -> (Shape, Face)? {
+        guard let cone = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1),
+                                      radius: 0, semiAngle: .pi / 6),
+              let shape = Shape.face(from: cone, uRange: 0...(2 * .pi), vRange: (-1.0)...10.0),
+              let face = Face(shape) else { return nil }
+        return (shape, face)
+    }
+
+    /// A cubic Bezier edge whose first two poles sit `spacing` apart, so `|D1(0)| = 3 * spacing`.
+    private static func cuspBezierEdge(spacing: Double) -> (Shape, Edge)? {
+        guard let bez = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(spacing, 0, 0),
+                                               SIMD3(1, 1, 0), SIMD3(2, 0, 0)]),
+              let shape = Shape.edgeFromCurve(bez),
+              let edge = Edge(shape) else { return nil }
+        return (shape, edge)
+    }
+
+    /// Relative comparison. The two families are not required to agree bit for bit: a
+    /// `BRepAdaptor_Curve` evaluates a Bezier or BSpline through an evaluation cache the raw
+    /// `Geom_Curve` handle does not use, which moves the last ULP (measured: 0.67461923686773151 vs
+    /// 0.6746192368677314 for the same curvature). Definedness, the thing #529 is about, is asserted
+    /// exactly.
+    private func expectClose(_ lhs: Double, _ rhs: Double, _ label: Comment) {
+        let scale = max(abs(lhs), abs(rhs), 1.0)
+        #expect(abs(lhs - rhs) <= 1e-9 * scale, label)
+    }
+
+    // MARK: Face
+
+    /// The regression proper, on the surface side. Every `v` from 3e-7 up to 1e-6 lands between
+    /// `Precision::Confusion()` and the old `1e-6`, so pre-fix `faceLPropMeanCurvature` returned 0
+    /// for a point where `Face.meanCurvature` returned a large negative number.
+    @Test("Inside the old 1e-6 window the two face families agree")
+    func faceToleranceWindowAgrees() {
+        guard let (shape, face) = Self.apexConeFace() else {
+            Issue.record("could not build the apex cone face")
+            return
+        }
+
+        for v in [3e-7, 5e-7, 1e-6, 1.5e-6, 3e-6, 1e-5, 1e-2, 1.0] {
+            let label: Comment = "cone v=\(v)"
+            guard let mean = face.meanCurvature(atU: 0, v: v),
+                  let gaussian = face.gaussianCurvature(atU: 0, v: v) else {
+                Issue.record("Face.meanCurvature undefined at v=\(v), which the probe reports as defined")
+                continue
+            }
+            // Non-zero is what makes this discriminating: the adaptor family reports 0 both for
+            // "flat here" and for "undefined here", so a zero expectation would pass pre-fix too.
+            #expect(mean != 0, label)
+            expectClose(shape.faceLPropMeanCurvature(u: 0, v: v), mean, label)
+            expectClose(shape.faceLPropGaussianCurvature(u: 0, v: v), gaussian, label)
+        }
+    }
+
+    @Test("Principal curvatures agree wherever the Geom_ family defines them")
+    func facePrincipalCurvaturesAgree() {
+        guard let (shape, face) = Self.apexConeFace() else {
+            Issue.record("could not build the apex cone face")
+            return
+        }
+        for v in [5e-7, 1e-6, 1e-3, 2.0] {
+            guard let principal = face.principalCurvatures(atU: 0.4, v: v) else { continue }
+            expectClose(shape.faceLPropMaxCurvature(u: 0.4, v: v), principal.kMax, "cone v=\(v)")
+            expectClose(shape.faceLPropMinCurvature(u: 0.4, v: v), principal.kMin, "cone v=\(v)")
+        }
+    }
+
+    /// A well-conditioned control, so the suite is not only about degenerate points.
+    @Test("Ordinary points on a sphere and a cylinder agree")
+    func ordinaryFacePointsAgree() {
+        let shapes: [(String, Shape?)] = [
+            ("sphere", Shape.sphere(radius: 5)),
+            ("cylinder", Shape.cylinder(radius: 3, height: 12)),
+        ]
+        for (name, solid) in shapes {
+            guard let solid else {
+                Issue.record("\(name) returned nil")
+                continue
+            }
+            for faceShape in solid.subShapes(ofType: .face) {
+                guard let face = Face(faceShape) else { continue }
+                for (u, v) in [(0.3, 0.2), (1.1, -0.4), (2.0, 0.9)] {
+                    let label: Comment = "\(name) u=\(u) v=\(v)"
+                    let mean = face.meanCurvature(atU: u, v: v)
+                    // Definedness has to match; the adaptor family spells "undefined" as 0.
+                    if let mean {
+                        expectClose(faceShape.faceLPropMeanCurvature(u: u, v: v), mean, label)
+                    }
+                    // The normal is reported by both, but only the Geom_ spelling applies the
+                    // face's orientation, so they agree up to sign — a contract difference, not
+                    // drift, and worth pinning so it is not mistaken for one later.
+                    let adaptorNormal = faceShape.faceLPropNormal(u: u, v: v)
+                    let orientedNormal = face.normal(atU: u, v: v)
+                    #expect((adaptorNormal != nil) == (orientedNormal != nil), label)
+                    if let adaptorNormal, let orientedNormal {
+                        let dot = simd_dot(adaptorNormal, orientedNormal)
+                        #expect(abs(abs(dot) - 1.0) < 1e-9, label)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Edge
+
+    /// The curve-side regression. At a pole spacing of 3e-7 the first derivative at `u = 0` is
+    /// 9e-7: significant at `Precision::Confusion()`, null at `1e-6`. Pre-fix the adaptor family
+    /// answered `RealLast()` (infinite curvature, the cusp sentinel) where the Geom_ family answered
+    /// 7.4e12.
+    @Test("Inside the old 1e-6 window the two edge families agree")
+    func edgeToleranceWindowAgrees() {
+        for spacing in [3e-7, 5e-7, 1e-6, 1e-5, 1e-3] {
+            guard let (shape, edge) = Self.cuspBezierEdge(spacing: spacing) else {
+                Issue.record("could not build the Bezier edge at spacing \(spacing)")
+                continue
+            }
+            let label: Comment = "spacing=\(spacing)"
+            guard let curvature = edge.curvature(at: 0) else {
+                Issue.record("Edge.curvature undefined at spacing \(spacing)")
+                continue
+            }
+            #expect(curvature != .greatestFiniteMagnitude, label)
+            expectClose(shape.edgeCurvatureLP(at: 0), curvature, label)
+
+            let adaptorCentre = shape.edgeCentreOfCurvature(at: 0)
+            let geomCentre = edge.centerOfCurvature(at: 0)
+            #expect((adaptorCentre != nil) == (geomCentre != nil), label)
+            if let adaptorCentre, let geomCentre {
+                expectClose(adaptorCentre.x, geomCentre.x, label)
+                expectClose(adaptorCentre.y, geomCentre.y, label)
+                expectClose(adaptorCentre.z, geomCentre.z, label)
+            }
+        }
+    }
+
+    /// The `RealLast()` defect, on the adaptor side this time. `CentreOfCurvature()` tests only
+    /// `|Curvature()| <= resolution`, which the infinite-curvature sentinel passes, and then divides
+    /// by the `myCurvature` field the sentinel path never assigned — so a near-cusp came back as a
+    /// point of `(nan, inf, nan)`, reported as a success.
+    @Test("A cusp has no centre of curvature and no normal, and does not fake one")
+    func cuspHasNoCentreOfCurvature() {
+        for spacing in [0.0, 1e-12, 1e-9, 1e-8] {
+            guard let (shape, edge) = Self.cuspBezierEdge(spacing: spacing) else {
+                Issue.record("could not build the Bezier edge at spacing \(spacing)")
+                continue
+            }
+            let label: Comment = "spacing=\(spacing)"
+            #expect(shape.edgeCentreOfCurvature(at: 0) == nil, label)
+            #expect(shape.edgeNormalLP(at: 0) == nil, label)
+            // Both families agree it is a cusp rather than an ordinary point.
+            #expect(edge.centerOfCurvature(at: 0) == nil, label)
+            #expect(shape.edgeCurvatureLP(at: 0) == .greatestFiniteMagnitude, label)
+        }
+    }
+
+    @Test("A straight edge has no centre of curvature and no normal")
+    func straightEdgeHasNoCentreOfCurvature() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("Shape.box returned nil")
+            return
+        }
+        let edges = box.subShapes(ofType: .edge)
+        #expect(!edges.isEmpty)
+        for edgeShape in edges {
+            #expect(edgeShape.edgeCentreOfCurvature(at: 5.0) == nil)
+            #expect(edgeShape.edgeNormalLP(at: 5.0) == nil)
+            #expect(edgeShape.edgeCurvatureLP(at: 5.0) == 0.0)
+            // The point and the derivative are still perfectly well defined there.
+            #expect(edgeShape.edgeLPropValue(at: 5.0) != nil)
+            #expect(edgeShape.edgeLPropD1(at: 5.0) != nil)
+        }
+    }
+
+    /// A circle is the case where the centre of curvature has one obvious right answer.
+    @Test("A circular edge's centre of curvature is its centre")
+    func circleCentreOfCurvature() {
+        guard let circle = Curve3D.circle(center: SIMD3(1, 2, 0), normal: SIMD3(0, 0, 1), radius: 4),
+              let edge = Shape.edgeFromCurve(circle) else {
+            Issue.record("could not build the circular edge")
+            return
+        }
+        for u in [0.0, 1.0, 2.5, 4.0] {
+            guard let centre = edge.edgeCentreOfCurvature(at: u) else {
+                Issue.record("no centre of curvature at u=\(u)")
+                continue
+            }
+            #expect(abs(centre.x - 1) < 1e-9, "u=\(u)")
+            #expect(abs(centre.y - 2) < 1e-9, "u=\(u)")
+            #expect(abs(centre.z) < 1e-9, "u=\(u)")
+            #expect(abs(edge.edgeCurvatureLP(at: u) - 0.25) < 1e-9, "u=\(u)")
+        }
+    }
+}
+
+/// The two `BRepLProp_SLProps` sites that are not curvature reporting: the midpoint normal behind
+/// `Face.normal` (and so behind every `isHorizontal` / `isUpwardFacing` / `isVertical` predicate),
+/// and the per-hit normal `Shape.raycast` returns.
+///
+/// The face-normal change is inert, which is a measurement rather than an assumption: `CSLib::Normal`
+/// tests the two first derivatives for nullity against `gp::Resolution()`, a fixed ~1e-300 epsilon,
+/// and uses the caller's value only as a **sine** tolerance on the angle between them. That test is
+/// scale-invariant, so a surface whose derivatives merely shrink keeps a defined normal all the way
+/// down. Swept over 662 faces of a real sewn solid plus every primitive here, not one face changed
+/// definedness or direction (`Scripts/repro/529-breplprop-resolution/occt_529_face_normal_decisions.cpp`).
+///
+/// The raycast change is not inert at all. A sine tolerance is dimensionless and saturates, and
+/// `raycast` was passing its caller's *intersection* tolerance into that slot.
+@Suite("Midpoint and raycast normals under the shared resolution (#529)")
+struct AdaptorNormalDecisionTests {
+
+    @Test("Primitive face normals and orientation predicates are unchanged")
+    func primitiveFaceNormalsUnchanged() {
+        let cases: [(String, Shape?, Int, Int)] = [
+            // shape, expected horizontal faces, expected upward faces
+            ("box", Shape.box(width: 10, height: 20, depth: 30), 2, 1),
+            ("cylinder", Shape.cylinder(radius: 5, height: 20), 2, 1),
+            ("cone", Shape.cone(bottomRadius: 5, topRadius: 0, height: 12), 1, 0),
+            ("sphere", Shape.sphere(radius: 7), 0, 0),
+        ]
+        for (name, solid, horizontal, upward) in cases {
+            guard let solid else {
+                Issue.record("\(name) returned nil")
+                continue
+            }
+            let faces = solid.faces()
+            #expect(faces.allSatisfy { $0.normal != nil || !$0.isPlanar },
+                    "\(name): a planar face with no normal")
+            #expect(solid.horizontalFaces().count == horizontal, "\(name) horizontal")
+            #expect(solid.upwardFaces().count == upward, "\(name) upward")
+        }
+    }
+
+    /// A face whose two parametric directions are *nearly parallel* is the one shape the sine
+    /// tolerance actually rejects. Skewing a linear extrusion by 5e-7 radians puts it between the
+    /// two values: the normal is undefined at `1e-6` and defined at `Precision::Confusion()`.
+    @Test("A nearly-degenerate parameterisation now reports its normal")
+    func skewedExtrusionHasANormal() {
+        guard let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)) else {
+            Issue.record("Curve3D.line returned nil")
+            return
+        }
+        let skew = 5e-7
+        guard let surface = Surface.extrusion(profile: line,
+                                              direction: SIMD3(cos(skew), sin(skew), 0)),
+              let shape = Shape.face(from: surface, uRange: 0...10, vRange: 0...10),
+              let face = Face(shape) else {
+            Issue.record("could not build the skewed extrusion face")
+            return
+        }
+        guard let normal = face.normal else {
+            Issue.record("the skewed extrusion face reports no normal")
+            return
+        }
+        #expect(abs(abs(normal.z) - 1.0) < 1e-6, "normal \(normal)")
+        #expect(face.isHorizontal())
+    }
+
+    /// The raycast regression. `tolerance` is documented as the intersection tolerance and it used
+    /// to double as the props resolution, where it is a dimensionless sine tolerance — so any value
+    /// at or above 1 rejected every normal there is, and `RayHit.normal` fell back to `(0, 0, 1)`
+    /// for every hit on every shape.
+    @Test("Raising the intersection tolerance does not erase the hit normals")
+    func raycastNormalsSurviveALooseTolerance() {
+        guard let sphere = Shape.sphere(radius: 5) else {
+            Issue.record("Shape.sphere returned nil")
+            return
+        }
+        for tolerance in [0.001, 0.1, 1.0, 2.0, 5.0] {
+            let hits = sphere.raycast(origin: SIMD3(-20, 0, 0),
+                                      direction: SIMD3(1, 0, 0),
+                                      tolerance: tolerance)
+            let label: Comment = "tolerance=\(tolerance)"
+            #expect(hits.count == 2, label)
+            for hit in hits {
+                #expect(hit.normalDefined, label)
+                // A sphere's normal is radial: parallel to the hit point itself.
+                let radial = simd_normalize(hit.point)
+                #expect(abs(abs(simd_dot(radial, hit.normal)) - 1.0) < 1e-6,
+                        "\(label) hit \(hit.point) normal \(hit.normal)")
+            }
+        }
+    }
+
+    @Test("A box's downward face still reports a downward normal at a loose tolerance")
+    func raycastKeepsFaceOrientationAtALooseTolerance() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("Shape.box returned nil")
+            return
+        }
+        for tolerance in [0.001, 1.0, 5.0] {
+            let hits = box.raycast(origin: SIMD3(0, 0, 40),
+                                   direction: SIMD3(0, 0, -1),
+                                   tolerance: tolerance)
+            let label: Comment = "tolerance=\(tolerance)"
+            #expect(hits.count == 2, label)
+            guard hits.count == 2 else { continue }
+            #expect(hits.allSatisfy { $0.normalDefined }, label)
+            // Nearest hit is the top face, pointing up; the far one is the bottom, pointing down.
+            #expect(hits[0].normal.z > 0.99, "\(label) near \(hits[0].normal)")
+            #expect(hits[1].normal.z < -0.99, "\(label) far \(hits[1].normal)")
+        }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -393,6 +393,108 @@ membership contract above. Proved against three injections rather than assumed: 
 returns its input unchanged, one that drops the last requested face, and a `defeature` that reports
 failure as the input shape each fail the tests that cover them, and only those.
 
+#### Breaking: one resolution behind the adaptor-backed local properties too, and the raycast normal it was quietly erasing (#529)
+
+#494 converged all 28 `GeomLProp_SLProps` / `GeomLProp_CLProps` / `GeomLProp_CLProps2d` constructions
+in the bridge onto `Precision::Confusion()` and recorded the `BRepLProp_*` half as a separate job on
+the grounds that it is "a different class family". It is not. In OCCT 8.0 `BRepLProp_SLProps.hxx` is
+nine lines long:
+
+```cpp
+using BRepLProp_SLProps = GeomLProp_SLPropsBase<BRepAdaptor_Surface>;
+```
+
+The same header-only template `GeomLProp_SLProps` aliases, over an adaptor instead of a
+`Geom_Surface` handle. Same `Resolution` argument, same meaning, so the 18 sites passing a literal
+`1e-6` were asking whether a quantity exists at a threshold a decade looser than the sites they sit
+beside. Measured on the pinned kernel, that decade is exactly where they disagreed: on a cone face
+approaching its apex, `Shape.faceLPropMeanCurvature(u: 0, v: 1e-6)` returned `0` — its spelling of
+"undefined" — where `Face.meanCurvature(atU: 0, v: 1e-6)` returned `-8.66e5` for the same point of
+the same face, and the disagreement ran down to `v = 3e-7`. All 18 now build through
+`occtFaceLocalProps` / `occtEdgeLocalProps`, alongside #494's `occtSurfaceLocalProps` and friends.
+
+**The census in the issue was three counts off**, in the direction of more work rather than less:
+
+| the issue says | measured |
+|---|---|
+| 19 literal-`1e-6` sites, 16 in `OCCTBridge_Properties.mm` | 18, of which 15 are in `Properties.mm` |
+| a different class family, so #494's factories are not reusable | the same two templates, one adaptor argument apart |
+| all three `Topology.mm` sites decide face *orientation*, not reported values | one of them is `OCCTFaceGetNormal`, which backs `Face.normal` and every `isHorizontal` / `isUpwardFacing` / `isVertical` predicate |
+| `OCCTShapeRaycast`'s caller-supplied tolerance is "not obviously wrong" | it is the worst site of the 19 (below) |
+
+**`raycast(tolerance:)` was erasing its own normals.** `OCCTShapeRaycast` forwarded the caller's
+tolerance twice: to `IntCurvesFace_ShapeIntersector::Load`, where it is the intersection distance it
+is documented as, and to `BRepLProp_SLProps`, where it becomes the resolution — which
+`CSLib::Normal` uses as a **sine** tolerance on the angle between the two parametric directions.
+That quantity is dimensionless and saturates. Measured: `raycast(tolerance: 1.0)` against a sphere
+reported no normal for either hit, so both fell back to `(0, 0, 1)`; at `5.0` a box's *downward*
+face came back pointing up. The intersection tolerance now stops at `Load`. `RayHit` also gains
+`normalDefined`, because the `(0, 0, 1)` fallback is otherwise indistinguishable from a real upward
+normal at a genuinely singular hit point. (Additive: `RayHit`'s memberwise initialiser is internal,
+so no caller constructs one.)
+
+**The curvature-inversion defect #494 found is on this side too, and `1e-6` made its window a decade
+wider.** `LProp_CurveUtils::Curvature()` returns `RealLast()` to mean infinite curvature at a cusp,
+on a path that never assigns the `myCurvature` field; `CentreOfCurvature()` tests only
+`|Curvature()| <= resolution`, which the sentinel passes, and then divides by that unassigned field.
+`Normal()` rejects the sentinel by name and throws; `CentreOfCurvature()` hands back a point of
+`(nan, inf, nan)` as a success. Both edge entry points that invert a curvature now gate on
+`occtCurveCurvatureIsInvertible`, the predicate #494 added. Measured on a cubic Bezier whose first
+two poles sit a controlled distance apart, at `u = 0`:
+
+| pole spacing | at `1e-6` (before) | at `Precision::Confusion()` (after) |
+|---|---|---|
+| 1e-3 … 1e-6 | real centre | real centre |
+| 3e-7 | `(nan, inf, nan)` reported as a point | real centre `(0, 1.35e-13, 0)` |
+| 1e-7 | `(inf, inf, nan)` reported as a point | real centre `(2.8e-30, 1.5e-14, 0)` |
+| 1e-8 … 1e-12 | `(nan, inf, nan)` reported as a point | `nil` — no centre of curvature at a cusp |
+| 0 (exactly coincident) | `(0, 0, 0)`, from the absorbed throw | `nil` |
+
+**Source-breaking, in four places**, all of them entry points that could not previously say "there
+is nothing here": `Shape.edgeNormalLP(at:)` and `Shape.edgeCentreOfCurvature(at:)` return
+`SIMD3<Double>?` rather than `SIMD3<Double>` (they returned `(0, 0, 0)` — not a direction, not a
+point — where the quantity does not exist), and `Shape.edgeLPropD1(at:)` joins them. Not a signature
+change but a behaviour one: `Shape.edgeLPropValue(at:)` was already declared optional and never
+returned `nil`; now it does.
+
+**Two of the three `Topology.mm` sites were orphans and are deleted rather than converged.**
+`OCCTShapeGetHorizontalFaces` and `OCCTShapeGetUpwardFaces` reimplemented `Face.isHorizontal` /
+`Face.isUpwardFacing` over the same midpoint normal, and nothing called them: `Shape.horizontalFaces`
+and `Shape.upwardFaces` filter `faces()` through the `Face` predicates. Same reasoning as #506 —
+`OCCTBridge` is a target, not a product, and an orphan freezes whatever contract it had when it was
+orphaned, so leaving them would have meant maintaining a second `1e-6` behind a symbol with no
+callers.
+
+**The surviving `Topology.mm` site's change is inert, and that is a measurement, not an assumption.**
+`CSLib::Normal` tests the two first derivatives for nullity against `gp::Resolution()` — a fixed
+~1e-300 epsilon, not the caller's value — and uses the caller's value only as the sine tolerance
+above. A surface whose derivatives merely shrink keeps a defined normal all the way down, which is
+why tightening the value changes nothing for the normal-only sites. Swept over every face of a box,
+cylinder, sphere, apex cone, frustum, torus, hemisphere, a fully filleted box and the 662 faces of
+`unify-crash-mmd-kiha10-body5.brep`: zero faces changed definedness, zero changed direction, and the
+horizontal (18) and upward (9) counts on the real fixture are identical before and after. The one
+geometry that does move is a nearly *singular parameterisation* — a linear extrusion skewed by 5e-7
+radians, whose normal is undefined at `1e-6` and defined at `Precision::Confusion()`.
+
+New suites `AdaptorLocalPropsParityTests` and `AdaptorNormalDecisionTests` (`OCCTAnalysisTests`), 11
+tests, following #494's `LocalPropsParityTests` pattern: each adaptor-backed entry point is asserted
+to agree with its `Geom_`-backed counterpart about definedness exactly, and about value to a
+relative tolerance — not bit for bit, because a `BRepAdaptor_Curve` evaluates a Bezier or BSpline
+through a cache the raw handle does not use, which moves the last ULP (measured: 0.67461923686773151
+against 0.6746192368677314 for the same curvature). Proved against three separate injections rather
+than assumed: restoring the `1e-6` resolution fails 4 tests, removing the two invertibility gates
+fails 1 (on the `(nan, inf, nan)` centre), and restoring the raycast tolerance forwarding fails 2.
+Four tests are controls and pass under all three.
+
+Probes and full figures at
+[`Scripts/repro/529-breplprop-resolution/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/529-breplprop-resolution).
+Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild.
+
+**Noticed, not fixed.** The face-side curvature getters (`faceLPropMaxCurvature` and its four
+siblings) still spell "undefined" as `0`, where the `Face` counterparts return `nil` — the
+silent-zero class #486 and #494 have both hit, and a wider change than a resolution. Filed rather
+than folded in.
+
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 
 `OCCTCurve3DArcLength`, `OCCTCurve3DArcLengthBetween` and `OCCTCurve3DLength` are gone. #408 routed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -492,8 +492,8 @@ Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild.
 
 **Noticed, not fixed.** The face-side curvature getters (`faceLPropMaxCurvature` and its four
 siblings) still spell "undefined" as `0`, where the `Face` counterparts return `nil` — the
-silent-zero class #486 and #494 have both hit, and a wider change than a resolution. Filed rather
-than folded in.
+silent-zero class #486 and #494 have both hit, and five more source-breaking signatures on top of
+the four here. Filed as #583 rather than folded in.
 
 #### Three orphaned arc-length bridge functions deleted, and they were not spare copies (#506)
 

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -1020,6 +1020,12 @@ public static func quinticRoots(a: Double, b: Double, c: Double, d: Double, e: D
 
 Extension on `Shape` for edge-level local geometric properties using `BRepLProp_CLProps`.
 
+These read an edge through a `BRepAdaptor_Curve`; [`Edge.curvature(at:)`](Edge.md) and its siblings
+read the curve underneath directly. Since #529 both decide whether a quantity exists at the same
+resolution (`Precision::Confusion()`), so the two spellings agree about definedness at every
+parameter of every edge. The values themselves can still differ in the last bits, because the
+adaptor evaluates a Bezier or B-spline through a cache the raw handle does not use.
+
 ### `Shape.edgeLPropValue(at:)`
 
 Evaluate the 3D point on an edge at the given parameter.
@@ -1028,7 +1034,8 @@ Evaluate the 3D point on an edge at the given parameter.
 public func edgeLPropValue(at param: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** Point on the edge curve at `param`.
+- **Returns:** Point on the edge curve at `param`, or `nil` for a parameter the edge cannot be
+  evaluated at. Before #529 the failure case returned `(0, 0, 0)` inside a non-`nil` optional.
 - **OCCT:** `BRepLProp_CLProps::Value` via `OCCTEdgeLPropValue`.
 
 ---
@@ -1054,7 +1061,9 @@ Scalar curvature on an edge at the given parameter.
 public func edgeCurvatureLP(at param: Double) -> Double
 ```
 
-- **Returns:** Signed curvature value (0 for a straight edge).
+- **Returns:** Curvature magnitude: `0` for a straight edge or a parameter with no tangent, and
+  `Double.greatestFiniteMagnitude` (OCCT's `RealLast()`, meaning infinite curvature) at a cusp —
+  the same two sentinels [`Edge.curvature(at:)`](Edge.md) reports for the curve underneath.
 - **OCCT:** `BRepLProp_CLProps::Curvature` via `OCCTEdgeLPropCurvature`.
 
 ---
@@ -1064,10 +1073,12 @@ public func edgeCurvatureLP(at param: Double) -> Double
 Normal direction on an edge at the given parameter.
 
 ```swift
-public func edgeNormalLP(at param: Double) -> SIMD3<Double>
+public func edgeNormalLP(at param: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** Normal vector in the osculating plane.
+- **Returns:** Unit normal in the osculating plane, or `nil` where the curvature cannot be inverted
+  into a direction — a straight stretch has no normal, and neither does a cusp. Before #529 both
+  cases returned `(0, 0, 0)`, which is not a direction (#529, source-breaking).
 - **OCCT:** `BRepLProp_CLProps::Normal` via `OCCTEdgeLPropNormal`.
 
 ---
@@ -1077,10 +1088,14 @@ public func edgeNormalLP(at param: Double) -> SIMD3<Double>
 Centre of curvature on an edge at the given parameter.
 
 ```swift
-public func edgeCentreOfCurvature(at param: Double) -> SIMD3<Double>
+public func edgeCentreOfCurvature(at param: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** The centre of the osculating circle at `param`.
+- **Returns:** The centre of the osculating circle at `param`, or `nil` where there is no such
+  circle (a straight stretch, or a cusp). Before #529 a near-cusp returned `(nan, inf, nan)` as
+  though it were a point: `CentreOfCurvature()` tests only `|Curvature()| <= resolution`, which
+  OCCT's infinite-curvature sentinel passes, and then divides by a field that path never assigned
+  (#529, source-breaking).
 - **OCCT:** `BRepLProp_CLProps::CentreOfCurvature` via `OCCTEdgeLPropCentreOfCurvature`.
 
 ---
@@ -1090,10 +1105,11 @@ public func edgeCentreOfCurvature(at param: Double) -> SIMD3<Double>
 First derivative vector on an edge at the given parameter.
 
 ```swift
-public func edgeLPropD1(at param: Double) -> SIMD3<Double>
+public func edgeLPropD1(at param: Double) -> SIMD3<Double>?
 ```
 
-- **Returns:** The first derivative `C'(param)`.
+- **Returns:** The first derivative `C'(param)`, or `nil` for a parameter the edge cannot be
+  evaluated at (#529, source-breaking).
 - **OCCT:** `BRepLProp_CLProps::D1` via `OCCTEdgeLPropD1`.
 - **Example:**
   ```swift
@@ -1107,6 +1123,13 @@ public func edgeLPropD1(at param: Double) -> SIMD3<Double>
 ## BRepLProp Face Extensions
 
 Extension on `Shape` for face-level local surface properties using `BRepLProp_SLProps`.
+
+The `Face` counterparts ([`Face.meanCurvature(atU:v:)`](Face.md) and siblings) read the surface
+under the face directly rather than through a `BRepAdaptor_Surface`. Since #529 both use the same
+resolution, so they agree about whether a curvature exists at a given `(u, v)`; the curvature
+getters here still spell "undefined" as `0`, where the `Face` spellings return `nil`. One contract
+difference is deliberate: `faceLPropNormal(u:v:)` reports the *surface* normal, while
+[`Face.normal(atU:v:)`](Face.md) applies the face's orientation, so the two agree up to sign.
 
 ### `Shape.faceLPropValue(u:v:)`
 

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -78,7 +78,11 @@ public var normal: SIMD3<Double>? { get }
 Evaluates the surface normal at the midpoint of the face's UV parameter range. Respects face orientation (`TopAbs_REVERSED` flips the result).
 
 - **Returns:** Unit normal vector, or `nil` if the normal is undefined at the centre (e.g. degenerate face or singular parametric point).
-- **OCCT:** `BRepAdaptor_Surface` + `BRepLProp_SLProps::Normal` — adapts the face, evaluates at `(uMid, vMid)`.
+- **OCCT:** `BRepAdaptor_Surface` + `BRepLProp_SLProps::Normal` — adapts the face, evaluates at `(uMid, vMid)`, at the same `Precision::Confusion()` resolution as [`normal(atU:v:)`](#normalatuv) since #529.
+- **Note:** that resolution reaches `CSLib::Normal` as a *sine* tolerance on the angle between the
+  two parametric directions, not as a length. A surface whose derivatives merely shrink (a cone at
+  its apex, a sphere at its pole) therefore keeps a defined normal; only a nearly *singular
+  parameterisation*, where the two directions become parallel, returns `nil`.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -300,6 +300,7 @@ public struct RayHit: Sendable {
     public let faceIndex: Int
     public let distance: Double
     public let uv: SIMD2<Double>
+    public let normalDefined: Bool
 }
 ```
 
@@ -308,6 +309,8 @@ public struct RayHit: Sendable {
 - `faceIndex` — 0-based index of the intersected face within the shape's `TopTools_IndexedMapOfShape`.
 - `distance` — signed ray parameter (distance from origin along the ray direction).
 - `uv` — UV surface parameters at the intersection point.
+- `normalDefined` — whether `normal` is the surface's own normal or the `(0, 0, 1)` fallback, which
+  is otherwise indistinguishable from a real upward normal (added by #529).
 
 ---
 
@@ -331,10 +334,14 @@ The direction vector is automatically normalised by `gp_Dir`. Intersections beyo
 - **Parameters:**
   - `origin` — ray start point in world space.
   - `direction` — ray direction (normalised internally).
-  - `tolerance` — intersection tolerance (default 0.001).
+  - `tolerance` — intersection tolerance (default 0.001). Bounds the intersection only. Until #529
+    it was also passed to `BRepLProp_SLProps` as the local-property resolution, where it is a
+    dimensionless *sine* tolerance: any value at or above 1 rejected every hit normal, so
+    `raycast(tolerance: 1.0)` on a sphere reported `(0, 0, 1)` for both hits, and at 5.0 a box's
+    downward face came back pointing up.
   - `maxHits` — maximum number of hits to collect (default 100).
 - **Returns:** Array of `RayHit` sorted by ascending `distance`; empty if no intersection.
-- **OCCT:** `IntCurvesFace_ShapeIntersector::Load` / `Perform` / `NbPnt` / `Pnt` / `WParameter` / `Face` / `UParameter` / `VParameter`; normals via `BRepAdaptor_Surface` + `BRepLProp_SLProps`.
+- **OCCT:** `IntCurvesFace_ShapeIntersector::Load` / `Perform` / `NbPnt` / `Pnt` / `WParameter` / `Face` / `UParameter` / `VParameter`; normals via `BRepAdaptor_Surface` + `BRepLProp_SLProps` at the shared `occtLocalPropsResolution()`.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!


### PR DESCRIPTION
Closes #529

## The premise, corrected

#494 converged all 28 `GeomLProp_SLProps` / `GeomLProp_CLProps` / `GeomLProp_CLProps2d` constructions
onto `Precision::Confusion()` and banked the `BRepLProp_*` half as a separate job, on the grounds
that it is "a different class family" whose factories "are not reusable as written". Reading the
pinned headers first says otherwise — `BRepLProp_SLProps.hxx` in OCCT 8.0.0p1 is nine lines:

```cpp
using BRepLProp_SLProps = GeomLProp_SLPropsBase<BRepAdaptor_Surface>;
```

The same header-only template `GeomLProp_SLProps` aliases, one adaptor argument apart. Same
`Resolution`, same meaning. So the 18 sites passing a literal `1e-6` were deciding whether a quantity
exists at a threshold a decade looser than the sites sitting beside them, and that decade is exactly
where they disagreed:

```
=== SLProps on a cone FACE (semi-angle 30 deg, apex radius 0), u=0 ===
v         | BRepLProp @ 1e-6 (before)  | BRepLProp @ Confusion     | GeomLProp @ Confusion
3e-06     | def H=-2.887e+05           | def H=-2.887e+05          | def H=-2.887e+05
1.5e-06   | UNDEFINED                  | def H=-5.774e+05          | def H=-5.774e+05
1e-06     | UNDEFINED                  | def H=-8.66e+05           | def H=-8.66e+05
3e-07     | UNDEFINED                  | def H=-2.887e+06          | def H=-2.887e+06
1e-07     | UNDEFINED                  | UNDEFINED                 | UNDEFINED
```

All 18 now build through `occtFaceLocalProps` / `occtEdgeLocalProps`, alongside #494's
`occtSurfaceLocalProps` and friends.

## Three census corrections, all toward more work

| the issue says | measured |
|---|---|
| 19 literal-`1e-6` sites, 16 in `Properties.mm` | **18**, of which **15** are in `Properties.mm` |
| a different class family, factories not reusable | the same two templates, one argument apart |
| all three `Topology.mm` sites decide face *orientation* | one is `OCCTFaceGetNormal`, which backs `Face.normal` and every `isHorizontal` / `isUpwardFacing` / `isVertical` predicate |
| the `Spatial.mm` site is "not obviously wrong" | it is the worst of the 19 |

## `raycast(tolerance:)` was erasing its own normals

`OCCTShapeRaycast` forwarded the caller's tolerance twice: to
`IntCurvesFace_ShapeIntersector::Load`, where it is the intersection distance it is documented as,
and to `BRepLProp_SLProps`, where `CSLib::Normal` uses it as a **sine** tolerance on the angle
between the two parametric directions. That quantity is dimensionless and saturates:

```
=== sphere r=5, ray down the Z axis ===
tolerance=0.9  hit1 normal (6.1e-17, 0, 1)   hit2 normal (6.1e-17, 0, -1)
tolerance=1    hit1 normal UNDEFINED -> reported as (0, 0, 1)   hit2 normal UNDEFINED -> (0, 0, 1)
=== box 10x10x10, ray down ===
tolerance=5    hit1 normal UNDEFINED -> (0, 0, 1)   hit2 normal UNDEFINED -> (0, 0, 1)
```

At `tolerance: 5.0` a box's *downward* face reported an upward normal — a wrong answer, not a
missing one, because `(0, 0, 1)` is the fallback. The intersection tolerance now stops at `Load`,
and `RayHit` gains `normalDefined` so the fallback is distinguishable at a genuinely singular hit
(additive: `RayHit`'s memberwise init is internal).

## The `RealLast()` centre, one decade wider on this side

`Curvature()` returns `RealLast()` at a cusp without assigning the `myCurvature` field;
`CentreOfCurvature()` tests only `|Curvature()| <= resolution`, which the sentinel passes, then
divides by that field. `Normal()` rejects the sentinel by name and throws — `CentreOfCurvature()`
hands back a non-point as a success. Both inverting entry points now gate on
`occtCurveCurvatureIsInvertible` (#494's predicate). On a cubic Bezier at `u = 0`:

| pole spacing | before | after |
|---|---|---|
| 1e-3 … 1e-6 | real centre | real centre |
| 3e-7 | `(nan, inf, nan)` as a point | real centre `(0, 1.35e-13, 0)` |
| 1e-7 | `(inf, inf, nan)` as a point | real centre `(2.8e-30, 1.5e-14, 0)` |
| 1e-8 … 1e-12 | `(nan, inf, nan)` as a point | `nil` |
| 0 | `(0, 0, 0)` from the absorbed throw | `nil` |

## Source-breaking, in four places

All entry points that could not previously say "there is nothing here":
`Shape.edgeNormalLP(at:)`, `Shape.edgeCentreOfCurvature(at:)` and `Shape.edgeLPropD1(at:)` return
`SIMD3<Double>?`. `Shape.edgeLPropValue(at:)` was already declared optional and never returned `nil`;
now it does. No consumer in the local ecosystem calls any of the four.

## Two orphans deleted rather than converged

`OCCTShapeGetHorizontalFaces` / `OCCTShapeGetUpwardFaces` reimplemented `Face.isHorizontal` /
`Face.isUpwardFacing` over the same midpoint normal and were called from nowhere —
`Shape.horizontalFaces` / `upwardFaces` filter `faces()` through the `Face` predicates. Same
reasoning as #506: `OCCTBridge` is a target, not a product, and an orphan freezes whatever contract
it had when it was orphaned, so keeping them meant maintaining a second `1e-6` behind a dead symbol.
Tombstone comments in both the header and the `.mm`.

## The surviving midpoint-normal site does not move, and that is measured

`CSLib::Normal` tests the two first derivatives for nullity against `gp::Resolution()` — a fixed
~1e-300 epsilon, **not** the caller's value — and uses the caller's value only as the sine tolerance
above, which is scale-invariant. So a surface whose derivatives merely shrink (a cone at its apex, a
sphere at its pole) keeps a defined normal all the way down. Swept over a box, cylinder, sphere, apex
cone, frustum, torus, hemisphere, a fully filleted box and the 662 faces of
`unify-crash-mmd-kiha10-body5.brep`: **0 faces changed definedness, 0 changed direction**, horizontal
18→18 and upward 9→9 on the real fixture. The one geometry that does move is a nearly *singular
parameterisation* — a linear extrusion skewed by 5e-7 rad, undefined at `1e-6` and defined at
`Confusion()`.

## Tests

`AdaptorLocalPropsParityTests` + `AdaptorNormalDecisionTests` (`OCCTAnalysisTests`), 11 tests,
following #494's `LocalPropsParityTests`. Definedness is asserted exactly, values relatively — a
`BRepAdaptor_Curve` evaluates a Bezier through a cache the raw handle does not use, which moves the
last ULP (0.67461923686773151 against 0.6746192368677314 for the same curvature).

Proved against three injections rather than assumed:

| injection | tests failed |
|---|---|
| restore the `1e-6` resolution in both factories | 4 |
| remove the two invertibility gates | 1 (on the `(nan, inf, nan)` centre) |
| restore the raycast tolerance forwarding | 2 |

Four tests are controls and pass under all three. Full suite: **4935 tests, 0 failures**.

Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild. Probes and full figures at
`Scripts/repro/529-breplprop-resolution/`. Docs updated in `docs/CHANGELOG.md`,
`docs/reference/Document-Math-Solvers.md`, `docs/reference/Face.md`, `docs/reference/Selection.md`.

**Noticed, not fixed** — filed as #583: the five face-side curvature getters still spell "undefined"
as `0` where the `Face` counterparts return `nil`. Fixing it means five more source-breaking
signatures, which does not belong in a tolerance fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)