### PR TITLE
fix(#618): the null-handle gate matched one spelling, and this bridge reaches a handle five ways

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,17 @@ turns into the same fallback a guard would return. Measure against
 noise, and the script's `ALLOWED` table records each such site with its measured reason.
 The handle does not have to be spelled `x->curve` to reach OCCT: this bridge also reaches it
 through a `reinterpret_cast`/`static_cast`/C-style cast, a pointer alias, a handle alias, and a
-shared bridge helper. The checker understands all of them (#618); a hand-audit that greps for
-`->curve` does not.
+shared bridge helper. The checker handles those four, which are the four this tree currently uses
+(#618); a hand-audit that greps for `->curve` handles none of them.
+
+**Four is a fact about this tree, not a closed set.** The checker is still blind to `(*cast).field`,
+a reference-to-wrapper alias, an `IsNull()` whose result is discarded or does not dominate the use,
+a negated guard, `extern "C"` on the definition line (which hides the whole function from its
+parser), and a helper that guards only some paths; and it would wrongly report
+`Handle(Geom_Curve) w(wrapper->curve);` constructor-init syntax. None of those appears today. If you
+write one, teach the checker the shape in the same PR, and note that an `ALLOWED` entry is keyed
+`(file, function)` with no argument index and no re-validation, so it exempts every argument of
+that function and every later change to it.
 
 ## Naming Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,22 @@ Opaque handle types (`OCCTShapeRef`, `OCCTWireRef`, `OCCTFaceRef`, `OCCTEdgeRef`
 
 If the new function takes an `OCCTCurve3DRef` / `OCCTCurve2DRef` / `OCCTSurfaceRef`, guard the
 handle as well as the pointer: `if (!x || x->curve.IsNull()) return <the fallback the catch below
-uses>;`. Checking only the pointer says nothing about the handle, and 24 of the 35 OCCT entry
+uses>;`. Checking only the pointer says nothing about the handle, and 36 of the 57 OCCT entry
 points this bridge passes such a handle into dereference it unconditionally, which is an
-uncatchable signal, not something `catch (...)` can absorb (#478, #556). Run
-`python3 Scripts/check-null-handle-guards.py` to verify; it exits 1 on any unguarded site.
+uncatchable signal, not something `catch (...)` can absorb (#478, #556, #618). Run
+`python3 Scripts/check-null-handle-guards.py` to verify; it exits 1 on any unguarded site, and
+`--self-test` proves both failure modes (an unguarded site reported, a guarded one not).
+
+**The guard is required only where the OCCT call actually needs it.** Not every entry point
+dereferences: `GeomLib_Tool::Parameter` returns false, `GeomAdaptor_Surface` and
+`Approx_SameParameter` raise a catchable `Standard_Failure` the surrounding `catch (...)` already
+turns into the same fallback a guard would return. Measure against
+`Scripts/repro/556-null-handle-guard-sweep` before adding one; a guard on a call that copes is
+noise, and the script's `ALLOWED` table records each such site with its measured reason.
+The handle does not have to be spelled `x->curve` to reach OCCT: this bridge also reaches it
+through a `reinterpret_cast`/`static_cast`/C-style cast, a pointer alias, a handle alias, and a
+shared bridge helper. The checker understands all of them (#618); a hand-audit that greps for
+`->curve` does not.
 
 ## Naming Conventions
 

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -14,7 +14,8 @@ test both:
 it to an OCCT API which dereferences it internally. This script is what keeps that at zero.
 
 #618: the walk that produced both lists matched `param->field` and nothing else, so it was blind
-to every site that reaches the handle through an indirection, and this bridge uses four:
+to every site that reaches the handle through an indirection. Four such forms occur in this tree,
+and the detector handles those four:
 
     1. a cast:            reinterpret_cast<OCCTSurface*>(surfaceRef)->surface
                           static_cast<OCCTCurve3D*>(curveRef)->curve
@@ -30,6 +31,25 @@ one call frame away, so a detector that learns 1-3 without learning 4 reports co
 resolved here: casts are normalised away, aliases are followed, and a use that hands the handle to
 a bridge helper whose own body `IsNull()`-checks that parameter first counts as guarded.
 
+WHAT THIS STILL CANNOT SEE. "Four" is a fact about this tree, not about C++, and the list was
+arrived at by enumerating what the bridge actually writes. Add any of these and the gate goes quiet
+on a real defect, so add the shape here too rather than assuming it is covered:
+
+  * `(*cast).field` instead of `cast->field`. Zero occurrences today.
+  * an alias bound by reference to the wrapper, `OCCTSurface& w = *ref;   ... w.surface`.
+  * a guard whose result is discarded or does not dominate the use: `x->curve.IsNull();` as a
+    statement, or an `if` that tests it and then falls through to the use anyway. The walk treats
+    the first `IsNull()` before the use as a guard and does not check for a control transfer.
+    Verified once, by hand, that every clearing guard in this tree does return or throw.
+  * a negated guard, `if (!x->curve.IsNull()) { } else { use(x->curve); }`.
+  * `extern "C"` on the definition line: the `"` is outside FUNC's return-type character class, so
+    the whole function is invisible to the parser, guarded or not. Zero occurrences today.
+  * a helper that guards on some paths only. `guarding_helpers()` asks whether the FIRST mention of
+    the parameter is an `IsNull()` test, not whether every path through the body is protected.
+
+And one false-positive direction: `Handle(Geom_Curve) w(wrapper->curve);` constructor-init syntax
+is not recognised as an alias binding, so it would be reported as an unguarded use. Also absent.
+
 Two exclusions, both load-bearing:
 
   * A `DownCast(x->curve)` is NOT a use: down-casting a null handle returns a null handle, and
@@ -39,6 +59,14 @@ Two exclusions, both load-bearing:
     entry point was *measured* to tolerate a null handle - #556's own standard, since a call that
     returns normally or raises a catchable `Standard_Failure` is already handled by the function's
     `catch (...)`. Every reason cites the measurement.
+
+    Know what an ALLOWED entry actually buys. It is keyed `(file, function)`, with no argument
+    index and no re-validation: it exempts EVERY wrapper argument of that function, and it keeps
+    exempting them after the body changes. A function cleared today because it called
+    `GeomLib_Tool::Parameter` stays cleared if someone swaps that for a call that dereferences.
+    The mechanism's only real safeguard is that it lives in a tracked file, so an entry has to
+    survive review. Re-measure before trusting an entry you did not write, and delete it rather
+    than widen it when a function grows a new argument.
 
 Usage (from the repo root):
 
@@ -92,15 +120,12 @@ ALLOWED = {
         'measured #618: GeomLib_Tool::Parameters(Geom_Surface) returns false on a null handle',
     ('OCCTBridge_Surface.mm', 'OCCTGeomConvertIsCanonical'):
         'measured #618: GeomConvert_SurfToAnaSurf::IsCanonical returns on a null handle',
-    ('OCCTBridge_IO.mm', 'OCCTGeomToolsCurveSetWrite'):
-        'measured #618: GeomTools_CurveSet::Add opens "return (C.IsNull()) ? 0 : myMap.Add(C)", '
-        'so a null section is dropped rather than written. Its 2D and surface twins have no such '
-        'check anywhere and DO crash - they are guarded, this one needs nothing',
-
     # --- measured: the OCCT call raises a catchable Standard_Failure, which each function's own
     #     catch (...) already turns into the same fallback a guard would return ---
     ('OCCTBridge_Curve3D.mm', 'OCCTApproxSameParameter'):
-        'measured #618: Approx_SameParameter raises a catchable Standard_Failure',
+        'measured #618: Approx_SameParameter raises a catchable Standard_Failure. Probed per '
+        'argument, not just all-three-null, since this function takes three handles and a guard '
+        'would protect each one separately: all four combinations are catchable',
     ('OCCTBridge_Curve3D.mm', 'OCCTExtremaExtCC'):
         'measured #618: GeomAdaptor_Curve raises a catchable Standard_Failure',
     ('OCCTBridge_Curve3D.mm', 'OCCTExtremaExtCCPoint'):
@@ -114,7 +139,9 @@ ALLOWED = {
     ('OCCTBridge_Geom2d.mm', 'OCCTExtremaLocateExtCC2d'):
         'measured #556: Geom2dAdaptor_Curve raises a catchable Standard_Failure',
     ('OCCTBridge_Geom2d.mm', 'OCCTGeom2dConvertApproxArcsSegments'):
-        'measured #618: Geom2dConvert_ApproxArcsSegments raises a catchable Standard_Failure',
+        'measured #618: the throw is the Geom2dAdaptor_Curve built on the preceding line '
+        '(OCCTBridge_Geom2d.mm:2935), not Geom2dConvert_ApproxArcsSegments itself; either way a '
+        'catchable Standard_Failure',
     ('OCCTBridge_Surface.mm', 'OCCTGeomLibIsPlanarSurface'):
         'measured #618: GeomLib_IsPlanarSurface raises a catchable Standard_Failure',
     ('OCCTBridge_Surface.mm', 'OCCTGeomLibPlanarSurfacePlane'):
@@ -235,16 +262,21 @@ def split_params(params):
 
 
 def wrapper_params(params):
-    """(name, handle field) for each wrapper-typed parameter."""
+    """(name, handle field, is_array) for each wrapper-typed parameter.
+
+    is_array marks `OCCTCurve3DRef*` / `OCCTCurve3DRef[]`, where the parameter is a pointer to
+    wrappers rather than a wrapper. It only affects the suggested fix that gets printed: writing
+    `curveRefs->curve` on one of those is a type error, so the hint has to name an element."""
     out = []
     for p in split_params(params):
         p = p.strip()
         for wrapper, field in WRAPPERS.items():
             if not re.search(r'\b' + wrapper + r'\b', p):
                 continue
-            m = re.search(r'(\w+)\s*(?:\[\s*\])?\s*$', p)
+            m = re.search(r'(\w+)\s*(\[\s*\])?\s*$', p)
             if m and m.group(1) not in WRAPPERS:
-                out.append((m.group(1), field))
+                tail = p[p.index(wrapper) + len(wrapper):]
+                out.append((m.group(1), field, '*' in tail or bool(m.group(2))))
             break
     return out
 
@@ -252,8 +284,14 @@ def wrapper_params(params):
 def guarding_helpers(sources):
     """(function, argument index) for every bridge function that IsNull-checks that Handle
     parameter before touching it. Passing a handle to one of these IS a guard: the check just
-    lives one call frame away. `occtCurveToAnalytical` and `occtSurfaceToAnalytical` are the two
-    in this tree, and both open with `if (curve.IsNull()) return false;`."""
+    lives one call frame away.
+
+    Seven (function, argument) pairs across six functions qualify in this tree:
+    `occtCurveToAnalytical`, `occtSurfaceToAnalytical`, `bgSurfacesSameDomain` (both arguments),
+    `occtNearestPointOnCurveRange`, `occtNearestPointOnCurve2dRange` and `occtPlateApproxSurface`.
+    Only the first two are load-bearing: drop this rule and exactly `OCCTGeomConvertCurveToAnalytical`
+    and `occtSurfToAnaSurfResult` are wrongly reported, nothing else. The other four are recognised
+    because they guard unconditionally, not because any caller currently relies on it."""
     guards = set()
     for _, text in sources:
         text = strip_comments(text)
@@ -335,7 +373,7 @@ def unguarded_sites(sources, helpers):
         lines = raw.splitlines()
         for name, params, bs, be in functions(text):
             body = ctext[bs:be + 1]
-            for param, field in wrapper_params(params):
+            for param, field, is_array in wrapper_params(params):
                 if (os.path.basename(path), name) in ALLOWED:
                     continue
                 ptr, handle, spans = aliases(body, param, field)
@@ -363,7 +401,7 @@ def unguarded_sites(sources, helpers):
                     continue
                 line = text.count('\n', 0, bs + first) + 1
                 found.append((os.path.basename(path), line, name, param, field,
-                              lines[line - 1].strip() if line <= len(lines) else ''))
+                              lines[line - 1].strip() if line <= len(lines) else '', is_array))
     return found
 
 
@@ -512,10 +550,16 @@ def main():
         return 0
     if not quiet:
         print(f'{len(sites)} (function, argument) pair(s) reach OCCT with an unchecked handle:\n')
-        for f, line, func, param, field, src in sites:
+        for f, line, func, param, field, src, is_array in sites:
             print(f'  {f}:{line}  {func}({param})')
             print(f'      {src}')
-            print(f'      want: if (!{param} || {param}->{field}.IsNull()) return <fallback>;')
+            if is_array:
+                # `param` is a pointer to wrappers, so `param->field` would not compile. The
+                # guard belongs on the element, inside the loop that reads it.
+                print(f'      want, per element of {param}:  '
+                      f'if (!e || e->{field}.IsNull()) return <fallback>;')
+            else:
+                print(f'      want: if (!{param} || {param}->{field}.IsNull()) return <fallback>;')
     return 1
 
 

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -3,26 +3,48 @@
 
 `OCCTCurve3DRef`, `OCCTCurve2DRef` and `OCCTSurfaceRef` are pointers to a wrapper struct whose
 only field is an OCCT `Handle`. Checking the pointer says nothing about the handle, and a null
-handle reaching OCCT is usually an unconditional dereference: `Scripts/repro/556-null-handle-guard-sweep`
-measures 24 of the 35 distinct OCCT entry points this bridge passes such a handle into as an
+handle reaching OCCT is often an unconditional dereference: `Scripts/repro/556-null-handle-guard-sweep`
+measures 36 of the 57 distinct OCCT entry points this bridge passes such a handle into as an
 uncatchable OS signal, which the enclosing `catch (...)` cannot intercept. So the opener has to
 test both:
 
     if (!x || x->curve.IsNull()) return <the same fallback the catch below uses>;
 
 #478 fixed the 14 functions that dereferenced the handle themselves; #556 fixed the 60 that pass
-it to an OCCT API which dereferences it internally. This script is what keeps that at zero: it is
-the same walk that produced both lists, so a new function that checks only the pointer is reported
-the moment it is added.
+it to an OCCT API which dereferences it internally. This script is what keeps that at zero.
 
-A `DownCast(x->curve)` is NOT a use: down-casting a null handle returns a null handle, and every
-such site in this bridge checks the cast result. Without that exclusion the walk reports several
-hundred false positives.
+#618: the walk that produced both lists matched `param->field` and nothing else, so it was blind
+to every site that reaches the handle through an indirection, and this bridge uses four:
+
+    1. a cast:            reinterpret_cast<OCCTSurface*>(surfaceRef)->surface
+                          static_cast<OCCTCurve3D*>(curveRef)->curve
+                          (OCCTSurface*)surface
+    2. a pointer alias:   auto* s = (OCCTSurface*)surface;   ... s->surface
+    3. a handle alias:    auto& surf = reinterpret_cast<OCCTSurface*>(ref)->surface;   ... f(surf)
+                          Handle(Geom_Surface) work = wrapper->surface;               ... f(work)
+    4. a bridge helper:   occtSurfaceToAnalytical(reinterpret_cast<OCCTSurface*>(ref)->surface, ...)
+
+Forms 1-3 hid unguarded sites from the gate. Form 4 is the opposite: the handle is checked, just
+one call frame away, so a detector that learns 1-3 without learning 4 reports correct code (the
+#624/#630 failure, where a sibling gate was confidently wrong about seven entries). All four are
+resolved here: casts are normalised away, aliases are followed, and a use that hands the handle to
+a bridge helper whose own body `IsNull()`-checks that parameter first counts as guarded.
+
+Two exclusions, both load-bearing:
+
+  * A `DownCast(x->curve)` is NOT a use: down-casting a null handle returns a null handle, and
+    every such site in this bridge checks the cast result. Without it the walk reports several
+    hundred false positives.
+  * ALLOWED below carries the sites where a guard would be noise. Most are there because the OCCT
+    entry point was *measured* to tolerate a null handle - #556's own standard, since a call that
+    returns normally or raises a catchable `Standard_Failure` is already handled by the function's
+    `catch (...)`. Every reason cites the measurement.
 
 Usage (from the repo root):
 
-    python3 Scripts/check-null-handle-guards.py          # report unguarded sites
-    python3 Scripts/check-null-handle-guards.py --quiet  # exit status only
+    python3 Scripts/check-null-handle-guards.py             # report unguarded sites
+    python3 Scripts/check-null-handle-guards.py --quiet     # exit status only
+    python3 Scripts/check-null-handle-guards.py --self-test # prove each failure mode is caught
 
 Exit status is 1 when any site is unguarded, so this can gate a commit.
 """
@@ -40,16 +62,83 @@ WRAPPERS = {
     'OCCTSurfaceRef': 'surface',
 }
 
-# Sites deliberately left unguarded, with the reason. Keep this list empty-by-default: an entry
-# is a promise that every caller checks both the pointer and the handle.
+# Sites deliberately left unguarded, with the reason. An entry is a promise: either every caller
+# checks both the pointer and the handle, or the OCCT entry point was measured to cope with a null
+# handle on its own. The measured verdicts come from Scripts/repro/556-null-handle-guard-sweep,
+# which #618 extended with the 22 entry points the pre-#618 walk never reached.
 ALLOWED = {
-    # Returns Geom2dGcc_QualifiedCurve by value, so it has no null-safe fallback to return.
-    # All of its callers reject a null pointer and a null handle before calling.
-    ('OCCTBridge_Geom2d.mm', 'makeQualifiedCurve'),
+    ('OCCTBridge_Geom2d.mm', 'makeQualifiedCurve'):
+        'returns Geom2dGcc_QualifiedCurve by value, so it has no null-safe fallback to return; '
+        'all of its callers reject a null pointer and a null handle before calling',
+
+    # --- the null handle never reaches OCCT ---
+    ('OCCTBridge_BRepGraph.mm', 'OCCTBRepGraphRepSetSurface'):
+        'stores into the bridge-owned side registry, not OCCT; the else branch of the same '
+        'expression deliberately stores a null handle to clear the slot',
+    ('OCCTBridge_BRepGraph.mm', 'OCCTBRepGraphRepSetCurve3D'):
+        'stores into the bridge-owned side registry, not OCCT; a null handle clears the slot',
+    ('OCCTBridge_BRepGraph.mm', 'OCCTBRepGraphRepSetCurve2D'):
+        'stores into the bridge-owned side registry, not OCCT; a null handle clears the slot',
+    ('OCCTBridge_BRepGraph.mm', 'OCCTBRepGraphCoEdgeSetPCurve'):
+        'BRepGraph_EditorView::SetPCurve documents the null handle as its clear-the-binding '
+        'contract ("Pass a null handle to clear the stored PCurve binding")',
+
+    # --- measured: the OCCT call returns normally on a null handle ---
+    ('OCCTBridge_Curve3D.mm', 'OCCTGeomLibToolParameter3D'):
+        'measured #618: GeomLib_Tool::Parameter(Geom_Curve) returns false on a null handle',
+    ('OCCTBridge_Geom2d.mm', 'OCCTGeomLibToolParameter2D'):
+        'measured #618: GeomLib_Tool::Parameter(Geom2d_Curve) returns false on a null handle',
+    ('OCCTBridge_Surface.mm', 'OCCTGeomLibToolParametersSurface'):
+        'measured #618: GeomLib_Tool::Parameters(Geom_Surface) returns false on a null handle',
+    ('OCCTBridge_Surface.mm', 'OCCTGeomConvertIsCanonical'):
+        'measured #618: GeomConvert_SurfToAnaSurf::IsCanonical returns on a null handle',
+    ('OCCTBridge_IO.mm', 'OCCTGeomToolsCurveSetWrite'):
+        'measured #618: GeomTools_CurveSet::Add opens "return (C.IsNull()) ? 0 : myMap.Add(C)", '
+        'so a null section is dropped rather than written. Its 2D and surface twins have no such '
+        'check anywhere and DO crash - they are guarded, this one needs nothing',
+
+    # --- measured: the OCCT call raises a catchable Standard_Failure, which each function's own
+    #     catch (...) already turns into the same fallback a guard would return ---
+    ('OCCTBridge_Curve3D.mm', 'OCCTApproxSameParameter'):
+        'measured #618: Approx_SameParameter raises a catchable Standard_Failure',
+    ('OCCTBridge_Curve3D.mm', 'OCCTExtremaExtCC'):
+        'measured #618: GeomAdaptor_Curve raises a catchable Standard_Failure',
+    ('OCCTBridge_Curve3D.mm', 'OCCTExtremaExtCCPoint'):
+        'measured #618: GeomAdaptor_Curve raises a catchable Standard_Failure',
+    ('OCCTBridge_Curve3D.mm', 'OCCTExtremaExtCS'):
+        'measured #618: GeomAdaptor_Curve / GeomAdaptor_Surface raise a catchable Standard_Failure',
+    ('OCCTBridge_Curve3D.mm', 'OCCTExtremaExtCSPoint'):
+        'measured #618: GeomAdaptor_Curve / GeomAdaptor_Surface raise a catchable Standard_Failure',
+    ('OCCTBridge_Curve3D.mm', 'OCCTExtremaLocateExtCC'):
+        'measured #618: GeomAdaptor_Curve raises a catchable Standard_Failure',
+    ('OCCTBridge_Geom2d.mm', 'OCCTExtremaLocateExtCC2d'):
+        'measured #556: Geom2dAdaptor_Curve raises a catchable Standard_Failure',
+    ('OCCTBridge_Geom2d.mm', 'OCCTGeom2dConvertApproxArcsSegments'):
+        'measured #618: Geom2dConvert_ApproxArcsSegments raises a catchable Standard_Failure',
+    ('OCCTBridge_Surface.mm', 'OCCTGeomLibIsPlanarSurface'):
+        'measured #618: GeomLib_IsPlanarSurface raises a catchable Standard_Failure',
+    ('OCCTBridge_Surface.mm', 'OCCTGeomLibPlanarSurfacePlane'):
+        'measured #618: GeomLib_IsPlanarSurface raises a catchable Standard_Failure',
+    ('OCCTBridge_Surface.mm', 'OCCTExtremaExtPS'):
+        'measured #618: GeomAdaptor_Surface raises a catchable Standard_Failure',
+    ('OCCTBridge_Surface.mm', 'OCCTExtremaExtPSPoint'):
+        'measured #618: GeomAdaptor_Surface raises a catchable Standard_Failure',
+    ('OCCTBridge_Surface.mm', 'OCCTExtremaExtSS'):
+        'measured #618: GeomAdaptor_Surface raises a catchable Standard_Failure',
+    ('OCCTBridge_Surface.mm', 'OCCTExtremaExtSSPoint'):
+        'measured #618: GeomAdaptor_Surface raises a catchable Standard_Failure',
 }
 
 FUNC = re.compile(r'^(?:static\s+)?[A-Za-z_][\w:<>,\s\*&]*?\b(\w+)\s*\(([^;{]*?)\)\s*\{', re.M | re.S)
 NOT_A_FUNCTION = {'if', 'for', 'while', 'switch', 'catch', 'return'}
+
+# A C++ named cast and its opening paren; the matching close paren is found by scanning.
+CAST_OPEN = re.compile(r'\b(?:reinterpret_cast|static_cast|const_cast|dynamic_cast)'
+                       r'\s*<(?:[^<>]|<[^<>]*>)*>\s*\(')
+# A C-style cast to one of the wrapper types: (OCCTSurface*), (OCCTCurve3DRef), ...
+C_CAST = re.compile(r'\(\s*OCCT\w+\s*\*?\s*\)')
+ASSIGN = re.compile(r'\b(\w+)\s*(=)\s*([^;]*);')
+HANDLE_PARAM = re.compile(r'(?:occ::handle\s*<|\bHandle\s*\()')
 
 
 def strip_comments(text):
@@ -80,6 +169,34 @@ def strip_comments(text):
     return ''.join(out)
 
 
+def strip_casts(text):
+    """Blank every cast wrapper, preserving length, so all four spellings of
+
+        reinterpret_cast<OCCTSurface*>(ref)->surface
+        static_cast<OCCTSurface*>(ref)->surface
+        (OCCTSurface*)ref ... ref->surface
+        ref->surface
+
+    reduce to the last one. Positions (and therefore line numbers) are unchanged.
+    """
+    out, n = list(text), len(text)
+    for m in CAST_OPEN.finditer(text):
+        depth, j = 0, m.end() - 1
+        while j < n:
+            if text[j] == '(':
+                depth += 1
+            elif text[j] == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if j < n:
+            for k in range(m.start(), m.end()):
+                out[k] = ' '
+            out[j] = ' '
+    return C_CAST.sub(lambda mm: ' ' * (mm.end() - mm.start()), ''.join(out))
+
+
 def functions(text):
     """(name, params, body start, body end) for every function definition in the file."""
     for m in FUNC.finditer(text):
@@ -99,63 +216,299 @@ def functions(text):
         yield name, params, start, i
 
 
+def split_params(params):
+    """Top-level comma split, so Handle(Geom_Curve) and handle<X, Y> stay in one piece."""
+    out, depth, cur = [], 0, ''
+    for ch in params:
+        if ch in '(<[':
+            depth += 1
+        elif ch in ')>]':
+            depth -= 1
+        if ch == ',' and depth == 0:
+            out.append(cur)
+            cur = ''
+        else:
+            cur += ch
+    if cur.strip():
+        out.append(cur)
+    return out
+
+
 def wrapper_params(params):
-    """(name, handle field, whether it is an array) for each wrapper-typed parameter."""
+    """(name, handle field) for each wrapper-typed parameter."""
     out = []
-    for p in params.split(','):
+    for p in split_params(params):
         p = p.strip()
         for wrapper, field in WRAPPERS.items():
             if not re.search(r'\b' + wrapper + r'\b', p):
                 continue
-            m = re.search(r'(\w+)\s*(\[\s*\])?\s*$', p)
+            m = re.search(r'(\w+)\s*(?:\[\s*\])?\s*$', p)
             if m and m.group(1) not in WRAPPERS:
-                tail = p[p.index(wrapper) + len(wrapper):]
-                out.append((m.group(1), field, '*' in tail or bool(m.group(2))))
+                out.append((m.group(1), field))
             break
     return out
 
 
-def unguarded_sites():
+def guarding_helpers(sources):
+    """(function, argument index) for every bridge function that IsNull-checks that Handle
+    parameter before touching it. Passing a handle to one of these IS a guard: the check just
+    lives one call frame away. `occtCurveToAnalytical` and `occtSurfaceToAnalytical` are the two
+    in this tree, and both open with `if (curve.IsNull()) return false;`."""
+    guards = set()
+    for _, text in sources:
+        text = strip_comments(text)
+        for name, params, bs, be in functions(text):
+            body = text[bs:be + 1]
+            for i, p in enumerate(split_params(params)):
+                if not HANDLE_PARAM.search(p):
+                    continue
+                m = re.search(r'(\w+)\s*$', p.strip())
+                if not m:
+                    continue
+                first = re.search(r'\b' + re.escape(m.group(1)) + r'\b', body)
+                if first and re.match(r'\s*\.\s*IsNull\s*\(', body[first.end():first.end() + 20]):
+                    guards.add((name, i))
+    return guards
+
+
+def enclosing_call(body, pos):
+    """(callee, argument index) for the call whose argument list encloses `pos`, else None."""
+    depth, i, commas = 0, pos - 1, 0
+    while i >= 0:
+        ch = body[i]
+        if ch == ')':
+            depth += 1
+        elif ch == '(':
+            if depth == 0:
+                m = re.search(r'(\w+)\s*$', body[:i])
+                return (m.group(1), commas) if m else None
+            depth -= 1
+        elif ch == ',' and depth == 0:
+            commas += 1
+        i -= 1
+    return None
+
+
+def aliases(body, param, field):
+    """Local names standing in for the wrapper pointer, and for the handle it carries."""
+    ptr, handle, spans = {param: -1}, {}, []
+    for _ in range(4):                        # fixpoint; alias chains are 1-2 deep in practice
+        grew = False
+        for m in ASSIGN.finditer(body):
+            if body[m.start(2) + 1:m.start(2) + 2] == '=':
+                continue                      # ==, not an assignment
+            name, rhs = m.group(1), m.group(3).strip().strip('() \t\n')
+            hit = re.fullmatch(r'(\w+)\s*(?:\[[^\]]*\])?', rhs)
+            if hit and hit.group(1) in ptr and name not in ptr:
+                ptr[name] = m.end()
+                grew = True
+                continue
+            hit = re.fullmatch(r'(\w+)\s*(?:\[[^\]]*\])?\s*->\s*' + field, rhs)
+            if hit and hit.group(1) in ptr and name not in handle:
+                handle[name] = m.end()
+                spans.append((m.start(), m.end()))
+                grew = True
+        if not grew:
+            break
+    return ptr, handle, spans
+
+
+def classify(body, start, end, helpers):
+    """'guard', 'use', or None (not a use at all) for one occurrence of the handle."""
+    after, before = body[end:end + 40], body[max(0, start - 80):start]
+    if re.match(r'\s*\.\s*IsNull\s*\(', after):
+        return 'guard'                        # this occurrence IS the guard
+    if re.search(r'DownCast\s*\(\s*$', before):
+        return None                           # null-safe: DownCast(null) returns null
+    call = enclosing_call(body, start)
+    if call in helpers:
+        return 'guard'                        # the callee IsNull-checks it before using it
+    return 'use'
+
+
+def unguarded_sites(sources, helpers):
     """Every (file, line, function, parameter) whose handle reaches OCCT without an IsNull test."""
     found = []
-    for path in sorted(glob.glob(os.path.join(SRC_DIR, '*.mm'))) + \
-            sorted(glob.glob(os.path.join(SRC_DIR, '*.h'))):
-        raw = open(path).read()
+    for path, raw in sources:
         text = strip_comments(raw)
-        for name, params, body_start, body_end in functions(text):
-            body = text[body_start:body_end + 1]
-            for param, field, is_array in wrapper_params(params):
-                if is_array:
-                    use = re.compile(r'\b' + re.escape(param) + r'\s*\[[^\]]*\]\s*->\s*' + field + r'\b')
-                else:
-                    use = re.compile(r'\b' + re.escape(param) + r'\s*->\s*' + field + r'\b')
-                first_real, guarded = None, False
-                for u in use.finditer(body):
-                    after = body[u.end():u.end() + 40]
-                    before = body[max(0, u.start() - 80):u.start()]
-                    if re.match(r'\s*\.\s*IsNull\s*\(', after):
-                        guarded = True          # this occurrence IS the guard
-                        continue
-                    if re.search(r'DownCast\s*\(\s*$', before):
-                        continue                # null-safe: DownCast(null) returns null
-                    first_real = u
-                    break
-                if first_real is None or guarded:
-                    continue
+        ctext = strip_casts(text)
+        lines = raw.splitlines()
+        for name, params, bs, be in functions(text):
+            body = ctext[bs:be + 1]
+            for param, field in wrapper_params(params):
                 if (os.path.basename(path), name) in ALLOWED:
                     continue
-                line = text.count('\n', 0, body_start + first_real.start()) + 1
+                ptr, handle, spans = aliases(body, param, field)
+                ev = []
+                for a, bound in ptr.items():
+                    pat = re.compile(r'\b' + re.escape(a) + r'\s*(?:\[[^\]]*\])?\s*->\s*'
+                                     + field + r'\b')
+                    for u in pat.finditer(body):
+                        if u.start() < bound or any(s <= u.start() < e for s, e in spans):
+                            continue          # before the alias exists, or merely binding one
+                        kind = classify(body, u.start(), u.end(), helpers)
+                        if kind:
+                            ev.append((u.start(), kind))
+                for h, bound in handle.items():
+                    pat = re.compile(r'(?<![\w>.])' + re.escape(h) + r'\b')
+                    for u in pat.finditer(body):
+                        if u.start() < bound or re.match(r'\s*=(?!=)', body[u.end():u.end() + 4]):
+                            continue
+                        kind = classify(body, u.start(), u.end(), helpers)
+                        if kind:
+                            ev.append((u.start(), kind))
+                ev.sort()
+                first = next((p for p, k in ev if k == 'use'), None)
+                if first is None or any(k == 'guard' and p < first for p, k in ev):
+                    continue
+                line = text.count('\n', 0, bs + first) + 1
                 found.append((os.path.basename(path), line, name, param, field,
-                              raw.splitlines()[line - 1].strip()))
+                              lines[line - 1].strip() if line <= len(lines) else ''))
     return found
+
+
+def bridge_sources():
+    paths = sorted(glob.glob(os.path.join(SRC_DIR, '*.mm'))) + \
+        sorted(glob.glob(os.path.join(SRC_DIR, '*.h')))
+    return [(p, open(p).read()) for p in paths]
+
+
+# Each fixture is one bridge function in one of the shapes this tree actually uses. The MISSED
+# half must be reported; the CLEAN half must not. Before #618 the detector matched `param->field`
+# only, so it scored 1/6 on MISSED - it caught the plain form and nothing else.
+MISSED = [
+    ('reinterpret_cast straight into OCCT', '''
+int OCCTFixtureA(OCCTSurfaceRef s) {
+    try { Splitter sp; sp.Init(reinterpret_cast<OCCTSurface*>(s)->surface); return 1; }
+    catch (...) { return 0; }
+}'''),
+    ('handle alias bound through a cast', '''
+int OCCTFixtureB(OCCTSurfaceRef surfaceRef) {
+    try {
+        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
+        Splitter sp; sp.Init(surface); return 1;
+    } catch (...) { return 0; }
+}'''),
+    ('pointer alias through a C-style cast', '''
+int OCCTFixtureC(OCCTSurfaceRef surface) {
+    try { auto* s = (OCCTSurface*)surface; GeomAdaptor_Surface a(s->surface); return 1; }
+    catch (...) { return 0; }
+}'''),
+    ('static_cast spelling', '''
+int OCCTFixtureD(OCCTCurve3DRef c) {
+    try { Splitter sp; sp.Init(static_cast<OCCTCurve3D*>(c)->curve); return 1; }
+    catch (...) { return 0; }
+}'''),
+    ('array element through a cast', '''
+int OCCTFixtureE(const OCCTCurve3DRef* refs, int n) {
+    try {
+        for (int i = 0; i < n; i++) {
+            auto* w = reinterpret_cast<OCCTCurve3D*>(refs[i]);
+            seq.Append(w->curve);
+        }
+        return 1;
+    } catch (...) { return 0; }
+}'''),
+    # The pre-#618 form. It must keep being caught: the fix is additive, not a replacement.
+    ('plain param->field, no indirection', '''
+int OCCTFixtureF(OCCTCurve3DRef curve) {
+    try { Splitter sp; sp.Init(curve->curve); return 1; }
+    catch (...) { return 0; }
+}'''),
+]
+
+# The other failure mode, and the one #624/#630 was: a detector taught indirection can start
+# reporting correct code. Each of these guards its handle in a way the tree really uses.
+CLEAN = [
+    ('plain two-condition opener', '''
+int OCCTFixtureG(OCCTCurve3DRef curve) {
+    if (!curve || curve->curve.IsNull()) return 0;
+    try { Splitter sp; sp.Init(curve->curve); return 1; }
+    catch (...) { return 0; }
+}'''),
+    ('guarded through the handle alias', '''
+int OCCTFixtureH(OCCTSurfaceRef surfaceRef) {
+    try {
+        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
+        if (surface.IsNull()) return 0;
+        Splitter sp; sp.Init(surface); return 1;
+    } catch (...) { return 0; }
+}'''),
+    ('guarded through a by-value Handle copy', '''
+int OCCTFixtureI(OCCTSurfaceRef initialSurface) {
+    try {
+        auto wrapper = (OCCTSurface*)initialSurface;
+        Handle(Geom_Surface) workSurface = wrapper->surface;
+        if (workSurface.IsNull()) return 0;
+        NLPlate_NLPlate solver(workSurface); return 1;
+    } catch (...) { return 0; }
+}'''),
+    ('guarded through the pointer alias', '''
+int OCCTFixtureJ(OCCTSurfaceRef surface, OCCTCurve2DRef curve2d) {
+    try {
+        auto* sw = (OCCTSurface*)surface;
+        auto* cw = (OCCTCurve2D*)curve2d;
+        if (!sw || sw->surface.IsNull() || !cw || cw->curve.IsNull()) return 0;
+        GeomAdaptor_Surface a(sw->surface); return 1;
+    } catch (...) { return 0; }
+}'''),
+    ('DownCast is not a use', '''
+int OCCTFixtureK(OCCTCurve2DRef curveRef) {
+    try {
+        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve);
+        if (bsp.IsNull()) return 0;
+        return 1;
+    } catch (...) { return 0; }
+}'''),
+    # Form 4. The handle is checked one frame away, inside the shared helper - the shape that
+    # makes a naive indirection-aware detector wrong about OCCTGeomConvertCurveToAnalytical.
+    ('guarded by the bridge helper it is passed to', '''
+inline bool occtFixtureToAnalytical(const occ::handle<Geom_Curve>& curve, double tol) {
+    if (curve.IsNull()) return false;
+    GeomConvert_CurveToAnaCurve converter(curve);
+    return converter.ConvertToAnalytical(tol);
+}
+int OCCTFixtureL(OCCTCurve3DRef curveRef) {
+    if (!curveRef) return 0;
+    return occtFixtureToAnalytical(reinterpret_cast<OCCTCurve3D*>(curveRef)->curve, 1e-7) ? 1 : 0;
+}'''),
+]
+
+
+def self_test():
+    """Prove both failure modes: an unguarded site is reported, a guarded one is not."""
+    failed = 0
+    for name, src in MISSED:
+        sources = [('fixture.mm', src)]
+        hit = unguarded_sites(sources, guarding_helpers(sources))
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} unguarded, {name}: '
+              f'{hit[0][2] + "(" + hit[0][3] + ")" if hit else "NOT REPORTED"}')
+    for name, src in CLEAN:
+        sources = [('fixture.mm', src)]
+        hit = unguarded_sites(sources, guarding_helpers(sources))
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} guarded, {name}: '
+              f'{hit[0][2] + " wrongly reported" if hit else "not reported"}')
+    total = len(MISSED) + len(CLEAN)
+    print(f'{total - failed}/{total} cases correct')
+    return 1 if failed else 0
 
 
 def main():
     quiet = '--quiet' in sys.argv
-    sites = unguarded_sites()
+    if '--self-test' in sys.argv:
+        return self_test()
+    if not os.path.isdir(SRC_DIR):
+        print(f'{SRC_DIR} not found - run from the repo root', file=sys.stderr)
+        return 2
+    sources = bridge_sources()
+    sites = unguarded_sites(sources, guarding_helpers(sources))
     if not sites:
         if not quiet:
             print('All bridge functions guard the geometry handle as well as the wrapper pointer.')
+            print(f'({len(ALLOWED)} site(s) exempt by name in ALLOWED, each with its reason.)')
         return 0
     if not quiet:
         print(f'{len(sites)} (function, argument) pair(s) reach OCCT with an unchecked handle:\n')

--- a/Scripts/repro/556-null-handle-guard-sweep/README.md
+++ b/Scripts/repro/556-null-handle-guard-sweep/README.md
@@ -24,10 +24,11 @@ with before the fix. A child killed by a signal is a case it could not.
 
 ## What it measures
 
-35 distinct OCCT entry points: every API that the 60 bridge functions #556 guards pass an
-`OCCTCurve3DRef` / `OCCTCurve2DRef` / `OCCTSurfaceRef`'s handle into.
+57 distinct OCCT entry points: every API that the bridge passes an `OCCTCurve3DRef` /
+`OCCTCurve2DRef` / `OCCTSurfaceRef`'s handle into. 35 of them come from #556; #618 added the
+other 22 (see below).
 
-**24 of 35 crash with an uncatchable signal. 5 raise a catchable `Standard_Failure`. 6 return.**
+**36 of 57 crash with an uncatchable signal. 10 raise a catchable `Standard_Failure`. 11 return.**
 
 ### The issue's headline example is one of the mild ones
 
@@ -82,6 +83,55 @@ constructed the object would have reported this whole 11-function family as safe
 
 Per CLAUDE.md, `OCC_CATCH_SIGNALS` is inert in this build, so none of the 24 is recoverable
 in-process. The enclosing `catch (...)` is not a fallback for any of them.
+
+## The 22 entry points #618 added
+
+The walk that produced #556's census matched `param->field` and nothing else, so it never saw the
+bridge sites that reach the handle through a cast or a local alias, and so these entry points,
+the ones those sites call, were never probed at all. #618 taught the checker every indirection in
+the tree and then measured what it turned up. Each probe below runs the bridge function's real
+sequence (`Init` *and* `Perform`, not just the first call), because the crash need not land on the
+first one.
+
+**13 crash, 5 raise a catchable `Standard_Failure`, 5 return.** Which means the "suspected
+unguarded" list #618 was filed with was partly wrong, in the direction that matters: measuring
+first avoided three guards that would have been noise.
+
+| OCCT call | reached from | null handle |
+|---|---|---|
+| `LocalAnalysis_CurveContinuity` ctor | `OCCTLocalAnalysisCurveContinuity{,Flags}` | SIGSEGV |
+| `LocalAnalysis_SurfaceContinuity` ctor | `OCCTLocalAnalysisSurfaceContinuity{,Flags}` | SIGSEGV |
+| `ShapeUpgrade_SplitCurve3dContinuity` `Init`+`Perform` | `OCCTSplitCurve3dContinuity` | SIGSEGV |
+| `ShapeUpgrade_SplitCurve2dContinuity` `Init`+`Perform` | `OCCTSplitCurve2dContinuity` | SIGSEGV |
+| `ShapeUpgrade_ConvertCurve2dToBezier` `Init`+`Perform` | `OCCTConvertCurve2dToBezier` | SIGSEGV |
+| `ShapeUpgrade_SplitSurface{Continuity,Angle,Area}` `Init`+`Perform` | the three `OCCTSplitSurface*` fns | SIGSEGV |
+| `GeomTools_Curve2dSet::Add` + `Write` | `OCCTGeomToolsCurve2dSetWrite` | SIGSEGV |
+| `GeomTools_SurfaceSet::Add` + `Write` | `OCCTGeomToolsSurfaceSetWrite` | SIGSEGV |
+| `GeomFill_NSections` + `ComputeSurface` / `SectionShape` | `OCCTGeomFillNSections{,Info}` | SIGSEGV |
+| `new Geom_TrimmedCurve` | `OCCTProjLibProjectOnSurface` | SIGSEGV |
+| `Approx_SameParameter` ctor | `OCCTApproxSameParameter` | `Standard_Failure` |
+| `GeomAdaptor_Surface` ctor | 9 `OCCTExtrema*` / `OCCTProjLib*` fns | `Standard_Failure` |
+| `GeomAdaptor_Curve(c, first, last)` | 5 `OCCTExtrema*` fns | `Standard_Failure` |
+| `GeomLib_IsPlanarSurface` ctor | `OCCTGeomLibIsPlanarSurface`, `OCCTGeomLibPlanarSurfacePlane` | `Standard_Failure` |
+| `Geom2dConvert_ApproxArcsSegments` | `OCCTGeom2dConvertApproxArcsSegments` | `Standard_Failure` |
+| `GeomLib_Tool::Parameter` (3D and 2D) | `OCCTGeomLibToolParameter{3D,2D}` | returns false |
+| `GeomLib_Tool::Parameters` (surface) | `OCCTGeomLibToolParametersSurface` | returns false |
+| `GeomConvert_SurfToAnaSurf::IsCanonical` | `OCCTGeomConvertIsCanonical` | returns |
+| `GeomTools_CurveSet::Add` + `Write` | `OCCTGeomToolsCurveSetWrite` | returns |
+
+### One asymmetry worth naming: `GeomTools`
+
+The three `GeomTools_*Set` writers are the same code three times over, and they do not behave the
+same way. `GeomTools_CurveSet::Add` opens
+
+```cpp
+return (C.IsNull()) ? 0 : myMap.Add(C);
+```
+
+so a null 3D curve is dropped rather than written. `GeomTools_Curve2dSet.cxx` and
+`GeomTools_SurfaceSet.cxx` contain no `IsNull` at all, and both crash. Upstream inconsistency, not
+ours; the two that crash are guarded bridge-side, the one that copes is left alone and recorded in
+the checker's `ALLOWED` with that reason.
 
 ## What this does not show
 

--- a/Scripts/repro/556-null-handle-guard-sweep/README.md
+++ b/Scripts/repro/556-null-handle-guard-sweep/README.md
@@ -30,6 +30,12 @@ other 22 (see below).
 
 **36 of 57 crash with an uncatchable signal. 10 raise a catchable `Standard_Failure`. 11 return.**
 
+Entry points and probes are not the same count, and the program prints the second one. It runs 60
+probes for those 57 entry points, because `Approx_SameParameter` takes three handles and is probed
+four ways: all three null, then each argument null with the other two valid. So its summary line
+reads `36 uncatchable, 13 catchable, 11 returned`. The three extra are all catchable, which is why
+the per-entry-point split above is unchanged. Do not add the two together.
+
 ### The issue's headline example is one of the mild ones
 
 #556 leads with `Geom2dAdaptor_Curve`, and argues from
@@ -81,8 +87,9 @@ Measured: `Geom2dAdaptor_Curve(null)` and `Geom2dAdaptor_Curve(null, 0, 1)` both
 normally, and the crash lands at the first `ValueOfUV`/`HasSingularities` call. A probe that only
 constructed the object would have reported this whole 11-function family as safe.
 
-Per CLAUDE.md, `OCC_CATCH_SIGNALS` is inert in this build, so none of the 24 is recoverable
-in-process. The enclosing `catch (...)` is not a fallback for any of them.
+Per CLAUDE.md, `OCC_CATCH_SIGNALS` is inert in this build, so none of the crashing cases is
+recoverable in-process, here or in the #618 set below (36 of 57 across both). The enclosing
+`catch (...)` is not a fallback for any of them.
 
 ## The 22 entry points #618 added
 
@@ -93,9 +100,21 @@ the tree and then measured what it turned up. Each probe below runs the bridge f
 sequence (`Init` *and* `Perform`, not just the first call), because the crash need not land on the
 first one.
 
-**13 crash, 5 raise a catchable `Standard_Failure`, 5 return.** Which means the "suspected
-unguarded" list #618 was filed with was partly wrong, in the direction that matters: measuring
-first avoided three guards that would have been noise.
+**12 crash, 5 raise a catchable `Standard_Failure`, 5 return** (22 entry points, 25 probes: see the
+`Approx_SameParameter` note above). Which means the "suspected unguarded" list #618 was filed with
+was partly wrong, in the direction that matters: measuring first avoided three guards that would
+have been noise.
+
+`Approx_SameParameter` is also where the clearing evidence was initially thinner than the claim it
+supported. One all-null probe only shows that the all-null case survives; the bridge function takes
+three separate handles, and a guard would be protecting each one individually. All four
+combinations turn out to raise the same catchable `Standard_Failure`, so the verdict did not move,
+but a multi-argument site needs per-argument probes before it can be cleared.
+
+The table below has one more crashing row than that, because `new Geom_TrimmedCurve` is not a new
+*entry point*: #556 already probed it as `Curve3DTrimmed` (`repro_556.mm:132`). What #618 added
+there is a new *site* reaching it, `OCCTProjLibProjectOnSurface`. Counting it again would make the
+same mistake this PR exists to fix, so it is listed for the call path and excluded from the 22.
 
 | OCCT call | reached from | null handle |
 |---|---|---|
@@ -108,7 +127,7 @@ first avoided three guards that would have been noise.
 | `GeomTools_Curve2dSet::Add` + `Write` | `OCCTGeomToolsCurve2dSetWrite` | SIGSEGV |
 | `GeomTools_SurfaceSet::Add` + `Write` | `OCCTGeomToolsSurfaceSetWrite` | SIGSEGV |
 | `GeomFill_NSections` + `ComputeSurface` / `SectionShape` | `OCCTGeomFillNSections{,Info}` | SIGSEGV |
-| `new Geom_TrimmedCurve` | `OCCTProjLibProjectOnSurface` | SIGSEGV |
+| `new Geom_TrimmedCurve` (already counted under #556) | `OCCTProjLibProjectOnSurface` | SIGSEGV |
 | `Approx_SameParameter` ctor | `OCCTApproxSameParameter` | `Standard_Failure` |
 | `GeomAdaptor_Surface` ctor | 9 `OCCTExtrema*` / `OCCTProjLib*` fns | `Standard_Failure` |
 | `GeomAdaptor_Curve(c, first, last)` | 5 `OCCTExtrema*` fns | `Standard_Failure` |
@@ -130,8 +149,14 @@ return (C.IsNull()) ? 0 : myMap.Add(C);
 
 so a null 3D curve is dropped rather than written. `GeomTools_Curve2dSet.cxx` and
 `GeomTools_SurfaceSet.cxx` contain no `IsNull` at all, and both crash. Upstream inconsistency, not
-ours; the two that crash are guarded bridge-side, the one that copes is left alone and recorded in
-the checker's `ALLOWED` with that reason.
+ours.
+
+All three are guarded bridge-side anyway, and the 3D one is not guarded for crash-safety. Dropping
+the null is not harmless: `Write()` then emits a set with fewer curves than the caller passed, and
+`Curve3D.serializeCurves` / `deserializeCurves` is a round trip, so the drop is a silent truncation
+whose surviving indices no longer line up with the input array. Refusing the batch is both the
+safer contract and what the two siblings already do, so the family stays converged rather than
+splitting three ways on null handling (#618).
 
 ## What this does not show
 

--- a/Scripts/repro/556-null-handle-guard-sweep/repro_556.mm
+++ b/Scripts/repro/556-null-handle-guard-sweep/repro_556.mm
@@ -25,6 +25,10 @@
 #include <Geom2d_CartesianPoint.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <Approx_SameParameter.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom2d_Line.hxx>
+#include <gp_Dir2d.hxx>
 #include <Geom2dConvert_ApproxArcsSegments.hxx>
 #include <GeomAdaptor_Surface.hxx>
 #include <GeomConvert_SurfToAnaSurf.hxx>
@@ -242,9 +246,29 @@ int main() {
     probe("GeomLibToolParams...Surf", "GeomLib_Tool::Parameters(Geom_Surface)", [&] {
         double u = 0, v = 0; (void)GeomLib_Tool::Parameters(ns, gp_Pnt(0, 0, 0), 1e-3, u, v);
     });
-    probe("ApproxSameParameter", "Approx_SameParameter ctor", [&] {
-        Approx_SameParameter a(nc, nc2, ns, 1e-3); (void)a.IsDone();
-    });
+    // Approx_SameParameter takes three handles, so one all-null probe does not cover the claim
+    // that the bridge function needs no guard: it only shows the all-null case is survivable. The
+    // three below null one argument at a time with the other two valid, which is what the guard
+    // would actually be protecting against. These are extra probes of an entry point already
+    // counted once, not extra entry points (same distinction as `new Geom_TrimmedCurve` above).
+    {
+        occ::handle<Geom_Curve>   goodC3d = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+        occ::handle<Geom2d_Curve> goodC2d = new Geom2d_Line(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+        occ::handle<Geom_Surface> goodSrf = new Geom_Plane(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+        probe("ApproxSameParameter", "Approx_SameParameter(null, null, null)", [&] {
+            Approx_SameParameter a(nc, nc2, ns, 1e-3); (void)a.IsDone();
+        });
+        probe("  \" (3D curve null only)", "Approx_SameParameter(null, c2d, surf)", [&] {
+            Approx_SameParameter a(nc, goodC2d, goodSrf, 1e-3); (void)a.IsDone();
+        });
+        probe("  \" (2D curve null only)", "Approx_SameParameter(c3d, null, surf)", [&] {
+            Approx_SameParameter a(goodC3d, nc2, goodSrf, 1e-3); (void)a.IsDone();
+        });
+        probe("  \" (surface null only)", "Approx_SameParameter(c3d, c2d, null)", [&] {
+            Approx_SameParameter a(goodC3d, goodC2d, ns, 1e-3); (void)a.IsDone();
+        });
+    }
     probe("SplitCurve3dContinuity", "ShapeUpgrade_SplitCurve3dContinuity Init+Perform", [&] {
         Handle(ShapeUpgrade_SplitCurve3dContinuity) s = new ShapeUpgrade_SplitCurve3dContinuity();
         s->Init(nc); s->SetCriterion(GeomAbs_C1); s->SetTolerance(1e-3); s->Perform(true);

--- a/Scripts/repro/556-null-handle-guard-sweep/repro_556.mm
+++ b/Scripts/repro/556-null-handle-guard-sweep/repro_556.mm
@@ -24,6 +24,24 @@
 #include <Geom2d_BoundedCurve.hxx>
 #include <Geom2d_CartesianPoint.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
+#include <Approx_SameParameter.hxx>
+#include <Geom2dConvert_ApproxArcsSegments.hxx>
+#include <GeomAdaptor_Surface.hxx>
+#include <GeomConvert_SurfToAnaSurf.hxx>
+#include <GeomFill_NSections.hxx>
+#include <GeomLib_IsPlanarSurface.hxx>
+#include <GeomLib_Tool.hxx>
+#include <GeomTools_Curve2dSet.hxx>
+#include <GeomTools_CurveSet.hxx>
+#include <GeomTools_SurfaceSet.hxx>
+#include <LocalAnalysis_CurveContinuity.hxx>
+#include <LocalAnalysis_SurfaceContinuity.hxx>
+#include <ShapeUpgrade_ConvertCurve2dToBezier.hxx>
+#include <ShapeUpgrade_SplitCurve2dContinuity.hxx>
+#include <ShapeUpgrade_SplitCurve3dContinuity.hxx>
+#include <ShapeUpgrade_SplitSurfaceAngle.hxx>
+#include <ShapeUpgrade_SplitSurfaceArea.hxx>
+#include <ShapeUpgrade_SplitSurfaceContinuity.hxx>
 #include <ShapeAnalysis_Curve.hxx>
 #include <ShapeAnalysis_Surface.hxx>
 #include <ShapeConstruct_Curve.hxx>
@@ -40,6 +58,7 @@
 #include <gp_Pnt.hxx>
 #include <gp_Pnt2d.hxx>
 
+#include <sstream>
 #include <cstdio>
 #include <cstring>
 #include <functional>
@@ -197,6 +216,102 @@ int main() {
     probe("BRepToolCurveOnPlane", "BRep_Tool::CurveOnPlane", [&] {
         TopoDS_Edge e; TopLoc_Location l; double f = 0, la = 0;
         (void)BRep_Tool::CurveOnPlane(e, ns, l, f, la);
+    });
+
+    // #618: the entry points the original sweep never saw. The walk that produced #556's census
+    // matched only `param->field`, so every site reaching the handle through a cast or a local
+    // alias was invisible, and so were the OCCT calls those sites make. Each probe below runs the
+    // bridge function's real sequence, not just its first call, because the crash need not be on
+    // the first one.
+    printf("\n  --- #618: reached through a cast or a local alias, never measured by #556 ---\n");
+
+    probe("LocalAnalysisCurveCont*", "LocalAnalysis_CurveContinuity ctor", [&] {
+        LocalAnalysis_CurveContinuity cc(nc, 0.5, nc, 0.5, GeomAbs_C1);
+        (void)cc.IsDone();
+    });
+    probe("LocalAnalysisSurfCont*", "LocalAnalysis_SurfaceContinuity ctor", [&] {
+        LocalAnalysis_SurfaceContinuity sc(ns, 0.5, 0.5, ns, 0.5, 0.5, GeomAbs_C1);
+        (void)sc.IsDone();
+    });
+    probe("GeomLibToolParameter3D", "GeomLib_Tool::Parameter(Geom_Curve)", [&] {
+        double p = 0; (void)GeomLib_Tool::Parameter(nc, gp_Pnt(0, 0, 0), 1e-3, p);
+    });
+    probe("GeomLibToolParameter2D", "GeomLib_Tool::Parameter(Geom2d_Curve)", [&] {
+        double p = 0; (void)GeomLib_Tool::Parameter(nc2, gp_Pnt2d(0, 0), 1e-3, p);
+    });
+    probe("GeomLibToolParams...Surf", "GeomLib_Tool::Parameters(Geom_Surface)", [&] {
+        double u = 0, v = 0; (void)GeomLib_Tool::Parameters(ns, gp_Pnt(0, 0, 0), 1e-3, u, v);
+    });
+    probe("ApproxSameParameter", "Approx_SameParameter ctor", [&] {
+        Approx_SameParameter a(nc, nc2, ns, 1e-3); (void)a.IsDone();
+    });
+    probe("SplitCurve3dContinuity", "ShapeUpgrade_SplitCurve3dContinuity Init+Perform", [&] {
+        Handle(ShapeUpgrade_SplitCurve3dContinuity) s = new ShapeUpgrade_SplitCurve3dContinuity();
+        s->Init(nc); s->SetCriterion(GeomAbs_C1); s->SetTolerance(1e-3); s->Perform(true);
+        (void)s->GetCurves();
+    });
+    probe("SplitCurve2dContinuity", "ShapeUpgrade_SplitCurve2dContinuity Init+Perform", [&] {
+        Handle(ShapeUpgrade_SplitCurve2dContinuity) s = new ShapeUpgrade_SplitCurve2dContinuity();
+        s->Init(nc2); s->SetCriterion(GeomAbs_C1); s->SetTolerance(1e-3); s->Perform(true);
+        (void)s->GetCurves();
+    });
+    probe("ConvertCurve2dToBezier", "ShapeUpgrade_ConvertCurve2dToBezier Init+Perform", [&] {
+        Handle(ShapeUpgrade_ConvertCurve2dToBezier) c = new ShapeUpgrade_ConvertCurve2dToBezier();
+        c->Init(nc2); c->Perform(true); (void)c->GetCurves();
+    });
+    probe("SplitSurfaceContinuity", "ShapeUpgrade_SplitSurfaceContinuity Init+Perform", [&] {
+        Handle(ShapeUpgrade_SplitSurfaceContinuity) s = new ShapeUpgrade_SplitSurfaceContinuity();
+        s->Init(ns); s->SetCriterion(GeomAbs_C1); s->SetTolerance(1e-3); s->Perform(true);
+        (void)s->USplitValues();
+    });
+    probe("SplitSurfaceAngle", "ShapeUpgrade_SplitSurfaceAngle Init+Perform", [&] {
+        Handle(ShapeUpgrade_SplitSurfaceAngle) s = new ShapeUpgrade_SplitSurfaceAngle(1.57);
+        s->Init(ns); s->Perform(true); (void)s->USplitValues();
+    });
+    probe("SplitSurfaceArea", "ShapeUpgrade_SplitSurfaceArea Init+Perform", [&] {
+        Handle(ShapeUpgrade_SplitSurfaceArea) s = new ShapeUpgrade_SplitSurfaceArea();
+        s->SetNumbersUVSplits(2, 2); s->Init(ns); s->Perform(true); (void)s->USplitValues();
+    });
+    probe("Extrema* / ProjLib*", "GeomAdaptor_Surface ctor", [&] {
+        Handle(GeomAdaptor_Surface) a = new GeomAdaptor_Surface(ns); (void)a;
+    });
+    probe("ExtremaExtCC etc", "GeomAdaptor_Curve(c, first, last)", [&] {
+        Handle(GeomAdaptor_Curve) a = new GeomAdaptor_Curve(nc, 0, 1); (void)a;
+    });
+    probe("GeomToolsCurveSetWrite", "GeomTools_CurveSet::Add + Write", [&] {
+        GeomTools_CurveSet cs; cs.Add(nc); std::ostringstream o; cs.Write(o);
+    });
+    probe("GeomToolsCurve2dSetWrite", "GeomTools_Curve2dSet::Add + Write", [&] {
+        GeomTools_Curve2dSet cs; cs.Add(nc2); std::ostringstream o; cs.Write(o);
+    });
+    probe("GeomToolsSurfaceSetWrite", "GeomTools_SurfaceSet::Add + Write", [&] {
+        GeomTools_SurfaceSet ss; ss.Add(ns); std::ostringstream o; ss.Write(o);
+    });
+    probe("GeomFillNSections", "GeomFill_NSections + ComputeSurface", [&] {
+        NCollection_Sequence<occ::handle<Geom_Curve>> sec;
+        NCollection_Sequence<double> par;
+        sec.Append(nc); par.Append(0.0);
+        sec.Append(nc); par.Append(1.0);
+        Handle(GeomFill_NSections) n = new GeomFill_NSections(sec, par);
+        n->ComputeSurface(); (void)n->BSplineSurface();
+    });
+    probe("GeomFillNSectionsInfo", "GeomFill_NSections + SectionShape", [&] {
+        NCollection_Sequence<occ::handle<Geom_Curve>> sec;
+        NCollection_Sequence<double> par;
+        sec.Append(nc); par.Append(0.0);
+        sec.Append(nc); par.Append(1.0);
+        Handle(GeomFill_NSections) n = new GeomFill_NSections(sec, par);
+        int a = 0, b = 0, c = 0; n->SectionShape(a, b, c);
+    });
+    probe("GeomLibIsPlanarSurface", "GeomLib_IsPlanarSurface ctor", [&] {
+        GeomLib_IsPlanarSurface p(ns, 1e-7); (void)p.IsPlanar();
+    });
+    probe("GeomConvertIsCanonical", "GeomConvert_SurfToAnaSurf::IsCanonical", [&] {
+        (void)GeomConvert_SurfToAnaSurf::IsCanonical(ns);
+    });
+    probe("Geom2dConvertApproxArcs", "Geom2dConvert_ApproxArcsSegments", [&] {
+        Geom2dAdaptor_Curve a(nc2);
+        Geom2dConvert_ApproxArcsSegments x(a, 1e-3, 1e-3); (void)x.GetResult();
     });
 
     printf("\n%d uncatchable signal(s), %d catchable exception(s), %d returned normally.\n",

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1631,6 +1631,7 @@ bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
     try {
         auto c1 = (OCCTCurve3D*)curve1;
         auto c2 = (OCCTCurve3D*)curve2;
+        if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return false;
 
         const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
         const int32_t measured = occtAnalysisMeasuredMask(effective);
@@ -1661,6 +1662,7 @@ int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, do
     try {
         auto c1 = (OCCTCurve3D*)curve1;
         auto c2 = (OCCTCurve3D*)curve2;
+        if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return 0;
 
         const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
         const int32_t measured = occtAnalysisMeasuredMask(effective);
@@ -2165,7 +2167,9 @@ bool OCCTApproxSameParameter(OCCTCurve3DRef _Nonnull curve3dRef,
 int OCCTSplitCurve3dContinuity(OCCTCurve3DRef _Nonnull curveRef, int criterion, double tolerance,
                                  OCCTCurve3DRef _Nullable* _Nullable outCurves, int maxCurves) {
     try {
-        auto& curve = reinterpret_cast<OCCTCurve3D*>(curveRef)->curve;
+        auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRef);
+        if (!wrapper || wrapper->curve.IsNull()) return 0;
+        auto& curve = wrapper->curve;
         Handle(ShapeUpgrade_SplitCurve3dContinuity) splitter = new ShapeUpgrade_SplitCurve3dContinuity();
         splitter->Init(curve);
         splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -2871,7 +2871,9 @@ int OCCTGccAnaLin2d2TanCircPnt(double cx, double cy, double radius,
 int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curveRef, int criterion, double tolerance,
                                  OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
     try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+        auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
+        if (!wrapper || wrapper->curve.IsNull()) return 0;
+        auto& curve = wrapper->curve;
         Handle(ShapeUpgrade_SplitCurve2dContinuity) splitter = new ShapeUpgrade_SplitCurve2dContinuity();
         splitter->Init(curve);
         splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
@@ -2900,7 +2902,9 @@ int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curveRef, int criterion, 
 int OCCTConvertCurve2dToBezier(OCCTCurve2DRef _Nonnull curveRef,
                                 OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
     try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+        auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
+        if (!wrapper || wrapper->curve.IsNull()) return 0;
+        auto& curve = wrapper->curve;
         Handle(ShapeUpgrade_ConvertCurve2dToBezier) converter = new ShapeUpgrade_ConvertCurve2dToBezier();
         converter->Init(curve);
         converter->Perform(true);

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3049,7 +3049,9 @@ int OCCTSplitSurfaceContinuity(OCCTSurfaceRef _Nonnull surfaceRef,
                                  int criterion, double tolerance,
                                  int* _Nullable outUSplitCount, int* _Nullable outVSplitCount) {
     try {
-        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
+        auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
+        if (!wrapper || wrapper->surface.IsNull()) return 0;
+        auto& surface = wrapper->surface;
         Handle(ShapeUpgrade_SplitSurfaceContinuity) splitter = new ShapeUpgrade_SplitSurfaceContinuity();
         splitter->Init(surface);
         splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
@@ -3070,7 +3072,9 @@ int OCCTSplitSurfaceContinuity(OCCTSurfaceRef _Nonnull surfaceRef,
 int OCCTSplitSurfaceAngle(OCCTSurfaceRef _Nonnull surfaceRef, double maxAngle,
                             int* _Nullable outUSplitCount, int* _Nullable outVSplitCount) {
     try {
-        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
+        auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
+        if (!wrapper || wrapper->surface.IsNull()) return 0;
+        auto& surface = wrapper->surface;
         Handle(ShapeUpgrade_SplitSurfaceAngle) splitter = new ShapeUpgrade_SplitSurfaceAngle(maxAngle);
         splitter->Init(surface);
         splitter->Perform(true);
@@ -3089,7 +3093,9 @@ int OCCTSplitSurfaceAngle(OCCTSurfaceRef _Nonnull surfaceRef, double maxAngle,
 int OCCTSplitSurfaceArea(OCCTSurfaceRef _Nonnull surfaceRef, int nbParts, bool intoSquares,
                            int* _Nullable outUSplitCount, int* _Nullable outVSplitCount) {
     try {
-        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
+        auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
+        if (!wrapper || wrapper->surface.IsNull()) return 0;
+        auto& surface = wrapper->surface;
         Handle(ShapeUpgrade_SplitSurfaceArea) splitter = new ShapeUpgrade_SplitSurfaceArea();
         splitter->Init(surface);
         splitter->NbParts() = nbParts;

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -1564,6 +1564,7 @@ const char * _Nullable OCCTGeomToolsCurve2dSetWrite(const OCCTCurve2DRef * curve
         GeomTools_Curve2dSet cs;
         for (int i = 0; i < count; i++) {
             auto* c = (OCCTCurve2D*)curveRefs[i];
+            if (!c || c->curve.IsNull()) return nullptr;
             cs.Add(c->curve);
         }
         std::ostringstream oss;
@@ -1615,6 +1616,7 @@ const char * _Nullable OCCTGeomToolsSurfaceSetWrite(const OCCTSurfaceRef * surfR
         GeomTools_SurfaceSet ss;
         for (int i = 0; i < count; i++) {
             auto* s = (OCCTSurface*)surfRefs[i];
+            if (!s || s->surface.IsNull()) return nullptr;
             ss.Add(s->surface);
         }
         std::ostringstream oss;

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -1512,6 +1512,14 @@ const char * _Nullable OCCTGeomToolsCurveSetWrite(const OCCTCurve3DRef * curveRe
         GeomTools_CurveSet cs;
         for (int i = 0; i < count; i++) {
             auto* c = (OCCTCurve3D*)curveRefs[i];
+            // Same opener as the Curve2dSet/SurfaceSet writers below, for a different reason.
+            // GeomTools_CurveSet::Add is the only one of the three that guards its handle
+            // (GeomTools_CurveSet.cxx:70, `return (C.IsNull()) ? 0 : myMap.Add(C)`), so a null
+            // here does not crash: it is silently dropped, and Write() then emits a set with
+            // fewer curves than the caller passed. Curve3D.serializeCurves/deserializeCurves is
+            // a round trip, so that is a silent truncation, and the surviving indices no longer
+            // match the input array. Refusing the batch is what the siblings already do (#618).
+            if (!c || c->curve.IsNull()) return nullptr;
             cs.Add(c->curve);
         }
         std::ostringstream oss;

--- a/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
@@ -1074,6 +1074,7 @@ OCCTCurve3DRef _Nullable OCCTProjLibProjectOnSurface(OCCTCurve3DRef curve, doubl
     try {
         auto* c = (OCCTCurve3D*)curve;
         auto* s = (OCCTSurface*)surface;
+        if (!c || c->curve.IsNull() || !s || s->surface.IsNull()) return nullptr;
         Handle(GeomAdaptor_Surface) as = new GeomAdaptor_Surface(s->surface);
         Handle(Geom_TrimmedCurve) trimmed = new Geom_TrimmedCurve(c->curve, uFirst, uLast);
         Handle(GeomAdaptor_Curve) ac = new GeomAdaptor_Curve(trimmed);

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -2538,6 +2538,7 @@ bool OCCTLocalAnalysisSurfaceContinuity(OCCTSurfaceRef _Nonnull surface1, double
     try {
         auto s1 = (OCCTSurface*)surface1;
         auto s2 = (OCCTSurface*)surface2;
+        if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull()) return false;
 
         const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
         const int32_t measured = occtAnalysisMeasuredMask(effective);
@@ -2562,6 +2563,7 @@ int32_t OCCTLocalAnalysisSurfaceContinuityFlags(OCCTSurfaceRef _Nonnull surface1
     try {
         auto s1 = (OCCTSurface*)surface1;
         auto s2 = (OCCTSurface*)surface2;
+        if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull()) return 0;
 
         const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
         const int32_t measured = occtAnalysisMeasuredMask(effective);
@@ -2680,6 +2682,7 @@ OCCTSurfaceRef OCCTGeomFillNSections(
         NCollection_Sequence<double> paramSeq;
         for (int32_t i = 0; i < count; i++) {
             auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRefs[i]);
+            if (!wrapper || wrapper->curve.IsNull()) return nullptr;
             sections.Append(wrapper->curve);
             paramSeq.Append(params[i]);
         }
@@ -2708,6 +2711,7 @@ void OCCTGeomFillNSectionsInfo(
         NCollection_Sequence<double> paramSeq;
         for (int32_t i = 0; i < count; i++) {
             auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRefs[i]);
+            if (!wrapper || wrapper->curve.IsNull()) return;
             sections.Append(wrapper->curve);
             paramSeq.Append(params[i]);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,58 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### The null-handle gate was blind to four of the five ways this bridge reaches a handle (#618)
+
+`Scripts/check-null-handle-guards.py` printed "All bridge functions guard the geometry handle as
+well as the wrapper pointer" and exited 0. Its use-detector matched `param->field` and nothing
+else, so every site that reaches the handle through an indirection was invisible to it, and this
+bridge uses four: a cast (`reinterpret_cast<OCCTSurface*>(ref)->surface`, `static_cast`,
+`(OCCTSurface*)ref`), a pointer alias (`auto* s = (OCCTSurface*)surface; ... s->surface`), a
+handle alias (`auto& surf = ...->surface;`, and the by-value `Handle(Geom_Surface) w = ...->surface;`
+copy), and a shared bridge helper. Casts are now normalised away before the walk, aliases are
+followed, and the detector scores 6/6 on fixtures the old one scored 1/6 on.
+
+The fourth form cuts the other way, and is why the fix is not just "teach it the cast spelling"
+(#624/#630's lesson, one issue earlier: a sibling gate that had been taught indirection badly was
+confidently wrong about seven correct entries). `OCCTGeomConvertCurveToAnalytical` and
+`occtSurfToAnaSurfResult` hand their handle to `occtCurveToAnalytical` / `occtSurfaceToAnalytical`,
+both of which open with `if (curve.IsNull()) return false;`: checked, just one call frame away. A
+detector taught forms 1-3 and not form 4 reports both as defects. It now recognises a bridge helper
+that `IsNull()`-checks the parameter it is handed as a guard in its own right.
+
+**54 candidate `(function, argument)` pairs across 39 functions (the old detector found 1), of
+which 20 needed a guard and 34 were cleared by measurement.** The issue's own list of
+seven suspected-unguarded sites was partly wrong, and measuring first is what caught it:
+`OCCTGeomLibToolParameter3D` and `OCCTGeomLibToolParameter2D` reach `GeomLib_Tool::Parameter`,
+which returns `false` on a null handle, and `OCCTApproxSameParameter` reaches
+`Approx_SameParameter`, which raises a catchable `Standard_Failure` the function's own `catch (...)`
+already turns into the same `false` a guard would return. Three of the seven needed nothing. The
+other four did, along with eleven sites the issue never named.
+
+Guards added to 15 functions (20 `(function, argument)` pairs): `OCCTLocalAnalysisCurveContinuity`
+`{,Flags}`, `OCCTLocalAnalysisSurfaceContinuity{,Flags}`, `OCCTSplitCurve3dContinuity`,
+`OCCTSplitCurve2dContinuity`, `OCCTConvertCurve2dToBezier`, `OCCTSplitSurface{Continuity,Angle,Area}`,
+`OCCTGeomToolsCurve2dSetWrite`, `OCCTGeomToolsSurfaceSetWrite`, `OCCTProjLibProjectOnSurface`,
+`OCCTGeomFillNSections{,Info}`. Each returns the fallback its surrounding `catch (...)` already
+returns. The remaining 34 pairs (24 functions) are recorded in the script's `ALLOWED` table, each
+with the measured reason it does not need one; four of those are not OCCT calls at all
+(`OCCTBRepGraphRepSet*` store
+into a bridge-owned side registry whose *else* branch deliberately stores a null handle to clear
+the slot, and `BRepGraph_EditorView::SetPCurve` documents the null handle as its clear-the-binding
+contract).
+
+`Scripts/repro/556-null-handle-guard-sweep` grew from 35 entry points to 57: the 22 the pre-#618
+walk never reached, so nobody had measured them. 36 of 57 are now uncatchable signals (was 24 of
+35). Along the way: `GeomTools_CurveSet::Add` guards with `return (C.IsNull()) ? 0 : myMap.Add(C)`
+while `GeomTools_Curve2dSet` and `GeomTools_SurfaceSet` contain no `IsNull` anywhere and both
+crash. An upstream inconsistency between three copies of the same writer.
+
+The script also gains `--self-test`, matching `check-bridge-index.py`. It proves both failure
+modes by injection: six fixtures that must be reported (one per indirection form, including the
+plain `param->field` form, so the fix is provably additive) and six that must not (including a
+guard reached only through a by-value `Handle` copy, and one only through the shared helper).
+No public API change; behaviour changes only for inputs no bridge call can currently produce.
+
 #### The index gate was reporting seven correct entries, because it could not read a template helper (#624)
 
 `Scripts/check-bridge-index.py` exited 1 with `0 stale, 7 misfiled`, every one of them on the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,7 +37,7 @@ detector taught forms 1-3 and not form 4 reports both as defects. It now recogni
 that `IsNull()`-checks the parameter it is handed as a guard in its own right.
 
 **54 candidate `(function, argument)` pairs across 39 functions (the old detector found 1), of
-which 20 needed a guard and 34 were cleared by measurement.** The issue's own list of
+which 21 needed a guard and 33 were cleared by measurement.** The issue's own list of
 seven suspected-unguarded sites was partly wrong, and measuring first is what caught it:
 `OCCTGeomLibToolParameter3D` and `OCCTGeomLibToolParameter2D` reach `GeomLib_Tool::Parameter`,
 which returns `false` on a null handle, and `OCCTApproxSameParameter` reaches
@@ -45,17 +45,25 @@ which returns `false` on a null handle, and `OCCTApproxSameParameter` reaches
 already turns into the same `false` a guard would return. Three of the seven needed nothing. The
 other four did, along with eleven sites the issue never named.
 
-Guards added to 15 functions (20 `(function, argument)` pairs): `OCCTLocalAnalysisCurveContinuity`
+Guards added to 16 functions (21 `(function, argument)` pairs): `OCCTLocalAnalysisCurveContinuity`
 `{,Flags}`, `OCCTLocalAnalysisSurfaceContinuity{,Flags}`, `OCCTSplitCurve3dContinuity`,
 `OCCTSplitCurve2dContinuity`, `OCCTConvertCurve2dToBezier`, `OCCTSplitSurface{Continuity,Angle,Area}`,
-`OCCTGeomToolsCurve2dSetWrite`, `OCCTGeomToolsSurfaceSetWrite`, `OCCTProjLibProjectOnSurface`,
+`OCCTGeomTools{Curve,Curve2d,Surface}SetWrite`, `OCCTProjLibProjectOnSurface`,
 `OCCTGeomFillNSections{,Info}`. Each returns the fallback its surrounding `catch (...)` already
-returns. The remaining 34 pairs (24 functions) are recorded in the script's `ALLOWED` table, each
+returns. The remaining 33 pairs (23 functions) are recorded in the script's `ALLOWED` table, each
 with the measured reason it does not need one; four of those are not OCCT calls at all
 (`OCCTBRepGraphRepSet*` store
 into a bridge-owned side registry whose *else* branch deliberately stores a null handle to clear
 the slot, and `BRepGraph_EditorView::SetPCurve` documents the null handle as its clear-the-binding
 contract).
+
+`OCCTGeomToolsCurveSetWrite` is the one guard here that measurement did *not* demand:
+`GeomTools_CurveSet::Add` guards its own handle, so a null cannot crash it. It is guarded anyway
+because the alternative was worse than noise. `Add` silently drops the null, `Write()` then emits a
+set with fewer curves than the caller passed, and `Curve3D.serializeCurves`/`deserializeCurves` is a
+round trip, so the surviving indices stop matching the input array. Guarding it also keeps the three
+identical `GeomTools_*SetWrite` writers from diverging three ways on null handling, which is the
+divergence shape this audit exists to remove.
 
 `Scripts/repro/556-null-handle-guard-sweep` grew from 35 entry points to 57: the 22 the pre-#618
 walk never reached, so nobody had measured them. 36 of 57 are now uncatchable signals (was 24 of


### PR DESCRIPTION
Closes #618

`Scripts/check-null-handle-guards.py` printed "All bridge functions guard the geometry handle as
well as the wrapper pointer" and exited 0. Its use-detector matched `param->field` and nothing
else, so every site reaching the handle through an indirection was invisible to it, and this bridge
uses **four**, not the one the issue names.

## The five ways this bridge reaches a handle

| # | form | example in the tree | old detector |
|---|---|---|---|
| 0 | direct | `curve->curve` | sees it |
| 1 | named cast | `reinterpret_cast<OCCTSurface*>(surfaceRef)->surface`, `static_cast<...>` | blind |
| 2 | C-style cast + pointer alias | `auto* s = (OCCTSurface*)surface; ... s->surface` | blind |
| 3 | handle alias | `auto& surf = ...->surface;` and the by-value `Handle(Geom_Surface) w = wrapper->surface;` copy | blind |
| 4 | shared bridge helper | `occtSurfaceToAnalytical(reinterpret_cast<OCCTSurface*>(ref)->surface, ...)` | blind |

Casts are now normalised away (position-preserving, so line numbers are unchanged) before the walk,
and aliases are followed to a fixpoint. Forms 1-3 were hiding unguarded sites.

**Form 4 cuts the other way, and is why "teach it the cast spelling" would have been the wrong
fix.** `OCCTGeomConvertCurveToAnalytical` and `occtSurfToAnaSurfResult` hand their handle to
`occtCurveToAnalytical` / `occtSurfaceToAnalytical` (`OCCTBridge_Internal.h:1591`, `:1620`), both of
which open with `if (curve.IsNull()) return false;`. Checked, one call frame away. A detector taught
1-3 and not 4 reports both as defects, which is exactly #624/#630 one issue earlier: a sibling gate
taught indirection badly was confidently wrong about seven correct entries. The detector now
recognises a bridge helper that `IsNull()`-checks the parameter it is handed as a guard in its own
right, and the self-test pins that case.

## Before / after

Before (`origin/refactor/381-pass1b`):

```
$ python3 Scripts/check-null-handle-guards.py; echo "exit=$?"
All bridge functions guard the geometry handle as well as the wrapper pointer.
exit=0
$ python3 Scripts/check-null-handle-guards.py --self-test; echo "exit=$?"
All bridge functions guard the geometry handle as well as the wrapper pointer.   # flag ignored
exit=0
```

With the corrected detector, before any guard was added: **54 `(function, argument)` pairs across 39 functions**, against the old detector's **1**. After measurement and the 21 guards:

```
$ python3 Scripts/check-null-handle-guards.py; echo "exit=$?"
All bridge functions guard the geometry handle as well as the wrapper pointer.
(23 site(s) exempt by name in ALLOWED, each with its reason.)
exit=0
$ python3 Scripts/check-null-handle-guards.py --self-test; echo "exit=$?"
12/12 cases correct
exit=0
```

It exits 0 legitimately now: every one of the 54 was adjudicated, not suppressed.

## Per-site measurement

Every candidate was treated as a candidate, per #556's method, and measured against the OCCT entry
point it actually reaches. `Scripts/repro/556-null-handle-guard-sweep/repro_556.mm` grew from 35
probes to 57, the 22 the pre-#618 walk never reached and nobody had measured. Each probe runs the
bridge function's real sequence (`Init` **and** `Perform`), because the crash need not land on the
first call.

### Needed a guard: 21 pairs, 16 functions

| bridge function | OCCT entry point | null handle | fallback added |
|---|---|---|---|
| `OCCTLocalAnalysisCurveContinuity` (x2 args) | `LocalAnalysis_CurveContinuity` ctor | SIGSEGV | `false` |
| `OCCTLocalAnalysisCurveContinuityFlags` (x2) | `LocalAnalysis_CurveContinuity` ctor | SIGSEGV | `0` |
| `OCCTLocalAnalysisSurfaceContinuity` (x2) | `LocalAnalysis_SurfaceContinuity` ctor | SIGSEGV | `false` |
| `OCCTLocalAnalysisSurfaceContinuityFlags` (x2) | `LocalAnalysis_SurfaceContinuity` ctor | SIGSEGV | `0` |
| `OCCTSplitCurve3dContinuity` | `ShapeUpgrade_SplitCurve3dContinuity` `Init`+`Perform` | SIGSEGV | `0` |
| `OCCTSplitCurve2dContinuity` | `ShapeUpgrade_SplitCurve2dContinuity` `Init`+`Perform` | SIGSEGV | `0` |
| `OCCTConvertCurve2dToBezier` | `ShapeUpgrade_ConvertCurve2dToBezier` `Init`+`Perform` | SIGSEGV | `0` |
| `OCCTSplitSurfaceContinuity` | `ShapeUpgrade_SplitSurfaceContinuity` `Init`+`Perform` | SIGSEGV | `0` |
| `OCCTSplitSurfaceAngle` | `ShapeUpgrade_SplitSurfaceAngle` `Init`+`Perform` | SIGSEGV | `0` |
| `OCCTSplitSurfaceArea` | `ShapeUpgrade_SplitSurfaceArea` `Init`+`Perform` | SIGSEGV | `0` |
| `OCCTGeomToolsCurve2dSetWrite` | `GeomTools_Curve2dSet::Add` + `Write` | SIGSEGV | `nullptr` |
| `OCCTGeomToolsCurveSetWrite` | `GeomTools_CurveSet::Add` + `Write` | returns, guards internally | `nullptr`, and not for crash-safety: see below |
| `OCCTGeomToolsSurfaceSetWrite` | `GeomTools_SurfaceSet::Add` + `Write` | SIGSEGV | `nullptr` |
| `OCCTGeomFillNSections` | `GeomFill_NSections` + `ComputeSurface` | SIGSEGV | `nullptr` |
| `OCCTGeomFillNSectionsInfo` | `GeomFill_NSections` + `SectionShape` | SIGSEGV | `return;` |
| `OCCTProjLibProjectOnSurface` (x2) | `new Geom_TrimmedCurve` (the curve arg) | SIGSEGV | `nullptr` |

### Cleared by measurement: 33 pairs, 23 functions, now in `ALLOWED` with the reason

| bridge function(s) | OCCT entry point | null handle | why no guard |
|---|---|---|---|
| `OCCTGeomLibToolParameter3D`, `...2D` | `GeomLib_Tool::Parameter` | returns `false` | copes |
| `OCCTGeomLibToolParametersSurface` | `GeomLib_Tool::Parameters` | returns `false` | copes |
| `OCCTGeomConvertIsCanonical` | `GeomConvert_SurfToAnaSurf::IsCanonical` | returns | copes |
| `OCCTApproxSameParameter` (x3) | `Approx_SameParameter` ctor | `Standard_Failure`, all four argument combinations | own `catch (...)` |
| `OCCTExtremaExtCC`, `...CCPoint`, `...CS`, `...CSPoint`, `...LocateExtCC` (x8) | `GeomAdaptor_Curve` / `GeomAdaptor_Surface` | `Standard_Failure` | own `catch (...)` |
| `OCCTExtremaExtPS`, `...PSPoint`, `...ExtSS`, `...SSPoint` (x6) | `GeomAdaptor_Surface` | `Standard_Failure` | own `catch (...)` |
| `OCCTExtremaLocateExtCC2d` (x2) | `Geom2dAdaptor_Curve` | `Standard_Failure` | own `catch (...)` |
| `OCCTGeom2dConvertApproxArcsSegments` | `Geom2dConvert_ApproxArcsSegments` | `Standard_Failure` | own `catch (...)` |
| `OCCTGeomLibIsPlanarSurface`, `OCCTGeomLibPlanarSurfacePlane` | `GeomLib_IsPlanarSurface` ctor | `Standard_Failure` | own `catch (...)` |
| `OCCTBRepGraphRepSetSurface`, `...Curve3D`, `...Curve2D` | none | n/a | not an OCCT call: stores into a bridge-owned side registry whose *else* branch deliberately stores a null handle to clear the slot |
| `OCCTBRepGraphCoEdgeSetPCurve` | `BRepGraph_EditorView::SetPCurve` | n/a | the header documents null as the contract: *"Pass a null handle to clear the stored PCurve binding"* |
| `makeQualifiedCurve` | `Geom2dAdaptor_Curve` | n/a | pre-existing entry; returns by value, no null-safe fallback. Re-verified: all 9 callers check both pointer and handle first |

Handled by rule rather than by allowlist, since the guard genuinely exists:
`OCCTGeomConvertCurveToAnalytical` and `occtSurfToAnaSurfResult` (form 4 above).

## Was the issue's premise right? Partly, and the wrong part is the useful part

The issue named seven suspected-unguarded sites. **Three of the seven needed nothing:**

- `OCCTGeomLibToolParameter3D` and `OCCTGeomLibToolParameter2D` reach `GeomLib_Tool::Parameter`,
  which **returns `false`** on a null handle.
- `OCCTApproxSameParameter` reaches `Approx_SameParameter`, which raises a catchable
  `Standard_Failure`. The function's own `catch (...) { return false; }` already produces exactly
  the value a guard would.

The issue was right that these were unmeasured, and right that the detector was blind. It was wrong
that all seven were defects. Measuring first is what caught it: three guards that would have been
noise. The other four were real, and **eleven more the issue never named** were real too, which is
the other half of the same point. A list produced by a blind scanner is short in both directions.

## One upstream inconsistency found on the way

The three `GeomTools_*Set` writers are the same code three times and do not behave the same way.
`GeomTools_CurveSet::Add` opens `return (C.IsNull()) ? 0 : myMap.Add(C);` so a null 3D curve is
dropped. `GeomTools_Curve2dSet.cxx` and `GeomTools_SurfaceSet.cxx` contain no `IsNull` at all, and
both crash. Guarded bridge-side here; not filed upstream (no OCCT change in this PR).

## Self-test coverage: does it cover both failure modes? Yes, each proved by injection

`--self-test` runs 12 fixtures through the real `unguarded_sites()`.

**Six that must be reported**, one per indirection form. Run against the *old* detector they score
**1/6**, catching only the plain form:

```
MISSED    reinterpret_cast straight into OCCT
MISSED    handle alias bound through a cast
MISSED    pointer alias through a C-style cast
MISSED    static_cast spelling
MISSED    array element through a cast
reported  plain param->field, no indirection
```

The plain form is deliberately kept in the set so the fix is provably **additive**, not a
replacement.

**Six that must not be reported**, which is the failure mode #630 was: plain two-condition opener;
guarded through the handle alias; guarded through a by-value `Handle` copy; guarded through the
pointer alias; `DownCast` is not a use; and guarded by the bridge helper it is passed to. Drop the
helper rule and that last one flips to `FALSE` (verified: removing it surfaces exactly the two
analytical sites and nothing else).

## Post-review changes

Review of #641 was independent rather than confirmatory, and two things came back that changed the
diff. Both are recorded here because they are corrections to my own claims.

**The `Approx_SameParameter` clearance was thinner than the conclusion it supported.** That function
takes three handles and I cleared it on a single all-three-null probe, which only shows the all-null
case survives. `repro_556.mm` now probes each argument null with the other two valid. All four
combinations raise the same catchable `Standard_Failure`, so the verdict stands and the evidence now
covers it. The general rule: a multi-argument site needs per-argument probes.

**`OCCTGeomToolsCurveSetWrite` is now guarded too, and measurement did not demand it.**
`GeomTools_CurveSet::Add` guards its own handle, so a null cannot crash it. But this PR had guarded
its two siblings, leaving a three-way split in one family: two refuse the batch, the third silently
drops the null. `Write()` then emits fewer curves than the caller passed, and
`Curve3D.serializeCurves`/`deserializeCurves` is a round trip, so that is a silent truncation whose
surviving indices no longer match the input array. Guarding it is the safer contract and keeps the
family converged, which is what this audit is for. Counts moved with it: 20 -> 21 guarded pairs,
15 -> 16 functions, 24 -> 23 `ALLOWED` entries, 34 -> 33 cleared.

**Accuracy-of-record fixes**, the same defect class this batch keeps producing:

- the repro README's #618 section summed to 23 for 22 probes. It is **12** crash, 5 catchable,
  5 return; `new Geom_TrimmedCurve` was double-counted, already probed under #556 as
  `Curve3DTrimmed`. A miscounted census inside a PR about miscounted censuses.
- a stale "none of **the 24** is recoverable" sat two paragraphs under the updated "36 of 57".
- the `OCCTGeom2dConvertApproxArcsSegments` `ALLOWED` reason named the wrong callee: the throw is
  the `Geom2dAdaptor_Curve` built on the preceding line, not `Geom2dConvert_ApproxArcsSegments`.
- `guarding_helpers()`' docstring claimed two helpers qualify in this tree. **Seven** (function,
  argument) pairs across six functions do; only the two analytical ones are load-bearing.
- the printed `want:` hint was a type error for the 4 array-parameter sites (`curveRefs` is a
  pointer to wrappers, so `curveRefs->curve` does not compile). It now names an element.

**The overclaim is withdrawn.** `CLAUDE.md` and the docstring said the bridge uses four indirections
and the checker understands all of them. Four is a fact about this tree, not a closed set. Both now
say the checker handles the four forms present here, and enumerate what it still cannot see:
`(*cast).field`; a reference-to-wrapper alias; an `IsNull()` whose result is discarded or does not
dominate the use; a negated guard; `extern "C"` on the definition line (the `"` falls outside
`FUNC`'s return-type class, hiding the whole function); and a helper guarding only some paths. Plus
one false-positive direction: `Handle(Geom_Curve) w(wrapper->curve);` ctor-init syntax would be
wrongly reported. **None occurs in this tree**, checked rather than assumed, including confirming by
hand that every clearing guard transfers control.

**`ALLOWED`'s own contract is now written down**, in the script and in `CLAUDE.md`: it is keyed
`(file, function)`, with no argument index and no re-validation, so an entry exempts every wrapper
argument of that function and every later change to it. Its only safeguard is living in a tracked
file where an entry has to survive review.

Not taken: `OCCTBridge_ProjLib_NLPlate.mm:1077`'s surface arm is redundant under the new rule
(`GeomAdaptor_Surface` is catchable), but the `!s` half and the curve arm are both required, so
splitting the condition to drop one catchable-only clause would cost clarity for nothing.

## Verification

- `python3 Scripts/check-null-handle-guards.py` exits 0; `--self-test` reports 12/12, exits 0
- `python3 Scripts/check-bridge-index.py` reports `0 stale, 0 misfiled`, exits 0 (unchanged here)
- `swift build` clean
- Bridge edits proved to compile from source, not masked by a stale `OCCTSWIFT_BRIDGE_PREBUILT`
  snapshot, by injecting a deliberate type error into `OCCTBridge_Healing.mm` and confirming the
  build failed on exactly that line

- `repro_556.mm` rebuilt and re-run: 57 probes, **36 uncatchable / 10 catchable / 11 return**
  (was 35 probes, 24 / 5 / 6)

### Tests: which were run, and which were not

Every domain touched by this diff was run, with the exit status taken from `swift test` itself
rather than from a pipe. Final state, both branches, same filters:

| filter | this PR | `refactor/381-pass1b` |
|---|---|---|
| **the full suite** | **5273 tests / 1394 suites passed**, `exit=0` | reviewer ran 5221 / 1388, `exit=0` |
| `OCCTSurfaceTests\|OCCTAnalysisTests\|OCCTStressTests` | 1390 / 357 **passed**, `exit=0` | not run |
| `OCCTCurveTests\|OCCTGeom2dTests\|OCCTShapeHealingTests\|OCCTIOTests` | 1454 / 355 **passed**, `exit=0` | 1443 / 353 **passed**, `exit=0` |
| `Issue300\|Issue525\|RobustImportProgress\|Cancellation` | 10 / 4 **passed**, `exit=0` | 10 / 4 **passed**, `exit=0` |

Those domains cover every file this PR changes (`OCCTBridge_Curve3D.mm`, `_Geom2d.mm`,
`_Healing.mm`, `_IO.mm`, `_ProjLib_NLPlate.mm`, `_Surface.mm`).

The full suite gap I flagged in the first round is closed: once the machine quietened it ran to
completion on the rebased head, **5273 tests in 1394 suites, `exit=0`**, built from source with
`OCCTSWIFT_BRIDGE_PREBUILT` unset. The reviewer independently ran 5221 / 1388 green on the earlier
head. The base side of the Surface/Analysis/Stress row is still not run.

**Three earlier runs of this branch did fail**, and every failure was in the `#525` / `#300`
cancellation family, so it is worth being explicit that they were chased down rather than waved
away:

| run | machine load | result |
|---|---|---|
| 1 | 7 concurrent suites | `loadSTEP cancelled on the first poll (#525)` + `loadRobust interrupts repair (#300)` |
| 2 | 7 concurrent suites | those two passed; `A caller that cancels once is not re-asked (#525)` failed |
| 3 | moderate | those passed; `loadRobust cancelled during the transfer (#525)` failed |
| 4, 5 | 3 concurrent suites | all pass, `exit=0`, on both filters |

**A different test failed each time, and none reproduces.** A deterministic regression does not
move between runs, and it does not stop happening when the machine quiets down.

The mechanism is the fixture-flake class CLAUDE.md already records for parallel runs: these tests
use fixed, non-unique filenames in the shared system temp directory
(`occt300_robust_repair.step` at `OCCTIOTests.swift:2344`, `occt525_oneshot_cancel.step` at
`:2521`), so concurrent suites clobber each other's files. One failure said so literally:
`.importFailed("Failed to import: /var/folders/.../occt300_robust_repair.step")`.

Independently, **this diff cannot reach any of them.** The only `OCCTBridge_IO.mm` change is inside
`OCCTGeomToolsCurve2dSetWrite` and `OCCTGeomToolsSurfaceSetWrite`, whose only callers anywhere are
`Surface.swift:2515` and `Curve2D.swift:2431`. Nothing on the STEP import or cancellation path
calls either.
- No public API change. Operation counts untouched (the pre-existing 4301-vs-4302 README and
  API_REFERENCE drift is present on `origin/refactor/381-pass1b` too, and is not from this PR)

Docs: `docs/CHANGELOG.md` Unreleased entry; `CLAUDE.md`'s claim corrected (it said 24 of 35 entry
points, and did not say that a guard is only required where the OCCT call actually needs one, nor
that the handle is reachable by four spellings a reader would not grep for);
`Scripts/repro/556-null-handle-guard-sweep/README.md` documents the 22 new entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

