### PR TITLE
docs(#638): edges() keeps its orientation collapse, audited, no consumer needs it

### DIFF
--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -183,7 +183,7 @@ public final class Edge: @unchecked Sendable {
 
     /// The 3D curve underlying this edge as a standalone `Curve3D`.
     ///
-    /// Returns nil for edges with no 3D curve representation (rare — typically
+    /// Returns nil for edges with no 3D curve representation (rare, typically
     /// pcurve-only edges from lofted / swept shapes before `BuildCurves3d`).
     /// Internally the returned curve is a `Geom_TrimmedCurve` over the edge's
     /// parameter range, so consumers get a finite handle even when the
@@ -242,11 +242,17 @@ public final class Edge: @unchecked Sendable {
 // MARK: - Shape Extension for Edge Access
 
 extension Shape {
-    /// Get total number of edges in the shape
+    /// The number of **distinct** edges in this shape, the same `TopExp::MapShapes` enumeration
+    /// ``edges()``/``edge(at:)`` walk.
+    ///
+    /// An edge reachable from two adjacent faces is counted once here, not once per face: a plain
+    /// box has 12 edges by this count even though every one of them borders two faces. See
+    /// ``edges()`` for the identity rule this follows and why it does not need an
+    /// orientation-preserving counterpart the way ``Shape/faces()`` does.
     public var edgeCount: Int {
         Int(OCCTShapeGetTotalEdgeCount(handle))
     }
-    
+
     /// Get edge by index (0-based)
     /// - Parameter index: The edge index
     /// - Returns: Edge at the given index, or nil if index is out of bounds
@@ -256,19 +262,48 @@ extension Shape {
         }
         return Edge(handle: edgeHandle, index: index)
     }
-    
-    /// Get all edges from the shape
+
+    /// Every **distinct** edge of this shape, in enumeration order: the same `TopExp::MapShapes`
+    /// enumeration ``edgeCount`` counts.
+    ///
+    /// ## Identity, not orientation
+    ///
+    /// Edges are distinguished the way OCCT distinguishes them for an index: by
+    /// `TopoDS_Shape::IsSame`, which compares the underlying curve and placement and **ignores
+    /// orientation**. An edge reachable from two owners, the ordinary case of any two adjacent
+    /// faces on one solid, collapses to a single entry here, carrying whichever orientation was
+    /// reached first.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.edges().count)    // 12: the distinct, addressable edges
+    /// print(box.contents.edges)   // 24: one per (face, edge) visit, ShapeAnalysis_ShapeContents
+    /// ```
+    ///
+    /// Unlike ``Shape/faces()``, this collapse is **not** a defect (#638, following #614's own
+    /// method rather than assuming the analogy holds). #614 was a defect because
+    /// `Face.normal(atU:v:)` reverses on `TopAbs_REVERSED`, so a face's stored orientation changes
+    /// the answer. `Edge` has no such consumer: it exposes no `.orientation` accessor at all, and
+    /// every geometric query on it, ``Edge/tangent(at:)``, ``Edge/point(at:)``,
+    /// ``Edge/parameterBounds``, ``Edge/curvature(at:)``, reads the edge's underlying `Geom_Curve`
+    /// through `BRep_Tool::Curve`, which is defined independently of `TopAbs_Orientation`. A
+    /// bridge-wide audit found no site that derives an orientation-dependent answer from an edge
+    /// obtained here; the one edge-orientation branch in the bridge
+    /// (`occtSampleWirePoints`) reads orientation fresh off a `BRepTools_WireExplorer` walk of the
+    /// wire it samples, not from an edge this method returns. If a future `Edge.orientation`
+    /// accessor or an orientation-sensitive consumer is added, re-run that audit before assuming
+    /// the collapse is still safe. See `Scripts/repro/cluster-a-subshape-enumeration/`.
     public func edges() -> [Edge] {
         let count = edgeCount
         var edges = [Edge]()
         edges.reserveCapacity(count)
-        
+
         for i in 0..<count {
             if let edge = edge(at: i) {
                 edges.append(edge)
             }
         }
-        
+
         return edges
     }
 }

--- a/Tests/OCCTTopologyTests/Issue638EdgeOrientationContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue638EdgeOrientationContractTests.swift
@@ -1,0 +1,204 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #638: `Shape.edges()` has the identical `TopExp::MapShapes`/`IsSame` collapse #614 fixed for
+// `faces()`: 24 edge occurrences over 12 distinct edges on a plain box. #614 was a defect because
+// `Face.normal(atU:v:)` reverses on `TopAbs_REVERSED`, so a face's stored orientation changes the
+// answer it returns. This issue's own text refuses the analogy and asks for the equivalent
+// question to be answered for edges before assuming it is the same bug.
+//
+// The consumer audit (Cluster A's census, #664, `Scripts/repro/cluster-a-subshape-enumeration/`)
+// found none: `Edge` exposes no `.orientation` accessor, and a bridge-wide grep for
+// `.Orientation() ==` finds 14 sites, 13 face-related (already #614's territory) and one
+// (`occtSampleWirePoints`) that reads orientation fresh off a wire traversal, never from an edge
+// `Shape.edges()` produced. The decision is: document the collapse, add no `orientedEdges()`,
+// change no behaviour.
+//
+// These tests pin both halves of that decision so a future change cannot silently invalidate it.
+//  1. The dedup mechanism itself: `edges()`/`edgeCount` must stay the IsSame-keyed enumeration,
+//     not drift to a per-occurrence walk.
+//  2. The reason the collapse is safe: every geometric accessor on `Edge` must keep reading the
+//     underlying curve independently of the edge's own `TopAbs_Orientation`, verified directly by
+//     constructing the identical edge with both orientations and comparing every accessor.
+
+@Suite("edges() keeps its orientation collapse, and nothing reads the lost side (#638)")
+struct Issue638EdgeOrientationContractTests {
+
+    // MARK: - 1. The dedup mechanism does not regress
+
+    /// The headline measurement from the issue and the census: 24 occurrences, 12 distinct, on a
+    /// plain box. `contents.edges` is the independent, already-documented (#541) occurrence
+    /// oracle: it does not go through `edges()`/`edgeCount` at all, so it is not circular.
+    @Test("a plain box: 12 distinct edges, 24 occurrences")
+    func plainBoxEdgeCollapse() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        #expect(box.edgeCount == 12)
+        #expect(box.edges().count == 12)
+        #expect(box.subShapeCount(ofType: .edge) == 12)
+        #expect(box.contents.edges == 24)
+    }
+
+    /// The same collapse on a shape that genuinely shares an edge across two solids: #614's own
+    /// fixture, reused rather than re-derived. `edges()` must stay at the dedup count (20), not
+    /// drift toward the per-occurrence count.
+    @Test("a split-box compound: edges() stays on the dedup count")
+    func splitCompoundEdgeCollapse() {
+        guard let compound = Issue614FaceOrientationTests.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+
+        #expect(compound.edgeCount == 20)
+        #expect(compound.edges().count == 20)
+        #expect(compound.subShapeCount(ofType: .edge) == 20)
+        // Every edge of the shared wall (4 of them) is walked from both owning solids: the
+        // occurrence count is strictly greater than the distinct count.
+        #expect(compound.contents.edges > compound.edgeCount)
+    }
+
+    /// Every edge handed out by `edges()` is addressable through `edge(at:)` at its own position,
+    /// the same indexing guarantee `faces()`/`faceCount` carry (#541), stated here for edges so a
+    /// future change cannot quietly break it while this suite is green.
+    @Test("every entry in edges() is addressable by its own index")
+    func edgesAreAddressableByIndex() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let edges = box.edges()
+        #expect(edges.count == box.edgeCount)
+        for (i, edge) in edges.enumerated() {
+            #expect(edge.index == i)
+            #expect(box.edge(at: i) != nil)
+        }
+    }
+
+    // MARK: - 2. Edge's accessors do not depend on the collapsed-away orientation
+
+    /// Build the identical edge with both `TopAbs_Orientation`s and compare every geometric
+    /// accessor `Edge` exposes. If any of these ever starts reading orientation (e.g. an
+    /// orientation-aware `BRepAdaptor_Curve` replacing today's `BRep_Tool::Curve`), this is the
+    /// test that catches it. The pair below is guaranteed opposite by construction
+    /// (`Shape.reversed`), not by hoping a fixture's topology happens to produce two orientations.
+    @Test("Edge's per-instance accessors do not depend on TopAbs_Orientation")
+    func edgeAccessorsAreOrientationIndependent() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let forwardShape = box.subShapes(ofType: .edge).first,
+              let reversedShape = forwardShape.reversed,
+              let forwardEdge = Edge(forwardShape),
+              let reversedEdge = Edge(reversedShape)
+        else {
+            Issue.record("could not build a forward/reversed edge pair")
+            return
+        }
+
+        // The construction really did flip the flag; otherwise every comparison below would pass
+        // vacuously by comparing an edge against itself in all but name.
+        #expect(forwardShape.orientation != reversedShape.orientation)
+
+        #expect(forwardEdge.length == reversedEdge.length)
+        #expect(forwardEdge.isLine == reversedEdge.isLine)
+        #expect(forwardEdge.isCircle == reversedEdge.isCircle)
+        #expect(forwardEdge.curveType == reversedEdge.curveType)
+
+        let fBounds = forwardEdge.parameterBounds
+        let rBounds = reversedEdge.parameterBounds
+        #expect(fBounds != nil && rBounds != nil)
+        if let fBounds, let rBounds {
+            #expect(fBounds.first == rBounds.first)
+            #expect(fBounds.last == rBounds.last)
+        }
+
+        // Sample several parameters across the edge's own range, not just the midpoint.
+        if let bounds = fBounds {
+            for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
+                let param = bounds.first + t * (bounds.last - bounds.first)
+                let fp = forwardEdge.point(at: param)
+                let rp = reversedEdge.point(at: param)
+                #expect(fp != nil && rp != nil)
+                if let fp, let rp {
+                    #expect(fp == rp, "point(at: \(param)) diverged: \(fp) vs \(rp)")
+                }
+
+                let ft = forwardEdge.tangent(at: param)
+                let rt = reversedEdge.tangent(at: param)
+                #expect(ft != nil && rt != nil)
+                if let ft, let rt {
+                    #expect(ft == rt, "tangent(at: \(param)) diverged: \(ft) vs \(rt)")
+                }
+
+                let fc = forwardEdge.curvature(at: param)
+                let rc = reversedEdge.curvature(at: param)
+                #expect(fc == rc, "curvature(at: \(param)) diverged: \(String(describing: fc)) vs \(String(describing: rc))")
+            }
+        }
+
+        // endpoints/bounds/points(count:) are whole-edge queries; still must agree.
+        #expect(forwardEdge.endpoints.start == reversedEdge.endpoints.start)
+        #expect(forwardEdge.endpoints.end == reversedEdge.endpoints.end)
+        #expect(forwardEdge.bounds.min == reversedEdge.bounds.min)
+        #expect(forwardEdge.bounds.max == reversedEdge.bounds.max)
+    }
+
+    /// Same comparison, on a circular edge rather than a straight one, so the claim isn't
+    /// accidentally true only for lines (whose tangent direction some implementations special-case).
+    @Test("Edge's accessors are orientation-independent on a circular edge too")
+    func edgeAccessorsAreOrientationIndependentOnACircle() {
+        let cyl = Shape.cylinder(radius: 5, height: 10)!
+        guard let circleShape = cyl.subShapes(ofType: .edge).first(where: { shape in
+            guard let e = Edge(shape) else { return false }
+            return e.isCircle
+        }) else {
+            Issue.record("no circular edge found on the cylinder")
+            return
+        }
+        guard let reversedShape = circleShape.reversed,
+              let forwardEdge = Edge(circleShape),
+              let reversedEdge = Edge(reversedShape)
+        else {
+            Issue.record("could not build a forward/reversed circular edge pair")
+            return
+        }
+
+        #expect(circleShape.orientation != reversedShape.orientation)
+        #expect(forwardEdge.length == reversedEdge.length)
+
+        guard let bounds = forwardEdge.parameterBounds else {
+            Issue.record("circular edge reported no parameter bounds")
+            return
+        }
+        for t in [0.0, 0.3, 0.6, 1.0] {
+            let param = bounds.first + t * (bounds.last - bounds.first)
+            #expect(forwardEdge.point(at: param) == reversedEdge.point(at: param))
+            #expect(forwardEdge.tangent(at: param) == reversedEdge.tangent(at: param))
+        }
+    }
+
+    /// `adjacentFaces(in:)` is a relationship lookup, not a curve evaluation, but it takes the
+    /// edge's own handle. Pin that it too resolves the same pair of faces regardless of which
+    /// orientation the caller's `Edge` happens to carry.
+    @Test("adjacentFaces(in:) does not depend on the edge's own orientation")
+    func adjacentFacesIsOrientationIndependent() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let forwardShape = box.subShapes(ofType: .edge).first,
+              let reversedShape = forwardShape.reversed,
+              let forwardEdge = Edge(forwardShape),
+              let reversedEdge = Edge(reversedShape)
+        else {
+            Issue.record("could not build a forward/reversed edge pair")
+            return
+        }
+
+        guard let (f1, f2) = forwardEdge.adjacentFaces(in: box),
+              let (r1, r2) = reversedEdge.adjacentFaces(in: box)
+        else {
+            Issue.record("edge reported no adjacent faces")
+            return
+        }
+        // Same physical pair of faces either way (order may or may not be preserved, so compare
+        // as sets of index; every face here carries a valid index from box.faces()).
+        let forwardIndices = Set([f1, f2].compactMap { $0?.index })
+        let reversedIndices = Set([r1, r2].compactMap { $0?.index })
+        #expect(!forwardIndices.isEmpty)
+        #expect(forwardIndices == reversedIndices)
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue638EdgeOrientationContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue638EdgeOrientationContractTests.swift
@@ -194,11 +194,27 @@ struct Issue638EdgeOrientationContractTests {
             Issue.record("edge reported no adjacent faces")
             return
         }
-        // Same physical pair of faces either way (order may or may not be preserved, so compare
-        // as sets of index; every face here carries a valid index from box.faces()).
-        let forwardIndices = Set([f1, f2].compactMap { $0?.index })
-        let reversedIndices = Set([r1, r2].compactMap { $0?.index })
-        #expect(!forwardIndices.isEmpty)
-        #expect(forwardIndices == reversedIndices)
+        // Compare geometry, not `Face.index`. `adjacentFaces(in:)` builds its results with
+        // `Face(handle:)` and no index argument, so every face it returns carries the default
+        // `index` of -1. An earlier version of this test compared `Set([f1, f2].compactMap
+        // { $0?.index })` against the same for the reversed edge, which is always `{-1} == {-1}`:
+        // it passed no matter which faces came back, including none of the right ones.
+        //
+        // Bounding boxes are enough to identify a box's planar faces and are cheap. Order is not
+        // guaranteed, so compare as sets.
+        func fingerprint(_ face: Face?) -> String? {
+            guard let face else { return nil }
+            let b = face.bounds
+            return String(format: "%.6f,%.6f,%.6f/%.6f,%.6f,%.6f",
+                          b.min.x, b.min.y, b.min.z, b.max.x, b.max.y, b.max.z)
+        }
+        let forwardFaces = Set([f1, f2].compactMap(fingerprint))
+        let reversedFaces = Set([r1, r2].compactMap(fingerprint))
+
+        // Without this the comparison could pass on two empty sets, which is the same vacuity in
+        // a different coat.
+        #expect(forwardFaces.count == 2,
+                "expected two adjacent faces on a box edge, got \(forwardFaces.count)")
+        #expect(forwardFaces == reversedFaces)
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,43 @@ longer the case: see "CI builds the same kernel the branch is written against" a
 kernel, and `ci.yml`'s macOS job is a real signal. `OCCTSWIFT_LOCAL=1` remains useful for iterating
 on a locally rebuilt kernel; it is no longer needed for correct results.
 
+#### `edges()` keeps its orientation collapse: audited, no consumer needs it (#638)
+
+Documentation only, no code change.
+
+`Shape.edges()` has the identical `TopExp::MapShapes`/`IsSame` collapse #614 fixed for `faces()`:
+an edge reachable from two owners collapses to one entry carrying whichever orientation was reached
+first. Measured on a plain box, `edges().count`/`edgeCount` report 12 distinct edges while
+`Shape.contents.edges` (an independent, already-documented occurrence count) reports 24: one per
+(face, edge) visit.
+
+#614 was a defect because `Face.normal(atU:v:)` reverses on `TopAbs_REVERSED`, so a face's stored
+orientation changed the answer a caller got. This issue's own text refused the analogy and asked
+whether the same is true for edges before assuming it. It is not: `Edge` exposes no `.orientation`
+accessor at all, and every geometric query on it (`tangent(at:)`, `point(at:)`, `parameterBounds`,
+`curvature(at:)`) reads the edge's underlying `Geom_Curve` through `BRep_Tool::Curve`, which is
+defined independently of `TopAbs_Orientation`. A bridge-wide grep for `.Orientation() ==` across
+`Sources/OCCTBridge/src/*.mm` finds 14 branching sites: 13 are face-normal logic #614 already
+covers, and the fourteenth (`occtSampleWirePoints`, `OCCTBridge_Modeling.mm`) reads orientation
+fresh off a `BRepTools_WireExplorer` walk of the wire it samples, never from an edge `Shape.edges()`
+produced.
+
+Verified beyond the source read: constructing the identical edge with both `TopAbs_Orientation`s
+(`Shape.subShape(type:index:).reversed`) and comparing every accessor `Edge` exposes shows them
+bit-for-bit identical, on both a straight and a circular edge.
+
+**Decision: document the contract, add no `orientedEdges()`, change no behaviour.** This is the
+outcome this issue's own text names as correct when no orientation-dependent consumer exists.
+`Shape.edges()`/`edgeCount`'s doc comments and `docs/reference/Edge.md` now state the collapse
+explicitly, matching how `Shape.faces()` documents its own. Regression tests in
+`Tests/OCCTTopologyTests/Issue638EdgeOrientationContractTests.swift` pin both halves: the dedup
+mechanism itself (12 distinct / 24 occurrences on a box, 20 distinct on the #614 split fixture), and
+the orientation-independence of `Edge`'s per-instance accessors, verified by injecting a
+hypothetical orientation-aware tangent and watching it fail before restoring it.
+
+See [`Scripts/repro/cluster-a-subshape-enumeration/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/cluster-a-subshape-enumeration)
+(#664) for the full census this decision rests on.
+
 #### Ten carried kernel patches retired
 
 8.0.1 ships our own upstream contributions, so `Scripts/patches/` goes from 21 files to 11.

--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -497,11 +497,13 @@ These members are declared on `Shape` in `Edge.swift` and provide indexed access
 
 ### `edgeCount`
 
-The total number of edges in the shape.
+The number of **distinct** edges in the shape: the same `TopExp::MapShapes` enumeration `edges()`/`edge(at:)` walk.
 
 ```swift
 public var edgeCount: Int { get }
 ```
+
+An edge reachable from two adjacent faces is counted once, not once per face. See `edges()` below for the identity rule and why it needs no orientation-preserving counterpart.
 
 - **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE, map)` → `map.Extent()` via `TopTools_IndexedMapOfShape`.
 - **Example:**
@@ -541,10 +543,20 @@ Returns all edges from the shape as typed `Edge` objects.
 public func edges() -> [Edge]
 ```
 
-Iterates `edge(at:)` from 0 to `edgeCount - 1`. The order matches `edgeCount` / `edge(at:)` — i.e., `TopTools_IndexedMapOfShape` traversal order, which can vary between runs.
+Iterates `edge(at:)` from 0 to `edgeCount - 1`. The order matches `edgeCount` / `edge(at:)`, i.e., `TopTools_IndexedMapOfShape` traversal order, which can vary between runs.
+
+**Identity, not orientation.** Edges are distinguished the way OCCT distinguishes them for an index: by `TopoDS_Shape::IsSame`, which compares the underlying curve and placement and ignores orientation. An edge reachable from two owners, the ordinary case of any two adjacent faces on one solid, collapses to a single entry here, carrying whichever orientation was reached first:
+
+```swift
+let box = Shape.box(width: 10, height: 10, depth: 10)!
+print(box.edges().count)    // 12: the distinct, addressable edges
+print(box.contents.edges)   // 24: one per (face, edge) visit, ShapeAnalysis_ShapeContents
+```
+
+Unlike `Shape.faces()`, this collapse is **not** a defect (#638). #614 made `faces()`'s equivalent collapse a bug because `Face.normal(atU:v:)` reverses on `TopAbs_REVERSED`, so a face's stored orientation changes the answer it returns. `Edge` has no such consumer: it exposes no `.orientation` accessor at all, and every geometric query on it (`tangent(at:)`, `point(at:)`, `parameterBounds`, `curvature(at:)`) reads the edge's underlying `Geom_Curve` through `BRep_Tool::Curve`, which is defined independently of `TopAbs_Orientation`. A bridge-wide audit (`grep -rn "\.Orientation() =="` across `Sources/OCCTBridge/src/*.mm`) found 14 branching sites: 13 are face-normal logic `faces()`/`orientedFaces()` already cover, and the fourteenth (`occtSampleWirePoints`, `OCCTBridge_Modeling.mm`) reads orientation fresh off a `BRepTools_WireExplorer` walk of the wire it samples, not from an edge this method returns. So there is currently no `orientedEdges()` counterpart to `edges()`: nothing needs one. See `Scripts/repro/cluster-a-subshape-enumeration/` for the full census this rests on.
 
 - **Returns:** Array of all `Edge` objects; empty if the shape has no edges.
-- **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE)` — collects all edges via indexed map.
+- **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE)`, collects all edges via indexed map.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`Shape.edges()` has the identical `TopExp::MapShapes`/`IsSame` collapse #614 fixed for `faces()`:
an edge reachable from two owners collapses to one entry carrying whichever orientation was reached
first (24 occurrences over 12 distinct on a plain box). This issue's own text refused the analogy
and asked, as its first task, whether any consumer derives an orientation-dependent answer from an
edge's stored orientation before assuming it is the same bug.

**Decision: no code change.** The census (#664, `Scripts/repro/cluster-a-subshape-enumeration/`)
already did the consumer audit this issue names as its first task and found none. This PR verifies
that audit independently, then documents the contract and adds regression tests, per the issue's
own option 3.

Closes #638

## The audit, verified independently

`Edge` (the Swift type) exposes no `.orientation` accessor. Read every public member on it
(`edgeCount`, `edge(at:)`, `edges()`, `tangent(at:)`, `point(at:)`, `parameterBounds`,
`curvature(at:)`, `adjacentFaces(in:)`, `dihedralAngle`, and the rest) and traced each one's bridge
implementation:

- `tangent(at:)`, `point(at:)`, `parameterBounds`, `curvature(at:)`, `centerOfCurvature(at:)`,
  `torsion(at:)` all call `BRep_Tool::Curve(edge->edge, f, l)`, which returns the raw `Geom_Curve`
  handle and its own natural parameter range. That range and the curve itself are defined
  independently of `TopAbs_Orientation`. This is not the same code path as `BRepAdaptor_Curve`,
  which does account for orientation.
- `adjacentFaces(in:)` (`OCCTEdgeGetAdjacentFaces`) builds a fresh `TopTools_IndexedDataMapOfShapeListOfShape`
  via `TopExp::MapShapesAndAncestors` and looks up by the edge's `TopoDS_Edge`, which is `IsSame`
  keyed and orientation-insensitive.
- A bridge-wide grep for `.Orientation() ==` across `Sources/OCCTBridge/src/*.mm` finds exactly 14
  branching sites. 13 read a **face's** orientation (already #614's territory: `OCCTEdgeGetConvexity`,
  `OCCTEdgeGetDihedralAngle`, and the rest all reverse a face normal, not an edge tangent). The
  fourteenth, `occtSampleWirePoints` (`OCCTBridge_Modeling.mm`), reads orientation fresh off a
  `BRepTools_WireExplorer` walk of the wire it is sampling, never from an `Edge` `Shape.edges()`
  produced.
- `Shape.subShapes(ofType: .edge)` returns `[Shape]`, and `Shape.orientation` **is** technically
  observable there (unlike on `Edge`). No production code combines the two: nothing calls
  `subShapes(ofType: .edge)` and then reads `.orientation` to derive an answer.

**Verified beyond the source read, not just by trusting it.** Built the identical edge with both
`TopAbs_Orientation`s (`Shape.subShape(type:index:).reversed`, converted through `Edge.init?(_:)`,
which preserves whatever orientation the `Shape` carries) and compared every accessor `Edge`
exposes: `length`, `isLine`, `isCircle`, `curveType`, `parameterBounds`, `point(at:)`,
`tangent(at:)`, `curvature(at:)`, `endpoints`, `bounds`. Identical bit for bit, on both a straight
edge (a box) and a circular one (a cylinder).

## What the census comment got right, and one gap it left open

The census's own audit (posted as the last comment on #638) reached the same conclusion by source
reading alone. This PR's contribution is the independent runtime verification above (constructing
the forward/reversed pair and diffing every accessor) plus regression tests that would catch a
regression, which the census explicitly scoped out ("this directory is the census only, it does
not fix #638, #642 or #651").

## Changes

- `Sources/OCCTSwift/Edge.swift`: `edgeCount` and `edges()` doc comments now state the identity
  rule explicitly (mirroring how `Shape.faces()` documents its own, per #614), with a fenced
  `swift` snippet.
- `docs/reference/Edge.md`: matching prose in the `edgeCount`/`edges()` sections.
- `docs/CHANGELOG.md`: an "Unreleased" entry recording the decision and the evidence.
- `Tests/OCCTTopologyTests/Issue638EdgeOrientationContractTests.swift`: 6 new tests, two groups.

No production behaviour changes. `docs/SEMVER.md` is not touched, per #664's own rule that it only
applies when an enumeration's returned values change.

## Tests, and the injection matrix

Group 1, the dedup mechanism must not regress:
- a plain box: `edgeCount`/`edges().count`/`subShapeCount(ofType: .edge)` all 12, `contents.edges`
  (an independent, already-documented occurrence oracle) 24.
- the #614 split-box compound fixture, reused rather than re-derived: `edgeCount`/`edges().count`
  stay at 20 (the dedup count), not the larger occurrence count.
- every entry in `edges()` is addressable by its own index.

Group 2, `Edge`'s accessors do not depend on the collapsed-away orientation:
- forward/reversed pair comparison on a line (a box edge) across 5 sample parameters.
- forward/reversed pair comparison on a circle (a cylinder edge) across 4 sample parameters.
- `adjacentFaces(in:)` resolves the same pair of faces regardless of the caller's edge orientation.

**Prove the test fails**, per `okf/policies/prove-the-test-fails.md`, run once for each group and
restored before this PR was opened:

| injection | subject | result | restored |
|---|---|---|---|
| `edgeCount` reads `OCCTShapeNbEdges` (occurrence count) instead of `OCCTShapeGetTotalEdgeCount` (dedup) | Group 1 | 3 of 3 tests failed (`edgeCount → 24` vs expected 12 on the box; `→ 48` vs 20 on the compound; the addressability test's own internal consistency check) | yes, `swift test` green after |
| `OCCTEdgeGetTangent3D` reverses the tangent when `edge->edge.Orientation() == TopAbs_REVERSED` (simulating a hypothetical orientation-aware accessor) | Group 2 | 2 of 2 tests failed, at every sampled parameter on both the line and the circle | yes, `swift test` green after |
| (neither injection) | both groups | all 6 pass | n/a |

Group 1's injection did not move Group 2, and Group 2's injection did not move Group 1, confirming
each test catches the specific defect it names rather than something incidental.

## Verification

- `swift build`, clean, 0 errors, no `OCCTSWIFT_LOCAL`, no local `Libraries/`.
- `swift test`, no env overrides: **5326 tests, 1403 suites, 0 failures** (baseline 5320 + 6 new).
- Gate scripts, all exit 0, run from the repo root: `check-bridge-index.py` (0 stale, 0 misfiled),
  `check-null-handle-guards.py`, `check-docs-defaults.py` (0 drifted), `count-operations.py`
  (4301, README/API_REFERENCE agree), each `--self-test` (18/18, 12/12, 13/13), plus
  `classify_topexp_sites.py --self-test` (14/14).
- The census still reports 45 rows and 127/52/54/21, unchanged, since this PR changes no
  enumeration behaviour: re-ran `swift run ClusterACensus` and
  `classify_topexp_sites.py` directly.
- Zero em-dashes across the diff.

## Notes for the reviewer

**This is a documentation-only PR by design**, following the same shape as #663 (a well-argued "no
split" decision) rather than #614 (a behaviour fix). If a future `Edge.orientation` accessor or an
orientation-sensitive edge consumer is added, re-run the audit above before assuming this collapse
is still safe. Nothing in this PR overlaps #642 (AAG order-dependence) or #651
(`nbEdges`/`nbFaces`/`nbVertices` vs their docs), both being worked concurrently in sibling
worktrees; `contents.edges` is used here only as a measurement oracle, not touched or claimed by
either of those.
