### PR TITLE
v2.0.0 plan, the two breakdown census scripts, and switching off the prebuilt bridge

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,18 @@ let occtTarget: Target = useLocalBinary
 // same core slices as OCCT.xcframework (macOS, iOS device, iOS simulator, see Scripts/build-occt.sh);
 // visionOS/tvOS consumers must leave the env var unset (source build) or rebuild the prebuilt locally
 // with BUILD_ALL_PLATFORMS=1.
-let useBridgePrebuilt = ProcessInfo.processInfo.environment["OCCTSWIFT_BRIDGE_PREBUILT"] == "1"
+// DISABLED FOR THE v2.0.0 LINE. The prebuilt path is switched off here rather than deleted: nearly
+// every issue in the 2.0.0 queue edits Sources/OCCTBridge/src/*.mm, and a prebuilt binary that
+// predates the edit links silently and reports a pass for code that was never compiled. The 8.0.1
+// absorb hit exactly that: the shared prebuilt predated the #656 null-pcurve guard while
+// OCCTSWIFT_BRIDGE_PREBUILT=1 was set in the environment, so the default path would have linked a
+// guard-less bridge against a kernel whose OCCT#1402 had started returning null, which is the
+// combination that SIGSEGVs. Paying ~50s per rebuild is the cheaper side of that trade.
+//
+// To restore (release commit, once the bridge stops changing every PR): delete the `false &&` and
+// bump the url:/checksum: below to a freshly built asset.
+let useBridgePrebuilt = false
+    && ProcessInfo.processInfo.environment["OCCTSWIFT_BRIDGE_PREBUILT"] == "1"
 let useBridgeLocalBinary = useBridgePrebuilt
     && FileManager.default.fileExists(atPath: occtPackageDir + "/Libraries/OCCTBridge.xcframework/Info.plist")
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ See [docs/guides/building-occt.md](docs/guides/building-occt.md) for details.
 ### Prebuilt OCCTBridge (opt-in)
 
 The Objective-C++ bridge (16 files, ~62K lines) compiles from source by default. Consumers who
-don't need to edit it can opt into a prebuilt binary instead — set `OCCTSWIFT_BRIDGE_PREBUILT=1`.
+don't need to edit it could opt into a prebuilt binary instead. That switch is **disabled on the
+v2.0.0 line** (see [the guide](docs/guides/prebuilt-bridge.md)); the bridge always builds from source.
 See [docs/guides/prebuilt-bridge.md](docs/guides/prebuilt-bridge.md).
 
 ## Documentation

--- a/Scripts/derive-bridge-header-split.py
+++ b/Scripts/derive-bridge-header-split.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Derive the OCCTBridge.h -> per-domain header split from the .mm files (#395).
+
+The implementation side of the bridge was split into 16 domain files long ago; the header never
+followed. This computes, for every function declared in OCCTBridge.h, which .mm file defines it,
+which is the only thing the split needs to be decided by. Run it before starting #395 and again
+afterwards to prove nothing moved to the wrong header.
+
+    python3 Scripts/derive-bridge-header-split.py            # print the manifest summary
+    python3 Scripts/derive-bridge-header-split.py --list      # print every symbol and its target
+    python3 Scripts/derive-bridge-header-split.py --verify    # exit 1 if the split is not total
+
+Exits 2 if run from anywhere but the repo root, matching the other gate scripts (#625).
+
+Why this is a script and not a list in an issue: the repo's history is full of censuses that were
+built by grep, written into an issue body, and then turned out to be wrong once measured (#558,
+#571, #583, #595, #573). A derivation that can be re-run does not go stale in the same way.
+"""
+
+import argparse
+import collections
+import json
+import os
+import re
+import sys
+
+SRC_DIR = "Sources/OCCTBridge/src"
+HEADER = "Sources/OCCTBridge/include/OCCTBridge.h"
+
+# A definition line in a .mm: optional return type, then the OCCT-prefixed name, then '('.
+DEFN = re.compile(r"^[A-Za-z_][\w\s\*\(\)<>,:]*?\b(OCCT[A-Za-z0-9_]+)\s*\(", re.M)
+# Any OCCT-prefixed name used in call/declaration position in the header.
+DECL = re.compile(r"\b(OCCT[A-Za-z0-9_]+)\s*\(")
+# Opaque handle typedefs stay in the umbrella header, they are not functions.
+TYPEDEF = re.compile(r"typedef\s+struct\s+\w+\s*\*\s*(OCCT[A-Za-z0-9_]+)\s*;")
+
+
+def target_header(mm_name):
+    """OCCTBridge_Modeling.mm -> OCCTBridge_Modeling.h; OCCTBridge.mm -> the umbrella."""
+    stem = mm_name[:-3]
+    return "OCCTBridge.h" if stem == "OCCTBridge" else f"{stem}.h"
+
+
+def derive():
+    definitions = {}
+    for name in sorted(os.listdir(SRC_DIR)):
+        if name.endswith(".mm"):
+            text = open(os.path.join(SRC_DIR, name), errors="ignore").read()
+            definitions[name] = set(DEFN.findall(text))
+
+    header = open(HEADER, errors="ignore").read()
+    declared = set(DECL.findall(header)) - set(TYPEDEF.findall(header))
+
+    mapping, ambiguous, unmapped = {}, {}, []
+    for symbol in sorted(declared):
+        owners = [mm for mm, names in definitions.items() if symbol in names]
+        if len(owners) == 1:
+            mapping[symbol] = target_header(owners[0])
+        elif owners:
+            ambiguous[symbol] = [target_header(o) for o in owners]
+        else:
+            unmapped.append(symbol)
+    return mapping, ambiguous, unmapped
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true", help="print every symbol and its target header")
+    ap.add_argument("--verify", action="store_true", help="exit 1 unless every symbol maps to one header")
+    ap.add_argument("--json", metavar="PATH", help="write the manifest as JSON")
+    args = ap.parse_args()
+
+    if not os.path.isdir(SRC_DIR) or not os.path.isfile(HEADER):
+        print(f"error: run from the repo root (expected {SRC_DIR} and {HEADER})", file=sys.stderr)
+        return 2
+
+    mapping, ambiguous, unmapped = derive()
+
+    if args.list:
+        for symbol, header in sorted(mapping.items(), key=lambda kv: (kv[1], kv[0])):
+            print(f"{header}\t{symbol}")
+    else:
+        for header, count in collections.Counter(mapping.values()).most_common():
+            print(f"  {count:5d}  {header}")
+
+    print(f"\nmapped: {len(mapping)}   ambiguous: {len(ambiguous)}   unmapped: {len(unmapped)}")
+
+    for symbol, headers in sorted(ambiguous.items()):
+        print(f"  AMBIGUOUS  {symbol}: {', '.join(headers)}", file=sys.stderr)
+    for symbol in unmapped:
+        print(f"  UNMAPPED   {symbol}", file=sys.stderr)
+
+    if args.json:
+        json.dump(mapping, open(args.json, "w"), indent=0, sort_keys=True)
+        print(f"manifest written to {args.json}")
+
+    if args.verify and (ambiguous or unmapped):
+        print(
+            "\nThe split is not total. Resolve each symbol above before moving declarations:\n"
+            "  AMBIGUOUS means two .mm files define the same symbol, which is a real defect.\n"
+            "  UNMAPPED means the header declares something no .mm defines, so it is either dead\n"
+            "  or defined somewhere the parser does not look.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/derive-swift-file-split.py
+++ b/Scripts/derive-swift-file-split.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Measure what is actually inside Document.swift and Shape.swift, for #393 and #394.
+
+Both issues were written on the premise that these files are already organised as thematic
+`extension` blocks, so the split is a mechanical move of each `// MARK:` section. Measurement says
+otherwise, and that premise is why the two issues need rewriting before anyone starts:
+
+  - The MARK sections are RELEASE BATCHES, not domains. 240 of Document.swift's 277 top-level marks
+    carry a version tag like "(v0.109.0)", and a batch contains whatever landed in that release
+    across every domain. Splitting on MARK boundaries would produce Document+v0.109.swift.
+  - Document.swift is not a Document file. It has more `extension Shape` than `extension Document`,
+    and 40% of it is standalone types that extend nothing.
+
+So the split axis is the TYPE each declaration belongs to, which is what this reports.
+
+    python3 Scripts/derive-swift-file-split.py                 # summary for both files
+    python3 Scripts/derive-swift-file-split.py --list Document # every declaration and its owner
+
+Exits 2 if run from anywhere but the repo root, matching the other gate scripts (#625).
+"""
+
+import argparse
+import collections
+import os
+import re
+import sys
+
+FILES = {
+    "Document": "Sources/OCCTSwift/Document.swift",
+    "Shape": "Sources/OCCTSwift/Shape.swift",
+}
+
+DECL = re.compile(
+    r"^(?:public |internal |private |package |)?(?:final )?"
+    r"(extension|class|struct|enum|protocol|actor)\s+([A-Za-z_]\w*)"
+)
+
+
+def scan(path):
+    """Yield (kind, name, line_count) for every top-level declaration, by brace depth."""
+    lines = open(path, errors="ignore").read().split("\n")
+    i, n = 0, len(lines)
+    while i < n:
+        m = DECL.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        kind, name, start = m.group(1), m.group(2), i
+        depth, opened = 0, False
+        while i < n:
+            depth += lines[i].count("{") - lines[i].count("}")
+            opened = opened or "{" in lines[i]
+            i += 1
+            if opened and depth <= 0:
+                break
+        yield kind, name, i - start
+
+
+def report(label, path, show_list):
+    extended = collections.Counter()
+    standalone = collections.Counter()
+    for kind, name, size in scan(path):
+        (extended if kind == "extension" else standalone)[name] += size
+        if show_list:
+            print(f"{size:6d}\t{'extension' if kind == 'extension' else 'type'}\t{name}")
+    if show_list:
+        return
+
+    total = sum(extended.values()) + sum(standalone.values())
+    file_lines = sum(1 for _ in open(path, errors="ignore"))
+    print(f"### {os.path.basename(path)}: {file_lines} lines, {total} inside top-level declarations")
+    print("    extensions, by the type they extend:")
+    for name, size in extended.most_common():
+        print(f"      {size:6d}  extension {name}")
+    print(f"    standalone types declared here: {len(standalone)} types, {sum(standalone.values())} lines")
+    for name, size in standalone.most_common(8):
+        print(f"      {size:6d}  {name}")
+    if len(standalone) > 8:
+        print(f"      ... and {len(standalone) - 8} more")
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", metavar="WHICH", choices=sorted(FILES), help="print every declaration")
+    args = ap.parse_args()
+
+    for path in FILES.values():
+        if not os.path.isfile(path):
+            print(f"error: run from the repo root (expected {path})", file=sys.stderr)
+            return 2
+
+    for label, path in FILES.items():
+        if args.list and args.list != label:
+            continue
+        report(label, path, bool(args.list))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -224,7 +224,7 @@ OCCTSwift/
 │           └── OCCTBridge.mm   # OCCT C++ implementations
 ├── Libraries/
 │   ├── OCCT.xcframework/       # Pre-built OCCT 8.0.0-rc5
-│   └── OCCTBridge.xcframework/ # Pre-built bridge (opt-in, see OCCTSWIFT_BRIDGE_PREBUILT)
+│   └── OCCTBridge.xcframework/ # Pre-built bridge (DISABLED on the v2.0.0 line)
 ├── Scripts/
 │   ├── build-occt.sh           # Build OCCT from source
 │   └── build-occtbridge.sh     # Build the prebuilt OCCTBridge.xcframework

--- a/docs/guides/prebuilt-bridge.md
+++ b/docs/guides/prebuilt-bridge.md
@@ -1,5 +1,11 @@
 # Prebuilt OCCTBridge (opt-in)
 
+> **Disabled on the v2.0.0 line.** `Package.swift` currently forces the source build and ignores
+> `OCCTSWIFT_BRIDGE_PREBUILT` entirely. Nearly every issue in the 2.0.0 queue edits
+> `Sources/OCCTBridge/src/*.mm`, and a prebuilt that predates the edit links silently and reports a
+> pass for code that was never compiled. The OCCT 8.0.1 absorb hit exactly that. Everything below
+> describes the mechanism and applies again once the switch is restored in the release commit.
+
 `OCCTBridge` is 16 Objective-C++ files, ~62K lines, wrapping the OCCT header tree. By default
 SwiftPM compiles it from source on every consumer build. Since every `.mm` translation unit
 includes a large slice of OCCT's ~1,700 headers, this dominates rebuild time in any consumer

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,8 @@ figure (interactive 3D where it helps). The **[Cookbook index](guides/cookbook/)
 - [Sharing the xcframework](guides/sharing-the-xcframework.md) — one shared local copy across repos + the `Package.resolved` pin footgun (#260).
 - [Thread Safety](thread-safety.md) · [Naming Conventions](naming-conventions.md) ·
   [Versioning (SemVer)](SEMVER.md) · [Ecosystem](ecosystem.md)
+- [v2.0.0 Release Plan](v2.0.0-plan.md) — scope, clusters, and the census-once rule for the
+  in-flight major.
 
 ## Project
 

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -8,14 +8,17 @@ nav_order: 12
 The scope, the working method, and the order of execution for the next major release. This is the
 durable reference; the GitHub issues point here rather than restating it.
 
+Tracking issue: **#669**. Branch: `refactor/381-pass1b`, and every child PR targets that branch
+rather than `main`.
+
 ## Scope
 
 Four workstreams, and nothing else:
 
 | Workstream | Issue | State |
 |---|---|---|
-| Pass 1a, geometry primitives duplication audit | #380 | Landed, under re-review |
-| Pass 1b, C++ bridge header duplication audit | #381 | 9 findings open |
+| Pass 1a, geometry primitives duplication audit | #380 | Closed, flagged for a re-review pass |
+| Pass 1b, C++ bridge header duplication audit | #381 | All 9 findings fixed, awaiting the merge to `main` to close |
 | OCCT 8.0.1 absorb | #654 | Kernel landed, follow-through open |
 | The three file breakdowns | #393, #394, #395 | Detailed, ready to dispatch |
 
@@ -95,7 +98,7 @@ APIs over one OCCT class) are instances of it. Do the census, then the instances
 approximation without reading its error (#597); the Gordon tests cannot fail (#645). Both are the
 tail of #522's blast radius, and #645 is a coverage prerequisite, not an ordinary fix.
 
-**Standalone**, owned directly by the master issue: #598 (the two pipe sweep modes are wired to each
+**Standalone**, owned directly by #669: #598 (the two pipe sweep modes are wired to each
 other's OCCT mode, a breaking fix) and #640 (solver dimension arguments trap, `leastSquares` reads
 out of bounds).
 
@@ -107,7 +110,8 @@ out of bounds).
    issue) so it goes first and de-risks the pattern.
 2. **Coverage prerequisites**: #645, and the INTERNAL/EXTERNAL gap named in #655.
 3. **Cluster censuses**, in parallel once the layout is stable.
-4. **Cluster A**, then **B**, **C**, **D**, **E** (B after A; C, D, E are independent).
+4. **Cluster A** (#664), then **B** (#665). **C** (#666), **D** (#667) and **E** (#668) are
+   independent of A and of each other.
 5. **Standalones and 8.0.1 follow-through** (#598, #640, #655, #657) any time after step 1.
 6. **Release**: `url:`/`checksum:` bump, prebuilt bridge re-enabled, docs, tag.
 

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -1,0 +1,142 @@
+---
+title: v2.0.0 Release Plan
+nav_order: 12
+---
+
+# v2.0.0 Release Plan
+
+The scope, the working method, and the order of execution for the next major release. This is the
+durable reference; the GitHub issues point here rather than restating it.
+
+## Scope
+
+Four workstreams, and nothing else:
+
+| Workstream | Issue | State |
+|---|---|---|
+| Pass 1a, geometry primitives duplication audit | #380 | Landed, under re-review |
+| Pass 1b, C++ bridge header duplication audit | #381 | 9 findings open |
+| OCCT 8.0.1 absorb | #654 | Kernel landed, follow-through open |
+| The three file breakdowns | #393, #394, #395 | Detailed, ready to dispatch |
+
+Everything from the branch code reviews rides along with these, grouped into clusters below.
+
+**Deferred to after 2.0.0:** audit Passes 2a through 5d (#382 to #392) and the further breakout
+backlog (#396). They are real work and they stay on the board, but they are not gating this
+release. #377 records that split.
+
+**Not in scope:** #342 (bridge thread-handling contract) and #369 (OSD_ThreadPool root cause).
+Both are architecture-scale investigations whose findings would reshape the bridge; starting them
+inside a release that is already redistributing 55,000 lines invites two rewrites of the same code.
+
+## Why this plan exists: the ground we keep re-covering
+
+The repo's own history names the failure mode. Nearly every closed issue records a variant of one
+sentence: *the census said N, the measurement said M.*
+
+- #558: census said 14 sites, measurement said 28
+- #571: census said 3, measured 6
+- #583: census said five, measured six
+- #595: census said six, measured nine
+- #573: the issue's own fix table contained a fresh error
+- #507, #553, #562: the census criterion itself was wrong
+
+The repeated ground is not the fixes. It is that **each issue rebuilds the same census from
+scratch, usually by grep, and gets it wrong**, then the next issue in the same family rebuilds it
+again and gets it wrong differently. Three of the gate scripts on this branch were confidently
+wrong for exactly this reason (#618, #624, #626).
+
+### The rule
+
+**Build each census once, as a committed executable artifact, before fixing anything in its
+family.**
+
+A census artifact is a probe under `Scripts/repro/<cluster>/` that *enumerates and measures* its
+family against the real kernel, and prints a table. Not a grep, not a list in an issue body. Every
+issue in the cluster consumes that artifact instead of re-deriving it, and the artifact is updated
+(not replaced) when a member issue proves it incomplete.
+
+This is the difference between twenty investigations and six. It also gives every fix in the
+cluster a before/after that costs nothing extra to produce.
+
+Two corollaries learned the hard way during the 8.0.1 absorb:
+
+- **A grep-shaped census is blind to indirection.** `check-null-handle-guards.py` misses handles
+  obtained locally and passed onward, which is how #656's SIGSEGV survived every gate.
+- **A green suite is not evidence where there is no coverage.** No test in this repo uses
+  INTERNAL/EXTERNAL edge orientation, and #645 records that the Gordon tests assert only status
+  ordinals. In those areas a passing run proves nothing, so the coverage has to come first.
+
+## Clusters
+
+Each cluster gets a tracking issue that owns its census artifact. Member issues are sub-issues of
+it and must not start before the census lands.
+
+**A. Sub-shape enumeration and orientation.** `edges()` collapses 24 occurrences to 12 distinct
+(#638); `detectPocketsAAG()` rides the lossy enumeration and returns different answers for the same
+geometry depending on compound member order (#642); the `nbEdges`/`nbVertices`/`nbFaces` counts
+contradict their own documentation (#651). #613 and #614 already fixed the `faces()` half of this.
+Highest leverage in the release: fixing the root changes what B even needs.
+
+**B. Fillet and chamfer edge-set contract.** A duplicate edge index silently discards a radius
+(#633); the family cannot tell a caller that OCCT declined edges it named (#639). Both are about
+how the family interprets the caller's edge list, so both depend on A.
+
+**C. Crash guards.** `Curve3D.extrema` on parallel curves (#636), `GeomTools_Curve2dSet`/`SurfaceSet`
+null handles (#643), `Surface.appSurf` with a single curve (#644). #656 is the same family and is
+already fixed. The census here is not a probe but a **checker upgrade**: teach
+`check-null-handle-guards.py` the shape it is currently blind to, and it enumerates the rest.
+
+**D. Continuity.** #513 is already an explicit census of 38 unaudited functions and four
+incompatible request encodings. #437 (`plateSurface` can never accept `.g2`) and #438 (two public
+APIs over one OCCT class) are instances of it. Do the census, then the instances fall out.
+
+**E. Approximation error reporting.** `GeomFill_Sweep` and `ShapeUpgrade_UnifySameDomain` accept an
+approximation without reading its error (#597); the Gordon tests cannot fail (#645). Both are the
+tail of #522's blast radius, and #645 is a coverage prerequisite, not an ordinary fix.
+
+**Standalone**, owned directly by the master issue: #598 (the two pipe sweep modes are wired to each
+other's OCCT mode, a breaking fix) and #640 (solver dimension arguments trap, `leastSquares` reads
+out of bounds).
+
+## Order
+
+1. **The three breakdowns (#395, then #394, #393).** They touch 55,000 lines across three files
+   that nearly every other issue also edits. Doing them first means every later fix lands in the
+   new layout; doing them last means three enormous rebases. #395 is fully mechanical (see the
+   issue) so it goes first and de-risks the pattern.
+2. **Coverage prerequisites**: #645, and the INTERNAL/EXTERNAL gap named in #655.
+3. **Cluster censuses**, in parallel once the layout is stable.
+4. **Cluster A**, then **B**, **C**, **D**, **E** (B after A; C, D, E are independent).
+5. **Standalones and 8.0.1 follow-through** (#598, #640, #655, #657) any time after step 1.
+6. **Release**: `url:`/`checksum:` bump, prebuilt bridge re-enabled, docs, tag.
+
+## Execution mechanics
+
+**The bridge always builds from source on this branch.** `Package.swift` forces it and ignores
+`OCCTSWIFT_BRIDGE_PREBUILT`. Nearly every issue here edits `Sources/OCCTBridge/src/*.mm`, and a
+prebuilt that predates the edit links silently and reports a pass for code that was never compiled.
+That is not hypothetical: it nearly happened during the 8.0.1 absorb. Restoring the switch is part
+of the release commit.
+
+**`build-and-test` is structurally red for the whole release and that is expected.** It resolves
+`Package.swift`'s pinned released asset, which cannot contain unreleased kernel patches (#585). The
+merge criterion is **parity with the base branch**, not green: same failing set, same count. Any
+change in the failure *set* or *mode* is a real signal and must be investigated, not waved through.
+During the 8.0.1 absorb the first run died with a SIGSEGV rather than the expected assertion
+failures, which turned out to be the known #344/#345 flake, but only checking established that.
+
+**`kernel-integration.yml` is the real check.** It is the only job that compiles the patched kernel,
+and it takes roughly 80 minutes. Run it at cluster boundaries rather than per PR.
+
+**`gate-scripts` must be green on every PR.** It is the one required check on `refactor/**` (#649).
+
+## Versioning
+
+v2.0.0 is triggered by Rule 2 in [SEMVER.md](SEMVER.md), the accumulated breaking changes to the
+public Swift API, not by the OCCT version. The 8.0.1 re-pin rides along rather than causing it.
+
+Every break lands in the register in `SEMVER.md` with its migration **before** the tag, not after.
+Known breaks so far: #609's twelve mass-property signature changes (already held for this major),
+#619, #495, #499, #541, #568, #613, #498, #502, and #598. The breakdowns (#393 to #395) must add
+none, and that is an acceptance criterion on each.


### PR DESCRIPTION
The v2.0.0 plan, written down, plus the two census scripts the file breakdowns needed and the
prebuilt-bridge switch-off. Issue structure for the release is in #669.

## docs/v2.0.0-plan.md

Scope is four workstreams (Pass 1a, Pass 1b, the OCCT 8.0.1 absorb, the three file breakdowns) plus
the branch review findings grouped into five clusters. Audit passes 2a to 5d and the breakout
backlog are deferred **explicitly** rather than left ambiguous, and #342/#369 are named out of scope
with the reason.

The load-bearing section is the census-once rule. The argument is the repo's own history: #558's
census said 14 and measured 28, #571 said 3 and measured 6, #583 said five and measured six, #595
said six and measured nine, #573's own fix table had a fresh error. What gets re-covered is not the
fixes, it is each issue rebuilding the same census by grep and getting it wrong differently. So each
cluster owns one committed executable census and no member issue starts before it lands.

## The prebuilt bridge is switched off for this line

Nearly every issue in the queue edits `Sources/OCCTBridge/src/*.mm`, and a prebuilt that predates the
edit links silently and reports a pass for code that was never compiled.

That is not hypothetical. During the 8.0.1 absorb the shared prebuilt predated the #656 null-pcurve
guard while `OCCTSWIFT_BRIDGE_PREBUILT=1` was set in the environment, so the default path would have
linked a guard-less bridge against a kernel whose OCCT#1402 had just started returning null: exactly
the pair that SIGSEGVs. It was caught only by comparing timestamps by hand.

Switched off as `false && <the env check>` rather than deleted, so restoring it in the release commit
is removing two words. Verified the source path is taken even with the variable set.

## Two census scripts, and what they found

**`derive-bridge-header-split.py`** answers #395 completely. Of the 4021 functions `OCCTBridge.h`
declares, every one is defined in exactly one `.mm`. Zero ambiguous, zero unmapped. That inverts the
issue's own risk assessment: #395 called itself "the highest-risk of the three" and it is in fact the
only one whose answer is a lookup rather than a judgement call.

**`derive-swift-file-split.py`** contradicts the premise of #393 and #394. Both said the files are
already thematic extension blocks splittable on `// MARK:` boundaries. Measured:

- The marks are **release batches**, not domains. 240 of `Document.swift`'s 277 carry a tag like
  `(v0.109.0)` and each spans every domain. A MARK-based split yields `Document+v0.109.swift`.
- **`Document.swift` is not a Document file.** 2489 lines of `extension Shape` against 2315 of
  `extension Document`, plus 6530 lines of 140 standalone types. Only 14% is what its name says.

Both issues have been rewritten around the measurements and broken into staged sub-issues.

Both scripts exit 2 outside the repo root, matching #625's convention.

## Verification

- All four existing gate scripts green, plus their `--self-test`s
- Both new scripts green, and both exit 2 from a non-root directory
- No `swift` source changed, so no test movement is expected; `Package.swift`'s manifest change was
  verified by building both resolution paths

## Note on why this is a PR

`refactor/381-pass1b` requires the `gate-scripts` check (#649), so a direct push is rejected. Every
change to that branch now goes through a PR, which is the intended behaviour.