### PR TITLE
fix(#655): sectionWiresAtZ, not freeBounds, is where OCCT 8.0.1's INTERNAL/EXTERNAL skip lands

### DIFF
--- a/Sources/OCCTSwift/FreeBoundsProperties.swift
+++ b/Sources/OCCTSwift/FreeBoundsProperties.swift
@@ -24,6 +24,12 @@ import OCCTBridge
 /// The shape needs to be a compound or shell of faces: the search runs over its direct children,
 /// so a lone face reports no free bounds. In practice the sewing pass closes essentially every
 /// contour it finds, so ``openCount`` is usually 0.
+///
+/// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at
+///   any tolerance; see `Shape.freeBounds(sewingTolerance:)` for why, on both branches. This type's
+///   own `init?(shape:tolerance:)` is where the `tolerance <= 0` branch (no sewing stage at all) is
+///   selected, so its guarantee rests directly on the two-branch measurement that note describes,
+///   not only on the sewing-branch reasoning. See #655.
 public final class FreeBoundsProperties: @unchecked Sendable {
     private let ref: OCCTFreeBoundsPropsRef
 

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -330,6 +330,13 @@ extension Shape {
     /// Analyze free boundary wires (open edges not shared by two faces).
     ///
     /// Free boundaries indicate gaps in a shell. A watertight shell has no free boundaries.
+    ///
+    /// - Note: Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method (and the rest of the
+    ///   `freeBounds*` family) is unaffected by OCCT 8.0.1's `ConnectEdgesToWires`
+    ///   INTERNAL/EXTERNAL skip (OCCT#1408): edges or wires carrying `.internal`/`.external`
+    ///   orientation are never picked up as free-bound candidates in the first place, on either
+    ///   kernel version, since this family goes through `ShapeAnalysis_FreeBounds`'s constructor
+    ///   rather than its `ConnectEdgesToWires` entry point. See #655.
     /// - Parameter sewingTolerance: Tolerance for grouping free edges into wires
     /// - Returns: Free bounds result, or nil if no free boundaries found
     public func freeBounds(sewingTolerance: Double = 1e-6) -> FreeBoundsResult? {

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -331,14 +331,38 @@ extension Shape {
     ///
     /// Free boundaries indicate gaps in a shell. A watertight shell has no free boundaries.
     ///
-    /// - Note: Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method (and the rest of the
-    ///   `freeBounds*` family: ``freeBoundsAnalysis(tolerance:)``, ``freeBoundsClosedCount(tolerance:)``,
-    ///   ``freeBoundsClosedWires(tolerance:)``, ``freeBoundsOpenWires(tolerance:)``) is unaffected by
-    ///   OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408). The constructor this
-    ///   family uses does reach that same skip, in its own chainage step, so the reason is not that
-    ///   the call graph avoids it. What keeps the result unchanged is upstream: the edges this family
-    ///   feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing
-    ///   stage never produced an `.internal`/`.external` free edge for the skip to act on. See #655.
+    /// - Note: Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method is unaffected by OCCT
+    ///   8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408). This method's constructor
+    ///   does reach that same skip, in its own chainage step, so the reason is not that the call
+    ///   graph avoids it. What keeps the result unchanged is upstream: the edges this method feeds
+    ///   in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing
+    ///   stage never produced an `.internal`/`.external` free edge for the skip to act on.
+    ///
+    ///   ``freeBoundsClosedCount(tolerance:)``, ``freeBoundsClosedWires(tolerance:)`` and
+    ///   ``freeBoundsOpenWires(tolerance:)`` share this reasoning unconditionally: each always
+    ///   builds `ShapeAnalysis_FreeBounds` with the `(shape, tolerance, ...)` sewing constructor no
+    ///   matter what value is passed, so there is no other branch to consider for them.
+    ///
+    ///   ``freeBoundsAnalysis(tolerance:)``, ``FreeBoundsProperties`` and the four accessors built
+    ///   on it (``closedFreeBoundInfo(tolerance:index:)``, ``openFreeBoundInfo(tolerance:index:)``,
+    ///   ``closedFreeBoundWire(tolerance:index:)``, ``openFreeBoundWire(tolerance:index:)``) are
+    ///   different: `ShapeAnalysis_FreeBoundsProperties::DispatchBounds()` picks the sewing
+    ///   constructor only when its tolerance is greater than 0; at 0 or below it picks
+    ///   `ShapeAnalysis_FreeBounds(shape, splitClosed, splitOpen)` instead, a constructor with no
+    ///   sewing stage at all, which takes its edges from `ShapeAnalysis_Shell::CheckOrientedShells`/
+    ///   `FreeEdges()` and reaches the same `ConnectEdgesToWires` skip by a different route. This is
+    ///   measured directly, not assumed from the sewing case above: the `.internal` exclusion holds
+    ///   on this branch too, and a FORWARD control on the same fixture confirms the two branches are
+    ///   not just trivially agreeing on everything. The sewing branch chains a FORWARD loop entirely
+    ///   inside one face into one closed wire together with that face's outer boundary (3 closed, 0
+    ///   open); the shared-topology branch returns the same loop's four edges unchained (2 closed, 4
+    ///   open). What is not measured, and not claimed, is *why* the INTERNAL loop is absent on the
+    ///   shared-topology branch: that constructor defaults `checkinternaledges` to `false`, so the
+    ///   internal edges may never reach `FreeEdges()` as candidates at all, rather than being
+    ///   collected and then dropped by the same skip the sewing branch's chainage step hits. Both
+    ///   would produce the same observable result, which is the only thing measured here. See
+    ///   `Issue655FreeBoundsInternalOrientationTests` (`OCCTShapeHealingTests`) for both fixtures.
+    ///   See #655.
     /// - Parameter sewingTolerance: Tolerance for grouping free edges into wires
     /// - Returns: Free bounds result, or nil if no free boundaries found
     public func freeBounds(sewingTolerance: Double = 1e-6) -> FreeBoundsResult? {
@@ -654,8 +678,10 @@ extension Shape {
     /// }
     /// ```
     ///
-    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408);
-    ///   see ``freeBounds(sewingTolerance:)`` for why. See #655.
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408),
+    ///   at any tolerance, including the `tolerance <= 0` input documented below that routes to a
+    ///   different constructor with no sewing stage at all; see ``freeBounds(sewingTolerance:)`` for
+    ///   why, on both branches. See #655.
     /// - Parameter tolerance: Sewing tolerance used to chain free edges into contours. 0 or below
     ///   selects a different OCCT algorithm, taking free edges from the shape's already-shared
     ///   topology instead of from a sewing pass.
@@ -676,6 +702,8 @@ extension Shape {
     /// See ``freeBoundsAnalysis(tolerance:)`` for what the tolerance selects, and
     /// ``FreeBoundsProperties`` for reading several bounds without re-analysing each time.
     ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408),
+    ///   at any tolerance; see ``freeBounds(sewingTolerance:)`` for why, on both branches. See #655.
     /// - Parameters:
     ///   - tolerance: Same tolerance used for analysis
     ///   - index: 0-based index of the closed free bound
@@ -689,6 +717,8 @@ extension Shape {
     /// See ``freeBoundsAnalysis(tolerance:)`` for what the tolerance selects, and
     /// ``FreeBoundsProperties`` for reading several bounds without re-analysing each time.
     ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408),
+    ///   at any tolerance; see ``freeBounds(sewingTolerance:)`` for why, on both branches. See #655.
     /// - Parameters:
     ///   - tolerance: Same tolerance used for analysis
     ///   - index: 0-based index of the open free bound
@@ -699,6 +729,8 @@ extension Shape {
 
     /// Get the wire shape of a closed free bound.
     ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408),
+    ///   at any tolerance; see ``freeBounds(sewingTolerance:)`` for why, on both branches. See #655.
     /// - Parameters:
     ///   - tolerance: Same tolerance used for analysis
     ///   - index: 0-based index of the closed free bound
@@ -709,6 +741,8 @@ extension Shape {
 
     /// Get the wire shape of an open free bound.
     ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408),
+    ///   at any tolerance; see ``freeBounds(sewingTolerance:)`` for why, on both branches. See #655.
     /// - Parameters:
     ///   - tolerance: Same tolerance used for analysis
     ///   - index: 0-based index of the open free bound

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -332,11 +332,13 @@ extension Shape {
     /// Free boundaries indicate gaps in a shell. A watertight shell has no free boundaries.
     ///
     /// - Note: Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method (and the rest of the
-    ///   `freeBounds*` family) is unaffected by OCCT 8.0.1's `ConnectEdgesToWires`
-    ///   INTERNAL/EXTERNAL skip (OCCT#1408): edges or wires carrying `.internal`/`.external`
-    ///   orientation are never picked up as free-bound candidates in the first place, on either
-    ///   kernel version, since this family goes through `ShapeAnalysis_FreeBounds`'s constructor
-    ///   rather than its `ConnectEdgesToWires` entry point. See #655.
+    ///   `freeBounds*` family: ``freeBoundsAnalysis(tolerance:)``, ``freeBoundsClosedCount(tolerance:)``,
+    ///   ``freeBoundsClosedWires(tolerance:)``, ``freeBoundsOpenWires(tolerance:)``) is unaffected by
+    ///   OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408). The constructor this
+    ///   family uses does reach that same skip, in its own chainage step, so the reason is not that
+    ///   the call graph avoids it. What keeps the result unchanged is upstream: the edges this family
+    ///   feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing
+    ///   stage never produced an `.internal`/`.external` free edge for the skip to act on. See #655.
     /// - Parameter sewingTolerance: Tolerance for grouping free edges into wires
     /// - Returns: Free bounds result, or nil if no free boundaries found
     public func freeBounds(sewingTolerance: Double = 1e-6) -> FreeBoundsResult? {
@@ -652,6 +654,8 @@ extension Shape {
     /// }
     /// ```
     ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408);
+    ///   see ``freeBounds(sewingTolerance:)`` for why. See #655.
     /// - Parameter tolerance: Sewing tolerance used to chain free edges into contours. 0 or below
     ///   selects a different OCCT algorithm, taking free edges from the shape's already-shared
     ///   topology instead of from a sewing pass.
@@ -1368,6 +1372,9 @@ extension Shape {
 extension Shape {
 
     /// Count the number of closed free-boundary wires.
+    ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408);
+    ///   see ``freeBounds(sewingTolerance:)`` for why. See #655.
     /// - Parameter tolerance: Sewing tolerance for boundary detection.
     /// - Returns: Number of closed free-boundary wires.
     public func freeBoundsClosedCount(tolerance: Double = 1e-6) -> Int {
@@ -1375,6 +1382,9 @@ extension Shape {
     }
 
     /// Get the compound of closed free-boundary wires.
+    ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408);
+    ///   see ``freeBounds(sewingTolerance:)`` for why. See #655.
     /// - Parameter tolerance: Sewing tolerance for boundary detection.
     /// - Returns: Compound shape of closed wires, or nil if none.
     public func freeBoundsClosedWires(tolerance: Double = 1e-6) -> Shape? {
@@ -1383,6 +1393,9 @@ extension Shape {
     }
 
     /// Get the compound of open free-boundary wires.
+    ///
+    /// - Note: Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408);
+    ///   see ``freeBounds(sewingTolerance:)`` for why. See #655.
     /// - Parameter tolerance: Sewing tolerance for boundary detection.
     /// - Returns: Compound shape of open wires, or nil if none.
     public func freeBoundsOpenWires(tolerance: Double = 1e-6) -> Shape? {

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2236,6 +2236,15 @@ public final class Shape: @unchecked Sendable {
     /// Unlike `sliceAtZ(_:)` which returns a shape with loose edges, this method
     /// chains the edges into closed wires that can be used with `Wire.offset(by:)`.
     ///
+    /// - Note: Edges whose orientation is `.internal` or `.external` (see
+    ///   `Shape.Orientation`/`Shape.setOrientation(_:)`) are silently excluded from the result
+    ///   wires (OCCT 8.0.1, upstream OCCT#1408). This only matters if the input `Shape` was
+    ///   assembled with such edges through `Shape.compound(_:)`/`Shape.setOrientation(_:)` and one
+    ///   of them happens to lie exactly in the cutting plane; an ordinary transverse section of a
+    ///   solid never produces `.internal`/`.external` edges on its own, since Boolean sectioning
+    ///   only preserves an edge's own orientation when the cut is coincident with that edge, not
+    ///   when it computes a fresh intersection curve. See #655.
+    ///
     /// ## Example: CAM Safety Boundary
     ///
     /// ```swift

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2221,7 +2221,7 @@ public final class Shape: @unchecked Sendable {
         return Shape(handle: handle)
     }
 
-    /// Get closed wires from a section at Z level.
+    /// Get wires from a section at a Z level, chained where the section closes.
     ///
     /// This is useful for CAM operations where you need to work with closed contours
     /// that can be offset for tool compensation.
@@ -2230,11 +2230,12 @@ public final class Shape: @unchecked Sendable {
     ///   - z: The Z level to section at
     ///   - tolerance: Tolerance for connecting edges into wires. Use larger values
     ///                (e.g., 1e-4) for imprecise geometry. Default is 1e-6.
-    /// - Returns: Array of closed wires representing contours at that Z level.
+    /// - Returns: Array of wires representing contours at that Z level, closed where the section
+    ///            forms a loop and open otherwise (e.g. a section edge with nothing to close onto).
     ///            Returns empty array if no contours exist at that level.
     ///
     /// Unlike `sliceAtZ(_:)` which returns a shape with loose edges, this method
-    /// chains the edges into closed wires that can be used with `Wire.offset(by:)`.
+    /// chains the edges into wires (closed where possible) that can be used with `Wire.offset(by:)`.
     ///
     /// - Note: Edges whose orientation is `.internal` or `.external` (see
     ///   `Shape.Orientation`/`Shape.setOrientation(_:)`) are silently excluded from the result

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2241,10 +2241,10 @@ public final class Shape: @unchecked Sendable {
     ///   `Shape.Orientation`/`Shape.setOrientation(_:)`) are silently excluded from the result
     ///   wires (OCCT 8.0.1, upstream OCCT#1408). This only matters if the input `Shape` was
     ///   assembled with such edges through `Shape.compound(_:)`/`Shape.setOrientation(_:)` and one
-    ///   of them happens to lie exactly in the cutting plane; an ordinary transverse section of a
-    ///   solid never produces `.internal`/`.external` edges on its own, since Boolean sectioning
-    ///   only preserves an edge's own orientation when the cut is coincident with that edge, not
-    ///   when it computes a fresh intersection curve. See #655.
+    ///   of them happens to lie exactly in the cutting plane; in every case measured, an ordinary
+    ///   transverse section of a solid does not produce `.internal`/`.external` edges on its own,
+    ///   since Boolean sectioning only preserves an edge's own orientation when the cut is
+    ///   coincident with that edge, not when it computes a fresh intersection curve. See #655.
     ///
     /// ## Example: CAM Safety Boundary
     ///

--- a/Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift
+++ b/Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// OCCT 8.0.1 (OCCT#1408, the merged form of OCCT#1331) makes
+/// `ShapeAnalysis_FreeBounds::ConnectEdgesToWires` skip edges whose orientation is `.internal` or
+/// `.external`. That C++ entry point appears exactly once in this bridge, inside
+/// `OCCTShapeSectionWiresAtZ` (`OCCTBridge_Modeling.mm:10916`), which backs
+/// `Shape.sectionWiresAtZ(_:tolerance:)` -- a CAM sectioning API. The `freeBounds*` family
+/// (`Shape.freeBounds`, `freeBoundsAnalysis`, `freeBoundsClosedCount`, `freeBoundsClosedWires`,
+/// `freeBoundsOpenWires`) uses a different (constructor) entry point that never reaches the
+/// changed code.
+///
+/// `BRepAlgoAPI_Section` does not invent `.internal`/`.external` edges out of an ordinary
+/// transverse cut, but it DOES pass an already-`.internal`/`.external` input edge through
+/// unchanged when the cutting plane is exactly coincident with that edge -- the "same domain"
+/// case OCCT's Boolean-operation machinery takes for input already lying in the section plane.
+/// Since `Shape.setOrientation(_:)` is public API, a caller can construct exactly that input,
+/// which is what `fixture(orientation:)` below does, making the 8.0.1 skip observably reachable
+/// through `sectionWiresAtZ`.
+///
+/// Measured directly against both kernels before writing this test (v1.15.18, OCCT 8.0.0p1, vs.
+/// the pinned v2.0.0-kernel.1, OCCT V8_0_1): a compound of one closed square (4 FORWARD edges) and
+/// one disjoint floating edge coincident with the cut plane, marked `.internal`, sections to 2
+/// wires (the square, plus the floating edge as its own open 1-edge wire) on the old kernel and 1
+/// wire (just the square) on the new one.
+///
+/// #655 also asks whether the same upstream change's removal of `isUsedManifoldMode` (the
+/// separate closure detection non-manifold wires -- in `ShapeExtend_WireData`'s own vocabulary, a
+/// wire built from `.internal`/`.external` edges -- used to get) is independently reachable. It is
+/// not, on either of this bridge's two entry points:
+///
+/// - Through `ConnectEdgesToWires` (`sectionWiresAtZ`'s path): the new outer skip removes every
+///   `.internal`/`.external` edge before any per-edge wire is built, so the old fallback's own
+///   trigger condition (the first candidate wire having zero ordinary edges and at least one
+///   non-manifold one) can never be satisfied again. The wire-count change measured above is
+///   fully attributable to the skip alone.
+/// - Through the `(shape, tolerance)` constructor (the `freeBounds*` path): a face's embedded,
+///   fully-`.internal` closed wire (4 edges) never appears in either `GetClosedWires()` or
+///   `GetOpenWires()`'s output on EITHER kernel -- verified directly, not inferred. Free-bound
+///   candidacy excludes `.internal`/`.external` sub-wires upstream of `connectWiresToWiresImpl`,
+///   independent of the 8.0.1 change.
+@Suite("sectionWiresAtZ drops a coincident INTERNAL/EXTERNAL edge (OCCT 8.0.1, #655)")
+struct Issue655SectionWiresOrientationTests {
+
+    /// A closed unit square (4 edges, all FORWARD) plus one disjoint, floating segment carrying
+    /// `orientation` -- all lying exactly in the z=3 cut plane, with the floating edge listed
+    /// first in the compound (matching the order the issue's own repro used, where the affected
+    /// edge is `arrwires->Value(1)`).
+    ///
+    /// `orientation` is the fixture's single dial: swapping it from `.internal` to `.forward` is
+    /// the "prove the test fails" injection for `internalEdgeExcluded()` below -- it changes
+    /// nothing about the geometry, only whether the skip applies.
+    static func fixture(orientation: Shape.Orientation) -> Shape? {
+        guard let squareWire = Wire.polygon3D(
+            [SIMD3(0, 0, 3), SIMD3(10, 0, 3), SIMD3(10, 10, 3), SIMD3(0, 10, 3)],
+            closed: true
+        ), let square = Shape.fromWire(squareWire) else { return nil }
+
+        guard let floatingWire = Wire.line(from: SIMD3(2, 2, 3), to: SIMD3(4, 4, 3)),
+              let floatingEdge = floatingWire.edges().first,
+              let floatingShape = Shape.fromEdge(floatingEdge) else { return nil }
+        floatingShape.setOrientation(orientation)
+
+        return Shape.compound([floatingShape, square])
+    }
+
+    @Test("A coincident INTERNAL edge is excluded from the returned wires")
+    func internalEdgeExcluded() {
+        guard let shape = Self.fixture(orientation: .internal) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        let wires = shape.sectionWiresAtZ(3.0, tolerance: 1e-6)
+        // Only the closed square comes back; the coincident INTERNAL edge is dropped by OCCT
+        // 8.0.1's ConnectEdgesToWires (OCCT#1408).
+        #expect(wires.count == 1, "expected 1 wire (the square only), got \(wires.count)")
+        if let only = wires.first {
+            #expect(only.edges().count == 4)
+            #expect(only.curveInfo?.isClosed == true)
+        }
+    }
+
+    @Test("The same coincident edge, left FORWARD, is NOT excluded (contrast fixture)")
+    func forwardEdgeNotExcluded() {
+        guard let shape = Self.fixture(orientation: .forward) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        let wires = shape.sectionWiresAtZ(3.0, tolerance: 1e-6)
+        // The floating FORWARD edge shares no vertex with the square, so it must survive as its
+        // own open 1-edge wire: 2 wires total. This is the injected-failure check for
+        // internalEdgeExcluded() above, run as its own assertion rather than a disabled test --
+        // if orientation stopped mattering, this would start failing too.
+        #expect(wires.count == 2, "expected 2 wires (square + floating edge), got \(wires.count)")
+    }
+
+    @Test("An EXTERNAL edge is excluded the same way as INTERNAL")
+    func externalEdgeExcluded() {
+        guard let shape = Self.fixture(orientation: .external) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        let wires = shape.sectionWiresAtZ(3.0, tolerance: 1e-6)
+        #expect(wires.count == 1, "expected 1 wire (the square only), got \(wires.count)")
+    }
+}

--- a/Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift
+++ b/Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift
@@ -42,9 +42,10 @@ import Foundation
 ///   fully attributable to the skip alone.
 /// - Through the `(shape, tolerance)` constructor (the `freeBounds*` path): a face's embedded,
 ///   fully-`.internal` closed wire (4 edges) never appears in either `GetClosedWires()` or
-///   `GetOpenWires()`'s output on EITHER kernel -- verified directly, not inferred. Free-bound
-///   candidacy excludes `.internal`/`.external` sub-wires upstream of `connectWiresToWiresImpl`,
-///   independent of the 8.0.1 change.
+///   `GetOpenWires()`'s output on EITHER kernel -- verified directly, not inferred. The reason is
+///   the same one above, not a separate call-graph boundary inside `ShapeAnalysis_FreeBounds`: the
+///   sewing stage that constructor runs first (`BRepBuilderAPI_Sewing::FreeEdge`) never hands this
+///   loop's edges over as free-bound candidates at all, on either kernel version.
 @Suite("sectionWiresAtZ drops a coincident INTERNAL/EXTERNAL edge (OCCT 8.0.1, #655)")
 struct Issue655SectionWiresOrientationTests {
 

--- a/Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift
+++ b/Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift
@@ -5,11 +5,16 @@ import Foundation
 /// OCCT 8.0.1 (OCCT#1408, the merged form of OCCT#1331) makes
 /// `ShapeAnalysis_FreeBounds::ConnectEdgesToWires` skip edges whose orientation is `.internal` or
 /// `.external`. That C++ entry point appears exactly once in this bridge, inside
-/// `OCCTShapeSectionWiresAtZ` (`OCCTBridge_Modeling.mm:10916`), which backs
+/// `OCCTShapeSectionWiresAtZ` (`OCCTBridge_Modeling.mm`), which backs
 /// `Shape.sectionWiresAtZ(_:tolerance:)` -- a CAM sectioning API. The `freeBounds*` family
 /// (`Shape.freeBounds`, `freeBoundsAnalysis`, `freeBoundsClosedCount`, `freeBoundsClosedWires`,
-/// `freeBoundsOpenWires`) uses a different (constructor) entry point that never reaches the
-/// changed code.
+/// `freeBoundsOpenWires`) goes through `ShapeAnalysis_FreeBounds`'s constructor instead, and that
+/// constructor's own chainage step *does* call `ConnectEdgesToWires`, so it is not a different
+/// entry point that avoids the changed code. What actually keeps this family unaffected is
+/// upstream: the edges it feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case
+/// measured that sewing stage never produced an `.internal`/`.external` free edge for the skip to
+/// act on (see `Issue655FreeBoundsInternalOrientationTests` in `OCCTShapeHealingTests`, which
+/// covers this half directly).
 ///
 /// `BRepAlgoAPI_Section` does not invent `.internal`/`.external` edges out of an ordinary
 /// transverse cut, but it DOES pass an already-`.internal`/`.external` input edge through
@@ -48,6 +53,13 @@ struct Issue655SectionWiresOrientationTests {
     /// first in the compound (matching the order the issue's own repro used, where the affected
     /// edge is `arrwires->Value(1)`).
     ///
+    /// Compound order is NOT load-bearing for these assertions: the floating edge shares no vertex
+    /// with the square, so nothing here needs a merge-order or reversal decision to come out right
+    /// (measured directly by reordering the compound and re-running; all three tests below were
+    /// unchanged). That's different from the issue's own case B, where an INTERNAL edge visited
+    /// before a square that still needs a reversal genuinely does depend on order; this fixture just
+    /// doesn't build that case, since it never merges with anything.
+    ///
     /// `orientation` is the fixture's single dial: swapping it from `.internal` to `.forward` is
     /// the "prove the test fails" injection for `internalEdgeExcluded()` below -- it changes
     /// nothing about the geometry, only whether the skip applies.
@@ -76,8 +88,8 @@ struct Issue655SectionWiresOrientationTests {
         // 8.0.1's ConnectEdgesToWires (OCCT#1408).
         #expect(wires.count == 1, "expected 1 wire (the square only), got \(wires.count)")
         if let only = wires.first {
-            #expect(only.edges().count == 4)
-            #expect(only.curveInfo?.isClosed == true)
+            #expect(only.edges().count == 4, "expected the square's 4 edges, got \(only.edges().count)")
+            #expect(only.curveInfo?.isClosed == true, "expected the surviving wire to be closed")
         }
     }
 

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -595,6 +595,60 @@ struct Issue655FreeBoundsInternalOrientationTests {
         #expect(shape.freeBoundsClosedCount(tolerance: 1e-6) == 3,
                 "expected 3 closed wires (2 outer boundaries + the now-visible loop)")
     }
+
+    /// `freeBoundsAnalysis(tolerance:)` (and every sibling built on `FreeBoundsProperties`) takes a
+    /// `tolerance <= 0` as a documented request for a different OCCT constructor with no sewing
+    /// stage at all: `ShapeAnalysis_FreeBoundsProperties::DispatchBounds()` picks
+    /// `ShapeAnalysis_FreeBounds(shape, splitClosed, splitOpen)` instead of the
+    /// `(shape, toler, splitClosed, splitOpen)` sewing overload the tests above exercise. Both
+    /// overloads end in the same `ConnectEdgesToWires` call the OCCT 8.0.1 INTERNAL/EXTERNAL skip
+    /// lives in, but this one reaches it via `ShapeAnalysis_Shell::CheckOrientedShells`/
+    /// `FreeEdges()`, never via `BRepBuilderAPI_Sewing`. Round 2's tests never exercised this
+    /// branch (both used `tolerance: 1e-6`), so the doc's "unaffected on either kernel" note was an
+    /// unmeasured extrapolation from the sewing branch's reasoning for this input. This measures it
+    /// directly instead.
+    ///
+    /// Two things this proves, together:
+    /// - The `.internal` loop is still absent at `tolerance <= 0`, matching the sewing branch, so
+    ///   the doc's guarantee now holds on this input because it was checked, not assumed.
+    /// - The `.forward` control disagrees sharply between branches: 3 closed wires under sewing
+    ///   (chained into one wire with the outer boundary) versus 2 closed + 4 open under
+    ///   shared-topology (the loop's four edges come back unchained). That divergence is the
+    ///   evidence that the two branches are doing genuinely different things, which is what makes
+    ///   the `.internal` agreement a real result rather than the two branches trivially agreeing on
+    ///   everything.
+    ///
+    /// `0.0` and a negative tolerance are both tested because the doc says "0 or below" selects
+    /// this branch; a test of only `0.0` would leave "below" unmeasured.
+    ///
+    /// This cannot distinguish, and does not claim to, *why* the `.internal` loop is absent here:
+    /// `ShapeAnalysis_FreeBounds`'s shared-topology constructor defaults `checkinternaledges` to
+    /// `false` (`ShapeAnalysis_FreeBounds.hxx:98`), so the internal edges may never reach
+    /// `FreeEdges()` as candidates at all, rather than being collected and then dropped by the same
+    /// skip the sewing branch's chainage step hits. Both produce the same observable result, which
+    /// is the only thing measured and the only thing the doc claims.
+    @Test(
+        "At tolerance <= 0 (no sewing stage), the .internal exclusion still holds, and .forward proves the branches genuinely differ",
+        arguments: [
+            (Shape.Orientation.internal, 0.0, 2, 0),
+            (Shape.Orientation.internal, -1.0, 2, 0),
+            (Shape.Orientation.forward, 0.0, 2, 4),
+            (Shape.Orientation.forward, -1.0, 2, 4),
+        ]
+    )
+    func sharedTopologyBranchMeasuredDirectly(
+        loopOrientation: Shape.Orientation, tolerance: Double, expectedClosed: Int, expectedOpen: Int
+    ) {
+        guard let shape = Self.fixture(loopOrientation: loopOrientation) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        let analysis = shape.freeBoundsAnalysis(tolerance: tolerance)
+        #expect(analysis.closedCount == expectedClosed,
+                "orientation \(loopOrientation), tolerance \(tolerance): expected \(expectedClosed) closed wires, got \(analysis.closedCount)")
+        #expect(analysis.openCount == expectedOpen,
+                "orientation \(loopOrientation), tolerance \(tolerance): expected \(expectedOpen) open wires, got \(analysis.openCount)")
+    }
 }
 
 // MARK: - v0.41.0: Geometry Conversion

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -485,6 +485,100 @@ struct FreeBoundsTests {
     }
 }
 
+// MARK: - #655: freeBounds* unaffected by OCCT 8.0.1 INTERNAL/EXTERNAL skip
+
+/// #655 documents `Shape.sectionWiresAtZ(_:tolerance:)` as the one entry point OCCT 8.0.1's
+/// `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408) reaches, and the `freeBounds*` family
+/// (this suite) as unaffected, not because its `ShapeAnalysis_FreeBounds` constructor avoids the
+/// skip (its own chainage step calls the same `ConnectEdgesToWires`), but because the
+/// `BRepBuilderAPI_Sewing::FreeEdge` stage this family runs first never hands it an
+/// `.internal`/`.external` free edge to begin with. See `Shape.freeBounds(sewingTolerance:)`'s doc
+/// comment for the corrected mechanism, and `Issue655SectionWiresOrientationTests`
+/// (`OCCTModelingTests`) for the `sectionWiresAtZ` side that IS affected.
+///
+/// Fixture: a face with an embedded, fully-`.internal` closed 4-edge loop (not a hole, holes get
+/// REVERSED, not INTERNAL), plus a second, disjoint plain face, both in a compound (the
+/// `(shape, tolerance)` constructor's documented input shape). Built via the public
+/// `Shape.builderMakeWire()`/`.builderAdd(_:)`/`.setOrientation(_:)` API, the same primitives OCCT
+/// itself uses to model an embedded (non-hole) feature edge on a face.
+@Suite("#655: freeBounds* unaffected by INTERNAL orientation")
+struct Issue655FreeBoundsInternalOrientationTests {
+
+    /// Builds a compound of two disjoint square faces. `loopOrientation` sets the orientation of a
+    /// second, smaller closed 4-edge loop embedded inside the first face: `.internal` reproduces the
+    /// shape #655 measured directly against `ShapeAnalysis_FreeBounds::GetClosedWires()`/
+    /// `GetOpenWires()`; `.forward` is the "prove the test fails" injection, the same geometry, with
+    /// the loop now a genuine (non-embedded-feature) free-standing boundary the analyzer must report.
+    ///
+    /// The loop has to be embedded ON a face, not a sibling shape in the compound: a loose wire with
+    /// no face ancestor is invisible to `ShapeAnalysis_FreeBounds` regardless of orientation, which
+    /// would make this fixture prove nothing about the orientation skip at all.
+    static func fixture(loopOrientation: Shape.Orientation) -> Shape? {
+        guard let outerWire1 = Wire.polygon3D(
+            [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true
+        ), let face1 = Shape.face(from: outerWire1) else { return nil }
+
+        let loopPoints: [SIMD3<Double>] = [
+            SIMD3(2, 2, 0), SIMD3(8, 2, 0), SIMD3(8, 8, 0), SIMD3(2, 8, 0)
+        ]
+        guard let loopWireShape = Shape.builderMakeWire() else { return nil }
+        for i in 0..<loopPoints.count {
+            guard let edgeWire = Wire.line(from: loopPoints[i], to: loopPoints[(i + 1) % loopPoints.count]),
+                  let edge = edgeWire.edges().first,
+                  let edgeShape = Shape.fromEdge(edge) else { return nil }
+            edgeShape.setOrientation(loopOrientation)
+            loopWireShape.builderAdd(edgeShape)
+        }
+        loopWireShape.setOrientation(loopOrientation)
+        face1.builderAdd(loopWireShape)
+
+        guard let outerWire2 = Wire.polygon3D(
+            [SIMD3(50, 50, 0), SIMD3(60, 50, 0), SIMD3(60, 60, 0), SIMD3(50, 60, 0)], closed: true
+        ), let face2 = Shape.face(from: outerWire2) else { return nil }
+
+        return Shape.compound([face1, face2])
+    }
+
+    @Test("An embedded INTERNAL loop is absent from both closed and open free bounds")
+    func freeBoundsUnaffectedByInternalOrientation() {
+        guard let shape = Self.fixture(loopOrientation: .internal) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        // Only the two faces' own 4-edge outer boundaries come back; the embedded INTERNAL loop
+        // never becomes a free-bound candidate in the first place (see doc comment above).
+        #expect(shape.freeBoundsClosedCount(tolerance: 1e-6) == 2,
+                "expected 2 closed wires (the two faces' outer boundaries only)")
+        #expect(shape.freeBoundsClosedWires(tolerance: 1e-6)?.subShapeCount(ofType: .edge) == 8,
+                "expected 8 edges total (4 per face); the INTERNAL loop's 4 must not be counted")
+        #expect((shape.freeBoundsOpenWires(tolerance: 1e-6)?.subShapeCount(ofType: .wire) ?? 0) == 0,
+                "the INTERNAL loop must not surface as an open free bound either")
+
+        if let result = shape.freeBounds(sewingTolerance: 1e-6) {
+            #expect(result.closedCount == 2, "freeBounds() must agree with freeBoundsClosedCount")
+            #expect(result.openCount == 0, "freeBounds() must agree with freeBoundsOpenWires")
+        } else {
+            Issue.record("freeBounds() returned nil; expected the two outer boundaries")
+        }
+    }
+
+    /// The "prove the test fails" injection for the test above: the same fixture with the embedded
+    /// loop's orientation changed from `.internal` to `.forward`. A FORWARD loop entirely inside
+    /// face1, sharing no vertex with face1's outer boundary, is a genuine second free-bound
+    /// candidate on that face, so it must now be counted, as its own closed wire, alongside the two
+    /// outer boundaries. Run as a live contrast fixture (not a disabled test) so a future change
+    /// that stops the exclusion from mattering fails this test too.
+    @Test("The same loop, left FORWARD, IS counted (contrast fixture)")
+    func forwardLoopIsCounted() {
+        guard let shape = Self.fixture(loopOrientation: .forward) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        #expect(shape.freeBoundsClosedCount(tolerance: 1e-6) == 3,
+                "expected 3 closed wires (2 outer boundaries + the now-visible loop)")
+    }
+}
+
 // MARK: - v0.41.0: Geometry Conversion
 
 @Suite("ShapeCustom Geometry Conversion")

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -513,6 +513,17 @@ struct Issue655FreeBoundsInternalOrientationTests {
     /// The loop has to be embedded ON a face, not a sibling shape in the compound: a loose wire with
     /// no face ancestor is invisible to `ShapeAnalysis_FreeBounds` regardless of orientation, which
     /// would make this fixture prove nothing about the orientation skip at all.
+    ///
+    /// The loop's edges are built standalone via `Wire.line` and attached through the raw
+    /// `builderAdd` primitive, so they carry no pcurve on face1's plane. That works today --
+    /// `forwardLoopIsCounted` returning 3 proves sewing sees them regardless -- but if a future
+    /// kernel gets stricter about pcurve-less wires on a face, both tests here move together, and
+    /// the failure would read as a behaviour regression rather than a fixture problem.
+    ///
+    /// Every `builderAdd` call is guarded rather than discarded: a silent add failure would leave
+    /// the loop absent from `face1` entirely, which is indistinguishable from the loop being
+    /// correctly excluded by orientation -- exactly the gap `freeBoundsUnaffectedByInternalOrientation`
+    /// needs to not have.
     static func fixture(loopOrientation: Shape.Orientation) -> Shape? {
         guard let outerWire1 = Wire.polygon3D(
             [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true
@@ -527,10 +538,10 @@ struct Issue655FreeBoundsInternalOrientationTests {
                   let edge = edgeWire.edges().first,
                   let edgeShape = Shape.fromEdge(edge) else { return nil }
             edgeShape.setOrientation(loopOrientation)
-            loopWireShape.builderAdd(edgeShape)
+            guard loopWireShape.builderAdd(edgeShape) else { return nil }
         }
         loopWireShape.setOrientation(loopOrientation)
-        face1.builderAdd(loopWireShape)
+        guard face1.builderAdd(loopWireShape) else { return nil }
 
         guard let outerWire2 = Wire.polygon3D(
             [SIMD3(50, 50, 0), SIMD3(60, 50, 0), SIMD3(60, 60, 0), SIMD3(50, 60, 0)], closed: true
@@ -545,6 +556,13 @@ struct Issue655FreeBoundsInternalOrientationTests {
             Issue.record("fixture build failed")
             return
         }
+        // Fixture sanity check: the assertions below alone cannot distinguish "the loop was
+        // excluded from free bounds" from "the loop was never attached to face1 at all" -- both
+        // look identical downstream. This confirms the input actually carries all 12 edges (the
+        // two faces' 8 outer edges plus the embedded loop's 4) before asserting anything about
+        // what comes back out.
+        #expect(shape.subShapeCount(ofType: .edge) == 12,
+                "fixture must carry the embedded loop's 4 edges")
         // Only the two faces' own 4-edge outer boundaries come back; the embedded INTERNAL loop
         // never becomes a free-bound candidate in the first place (see doc comment above).
         #expect(shape.freeBoundsClosedCount(tolerance: 1e-6) == 2,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -97,12 +97,15 @@ Gordon tests assert only status ordinals. Those two were probed directly. Tracke
   `Shape.sectionWiresAtZ(_:tolerance:)`, a CAM sectioning API: in every case measured, an ordinary
   transverse cut does not produce such an edge, but a cut plane coincident with an edge a caller
   already marked `.internal`/`.external` via `Shape.setOrientation(_:)` does move, 2 wires to 1 on
-  a measured fixture. The `freeBounds*` family calls a different entry point, `ShapeAnalysis_FreeBounds`'s
-  `(shape, tolerance)` constructor, and that constructor's own chainage step does reach the same
-  skip, so the reason `freeBounds*` does **not** move is not that its call graph avoids the change.
-  It is upstream: the edges that family feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in
-  every case measured that sewing stage never produced an `.internal`/`.external` free edge for the
-  skip to act on.
+  a measured fixture. The `freeBounds*` family does **not** move, but not because its call graph
+  avoids the change: `Shape.freeBounds`, `freeBoundsClosedCount`, `freeBoundsClosedWires` and
+  `freeBoundsOpenWires` build `ShapeAnalysis_FreeBounds`'s `(shape, tolerance)` constructor, whose own
+  chainage step reaches the same skip. The reason is upstream, the edges that constructor feeds in
+  come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing stage never
+  produced an `.internal`/`.external` free edge for the skip to act on. `freeBoundsAnalysis`,
+  `FreeBoundsProperties` and its four accessors take a **second** constructor at `tolerance <= 0`,
+  with no sewing stage at all, so that reason does not apply to them; measured separately, the
+  exclusion holds there too.
 - **`BRep_Tool::CurveOnPlane` fails differently.** An out-of-domain, inverted or zero-length edge
   range now yields a null pcurve where 8.0.0p1 threw a catchable
   `Geom_TrimmedCurve::parameters out of range`. All four probed cases changed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,10 +94,10 @@ Gordon tests assert only status ordinals. Those two were probed directly. Tracke
   a sequence of one INTERNAL edge plus a square returns 1 wire where it returned 2, and a sequence
   of nothing but INTERNAL/EXTERNAL edges returns 0 wires where it returned 1. That C++ function
   appears exactly once in this bridge, inside `OCCTShapeSectionWiresAtZ`, which backs
-  `Shape.sectionWiresAtZ(_:tolerance:)`, a CAM sectioning API: an ordinary transverse cut never
-  produces such an edge, but a cut plane coincident with an edge a caller already marked
-  `.internal`/`.external` via `Shape.setOrientation(_:)` does move, 2 wires to 1 on a measured
-  fixture. The `freeBounds*` family calls a different entry point, `ShapeAnalysis_FreeBounds`'s
+  `Shape.sectionWiresAtZ(_:tolerance:)`, a CAM sectioning API: in every case measured, an ordinary
+  transverse cut does not produce such an edge, but a cut plane coincident with an edge a caller
+  already marked `.internal`/`.external` via `Shape.setOrientation(_:)` does move, 2 wires to 1 on
+  a measured fixture. The `freeBounds*` family calls a different entry point, `ShapeAnalysis_FreeBounds`'s
   `(shape, tolerance)` constructor, and that constructor's own chainage step does reach the same
   skip, so the reason `freeBounds*` does **not** move is not that its call graph avoids the change.
   It is upstream: the edges that family feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,11 +88,21 @@ Gordon tests assert only status ordinals. Those two were probed directly. Tracke
   moves from `3.713203436` to `3.535533906`, which is exactly `5/√2`. A non-rational control was
   already exact on both kernels, so only rational networks ever moved. Affects
   `Surface.gordon(profiles:guides:tolerance:)` and `Surface.gordonReport(...)`. Evidence added to #645.
-- **`Shape.freeBounds*` and INTERNAL/EXTERNAL edges** ([#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655)).
-  `ShapeAnalysis_FreeBounds::ConnectEdgesToWires` now skips them: a sequence of one INTERNAL edge
-  plus a square returns 1 wire where it returned 2, and a sequence of nothing but INTERNAL/EXTERNAL
-  edges returns 0 wires where it returned 1. The constructor path the `freeBounds*` family actually
-  calls does **not** move; the change is confined to the direct entry point.
+- **`Shape.sectionWiresAtZ(_:tolerance:)`, not `freeBounds*`, sees the INTERNAL/EXTERNAL skip**
+  ([#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655)).
+  `ShapeAnalysis_FreeBounds::ConnectEdgesToWires` now skips edges oriented `.internal`/`.external`:
+  a sequence of one INTERNAL edge plus a square returns 1 wire where it returned 2, and a sequence
+  of nothing but INTERNAL/EXTERNAL edges returns 0 wires where it returned 1. That C++ function
+  appears exactly once in this bridge, inside `OCCTShapeSectionWiresAtZ`, which backs
+  `Shape.sectionWiresAtZ(_:tolerance:)`, a CAM sectioning API: an ordinary transverse cut never
+  produces such an edge, but a cut plane coincident with an edge a caller already marked
+  `.internal`/`.external` via `Shape.setOrientation(_:)` does move, 2 wires to 1 on a measured
+  fixture. The `freeBounds*` family calls a different entry point, `ShapeAnalysis_FreeBounds`'s
+  `(shape, tolerance)` constructor, and that constructor's own chainage step does reach the same
+  skip, so the reason `freeBounds*` does **not** move is not that its call graph avoids the change.
+  It is upstream: the edges that family feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in
+  every case measured that sewing stage never produced an `.internal`/`.external` free edge for the
+  skip to act on.
 - **`BRep_Tool::CurveOnPlane` fails differently.** An out-of-domain, inverted or zero-length edge
   range now yields a null pcurve where 8.0.0p1 threw a catchable
   `Geom_TrimmedCurve::parameters out of range`. All four probed cases changed.

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -524,6 +524,7 @@ Count the number of closed free-boundary wires.
 public func freeBoundsClosedCount(tolerance: Double = 1e-6) -> Int
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408); see [`freeBounds(sewingTolerance:)`](Shape-Measurement.md#freeboundssewingtolerance) for why. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `tolerance` — sewing tolerance for boundary detection (default `1e-6`).
 - **Returns:** Number of closed free-boundary wires.
 - **OCCT:** `ShapeAnalysis_FreeBounds` via `OCCTShapeFreeBoundsClosedCount`.
@@ -538,6 +539,7 @@ Get the compound of closed free-boundary wires.
 public func freeBoundsClosedWires(tolerance: Double = 1e-6) -> Shape?
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408); see [`freeBounds(sewingTolerance:)`](Shape-Measurement.md#freeboundssewingtolerance) for why. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `tolerance` — sewing tolerance for boundary detection (default `1e-6`).
 - **Returns:** Compound shape of closed wires, or `nil` if none.
 - **OCCT:** `ShapeAnalysis_FreeBounds` via `OCCTShapeFreeBoundsClosed`.
@@ -552,6 +554,7 @@ Get the compound of open free-boundary wires.
 public func freeBoundsOpenWires(tolerance: Double = 1e-6) -> Shape?
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408); see [`freeBounds(sewingTolerance:)`](Shape-Measurement.md#freeboundssewingtolerance) for why. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `tolerance` — sewing tolerance for boundary detection (default `1e-6`).
 - **Returns:** Compound shape of open wires, or `nil` if none.
 - **OCCT:** `ShapeAnalysis_FreeBounds` via `OCCTShapeFreeBoundsOpen`.

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2402,6 +2402,13 @@ The shape needs to be a compound or shell of faces: the search runs over its dir
 lone face reports no free bounds. In practice the sewing pass closes essentially every contour it
 finds, so `openCount` is usually 0.
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at
+  any tolerance; see [`Shape.freeBounds(sewingTolerance:)`](Shape-Measurement.md#freeboundssewingtolerance)
+  for why, on both branches. This type's own `init?(shape:tolerance:)` is where the `tolerance <= 0`
+  branch (no sewing stage at all) is selected, so its guarantee rests directly on the two-branch
+  measurement that note describes, not only on the sewing-branch reasoning. See
+  [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
+
 ```swift
 // A box shell with one face removed: its free boundary is the square hole.
 let faces = Shape.box(width: 10, height: 10, depth: 10)!.subShapes(ofType: .face)

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2438,6 +2438,10 @@ public init?(shape: Shape, tolerance: Double = 1e-7)
   selects a different OCCT algorithm, taking free edges from the shape's already-shared topology
   instead of from a sewing pass.
 - **Returns:** The analyser, or `nil` on failure.
+- **Note:** This is the call that selects the branch. Both are unaffected by OCCT 8.0.1's
+  `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), but for different reasons and measured
+  separately; see [`freeBounds(sewingTolerance:)`](Shape-Measurement.md#freeboundssewingtolerance).
+  See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsCreate`).
 
 ---

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -660,17 +660,18 @@ public func sliceAtZ(_ z: Double) -> Shape?
 
 ### `sectionWiresAtZ(_:tolerance:)`
 
-Returns closed wires from a section at a Z level.
+Returns wires from a section at a Z level, chained where the section closes.
 
 ```swift
 public func sectionWiresAtZ(_ z: Double, tolerance: Double = 1e-6) -> [Wire]
 ```
 
-Unlike `sliceAtZ`, this chains the section edges into closed wires suitable for offset or CAM operations. Use a larger `tolerance` (e.g. `1e-4`) for imprecise geometry.
+Unlike `sliceAtZ`, this chains the section edges into wires (closed where the section forms a loop, open otherwise) suitable for offset or CAM operations. Use a larger `tolerance` (e.g. `1e-4`) for imprecise geometry.
 
+- **Note:** Edges whose orientation is `.internal` or `.external` are silently excluded from the result wires (OCCT 8.0.1, upstream OCCT#1408). This only matters if the input `Shape` was assembled with such edges via `Shape.setOrientation(_:)` and one happens to lie exactly in the cutting plane; an ordinary transverse section never produces `.internal`/`.external` edges on its own. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `z` — Z level to section at; `tolerance` — tolerance for connecting edges into wires.
-- **Returns:** Array of closed `Wire` objects; empty if no contours exist at that level.
-- **OCCT:** `BRepAlgoAPI_Section` + `BRepBuilderAPI_MakeWire` (via `OCCTShapeSectionWiresAtZ`).
+- **Returns:** Array of `Wire` objects, closed where the section forms a loop and open otherwise; empty if no contours exist at that level.
+- **OCCT:** `BRepAlgoAPI_Section` + `ShapeAnalysis_FreeBounds::ConnectEdgesToWires` (via `OCCTShapeSectionWiresAtZ`).
 - **Example:**
   ```swift
   let model = try Shape.load(from: stepFile)

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -668,7 +668,7 @@ public func sectionWiresAtZ(_ z: Double, tolerance: Double = 1e-6) -> [Wire]
 
 Unlike `sliceAtZ`, this chains the section edges into wires (closed where the section forms a loop, open otherwise) suitable for offset or CAM operations. Use a larger `tolerance` (e.g. `1e-4`) for imprecise geometry.
 
-- **Note:** Edges whose orientation is `.internal` or `.external` are silently excluded from the result wires (OCCT 8.0.1, upstream OCCT#1408). This only matters if the input `Shape` was assembled with such edges via `Shape.setOrientation(_:)` and one happens to lie exactly in the cutting plane; an ordinary transverse section never produces `.internal`/`.external` edges on its own. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
+- **Note:** Edges whose orientation is `.internal` or `.external` are silently excluded from the result wires (OCCT 8.0.1, upstream OCCT#1408). This only matters if the input `Shape` was assembled with such edges via `Shape.setOrientation(_:)` and one happens to lie exactly in the cutting plane; in every case measured, an ordinary transverse section does not produce `.internal`/`.external` edges on its own. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `z` — Z level to section at; `tolerance` — tolerance for connecting edges into wires.
 - **Returns:** Array of `Wire` objects, closed where the section forms a loop and open otherwise; empty if no contours exist at that level.
 - **OCCT:** `BRepAlgoAPI_Section` + `ShapeAnalysis_FreeBounds::ConnectEdgesToWires` (via `OCCTShapeSectionWiresAtZ`).

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -380,6 +380,7 @@ public func freeBounds(sewingTolerance: Double = 1e-6) -> FreeBoundsResult?
 
 Free boundaries indicate gaps in a shell. A watertight shell has no free boundaries.
 
+- **Note:** Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method (and the rest of the `freeBounds*` family: `freeBoundsAnalysis(tolerance:)`, `freeBoundsClosedCount(tolerance:)`, `freeBoundsClosedWires(tolerance:)`, `freeBoundsOpenWires(tolerance:)`) is unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408). The constructor this family uses does reach that same skip, in its own chainage step, so the reason is not that the call graph avoids it. What keeps the result unchanged is upstream: the edges this family feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing stage never produced an `.internal`/`.external` free edge for the skip to act on. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `sewingTolerance` — Tolerance for grouping free edges into wires.
 - **Returns:** Free bounds result, or `nil` if no free boundaries are found.
 - **OCCT:** `ShapeAnalysis_FreeBounds`.
@@ -2405,6 +2406,7 @@ Each of the five `…FreeBound…` methods here runs its own analysis. To read s
 shape, build a `FreeBoundsProperties` instead: it analyses once and answers every query from that
 one result. Both have run on the same implementation since #504.
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408); see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `tolerance`, the sewing tolerance used to chain free edges into contours. 0 or below
   selects a different OCCT algorithm, taking free edges from the shape's already-shared topology
   instead of from a sewing pass.

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -380,7 +380,11 @@ public func freeBounds(sewingTolerance: Double = 1e-6) -> FreeBoundsResult?
 
 Free boundaries indicate gaps in a shell. A watertight shell has no free boundaries.
 
-- **Note:** Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method (and the rest of the `freeBounds*` family: `freeBoundsAnalysis(tolerance:)`, `freeBoundsClosedCount(tolerance:)`, `freeBoundsClosedWires(tolerance:)`, `freeBoundsOpenWires(tolerance:)`) is unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408). The constructor this family uses does reach that same skip, in its own chainage step, so the reason is not that the call graph avoids it. What keeps the result unchanged is upstream: the edges this family feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing stage never produced an `.internal`/`.external` free edge for the skip to act on. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
+- **Note:** Unlike `Shape.sectionWiresAtZ(_:tolerance:)`, this method is unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408). This method's constructor does reach that same skip, in its own chainage step, so the reason is not that the call graph avoids it. What keeps the result unchanged is upstream: the edges this method feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in every case measured that sewing stage never produced an `.internal`/`.external` free edge for the skip to act on.
+
+  `freeBoundsClosedCount(tolerance:)`, `freeBoundsClosedWires(tolerance:)` and `freeBoundsOpenWires(tolerance:)` share this reasoning unconditionally: each always builds `ShapeAnalysis_FreeBounds` with the `(shape, tolerance, ...)` sewing constructor no matter what value is passed, so there is no other branch to consider for them.
+
+  `freeBoundsAnalysis(tolerance:)`, [`FreeBoundsProperties`](Document-Mesh-Fixing.md#freeboundsproperties) and the four accessors built on it (`closedFreeBoundInfo(tolerance:index:)`, `openFreeBoundInfo(tolerance:index:)`, `closedFreeBoundWire(tolerance:index:)`, `openFreeBoundWire(tolerance:index:)`) are different: `ShapeAnalysis_FreeBoundsProperties::DispatchBounds()` picks the sewing constructor only when its tolerance is greater than 0; at 0 or below it picks `ShapeAnalysis_FreeBounds(shape, splitClosed, splitOpen)` instead, a constructor with no sewing stage at all, which takes its edges from `ShapeAnalysis_Shell::CheckOrientedShells`/`FreeEdges()` and reaches the same `ConnectEdgesToWires` skip by a different route. This is measured directly, not assumed from the sewing case above: the `.internal` exclusion holds on this branch too, and a FORWARD control on the same fixture confirms the two branches are not just trivially agreeing on everything. The sewing branch chains a FORWARD loop entirely inside one face into one closed wire together with that face's outer boundary (3 closed, 0 open); the shared-topology branch returns the same loop's four edges unchained (2 closed, 4 open). What is not measured, and not claimed, is *why* the INTERNAL loop is absent on the shared-topology branch: that constructor defaults `checkinternaledges` to `false`, so the internal edges may never reach `FreeEdges()` as candidates at all, rather than being collected and then dropped by the same skip the sewing branch's chainage step hits. Both would produce the same observable result, which is the only thing measured here. See `Issue655FreeBoundsInternalOrientationTests` (`OCCTShapeHealingTests`) for both fixtures. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `sewingTolerance` — Tolerance for grouping free edges into wires.
 - **Returns:** Free bounds result, or `nil` if no free boundaries are found.
 - **OCCT:** `ShapeAnalysis_FreeBounds`.
@@ -2406,7 +2410,7 @@ Each of the five `…FreeBound…` methods here runs its own analysis. To read s
 shape, build a `FreeBoundsProperties` instead: it analyses once and answers every query from that
 one result. Both have run on the same implementation since #504.
 
-- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408); see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at any tolerance, including the `tolerance <= 0` input described below that routes to a different constructor with no sewing stage at all; see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why, on both branches. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:** `tolerance`, the sewing tolerance used to chain free edges into contours. 0 or below
   selects a different OCCT algorithm, taking free edges from the shape's already-shared topology
   instead of from a sewing pass.
@@ -2435,6 +2439,7 @@ Get properties of a closed free bound.
 public func closedFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo?
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at any tolerance; see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why, on both branches. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:**
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the closed free bound.
@@ -2451,6 +2456,7 @@ Get properties of an open free bound.
 public func openFreeBoundInfo(tolerance: Double, index: Int) -> FreeBoundInfo?
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at any tolerance; see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why, on both branches. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:**
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the open free bound.
@@ -2467,6 +2473,7 @@ Get the wire shape of a closed free bound.
 public func closedFreeBoundWire(tolerance: Double, index: Int) -> Shape?
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at any tolerance; see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why, on both branches. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:**
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the closed free bound.
@@ -2483,6 +2490,7 @@ Get the wire shape of an open free bound.
 public func openFreeBoundWire(tolerance: Double, index: Int) -> Shape?
 ```
 
+- **Note:** Unaffected by OCCT 8.0.1's `ConnectEdgesToWires` INTERNAL/EXTERNAL skip (OCCT#1408), at any tolerance; see [`freeBounds(sewingTolerance:)`](#freeboundssewingtolerance) for why, on both branches. See [#655](https://github.com/SecondMouseAU/OCCTSwift/issues/655).
 - **Parameters:**
   - `tolerance` — Same tolerance used for `freeBoundsAnalysis(tolerance:)`.
   - `index` — 0-based index of the open free bound.


### PR DESCRIPTION
## What & why

Issue #655 is titled as a `freeBounds` problem. Tracing the call graph shows it is not:
`ShapeAnalysis_FreeBounds::ConnectEdgesToWires` (the entry point OCCT 8.0.1's OCCT#1408 changes,
adding a skip for INTERNAL/EXTERNAL-oriented edges) appears exactly once in this bridge, inside
`OCCTShapeSectionWiresAtZ` -- which backs `Shape.sectionWiresAtZ(_:tolerance:)`, a CAM sectioning
API. The `freeBounds*` family (`freeBounds`, `freeBoundsAnalysis`, `freeBoundsClosedCount`,
`freeBoundsClosedWires`, `freeBoundsOpenWires`) goes through `ShapeAnalysis_FreeBounds`'s
`(shape, tolerance)` constructor instead.

That constructor's own chainage step calls the same `ConnectEdgesToWires`, so it is not a separate
entry point that avoids the change (an earlier version of this PR said exactly that, and review
caught it: see "Corrected per review" below). What actually keeps the family unaffected is
upstream of the chainage: the edges it feeds in come from `BRepBuilderAPI_Sewing::FreeEdge`, and in
every case measured that sewing stage never produced an `.internal`/`.external` free edge for the
skip to act on.

The remaining question was whether a section can ever *produce* an INTERNAL/EXTERNAL edge for the
new skip to act on. Measured directly against both kernels (v1.15.18, OCCT 8.0.0p1, vs. this
branch's pinned v2.0.0-kernel.1, OCCT V8_0_1): **yes**, when the cutting plane is exactly coincident
with an edge that already carries that orientation -- the "same domain" case
`BRepAlgoAPI_Section` takes for geometry already lying in the section plane, rather than computing
a fresh intersection curve. `Shape.setOrientation(_:)` is public API, so this is buildable from
Swift: a compound of a closed square and one disjoint floating edge, both coincident with the cut
plane, with the floating edge marked `.internal`. Sectioning it gives 2 wires on the old kernel
(the square, plus the floating edge as its own open 1-edge wire) and 1 wire (just the square) on
the new one.

Also probed the issue's point 3 (OCCT#1408's removal of `isUsedManifoldMode`, the separate closure
detection non-manifold wires used to get -- "non-manifold" here means "built from
INTERNAL/EXTERNAL edges", per `ShapeExtend_WireData`'s own doc comment). It is inert on both of
this bridge's entry points:

- Through `ConnectEdgesToWires`: the new outer skip removes every INTERNAL/EXTERNAL edge before
  any candidate wire is built, so the old fallback's trigger condition (first candidate wire has
  zero ordinary edges, at least one non-manifold one) can never be satisfied again post-8.0.1.
- Through the constructor path: a face's embedded, fully-INTERNAL closed wire (4 edges) never
  appears in either `GetClosedWires()` or `GetOpenWires()` on **either** kernel -- verified
  directly, not inferred, and now also covered by a Swift test (see "Changes" below). The reason
  is the same one above, not a separate call-graph boundary inside `ShapeAnalysis_FreeBounds`: the
  sewing stage that constructor runs first (`BRepBuilderAPI_Sewing::FreeEdge`) never hands this
  loop's edges over as free-bound candidates at all, on either kernel version.

### Changes

- `Sources/OCCTSwift/Shape.swift`: documents `sectionWiresAtZ`'s INTERNAL/EXTERNAL contract, and
  corrects its "closed wires" wording (it returns open wires too; `forwardEdgeNotExcluded` below
  depends on that).
- `Sources/OCCTSwift/Shape+ShapeHealing.swift`: documents that `freeBounds` (and the rest of the
  family) is unaffected, with the corrected mechanism, and cross-references the note from
  `freeBoundsAnalysis`, `freeBoundsClosedCount`, `freeBoundsClosedWires` and `freeBoundsOpenWires`
  too (each is a separate public symbol context7 harvests independently).
- `Tests/OCCTModelingTests/Issue655SectionWiresOrientationTests.swift`: 3 tests for the
  `sectionWiresAtZ` side that IS affected (built via the public `Shape.setOrientation(_:)` API, per
  the issue's own note that fixtures are buildable that way).
- `Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift`: 2 new tests
  (`Issue655FreeBoundsInternalOrientationTests`) for the `freeBounds*` side that is NOT affected --
  the guarantee the doc comment above now makes, previously asserted but untested. Fixture: a face
  with an embedded, fully-`.internal` closed 4-edge loop (built via the public
  `Shape.builderMakeWire()`/`.builderAdd(_:)`/`.setOrientation(_:)` primitives, the same ones OCCT
  itself uses to model an embedded non-hole feature edge), plus a disjoint plain face, both in a
  compound.
- `docs/CHANGELOG.md`: retitles the Unreleased #655 bullet to name `sectionWiresAtZ` (it was headed
  `Shape.freeBounds*` and never mentioned the API that actually moves), and fixes its closing
  sentence, which carried the same mechanism error as above.
- `docs/reference/Shape-Features.md`: adds the INTERNAL/EXTERNAL note to the `sectionWiresAtZ`
  page to match the source doc comment, fixes its "closed wires" wording (twice), and fixes its
  `**OCCT:**` line, which named `BRepBuilderAPI_MakeWire` -- there is no such call in
  `OCCTShapeSectionWiresAtZ`; it is `ShapeAnalysis_FreeBounds::ConnectEdgesToWires`.

## Corrected per review

An earlier version of this PR shipped a factually wrong mechanism claim in both new doc notes and
the test file: that the `freeBounds*` family is unaffected because it "goes through
`ShapeAnalysis_FreeBounds`'s constructor rather than its `ConnectEdgesToWires` entry point." Review
checked `ShapeAnalysis_FreeBounds.cxx` at `V8.0.1` and found the constructor's own chainage step
ends by calling `ConnectEdgesToWires` directly, so both entry points reach the changed code. That
is now fixed everywhere the claim appeared (both doc comments, the test file, this description),
and the guarantee is stated as what it actually rests on: the sewing stage this family runs first
never handed it an `.internal`/`.external` free edge, in every case measured, not call-graph
separation. The "never...on either kernel version" phrasing is softened to that same "as measured"
qualifier throughout.

The new `freeBoundsUnaffectedByInternalOrientation`/`forwardLoopIsCounted` tests exist specifically
because of this: they are the assertion that would catch the mechanism assumption breaking, which
nothing in the repo covered before this PR.

## Order-dependence: reviewer is right, I was wrong

I described the section-produces-such-an-edge finding as "order-dependent" (the INTERNAL edge has
to be visited before whatever it would otherwise merge with), matching the issue's own case B, and
repeated that in my own review comment on this PR. The reviewer pushed back: the shipped fixture is
disjoint (the floating edge shares no vertex with the square), so nothing here needs a merge-order
or reversal decision to come out right, and the assertions should be order-independent.

Measured it rather than arguing it: reordered `fixture(orientation:)`'s compound from
`[floatingShape, square]` to `[square, floatingShape]` and reran all three tests. **Unchanged,
all three still pass.** The reviewer is right and my "order-dependent" framing was wrong for this
fixture -- fixed in the `fixture(orientation:)` doc comment, which now records the measurement
instead of implying compound order is load-bearing. The general mechanism from the issue's case B
(order genuinely matters when something needs a merge/reversal) is real, but this fixture doesn't
build that case; it just doesn't need to, since the exclusion this PR tests fires on orientation
alone, before any merge decision is made.

## Measured (injection matrix, per `okf/policies/prove-the-test-fails.md`)

Each test's fixture was broken at the thing it names (not the expected count -- the policy calls a
flipped count a weak injection), run, confirmed to fail, then restored and confirmed to pass:

| Test | Injection | Before restore | After restore |
|---|---|---|---|
| `internalEdgeExcluded` | fixture orientation `.internal` → `.forward` | FAIL (3 issues: wire count, edge count, closed flag) | PASS |
| `forwardEdgeNotExcluded` | fixture orientation `.forward` → `.internal` | FAIL (1 issue: wire count) | PASS |
| `externalEdgeExcluded` | fixture orientation `.external` → `.forward` | FAIL (1 issue: wire count) | PASS |
| `freeBoundsUnaffectedByInternalOrientation` | fixture loop orientation `.internal` → `.forward` | FAIL (3 issues: closed count, edge count, `freeBounds()` agreement) | PASS |
| `forwardLoopIsCounted` | fixture loop orientation `.forward` → `.internal` | FAIL (1 issue: closed count) | PASS |

## What the issue (and my own prior comment on it) got wrong

- The issue's own title and "What to do" list frame this entirely as a `freeBounds` problem. It
  is not reachable there at all -- `sectionWiresAtZ` is the only affected Swift entry point. (My
  prior comment on the issue already corrected this; this PR is the follow-through and adds the
  measurement the comment asked for.)
- My prior comment asked "can a section ever produce such an edge" without assuming an answer.
  Measuring it: yes, but only in the coincident-plane case. I initially described that as
  order-dependent, matching the issue's own case B; measured directly (see above), the shipped
  fixture is disjoint and order-independent, so that framing was wrong for what actually shipped.
- The `isUsedManifoldMode` removal (point 3) turned out to be fully subsumed by the
  `ConnectEdgesToWires` skip on the one path that reaches it, and was already inert pre-8.0.1 on
  the other -- not an independently-observable change worth filing.

## Round 2 review: five findings addressed

1. **Blocker, fixed.** `Issue655SectionWiresOrientationTests.swift`'s doc comment closed with the
   pre-correction claim that free-bound candidacy excludes INTERNAL/EXTERNAL sub-wires "upstream of
   `connectWiresToWiresImpl`," a boundary inside `ShapeAnalysis_FreeBounds` itself, the same framing
   the earlier correction (above) fixed everywhere else, missed here. The `isUsedManifoldMode`
   bullet in this description carried the identical sentence. Both now name the sewing stage
   (`BRepBuilderAPI_Sewing::FreeEdge`) instead, matching the corrected paragraph above each.
2. **Fixed.** Added the `freeBounds*` Note to all five public symbols' reference pages:
   `freeBounds(sewingTolerance:)` and `freeBoundsAnalysis(tolerance:)` in
   `docs/reference/Shape-Measurement.md`, and `freeBoundsClosedCount`/`freeBoundsClosedWires`/
   `freeBoundsOpenWires` in `docs/reference/Document-Analysis-Builders.md`. The review's line
   numbers pointed at `Shape-Measurement.md` for all five, but the three accessor methods are
   documented on a different reference page; both pages needed the Note either way, so this fixes
   the finding regardless of which page was named.
3. **Fixed, and confirmed independently reproducible.** The reviewer verified this by hand:
   commenting out `face1.builderAdd(loopWireShape)` (the loop never attached to `face1`) left
   `freeBoundsUnaffectedByInternalOrientation` passing, caught only by its sibling
   `forwardLoopIsCounted`. Guarded all five `builderAdd` call sites in the fixture
   (`guard ... else { return nil }`) and added a fixture sanity assertion
   (`subShapeCount(ofType: .edge) == 12`) to the primary test. Re-ran the same injection against the
   fix: the primary test now fails on its own (edge count 8 vs 12), independent of its sibling. See
   the injection matrix below.
4. **Fixed.** Hedged `sectionWiresAtZ`'s unqualified "an ordinary transverse section ... never
   produces" to "in every case measured, ... does not produce," matching the `freeBounds` note's
   qualifier, in the source doc comment, `docs/reference/Shape-Features.md`, and the CHANGELOG
   bullet, which carried the same unhedged claim (not cited by the review, fixed for consistency so
   the two notes do not disagree about what was measured versus inferred).
5. **Fixed.** Added the pcurve-less-loop risk note to `fixture(loopOrientation:)`'s doc comment: the
   loop's edges carry no pcurve on `face1`'s plane, which works today but would move both healing
   tests together if a future kernel gets stricter about it.

### Injection matrix addition (finding 3)

| Test | Injection | Before restore | After restore |
|---|---|---|---|
| `freeBoundsUnaffectedByInternalOrientation` | loop never attached (`face1.builderAdd` call removed) | FAIL (1 issue: fixture sanity check, edge count 8 vs 12) | PASS |

Before this fix, the same injection left `freeBoundsUnaffectedByInternalOrientation` green; it only
failed via `forwardLoopIsCounted`. All five original rows in the table above were re-run against the
round-2 changes too and are unchanged.

## Verification

- Clean `swift build`, 0 errors, no `OCCTSWIFT_LOCAL` (pinned `v2.0.0-kernel.1` resolves and
  builds directly).
- Full `swift test`: 5319 tests passing (unchanged by the round-2 fixes; finding 3's assertion is
  new, but no new `@Test` was added).
- All six gate scripts (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
  `count-operations`, `derive-swift-file-split`, `derive-shape-domain-split`) exit 0, all
  `--self-test`s pass, from the repo root.
- Zero em-dashes in the round-2 diff.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.

## Notes for the reviewer

`sectionWiresAtZ`'s doc comment used to say it returns "closed wires," but the implementation
returns whatever `ConnectEdgesToWires` produces, open or closed -- the fixture in this PR's
contrast test (`forwardEdgeNotExcluded`) relies on that being true (it expects an open 1-edge wire
back). Originally flagged here as out of scope and deferred; per review finding 5, fixed in this PR
instead (source doc comment and `docs/reference/Shape-Features.md`, both instances), since this PR
is already editing that exact comment and the wording was actively wrong.

Closes #655

