### PR TITLE
fix(#612): a fillet radius law goes to the edge's own slot, in the edge's own contour

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1748,12 +1748,18 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
 /// Fillet specific edges with linear radius interpolation
 ///
 /// Shares occtShapeFilletEdgeList with OCCTShapeFilletEdges and OCCTShapeBlendEdges. #489
+///
+/// The law goes to each edge's own slot in its own contour, not to (NbContours(), 1). This is
+/// observable here despite the batch sharing one law: with startRadius != endRadius, two
+/// tangent-continuous edges written to slot 1 measure exactly as filleting the first alone
+/// (10273.238348 on a slot rim at 1 -> 4) against 10297.711861 with each in its own slot. Done with
+/// OCCT's own one-call Add(R1, R2, E), which is Add(E) + the same slot resolution + SetRadius. #612
 /// @param shape The shape to fillet
 /// @param edgeIndices Array of edge indices (0-based; an index naming no edge of `shape` rejects
-///   the whole call, #520)
+///   the whole call, #520). An edge OCCT declines to add is skipped, as Add(Radius, E) skips it.
 /// @param edgeCount Number of edges to fillet
-/// @param startRadius Radius at start of each edge; must be > 0
-/// @param endRadius Radius at end of each edge; must be > 0
+/// @param startRadius Radius at the start of each named edge's law; must be > 0
+/// @param endRadius Radius at the end of each named edge's law; must be > 0
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeIndices,
                                          int32_t edgeCount, double startRadius, double endRadius);
@@ -5437,9 +5443,17 @@ typedef struct {
 /// The multi-edge radius-law entry point, sharing occtFilletAddEdges with the other four fillet
 /// edge-list functions and occtFilletSetRadiusProfile with OCCTShapeFilletVariable
 /// (OCCTBridge_Internal.h). Its indices were 1-based until #520 made the family agree.
+///
+/// Each edge's law is written to that edge's own slot in that edge's own contour, resolved with
+/// Contour(E) and NbEdges(IC)/Edge(IC, J). It used to be written to (NbContours(), 1): the first is
+/// the edge's contour only when every Add(edge) creates one — a tangent-continuous edge extends an
+/// existing contour instead — and the second collapsed every edge of a contour onto one slot, so
+/// only the last law of a tangent chain survived. #612
 /// @param shape The shape
 /// @param edgeIndices Array of edge indices (0-based since #520; an index naming no edge of
-///   `shape` rejects the whole call)
+///   `shape` rejects the whole call). Tangent-continuous edges share a contour but not a slot, so
+///   each keeps its own law; the same index twice writes one slot twice and the later law wins. An
+///   edge OCCT declines to add has no slot and is skipped, as Add(Radius, E) skips it. #612
 /// @param edgeCount Number of edges
 /// @param radiusPoints Array of parameter-radius pairs per edge (flattened: edge0[rp0,rp1,...], edge1[rp0,...], ...);
 ///   every radius must be > 0, and each edge's parameters must lie in [0, 1] and strictly increase

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -486,12 +486,22 @@ OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
 
     try {
         BRepFilletAPI_MakeFillet fillet(shape->shape);
+        TopoDS_Edge added;
         if (!occtFilletAddEdges(fillet, shape->shape, &edgeIndex, 1,
-                                [](BRepFilletAPI_MakeFillet& f, const TopoDS_Edge& edge, int32_t) {
+                                [&added](BRepFilletAPI_MakeFillet& f,
+                                         const TopoDS_Edge& edge, int32_t) {
             f.Add(edge);  // the radius-law overload: the profile below supplies the radius
+            added = edge;
+            return true;
         })) return nullptr;
 
-        if (!occtFilletSetRadiusProfile(fillet, fillet.NbContours(), count,
+        // #612: the profile goes to this edge's own slot in this edge's own contour. One edge is
+        // added, so the contour index agreed with NbContours() whenever there was one at all — but
+        // when OCCT *declines* the edge (a free-boundary edge of an open shell) NbContours() is 0,
+        // and SetRadius(law, 0, 1) is the unchecked low side #505 measured: it used to SIGSEGV,
+        // uncatchably, rather than fail. Resolving the slot returns no slot instead, and the empty
+        // fillet then fails in Build().
+        if (!occtFilletSetRadiusProfile(fillet, added, count,
                                         [radii, params](int32_t i) {
             return gp_Pnt2d(params[i], radii[i]);
         })) return nullptr;
@@ -712,6 +722,7 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
                                    [radii](BRepFilletAPI_MakeFillet& fillet,
                                            const TopoDS_Edge& edge, int32_t entry) {
         fillet.Add(radii[entry], edge);
+        return true;
     });
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1427,13 +1427,86 @@ inline bool occtValidFilletRadii(const double* radii, int32_t count) {
 //
 // Radius validation is the caller's, since the shapes it takes (one scalar, two scalars, an array,
 // a (parameter, radius) point list) have nothing in common but occtValidFilletRadius above.
+//
+// #612: `addEdge` answers false for a request it cannot honour — in practice a malformed radius
+// law, which is a caller error rather than a property of the geometry. The rest of the batch is
+// then left unadded and the whole call fails, because every caller returns before Build() on false
+// and a fillet carrying a contour with no radius must never reach it (see the SIGSEGV #520
+// measured, below). The shared index resolver's own visitor stays void: the five other families
+// that share it have nothing to refuse.
 template <class AddEdge>
 bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
                         const int32_t* edgeIndices, int32_t edgeCount, AddEdge addEdge) {
-    return occtUseSubShapesByIndex(shape, TopAbs_EDGE, edgeIndices, edgeCount,
-                                   [&](const TopoDS_Shape& edge, int32_t i) {
-        addEdge(fillet, TopoDS::Edge(edge), i);
+    bool honoured = true;
+    bool resolved = occtUseSubShapesByIndex(shape, TopAbs_EDGE, edgeIndices, edgeCount,
+                                            [&](const TopoDS_Shape& edge, int32_t i) {
+        if (!honoured) return;
+        honoured = addEdge(fillet, TopoDS::Edge(edge), i);
     });
+    return resolved && honoured;
+}
+
+// === #612: a radius law belongs to the edge's own slot, in the edge's own contour ===
+//
+// Two independent facts about BRepFilletAPI_MakeFillet, both of which the bridge used to get wrong
+// by writing `SetRadius(law, NbContours(), 1)`.
+//
+// (1) Add(edge) does not always create a contour. An edge tangent-continuous with one already added
+// *extends* that contour instead, so NbContours() — "the contour that exists after the most recent
+// Add" — names the edge's own contour only when every Add happens to create one. Measured on a
+// rounded-slot prism (2 lines + 2 semicircular arcs, extruded), adding a top-rim edge, a bottom-rim
+// edge, then a second top-rim edge:
+//
+//   add top    -> NbContours()=1  Contour(edge)=1
+//   add bottom -> NbContours()=2  Contour(edge)=2
+//   add top    -> NbContours()=2  Contour(edge)=1   <<< the third law lands on the bottom rim
+//
+// Contour(E) returns the index of the contour holding E, or 0 for an edge in none, and is populated
+// by Add() rather than by Build() — the same property #505 relies on.
+//
+// (2) SetRadius's third argument, IinC, is the index of the edge *within* that contour, and it
+// selects a distinct per-edge slot. The bridge hardcoded it to 1, which is what made two edges of
+// one contour look like an unresolvable conflict: both laws went to the same slot and the second
+// replaced the first. It is not a conflict at all. Measured on the same slot rim, filleting the
+// straight side and the tangent arc with radius 2 and 5:
+//
+//   both laws at IinC=1 (the old idiom)      9974.608333   <- the arc's 5 overwrote the line's 2
+//   each law at its own IinC                10139.793468   <- BOTH honoured
+//   Add(Radius, E), i.e. blendedEdges       10139.793468   <- byte-identical
+//
+// The Add(Radius, E) overload resolves the same slot internally (BRepFilletAPI_MakeFillet.cxx:67-77
+// walks Contains(E, IinC)), which is why blendedEdges already honoured the very request
+// filletEvolving could not. A non-constant law makes the slot visible on a single edge too: a
+// 1 -> 4 taper on one added edge measures 10273.238348 / 10297.711861 / 10343.333856 / 10402.168644
+// at IinC 1/2/3/4.
+//
+// So there is no ambiguity to refuse and no law to discard: each edge's law goes to its own slot.
+// A single edge named twice in one call writes the same slot twice, and the later law wins — the
+// ordinary meaning of assigning the same thing twice, not a silent substitution of some *other*
+// edge's request.
+//
+// `indexInContour` is 0 when the edge is not in the named contour. Add() legitimately refuses an
+// edge it cannot fillet — a free-boundary edge of an open shell, 4 of 12 on a box missing a face —
+// and then Contour(E) is 0 and there is no slot to write. That is not an error here: Add(Radius, E)
+// silently declines the same edges, and skipping them makes the law paths agree with it to the
+// digit — surface area 465.09733552923257 both ways over all 12 edges of that shell. Measure such a
+// shell by AREA: it is not a solid, so BRepGProp::VolumeProperties fabricates a number for it (the
+// #605/#609 defect class), and that number is not even a property of the shape — it ranges 746.83
+// to 748.28 depending on which face is dropped, while the area is 465.097 for all six.
+//
+// A batch in which *every* edge is refused leaves zero contours and Build() throws, so an
+// all-refused request still fails rather than quietly returning the unfilleted input.
+inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge,
+                               int32_t& contourIndex, int32_t& indexInContour) {
+    contourIndex = fillet.Contour(edge);
+    if (contourIndex < 1 || contourIndex > fillet.NbContours()) return false;
+    for (int32_t j = 1; j <= fillet.NbEdges(contourIndex); j++) {
+        if (fillet.Edge(contourIndex, j).IsSame(edge)) {
+            indexInContour = j;
+            return true;
+        }
+    }
+    return false;
 }
 
 // === #520: the radius law, for the two entry points that take one ===
@@ -1467,8 +1540,16 @@ bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& sh
 // `pointAt(i)` returns the i-th point as a gp_Pnt2d(relative parameter, radius); the two callers
 // hold their profiles in different layouts (parallel arrays, and an array of OCCTFilletRadiusPoint)
 // and neither is worth copying to share this.
+//
+// #612: this takes the *edge* rather than a contour index and resolves both the contour and the
+// edge's slot within it (occtFilletEdgeSlot above), so a caller can no longer name the wrong one —
+// which is exactly what `SetRadius(law, NbContours(), 1)` did here.
+//
+// False means the *profile* is malformed, which is a caller error and rejects the whole call. An
+// edge OCCT declined to add is not a caller error and returns true having placed nothing: see
+// occtFilletEdgeSlot for why that matches what Add(Radius, E) does with the same edge.
 template <class PointAt>
-bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, int32_t contourIndex,
+bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge,
                                 int32_t pointCount, PointAt pointAt) {
     if (pointCount < 1) return false;
 
@@ -1485,7 +1566,10 @@ bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, int32_t contou
         UandR.SetValue(i + 1, point);
     }
 
-    fillet.SetRadius(UandR, contourIndex, 1);
+    int32_t contourIndex = 0, indexInContour = 0;
+    if (!occtFilletEdgeSlot(fillet, edge, contourIndex, indexInContour)) return true;
+
+    fillet.SetRadius(UandR, contourIndex, indexInContour);
     return true;
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -332,6 +332,7 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
                                    [radius](BRepFilletAPI_MakeFillet& fillet,
                                             const TopoDS_Edge& edge, int32_t) {
         fillet.Add(radius, edge);
+        return true;
     });
 }
 
@@ -342,10 +343,21 @@ OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeI
     return occtShapeFilletEdgeList(shape, edgeIndices, edgeCount,
                                    [startRadius, endRadius](BRepFilletAPI_MakeFillet& fillet,
                                                             const TopoDS_Edge& edge, int32_t) {
-        // The radius-law overload takes no radius: add the edge as its own contour first, then
-        // vary the radius across that contour.
-        fillet.Add(edge);
-        fillet.SetRadius(startRadius, endRadius, fillet.NbContours(), 1);
+        // #612: this used to be Add(edge) followed by SetRadius(R1, R2, NbContours(), 1). Both
+        // coordinates were wrong — a tangent-continuous edge extends an existing contour rather
+        // than creating one, and the third argument is the edge's index *within* the contour, not
+        // a constant 1, so every edge of a tangent chain landed on one slot and only the last
+        // survived (measured 10273.238348 for two edges of a slot rim at 1 -> 4, exactly what
+        // filleting the first alone produces, against 10297.711861 correct).
+        //
+        // OCCT ships the whole thing as one call: Add(R1, R2, E) is Add(E) plus the same
+        // Contains(E, IinC) slot resolution plus SetRadius(R1, R2, IC, IinC). Verified equivalent
+        // to resolving the slot by hand — identical to the digit on that rim for the pair
+        // (10297.711860842), the straight side alone (10273.238347801) and the arc alone
+        // (10276.405613964) — and it declines an unfilletable edge by construction, which is the
+        // skip the sibling entry points get from Add(Radius, E).
+        fillet.Add(startRadius, endRadius, edge);
+        return true;
     });
 }
 
@@ -1853,6 +1865,7 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdges(OCCTShapeRef shape,
                                 [radius](BRepFilletAPI_MakeFillet& fillet,
                                          const TopoDS_Edge& edge, int32_t) {
             fillet.Add(radius, edge);
+            return true;
         })) return nullptr;
         op->Build();
         if (!op->IsDone()) return nullptr;
@@ -1878,12 +1891,15 @@ OCCTBooleanHistoryRef OCCTShapeHistoryFromFilletEdgeVariable(OCCTShapeRef shape,
         if (idx < 1 || idx > edgeMap.Extent()) return nullptr;
         TopoDS_Edge edge = TopoDS::Edge(edgeMap(idx));
         std::unique_ptr<BRepFilletAPI_MakeFillet> op(new BRepFilletAPI_MakeFillet(shape->shape));
-        op->Add(edge);
-        // Map the variable radius along the edge: (param=0, startR), (param=1, endR).
-        TColgp_Array1OfPnt2d radii(1, 2);
-        radii.SetValue(1, gp_Pnt2d(0.0, startRadius));
-        radii.SetValue(2, gp_Pnt2d(1.0, endRadius));
-        op->SetRadius(radii, 1, 1);
+        // #612: the same one-call overload OCCTShapeFilletEdgesLinear uses, replacing Add(edge)
+        // plus a two-point array written to SetRadius(radii, 1, 1). That literal 1 was in fact
+        // safe here — a single added edge always lands at index 1 of its contour's spine, measured
+        // on all four edges of a tangent rim, and a *literal* 1 is bounds-checked upstream even
+        // when the edge was declined and there are no contours (unlike the 0 that NbContours()
+        // yields there, which is the unchecked low side that used to SIGSEGV). Converted anyway so
+        // the idiom is gone: Add(R1, R2, E) measures identical to the array law (492.500243 on an
+        // accepted edge) and declines an unfilletable edge by construction.
+        op->Add(startRadius, endRadius, edge);
         op->Build();
         if (!op->IsDone()) return nullptr;
         TopoDS_Shape result = op->Shape();
@@ -2380,20 +2396,23 @@ OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
         // The profile of edge i starts where the profiles of edges 0..i-1 end, so the offset walks
         // forward with the loop inside occtFilletAddEdges rather than being indexable from `entry`.
         int32_t offset = 0;
-        bool profilesOk = true;
-        bool indicesOk = occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount,
-                                            [&](BRepFilletAPI_MakeFillet& f,
-                                                const TopoDS_Edge& edge, int32_t entry) {
-            if (!profilesOk) return;
+        bool ok = occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount,
+                                     [&](BRepFilletAPI_MakeFillet& f,
+                                         const TopoDS_Edge& edge, int32_t entry) {
             f.Add(edge);
             const OCCTFilletRadiusPoint* points = radiusPoints + offset;
-            profilesOk = occtFilletSetRadiusProfile(f, f.NbContours(), pointCounts[entry],
-                                                    [points](int32_t j) {
+            // Both the contour and the edge's slot within it are resolved from `edge` inside the
+            // helper, not from (NbContours(), 1). Two tangent-continuous edges share a contour but
+            // not a slot, so both laws are honoured — measured 10139.793468, byte-identical to the
+            // blendedEdges request that always could. #612
+            bool profileOk = occtFilletSetRadiusProfile(f, edge, pointCounts[entry],
+                                                        [points](int32_t j) {
                 return gp_Pnt2d(points[j].parameter, points[j].radius);
             });
             offset += pointCounts[entry];
+            return profileOk;
         });
-        if (!indicesOk || !profilesOk) return nullptr;
+        if (!ok) return nullptr;
 
         fillet.Build();
         if (!fillet.IsDone()) return nullptr;

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6293,9 +6293,19 @@ public struct EvolvingFilletEdge: Sendable {
 extension Shape {
     /// Apply evolving-radius fillets to multiple edges simultaneously.
     ///
-    /// Every edge is filleted or none is: an `edgeIndex` naming no edge of this shape returns `nil`
-    /// rather than filleting the rest, and so does any radius that is not positive, any parameter
-    /// outside `0...1`, any non-increasing parameter sequence, and an empty `radiusPoints`.
+    /// The request is rejected as a whole, rather than partly applied, whenever it is malformed: an
+    /// `edgeIndex` naming no edge of this shape returns `nil` rather than filleting the rest, and so
+    /// does any radius that is not positive, any parameter outside `0...1`, any non-increasing
+    /// parameter sequence, and an empty `radiusPoints`.
+    ///
+    /// Each edge's law is applied to that edge's own position within its own contour, so
+    /// tangent-continuous edges — the sides and ends of a rounded slot's rim, say — can each carry a
+    /// different law even though OCCT groups them into a single contour.
+    ///
+    /// Separately from a malformed request, OCCT itself declines to fillet some edges outright (a
+    /// free-boundary edge of an open shell). Those are skipped, exactly as ``Shape/blendedEdges(_:)``
+    /// and ``Shape/filleted(edges:radius:)`` skip them; if OCCT declines *every* edge of the
+    /// request, the call returns `nil` rather than the unfilleted input. (#612)
     ///
     /// ```swift
     /// let box = Shape.box(width: 20, height: 20, depth: 20)!
@@ -6304,9 +6314,25 @@ extension Shape {
     ///     EvolvingFilletEdge(edge: edges[0], radiusPoints: [(0.0, 1.0), (1.0, 3.0)]),
     ///     EvolvingFilletEdge(edge: edges[2], radiusPoints: [(0.0, 1.0), (0.5, 4.0), (1.0, 1.0)]),
     /// ])
+    ///
+    /// // A rounded slot: two straight sides joined by two semicircular ends, extruded. Its whole
+    /// // top rim is one tangent-continuous contour, and each edge of it still carries its own law.
+    /// let profile = Wire.join([
+    ///     Wire.line(from: SIMD3(-10, -8, 0), to: SIMD3(10, -8, 0))!,
+    ///     Wire.arc(start: SIMD3(10, -8, 0), midpoint: SIMD3(18, 0, 0), end: SIMD3(10, 8, 0))!,
+    ///     Wire.line(from: SIMD3(10, 8, 0), to: SIMD3(-10, 8, 0))!,
+    ///     Wire.arc(start: SIMD3(-10, 8, 0), midpoint: SIMD3(-18, 0, 0), end: SIMD3(-10, -8, 0))!,
+    /// ])!
+    /// let slot = Shape.face(from: profile)!.extruded(by: SIMD3(0, 0, 20))!
+    /// let rim = slot.edges()
+    /// let tapered = slot.filletEvolving([
+    ///     EvolvingFilletEdge(edge: rim[3], radiusPoints: [(0.0, 1.0), (1.0, 3.0)]),
+    ///     EvolvingFilletEdge(edge: rim[6], radiusPoints: [(0.0, 5.0), (1.0, 5.0)]),
+    /// ])
     /// ```
     ///
-    /// - Parameter edges: Array of edge specifications with radius evolution.
+    /// - Parameter edges: Array of edge specifications with radius evolution. Naming the same edge
+    ///   twice writes its law twice, and the later one wins.
     /// - Returns: Filleted shape, or nil on failure.
     public func filletEvolving(_ edges: [EvolvingFilletEdge]) -> Shape? {
         guard !edges.isEmpty else { return nil }

--- a/Tests/OCCTModelingTests/Issue612FilletContourSelectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue612FilletContourSelectionTests.swift
@@ -1,0 +1,337 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// The fillet radius-law entry points wrote every law to `SetRadius(law, NbContours(), 1)`. Both
+/// coordinates were wrong.
+///
+/// `NbContours()` is "the contour that exists after the most recent `Add`", which is the edge's own
+/// contour only when every `Add` creates one — a tangent-continuous edge *extends* an existing
+/// contour instead. And the third argument is the edge's index **within** the contour, selecting a
+/// distinct per-edge slot; hardcoding it to `1` sent every edge of a tangent chain to the same slot,
+/// so only the last survived.
+///
+/// The second half is what made two edges of one contour look like an unresolvable conflict. It is
+/// not one: `Add(Radius, E)` (behind ``Shape/blendedEdges(_:)``) has always resolved that slot
+/// itself, so it already honoured the very request `filletEvolving` could not. #612
+@Suite("Fillet radius laws go to the edge's own slot in the edge's own contour (#612)")
+struct Issue612FilletContourSelection {
+
+    // MARK: - Fixture
+
+    static let slotHalfLength = 10.0
+    static let slotRadius = 8.0
+    static let slotHeight = 20.0
+
+    /// A rounded-slot prism: two straight sides joined by two semicircular ends, extruded in +Z.
+    /// Every edge of the top rim is tangent-continuous with its neighbours, so the whole rim is a
+    /// single fillet contour holding four edges; the bottom rim is a second, independent one.
+    static func roundedSlot() -> Shape? {
+        let l = slotHalfLength, r = slotRadius
+        guard let bottom = Wire.line(from: SIMD3(-l, -r, 0), to: SIMD3(l, -r, 0)),
+              let right = Wire.arc(start: SIMD3(l, -r, 0),
+                                   midpoint: SIMD3(l + r, 0, 0),
+                                   end: SIMD3(l, r, 0)),
+              let top = Wire.line(from: SIMD3(l, r, 0), to: SIMD3(-l, r, 0)),
+              let left = Wire.arc(start: SIMD3(-l, r, 0),
+                                  midpoint: SIMD3(-l - r, 0, 0),
+                                  end: SIMD3(-l, -r, 0)),
+              let profile = Wire.join([bottom, right, top, left]),
+              let face = Shape.face(from: profile) else { return nil }
+        return face.extruded(by: SIMD3(0, 0, slotHeight))
+    }
+
+    /// A 10mm box with one face dropped and the rest sewn back together: an open shell whose free
+    /// boundary edges `BRepFilletAPI_MakeFillet::Add` refuses (measured: 4 of its 12 edges).
+    static func openShell() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        let faces = box.faces().compactMap { Shape.fromFace($0) }
+        guard faces.count == 6 else { return nil }
+        return Shape.sew(shapes: Array(faces.dropFirst()))
+    }
+
+    /// Edge indices on a rim at height `z`, split by curve kind.
+    static func rimEdges(of shape: Shape, atHeight z: Double) -> (lines: [Int], arcs: [Int]) {
+        var lines: [Int] = [], arcs: [Int] = []
+        for (index, edge) in shape.edges().enumerated() {
+            let (start, end) = edge.endpoints
+            guard abs(start.z - z) < 1e-7, abs(end.z - z) < 1e-7 else { continue }
+            if edge.isLine { lines.append(index) } else if edge.isCircle { arcs.append(index) }
+        }
+        return (lines, arcs)
+    }
+
+    static func constant(_ radius: Double) -> [(parameter: Double, radius: Double)] {
+        [(0.0, radius), (1.0, radius)]
+    }
+
+    /// The top rim's straight side and one tangent arc: same contour, different slots.
+    static func tangentPair(of slot: Shape)
+        -> (line: Edge, arc: Edge, lineIndex: Int, arcIndex: Int)? {
+        let top = rimEdges(of: slot, atHeight: slotHeight)
+        let edges = slot.edges()
+        guard let li = top.lines.first, let ai = top.arcs.first,
+              edges.indices.contains(li), edges.indices.contains(ai) else { return nil }
+        return (edges[li], edges[ai], li, ai)
+    }
+
+    // MARK: - The premise
+
+    @Test("The top rim is one contour of four edges, so one contour is not one law")
+    func fixtureHasATangentContinuousRim() {
+        guard let slot = Self.roundedSlot(), let pair = Self.tangentPair(of: slot) else {
+            Issue.record("rounded slot fixture failed to build")
+            return
+        }
+        let top = Self.rimEdges(of: slot, atHeight: Self.slotHeight)
+        let bottom = Self.rimEdges(of: slot, atHeight: 0)
+        #expect(top.lines.count == 2)
+        #expect(top.arcs.count == 2)
+        #expect(bottom.lines.count == 2)
+        #expect(bottom.arcs.count == 2)
+
+        guard let builder = FilletBuilder(shape: slot) else {
+            Issue.record("could not build the tangency probe")
+            return
+        }
+        builder.addEdge(pair.line, radius: 2)
+        // One contour, and it already holds the arc the caller never added.
+        #expect(builder.contourCount == 1)
+        #expect(builder.contour(for: pair.arc) == 1)
+    }
+
+    // MARK: - Two laws, one contour, both honoured
+
+    @Test("Two tangent-continuous edges carry different radius laws, matching blendedEdges exactly")
+    func bothLawsOnOneContourAreHonoured() {
+        guard let slot = Self.roundedSlot(), let pair = Self.tangentPair(of: slot) else {
+            Issue.record("rounded slot fixture failed to build")
+            return
+        }
+
+        // The request #612 was filed against, in its simplest form: one contour, two laws.
+        let evolving = slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: Self.constant(2)),
+            EvolvingFilletEdge(edge: pair.arc, radiusPoints: Self.constant(5)),
+        ])
+
+        // blendedEdges reaches Add(Radius, E), which has always resolved the per-edge slot itself.
+        // It is the independent oracle for what the request means.
+        let blended = slot.blendedEdges([(pair.lineIndex, 2.0), (pair.arcIndex, 5.0)])
+
+        guard let evolvingVolume = evolving?.volume, let blendedVolume = blended?.volume else {
+            Issue.record("one of the two-law requests did not produce a measurable solid")
+            return
+        }
+
+        // Byte-identical: both laws honoured, each in its own slot.
+        #expect(abs(evolvingVolume - blendedVolume) < 1e-6)
+        #expect(abs(evolvingVolume - 10139.793468) < 1e-3)
+
+        // Not the last-writer-wins answer the old code produced, where both laws went to slot 1.
+        #expect(abs(evolvingVolume - 9974.608333) > 1.0)
+    }
+
+    @Test("The issue's own request — a taper on one edge, a constant on its tangent neighbour")
+    func taperAndConstantOnOneContourBuild() {
+        guard let slot = Self.roundedSlot(), let pair = Self.tangentPair(of: slot) else {
+            Issue.record("rounded slot fixture failed to build")
+            return
+        }
+
+        // #612's failure scenario verbatim: a taper on one edge, a constant on the other. This used
+        // to come back with the constant applied to both.
+        let out = slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: [(0.0, 1.0), (1.0, 3.0)]),
+            EvolvingFilletEdge(edge: pair.arc, radiusPoints: Self.constant(5)),
+        ])
+
+        guard let volume = out?.volume else {
+            Issue.record("the taper-plus-constant request did not produce a measurable solid")
+            return
+        }
+        #expect(abs(volume - 10171.225408) < 1e-3)
+
+        // The taper is really a taper: replacing it with a constant moves the result.
+        if let flat = slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: Self.constant(3)),
+            EvolvingFilletEdge(edge: pair.arc, radiusPoints: Self.constant(5)),
+        ])?.volume {
+            #expect(abs(volume - flat) > 1.0)
+        }
+    }
+
+    // MARK: - The wrong-contour half
+
+    @Test("A third edge extending contour 1 does not overwrite contour 2's radius law")
+    func lawLandsOnTheEdgesOwnContour() {
+        guard let slot = Self.roundedSlot(), let pair = Self.tangentPair(of: slot) else {
+            Issue.record("rounded slot fixture failed to build")
+            return
+        }
+        let bottom = Self.rimEdges(of: slot, atHeight: 0)
+        let edges = slot.edges()
+        guard let bottomIndex = bottom.lines.first, edges.indices.contains(bottomIndex) else {
+            Issue.record("could not identify the bottom rim")
+            return
+        }
+        let bottomLine = edges[bottomIndex]
+        let topRadius = 2.0, bottomRadius = 5.0
+
+        // Reference: top rim at 2, bottom rim at 5, one edge per contour — needs no shared-contour
+        // resolution, so it was already correct before this fix.
+        let intended = slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: Self.constant(topRadius)),
+            EvolvingFilletEdge(edge: bottomLine, radiusPoints: Self.constant(bottomRadius)),
+        ])
+
+        // What the defect produced: the third edge's law overwrote contour 2, so the bottom rim
+        // came out at the top rim's radius instead of its own.
+        let clobbered = slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: Self.constant(topRadius)),
+            EvolvingFilletEdge(edge: bottomLine, radiusPoints: Self.constant(topRadius)),
+        ])
+
+        // The request under test: a third edge, in contour 1, added after contour 2 exists.
+        let actual = slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: Self.constant(topRadius)),
+            EvolvingFilletEdge(edge: bottomLine, radiusPoints: Self.constant(bottomRadius)),
+            EvolvingFilletEdge(edge: pair.arc, radiusPoints: Self.constant(topRadius)),
+        ])
+
+        guard let intendedVolume = intended?.volume,
+              let clobberedVolume = clobbered?.volume,
+              let actualVolume = actual?.volume else {
+            Issue.record("one of the fillet requests did not produce a measurable solid")
+            return
+        }
+
+        // The two references must differ, or the assertions below prove nothing.
+        #expect(abs(intendedVolume - clobberedVolume) > 1.0)
+        // The third edge only repeats its own contour's law, so the geometry is the intended one.
+        #expect(abs(actualVolume - intendedVolume) < 1e-6)
+        // The bottom rim keeps the 5mm it was asked for, rather than the top rim's 2mm.
+        #expect(abs(actualVolume - clobberedVolume) > 1.0)
+    }
+
+    // MARK: - The sibling site, which the first attempt wrongly called unobservable
+
+    @Test("filletLinear places each edge's law in that edge's own slot")
+    func linearFilletPlacesEachEdgesLaw() {
+        guard let slot = Self.roundedSlot(), let pair = Self.tangentPair(of: slot) else {
+            Issue.record("rounded slot fixture failed to build")
+            return
+        }
+
+        // A NON-constant law is what makes the slot visible. With startRadius == endRadius every
+        // slot carries the same number and the defect hides — which is why this site was first,
+        // wrongly, called "never observably wrong".
+        let pairResult = slot.filleted(edges: [pair.line, pair.arc], startRadius: 1, endRadius: 4)
+        let lineOnly = slot.filleted(edges: [pair.line], startRadius: 1, endRadius: 4)
+
+        guard let pairVolume = pairResult?.volume, let lineVolume = lineOnly?.volume else {
+            Issue.record("linear fillet did not produce a measurable solid")
+            return
+        }
+
+        // Each law in its own slot.
+        #expect(abs(pairVolume - 10297.711861) < 1e-3)
+        // The old idiom wrote both to slot 1, which measures exactly as filleting the line alone.
+        #expect(abs(lineVolume - 10273.238348) < 1e-3)
+        #expect(abs(pairVolume - lineVolume) > 1.0)
+    }
+
+    // MARK: - Edges OCCT declines to add
+
+    @Test("An edge Add() refuses is skipped, not turned into a nil result")
+    func refusedEdgesAreSkippedNotRejected() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edges = shell.edges()
+        #expect(edges.count == 12)
+        let allIndices = Array(edges.indices)
+
+        // The entry points that reach Add(Radius, E) have always skipped the free-boundary edges
+        // this shell has; the law-taking ones must agree rather than returning nil.
+        let constantRadius = shell.filleted(edges: edges, radius: 1)
+        let blended = shell.blendedEdges(allIndices.map { ($0, 1.0) })
+        let linear = shell.filleted(edges: edges, startRadius: 1, endRadius: 1)
+        let evolving = shell.filletEvolving(edges.map {
+            EvolvingFilletEdge(edge: $0, radiusPoints: Self.constant(1))
+        })
+        let withHistory = shell.filletedWithFullHistory(radius: 1, edges: allIndices)?.result
+
+        // Measured by surface AREA, not volume: an open shell is not a solid, so `volume` is nil
+        // for every one of these results whether the fillet succeeded or not — and asking OCCT
+        // directly gets a fabricated number that is not even a property of the shape (#605/#609).
+        // Reported per entry point, so a failure names the one that regressed rather than the batch.
+        let measured: [(String, Double?)] = [
+            ("filleted(edges:radius:)", constantRadius?.surfaceArea),
+            ("blendedEdges(_:)", blended?.surfaceArea),
+            ("filleted(edges:startRadius:endRadius:)", linear?.surfaceArea),
+            ("filletEvolving(_:)", evolving?.surfaceArea),
+            ("filletedWithFullHistory(radius:edges:)", withHistory?.surfaceArea),
+        ]
+        for (name, area) in measured where area == nil {
+            Issue.record("\(name) returned nil over an open shell instead of skipping the edges OCCT declined")
+        }
+
+        guard let plainArea = shell.surfaceArea else {
+            Issue.record("the open shell fixture itself has no measurable surface area")
+            return
+        }
+        guard let constantArea = constantRadius?.surfaceArea else { return }
+        for (name, area) in measured {
+            guard let area else { continue }
+            #expect(abs(area - constantArea) < 1e-6, "\(name) disagrees with the family")
+        }
+        // The agreed answer, measured against the kernel directly.
+        #expect(abs(constantArea - 465.09733552923257) < 1e-6)
+        // And the fillet did happen — rounding the accepted edges changed the surface.
+        #expect(abs(constantArea - plainArea) > 1.0)
+    }
+
+    @Test("A variable fillet on an edge Add() refuses fails, where it used to SIGSEGV")
+    func variableFilletOnARefusedEdgeDoesNotCrash() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+
+        // Reaching the end of this loop at all is the assertion: SetRadius(law, 0, 1) on a refused
+        // edge is the unchecked low side of OCCT's contour index, and it used to take the whole
+        // test process down with SIGSEGV — uncatchable, so no catch(...) on the bridge side helps.
+        var refusedCount = 0
+        for index in shell.edges().indices {
+            if shell.filletedVariable(edgeIndex: index,
+                                      radiusProfile: [(0.0, 1.0), (1.0, 2.0)]) == nil {
+                refusedCount += 1
+            }
+        }
+        // At least one edge of this shell is one OCCT declines, and it now fails cleanly.
+        #expect(refusedCount > 0)
+    }
+
+    // MARK: - Preconditions still reject
+
+    @Test("A malformed profile still rejects the whole call")
+    func malformedProfilesStillReject() {
+        guard let slot = Self.roundedSlot(), let pair = Self.tangentPair(of: slot) else {
+            Issue.record("rounded slot fixture failed to build")
+            return
+        }
+        // Skipping an edge OCCT declines must not have loosened the profile contract (#520).
+        #expect(slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: Self.constant(2)),
+            EvolvingFilletEdge(edge: pair.arc, radiusPoints: [(0.0, -3.0), (1.0, 2.0)]),
+        ]) == nil)
+        #expect(slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: [(1.0, 2.0), (0.0, 3.0)]),
+        ]) == nil)
+        #expect(slot.filletEvolving([
+            EvolvingFilletEdge(edge: pair.line, radiusPoints: []),
+        ]) == nil)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -279,6 +279,74 @@ suites with 41 issues, and the test pinning the *preserved* windowed primary pat
 it must. The 2D sweep's ground-truth anchor was separately proved non-vacuous by over-reporting the
 distance in the helper: 9 failures with `abs()`, 0 without it.
 
+#### A fillet radius law goes to the edge's own slot, in the edge's own contour (#612)
+
+`filletEvolving`, `filleted(edges:startRadius:endRadius:)` and `filletedVariable` all wrote their
+law with `SetRadius(law, NbContours(), 1)`. Both coordinates were wrong, independently.
+
+**The contour.** `NbContours()` is "the contour that exists after the most recent `Add`", which is
+the edge's own contour only when every `Add` creates one — a tangent-continuous edge **extends** an
+existing contour instead. Measured on a rounded-slot prism (two straight sides joined by two
+semicircular ends, extruded 20mm), adding a top-rim edge, a bottom-rim edge, then a second top-rim
+edge:
+
+| after | `NbContours()` | `Contour(edge)` |
+|---|---|---|
+| add top-rim edge | 1 | 1 |
+| add bottom-rim edge | 2 | 2 |
+| add second top-rim edge | 2 | **1** |
+
+The third edge's law was written to contour 2, replacing the bottom rim's own. Asking for top rim
+2mm and bottom rim 5mm returned **10271.088459** — byte-identical to filleting *both* rims at 2mm —
+against the intended **9899.533264**.
+
+**The slot.** `SetRadius`'s third argument, `IinC`, is the edge's index *within* the contour and
+selects a distinct per-edge slot. Hardcoding it to `1` sent every edge of a tangent chain to the
+same slot, so only the last survived. On the same rim, filleting the straight side at 2mm and its
+tangent arc at 5mm:
+
+| | volume |
+|---|---|
+| both laws at slot 1 (the old idiom) | 9974.608333 — the arc's 5mm overwrote the line's 2mm |
+| each law in its own slot | **10139.793468** — both honoured |
+| `blendedEdges([(line, 2), (arc, 5)])` | **10139.793468** — byte-identical |
+
+`Add(Radius, E)`, which backs `blendedEdges`, resolves that slot itself, so it always honoured the
+very request `filletEvolving` could not express. **There was never a "one law per contour" limit to
+work around** — the conflict was an artefact of the hardcoded `1`. #612's own example (a taper on
+one edge, a constant on its tangent neighbour) is an ordinary request and now builds, at
+10171.225408.
+
+The slot is visible on a single edge too: a 1 → 4 taper on one added edge measures 10273.238348,
+10297.711861, 10343.333856, 10402.168644 at slots 1, 2, 3, 4.
+
+**The linear entry point was observably wrong after all.** Its batch shares one `(startRadius,
+endRadius)`, so with a *constant* law two edges of a contour rewrite the same number and nothing
+moves — but a genuine taper does not: two tangent-continuous edges at 1 → 4 measured
+**10273.238348**, exactly what filleting the first alone produces, against **10297.711861** with
+each law in its own slot. It now uses OCCT's own one-call `Add(R1, R2, E)`, which is `Add(E)` plus
+the same slot resolution plus `SetRadius` — verified identical to resolving the slot by hand, and it
+declines an unfilletable edge by construction. `OCCTShapeHistoryFromFilletEdgeVariable` moves to the
+same overload: its `SetRadius(radii, 1, 1)` was in fact safe, because a single added edge always
+lands at index 1 of its contour's spine (measured on all four edges of a tangent rim) and a
+*literal* 1 is bounds-checked upstream, but the idiom is gone.
+
+**And `filletedVariable` on such an edge did not merely pick a wrong index — it SIGSEGV'd.** When
+OCCT declines an edge outright (a free-boundary edge of an open shell; 4 of the 12 edges of a box
+missing one face), `Contour(E)` is 0 and `NbContours()` is 0, so the call became
+`SetRadius(law, 0, 1)` — the unchecked low side of the contour index #505 measured. That is an OS
+signal, uncatchable in process. Confirmed by re-injecting the old code: `swift test` exits with
+signal 11. Such an edge is now resolved to no slot and skipped, which is exactly what
+`Add(Radius, E)` already does with it — measured identical to the digit, **surface area
+465.09733552923257** over all 12 edges of that shell, whichever entry point applies it, so the
+edge-list fillet family agrees. A batch in which *every* edge is declined leaves zero contours and
+fails in `Build()`, so an all-refused request still returns `nil` rather than the unfilleted input.
+
+Measure an open shell by **area**, not volume: it is not a solid, so `BRepGProp::VolumeProperties`
+fabricates a number for it — the very defect class #605/#609 exist to reject — and that number is
+not even a property of the shape. It ranges 746.83 to 748.28 depending on which of the six faces is
+dropped, while the surface area is 465.097 for all six.
+
 #### A NaN parameter bound stops being a plausible arc length (#548)
 
 `Curve3D.length(from:to:)` documents itself as the entry point that tells failure apart from a real

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1117,15 +1117,23 @@ Fillets specific edges with a linear radius interpolation.
 public func filleted(edges: [Edge], startRadius: Double, endRadius: Double) -> Shape?
 ```
 
-The radius varies linearly from `startRadius` at the start of each edge to `endRadius` at its end.
+Each named edge is given a law running from `startRadius` to `endRadius`, placed in that edge's own
+slot within its contour. A contour is not always one edge — OCCT groups tangent-continuous edges
+into a single contour — and the radius over the whole contour is the interpolation of its edges'
+slots, so naming two edges of one tangent chain is not the same as naming one of them. Measured on
+a rounded slot's rim at 1 → 4: the straight side alone gives 10273.238348, the side plus its tangent
+arc 10297.711861 (#612).
 
-- **Parameters:** `edges` — edges to fillet; `startRadius` — radius at edge start (> 0); `endRadius` — radius at edge end (> 0).
+- **Parameters:** `edges` — edges to fillet; `startRadius` — radius at the start of each named edge's law (> 0); `endRadius` — radius at its end (> 0).
 - **Returns:** Filleted shape, or `nil` on failure, which includes a non-positive or NaN radius at
   either end.
-- **OCCT:** `BRepFilletAPI_MakeFillet` with law-driven radius (via `OCCTShapeFilletEdgesLinear`).
+- **OCCT:** `BRepFilletAPI_MakeFillet::Add(R1, R2, E)` (via `OCCTShapeFilletEdgesLinear`), which
+  places each law in that edge's own slot within its contour (#612).
 - **Notes:** shares one bridge implementation with [`filleted(edges:radius:)`](#filletededgesradius)
   and [`blendedEdges(_:)`](#blendededges_) (#489), including their all-or-nothing index contract
-  (#520).
+  (#520). An edge OCCT declines to fillet outright — a free-boundary edge of an open shell — is
+  skipped by all five edge-list fillet entry points alike; a batch in which every edge is declined
+  returns `nil` (#612).
 
 ---
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -283,13 +283,35 @@ public func filletEvolving(_ edges: [EvolvingFilletEdge]) -> Shape?
   `edgeIndex` naming no edge of this shape returns `nil` rather than filleting the rest, and so
   does a non-positive radius, a parameter outside `0...1`, a non-increasing parameter sequence, or
   an empty `radiusPoints` (#520).
-- **OCCT:** `BRepFilletAPI_MakeFillet` with evolving law (via `OCCTShapeFilletEvolving`).
+- **Contours and slots:** each edge's law is applied to that edge's own slot within its own contour.
+  OCCT groups tangent-continuous edges into a single contour, but a contour holds one law *per
+  edge*, so two edges of one tangent chain can each carry a different law. An edge OCCT declines to
+  fillet (a free-boundary edge of an open shell) is skipped, matching
+  [`blendedEdges(_:)`](#blendededges_); a request in which it declines every edge returns `nil`.
+  Naming the same edge twice writes its slot twice and the later law wins (#612).
+- **OCCT:** `BRepFilletAPI_MakeFillet` with evolving law (via `OCCTShapeFilletEvolving`), with the
+  contour and the index within it resolved per edge by `Contour(E)` / `NbEdges(IC)` / `Edge(IC, J)`.
 - **Example:**
   ```swift
   let spec = EvolvingFilletEdge(edge: box.edges()[0], radiusPoints: [(0.0, 1.0), (1.0, 3.0)])
   if let filled = box.filletEvolving([spec]) {
       print(filled.isValid)
   }
+
+  // A rounded slot — two straight sides joined by two semicircular ends, extruded. Its whole
+  // top rim is one tangent-continuous contour, and each edge of it still carries its own law.
+  let profile = Wire.join([
+      Wire.line(from: SIMD3(-10, -8, 0), to: SIMD3(10, -8, 0))!,
+      Wire.arc(start: SIMD3(10, -8, 0), midpoint: SIMD3(18, 0, 0), end: SIMD3(10, 8, 0))!,
+      Wire.line(from: SIMD3(10, 8, 0), to: SIMD3(-10, 8, 0))!,
+      Wire.arc(start: SIMD3(-10, 8, 0), midpoint: SIMD3(-18, 0, 0), end: SIMD3(-10, -8, 0))!,
+  ])!
+  let slot = Shape.face(from: profile)!.extruded(by: SIMD3(0, 0, 20))!
+  let rim = slot.edges()
+  slot.filletEvolving([
+      EvolvingFilletEdge(edge: rim[3], radiusPoints: [(0.0, 1.0), (1.0, 3.0)]),
+      EvolvingFilletEdge(edge: rim[6], radiusPoints: [(0.0, 5.0), (1.0, 5.0)]),
+  ])
   ```
 
 ---


### PR DESCRIPTION
Closes #612

## The defect

The radius-law fillet entry points wrote every law to `SetRadius(law, NbContours(), 1)`. **Both coordinates were wrong, independently.**

### The contour

`NbContours()` is "the contour that exists after the most recent `Add`", which is the edge's own contour only when every `Add` *creates* one. A tangent-continuous edge **extends** an existing contour instead. Measured on a rounded-slot prism (two straight sides joined by two semicircular ends, extruded 20mm), adding a top-rim edge, a bottom-rim edge, then a second top-rim edge:

| after | `NbContours()` | `Contour(edge)` |
|---|---|---|
| add top-rim edge | 1 | 1 |
| add bottom-rim edge | 2 | 2 |
| add second top-rim edge | 2 | **1** |

The third edge's law was written to contour 2, replacing the bottom rim's own.

### The slot

`SetRadius`'s third argument, `IinC`, is the edge's index **within** the contour and selects a distinct per-edge slot. Hardcoding it to `1` sent every edge of a tangent chain to one slot, so only the last survived.

`Add(Radius, E)` — which backs `blendedEdges` — resolves that slot itself, so **it already honoured the very request `filletEvolving` could not express.** There was never a "one law per contour" limit; the apparent conflict was an artefact of our own hardcoded `1`.

## Measured, before and after

| request | before | after |
|---|---|---|
| top rim 2mm + bottom rim 5mm + a third top-rim edge | **10271.088459** — byte-identical to filleting *both* rims at 2mm | **9899.533264** (intended) |
| slot rim straight side 2mm + tangent arc 5mm | **9974.608333** — the arc's 5 overwrote the line's 2 | **10139.793468** — both honoured, byte-identical to `blendedEdges` |
| #612's own taper 1→3 + constant 5 | the constant applied to both | **10171.225408** |
| linear, two tangent edges at 1 → 4 | **10273.238348** — exactly filleting the first alone | **10297.711861** |

The per-slot effect on a single edge, for reference: a 1 → 4 taper measures 10273.238348 / 10297.711861 / 10343.333856 / 10402.168644 at `IinC` 1/2/3/4.

## Two things I got wrong in earlier rounds, both corrected

1. **I first shipped a *refusal*** — `filletEvolving` returning `nil` for two edges of one contour with different laws — justified by "OCCT holds one law per contour". That premise was false, and the measurement above disproves it. The refusal, its `OCCTFilletContourLaws` machinery and its `SEMVER.md` recorded exception are all gone; `docs/SEMVER.md` is byte-identical to base.

2. **I claimed the linear entry point was "never observably wrong"** and that its test "cannot fail under injection". Both false — I had only tested a *constant* law, where every slot holds the same number. With a genuine taper it is plainly wrong, as the table shows, and its test does fail under injection.

## A real crash, fixed

`filletedVariable` on an edge OCCT declines did not merely pick a wrong index — it **SIGSEGV'd**. A declined edge leaves `Contour(E) == 0` and `NbContours() == 0`, so the call became `SetRadius(law, 0, 1)`: the unchecked *low* side of the contour index that #505 measured. Uncatchable, so no `catch(...)` on the bridge side helps.

(A *literal* `1` is bounds-checked upstream even with zero contours, which is why the sibling `OCCTShapeHistoryFromFilletEdgeVariable` was safe — verified, then converted anyway so the idiom is gone.)

## Declined edges are skipped, and the family agrees

An open shell (box less one face) has 4 of its 12 edges declined by `Add()`. Skipping them makes the law paths agree with `Add(Radius, E)` **to the digit — surface area `465.09733552923257`** across all six entry points: `filleted(edges:radius:)`, `blendedEdges(_:)`, `filleted(edges:startRadius:endRadius:)`, `filletEvolving(_:)`, `filletedVariable` and `filletedWithFullHistory(radius:edges:)`. A batch in which *every* edge is declined leaves zero contours and fails in `Build()`, so it still returns `nil` rather than the unfilleted input.

> **Measure an open shell by area, not volume.** It is not a solid, so `VolumeProperties` fabricates a number for it (the #605/#609 defect class) — and that number is not even a property of the shape: it ranges 746.83 to 748.28 depending on which face is dropped, while the area is 465.097 for all six. An earlier revision of this PR cited `748.283182` as the agreement figure; that was exactly this trap, and it is corrected in both the bridge comment and the changelog.

I deliberately did **not** make all the entry points *reject* a declined edge. Two of them have always skipped, by construction — they go through `Add(Radius, E)`, which declines silently — so converging on reject would change `filleted(edges:radius:)` on every open shell. That is wider than #612 and is tracked separately as #639.

## Simplification

`OCCTShapeFilletEdgesLinear` now uses OCCT's one-call `Add(R1, R2, E)` rather than a hand-rolled `Add(E)` + slot scan + `SetRadius`. Verified identical on the slot rim for the pair (10297.711860842), the straight side alone (10273.238347801) and the arc alone (10276.405613964).

## Inject-the-bug proof

**Injection A** — restore `(NbContours(), 1)` at both sites: **4 of 8 tests fail, 9 issues.**

```
bothLawsOnOneContourAreHonoured:  |evolving - blended| → 165.18513533517216   (lands on 9974.608333, Δ 9.5e-08)
linearFilletPlacesEachEdgesLaw:   |pairVolume - lineVolume| → 0.0             (the arc's law lost)
taperAndConstantOnOneContour:     |volume - flat| → 0.0                       (the taper lost)
lawLandsOnTheEdgesOwnContour:     |actual - intended| → 371.5551946745254, |actual - clobbered| → 0.0
```

**Injection B** — additionally drop the slot guard, the true pre-#612 line: `swift test` **exits with signal 11**.

Both reverted; 8/8 green. Re-run after the `Add(R1, R2, E)` simplification: same 4 failures, same 9 issues.

## Tests

`Tests/OCCTModelingTests/Issue612FilletContourSelectionTests.swift` — 8 tests, asserting on measured geometry against independently-computed references (`blendedEdges` is the oracle for the two-law case). Rim edges are discovered geometrically, not by hardcoded index.

- Full suite: **5240 tests, all pass**
- `swift build` clean; `check-null-handle-guards.py` and `check-bridge-index.py` both clean
- Built with `OCCTSWIFT_BRIDGE_PREBUILT` unset throughout, so the `.mm` edits actually compiled

## Docs

`docs/CHANGELOG.md` (Unreleased, no invented version), `docs/reference/Shape-Measurement.md`, `docs/reference/Shape-Features.md`, the `///` comment on `filletEvolving(_:)` and two bridge-header contracts. The linear-fillet reference also had a pre-existing inaccuracy corrected: it described the law as varying "at the start of each **edge**", where the law goes in the named edge's slot and the contour's radius is the interpolation across its slots.

Rebased onto `origin/refactor/381-pass1b` at #632 (#615). Red macOS CI is the pre-existing branch-wide kernel-patch gap (#585).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
