### PR TITLE
chore(#664): build the Cluster A sub-shape enumeration census

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -222,6 +222,20 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+
+        // #664 Cluster A census: measures every public sub-shape enumeration entry point against
+        // a duplicated-orientation fixture. Source lives in the repro directory itself (not under
+        // Sources/), matching the "runnable program committed under Scripts/repro/<cluster>"
+        // convention docs/v2.0.0-plan.md's census rule asks for. `swift run ClusterACensus`.
+        .executableTarget(
+            name: "ClusterACensus",
+            dependencies: ["OCCTSwift"],
+            path: "Scripts/repro/cluster-a-subshape-enumeration",
+            exclude: ["README.md", "classify_topexp_sites.py"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
     ],
     cxxLanguageStandard: .cxx17
 )

--- a/Scripts/repro/cluster-a-subshape-enumeration/README.md
+++ b/Scripts/repro/cluster-a-subshape-enumeration/README.md
@@ -232,22 +232,36 @@ fixtures were added for all four, plus J and K (which only guard `self_test()`'s
 (added proactively, by the same failure mode as L, though nothing in the current tree exercises
 it yet).
 
-**Five guards (B, C, E, F, H) remain without self-test coverage and were left that way
-deliberately, not overlooked.** Each is provably unreachable given how the classifier is
-constructed, not merely untriggered by today's source tree:
-- **B** (`control_words`) and **C** (the comment-line skip in `split_functions`) can never fire on
-  compiling C++: `FUNC_START_RE`'s `^` anchor means its overall match always starts exactly at a
-  line's first character, so the text checked by C (`text[line_start:m.start()]`) is always the
-  empty string, and B's `name` is only ever populated from a token preceded by a return-type span,
-  which none of `if`/`for`/`while`/`switch`/`catch`/`return`/`sizeof` can be (they are C++ reserved
-  words; none can be a real identifier).
+**Guard B was wrongly filed here as unreachable, and now has a case.** The original argument was
+that B's `name` can only come from a token preceded by a return-type span, which no C++ reserved
+word can be. That is wrong: `FUNC_START_RE`'s return-type span is `[A-Za-z_][\w:<>\*&\s,]*?`, which
+cannot tell a token is not a type, so a single-line `else if (cond) {` offers `else` as the return
+type and `if` as the name. Measured, with B removed:
+
+```
+WITH guard   : ['OCCTRealFunctionWithElseIf']
+WITHOUT guard: ['OCCTRealFunctionWithElseIf', 'if']
+```
+
+The phantom `if` carries whatever loop follows, so it would appear as an extra OCCURRENCE row. B
+belongs with **M**: reachable on ordinary C++, merely untriggered by today's tree, which happens to
+contain no single-line `else if (`. `guard_b_else_if_is_not_a_function` covers it, and catching it
+needed a harness change too, since a spurious *extra* function is appended after the real one, so
+classifying `funcs[0]` alone still gave the right answer.
+
+**Four guards (C, E, F, H) remain without self-test coverage, deliberately.** These are provably
+unreachable given how the classifier is constructed, not merely untriggered:
+- **C** (the comment-line skip in `split_functions`) can never fire on compiling C++:
+  `FUNC_START_RE`'s `^` anchor means its overall match always starts exactly at a line's first
+  character, so the text C checks (`text[line_start:m.start()]`) is always the empty string.
 - **E**, **F**, **H** are bounds checks inside `_loop_body_span` that only fail on syntactically
   unbalanced input (an unterminated `for (...`, a truncated file, a statement with no closing `;`)
   which cannot arise from a file that compiles.
 
 Writing a self-test fixture for code that cannot occur in valid input would test nothing; it would
-just be a seventh decorative case pretending to prove something. They are listed here, with the
-reasoning, instead.
+just be a decorative case pretending to prove something. They are listed here, with the reasoning,
+instead. B's misfiling is the argument for stating that reasoning explicitly rather than asserting
+the bucket: the claim was checkable, and it did not hold.
 
 ## Findings
 

--- a/Scripts/repro/cluster-a-subshape-enumeration/README.md
+++ b/Scripts/repro/cluster-a-subshape-enumeration/README.md
@@ -1,0 +1,302 @@
+# Cluster A census (#664): sub-shape enumeration, dedup vs occurrence
+
+The census artifact `docs/v2.0.0-plan.md` names as a hard prerequisite before any of #638, #642 or
+#651 starts. It answers, for every public entry point that walks sub-shapes of a `Shape`, whether
+it reads the deduplicated map (`TopExp::MapShapes`, `IsSame`-keyed) or the raw occurrence explorer
+(a bare `TopExp_Explorer` walk), and what each returns on a shape with duplicated orientations.
+
+**This directory is the census only. It does not fix #638, #642 or #651.** Per #664: "fix the
+root, then re-measure: some members may resolve without their own change." The last section below
+re-scopes the three members against what was actually measured, and corrects two things #642 and
+#651 either understated or a naive reading of #614's own fixture would have missed.
+
+## Method
+
+Two independent halves, per #664's own instruction that a grep is not sufficient evidence on its
+own here:
+
+1. **Dynamic (primary).** `main.swift`, built as the `ClusterACensus` executable target
+   (`swift run ClusterACensus`), builds real fixtures with the public `Shape`/`Face`/`Wire` API and
+   calls every identified public entry point on each one, printing the measured table below. This
+   is the evidence: an entry point is DEDUP or OCCURRENCE because it was *measured* to return the
+   deduplicated or the per-occurrence count/array, not because a doc comment says so.
+2. **Static (secondary cross-check).** `classify_topexp_sites.py` scans every `.mm` file under
+   `Sources/OCCTBridge/src/` for `TopExp_Explorer`/`TopExp::MapShapes` call sites and classifies
+   each enclosing C function as DEDUP / OCCURRENCE / OTHER from the source text alone. #664 warned
+   this kind of tool "must not be the primary evidence: a shared helper, a cast, or an entry point
+   that walks via another entry point will all defeat it", and it was right twice over during this
+   census's own construction (see "Where the two methods disagreed" below, which is the most
+   useful part of this artifact per the task that commissioned it).
+
+Both are runnable and both are committed, per the census-once rule: `swift run ClusterACensus` and
+`python3 Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py` regenerate the
+tables from the pinned kernel and the current tree, respectively.
+
+## Fixtures
+
+Built from the real Shape API, not hand-assembled topology, so every number below is what an
+ordinary caller would see:
+
+- **`plainBox`**, `Shape.box(width: 10, height: 10, depth: 10)`, one solid, origin-centred
+  `-5...5`. No sub-shape is reachable from more than one *parent shape*, but every edge is still
+  reachable from two adjacent faces and every vertex from three edges within the one solid. This
+  is #502's own box measurement (24 edge occurrences over 12 distinct, 48 vertex occurrences over
+  8 distinct) and it needs no compound at all.
+- **`splitBoxCompound(order:)`** ("vertical-cut fixture", `compoundA`/`compoundB` below), the
+  *exact* construction `Tests/OCCTTopologyTests/Issue614FaceOrientationTests.swift` already uses
+  and has coverage for: a 20×10×10 block cut by an upright plane, recompounded in two member
+  orders. Measured here at 11 distinct faces / 12 occurrences, matching that test file exactly.
+- **`horizontalSplitBoxCompound(order:)`** ("horizontal-cut fixture", `hCompoundA`/`hCompoundB`
+  below), a second two-solid split, cut through `z=4` on an origin-centred 10mm box (`split(atPlane:
+  normal:)`), also recompounded in two member orders.
+
+**Both split fixtures were needed, and that is itself a finding.** The vertical-cut fixture's
+shared wall has a horizontal-*axis* normal (it's a side wall), so it never touches
+`isHorizontal()`/`isUpward()` at all. Measuring only that fixture would have concluded AAG is
+order-*independent*, which is wrong. #642's own claim (`detectPocketsAAG()` 2 vs 1, AAG
+upward+horizontal node set `[2, 8]` vs `[2]`) only reproduces on the horizontal-cut fixture, where
+the shared wall itself is one of the faces `isUpward`/`isHorizontal` classifies as such. A census
+that stopped at "reuse #614's own committed fixture" would have silently failed to reproduce
+#642's own numbers.
+
+## Build and run
+
+```bash
+swift run ClusterACensus
+python3 Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
+python3 Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py --self-test
+```
+
+`ClusterACensus` is a package executable target (see `Package.swift`) whose source lives in this
+directory rather than under `Sources/`, matching the "runnable program committed under
+`Scripts/repro/<cluster>`" shape the other census artifacts in this tree use.
+
+## Full dynamic result table
+
+45 rows, three fixtures (`plain box`, `order A`, `order B`, vertical-cut unless the entry point
+name says `[horizontal-cut fixture]`).
+
+| family | entry point | plain box | order A | order B | note |
+|---|---|---|---|---|---|
+| vertex | vertexCount (dedup canonical) | 8 | 12 | 12 | |
+| vertex | vertices().count (dedup) | 8 | 12 | 12 | |
+| vertex | uniqueVertexCount (alias of vertexCount) | 8 | 12 | 12 | |
+| vertex | subShapeCount(ofType: .vertex) (dedup canonical) | 8 | 12 | 12 | |
+| vertex | **nbVertices** (#651: docs say dedup) | 48 | 96 | 96 | occurrence; `docs/reference/Document-Completions.md:1438` states `box.nbVertices == 8` |
+| vertex | contents.vertices (ShapeAnalysis_ShapeContents, occurrence) | 48 | 96 | 96 | |
+| vertex | contentsExtended().nbVertices (occurrence) | 48 | 96 | 96 | |
+| edge | edgeCount (dedup canonical) | 12 | 20 | 20 | |
+| edge | edges().count (dedup) | 12 | 20 | 20 | |
+| edge | uniqueEdgeCount (alias of edgeCount) | 12 | 20 | 20 | |
+| edge | subShapeCount(ofType: .edge) (dedup canonical) | 12 | 20 | 20 | |
+| edge | **nbEdges** (#651: docs say dedup) | 24 | 48 | 48 | occurrence; `docs/reference/Document-Completions.md:1406` states `box.nbEdges == 12` |
+| edge | contents.edges (ShapeAnalysis_ShapeContents, occurrence) | 24 | 48 | 48 | |
+| edge | contentsExtended().nbEdges (occurrence) | 24 | 48 | 48 | |
+| edge | Shape(wire).edgeCount (dedup; a wire's own edges) | 4 | n/a | n/a | a wire's own edges aren't shared cross-parent in these fixtures |
+| face | faceCount (dedup canonical, #541) | 6 | 11 | 11 | |
+| face | faces().count (dedup) | 6 | 11 | 11 | |
+| face | orientedFaces().count (occurrence, deliberate #614) | 6 | 12 | 12 | documented, paired counterpart of faces(), not a defect |
+| face | uniqueFaceCount (alias of faceCount) | 6 | 11 | 11 | |
+| face | subShapeCount(ofType: .face) (dedup canonical) | 6 | 11 | 11 | |
+| face | nbFaces (#651: docs say dedup) | 6 | 12 | 12 | occurrence; no divergence on a *plain box* since no face is shared there, see correction below |
+| face | contents.faces (occurrence) | 6 | 12 | 12 | |
+| face | contentsExtended().nbFaces (occurrence) | 6 | 12 | 12 | |
+| face | contentsExtended().nbSharedFaces (a THIRD rule: location-discarding dedup) | 6 | 11 | 11 | |
+| face (already fixed) | horizontalFaces().count (#614, reads orientedFaces()) | 2 | 4 | 4 | |
+| face (already fixed) | upwardFaces().count (#614, reads orientedFaces()) | 1 | 2 | 2 | |
+| face (already fixed) | facesByZLevel() total (#614, reads horizontalFaces()) | 2 | 4 | 4 | |
+| face (already fixed) | upwardFaces().count **[horizontal-cut fixture]** | 1 | 2 | 2 | corroborates #642's own table: #614's fix IS order-independent on the SAME fixture AAG is not |
+| face (AAG, #642) | buildAAG().nodes.count [vertical-cut fixture] | 6 | 11 | 11 | |
+| face (AAG, #642) | AAG upward+horizontal count [vertical-cut fixture] | n/a | 2 | 2 | shared wall's normal is horizontal-axis here, order-independent by construction, not by a fix |
+| face (AAG, #642) | detectPocketsAAG().count [vertical-cut fixture] | 1 | 1 | 1 | no pocket geometry here regardless of order, this fixture does not exercise #642 |
+| face (AAG, #642) | buildAAG().nodes.count [horizontal-cut fixture] | 6 | 11 | 11 | |
+| face (AAG, #642) | **AAG upward+horizontal NODE INDICES [horizontal-cut fixture]** | n/a | **[2, 8]** | **[2]** | the shared wall's node keeps whichever half's orientation `faces()` reached first, the #642 mechanism |
+| face (AAG, #642) | **detectPocketsAAG().count [horizontal-cut fixture]** | 1 | **2** | **1** | THE #642 HEADLINE MEASUREMENT, reproduced exactly |
+| wire | wireCount (dedup) | 6 | 11 | 11 | |
+| wire | wires.count (dedup) | 6 | 11 | 11 | |
+| wire | subShapeCount(ofType: .wire) (dedup canonical) | 6 | 11 | 11 | |
+| wire | contents.wires (occurrence) | 6 | 12 | 12 | |
+| shell | shellCount (dedup) | 1 | 2 | 2 | |
+| shell | shells.count (dedup) | 1 | 2 | 2 | |
+| shell | subShapeCount(ofType: .shell) (dedup canonical) | 1 | 2 | 2 | |
+| shell | outerShells.count (occurrence explorer, #439 restricts to per-solid use) | 1 | 2 | 2 | |
+| solid | solidCount (dedup) | 1 | 2 | 2 | |
+| solid | solids.count (dedup) | 1 | 2 | 2 | |
+| solid | subShapeCount(ofType: .solid) (dedup canonical) | 1 | 2 | 2 | |
+
+(exact output reproduced by `swift run ClusterACensus`; the printed table additionally right-pads
+columns for terminal alignment, omitted here for Markdown)
+
+## Static classification summary
+
+`classify_topexp_sites.py` found **127 C functions** in `Sources/OCCTBridge/src/*.mm` containing a
+`TopExp_Explorer` or `TopExp::MapShapes` call: **52 DEDUP, 54 OCCURRENCE, 21 OTHER** (find-first /
+existence-check / dead declaration). Re-run the script for the full 127-row table; the entry points
+that matter for cluster A specifically are cross-referenced against the dynamic table above.
+
+Two functions are declared and implemented but **called from nowhere in `Sources/OCCTSwift/`**:
+`OCCTShapeCountFaces` and `OCCTShapeCountEdges` (`OCCTBridge_Topology.mm`), both OCCURRENCE. Since
+`OCCTBridge` is not a package product (only `OCCTSwift` is, per `Package.swift`'s `products:`),
+these are unreachable from any consumer of this package, orphaned, not part of the public surface
+`#664` asks about, despite matching the OCCURRENCE shape of the ones that are (`OCCTShapeNbFaces`/
+`OCCTShapeNbEdges`, which back the *reachable* `nbFaces`/`nbEdges`).
+
+## Where the two methods disagreed
+
+The most useful output of this census, per the task that commissioned it. Two were real bugs in
+the classifier, found and fixed while building it. Both are now `--self-test` cases, proven to
+fail with the fix reverted (see "Self-test, proven" below):
+
+1. **A nested-paren return type broke the function-name parser.** `static Handle(Poly_Triangulation)
+   occtMergedTriangulation(...)` was mis-parsed with `Handle` as the function name, greedily
+   swallowing everything up to the *real* closing paren as its "argument list" and hiding the real
+   function from classification entirely. Fixed by blanking the `Handle(Type)` idiom to a
+   same-length, paren-free placeholder before matching (`_blank_handle_macro`).
+2. **A braceless single-statement loop body was matched against the wrong braces.**
+   `OCCTShapeCountFaces`, `OCCTShapeCountEdges` and `OCCTFaceWireCount` are all
+   `for (TopExp_Explorer ex(...); ex.More(); ex.Next()) count++;`, no braces on the loop body at
+   all. The first version of the loop-body finder searched forward for the next `{`, found the
+   function's own `catch (...) { return 0; }` a few lines later, and reported a `return` "inside
+   the loop" for all three, misclassifying three genuine OCCURRENCE functions as OTHER
+   (find-first). Fixed by handling the braceless case explicitly (`_loop_body_span` now checks for
+   `{` before assuming one).
+3. **Not fixed, documented instead: the `while (explorer.More() && count < max)` idiom.**
+   `OCCTShapeCheckSmallFaces` and `OCCTShapeGetContourPoints` declare the `TopExp_Explorer` on its
+   own line and drive it with a `while` whose condition also checks a caller-supplied output-buffer
+   cap (`found < maxResults` / `pointCount < maxPoints`), not the `for (...; .More(); .Next())`
+   idiom the classifier's loop-body finder assumes. Both are reported **OTHER** by the script.
+   Manual reading of both (`OCCTBridge_Healing.mm:1614`, `OCCTBridge_Modeling.mm:10819`) shows
+   neither is a find-first: both walk every occurrence up to the cap with no dedup, i.e. they are
+   OCCURRENCE, just *bounded* OCCURRENCE. A shared face/edge could still appear twice in the
+   output, just possibly evicting a later, unrelated one past the cap. The static tool's blind spot
+   here is exactly what #664 warned about ("a shared helper... will defeat it"). This is a
+   different loop idiom, not a helper, but the same lesson: a grep-shaped classifier finds shapes
+   it was taught to recognise, not the ones actually in the tree, and neither of these two is fed
+   into or read from the dynamic table above regardless (they cap a diagnostics buffer, not a
+   sub-shape count/array), so this blind spot did not affect any measured conclusion in this
+   artifact.
+4. **`occtHasSelfIntersectingWire`: the classifier was right, and an earlier manual read (done
+   while scoping this census) was not careful enough about `return` vs `break`.** It walks
+   `TopAbs_WIRE` and returns `true` from inside the loop the moment it finds a self-intersecting
+   one, a genuine find-first, correctly OTHER once the classifier was taught to look for `return`
+   as well as `break` inside the loop body (not just after it, where a legitimately-accumulated
+   result is returned once the walk completes).
+
+None of these four bears on the dynamic table's conclusions. The classifier is intentionally the
+secondary check here, and every entry point actually measured in the table above was measured, not
+inferred from source text. They are recorded because the disagreement itself, and how each was
+resolved, is what #664 asked this artifact to surface.
+
+## Self-test, proven
+
+Per `okf/policies/prove-the-test-fails.md`: every self-test case was run once with the mechanism it
+exists to catch reverted.
+
+| guard removed | cases correct | which failed |
+|---|---|---|
+| (none, baseline) | 6/6 | n/a |
+| `TopExp::MapShapes` detection disabled | 5/6 | `dedup_literal_mapshapes` (expected DEDUP, got OTHER) |
+| braceless-loop handling reverted to brace-only | 5/6 | `occurrence_braceless_loop_with_later_catch_return` (expected OCCURRENCE, got OTHER) |
+| (restored) | 6/6 | n/a |
+
+## Findings
+
+**Already correct, and must not regress.** `faces()`/`orientedFaces()` (#614), `faceCount`/`edgeCount`/
+`vertexCount`/`wireCount`/`shellCount`/`solidCount`/`subShapeCount(ofType:)` (#502/#541),
+`horizontalFaces()`/`upwardFaces()`/`facesByZLevel()` (#614, confirmed order-independent on *both*
+split fixtures in this census, rows above). Any Cluster A fix has to leave every one of these
+numbers unchanged.
+
+**#651 is confirmed, and its own table was already careful about the one thing worth checking.**
+`nbEdges`/`nbFaces`/`nbVertices` are bare `TopExp_Explorer` counts (`OCCTShapeNbEdges`/`NbFaces`/
+`NbVertices`, `OCCTBridge_Topology.mm:3694-3719`) while `docs/reference/Document-Completions.md`
+documents all three with the *deduplicated* value (`box.nbEdges // 12`, `box.nbVertices // 8`,
+confirmed by direct read of lines 1406/1438). #651's own table already shows `nbFaces`/`faceCount`
+agreeing on a box (6/6, correctly: no face is shared within one solid) and diverging only on the
+two-solid compound (12/11). This census's own table reproduces that distinction exactly (`nbFaces`
+row: 6/12/12 across plain box/order A/order B, matching `contentsExtended().nbFaces` and
+`contents.faces` bit for bit) rather than contradicting it. The measured dynamic table also confirms
+#651's own "watch for" note: `nbEdges`/`nbFaces`/`nbVertices` are pure OCCURRENCE duplicates of
+`edgeCount`/`faceCount`/`vertexCount` in every fixture measured. The #490/#491/#492 precedent
+(retire the duplicate spelling, not just repoint its implementation) applies directly.
+
+**`ShapeAnalysis_ShapeContents` (`Shape.contents`) and `contentsExtended()` are occurrence-based
+too, and undocumented as such beyond `Shape.contents`'s own doc comment.** Both track the raw
+explorer count (matching #541's README, which established this for faces specifically:
+"`ShapeAnalysis_ShapeContents` is a fourth answer... its `NbFaces` tracks the explorer exactly").
+`contentsExtended().nbSharedFaces` is a confirmed *third* counting rule (dedup with the placement
+discarded, per #541), not a second copy of `faceCount`'s dedup rule. It happens to agree with
+`faceCount` on both fixtures here only because neither compounds a moved copy of the same face; #541's
+own `compound(box, box.Moved())` fixture is where the three answers (occurrence 12, `IsSame`-dedup
+12, location-discarding dedup 6) actually separate.
+
+**#638 (`edges()` collapse): the census supplies the consumer audit #638's own text asks for, and
+finds none.** `edges()` collapses 24 occurrences to 12 distinct on a box, the identical mechanism
+#614 fixed for faces (confirmed measurement, this table's edge rows). But `Edge` (the Swift type)
+exposes no `.orientation` accessor at all: `edgeCount`, `edge(at:)`, `edges()`, `hasCurve3D`,
+`isClosed3D`, `isSeam(on:)`, `adjacentFaces(in:)`, `dihedralAngle`, `tangent(at:)`, `curve3D`, and
+every other public member on it were checked, and none reads a stored `TopAbs_Orientation` off the
+edge. Searching the bridge directly (`grep -rn "\.Orientation() =="` across every `.mm` file) finds
+exactly 14 sites that branch on an edge's or face's orientation; 13 are face-normal logic already
+covered by #614's fix, and the one edge-orientation site
+(`OCCTBridge_Modeling.mm:2646`, `occtSampleWirePoints`) reads its orientation fresh from a
+`BRepTools_WireExplorer` walk of the *wire*, not from an `Edge` obtained via `Shape.edges()`, so it
+is not a consumer of the collapse at all. **No currently-existing public consumer of `edges()`'s
+stored orientation was found.** This is evidence toward #638's own option 2 ("the collapse is
+correct behaviour... a documented contract plus a test, not a code change") but #638's own text is
+right that this needs stating in that issue's PR, not settled here. A future `Edge.orientation`
+accessor, or an edge-level consumer added later, would need to re-run this same search.
+
+**#642 reproduces exactly, but only on a fixture #642's own issue text doesn't fully specify,
+which is the correction worth posting.** `detectPocketsAAG()` 2 vs 1 and the AAG upward+horizontal
+node set `[2, 8]` vs `[2]` are reproduced bit-for-bit on the horizontal-cut fixture. They do **not**
+reproduce on the vertical-cut fixture, the one `Issue614FaceOrientationTests.swift` already commits
+and the one a reader would naturally reach for first ("PR #631's own two-solid split fixture"). A
+future PR for #642 that reused #614's committed fixture verbatim, expecting the same order-dependence,
+would have found none and wrongly concluded the defect didn't reproduce. #642's own "complete
+consumer set" table (three executable consumers of `faces()`: `FeatureRecognition.swift:96`,
+`ConstructionEntity.swift:261`, `ShapeMeasurements.swift:66`) was independently re-verified here by
+grepping every `.faces()` occurrence in `Sources/OCCTSwift/*.swift` and excluding doc-comment
+matches. It is exactly right: three sites, no more.
+
+## Re-scoping the three members
+
+#664 asks which members are "the same defect" and which are independent, now that the census
+exists. They are **three different, independent fixes**, not one fix in three places. The
+census's job here is to show that clearly rather than let a fourth issue re-derive it:
+
+- **#638** (`edges()` undocumented collapse) has **no fix depending on #642 or #651, and no fix
+  they depend on**. Its own open question (does the collapse need `orientedEdges()`, mirroring
+  #614's `orientedFaces()`) is answered "probably not, on current evidence" by the consumer audit
+  above, but that is #638's call to make and record, not this census's.
+- **#642** (AAG order-dependence) **shares its root mechanism with #614** (a normal/predicate
+  derived from a dedup-collapsed face loses information for whichever occurrence didn't survive)
+  but **#614 already shipped the general-purpose fix** (`orientedFaces()`). #642 is not blocked on
+  any further root-level change to `faces()`/`edges()`. The fix it needs is AAG's own node-identity
+  redesign (per #642's own three suggested approaches), which is a consumer-side migration, not a
+  root-cause fix. #642 can start immediately; it was never gated on #638 or #651.
+- **#651** (`nbEdges`/`nbFaces`/`nbVertices` vs their own docs) is **orthogonal to orientation
+  entirely**. It is a "two implementations of one count, the docs describe the wrong one" bug, with
+  no face/edge-orientation dimension at all. It does not share a mechanism with #638 or #642 beyond
+  both families living under `TopExp_Explorer`/`TopExp::MapShapes`. Confirmed retirable in favour of
+  `edgeCount`/`faceCount`/`vertexCount` per the measured duplication above.
+
+**Practical consequence:** there is no single "fix the root" commit left to land for Cluster A that
+would move all three members. The root for the *face* side (#614) already shipped; #638 is a
+documentation decision; #642 is a standalone design task; #651 is a standalone retire-the-duplicate
+task. All three can proceed in parallel once opened, in any order.
+
+## Verify
+
+```bash
+swift build                                    # 0 errors, no OCCTSWIFT_LOCAL, pinned v2.0.0-kernel.1
+swift test                                     # full suite
+python3 Scripts/check-bridge-index.py
+python3 Scripts/check-null-handle-guards.py
+python3 Scripts/check-docs-defaults.py
+python3 Scripts/count-operations.py
+python3 Scripts/check-bridge-index.py --self-test
+python3 Scripts/check-null-handle-guards.py --self-test
+python3 Scripts/check-docs-defaults.py --self-test
+python3 Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py --self-test
+```

--- a/Scripts/repro/cluster-a-subshape-enumeration/README.md
+++ b/Scripts/repro/cluster-a-subshape-enumeration/README.md
@@ -144,8 +144,11 @@ these are unreachable from any consumer of this package, orphaned, not part of t
 ## Where the two methods disagreed
 
 The most useful output of this census, per the task that commissioned it. Two were real bugs in
-the classifier, found and fixed while building it. Both are now `--self-test` cases, proven to
-fail with the fix reverted (see "Self-test, proven" below):
+the classifier, found and fixed while building it. **An earlier version of this README claimed
+both were now `--self-test` cases "proven to fail with the fix reverted." That claim was wrong for
+both.** Disabling either guard as it actually reads in the source left the self-test at 6/6; see
+"Self-test guard-removal matrix" below for what was actually measured, case by case, and what was
+added to close the gap.
 
 1. **A nested-paren return type broke the function-name parser.** `static Handle(Poly_Triangulation)
    occtMergedTriangulation(...)` was mis-parsed with `Handle` as the function name, greedily
@@ -187,17 +190,64 @@ secondary check here, and every entry point actually measured in the table above
 inferred from source text. They are recorded because the disagreement itself, and how each was
 resolved, is what #664 asked this artifact to surface.
 
-## Self-test, proven
+## Self-test guard-removal matrix
 
-Per `okf/policies/prove-the-test-fails.md`: every self-test case was run once with the mechanism it
-exists to catch reverted.
+Per `okf/policies/prove-the-test-fails.md`: "if removing a guard leaves the count unchanged, that
+case is decorative and needs rewriting, not celebrating." A PR #693 review measured this directly
+and found the two guards above were exactly that: neither's removal changed the self-test result.
+The table below is the corrected, full audit: every conditional in the classifier that gates a
+verdict, removed one at a time, against both the self-test and the real 127-function report.
+`self-test` shows cases-correct out of the full suite; `FAILS` lists which case(s) actually caught
+it (empty means none did). `real report` shows whether the actual classification of the 127 real
+bridge functions changed.
 
-| guard removed | cases correct | which failed |
-|---|---|---|
-| (none, baseline) | 6/6 | n/a |
-| `TopExp::MapShapes` detection disabled | 5/6 | `dedup_literal_mapshapes` (expected DEDUP, got OTHER) |
-| braceless-loop handling reverted to brace-only | 5/6 | `occurrence_braceless_loop_with_later_catch_return` (expected OCCURRENCE, got OTHER) |
-| (restored) | 6/6 | n/a |
+| guard removed | self-test | FAILS | real report |
+|---|---|---|---|
+| (none, baseline) | 13/13 | | 127 total, 52/54/21 |
+| A: `_blank_handle_macro` neutered (`Handle(Type)` no longer blanked before parsing) | 12/13 | `occurrence_handle_return_type` | **CHANGED**: 126 total, 52/53/21 (`occtMergedTriangulation` drops out entirely) |
+| B: `control_words` skip forced off | 13/13 | none | unchanged |
+| C: comment-line skip in `split_functions` forced off | 13/13 | none | unchanged |
+| D: `_loop_body_span`'s `if not next_match: return None` removed | 12/13 | `occurrence_explorer_checked_once_no_next_call` | **CRASHES**: `AttributeError: 'NoneType' object has no attribute 'end'` (10 real functions hit this) |
+| E: `_loop_body_span`'s `if for_close == -1: return None` removed | 13/13 | none | unchanged |
+| F: `_loop_body_span`'s `if i >= len(code): return None` removed | 13/13 | none | unchanged |
+| G: `if code[i] == "{":` forced to `if True:` (the review's braceless finding) | 12/13 | `other_braceless_find_first_with_later_catch_return` | **CHANGED**: 127 total, 52/55/20 |
+| H: `_loop_body_span`'s `if semi == -1: return None` removed | 13/13 | none | unchanged |
+| I: `BREAK_OR_RETURN_RE` check in `classify_body` neutered | 11/13 | `other_find_first_break`, `other_braceless_find_first_with_later_catch_return` | **CHANGED**: 127 total, 52/75/0 |
+| J: `if not explorer_matches: return "OTHER"` removed | 12/13 | `other_unrelated_iterator_no_topexp_usage` | unchanged on real data (this guard protects `self_test()`'s own direct call to `classify_body`, which `classify_file`'s pre-filter in `run_report()` makes otherwise unreachable) |
+| K: `if not MORE_RE.search(code): return "OTHER"` removed | 12/13 | `other_dead_explorer_declaration` | unchanged (no real function declares a dead `TopExp_Explorer` today) |
+| L: line-comment stripping neutered | 12/13 | `occurrence_comment_contains_return_word` | **CHANGED**: 127 total, 52/53/22 (`OCCTShapeFixSolid` flips OCCURRENCE to OTHER: a comment containing "...only ever **returns** the input solid..." reads as code) |
+| M: block-comment stripping neutered | 12/13 | `occurrence_block_comment_contains_return_word` | unchanged on real data (no real function hits the `/* */` form of L's failure mode yet; added for symmetry, not because it fired) |
+| N: `MAPSHAPES_RE` check (DEDUP via `TopExp::MapShapes`) neutered | 12/13 | `dedup_literal_mapshapes` | **CHANGED**: 127 total, 2/54/71 |
+| O: hand-rolled-dedup `.Add()` check neutered | 12/13 | `dedup_hand_rolled_add` | **CHANGED**: 127 total, 50/56/21 |
+| (restored) | 13/13 | | 127 total, 52/54/21 |
+
+**Four guards (A, D, G, L) were load-bearing on the real 127-function corpus and had zero self-test
+coverage before this pass** (A and G are the review's two; D and L were found auditing the rest per
+the review's own instruction not to stop at two). D is the more serious of the pair found here: its
+absence does not misclassify, it **crashes** classification outright on 10 real functions that use
+a `TopExp_Explorer` to read the first match of a type with no enclosing loop at all
+(`occtShellIsInsideSolid`, `OCCTShapeCreateHalfSpace`, `OCCTSolidFromShells`, and seven more). New
+fixtures were added for all four, plus J and K (which only guard `self_test()`'s own bypass of
+`classify_file`'s pre-filter, so they can never show a real-report effect by construction) and M
+(added proactively, by the same failure mode as L, though nothing in the current tree exercises
+it yet).
+
+**Five guards (B, C, E, F, H) remain without self-test coverage and were left that way
+deliberately, not overlooked.** Each is provably unreachable given how the classifier is
+constructed, not merely untriggered by today's source tree:
+- **B** (`control_words`) and **C** (the comment-line skip in `split_functions`) can never fire on
+  compiling C++: `FUNC_START_RE`'s `^` anchor means its overall match always starts exactly at a
+  line's first character, so the text checked by C (`text[line_start:m.start()]`) is always the
+  empty string, and B's `name` is only ever populated from a token preceded by a return-type span,
+  which none of `if`/`for`/`while`/`switch`/`catch`/`return`/`sizeof` can be (they are C++ reserved
+  words; none can be a real identifier).
+- **E**, **F**, **H** are bounds checks inside `_loop_body_span` that only fail on syntactically
+  unbalanced input (an unterminated `for (...`, a truncated file, a statement with no closing `;`)
+  which cannot arise from a file that compiles.
+
+Writing a self-test fixture for code that cannot occur in valid input would test nothing; it would
+just be a seventh decorative case pretending to prove something. They are listed here, with the
+reasoning, instead.
 
 ## Findings
 

--- a/Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
+++ b/Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
@@ -437,9 +437,13 @@ SELF_TEST_CASES = [
         # the verdict here (both paths land on OCCURRENCE, since a span-less call always takes the
         # default) -- it crashes 10 real functions in the actual census outright, which is a
         # stronger, not weaker, argument for testing it: a self-test that reports 6/6 while this
-        # guard has zero coverage is silent about a real crash-on-real-data risk. This case
-        # exists to keep that guard from being removed unnoticed even though it cannot, by
-        # construction, be proven via a verdict mismatch the way the other new cases are.
+        # guard has zero coverage is silent about a real crash-on-real-data risk.
+        #
+        # This case IS proven, and the sentence here previously claiming otherwise was wrong.
+        # Removing the guard gives `CRASH: 'NoneType' object has no attribute 'end'` and drops
+        # the self-test by one, via the `except Exception` arm of `self_test()`, which exists so
+        # a mutation that crashes reports as a failed case rather than a bare traceback. A crash
+        # is a verdict mismatch like any other here.
         "occurrence_explorer_checked_once_no_next_call",
         """
         bool OCCTFakeNoNextCall(OCCTShapeRef shape) {
@@ -485,6 +489,27 @@ SELF_TEST_CASES = [
         """,
         "OTHER",
     ),
+    (
+        # Guard B (`control_words`). FUNC_START_RE's return-type span is
+        # `[A-Za-z_][\w:<>\*&\s,]*?`, which cannot tell that a token is not a type, so a
+        # single-line `else if (cond) {` offers `else` as the return type and `if` as the
+        # function name. Without guard B this fixture parses TWO functions, the real one and a
+        # phantom `if` carrying the explorer loop, which would appear as an extra OCCURRENCE
+        # row in the census. The README previously filed B as provably unreachable; it is not,
+        # it is merely untriggered by today's tree, which contains no single-line `else if (`.
+        "guard_b_else_if_is_not_a_function",
+        """
+        void OCCTRealFunctionWithElseIf(OCCTShapeRef shape) {
+            if (!shape) { return; }
+            else if (shape->needsWalk) {
+                for (TopExp_Explorer ex(shape->shape, TopAbs_FACE); ex.More(); ex.Next()) {
+                    total++;
+                }
+            }
+        }
+        """,
+        "OCCURRENCE",
+    ),
 ]
 
 
@@ -495,6 +520,14 @@ def self_test(verbose=True):
         funcs = split_functions(snippet)
         if not funcs:
             verdict, reason = "NO FUNCTION PARSED", "split_functions() found no function in the fixture"
+        elif len(funcs) != 1:
+            # Every fixture here is deliberately one function, so a second one is a parser
+            # defect, not a fixture property. Classifying funcs[0] alone would miss it: a
+            # spurious extra function is appended AFTER the real one, so funcs[0] stays right
+            # and the case passes while the census silently gains a phantom row. Guard B's
+            # removal produces exactly this shape and nothing detected it before.
+            verdict = f"MULTIPLE FUNCTIONS PARSED: {[f[0] for f in funcs]}"
+            reason = "split_functions() invented a function that is not one"
         else:
             _, body = funcs[0]
             # A guard removed by mutation can turn a graceful "wrong verdict" into an

--- a/Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
+++ b/Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Cluster A census (#664), static half: classify every TopExp_Explorer / TopExp::MapShapes
+call site in the OCCTBridge .mm sources as DEDUP, OCCURRENCE or OTHER.
+
+This is the SECONDARY, cross-check evidence the census README describes -- not the primary
+evidence. #664 is explicit that a grep-shaped classifier "must not be the primary evidence: a
+shared helper, a cast, or an entry point that walks via another entry point will all defeat it."
+This script is exactly that kind of grep-shaped classifier: it finds a C function's own body and
+looks for textual patterns, so it is blind to indirection (a helper called BY the function that
+does the real walk) and to functions that share a header comment but not a body. It exists to be
+compared against the DYNAMIC measurement in main.swift / README.md, not to replace it. Where the
+two disagree, that disagreement is the most valuable output (README.md's "static vs dynamic"
+section).
+
+Classification per C function definition found in Sources/OCCTBridge/src/*.mm:
+
+  DEDUP      -- the function calls `TopExp::MapShapes` (any of the three overloads:
+                `MapShapes`, `MapShapesAndAncestors`, `MapShapesAndUniqueAncestors`), or builds an
+                indexed/plain shape map (`TopTools_IndexedMapOfShape` / `TopTools_MapOfShape` /
+                `NCollection_IndexedMap<TopoDS_Shape>`) and calls `.Add(` on it from inside a
+                `TopExp_Explorer` loop -- the hand-rolled-dedup shape #664 asks a static check to
+                still recognise.
+  OCCURRENCE -- the function has a bare `TopExp_Explorer` loop (a `for`/`while` whose condition
+                calls `.More()`) with no DEDUP structure anywhere in the same function, and the
+                loop is not a find-first-then-break (see OTHER below).
+  OTHER      -- anything else: no live TopExp usage in the function (comment-only or an unrelated
+                match), or a `TopExp_Explorer` used to find a single match and `break`/`return`
+                within a few lines of entering the loop, which is existence-checking rather than
+                enumeration.
+
+Usage:
+    python3 classify_topexp_sites.py              # print the classification table
+    python3 classify_topexp_sites.py --self-test   # prove the classifier on known fixtures
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BRIDGE_SRC = REPO_ROOT / "Sources" / "OCCTBridge" / "src"
+BRIDGE_INCLUDE = REPO_ROOT / "Sources" / "OCCTBridge" / "include"
+SWIFT_SRC = REPO_ROOT / "Sources" / "OCCTSwift"
+
+MAPSHAPES_RE = re.compile(r"TopExp::MapShapes(AndAncestors|AndUniqueAncestors)?\s*\(")
+EXPLORER_RE = re.compile(r"TopExp_Explorer\s+\w+\s*\(")
+MAP_DECL_RE = re.compile(
+    r"(TopTools_IndexedMapOfShape|TopTools_MapOfShape|NCollection_IndexedMap\s*<\s*TopoDS_Shape\s*>)\s+(\w+)"
+)
+MAP_ADD_RE = re.compile(r"\b(\w+)\.Add\s*\(")
+MORE_RE = re.compile(r"\.More\s*\(\s*\)")
+BREAK_OR_RETURN_RE = re.compile(r"\b(break|return[^;]*)\s*;")
+
+# A C function definition: return-type-ish tokens, a name starting with a letter, a paren'd
+# parameter list, then an opening brace on the same or a later line. Deliberately permissive: this
+# is a classifier, not a C++ parser, and every function in this bridge follows this shape.
+FUNC_START_RE = re.compile(
+    r"^[ \t]*(?:[A-Za-z_][\w:<>\*&\s,]*?)\s+(\b[A-Za-z_]\w*)\s*\(([^;{}()]*)\)\s*\{", re.MULTILINE
+)
+
+
+HANDLE_MACRO_RE = re.compile(r"\bHandle\(\s*[\w:]+\s*\)")
+
+
+def _blank_handle_macro(text):
+    """Collapse OCCT's `Handle(Type)` return-type/cast idiom to a same-length run of `_`.
+
+    `Handle(Type)` contains a nested paren pair, which defeats FUNC_START_RE's single-level
+    `\\(...\\)` parameter-list match: on `static Handle(Poly_Triangulation) occtMergedTriangulation(...)`
+    the naive regex either captures "Handle" as the function name (swallowing everything up to the
+    real closing paren, an early bug this comment replaces) or, once that greedy span is
+    disallowed, fails to match the line at all and silently drops a real function -- worse, since a
+    dropped function is invisible rather than mislabeled. Blanking the macro to a same-length,
+    paren-free placeholder BEFORE matching keeps every byte offset valid (so brace-matching against
+    the same string still lines up) while letting the return-type portion of FUNC_START_RE span
+    across it like any other identifier.
+    """
+    return HANDLE_MACRO_RE.sub(lambda m: "H" + "_" * (len(m.group(0)) - 1), text)
+
+
+def split_functions(text):
+    """Yield (name, body) for each top-level C/ObjC++ function definition in `text`.
+
+    Brace-depth matching from the opening `{` found by FUNC_START_RE. Skips anything whose
+    "name(args) {" is actually a control-flow construct (if/for/while/switch/catch) by name
+    filtering, and skips matches inside a `//` line comment.
+    """
+    text = _blank_handle_macro(text)
+    control_words = {"if", "for", "while", "switch", "catch", "return", "sizeof"}
+    functions = []
+    for m in FUNC_START_RE.finditer(text):
+        name = m.group(1)
+        if name in control_words:
+            continue
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line = text[line_start:m.start()]
+        if "//" in line:
+            continue
+        brace_start = m.end() - 1
+        depth = 0
+        i = brace_start
+        while i < len(text):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        body = text[brace_start:i + 1]
+        functions.append((name, body))
+    return functions
+
+
+def strip_comments(text):
+    """Remove // and /* */ comments so they cannot masquerade as live code."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    text = re.sub(r"//[^\n]*", "", text)
+    return text
+
+
+NEXT_CALL_RE = re.compile(r"\.Next\s*\(\s*\)")
+
+
+def _loop_body_span(code, explorer_start):
+    """Find the body of the `for (TopExp_Explorer ...) BODY` starting near `explorer_start`, by
+    anchoring on the loop header's `.Next())` close. `BODY` is either a braced block (brace-match
+    it) or -- just as common in this bridge, e.g. `for (...; ex.More(); ex.Next()) count++;` --
+    a single unbraced statement up to its own `;`. Getting this wrong is not academic: the first
+    version of this script brace-matched the wrong `{` (the function's own `try`/`catch` block,
+    the next one in the file) for every braceless loop, and a `catch (...) { return 0; }` a few
+    lines later made every one of them look like a find-first `return` inside the loop. Returns
+    (body_start, body_end) or None if the shape doesn't match."""
+    next_match = NEXT_CALL_RE.search(code, explorer_start)
+    if not next_match:
+        return None
+    for_close = code.find(")", next_match.end())
+    if for_close == -1:
+        return None
+    i = for_close + 1
+    while i < len(code) and code[i].isspace():
+        i += 1
+    if i >= len(code):
+        return None
+    if code[i] == "{":
+        depth = 0
+        j = i
+        while j < len(code):
+            if code[j] == "{":
+                depth += 1
+            elif code[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    return (i, j + 1)
+            j += 1
+        return None
+    # Braceless single-statement loop body: up to its own terminating `;`.
+    semi = code.find(";", i)
+    if semi == -1:
+        return None
+    return (i, semi + 1)
+
+
+def classify_body(body):
+    """Classify one function body. Returns (verdict, reason)."""
+    code = strip_comments(body)
+
+    if MAPSHAPES_RE.search(code):
+        return "DEDUP", "calls TopExp::MapShapes(AndAncestors/AndUniqueAncestors)"
+
+    map_names = {mm.group(2) for mm in MAP_DECL_RE.finditer(code)}
+    if map_names:
+        for add_match in MAP_ADD_RE.finditer(code):
+            if add_match.group(1) in map_names:
+                return "DEDUP", f"builds {sorted(map_names)} and calls .Add() on it"
+
+    explorer_matches = list(EXPLORER_RE.finditer(code))
+    if not explorer_matches:
+        return "OTHER", "no TopExp_Explorer / TopExp::MapShapes in this function"
+
+    if not MORE_RE.search(code):
+        return "OTHER", "TopExp_Explorer present but .More() never called (unused/dead declaration)"
+
+    # Find-first: a `break` or `return` INSIDE the loop's own body (not after it, where an
+    # accumulated count/array is legitimately returned once the walk is done).
+    span = _loop_body_span(code, explorer_matches[0].start())
+    if span is not None:
+        loop_body = code[span[0]:span[1]]
+        if BREAK_OR_RETURN_RE.search(loop_body):
+            return "OTHER", "TopExp_Explorer loop contains a break/return (find-first, not an enumeration)"
+
+    return "OCCURRENCE", "bare TopExp_Explorer loop, no dedup map in this function"
+
+
+def classify_file(path):
+    text = path.read_text()
+    results = []
+    for name, body in split_functions(text):
+        code_only = strip_comments(body)
+        if not (MAPSHAPES_RE.search(code_only) or EXPLORER_RE.search(code_only)):
+            continue
+        verdict, reason = classify_body(body)
+        results.append((name, verdict, reason))
+    return results
+
+
+def swift_reachable_names():
+    """C function names actually referenced from Sources/OCCTSwift/*.swift -- the reachability
+    check that separates a genuine public entry point from an orphaned bridge function nobody
+    calls (OCCTShapeCountFaces / OCCTShapeCountEdges are exactly this: declared and implemented,
+    called from nowhere)."""
+    names = set()
+    for f in SWIFT_SRC.glob("*.swift"):
+        text = f.read_text()
+        for m in re.finditer(r"\bOCCT[A-Za-z0-9_]+\s*\(", text):
+            names.add(m.group(0)[:-1].strip())
+    return names
+
+
+def header_declared_names():
+    names = set()
+    for f in BRIDGE_INCLUDE.glob("*.h"):
+        text = f.read_text()
+        for m in re.finditer(r"\b(OCCT[A-Za-z0-9_]+)\s*\(", text):
+            names.add(m.group(1))
+    return names
+
+
+def run_report():
+    reachable = swift_reachable_names()
+    declared = header_declared_names()
+    total = 0
+    by_verdict = {"DEDUP": 0, "OCCURRENCE": 0, "OTHER": 0}
+    print(f"{'file':<28} {'function':<42} {'verdict':<11} {'reachable?':<11} reason")
+    print("-" * 140)
+    for path in sorted(BRIDGE_SRC.glob("*.mm")):
+        for name, verdict, reason in classify_file(path):
+            total += 1
+            by_verdict[verdict] += 1
+            reach = "swift" if name in reachable else ("header-only" if name in declared else "internal")
+            print(f"{path.name:<28} {name:<42} {verdict:<11} {reach:<11} {reason}")
+    print("-" * 140)
+    print(f"total functions containing TopExp usage: {total}")
+    print(f"  DEDUP:      {by_verdict['DEDUP']}")
+    print(f"  OCCURRENCE: {by_verdict['OCCURRENCE']}")
+    print(f"  OTHER:      {by_verdict['OTHER']}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Self-test: prove the classifier actually distinguishes the three verdicts,
+# per okf/policies/prove-the-test-fails.md.
+# ---------------------------------------------------------------------------
+
+SELF_TEST_CASES = [
+    (
+        "dedup_literal_mapshapes",
+        """
+        int32_t OCCTFakeDedupLiteral(OCCTShapeRef shape) {
+            TopTools_IndexedMapOfShape faceMap;
+            TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
+            return faceMap.Extent();
+        }
+        """,
+        "DEDUP",
+    ),
+    (
+        "dedup_hand_rolled_add",
+        """
+        int32_t OCCTFakeDedupHandRolled(OCCTShapeRef shape) {
+            TopTools_IndexedMapOfShape seen;
+            for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
+                seen.Add(exp.Current());
+            }
+            return seen.Extent();
+        }
+        """,
+        "DEDUP",
+    ),
+    (
+        "occurrence_bare_explorer",
+        """
+        int32_t OCCTFakeOccurrence(OCCTShapeRef shape) {
+            int32_t count = 0;
+            for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
+                count++;
+            }
+            return count;
+        }
+        """,
+        "OCCURRENCE",
+    ),
+    (
+        "other_find_first_break",
+        """
+        bool OCCTFakeFindFirst(OCCTShapeRef shape) {
+            for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
+                if (isTheOneWeWant(exp.Current())) {
+                    break;
+                }
+            }
+            return true;
+        }
+        """,
+        "OTHER",
+    ),
+    (
+        "other_comment_only",
+        """
+        void OCCTFakeCommentOnly(OCCTShapeRef shape) {
+            // historically this used TopExp_Explorer; see OCCTShapeNbEdges for the real one.
+            doSomethingElse(shape);
+        }
+        """,
+        "OTHER",
+    ),
+    (
+        # The exact shape of OCCTShapeCountFaces/OCCTShapeCountEdges/OCCTFaceWireCount: a
+        # braceless single-statement loop body, followed (outside the loop) by a `catch` block
+        # that itself contains a `return`. A version of this script that only knew how to
+        # brace-match found that catch block's `{ return 0; }` instead of the (nonexistent) loop
+        # braces, and misclassified every one of these three real functions as OTHER.
+        "occurrence_braceless_loop_with_later_catch_return",
+        """
+        int32_t OCCTFakeBracelessLoop(OCCTShapeRef shape) {
+            if (!shape) return 0;
+            try {
+                int count = 0;
+                for (TopExp_Explorer ex(shape->shape, TopAbs_FACE); ex.More(); ex.Next()) count++;
+                return count;
+            } catch (...) { return 0; }
+        }
+        """,
+        "OCCURRENCE",
+    ),
+]
+
+
+def self_test(verbose=True):
+    passed = 0
+    failed = []
+    for case_name, snippet, expected in SELF_TEST_CASES:
+        funcs = split_functions(snippet)
+        if not funcs:
+            failed.append((case_name, expected, "NO FUNCTION PARSED"))
+            continue
+        _, body = funcs[0]
+        verdict, reason = classify_body(body)
+        ok = verdict == expected
+        if ok:
+            passed += 1
+        else:
+            failed.append((case_name, expected, verdict))
+        if verbose:
+            status = "PASS" if ok else "FAIL"
+            print(f"[{status}] {case_name}: expected {expected}, got {verdict} ({reason})")
+    print(f"\nself-test: {passed}/{len(SELF_TEST_CASES)} cases correct")
+    if failed:
+        print("failures:")
+        for case_name, expected, got in failed:
+            print(f"  {case_name}: expected {expected}, got {got}")
+    return len(failed) == 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        ok = self_test()
+        return 0 if ok else 1
+    return run_report()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
+++ b/Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py
@@ -320,6 +320,15 @@ SELF_TEST_CASES = [
         # that itself contains a `return`. A version of this script that only knew how to
         # brace-match found that catch block's `{ return 0; }` instead of the (nonexistent) loop
         # braces, and misclassified every one of these three real functions as OTHER.
+        #
+        # NOTE (PR #693 review): this case does NOT prove `_loop_body_span`'s braceless dispatch
+        # (`if code[i] == "{"`) is load-bearing. Forcing that check to always take the brace-match
+        # path still lands on OCCURRENCE here, for a different reason (the depth-scan finds no
+        # zero-crossing at all inside a braceless body with no braces of its own until the
+        # trailing `catch`, so it returns None, and None defaults to OCCURRENCE too). Both the
+        # correct code and the broken code agree by accident. Kept as a regression test for the
+        # original brace-matching bug it documents; the dispatch guard itself is proven by
+        # `other_braceless_find_first_with_later_catch_return` below.
         "occurrence_braceless_loop_with_later_catch_return",
         """
         int32_t OCCTFakeBracelessLoop(OCCTShapeRef shape) {
@@ -333,6 +342,149 @@ SELF_TEST_CASES = [
         """,
         "OCCURRENCE",
     ),
+    (
+        # Same braceless-loop-then-catch shape as above, but the loop's single statement is
+        # itself a find-first (`return true;`), so the correct and broken answers diverge: forcing
+        # `if code[i] == "{"` to always take the brace-match path makes the depth-scan cross zero
+        # on the CATCH block's closing brace with the wrong starting depth (it dips negative on
+        # the `try`'s own closing brace first), never finds a legitimate zero-crossing, and
+        # returns None -- which silently defaults to OCCURRENCE instead of the correct OTHER.
+        "other_braceless_find_first_with_later_catch_return",
+        """
+        bool OCCTFakeBracelessFindFirst(OCCTShapeRef shape) {
+            try {
+                for (TopExp_Explorer ex(shape->shape, TopAbs_FACE); ex.More(); ex.Next())
+                    if (isTheOneWeWant(ex.Current())) return true;
+                return false;
+            } catch (...) { return false; }
+        }
+        """,
+        "OTHER",
+    ),
+    (
+        # Models the real `static Handle(Poly_Triangulation) occtMergedTriangulation(...)`
+        # (OCCTBridge_Document.mm). `Handle(Type)` nests a nested paren pair inside the return
+        # type, which FUNC_START_RE's single-level `\\(...\\)` parameter match cannot cross.
+        # `_blank_handle_macro` exists to blank it out before matching. With that guard
+        # neutered, FUNC_START_RE cannot match this function's signature line at all --
+        # `split_functions` returns no functions, and the case fails as NO FUNCTION PARSED,
+        # not as a misclassification. No prior case in this list contains the literal text
+        # `Handle(`, so this parser path was previously untested end to end.
+        "occurrence_handle_return_type",
+        """
+        static Handle(Poly_Triangulation) OCCTFakeHandleReturnType(const TopoDS_Shape& shape) {
+            int32_t count = 0;
+            for (TopExp_Explorer exp(shape, TopAbs_FACE); exp.More(); exp.Next()) {
+                count++;
+            }
+            if (count == 0) return Handle(Poly_Triangulation)();
+            return new Poly_Triangulation();
+        }
+        """,
+        "OCCURRENCE",
+    ),
+    (
+        # Models the real `OCCTShapeFixSolid` (OCCTBridge_Healing.mm), whose loop body carries a
+        # comment reading "...Shape() only ever returns the input solid, one fixed solid, or a
+        # compound." Unstripped, `\\breturn` matches inside "returns" (the word boundary check
+        # only anchors the START of the match) and `[^;]*` then swallows everything up to the
+        # next real semicolon, which lands well past the comment, in genuine code -- a false
+        # find-first match that flips the verdict from OCCURRENCE to OTHER. `strip_comments`'s
+        # line-comment removal is what keeps this from happening; disabling it moved the real
+        # census's OCCURRENCE/OTHER totals by one function in each direction (54/21 to 53/22),
+        # a real effect the PR's own self-test run never caught.
+        "occurrence_comment_contains_return_word",
+        """
+        int32_t OCCTFakeCommentMentionsReturn(OCCTShapeRef shape) {
+            int32_t count = 0;
+            for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
+                // Shape() only ever returns the input solid, one fixed solid, or a compound;
+                count++;
+            }
+            return count;
+        }
+        """,
+        "OCCURRENCE",
+    ),
+    (
+        # Same false-positive mechanism as the line-comment case above, for a `/* ... */` block
+        # comment instead. No real function in the current bridge hits this (the equivalent
+        # mutation leaves the real census unchanged), but the failure mode is identical and
+        # untested without this case: nothing currently proves `strip_comments`' block-comment
+        # removal is load-bearing, only that it happens not to matter yet.
+        "occurrence_block_comment_contains_return_word",
+        """
+        int32_t OCCTFakeBlockCommentMentionsReturn(OCCTShapeRef shape) {
+            int32_t count = 0;
+            for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
+                /* Shape() only ever returns the input solid, one fixed solid, or a compound; */
+                count++;
+            }
+            return count;
+        }
+        """,
+        "OCCURRENCE",
+    ),
+    (
+        # A TopExp_Explorer used purely as "give me the first item of this type", never looped:
+        # `.More()` is checked once and there is no `.Next()` anywhere in the function. Models
+        # the real `occtShellIsInsideSolid`/`OCCTShapeCreateHalfSpace`/`OCCTSolidFromShells`
+        # shape (OCCTBridge_Healing.mm / OCCTBridge_Modeling.mm), among others. `_loop_body_span`
+        # cannot find a loop body at all here (there is no `.Next()` to anchor the search on);
+        # the `if not next_match: return None` guard is what turns that into a graceful
+        # "no span found" (classify_body then falls through to its OCCURRENCE default) instead of
+        # an AttributeError crash calling `.end()` on `None`. Removing the guard does not change
+        # the verdict here (both paths land on OCCURRENCE, since a span-less call always takes the
+        # default) -- it crashes 10 real functions in the actual census outright, which is a
+        # stronger, not weaker, argument for testing it: a self-test that reports 6/6 while this
+        # guard has zero coverage is silent about a real crash-on-real-data risk. This case
+        # exists to keep that guard from being removed unnoticed even though it cannot, by
+        # construction, be proven via a verdict mismatch the way the other new cases are.
+        "occurrence_explorer_checked_once_no_next_call",
+        """
+        bool OCCTFakeNoNextCall(OCCTShapeRef shape) {
+            TopExp_Explorer exp(shape->shape, TopAbs_VERTEX);
+            if (!exp.More()) return false;
+            return true;
+        }
+        """,
+        "OCCURRENCE",
+    ),
+    (
+        # A TopExp_Explorer declared and never used again: no `.More()` call at all. Models the
+        # "unused/dead declaration" branch's own stated reason. This function is called directly
+        # by `self_test()`, bypassing `classify_file`'s own pre-filter (which only invokes
+        # `classify_body` when TopExp usage is already known to exist) -- so unlike in
+        # `run_report()`, a fixture reaching `classify_body` here is not guaranteed to have a
+        # live `.More()` call, and this is the only case that exercises that branch at all.
+        "other_dead_explorer_declaration",
+        """
+        int32_t OCCTFakeDeadExplorerDeclaration(OCCTShapeRef shape) {
+            TopExp_Explorer exp(shape->shape, TopAbs_FACE);
+            return 0;
+        }
+        """,
+        "OTHER",
+    ),
+    (
+        # No TopExp_Explorer or TopExp::MapShapes anywhere, but a DIFFERENT iterator's `.More()`
+        # call is present (`MORE_RE` matches any `.More()`, not just a TopExp_Explorer's). In
+        # `run_report()`, `classify_file`'s pre-filter means `classify_body` is never called on a
+        # function like this at all. `self_test()` calls `classify_body` directly, bypassing that
+        # filter -- so the `if not explorer_matches: return OTHER` guard is the only thing
+        # standing between this shape and `explorer_matches[0]` on an empty list, an IndexError.
+        "other_unrelated_iterator_no_topexp_usage",
+        """
+        int32_t OCCTFakeUnrelatedIterator(OCCTShapeRef shape) {
+            TDF_ChildIterator it(shape->label);
+            for (; it.More(); it.Next()) {
+                doSomething(it.Value());
+            }
+            return 0;
+        }
+        """,
+        "OTHER",
+    ),
 ]
 
 
@@ -342,10 +494,17 @@ def self_test(verbose=True):
     for case_name, snippet, expected in SELF_TEST_CASES:
         funcs = split_functions(snippet)
         if not funcs:
-            failed.append((case_name, expected, "NO FUNCTION PARSED"))
-            continue
-        _, body = funcs[0]
-        verdict, reason = classify_body(body)
+            verdict, reason = "NO FUNCTION PARSED", "split_functions() found no function in the fixture"
+        else:
+            _, body = funcs[0]
+            # A guard removed by mutation can turn a graceful "wrong verdict" into an
+            # uncaught exception (e.g. `_loop_body_span` dereferencing a None match). Catching
+            # it here keeps the report a clean per-case matrix instead of a bare traceback that
+            # stops evaluating every case after it -- the failure is exactly as real either way.
+            try:
+                verdict, reason = classify_body(body)
+            except Exception as exc:
+                verdict, reason = f"CRASH: {exc}", "unhandled exception in classify_body"
         ok = verdict == expected
         if ok:
             passed += 1

--- a/Scripts/repro/cluster-a-subshape-enumeration/main.swift
+++ b/Scripts/repro/cluster-a-subshape-enumeration/main.swift
@@ -1,0 +1,280 @@
+// Cluster A census (#664): does a public entry point read the deduplicated sub-shape map or the
+// raw TopExp_Explorer, and what does it return on a shape with duplicated orientations?
+//
+// This is the DYNAMIC half of the census: it builds the fixtures with the real Shape/Face/Wire
+// public API, calls every entry point identified by the Swift-side + bridge-side inventory sweep,
+// and prints the measured table. See README.md for the method, the full table and the
+// conclusions; `classify_topexp_sites.py` is the STATIC half (a source-level cross-check), and the
+// README records where the two disagree.
+//
+// Run with: swift run ClusterACensus
+
+import Foundation
+import OCCTSwift
+import simd
+
+// MARK: - Fixtures
+
+enum Fixture {
+    /// A single 10mm box, origin-centred (-5...5 on every axis). No sub-shape here is reachable
+    /// from more than one PARENT SHAPE, but every edge is still reachable from two adjacent faces
+    /// and every vertex from three edges within the one solid -- #502's own box measurement (24
+    /// edge occurrences over 12 distinct, 48 vertex occurrences over 8 distinct).
+    static func plainBox() -> Shape {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            fatalError("Shape.box failed")
+        }
+        return box
+    }
+
+    /// Two solids sharing one cut face, from one BRepAlgoAPI_Splitter run -- the exact
+    /// construction Tests/OCCTTopologyTests/Issue614FaceOrientationTests.swift uses (measured
+    /// there: 11 distinct faces, 12 face occurrences). `order` controls which half is compounded
+    /// first, which is #642's whole claim: AAG answers differently depending on this order alone.
+    static func splitBoxCompound(order: CompoundOrder) -> Shape {
+        guard let block = Shape.box(origin: .zero, width: 20, height: 10, depth: 10),
+              let plate = Shape.face(from: Wire.rectangle(width: 60, height: 60)!),
+              let upright = plate.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2),
+              let knife = upright.translated(by: SIMD3(10, 0, 0)),
+              let pieces = block.split(by: knife),
+              pieces.count == 2
+        else {
+            fatalError("could not build the split-box fixture")
+        }
+        let ordered = order == .asSplit ? pieces : pieces.reversed()
+        guard let compound = Shape.compound(Array(ordered)) else {
+            fatalError("Shape.compound failed")
+        }
+        return compound
+    }
+
+    enum CompoundOrder: String { case asSplit = "order A (lower, upper)", reversed = "order B (upper, lower)" }
+
+    /// A second two-solid split, cut HORIZONTALLY (z=4 through an origin-centred 10mm box) rather
+    /// than down the middle. #642's own measurement ("upward+horizontal node set [2,8] vs [2]")
+    /// needs the SHARED wall itself to be horizontal, which `splitBoxCompound` above is not: that
+    /// fixture cuts with a VERTICAL plane, so its shared wall's normal is horizontal-axis (X), not
+    /// vertical, and isHorizontal()/isUpward() never look at the duplicated face at all. Measuring
+    /// only that fixture would silently miss #642's actual claim -- this is exactly the kind of gap
+    /// a census is supposed to catch, not repeat.
+    static func horizontalSplitBoxCompound(order: CompoundOrder) -> Shape {
+        guard let block = Shape.box(width: 10, height: 10, depth: 10),
+              let pieces = block.split(atPlane: SIMD3(0, 0, 4), normal: SIMD3(0, 0, 1)),
+              pieces.count == 2
+        else {
+            fatalError("could not build the horizontal split-box fixture")
+        }
+        let ordered = order == .asSplit ? pieces : pieces.reversed()
+        guard let compound = Shape.compound(Array(ordered)) else {
+            fatalError("Shape.compound failed")
+        }
+        return compound
+    }
+}
+
+// MARK: - Report plumbing
+
+struct Row {
+    let family: String
+    let entryPoint: String
+    let plainBox: String
+    let orderA: String
+    let orderB: String
+    let note: String
+}
+
+nonisolated(unsafe) var rows: [Row] = []
+
+func record(_ family: String, _ entryPoint: String, plainBox: Any, orderA: Any, orderB: Any, note: String = "") {
+    rows.append(Row(family: family, entryPoint: entryPoint,
+                     plainBox: "\(plainBox)", orderA: "\(orderA)", orderB: "\(orderB)", note: note))
+}
+
+// MARK: - Fixtures under measurement
+
+let box = Fixture.plainBox()
+let compoundA = Fixture.splitBoxCompound(order: .asSplit)
+let compoundB = Fixture.splitBoxCompound(order: .reversed)
+let hCompoundA = Fixture.horizontalSplitBoxCompound(order: .asSplit)
+let hCompoundB = Fixture.horizontalSplitBoxCompound(order: .reversed)
+
+// MARK: - VERTEX family
+
+record("vertex", "vertexCount (dedup canonical)",
+       plainBox: box.vertexCount, orderA: compoundA.vertexCount, orderB: compoundB.vertexCount)
+record("vertex", "vertices().count (dedup)",
+       plainBox: box.vertices().count, orderA: compoundA.vertices().count, orderB: compoundB.vertices().count)
+record("vertex", "uniqueVertexCount (alias of vertexCount)",
+       plainBox: box.uniqueVertexCount, orderA: compoundA.uniqueVertexCount, orderB: compoundB.uniqueVertexCount)
+record("vertex", "subShapeCount(ofType: .vertex) (dedup canonical)",
+       plainBox: box.subShapeCount(ofType: .vertex), orderA: compoundA.subShapeCount(ofType: .vertex),
+       orderB: compoundB.subShapeCount(ofType: .vertex))
+record("vertex", "nbVertices (#651: docs say dedup)",
+       plainBox: box.nbVertices, orderA: compoundA.nbVertices, orderB: compoundB.nbVertices,
+       note: "occurrence; docs/reference/Document-Completions.md:1438 states box.nbVertices == 8")
+record("vertex", "contents.vertices (ShapeAnalysis_ShapeContents, occurrence)",
+       plainBox: box.contents.vertices, orderA: compoundA.contents.vertices, orderB: compoundB.contents.vertices)
+record("vertex", "contentsExtended().nbVertices (occurrence)",
+       plainBox: box.contentsExtended().nbVertices, orderA: compoundA.contentsExtended().nbVertices,
+       orderB: compoundB.contentsExtended().nbVertices)
+
+// MARK: - EDGE family
+
+record("edge", "edgeCount (dedup canonical)",
+       plainBox: box.edgeCount, orderA: compoundA.edgeCount, orderB: compoundB.edgeCount)
+record("edge", "edges().count (dedup)",
+       plainBox: box.edges().count, orderA: compoundA.edges().count, orderB: compoundB.edges().count)
+record("edge", "uniqueEdgeCount (alias of edgeCount)",
+       plainBox: box.uniqueEdgeCount, orderA: compoundA.uniqueEdgeCount, orderB: compoundB.uniqueEdgeCount)
+record("edge", "subShapeCount(ofType: .edge) (dedup canonical)",
+       plainBox: box.subShapeCount(ofType: .edge), orderA: compoundA.subShapeCount(ofType: .edge),
+       orderB: compoundB.subShapeCount(ofType: .edge))
+record("edge", "nbEdges (#651: docs say dedup)",
+       plainBox: box.nbEdges, orderA: compoundA.nbEdges, orderB: compoundB.nbEdges,
+       note: "occurrence; docs/reference/Document-Completions.md:1406 states box.nbEdges == 12")
+record("edge", "contents.edges (ShapeAnalysis_ShapeContents, occurrence)",
+       plainBox: box.contents.edges, orderA: compoundA.contents.edges, orderB: compoundB.contents.edges)
+record("edge", "contentsExtended().nbEdges (occurrence)",
+       plainBox: box.contentsExtended().nbEdges, orderA: compoundA.contentsExtended().nbEdges,
+       orderB: compoundB.contentsExtended().nbEdges)
+
+if let wireOfBox = box.wires.first {
+    record("edge", "Shape(wire).edgeCount (dedup; a wire's own edges, not the parent solid's)",
+           plainBox: wireOfBox.edgeCount, orderA: "n/a (single-solid wire)", orderB: "n/a",
+           note: "a wire's own edges aren't shared cross-parent in these fixtures")
+}
+
+// MARK: - FACE family
+
+record("face", "faceCount (dedup canonical, #541)",
+       plainBox: box.faceCount, orderA: compoundA.faceCount, orderB: compoundB.faceCount)
+record("face", "faces().count (dedup)",
+       plainBox: box.faces().count, orderA: compoundA.faces().count, orderB: compoundB.faces().count)
+record("face", "orientedFaces().count (occurrence, deliberate #614)",
+       plainBox: box.orientedFaces().count, orderA: compoundA.orientedFaces().count,
+       orderB: compoundB.orientedFaces().count,
+       note: "documented, paired counterpart of faces() -- not a defect")
+record("face", "uniqueFaceCount (alias of faceCount)",
+       plainBox: box.uniqueFaceCount, orderA: compoundA.uniqueFaceCount, orderB: compoundB.uniqueFaceCount)
+record("face", "subShapeCount(ofType: .face) (dedup canonical)",
+       plainBox: box.subShapeCount(ofType: .face), orderA: compoundA.subShapeCount(ofType: .face),
+       orderB: compoundB.subShapeCount(ofType: .face))
+record("face", "nbFaces (#651: docs say dedup)",
+       plainBox: box.nbFaces, orderA: compoundA.nbFaces, orderB: compoundB.nbFaces,
+       note: "occurrence; docs/reference/Document-Completions.md:1422 states box.nbFaces == 6 (no divergence on a plain box, since no face is shared)")
+record("face", "contents.faces (ShapeAnalysis_ShapeContents, occurrence)",
+       plainBox: box.contents.faces, orderA: compoundA.contents.faces, orderB: compoundB.contents.faces)
+record("face", "contentsExtended().nbFaces (occurrence)",
+       plainBox: box.contentsExtended().nbFaces, orderA: compoundA.contentsExtended().nbFaces,
+       orderB: compoundB.contentsExtended().nbFaces)
+record("face", "contentsExtended().nbSharedFaces (location-discarding dedup, a THIRD rule)",
+       plainBox: box.contentsExtended().nbSharedFaces, orderA: compoundA.contentsExtended().nbSharedFaces,
+       orderB: compoundB.contentsExtended().nbSharedFaces)
+
+record("face (occurrence-derived, already fixed)", "horizontalFaces().count (#614, reads orientedFaces())",
+       plainBox: box.horizontalFaces().count, orderA: compoundA.horizontalFaces().count,
+       orderB: compoundB.horizontalFaces().count)
+record("face (occurrence-derived, already fixed)", "upwardFaces().count (#614, reads orientedFaces())",
+       plainBox: box.upwardFaces().count, orderA: compoundA.upwardFaces().count,
+       orderB: compoundB.upwardFaces().count)
+record("face (occurrence-derived, already fixed)", "facesByZLevel() total (#614, reads horizontalFaces())",
+       plainBox: box.facesByZLevel().values.reduce(0) { $0 + $1.count },
+       orderA: compoundA.facesByZLevel().values.reduce(0) { $0 + $1.count },
+       orderB: compoundB.facesByZLevel().values.reduce(0) { $0 + $1.count })
+record("face (occurrence-derived, already fixed)", "upwardFaces().count [horizontal-cut fixture]",
+       plainBox: box.upwardFaces().count, orderA: hCompoundA.upwardFaces().count,
+       orderB: hCompoundB.upwardFaces().count,
+       note: "corroborates #642's own table: #614's fix IS order-independent on the SAME fixture AAG is not")
+
+// MARK: - #642: AAG rides the lossy faces()
+//
+// Measured on BOTH split fixtures. The vertical-cut compound (compoundA/B) shares a face whose
+// normal is horizontal-axis, so it never touches isHorizontal()/isUpward() at all -- a census that
+// stopped there would wrongly conclude AAG is order-INDEPENDENT. The horizontal-cut compound
+// (hCompoundA/B) shares a face whose normal IS vertical, which is #642's actual claim.
+
+let aagA = compoundA.buildAAG()
+let aagB = compoundB.buildAAG()
+record("face (AAG, #642)", "buildAAG().nodes.count [vertical-cut fixture]",
+       plainBox: box.buildAAG().nodes.count, orderA: aagA.nodes.count, orderB: aagB.nodes.count)
+let upwardHorizontalA = aagA.nodes.filter { $0.isUpward && $0.isHorizontal }.count
+let upwardHorizontalB = aagB.nodes.filter { $0.isUpward && $0.isHorizontal }.count
+record("face (AAG, #642)", "AAG upward+horizontal count [vertical-cut fixture]",
+       plainBox: "n/a", orderA: upwardHorizontalA, orderB: upwardHorizontalB,
+       note: "shared wall's normal is horizontal-axis here, so it never reaches isHorizontal() -- order-independent by construction, not by a fix")
+record("face (AAG, #642)", "detectPocketsAAG().count [vertical-cut fixture]",
+       plainBox: box.detectPocketsAAG().count, orderA: compoundA.detectPocketsAAG().count,
+       orderB: compoundB.detectPocketsAAG().count,
+       note: "no pocket geometry here regardless of order -- this fixture does not exercise #642")
+
+let hAagA = hCompoundA.buildAAG()
+let hAagB = hCompoundB.buildAAG()
+record("face (AAG, #642)", "buildAAG().nodes.count [horizontal-cut fixture]",
+       plainBox: box.buildAAG().nodes.count, orderA: hAagA.nodes.count, orderB: hAagB.nodes.count)
+let hUpwardHorizontalIdxA = hAagA.nodes.enumerated().filter { $0.element.isUpward && $0.element.isHorizontal }.map(\.offset)
+let hUpwardHorizontalIdxB = hAagB.nodes.enumerated().filter { $0.element.isUpward && $0.element.isHorizontal }.map(\.offset)
+record("face (AAG, #642)", "AAG upward+horizontal NODE INDICES [horizontal-cut fixture]",
+       plainBox: "n/a", orderA: "\(hUpwardHorizontalIdxA)", orderB: "\(hUpwardHorizontalIdxB)",
+       note: "the shared wall's node keeps whichever half's orientation faces() reached first -- this is the #642 mechanism")
+record("face (AAG, #642)", "detectPocketsAAG().count [horizontal-cut fixture]",
+       plainBox: box.detectPocketsAAG().count, orderA: hCompoundA.detectPocketsAAG().count,
+       orderB: hCompoundB.detectPocketsAAG().count,
+       note: "THE #642 HEADLINE MEASUREMENT -- same geometry, order-dependent answer if it reproduces here")
+
+// MARK: - WIRE family
+
+record("wire", "wireCount (forwards to subShapeCount(.wire), dedup)",
+       plainBox: box.wireCount, orderA: compoundA.wireCount, orderB: compoundB.wireCount)
+record("wire", "wires.count (dedup)",
+       plainBox: box.wires.count, orderA: compoundA.wires.count, orderB: compoundB.wires.count)
+record("wire", "subShapeCount(ofType: .wire) (dedup canonical)",
+       plainBox: box.subShapeCount(ofType: .wire), orderA: compoundA.subShapeCount(ofType: .wire),
+       orderB: compoundB.subShapeCount(ofType: .wire))
+record("wire", "contents.wires (occurrence)",
+       plainBox: box.contents.wires, orderA: compoundA.contents.wires, orderB: compoundB.contents.wires)
+
+// MARK: - SHELL family
+
+record("shell", "shellCount (forwards to subShapeCount(.shell), dedup)",
+       plainBox: box.shellCount, orderA: compoundA.shellCount, orderB: compoundB.shellCount)
+record("shell", "shells.count (dedup)",
+       plainBox: box.shells.count, orderA: compoundA.shells.count, orderB: compoundB.shells.count)
+record("shell", "subShapeCount(ofType: .shell) (dedup canonical)",
+       plainBox: box.subShapeCount(ofType: .shell), orderA: compoundA.subShapeCount(ofType: .shell),
+       orderB: compoundB.subShapeCount(ofType: .shell))
+record("shell", "outerShells.count (occurrence explorer, #439 restricts to per-solid use)",
+       plainBox: box.outerShells.count, orderA: compoundA.outerShells.count, orderB: compoundB.outerShells.count)
+
+// MARK: - SOLID family
+
+record("solid", "solidCount (forwards to subShapeCount(.solid), dedup)",
+       plainBox: box.solidCount, orderA: compoundA.solidCount, orderB: compoundB.solidCount)
+record("solid", "solids.count (dedup)",
+       plainBox: box.solids.count, orderA: compoundA.solids.count, orderB: compoundB.solids.count)
+record("solid", "subShapeCount(ofType: .solid) (dedup canonical)",
+       plainBox: box.subShapeCount(ofType: .solid), orderA: compoundA.subShapeCount(ofType: .solid),
+       orderB: compoundB.subShapeCount(ofType: .solid))
+
+// MARK: - Print the table
+
+func pad(_ s: String, _ width: Int) -> String {
+    s.count >= width ? s : s + String(repeating: " ", count: width - s.count)
+}
+
+let header = ["family", "entry point", "plain box", "order A", "order B", "note"]
+let widths = [30, 62, 12, 10, 10, 90]
+
+print(zip(header, widths).map { pad($0, $1) }.joined(separator: " | "))
+print(widths.map { String(repeating: "-", count: $0) }.joined(separator: "-|-"))
+for row in rows {
+    let cells = [row.family, row.entryPoint, row.plainBox, row.orderA, row.orderB, row.note]
+    print(zip(cells, widths).map { pad($0, $1) }.joined(separator: " | "))
+}
+
+print()
+print("fixtures:")
+print("  plain box:  Shape.box(width: 10, height: 10, depth: 10) -- one solid, no cross-parent sharing")
+print("  order A:    Fixture.splitBoxCompound(order: .asSplit)   -- two solids, cut face shared, split-order kept")
+print("  order B:    Fixture.splitBoxCompound(order: .reversed)  -- same geometry, compound member order reversed")
+print()
+print("row count: \(rows.count)")


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Cluster A (#664) names `Scripts/repro/cluster-a-subshape-enumeration/` a hard prerequisite before
any of its member issues (#638, #642, #651) can start, per `docs/v2.0.0-plan.md`'s census-once
rule: build the census once, as a committed executable artifact, rather than let each member issue
rebuild it from scratch by grep and get it wrong differently.

This PR is the census only. It does not fix #638, #642 or #651.

Two independent halves, per #664's own warning that a grep undercounts this family (#558 said 14
sites, measured 28; #571 said 3, measured 6; #583 said five, measured six; #595 said six, measured
nine):

1. **Dynamic (primary).** `Scripts/repro/cluster-a-subshape-enumeration/main.swift`, built as the
   `ClusterACensus` executable target (`swift run ClusterACensus`), builds a plain box and two
   duplicated-orientation compound fixtures with the real public `Shape`/`Face`/`Wire` API, then
   calls every identified public sub-shape enumeration entry point on each, printing 45 measured
   rows.
2. **Static (secondary cross-check).** `classify_topexp_sites.py` classifies every
   `TopExp_Explorer`/`TopExp::MapShapes` call site in the bridge (127 functions: 52 DEDUP, 54
   OCCURRENCE, 21 OTHER).

Full method, fixtures, results table, static/dynamic disagreement log and re-scoping writeup in
`Scripts/repro/cluster-a-subshape-enumeration/README.md`.

## Headline findings

- Already-correct entry points (`faces()`/`orientedFaces()` per #614, all six `subShapeCount`
  families per #502/#541, `horizontalFaces()`/`upwardFaces()`/`facesByZLevel()` per #614) measured
  order-independent on both split fixtures. Any Cluster A fix has to leave these unchanged.
- #651 confirmed exactly: `nbEdges`/`nbFaces`/`nbVertices` are occurrence counts, the docs say
  dedup, and they are pure duplicates of `edgeCount`/`faceCount`/`vertexCount` in every fixture
  measured, so the #490/#491/#492 retire-the-duplicate precedent applies.
- #642 reproduced exactly (`detectPocketsAAG()` 2 vs 1, node set `[2, 8]` vs `[2]`), but only on a
  fixture whose shared wall is itself horizontal. #614's own committed test fixture (a vertical
  cut) does not exercise this defect at all, a correction posted on #642.
- #638's consumer audit (its own stated "first task") is done and found nothing: no public member
  on `Edge` exposes a stored orientation, and the one edge-orientation branch in the whole bridge
  reads a fresh wire-explorer walk, not `Shape.edges()`.
- Re-scoping: the three members are three different, independent fixes, not one fix in three
  places. #642 shares its root mechanism with #614 but not its fix (AAG needs its own node-identity
  redesign); #651 is orthogonal to orientation entirely; #638's own open question is answered
  "probably not, on current evidence" by the audit above, but that call is #638's to make.

Two real bugs were found and fixed in the static classifier while building it (a nested-paren
return-type parse failure, and a braceless-loop body mismatched against the wrong braces).

**Update: a review of this PR found the self-test claim above was wrong.** Disabling either guard
left the self-test at 6/6 unchanged; neither case actually exercised the guard it was named after.
Per `okf/policies/prove-the-test-fails.md`, that makes both decorative, not proven. Fixed by adding
fixtures that actually fail when each guard is removed, then auditing every other conditional in
the classifier the same way rather than stopping at the two reported. Two more turned out to be
load-bearing on the real 127-function corpus with zero coverage (one of them a crash on 10 real
functions, not just a misclassification); three more guard `self_test()`'s own direct-call path and
were given coverage too; five are provably unreachable given how the classifier is built and were
left uncovered on that basis, not by oversight. Full guard-removal matrix, one row per guard, is in
the README's "Self-test guard-removal matrix" section (replacing the old "Self-test, proven"
table, which is what asserted the now-retracted claim).

Refs #664. Comments posted on #664, #638, #642 and #651 with the findings and corrections above.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification). N/A in the literal sense: this PR changes no runtime behavior. Its own
      correctness claims are backed by a runnable, committed measurement program
      (`ClusterACensus`) and a self-tested static classifier (`classify_topexp_sites.py
      --self-test`, 13/13, with every one of the classifier's 15 guards individually removed and
      checked against both the self-test and the real 127-function report; see the README's
      guard-removal matrix).

## Notes for the reviewer

- Addresses the blocking review comment ("Verification: the census is good, the classifier's
  `--self-test` is decorative"). See the "Update" paragraph above and the README's guard-removal
  matrix for the full response.
- `swift run ClusterACensus` and `python3 Scripts/repro/cluster-a-subshape-enumeration/classify_topexp_sites.py`
  regenerate the tables from the pinned kernel and the current tree respectively. Both still report
  the same totals as before this fix (45 rows; 127 functions, 52 DEDUP, 54 OCCURRENCE, 21 OTHER):
  this pass changed the self-test's own coverage of the classifier, not the classifier's behavior.
- Clean `swift build`, 0 errors, no `OCCTSWIFT_LOCAL` (pins `v2.0.0-kernel.1`).
- Full `swift test`: 5320 tests passing, matching the documented baseline exactly.
- All four gate scripts exit 0, plus the three `--self-test`s: `check-bridge-index`,
  `check-null-handle-guards`, `check-docs-defaults` (both with and without `--self-test`), and
  `count-operations` (no `--self-test` by design).
- Zero em-dashes in the diff, PR text and the four GitHub comments this PR's description links to.

