### PR TITLE
chore(#585): pin the 8.0.1 kernel so CI builds what the branch is written against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI
 # Fast per-PR/per-push gate. Deliberately does NOT rebuild OCCT from source: a clean checkout has
 # no local Libraries/, so Package.swift's binaryTarget resolves OCCT.xcframework from its pinned
 # release URL and verifies the checksum, which only costs a download. A PR that touches
-# Scripts/patches/ (a carried kernel patch not yet in a release) gets kernel-integration.yml
-# instead, which does rebuild from source and runs swift test against that binary (#585) — this
-# workflow's own macOS check will fail such a PR's new regression tests against the stale pinned
-# kernel, and that's expected, not a defect; read kernel-integration.yml's result instead.
+# Scripts/patches/ (a carried kernel patch not yet in a release) also gets
+# kernel-integration.yml, which rebuilds from source and runs swift test against that binary.
+# This workflow's macOS check resolves whatever Package.swift pins, so a patch NEWER than the
+# pinned asset will fail that patch's own regression tests here (#585). The fix is to publish
+# the next vX.Y.Z-kernel.N pre-release and bump the pin (docs/guides/building-occt.md step 4),
+# not to treat this job as permanently unreliable: as of the v2.0.0-kernel.1 pin it is green.
 # OCCTBridge compiles from source by default (no OCCTSWIFT_BRIDGE_PREBUILT set), which is the
 # repo's own intended default, see the comment above `useBridgePrebuilt` in Package.swift, and
 # it's a couple of minutes, not tens of minutes.
@@ -31,10 +33,11 @@ jobs:
   #
   #   - separate job, not a step in build-and-test, so it reports in well under a minute instead of
   #     behind the ~6-minute build, and so it carries its own status check. That second half is the
-  #     load-bearing one: build-and-test is red branch-wide on refactor/** whenever the branch
-  #     carries a kernel patch newer than Package.swift's pinned xcframework (#585), and a gate
-  #     folded into that job would be red for a reason that has nothing to do with it, which is the
-  #     same as not having it.
+  #     load-bearing one: build-and-test goes red branch-wide whenever the branch carries a kernel
+  #     patch newer than Package.swift's pinned xcframework (#585), and a gate folded into that
+  #     job would be red for a reason that has nothing to do with it, which is the same as not
+  #     having it. That state is fixable by bumping the pin, and is fixed today, but the
+  #     separation is what makes the gate survive the next time it happens.
   #   - ubuntu-latest, because all four are pure Python over the repo's own text: no Xcode, no
   #     OCCT, no swift build. A macOS runner would cost 10x the minutes to run the identical checks.
   #   - each script's --self-test runs alongside its real invocation. A gate whose detector is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ on:
 jobs:
   verify-binary-pins:
     name: Verify binary pins + tagged build
+    # Skipped for pre-releases. A vX.Y.Z-kernel.N kernel pre-release is published BEFORE the
+    # commit that pins it, by construction (you cannot compute the checksum of an asset that
+    # does not exist yet), so the tag it points at still carries the previous pin and this job
+    # would fail for a reason that has nothing to do with the artifact it is verifying. That
+    # is the same false-red this pattern exists to remove, one level up. workflow_dispatch is
+    # still allowed, so a kernel pre-release can be verified deliberately against a ref that
+    # does carry the new pin. See docs/guides/building-occt.md step 4.
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ Until 2026-08-04 this was not true: the pin was the v1.15.18 asset (`V8_0_0_p1` 
 regression, and seven suites were red for that reason alone (#585). If you find advice to read
 `kernel-integration.yml` instead of `ci.yml`, or to rely on `OCCTSWIFT_LOCAL=1` for correct results
 rather than for speed, it predates that fix. The release commit re-points `url:`/`checksum:` at the
-final v2.0.0 asset (#512). See [`docs/occt-upgrades.md`](docs/occt-upgrades.md#p1-to-801-unreleased).
+final v2.0.0 asset (#512).
+See [`docs/occt-upgrades.md`](docs/occt-upgrades.md#p1-to-801-unreleased).
 
 ## Build & Test Commands
 
@@ -34,8 +35,9 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 Four pure-Python checks over the repo's own text. No OCCT, no build, ~3s for all four. **CI runs
 every one of them, plus each `--self-test`, in `ci.yml`'s `gate-scripts` job** — a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
-its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a defect and 0 when clean; `check-bridge-index`
-and `check-null-handle-guards` exit **2** if run from anywhere but the repo root (#625).
+its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a
+defect and 0 when clean; `check-bridge-index` and `check-null-handle-guards` exit **2** if run
+from anywhere but the repo root (#625).
 
 **`gate-scripts` is a required status check on `refactor/**`** (#649), via a repository ruleset — the
 repo's only branch protection. Three consequences worth knowing before you touch it:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 OCCTSwift is a comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.1. It exposes B-Rep solid modeling capabilities to Swift for macOS (arm64, v12+) and iOS (arm64, v15+) via a three-layer architecture: Swift public API → Objective-C++ bridge (C functions) → OCCT C++ library. Uses Swift 6 language mode (strict concurrency).
 
-**Two OCCT versions are in play until v2.0.0 ships.** `Scripts/build-occt.sh` builds `V8_0_1`, but
-`Package.swift`'s `url:` still resolves the v1.15.18 release asset, which is `V8_0_0_p1` + patches
-0001-0016. The `url:`/`checksum:` bump belongs to the release commit (#512), so a clean checkout
-with no local `Libraries/` gets the **old** kernel. Build locally and use `OCCTSWIFT_LOCAL=1` to
-work against the new one, and read `kernel-integration.yml` rather than `ci.yml`'s macOS job for
-the real signal (#585). See [`docs/occt-upgrades.md`](docs/occt-upgrades.md#p1-to-801-unreleased).
+**One OCCT version is in play.** `Scripts/build-occt.sh` builds `V8_0_1` and `Package.swift` pins
+the **`v2.0.0-kernel.1` pre-release**, which is that same `V8_0_1` plus the eleven carried patches
+`0010`-`0012` and `0014`-`0021`. A clean checkout with no local `Libraries/` now gets the right
+kernel, and `ci.yml`'s macOS job is a real signal again.
+
+Until 2026-08-04 this was not true: the pin was the v1.15.18 asset (`V8_0_0_p1` + patches
+`0001`-`0016`), so every test asserting a newer patch's fix failed in CI indistinguishably from a
+regression, and seven suites were red for that reason alone (#585). If you find advice to read
+`kernel-integration.yml` instead of `ci.yml`, or to rely on `OCCTSWIFT_LOCAL=1` for correct results
+rather than for speed, it predates that fix. The release commit re-points `url:`/`checksum:` at the
+final v2.0.0 asset (#512). See [`docs/occt-upgrades.md`](docs/occt-upgrades.md#p1-to-801-unreleased).
 
 ## Build & Test Commands
 
@@ -29,8 +34,7 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 Four pure-Python checks over the repo's own text. No OCCT, no build, ~3s for all four. **CI runs
 every one of them, plus each `--self-test`, in `ci.yml`'s `gate-scripts` job** — a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
-its own status check when `build-and-test` is red for an unrelated reason (#585's pinned-kernel
-mismatch on `refactor/**` branches). Each exits 1 on a defect and 0 when clean; `check-bridge-index`
+its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a defect and 0 when clean; `check-bridge-index`
 and `check-null-handle-guards` exit **2** if run from anywhere but the repo root (#625).
 
 **`gate-scripts` is a required status check on `refactor/**`** (#649), via a repository ruleset — the
@@ -45,9 +49,11 @@ repo's only branch protection. Three consequences worth knowing before you touch
   required check that never reports blocks a PR permanently with "Expected, waiting for status to be
   reported", and there is no way to clear it. For a `pull_request` the workflow is read from the
   merge ref, so once the base has the job every PR gets it regardless of how stale the head is.
-- **`build-and-test` is deliberately not required on `refactor/**`** — it is 0-for-21 there under
-  #585. It *is* ~9/10 green on `main`, so the requirable set inverts per branch; #585 is confined to
-  this branch and its descendants, not repo-wide.
+- **`build-and-test` is not required on `refactor/**`, and that is now worth revisiting.** It was
+  0-for-21 there under #585, because the pinned asset was an older kernel than the branch's tests
+  were written against. Pinning `v2.0.0-kernel.1` fixed that and the job is green on the branch, so
+  the reason it was excluded no longer holds. Making it required is a separate decision that has not
+  been taken: measure a run of green results first rather than requiring it on one.
 
 ```bash
 python3 Scripts/check-bridge-index.py        # OCCTBridge.h's class → symbol index: stale / misfiled entries
@@ -142,11 +148,9 @@ uncatchable signal, not something `catch (...)` can absorb (#478, #556, #618). R
 `--self-test` proves both failure modes (an unguarded site reported, a guarded one not). **Both are
 run by CI** in `ci.yml`'s `gate-scripts` job, so an unguarded site turns the PR's check red — until
 #625 they were run by nothing at all, and this instruction described a gate that existed only as
-prose. Note the repo has **no branch protection and no rulesets**, so a red check is visible but
-does not itself block a merge; making `gate-scripts` a required check is tracked separately and is
-safe for this one specifically, because unlike `build-and-test` (red branch-wide while #585 stands)
-it is fast and green on every branch. See "Static Gate Scripts" above for the optional pre-commit
-hook.
+prose. `gate-scripts` is a **required** status check on `refactor/**` (#649, via the repo's one
+ruleset), so an unguarded site blocks the merge rather than merely showing red. See "Static Gate
+Scripts" above for the rules that come with that, and for the optional pre-commit hook.
 
 **The guard is required only where the OCCT call actually needs it.** Not every entry point
 dereferences: `GeomLib_Tool::Parameter` returns false, `GeomAdaptor_Surface` and

--- a/Package.swift
+++ b/Package.swift
@@ -50,15 +50,24 @@ let occtTarget: Target = useLocalBinary
     // (BRepFeat_MakeCylindricalHole tool-part selection, #532), and 0021 (CPnts adaptive
     // arc-length integration, #603).
     //
-    // The url:/checksum: pair below moves in the RELEASE commit, not here (#512): until then, work
-    // against the rebuilt kernel with a local Libraries/OCCT.xcframework and OCCTSWIFT_LOCAL=1, and
-    // read kernel-integration.yml rather than ci.yml's macOS job for the real signal (#585).
-    // Bump BOTH url and checksum whenever the xcframework is rebuilt, or URL-resolving consumers
-    // silently keep the previous kernel while local sibling builds get the new one.
+    // Pinned to the v2.0.0-kernel.1 PRE-RELEASE: upstream V8_0_1 plus the eleven patches listed
+    // above. This is a kernel-only pre-release, not a library release, and it exists so ci.yml
+    // builds the same kernel this branch's tests are written against.
+    //
+    // Until it was published, ci.yml resolved v1.15.18 (V8_0_0_p1 + patches 0001-0016) while the
+    // branch built V8_0_1 + 0010-0021, so every test asserting a newer patch's fix failed in CI
+    // indistinguishably from a real regression: seven suites were red for that reason alone (#585),
+    // and each correctness fix added more. Reading kernel-integration.yml instead of ci.yml was the
+    // documented workaround; pinning a real asset removes the need for one.
+    //
+    // The RELEASE commit re-points this pair at the final v2.0.0 asset and the pre-release can then
+    // be deleted (#512). Bump BOTH url and checksum whenever the xcframework is rebuilt, or
+    // URL-resolving consumers silently keep the previous kernel while local sibling builds get the
+    // new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v1.15.18/OCCT.xcframework.zip",
-        checksum: "dc7902a558786c113e80c0a79051415af8a5bac976208c58c1ab0dc4db74726c"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v2.0.0-kernel.1/OCCT.xcframework.zip",
+        checksum: "1f1e5cd95eb10b2098b2aa5d7bedcb973c44d8575477a9457e35f5a0d84cf217"
     )
 
 // OCCTBridge is 16 Objective-C++ files / ~62K lines wrapping the OCCT header tree; SwiftPM recompiles

--- a/Package.swift
+++ b/Package.swift
@@ -33,10 +33,9 @@ let occtTarget: Target = useLocalBinary
         name: "OCCT",
         path: "Libraries/OCCT.xcframework"
     )
-    // v1.15.18 rebuild: OCCT 8.0.0p1 + carried patches 0001-0016.
+    // OCCT V8_0_1 + the eleven carried patches listed below.
     //
-    // NOTE: this URL is one kernel behind the source tree. Scripts/build-occt.sh now builds OCCT
-    // V8_0_1, which absorbed ten of those patches (0001-0009 and 0013; their files are deleted,
+    // Scripts/build-occt.sh builds V8_0_1, which absorbed ten of the previously carried patches (0001-0009 and 0013; their files are deleted,
     // their writeups kept in Scripts/patches/README.md under "Retired patches"). The eleven that
     // survive are 0010 (Intf_Interference O(1) tangent-zone lookup + checkpointed breaker, #319),
     // 0011 (XCAFDoc_ShapeTool::OwnAutoNamingScope per-instance override, #341/#363), 0012
@@ -60,8 +59,11 @@ let occtTarget: Target = useLocalBinary
     // and each correctness fix added more. Reading kernel-integration.yml instead of ci.yml was the
     // documented workaround; pinning a real asset removes the need for one.
     //
-    // The RELEASE commit re-points this pair at the final v2.0.0 asset and the pre-release can then
-    // be deleted (#512). Bump BOTH url and checksum whenever the xcframework is rebuilt, or
+    // The RELEASE commit re-points this pair at the final v2.0.0 asset (#512). Do NOT delete the
+    // pre-release afterwards: every commit in the v2.0.0 window pins it, so deleting it takes its
+    // asset with it and makes those commits unbuildable from a clean checkout, which breaks
+    // git bisect and any historical re-measurement.
+    // Bump BOTH url and checksum whenever the xcframework is rebuilt, or
     // URL-resolving consumers silently keep the previous kernel while local sibling builds get the
     // new one.
     : .binaryTarget(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,31 @@ All notable changes to OCCTSwift.
 
 ## Unreleased
 
+### CI builds the same kernel the branch is written against
+
+`Package.swift` now pins the [`v2.0.0-kernel.1`](https://github.com/SecondMouseAU/OCCTSwift/releases/tag/v2.0.0-kernel.1)
+pre-release: upstream `V8_0_1` plus the eleven carried patches `0010`-`0012` and `0014`-`0021`. It
+previously pinned v1.15.18, which is `V8_0_0_p1` + patches `0001`-`0016`.
+
+That mismatch made `ci.yml`'s macOS job useless as a signal on this branch. Every test asserting
+behaviour a newer patch fixes failed there, indistinguishably from a real regression, and **seven
+suites were red for that reason alone**: `#522` approximation collapse, `#570` healing
+approximations, both `#572` sweep and conversion suites, `#491` approximation parity, `#496`
+cylindrical hole contracts and `#532` hole part selection. Every new correctness fix added more,
+and the documented workaround was to read `kernel-integration.yml` instead (#585).
+
+Against the new pin, with no local `Libraries/` and no `OCCTSWIFT_LOCAL`, the full suite is **5,313
+tests, 0 failures**. `OCCTSWIFT_LOCAL=1` remains useful for iterating on a locally rebuilt kernel; it
+is no longer required to get correct results.
+
+The pre-release is temporary and is not a library release. The v2.0.0 release commit re-points
+`url:`/`checksum:` at the final asset, after which it can be deleted (#512).
+
+Verified before publishing, per `docs/guides/building-occt.md`'s shipping checklist: `occt-src` at
+exactly `V8_0_1`, all eleven patches reverse-apply, and zero modified files that no carried patch
+touches, so no investigation probe is compiled in. The published asset re-downloads to the same
+SHA256 it was uploaded with.
+
 ### OCCT re-pinned to 8.0.1
 
 The source pin moves from `V8_0_0_p1` to [`V8_0_1`](https://github.com/Open-Cascade-SAS/OCCT/releases/tag/V8.0.1)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,8 +32,10 @@ Against the new pin, with no local `Libraries/` and no `OCCTSWIFT_LOCAL`, the fu
 tests, 0 failures**. `OCCTSWIFT_LOCAL=1` remains useful for iterating on a locally rebuilt kernel; it
 is no longer required to get correct results.
 
-The pre-release is temporary and is not a library release. The v2.0.0 release commit re-points
-`url:`/`checksum:` at the final asset, after which it can be deleted (#512).
+The pre-release is not a library release, and is not installable as one. The v2.0.0 release commit
+re-points `url:`/`checksum:` at the final asset (#512), but the pre-release itself is **kept**: every
+commit in the v2.0.0 window pins it, so deleting it would take its asset with it and make those
+commits unbuildable from a clean checkout, breaking `git bisect` and historical re-measurement.
 
 Verified before publishing, per `docs/guides/building-occt.md`'s shipping checklist: `occt-src` at
 exactly `V8_0_1`, all eleven patches reverse-apply, and zero modified files that no carried patch
@@ -48,11 +50,12 @@ fast-forward (23 commits, 74 files, nothing reverted) and it carries **no API or
 the only public header in the whole diff is `ShapeAnalysis_FreeBounds.hxx`, changed by one comment
 line. Nothing to migrate for the OCCT API itself.
 
-**`Package.swift`'s `url:`/`checksum:` deliberately still point at the v1.15.18 asset**, which is
-p1 + patches 0001-0016. That bump belongs to the release commit (#512), so until v2.0.0 ships a
-clean checkout with no local `Libraries/` resolves the **old** kernel. Build locally and use
-`OCCTSWIFT_LOCAL=1` for the new one, and read `kernel-integration.yml` rather than `ci.yml`'s
-macOS job for the real signal (#585).
+**`Package.swift`'s `url:`/`checksum:` pointed at the v1.15.18 asset when this landed**, which is
+p1 + patches 0001-0016, on the #512 rule that the bump belongs to the release commit. That is no
+longer the case: see "CI builds the same kernel the branch is written against" above, which pins the
+`v2.0.0-kernel.1` pre-release. A clean checkout with no local `Libraries/` now resolves the right
+kernel, and `ci.yml`'s macOS job is a real signal. `OCCTSWIFT_LOCAL=1` remains useful for iterating
+on a locally rebuilt kernel; it is no longer needed for correct results.
 
 #### Ten carried kernel patches retired
 

--- a/docs/guides/building-occt.md
+++ b/docs/guides/building-occt.md
@@ -337,10 +337,14 @@ the patch's `Scripts/repro/<issue>/README.md` recorded. Then a full `swift test`
 
 Pushing a commit that touches `Scripts/patches/**` also triggers `.github/workflows/
 kernel-integration.yml` (#585), which rebuilds from source in CI and runs `swift test` against
-that binary. `ci.yml`'s own macOS check still runs too and will fail any new regression test that
-asserts the patch's fixed behaviour, since it always resolves the pinned *released* kernel; that
-failure is expected until a release ships this patch, not a sign the patch is broken — read
-`kernel-integration.yml`'s result for the real signal.
+that binary.
+
+`ci.yml`'s macOS check resolves whatever `Package.swift` pins, so a patch newer than the pinned
+asset makes that patch's own regression tests fail there. **Do not leave it in that state for a
+whole release.** Reading `kernel-integration.yml` instead works for one PR, but the red accumulates:
+during v2.0.0 seven suites were red at once for this reason, `build-and-test` was excluded from the
+required checks because of it, and every reviewer had to merge on parity with the base branch rather
+than on green. Publish a kernel pre-release and bump the pin instead.
 
 **4. Package and pin.** The zip is the release asset; its checksum is what SwiftPM verifies.
 
@@ -366,6 +370,41 @@ Then, in the release commit:
 Between the rebuild and the release the two consumer paths diverge on purpose: this checkout and
 every sibling repo path-depending on its `Libraries/OCCT.xcframework` get the new kernel
 immediately, while anything resolving the remote `url:` stays on the previously released one.
+
+### Mid-release: publish a `vX.Y.Z-kernel.N` pre-release
+
+The divergence above is fine for a day. It is **not** fine for a whole release, because CI resolves
+the remote `url:`, so every regression test asserting the new patch's fix fails there until the
+release ships. During v2.0.0 that reached seven simultaneously red suites, got `build-and-test`
+excluded from the required checks, and forced every reviewer to merge on parity with the base branch
+instead of on green (#585).
+
+So when a patch lands mid-release, do not wait for the release commit and do not tell people to read
+`kernel-integration.yml` instead. Publish the kernel on its own:
+
+```bash
+gh release create vX.Y.Z-kernel.N --target <branch-head-sha> --prerelease \
+    --title "vX.Y.Z-kernel.N: OCCT <tag> + N carried patches (kernel pre-release)" \
+    --notes-file <notes>
+gh release upload vX.Y.Z-kernel.N Libraries/OCCT.xcframework.zip
+```
+
+Then bump `url:`/`checksum:` on the branch, exactly as the release commit will later do again.
+
+Three things this needs:
+
+- **Verify provenance before publishing**, using steps 1 to 3 above. A local build directory is not
+  evidence on its own: `occt-src` must be at exactly the pinned tag, every carried patch must
+  reverse-apply, and `git -C Libraries/occt-src status --porcelain` must list *only* files a patch
+  touches, or an investigation probe ships inside a public binary.
+- **`release.yml` must not run on it.** It checks out the tag and builds, but a kernel pre-release is
+  published *before* the commit that pins it, by construction, so the tag still carries the old pin
+  and the run fails for a reason unrelated to the artifact. The workflow is gated on
+  `!github.event.release.prerelease` for this reason.
+- **Do not delete the pre-release afterwards.** Every commit in the release window pins it, so
+  deleting it takes its asset with it and makes those commits unbuildable from a clean checkout,
+  which breaks `git bisect` and any historical re-measurement. Release storage is cheap; the
+  bisectability is not.
 
 ## Alternative: Pre-built Binaries
 

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -149,10 +149,19 @@ prebuilt that predates the edit links silently and reports a pass for code that 
 That is not hypothetical: it nearly happened during the 8.0.1 absorb. Restoring the switch is part
 of the release commit.
 
-**`build-and-test` is structurally red for the whole release and that is expected.** It resolves
-`Package.swift`'s pinned released asset, which cannot contain unreleased kernel patches (#585). The
-merge criterion is **parity with the base branch**, not green: same failing set, same count. Any
-change in the failure *set* or *mode* is a real signal and must be investigated, not waved through.
+**`build-and-test` is green, and green is the merge criterion.** This changed on 2026-08-04. It
+resolves `Package.swift`'s pinned asset, which is now the `v2.0.0-kernel.1` pre-release carrying the
+eleven unreleased patches, so the job finally builds the kernel this branch's tests are written
+against.
+
+Before that the asset was v1.15.18, which could not contain an unreleased patch, so the job was
+structurally red (#585) and the criterion was **parity with the base branch**: same failing set,
+same count. If you are reading a PR from before that date, that is the rule it was merged under.
+
+**When a new kernel patch lands mid-release the problem returns**, because the pinned asset predates
+it. The fix is to publish the next `vX.Y.Z-kernel.N` pre-release and bump the pin, not to fall back
+to parity. `docs/guides/building-occt.md` has the procedure. Any change in the failure set or mode is
+a real signal and must be investigated, not waved through.
 During the 8.0.1 absorb the first run died with a SIGSEGV rather than the expected assertion
 failures, which turned out to be the known #344/#345 flake, but only checking established that.
 


### PR DESCRIPTION
Fixes the branch-wide CI redness rather than working around it.

## The problem

`ci.yml` resolves `Package.swift`'s pinned **release asset**. That was v1.15.18, which is
`V8_0_0_p1` + patches `0001`-`0016`. The branch builds `V8_0_1` + patches `0010`-`0012` and
`0014`-`0021`.

So every test asserting behaviour that a newer patch fixes failed in CI, indistinguishably from a
real regression. **Seven suites were red for that reason alone:**

`#522` approximation collapse, `#570` healing approximations, `#572` sweep, `#572` conversion,
`#491` approximation parity, `#496` cylindrical hole contracts, `#532` hole part selection.

Nineteen tests, 56 issues, stable across every PR. The documented workaround was to read
`kernel-integration.yml` instead of `ci.yml` (#585), and each new correctness fix added more red.
PR #690's three Gordon tests were about to be the eighth suite.

## The fix

Publishes the kernel the branch already builds as the
[`v2.0.0-kernel.1`](https://github.com/SecondMouseAU/OCCTSwift/releases/tag/v2.0.0-kernel.1)
pre-release and pins it.

**Measured, with no local `Libraries/` and no `OCCTSWIFT_LOCAL`, which is what CI does:**

| | before | after |
|---|---|---|
| full suite | 19 failing / 56 issues | **5,313 tests, 0 failures** |
| the seven suites above | red | green |
| #690's Gordon tests | 6 issues | green (verified by checking that branch's test file out against this pin) |

`OCCTSWIFT_LOCAL=1` is still useful for iterating on a locally rebuilt kernel. It is no longer
required to get correct results.

## Provenance of the published binary

Run before publishing, per `docs/guides/building-occt.md`'s shipping checklist, because a leftover
diagnostic probe from an investigation would otherwise be compiled into a release artifact:

- `occt-src` at exactly `V8_0_1`.
- All eleven carried patches reverse-apply, so all eleven are present.
- **Zero** modified files that no carried patch touches (43 modified, 43 patch-touched).
- Library newer than the newest patched source.
- 8.0.1's `GeomFill_Gordon` fix confirmed present by measurement, not assumed.
- The published asset re-downloads to the same SHA256 it was uploaded with.

Worth recording: the main checkout's `occt-src` is still at `V8_0_0_p1` with the pre-absorb 21-patch
set applied, so it is **not** the tree this binary was built from and cannot be used to verify it.
The `V8_0_1` tree is in the `1b` worktree, which is where the absorb build ran.

## Docs

`CLAUDE.md` carried three stale claims, all corrected here:

1. The project summary described the two-kernel split as current and told readers a clean checkout
   gets the old kernel.
2. It advised reading `kernel-integration.yml` rather than `ci.yml` for the real signal.
3. A third passage still said the repo has **no branch protection and no rulesets**, and that making
   `gate-scripts` required was "tracked separately". #649 made it required, and the same file already
   said so forty lines earlier. The file contradicted itself.

Also noted, not acted on: `build-and-test` is excluded from the required set on `refactor/**`
because it was 0-for-21 under #585. That reason no longer holds. Requiring it is a separate decision
and wants a run of green results first, so this only records that the exclusion is now unjustified.

## Relationship to #512

#512 says the `url:`/`checksum:` bump belongs to the release commit. That rule exists to stop the
pin pointing at an asset that does not exist yet. This points at a real, published, verified
pre-release, and the release commit still re-points at the final v2.0.0 asset, after which this
pre-release can be deleted.

Closes nothing. #585 is already closed; this removes the condition it described.
