### PR TITLE
fix(#613, #695): edge and vertex indices addressed occurrences, not the edges edges() names

### DIFF
--- a/Scripts/repro/613-edge-index-census/README.md
+++ b/Scripts/repro/613-edge-index-census/README.md
@@ -1,0 +1,54 @@
+# #613 / #695 — the sub-shape index census
+
+`census.py` enumerates every bridge site that resolves an index by walking a `TopExp_Explorer`
+instead of reading the deduplicated `TopExp::MapShapes` enumeration, grouped by the sub-shape type
+being walked.
+
+```bash
+python3 Scripts/repro/613-edge-index-census/census.py Sources/OCCTBridge/src
+```
+
+## Why this exists as a committed artifact
+
+The first pass at #613's back-port to `main` rebuilt the site list by reading #613's own issue body,
+and missed three sites (`OCCTBRepCheckSubShapeValid`, `OCCTBRepExtremaExtPC`,
+`OCCTBRepExtremaExtCF`) — two of them immediately adjacent to functions the same PR *did* convert.
+They were missed because #613's list was written against `refactor/381-pass1b`, where #541 had
+already converted them, so they never appeared in #613's scope. `main` never had #541.
+
+That is the failure mode `docs/v2.0.0-plan.md` names: *the census said N, the measurement said M*.
+Grep the tree, don't transcribe an issue.
+
+## Expected output on a converged tree
+
+```
+9 explorer-indexed sites
+
+--- TopAbs_FACE  (7) ---   <- deferred to #541, see below
+--- type  (2) ---          <- the deliberate WIRE/SHELL fallbacks
+```
+
+**Zero `TopAbs_EDGE` or `TopAbs_VERTEX` entries.** Any that appear are regressions: those two
+families are consistently map-based on both sides, so an occurrence walk always disagrees with its
+consumer.
+
+The two `type` entries are the WIRE/SHELL branches of `OCCTBRepCheckSubShapeValid` and
+`checkSubShape`. They are deliberate: `OCCTShapeGetWires`/`GetShells` and their counts are explorer
+walks too, so those paths already agree with their own consumers.
+
+## Why FACE is deferred rather than fixed
+
+Faces do not have the edge family's problem. Measured against the pinned kernel:
+
+| shape | FACE map / explorer | EDGE map / explorer |
+|---|---|---|
+| solid box | 6 / 6 agree | 12 / 24 diverge |
+| L-prism | 8 / 8 agree | 18 / 36 diverge |
+| compound, 2 disjoint solids | 12 / 12 agree | 24 / 48 diverge |
+| fused overlapping boxes | 14 / 14 agree | 32 / 64 diverge |
+| compound, same solid twice | 6 / 12 **diverge** | 12 / 48 diverge |
+
+An edge is shared by the two faces it bounds, so EDGE diverges on every ordinary solid. A face has
+one parent unless a compound gives it two, so FACE agrees except in that exotic case. `main`'s own
+split — `faces()` on the explorer against `faceCount`/`face(at:)` on the map — is therefore latent,
+and reconciling it is #541, a registered v2.0.0 breaking change, not a 1.x bug fix.

--- a/Scripts/repro/613-edge-index-census/census.py
+++ b/Scripts/repro/613-edge-index-census/census.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Mechanical sweep: every bridge site that resolves an index by walking a TopExp_Explorer.
+
+Flags a site when an explorer construction is followed within a few lines by an index comparison --
+the "walk until idx == N" idiom, which addresses topology OCCURRENCES rather than the deduplicated
+TopExp::MapShapes enumeration that edges()/edge(at:)/vertices() hand out.
+
+Reports every sub-shape type, grouped, rather than only the ones currently believed to matter: the
+grouping is what makes a deliberate exclusion (FACE, and the WIRE/SHELL fallbacks) visible as a
+decision rather than an oversight. See README.md for the expected output on a converged tree.
+"""
+import re
+import pathlib
+import sys
+
+SRC = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "Sources/OCCTBridge/src")
+
+explorer = re.compile(r"TopExp_Explorer\s+(\w+)\s*\(([^,]+),\s*([A-Za-z_][\w:]*)")
+compare = re.compile(r"\b(\w+)\s*==\s*(\w*[Ii]ndex\w*|\w*Idx\w*)\b|\b(\w*[Ii]ndex\w*|\w*Idx\w*)\s*==\s*(\w+)\b")
+
+rows = []
+for path in sorted(SRC.glob("*.mm")):
+    lines = path.read_text().splitlines()
+    for n, line in enumerate(lines):
+        m = explorer.search(line)
+        if not m:
+            continue
+        shape_type = m.group(3)
+        # Look ahead a few lines for an index comparison inside the loop body.
+        window = "\n".join(lines[n:n + 6])
+        if not compare.search(window):
+            continue
+        rows.append((str(path), n + 1, shape_type, line.strip()[:95]))
+
+by_type = {}
+for path, n, t, _ in rows:
+    by_type.setdefault(t, []).append((path, n))
+
+print(f"{len(rows)} explorer-indexed sites\n")
+for t in sorted(by_type):
+    print(f"--- {t}  ({len(by_type[t])}) ---")
+    for path, n in by_type[t]:
+        print(f"    {path}:{n}")
+    print()

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -1232,6 +1232,19 @@ int32_t OCCTShapeGetTotalEdgeCount(OCCTShapeRef shape);
 /// @return Edge reference, or NULL if index out of bounds. Caller must release.
 OCCTEdgeRef OCCTShapeGetEdgeAtIndex(OCCTShapeRef shape, int32_t index);
 
+/// The 0-based index of `edgeShape` within `shape`'s edge enumeration — the inverse of
+/// OCCTShapeGetEdgeAtIndex, and the same enumeration OCCTShapeGetTotalEdgeCount counts.
+///
+/// Use it to stamp an index onto an edge produced by an operation that returns loose edges
+/// (LocOpe_FindEdges, LocOpe_FindEdgesInFace), so the caller can feed it straight back into
+/// edge-index consumers such as filleting. Orientation-insensitive: a REVERSED occurrence resolves
+/// to the index its FORWARD twin is stored under.
+///
+/// @param shape The parent shape whose enumeration defines the index
+/// @param edgeShape A shape wrapping the TopoDS_Edge to locate
+/// @return 0-based index, or -1 if `edgeShape` is not an edge of `shape`
+int32_t OCCTShapeIndexOfEdge(OCCTShapeRef shape, OCCTShapeRef edgeShape);
+
 /// Release an edge reference
 void OCCTEdgeRelease(OCCTEdgeRef edge);
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2048,14 +2048,24 @@ static OCCTShapeCheckResult checkSubShape(OCCTShapeRef shape, TopAbs_ShapeEnum t
     if (!shape) return result;
 
     try {
+        // #613: EDGE and VERTEX indices are positions in the deduplicated TopExp::MapShapes
+        // enumeration, which is what Shape.edges()/edge(at:) and Shape.vertices() hand out; a bare
+        // explorer walk names a different sub-shape from the first repeated occurrence onwards.
+        // WIRE and SHELL stay on the explorer deliberately: OCCTShapeGetWires/GetShells and their
+        // counts are explorer walks too, so these paths already agree with their own consumers,
+        // and converging them belongs with converting those accessors.
         TopoDS_Shape subShape;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, type); exp.More(); exp.Next()) {
-            if (idx == index) {
-                subShape = exp.Current();
-                break;
+        if (type == TopAbs_EDGE || type == TopAbs_VERTEX) {
+            subShape = occtSubShapeAtIndex(shape->shape, type, index);
+        } else {
+            int idx = 0;
+            for (TopExp_Explorer exp(shape->shape, type); exp.More(); exp.Next()) {
+                if (idx == index) {
+                    subShape = exp.Current();
+                    break;
+                }
+                idx++;
             }
-            idx++;
         }
         if (subShape.IsNull()) return result;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2027,7 +2027,18 @@ bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape, int32_t subShapeType, 
     try {
         BRepCheck_Analyzer analyzer(parentShape->shape, true);
 
+        // #613: the other half of the same "is this sub-shape valid" surface as checkSubShape
+        // below, and it must read the index the same way -- otherwise isSubShapeValid(type: .edge,
+        // at: 12) and checkEdge(at: 12) disagree about which edge index 12 is, on a 12-edge box.
+        // EDGE and VERTEX read the deduplicated map; WIRE/SHELL/FACE keep the traversal for the
+        // reasons given at checkSubShape.
         TopAbs_ShapeEnum type = (TopAbs_ShapeEnum)subShapeType;
+        if (type == TopAbs_EDGE || type == TopAbs_VERTEX) {
+            const TopoDS_Shape sub = occtSubShapeAtIndex(parentShape->shape, type, subShapeIndex);
+            if (sub.IsNull()) return false;
+            return analyzer.IsValid(sub);
+        }
+
         int idx = 0;
         for (TopExp_Explorer exp(parentShape->shape, type); exp.More(); exp.Next()) {
             if (idx == subShapeIndex) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -53,6 +53,60 @@
 #include <TDF_Label.hxx>
 #include <TNaming_Scope.hxx>
 #include <BRepOffsetAPI_MakeFilling.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+
+// === #613: one meaning for an edge or vertex index ===
+//
+// An edge or vertex index crossing this bridge is a 0-based position in the DEDUPLICATED
+// TopExp::MapShapes enumeration -- the one Shape.edges()/edgeCount/edge(at:) and
+// Shape.vertices()/vertexCount already read. It is NOT a position in a bare TopExp_Explorer walk,
+// which yields one entry per topology OCCURRENCE.
+//
+// The two disagree on every ordinary solid, because an edge is shared by the two faces it bounds.
+// Measured on this branch's kernel: a 20mm box has 12 distinct edges and 24 edge occurrences; the
+// issue's L-prism has 18 and 36. From the first repeat onwards, index n names a different edge in
+// each enumeration. (Faces are the exception -- explorer and map agree on ordinary solids and
+// diverge only when one face has two parents, e.g. the same solid added twice to a compound --
+// which is why face indexing is left alone here and belongs to #541.)
+//
+// Reading the map rather than the traversal is safe for these consumers: the map's equality is
+// TopoDS_Shape::IsSame (TopTools_ShapeMapHasher), so orientation cannot select a different entry,
+// and none of the call sites converted here depend on an occurrence's orientation.
+
+/// The edge at 0-based `index` in `shape`'s deduplicated edge enumeration, or a null TopoDS_Edge
+/// when the index is negative or past the end.
+inline TopoDS_Edge occtEdgeAtIndex(const TopoDS_Shape& shape, int32_t index) {
+    if (index < 0) return TopoDS_Edge();
+    TopTools_IndexedMapOfShape map;
+    TopExp::MapShapes(shape, TopAbs_EDGE, map);
+    if (index >= map.Extent()) return TopoDS_Edge();
+    return TopoDS::Edge(map(index + 1));  // OCCT's indexed maps are 1-based
+}
+
+/// The sub-shape at 0-based `index` in `shape`'s deduplicated enumeration of `type`, or a null
+/// TopoDS_Shape when the index is out of range.
+inline TopoDS_Shape occtSubShapeAtIndex(const TopoDS_Shape& shape, TopAbs_ShapeEnum type,
+                                        int32_t index) {
+    if (index < 0) return TopoDS_Shape();
+    TopTools_IndexedMapOfShape map;
+    TopExp::MapShapes(shape, type, map);
+    if (index >= map.Extent()) return TopoDS_Shape();
+    return map(index + 1);
+}
+
+/// The 0-based position of `sub` in `shape`'s deduplicated enumeration of `type`, or -1 when `sub`
+/// is not a sub-shape of that type. The inverse of occtSubShapeAtIndex, used to stamp an index a
+/// caller can feed straight back into edges()/edge(at:).
+inline int32_t occtIndexOfSubShape(const TopoDS_Shape& shape, TopAbs_ShapeEnum type,
+                                   const TopoDS_Shape& sub) {
+    if (sub.IsNull()) return -1;
+    TopTools_IndexedMapOfShape map;
+    TopExp::MapShapes(shape, type, map);
+    const int32_t found = map.FindIndex(sub);
+    return found > 0 ? found - 1 : -1;  // FindIndex is 1-based, 0 means absent
+}
 
 // === Foundation struct definitions ===
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -4798,16 +4798,8 @@ OCCTShapeRef OCCTLocOpeSplitShapeByVertex(OCCTShapeRef shape, int32_t edgeIndex,
     try {
         LocOpe_SplitShape splitter(shape->shape);
 
-        // Find the target edge
-        TopoDS_Edge edge;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            if (idx == edgeIndex) {
-                edge = TopoDS::Edge(exp.Current());
-                break;
-            }
-            idx++;
-        }
+        // #613: the deduplicated enumeration edges()/edge(at:) hand out, not an occurrence walk.
+        TopoDS_Edge edge = occtEdgeAtIndex(shape->shape, edgeIndex);
         if (edge.IsNull()) return nullptr;
 
         // Get edge parameter range
@@ -7189,18 +7181,15 @@ OCCTShapeRef _Nullable OCCTBiTgteBlend(OCCTShapeRef _Nonnull shape,
     try {
         BiTgte_Blend blend(shape->shape, radius, tolerance, nubs);
 
-        // Collect edges by index
-        TopExp_Explorer edgeExp(shape->shape, TopAbs_EDGE);
-        std::vector<TopoDS_Edge> allEdges;
-        while (edgeExp.More()) {
-            allEdges.push_back(TopoDS::Edge(edgeExp.Current()));
-            edgeExp.Next();
-        }
+        // Collect edges by index. #613: the deduplicated TopExp::MapShapes enumeration, which is
+        // where the caller's Edge.index came from, not an occurrence walk.
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
         for (int32_t i = 0; i < edgeCount; i++) {
             int32_t idx = edgeIndices[i];
-            if (idx >= 0 && idx < (int32_t)allEdges.size()) {
-                blend.SetEdge(allEdges[idx]);
+            if (idx >= 0 && idx < edgeMap.Extent()) {
+                blend.SetEdge(TopoDS::Edge(edgeMap(idx + 1)));  // maps are 1-based
             }
         }
 
@@ -7227,17 +7216,15 @@ OCCTBiTgteBlendInfo OCCTBiTgteBlendInfo_(OCCTShapeRef _Nonnull shape,
     try {
         BiTgte_Blend blend(shape->shape, radius, tolerance, false);
 
-        TopExp_Explorer edgeExp(shape->shape, TopAbs_EDGE);
-        std::vector<TopoDS_Edge> allEdges;
-        while (edgeExp.More()) {
-            allEdges.push_back(TopoDS::Edge(edgeExp.Current()));
-            edgeExp.Next();
-        }
+        // #613: same deduplicated enumeration as OCCTBiTgteBlend above, so the info a caller reads
+        // back describes the same edge set the build would use.
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
 
         for (int32_t i = 0; i < edgeCount; i++) {
             int32_t idx = edgeIndices[i];
-            if (idx >= 0 && idx < (int32_t)allEdges.size()) {
-                blend.SetEdge(allEdges[idx]);
+            if (idx >= 0 && idx < edgeMap.Extent()) {
+                blend.SetEdge(TopoDS::Edge(edgeMap(idx + 1)));
             }
         }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1052,10 +1052,18 @@ int32_t OCCTShapeAnalyzeEdgeConcavity(OCCTShapeRef shape, double angle,
         BRepOffset_Analyse analyser(shape->shape, angle);
         if (!analyser.IsDone()) return -1;
 
+        // #695: this walked a bare TopExp_Explorer, one entry per OCCURRENCE, while Swift zips the
+        // result against edges() -- the deduplicated TopExp::MapShapes enumeration. A 20mm box has
+        // 24 edge occurrences over 12 edges, so the two desynchronise from the first repeat and
+        // every classification after it lands on the wrong edge. Measured on the issue's L-prism:
+        // the one genuinely concave edge (map index 7, the reentrant corner) was reported convex
+        // while map indices 9 and 12, two convex edges in the top cap, were reported concave.
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
+
         int32_t count = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More() && count < maxEntries; exp.Next()) {
-            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
-            const auto& intervals = analyser.Type(edge);
+        for (int32_t i = 1; i <= edgeMap.Extent() && count < maxEntries; i++) {
+            const auto& intervals = analyser.Type(TopoDS::Edge(edgeMap(i)));  // maps are 1-based
             // Use the first interval's type for the overall edge classification
             for (auto it = intervals.begin(); it != intervals.end(); ++it) {
                 OCCTConcavityType type;
@@ -1084,10 +1092,14 @@ int32_t OCCTShapeCountEdgeConcavity(OCCTShapeRef shape, double angle, int32_t ty
         else if (type == 1) targetType = ChFiDS_Concave;
         else targetType = ChFiDS_Tangential;
 
+        // #695: counted occurrences, so a 12-edge box reported 24 convex edges. Distinct edges now,
+        // which is the number edgeCount reports and the number of entries the classifier above fills.
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape->shape, TopAbs_EDGE, edgeMap);
+
         int32_t count = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
-            const auto& intervals = analyser.Type(edge);
+        for (int32_t i = 1; i <= edgeMap.Extent(); i++) {
+            const auto& intervals = analyser.Type(TopoDS::Edge(edgeMap(i)));
             for (auto it = intervals.begin(); it != intervals.end(); ++it) {
                 if (it->Type() == targetType) {
                     count++;
@@ -1107,18 +1119,12 @@ OCCTEdgeEdgeExtremaResult OCCTBRepExtremaExtCC(OCCTShapeRef shape1, int32_t edge
     OCCTEdgeEdgeExtremaResult result = {};
     if (!shape1 || !shape2) return result;
     try {
-        // Find edges
-        TopoDS_Edge e1, e2;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape1->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            if (idx == edgeIndex1) { e1 = TopoDS::Edge(exp.Current()); break; }
-            idx++;
-        }
-        idx = 0;
-        for (TopExp_Explorer exp(shape2->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            if (idx == edgeIndex2) { e2 = TopoDS::Edge(exp.Current()); break; }
-            idx++;
-        }
+        // Find edges. #613: an edge index crossing this bridge is a position in the deduplicated
+        // TopExp::MapShapes enumeration -- the one edges()/edgeCount/edge(at:) share -- not in a
+        // bare explorer walk, which yields one entry per occurrence and so names a different edge
+        // from the first repeat onwards.
+        TopoDS_Edge e1 = occtEdgeAtIndex(shape1->shape, edgeIndex1);
+        TopoDS_Edge e2 = occtEdgeAtIndex(shape2->shape, edgeIndex2);
         if (e1.IsNull() || e2.IsNull()) return result;
 
         BRepExtrema_ExtCC extCC(e1, e2);
@@ -4276,6 +4282,17 @@ OCCTEdgeRef OCCTShapeGetEdgeAtIndex(OCCTShapeRef shape, int32_t index) {
         return new OCCTEdge(edge);
     } catch (...) {
         return nullptr;
+    }
+}
+
+int32_t OCCTShapeIndexOfEdge(OCCTShapeRef shape, OCCTShapeRef edgeShape) {
+    if (!shape || !edgeShape) return -1;
+
+    try {
+        if (edgeShape->shape.IsNull() || edgeShape->shape.ShapeType() != TopAbs_EDGE) return -1;
+        return occtIndexOfSubShape(shape->shape, TopAbs_EDGE, edgeShape->shape);
+    } catch (...) {
+        return -1;
     }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1273,12 +1273,8 @@ OCCTPointEdgeExtremaResult OCCTBRepExtremaExtPC(double px, double py, double pz,
     OCCTPointEdgeExtremaResult result = {};
     if (!shape) return result;
     try {
-        TopoDS_Edge edge;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            if (idx == edgeIndex) { edge = TopoDS::Edge(exp.Current()); break; }
-            idx++;
-        }
+        // #613: the deduplicated enumeration, matching its ExtCC/ExtCF siblings in this file.
+        TopoDS_Edge edge = occtEdgeAtIndex(shape->shape, edgeIndex);
         if (edge.IsNull()) return result;
 
         TopoDS_Vertex vertex = BRepBuilderAPI_MakeVertex(gp_Pnt(px, py, pz));
@@ -1313,16 +1309,14 @@ OCCTEdgeFaceExtremaResult OCCTBRepExtremaExtCF(OCCTShapeRef shape1, int32_t edge
     OCCTEdgeFaceExtremaResult result = {};
     if (!shape1 || !shape2) return result;
     try {
-        TopoDS_Edge edge;
-        int idx = 0;
-        for (TopExp_Explorer exp(shape1->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            if (idx == edgeIndex) { edge = TopoDS::Edge(exp.Current()); break; }
-            idx++;
-        }
+        // #613: the edge index reads the deduplicated enumeration. The face index deliberately does
+        // not -- faces are the exception (explorer and map agree on ordinary solids, diverging only
+        // when one face has two parents), and reconciling faces() with faceCount/face(at:) is #541.
+        TopoDS_Edge edge = occtEdgeAtIndex(shape1->shape, edgeIndex);
         if (edge.IsNull()) return result;
 
         TopoDS_Face face;
-        idx = 0;
+        int idx = 0;
         for (TopExp_Explorer exp(shape2->shape, TopAbs_FACE); exp.More(); exp.Next()) {
             if (idx == faceIndex) { face = TopoDS::Face(exp.Current()); break; }
             idx++;

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -6623,6 +6623,15 @@ extension Shape {
     /// Analyzes the angles between adjacent faces at each edge to determine
     /// whether each edge is convex, concave, or tangent.
     ///
+    /// One entry per distinct edge, in ``edges()`` order — so the classification at position `n`
+    /// describes `edges()[n]`, and `result[n].0.index == n`.
+    ///
+    /// ```swift
+    /// for (edge, kind) in bracket.edgeConcavities() ?? [] where kind == .concave {
+    ///     print("inside corner at edge \(edge.index), length \(edge.length)")
+    /// }
+    /// ```
+    ///
     /// - Parameter angle: Threshold angle for tangent classification (radians, default 0.01)
     /// - Returns: Array of (edge, concavity) pairs, or nil on error
     public func edgeConcavities(angle: Double = 0.01) -> [(Edge, EdgeConcavity)]? {
@@ -6652,6 +6661,15 @@ extension Shape {
     }
 
     /// Count edges of a specific concavity type.
+    ///
+    /// Counts distinct edges, so the three type counts sum to at most ``edgeCount`` — before #613
+    /// this counted topology *occurrences* and a 12-edge box reported 24 convex edges.
+    ///
+    /// ```swift
+    /// let box = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20)!
+    /// box.edgeConcavityCount(.convex)   // 12, matching box.edgeCount
+    /// box.edgeConcavityCount(.concave)  // 0
+    /// ```
     ///
     /// - Parameters:
     ///   - type: Concavity type to count
@@ -7311,8 +7329,18 @@ extension Shape {
     ///
     /// Uses LocOpe_FindEdges to identify shared edges.
     ///
+    /// Each returned edge carries the index it has in *this* shape's ``edges()``, so it feeds
+    /// straight into edge-index consumers such as ``filleted(edges:radius:)``. Before #613 the
+    /// stamped index was the position in the result buffer, which addressed an unrelated edge.
+    ///
+    /// ```swift
+    /// let shared = bracket.commonEdges(with: plate)
+    /// bracket.edges()[shared[0].index].length == shared[0].length   // true
+    /// let rounded = bracket.filleted(edges: shared, radius: 1)
+    /// ```
+    ///
     /// - Parameter other: Shape to compare with
-    /// - Returns: Array of common edges
+    /// - Returns: Array of common edges, each carrying its index in this shape's ``edges()``
     public func commonEdges(with other: Shape) -> [Edge] {
         var buffer = [OCCTShapeRef?](repeating: nil, count: 100)
         let count = OCCTLocOpeFindEdges(handle, other.handle, &buffer, 100)
@@ -7339,8 +7367,16 @@ extension Shape {
     ///
     /// Uses LocOpe_FindEdgesInFace.
     ///
+    /// As with ``commonEdges(with:)``, each returned edge carries its index in this shape's
+    /// ``edges()`` (#613), so the result feeds straight into edge-index consumers.
+    ///
+    /// ```swift
+    /// let onTop = part.edgesInFace(at: 0)
+    /// let rounded = part.filleted(edges: onTop, radius: 1)
+    /// ```
+    ///
     /// - Parameter faceIndex: Index of the face to check (0-based)
-    /// - Returns: Array of edges found in the face
+    /// - Returns: Array of edges found in the face, each carrying its index in ``edges()``
     public func edgesInFace(at faceIndex: Int) -> [Edge] {
         var buffer = [OCCTShapeRef?](repeating: nil, count: 100)
         let count = OCCTLocOpeFindEdgesInFace(handle, Int32(faceIndex), &buffer, 100)

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -7320,9 +7320,12 @@ extension Shape {
         edges.reserveCapacity(Int(count))
         for i in 0..<Int(count) {
             if let ref = buffer[i] {
-                // Convert shape to edge
+                // Convert shape to edge. #613: stamp the index this edge has in THIS shape's
+                // edges() enumeration, not its position in the result buffer -- the buffer
+                // position addresses an unrelated edge once fed back into filleted(edges:).
                 if let edgeRef = OCCTShapeGetEdgeAtIndex(ref, 0) {
-                    edges.append(Edge(handle: edgeRef, index: i))
+                    edges.append(Edge(handle: edgeRef,
+                                      index: Int(OCCTShapeIndexOfEdge(handle, ref))))
                 }
                 OCCTShapeRelease(ref)
             }
@@ -7345,8 +7348,10 @@ extension Shape {
         edges.reserveCapacity(Int(count))
         for i in 0..<Int(count) {
             if let ref = buffer[i] {
+                // #613: the index this edge has in edges(), not its buffer position.
                 if let edgeRef = OCCTShapeGetEdgeAtIndex(ref, 0) {
-                    edges.append(Edge(handle: edgeRef, index: i))
+                    edges.append(Edge(handle: edgeRef,
+                                      index: Int(OCCTShapeIndexOfEdge(handle, ref))))
                 }
                 OCCTShapeRelease(ref)
             }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -7351,9 +7351,15 @@ extension Shape {
                 // Convert shape to edge. #613: stamp the index this edge has in THIS shape's
                 // edges() enumeration, not its position in the result buffer -- the buffer
                 // position addresses an unrelated edge once fed back into filleted(edges:).
-                if let edgeRef = OCCTShapeGetEdgeAtIndex(ref, 0) {
-                    edges.append(Edge(handle: edgeRef,
-                                      index: Int(OCCTShapeIndexOfEdge(handle, ref))))
+                //
+                // An unresolvable edge is dropped rather than stamped -1: every Edge these APIs
+                // hand back promises to be addressable in edges(), and a -1 would fail later and
+                // elsewhere (a trap in edges()[index], or a bad index into filleted(edges:)).
+                // LocOpe_FindEdges returns sub-shapes of this very shape and the lookup is
+                // IsSame-based, so this is a guard against a broken promise, not an expected path.
+                let parentIndex = Int(OCCTShapeIndexOfEdge(handle, ref))
+                if parentIndex >= 0, let edgeRef = OCCTShapeGetEdgeAtIndex(ref, 0) {
+                    edges.append(Edge(handle: edgeRef, index: parentIndex))
                 }
                 OCCTShapeRelease(ref)
             }
@@ -7384,10 +7390,11 @@ extension Shape {
         edges.reserveCapacity(Int(count))
         for i in 0..<Int(count) {
             if let ref = buffer[i] {
-                // #613: the index this edge has in edges(), not its buffer position.
-                if let edgeRef = OCCTShapeGetEdgeAtIndex(ref, 0) {
-                    edges.append(Edge(handle: edgeRef,
-                                      index: Int(OCCTShapeIndexOfEdge(handle, ref))))
+                // #613: the index this edge has in edges(), not its buffer position. Unresolvable
+                // edges are dropped rather than stamped -1, as in commonEdges(with:) above.
+                let parentIndex = Int(OCCTShapeIndexOfEdge(handle, ref))
+                if parentIndex >= 0, let edgeRef = OCCTShapeGetEdgeAtIndex(ref, 0) {
+                    edges.append(Edge(handle: edgeRef, index: parentIndex))
                 }
                 OCCTShapeRelease(ref)
             }
@@ -7448,6 +7455,15 @@ extension Shape {
     }
 
     /// Check if a specific sub-shape is valid within this shape's context.
+    ///
+    /// For `.edge` and `.vertex` the index addresses the same sub-shape as ``edges()``/`vertices()`,
+    /// so this agrees with ``checkEdge(at:)``/``checkVertex(at:)`` at every index (#613).
+    ///
+    /// ```swift
+    /// let box = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20)!
+    /// box.isSubShapeValid(type: .edge, at: 3)   // true, same edge as box.edges()[3]
+    /// box.isSubShapeValid(type: .edge, at: 12)  // false — past edgeCount
+    /// ```
     ///
     /// - Parameters:
     ///   - type: Type of sub-shape to check
@@ -7757,10 +7773,20 @@ extension Shape {
     ///
     /// Uses BRepExtrema_ExtPC to find the closest point on the specified edge.
     ///
+    /// `edgeIndex` addresses the same edge as `edges()[edgeIndex]` (#613). Note that
+    /// `BRepExtrema_ExtPC` reports *interior* extrema only, so an edge whose nearest point is one of
+    /// its endpoints yields nil — use ``Edge/distance(to:)`` for an unconditional minimum.
+    ///
+    /// ```swift
+    /// if let hit = part.pointEdgeExtrema(point: probe, edgeIndex: 2) {
+    ///     print("nearest point on edges()[2] is \(hit.pointOnEdge) at \(hit.distance)")
+    /// }
+    /// ```
+    ///
     /// - Parameters:
     ///   - point: 3D point
-    ///   - edgeIndex: 0-based edge index
-    /// - Returns: Extrema result, or nil if computation fails
+    ///   - edgeIndex: 0-based edge index, as handed out by ``edges()``
+    /// - Returns: Extrema result, or nil if computation fails or the index is out of range
     public func pointEdgeExtrema(point: SIMD3<Double>, edgeIndex: Int) -> PointEdgeExtrema? {
         let result = OCCTBRepExtremaExtPC(point.x, point.y, point.z, handle, Int32(edgeIndex))
         guard result.solutionCount > 0 else { return nil }
@@ -7797,8 +7823,15 @@ extension Shape {
     /// Uses BRepExtrema_ExtCF to find the closest points between
     /// the specified edge of this shape and a face of another shape.
     ///
+    /// `edgeIndex` addresses the same edge as `edges()[edgeIndex]` (#613); an index at or above
+    /// ``edgeCount`` yields nil. Face indexing is unchanged and still follows `faces()`.
+    ///
+    /// ```swift
+    /// let gap = bracket.edgeFaceExtrema(edgeIndex: 4, other: plate, faceIndex: 0)?.distance
+    /// ```
+    ///
     /// - Parameters:
-    ///   - edgeIndex: 0-based edge index in this shape
+    ///   - edgeIndex: 0-based edge index in this shape, as handed out by ``edges()``
     ///   - other: Shape containing the face
     ///   - faceIndex: 0-based face index in the other shape
     /// - Returns: Extrema result, or nil if parallel or computation fails

--- a/Tests/OCCTTopologyTests/Issue613EdgeIndexContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue613EdgeIndexContractTests.swift
@@ -1,0 +1,152 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #613: an edge or vertex index crossing the bridge means a position in the **deduplicated**
+/// `TopExp::MapShapes` enumeration — the one `edges()` / `edgeCount` / `edge(at:)` and
+/// `vertices()` / `vertexCount` already use. Several entry points instead walked a bare
+/// `TopExp_Explorer`, which yields one entry per topology **occurrence**.
+///
+/// The two disagree on every ordinary solid, because each edge is shared by the two faces it
+/// bounds. Measured against this kernel: a 20 mm box has 12 distinct edges and **24** edge
+/// occurrences; the L-prism has 18 and 36.
+///
+/// That surplus is what these tests key on. An index at or above `edgeCount` is one `edges()` can
+/// never hand out, but it addressed a real edge under the occurrence walk — so every converted
+/// entry point must now refuse it. A test that only passed valid indices would not tell the two
+/// schemes apart at all.
+@Suite("Issue 613 — edge and vertex index contract")
+struct Issue613EdgeIndexContractTests {
+
+    /// Distinct sub-shapes versus occurrences, the asymmetry the whole issue rests on.
+    @Test("a box has twice as many edge occurrences as it has distinct edges")
+    func occurrencesExceedDistinctEdges() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        #expect(box.edgeCount == 12)
+        #expect(box.edges().count == 12)
+        // 12 faces-worth of sharing: every index in 12..<24 was reachable through the old walk.
+        #expect(box.subShapeCount(ofType: .edge) == 12)
+    }
+
+    // MARK: - BRepCheck per sub-shape (checkSubShape)
+
+    @Test("checkEdge refuses an index edges() cannot produce")
+    func checkEdgeRefusesOutOfRange() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+
+        // Every real edge checks out.
+        for i in 0..<box.edgeCount {
+            #expect(box.checkEdge(at: i).isValid, "edge \(i) should be a valid edge")
+        }
+        // The first index past the end. Under the occurrence walk this named a real edge and
+        // reported valid; there are 24 occurrences behind these 12 edges.
+        #expect(!box.checkEdge(at: box.edgeCount).isValid)
+        #expect(!box.checkEdge(at: box.edgeCount + 5).isValid)
+    }
+
+    @Test("checkVertex refuses an index vertices() cannot produce")
+    func checkVertexRefusesOutOfRange() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        #expect(box.vertexCount == 8)
+
+        for i in 0..<box.vertexCount {
+            #expect(box.checkVertex(at: i).isValid, "vertex \(i) should be a valid vertex")
+        }
+        // A box has 8 distinct vertices behind 48 occurrences.
+        #expect(!box.checkVertex(at: box.vertexCount).isValid)
+        #expect(!box.checkVertex(at: box.vertexCount + 10).isValid)
+    }
+
+    // MARK: - BRepExtrema_ExtCC (edgeEdgeExtrema)
+
+    @Test("edgeEdgeExtrema refuses an index edges() cannot produce")
+    func extremaAddressesTheNamedEdge() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 20, height: 20, depth: 20))
+        let moved = try #require(Shape.box(origin: SIMD3(0, 0, 50),
+                                           width: 20, height: 20, depth: 20))
+
+        // In-range indices resolve. Not all of them: the two shapes are translates, so many
+        // same-index pairs are parallel, and BRepExtrema_ExtCC reports no solution for those by
+        // design (the parallel guard this repo carries for the OCCT crash). Some must resolve.
+        let resolved = (0..<box.edgeCount).filter {
+            box.edgeEdgeExtrema(edgeIndex1: $0, other: moved, edgeIndex2: $0) != nil
+        }
+        #expect(!resolved.isEmpty, "no in-range edge pair resolved at all")
+
+        // The discriminating half: indices 12..23 each addressed a real edge under the occurrence
+        // walk, because a 12-edge box has 24 edge occurrences. None may resolve now.
+        for i in box.edgeCount..<(box.edgeCount * 2) {
+            #expect(box.edgeEdgeExtrema(edgeIndex1: i, other: moved, edgeIndex2: 0) == nil,
+                    "index \(i) is past edgeCount \(box.edgeCount) and must not resolve")
+        }
+        #expect(box.edgeEdgeExtrema(edgeIndex1: 0, other: moved, edgeIndex2: moved.edgeCount) == nil)
+    }
+
+    // MARK: - LocOpe_SplitShape (splitEdge)
+
+    /// The sharpest of these: a 10x20x30 box has edges of three distinct lengths, and `splitEdge`
+    /// hands back just the two halves. Splitting index `i` at t = 0.5 must therefore produce two
+    /// pieces of exactly `edges()[i].length / 2` — which pins the index to one specific edge
+    /// rather than merely to "some edge".
+    @Test("splitEdge halves the edge edges() names, at every index")
+    func splitEdgeUsesTheSameEnumeration() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 10, height: 20, depth: 30))
+        let lengths = box.edges().map(\.length)
+        try #require(Set(lengths.map { Int($0.rounded()) }) == [10, 20, 30],
+                     "the fixture must have distinct edge lengths to be discriminating")
+
+        for i in 0..<box.edgeCount {
+            let split = try #require(box.splitEdge(at: i, parameter: 0.5),
+                                     "edge \(i) should split")
+            #expect(split.edgeCount == 2, "a halved edge is two pieces, got \(split.edgeCount)")
+            for piece in split.edges() {
+                #expect(abs(piece.length - lengths[i] / 2) < 1e-6,
+                        "edge \(i) is \(lengths[i]) long, so each half is \(lengths[i] / 2), got \(piece.length)")
+            }
+        }
+
+        #expect(box.splitEdge(at: box.edgeCount, parameter: 0.5) == nil)
+    }
+
+    // MARK: - Edge.index stamped on loose edges (LocOpe_FindEdges / FindEdgesInFace)
+
+    @Test("commonEdges stamps an index that round-trips through edges()")
+    func commonEdgesStampParentIndex() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 20, height: 20, depth: 20))
+        let other = try #require(Shape.box(origin: SIMD3(20, 0, 0),
+                                           width: 20, height: 20, depth: 20))
+
+        let shared = box.commonEdges(with: other)
+        try #require(!shared.isEmpty, "the two boxes abut, so they share edges")
+
+        for e in shared {
+            // Before the fix this was the position in the result buffer (0, 1, 2, ...), which
+            // addresses an unrelated edge once fed back into edges() or filleted(edges:).
+            #expect(e.index >= 0 && e.index < box.edgeCount,
+                    "index \(e.index) is not addressable in a \(box.edgeCount)-edge shape")
+            let named = box.edges()[e.index]
+            #expect(abs(named.length - e.length) < 1e-6,
+                    "edges()[\(e.index)] is \(named.length) long, the stamped edge is \(e.length)")
+        }
+    }
+
+    @Test("edgesInFace stamps an index that round-trips through edges()")
+    func edgesInFaceStampParentIndex() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 20, height: 20, depth: 20))
+
+        let found = box.edgesInFace(at: 0)
+        try #require(!found.isEmpty, "a box face is bounded by edges")
+
+        for e in found {
+            #expect(e.index >= 0 && e.index < box.edgeCount,
+                    "index \(e.index) is not addressable in a \(box.edgeCount)-edge shape")
+            let named = box.edges()[e.index]
+            #expect(abs(named.length - e.length) < 1e-6,
+                    "edges()[\(e.index)] is \(named.length) long, the stamped edge is \(e.length)")
+        }
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue613EdgeIndexContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue613EdgeIndexContractTests.swift
@@ -110,6 +110,82 @@ struct Issue613EdgeIndexContractTests {
         #expect(box.splitEdge(at: box.edgeCount, parameter: 0.5) == nil)
     }
 
+    // MARK: - BRepCheck_Analyzer (isSubShapeValid), the other half of the check surface
+
+    /// `isSubShapeValid(type:at:)` and `checkEdge(at:)` answer the same question about the same
+    /// index, so they must read the same enumeration. Converting one and not the other leaves them
+    /// disagreeing about which edge index 12 is on a 12-edge box.
+    @Test("isSubShapeValid reads the same enumeration as checkEdge and checkVertex")
+    func subShapeValidMatchesTheCheckEntryPoints() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 20, height: 20, depth: 20))
+
+        for i in 0..<box.edgeCount {
+            #expect(box.isSubShapeValid(type: .edge, at: i) == box.checkEdge(at: i).isValid,
+                    "the two check entry points disagree about edge \(i)")
+        }
+        for i in 0..<box.vertexCount {
+            #expect(box.isSubShapeValid(type: .vertex, at: i) == box.checkVertex(at: i).isValid,
+                    "the two check entry points disagree about vertex \(i)")
+        }
+
+        // The surplus: these kept answering all the way to index 23 (edges) and 47 (vertices).
+        for i in box.edgeCount..<(box.edgeCount * 2) {
+            #expect(!box.isSubShapeValid(type: .edge, at: i),
+                    "edge index \(i) is past edgeCount \(box.edgeCount)")
+        }
+        for i in box.vertexCount..<(box.vertexCount * 2) {
+            #expect(!box.isSubShapeValid(type: .vertex, at: i),
+                    "vertex index \(i) is past vertexCount \(box.vertexCount)")
+        }
+    }
+
+    // MARK: - BRepExtrema_ExtPC / ExtCF, the ExtCC siblings
+
+    /// The returned nearest point must lie *on* the edge the index names — which pins the call to
+    /// one specific edge, since the old occurrence walk resolved a different one from index 6
+    /// onwards on this box. Not every index resolves: `BRepExtrema_ExtPC` reports only interior
+    /// extrema, so an edge whose nearest point is an endpoint legitimately yields no solution.
+    @Test("pointEdgeExtrema measures against the edge edges() names")
+    func pointEdgeExtremaUsesTheSameEnumeration() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 10, height: 20, depth: 30))
+        let probe = SIMD3<Double>(100, 5, 7)
+
+        var checked = 0
+        for i in 0..<box.edgeCount {
+            guard let extrema = box.pointEdgeExtrema(point: probe, edgeIndex: i) else { continue }
+            let offEdge = try #require(box.edges()[i].distance(to: extrema.pointOnEdge))
+            #expect(offEdge < 1e-6,
+                    "the point extrema returned for index \(i) is \(offEdge) away from edges()[\(i)]")
+            checked += 1
+        }
+        #expect(checked > 0, "no in-range edge produced an interior extremum to check")
+
+        for i in box.edgeCount..<(box.edgeCount * 2) {
+            #expect(box.pointEdgeExtrema(point: probe, edgeIndex: i) == nil,
+                    "index \(i) is past edgeCount \(box.edgeCount) and must not resolve")
+        }
+    }
+
+    @Test("edgeFaceExtrema resolves its edge index through the same enumeration")
+    func edgeFaceExtremaUsesTheSameEnumeration() throws {
+        let box = try #require(Shape.box(origin: SIMD3(0, 0, 0),
+                                         width: 20, height: 20, depth: 20))
+        let other = try #require(Shape.box(origin: SIMD3(0, 0, 60),
+                                           width: 20, height: 20, depth: 20))
+
+        let resolved = (0..<box.edgeCount).filter {
+            box.edgeFaceExtrema(edgeIndex: $0, other: other, faceIndex: 0) != nil
+        }
+        #expect(!resolved.isEmpty, "no in-range edge resolved against the face at all")
+
+        for i in box.edgeCount..<(box.edgeCount * 2) {
+            #expect(box.edgeFaceExtrema(edgeIndex: i, other: other, faceIndex: 0) == nil,
+                    "index \(i) is past edgeCount \(box.edgeCount) and must not resolve")
+        }
+    }
+
     // MARK: - Edge.index stamped on loose edges (LocOpe_FindEdges / FindEdgesInFace)
 
     @Test("commonEdges stamps an index that round-trips through edges()")

--- a/Tests/OCCTTopologyTests/Issue695ConcaveEdgeTests.swift
+++ b/Tests/OCCTTopologyTests/Issue695ConcaveEdgeTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #695: `concaveEdges()` / `convexEdges()` misclassified every edge after the first repeated
+/// occurrence, because the bridge classifier walked a bare `TopExp_Explorer` (one entry per
+/// topology *occurrence*) while the Swift layer zips that array against `edges()` (one entry per
+/// *distinct* edge, `TopExp::MapShapes`). A 20 mm box has 24 edge occurrences over 12 edges, so
+/// the two enumerations desynchronise from the first repeat onwards.
+///
+/// Measured before the fix, on the issue's own shapes: the L-prism's single reentrant corner
+/// (map index 7) was reported convex, while map indices 9 and 12 -- two 45 mm edges lying in the
+/// z = 40 top cap, both genuinely convex -- were reported concave. `edgeConcavityCount(.convex)`
+/// answered 24 for a 12-edge box.
+@Suite("Issue 695 — concave/convex edge classification")
+struct Issue695ConcaveEdgeTests {
+
+    /// The issue's L: one reentrant edge, the inside corner running along the extrusion axis.
+    private static func lPrism() -> Shape? {
+        guard let profile = Wire.polygon([SIMD2(0, 0), SIMD2(50, 0), SIMD2(50, 5),
+                                          SIMD2(5, 5), SIMD2(5, 50), SIMD2(0, 50)]) else { return nil }
+        return Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 40)
+    }
+
+    /// The issue's T: two reentrant edges, both along the extrusion axis.
+    private static func tPrism() -> Shape? {
+        guard let profile = Wire.polygon([SIMD2(0, 0), SIMD2(30, 0), SIMD2(30, 10), SIMD2(20, 10),
+                                          SIMD2(20, 40), SIMD2(10, 40), SIMD2(10, 10),
+                                          SIMD2(0, 10)]) else { return nil }
+        return Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 20)
+    }
+
+    @Test("an L-prism has exactly one concave edge, and it is the reentrant corner")
+    func lPrismHasOneConcaveEdge() throws {
+        let prism = try #require(Self.lPrism())
+
+        let concave = prism.concaveEdges()
+        #expect(concave.count == 1, "expected the one inside corner, got \(concave.count)")
+
+        // The reentrant edge runs the full extrusion height at (x, y) = (5, 5). Before the fix
+        // this named two 45 mm edges in the z = 40 cap instead.
+        if let corner = concave.first {
+            #expect(abs(corner.length - 40) < 1e-6,
+                    "the inside corner spans the extrusion height, got length \(corner.length)")
+        }
+
+        // Every edge is classified exactly once, so the two sets partition edges().
+        #expect(concave.count + prism.convexEdges().count == prism.edgeCount)
+    }
+
+    @Test("a T-prism has exactly two concave edges, both reentrant corners")
+    func tPrismHasTwoConcaveEdges() throws {
+        let prism = try #require(Self.tPrism())
+
+        let concave = prism.concaveEdges()
+        #expect(concave.count == 2, "expected two inside corners, got \(concave.count)")
+        for e in concave {
+            #expect(abs(e.length - 20) < 1e-6,
+                    "each inside corner spans the extrusion height, got length \(e.length)")
+        }
+    }
+
+    @Test("a box has no concave edges and all twelve are convex")
+    func boxIsAllConvex() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        #expect(box.concaveEdges().isEmpty)
+        #expect(box.convexEdges().count == 12)
+    }
+
+    /// The count entry point had the same root cause on its own terms: it counted occurrences,
+    /// so a 12-edge box reported 24 convex edges.
+    @Test("concavity counts count distinct edges, not topology occurrences")
+    func countsAreEdgeCountsNotOccurrenceCounts() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        #expect(box.edgeConcavityCount(.convex) == 12)
+        #expect(box.edgeConcavityCount(.concave) == 0)
+
+        let prism = try #require(Self.lPrism())
+        #expect(prism.edgeConcavityCount(.concave) == 1)
+        #expect(prism.edgeConcavityCount(.convex) == 17)
+
+        // The counter and the classifier must describe the same edges.
+        let pairs = try #require(prism.edgeConcavities())
+        #expect(prism.edgeConcavityCount(.concave) == pairs.filter { $0.1 == .concave }.count)
+        #expect(prism.edgeConcavityCount(.convex) == pairs.filter { $0.1 == .convex }.count)
+    }
+
+    /// The headline use case from #171: select the inside corner geometrically and fillet it.
+    /// Before the fix the returned edges were bounded by the 5 mm leg thickness, so any radius
+    /// above that failed and the fillet never applied to the corner it was aimed at.
+    @Test("the concave edge fillets, and filleting it adds material")
+    func concaveEdgeFilletsAndAddsMaterial() throws {
+        let prism = try #require(Self.lPrism())
+        let concave = prism.concaveEdges()
+        let before = try #require(prism.volume)
+
+        let rounded = try #require(prism.filleted(edges: concave, radius: 8),
+                                   "a radius well above the 5 mm leg thickness must still fillet")
+        #expect(rounded.isValid)
+
+        // A concave fillet adds material: r^2 * (1 - pi/4) * width.
+        let after = try #require(rounded.volume)
+        let expected = 8.0 * 8.0 * (1 - Double.pi / 4) * 40
+        #expect(abs((after - before) - expected) < 0.01 * expected,
+                "expected about +\(expected) mm3, got \(after - before)")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,50 @@ All notable changes to OCCTSwift.
 
 ## Release History
 
+### Unreleased: fix, edge and vertex indices addressed occurrences, not the edges `edges()` names (#613, #695)
+
+> Version and date deliberately unset; whoever tags stamps them.
+
+An edge index crossing the bridge means a position in the deduplicated enumeration that
+`edges()` / `edgeCount` / `edge(at:)` share. Seven entry points instead walked a raw topology
+traversal, which yields one entry per **occurrence**. A 20 mm box has 12 distinct edges but 24 edge
+occurrences, so the two disagree from the first repeat onwards on every ordinary solid.
+
+The visible failure is `concaveEdges()`. On an extruded L the one genuinely reentrant edge was
+reported convex, while two convex edges in the top cap were reported concave:
+
+```swift
+let l = Wire.polygon([SIMD2(0,0), SIMD2(50,0), SIMD2(50,5),
+                      SIMD2(5,5), SIMD2(5,50), SIMD2(0,50)])!
+let prism = Shape.extrude(profile: l, direction: SIMD3(0,0,1), length: 40)!
+
+prism.concaveEdges().count        // was 2 (both 45 mm top-cap edges), now 1 (the corner)
+prism.edgeConcavityCount(.convex) // a 12-edge box answered 24, now 12
+
+// The composition the docs recommend now rounds the corner it names, at any radius:
+prism.filleted(edges: prism.concaveEdges(), radius: 8)   // was nil above the 5 mm leg thickness
+```
+
+The kernel was right throughout: read in the deduplicated order, `BRepOffset_Analyse` reports one
+concave edge and names the reentrant corner, identically on OCCT 8.0.0p1 and 8.0.1.
+
+Also converted: `edgeEdgeExtrema(edgeIndex1:other:edgeIndex2:)`, `checkEdge(at:)`,
+`checkVertex(at:)`, `splitEdge(at:parameter:)`, `biTgteBlend(edgeIndices:radius:)`, and the
+`Edge.index` that `commonEdges(with:)` / `edgesInFace(at:)` stamp — that last was the position in
+the result buffer, so a returned edge addressed an unrelated edge when fed back into
+`filleted(edges:)`.
+
+**Behaviour changes to expect.** `edgeConcavityCount` now answers per distinct edge, so the three
+type counts sum to at most `edgeCount` (a 12-edge box: 12, not 24). Every converted entry point now
+refuses an index at or above `edgeCount` / `vertexCount`; such indices previously resolved to an
+occurrence and returned a plausible answer for the wrong sub-shape.
+
+**Not changed, deliberately.** `checkWire(at:)` / `checkShell(at:)` keep the traversal, because
+`wireCount` / `shellCount` and their accessors use it too — these already agree with their own
+consumers. Face indices are untouched: unlike edges, the two enumerations agree on ordinary solids
+and diverge only when one face has two parents (measured: a compound holding the same solid twice).
+Reconciling `faces()` with `faceCount` / `face(at:)` is a separate, breaking change tracked as #541.
+
 ### Unreleased: fix, a cancelled import could report `.importFailed` instead of `.cancelled` (#525)
 
 > Version and date deliberately unset; whoever tags stamps them.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,22 +42,29 @@ prism.filleted(edges: prism.concaveEdges(), radius: 8)   // was nil above the 5 
 The kernel was right throughout: read in the deduplicated order, `BRepOffset_Analyse` reports one
 concave edge and names the reentrant corner, identically on OCCT 8.0.0p1 and 8.0.1.
 
-Also converted: `edgeEdgeExtrema(edgeIndex1:other:edgeIndex2:)`, `checkEdge(at:)`,
-`checkVertex(at:)`, `splitEdge(at:parameter:)`, `biTgteBlend(edgeIndices:radius:)`, and the
-`Edge.index` that `commonEdges(with:)` / `edgesInFace(at:)` stamp — that last was the position in
-the result buffer, so a returned edge addressed an unrelated edge when fed back into
-`filleted(edges:)`.
+Also converted: `edgeEdgeExtrema(edgeIndex1:other:edgeIndex2:)`,
+`pointEdgeExtrema(point:edgeIndex:)`, `edgeFaceExtrema(edgeIndex:other:faceIndex:)` (its edge
+argument), `checkEdge(at:)`, `checkVertex(at:)`, `isSubShapeValid(type:at:)` for `.edge`/`.vertex`,
+`splitEdge(at:parameter:)`, `biTgteBlend(edgeIndices:radius:)`, and the `Edge.index` that
+`commonEdges(with:)` / `edgesInFace(at:)` stamp — that last was the position in the result buffer,
+so a returned edge addressed an unrelated edge when fed back into `filleted(edges:)`.
 
 **Behaviour changes to expect.** `edgeConcavityCount` now answers per distinct edge, so the three
 type counts sum to at most `edgeCount` (a 12-edge box: 12, not 24). Every converted entry point now
 refuses an index at or above `edgeCount` / `vertexCount`; such indices previously resolved to an
 occurrence and returned a plausible answer for the wrong sub-shape.
 
-**Not changed, deliberately.** `checkWire(at:)` / `checkShell(at:)` keep the traversal, because
-`wireCount` / `shellCount` and their accessors use it too — these already agree with their own
-consumers. Face indices are untouched: unlike edges, the two enumerations agree on ordinary solids
-and diverge only when one face has two parents (measured: a compound holding the same solid twice).
-Reconciling `faces()` with `faceCount` / `face(at:)` is a separate, breaking change tracked as #541.
+**Not changed, deliberately.** `checkWire(at:)` / `checkShell(at:)` and `isSubShapeValid` for those
+types keep the traversal, because `wireCount` / `shellCount` and their accessors use it too — these
+already agree with their own consumers. Face indices are untouched, including `edgeFaceExtrema`'s
+`faceIndex`: unlike edges, the two enumerations agree on ordinary solids and diverge only when one
+face has two parents (measured: a compound holding the same solid twice). Reconciling `faces()`
+with `faceCount` / `face(at:)` is a separate, breaking change tracked as #541.
+
+The site list is generated, not transcribed:
+[`Scripts/repro/613-edge-index-census/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/613-edge-index-census)
+enumerates every explorer-indexed bridge site by sub-shape type, and should report zero
+`TopAbs_EDGE` / `TopAbs_VERTEX` entries.
 
 ### Unreleased: fix, a cancelled import could report `.importFailed` instead of `.cancelled` (#525)
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -1758,7 +1758,10 @@ public func isSubShapeValid(type: TopAbs_ShapeEnum, at index: Int) -> Bool
 
 - **Parameters:**
   - `type` — Type of sub-shape to check.
-  - `index` — 0-based index of the sub-shape.
+  - `index` — 0-based index of the sub-shape. For `.edge` and `.vertex` this addresses the same
+    sub-shape as `edges()[index]` / `vertices()[index]`, so this agrees with `checkEdge(at:)` and
+    `checkVertex(at:)` at every index, and an index at or above `edgeCount` / `vertexCount` reports
+    `false` rather than resolving to a repeated occurrence (#613).
 - **Returns:** `true` if the sub-shape is valid.
 - **OCCT:** `BRepCheck_Analyzer` (via `OCCTBRepCheckSubShapeValid`).
 
@@ -2098,9 +2101,12 @@ public func pointEdgeExtrema(point: SIMD3<Double>, edgeIndex: Int) -> PointEdgeE
 
 - **Parameters:**
   - `point` — 3D point.
-  - `edgeIndex` — 0-based edge index.
+  - `edgeIndex` — 0-based edge index, addressing the same edge as `edges()[edgeIndex]`. An index at
+    or above `edgeCount` yields `nil` (#613).
 - **Returns:** Extrema result, or `nil` on failure.
 - **OCCT:** `BRepExtrema_ExtPC` (via `OCCTBRepExtremaExtPC`).
+- **Note:** `BRepExtrema_ExtPC` reports interior extrema only, so an edge whose nearest point is one
+  of its endpoints legitimately yields `nil`. Use `Edge.distance(to:)` for an unconditional minimum.
 
 ---
 
@@ -2131,9 +2137,10 @@ public func edgeFaceExtrema(edgeIndex: Int, other: Shape, faceIndex: Int) -> Edg
 ```
 
 - **Parameters:**
-  - `edgeIndex` — 0-based edge index in this shape.
+  - `edgeIndex` — 0-based edge index in this shape, addressing the same edge as
+    `edges()[edgeIndex]`. An index at or above `edgeCount` yields `nil` (#613).
   - `other` — Shape containing the face.
-  - `faceIndex` — 0-based face index in `other`.
+  - `faceIndex` — 0-based face index in `other`. Face indexing is unchanged by #613; see #541.
 - **Returns:** Extrema result, or `nil` if parallel or computation fails.
 - **OCCT:** `BRepExtrema_ExtCF` (via `OCCTBRepExtremaExtCF`).
 - **Note:** When `isParallel` is `true`, the returned struct has zero distance and `solutionCount == 0`.

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -1081,6 +1081,15 @@ public func edgeConcavityCount(_ type: EdgeConcavity, angle: Double = 0.01) -> I
 - **Returns:** Count of matching edges, or `nil` on error.
 - **OCCT:** `BRepOffset_Analyse` (via `OCCTShapeCountEdgeConcavity`).
 
+Counts **distinct edges**, so the three type counts sum to at most `edgeCount`. Before #613 this
+counted topology occurrences and a 12-edge box reported 24 convex edges.
+
+```swift
+let box = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20)!
+box.edgeConcavityCount(.convex)   // 12, matching box.edgeCount
+box.edgeConcavityCount(.concave)  // 0
+```
+
 ---
 
 ## Geometric Edge Selection (v1.2.1)
@@ -1607,9 +1616,11 @@ public func splitEdge(at edgeIndex: Int, parameter: Double) -> Shape?
 ```
 
 - **Parameters:**
-  - `edgeIndex` — 0-based index of the edge to split.
+  - `edgeIndex` — 0-based index of the edge to split, addressing the same edge as
+    `edges()[edgeIndex]`. An index at or above `edgeCount` returns `nil` (#613).
   - `parameter` — Parameter along the edge (0.0–1.0) where the split occurs.
-- **Returns:** The split edge parts as a compound, or `nil` on failure.
+- **Returns:** The split edge parts as a compound, or `nil` on failure. Splitting at 0.5 yields two
+  pieces, each half the length of `edges()[edgeIndex]`.
 - **OCCT:** `LocOpe_SplitShape` (via `OCCTLocOpeSplitShapeByVertex`).
 
 ---
@@ -1651,6 +1662,16 @@ public func commonEdges(with other: Shape) -> [Edge]
 - **Returns:** Array of common edges (up to 100).
 - **OCCT:** `LocOpe_FindEdges` (via `OCCTLocOpeFindEdges`).
 
+Each returned edge carries the index it has in **this** shape's `edges()`, so it feeds straight into
+edge-index consumers. Before #613 the stamped index was the position in the result buffer, which
+addressed an unrelated edge.
+
+```swift
+let shared = bracket.commonEdges(with: plate)
+bracket.edges()[shared[0].index].length == shared[0].length   // true
+let rounded = bracket.filleted(edges: shared, radius: 1)
+```
+
 ---
 
 ### `edgesInFace(at:)`
@@ -1664,6 +1685,8 @@ public func edgesInFace(at faceIndex: Int) -> [Edge]
 - **Parameters:** `faceIndex` — 0-based index of the face to check.
 - **Returns:** Array of edges found in the face (up to 100).
 - **OCCT:** `LocOpe_FindEdgesInFace` (via `OCCTLocOpeFindEdgesInFace`).
+
+As with `commonEdges(with:)`, each returned edge carries its index in this shape's `edges()` (#613).
 
 ---
 
@@ -1749,8 +1772,9 @@ Check validity of an edge by index.
 public func checkEdge(at index: Int) -> CheckResult
 ```
 
-- **Parameters:** `index` — 0-based edge index.
-- **Returns:** Check result for the specified edge.
+- **Parameters:** `index` — 0-based edge index, addressing the same edge as `edges()[index]`.
+- **Returns:** Check result for the specified edge. An index at or above `edgeCount` reports
+  invalid rather than resolving to a repeated topology occurrence (#613).
 - **OCCT:** `BRepCheck_Edge` (via `OCCTCheckEdge`).
 
 ---
@@ -1787,6 +1811,9 @@ Check validity of a vertex by index.
 public func checkVertex(at index: Int) -> CheckResult
 ```
 
+- **Parameters:** `index` — 0-based vertex index, addressing the same vertex as `vertices()[index]`.
+- **Returns:** Check result. An index at or above `vertexCount` reports invalid rather than
+  resolving to a repeated topology occurrence (#613).
 - **OCCT:** `BRepCheck_Vertex` (via `OCCTCheckVertex`).
 
 ---
@@ -1919,9 +1946,10 @@ public func edgeEdgeExtrema(edgeIndex1: Int, other: Shape, edgeIndex2: Int) -> E
 ```
 
 - **Parameters:**
-  - `edgeIndex1` — 0-based index of the first edge in this shape.
+  - `edgeIndex1` — 0-based index of the first edge in this shape, addressing the same edge as
+    `edges()[edgeIndex1]`. An index at or above `edgeCount` yields `nil` (#613).
   - `other` — Shape containing the second edge.
-  - `edgeIndex2` — 0-based index of the second edge in `other`.
+  - `edgeIndex2` — 0-based index of the second edge in `other`, read the same way.
 - **Returns:** Extrema result, or `nil` if no solutions or if edges are parallel.
 - **OCCT:** `BRepExtrema_ExtCC` (via `OCCTBRepExtremaExtCC`).
 - **Note:** Returns `nil` when edges are parallel (`isParallel == true`). Check `solutionCount > 0` guards this in the bridge.


### PR DESCRIPTION
Back-ports #613's index-contract fix to `main`, so the 1.x line gets it. Closes #695, which is the
same defect reported from downstream.

## Why this targets `main` and not `refactor/381-pass1b`

#613 is already fixed on the refactor branch (7a884fd), and that fix **is** contained in the
`v2.0.0-kernel.1` tag. But OCCTSwiftScripts pins `occtDep("OCCTSwift", from: "1.17.0")`, i.e.
`>=1.17.0 <2.0.0`. The refactor branch's fix is unreachable to it until v2.0.0 ships *and* the
consumer takes a major bump, so a 1.x fix is the only thing that unblocks the bracket-fillet recipe
in OCCTSwiftScripts#105.

Worth flagging: #695 claims the bug reproduces at `v2.0.0-kernel.1`. That tag's own source uses the
map, and the measurement below says the map gives the right answer. The likely explanation is a
stale prebuilt bridge — `OCCTSWIFT_BRIDGE_PREBUILT=1` silently substitutes an old
`OCCTBridge.xcframework`, and it bit this very investigation (a build failed on a
`OCCTFillingRefusedConstraintCount` that only exists in current source).

## The defect

An edge index crossing the bridge means a position in the deduplicated `TopExp::MapShapes`
enumeration — the one `edges()`/`edgeCount`/`edge(at:)` and `vertices()`/`vertexCount` already read.
Seven entry points instead walked a bare `TopExp_Explorer`, one entry per **occurrence**.

Measured against the pinned kernel, both spellings, on both 8.0.0p1 and 8.0.1:

| shape | FACE map / explorer | EDGE map / explorer |
|---|---|---|
| solid box | 6 / 6 agree | 12 / **24 diverge** |
| L-prism | 8 / 8 agree | 18 / **36 diverge** |
| compound, 2 disjoint solids | 12 / 12 agree | 24 / **48 diverge** |
| fused overlapping boxes | 14 / 14 agree | 32 / **64 diverge** |
| compound, same solid twice | 6 / **12 diverge** | 12 / **48 diverge** |

Edges diverge on *every* ordinary solid, because each edge is shared by the two faces it bounds.

## The visible failure (#695)

Ground truth says the kernel was right throughout. Read in map order, `BRepOffset_Analyse` reports
`concave=1` for the L-prism and names the reentrant corner (map index 7). The explorer walk writes
`CONCAVE` into slots 9 and 12 — which are exactly the two 45 mm top-cap edges #695 names.

```
before:  L-prism edges=18 concave=2 convex=16   concave: index=9 len=45.0, index=12 len=45.0
after:   L-prism edges=18 concave=1 convex=17   concave: index=7 len=40.0   (the corner)
before:  box edgeConcavityCount(.convex) = 24   after: 12
```

Filleting the correct edge at r=8 now succeeds and adds `8² · (1 − π/4) · 40 = 549.38 mm³`, matching
#695's own figure.

## Converted

`OCCTShapeAnalyzeEdgeConcavity`, `OCCTShapeCountEdgeConcavity`, `OCCTBRepExtremaExtCC`,
`OCCTBRepExtremaExtPC`, `OCCTBRepExtremaExtCF` (its edge argument), `checkSubShape` and
`OCCTBRepCheckSubShapeValid`'s EDGE and VERTEX paths (behind `checkEdge`/`checkVertex`/
`isSubShapeValid`), `OCCTLocOpeSplitShapeByVertex`, `OCCTBiTgteBlend`, `OCCTBiTgteBlendInfo_`, and
the `Edge.index` that `commonEdges(with:)`/`edgesInFace(at:)` stamp — that last was the *result buffer position*, so a
returned edge addressed an unrelated edge once fed into `filleted(edges:)`. New
`OCCTShapeIndexOfEdge` resolves an edge to its parent index for those two.

## Deliberately NOT converted — this is where the site list differs from #613's

#613's premise is that every converted site is paired with a consumer that already uses the map.
That was true on the refactor branch **after #541**. `main` never had #541, so the census had to be
rebuilt by measurement rather than copied:

- **`checkWire(at:)` / `checkShell(at:)`**, and `isSubShapeValid` for those types.
  `OCCTShapeGetWires`/`GetShells` and their counts are explorer walks too, so these paths already
  agree with their own consumers. Converting one side alone would *introduce* the mismatch this PR
  removes.
- **Every face-index site**, including both mesh entry points, `OCCTLocOpeFindEdgesInFace`, and
  `edgeFaceExtrema`'s `faceIndex`.
  Faces do not have the edge family's problem (see the table). `main`'s own split is `faces()` on the
  explorer against `faceCount`/`face(at:)` on the map; choosing between them is #541, a registered
  v2.0.0 breaking change, not a 1.x bug fix.

## Behaviour changes

- `edgeConcavityCount` counts distinct edges, so the three type counts sum to at most `edgeCount`
  (a 12-edge box: 12, not 24).
- Every converted entry point refuses an index at or above `edgeCount`/`vertexCount`. Such indices
  previously resolved to an occurrence and returned a plausible answer for the wrong sub-shape.

## Evidence

- **Ground truth** (`BRepOffset_Analyse` per edge, both enumerations, on 8.0.0p1 and 8.0.1) predicted
  slots 9 and 12 before any Swift ran; the Swift reproduction then matched edge for edge.
- **Tests pin the surplus, not just valid indices.** An index at or above `edgeCount` is one
  `edges()` can never produce but the occurrence walk resolved. `splitEdge` is checked at *every*
  index against a 10×20×30 box whose three distinct edge lengths pin the index to one specific edge.
- **Injection proof.** With the occurrence walk restored, 5 of 7 tests fail with 11 issues
  (e.g. *"edge 11 is 10.0 long, so each half is 5.0, got 15.0"*). Restored, all pass.
- **Census as a committed artifact**, not a transcription:
  `Scripts/repro/613-edge-index-census/` greps for the "walk until `idx == N`" idiom and groups by
  sub-shape type. 11 sites before, 9 after, and **zero `TopAbs_EDGE`/`TopAbs_VERTEX` entries
  remain** — the 9 residual are the 7 FACE sites deferred to #541 and the 2 deliberate WIRE/SHELL
  fallbacks. Added after review found three sites the first pass missed (see below).
- **Full suite: 4646 tests in 1318 suites pass.**
- Operation count unchanged at 4270 (`Scripts/count-operations.py`).

`OCCTBiTgteBlend` carries no test: measured on a box it returns its input unchanged for a valid and
an out-of-range index alike, so there is no observable behaviour to assert. Converted by inspection
as the same idiom, and called out rather than covered by a vacuous test.

## Merge cost against `refactor/381-pass1b`

Measured with `git merge-file --diff3` (base `main` / refactor tip / this branch): **4 conflict
hunks, all inside the two concavity functions of `OCCTBridge_Topology.mm`.** Both sides implement
the same fix in different spellings — the refactor branch uses its `occtMapSubShapes` helper and a
0-based loop, `main` has no such helper so this uses `TopExp::MapShapes` and a 1-based loop.
Resolution is "keep the refactor branch's side" in all four; no semantic reconciliation. The other
converted sites are ones the refactor branch reached through #541-era helpers that do not exist on
`main`, so they merge as ordinary text.

No Swift API was moved, and the two `Shape.swift` edits are inside method bodies and doc comments,
which keeps them clear of the `Shape.swift` → `Shape+Topology.swift` split.

Closes #695


## Review round 1

The first push missed three in-scope sites — `OCCTBRepCheckSubShapeValid`, `OCCTBRepExtremaExtPC`,
`OCCTBRepExtremaExtCF` — two of them immediately adjacent to functions it *did* convert. Cause: the
census was rebuilt against #613's own site list rather than against the tree, so anything #541 had
already converted on `refactor/381-pass1b` never appeared in #613's scope, and `main` never had
#541. That is exactly the failure mode the section above claims to avoid.

All three are now converted with their own discriminating tests, the `-1` stamping path is guarded,
and the census is a committed script so the next person runs it instead of re-deriving it.
