### PR TITLE
fix(#639): the fillet family reports declined edges instead of only skipping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,301 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,304 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/repro/censuses/ClusterB.swift
+++ b/Scripts/repro/censuses/ClusterB.swift
@@ -157,7 +157,7 @@ enum ClusterB {
             record("fillet-edges", "filleted(edges:radius:)",
                    duplicate: volumesAgree(dup, single) ? "N/A: uniform radius (dup vol \(fmt(dup)) == single \(fmt(single)))" : "differs (dup \(fmt(dup)) vs single \(fmt(single)))",
                    outOfRange: outOfRange == nil ? "REJECT (nil)" : "measured non-nil",
-                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea)))" : "REJECT (nil)",
+                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea))) -- #639 fixed: filletedWithReport(edges:radius:) sibling reports declinedEdgeIndices" : "REJECT (nil)",
                    empty: box.filleted(edges: [], radius: 2.0) == nil ? "REJECT (nil)" : "non-nil",
                    note: "out-of-range probe: compound.edges()[15] (.index 15) passed to box (12 edges) -- Cluster A's shared fixture reused, #694")
         }
@@ -174,7 +174,7 @@ enum ClusterB {
             record("fillet-linear", "filleted(edges:startRadius:endRadius:)",
                    duplicate: volumesAgree(dup, single) ? "N/A: uniform law (dup vol \(fmt(dup)) == single \(fmt(single)))" : "differs (dup \(fmt(dup)) vs single \(fmt(single)))",
                    outOfRange: outOfRange == nil ? "REJECT (nil)" : "measured non-nil",
-                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea)))" : "REJECT (nil)",
+                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea))) -- #639 fixed: filletedWithReport(edges:startRadius:endRadius:) sibling reports declinedEdgeIndices" : "REJECT (nil)",
                    empty: box.filleted(edges: [], startRadius: 1.0, endRadius: 3.0) == nil ? "REJECT (nil)" : "non-nil")
         }
 
@@ -251,7 +251,7 @@ enum ClusterB {
             record("fillet-evolving", "filletEvolving(_:)",
                    duplicate: dupVerdict,
                    outOfRange: outOfRange == nil ? "REJECT (nil)" : "measured non-nil",
-                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea))) -- the #639 gap: no count of how many were skipped" : "REJECT (nil)",
+                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea))) -- #639 fixed: filletEvolvingWithReport(_:) now reports declinedEdgeIndices" : "REJECT (nil)",
                    empty: box.filletEvolving([]) == nil ? "REJECT (nil)" : "non-nil")
         }
 
@@ -266,7 +266,7 @@ enum ClusterB {
             record("fillet-edges (with history)", "filletedWithFullHistory(radius:edges:)",
                    duplicate: volumesAgree(dup, one) ? "N/A: uniform radius (dup \(fmt(dup)) == single-edge \(fmt(one)), both bigger than two-distinct-edges \(fmt(both)) -- fewer edges removed means less material gone)" : "differs (dup \(fmt(dup)) vs single \(fmt(one)))",
                    outOfRange: outOfRange == nil ? "REJECT (nil)" : "measured non-nil",
-                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea)))" : "REJECT (nil)",
+                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea))) -- #639: needed no new API, history.record(of:)'s !isDeleted && generated.isEmpty already names the declined set" : "REJECT (nil)",
                    empty: box.filletedWithFullHistory(radius: 1.0, edges: []) == nil ? "REJECT (nil)" : "non-nil")
         }
 
@@ -494,6 +494,12 @@ enum ClusterB {
 
             let foreignEdge = foreignShape.edges()[0]
             let foreignAdded = builderForeign.addEdge(foreignEdge, radius: 2.0)
+            // #639 correction: contour(for:) -- present in this class before #639, unrelated to
+            // it -- already answers "did this added edge make it into a contour" for exactly this
+            // foreign-edge case, the same Contour(E) == 0 signal it gives a same-shape edge OCCT
+            // declines on geometric grounds. The original census note here ("no per-edge signal
+            // beyond addEdge's own Bool return") never tried this query and was wrong.
+            let foreignContour = builderForeign.contour(for: foreignEdge)
             let foreignBuiltVolume = builderForeign.build()?.volume
             let foreignNoOp = foreignBuiltVolume.map { abs($0 - (box.volume ?? -1)) < 1e-6 } ?? false
 
@@ -502,9 +508,9 @@ enum ClusterB {
             record("fillet (class API)", "FilletBuilder.addEdge(_:radius:)",
                    duplicate: dupVerdict,
                    outOfRange: "N/A: takes an Edge object, not an index -- no out-of-range index to name",
-                   declined: "foreign edge (belongs to a different Shape entirely): addEdge returned \(foreignAdded), build() \(foreignBuiltVolume == nil ? "REJECT (nil)" : (foreignNoOp ? "NO-OP (non-nil, volume unchanged)" : "non-nil, volume changed"))",
+                   declined: "foreign edge (belongs to a different Shape entirely): addEdge returned \(foreignAdded), contour(for:) == \(foreignContour), build() \(foreignBuiltVolume == nil ? "REJECT (nil)" : (foreignNoOp ? "NO-OP (non-nil, volume unchanged)" : "non-nil, volume changed"))",
                    empty: "build() with zero addEdge calls: \(emptyResult == nil ? "REJECT (nil)" : "non-nil")",
-                   note: "no index resolution at all in this path: no occtUseSubShapesByIndex, no occtValidFilletRadius -- #639's declined-edge gap applies here too, and there is no per-edge signal beyond addEdge's own Bool return")
+                   note: "no index resolution at all in this path: no occtUseSubShapesByIndex, no occtValidFilletRadius -- but contour(for:) == 0 already reports the decline per edge (#639 correction), readable right after addEdge with no build() required")
         }
 
         // MARK: - ChamferBuilder class API  [takes Edge objects directly, not indices]

--- a/Scripts/repro/cluster-b-fillet-edge-contract/README.md
+++ b/Scripts/repro/cluster-b-fillet-edge-contract/README.md
@@ -55,12 +55,12 @@ python3 Scripts/repro/cluster-b-fillet-edge-contract/classify_fillet_sites.py --
 
 | family | entry point | duplicate index | out-of-range index | OCCT-declined index | empty list |
 |---|---|---|---|---|---|
-| fillet-edges | `filleted(edges:radius:)` | N/A: uniform radius (dup 991.415927 == single 991.415927) | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) | REJECT (nil) |
-| fillet-linear | `filleted(edges:startRadius:endRadius:)` | N/A: uniform law (dup 990.523733 == single 990.523733) | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) | REJECT (nil) |
+| fillet-edges | `filleted(edges:radius:)` | N/A: uniform radius (dup 991.415927 == single 991.415927) | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) -- **#639 fixed**: `filletedWithReport(edges:radius:)` sibling reports `declinedEdgeIndices` | REJECT (nil) |
+| fillet-linear | `filleted(edges:startRadius:endRadius:)` | N/A: uniform law (dup 990.523733 == single 990.523733) | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) -- **#639 fixed**: `filletedWithReport(edges:startRadius:endRadius:)` sibling reports `declinedEdgeIndices` | REJECT (nil) |
 | fillet-edges (per-edge radius) | `blendedEdges(_:)` | **OVERWRITE: last radius wins** (dup 946.349541 == last-only 946.349541, != first-only 991.415927) -- #633 | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) | REJECT (nil) |
 | fillet-variable | `filletedVariable(edgeIndex:radiusProfile:)` | N/A: scalar edgeIndex, no list | REJECT (nil) | REJECT (nil): single edge, no partial fillet possible | N/A: no list; `radiusProfile` needs >=2 points, stricter than `filletEvolving`'s >=1 |
-| fillet-evolving | `filletEvolving(_:)` | **OVERWRITE: last law wins** (dup 946.349541 == last-only 946.349541), documented on `EvolvingFilletEdge`, same mechanism as #633 | REJECT (nil) | SKIP (non-nil, area 465.097336) -- **the #639 gap**: no count of how many were skipped | REJECT (nil) |
-| fillet-edges (with history) | `filletedWithFullHistory(radius:edges:)` | N/A: uniform radius (dup 997.853982 == single-edge 997.853982) | REJECT (nil) | SKIP (non-nil, area 465.097336) | REJECT (nil) |
+| fillet-evolving | `filletEvolving(_:)` | **OVERWRITE: last law wins** (dup 946.349541 == last-only 946.349541), documented on `EvolvingFilletEdge`, same mechanism as #633 | REJECT (nil) | SKIP (non-nil, area 465.097336) -- **#639 fixed**: `filletEvolvingWithReport(_:)` now reports `declinedEdgeIndices` | REJECT (nil) |
+| fillet-edges (with history) | `filletedWithFullHistory(radius:edges:)` | N/A: uniform radius (dup 997.853982 == single-edge 997.853982) | REJECT (nil) | SKIP (non-nil, area 465.097336) -- **#639**: needed no new API; `history.record(of:)`'s `!isDeleted && generated.isEmpty` already names the declined set | REJECT (nil) |
 | fillet-variable (with history) | `filletedWithFullHistory(edge:startRadius:endRadius:)` | N/A: scalar edge index, no list | REJECT (nil) | REJECT (nil): single edge | N/A: no list |
 | blend (BiTgte_Blend) | `biTgteBlend(edgeIndices:radius:)` | N/A: uniform radius over a set; `BiTgte_Blend` keys edges into an `IndexedMap` (dup 1000.000000 == single 1000.000000) | REJECT (nil), fixed by #613 | **NO-OP** on a convex edge (non-nil, volume unchanged): structurally different from a skip-from-a-batch, see note below | REJECT (nil) |
 | chamfer (two distances) | `chamferedTwoDistances(_:)` | **FIRST WINS** (dup 995.000000 == first-only 995.000000, != last-only 980.000000) -- the OPPOSITE of #633's last-wins | REJECT (nil) | REJECT (nil): single-edge batch, whole call fails | REJECT (nil) |
@@ -69,7 +69,7 @@ python3 Scripts/repro/cluster-b-fillet-edge-contract/classify_fillet_sites.py --
 | offset-per-face | `offsetPerFace(defaultOffset:faceOffsets:)` | N/A: `faceOffsets` is a `Dictionary`, a duplicate key cannot be constructed | REJECT (nil), fixed by **#541** (see "Corrections" below) | N/A: `BRepOffset_MakeOffset` has no per-face decline analogous to `Add()` on a free-boundary edge | ACCEPTS (non-nil): applies `defaultOffset` uniformly, a legitimate no-override request |
 | 2D fillet (face) | `fillet2D(vertexIndices:radii:)` | REJECT (nil) on a duplicated vertex index | REJECT (nil), fixed by #568 | UNMEASURED: no open/degenerate planar-face fixture built here | REJECT (nil), Swift-side guard |
 | 2D chamfer (face) | `chamfer2D(edgePairs:distances:)` | **CRASH (SIGSEGV, uncatchable)** on a duplicated edge pair -- see "New findings" below | REJECT (nil), fixed by #568 | UNMEASURED, same reason as `fillet2D` | REJECT (nil), Swift-side guard |
-| fillet (class API) | `FilletBuilder.addEdge(_:radius:)` | **OVERWRITE: last radius wins**, same mechanism as #633, unaudited by #489/#520/#568 | N/A: takes an `Edge`, not an index | foreign edge (a different `Shape` entirely): `addEdge` returns `true`, `build()` REJECT (nil) | `build()` with zero `addEdge` calls: REJECT (nil) |
+| fillet (class API) | `FilletBuilder.addEdge(_:radius:)` | **OVERWRITE: last radius wins**, same mechanism as #633, unaudited by #489/#520/#568 | N/A: takes an `Edge`, not an index | foreign edge (a different `Shape` entirely): `addEdge` returns `true`, `contour(for:) == 0`, `build()` REJECT (nil) -- **#639 correction**: `contour(for:)` already reports the decline per edge | `build()` with zero `addEdge` calls: REJECT (nil) |
 | chamfer (class API) | `ChamferBuilder.addEdge(_:distance:)` | **FIRST WINS**, matches `chamferedTwoDistances` -- `addEdge` itself prefers the first call, not just the bridge's hand-rolled loop | N/A: takes an `Edge`, not an index | foreign edge: `addEdge` returns `true`, `build()` REJECT (nil) | `build()` with zero `addEdge` calls: REJECT (nil) |
 
 Full command output (with the `note` column this table drops for width) is reproduced exactly by
@@ -116,10 +116,15 @@ family, not just deciding to reject/dedupe/document.
    of any kind.** No `occtUseSubShapesByIndex`, no `occtValidFilletRadius`. A foreign edge (one
    belonging to an entirely different `Shape`) is silently accepted by `addEdge` (returns `true`)
    and produces no built result (`build()` returns `nil`) with no signal as to why. This is a
-   second, independent access path into the same OCCT builder classes the free functions wrap, and
-   it inherits the #639 declined-edge-reporting gap on its own terms: there is no per-edge report
-   at all, only `addEdge`'s own `Bool` return, which per the above is `true` even for a foreign
-   edge that changes nothing.
+   second, independent access path into the same OCCT builder classes the free functions wrap.
+   **Correction (#639): the claim that "there is no per-edge report at all" was wrong, and #639
+   found it by trying the query this census never tried.** `FilletBuilder.contour(for:)` --
+   present since before this census, unrelated to #639 -- already answers exactly this: `Contour(E)
+   == 0` for the foreign edge above (measured directly: `addEdge` returns `true`,
+   `contour(for: foreignEdge)` returns `0`, `build()` returns `nil`), the identical signal it
+   reports for a same-shape edge OCCT declines on geometric grounds. Neither this census nor #639's
+   own issue text noticed the query already existed; #639 documents the recipe rather than adding
+   new bridge code for this class.
 3. **`offsetPerFace`'s reject-not-skip fix is attributed to #541 in the bridge's own comment, not
    #568.** See "Corrections" below.
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -270,7 +270,9 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType);
 ///   `edgeIndices`, that OCCT declined to fillet (#639) -- a free-boundary edge, e.g. Must have
 ///   capacity >= edgeCount when non-NULL.
 /// @param outDeclinedCount Optional (may be NULL): set to the number of entries written to
-///   `declinedEdgeIndices`, or 0 if the call fails before OCCT is touched.
+///   `declinedEdgeIndices`. **Read it only when the returned shape is non-NULL.** It is zeroed on
+///   entry, so an early failure leaves 0, but a Build() failure returns NULL with the count already
+///   written, and that count describes a shape the caller never receives.
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices,
                                    int32_t edgeCount, double radius,

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -266,9 +266,16 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType);
 ///   the whole call, #520)
 /// @param edgeCount Number of edges to fillet
 /// @param radius Fillet radius; must be > 0, or the call fails without touching OCCT
+/// @param declinedEdgeIndices Optional (may be NULL): filled with the 0-based indices, from
+///   `edgeIndices`, that OCCT declined to fillet (#639) -- a free-boundary edge, e.g. Must have
+///   capacity >= edgeCount when non-NULL.
+/// @param outDeclinedCount Optional (may be NULL): set to the number of entries written to
+///   `declinedEdgeIndices`, or 0 if the call fails before OCCT is touched.
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices,
-                                   int32_t edgeCount, double radius);
+                                   int32_t edgeCount, double radius,
+                                   int32_t* _Nullable declinedEdgeIndices,
+                                   int32_t* _Nullable outDeclinedCount);
 
 /// Fillet specific edges with linear radius interpolation
 ///
@@ -285,9 +292,14 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
 /// @param edgeCount Number of edges to fillet
 /// @param startRadius Radius at the start of each named edge's law; must be > 0
 /// @param endRadius Radius at the end of each named edge's law; must be > 0
+/// @param declinedEdgeIndices Optional (may be NULL): same #639 reporting contract as
+///   OCCTShapeFilletEdges.
+/// @param outDeclinedCount Optional (may be NULL): same contract as OCCTShapeFilletEdges.
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeIndices,
-                                         int32_t edgeCount, double startRadius, double endRadius);
+                                         int32_t edgeCount, double startRadius, double endRadius,
+                                         int32_t* _Nullable declinedEdgeIndices,
+                                         int32_t* _Nullable outDeclinedCount);
 
 /// Add draft angle to faces for mold release
 /// @param shape The shape to draft
@@ -1354,11 +1366,16 @@ typedef struct {
 ///   every radius must be > 0, and each edge's parameters must lie in [0, 1] and strictly increase
 /// @param pointCounts Array of how many radius points per edge; fewer than 1 for any edge rejects
 ///   the call, since a contour with no radius SIGSEGVs in Build()
+/// @param declinedEdgeIndices Optional (may be NULL): same #639 reporting contract as
+///   OCCTShapeFilletEdges.
+/// @param outDeclinedCount Optional (may be NULL): same contract as OCCTShapeFilletEdges.
 /// @return Filleted shape, or NULL on failure
 OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
                                       const int32_t* edgeIndices, int32_t edgeCount,
                                       const OCCTFilletRadiusPoint* radiusPoints,
-                                      const int32_t* pointCounts);
+                                      const int32_t* pointCounts,
+                                      int32_t* _Nullable declinedEdgeIndices,
+                                      int32_t* _Nullable outDeclinedCount);
 
 // MARK: - Per-Face Variable Offset (v0.38.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1673,13 +1673,71 @@ bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, const TopoDS_E
     return true;
 }
 
+// === #639: which requested edges did OCCT decline ===
+//
+// Add(edge) and its radius-carrying overloads add a fillet contour, or do nothing at all when the
+// edge cannot support one (a free-boundary edge of an open shell, one adjacent face short of the
+// two a blend needs) -- silently, with no exception and no false return, which is why
+// filleted(edges:radius:) and its siblings could only ever SKIP a declined edge, never report it.
+// Contour(E) is the one signal OCCT exposes for this: 0 when E landed in no contour, populated by
+// Add() itself rather than by Build() (the same fact #612's occtFilletEdgeSlot above already
+// relies on for per-edge radius-law placement). There is no second signal for *why* -- Add()
+// returns void, and BRepFilletAPI_MakeFillet's own NbFaultyContours()/BadShape()/StripeStatus()
+// describe a contour that failed during Build(), which a never-added edge never reaches -- so this
+// reports WHICH edges were declined, not why, matching what OCCT itself can answer.
+//
+// Called after every Add() in `edgeIndices` has run and before Build(), so a later edge's Add()
+// extending an earlier edge's tangent contour is already reflected. Re-resolves `edgeIndices`
+// against `shape`'s own edge map rather than threading resolved TopoDS_Edge values out of
+// occtFilletAddEdges's visitor, trading one extra read-only walk for keeping that helper's
+// signature untouched. An index the map cannot resolve is skipped rather than asserted: the caller
+// (occtFilletAddEdges) already rejected the whole request in that case, so every index reaching
+// here resolved the first time too.
+inline std::vector<int32_t> occtFilletDeclinedIndices(const BRepFilletAPI_MakeFillet& fillet,
+                                                       const TopoDS_Shape& shape,
+                                                       const int32_t* edgeIndices, int32_t count) {
+    std::vector<int32_t> declined;
+    TopTools_IndexedMapOfShape map;
+    occtMapSubShapes(shape, TopAbs_EDGE, map);
+    for (int32_t i = 0; i < count; i++) {
+        TopoDS_Shape sub = occtMappedSubShapeAt(map, edgeIndices[i]);
+        if (sub.IsNull()) continue;
+        if (fillet.Contour(TopoDS::Edge(sub)) == 0) declined.push_back(edgeIndices[i]);
+    }
+    return declined;
+}
+
+// Writes occtFilletDeclinedIndices's result into the two optional caller-owned out-params every
+// #639-reporting entry point takes: `outDeclinedCount` gets the true count, and (when non-null)
+// `declinedEdgeIndices` gets that many indices, in `edgeIndices`' own order. The caller is
+// responsible for sizing `declinedEdgeIndices` to at least `edgeCount` -- the mathematical upper
+// bound on how many of `edgeCount` requested edges can be declined -- so there is no separate
+// capacity parameter to get wrong.
+inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
+                                    const int32_t* edgeIndices, int32_t edgeCount,
+                                    int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
+    if (!declinedEdgeIndices && !outDeclinedCount) return;
+    std::vector<int32_t> declined = occtFilletDeclinedIndices(fillet, shape, edgeIndices, edgeCount);
+    if (outDeclinedCount) *outDeclinedCount = static_cast<int32_t>(declined.size());
+    if (declinedEdgeIndices) {
+        for (size_t i = 0; i < declined.size(); i++) declinedEdgeIndices[i] = declined[i];
+    }
+}
+
 // occtFilletAddEdges plus the build-and-wrap half: the guard, the perform/check/result triad, and
 // the catch(...) that turns any OCCT failure into nullptr. This is the whole body of the three
 // edge-list fillet entry points bar their radius law.
+//
+// `declinedEdgeIndices`/`outDeclinedCount` default to null for the two callers that do not report
+// (#639): occtFilletWriteDeclined is then a no-op and nothing about the existing skip behaviour or
+// its cost changes.
 template <class AddEdge>
 OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
                                      const int32_t* edgeIndices, int32_t edgeCount,
-                                     AddEdge addEdge) {
+                                     AddEdge addEdge,
+                                     int32_t* declinedEdgeIndices = nullptr,
+                                     int32_t* outDeclinedCount = nullptr) {
+    if (outDeclinedCount) *outDeclinedCount = 0;
     if (!shape || !edgeIndices || edgeCount < 1) return nullptr;
 
     try {
@@ -1687,6 +1745,9 @@ OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
         if (!occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge)) {
             return nullptr;
         }
+
+        occtFilletWriteDeclined(fillet, shape->shape, edgeIndices, edgeCount,
+                                declinedEdgeIndices, outDeclinedCount);
 
         fillet.Build();
         if (!fillet.IsDone()) return nullptr;

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -324,8 +324,15 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType) 
 // The three edge-list fillet entry points share occtShapeFilletEdgeList (OCCTBridge_Internal.h)
 // and supply only their own radius law; OCCTShapeBlendEdges, the per-edge one, lives in
 // OCCTBridge_Healing.mm. See that helper for why the radius precondition is the bridge's. #489
+//
+// #639: `declinedEdgeIndices`/`outDeclinedCount` report which of `edgeIndices` OCCT declined
+// (occtFilletWriteDeclined). Both are nullable and the existing skip behaviour is unchanged when
+// they are null; `filleted(edges:radius:)` passes null for both, `filletedWithReport(edges:radius:)`
+// does not. `declinedEdgeIndices`, when non-null, must have capacity >= edgeCount.
 OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices,
-                                   int32_t edgeCount, double radius) {
+                                   int32_t edgeCount, double radius,
+                                   int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
+    if (outDeclinedCount) *outDeclinedCount = 0;
     if (!occtValidFilletRadius(radius)) return nullptr;
 
     return occtShapeFilletEdgeList(shape, edgeIndices, edgeCount,
@@ -333,11 +340,14 @@ OCCTShapeRef OCCTShapeFilletEdges(OCCTShapeRef shape, const int32_t* edgeIndices
                                             const TopoDS_Edge& edge, int32_t) {
         fillet.Add(radius, edge);
         return true;
-    });
+    }, declinedEdgeIndices, outDeclinedCount);
 }
 
+// #639: same reporting contract as OCCTShapeFilletEdges above.
 OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeIndices,
-                                         int32_t edgeCount, double startRadius, double endRadius) {
+                                         int32_t edgeCount, double startRadius, double endRadius,
+                                         int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
+    if (outDeclinedCount) *outDeclinedCount = 0;
     if (!occtValidFilletRadius(startRadius) || !occtValidFilletRadius(endRadius)) return nullptr;
 
     return occtShapeFilletEdgeList(shape, edgeIndices, edgeCount,
@@ -358,7 +368,7 @@ OCCTShapeRef OCCTShapeFilletEdgesLinear(OCCTShapeRef shape, const int32_t* edgeI
         // skip the sibling entry points get from Add(Radius, E).
         fillet.Add(startRadius, endRadius, edge);
         return true;
-    });
+    }, declinedEdgeIndices, outDeclinedCount);
 }
 
 OCCTShapeRef OCCTShapeDraft(OCCTShapeRef shape, const int32_t* faceIndices, int32_t faceCount,
@@ -2385,10 +2395,17 @@ OCCTShapeRef OCCTShapeCutAndBlend(OCCTShapeRef shape1, OCCTShapeRef shape2, doub
 // 1-based edge index in the family. And a per-edge point count below 1 is now rejected: it used to
 // take neither branch, leaving a contour with no radius at all, which SIGSEGVs in Build() rather
 // than failing IsDone(). Reachable from Swift as EvolvingFilletEdge(edge:radiusPoints: []).
+//
+// #639: `declinedEdgeIndices`/`outDeclinedCount` report which of `edgeIndices` OCCT declined, same
+// contract as OCCTShapeFilletEdges. This is the entry point the census named directly: filleting an
+// open shell's whole edge list SKIPs the edges OCCT declines with no way to learn which or how
+// many. `filletEvolving(_:)` passes null for both; `filletEvolvingWithReport(_:)` does not.
 OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
                                       const int32_t* edgeIndices, int32_t edgeCount,
                                       const OCCTFilletRadiusPoint* radiusPoints,
-                                      const int32_t* pointCounts) {
+                                      const int32_t* pointCounts,
+                                      int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
+    if (outDeclinedCount) *outDeclinedCount = 0;
     if (!shape || !edgeIndices || edgeCount <= 0 || !radiusPoints || !pointCounts) return nullptr;
     try {
         BRepFilletAPI_MakeFillet fillet(shape->shape);
@@ -2413,6 +2430,9 @@ OCCTShapeRef OCCTShapeFilletEvolving(OCCTShapeRef shape,
             return profileOk;
         });
         if (!ok) return nullptr;
+
+        occtFilletWriteDeclined(fillet, shape->shape, edgeIndices, edgeCount,
+                                declinedEdgeIndices, outDeclinedCount);
 
         fillet.Build();
         if (!fillet.IsDone()) return nullptr;

--- a/Sources/OCCTSwift/BooleanResult.swift
+++ b/Sources/OCCTSwift/BooleanResult.swift
@@ -13,6 +13,31 @@ public struct BooleanResult: Sendable {
 /// Per-input-subshape history for a boolean operation: which output
 /// sub-shapes the input was modified into, which output sub-shapes were
 /// generated FROM it, and whether it was deleted with no replacement.
+///
+/// ## Finding a declined fillet edge (#639)
+///
+/// ``Shape/filletedWithFullHistory(radius:edges:)`` skips an edge OCCT declines to fillet (a
+/// free-boundary edge of an open shell, most commonly) rather than rejecting the whole call, and
+/// this record is how a caller finds out which requested edges those were: check `!isDeleted &&
+/// generated.isEmpty` for each one. An edge OCCT actually filleted is always deleted, with the new
+/// fillet-boundary edges in `generated` (measured: 12/12 on the fixture below). Do **not** test
+/// `modified.isEmpty` alone: a declined edge can still show up with one `modified` entry when an
+/// *accepted* neighbour's fillet trims its shared endpoint, so `modified` is not empty on a
+/// declined edge in general, only `generated`/`isDeleted` are the reliable signal.
+///
+/// ```swift
+/// let box = Shape.box(width: 10, height: 10, depth: 10)!
+/// let faces = box.faces().dropFirst().compactMap { Shape.fromFace($0) }
+/// let shell = Shape.sew(shapes: Array(faces))!
+/// let edgeShapes = shell.subShapes(ofType: .edge)
+/// if let (_, history) = shell.filletedWithFullHistory(radius: 1.0, edges: Array(0..<edgeShapes.count)) {
+///     let declined = edgeShapes.indices.filter {
+///         let record = history.record(of: edgeShapes[$0])
+///         return !record.isDeleted && record.generated.isEmpty
+///     }
+///     print(declined)   // e.g. [6, 9, 10, 11]
+/// }
+/// ```
 public struct ShapeHistoryRecord: Sendable {
     /// Output sub-shapes that are modifications of the input (1:1 or 1:N).
     /// Example: a face split by a boolean cut → multiple modified faces.

--- a/Sources/OCCTSwift/FilletBuilder.swift
+++ b/Sources/OCCTSwift/FilletBuilder.swift
@@ -3,6 +3,26 @@ import simd
 import OCCTBridge
 
 /// Builder for creating fillets on edges of a shape, wrapping BRepFilletAPI_MakeFillet.
+///
+/// ## Finding a declined edge (#639)
+///
+/// `addEdge` returns `true` even for an edge OCCT goes on to silently decline: a free-boundary
+/// edge of an open shell, most commonly, which has only one adjacent face where a fillet needs
+/// two. Unlike the free functions (``Shape/filleted(edges:radius:)`` and siblings), this class
+/// already has the query for it: ``contour(for:)`` returns `0` for an edge that never entered any
+/// contour, populated by `Add()` itself so it is readable right after `addEdge`, with no need to
+/// call ``build()`` first.
+///
+/// ```swift
+/// let box = Shape.box(width: 10, height: 10, depth: 10)!
+/// let faces = box.faces().dropFirst().compactMap { Shape.fromFace($0) }
+/// let shell = Shape.sew(shapes: Array(faces))!       // an open shell: some edges are unfilletable
+/// let builder = FilletBuilder(shape: shell)!
+/// let edges = shell.edges()
+/// for edge in edges { builder.addEdge(edge, radius: 1.0) }
+/// let declined = edges.filter { builder.contour(for: $0) == 0 }
+/// print(declined.map(\.index))   // e.g. [6, 9, 10, 11]
+/// ```
 public final class FilletBuilder: @unchecked Sendable {
     private let handle: OCCTFilletBuilderRef
 
@@ -102,6 +122,11 @@ extension FilletBuilder {
     }
 
     /// Get contour index for an edge (0 if not found).
+    ///
+    /// `0` covers two different things a caller may need to tell apart: an edge never passed to
+    /// ``addEdge(_:radius:)``/``addEdge(_:radius1:radius2:)`` at all, and one that was but that
+    /// OCCT declined (#639, see the type's own doc). This only distinguishes them for edges the
+    /// caller itself tracked as added.
     public func contour(for edge: Edge) -> Int {
         Int(OCCTFilletBuilderContour(handle, edge.handle))
     }

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -38,6 +38,38 @@ extension Shape {
     }
     // MARK: - Selective Fillet
 
+    /// Result of a fillet call that also reports which requested edges OCCT declined (#639).
+    ///
+    /// `BRepFilletAPI_MakeFillet::Add` silently does nothing for an edge it cannot fillet, most
+    /// commonly a free-boundary edge of an open shell, which has only one adjacent face where a
+    /// fillet needs two. So the plain fillet methods (``filleted(edges:radius:)``,
+    /// ``filleted(edges:startRadius:endRadius:)``, ``filletEvolving(_:)``) build successfully and
+    /// silently skip it. `FilletResult` is how a caller who used the `WithReport` sibling of one of
+    /// those methods finds out which ones and how many.
+    ///
+    /// There is no *reason* to go with the list: `Add` returns nothing, and
+    /// `BRepFilletAPI_MakeFillet::NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a
+    /// contour that failed during `Build()`, which an edge OCCT never added to any contour never
+    /// reaches. `Contour(edge) == 0`, populated by `Add()` and not `Build()`, is the only signal
+    /// OCCT itself exposes, so this reports *which* edges were declined, not *why*.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let faces = box.faces().dropFirst().compactMap { Shape.fromFace($0) }   // drop one face
+    /// let shell = Shape.sew(shapes: Array(faces))!                            // -> an open shell
+    /// if let report = shell.filletedWithReport(edges: shell.edges(), radius: 1.0) {
+    ///     print(report.declinedEdgeIndices)   // e.g. [6, 9, 10, 11]: skipped, not an error
+    /// }
+    /// ```
+    public struct FilletResult: Sendable {
+        /// The filleted shape. Identical to what the non-reporting sibling returns for the same
+        /// input: this reports skipped edges, it does not reject the call over them.
+        public let shape: Shape
+        /// 0-based indices, matching ``Edge/index``, of the requested edges OCCT declined to
+        /// fillet. Empty when every requested edge was accepted.
+        public let declinedEdgeIndices: [Int]
+    }
+
     /// Fillet specific edges with uniform radius
     ///
     /// Every edge must belong to this shape: only ``Edge/index`` is carried across, so an edge
@@ -64,10 +96,50 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeFilletEdges(handle, buffer.baseAddress, Int32(indices.count), radius) else {
+            guard let result = OCCTShapeFilletEdges(handle, buffer.baseAddress, Int32(indices.count), radius, nil, nil) else {
                 return nil
             }
             return Shape(handle: result)
+        }
+    }
+
+    /// ``filleted(edges:radius:)``, also reporting which requested edges OCCT declined (#639).
+    ///
+    /// An edge OCCT cannot fillet is still skipped, not rejected: this changes only what a caller
+    /// can learn about it, not the shape returned. See ``FilletResult`` for why the report is a
+    /// list of indices rather than a count or a reason.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// if let report = box.filletedWithReport(edges: box.edges(), radius: 1.0) {
+    ///     precondition(report.declinedEdgeIndices.isEmpty)   // every edge of a closed solid fillets
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - edges: Edges to fillet (must have valid indices from this shape)
+    ///   - radius: Fillet radius; must be > 0
+    /// - Returns: A ``FilletResult``, or nil on failure, including an edge that is not this shape's
+    public func filletedWithReport(edges: [Edge], radius: Double) -> FilletResult? {
+        guard !edges.isEmpty, radius > 0 else { return nil }
+
+        var indices = [Int32]()
+        indices.reserveCapacity(edges.count)
+        for edge in edges {
+            guard edge.index >= 0 else { return nil }
+            indices.append(Int32(edge.index))
+        }
+
+        return indices.withUnsafeBufferPointer { buffer -> FilletResult? in
+            var declined = [Int32](repeating: 0, count: indices.count)
+            var declinedCount: Int32 = 0
+            let result: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
+                OCCTShapeFilletEdges(handle, buffer.baseAddress, Int32(indices.count), radius,
+                                     declinedBuffer.baseAddress, &declinedCount)
+            }
+            guard let result else { return nil }
+            let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
+            return FilletResult(shape: Shape(handle: result), declinedEdgeIndices: declinedIndices)
         }
     }
 
@@ -97,10 +169,42 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeFilletEdgesLinear(handle, buffer.baseAddress, Int32(indices.count), startRadius, endRadius) else {
+            guard let result = OCCTShapeFilletEdgesLinear(handle, buffer.baseAddress, Int32(indices.count), startRadius, endRadius, nil, nil) else {
                 return nil
             }
             return Shape(handle: result)
+        }
+    }
+
+    /// ``filleted(edges:startRadius:endRadius:)``, also reporting which requested edges OCCT
+    /// declined (#639). See ``filletedWithReport(edges:radius:)`` for the reporting contract.
+    ///
+    /// - Parameters:
+    ///   - edges: Edges to fillet (must have valid indices from this shape)
+    ///   - startRadius: Radius at start of each edge; must be > 0
+    ///   - endRadius: Radius at end of each edge; must be > 0
+    /// - Returns: A ``FilletResult``, or nil on failure, including an edge that is not this shape's
+    public func filletedWithReport(edges: [Edge], startRadius: Double, endRadius: Double) -> FilletResult? {
+        guard !edges.isEmpty, startRadius > 0, endRadius > 0 else { return nil }
+
+        var indices = [Int32]()
+        indices.reserveCapacity(edges.count)
+        for edge in edges {
+            guard edge.index >= 0 else { return nil }
+            indices.append(Int32(edge.index))
+        }
+
+        return indices.withUnsafeBufferPointer { buffer -> FilletResult? in
+            var declined = [Int32](repeating: 0, count: indices.count)
+            var declinedCount: Int32 = 0
+            let result: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
+                OCCTShapeFilletEdgesLinear(handle, buffer.baseAddress, Int32(indices.count),
+                                           startRadius, endRadius,
+                                           declinedBuffer.baseAddress, &declinedCount)
+            }
+            guard let result else { return nil }
+            let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
+            return FilletResult(shape: Shape(handle: result), declinedEdgeIndices: declinedIndices)
         }
     }
 
@@ -1013,6 +1117,10 @@ extension Shape {
     /// `IsDeleted` per input sub-shape (e.g. a filleted edge → multiple
     /// generated fillet faces).
     ///
+    /// An edge OCCT declines to fillet is skipped, exactly as ``filleted(edges:radius:)`` skips
+    /// it; see ``ShapeHistoryRecord``'s own doc for how to recover which requested edges those
+    /// were from the returned history (#639).
+    ///
     /// `radius` must be positive, matching ``filleted(edges:radius:)``.
     public func filletedWithFullHistory(radius: Double, edges: [Int])
         -> (result: Shape, history: ShapeHistoryRef)?
@@ -1413,8 +1521,51 @@ extension Shape {
         }
 
         guard let h = OCCTShapeFilletEvolving(handle, edgeIndices, Int32(edges.count),
-                                               radiusPoints, pointCounts) else { return nil }
+                                               radiusPoints, pointCounts, nil, nil) else { return nil }
         return Shape(handle: h)
+    }
+
+    /// ``filletEvolving(_:)``, also reporting which requested edges OCCT declined (#639): the
+    /// entry point the census named directly. Filleting an open shell's whole edge list SKIPs the
+    /// edges OCCT declines, with nothing that says which or how many. See
+    /// ``filletedWithReport(edges:radius:)`` for the reporting contract; the meaning is identical
+    /// here, keyed by ``EvolvingFilletEdge/edgeIndex``.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let faces = box.faces().dropFirst().compactMap { Shape.fromFace($0) }
+    /// let shell = Shape.sew(shapes: Array(faces))!
+    /// let laws = shell.edges().map { EvolvingFilletEdge(edge: $0, radiusPoints: [(0.0, 1.0), (1.0, 1.0)]) }
+    /// if let report = shell.filletEvolvingWithReport(laws) {
+    ///     print(report.declinedEdgeIndices.count, "of", laws.count, "edges declined")
+    /// }
+    /// ```
+    ///
+    /// - Parameter edges: Array of edge specifications with radius evolution. Naming the same edge
+    ///   twice writes its law twice, and the later one wins.
+    /// - Returns: A ``FilletResult``, or nil on failure.
+    public func filletEvolvingWithReport(_ edges: [EvolvingFilletEdge]) -> FilletResult? {
+        guard !edges.isEmpty else { return nil }
+
+        let edgeIndices = edges.map { Int32($0.edgeIndex) }
+        let pointCounts = edges.map { Int32($0.radiusPoints.count) }
+        var radiusPoints = [OCCTFilletRadiusPoint]()
+        for edge in edges {
+            for rp in edge.radiusPoints {
+                radiusPoints.append(OCCTFilletRadiusPoint(parameter: rp.parameter, radius: rp.radius))
+            }
+        }
+
+        var declined = [Int32](repeating: 0, count: edges.count)
+        var declinedCount: Int32 = 0
+        let h: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
+            OCCTShapeFilletEvolving(handle, edgeIndices, Int32(edges.count),
+                                    radiusPoints, pointCounts,
+                                    declinedBuffer.baseAddress, &declinedCount)
+        }
+        guard let h else { return nil }
+        let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
+        return FilletResult(shape: Shape(handle: h), declinedEdgeIndices: declinedIndices)
     }
     /// Offset a shape with different distances per face.
     ///

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -67,6 +67,10 @@ extension Shape {
         public let shape: Shape
         /// 0-based indices, matching ``Edge/index``, of the requested edges OCCT declined to
         /// fillet. Empty when every requested edge was accepted.
+        ///
+        /// This mirrors the request list rather than deduplicating it: naming the same declined
+        /// edge twice reports it twice, so the count matches how many entries of the caller's list
+        /// were refused. Use `Set(declinedEdgeIndices)` for distinct edges.
         public let declinedEdgeIndices: [Int]
     }
 
@@ -83,7 +87,8 @@ extension Shape {
     /// - Parameters:
     ///   - edges: Edges to fillet (must have valid indices from this shape)
     ///   - radius: Fillet radius; must be > 0
-    /// - Returns: Filleted shape, or nil on failure, including an edge that is not this shape's
+    /// - Returns: Filleted shape, or nil on failure, including when the list names an edge that is not
+    ///   this shape's.
     public func filleted(edges: [Edge], radius: Double) -> Shape? {
         guard !edges.isEmpty, radius > 0 else { return nil }
 
@@ -119,7 +124,8 @@ extension Shape {
     /// - Parameters:
     ///   - edges: Edges to fillet (must have valid indices from this shape)
     ///   - radius: Fillet radius; must be > 0
-    /// - Returns: A ``FilletResult``, or nil on failure, including an edge that is not this shape's
+    /// - Returns: A ``FilletResult``, or nil on failure, including when the list names an edge that is not
+    ///   this shape's.
     public func filletedWithReport(edges: [Edge], radius: Double) -> FilletResult? {
         guard !edges.isEmpty, radius > 0 else { return nil }
 
@@ -157,7 +163,8 @@ extension Shape {
     ///   - edges: Edges to fillet (must have valid indices from this shape)
     ///   - startRadius: Radius at start of each edge; must be > 0
     ///   - endRadius: Radius at end of each edge; must be > 0
-    /// - Returns: Filleted shape, or nil on failure, including an edge that is not this shape's
+    /// - Returns: Filleted shape, or nil on failure, including when the list names an edge that is not
+    ///   this shape's.
     public func filleted(edges: [Edge], startRadius: Double, endRadius: Double) -> Shape? {
         guard !edges.isEmpty, startRadius > 0, endRadius > 0 else { return nil }
 
@@ -183,7 +190,8 @@ extension Shape {
     ///   - edges: Edges to fillet (must have valid indices from this shape)
     ///   - startRadius: Radius at start of each edge; must be > 0
     ///   - endRadius: Radius at end of each edge; must be > 0
-    /// - Returns: A ``FilletResult``, or nil on failure, including an edge that is not this shape's
+    /// - Returns: A ``FilletResult``, or nil on failure, including when the list names an edge that is not
+    ///   this shape's.
     public func filletedWithReport(edges: [Edge], startRadius: Double, endRadius: Double) -> FilletResult? {
         guard !edges.isEmpty, startRadius > 0, endRadius > 0 else { return nil }
 

--- a/Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift
+++ b/Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift
@@ -182,4 +182,39 @@ struct Issue639FilletDeclinedEdgeReport {
             #expect(!record.generated.isEmpty)
         }
     }
+
+    /// The review noted no case drove a **duplicate** requested edge through a `WithReport` method,
+    /// which is also the semantics nit 1 documents: `declinedEdgeIndices` mirrors the request list
+    /// rather than deduplicating it, so a declined edge named twice is reported twice.
+    ///
+    /// Pinning it matters because the alternative, silently deduplicating, is the more "obvious"
+    /// implementation and would make the count stop matching how many entries of the caller's list
+    /// were refused.
+    @Test("A declined edge named twice is reported twice, matching the request list")
+    func declinedEdgeNamedTwiceIsReportedTwice() {
+        guard let shell = Self.openShell() else {
+            Issue.record("could not build the open-shell fixture")
+            return
+        }
+        let edges = shell.edges()
+        guard let declined = Self.declinedIndices.first, declined < edges.count else {
+            Issue.record("fixture has no declined edge to duplicate")
+            return
+        }
+        // An accepted edge has to be in the list too. Requesting only declined edges leaves
+        // nothing to fillet, so Build() fails and the call returns nil with no report to read,
+        // which is a different behaviour and not the one under test here.
+        guard let accepted = (0..<edges.count).first(where: { !Self.declinedIndices.contains($0) }) else {
+            Issue.record("fixture has no accepted edge")
+            return
+        }
+        let doubled = [edges[declined], edges[declined], edges[accepted]]
+        guard let report = shell.filletedWithReport(edges: doubled, radius: 0.5) else {
+            Issue.record("filletedWithReport returned nil for the duplicated declined edge")
+            return
+        }
+        #expect(report.declinedEdgeIndices.count == 2,
+                "expected the decline reported once per request entry, got \(report.declinedEdgeIndices)")
+        #expect(Set(report.declinedEdgeIndices) == [declined])
+    }
 }

--- a/Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift
+++ b/Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift
@@ -1,0 +1,185 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// `BRepFilletAPI_MakeFillet::Add` silently does nothing for an edge it cannot fillet (most
+/// commonly a free-boundary edge of an open shell, which has only one adjacent face where a
+/// fillet needs two), so `filleted(edges:radius:)` and its siblings build successfully and skip
+/// the edge with no way for a caller to learn which one, or how many. #639.
+///
+/// The Cluster B census (`Scripts/repro/cluster-b-fillet-edge-contract/`) measured the declined
+/// set on this exact fixture: 4 of 12 edges declined (`[6, 9, 10, 11]`), the rest (`[0, 1, 2, 3,
+/// 4, 5, 7, 8]`) accepted. Reused here rather than re-derived.
+///
+/// Three genuinely new entry points were added: `filletedWithReport(edges:radius:)`,
+/// `filletedWithReport(edges:startRadius:endRadius:)` and `filletEvolvingWithReport(_:)`. Two
+/// more members named in the issue (`filletedWithFullHistory(radius:edges:)` and the
+/// `FilletBuilder` class API) already carry the mechanism to answer this: `ShapeHistoryRecord`'s
+/// `generated`/`isDeleted` pair, and `FilletBuilder.contour(for:)` respectively, measured here
+/// too, so a regression in either recipe is caught even though neither got new bridge code.
+@Suite("Fillet family reports declined edges (#639)")
+struct Issue639FilletDeclinedEdgeReport {
+
+    static let declinedIndices = [6, 9, 10, 11]
+    static let acceptedIndices = [0, 1, 2, 3, 4, 5, 7, 8]
+
+    /// A 10mm box with one face dropped and the rest sewn back together: an open shell whose free
+    /// boundary edges `BRepFilletAPI_MakeFillet::Add` declines. Identical construction to
+    /// `Issue612FilletContourSelectionTests.openShell()` and the census's own fixture, reused
+    /// rather than rebuilt.
+    static func openShell() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        let faces = box.faces().compactMap { Shape.fromFace($0) }
+        guard faces.count == 6 else { return nil }
+        return Shape.sew(shapes: Array(faces.dropFirst()))
+    }
+
+    // MARK: - filletedWithReport(edges:radius:)
+
+    @Test("filletedWithReport(edges:radius:) names exactly the census's declined set")
+    func filletedWithReportNamesDeclinedEdges() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edges = shell.edges()
+        #expect(edges.count == 12)
+
+        guard let report = shell.filletedWithReport(edges: edges, radius: 1.0) else {
+            Issue.record("filletedWithReport unexpectedly returned nil")
+            return
+        }
+        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        // Reporting must not change the built geometry: same skip-not-reject answer as the
+        // non-reporting sibling.
+        guard let plain = shell.filleted(edges: edges, radius: 1.0) else {
+            Issue.record("filleted(edges:radius:) unexpectedly returned nil")
+            return
+        }
+        #expect(abs((report.shape.surfaceArea ?? -1) - (plain.surfaceArea ?? -2)) < 1e-9)
+    }
+
+    @Test("filletedWithReport(edges:radius:) reports no declines on a closed solid")
+    func filletedWithReportEmptyOnClosedSolid() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        guard let report = box.filletedWithReport(edges: box.edges(), radius: 1.0) else {
+            Issue.record("filletedWithReport unexpectedly returned nil on a closed box")
+            return
+        }
+        #expect(report.declinedEdgeIndices.isEmpty)
+    }
+
+    // MARK: - filletedWithReport(edges:startRadius:endRadius:)
+
+    @Test("filletedWithReport(edges:startRadius:endRadius:) names the same declined set")
+    func filletedLinearWithReportNamesDeclinedEdges() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edges = shell.edges()
+        guard let report = shell.filletedWithReport(edges: edges, startRadius: 1.0, endRadius: 1.0) else {
+            Issue.record("filletedWithReport(startRadius:endRadius:) unexpectedly returned nil")
+            return
+        }
+        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+    }
+
+    // MARK: - filletEvolvingWithReport(_:)
+
+    @Test("filletEvolvingWithReport(_:) names the same declined set -- the #639 gap named directly")
+    func filletEvolvingWithReportNamesDeclinedEdges() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edges = shell.edges()
+        let laws = edges.map { EvolvingFilletEdge(edge: $0, radiusPoints: [(0.0, 1.0), (1.0, 1.0)]) }
+        guard let report = shell.filletEvolvingWithReport(laws) else {
+            Issue.record("filletEvolvingWithReport unexpectedly returned nil")
+            return
+        }
+        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+    }
+
+    @Test("filletEvolvingWithReport(_:) reports no declines on a closed solid")
+    func filletEvolvingWithReportEmptyOnClosedSolid() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        let laws = box.edges().map { EvolvingFilletEdge(edge: $0, radiusPoints: [(0.0, 1.0), (1.0, 1.0)]) }
+        guard let report = box.filletEvolvingWithReport(laws) else {
+            Issue.record("filletEvolvingWithReport unexpectedly returned nil on a closed box")
+            return
+        }
+        #expect(report.declinedEdgeIndices.isEmpty)
+    }
+
+    // MARK: - FilletBuilder.contour(for:) already answers this (documented, not new code)
+
+    @Test("FilletBuilder.contour(for:) == 0 already names the declined set")
+    func filletBuilderContourNamesDeclinedEdges() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        guard let builder = FilletBuilder(shape: shell) else {
+            Issue.record("FilletBuilder(shape:) unexpectedly returned nil")
+            return
+        }
+        let edges = shell.edges()
+        for edge in edges { builder.addEdge(edge, radius: 1.0) }
+
+        // Contour(E) is populated by Add(), not Build(): readable before build() is called.
+        let declinedBeforeBuild = edges.filter { builder.contour(for: $0) == 0 }.map(\.index)
+        #expect(Set(declinedBeforeBuild) == Set(Self.declinedIndices))
+
+        #expect(builder.build() != nil)
+        let declinedAfterBuild = edges.filter { builder.contour(for: $0) == 0 }.map(\.index)
+        #expect(Set(declinedAfterBuild) == Set(Self.declinedIndices))
+    }
+
+    // MARK: - ShapeHistoryRecord already answers this (documented, not new code)
+
+    @Test("filletedWithFullHistory's ShapeHistoryRecord names the declined set via generated/isDeleted")
+    func historyRecordNamesDeclinedEdges() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edgeShapes = shell.subShapes(ofType: .edge)
+        #expect(edgeShapes.count == 12)
+
+        guard let (_, history) = shell.filletedWithFullHistory(radius: 1.0, edges: Array(0..<edgeShapes.count)) else {
+            Issue.record("filletedWithFullHistory unexpectedly returned nil")
+            return
+        }
+
+        let declined = edgeShapes.indices.filter {
+            let record = history.record(of: edgeShapes[$0])
+            return !record.isDeleted && record.generated.isEmpty
+        }
+        #expect(Set(declined) == Set(Self.declinedIndices))
+
+        // The reliable signal is generated/isDeleted, not modified.isEmpty: a declined edge can
+        // still carry one `modified` entry when an accepted neighbour's fillet trims its shared
+        // endpoint. At least one declined edge in this fixture demonstrates that -- if none did,
+        // the note above would be untested, not merely unnecessary.
+        let declinedWithNonEmptyModified = Self.declinedIndices.filter {
+            !history.record(of: edgeShapes[$0]).modified.isEmpty
+        }
+        #expect(!declinedWithNonEmptyModified.isEmpty,
+                "expected at least one declined edge to show a non-empty `modified` from neighbour trimming")
+
+        // And every accepted edge is deleted with something generated -- the opposite pattern.
+        for index in Self.acceptedIndices {
+            let record = history.record(of: edgeShapes[index])
+            #expect(record.isDeleted)
+            #expect(!record.generated.isEmpty)
+        }
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -36,7 +36,7 @@ a map of the major areas, and the `Total` as the count.
 | **Primitives** | 13 | box, cylinder, cylinder(at:), sphere, cone, torus, surface, wedge, halfSpace, vertex, shell(from surface), shell(from Surface), nonUniformScale |
 | **Sweeps** | 24 | pipe sweep, pipeShell, pipeShellMultiSection, pipeShellWithTransition (deprecated, #503), pipeShellWithLaw, extrude, revolve, loft, loft(ruled+vertex), ruled, revolutionFromCurve, ruledShell, advancedEvolved, pipeSweep, compatibleWires, thruSectionsCreate, thruSectionsAddWire, thruSectionsAddVertex, thruSectionsSetSmoothing, thruSectionsSetMaxDegree, thruSectionsSetContinuity, thruSectionsBuild, thruSectionsShape, thruSectionsRelease |
 | **Booleans** | 12 | union (+), subtract (-), intersect (&), section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory |
-| **Modifications** | 33 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
+| **Modifications** | 36 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, filletedWithReport, filletedWithReport(startRadius:endRadius:), filletEvolvingWithReport, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
 | **Transforms** | 10 | translate, rotate, scale, mirror, mirrorAboutPoint, mirrorAboutAxis, scaleAboutPoint, translated(from:to:), transformed(matrix:), gTransformed(matrix:) |
 | **Wires** | 31 | rectangle, circle, polygon, polygon3D, line, arc, bspline, nurbs, path, join, offset, offset3D, interpolate, fillet2D, filletAll2D, chamfer2D, chamferAll2D, helix, helixTapered, orderedEdgeCount, orderedEdgePoints, orderedEdgePointCount, analyze, wireFromEdges, edges, allEdgePolylines, allEdgePolylinesIndexed, edgePolyline, bounds |
 | **Curve Analysis** | 6 | length, curveInfo, point(at:), tangent(at:), curvature(at:), curvePoint(at:) |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,301** | |
+| **Total** | **4,304** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -985,6 +985,18 @@ addressable. (#614)
 | Swift API | OCCT Class |
 |-----------|------------|
 | `shape.filletEvolving(_:)` | `BRepFilletAPI_MakeFillet.SetRadius(UandR)` |
+
+#### Fillet Decline Reporting (#639)
+| Swift API | OCCT Class |
+|-----------|------------|
+| `shape.filletedWithReport(edges:radius:)` | `BRepFilletAPI_MakeFillet` + `Contour(edge)` per requested edge |
+| `shape.filletedWithReport(edges:startRadius:endRadius:)` | `BRepFilletAPI_MakeFillet.Add(R1, R2, E)` + `Contour(edge)` |
+| `shape.filletEvolvingWithReport(_:)` | `BRepFilletAPI_MakeFillet.SetRadius(UandR)` + `Contour(edge)` |
+
+Each shares its non-reporting sibling's build, and additionally reports which requested edges
+`Contour(edge) == 0` after `Add()`: the ones OCCT declined to fillet (a free-boundary edge of an
+open shell, most commonly), which the non-reporting siblings silently skip. See
+`Shape.FilletResult`.
 
 #### Per-Face Variable Offset (v0.38.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -171,6 +171,81 @@ otherwise, naming the tree so a diagnostic probe left by an investigation is not
 
 ### Pass 1b of the #377 duplication audit
 
+#### The fillet family could not report a declined edge, only skip it silently (#639)
+
+`BRepFilletAPI_MakeFillet::Add` does nothing, with no exception and no false return, for an edge it
+cannot fillet, most commonly a free-boundary edge of an open shell, which has only one adjacent
+face where a fillet needs two. `filleted(edges:radius:)`, `filleted(edges:startRadius:endRadius:)`
+and `filletEvolving(_:)` have always skipped such an edge rather than rejecting the whole call
+(#612), correctly, but had no way to tell a caller which edges those were, or how many. The Cluster
+B census (`Scripts/repro/cluster-b-fillet-edge-contract/`) measured the gap concretely: filleting
+all 12 edges of an open shell (a box with one face dropped, sewn) accepts 8 and silently declines 4
+(`[6, 9, 10, 11]`), and every one of these three entry points reports plain success.
+
+**The decision this issue asked for, made explicitly:** report, do not reject. Converging every
+declining entry point onto rejecting a batch with any declined edge would change
+`filleted(edges:radius:)`, `filleted(edges:startRadius:endRadius:)` and `blendedEdges(_:)` on every
+open shell: a behaviour change wider than this issue, and the same mistake an earlier draft of
+#633 made and withdrew. Skip stays the answer; the fix is observability, following #482's
+`FillingSurface.refusedConstraintCount` precedent named in the issue.
+
+**What OCCT can actually say, measured before designing around it:** `Add` returns nothing, and
+`BRepFilletAPI_MakeFillet::NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a *contour*
+that failed during `Build()`, which an edge OCCT never added to any contour never reaches. The one
+signal OCCT does expose is `Contour(edge) == 0`, populated by `Add()` itself rather than by
+`Build()`. So this reports **which** edges were declined (a list of indices, not just a count: the
+issue's own "count is cheap, naming which is more useful" argument, taken as far as it goes), and
+**not why**: no reason is reachable from this API.
+
+**Fixed for the three entry points that genuinely had no side channel**: `filleted(edges:radius:)`
+and `filleted(edges:startRadius:endRadius:)` (`OCCTShapeFilletEdges`/`OCCTShapeFilletEdgesLinear`,
+sharing `occtShapeFilletEdgeList`) and `filletEvolving(_:)` (`OCCTShapeFilletEvolving`) each gained
+a `WithReport` sibling, `filletedWithReport(edges:radius:)`,
+`filletedWithReport(edges:startRadius:endRadius:)`, `filletEvolvingWithReport(_:)`, returning a
+new `Shape.FilletResult { shape, declinedEdgeIndices }`. The bridge computes the report with a new
+shared helper (`occtFilletDeclinedIndices`/`occtFilletWriteDeclined`, `OCCTBridge_Internal.h`) that
+re-checks `Contour(edge)` for each requested index after every `Add()` and before `Build()`; the
+three underlying bridge functions gained two nullable trailing out-parameters the existing
+non-reporting call sites pass `nil` for, so nothing about their cost or behaviour changes.
+
+**Two of the issue's own named members already carried the mechanism, measured rather than assumed
+missing:** `filletedWithFullHistory(radius:edges:)`'s `ShapeHistoryRef` distinguishes a declined
+edge from an accepted one via `!record.isDeleted && record.generated.isEmpty`. An edge OCCT
+actually filleted is always deleted with the new fillet-boundary edges in `generated` (12/12 on the
+fixture). **The first hypothesis for this recipe was wrong and caught by measuring it**: a declined
+edge is not necessarily `modified.isEmpty` too. On this fixture every declined edge shows exactly
+one `modified` entry, a *different* edge instance with a shorter length (10.0 to 8.0), because an
+*accepted* neighbour's fillet trims the declined edge's shared endpoint. `modified` alone is not the
+signal; `generated`/`isDeleted` are. Separately, `FilletBuilder.contour(for:)`, already present and
+unrelated to this issue, answers the identical `Contour(edge) == 0` question directly, readable
+right after `addEdge` with no `build()` required, matching the census's measured set exactly before
+and after `build()`. Both are documented (`ShapeHistoryRecord`, `FilletBuilder`) with a runnable
+recipe rather than given new bridge code, since there was nothing to add.
+
+**`blendedEdges(_:)`, #633's own site, does not adopt this mechanism here.** It is the same SKIP
+behaviour on the same declined-edge axis, so the same `WithReport` shape would apply, but #633 is
+about a *different* axis of this contract (a duplicated edge index silently discards a radius) and
+is scheduled after this PR specifically because the reporting decision made here might change what
+#633 should do. Recommendation for that issue: adopt the same `FilletResult`-shaped report,
+extended to also carry which duplicate indices were overwritten, since the same
+"list what happened, do not change what SKIP or OVERWRITE means" principle applies to it too.
+
+New tests: `Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift`, seven cases
+covering all five members named in the issue (the three `WithReport` siblings, the `FilletBuilder`
+recipe, the history recipe) plus two "empty on a closed solid" negative controls. Each of the five
+declined-set assertions was proven to catch its own mechanism, not just some regression elsewhere:
+reverting `occtFilletWriteDeclined` to report nothing fails exactly the three `WithReport` tests (the
+two negative controls correctly stay green, since they expect empty anyway); separately reverting
+`OCCTFilletBuilderContour` fails exactly the `FilletBuilder` test; separately reverting
+`OCCTBooleanHistoryIsDeleted` fails exactly the history test.
+
+This is additive, non-breaking Swift API (three new methods, one new struct, no existing signature
+changed), recorded in [`SEMVER.md`](SEMVER.md#639-additive-fillet-decline-reporting-not-an-exception)
+per #664's discipline of writing this down now rather than at tag time, even though nothing here
+moves the file's own "twelve recorded exceptions" count. `Scripts/repro/cluster-b-fillet-edge-contract/`
+is unchanged: the census measures the contract, this issue only adds a way to observe one axis of
+it, and the measured grid itself (SKIP/REJECT per cell) does not move.
+
 #### `AAG` rode the lossy `faces()`, so `detectPocketsAAG()` answered 2 or 1 for the same geometry depending on compound member order (#642)
 
 `AAG.buildGraph()` built its node set from `Shape.faces()`, the `IsSame`-keyed enumeration #614

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -363,6 +363,32 @@ The exception was taken because:
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 
+#### #639: additive fillet decline reporting, not an exception
+
+**Recorded here per #664's own rule of writing a public-API change down in this file before the
+tag, not because this one is a recorded exception.** `filleted(edges:radius:)`,
+`filleted(edges:startRadius:endRadius:)` and `filletEvolving(_:)` each gained a `WithReport`
+sibling (`filletedWithReport(edges:radius:)`, `filletedWithReport(edges:startRadius:endRadius:)`,
+`filletEvolvingWithReport(_:)`) returning a new `Shape.FilletResult`: the edges OCCT declined to
+fillet, alongside the shape, for a caller who wants to know (#639).
+
+This does **not** move the "twelve recorded exceptions" count above, checked and confirmed
+unchanged by this entry: no existing method's signature or behaviour changed. `filleted(edges:
+radius:)` and its two siblings still return exactly what they always did, for exactly the same
+inputs; a caller who never calls the three new methods sees no difference at all. This is the
+**MINOR**, additive Swift API, case the quick reference table already names, not the MAJOR-avoided,
+compile-error-or-silent-behaviour-change case every entry above it is. It is recorded here anyway,
+rather than left to the release's own `CHANGELOG.md` entry, because #664 asks for every public-API
+change in this cluster of work to be written down at the same time it lands, and distinguishing
+"additive, no exception" from "exception" is itself information a reviewer of this file benefits
+from having next to the twelve that are.
+
+Two of the issue's own named members (`filletedWithFullHistory(radius:edges:)`,
+`FilletBuilder.contour(for:)`) needed no new API at all: both already carry a way to answer the
+same question, documented in this PR with a runnable recipe rather than given new bridge code. See
+[`CHANGELOG.md`](CHANGELOG.md#the-fillet-family-could-not-report-a-declined-edge-only-skip-it-silently-639)
+for the full measurement and the reasoning against converging fillet's SKIP behaviour onto reject.
+
 ### MINOR — `x.y.0`
 
 A minor bump is for additive change. Two routes:

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1113,6 +1113,53 @@ public func filleted(edges: [Edge], radius: Double) -> Shape?
 
 ---
 
+### `Shape.FilletResult`
+
+Result of a fillet call that also reports which requested edges OCCT declined (#639).
+
+```swift
+public struct FilletResult: Sendable {
+    public let shape: Shape
+    public let declinedEdgeIndices: [Int]
+}
+```
+
+- **Fields:** `shape`: the filleted shape, identical to what the non-reporting sibling returns for
+  the same input. `declinedEdgeIndices`: 0-based indices, matching `Edge.index`, of the requested
+  edges OCCT declined to fillet. Empty when every requested edge was accepted.
+- **Notes:** there is no *reason* alongside the list. `BRepFilletAPI_MakeFillet::Add` returns
+  nothing, and `NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a contour that failed
+  during `Build()`, which an edge OCCT never added to any contour never reaches. `Contour(edge) ==
+  0`, populated by `Add()` and not `Build()`, is the only signal OCCT itself exposes, so this reports
+  *which* edges were declined, not *why*.
+
+---
+
+### `filletedWithReport(edges:radius:)`
+
+`filleted(edges:radius:)`, also reporting which requested edges OCCT declined (#639).
+
+```swift
+public func filletedWithReport(edges: [Edge], radius: Double) -> FilletResult?
+```
+
+- **Parameters:** same as `filleted(edges:radius:)`.
+- **Returns:** a `FilletResult`, or `nil` on failure under the same conditions as
+  `filleted(edges:radius:)`.
+- **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeFilletEdges`), reading `Contour(edge)` for
+  each requested edge after `Add()` and before `Build()`.
+- **Notes:** an edge OCCT cannot fillet is still skipped, not rejected: this changes only what a
+  caller can learn about it, not the shape returned. See `Shape.FilletResult` above.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  if let report = box.filletedWithReport(edges: box.edges(), radius: 1.0) {
+      precondition(report.declinedEdgeIndices.isEmpty)   // every edge of a closed solid fillets
+  }
+  ```
+
+---
+
 ### `filleted(edges:startRadius:endRadius:)`
 
 Fillets specific edges with a linear radius interpolation.
@@ -1138,6 +1185,23 @@ arc 10297.711861 (#612).
   (#520). An edge OCCT declines to fillet outright — a free-boundary edge of an open shell — is
   skipped by all five edge-list fillet entry points alike; a batch in which every edge is declined
   returns `nil` (#612).
+
+---
+
+### `filletedWithReport(edges:startRadius:endRadius:)`
+
+`filleted(edges:startRadius:endRadius:)`, also reporting which requested edges OCCT declined
+(#639). See [`Shape.FilletResult`](#shapefilletresult) and
+[`filletedWithReport(edges:radius:)`](#filletedwithreportedgesradius) for the reporting contract.
+
+```swift
+public func filletedWithReport(edges: [Edge], startRadius: Double, endRadius: Double) -> FilletResult?
+```
+
+- **Parameters:** same as `filleted(edges:startRadius:endRadius:)`.
+- **Returns:** a `FilletResult`, or `nil` on failure under the same conditions as
+  `filleted(edges:startRadius:endRadius:)`.
+- **OCCT:** `BRepFilletAPI_MakeFillet::Add(R1, R2, E)` (via `OCCTShapeFilletEdgesLinear`).
 
 ---
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -2096,6 +2096,12 @@ public func filletedWithFullHistory(radius: Double, edges: [Int])
 - **Returns:** Result shape and history, or nil on failure, an empty edge list, or a non-positive
   radius (#489).
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeHistoryFromFilletEdges`).
+- **Finding a declined edge (#639):** an edge OCCT declines to fillet is skipped, not rejected. To
+  find which requested edges those were, check `!history.record(of: edge).isDeleted &&
+  history.record(of: edge).generated.isEmpty` for each one. An edge that WAS filleted is always
+  deleted with the new fillet-boundary edges in `generated`. Do not test `modified.isEmpty` alone:
+  a declined edge can still show a non-empty `modified` when an *accepted* neighbour's fillet trims
+  its shared endpoint.
 - **Example:**
   ```swift
   if let (result, history) = box.filletedWithFullHistory(radius: 2, edges: [0, 1, 2]) { }

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -316,6 +316,35 @@ public func filletEvolving(_ edges: [EvolvingFilletEdge]) -> Shape?
 
 ---
 
+### `filletEvolvingWithReport(_:)`
+
+`filletEvolving(_:)`, also reporting which requested edges OCCT declined (#639): the entry point
+the Cluster B census named directly. Filleting an open shell's whole edge list skips the edges OCCT
+declines, with nothing that says which or how many.
+
+```swift
+public func filletEvolvingWithReport(_ edges: [EvolvingFilletEdge]) -> FilletResult?
+```
+
+- **Parameters:** same as `filletEvolving(_:)`.
+- **Returns:** a [`Shape.FilletResult`](Shape-Features#shapefilletresult), or `nil` on failure under
+  the same conditions as `filletEvolving(_:)`. `declinedEdgeIndices` is keyed by
+  `EvolvingFilletEdge.edgeIndex`.
+- **OCCT:** `BRepFilletAPI_MakeFillet` with evolving law (via `OCCTShapeFilletEvolving`), reading
+  `Contour(edge)` for each requested edge after `Add()` and before `Build()`.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let faces = box.faces().dropFirst().compactMap { Shape.fromFace($0) }
+  let shell = Shape.sew(shapes: Array(faces))!
+  let laws = shell.edges().map { EvolvingFilletEdge(edge: $0, radiusPoints: [(0.0, 1.0), (1.0, 1.0)]) }
+  if let report = shell.filletEvolvingWithReport(laws) {
+      print(report.declinedEdgeIndices.count, "of", laws.count, "edges declined")
+  }
+  ```
+
+---
+
 ## Per-Face Variable Offset (v0.38.0)
 
 ### `offsetPerFace(defaultOffset:faceOffsets:tolerance:joinType:)`


### PR DESCRIPTION
## What & why

`BRepFilletAPI_MakeFillet::Add` silently does nothing for an edge it cannot fillet, most commonly a free-boundary edge of an open shell. `filleted(edges:radius:)`, `filleted(edges:startRadius:endRadius:)` and `filletEvolving(_:)` have always skipped such an edge rather than rejecting the whole call, correctly, but had no way to tell a caller which edges those were, or how many.

The Cluster B census (`Scripts/repro/cluster-b-fillet-edge-contract/`) measured this concretely: filleting all 12 edges of an open shell (a box with one face dropped, sewn) accepts 8 and silently declines 4 (`[6, 9, 10, 11]`).

Closes #639

## The decision

Report, do not reject. Converging every declining entry point onto rejecting a batch with any declined edge would change `filleted(edges:radius:)`, `filleted(edges:startRadius:endRadius:)` and `blendedEdges(_:)` on every open shell: a behaviour change wider than this issue, and the same mistake an earlier draft of #633 made and withdrew. Skip stays the answer; the fix is observability, following #482's `FillingSurface.refusedConstraintCount` precedent.

`Contour(edge) == 0`, populated by `Add()` and not `Build()`, is the only signal OCCT itself exposes for a declined edge. `Add` returns nothing, and `NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a contour that failed during `Build()`, which an edge OCCT never added to any contour never reaches. So this reports **which** edges were declined (a list of indices, not just a count), and **not why**: no reason is reachable from this API.

## What changed

Three genuinely new entry points, for the three members that had no side channel at all:

- `filletedWithReport(edges:radius:)`
- `filletedWithReport(edges:startRadius:endRadius:)`
- `filletEvolvingWithReport(_:)`

Each returns a new `Shape.FilletResult { shape, declinedEdgeIndices }`. The bridge computes the report with a new shared helper (`occtFilletDeclinedIndices`/`occtFilletWriteDeclined`) that re-checks `Contour(edge)` for each requested index after `Add()` and before `Build()`. The three underlying bridge functions gained two nullable trailing out-parameters; existing non-reporting call sites pass `nil` and see no change in cost or behaviour.

**Two of the issue's own named members needed no new code, only documentation, measured rather than assumed:**

- `filletedWithFullHistory(radius:edges:)`'s `ShapeHistoryRef` already distinguishes a declined edge via `!record.isDeleted && record.generated.isEmpty`. My first hypothesis for this recipe was wrong, and measuring it caught that: a declined edge is not necessarily `modified.isEmpty` too. On the shell fixture every declined edge shows one `modified` entry, a different edge instance with a shorter length (10.0 to 8.0), because an accepted neighbour's fillet trims the declined edge's shared endpoint. `modified` alone is not the signal; `generated`/`isDeleted` are.
- `FilletBuilder.contour(for:)` already answers the identical `Contour(edge) == 0` question directly, readable right after `addEdge` with no `build()` required. This also corrects a Cluster B census finding: its claim that the class API has "no per-edge signal beyond `addEdge`'s own Bool return" was wrong, it simply never tried this query. Measured directly: a foreign edge from a different shape gives `addEdge` returns `true`, `contour(for:)` returns `0`, the identical signal a genuine same-shape decline gives.

`blendedEdges(_:)` (#633's own site) does not adopt this mechanism here, and is out of scope for this PR per the task boundaries. Recommendation for #633: adopt the same `FilletResult`-shaped report, extended to also carry which duplicate indices were overwritten.

## Docs

- `docs/SEMVER.md`: recorded as additive (not one of the twelve "recorded exceptions", since nothing existing changed signature or behaviour; checked and confirmed the counter arithmetic is unaffected).
- `docs/CHANGELOG.md`, `docs/API_REFERENCE.md` (+3 to the operation count, 4301 to 4304), `README.md` headline count.
- `docs/reference/Shape-Features.md`, `Shape-Measurement.md`, `Shape-Healing.md`: new entries plus the declined-edge recipe for `filletedWithFullHistory`.
- `Scripts/repro/cluster-b-fillet-edge-contract/README.md` and `ClusterB.swift`: the measured grid values did not move (still SKIP/REJECT the same way), only the annotations on the now-fixed rows, plus the `FilletBuilder` class-API row's correction. `swift run Censuses cluster-b` still emits 16 rows, `cluster-a` still 45.

## Test plan

- [x] New test: `Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift`, 7 cases covering all 5 members named in the issue plus 2 negative controls, following `okf/policies/prove-the-test-fails.md`. Injection matrix:

| Injection | Result |
|---|---|
| `occtFilletWriteDeclined` reports empty | The 3 `WithReport` "names declined set" tests fail; the 2 "empty on closed solid" negative controls correctly stay green |
| `OCCTFilletBuilderContour` always returns 1 | The `FilletBuilder` recipe test fails (both its assertions) |
| `OCCTBooleanHistoryIsDeleted` always returns true | The history recipe test fails |

Each injection restored and confirmed green again afterward.

- [x] Clean `swift build`, 0 errors, no new warnings, no `OCCTSWIFT_LOCAL`.
- [x] Full `swift test`, no env overrides: **5353 tests passing** (baseline 5346 + 7 new), 2 consecutive clean runs, no crash flake.
- [x] `swift run Censuses cluster-a` still 45 rows, `cluster-b` still 16 rows.
- [x] `check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py` each pass with and without `--self-test`; `count-operations.py` (no `--self-test`) passes, README/API_REFERENCE totals now match derived (4304).
- [x] Zero em-dashes in code, docs, and this PR body.

## Notes for the reviewer

- The real gap, once measured, was narrower than the issue's own list of five: only 3 of 5 named members needed new bridge code. The other 2 already carried the answer; nobody had connected it to #639 before.
- `FilletBuilder`'s `contour(for:)` gives you `0` for both "never added" and "added but declined". Documented explicitly; a caller who wants to tell these apart has to track its own added-edges list, which it already does since it called `addEdge` itself.
