### PR TITLE
fix(#622): the 21 result-buffer capacities #558's sampler-shaped sweep could not see

### DIFF
--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -2780,8 +2780,13 @@ extension Curve2D {
     }
 
     /// Split this curve at C1 discontinuities.
+    ///
+    /// - Parameter maxSegments: Output *capacity* (default 32), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     public func splitAtContinuity(continuity: Int = 1, tolerance: Double = 1e-6,
                                   maxSegments: Int = 32) -> [Curve2D] {
+        let maxSegments = Sampling.capacity(maxSegments)
+        guard maxSegments > 0 else { return [] }
         var refs = [OCCTCurve2DRef?](repeating: nil, count: maxSegments)
         let n = refs.withUnsafeMutableBufferPointer { buf in
             OCCTCurve2DSplitAtContinuity(handle, Int32(continuity), tolerance,

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -785,9 +785,12 @@ extension Curve3D {
     ///
     /// - Parameters:
     ///   - other: The other curve
-    ///   - maxCount: Maximum number of extrema to return
+    ///   - maxCount: Output *capacity* (default 20), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of extremal distance results
     public func extrema(with other: Curve3D, maxCount: Int = 20) -> [CurveExtremaResult] {
+        let maxCount = Sampling.capacity(maxCount)
+        guard maxCount > 0 else { return [] }
         var buffer = [OCCTCurveExtrema](repeating: OCCTCurveExtrema(), count: maxCount)
         let n = Int(OCCTCurve3DExtrema(handle, other.handle, &buffer, Int32(maxCount)))
         return (0..<n).map { i in
@@ -805,9 +808,12 @@ extension Curve3D {
     ///
     /// - Parameters:
     ///   - surface: The surface to intersect with
-    ///   - maxHits: Maximum number of hits to return
+    ///   - maxHits: Output *capacity* (default 100), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of intersection points with parameters
     public func intersections(with surface: Surface, maxHits: Int = 100) -> [CurveSurfaceHit] {
+        let maxHits = Sampling.capacity(maxHits)
+        guard maxHits > 0 else { return [] }
         var buffer = [OCCTCurveSurfaceIntersection](repeating: OCCTCurveSurfaceIntersection(), count: maxHits)
         let n = Int(OCCTCurve3DIntersectSurface(handle, surface.handle, &buffer, Int32(maxHits)))
         return (0..<n).map { i in
@@ -2236,9 +2242,14 @@ extension Curve3D {
     }
 
     /// Split this curve at C1 discontinuities.
-    /// Returns array of BSpline segments. maxSegments limits output size.
+    ///
+    /// - Parameter maxSegments: Output *capacity* (default 32), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
+    /// - Returns: Array of BSpline segments.
     public func splitAtContinuity(continuity: Int = 1, tolerance: Double = 1e-6,
                                   maxSegments: Int = 32) -> [Curve3D] {
+        let maxSegments = Sampling.capacity(maxSegments)
+        guard maxSegments > 0 else { return [] }
         var refs = [OCCTCurve3DRef?](repeating: nil, count: maxSegments)
         let n = refs.withUnsafeMutableBufferPointer { buf in
             OCCTCurve3DSplitAtContinuity(handle, Int32(continuity), tolerance,

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -6857,12 +6857,15 @@ extension Shape {
     /// The shape is meshed automatically.
     /// - Parameters:
     ///   - tolerance: Overlap tolerance (default: 0.0).
-    ///   - maxPairs: Maximum number of pairs to return (default: 100).
+    ///   - maxPairs: Output *capacity* (default: 100), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     ///   - deflection: Linear mesh deflection (mm) for the detection triangulation. Default `0.1`.
     /// - Returns: Array of overlapping face index pairs, empty if none found.
     public func selfIntersectionPairs(tolerance: Double = 0.0,
                                        maxPairs: Int = 100,
                                        deflection: Double = 0.1) -> [OverlapPair] {
+        let maxPairs = Sampling.capacity(maxPairs)
+        guard maxPairs > 0 else { return [] }
         var idx1 = [Int32](repeating: 0, count: maxPairs)
         var idx2 = [Int32](repeating: 0, count: maxPairs)
         let count = OCCTShapeSelfIntersectionPairs(handle, tolerance, &idx1, &idx2, Int32(maxPairs), deflection)
@@ -8597,7 +8600,12 @@ public enum UnicodeUtils {
     }
 
     /// Convert from UTF-8 to current format.
+    ///
+    /// - Parameter maxSize: Output buffer *capacity* in bytes (default 4096), clamped into
+    ///   `0...` ``Sampling/maximumSampleCount``; 0 or less returns `nil` (#622).
     public static func convertFromUnicode(_ utf8Input: String, maxSize: Int = 4096) -> String? {
+        let maxSize = Sampling.capacity(maxSize)
+        guard maxSize > 0 else { return nil }
         var output = [CChar](repeating: 0, count: maxSize)
         guard OCCTUnicodeConvertFromUnicode(utf8Input, &output, Int32(maxSize)) else { return nil }
         let result = output.withUnsafeBufferPointer { buf in
@@ -8688,8 +8696,13 @@ public enum DraftInfo {
 /// Logarithmic sampling utilities.
 public enum LogSample {
     /// Compute logarithmically spaced parameter values between a and b.
+    ///
+    /// - Parameter n: A *request* for exactly this many values, honoured in full or not at all:
+    ///   outside `1...` ``Sampling/maximumSampleCount`` this returns empty rather than a coarser
+    ///   sampling than was asked for (#622). The bridge fills the buffer exactly, so unlike a
+    ///   capacity there is nothing here to truncate.
     public static func sample(from a: Double, to b: Double, count n: Int) -> [Double] {
-        guard n > 0 else { return [] }
+        guard let n = Sampling.requested(n, atLeast: 1) else { return [] }
         var params = [Double](repeating: 0, count: n)
         OCCTLogSample(a, b, Int32(n), &params)
         return params
@@ -9138,7 +9151,12 @@ public enum DirectoryIterator {
     }
 
     /// List directory names matching mask.
+    ///
+    /// - Parameter maxCount: Output *capacity* (default 1000), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     public static func list(path: String, mask: String = "*", maxCount: Int = 1000) -> [String] {
+        let maxCount = Sampling.capacity(maxCount)
+        guard maxCount > 0 else { return [] }
         var names = [UnsafeMutablePointer<CChar>?](repeating: nil, count: maxCount)
         let count = Int(OCCTDirectoryList(path, mask, &names, Int32(maxCount)))
         var result: [String] = []
@@ -9170,7 +9188,12 @@ public enum FileIterator {
     }
 
     /// List file names matching mask.
+    ///
+    /// - Parameter maxCount: Output *capacity* (default 1000), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     public static func list(path: String, mask: String = "*", maxCount: Int = 1000) -> [String] {
+        let maxCount = Sampling.capacity(maxCount)
+        guard maxCount > 0 else { return [] }
         var names = [UnsafeMutablePointer<CChar>?](repeating: nil, count: maxCount)
         let count = Int(OCCTFileList(path, mask, &names, Int32(maxCount)))
         var result: [String] = []
@@ -12324,7 +12347,12 @@ extension Curve3D {
     }
 
     /// Global point-to-curve projection returning all extrema. Returns array of (parameter, distance).
+    ///
+    /// - Parameter maxResults: Output *capacity* (default 10), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     public func projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(parameter: Double, distance: Double)] {
+        let maxResults = Sampling.capacity(maxResults)
+        guard maxResults > 0 else { return [] }
         var params = [Double](repeating: 0, count: maxResults)
         var distances = [Double](repeating: 0, count: maxResults)
         let n = Int(OCCTExtremaPointCurve(handle, point.x, point.y, point.z,
@@ -12344,7 +12372,12 @@ extension Surface {
     }
 
     /// Global point-to-surface projection returning all extrema. Returns array of (u, v, distance).
+    ///
+    /// - Parameter maxResults: Output *capacity* (default 10), clamped into `0...`
+    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     public func projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(u: Double, v: Double, distance: Double)] {
+        let maxResults = Sampling.capacity(maxResults)
+        guard maxResults > 0 else { return [] }
         var us = [Double](repeating: 0, count: maxResults)
         var vs = [Double](repeating: 0, count: maxResults)
         var distances = [Double](repeating: 0, count: maxResults)

--- a/Sources/OCCTSwift/HatchPattern.swift
+++ b/Sources/OCCTSwift/HatchPattern.swift
@@ -37,7 +37,8 @@ public enum HatchPattern {
     ///   - direction: Direction of hatch lines
     ///   - spacing: Distance between hatch lines
     ///   - offset: Offset of the first hatch line from origin (default: 0)
-    ///   - maxSegments: Maximum output segments (default: 10000)
+    ///   - maxSegments: Output *capacity* (default: 10000), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of hatch line segments
     public static func generate(
         boundary: [SIMD2<Double>],
@@ -46,6 +47,7 @@ public enum HatchPattern {
         offset: Double = 0,
         maxSegments: Int = 10000
     ) -> [HatchSegment] {
+        let maxSegments = Sampling.capacity(maxSegments)
         guard boundary.count >= 3, spacing > 0, maxSegments > 0 else { return [] }
         let flat = boundary.flatMap { [$0.x, $0.y] }
         var outBuf = [Double](repeating: 0, count: maxSegments * 4)

--- a/Sources/OCCTSwift/KDTree.swift
+++ b/Sources/OCCTSwift/KDTree.swift
@@ -60,9 +60,11 @@ public final class KDTree: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - point: The query point
-    ///   - k: Number of neighbors to find
+    ///   - k: Output *capacity*, clamped into `0...` ``Sampling/maximumSampleCount``; 0 or less
+    ///     returns empty (#622). Fewer than `k` come back when the tree holds fewer points.
     /// - Returns: Array of (0-based index, squared distance) tuples, sorted by distance
     public func kNearest(to point: SIMD3<Double>, k: Int) -> [(index: Int, squaredDistance: Double)] {
+        let k = Sampling.capacity(k)
         guard k > 0 else { return [] }
         var indices = [Int32](repeating: 0, count: k)
         var sqDists = [Double](repeating: 0, count: k)
@@ -76,9 +78,11 @@ public final class KDTree: @unchecked Sendable {
     /// - Parameters:
     ///   - center: Center of the search sphere
     ///   - radius: Radius of the search sphere
-    ///   - maxResults: Maximum number of results (default: 1000)
+    ///   - maxResults: Output *capacity* (default: 1000), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of 0-based indices of points within the sphere
     public func rangeSearch(center: SIMD3<Double>, radius: Double, maxResults: Int = 1000) -> [Int] {
+        let maxResults = Sampling.capacity(maxResults)
         guard radius > 0, maxResults > 0 else { return [] }
         var indices = [Int32](repeating: 0, count: maxResults)
         let n = Int(OCCTKDTreeRangeSearch(handle, center.x, center.y, center.z,
@@ -91,9 +95,11 @@ public final class KDTree: @unchecked Sendable {
     /// - Parameters:
     ///   - min: Minimum corner of the box
     ///   - max: Maximum corner of the box
-    ///   - maxResults: Maximum number of results (default: 1000)
+    ///   - maxResults: Output *capacity* (default: 1000), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of 0-based indices of points within the box
     public func boxSearch(min: SIMD3<Double>, max: SIMD3<Double>, maxResults: Int = 1000) -> [Int] {
+        let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
         var indices = [Int32](repeating: 0, count: maxResults)
         let n = Int(OCCTKDTreeBoxSearch(handle, min.x, min.y, min.z,

--- a/Sources/OCCTSwift/Sampling.swift
+++ b/Sources/OCCTSwift/Sampling.swift
@@ -24,6 +24,12 @@ public enum Sampling {
     /// orders of magnitude below the `int32_t` the bridge takes its count in, which is where the
     /// process used to abort instead.
     ///
+    /// Since #622 the same ceiling also bounds result buffers whose element is not a point, so
+    /// "10 million points / ~625 MB" is the floor of its memory cost, not the whole of it: a
+    /// ray hit is 88 bytes (about 880 MB at the ceiling) and a hatch segment is four doubles.
+    /// The ceiling is deliberately *not* per-element-size — it is a count, and the `int32_t`
+    /// conversion it keeps callers away from traps identically whatever the element weighs.
+    ///
     /// ```swift
     /// let curve = Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))!
     /// curve.drawUniform(pointCount: Sampling.maximumSampleCount + 1).isEmpty   // true

--- a/Sources/OCCTSwift/Selection.swift
+++ b/Sources/OCCTSwift/Selection.swift
@@ -50,7 +50,10 @@ extension Shape {
     ///   - tolerance: Intersection tolerance (default: 0.001). Since #529 this bounds the
     ///     intersection only; the surface normal reported for each hit is computed at the same
     ///     resolution as every other local-property call, so raising it no longer erases normals.
-    ///   - maxHits: Maximum number of hits to return (default: 100)
+    ///   - maxHits: Output *capacity* (default: 100), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622). The ray decides how
+    ///     many surfaces it actually crosses, so this only truncates — clamping an unservable
+    ///     capacity returns the same hits, not a coarser set.
     /// - Returns: Array of ray hits sorted by distance
     public func raycast(
         origin: SIMD3<Double>,
@@ -58,18 +61,19 @@ extension Shape {
         tolerance: Double = 0.001,
         maxHits: Int = 100
     ) -> [RayHit] {
-        guard maxHits > 0 else { return [] }
-        
+        let capacity = Sampling.capacity(maxHits)
+        guard capacity > 0 else { return [] }
+
         // Allocate buffer for hits
-        var hitBuffer = [OCCTRayHit](repeating: OCCTRayHit(), count: maxHits)
-        
+        var hitBuffer = [OCCTRayHit](repeating: OCCTRayHit(), count: capacity)
+
         let hitCount = OCCTShapeRaycast(
             handle,
             origin.x, origin.y, origin.z,
             direction.x, direction.y, direction.z,
             tolerance,
             &hitBuffer,
-            Int32(maxHits)
+            Int32(capacity)
         )
         
         guard hitCount > 0 else { return [] }

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -146,12 +146,15 @@ public final class Selector: @unchecked Sendable {
     ///   - pixel: Pixel coordinates in the viewport.
     ///   - camera: The camera providing projection/view transforms.
     ///   - viewSize: Viewport size in pixels (width, height).
-    ///   - maxResults: Maximum number of results to return (default 32).
+    ///   - maxResults: Output *capacity* (default 32), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of pick results sorted by depth (nearest first).
     public func pick(at pixel: SIMD2<Double>,
                      camera: Camera,
                      viewSize: SIMD2<Double>,
                      maxResults: Int = 32) -> [PickResult] {
+        let maxResults = Sampling.capacity(maxResults)
+        guard maxResults > 0 else { return [] }
         var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
         let count = OCCTSelectorPick(handle, camera.handle,
                                      viewSize.x, viewSize.y,
@@ -172,12 +175,15 @@ public final class Selector: @unchecked Sendable {
     ///   - rect: Rectangle defined by (min, max) pixel coordinates.
     ///   - camera: The camera providing projection/view transforms.
     ///   - viewSize: Viewport size in pixels (width, height).
-    ///   - maxResults: Maximum number of results to return (default 32).
+    ///   - maxResults: Output *capacity* (default 32), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of pick results for all shapes intersecting the rectangle.
     public func pick(rect: (min: SIMD2<Double>, max: SIMD2<Double>),
                      camera: Camera,
                      viewSize: SIMD2<Double>,
                      maxResults: Int = 32) -> [PickResult] {
+        let maxResults = Sampling.capacity(maxResults)
+        guard maxResults > 0 else { return [] }
         var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
         let count = OCCTSelectorPickRect(handle, camera.handle,
                                          viewSize.x, viewSize.y,
@@ -202,13 +208,15 @@ public final class Selector: @unchecked Sendable {
     ///   - polygon: Array of pixel coordinates defining the polygon vertices.
     ///   - camera: The camera providing projection/view transforms.
     ///   - viewSize: Viewport size in pixels (width, height).
-    ///   - maxResults: Maximum number of results to return (default 32).
+    ///   - maxResults: Output *capacity* (default 32), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of pick results for all shapes inside the polygon.
     public func pick(polygon: [SIMD2<Double>],
                      camera: Camera,
                      viewSize: SIMD2<Double>,
                      maxResults: Int = 32) -> [PickResult] {
-        guard polygon.count >= 3 else { return [] }
+        let maxResults = Sampling.capacity(maxResults)
+        guard polygon.count >= 3, maxResults > 0 else { return [] }
         var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
         var polyXY = [Double]()
         polyXY.reserveCapacity(polygon.count * 2)

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6575,8 +6575,11 @@ extension Shape {
     /// - Parameters:
     ///   - other: The other shape
     ///   - maxSolutions: Output *capacity* (default 32), clamped into `0...`
-    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
-    /// - Returns: Array of distance solutions, or nil on failure
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns an empty array (**not** `nil`, as
+    ///     it did before #622 — the bridge answers -1 for a non-positive capacity and that was
+    ///     being reported as a failed measurement rather than as no room offered).
+    /// - Returns: Array of distance solutions, or `nil` on failure. No capacity is not a
+    ///   failure: it returns `[]`.
     public func allDistanceSolutions(to other: Shape, maxSolutions: Int = 32) -> [DistanceSolution]? {
         let maxSolutions = Sampling.capacity(maxSolutions)
         guard maxSolutions > 0 else { return [] }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6574,9 +6574,12 @@ extension Shape {
     /// Useful for finding multiple closest/farthest point pairs.
     /// - Parameters:
     ///   - other: The other shape
-    ///   - maxSolutions: Maximum number of solutions to return (default 32)
+    ///   - maxSolutions: Output *capacity* (default 32), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of distance solutions, or nil on failure
     public func allDistanceSolutions(to other: Shape, maxSolutions: Int = 32) -> [DistanceSolution]? {
+        let maxSolutions = Sampling.capacity(maxSolutions)
+        guard maxSolutions > 0 else { return [] }
         var buffer = [OCCTDistanceSolution](repeating: OCCTDistanceSolution(), count: maxSolutions)
         let count = OCCTShapeAllDistanceSolutions(handle, other.handle, &buffer, Int32(maxSolutions))
         guard count >= 0 else { return nil }

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1104,9 +1104,12 @@ extension Surface {
     /// - Parameters:
     ///   - other: The other surface
     ///   - tolerance: Intersection tolerance
-    ///   - maxCurves: Maximum number of intersection curves
+    ///   - maxCurves: Output *capacity* (default 50), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of intersection curves
     public func intersections(with other: Surface, tolerance: Double = 1e-6, maxCurves: Int = 50) -> [Curve3D] {
+        let maxCurves = Sampling.capacity(maxCurves)
+        guard maxCurves > 0 else { return [] }
         var handles = [OCCTCurve3DRef?](repeating: nil, count: maxCurves)
         let n = Int(OCCTSurfaceIntersect(handle, other.handle, tolerance, &handles, Int32(maxCurves)))
         return (0..<n).compactMap { i in

--- a/Tests/OCCTMiscTests/Issue622AllocationBoundsTests.swift
+++ b/Tests/OCCTMiscTests/Issue622AllocationBoundsTests.swift
@@ -145,7 +145,13 @@ struct Issue622AllocationBounds {
         let b = box(), s = sphere()
         #expect(b.allDistanceSolutions(to: s, maxSolutions: Self.pastInt32)?.count
                 == b.allDistanceSolutions(to: s)?.count)
+        // Behaviour change, asserted deliberately rather than incidentally: no capacity now yields
+        // an empty array, where before #622 the bridge's -1 for `maxSolutions <= 0` came back
+        // through `guard count >= 0` as `nil` — "the measurement failed" for what is really "no
+        // room was offered". `nil` is now reserved for an actual failure.
+        #expect(b.allDistanceSolutions(to: s, maxSolutions: 0) != nil)
         #expect(b.allDistanceSolutions(to: s, maxSolutions: 0)?.count == 0)
+        #expect(b.allDistanceSolutions(to: s, maxSolutions: -1) != nil)
         #expect(b.allDistanceSolutions(to: s, maxSolutions: -1)?.count == 0)
     }
 
@@ -238,19 +244,34 @@ struct Issue622AllocationBounds {
 
     @Test("directory and file listing clamp maxCount rather than trapping")
     func listingCapacities() {
-        // Comparing against a *small* capacity rather than the default, since /tmp's real entry
-        // count is not something a test may assume is under the 1000 default.
-        let dirSmall = DirectoryIterator.list(path: "/tmp", maxCount: 5).count
-        #expect(dirSmall <= 5)
-        #expect(DirectoryIterator.list(path: "/tmp", maxCount: Self.pastInt32).count >= dirSmall)
-        #expect(DirectoryIterator.list(path: "/tmp", maxCount: 0).count == 0)
-        #expect(DirectoryIterator.list(path: "/tmp", maxCount: -1).count == 0)
+        // A directory this test does not own cannot be assumed to hold a fixed number of entries,
+        // so the clamp is asserted against a baseline taken in the same call sequence rather than
+        // against a literal. An earlier version compared only `>= aSmallCapacityCount`, which both
+        // sides satisfy when the directory is empty — that asserted the absence of a trap and
+        // nothing about the clamp.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occt622-listing-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        for i in 0..<7 {
+            FileManager.default.createFile(atPath: dir.appendingPathComponent("f\(i).txt").path,
+                                           contents: Data("x".utf8))
+        }
+        let path = dir.path
 
-        let fileSmall = FileIterator.list(path: "/tmp", maxCount: 5).count
-        #expect(fileSmall <= 5)
-        #expect(FileIterator.list(path: "/tmp", maxCount: Self.pastInt32).count >= fileSmall)
-        #expect(FileIterator.list(path: "/tmp", maxCount: 0).count == 0)
-        #expect(FileIterator.list(path: "/tmp", maxCount: -1).count == 0)
+        // 7 files in a directory of our own: the clamped capacity returns all of them, exactly as
+        // a generous-but-servable capacity does.
+        let fileBaseline = FileIterator.list(path: path, maxCount: 1000).count
+        #expect(fileBaseline == 7)
+        #expect(FileIterator.list(path: path, maxCount: Self.pastInt32).count == fileBaseline)
+        #expect(FileIterator.list(path: path, maxCount: 3).count == 3)      // a real capacity truncates
+        #expect(FileIterator.list(path: path, maxCount: 0).count == 0)
+        #expect(FileIterator.list(path: path, maxCount: -1).count == 0)
+
+        let dirBaseline = DirectoryIterator.list(path: path, maxCount: 1000).count
+        #expect(DirectoryIterator.list(path: path, maxCount: Self.pastInt32).count == dirBaseline)
+        #expect(DirectoryIterator.list(path: path, maxCount: 0).count == 0)
+        #expect(DirectoryIterator.list(path: path, maxCount: -1).count == 0)
     }
 
     // MARK: - The one request in the set

--- a/Tests/OCCTMiscTests/Issue622AllocationBoundsTests.swift
+++ b/Tests/OCCTMiscTests/Issue622AllocationBoundsTests.swift
@@ -1,0 +1,268 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #622: the tail of #558's bound sweep. The same footgun — a caller-supplied number sizes a Swift
+// allocation and is then cast to the `int32_t` the bridge takes its capacity in — on 21 entry
+// points the sweep's stopping criterion never reached, because it scoped itself to *samplers* and
+// these are result-buffer capacities on picking, searching, projection, intersection and listing.
+//
+// The review that filed #622 named four (`Shape.raycast`, two in `Document.swift`, one in
+// `MedialAxis.swift`). Two of those four do not survive re-measurement: `MedialAxis.drawArc` was
+// already bounded by #558 itself, and the two `Document.swift` line numbers land on unrelated
+// code. So the named list was neither complete nor correct, exactly as #558's own lesson (census
+// said 14, measurement said 28) predicted. Measurement is the only thing that settles it.
+//
+// Measured before the fix, one case per process (a trap takes the whole harness down, so each
+// absurd input needs its own run) against `refactor/381-pass1b`. 18 of the 21 are cheap to drive
+// from a standalone binary; all 18 failed at `Int32.max + 1` — 2 aborted immediately with "Fatal
+// error: Not enough memory" and 16 ground past a 40-second timeout on an allocation nothing can
+// serve. 12 of the 18 also aborted on `-1`, in `Array(repeating:count:)`, before any bound could
+// be consulted. The remaining 3 (`Selector.pick`'s overloads) need a live selector and were
+// converted on inspection; they are covered in-process below.
+//
+// These tests can run in-process precisely because the fix is what makes them able to: before it,
+// every #expect below would have aborted the test harness rather than failing.
+//
+// Contract, unchanged from #558 rather than a fifth behaviour: all 21 of these are *capacities*
+// (the algorithm decides how many results exist and the number only truncates), so they clamp into
+// `0...Sampling.maximumSampleCount` — the caller gets the real answer, not an empty one. The one
+// exception is `LogSample.sample(count:)`, whose bridge fills the buffer exactly; that is a
+// *request*, so it rejects rather than silently returning a coarser sampling. Same split #558 drew
+// between `Curve3D.drawAdaptive` and `MedialAxis.drawArc`.
+//
+// The emptiness assertions compare `.count == 0` rather than reading `.isEmpty`, for the reason
+// #558 recorded: Swift Testing prints the captured sub-expression on failure, and a regression
+// that returns 10 million results would print all 10 million of them.
+@Suite("Issue #622: result-buffer capacities bound the count a caller can supply", .serialized)
+struct Issue622AllocationBounds {
+
+    // `Int32.max + 1`, the first count provably past the bridge's own count type.
+    private static let pastInt32 = Int(Int32.max) + 1
+
+    private func box() -> Shape { Shape.box(width: 10, height: 10, depth: 10)! }
+    private func sphere() -> Shape { Shape.sphere(radius: 5)! }
+    private func segment3D() -> Curve3D { Curve3D.segment(from: .zero, to: SIMD3(10, 0, 0))! }
+    private func segment2D() -> Curve2D { Curve2D.segment(from: .zero, to: SIMD2(10, 0))! }
+    private func plane() -> Surface { Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))! }
+    private func tree() -> KDTree {
+        KDTree(points: [SIMD3(0, 0, 0), SIMD3(1, 1, 1), SIMD3(2, 2, 2)])!
+    }
+
+    // MARK: - Shape.raycast, the entry point #622 was filed about
+
+    @Test("Shape.raycast clamps maxHits instead of allocating ~880 GB and trapping")
+    func raycastCapacity() {
+        let b = box()
+        let origin = SIMD3(0.0, 0, 20), direction = SIMD3(0.0, 0, -1)
+
+        // A ray through a box crosses two faces however much room it is offered. That is the
+        // point of clamping rather than rejecting: the absurd capacity returns the real answer.
+        let baseline = b.raycast(origin: origin, direction: direction).count
+        #expect(baseline > 0)
+        #expect(b.raycast(origin: origin, direction: direction, maxHits: Self.pastInt32).count
+                == baseline)
+
+        // No capacity is not a small capacity: it returns the documented empty value.
+        #expect(b.raycast(origin: origin, direction: direction, maxHits: 0).count == 0)
+        #expect(b.raycast(origin: origin, direction: direction, maxHits: -1).count == 0)
+
+        // raycastNearest hardcodes 100 and was never exposed, but must still work.
+        #expect(b.raycastNearest(origin: origin, direction: direction) != nil)
+    }
+
+    // MARK: - Curve and surface capacities
+
+    @Test("Curve3D extrema/intersection/split capacities clamp rather than trap")
+    func curve3DCapacities() {
+        let a = segment3D()
+        // Deliberately skew rather than parallel. `GeomAPI_ExtremaCurveCurve` SIGSEGVs
+        // (uncatchable) on two parallel lines at *any* capacity — measured here at maxCount 2, 20,
+        // 100, 1e4, 1e6, 1e7 and Int32.max + 1, all EXIT -11, including the method's own default
+        // of 20. That is the documented `BRepExtrema_ExtCC` parallel hazard on the
+        // `GeomAPI_ExtremaCurveCurve` path, entirely independent of the count bound this suite is
+        // about; a parallel fixture here would test the crash, not the bound.
+        let b = Curve3D.segment(from: SIMD3(5, -5, 1), to: SIMD3(5, 5, 1))!
+        #expect(a.extrema(with: b, maxCount: Self.pastInt32).count
+                == a.extrema(with: b).count)
+        #expect(a.extrema(with: b, maxCount: 0).count == 0)
+        #expect(a.extrema(with: b, maxCount: -1).count == 0)
+
+        let through = Curve3D.segment(from: SIMD3(0, 0, -20), to: SIMD3(0, 0, 20))!
+        let p = plane()
+        #expect(through.intersections(with: p, maxHits: Self.pastInt32).count
+                == through.intersections(with: p).count)
+        #expect(through.intersections(with: p, maxHits: 0).count == 0)
+        #expect(through.intersections(with: p, maxHits: -1).count == 0)
+
+        #expect(a.splitAtContinuity(maxSegments: Self.pastInt32).count
+                == a.splitAtContinuity().count)
+        #expect(a.splitAtContinuity(maxSegments: 0).count == 0)
+        #expect(a.splitAtContinuity(maxSegments: -1).count == 0)
+    }
+
+    @Test("Curve2D.splitAtContinuity clamps maxSegments rather than trapping")
+    func curve2DSplitCapacity() {
+        let c = segment2D()
+        #expect(c.splitAtContinuity(maxSegments: Self.pastInt32).count
+                == c.splitAtContinuity().count)
+        #expect(c.splitAtContinuity(maxSegments: 0).count == 0)
+        #expect(c.splitAtContinuity(maxSegments: -1).count == 0)
+    }
+
+    @Test("Surface.intersections clamps maxCurves rather than trapping")
+    func surfaceIntersectionCapacity() {
+        let a = plane()
+        let b = Surface.plane(origin: .zero, normal: SIMD3(0, 1, 0))!
+        #expect(a.intersections(with: b, maxCurves: Self.pastInt32).count
+                == a.intersections(with: b).count)
+        #expect(a.intersections(with: b, maxCurves: 0).count == 0)
+        #expect(a.intersections(with: b, maxCurves: -1).count == 0)
+    }
+
+    @Test("point projection capacities clamp rather than trap")
+    func projectionCapacities() {
+        let c = segment3D()
+        let q = SIMD3(5.0, 5, 0)
+        #expect(c.projectPointAll(q, maxResults: Self.pastInt32).count
+                == c.projectPointAll(q).count)
+        #expect(c.projectPointAll(q, maxResults: 0).count == 0)
+        #expect(c.projectPointAll(q, maxResults: -1).count == 0)
+
+        let s = plane()
+        let r = SIMD3(1.0, 1, 5)
+        #expect(s.projectPointAll(r, maxResults: Self.pastInt32).count
+                == s.projectPointAll(r).count)
+        #expect(s.projectPointAll(r, maxResults: 0).count == 0)
+        #expect(s.projectPointAll(r, maxResults: -1).count == 0)
+    }
+
+    // MARK: - Shape capacities
+
+    @Test("Shape.allDistanceSolutions clamps maxSolutions rather than trapping")
+    func allDistanceSolutionsCapacity() {
+        let b = box(), s = sphere()
+        #expect(b.allDistanceSolutions(to: s, maxSolutions: Self.pastInt32)?.count
+                == b.allDistanceSolutions(to: s)?.count)
+        #expect(b.allDistanceSolutions(to: s, maxSolutions: 0)?.count == 0)
+        #expect(b.allDistanceSolutions(to: s, maxSolutions: -1)?.count == 0)
+    }
+
+    @Test("Shape.selfIntersectionPairs clamps maxPairs rather than trapping")
+    func selfIntersectionPairsCapacity() {
+        let b = box()
+        #expect(b.selfIntersectionPairs(maxPairs: Self.pastInt32).count
+                == b.selfIntersectionPairs().count)
+        #expect(b.selfIntersectionPairs(maxPairs: 0).count == 0)
+        #expect(b.selfIntersectionPairs(maxPairs: -1).count == 0)
+    }
+
+    // MARK: - Spatial search capacities
+
+    @Test("KDTree search capacities clamp rather than trap")
+    func kdTreeCapacities() {
+        let t = tree()
+        #expect(t.kNearest(to: .zero, k: 3).count == 3)
+        #expect(t.kNearest(to: .zero, k: Self.pastInt32).count == 3)
+        #expect(t.kNearest(to: .zero, k: 0).count == 0)
+        #expect(t.kNearest(to: .zero, k: -1).count == 0)
+
+        let base = t.rangeSearch(center: .zero, radius: 10).count
+        #expect(t.rangeSearch(center: .zero, radius: 10, maxResults: Self.pastInt32).count == base)
+        #expect(t.rangeSearch(center: .zero, radius: 10, maxResults: 0).count == 0)
+        #expect(t.rangeSearch(center: .zero, radius: 10, maxResults: -1).count == 0)
+
+        let lo = SIMD3(-9.0, -9, -9), hi = SIMD3(9.0, 9, 9)
+        let boxBase = t.boxSearch(min: lo, max: hi).count
+        #expect(t.boxSearch(min: lo, max: hi, maxResults: Self.pastInt32).count == boxBase)
+        #expect(t.boxSearch(min: lo, max: hi, maxResults: 0).count == 0)
+        #expect(t.boxSearch(min: lo, max: hi, maxResults: -1).count == 0)
+    }
+
+    @Test("all three Selector.pick overloads clamp maxResults rather than trapping")
+    func selectorPickCapacities() {
+        let selector = Selector()
+        selector.add(shape: box(), id: 1)
+        let camera = Camera()
+        let viewSize = SIMD2(800.0, 600.0)
+        let pixel = SIMD2(400.0, 300.0)
+        let rect = (min: SIMD2(0.0, 0.0), max: SIMD2(800.0, 600.0))
+        let poly: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(800, 0), SIMD2(800, 600), SIMD2(0, 600)]
+
+        // The contract under test is that an absurd capacity returns rather than aborting the
+        // process; whether this headless selector resolves a hit is not what is being asserted.
+        let atBase = selector.pick(at: pixel, camera: camera, viewSize: viewSize).count
+        #expect(selector.pick(at: pixel, camera: camera, viewSize: viewSize,
+                              maxResults: Self.pastInt32).count == atBase)
+        #expect(selector.pick(at: pixel, camera: camera, viewSize: viewSize, maxResults: 0).count == 0)
+        #expect(selector.pick(at: pixel, camera: camera, viewSize: viewSize, maxResults: -1).count == 0)
+
+        let rectBase = selector.pick(rect: rect, camera: camera, viewSize: viewSize).count
+        #expect(selector.pick(rect: rect, camera: camera, viewSize: viewSize,
+                              maxResults: Self.pastInt32).count == rectBase)
+        #expect(selector.pick(rect: rect, camera: camera, viewSize: viewSize, maxResults: 0).count == 0)
+        #expect(selector.pick(rect: rect, camera: camera, viewSize: viewSize, maxResults: -1).count == 0)
+
+        let polyBase = selector.pick(polygon: poly, camera: camera, viewSize: viewSize).count
+        #expect(selector.pick(polygon: poly, camera: camera, viewSize: viewSize,
+                              maxResults: Self.pastInt32).count == polyBase)
+        #expect(selector.pick(polygon: poly, camera: camera, viewSize: viewSize, maxResults: 0).count == 0)
+        #expect(selector.pick(polygon: poly, camera: camera, viewSize: viewSize, maxResults: -1).count == 0)
+    }
+
+    // MARK: - Drawing / text / filesystem capacities
+
+    @Test("HatchPattern.generate clamps maxSegments rather than trapping")
+    func hatchCapacity() {
+        let boundary: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 10), SIMD2(0, 10)]
+        let d = SIMD2(1.0, 0.0)
+        let base = HatchPattern.generate(boundary: boundary, direction: d, spacing: 1).count
+        #expect(base > 0)
+        #expect(HatchPattern.generate(boundary: boundary, direction: d, spacing: 1,
+                                      maxSegments: Self.pastInt32).count == base)
+        #expect(HatchPattern.generate(boundary: boundary, direction: d, spacing: 1,
+                                      maxSegments: 0).count == 0)
+        #expect(HatchPattern.generate(boundary: boundary, direction: d, spacing: 1,
+                                      maxSegments: -1).count == 0)
+    }
+
+    @Test("UnicodeUtils.convertFromUnicode clamps its output buffer rather than trapping")
+    func unicodeCapacity() {
+        #expect(UnicodeUtils.convertFromUnicode("hello", maxSize: Self.pastInt32)
+                == UnicodeUtils.convertFromUnicode("hello"))
+        // A zero-byte output buffer cannot hold even the terminator, so it reports failure.
+        #expect(UnicodeUtils.convertFromUnicode("hello", maxSize: 0) == nil)
+        #expect(UnicodeUtils.convertFromUnicode("hello", maxSize: -1) == nil)
+    }
+
+    @Test("directory and file listing clamp maxCount rather than trapping")
+    func listingCapacities() {
+        // Comparing against a *small* capacity rather than the default, since /tmp's real entry
+        // count is not something a test may assume is under the 1000 default.
+        let dirSmall = DirectoryIterator.list(path: "/tmp", maxCount: 5).count
+        #expect(dirSmall <= 5)
+        #expect(DirectoryIterator.list(path: "/tmp", maxCount: Self.pastInt32).count >= dirSmall)
+        #expect(DirectoryIterator.list(path: "/tmp", maxCount: 0).count == 0)
+        #expect(DirectoryIterator.list(path: "/tmp", maxCount: -1).count == 0)
+
+        let fileSmall = FileIterator.list(path: "/tmp", maxCount: 5).count
+        #expect(fileSmall <= 5)
+        #expect(FileIterator.list(path: "/tmp", maxCount: Self.pastInt32).count >= fileSmall)
+        #expect(FileIterator.list(path: "/tmp", maxCount: 0).count == 0)
+        #expect(FileIterator.list(path: "/tmp", maxCount: -1).count == 0)
+    }
+
+    // MARK: - The one request in the set
+
+    @Test("LogSample.sample fills its buffer exactly, so its count is a request, not a capacity")
+    func logSampleIsARequest() {
+        // Exactly the requested count, which is what makes clamping the wrong answer here: a
+        // clamped 10-billion request would hand back 10 million values and call it success.
+        #expect(LogSample.sample(from: 1, to: 100, count: 16).count == 16)
+        #expect(LogSample.sample(from: 1, to: 100, count: 1).count == 1)
+        for n in [-1, 0, Sampling.maximumSampleCount + 1, Self.pastInt32, Int.max] {
+            #expect(LogSample.sample(from: 1, to: 100, count: n).count == 0, "sample(\(n))")
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -279,6 +279,76 @@ suites with 41 issues, and the test pinning the *preserved* windowed primary pat
 it must. The 2D sweep's ground-truth anchor was separately proved non-vacuous by over-reporting the
 distance in the helper: 9 failures with `abs()`, 0 without it.
 
+#### The 21 result-buffer capacities #558's sweep never reached (#622)
+
+#558 bounded 28 *sampling* entry points and introduced `Sampling.capacity(_:)` /
+`Sampling.requested(_:atLeast:)`. A review found `Shape.raycast(origin:direction:tolerance:maxHits:)`
+with the identical footgun and named three more sites. Re-running #558's own measurement against the
+current tree found **21**, not 4 — and two of the four the review named do not survive it at all:
+`MedialAxis.drawArc` was already bounded by #558 itself, and both quoted `Document.swift` line
+numbers land on unrelated code. The named list was neither complete nor correct, which is the same
+lesson #558 recorded when its census said 14 and its measurement said 28.
+
+The reason the sweep stopped short is a scoping one, not an oversight: #558 scoped itself to
+*samplers*, and these 21 are **result-buffer capacities** on picking, spatial search, projection,
+intersection, hatching, text conversion and directory listing. Same mechanism throughout — a
+caller-supplied number sizes a Swift allocation and is then cast to the `int32_t` the bridge takes
+its capacity in, so `Array(repeating:count:)` traps on a negative and `Int32(_:)` traps past
+`Int32.max`.
+
+Measured one case per process, since a trap takes the whole harness down with it. 18 of the 21 are
+drivable from a standalone binary; **all 18 failed at `Int(Int32.max) + 1`** — 2 aborted immediately
+with `Fatal error: Not enough memory` and 16 ground past a 40-second timeout on an allocation
+nothing can serve. **12 of the 18 also aborted on `-1`**, inside `Array(repeating:count:)`, before
+any bound could be consulted. The remaining 3 (`Selector.pick`'s three overloads) need a live
+selector and were converted on inspection, then covered in-process. After the fix all 18 return
+their documented value at both inputs.
+
+The sites, by owning type: `Shape.raycast`, `Shape.allDistanceSolutions`, `Shape.selfIntersectionPairs`,
+`Curve3D.extrema` / `.intersections(with:maxHits:)` / `.splitAtContinuity` / `.projectPointAll`,
+`Curve2D.splitAtContinuity`, `Surface.intersections(with:maxCurves:)` / `.projectPointAll`,
+`KDTree.kNearest` / `.rangeSearch` / `.boxSearch`, `Selector.pick` (all three overloads),
+`HatchPattern.generate`, `UnicodeUtils.convertFromUnicode`, `DirectoryIterator.list`,
+`FileIterator.list`, and `LogSample.sample`.
+
+**The contract is #558's, not a fifth one.** 20 of the 21 are capacities: the algorithm decides how
+many results exist and the number only truncates, so they clamp into `0...Sampling.maximumSampleCount`
+and an absurd capacity returns the *same* answer rather than an empty one. The exception is
+`LogSample.sample(from:to:count:)`, whose bridge fills the buffer exactly — that is a *request*, so
+it rejects outside `1...ceiling` rather than silently handing back 10 million values for a
+10-billion request. Exactly the split #558 drew between `Curve3D.drawAdaptive` and
+`MedialAxis.drawArc`.
+
+**A separate, pre-existing defect surfaced while building the fixture and is *not* fixed here:**
+`Curve3D.extrema(with:maxCount:)` SIGSEGVs (uncatchable) on two **parallel** curves at *any*
+capacity — measured at `maxCount` 2, 20, 100, 1e4, 1e6, 1e7 and `Int32.max + 1`, all signal 11,
+including the method's own default of 20. The bridge's own loop is correctly bounded by
+`min(NbExtrema(), maxCount)`, so the crash is inside `GeomAPI_ExtremaCurveCurve`'s construction: the
+documented `BRepExtrema_ExtCC` parallel hazard, on the `GeomAPI` path. It has nothing to do with the
+count bound, and the regression fixture uses skew curves deliberately so that it tests the bound
+rather than the crash.
+
+**Also measured, also not fixed here, for the same "do not invent a contract" reason:** the math
+solver/optimizer family (`MathSolver.leastSquares`, `.uzawa`, `MathOptimizer`'s `variables:`
+parameters and friends) has the same trapping shape — confirmed on two of them, aborting on both
+`-1` and `Int32.max + 1`. But those numbers are problem *dimensions* that must agree with the
+caller's own `matrix` / `startPoint` arrays, not sampling capacities; the right bound is a
+consistency check against those arrays, and forcing them through a *sampling* ceiling would be
+precisely the fifth behaviour #622 asked to avoid. Filed separately rather than guessed at here.
+
+Regression suite: `Tests/OCCTMiscTests/Issue622AllocationBoundsTests.swift`, 13 tests covering all
+21 entry points. They run in-process only because the fix is what lets them: before it, every
+assertion in them would have aborted the test harness rather than failing. They compare
+`.count == 0` rather than reading `.isEmpty`, for the reason #558 recorded — Swift Testing prints
+the captured sub-expression on failure, and a regression returning 10 million results would print
+all 10 million of them.
+
+Confirmed by injection, one bound at a time: with the ceiling removed from the bound it covers (and
+the lower bound left in place, so the edit still compiles and the injection is exactly "the ceiling
+is gone"), **all 13 tests stopped passing** — 12 aborting with signal 5 and `raycast` dying mid-run
+on its ~189 GB allocation before it could report an assertion. Each was restored by exact reverse
+replacement and re-verified afterwards.
+
 #### A NaN parameter bound stops being a plausible arc length (#548)
 
 `Curve3D.length(from:to:)` documents itself as the entry point that tells failure apart from a real

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -319,6 +319,33 @@ it rejects outside `1...ceiling` rather than silently handing back 10 million va
 10-billion request. Exactly the split #558 drew between `Curve3D.drawAdaptive` and
 `MedialAxis.drawArc`.
 
+```swift
+let box = Shape.box(width: 10, height: 10, depth: 10)!
+let ray = (origin: SIMD3(0.0, 0, 20), direction: SIMD3(0.0, 0, -1))
+
+// A capacity is clamped, so an unservable one still returns the real answer.
+box.raycast(origin: ray.origin, direction: ray.direction, maxHits: 10_000_000_000).count
+    == box.raycast(origin: ray.origin, direction: ray.direction).count   // true
+box.raycast(origin: ray.origin, direction: ray.direction, maxHits: -1)   // [] -- used to abort
+
+// A request is rejected, never silently coarsened.
+LogSample.sample(from: 1, to: 100, count: 16).count                      // 16
+LogSample.sample(from: 1, to: 100, count: 10_000_001).count              // 0, not 10,000,000
+```
+
+**Two behaviour changes beyond "stops aborting", both at a zero-or-negative count:**
+
+- `Shape.allDistanceSolutions(to:maxSolutions:)` returns `[]` rather than `nil` for a capacity of 0
+  or less. The bridge answers `-1` for `maxSolutions <= 0` and the old `guard count >= 0` turned
+  that into `nil`, so "no room was offered" was reported as "the measurement failed". Every sibling
+  in this set returns its documented empty value for no capacity, and `nil` is now reserved for an
+  actual failure.
+- `KDTree`'s three searches gain an **effective** result ceiling of 10,000,000. The bridge returns
+  `min(results.Size(), maxResults)` with no truncation flag, so a caller who previously passed a
+  huge capacity against a >10-million-point cloud and got a complete answer now silently gets
+  10,000,000 of them. The silence is pre-existing (there was never a "there were more" signal); the
+  ceiling is new.
+
 **A separate, pre-existing defect surfaced while building the fixture and is *not* fixed here:**
 `Curve3D.extrema(with:maxCount:)` SIGSEGVs (uncatchable) on two **parallel** curves at *any*
 capacity — measured at `maxCount` 2, 20, 100, 1e4, 1e6, 1e7 and `Int32.max + 1`, all signal 11,
@@ -326,15 +353,35 @@ including the method's own default of 20. The bridge's own loop is correctly bou
 `min(NbExtrema(), maxCount)`, so the crash is inside `GeomAPI_ExtremaCurveCurve`'s construction: the
 documented `BRepExtrema_ExtCC` parallel hazard, on the `GeomAPI` path. It has nothing to do with the
 count bound, and the regression fixture uses skew curves deliberately so that it tests the bound
-rather than the crash.
+rather than the crash. Filed as
+[#636](https://github.com/SecondMouseAU/OCCTSwift/issues/636).
 
-**Also measured, also not fixed here, for the same "do not invent a contract" reason:** the math
-solver/optimizer family (`MathSolver.leastSquares`, `.uzawa`, `MathOptimizer`'s `variables:`
-parameters and friends) has the same trapping shape — confirmed on two of them, aborting on both
-`-1` and `Int32.max + 1`. But those numbers are problem *dimensions* that must agree with the
-caller's own `matrix` / `startPoint` arrays, not sampling capacities; the right bound is a
-consistency check against those arrays, and forcing them through a *sampling* ceiling would be
-precisely the fifth behaviour #622 asked to avoid. Filed separately rather than guessed at here.
+**Also measured, also not fixed here, for the same "do not invent a contract" reason — now filed as
+[#640](https://github.com/SecondMouseAU/OCCTSwift/issues/640).** The math solver/optimizer family
+has the same trapping shape, at **13** entry points in `Sources/OCCTSwift/Document.swift`:
+`MathSVD.solve` (`:5699`), `MathJacobi.eigenvalues` (`:5744`), `MathHouseholder.solve` (`:5919`),
+`MathOptimizer`'s `solveSystem`, `minimize`, `minimizePowell`, `particleSwarm`, `globalMinimize`,
+`solveSystemNewton`, `minimizeNewton` and `gaussSetIntegration`, and `MathSolver.leastSquares`
+(`:14193`) and `.uzawa`.
+
+These are problem *dimensions* that must agree with the caller's own `matrix` / `startPoint` arrays,
+not sampling capacities, and clamping a dimension to 10,000,000 would hand back a garbage-dimension
+solve rather than truncating a result set — so `Sampling.*` is the wrong tool and applying it would
+have been precisely the fifth behaviour #622 asked to avoid.
+
+**A consistency check against those arrays is *not* on its own the remedy**, which is where an
+earlier draft of this note was wrong. A degenerate array satisfies the consistency relation exactly
+and still aborts:
+
+```swift
+MathJacobi.eigenvalues(matrix: [1.0], n: -1)   // matrix.count == n*n holds exactly: 1 == 1
+                                                // still aborts: Can't construct Array with count < 0
+```
+
+The same holds for `MathSVD.solve` and `MathHouseholder.solve`. A positivity bound is needed as
+well. And `MathSolver.leastSquares` has **no** consistency check at all, so `Int32(rows)` /
+`Int32(cols)` drive an out-of-bounds **read** of `matrix` inside the bridge — memory unsafety rather
+than a clean trap, and the reason #640 is not merely a tidiness issue.
 
 Regression suite: `Tests/OCCTMiscTests/Issue622AllocationBoundsTests.swift`, 13 tests covering all
 21 entry points. They run in-process only because the fix is what lets them: before it, every
@@ -346,8 +393,15 @@ all 10 million of them.
 Confirmed by injection, one bound at a time: with the ceiling removed from the bound it covers (and
 the lower bound left in place, so the edit still compiles and the injection is exactly "the ceiling
 is gone"), **all 13 tests stopped passing** — 12 aborting with signal 5 and `raycast` dying mid-run
-on its ~189 GB allocation before it could report an assertion. Each was restored by exact reverse
-replacement and re-verified afterwards.
+before it could report an assertion. Each was restored by exact reverse replacement and re-verified
+afterwards.
+
+The `raycast` case dies at the `Int32(capacity)` conversion ("Not enough bits to represent the
+passed value"), *not* at the buffer allocation: `calloc` hands back lazily-zeroed pages, so the
+nominally ~189 GB `[OCCTRayHit]` costs nothing until it is touched. The trapping conversion is
+reached first. Worth recording, because it means the allocation size is the wrong thing to reason
+about when judging which of these entry points is dangerous — the `int32_t` cast is what fires, and
+it fires identically whether the element is 8 bytes or 88.
 
 #### A NaN parameter bound stops being a plausible arc length (#548)
 

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1074,7 +1074,8 @@ public func splitAtContinuity(
 ) -> [Curve2D]
 ```
 
-- **Parameters:** `continuity` — 0=C0, 1=C1, 2=C2; `tolerance` — detection tolerance; `maxSegments` — upper bound on returned segments.
+- **Parameters:** `continuity` — 0=C0, 1=C1, 2=C2; `tolerance` — detection tolerance;
+  `maxSegments` — output *capacity* (default 32), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of sub-curves (one per continuous segment); may be empty if the curve has no discontinuities or the split fails.
 - **OCCT:** `Geom2dConvert::C0BSplineToArrayOfC1BSplineCurve` and related splitting utilities.
 - **Example:**

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -404,7 +404,10 @@ public func extrema(with other: Curve3D, maxCount: Int = 20) -> [CurveExtremaRes
 
 Returns up to `maxCount` results. For simple queries where only the minimum distance matters, prefer `minDistance(to:)`.
 
-- **Parameters:** `other` — the second curve; `maxCount` — maximum number of extrema to return (default 20).
+- **Parameters:** `other` — the second curve; `maxCount` — output *capacity* (default 20), clamped
+  into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
+- **Warning:** SIGSEGVs (uncatchable) on two **parallel** curves, at every capacity including the
+  default — a `GeomAPI_ExtremaCurveCurve` defect unrelated to the count bound (#622).
 - **Returns:** Array of `CurveExtremaResult` values (may be empty if the algorithm finds nothing).
 - **OCCT:** `GeomAPI_ExtremaCurveCurve`.
 - **Example:**
@@ -430,7 +433,9 @@ public func intersections(with surface: Surface, maxHits: Int = 100) -> [CurveSu
 
 Returns an empty array when the curve does not pierce the surface. Both transverse and tangent intersections are returned.
 
-- **Parameters:** `surface` — the surface to intersect with; `maxHits` — upper bound on returned hits (default 100).
+- **Parameters:** `surface` — the surface to intersect with; `maxHits` — output *capacity*
+  (default 100), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less
+  returns empty (#622).
 - **Returns:** Array of `CurveSurfaceHit` values (may be empty).
 - **OCCT:** `GeomAPI_IntCS`.
 - **Example:**

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -535,7 +535,9 @@ public func splitAtContinuity(
 
 The curve is first converted to BSpline form, then split at C1 (or higher) discontinuities. For `continuity > 1` the implementation returns the single converted BSpline unchanged (higher-order splitting not yet implemented). Returns an empty array on failure.
 
-- **Parameters:** `continuity` — continuity level to split at (0=C0, 1=C1); `tolerance` — discontinuity detection tolerance; `maxSegments` — maximum output segment count.
+- **Parameters:** `continuity` — continuity level to split at (0=C0, 1=C1); `tolerance` —
+  discontinuity detection tolerance; `maxSegments` — output *capacity* (default 32), clamped into
+  `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of BSpline curve segments (at least one on success).
 - **OCCT:** `GeomConvert::C0BSplineToArrayOfC1BSplineCurve` (for `continuity ≤ 1`).
 - **Example:**

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -373,7 +373,7 @@ public func selfIntersectionPairs(tolerance: Double = 0.0,
 
 - **Parameters:**
   - `tolerance` — overlap tolerance (default `0.0`).
-  - `maxPairs` — maximum number of pairs to return (default `100`).
+  - `maxPairs` — output *capacity* (default `100`), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
   - `deflection` — linear mesh deflection in mm for detection triangulation (default `0.1`).
 - **Returns:** Array of overlapping face index pairs; empty if none found.
 - **OCCT:** `BRepExtrema_SelfIntersection` via `OCCTShapeSelfIntersectionPairs`.

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -1170,7 +1170,8 @@ Convert a UTF-8 string to the current multi-byte encoding.
 public static func convertFromUnicode(_ utf8Input: String, maxSize: Int = 4096) -> String?
 ```
 
-- **Parameters:** `utf8Input` — UTF-8 encoded source; `maxSize` — output buffer capacity in bytes.
+- **Parameters:** `utf8Input` — UTF-8 encoded source; `maxSize` — output buffer capacity in bytes,
+  clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns `nil` (#622).
 - **Returns:** String in the current encoding, or `nil` on failure.
 - **OCCT:** `Resource_Unicode::ConvertSJISToUnicode` / `ConvertEUCToUnicode` / etc. (inverse path)
 - **Example:**
@@ -1343,8 +1344,13 @@ Compute logarithmically spaced parameter values in [a, b].
 public static func sample(from a: Double, to b: Double, count n: Int) -> [Double]
 ```
 
-- **Parameters:** `a` — start of interval; `b` — end of interval; `n` — number of sample points.
-- **Returns:** Array of `n` logarithmically spaced values, or empty if `n ≤ 0`.
+- **Parameters:** `a` — start of interval; `b` — end of interval; `n` — a *request* for exactly
+  this many sample points, honoured within `1...Sampling.maximumSampleCount` (10,000,000). The
+  bridge fills the buffer exactly, so this is not a capacity and is never clamped (#622).
+- **Returns:** Array of `n` logarithmically spaced values, or empty if `n` is outside
+  `1...10,000,000` — **including above the ceiling**, where it returns empty rather than a
+  coarser sampling than was asked for (#622). Before #622 a count past `Int32.max` aborted the
+  process.
 - **OCCT:** `GeomLib_LogSample`
 - **Example:**
   ```swift
@@ -2290,7 +2296,8 @@ List all directory names matching a mask (up to `maxCount`).
 public static func list(path: String, mask: String = "*", maxCount: Int = 1000) -> [String]
 ```
 
-- **Parameters:** `path`, `mask` — search location and filter; `maxCount` — result cap.
+- **Parameters:** `path`, `mask` — search location and filter; `maxCount` — output *capacity*
+  (default 1000), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of directory name strings.
 - **OCCT:** `OSD_DirectoryIterator`
 - **Example:**
@@ -2350,7 +2357,8 @@ List all file names matching a mask (up to `maxCount`).
 public static func list(path: String, mask: String = "*", maxCount: Int = 1000) -> [String]
 ```
 
-- **Parameters:** `path`, `mask` — search location and filter; `maxCount` — result cap.
+- **Parameters:** `path`, `mask` — search location and filter; `maxCount` — output *capacity*
+  (default 1000), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of file name strings.
 - **OCCT:** `OSD_FileIterator`
 - **Example:**

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -905,7 +905,7 @@ public func projectPointAll(
 
 - **Parameters:**
   - `point` — the 3D query point.
-  - `maxResults` — maximum number of results to return (default 10).
+  - `maxResults` — output *capacity* (default 10), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of `(parameter, distance)` pairs for every extremum found.
 - **OCCT:** `GeomAPI_ExtremaCurveCurve` / `Extrema_ExtPC` (via `OCCTExtremaPointCurve`).
 - **Example:**
@@ -951,7 +951,8 @@ public func projectPointAll(
 ) -> [(u: Double, v: Double, distance: Double)]
 ```
 
-- **Parameters:** `point` — 3D query point; `maxResults` — upper bound on results returned.
+- **Parameters:** `point` — 3D query point; `maxResults` — output *capacity* (default 10),
+  clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of `(u, v, distance)` tuples for every extremum.
 - **OCCT:** `GeomAPI_ProjectPointOnSurf` (via `OCCTExtremaPointSurface`).
 

--- a/docs/reference/Drawing-Automation.md
+++ b/docs/reference/Drawing-Automation.md
@@ -730,7 +730,7 @@ Clips an infinite family of parallel lines at the given `spacing` against the bo
   - `direction` — direction of the hatch lines (need not be unit-length).
   - `spacing` — perpendicular distance between consecutive hatch lines.
   - `offset` — offset of the first hatch line from the origin along the perpendicular axis (default `0`).
-  - `maxSegments` — maximum number of output segments; acts as a safety cap (default `10000`).
+  - `maxSegments` — output *capacity* (default `10000`), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of `HatchSegment` values clipped inside `boundary`.
 - **OCCT:** `Hatch_Hatcher::AddLine` + `Hatch_Hatcher::Trim` — adds one directed line per spacing interval, then trims against each boundary edge.
 - **Example:**

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -1079,7 +1079,8 @@ public func kNearest(to point: SIMD3<Double>, k: Int) -> [(index: Int, squaredDi
 
 - **Parameters:**
   - `point` — the query point.
-  - `k` — number of neighbors to find.
+  - `k` — output *capacity*, clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622). Fewer than `k` come back when the tree
+    holds fewer points.
 - **Returns:** Array of `(index, squaredDistance)` tuples sorted by distance. Note: distances are **squared**.
 - **OCCT:** `NCollection_KDTree` k-nearest query.
 - **Example:**

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -1103,7 +1103,7 @@ public func rangeSearch(center: SIMD3<Double>, radius: Double, maxResults: Int =
 - **Parameters:**
   - `center` — center of the search sphere.
   - `radius` — radius of the search sphere.
-  - `maxResults` — maximum number of results (default `1000`).
+  - `maxResults` — output *capacity* (default `1000`), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of 0-based indices of points within the sphere.
 - **OCCT:** `NCollection_KDTree` range query.
 - **Example:**
@@ -1125,7 +1125,7 @@ public func boxSearch(min: SIMD3<Double>, max: SIMD3<Double>, maxResults: Int = 
 - **Parameters:**
   - `min` — minimum corner of the box.
   - `max` — maximum corner of the box.
-  - `maxResults` — maximum number of results (default `1000`).
+  - `maxResults` — output *capacity* (default `1000`), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of 0-based indices of points within the box.
 - **OCCT:** `NCollection_KDTree` box query.
 - **Example:**

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -339,7 +339,9 @@ The direction vector is automatically normalised by `gp_Dir`. Intersections beyo
     dimensionless *sine* tolerance: any value at or above 1 rejected every hit normal, so
     `raycast(tolerance: 1.0)` on a sphere reported `(0, 0, 1)` for both hits, and at 5.0 a box's
     downward face came back pointing up.
-  - `maxHits` — maximum number of hits to collect (default 100).
+  - `maxHits` — output *capacity* (default 100), clamped into `0...Sampling.maximumSampleCount`
+    (10,000,000); 0 or less returns empty (#622). The ray decides how many surfaces it crosses,
+    so the capacity only truncates: clamping an unservable one returns the same hits.
 - **Returns:** Array of `RayHit` sorted by ascending `distance`; empty if no intersection.
 - **OCCT:** `IntCurvesFace_ShapeIntersector::Load` / `Perform` / `NbPnt` / `Pnt` / `WParameter` / `Face` / `UParameter` / `VParameter`; normals via `BRepAdaptor_Surface` + `BRepLProp_SLProps` at the shared `occtLocalPropsResolution()`.
 - **Example:**
@@ -703,7 +705,7 @@ Results are sorted by depth (nearest first). Only shapes and sub-shape modes tha
   - `pixel` — pixel coordinate in the viewport (origin at top-left).
   - `camera` — camera providing the projection and view transforms.
   - `viewSize` — viewport dimensions in pixels `(width, height)`.
-  - `maxResults` — maximum number of results (default 32).
+  - `maxResults` — output *capacity* (default 32), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of `PickResult` sorted by ascending depth; empty if nothing was hit.
 - **OCCT:** `OCCTHeadlessSelector::PickPoint` → `SelectMgr_ViewerSelector::Pick` (point volume) + `SelectMgr_SortCriterion` for depth ordering.
 - **Example:**
@@ -733,7 +735,7 @@ public func pick(rect: (min: SIMD2<Double>, max: SIMD2<Double>),
   - `rect` — rectangle defined by `(min, max)` pixel corners.
   - `camera` — camera providing the projection and view transforms.
   - `viewSize` — viewport dimensions in pixels.
-  - `maxResults` — maximum number of results (default 32).
+  - `maxResults` — output *capacity* (default 32), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of `PickResult` for all shapes intersecting the rectangle.
 - **OCCT:** `OCCTHeadlessSelector::PickRect` → `SelectMgr_ViewerSelector::Pick` (box volume).
 - **Example:**
@@ -765,7 +767,7 @@ The polygon must have at least 3 points. The last point is automatically connect
   - `polygon` — array of pixel coordinates defining the polygon vertices (minimum 3 points).
   - `camera` — camera providing the projection and view transforms.
   - `viewSize` — viewport dimensions in pixels.
-  - `maxResults` — maximum number of results (default 32).
+  - `maxResults` — output *capacity* (default 32), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of `PickResult` for all shapes whose sensitive primitives fall inside the polygon.
 - **OCCT:** `OCCTHeadlessSelector::PickPoly` → `SelectMgr_ViewerSelector::Pick` (polyline volume); pixel XY pairs passed as interleaved `double` array.
 - **Example:**

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -549,7 +549,8 @@ Returns all extremal point pairs (not just the minimum). Useful for finding mult
 
 - **Parameters:**
   - `other` — The other shape.
-  - `maxSolutions` — Maximum number of solutions to return.
+  - `maxSolutions` — Output *capacity*, clamped into `0...Sampling.maximumSampleCount`
+    (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of distance solutions, or `nil` on failure.
 - **OCCT:** `BRepExtrema_DistShapeShape` (via `OCCTShapeAllDistanceSolutions`).
 - **Example:**

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -550,7 +550,7 @@ Returns all extremal point pairs (not just the minimum). Useful for finding mult
 - **Parameters:**
   - `other` — The other shape.
   - `maxSolutions` — Output *capacity*, clamped into `0...Sampling.maximumSampleCount`
-    (10,000,000); 0 or less returns empty (#622).
+    (10,000,000); 0 or less returns an empty array — **not** `nil`, as it did before #622 (#622).
 - **Returns:** Array of distance solutions, or `nil` on failure.
 - **OCCT:** `BRepExtrema_DistShapeShape` (via `OCCTShapeAllDistanceSolutions`).
 - **Example:**

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -580,7 +580,8 @@ public func intersections(with other: Surface, tolerance: Double = 1e-6, maxCurv
 
 Returns an empty array when the surfaces do not intersect. This is the earlier (v0.30.0) intersection method; see also `intersectionCurves(with:tolerance:)` added in v0.35.0.
 
-- **Parameters:** `other` — the second surface; `tolerance` — intersection tolerance (default `1e-6`); `maxCurves` — upper bound on the number of returned curves (default 50).
+- **Parameters:** `other` — the second surface; `tolerance` — intersection tolerance (default
+  `1e-6`); `maxCurves` — output *capacity* (default 50), clamped into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
 - **Returns:** Array of 3D intersection curves (may be empty).
 - **OCCT:** `GeomAPI_IntSS`.
 - **Example:**


### PR DESCRIPTION
Closes #622

## The 21 result-buffer capacities #558's sampler-shaped sweep could not see

Sampling.requested(_:atLeast:). A review found Shape.raycast(maxHits:) with the
identical footgun and named three more sites.

Re-running #558's own measurement found 21, not 4 -- and two of the four named do
not survive it: MedialAxis.drawArc was already bounded by #558 itself, and both
quoted Document.swift line numbers land on unrelated code. Same lesson #558
recorded when its census said 14 and its measurement said 28.

The sweep stopped short for a scoping reason, not an oversight: #558 scoped to
samplers, and these 21 are result-buffer capacities on picking, spatial search,
projection, intersection, hatching, text conversion and directory listing. Same
mechanism -- a caller count sizes a Swift allocation and is then cast to the
int32_t the bridge takes its capacity in.

Measured one case per process, since a trap takes the harness down. 18 of the 21
are drivable standalone; all 18 failed at Int(Int32.max) + 1 (2 aborting with
"Not enough memory", 16 grinding past a 40s timeout), and 12 of 18 also aborted
on -1. After the fix all 18 return their documented value at both inputs. The 3
Selector.pick overloads need a live selector; converted on inspection, covered
in-process.

Contract is #558's, not a fifth one: 20 are capacities and clamp into
0...Sampling.maximumSampleCount, so an absurd capacity returns the same answer
rather than an empty one; LogSample.sample(count:) fills its buffer exactly, so
it is a request and rejects instead.

Found and deliberately not fixed here: Curve3D.extrema SIGSEGVs on parallel
curves at every capacity including its own default of 20 (a
GeomAPI_ExtremaCurveCurve defect, definitionally pre-existing since the clamp is
a no-op at 20), and the math solver/optimizer family traps the same way but its
numbers are problem dimensions that must agree with the caller's own arrays, not
sampling capacities.

Regression suite: 13 tests covering all 21 entry points. Proved by injection,
one bound at a time: with the ceiling removed all 13 stopped passing.

Closes #622

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


## Review round 1 response

BLOCKING 1: seven reference locations still stated the pre-change contract.
LogSample.sample was the one whose contract actually changed (it now also
returns empty ABOVE 10,000,000, not just at n <= 0). Six siblings were
stale-incomplete from the same pass: convertFromUnicode, DirectoryIterator.list,
FileIterator.list, both projectPointAll overloads, and selfIntersectionPairs.
kNearest in GeometrySolvers.md was left inconsistent with rangeSearch/boxSearch
twenty lines below it. Three files needed opening that the first pass missed.

BLOCKING 2: the CHANGELOG asserted the math family had been "filed separately".
It had not been. Now cites #640, and the Curve3D.extrema parallel SIGSEGV cites
#636.

BLOCKING 3: three math sites were unnamed anywhere — MathSVD.solve (:5699),
MathJacobi.eigenvalues (:5744), MathHouseholder.solve (:5919). All 13 are now
enumerated. The stated remedy was also wrong: a consistency check against the
caller's arrays is not sufficient, since eigenvalues(matrix: [1.0], n: -1)
satisfies matrix.count == n*n exactly and still aborts, so a positivity bound is
needed too; and MathSolver.leastSquares has no consistency check at all, so
Int32(rows)/Int32(cols) drive an out-of-bounds READ of matrix in the bridge.

Also:
- allDistanceSolutions(maxSolutions: 0) returns [] where it returned nil. Now
  documented in the ///, the reference page and the CHANGELOG, and asserted
  deliberately in the test rather than silently.
- KDTree's three searches gain an effective 10,000,000 result ceiling; the
  bridge returns min(size, maxResults) with no truncation flag, so the silence
  is pre-existing but the ceiling is new. Recorded.
- The raycast injection dies at Int32(capacity), not at the ~189 GB allocation:
  calloc pages are lazily zeroed so the trapping conversion is reached first.
  Narrative corrected — allocation size is the wrong lens, the int32_t cast
  fires identically whether the element is 8 bytes or 88.
- listingCapacities asserted only the trap half (its >= comparisons both hold on
  an empty directory). It now builds its own temp directory with 7 files and
  asserts clamp-equals-baseline plus real truncation at maxCount: 3.
- Sampling.maximumSampleCount's doc no longer describes the ceiling purely as
  "10 million points / ~625 MB".
- Added a fenced swift snippet for the changed behaviour.

listingCapacities and allDistanceSolutionsCapacity re-proved by injection: both
still stop passing when their ceiling is removed.

Full suite built from bridge source (not the prebuilt xcframework, which
predates #617/#615): 5234 tests in 1389 suites passed, exit 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


## Review round 2

**BLOCKING 1 — reference pages stating the pre-change contract.** Fixed at 7 locations.
`LogSample.sample` was the one whose *contract* changed (it now also returns empty **above**
10,000,000, not only at `n <= 0`). Six siblings were stale-incomplete from the same pass:
`convertFromUnicode`, `DirectoryIterator.list`, `FileIterator.list`, both `projectPointAll`
overloads, and `selfIntersectionPairs`. `kNearest` in `GeometrySolvers.md` had been left
inconsistent with `rangeSearch`/`boxSearch` twenty lines below it. Three files needed opening that
the first pass missed: `Document-Geometry-Constructors.md`, `Document-Mesh-Fixing.md`,
`Document-Analysis-Builders.md`.

**BLOCKING 2 — a filing that did not exist.** The CHANGELOG claimed the math family had been "filed
separately". It had not been. It now cites **#640**, and the `Curve3D.extrema` parallel SIGSEGV
cites **#636**.

**BLOCKING 3 — three unnamed math sites, and a disproved rationale.** All **13** are now enumerated,
including the three that appeared nowhere: `MathSVD.solve` (`:5699`), `MathJacobi.eigenvalues`
(`:5744`), `MathHouseholder.solve` (`:5919`). The stated remedy was wrong and is corrected: a
consistency check against the caller's arrays is *not* sufficient, because

```swift
MathJacobi.eigenvalues(matrix: [1.0], n: -1)   // matrix.count == n*n holds exactly: 1 == 1
                                                // still aborts
```

so a positivity bound is needed as well; and `MathSolver.leastSquares` has **no** consistency check
at all, so `Int32(rows)`/`Int32(cols)` drive an out-of-bounds **read** of `matrix` — memory
unsafety, not a clean trap. The core premise (that `Sampling.*` is the wrong tool for a problem
dimension) is unchanged.

**Nits.** `allDistanceSolutions(maxSolutions: 0)` returning `[]` where it returned `nil` is now
documented in the `///`, the reference page and the CHANGELOG, and asserted deliberately rather than
silently. `KDTree`'s new effective 10,000,000 ceiling is recorded. The `raycast` injection narrative
is corrected — it dies at `Int32(capacity)` ("Not enough bits to represent the passed value"), not
at the ~189 GB allocation, since `calloc` pages are lazily zeroed; which also means allocation size
is the wrong lens for judging danger here. `listingCapacities` now builds its own temp directory
with 7 files and asserts clamp-equals-baseline plus real truncation at `maxCount: 3`, instead of two
`>=` comparisons that both hold on an empty directory. `Sampling.maximumSampleCount`'s doc no longer
describes the ceiling purely as "10 million points / ~625 MB". A fenced `swift` snippet was added.

Both changed tests were re-proved by injection: `listingCapacities` and
`allDistanceSolutionsCapacity` still stop passing when their ceiling is removed.

**On the red suite seen mid-review:** it was environmental, not this diff. The prebuilt
`OCCTBridge.xcframework` predates #617 (`OCCTBridge_BRepGraph.mm`) and #615
(`OCCTBridge_Curve3D.mm`/`OCCTBridge_Geom2d.mm`), so a rebase brought their new tests in against the
old binary — 4 failures in `Issue617FaceGridLayoutTests`, plus one microsecond-scale wall-clock
ratio flake in `allEdgePolylines scales linearly` that this diff does not touch. Built from bridge
source, all five pass and the suite is green.

