### PR TITLE
docs(#626): the reference page kept documenting the continuity default #491 replaced

### DIFF
--- a/Scripts/check-docs-defaults.py
+++ b/Scripts/check-docs-defaults.py
@@ -775,6 +775,30 @@ SELF_TEST_CASES = [
         {'changed': 1},
     ),
     (
+        'a protocol requirement takes its protocol access level',
+        {'Sources/OCCTSwift/A.swift':
+            'public protocol ImportProgress {\n'
+            '    func progress(fraction: Double, step: String = "load")\n}\n'},
+        {'docs/reference/Concurrency.md':
+            '### `ImportProgress.progress(fraction:step:)`\n\n```swift\n'
+            'func progress(fraction: Double, step: String = "start")\n```\n'},
+        # Without the rule the requirement is not public, the restatement lands in `unmatched`,
+        # and the changed default goes unreported.
+        {'changed': 1},
+    ),
+    (
+        'an enclosing section heading names the type the nearest heading omits',
+        {'Sources/OCCTSwift/A.swift':
+            'extension WireCurve {\n    public func points(count: Int) -> [Int] { [] }\n}\n'
+            'extension Edge {\n    public func points(count: Int? = nil) -> [Int] { [] }\n}\n'},
+        {'docs/reference/CurveAdaptors.md':
+            '## WireCurve\n\n### `points(count:)`\n\n```swift\n'
+            'public func points(count: Int = 5) -> [Int]\n```\n'},
+        # Without the outward walk nothing names a type -- the filename is `CurveAdaptors` -- so
+        # the pool stays at two disagreeing candidates and this reads as `unverified` instead.
+        {'docs_only': 1},
+    ),
+    (
         'a `.init(` call site in an example is not a declaration',
         {'Sources/OCCTSwift/A.swift': 'extension Surface {\n'
                                       '    public func fit(tol: Double = 1e-3) -> Int { 0 }\n}\n'},
@@ -793,11 +817,15 @@ def self_test():
     failures = 0
     for name, src_files, doc_files, expect in SELF_TEST_CASES:
         rep = analyse(source_decls_from(src_files), doc_decls_from(doc_files))
+        # `unmatched` is asserted too, not just the four drift buckets. Without it a case can go
+        # green for the wrong reason: the `.init(` case passed with its call-site guard removed,
+        # because the stray declaration merely landed in a bucket nothing was watching.
         got = {
             'changed': len(rep.changed),
             'docs_only': len(rep.docs_only),
             'source_only': len(rep.source_only),
             'unverified': len(rep.unverified),
+            'unmatched': len(rep.unmatched),
         }
         want = {k: expect.get(k, 0) for k in got}
         if got == want:

--- a/Scripts/check-docs-defaults.py
+++ b/Scripts/check-docs-defaults.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Verify that every default value a `docs/reference/` page restates matches its declaration.
+
+Each page under `docs/reference/` documents an API by *restating* its signature in a fenced
+```swift block:
+
+    ### `Surface.approxWithDetails(tolerance:uContinuity:vContinuity:maxDegree:maxSegments:)`
+
+    ```swift
+    public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c2,
+                                  vContinuity: ParametricContinuity = .c2,
+                                  maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult
+    ```
+
+That restatement is a copy, and a copy drifts. #491 flipped both continuity defaults from `.c1`
+to `.c2` and updated `docs/reference/Surface.md`; `docs/reference/Shape-HLR-Geom.md` documents the
+same method and kept saying `.c1` (#626). A caller who omits the argument then believes they get a
+C1 fit and gets a C2 one, which per #572 is not cosmetic: continuity is one of the inputs deciding
+how far the fitted surface moves.
+
+This script re-runs that comparison for every restated default in the tree. It parses each page's
+fenced-swift declarations, finds the matching `public` declaration in `Sources/OCCTSwift`, and
+compares the default of each parameter the two have in common.
+
+Only a *disagreement* is an error: both sides state a default for the same parameter and the two
+literals differ. The two asymmetric cases are reported separately and do not fail the run, because
+each has a legitimate form:
+
+  - docs state a default the source does not have (`--strict` promotes this to an error; it is
+    almost always wrong, but a doc may be describing a protocol requirement or a shim);
+  - docs omit a default the source has, which is ordinary abbreviation.
+
+A doc declaration that matches no source declaration is listed under `unmatched` and never fails:
+the tree documents nested types, bridge C structs and illustrative pseudo-signatures that have no
+`public` counterpart in `Sources/OCCTSwift`.
+
+Where several source declarations share one name and parameter-label list (`approximated` exists
+on `Curve3D`, `Curve2D` and `Surface`), the doc heading's `Type.` prefix picks one when it has
+them; otherwise the doc is accepted if it agrees with *any* candidate, so ambiguity never
+manufactures a failure.
+
+Usage (from the repo root):
+
+    python3 Scripts/check-docs-defaults.py           # report drifted defaults
+    python3 Scripts/check-docs-defaults.py --verbose # also list every default checked
+    python3 Scripts/check-docs-defaults.py --strict  # also fail on docs-only defaults
+    python3 Scripts/check-docs-defaults.py --quiet   # exit status only
+
+Exit status is 1 when any default disagrees, so this can gate a commit.
+"""
+import argparse
+import glob
+import os
+import re
+import sys
+
+SRC_GLOB = 'Sources/OCCTSwift/*.swift'
+DOCS_GLOB = 'docs/reference/*.md'
+
+# A declaration this script can compare: it has a parameter list with defaults in it.
+DECL_RE = re.compile(
+    r'\b(?:public\s+|open\s+)?'
+    r'(?:static\s+|class\s+|final\s+|mutating\s+|override\s+|convenience\s+)*'
+    r'(?P<kind>func|init)\b'
+    r'(?P<gen>\s*<[^>]*>)?'
+    r'\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)?'
+    r'(?P<optional>\?)?'
+    r'\s*\('
+)
+
+# Enclosing-type tracker for Sources: `extension Surface {`, `public struct Foo {`, ...
+TYPE_RE = re.compile(
+    r'^\s*(?P<access>public\s+|internal\s+|private\s+|fileprivate\s+|open\s+)?'
+    r'(?:final\s+)?(?P<kind>extension|struct|class|enum|actor|protocol)\s+'
+    r'(?P<name>[A-Za-z_][A-Za-z0-9_.]*)'
+)
+
+# An explicit access modifier on the member itself overrides what the container implies.
+EXPLICIT_ACCESS_RE = re.compile(r'\b(private|fileprivate|internal)\b')
+
+# `### `Surface.approxWithDetails(tolerance:...)`` -> owning type hint for a doc declaration.
+HEADING_RE = re.compile(r'^#{2,4}\s+`?(?P<text>[^`\n]+)`?\s*$')
+
+
+def split_top_level(text, sep=','):
+    """Split on `sep` at nesting depth zero (parens, brackets, angle brackets, strings)."""
+    parts, depth, angle, buf, i, in_str = [], 0, 0, [], 0, False
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            if c == '\\':
+                buf.append(c)
+                i += 1
+                if i < len(text):
+                    buf.append(text[i])
+                    i += 1
+                continue
+            if c == '"':
+                in_str = False
+            buf.append(c)
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+        elif c in '([{':
+            depth += 1
+        elif c in ')]}':
+            depth -= 1
+        elif c == '<':
+            # only count as a generic bracket when it looks like one
+            angle += 1
+        elif c == '>' and angle > 0:
+            angle -= 1
+        if c == sep and depth == 0 and angle == 0:
+            parts.append(''.join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append(''.join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def parse_params(param_text):
+    """[(label, default_or_None)] for one parameter list, in declared order."""
+    params = []
+    for raw in split_top_level(param_text):
+        # attributes/modifiers Swift allows before the label
+        cleaned = re.sub(r'^(?:@\w+(?:\([^)]*\))?\s+|inout\s+|isolated\s+)+', '', raw).strip()
+        head, _, tail = cleaned.partition(':')
+        if not tail:
+            continue  # not `label: Type` shaped (e.g. a lone `...`)
+        names = head.split()
+        if not names:
+            continue
+        label = names[0]
+        # default is everything after a top-level `=` in the type part
+        default = None
+        eq_parts = split_top_level(tail, '=')
+        if len(eq_parts) >= 2 and '=' in tail:
+            # guard against `==` or default-less generic constraints
+            m = re.search(r'(?<![=!<>])=(?![=])', tail)
+            if m:
+                default = tail[m.end():].strip()
+        params.append((label, default or None))
+    return params
+
+
+def normalize_default(text):
+    """Compare default literals modulo layout: `SIMD3(0, 0, 1)` == `SIMD3(0,0,1)`.
+
+    Whitespace inside a string literal is kept, so `"a b"` never equals `"ab"`.
+    """
+    out, i, in_str = [], 0, False
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            out.append(c)
+            if c == '\\' and i + 1 < len(text):
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            out.append(c)
+        elif not c.isspace():
+            out.append(c)
+        i += 1
+    return ''.join(out)
+
+
+def strip_line_comment(line):
+    """Drop a trailing `//` comment. A `//` inside a string literal is not a comment.
+
+    `tolerance: String,  // e.g. "0.1" or "0.1 M" for MMC` has quotes *after* the `//`, so a
+    regex guarded by a lookahead for a following quote keeps the comment and corrupts the next
+    parameter's label. This scans instead.
+    """
+    i, in_str = 0, False
+    while i < len(line):
+        c = line[i]
+        if in_str:
+            if c == '\\':
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+        elif c == '"':
+            in_str = True
+        elif c == '/' and i + 1 < len(line) and line[i + 1] == '/':
+            return line[:i].rstrip()
+        i += 1
+    return line
+
+
+def gather_decl(lines, start_idx):
+    """Join lines from `start_idx` until the signature's parens balance. Returns (text, end)."""
+    depth, buf, i = 0, [], start_idx
+    started = False
+    while i < len(lines) and i < start_idx + 40:
+        line = strip_line_comment(lines[i])
+        for c in line:
+            if c == '(':
+                depth += 1
+                started = True
+            elif c == ')':
+                depth -= 1
+        buf.append(line)
+        i += 1
+        if started and depth <= 0:
+            break
+    return ' '.join(buf), i
+
+
+def extract_decls(text, source_label, want_public):
+    """Yield dicts for every func/init declaration with a parameter list."""
+    lines = text.split('\n')
+    out = []
+    type_stack = []
+    brace_depth = 0
+    pending_type = None
+    for idx, line in enumerate(lines):
+        tm = TYPE_RE.match(line)
+        if tm:
+            # `public extension Foo {` makes its members public without repeating the keyword;
+            # `public struct Foo {` does not. Only the extension form implies public members.
+            implied = bool(tm.group('access')) and \
+                tm.group('access').strip() in ('public', 'open') and \
+                tm.group('kind') == 'extension'
+            pending_type = (tm.group('name'), implied)
+        if pending_type and '{' in line:
+            type_stack.append((pending_type[0], brace_depth, pending_type[1]))
+            pending_type = None
+        opens = line.count('{')
+        closes = line.count('}')
+        brace_depth += opens - closes
+        while type_stack and brace_depth <= type_stack[-1][1]:
+            type_stack.pop()
+
+        m = DECL_RE.search(line)
+        if not m:
+            continue
+        if want_public:
+            explicit_public = 'public' in line or 'open' in line
+            implied_public = (bool(type_stack) and type_stack[-1][2]
+                              and not EXPLICIT_ACCESS_RE.search(line))
+            if not (explicit_public or implied_public):
+                continue
+        # skip a call site that happens to contain `func` in a comment/string
+        if line.lstrip().startswith(('//', '*', '///')):
+            continue
+        joined, _ = gather_decl(lines, idx)
+        m2 = DECL_RE.search(joined)
+        if not m2:
+            continue
+        open_paren = joined.index('(', m2.end() - 1)
+        depth, j = 0, open_paren
+        while j < len(joined):
+            if joined[j] == '(':
+                depth += 1
+            elif joined[j] == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if j >= len(joined):
+            continue
+        params = parse_params(joined[open_paren + 1:j])
+        name = m2.group('name') or 'init'
+        if m2.group('kind') == 'init':
+            name = 'init'
+        out.append({
+            'name': name,
+            'params': params,
+            'labels': tuple(p[0] for p in params),
+            'type': type_stack[-1][0] if type_stack else None,
+            'file': source_label,
+            'line': idx + 1,
+            'text': ' '.join(joined.split()),
+        })
+    return out
+
+
+def doc_swift_blocks(text):
+    """Yield (block_text, first_line_number) for each fenced ```swift block."""
+    lines = text.split('\n')
+    blocks, i = [], 0
+    heading = None
+    while i < len(lines):
+        hm = HEADING_RE.match(lines[i])
+        if hm:
+            heading = hm.group('text').strip().strip('`')
+        if re.match(r'^\s*```\s*swift\s*$', lines[i]):
+            start = i + 1
+            j = start
+            while j < len(lines) and not re.match(r'^\s*```\s*$', lines[j]):
+                j += 1
+            blocks.append(('\n'.join(lines[start:j]), start + 1, heading))
+            i = j + 1
+            continue
+        i += 1
+    return blocks
+
+
+def heading_type(heading):
+    """`Surface.approxWithDetails(a:b:)` -> 'Surface'. None when the heading names no type."""
+    if not heading:
+        return None
+    text = heading.split('(')[0].strip()
+    if '.' in text:
+        return text.rsplit('.', 1)[0].split()[-1]
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--verbose', action='store_true', help='list every default compared')
+    ap.add_argument('--quiet', action='store_true', help='exit status only')
+    ap.add_argument('--strict', action='store_true',
+                    help='also fail when docs state a default the source does not have')
+    args = ap.parse_args()
+
+    src_decls = []
+    for path in sorted(glob.glob(SRC_GLOB)):
+        with open(path, encoding='utf-8') as fh:
+            src_decls.extend(extract_decls(fh.read(), path, want_public=True))
+
+    by_key = {}
+    for d in src_decls:
+        by_key.setdefault((d['name'], d['labels']), []).append(d)
+
+    drifted, docs_only, unmatched, checked, compared_decls = [], [], [], 0, 0
+    for path in sorted(glob.glob(DOCS_GLOB)):
+        with open(path, encoding='utf-8') as fh:
+            text = fh.read()
+        for block, base_line, heading in doc_swift_blocks(text):
+            for d in extract_decls(block, path, want_public=False):
+                # only a restated *declaration* carries defaults worth checking
+                if not any(p[1] for p in d['params']):
+                    continue
+                d['line'] = base_line + d['line'] - 1
+                candidates = by_key.get((d['name'], d['labels']), [])
+                if not candidates:
+                    unmatched.append(d)
+                    continue
+                htype = heading_type(heading)
+                narrowed = [c for c in candidates if htype and c['type'] == htype]
+                pool = narrowed or candidates
+                compared_decls += 1
+
+                # accept if the doc agrees with any candidate in the pool
+                def diffs_against(cand):
+                    src_map = dict(cand['params'])
+                    bad, only = [], []
+                    for label, dv in d['params']:
+                        if dv is None:
+                            continue
+                        sv = src_map.get(label)
+                        if sv is None:
+                            only.append((label, dv))
+                        elif normalize_default(sv) != normalize_default(dv):
+                            bad.append((label, dv, sv))
+                    return bad, only
+
+                results = [(c,) + diffs_against(c) for c in pool]
+                clean = [r for r in results if not r[1] and not r[2]]
+                if clean:
+                    checked += sum(1 for p in d['params'] if p[1])
+                    if args.verbose and not args.quiet:
+                        print(f'  ok   {path}:{d["line"]} {d["name"]}({",".join(d["labels"])})')
+                    continue
+                # report against the best candidate (fewest disagreements)
+                cand, bad, only = min(results, key=lambda r: (len(r[1]), len(r[2])))
+                checked += sum(1 for p in d['params'] if p[1])
+                for label, dv, sv in bad:
+                    drifted.append((path, d['line'], cand, d['name'], label, dv, sv,
+                                    len(pool) > 1))
+                for label, dv in only:
+                    docs_only.append((path, d['line'], cand, d['name'], label, dv))
+
+    if not args.quiet:
+        print(f'restated declarations with defaults: {compared_decls + len(unmatched)} '
+              f'({compared_decls} matched to a source declaration, '
+              f'{len(unmatched)} with no `public` counterpart)')
+        print(f'individual defaults compared:        {checked}')
+        print(f'drifted:                             {len(drifted)}')
+        print(f'stated only in docs:                 {len(docs_only)}')
+        if drifted:
+            print('\nDRIFTED — docs and source both state a default and they differ:')
+            for path, line, cand, name, label, dv, sv, ambiguous in drifted:
+                note = '  (ambiguous overload set)' if ambiguous else ''
+                print(f'  {path}:{line}')
+                print(f'    {name}(… {label}:) docs `{dv}` vs '
+                      f'{cand["file"]}:{cand["line"]} `{sv}`{note}')
+        if docs_only:
+            print('\nSTATED ONLY IN DOCS — the source parameter has no default:')
+            for path, line, cand, name, label, dv in docs_only:
+                print(f'  {path}:{line}  {name}(… {label}: = {dv})  '
+                      f'source {cand["file"]}:{cand["line"]}')
+        if args.verbose and unmatched:
+            print('\nUNMATCHED — no `public` declaration in Sources/OCCTSwift (not an error):')
+            for d in unmatched:
+                print(f'  {d["file"]}:{d["line"]}  {d["name"]}({",".join(d["labels"])})')
+
+    fail = bool(drifted) or (args.strict and bool(docs_only))
+    return 1 if fail else 0
+
+
+if __name__ == '__main__':
+    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+    sys.exit(main())

--- a/Scripts/check-docs-defaults.py
+++ b/Scripts/check-docs-defaults.py
@@ -19,34 +19,57 @@ C1 fit and gets a C2 one, which per #572 is not cosmetic: continuity is one of t
 how far the fitted surface moves.
 
 This script re-runs that comparison for every restated default in the tree. It parses each page's
-fenced-swift declarations, finds the matching `public` declaration in `Sources/OCCTSwift`, and
-compares the default of each parameter the two have in common.
+fenced-swift declarations, finds the matching declaration in `Sources/OCCTSwift`, and compares the
+default of each parameter the two have in common.
 
-Only a *disagreement* is an error: both sides state a default for the same parameter and the two
-literals differ. The two asymmetric cases are reported separately and do not fail the run, because
-each has a legitimate form:
+## The three shapes a default can drift in
 
-  - docs state a default the source does not have (`--strict` promotes this to an error; it is
-    almost always wrong, but a doc may be describing a protocol requirement or a shim);
-  - docs omit a default the source has, which is ordinary abbreviation.
+All three are reported and all three fail the run, because a gate that reports a defect while
+exiting 0 is not a gate:
 
-A doc declaration that matches no source declaration is listed under `unmatched` and never fails:
-the tree documents nested types, bridge C structs and illustrative pseudo-signatures that have no
-`public` counterpart in `Sources/OCCTSwift`.
+  - `changed`      — both sides state a default and the literals differ (the #626 shape);
+  - `docs-only`    — docs state a default the source does not have, so a caller believes an
+    argument is optional when it is required;
+  - `source-only`  — the source states a default the docs omit, so a caller believes an argument
+    is required when it is optional. This is also how a *source-side* addition hides: the source
+    gains `= 8` and the unchanged page keeps reading `maxDegree: Int`.
 
-Where several source declarations share one name and parameter-label list (`approximated` exists
-on `Curve3D`, `Curve2D` and `Surface`), the doc heading's `Type.` prefix picks one when it has
-them; otherwise the doc is accepted if it agrees with *any* candidate, so ambiguity never
-manufactures a failure.
+`--lenient` drops `source-only` to a warning, for a tree that has not finished paying that down.
+Layout is not drift: `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` compare equal, whitespace inside a string
+literal excepted.
+
+## Picking the right declaration to compare against
+
+Several declarations can share one name and parameter-label list — `writeOBJ(to:deflection:)` is
+both `Document.writeOBJ` (deflection 1.0) and `Shape.writeOBJ` (0.1), and `approximated` exists on
+`Curve3D`, `Curve2D` and `Surface`. Comparing against the wrong one is how the first version of
+this script let a page state `Shape.writeOBJ`'s default for `Document.writeOBJ` and still exit 0 —
+the #626 defect shape passing through the gate built to catch it.
+
+So the owning type is resolved in three steps, most specific first:
+
+  1. the heading's own qualifier — ``### `Surface.approxWithDetails(...)` ``;
+  2. failing that, the page filename — `Document-Persistence-IO.md` -> `Document`;
+  3. failing that, every candidate.
+
+Steps 1 and 2 narrow only when they select a non-empty set, because a page documents types other
+than its title: `Shape-HLR-Geom.md` carries `Surface.approxWithDetails`. Where nothing narrows to
+a single declaration and the remaining candidates disagree about a default the doc states, the
+comparison cannot be trusted either way; those are counted and listed as `unverified` and fail the
+run, so the blind spot is visible instead of invisible.
+
+A doc declaration matching no source declaration is listed under `unmatched` and never fails: the
+tree documents nested types, bridge C structs and helper functions defined inside example snippets.
 
 Usage (from the repo root):
 
-    python3 Scripts/check-docs-defaults.py           # report drifted defaults
-    python3 Scripts/check-docs-defaults.py --verbose # also list every default checked
-    python3 Scripts/check-docs-defaults.py --strict  # also fail on docs-only defaults
-    python3 Scripts/check-docs-defaults.py --quiet   # exit status only
+    python3 Scripts/check-docs-defaults.py            # report drifted defaults
+    python3 Scripts/check-docs-defaults.py --verbose  # also list every default checked
+    python3 Scripts/check-docs-defaults.py --lenient  # source-only omissions warn instead of fail
+    python3 Scripts/check-docs-defaults.py --quiet    # exit status only
 
-Exit status is 1 when any default disagrees, so this can gate a commit.
+Exit status is 1 when any default disagrees, so this can gate a commit. Nothing in this tree runs
+it yet; wiring the gate scripts into CI is #625, which covers all of them together.
 """
 import argparse
 import glob
@@ -57,14 +80,16 @@ import sys
 SRC_GLOB = 'Sources/OCCTSwift/*.swift'
 DOCS_GLOB = 'docs/reference/*.md'
 
-# A declaration this script can compare: it has a parameter list with defaults in it.
+# A declaration this script can compare. The generic-parameter group follows the name, as Swift
+# writes it (`func f<T>(...)`); putting it first made every generic declaration invisible.
 DECL_RE = re.compile(
     r'\b(?:public\s+|open\s+)?'
-    r'(?:static\s+|class\s+|final\s+|mutating\s+|override\s+|convenience\s+)*'
-    r'(?P<kind>func|init)\b'
-    r'(?P<gen>\s*<[^>]*>)?'
+    r'(?:static\s+|class\s+|final\s+|mutating\s+|override\s+|convenience\s+|required\s+'
+    r'|nonisolated\s+)*'
+    r'(?P<kind>func|init|subscript)\b'
     r'\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)?'
-    r'(?P<optional>\?)?'
+    r'(?P<optional>[?!])?'
+    r'(?P<gen>\s*<[^<>]*>)?'
     r'\s*\('
 )
 
@@ -76,10 +101,12 @@ TYPE_RE = re.compile(
 )
 
 # An explicit access modifier on the member itself overrides what the container implies.
-EXPLICIT_ACCESS_RE = re.compile(r'\b(private|fileprivate|internal)\b')
+# Word-anchored: a substring test reads `private func openFile(...)` as public, via `open`.
+EXPLICIT_ACCESS_RE = re.compile(r'(?<![A-Za-z0-9_])(private|fileprivate|internal)(?![A-Za-z0-9_])')
+PUBLIC_RE = re.compile(r'(?<![A-Za-z0-9_])(public|open)(?![A-Za-z0-9_])')
 
-# `### `Surface.approxWithDetails(tolerance:...)`` -> owning type hint for a doc declaration.
-HEADING_RE = re.compile(r'^#{2,4}\s+`?(?P<text>[^`\n]+)`?\s*$')
+# `### `Surface.approxWithDetails(a:b:)`` -> owning type hint for a doc declaration.
+HEADING_RE = re.compile(r'^#{2,6}\s+(?P<text>.+?)\s*$')
 
 
 def split_top_level(text, sep=','):
@@ -107,7 +134,6 @@ def split_top_level(text, sep=','):
         elif c in ')]}':
             depth -= 1
         elif c == '<':
-            # only count as a generic bracket when it looks like one
             angle += 1
         elif c == '>' and angle > 0:
             angle -= 1
@@ -125,7 +151,6 @@ def parse_params(param_text):
     """[(label, default_or_None)] for one parameter list, in declared order."""
     params = []
     for raw in split_top_level(param_text):
-        # attributes/modifiers Swift allows before the label
         cleaned = re.sub(r'^(?:@\w+(?:\([^)]*\))?\s+|inout\s+|isolated\s+)+', '', raw).strip()
         head, _, tail = cleaned.partition(':')
         if not tail:
@@ -134,15 +159,11 @@ def parse_params(param_text):
         if not names:
             continue
         label = names[0]
-        # default is everything after a top-level `=` in the type part
         default = None
-        eq_parts = split_top_level(tail, '=')
-        if len(eq_parts) >= 2 and '=' in tail:
-            # guard against `==` or default-less generic constraints
-            m = re.search(r'(?<![=!<>])=(?![=])', tail)
-            if m:
-                default = tail[m.end():].strip()
-        params.append((label, default or None))
+        m = re.search(r'(?<![=!<>])=(?![=])', tail)
+        if m:
+            default = tail[m.end():].strip() or None
+        params.append((label, default))
     return params
 
 
@@ -197,6 +218,46 @@ def strip_line_comment(line):
     return line
 
 
+def code_skeleton(line, in_block):
+    """Blank out strings and comments so brace counting sees only code.
+
+    Returns (skeleton, still_in_block_comment). A `{` inside a string literal or a doc comment is
+    not a scope, and counting it desynchronises the enclosing-type stack for the rest of the file.
+    """
+    out, i, in_str = [], 0, False
+    while i < len(line):
+        c = line[i]
+        if in_block:
+            if c == '*' and i + 1 < len(line) and line[i + 1] == '/':
+                in_block = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_str:
+            if c == '\\':
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            i += 1
+            continue
+        if c == '/' and i + 1 < len(line):
+            if line[i + 1] == '/':
+                break
+            if line[i + 1] == '*':
+                in_block = True
+                i += 2
+                continue
+        out.append(c)
+        i += 1
+    return ''.join(out), in_block
+
+
 def gather_decl(lines, start_idx):
     """Join lines from `start_idx` until the signature's parens balance. Returns (text, end)."""
     depth, buf, i = 0, [], start_idx
@@ -217,42 +278,46 @@ def gather_decl(lines, start_idx):
 
 
 def extract_decls(text, source_label, want_public):
-    """Yield dicts for every func/init declaration with a parameter list."""
+    """Yield dicts for every func/init/subscript declaration with a parameter list."""
     lines = text.split('\n')
     out = []
     type_stack = []
     brace_depth = 0
     pending_type = None
+    in_block = False
     for idx, line in enumerate(lines):
-        tm = TYPE_RE.match(line)
-        if tm:
-            # `public extension Foo {` makes its members public without repeating the keyword;
-            # `public struct Foo {` does not. Only the extension form implies public members.
-            implied = bool(tm.group('access')) and \
-                tm.group('access').strip() in ('public', 'open') and \
-                tm.group('kind') == 'extension'
-            pending_type = (tm.group('name'), implied)
-        if pending_type and '{' in line:
-            type_stack.append((pending_type[0], brace_depth, pending_type[1]))
-            pending_type = None
-        opens = line.count('{')
-        closes = line.count('}')
-        brace_depth += opens - closes
+        skeleton, next_block = code_skeleton(line, in_block)
+        was_in_block = in_block
+        in_block = next_block
+
+        if not was_in_block:
+            tm = TYPE_RE.match(skeleton)
+            if tm:
+                # `public extension Foo {` makes its members public without repeating the
+                # keyword; `public struct Foo {` does not.
+                access = (tm.group('access') or '').strip()
+                implied = access in ('public', 'open') and tm.group('kind') == 'extension'
+                pending_type = (tm.group('name'), implied)
+            if pending_type and '{' in skeleton:
+                type_stack.append((pending_type[0], brace_depth, pending_type[1]))
+                pending_type = None
+
+        brace_depth += skeleton.count('{') - skeleton.count('}')
         while type_stack and brace_depth <= type_stack[-1][1]:
             type_stack.pop()
 
-        m = DECL_RE.search(line)
+        if was_in_block:
+            continue
+        m = DECL_RE.search(skeleton)
         if not m:
             continue
         if want_public:
-            explicit_public = 'public' in line or 'open' in line
+            explicit_public = bool(PUBLIC_RE.search(skeleton))
             implied_public = (bool(type_stack) and type_stack[-1][2]
-                              and not EXPLICIT_ACCESS_RE.search(line))
+                              and not EXPLICIT_ACCESS_RE.search(skeleton))
             if not (explicit_public or implied_public):
                 continue
-        # skip a call site that happens to contain `func` in a comment/string
-        if line.lstrip().startswith(('//', '*', '///')):
-            continue
+
         joined, _ = gather_decl(lines, idx)
         m2 = DECL_RE.search(joined)
         if not m2:
@@ -270,9 +335,10 @@ def extract_decls(text, source_label, want_public):
         if j >= len(joined):
             continue
         params = parse_params(joined[open_paren + 1:j])
-        name = m2.group('name') or 'init'
-        if m2.group('kind') == 'init':
-            name = 'init'
+        kind = m2.group('kind')
+        name = m2.group('name') or kind
+        if kind in ('init', 'subscript'):
+            name = kind
         out.append({
             'name': name,
             'params': params,
@@ -280,20 +346,19 @@ def extract_decls(text, source_label, want_public):
             'type': type_stack[-1][0] if type_stack else None,
             'file': source_label,
             'line': idx + 1,
-            'text': ' '.join(joined.split()),
         })
     return out
 
 
 def doc_swift_blocks(text):
-    """Yield (block_text, first_line_number) for each fenced ```swift block."""
+    """Yield (block_text, first_line_number, nearest_heading) for each fenced ```swift block."""
     lines = text.split('\n')
     blocks, i = [], 0
     heading = None
     while i < len(lines):
         hm = HEADING_RE.match(lines[i])
         if hm:
-            heading = hm.group('text').strip().strip('`')
+            heading = hm.group('text').strip().strip('`').strip()
         if re.match(r'^\s*```\s*swift\s*$', lines[i]):
             start = i + 1
             j = start
@@ -311,9 +376,32 @@ def heading_type(heading):
     if not heading:
         return None
     text = heading.split('(')[0].strip()
-    if '.' in text:
-        return text.rsplit('.', 1)[0].split()[-1]
-    return None
+    words = text.split()
+    if not words:
+        return None
+    text = words[-1]
+    if '.' not in text:
+        return None
+    return text.rsplit('.', 1)[0]
+
+
+def filename_type(path):
+    """`docs/reference/Document-Persistence-IO.md` -> 'Document'.
+
+    The page title's first hyphen-separated component is its principal type. Only a hint: a page
+    documents types other than its title (`Shape-HLR-Geom.md` carries `Surface.approxWithDetails`),
+    so it narrows only when it selects something.
+    """
+    return os.path.basename(path)[:-3].split('-')[0]
+
+
+def type_matches(cand_type, hint):
+    """Tolerate qualification on either side: `BRepGraph.Editor` vs `Editor`."""
+    if not cand_type or not hint:
+        return False
+    if cand_type == hint:
+        return True
+    return cand_type.endswith('.' + hint) or hint.endswith('.' + cand_type)
 
 
 def main():
@@ -321,8 +409,8 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--verbose', action='store_true', help='list every default compared')
     ap.add_argument('--quiet', action='store_true', help='exit status only')
-    ap.add_argument('--strict', action='store_true',
-                    help='also fail when docs state a default the source does not have')
+    ap.add_argument('--lenient', action='store_true',
+                    help='report source-only omissions without failing the run')
     args = ap.parse_args()
 
     src_decls = []
@@ -334,80 +422,141 @@ def main():
     for d in src_decls:
         by_key.setdefault((d['name'], d['labels']), []).append(d)
 
-    drifted, docs_only, unmatched, checked, compared_decls = [], [], [], 0, 0
+    changed, docs_only, source_only, unverified, unmatched = [], [], [], [], []
+    checked = matched = 0
+    resolved_by = {'unique': 0, 'heading': 0, 'filename': 0, 'unnarrowed': 0}
+
     for path in sorted(glob.glob(DOCS_GLOB)):
         with open(path, encoding='utf-8') as fh:
             text = fh.read()
         for block, base_line, heading in doc_swift_blocks(text):
             for d in extract_decls(block, path, want_public=False):
-                # only a restated *declaration* carries defaults worth checking
                 if not any(p[1] for p in d['params']):
-                    continue
+                    continue  # nothing to compare
                 d['line'] = base_line + d['line'] - 1
                 candidates = by_key.get((d['name'], d['labels']), [])
                 if not candidates:
                     unmatched.append(d)
                     continue
-                htype = heading_type(heading)
-                narrowed = [c for c in candidates if htype and c['type'] == htype]
-                pool = narrowed or candidates
-                compared_decls += 1
+                matched += 1
 
-                # accept if the doc agrees with any candidate in the pool
-                def diffs_against(cand):
-                    src_map = dict(cand['params'])
-                    bad, only = [], []
-                    for label, dv in d['params']:
-                        if dv is None:
-                            continue
-                        sv = src_map.get(label)
-                        if sv is None:
-                            only.append((label, dv))
-                        elif normalize_default(sv) != normalize_default(dv):
-                            bad.append((label, dv, sv))
-                    return bad, only
+                pool, how = candidates, 'unnarrowed'
+                if len(candidates) == 1:
+                    how = 'unique'
+                else:
+                    ht = heading_type(heading)
+                    narrowed = [c for c in candidates if type_matches(c['type'], ht)]
+                    if narrowed:
+                        pool, how = narrowed, 'heading'
+                    else:
+                        ft = filename_type(path)
+                        narrowed = [c for c in candidates if type_matches(c['type'], ft)]
+                        if narrowed:
+                            pool, how = narrowed, 'filename'
+                resolved_by[how] += 1
+                checked += sum(1 for _, dv in d['params'] if dv is not None)
 
-                results = [(c,) + diffs_against(c) for c in pool]
-                clean = [r for r in results if not r[1] and not r[2]]
+                def diffs(cand):
+                    # Positional, not keyed by label: a signature may repeat `_` several times
+                    # (`circlesTangentTo(_ c1:, _ q1:, _ c2:, ...)`), and a label-keyed lookup
+                    # collapses those to one entry, inventing drift for every `_` but the last.
+                    # Both sides matched on the ordered label tuple, so index i is the same
+                    # parameter on both.
+                    ch, only_d, only_s = [], [], []
+                    for i, (lab, dv) in enumerate(d['params']):
+                        sv = cand['params'][i][1]
+                        if dv is not None and sv is None:
+                            only_d.append((lab, dv))
+                        elif dv is None and sv is not None:
+                            only_s.append((lab, sv))
+                        elif dv is not None and sv is not None and \
+                                normalize_default(sv) != normalize_default(dv):
+                            ch.append((lab, dv, sv))
+                    return ch, only_d, only_s
+
+                results = [(c,) + diffs(c) for c in pool]
+
+                # Checked BEFORE accepting a clean match, not after. When neither the heading nor
+                # the filename supplied any type evidence and the candidates disagree about a
+                # default, agreeing with one of them proves nothing about the intended one — that
+                # is exactly how a page stating `Shape.writeOBJ`'s 0.1 for `Document.writeOBJ`
+                # passed. Deciding it on "some candidate matched" is the blind spot, so say so
+                # instead. A pool narrowed to one type may still hold several overloads (a
+                # deprecated twin carrying no defaults); there the doc's own defaults do pick one,
+                # so that stays a verified match.
+                if how == 'unnarrowed' and len(pool) > 1:
+                    spread = [set() for _ in d['params']]
+                    for c in pool:
+                        for i in range(len(d['params'])):
+                            sv = c['params'][i][1]
+                            spread[i].add(normalize_default(sv) if sv else None)
+                    if any(len(s) > 1 for s in spread):
+                        unverified.append((path, d['line'], d['name'], pool))
+                        continue
+
+                clean = [r for r in results if not r[1] and not r[2] and not r[3]]
                 if clean:
-                    checked += sum(1 for p in d['params'] if p[1])
                     if args.verbose and not args.quiet:
                         print(f'  ok   {path}:{d["line"]} {d["name"]}({",".join(d["labels"])})')
                     continue
-                # report against the best candidate (fewest disagreements)
-                cand, bad, only = min(results, key=lambda r: (len(r[1]), len(r[2])))
-                checked += sum(1 for p in d['params'] if p[1])
-                for label, dv, sv in bad:
-                    drifted.append((path, d['line'], cand, d['name'], label, dv, sv,
-                                    len(pool) > 1))
-                for label, dv in only:
-                    docs_only.append((path, d['line'], cand, d['name'], label, dv))
+
+                # Deterministic pick, so a report never names an arbitrary sibling's file.
+                cand, ch, only_d, only_s = min(
+                    results,
+                    key=lambda r: (len(r[1]) + len(r[2]) + len(r[3]), r[0]['file'], r[0]['line']))
+                for lab, dv, sv in ch:
+                    changed.append((path, d['line'], cand, d['name'], lab, dv, sv))
+                for lab, dv in only_d:
+                    docs_only.append((path, d['line'], cand, d['name'], lab, dv))
+                for lab, sv in only_s:
+                    source_only.append((path, d['line'], cand, d['name'], lab, sv))
 
     if not args.quiet:
-        print(f'restated declarations with defaults: {compared_decls + len(unmatched)} '
-              f'({compared_decls} matched to a source declaration, '
-              f'{len(unmatched)} with no `public` counterpart)')
+        total = matched + len(unmatched)
+        print(f'restated declarations with defaults: {total} '
+              f'({matched} matched to a source declaration, '
+              f'{len(unmatched)} with no counterpart)')
+        print(f'  owning declaration resolved by:    '
+              f'{resolved_by["unique"]} unique, {resolved_by["heading"]} heading, '
+              f'{resolved_by["filename"]} filename, {resolved_by["unnarrowed"]} unnarrowed')
         print(f'individual defaults compared:        {checked}')
-        print(f'drifted:                             {len(drifted)}')
-        print(f'stated only in docs:                 {len(docs_only)}')
-        if drifted:
-            print('\nDRIFTED — docs and source both state a default and they differ:')
-            for path, line, cand, name, label, dv, sv, ambiguous in drifted:
-                note = '  (ambiguous overload set)' if ambiguous else ''
+        print(f'drifted (default changed):           {len(changed)}')
+        print(f'drifted (stated only in docs):       {len(docs_only)}')
+        print(f'drifted (stated only in source):     {len(source_only)}'
+              f'{"  [warning only]" if args.lenient else ""}')
+        print(f'unverified (ambiguous, not checked): {len(unverified)}')
+
+        if changed:
+            print('\nCHANGED — docs and source both state a default and they differ:')
+            for path, line, cand, name, lab, dv, sv in changed:
                 print(f'  {path}:{line}')
-                print(f'    {name}(… {label}:) docs `{dv}` vs '
-                      f'{cand["file"]}:{cand["line"]} `{sv}`{note}')
+                print(f'    {name}(… {lab}:) docs `{dv}` vs {cand["file"]}:{cand["line"]} `{sv}`')
         if docs_only:
-            print('\nSTATED ONLY IN DOCS — the source parameter has no default:')
-            for path, line, cand, name, label, dv in docs_only:
-                print(f'  {path}:{line}  {name}(… {label}: = {dv})  '
+            print('\nSTATED ONLY IN DOCS — the source parameter has no default, so the argument '
+                  'is required:')
+            for path, line, cand, name, lab, dv in docs_only:
+                print(f'  {path}:{line}  {name}(… {lab}: = {dv})  '
                       f'source {cand["file"]}:{cand["line"]}')
+        if source_only:
+            print('\nSTATED ONLY IN SOURCE — the docs omit a default, so the argument reads as '
+                  'required when it is optional:')
+            for path, line, cand, name, lab, sv in source_only:
+                print(f'  {path}:{line}  {name}(… {lab}:)  source has `= {sv}` at '
+                      f'{cand["file"]}:{cand["line"]}')
+        if unverified:
+            print('\nUNVERIFIED — several declarations share this name and label list, nothing '
+                  'narrowed to one, and they disagree about a default:')
+            for path, line, name, pool in unverified:
+                where = ', '.join(f'{c["type"]} ({c["file"]}:{c["line"]})' for c in pool)
+                print(f'  {path}:{line}  {name} — candidates: {where}')
         if args.verbose and unmatched:
-            print('\nUNMATCHED — no `public` declaration in Sources/OCCTSwift (not an error):')
+            print('\nUNMATCHED — no declaration in Sources/OCCTSwift (not an error):')
             for d in unmatched:
                 print(f'  {d["file"]}:{d["line"]}  {d["name"]}({",".join(d["labels"])})')
 
-    fail = bool(drifted) or (args.strict and bool(docs_only))
+    fail = bool(changed) or bool(docs_only) or bool(unverified)
+    if not args.lenient:
+        fail = fail or bool(source_only)
     return 1 if fail else 0
 
 

--- a/Scripts/check-docs-defaults.py
+++ b/Scripts/check-docs-defaults.py
@@ -34,6 +34,12 @@ exiting 0 is not a gate:
     is required when it is optional. This is also how a *source-side* addition hides: the source
     gains `= 8` and the unchanged page keeps reading `maxDegree: Int`.
 
+That last shape is why the comparison covers restatements stating **no** defaults at all, not only
+the ones that state some. Skipping a default-free restatement before looking up its declaration
+would mean a page reading `zzNoDef(a: Double, tol: Double)` never notices the source acquiring
+`tol: Double = 5e-9`; on this tree that would leave roughly 2500 restatements uncovered against
+876 covered. A restatement is skipped only once its declaration is known to be default-free too.
+
 `--lenient` drops `source-only` to a warning, for a tree that has not finished paying that down.
 Layout is not drift: `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` compare equal, whitespace inside a string
 literal excepted.
@@ -46,30 +52,42 @@ both `Document.writeOBJ` (deflection 1.0) and `Shape.writeOBJ` (0.1), and `appro
 this script let a page state `Shape.writeOBJ`'s default for `Document.writeOBJ` and still exit 0 —
 the #626 defect shape passing through the gate built to catch it.
 
-So the owning type is resolved in three steps, most specific first:
+So the owning type is resolved most specific first:
 
-  1. the heading's own qualifier — ``### `Surface.approxWithDetails(...)` ``;
-  2. failing that, the page filename — `Document-Persistence-IO.md` -> `Document`;
-  3. failing that, every candidate.
+  1. the nearest heading's qualifier — ``### `Surface.approxWithDetails(...)` ``;
+  2. then outward through the enclosing section headings — `CurveAdaptors.md` holds
+     `## WireCurve` and `## EdgeCurve`, each with an identically titled `### points(count:)`,
+     which the nearest heading alone cannot tell apart;
+  3. then the page filename — `Document-Persistence-IO.md` -> `Document`;
+  4. failing all of that, every candidate.
 
-Steps 1 and 2 narrow only when they select a non-empty set, because a page documents types other
-than its title: `Shape-HLR-Geom.md` carries `Surface.approxWithDetails`. Where nothing narrows to
-a single declaration and the remaining candidates disagree about a default the doc states, the
-comparison cannot be trusted either way; those are counted and listed as `unverified` and fail the
-run, so the blind spot is visible instead of invisible.
+Each hint narrows only when it selects a non-empty set, because a page documents types other than
+its title: `Shape-HLR-Geom.md` carries `Surface.approxWithDetails`.
 
-A doc declaration matching no source declaration is listed under `unmatched` and never fails: the
-tree documents nested types, bridge C structs and helper functions defined inside example snippets.
+Narrowing to a type is not the end of it. A type can hold two overloads, and deprecating a method
+by keeping its old signature verbatim — defaults included — is the ordinary way to deprecate, so a
+stale page goes on matching the retained twin. Wherever a pool still holds candidates that
+*disagree* about a default, the restatement is reported as `unverified` and fails, instead of being
+decided by whichever candidate happened to match cleanly. A twin that merely *lacks* a default is
+not a disagreement: the doc's own defaults still pick the overload that has one, so the ordinary
+deprecation shape stays quiet.
+
+A doc declaration matching no source declaration is listed under `unmatched`. That bucket is
+pinned rather than ignored: a restatement stops being compared the moment its labels stop matching
+any declaration, so a renamed or reordered parameter would otherwise slip into it silently. Growth
+fails the run.
 
 Usage (from the repo root):
 
-    python3 Scripts/check-docs-defaults.py            # report drifted defaults
-    python3 Scripts/check-docs-defaults.py --verbose  # also list every default checked
-    python3 Scripts/check-docs-defaults.py --lenient  # source-only omissions warn instead of fail
-    python3 Scripts/check-docs-defaults.py --quiet    # exit status only
+    python3 Scripts/check-docs-defaults.py                  # report drifted defaults
+    python3 Scripts/check-docs-defaults.py --self-test      # run the built-in drift battery
+    python3 Scripts/check-docs-defaults.py --list-unmatched # show uncomparable restatements
+    python3 Scripts/check-docs-defaults.py --lenient        # source-only warns instead of failing
+    python3 Scripts/check-docs-defaults.py --quiet          # exit status only
 
-Exit status is 1 when any default disagrees, so this can gate a commit. Nothing in this tree runs
-it yet; wiring the gate scripts into CI is #625, which covers all of them together.
+Exit status is 1 when a default disagrees, when a restatement cannot be adjudicated, or when the
+`unmatched` bucket grows — so this can gate a commit. Nothing in this tree runs it yet; wiring the
+gate scripts into CI is #625, which covers all of them together.
 """
 import argparse
 import glob
@@ -79,6 +97,17 @@ import sys
 
 SRC_GLOB = 'Sources/OCCTSwift/*.swift'
 DOCS_GLOB = 'docs/reference/*.md'
+
+# Restatements whose name and label list match no declaration in `Sources/OCCTSwift`. These are
+# genuinely uncomparable — helper functions defined inside example snippets, and signatures whose
+# labels the page spells differently from the declaration. The count is pinned because a
+# restatement stops being compared the moment its labels stop matching: renaming or reordering a
+# parameter on one side moves it here, and an unpinned bucket would absorb that silently. Raise it
+# only after checking each new entry (`--list-unmatched`).
+#
+# The three today: a `requestCancel()` and a `printTree(_:indent:)` defined inside example
+# snippets, and `Shape.init(handle:)`, which the page restates as `internal init` on purpose.
+EXPECTED_UNMATCHED = 3
 
 # A declaration this script can compare. The generic-parameter group follows the name, as Swift
 # writes it (`func f<T>(...)`); putting it first made every generic declaration invisible.
@@ -159,12 +188,22 @@ def parse_params(param_text):
         if not names:
             continue
         label = names[0]
+        # `_ q1: Type` — the internal name is what tells three `_` positions apart in a report.
+        internal = names[1] if len(names) > 1 else names[0]
         default = None
         m = re.search(r'(?<![=!<>])=(?![=])', tail)
         if m:
             default = tail[m.end():].strip() or None
-        params.append((label, default))
+        params.append((label, default, internal))
     return params
+
+
+def param_desc(decl, i):
+    """`_` renders identically three times over; say which one."""
+    label, _, internal = decl['params'][i]
+    if label == '_':
+        return f'#{i + 1} `_ {internal}`'
+    return f'`{label}:`'
 
 
 def normalize_default(text):
@@ -296,7 +335,11 @@ def extract_decls(text, source_label, want_public):
                 # `public extension Foo {` makes its members public without repeating the
                 # keyword; `public struct Foo {` does not.
                 access = (tm.group('access') or '').strip()
-                implied = access in ('public', 'open') and tm.group('kind') == 'extension'
+                # `public extension Foo { func bar() }` makes `bar` public without repeating the
+                # keyword, and a protocol requirement takes the protocol's own access level.
+                # `public struct Foo { func bar() }` does neither: there `bar` is internal.
+                implied = (access in ('public', 'open')
+                           and tm.group('kind') in ('extension', 'protocol'))
                 pending_type = (tm.group('name'), implied)
             if pending_type and '{' in skeleton:
                 type_stack.append((pending_type[0], brace_depth, pending_type[1]))
@@ -310,6 +353,10 @@ def extract_decls(text, source_label, want_public):
             continue
         m = DECL_RE.search(skeleton)
         if not m:
+            continue
+        # `.extrude(.init(profilePoints2D: ...))` in an example is a call, not a declaration.
+        ks = m.start('kind')
+        if ks > 0 and skeleton[ks - 1] == '.':
             continue
         if want_public:
             explicit_public = bool(PUBLIC_RE.search(skeleton))
@@ -354,17 +401,23 @@ def doc_swift_blocks(text):
     """Yield (block_text, first_line_number, nearest_heading) for each fenced ```swift block."""
     lines = text.split('\n')
     blocks, i = [], 0
-    heading = None
+    # Heading *stack*, by level. A page section names the type its subsections belong to:
+    # `CurveAdaptors.md` carries `## WireCurve` and `## EdgeCurve`, each holding an identically
+    # titled `### points(count:)`. The nearest heading alone cannot tell those apart.
+    stack = {}
     while i < len(lines):
         hm = HEADING_RE.match(lines[i])
         if hm:
-            heading = hm.group('text').strip().strip('`').strip()
+            level = len(lines[i]) - len(lines[i].lstrip('#'))
+            stack = {k: v for k, v in stack.items() if k < level}
+            stack[level] = hm.group('text').strip().strip('`').strip()
         if re.match(r'^\s*```\s*swift\s*$', lines[i]):
             start = i + 1
             j = start
             while j < len(lines) and not re.match(r'^\s*```\s*$', lines[j]):
                 j += 1
-            blocks.append(('\n'.join(lines[start:j]), start + 1, heading))
+            chain = [stack[k] for k in sorted(stack)]
+            blocks.append(('\n'.join(lines[start:j]), start + 1, chain))
             i = j + 1
             continue
         i += 1
@@ -383,6 +436,18 @@ def heading_type(heading):
     if '.' not in text:
         return None
     return text.rsplit('.', 1)[0]
+
+
+def heading_bare_type(heading):
+    """`## WireCurve` -> 'WireCurve'. A section heading that is just a type name.
+
+    Only meaningful for an enclosing heading; a method-shaped one (`### points(count:)`) yields
+    `points`, which matches no type and is harmless.
+    """
+    if not heading:
+        return None
+    text = heading.split('(')[0].strip()
+    return text if re.fullmatch(r'[A-Za-z_][A-Za-z0-9_.]*', text) else None
 
 
 def filename_type(path):
@@ -404,159 +469,390 @@ def type_matches(cand_type, hint):
     return cand_type.endswith('.' + hint) or hint.endswith('.' + cand_type)
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument('--verbose', action='store_true', help='list every default compared')
-    ap.add_argument('--quiet', action='store_true', help='exit status only')
-    ap.add_argument('--lenient', action='store_true',
-                    help='report source-only omissions without failing the run')
-    args = ap.parse_args()
+class Report:
+    """Buckets for one comparison run."""
 
-    src_decls = []
-    for path in sorted(glob.glob(SRC_GLOB)):
-        with open(path, encoding='utf-8') as fh:
-            src_decls.extend(extract_decls(fh.read(), path, want_public=True))
+    def __init__(self):
+        self.changed = []       # docs and source both state a default, and they differ
+        self.docs_only = []     # docs state one the source has not
+        self.source_only = []   # source states one the docs omit
+        self.unverified = []    # several candidates disagree and nothing picked one
+        self.unmatched = []     # no declaration in Sources with this name and label list
+        self.checked = 0
+        self.matched = 0
+        self.compared_decls = 0
+        self.no_defaults_either_side = 0
+        self.resolved_by = {'unique': 0, 'heading': 0, 'filename': 0, 'unnarrowed': 0}
 
+    @property
+    def drift_total(self):
+        return len(self.changed) + len(self.docs_only) + len(self.source_only)
+
+
+def source_decls_from(files):
+    """files: {path: text} -> the public declarations they contain."""
+    out = []
+    for path in sorted(files):
+        out.extend(extract_decls(files[path], path, want_public=True))
+    return out
+
+
+def doc_decls_from(files):
+    """files: {path: markdown} -> [(decl, path, heading)] for every fenced-swift declaration."""
+    out = []
+    for path in sorted(files):
+        for block, base_line, heading in doc_swift_blocks(files[path]):
+            for d in extract_decls(block, path, want_public=False):
+                d['line'] = base_line + d['line'] - 1
+                out.append((d, path, heading))
+    return out
+
+
+def analyse(src_decls, doc_entries):
+    """Compare every restated declaration against the declaration it documents."""
     by_key = {}
     for d in src_decls:
         by_key.setdefault((d['name'], d['labels']), []).append(d)
 
-    changed, docs_only, source_only, unverified, unmatched = [], [], [], [], []
-    checked = matched = 0
-    resolved_by = {'unique': 0, 'heading': 0, 'filename': 0, 'unnarrowed': 0}
+    rep = Report()
+    for d, path, heading in doc_entries:
+        candidates = by_key.get((d['name'], d['labels']), [])
+        if not candidates:
+            rep.unmatched.append((d, path))
+            continue
+        rep.matched += 1
 
-    for path in sorted(glob.glob(DOCS_GLOB)):
-        with open(path, encoding='utf-8') as fh:
-            text = fh.read()
-        for block, base_line, heading in doc_swift_blocks(text):
-            for d in extract_decls(block, path, want_public=False):
-                if not any(p[1] for p in d['params']):
-                    continue  # nothing to compare
-                d['line'] = base_line + d['line'] - 1
-                candidates = by_key.get((d['name'], d['labels']), [])
-                if not candidates:
-                    unmatched.append(d)
-                    continue
-                matched += 1
-
-                pool, how = candidates, 'unnarrowed'
-                if len(candidates) == 1:
-                    how = 'unique'
-                else:
-                    ht = heading_type(heading)
-                    narrowed = [c for c in candidates if type_matches(c['type'], ht)]
+        pool, how = candidates, 'unnarrowed'
+        if len(candidates) == 1:
+            how = 'unique'
+        else:
+            # Nearest heading first, then out through the enclosing sections, then the filename.
+            # Each is only a hint and narrows only when it selects something, because a page
+            # documents types other than its title (`Shape-HLR-Geom.md` carries
+            # `Surface.approxWithDetails`).
+            for hd in reversed(heading):
+                for hint in (heading_type(hd), heading_bare_type(hd)):
+                    narrowed = [c for c in candidates if type_matches(c['type'], hint)]
                     if narrowed:
                         pool, how = narrowed, 'heading'
-                    else:
-                        ft = filename_type(path)
-                        narrowed = [c for c in candidates if type_matches(c['type'], ft)]
-                        if narrowed:
-                            pool, how = narrowed, 'filename'
-                resolved_by[how] += 1
-                checked += sum(1 for _, dv in d['params'] if dv is not None)
+                        break
+                if how == 'heading':
+                    break
+            if how != 'heading':
+                ft = filename_type(path)
+                narrowed = [c for c in candidates if type_matches(c['type'], ft)]
+                if narrowed:
+                    pool, how = narrowed, 'filename'
+        rep.resolved_by[how] += 1
 
-                def diffs(cand):
-                    # Positional, not keyed by label: a signature may repeat `_` several times
-                    # (`circlesTangentTo(_ c1:, _ q1:, _ c2:, ...)`), and a label-keyed lookup
-                    # collapses those to one entry, inventing drift for every `_` but the last.
-                    # Both sides matched on the ordered label tuple, so index i is the same
-                    # parameter on both.
-                    ch, only_d, only_s = [], [], []
-                    for i, (lab, dv) in enumerate(d['params']):
-                        sv = cand['params'][i][1]
-                        if dv is not None and sv is None:
-                            only_d.append((lab, dv))
-                        elif dv is None and sv is not None:
-                            only_s.append((lab, sv))
-                        elif dv is not None and sv is not None and \
-                                normalize_default(sv) != normalize_default(dv):
-                            ch.append((lab, dv, sv))
-                    return ch, only_d, only_s
+        n = len(d['params'])
+        doc_has = any(p[1] is not None for p in d['params'])
+        pool_has = any(c['params'][i][1] is not None for c in pool for i in range(n))
+        if not doc_has and not pool_has:
+            # Neither side states a default anywhere: nothing this gate can compare.
+            rep.no_defaults_either_side += 1
+            continue
+        rep.compared_decls += 1
 
-                results = [(c,) + diffs(c) for c in pool]
-
-                # Checked BEFORE accepting a clean match, not after. When neither the heading nor
-                # the filename supplied any type evidence and the candidates disagree about a
-                # default, agreeing with one of them proves nothing about the intended one — that
-                # is exactly how a page stating `Shape.writeOBJ`'s 0.1 for `Document.writeOBJ`
-                # passed. Deciding it on "some candidate matched" is the blind spot, so say so
-                # instead. A pool narrowed to one type may still hold several overloads (a
-                # deprecated twin carrying no defaults); there the doc's own defaults do pick one,
-                # so that stays a verified match.
-                if how == 'unnarrowed' and len(pool) > 1:
-                    spread = [set() for _ in d['params']]
-                    for c in pool:
-                        for i in range(len(d['params'])):
-                            sv = c['params'][i][1]
-                            spread[i].add(normalize_default(sv) if sv else None)
-                    if any(len(s) > 1 for s in spread):
-                        unverified.append((path, d['line'], d['name'], pool))
+        # Ambiguity is judged for EVERY pool holding more than one candidate, not only for a pool
+        # nothing narrowed. A heading or filename picks a *type*; a type can still hold two
+        # overloads, and deprecating by keeping the old signature verbatim -- defaults included --
+        # is the ordinary way to deprecate. Deciding such a pool by "some candidate matched
+        # cleanly" is the same unsound reasoning that let a cross-type default through.
+        #
+        # When a hint did narrow, a candidate that merely *lacks* a default at some position is
+        # not evidence of disagreement: the doc's own defaults still pick the overload that has
+        # one. So `None` is skipped there, and only two competing *values* count as ambiguous.
+        if len(pool) > 1:
+            ambiguous = False
+            for i in range(n):
+                vals = set()
+                for c in pool:
+                    sv = c['params'][i][1]
+                    if sv is None:
+                        if how == 'unnarrowed':
+                            vals.add(None)
                         continue
+                    vals.add(normalize_default(sv))
+                if len(vals) > 1:
+                    ambiguous = True
+                    break
+            if ambiguous:
+                rep.unverified.append((d, path, pool))
+                continue
 
-                clean = [r for r in results if not r[1] and not r[2] and not r[3]]
-                if clean:
-                    if args.verbose and not args.quiet:
-                        print(f'  ok   {path}:{d["line"]} {d["name"]}({",".join(d["labels"])})')
-                    continue
+        def diffs(cand):
+            # Positional, not keyed by label: a signature may repeat `_` several times
+            # (`circlesTangentTo(_ c1:, _ q1:, _ c2:, ...)`), and a label-keyed lookup collapses
+            # those to one entry, inventing drift for every `_` but the last. Both sides matched
+            # on the ordered label tuple, so index i is the same parameter on both.
+            ch, only_d, only_s = [], [], []
+            for i in range(n):
+                dv = d['params'][i][1]
+                sv = cand['params'][i][1]
+                if dv is not None and sv is None:
+                    only_d.append((i, dv))
+                elif dv is None and sv is not None:
+                    only_s.append((i, sv))
+                elif dv is not None and sv is not None and \
+                        normalize_default(sv) != normalize_default(dv):
+                    ch.append((i, dv, sv))
+            return ch, only_d, only_s
 
-                # Deterministic pick, so a report never names an arbitrary sibling's file.
-                cand, ch, only_d, only_s = min(
-                    results,
-                    key=lambda r: (len(r[1]) + len(r[2]) + len(r[3]), r[0]['file'], r[0]['line']))
-                for lab, dv, sv in ch:
-                    changed.append((path, d['line'], cand, d['name'], lab, dv, sv))
-                for lab, dv in only_d:
-                    docs_only.append((path, d['line'], cand, d['name'], lab, dv))
-                for lab, sv in only_s:
-                    source_only.append((path, d['line'], cand, d['name'], lab, sv))
+        results = [(c,) + diffs(c) for c in pool]
+        clean = [r for r in results if not r[1] and not r[2] and not r[3]]
+        best = min(results,
+                   key=lambda r: (len(r[1]) + len(r[2]) + len(r[3]), r[0]['file'], r[0]['line']))
+        ref = clean[0][0] if clean else best[0]
+        rep.checked += sum(1 for i in range(n)
+                           if d['params'][i][1] is not None or ref['params'][i][1] is not None)
+        if clean:
+            continue
 
+        cand, ch, only_d, only_s = best
+        for i, dv, sv in ch:
+            rep.changed.append((d, path, cand, i, dv, sv, pool))
+        for i, dv in only_d:
+            rep.docs_only.append((d, path, cand, i, dv, pool))
+        for i, sv in only_s:
+            rep.source_only.append((d, path, cand, i, sv, pool))
+    return rep
+
+
+def _cands(pool):
+    return ', '.join(f'{c["type"]} ({c["file"]}:{c["line"]})' for c in pool)
+
+
+def print_report(rep, lenient):
+    total = rep.matched + len(rep.unmatched)
+    print(f'restated declarations:               {total} '
+          f'({rep.matched} matched to a source declaration, '
+          f'{len(rep.unmatched)} with no counterpart)')
+    print(f'  owning declaration resolved by:    '
+          f'{rep.resolved_by["unique"]} unique, {rep.resolved_by["heading"]} heading, '
+          f'{rep.resolved_by["filename"]} filename, {rep.resolved_by["unnarrowed"]} unnarrowed')
+    print(f'  carrying a default on either side: {rep.compared_decls} '
+          f'({rep.no_defaults_either_side} state none on either side, nothing to compare)')
+    print(f'individual defaults compared:        {rep.checked}')
+    print(f'drifted (default changed):           {len(rep.changed)}')
+    print(f'drifted (stated only in docs):       {len(rep.docs_only)}')
+    print(f'drifted (stated only in source):     {len(rep.source_only)}'
+          f'{"  [warning only]" if lenient else ""}')
+    print(f'unverified (ambiguous, not checked): {len(rep.unverified)}')
+
+    if rep.changed:
+        print('\nCHANGED - docs and source both state a default and they differ:')
+        for d, path, cand, i, dv, sv, pool in rep.changed:
+            print(f'  {path}:{d["line"]}')
+            print(f'    {d["name"]}(... {param_desc(d, i)}) docs `{dv}` vs '
+                  f'{cand["file"]}:{cand["line"]} `{sv}`')
+            if len(pool) > 1:
+                print(f'      candidates: {_cands(pool)}')
+    if rep.docs_only:
+        print('\nSTATED ONLY IN DOCS - the source parameter has no default, so the argument is '
+              'required:')
+        for d, path, cand, i, dv, pool in rep.docs_only:
+            print(f'  {path}:{d["line"]}  {d["name"]}(... {param_desc(d, i)} = {dv})  '
+                  f'source {cand["file"]}:{cand["line"]}')
+            if len(pool) > 1:
+                print(f'      candidates: {_cands(pool)}')
+    if rep.source_only:
+        print('\nSTATED ONLY IN SOURCE - the docs omit a default, so the argument reads as '
+              'required when it is optional:')
+        for d, path, cand, i, sv, pool in rep.source_only:
+            print(f'  {path}:{d["line"]}  {d["name"]}(... {param_desc(d, i)})  source has '
+                  f'`= {sv}` at {cand["file"]}:{cand["line"]}')
+            if len(pool) > 1:
+                print(f'      candidates: {_cands(pool)}')
+    if rep.unverified:
+        print('\nUNVERIFIED - several declarations share this name and label list and they '
+              'disagree about a default, so this restatement cannot be adjudicated:')
+        for d, path, pool in rep.unverified:
+            print(f'  {path}:{d["line"]}  {d["name"]} - candidates: {_cands(pool)}')
+
+
+# --- self-test -------------------------------------------------------------------------------
+# Committed because three gate scripts on this branch have now shipped confidently wrong. Each
+# case is a drift shape that reached this script through review; none of them touch the real tree.
+
+SELF_TEST_CASES = [
+    (
+        'clean pair reports nothing',
+        {'Sources/OCCTSwift/A.swift': 'extension Surface {\n'
+                                      '    public func fit(tol: Double = 1e-3) -> Int { 0 }\n}\n'},
+        {'docs/reference/Surface.md': '### `Surface.fit(tol:)`\n\n```swift\n'
+                                      'public func fit(tol: Double = 1e-3) -> Int\n```\n'},
+        {},
+    ),
+    (
+        'changed default on a uniquely-named method (the #626 shape)',
+        {'Sources/OCCTSwift/A.swift': 'extension Surface {\n'
+                                      '    public func fit(tol: Double = 1e-9) -> Int { 0 }\n}\n'},
+        {'docs/reference/Surface.md': '### `Surface.fit(tol:)`\n\n```swift\n'
+                                      'public func fit(tol: Double = 1e-3) -> Int\n```\n'},
+        {'changed': 1},
+    ),
+    (
+        'changed default across an overloaded name resolved by filename',
+        {'Sources/OCCTSwift/A.swift':
+            'extension Document {\n    public func writeOBJ(to url: URL, deflection: Double = 1.0)'
+            ' -> Bool { true }\n}\n'
+            'extension Shape {\n    public func writeOBJ(to url: URL, deflection: Double = 0.1)'
+            ' -> Bool { true }\n}\n'},
+        {'docs/reference/Document-Persistence-IO.md':
+            '### `writeOBJ(to:deflection:)`\n\n```swift\n'
+            'public func writeOBJ(to url: URL, deflection: Double = 0.1) -> Bool\n```\n'},
+        {'changed': 1},
+    ),
+    (
+        'default stated only in docs',
+        {'Sources/OCCTSwift/A.swift': 'extension Surface {\n'
+                                      '    public func fit(tol: Double) -> Int { 0 }\n}\n'},
+        {'docs/reference/Surface.md': '### `Surface.fit(tol:)`\n\n```swift\n'
+                                      'public func fit(tol: Double = 1e-3) -> Int\n```\n'},
+        {'docs_only': 1},
+    ),
+    (
+        'default stated only in source, docs restating another default',
+        {'Sources/OCCTSwift/A.swift':
+            'extension Surface {\n    public func fit(tol: Double = 1e-3, n: Int = 4)'
+            ' -> Int { 0 }\n}\n'},
+        {'docs/reference/Surface.md': '### `Surface.fit(tol:n:)`\n\n```swift\n'
+                                      'public func fit(tol: Double, n: Int = 4) -> Int\n```\n'},
+        {'source_only': 1},
+    ),
+    (
+        'source-side addition where the page restates NO default at all',
+        {'Sources/OCCTSwift/A.swift': 'extension Surface {\n'
+                                      '    public func fit(tol: Double = 5e-9) -> Int { 0 }\n}\n'},
+        {'docs/reference/Surface.md': '### `Surface.fit(tol:)`\n\n```swift\n'
+                                      'public func fit(tol: Double) -> Int\n```\n'},
+        {'source_only': 1},
+    ),
+    (
+        'unnarrowable ambiguous pool is surfaced, not silently accepted',
+        {'Sources/OCCTSwift/A.swift':
+            'extension Document {\n    public func writeOBJ(to url: URL, deflection: Double = 1.0)'
+            ' -> Bool { true }\n}\n'
+            'extension Shape {\n    public func writeOBJ(to url: URL, deflection: Double = 0.1)'
+            ' -> Bool { true }\n}\n'},
+        {'docs/reference/Concurrency.md':
+            '### `writeOBJ(to:deflection:)`\n\n```swift\n'
+            'public func writeOBJ(to url: URL, deflection: Double = 1.0) -> Bool\n```\n'},
+        {'unverified': 1},
+    ),
+    (
+        'narrowed pool whose two overloads DISAGREE is unverified, not decided by a clean match',
+        {'Sources/OCCTSwift/A.swift':
+            'extension ZZProbe {\n'
+            '    @available(*, deprecated)\n'
+            '    public func zzFit(tol: Float = 1e-3) -> Int { 0 }\n'
+            '    public func zzFit(tol: Double = 1e-9) -> Int { 0 }\n}\n'},
+        {'docs/reference/ZZProbe.md': '### `ZZProbe.zzFit(tol:)`\n\n```swift\n'
+                                      'public func zzFit(tol: Float = 1e-3) -> Int\n```\n'},
+        {'unverified': 1},
+    ),
+    (
+        'narrowed pool whose deprecated twin merely lacks a default still verifies',
+        {'Sources/OCCTSwift/A.swift':
+            'extension Curve3D {\n'
+            '    public func continuityWith(order: ContinuityClass = .c2) -> Int { 0 }\n'
+            '    @available(*, deprecated)\n'
+            '    public func continuityWith(order: Int) -> Int { 0 }\n}\n'},
+        {'docs/reference/Curve3D-Analysis.md':
+            '### `continuityWith(order:)`\n\n```swift\n'
+            'public func continuityWith(order: ContinuityClass = .c2) -> Int\n```\n'},
+        {},
+    ),
+    (
+        'each repeated `_` position is watched independently',
+        {'Sources/OCCTSwift/A.swift':
+            'extension Curve2D {\n    public static func tangents(_ a: Int = 1, _ b: Int = 2,'
+            ' _ c: Int = 3) -> Int { 0 }\n}\n'},
+        {'docs/reference/Curve2D.md':
+            '### `Curve2D.tangents(_:_:_:)`\n\n```swift\n'
+            'public static func tangents(_ a: Int = 1, _ b: Int = 9, _ c: Int = 3) -> Int\n```\n'},
+        {'changed': 1},
+    ),
+    (
+        'a `.init(` call site in an example is not a declaration',
+        {'Sources/OCCTSwift/A.swift': 'extension Surface {\n'
+                                      '    public func fit(tol: Double = 1e-3) -> Int { 0 }\n}\n'},
+        {'docs/reference/Surface.md':
+            '### `Surface.fit(tol:)`\n\n```swift\n'
+            'public func fit(tol: Double = 1e-3) -> Int\n```\n\n'
+            '- **Example:**\n  ```swift\n  let s = FeatureSpec.extrude(.init(profile: pts,'
+            ' origin: .zero))\n  ```\n'},
+        {},
+    ),
+]
+
+
+def self_test():
+    """Run the drift battery in memory. Returns the number of failing cases."""
+    failures = 0
+    for name, src_files, doc_files, expect in SELF_TEST_CASES:
+        rep = analyse(source_decls_from(src_files), doc_decls_from(doc_files))
+        got = {
+            'changed': len(rep.changed),
+            'docs_only': len(rep.docs_only),
+            'source_only': len(rep.source_only),
+            'unverified': len(rep.unverified),
+        }
+        want = {k: expect.get(k, 0) for k in got}
+        if got == want:
+            print(f'  PASS  {name}')
+        else:
+            failures += 1
+            print(f'  FAIL  {name}')
+            print(f'          expected {want}')
+            print(f'          got      {got}')
+    print(f'\nself-test: {len(SELF_TEST_CASES) - failures} passed, {failures} failed')
+    return failures
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--quiet', action='store_true', help='exit status only')
+    ap.add_argument('--lenient', action='store_true',
+                    help='report source-only omissions without failing the run')
+    ap.add_argument('--self-test', action='store_true',
+                    help='run the built-in drift battery instead of scanning the tree')
+    ap.add_argument('--list-unmatched', action='store_true',
+                    help='list restatements with no declaration in Sources')
+    args = ap.parse_args()
+
+    if args.self_test:
+        return 1 if self_test() else 0
+
+    src_files, doc_files = {}, {}
+    for path in sorted(glob.glob(SRC_GLOB)):
+        with open(path, encoding='utf-8') as fh:
+            src_files[path] = fh.read()
+    for path in sorted(glob.glob(DOCS_GLOB)):
+        with open(path, encoding='utf-8') as fh:
+            doc_files[path] = fh.read()
+
+    rep = analyse(source_decls_from(src_files), doc_decls_from(doc_files))
+
+    unmatched_grew = len(rep.unmatched) > EXPECTED_UNMATCHED
     if not args.quiet:
-        total = matched + len(unmatched)
-        print(f'restated declarations with defaults: {total} '
-              f'({matched} matched to a source declaration, '
-              f'{len(unmatched)} with no counterpart)')
-        print(f'  owning declaration resolved by:    '
-              f'{resolved_by["unique"]} unique, {resolved_by["heading"]} heading, '
-              f'{resolved_by["filename"]} filename, {resolved_by["unnarrowed"]} unnarrowed')
-        print(f'individual defaults compared:        {checked}')
-        print(f'drifted (default changed):           {len(changed)}')
-        print(f'drifted (stated only in docs):       {len(docs_only)}')
-        print(f'drifted (stated only in source):     {len(source_only)}'
-              f'{"  [warning only]" if args.lenient else ""}')
-        print(f'unverified (ambiguous, not checked): {len(unverified)}')
+        print_report(rep, args.lenient)
+        if unmatched_grew or args.list_unmatched:
+            print(f'\nUNMATCHED — no declaration in Sources/OCCTSwift with this name and label '
+                  f'list (baseline {EXPECTED_UNMATCHED}, now {len(rep.unmatched)}):')
+            for d, path in rep.unmatched:
+                print(f'  {path}:{d["line"]}  {d["name"]}({",".join(d["labels"])})')
+        if unmatched_grew:
+            print(f'\n  A restatement stops being compared the moment its labels stop matching '
+                  f'any\n  declaration, so growth here is drift that would otherwise pass '
+                  f'silently. Check\n  each new entry, then raise EXPECTED_UNMATCHED if it is '
+                  f'genuinely uncomparable.')
 
-        if changed:
-            print('\nCHANGED — docs and source both state a default and they differ:')
-            for path, line, cand, name, lab, dv, sv in changed:
-                print(f'  {path}:{line}')
-                print(f'    {name}(… {lab}:) docs `{dv}` vs {cand["file"]}:{cand["line"]} `{sv}`')
-        if docs_only:
-            print('\nSTATED ONLY IN DOCS — the source parameter has no default, so the argument '
-                  'is required:')
-            for path, line, cand, name, lab, dv in docs_only:
-                print(f'  {path}:{line}  {name}(… {lab}: = {dv})  '
-                      f'source {cand["file"]}:{cand["line"]}')
-        if source_only:
-            print('\nSTATED ONLY IN SOURCE — the docs omit a default, so the argument reads as '
-                  'required when it is optional:')
-            for path, line, cand, name, lab, sv in source_only:
-                print(f'  {path}:{line}  {name}(… {lab}:)  source has `= {sv}` at '
-                      f'{cand["file"]}:{cand["line"]}')
-        if unverified:
-            print('\nUNVERIFIED — several declarations share this name and label list, nothing '
-                  'narrowed to one, and they disagree about a default:')
-            for path, line, name, pool in unverified:
-                where = ', '.join(f'{c["type"]} ({c["file"]}:{c["line"]})' for c in pool)
-                print(f'  {path}:{line}  {name} — candidates: {where}')
-        if args.verbose and unmatched:
-            print('\nUNMATCHED — no declaration in Sources/OCCTSwift (not an error):')
-            for d in unmatched:
-                print(f'  {d["file"]}:{d["line"]}  {d["name"]}({",".join(d["labels"])})')
-
-    fail = bool(changed) or bool(docs_only) or bool(unverified)
+    fail = bool(rep.changed) or bool(rep.docs_only) or bool(rep.unverified) or unmatched_grew
     if not args.lenient:
-        fail = fail or bool(source_only)
+        fail = fail or bool(rep.source_only)
     return 1 if fail else 0
 
 

--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -232,6 +232,17 @@ extension ContinuityClass {
     ///
     /// ``g1`` and ``g2`` are false: they constrain tangent direction and curvature but not the
     /// derivative vectors themselves.
+    ///
+    /// ```swift
+    /// ContinuityClass.c1.isParametric   // true
+    /// ContinuityClass.g2.isParametric   // false — curvature matches, C2 does not follow
+    /// ```
+    ///
+    /// - Important: `false` means "not a C-class", not "meets no floor at all" — the same
+    ///   distinction ``derivativeOrder`` carries. A geometric class still meets the C0 floor,
+    ///   so `guard measured.isParametric else { return false }` ahead of a `.c0` check reports
+    ///   a tangent-continuous curve as not even connected, which is #623 exactly. Gate on
+    ///   ``satisfies(_:)``; use this property to *describe* a class, not to gate on one.
     public var isParametric: Bool {
         switch self {
         case .c0, .c1, .c2, .c3, .cN: return true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -185,15 +185,43 @@ far the fitted surface moves. It also reinstated, in the documentation layer, th
 #491 existed to remove.
 
 The interesting part is not the one-line correction. A per-type reference page that restates a
-signature is a **copy**, and 877 such restatements carry a default value somewhere in this tree.
-`Scripts/check-docs-defaults.py` now parses every one of them, matches it to its `public`
-declaration in `Sources/OCCTSwift`, and compares each default the two state in common: **1460
-defaults checked, 2 drifted**, both of them this one. It reports a disagreement only when both sides
-state a default and the literals differ (modulo layout, so `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` are
-not a finding), which is what keeps the run at zero false positives; where several declarations
-share a name and parameter-label list, the doc heading's `Type.` prefix picks one and otherwise
-agreement with any candidate is accepted, so ambiguity cannot manufacture a failure either. Exit
-status is 1 on any drift, so it can gate a commit the way `check-null-handle-guards.py` does.
+signature is a **copy**, and this tree holds 3426 such restatements.
+`Scripts/check-docs-defaults.py` parses every one of them, matches it to its declaration in
+`Sources/OCCTSwift`, and compares them position by position: **1460 defaults compared, 2 drifted**,
+both of them this one.
+
+A default drifts in three shapes, and all three fail the run, because a gate that reports a defect
+while exiting 0 is not a gate. The literals can differ. The docs can state a default the source
+does not have, so a required argument reads as optional. Or the source can state one the docs omit
+— which is also how a *source-side* addition hides behind an unchanged page, and it is the reason
+the comparison covers restatements carrying no defaults at all rather than only the 876 that do.
+Layout is not drift: `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` compare equal.
+
+All of that depends on comparing against the **right** declaration, because several share one name
+and label list: `writeOBJ(to:deflection:)` is both `Document.writeOBJ` (deflection 1.0) and
+`Shape.writeOBJ` (0.1). Resolving that by accepting agreement with any candidate cannot invent a
+failure, but it can swallow one, and it did — twice, at two different depths. First across types,
+letting a page state `Shape.writeOBJ`'s default for `Document.writeOBJ` and exit 0. Then, once a
+hint selected the right *type*, across the overloads within it: deprecating a method by keeping its
+old signature verbatim, defaults included, is the ordinary way to deprecate, and the stale page
+went on matching the retained twin. Both are the #626 shape walking through the gate built for it.
+
+So the owning type is resolved from the nearest heading's qualifier, then outward through the
+enclosing section headings (`CurveAdaptors.md` holds `## WireCurve` and `## EdgeCurve`, each with
+an identically titled `### points(count:)`), then the page filename — and where that still leaves
+two candidates *disagreeing* about a default, the restatement is reported as `unverified` and
+fails, rather than being quietly decided by whichever one happened to match. A twin that merely
+lacks a default is still disambiguated by the doc's own defaults, so the ordinary deprecation
+shape stays quiet. On this tree: 2712 resolved uniquely, 504 by heading, 163 by filename, and
+**0 unverified**.
+
+Exit status is 1 on any drift, on an unverified restatement, or on growth in the `unmatched`
+bucket — a restatement stops being compared the moment its labels stop matching, so an unpinned
+bucket there would absorb a rename silently. `--self-test` runs an 11-case battery in memory,
+covering each shape above; it is committed because three gate scripts on this branch have now
+shipped confidently wrong, and an uncommitted battery regresses without saying so. Nothing runs
+this script yet — wiring the gate scripts into CI is #625, whose own note warns against installing
+a gate that passes unconditionally.
 
 `ContinuityClass.isParametric` was flagged as the same root cause and is the same shape of miss.
 #623 fixed `satisfies(_:)` and gave `derivativeOrder` an explicit warning that its `nil` means "no

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -171,6 +171,38 @@ throw and `catch (...)` would return `nullptr`, so `nil` comes back either way. 
 can separate those two layers, and claiming otherwise would be the same kind of overstatement this
 entry is about.
 
+#### The reference page that kept documenting the continuity default #491 replaced (#626)
+
+Two pages under `docs/reference/` restate `Surface.approxWithDetails`. #491 flipped both of its
+continuity defaults from C1 to C2 — so that it and `Surface.approximated` stop fitting to different
+smoothness when neither is given a continuity argument — and updated `Surface.md`.
+`Shape-HLR-Geom.md` went on declaring `uContinuity: ParametricContinuity = .c1, vContinuity: .c1`.
+
+That page **is** in this branch's changed set: its `quasiUniformParameters` entry was rewritten
+thirty lines below the stale default. A reader following it and omitting the arguments expects a C1
+fit and gets a C2 one, which per #572 is not cosmetic — continuity is one of the inputs deciding how
+far the fitted surface moves. It also reinstated, in the documentation layer, the exact divergence
+#491 existed to remove.
+
+The interesting part is not the one-line correction. A per-type reference page that restates a
+signature is a **copy**, and 877 such restatements carry a default value somewhere in this tree.
+`Scripts/check-docs-defaults.py` now parses every one of them, matches it to its `public`
+declaration in `Sources/OCCTSwift`, and compares each default the two state in common: **1460
+defaults checked, 2 drifted**, both of them this one. It reports a disagreement only when both sides
+state a default and the literals differ (modulo layout, so `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` are
+not a finding), which is what keeps the run at zero false positives; where several declarations
+share a name and parameter-label list, the doc heading's `Type.` prefix picks one and otherwise
+agreement with any candidate is accepted, so ambiguity cannot manufacture a failure either. Exit
+status is 1 on any drift, so it can gate a commit the way `check-null-handle-guards.py` does.
+
+`ContinuityClass.isParametric` was flagged as the same root cause and is the same shape of miss.
+#623 fixed `satisfies(_:)` and gave `derivativeOrder` an explicit warning that its `nil` means "no
+parametric order", not "meets no floor", because `guard let o = derivativeOrder else { return
+false }` reproduces #623 verbatim. `isParametric` is that property's structural sibling with the
+identical trap — it is `false` for the geometric classes, so `guard measured.isParametric` ahead of
+a `.c0` check reports a tangent-continuous curve as not even connected — and the warning was added
+to only one of the two. It now carries it as well, pointing at `satisfies(_:)` the same way.
+
 #### The one grid layout finally covers the third type holding a grid (#617)
 
 #486 declared **U-major** (`occtSurfaceGridIndex`, `iu * vCount + iv`) THE surface-grid buffer

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -185,7 +185,7 @@ far the fitted surface moves. It also reinstated, in the documentation layer, th
 #491 existed to remove.
 
 The interesting part is not the one-line correction. A per-type reference page that restates a
-signature is a **copy**, and this tree holds 3426 such restatements.
+signature is a **copy**, and this tree holds 3427 such restatements.
 `Scripts/check-docs-defaults.py` parses every one of them, matches it to its declaration in
 `Sources/OCCTSwift`, and compares them position by position: **1460 defaults compared, 2 drifted**,
 both of them this one.
@@ -195,7 +195,8 @@ while exiting 0 is not a gate. The literals can differ. The docs can state a def
 does not have, so a required argument reads as optional. Or the source can state one the docs omit
 — which is also how a *source-side* addition hides behind an unchanged page, and it is the reason
 the comparison covers restatements carrying no defaults at all rather than only the 876 that do.
-Layout is not drift: `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` compare equal.
+(`--lenient` drops that third shape to a warning, for a tree still paying it down; the other two
+fail either way.) Layout is not drift: `SIMD3(0, 0, 1)` and `SIMD3(0,0,1)` compare equal.
 
 All of that depends on comparing against the **right** declaration, because several share one name
 and label list: `writeOBJ(to:deflection:)` is both `Document.writeOBJ` (deflection 1.0) and
@@ -212,16 +213,29 @@ an identically titled `### points(count:)`), then the page filename — and wher
 two candidates *disagreeing* about a default, the restatement is reported as `unverified` and
 fails, rather than being quietly decided by whichever one happened to match. A twin that merely
 lacks a default is still disambiguated by the doc's own defaults, so the ordinary deprecation
-shape stays quiet. On this tree: 2712 resolved uniquely, 504 by heading, 163 by filename, and
+shape stays quiet. On this tree: 2713 resolved uniquely, 504 by heading, 163 by filename, and
 **0 unverified**.
+
+Worth stating exactly, rather than leaving it implied. 129 doc sites across 67 signature groups
+still hold more than one candidate after narrowing, but 108 of those are skipped upstream — neither
+side states a default, so there is nothing to compare — and only **21 sites across 9 groups** reach
+the ambiguity guard at all. Of those, 0 disagree on a value, 4 have a twin merely lacking one, and
+17 agree outright; the 17 are protected by the rule rather than by luck, since any later divergence
+between them reports `unverified`. The carve-out is narrower than "safe": a **single-sided
+acquisition** — one overload gains a default, a bare twin remains, and the page states none — stays
+quiet. That is the mirror of the documented twin exemption, it can only ever miss a `source_only`
+-class defect, and it is strictly better than before this change, when all 108 were not examined at
+all.
 
 Exit status is 1 on any drift, on an unverified restatement, or on growth in the `unmatched`
 bucket — a restatement stops being compared the moment its labels stop matching, so an unpinned
-bucket there would absorb a rename silently. `--self-test` runs an 11-case battery in memory,
-covering each shape above; it is committed because three gate scripts on this branch have now
-shipped confidently wrong, and an uncommitted battery regresses without saying so. Nothing runs
-this script yet — wiring the gate scripts into CI is #625, whose own note warns against installing
-a gate that passes unconditionally.
+bucket there would absorb a rename silently. `--self-test` runs a 13-case battery in memory,
+covering each shape above and each mechanism the gate depends on; every case was checked by
+reverting the mechanism it guards and confirming the battery goes red, because a case that passes
+with its subject removed is not a test. It is committed because three gate scripts on this branch
+have now shipped confidently wrong, and an uncommitted battery regresses without saying so. Nothing
+runs this script yet — wiring the gate scripts into CI is #625, whose own note warns against
+installing a gate that passes unconditionally.
 
 `ContinuityClass.isParametric` was flagged as the same root cause and is the same shape of miss.
 #623 fixed `satisfies(_:)` and gave `derivativeOrder` an explicit warning that its `nil` means "no

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -1086,8 +1086,8 @@ public struct ApproxSurfaceResult {
 Approximates a surface as a BSpline with detailed result information.
 
 ```swift
-public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c1,
-                               vContinuity: ParametricContinuity = .c1,
+public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c2,
+                               vContinuity: ParametricContinuity = .c2,
                                maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult
 ```
 
@@ -1099,7 +1099,7 @@ public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinui
   - `maxSegments` — maximum number of BSpline segments.
 - **Returns:** `ApproxSurfaceResult` with the output `Surface` (or `nil`), `maxError`, and status flags.
 - **OCCT:** `GeomConvert_ApproxSurface` via `OCCTGeomConvertApproxSurface`.
-- **Note:** Prefer `Surface.approximated(tolerance:continuity:maxSegments:maxDegree:)` for simpler use; use this variant when you need the error and status separately.
+- **Note:** Prefer `Surface.approximated(tolerance:continuity:maxSegments:maxDegree:)` for simpler use; use this variant when you need the error and status separately. Both continuity defaults are C2, matching `Surface.approximated`; before #491 they were C1 here, so the two no-continuity-argument calls fitted to different smoothness and returned different surfaces.
 - **Example:**
   ```swift
   let result = surface.approxWithDetails(tolerance: 0.001)


### PR DESCRIPTION
Closes #626

## The defect

Two pages under `docs/reference/` restate `Surface.approxWithDetails`. #491 flipped both continuity
defaults from C1 to C2 — so it and `Surface.approximated` stop fitting to different smoothness when
neither is given a continuity argument — and updated `Surface.md`. `Shape-HLR-Geom.md` went on
declaring `.c1` / `.c1`, thirty lines above a `quasiUniformParameters` entry this same branch
rewrote. Per #572 that is not cosmetic: continuity decides how far the fitted surface moves.

| # | docs | source | parameter | docs said | source says |
|---|---|---|---|---|---|
| 1 | `docs/reference/Shape-HLR-Geom.md:1089` | `Sources/OCCTSwift/Shape.swift:12559` | `uContinuity` | `.c1` | `.c2` |
| 2 | `docs/reference/Shape-HLR-Geom.md:1090` | `Sources/OCCTSwift/Shape.swift:12560` | `vContinuity` | `.c1` | `.c2` |

**1460 defaults compared, 2 drifted**, both this one, both fixed.

## Round-3 nits

Rebased onto #620/#631. The add/add CHANGELOG conflict kept every entry.

### Nit 2 — self-test case 11 was vacuous ✅

Correct, and it is the third instance of this defect class on this branch. The battery asserted
only the four drift buckets, so deleting the `.` call-site guard left it green: the stray `.init(`
simply moved to `unmatched`, which nothing was watching. **`unmatched` is now asserted on every
case.**

### Nit 3 — neither new mechanism had a case ✅

Added one each:

- **protocol-access rule** — a `public protocol` requirement whose default drifts. Without the rule
  the requirement is not public, so the restatement lands in `unmatched` and the drift goes
  unreported.
- **outward heading walk** — a page whose enclosing `## WireCurve` names the type its
  `### points(count:)` omits. Without the walk nothing names a type (the filename is
  `CurveAdaptors`), the pool stays at two disagreeing candidates, and this reads as `unverified`.

### All three mechanisms proven load-bearing, not assumed

Rather than adding the cases and trusting them, I reverted each mechanism in turn and confirmed the
battery goes red naming that exact case — restoring from a scratchpad copy, never `git checkout`,
which is what discarded the CHANGELOG rewrite earlier in this PR:

```
PASS  remove the `.` call-site guard
      -> battery goes red, and it is "a `.init(` call site in an example is not a declaration"
PASS  revert the protocol-access rule
      -> battery goes red, and it is "a protocol requirement takes its protocol access level"
PASS  revert the outward heading walk (nearest heading only)
      -> battery goes red, and it is "an enclosing section heading names the type the nearest heading omits"

restored; battery is self-test: 13 passed, 0 failed
load-bearing check: 3/3 mechanisms proven
```

### Nit 1 — framing corrected ✅

You are right that "125 safe because the gate fails if any diverges" left the scope implied. Stated
exactly now, in the changelog and here. Re-measured on the rebased tree, and it reconciles with
your 21/8 precisely as you described:

| | |
|---|---|
| doc sites whose pool holds >1 candidate after narrowing | **129** (67 signature groups) |
| skipped upstream at "nothing to compare" | **108** |
| **actually reaching the ambiguity guard** | **21** (9 signature groups) |
| — competing values → `unverified`, gate fails | 0 |
| — twin merely lacks a default → doc's defaults decide | 4 |
| — candidates agree on every default | 17 |

Both numbers were right about different things: 129 counts every multi-candidate pool, 21 counts
those the guard actually adjudicates.

And the carve-out is narrower than "safe", so it is now said outright rather than implied: a
**single-sided acquisition** — one overload gains a default, a bare twin remains, and the page
states none — stays quiet. That is the mirror of the documented twin exemption, it can only ever
miss a `source_only`-class defect, and it is strictly better than before this change, when all 108
were not examined at all.

### Nit 4 — `--lenient` ✅

The changelog entry now names it and its semantics: it drops `source-only` to a warning; `changed`
and `docs-only` fail either way.

## Self-test — 13/13

```
PASS  clean pair reports nothing
PASS  changed default on a uniquely-named method (the #626 shape)
PASS  changed default across an overloaded name resolved by filename
PASS  default stated only in docs
PASS  default stated only in source, docs restating another default
PASS  source-side addition where the page restates NO default at all
PASS  unnarrowable ambiguous pool is surfaced, not silently accepted
PASS  narrowed pool whose two overloads DISAGREE is unverified, not decided by a clean match
PASS  narrowed pool whose deprecated twin merely lacks a default still verifies
PASS  each repeated `_` position is watched independently
PASS  a protocol requirement takes its protocol access level                  [new]
PASS  an enclosing section heading names the type the nearest heading omits   [new]
PASS  a `.init(` call site in an example is not a declaration                 [now non-vacuous]
```

## Clean-tree run (rebased)

```
restated declarations:               3427 (3424 matched, 3 with no counterpart)
  owning declaration resolved by:    2713 unique, 504 heading, 163 filename, 44 unnarrowed
  carrying a default on either side: 876 (2548 state none on either side)
individual defaults compared:        1460
drifted (default changed):           0
drifted (stated only in docs):       0
drifted (stated only in source):     0
unverified (ambiguous, not checked): 0
exit 0
```

## Also

`ContinuityClass.isParametric` (`Sources/OCCTSwift/Continuity.swift:246`) is correct and not
drifted; the miss is the same *shape* as #626 — #623 gave `derivativeOrder` an explicit warning
that its `nil` means "no parametric order", not "meets no floor", and its structural sibling with
the identical trap got none. It now carries it, pointing at `satisfies(_:)`.

## Checks

- `./Scripts/check-docs-defaults.py` — all buckets 0, exit 0.
- `./Scripts/check-docs-defaults.py --self-test` — 13/13, and 3/3 mechanisms proven load-bearing.
- `swift build` — clean.
- `swift test --filter "Issue623ContinuityFloorTests|Issue485SurfaceContinuityTests|Issue398Continuity"`
  — 22 tests, 3 suites, pass.

One environment note for whoever picks this up: `OCCTSWIFT_BRIDGE_PREBUILT=1` no longer builds this
branch, because #614 added `OCCTFaceGetOrientation` / `OCCTShapeGetFaceOccurrenceCount` /
`OCCTShapeGetOrientedFaces` to the bridge and the released `OCCTBridge.xcframework` predates them.
Unrelated to this PR; build from source. Red macOS CI remains the known pinned-kernel gap (#585).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
