### PR TITLE
Record how the v2.0.0 release is tracked on the board

### DIFF
--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -115,6 +115,27 @@ out of bounds).
 5. **Standalones and 8.0.1 follow-through** (#598, #640, #655, #657) any time after step 1.
 6. **Release**: `url:`/`checksum:` bump, prebuilt bridge re-enabled, docs, tag.
 
+## How the release is tracked
+
+Four mechanisms, each doing one job, so none of them has to be maintained by hand from the others:
+
+| Mechanism | What it expresses |
+|---|---|
+| **Milestone `v2.0.0`** | Membership. 123 issues, derived by walking the #669 sub-issue tree rather than typed out. Gives the progress bar. |
+| **Sub-issue links** | Hierarchy. GitHub derives the board's read-only `Parent issue` and `Sub-issues progress` fields from these, so the tree needs no separate upkeep. |
+| **`phase:*` labels** | Workstream. Extends the existing audit-pass taxonomy with `phase:cluster-a` to `phase:cluster-e`, `phase:occt-801`, and the pre-existing `phase:file-breakout`. |
+| **Board `Status`** | State. Backlog, In Progress, PR Review, Code-Review, Ready, Done. |
+
+`release:v2.0.0` duplicates the milestone as a label, because the board can filter on labels in views
+where milestone filtering is awkward. The two are kept in exact agreement; if they ever disagree the
+milestone wins, since it is the one derived from the issue tree.
+
+**One trap worth knowing.** 31 issues in this milestone are fixed and merged but still show open,
+because `Closes #N` only fires when a PR merges into the **default** branch and everything here
+merges into `refactor/381-pass1b`. They are marked **Done** on the board and will close themselves
+when the branch reaches `main`. Check the board Status before picking anything up: the GitHub open
+or closed state is not the truth during this release.
+
 ## Execution mechanics
 
 **The bridge always builds from source on this branch.** `Package.swift` forces it and ignores


### PR DESCRIPTION
Documents the four tracking mechanisms now in place (milestone for membership, sub-issue links for hierarchy, `phase:*` labels for workstream, board Status for state) and, more usefully, the trap that 31 issues in the milestone are fixed and merged while still showing open.

That happens because `Closes #N` only fires on a merge to the **default** branch, and everything in this release merges into `refactor/381-pass1b`. They are marked Done on the board. During this release the GitHub open/closed state is not the truth, which is exactly the sort of thing that gets work redone.

Docs only, no code.