### PR TITLE
fix(#617): the third grid buffer was written against the layout #486 declared

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -21592,9 +21592,13 @@ uint32_t OCCTBRepGraphCachedCoEdgeMeshStoredOwnGen(OCCTBRepGraphRef _Nonnull gra
 /// All four buffers share one layout: **U-major**, u varying slowest and v fastest, i.e. sample
 /// (iu, iv) sits at `occtSurfaceGridIndex(iu, iv, vSamples)` == `iu * vSamples + iv` — the same
 /// index every other surface grid in this bridge uses (#404/#486). Scalar buffers are indexed by
-/// that value directly; the xyz buffers by `idx * 3 + {0,1,2}`. This wrote the transposed
-/// `iv * uSamples + iu` until #617, which is silently wrong on a square grid and out of bounds on
-/// a non-square one — do not re-spell the formula here, use the shared helper.
+/// that value directly; the xyz buffers by `idx * 3 + {0,1,2}`.
+///
+/// This wrote the transposed `iv * uSamples + iu` until #617. Note what that defect did and did
+/// not do: a transpose is a bijection onto the same `0..<uSamples * vSamples` range, so it is in
+/// bounds at every aspect ratio and every reader of it got a silent wrong answer, never a trap.
+/// (The out-of-range failure in this family needs a different slip, a caller striding by the
+/// wrong count.) Do not re-spell the formula here — use the shared helper.
 int32_t OCCTBRepGraphSampleFaceUVGrid(
     OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex,
     int32_t uSamples, int32_t vSamples,

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -21588,6 +21588,13 @@ uint32_t OCCTBRepGraphCachedCoEdgeMeshStoredOwnGen(OCCTBRepGraphRef _Nonnull gra
 /// Sample a regular UV grid on a face surface. Returns point count (uSamples * vSamples),
 /// or 0 on failure. Caller provides output buffers: positions (count*3 doubles),
 /// normals (count*3 doubles), gaussianCurvatures (count doubles), meanCurvatures (count doubles).
+///
+/// All four buffers share one layout: **U-major**, u varying slowest and v fastest, i.e. sample
+/// (iu, iv) sits at `occtSurfaceGridIndex(iu, iv, vSamples)` == `iu * vSamples + iv` — the same
+/// index every other surface grid in this bridge uses (#404/#486). Scalar buffers are indexed by
+/// that value directly; the xyz buffers by `idx * 3 + {0,1,2}`. This wrote the transposed
+/// `iv * uSamples + iu` until #617, which is silently wrong on a square grid and out of bounds on
+/// a non-square one — do not re-spell the formula here, use the shared helper.
 int32_t OCCTBRepGraphSampleFaceUVGrid(
     OCCTBRepGraphRef _Nonnull graph, int32_t faceIndex,
     int32_t uSamples, int32_t vSamples,

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -2965,11 +2965,15 @@ int32_t OCCTBRepGraphSampleFaceUVGrid(OCCTBRepGraphRef g, int32_t faceIndex,
         double uStep = (uSamples > 1) ? (uMax - uMin) / (uSamples - 1) : 0.0;
         double vStep = (vSamples > 1) ? (vMax - vMin) / (vSamples - 1) : 0.0;
 
-        for (int32_t iv = 0; iv < vSamples; ++iv) {
-            double v = vMin + iv * vStep;
-            for (int32_t iu = 0; iu < uSamples; ++iu) {
-                double u = uMin + iu * uStep;
-                int32_t idx = iv * uSamples + iu;
+        // #617: U-major, via the one shared index (occtSurfaceGridIndex, #486) rather than a
+        // hand-spelled formula. This buffer used to be written `iv * uSamples + iu` — the exact
+        // opposite of what #486 declared THE surface-grid layout, and the only guidance a caller
+        // of BRepGraph.FaceGridSample had. Loop order follows the index so writes stay sequential.
+        for (int32_t iu = 0; iu < uSamples; ++iu) {
+            double u = uMin + iu * uStep;
+            for (int32_t iv = 0; iv < vSamples; ++iv) {
+                double v = vMin + iv * vStep;
+                int32_t idx = occtSurfaceGridIndex(iu, iv, vSamples);
 
                 GeomLProp_SLProps props = occtSurfaceLocalProps(surfHandle, u, v, 2);
 

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -1969,9 +1969,19 @@ public final class BRepGraph: @unchecked Sendable {
     ///
     /// All four parallel arrays share one layout: **U-major**, u varying slowest and v fastest,
     /// so the sample at grid position `(u, v)` lives at flat index `u * vSamples + v` — the same
-    /// index ``SurfaceGrid`` and ``SurfaceGridD1`` use (#404/#486). Prefer ``at(u:v:)`` over
-    /// spelling that out: a hand-rolled `u * uSamples + v` is silently wrong on a square grid and
-    /// traps out of range on a non-square one, which is exactly the bug #617 fixed.
+    /// index ``SurfaceGrid`` and ``SurfaceGridD1`` use (#404/#486).
+    ///
+    /// Prefer ``at(u:v:)`` over spelling the index out, because the two ways to get it wrong fail
+    /// differently and neither announces itself:
+    ///
+    /// - Using the layout but the **wrong count as the stride** (`u * uSamples + v`) is correct
+    ///   only on a square grid, where the two counts coincide. On a non-square grid it is in
+    ///   range and quietly wrong when `uSamples < vSamples` (3x10 reaches 15 of 30), and past the
+    ///   end when `uSamples > vSamples` (10x3 reaches 92 of 30).
+    /// - Reading with the **transposed index** (`v * uSamples + u`) never traps at any aspect
+    ///   ratio: it is a bijection onto the same `0..<uSamples * vSamples` range, so it can only
+    ///   ever be a silent wrong answer. That was the layout this buffer was written in until
+    ///   #617.
     ///
     /// ```swift
     /// guard let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)

--- a/Sources/OCCTSwift/BRepGraph.swift
+++ b/Sources/OCCTSwift/BRepGraph.swift
@@ -1966,22 +1966,88 @@ public final class BRepGraph: @unchecked Sendable {
     // MARK: - UV-Grid Sampling (v0.136.0)
 
     /// Result of sampling a face surface on a regular UV grid.
+    ///
+    /// All four parallel arrays share one layout: **U-major**, u varying slowest and v fastest,
+    /// so the sample at grid position `(u, v)` lives at flat index `u * vSamples + v` — the same
+    /// index ``SurfaceGrid`` and ``SurfaceGridD1`` use (#404/#486). Prefer ``at(u:v:)`` over
+    /// spelling that out: a hand-rolled `u * uSamples + v` is silently wrong on a square grid and
+    /// traps out of range on a non-square one, which is exactly the bug #617 fixed.
+    ///
+    /// ```swift
+    /// guard let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
+    /// else { return }
+    /// // Flat storage is U-major: index (u, v) == u * sample.vSamples + v.
+    /// let s = sample.at(u: 9, v: 2)
+    /// print(s.position, s.normal, s.gaussianCurvature, s.meanCurvature)
+    ///
+    /// // Walk the grid row by row (u outer, v inner) to read the buffers in storage order.
+    /// for u in 0..<sample.uSamples {
+    ///     for v in 0..<sample.vSamples {
+    ///         let mean = sample.at(u: u, v: v).meanCurvature
+    ///         if abs(mean) > 1e-6 { print("curved at (\(u), \(v)): \(mean)") }
+    ///     }
+    /// }
+    /// ```
     public struct FaceGridSample: Sendable {
-        /// Surface positions at grid points.
+        /// Surface positions at grid points, U-major (see ``at(u:v:)``).
         public let positions: [SIMD3<Double>]
-        /// Surface normals at grid points.
+        /// Surface normals at grid points, U-major (see ``at(u:v:)``).
         public let normals: [SIMD3<Double>]
-        /// Gaussian curvature at each grid point.
+        /// Gaussian curvature at each grid point, U-major (see ``at(u:v:)``).
         public let gaussianCurvatures: [Double]
-        /// Mean curvature at each grid point.
+        /// Mean curvature at each grid point, U-major (see ``at(u:v:)``).
         public let meanCurvatures: [Double]
         /// Number of samples in U direction.
         public let uSamples: Int
         /// Number of samples in V direction.
         public let vSamples: Int
+
+        /// Position, normal and curvatures at the given U/V grid index.
+        ///
+        /// The counterpart of ``SurfaceGrid/at(u:v:)``, resolving the same U-major index through
+        /// the same shared `surfaceGridIndex` helper, so the two grid families cannot drift apart
+        /// again (#617).
+        ///
+        /// ```swift
+        /// if let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 3, vSamples: 10) {
+        ///     let corner = sample.at(u: 2, v: 9)
+        ///     print(corner.position, corner.meanCurvature)
+        /// }
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - u: U grid index, `0..<uSamples`.
+        ///   - v: V grid index, `0..<vSamples`.
+        public func at(u: Int, v: Int) -> (position: SIMD3<Double>, normal: SIMD3<Double>,
+                                           gaussianCurvature: Double, meanCurvature: Double) {
+            precondition(u >= 0 && u < uSamples && v >= 0 && v < vSamples,
+                         "FaceGridSample.at(u: \(u), v: \(v)) out of range "
+                         + "(uSamples: \(uSamples), vSamples: \(vSamples))")
+            let i = surfaceGridIndex(u: u, v: v, vCount: vSamples)
+            // The buffers carry the count the bridge actually wrote, which #419 deliberately does
+            // not assume equals uSamples * vSamples — so the grid bounds above are necessary but
+            // not sufficient.
+            precondition(i < positions.count,
+                         "FaceGridSample.at(u: \(u), v: \(v)) names index \(i), but only "
+                         + "\(positions.count) samples were written")
+            return (position: positions[i], normal: normals[i],
+                    gaussianCurvature: gaussianCurvatures[i], meanCurvature: meanCurvatures[i])
+        }
     }
 
     /// Sample a face surface on a regular UV grid, evaluating positions, normals, and curvatures.
+    ///
+    /// The returned buffers are **U-major** (`u * vSamples + v`); read them through
+    /// ``FaceGridSample/at(u:v:)`` rather than indexing by hand.
+    ///
+    /// ```swift
+    /// guard let graph = BRepGraph(shape: solid),
+    ///       let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
+    /// else { return }
+    /// let midpoint = sample.at(u: 5, v: 1)
+    /// print(midpoint.position, midpoint.gaussianCurvature)
+    /// ```
+    ///
     /// - Parameters:
     ///   - faceIndex: Face definition index.
     ///   - uSamples: Number of samples in U direction (must be >= 1).

--- a/Tests/OCCTBRepGraphTests/Issue617FaceGridLayoutTests.swift
+++ b/Tests/OCCTBRepGraphTests/Issue617FaceGridLayoutTests.swift
@@ -10,12 +10,21 @@ import simd
 /// documented no layout and offered no accessor, so the only guidance a caller had was the
 /// convention that was wrong for this one type.
 ///
-/// The two faces of the same mistake, both covered below:
-///   - `uSamples < vSamples` (3x10): the U-major index stays inside the 30-element buffer by
-///     coincidence of the shape, so the caller silently reads the *transposed* point — a normal
-///     or a curvature attributed to the wrong place on the face, no trap.
-///   - `uSamples > vSamples` (10x3): the same expression runs past the end of the same
-///     30-element buffer and traps with "Index out of range".
+/// #617's own report crosses two different mistakes here, so state the model carefully — getting
+/// this arithmetic wrong is the exact failure the fix exists to prevent, and `handRolledIndexArithmetic`
+/// below asserts every claim in this paragraph:
+///
+///   - A caller reading the U-major index off a transposed buffer **never traps**, at any aspect
+///     ratio. `u * vSamples + v` is a bijection onto `0..<uSamples * vSamples`, so at both 3x10
+///     and 10x3 it lands on exactly the last valid slot at worst (29 of 30). Every such read is a
+///     silent wrong answer: a position, normal or curvature attributed to the wrong place on the
+///     face, no diagnostic. That is what the pre-#617 write produced.
+///   - The out-of-range trap needs a *different* slip, striding by the wrong count
+///     (`u * uSamples + v`). That one does split by aspect ratio: in range and quietly wrong at
+///     3x10 (15 of 30), past the end at 10x3 (92 of 30).
+///
+/// So "silently wrong" and "traps" are not the two aspect ratios of one expression; they are two
+/// expressions, one of which never traps at all. `at(u:v:)` retires both by owning the index.
 ///
 /// Fixed by writing the bridge buffer U-major through the shared `occtSurfaceGridIndex`, so the
 /// codebase has one rule, plus a `FaceGridSample.at(u:v:)` that resolves it through the shared
@@ -40,27 +49,58 @@ struct Issue617FaceGridLayoutTests {
 
     /// Build the single-face shape, its graph, and the UV bounds the bridge itself samples over
     /// (`BRepTools::UVBounds`, mirrored by `Face.uvBounds`).
+    ///
+    /// Every failure here records an issue rather than returning a bare `nil`. A suite whose only
+    /// job is catching a layout regression must not be able to go green by failing to build its
+    /// own fixture: with a silent `guard ... else { return }` at each call site, breaking
+    /// `asymmetricPatch()` alone turns all 7 tests green while asserting nothing.
     private func fixture() -> (surface: Surface, graph: BRepGraph,
                                uMin: Double, uMax: Double, vMin: Double, vMax: Double)? {
-        guard let surface = asymmetricPatch(),
-              let shape = surface.toFace(),
-              let face = shape.faces().first,
-              let bounds = face.uvBounds,
-              let graph = BRepGraph(shape: shape),
-              graph.faceCount == 1 else { return nil }
+        guard let surface = asymmetricPatch() else {
+            Issue.record("fixture: Surface.bezier returned nil for the asymmetric patch")
+            return nil
+        }
+        guard let shape = surface.toFace() else {
+            Issue.record("fixture: Surface.toFace returned nil")
+            return nil
+        }
+        guard let face = shape.faces().first else {
+            Issue.record("fixture: the face shape exposed no Face")
+            return nil
+        }
+        guard let bounds = face.uvBounds else {
+            Issue.record("fixture: Face.uvBounds returned nil")
+            return nil
+        }
+        guard let graph = BRepGraph(shape: shape) else {
+            Issue.record("fixture: BRepGraph(shape:) returned nil")
+            return nil
+        }
+        guard graph.faceCount == 1 else {
+            Issue.record("fixture: expected exactly 1 face, got \(graph.faceCount); the grid tests address faceIndex 0 and rely on it being the patch")
+            return nil
+        }
         return (surface, graph, bounds.uMin, bounds.uMax, bounds.vMin, bounds.vMax)
     }
 
-    /// Every `.at(u:v:)` position must equal a direct `Surface.point(atU:v:)` evaluation at the
-    /// parameters that grid slot stands for. Run on both aspect ratios: 10x3 is the one that used
-    /// to trap, 3x10 the one that used to be silently transposed.
-    private func checkGrid(uSamples: Int, vSamples: Int) {
-        guard let f = fixture() else { return }
-        guard let sample = f.graph.sampleFaceUVGrid(
+    /// `sampleFaceUVGrid` returning nil is a failure too, never a reason to skip quietly.
+    private func requireSample(_ graph: BRepGraph, _ uSamples: Int, _ vSamples: Int)
+        -> BRepGraph.FaceGridSample? {
+        guard let sample = graph.sampleFaceUVGrid(
             faceIndex: 0, uSamples: uSamples, vSamples: vSamples) else {
             Issue.record("sampleFaceUVGrid returned nil for \(uSamples)x\(vSamples)")
-            return
+            return nil
         }
+        return sample
+    }
+
+    /// Every `.at(u:v:)` position must equal a direct `Surface.point(atU:v:)` evaluation at the
+    /// parameters that grid slot stands for. Run on **both** aspect ratios: the pre-#617 buffer
+    /// was silently transposed at each of them, and a square grid alone would not distinguish a
+    /// stride mistake from a correct read.
+    private func checkGrid(uSamples: Int, vSamples: Int) {
+        guard let f = fixture(),
+              let sample = requireSample(f.graph, uSamples, vSamples) else { return }
 
         #expect(sample.uSamples == uSamples)
         #expect(sample.vSamples == vSamples)
@@ -85,12 +125,12 @@ struct Issue617FaceGridLayoutTests {
         }
     }
 
-    @Test("10x3: .at(u:v:) matches direct evaluation (the aspect ratio that used to trap)")
+    @Test("10x3 (uSamples > vSamples): .at(u:v:) matches direct evaluation")
     func tallGridMatchesDirectEvaluation() {
         checkGrid(uSamples: 10, vSamples: 3)
     }
 
-    @Test("3x10: .at(u:v:) matches direct evaluation (the aspect ratio that was silently wrong)")
+    @Test("3x10 (uSamples < vSamples): .at(u:v:) matches direct evaluation")
     func wideGridMatchesDirectEvaluation() {
         checkGrid(uSamples: 3, vSamples: 10)
     }
@@ -102,8 +142,7 @@ struct Issue617FaceGridLayoutTests {
     @Test("The fixture patch actually distinguishes U from V")
     func transposedReadIsMateriallyDifferent() {
         guard let f = fixture(),
-              let sample = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 3, vSamples: 10)
-        else { return }
+              let sample = requireSample(f.graph, 3, 10) else { return }
 
         var maxDrift = 0.0
         for iu in 0..<3 {
@@ -127,8 +166,7 @@ struct Issue617FaceGridLayoutTests {
     @Test("at(u:v:) reads the documented U-major slot of all four buffers")
     func accessorAgreesWithDocumentedIndex() {
         guard let f = fixture(),
-              let sample = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
-        else { return }
+              let sample = requireSample(f.graph, 10, 3) else { return }
 
         for iu in 0..<10 {
             for iv in 0..<3 {
@@ -149,8 +187,7 @@ struct Issue617FaceGridLayoutTests {
     @Test("Normals land on the same U-major slot as positions")
     func normalsMatchDirectEvaluationPerSlot() {
         guard let f = fixture(),
-              let sample = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
-        else { return }
+              let sample = requireSample(f.graph, 10, 3) else { return }
 
         let uStep = (f.uMax - f.uMin) / 9
         let vStep = (f.vMax - f.vMin) / 2

--- a/Tests/OCCTBRepGraphTests/Issue617FaceGridLayoutTests.swift
+++ b/Tests/OCCTBRepGraphTests/Issue617FaceGridLayoutTests.swift
@@ -1,0 +1,242 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #617: `BRepGraph.FaceGridSample` handed back flat position / normal / curvature buffers that
+/// the bridge wrote **V-major** (`iv * uSamples + iu`), while #486 had already declared U-major
+/// (`occtSurfaceGridIndex`, `iu * vSamples + iv`) THE surface-grid layout of this codebase and
+/// given `SurfaceGrid` / `SurfaceGridD1` an `.at(u:v:)` accessor for it. `FaceGridSample`
+/// documented no layout and offered no accessor, so the only guidance a caller had was the
+/// convention that was wrong for this one type.
+///
+/// The two faces of the same mistake, both covered below:
+///   - `uSamples < vSamples` (3x10): the U-major index stays inside the 30-element buffer by
+///     coincidence of the shape, so the caller silently reads the *transposed* point — a normal
+///     or a curvature attributed to the wrong place on the face, no trap.
+///   - `uSamples > vSamples` (10x3): the same expression runs past the end of the same
+///     30-element buffer and traps with "Index out of range".
+///
+/// Fixed by writing the bridge buffer U-major through the shared `occtSurfaceGridIndex`, so the
+/// codebase has one rule, plus a `FaceGridSample.at(u:v:)` that resolves it through the shared
+/// Swift-side `surfaceGridIndex`. No consumer depended on the V-major order: every in-repo and
+/// ecosystem caller either sampled a square grid and mapped the arrays element-wise, or reduced
+/// them order-independently (a mean position/normal signature).
+@Suite("Issue 617: FaceGridSample U-major layout")
+struct Issue617FaceGridLayoutTests {
+
+    /// A Bezier patch on an asymmetric 4x3 pole grid: non-periodic (so no parameter wraps onto
+    /// another sample), curved in both directions (so normals and curvatures vary too), and
+    /// deliberately *not* symmetric under swapping u and v — the point (u, v) and the point
+    /// (v, u) must be far apart or a transposed read could pass by accident.
+    private func asymmetricPatch() -> Surface? {
+        Surface.bezier(poles: [
+            [SIMD3(0, 0, 0), SIMD3(0, 4, 3), SIMD3(0, 8, 0)],
+            [SIMD3(7, 0, 5), SIMD3(7, 4, 11), SIMD3(7, 8, 4)],
+            [SIMD3(14, 0, 2), SIMD3(14, 4, 9), SIMD3(14, 8, 1)],
+            [SIMD3(21, 0, 0), SIMD3(21, 4, 6), SIMD3(21, 8, 3)],
+        ])
+    }
+
+    /// Build the single-face shape, its graph, and the UV bounds the bridge itself samples over
+    /// (`BRepTools::UVBounds`, mirrored by `Face.uvBounds`).
+    private func fixture() -> (surface: Surface, graph: BRepGraph,
+                               uMin: Double, uMax: Double, vMin: Double, vMax: Double)? {
+        guard let surface = asymmetricPatch(),
+              let shape = surface.toFace(),
+              let face = shape.faces().first,
+              let bounds = face.uvBounds,
+              let graph = BRepGraph(shape: shape),
+              graph.faceCount == 1 else { return nil }
+        return (surface, graph, bounds.uMin, bounds.uMax, bounds.vMin, bounds.vMax)
+    }
+
+    /// Every `.at(u:v:)` position must equal a direct `Surface.point(atU:v:)` evaluation at the
+    /// parameters that grid slot stands for. Run on both aspect ratios: 10x3 is the one that used
+    /// to trap, 3x10 the one that used to be silently transposed.
+    private func checkGrid(uSamples: Int, vSamples: Int) {
+        guard let f = fixture() else { return }
+        guard let sample = f.graph.sampleFaceUVGrid(
+            faceIndex: 0, uSamples: uSamples, vSamples: vSamples) else {
+            Issue.record("sampleFaceUVGrid returned nil for \(uSamples)x\(vSamples)")
+            return
+        }
+
+        #expect(sample.uSamples == uSamples)
+        #expect(sample.vSamples == vSamples)
+        #expect(sample.positions.count == uSamples * vSamples)
+        #expect(sample.normals.count == uSamples * vSamples)
+        #expect(sample.gaussianCurvatures.count == uSamples * vSamples)
+        #expect(sample.meanCurvatures.count == uSamples * vSamples)
+
+        let uStep = uSamples > 1 ? (f.uMax - f.uMin) / Double(uSamples - 1) : 0
+        let vStep = vSamples > 1 ? (f.vMax - f.vMin) / Double(vSamples - 1) : 0
+
+        for iu in 0..<uSamples {
+            for iv in 0..<vSamples {
+                let u = f.uMin + Double(iu) * uStep
+                let v = f.vMin + Double(iv) * vStep
+                let expected = f.surface.point(atU: u, v: v)
+                let got = sample.at(u: iu, v: iv).position
+                let d = simd_distance(got, expected)
+                #expect(d < 1e-9,
+                        "\(uSamples)x\(vSamples) at (u: \(iu), v: \(iv)) gave \(got), expected \(expected) at (\(u), \(v)), off by \(d)")
+            }
+        }
+    }
+
+    @Test("10x3: .at(u:v:) matches direct evaluation (the aspect ratio that used to trap)")
+    func tallGridMatchesDirectEvaluation() {
+        checkGrid(uSamples: 10, vSamples: 3)
+    }
+
+    @Test("3x10: .at(u:v:) matches direct evaluation (the aspect ratio that was silently wrong)")
+    func wideGridMatchesDirectEvaluation() {
+        checkGrid(uSamples: 3, vSamples: 10)
+    }
+
+    /// The transposition-catching property stated on its own, independent of the fix's index
+    /// arithmetic: reading a 3x10 grid with the buffer's *old* V-major formula must land on a
+    /// materially different point of the face. If this fails, the fixture surface is too
+    /// symmetric and the two tests above could pass while transposed.
+    @Test("The fixture patch actually distinguishes U from V")
+    func transposedReadIsMateriallyDifferent() {
+        guard let f = fixture(),
+              let sample = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 3, vSamples: 10)
+        else { return }
+
+        var maxDrift = 0.0
+        for iu in 0..<3 {
+            for iv in 0..<10 {
+                let vMajor = iv * 3 + iu           // the pre-#617 write order
+                let uMajor = iu * 10 + iv          // the layout #486 declared
+                guard vMajor != uMajor,
+                      vMajor < sample.positions.count else { continue }
+                maxDrift = max(maxDrift,
+                               simd_distance(sample.positions[vMajor], sample.positions[uMajor]))
+            }
+        }
+        // The patch spans 21 in X and 8 in Y; a transposed read is nowhere near a rounding error.
+        #expect(maxDrift > 1.0,
+                "transposed reads differ by at most \(maxDrift); fixture is too symmetric to distinguish U-major from V-major")
+    }
+
+    /// `.at(u:v:)` is the accessor #486 gave `SurfaceGrid`, so it must agree with the flat arrays
+    /// on the documented index — not just with the geometry. Also pins normals and curvatures to
+    /// the same slot as positions, since all four buffers share one layout.
+    @Test("at(u:v:) reads the documented U-major slot of all four buffers")
+    func accessorAgreesWithDocumentedIndex() {
+        guard let f = fixture(),
+              let sample = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
+        else { return }
+
+        for iu in 0..<10 {
+            for iv in 0..<3 {
+                let i = iu * sample.vSamples + iv
+                let s = sample.at(u: iu, v: iv)
+                #expect(s.position == sample.positions[i])
+                #expect(s.normal == sample.normals[i])
+                #expect(s.gaussianCurvature == sample.gaussianCurvatures[i])
+                #expect(s.meanCurvature == sample.meanCurvatures[i])
+            }
+        }
+    }
+
+    /// Normals sampled on a curved patch must be the surface's own normal at that (u, v), up to
+    /// sign (OCCT orients against the face). A transposed buffer fails this on a patch whose
+    /// normal actually turns, which is why the fixture is curved in both directions rather than
+    /// planar.
+    @Test("Normals land on the same U-major slot as positions")
+    func normalsMatchDirectEvaluationPerSlot() {
+        guard let f = fixture(),
+              let sample = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
+        else { return }
+
+        let uStep = (f.uMax - f.uMin) / 9
+        let vStep = (f.vMax - f.vMin) / 2
+
+        for iu in 0..<10 {
+            for iv in 0..<3 {
+                let u = f.uMin + Double(iu) * uStep
+                let v = f.vMin + Double(iv) * vStep
+                let d = f.surface.d1(atU: u, v: v)
+                let cross = simd_cross(d.du, d.dv)
+                let len = simd_length(cross)
+                guard len > 1e-9 else { continue }
+                let expected = cross / len
+                let got = sample.at(u: iu, v: iv).normal
+                guard simd_length(got) > 0.5 else { continue }  // undefined normal, skip
+                #expect(abs(simd_dot(got, expected)) > 0.999_999,
+                        "normal at (u: \(iu), v: \(iv)) is \(got), expected ±\(expected)")
+            }
+        }
+    }
+
+    /// The other face of #617: the hand-rolled read that traps rather than lying quietly.
+    ///
+    /// #617's prose and its code snippet disagree on which expression that is, so the arithmetic
+    /// is pinned here. The layout-conforming stride (`u * vSamples + v`) is *always* inside a
+    /// `uSamples * vSamples` buffer, at either aspect ratio, so on its own it can only ever be
+    /// silently transposed. The out-of-range trap needs the other plausible slip, using the wrong
+    /// count as the stride (`u * uSamples + v`) — and that one splits exactly the way the issue
+    /// describes: in range and quietly wrong at 3x10, past the end at 10x3.
+    ///
+    /// `at(u:v:)` retires both by owning the index, which is why this test asserts on the
+    /// arithmetic rather than provoking a real trap (a trap would take the test runner down).
+    @Test("Both hand-rolled slips are pinned: one silently in range, one past the end")
+    func handRolledIndexArithmetic() {
+        // 3x10: the wrong-stride read stays inside the buffer, so it is a silent wrong answer.
+        let wideCount = 3 * 10
+        let wideWorstWrongStride = (3 - 1) * 3 + (10 - 1)          // u * uSamples + v
+        #expect(wideWorstWrongStride < wideCount)
+        let wideWorstRightStride = (3 - 1) * 10 + (10 - 1)         // u * vSamples + v
+        #expect(wideWorstRightStride == wideCount - 1)
+
+        // 10x3: the same wrong-stride read runs off the end and traps.
+        let tallCount = 10 * 3
+        let tallWorstWrongStride = (10 - 1) * 10 + (3 - 1)         // u * uSamples + v
+        #expect(tallWorstWrongStride >= tallCount)
+        let tallWorstRightStride = (10 - 1) * 3 + (3 - 1)          // u * vSamples + v
+        #expect(tallWorstRightStride == tallCount - 1)
+
+        // And `at(u:v:)` is a bijection onto 0..<count at both aspect ratios, so no caller
+        // following the accessor can land off the end or read the same slot twice.
+        for (uS, vS) in [(10, 3), (3, 10)] {
+            var seen = Set<Int>()
+            for u in 0..<uS {
+                for v in 0..<vS { seen.insert(surfaceGridIndex(u: u, v: v, vCount: vS)) }
+            }
+            #expect(seen.count == uS * vS)
+            #expect(seen.min() == 0)
+            #expect(seen.max() == uS * vS - 1)
+        }
+    }
+
+    /// A 1x1 grid and a square grid still work — the fix changes an index, not the sample set.
+    @Test("Degenerate and square grids are unaffected")
+    func squareAndSingleGridsStillWork() {
+        guard let f = fixture() else { return }
+
+        if let one = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 1, vSamples: 1) {
+            #expect(one.positions.count == 1)
+            #expect(one.at(u: 0, v: 0).position == one.positions[0])
+        } else {
+            Issue.record("1x1 sample returned nil")
+        }
+
+        if let square = f.graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 4, vSamples: 4) {
+            #expect(square.positions.count == 16)
+            let uStep = (f.uMax - f.uMin) / 3
+            let vStep = (f.vMax - f.vMin) / 3
+            for iu in 0..<4 {
+                for iv in 0..<4 {
+                    let expected = f.surface.point(atU: f.uMin + Double(iu) * uStep,
+                                                   v: f.vMin + Double(iv) * vStep)
+                    #expect(simd_distance(square.at(u: iu, v: iv).position, expected) < 1e-9)
+                }
+            }
+        } else {
+            Issue.record("4x4 sample returned nil")
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,46 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### The one grid layout finally covers the third type holding a grid (#617)
+
+#486 declared **U-major** (`occtSurfaceGridIndex`, `iu * vCount + iv`) THE surface-grid buffer
+layout of this codebase, and gave `SurfaceGrid` / `SurfaceGridD1` an `.at(u:v:)` accessor for it,
+precisely so two bridge functions could not go on writing opposite layouts while each header called
+its own "row-major". A third type holding the same shape of buffer was left out of that sweep.
+
+`BRepGraph.FaceGridSample` hands back four parallel flat buffers (positions, normals, Gaussian and
+mean curvature) that `OCCTBRepGraphSampleFaceUVGrid` wrote **transposed**, `iv * uSamples + iu`.
+The Swift type documented no layout and offered no accessor, so the only guidance a caller had was
+the convention #486 had just declared, which was the wrong one for this one type.
+
+Two things make this worse than a plain inconsistency. `docs/reference/BRepGraph-Editor-Identity.md`
+**already documented the U-major index** (`index = u * vSamples + v`) for this type, so the bridge
+was contradicting its own published reference page, not just a sibling type. And the failure is not
+uniform: a caller reading with the layout-conforming stride gets a silent wrong answer at every
+aspect ratio (a normal or a curvature attributed to the wrong place on the face, no trap), while
+the neighbouring slip of using the wrong count as the stride (`u * uSamples + v`) stays in range on
+a 3×10 grid and runs off the end of the same 30-element buffer on a 10×3 one. #617's own report has
+these two expressions crossed; the arithmetic is now pinned in a test.
+
+**Converted the bridge to U-major** rather than documenting the transpose, so the codebase keeps one
+rule, and routed it through the shared `occtSurfaceGridIndex` so the formula is not re-spelled at a
+third site. `FaceGridSample` gains the `.at(u:v:)` accessor its siblings have, resolving the index
+through the same shared Swift-side `surfaceGridIndex`, plus an explicit layout line and worked
+snippets on the type, the method and the reference page. `OCCTBridge.h`'s declaration now states the
+literal index instead of being silent.
+
+**No consumer depended on the old order.** Every in-repo caller and all three ecosystem callers
+(`PadCAMEngine`'s `PadCAMMLExport`, `OCCTSwiftScripts`' `occtkit graph-ml` and `GraphML`) sample a
+**square** grid and either map the arrays element-wise into a JSON payload or reduce them
+order-independently (a mean position/normal face signature), so none reads a specific `(u, v)`. The
+observable change is limited to the order of the flat arrays those exporters serialize, which was
+never a documented contract on the emitted payload.
+
+| API | Before | After |
+|---|---|---|
+| `OCCTBRepGraphSampleFaceUVGrid` buffers | V-major, `iv * uSamples + iu`, layout undocumented | U-major via `occtSurfaceGridIndex`, index stated in the header |
+| `BRepGraph.FaceGridSample` | four flat arrays, no layout doc, no accessor | same arrays documented U-major, plus `at(u:v:)` |
+
 #### A NaN parameter bound stops being a plausible arc length (#548)
 
 `Curve3D.length(from:to:)` documents itself as the entry point that tells failure apart from a real

--- a/docs/reference/BRepGraph-Editor-Identity.md
+++ b/docs/reference/BRepGraph-Editor-Identity.md
@@ -664,22 +664,40 @@ Result of sampling a face surface on a regular UV grid.
 
 ```swift
 public struct FaceGridSample: Sendable {
-    /// Surface positions at grid points.
+    /// Surface positions at grid points, U-major.
     public let positions: [SIMD3<Double>]
-    /// Surface normals at grid points.
+    /// Surface normals at grid points, U-major.
     public let normals: [SIMD3<Double>]
-    /// Gaussian curvature at each grid point.
+    /// Gaussian curvature at each grid point, U-major.
     public let gaussianCurvatures: [Double]
-    /// Mean curvature at each grid point.
+    /// Mean curvature at each grid point, U-major.
     public let meanCurvatures: [Double]
     /// Number of samples in U direction.
     public let uSamples: Int
     /// Number of samples in V direction.
     public let vSamples: Int
+
+    /// Position, normal and curvatures at the given U/V grid index.
+    public func at(u: Int, v: Int) -> (position: SIMD3<Double>, normal: SIMD3<Double>,
+                                       gaussianCurvature: Double, meanCurvature: Double)
 }
 ```
 
-Grid points are laid out in row-major order: `index = u * vSamples + v` where `u ∈ [0, uSamples)` and `v ∈ [0, vSamples)`.
+All four arrays share one layout: **U-major**, u varying slowest and v fastest, so grid position `(u, v)` sits at `index = u * vSamples + v` for `u ∈ [0, uSamples)` and `v ∈ [0, vSamples)`. This is the layout `SurfaceGrid` and `SurfaceGridD1` use, and the one #486 declared for the whole API.
+
+Read through `at(u:v:)` rather than spelling the index out. Until #617 the bridge wrote these buffers *transposed* (`v * uSamples + u`) while this page already documented the U-major index above, so a caller who followed the docs read the wrong point of the face; getting the stride wrong instead (`u * uSamples + v`) is silently in range on a 3×10 grid and out of bounds on a 10×3 one. `at(u:v:)` removes both failure modes by owning the index.
+
+```swift
+guard let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
+else { return }
+
+for u in 0..<sample.uSamples {
+    for v in 0..<sample.vSamples {
+        let s = sample.at(u: u, v: v)
+        print("(\(u), \(v)) -> \(s.position)  kG=\(s.gaussianCurvature) kH=\(s.meanCurvature)")
+    }
+}
+```
 
 ---
 
@@ -697,7 +715,7 @@ public func sampleFaceUVGrid(faceIndex: Int, uSamples: Int, vSamples: Int) -> Fa
   - `vSamples` — number of samples in V direction (must be ≥ 1).
 
   The bound is on the **product**: `uSamples * vSamples` must not exceed `Sampling.maximumSampleCount` (10,000,000), and each factor is checked on its own, since two negatives multiply to a plausible positive total (#558). This sampler fills four buffers per point (position, normal, Gaussian and mean curvature), so it reaches the ceiling's memory cost sooner than the point-only samplers do.
-- **Returns:** `FaceGridSample` with `uSamples × vSamples` entries, or `nil` if the face has no surface, sampling fails, or the grid cannot be served.
+- **Returns:** `FaceGridSample` with `uSamples × vSamples` entries laid out **U-major** (`u * vSamples + v`, see `FaceGridSample` above), or `nil` if the face has no surface, sampling fails, or the grid cannot be served.
 - **OCCT:** `GeomLProp_SLProps` (position, normal, curvature evaluation) via `OCCTBRepGraphSampleFaceUVGrid`.
 - **Example:**
   ```swift
@@ -707,6 +725,14 @@ public func sampleFaceUVGrid(faceIndex: Int, uSamples: Int, vSamples: Int) -> Fa
           let kH = grid.meanCurvatures[i]
           print("(\(pos.x), \(pos.y), \(pos.z))  kG=\(kG) kH=\(kH)")
       }
+  }
+  ```
+- **Example (indexed by grid position, not flat order):**
+  ```swift
+  if let grid = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3) {
+      // The far corner of a non-square grid: `at` resolves the U-major index for you.
+      let corner = grid.at(u: grid.uSamples - 1, v: grid.vSamples - 1)
+      print(corner.position, corner.normal, corner.meanCurvature)
   }
   ```
 


### PR DESCRIPTION
Closes #617

#486 declared **U-major** (`occtSurfaceGridIndex`, `iu * vCount + iv`) THE surface-grid buffer layout of this codebase and gave `SurfaceGrid` / `SurfaceGridD1` an `.at(u:v:)` accessor for it, precisely so two bridge functions could not go on writing opposite layouts while each header called its own "row-major". A third type holding the same shape of buffer was left out of that sweep.

`BRepGraph.FaceGridSample` hands back four parallel flat buffers (positions, normals, Gaussian and mean curvature) that `OCCTBRepGraphSampleFaceUVGrid` wrote **transposed**, `iv * uSamples + iu`. The Swift type documented no layout and offered no accessor, so the only guidance a caller had was the convention #486 had just declared, which was the wrong one for this one type.

## Direction converted, and why

**Bridge converted to U-major** — the option that leaves the codebase one rule, which is the point of #486. Documenting the transpose and keeping V-major would have preserved a second, contradicting convention behind an accessor.

The write now goes through the shared `occtSurfaceGridIndex` helper rather than a third hand-spelled formula, and the loops were reordered u-outer/v-inner so writes stay sequential in the new layout. `OCCTBridge.h`'s declaration, previously silent on layout, now states the literal index.

**An extra reason the transpose had to go, not get documented:** `docs/reference/BRepGraph-Editor-Identity.md` **already documented the U-major index** for this type (`index = u * vSamples + v`). The bridge was contradicting its own published reference page, not just a sibling type — so a caller who read the docs for exactly this API still got the wrong point of the face.

## Consumer check: nothing depended on the V-major write

Grepped the repo, the tests, and the wider ecosystem checkouts on disk.

| Consumer | Grid | How it reads the buffers |
|---|---|---|
| `Tests/OCCTBRepGraphTests` `sampleBoxFace` / `sampleSphereFace` / `sampleSinglePoint` | 5×5, 4×4, 1×1 | iterates all elements, or asserts counts |
| `Tests/OCCTBRepGraphTests` `faceSignature` (UID suites) | 3×3 | **mean** position/normal, order-independent |
| `Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests` | n/a | nil / non-nil only |
| `PadCAMEngine` `PadCAMMLExport` | square `uvSamples × uvSamples` | element-wise `.map` into a JSON payload |
| `OCCTSwiftScripts` `occtkit graph-ml` | square | element-wise `.map` |
| `OCCTSwiftScripts` `GraphML/main.swift` | square | element-wise `.map` |
| `OCCTSwiftIO` `MLExport.swift` | n/a | comment only, no call |

**No consumer indexes by `(u, v)` at all**, and every one that touches the arrays either sampled a square grid or reduced them order-independently. The only observable change is the order of the flat arrays the three ML exporters serialize; that ordering was never a documented contract on the emitted payload, and no consumer cross-references a flat position back to a grid slot.

## A correction to #617's own failure scenario

The issue's prose and its code snippet name different expressions, and the arithmetic splits differently than reported. Verified and now pinned in a test:

- The **layout-conforming stride** (`u * vSamples + v`) is always inside a `uSamples * vSamples` buffer, at **either** aspect ratio. On its own it can only ever be a silent wrong answer — it never traps.
- The **out-of-range trap** needs the neighbouring slip of using the wrong count as the stride (`u * uSamples + v`). That one does split exactly the way the issue describes: max index 15 against 30 elements at 3×10 (in range, quietly wrong), max index 92 against 30 at 10×3 (past the end).

`at(u:v:)` retires both by owning the index.

## What changed

- `Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm` — `OCCTBRepGraphSampleFaceUVGrid` writes U-major via `occtSurfaceGridIndex`.
- `Sources/OCCTBridge/include/OCCTBridge.h` — the declaration states the literal index and the shared helper.
- `Sources/OCCTSwift/BRepGraph.swift` — `FaceGridSample.at(u:v:)` returning `(position:normal:gaussianCurvature:meanCurvature:)`, resolving through the same shared `surfaceGridIndex` as `SurfaceGrid`; layout docs and fenced ```swift snippets on both the type and `sampleFaceUVGrid`. A second precondition covers the #419 case where the bridge writes fewer samples than the grid nominally holds, which the grid bounds alone do not.
- `Tests/OCCTBRepGraphTests/Issue617FaceGridLayoutTests.swift` — 7 tests.
- `docs/CHANGELOG.md` (Unreleased), `docs/reference/BRepGraph-Editor-Identity.md`.

## Tests

The fixture is a Bezier patch on an asymmetric 4×3 pole grid: non-periodic (no parameter wraps onto another sample), curved in both directions (so normals and curvatures vary too), and deliberately not symmetric under swapping u and v. A dedicated test asserts the fixture really does distinguish U from V (max transposed drift > 1.0 against a 21×8 patch), so the other tests cannot pass while transposed.

Both aspect ratios cross-check every `.at(u:v:)` slot against a direct `Surface.point(atU:v:)` evaluation at the parameters that slot stands for, using the face's own `uvBounds` (the same `BRepTools::UVBounds` the bridge samples over).

## Proof the tests catch it

Flipped the index expression back to `iv * uSamples + iu` and re-ran:

| Test | Bug injected | Fixed |
|---|---|---|
| `10x3: .at(u:v:) matches direct evaluation` | **FAIL** — 28 issues, positions off by up to 16.16 | pass |
| `3x10: .at(u:v:) matches direct evaluation` | **FAIL** — 28 issues, positions off by up to 21.73 | pass |
| `Normals land on the same U-major slot as positions` | **FAIL** — 28 issues, `abs(dot)` down to 0.126 | pass |
| `Degenerate and square grids are unaffected` | **FAIL** — 12 issues | pass |
| `at(u:v:) reads the documented U-major slot of all four buffers` | pass (by design) | pass |
| `The fixture patch actually distinguishes U from V` | pass (by design) | pass |
| `Both hand-rolled slips are pinned` | pass (by design) | pass |

`✘ Test run with 6 tests in 1 suite failed after 0.005 seconds with 96 issues` with the bug in; `✔ Test run with 7 tests in 1 suite passed` after restoring. The three that still pass by design are layout-independent on purpose: two are accessor/index consistency and pure arithmetic, the third is the fixture-symmetry sanity check that guards the others.

Note the injected run shows the square 4×4 grid failing too — a transpose is wrong on a square grid as well, just never out of range, which is the "silent" half of the defect.

## Verification

- `swift build` clean.
- `swift test --filter OCCTBRepGraphTests` — 185 tests, 66 suites, all pass.
- `swift test --filter Issue558SamplingCountBoundsTests` — 21 pass (the other `sampleFaceUVGrid` consumer).
- `swift test --filter SurfaceGrid` — 5 pass (#486's own layout suite, unaffected).

Bridge-only change plus Swift/docs. No OCCT kernel patch, no xcframework rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
