### PR TITLE
chore(#648): every workflow action pin moves to a Node 24 major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      # v7, not the v4 the sibling jobs in this file pin. Deprecation annotations are emitted per
-      # JOB, not per workflow, so this job's pins decide this job's annotation: at v4/v5 it raised
-      # its own "Node.js 20 is deprecated" warning, which this job would have been newly
-      # introducing (nothing in the repo used setup-python before). v7 of both targets node24, so
-      # the annotation is simply absent here. It leaves this file mixed-version until the other two
-      # jobs are bumped, which is a repo-wide change with its own PR.
+      # Every action pin across .github/workflows/ now targets a Node 24 major (#648). The target
+      # for each was established by reading that action's own action.yml at the pinned ref and
+      # checking `using:`, not by assuming a version number implies a runtime — actions/github-script
+      # is node20 at v7 and only reaches node24 at v8, so a "match the v7 the other pins use" rule
+      # would have left require-issue-labels.yml deprecated while looking consistent.
+      #
+      # Deprecation annotations are emitted per JOB, not per workflow, so one stale v4 pin anywhere
+      # raises its own "Node.js 20 is deprecated" warning on that job alone; keep new jobs on these
+      # majors rather than copying an older workflow's pins.
       - uses: actions/checkout@v7
 
       # Pinned rather than the image default: these gates parse Swift and C++ with regexes, and a
@@ -105,7 +108,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -115,7 +118,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Cache SwiftPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .build
@@ -135,7 +138,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -143,7 +146,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Cache SwiftPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .build

--- a/.github/workflows/kernel-integration.yml
+++ b/.github/workflows/kernel-integration.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -50,13 +50,13 @@ jobs:
       # invalidates it.
       - name: Cache OCCT.xcframework
         id: occt-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Libraries/OCCT.xcframework
           key: occt-xcframework-${{ hashFiles('Scripts/patches/*.patch', 'Scripts/build-occt.sh') }}
 
       - name: Cache SwiftPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .build

--- a/.github/workflows/occt-parallel-crash-test.yml
+++ b/.github/workflows/occt-parallel-crash-test.yml
@@ -18,7 +18,7 @@ jobs:
     if: inputs.platform == 'windows' || inputs.platform == 'both'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Build OCCT from source as static libraries.
       # Key settings:
@@ -94,7 +94,7 @@ jobs:
     if: inputs.platform == 'macos' || inputs.platform == 'both'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build OCCT from source
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
 

--- a/.github/workflows/require-issue-labels.yml
+++ b/.github/workflows/require-issue-labels.yml
@@ -12,7 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for type:* and priority:* labels
-        uses: actions/github-script@v7
+        # v9, not the v7 that actions/checkout and actions/setup-python use elsewhere in this repo:
+        # github-script's v7 is `using: node20` and it is v8 that first moves to node24, so matching
+        # the version number rather than the runtime would have left this job deprecated (#648).
+        # v9's two breaking changes do not apply to the script below — it never calls
+        # require('@actions/github') and never declares a `getOctokit` binding, using only the
+        # injected `context` and `github.rest.*`.
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- require-issue-labels -->';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,32 @@ All notable changes to OCCTSwift.
 
 ### Pass 1b of the #377 duplication audit
 
+#### Every workflow action pin moves to a Node 24 major (#648)
+
+#625 bumped only the job it introduced, so `ci.yml` was left mixed-version: `actions/checkout@v7` in
+`gate-scripts`, `actions/checkout@v4` in `build-and-test` and `ios-simulator-build`. Deprecation
+annotations are emitted per **job**, not per workflow, so each remaining v4 job raised its own
+"Node.js 20 is deprecated" warning.
+
+All 17 pins across the five workflow files were enumerated rather than just the two the issue named:
+`actions/checkout` v4 → v7 (six sites), `actions/cache` v4 → v6 (four sites), and
+`actions/github-script` v7 → v9 (one site). `maxim-lobanov/setup-xcode@v1` is unchanged — the moving
+`v1` tag already resolves to a `node24` build — as are `gate-scripts`' own `actions/checkout@v7` and
+`actions/setup-python@v7`.
+
+**The target for each was read out of that action's `action.yml` at the pinned ref, not inferred from
+the version number**, and one action does not follow the pattern: `actions/github-script@v7` is
+`using: node20`, and node24 only arrives at v8. A sweep that made every pin say `v7` would have
+produced a repo that looked consistent and left `require-issue-labels.yml` deprecated — the same
+shape of defect as the mixed-version file it was fixing.
+
+No bump changed an interface: `action.yml` at the new ref is byte-identical to the old one apart from
+the `using:` line in all three cases, so `fetch-depth`, `submodules`, `persist-credentials` and
+`cache-hit` keep their existing defaults and semantics. The two real behaviour changes are inert
+here — checkout v6 persists credentials to a separate file rather than `.git/config` (no workflow
+reads them or pushes), and checkout v7 blocks checking out a fork PR head under `pull_request_target`
+or `workflow_run` (neither trigger is used; the two `pull_request` workflows are unaffected).
+
 #### Four gate scripts documented as gating on exit status, run by nothing (#625)
 
 `check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py` and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,12 @@ All 17 pins across the five workflow files were enumerated rather than just the 
 `v1` tag already resolves to a `node24` build — as are `gate-scripts`' own `actions/checkout@v7` and
 `actions/setup-python@v7`.
 
+**Bumping `actions/checkout` alone would not have cleared the warning.** The annotation on the base
+commit names two actions, not one — "the following actions target Node.js 20 ... `actions/cache@v4,
+actions/checkout@v4`" — because it is emitted once per job listing every Node 20 action in that job.
+Changing only the action the issue names would have left `actions/cache@v4` behind and the warning
+still standing, while the diff looked like a fix.
+
 **The target for each was read out of that action's `action.yml` at the pinned ref, not inferred from
 the version number**, and one action does not follow the pattern: `actions/github-script@v7` is
 `using: node20`, and node24 only arrives at v8. A sweep that made every pin say `v7` would have

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,7 +44,7 @@ shape of defect as the mixed-version file it was fixing.
 
 No bump changed an interface: `action.yml` at the new ref is byte-identical to the old one apart from
 the `using:` line in all three cases, so `fetch-depth`, `submodules`, `persist-credentials` and
-`cache-hit` keep their existing defaults and semantics. The two real behaviour changes are inert
+`cache-hit` keep their declared defaults. The two real behaviour changes are inert
 here — checkout v6 persists credentials to a separate file rather than `.git/config` (no workflow
 reads them or pushes), and checkout v7 blocks checking out a fork PR head under `pull_request_target`
 or `workflow_run` (neither trigger is used; the two `pull_request` workflows are unaffected).


### PR DESCRIPTION
Closes #648

#625 bumped only the job it introduced, so `ci.yml` was left mixed-version: `actions/checkout@v7` in
`gate-scripts`, `actions/checkout@v4` in `build-and-test` and `ios-simulator-build`. Deprecation
annotations are emitted per **job**, not per workflow, so each remaining v4 job raised its own
"Node.js 20 is deprecated" warning.

## Full pin inventory — all 17, across all five workflow files

The issue named `ci.yml`. Sweeping only that file would have left the repo mixed-version while making
one file look consistent, which is the same defect one directory up. Every `uses:` in
`.github/workflows/` is listed, whether or not it changed.

The runtime column is what that action's own `action.yml` declares in `runs.using:` **at the pinned
ref**, read via `gh api repos/<owner>/<action>/contents/action.yml?ref=<tag>`, not inferred from the
version number.

| file | job | action | before | after | runtime (verified) | changed |
|---|---|---|---|---|---|---|
| `ci.yml` | `gate-scripts` | `actions/checkout` | `v7` | `v7` | `node24` | no |
| `ci.yml` | `gate-scripts` | `actions/setup-python` | `v7` | `v7` | `node24` | no |
| `ci.yml` | `build-and-test` | `actions/checkout` | `v4` | `v7` | `node20` → `node24` | **yes** |
| `ci.yml` | `build-and-test` | `maxim-lobanov/setup-xcode` | `v1` | `v1` | `node24` | no |
| `ci.yml` | `build-and-test` | `actions/cache` | `v4` | `v6` | `node20` → `node24` | **yes** |
| `ci.yml` | `ios-simulator-build` | `actions/checkout` | `v4` | `v7` | `node20` → `node24` | **yes** |
| `ci.yml` | `ios-simulator-build` | `maxim-lobanov/setup-xcode` | `v1` | `v1` | `node24` | no |
| `ci.yml` | `ios-simulator-build` | `actions/cache` | `v4` | `v6` | `node20` → `node24` | **yes** |
| `kernel-integration.yml` | `build-and-test` | `actions/checkout` | `v4` | `v7` | `node20` → `node24` | **yes** |
| `kernel-integration.yml` | `build-and-test` | `maxim-lobanov/setup-xcode` | `v1` | `v1` | `node24` | no |
| `kernel-integration.yml` | `build-and-test` | `actions/cache` (OCCT.xcframework) | `v4` | `v6` | `node20` → `node24` | **yes** |
| `kernel-integration.yml` | `build-and-test` | `actions/cache` (SwiftPM) | `v4` | `v6` | `node20` → `node24` | **yes** |
| `occt-parallel-crash-test.yml` | `test-windows` | `actions/checkout` | `v4` | `v7` | `node20` → `node24` | **yes** |
| `occt-parallel-crash-test.yml` | `test-macos` | `actions/checkout` | `v4` | `v7` | `node20` → `node24` | **yes** |
| `release.yml` | `verify-binary-pins` | `actions/checkout` | `v4` | `v7` | `node20` → `node24` | **yes** |
| `release.yml` | `verify-binary-pins` | `maxim-lobanov/setup-xcode` | `v1` | `v1` | `node24` | no |
| `require-issue-labels.yml` | `check-labels` | `actions/github-script` | `v7` | `v9` | `node20` → `node24` | **yes** |

**11 changed, 6 left alone.** After the sweep, no pin in the repo resolves to a Node 20 runtime.

### The two deliberately left unchanged, with reasons

- **`maxim-lobanov/setup-xcode@v1`** (4 sites). The issue flagged this as third-party and possibly
  without a Node 24 major. It has one, in place. `v1` is the only major tag that exists, and the
  moving tag resolves to commit `ed7a3b1` (2026-03-18) — the same commit `v1.7.0` resolves to —
  whose `action.yml` declares `using: 'node24'`. Bumping was neither possible nor needed, and the pin
  is not stale.
- **`gate-scripts`' own `actions/checkout@v7` and `actions/setup-python@v7`** — already `node24` from
  #625, and v7 is the current major for both. `actions/setup-python` was checked rather than assumed
  correct, because it shares a version number with the action that breaks the pattern below.

### Bumping `actions/checkout` alone would have left the warning standing

The issue, and the annotation quoted in it, are both phrased around `actions/checkout@v4`. The actual
annotation GitHub emitted on the base commit names **two** actions:

> **warning:** Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced
> to run on Node.js 24: **`actions/cache@v4, actions/checkout@v4`**.

One annotation per job, listing every Node 20 action in that job. So bumping only `actions/checkout` —
the action the issue names — would have left `actions/cache@v4` behind, the warning would still have
been emitted on both `build-and-test` and `ios-simulator-build`, and the diff would have looked like a
fix while changing nothing observable. That is the same trap as #647's, one level in: #647 got the
*per-job* granularity right and missed the sibling jobs; reading only the issue's headline action
would have got the *per-job* granularity right and missed the sibling action in the same job.

This is why the fix is 11 pins and not 6.

### The version number is not the runtime

`actions/github-script@v7` is **`using: node20`**, despite matching the `v7` that `actions/checkout`
and `actions/setup-python` are correct at. node24 first arrives in github-script **v8**. A sweep
driven by "make everything say v7" — which the issue's own summary invites, naming v7 as the current
major — would have produced a repo where every pin agreed and `require-issue-labels.yml` was still
deprecated. That job goes to **v9**, the current major.

Each target tag was also confirmed to exist before pinning
(`gh api repos/<owner>/<action>/git/matching-refs/tags/v`): checkout `v1`–`v7`, cache `v1`–`v6`
(**no v7** — v6 is the current major, which is why cache lands on a different number than checkout),
github-script `v1`–`v9`, setup-python `v1`–`v7`, setup-xcode `v1` only.

## Breaking-change check, per action

**No bump changed an interface.** `action.yml` at the new ref is byte-identical to the old ref apart
from the `using:` line, in all three cases — established by diffing the two files, not by trusting
release notes:

```
$ diff checkout-v4.yml checkout-v7.yml
116c116
<   using: node20
---
>   using: node24
```

The same single-line diff holds for `cache` v4→v6 and `github-script` v7→v9. So `fetch-depth`
(default `1`), `submodules` (default `false`), `persist-credentials` (default `true`) and cache's
`cache-hit` output all keep their declared defaults. What the manifest proves is the *declared*
interface; the compiled JS behind it is covered by the behaviour-change review below, not by this
diff. `kernel-integration.yml` reads
`steps.occt-cache.outputs.cache-hit` to skip a 60-minute source build; that output is unchanged.

Behaviour changes that exist outside the interface, from each action's changelog:

- **`actions/checkout` v6.0.0 — "Persist creds to a separate file"** ([PR 2286](https://github.com/actions/checkout/pull/2286)).
  Credentials move out of `.git/config` into a separate credential file. Inert here:
  `grep -rn "persist-credentials\|GITHUB_TOKEN\|git push\|git config\|\.git/config\|extraheader" .github/workflows/`
  returns nothing — no workflow pushes, reads the persisted token, or re-uses the checkout's git
  credentials.
- **`actions/checkout` v7.0.0 — "Block checking out fork PR for `pull_request_target` and
  `workflow_run`"** ([PR 2454](https://github.com/actions/checkout/pull/2454)). A genuine refusal,
  not a warning. Inert here: neither trigger is used anywhere in the repo. The triggers in use are
  `pull_request` (ci, kernel-integration), `push`, `workflow_dispatch`, `release` and `issues`, and
  plain `pull_request` is unaffected.
- **`actions/checkout` v5 / `actions/cache` v5 / `actions/github-script` v8 — minimum runner
  `v2.327.1`.** Every `runs-on` in the repo is GitHub-hosted (`ubuntu-latest`, `macos-15`,
  `macos-latest`, `windows-latest`); there are no self-hosted runners, so the floor is met.
- **`actions/cache` v6.0.0 — ESM migration.** Packaging only; no documented behaviour change and no
  interface change per the diff above.
- **`actions/github-script` v9.0.0 — two breaking changes.** `require('@actions/github')` no longer
  works inside a script, and `getOctokit` is now an injected parameter, so a script declaring
  `const getOctokit` gets a `SyntaxError`. Neither applies: the script in `require-issue-labels.yml`
  uses only the injected `context` and `github.rest.issues.*`, and greps clean for `require(`,
  `getOctokit` and `@actions/github`.

Nothing needed adapting, and nothing had to be held back at an old pin for a behavioural reason.

## Evidence

- All five workflow files re-parse as YAML after the edits.
- The four `gate-scripts` gates run clean locally on this branch: `check-bridge-index.py` exit 0
  (728 symbols / 383 classes, 0 stale, 0 misfiled), `check-null-handle-guards.py` exit 0,
  `check-docs-defaults.py` exit 0 (0 drifted, 0 unverified), `count-operations.py` exit 0
  (4301 = README = API_REFERENCE).
- Per-job annotation state from this PR's own CI run is posted as a comment below, since annotations
  are emitted per job and can only be read off a real run.

`build-and-test` (macOS) is red branch-wide on `refactor/**` from #585's pinned-kernel mismatch and
stays red here for that reason. What this PR is accountable for is that it still reaches `swift test`
rather than failing earlier, at checkout or cache restore.

## Docs

`docs/CHANGELOG.md` gains an Unreleased entry under the Pass 1b heading. No version invented, no
operation counts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
