### PR TITLE
fix(#585): validate carried kernel patches against the patched kernel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 name: CI
 
-# Fast per-PR/per-push gate. Deliberately does NOT rebuild OCCT from source (that is a manual
-# local `Scripts/build-occt.sh` run, ~30-60 min, done only when a carried patch in
-# Scripts/patches/ needs to reach the shipped binary). A clean checkout has no local Libraries/, so
-# Package.swift's binaryTarget resolves OCCT.xcframework from its pinned release URL and
-# verifies the checksum, which only costs a download. OCCTBridge compiles from source by
-# default (no OCCTSWIFT_BRIDGE_PREBUILT set), which is the repo's own intended default, see
-# the comment above `useBridgePrebuilt` in Package.swift, and it's a couple of minutes, not
-# tens of minutes.
+# Fast per-PR/per-push gate. Deliberately does NOT rebuild OCCT from source: a clean checkout has
+# no local Libraries/, so Package.swift's binaryTarget resolves OCCT.xcframework from its pinned
+# release URL and verifies the checksum, which only costs a download. A PR that touches
+# Scripts/patches/ (a carried kernel patch not yet in a release) gets kernel-integration.yml
+# instead, which does rebuild from source and runs swift test against that binary (#585) — this
+# workflow's own macOS check will fail such a PR's new regression tests against the stale pinned
+# kernel, and that's expected, not a defect; read kernel-integration.yml's result instead.
+# OCCTBridge compiles from source by default (no OCCTSWIFT_BRIDGE_PREBUILT set), which is the
+# repo's own intended default, see the comment above `useBridgePrebuilt` in Package.swift, and
+# it's a couple of minutes, not tens of minutes.
 
 on:
   pull_request:

--- a/.github/workflows/kernel-integration.yml
+++ b/.github/workflows/kernel-integration.yml
@@ -1,0 +1,73 @@
+name: Kernel Integration
+
+# Validates a carried OCCT kernel patch against the actual patched binary. ci.yml deliberately
+# never rebuilds OCCT from source (a clean checkout has no local Libraries/, so Package.swift's
+# binaryTarget resolves the pinned, released OCCT.xcframework), so a PR that adds regression tests
+# for a not-yet-released kernel patch fails ci.yml's macOS check indistinguishably from a real
+# regression (#585, surfaced by #519). This workflow only runs when Scripts/patches/ or the build
+# script itself changes, builds OCCT from source with those patches applied, and runs swift test
+# against that binary instead of the pinned release.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'refactor/**'
+    paths:
+      - 'Scripts/patches/**'
+      - 'Scripts/build-occt.sh'
+  push:
+    branches:
+      - main
+      - 'refactor/**'
+    paths:
+      - 'Scripts/patches/**'
+      - 'Scripts/build-occt.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: kernel-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: swift test against patched kernel (macOS)
+    runs-on: macos-15
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # Cache the FINAL xcframework only, never the intermediate occt-build-*/occt-src trees:
+      # CMakeCache bakes in an absolute build-tree path, which a fresh runner never reuses across
+      # runs, so caching the half-built tree would just restore an unusable cache every time (same
+      # gotcha as caching a local build directory across sibling checkouts on one machine). The key
+      # is the patch set plus the build script itself, so a pinned-OCCT-version bump also
+      # invalidates it.
+      - name: Cache OCCT.xcframework
+        id: occt-cache
+        uses: actions/cache@v4
+        with:
+          path: Libraries/OCCT.xcframework
+          key: occt-xcframework-${{ hashFiles('Scripts/patches/*.patch', 'Scripts/build-occt.sh') }}
+
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-kernel-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-kernel-
+
+      - name: Build OCCT from source (cache miss only)
+        if: steps.occt-cache.outputs.cache-hit != 'true'
+        run: ./Scripts/build-occt.sh
+
+      - name: swift test
+        run: swift test

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1749,6 +1749,28 @@ and the before/after sweep transcripts:
 [`Scripts/repro/522-approx-c0-collapse/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/522-approx-c0-collapse).
 Filed upstream as [OCCT#1418](https://github.com/Open-Cascade-SAS/OCCT/pull/1418).
 
+### New workflow: `kernel-integration.yml` validates a carried patch against the patched kernel (#585)
+
+`ci.yml`'s macOS check always resolves `Package.swift`'s pinned, **released** OCCT.xcframework, since
+a clean checkout has no local `Libraries/`. A PR that carries a kernel patch not yet in a release
+and adds a regression test for its fixed behaviour therefore fails that check indistinguishably
+from a real regression: #519 (patches `0016`(redesign)/`0018`/`0019`, closing #518/#522/#555) hit
+this exactly, its new #522 test reproducing the original bug's own symptom against the stale
+kernel, needing a manual dig to tell "expected gap" apart from "the patch doesn't work." The old
+`ci.yml` comment already named the fix and never built it: "that's `kernel-rebuild.yml`'s job,
+~30-60 min" describes a workflow that never existed anywhere in this repo's history.
+
+`kernel-integration.yml` is that workflow, finally built. It triggers only on a PR/push touching
+`Scripts/patches/**` or `Scripts/build-occt.sh`, so ordinary PRs stay on the fast `ci.yml` path.
+`actions/cache@v4` keys on a hash of the patch files plus the build script itself (so a pinned-OCCT
+version bump also invalidates it): the first run after a patch changes pays the full rebuild, every
+later run with the same patch set restores `Libraries/OCCT.xcframework` in seconds. Deliberately
+caches only the **final** xcframework, never the intermediate `occt-build-*`/`occt-src` trees —
+`CMakeCache.txt` bakes in the configuring checkout's absolute path, which a fresh runner never
+reuses, so caching a half-built tree would just restore an unusable cache every run (the same
+gotcha `docs/guides/building-occt.md` already documents for resuming an interrupted local build).
+`ci.yml`'s own comment now points here instead of describing the rebuild as manual-only.
+
 ---
 
 ## Release History

--- a/docs/guides/building-occt.md
+++ b/docs/guides/building-occt.md
@@ -331,6 +331,13 @@ not re-run `build-occt.sh`, which `rm -rf`s each slice's build dir before starti
 xcframework with **no** override-linked TUs, and re-check whatever "no behaviour change" evidence
 the patch's `Scripts/repro/<issue>/README.md` recorded. Then a full `swift test`.
 
+Pushing a commit that touches `Scripts/patches/**` also triggers `.github/workflows/
+kernel-integration.yml` (#585), which rebuilds from source in CI and runs `swift test` against
+that binary. `ci.yml`'s own macOS check still runs too and will fail any new regression test that
+asserts the patch's fixed behaviour, since it always resolves the pinned *released* kernel; that
+failure is expected until a release ships this patch, not a sign the patch is broken — read
+`kernel-integration.yml`'s result for the real signal.
+
 **4. Package and pin.** The zip is the release asset; its checksum is what SwiftPM verifies.
 
 ```bash
@@ -362,7 +369,9 @@ If you don't want to build OCCT yourself:
 
 1. **This package's own release asset**: the normal path, and the one that carries our patches.
    `OCCT.xcframework.zip` is attached to each release that rebuilt the kernel, and `Package.swift`
-   resolves it by `url:`/`checksum:` automatically on any checkout with no local `Libraries/`. There
-   is no CI job that builds OCCT; the rebuild is the manual local run documented above.
+   resolves it by `url:`/`checksum:` automatically on any checkout with no local `Libraries/`. The
+   rebuild itself is the manual local run documented above; `kernel-integration.yml` (#585) builds
+   from source too, but only to validate a carried patch in CI before release, not to produce the
+   shipped release asset.
 2. **Open Cascade Commercial**: Contact sales@opencascade.com for pre-built iOS libraries
 3. **Community Builds**: Check OCCT forum for community-provided builds


### PR DESCRIPTION
## Summary
- `ci.yml`'s macOS check always resolves `Package.swift`'s pinned, released `OCCT.xcframework` — a PR carrying a kernel patch not yet in a release, with a regression test for its fixed behaviour, fails that check indistinguishably from a real regression. #519 hit this exactly and needed a manual investigation to tell "expected structural gap" apart from "the patch is broken."
- New `kernel-integration.yml`, path-filtered to `Scripts/patches/**` and `Scripts/build-occt.sh` (ordinary PRs stay on the fast `ci.yml` path): rebuilds OCCT from source, cached by patch-set hash so only the first run after a patch change pays the full ~30-60 min cost, then runs `swift test` against that binary instead of the pinned release.
- Fulfils what the old `ci.yml` comment already named and never built — a `kernel-rebuild.yml` that never existed anywhere in this repo's history.
- `ci.yml`'s comment updated to point at the new workflow instead of describing the rebuild as manual-only; `docs/guides/building-occt.md` updated in both places it discussed CI/kernel-rebuild interaction.

Closes #585.

## Test plan
- [x] Both workflow YAML files parse cleanly (`yaml.safe_load`).
- [x] `Scripts/count-operations.py` unaffected (no Swift API change).
- [x] No Swift/bridge code touched — docs + CI config only, so no local build/test run.
- [ ] First live run of `kernel-integration.yml` on this PR itself (it touches `Scripts/build-occt.sh`'s neighbourhood only via docs, not the script — will confirm the path filter and cache key behave correctly on the next PR that actually touches `Scripts/patches/`).