### PR TITLE
chore(#649): the required check's name stops being a prose string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,13 @@ jobs:
   # Two of the four (check-bridge-index, check-null-handle-guards) resolve their inputs relative to
   # the working directory and exit 2 with "run from the repo root" elsewhere; the other two resolve
   # from __file__. A GitHub Actions step starts at the repo root, so both kinds are satisfied.
+  # Deliberately NO `name:` key. The check-run name GitHub publishes is a job's `name:` when it has
+  # one and the job id otherwise, and that string is what a required-status-check rule matches. A
+  # prose name reads like a comment, so rewording it for clarity would silently stop satisfying the
+  # rule — the check would drop out of "required" and the PR UI would look identical to a working
+  # gate. Falling back to the job id makes the required context a stable identifier nobody edits for
+  # readability. This job is required on refactor/** (#649); see CLAUDE.md before renaming it.
   gate-scripts:
-    name: gate scripts (static, no build)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,22 @@ its own status check when `build-and-test` is red for an unrelated reason (#585'
 mismatch on `refactor/**` branches). Each exits 1 on a defect and 0 when clean; `check-bridge-index`
 and `check-null-handle-guards` exit **2** if run from anywhere but the repo root (#625).
 
+**`gate-scripts` is a required status check on `refactor/**`** (#649), via a repository ruleset — the
+repo's only branch protection. Three consequences worth knowing before you touch it:
+
+- **Do not give the job a `name:` key.** The published check-run name is the job's `name:` when it
+  has one and the job id otherwise, and that string is what the rule matches. A prose name reads
+  like a comment, so rewording it would silently stop satisfying the rule while the PR UI looked
+  unchanged — the same class of failure the gates themselves exist to catch. The job id is a stable
+  identifier nobody edits for readability.
+- **It is not required on `main`, and must not be until `ci.yml` carrying this job lands there.** A
+  required check that never reports blocks a PR permanently with "Expected, waiting for status to be
+  reported", and there is no way to clear it. For a `pull_request` the workflow is read from the
+  merge ref, so once the base has the job every PR gets it regardless of how stale the head is.
+- **`build-and-test` is deliberately not required on `refactor/**`** — it is 0-for-21 there under
+  #585. It *is* ~9/10 green on `main`, so the requirable set inverts per branch; #585 is confined to
+  this branch and its descendants, not repo-wide.
+
 ```bash
 python3 Scripts/check-bridge-index.py        # OCCTBridge.h's class → symbol index: stale / misfiled entries
 python3 Scripts/check-null-handle-guards.py  # every bridge fn guards the Handle, not just the pointer


### PR DESCRIPTION
Part of #649 — the rename that must land **before** the ruleset is applied.

## Why

`gate-scripts` is becoming a required status check on `refactor/**`. The context such a rule matches is the **check-run name**, which GitHub takes from the job's `name:` when it has one and from the **job id** otherwise.

Today that name is the prose string `gate scripts (static, no build)`. It reads like a comment. If anyone rewords it for clarity, the ruleset keeps pointing at the old string, the check quietly stops being required, and the PR UI looks identical to a working gate.

That is the #618 failure class — a detector reporting *all clear* because it is blind, indistinguishable from one reporting *all clear* because the tree is clean — reproduced one level up, in the enforcement rather than the detector. Three gate scripts on this branch already shipped confidently wrong; this makes the thing that enforces them harder to disarm by accident.

Dropping the key makes the required context the job id, which nobody edits for readability. **Cost:** a less readable label in the checks list.

## Ordering

This must merge before the ruleset is created. Applying a rule that requires `gate-scripts` while the job still publishes `gate scripts (static, no build)` would block every PR into `refactor/**` with an unclearable *"Expected, waiting for status to be reported"* — including this one.

## Also recorded in CLAUDE.md

- The requirement itself, and why the `name:` key is deliberately absent.
- **It is not required on `main`, and must not be until `ci.yml` carrying this job lands there.** For a `pull_request` the workflow is read from the merge ref, so once the base has the job every PR gets it regardless of how stale the head is — but until then a required check would never report.
- **`build-and-test` is deliberately not required on `refactor/**`** (0-for-21 under #585). It is ~9/10 green on `main`, so the requirable set inverts per branch. #585 is confined to this branch and its descendants, not repo-wide — a correction to how it has been described.

## Verification

YAML parses; jobs unchanged at `gate-scripts`, `build-and-test`, `ios-simulator-build`; `gate-scripts` now has no `name:` key. All four gates pass locally (exit 0). The check-run name this PR's own CI run publishes is the confirmation that matters, and it is read from the API rather than the PR UI before the ruleset goes anywhere near the repo.

`build-and-test` is expected red (#585, signature `Issue570HealingApproxTests (fitted.uDegree → 1) > 1`).