### PR TITLE
fix(#624): the index gate was reporting seven correct entries, because it could not read a template helper

### DIFF
--- a/Scripts/check-bridge-index.py
+++ b/Scripts/check-bridge-index.py
@@ -48,7 +48,9 @@ indirectly" fails on correct entries and gets switched off.
 2. **Helper indirection** — `TDataStd_NamedData` is reached only through two lowercase
    `static` helpers, so no `OCCT`-prefixed function body names it. A function reaches
    what its file-local helpers (and the shared `OCCTBridge_Internal.h` ones) reach.
-   This is the near-miss that almost got the entry wrongly deleted in #510.
+   This is the near-miss that almost got the entry wrongly deleted in #510. The helper
+   may be a `template <class T>` one, which has to be parsed as a function and not as a
+   definition of a class called `T` — see `without_template_head` (#624).
 3. **Static facades** — `ShapeCustom::SweptToElementary` is how the bridge reaches
    `ShapeCustom_SweptToElementary`; the worker class is never named. A `Foo::Bar` call
    counts as naming `Foo_Bar`. (Facades with no worker class of their own, such as
@@ -89,6 +91,7 @@ VIA = re.compile(r'\(via ([A-Za-z0-9_]+)')
 IDENT = re.compile(r'\b[A-Za-z_][A-Za-z0-9_]*\b')
 SCOPED = re.compile(r'\b([A-Za-z_][A-Za-z0-9_]*)::([A-Za-z_][A-Za-z0-9_]*)')
 AGGREGATE = re.compile(r'\b(?:struct|class|union|namespace|enum)\s')
+TEMPLATE_HEAD = re.compile(r'\btemplate\s*<')
 WORD = re.compile(r'[A-Z][a-z0-9]*|\d+')
 
 
@@ -187,6 +190,39 @@ def strip_noise(text):
     return re.sub(r'^\s*#[^\n]*', '', text, flags=re.M)
 
 
+def without_template_head(sig):
+    """`template <class TheAdaptor>` introduces a parameter, not a class definition.
+
+    The `class` in a template head otherwise satisfies AGGREGATE below, so every one of
+    the bridge's `template <class TheAdaptor>` helpers was filed as a *type* named
+    `TheAdaptor` rather than as the function it is — and a type is only ever reached by a
+    function that names it, which none do. That silently cut the helper-indirection chain
+    at its first template link: `OCCTCurve3DGetLength` reaches `GCPnts_AbscissaPoint`
+    through `occtAdaptorArcLength -> occtArcConvergedLength -> occtArcQuadrature`, all
+    three of them templates, so the class looked unreached and all seven symbols on the
+    `GCPnts_AbscissaPoint` line were reported misfiled when the line was correct (#624).
+    The tell was that `OCCTBridge_Modeling.mm`'s one `template <typename BoolOpT>` helper
+    parsed fine: `typename` is not in AGGREGATE, `class` is.
+    """
+    out, i = [], 0
+    while True:
+        m = TEMPLATE_HEAD.search(sig, i)
+        if not m:
+            return ''.join(out) + sig[i:]
+        out.append(sig[i:m.start()])
+        depth, j = 0, m.end() - 1
+        while j < len(sig):
+            if sig[j] == '<':
+                depth += 1
+            elif sig[j] == '>':
+                depth -= 1
+                if depth == 0:
+                    j += 1
+                    break
+            j += 1
+        i = j
+
+
 def definitions(path):
     """(kind, name, names-it-reaches) for every brace-balanced definition at file scope."""
     with open(path, errors='replace') as f:
@@ -205,12 +241,14 @@ def definitions(path):
                 names = set(IDENT.findall(sig)) | set(IDENT.findall(body))
                 # a `Foo::Bar` call is how the bridge reaches worker class `Foo_Bar`
                 names |= {f'{a}_{b}' for a, b in SCOPED.findall(body)}
-                if AGGREGATE.search(sig):
-                    m = re.search(r'\b(?:struct|class|union)\s+(\w+)', sig)
+                # classified on the declaration proper: a template head is not a definition
+                decl = without_template_head(sig)
+                if AGGREGATE.search(decl):
+                    m = re.search(r'\b(?:struct|class|union)\s+(\w+)', decl)
                     if m:
                         out.append(('type', m.group(1), names))
                 else:
-                    m = list(re.finditer(r'\b([A-Za-z_][A-Za-z0-9_]*)\s*\(', sig))
+                    m = list(re.finditer(r'\b([A-Za-z_][A-Za-z0-9_]*)\s*\(', decl))
                     if m:
                         out.append(('fn', m[-1].group(1), names))
                 start, sig_start = None, i + 1
@@ -337,6 +375,12 @@ SELF_TEST = [
 
 # Each case is an entry filed under the wrong class — the four shapes #565 found. Every
 # one names a symbol that exists, so the existence check above calls them all clean.
+#
+# The last case is the one that makes this per-SYMBOL rather than per-entry, and it is not
+# redundant: the first four each name a single symbol, so an entry-level rule ("at least one
+# of these reaches the class") passes all four and the whole suite still reported 16/16 with
+# the regression `misfiled_entries` warns against injected. Its third field pins which symbol
+# must be named, so a rule that flags the entry but blames the wrong symbol fails too (#624).
 DIRECTION_TEST = [
     ('symbol drives a neighbouring class', [
         '// BOPAlgo_CellsBuilder                → OCCTBOPAlgoSplit']),
@@ -346,6 +390,9 @@ DIRECTION_TEST = [
         '// LProp_AnalyticCurInf                → OCCTLPropAnalyticCurInf']),
     ('class name is one letter off', [
         '// Law_Interpol                        → OCCTLawInterpolate']),
+    ('one wrong symbol among correct neighbours', [
+        '// GCPnts_AbscissaPoint                → OCCTCurve3DGetLength*, OCCTBOPAlgoSplit'],
+        'OCCTBOPAlgoSplit'),
 ]
 
 # The four indirection forms, plus the two shapes carrying an explicit exemption. A
@@ -356,6 +403,13 @@ INDIRECTION_TEST = [
         '// XCAFDoc_ShapeTool                   → OCCTDocumentAddShape']),
     ('lowercase static helper', [
         '// TDataStd_NamedData                  → OCCTDocumentNamedData*']),
+    # The helper case above is a plain `inline`; this one is reached only through a chain of
+    # `template <class TheAdaptor>` helpers, which is a different parse. All seven symbols on
+    # this line were reported misfiled until #624 stopped a template head from being read as a
+    # `class` definition — the entry was correct the whole time.
+    ('template static helper', [
+        '// GCPnts_AbscissaPoint                → OCCTCurve3DGetLength*, OCCTEdgeParameterAt*,',
+        '//                                       OCCTWireGetLength']),
     ('static facade', [
         '// ShapeCustom_SweptToElementary       → OCCTShapeSweptToElementary']),
     ('multi-class heading', [
@@ -377,11 +431,13 @@ def self_test(known, reach):
         failed += not flagged
         print(f'  {"ok  " if flagged else "MISS"} stale, {name}: '
               f'{", ".join(flagged) or "injected name not reported"}')
-    for name, lines in DIRECTION_TEST:
+    for name, lines, *expected in DIRECTION_TEST:
         flagged = misfiled_entries(index_entries(lines), reach)
+        if expected:  # the entry must be flagged *on this symbol*, not merely flagged
+            flagged = [f for f in flagged if f[2] == expected[0]]
         failed += not flagged
         print(f'  {"ok  " if flagged else "MISS"} misfiled, {name}: '
-              f'{flagged[0][1] if flagged else "mis-attribution not reported"}')
+              f'{flagged[0][1] + " → " + flagged[0][2] if flagged else "mis-attribution not reported"}')
     for name, lines in INDIRECTION_TEST:
         flagged = misfiled_entries(index_entries(lines), reach)
         failed += bool(flagged)

--- a/Scripts/check-bridge-index.py
+++ b/Scripts/check-bridge-index.py
@@ -248,6 +248,9 @@ def definitions(path):
                     if m:
                         out.append(('type', m.group(1), names))
                 else:
+                    # the last `ident(` in a declaration is its name for everything the bridge
+                    # currently declares; a function-pointer or trailing-return parameter would
+                    # put a different identifier last and mis-name the function
                     m = list(re.finditer(r'\b([A-Za-z_][A-Za-z0-9_]*)\s*\(', decl))
                     if m:
                         out.append(('fn', m[-1].group(1), names))

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -279,8 +279,10 @@
 //                                       (three further spellings were deleted by #506/#549; their
 //                                       tombstones sit at the old declaration sites. None of the
 //                                       seven names the class any more: since #603 they all reach
-//                                       it through the shared occtArcQuadrature /
-//                                       occtArcWalkToLength helpers, so grep those, not the class)
+//                                       it through the shared helpers, so grep those, not the
+//                                       class. Three sites construct it: occtArcQuadrature's
+//                                       single-span branch, occtArcWalkToLength's final piece,
+//                                       and occtAdaptorParameterAtLength's fallback solver)
 // CPnts_AbscissaPoint                 → the same functions, as occtArcQuadrature's per-span integrator on composite curves (#603)
 // GCPnts_QuasiUniformAbscissa         → OCCTCurve3DQuasiUniformAbscissa, OCCTGCPntsQuasiUniform
 // GCPnts_QuasiUniformDeflection       → OCCTCurve3DQuasiUniformDeflection

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -277,7 +277,10 @@
 //                                       OCCTCurve2DGetLength*, OCCTCurve2DParameterAtLength,
 //                                       OCCTEdgeArcLength*, OCCTEdgeParameterAt*, OCCTWireGetLength
 //                                       (three further spellings were deleted by #506/#549; their
-//                                       tombstones sit at the old declaration sites)
+//                                       tombstones sit at the old declaration sites. None of the
+//                                       seven names the class any more: since #603 they all reach
+//                                       it through the shared occtArcQuadrature /
+//                                       occtArcWalkToLength helpers, so grep those, not the class)
 // CPnts_AbscissaPoint                 → the same functions, as occtArcQuadrature's per-span integrator on composite curves (#603)
 // GCPnts_QuasiUniformAbscissa         → OCCTCurve3DQuasiUniformAbscissa, OCCTGCPntsQuasiUniform
 // GCPnts_QuasiUniformDeflection       → OCCTCurve3DQuasiUniformDeflection

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,12 +44,35 @@ said, on the `CPnts_AbscissaPoint` line directly beneath.
 
 The defect was the checker's. It classifies each brace-balanced definition by searching its
 signature for `struct|class|union|namespace|enum`, and a `template <class TheAdaptor>` head
-satisfies that: all nine of the shared arc-length helpers were filed as a *type* named `TheAdaptor`
-instead of as functions. A type is only ever reached by a function that names it, and none do, so
-the helper-indirection chain was cut at its first template link and the class looked unreached. The
-tell was that `OCCTBridge_Modeling.mm`'s one `template <typename BoolOpT>` helper parsed correctly:
-`typename` is not in that alternation, `class` is. `without_template_head` now strips the head
-before classification; a `template <class T> struct Foo` is still read as a type.
+satisfies that, so the helper was filed as a *type* named `TheAdaptor` instead of as a function. A
+type is only ever reached by a function that names it, and none do, so the helper-indirection chain
+was cut at its first template link and the class looked unreached. The tell was that
+`OCCTBridge_Modeling.mm`'s one `template <typename BoolOpT>` helper parsed correctly: `typename` is
+not in that alternation, `class` is. `without_template_head` now strips the head before
+classification; a `template <class T> struct Foo` is still read as a type.
+
+The nine arc-length helpers are what the misfiled entries pointed at, but they are not the whole of
+it. Every `template <class ...>` definition in the bridge was affected — **15** of them, filed under
+**6** bogus type names:
+
+| bogus type | count | helpers |
+|---|---|---|
+| `TheAdaptor` | 9 | `occtArcQuadrature`, `occtArcConvergedLength`, `occtArcIntervals`, `occtAdaptorArcLength`, `occtArcWalkToLength`, `occtAdaptorParameterAtLength`, `occtConfineToDomain`, `occtAdaptorWindsPeriodically`, `occtAdaptorLengthBetween` |
+| `AddEdge` | 2 | `occtFilletAddEdges`, `occtShapeFilletEdgeList` |
+| `T` | 1 | `occtWriteKnotSplits` |
+| `SplitIndexAt` | 1 | `occtWriteKnotSplitParams` |
+| `Use` | 1 | `occtUseSubShapesByIndex` |
+| `PointAt` | 1 | `occtFilletSetRadiusProfile` |
+
+Across the whole bridge, 34 `OCCT`-prefixed functions' reach sets change: 31 grow, and **3 shrink**.
+The shrinking direction is the one that is easy to miss — the old parser was also false-*widening*.
+`types['T']` was a real bucket holding everything `occtWriteKnotSplits` reaches, and the
+wrapper-type resolution step hands a function the contents of any type it names, so
+`OCCTGeomFillGuideTrihedronACD0`, `OCCTGeomFillGuideTrihedronPlanD0` and `OCCTWireGetCurvePointAt`
+each inherited that bucket purely for containing a local identifier `T`. Fifteen junk names apiece.
+No index verdict depended on any of this — the run went `0 stale, 7 misfiled` to `0 stale,
+0 misfiled` and nothing else moved — but a direction check is only as good as its reach sets, so the
+record should say what actually moved rather than only the part that was being complained about.
 
 No bridge or Swift source changed — the index entry was right, and the note added to it records
 that the seven reach the class through the helpers rather than by naming it, so the next reader

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,57 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### The index gate was reporting seven correct entries, because it could not read a template helper (#624)
+
+`Scripts/check-bridge-index.py` exited 1 with `0 stale, 7 misfiled`, every one of them on the
+`GCPnts_AbscissaPoint` line of `OCCTBridge.h`'s cross-reference index, and every one reported as
+`no bridge function reaches this class`. The reading that fits — #477, #549, #600 and #603 did
+progressively move arc-length measurement off `GCPnts_AbscissaPoint` — is that the entries had
+drifted and needed re-filing. They had not.
+
+Adjudicated per symbol, by reading each body and following the call path rather than the name:
+
+| symbol | call path | reaches |
+|---|---|---|
+| `OCCTCurve3DGetLength*` | `occtAdaptorArcLength` / `occtAdaptorLengthBetween` → `occtArcConvergedLength` → `occtArcQuadrature` | `GCPnts_AbscissaPoint::Length` |
+| `OCCTCurve3DParameterAtLength` | `occtAdaptorParameterAtLength` → `occtArcWalkToLength` | `GCPnts_AbscissaPoint` (constructed) |
+| `OCCTCurve2DGetLength*` | same helpers, `Geom2dAdaptor_Curve` | `GCPnts_AbscissaPoint::Length` |
+| `OCCTCurve2DParameterAtLength` | `occtAdaptorParameterAtLength` | `GCPnts_AbscissaPoint` (constructed) |
+| `OCCTEdgeArcLength*` | same helpers, `BRepAdaptor_Curve` | `GCPnts_AbscissaPoint::Length` |
+| `OCCTEdgeParameterAt*` | `occtAdaptorParameterAtLength` | `GCPnts_AbscissaPoint` (constructed) |
+| `OCCTWireGetLength` | same helpers, `BRepAdaptor_CompCurve` | `GCPnts_AbscissaPoint::Length` |
+
+All seven still reach the class. `occtArcQuadrature` (`OCCTBridge_Internal.h`) is
+`singleSpan ? GCPnts_AbscissaPoint::Length(...) : CPnts_AbscissaPoint::Length(...)`, so #603 added
+a second class to these functions rather than replacing the first — which is what the index already
+said, on the `CPnts_AbscissaPoint` line directly beneath.
+
+The defect was the checker's. It classifies each brace-balanced definition by searching its
+signature for `struct|class|union|namespace|enum`, and a `template <class TheAdaptor>` head
+satisfies that: all nine of the shared arc-length helpers were filed as a *type* named `TheAdaptor`
+instead of as functions. A type is only ever reached by a function that names it, and none do, so
+the helper-indirection chain was cut at its first template link and the class looked unreached. The
+tell was that `OCCTBridge_Modeling.mm`'s one `template <typename BoolOpT>` helper parsed correctly:
+`typename` is not in that alternation, `class` is. `without_template_head` now strips the head
+before classification; a `template <class T> struct Foo` is still read as a type.
+
+No bridge or Swift source changed — the index entry was right, and the note added to it records
+that the seven reach the class through the helpers rather than by naming it, so the next reader
+greps the right thing.
+
+Two holes in the script's own `--self-test`, both of which had to be closed for #625 to gate on it:
+
+- `DIRECTION_TEST` did prove the misfiled mode was caught, but all four of its cases named a single
+  symbol, so the entry-level rule `misfiled_entries` explicitly warns against — "at least one of
+  these reaches the class", which lets one wrong symbol hide behind correct neighbours — passed the
+  whole suite 16/16 when injected. A fifth case mixes a correct symbol with a wrong one and pins
+  which symbol must be blamed.
+- `INDIRECTION_TEST` covered the plain `inline` helper but not the template one, so nothing failed
+  when the parse above broke. A case for it now asserts the `GCPnts_AbscissaPoint` line stays clean.
+
+Both were verified by injecting the regression they describe and confirming 17/18. The suite is
+18/18 and the gate exits 0.
+
 #### A NaN parameter bound stops being a plausible arc length (#548)
 
 `Curve3D.length(from:to:)` documents itself as the entry point that tells failure apart from a real


### PR DESCRIPTION
Closes #624

`check-bridge-index.py` exited 1 with `0 stale, 7 misfiled`, every one on the `GCPnts_AbscissaPoint`
line of the index and every one reported as `no bridge function reaches this class`. The reading that
fits the history — #477, #549, #600 and #603 did progressively move arc-length measurement off that
class — is that the entries drifted and need re-filing. **They did not. All seven are correct, and the
checker was wrong about all seven.**

## Per-symbol verdicts

Adjudicated per symbol by reading each body and following the call path, not the name (#565's lesson;
`OCCTCurve3DGetLength` reaching something else is exactly what the name would lie about).

| symbol | call path | class it actually reaches | verdict |
|---|---|---|---|
| `OCCTCurve3DGetLength*` | `Curve3D.mm:661,675` → `occtAdaptorArcLength` / `occtAdaptorLengthBetween` → `occtArcConvergedLength` → `occtArcQuadrature` | `GCPnts_AbscissaPoint::Length` (`Internal.h:995`) | correct as filed |
| `OCCTCurve3DParameterAtLength` | `Curve3D.mm:4679` → `occtAdaptorParameterAtLength` → `occtArcWalkToLength` | `GCPnts_AbscissaPoint` constructed (`Internal.h:1108`, `:1128`) | correct as filed |
| `OCCTCurve2DGetLength*` | `Geom2d.mm:5524,5538` → same helpers, `Geom2dAdaptor_Curve` | `GCPnts_AbscissaPoint::Length` | correct as filed |
| `OCCTCurve2DParameterAtLength` | `Geom2d.mm:5997` → `occtAdaptorParameterAtLength` | `GCPnts_AbscissaPoint` constructed | correct as filed |
| `OCCTEdgeArcLength*` | `Topology.mm:3114,3128` → same helpers, `BRepAdaptor_Curve` | `GCPnts_AbscissaPoint::Length` | correct as filed |
| `OCCTEdgeParameterAt*` | `Topology.mm:3100,3142` → `occtAdaptorParameterAtLength` | `GCPnts_AbscissaPoint` constructed | correct as filed |
| `OCCTWireGetLength` | `Properties.mm:794` → same helpers, `BRepAdaptor_CompCurve` | `GCPnts_AbscissaPoint::Length` | correct as filed |

The load-bearing line is `occtArcQuadrature` (`OCCTBridge_Internal.h:994`):

```cpp
return singleSpan ? GCPnts_AbscissaPoint::Length(adaptor, lo, hi)
                  : CPnts_AbscissaPoint::Length(adaptor, lo, hi);
```

#603 **added** a second class to these functions rather than replacing the first. That is already what
the index says: the `CPnts_AbscissaPoint` line directly beneath reads "the same functions, as
occtArcQuadrature's per-span integrator on composite curves (#603)". Both lines were right.

## Was the checker itself wrong? Yes — about all seven (#573's lesson)

`definitions()` classifies each brace-balanced definition by searching its signature for
`struct|class|union|namespace|enum`. A `template <class TheAdaptor>` head satisfies that, so all nine
shared arc-length helpers were filed as a **type named `TheAdaptor`** instead of as the functions they
are. A type is only ever reached by a function that names it, and no bridge function writes
`TheAdaptor`, so the documented helper-indirection chain (form 2) was cut at its first template link.

Probed directly, before the fix:

```
--- how the arc-length helpers are parsed ---
    (nothing: none of the six is registered as a function)
--- 'TheAdaptor' registered as a type? ---
  ('type','TheAdaptor') count = 9
  does that bucket name GCPnts_AbscissaPoint? True
--- is ANY name in Internal.h's shared fn table an arc helper? ---
  occtAdaptorArcLength in shared fns: False
  occtValidParameterRange in shared fns: True      <- plain `inline`, parsed fine
```

The tell that pins the mechanism: `OCCTBridge_Modeling.mm:10483`'s `template <typename BoolOpT>` helper
parsed correctly all along. `typename` is not in that alternation; `class` is.

`without_template_head()` now strips the head before classification. A `template <class T> struct Foo`
is still read as a type.

## Before / after

Before:

```
723 index symbols across 383 OCCT classes
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTCurve3DGetLength*  (no bridge function reaches this class)
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTCurve3DParameterAtLength  (no bridge function reaches this class)
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTCurve2DGetLength*  (no bridge function reaches this class)
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTCurve2DParameterAtLength  (no bridge function reaches this class)
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTEdgeArcLength*  (no bridge function reaches this class)
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTEdgeParameterAt*  (no bridge function reaches this class)
  MISFILED Sources/OCCTBridge/include/OCCTBridge.h:276  GCPnts_AbscissaPoint → OCCTWireGetLength  (no bridge function reaches this class)
0 stale, 7 misfiled
exit=1
```

After:

```
723 index symbols across 383 OCCT classes
0 stale, 0 misfiled
exit=0
```

No other entry changed verdict.

## Does `--self-test` prove the MISFILED mode is caught?

**Yes — `DIRECTION_TEST`'s four cases already asserted it, so the answer to the issue's question is
that misfiled was covered, not only stale.** But it had two holes, and both are the reason this drifted
for four issues. Both are now filled, and each was verified by injecting the regression it describes.

1. **Per-symbol was untested.** All four `DIRECTION_TEST` cases named a *single* symbol. So the
   entry-level rule `misfiled_entries`' own docstring warns against — "at least one of these reaches
   the class", which lets one wrong symbol hide behind correct neighbours — passed the whole suite
   **16/16** when injected. This is #565's lesson unenforced by the test that exists to enforce it. New
   case mixes a correct symbol with a wrong one and pins *which* symbol must be blamed; with the
   entry-level rule injected it now reports `MISS ... 17/18`.
2. **Template helper indirection was untested.** `INDIRECTION_TEST` covered the plain `inline` helper
   (`TDataStd_NamedData`) but not the template one, so nothing failed when the parse above broke. New
   case asserts the `GCPnts_AbscissaPoint` line stays clean; with the fix reverted it reports
   `FALSE indirect, template static helper: GCPnts_AbscissaPoint wrongly reported ... 17/18`.

Suite is now **18/18**.

## Scope

No bridge or Swift source changed, as the issue predicted — three files: the checker, a note on the
index entry (recording that the seven reach the class through the helpers rather than by naming it, so
the next reader greps the right thing), and the changelog. The index note was itself caught by the gate
on first attempt: writing "OCCTBridge_Internal.h" in the aside made `OCCTBridge_Internal` parse as a
fabricated symbol and the run went `1 stale`. Rephrased.

## Verification

- `python3 Scripts/check-bridge-index.py` → `0 stale, 0 misfiled`, exit 0
- `python3 Scripts/check-bridge-index.py --self-test` → 18/18
- `python3 Scripts/check-null-handle-guards.py` (the sibling gate #625 also wires up) → exit 0
- `swift build` clean
- `swift test --filter Issue603` → 15 tests, suite "Arc length stops being one quadrature per span (#603)" passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Corrections after review (commit `3ad0e78`)

**Blast radius was understated.** The write-up framed it as the nine `template <class TheAdaptor>`
arc-length helpers, because those are what the misfiled entries pointed at. Measured properly, every
`template <class ...>` definition in the bridge was affected — **15**, under **6** bogus type names:

| bogus type | count | helpers |
|---|---|---|
| `TheAdaptor` | 9 | the arc-length family |
| `AddEdge` | 2 | `occtFilletAddEdges`, `occtShapeFilletEdgeList` |
| `T` | 1 | `occtWriteKnotSplits` |
| `SplitIndexAt` | 1 | `occtWriteKnotSplitParams` |
| `Use` | 1 | `occtUseSubShapesByIndex` |
| `PointAt` | 1 | `occtFilletSetRadiusProfile` |

**Reach-set movement, and the direction I did not mention at all.** 34 `OCCT`-prefixed bridge
functions change: **31 grow, 3 shrink**. The old parser was also false-*widening*: `types['T']` was a
real bucket, and the wrapper-type resolution step hands a function the contents of any type it names,
so `OCCTGeomFillGuideTrihedronACD0`, `OCCTGeomFillGuideTrihedronPlanD0` and `OCCTWireGetCurvePointAt`
each inherited 15 junk names purely for containing a local identifier `T`.

One arithmetic correction to the review: grew is **31**, not 33 — 33 + 3 = 36, whereas the reviewer's
own total of 34 is right and matches 31 + 3. Their 15, their 6 type names and their 3 shrinking all
reproduce exactly. (Counting all parsed definitions including the lowercase helpers it is 51 / 48 / 3;
restricted to `OCCT`-prefixed bridge functions it is 34 / 31 / 3.)

**Index pointer completed.** `OCCTBridge.h` pointed at `occtArcQuadrature` / `occtArcWalkToLength`,
which is 2 of the 3 sites constructing `GCPnts_AbscissaPoint`; `occtAdaptorParameterAtLength`'s
fallback solver (`OCCTBridge_Internal.h:1128`) is the third and is now named.

Also left a one-line note next to the `m[-1]` function-name heuristic saying what would break it.

Gate still `0 stale, 0 misfiled`; self-test still 18/18.
