### PR TITLE
chore(#625): four gate scripts documented as gating on exit status, run by nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The repo's static gate scripts. Deliberately a separate job, on Linux, ahead of nothing:
+  #
+  #   - separate job, not a step in build-and-test, so it reports in well under a minute instead of
+  #     behind the ~6-minute build, and so it carries its own status check. That second half is the
+  #     load-bearing one: build-and-test is red branch-wide on refactor/** whenever the branch
+  #     carries a kernel patch newer than Package.swift's pinned xcframework (#585), and a gate
+  #     folded into that job would be red for a reason that has nothing to do with it, which is the
+  #     same as not having it.
+  #   - ubuntu-latest, because all four are pure Python over the repo's own text: no Xcode, no
+  #     OCCT, no swift build. A macOS runner would cost 10x the minutes to run the identical checks.
+  #   - each script's --self-test runs alongside its real invocation. A gate whose detector is
+  #     wrong reports "all clear" just as confidently as a gate whose subject is clean; this branch
+  #     shipped three gate scripts that were confidently wrong (#618, #624/#630, #626), so the
+  #     detector's own fixtures are part of what CI checks, not a developer-only convenience.
+  #   - `if: '!cancelled()'` on every step after the first, so one failing gate does not hide the
+  #     other three. Without it a contributor fixes them one CI round trip at a time. It is
+  #     `!cancelled()` rather than `always()` so the concurrency group's cancel-in-progress still
+  #     takes effect.
+  #
+  # Two of the four (check-bridge-index, check-null-handle-guards) resolve their inputs relative to
+  # the working directory and exit 2 with "run from the repo root" elsewhere; the other two resolve
+  # from __file__. A GitHub Actions step starts at the repo root, so both kinds are satisfied.
+  gate-scripts:
+    name: gate scripts (static, no build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned rather than the image default: these gates parse Swift and C++ with regexes, and a
+      # runner-image Python bump silently changing a verdict is exactly the failure mode the gates
+      # exist to prevent. Nothing here needs a third-party package — stdlib only (re, sys, os,
+      # glob, argparse, collections) — so there is no install step.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: check-bridge-index.py --self-test
+        run: python3 Scripts/check-bridge-index.py --self-test
+
+      - name: check-bridge-index.py
+        if: '!cancelled()'
+        run: python3 Scripts/check-bridge-index.py
+
+      - name: check-null-handle-guards.py --self-test
+        if: '!cancelled()'
+        run: python3 Scripts/check-null-handle-guards.py --self-test
+
+      - name: check-null-handle-guards.py
+        if: '!cancelled()'
+        run: python3 Scripts/check-null-handle-guards.py
+
+      - name: check-docs-defaults.py --self-test
+        if: '!cancelled()'
+        run: python3 Scripts/check-docs-defaults.py --self-test
+
+      - name: check-docs-defaults.py
+        if: '!cancelled()'
+        run: python3 Scripts/check-docs-defaults.py
+
+      # No --self-test of its own. It takes no options other than --fix/--audit and ignores an
+      # unrecognised one, so it is invoked bare; `--self-test` would be silently accepted and run
+      # the ordinary report, which reads as a passing self-test that never existed.
+      - name: count-operations.py
+        if: '!cancelled()'
+        run: python3 Scripts/count-operations.py
+
   build-and-test:
     name: swift build + test (macOS)
     runs-on: macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      # v7, not the v4 the sibling jobs in this file pin. Deprecation annotations are emitted per
+      # JOB, not per workflow, so this job's pins decide this job's annotation: at v4/v5 it raised
+      # its own "Node.js 20 is deprecated" warning, which this job would have been newly
+      # introducing (nothing in the repo used setup-python before). v7 of both targets node24, so
+      # the annotation is simply absent here. It leaves this file mixed-version until the other two
+      # jobs are bumped, which is a repo-wide change with its own PR.
+      - uses: actions/checkout@v7
 
       # Pinned rather than the image default: these gates parse Swift and C++ with regexes, and a
       # runner-image Python bump silently changing a verdict is exactly the failure mode the gates
       # exist to prevent. Nothing here needs a third-party package — stdlib only (re, sys, os,
       # glob, argparse, collections) — so there is no install step.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,19 +37,28 @@ The first three take `--self-test`, which runs a fixture battery proving the *de
 failure mode. Run it whenever you change one of these scripts — three gate scripts on this branch
 were confidently wrong (#618, #624/#630, #626), and a detector that reports "all clear" because it
 is blind looks exactly like one reporting "all clear" because the tree is clean.
-`count-operations.py` has no `--self-test` and **silently ignores an unrecognised option**, so
-passing it one runs the ordinary report and looks like a passing self-test that does not exist.
+`count-operations.py` has no `--self-test` and **exits 2 on an unrecognised option** rather than
+running the report, so writing `count-operations.py --self-test` to match its siblings fails loudly
+instead of passing forever.
 
 **Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs the same seven invocations
-locally. It is **opt-in and not installed by cloning** — enable it deliberately, from the repo root:
+locally, flag for flag. It is **opt-in and not installed by cloning** — enable it deliberately:
 
 ```bash
-ln -s ../../Scripts/git-hooks/pre-commit .git/hooks/pre-commit   # recommended: leaves other hooks alone
-git config core.hooksPath Scripts/git-hooks                      # alternative: REPLACES .git/hooks entirely
+# main checkout — surgical, leaves other hooks alone
+ln -s ../../Scripts/git-hooks/pre-commit .git/hooks/pre-commit
+
+# LINKED WORKTREE (.claude/worktrees/*) — the symlink above fails with "Not a directory" there,
+# because a worktree's .git is a file, not a directory. Use either of these instead:
+git config core.hooksPath Scripts/git-hooks                          # per-worktree
+ln -s <main>/Scripts/git-hooks/pre-commit <main>/.git/hooks/pre-commit  # once, covers every worktree
 ```
 
-`git commit --no-verify` skips it. It checks the working tree rather than the staged snapshot, so a
-partially-staged commit can pass it and still fail CI; CI is the authority.
+`core.hooksPath` REPLACES `.git/hooks` rather than adding to it, so any hook you already have stops
+firing while it is set. `git commit --no-verify` skips the hook. It checks the working tree rather
+than the staged snapshot, runs whatever `python3` is on your PATH (CI pins 3.12), and exits 0 with a
+warning if `python3` is missing — so a passing hook is weaker evidence than a passing CI job. CI is
+the authority.
 
 ### Compile a Ground Truth C++ Test
 
@@ -108,9 +117,13 @@ points this bridge passes such a handle into dereference it unconditionally, whi
 uncatchable signal, not something `catch (...)` can absorb (#478, #556, #618). Run
 `python3 Scripts/check-null-handle-guards.py` to verify; it exits 1 on any unguarded site, and
 `--self-test` proves both failure modes (an unguarded site reported, a guarded one not). **Both are
-run by CI** in `ci.yml`'s `gate-scripts` job, so an unguarded site fails the PR rather than merging
-green — until #625 they were run by nothing at all, and this instruction described a gate that
-existed only as prose. See "Static Gate Scripts" above for the optional pre-commit hook.
+run by CI** in `ci.yml`'s `gate-scripts` job, so an unguarded site turns the PR's check red — until
+#625 they were run by nothing at all, and this instruction described a gate that existed only as
+prose. Note the repo has **no branch protection and no rulesets**, so a red check is visible but
+does not itself block a merge; making `gate-scripts` a required check is tracked separately and is
+safe for this one specifically, because unlike `build-and-test` (red branch-wide while #585 stands)
+it is fast and green on every branch. See "Static Gate Scripts" above for the optional pre-commit
+hook.
 
 **The guard is required only where the OCCT call actually needs it.** Not every entry point
 dereferences: `GeomLib_Tool::Parameter` returns false, `GeomAdaptor_Surface` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,40 @@ swift run OCCTTest                   # Run test executable
 Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concurrency-touching changes (see docs/thread-safety.md)
 ```
 
+### Static Gate Scripts
+
+Four pure-Python checks over the repo's own text. No OCCT, no build, ~3s for all four. **CI runs
+every one of them, plus each `--self-test`, in `ci.yml`'s `gate-scripts` job** — a separate
+`ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
+its own status check when `build-and-test` is red for an unrelated reason (#585's pinned-kernel
+mismatch on `refactor/**` branches). Each exits 1 on a defect and 0 when clean; `check-bridge-index`
+and `check-null-handle-guards` exit **2** if run from anywhere but the repo root (#625).
+
+```bash
+python3 Scripts/check-bridge-index.py        # OCCTBridge.h's class → symbol index: stale / misfiled entries
+python3 Scripts/check-null-handle-guards.py  # every bridge fn guards the Handle, not just the pointer
+python3 Scripts/check-docs-defaults.py       # every default docs/reference/ restates matches its declaration
+python3 Scripts/count-operations.py          # README + API_REFERENCE totals match the derived count
+```
+
+The first three take `--self-test`, which runs a fixture battery proving the *detector* catches each
+failure mode. Run it whenever you change one of these scripts — three gate scripts on this branch
+were confidently wrong (#618, #624/#630, #626), and a detector that reports "all clear" because it
+is blind looks exactly like one reporting "all clear" because the tree is clean.
+`count-operations.py` has no `--self-test` and **silently ignores an unrecognised option**, so
+passing it one runs the ordinary report and looks like a passing self-test that does not exist.
+
+**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs the same seven invocations
+locally. It is **opt-in and not installed by cloning** — enable it deliberately, from the repo root:
+
+```bash
+ln -s ../../Scripts/git-hooks/pre-commit .git/hooks/pre-commit   # recommended: leaves other hooks alone
+git config core.hooksPath Scripts/git-hooks                      # alternative: REPLACES .git/hooks entirely
+```
+
+`git commit --no-verify` skips it. It checks the working tree rather than the staged snapshot, so a
+partially-staged commit can pass it and still fail CI; CI is the authority.
+
 ### Compile a Ground Truth C++ Test
 
 ```bash
@@ -73,7 +107,10 @@ uses>;`. Checking only the pointer says nothing about the handle, and 36 of the 
 points this bridge passes such a handle into dereference it unconditionally, which is an
 uncatchable signal, not something `catch (...)` can absorb (#478, #556, #618). Run
 `python3 Scripts/check-null-handle-guards.py` to verify; it exits 1 on any unguarded site, and
-`--self-test` proves both failure modes (an unguarded site reported, a guarded one not).
+`--self-test` proves both failure modes (an unguarded site reported, a guarded one not). **Both are
+run by CI** in `ci.yml`'s `gate-scripts` job, so an unguarded site fails the PR rather than merging
+green — until #625 they were run by nothing at all, and this instruction described a gate that
+existed only as prose. See "Static Gate Scripts" above for the optional pre-commit hook.
 
 **The guard is required only where the OCCT call actually needs it.** Not every entry point
 dereferences: `GeomLib_Tool::Parameter` returns false, `GeomAdaptor_Surface` and

--- a/Scripts/check-bridge-index.py
+++ b/Scripts/check-bridge-index.py
@@ -73,7 +73,8 @@ Usage (from the repo root):
     python3 Scripts/check-bridge-index.py --quiet     # exit status only
     python3 Scripts/check-bridge-index.py --self-test # prove each failure mode is caught
 
-Exit status is 1 when any entry is stale or misfiled, so this can gate a commit.
+Exit status is 1 when any entry is stale or misfiled, so this can gate a commit. CI runs it, and
+its `--self-test`, in `ci.yml`'s `gate-scripts` job (#625).
 """
 import os
 import re

--- a/Scripts/check-docs-defaults.py
+++ b/Scripts/check-docs-defaults.py
@@ -86,8 +86,8 @@ Usage (from the repo root):
     python3 Scripts/check-docs-defaults.py --quiet          # exit status only
 
 Exit status is 1 when a default disagrees, when a restatement cannot be adjudicated, or when the
-`unmatched` bucket grows — so this can gate a commit. Nothing in this tree runs it yet; wiring the
-gate scripts into CI is #625, which covers all of them together.
+`unmatched` bucket grows — so this can gate a commit. CI runs it, and its `--self-test`, in
+`ci.yml`'s `gate-scripts` job (#625).
 """
 import argparse
 import glob

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -74,7 +74,8 @@ Usage (from the repo root):
     python3 Scripts/check-null-handle-guards.py --quiet     # exit status only
     python3 Scripts/check-null-handle-guards.py --self-test # prove each failure mode is caught
 
-Exit status is 1 when any site is unguarded, so this can gate a commit.
+Exit status is 1 when any site is unguarded, so this can gate a commit. CI runs it, and its
+`--self-test`, in `ci.yml`'s `gate-scripts` job (#625).
 """
 import glob
 import os

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -31,6 +31,13 @@ Usage:
     ./Scripts/count-operations.py           # report; exit 1 if the docs disagree
     ./Scripts/count-operations.py --fix     # rewrite README + API_REFERENCE Total
     ./Scripts/count-operations.py --audit   # list counted entry points with no reference doc
+
+Exit status is 1 when README's headline or API_REFERENCE's Total disagrees with the derived
+count, so this can gate a commit — it always could; it was the one gate script whose docstring
+never said so, which is why it read as a release-time reporting tool. It has no `--self-test`,
+and it ignores an unrecognised option rather than rejecting it, so do not pass one: `--self-test`
+would be silently accepted and run the ordinary report, which reads as a passing self-test that
+does not exist. CI runs this in `ci.yml`'s `gate-scripts` job (#625).
 """
 import re
 import sys

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -34,10 +34,11 @@ Usage:
 
 Exit status is 1 when README's headline or API_REFERENCE's Total disagrees with the derived
 count, so this can gate a commit — it always could; it was the one gate script whose docstring
-never said so, which is why it read as a release-time reporting tool. It has no `--self-test`,
-and it ignores an unrecognised option rather than rejecting it, so do not pass one: `--self-test`
-would be silently accepted and run the ordinary report, which reads as a passing self-test that
-does not exist. CI runs this in `ci.yml`'s `gate-scripts` job (#625).
+never said so, which is why it read as a release-time reporting tool. Exit status is 2 for an
+unrecognised option: this script has no `--self-test`, its three sibling gates do, and CI pairs
+each of theirs with its real run, so `count-operations.py --self-test` is the natural thing to
+write when extending that list — it used to be accepted silently and run the ordinary report,
+passing forever. CI runs this bare in `ci.yml`'s `gate-scripts` job (#625).
 """
 import re
 import sys
@@ -245,8 +246,23 @@ def fix(derived):
 
 
 def main():
-    derived, breakdown, ops = count_entry_points()
     mode = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    # Reject an unrecognised option rather than falling through to the report. Silently ignoring
+    # one made `--self-test` a trap: this script has no self-test, its three sibling gates do, and
+    # CI pairs each of theirs with its real run — so the natural thing to write when adding this
+    # script to that list is `count-operations.py --self-test`, which would have run the ordinary
+    # report and passed forever, exactly the "a gate that cannot fail" defect #625 exists to end.
+    # A prose warning was the first fix and was the wrong one: #625's whole premise is that prose
+    # describing a gate is not a gate. Exit 2, matching the sibling scripts' "cannot run" status
+    # (they use it for a wrong working directory), so it is distinguishable from a real failure.
+    # Also stops `--fi` silently reporting when `--fix` was meant.
+    if mode not in ("", "--fix", "--audit"):
+        print(f"unknown option: {mode}", file=sys.stderr)
+        print("usage: count-operations.py [--fix | --audit]", file=sys.stderr)
+        return 2
+
+    derived, breakdown, ops = count_entry_points()
 
     if mode == "--audit":
         typed_doc, bare_doc = documented_index()

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Opt-in pre-commit hook: runs the same four static gate scripts CI's `gate-scripts` job runs.
+#
+# NOT installed by cloning. A repo cannot install its own hooks — `.git/hooks` is not versioned —
+# and that is the right default here: a hook that appears in a contributor's workflow without them
+# asking is a surprise, and this one adds a few seconds to every single commit. Enable it with one
+# of the two commands below, from the repo root.
+#
+#   Recommended (surgical — leaves any other hook you already have in place):
+#
+#       ln -s ../../Scripts/git-hooks/pre-commit .git/hooks/pre-commit
+#
+#   Alternative (whole hooks directory):
+#
+#       git config core.hooksPath Scripts/git-hooks
+#
+#   `core.hooksPath` REPLACES the hooks directory rather than adding to it, so any hook you already
+#   have in `.git/hooks` stops firing while it is set. Prefer the symlink unless you want every
+#   hook this repo ships. Undo either with `rm .git/hooks/pre-commit` or
+#   `git config --unset core.hooksPath`.
+#
+# Skip it for one commit with `git commit --no-verify`. CI is the authority either way: this hook
+# is a faster local copy of the same checks, never a substitute, and it is deliberately kept
+# identical to the CI job so "passed locally, failed in CI" cannot mean the two disagree.
+#
+# It checks the WORKING TREE, not the staged snapshot. A partially-staged commit can therefore pass
+# the hook and fail CI on what was actually committed. Making it accurate would mean checking out
+# the index to a temp tree on every commit, which costs more than it saves for a convenience hook —
+# CI closes that gap. #625.
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+    echo "pre-commit: $PY not found; skipping the gate scripts (CI still runs them)." >&2
+    exit 0
+fi
+
+failed=()
+
+# Run every gate even after one fails, so a commit reports all its problems at once rather than one
+# per attempt — same reason CI's steps carry `if: !cancelled()`.
+run() {
+    local label="$1"; shift
+    if ! "$PY" "$@" >/tmp/occtswift-gate-$$.log 2>&1; then
+        echo ""
+        echo "--- FAIL: $label"
+        cat /tmp/occtswift-gate-$$.log
+        failed+=("$label")
+    fi
+    rm -f /tmp/occtswift-gate-$$.log
+}
+
+run "check-bridge-index.py --self-test"       Scripts/check-bridge-index.py --self-test
+run "check-bridge-index.py"                   Scripts/check-bridge-index.py --quiet
+run "check-null-handle-guards.py --self-test" Scripts/check-null-handle-guards.py --self-test
+run "check-null-handle-guards.py"             Scripts/check-null-handle-guards.py --quiet
+run "check-docs-defaults.py --self-test"      Scripts/check-docs-defaults.py --self-test
+run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py --quiet
+run "count-operations.py"                     Scripts/count-operations.py
+
+if [ ${#failed[@]} -ne 0 ]; then
+    echo ""
+    echo "pre-commit: ${#failed[@]} gate(s) failed: ${failed[*]}"
+    echo "Fix them, or commit with --no-verify if you intend to fix them in a follow-up."
+    exit 1
+fi
+
+exit 0

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -7,27 +7,38 @@
 # asking is a surprise, and this one adds a few seconds to every single commit. Enable it with one
 # of the two commands below, from the repo root.
 #
-#   Recommended (surgical — leaves any other hook you already have in place):
+#   In a MAIN checkout — surgical, leaves any other hook you already have in place:
 #
 #       ln -s ../../Scripts/git-hooks/pre-commit .git/hooks/pre-commit
 #
-#   Alternative (whole hooks directory):
+#   In a LINKED WORKTREE (`.claude/worktrees/*`, where most work on this repo happens) that symlink
+#   FAILS with "Not a directory": a worktree's `.git` is a file pointing at the main checkout, not
+#   a directory, so there is no `.git/hooks` to link into. Use either:
 #
-#       git config core.hooksPath Scripts/git-hooks
+#       git config core.hooksPath Scripts/git-hooks                    # per-worktree, no symlink
+#       ln -s <main-checkout>/Scripts/git-hooks/pre-commit \
+#             <main-checkout>/.git/hooks/pre-commit                    # once, covers every worktree
 #
 #   `core.hooksPath` REPLACES the hooks directory rather than adding to it, so any hook you already
-#   have in `.git/hooks` stops firing while it is set. Prefer the symlink unless you want every
-#   hook this repo ships. Undo either with `rm .git/hooks/pre-commit` or
-#   `git config --unset core.hooksPath`.
+#   have in `.git/hooks` stops firing while it is set. Prefer the symlink where you can use one.
+#   Undo either with `rm .git/hooks/pre-commit` or `git config --unset core.hooksPath`.
 #
-# Skip it for one commit with `git commit --no-verify`. CI is the authority either way: this hook
-# is a faster local copy of the same checks, never a substitute, and it is deliberately kept
-# identical to the CI job so "passed locally, failed in CI" cannot mean the two disagree.
+#   The hook body itself is worktree-correct either way — it `cd`s to `git rev-parse --show-toplevel`,
+#   which resolves to the worktree you are committing in, not the main checkout.
 #
-# It checks the WORKING TREE, not the staged snapshot. A partially-staged commit can therefore pass
-# the hook and fail CI on what was actually committed. Making it accurate would mean checking out
-# the index to a temp tree on every commit, which costs more than it saves for a convenience hook —
-# CI closes that gap. #625.
+# Skip it for one commit with `git commit --no-verify`. CI is the authority either way: this hook is
+# a faster local copy of the same checks, never a substitute. The seven INVOCATIONS below are
+# deliberately identical to the CI job's, flag for flag, so a disagreement can never come from the
+# two running different things. Three ways they can still diverge, none of them worth closing here:
+#
+#   - it checks the WORKING TREE, not the staged snapshot, so a partially-staged commit can pass the
+#     hook and fail CI on what was actually committed. Fixing it means checking the index out to a
+#     temp tree on every commit, which costs more than it saves for a convenience hook;
+#   - it runs whatever `python3` is on your PATH; CI pins 3.12;
+#   - if `python3` is missing entirely it warns and exits 0, so "the hook passed" can mean "the hook
+#     did nothing".
+#
+# All three resolve the same way: CI is what decides, and it runs on every push regardless. #625.
 
 set -uo pipefail
 
@@ -54,12 +65,16 @@ run() {
     rm -f /tmp/occtswift-gate-$$.log
 }
 
+# Deliberately NOT --quiet, even though run() only prints on failure. --quiet is exit-status-only,
+# so the hook would name the failing gate and then print nothing about WHERE — a fabricated index
+# entry gets you "FAIL: check-bridge-index.py" instead of the file and line CI names. These are the
+# same invocations CI runs, which is the point: the two must not be able to disagree.
 run "check-bridge-index.py --self-test"       Scripts/check-bridge-index.py --self-test
-run "check-bridge-index.py"                   Scripts/check-bridge-index.py --quiet
+run "check-bridge-index.py"                   Scripts/check-bridge-index.py
 run "check-null-handle-guards.py --self-test" Scripts/check-null-handle-guards.py --self-test
-run "check-null-handle-guards.py"             Scripts/check-null-handle-guards.py --quiet
+run "check-null-handle-guards.py"             Scripts/check-null-handle-guards.py
 run "check-docs-defaults.py --self-test"      Scripts/check-docs-defaults.py --self-test
-run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py --quiet
+run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py
 run "count-operations.py"                     Scripts/count-operations.py
 
 if [ ${#failed[@]} -ne 0 ]; then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,9 +54,17 @@ than `always()` so the workflow's `cancel-in-progress` concurrency still takes e
 **`count-operations.py` gains the docstring line its three siblings already had.** It was always a
 gate — `return 0 if (readme_n == derived and apiref_n == derived) else 1` — but nothing said so, so
 it read as a release-time reporting tool, which is the only way it was ever used. Its counts had
-drifted on this branch before (#625's own scope note). It also **silently ignores an unrecognised
-option**, so `--self-test` would be accepted, run the ordinary report, and exit 0: a passing
-self-test that does not exist. CI invokes it bare, and the docstring now says why.
+drifted on this branch before (#625's own scope note).
+
+It also **now exits 2 on an unrecognised option instead of silently ignoring it**. This one is a
+trap this PR itself arms: the other three gates all take `--self-test`, and CI pairs each self-test
+with its real run, so "seven invocations, self-test beside gate" becomes the house pattern in two
+places — and the natural thing to write when extending that list is `count-operations.py
+--self-test`, which was accepted, ran the ordinary report, and passed forever. The first fix was a
+docstring warning, which is the wrong shape of fix for an issue whose entire premise is that prose
+describing a gate is not a gate. Exit 2 matches the siblings' "cannot run" status (they use it for
+a wrong working directory) so it is distinguishable from a real failure, and it also stops `--fi`
+silently reporting when `--fix` was meant.
 
 **An opt-in pre-commit hook, not an installed one.** `Scripts/git-hooks/pre-commit` runs the same
 seven invocations locally, for the case `CLAUDE.md` actually addresses: a contributor mid-change,
@@ -66,15 +74,41 @@ silently disables any hook a contributor already has). **The rejected alternativ
 auto-installation** — a bootstrap script or SwiftPM plugin writing `.git/hooks/pre-commit` on first
 build. It was rejected because it changes when a contributor's commits succeed without them asking,
 and its failure mode is a commit refused by a hook they did not know existed and cannot find in the
-tree. The hook mirrors the CI job exactly, so "passed locally, failed in CI" can never mean the two
-disagree; it checks the working tree rather than the staged snapshot, so a partially-staged commit
-can pass it and still fail CI, which is documented in the hook and is why CI stays the authority.
+tree. The hook runs the same seven invocations **flag for flag**. It first ran the three real gates with
+`--quiet`, which is exit-status-only, so it named the failing gate and then printed nothing about
+where — a fabricated index entry got you `FAIL: check-bridge-index.py` where CI names
+`OCCTBridge.h:66`. The flag was redundant anyway, since the runner already buffers output and only
+prints it on failure. **The reason that survived the first round of proof is worth recording**: the
+hook was proven with `count-operations.py`, the one invocation that had no `--quiet` and therefore
+the one case that could not exhibit the defect. A proof that exercises only the case immune to the
+bug is the same shape as the vacuous self-tests this batch keeps finding — the re-proof breaks all
+three of the previously-`--quiet` gates individually and confirms each now prints its site.
+
+Three ways the hook can still diverge from CI, all documented in it rather than closed: it checks
+the working tree rather than the staged snapshot, so a partially-staged commit can pass it and fail
+CI; it runs whatever `python3` is on `PATH` while CI pins 3.12; and it warns and exits 0 if
+`python3` is missing, so "the hook passed" can mean "the hook did nothing". All three resolve the
+same way — CI decides, and it runs on every push regardless.
+
+The install instruction was also wrong for this repo's normal working mode: `ln -s ...
+.git/hooks/pre-commit` fails with "Not a directory" in a linked worktree, because a worktree's
+`.git` is a file, and almost all work here happens in `.claude/worktrees/*`. The hook *body* was
+already worktree-correct (`cd "$(git rev-parse --show-toplevel)"`); only the instruction was not.
+Both the hook header and `CLAUDE.md` now give the worktree forms.
 
 **Verified by breaking each condition and confirming the gate catches it.** Fabricating an index
 entry (`OCCTShapeBoxNope`) took `check-bridge-index.py` 0 → 1; deleting the `IsNull()` from a
 guarded bridge opener took `check-null-handle-guards.py` 0 → 1; editing a restated default in
 `docs/reference/` took `check-docs-defaults.py` 0 → 1; editing README's headline count took
-`count-operations.py` 0 → 1. All four returned to 0 on restore.
+`count-operations.py` 0 → 1. All four returned to 0 on restore. The job is pinned to
+`actions/checkout@v7` + `actions/setup-python@v7` (both `using: node24`) rather than the `@v4` its
+sibling jobs use, so it does not newly introduce a Node 20 deprecation annotation — those are
+emitted per job, so this job's pins decide this job's warning. Bumping the other two jobs is #648.
+
+**What this does not do:** the repo has no branch protection and no rulesets, so a red
+`gate-scripts` is a visible red X that does not block a merge. Making it a required check is #649,
+and it is the one check in the repo that can be required without a caveat — unlike `build-and-test`
+it needs no OCCT, no build and no xcframework, so #585's pinned-kernel mismatch cannot make it red.
 
 #### The null-handle gate was blind to four of the five ways this bridge reaches a handle (#618)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,65 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### Four gate scripts documented as gating on exit status, run by nothing (#625)
+
+`check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py` and
+`count-operations.py` were each written to gate a commit, and three said so in their own docstring.
+No workflow, hook, script or Makefile invoked any of them. `CLAUDE.md` told contributors the guard
+script "exits 1 on any unguarded site" — true, and it still merged green when it didn't, because
+nothing ran it. The documentation described a gate that existed only as prose.
+
+All four now run in a new `gate-scripts` job in `.github/workflows/ci.yml`, together with the three
+`--self-test` batteries, on `ubuntu-latest`, in about three seconds of work.
+
+**A separate job rather than a step in `build-and-test`, for a reason beyond speed.** The obvious
+argument is that a pure-Python check should not wait ~6 minutes behind a Swift build to say a
+symbol name is misspelled. The load-bearing one is the status check: `build-and-test` is red
+branch-wide on any `refactor/**` branch carrying a kernel patch newer than `Package.swift`'s pinned
+xcframework (#585), so a gate folded into that job would be red for a reason that has nothing to do
+with it — indistinguishable from having no gate at all. Linux rather than macOS because none of the
+four needs Xcode, OCCT or a build, and a macOS runner bills ten times the minutes for the identical
+result. Python is pinned at 3.12 rather than taken from the image: these gates parse Swift and C++
+with regexes, and a runner-image Python bump quietly changing a verdict is the exact failure mode
+they exist to prevent.
+
+**Each script's `--self-test` runs alongside its real invocation.** A detector that reports "all
+clear" because it is blind looks exactly like one reporting "all clear" because the tree is clean,
+and this branch shipped three gate scripts that were confidently wrong — #618 (the guard checker
+saw one of the five ways this bridge reaches a handle), #624/#630 (the index checker called seven
+correct entries misfiled), #626 (the drift it was written to catch was live in the tree). Two of
+those had self-tests with holes. Running the fixtures in CI is what keeps the gate from rotting
+into vacuity while still exiting 0.
+
+Every step after the first carries `if: '!cancelled()'`, so one failing gate does not hide the
+other three; without it a contributor fixes them one CI round trip at a time. `!cancelled()` rather
+than `always()` so the workflow's `cancel-in-progress` concurrency still takes effect.
+
+**`count-operations.py` gains the docstring line its three siblings already had.** It was always a
+gate — `return 0 if (readme_n == derived and apiref_n == derived) else 1` — but nothing said so, so
+it read as a release-time reporting tool, which is the only way it was ever used. Its counts had
+drifted on this branch before (#625's own scope note). It also **silently ignores an unrecognised
+option**, so `--self-test` would be accepted, run the ordinary report, and exit 0: a passing
+self-test that does not exist. CI invokes it bare, and the docstring now says why.
+
+**An opt-in pre-commit hook, not an installed one.** `Scripts/git-hooks/pre-commit` runs the same
+seven invocations locally, for the case `CLAUDE.md` actually addresses: a contributor mid-change,
+not a reviewer. It is enabled deliberately with a symlink into `.git/hooks` (or `core.hooksPath`,
+which replaces the hooks directory wholesale rather than adding to it — documented, because that
+silently disables any hook a contributor already has). **The rejected alternative was
+auto-installation** — a bootstrap script or SwiftPM plugin writing `.git/hooks/pre-commit` on first
+build. It was rejected because it changes when a contributor's commits succeed without them asking,
+and its failure mode is a commit refused by a hook they did not know existed and cannot find in the
+tree. The hook mirrors the CI job exactly, so "passed locally, failed in CI" can never mean the two
+disagree; it checks the working tree rather than the staged snapshot, so a partially-staged commit
+can pass it and still fail CI, which is documented in the hook and is why CI stays the authority.
+
+**Verified by breaking each condition and confirming the gate catches it.** Fabricating an index
+entry (`OCCTShapeBoxNope`) took `check-bridge-index.py` 0 → 1; deleting the `IsNull()` from a
+guarded bridge opener took `check-null-handle-guards.py` 0 → 1; editing a restated default in
+`docs/reference/` took `check-docs-defaults.py` 0 → 1; editing README's headline count took
+`count-operations.py` 0 → 1. All four returned to 0 on restore.
+
 #### The null-handle gate was blind to four of the five ways this bridge reaches a handle (#618)
 
 `Scripts/check-null-handle-guards.py` printed "All bridge functions guard the geometry handle as


### PR DESCRIPTION
Closes #625

Four gate scripts, each written to gate a commit and three saying so in their own docstring, were
invoked by no workflow, hook, script or Makefile. `CLAUDE.md` told contributors the guard script
"exits 1 on any unguarded site" — true, and it still merged green when it didn't, because nothing
ran it. The documentation described a gate that existed only as prose.

## The four, verified on this base before touching anything

Both blockers have cleared (#630 fixed the index checker's `template <class T>` parse bug, #641
taught the guard checker the four indirections this bridge uses), so all four are genuinely green
rather than quietly broken:

| script | `python3 Scripts/<name>.py` | `--self-test` |
|---|---|---|
| `check-bridge-index.py` | **0** — 728 index symbols / 383 classes, 0 stale, 0 misfiled | **0** — 18/18 cases |
| `check-null-handle-guards.py` | **0** — all bridge fns guard the handle (23 `ALLOWED` exemptions) | **0** — 12/12 cases |
| `check-docs-defaults.py` | **0** — 1460 defaults compared, 0 drifted, 0 unverified | **0** — 13/13 cases |
| `count-operations.py` | **0** — derived 4304, README 4304 ✓, API_REFERENCE 4304 ✓ | no self-test (see below) |

Also measured: two of them (`check-bridge-index`, `check-null-handle-guards`) resolve inputs
relative to the working directory and exit **2** with "run from the repo root" anywhere else; the
other two resolve from `__file__`. A GitHub Actions step starts at the repo root, so both kinds are
satisfied without a `working-directory:`.

## Where the job went, and why

A new `gate-scripts` job in `.github/workflows/ci.yml`, on `ubuntu-latest`. Total work ~3.3s
(0.96 + 0.78 + 1.08 + 0.43s locally), plus the three self-tests.

- **Separate job, not a step in `build-and-test`.** The obvious argument is speed: a pure-Python
  check should not wait ~6 minutes behind a Swift build to say a symbol name is misspelled. The
  load-bearing argument is the **status check**. `build-and-test` is red branch-wide on any
  `refactor/**` branch carrying a kernel patch newer than `Package.swift`'s pinned xcframework
  (#585) — including this one. A gate folded into that job would be red for a reason that has
  nothing to do with it, which is indistinguishable from having no gate at all. As its own job it
  stays meaningful today.
- **`ubuntu-latest`, not macOS.** None of the four needs Xcode, OCCT or a build. A macOS runner
  bills 10x the minutes for the identical result.
- **Python pinned at 3.12** via `actions/setup-python@v5` rather than taken from the runner image.
  These gates parse Swift and C++ with regexes; a runner-image Python bump quietly changing a
  verdict is precisely the failure mode they exist to prevent. All four are stdlib-only (`re`,
  `sys`, `os`, `glob`, `argparse`, `collections`) — no install step.
- **`if: '!cancelled()'` on every step after the first**, so one failing gate does not hide the
  other three; without it a contributor fixes them one CI round trip at a time. `!cancelled()`
  rather than `always()` so the workflow's `cancel-in-progress` concurrency still takes effect.

## Self-tests run in CI too

Each script's `--self-test` runs alongside its real invocation. A detector that reports "all clear"
because it is blind looks exactly like one reporting "all clear" because the tree is clean, and
this branch shipped three gate scripts that were confidently wrong — #618 (the guard checker saw
one of the five ways this bridge reaches a handle), #624/#630 (the index checker called seven
*correct* entries misfiled), #626 (the drift it was written to catch was live in the tree). Two of
those had self-tests with holes. Running the fixture batteries in CI is what stops a gate rotting
into vacuity while still exiting 0.

`count-operations.py` has no self-test and is invoked **bare**: it silently ignores an unrecognised
option, so `--self-test` would be accepted, run the ordinary report and exit 0 — a passing
self-test that does not exist. That is now stated in its docstring rather than left as a trap.

## Hook decision: opt-in, shipped, not installed

`Scripts/git-hooks/pre-commit` runs the same seven invocations locally, for the case `CLAUDE.md`
actually addresses — a contributor mid-change, not a reviewer. Enabled deliberately, from the repo
root:

```bash
ln -s ../../Scripts/git-hooks/pre-commit .git/hooks/pre-commit   # recommended: leaves other hooks alone
git config core.hooksPath Scripts/git-hooks                      # alternative: REPLACES .git/hooks entirely
```

`core.hooksPath`'s replace-rather-than-add behaviour is documented in the hook and in `CLAUDE.md`,
because it silently disables any hook a contributor already has. `--no-verify` skips it.

**Rejected alternative: auto-installation** — a bootstrap script or SwiftPM plugin writing
`.git/hooks/pre-commit` on first build. Rejected because it changes when a contributor's commits
succeed without them asking, and its failure mode is a commit refused by a hook they did not know
existed and cannot find in the tree. A repo cannot install its own hooks (`.git/hooks` is not
versioned), and that constraint is the right default here rather than something to work around.

Two limits, both documented in the hook itself: it mirrors the CI job exactly, so "passed locally,
failed in CI" can never mean the two disagree; and it checks the **working tree**, not the staged
snapshot, so a partially-staged commit can pass it and still fail CI. CI stays the authority.

## Break it and confirm — all four, plus the hook

Each condition broken locally, the exact command the workflow runs re-run, then restored:

| script | break | before | broken | restored |
|---|---|---|---|---|
| `check-bridge-index.py` | fabricated index entry `Adaptor2d_Curve2d → OCCTShapeBoxNope` in `OCCTBridge.h` | 0 | **1** — reported both `STALE` and `MISFILED` at `OCCTBridge.h:66` | 0 |
| `check-null-handle-guards.py` | deleted `\|\| c->curve.IsNull()` from `OCCTCurve3DIsClosed`'s opener | 0 | **1** — named `OCCTBridge_Curve3D.mm:202  OCCTCurve3DIsClosed(c)` with the wanted guard | 0 |
| `check-docs-defaults.py` | `Surface.gordon`'s `tolerance:` default `1e-3` → `1e-6` in `docs/reference/Surface.md` | 0 | **1** — `CHANGED`, docs `1e-6` vs `Surface.swift:3397` `1e-3` | 0 |
| `count-operations.py` | README headline `4,304` → `4,299` | 0 | **1** — `README headline 4299 ✗ (should be 4304)` | 0 |

Every one named the specific site, not just a non-zero exit. The hook was proven separately by the
same README break: it printed `--- FAIL: count-operations.py`, the script's own output, and
`pre-commit: 1 gate(s) failed`, exiting 1; back to 0 on restore.

`ci.yml` was parsed with `yaml.safe_load` to confirm the job and all 9 steps resolve as intended.

## Docs

- `docs/CHANGELOG.md` — Unreleased entry under Pass 1b (no invented version).
- `CLAUDE.md` — new "Static Gate Scripts" section under Build & Test Commands listing all four, the
  exit contracts (including the exit-2 repo-root requirement), the self-test guidance and the
  opt-in hook. The null-handle-guard paragraph, which the issue flagged as true-but-silent about
  CI, now says CI runs it and that until #625 it was run by nothing at all.
- All four script docstrings now name the CI job that runs them, so the next reader does not have
  to grep to find out whether the gate is real. `check-docs-defaults.py`'s "Nothing in this tree
  runs it yet; wiring the gate scripts into CI is #625" line is replaced rather than left stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
