### PR TITLE
fix(#620): a single iso-row was documented, accepted, then silently refused

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -3372,8 +3372,11 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef surface,
                              double* outXYZ, int32_t maxPoints,
                              int32_t* outLineLengths, int32_t maxLines);
 
-/// Sample a uniform grid of points for mesh triangulation
-/// Returns total point count (uCount * vCount)
+/// Sample a uniform grid of points for mesh triangulation.
+/// Returns total point count (uCount * vCount), or 0 on failure.
+/// uCount and vCount must each be **at least 1**, not 2: this samples Geom_Surface::D0 over the
+/// parametric bounds and a single iso-row (or a single point) is a valid request (#620).
+/// Output is U-major, `outXYZ[(iu * vCount + iv) * 3 + {0,1,2}]`, matching occtSurfaceGridIndex.
 int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef surface,
                              int32_t uCount, int32_t vCount,
                              double* outXYZ);

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -3375,7 +3375,9 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef surface,
 /// Sample a uniform grid of points for mesh triangulation.
 /// Returns total point count (uCount * vCount), or 0 on failure.
 /// uCount and vCount must each be **at least 1**, not 2: this samples Geom_Surface::D0 over the
-/// parametric bounds and a single iso-row (or a single point) is a valid request (#620).
+/// sampled range and a single iso-row (or a single point) is a valid request (#620).
+/// The sampled range is the surface's parametric bounds with infinite ends clamped to ±100, so on
+/// an unbounded surface a single sample lands on the clamp (-100), not on the surface's own uMin.
 /// Output is U-major, `outXYZ[(iu * vCount + iv) * 3 + {0,1,2}]`, matching occtSurfaceGridIndex.
 int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef surface,
                              int32_t uCount, int32_t vCount,

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -863,6 +863,22 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
     return iu * vCount + iv;
 }
 
+/// THE definition of the i-th of `count` uniformly spaced parameters across `[lo, hi]`.
+///
+/// The whole content of this function is the divisor. `count - 1` is the number of *intervals*,
+/// which is the right spacing for two or more samples and a division by zero for one, and a
+/// single sample is a legitimate request: it means the low end of the range, the degenerate
+/// interval. Every sampling loop in this file needs that guard, and #620 is what happens when one
+/// of them is written without it — OCCTSurfaceDrawMesh divided by `count - 1` bare, so it had to
+/// reject `count == 1` to avoid handing NaN to Geom_Surface::D0, which does not throw on NaN but
+/// returns NaN coordinates. The bound that cost the caller was never OCCT's; it was this
+/// expression's. It is written once here so no future loop can re-derive the version without the
+/// guard, which is exactly how DrawGrid and DrawMesh came to disagree in the commit that
+/// introduced both of them.
+inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count) {
+    return lo + (hi - lo) * index / (count > 1 ? (count - 1) : 1);
+}
+
 // === #501: GCPnts arc-length samplers can return more points than were asked for ===
 //
 // GCPnts_UniformAbscissa::initialize sizes its own parameter array at `nbPoints + 5` and lets the

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -875,6 +875,11 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
 /// expression's. It is written once here so no future loop can re-derive the version without the
 /// guard, which is exactly how DrawGrid and DrawMesh came to disagree in the commit that
 /// introduced both of them.
+///
+/// Not every `count > 1 ? ... : ...` in the bridge is this function. OCCTGeomFillCoonsPatchEval's
+/// pair reads `(evalU > 1) ? (double)i / (evalU - 1) : 0.5` — its single-sample answer is the
+/// patch MIDPOINT, not the low end, so it is a different contract that happens to share a shape.
+/// Check the else-branch before folding a site in here.
 inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count) {
     return lo + (hi - lo) * index / (count > 1 ? (count - 1) : 1);
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -388,6 +388,12 @@ OCCTSurfaceRef OCCTSurfaceCreateRevolution(OCCTCurve3DRef meridian,
 
 // Freeform Surfaces
 
+// Unlike OCCTSurfaceDrawMesh's superficially identical `< 2` (which was this function's own
+// divisor masquerading as a kernel rule, #620), the 2 here IS OCCT's constraint and must stay:
+// Geom_BezierSurface's header states it raises "if the number of poles of the surface is lower
+// than 2 ... in one of the two directions U or V", since a Bezier's degree is poles - 1 and must
+// be >= 1. Measured: a 1 x N pole array throws Standard_ConstructionError, 2 x 2 builds a
+// degree-1 x degree-1 surface. Surface.bezier(poles:weights:) already guards the same bound.
 OCCTSurfaceRef OCCTSurfaceCreateBezier(const double* poles,
                                         int32_t uCount, int32_t vCount,
                                         const double* weights) {
@@ -817,10 +823,19 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef s,
     }
 }
 
+// The minimum here is 1 sample per direction, not 2. Despite the name this is not a mesher:
+// there is no BRepMesh, no triangulation and no quad, just a uniform walk of the parametric
+// bounds evaluating Geom_Surface::D0, and a single (u, v) is a perfectly valid OCCT evaluation
+// (measured: a 1 x 20 iso-row off a sphere is 20 finite points). The old `uCount < 2` guard was
+// not OCCT's constraint but this function's own divisor: `i / (uCount - 1)` divides by zero at
+// count 1, and the NaN parameter that produces is worse than a throw, because D0 does not throw
+// on NaN — it returns NaN coordinates silently. OCCTSurfaceDrawGrid, forty lines above, samples
+// the same bounds the same way and has always spelled the divisor defensively; that spelling is
+// now shared, so a single iso-row is served rather than rejected (#620).
 int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
                              int32_t uCount, int32_t vCount,
                              double* outXYZ) {
-    if (!s || s->surface.IsNull() || !outXYZ || uCount < 2 || vCount < 2) return 0;
+    if (!s || s->surface.IsNull() || !outXYZ || uCount < 1 || vCount < 1) return 0;
     try {
         double uMin, uMax, vMin, vMax;
         s->surface->Bounds(uMin, uMax, vMin, vMax);
@@ -833,9 +848,9 @@ int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
 
         int32_t idx = 0;
         for (int32_t i = 0; i < uCount; i++) {
-            double u = uMin + (uMax - uMin) * i / (uCount - 1);
+            double u = uMin + (uMax - uMin) * i / (uCount > 1 ? (uCount - 1) : 1);
             for (int32_t j = 0; j < vCount; j++) {
-                double v = vMin + (vMax - vMin) * j / (vCount - 1);
+                double v = vMin + (vMax - vMin) * j / (vCount > 1 ? (vCount - 1) : 1);
                 gp_Pnt p;
                 s->surface->D0(u, v, p);
                 outXYZ[idx * 3]     = p.X();

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -785,10 +785,10 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef s,
 
         // U-iso lines (constant U, varying V)
         for (int32_t i = 0; i < uCount && lineIdx < maxLines; i++) {
-            double u = uMin + (uMax - uMin) * i / (uCount > 1 ? (uCount - 1) : 1);
+            double u = occtUniformParameter(uMin, uMax, i, uCount);
             int32_t ptsInLine = 0;
             for (int32_t j = 0; j < pointsPerLine && totalPoints < maxPoints; j++) {
-                double v = vMin + (vMax - vMin) * j / (pointsPerLine > 1 ? (pointsPerLine - 1) : 1);
+                double v = occtUniformParameter(vMin, vMax, j, pointsPerLine);
                 gp_Pnt p;
                 s->surface->D0(u, v, p);
                 outXYZ[totalPoints * 3]     = p.X();
@@ -802,10 +802,10 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef s,
 
         // V-iso lines (constant V, varying U)
         for (int32_t j = 0; j < vCount && lineIdx < maxLines; j++) {
-            double v = vMin + (vMax - vMin) * j / (vCount > 1 ? (vCount - 1) : 1);
+            double v = occtUniformParameter(vMin, vMax, j, vCount);
             int32_t ptsInLine = 0;
             for (int32_t i = 0; i < pointsPerLine && totalPoints < maxPoints; i++) {
-                double u = uMin + (uMax - uMin) * i / (pointsPerLine > 1 ? (pointsPerLine - 1) : 1);
+                double u = occtUniformParameter(uMin, uMax, i, pointsPerLine);
                 gp_Pnt p;
                 s->surface->D0(u, v, p);
                 outXYZ[totalPoints * 3]     = p.X();
@@ -830,8 +830,14 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef s,
 // not OCCT's constraint but this function's own divisor: `i / (uCount - 1)` divides by zero at
 // count 1, and the NaN parameter that produces is worse than a throw, because D0 does not throw
 // on NaN — it returns NaN coordinates silently. OCCTSurfaceDrawGrid, forty lines above, samples
-// the same bounds the same way and has always spelled the divisor defensively; that spelling is
-// now shared, so a single iso-row is served rather than rejected (#620).
+// the same bounds and had spelled the divisor defensively since the commit that introduced both
+// functions; that expression is now occtUniformParameter, so neither loop states it in its own
+// words and a single iso-row is served rather than rejected (#620). Every other member of this
+// U-major grid family already accepted 1 — DrawGrid guards no count at all, EvaluateGrid and
+// EvaluateGridD1 guard `<= 0` — so the 2 here was the family's sole outlier.
+//
+// Note the infinite-bounds clamp below happens BEFORE the sampling, so on an unbounded surface
+// the row a single sample lands on is the clamped -100, not the surface's own -2e100 uMin.
 int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
                              int32_t uCount, int32_t vCount,
                              double* outXYZ) {
@@ -848,9 +854,9 @@ int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
 
         int32_t idx = 0;
         for (int32_t i = 0; i < uCount; i++) {
-            double u = uMin + (uMax - uMin) * i / (uCount > 1 ? (uCount - 1) : 1);
+            double u = occtUniformParameter(uMin, uMax, i, uCount);
             for (int32_t j = 0; j < vCount; j++) {
-                double v = vMin + (vMax - vMin) * j / (vCount > 1 ? (vCount - 1) : 1);
+                double v = occtUniformParameter(vMin, vMax, j, vCount);
                 gp_Pnt p;
                 s->surface->D0(u, v, p);
                 outXYZ[idx * 3]     = p.X();
@@ -6574,10 +6580,10 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
         // Uniform locator parameters in [0,1].
         NCollection_Array1<double> profileParams(1, profileCount);
         for (int i = 0; i < profileCount; i++)
-            profileParams.SetValue(i + 1, profileCount > 1 ? (double)i / (profileCount - 1) : 0.0);
+            profileParams.SetValue(i + 1, occtUniformParameter(0.0, 1.0, i, profileCount));
         NCollection_Array1<double> guideParams(1, guideCount);
         for (int j = 0; j < guideCount; j++)
-            guideParams.SetValue(j + 1, guideCount > 1 ? (double)j / (guideCount - 1) : 0.0);
+            guideParams.SetValue(j + 1, occtUniformParameter(0.0, 1.0, j, guideCount));
 
         // Intersection grid: row = profile (i), col = guide (j). Sample profile i
         // at the parameter matching guide j's normalized position along the profile.
@@ -6587,7 +6593,7 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
             const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
             double f = pc->FirstParameter(), l = pc->LastParameter();
             for (int j = 0; j < guideCount; j++) {
-                double t = guideCount > 1 ? f + (l - f) * ((double)j / (guideCount - 1)) : f;
+                double t = occtUniformParameter(f, l, j, guideCount);
                 ipts.SetValue(i + 1, j + 1, pc->Value(t));
                 iwts.SetValue(i + 1, j + 1, 1.0);
             }

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -2489,7 +2489,7 @@ void OCCTAdaptor3dIsoCurveEval(OCCTShapeRef faceShape, int isoType, double param
         if (last > 1e6) last = 1e6;
 
         for (int i = 0; i < evalCount; i++) {
-            double t = (evalCount > 1) ? first + (last - first) * i / (evalCount - 1) : first;
+            double t = occtUniformParameter(first, last, i, evalCount);
             gp_Pnt pt;
             iso.D0(t, pt);
             outPoints[i*3]     = pt.X();
@@ -6593,6 +6593,18 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
             const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
             double f = pc->FirstParameter(), l = pc->LastParameter();
             for (int j = 0; j < guideCount; j++) {
+                // The one site of the ten that is not a bit-identical substitution. It read
+                // `f + (l - f) * ((double)j / (guideCount - 1))`, so folding it into the shared
+                // helper reassociates the multiply and the divide: `(l-f)*(j/(n-1))` becomes
+                // `((l-f)*j)/(n-1)`. Measured across ten realistic [FirstParameter, LastParameter]
+                // ranges, 25-33% of cases differ by 1-2 ulp (<= 4e-15 over the whole span, and
+                // exactly 0 on this repo's own Gordon fixture). One structural consequence beyond
+                // the magnitude: the old form always landed the last sample exactly on
+                // f + (l - f), whereas this one can land 1 ulp PAST LastParameter (4 cases of
+                // n = 2..60 on a 0..2pi profile). Probed as harmless here because the builder
+                // SetNotPeriodic()s these curves first, so Geom_BSplineCurve::D0 does not throw
+                // just outside the range — but it is a boundary the old expression structurally
+                // could not cross, so a future caller that stops doing that must re-check it.
                 double t = occtUniformParameter(f, l, j, guideCount);
                 ipts.SetValue(i + 1, j + 1, pc->Value(t));
                 iwts.SetValue(i + 1, j + 1, 1.0);

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -688,21 +688,35 @@ public final class Surface: @unchecked Sendable {
     ///   `drawMesh(uCount: -1, vCount: -1)` used to look well-behaved while
     ///   `drawMesh(uCount: -1, vCount: 3)` aborted the process.
     ///
+    /// Samples span the **sampled range**, which is the surface's parametric domain with infinite
+    /// bounds clamped to ±100. For a bounded surface that is ``domain``; for an unbounded one
+    /// (a plane, an unbounded cylinder) it is not, and the difference is extreme rather than
+    /// marginal — a plane's `domain.uMin` is about -2e100 while its first sample sits at -100.
+    ///
     /// **One sample in a direction is a request, not a degenerate case.** Despite the name nothing
-    /// here triangulates: the bridge walks the parametric bounds evaluating the surface pointwise,
-    /// so `uCount: 1` is the single iso-row at `uMin` and a 1×1 grid is one point. The bridge used
-    /// to demand 2 per direction — its own interpolation divisor, not an OCCT rule — so a request
-    /// this doc called in-range came back as an empty grid the caller could not tell apart from a
-    /// surface that failed to sample (#620). Counts below 1 are still rejected, and rejection is
-    /// still an empty grid, the documented answer every ``Sampling`` entry point gives.
+    /// here triangulates: the bridge walks that range evaluating the surface pointwise, so
+    /// `uCount: 1` is the single iso-row at the low end of the sampled U range and a 1×1 grid is
+    /// one point. The bridge used to demand 2 per direction — its own interpolation divisor, not
+    /// an OCCT rule — so a request this doc called in-range came back as an empty grid the caller
+    /// could not tell apart from a surface that failed to sample (#620). Counts below 1 are still
+    /// rejected, and rejection is still an empty grid, the documented answer every ``Sampling``
+    /// entry point gives.
     ///
     /// ```swift
     /// let grid = surface.drawMesh(uCount: 30, vCount: 30)
     /// let p = grid.at(u: 5, v: 3)
     ///
-    /// // A single V iso-row: 20 points along v at the surface's minimum u.
+    /// // A single V iso-row: 20 points along v, at the low end of the sampled U range.
     /// let isoRow = surface.drawMesh(uCount: 1, vCount: 20)
     /// let along = (0..<isoRow.vCount).map { isoRow.at(u: 0, v: $0) }
+    ///
+    /// // Bounded surface: that low end is domain.uMin.
+    /// let sphere = Surface.sphere(center: .zero, radius: 10)!
+    /// sphere.drawMesh(uCount: 1, vCount: 4).at(u: 0, v: 0)   // == sphere.point(atU: 0, v: -.pi / 2)
+    ///
+    /// // Unbounded surface: it is the clamp, not domain.uMin.
+    /// let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+    /// plane.drawMesh(uCount: 1, vCount: 4).at(u: 0, v: 0).x   // -100, not plane.domain.uMin
     /// ```
     public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid {
         // `atLeast: 1` is gridTotal's default, but it is spelled out because it is a contract the

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -328,10 +328,24 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Freeform Surfaces
 
-    /// Create a Bezier surface from control points
+    /// Create a Bezier surface from control points.
+    ///
     /// - Parameters:
-    ///   - poles: 2D array of control points [uRow][vCol]
-    ///   - weights: Optional 2D array of weights (same dimensions as poles)
+    ///   - poles: 2D array of control points `[uRow][vCol]`, **at least 2 × 2**.
+    ///   - weights: Optional 2D array of weights (same dimensions as poles).
+    /// - Returns: The surface, or `nil` if either direction has fewer than 2 poles or OCCT rejects
+    ///   the poles. Unlike ``drawMesh(uCount:vCount:)``, whose superficially identical minimum of 2
+    ///   turned out to be a bridge artifact (#620), this one is the kernel's: a Bezier's degree is
+    ///   its pole count minus 1 and must be at least 1, so `Geom_BezierSurface` raises
+    ///   `Standard_ConstructionError` on a single-pole direction. A 2 × 2 patch is the smallest
+    ///   legal one, bilinear in both directions.
+    ///
+    /// ```swift
+    /// let patch = Surface.bezier(poles: [
+    ///     [SIMD3(0, 0, 0), SIMD3(0, 1, 0)],
+    ///     [SIMD3(1, 0, 0), SIMD3(1, 1, 1)],
+    /// ])
+    /// ```
     public static func bezier(poles: [[SIMD3<Double>]],
                               weights: [[Double]]? = nil) -> Surface? {
         let uCount = Int32(poles.count)
@@ -662,7 +676,7 @@ public final class Surface: @unchecked Sendable {
         return result
     }
 
-    /// Sample a uniform mesh grid of points for Metal visualization.
+    /// Sample a uniform grid of points over the surface's parametric bounds.
     ///
     /// - Parameters:
     ///   - uCount: Samples in U, at least 1.
@@ -674,12 +688,26 @@ public final class Surface: @unchecked Sendable {
     ///   `drawMesh(uCount: -1, vCount: -1)` used to look well-behaved while
     ///   `drawMesh(uCount: -1, vCount: 3)` aborted the process.
     ///
+    /// **One sample in a direction is a request, not a degenerate case.** Despite the name nothing
+    /// here triangulates: the bridge walks the parametric bounds evaluating the surface pointwise,
+    /// so `uCount: 1` is the single iso-row at `uMin` and a 1×1 grid is one point. The bridge used
+    /// to demand 2 per direction — its own interpolation divisor, not an OCCT rule — so a request
+    /// this doc called in-range came back as an empty grid the caller could not tell apart from a
+    /// surface that failed to sample (#620). Counts below 1 are still rejected, and rejection is
+    /// still an empty grid, the documented answer every ``Sampling`` entry point gives.
+    ///
     /// ```swift
     /// let grid = surface.drawMesh(uCount: 30, vCount: 30)
     /// let p = grid.at(u: 5, v: 3)
+    ///
+    /// // A single V iso-row: 20 points along v at the surface's minimum u.
+    /// let isoRow = surface.drawMesh(uCount: 1, vCount: 20)
+    /// let along = (0..<isoRow.vCount).map { isoRow.at(u: 0, v: $0) }
     /// ```
     public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid {
-        guard let total = Sampling.gridTotal(uCount, vCount) else { return .empty }
+        // `atLeast: 1` is gridTotal's default, but it is spelled out because it is a contract the
+        // bridge has to match exactly: the one time it was left implicit the two disagreed (#620).
+        guard let total = Sampling.gridTotal(uCount, vCount, atLeast: 1) else { return .empty }
         var buffer = [Double](repeating: 0, count: total * 3)
         let n = Int(OCCTSurfaceDrawMesh(handle, Int32(uCount), Int32(vCount), &buffer))
         guard n == total else { return .empty }

--- a/Tests/OCCTSurfaceTests/Issue620DrawMeshCountContractTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue620DrawMeshCountContractTests.swift
@@ -1,0 +1,170 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #620. Three layers disagreed about `drawMesh`'s minimum count, and the caller paid.
+///
+/// The doc comment and the `Sampling.gridTotal` guard both said 1; the bridge said 2 and returned
+/// 0 for anything less, which the wrapper's `guard n == total` turned into `SurfaceGrid.empty`.
+/// So `drawMesh(uCount: 1, vCount: 20)` — in range by its own documentation — came back empty,
+/// indistinguishable from a surface that genuinely failed to sample.
+///
+/// Measured before choosing a side, because the doc was written asserting 1 works and somebody
+/// believed it. `OCCTSurfaceDrawMesh` is not a mesher: no `BRepMesh`, no triangulation, no quad,
+/// just a uniform walk of the parametric bounds calling `Geom_Surface::D0`, and a single `(u, v)`
+/// is a valid OCCT evaluation. The 2 was the function's own divisor — `i / (uCount - 1)` divides
+/// by zero at count 1 — and the resulting NaN parameter is worse than a throw, since `D0` does not
+/// throw on NaN, it returns NaN coordinates. `OCCTSurfaceDrawGrid`, sampling the same bounds forty
+/// lines above in the same file, had always spelled that divisor defensively. So the bridge was
+/// the wrong layer, and the doc and the Swift guard were right.
+///
+/// The tests below therefore assert the *documented* contract: 1 is servable, and it is servable
+/// with the same points the surface reports on its own.
+@Suite("drawMesh honours its documented minimum of one sample per direction (#620)")
+struct Issue620DrawMeshCountContractTests {
+
+    static func sphere() -> Surface? { Surface.sphere(center: .zero, radius: 10) }
+
+    static func isFinite(_ p: SIMD3<Double>) -> Bool {
+        p.x.isFinite && p.y.isFinite && p.z.isFinite
+    }
+
+    // MARK: - The two reported requests
+
+    @Test("uCount 1 returns a single V iso-row, not an empty grid")
+    func singleURow() {
+        guard let s = Self.sphere() else { return }
+        let grid = s.drawMesh(uCount: 1, vCount: 20)
+
+        // The defect: this was SurfaceGrid.empty.
+        #expect(!grid.isEmpty)
+        #expect(grid.uCount == 1)
+        #expect(grid.vCount == 20)
+
+        // Every point finite, i.e. the divisor did not go through 0/0.
+        for v in 0..<grid.vCount {
+            #expect(Self.isFinite(grid.at(u: 0, v: v)))
+        }
+    }
+
+    @Test("vCount 1 returns a single U iso-row, not an empty grid")
+    func singleVRow() {
+        guard let s = Self.sphere() else { return }
+        let grid = s.drawMesh(uCount: 20, vCount: 1)
+
+        #expect(!grid.isEmpty)
+        #expect(grid.uCount == 20)
+        #expect(grid.vCount == 1)
+
+        for u in 0..<grid.uCount {
+            #expect(Self.isFinite(grid.at(u: u, v: 0)))
+        }
+    }
+
+    // MARK: - The row is the right row
+
+    /// Finiteness alone would pass on any arbitrary parameter. This pins *which* iso-row a
+    /// one-sample direction means: the one at the domain minimum, cross-checked against the
+    /// surface's own point evaluation rather than against another grid call.
+    @Test("The single row sits at the domain minimum and matches point(atU:v:)")
+    func singleRowSitsAtTheDomainMinimum() {
+        guard let s = Self.sphere() else { return }
+        let d = s.domain
+        let vCount = 8
+        let grid = s.drawMesh(uCount: 1, vCount: vCount)
+        guard grid.vCount == vCount else {
+            #expect(Bool(false), "expected \(vCount) V samples, got \(grid.vCount)")
+            return
+        }
+
+        for j in 0..<vCount {
+            let v = d.vMin + (d.vMax - d.vMin) * Double(j) / Double(vCount - 1)
+            let expected = s.point(atU: d.uMin, v: v)
+            let got = grid.at(u: 0, v: j)
+            #expect(simd_distance(got, expected) < 1e-9)
+        }
+    }
+
+    /// The same row, reached the other way: row 0 of a multi-row grid is also the `uMin` row, and
+    /// its V samples are spaced identically. A one-row grid must agree with it point for point.
+    @Test("A one-row grid equals row 0 of a many-row grid")
+    func oneRowEqualsRowZeroOfAManyRowGrid() {
+        guard let s = Self.sphere() else { return }
+        let vCount = 12
+        let one = s.drawMesh(uCount: 1, vCount: vCount)
+        let many = s.drawMesh(uCount: 6, vCount: vCount)
+        guard one.vCount == vCount, many.vCount == vCount, many.uCount == 6 else {
+            #expect(Bool(false), "grids not served: \(one.uCount)x\(one.vCount), \(many.uCount)x\(many.vCount)")
+            return
+        }
+
+        for j in 0..<vCount {
+            #expect(simd_distance(one.at(u: 0, v: j), many.at(u: 0, v: j)) < 1e-9)
+        }
+    }
+
+    @Test("A 1x1 grid is one point, at the domain corner")
+    func oneByOneIsASinglePoint() {
+        guard let s = Self.sphere() else { return }
+        let grid = s.drawMesh(uCount: 1, vCount: 1)
+        #expect(!grid.isEmpty)
+        #expect(grid.uCount == 1)
+        #expect(grid.vCount == 1)
+
+        let d = s.domain
+        #expect(simd_distance(grid.at(u: 0, v: 0), s.point(atU: d.uMin, v: d.vMin)) < 1e-9)
+    }
+
+    /// An unbounded surface takes the bridge's infinite-bounds clamp before the divisor, so it
+    /// exercises a different pair of endpoints. It must still serve one row.
+    @Test("A surface with infinite bounds also serves a one-sample direction")
+    func infiniteBoundsSurfaceServesOneRow() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else { return }
+        let grid = plane.drawMesh(uCount: 1, vCount: 5)
+        #expect(!grid.isEmpty)
+        #expect(grid.uCount == 1)
+        #expect(grid.vCount == 5)
+        for v in 0..<grid.vCount {
+            #expect(Self.isFinite(grid.at(u: 0, v: v)))
+        }
+    }
+
+    // MARK: - The bound moved to 1, it did not disappear
+
+    /// #558's bounds are still in force. Lowering the minimum to 1 must not readmit 0, a negative,
+    /// or a product past the ceiling — those stay rejected at the Swift boundary, before any
+    /// allocation, and rejection is still the documented empty grid.
+    @Test("Counts below 1 and products past the ceiling are still rejected")
+    func belowOneAndPastTheCeilingStillRejected() {
+        guard let s = Self.sphere() else { return }
+
+        #expect(s.drawMesh(uCount: 0, vCount: 20).isEmpty)
+        #expect(s.drawMesh(uCount: 20, vCount: 0).isEmpty)
+        #expect(s.drawMesh(uCount: -1, vCount: 20).isEmpty)
+        #expect(s.drawMesh(uCount: 20, vCount: -1).isEmpty)
+        // Two negatives multiply to a plausible positive total; each factor is checked on its own.
+        #expect(s.drawMesh(uCount: -1, vCount: -1).isEmpty)
+        // Past Sampling.maximumSampleCount as a product, with both factors individually in range.
+        #expect(s.drawMesh(uCount: 5000, vCount: 2001).isEmpty)
+        #expect(s.drawMesh(uCount: Int.max, vCount: Int.max).isEmpty)
+    }
+
+    // MARK: - The sibling site keeps its 2
+
+    /// `OCCTSurfaceCreateBezier` carries a visually identical `uCount < 2 || vCount < 2`, but that
+    /// one is the kernel's rule, not a divisor: a Bezier's degree is poles - 1 and must be >= 1, so
+    /// `Geom_BezierSurface` raises on a single-pole direction. Measured against the kernel, and
+    /// pinned here so the two look-alike guards are not "made consistent" in some later sweep.
+    @Test("Bezier keeps its minimum of two poles per direction, which is OCCT's own")
+    func bezierKeepsItsTwoPoleMinimum() {
+        // One pole in U: rejected.
+        #expect(Surface.bezier(poles: [[SIMD3(0, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 2, 0)]]) == nil)
+        // One pole in V: rejected.
+        #expect(Surface.bezier(poles: [[SIMD3(0, 0, 0)], [SIMD3(1, 0, 0)]]) == nil)
+        // The smallest legal patch: accepted.
+        #expect(Surface.bezier(poles: [
+            [SIMD3(0, 0, 0), SIMD3(0, 1, 0)],
+            [SIMD3(1, 0, 0), SIMD3(1, 1, 1)],
+        ]) != nil)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue620DrawMeshCountContractTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue620DrawMeshCountContractTests.swift
@@ -11,19 +11,30 @@ import simd
 ///
 /// Measured before choosing a side, because the doc was written asserting 1 works and somebody
 /// believed it. `OCCTSurfaceDrawMesh` is not a mesher: no `BRepMesh`, no triangulation, no quad,
-/// just a uniform walk of the parametric bounds calling `Geom_Surface::D0`, and a single `(u, v)`
-/// is a valid OCCT evaluation. The 2 was the function's own divisor — `i / (uCount - 1)` divides
-/// by zero at count 1 — and the resulting NaN parameter is worse than a throw, since `D0` does not
-/// throw on NaN, it returns NaN coordinates. `OCCTSurfaceDrawGrid`, sampling the same bounds forty
-/// lines above in the same file, had always spelled that divisor defensively. So the bridge was
-/// the wrong layer, and the doc and the Swift guard were right.
+/// just a uniform walk of the sampled range calling `Geom_Surface::D0`, and a single `(u, v)` is
+/// a valid OCCT evaluation. The 2 was the function's own divisor — `i / (uCount - 1)` divides by
+/// zero at count 1 — and the resulting NaN parameter is worse than a throw, since `D0` does not
+/// throw on NaN, it returns NaN coordinates. Every other member of the same U-major grid family
+/// already accepted 1 (`OCCTSurfaceDrawGrid` guards no count at all, `EvaluateGrid` and
+/// `EvaluateGridD1` guard `<= 0`), so `drawMesh` was the sole outlier. The bridge was the wrong
+/// layer; the doc and the Swift guard were right.
 ///
-/// The tests below therefore assert the *documented* contract: 1 is servable, and it is servable
-/// with the same points the surface reports on its own.
+/// Two things these tests are careful about, both learned from review:
+///
+/// - **No unguarded `.at(u:v:)`.** It is a `precondition`, so on an empty grid it traps the whole
+///   target with a signal instead of failing. Swift Testing does not short-circuit, so a count
+///   assertion above does not protect a subscript below; every read here is behind a `guard`.
+/// - **The single row sits at the low end of the *sampled range*, not at `domain.uMin`.** The
+///   bridge clamps infinite bounds to ±100 before sampling, so those two coincide only for a
+///   bounded surface. Asserting `domain.uMin` on a sphere and calling it the contract is how #620
+///   happened in the first place: a claim true of the fixture in front of you and false in
+///   general. `singleRowOnAnUnboundedSurfaceSitsAtTheClamp` pins the other half.
 @Suite("drawMesh honours its documented minimum of one sample per direction (#620)")
 struct Issue620DrawMeshCountContractTests {
 
-    static func sphere() -> Surface? { Surface.sphere(center: .zero, radius: 10) }
+    /// The bridge's own infinite-bounds clamp (`OCCTBridge_Surface.mm`): anything beyond ±1e6
+    /// becomes ±100, and that happens before the sampling parameters are derived.
+    static let clamp = 100.0
 
     static func isFinite(_ p: SIMD3<Double>) -> Bool {
         p.x.isFinite && p.y.isFinite && p.z.isFinite
@@ -33,13 +44,16 @@ struct Issue620DrawMeshCountContractTests {
 
     @Test("uCount 1 returns a single V iso-row, not an empty grid")
     func singleURow() {
-        guard let s = Self.sphere() else { return }
+        guard let s = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture nil"); return
+        }
         let grid = s.drawMesh(uCount: 1, vCount: 20)
 
         // The defect: this was SurfaceGrid.empty.
         #expect(!grid.isEmpty)
-        #expect(grid.uCount == 1)
-        #expect(grid.vCount == 20)
+        guard grid.uCount == 1, grid.vCount == 20 else {
+            Issue.record("expected a 1x20 grid, got \(grid.uCount)x\(grid.vCount)"); return
+        }
 
         // Every point finite, i.e. the divisor did not go through 0/0.
         for v in 0..<grid.vCount {
@@ -49,12 +63,15 @@ struct Issue620DrawMeshCountContractTests {
 
     @Test("vCount 1 returns a single U iso-row, not an empty grid")
     func singleVRow() {
-        guard let s = Self.sphere() else { return }
+        guard let s = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture nil"); return
+        }
         let grid = s.drawMesh(uCount: 20, vCount: 1)
 
         #expect(!grid.isEmpty)
-        #expect(grid.uCount == 20)
-        #expect(grid.vCount == 1)
+        guard grid.uCount == 20, grid.vCount == 1 else {
+            Issue.record("expected a 20x1 grid, got \(grid.uCount)x\(grid.vCount)"); return
+        }
 
         for u in 0..<grid.uCount {
             #expect(Self.isFinite(grid.at(u: u, v: 0)))
@@ -64,37 +81,78 @@ struct Issue620DrawMeshCountContractTests {
     // MARK: - The row is the right row
 
     /// Finiteness alone would pass on any arbitrary parameter. This pins *which* iso-row a
-    /// one-sample direction means: the one at the domain minimum, cross-checked against the
-    /// surface's own point evaluation rather than against another grid call.
-    @Test("The single row sits at the domain minimum and matches point(atU:v:)")
-    func singleRowSitsAtTheDomainMinimum() {
-        guard let s = Self.sphere() else { return }
+    /// one-sample direction means on a **bounded** surface, where the sampled range is the domain,
+    /// cross-checked against the surface's own point evaluation rather than another grid call.
+    @Test("On a bounded surface the single row sits at domain.uMin")
+    func singleRowOnABoundedSurfaceSitsAtDomainMin() {
+        guard let s = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture nil"); return
+        }
         let d = s.domain
+        // A sphere is bounded, so the clamp cannot have moved either end.
+        #expect(abs(d.uMin) < 1e6 && abs(d.uMax) < 1e6)
+
         let vCount = 8
         let grid = s.drawMesh(uCount: 1, vCount: vCount)
-        guard grid.vCount == vCount else {
-            #expect(Bool(false), "expected \(vCount) V samples, got \(grid.vCount)")
-            return
+        guard grid.uCount == 1, grid.vCount == vCount else {
+            Issue.record("expected a 1x\(vCount) grid, got \(grid.uCount)x\(grid.vCount)"); return
         }
 
         for j in 0..<vCount {
             let v = d.vMin + (d.vMax - d.vMin) * Double(j) / Double(vCount - 1)
             let expected = s.point(atU: d.uMin, v: v)
-            let got = grid.at(u: 0, v: j)
-            #expect(simd_distance(got, expected) < 1e-9)
+            #expect(simd_distance(grid.at(u: 0, v: j), expected) < 1e-9)
         }
     }
 
-    /// The same row, reached the other way: row 0 of a multi-row grid is also the `uMin` row, and
+    /// The other half of the contract, and the half the first version of this suite got wrong.
+    ///
+    /// A plane is unbounded, so `domain.uMin` is about -2e100 while the bridge clamps to -100
+    /// *before* deriving parameters. The single row therefore sits at the clamp, nowhere near
+    /// `domain.uMin`. Checking only finiteness here (as this suite first did) passes under either
+    /// reading and so cannot tell the doc it is wrong.
+    @Test("On an unbounded surface the single row sits at the clamp, not at domain.uMin")
+    func singleRowOnAnUnboundedSurfaceSitsAtTheClamp() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else {
+            Issue.record("plane fixture nil"); return
+        }
+        let d = plane.domain
+        // The premise: this surface really is unbounded, so domain and sampled range differ.
+        #expect(d.uMin < -1e6)
+
+        let vCount = 5
+        let grid = plane.drawMesh(uCount: 1, vCount: vCount)
+        guard grid.uCount == 1, grid.vCount == vCount else {
+            Issue.record("expected a 1x\(vCount) grid, got \(grid.uCount)x\(grid.vCount)"); return
+        }
+
+        // This plane's parametrisation is (u, v) -> (u, v, 0), so the row's x IS its u parameter.
+        for j in 0..<vCount {
+            let p = grid.at(u: 0, v: j)
+            #expect(Self.isFinite(p))
+            #expect(abs(p.x - (-Self.clamp)) < 1e-9)
+        }
+
+        // And the row spans the clamped V range, not 2e100 of it.
+        let first = grid.at(u: 0, v: 0)
+        let last = grid.at(u: 0, v: vCount - 1)
+        #expect(abs(first.y - (-Self.clamp)) < 1e-9)
+        #expect(abs(last.y - Self.clamp) < 1e-9)
+    }
+
+    /// The same row, reached the other way: row 0 of a multi-row grid is also the low-end row, and
     /// its V samples are spaced identically. A one-row grid must agree with it point for point.
     @Test("A one-row grid equals row 0 of a many-row grid")
     func oneRowEqualsRowZeroOfAManyRowGrid() {
-        guard let s = Self.sphere() else { return }
+        guard let s = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture nil"); return
+        }
         let vCount = 12
         let one = s.drawMesh(uCount: 1, vCount: vCount)
         let many = s.drawMesh(uCount: 6, vCount: vCount)
-        guard one.vCount == vCount, many.vCount == vCount, many.uCount == 6 else {
-            #expect(Bool(false), "grids not served: \(one.uCount)x\(one.vCount), \(many.uCount)x\(many.vCount)")
+        guard one.uCount == 1, one.vCount == vCount,
+              many.uCount == 6, many.vCount == vCount else {
+            Issue.record("grids not served: \(one.uCount)x\(one.vCount), \(many.uCount)x\(many.vCount)")
             return
         }
 
@@ -103,30 +161,23 @@ struct Issue620DrawMeshCountContractTests {
         }
     }
 
-    @Test("A 1x1 grid is one point, at the domain corner")
+    @Test("A 1x1 grid is one point, at the sampled-range corner")
     func oneByOneIsASinglePoint() {
-        guard let s = Self.sphere() else { return }
+        guard let s = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture nil"); return
+        }
         let grid = s.drawMesh(uCount: 1, vCount: 1)
         #expect(!grid.isEmpty)
-        #expect(grid.uCount == 1)
-        #expect(grid.vCount == 1)
+        // `.at` is a precondition, not an optional: reading it on an empty grid traps the whole
+        // test target with a signal and no run summary. Never subscript before this guard — the
+        // first version of this test did, and the regression it exists to catch killed the target
+        // instead of reporting a failure.
+        guard grid.uCount == 1, grid.vCount == 1 else {
+            Issue.record("expected a 1x1 grid, got \(grid.uCount)x\(grid.vCount)"); return
+        }
 
         let d = s.domain
         #expect(simd_distance(grid.at(u: 0, v: 0), s.point(atU: d.uMin, v: d.vMin)) < 1e-9)
-    }
-
-    /// An unbounded surface takes the bridge's infinite-bounds clamp before the divisor, so it
-    /// exercises a different pair of endpoints. It must still serve one row.
-    @Test("A surface with infinite bounds also serves a one-sample direction")
-    func infiniteBoundsSurfaceServesOneRow() {
-        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else { return }
-        let grid = plane.drawMesh(uCount: 1, vCount: 5)
-        #expect(!grid.isEmpty)
-        #expect(grid.uCount == 1)
-        #expect(grid.vCount == 5)
-        for v in 0..<grid.vCount {
-            #expect(Self.isFinite(grid.at(u: 0, v: v)))
-        }
     }
 
     // MARK: - The bound moved to 1, it did not disappear
@@ -136,7 +187,9 @@ struct Issue620DrawMeshCountContractTests {
     /// allocation, and rejection is still the documented empty grid.
     @Test("Counts below 1 and products past the ceiling are still rejected")
     func belowOneAndPastTheCeilingStillRejected() {
-        guard let s = Self.sphere() else { return }
+        guard let s = Surface.sphere(center: .zero, radius: 10) else {
+            Issue.record("sphere fixture nil"); return
+        }
 
         #expect(s.drawMesh(uCount: 0, vCount: 20).isEmpty)
         #expect(s.drawMesh(uCount: 20, vCount: 0).isEmpty)
@@ -153,14 +206,24 @@ struct Issue620DrawMeshCountContractTests {
 
     /// `OCCTSurfaceCreateBezier` carries a visually identical `uCount < 2 || vCount < 2`, but that
     /// one is the kernel's rule, not a divisor: a Bezier's degree is poles - 1 and must be >= 1, so
-    /// `Geom_BezierSurface` raises on a single-pole direction. Measured against the kernel, and
-    /// pinned here so the two look-alike guards are not "made consistent" in some later sweep.
+    /// `Geom_BezierSurface` raises on a single-pole direction (measured against the pinned kernel;
+    /// the precondition is not elided in this build).
+    ///
+    /// **Scope, stated exactly:** this pins the *public* contract, not the bridge guard. Relaxing
+    /// the bridge's `< 2` on its own leaves this test passing, because `Surface.bezier` guards
+    /// `>= 2` in Swift and never reaches the bridge — and even if it did, OCCT would throw and
+    /// `catch (...)` would return `nullptr`, so the observable answer is `nil` either way. What
+    /// holds the bridge guard in place is the comment at that site plus the kernel's own
+    /// precondition; no black-box test can separate the two layers here. Said plainly because the
+    /// earlier version of this comment claimed protection this test does not provide.
     @Test("Bezier keeps its minimum of two poles per direction, which is OCCT's own")
     func bezierKeepsItsTwoPoleMinimum() {
         // One pole in U: rejected.
         #expect(Surface.bezier(poles: [[SIMD3(0, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 2, 0)]]) == nil)
         // One pole in V: rejected.
         #expect(Surface.bezier(poles: [[SIMD3(0, 0, 0)], [SIMD3(1, 0, 0)]]) == nil)
+        // One pole in both: rejected.
+        #expect(Surface.bezier(poles: [[SIMD3(0, 0, 0)]]) == nil)
         // The smallest legal patch: accepted.
         #expect(Surface.bezier(poles: [
             [SIMD3(0, 0, 0), SIMD3(0, 1, 0)],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,36 @@ Two holes in the script's own `--self-test`, both of which had to be closed for 
 Both were verified by injecting the regression they describe and confirming 17/18. The suite is
 18/18 and the gate exits 0.
 
+#### A single iso-row stops being documented, accepted, and then silently refused (#620)
+
+Three layers disagreed about the minimum count `Surface.drawMesh(uCount:vCount:)` accepts. The doc
+comment said "at least 1", the Swift guard (`Sampling.gridTotal`, default `atLeast: 1`) accepted 1,
+and the bridge returned 0 for anything under 2. The wrapper's `guard n == total` turned that 0 into
+`SurfaceGrid.empty`, so `drawMesh(uCount: 1, vCount: 20)` — in range by its own documentation —
+came back empty, and the caller had no way to tell "you asked for something unsupported" from "this
+surface has no mesh".
+
+**The bridge was the layer that was wrong**, which is not what the issue expected ("a mesh of one
+row has no quads"). Measured against the kernel first: despite the name `OCCTSurfaceDrawMesh` does
+not mesh anything. There is no `BRepMesh`, no triangulation and no quad, just a uniform walk of the
+parametric bounds calling `Geom_Surface::D0`, and a single `(u, v)` is a valid OCCT evaluation — a
+1 × 20 iso-row off a sphere is 20 finite points. The 2 was never OCCT's rule, it was this
+function's own divisor: `i / (uCount - 1)` divides by zero at count 1. And the NaN that produces is
+worse than a throw would have been, because `D0` does not throw on NaN, it returns NaN coordinates
+silently. `OCCTSurfaceDrawGrid`, forty lines above in the same file, samples the same bounds the
+same way and had always spelled that divisor defensively; that spelling is now shared. The bound
+moved to 1 rather than disappearing: below 1, and products past `Sampling.maximumSampleCount`, are
+still rejected at the Swift boundary before any allocation, which is #558's contract unchanged.
+
+**The sibling site keeps its 2.** `OCCTSurfaceCreateBezier` carries a visually identical
+`uCount < 2 || vCount < 2`, and that one is the kernel's: a Bezier's degree is its pole count minus
+1 and must be at least 1, so `Geom_BezierSurface` raises `Standard_ConstructionError` on a
+single-pole direction (measured; 2 × 2 builds a bilinear patch). `Surface.bezier(poles:weights:)`
+already guarded the same bound, so that site had no three-layer mismatch at all — only a doc that
+was silent about the bound rather than wrong about it. Both look-alike guards now say in a comment
+which kind they are, and a test pins the Bezier minimum so the two are not "made consistent" by a
+later sweep.
+
 #### The one grid layout finally covers the third type holding a grid (#617)
 
 #486 declared **U-major** (`occtSurfaceGridIndex`, `iu * vCount + iv`) THE surface-grid buffer

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,10 +116,38 @@ products past `Sampling.maximumSampleCount`, are still rejected at the Swift bou
 allocation, which is #558's contract unchanged.
 
 That divisor is now `occtUniformParameter` in `OCCTBridge_Internal.h`, next to
-`occtSurfaceGridIndex` and for the same reason: it had been open-coded **nine** times in
-`OCCTBridge_Surface.mm` in three different spellings, and #620 is what a single copy written
-without the guard costs. Sharing the expression is what stops a tenth loop re-deriving the
+`occtSurfaceGridIndex` and for the same reason: it had been open-coded **ten** times in
+`OCCTBridge_Surface.mm` in four different spellings, and #620 is what a single copy written
+without the guard costs. Sharing the expression is what stops an eleventh loop re-deriving the
 unguarded form.
+
+Nine of the ten are bit-identical substitutions. **The tenth reassociates**: the Gordon network
+builder's `f + (l - f) * ((double)j / (guideCount - 1))` becomes `((l - f) * j) / (guideCount - 1)`,
+and across ten realistic `[FirstParameter, LastParameter]` ranges 25-33% of cases differ by 1-2 ulp
+(≤ 4e-15 over the whole span, exactly 0 on this repo's own Gordon fixture). One structural
+consequence beyond the magnitude: the old form always landed the last sample exactly on
+`f + (l - f)`, while the new one can land 1 ulp **past** `LastParameter` (4 cases of n = 2…60 on a
+0..2π profile). Harmless here, because the builder `SetNotPeriodic()`s the curves first so
+`Geom_BSplineCurve::D0` does not throw just outside the range, but it is a boundary the old
+expression structurally could not cross, so it is recorded at the site rather than left for
+someone to rediscover.
+
+Three open-coded lines remain, across two sites, both deliberately.
+`OCCTGeomFillAppSurf`'s `(double)i / (count - 1)` is
+**unguarded** — the exact #620 shape — but chasing it turned up a separate, larger defect
+(`Surface.appSurf(curves:)` segfaults on a single curve regardless of the parameter value, so it
+is a missing arity guard rather than a divisor bug), which is filed on its own; converting the
+divisor would not fix it and would muddy that fix. `OCCTGeomFillCoonsPatchEval`'s two lines are a
+different contract, not the same expression: their single-sample branch is `0.5`, the patch
+midpoint, where every other site's is the low end. The helper's own doc says so, so the next
+sweep does not fold them in on shape alone.
+
+**Recorded, not fixed: the Gordon family has no behavioural test coverage at all.** All five
+Gordon tests assert only nil-ness and status ordinals — not one checks a point, pole, degree or
+bound — and `networkSurfaceBuildsOrReportsStatus`, the only test reaching the changed line, accepts
+any status but `.notStarted`; on the repo's own `makeNetwork()` fixture the builder returns
+`KnotAlignmentFailed`, so it never builds a surface. Nothing in the repo would have caught the 1-ulp
+change above, or one many orders of magnitude larger. Filed separately.
 
 **A second wrong claim, caught reviewing the first fix.** The new contract sentence said
 `uCount: 1` is "the single iso-row at `uMin`". That holds only for a bounded surface: the bridge

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,14 +103,32 @@ surface has no mesh".
 **The bridge was the layer that was wrong**, which is not what the issue expected ("a mesh of one
 row has no quads"). Measured against the kernel first: despite the name `OCCTSurfaceDrawMesh` does
 not mesh anything. There is no `BRepMesh`, no triangulation and no quad, just a uniform walk of the
-parametric bounds calling `Geom_Surface::D0`, and a single `(u, v)` is a valid OCCT evaluation — a
+sampled range calling `Geom_Surface::D0`, and a single `(u, v)` is a valid OCCT evaluation — a
 1 × 20 iso-row off a sphere is 20 finite points. The 2 was never OCCT's rule, it was this
 function's own divisor: `i / (uCount - 1)` divides by zero at count 1. And the NaN that produces is
 worse than a throw would have been, because `D0` does not throw on NaN, it returns NaN coordinates
-silently. `OCCTSurfaceDrawGrid`, forty lines above in the same file, samples the same bounds the
-same way and had always spelled that divisor defensively; that spelling is now shared. The bound
-moved to 1 rather than disappearing: below 1, and products past `Sampling.maximumSampleCount`, are
-still rejected at the Swift boundary before any allocation, which is #558's contract unchanged.
+silently. Every other member of the same U-major grid family already accepted 1 —
+`OCCTSurfaceDrawGrid` guards no count at all, `EvaluateGrid` and `EvaluateGridD1` guard `<= 0` — so
+`drawMesh` was the family's sole outlier. `OCCTSurfaceDrawGrid`, forty lines above in the same
+file, samples the same bounds and had spelled that divisor defensively since `b1cd75d`, the commit
+that introduced both functions. The bound moved to 1 rather than disappearing: below 1, and
+products past `Sampling.maximumSampleCount`, are still rejected at the Swift boundary before any
+allocation, which is #558's contract unchanged.
+
+That divisor is now `occtUniformParameter` in `OCCTBridge_Internal.h`, next to
+`occtSurfaceGridIndex` and for the same reason: it had been open-coded **nine** times in
+`OCCTBridge_Surface.mm` in three different spellings, and #620 is what a single copy written
+without the guard costs. Sharing the expression is what stops a tenth loop re-deriving the
+unguarded form.
+
+**A second wrong claim, caught reviewing the first fix.** The new contract sentence said
+`uCount: 1` is "the single iso-row at `uMin`". That holds only for a bounded surface: the bridge
+clamps infinite bounds to ±100 **before** deriving parameters, so on a plane `domain.uMin` is about
+-2e100 while the single row sits at -100. Same defect class as #620 itself — a claim true of the
+fixture in front of you and false in general — so the docs now name the **sampled range** (the
+domain, with infinite bounds clamped) rather than the domain, and a test pins the clamped value on
+an unbounded surface. The first version of that test checked only finiteness, which passes under
+either reading and so could not contradict the doc.
 
 **The sibling site keeps its 2.** `OCCTSurfaceCreateBezier` carries a visually identical
 `uCount < 2 || vCount < 2`, and that one is the kernel's: a Bezier's degree is its pole count minus
@@ -118,8 +136,12 @@ still rejected at the Swift boundary before any allocation, which is #558's cont
 single-pole direction (measured; 2 × 2 builds a bilinear patch). `Surface.bezier(poles:weights:)`
 already guarded the same bound, so that site had no three-layer mismatch at all — only a doc that
 was silent about the bound rather than wrong about it. Both look-alike guards now say in a comment
-which kind they are, and a test pins the Bezier minimum so the two are not "made consistent" by a
-later sweep.
+which kind they are, so the two are not "made consistent" by a later sweep. The accompanying test
+pins the *public* contract only, and says so: relaxing the bridge guard alone leaves it passing,
+because `Surface.bezier` rejects in Swift and never reaches the bridge — and if it did, OCCT would
+throw and `catch (...)` would return `nullptr`, so `nil` comes back either way. No black-box test
+can separate those two layers, and claiming otherwise would be the same kind of overstatement this
+entry is about.
 
 #### The one grid layout finally covers the third type holding a grid (#617)
 

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -988,7 +988,7 @@ public struct SurfaceGridD1: Sendable {
 
 ### `drawMesh(uCount:vCount:)`
 
-Samples a uniform mesh grid of points for Metal visualisation.
+Samples a uniform grid of points over the surface's parametric bounds.
 
 ```swift
 public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid
@@ -996,11 +996,16 @@ public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid
 
 - **Parameters:** `uCount` — number of U sample points, at least 1; `vCount` — number of V sample points, at least 1.
 - **Returns:** A `SurfaceGrid` indexed `.at(u:v:)`, or an empty grid if sampling fails or the grid cannot be served. The bound is on the **product**: `uCount * vCount` must not exceed `Sampling.maximumSampleCount` (10,000,000). Each factor is also checked on its own, which is not redundant — two negative counts multiply to a plausible positive total, so `drawMesh(uCount: -1, vCount: -1)` used to look well-behaved while `drawMesh(uCount: -1, vCount: 3)` aborted the process (#558).
+- **One sample in a direction is a request, not a degenerate case.** Despite the name nothing here triangulates, so `uCount: 1` is the single iso-row at `uMin` and a 1×1 grid is one point. The bridge used to demand 2 per direction — its own interpolation divisor, not an OCCT rule — so a request this page called in-range came back as an empty grid indistinguishable from a failed sample (#620). Counts below 1 are still rejected, and rejection is still an empty grid.
 - **OCCT:** `Geom_Surface::D0` sampled on a uniform UV grid.
 - **Example:**
   ```swift
   let mesh = surface.drawMesh(uCount: 30, vCount: 30)
   let p = mesh.at(u: 5, v: 3)
+
+  // A single V iso-row: 20 points along v at the surface's minimum u.
+  let isoRow = surface.drawMesh(uCount: 1, vCount: 20)
+  let along = (0..<isoRow.vCount).map { isoRow.at(u: 0, v: $0) }
   ```
 
 ---

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -996,16 +996,21 @@ public func drawMesh(uCount: Int = 20, vCount: Int = 20) -> SurfaceGrid
 
 - **Parameters:** `uCount` — number of U sample points, at least 1; `vCount` — number of V sample points, at least 1.
 - **Returns:** A `SurfaceGrid` indexed `.at(u:v:)`, or an empty grid if sampling fails or the grid cannot be served. The bound is on the **product**: `uCount * vCount` must not exceed `Sampling.maximumSampleCount` (10,000,000). Each factor is also checked on its own, which is not redundant — two negative counts multiply to a plausible positive total, so `drawMesh(uCount: -1, vCount: -1)` used to look well-behaved while `drawMesh(uCount: -1, vCount: 3)` aborted the process (#558).
-- **One sample in a direction is a request, not a degenerate case.** Despite the name nothing here triangulates, so `uCount: 1` is the single iso-row at `uMin` and a 1×1 grid is one point. The bridge used to demand 2 per direction — its own interpolation divisor, not an OCCT rule — so a request this page called in-range came back as an empty grid indistinguishable from a failed sample (#620). Counts below 1 are still rejected, and rejection is still an empty grid.
+- **Sampled range:** the surface's parametric domain with infinite bounds clamped to ±100. For a bounded surface that is `domain`; for an unbounded one it is not, and the difference is extreme rather than marginal — a plane's `domain.uMin` is about -2e100 while its first sample sits at -100.
+- **One sample in a direction is a request, not a degenerate case.** Despite the name nothing here triangulates, so `uCount: 1` is the single iso-row at the low end of the sampled U range and a 1×1 grid is one point. The bridge used to demand 2 per direction — its own interpolation divisor, not an OCCT rule — so a request this page called in-range came back as an empty grid indistinguishable from a failed sample (#620). Counts below 1 are still rejected, and rejection is still an empty grid.
 - **OCCT:** `Geom_Surface::D0` sampled on a uniform UV grid.
 - **Example:**
   ```swift
   let mesh = surface.drawMesh(uCount: 30, vCount: 30)
   let p = mesh.at(u: 5, v: 3)
 
-  // A single V iso-row: 20 points along v at the surface's minimum u.
+  // A single V iso-row: 20 points along v, at the low end of the sampled U range.
   let isoRow = surface.drawMesh(uCount: 1, vCount: 20)
   let along = (0..<isoRow.vCount).map { isoRow.at(u: 0, v: $0) }
+
+  // Bounded: that low end is domain.uMin. Unbounded: it is the clamp instead.
+  let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+  plane.drawMesh(uCount: 1, vCount: 4).at(u: 0, v: 0).x   // -100, not plane.domain.uMin
   ```
 
 ---


### PR DESCRIPTION
Closes #620

## What was wrong

Three layers disagreed about `Surface.drawMesh(uCount:vCount:)`'s minimum count. The doc comment
(added in this branch) said "at least 1", the Swift guard `Sampling.gridTotal(u, v)` defaulted to
`atLeast: 1` and accepted 1, and the bridge returned 0 for anything under 2. The wrapper's
`guard n == total` turned that 0 into `SurfaceGrid.empty`, so `drawMesh(uCount: 1, vCount: 20)` —
in range by its own documentation — came back empty, and the caller had no way to tell "you asked
for something unsupported" from "this surface has no mesh".

## What I measured

Ground-truth C++ against the pinned kernel before choosing a side, because the issue expected the
doc to be the wrong layer ("a mesh of one row has no quads").

**OCCT's real minimum for this path is 1.** Despite the name, `OCCTSurfaceDrawMesh` does not mesh
anything: no `BRepMesh`, no triangulation, no quad, just a uniform walk of the sampled range
calling `Geom_Surface::D0`. A single `(u, v)` is a valid OCCT evaluation, and a 1 × 20 iso-row off
a radius-10 sphere is 20 finite points.

The 2 was never the kernel's rule. It was this function's own divisor: `i / (uCount - 1)` divides
by zero at count 1, giving a NaN parameter. The measurement that made the fix non-obvious, and the
reason the guard could not simply be deleted: **`D0` does not throw on NaN — it returns NaN
coordinates silently.**

Two corroborations found in review, both of which strengthen the verdict:

- **`drawMesh` was the sole outlier in its own family.** Every other member of the U-major grid
  family already accepts 1: `OCCTSurfaceDrawGrid` has no count guard at all, and `EvaluateGrid` /
  `EvaluateGridD1` guard `<= 0`.
- **The divergence dates to the commit that introduced both functions.** At `b1cd75d`, `DrawGrid`
  already had the defensive ternary and `DrawMesh` had the bare one, so "always" is literal.

## Which layer I changed, and why

**The bridge.** The doc and the Swift guard were right; the bridge was the outlier, and the fix it
needed already existed in its own file.

The bound moved to 1 rather than disappearing. Counts below 1 and products past
`Sampling.maximumSampleCount` are still rejected at the Swift boundary before any allocation, which
is #558's contract unchanged. The call site now passes `atLeast: 1` explicitly, since leaving it
implicit is how the ends drifted apart.

**The divisor is now extracted, not copy-pasted.** `occtUniformParameter` lives in
`OCCTBridge_Internal.h` beside `occtSurfaceGridIndex`, for the same reason. It replaces **ten**
open-coded copies in `OCCTBridge_Surface.mm` written in four different spellings: six in
`DrawGrid`/`DrawMesh`, three in the Gordon network builder, and `OCCTAdaptor3dIsoCurveEval`'s
`(evalCount > 1) ? first + (last - first) * i / (evalCount - 1) : first` — the closest sibling of
all of them, converted in review.

**Nine of the ten are bit-identical. The tenth reassociates, and that is worth stating plainly.**
The Gordon builder's `f + (l - f) * ((double)j / (guideCount - 1))` becomes
`((l - f) * j) / (guideCount - 1)`; across ten realistic `[FirstParameter, LastParameter]` ranges
**25-33% of cases differ by 1-2 ulp** (≤ 4e-15 over the whole span, exactly 0 on this repo's own
Gordon fixture). One structural consequence beyond the magnitude: the old form always landed the
last sample exactly on `f + (l - f)`, while the new one can land **1 ulp past `LastParameter`**
(4 cases of n = 2…60 on a 0..2π profile). Harmless here — the builder `SetNotPeriodic()`s first, so
`Geom_BSplineCurve::D0` does not throw just outside the range — but it is a boundary the old
expression structurally could not cross, so it is recorded at the site rather than left to be
rediscovered. My earlier "values verified identical at count 1 for all nine" was literally true and
read as more than it said.

**Coverage gap, recorded not fixed (filed separately).** The Gordon family has **no behavioural
test coverage at all**: all five Gordon tests assert only nil-ness and status ordinals — not one
checks a point, pole, degree or bound — and `networkSurfaceBuildsOrReportsStatus`, the only test
reaching the changed line, accepts any status but `.notStarted`; on the repo's own `makeNetwork()`
fixture the builder returns `KnotAlignmentFailed`, so it never builds a surface. Nothing in the repo
would have caught the 1-ulp change above, or one many orders of magnitude larger.

**Three open-coded lines remain, across two sites, both deliberately.**
`OCCTGeomFillAppSurf`'s `(double)i / (count - 1)` is **unguarded** — the exact #620 shape — but is
left alone: chasing it turned up a separate, larger defect (`Surface.appSurf(curves:)` segfaults on
a single curve *regardless of the parameter value*, so a missing arity guard rather than a divisor
bug), filed on its own, and converting the divisor would neither fix it nor belong in that fix.
`OCCTGeomFillCoonsPatchEval`'s two lines are a different contract wearing the same shape: their
single-sample branch is `0.5`, the patch midpoint, where every other site's is the low end. The
helper's doc comment now says to check the else-branch before folding a site in.

## Sibling site verdict: no mismatch, keeps its 2

`OCCTSurfaceCreateBezier` carries a visually identical `uCount < 2 || vCount < 2`. **That one is
genuine and stays.** `Geom_BezierSurface`'s pinned header states it raises when a direction has
fewer than 2 poles, since a Bezier's degree is poles − 1 and must be ≥ 1. Measured: 1×3, 3×1 and
1×1 each throw `Standard_ConstructionError`; 2×2 builds `UDegree=1 VDegree=1`. The precondition is
not elided in this pinned kernel.

All three layers there already agreed — `Surface.bezier` guards `>= 2` on both directions. The only
gap was a doc silent about the bound rather than wrong about it, now filled in. Both look-alike
guards carry a comment saying which kind they are.

The accompanying test pins the **public** contract only, and now says so explicitly: relaxing the
bridge's `< 2` alone leaves it passing, because `Surface.bezier` rejects in Swift and never reaches
the bridge — and if it did, OCCT would throw and `catch (...)` would return `nullptr`, so `nil`
comes back either way. No black-box test can separate those two layers.

## Proof the tests catch it

8 tests in `Tests/OCCTSurfaceTests/Issue620DrawMeshCountContractTests.swift`. They pin *which*
iso-row a one-sample direction means, cross-checked against `point(atU:v:)` (an independent
evaluation path, not another grid call), plus the invariant that a one-row grid equals row 0 of a
many-row grid, plus the clamp behaviour on an unbounded surface.

**Corrected transcript.** The first version of this claim was not reproducible: `oneByOneIsASingle
Point` subscripted an empty grid through `SurfaceGrid.at`, which is a `precondition`, so under the
injected regression it aborted the whole target with signal 5 and printed no run summary at all.
That is fixed — every grid read is behind a `guard`. Re-measured, restoring **both** pre-fix
elements (the `< 2` guard and the bare `(uCount - 1)` divisor) and rebuilding from source:

```
✘ Test run with 8 tests in 1 suite failed after 0.017 seconds with 9 issues.
```

- **6 of 8 fail**, cleanly and diagnosably, each reporting
  `SurfaceGrid(uCount: 0, vCount: 0, points: [])` — the reported defect exactly. No signal, no
  aborted target.
- **2 pass**, correctly indifferent: the below-1/past-ceiling rejection test (unchanged behaviour
  either way) and the Bezier sibling test (a different function, untouched).
- With the fix: **8/8 pass**, `Test run with 8 tests in 1 suite passed`.

## Testing

- Full `swift test`: **5229 tests in 1389 suites, all passed**, run after the extraction so it
  covers `DrawGrid` and the Gordon builder as well as `drawMesh`.
- Built with `OCCTSWIFT_BRIDGE_PREBUILT=` throughout, so the `.mm` edits are genuinely compiled
  rather than masked by the prebuilt bridge — confirmed by the injected bug changing test outcomes.
- `Scripts/count-operations.py` exits **1** (4302 derived vs 4301 documented). Pre-existing and
  identical on base — PR #631 carries it — but stating it rather than letting it read as green.
- Ground-truth C++ probe compiled and run against `OCCT.xcframework`.

Rebased onto current `refactor/381-pass1b`; the CHANGELOG conflict was add/add and all entries are
kept.

The macOS CI job is red for the pre-existing reason in #585 (CI resolves the kernel from
`Package.swift`'s pinned v1.15.18, predating carried patches 0017-0021). Not related to this change.

## Docs

- `docs/CHANGELOG.md` — Unreleased entry (no version number invented).
- `Sources/OCCTSwift/Surface.swift` — corrected `///` for `drawMesh` with fenced `swift` snippets
  covering both the bounded and unbounded readings, plus the previously-silent bound on
  `Surface.bezier`.
- `docs/reference/Surface.md` — the `drawMesh` entry, which had inherited the same wrong promise.
- `Sources/OCCTBridge/include/OCCTBridge.h` — the declaration now states the real minimum, and the clamp, which was the one doc site of four still saying "the parametric bounds".

## Corrected in review

- **The test trapped the process under the exact regression it exists to detect** (blocking).
  Fixed, and the evidence claim above is re-measured rather than restated.
- **"the single iso-row at `uMin`" was wrong for every unbounded surface** (blocking). The bridge
  clamps infinite bounds to ±100 *before* the divisor, so a plane's `domain.uMin` is about -2e100
  while its single row sits at -100. Same defect class as #620 itself: a claim true of the fixture
  in front of you and false in general. The docs now name the **sampled range**, and
  `singleRowOnAnUnboundedSurfaceSitsAtTheClamp` pins the clamped value — the original test checked
  only finiteness there, which passes under either reading and so could not contradict the doc.
- Seven fixture-nil guards `return`ed silently, so all 8 tests would have passed vacuously if
  `Surface.sphere` regressed. They now `Issue.record`.
- The Bezier test's comment promised protection it does not provide; scope now stated exactly.
- "now shared by both" was copy-paste, not extraction; the divisor is now genuinely extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
