### PR TITLE
fix(#619): a merely tangent-continuous curve was passing a C2 check, and the old CN fast path went quietly dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,304 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,301 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -2931,7 +2931,9 @@ extension Curve2D {
         OCCTCurve2DBSplineIsPeriodic(handle)
     }
 
-    /// BSpline curve continuity (0=C0, 1=C1, 2=C2, 3=C3, 4=CN).
+    /// BSpline curve continuity, as a raw `GeomAbs_Shape` ordinal
+    /// (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`) — so a C2 cubic reports `4`, not `2`.
+    /// `0` if the curve is not a BSpline. Prefer ``ContinuityClass`` (#619).
     public var bsplineContinuity: Int {
         Int(OCCTCurve2DBSplineContinuity(handle))
     }

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -2322,7 +2322,10 @@ extension Curve3D {
         OCCTCurve3DBezierIsPeriodic(handle)
     }
 
-    /// Bezier curve continuity (0=C0, 1=C1, 2=C2, 3=C3, 4=CN).
+    /// Bezier curve continuity, as a raw `GeomAbs_Shape` ordinal
+    /// (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`). A Bezier curve is CN by construction, so
+    /// this is `6`; `0` if the curve is not a Bezier. Prefer ``ContinuityClass`` for a named
+    /// result (#619).
     public var bezierContinuity: Int {
         Int(OCCTCurve3DBezierContinuity(handle))
     }

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -10947,7 +10947,9 @@ extension Surface {
         G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
         continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
         analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against (#619).
+        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+        migrated `< 0` error check can never fire (#619).
         """)
     public var surfaceContinuityOrder: Int { Int(OCCTSurfaceGetContinuity(handle)) }
 
@@ -15489,13 +15491,23 @@ extension Curve3D {
     ///
     /// ``continuity`` is the same `Int` under an honest name if a raw ordinal is genuinely what
     /// you want — but it is the *new* ordinal, so re-check any constant compared against it.
+    ///
+    /// - Important: The retired encoding had an eighth value the tables above do not show. It
+    ///   signalled failure out of band, returning `-1` from its `default:` branch and for a null
+    ///   or unreadable handle. ``continuity`` has no such sentinel: it returns `0` in the same
+    ///   situations, and `0` is an ordinary C0 measurement. A migrated
+    ///   `if continuityOrder < 0 { handleError() }` becomes a branch that can never be taken, and
+    ///   an unreadable curve now reads as a genuinely C0 one. There is no in-band way to tell the
+    ///   two apart; check the handle before asking.
     @available(*, unavailable, message: """
         continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
         G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
         C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
         continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
         analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against (#619).
+        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+        migrated `< 0` error check can never fire (#619).
         """)
     public var continuityOrder: Int { Int(OCCTCurve3DGetContinuity(handle)) }
 
@@ -15554,7 +15566,9 @@ extension Curve2D {
         C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
         continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
         analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against (#619).
+        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+        migrated `< 0` error check can never fire (#619).
         """)
     public var continuityOrder: Int { Int(OCCTCurve2DGetContinuity(handle)) }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -9360,6 +9360,13 @@ extension Curve3D {
     /// print(bspline.continuity)        // 2
     /// print(bspline.continuityClass)   // .c1
     /// ```
+    ///
+    /// - Warning: This is the migration target for the retired `continuityOrder`, but it is not a
+    ///   drop-in one: `continuityOrder` used to answer a different set of numbers
+    ///   (`C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3`). A threshold moved across unchanged
+    ///   reads as one class too low — `>= 2` accepts C1 here and accepted C2 there — and `== 99`
+    ///   is now unreachable. Prefer ``continuityClass`` and ``ContinuityClass/satisfies(_:)``,
+    ///   which cannot be compared against the wrong constant at all (#619).
     public var continuity: Int {
         Int(OCCTCurve3DGetContinuity(handle))
     }
@@ -9383,6 +9390,9 @@ extension Curve2D {
     ///
     /// The ordinals are `GeomAbs_Shape`'s own declared order — `0=C0, 1=G1, 2=C1, 3=G2,
     /// 4=C2, 5=C3, 6=CN` — not a 0/1/2 order. Prefer ``continuityClass``, which names them.
+    ///
+    /// - Warning: The migration target for the retired `continuityOrder`, but not a drop-in one —
+    ///   see ``Curve3D/continuity`` for the constants that shift (#619).
     public var continuity: Int {
         Int(OCCTCurve2DGetContinuity(handle))
     }
@@ -9405,6 +9415,9 @@ extension Surface {
     ///
     /// The ordinals are `GeomAbs_Shape`'s own declared order — `0=C0, 1=G1, 2=C1, 3=G2,
     /// 4=C2, 5=C3, 6=CN` — not a 0/1/2 order. Prefer ``continuityClass``, which names them.
+    ///
+    /// - Warning: The migration target for the retired `surfaceContinuityOrder`, but not a
+    ///   drop-in one — see ``Curve3D/continuity`` for the constants that shift (#619).
     public var continuity: Int {
         Int(OCCTSurfaceGetContinuity(handle))
     }
@@ -10913,15 +10926,29 @@ extension Surface {
         return (uMin, uMax, vMin, vMax)
     }
 
-    /// Measured surface continuity as a raw `GeomAbs_Shape` ordinal. Same value as
-    /// ``continuity``; prefer ``continuityClass``.
+    /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
+    /// underneath it. Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
     ///
-    /// - Warning: The values changed in #485. This used to report a hand-invented encoding
-    ///   (`C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3`) that matched neither `GeomAbs_Shape`
-    ///   nor its own documentation, and disagreed with ``continuity`` on the same surface for
-    ///   every class except C0. It now returns the real ordinal.
-    @available(*, deprecated, renamed: "continuityClass",
-               message: "Raw values changed in #485: this reported a hand-invented encoding (CN=99, G1=-2). Use continuityClass, or continuity for the raw GeomAbs_Shape ordinal.")
+    /// Same retirement, same reasons, as ``Curve3D/continuityOrder``: the pre-#485 encoding was
+    /// `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` and the value is now the real
+    /// `GeomAbs_Shape` ordinal (`C0=0, G1=1, C1=2, G2=3, C2=4, C3=5, CN=6`), so every threshold
+    /// check kept compiling and quietly changed meaning (#619).
+    ///
+    /// ```swift
+    /// // Before: `2` was C2. After: `2` is C1, and an analytic surface answers 6, never 99.
+    /// if surface.surfaceContinuityOrder >= 2 { offsetSafely() }
+    ///
+    /// // Ask it so it cannot drift again:
+    /// if surface.continuityClass.satisfies(.c2) { offsetSafely() }
+    /// ```
+    @available(*, unavailable, message: """
+        surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
+        G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
+        G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+        you compare against (#619).
+        """)
     public var surfaceContinuityOrder: Int { Int(OCCTSurfaceGetContinuity(handle)) }
 
     /// Create a deep copy of this surface.
@@ -15437,15 +15464,39 @@ extension Curve2D {
 
 extension Curve3D {
 
-    /// Measured continuity as a raw `GeomAbs_Shape` ordinal. Same value as ``continuity``;
-    /// prefer ``continuityClass``.
+    /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
+    /// underneath it. Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
     ///
-    /// - Warning: The values changed in #485. This used to report a hand-invented encoding
-    ///   (`C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3`) that matched neither `GeomAbs_Shape`
-    ///   nor its own documentation, and disagreed with ``continuity`` on the same curve for
-    ///   every class except C0. It now returns the real ordinal.
-    @available(*, deprecated, renamed: "continuityClass",
-               message: "Raw values changed in #485: this reported a hand-invented encoding (CN=99, G1=-2). Use continuityClass, or continuity for the raw GeomAbs_Shape ordinal.")
+    /// Until #485 this property answered `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` — a
+    /// scheme of OCCTSwift's own invention that matched neither `GeomAbs_Shape` nor its own doc
+    /// comment, and disagreed with ``continuity`` on the same curve for every class except C0.
+    /// #485 replaced it with the real `GeomAbs_Shape` ordinal (`C0=0, G1=1, C1=2, G2=3, C2=4,
+    /// C3=5, CN=6`).
+    ///
+    /// Every existing threshold check kept compiling across that change and quietly changed
+    /// meaning, which is why the spelling is retired rather than reinterpreted (#619):
+    ///
+    /// ```swift
+    /// // Before: `2` was C2. After: `2` is C1, so a merely tangent-continuous curve passed.
+    /// if curve.continuityOrder >= 2 { useAsC2Spline() }
+    ///
+    /// // The question that idiom meant to ask, asked so it cannot drift again:
+    /// if curve.continuityClass.satisfies(.c2) { useAsC2Spline() }
+    ///
+    /// // And the old `== 99` fast path for analytic geometry, which can never fire again:
+    /// if curve.continuityClass == .cN { useAnalyticFastPath() }
+    /// ```
+    ///
+    /// ``continuity`` is the same `Int` under an honest name if a raw ordinal is genuinely what
+    /// you want — but it is the *new* ordinal, so re-check any constant compared against it.
+    @available(*, unavailable, message: """
+        continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
+        G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
+        C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+        you compare against (#619).
+        """)
     public var continuityOrder: Int { Int(OCCTCurve3DGetContinuity(handle)) }
 
     /// Check if this curve has at least Cn continuity.
@@ -15482,15 +15533,29 @@ extension Curve3D {
 
 extension Curve2D {
 
-    /// Measured continuity as a raw `GeomAbs_Shape` ordinal. Same value as ``continuity``;
-    /// prefer ``continuityClass``.
+    /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
+    /// underneath it. Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
     ///
-    /// - Warning: The values changed in #485. This used to report a hand-invented encoding
-    ///   (`C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3`) that matched neither `GeomAbs_Shape`
-    ///   nor its own documentation, and disagreed with ``continuity`` on the same curve for
-    ///   every class except C0. It now returns the real ordinal.
-    @available(*, deprecated, renamed: "continuityClass",
-               message: "Raw values changed in #485: this reported a hand-invented encoding (CN=99, G1=-2). Use continuityClass, or continuity for the raw GeomAbs_Shape ordinal.")
+    /// Same retirement, same reasons, as ``Curve3D/continuityOrder``: the pre-#485 encoding was
+    /// `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` and the value is now the real
+    /// `GeomAbs_Shape` ordinal (`C0=0, G1=1, C1=2, G2=3, C2=4, C3=5, CN=6`), so every threshold
+    /// check kept compiling and quietly changed meaning (#619).
+    ///
+    /// ```swift
+    /// // Before: `2` was C2. After: `2` is C1.
+    /// if pcurve.continuityOrder >= 2 { treatAsC2() }
+    ///
+    /// // Ask it so it cannot drift again:
+    /// if pcurve.continuityClass.satisfies(.c2) { treatAsC2() }
+    /// ```
+    @available(*, unavailable, message: """
+        continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
+        G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
+        C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+        you compare against (#619).
+        """)
     public var continuityOrder: Int { Int(OCCTCurve2DGetContinuity(handle)) }
 
     /// Check if this curve has at least Cn continuity.

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -3072,7 +3072,9 @@ extension Surface {
         OCCTSurfaceBezierIsVPeriodic(handle)
     }
 
-    /// Bezier surface continuity (0=C0, 1=C1, 2=C2, 3=C3, 4=CN).
+    /// Bezier surface continuity, as a raw `GeomAbs_Shape` ordinal
+    /// (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`). A Bezier surface is CN by construction, so
+    /// this is `6`; `0` if the surface is not a Bezier. Prefer ``ContinuityClass`` (#619).
     public var bezierContinuity: Int {
         Int(OCCTSurfaceBezierContinuity(handle))
     }

--- a/Tests/OCCTCurveTests/Issue485Curve3DContinuityTests.swift
+++ b/Tests/OCCTCurveTests/Issue485Curve3DContinuityTests.swift
@@ -100,35 +100,38 @@ struct Issue485Curve3DContinuityTests {
 
     // MARK: - The divergence itself
 
-    @Test("continuity and continuityOrder agree on the same curve, in every class")
-    @available(*, deprecated, message: "continuityOrder is deprecated; this is the regression guard")
+    // These two originally compared `continuity` against `continuityOrder`, silencing the
+    // deprecation warning with `@available(*, deprecated)` on the test function — which is
+    // exactly what a real caller does, and exactly why a warning was not enough of a signal.
+    // `continuityOrder` is unavailable as of #619, so the substance moved onto the two
+    // properties that survive.
+
+    @Test("continuity and continuityClass agree on the same curve, in every class")
     func bothPropertiesAgree() {
-        // This is the comparison no pre-existing test made. Before the fix it failed for every
-        // fixture below except the C0 one.
+        // This is the comparison no pre-#485 test made. Before that fix the two spellings of
+        // the measured value disagreed for every fixture below except the C0 one.
         var checked = 0
         for curve in [Self.bspline(interiorMultiplicity: 1),
                       Self.bspline(interiorMultiplicity: 2),
                       Self.bspline(interiorMultiplicity: 3),
                       Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
                       Self.offsetOfG1Basis()].compactMap({ $0 }) {
-            #expect(curve.continuity == curve.continuityOrder)
-            #expect(curve.continuityOrder == Int(curve.continuityClass.rawValue))
+            #expect(curve.continuity == Int(curve.continuityClass.rawValue))
             checked += 1
         }
         #expect(checked == 5, "every fixture should build; the G1 one is the fragile member")
     }
 
     @Test("The retired encoding's sentinel values never appear")
-    @available(*, deprecated, message: "continuityOrder is deprecated; this is the regression guard")
     func retiredSentinelValuesAreGone() {
         for curve in [Self.bspline(interiorMultiplicity: 1),
                       Self.bspline(interiorMultiplicity: 2),
                       Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
                       Self.offsetOfG1Basis()].compactMap({ $0 }) {
-            #expect(curve.continuityOrder != 99)     // was CN
-            #expect(curve.continuityOrder != -2)     // was G1
-            #expect(curve.continuityOrder != -3)     // was G2
-            #expect(curve.continuityOrder >= 0 && curve.continuityOrder <= 6)
+            #expect(curve.continuity != 99)     // was CN
+            #expect(curve.continuity != -2)     // was G1
+            #expect(curve.continuity != -3)     // was G2
+            #expect(curve.continuity >= 0 && curve.continuity <= 6)
         }
     }
 }

--- a/Tests/OCCTCurveTests/Issue619ContinuityEncodingTests.swift
+++ b/Tests/OCCTCurveTests/Issue619ContinuityEncodingTests.swift
@@ -37,13 +37,31 @@ struct Issue619ContinuityEncodingTests {
     func analyticCurveReportsCN() {
         // The `continuityOrder == 99` fast path was the issue's second failure: not a wrong
         // answer but silently dead code, because nothing can produce 99 any more.
+        var checked = 0
         for curve in [Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
                       Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10)]
                         .compactMap({ $0 }) {
             #expect(curve.continuityClass == .cN)
             #expect(curve.continuity == 6)
             #expect(curve.continuity != 99)
+            checked += 1
         }
+        #expect(checked == 2, "both analytic fixtures must build, or this passes vacuously")
+    }
+
+    @Test("The sibling raw-ordinal accessors use the same encoding, so CN is 6 there too")
+    func siblingAccessorsUseTheSameOrdinal() {
+        // `bezierContinuity` is a separate `(int32_t)Continuity()` cast on a different OCCT
+        // class, and several reference pages documented it as `4 = CN` — the same wrong table
+        // that let `continuity` and `continuityOrder` disagree. A Bezier is CN by construction.
+        guard let bezier = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(1, 1, 0), SIMD3(2, 0, 0)])
+        else {
+            Issue.record("could not build the Bezier fixture")
+            return
+        }
+        #expect(bezier.bezierContinuity == 6)
+        #expect(bezier.bezierContinuity != 4)
+        #expect(bezier.continuityClass == .cN)
     }
 
     @Test("A C1 spline reports C1 as ordinal 2, not 1")
@@ -115,6 +133,7 @@ struct Issue619ContinuityEncodingTests {
         // Whatever the bridge reports, the two public spellings must name the same thing. If the
         // ordinal were restored to the old scheme, `ContinuityClass(rawValue:)` would fail to
         // decode 99/-2/-3 and fall back to `.c0`, breaking this.
+        var checked = 0
         for curve in [Self.bspline(interiorMultiplicity: 1),
                       Self.bspline(interiorMultiplicity: 2),
                       Self.bspline(interiorMultiplicity: 3),
@@ -122,6 +141,8 @@ struct Issue619ContinuityEncodingTests {
             #expect(curve.continuity == Int(curve.continuityClass.rawValue))
             #expect(ContinuityClass(rawValue: Int32(curve.continuity)) != nil)
             #expect(curve.continuity >= 0 && curve.continuity <= 6)
+            checked += 1
         }
+        #expect(checked == 4, "every fixture must build, or this passes vacuously")
     }
 }

--- a/Tests/OCCTCurveTests/Issue619ContinuityEncodingTests.swift
+++ b/Tests/OCCTCurveTests/Issue619ContinuityEncodingTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #619: `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder`
+/// changed what their numbers *mean* without changing their type or their name.
+///
+/// #485 was right to make them report the real `GeomAbs_Shape` ordinal — the hand-invented
+/// `{C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3}` scheme matched nothing, not even its own doc
+/// comment. What it left behind was a caller-visible hazard with only a *warning* attached: every
+/// `continuityOrder >= n` threshold and every `== 99` analytic fast path kept compiling and
+/// quietly meant something else. #619 retires the spelling outright, so those call sites become
+/// compile errors carrying the migration in the diagnostic.
+///
+/// This suite pins the half a test can reach: the encoding itself against known geometry, and the
+/// two idioms that changed answer. The source break is pinned by the `@available(*, unavailable)`
+/// attribute on the three properties — a test cannot call them, which is the point.
+@Suite("Measured continuity encoding after the retirement (#619)")
+struct Issue619ContinuityEncodingTests {
+
+    /// A cubic BSpline whose interior knot multiplicity sets its measured continuity:
+    /// mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
+    static func bspline(interiorMultiplicity multiplicity: Int32) -> Curve3D? {
+        let poleCount = 4 + Int(multiplicity)
+        let poles = (1...poleCount).map { i in
+            SIMD3<Double>(Double(i), Double(i % 2) * 2.0, 0)
+        }
+        return Curve3D.bspline(poles: poles,
+                               knots: [0.0, 0.5, 1.0],
+                               multiplicities: [4, multiplicity, 4],
+                               degree: 3)
+    }
+
+    // MARK: - The encoding, against geometry whose class is known by construction
+
+    @Test("An analytic curve reports CN as ordinal 6 — the old encoding's 99 is unreachable")
+    func analyticCurveReportsCN() {
+        // The `continuityOrder == 99` fast path was the issue's second failure: not a wrong
+        // answer but silently dead code, because nothing can produce 99 any more.
+        for curve in [Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
+                      Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 10)]
+                        .compactMap({ $0 }) {
+            #expect(curve.continuityClass == .cN)
+            #expect(curve.continuity == 6)
+            #expect(curve.continuity != 99)
+        }
+    }
+
+    @Test("A C1 spline reports C1 as ordinal 2, not 1")
+    func c1SplineReportsOrdinalTwo() {
+        // A doubled interior knot on a cubic drops it from C2 to C1. Under the old encoding this
+        // curve answered 1; it answers 2 now. That single shift is the whole defect: the number
+        // a C1 curve reports is the number a C2 curve used to report.
+        guard let c1 = Self.bspline(interiorMultiplicity: 2) else {
+            Issue.record("could not build the C1 BSpline fixture")
+            return
+        }
+        #expect(c1.continuityClass == .c1)
+        #expect(c1.continuity == 2)
+
+        // ... and the C2 curve, which used to be the one answering 2, now answers 4.
+        guard let c2 = Self.bspline(interiorMultiplicity: 1) else {
+            Issue.record("could not build the C2 BSpline fixture")
+            return
+        }
+        #expect(c2.continuityClass == .c2)
+        #expect(c2.continuity == 4)
+    }
+
+    // MARK: - The failure scenario the issue described
+
+    @Test("A raw threshold of 2 now admits a merely-C1 curve; satisfies(.c2) still refuses it")
+    func rawThresholdAdmitsC1WhereSatisfiesRefuses() {
+        guard let c1 = Self.bspline(interiorMultiplicity: 2) else {
+            Issue.record("could not build the C1 BSpline fixture")
+            return
+        }
+
+        // `if curve.continuityOrder >= 2 { useAsC2Spline() }` — the issue's exact line. Under the
+        // old encoding this was false for a C1 curve (it answered 1). Under the new one the same
+        // comparison is true, and the C1 curve is fed to a path that assumes C2. Asserting the
+        // trap is *live* is what makes this a regression test rather than a restatement.
+        #expect(c1.continuity >= 2)
+
+        // The question that line meant to ask. It is false, as it always should have been.
+        #expect(!c1.continuityClass.satisfies(.c2))
+        #expect(c1.continuityClass.satisfies(.c1))
+
+        // A genuine C2 curve passes both, so the trap is specifically about the C1 case rather
+        // than the floor being unreachable.
+        if let c2 = Self.bspline(interiorMultiplicity: 1) {
+            #expect(c2.continuity >= 2)
+            #expect(c2.continuityClass.satisfies(.c2))
+        }
+    }
+
+    @Test("The two vocabularies' constants do not line up, which is why the raw form drifted")
+    func requestAndResultConstantsDiffer() {
+        // `continuityOrder >= ParametricContinuity.c2.rawValue` was a natural way to write the
+        // check and was always comparing a result ordinal against a request order. They differ
+        // for every class above C0, so no constant carried over correctly.
+        #expect(ContinuityClass.c1.rawValue != ParametricContinuity.c1.rawValue)   // 2 vs 1
+        #expect(ContinuityClass.c2.rawValue != ParametricContinuity.c2.rawValue)   // 4 vs 2
+        #expect(ContinuityClass.c3.rawValue != ParametricContinuity.c3.rawValue)   // 5 vs 3
+        #expect(ContinuityClass.c0.rawValue == ParametricContinuity.c0.rawValue)   // 0, the only match
+
+        // `satisfies(_:)` is the bridge between them and takes the request vocabulary by type,
+        // so the mismatched constant cannot be written at all (#485, #623).
+        #expect(ContinuityClass.c2.satisfies(.c2))
+        #expect(!ContinuityClass.c1.satisfies(.c2))
+    }
+
+    @Test("Every measured class round-trips through the raw ordinal")
+    func measuredClassRoundTripsThroughOrdinal() {
+        // Whatever the bridge reports, the two public spellings must name the same thing. If the
+        // ordinal were restored to the old scheme, `ContinuityClass(rawValue:)` would fail to
+        // decode 99/-2/-3 and fall back to `.c0`, breaking this.
+        for curve in [Self.bspline(interiorMultiplicity: 1),
+                      Self.bspline(interiorMultiplicity: 2),
+                      Self.bspline(interiorMultiplicity: 3),
+                      Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))].compactMap({ $0 }) {
+            #expect(curve.continuity == Int(curve.continuityClass.rawValue))
+            #expect(ContinuityClass(rawValue: Int32(curve.continuity)) != nil)
+            #expect(curve.continuity >= 0 && curve.continuity <= 6)
+        }
+    }
+}

--- a/Tests/OCCTGeom2dTests/Issue485Curve2DContinuityTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue485Curve2DContinuityTests.swift
@@ -71,8 +71,10 @@ struct Issue485Curve2DContinuityTests {
         #expect(g1.continuity == 1)      // the old encoding said -2
     }
 
-    @Test("continuity and continuityOrder agree on the same curve, in every class")
-    @available(*, deprecated, message: "continuityOrder is deprecated; this is the regression guard")
+    // Originally compared `continuity` against `continuityOrder`, silencing the deprecation
+    // warning on the test function. `continuityOrder` is unavailable as of #619; the substance
+    // moved onto the two properties that survive.
+    @Test("continuity and continuityClass agree on the same curve, in every class")
     func bothPropertiesAgree() {
         var checked = 0
         for curve in [Self.bspline(interiorMultiplicity: 1),
@@ -80,10 +82,9 @@ struct Issue485Curve2DContinuityTests {
                       Self.bspline(interiorMultiplicity: 3),
                       Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0)),
                       Self.offsetOfG1Basis()].compactMap({ $0 }) {
-            #expect(curve.continuity == curve.continuityOrder)
-            #expect(curve.continuityOrder == Int(curve.continuityClass.rawValue))
-            #expect(curve.continuityOrder != 99)
-            #expect(curve.continuityOrder != -2)
+            #expect(curve.continuity == Int(curve.continuityClass.rawValue))
+            #expect(curve.continuity != 99)
+            #expect(curve.continuity != -2)
             checked += 1
         }
         #expect(checked == 5)

--- a/Tests/OCCTGeom2dTests/Issue619Curve2DContinuityEncodingTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue619Curve2DContinuityEncodingTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #619, the 2D half. `Curve2D.continuityOrder` changed from the hand-invented
+/// `{C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3}` encoding to the real `GeomAbs_Shape` ordinal
+/// under an unchanged `Int` signature, and is retired as of #619. These pin the encoding the
+/// surviving spellings report, and the threshold that changed answer.
+@Suite("Curve2D measured continuity encoding after the retirement (#619)")
+struct Issue619Curve2DContinuityEncodingTests {
+
+    /// Cubic BSpline whose interior knot multiplicity sets its measured continuity:
+    /// mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
+    static func bspline(interiorMultiplicity multiplicity: Int32) -> Curve2D? {
+        let poleCount = 4 + Int(multiplicity)
+        let poles = (1...poleCount).map { i in
+            SIMD2<Double>(Double(i), Double(i % 2) * 2.0)
+        }
+        return Curve2D.bspline(poles: poles,
+                               knots: [0.0, 0.5, 1.0],
+                               multiplicities: [4, multiplicity, 4],
+                               degree: 3)
+    }
+
+    @Test("An analytic 2D curve reports CN as ordinal 6 — the old encoding's 99 is unreachable")
+    func analyticCurveReportsCN() {
+        guard let segment = Curve2D.segment(from: SIMD2(0, 0), to: SIMD2(10, 0)) else {
+            Issue.record("could not build the segment fixture")
+            return
+        }
+        #expect(segment.continuityClass == .cN)
+        #expect(segment.continuity == 6)
+        #expect(segment.continuity != 99)
+    }
+
+    @Test("A C1 pcurve reports C1 as ordinal 2, not 1")
+    func c1SplineReportsOrdinalTwo() {
+        if let c1 = Self.bspline(interiorMultiplicity: 2) {
+            #expect(c1.continuityClass == .c1)
+            #expect(c1.continuity == 2)
+        }
+        if let c2 = Self.bspline(interiorMultiplicity: 1) {
+            #expect(c2.continuityClass == .c2)
+            #expect(c2.continuity == 4)
+        }
+    }
+
+    @Test("A raw threshold of 2 now admits a merely-C1 pcurve; satisfies(.c2) still refuses it")
+    func rawThresholdAdmitsC1WhereSatisfiesRefuses() {
+        guard let c1 = Self.bspline(interiorMultiplicity: 2) else {
+            Issue.record("could not build the C1 BSpline fixture")
+            return
+        }
+        #expect(c1.continuity >= 2)                       // the trap, still live
+        #expect(!c1.continuityClass.satisfies(.c2))       // the question it meant to ask
+        #expect(c1.continuityClass.satisfies(.c1))
+    }
+}

--- a/Tests/OCCTGeom2dTests/Issue619Curve2DContinuityEncodingTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue619Curve2DContinuityEncodingTests.swift
@@ -35,14 +35,20 @@ struct Issue619Curve2DContinuityEncodingTests {
 
     @Test("A C1 pcurve reports C1 as ordinal 2, not 1")
     func c1SplineReportsOrdinalTwo() {
-        if let c1 = Self.bspline(interiorMultiplicity: 2) {
-            #expect(c1.continuityClass == .c1)
-            #expect(c1.continuity == 2)
+        guard let c1 = Self.bspline(interiorMultiplicity: 2),
+              let c2 = Self.bspline(interiorMultiplicity: 1) else {
+            Issue.record("could not build the BSpline fixtures")
+            return
         }
-        if let c2 = Self.bspline(interiorMultiplicity: 1) {
-            #expect(c2.continuityClass == .c2)
-            #expect(c2.continuity == 4)
-        }
+        #expect(c1.continuityClass == .c1)
+        #expect(c1.continuity == 2)
+        #expect(c2.continuityClass == .c2)
+        #expect(c2.continuity == 4)
+
+        // The same encoding on the separate `bsplineContinuity` accessor, whose reference page
+        // documented a C2 cubic as reporting `2`. It reports 4.
+        #expect(c2.bsplineContinuity == 4)
+        #expect(c2.bsplineContinuity != 2)
     }
 
     @Test("A raw threshold of 2 now admits a merely-C1 pcurve; satisfies(.c2) still refuses it")

--- a/Tests/OCCTSurfaceTests/Issue485SurfaceContinuityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue485SurfaceContinuityTests.swift
@@ -119,18 +119,19 @@ struct Issue485SurfaceContinuityTests {
         }
     }
 
-    @Test("continuity and surfaceContinuityOrder agree on the same surface, in every class")
-    @available(*, deprecated, message: "surfaceContinuityOrder is deprecated; this is the regression guard")
+    // Originally compared `continuity` against `surfaceContinuityOrder`, silencing the
+    // deprecation warning on the test function. `surfaceContinuityOrder` is unavailable as of
+    // #619; the substance moved onto the two properties that survive.
+    @Test("continuity and continuityClass agree on the same surface, in every class")
     func bothPropertiesAgree() {
         var checked = 0
         for surface in [Self.bsplineSurface(interiorMultiplicityU: 1),
                         Self.bsplineSurface(interiorMultiplicityU: 2),
                         Self.bsplineSurface(interiorMultiplicityU: 3),
                         Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))].compactMap({ $0 }) {
-            #expect(surface.continuity == surface.surfaceContinuityOrder)
-            #expect(surface.surfaceContinuityOrder == Int(surface.continuityClass.rawValue))
-            #expect(surface.surfaceContinuityOrder != 99)
-            #expect(surface.surfaceContinuityOrder >= 0 && surface.surfaceContinuityOrder <= 6)
+            #expect(surface.continuity == Int(surface.continuityClass.rawValue))
+            #expect(surface.continuity != 99)
+            #expect(surface.continuity >= 0 && surface.continuity <= 6)
             checked += 1
         }
         #expect(checked == 4)

--- a/Tests/OCCTSurfaceTests/Issue619SurfaceContinuityEncodingTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue619SurfaceContinuityEncodingTests.swift
@@ -26,24 +26,44 @@ struct Issue619SurfaceContinuityEncodingTests {
 
     @Test("An analytic surface reports CN as ordinal 6 — the old encoding's 99 is unreachable")
     func analyticSurfaceReportsCN() {
+        var checked = 0
         for surface in [Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
                         Surface.sphere(center: .zero, radius: 5)].compactMap({ $0 }) {
             #expect(surface.continuityClass == .cN)
             #expect(surface.continuity == 6)
             #expect(surface.continuity != 99)
+            checked += 1
         }
+        #expect(checked == 2, "both analytic fixtures must build, or this passes vacuously")
     }
 
     @Test("A C1 surface reports C1 as ordinal 2, not 1")
     func c1SurfaceReportsOrdinalTwo() {
-        if let c1 = Self.bsplineSurface(interiorMultiplicityU: 2) {
-            #expect(c1.continuityClass == .c1)
-            #expect(c1.continuity == 2)
+        guard let c1 = Self.bsplineSurface(interiorMultiplicityU: 2),
+              let c2 = Self.bsplineSurface(interiorMultiplicityU: 1) else {
+            Issue.record("could not build the BSpline surface fixtures")
+            return
         }
-        if let c2 = Self.bsplineSurface(interiorMultiplicityU: 1) {
-            #expect(c2.continuityClass == .c2)
-            #expect(c2.continuity == 4)
+        #expect(c1.continuityClass == .c1)
+        #expect(c1.continuity == 2)
+        #expect(c2.continuityClass == .c2)
+        #expect(c2.continuity == 4)
+    }
+
+    @Test("The sibling bezierContinuity accessor uses the same encoding, so CN is 6 there too")
+    func bezierContinuityUsesTheSameOrdinal() {
+        // A separate `(int32_t)Continuity()` cast on `Geom_BezierSurface`, documented as
+        // `4 = CN` on its reference page — the same wrong table this issue is about.
+        let poles: [[SIMD3<Double>]] = (0..<3).map { i in
+            (0..<3).map { j in SIMD3<Double>(Double(i), Double(j), Double((i + j) % 2)) }
         }
+        guard let bezier = Surface.bezier(poles: poles) else {
+            Issue.record("could not build the Bezier surface fixture")
+            return
+        }
+        #expect(bezier.bezierContinuity == 6)
+        #expect(bezier.bezierContinuity != 4)
+        #expect(bezier.continuityClass == .cN)
     }
 
     @Test("A raw threshold of 2 now admits a merely-C1 surface; satisfies(.c2) still refuses it")

--- a/Tests/OCCTSurfaceTests/Issue619SurfaceContinuityEncodingTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue619SurfaceContinuityEncodingTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #619, the surface half. `Surface.surfaceContinuityOrder` changed from the hand-invented
+/// `{C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3}` encoding to the real `GeomAbs_Shape` ordinal
+/// under an unchanged `Int` signature, and is retired as of #619. These pin the encoding the
+/// surviving spellings report, and the threshold that changed answer.
+@Suite("Surface measured continuity encoding after the retirement (#619)")
+struct Issue619SurfaceContinuityEncodingTests {
+
+    /// A bicubic BSpline surface whose interior U knot multiplicity drives the measured
+    /// continuity: mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
+    static func bsplineSurface(interiorMultiplicityU multiplicity: Int32) -> Surface? {
+        let uCount = 4 + Int(multiplicity)
+        let poles: [[SIMD3<Double>]] = (1...uCount).map { i in
+            (1...4).map { j in
+                SIMD3<Double>(Double(i), Double(j), Double((i + j) % 2))
+            }
+        }
+        return Surface.bspline(poles: poles,
+                               knotsU: [0.0, 0.5, 1.0], multiplicitiesU: [4, multiplicity, 4],
+                               knotsV: [0.0, 1.0], multiplicitiesV: [4, 4],
+                               degreeU: 3, degreeV: 3)
+    }
+
+    @Test("An analytic surface reports CN as ordinal 6 — the old encoding's 99 is unreachable")
+    func analyticSurfaceReportsCN() {
+        for surface in [Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+                        Surface.sphere(center: .zero, radius: 5)].compactMap({ $0 }) {
+            #expect(surface.continuityClass == .cN)
+            #expect(surface.continuity == 6)
+            #expect(surface.continuity != 99)
+        }
+    }
+
+    @Test("A C1 surface reports C1 as ordinal 2, not 1")
+    func c1SurfaceReportsOrdinalTwo() {
+        if let c1 = Self.bsplineSurface(interiorMultiplicityU: 2) {
+            #expect(c1.continuityClass == .c1)
+            #expect(c1.continuity == 2)
+        }
+        if let c2 = Self.bsplineSurface(interiorMultiplicityU: 1) {
+            #expect(c2.continuityClass == .c2)
+            #expect(c2.continuity == 4)
+        }
+    }
+
+    @Test("A raw threshold of 2 now admits a merely-C1 surface; satisfies(.c2) still refuses it")
+    func rawThresholdAdmitsC1WhereSatisfiesRefuses() {
+        guard let c1 = Self.bsplineSurface(interiorMultiplicityU: 2) else {
+            Issue.record("could not build the C1 BSpline surface fixture")
+            return
+        }
+        #expect(c1.continuity >= 2)                       // the trap, still live
+        #expect(!c1.continuityClass.satisfies(.c2))       // the question it meant to ask
+        #expect(c1.continuityClass.satisfies(.c1))
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,304** | |
+| **Total** | **4,301** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -427,7 +427,7 @@ a map of the major areas, and the `Total` as the count.
 | **Shape Topology Counting** | 3 | faceCount, edgeCount, shapeTypeString |
 | **Curve3D Extras** | 4 | reverse, copy, continuity, continuityClass |
 | **Curve2D Extras** | 4 | reverse, copy, continuity, continuityClass |
-| **Surface Extras** | 3 | parameterBounds, surfaceContinuityOrder (deprecated, #485), copy |
+| **Surface Extras** | 3 | parameterBounds, surfaceContinuityOrder (unavailable, #619), copy |
 | **Math Solvers** | 7 | findRoot, findRootBounded, findRootBisection, solveSystem, minimize (BFGS), minimizePowell, minimizeBrent |
 | **Curve3D Evaluation** | 6 | evalD0, evalD1, evalD2, evalD3, evalBatchD0, evalBatchD1 |
 | **Curve2D Evaluation** | 5 | evalD0, evalD1, evalD2, evalBatchD0, evalBatchD1 |
@@ -484,7 +484,7 @@ a map of the major areas, and the `Total` as the count.
 | **Curve2D Bezier** | 7 | bezierProperties (degree, poleCount, isRational, pole, setPole, setWeight, resolution) |
 | **Curve2D BSpline Extras** | 3 | bsplineSetPeriodic, bsplineWeight, bsplineWeights |
 | **BSplineSurface Extras** | 4 | bsplineResolution, bsplineSetUPeriodic, bsplineSetVPeriodic, bsplineWeight |
-| **Final Cleanup** | 25 | IsCN (curve3D/curve2D/surfaceU/V), ReversedParameter (curve3D/2D), ParametricTransformation, continuityOrder (curve3D/2D, deprecated #485), surface UReversed/VReversed/UReversedParam/VReversedParam, RemoveVKnot, vecCrossMagnitude/CrossSquareMagnitude, dirIsOpposite/IsNormal, BezierResolution (curve3D/surface), MaxDegree (bezierCurve3D/2D/surface, bsplineSurface/curve2D) |
+| **Final Cleanup** | 25 | IsCN (curve3D/curve2D/surfaceU/V), ReversedParameter (curve3D/2D), ParametricTransformation, continuityOrder (curve3D/2D, unavailable #619), surface UReversed/VReversed/UReversedParam/VReversedParam, RemoveVKnot, vecCrossMagnitude/CrossSquareMagnitude, dirIsOpposite/IsNormal, BezierResolution (curve3D/surface), MaxDegree (bezierCurve3D/2D/surface, bsplineSurface/curve2D) |
 | **GLTF Import/Export** | 5 | importGLTF, exportGLTF (GLB/GLTF), documentLoadGLTF, documentWriteGLTF |
 | **FilletBuilder** | 16 | create, addEdge, addEdgeEvolving, build, nbContours, nbEdges, hasResult, badShape, faultyContours, faultyVertices, getRadius, getLength, isConstant, removeEdge, reset |
 | **ChamferBuilder** | 8 | create, addEdge, addEdgeTwoDists, addEdgeDistAngle, build, nbContours, isDistAngle |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -299,10 +299,17 @@ if curve.continuityOrder >= 2 { useAsC2Spline() }
 if curve.continuityOrder == 99 { useAnalyticFastPath() }
 ```
 
-The clearest evidence that a warning was not enough is in this repo: #485's own regression suites
-silenced it with `@available(*, deprecated)` on the test function, which is exactly what a caller
-does. Retiring the spelling turns both lines above into errors that name the old encoding, the new
-one, and the replacement.
+A warning does not stop compilation, and neither outcome above is one a warning prevents: the first
+is a wrong geometric answer produced silently by a build that succeeded, the second is a branch that
+quietly stopped being taken. Retiring the spelling turns both lines into errors that name the old
+encoding, the new one, and the replacement.
+
+**There is no error sentinel any more, and that is its own migration hazard.** The retired encoding
+signalled failure out of band, returning `-1` from its `default:` branch and for a null or
+unreadable handle. `continuity` returns `0` in the same situations, and `0` is an ordinary C0
+measurement. So `if continuityOrder < 0 { handleError() }` migrates to a branch that can never be
+taken, and an unreadable curve now reads as a genuinely C0 one. There is no in-band way to tell them
+apart — check the handle before asking.
 
 Migration — both replacements predate this change and neither is new API:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -265,6 +265,76 @@ plain `param->field` form, so the fix is provably additive) and six that must no
 guard reached only through a by-value `Handle` copy, and one only through the shared helper).
 No public API change; behaviour changes only for inputs no bridge call can currently produce.
 
+#### Breaking: `continuityOrder` is retired, because a warning did not stop the numbers changing underneath it (#619)
+
+**Source-breaking.** `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and
+`Surface.surfaceContinuityOrder` are now `@available(*, unavailable)`. Any use is a compile error
+carrying the migration in the diagnostic.
+
+Nothing about the *values* changes here. They already changed, in #485:
+
+| class | before #485 | now |
+|---|---|---|
+| C0 | 0 | 0 |
+| G1 | −2 | 1 |
+| C1 | 1 | 2 |
+| G2 | −3 | 3 |
+| C2 | 2 | 4 |
+| C3 | 3 | 5 |
+| CN | 99 | 6 |
+
+The old scheme was OCCTSwift's own invention. It matched neither `GeomAbs_Shape` nor its own doc
+comment, and disagreed with the `continuity` property on the same curve for every class except C0.
+Reporting the real ordinal is right and is not reverted.
+
+What #485 could not do with a deprecation attribute is stop the change being silent. The type stayed
+`Int` and the name stayed the same, so every call site kept compiling:
+
+```swift
+// Before: `2` was C2, so this rejected a C1 curve.
+// After:  `2` is C1, so a merely tangent-continuous curve reaches a path assuming curvature.
+if curve.continuityOrder >= 2 { useAsC2Spline() }
+
+// And this, the analytic fast path, became unreachable rather than wrong — silently dead code.
+if curve.continuityOrder == 99 { useAnalyticFastPath() }
+```
+
+The clearest evidence that a warning was not enough is in this repo: #485's own regression suites
+silenced it with `@available(*, deprecated)` on the test function, which is exactly what a caller
+does. Retiring the spelling turns both lines above into errors that name the old encoding, the new
+one, and the replacement.
+
+Migration — both replacements predate this change and neither is new API:
+
+```swift
+// A continuity floor. Takes the request vocabulary by type, so the mismatched
+// constant cannot be written at all.
+if curve.continuityClass.satisfies(.c2) { useAsC2Spline() }
+
+// The analytic fast path.
+if curve.continuityClass == .cN { useAnalyticFastPath() }
+
+// A raw ordinal, if that is genuinely what you want — but it is the *new*
+// ordinal, so re-check the constant you compare against.
+let ordinal = curve.continuity
+```
+
+`continuity` is unchanged in value: it read the real ordinal before the refactor and still does.
+Only its doc comment was wrong, which is what let the two spellings disagree unnoticed.
+
+- **`unavailable` rather than deletion.** The declaration stays so the compiler can explain itself;
+  deleting it outright would say only "has no member `continuityOrder`". Follows
+  `EvolvingFilletEdge.init(edgeIndex:)` (#520), the same response to the same shape of hazard. The
+  operation count drops by 3 (4,301 → 4,299) — `Scripts/count-operations.py` does not count a
+  retired spelling as a wrapped operation, and no new API was added.
+- **Tests:** `Issue619ContinuityEncodingTests` (`OCCTCurveTests`),
+  `Issue619Curve2DContinuityEncodingTests` (`OCCTGeom2dTests`) and
+  `Issue619SurfaceContinuityEncodingTests` (`OCCTSurfaceTests`) pin the encoding against geometry
+  whose class is known by construction, and assert the trap is live: a C1 BSpline satisfies
+  `continuity >= 2` while `continuityClass.satisfies(.c2)` correctly refuses it. The #485 suites had
+  their `continuityOrder` assertions moved onto `continuity`/`continuityClass`.
+- Recorded as a break in [`SEMVER.md`](SEMVER.md).
+
 #### The index gate was reporting seven correct entries, because it could not read a template helper (#624)
 
 `Scripts/check-bridge-index.py` exited 1 with `0 stale, 7 misfiled`, every one of them on the

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -170,6 +170,39 @@ The exception was taken because:
 - **This does not finish the idiom.** `Shape.nbEdges` / `nbVertices` / `nbFaces` still return per-occurrence counts (**24** and **48** on a box against `edgeCount` 12 and `vertexCount` 8) and are filed as **#651**; they are unchanged here, so no caller of them is affected by this entry.
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurements, and to be named in the release notes.
 
+#### Recorded exception: Unreleased, `continuityOrder` is retired rather than reinterpreted (#619)
+
+**Three compile errors, deliberately — this exception is taken to *convert* a silent behaviour change into a break.** Recorded here before the tag is cut:
+
+| Break | What a caller does |
+|---|---|
+| `Curve3D.continuityOrder` is `@available(*, unavailable)` | Replace with `continuityClass.satisfies(_:)` for a floor, `continuityClass == .cN` for the analytic fast path, or `continuity` for a raw ordinal — re-checking the constant compared against |
+| `Curve2D.continuityOrder` likewise | Same |
+| `Surface.surfaceContinuityOrder` likewise | Same |
+
+The values these three reported already changed, in #485, from a hand-invented `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` to the real `GeomAbs_Shape` ordinal `C0=0, G1=1, C1=2, G2=3, C2=4, C3=5, CN=6`. That change was correct and is not reverted. The exception was taken because:
+
+- **A warning was demonstrably not enough.** #485 shipped the encoding change with a deprecation attribute carrying the exact before/after in its `message:`. `if curve.continuityOrder >= 2 { useAsC2Spline() }` still compiled, and `2` went from meaning C2 to meaning C1, so a merely tangent-continuous curve reached a path that assumes curvature continuity. Symmetrically `continuityOrder == 99`, the analytic-geometry fast path, became unreachable — silently dead code rather than a wrong answer. The strongest evidence is in this repo: the #485 regression suites themselves silenced the warning with `@available(*, deprecated)` on the test function, which is exactly what a caller under `-warnings-as-errors` does.
+- **There is no spelling in which both survive.** As with #541 and #568 this is a *value* contract, and Swift cannot overload on return value. But unlike those two, a name is available to attach a diagnostic to, so the break can be made loud instead of silent — which is the whole point of taking it.
+- **Both replacements already exist and neither is new API.** `continuity` (raw ordinal, unchanged in value since before the refactor) and `continuityClass` (named cases, `Comparable`, with `satisfies(_:)`) both predate this change. Nothing was added; the operation count drops by 3, which is `Scripts/count-operations.py` correctly declining to count a retired spelling as a wrapped operation.
+- **`unavailable` rather than deletion**, following `EvolvingFilletEdge.init(edgeIndex:)` (#520): deleting gives `value of type 'Curve3D' has no member 'continuityOrder'`, which says nothing about the encoding. The retained declaration puts the whole migration in the compiler's own error text.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the before/after table, and to be named in the release notes.
+
+#### Recorded exception: Unreleased, `buildCurves3d`'s default tolerance loosens (#498)
+
+**One silent behaviour change, not a compile error.** Recorded here on the #619 sweep, which asked of every "a value changed under an unchanged signature" site whether the change was decided or merely happened:
+
+| Break | What a caller does |
+|---|---|
+| `Shape.buildCurves3d(tolerance:)`'s default moves from `1e-7` to `1e-5`, a 100× loosening | Nothing, unless the tighter curve was being relied on — then pass `tolerance: 1e-7` explicitly. The value is also written onto the rebuilt edge as its tolerance, so a caller who cared about edge tolerance downstream should re-check it |
+
+**Decision: keep `1e-5`.** The alternatives considered were reverting to `1e-7`, and removing the default outright so every caller must choose (the response #541 took for `defeature(faces:tolerance:)`). Both were rejected:
+
+- **`1e-5` is OCCT's own default, and `1e-7` was OCCTSwift's invention.** `BRepLib::BuildCurves3d(const TopoDS_Shape&)` is literally `return BRepLib::BuildCurves3d(S, 1.0e-5);` (`BRepLib.cxx:463`), and `BRepLib::BuildCurve3d`'s header declares `Tolerance = 1.0e-5`. Reverting would restore a number no upstream API asks for.
+- **The old default over-claimed.** OCCT writes this tolerance onto the edge as a floor rather than the deviation actually achieved, so `1e-7` had every rebuilt edge asserting a tightness the approximation may not hold on hard geometry. Measured on a helix, `1e-5` deviates 2.6e-6 and `1e-7` deviates 9.0e-8 — the tighter fit is real, but it costs a pole or two and it is a claim the caller should make deliberately.
+- **Removing the default is disproportionate here.** Unlike the index rebases of #541/#568, the two values do not mean *different things* — both are tolerances, in the same units, ordered the obvious way. A caller reading `1e-5` is not misled about what it is; a caller reading a 0-based index as 1-based is. The break is a precision change, not a semantic one, so a recorded decision plus the doc note is the proportionate response.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release notes.
+
 ### MINOR — `x.y.0`
 
 A minor bump is for additive change. Two routes:

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,7 +17,22 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with six recorded exceptions: [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places, [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return without breaking the build, [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one, also without breaking the build, [#568](#recorded-exception-unreleased-an-unresolvable-sub-shape-index-refuses-the-call-568) makes five more entry points refuse an index they used to skip, and [#613](#recorded-exception-unreleased-the-last-seven-entry-points-join-the-one-sub-shape-enumeration-613) moves the last seven entry points off the per-occurrence walk onto that same enumeration. A seventh was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **nine** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+
+- [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
+- [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
+- [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
+
+The other six change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+
+- [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
+- [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
+- [#568](#recorded-exception-unreleased-an-unresolvable-sub-shape-index-refuses-the-call-568) makes five more entry points refuse an index they used to skip.
+- [#613](#recorded-exception-unreleased-the-last-seven-entry-points-join-the-one-sub-shape-enumeration-613) moves the last seven entry points off the per-occurrence walk onto that same enumeration.
+- [#498](#recorded-exception-unreleased-buildcurves3ds-default-tolerance-loosens-498) loosens `buildCurves3d`'s default tolerance 100×.
+- [#502](#recorded-exception-unreleased-the-wiresshellssolids-enumerations-join-the-deduplicated-map-502) collapses the `wires`/`shells`/`solids` enumerations onto the deduplicated sub-shape map.
+
+A tenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
 
 ## Rules
 
@@ -182,11 +197,30 @@ The exception was taken because:
 
 The values these three reported already changed, in #485, from a hand-invented `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` to the real `GeomAbs_Shape` ordinal `C0=0, G1=1, C1=2, G2=3, C2=4, C3=5, CN=6`. That change was correct and is not reverted. The exception was taken because:
 
-- **A warning was demonstrably not enough.** #485 shipped the encoding change with a deprecation attribute carrying the exact before/after in its `message:`. `if curve.continuityOrder >= 2 { useAsC2Spline() }` still compiled, and `2` went from meaning C2 to meaning C1, so a merely tangent-continuous curve reached a path that assumes curvature continuity. Symmetrically `continuityOrder == 99`, the analytic-geometry fast path, became unreachable — silently dead code rather than a wrong answer. The strongest evidence is in this repo: the #485 regression suites themselves silenced the warning with `@available(*, deprecated)` on the test function, which is exactly what a caller under `-warnings-as-errors` does.
+- **A warning was not enough, because a warning does not stop compilation.** #485 shipped the encoding change with a deprecation attribute carrying the exact before/after in its `message:`, and `if curve.continuityOrder >= 2 { useAsC2Spline() }` still built and still ran. `2` went from meaning C2 to meaning C1, so a merely tangent-continuous curve reached a path that assumes curvature continuity — a wrong geometric answer, produced silently, in a build that succeeded. Symmetrically `continuityOrder == 99`, the analytic-geometry fast path, became unreachable: dead code rather than a wrong answer. Neither outcome is one a warning prevents.
 - **There is no spelling in which both survive.** As with #541 and #568 this is a *value* contract, and Swift cannot overload on return value. But unlike those two, a name is available to attach a diagnostic to, so the break can be made loud instead of silent — which is the whole point of taking it.
 - **Both replacements already exist and neither is new API.** `continuity` (raw ordinal, unchanged in value since before the refactor) and `continuityClass` (named cases, `Comparable`, with `satisfies(_:)`) both predate this change. Nothing was added; the operation count drops by 3, which is `Scripts/count-operations.py` correctly declining to count a retired spelling as a wrapped operation.
 - **`unavailable` rather than deletion**, following `EvolvingFilletEdge.init(edgeIndex:)` (#520): deleting gives `value of type 'Curve3D' has no member 'continuityOrder'`, which says nothing about the encoding. The retained declaration puts the whole migration in the compiler's own error text.
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the before/after table, and to be named in the release notes.
+
+#### Recorded exception: Unreleased, the `wires`/`shells`/`solids` enumerations join the deduplicated map (#502)
+
+**Six silent behaviour changes, none a compile error.** Recorded here on the #619 sweep. #541 recorded the *face* half of the explorer→`TopExp::MapShapes` conversion and #613 the last seven entry points; these six were converted by #502 and documented only in their own `///` comments, never in this file. The criterion for recording is the one this document already applies: a change a consumer can absorb without a diagnostic belongs in the table a consumer reads before upgrading blindly.
+
+| Break | What a caller does |
+|---|---|
+| `Shape.solids` / `solidCount` count *distinct* solids, not occurrences | Nothing on a shape that shares no sub-shape. On one that does, the count is lower and the array shorter — `Shape.compound([box, box]).solidCount` is `1`, and was `2` |
+| `Shape.shells` / `shellCount` likewise | A shell reused by two solids (what `solidFromShells` produces when handed the same shell twice) is now one shell |
+| `Shape.wires` / `wireCount` likewise | A wire used to build two faces counts once, being one wire seen from two parents |
+
+On `origin/main` each of these called its own explorer-backed bridge function (`OCCTShapeGetSolidCount` and siblings, a `TopExp_Explorer` occurrence walk); each is now a named spelling of `subShapeCount(ofType:)` / `subShapes(ofType:)`, which read `TopExp::MapShapes`. `MapShapes` keys on `TopoDS_Shape::IsSame`, which ignores orientation, so duplicate occurrences collapse and the surviving entry carries the first occurrence's orientation.
+
+The exception was taken because:
+
+- **The disagreement is the bug.** These six and `subShapeCount(ofType:)` answered the same question about the same shape with different numbers, neither cross-checked against the other. That is the #502 finding, and it is the same defect class as #541's face indices.
+- **There is no spelling in which both survive.** As with #541 and #568 these are *values*, so Swift cannot overload on them and a deprecation attribute has nothing to attach to.
+- **On every shape that shares no sub-shape, nothing moves** — primitives, booleans, sewn sheets and compsolids are unaffected.
+- Documented in each property's `///` comment; recorded here so the guarantee paragraph above is complete.
 
 #### Recorded exception: Unreleased, `buildCurves3d`'s default tolerance loosens (#498)
 

--- a/docs/reference/BRepGraph.md
+++ b/docs/reference/BRepGraph.md
@@ -937,7 +937,7 @@ Get the maximum continuity order of an edge (as `GeomAbs_Shape` raw int).
 public func edgeMaxContinuity(_ edgeIndex: Int) -> Int
 ```
 
-Returns the `GeomAbs_Shape` continuity enum raw value (0 = C0, 1 = C1, 2 = C2, …). Currently returns `0` always — `BRepGraph_LayerRegularity` is unavailable in OCCT 8.0.0 p1 due to an upstream header bug. Use `Shape.maxContinuity` (`BRep_Tool::MaxContinuity`) as an alternative.
+Returns the `GeomAbs_Shape` continuity enum raw value (`0` = C0, `1` = G1, `2` = C1, `3` = G2, `4` = C2, `5` = C3, `6` = CN). Currently returns `0` always — `BRepGraph_LayerRegularity` is unavailable in OCCT 8.0.0 p1 due to an upstream header bug. Use `Shape.maxContinuity` (`BRep_Tool::MaxContinuity`) as an alternative.
 
 - **Parameters:** `edgeIndex` — zero-based edge index.
 - **Note:** Always returns 0 in OCCT 8.0.0 p1 — `BRepGraph_LayerRegularity` does not compile/link. Use `Shape.maxContinuity` instead.

--- a/docs/reference/Curve2D-Analytic-Types.md
+++ b/docs/reference/Curve2D-Analytic-Types.md
@@ -1090,11 +1090,11 @@ The global geometric continuity of the BSpline.
 public var bsplineContinuity: Int { get }
 ```
 
-- **Returns:** Integer code: `0` = C0, `1` = C1, `2` = C2, `3` = C3, `4` = CN; `0` if not a BSpline.
+- **Returns:** a raw `GeomAbs_Shape` ordinal (`0` = C0, `1` = G1, `2` = C1, `3` = G2, `4` = C2, `5` = C3, `6` = CN); `0` if not a BSpline.
 - **OCCT:** `Geom2d_BSplineCurve::Continuity`.
 - **Example:**
   ```swift
-  let cont = curve.bsplineContinuity  // typically 2 (C2) for cubic B-splines
+  let cont = curve.bsplineContinuity  // typically 4 (C2) for cubic B-splines
   ```
 
 ---

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -1121,19 +1121,19 @@ Bézier curves are never periodic in OCCT; this always returns `false` for `Geom
 
 ### `bezierContinuity`
 
-The global continuity class of the Bézier curve (0 = C0, 1 = C1, 2 = C2, 3 = C3, 4 = CN).
+The global continuity class of the Bézier curve, as a raw `GeomAbs_Shape` ordinal (`0` = C0, `1` = G1, `2` = C1, `3` = G2, `4` = C2, `5` = C3, `6` = CN).
 
 ```swift
 public var bezierContinuity: Int { get }
 ```
 
-A Bézier curve of degree ≥ 1 is always C∞ (returns `4` = CN). Returns `0` for non-Bézier curves.
+A Bézier curve of degree ≥ 1 is always C∞ (returns `6` = CN). Returns `0` for non-Bézier curves.
 
 - **OCCT:** `Geom_BezierCurve::Continuity` → `GeomAbs_Shape` mapped to Int.
 - **Example:**
   ```swift
   if let curve = Curve3D.bezier(poles: [SIMD3(0,0,0), SIMD3(1,1,0), SIMD3(2,0,0)]) {
-      let cont = curve.bezierContinuity  // 4 (CN)
+      let cont = curve.bezierContinuity  // 6 (CN)
   }
   ```
 

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -251,11 +251,24 @@ public var hashCode: Int
 
 ## Curve3D/Curve2D/Surface Continuity
 
-Continuity integer accessors added to `Curve3D`, `Curve2D`, and `Surface` (v0.106.0). The integer encodes the `GeomAbs_Shape` enum: 0 = C0, 1 = C1, 2 = C2, 3 = C3, 4 = CN, 5 = G1, 6 = G2.
+Continuity integer accessors added to `Curve3D`, `Curve2D`, and `Surface` (v0.106.0). The integer is
+a raw `GeomAbs_Shape` ordinal, in that enum's own declared order, which interleaves the geometric
+classes with the parametric ones:
+
+| ordinal | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|---|
+| class | C0 | G1 | C1 | G2 | C2 | C3 | CN |
+
+> This page previously documented the encoding as `0 = C0, 1 = C1, 2 = C2, 3 = C3, 4 = CN, 5 = G1,
+> 6 = G2`. That was never what a `static_cast` of `GeomAbs_Shape` produces — it was a copy of the
+> incorrect doc comment that let `continuity` and the retired `continuityOrder` disagree unnoticed
+> until #485. Prefer `continuityClass`, which names the cases, and `continuityClass.satisfies(_:)`
+> for a continuity floor; a raw ordinal compared against a hand-written constant is the defect
+> #619 was filed about.
 
 ### `Curve3D.continuity`
 
-Global geometric continuity of the 3D curve.
+Global geometric continuity of the 3D curve, as a raw `GeomAbs_Shape` ordinal.
 
 ```swift
 public var continuity: Int
@@ -264,8 +277,9 @@ public var continuity: Int
 - **OCCT:** `Geom_Curve::Continuity`.
 - **Example:**
   ```swift
-  if let c = Curve3D.makeCircle(center: .zero, normal: SIMD3(0,0,1), radius: 5) {
-      print(c.continuity) // 4 (CN — infinitely differentiable)
+  if let c = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+      print(c.continuity)        // 6 — CN, infinitely differentiable
+      print(c.continuityClass)   // .cN
   }
   ```
 
@@ -273,7 +287,7 @@ public var continuity: Int
 
 ### `Curve2D.continuity`
 
-Global geometric continuity of the 2D curve.
+Global geometric continuity of the 2D curve, as a raw `GeomAbs_Shape` ordinal (see the table above).
 
 ```swift
 public var continuity: Int
@@ -285,7 +299,7 @@ public var continuity: Int
 
 ### `Surface.continuity`
 
-Global geometric continuity of the surface.
+Global geometric continuity of the surface, as a raw `GeomAbs_Shape` ordinal (see the table above).
 
 ```swift
 public var continuity: Int

--- a/docs/reference/Document-Builders-Fillet.md
+++ b/docs/reference/Document-Builders-Fillet.md
@@ -33,18 +33,33 @@ mappings, parametric-transformation scale factors, and Bezier/BSpline static lim
 
 ### `Curve3D.continuityOrder`
 
-**Deprecated** (#485) — use `continuityClass`. Measured continuity as a raw `GeomAbs_Shape`
-ordinal (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`), identical to `continuity`.
+**Unavailable** (#619) — use `continuityClass`, or `continuity` for a raw ordinal. Any use is a
+compile error.
 
 ```swift
-@available(*, deprecated, renamed: "continuityClass")
+@available(*, unavailable, message: "...")
 public var continuityOrder: Int { get }
 ```
 
-- **Warning:** the raw values changed in #485. This previously reported a hand-invented
-  encoding (`C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3`) that matched neither `GeomAbs_Shape`
-  nor its own documentation, and disagreed with `continuity` on the same curve for every class
-  except C0.
+The values this reported changed in #485, from a hand-invented `C0=0, C1=1, C2=2, C3=3, CN=99,
+G1=-2, G2=-3` — matching neither `GeomAbs_Shape` nor its own documentation, and disagreeing with
+`continuity` on the same curve for every class except C0 — to the real ordinal `0=C0, 1=G1, 2=C1,
+3=G2, 4=C2, 5=C3, 6=CN`. The type and name were unchanged, so `continuityOrder >= 2` kept compiling
+and went from meaning "at least C2" to meaning "at least C1", and `continuityOrder == 99` (the
+analytic fast path) became unreachable. #619 retires the spelling so both become errors.
+
+```swift
+// A continuity floor — takes the request vocabulary by type, so the wrong
+// constant cannot be written at all.
+if curve.continuityClass.satisfies(.c2) { useAsC2Spline() }
+
+// The analytic fast path that `== 99` used to express.
+if curve.continuityClass == .cN { useAnalyticFastPath() }
+
+// A raw ordinal, if that is what you want — re-check the constant you compare against.
+let ordinal = curve.continuity
+```
+
 - **OCCT:** `Geom_Curve::Continuity` (via `OCCTCurve3DGetContinuity`).
 
 ---
@@ -125,15 +140,20 @@ public static var bezierMaxDegree: Int { get }
 
 ### `Curve2D.continuityOrder`
 
-**Deprecated** (#485) — use `continuityClass`. Measured continuity as a raw `GeomAbs_Shape`
-ordinal (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`), identical to `continuity`.
+**Unavailable** (#619) — use `continuityClass`, or `continuity` for a raw ordinal. Any use is a
+compile error.
 
 ```swift
-@available(*, deprecated, renamed: "continuityClass")
+@available(*, unavailable, message: "...")
 public var continuityOrder: Int { get }
 ```
 
-- **Warning:** the raw values changed in #485 — see the `Curve3D.continuityOrder` note above.
+```swift
+if pcurve.continuityClass.satisfies(.c2) { treatAsC2() }
+```
+
+- **Warning:** the raw values changed in #485 and the spelling was retired in #619 — see the
+  `Curve3D.continuityOrder` note above for the before/after encoding.
 - **OCCT:** `Geom2d_Curve::Continuity` (via `OCCTCurve2DGetContinuity`).
 
 ---

--- a/docs/reference/Document-Builders-Fillet.md
+++ b/docs/reference/Document-Builders-Fillet.md
@@ -61,6 +61,7 @@ let ordinal = curve.continuity
 ```
 
 - **OCCT:** `Geom_Curve::Continuity` (via `OCCTCurve3DGetContinuity`).
+- **No error sentinel.** The retired encoding returned `-1` for a null or unreadable handle and from its `default:` branch; `continuity` returns `0`, which is an ordinary C0. A migrated `< 0` error check can never fire (#619).
 
 ---
 

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -598,13 +598,30 @@ public var parameterBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Dou
 
 ### `Surface.surfaceContinuityOrder`
 
-Continuity order as an integer: 0=C0, 1=C1, 2=C2, 3=C3, 99=CN.
+**Unavailable** (#619) — use `Surface.continuityClass`, or `Surface.continuity` for a raw ordinal.
+Any use is a compile error.
 
 ```swift
+@available(*, unavailable, message: "...")
 public var surfaceContinuityOrder: Int { get }
 ```
 
-- **OCCT:** `Geom_Surface::Continuity` via `OCCTSurfaceContinuity`.
+This page previously documented the encoding as `0=C0, 1=C1, 2=C2, 3=C3, 99=CN`. That was the
+hand-invented scheme #485 replaced with the real `GeomAbs_Shape` ordinal (`0=C0, 1=G1, 2=C1, 3=G2,
+4=C2, 5=C3, 6=CN`); the page was not updated at the time, so it went on describing retired numbers.
+Because the type and name were unchanged, `surfaceContinuityOrder >= 2` kept compiling and went from
+meaning "at least C2" to meaning "at least C1". #619 retires the spelling so that becomes an error.
+
+```swift
+// A continuity floor — takes the request vocabulary by type, so the wrong
+// constant cannot be written at all.
+if surface.continuityClass.satisfies(.c2) { offsetSafely() }
+
+// The analytic fast path that `== 99` used to express.
+if surface.continuityClass == .cN { useAnalyticFastPath() }
+```
+
+- **OCCT:** `Geom_Surface::Continuity` via `OCCTSurfaceGetContinuity`.
 
 ---
 

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -622,6 +622,7 @@ if surface.continuityClass == .cN { useAnalyticFastPath() }
 ```
 
 - **OCCT:** `Geom_Surface::Continuity` via `OCCTSurfaceGetContinuity`.
+- **No error sentinel.** The retired encoding returned `-1` for a null or unreadable handle and from its `default:` branch; `continuity` returns `0`, which is an ordinary C0. A migrated `< 0` error check can never fire (#619).
 
 ---
 

--- a/docs/reference/Surface-BSpline-Bezier.md
+++ b/docs/reference/Surface-BSpline-Bezier.md
@@ -609,11 +609,11 @@ Continuity class of the Bezier surface.
 public var bezierContinuity: Int { get }
 ```
 
-- **Returns:** Integer code: 0 = C0, 1 = C1, 2 = C2, 3 = C3, 4 = CN. Bezier surfaces are CN by construction (returns 4).
+- **Returns:** a raw `GeomAbs_Shape` ordinal (`0` = C0, `1` = G1, `2` = C1, `3` = G2, `4` = C2, `5` = C3, `6` = CN); `0` if not a Bezier surface. Bezier surfaces are CN by construction, so this returns **6**.
 - **OCCT:** `Geom_BezierSurface::Continuity`.
 - **Example:**
   ```swift
-  let c = surface.bezierContinuity  // 4 (CN)
+  let c = surface.bezierContinuity  // 6 (CN)
   ```
 
 ---


### PR DESCRIPTION
Closes #619

## The old encoding, verified rather than assumed

The issue read it off a diff. Checked against the pre-refactor source
(`git show origin/main:Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`, `OCCTCurve3DContinuity`),
it was a hand-written switch and the issue's table is **correct** — plus an eighth value it omitted:

| class | old (`OCCTCurve3DContinuity`) | now (raw `GeomAbs_Shape`) |
|---|---|---|
| C0 | 0 | 0 |
| G1 | −2 | 1 |
| C1 | 1 | 2 |
| G2 | −3 | 3 |
| C2 | 2 | 4 |
| C3 | 3 | 5 |
| CN | 99 | 6 |
| **null / unreadable** | **−1** | **0 — indistinguishable from a real C0** |

That last row is a migration hazard in its own right, and it now appears in the `unavailable`
message, the `///` docs, CHANGELOG, SEMVER and both reference pages: the old spelling signalled
failure **out of band** as `-1`, while `continuity` returns `0`, which is an ordinary C0. So
`if continuityOrder < 0 { handleError() }` migrates to a branch that can never be taken, and an
unreadable curve reads as a genuinely C0 one. There is no in-band way to tell them apart.

Two corrections to the issue's framing, both found by measurement:

1. **"No existing call site is diagnosed" is not accurate.** At the exact commit the review read
   (`e6d6da3`), all three properties already carried
   `@available(*, deprecated, renamed: "continuityClass", message: "Raw values changed in #485…")`,
   landed by PR #509 on 2026-07-30 — three days before #619 was filed. Callers *were* diagnosed.
2. **The substantive complaint survives that correction intact.** A deprecation is a *warning*, and
   a warning does not stop compilation. `if curve.continuityOrder >= 2 { useAsC2Spline() }` still
   built and still ran, and `2` went from meaning C2 to meaning C1 — a wrong geometric answer,
   produced silently, in a build that succeeded. Symmetrically `continuityOrder == 99` became
   unreachable: dead code rather than a wrong answer. Neither outcome is one a warning prevents.

`Curve3D.continuity` was **not** part of the value change — it read the real ordinal on `origin/main`
too. Only its doc comment was wrong (`0=C0, 1=C1, 2=C2, 3=C3, 4=CN, 5=G1, 6=G2`, which is not what a
`static_cast` of `GeomAbs_Shape` produces), which is what let the two spellings disagree unnoticed.

## The fix

The encoding change is right and is **not reverted**. What was missing is a source-breaking signal,
so the three retired spellings become `@available(*, unavailable)`:

- `Curve3D.continuityOrder`
- `Curve2D.continuityOrder`
- `Surface.surfaceContinuityOrder`

Any use is now a compile error carrying the whole migration in the diagnostic — the old table, the
new table, three migration routes, and the vanished error sentinel.

`unavailable` rather than deletion follows this repo's own precedent for the same hazard shape —
`EvolvingFilletEdge.init(edgeIndex:)` (#520), retired for a 1-based→0-based rebase. Deleting gives
only "has no member `continuityOrder`", which says nothing about the encoding.

Both replacements predate this change; **no new API was added**. `continuityClass` composes with
what #627/#623 just landed — `satisfies(_:)` takes `ParametricContinuity` *by type*, so the
mismatched constant that caused this cannot be written at all.

## The stale-docs sweep (the part the first round got wrong)

The first round fixed `Document-Math-Solvers.md` and stopped. The sweep was incomplete, and what it
missed was the worst possible page: **`docs/reference/Document-BSpline-Extrema.md` documented the
*migration target* `continuity` with the retired encoding** (`0 = C0, 1 = C1, 2 = C2, 3 = C3,
4 = CN, 5 = G1, 6 = G2`) and showed `print(c.continuity) // 4 (CN)` for a circle, where this PR's
own passing test asserts **6**. A caller following the `unavailable` message to `continuity` and
then consulting that page would have written `== 4` for CN and reproduced this exact defect on the
migration path this PR creates.

Swept properly this time (`grep -rn "4 = CN\|4=CN\|4 (CN\|5 = G1\|5=G1" docs/ Sources/OCCTSwift/`)
and fixed every hit. All were raw `(int32_t)Continuity()` casts documented as `4 = CN`:

| Site | Was | Is |
|---|---|---|
| `Document-BSpline-Extrema.md` §Continuity + worked example | `4 = CN`, circle prints `4` | ordinal table, circle prints `6` |
| `Surface-BSpline-Bezier.md:612,616` | `bezierContinuity` "returns 4" | returns `6` |
| `Curve3D-Analytic-Types.md:1124,1130,1136` | Bézier "returns `4` = CN" | returns `6` |
| `Curve2D-Analytic-Types.md:1093,1097` | C2 cubic "typically 2 (C2)" | typically `4` |
| `BRepGraph.md:940` | `0 = C0, 1 = C1, 2 = C2, …` | full ordinal table |
| `Curve3D.swift:2325`, `Surface.swift:3075`, `Curve2D.swift:2934` | `4=CN` in `///` | full ordinal table |

Not taken on trust: two new tests **pin** the claim rather than asserting it in prose —
`siblingAccessorsUseTheSameOrdinal` (Bézier curve) and `bezierContinuityUsesTheSameOrdinal`
(Bézier surface) assert `bezierContinuity == 6 && != 4`, and the 2D suite asserts a C2 cubic's
`bsplineContinuity == 4 && != 2`. All pass.

## `SEMVER.md`'s guarantee paragraph

The intro enumerated the exceptions and had drifted: it counted six (base had added #613) while this
PR adds two more, and it grouped them in a way that hid the break. Rewritten to enumerate **nine**,
split by the only distinction that matters to "is this upgrade safe to take blindly":

- **Three do not compile until the caller acts** — v1.17.0, #495, and now #619.
- **Six change behaviour without breaking the build** — #499, #541, #568, #613, #498, #502.

One correction to the review here: **#619 is not the first Unreleased exception that breaks the
build.** #495 already did — its own section says "One source break, taken under the same terms as
v1.17.0 above", and the #499 section's opening line ("unlike the two exceptions above these are
*not* compile errors") counts v1.17.0 and #495 as the two. The paragraph now says so explicitly
rather than lumping all Unreleased entries together.

## Sibling-site census

The issue named four. All four are real, and a sweep found nine more it did not list.

| # | Site | Verdict | Evidence |
|---|---|---|---|
| 1 | `PathParser.trek/name/fileExtension` → `OSDPath` | **REAL**, partly mitigated | Signatures identical; `"step"`→`".step"`, `"/home/user"`→`"/home/user/"`, `nil`→`".config"`. **Correction from the last round:** only `trek` and `fileExtension` carry an explanatory `message:`; `name(_:)` (`Document.swift:4730`) carries `renamed:` alone, so its format change is undiagnosed in prose. Recorded in SEMVER (#499) |
| 2 | `Shape.swift:6223` → `offsetPerFace(defaultOffset:faceOffsets:…)` | **REAL, and worse than the issue implies** | Swift signature *and body* byte-identical to main. Bridge-side only: `faceIndices[i]` → `faceIndices[i] + 1`, so `faceOffsets` keys went 1-based → 0-based, and an out-of-range key now fails the whole call instead of being skipped. **No diagnostic of any kind.** Recorded in SEMVER under #541 |
| 3 | `OCCTBridge_Internal.h:965` → `occtFilletSetRadiusProfile` range check | **REAL but a different failure mode** | Main passed the profile to `SetRadius` unvalidated; now a non-positive radius, a parameter outside `[0,1]`, or a non-increasing sequence returns `nil`. Converts a *wrong answer* into `nil` — a tightening, where the old behaviour was the defect |
| 4 | `buildCurves3d(tolerance:)` default `1e-7` → `1e-5` | **REAL, confirmed exactly** | Same extension, same body, 100× loosening, no deprecation. See the decision below |

Not listed by the issue, same shape, unchanged public signatures: `Shape.faces()` (explorer →
`TopExp::MapShapes`, collapsing duplicate occurrences and shifting every downstream `Face.index`);
`Shape.wires`/`wireCount`/`shells`/`shellCount`/`solids`/`solidCount` (same mechanism);
`Shape.buildWires(faceIndex:)` (default `0` → `-1` *and* re-based); `Surface.approxWithDetails`
(defaults `.c1,.c1` → `.c2,.c2`, types unchanged); `LawFunction.knotSplitting`/`knotSplitParameters`
(`Int = 2` → `.c1`, so the default-omitting caller asks a different question); `Shape.volume`
(open shells `nil`, intentional, #605/#609); `Shape.signedVolume` (error sentinel `-1.0` → `0`);
`Curve3D.closestParameter(to:)` (sentinel `0` → `.nan`, mitigated); `Curve2D.arcLength(from:to:)`
(rewritten out-of-domain handling, unmitigated).

**Correction from the last round:** I wrote that the `wires`/`shells`/`solids` family was "recorded
in SEMVER under #541". It was not — #541's table lists `faces()`, `adjacentFaces`,
`splitByWireOnFace`, `buildWires`, `offsetPerFace` and the index cluster, and that family was
documented only in `///` comments under #502. **This PR now records it**, as its own SEMVER
exception, with the measurement (`Shape.compound([box, box]).solidCount` is `1`, was `2`) — which
also answers the asymmetry the review raised: the criterion is the one the document already
applies, that a change a consumer can absorb without a diagnostic belongs in the table a consumer
reads before upgrading blindly. `buildCurves3d` and the #502 family both meet it; both are now
recorded.

Measured and **NOT REAL**: `bsplineRestrictionAdvanced` (both paths decode to `GeomAbs_C1`),
`pipeShell`'s `transition: .transformed` (a no-op — OCCT's constructor already defaults to it),
`Surface.continuityClass` (type rename, identical raw values), `continuityWith(…, order:)`
(`Int = 4` → `.c2`, `rawValue == 4`), `Curve2D.splitIndicesAtDiscontinuities` and
`Surface.knotSplitting` (defaults unchanged in value), every `Double`→`Double?` / `Bool`→`Bool?`
return (a compile error at every use site, therefore not silent), and
`Shape.defeature(faces:tolerance:)` (lost its default — correctly source-breaking).

## The `buildCurves3d` decision

**Keep `1e-5`, and record it as a break in `SEMVER.md`.**

- **`1e-5` is OCCT's own default; `1e-7` was OCCTSwift's invention.**
  `BRepLib::BuildCurves3d(const TopoDS_Shape&)` is literally `return BRepLib::BuildCurves3d(S, 1.0e-5);`
  (`BRepLib.cxx:463`), and `BRepLib::BuildCurve3d`'s header declares `Tolerance = 1.0e-5`
  (`BRepLib.hxx:91`).
- **Reverting would reopen a drift #498 closed.** As the review noted, `buildCurves3dAll` already
  defaulted to `1e-5` on `main`, so restoring `1e-7` on `buildCurves3d` would put the two sibling
  entry points 100× apart again — the exact divergence #498 existed to remove.
- **The old default over-claimed.** OCCT writes this tolerance onto the edge as a *floor*, not the
  deviation achieved, so `1e-7` had every rebuilt edge asserting a tightness the approximation may
  not hold. Measured on a helix: `1e-5` deviates 2.6e-6, `1e-7` deviates 9.0e-8.
- **Rejected alternative: remove the default outright**, as #541 did for
  `defeature(faces:tolerance:)`. Rejected as disproportionate: unlike the index rebases of
  #541/#568, the two values do not mean *different things* — both are tolerances, same units,
  obvious ordering. A caller reading `1e-5` is not misled about what it is; a caller reading a
  0-based index as 1-based is. A precision change, not a semantic one.

## Proving the tests catch it

Restored the old encoding at the property layer (the three `continuity` bodies mapping the ordinal
back to `{C0=0, G1=−2, C1=1, G2=−3, C2=2, C3=3, CN=99}`), on the rebased tree:

- **With the bug injected:** of 13 tests in the three new suites, **10 fail with 24 issues** —
  e.g. `(curve.continuity → 99) == 6`, `(c1.continuity → 1) == 2`, `(c1.continuity → 1) >= 2`,
  `(ContinuityClass(rawValue: Int32(curve.continuity)) → nil) != nil`. The #485 suites fail too.
  (The last round reported 9; that was wrong — the correct figure is 10.) The three survivors are
  `requestAndResultConstantsDiffer` and the two Bézier sibling tests, which read different bridge
  functions the injection does not touch.
- **Restored:** `Issue619|Issue485` → 30 tests in 6 suites, all pass.

## Tests

- `Issue619ContinuityEncodingTests` (`OCCTCurveTests`), `Issue619Curve2DContinuityEncodingTests`
  (`OCCTGeom2dTests`), `Issue619SurfaceContinuityEncodingTests` (`OCCTSurfaceTests`).
- The failure scenario is asserted *live* rather than restated: a C1 BSpline satisfies
  `continuity >= 2` **and** `continuityClass.satisfies(.c2)` correctly refuses it.
- **Vacuity fixed** (review nit 4): every bare `if let` fixture is now a `guard let … else
  { Issue.record }`, and every `.compactMap { $0 }` loop carries a `#expect(checked == N)` guard,
  matching the pattern the #485 suites already used.
- The #485 suites had their `continuityOrder` assertions moved onto `continuity`/`continuityClass`;
  they no longer need `@available(*, deprecated)` on the test function to compile.

## Docs

- `docs/CHANGELOG.md` — Unreleased entry headed **Breaking**, with the before/after table, the
  vanished error sentinel, and the migration.
- `docs/SEMVER.md` — rewritten guarantee paragraph (nine exceptions, split by whether they compile)
  plus three recorded exceptions: `continuityOrder` (#619), `buildCurves3d` (#498), and the
  `wires`/`shells`/`solids` collapse (#502).
- Eight stale-encoding sites corrected across five reference pages and three `///` comments.
- **Operation count set from `Scripts/count-operations.py`, not by hand: 4,304 → 4,301.**
  Composition on this branch: `func` 3155, `computed var` 964, `init` 181, `subscript` 1 = 4301.
  The base derives 4,304 with both documents agreeing; the −3 is exactly the three retired
  spellings, which the counter deliberately does not count as wrapped operations.

## Verification

- Rebased onto current `origin/refactor/381-pass1b` (28 commits, through #650). CHANGELOG/SEMVER
  conflicts were add/add and resolved keep-both by stripping marker lines by number; net line
  deltas were exactly the marker counts (−4, −4) with no content lost.
- `swift build` clean from bridge source (`env -u OCCTSWIFT_BRIDGE_PREBUILT`), not the prebuilt
  xcframework.
- Full `swift test`: **5311 tests in 1399 suites, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
