### PR TITLE
Add okf/policies/prove-the-test-fails, and point the open issues at it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,12 @@ suite into these targets (each `Tests/OCCT<Domain>Tests/`, declared in `Package.
   Not: `#expect(result != nil); #expect(result!.isValid)`
 - Edge indices may vary across runs — iterate edges to find a working one when testing edge-specific operations
 - Wrap OCCT calls that may throw `StdFail_NotDone` in try-catch on the C bridge side
+- **Prove the test fails.** Every new test, and every new `--self-test` case, is run once with its
+  subject broken: inject the defect, confirm the failure, restore, confirm the pass, report both.
+  Adding a self-test is not the rule, watching it fail is. See
+  [`okf/policies/prove-the-test-fails.md`](okf/policies/prove-the-test-fails.md) for why this is a
+  policy here rather than a preference, including the two occasions a `--self-test` passed 6/6
+  while one of its cases proved nothing.
 
 ## Known OCCT Bugs
 

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -69,6 +69,11 @@ Two corollaries learned the hard way during the 8.0.1 absorb:
 - **A green suite is not evidence where there is no coverage.** No test in this repo uses
   INTERNAL/EXTERNAL edge orientation, and #645 records that the Gordon tests assert only status
   ordinals. In those areas a passing run proves nothing, so the coverage has to come first.
+- **A passing test is worth nothing until you have watched it fail.** Every new test and every new
+  `--self-test` case gets run once with its subject broken: inject the defect, confirm the failure,
+  restore, confirm the pass, and report both. `derive-shape-domain-split.py` shipped a `--self-test`
+  that passed 6/6 while one of its cases proved nothing, twice over, and only the removal check
+  found it. Policy: [`okf/policies/prove-the-test-fails.md`](../okf/policies/prove-the-test-fails.md).
 
 ## Clusters
 

--- a/okf/index.md
+++ b/okf/index.md
@@ -46,6 +46,7 @@ See [`references/`](references/index.md) — OpenCASCADE upstream and licensing 
 - [Query `context` first for OCCT / OCCTSwift docs](policies/context-first.md)
 - [Documentation updates are mandatory](policies/docs-current.md)
 - [No em-dashes, banned words in prose](policies/writing-style.md)
+- [Prove the test fails](policies/prove-the-test-fails.md)
 - [Search before building](policies/search-before-building.md)
 - [Upstream OCCT PRs follow OCCT's house style](policies/upstream-occt-style.md)
 - [Issue labels and project-board tracking](policies/issue-tracking.md)

--- a/okf/policies/prove-the-test-fails.md
+++ b/okf/policies/prove-the-test-fails.md
@@ -1,0 +1,69 @@
+---
+type: policy
+title: Prove the test fails
+description: A passing test is worth nothing until you have watched it fail. Inject the defect it exists to catch, confirm the failure, restore, and report both results.
+tags: [policy, testing, detectors, gates, agents]
+timestamp: 2026-08-04
+---
+
+# Prove the test fails
+
+**Every new test, and every new `--self-test` case, is run once with its subject broken.** Inject
+the defect the test exists to catch, confirm it fails, restore, confirm it passes. Report both
+results in the PR, not just the green one.
+
+This applies ecosystem-wide, not only the OCCT/OCCTSwift stack. It applies most sharply to
+*detectors*: gate scripts, census scripts, linters, anything whose output is "all clear".
+
+## Why
+
+A detector reporting "all clear" because it is blind is indistinguishable from one reporting "all
+clear" on a clean tree. Nothing in a green run tells the two apart. The removal check is the only
+thing that does.
+
+This is written down because it is a failure this repo keeps having, not because it is good
+practice in the abstract:
+
+- Three gate scripts were confidently wrong while reporting all clear: #618, #624, #626.
+- `check-null-handle-guards.py` was blind to the shape that produced #656's uncatchable SIGSEGV. It
+  checks a bridge function's own handle *arguments*, not a handle obtained locally and passed
+  onward, so every gate passed on the crash.
+- `derive-swift-file-split.py` never matched a top-level `func`, so free functions were invisible.
+  #659 found nine of them by hand, by diffing every top-level line against the ranges the census
+  did report.
+- `derive-shape-domain-split.py` had no brace-depth check and counted local variables and
+  nested-type fields as members: 557 reported against a real 446, and 93 "untested" members against
+  a real 17. That wrong number was quoted as a finding before anyone measured it.
+
+## The part that is easy to miss
+
+Adding a `--self-test` is not the rule. Watching it fail is.
+
+`derive-shape-domain-split.py` grew a `--self-test` that passed 6/6 while one of its cases proved
+nothing, **twice in a row**:
+
+1. First the block-comment fixture sat *outside* the region the scanner tracks, so the guard it was
+   meant to exercise never ran.
+2. Then it sat inside, but its braces balanced across the block, so removing the guard changed no
+   outcome.
+
+Both versions looked exactly like coverage. Only removing the guard and watching the test still
+pass revealed they were not, and a third pass found the guard itself had an adjacent hole where a
+closing `*/` shared a line with real code (#680).
+
+## How to apply
+
+For a test: break the code it covers, run it, see red, restore, see green.
+
+For a detector's `--self-test`: remove each guard in turn, run the self-test, confirm the case
+count drops, restore. If removing a guard leaves the count unchanged, that case is decorative and
+needs rewriting, not celebrating.
+
+Report the matrix. A table of "guard removed" against "cases correct" is short, and it is the
+difference between a reviewer trusting the suite and taking your word for it.
+
+## Related
+
+- [Documentation updates are mandatory](docs-current.md)
+- [Search before building](search-before-building.md)
+- `CLAUDE.md` → Test Conventions, for the repo-specific test rules this sits alongside.


### PR DESCRIPTION
Adds `okf/policies/prove-the-test-fails.md`, listed in `okf/index.md` alongside the other policies, with one-line pointers from `CLAUDE.md`'s Test Conventions and `docs/v2.0.0-plan.md`.

**Rule:** every new test, and every new `--self-test` case, is run once with its subject broken. Inject the defect it exists to catch, confirm it fails, restore, confirm it passes, report both.

## Why it is a policy and not a preference

It is a failure this repo keeps having:

- Three gate scripts were confidently wrong while reporting all clear: #618, #624, #626
- `check-null-handle-guards.py` was blind to the shape behind #656's uncatchable SIGSEGV
- `derive-swift-file-split.py` never matched a top-level `func`, so #659 found nine free functions by hand
- `derive-shape-domain-split.py` counted local variables as members: **557 against a real 446**, and 93 "untested" against a real 17, a number quoted as a finding before anyone measured it

## The part the policy leads on

Adding a self-test is not the rule. Watching it fail is.

That last script grew a `--self-test` that passed 6/6 while one case proved nothing, **twice**: first the fixture sat outside the region the scanner tracks, then its braces balanced across the block. Both looked exactly like coverage. Only removing the guard and seeing the test still pass revealed otherwise, and a third pass found the guard itself had an adjacent hole (#680).

## Also done

The 30 outstanding issues in the v2.0.0 milestone each carry a short comment pointing at the policy. I had previously inlined the rationale into those comments; those are deleted, so each issue has exactly one comment and the policy is the only copy of the text. Verified.

Skipped the 16 milestone issues already marked Done on the board, since they are merged and awaiting the main merge, and the 35 open issues outside the milestone.

## Candidate for the ecosystem standard

This is not OCCT-specific. `okf/policies/writing-style.md` and `issue-tracking.md` both have canonical versions in `ecosystem/OKF-STANDARD.md`, and this belongs there on the same grounds. I have not touched that repo. Say the word and I will raise it.

Docs only.
