### PR TITLE
fix(#699): AAG restricts adjacency and convexity to one solid

### DIFF
--- a/Scripts/repro/cluster-a-subshape-enumeration/README.md
+++ b/Scripts/repro/cluster-a-subshape-enumeration/README.md
@@ -108,10 +108,10 @@ name says `[horizontal-cut fixture]`).
 | face (already fixed) | upwardFaces().count **[horizontal-cut fixture]** | 1 | 2 | 2 | corroborates #642's own table: #614's fix IS order-independent on the SAME fixture AAG is not |
 | face (AAG, #642, fixed) | buildAAG().nodes.count [vertical-cut fixture] | 6 | 12 | 12 | post-fix: was 11/11, now matches orientedFaces() (the shared wall is 2 nodes) |
 | face (AAG, #642, fixed) | AAG upward+horizontal count [vertical-cut fixture] | n/a | 2 | 2 | unchanged: shared wall's normal is horizontal-axis here, order-independent before and after |
-| face (AAG, #642, NEW FINDING) | detectPocketsAAG().count [vertical-cut fixture] | 1 | 1 | **2** | post-fix: was 1/1 (see "Update following #642's fix" below, a different, pre-existing defect this fix unmasked rather than caused) |
+| face (AAG, #642/#699) | detectPocketsAAG().count [vertical-cut fixture] | 1 | 1 | 1 | #642-fixed: was 1/1/1 pre-#699 with a NEW order-dependence (1/1/2) exposed by #642's own fix; #699 fixed the cross-solid adjacency this exposed, restoring 1/1/1 (see "Update following #699's fix" below) |
 | face (AAG, #642, fixed) | buildAAG().nodes.count [horizontal-cut fixture] | 6 | 12 | 12 | post-fix: was 11/11, now matches orientedFaces() |
 | face (AAG, #642, fixed) | **AAG upward+horizontal NODE INDICES [horizontal-cut fixture]** | n/a | **[2, 8]** | **[2, 8]** | post-fix: was `[2, 8]` vs `[2]`, now agrees. The shared wall is its own node per side, so neither side's index depends on which one `faces()` used to keep |
-| face (AAG, #642, fixed) | **detectPocketsAAG().count [horizontal-cut fixture]** | 1 | **2** | **2** | post-fix: was `2` vs `1` (THE #642 HEADLINE MEASUREMENT), now agrees |
+| face (AAG, #642/#699) | **detectPocketsAAG().count [horizontal-cut fixture]** | 1 | 1 | 1 | #642-fixed: agreed at 2/2 (THE #642 HEADLINE MEASUREMENT); #699 found that agreement itself rode a cross-solid false adjacency and corrected it to 1/1 (see "Update following #699's fix" below) |
 | wire | wireCount (dedup) | 6 | 11 | 11 | |
 | wire | wires.count (dedup) | 6 | 11 | 11 | |
 | wire | subShapeCount(ofType: .wire) (dedup canonical) | 6 | 11 | 11 | |
@@ -381,6 +381,54 @@ of solid membership for a multi-solid compound. Recorded here rather than fixed 
 does not have to re-derive it: the fix would need `AAG` to know which solid a face occurrence
 belongs to, so it can restrict adjacency/convexity checks to same-solid pairs, which the census's
 own consumer audit was not asked to design.
+
+## Update following #699's fix
+
+#699 is fixed: `AAG.buildGraph()` now restricts its pairwise adjacency/convexity check (the
+`OCCTFacesAreAdjacent`/`OCCTEdgeGetConvexity` calls) to occurrence pairs that share a solid.
+Solid membership per occurrence is derived, not looked up through a new bridge function: the same
+`TopExp_Explorer` descent `OCCTShapeGetOrientedFaces` already drives visits every occurrence under
+one top-level solid contiguously before moving to the next, in the same first-encountered order
+`Shape.solids` itself walks, so the flat occurrence list partitions into contiguous runs sized by
+each solid's own face-occurrence count. Confirmed against both split fixtures (dumping every
+occurrence's bounds alongside each solid's own `orientedFaces()` count) before relying on it,
+not assumed from the traversal's documented behavior alone. `AAG.buildGraph()` falls back to the
+pre-#699 unrestricted comparison whenever a shape has zero or one solid, or whenever the per-solid
+counts don't sum to the total occurrence count -- silently mis-partitioning would be worse than not
+partitioning at all, and neither case can arise on the fixtures this census measures.
+
+**The vertical-cut fixture's new order-dependence is gone**, restoring the 1/1/1 the previous
+section recorded as the pre-#642-fix baseline: `detectPocketsAAG().count` is `1` in plain box,
+order A and order B alike.
+
+**The horizontal-cut fixture's count moved too, from `2` to `1` in both orders.** This is not a
+regression: #642's own headline measurement was ORDER-AGREEMENT (`2` in both orders, instead of `2`
+vs `1`), and that agreement survives #699 intact (`1` in both orders, still equal). What changed is
+that one of the two "pockets" `detectPockets()` reported before #699 was built from a cross-solid
+comparison between the horizontal cut's own shared wall and the wrong side of a split face, exactly
+the mechanism #699 fixes -- restricting to same-solid pairs removes it, and the fixture has one
+genuine same-solid floor candidate left. Measured directly: with `AAG.buildGraph()`'s solid
+restriction temporarily reverted, the horizontal fixture's floor at the *small* slab's top face
+shows two same-index-range neighbors classified concave that a same-solid-only walk of that solid
+in isolation also shows concave (`OCCTEdgeGetConvexity`'s own sign convention is a separate, far
+older defect, present on a single plain box too -- see below), while the floor on the *large*
+slab's top face shows zero concave same-solid neighbors either way. The `2`-vs-`1` swing was two
+independent cross-solid comparisons landing on the large slab's floor before #699 and nowhere after.
+
+**A third, unrelated defect was found while explaining this, and is also deliberately not fixed
+here.** `OCCTEdgeGetConvexity`'s reported concavity for a given physical edge depends on which face
+is passed as `face1` and which as `face2` -- the underlying `(tangent × n1) · n2` triple product
+negates under that swap, and `AAG.buildGraph()`'s pairwise loop picks `face1`/`face2` by array
+index order (`faces[i]`, `faces[j]`, `i < j`), not by any geometric convention. This reproduces on a
+**single, uncut plain box** (`detectPocketsAAG().count` is `1` for the plain-box fixture throughout
+this whole census, in every row that measures it, both before and after #642 and #699): two of the
+box's four side-wall-to-top-face dihedrals are genuinely convex but get reported concave, purely
+because of index order, which is what feeds the plain box's own false-positive pocket. This is
+orthogonal to solid membership (it needs no compound, no shared face, no second solid) and orthogonal
+to #699's fix (restricting to same-solid pairs does not touch which face lands at the lower index
+within a solid). Not filed as its own issue here since it was found explaining a side effect rather
+than measured as a primary claim; a future pass on `detectPockets()`'s accuracy should start from
+this note rather than re-derive it.
 
 ## Re-scoping the three members
 

--- a/Scripts/repro/cluster-a-subshape-enumeration/main.swift
+++ b/Scripts/repro/cluster-a-subshape-enumeration/main.swift
@@ -219,10 +219,10 @@ let upwardHorizontalB = aagB.nodes.filter { $0.isUpward && $0.isHorizontal }.cou
 record("face (AAG, #642)", "AAG upward+horizontal count [vertical-cut fixture]",
        plainBox: "n/a", orderA: upwardHorizontalA, orderB: upwardHorizontalB,
        note: "shared wall's normal is horizontal-axis here, so it never reaches isHorizontal() -- order-independent by construction, not by a fix")
-record("face (AAG, #642)", "detectPocketsAAG().count [vertical-cut fixture]",
+record("face (AAG, #642/#699)", "detectPocketsAAG().count [vertical-cut fixture]",
        plainBox: box.detectPocketsAAG().count, orderA: compoundA.detectPocketsAAG().count,
        orderB: compoundB.detectPocketsAAG().count,
-       note: "no pocket geometry here regardless of order -- this fixture does not exercise #642")
+       note: "this fixture does not exercise #642 (shared wall's normal is horizontal-axis); it DOES exercise #699 -- was 1/1/2 before #699 scoped adjacency/convexity to one solid, now 1/1/1")
 
 let hAagA = hCompoundA.buildAAG()
 let hAagB = hCompoundB.buildAAG()
@@ -233,10 +233,10 @@ let hUpwardHorizontalIdxB = hAagB.nodes.enumerated().filter { $0.element.isUpwar
 record("face (AAG, #642)", "AAG upward+horizontal NODE INDICES [horizontal-cut fixture]",
        plainBox: "n/a", orderA: "\(hUpwardHorizontalIdxA)", orderB: "\(hUpwardHorizontalIdxB)",
        note: "the shared wall's node keeps whichever half's orientation faces() reached first -- this is the #642 mechanism")
-record("face (AAG, #642)", "detectPocketsAAG().count [horizontal-cut fixture]",
+record("face (AAG, #642/#699)", "detectPocketsAAG().count [horizontal-cut fixture]",
        plainBox: box.detectPocketsAAG().count, orderA: hCompoundA.detectPocketsAAG().count,
        orderB: hCompoundB.detectPocketsAAG().count,
-       note: "THE #642 HEADLINE MEASUREMENT -- same geometry, order-dependent answer if it reproduces here")
+       note: "THE #642 HEADLINE MEASUREMENT agrees across order (was 2/2); #699 found the agreement itself was partly a cross-solid false adjacency and corrected it to 1/1")
 
 // MARK: - WIRE family
 

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -105,7 +105,7 @@ public struct AAGEdge: Sendable {
 /// touch the same edge locus. Neither `OCCTFacesAreAdjacent` nor `OCCTEdgeGetConvexity` has any
 /// notion of solid membership on their own, so `buildGraph()` restricts which occurrence pairs it
 /// hands to them, using `Shape.solids` and `orientedFaces()`'s own traversal order rather than a
-/// new bridge entry point (see `AAG.solidGroups(of:in:)`'s doc comment for the derivation). On a
+/// new bridge entry point (see `AAG.solidGroups(occurrenceCount:in:)`'s doc comment for the derivation). On a
 /// shape with zero or one solid, including every single-solid shape, this changes nothing: there
 /// is no cross-solid pair to restrict.
 ///
@@ -196,7 +196,7 @@ public final class AAG: @unchecked Sendable {
         // vertical cut, the two top-face halves (which border each other along the cut line) and
         // each half's own side of the shared wall were being compared cross-solid as well as
         // within their own solid, on top of the correct same-solid adjacencies.
-        let group = Self.solidGroups(of: faces, in: shape)
+        let groups = Self.solidGroups(occurrenceCount: faces.count, in: shape)
 
         // Build edges by checking all face pairs for adjacency
         for i in 0..<faceCount {
@@ -215,7 +215,7 @@ public final class AAG: @unchecked Sendable {
                 // the latter. `group` is nil when solid membership could not be established (a
                 // single-solid shape, or a shape whose occurrence count didn't partition cleanly by
                 // solid), in which case every pair is compared exactly as before #699.
-                if let group, group[i] != group[j] { continue }
+                if let groups, groups[i] != groups[j] { continue }
 
                 // Check if adjacent
                 if OCCTFacesAreAdjacent(shape.handle, face1.handle, face2.handle) {
@@ -283,16 +283,24 @@ public final class AAG: @unchecked Sendable {
     /// cross-solid pair can exist, so nothing needs restricting), and a shape whose per-solid
     /// occurrence counts don't sum to the total occurrence count (a compound mixing solids with
     /// free shells/faces, or a future shape this partitioning assumption doesn't hold for). Either
-    /// way, `buildGraph()` falls back to comparing every pair, exactly as it did before #699 --
-    /// silently mis-partitioning would be worse than not partitioning at all.
-    private static func solidGroups(of occurrences: [Face], in shape: Shape) -> [Int]? {
+    /// way, `buildGraph()` falls back to comparing every pair, exactly as it did before #699.
+    ///
+    /// Note what that sum check does and does not buy. It is necessary, not sufficient: it confirms
+    /// the totals line up, not that each solid's occurrences are actually contiguous or that
+    /// `Shape.solids` enumerates solids in the same order the face walk meets them. Those hold
+    /// because both are `TopExp_Explorer` walks over one shape tree, which is a structural property
+    /// of the traversal rather than something checked at runtime. A future topology that broke it
+    /// while still summing correctly would mis-partition silently. That is an unenforced cross-API
+    /// invariant, validated empirically on the fixtures in `Issue699AAGSolidScopedAdjacencyTests`,
+    /// and it is the thing to re-measure first if this ever produces a surprising adjacency.
+    private static func solidGroups(occurrenceCount: Int, in shape: Shape) -> [Int]? {
         let bodies = shape.solids
         guard bodies.count > 1 else { return nil }
 
         let counts = bodies.map { Int(OCCTShapeGetFaceOccurrenceCount($0.handle)) }
-        guard counts.reduce(0, +) == occurrences.count else { return nil }
+        guard counts.reduce(0, +) == occurrenceCount else { return nil }
 
-        var groups = [Int](repeating: -1, count: occurrences.count)
+        var groups = [Int](repeating: -1, count: occurrenceCount)
         var cursor = 0
         for (bodyIndex, count) in counts.enumerated() {
             for k in 0..<count { groups[cursor + k] = bodyIndex }

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -93,9 +93,21 @@ public struct AAGEdge: Sendable {
 /// - Nodes are face **occurrences** (``Shape/orientedFaces()``, #642). A face shared between two
 ///   solids in a compound is two nodes, one per owning solid, each with that solid's own normal
 ///   and derived predicates
-/// - Edges connect adjacent occurrences (those sharing a B-Rep edge), except the two occurrences
-///   of one shared face, which are never linked to each other
+/// - Edges connect adjacent occurrences (those sharing a B-Rep edge) **within the same solid**
+///   (#699), except the two occurrences of one shared face, which are never linked to each other
 /// - Each graph edge is attributed with convexity information
+///
+/// ## Adjacency is scoped to one solid (#699)
+///
+/// Two occurrences sharing a B-Rep edge but belonging to different solids in a compound are
+/// adjacent *in the compound* and not adjacent in *either* solid: a floor face's candidate walls
+/// are the faces bounding the same body, not any face anywhere in the compound that happens to
+/// touch the same edge locus. Neither `OCCTFacesAreAdjacent` nor `OCCTEdgeGetConvexity` has any
+/// notion of solid membership on their own, so `buildGraph()` restricts which occurrence pairs it
+/// hands to them, using `Shape.solids` and `orientedFaces()`'s own traversal order rather than a
+/// new bridge entry point (see `AAG.solidGroups(of:in:)`'s doc comment for the derivation). On a
+/// shape with zero or one solid, including every single-solid shape, this changes nothing: there
+/// is no cross-solid pair to restrict.
 ///
 /// ## Node identity (#642)
 ///
@@ -177,6 +189,15 @@ public final class AAG: @unchecked Sendable {
             nodes.append(node)
         }
 
+        // #699: which solid each occurrence belongs to, so the pairwise loop below never asks
+        // OCCTFacesAreAdjacent/OCCTEdgeGetConvexity about two faces from different solids. Neither
+        // bridge function has any notion of solid membership -- both compare face1/face2 purely on
+        // their own edge geometry, ignoring the `shape` argument beyond a null check -- so on a
+        // vertical cut, the two top-face halves (which border each other along the cut line) and
+        // each half's own side of the shared wall were being compared cross-solid as well as
+        // within their own solid, on top of the correct same-solid adjacencies.
+        let group = Self.solidGroups(of: faces, in: shape)
+
         // Build edges by checking all face pairs for adjacency
         for i in 0..<faceCount {
             for j in (i+1)..<faceCount {
@@ -188,6 +209,13 @@ public final class AAG: @unchecked Sendable {
                 // itself. Without this guard OCCTFacesAreAdjacent (which compares edge sets by
                 // IsSame, ignoring orientation) reports a self-loop for every shared face.
                 guard face1.index != face2.index else { continue }
+
+                // #699: two occurrences in different solids are adjacent in the compound and not
+                // in either solid; AAG's consumers (detectPockets(), concaveNeighbors(), etc.) want
+                // the latter. `group` is nil when solid membership could not be established (a
+                // single-solid shape, or a shape whose occurrence count didn't partition cleanly by
+                // solid), in which case every pair is compared exactly as before #699.
+                if let group, group[i] != group[j] { continue }
 
                 // Check if adjacent
                 if OCCTFacesAreAdjacent(shape.handle, face1.handle, face2.handle) {
@@ -230,6 +258,47 @@ public final class AAG: @unchecked Sendable {
                 }
             }
         }
+    }
+
+    /// Which solid each entry of `occurrences` (``Shape/orientedFaces()``, in order) belongs to,
+    /// or `nil` if solid membership can't be established for this shape (#699).
+    ///
+    /// Returns one group id per occurrence, two occurrences sharing a group id if and only if they
+    /// belong to the same solid. The ids are arbitrary integers, not ``Shape/solids``'s own
+    /// indices, and callers should compare them for equality only.
+    ///
+    /// There is no bridge entry point that answers "which solid owns this face occurrence"
+    /// directly, and this deliberately does not add one: `OCCTShapeGetOrientedFaces`, the walk
+    /// `orientedFaces()` already runs, visits every occurrence under one top-level solid
+    /// contiguously before moving to the next, because it is driven by the same single
+    /// `TopExp_Explorer` descent that ``Shape/solids`` itself uses to enumerate solids in
+    /// first-encountered order (both are one DFS over the same shape, filtered to a different
+    /// target type). So the flat occurrence list partitions into contiguous runs whose lengths are
+    /// each solid's own face-occurrence count, with no need to match individual faces back to a
+    /// solid by identity. Confirmed against both the vertical- and horizontal-cut two-solid
+    /// fixtures in `Scripts/repro/cluster-a-subshape-enumeration` before relying on it here, not
+    /// assumed from the traversal's documented behavior alone.
+    ///
+    /// `nil` covers two cases deliberately treated the same: a shape with zero or one solid (no
+    /// cross-solid pair can exist, so nothing needs restricting), and a shape whose per-solid
+    /// occurrence counts don't sum to the total occurrence count (a compound mixing solids with
+    /// free shells/faces, or a future shape this partitioning assumption doesn't hold for). Either
+    /// way, `buildGraph()` falls back to comparing every pair, exactly as it did before #699 --
+    /// silently mis-partitioning would be worse than not partitioning at all.
+    private static func solidGroups(of occurrences: [Face], in shape: Shape) -> [Int]? {
+        let bodies = shape.solids
+        guard bodies.count > 1 else { return nil }
+
+        let counts = bodies.map { Int(OCCTShapeGetFaceOccurrenceCount($0.handle)) }
+        guard counts.reduce(0, +) == occurrences.count else { return nil }
+
+        var groups = [Int](repeating: -1, count: occurrences.count)
+        var cursor = 0
+        for (bodyIndex, count) in counts.enumerated() {
+            for k in 0..<count { groups[cursor + k] = bodyIndex }
+            cursor += count
+        }
+        return groups
     }
 
     /// Get neighbors of a face

--- a/Tests/OCCTModelingTests/Issue642AAGNodeIdentityTests.swift
+++ b/Tests/OCCTModelingTests/Issue642AAGNodeIdentityTests.swift
@@ -43,7 +43,14 @@ struct Issue642AAGNodeIdentityTests {
 
     // MARK: - The headline
 
-    /// The defect itself, reverted: before the fix this was 2 vs 1 for identical geometry.
+    /// The defect itself, reverted: before this fix it was 2 vs 1 for identical geometry.
+    ///
+    /// - Note: The pinned count moved from `2` to `1` under #699, which restricted `AAG`'s
+    ///   adjacency/convexity checks to same-solid face pairs. That is a DIFFERENT, later fix
+    ///   (`Issue699AAGSolidScopedAdjacencyTests`). The count it corrected was itself partly built
+    ///   from a cross-solid false adjacency, which #642 alone had no way to see. What this test
+    ///   still guards, unchanged since #642, is the AGREEMENT across compound member order; see
+    ///   `Scripts/repro/cluster-a-subshape-enumeration/README.md`'s "Update following #699's fix".
     @Test("detectPocketsAAG() agrees across compound member order")
     func detectPocketsAgreesAcrossOrder() {
         guard let orderA = Self.horizontalSplitBoxCompound(order: .asSplit),
@@ -58,8 +65,8 @@ struct Issue642AAGNodeIdentityTests {
         #expect(pocketsA.count == pocketsB.count)
         // Pinned to the measured value so a future change that breaks this loudly disagrees with
         // a concrete number rather than only with itself.
-        #expect(pocketsA.count == 2)
-        #expect(pocketsB.count == 2)
+        #expect(pocketsA.count == 1)
+        #expect(pocketsB.count == 1)
     }
 
     /// The AAG-level symptom the issue named directly: the upward+horizontal node set's SIZE must

--- a/Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift
+++ b/Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift
@@ -195,4 +195,76 @@ struct Issue699AAGSolidScopedAdjacencyTests {
         #expect(pocketsA.count == 1)
         #expect(pocketsB.count == 1)
     }
+
+    // MARK: - The two fallback branches (review follow-up)
+
+    /// `solidGroups` returns `nil` when the per-solid occurrence counts do not sum to the total, and
+    /// `buildGraph()` then compares every pair as it did before #699. A compound of two solids plus
+    /// a free face is that case: 6 + 6 occurrences against 13 in the shape.
+    ///
+    /// **This case is not proven by removing the guard, and saying so is the point.** I expected it
+    /// to be: `groups` looked like it would be sized 12 and indexed to 12. It is not. It is sized
+    /// from `occurrenceCount` (13) and the fill loop covers only 0...11, leaving the free face at
+    /// the sentinel `-1`, which compares unequal to every real group and so is simply never adjacent
+    /// to anything. Measured: with the guard removed this test still passes. I also tried making the
+    /// free face coincident with the box's top face to give it an adjacency worth losing, and it
+    /// still has zero neighbours, because a separately built face carries its own `TopoDS` edges
+    /// rather than the solid's.
+    ///
+    /// So the guard is **defensive**, not load-bearing on any fixture reachable through the public
+    /// API today. It stays because the sentinel being harmless is a property of this partitioning,
+    /// not a guarantee. What this test does pin is that the branch is reached and yields a complete
+    /// graph over every occurrence, which is worth having even though a removal check cannot
+    /// distinguish it. Per `okf/policies/prove-the-test-fails.md`, a case that survives its guard's
+    /// removal is labelled, not counted as coverage.
+    ///
+    /// Note the shape the review suggested for this, `Shape.compound([box, freeFace])`, does not
+    /// reach here: one solid exits at the earlier `bodies.count <= 1` guard. Two solids are needed
+    /// before the sum can disagree.
+    @Test("A compound mixing solids with a free face falls back instead of mis-partitioning")
+    func countMismatchFallsBackToUnrestrictedComparison() {
+        guard let a = Shape.box(width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+              let wire = Wire.polygon3D(
+                  [SIMD3(40, 0, 0), SIMD3(50, 0, 0), SIMD3(50, 10, 0), SIMD3(40, 10, 0)], closed: true),
+              let freeFace = Shape.face(from: wire),
+              let mixed = Shape.compound([a, b, freeFace])
+        else {
+            Issue.record("could not build the solids-plus-free-face fixture")
+            return
+        }
+
+        // The fixture must actually reach the branch, or this proves nothing.
+        let total = mixed.orientedFaces().count
+        let perSolid = mixed.solids.map { $0.orientedFaces().count }
+        #expect(mixed.solids.count > 1, "need more than one solid to get past the first guard")
+        #expect(perSolid.reduce(0, +) != total,
+                "fixture must make the counts disagree: perSolid \(perSolid), total \(total)")
+
+        // Falling back is a complete, non-crashing graph over every occurrence.
+        let aag = mixed.buildAAG()
+        #expect(aag.nodes.count == total)
+        #expect(mixed.detectPocketsAAG().count == 2)
+    }
+
+    /// Both other fixtures are exactly two solids, so the partition loop is only ever exercised
+    /// pairwise. Three disjoint boxes walk it past that, and permuting them must not move anything.
+    @Test("The partition generalises past two solids")
+    func threeSolidCompoundPartitions() {
+        func compound(_ order: [Int]) -> Shape? {
+            let boxes = (0..<3).compactMap {
+                Shape.box(origin: SIMD3(Double($0) * 20, 0, 0), width: 10, height: 10, depth: 10)
+            }
+            guard boxes.count == 3 else { return nil }
+            return Shape.compound(order.map { boxes[$0] })
+        }
+        guard let straight = compound([0, 1, 2]), let permuted = compound([2, 0, 1]) else {
+            Issue.record("could not build the three-solid fixture")
+            return
+        }
+        #expect(straight.solids.count == 3)
+        #expect(straight.buildAAG().nodes.count == 18)
+        #expect(straight.buildAAG().nodes.count == permuted.buildAAG().nodes.count)
+        #expect(straight.detectPocketsAAG().count == permuted.detectPocketsAAG().count)
+    }
 }

--- a/Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift
+++ b/Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift
@@ -1,0 +1,198 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #699: `AAG.buildGraph()` compared every pair of face occurrences for adjacency and convexity,
+// with no notion of which solid each occurrence belongs to. `OCCTFacesAreAdjacent` and
+// `OCCTEdgeGetConvexity` (`OCCTBridge_BRepGraph.mm`) test two `TopoDS_Face` values purely on their
+// own edge geometry, ignoring the `shape` argument they are handed beyond a null check, so two
+// faces from DIFFERENT solids in one compound that happen to share a B-Rep edge were reported
+// adjacent, and the convexity of that shared edge was computed with no reference to which solid
+// was asking.
+//
+// Found while measuring #642's own fix (Cluster A's census,
+// `Scripts/repro/cluster-a-subshape-enumeration/README.md`, "Update following #642's fix"): on a
+// VERTICAL two-solid split, `detectPocketsAAG().count` disagreed across compound member order
+// (1 vs 2), even though #642's fix (`orientedFaces()`-based nodes) is correct and complete for
+// what it claims. The two defects are independent and need different fixtures to show: #642's own
+// headline needs a HORIZONTAL cut (the shared wall's normal has to be vertical to reach
+// `isHorizontal()`/`isUpward()` at all); this one needs a VERTICAL cut (the shared wall borders two
+// half-faces of the box's original top face, which also border EACH OTHER along the cut line, so
+// one edge is common to three face occurrences: both top-face halves and both sides of the wall).
+//
+// ## The contract
+//
+// Two faces sharing a B-Rep edge but belonging to different solids in a compound are adjacent IN
+// THE COMPOUND and not adjacent in EITHER solid. `AAG` and its consumers (`detectPockets()`,
+// `concaveNeighbors(of:)`, `convexNeighbors(of:)`) want the solid-scoped answer: a floor face's
+// candidate walls are the faces that bound the SAME body, not any face anywhere in the compound
+// that happens to touch the same edge locus. `AAG.buildGraph()` now restricts its pairwise
+// adjacency/convexity check to occurrence pairs sharing a solid, derived from `Shape.solids` and
+// `orientedFaces()`'s own traversal order rather than a new bridge function (see
+// `AAG.solidGroups(of:in:)`'s doc comment for why the existing bridge surface is enough).
+//
+// ## A further correction to #642's own headline measurement
+//
+// Restricting to same-solid pairs also changes the HORIZONTAL fixture's `detectPocketsAAG().count`
+// from `2` (in both orders, #642's own fix) to `1` (in both orders). This is not a regression: #642
+// was about order-AGREEMENT, and the horizontal fixture still agrees after #699 (`1` in both
+// orders, was `2` in both orders). What moved is that one of the two "pockets" `detectPockets()`
+// reported before #699 was itself built from a cross-solid comparison between the shared wall and
+// the wrong side of a split face -- exactly the mechanism #699 fixes. See
+// `Scripts/repro/cluster-a-subshape-enumeration/README.md`'s "Update following #699's fix" for the
+// full measurement.
+@Suite("AAG restricts adjacency and convexity to one solid (#699)")
+struct Issue699AAGSolidScopedAdjacencyTests {
+
+    // MARK: - Fixture
+
+    /// The issue's own construction: a plain, origin-centred 10mm box split by an X-normal plane
+    /// through x=4, recompounded in both member orders. A one-line change to
+    /// `Issue642AAGNodeIdentityTests.horizontalSplitBoxCompound(order:)`'s normal and point, per
+    /// #699's own instructions -- the two fixtures are otherwise identical in shape.
+    enum Order { case asSplit, reversed }
+
+    static func verticalSplitBoxCompound(order: Order) -> Shape? {
+        guard let block = Shape.box(width: 10, height: 10, depth: 10),
+              let pieces = block.split(atPlane: SIMD3(4, 0, 0), normal: SIMD3(1, 0, 0)),
+              pieces.count == 2
+        else { return nil }
+        let ordered = order == .asSplit ? pieces : pieces.reversed()
+        return Shape.compound(Array(ordered))
+    }
+
+    // MARK: - The headline
+
+    /// The defect itself, reverted: before the fix this was 1 vs 2 for identical geometry
+    /// (measured directly against the tree at HEAD before this fix landed).
+    @Test("detectPocketsAAG() agrees across compound member order on a vertical cut")
+    func detectPocketsAgreesAcrossOrder() {
+        guard let orderA = Self.verticalSplitBoxCompound(order: .asSplit),
+              let orderB = Self.verticalSplitBoxCompound(order: .reversed) else {
+            Issue.record("could not build the vertical split-box fixture")
+            return
+        }
+
+        let pocketsA = orderA.detectPocketsAAG()
+        let pocketsB = orderB.detectPocketsAAG()
+
+        #expect(pocketsA.count == pocketsB.count)
+        // Pinned to the measured value so a future change that breaks this loudly disagrees with
+        // a concrete number rather than only with itself.
+        #expect(pocketsA.count == 1)
+        #expect(pocketsB.count == 1)
+    }
+
+    /// `buildAAG().nodes.count` is unaffected: #699 restricts EDGES, not the node set #642 already
+    /// fixed. Both orders keep 12 occurrence nodes (6 per solid) for this fixture.
+    @Test("buildAAG().nodes.count is unaffected by the adjacency fix")
+    func nodeCountUnaffected() {
+        guard let orderA = Self.verticalSplitBoxCompound(order: .asSplit),
+              let orderB = Self.verticalSplitBoxCompound(order: .reversed) else {
+            Issue.record("could not build the vertical split-box fixture")
+            return
+        }
+
+        #expect(orderA.buildAAG().nodes.count == 12)
+        #expect(orderB.buildAAG().nodes.count == 12)
+    }
+
+    /// Each solid, in isolation, is a plain 6-face box (12 face-adjacency edges: every face touches
+    /// 4 others, 6*4/2 = 12). With adjacency correctly scoped to one solid, the compound's graph is
+    /// exactly two such box graphs and nothing more: 24 edges, none of them crossing the solid
+    /// boundary. Before #699 this was higher, and order-dependent, because cross-solid pairs were
+    /// included too.
+    @Test("the graph is exactly two independent 12-edge box graphs, no cross-solid edges")
+    func edgeCountIsTwoIndependentBoxGraphs() {
+        guard let orderA = Self.verticalSplitBoxCompound(order: .asSplit),
+              let orderB = Self.verticalSplitBoxCompound(order: .reversed) else {
+            Issue.record("could not build the vertical split-box fixture")
+            return
+        }
+
+        #expect(orderA.buildAAG().edges.count == 24)
+        #expect(orderB.buildAAG().edges.count == 24)
+    }
+
+    /// The shared wall's two occurrences (same `distinctFaceIndex`, opposite orientation) are each
+    /// adjacent only to faces on their OWN solid's side. Neither wall occurrence is adjacent to the
+    /// other (that guard predates #699, see `Issue642AAGNodeIdentityTests`), and -- the #699 part --
+    /// neither is adjacent to the OTHER solid's half of the split top face either, even though that
+    /// half shares the wall's own top boundary edge.
+    @Test("the shared wall's two occurrences are not adjacent to the other solid's split top-face half")
+    func wallOccurrencesDoNotCrossSolidBoundary() {
+        guard let compound = Self.verticalSplitBoxCompound(order: .asSplit) else {
+            Issue.record("could not build the vertical split-box fixture")
+            return
+        }
+
+        let aag = compound.buildAAG()
+        let grouped = Dictionary(grouping: aag.nodes.enumerated().map { ($0.offset, $0.element) },
+                                  by: \.1.distinctFaceIndex)
+        guard let wallSides = grouped.first(where: { $0.value.count > 1 })?.value, wallSides.count == 2 else {
+            Issue.record("expected exactly one face shared by two nodes (the cut wall)")
+            return
+        }
+
+        // Every neighbor of each wall occurrence must be a face that is ALSO a neighbor of, or
+        // equal to, one of the two wall occurrences' own solid-mates -- concretely: no neighbor of
+        // wallSides[0] should be adjacent to wallSides[1] and vice versa, which is what "different
+        // solids never touch" implies for a shape where each solid is a single connected box.
+        let (indexA, _) = wallSides[0]
+        let (indexB, _) = wallSides[1]
+        let neighborsA = Set(aag.neighbors(of: indexA))
+        let neighborsB = Set(aag.neighbors(of: indexB))
+
+        // If solid-scoping were absent, the two wall sides (which are geometrically coincident)
+        // would share every neighbor, since anything adjacent to one side's edge loop is adjacent
+        // to the other's too. Scoped to one solid each, their neighbor sets are disjoint.
+        #expect(neighborsA.isDisjoint(with: neighborsB))
+        #expect(!neighborsA.contains(indexB))
+        #expect(!neighborsB.contains(indexA))
+    }
+
+    // MARK: - No regression on the unshared case
+
+    /// A single solid has no cross-solid pair to restrict: `AAG.solidGroups(of:in:)` returns `nil`
+    /// for `Shape.solids.count <= 1`, so `buildGraph()` falls back to comparing every pair exactly
+    /// as it did before #699. A plain box's graph is unchanged.
+    @Test("a plain box's AAG is unaffected")
+    func plainBoxUnaffected() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build the box")
+            return
+        }
+
+        let aag = box.buildAAG()
+        #expect(aag.nodes.count == 6)
+        #expect(aag.edges.count == 12)
+    }
+
+    // MARK: - No regression on #642's own fixture (order-agreement survives, though the count moved)
+
+    /// #642's own horizontal-cut fixture must still agree across compound member order after #699.
+    /// The exact count moved from `2` to `1` (see the suite's own doc comment and
+    /// `Scripts/repro/cluster-a-subshape-enumeration/README.md`'s "Update following #699's fix");
+    /// what must never regress is the AGREEMENT itself, which is what #642 was about and what this
+    /// fixture is uniquely positioned to catch since the vertical fixture above never reaches
+    /// `isHorizontal()`/`isUpward()` at all.
+    @Test("#642's horizontal-cut fixture still agrees across order, at the corrected count")
+    func horizontalFixtureStillAgreesAtCorrectedCount() {
+        guard let block = Shape.box(width: 10, height: 10, depth: 10),
+              let pieces = block.split(atPlane: SIMD3(0, 0, 4), normal: SIMD3(0, 0, 1)),
+              pieces.count == 2,
+              let orderA = Shape.compound(pieces),
+              let orderB = Shape.compound(pieces.reversed())
+        else {
+            Issue.record("could not build the horizontal split-box fixture")
+            return
+        }
+
+        let pocketsA = orderA.detectPocketsAAG()
+        let pocketsB = orderB.detectPocketsAAG()
+
+        #expect(pocketsA.count == pocketsB.count)
+        #expect(pocketsA.count == 1)
+        #expect(pocketsB.count == 1)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -229,6 +229,77 @@ no-regression tests, on a plain box and on #614's own vertical-cut fixture, corr
 separately reverting only the `distinctFaceIndex` adjacency guard fails exactly the one test that
 exists to catch it.
 
+#### `AAG` linked faces across a solid boundary, so #642's own fix moved a second, independent order-dependence into view (#699)
+
+Found while measuring #642's own fix. Cluster A's census (`Scripts/repro/cluster-a-subshape-enumeration/`)
+re-ran after #642 landed and caught a NEW disagreement on a fixture #642 does not touch: a plain
+10mm box split by an X-normal plane through x=4, recompounded in both member orders,
+`detectPocketsAAG().count` was **1** in one order and **2** in the other, for identical geometry.
+Confirmed with `git stash` that reverting #642 alone reproduces the identical asymmetry, so this is
+not something #642 introduced: #642's fix (doubling a shared face's node count) exercised it twice
+as often, which is why a previously-accidental cancellation stopped holding.
+
+**The mechanism is different from #642's, and needs a different fixture to show.** #642 was about
+node identity: which faces become graph nodes. #699 is about edges: which nodes get linked and with
+what attribute. `OCCTFacesAreAdjacent` and `OCCTEdgeGetConvexity` (`OCCTBridge_BRepGraph.mm`) have
+no concept of solid membership: both compare two `TopoDS_Face` values purely on their own edge
+geometry, ignoring the `shape` argument they are handed beyond a null check. On a vertical two-solid
+split, the shared wall borders two half-faces of the box's original top face that also border
+**each other** along the cut line, so one edge is common to three face occurrences (both top-face
+halves and both sides of the wall). `AAG.buildGraph()`'s pairwise loop compared all three against
+each other regardless of which solid each belonged to, linking a face in one solid to a face in
+another and attributing a convexity meaningless for either. #642's own fixture (a horizontal cut)
+never exercises this: its shared wall's normal is horizontal-axis, so `isHorizontal()`/`isUpward()`
+never reach the duplicated face at all, and conversely #642's own defect needs a horizontal cut, so
+neither fixture reproduces the other's mechanism.
+
+**The contract:** two faces sharing a B-Rep edge but belonging to different solids in a compound are
+adjacent *in the compound* and not adjacent in *either* solid, and `AAG`'s consumers
+(`detectPockets()`, `concaveNeighbors(of:)`, `convexNeighbors(of:)`) want the solid-scoped answer.
+
+**Fixed** by restricting `AAG.buildGraph()`'s pairwise adjacency/convexity check to occurrence pairs
+it can establish share a solid, rather than by adding solid-scoping to the bridge functions
+themselves: an audit found `OCCTFacesAreAdjacent`/`OCCTEdgeGetConvexity` have exactly one Swift
+call site each, both inside `buildGraph()`, so there was no other consumer a bridge-side change
+could have broken, and the Swift-side fix is the smaller change either way. Solid membership per
+occurrence is derived rather than looked up through a new bridge entry point: `orientedFaces()`'s
+underlying `TopExp_Explorer` walk visits every occurrence under one top-level solid contiguously
+before moving to the next, in the same first-encountered order `Shape.solids` itself enumerates
+solids in (both are one DFS over the same shape), so the flat occurrence list partitions into
+contiguous runs sized by each solid's own face-occurrence count. Confirmed against both split
+fixtures (dumping every occurrence's bounds alongside each solid's own `orientedFaces()` count)
+before relying on it. `AAG.buildGraph()` falls back to the pre-#699 unrestricted comparison on a
+shape with zero or one solid, or if the per-solid counts don't sum to the total occurrence count.
+Silently mis-partitioning would be worse than not partitioning at all, and neither case arises on
+any fixture this change measures.
+
+`OCCTEdgeGetConvexity` did not need its own solid-membership fix on top of this: once adjacency is
+restricted to same-solid pairs, convexity is only ever computed for a legitimate same-solid
+neighbor. (A separate, unrelated defect was found while explaining a side effect below:
+`OCCTEdgeGetConvexity`'s reported concavity for a given physical edge depends on argument order,
+which reproduces on a single, uncut box and has nothing to do with solid membership. Recorded in
+`Scripts/repro/cluster-a-subshape-enumeration/README.md` rather than fixed here, since it was found
+explaining a side effect rather than measured as this issue's own claim.)
+
+**A further correction to #642's own headline measurement.** Restricting to same-solid pairs also
+moves the HORIZONTAL fixture's `detectPocketsAAG().count` from `2` (in both orders, #642's own fix)
+to `1` (in both orders). This is not a regression: #642 was about order-AGREEMENT, which survives
+intact (`1` in both orders, was `2` in both orders, still equal either way). What moved is that one
+of the two "pockets" reported before #699 was itself built from a cross-solid comparison between
+the shared wall and the wrong side of a split face, exactly the mechanism this issue fixes.
+`Tests/OCCTModelingTests/Issue642AAGNodeIdentityTests.swift`'s own pinned count moves from `2` to
+`1` accordingly, with a note explaining why; the AGREEMENT assertion it exists to guard is
+unchanged and still passes.
+
+This is a further behaviour change on `Shape.detectPocketsAAG()`, recorded alongside #642's own
+entry in [`SEMVER.md`](SEMVER.md#recorded-exception-unreleased-aag-adjacency-and-convexity-are-scoped-to-one-solid-699)
+rather than a new one, since it is the same public API. On every shape with zero or one solid,
+nothing changes. Tests: `Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift`, each
+proven to catch its own mechanism by reverting the fix alone (7 assertions across 3 tests fail,
+reproducing the exact 1-vs-2 and 2-vs-1 disagreements measured above; the single-solid and
+node-count tests correctly still pass, since #699's fix touches edges, not nodes, and never applies
+to a single-solid shape).
+
 #### Every workflow action pin moves to a Node 24 major (#648)
 
 #625 bumped only the job it introduced, so `ci.yml` was left mixed-version: `actions/checkout@v7` in

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,13 +17,13 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **eleven** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **twelve** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
 
 - [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
 - [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
 - [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
 
-The other eight change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+The other nine change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
 
 - [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
 - [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
@@ -33,8 +33,9 @@ The other eight change behaviour **without breaking the build**, which is the se
 - [#502](#recorded-exception-unreleased-the-wiresshellssolids-enumerations-join-the-deduplicated-map-502) collapses the `wires`/`shells`/`solids` enumerations onto the deduplicated sub-shape map.
 - [#642](#recorded-exception-unreleased-aag-builds-nodes-from-face-occurrences-642) moves `AAG`'s node set from distinct faces to face occurrences, so `detectPocketsAAG()` and `buildAAG().nodes` can return more entries on a shape with a shared face.
 - [#651](#recorded-exception-unreleased-nbedgesnbfacesnbvertices-are-deprecated-and-forward-to-the-deduplicated-count-651) deprecates `Shape.nbEdges`/`nbFaces`/`nbVertices` in favour of `edgeCount`/`faceCount`/`vertexCount`, and changes what the deprecated three return on the way.
+- [#699](#recorded-exception-unreleased-aag-adjacency-and-convexity-are-scoped-to-one-solid-699) restricts `AAG`'s adjacency/convexity checks to same-solid face pairs, further changing what `detectPocketsAAG()` can return on a multi-solid compound: the same public API #642 already named, corrected further rather than a new one opened.
 
-A twelfth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
+A thirteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
 
 ## Rules
 
@@ -316,6 +317,49 @@ The exception was taken because:
   `orientedFaces()` is documented to equal `faces()` exactly whenever nothing is shared.
 - **`AAGNode.distinctFaceIndex` is new, additive API** that gives a caller who needs the old,
   one-node-per-distinct-face view a way back to it, without reintroducing the order-dependence.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
+  notes.
+
+#### Recorded exception: Unreleased, AAG adjacency and convexity are scoped to one solid (#699)
+
+**One further silent behaviour change on the same public APIs #642 already named, not a compile
+error.** Found measuring #642's own fix: `AAG.buildGraph()`'s pairwise adjacency check had no
+concept of solid membership, so two face occurrences from *different* solids in a compound that
+happened to share a B-Rep edge were reported adjacent, and the convexity of that shared edge was
+computed with no reference to which solid was asking. Recorded here before the tag is cut:
+
+| Break | What a caller does |
+|---|---|
+| `Shape.buildAAG().edges`, `AAG.neighbors(of:)`, `AAG.concaveNeighbors(of:)` and `AAG.convexNeighbors(of:)` no longer report a cross-solid pair as adjacent | Nothing on a shape with zero or one solid, which includes every single-solid shape. On a multi-solid compound, a caller relying on a cross-solid adjacency edge (there is no documented use for one: every consumer wants same-solid adjacency) sees fewer edges and fewer neighbors |
+| `Shape.detectPocketsAAG()` can return a different count on a multi-solid compound, in **both** directions from before this fix: a spurious cross-solid pocket disappears, or two orders that used to disagree now agree at a value neither order reported before | Nothing on a single-solid shape. On a multi-solid compound, re-measure rather than assume the pre-#699 count: #642's own horizontal-cut fixture moved from `2` (agreeing across order) to `1` (agreeing across order, at a lower count), because one of the two pockets `2` counted was itself built from the cross-solid mechanism #699 removes |
+
+Before this fix, `AAG.buildGraph()`'s pairwise loop tested every pair of face occurrences with
+`OCCTFacesAreAdjacent`/`OCCTEdgeGetConvexity`, neither of which has any notion of solid membership:
+both compare two `TopoDS_Face` values purely on their own edge geometry. On a vertical two-solid
+split, the shared wall borders two half-faces of the box's original top face that also border each
+other along the cut line, so one edge is common to three face occurrences; the pairwise loop
+compared all three regardless of which solid each belonged to. Measured on a plain 10mm box split
+by an X-normal plane through x=4: `detectPocketsAAG().count` was `1` in one compound member order
+and `2` in the other, for identical geometry: the same class of order-dependence #642 fixed, from
+a different mechanism, on a fixture #642's own does not exercise (its shared wall's normal is
+horizontal-axis, never reaching `isHorizontal()`/`isUpward()`).
+
+The exception was taken because:
+
+- **The disagreement is the bug, and it produced a different answer for identical geometry
+  depending only on argument order to `Shape.compound(_:)`**, the same standard #642's own
+  exception was taken under, for a different mechanism.
+- **There is no spelling in which both survive.** A graph edge either represents same-solid
+  adjacency or it doesn't; there is no default parameter or overload that lets a caller opt into
+  the old, solid-blind comparison, and no consumer of this library was found wanting one (an audit
+  of `OCCTFacesAreAdjacent`/`OCCTEdgeGetConvexity` found exactly one Swift call site each, both
+  inside `AAG.buildGraph()`, so no other caller could be relying on the unscoped behavior).
+- **On every shape with zero or one solid, nothing moves.** `AAG.buildGraph()` falls back to the
+  pre-#699 unrestricted comparison whenever there is no cross-solid pair to restrict, so a single
+  solid's own graph, and every test built on one, is byte-for-byte unaffected.
+- **This is a correction to #642's own recorded exception, not a new consumer-visible surface.**
+  `Shape.detectPocketsAAG()` and `Shape.buildAAG()` are the identical two APIs #642 already listed;
+  #699 changes what they return further rather than opening a second name for the same contract.
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -27,6 +27,8 @@ public enum EdgeConvexity: Int32, Sendable {
 
 Maps to `OCCTEdgeConvexity` from the bridge. The classification is computed by `OCCTEdgeGetConvexity` using `BRepAdaptor_Surface` surface normals and edge tangents — specifically the sign of `(tangent × n1) · n2` at the edge midpoint.
 
+`OCCTEdgeGetConvexity` (like `OCCTFacesAreAdjacent`) has no notion of which solid `face1`/`face2` belong to; it is `AAG.buildGraph()` that restricts which pairs reach it to occurrences sharing a solid (#699). Called directly on two faces from different solids the result is not meaningful for either, see `AAG`, below.
+
 - `concave` — the two face normals "open inward"; typical of pocket walls meeting a floor.
 - `smooth` — faces are tangent (within ~0.5°); typical of filleted edges.
 - `convex` — the two face normals "open outward"; typical of external edges.
@@ -80,9 +82,27 @@ public struct AAGEdge: Sendable {
 
 ## AAG
 
-Attributed Adjacency Graph for feature recognition. Nodes are face occurrences (`Shape.orientedFaces()`, #642); graph edges connect pairs of adjacent occurrences and carry convexity attributes.
+Attributed Adjacency Graph for feature recognition. Nodes are face occurrences (`Shape.orientedFaces()`, #642); graph edges connect pairs of adjacent occurrences **within the same solid** (#699) and carry convexity attributes.
 
 A face shared by two solids in a compound is two nodes, one per owning solid, each carrying that solid's own normal and derived predicates. `AAG` does not build a graph edge between the two occurrences of one shared face: they are the same face, not neighbors of it. On a shape whose faces are not shared this is exactly the node set the old `Shape.faces()`-based graph produced, in the same order.
+
+### Adjacency is scoped to one solid (#699)
+
+Two occurrences that share a B-Rep edge but belong to different solids in a compound are adjacent *in the compound* and not adjacent in *either* solid: a floor face's candidate walls are the faces bounding the same body, not any face anywhere in the compound that happens to touch the same edge locus. Neither `OCCTFacesAreAdjacent` nor `OCCTEdgeGetConvexity` has any notion of solid membership on their own (both compare two `TopoDS_Face` values purely on their own edge geometry), so `AAG.buildGraph()` restricts which pairs it hands to them: only occurrences it can establish share a solid are compared at all.
+
+Solid membership per occurrence is derived from the shape's own traversal order rather than a new bridge entry point: `orientedFaces()`'s underlying `TopExp_Explorer` walk visits every occurrence under one top-level solid contiguously before moving to the next, in the same first-encountered order `Shape.solids` itself enumerates solids in, so the flat occurrence list partitions into contiguous runs sized by each solid's own face-occurrence count. On a shape with zero or one solid, including every single-solid shape, there is no cross-solid pair to restrict, so nothing changes: this is a compound-only concern.
+
+```swift
+let box = Shape.box(width: 10, height: 10, depth: 10)!
+let halves = box.split(atPlane: SIMD3(4, 0, 0), normal: SIMD3(1, 0, 0))!
+
+// Same geometry, opposite compound member order.
+let orderA = Shape.compound(halves)!
+let orderB = Shape.compound(halves.reversed())!
+
+// Order-independent: cross-solid pairs never reach OCCTFacesAreAdjacent at all.
+print(orderA.detectPocketsAAG().count == orderB.detectPocketsAAG().count)   // true
+```
 
 ### `AAG.init(shape:)`
 
@@ -92,7 +112,7 @@ Constructs the AAG by traversing all face-occurrence pairs in the shape.
 public init(shape: Shape)
 ```
 
-Calls `buildGraph()` which reads `shape.orientedFaces()`, iterates all `(i, j)` occurrence pairs (skipping any pair that is the two sides of one shared face), tests adjacency via `OCCTFacesAreAdjacent` (backed by `TopExp::MapShapes` + `TopoDS_Edge::IsSame`), retrieves shared edges via `OCCTFaceGetSharedEdges`, and classifies each shared edge via `OCCTEdgeGetConvexity` (`BRepAdaptor_Surface` + `BRep_Tool::CurveOnSurface`).
+Calls `buildGraph()` which reads `shape.orientedFaces()`, iterates all `(i, j)` occurrence pairs (skipping any pair that is the two sides of one shared face, and any pair `AAG` can establish belongs to two different solids, #699), tests adjacency via `OCCTFacesAreAdjacent` (backed by `TopExp::MapShapes` + `TopoDS_Edge::IsSame`), retrieves shared edges via `OCCTFaceGetSharedEdges`, and classifies each shared edge via `OCCTEdgeGetConvexity` (`BRepAdaptor_Surface` + `BRep_Tool::CurveOnSurface`).
 
 - **Parameters:** `shape` — the solid to analyse. Works best on closed solids.
 - **OCCT:** `TopExp::MapShapes` / `TopoDS_Edge::IsSame` (adjacency); `BRepAdaptor_Surface` + `BRep_Tool::CurveOnSurface` (convexity).
@@ -397,7 +417,7 @@ Detects pockets using AAG-based feature recognition.
 public func detectPocketsAAG() -> [PocketFeature]
 ```
 
-Equivalent to `buildAAG().detectPockets()`. Selects on each node's `isUpward`, `isHorizontal` and `isPlanar`, which `buildAAG()` derives per face occurrence, so the result no longer depends on a compound's member order (#642): before the fix, a face shared between two solids in a compound could report a different pocket count depending only on which order the solids were compounded in, for identical geometry.
+Equivalent to `buildAAG().detectPockets()`. Selects on each node's `isUpward`, `isHorizontal` and `isPlanar`, which `buildAAG()` derives per face occurrence, so the result no longer depends on a compound's member order (#642): before that fix, a face shared between two solids in a compound could report a different pocket count depending only on which order the solids were compounded in, for identical geometry. #699 closed a second, independent source of the same symptom: `concaveNeighbors(of:)` (which `detectPockets()` reads to find candidate walls) used to include neighbors from a *different* solid than the floor's own, which could make the result order-dependent on a fixture #642 alone did not fix (a vertical, rather than horizontal, two-solid split) and could inflate the count with a wall that was never really adjacent to that floor in either solid.
 
 - **Returns:** Array of `PocketFeature` values, sorted deepest-first.
 - **Example:**


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`OCCTFacesAreAdjacent` and `OCCTEdgeGetConvexity` have no concept of solid membership: both
compare two `TopoDS_Face` values purely on their own edge geometry, ignoring the `shape`
argument they are handed beyond a null check. So two face occurrences from *different* solids
in one compound that happen to share a B-Rep edge were reported adjacent, and the convexity of
that shared edge was computed with no reference to which solid was asking.

Found measuring #642's own fix. On a vertical two-solid split (a plain 10mm box cut by an
X-normal plane through x=4), the shared wall borders two half-faces of the box's original top
face that also border **each other** along the cut line, so one edge is common to three face
occurrences. `AAG.buildGraph()`'s pairwise loop compared all three against each other
regardless of which solid each belonged to. `detectPocketsAAG().count` was `1` in one compound
member order and `2` in the other, for identical geometry.

Closes #699

## The decision

**The contract:** two faces sharing a B-Rep edge but belonging to different solids in a
compound are adjacent *in the compound* and not adjacent in *either* solid. `AAG`'s consumers
(`detectPockets()`, `concaveNeighbors(of:)`, `convexNeighbors(of:)`) want the solid-scoped
answer.

**Taken: restrict `AAG.buildGraph()`'s pairwise check, not the bridge functions.** An audit
found `OCCTFacesAreAdjacent`/`OCCTEdgeGetConvexity` have exactly one Swift call site each,
both inside `buildGraph()`, so there is no other consumer a bridge-side change could have
broken, and the Swift-side fix is the smaller change either way.

**Solid membership per occurrence is derived, not looked up through a new bridge function.**
Checked before adding one, per the issue's own instruction: `orientedFaces()`'s underlying
`TopExp_Explorer` walk visits every occurrence under one top-level solid contiguously before
moving to the next, in the same first-encountered order `Shape.solids` itself enumerates
solids in (both are one DFS over the same shape, filtered to a different target type). So the
flat occurrence list partitions into contiguous runs sized by each solid's own
face-occurrence count. Confirmed against both split fixtures (dumping every occurrence's
bounds alongside each solid's own `orientedFaces()` count) before relying on it, not assumed
from the traversal's documented behavior alone. `AAG.buildGraph()` falls back to the pre-#699
unrestricted comparison on a shape with zero or one solid, or if the per-solid counts don't
sum to the total occurrence count: silently mis-partitioning would be worse than not
partitioning at all.

**`OCCTEdgeGetConvexity` did not need its own solid-membership fix.** Once adjacency is
restricted to same-solid pairs, convexity is only ever computed for a legitimate same-solid
neighbor.

## A further correction to #642's own headline measurement

Restricting to same-solid pairs also moves the HORIZONTAL fixture's
`detectPocketsAAG().count` from `2` (in both orders, #642's own fix) to `1` (in both orders).
This is not a regression: #642 was about order-AGREEMENT, which survives intact (`1` in both
orders, was `2` in both orders, still equal either way). What moved is that one of the two
"pockets" `detectPockets()` reported before #699 was itself built from a cross-solid
comparison between the shared wall and the wrong side of a split face, exactly the mechanism
this fixes. `Issue642AAGNodeIdentityTests`'s own pinned count moves from `2` to `1`
accordingly, with a note explaining why; the agreement assertion it exists to guard is
unchanged and still passes.

## A defect found and deliberately not fixed here

`OCCTEdgeGetConvexity`'s reported concavity for a given physical edge depends on which face is
passed as `face1` and which as `face2`: the underlying `(tangent × n1) · n2` triple product
negates under that swap, and `AAG.buildGraph()`'s pairwise loop picks `face1`/`face2` by array
index order, not by any geometric convention. This reproduces on a **single, uncut plain box**
(`detectPocketsAAG().count` is `1` for the plain-box fixture throughout the whole census, both
before and after #642 and #699): two of a box's four side-wall-to-top-face dihedrals are
genuinely convex but get reported concave, purely from index order, which is what feeds the
plain box's own false-positive pocket. Orthogonal to solid membership (needs no compound, no
shared face, no second solid) and orthogonal to this fix. Recorded in
`Scripts/repro/cluster-a-subshape-enumeration/README.md` rather than filed as its own issue,
since it was found explaining a side effect rather than measured as a primary claim.

## What the issue and my own measurements got wrong

- The issue's own suggestion that `AAGNode.distinctFaceIndex` "may be" enough to derive owning
  solid without new bridge surface was on the right track but not quite it:
  `distinctFaceIndex` identifies a face, not a solid, and two nodes sharing one (the two sides
  of a wall) belong to *different* solids by construction. The actual derivation is
  traversal-order based (see above), independent of `distinctFaceIndex`.
- My own first attempt assumed restricting to same-solid pairs would only ever *remove* false
  positives and could not move #642's own already-passing horizontal-cut count. Measured
  directly and found otherwise: the horizontal fixture's count moved too (`2` to `1`), because
  one of its two counted pockets was itself riding the same cross-solid mechanism. Chased this
  down to a third, unrelated, pre-existing defect in `OCCTEdgeGetConvexity`'s own sign
  convention (see above) before concluding `1` is the right post-fix answer, not a fresh bug.

## Injection matrix (prove-the-test-fails)

Every new/changed assertion run once with the fix reverted (`git stash` on
`Sources/OCCTSwift/FeatureRecognition.swift` alone), confirmed to fail, restored, confirmed to
pass:

| Test | Reverted result |
|---|---|
| `Issue699...detectPocketsAgreesAcrossOrder` | FAILED: `pocketsA.count → 1`, `pocketsB.count → 2` (the exact issue numbers) |
| `Issue699...edgeCountIsTwoIndependentBoxGraphs` | FAILED: `edges.count → 36` (expected `24`) in both orders |
| `Issue699...wallOccurrencesDoNotCrossSolidBoundary` | FAILED: the wall's two occurrences' neighbor sets were not disjoint |
| `Issue699...nodeCountUnaffected` | PASSED (positive control: #699 touches edges, not nodes) |
| `Issue699...plainBoxUnaffected` | PASSED (positive control: no cross-solid pair on a single solid) |
| `Issue642...detectPocketsAgreesAcrossOrder` | FAILED: `pocketsA.count → 2` (expected the corrected `1`) |
| All 7 other `Issue642...` tests | PASSED (#699 doesn't touch node identity, only edge scoping) |

All restored and re-verified green before this PR was opened.

## Audit: other callers of `OCCTFacesAreAdjacent` / `OCCTEdgeGetConvexity`

Grepped every `.swift`/`.mm` file in the tree for a call (not just the declaration) to either
function. **Exactly one Swift call site each, both inside `AAG.buildGraph()`
(`FeatureRecognition.swift`).** No other `.mm` file calls either function internally. This is
why the fix lives in `AAG.buildGraph()` rather than the bridge: there is no other consumer to
keep in sync, and no other consumer that could have been relying on the unscoped behavior.

## Verification

- `swift build`: clean (`rm -rf .build` first), 0 errors, no `OCCTSWIFT_LOCAL`.
- `swift test`: **5344 tests, 0 failures** (baseline 5338 + 6 new).
- Gate scripts, all exit 0, with and without `--self-test` (`count-operations.py` has none by
  design): `check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py`,
  `count-operations.py` (4301, unchanged: no public entry point added or removed, behavior
  only).
- Census re-run (`swift run ClusterACensus`): both `detectPocketsAAG().count` rows (vertical-
  and horizontal-cut fixtures) updated to `1/1/1`. The committed
  `Scripts/repro/cluster-a-subshape-enumeration/README.md` matches exactly (new "Update
  following #699's fix" section).
- Zero em-dashes across the diff.

## Docs

- `Sources/OCCTSwift/FeatureRecognition.swift`: `AAG`'s class doc comment and `buildGraph()`
  inline comments explain the contract; new private `solidGroups(of:in:)` documents the
  traversal-order derivation and its fallback.
- `docs/reference/FeatureRecognition.md`: new "Adjacency is scoped to one solid (#699)"
  section with a runnable `swift` snippet, plus updates to `AAG.init(shape:)` and
  `detectPocketsAAG()`'s prose.
- `docs/SEMVER.md`: new recorded exception (#699), extending #642's own rather than
  duplicating it, with the before/after table and rejected-alternative reasoning.
- `docs/CHANGELOG.md`: new Unreleased entry alongside #642's.
- `Scripts/repro/cluster-a-subshape-enumeration/README.md`: new "Update following #699's fix"
  section, two table rows updated in place, per the artifact's own rule that a census
  disagreeing with the tree is worse than none.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification): `Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift`.

## Notes for the reviewer

Cluster A's other three members (#638, #642, #651) are already merged. This is the last one
open, found during #642's own verification rather than planned in advance.
