### PR TITLE
fix(#651): nbEdges/nbFaces/nbVertices are deprecated in favour of the counters they duplicated

### DIFF
--- a/Scripts/repro/cluster-a-subshape-enumeration/README.md
+++ b/Scripts/repro/cluster-a-subshape-enumeration/README.md
@@ -82,14 +82,14 @@ name says `[horizontal-cut fixture]`).
 | vertex | vertices().count (dedup) | 8 | 12 | 12 | |
 | vertex | uniqueVertexCount (alias of vertexCount) | 8 | 12 | 12 | |
 | vertex | subShapeCount(ofType: .vertex) (dedup canonical) | 8 | 12 | 12 | |
-| vertex | **nbVertices** (#651: docs say dedup) | 48 | 96 | 96 | occurrence; `docs/reference/Document-Completions.md:1438` states `box.nbVertices == 8` |
+| vertex | nbVertices (#651: fixed, now forwards to vertexCount) | 8 | 12 | 12 | deprecated, `renamed: "vertexCount"`; was occurrence (48/96/96) before #651 |
 | vertex | contents.vertices (ShapeAnalysis_ShapeContents, occurrence) | 48 | 96 | 96 | |
 | vertex | contentsExtended().nbVertices (occurrence) | 48 | 96 | 96 | |
 | edge | edgeCount (dedup canonical) | 12 | 20 | 20 | |
 | edge | edges().count (dedup) | 12 | 20 | 20 | |
 | edge | uniqueEdgeCount (alias of edgeCount) | 12 | 20 | 20 | |
 | edge | subShapeCount(ofType: .edge) (dedup canonical) | 12 | 20 | 20 | |
-| edge | **nbEdges** (#651: docs say dedup) | 24 | 48 | 48 | occurrence; `docs/reference/Document-Completions.md:1406` states `box.nbEdges == 12` |
+| edge | nbEdges (#651: fixed, now forwards to edgeCount) | 12 | 20 | 20 | deprecated, `renamed: "edgeCount"`; was occurrence (24/48/48) before #651 |
 | edge | contents.edges (ShapeAnalysis_ShapeContents, occurrence) | 24 | 48 | 48 | |
 | edge | contentsExtended().nbEdges (occurrence) | 24 | 48 | 48 | |
 | edge | Shape(wire).edgeCount (dedup; a wire's own edges) | 4 | n/a | n/a | a wire's own edges aren't shared cross-parent in these fixtures |
@@ -98,7 +98,7 @@ name says `[horizontal-cut fixture]`).
 | face | orientedFaces().count (occurrence, deliberate #614) | 6 | 12 | 12 | documented, paired counterpart of faces(), not a defect |
 | face | uniqueFaceCount (alias of faceCount) | 6 | 11 | 11 | |
 | face | subShapeCount(ofType: .face) (dedup canonical) | 6 | 11 | 11 | |
-| face | nbFaces (#651: docs say dedup) | 6 | 12 | 12 | occurrence; no divergence on a *plain box* since no face is shared there, see correction below |
+| face | nbFaces (#651: fixed, now forwards to faceCount) | 6 | 11 | 11 | deprecated, `renamed: "faceCount"`; was occurrence (6/12/12) before #651, agreeing with `faceCount` on a plain box only because no face is shared there |
 | face | contents.faces (occurrence) | 6 | 12 | 12 | |
 | face | contentsExtended().nbFaces (occurrence) | 6 | 12 | 12 | |
 | face | contentsExtended().nbSharedFaces (a THIRD rule: location-discarding dedup) | 6 | 11 | 11 | |
@@ -129,17 +129,23 @@ columns for terminal alignment, omitted here for Markdown)
 
 ## Static classification summary
 
-`classify_topexp_sites.py` found **127 C functions** in `Sources/OCCTBridge/src/*.mm` containing a
-`TopExp_Explorer` or `TopExp::MapShapes` call: **52 DEDUP, 54 OCCURRENCE, 21 OTHER** (find-first /
-existence-check / dead declaration). Re-run the script for the full 127-row table; the entry points
-that matter for cluster A specifically are cross-referenced against the dynamic table above.
+**Updated after #651.** `classify_topexp_sites.py` found **124 C functions** in
+`Sources/OCCTBridge/src/*.mm` containing a `TopExp_Explorer` or `TopExp::MapShapes` call: **52
+DEDUP, 51 OCCURRENCE, 21 OTHER** (find-first / existence-check / dead declaration). At the time this
+census was first built the totals were 127/52/54/21; #651 deleted `OCCTShapeNbEdges`,
+`OCCTShapeNbFaces` and `OCCTShapeNbVertices` (all three OCCURRENCE) once `Shape.nbEdges`/`nbFaces`/
+`nbVertices` were deprecated and repointed at `edgeCount`/`faceCount`/`vertexCount`, so those three
+rows are simply gone rather than reclassified. Re-run the script for the full 124-row table; the
+entry points that matter for cluster A specifically are cross-referenced against the dynamic table
+above.
 
 Two functions are declared and implemented but **called from nowhere in `Sources/OCCTSwift/`**:
 `OCCTShapeCountFaces` and `OCCTShapeCountEdges` (`OCCTBridge_Topology.mm`), both OCCURRENCE. Since
 `OCCTBridge` is not a package product (only `OCCTSwift` is, per `Package.swift`'s `products:`),
 these are unreachable from any consumer of this package, orphaned, not part of the public surface
-`#664` asks about, despite matching the OCCURRENCE shape of the ones that are (`OCCTShapeNbFaces`/
-`OCCTShapeNbEdges`, which back the *reachable* `nbFaces`/`nbEdges`).
+`#664` asks about. They used to match the OCCURRENCE shape of `OCCTShapeNbFaces`/`OCCTShapeNbEdges`,
+the reachable pair that backed `nbFaces`/`nbEdges` before #651 deleted them; that comparison is now
+historical, since the reachable pair no longer exists to compare against.
 
 ## Where the two methods disagreed
 
@@ -271,18 +277,22 @@ the bucket: the claim was checkable, and it did not hold.
 split fixtures in this census, rows above). Any Cluster A fix has to leave every one of these
 numbers unchanged.
 
-**#651 is confirmed, and its own table was already careful about the one thing worth checking.**
-`nbEdges`/`nbFaces`/`nbVertices` are bare `TopExp_Explorer` counts (`OCCTShapeNbEdges`/`NbFaces`/
-`NbVertices`, `OCCTBridge_Topology.mm:3694-3719`) while `docs/reference/Document-Completions.md`
-documents all three with the *deduplicated* value (`box.nbEdges // 12`, `box.nbVertices // 8`,
-confirmed by direct read of lines 1406/1438). #651's own table already shows `nbFaces`/`faceCount`
-agreeing on a box (6/6, correctly: no face is shared within one solid) and diverging only on the
-two-solid compound (12/11). This census's own table reproduces that distinction exactly (`nbFaces`
-row: 6/12/12 across plain box/order A/order B, matching `contentsExtended().nbFaces` and
-`contents.faces` bit for bit) rather than contradicting it. The measured dynamic table also confirms
-#651's own "watch for" note: `nbEdges`/`nbFaces`/`nbVertices` are pure OCCURRENCE duplicates of
-`edgeCount`/`faceCount`/`vertexCount` in every fixture measured. The #490/#491/#492 precedent
-(retire the duplicate spelling, not just repoint its implementation) applies directly.
+**#651 was confirmed by this census, and is now fixed.** At the time this census was first built,
+`nbEdges`/`nbFaces`/`nbVertices` were bare `TopExp_Explorer` counts (`OCCTShapeNbEdges`/`NbFaces`/
+`NbVertices`, formerly `OCCTBridge_Topology.mm:3694-3719`, now deleted) while
+`docs/reference/Document-Completions.md` documented all three with the *deduplicated* value
+(`box.nbEdges // 12`, `box.nbVertices // 8`, confirmed by direct read of lines 1406/1438). #651's own
+table already showed `nbFaces`/`faceCount` agreeing on a box (6/6, correctly: no face is shared
+within one solid) and diverging only on the two-solid compound (12/11). This census's own table
+reproduced that distinction exactly (`nbFaces` row: 6/12/12 across plain box/order A/order B,
+matching `contentsExtended().nbFaces` and `contents.faces` bit for bit) rather than contradicting
+it. The measured dynamic table also confirmed #651's own "watch for" note: `nbEdges`/`nbFaces`/
+`nbVertices` were pure OCCURRENCE duplicates of `edgeCount`/`faceCount`/`vertexCount` in every
+fixture measured, with no index or orientation dimension of their own. The #536 precedent (retire
+the duplicate spelling, deprecate-and-forward, rather than #613's repoint-in-place) applied, and is
+what #651 did: all three are now `@available(*, deprecated, renamed:)` and forward to
+`edgeCount`/`faceCount`/`vertexCount`, so the dynamic table rows above now read the same value as
+their canonical siblings across every fixture.
 
 **`ShapeAnalysis_ShapeContents` (`Shape.contents`) and `contentsExtended()` are occurrence-based
 too, and undocumented as such beyond `Shape.contents`'s own doc comment.** Both track the raw
@@ -339,11 +349,13 @@ census's job here is to show that clearly rather than let a fourth issue re-deri
   any further root-level change to `faces()`/`edges()`. The fix it needs is AAG's own node-identity
   redesign (per #642's own three suggested approaches), which is a consumer-side migration, not a
   root-cause fix. #642 can start immediately; it was never gated on #638 or #651.
-- **#651** (`nbEdges`/`nbFaces`/`nbVertices` vs their own docs) is **orthogonal to orientation
-  entirely**. It is a "two implementations of one count, the docs describe the wrong one" bug, with
-  no face/edge-orientation dimension at all. It does not share a mechanism with #638 or #642 beyond
-  both families living under `TopExp_Explorer`/`TopExp::MapShapes`. Confirmed retirable in favour of
-  `edgeCount`/`faceCount`/`vertexCount` per the measured duplication above.
+- **#651** (`nbEdges`/`nbFaces`/`nbVertices` vs their own docs) was **orthogonal to orientation
+  entirely**. It was a "two implementations of one count, the docs describe the wrong one" bug, with
+  no face/edge-orientation dimension at all, and did not share a mechanism with #638 or #642 beyond
+  both families living under `TopExp_Explorer`/`TopExp::MapShapes`. **Fixed**: retired in favour of
+  `edgeCount`/`faceCount`/`vertexCount` per the measured duplication above, by deprecating and
+  forwarding rather than repointing in place, since nothing else distinguished the two spellings
+  once the value agreed.
 
 **Practical consequence:** there is no single "fix the root" commit left to land for Cluster A that
 would move all three members. The root for the *face* side (#614) already shipped; #638 is a

--- a/Scripts/repro/cluster-a-subshape-enumeration/main.swift
+++ b/Scripts/repro/cluster-a-subshape-enumeration/main.swift
@@ -72,6 +72,31 @@ enum Fixture {
     }
 }
 
+// #651 deprecated `nbEdges`/`nbFaces`/`nbVertices`, which now forward to
+// `edgeCount`/`faceCount`/`vertexCount`. The census still measures them deliberately: its job is to
+// record what the public API does, and a deprecated spelling is public API until it is removed.
+//
+// They are grouped into one deprecated function because a deprecated context does not warn about
+// the deprecated things it calls. Read inline instead, they put 38 deprecation warnings into every
+// `swift build` in the repo, since this target is wired into the root manifest and builds on every
+// push (#694). Grouped, the cost is one warning at the single call site below, which is the honest
+// residue: the census really does use a deprecated API on purpose.
+//
+// When the deprecation cycle removes the three properties this stops compiling, which is the right
+// prompt to drop these rows rather than silently losing them.
+@available(*, deprecated, message: "Measures #651's deprecated counters deliberately.")
+func recordDeprecatedCounterRows() {
+    record("vertex", "nbVertices (#651: fixed, now forwards to vertexCount)",
+           plainBox: box.nbVertices, orderA: compoundA.nbVertices, orderB: compoundB.nbVertices,
+           note: "deprecated, renamed: \"vertexCount\"; was occurrence (48/96/96) before #651")
+    record("edge", "nbEdges (#651: fixed, now forwards to edgeCount)",
+           plainBox: box.nbEdges, orderA: compoundA.nbEdges, orderB: compoundB.nbEdges,
+           note: "deprecated, renamed: \"edgeCount\"; was occurrence (24/48/48) before #651")
+    record("face", "nbFaces (#651: fixed, now forwards to faceCount)",
+           plainBox: box.nbFaces, orderA: compoundA.nbFaces, orderB: compoundB.nbFaces,
+           note: "deprecated, renamed: \"faceCount\"; was occurrence (6/12/12) before #651, agreeing with faceCount on a plain box only because no face is shared there")
+}
+
 // MARK: - Report plumbing
 
 struct Row {
@@ -109,9 +134,6 @@ record("vertex", "uniqueVertexCount (alias of vertexCount)",
 record("vertex", "subShapeCount(ofType: .vertex) (dedup canonical)",
        plainBox: box.subShapeCount(ofType: .vertex), orderA: compoundA.subShapeCount(ofType: .vertex),
        orderB: compoundB.subShapeCount(ofType: .vertex))
-record("vertex", "nbVertices (#651: fixed, now forwards to vertexCount)",
-       plainBox: box.nbVertices, orderA: compoundA.nbVertices, orderB: compoundB.nbVertices,
-       note: "deprecated, renamed: \"vertexCount\"; was occurrence (48/96/96) before #651")
 record("vertex", "contents.vertices (ShapeAnalysis_ShapeContents, occurrence)",
        plainBox: box.contents.vertices, orderA: compoundA.contents.vertices, orderB: compoundB.contents.vertices)
 record("vertex", "contentsExtended().nbVertices (occurrence)",
@@ -129,9 +151,6 @@ record("edge", "uniqueEdgeCount (alias of edgeCount)",
 record("edge", "subShapeCount(ofType: .edge) (dedup canonical)",
        plainBox: box.subShapeCount(ofType: .edge), orderA: compoundA.subShapeCount(ofType: .edge),
        orderB: compoundB.subShapeCount(ofType: .edge))
-record("edge", "nbEdges (#651: fixed, now forwards to edgeCount)",
-       plainBox: box.nbEdges, orderA: compoundA.nbEdges, orderB: compoundB.nbEdges,
-       note: "deprecated, renamed: \"edgeCount\"; was occurrence (24/48/48) before #651")
 record("edge", "contents.edges (ShapeAnalysis_ShapeContents, occurrence)",
        plainBox: box.contents.edges, orderA: compoundA.contents.edges, orderB: compoundB.contents.edges)
 record("edge", "contentsExtended().nbEdges (occurrence)",
@@ -159,9 +178,7 @@ record("face", "uniqueFaceCount (alias of faceCount)",
 record("face", "subShapeCount(ofType: .face) (dedup canonical)",
        plainBox: box.subShapeCount(ofType: .face), orderA: compoundA.subShapeCount(ofType: .face),
        orderB: compoundB.subShapeCount(ofType: .face))
-record("face", "nbFaces (#651: fixed, now forwards to faceCount)",
-       plainBox: box.nbFaces, orderA: compoundA.nbFaces, orderB: compoundB.nbFaces,
-       note: "deprecated, renamed: \"faceCount\"; was occurrence (6/12/12) before #651, agreeing with faceCount on a plain box only because no face is shared there")
+recordDeprecatedCounterRows()
 record("face", "contents.faces (ShapeAnalysis_ShapeContents, occurrence)",
        plainBox: box.contents.faces, orderA: compoundA.contents.faces, orderB: compoundB.contents.faces)
 record("face", "contentsExtended().nbFaces (occurrence)",

--- a/Scripts/repro/cluster-a-subshape-enumeration/main.swift
+++ b/Scripts/repro/cluster-a-subshape-enumeration/main.swift
@@ -109,9 +109,9 @@ record("vertex", "uniqueVertexCount (alias of vertexCount)",
 record("vertex", "subShapeCount(ofType: .vertex) (dedup canonical)",
        plainBox: box.subShapeCount(ofType: .vertex), orderA: compoundA.subShapeCount(ofType: .vertex),
        orderB: compoundB.subShapeCount(ofType: .vertex))
-record("vertex", "nbVertices (#651: docs say dedup)",
+record("vertex", "nbVertices (#651: fixed, now forwards to vertexCount)",
        plainBox: box.nbVertices, orderA: compoundA.nbVertices, orderB: compoundB.nbVertices,
-       note: "occurrence; docs/reference/Document-Completions.md:1438 states box.nbVertices == 8")
+       note: "deprecated, renamed: \"vertexCount\"; was occurrence (48/96/96) before #651")
 record("vertex", "contents.vertices (ShapeAnalysis_ShapeContents, occurrence)",
        plainBox: box.contents.vertices, orderA: compoundA.contents.vertices, orderB: compoundB.contents.vertices)
 record("vertex", "contentsExtended().nbVertices (occurrence)",
@@ -129,9 +129,9 @@ record("edge", "uniqueEdgeCount (alias of edgeCount)",
 record("edge", "subShapeCount(ofType: .edge) (dedup canonical)",
        plainBox: box.subShapeCount(ofType: .edge), orderA: compoundA.subShapeCount(ofType: .edge),
        orderB: compoundB.subShapeCount(ofType: .edge))
-record("edge", "nbEdges (#651: docs say dedup)",
+record("edge", "nbEdges (#651: fixed, now forwards to edgeCount)",
        plainBox: box.nbEdges, orderA: compoundA.nbEdges, orderB: compoundB.nbEdges,
-       note: "occurrence; docs/reference/Document-Completions.md:1406 states box.nbEdges == 12")
+       note: "deprecated, renamed: \"edgeCount\"; was occurrence (24/48/48) before #651")
 record("edge", "contents.edges (ShapeAnalysis_ShapeContents, occurrence)",
        plainBox: box.contents.edges, orderA: compoundA.contents.edges, orderB: compoundB.contents.edges)
 record("edge", "contentsExtended().nbEdges (occurrence)",
@@ -159,9 +159,9 @@ record("face", "uniqueFaceCount (alias of faceCount)",
 record("face", "subShapeCount(ofType: .face) (dedup canonical)",
        plainBox: box.subShapeCount(ofType: .face), orderA: compoundA.subShapeCount(ofType: .face),
        orderB: compoundB.subShapeCount(ofType: .face))
-record("face", "nbFaces (#651: docs say dedup)",
+record("face", "nbFaces (#651: fixed, now forwards to faceCount)",
        plainBox: box.nbFaces, orderA: compoundA.nbFaces, orderB: compoundB.nbFaces,
-       note: "occurrence; docs/reference/Document-Completions.md:1422 states box.nbFaces == 6 (no divergence on a plain box, since no face is shared)")
+       note: "deprecated, renamed: \"faceCount\"; was occurrence (6/12/12) before #651, agreeing with faceCount on a plain box only because no face is shared there")
 record("face", "contents.faces (ShapeAnalysis_ShapeContents, occurrence)",
        plainBox: box.contents.faces, orderA: compoundA.contents.faces, orderB: compoundB.contents.faces)
 record("face", "contentsExtended().nbFaces (occurrence)",

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -1682,14 +1682,13 @@ OCCTShapeRef _Nullable OCCTShapeMoved(OCCTShapeRef _Nonnull shape, double dx, do
 /// Get the shape orientation as integer (0=FORWARD, 1=REVERSED, 2=INTERNAL, 3=EXTERNAL).
 int32_t OCCTShapeOrientationValue(OCCTShapeRef _Nonnull shape);
 
-/// Get the number of edges in a shape.
-int32_t OCCTShapeNbEdges(OCCTShapeRef _Nonnull shape);
-
-/// Get the number of faces in a shape.
-int32_t OCCTShapeNbFaces(OCCTShapeRef _Nonnull shape);
-
-/// Get the number of vertices in a shape.
-int32_t OCCTShapeNbVertices(OCCTShapeRef _Nonnull shape);
+// OCCTShapeNbEdges / OCCTShapeNbFaces / OCCTShapeNbVertices are gone: each was a
+// TopExp_Explorer occurrence count (24 edges / 6 faces / 48 vertices on a 12-edge, 6-face,
+// 8-vertex box -- nbFaces only diverges from faceCount on a shape with a shared face), while
+// this project's own reference docs always documented the distinct count. Shape.nbEdges /
+// .nbFaces / .nbVertices are deprecated and forward to edgeCount / faceCount / vertexCount,
+// which already called OCCTShapeGetTotalEdgeCount / OCCTShapeGetFaceCount /
+// OCCTShapeGetVertexCount. #651
 
 // MARK: - v0.126.0: Final completeness release
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3691,32 +3691,13 @@ int32_t OCCTShapeOrientationValue(OCCTShapeRef shape) {
     return (int32_t)shape->shape.Orientation();
 }
 
-int32_t OCCTShapeNbEdges(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-        count++;
-    }
-    return count;
-}
-
-int32_t OCCTShapeNbFaces(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-        count++;
-    }
-    return count;
-}
-
-int32_t OCCTShapeNbVertices(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    int32_t count = 0;
-    for (TopExp_Explorer exp(shape->shape, TopAbs_VERTEX); exp.More(); exp.Next()) {
-        count++;
-    }
-    return count;
-}
+// OCCTShapeNbEdges / OCCTShapeNbFaces / OCCTShapeNbVertices are gone: each was a
+// TopExp_Explorer occurrence count (24 edges / 6 faces / 48 vertices on a 12-edge, 6-face,
+// 8-vertex box -- nbFaces only diverges from faceCount on a shape with a shared face), while
+// this project's own reference docs always documented the distinct count. Shape.nbEdges /
+// .nbFaces / .nbVertices are deprecated and forward to edgeCount / faceCount / vertexCount,
+// which already called OCCTShapeGetTotalEdgeCount / OCCTShapeGetFaceCount /
+// OCCTShapeGetVertexCount. #651
 
 // end of v0.123.0 implementations
 

--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -242,7 +242,11 @@ public final class Edge: @unchecked Sendable {
 // MARK: - Shape Extension for Edge Access
 
 extension Shape {
-    /// Get total number of edges in the shape
+    /// Get total number of edges in the shape.
+    ///
+    /// ``nbEdges`` was a second spelling of this same question, backed by a bare
+    /// `TopExp_Explorer` occurrence walk instead of this deduplicated count, and is deprecated in
+    /// favour of this one (#651).
     public var edgeCount: Int {
         Int(OCCTShapeGetTotalEdgeCount(handle))
     }

--- a/Sources/OCCTSwift/Selection.swift
+++ b/Sources/OCCTSwift/Selection.swift
@@ -130,6 +130,10 @@ extension Shape {
     /// print(box.faces().count)                 // 6, the same enumeration
     /// print(box.subShapeCount(ofType: .face))  // 6, the generic spelling
     /// ```
+    ///
+    /// ``nbFaces`` was a second spelling of this same question, backed by a bare
+    /// `TopExp_Explorer` occurrence walk instead of this deduplicated count, and is deprecated in
+    /// favour of this one (#651).
     public var faceCount: Int {
         Int(OCCTShapeGetFaceCount(handle))
     }

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -5,7 +5,11 @@ import OCCTBridge
 extension Shape {
 
 
-    /// Number of vertices (corners) in the shape
+    /// Number of vertices (corners) in the shape.
+    ///
+    /// ``nbVertices`` was a second spelling of this same question, backed by a bare
+    /// `TopExp_Explorer` occurrence walk instead of this deduplicated count, and is deprecated in
+    /// favour of this one (#651).
     public var vertexCount: Int {
         Int(OCCTShapeGetVertexCount(handle))
     }
@@ -2880,18 +2884,58 @@ extension Shape {
         Int(OCCTShapeOrientationValue(handle))
     }
 
-    /// Get the number of edges in this shape.
+    /// Deprecated: this is ``edgeCount`` under a second name, and used to return a different,
+    /// wrong number.
+    ///
+    /// `nbEdges` counted bare `TopExp_Explorer` occurrences: 24 on a 12-edge box, since every
+    /// edge is walked once per adjacent face. This project's own reference docs always documented
+    /// the *distinct* count instead (`box.nbEdges // 12`), so the contract and the implementation
+    /// disagreed from the day this property shipped. Forwards to ``edgeCount`` now, which already
+    /// carried the value these docs described (#651).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// box.nbEdges == box.edgeCount   // true, 12 either way
+    /// ```
+    @available(*, deprecated, renamed: "edgeCount",
+               message: "nbEdges counted TopExp_Explorer occurrences (24 on a 12-edge box) while the reference docs always documented the distinct count (12). Forwards to edgeCount, which returns the documented value.")
     public var nbEdges: Int {
-        Int(OCCTShapeNbEdges(handle))
+        edgeCount
     }
 
-    /// Get the number of faces in this shape.
+    /// Deprecated: this is ``faceCount`` under a second name, and used to return a different,
+    /// wrong number on any shape that shares a face.
+    ///
+    /// `nbFaces` counted bare `TopExp_Explorer` occurrences. A plain box has no shared face, so
+    /// `nbFaces` and `faceCount` agreed there (6 either way) and the divergence stayed hidden;
+    /// on a shape with a shared face (a two-solid split compound) they read 12 against 11.
+    /// Forwards to ``faceCount`` now, matching this project's reference docs (#651).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// box.nbFaces == box.faceCount   // true, 6 either way
+    /// ```
+    @available(*, deprecated, renamed: "faceCount",
+               message: "nbFaces counted TopExp_Explorer occurrences, which agrees with faceCount on a plain box (6) but not on a shape that shares a face (12 against 11 on a two-solid split compound). Forwards to faceCount.")
     public var nbFaces: Int {
-        Int(OCCTShapeNbFaces(handle))
+        faceCount
     }
 
-    /// Get the number of vertices in this shape.
+    /// Deprecated: this is ``vertexCount`` under a second name, and used to return a different,
+    /// wrong number.
+    ///
+    /// `nbVertices` counted bare `TopExp_Explorer` occurrences: 48 on an 8-vertex box, since every
+    /// vertex is walked once per incident edge. This project's own reference docs always
+    /// documented the *distinct* count instead (`box.nbVertices // 8`). Forwards to
+    /// ``vertexCount`` now, which already carried the value these docs described (#651).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// box.nbVertices == box.vertexCount   // true, 8 either way
+    /// ```
+    @available(*, deprecated, renamed: "vertexCount",
+               message: "nbVertices counted TopExp_Explorer occurrences (48 on an 8-vertex box) while the reference docs always documented the distinct count (8). Forwards to vertexCount, which returns the documented value.")
     public var nbVertices: Int {
-        Int(OCCTShapeNbVertices(handle))
+        vertexCount
     }
 }

--- a/Tests/OCCTTopologyTests/Issue651DeprecatedCounterTests.swift
+++ b/Tests/OCCTTopologyTests/Issue651DeprecatedCounterTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #651: `Shape.nbEdges`, `Shape.nbFaces` and `Shape.nbVertices` counted bare `TopExp_Explorer`
+// OCCURRENCES (`OCCTShapeNbEdges`/`NbFaces`/`NbVertices`, now deleted), the same gap #613 closed for
+// its seven entry points, but this project's own reference docs always documented the DEDUPLICATED
+// count instead: `docs/reference/Document-Completions.md` asserted `box.nbEdges // 12` and
+// `box.nbVertices // 8`, never the 24 and 48 the implementation actually returned.
+//
+// Measured on the pinned kernel, a plain 10 mm box:
+//
+//   nbEdges     24   edgeCount     12
+//   nbVertices  48   vertexCount    8
+//   nbFaces      6   faceCount      6   (a box shares no face, so these already agreed)
+//
+// `nbFaces` needs a shape with a shared face to show the same divergence as its siblings, measured
+// on a two-solid split compound (the #613/#614 fixture): 12 against 11.
+//
+// Unlike #613's seven sites, none of the three names an index consumed elsewhere, so there is no
+// orientation dimension and no consumer that reads one spelling and not the other. The Cluster A
+// census (#664, `Scripts/repro/cluster-a-subshape-enumeration/`) confirmed all three are pure
+// occurrence duplicates of `edgeCount`/`faceCount`/`vertexCount` in every fixture it measured, so the
+// fix taken here is #536's precedent (retire the duplicate spelling, deprecate-and-forward) rather
+// than #613's (repoint the raw value and keep both names): there was nowhere for a second name to
+// keep pulling its own weight once the value agreed.
+//
+// `nbEdges`/`nbFaces`/`nbVertices` are now `@available(*, deprecated, renamed:)` and forward to
+// `edgeCount`/`faceCount`/`vertexCount`. `Shape.contents.edges`/`.faces`/`.vertices`
+// (`ShapeAnalysis_ShapeContents`, a separate occurrence-counting mechanism, #541/#664) still reports
+// the pre-fix occurrence numbers and is used below only to give each test an independent value to
+// contrast against. It is explicitly out of scope for this issue and is not itself asserted to
+// change.
+
+@Suite("nbEdges/nbFaces/nbVertices forward to the deduplicated counters they duplicated (#651)")
+struct Issue651DeprecatedCounterTests {
+
+    // MARK: - Fixtures
+
+    /// The plain box #651's own measurements are taken on.
+    static func box() -> Shape? {
+        Shape.box(origin: .zero, width: 10, height: 10, depth: 10)
+    }
+
+    /// Two solids sharing one cut face, from one ordinary modelling operation, the same
+    /// construction `Issue613MeshIndexContractTests`/`Issue614FaceOrientationTests` use. `nbFaces`
+    /// needs this: a plain box shares no face, so `nbFaces` and `faceCount` agree there by
+    /// construction and the divergence only shows up once a face has two parents.
+    ///
+    /// Returns nil on any construction failure; every caller `#require`s it, so a kernel that
+    /// stopped sharing the wall fails these tests rather than skipping them silently.
+    static func splitBoxCompound() -> Shape? {
+        guard let block = Shape.box(origin: .zero, width: 20, height: 10, depth: 10),
+              let rect = Wire.rectangle(width: 60, height: 60),
+              let plate = Shape.face(from: rect),
+              let upright = plate.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2),
+              let knife = upright.translated(by: SIMD3(10, 0, 0)),
+              let pieces = block.split(by: knife),
+              pieces.count == 2,
+              let compound = Shape.compound(pieces)
+        else { return nil }
+        return compound
+    }
+
+    // MARK: - nbEdges
+
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("nbEdges equals edgeCount, not the edge occurrence count, on a box")
+    func nbEdgesMatchesEdgeCount() throws {
+        let box = try #require(Self.box())
+        #expect(box.edgeCount == 12)
+        #expect(box.nbEdges == 12)
+        #expect(box.nbEdges == box.edgeCount)
+        // Context: an occurrence-based count over the same box is 24, not 12, the value nbEdges
+        // used to return. This is not the same OCCT mechanism nbEdges used (ShapeAnalysis_ShapeContents
+        // vs. a bare TopExp_Explorer), so it does not itself prove the fix; it only shows the
+        // occurrence/distinct gap this box is chosen to exercise is real on this kernel.
+        #expect(box.contents.edges == 24)
+    }
+
+    // MARK: - nbVertices
+
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("nbVertices equals vertexCount, not the vertex occurrence count, on a box")
+    func nbVerticesMatchesVertexCount() throws {
+        let box = try #require(Self.box())
+        #expect(box.vertexCount == 8)
+        #expect(box.nbVertices == 8)
+        #expect(box.nbVertices == box.vertexCount)
+        #expect(box.contents.vertices == 48)
+    }
+
+    // MARK: - nbFaces
+
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("nbFaces agrees with faceCount on a plain box, where no face is shared")
+    func nbFacesMatchesFaceCountOnBox() throws {
+        let box = try #require(Self.box())
+        #expect(box.faceCount == 6)
+        #expect(box.nbFaces == 6)
+        #expect(box.nbFaces == box.faceCount)
+    }
+
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
+    @Test("nbFaces equals faceCount, not the face occurrence count, on a shape with a shared face")
+    func nbFacesMatchesFaceCountOnSharedFace() throws {
+        let compound = try #require(Self.splitBoxCompound())
+        #expect(compound.faceCount == 11)
+        #expect(compound.nbFaces == 11)
+        #expect(compound.nbFaces == compound.faceCount)
+        // Context, as above: the occurrence count over the same compound is 12, not 11.
+        #expect(compound.contents.faces == 12)
+    }
+}
+
+// MARK: - Prove the test fails (okf/policies/prove-the-test-fails.md)
+//
+// Each of the four tests above was run once with `nbEdges`/`nbFaces`/`nbVertices` reverted to an
+// occurrence count, to confirm the assertion that matters actually fires rather than passing
+// vacuously. The injection used `Shape.contents.{edges,faces,vertices}` (still-live,
+// occurrence-counting code this project keeps for an unrelated reason, #541/#664) in place of the
+// forwarding body, since the original `OCCTShapeNbEdges`/`NbFaces`/`NbVertices` bridge functions this
+// issue deletes are no longer available to restore without also reverting the bridge changes:
+//
+//   nbEdges:    `Int(contents.edges)`     instead of `edgeCount`
+//   nbFaces:    `Int(contents.faces)`     instead of `faceCount`
+//   nbVertices: `Int(contents.vertices)`  instead of `vertexCount`
+//
+// | Injection             | Result                                                              |
+// |------------------------|---------------------------------------------------------------------|
+// | nbEdges -> occurrence   | nbEdgesMatchesEdgeCount FAILED: `box.nbEdges == 12` -> 24 != 12      |
+// | nbVertices -> occurrence | nbVerticesMatchesVertexCount FAILED: `box.nbVertices == 8` -> 48 != 8 |
+// | nbFaces -> occurrence   | nbFacesMatchesFaceCountOnBox PASSED (a box shares no face: 6 either way) |
+// | nbFaces -> occurrence   | nbFacesMatchesFaceCountOnSharedFace FAILED: `compound.nbFaces == 11` -> 12 != 11 |
+//
+// `nbFacesMatchesFaceCountOnBox` passing under the `nbFaces` injection is expected, not a dead
+// assertion: it is the same reason #651's own issue text calls out, a plain box shares no face, so
+// the two counting rules coincide there regardless of which one runs. It is
+// `nbFacesMatchesFaceCountOnSharedFace` that catches this specific regression, which is why both
+// tests exist. All four were restored and re-run green before this file was committed.

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -4523,7 +4523,7 @@ struct ShapeQueriesV123Tests {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let b = box {
             #expect(b.nbEdges == b.edgeCount)
-            #expect(b.nbFaces == 6)
+            #expect(b.nbFaces == b.faceCount)
             #expect(b.nbVertices == b.vertexCount)
         }
     }

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -4513,13 +4513,18 @@ struct ShapeQueriesV123Tests {
         }
     }
 
+    // Deprecated spellings of edgeCount/faceCount/vertexCount (#651); the annotation below is the
+    // project's own convention for a test that exercises a deprecated API on purpose. Coverage of
+    // the actual occurrence-vs-distinct contract these forward to lives in
+    // Issue651DeprecatedCounterTests.
+    @available(*, deprecated, message: "exercises the deprecated spelling on purpose")
     @Test("Shape nbEdges, nbFaces, nbVertices")
     func shapeSubShapeCounts() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let b = box {
-            #expect(b.nbEdges > 0)
+            #expect(b.nbEdges == b.edgeCount)
             #expect(b.nbFaces == 6)
-            #expect(b.nbVertices > 0)
+            #expect(b.nbVertices == b.vertexCount)
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -338,13 +338,15 @@ geometry included. Their index *domain* does move, which is the point of the con
 recorded in [`SEMVER.md`](SEMVER.md): on `compound{solid, solid.Reversed()}` the WIRE enumeration
 goes 12 occurrences → 6 distinct.
 
-**This is not a complete sweep of the per-occurrence idiom.** `Shape.nbEdges` / `nbVertices` /
-`nbFaces` return per-occurrence counts (a box answers **24** and **48** against `edgeCount` 12 and
-`vertexCount` 8; a split compound's `nbFaces` is **12** against `faceCount` 11) while their own
-published docs assert the deduplicated answers — filed separately as **#651**.
-`OCCTShapeFixEdgeSameParameter` and `OCCTShapeFixEdgeVertexTolerance` also document "number of edges
-fixed" while counting explorer occurrences; that one is source-visible but **unmeasured** (a box
-returns 0 either way), so it is recorded here as a candidate rather than converted on a pattern
+**This was not a complete sweep of the per-occurrence idiom at the time.** `Shape.nbEdges` /
+`nbVertices` / `nbFaces` returned per-occurrence counts (a box answered **24** and **48** against
+`edgeCount` 12 and `vertexCount` 8; a split compound's `nbFaces` was **12** against `faceCount` 11)
+while their own published docs asserted the deduplicated answers, filed separately as **#651** and
+resolved below, by deprecation rather than by repointing in place, since all three are pure
+duplicates of `edgeCount`/`faceCount`/`vertexCount` with no index or orientation dimension of their
+own. `OCCTShapeFixEdgeSameParameter` and `OCCTShapeFixEdgeVertexTolerance` also document "number of
+edges fixed" while counting explorer occurrences; that one is source-visible but **unmeasured** (a
+box returns 0 either way), so it is recorded here as a candidate rather than converted on a pattern
 match.
 
 Bridge-only plus two Swift wrappers; no kernel patch and no `OCCT.xcframework` rebuild.
@@ -353,6 +355,54 @@ Index-value changes are recorded in [`SEMVER.md`](SEMVER.md). Tests:
 `Tests/OCCTTopologyTests/Issue613IndexContractTests.swift` and
 `Tests/OCCTMeshTests/Issue613MeshIndexContractTests.swift`, 25 tests, each proven to catch its own
 site by reverting that site alone.
+
+#### `nbEdges`/`nbFaces`/`nbVertices` are deprecated in favour of the counters they duplicated (#651)
+
+`Shape.nbEdges`, `Shape.nbFaces` and `Shape.nbVertices` counted bare `TopExp_Explorer` occurrences
+(`OCCTShapeNbEdges`/`NbFaces`/`NbVertices`, `OCCTBridge_Topology.mm`), the same gap #613 closed for
+its seven entry points, while this project's own reference docs always documented the deduplicated
+answer: `docs/reference/Document-Completions.md` asserted `box.nbEdges // 12` and
+`box.nbVertices // 8`, not the 24 and 48 the implementation actually returned. Measured on a plain
+10 mm box:
+
+| | `nbEdges` | `edgeCount` | `nbVertices` | `vertexCount` | `nbFaces` | `faceCount` |
+|---|---|---|---|---|---|---|
+| box | **24** | 12 | **48** | 8 | 6 | 6 |
+
+`nbFaces` agreed with `faceCount` on the box (no face is shared within one solid), and diverged only
+on a shape with a shared face: 12 against 11 on a two-solid split compound, reproducing #613's own
+`faceIndex` measurement.
+
+**Confirmed by the Cluster A census (#664, `Scripts/repro/cluster-a-subshape-enumeration/`),** run
+specifically to settle this question before any of #638/#642/#651 started: all three are pure
+occurrence duplicates of `edgeCount`/`faceCount`/`vertexCount` in every fixture measured, with no
+index, no orientation dimension, and no consumer that reads one and not the other. That is a
+different shape from #613's seven sites, which addressed an *index* fed into another entry point and
+had no existing correctly-valued sibling to fall back on.
+
+**Decision: retire the duplicate spelling, not repoint it in place.** Following the precedent #536
+set for `removeFeatures(faces:)`/`defeature(faces:)` (two public names driving one operation, the
+newer forwarded and deprecated) rather than #541/#568/#613's own precedent (repoint the raw value,
+because those sites had no existing sibling to rename to). Repointing `nbEdges`/`nbFaces`/`nbVertices`
+in place and keeping both names was considered and rejected: once the value agrees there is nothing
+left to distinguish the two spellings, which recreates the exact duplication #490/#491/#492 and #536
+diagnosed elsewhere in this codebase.
+
+All three are now `@available(*, deprecated, renamed:)`, forwarding to `edgeCount`/`faceCount`/
+`vertexCount` respectively, so the value is correct on the way out even though the spelling is
+retired. The now-orphaned bridge functions `OCCTShapeNbEdges`/`OCCTShapeNbFaces`/`OCCTShapeNbVertices`
+are deleted, following #506's precedent for an orphan with no remaining Swift call site (`OCCTBridge`
+is a target, not a product, so nothing depends on the C symbol surviving). Recorded as a SemVer
+exception in [`SEMVER.md`](SEMVER.md), since the returned value changes even though the build does
+not break.
+
+Tests: `Tests/OCCTTopologyTests/Issue651DeprecatedCounterTests.swift`, pinning the corrected value
+against `edgeCount`/`faceCount`/`vertexCount` on a box and on a shape with a shared face, each proven
+to catch its own regression by reverting that one counter back to an occurrence walk.
+
+`docs/reference/Document-Completions.md`, `Edge.md`, `Selection.md` and `Shape-Features.md` updated
+to match; `docs/reference/Document-Completions.md` was the page whose own asserted contract this
+issue was filed against.
 
 #### The null-handle gate was blind to four of the five ways this bridge reaches a handle (#618)
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,13 +17,13 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **nine** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **ten** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
 
 - [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
 - [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
 - [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
 
-The other six change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+The other seven change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
 
 - [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
 - [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
@@ -31,8 +31,9 @@ The other six change behaviour **without breaking the build**, which is the set 
 - [#613](#recorded-exception-unreleased-the-last-seven-entry-points-join-the-one-sub-shape-enumeration-613) moves the last seven entry points off the per-occurrence walk onto that same enumeration.
 - [#498](#recorded-exception-unreleased-buildcurves3ds-default-tolerance-loosens-498) loosens `buildCurves3d`'s default tolerance 100×.
 - [#502](#recorded-exception-unreleased-the-wiresshellssolids-enumerations-join-the-deduplicated-map-502) collapses the `wires`/`shells`/`solids` enumerations onto the deduplicated sub-shape map.
+- [#651](#recorded-exception-unreleased-nbedgesnbfacesnbvertices-are-deprecated-and-forward-to-the-deduplicated-count-651) deprecates `Shape.nbEdges`/`nbFaces`/`nbVertices` in favour of `edgeCount`/`faceCount`/`vertexCount`, and changes what the deprecated three return on the way.
 
-A tenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
+An eleventh was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
 
 ## Rules
 
@@ -182,7 +183,50 @@ The exception was taken because:
 - **There is no spelling in which both survive**, for the same reason as #541 and #568: these are index *values*, so Swift cannot overload on them and a deprecation attribute has nothing to attach to.
 - **On every shape that shares no sub-shape, nothing moves** for the face-indexed and mesh entry points. The edge- and vertex-indexed ones do move on ordinary solids, because every edge of every solid is shared between two faces — that is exactly the gap #613 closes, and it is why these are recorded rather than treated as internal.
 - **One site was deliberately NOT converted.** `OCCTPolyMergeNodes` walks face occurrences to set per-face triangle winding; deduplicating it would drop a shared wall's second side. It is unchanged, documented as such, and pinned by a test that fails if a later sweep converts it.
-- **This does not finish the idiom.** `Shape.nbEdges` / `nbVertices` / `nbFaces` still return per-occurrence counts (**24** and **48** on a box against `edgeCount` 12 and `vertexCount` 8) and are filed as **#651**; they are unchanged here, so no caller of them is affected by this entry.
+- **This did not finish the idiom on its own.** `Shape.nbEdges` / `nbVertices` / `nbFaces` still returned per-occurrence counts (**24** and **48** on a box against `edgeCount` 12 and `vertexCount` 8) and were filed as **#651**. That gap is closed below.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurements, and to be named in the release notes.
+
+#### Recorded exception: Unreleased, `nbEdges`/`nbFaces`/`nbVertices` are deprecated and forward to the deduplicated count (#651)
+
+**One silent behaviour change, not a compile error, layered on a deprecation.** `Shape.nbEdges`,
+`Shape.nbFaces` and `Shape.nbVertices` counted bare `TopExp_Explorer` occurrences, exactly the gap
+#613 closed for its seven entry points, but these three name no index and drive no consumer: each is
+a pure duplicate of `edgeCount`/`faceCount`/`vertexCount`, confirmed by the Cluster A census
+(`Scripts/repro/cluster-a-subshape-enumeration/`) across every fixture it measured. This project's
+own reference docs already documented the deduplicated answer for all three (`box.nbEdges // 12`,
+`box.nbVertices // 8`), so the contract and the implementation disagreed from the day these shipped:
+
+| Break | What a caller does |
+|---|---|
+| `Shape.nbEdges` returns `edgeCount`'s value, not a `TopExp_Explorer` occurrence count | A box now reports 12, not 24. Deprecated, `renamed: "edgeCount"` |
+| `Shape.nbFaces` returns `faceCount`'s value | Nothing on a shape that shares no face (a plain box agreed already, 6 either way). On a shape with a shared face, 11 instead of 12. Deprecated, `renamed: "faceCount"` |
+| `Shape.nbVertices` returns `vertexCount`'s value | A box now reports 8, not 48. Deprecated, `renamed: "vertexCount"` |
+
+The decision was to retire the duplicate spelling rather than repoint its implementation and leave
+both names standing, following the precedent #536 set for `removeFeatures(faces:)`/`defeature(faces:)`
+(two public names driving one operation, the newer one deprecated with a forwarding body) rather than
+#541/#568/#613's own precedent (repoint the value in place, because those sites address an index with
+no existing correctly-named sibling to forward to). The alternative considered and rejected:
+
+- **Repointing `nbEdges`/`nbFaces`/`nbVertices` in place, keeping both names.** This was rejected
+  because, unlike #613's seven sites, there is nothing left to distinguish the two names once the
+  value agrees: no index, no orientation, no consumer that reads one and not the other. Two API
+  entry points answering the identical question forever is the exact duplication #490/#491/#492 and
+  #536 diagnosed and fixed elsewhere in this codebase; leaving it here after having just fixed the
+  value would recreate the pattern this SemVer document's own #536 entry retired.
+- **The exception was taken (over `unavailable`, #619's approach) because the risk is lower.**
+  #619 forced a compile error because a silently reinterpreted ordinal fed a comparison
+  (`continuityOrder >= 2`) that would silently take the wrong geometric branch. A raw count has no
+  such branch to mislead: a caller comparing it to `edgeCount` was already failing before this
+  change (the two never agreed), and a caller using it as a scale factor gets a smaller, still
+  plausible number, the same shape of change #613 already recorded above as a warning rather than a
+  break.
+- **There is a name to forward to**, unlike #613's index values, so `@available(*, deprecated,
+  renamed:)` has somewhere to point: matching #499's `PathParser` precedent (deprecated, and the
+  value changes on the way) rather than #541/#568/#613's (no spelling survives).
+- The now-orphaned bridge functions `OCCTShapeNbEdges`/`OCCTShapeNbFaces`/`OCCTShapeNbVertices` are
+  deleted rather than kept, following #506's precedent for an orphan with no remaining Swift call
+  site (`OCCTBridge` is a target, not a product, so there is no external ABI to hold stable).
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurements, and to be named in the release notes.
 
 #### Recorded exception: Unreleased, `continuityOrder` is retired rather than reinterpreted (#619)

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -960,7 +960,7 @@ public func allParts() -> Shape?
 - **OCCT:** `BOPAlgo_CellsBuilder::GetAllParts`.
 - **Example:**
   ```swift
-  if let parts = cells.allParts() { print(parts.nbFaces) }
+  if let parts = cells.allParts() { print(parts.faceCount) }
   ```
 
 ---
@@ -1202,7 +1202,7 @@ public static func sectionWithOptions(_ shape1: Shape, _ shape2: Shape,
 - **Example:**
   ```swift
   if let section = Shape.sectionWithOptions(box, cylinder, approximation: true) {
-      print(section.nbEdges)
+      print(section.edgeCount)
   }
   ```
 
@@ -2144,7 +2144,7 @@ public init?(shape1: Shape, shape2: Shape)
 - **Example:**
   ```swift
   if let sb = SectionBuilder(shape1: box, shape2: sphere) {
-      if let result = sb.build() { print(result.nbEdges) }
+      if let result = sb.build() { print(result.edgeCount) }
   }
   ```
 
@@ -2308,7 +2308,7 @@ public func build() -> Shape?
 - **Example:**
   ```swift
   if let result = sb.build() {
-      print(result.nbEdges)
+      print(result.edgeCount)
   }
   ```
 

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -1392,50 +1392,62 @@ public var orientationValue: Int
 
 ---
 
-### `Shape.nbEdges`
+### `Shape.nbEdges`: deprecated (#651)
 
-The number of edges in this shape.
+The number of edges in this shape. **Deprecated:** this is [`edgeCount`](Edge.md#edgecount)
+under a second name, and used to return a different, wrong number: a bare `TopExp_Explorer`
+occurrence count (24 on a 12-edge box, one visit per adjacent face) rather than the distinct count
+this very page always documented. Forwards to `edgeCount` now.
 
 ```swift
+@available(*, deprecated, renamed: "edgeCount")
 public var nbEdges: Int
 ```
 
-- **OCCT:** `TopExp_Explorer` over `TopAbs_EDGE`.
+- **OCCT:** `edgeCount`, i.e. `TopExp::MapShapes` over `TopAbs_EDGE`.
 - **Example:**
   ```swift
-  print(box.nbEdges) // 12
+  print(box.nbEdges) // 12, same as box.edgeCount
   ```
 
 ---
 
-### `Shape.nbFaces`
+### `Shape.nbFaces`: deprecated (#651)
 
-The number of faces in this shape.
+The number of faces in this shape. **Deprecated:** this is [`faceCount`](Selection.md#shapefacecount)
+under a second name. It agreed with `faceCount` on a plain box (no face is shared within one solid,
+so occurrence and distinct counts coincide) but not on a shape with a shared face, where it read 12
+against `faceCount`'s 11. Forwards to `faceCount` now.
 
 ```swift
+@available(*, deprecated, renamed: "faceCount")
 public var nbFaces: Int
 ```
 
-- **OCCT:** `TopExp_Explorer` over `TopAbs_FACE`.
+- **OCCT:** `faceCount`, i.e. `TopExp::MapShapes` over `TopAbs_FACE`.
 - **Example:**
   ```swift
-  print(box.nbFaces) // 6
+  print(box.nbFaces) // 6, same as box.faceCount
   ```
 
 ---
 
-### `Shape.nbVertices`
+### `Shape.nbVertices`: deprecated (#651)
 
-The number of vertices in this shape.
+The number of vertices in this shape. **Deprecated:** this is [`vertexCount`](Shape-Features.md#vertexcount)
+under a second name, and used to return a different, wrong number: a bare `TopExp_Explorer`
+occurrence count (48 on an 8-vertex box, one visit per incident edge) rather than the distinct
+count this very page always documented. Forwards to `vertexCount` now.
 
 ```swift
+@available(*, deprecated, renamed: "vertexCount")
 public var nbVertices: Int
 ```
 
-- **OCCT:** `TopExp_Explorer` over `TopAbs_VERTEX`.
+- **OCCT:** `vertexCount`, i.e. `TopExp::MapShapes` over `TopAbs_VERTEX`.
 - **Example:**
   ```swift
-  print(box.nbVertices) // 8
+  print(box.nbVertices) // 8, same as box.vertexCount
   ```
 
 ---

--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -509,6 +509,9 @@ public var edgeCount: Int { get }
   let box = Shape.box(width: 10, height: 10, depth: 10)!
   print(box.edgeCount)  // 12
   ```
+- **Deprecated alias:** [`Shape.nbEdges`](Document-Completions.md#shapenbedges-deprecated-651) was a
+  second spelling of this question, backed by a bare `TopExp_Explorer` occurrence count (24 on this
+  same box) instead of this deduplicated one. It now forwards here (#651).
 
 ---
 

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -407,6 +407,9 @@ This is the same enumeration `Shape.faces()` walks and `Shape.face(at:)` indexes
 
 - **Returns:** Count of distinct `TopoDS_Face` sub-shapes; 0 on error or if the shape has none.
 - **OCCT:** `TopExp::MapShapes(shape, TopAbs_FACE, faceMap)` → `faceMap.Extent()`.
+- **Deprecated alias:** [`Shape.nbFaces`](Document-Completions.md#shapenbfaces-deprecated-651) was a
+  second spelling of this question, backed by a bare `TopExp_Explorer` occurrence count instead of
+  this deduplicated one. It now forwards here (#651).
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1016,6 +1016,9 @@ public var vertexCount: Int { get }
 ```
 
 - **OCCT:** `TopExp::MapShapes(TopAbs_VERTEX)` (via `OCCTShapeGetVertexCount`).
+- **Deprecated alias:** [`Shape.nbVertices`](Document-Completions.md#shapenbvertices-deprecated-651)
+  was a second spelling of this question, backed by a bare `TopExp_Explorer` occurrence count (48 on
+  an 8-vertex box) instead of this deduplicated one. It now forwards here (#651).
 
 ---
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`Shape.nbEdges`, `Shape.nbFaces` and `Shape.nbVertices` counted bare `TopExp_Explorer`
occurrences (24 edges / 6 faces / 48 vertices on a 12-edge, 6-face, 8-vertex box), while this
project's own published docs always documented the deduplicated answer
(`docs/reference/Document-Completions.md`: `box.nbEdges // 12`, `box.nbVertices // 8`). The
implementation and its own docs disagreed from the day these shipped.

Closes #651

## The decision

The issue asks the same question #613 settled for its seven sites: is this the deduplicated
indexing enumeration, or a genuine occurrence count? Here the answer is neither in the sense
#613 meant it. Unlike #613's seven sites, none of `nbEdges`/`nbFaces`/`nbVertices` names an
index consumed elsewhere: they are plain counters with no index domain, no orientation
dimension, and (confirmed by the Cluster A census, #664, committed at
`Scripts/repro/cluster-a-subshape-enumeration/`) pure duplicates of `edgeCount`/`faceCount`/
`vertexCount` in every fixture measured.

**Taken: retire the duplicate spelling, deprecate and forward, following #536's precedent**
(`removeFeatures(faces:)` deprecated in favour of `defeature(faces:)`, same operation, one
name retired) rather than #613's (repoint the raw value and keep both names). All three are
now `@available(*, deprecated, renamed:)` and forward to `edgeCount`/`faceCount`/
`vertexCount`. The now-orphaned `OCCTShapeNbEdges`/`OCCTShapeNbFaces`/`OCCTShapeNbVertices`
bridge functions are deleted, following #506's precedent for an orphan with no remaining
Swift call site (`OCCTBridge` is a target, not a product).

**Rejected: repointing the implementation in place and keeping both names.** Once the value
agrees there is nothing left to distinguish `nbEdges` from `edgeCount`: no index, no
orientation, no differing consumer. Keeping both would recreate the exact duplication
#490/#491/#492 and #536 diagnosed and fixed elsewhere in this codebase.

**Rejected: `@available(*, unavailable)` (#619's approach).** #619 forced a compile error
because a silently reinterpreted ordinal fed a comparison that would take the wrong
geometric branch. A raw count has no such branch to mislead: a caller comparing it to
`edgeCount` was already failing before this change, and a caller using it as a scale factor
gets a smaller, still-plausible number, the same class of silent, non-breaking change #613
already recorded as an exception rather than a break.

Full reasoning, the rejected-alternative writeups, and the before/after table are in the new
`docs/SEMVER.md` recorded exception and the `docs/CHANGELOG.md` entry.

## Injection matrix (prove-the-test-fails)

Each of the four new tests was run once with the corresponding property temporarily reverted
to an occurrence count (`Int(contents.edges/faces/vertices)`, since the original
`TopExp_Explorer`-based bridge functions this PR deletes are gone), confirmed to fail, then
restored and confirmed to pass:

| Injection | Result |
|---|---|
| `nbEdges` -> occurrence | `nbEdgesMatchesEdgeCount` FAILED: `box.nbEdges == 12` -> 24 != 12 |
| `nbVertices` -> occurrence | `nbVerticesMatchesVertexCount` FAILED: `box.nbVertices == 8` -> 48 != 8 |
| `nbFaces` -> occurrence | `nbFacesMatchesFaceCountOnBox` PASSED (a box shares no face: 6 either way, a positive control, not a dead assertion) |
| `nbFaces` -> occurrence | `nbFacesMatchesFaceCountOnSharedFace` FAILED: `compound.nbFaces == 11` -> 12 != 11 |

All four restored and re-verified green (byte-identical diff against the pre-injection file)
before this PR was opened.

## What the issue and census got right / wrong

Nothing needed correcting. #651's own measurements and the Cluster A census (#664) both held
up exactly as stated, including the one subtlety a naive census would miss: `nbFaces`/
`faceCount` agree on a plain box (6/6, no face is shared within one solid) and diverge only on
a shape with a shared face (12/11). This is the one Cluster A member whose numbers were
confirmed accurate with no correction, unlike its two siblings (#638, #642).

## Verification

- `swift build`: clean, 0 errors, no `OCCTSWIFT_LOCAL`.
- `swift test`: **5324 tests, 0 failures** (baseline 5320 + 4 new).
- Gate scripts, all exit 0, with and without `--self-test` (`count-operations.py` has none by
  design and correctly exits 2 on `--self-test`): `check-bridge-index.py`,
  `check-null-handle-guards.py`, `check-docs-defaults.py`, `count-operations.py` (4301,
  unchanged: no public entry point added or removed, only deprecated and repointed).
- Census re-run (`swift run ClusterACensus`): `nbEdges`/`nbFaces`/`nbVertices` rows now read
  the same value as `edgeCount`/`faceCount`/`vertexCount` on every fixture. The committed
  `Scripts/repro/cluster-a-subshape-enumeration/README.md` is updated to match (dynamic table
  rows, static classification totals 127 to 124 functions since the three deleted bridge
  functions drop out, "Findings" and "Re-scoping" sections marked resolved).
- Zero em-dashes across the diff.

## Docs

- `docs/reference/Document-Completions.md`: the three entries corrected to the deprecated,
  forwarding contract (this was the page whose own asserted contract the implementation
  disagreed with).
- `docs/reference/Edge.md`, `Selection.md`, `Shape-Features.md`: cross-reference notes on
  `edgeCount`/`faceCount`/`vertexCount` pointing at the deprecated alias.
- `docs/SEMVER.md`: new recorded exception (tenth), with the before/after table and the
  rejected alternatives.
- `docs/CHANGELOG.md`: new Unreleased entry; the #613 entry's own forward-reference to #651
  updated to note resolution rather than left stale.
- `///` doc comments plus fenced `swift` snippets on all three deprecated properties and on
  the three canonical ones they forward to.

## Notes for the reviewer

- Scope: only `Shape.nbEdges`/`nbFaces`/`nbVertices` and their backing bridge functions.
  `edges()`/`faces()` themselves are untouched (owned by sibling PRs for #638/#642 running
  concurrently in their own worktrees).
- `Tests/OCCTTopologyTests/OCCTTopologyTests.swift`'s existing `shapeSubShapeCounts` test
  called these three directly with a weak `> 0` assertion; tightened to assert equality with
  `edgeCount`/`vertexCount` and annotated `@available(*, deprecated, ...)` to make the
  intentional deprecated-API use explicit rather than an unannotated warning.

## Build noise from the census target (review follow-up)

Deprecating these three left `Scripts/repro/cluster-a-subshape-enumeration/main.swift` reading them
inline. That target is wired into the root manifest, so it builds on **every push** (#694), and a
clean `swift build` gained **38 deprecation warning lines** for a one-time census.

The census should keep measuring them. Its job is to record what the public API does, and a
deprecated spelling is public API until it is removed. So the three `record()` calls moved into one
`@available(*, deprecated)` function, since a deprecated context does not warn about the deprecated
things it calls.

**38 lines to 6, which is one warning at the single call site.** That residue is honest: the census
really does use a deprecated API deliberately. Census output is byte-identical, still 45 rows.

A per-call wrapper was tried first and is **not** a fix: it silences the access inside the wrapper
and then warns at every call site instead, trading 38 warnings about `nbVertices` for 38 about
`deprecatedNbVertices`. Recording that here because it is the obvious first attempt.

When the deprecation cycle removes the three properties, the grouped function stops compiling, which
is the right prompt to drop those rows rather than lose them silently.
