### PR TITLE
docs(#679): drop stale source-line citations from reference pages

### DIFF
--- a/docs/reference/BRepGraph-Builders.md
+++ b/docs/reference/BRepGraph-Builders.md
@@ -5,9 +5,9 @@ parent: API Reference
 
 # BRepGraph — Builders & Editor Mutation
 
-This page covers the **mutation surface** of `BRepGraph` — every query and builder method from
+This page covers the **mutation surface** of `BRepGraph`: every query and builder method from
 the `// MARK: Edge/Face/Shell/Solid Additional Queries`, `CompSolid Count`, `Builder:` and
-`EditorView` sections (source lines 1093–1621). See the main **BRepGraph** page for
+`EditorView` sections. See the main **BRepGraph** page for
 construction, traversal, and the core query API.
 
 ## Topics

--- a/docs/reference/BRepGraph-Editor-Identity.md
+++ b/docs/reference/BRepGraph-Editor-Identity.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # BRepGraph — Editor Geometry, Sampling & Durable Identity
 
-This page covers the final sections of `BRepGraph` (source lines 1622–2055): geometric setters for the EditorView, assembly-building ProductOps, in-place RepOps swaps, MeshView cache inspection, UV-grid and edge-curve sampling, and the durable-identity UID/RefUID/ItemUID API. See the other **BRepGraph — …** pages for the core read API, write helpers, and I/O.
+This page covers the final sections of `BRepGraph`: geometric setters for the EditorView, assembly-building ProductOps, in-place RepOps swaps, MeshView cache inspection, UV-grid and edge-curve sampling, and the durable-identity UID/RefUID/ItemUID API. See the other **BRepGraph — …** pages for the core read API, write helpers, and I/O.
 
 ## Topics
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — Shape Analysis, OSD & Geometry Builders
 
-This page covers the shape analysis, file I/O helpers, analytic bounding, geometry property computation, transformation factories, and conic curve builders introduced across v0.99–v0.105 (lines 6351–7633 of `Document.swift`). For the core document lifecycle and STEP/IGES I/O see the main [Document](Document.md) page.
+This page covers the shape analysis, file I/O helpers, analytic bounding, geometry property computation, transformation factories, and conic curve builders introduced across v0.99–v0.105 in `Document.swift`. For the core document lifecycle and STEP/IGES I/O see the main [Document](Document.md) page.
 
 ## Topics
 

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — BSpline/Bezier Methods & Extrema
 
-This page covers lines 8729–9929 of `Sources/OCCTSwift/Document.swift` (v0.106–v0.109): topology-flag extensions on `Shape`, continuity properties on `Curve3D`/`Curve2D`/`Surface`, the BSpline and Bezier nested namespaces on those types, `BRepTools`/`BRepLib` utilities, `MakeFace` convenience factories, `SewingBuilder`, `HatchBuilder`, edge/face/vertex extraction, the full `Extrema` family (`ExtremaElC`, `ExtremaElCS`, `ExtremaElSS`, `ExtremaPointCurve`, `ExtremaPointSurface`), and the `TrigRoots` solver.
+This page covers `Sources/OCCTSwift/Document.swift`'s v0.106–v0.109 additions: topology-flag extensions on `Shape`, continuity properties on `Curve3D`/`Curve2D`/`Surface`, the BSpline and Bezier nested namespaces on those types, `BRepTools`/`BRepLib` utilities, `MakeFace` convenience factories, `SewingBuilder`, `HatchBuilder`, edge/face/vertex extraction, the full `Extrema` family (`ExtremaElC`, `ExtremaElCS`, `ExtremaElSS`, `ExtremaPointCurve`, `ExtremaPointSurface`), and the `TrigRoots` solver.
 
 See the [Document index page](Document.md) for the full split-chunk table of contents.
 

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — XCAF & API Completions
 
-This page covers every public member declared from line 15061 to the end of `Sources/OCCTSwift/Document.swift` — a collection of extension completions added across versions 0.122.0–0.130.0, spanning `WireFixer`, `ShapeFix_Edge`, `BRepTools`/`BRepLib` statics, shape history, sewing, builder extensions, section operations, curve/surface queries, XCAF color/shape-tool completions, fillet/chamfer history queries, a standalone `SectionBuilder`, and the `GeomEval`/`Geom2dEval` analytical evaluators. See the main [`Document`](Document.md) page for core load/save and assembly operations.
+This page covers the last group of public members declared in `Sources/OCCTSwift/Document.swift`: a collection of extension completions added across versions 0.122.0–0.130.0, spanning `WireFixer`, `ShapeFix_Edge`, `BRepTools`/`BRepLib` statics, shape history, sewing, builder extensions, section operations, curve/surface queries, XCAF color/shape-tool completions, fillet/chamfer history queries, a standalone `SectionBuilder`, and the `GeomEval`/`Geom2dEval` analytical evaluators. See the main [`Document`](Document.md) page for core load/save and assembly operations.
 
 ## Topics
 

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — Geometry Constructors & Pipe Shells
 
-This page covers geometry construction and analysis utilities added across v0.105.0–v0.106.0 (lines 7634–8728 of `Document.swift`): 2D parabola constructors, uniform arc-length sampling, curve/surface concatenation and knot splitting, bounding-box extensions, geometric property helpers, shape reshaping, pipe-shell sweeping, directory/file access, quadric intersections, XCAF explorer queries, Unicode utilities, and shape-analysis diagnostics. For the core document lifecycle, shape tools, and STEP/IGES I/O see the main [Document](Document.md) page.
+This page covers geometry construction and analysis utilities added across v0.105.0–v0.106.0 in `Document.swift`: 2D parabola constructors, uniform arc-length sampling, curve/surface concatenation and knot splitting, bounding-box extensions, geometric property helpers, shape reshaping, pipe-shell sweeping, directory/file access, quadric intersections, XCAF explorer queries, Unicode utilities, and shape-analysis diagnostics. For the core document lifecycle, shape tools, and STEP/IGES I/O see the main [Document](Document.md) page.
 
 ## Topics
 

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — Math, Bounds, OSD & Conversions
 
-This page covers the math solvers, bounding-box types, quaternion/timer utilities, point classification, curve/surface conversion helpers, and OSD utilities found in lines 4959–6350 of `Document.swift`. For the core document lifecycle, shape tools, and XCAF I/O see the main [Document](Document.md) page.
+This page covers the math solvers, bounding-box types, quaternion/timer utilities, point classification, curve/surface conversion helpers, and OSD utilities found in `Document.swift`. For the core document lifecycle, shape tools, and XCAF I/O see the main [Document](Document.md) page.
 
 ## Topics
 

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — Math Solvers & Local Properties
 
-This page covers `Document.swift` lines 9930-11279: 2D conic utilities, normal projection, disk/shared-library/message system helpers, `PlateSolver` constraint extensions, extra methods on `Shape`, `Curve3D`, `Curve2D`, and `Surface`, the full `MathSolver` numerical toolkit, `PolynomialSolver` Laguerre extensions, `BRepLProp` edge/face local properties, the deprecated `GeomGridEval` batch-evaluation spellings (#486), single-parameter curve/surface evaluators, and the Newton-Hessian minimizer.
+This page covers `Document.swift`'s Math Solvers & Local Properties additions: 2D conic utilities, normal projection, disk/shared-library/message system helpers, `PlateSolver` constraint extensions, extra methods on `Shape`, `Curve3D`, `Curve2D`, and `Surface`, the full `MathSolver` numerical toolkit, `PolynomialSolver` Laguerre extensions, `BRepLProp` edge/face local properties, the deprecated `GeomGridEval` batch-evaluation spellings (#486), single-parameter curve/surface evaluators, and the Newton-Hessian minimizer.
 
 > See also the main **[Document](Document.md)** page for the `Document` class itself and the other chunk pages.
 

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — OCAF Attributes, Naming & Elementary Geometry
 
-This page covers the OCAF attribute types, shape-naming extensions, geometry helpers, and elementary curve/surface utilities declared in lines 3350–4958 of `Document.swift`. See the main `Document` page for lifecycle, I/O, label management, and the core XCAF operations.
+This page covers the OCAF attribute types, shape-naming extensions, geometry helpers, and elementary curve/surface utilities declared in `Document.swift`. See the main `Document` page for lifecycle, I/O, label management, and the core XCAF operations.
 
 ## Topics
 

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — Coordinate Systems, Transforms & Completions
 
-This page covers the geometry, math, and completion APIs exposed in `Document.swift` (lines 12717–14159): coordinate systems, 2D transforms, matrix math, quaternion interpolation, vector utilities, numeric solvers, unit conversion, local surface/curve properties, projection, bounding boxes, shape analysis, boolean checking, defeaturing, polynomial conversion, transform extras, topology extras, sewing extras, and BREP serialization. See the main [`Document`](Document.md) page for XCAF assembly, attribute, and STEP/OCAF I/O.
+This page covers the geometry, math, and completion APIs exposed in `Document.swift`: coordinate systems, 2D transforms, matrix math, quaternion interpolation, vector utilities, numeric solvers, unit conversion, local surface/curve properties, projection, bounding boxes, shape analysis, boolean checking, defeaturing, polynomial conversion, transform extras, topology extras, sewing extras, and BREP serialization. See the main [`Document`](Document.md) page for XCAF assembly, attribute, and STEP/OCAF I/O.
 
 ## Topics
 

--- a/docs/reference/Document-XCAF-Notes.md
+++ b/docs/reference/Document-XCAF-Notes.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Document — XCAF Notes, Views & Materials
 
-This page covers the XCAF annotation, view, material, and utility subsystems exposed on `Document`, `AssemblyNode`, and several standalone types (lines 2381–3349 of `Document.swift`). For the core document lifecycle, shape tools, and STEP/IGES I/O see the main [Document](Document.md) page.
+This page covers the XCAF annotation, view, material, and utility subsystems exposed on `Document`, `AssemblyNode`, and several standalone types in `Document.swift`. For the core document lifecycle, shape tools, and STEP/IGES I/O see the main [Document](Document.md) page.
 
 ## Topics
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Shape — Features, Sweeps & Surface Building
 
-This page documents the Shape API from **Geometry Construction** through **Plate Surfaces** (source lines 1258–3344 of `Shape.swift`). It covers face and solid assembly, feature-based modeling (bosses, pockets, holes, patterns), shape inspection, slicing, measurement, advanced pipe sweeps, surface building, and healing. For the primitive factories, boolean operations, and transforms that precede this range, see the main **Shape** index page (not yet written; use `Surface.md` as an exemplar for style).
+This page documents the Shape API from **Geometry Construction** through **Plate Surfaces** in `Shape.swift`. It covers face and solid assembly, feature-based modeling (bosses, pockets, holes, patterns), shape inspection, slicing, measurement, advanced pipe sweeps, surface building, and healing. For the primitive factories, boolean operations, and transforms that precede this range, see the main **Shape** index page (not yet written; use `Surface.md` as an exemplar for style).
 
 ## Topics
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Shape — Measurement, Sub-Shapes & Local Operations
 
-This page covers the measurement, decomposition, healing, and local-operation APIs on `Shape` (source lines 4955–6935). For the core primitives, Boolean operations, and transforms, see the main **[Shape](Shape.md)** page.
+This page covers the measurement, decomposition, healing, and local-operation APIs on `Shape`, declared in `Shape.swift`. For the core primitives, Boolean operations, and transforms, see the main **[Shape](Shape.md)** page.
 
 ## Topics
 

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Shape — Geometry Recognition & Polygon/Triangulation Data
 
-This page documents the geometry-utility and polygon/triangulation public API from `Sources/OCCTSwift/Shape.swift` (lines 11078–12192). It covers coordinate-system helpers, curve/surface construction utilities, 2D constraint solvers, shape modification tools, and the full polygon and triangulation layer. See the main [Shape](Shape.md) page for the core B-Rep API.
+This page documents the geometry-utility and polygon/triangulation public API from `Sources/OCCTSwift/Shape.swift`. It covers coordinate-system helpers, curve/surface construction utilities, 2D constraint solvers, shape modification tools, and the full polygon and triangulation layer. See the main [Shape](Shape.md) page for the core B-Rep API.
 
 ## Topics
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`docs/reference/` pages cited source positions as prose ("lines 8729-9929"), and nothing detected
them going stale. The #659/#660/#661/#662/#663 `Document.swift`/`Shape.swift` breakdowns
invalidated them three times inside one release. This drops the line-number clause from all 14
sites that carry it (9 on `Document-*.md`, 3 on `Shape-*.md`, 2 on `BRepGraph-*.md` that are not
yet stale but carry the same defect), following option 1 from #679: name the file, let the
`## Topics` line already under each intro (a direct anchor list generated from the page's own
headings) do the job of naming the symbols. Nothing else in each paragraph changed; every page
still names its source file and keeps its full descriptive/symbol content.

Closes #679

## Option chosen: drop the numbers (option 1), not a GitHub permalink (option 2)

Option 2 does not actually solve the staleness problem, it relocates it. A stable permalink to a
symbol has to pin a commit SHA (GitHub has no "jump to symbol by name" URL), and a SHA-pinned link
never breaks in the sense of 404ing, but the code at that SHA is exactly the pre-breakdown version
this issue is about: pinning it does not track the current file structure any better than a line
number did, and a working link that resolves to since-relocated code reads as more authoritative
than a plainly wrong number, which is worse, not better. Option 1 was already the recommendation
in the issue; this PR did not find a reason to prefer option 2.

## No gate script

Considered, not added. Once the citation is gone from these pages there is nothing left to
resync: option 1 makes the defect unrepresentable here rather than merely detectable, which the
issue itself flagged as the strongest argument for this option. A regex detector guarding against
a *new* one being introduced later would need to carry an allowlist for at least three distinct
false-positive shapes measured on this tree:

- `\bline[s]?\s+\d+` matches inside "BSpline" without a word boundary (`Curve2D-Analysis.md:1051`,
  `CHANGELOG.md:1143`, both "for a BSpline 457.26 long"), per the issue.
- `CHANGELOG.md:759-760` quote OCCT's own documentation ("says at line 1281 that..."), not this
  repo's source, per the issue.
- Not previously flagged: `Curve2D-Constraint-Solvers.md:561` and `:859` document
  `line1Point`/`line2Dir`-style parameters ("point and direction of line 1; ... line 2"), which a
  naive detector also matches.

Three maintained false-positive classes for a defect this fix already retires on the only pages
that had it was judged not worth the permanent CI cost. A future reviewer is still the backstop
against a new hand-written line citation, same as any other doc-quality regression.

## Measurement: what I found vs. what the issue's comments say

My own fresh sweep (`grep -rn -E '\bline[s]?\s+[0-9]+' docs/ README.md CLAUDE.md`, then manually
excluding the parameter-name and OCCT-quote false positives) finds **14** true citations before
this PR, not 19: 9 on `Document-*.md`, 3 on `Shape-*.md`, 2 on `BRepGraph-*.md`. All 12 of the
`Document-*`/`Shape-*` ones matched exactly the "12 of 19... point past the end" table in the
second comment on #679, and all 12 were already invalid before this PR. I could not find the
other 7 the "19" implies exist somewhere in scope; every `Document-*.md`/`Shape-*.md` page without
a table entry has zero citations of this shape, confirmed by grepping full file contents, not just
each page's intro line. Worth a second look if the true count matters elsewhere, but it does not
change the fix here: whatever the real starting count, the ending count for this pattern across
`docs/`, `README.md`, and `CLAUDE.md` is 0, less the 3 legitimate exceptions (2 CHANGELOG OCCT
quotes, `line1Point`/`line2Dir` parameter docs).

The two false positives in the issue's third comment (`Curve2D-Analysis.md:1051`, the "BSpline"
substring, and `CHANGELOG.md:759-760`, the OCCT-doc quotes) were confirmed real and left untouched.
The "`lines 9930-1127`" inverted-range claim from the original issue body was already corrected by
the second comment (it reads `9930-11279`, ascending, merely out of range) and this PR does not
repeat it.

## Verification

| check | result |
|---|---|
| `grep -rn -E '\bline[s]?\s+[0-9]+' docs/reference/Document-*.md docs/reference/Shape-*.md docs/reference/BRepGraph-*.md` | 14 hits before, 0 after |
| Same sweep across all of `docs/`, `README.md`, `CLAUDE.md` | only the 2 CHANGELOG OCCT-quote lines and the `line1Point`/`line2Dir` parameter doc remain, all correctly untouched |
| `git diff` reviewed line by line | every edit is a minimal in-sentence clause replacement; no MARK header, explanatory sentence, or Topics entry was removed (the #660/#682 failure mode) |
| `check-bridge-index.py` (+ `--self-test`) | clean, 18/18 |
| `check-null-handle-guards.py` (+ `--self-test`) | clean, 12/12 |
| `check-docs-defaults.py` (+ `--self-test`) | clean, 13/13, 0 drift |
| `count-operations.py` | 4301, matches README/API_REFERENCE |
| `derive-swift-file-split.py` (+ `--self-test`) | clean, 6/6 |
| `derive-shape-domain-split.py` (+ `--self-test`) | clean, 10/10 |

Docs-only change, nothing under `Sources/` or `Tests/` touched, so `swift build`/`swift test`
were not run for this PR (no code path can regress from a prose edit).

## Notes for the reviewer

- Scope is exactly `Document-*.md`, `Shape-*.md`, `BRepGraph-*.md`, per the issue and its scope
  correction comment. `Document-Builders-Fillet.md`, `Document-Mesh-Fixing.md`, and
  `Document-Persistence-IO.md` were checked and never had a numeric citation.
- Did not touch the pervasive `**Parameters:**` bullet convention, which separates each parameter
  name from its description with an em dash throughout every reference page (thousands of
  instances, pre-dating the em-dash ban, unrelated to this issue). The writing-style policy's
  "clear them from any file you are already editing" is applied here only to the sentences
  actually rewritten; a wholesale em-dash purge of the doc corpus is a separate initiative, not a
  side effect of a line-citation fix.
