### PR TITLE
fix(#571): the plate approximation now honours the tolerance it was given

### DIFF
--- a/Scripts/repro/571-plate-approx-contract/README.md
+++ b/Scripts/repro/571-plate-approx-contract/README.md
@@ -1,0 +1,116 @@
+# OCCTSwift#571 reproducer — `Nbmax = 1` makes `GeomPlate_MakeApprox` ignore its own error criterion
+
+Standalone, deterministic probes for the two `GeomPlate_MakeApprox` arguments that decided whether
+the `tolerance` parameter of the six plate entry points meant anything. No fixture file is needed;
+both programs build their own plates from point constraints.
+
+**Fixed bridge-side** — no kernel patch, no `OCCT.xcframework` rebuild. All six sites now share
+`occtPlateApproxSurface` (`Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm`, contract
+documented in `OCCTBridge_Internal.h`).
+
+Compile with the standard ground-truth invocation from `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/571-plate-approx-contract/occt_571_plate_sweep.mm -o /tmp/occt_571_sweep
+/tmp/occt_571_sweep
+```
+
+## The census the issue asked for
+
+`GeomPlate_MakeApprox` is the one consumer of `AdvApp2Var_ApproxAFunc2Var` that does not go through
+`GeomConvert_ApproxSurface` — it drives the approximator directly — so it sat outside every census
+built by grepping for `GeomConvert_ApproxSurface`. **#571 named three bridge call sites; there are
+six**, and the two that the issue's list missed are the ones that diverge most:
+
+| # | site | Nbmax | dmax |
+|---|---|---|---|
+| 1 | `OCCTShapePlatePoints` (`OCCTBridge_Healing.mm`) | 1 | `tolerance * 10` |
+| 2 | `OCCTShapePlateCurves` (`OCCTBridge_Healing.mm`) | 1 | `tolerance * 10` |
+| 3 | `OCCTShapePlatePointsAdvanced` (`OCCTBridge_ProjLib_NLPlate.mm`) | 1 | `tolerance * 10` |
+| 4 | `OCCTShapePlateMixed` (`OCCTBridge_ProjLib_NLPlate.mm`) | 1 | `tolerance * 10` |
+| 5 | `OCCTSurfacePlateThrough` (`OCCTBridge_ProjLib_NLPlate.mm`) | 1 | `tolerance * 10` |
+| 6 | `OCCTGeomPlateSurface` (`OCCTBridge_ProjLib_NLPlate.mm`) | caller's `maxSegments` (default 20) | `tolerance * 0.1` |
+
+Sites 1 and 6 are reachable from **overloads of one Swift name** — `Shape.plateSurface(through:)`
+and `Shape.plateSurface(points:)` — doing the same job with contracts 22x apart on accuracy.
+
+## Root cause
+
+`Nbmax` caps the number of Bezier patches, and **1 is the one value that disarms the algorithm.**
+`AdvApp2Var_ApproxAFunc2Var::ComputePatches` derives its cut decision `NumDec` from `myMaxPatches`:
+
+```cpp
+if (((NbPatch + NbV) <= myMaxPatches) && ((NbPatch + NbU) > myMaxPatches) && (Umore)) NumDec = 1;
+// ... every branch requires a sum of at least 2 to be <= myMaxPatches
+```
+
+At `myMaxPatches == 1` every guard fails and `NumDec` stays 0. `AdvApp2Var_Patch::CutSense` then
+returns 0 whether or not the criterion is satisfied:
+
+```cpp
+if (Crit.IsSatisfied(*this)) { return 0; } else { return NumDec; }   // NumDec is 0 too
+```
+
+so "the fit missed" and "the fit is fine" issue the same instruction — keep this patch. The
+criterion is still computed and still reported through `CriterionError()`; it just cannot act.
+
+`dmax` sets that criterion's threshold, as `seuil = max(Tol3d, 10 * dmax)`
+(`GeomPlate_MakeApprox.cxx:391-399`), so `dmax = tolerance * 10` asks the G0 criterion to accept
+100x the tolerance the caller requested.
+
+## What the probes show
+
+`criterion-probe.txt` is the direct proof that the criterion is violated and ignored:
+
+```
+  Nbmax=1 dmax=1e-09    seuil=0.01     critErr=0.0981545    violated=YES | uP=9 vP=9
+  Nbmax=1 dmax=1e-06    seuil=0.01     critErr=0.0981545    violated=YES | uP=9 vP=9
+  Nbmax=1 dmax=0.001    seuil=0.01     critErr=0.0981545    violated=YES | uP=9 vP=9
+  Nbmax=2 dmax=1e-09    seuil=0.01     critErr=0.00484093   violated=no  | uP=16 vP=16
+```
+
+`Nbmax = 2` is enough; everything from 2 to 100 produces the identical surface on this fixture. And
+at `Nbmax = 1`, sweeping `dmax` across nine orders of magnitude (`1e-5` to `1e4`) yields
+**bit-identical control nets** — a dead argument in the sense of #497's inert `SetFuzzyValue`.
+
+The same probe pins the continuity contract: `GeomPlate_MakeApprox` accepts `C0`, `C1` and `C2`
+only. `G1`, `G2`, `C3` and `CN` each throw `AdvApp2Var_ApproxAFunc2Var : UContinuity Error`, which
+is why `occtGeomAbsFromSurfaceContinuity` (order 1 → `GeomAbs_G1`) must not feed that argument.
+
+## The #522 question: did the surfaces move?
+
+**No.** `sweep-stock.txt` and `sweep-0019.txt` are the same 54-case sweep either side of
+`Scripts/patches/0019-AdvApp2Var-jacobi-max-wrong-workspace-slot-522.patch`, the "stock" side built
+by compiling the unpatched `AdvApp2Var_ApproxF2var.cxx` as a single TU and linking it ahead of the
+archive:
+
+```bash
+clang++ -std=c++17 -c -w -O2 -DNo_Exception \
+  -I"Libraries/occt-src/src/ModelingData/TKGeomBase/AdvApp2Var" \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  AdvApp2Var_ApproxF2var_stock.cxx -o stock.o
+# then link stock.o BEFORE -lOCCT-macos
+```
+
+Every one of the 54 pole fingerprints is identical, as are all degrees and pole counts. Only the
+reported `ApproxError()` changed, rising 1.03x to 5.37x (median 1.15x) — the interior contribution
+being counted for the first time, exactly the effect #522 documented. At the implicit `C1` default
+the `NDMINU` degree floor is already 8, so #522's collapse could not reach these sites, which is
+what #571 predicted. Nothing in the plate family needed re-baselining because of `0019`.
+
+Verify the override-link is actually taking effect before trusting a "stock" run — link it into
+`Scripts/repro/522-approx-c0-collapse/occt_522_c0_minimal.mm` and check the `cont=C0` row reports
+`uDeg=1 uPoles=2` (the collapse) rather than `uDeg=7 uPoles=15` (patched).
+
+## Note on the `EnlargeCoeff` domain
+
+`GeomPlate_MakeApprox` scales each of the plate's real bounds by `EnlargeCoeff` (default 1.1) rather
+than expanding the interval about its centre, so the fit domain is only genuinely enlarged when the
+bounds straddle zero. Plate UV domains from `GeomPlate_BuildPlateSurface` are centred near the
+origin, so in practice they do — the sweep prints both domains and the count of constraint points
+falling strictly inside the enlarged one, since `GeomPlate_PlateG0Criterion::Value` skips any point
+on or outside the patch boundary and would silently measure nothing if they all fell outside.

--- a/Scripts/repro/571-plate-approx-contract/criterion-probe.txt
+++ b/Scripts/repro/571-plate-approx-contract/criterion-probe.txt
@@ -1,0 +1,28 @@
+=== which Continuity values does GeomPlate_MakeApprox accept? ===
+  cont=C0 -> OK  uDeg=8 vDeg=8 uP=17 vP=17 approxErr=0.00734231
+  cont=G1 -> THREW: AdvApp2Var_ApproxAFunc2Var : UContinuity Error
+  cont=C1 -> OK  uDeg=8 vDeg=8 uP=16 vP=16 approxErr=0.0228438
+  cont=G2 -> THREW: AdvApp2Var_ApproxAFunc2Var : UContinuity Error
+  cont=C2 -> OK  uDeg=8 vDeg=8 uP=21 vP=21 approxErr=7.90633
+  cont=C3 -> THREW: AdvApp2Var_ApproxAFunc2Var : UContinuity Error
+  cont=CN -> THREW: AdvApp2Var_ApproxAFunc2Var : UContinuity Error
+
+=== at Nbmax=1, is the criterion VIOLATED yet still ignored? ===
+(seuil = max(Tol3d, 10*dmax); criterion is satisfied iff critErr < seuil)
+  Nbmax=1 dmax=1e-09    seuil=0.01     critErr=0.0981545    violated=YES | uP=9 vP=9
+  Nbmax=1 dmax=1e-06    seuil=0.01     critErr=0.0981545    violated=YES | uP=9 vP=9
+  Nbmax=1 dmax=0.001    seuil=0.01     critErr=0.0981545    violated=YES | uP=9 vP=9
+  (same for Nbmax=2, where subdivision IS permitted)
+  Nbmax=2 dmax=1e-09    seuil=0.01     critErr=0.00484093   violated=no  | uP=16 vP=16
+  Nbmax=2 dmax=1e-06    seuil=0.01     critErr=0.00484093   violated=no  | uP=16 vP=16
+  Nbmax=2 dmax=0.001    seuil=0.01     critErr=0.00484093   violated=no  | uP=16 vP=16
+
+=== does raising Nbmax keep helping, and where does it stop? ===
+  Nbmax=1    uP=9    vP=9    approxErr=0.579399     critErr=0.0981545   
+  Nbmax=2    uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  
+  Nbmax=3    uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  
+  Nbmax=5    uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  
+  Nbmax=10   uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  
+  Nbmax=20   uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  
+  Nbmax=50   uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  
+  Nbmax=100  uP=16   vP=16   approxErr=0.0228438    critErr=0.00484093  

--- a/Scripts/repro/571-plate-approx-contract/occt_571_criterion_probe.mm
+++ b/Scripts/repro/571-plate-approx-contract/occt_571_criterion_probe.mm
@@ -1,0 +1,84 @@
+// OCCTSwift#571 probe 2: which GeomAbs_Shape values does GeomPlate_MakeApprox actually accept,
+// and does the criterion ever act at Nbmax=1 even when it is violated?
+
+#include <GeomPlate_BuildPlateSurface.hxx>
+#include <GeomPlate_PointConstraint.hxx>
+#include <GeomPlate_Surface.hxx>
+#include <GeomPlate_MakeApprox.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <gp_Pnt.hxx>
+#include <Standard_Failure.hxx>
+#include <cstdio>
+#include <cmath>
+#include <vector>
+
+static const char* nm(GeomAbs_Shape s) {
+    switch (s) {
+        case GeomAbs_C0: return "C0"; case GeomAbs_G1: return "G1"; case GeomAbs_C1: return "C1";
+        case GeomAbs_G2: return "G2"; case GeomAbs_C2: return "C2"; case GeomAbs_C3: return "C3";
+        default: return "CN";
+    }
+}
+
+int main() {
+    std::vector<gp_Pnt> pts;
+    for (int i = 0; i < 5; i++)
+        for (int j = 0; j < 5; j++)
+            pts.push_back(gp_Pnt(i * 4.0, j * 4.0, 4.0 * std::sin(i * 1.3) * std::cos(j * 1.1)));
+
+    GeomPlate_BuildPlateSurface b(3, 15, 2);
+    for (auto& p : pts) b.Add(new GeomPlate_PointConstraint(p, 0));
+    b.Perform();
+    Handle(GeomPlate_Surface) plate = b.Surface();
+
+    printf("=== which Continuity values does GeomPlate_MakeApprox accept? ===\n");
+    for (GeomAbs_Shape c : {GeomAbs_C0, GeomAbs_G1, GeomAbs_C1, GeomAbs_G2, GeomAbs_C2, GeomAbs_C3, GeomAbs_CN}) {
+        printf("  cont=%-2s -> ", nm(c));
+        try {
+            GeomPlate_MakeApprox a(plate, 0.01, 20, 8, 0.001, 0, c);
+            Handle(Geom_BSplineSurface) s = a.Surface();
+            if (s.IsNull()) printf("NULL surface\n");
+            else printf("OK  uDeg=%d vDeg=%d uP=%d vP=%d approxErr=%g\n",
+                        s->UDegree(), s->VDegree(), s->NbUPoles(), s->NbVPoles(), a.ApproxError());
+        } catch (Standard_Failure const& f) {
+            printf("THREW: %s\n", f.GetMessageString() ? f.GetMessageString() : "(no message)");
+        } catch (...) { printf("THREW (unknown)\n"); }
+    }
+
+    printf("\n=== at Nbmax=1, is the criterion VIOLATED yet still ignored? ===\n");
+    printf("(seuil = max(Tol3d, 10*dmax); criterion is satisfied iff critErr < seuil)\n");
+    for (double dmax : {1e-9, 1e-6, 1e-3}) {
+        double tol = 0.01, seuil = std::max(tol, 10 * dmax);
+        try {
+            GeomPlate_MakeApprox a(plate, tol, 1, 8, dmax, 0, GeomAbs_C1);
+            Handle(Geom_BSplineSurface) s = a.Surface();
+            printf("  Nbmax=1 dmax=%-8g seuil=%-8g critErr=%-12g violated=%-3s | uP=%d vP=%d\n",
+                   dmax, seuil, a.CriterionError(),
+                   (a.CriterionError() >= seuil) ? "YES" : "no",
+                   s->NbUPoles(), s->NbVPoles());
+        } catch (...) { printf("  THREW\n"); }
+    }
+    printf("  (same for Nbmax=2, where subdivision IS permitted)\n");
+    for (double dmax : {1e-9, 1e-6, 1e-3}) {
+        double tol = 0.01, seuil = std::max(tol, 10 * dmax);
+        try {
+            GeomPlate_MakeApprox a(plate, tol, 2, 8, dmax, 0, GeomAbs_C1);
+            Handle(Geom_BSplineSurface) s = a.Surface();
+            printf("  Nbmax=2 dmax=%-8g seuil=%-8g critErr=%-12g violated=%-3s | uP=%d vP=%d\n",
+                   dmax, seuil, a.CriterionError(),
+                   (a.CriterionError() >= seuil) ? "YES" : "no",
+                   s->NbUPoles(), s->NbVPoles());
+        } catch (...) { printf("  THREW\n"); }
+    }
+
+    printf("\n=== does raising Nbmax keep helping, and where does it stop? ===\n");
+    for (int nb : {1, 2, 3, 5, 10, 20, 50, 100}) {
+        try {
+            GeomPlate_MakeApprox a(plate, 0.01, nb, 8, 0.001, 0, GeomAbs_C1);
+            Handle(Geom_BSplineSurface) s = a.Surface();
+            printf("  Nbmax=%-4d uP=%-4d vP=%-4d approxErr=%-12g critErr=%-12g\n",
+                   nb, s->NbUPoles(), s->NbVPoles(), a.ApproxError(), a.CriterionError());
+        } catch (...) { printf("  Nbmax=%-4d THREW\n", nb); }
+    }
+    return 0;
+}

--- a/Scripts/repro/571-plate-approx-contract/occt_571_plate_sweep.mm
+++ b/Scripts/repro/571-plate-approx-contract/occt_571_plate_sweep.mm
@@ -1,0 +1,197 @@
+// Ground truth for OCCTSwift#571: what GeomPlate_MakeApprox's Nbmax / dmax / CritOrder /
+// Continuity arguments actually do at the six bridge call sites.
+//
+// Mirrors the bridge's own construction exactly (GeomPlate_BuildPlateSurface with point
+// constraints, then GeomPlate_MakeApprox), then sweeps one argument at a time and reports
+// a fingerprint of the resulting surface plus every error the API exposes.
+
+#include <GeomPlate_BuildPlateSurface.hxx>
+#include <GeomPlate_PointConstraint.hxx>
+#include <GeomPlate_CurveConstraint.hxx>
+#include <GeomPlate_Surface.hxx>
+#include <GeomPlate_MakeApprox.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <TopoDS_Edge.hxx>
+#include <gp_Pnt.hxx>
+#include <NCollection_Sequence.hxx>
+#include <Standard_Failure.hxx>
+
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <string>
+
+static const char* contName(GeomAbs_Shape s) {
+    switch (s) {
+        case GeomAbs_C0: return "C0";
+        case GeomAbs_G1: return "G1";
+        case GeomAbs_C1: return "C1";
+        case GeomAbs_G2: return "G2";
+        case GeomAbs_C2: return "C2";
+        case GeomAbs_C3: return "C3";
+        default: return "CN";
+    }
+}
+
+// A stable, order-independent-ish digest of the control net, so "did the surface move?"
+// is one number instead of an eyeball diff.
+static double poleFingerprint(const Handle(Geom_BSplineSurface)& s) {
+    if (s.IsNull()) return -1.0;
+    double acc = 0.0;
+    int nu = s->NbUPoles(), nv = s->NbVPoles();
+    for (int i = 1; i <= nu; i++)
+        for (int j = 1; j <= nv; j++) {
+            gp_Pnt p = s->Pole(i, j);
+            double w = double(i * 31 + j * 17);
+            acc += w * (p.X() + 2.0 * p.Y() + 3.0 * p.Z());
+        }
+    return acc;
+}
+
+struct Dev { double gridMax; double ctrMax; };
+
+// gridMax: worst |bspline - plate| over a sample grid of the plate's real bounds.
+// ctrMax : worst |bspline - plate| at the plate's own order-0 constraint UVs, which is
+//          precisely the quantity GeomPlate_PlateG0Criterion measures and bounds.
+static Dev deviation(const Handle(Geom_BSplineSurface)& bs,
+                     const Handle(GeomPlate_Surface)& plate) {
+    Dev d{-1.0, -1.0};
+    if (bs.IsNull() || plate.IsNull()) return d;
+    double u0, u1, v0, v1;
+    plate->RealBounds(u0, u1, v0, v1);
+
+    double worst = 0.0;
+    const int N = 24;
+    for (int i = 0; i <= N; i++) {
+        double u = u0 + (u1 - u0) * i / N;
+        for (int j = 0; j <= N; j++) {
+            double v = v0 + (v1 - v0) * j / N;
+            gp_Pnt a, b;
+            try { plate->D0(u, v, a); bs->D0(u, v, b); } catch (...) { continue; }
+            worst = std::max(worst, a.Distance(b));
+        }
+    }
+    d.gridMax = worst;
+
+    NCollection_Sequence<gp_XY> seq;
+    plate->Constraints(seq);
+    double cworst = 0.0;
+    for (int i = 1; i <= seq.Length(); i++) {
+        gp_XY uv = seq.Value(i);
+        gp_Pnt a, b;
+        try { plate->D0(uv.X(), uv.Y(), a); bs->D0(uv.X(), uv.Y(), b); } catch (...) { continue; }
+        cworst = std::max(cworst, a.Distance(b));
+    }
+    d.ctrMax = cworst;
+    return d;
+}
+
+static Handle(GeomPlate_Surface) buildPlate(const std::vector<gp_Pnt>& pts,
+                                            int degree, int nbPtsOnCur, int nbIter) {
+    GeomPlate_BuildPlateSurface builder(degree, nbPtsOnCur, nbIter);
+    for (const auto& p : pts)
+        builder.Add(new GeomPlate_PointConstraint(p, 0));
+    builder.Perform();
+    if (!builder.IsDone()) return Handle(GeomPlate_Surface)();
+    return builder.Surface();
+}
+
+static void runCase(const char* label,
+                    const Handle(GeomPlate_Surface)& plate,
+                    double tol, int nbmax, int dgmax, double dmax,
+                    int critOrder, GeomAbs_Shape cont) {
+    printf("  %-34s tol=%-8g Nbmax=%-3d dgmax=%d dmax=%-10g Crit=%-2d cont=%-2s | ",
+           label, tol, nbmax, dgmax, dmax, critOrder, contName(cont));
+    try {
+        GeomPlate_MakeApprox approx(plate, tol, nbmax, dgmax, dmax, critOrder, cont);
+        Handle(Geom_BSplineSurface) bs = approx.Surface();
+        if (bs.IsNull()) { printf("NULL SURFACE\n"); return; }
+        Dev d = deviation(bs, plate);
+        printf("uDeg=%d vDeg=%d uP=%-3d vP=%-3d approxErr=%-12.6g critErr=%-12.6g "
+               "gridDev=%-12.6g ctrDev=%-12.6g fp=%.10g\n",
+               bs->UDegree(), bs->VDegree(), bs->NbUPoles(), bs->NbVPoles(),
+               approx.ApproxError(), approx.CriterionError(),
+               d.gridMax, d.ctrMax, poleFingerprint(bs));
+    } catch (Standard_Failure const& f) {
+        printf("THREW: %s\n", f.GetMessageString() ? f.GetMessageString() : "(no message)");
+    } catch (...) {
+        printf("THREW (unknown)\n");
+    }
+}
+
+int main() {
+    // A saddle: five points that no single low-degree patch fits exactly. Deliberately
+    // NOT planar and not a pure quadric, so degree and subdivision both matter.
+    std::vector<gp_Pnt> saddle = {
+        gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 3), gp_Pnt(10, 10, 0),
+        gp_Pnt(0, 10, 3), gp_Pnt(5, 5, -4)
+    };
+    // A denser, wavier set: forces the criterion to have something to complain about.
+    std::vector<gp_Pnt> wavy;
+    for (int i = 0; i < 5; i++)
+        for (int j = 0; j < 5; j++)
+            wavy.push_back(gp_Pnt(i * 4.0, j * 4.0,
+                                  4.0 * std::sin(i * 1.3) * std::cos(j * 1.1)));
+
+    struct Fixture { const char* name; std::vector<gp_Pnt> pts; int degree; };
+    std::vector<Fixture> fixtures = {
+        {"saddle-5pt", saddle, 3},
+        {"wavy-25pt",  wavy,   3},
+    };
+
+    for (auto& fx : fixtures) {
+        printf("\n================ fixture %s (%zu pts) ================\n",
+               fx.name, fx.pts.size());
+        Handle(GeomPlate_Surface) plate = buildPlate(fx.pts, fx.degree, 15, 2);
+        if (plate.IsNull()) { printf("  plate build FAILED\n"); continue; }
+        double u0, u1, v0, v1;
+        plate->RealBounds(u0, u1, v0, v1);
+        NCollection_Sequence<gp_XY> seq; plate->Constraints(seq);
+        printf("  plate realBounds U[%g %g] V[%g %g], %d order-0 constraint pts\n",
+               u0, u1, v0, v1, seq.Length());
+        // How many constraint UVs land strictly inside the enlarged patch domain the
+        // criterion actually tests against (EnlargeCoeff = 1.1 scales each bound).
+        double e = 1.1, EU0 = e*u0, EU1 = e*u1, EV0 = e*v0, EV1 = e*v1;
+        int inside = 0;
+        for (int i = 1; i <= seq.Length(); i++) {
+            gp_XY p = seq.Value(i);
+            if (EU0 < p.X() && p.X() < EU1 && EV0 < p.Y() && p.Y() < EV1) inside++;
+        }
+        printf("  enlarged patch domain U[%g %g] V[%g %g]; %d/%d constraint pts strictly inside\n",
+               EU0, EU1, EV0, EV1, inside, seq.Length());
+
+        const double tol = 0.01;
+
+        printf("\n  -- Q2a: exactly what the bridge does today (Nbmax=1, dmax=tol*10) --\n");
+        runCase("bridge sites 1-5", plate, tol, 1, 8, tol * 10, 0, GeomAbs_C1);
+        runCase("bridge site 6 (GeomPlateSurface)", plate, tol, 20, 8, tol * 0.1, 0, GeomAbs_C1);
+
+        printf("\n  -- Q2b: at Nbmax=1, does dmax change ANYTHING? --\n");
+        for (double dm : {tol * 0.001, tol * 0.1, tol * 10, tol * 1e6})
+            runCase("Nbmax=1 dmax sweep", plate, tol, 1, 8, dm, 0, GeomAbs_C1);
+
+        printf("\n  -- Q2c: at Nbmax=1, does CritOrder change anything? --\n");
+        for (int co : {-1, 0, 1})
+            runCase("Nbmax=1 CritOrder sweep", plate, tol, 1, 8, tol * 10, co, GeomAbs_C1);
+
+        printf("\n  -- Q2d: same sweeps with Nbmax=20 (criterion has room to subdivide) --\n");
+        for (double dm : {tol * 0.001, tol * 0.1, tol * 10, tol * 1e6})
+            runCase("Nbmax=20 dmax sweep", plate, tol, 20, 8, dm, 0, GeomAbs_C1);
+        for (int co : {-1, 0, 1})
+            runCase("Nbmax=20 CritOrder sweep", plate, tol, 20, 8, tol * 0.1, co, GeomAbs_C1);
+
+        printf("\n  -- Q3: does the implicit Continuity default matter? --\n");
+        for (GeomAbs_Shape c : {GeomAbs_C0, GeomAbs_C1, GeomAbs_C2})
+            runCase("Nbmax=1 continuity sweep", plate, tol, 1, 8, tol * 10, 0, c);
+        for (GeomAbs_Shape c : {GeomAbs_C0, GeomAbs_C1, GeomAbs_C2})
+            runCase("Nbmax=20 continuity sweep", plate, tol, 20, 8, tol * 0.1, 0, c);
+
+        printf("\n  -- does Nbmax alone move the surface? (dmax/Crit/cont fixed) --\n");
+        for (int nb : {1, 2, 4, 9, 20})
+            runCase("Nbmax sweep", plate, tol, nb, 8, tol * 0.1, 0, GeomAbs_C1);
+    }
+    printf("\ndone\n");
+    return 0;
+}

--- a/Scripts/repro/571-plate-approx-contract/sweep-0019.txt
+++ b/Scripts/repro/571-plate-approx-contract/sweep-0019.txt
@@ -1,0 +1,88 @@
+
+================ fixture saddle-5pt (5 pts) ================
+  plate realBounds U[-7.07107 7.07107] V[-7.07107 7.07107], 5 order-0 constraint pts
+  enlarged patch domain U[-7.77817 7.77817] V[-7.77817 7.77817]; 5/5 constraint pts strictly inside
+
+  -- Q2a: exactly what the bridge does today (Nbmax=1, dmax=tol*10) --
+  bridge sites 1-5                   tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  bridge site 6 (GeomPlateSurface)   tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q2b: at Nbmax=1, does dmax change ANYTHING? --
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q2c: at Nbmax=1, does CritOrder change anything? --
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=-1 cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.92508e-07  critErr=0            gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=1  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=1.57544e-08  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q2d: same sweeps with Nbmax=20 (criterion has room to subdivide) --
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=-1 cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.92506e-07  critErr=0            gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=1  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=1.57544e-08  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q3: does the implicit Continuity default matter? --
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C0 | uDeg=2 vDeg=2 uP=3   vP=3   approxErr=8.57949e-08  critErr=8.48014e-08  gridDev=8.48014e-08  ctrDev=8.48014e-08  fp=14751.83994
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C2 | uDeg=5 vDeg=5 uP=6   vP=6   approxErr=5.53729e-06  critErr=4.28137e-07  gridDev=4.28137e-07  ctrDev=4.28137e-07  fp=103262.8823
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C0 | uDeg=2 vDeg=2 uP=3   vP=3   approxErr=8.57949e-08  critErr=8.48014e-08  gridDev=8.48014e-08  ctrDev=8.48014e-08  fp=14751.83994
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C2 | uDeg=5 vDeg=5 uP=6   vP=6   approxErr=5.53729e-06  critErr=4.28137e-07  gridDev=4.28137e-07  ctrDev=4.28137e-07  fp=103262.8823
+
+  -- does Nbmax alone move the surface? (dmax/Crit/cont fixed) --
+  Nbmax sweep                        tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=2   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=4   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=9   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=7.91693e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+================ fixture wavy-25pt (25 pts) ================
+  plate realBounds U[-9.72015 9.75741] V[-9.72579 9.72579], 25 order-0 constraint pts
+  enlarged patch domain U[-10.6922 10.7332] V[-10.6984 10.6984]; 25/25 constraint pts strictly inside
+
+  -- Q2a: exactly what the bridge does today (Nbmax=1, dmax=tol*10) --
+  bridge sites 1-5                   tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  bridge site 6 (GeomPlateSurface)   tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+
+  -- Q2b: at Nbmax=1, does dmax change ANYTHING? --
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+
+  -- Q2c: at Nbmax=1, does CritOrder change anything? --
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=-1 cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.949145     critErr=0            gridDev=0.0985815    ctrDev=0.0992873    fp=575901.4437
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=1  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0270621    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+
+  -- Q2d: same sweeps with Nbmax=20 (criterion has room to subdivide) --
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=-1 cont=C1 | uDeg=8 vDeg=8 uP=37  vP=30  approxErr=0.0378079    critErr=0            gridDev=0.00335826   ctrDev=0.00335263   fp=23503440.56
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=1  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00319615   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+
+  -- Q3: does the implicit Continuity default matter? --
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C0 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.207164     critErr=0.0627565    gridDev=0.0633396    ctrDev=0.0627565    fp=575866.8844
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C2 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=8.83547      critErr=0.20095      gridDev=0.198594     ctrDev=0.20095      fp=575877.8027
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C0 | uDeg=8 vDeg=8 uP=17  vP=17  approxErr=0.00734231   critErr=0.00364433   gridDev=0.00311821   ctrDev=0.00364433   fp=3704507.616
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C2 | uDeg=8 vDeg=8 uP=21  vP=21  approxErr=7.90633      critErr=0.00429028   gridDev=0.0045821    ctrDev=0.00429028   fp=6953896.435
+
+  -- does Nbmax alone move the surface? (dmax/Crit/cont fixed) --
+  Nbmax sweep                        tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.579399     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax sweep                        tol=0.01     Nbmax=2   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax sweep                        tol=0.01     Nbmax=4   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax sweep                        tol=0.01     Nbmax=9   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax sweep                        tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0228438    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+
+done

--- a/Scripts/repro/571-plate-approx-contract/sweep-stock.txt
+++ b/Scripts/repro/571-plate-approx-contract/sweep-stock.txt
@@ -1,0 +1,88 @@
+
+================ fixture saddle-5pt (5 pts) ================
+  plate realBounds U[-7.07107 7.07107] V[-7.07107 7.07107], 5 order-0 constraint pts
+  enlarged patch domain U[-7.77817 7.77817] V[-7.77817 7.77817]; 5/5 constraint pts strictly inside
+
+  -- Q2a: exactly what the bridge does today (Nbmax=1, dmax=tol*10) --
+  bridge sites 1-5                   tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  bridge site 6 (GeomPlateSurface)   tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q2b: at Nbmax=1, does dmax change ANYTHING? --
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q2c: at Nbmax=1, does CritOrder change anything? --
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=-1 cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89988e-07  critErr=0            gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=1  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=1.57544e-08  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q2d: same sweeps with Nbmax=20 (criterion has room to subdivide) --
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=-1 cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89988e-07  critErr=0            gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=1  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=1.57544e-08  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+  -- Q3: does the implicit Continuity default matter? --
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C0 | uDeg=2 vDeg=2 uP=3   vP=3   approxErr=1.5976e-08   critErr=8.48014e-08  gridDev=8.48014e-08  ctrDev=8.48014e-08  fp=14751.83994
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C2 | uDeg=5 vDeg=5 uP=6   vP=6   approxErr=5.24146e-06  critErr=4.28137e-07  gridDev=4.28137e-07  ctrDev=4.28137e-07  fp=103262.8823
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C0 | uDeg=2 vDeg=2 uP=3   vP=3   approxErr=1.5976e-08   critErr=8.48014e-08  gridDev=8.48014e-08  ctrDev=8.48014e-08  fp=14751.83994
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C2 | uDeg=5 vDeg=5 uP=6   vP=6   approxErr=5.24146e-06  critErr=4.28137e-07  gridDev=4.28137e-07  ctrDev=4.28137e-07  fp=103262.8823
+
+  -- does Nbmax alone move the surface? (dmax/Crit/cont fixed) --
+  Nbmax sweep                        tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=2   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=4   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=9   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+  Nbmax sweep                        tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=3 vDeg=3 uP=4   vP=4   approxErr=6.89248e-07  critErr=3.12432e-07  gridDev=3.12432e-07  ctrDev=3.12432e-07  fp=32781.86708
+
+================ fixture wavy-25pt (25 pts) ================
+  plate realBounds U[-9.72015 9.75741] V[-9.72579 9.72579], 25 order-0 constraint pts
+  enlarged patch domain U[-10.6922 10.7332] V[-10.6984 10.6984]; 25/25 constraint pts strictly inside
+
+  -- Q2a: exactly what the bridge does today (Nbmax=1, dmax=tol*10) --
+  bridge sites 1-5                   tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  bridge site 6 (GeomPlateSurface)   tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+
+  -- Q2b: at Nbmax=1, does dmax change ANYTHING? --
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 dmax sweep                 tol=0.01     Nbmax=1   dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+
+  -- Q2c: at Nbmax=1, does CritOrder change anything? --
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=-1 cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.5984       critErr=0            gridDev=0.0985815    ctrDev=0.0992873    fp=575901.4437
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 CritOrder sweep            tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=1  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0270621    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+
+  -- Q2d: same sweeps with Nbmax=20 (criterion has room to subdivide) --
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=1e-05      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=20 dmax sweep                tol=0.01     Nbmax=20  dgmax=8 dmax=10000      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=-1 cont=C1 | uDeg=8 vDeg=8 uP=37  vP=30  approxErr=0.0365534    critErr=0            gridDev=0.00335826   ctrDev=0.00335263   fp=23503440.56
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 CritOrder sweep           tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=1  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00319615   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+
+  -- Q3: does the implicit Continuity default matter? --
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C0 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.0822217    critErr=0.0627565    gridDev=0.0633396    ctrDev=0.0627565    fp=575866.8844
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax=1 continuity sweep           tol=0.01     Nbmax=1   dgmax=8 dmax=0.1        Crit=0  cont=C2 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=8.41372      critErr=0.20095      gridDev=0.198594     ctrDev=0.20095      fp=575877.8027
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C0 | uDeg=8 vDeg=8 uP=17  vP=17  approxErr=0.00246755   critErr=0.00364433   gridDev=0.00311821   ctrDev=0.00364433   fp=3704507.616
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax=20 continuity sweep          tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C2 | uDeg=8 vDeg=8 uP=21  vP=21  approxErr=7.87158      critErr=0.00429028   gridDev=0.0045821    ctrDev=0.00429028   fp=6953896.435
+
+  -- does Nbmax alone move the surface? (dmax/Crit/cont fixed) --
+  Nbmax sweep                        tol=0.01     Nbmax=1   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=9   vP=9   approxErr=0.385661     critErr=0.0981545    gridDev=0.0975505    ctrDev=0.0981545    fp=575915.6225
+  Nbmax sweep                        tol=0.01     Nbmax=2   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax sweep                        tol=0.01     Nbmax=4   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax sweep                        tol=0.01     Nbmax=9   dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+  Nbmax sweep                        tol=0.01     Nbmax=20  dgmax=8 dmax=0.001      Crit=0  cont=C1 | uDeg=8 vDeg=8 uP=16  vP=16  approxErr=0.0195227    critErr=0.00484093   gridDev=0.00436733   ctrDev=0.00484093   fp=3116543.597
+
+done

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -944,8 +944,10 @@ OCCTShapeRef OCCTShapePlatePoints(const double* points, int32_t pointCount, doub
         if (plateSurface.IsNull()) return nullptr;
 
         // Approximate with B-spline surface
-        GeomPlate_MakeApprox approx(plateSurface, tolerance, 1, 8, tolerance * 10, 0);
-        Handle(Geom_BSplineSurface) bsplineSurf = approx.Surface();
+        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
+            plateSurface, tolerance,
+            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
+            occtPlateApproxDefaultContinuity());
         if (bsplineSurf.IsNull()) return nullptr;
 
         // Create face from surface
@@ -991,8 +993,13 @@ OCCTShapeRef OCCTShapePlateCurves(const OCCTWireRef* curves, int32_t curveCount,
         Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
         if (plateSurface.IsNull()) return nullptr;
 
-        GeomPlate_MakeApprox approx(plateSurface, tolerance, 1, 8, tolerance * 10, 0);
-        Handle(Geom_BSplineSurface) bsplineSurf = approx.Surface();
+        // The caller's `continuity` is the CONSTRAINT order (applied to each GeomPlate_CurveConstraint
+        // above); the approximation's own continuity is the join between Bezier patches, a separate
+        // axis, so it keeps the shared default rather than following it. See OCCTBridge_Internal.h.
+        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
+            plateSurface, tolerance,
+            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
+            occtPlateApproxDefaultContinuity());
         if (bsplineSurf.IsNull()) return nullptr;
 
         BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -510,6 +510,78 @@ bool occtFillingAddConstraint(BRepOffsetAPI_MakeFilling& filling,
                               GeomAbs_Shape order,
                               bool isBound);
 
+// === #571: one GeomPlate_MakeApprox contract behind all six plate entry points ===
+
+class GeomPlate_Surface;
+class Geom_BSplineSurface;
+
+//
+// GeomPlate_MakeApprox is the one consumer of AdvApp2Var_ApproxAFunc2Var that does not go through
+// GeomConvert_ApproxSurface — it drives the approximator directly — so it sat outside every census
+// built by grepping for GeomConvert_ApproxSurface, including the PrecisCode census in
+// OCCTBridge_Surface.mm. Six bridge functions construct it: OCCTShapePlatePoints and
+// OCCTShapePlateCurves (OCCTBridge_Healing.mm), OCCTShapePlatePointsAdvanced, OCCTShapePlateMixed,
+// OCCTSurfacePlateThrough and OCCTGeomPlateSurface (OCCTBridge_ProjLib_NLPlate.mm). Five of them
+// hard-coded `Nbmax = 1, dmax = tolerance * 10`; the sixth passed the caller's maxSegments and
+// `dmax = tolerance * 0.1`. Definition lives in OCCTBridge_ProjLib_NLPlate.mm.
+//
+// The two arguments that differed are the two that decide whether `tolerance` means anything:
+//
+//   Nbmax caps the number of Bezier patches, and 1 is the one value that breaks the algorithm.
+//   AdvApp2Var_ApproxAFunc2Var::ComputePatches derives its cut decision NumDec from myMaxPatches,
+//   and at 1 every branch leaves NumDec = 0; AdvApp2Var_Patch::CutSense then returns 0 whether or
+//   not the criterion is satisfied, so "the fit missed" and "the fit is fine" issue the same
+//   instruction — keep this patch. The criterion is still evaluated and still reported through
+//   CriterionError(), it just cannot act. Measured on a 25-point wavy plate at tolerance 1e-2:
+//   Nbmax = 1 returns a 9x9 surface deviating 9.8e-2, i.e. 9.8x the tolerance it was given, with
+//   the criterion violated (critErr 9.8e-2 against a 1e-2 threshold) and ignored; Nbmax = 2 or
+//   more returns 16x16 deviating 4.4e-3, inside tolerance. Sweeping dmax across nine orders of
+//   magnitude at Nbmax = 1 yields bit-identical control nets — a dead argument in the sense of
+//   #497's inert SetFuzzyValue.
+//
+//   dmax sets the criterion threshold, as seuil = max(Tol3d, 10 * dmax) (GeomPlate_MakeApprox.cxx).
+//   So `dmax = tolerance * 10` asks the G0 criterion to accept 100x the tolerance the caller
+//   requested — and it is not merely dead weight once Nbmax allows subdivision: at Nbmax = 20 that
+//   value reproduces the bad 9x9 answer exactly, while tolerance * 0.1 gives the good 16x16 one.
+//   tolerance * 0.1 makes 10 * dmax == Tol3d, so seuil is the caller's own tolerance. It is the
+//   value the sixth site already used, and measurement picks it over the other five.
+//
+// CritOrder stays 0. The G0 criterion measures the distance between the fitted patch and the plate
+// at the plate's own order-0 constraint UVs, which is exactly what `tolerance` promises for a
+// surface built to pass through points. CritOrder = -1 disables the criterion outright (and flips
+// the Jacobi precision, myPrec 0 -> 1); CritOrder = 1 measures normals instead of positions.
+//
+// `continuity` is the continuity of the joins BETWEEN patches, a different axis from the
+// constraint order handed to GeomPlate_PointConstraint/GeomPlate_CurveConstraint — which is why
+// OCCTShapePlateCurves' caller-supplied order is NOT forwarded here. It was implicit at all six
+// sites (GeomPlate_MakeApprox.hxx defaults it to GeomAbs_C1); passing it explicitly keeps that
+// value while making it reviewable, and it is not cosmetic — C0/C1/C2 give 17x17, 16x16 and 21x21
+// control nets on the fixture above. Only those three are accepted: G1, G2, C3 and CN all throw
+// Standard_Failure ("AdvApp2Var_ApproxAFunc2Var : UContinuity Error"), measured, so callers must
+// clamp into the parametric ladder rather than reach for occtGeomAbsFromSurfaceContinuity, whose
+// order-1 answer is GeomAbs_G1.
+//
+// Returns a null handle when the approximation cannot be built; callers treat that as failure.
+occ::handle<Geom_BSplineSurface> occtPlateApproxSurface(const occ::handle<GeomPlate_Surface>& plate,
+                                                        double tolerance,
+                                                        int32_t maxDegree,
+                                                        int32_t maxSegments,
+                                                        GeomAbs_Shape continuity);
+
+// The patch-join continuity every plate entry point asks for unless told otherwise. C1 is what all
+// six sites got from GeomPlate_MakeApprox's own default before #571 made it explicit.
+inline GeomAbs_Shape occtPlateApproxDefaultContinuity() { return GeomAbs_C1; }
+
+// The largest number of Bezier patches a plate approximation may use unless the caller names one.
+// A cap, not a target: the approximator stops as soon as the criterion is met, and on the #571
+// fixture everything from 2 upwards produces the identical surface. Matches the `maxSegments: 20`
+// default that Shape.plateSurface(points:) already exposed.
+inline int32_t occtPlateApproxDefaultMaxSegments() { return 20; }
+
+// The largest Bezier degree a plate approximation may use unless the caller names one. All six
+// sites already used 8.
+inline int32_t occtPlateApproxDefaultMaxDegree() { return 8; }
+
 // === #497: one BRepAlgoAPI_Defeaturing skeleton ===
 //
 // Four entry points remove faces with BRepAlgoAPI_Defeaturing: OCCTShapeRemoveFeatures and

--- a/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
@@ -205,6 +205,42 @@ bool OCCTSurfaceProjectPoint(OCCTSurfaceRef surface,
 #include <GeomAPI_PointsToBSplineSurface.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 
+// === #571: the one GeomPlate_MakeApprox call ===
+//
+// See OCCTBridge_Internal.h for why Nbmax, dmax and continuity are what they are, and for the
+// measurements behind each. In short: Nbmax = 1 makes the criterion unable to act and the
+// tolerance unreachable, and dmax = tolerance * 10 sets the criterion threshold to 100x the
+// tolerance the caller asked for. Five of the six sites had both.
+occ::handle<Geom_BSplineSurface> occtPlateApproxSurface(const occ::handle<GeomPlate_Surface>& plate,
+                                                        double tolerance,
+                                                        int32_t maxDegree,
+                                                        int32_t maxSegments,
+                                                        GeomAbs_Shape continuity) {
+    if (plate.IsNull() || !(tolerance > 0)) return occ::handle<Geom_BSplineSurface>();
+
+    // A single patch cannot be cut, so the criterion's verdict is discarded and `tolerance` stops
+    // being enforceable at all. Two is the smallest cap that lets the approximator honour it.
+    int32_t nbMax = maxSegments < 2 ? 2 : maxSegments;
+    int32_t dgMax = maxDegree < 1 ? occtPlateApproxDefaultMaxDegree() : maxDegree;
+
+    // AdvApp2Var accepts C0, C1 and C2 only; G1/G2/C3/CN each throw. Clamp into that ladder
+    // rather than let a caller's continuity turn the whole call into a nullptr.
+    GeomAbs_Shape cont = continuity;
+    if (cont == GeomAbs_G1) cont = GeomAbs_C1;
+    else if (cont == GeomAbs_G2) cont = GeomAbs_C2;
+    else if (cont == GeomAbs_C3 || cont == GeomAbs_CN) cont = GeomAbs_C2;
+
+    // seuil = max(Tol3d, 10 * dmax), so this makes the criterion threshold the caller's tolerance.
+    const double dmax = tolerance * 0.1;
+
+    try {
+        GeomPlate_MakeApprox approx(plate, tolerance, nbMax, dgMax, dmax, 0, cont);
+        return approx.Surface();
+    } catch (...) {
+        return occ::handle<Geom_BSplineSurface>();
+    }
+}
+
 OCCTShapeRef OCCTShapePlatePointsAdvanced(const double* points, int32_t pointCount,
                                            const int32_t* orders, int32_t degree,
                                            int32_t nbPtsOnCur, int32_t nbIter,
@@ -229,8 +265,10 @@ OCCTShapeRef OCCTShapePlatePointsAdvanced(const double* points, int32_t pointCou
         Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
         if (plateSurface.IsNull()) return nullptr;
 
-        GeomPlate_MakeApprox approx(plateSurface, tolerance, 1, 8, tolerance * 10, 0);
-        Handle(Geom_BSplineSurface) bsplineSurf = approx.Surface();
+        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
+            plateSurface, tolerance,
+            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
+            occtPlateApproxDefaultContinuity());
         if (bsplineSurf.IsNull()) return nullptr;
 
         BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);
@@ -289,8 +327,10 @@ OCCTShapeRef OCCTShapePlateMixed(const double* points, const int32_t* pointOrder
         Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
         if (plateSurface.IsNull()) return nullptr;
 
-        GeomPlate_MakeApprox approx(plateSurface, tolerance, 1, 8, tolerance * 10, 0);
-        Handle(Geom_BSplineSurface) bsplineSurf = approx.Surface();
+        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
+            plateSurface, tolerance,
+            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
+            occtPlateApproxDefaultContinuity());
         if (bsplineSurf.IsNull()) return nullptr;
 
         BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);
@@ -321,8 +361,10 @@ OCCTSurfaceRef OCCTSurfacePlateThrough(const double* points, int32_t pointCount,
         Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
         if (plateSurface.IsNull()) return nullptr;
 
-        GeomPlate_MakeApprox approx(plateSurface, tolerance, 1, 8, tolerance * 10, 0);
-        Handle(Geom_BSplineSurface) bsplineSurf = approx.Surface();
+        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
+            plateSurface, tolerance,
+            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
+            occtPlateApproxDefaultContinuity());
         if (bsplineSurf.IsNull()) return nullptr;
 
         return new OCCTSurface(bsplineSurf);
@@ -534,9 +576,9 @@ OCCTShapeRef OCCTGeomPlateSurface(const double* points, int32_t ptCount,
         if (plateSurf.IsNull()) return nullptr;
 
         // Convert to BSpline for use as a face
-        GeomPlate_MakeApprox approx(plateSurf, tolerance, maxSegments, maxDegree,
-                                     tolerance * 0.1, 0);
-        Handle(Geom_BSplineSurface) bspline = approx.Surface();
+        Handle(Geom_BSplineSurface) bspline = occtPlateApproxSurface(
+            plateSurf, tolerance, maxDegree, maxSegments,
+            occtPlateApproxDefaultContinuity());
         if (bspline.IsNull()) return nullptr;
 
         BRepBuilderAPI_MakeFace faceMaker(bspline, tolerance);

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -9119,11 +9119,25 @@ extension Shape {
     /// Creates a smooth BSpline surface that passes through or near the given points.
     /// Useful for creating surfaces from scattered point data.
     ///
+    /// The fit subdivides into more Bezier patches until it is within `tolerance` of the plate.
+    /// `maxSegments` caps that subdivision; **1 is clamped to 2**, because a single patch cannot be
+    /// cut and the approximator then ignores its own error criterion entirely, which makes
+    /// `tolerance` unenforceable rather than merely coarse (#571).
+    ///
+    /// ```swift
+    /// let points: [SIMD3<Double>] = [
+    ///     SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(0, 10, -1), SIMD3(10, 10, 0.5),
+    /// ]
+    /// if let face = Shape.plateSurface(points: points, tolerance: 1e-3) {
+    ///     print(face.surfaceArea ?? 0)
+    /// }
+    /// ```
+    ///
     /// - Parameters:
     ///   - points: Array of 3D points to fit the surface through
     ///   - tolerance: Approximation tolerance (default 1e-3)
     ///   - maxDegree: Maximum BSpline degree (default 8)
-    ///   - maxSegments: Maximum BSpline segments (default 20)
+    ///   - maxSegments: Maximum BSpline segments (default 20; values below 2 are clamped to 2)
     /// - Returns: Face with plate surface, or nil on failure
     public static func plateSurface(points: [SIMD3<Double>], tolerance: Double = 1e-3,
                                      maxDegree: Int = 8, maxSegments: Int = 20) -> Shape? {

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -861,10 +861,29 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Advanced Plate Surfaces (v0.23.0)
 
-    /// Create a plate surface (parametric) interpolating through 3D points.
+    /// Create a plate surface (parametric) approximating a set of 3D points.
     ///
-    /// Uses `GeomPlate_BuildPlateSurface` + `GeomPlate_MakeApprox` to produce
-    /// a BSpline surface that passes through all given points.
+    /// Uses `GeomPlate_BuildPlateSurface` + `GeomPlate_MakeApprox` to produce a BSpline surface
+    /// through the given points. It **approximates** rather than interpolates: the fit subdivides
+    /// into more Bezier patches until it is within `tolerance` of the plate, and a cloud that
+    /// cannot be fitted that tightly still returns its best effort. Check the result:
+    ///
+    /// ```swift
+    /// let points: [SIMD3<Double>] = (0..<5).flatMap { i in
+    ///     (0..<5).map { j in
+    ///         SIMD3(Double(i) * 4, Double(j) * 4,
+    ///               4 * sin(Double(i) * 1.3) * cos(Double(j) * 1.1))
+    ///     }
+    /// }
+    /// if let plate = Surface.plateThrough(points, degree: 3, tolerance: 0.01) {
+    ///     let worst = points.compactMap { plate.projectPoint($0)?.distance }.max() ?? 0
+    ///     print(worst)              // 0.0032 — inside tolerance
+    ///     print(plate.uPoleCount)   // 16 — more than one patch, so the fit did subdivide
+    /// }
+    /// ```
+    ///
+    /// A `uPoleCount` no greater than the degree cap plus one means the fit stayed on a single
+    /// Bezier patch. Before #571 that was forced, and `tolerance` was unenforceable as a result.
     ///
     /// - Parameters:
     ///   - points: Array of 3D points (minimum 3)

--- a/Tests/OCCTSurfaceTests/Issue571PlateApproxTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue571PlateApproxTests.swift
@@ -1,0 +1,149 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #571 — the six plate entry points drive `GeomPlate_MakeApprox` directly rather than through
+/// `GeomConvert_ApproxSurface`, and five of them passed `Nbmax = 1` with `dmax = tolerance * 10`.
+///
+/// `Nbmax = 1` is the one value that disarms the algorithm: `AdvApp2Var_ApproxAFunc2Var` derives
+/// its cut decision from the patch cap, and at 1 it decides "keep this patch" whether or not the
+/// G0 criterion was satisfied — so the criterion is evaluated, violated, and ignored. `dmax` then
+/// set the criterion's own threshold to `max(Tol3d, 10 * dmax)` = 100x the requested tolerance.
+/// Together they made `tolerance` unenforceable: measured at 7.2x the value asked for.
+///
+/// These tests pin the contract at the public API, so a regression shows up as a surface that
+/// misses its tolerance rather than as an argument that looks plausible at the call site.
+@Suite("Issue 571 — plate approximation honours its tolerance")
+struct Issue571PlateApproxTests {
+
+    /// A surface no single Bezier patch can fit: two full periods of a product of sines across a
+    /// 16x16 span. A gentler fixture is reproduced exactly by one patch, which hides the defect —
+    /// the previously-shipped plate tests all used 4-to-9-point near-planar sets for that reason.
+    static var wavyPoints: [SIMD3<Double>] {
+        var points: [SIMD3<Double>] = []
+        for i in 0..<5 {
+            for j in 0..<5 {
+                points.append(SIMD3(Double(i) * 4.0,
+                                    Double(j) * 4.0,
+                                    4.0 * sin(Double(i) * 1.3) * cos(Double(j) * 1.1)))
+            }
+        }
+        return points
+    }
+
+    /// Worst distance from any input point to the fitted surface.
+    static func worstDeviation(of surface: Surface, from points: [SIMD3<Double>]) -> Double {
+        var worst = 0.0
+        for point in points {
+            guard let projection = surface.projectPoint(point) else { continue }
+            worst = max(worst, projection.distance)
+        }
+        return worst
+    }
+
+    @Test("A plate surface lands within the tolerance it was given")
+    func toleranceIsHonoured() {
+        let points = Self.wavyPoints
+        let tolerance = 0.01
+        guard let surface = Surface.plateThrough(points, degree: 3, tolerance: tolerance) else {
+            Issue.record("plate build failed")
+            return
+        }
+        // Pre-#571 this measured 0.0724 — 7.2x the tolerance, reported as a success.
+        let deviation = Self.worstDeviation(of: surface, from: points)
+        #expect(deviation <= tolerance,
+                "worst deviation \(deviation) exceeds requested tolerance \(tolerance)")
+    }
+
+    @Test("The approximation is allowed to use more than one Bezier patch")
+    func subdivisionIsPermitted() {
+        guard let surface = Surface.plateThrough(Self.wavyPoints, degree: 3, tolerance: 0.01) else {
+            Issue.record("plate build failed")
+            return
+        }
+        // One patch of degree d has exactly d+1 poles per direction, so <= 9 at the degree cap of
+        // 8 means the fit never subdivided — which is what Nbmax = 1 forced regardless of error.
+        #expect(surface.uPoleCount > 9,
+                "uPoleCount \(surface.uPoleCount) means the fit stayed on a single Bezier patch")
+    }
+
+    @Test("Asking for a tighter tolerance actually produces a tighter fit")
+    func toleranceChangesTheResult() {
+        let points = Self.wavyPoints
+        guard let loose = Surface.plateThrough(points, degree: 3, tolerance: 0.1),
+              let tight = Surface.plateThrough(points, degree: 3, tolerance: 0.0005) else {
+            Issue.record("plate build failed")
+            return
+        }
+        let looseDeviation = Self.worstDeviation(of: loose, from: points)
+        let tightDeviation = Self.worstDeviation(of: tight, from: points)
+        // With dmax = tolerance * 10 the criterion threshold scaled with the tolerance instead of
+        // being bounded by it, so both requests resolved to the same single-patch surface.
+        #expect(tightDeviation < looseDeviation,
+                "tolerance had no effect: loose \(looseDeviation) vs tight \(tightDeviation)")
+        #expect(tight.uPoleCount >= loose.uPoleCount)
+    }
+
+    @Test("maxSegments below the algorithm's floor still honours the tolerance")
+    func degenerateMaxSegmentsIsClamped() {
+        let points = Self.wavyPoints
+        // maxSegments: 1 reads like "use one patch", but it is the value that makes the tolerance
+        // unenforceable rather than merely coarse, so the bridge lifts it to the floor of 2.
+        guard let one = Shape.plateSurface(points: points, tolerance: 0.01, maxSegments: 1),
+              let many = Shape.plateSurface(points: points, tolerance: 0.01, maxSegments: 20) else {
+            Issue.record("plate build failed")
+            return
+        }
+        #expect(one.isValid)
+        let oneArea = one.surfaceArea ?? 0
+        let manyArea = many.surfaceArea ?? 0
+        #expect(oneArea > 0)
+        #expect(abs(oneArea - manyArea) < 1e-6,
+                "maxSegments 1 gave \(oneArea) but 20 gave \(manyArea)")
+    }
+
+    @Test("Both plate-through-points entry points agree on the same input")
+    func bothEntryPointsAgree() {
+        let points = Self.wavyPoints
+        // Shape.plateSurface(through:) and Shape.plateSurface(points:) are overloads of one name
+        // doing one job, but they reached GeomPlate_MakeApprox with different Nbmax and dmax —
+        // 22x apart on accuracy for the same request until #571 gave them one contract.
+        guard let through = Shape.plateSurface(through: points, tolerance: 0.01),
+              let named = Shape.plateSurface(points: points, tolerance: 0.01) else {
+            Issue.record("plate build failed")
+            return
+        }
+        let throughArea = through.surfaceArea ?? 0
+        let namedArea = named.surfaceArea ?? 0
+        #expect(throughArea > 0)
+        #expect(abs(throughArea - namedArea) < 1e-6,
+                "plateSurface(through:) gave \(throughArea), plateSurface(points:) gave \(namedArea)")
+    }
+
+    @Test("Curve-constrained plates honour their tolerance too")
+    func curveConstrainedPlateHonoursTolerance() {
+        // OCCTShapePlateCurves shared the same defective arguments; it is exercised through its
+        // own entry point so the shared helper cannot regress for one caller only. The boundary
+        // is a warped octagon — a four-corner ring is reproduced by one patch and proves nothing.
+        var corners: [SIMD3<Double>] = []
+        for i in 0..<8 {
+            let angle = Double(i) * .pi / 4
+            corners.append(SIMD3(8 * cos(angle), 8 * sin(angle), 3 * sin(Double(i) * 2.1)))
+        }
+        guard let wire = Wire.polygon3D(corners, closed: true),
+              let shape = Shape.plateSurface(constrainedBy: [wire], continuity: .g0,
+                                             tolerance: 0.01),
+              let face = shape.face(at: 0) else {
+            Issue.record("curve-constrained plate build failed")
+            return
+        }
+        #expect((shape.surfaceArea ?? 0) > 0)
+        // The plate is built to pass through its boundary, so the fitted face must too.
+        var worst = 0.0
+        for corner in corners {
+            guard let projection = face.project(point: corner) else { continue }
+            worst = max(worst, projection.distance)
+        }
+        #expect(worst <= 0.01, "boundary deviation \(worst) exceeds the requested tolerance 0.01")
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -488,7 +488,7 @@ struct FillingSupportFaceTests {
     }
 }
 
-@Suite("Plate Surface Tests", .disabled("Plate surface operations cause segfault in OCCT — pre-existing issue"))
+@Suite("Plate Surface Tests")
 struct PlateSurfaceTests {
 
     @Test("Plate surface through grid of points")
@@ -1323,7 +1323,7 @@ struct AdvancedPlateSurfaceTests {
     }
 }
 
-@Suite("Parametric Plate Surface Tests", .disabled("Plate surface operations cause segfault in OCCT — pre-existing issue"))
+@Suite("Parametric Plate Surface Tests")
 struct ParametricPlateSurfaceTests {
 
     @Test("Plate through points returns parametric surface")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -178,6 +178,64 @@ comment blames a hang, #522 is not a hang, and retiring a hang guard needs a rep
 Post-`0019` the workaround also costs nothing measurable — forced C0 returns a slightly coarser fit
 (1.2e-7 against 1.4e-8) that is comfortably inside tolerance either way.
 
+#### Breaking: plate surfaces honour the tolerance they were given (#571)
+
+Six bridge functions build a surface with `GeomPlate_MakeApprox` — `Shape.plateSurface(through:)`,
+`plateSurface(constrainedBy:)`, `plateSurface(through:orders:)`, `plateSurface(through:curves:)`,
+`plateSurface(points:)` and `Surface.plateThrough(_:)`. Five of them passed `Nbmax = 1` and
+`dmax = tolerance * 10`, and between them those two arguments made `tolerance` unenforceable.
+
+`Nbmax` caps the number of Bezier patches, and **1 is the one value that disarms the algorithm**.
+`AdvApp2Var_ApproxAFunc2Var::ComputePatches` derives its cut decision from that cap; at 1 every
+branch leaves it at "do not cut", so `AdvApp2Var_Patch::CutSense` returns the same answer whether or
+not the G0 criterion was satisfied. The criterion is still evaluated and still reported through
+`CriterionError()` — it simply cannot act. Measured on a 25-point wavy plate at `tolerance: 0.01`:
+the criterion came back at `0.098` against its own `0.01` threshold, violated, and the surface was
+returned unchanged. `Nbmax = 2` or more fits the same plate to `0.0044`.
+
+`dmax` sets that threshold, as `seuil = max(Tol3d, 10 * dmax)`. `tolerance * 10` therefore asked the
+criterion to accept **100x the tolerance the caller requested** — and it is not merely dead weight
+once subdivision is allowed: at `Nbmax = 20` that value reproduces the bad single-patch answer
+exactly, while `tolerance * 0.1` gives the good one. `tolerance * 0.1` makes `10 * dmax == Tol3d`,
+so the threshold is the caller's own tolerance. It is the value the sixth site already used.
+
+All six now share one helper (`occtPlateApproxSurface`) with one contract. What changes for callers:
+
+| | before | after |
+|---|---|---|
+| worst deviation, 25-point wavy plate at `tolerance: 0.01` | `0.0724` (7.2x the request) | `0.0032` |
+| control points in U | 9 (a single degree-8 patch) | 16 |
+| `plateSurface(through:)` vs `plateSurface(points:)`, same input | 22x apart on accuracy | identical |
+
+Surfaces from these six entry points therefore **move**, and callers who stored derived geometry
+should regenerate it. Two related contracts are now explicit rather than implicit:
+
+- **`maxSegments: 1` is clamped to 2.** `Shape.plateSurface(points:maxSegments:)` is the one entry
+  point that exposes the cap, and 1 there is not a coarser request but the value that voids
+  `tolerance` entirely.
+- **The approximation's continuity is passed explicitly, and stays `GeomAbs_C1`.** It is the
+  continuity of the joins *between* patches, a different axis from the constraint order handed to
+  `GeomPlate_PointConstraint`/`GeomPlate_CurveConstraint` — so `plateSurface(constrainedBy:continuity:)`
+  still applies the caller's `.g0`/`.g1`/`.g2` to the boundary constraints only, and does not forward
+  it to the fit. Only `C0`, `C1` and `C2` are accepted there at all: `G1`, `G2`, `C3` and `CN` each
+  throw `AdvApp2Var_ApproxAFunc2Var : UContinuity Error` (measured), which is why
+  `occtGeomAbsFromSurfaceContinuity` — whose order-1 answer is `GeomAbs_G1` — must not feed it.
+
+**This is not fallout from [#522](https://github.com/SecondMouseAU/OCCTSwift/issues/522), though
+that is what prompted the audit.** `GeomPlate_MakeApprox` is the one consumer of the defective
+approximator that does not go through `GeomConvert_ApproxSurface`, so it took #522's always-zero
+interior error without appearing in any census built by grepping for that class. Fingerprinting the
+control net of 54 plate fits either side of the `0019` patch — a stock override-link against the
+patched kernel — shows **every one identical**. Only the reported `ApproxError()` moved, rising
+1.03x to 5.37x as the interior contribution is counted for the first time. At the implicit `C1`
+default the degree floor is already 8, so #522's collapse could not reach these sites, exactly as
+#571 predicted.
+
+Two plate suites carrying `.disabled("Plate surface operations cause segfault in OCCT")` are
+re-enabled: 18 tests, 13 consecutive clean runs, and they pass against the pre-fix arguments too, so
+the annotation was stale rather than describing something this change cured. They cover two of the
+six sites. Reproducers and both transcripts: [`Scripts/repro/571-plate-approx-contract/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/571-plate-approx-contract).
+
 #### The cross-reference index stops naming 135 symbols that never existed (#510)
 
 `OCCTBridge.h` opens with a hand-maintained index mapping each wrapped OCCT class to the bridge

--- a/docs/guides/cookbook/surfaces-from-points.md
+++ b/docs/guides/cookbook/surfaces-from-points.md
@@ -64,6 +64,19 @@ guard let plate = Surface.plateThrough(points, degree: 3, tolerance: 0.01) else 
 constraint points (probe data, feature points). The trade-off is less direct control over the
 parametrization than the grid fit gives you.
 
+Like the grid fit, it **approximates** — so check the result against `tolerance` rather than
+assuming it, especially on a cloud with real curvature in it:
+
+```swift
+let worst = points.compactMap { plate.projectPoint($0)?.distance }.max() ?? 0
+if worst > 0.01 { /* the plate could not be fitted this tightly */ }
+```
+
+Before #571 that check could never pass on a demanding cloud: the fit was capped at a single Bezier
+patch, which is the one setting that stops the approximator acting on its own error estimate, so a
+`tolerance: 0.01` request could return a surface `0.072` away and report success. If
+`plate.uPoleCount` is at most `degree + 1`, the fit never subdivided.
+
 ## Deform an existing surface to hit target points
 
 If you already have a surface and want to **pull it through** specific positions, the non-linear plate

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -48,6 +48,34 @@ for scattered probe data, feature points, or any unstructured point set. See als
   }
   ```
 
+#### What `tolerance` means here (#571)
+
+`tolerance` bounds the distance between the fitted BSpline and the plate at the plate's own
+constraint points, and the approximator subdivides into more Bezier patches until it is met. Before
+#571 it could not be met: five of the six plate entry points capped the approximation at a single
+patch, which is the one value that stops `AdvApp2Var_ApproxAFunc2Var` from acting on its own error
+criterion, so a violated tolerance and a satisfied one produced the same surface. A 25-point wavy
+plate asked for `tolerance: 0.01` came back deviating `0.072`.
+
+Verify it rather than assume it — the fit is a least-squares approximation, not an interpolation,
+and a plate that genuinely cannot be fitted still returns its best effort:
+
+```swift
+let points: [SIMD3<Double>] = (0..<5).flatMap { i in
+    (0..<5).map { j in
+        SIMD3(Double(i) * 4, Double(j) * 4,
+              4 * sin(Double(i) * 1.3) * cos(Double(j) * 1.1))
+    }
+}
+if let plate = Surface.plateThrough(points, degree: 3, tolerance: 0.01) {
+    let worst = points.compactMap { plate.projectPoint($0)?.distance }.max() ?? 0
+    print(worst)                // 0.0032 — inside tolerance
+    print(plate.uPoleCount)     // 16 — more than one degree-8 patch, so it did subdivide
+}
+```
+
+`uPoleCount <= degreeCap + 1` (9 at the default cap of 8) means the fit never subdivided.
+
 ---
 
 ### `nlPlateDeformed(constraints:maxIterations:tolerance:)`


### PR DESCRIPTION
Six bridge functions build a surface with `GeomPlate_MakeApprox` — **not the three #571 lists**.
Five of them passed `Nbmax = 1` with `dmax = tolerance * 10`, and between them those two arguments
made `tolerance` unenforceable.

| # | site | Nbmax | dmax |
|---|---|---|---|
| 1 | `OCCTShapePlatePoints` (`OCCTBridge_Healing.mm`) | 1 | `tolerance * 10` |
| 2 | `OCCTShapePlateCurves` (`OCCTBridge_Healing.mm`) | 1 | `tolerance * 10` |
| 3 | `OCCTShapePlatePointsAdvanced` (`OCCTBridge_ProjLib_NLPlate.mm`) | 1 | `tolerance * 10` |
| 4 | `OCCTShapePlateMixed` (`OCCTBridge_ProjLib_NLPlate.mm`) | 1 | `tolerance * 10` |
| 5 | `OCCTSurfacePlateThrough` (`OCCTBridge_ProjLib_NLPlate.mm`) | 1 | `tolerance * 10` |
| 6 | `OCCTGeomPlateSurface` (`OCCTBridge_ProjLib_NLPlate.mm`) | caller's `maxSegments` (default 20) | `tolerance * 0.1` |

Sites 1 and 6 are reachable from **overloads of one Swift name** — `Shape.plateSurface(through:)`
and `Shape.plateSurface(points:)` — doing one job with contracts 22x apart on accuracy.

## Q2 — was the `CritOrder = 0` criterion inert?

**Yes, and `dmax` was a dead argument — but not for the reason the issue proposed.** The issue
guessed the threshold could never be exceeded. It is exceeded, and nothing happens.

`Nbmax` caps the Bezier patch count, and **1 is the one value that disarms the algorithm**.
`AdvApp2Var_ApproxAFunc2Var::ComputePatches` derives its cut decision `NumDec` from `myMaxPatches`;
every branch needs a sum of at least 2 to fit under the cap, so at 1 `NumDec` stays 0.
`AdvApp2Var_Patch::CutSense` then returns 0 whether or not the criterion is satisfied — "the fit
missed" and "the fit is fine" issue the same instruction. The criterion is still computed and still
reported through `CriterionError()`; it just cannot act:

```
Nbmax=1 dmax=1e-09  seuil=0.01  critErr=0.0981545   violated=YES | uP=9  vP=9
Nbmax=1 dmax=1e-06  seuil=0.01  critErr=0.0981545   violated=YES | uP=9  vP=9
Nbmax=2 dmax=1e-09  seuil=0.01  critErr=0.00484093  violated=no  | uP=16 vP=16
```

Sweeping `dmax` across nine orders of magnitude at `Nbmax = 1` gives **bit-identical control nets**.
`Nbmax = 2` is enough; 2 through 100 produce the identical surface on this fixture.

`dmax` sets that threshold, as `seuil = max(Tol3d, 10 * dmax)`, so `tolerance * 10` asked the G0
criterion to accept **100x the requested tolerance**. It is not merely dead weight once subdivision
is allowed: at `Nbmax = 20` that value reproduces the bad single-patch answer exactly, while
`tolerance * 0.1` gives the good one. `tolerance * 0.1` makes `10 * dmax == Tol3d` — the value the
sixth site already used, so measurement picks it over the other five.

## Q1 — did the surfaces move under patch `0019`?

**No.** 54 plate fits fingerprinted either side of `0019`, the stock side built by override-linking
the unpatched `AdvApp2Var_ApproxF2var.cxx` ahead of the archive: **every fingerprint identical**,
degrees and pole counts identical. Only the reported `ApproxError()` moved, rising 1.03x to 5.37x
(median 1.15x) as the interior contribution is counted for the first time. At the implicit `C1`
default the `NDMINU` floor is already 8, so #522's collapse could not reach these sites — exactly
as #571 predicted. Nothing in the plate family needed re-baselining.

## Q3 — should `Continuity` be explicit?

Passed explicitly, **staying `GeomAbs_C1`**. It is the continuity of joins *between* patches, a
different axis from the constraint order handed to `GeomPlate_PointConstraint`/`CurveConstraint`, so
`plateSurface(constrainedBy:continuity:)` still applies the caller's `.g0`/`.g1`/`.g2` to the
boundary constraints only and does not forward it to the fit. It is not cosmetic — C0/C1/C2 give
17x17, 16x16 and 21x21 control nets. Only those three are accepted at all: **`G1`, `G2`, `C3` and
`CN` each throw** `AdvApp2Var_ApproxAFunc2Var : UContinuity Error` (measured), which is why
`occtGeomAbsFromSurfaceContinuity` — whose order-1 answer is `GeomAbs_G1` — must not feed it.

## What changes for callers

| | before | after |
|---|---|---|
| worst deviation, 25-point wavy plate at `tolerance: 0.01` | `0.0724` (7.2x the request) | `0.0032` |
| control points in U | 9 (a single degree-8 patch) | 16 |
| `plateSurface(through:)` vs `plateSurface(points:)`, same input | 22x apart | identical |

Surfaces from these six entry points **move**; callers holding derived geometry should regenerate
it. `maxSegments: 1` is clamped to 2 at the one entry point exposing the cap, since it is not a
coarser request but the value that voids `tolerance` entirely.

## Re-enabled suites

Two plate suites carried `.disabled("Plate surface operations cause segfault in OCCT")`. 18 tests,
13 consecutive clean runs — and they pass against the **pre-fix** arguments too, so the annotation
was stale rather than describing anything this change cured. They cover two of the six sites.

## Verification

- `swift test`: 5049 tests, 3 failures, all in `Issue496CylindricalHoleTests` and **confirmed
  identical on the base commit `5452a73`** — pre-existing, unrelated to plates.
- Every new test checked by injecting the defect it targets and confirming it fails: old
  `Nbmax`/`dmax` (3 tests), re-diverging site 1 from the shared helper (1), removing the
  `maxSegments` clamp (1), and the curve-constrained boundary deviation (1).
- Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild. `Package.swift` untouched, per the
  convention that the url/checksum bump belongs to the release commit.
- `Scripts/check-bridge-index.py`: 680 symbols across 369 classes, 0 stale.

Reproducers, both sweep transcripts and the criterion probe:
[`Scripts/repro/571-plate-approx-contract/`](https://github.com/SecondMouseAU/OCCTSwift/tree/fix/571-plate-approx-contract/Scripts/repro/571-plate-approx-contract).

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
