### PR TITLE
fix(#615): the nearest point on a curve, for the entry points #539 left behind and the whole 2D side

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -352,6 +352,12 @@
 // Geom2dAPI_ProjectPointOnCurve       → OCCTCurve2DProjectPoint, OCCTCurve2DProjectPointAll,
 //                                       OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve,
 //                                       OCCTCurve2DNearestParameter
+//                                       (all but OCCTCurve2DProjectPointAll only as one of the two
+//                                       candidate sources occtNearestPointOnCurve2dRange takes a
+//                                       minimum over, the other being the curve's own two ends;
+//                                       there is no 2D ShapeAnalysis_Curve to be the third, see
+//                                       #615. OCCTCurve2DProjectPointAll wants the extrema
+//                                       themselves and constructs its own)
 //
 // --- Geom2dGcc ---
 // Geom2dGcc_Circ2d2TanOn              → OCCTGeom2dGccCirc2d2TanOn*
@@ -383,10 +389,14 @@
 //                                       OCCTExtremaPointCurve, OCCTProjOnCurve*,
 //                                       OCCTEdgeProjectPoint, OCCTCurve3DProjectPoint,
 //                                       OCCTBRepExtremaExtPC
-//                                       (the last three only as one of the three candidate sources
+//                                       (all but OCCTExtremaPointCurve and OCCTProjOnCurve* only as
+//                                       one of the three candidate sources
 //                                       occtNearestPointOnCurveRange takes a minimum over; see
-//                                       ShapeAnalysis_Curve for the other, and #539 for why
-//                                       neither class answers correctly on its own)
+//                                       ShapeAnalysis_Curve for the second, the curve's own two
+//                                       ends for the third, and #539 for why neither class answers
+//                                       correctly on its own. OCCTExtremaLocateOnCurve reaches it
+//                                       only through its full-range fallback -- its primary local
+//                                       window search is a bare GeomAPI extremum by design, #615)
 // GeomAPI_ProjectPointOnSurf          → OCCTSurfaceProjectPoint, OCCTFaceProject*
 //
 // --- GeomConvert ---
@@ -2697,8 +2707,11 @@ typedef struct {
 
 /// Project a point onto a curve, nearest solution only.
 /// @return Projection with `distance >= 0` on success; on failure `distance` is -1 and the
-///         other fields are zeroed. A curve can legitimately have no projection for a point
-///         (one beyond the ends of a bounded curve, or a circle's centre).
+///         other fields are zeroed. The answer is the nearest point over the curve's own range,
+///         ends included, so a point with no perpendicular foot (one beyond the ends of a bounded
+///         curve, or a circle's centre) is answered rather than refused; -1 means there was no
+///         curve to answer about (#615). OCCTCurve2DProjectPointAll asks for the extrema instead,
+///         and still reports none for those points.
 OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef curve, double px, double py);
 /// Project a point onto a curve, all local-minimum solutions.
 /// @return Number of solutions written to `out` (0 if there are none).
@@ -9044,9 +9057,10 @@ OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref,
 OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
     double ox, double oy, double dx, double dy);
 /// Distance from point to curve
-/// @return Minimum distance, or -1 when the point has no projection onto the curve (one beyond
-///         the ends of a bounded curve, or a circle's centre). Swift's Point2D.distance(to:)
-///         maps that to .infinity.
+/// @return Minimum distance over the curve's own range, ends included, so a point with no
+///         perpendicular foot (one beyond the ends of a bounded curve, or a circle's centre) is
+///         measured rather than refused (#615). -1 means there was no curve to measure to; Swift's
+///         Point2D.distance(to:) maps that to .infinity.
 double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve);
 /// Apply a Transform2D to a point, returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
@@ -9157,7 +9171,9 @@ OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1
     OCCTPoint2DRef _Nonnull p2);
 
 /// Project a Point2D onto a Curve2D, returns parameter at closest point
-/// @param outDistance Output: minimum distance, or -1 on failure — this is the failure signal
+/// @param outDistance Output: minimum distance, or -1 on failure — this is the failure signal.
+///         Since #615 failure means only "no curve": the nearest point is taken over the curve's
+///         own range, ends included, so a point with no perpendicular foot is answered.
 /// @return parameter on curve, or NaN on failure. Do NOT test the return value against 0: 0 is a
 ///         legitimate parameter on any curve whose domain includes it (projecting a segment's own
 ///         start point onto it returns exactly 0). Test `outDistance < 0` instead.
@@ -16947,11 +16963,15 @@ int32_t OCCTCurve3DCurveType(OCCTCurve3DRef _Nonnull curve);
 
 /// Find the parameter on a 3D curve nearest to a 3D point, over the curve's whole range.
 ///
-/// Returns false and leaves *outParameter untouched when the point has no projection at all:
-/// one beyond the ends of a bounded curve, or a circle's centre. That is an ordinary outcome, not
-/// an error, and it cannot be signalled through the parameter: every double is a legitimate
-/// parameter on some curve. Replaces OCCTCurve3DParameterAtPoint and OCCTCurve3DClosestParameter,
-/// which ran the identical projection and disagreed about the no-projection case (#500).
+/// The nearest point over the curve's own range, ends included, not the nearest perpendicular
+/// foot: a point beyond the end of a bounded curve is nearest to that end, and a circle's centre
+/// is equidistant from every point on it, so both are answered (#615). Agrees exactly with
+/// OCCTCurve3DProjectPoint, which shares occtNearestPointOnCurveRange with it.
+///
+/// Returns false and leaves *outParameter untouched only when there is no curve to answer about.
+/// Failure cannot be signalled through the parameter: every double is a legitimate parameter on
+/// some curve. Replaces OCCTCurve3DParameterAtPoint and OCCTCurve3DClosestParameter, which ran the
+/// identical projection and disagreed about how to report its absence (#500).
 bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve, double x, double y, double z,
                                  double* _Nonnull outParameter);
 
@@ -16962,8 +16982,12 @@ int32_t OCCTCurve2DCurveType(OCCTCurve2DRef _Nonnull curve);
 
 /// Find the parameter on a 2D curve nearest to a 2D point, over the curve's whole range.
 ///
-/// Returns false and leaves *outParameter untouched when the point has no projection at all,
-/// on the same contract as the other Geom2dAPI_ProjectPointOnCurve entry points (#413, #500).
+/// The nearest point over the curve's own range, ends included, not the nearest perpendicular
+/// foot, on the same contract as the other three 2D nearest-point entry points it shares
+/// occtNearestPointOnCurve2dRange with: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D and
+/// OCCTPoint2DDistanceToCurve (#413, #500, #615).
+///
+/// Returns false and leaves *outParameter untouched only when there is no curve to answer about.
 /// Replaces OCCTCurve2DParameterAtPoint, which reported that case as FirstParameter().
 bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve, double x, double y,
                                  double* _Nonnull outParameter);
@@ -16975,7 +16999,17 @@ int32_t OCCTSurfaceGetType(OCCTSurfaceRef _Nonnull surface);
 
 // --- Extrema extras ---
 
-/// Local point-on-curve search from initial parameter guess.
+/// Local point-on-curve search from an initial parameter guess.
+///
+/// Two searches with two different contracts. The PRIMARY one reports the LOWEST-DISTANCE extremum
+/// within a window of +/-10% of the domain around the guess: initParam bounds the window, it does
+/// not rank what is found inside it, so the extremum returned need not be the one nearest the guess.
+/// The window is what makes the answer local, and a windowed minimum can still be a global MAXIMUM.
+/// The FALLBACK, which fires only when that window holds no extremum, searches the whole curve and
+/// reports its true nearest point, agreeing with OCCTCurve3DNearestParameter (#615). Callers wanting
+/// the global answer should use that instead.
+///
+/// Returns false only when there is no curve to answer about.
 bool OCCTExtremaLocateOnCurve(OCCTCurve3DRef _Nonnull curve,
                               double px, double py, double pz,
                               double initParam, double tol,

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -4209,53 +4209,106 @@ int32_t OCCTCurve3DCurveType(OCCTCurve3DRef curve) {
     } catch (...) { return 7; }
 }
 
-// The 3D counterpart of OCCTBridge_Geom2d.mm's occtNearestProjectionOnCurve2d, which #413 gave the
-// 2D side and #500 found the 3D side had never had: one GeomAPI_ProjectPointOnCurve construction
-// behind every entry point that wants the nearest solution over the curve's whole range:
-// OCCTCurve3DNearestParameter and OCCTExtremaLocateOnCurve's full-range fallback.
+// One nearest-point answer behind every entry point that wants the nearest solution over the curve's
+// whole range: OCCTCurve3DNearestParameter and OCCTExtremaLocateOnCurve's full-range fallback.
 //
-// Returns false when there is no projection at all, an ordinary outcome rather than an error: a point
-// beyond the ends of a bounded curve, or the centre of a circle, has no extremum. Failure may not
-// be reported through the parameter, since every double is a legitimate parameter on some curve.
+// #500 unified them onto a single GeomAPI_ProjectPointOnCurve construction. #615 makes that
+// construction the RIGHT one: GeomAPI reports extrema, not minima, so LowerDistance is not the
+// nearest point and NbPoints() == 0 is not "no nearest point". Measured on the geometry #539 named,
+// a half circle of radius 5 queried from (0, -6, 0): this reported the far side of the arc, 11 away,
+// where OCCTCurve3DProjectPoint -- converted by #539, same promise, same curve, same point --
+// reported the true nearest at 7.81; and on a segment trimmed to [3, 8] queried at (100, 0, 0) it
+// reported nothing at all where the converted sibling reported the segment's own end, 92 away. So
+// the two spellings disagreed about which point is nearest AND about whether there is one.
 //
-// Not routed through here, and why: OCCTExtremaLocateOnCurve's primary search and
-// OCCTEdgeProjectPoint (OCCTBridge_Properties.mm) pass an explicit parameter window;
-// OCCTExtremaPointCurve and OCCTProjOnCurve* need every extremum, not the nearest;
-// OCCTCurve3DProjectPoint runs ShapeAnalysis_Curve::Project, a different algorithm with a
-// different contract, adjusting to the curve ends rather than reporting no projection.
+// Both are now the same answer because both are now the same helper. See
+// occtNearestPointOnCurveRange (OCCTBridge_Internal.h) for what each of its three candidate sources
+// contributes and why none of them suffices alone.
+//
+// CONSEQUENCE, and it is the point rather than a side effect: this no longer returns false for a
+// point with no perpendicular foot. A point beyond the end of a bounded curve is nearest to that
+// end, and a circle's centre is equidistant from every point on it, so both now answer -- with a
+// real parameter and a true distance. False is left meaning what it means for the converted
+// siblings: no curve to answer about. Precision::Confusion() is the projection precision, matching
+// the two converted entry points that likewise take none from their caller:
+// OCCTEdgeProjectPoint (OCCTBridge_Properties.mm) and OCCTBRepExtremaExtPC
+// (OCCTBridge_Topology.mm). Nothing in THIS file set that precedent -- OCCTCurve3DProjectPoint,
+// the only other local caller of the helper, is handed a precision by its own caller.
+//
+// Not routed through here, and why: OCCTExtremaLocateOnCurve's PRIMARY search deliberately reports
+// a windowed extremum near a caller-supplied guess (see there, and note that "near" is the window,
+// not a ranking); OCCTExtremaPointCurve and OCCTProjOnCurve* need every extremum, not the nearest;
+// OCCTEdgeProjectPoint (OCCTBridge_Properties.mm) reaches the same shared helper by its own route,
+// from BRep_Tool::Curve's range rather than a Geom_Curve's.
 static bool occtNearestProjectionOnCurve3d(OCCTCurve3DRef curve, const gp_Pnt& point,
                                            gp_Pnt* outNearest, double* outParameter,
                                            double* outDistance) {
     if (!curve || curve->curve.IsNull()) return false;
     try {
-        GeomAPI_ProjectPointOnCurve proj(point, curve->curve);
-        if (proj.NbPoints() == 0) return false;
-        if (outNearest) *outNearest = proj.NearestPoint();
-        if (outParameter) *outParameter = proj.LowerDistanceParameter();
-        if (outDistance) *outDistance = proj.LowerDistance();
-        return true;
+        return occtNearestPointOnCurveRange(curve->curve, point,
+                                            curve->curve->FirstParameter(),
+                                            curve->curve->LastParameter(),
+                                            Precision::Confusion(),
+                                            outNearest, outParameter, outDistance);
     } catch (...) {
         return false;
     }
 }
 
-// Failure contract: returns false, leaving *outParameter untouched. This replaces two functions
-// that computed the identical projection and disagreed about how to report its absence:
-// OCCTCurve3DParameterAtPoint returned curve->FirstParameter(), OCCTCurve3DClosestParameter
-// returned 0, which is not even in the domain of a curve trimmed to, say, [3, 8] (#500).
+// Failure contract: returns false, leaving *outParameter untouched. That now means only "no curve":
+// every real curve has a nearest point to every point (#615). It used to also mean "no extremum",
+// which is why this replaced two functions that computed the identical projection and disagreed
+// about how to report its absence: OCCTCurve3DParameterAtPoint returned curve->FirstParameter(),
+// OCCTCurve3DClosestParameter returned 0, which is not even in the domain of a curve trimmed to,
+// say, [3, 8] (#500).
 bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve, double x, double y, double z,
                                  double* _Nonnull outParameter) {
     return occtNearestProjectionOnCurve3d(curve, gp_Pnt(x, y, z), nullptr, outParameter, nullptr);
 }
 // --- Extrema extras ---
 
+// Two searches, and #615 deliberately changed only the second of them.
+//
+// The PRIMARY search is local by RANGE, not by proximity: it reports the LOWEST-DISTANCE extremum
+// within a window of +/-10% of the domain around the guess. Note what initParam does and does not
+// buy -- it bounds the window, and nothing selects among the extrema inside it by how near the guess
+// they are, because the selection is GeomAPI_ProjectPointOnCurve::LowerDistanceParameter(). Measured
+// on a ramped sine BSpline, a guess of 90.9114 returns param 79.9751, 10.94 away from the guess, in
+// preference to an extremum 0.13 away at 91.0378, because the far one is the closer of the two to
+// the query POINT (10.07 against 15.19); 22 of 46 multi-extremum windows in that sweep behave so.
+//
+// The window is still what makes the answer local, and a windowed minimum can be a global MAXIMUM:
+// on a half circle of radius 5 queried from (0, -6, 0) with a guess of pi/2 this reports 11, the far
+// side. That is not the nearest point on the curve and is not claimed to be.
+//
+// Adding the window's two ends to that minimum -- the #539 recipe applied to [lo, hi] rather than to
+// the whole curve -- was considered and rejected, on two grounds, and NOT on the ground that it would
+// redefine initParam. It would not: the function already minimises over the window, so the ends are
+// the only thing the change adds. The grounds are (1) it does not make the function correct under its
+// own name, answering 10.865697905689686 on the arc above where the true nearest point is 7.81 away,
+// and (2) a window's ends always evaluate, so the minimum would always be found, and the fallback
+// below would become unreachable -- deleting the one path in this function that #615 fixes. Making
+// the search global outright would leave initParam meaning nothing at all and the function a
+// duplicate of OCCTCurve3DNearestParameter. So the primary search is left exactly as it was.
+//
+// The FALLBACK is a different matter, and was wrong. It fires precisely when the window contains no
+// extremum, at which point the function has already abandoned locality and searched the whole curve.
+// Having done that, it must give the whole curve's answer, which is the one
+// OCCTCurve3DNearestParameter gives -- and #615 is that those two disagreed. Measured before:
+// locateNearestPoint((0, -6, 0), initParam: 0) on that same half circle fell through to the fallback
+// and answered pi/2 at distance 11, a point diametrically opposite a guess that sat on the true
+// nearest point; and on a segment trimmed to [3, 8] queried at (100, 0, 0) it answered nil for every
+// guess, because no window and no full-range search contains a perpendicular foot. Both now answer
+// through the shared helper: 0 at 7.81, and 8 at 92.
 bool OCCTExtremaLocateOnCurve(OCCTCurve3DRef curve,
                               double px, double py, double pz,
                               double initParam, double tol,
                               double* param, double* distance) {
     if (!curve || curve->curve.IsNull()) return false;
     try {
-        // Use ProjectPointOnCurve in a narrow window around initParam for local search
+        // Local search: the lowest-distance extremum inside a narrow window around the guess.
+        // LowerDistanceParameter() below picks by distance to the query point, not by nearness to
+        // initParam -- the guess bounds the window, it does not rank what is found in it.
         double f = curve->curve->FirstParameter();
         double l = curve->curve->LastParameter();
         double range = (l - f) * 0.1;
@@ -4263,7 +4316,8 @@ bool OCCTExtremaLocateOnCurve(OCCTCurve3DRef curve,
         double hi = std::min(l, initParam + range);
         GeomAPI_ProjectPointOnCurve proj(gp_Pnt(px, py, pz), curve->curve, lo, hi);
         if (proj.NbPoints() < 1) {
-            // Fallback to full range
+            // No extremum near the guess: fall back to the whole curve, and to the whole curve's
+            // nearest point rather than to whichever extremum a full-range search turns up (#615).
             return occtNearestProjectionOnCurve3d(curve, gp_Pnt(px, py, pz), nullptr,
                                                   param, distance);
         }

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -161,31 +161,46 @@
 // radius-5 circle offset by -5 yields radius 0 and by -6 yields radius 1, so GC_MakeCircle2d takes
 // the absolute value rather than refusing an offset that passes through the centre.
 
-// One Geom2dAPI_ProjectPointOnCurve construction behind every entry point that wants the nearest
-// solution: OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve and
+// One nearest-point answer behind every 2D entry point that wants the nearest solution:
+// OCCTCurve2DProjectPoint, OCCTCurve2DProjectPoint2D, OCCTPoint2DDistanceToCurve and
 // OCCTCurve2DNearestParameter. They were four independent constructions of the same algorithm with
 // four different failure-signalling conventions bolted on separately (#413 unified the first
 // three, #500 the fourth). It also gives those that lacked one an explicit null-handle guard
 // rather than relying on catch(...) to absorb the dereference.
 //
-// Returns false when there is no projection at all — an ordinary outcome, not an error: a point
-// beyond the ends of a bounded curve, or the centre of a circle, has no extremum. Each caller
-// applies its own documented sentinel; none of them may report failure through the parameter,
+// #615 makes that one construction the RIGHT one, the treatment #539/#580 gave the 3D side and
+// never gave this one. Geom2dAPI_ProjectPointOnCurve reports extrema, not minima, so LowerDistance
+// is not the nearest point and NbPoints() == 0 is not "no nearest point". Measured, on the 2D twin
+// of the geometry #539 named: a half circle of radius 5 queried from (0, -6) reported the far side
+// of the arc at distance 11 where the truth is 7.81, and a point on the circle but off the arc,
+// (3, -4), reported 10 where the truth is 4.47; a segment trimmed to [3, 8] queried at (100, 0)
+// reported no projection at all where the truth is its own end, 92 away. Every 2D spelling was
+// wrong the same way, so they agreed with each other and with nothing else.
+//
+// See occtNearestPointOnCurve2dRange (OCCTBridge_Internal.h) for the candidate set, and for the one
+// source the 3D helper has that this one cannot: ShapeAnalysis_Curve has no 2D projection.
+//
+// CONSEQUENCE, and it is the point rather than a side effect: this no longer returns false for a
+// point with no perpendicular foot. A point beyond the end of a bounded curve is nearest to that
+// end, and a circle's centre is equidistant from every point on it, so both now answer -- with a
+// real parameter and a true distance. Each caller keeps its own documented sentinel for the case
+// that remains: no curve to answer about. None of them may report failure through the parameter,
 // since 0 is a legitimate parameter on any curve whose domain includes it.
 //
 // OCCTCurve2DProjectPointAll is the multi-solution sibling: it needs every extremum rather than
-// the nearest one, so it constructs its own and is not routed through here.
+// the nearest one, so it constructs its own and is not routed through here. It therefore still
+// reports nothing where these four now answer, and that is correct -- "the extrema" and "the
+// nearest point" have been different questions since #539, and on a bounded curve queried from
+// beyond its end the honest answer to the first one is that there are none.
 static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d& point,
                                             gp_Pnt2d* outNearest, double* outParameter,
                                             double* outDistance) {
     if (!curve || curve->curve.IsNull()) return false;
     try {
-        Geom2dAPI_ProjectPointOnCurve proj(point, curve->curve);
-        if (proj.NbPoints() == 0) return false;
-        if (outNearest) *outNearest = proj.NearestPoint();
-        if (outParameter) *outParameter = proj.LowerDistanceParameter();
-        if (outDistance) *outDistance = proj.LowerDistance();
-        return true;
+        return occtNearestPointOnCurve2dRange(curve->curve, point,
+                                              curve->curve->FirstParameter(),
+                                              curve->curve->LastParameter(),
+                                              outNearest, outParameter, outDistance);
     } catch (...) {
         return false;
     }

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1852,6 +1852,89 @@ inline bool occtNearestPointOnCurveRange(const occ::handle<Geom_Curve>& curve, c
     return true;
 }
 
+// === #615: the same question in 2D ===
+//
+// The twin of occtNearestPointOnCurveRange above, for every 2D entry point that promises the CLOSEST
+// point on a bounded curve. #539/#580 converted the 3D side and left this one reporting
+// Geom2dAPI_ProjectPointOnCurve::LowerDistance directly, so the 2D API was wrong in exactly the two
+// ways the 3D API used to be: a half circle of radius 5 queried from (0, -6) reported the FAR side at
+// distance 11 where the truth is 7.81, and a segment trimmed to [3, 8] queried at (100, 0) reported no
+// projection at all where the truth is its own end, 92 away.
+//
+// ONE candidate source is missing relative to the 3D helper, and it is missing from OCCT, not from
+// here: ShapeAnalysis_Curve has no 2D projection. Its Project overloads take Geom_Curve or
+// Adaptor3d_Curve only -- the Geom2d_Curve members of that class (FillBndBox, SelectForwardSeam,
+// GetSamplePoints, IsPeriodic) do something else entirely. So the 2D candidate set is the extrema
+// plus both ends, which is the "all extrema + the two ends" row #580 measured at 188/189 rather than
+// the 189/189 the 3D helper's third source buys. The one case that row misses is Extrema failing to
+// converge on a BSpline, where an end then wins by a fraction of a percent; there is no 2D-NATIVE
+// second algorithm to break that tie. (A Geom2d_Curve could in principle be lifted into the z = 0
+// plane and run through the 3D ShapeAnalysis_Curve. Not done: #580 measured extrema-plus-ends at
+// 188/189, so the lift would buy one case in 189 at the cost of a per-call curve conversion.)
+//
+// Everything else matches the 3D helper deliberately, including the treatment of infinite bounds and
+// of periodic bases; see its comment for why each choice is what it is.
+//
+// Returns false only when there is nothing to answer with: a null curve, or a curve on which every
+// candidate failed to evaluate. With no ShapeAnalysis fallback there is no "kept the analytic answer"
+// path, so an unbounded 2D curve with no extremum at all -- which no Geom2d type measured here
+// actually produces, since a line, parabola and hyperbola each always have a perpendicular foot --
+// would report false rather than a wrong answer.
+
+#include <Geom2dAPI_ProjectPointOnCurve.hxx>
+
+inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curve,
+                                           const gp_Pnt2d& point,
+                                           double first, double last,
+                                           gp_Pnt2d* outPoint, double* outParameter,
+                                           double* outDistance) {
+    if (curve.IsNull()) return false;
+
+    const bool firstFinite = !Precision::IsInfinite(first);
+    const bool lastFinite = !Precision::IsInfinite(last);
+
+    double bestParam = 0.0, bestDistance = RealLast();
+    gp_Pnt2d bestPoint;
+    bool found = false;
+
+    auto consider = [&](double param) {
+        if (firstFinite && param < first) return;
+        if (lastFinite && param > last) return;
+        gp_Pnt2d candidate;
+        try {
+            candidate = curve->Value(param);
+        } catch (...) {
+            return;
+        }
+        double distance = point.Distance(candidate);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestParam = param;
+            bestPoint = candidate;
+            found = true;
+        }
+    };
+
+    // 1. Every extremum inside the range, since the nearest one is not always the first.
+    try {
+        Geom2dAPI_ProjectPointOnCurve projector(point, curve, first, last);
+        for (int i = 1; i <= projector.NbPoints(); i++) consider(projector.Parameter(i));
+    } catch (...) {
+        // Leave it to the ends.
+    }
+
+    // 2. The ends, where they are real parameters rather than OCCT's infinity sentinel.
+    if (firstFinite) consider(first);
+    if (lastFinite) consider(last);
+
+    if (!found) return false;
+
+    if (outPoint) *outPoint = bestPoint;
+    if (outParameter) *outParameter = bestParam;
+    if (outDistance) *outDistance = bestDistance;
+    return true;
+}
+
 // === #496: the drilling preconditions, and one BRepFeat_MakeCylindricalHole skeleton ===
 //
 // OCCTSwift drills round holes two ways, and the audit read the older one as a crude

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -816,19 +816,28 @@ public final class Curve2D: @unchecked Sendable {
     /// Project a point onto this curve, returning the nearest projection.
     ///
     /// - Parameter p: Point to project.
-    /// - Returns: The nearest projection, or `nil` if the point has no projection onto this curve
-    ///     one beyond the ends of a bounded curve, or the centre of a circle.
+    /// - Returns: The nearest projection, or `nil` if there is no curve to answer about.
     ///
-    /// `project(_:)` (the `Point2D` overload) and `Point2D.distance(to:)` compute the same nearest
-    /// solution through the same shared bridge path, and agree on both the value and on when
-    /// there is no projection.
+    /// The answer is always inside this curve's own ``domain``, and always the true nearest point:
+    /// where the point has no perpendicular foot on the curve — anything past the end of a trimmed
+    /// curve, or off to one side of an arc — the nearest point is an end, and that is what comes
+    /// back. `project(_:)` (the `Point2D` overload), `Point2D.distance(to:)` and
+    /// ``nearestParameter(to:)`` compute the same nearest solution through the same shared bridge
+    /// path and agree with it exactly.
     ///
     /// ```swift
     /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
     /// let hit = segment.project(point: SIMD2(5, 3))
     /// #expect(hit?.distance == 3)
-    /// #expect(segment.project(point: SIMD2(100, 0)) == nil)   // past the end
+    /// #expect(segment.project(point: SIMD2(100, 0))?.distance == 90)   // past the end: the end
+    ///
+    /// let arc = Curve2D.circle(center: .zero, radius: 5)!.trimmed(from: 0, to: .pi)!
+    /// #expect(arc.project(point: SIMD2(0, -6))?.parameter == 0)        // the near end, 7.81 away
     /// ```
+    ///
+    /// Before #615 this reported `Geom2dAPI_ProjectPointOnCurve`'s extremum instead — the arc above
+    /// answered π/2, the far side, 11 away — and `nil` for the segment. ``allProjections(of:)`` asks
+    /// for the extrema, which is a different question, and still reports none in both cases.
     public func project(point p: SIMD2<Double>) -> Curve2DProjection? {
         let r = OCCTCurve2DProjectPoint(handle, p.x, p.y)
         guard r.distance >= 0 else { return nil }
@@ -838,24 +847,27 @@ public final class Curve2D: @unchecked Sendable {
     /// The parameter of the point on this curve nearest to `point`.
     ///
     /// - Parameter point: Point to project.
-    /// - Returns: The nearest parameter, or `nil` if the point has no projection onto this curve
-    ///     one beyond the ends of a bounded curve, or the centre of a circle.
+    /// - Returns: The nearest parameter, always inside this curve's own ``domain``, or `nil` if
+    ///     there is no curve to answer about.
     ///
-    /// The scalar form of `project(point:)`, computed by the same shared bridge path and agreeing
-    /// with it, with `Point2D.distance(to:)` and with `allProjections(of:)` on exactly when there
-    /// is no projection.
+    /// The scalar form of ``project(point:)``, computed by the same shared bridge path and agreeing
+    /// with it and with `Point2D.distance(to:)` exactly. Like them it reports the true nearest
+    /// point rather than the nearest perpendicular foot, so a point past the end of a bounded curve
+    /// answers with that end.
     ///
-    /// `nil` is the only answer that says so, which is why this replaces the deprecated
-    /// `parameterAtPoint(_:)`: no `Double` can carry the signal. `0` is a legitimate parameter on
-    /// any curve whose domain includes it, and so is every other value.
+    /// This replaces the deprecated `parameterAtPoint(_:)` because no `Double` can carry a failure
+    /// signal: `0` is a legitimate parameter on any curve whose domain includes it, and so is every
+    /// other value.
     ///
     /// ```swift
     /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
     /// #expect(segment.nearestParameter(to: SIMD2(5, 3)) == 5)
-    /// #expect(segment.nearestParameter(to: SIMD2(100, 0)) == nil)   // past the end
+    /// #expect(segment.nearestParameter(to: SIMD2(100, 0)) == 10)   // past the end: the end
     ///
     /// let circle = Curve2D.circle(center: .zero, radius: 5)!
-    /// #expect(circle.nearestParameter(to: .zero) == nil)            // equidistant everywhere
+    /// // Equidistant everywhere, so every point is a nearest one; it names a tied parameter
+    /// // rather than refusing to answer (#615).
+    /// #expect(circle.nearestParameter(to: .zero) != nil)
     /// ```
     public func nearestParameter(to point: SIMD2<Double>) -> Double? {
         var parameter = 0.0
@@ -863,7 +875,21 @@ public final class Curve2D: @unchecked Sendable {
         return parameter
     }
 
-    /// Project a point onto this curve, returning all projections.
+    /// Project a point onto this curve, returning every projection.
+    ///
+    /// This asks for the **extrema** of the distance function — the perpendicular feet — which is a
+    /// different question from "the nearest point", and since #615 gives a visibly different answer.
+    /// A bounded curve queried from beyond its end has no perpendicular foot at all, so this
+    /// correctly returns empty where ``project(point:)`` and ``nearestParameter(to:)`` answer with
+    /// the end. An extremum may also be a local *maximum*: on a half arc queried from the far side
+    /// the only element here is the point furthest away.
+    ///
+    /// ```swift
+    /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
+    /// #expect(segment.allProjections(of: SIMD2(5, 3)).count == 1)      // a foot at (5, 0)
+    /// #expect(segment.allProjections(of: SIMD2(100, 0)).isEmpty)       // no foot past the end
+    /// #expect(segment.project(point: SIMD2(100, 0))?.parameter == 10)  // but a nearest point
+    /// ```
     public func allProjections(of p: SIMD2<Double>) -> [Curve2DProjection] {
         var buffer = [OCCTCurve2DProjection](repeating: OCCTCurve2DProjection(), count: 64)
         let n = Int(OCCTCurve2DProjectPointAll(handle, p.x, p.y, &buffer, 64))
@@ -2158,19 +2184,20 @@ extension Curve2D {
     /// Project a `Point2D` onto this curve.
     ///
     /// - Parameter point: Point to project.
-    /// - Returns: `(parameter, distance)` of the nearest solution, or `nil` if the point has no
-    ///   projection onto this curve.
+    /// - Returns: `(parameter, distance)` of the nearest solution, or `nil` if there is no curve to
+    ///   answer about.
     ///
-    /// The same nearest-solution computation as `project(point:)`, returned without the projected
-    /// point itself. Note that a parameter of `0` is a perfectly ordinary success — projecting a
-    /// segment's own start point onto it returns exactly that — so `nil` is the only failure
-    /// signal.
+    /// The same nearest-solution computation as ``project(point:)``, returned without the projected
+    /// point itself, so it reports the true nearest point over the curve's own domain — a point past
+    /// the end answers with that end (#615). Note that a parameter of `0` is a perfectly ordinary
+    /// success — projecting a segment's own start point onto it returns exactly that — so `nil` is
+    /// the only failure signal.
     ///
     /// ```swift
     /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
     /// let start = Point2D(x: 0, y: 0)!
-    /// #expect(segment.project(start)?.parameter == 0)          // success, at parameter 0
-    /// #expect(segment.project(Point2D(x: 100, y: 0)!) == nil)  // no projection
+    /// #expect(segment.project(start)?.parameter == 0)                    // success, at parameter 0
+    /// #expect(segment.project(Point2D(x: 100, y: 0)!)?.parameter == 10)  // past the end: the end
     /// ```
     public func project(_ point: Point2D) -> (parameter: Double, distance: Double)? {
         var dist: Double = 0

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1081,7 +1081,8 @@ extension Curve3D {
     /// The answer is always inside this curve's own ``domain``, and always the true nearest point:
     /// where the point has no perpendicular foot on the curve — anything past the end of a trimmed
     /// curve, or off to one side of an arc — the nearest point is an end, and that is what comes
-    /// back. Unlike ``nearestParameter(to:)``, this always answers.
+    /// back. ``nearestParameter(to:)`` is the scalar spelling of this and agrees with it exactly
+    /// (#615); ``distance(to:precision:)`` is the distance-only one.
     ///
     /// ```swift
     /// let segment = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!
@@ -2190,25 +2191,32 @@ extension Curve3D {
     /// The parameter of the point on this curve nearest to `point`.
     ///
     /// - Parameter point: Point to project.
-    /// - Returns: The nearest parameter, or `nil` if the point has no projection onto this curve
-    ///     one beyond the ends of a bounded curve, or the centre of a circle.
+    /// - Returns: The nearest parameter, always inside this curve's own ``domain``, or `nil` if
+    ///     there is no curve to answer about.
     ///
-    /// `nil` is the only answer that says so: no `Double` can carry the signal, because
-    /// every value is a legitimate parameter on some curve. This is the 3D counterpart of
+    /// The answer is the true nearest point, not the nearest perpendicular foot. Where the point has
+    /// no foot at all — anything past the end of a trimmed curve, or off to one side of an arc — the
+    /// nearest point is an end, and that is what comes back. This is the scalar spelling of
+    /// ``projectPoint(_:precision:)`` and agrees with it exactly; it is the 3D counterpart of
     /// `Curve2D.nearestParameter(to:)`, and it replaces both `closestParameter(to:)` and
     /// `parameterAtPoint(_:)`, which ran the identical projection and disagreed about how to
     /// report its absence.
-    ///
-    /// Contrast `projectPoint(_:precision:)`, which runs a different OCCT algorithm
-    /// (`ShapeAnalysis_Curve::Project`) that always answers, adjusting to the curve's ends rather
-    /// than reporting that there is no projection.
     ///
     /// ```swift
     /// let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))!
     /// let segment = line.trimmed(from: 3, to: 8)!
     /// #expect(segment.nearestParameter(to: SIMD3(5, 2, 0)) == 5)
-    /// #expect(segment.nearestParameter(to: SIMD3(100, 0, 0)) == nil)   // past the end
+    /// #expect(segment.nearestParameter(to: SIMD3(100, 0, 0)) == 8)   // past the end: the end
+    ///
+    /// let arc = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    ///     .trimmed(from: 0, to: .pi)!
+    /// #expect(arc.nearestParameter(to: SIMD3(0, -6, 0)) == 0)        // the near end, 7.81 away
     /// ```
+    ///
+    /// Before #615 this reported `GeomAPI_ProjectPointOnCurve`'s extremum instead: the arc above
+    /// answered π/2, the far side, 11 away, and the segment answered `nil`. `Optional` remains
+    /// because no `Double` can carry a failure signal — every value is a legitimate parameter on
+    /// some curve — not because a point can fail to have a nearest one.
     public func nearestParameter(to point: SIMD3<Double>) -> Double? {
         var parameter = 0.0
         guard OCCTCurve3DNearestParameter(handle, point.x, point.y, point.z, &parameter) else {
@@ -2219,9 +2227,9 @@ extension Curve3D {
 
     /// Find the parameter of the closest point on this curve to a given point.
     @available(*, deprecated, message: """
-        Returns .nan when there is no projection, where it used to return 0, a value that is not \
-        even in the domain of a curve trimmed to, say, [3, 8]. Use nearestParameter(to:), which \
-        returns nil.
+        No Double can signal failure here: every value is a legitimate parameter on some curve, \
+        and this used to return 0, which is not even in the domain of a curve trimmed to, say, \
+        [3, 8]. Use nearestParameter(to:), which returns an Optional.
         """)
     public func closestParameter(to point: SIMD3<Double>) -> Double {
         nearestParameter(to: point) ?? .nan

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -12242,9 +12242,9 @@ extension Curve3D {
 
     /// Find parameter on curve nearest to a 3D point.
     @available(*, deprecated, message: """
-        Returns .nan when there is no projection, where it used to return the curve's \
-        firstParameter, a real parameter in its own domain, right or maximally wrong depending \
-        only on which end the point fell off. Use nearestParameter(to:), which returns nil.
+        No Double can signal failure here: every value is a legitimate parameter on some curve, \
+        and this used to return the curve's firstParameter, right or maximally wrong depending \
+        only on which end the point fell off. Use nearestParameter(to:), which returns an Optional.
         """)
     public func parameterAtPoint(_ point: SIMD3<Double>) -> Double {
         nearestParameter(to: point) ?? .nan
@@ -12262,9 +12262,9 @@ extension Curve2D {
 
     /// Find parameter on 2D curve nearest to a 2D point.
     @available(*, deprecated, message: """
-        Returns .nan when there is no projection, where it used to return the curve's \
-        firstParameter, a real parameter in its own domain, right or maximally wrong depending \
-        only on which end the point fell off. Use nearestParameter(to:), which returns nil.
+        No Double can signal failure here: every value is a legitimate parameter on some curve, \
+        and this used to return the curve's firstParameter, right or maximally wrong depending \
+        only on which end the point fell off. Use nearestParameter(to:), which returns an Optional.
         """)
     public func parameterAtPoint(_ point: SIMD2<Double>) -> Double {
         nearestParameter(to: point) ?? .nan
@@ -12285,7 +12285,37 @@ extension Surface {
 
 extension Curve3D {
 
-    /// Local point-on-curve search from initial parameter guess. Returns (parameter, distance).
+    /// Local point-on-curve search from an initial parameter guess. Returns `(parameter, distance)`.
+    ///
+    /// Searches a window of ±10% of the domain around `initParam` and reports the
+    /// **lowest-distance extremum inside that window**. `initParam` bounds the window; it does not
+    /// rank what is found in it, so the extremum you get back is not necessarily the one nearest
+    /// your guess — where a window holds several, the one closest to the *query point* wins.
+    ///
+    /// The window is what makes the answer local, and a windowed minimum can still be a global
+    /// *maximum*: on a half circle of radius 5 queried from `(0, -6, 0)` with a guess of `.pi / 2`,
+    /// the window holds the far side of the arc and this reports 11, where the nearest point on the
+    /// curve is 7.81 away. Use ``nearestParameter(to:)`` or ``projectPoint(_:precision:)`` when you
+    /// want the global answer.
+    ///
+    /// When the window holds no extremum at all, the search falls back to the whole curve — and,
+    /// since #615, to the whole curve's true nearest point, which is what those two report. Before
+    /// #615 the fallback reported an extremum instead, so a guess sitting *on* the nearest point
+    /// returned the point diametrically opposite it, and a bounded segment queried from past its own
+    /// end returned `nil` for every guess.
+    ///
+    /// ```swift
+    /// let arc = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)!
+    ///     .trimmed(from: 0, to: .pi)!
+    ///
+    /// // Guess 0: no extremum nearby, so the whole curve is searched, correctly.
+    /// #expect(arc.locateNearestPoint(SIMD3(0, -6, 0), initParam: 0)?.parameter == 0)
+    ///
+    /// // Guess .pi / 2: an extremum IS nearby, and it is the far side of the arc.
+    /// #expect(arc.locateNearestPoint(SIMD3(0, -6, 0), initParam: .pi / 2)?.distance == 11)
+    /// ```
+    ///
+    /// - Returns: `nil` only when the curve cannot be read.
     public func locateNearestPoint(_ point: SIMD3<Double>, initParam: Double, tolerance: Double = 1e-6) -> (parameter: Double, distance: Double)? {
         var param = 0.0, dist = 0.0
         let ok = OCCTExtremaLocateOnCurve(handle, point.x, point.y, point.z,

--- a/Sources/OCCTSwift/Point2D.swift
+++ b/Sources/OCCTSwift/Point2D.swift
@@ -76,13 +76,13 @@ public final class Point2D: @unchecked Sendable {
     /// Minimum distance from this point to a 2D curve.
     ///
     /// - Parameter curve: Curve to measure to.
-    /// - Returns: The distance to the nearest point of the curve, or `.infinity` if the point has
-    ///   no projection onto it at all.
+    /// - Returns: The distance to the nearest point of the curve, or `.infinity` if there is no
+    ///   curve to measure to.
     ///
-    /// A point can legitimately have no projection: one beyond the ends of a bounded curve, or
-    /// the centre of a circle (equidistant from every point, so there is no local minimum). This
-    /// used to return the bridge's raw `-1` sentinel for that case, which any threshold test
-    /// (`distance < tolerance`) would read as "touching" — the opposite of the truth (#413).
+    /// Measured over the curve's own domain, ends included, so it is the true minimum rather than
+    /// the nearest perpendicular foot. A point beyond the end of a bounded curve is measured to
+    /// that end, and a circle's centre to the radius. Agrees exactly with
+    /// `Curve2D.project(point:)` and `Curve2D.nearestParameter(to:)`, which share its bridge path.
     ///
     /// ```swift
     /// let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0))!
@@ -90,8 +90,14 @@ public final class Point2D: @unchecked Sendable {
     /// #expect(abs(above.distance(to: segment) - 3) < 1e-9)
     ///
     /// let pastTheEnd = Point2D(x: 100, y: 0)!
-    /// #expect(pastTheEnd.distance(to: segment) == .infinity)
+    /// #expect(pastTheEnd.distance(to: segment) == 90)   // to the end at (10, 0)
     /// ```
+    ///
+    /// Two sentinels have been retired from this one method. It first returned the bridge's raw
+    /// `-1` for a point with no perpendicular foot, which any threshold test (`distance < tolerance`)
+    /// read as "touching" — the opposite of the truth (#413). `.infinity` replaced it, which was
+    /// safe but still discarded a real, finite distance; #615 measures it instead. `.infinity` now
+    /// means only that the curve could not be read at all.
     public func distance(to curve: Curve2D) -> Double {
         let d = OCCTPoint2DDistanceToCurve(handle, curve.handle)
         return d < 0 ? .infinity : d

--- a/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
+++ b/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
@@ -32,67 +32,70 @@ struct Issue500Curve3DNearestParameterTests {
         #expect(curve.nearestParameter(to: SIMD3(8, -1, 0)) == 8)    // the end point itself
     }
 
-    /// A point beyond the ends of a bounded curve has no extremum, so no projection. This is the
-    /// case the two old spellings answered differently, and neither answer was reportable.
-    @Test("No projection is nil, not a parameter from either old convention")
-    func noProjectionIsNil() throws {
+    /// A point beyond the ends of a bounded curve has no perpendicular foot, which is not the same
+    /// as having no nearest point: the nearest point is the end it fell off.
+    ///
+    /// Until #615 this returned `nil` for all three, because the shared helper reported
+    /// `GeomAPI_ProjectPointOnCurve`'s extrema and there are none. `projectPoint(_:precision:)`,
+    /// converted by #539, answered 8 and 3 for the same curve and the same points the whole time.
+    @Test("A point past the end answers with the end, not nil")
+    func pastTheEndAnswersWithTheEnd() throws {
         let curve = try #require(Self.trimmedSegment())
-        for p in [SIMD3<Double>(100, 0, 0), SIMD3(0, 0, 0), SIMD3(-50, 3, 0)] {
-            #expect(curve.nearestParameter(to: p) == nil, "\(p)")
-        }
+        #expect(curve.nearestParameter(to: SIMD3(100, 0, 0)) == 8)
+        #expect(curve.nearestParameter(to: SIMD3(0, 0, 0)) == 3)
+        #expect(curve.nearestParameter(to: SIMD3(-50, 3, 0)) == 3)
     }
 
     /// A circle's centre is equidistant from every point on it, so there is no local minimum to
-    /// find. The 2D parity suite uses the same case (#413).
-    @Test("A circle's centre has no projection")
-    func circleCentreHasNoProjection() throws {
+    /// find — but every point on it is a nearest point, all at the radius. Since #615 that is what
+    /// comes back, matching `projectPoint(_:precision:)`, which has reported it since #539.
+    @Test("A circle's centre answers with a tied nearest point at the radius")
+    func circleCentreAnswersAtTheRadius() throws {
         let circle = try #require(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5))
-        #expect(circle.nearestParameter(to: .zero) == nil)
+        let parameter = try #require(circle.nearestParameter(to: .zero))
+        let onCurve = circle.point(at: parameter)
+        #expect(abs((onCurve.x * onCurve.x + onCurve.y * onCurve.y).squareRoot() - 5) < 1e-9)
+        #expect(abs(circle.projectPoint(.zero).distance - 5) < 1e-9)
         #expect(circle.nearestParameter(to: SIMD3(3, 4, 0)) != nil)   // on the circle: fine
     }
 
-    /// Both deprecated spellings now route through the one implementation, so they agree with each
-    /// other and with `nearestParameter(to:)` — including on the no-projection case, where they
-    /// report `.nan`. `.nan` is the only `Double` that is not a legitimate parameter on some curve.
+    /// Both deprecated spellings route through the one implementation, so they agree with each
+    /// other and with `nearestParameter(to:)`. Since #615 there is no reachable `.nan` case left on
+    /// a real curve: `nil` now means "no curve", not "no extremum". The spellings stay deprecated
+    /// for the reason they always were — no `Double` can carry a failure signal, because every value
+    /// is a legitimate parameter on some curve.
     @Test("The two deprecated spellings agree with each other and with nearestParameter")
     @available(*, deprecated, message: "exercises the deprecated spellings on purpose")
     func deprecatedSpellingsAgree() throws {
         let curve = try #require(Self.trimmedSegment())
 
-        // Where there is a projection, all three give the same real parameter.
-        #expect(curve.nearestParameter(to: SIMD3(5, 2, 0)) == 5)
-        #expect(curve.parameterAtPoint(SIMD3(5, 2, 0)) == 5)
-        #expect(curve.closestParameter(to: SIMD3(5, 2, 0)) == 5)
-
-        // Where there is none, the scalar spellings say so instead of inventing a parameter.
-        // Before #500: parameterAtPoint returned 3 (firstParameter) and closestParameter
-        // returned 0 — a value not even inside this curve's [3, 8] domain.
-        for p in [SIMD3<Double>(100, 0, 0), SIMD3(0, 0, 0)] {
-            #expect(curve.nearestParameter(to: p) == nil, "\(p)")
-            #expect(curve.parameterAtPoint(p).isNaN, "\(p)")
-            #expect(curve.closestParameter(to: p).isNaN, "\(p)")
+        for p in [SIMD3<Double>(5, 2, 0), SIMD3(100, 0, 0), SIMD3(0, 0, 0)] {
+            let nearest = try #require(curve.nearestParameter(to: p), "\(p)")
+            #expect(curve.parameterAtPoint(p) == nearest, "\(p)")
+            #expect(curve.closestParameter(to: p) == nearest, "\(p)")
         }
+
+        // Before #500: parameterAtPoint returned 3 (firstParameter) and closestParameter returned
+        // 0 — a value not even inside this curve's [3, 8] domain — for the two points above that
+        // have no perpendicular foot. Both now report the end those points fell off.
+        #expect(curve.parameterAtPoint(SIMD3(5, 2, 0)) == 5)
+        #expect(curve.parameterAtPoint(SIMD3(100, 0, 0)) == 8)
+        #expect(curve.closestParameter(to: SIMD3(0, 0, 0)) == 3)
     }
 
-    /// `projectPoint(_:precision:)` is deliberately *not* part of this family, and asks a different
-    /// question: the nearest point on the curve, which exists for every point, rather than the
-    /// nearest *perpendicular foot*, which does not. Pinned here so a later pass does not "unify"
-    /// two entry points that genuinely compute different things.
-    ///
-    /// When #500 shipped, its answer here was parameter 100, distance 0 — it projected onto the
-    /// curve's underlying unbounded line, recorded as-is rather than asserted correct. #539 fixed
-    /// that: the answer is now the curve's own end. The contracts still differ, but only in whether
-    /// a point with no perpendicular foot gets an answer, not in whether the answer is true.
-    @Test("projectPoint runs a different algorithm and keeps its own contract")
-    func projectPointIsADifferentAlgorithm() throws {
+    /// `projectPoint(_:precision:)` reaches the answer by a different route — `ShapeAnalysis_Curve`
+    /// is in its candidate set and not in this one — but since #615 it is the same answer. The two
+    /// used to differ on both questions a projection asks: #539 converted `projectPoint` and left
+    /// this spelling reporting an extremum, so on a point past the end one said 8 and the other said
+    /// there was no such point at all.
+    @Test("projectPoint and nearestParameter now agree")
+    func projectPointAndNearestParameterAgree() throws {
         let curve = try #require(Self.trimmedSegment())
         let p = SIMD3<Double>(100, 0, 0)
 
-        #expect(curve.nearestParameter(to: p) == nil)
-
-        // It answers where nearestParameter does not, with the end of the curve (#539).
         let projected = curve.projectPoint(p)
         #expect(projected.parameter == 8)
         #expect(projected.distance == 92)
+        #expect(curve.nearestParameter(to: p) == projected.parameter)
     }
 }

--- a/Tests/OCCTCurveTests/Issue539NearestPointOnCurveTests.swift
+++ b/Tests/OCCTCurveTests/Issue539NearestPointOnCurveTests.swift
@@ -136,13 +136,16 @@ struct Issue539NearestPointOnCurveTests {
         #expect(abs(above.parameter - .pi / 2) < 1e-6)
     }
 
-    /// A circle's centre has no perpendicular foot at all — `nearestParameter(to:)` reports `nil`
-    /// for it (#500). `projectPoint` still answers, and the radius it answers with was already
-    /// right, because the whole domain is in range.
+    /// A circle's centre has no perpendicular foot at all. `projectPoint` still answers, and the
+    /// radius it answers with was already right, because the whole domain is in range.
+    ///
+    /// `nearestParameter(to:)` reported `nil` here until #615 routed it through the same helper;
+    /// it now names one of the infinitely many tied nearest points, all at the radius.
     @Test("A closed curve, and a point with no perpendicular foot, still answer")
     func closedCurveStillAnswers() throws {
         let circle = try #require(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5))
-        #expect(circle.nearestParameter(to: .zero) == nil)
+        let tied = try #require(circle.nearestParameter(to: .zero))
+        #expect(abs(simd_length(circle.point(at: tied)) - 5) < 1e-9)
 
         let centre = circle.projectPoint(.zero)
         #expect(abs(centre.distance - 5) < 1e-9)

--- a/Tests/OCCTCurveTests/Issue615NearestParameterRangeTests.swift
+++ b/Tests/OCCTCurveTests/Issue615NearestParameterRangeTests.swift
@@ -1,0 +1,172 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// MARK: - #615: the two point-to-curve spellings #539/#580 left disagreeing
+
+/// #539 established that `GeomAPI_ProjectPointOnCurve::LowerDistance()` reports an extremum, which
+/// on a bounded curve is neither necessarily the nearest point nor necessarily present at all, and
+/// introduced `occtNearestPointOnCurveRange` — the minimum over `ShapeAnalysis_Curve`, every
+/// extremum in range, and both ends. Three entry points were converted. The shared helper behind
+/// `Curve3D.nearestParameter(to:)` and `Curve3D.locateNearestPoint`'s full-range fallback was not.
+///
+/// So the two spellings of the same question disagreed about **which** point is nearest and about
+/// **whether there is one**. Measured on the geometry #539 itself used, a half circle of radius 5
+/// queried from below at `(0, -6, 0)`:
+///
+/// | | before | after |
+/// |---|---|---|
+/// | `projectPoint` (converted by #539) | param 0, distance 7.8102 | unchanged |
+/// | `nearestParameter` | param π/2, distance **11** | param 0, distance 7.8102 |
+/// | `nearestParameter`, point past the end | **nil** | the end |
+///
+/// A caller seeding a trim or a split from `nearestParameter` landed on the opposite side of the arc
+/// from where `projectPoint` said the nearest point was.
+@Suite("nearestParameter reports the nearest point over the range (#615)")
+struct Issue615NearestParameterRangeTests {
+
+    /// #539's own repro geometry: a half circle of radius 5 over `[0, π]`, so parameter `t` is the
+    /// point `(5 cos t, 5 sin t, 0)`. The arc lies in the upper half plane; a query from below has
+    /// its nearest point at an end, and its only extremum at the far side.
+    private static func halfCircle() -> Curve3D? {
+        Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)?.trimmed(from: 0, to: .pi)
+    }
+
+    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`.
+    private static func trimmedSegment() -> Curve3D? {
+        Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
+    }
+
+    private static func distance(_ a: SIMD3<Double>, _ b: SIMD3<Double>) -> Double {
+        let d = a - b
+        return (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
+    }
+
+    /// Defect 1: the far side of the arc reported as the nearest point.
+    ///
+    /// The sole in-range extremum is the top of the arc at π/2, 11 away. The nearest point is the
+    /// arc's own start at `(5, 0, 0)`, 7.8102 away, and no extremum search will ever find it because
+    /// it is an end.
+    @Test("A half circle queried from below answers with the near end, not the far side")
+    func halfCircleFromBelowAnswersTheNearEnd() throws {
+        let arc = try #require(Self.halfCircle())
+        let query = SIMD3<Double>(0, -6, 0)
+        let truth = 61.0.squareRoot()   // hypot(5, 6) = 7.810249675906654
+
+        let parameter = try #require(arc.nearestParameter(to: query))
+        #expect(abs(parameter - 0) < 1e-9)
+        #expect(abs(Self.distance(arc.point(at: parameter), query) - truth) < 1e-9)
+
+        // Before #615 this was π/2, whose point is 11 away — further from the query than the far
+        // end of the arc is, and on the opposite side of it.
+        #expect(Self.distance(arc.point(at: parameter), query) < 11)
+    }
+
+    /// The second row of #580's table, on the curve rather than the edge: a point that lies on the
+    /// full circle but not on this half of it. The extremum is the mirrored point at distance 10.
+    @Test("A point on the circle but off the arc answers with the arc's end")
+    func pointOnTheCircleButOffTheArc() throws {
+        let arc = try #require(Self.halfCircle())
+        let query = SIMD3<Double>(3, -4, 0)
+
+        let parameter = try #require(arc.nearestParameter(to: query))
+        #expect(abs(Self.distance(arc.point(at: parameter), query) - 4.47213595499958) < 1e-9)
+    }
+
+    /// Defect 2: `nil` where the converted sibling answers.
+    ///
+    /// A point past the end of a bounded curve has no perpendicular foot, so no extremum — but it
+    /// does have a nearest point, and `projectPoint` has reported it since #539.
+    @Test("A point past the end is answered, not refused")
+    func pastTheEndIsAnswered() throws {
+        let segment = try #require(Self.trimmedSegment())
+
+        #expect(segment.nearestParameter(to: SIMD3(100, 0, 0)) == 8)
+        #expect(segment.nearestParameter(to: SIMD3(0, 0, 0)) == 3)
+        #expect(segment.nearestParameter(to: SIMD3(-50, 3, 0)) == 3)
+    }
+
+    /// The property the issue is actually about: the two spellings must not disagree. Swept over
+    /// both defect geometries plus an ordinary interior projection, an unbounded line and a full
+    /// circle, so a future change that fixes one entry point and not the other fails here.
+    @Test("nearestParameter and projectPoint agree on every query")
+    func theTwoSpellingsAgree() throws {
+        let arc = try #require(Self.halfCircle())
+        let segment = try #require(Self.trimmedSegment())
+        let circle = try #require(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5))
+        let line = try #require(Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)))
+
+        let cases: [(Curve3D, SIMD3<Double>, String)] = [
+            (arc, SIMD3(0, -6, 0), "half circle from below"),
+            (arc, SIMD3(3, -4, 0), "on the circle, off the arc"),
+            (arc, SIMD3(0, 7, 0), "above the arc, an ordinary foot"),
+            (segment, SIMD3(5, 2, 0), "an ordinary foot"),
+            (segment, SIMD3(100, 0, 0), "past the end"),
+            (segment, SIMD3(0, 0, 0), "before the start"),
+            (circle, SIMD3(10, 0, 0), "outside a closed curve"),
+            (line, SIMD3(5, 3, 0), "an unbounded line"),
+        ]
+
+        for (curve, query, label) in cases {
+            let projected = curve.projectPoint(query)
+            let parameter = try #require(curve.nearestParameter(to: query), "\(label)")
+
+            // Same point, so same distance. Compared by distance rather than by parameter because a
+            // tie (a closed curve queried from its centre) is free to name either of two parameters.
+            #expect(abs(Self.distance(curve.point(at: parameter), query) - projected.distance) < 1e-9,
+                    "\(label): nearestParameter \(parameter) vs projectPoint \(projected.parameter)")
+
+            // And it is a real answer over the curve's own domain, not over its basis curve.
+            #expect(curve.domain.contains(parameter), "\(label): \(parameter) outside \(curve.domain)")
+        }
+    }
+
+    /// `Curve3D.locateNearestPoint(_:initParam:tolerance:)` shares the helper, and its full-range
+    /// fallback inherited both defects. The fallback fires when the ±10% window around the guess
+    /// holds no extremum — which is exactly the situation the guess was closest to being right in.
+    ///
+    /// Before #615, a guess sitting *on* the true nearest point returned the point diametrically
+    /// opposite it.
+    @Test("The locate-from-a-guess fallback answers over the whole curve, correctly")
+    func locateFallbackIsCorrect() throws {
+        let arc = try #require(Self.halfCircle())
+        let query = SIMD3<Double>(0, -6, 0)
+        let truth = 61.0.squareRoot()
+
+        // Guess 0 is the true answer; the window [0, 0.314] holds no extremum, so this falls back.
+        let atStart = try #require(arc.locateNearestPoint(query, initParam: 0))
+        #expect(abs(atStart.parameter - 0) < 1e-9)
+        #expect(abs(atStart.distance - truth) < 1e-9)
+
+        // A bounded segment queried past its end has no extremum anywhere, so every guess falls
+        // back. Before #615 the fallback found none either and the whole call returned nil.
+        let segment = try #require(Self.trimmedSegment())
+        for guess in [3.0, 5.5, 8.0] {
+            let located = try #require(segment.locateNearestPoint(SIMD3(100, 0, 0), initParam: guess),
+                                       "guess \(guess)")
+            #expect(located.parameter == 8, "guess \(guess)")
+            #expect(located.distance == 92, "guess \(guess)")
+        }
+    }
+
+    /// The other half of that decision, pinned so it is not "fixed" by accident: the PRIMARY search
+    /// is deliberately still windowed, and a windowed minimum can be a global maximum.
+    ///
+    /// It reports the lowest-distance extremum *inside* the ±10% window, not the extremum nearest
+    /// the guess — `initParam` bounds the window, it does not rank what is found in it. With a guess
+    /// of π/2 the window holds the far side of the arc, and that is what comes back: 11, not the
+    /// global nearest 7.8102.
+    ///
+    /// Adding the window's ends to that minimum would answer 10.8657, still not 7.8102, and would
+    /// make the fallback above unreachable, since a window's ends always evaluate. Making the search
+    /// global outright would leave `initParam` meaning nothing and the function a duplicate of
+    /// `nearestParameter(to:)`.
+    @Test("The locate-from-a-guess primary search stays local, maxima included")
+    func locatePrimarySearchStaysLocal() throws {
+        let arc = try #require(Self.halfCircle())
+
+        let atFarSide = try #require(arc.locateNearestPoint(SIMD3(0, -6, 0), initParam: .pi / 2))
+        #expect(abs(atFarSide.parameter - .pi / 2) < 1e-9)
+        #expect(abs(atFarSide.distance - 11) < 1e-9)
+    }
+}

--- a/Tests/OCCTGeom2dTests/Issue615Curve2DNearestPointTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue615Curve2DNearestPointTests.swift
@@ -1,0 +1,168 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// MARK: - #615: the 2D twin that #539/#580 never touched
+
+/// #539 established that `GeomAPI_ProjectPointOnCurve::LowerDistance()` reports an extremum, which
+/// on a bounded curve is neither necessarily the nearest point nor necessarily present at all, and
+/// converted the 3D entry points onto a helper that takes the minimum over `ShapeAnalysis_Curve`,
+/// every extremum in range, and both ends. The 2D twin was never touched at all, so every 2D
+/// spelling — `Curve2D.project(point:)`, `Curve2D.project(_ point: Point2D)`,
+/// `Point2D.distance(to:)` and `Curve2D.nearestParameter(to:)` — was wrong in both of the ways the
+/// 3D side used to be. They agreed with each other, and with nothing else.
+///
+/// Measured on the 2D twin of #539's own repro geometry, a half circle of radius 5 queried from
+/// below at `(0, -6)`:
+///
+/// | | before | after |
+/// |---|---|---|
+/// | `project(point:)` | point (0, 5), distance **11** | point (5, 0), distance 7.8102 |
+/// | `project(point:)`, past the end of a segment | **nil** | the end |
+/// | `Point2D.distance(to:)`, past the end | **`.infinity`** | the true distance |
+///
+/// There is no `ShapeAnalysis_Curve` in the 2D candidate set because OCCT has no 2D projection in
+/// that class — its `Project` overloads take `Geom_Curve` or `Adaptor3d_Curve` only. So the 2D
+/// helper is the extrema plus both ends, which is the row #580 measured at 188/189 rather than the
+/// 189/189 the third source buys.
+@Suite("Curve2D reports the nearest point over the range (#615)")
+struct Issue615Curve2DNearestPointTests {
+
+    /// A half circle of radius 5 over `[0, π]`: parameter `t` is the point `(5 cos t, 5 sin t)`.
+    private static func halfCircle() -> Curve2D? {
+        Curve2D.circle(center: .zero, radius: 5)?.trimmed(from: 0, to: .pi)
+    }
+
+    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0)`.
+    private static func trimmedSegment() -> Curve2D? {
+        Curve2D.line(through: .zero, direction: SIMD2(1, 0))?.trimmed(from: 3, to: 8)
+    }
+
+    private static func distance(_ a: SIMD2<Double>, _ b: SIMD2<Double>) -> Double {
+        let d = a - b
+        return (d.x * d.x + d.y * d.y).squareRoot()
+    }
+
+    /// Defect 1, through all four spellings: the far side of the arc reported as the nearest point.
+    ///
+    /// The sole in-range extremum is the top of the arc at π/2, 11 away. The nearest point is the
+    /// arc's own start at `(5, 0)`, 7.8102 away, and no extremum search will find it: it is an end.
+    @Test("A half circle queried from below answers with the near end, not the far side")
+    func halfCircleFromBelowAnswersTheNearEnd() throws {
+        let arc = try #require(Self.halfCircle())
+        let query = SIMD2<Double>(0, -6)
+        let point2D = try #require(Point2D(x: query.x, y: query.y))
+        let truth = 61.0.squareRoot()   // hypot(5, 6) = 7.810249675906654
+
+        let projected = try #require(arc.project(point: query))
+        #expect(abs(projected.distance - truth) < 1e-9)
+        #expect(abs(projected.parameter - 0) < 1e-9)
+        #expect(Self.distance(projected.point, SIMD2(5, 0)) < 1e-9)
+
+        // Before #615 every one of these was 11, at point (0, 5) and parameter π/2.
+        #expect(abs(point2D.distance(to: arc) - truth) < 1e-9)
+        let asTuple = try #require(arc.project(point2D))
+        #expect(abs(asTuple.distance - truth) < 1e-9)
+        let scalar = try #require(arc.nearestParameter(to: query))
+        #expect(abs(Self.distance(arc.point(at: scalar), query) - truth) < 1e-9)
+    }
+
+    /// A point on the full circle but not on this half of it. The extremum is the mirrored point at
+    /// distance 10; the truth is the arc's start at 4.4721.
+    @Test("A point on the circle but off the arc answers with the arc's end")
+    func pointOnTheCircleButOffTheArc() throws {
+        let arc = try #require(Self.halfCircle())
+        let query = SIMD2<Double>(3, -4)
+
+        let projected = try #require(arc.project(point: query))
+        #expect(abs(projected.distance - 4.47213595499958) < 1e-9)
+        #expect(Self.distance(projected.point, SIMD2(5, 0)) < 1e-9)
+    }
+
+    /// Defect 2: `nil` and `.infinity` where there is a perfectly good answer.
+    ///
+    /// A point past the end of a bounded curve has no perpendicular foot, so no extremum — but the
+    /// end is right there, 92 away.
+    @Test("A point past the end is answered, not refused")
+    func pastTheEndIsAnswered() throws {
+        let segment = try #require(Self.trimmedSegment())
+
+        let beyond = try #require(segment.project(point: SIMD2(100, 0)))
+        #expect(beyond.parameter == 8)
+        #expect(beyond.distance == 92)
+        #expect(Self.distance(beyond.point, SIMD2(8, 0)) < 1e-9)
+
+        let before = try #require(segment.project(point: SIMD2(0, 0)))
+        #expect(before.parameter == 3)
+        #expect(before.distance == 3)
+
+        #expect(segment.nearestParameter(to: SIMD2(100, 0)) == 8)
+        #expect(segment.nearestParameter(to: SIMD2(0, 0)) == 3)
+
+        // Point2D.distance(to:) mapped the bridge's negative sentinel to `.infinity`, so a point 92
+        // units from a segment measured as infinitely far from it.
+        let past = try #require(Point2D(x: 100, y: 0))
+        #expect(past.distance(to: segment) == 92)
+    }
+
+    /// The property the issue is about, swept: the four spellings must not diverge from each other,
+    /// and must land inside the curve's own domain rather than on its unbounded basis curve.
+    @Test("All four nearest-point spellings agree on every query")
+    func theFourSpellingsAgree() throws {
+        let arc = try #require(Self.halfCircle())
+        let segment = try #require(Self.trimmedSegment())
+        let circle = try #require(Curve2D.circle(center: .zero, radius: 5))
+        let line = try #require(Curve2D.line(through: .zero, direction: SIMD2(1, 0)))
+
+        let cases: [(Curve2D, SIMD2<Double>, String)] = [
+            (arc, SIMD2(0, -6), "half circle from below"),
+            (arc, SIMD2(3, -4), "on the circle, off the arc"),
+            (arc, SIMD2(0, 7), "above the arc, an ordinary foot"),
+            (segment, SIMD2(5, 2), "an ordinary foot"),
+            (segment, SIMD2(100, 0), "past the end"),
+            (segment, SIMD2(0, 0), "before the start"),
+            (circle, SIMD2(10, 0), "outside a closed curve"),
+            (circle, SIMD2(0, 0), "a closed curve's centre, tied everywhere"),
+            (line, SIMD2(5, 3), "an unbounded line"),
+        ]
+
+        for (curve, query, label) in cases {
+            let point2D = try #require(Point2D(x: query.x, y: query.y), "\(label)")
+            let projected = try #require(curve.project(point: query), "\(label)")
+            let asTuple = try #require(curve.project(point2D), "\(label)")
+            let scalar = try #require(curve.nearestParameter(to: query), "\(label)")
+
+            #expect(projected.parameter == asTuple.parameter, "\(label)")
+            #expect(projected.distance == asTuple.distance, "\(label)")
+            #expect(projected.distance == point2D.distance(to: curve), "\(label)")
+            #expect(scalar == projected.parameter, "\(label)")
+
+            // The reported distance is the distance to the reported point, and the reported point is
+            // where the reported parameter says it is. This is the sweep's only ground-truth anchor:
+            // the four spellings above share one bridge path, so they would agree with each other
+            // even if all four were wrong. It needs abs() for that reason — without it the
+            // comparison is one-sided and passes for any reported distance LARGER than the truth,
+            // which is the exact direction every defect in this issue erred in.
+            #expect(abs(Self.distance(projected.point, query) - projected.distance) < 1e-9, "\(label)")
+            #expect(Self.distance(curve.point(at: scalar), projected.point) < 1e-9, "\(label)")
+            #expect(curve.domain.contains(scalar), "\(label): \(scalar) outside \(curve.domain)")
+        }
+    }
+
+    /// The 2D answer must be the 3D answer for the same geometry in the z = 0 plane. This is the
+    /// cross-check the two sides never had, and the reason the 2D defect survived #539: nothing
+    /// compared them.
+    @Test("The 2D and 3D answers match for the same geometry")
+    func twoDAndThreeDMatch() throws {
+        let arc2 = try #require(Self.halfCircle())
+        let arc3 = try #require(
+            Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)?.trimmed(from: 0, to: .pi))
+
+        for query in [SIMD2<Double>(0, -6), SIMD2(3, -4), SIMD2(0, 7), SIMD2(-8, -1)] {
+            let flat = try #require(arc2.project(point: query), "\(query)")
+            let solid = arc3.projectPoint(SIMD3(query.x, query.y, 0))
+            #expect(abs(flat.distance - solid.distance) < 1e-9, "\(query)")
+            #expect(abs(flat.parameter - solid.parameter) < 1e-9, "\(query)")
+        }
+    }
+}

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4708,30 +4708,42 @@ struct Curve2DProjectionParityTests {
         }
     }
 
-    /// A point with no projection at all is an ordinary outcome, not an error: one beyond the
-    /// ends of a bounded curve, or a circle's centre (equidistant everywhere, so no local
-    /// minimum). All five entry points must report it, and none may report it as a distance a
-    /// threshold test would accept, or as a parameter a caller could mistake for a real one.
-    @Test("All five entry points agree when there is no projection")
-    func failureAgreesAcrossAllFive() {
-        let cases: [(Curve2D, SIMD2<Double>)] = [
-            (Self.segment, SIMD2(100, 0)),      // past the end
-            (Self.segment, SIMD2(-50, 3)),      // before the start
-            (Curve2D.circle(center: .zero, radius: 5)!, SIMD2(0, 0)),   // circle centre
+    /// A point with no *perpendicular foot* — one beyond the ends of a bounded curve, or a circle's
+    /// centre (equidistant everywhere, so no local minimum) — still has a nearest point, and since
+    /// #615 the four nearest-point spellings all report it rather than reporting nothing.
+    ///
+    /// `allProjections(of:)` is the one that still reports nothing, and correctly: it asks for the
+    /// extrema, which is a different question, and here there are none. Before #615 all five agreed
+    /// only because the other four were asking the extrema question too.
+    @Test("The four nearest-point entry points agree where there is no perpendicular foot")
+    func noPerpendicularFootAgreesAcrossTheFour() throws {
+        let cases: [(Curve2D, SIMD2<Double>, Double)] = [
+            (Self.segment, SIMD2(100, 0), 90),                  // past the end, nearest is (10, 0)
+            (Self.segment, SIMD2(-50, 3), 2509.0.squareRoot()), // before the start, nearest is (0, 0)
+            (Curve2D.circle(center: .zero, radius: 5)!, SIMD2(0, 0), 5),   // centre: tied at r
         ]
-        for (curve, p) in cases {
-            guard let point2D = Point2D(x: p.x, y: p.y) else { continue }
+        for (curve, p, truth) in cases {
+            let point2D = try #require(Point2D(x: p.x, y: p.y))
             let comment: Comment = "\(p)"
 
-            #expect(curve.project(point: p) == nil, comment)
-            #expect(curve.project(point2D) == nil, comment)
-            #expect(curve.allProjections(of: p).isEmpty, comment)
-            #expect(curve.nearestParameter(to: p) == nil, comment)
-
-            // Not -1: a raw sentinel here reads as "touching" to any `distance < tolerance` test.
+            let nearest = try #require(curve.project(point: p), comment)
+            let asTuple = try #require(curve.project(point2D), comment)
+            let scalar = try #require(curve.nearestParameter(to: p), comment)
             let distance = point2D.distance(to: curve)
-            #expect(distance == .infinity, comment)
+
+            #expect(abs(nearest.distance - truth) < 1e-4, comment)
+            #expect(nearest.parameter == asTuple.parameter, comment)
+            #expect(nearest.distance == asTuple.distance, comment)
+            #expect(nearest.distance == distance, comment)
+            #expect(scalar == nearest.parameter, comment)
+
+            // Never the old sentinels: `.infinity` from Point2D.distance(to:) was a real distance
+            // thrown away, and -1 underneath it reads as "touching" to a `distance < tolerance` test.
+            #expect(distance.isFinite, comment)
             #expect(distance > 0, comment)
+
+            // The extrema question is genuinely unanswerable here, and still says so.
+            #expect(curve.allProjections(of: p).isEmpty, comment)
         }
     }
 
@@ -4756,23 +4768,29 @@ struct Curve2DProjectionParityTests {
 
     /// The fifth entry point, which #413 missed. `parameterAtPoint(_:)` answered a no-projection
     /// with `firstParameter`: right by luck when the point fell off the start, and the far end of
-    /// the curve when it fell off the finish. Neither is distinguishable from a real result, so
-    /// the scalar spelling had to become optional; the deprecated one now says `.nan` instead.
-    @Test("The deprecated scalar spelling no longer answers with a real parameter")
+    /// the curve when it fell off the finish. Neither was distinguishable from a real result, so
+    /// the scalar spelling became optional.
+    ///
+    /// Since #615 there is no reachable `.nan` case left on a real curve — a point past the end is
+    /// nearest to that end, so it gets a real parameter — and `firstParameter` is now right for the
+    /// point that fell off the start for the *right* reason. The spelling stays deprecated because
+    /// no `Double` can carry a failure signal, not because this input has no answer.
+    @Test("The deprecated scalar spelling agrees with the optional one")
     @available(*, deprecated, message: "exercises the deprecated parameterAtPoint on purpose")
-    func deprecatedScalarSpellingReportsNaN() {
+    func deprecatedScalarSpellingAgrees() throws {
         // A domain that does not start at 0, so `firstParameter` is visibly not a default.
-        guard let line = Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0)),
-              let trimmed = line.trimmed(from: 3, to: 8) else { return }
+        let line = try #require(Curve2D.line(through: SIMD2(0, 0), direction: SIMD2(1, 0)))
+        let trimmed = try #require(line.trimmed(from: 3, to: 8))
         #expect(trimmed.domain == 3...8)
 
-        // Fell off the far end: `firstParameter` (3) was the worst answer available.
-        #expect(trimmed.nearestParameter(to: SIMD2(100, 0)) == nil)
-        #expect(trimmed.parameterAtPoint(SIMD2(100, 0)).isNaN)
+        // Fell off the far end: `firstParameter` (3) was the worst answer available; the end is 8.
+        #expect(trimmed.nearestParameter(to: SIMD2(100, 0)) == 8)
+        #expect(trimmed.parameterAtPoint(SIMD2(100, 0)) == 8)
 
-        // Fell off the start: `firstParameter` (3) was the right point for the wrong reason.
-        #expect(trimmed.nearestParameter(to: SIMD2(0, 0)) == nil)
-        #expect(trimmed.parameterAtPoint(SIMD2(0, 0)).isNaN)
+        // Fell off the start: 3 all along, now because it is the nearest point rather than because
+        // it is the first parameter.
+        #expect(trimmed.nearestParameter(to: SIMD2(0, 0)) == 3)
+        #expect(trimmed.parameterAtPoint(SIMD2(0, 0)) == 3)
 
         // A real projection still returns the real parameter through both spellings.
         #expect(trimmed.nearestParameter(to: SIMD2(5, 2)) == 5)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -624,7 +624,8 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `edge.parameterBounds` / `edge.curveType` | `BRep_Tool` / `GeomAdaptor_Curve` |
 | `edge.point(at:)` / `edge.tangent(at:)` / `edge.normal(at:)` | `GeomLProp_CLProps` |
 | `edge.curvature(at:)` / `edge.centerOfCurvature(at:)` / `edge.torsion(at:)` | `GeomLProp_CLProps` |
-| `edge.project(point:)` / `edge.distance(to:)` — and `curve3d.projectPoint(_:precision:)` / `curve3d.distance(to:precision:)`, one shared implementation since #539 | `ShapeAnalysis_Curve::Project` + `GeomAPI_ProjectPointOnCurve`, minimised together with the range's ends |
+| `edge.project(point:)` / `edge.distance(to:)` — and `curve3d.projectPoint(_:precision:)` / `curve3d.distance(to:precision:)` / `curve3d.nearestParameter(to:)`, one shared implementation since #539/#615 | `ShapeAnalysis_Curve::Project` + `GeomAPI_ProjectPointOnCurve`, minimised together with the range's ends |
+| `curve2d.project(point:)` / `curve2d.project(_:)` / `curve2d.nearestParameter(to:)` / `point2d.distance(to:)` — the 2D twin, one shared implementation since #615 | `Geom2dAPI_ProjectPointOnCurve`, minimised together with the range's ends (no 2D `ShapeAnalysis_Curve` exists) |
 
 #### Shape Proximity (v0.18.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -193,6 +193,92 @@ clear a floor the ladder never reaches. The matrix is what would have caught thi
 would not have. `Issue485SurfaceContinuityTests` had pinned the old answer as correct and is
 corrected.
 
+#### Breaking: the nearest point on a curve, for the entry points #539 left behind, and the whole 2D side (#615)
+
+#539 established that `GeomAPI_ProjectPointOnCurve::LowerDistance()` reports an *extremum*, which on
+a bounded curve is neither necessarily the nearest point nor necessarily present at all, and
+introduced `occtNearestPointOnCurveRange` — the minimum over `ShapeAnalysis_Curve`, every extremum
+in range, and both curve ends. Three entry points were converted. The shared helper behind three
+more was not, and its 2D twin was never touched.
+
+So the two spellings of one question disagreed. Measured through the public Swift API on #539's own
+repro geometry, a half circle of radius 5 over `[0, π]` queried from below at `(0, -6, 0)`:
+
+| | before | after |
+|---|---|---|
+| `Curve3D.projectPoint` (converted by #539) | param 0, distance **7.8102** | unchanged |
+| `Curve3D.nearestParameter` | param **π/2**, distance **11** | param 0, distance 7.8102 |
+| `Curve3D.nearestParameter`, point past a `[3, 8]` segment's end | **`nil`** | param 8, distance 92 |
+| `Curve2D.project(point:)` | point (0, 5), distance **11** | point (5, 0), distance 7.8102 |
+| `Curve2D.project(point:)`, past the end | **`nil`** | param 8, distance 92 |
+| `Point2D.distance(to:)`, past the end | **`.infinity`** | 92 |
+
+A caller seeding a trim or a split from `nearestParameter` landed on the opposite side of the arc
+from where `projectPoint` said the nearest point was. The two spellings disagreed about *which*
+point is nearest **and** about *whether there is one*.
+
+**Both defects, both dimensions, one helper each.** `occtNearestProjectionOnCurve3d` now routes
+through `occtNearestPointOnCurveRange`; the new `occtNearestPointOnCurve2dRange` gives the 2D side
+the equivalent treatment.
+
+**The 2D candidate set is the extrema plus both ends, and cannot be more.** `ShapeAnalysis_Curve`
+has no 2D projection — its `Project` overloads take `Geom_Curve` or `Adaptor3d_Curve` only, and its
+`Geom2d_Curve` members (`FillBndBox`, `SelectForwardSeam`, `GetSamplePoints`, `IsPeriodic`) do
+something else entirely. That is the "all extrema + the two ends" row #580 measured at 188/189
+rather than the 189/189 the third source buys; the one case it misses is `Extrema` failing to
+converge on a BSpline, where an end then wins by a fraction of a percent, and there is no 2D-*native*
+second algorithm to break that tie. (A `Geom2d_Curve` could in principle be lifted into the `z = 0`
+plane and run through the 3D `ShapeAnalysis_Curve`; not done, since that buys one case in 189 at the
+cost of a per-call curve conversion.)
+
+**Breaking: `nil` no longer means "no perpendicular foot".** A point past the end of a bounded curve
+is nearest to that end, and a circle's centre is equidistant from every point on it; all of these
+now answer with a real parameter and a true distance. `nil` (and `Point2D.distance(to:)`'s
+`.infinity`) is left meaning what it means for the entry points #539 converted: no curve to answer
+about. Affects `Curve3D.nearestParameter(to:)`, `Curve2D.nearestParameter(to:)`,
+`Curve2D.project(point:)`, `Curve2D.project(_:)`, `Point2D.distance(to:)` and the deprecated
+`parameterAtPoint`/`closestParameter` spellings, which no longer have a reachable `.nan` case on a
+real curve. They stay deprecated for the reason they always were: no `Double` can carry a failure
+signal, because every value is a legitimate parameter on some curve.
+
+**`Curve2D.allProjections(of:)` still reports nothing where the other four now answer, and that is
+correct.** It asks for the extrema, which has been a different question since #539, and on a bounded
+curve queried from beyond its end the honest answer is that there are none. Before #615 all five
+agreed only because the other four were asking the extrema question too.
+
+**`Curve3D.locateNearestPoint`: the fallback changed, the primary search deliberately did not.** The
+primary reports the **lowest-distance extremum inside a ±10% window** around `initParam`. The guess
+bounds the window; it does not rank what is found in it, so the extremum returned is not necessarily
+the one nearest the guess — measured on a ramped sine BSpline, a guess of 90.9114 returns param
+79.9751, 10.94 away, over an extremum 0.13 away at 91.0378, because the far one is closer to the
+query *point* (10.07 against 15.19); 22 of 46 multi-extremum windows behave so. The window is what
+makes the answer local, and a windowed minimum can still be a global maximum: with a guess of π/2 on
+the arc above it reports 11, and that is pinned by test.
+
+Adding the window's two ends to that minimum was considered and rejected — **not** because it would
+redefine `initParam`, which it would not, since the function already minimises over the window and
+the ends are all the change adds. It was rejected because (1) it does not make the function correct
+under its own name, answering 10.865697905689686 where the true nearest point is 7.8102 away, and
+(2) a window's ends always evaluate, so the minimum would always be found and the fallback would
+become **unreachable** — deleting the one path in this function that #615 fixes. Making the search
+global outright would leave `initParam` meaning nothing and the function a duplicate of
+`nearestParameter`.
+
+The full-range fallback is a different matter: it fires only when the window holds no extremum, at
+which point the function has already abandoned locality, so it must give the whole curve's answer.
+Measured, a guess of `0` — sitting *on* the true nearest point — used to fall through and return the
+point diametrically opposite it (π/2, distance 11); it now returns 0 at 7.8102. A `[3, 8]` segment
+queried at `(100, 0, 0)` returned `nil` for every guess and now returns param 8, distance 92.
+
+Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild. Regression suites
+`Issue615NearestParameterRangeTests` (`OCCTCurveTests`) and `Issue615Curve2DNearestPointTests`
+(`OCCTGeom2dTests`), including a 2D-vs-3D cross-check on the same geometry in the `z = 0` plane —
+the comparison neither side had, and the reason the 2D defect survived #539. Proved by injection:
+restoring both `LowerDistance` helper bodies fails 17 of the 32 tests across the five affected
+suites with 41 issues, and the test pinning the *preserved* windowed primary path keeps passing, as
+it must. The 2D sweep's ground-truth anchor was separately proved non-vacuous by over-reporting the
+distance in the helper: 9 failures with `abs()`, 0 without it.
+
 #### A NaN parameter bound stops being a plausible arc length (#548)
 
 `Curve3D.length(from:to:)` documents itself as the entry point that tells failure apart from a real

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -338,9 +338,9 @@ public func project(point p: SIMD2<Double>) -> Curve2DProjection?
 ```
 
 - **Parameters:** `p` — 2D point to project.
-- **Returns:** Nearest `Curve2DProjection`, or `nil` when the point has no projection onto the curve — one beyond the ends of a bounded curve, or a circle's centre. An ordinary outcome, not an error.
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (`NearestPoint`/`LowerDistanceParameter`/`LowerDistance`).
-- **Note:** `project(_:)` (the `Point2D` overload) and [`Point2D.distance(to:)`](Geometry2D.md) compute the same nearest solution through the same shared bridge path, so all three agree on the value and on when there is no projection (#413).
+- **Returns:** Nearest `Curve2DProjection`, always inside the curve's own domain, or `nil` when there is no curve to answer about.
+- **OCCT:** `occtNearestPointOnCurve2dRange` — the minimum over every `Geom2dAPI_ProjectPointOnCurve` extremum in range and both curve ends. There is no third source: `ShapeAnalysis_Curve` has no 2D projection (#615).
+- **Note:** `project(_:)` (the `Point2D` overload), [`Point2D.distance(to:)`](Geometry2D.md) and `nearestParameter(to:)` compute the same nearest solution through the same shared bridge path and agree with it exactly (#413, #615). The answer is the true nearest point rather than the nearest *perpendicular foot*: a point past the end of a bounded curve is nearest to that end, and a half arc queried from below answers with its near end. Until #615 all of these reported an extremum instead — the far side of that arc, `11` away where the truth is `7.81` — or `nil` where there was none. [`allProjections(of:)`](#allprojectionsof) is deliberately **not** in the agreement; it asks for the extrema, and still reports none for those points.
 - **Example:**
   ```swift
   if let circle = Curve2D.circle(center: .zero, radius: 5),
@@ -362,8 +362,9 @@ public func allProjections(of p: SIMD2<Double>) -> [Curve2DProjection]
 Capped at 64 results. Useful when a point has several local-minimum projections — e.g. a point outside a circle projects to both the near and the far side.
 
 - **Parameters:** `p` — 2D point to project.
-- **Returns:** Array of `Curve2DProjection` values, empty when there is no projection at all.
+- **Returns:** Array of `Curve2DProjection` values, empty when there is no extremum at all.
 - **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (all solutions).
+- **Note:** This asks for the **extrema** — the perpendicular feet — which since #615 is visibly a different question from "the nearest point". A bounded curve queried from beyond its end has no foot, so this returns empty where [`project(point:)`](#projectpoint) answers with the end. An extremum may also be a local *maximum*: on a half arc queried from the far side, the only element here is the point furthest away.
 - **Example:**
   ```swift
   if let circle = Curve2D.circle(center: .zero, radius: 5) {
@@ -1503,8 +1504,8 @@ public func project(_ point: Point2D) -> (parameter: Double, distance: Double)?
 ```
 
 - **Parameters:** `point` — the `Point2D` to project.
-- **Returns:** `(parameter, distance)` tuple, or `nil` when the point has no projection onto the curve.
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (`LowerDistanceParameter`/`LowerDistance`).
+- **Returns:** `(parameter, distance)` tuple, or `nil` when there is no curve to answer about.
+- **OCCT:** `occtNearestPointOnCurve2dRange`, shared with [`project(point:)`](#projectpoint), so it reports the true nearest point over the curve's own domain — a point past the end answers with that end (#615).
 - **Note:** A `parameter` of `0` is an ordinary success — projecting a segment's own start point onto it returns exactly that — so `nil` is the only failure signal. The underlying bridge function used to return `0` on failure too, conflating the two (#413).
 - **Example:**
   ```swift

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -574,7 +574,7 @@ public func projectPoint(_ point: SIMD3<Double>, precision: Double = 1e-6) -> Po
 
 Always returns a result (never `nil`); a non-zero `distance` indicates the query point was not on the curve.
 
-The answer is always inside the curve's own `domain`, and always the true nearest point. Where the query point has no perpendicular foot on the curve — anything past the end of a trimmed curve, or off to one side of an arc — the nearest point is an end, and that is what comes back. Contrast [`nearestParameter(to:)`](Curve3D-Construction.md#nearestparameterto), which reports `nil` for exactly those points instead.
+The answer is always inside the curve's own `domain`, and always the true nearest point. Where the query point has no perpendicular foot on the curve — anything past the end of a trimmed curve, or off to one side of an arc — the nearest point is an end, and that is what comes back. [`nearestParameter(to:)`](Curve3D-Construction.md#nearestparameterto) is the scalar spelling of this and agrees with it exactly; it reported `nil` for exactly those points until #615 routed it through the same helper.
 
 - **Parameters:** `point` — 3D point to project; `precision` — projection precision (default `1e-6`).
 - **Returns:** `PointProjection` with distance, parameter, and closest curve point.

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -482,10 +482,9 @@ public func nearestParameter(to point: SIMD3<Double>) -> Double?
 
 - **Parameters:** `point` — the query point in 3D space.
 - **Returns:** Parameter `u` such that `self.point(at: u)` is the nearest point on the curve to
-  `point`, or `nil` if the point has no projection at all: one beyond the ends of a bounded
-  curve, or the centre of a circle, which is equidistant from every point on it. `nil` is the
-  only answer that says so: every `Double` is a legitimate parameter on some curve.
-- **OCCT:** `GeomAPI_ProjectPointOnCurve::LowerDistanceParameter`.
+  `point`, always inside the curve's own domain, or `nil` if there is no curve to answer about.
+- **OCCT:** `occtNearestPointOnCurveRange` — the minimum over `ShapeAnalysis_Curve::Project`, every
+  `GeomAPI_ProjectPointOnCurve` extremum in range, and both curve ends.
 - **Example:**
   ```swift
   if let line = Curve3D.line(through: .zero, direction: SIMD3(1,0,0)) {
@@ -493,20 +492,32 @@ public func nearestParameter(to point: SIMD3<Double>) -> Double?
       #expect(param.map { abs($0 - 5.0) < 0.1 } == true)
   }
 
-  // A curve trimmed to [3, 8]: a point past the end has no projection.
+  // A curve trimmed to [3, 8]: a point past the end is nearest to that end.
   if let seg = Curve3D.line(through: .zero, direction: SIMD3(1,0,0))?.trimmed(from: 3, to: 8) {
-      #expect(seg.nearestParameter(to: SIMD3(100, 0, 0)) == nil)
+      #expect(seg.nearestParameter(to: SIMD3(100, 0, 0)) == 8)
+  }
+
+  // A half arc queried from below: the near end, not the extremum on the far side.
+  if let arc = Curve3D.circle(center: .zero, normal: SIMD3(0,0,1), radius: 5)?
+      .trimmed(from: 0, to: .pi) {
+      #expect(arc.nearestParameter(to: SIMD3(0, -6, 0)) == 0)   // 7.81 away, not 11
   }
   ```
 
-Contrast [`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision), which asks a
-different question and so always answers: the nearest point on the curve, which exists for every
-query point, rather than the nearest perpendicular foot, which does not. For the trimmed segment
-above it reports the curve's end, parameter `8` at distance `92` (#539).
+This is the scalar spelling of
+[`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision) and agrees with it
+exactly. Both report the true nearest point rather than the nearest *perpendicular foot*: where the
+point has no foot, the nearest point is an end, and that is the answer.
 
-`closestParameter(to:)` is the deprecated spelling of this method. It returns `.nan` where this
-one returns `nil`; before #500 it returned `0`, which is not even inside the domain of a curve
-trimmed to `[3, 8]`.
+Until #615 the two disagreed, because this one reported `GeomAPI_ProjectPointOnCurve`'s extremum:
+for the half arc above it answered π/2, the far side, 11 away, and for the trimmed segment it
+answered `nil` where `projectPoint` answered `8` at distance `92`. `Optional` remains because no
+`Double` can carry a failure signal — every value is a legitimate parameter on some curve — not
+because a point can fail to have a nearest one.
+
+`closestParameter(to:)` is the deprecated spelling of this method. It returns `.nan` where this one
+returns `nil`; before #500 it returned `0`, which is not even inside the domain of a curve trimmed
+to `[3, 8]`.
 
 ---
 

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -784,13 +784,20 @@ public func nearestParameter(to point: SIMD3<Double>) -> Double?
 ```
 
 - **Parameters:** `point` — the 3D query point.
-- **Returns:** The nearest parameter `u` on the curve, or `nil` if the point has no projection at
-  all: one beyond the ends of a bounded curve, or the centre of a circle.
-- **OCCT:** `GeomAPI_ProjectPointOnCurve` (via `OCCTCurve3DNearestParameter`).
+- **Returns:** The nearest parameter `u` on the curve, always inside its own domain, or `nil` if
+  there is no curve to answer about.
+- **OCCT:** `occtNearestPointOnCurveRange` (via `OCCTCurve3DNearestParameter`) — the minimum over
+  `ShapeAnalysis_Curve`, every `GeomAPI_ProjectPointOnCurve` extremum in range, and both ends.
+
+The true nearest point, not the nearest perpendicular foot: a point past the end of a bounded curve
+is nearest to that end, and that is the answer. Agrees exactly with
+[`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision), which shares its helper;
+until #615 this one reported an extremum instead, so the two disagreed about which point is nearest
+and about whether there was one.
 
 Replaces `parameterAtPoint(_:)` and
 [`closestParameter(to:)`](Curve3D-Construction.md#nearestparameterto), both deprecated: they ran
-the identical projection and disagreed about the no-projection case (#500).
+the identical projection and disagreed about how to report its absence (#500).
 
 ---
 
@@ -816,10 +823,17 @@ Find the 2D curve parameter nearest to a 2D point.
 public func nearestParameter(to point: SIMD2<Double>) -> Double?
 ```
 
-- **Returns:** The nearest parameter, or `nil` if the point has no projection at all. Agrees with
-  `Curve2D.project(point:)`, `Curve2D.allProjections(of:)`, `Curve2D.project(_:)` and
-  `Point2D.distance(to:)` on exactly when that is (#413, #500).
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve` (via `OCCTCurve2DNearestParameter`).
+- **Returns:** The nearest parameter, always inside the curve's own domain, or `nil` if there is no
+  curve to answer about. Agrees exactly with `Curve2D.project(point:)`, `Curve2D.project(_:)` and
+  `Point2D.distance(to:)`, which share its bridge path (#413, #500, #615).
+- **OCCT:** `occtNearestPointOnCurve2dRange` (via `OCCTCurve2DNearestParameter`) — the minimum over
+  every `Geom2dAPI_ProjectPointOnCurve` extremum in range and both ends. There is no third source:
+  `ShapeAnalysis_Curve` has no 2D projection.
+
+`Curve2D.allProjections(of:)` is **not** in that agreement, by design. It asks for the extrema, so
+it reports none where these four answer with an end — a point past the end of a bounded curve has a
+nearest point but no perpendicular foot. Before #615 all five agreed only because the other four
+were asking the extrema question too, and so were wrong.
 
 Replaces `parameterAtPoint(_:)`, deprecated: it reported the no-projection case as the curve's
 own `firstParameter`.
@@ -856,8 +870,25 @@ public func locateNearestPoint(
   - `point` — the 3D query point.
   - `initParam` — starting parameter for the local search.
   - `tolerance` — convergence tolerance.
-- **Returns:** `(parameter, distance)` tuple, or `nil` if the search diverges.
-- **OCCT:** `Extrema_ExtPC` local mode (via `OCCTExtremaLocateOnCurve`).
+- **Returns:** `(parameter, distance)` tuple, or `nil` only if there is no curve to answer about.
+- **OCCT:** `GeomAPI_ProjectPointOnCurve` over a ±10% window around `initParam`, falling back to
+  `occtNearestPointOnCurveRange` over the whole curve (via `OCCTExtremaLocateOnCurve`).
+
+Two searches with two different contracts. The **primary** one reports the **lowest-distance extremum
+inside that window** — `initParam` bounds the window, it does not rank what is found in it, so the
+extremum returned is not necessarily the one nearest the guess; where a window holds several, the one
+closest to the *query point* wins. The window is what makes the answer local, and a windowed minimum
+can still be a global *maximum*. On a half circle of radius 5 queried from `(0, -6, 0)` with a guess
+of `.pi / 2` it reports `11`, where the nearest point on the curve is `7.81` away. Use
+[`nearestParameter(to:)`](#curve3dnearestparameterto) or
+[`projectPoint(_:precision:)`](Curve3D-Analysis.md#projectpointprecision) when you want the global
+answer.
+
+The **fallback** fires only when the window holds no extremum, at which point the search has already
+abandoned locality — so since #615 it reports the whole curve's true nearest point, agreeing with
+those two. Before #615 it reported an extremum instead, so a guess sitting *on* the nearest point
+returned the point diametrically opposite it, and a bounded segment queried from past its own end
+returned `nil` for every guess.
 
 ---
 

--- a/docs/reference/Geometry2D.md
+++ b/docs/reference/Geometry2D.md
@@ -233,14 +233,14 @@ Minimum distance from this point to a 2D curve.
 public func distance(to curve: Curve2D) -> Double
 ```
 
-Returns `.infinity` when the point has no projection onto the curve at all — one beyond the ends of a bounded curve, or the centre of a circle (equidistant from every point, so there is no local minimum). This is an ordinary outcome, not an error.
+Measured over the curve's own domain, ends included, so it is the true minimum rather than the distance to the nearest *perpendicular foot*. A point beyond the end of a bounded curve is measured to that end, and a circle's centre to the radius.
 
-Before #413 this returned the bridge's raw `-1.0` sentinel for that case, which any threshold test (`distance < tolerance`) would read as "touching" — the opposite of the truth.
+Two sentinels have been retired from this one method. It first returned the bridge's raw `-1.0` for a point with no perpendicular foot, which any threshold test (`distance < tolerance`) read as "touching" — the opposite of the truth (#413). `.infinity` replaced it, which was safe but still discarded a real, finite distance: a point 92 units from a segment measured as infinitely far from it. #615 measures it instead.
 
 - **Parameters:** `curve` — the 2D curve to measure against.
-- **Returns:** Minimum distance, or `.infinity` if there is no projection.
-- **OCCT:** `Geom2dAPI_ProjectPointOnCurve::LowerDistance()`.
-- **Note:** Shares one bridge path with [`Curve2D.project(point:)`](Curve2D-Analysis.md) and `Curve2D.project(_:)`, so all three agree on the value and on when there is no projection (#413).
+- **Returns:** Minimum distance, or `.infinity` only if there is no curve to measure to.
+- **OCCT:** `occtNearestPointOnCurve2dRange` — the minimum over every `Geom2dAPI_ProjectPointOnCurve` extremum in range and both curve ends.
+- **Note:** Shares one bridge path with [`Curve2D.project(point:)`](Curve2D-Analysis.md), `Curve2D.project(_:)` and `Curve2D.nearestParameter(to:)`, so all four agree exactly (#413, #615).
 - **Example:**
   ```swift
   if let p = Point2D(x: 5.0, y: 5.0),


### PR DESCRIPTION
#539 established that `GeomAPI_ProjectPointOnCurve::LowerDistance()` reports an *extremum*, which on
a bounded curve is neither necessarily the nearest point nor necessarily present at all, and
introduced `occtNearestPointOnCurveRange` — the minimum over `ShapeAnalysis_Curve`, every extremum in
range, and both curve ends. Three entry points were converted. The shared helper behind three more
was not, and its 2D twin was never touched.

## Measured before the fix, through the public Swift API

The issue predicted 11 vs 7.81 on #539's own geometry (half circle radius 5 over `[0, π]`, queried
from below at `(0, -6, 0)`). Verified, not assumed — measured on the true head of
`refactor/381-pass1b`, before and after:

| call | before | after |
|---|---|---|
| `Curve3D.projectPoint((0,-6,0))` (converted by #539) | param 0, distance **7.810249675906654** | unchanged |
| `Curve3D.nearestParameter((0,-6,0))` | param **π/2**, its point **11** away | param 0, distance 7.810249675906654 |
| `Curve3D.nearestParameter((3,-4,0))` | param 2.2143, **10** away | param 0, distance 4.47213595499958 |
| `Curve3D.nearestParameter((100,0,0))` on a `[3,8]` segment | **`nil`** | **8** |
| `Curve3D.nearestParameter((0,0,0))` on the same segment | **`nil`** | **3** |
| `Curve3D.locateNearestPoint((0,-6,0), initParam: 0)` | (**π/2**, **11**) | (0, 7.810249675906654) |
| `Curve3D.locateNearestPoint((100,0,0), initParam: any)` | **`nil`** | (8, 92) |
| `Curve2D.project(point:(0,-6))` | point (0,5), param π/2, distance **11** | point (5,0), param 0, distance 7.810249675906654 |
| `Curve2D.project(point:(3,-4))` | distance **10** | distance 4.47213595499958 |
| `Curve2D.project(point:(100,0))` on a `[3,8]` segment | **`nil`** | param 8, distance 92 |
| `Point2D(0,-6).distance(to: arc2D)` | **11** | 7.810249675906654 |
| `Point2D(100,0).distance(to: segment2D)` | **`.infinity`** | **92** |

Both defects the issue names, in both dimensions. A caller seeding a trim or a split from
`nearestParameter` landed on the opposite side of the arc from where `projectPoint` said the nearest
point was, and the 3D and 2D answers for the same geometry in the `z = 0` plane disagreed with each
other.

## The fix

- `occtNearestProjectionOnCurve3d` (`OCCTBridge_Curve3D.mm`) now routes through
  `occtNearestPointOnCurveRange`, exactly as #539/#580 did for the three converted entry points.
- **New `occtNearestPointOnCurve2dRange`** (`OCCTBridge_Internal.h`, next to its 3D twin) gives the
  2D side the equivalent treatment, and `occtNearestProjectionOnCurve2d` routes through it.

**The 2D candidate set is the extrema plus both ends, and cannot be more.** As the issue anticipated:
`ShapeAnalysis_Curve` has **no 2D projection**. Its `Project` overloads take `Geom_Curve` or
`Adaptor3d_Curve` only; its `Geom2d_Curve` members (`FillBndBox`, `SelectForwardSeam`,
`GetSamplePoints`, `IsPeriodic`) do something else entirely — checked against the pinned
`ShapeAnalysis_Curve.hxx`. So the 2D helper is the "all extrema + the two ends" row #580 measured at
188/189 rather than the 189/189 the third source buys. The one case it misses is `Extrema` failing to
converge on a BSpline, where an end then wins by a fraction of a percent; there is no second 2D
algorithm available to break that tie, and that is stated in the helper's own comment.

### Breaking: `nil` no longer means "no perpendicular foot"

A point past the end of a bounded curve is nearest to that end, and a circle's centre is equidistant
from every point on it; all of these now answer with a real parameter and a true distance. `nil` (and
`Point2D.distance(to:)`'s `.infinity`) is left meaning what it already means for the entry points
#539 converted: no curve to answer about.

`Curve2D.allProjections(of:)` still reports nothing where the other four now answer, **and that is
correct** — it asks for the extrema, which has been a different question since #539. Before #615 all
five agreed only because the other four were asking the extrema question too.

## The `OCCTExtremaLocateOnCurve` judgement call

The issue flagged this: the fallback may be deliberately reporting an extremum rather than a nearest
point. **Measured, then decided: change the fallback, leave the primary search alone.**

**Corrected in review — how the primary selects.** An earlier revision of this PR described the
primary as reporting "the extremum *nearest the guess*". That is false, and the review was right to
block on it. The selection is `LowerDistanceParameter()`: the **lowest-distance extremum within a
±10% window** around `initParam`. The guess *bounds* the window; nothing ranks what is found inside
it by proximity to the guess. Verified independently on a ramped sine BSpline — a guess of 71.4232
returns param 60.7466, **10.68** away from the guess, in preference to an extremum **10.47** away,
because the far one is closer to the query *point* (25.69 against 31.28); **30 of 59** multi-extremum
windows in that sweep behave this way. The wording is corrected at all five sites, including the
public `///` and the `docs/reference` page.

**The primary search stays as it is.** The window is what makes the answer local, and a windowed
minimum can still be a global *maximum*: with a guess of π/2 on the arc above it reports 11, where
the nearest point is 7.81 away. Two alternatives were considered and rejected:

- Add the window's two ends to that minimum. **The review correctly narrowed this argument**: since
  the function already minimises over the window, the ends are all the change adds, so it would
  *not* redefine `initParam` as I first wrote. It is rejected on the two remaining grounds — (1) it
  answers **10.865697905689686**, still not the global 7.81, so it does not make the function correct
  under its own name, and (2) a window's ends always evaluate, so the minimum would always be found
  and **the fallback would become unreachable**, deleting the one path in this function that #615
  fixes.
- Make it global outright. Then `initParam` means nothing and the function is a duplicate of
  `nearestParameter`.

So the primary path is byte-identical, and a test pins it (`locatePrimarySearchStaysLocal`) so it is
not "fixed" by accident.

**The fallback was a different matter, and was wrong.** It fires precisely when the window holds no
extremum, at which point the function has *already* abandoned locality and searched the whole curve.
Having done that, it must give the whole curve's answer — which is the one `OCCTCurve3DNearestParameter`
gives, and #615 is that those two disagreed. Measured, the fallback's own failure was worse than the
issue implies: `locateNearestPoint((0,-6,0), initParam: 0)`, a guess sitting **on** the true nearest
point, fell through and returned the point diametrically opposite it (π/2, distance 11); and a `[3,8]`
segment queried at `(100,0,0)` returned `nil` for every guess, because neither the window nor a
full-range extremum search contains a perpendicular foot anywhere.

## Did `fix(#549)` affect the 2D conversion?

**No.** `fix(#549)` (627a07c) is the only recent commit touching `OCCTBridge_Geom2d.mm`, and its diff
there is 5 insertions / 12 deletions confined to the arc-length path (`OCCTCurve2DLength` removal and
its tombstone). It touches no member of the projection family —
`occtNearestProjectionOnCurve2d`, `OCCTCurve2DProjectPoint`, `OCCTCurve2DProjectPoint2D`,
`OCCTPoint2DDistanceToCurve` and `OCCTCurve2DNearestParameter` are all unchanged by it. Verified by
grepping the commit's own diff, and the pre-fix 2D measurements reproduce identically on the true head.

*(Housekeeping: rebased three times as `refactor/381-pass1b` moved — onto 196b703, 3d20ff7, and now
0fb3cc3 with #627/#628/#630 merged. All CHANGELOG conflicts were add/add at the same anchor and every
entry is kept, which the 86-insertion / 0-deletion diff on that file confirms. All measurements were
re-taken after each rebase.)*

## Tests

- **`Issue615NearestParameterRangeTests`** (`OCCTCurveTests`, 6 tests) — the half-circle-from-below
  case, the point on the circle but off the arc, the out-of-domain point, a sweep asserting
  `nearestParameter` and `projectPoint` agree across 8 curve/point combinations, and both halves of
  the `locateNearestPoint` decision.
- **`Issue615Curve2DNearestPointTests`** (`OCCTGeom2dTests`, 5 tests) — the same through all four 2D
  spellings, plus a **2D-vs-3D cross-check** on the same geometry in the `z = 0` plane. That
  comparison is the one neither side had, and the reason the 2D defect survived #539.
- Updated for the new contract: `Issue500Curve3DNearestParameterTests`,
  `Issue539NearestPointOnCurveTests`, `Curve2DProjectionParityTests`.

### Proved by injection

Reverting both helper bodies to the pre-fix `LowerDistance` form and re-running the five affected
suites: **17 of 32 tests fail with 41 issues**. Restoring: **32/32 pass**. Both outcomes were run and
recorded. `locatePrimarySearchStaysLocal` — the test pinning the *preserved* windowed primary path —
keeps passing under injection, as it must, since the fix does not change that path.

*(The count is 17, not the 15 I first reported. My original tally used `sort -u` on test names, which
silently merged three names that exist in **both** the 3D and 2D suites. The 41-issue figure was
right throughout, and 17 per-test failure lines sum to exactly 41.)*

### The 2D anchor, proved non-vacuous

The review caught a missing `abs()` on the sweep's only ground-truth assertion — the other four
comparisons in `theFourSpellingsAgree` check spellings that share one bridge path, so they would
agree even if all four were wrong. As written it passed for **any** reported distance larger than the
truth, which is the exact direction every defect in this issue erred in. Fixed, and proved by a
second, targeted injection: over-reporting the distance in `occtNearestPointOnCurve2dRange`
(`bestDistance * 2.0`) gives **9 failures with `abs()` and 0 without it**, against the identical bug.

## Docs

`docs/CHANGELOG.md` (Unreleased), `docs/API_REFERENCE.md`, four `docs/reference/` pages
(`Curve3D-Construction.md`, `Curve3D-Analysis.md`, `Curve2D-Analysis.md`, `Geometry2D.md`,
`Document-Mesh-Fixing.md`), the `///` comments on all eight affected Swift entry points, the two
`@available(deprecated:)` messages that promised a `.nan` case that no longer exists, and six
`OCCTBridge.h` declarations plus its two cross-reference index rows — the 3D row said "the last three"
route through the helper, and it is now five. `Scripts/check-bridge-index.py` reports 0 stale (its 7
misfiled `GCPnts_AbscissaPoint` rows are pre-existing and untouched by this diff);
`Scripts/check-null-handle-guards.py` clean.

Two non-blocking review notes also applied: the 2D helper now says there is no 2D-**native** second
algorithm (a `Geom2d_Curve` could in principle be lifted into the `z = 0` plane and run through the 3D
`ShapeAnalysis_Curve`; not done, since #580 measured extrema-plus-ends at 188/189, so it buys one case
in 189 for a per-call conversion), and the `Precision::Confusion()` precedent is now attributed to its
actual sites, `OCCTBridge_Properties.mm:599` and `OCCTBridge_Topology.mm:1255`, rather than to this
file.

Bridge-only: no kernel patch, no `OCCT.xcframework` rebuild. `swift build` clean; full suite green
(**5232 tests in 1390 suites**) on the final base; `check-bridge-index.py` **0 stale / 0 misfiled**
(the 7 misfiled `GCPnts_AbscissaPoint` rows I previously flagged as pre-existing were fixed by #630,
which this branch is now rebased onto); `check-null-handle-guards.py` clean.

Closes #615
