### PR TITLE
Restore the three tombstone comments #660 dropped

### DIFF
--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -2624,6 +2624,9 @@ extension Curve3D {
 }
 
 extension Curve3D {
+    // Continuity level for approximation is `ParametricContinuity` (Continuity.swift); the
+    // `ApproxContinuity` copy Shape.swift used to declare is now a deprecated alias of it. See #398.
+
     /// Approximate this curve as a BSpline, reporting the fit's error and completion status.
     ///
     /// The same approximation ``Curve3D/approximated(tolerance:continuity:maxSegments:maxDegree:)``

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -554,6 +554,9 @@ extension Shape {
     }
     // MARK: - Variable Radius Fillet (v0.14.0)
 
+    // `SurfaceContinuity` (formerly declared in Shape.swift beside this code, alongside a second
+    // `PlateConstraintOrder` copy of the same vocabulary) now lives in Continuity.swift. See #398.
+
     /// Apply a variable radius fillet to a specific edge.
     ///
     /// The radius varies along the edge according to the given radius/parameter pairs.

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -554,9 +554,6 @@ extension Shape {
     }
     // MARK: - Variable Radius Fillet (v0.14.0)
 
-    // `SurfaceContinuity` (formerly declared in Shape.swift beside this code, alongside a second
-    // `PlateConstraintOrder` copy of the same vocabulary) now lives in Continuity.swift. See #398.
-
     /// Apply a variable radius fillet to a specific edge.
     ///
     /// The radius varies along the edge according to the given radius/parameter pairs.

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -182,9 +182,6 @@ extension Shape {
         return Shape(handle: handle)
     }
 
-    // Continuity level for approximation is `ParametricContinuity` (Continuity.swift); the
-    // `ApproxContinuity` copy Shape.swift used to declare is now a deprecated alias of it. See #398.
-
     /// Convert all surfaces to BSpline
     ///
     /// - Returns: Shape with BSpline surfaces, or nil on failure

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -101,6 +101,10 @@ extension Shape {
         return Shape(handle: result)
     }
 
+    // The enum formerly declared in Shape.swift as `GeometricContinuity` was a misnomer: it maps to
+    // GeomAbs_C0...C3, so it is parametric continuity. It is now `ParametricContinuity` in
+    // Continuity.swift, shared with the other APIs that take a continuity floor. See #398.
+
     /// Divide a shape at continuity discontinuities
     ///
     /// - Parameter continuity: Target continuity level
@@ -177,6 +181,9 @@ extension Shape {
         guard let handle = OCCTShapeRevolutionToElementary(self.handle) else { return nil }
         return Shape(handle: handle)
     }
+
+    // Continuity level for approximation is `ParametricContinuity` (Continuity.swift); the
+    // `ApproxContinuity` copy Shape.swift used to declare is now a deprecated alias of it. See #398.
 
     /// Convert all surfaces to BSpline
     ///

--- a/Sources/OCCTSwift/Shape+Surface.swift
+++ b/Sources/OCCTSwift/Shape+Surface.swift
@@ -75,6 +75,10 @@ extension Shape {
 
     // MARK: - Surface Filling (v0.14.0)
 
+    // `SurfaceContinuity` (formerly declared in Shape.swift beside the blends and filling code,
+    // alongside a second `PlateConstraintOrder` copy of the same vocabulary) now lives in
+    // Continuity.swift. It is the vocabulary `fill` and `plateSurface` below take. See #398.
+
     /// Fill an N-sided boundary with a smooth surface.
     ///
     /// Creates a surface that passes through the given boundary wires

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -3590,6 +3590,9 @@ extension Surface {
 }
 
 extension Surface {
+    // Continuity level for approximation is `ParametricContinuity` (Continuity.swift); the
+    // `ApproxContinuity` copy Shape.swift used to declare is now a deprecated alias of it. See #398.
+
     /// Approximate this surface as a BSpline surface, reporting the fit's error and completion status.
     ///
     /// The same approximation ``Surface/approximated(tolerance:continuity:maxSegments:maxDegree:)``


### PR DESCRIPTION
Acts on the one finding in the #677 review. #678's review found nothing to fix.

## The finding

#660 disclosed that it dropped `// MARK:` headers, and was right to. It did not disclose that three free-floating explanatory comments went with them, and the review was right that this is a different class of loss.

They are git-archaeology breadcrumbs pointing at #398's continuity consolidation. They had nothing to attach to: the migration attached a leading comment block to the declaration below it, and these floated between blocks separated by blank lines. As the review notes, two similar comments survived only because they sat adjacent to a real doc comment and got swept up with it, which is an accident of formatting rather than a rule that preserves this class.

## Restored beside the code each one describes

| comment | now above |
|---|---|
| `SurfaceContinuity` moved to Continuity.swift | `filletedVariable` in `Shape+Modeling.swift` |
| `GeometricContinuity` was a misnomer | `divided(at:)` in `Shape+ShapeHealing.swift` |
| approximation continuity is `ParametricContinuity` | `convertedToBSpline` in `Shape+ShapeHealing.swift` |

Not gathered into one place. `Continuity.swift` already documents the forward direction on each alias, thoroughly. What #660 lost is the *reverse* breadcrumb from the Shape side, and that only helps where the reader actually asks the question, which is next to the code that used to sit beside the declaration.

The third one's original section (`// MARK: - GeomConvert_ApproxCurve/Surface`) is empty, so it had no surviving neighbour to follow; it went above the approximation entry point its text is about.

## Not verbatim, deliberately

Two of them said "declared **here**" and "**this file** used to declare". True in `Shape.swift`, false in the files they now sit in. Copying that across would have reproduced exactly the defect #549 recorded, a tombstone that reads as a statement about the file it is in. Each now names `Shape.swift` explicitly. Everything else is unchanged.

## Completeness

Swept the whole pre-split `Shape.swift` for plain `//` comments (excluding `///` and `// MARK:`) absent from the current tree. The only ones missing are these three, so the review's count of three is complete and nothing else was lost.

## Verification

- From-clean build: clean
- Full suite: 5313 tests, all passed
- Six gate and census scripts, all with `--self-test`: green
- Comment-only change, no code touched
