### PR TITLE
chore(#666): teach the null-handle checker the #656 shape, Cluster C census

### DIFF
--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -104,15 +104,28 @@ constructor, now confirmed for a curve arriving by this second route too. Added 
 Full method, the guard-removal matrix and the triage are in
 `Scripts/repro/cluster-c-null-handle-shapes/README.md`.
 
+NOW ALSO TAUGHT (follow-up, same PR): the constructor-init connector, `Handle(Geom_Curve) c2d(
+BRep_Tool::CurveOnSurface(...));` - #656's exact shape, written with parens instead of `=`. The
+false-positive direction two paragraphs below (`Handle(Geom_Curve) w(wrapper->curve);` defeating
+the WRAPPER-ARGUMENT alias binding) is a different code path (`aliases()`, not `LOCAL_HANDLE_DECL`)
+and is UNCHANGED by this - a local sourced from a wrapper's own field and a local sourced from
+`BRep_Tool::` are tracked by two different mechanisms, and only the second gained paren support
+here. Also added: a dedicated fixture for the `occ::handle<>` spelling as a LOCAL declaration
+(previously only exercised as a helper's parameter type, fixture R) - the regex already covered it,
+but nothing had proven that for a local until now. Zero real occurrences of either form motivated
+both; see the census README for the measurement and the extended guard-removal matrix.
+
 STILL NOT TAUGHT, DELIBERATELY, AND STILL BLIND: every item in the list above (non-dominating
 guard, negated guard, partial-path helper, `(*cast).field`, reference-to-wrapper alias) applies
 just as much to a `BRep_Tool::`-sourced local, and none has a known instance in this tree today.
 Also still blind: a `BRep_Tool::` handle carried through one more level of copy (`Handle(Geom_Curve)
-tmp = c3d;`) rather than used directly, and any locally-obtained handle whose producer is not
-spelled `BRep_Tool::` - a different OCCT accessor with the same null-for-valid-topology contract
-would not be caught by this walk. Enumerating that wider set was explicitly out of scope for this
-pass; the census README's method section says why `BRep_Tool::` specifically, not "every OCCT
-call", was the line drawn.
+tmp = c3d;`) rather than used directly, any locally-obtained handle whose producer is not spelled
+`BRep_Tool::` - a different OCCT accessor with the same null-for-valid-topology contract would not
+be caught by this walk - and the `extern "C" { ... }` block form (as opposed to the per-function
+prefix this PR does handle), which would need to widen `FUNC`'s notion of "outside a function" to
+cover a whole enclosing block rather than one definition line. Enumerating the wider producer set
+was explicitly out of scope for this pass; the census README's method section says why
+`BRep_Tool::` specifically, not "every OCCT call", was the line drawn.
 
 A FIFTH ALIAS FORM, FOUND BUT NOT TAUGHT: `OCCTBridge_Surface.mm` has nine sites shaped
 `const Handle(Geom_Curve)& x = *(const Handle(Geom_Curve)*)wrapperParam;` (and its `occ::handle<>`
@@ -260,10 +273,14 @@ HANDLE_PARAM = re.compile(r'(?:occ::handle\s*<|\bHandle\s*\()')
 # accessor rather than a wrapper argument - the #656 shape. `BRep_Tool::` is a deliberate
 # allowlist, not "any call": see the module docstring for why (672 candidates unrestricted, 63
 # once narrowed to the accessor family OCCT documents as legitimately null-returning).
+# The connector between the name and the producer is `=` (the assignment form) or `(` (the
+# constructor-init form, `Handle(Type) name(BRep_Tool::Whatever(...));`) - #656's exact shape,
+# written with parens instead of `=`. Both spellings, both connectors: four surface forms, one
+# regex, since only the text between `name` and `BRep_Tool::` differs.
 LOCAL_HANDLE_DECL = re.compile(
     r'\b(?:Handle\s*\(\s*(Geom_Curve|Geom2d_Curve|Geom_Surface)\s*\)|'
     r'occ::handle\s*<\s*(Geom_Curve|Geom2d_Curve|Geom_Surface)\s*>)'
-    r'\s+(\w+)\s*=\s*(BRep_Tool::\w+)\s*\(')
+    r'\s+(\w+)\s*(?:=|\()\s*(BRep_Tool::\w+)\s*\(')
 
 
 def strip_comments(text):
@@ -633,6 +650,29 @@ bool OCCTFixtureO(OCCTSurfaceRef surf, OCCTShapeRef faceRef) {
             return surf->IsUPeriodic();
         }
     } catch (...) { return false; }
+}'''),
+    # #666 follow-up: the constructor-init connector. LOCAL_HANDLE_DECL required `name =
+    # BRep_Tool::...(`; this is #656's exact shape written with parens instead - `name(BRep_Tool::
+    # ...(`. The module docstring already warned this spelling defeats the wrapper-argument walk's
+    # alias binding; it applied equally here and was unaddressed until now.
+    ('local handle from BRep_Tool::, constructor-init paren syntax (the #656 shape, no `=`)', '''
+double OCCTFixtureT(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
+    try {
+        double first, last;
+        Handle(Geom2d_Curve) c2d(BRep_Tool::CurveOnSurface(edgeRef->shape, faceRef->shape, first, last));
+        return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
+    } catch (...) { return 0.0; }
+}'''),
+    # #666 follow-up: the `occ::handle<>` spelling had never been exercised for a LOCAL
+    # declaration (only for a helper's parameter type, fixture R) - the regex already covered it,
+    # but nothing proved that until this fixture.
+    ('local handle from BRep_Tool::, occ::handle<> spelling, unguarded', '''
+double OCCTFixtureU(OCCTShapeRef edgeRef) {
+    try {
+        double first, last;
+        occ::handle<Geom_Curve> curve = BRep_Tool::Curve(edgeRef->shape, first, last);
+        return curve->FirstParameter();
+    } catch (...) { return 0.0; }
 }'''),
 ]
 

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -89,13 +89,20 @@ this needed that the wrapper-argument walk did not:
     walk conflates them: an early version of this detector mistook `OCCTFaceGetPrimaryAxis`'s SECOND
     `case`'s properly-guarded `surf` for a continuation of the FIRST `case`'s `surf` (consumed only
     by `DownCast`, itself null-safe) and reported the first as unguarded - a false positive that
-    would not have survived review. Fixed by treating a later `Handle(...) name = ...`
-    redeclaration of the identical name, anywhere later in the same function body, as the end of the
-    earlier declaration's own tracking window. The guard-removal fixtures below prove both
-    directions: G1 is this false positive, minimised; G2 is the mirror-image risk the window's
-    LOWER bound guards against - an unrelated, earlier, same-named guard (e.g. on a same-named
-    parameter, later shadowed by a local) wrongly "protecting" a genuinely unguarded local declared
-    after it.
+    would not have survived review.
+
+    Originally fixed by treating a later `Handle(...) name = BRep_Tool::...` redeclaration of the
+    identical name, anywhere later in the function body, as the end of the earlier declaration's own
+    tracking window - textual, not scope-aware. An automated review round on this same PR found two
+    real holes in that: a sibling redeclaration from ANY OTHER SOURCE (not `BRep_Tool::`) never
+    fenced anything, since it never matched the pattern the fence looked for; and a redeclaration
+    inside a NESTED block ended the OUTER variable's window right there, so a real use of the outer
+    variable resuming after the nested block closes went untracked - a genuine, reproduced miss
+    (self-test fixture `W`), not a theoretical one. `var_declarations()`/`binds_to()` replace the
+    textual fence with real C++ block scoping - every occurrence of a name binds to the innermost
+    still-in-scope declaration of it, exactly the rule the compiler itself uses - which subsumes the
+    original G1/G2 fixtures (see `local_handle_sites()`'s own docstring) and additionally closes the
+    nested-block miss neither of them exercised.
 
 Measured against the tree as it stands: 63 `BRep_Tool::`-sourced locals of these three types, 62
 already guarded, 1 reaching `GeomAdaptor_Curve`'s constructor unguarded
@@ -124,11 +131,21 @@ just as much to a `BRep_Tool::`-sourced local, and none has a known instance in 
 Also still blind: a `BRep_Tool::` handle carried through one more level of copy (`Handle(Geom_Curve)
 tmp = c3d;`) rather than used directly, any locally-obtained handle whose producer is not spelled
 `BRep_Tool::` - a different OCCT accessor with the same null-for-valid-topology contract would not
-be caught by this walk - and the `extern "C" { ... }` block form (as opposed to the per-function
-prefix this PR does handle), which would need to widen `FUNC`'s notion of "outside a function" to
-cover a whole enclosing block rather than one definition line. Enumerating the wider producer set
-was explicitly out of scope for this pass; the census README's method section says why
-`BRep_Tool::` specifically, not "every OCCT call", was the line drawn.
+be caught by this walk - and a SPLIT declare-then-assign (`Handle(Geom_Curve) c; ... c =
+BRep_Tool::Curve(...);`), since `LOCAL_HANDLE_DECL` only matches an INITIALISING declaration: measured
+at zero occurrences tree-wide before shipping this claim, per this repo's own "an untested claim of
+coverage is not coverage" standard, rather than left as an assertion the way earlier passes over
+this file were caught doing. Enumerating the wider producer set was explicitly out of scope for
+this pass; the census README's method section says why `BRep_Tool::` specifically, not "every OCCT
+call", was the line drawn.
+
+CORRECTED, NOT BLIND: the `extern "C" { ... }` BLOCK form (as opposed to the inline `extern "C" int
+foo() {` prefix `FUNC` already handles) used to be listed here as blind too - wrongly. An automated
+review round confirmed live, before changing this text, that `FUNC` already parses a function
+defined inside such a block correctly: the block's own `extern "C" {`/`}` are just text to
+`functions()`, which finds a function by its OWN signature line, and a function nested inside the
+block has no `extern "C"` text on ITS line to hide it from that match in the first place - it was
+never a distinct case FUNC needed to learn. Fixture `V` locks this in.
 
 FOUR MORE, SAME CLASS - `LOCAL_HANDLE_DECL` requires an explicit `Handle(Type)`/`occ::handle<Type>`
 spelling directly followed by a bare name and one of the two known connectors, so anything else
@@ -192,6 +209,37 @@ Two exclusions, both load-bearing:
     going forward, so a reader can tell what a given entry does and does not cover without
     re-deriving it from the function's signature.
 
+    An automated review round asked, again, whether the other 23 pre-existing entries - each
+    reviewed only against `unguarded_sites()`, never against `local_handle_sites()` - might be
+    silently exempting a real local-handle finding nobody has looked for. Re-audited by measurement,
+    not by re-reading each entry: removing every `ALLOWED` exemption from `local_handle_sites()` and
+    re-running against the real tree surfaces exactly one finding, `OCCTGeomFillCoonsAlgPatchEval` -
+    the same one already known and already in this table. None of the other 23 has a hidden
+    local-handle defect behind its entry TODAY. That is not a standing guarantee (the docstring
+    warning above already covers "after the body changes"), only a measured answer to "as of this
+    audit," which is exactly the standard the rest of this table is held to.
+
+ROUND-2 REVIEW, THE REMAINING FINDINGS - all mechanical, none changing what gets reported today:
+
+  * `self_test()` used to check only the combined `all_sites()` result, which proves some detector
+    in the union catches a fixture, not specifically that the mechanism it exercises still does - a
+    regression confined to `unguarded_sites()` could in principle hide behind a coincidental change
+    elsewhere. Every fixture is now tagged 'wrapper' or 'local' and is also checked directly against
+    its own mechanism (see `self_test()`'s own docstring for a worked example of the exact masking
+    this closes).
+  * `all_sites()` ran `guarding_helpers()`, `unguarded_sites()` and `local_handle_sites()` as three
+    independent passes over the same source files, each re-doing the same comment/cast-stripping and
+    function-boundary scan. `parse_sources()` does that work once and all three now share it.
+  * The report tuple's `field` (wrapper) / `callee` (local) slot meant two different things
+    depending on `kind`, tracked only by convention and a comment. It is a named `Site.detail` now,
+    with the dual meaning spelled out where it is declared rather than implied at each call site.
+  * `probe_cluster_c.mm`'s `fork()` return was never checked: on failure, the subsequent
+    `waitpid(-1, ...)` returns immediately via `ECHILD` with `st` left at 0, which the verdict switch
+    reads as "returned normally" - the opposite of what happened. Now reported as its own verdict.
+  * The census README was trimmed - it had grown to carry its own review log (corrections found
+    while responding to feedback, a near-miss in a throwaway verification script) well past this
+    project's `docs/` length norms and its own cited `556-null-handle-guard-sweep` precedent.
+
 Usage (from the repo root):
 
     python3 Scripts/check-null-handle-guards.py             # report unguarded sites
@@ -205,6 +253,16 @@ import glob
 import os
 import re
 import sys
+from collections import namedtuple
+
+# One reported site, from either walk. `detail` is deliberately dual-purpose rather than split into
+# two mutually-exclusive fields: for a 'wrapper' site it is the wrapper's handle field name (e.g.
+# `curve`), for a 'local' site it is the BRep_Tool:: producer call that obtained it (e.g.
+# `BRep_Tool::Curve`) - #666 round-2 review's readability nit. A split (`field`/`callee`) would
+# still need `kind` to know which one is meaningful, so this documents the same dual meaning the
+# comment used to carry implicitly, in the name itself, rather than inventing two fields only one
+# of which is ever populated for a given `kind`.
+Site = namedtuple('Site', 'file line func name detail src is_array kind')
 
 SRC_DIR = 'Sources/OCCTBridge/src'
 
@@ -321,6 +379,68 @@ LOCAL_HANDLE_DECL = re.compile(
     r'occ::handle\s*<\s*(Geom_Curve|Geom2d_Curve|Geom_Surface)\s*>)'
     r'\s+(\w+)\s*(?:=|\()\s*(BRep_Tool::\w+)\s*\(')
 
+# The producer-agnostic sibling of LOCAL_HANDLE_DECL: same three tracked types, same two
+# connectors, but no `BRep_Tool::` requirement. Not a source of reportable sites - a redeclaration
+# from `new T(...)` or a builder is not #656's shape - but a real C++ redeclaration of the same
+# name all the same, and the scope fence below needs to know about every one of them, not just the
+# `BRep_Tool::`-sourced ones, to resolve shadowing correctly (#666 round-2 review: a sibling/nested
+# redeclaration "from any other source" was invisible to the old fence).
+ANY_HANDLE_DECL = re.compile(
+    r'\b(?:Handle\s*\(\s*(?:Geom_Curve|Geom2d_Curve|Geom_Surface)\s*\)|'
+    r'occ::handle\s*<\s*(?:Geom_Curve|Geom2d_Curve|Geom_Surface)\s*>)'
+    r'\s+(\w+)\s*(?:=|\()')
+
+
+def block_spans(body):
+    """(open, close) for every brace-delimited block in `body`, via one stack-based pass, plus a
+    synthetic (-1, len(body)) span standing in for "no enclosing braces at all" - the function's
+    own top level, which is a scope too even though it has no literal wrapping `{`/`}` of its own
+    (the function's own `{`/`}` are already part of `body`, at index 0 and len(body)-1, and DO
+    become a real span here like any other)."""
+    spans, stack = [], []
+    for i, ch in enumerate(body):
+        if ch == '{':
+            stack.append(i)
+        elif ch == '}' and stack:
+            spans.append((stack.pop(), i))
+    spans.append((-1, len(body)))
+    return spans
+
+
+def innermost_span(spans, pos):
+    """The smallest span that strictly contains `pos` - `pos`'s immediately enclosing scope."""
+    best = None
+    for o, c in spans:
+        if o < pos < c and (best is None or (c - o) < (best[1] - best[0])):
+            best = (o, c)
+    return best
+
+
+def var_declarations(body):
+    """name -> [(start, block_open, block_close), ...] for every ANY_HANDLE_DECL match in body,
+    each tagged with its own immediately-enclosing block span. Computed once per function and
+    shared by every LOCAL_HANDLE_DECL site in it (see `local_handle_sites()`)."""
+    spans = block_spans(body)
+    out = {}
+    for m in ANY_HANDLE_DECL.finditer(body):
+        name = m.group(1)
+        o, c = innermost_span(spans, m.start())
+        out.setdefault(name, []).append((m.start(), o, c))
+    return out
+
+
+def binds_to(decls, pos):
+    """Ordinary C++ block scoping: which declaration (its `start`) an occurrence of its name at
+    `pos` resolves to, out of every declaration of that name in the function. A declaration is a
+    candidate only while `pos` is still inside ITS OWN immediately-enclosing block (`o < pos < c`)
+    - once that block closes, the declaration is out of scope again, exactly as C++ requires - and
+    among the candidates still in scope, the most recently declared one (the largest `start` less
+    than `pos`) wins, which is what makes a nested redeclaration shadow an outer one for uses
+    inside its own block, while an outer declaration's uses AFTER that nested block closes correctly
+    resume binding to the outer declaration rather than staying stuck on the inner one."""
+    candidates = [d for d, o, c in decls if o < d < pos < c]
+    return max(candidates) if candidates else None
+
 
 def strip_comments(text):
     """Blank out comments and preserve every newline, so line numbers still line up."""
@@ -435,7 +555,29 @@ def wrapper_params(params):
     return out
 
 
-def guarding_helpers(sources):
+def parse_sources(sources):
+    """(path, raw, text, ctext, lines, funcs) once per file - the shared, expensive parse work
+    that guarding_helpers()/unguarded_sites()/local_handle_sites() each used to redo independently.
+
+    #666 round-2 review (item 8): all_sites() ran all three walks over the same `sources` from
+    scratch - comment-stripping, cast-stripping and re-finding every function's boundaries three
+    times per file per invocation, for no new information the first pass didn't already have.
+    `text` (comments blanked, casts intact) and `ctext` (both blanked) are kept as two separate
+    strings, not one: guarding_helpers() deliberately wants casts LEFT IN (a helper parameter typed
+    straight as a `Handle`, never itself behind a cast, is what it looks for), while the other two
+    walks want them stripped. `funcs` (the `functions()` boundary list) is identical either way,
+    since `functions()` only reads return-type/name/param text, none of which a cast can appear
+    inside, so it is computed once against `text` and reused for both."""
+    parsed = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        ctext = strip_casts(text)
+        lines = raw.splitlines()
+        parsed.append((path, raw, text, ctext, lines, list(functions(text))))
+    return parsed
+
+
+def guarding_helpers(parsed):
     """(function, argument index) for every bridge function that IsNull-checks that Handle
     parameter before touching it. Passing a handle to one of these IS a guard: the check just
     lives one call frame away.
@@ -447,9 +589,8 @@ def guarding_helpers(sources):
     and `occtSurfToAnaSurfResult` are wrongly reported, nothing else. The other four are recognised
     because they guard unconditionally, not because any caller currently relies on it."""
     guards = set()
-    for _, text in sources:
-        text = strip_comments(text)
-        for name, params, bs, be in functions(text):
+    for path, raw, text, ctext, lines, funcs in parsed:
+        for name, params, bs, be in funcs:
             body = text[bs:be + 1]
             for i, p in enumerate(split_params(params)):
                 if not HANDLE_PARAM.search(p):
@@ -518,14 +659,11 @@ def classify(body, start, end, helpers):
     return 'use'
 
 
-def unguarded_sites(sources, helpers):
+def unguarded_sites(parsed, helpers):
     """Every (file, line, function, parameter) whose handle reaches OCCT without an IsNull test."""
     found = []
-    for path, raw in sources:
-        text = strip_comments(raw)
-        ctext = strip_casts(text)
-        lines = raw.splitlines()
-        for name, params, bs, be in functions(text):
+    for path, raw, text, ctext, lines, funcs in parsed:
+        for name, params, bs, be in funcs:
             body = ctext[bs:be + 1]
             for param, field, is_array in wrapper_params(params):
                 if (os.path.basename(path), name) in ALLOWED:
@@ -554,13 +692,13 @@ def unguarded_sites(sources, helpers):
                 if first is None or any(k == 'guard' and p < first for p, k in ev):
                     continue
                 line = text.count('\n', 0, bs + first) + 1
-                found.append((os.path.basename(path), line, name, param, field,
-                              lines[line - 1].strip() if line <= len(lines) else '', is_array,
-                              'wrapper'))
+                found.append(Site(os.path.basename(path), line, name, param, field,
+                                   lines[line - 1].strip() if line <= len(lines) else '', is_array,
+                                   'wrapper'))
     return found
 
 
-def local_handle_sites(sources, helpers):
+def local_handle_sites(parsed, helpers):
     """#666: every local Handle(Geom_Curve)/Handle(Geom2d_Curve)/Handle(Geom_Surface), obtained
     from a BRep_Tool:: call rather than a wrapper argument, that reaches a use before an IsNull
     test - the #656 shape. Same (file, line, function, name) shape as unguarded_sites(), tagged
@@ -568,44 +706,61 @@ def local_handle_sites(sources, helpers):
 
     Two things a wrapper argument never needed:
 
-    * A SCOPE FENCE. A later `Handle(...) name = ...` redeclaration of the identical name, later
-      in the same function body, ends the earlier declaration's own tracking window. Without it,
-      two sibling `switch` cases that each declare their own `Handle(Geom_Surface) surf = ...`
-      get conflated into one variable, and a later case's guard is misread as covering an earlier
-      case's unguarded use (see the module docstring's G1) - or the reverse, an earlier unrelated
-      guard on the same name wrongly "protects" a later, genuinely unguarded redeclaration (G2),
-      which is why the use-window also starts at THIS declaration's own end, never before it.
+    * A SCOPE FENCE, now genuinely block-scope-aware (round-2 review of #666: the original fence
+      was textual, not scoped - it ended a name's tracking window at the next `Handle(...) name =
+      BRep_Tool::...` redeclaration and nothing else, so (a) a sibling redeclaration from ANY OTHER
+      SOURCE (`name = SomeOtherFactory(...)`, no `BRep_Tool::`) didn't fence at all, since it never
+      matched `LOCAL_HANDLE_DECL`, and (b) a redeclaration inside a NESTED block ended the outer
+      variable's window right there, so a real use of the OUTER variable resuming after the nested
+      block closed was silently dropped - proven, not just suspected: reverting this fix to the old
+      end-bound reproduces a live miss on exactly that shape (self-test fixture `W`).
 
-      The fence itself is textual, not scope-aware: a redeclaration inside a NESTED block still
-      ends the outer variable's window at that point, so a real use of the outer variable resuming
-      after the nested block closes goes untracked (both would have to be named the same for this
-      to matter at all); a non-initialising declaration (`Handle(Geom_Curve) x;`) or a plain
-      reassignment (`x = other;`) does not fence anything, since `LOCAL_HANDLE_DECL` only matches
-      an initialising declaration off a `BRep_Tool::` call. Also unguarded against: a mid-window
-      reassignment of the tracked name is itself picked up by the use-scan (there is no equivalent
-      of `unguarded_sites()`'s `spans` exclusion for "this occurrence merely binds/rebinds, it is
-      not a read"), so it can be misclassified as a use - a false-positive-only risk, the same
-      direction as a spurious report rather than a missed one. None of the four has a known
-      instance in this tree.
+      `var_declarations()`/`binds_to()` replace the linear "next same-name redeclaration" fence with
+      real C++ block scoping: every ANY_HANDLE_DECL-typed declaration of the name in the function -
+      any producer, not just `BRep_Tool::` - is tagged with its own immediately-enclosing block, and
+      each occurrence of the name binds to the innermost still-in-scope declaration at that point
+      (`binds_to`), the same rule the C++ compiler itself uses. This subsumes both guard-removal
+      fixtures the old fence needed (G1: two sibling `switch`-case declarations of `surf` correctly
+      resolve to their own case, since each case's occurrences fall outside the other case's block;
+      G2: an unrelated earlier guard on the same bare name - a parameter, never a candidate
+      declaration at all - cannot protect a later local, since it was never in `decls_by_var` to
+      begin with) and additionally fixes the nested-block miss neither fixture exercised.
+
+    * THE SAME `spans`-STYLE EXCLUSION `unguarded_sites()` ALREADY HAD, extended here (round-2
+      review: without it, a mid-window reassignment of the tracked name - `c = BRep_Tool::Curve(...)`
+      with no `Handle(...)` retype, so it doesn't touch the scope fence above at all - was itself
+      picked up by the use-scan and misclassified as an unguarded use, even when the reassigned
+      value goes on to be properly guarded before its real read: self-test fixture `X` reproduces
+      this as a live false positive against the pre-fix code). The exclusion does not make a
+      reassignment's OWN un-rechecked null risk visible - if the reassigned value is used
+      unguarded and nothing rechecks it, the ORIGINAL declaration's earlier guard still (wrongly)
+      reads as covering it, the identical false-negative trade-off `unguarded_sites()`'s own
+      `spans` exclusion already accepts for a wrapper-derived handle alias. Not new here, just
+      inherited: re-verify a reassigned handle by eye same as a reassigned alias.
+
+    A shadow from a declaration of a DIFFERENT, untracked shape (`auto name = ...;` with no type
+    name to anchor on, or an unrelated type like `TopoDS_Face name;`) still doesn't fence - neither
+    is matched by `ANY_HANDLE_DECL`, which only knows the three tracked `Handle`/`occ::handle<>`
+    types - and remains exactly the residual the module docstring's "FOUR MORE, SAME CLASS" section
+    already describes for the deduced-type case. No known instance of either in this tree today.
     """
     found = []
-    for path, raw in sources:
-        text = strip_comments(raw)
-        ctext = strip_casts(text)
-        lines = raw.splitlines()
-        for name, params, bs, be in functions(text):
+    for path, raw, text, ctext, lines, funcs in parsed:
+        for name, params, bs, be in funcs:
             if (os.path.basename(path), name) in ALLOWED:
                 continue
             body = ctext[bs:be + 1]
-            decls = list(LOCAL_HANDLE_DECL.finditer(body))
-            for i, m in enumerate(decls):
+            decls_by_var = var_declarations(body)
+            for m in LOCAL_HANDLE_DECL.finditer(body):
                 var, callee = m.group(3), m.group(4)
-                start_bound = m.end()                    # never before this declaration (G2)
-                end_bound = next((later.start() for later in decls[i + 1:]
-                                   if later.group(3) == var), len(body))   # scope fence (G1)
+                mine = m.start()
                 pat = re.compile(r'(?<![\w>.])' + re.escape(var) + r'\b')
                 ev = []
-                for u in pat.finditer(body, start_bound, end_bound):
+                for u in pat.finditer(body, m.end()):
+                    if binds_to(decls_by_var.get(var, ()), u.start()) != mine:
+                        continue                      # a later/sibling redeclaration owns this one
+                    if re.match(r'\s*=(?!=)', body[u.end():u.end() + 4]):
+                        continue                      # binds/rebinds the name, not a read
                     kind = classify(body, u.start(), u.end(), helpers)
                     if kind:
                         ev.append((u.start(), kind))
@@ -614,16 +769,19 @@ def local_handle_sites(sources, helpers):
                 if first is None or any(k == 'guard' and p < first for p, k in ev):
                     continue
                 line = text.count('\n', 0, bs + first) + 1
-                found.append((os.path.basename(path), line, name, var, callee,
-                              lines[line - 1].strip() if line <= len(lines) else '', False,
-                              'local'))
+                found.append(Site(os.path.basename(path), line, name, var, callee,
+                                   lines[line - 1].strip() if line <= len(lines) else '', False,
+                                   'local'))
     return found
 
 
 def all_sites(sources):
-    """The full report: both handle origins, one combined list."""
-    helpers = guarding_helpers(sources)
-    return unguarded_sites(sources, helpers) + local_handle_sites(sources, helpers)
+    """The full report: both handle origins, one combined list. Parses every file once
+    (`parse_sources`) and shares that parse across `guarding_helpers()` and both site walks,
+    rather than each redoing it (#666 round-2 review, item 8)."""
+    parsed = parse_sources(sources)
+    helpers = guarding_helpers(parsed)
+    return unguarded_sites(parsed, helpers) + local_handle_sites(parsed, helpers)
 
 
 def bridge_sources():
@@ -640,24 +798,24 @@ MISSED = [
 int OCCTFixtureA(OCCTSurfaceRef s) {
     try { Splitter sp; sp.Init(reinterpret_cast<OCCTSurface*>(s)->surface); return 1; }
     catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('handle alias bound through a cast', '''
 int OCCTFixtureB(OCCTSurfaceRef surfaceRef) {
     try {
         auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
         Splitter sp; sp.Init(surface); return 1;
     } catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('pointer alias through a C-style cast', '''
 int OCCTFixtureC(OCCTSurfaceRef surface) {
     try { auto* s = (OCCTSurface*)surface; GeomAdaptor_Surface a(s->surface); return 1; }
     catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('static_cast spelling', '''
 int OCCTFixtureD(OCCTCurve3DRef c) {
     try { Splitter sp; sp.Init(static_cast<OCCTCurve3D*>(c)->curve); return 1; }
     catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('array element through a cast', '''
 int OCCTFixtureE(const OCCTCurve3DRef* refs, int n) {
     try {
@@ -667,13 +825,13 @@ int OCCTFixtureE(const OCCTCurve3DRef* refs, int n) {
         }
         return 1;
     } catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     # The pre-#618 form. It must keep being caught: the fix is additive, not a replacement.
     ('plain param->field, no indirection', '''
 int OCCTFixtureF(OCCTCurve3DRef curve) {
     try { Splitter sp; sp.Init(curve->curve); return 1; }
     catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     # #666: the #656 shape itself - a local handle from BRep_Tool::, not a wrapper argument.
     ('local handle from BRep_Tool::, passed onward unguarded (the #656 shape)', '''
 double OCCTFixtureM(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
@@ -682,14 +840,14 @@ double OCCTFixtureM(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
         Handle(Geom2d_Curve) c2d = BRep_Tool::CurveOnSurface(edgeRef->shape, faceRef->shape, first, last);
         return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
     } catch (...) { return 0.0; }
-}'''),
+}''', 'local'),
     # #666: FUNC must see through `extern "C"` on the definition line, or this whole function -
     # an otherwise-plain, otherwise-caught unguarded site - is invisible to every check below.
     ('extern "C" on the definition line must not hide the function', '''
 extern "C" int OCCTFixtureN(OCCTCurve3DRef curve) {
     try { Splitter sp; sp.Init(curve->curve); return 1; }
     catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     # #666 (G2): the scope fence's LOWER bound. An unrelated, earlier guard on the same bare name
     # (here, a same-named parameter) must not be read as covering a later local that shadows it.
     ('an earlier guard on an unrelated same-named parameter must not shadow a later local', '''
@@ -701,7 +859,7 @@ bool OCCTFixtureO(OCCTSurfaceRef surf, OCCTShapeRef faceRef) {
             return surf->IsUPeriodic();
         }
     } catch (...) { return false; }
-}'''),
+}''', 'local'),
     # #666 follow-up: the constructor-init connector. LOCAL_HANDLE_DECL required `name =
     # BRep_Tool::...(`; this is #656's exact shape written with parens instead - `name(BRep_Tool::
     # ...(`. The module docstring already warned this spelling defeats the wrapper-argument walk's
@@ -713,7 +871,7 @@ double OCCTFixtureT(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
         Handle(Geom2d_Curve) c2d(BRep_Tool::CurveOnSurface(edgeRef->shape, faceRef->shape, first, last));
         return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
     } catch (...) { return 0.0; }
-}'''),
+}''', 'local'),
     # #666 follow-up: the `occ::handle<>` spelling had never been exercised for a LOCAL
     # declaration (only for a helper's parameter type, fixture R) - the regex already covered it,
     # but nothing proved that until this fixture.
@@ -724,7 +882,41 @@ double OCCTFixtureU(OCCTShapeRef edgeRef) {
         occ::handle<Geom_Curve> curve = BRep_Tool::Curve(edgeRef->shape, first, last);
         return curve->FirstParameter();
     } catch (...) { return 0.0; }
-}'''),
+}''', 'local'),
+    # #666 round-2 review: FUNC already parses a function defined inside an `extern "C" { ... }`
+    # block - the block's own braces are just ordinary text to `functions()`, and the function
+    # signature inside has no `extern "C"` text of its own to hide it - so this was NEVER blind,
+    # contrary to what the module docstring used to claim. Not a new guard (nothing in FUNC changes
+    # for this fixture to pass); it freezes the corrected claim against a future regression, the
+    # same reasoning fixture N used for the inline form.
+    ('extern "C" block form (as opposed to the inline prefix) must not hide a function either', '''
+extern "C" {
+
+int OCCTFixtureV(OCCTCurve3DRef curve) {
+    try { Splitter sp; sp.Init(curve->curve); return 1; }
+    catch (...) { return 0; }
+}
+
+}''', 'wrapper'),
+    # #666 round-2 review (item 1): the scope fence used to be purely textual - it ended a name's
+    # tracking window only at the next *BRep_Tool::-sourced* redeclaration of that name, so it never
+    # noticed a redeclaration inside a NESTED block, and a real use of the OUTER variable resuming
+    # after that block closes was silently dropped. Confirmed empirically against the pre-fix code
+    # before this fixture was written: `all_sites()` returned `[]` for this exact shape.
+    ('outer local resumes after a nested same-named redeclaration closes; the outer use is real', '''
+double OCCTFixtureW(OCCTShapeRef edgeRef, OCCTShapeRef otherEdgeRef) {
+    try {
+        double first, last;
+        Handle(Geom2d_Curve) c2d = BRep_Tool::CurveOnSurface(edgeRef->shape, edgeRef->shape, first, last);
+        {
+            double f2, l2;
+            Handle(Geom2d_Curve) c2d = BRep_Tool::CurveOnSurface(otherEdgeRef->shape, otherEdgeRef->shape, f2, l2);
+            if (c2d.IsNull()) return 0.0;
+            DoSomething(c2d);
+        }
+        return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
+    } catch (...) { return 0.0; }
+}''', 'local'),
 ]
 
 # The other failure mode, and the one #624/#630 was: a detector taught indirection can start
@@ -735,7 +927,7 @@ int OCCTFixtureG(OCCTCurve3DRef curve) {
     if (!curve || curve->curve.IsNull()) return 0;
     try { Splitter sp; sp.Init(curve->curve); return 1; }
     catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('guarded through the handle alias', '''
 int OCCTFixtureH(OCCTSurfaceRef surfaceRef) {
     try {
@@ -743,7 +935,7 @@ int OCCTFixtureH(OCCTSurfaceRef surfaceRef) {
         if (surface.IsNull()) return 0;
         Splitter sp; sp.Init(surface); return 1;
     } catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('guarded through a by-value Handle copy', '''
 int OCCTFixtureI(OCCTSurfaceRef initialSurface) {
     try {
@@ -752,7 +944,7 @@ int OCCTFixtureI(OCCTSurfaceRef initialSurface) {
         if (workSurface.IsNull()) return 0;
         NLPlate_NLPlate solver(workSurface); return 1;
     } catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('guarded through the pointer alias', '''
 int OCCTFixtureJ(OCCTSurfaceRef surface, OCCTCurve2DRef curve2d) {
     try {
@@ -761,7 +953,7 @@ int OCCTFixtureJ(OCCTSurfaceRef surface, OCCTCurve2DRef curve2d) {
         if (!sw || sw->surface.IsNull() || !cw || cw->curve.IsNull()) return 0;
         GeomAdaptor_Surface a(sw->surface); return 1;
     } catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     ('DownCast is not a use', '''
 int OCCTFixtureK(OCCTCurve2DRef curveRef) {
     try {
@@ -770,7 +962,7 @@ int OCCTFixtureK(OCCTCurve2DRef curveRef) {
         if (bsp.IsNull()) return 0;
         return 1;
     } catch (...) { return 0; }
-}'''),
+}''', 'wrapper'),
     # Form 4. The handle is checked one frame away, inside the shared helper - the shape that
     # makes a naive indirection-aware detector wrong about OCCTGeomConvertCurveToAnalytical.
     ('guarded by the bridge helper it is passed to', '''
@@ -782,7 +974,7 @@ inline bool occtFixtureToAnalytical(const occ::handle<Geom_Curve>& curve, double
 int OCCTFixtureL(OCCTCurve3DRef curveRef) {
     if (!curveRef) return 0;
     return occtFixtureToAnalytical(reinterpret_cast<OCCTCurve3D*>(curveRef)->curve, 1e-7) ? 1 : 0;
-}'''),
+}''', 'wrapper'),
     # #666: local handle from BRep_Tool::, guarded before use - the actual #656 fix, reduced.
     ('local handle from BRep_Tool::, guarded before use', '''
 double OCCTFixtureP(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
@@ -792,7 +984,7 @@ double OCCTFixtureP(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
         if (c2d.IsNull()) return 0.0;
         return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
     } catch (...) { return 0.0; }
-}'''),
+}''', 'local'),
     # #666: a local handle from BRep_Tool:: consumed only by DownCast is the same null-safe
     # exclusion as a wrapper-derived one - this is the bridge's real Copy()+DownCast clone idiom.
     ('local handle from BRep_Tool:: consumed only by DownCast', '''
@@ -803,7 +995,7 @@ bool OCCTFixtureQ(OCCTShapeRef faceRef) {
         if (plane.IsNull()) return false;
         return true;
     } catch (...) { return false; }
-}'''),
+}''', 'local'),
     # #666: local handle from BRep_Tool::, guarded one call frame away by the bridge helper.
     ('local handle from BRep_Tool::, guarded by the bridge helper it is passed to', '''
 inline bool occtFixtureCurveGuard(const occ::handle<Geom_Curve>& curve, double tol) {
@@ -814,7 +1006,7 @@ bool OCCTFixtureR(OCCTShapeRef edgeRef) {
     double first, last;
     Handle(Geom_Curve) curve = BRep_Tool::Curve(edgeRef->shape, first, last);
     return occtFixtureCurveGuard(curve, 1e-7);
-}'''),
+}''', 'local'),
     # #666 (G1): two sibling scopes reuse the same local name, each independently guarded via
     # DownCast. Reduced from the real false positive an early version of this detector reported
     # on OCCTFaceGetPrimaryAxis, where the SECOND case's properly-guarded `surf` was misread as
@@ -833,31 +1025,64 @@ bool OCCTFixtureS(OCCTShapeRef faceRef, int mode) {
         if (c.IsNull()) return false;
         return true;
     } catch (...) { return false; }
-}'''),
+}''', 'local'),
+    # #666 round-2 review (item 7): a mid-window reassignment of the tracked name (`c = BRep_Tool::
+    # Curve(...)`, no `Handle(...)` retype, so it never touches the scope fence at all) used to be
+    # picked up by the use-scan itself and misclassified as an unguarded use, even though `c` really
+    # is guarded before its one dereferencing read. Confirmed empirically against the pre-fix code
+    # before this fixture was written: the reassignment line itself was reported as unguarded.
+    ('a plain reassignment of the tracked name is a rebind, not a read, even mid-window', '''
+double OCCTFixtureX(OCCTShapeRef edgeRef, OCCTShapeRef otherEdgeRef) {
+    try {
+        double first, last;
+        Handle(Geom_Curve) c = BRep_Tool::Curve(edgeRef->shape, first, last);
+        c = BRep_Tool::Curve(otherEdgeRef->shape, first, last);
+        if (c.IsNull()) return 0.0;
+        return c->FirstParameter();
+    } catch (...) { return 0.0; }
+}''', 'local'),
 ]
 
 
 def self_test():
     """Prove both failure modes: an unguarded site is reported, a guarded one is not.
 
-    Runs every fixture through all_sites() - both the wrapper-argument walk and #666's
-    local-handle walk - since a fixture that only exercises one origin still has to survive the
-    other running over it unharmed (e.g. a local-handle fixture must not trip the wrapper-argument
-    walk, and vice versa).
+    Every fixture is tagged 'wrapper' or 'local' for the mechanism it exercises, and is checked
+    TWICE: once through that mechanism directly (unguarded_sites()/local_handle_sites(), with a
+    shared `helpers`, matching how all_sites() itself combines them), and once through the
+    combined all_sites() - the same round-trip #666's own report used, since a fixture that only
+    exercises one origin still has to survive the OTHER walk running over it unharmed (e.g. a
+    local-handle fixture must not trip the wrapper-argument walk, and vice versa).
+
+    #666 round-2 review (item 5): checking only the combined all_sites() result, as this used to,
+    proves some detector in the union catches each fixture - not specifically that the mechanism a
+    fixture is FOR still does. A regression confined to unguarded_sites()/classify()/aliases() that
+    happened to leave the union's answer unchanged for every 'wrapper' fixture would have passed
+    silently. Checking the direct mechanism per fixture closes that.
     """
     failed = 0
-    for name, src in MISSED:
+    for name, src, walk in MISSED:
         sources = [('fixture.mm', src)]
+        parsed = parse_sources(sources)
+        helpers = guarding_helpers(parsed)
+        direct = unguarded_sites(parsed, helpers) if walk == 'wrapper' \
+            else local_handle_sites(parsed, helpers)
         hit = all_sites(sources)
-        failed += not hit
-        print(f'  {"ok  " if hit else "MISS"} unguarded, {name}: '
-              f'{hit[0][2] + "(" + hit[0][3] + ")" if hit else "NOT REPORTED"}')
-    for name, src in CLEAN:
+        ok = bool(direct) and bool(hit)
+        failed += not ok
+        print(f'  {"ok  " if ok else "MISS"} unguarded, {name}: '
+              f'{hit[0].func + "(" + hit[0].name + ")" if hit else "NOT REPORTED"}')
+    for name, src, walk in CLEAN:
         sources = [('fixture.mm', src)]
+        parsed = parse_sources(sources)
+        helpers = guarding_helpers(parsed)
+        direct = unguarded_sites(parsed, helpers) if walk == 'wrapper' \
+            else local_handle_sites(parsed, helpers)
         hit = all_sites(sources)
-        failed += bool(hit)
-        print(f'  {"ok  " if not hit else "FALSE"} guarded, {name}: '
-              f'{hit[0][2] + " wrongly reported" if hit else "not reported"}')
+        ok = not direct and not hit
+        failed += not ok
+        print(f'  {"ok  " if ok else "FALSE"} guarded, {name}: '
+              f'{hit[0].func + " wrongly reported" if hit else "not reported"}')
     total = len(MISSED) + len(CLEAN)
     print(f'{total - failed}/{total} cases correct')
     return 1 if failed else 0
@@ -879,21 +1104,21 @@ def main():
         return 0
     if not quiet:
         print(f'{len(sites)} site(s) reach OCCT with an unchecked handle:\n')
-        for f, line, func, param, field, src, is_array, kind in sites:
-            print(f'  {f}:{line}  {func}({param})')
-            print(f'      {src}')
-            if kind == 'local':
-                # `param` is a local, not a wrapper argument: there is no pointer to null-check
-                # alongside it, just the handle itself, obtained from `field` (the BRep_Tool::
+        for s in sites:
+            print(f'  {s.file}:{s.line}  {s.func}({s.name})')
+            print(f'      {s.src}')
+            if s.kind == 'local':
+                # `s.name` is a local, not a wrapper argument: there is no pointer to null-check
+                # alongside it, just the handle itself, obtained from `s.detail` (the BRep_Tool::
                 # call that produced it).
-                print(f'      obtained from {field}(); want: if ({param}.IsNull()) return <fallback>;')
-            elif is_array:
-                # `param` is a pointer to wrappers, so `param->field` would not compile. The
+                print(f'      obtained from {s.detail}(); want: if ({s.name}.IsNull()) return <fallback>;')
+            elif s.is_array:
+                # `s.name` is a pointer to wrappers, so `s.name->s.detail` would not compile. The
                 # guard belongs on the element, inside the loop that reads it.
-                print(f'      want, per element of {param}:  '
-                      f'if (!e || e->{field}.IsNull()) return <fallback>;')
+                print(f'      want, per element of {s.name}:  '
+                      f'if (!e || e->{s.detail}.IsNull()) return <fallback>;')
             else:
-                print(f'      want: if (!{param} || {param}->{field}.IsNull()) return <fallback>;')
+                print(f'      want: if (!{s.name} || {s.name}->{s.detail}.IsNull()) return <fallback>;')
     return 1
 
 

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -70,9 +70,12 @@ handle alias once declared - the same `classify()`, the same DownCast exclusion,
 guarding-helper exclusion - so a use before an `IsNull()` guard is reported the same way. Two things
 this needed that the wrapper-argument walk did not:
 
-  * A PRODUCER ALLOWLIST, NOT "ANY CALL". The RHS has to start with `BRep_Tool::` - the accessor
-    family OCCT documents as legitimately returning a null handle for ordinary topology (no 3D
-    curve; no pcurve on a given face). "Any local Handle initialised from any call" was tried first
+  * A PRODUCER ALLOWLIST, NOT "ANY CALL". The RHS has to start with `BRep_Tool::`. At least
+    `Curve` ("May be a Null handle") and `CurveOnSurface` ("Returns a NULL handle if this curve
+    does not exist") say so in `BRep_Tool.hxx` itself; `Surface(const TopoDS_Face&)` documents no
+    such thing ("Returns the geometric surface of the face"), and is tracked anyway as a
+    conservative over-approximation, not because OCCT promises a null there. "Any local Handle
+    initialised from any call" was tried first
     and matched 672 declarations tree-wide - mostly `new T(...)` (never null), a same-family
     `DownCast` (null-safe by construction, and this bridge's own established cloning idiom: `Handle
     (Geom_Curve) copy = Handle(Geom_Curve)::DownCast(c->curve->Copy());`), or a builder's
@@ -127,6 +130,27 @@ cover a whole enclosing block rather than one definition line. Enumerating the w
 was explicitly out of scope for this pass; the census README's method section says why
 `BRep_Tool::` specifically, not "every OCCT call", was the line drawn.
 
+FOUR MORE, SAME CLASS - `LOCAL_HANDLE_DECL` requires an explicit `Handle(Type)`/`occ::handle<Type>`
+spelling directly followed by a bare name and one of the two known connectors, so anything else
+between the type and the producer call is invisible, guarded or not:
+
+  * a deduced type: `auto c2d = BRep_Tool::CurveOnSurface(...);` - no type name for the regex to
+    anchor on at all. NOT hypothetical: `OCCTBRepToolCurveOnSurface` (`OCCTBridge_Topology.mm:3717`)
+    uses exactly this, already guarded in substance (`if (c2d.IsNull()) return nullptr;` the next
+    line) - safe today, invisible either way.
+  * a reference binding: `const Handle(Geom_Surface)& s = BRep_Tool::Surface(...);` - the `&`
+    sits exactly where the regex expects nothing but whitespace before the bare name. Zero
+    occurrences.
+  * global qualification: `::BRep_Tool::Curve(...)` - the leading `::` breaks the literal
+    `BRep_Tool::` anchor. Zero occurrences.
+  * a ternary initialiser: `Handle(Geom_Curve) c = cond ? BRep_Tool::Curve(...) : ...;` - anything
+    between the connector and `BRep_Tool::` breaks the immediate-adjacency the regex requires.
+    Zero occurrences.
+
+Not taught here: this is a documentation-accuracy pass over an already-shipped mechanism, not a
+new detection pass, and the one real instance found is already safe. Re-measure before assuming
+that stays true.
+
 A FIFTH ALIAS FORM, FOUND BUT NOT TAUGHT: `OCCTBridge_Surface.mm` has nine sites shaped
 `const Handle(Geom_Curve)& x = *(const Handle(Geom_Curve)*)wrapperParam;` (and its `occ::handle<>`
 spelling, used safely 12 more times elsewhere, always guarded) - a raw pointer reinterpretation
@@ -156,6 +180,17 @@ Two exclusions, both load-bearing:
     The mechanism's only real safeguard is that it lives in a tracked file, so an entry has to
     survive review. Re-measure before trusting an entry you did not write, and delete it rather
     than widen it when a function grows a new argument.
+
+    #666 made this coarser, not just still-coarse: the same key now ALSO exempts every
+    `local_handle_sites()` finding for that function, not only `unguarded_sites()`'s wrapper
+    arguments. `OCCTGeomFillCoonsAlgPatchEval` is the concrete cost, bounded but real: it passed
+    the wrapper-argument walk clean *before* #666 and was never in this table, so its new entry
+    (added for the local-handle finding) retroactively exempts wrapper-argument checking on that
+    function too - dead weight today only because the function happens to have no
+    `OCCTCurve3DRef`/`OCCTCurve2DRef`/`OCCTSurfaceRef` parameter to check, not because the table
+    knows that. State which walk (or walks) an entry was actually measured against in its reason,
+    going forward, so a reader can tell what a given entry does and does not cover without
+    re-deriving it from the function's signature.
 
 Usage (from the repo root):
 
@@ -247,11 +282,14 @@ ALLOWED = {
 
     # --- #666: a local handle fetched from BRep_Tool::, not a wrapper argument ---
     ('OCCTBridge_Surface.mm', 'OCCTGeomFillCoonsAlgPatchEval'):
-        'measured #666 (Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm): '
-        'GeomAdaptor_Curve raises a catchable Standard_Failure on a null Handle(Geom_Curve), on '
-        'both the 1-arg and the 3-arg (trimmed) constructor - same verdict #618 already recorded '
-        'for OCCTExtremaExtCC, now confirmed for a curve obtained from BRep_Tool::Curve rather '
-        'than a wrapper argument',
+        'measured against local_handle_sites() only (this function has no OCCTCurve3DRef/'
+        'OCCTCurve2DRef/OCCTSurfaceRef parameter for unguarded_sites() to check, so this entry '
+        'costs nothing on that walk today, but see the docstring rule above this table for what '
+        'that would mean if it ever grew one): #666 '
+        '(Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm), GeomAdaptor_Curve raises '
+        'a catchable Standard_Failure on a null Handle(Geom_Curve), on both the 1-arg and the '
+        '3-arg (trimmed) constructor - same verdict #618 already recorded for OCCTExtremaExtCC, '
+        'now confirmed for a curve obtained from BRep_Tool::Curve rather than a wrapper argument',
 }
 
 # extern "C" is tolerated ahead of the return type (#666): without it, a function defined that way
@@ -272,7 +310,8 @@ HANDLE_PARAM = re.compile(r'(?:occ::handle\s*<|\bHandle\s*\()')
 # #666: a local Handle of one of the three tracked types, freshly obtained from a BRep_Tool
 # accessor rather than a wrapper argument - the #656 shape. `BRep_Tool::` is a deliberate
 # allowlist, not "any call": see the module docstring for why (672 candidates unrestricted, 63
-# once narrowed to the accessor family OCCT documents as legitimately null-returning).
+# once narrowed to the `BRep_Tool::` accessor family - at least two of which document a null
+# return; the walk tracks the family conservatively rather than per-documented-function).
 # The connector between the name and the producer is `=` (the assignment form) or `(` (the
 # constructor-init form, `Handle(Type) name(BRep_Tool::Whatever(...));`) - #656's exact shape,
 # written with parens instead of `=`. Both spellings, both connectors: four surface forms, one
@@ -536,6 +575,18 @@ def local_handle_sites(sources, helpers):
       case's unguarded use (see the module docstring's G1) - or the reverse, an earlier unrelated
       guard on the same name wrongly "protects" a later, genuinely unguarded redeclaration (G2),
       which is why the use-window also starts at THIS declaration's own end, never before it.
+
+      The fence itself is textual, not scope-aware: a redeclaration inside a NESTED block still
+      ends the outer variable's window at that point, so a real use of the outer variable resuming
+      after the nested block closes goes untracked (both would have to be named the same for this
+      to matter at all); a non-initialising declaration (`Handle(Geom_Curve) x;`) or a plain
+      reassignment (`x = other;`) does not fence anything, since `LOCAL_HANDLE_DECL` only matches
+      an initialising declaration off a `BRep_Tool::` call. Also unguarded against: a mid-window
+      reassignment of the tracked name is itself picked up by the use-scan (there is no equivalent
+      of `unguarded_sites()`'s `spans` exclusion for "this occurrence merely binds/rebinds, it is
+      not a read"), so it can be misclassified as a use - a false-positive-only risk, the same
+      direction as a spurious report rather than a missed one. None of the four has a known
+      instance in this tree.
     """
     found = []
     for path, raw in sources:

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -42,13 +42,89 @@ on a real defect, so add the shape here too rather than assuming it is covered:
     the first `IsNull()` before the use as a guard and does not check for a control transfer.
     Verified once, by hand, that every clearing guard in this tree does return or throw.
   * a negated guard, `if (!x->curve.IsNull()) { } else { use(x->curve); }`.
-  * `extern "C"` on the definition line: the `"` is outside FUNC's return-type character class, so
-    the whole function is invisible to the parser, guarded or not. Zero occurrences today.
   * a helper that guards on some paths only. `guarding_helpers()` asks whether the FIRST mention of
     the parameter is an `IsNull()` test, not whether every path through the body is protected.
 
+`extern "C"` on the definition line is now handled (#666): FUNC used to require its return-type
+span to be free of `"`, so the whole function was invisible to the parser, guarded or not. Zero
+real occurrences motivated this - it was still worth one line, since the failure mode (a whole
+function silently unparsed) is worse than the false positive a wrong fix would risk.
+
 And one false-positive direction: `Handle(Geom_Curve) w(wrapper->curve);` constructor-init syntax
 is not recognised as an alias binding, so it would be reported as an unguarded use. Also absent.
+
+#666 (CLUSTER C): A SECOND, INDEPENDENT ORIGIN FOR A RISKY HANDLE, PROVEN BY #656. Every shape
+above is about a handle that starts life as a bridge function's OWN `OCCTCurve3DRef`/
+`OCCTCurve2DRef`/`OCCTSurfaceRef` argument. #656 (`OCCTBRepToolsEvalAndUpdateTol`) was a null
+`Handle(Geom2d_Curve)` that never came from any argument: it was fetched locally, mid-body, from
+`BRep_Tool::CurveOnSurface(edge, face, ...)`, and handed straight to `BRepTools::EvalAndUpdateTol`,
+which dereferences it unconditionally. Every check above reported clean, because none of them looks
+past a wrapper argument to a handle the function went and obtained for itself.
+
+`local_handle_sites()` closes this specific instance: a local
+
+    Handle(Geom_Curve)/Handle(Geom2d_Curve)/Handle(Geom_Surface) name = BRep_Tool::Whatever(...);
+
+(`Handle(Type)` or `occ::handle<Type>` spelling, either) is tracked exactly like a wrapper-derived
+handle alias once declared - the same `classify()`, the same DownCast exclusion, the same
+guarding-helper exclusion - so a use before an `IsNull()` guard is reported the same way. Two things
+this needed that the wrapper-argument walk did not:
+
+  * A PRODUCER ALLOWLIST, NOT "ANY CALL". The RHS has to start with `BRep_Tool::` - the accessor
+    family OCCT documents as legitimately returning a null handle for ordinary topology (no 3D
+    curve; no pcurve on a given face). "Any local Handle initialised from any call" was tried first
+    and matched 672 declarations tree-wide - mostly `new T(...)` (never null), a same-family
+    `DownCast` (null-safe by construction, and this bridge's own established cloning idiom: `Handle
+    (Geom_Curve) copy = Handle(Geom_Curve)::DownCast(c->curve->Copy());`), or a builder's
+    post-success result accessor. None of those is #656's shape, and auditing 672 by hand would not
+    have been a defence - it would have been a bigger, less careful repeat of #618's own "blind to
+    indirection" mistake with a different indirection. `BRep_Tool::` narrowed it to 63 real
+    declarations.
+  * A SCOPE FENCE. This bridge reuses generic local names (`surf`, `curve`, `pcurve`) across sibling
+    blocks in one function - most visibly a `switch` with one `Handle(Geom_Surface) surf =
+    BRep_Tool::Surface(...)` per `case`. A flat "every later mention of this name is this variable"
+    walk conflates them: an early version of this detector mistook `OCCTFaceGetPrimaryAxis`'s SECOND
+    `case`'s properly-guarded `surf` for a continuation of the FIRST `case`'s `surf` (consumed only
+    by `DownCast`, itself null-safe) and reported the first as unguarded - a false positive that
+    would not have survived review. Fixed by treating a later `Handle(...) name = ...`
+    redeclaration of the identical name, anywhere later in the same function body, as the end of the
+    earlier declaration's own tracking window. The guard-removal fixtures below prove both
+    directions: G1 is this false positive, minimised; G2 is the mirror-image risk the window's
+    LOWER bound guards against - an unrelated, earlier, same-named guard (e.g. on a same-named
+    parameter, later shadowed by a local) wrongly "protecting" a genuinely unguarded local declared
+    after it.
+
+Measured against the tree as it stands: 63 `BRep_Tool::`-sourced locals of these three types, 62
+already guarded, 1 reaching `GeomAdaptor_Curve`'s constructor unguarded
+(`OCCTGeomFillCoonsAlgPatchEval`, `OCCTBridge_Surface.mm`) - measured, not assumed, against the
+pinned kernel (`Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm`) to raise a
+catchable `Standard_Failure` on both the 1-arg and the 3-arg (trimmed) constructor, the same
+verdict #618 already recorded for `OCCTExtremaExtCC`'s wrapper-argument call to the same
+constructor, now confirmed for a curve arriving by this second route too. Added to ALLOWED below.
+Full method, the guard-removal matrix and the triage are in
+`Scripts/repro/cluster-c-null-handle-shapes/README.md`.
+
+STILL NOT TAUGHT, DELIBERATELY, AND STILL BLIND: every item in the list above (non-dominating
+guard, negated guard, partial-path helper, `(*cast).field`, reference-to-wrapper alias) applies
+just as much to a `BRep_Tool::`-sourced local, and none has a known instance in this tree today.
+Also still blind: a `BRep_Tool::` handle carried through one more level of copy (`Handle(Geom_Curve)
+tmp = c3d;`) rather than used directly, and any locally-obtained handle whose producer is not
+spelled `BRep_Tool::` - a different OCCT accessor with the same null-for-valid-topology contract
+would not be caught by this walk. Enumerating that wider set was explicitly out of scope for this
+pass; the census README's method section says why `BRep_Tool::` specifically, not "every OCCT
+call", was the line drawn.
+
+A FIFTH ALIAS FORM, FOUND BUT NOT TAUGHT: `OCCTBridge_Surface.mm` has nine sites shaped
+`const Handle(Geom_Curve)& x = *(const Handle(Geom_Curve)*)wrapperParam;` (and its `occ::handle<>`
+spelling, used safely 12 more times elsewhere, always guarded) - a raw pointer reinterpretation
+that exploits the wrapper struct's one-field layout, syntactically unrelated to `IDENT->field` and
+invisible to `aliases()`. Three of the nine reach an unguarded, measured, uncatchable SIGSEGV:
+`OCCTGeomFillProfilerAddCurve`, `OCCTGeomFillAppSurf` (the #644 function itself - its own curve
+array, a DIFFERENT defect from #644's filed arity bug) and `OCCTGeomFillSectionPlacement`'s
+`sectionCurve`. Measured in `Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm`, not
+taught here and not fixed here: teaching the shape without fixing the three real sites it would
+find would leave this gate red, which is out of bounds for a census-only pass. See the census
+README's section on this fifth form, and #710, filed for it.
 
 Two exclusions, both load-bearing:
 
@@ -155,9 +231,21 @@ ALLOWED = {
         'measured #618: GeomAdaptor_Surface raises a catchable Standard_Failure',
     ('OCCTBridge_Surface.mm', 'OCCTExtremaExtSSPoint'):
         'measured #618: GeomAdaptor_Surface raises a catchable Standard_Failure',
+
+    # --- #666: a local handle fetched from BRep_Tool::, not a wrapper argument ---
+    ('OCCTBridge_Surface.mm', 'OCCTGeomFillCoonsAlgPatchEval'):
+        'measured #666 (Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm): '
+        'GeomAdaptor_Curve raises a catchable Standard_Failure on a null Handle(Geom_Curve), on '
+        'both the 1-arg and the 3-arg (trimmed) constructor - same verdict #618 already recorded '
+        'for OCCTExtremaExtCC, now confirmed for a curve obtained from BRep_Tool::Curve rather '
+        'than a wrapper argument',
 }
 
-FUNC = re.compile(r'^(?:static\s+)?[A-Za-z_][\w:<>,\s\*&]*?\b(\w+)\s*\(([^;{]*?)\)\s*\{', re.M | re.S)
+# extern "C" is tolerated ahead of the return type (#666): without it, a function defined that way
+# is invisible to this regex, guarded or not, because `"` sits outside the return-type character
+# class. Zero real occurrences in this tree motivated it - still worth one line.
+FUNC = re.compile(r'^(?:extern\s*"C"\s*)?(?:static\s+)?[A-Za-z_][\w:<>,\s\*&]*?\b(\w+)\s*'
+                  r'\(([^;{]*?)\)\s*\{', re.M | re.S)
 NOT_A_FUNCTION = {'if', 'for', 'while', 'switch', 'catch', 'return'}
 
 # A C++ named cast and its opening paren; the matching close paren is found by scanning.
@@ -167,6 +255,15 @@ CAST_OPEN = re.compile(r'\b(?:reinterpret_cast|static_cast|const_cast|dynamic_ca
 C_CAST = re.compile(r'\(\s*OCCT\w+\s*\*?\s*\)')
 ASSIGN = re.compile(r'\b(\w+)\s*(=)\s*([^;]*);')
 HANDLE_PARAM = re.compile(r'(?:occ::handle\s*<|\bHandle\s*\()')
+
+# #666: a local Handle of one of the three tracked types, freshly obtained from a BRep_Tool
+# accessor rather than a wrapper argument - the #656 shape. `BRep_Tool::` is a deliberate
+# allowlist, not "any call": see the module docstring for why (672 candidates unrestricted, 63
+# once narrowed to the accessor family OCCT documents as legitimately null-returning).
+LOCAL_HANDLE_DECL = re.compile(
+    r'\b(?:Handle\s*\(\s*(Geom_Curve|Geom2d_Curve|Geom_Surface)\s*\)|'
+    r'occ::handle\s*<\s*(Geom_Curve|Geom2d_Curve|Geom_Surface)\s*>)'
+    r'\s+(\w+)\s*=\s*(BRep_Tool::\w+)\s*\(')
 
 
 def strip_comments(text):
@@ -402,8 +499,63 @@ def unguarded_sites(sources, helpers):
                     continue
                 line = text.count('\n', 0, bs + first) + 1
                 found.append((os.path.basename(path), line, name, param, field,
-                              lines[line - 1].strip() if line <= len(lines) else '', is_array))
+                              lines[line - 1].strip() if line <= len(lines) else '', is_array,
+                              'wrapper'))
     return found
+
+
+def local_handle_sites(sources, helpers):
+    """#666: every local Handle(Geom_Curve)/Handle(Geom2d_Curve)/Handle(Geom_Surface), obtained
+    from a BRep_Tool:: call rather than a wrapper argument, that reaches a use before an IsNull
+    test - the #656 shape. Same (file, line, function, name) shape as unguarded_sites(), tagged
+    'local' in the last field so main()'s report can tell the two origins apart.
+
+    Two things a wrapper argument never needed:
+
+    * A SCOPE FENCE. A later `Handle(...) name = ...` redeclaration of the identical name, later
+      in the same function body, ends the earlier declaration's own tracking window. Without it,
+      two sibling `switch` cases that each declare their own `Handle(Geom_Surface) surf = ...`
+      get conflated into one variable, and a later case's guard is misread as covering an earlier
+      case's unguarded use (see the module docstring's G1) - or the reverse, an earlier unrelated
+      guard on the same name wrongly "protects" a later, genuinely unguarded redeclaration (G2),
+      which is why the use-window also starts at THIS declaration's own end, never before it.
+    """
+    found = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        ctext = strip_casts(text)
+        lines = raw.splitlines()
+        for name, params, bs, be in functions(text):
+            if (os.path.basename(path), name) in ALLOWED:
+                continue
+            body = ctext[bs:be + 1]
+            decls = list(LOCAL_HANDLE_DECL.finditer(body))
+            for i, m in enumerate(decls):
+                var, callee = m.group(3), m.group(4)
+                start_bound = m.end()                    # never before this declaration (G2)
+                end_bound = next((later.start() for later in decls[i + 1:]
+                                   if later.group(3) == var), len(body))   # scope fence (G1)
+                pat = re.compile(r'(?<![\w>.])' + re.escape(var) + r'\b')
+                ev = []
+                for u in pat.finditer(body, start_bound, end_bound):
+                    kind = classify(body, u.start(), u.end(), helpers)
+                    if kind:
+                        ev.append((u.start(), kind))
+                ev.sort()
+                first = next((p for p, k in ev if k == 'use'), None)
+                if first is None or any(k == 'guard' and p < first for p, k in ev):
+                    continue
+                line = text.count('\n', 0, bs + first) + 1
+                found.append((os.path.basename(path), line, name, var, callee,
+                              lines[line - 1].strip() if line <= len(lines) else '', False,
+                              'local'))
+    return found
+
+
+def all_sites(sources):
+    """The full report: both handle origins, one combined list."""
+    helpers = guarding_helpers(sources)
+    return unguarded_sites(sources, helpers) + local_handle_sites(sources, helpers)
 
 
 def bridge_sources():
@@ -453,6 +605,34 @@ int OCCTFixtureE(const OCCTCurve3DRef* refs, int n) {
 int OCCTFixtureF(OCCTCurve3DRef curve) {
     try { Splitter sp; sp.Init(curve->curve); return 1; }
     catch (...) { return 0; }
+}'''),
+    # #666: the #656 shape itself - a local handle from BRep_Tool::, not a wrapper argument.
+    ('local handle from BRep_Tool::, passed onward unguarded (the #656 shape)', '''
+double OCCTFixtureM(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
+    try {
+        double first, last;
+        Handle(Geom2d_Curve) c2d = BRep_Tool::CurveOnSurface(edgeRef->shape, faceRef->shape, first, last);
+        return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
+    } catch (...) { return 0.0; }
+}'''),
+    # #666: FUNC must see through `extern "C"` on the definition line, or this whole function -
+    # an otherwise-plain, otherwise-caught unguarded site - is invisible to every check below.
+    ('extern "C" on the definition line must not hide the function', '''
+extern "C" int OCCTFixtureN(OCCTCurve3DRef curve) {
+    try { Splitter sp; sp.Init(curve->curve); return 1; }
+    catch (...) { return 0; }
+}'''),
+    # #666 (G2): the scope fence's LOWER bound. An unrelated, earlier guard on the same bare name
+    # (here, a same-named parameter) must not be read as covering a later local that shadows it.
+    ('an earlier guard on an unrelated same-named parameter must not shadow a later local', '''
+bool OCCTFixtureO(OCCTSurfaceRef surf, OCCTShapeRef faceRef) {
+    try {
+        if (!surf || surf->surface.IsNull()) return false;
+        {
+            Handle(Geom_Surface) surf = BRep_Tool::Surface(faceRef->shape);
+            return surf->IsUPeriodic();
+        }
+    } catch (...) { return false; }
 }'''),
 ]
 
@@ -512,21 +692,78 @@ int OCCTFixtureL(OCCTCurve3DRef curveRef) {
     if (!curveRef) return 0;
     return occtFixtureToAnalytical(reinterpret_cast<OCCTCurve3D*>(curveRef)->curve, 1e-7) ? 1 : 0;
 }'''),
+    # #666: local handle from BRep_Tool::, guarded before use - the actual #656 fix, reduced.
+    ('local handle from BRep_Tool::, guarded before use', '''
+double OCCTFixtureP(OCCTShapeRef edgeRef, OCCTShapeRef faceRef) {
+    try {
+        double first, last;
+        Handle(Geom2d_Curve) c2d = BRep_Tool::CurveOnSurface(edgeRef->shape, faceRef->shape, first, last);
+        if (c2d.IsNull()) return 0.0;
+        return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
+    } catch (...) { return 0.0; }
+}'''),
+    # #666: a local handle from BRep_Tool:: consumed only by DownCast is the same null-safe
+    # exclusion as a wrapper-derived one - this is the bridge's real Copy()+DownCast clone idiom.
+    ('local handle from BRep_Tool:: consumed only by DownCast', '''
+bool OCCTFixtureQ(OCCTShapeRef faceRef) {
+    try {
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(faceRef->shape);
+        Handle(Geom_Plane) plane = Handle(Geom_Plane)::DownCast(surf);
+        if (plane.IsNull()) return false;
+        return true;
+    } catch (...) { return false; }
+}'''),
+    # #666: local handle from BRep_Tool::, guarded one call frame away by the bridge helper.
+    ('local handle from BRep_Tool::, guarded by the bridge helper it is passed to', '''
+inline bool occtFixtureCurveGuard(const occ::handle<Geom_Curve>& curve, double tol) {
+    if (curve.IsNull()) return false;
+    return true;
+}
+bool OCCTFixtureR(OCCTShapeRef edgeRef) {
+    double first, last;
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edgeRef->shape, first, last);
+    return occtFixtureCurveGuard(curve, 1e-7);
+}'''),
+    # #666 (G1): two sibling scopes reuse the same local name, each independently guarded via
+    # DownCast. Reduced from the real false positive an early version of this detector reported
+    # on OCCTFaceGetPrimaryAxis, where the SECOND case's properly-guarded `surf` was misread as
+    # covering the FIRST case's (also-guarded, but via DownCast) `surf`.
+    ('two sibling scopes reuse the same local name, each independently guarded via DownCast', '''
+bool OCCTFixtureS(OCCTShapeRef faceRef, int mode) {
+    try {
+        if (mode == 0) {
+            Handle(Geom_Surface) surf = BRep_Tool::Surface(faceRef->shape);
+            Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surf);
+            if (p.IsNull()) return false;
+            return true;
+        }
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(faceRef->shape);
+        Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surf);
+        if (c.IsNull()) return false;
+        return true;
+    } catch (...) { return false; }
+}'''),
 ]
 
 
 def self_test():
-    """Prove both failure modes: an unguarded site is reported, a guarded one is not."""
+    """Prove both failure modes: an unguarded site is reported, a guarded one is not.
+
+    Runs every fixture through all_sites() - both the wrapper-argument walk and #666's
+    local-handle walk - since a fixture that only exercises one origin still has to survive the
+    other running over it unharmed (e.g. a local-handle fixture must not trip the wrapper-argument
+    walk, and vice versa).
+    """
     failed = 0
     for name, src in MISSED:
         sources = [('fixture.mm', src)]
-        hit = unguarded_sites(sources, guarding_helpers(sources))
+        hit = all_sites(sources)
         failed += not hit
         print(f'  {"ok  " if hit else "MISS"} unguarded, {name}: '
               f'{hit[0][2] + "(" + hit[0][3] + ")" if hit else "NOT REPORTED"}')
     for name, src in CLEAN:
         sources = [('fixture.mm', src)]
-        hit = unguarded_sites(sources, guarding_helpers(sources))
+        hit = all_sites(sources)
         failed += bool(hit)
         print(f'  {"ok  " if not hit else "FALSE"} guarded, {name}: '
               f'{hit[0][2] + " wrongly reported" if hit else "not reported"}')
@@ -543,18 +780,23 @@ def main():
         print(f'{SRC_DIR} not found - run from the repo root', file=sys.stderr)
         return 2
     sources = bridge_sources()
-    sites = unguarded_sites(sources, guarding_helpers(sources))
+    sites = all_sites(sources)
     if not sites:
         if not quiet:
             print('All bridge functions guard the geometry handle as well as the wrapper pointer.')
             print(f'({len(ALLOWED)} site(s) exempt by name in ALLOWED, each with its reason.)')
         return 0
     if not quiet:
-        print(f'{len(sites)} (function, argument) pair(s) reach OCCT with an unchecked handle:\n')
-        for f, line, func, param, field, src, is_array in sites:
+        print(f'{len(sites)} site(s) reach OCCT with an unchecked handle:\n')
+        for f, line, func, param, field, src, is_array, kind in sites:
             print(f'  {f}:{line}  {func}({param})')
             print(f'      {src}')
-            if is_array:
+            if kind == 'local':
+                # `param` is a local, not a wrapper argument: there is no pointer to null-check
+                # alongside it, just the handle itself, obtained from `field` (the BRep_Tool::
+                # call that produced it).
+                print(f'      obtained from {field}(); want: if ({param}.IsNull()) return <fallback>;')
+            elif is_array:
                 # `param` is a pointer to wrappers, so `param->field` would not compile. The
                 # guard belongs on the element, inside the loop that reads it.
                 print(f'      want, per element of {param}:  '

--- a/Scripts/repro/cluster-c-null-handle-shapes/README.md
+++ b/Scripts/repro/cluster-c-null-handle-shapes/README.md
@@ -29,11 +29,17 @@ method is:
    construction, and this bridge's own established `Copy()`+`DownCast` cloning idiom), or a
    builder's post-success result accessor. None of those is #656's shape, and auditing 672 by hand
    would have been a bigger, less careful repeat of #618's own "blind to indirection" mistake with
-   a different indirection. Narrowing the producer to `BRep_Tool::` - the accessor family OCCT
-   documents as legitimately returning a null handle for ordinary topology (no 3D curve; no pcurve
-   on a given face) - cut it to 63 real declarations of the three tracked types
-   (`Handle(Geom_Curve)`/`Handle(Geom2d_Curve)`/`Handle(Geom_Surface)`, `occ::handle<>` spelling
-   included).
+   a different indirection. Narrowing the producer to `BRep_Tool::` cut it to 63 real declarations
+   of the three tracked types (`Handle(Geom_Curve)`/`Handle(Geom2d_Curve)`/`Handle(Geom_Surface)`,
+   `occ::handle<>` spelling included). At least two members of that family document the null
+   themselves - `BRep_Tool.hxx`'s `Curve` ("May be a Null handle") and `CurveOnSurface` ("Returns
+   a NULL handle if this curve does not exist") - but not all: `Surface(const TopoDS_Face&)`'s own
+   doc comment says only "Returns the geometric surface of the face," no null mentioned anywhere.
+   Tracking `Geom_Surface` through this walk anyway is the right conservative over-approximation -
+   #656's own defect involved `Surface` too, alongside `Curve` and `CurveOnSurface` - but the
+   claim should say what was verified, not what would be tidy: `BRep_Tool::` is tracked as a
+   family because that is the natural boundary this bridge's own accessor usage falls into, not
+   because every member of it documents a null return.
 3. **Reuse, don't reinvent, the existing classification.** Once a local is tracked, it goes through
    the exact same `classify()` - the same DownCast exclusion, the same guarding-helper exclusion -
    that the wrapper-argument walk already uses and this repo's prior censuses (#618, #624/#630)
@@ -200,7 +206,7 @@ PART 2: GeomFill_* family on a null Handle(Geom_Curve), the fifth alias form the
 
   GeomFill_Profiler().AddCurve(nullCurve)                  [OCCTGeomFillProfilerAddCurve]          SIGSEGV (uncatchable)
   GeomFill_SectionGenerator().AddCurve(nullCurve)          [OCCTGeomFillAppSurf, #644's own fn]     SIGSEGV (uncatchable)
-  GeomFill_SectionPlacement(loc, nullCurve) ctor            [OCCTGeomFillSectionPlacement]          SIGSEGV (uncatchable)
+  GeomFill_SectionPlacement(loc, nullCurve) ctor+Perform     [OCCTGeomFillSectionPlacement]          SIGSEGV (uncatchable)
 ```
 
 `OCCTGeomFillAppSurf` is **#644's own function** - and this is a genuinely different bug from the

--- a/Scripts/repro/cluster-c-null-handle-shapes/README.md
+++ b/Scripts/repro/cluster-c-null-handle-shapes/README.md
@@ -138,6 +138,48 @@ named this with "zero occurrences today," confirmed still true by grep - this is
 not a live finding. Real report is unchanged (0 unguarded, same 62/63 split); a dedicated MISSED
 fixture (`extern "C" int OCCTFixtureN(...)`) is what proves the parser can now see through it.
 
+### Shape 3 (follow-up, maintainer-approved, same PR): the constructor-init connector and the `occ::handle<>` fixture gap
+
+Two hardening fixes to `local_handle_sites()` added after the maintainer's own review measured
+both against the real tree and found **zero occurrences of either**, which is why they land here
+rather than as a separate PR: neither can turn the gate red, and the cost is one regex alternation
+plus two fixtures.
+
+**Finding 1: the constructor-init connector.** `LOCAL_HANDLE_DECL` required `name = BRep_Tool::
+...(`. It never matched `name(BRep_Tool::...(` - #656's exact shape, written with parens:
+
+```cpp
+Handle(Geom2d_Curve) c2d(BRep_Tool::CurveOnSurface(edgeRef->shape, faceRef->shape, first, last));
+return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
+```
+
+The module docstring already warned this exact spelling defeats the WRAPPER-ARGUMENT alias binding
+(`Handle(Geom_Curve) w(wrapper->curve);`, `aliases()`'s own blind spot, unrelated to and unchanged
+by this fix) - it applied equally to the new local-handle mechanism and was simply not checked
+there before this pass. Fixed by widening the connector between the variable name and the producer
+call from `=` to `(?:=|\()`, which handles both forms with one alternation since the text after the
+connector (`BRep_Tool::Whatever(`) is identical either way.
+
+**Finding 2: `occ::handle<>` had no fixture for a LOCAL declaration.** The regex and docstring both
+claimed `occ::handle<Geom_Curve> curve = BRep_Tool::Curve(...)` is tracked identically to the
+`Handle(Geom_Curve)` spelling - and it already was, correctly, with no code change needed - but no
+fixture had ever exercised that spelling for a local; the existing `occ::handle<>` fixture (S, the
+bridge-helper one) only uses it for a helper's *parameter* type. Per this PR's own measure-before-
+you-trust standard, an untested claim of coverage is not coverage. Added a dedicated fixture.
+
+Measured before writing either fixture, per the maintainer's own zero-site claim:
+
+```
+local, BRep_Tool producer, constructor-init paren form      : 0 occurrences
+occ::handle<> local declaration with a BRep_Tool producer    : 0 occurrences
+```
+
+Confirmed. Real report stayed at 0 unguarded, same 24 `ALLOWED` entries, both before and after -
+teaching either shape reported nothing new, exactly as the zero-site measurement predicted.
+
+Self-test 19/19 -> 21/21 (two new MISSED fixtures, `T` and `U`); guard-removal proof for both is
+in the extended matrix below.
+
 ### Found, deliberately not taught: a fifth alias form, with three real, live SIGSEGVs
 
 While confirming there was nothing else obviously in scope for #644 (Cluster C's own arity
@@ -208,6 +250,38 @@ confirm the new path actually depends on them rather than merely being adjacent 
 distinction Cluster A's own audit drew between guards J/K (real, but only ever exercised by
 `self_test()`'s own bypass) and guards A/D/G/L (real and load-bearing on the actual corpus).
 
+### Extended: the Shape 3 follow-up (constructor-init connector, `occ::handle<>` local fixture)
+
+Same method, run against the tree with fixtures `T` and `U` added (21 total cases). Both rows below
+are measured against this 21-case baseline, not the 19-case one above:
+
+| guard removed | self-test | FAILS | real report |
+|---|---|---|---|
+| (none, baseline, post follow-up) | 21/21 | | 0 unguarded (same 24 `ALLOWED` entries) |
+| constructor-init connector narrowed back to `=` only | 20/21 | `local handle from BRep_Tool::, constructor-init paren syntax (the #656 shape, no =)` | unchanged (0 real occurrences either way - the maintainer's zero-site measurement holds) |
+| `occ::handle<>` alternative removed from `LOCAL_HANDLE_DECL` | 20/21 | `local handle from BRep_Tool::, occ::handle<> spelling, unguarded` | unchanged (0 real occurrences either way) |
+
+Both rows are single-case failures with no real-report change, exactly as the maintainer's own
+zero-site measurement predicted before either fixture was written - neither shape was a live
+finding, both were pure fixture-coverage gaps.
+
+**A near-miss while building the removal test for the second row, worth recording since it is
+exactly the failure mode this whole exercise exists to catch.** `LOCAL_HANDLE_DECL` has two
+alternative type-spelling groups (`Handle(Type)` is group 1, `occ::handle<Type>` is group 2), so
+removing the `occ::handle<>` alternative shifts every later group index down by one everywhere the
+match is read. The first removal attempt patched `local_handle_sites()`'s own `m.group(3)`/
+`m.group(4)` reads but missed the scope fence's `later.group(3)` comparison a few lines below -
+which silently degraded into comparing a variable name against a producer name, never matching, so
+the scope fence stopped firing for every redeclaration case. That produced a false "1 unguarded,
+CHANGED" result and an unrelated CLEAN-case failure, which would have been read as "removing
+`occ::handle<>` support somehow also breaks the scope fence" - a plausible-sounding but wrong
+conclusion. Fixing the second reference (`later.group(2)`) reproduced the two-guard-removal
+harness correctly, giving the clean, single-case-failure result the table reports. Not a defect in
+the shipped checker - `local_handle_sites()` itself only ever reads `m.group(3)`/`m.group(4)`
+against the REAL, unmodified `LOCAL_HANDLE_DECL`, where the group numbering is fixed and correct -
+only in the throwaway ad hoc removal script built to test it, which is precisely why the *fixed*
+version of the removal test, not the first draft, is what belongs in this table.
+
 ## Which of #636 / #643 / #644 the upgraded checker catches
 
 **None of the three.** This is the expected, correct answer, not a shortfall: none of the three is
@@ -274,6 +348,15 @@ actually a null-handle-guard defect in the bridge.
   named members turned out to need no checker change to explain (#636, #644) or were already
   bridge-side mitigated (#643); the fifth alias form and its three live SIGSEGVs were not on
   anyone's list going in.
+- **The Shape 3 follow-up's own zero-site measurement held, but the verification harness built to
+  prove it needed its own fix first.** The maintainer's pre-review measurement (0 occurrences of
+  both the constructor-init and `occ::handle<>`-local forms) was independently reproduced before
+  either fixture was written, and both post-fixture guard-removal rows confirm it: single-case
+  self-test failures, zero real-report change. The one wrinkle was in the removal *test* itself, not
+  the shipped detector - see the extended guard-removal matrix's note on the `occ::handle<>` group-
+  index near-miss. Recorded because it is a small, concrete instance of exactly the risk
+  `okf/policies/prove-the-test-fails.md` warns about: a removal check that looks right on first
+  read can still be measuring the wrong thing.
 
 ## Does this belong in the shared `Censuses` target too?
 

--- a/Scripts/repro/cluster-c-null-handle-shapes/README.md
+++ b/Scripts/repro/cluster-c-null-handle-shapes/README.md
@@ -19,45 +19,33 @@ free - which is worth more than fixing the three known members by hand.
 ## Method
 
 One artifact, not two independent halves like Cluster A/B: there is no dynamic Swift-level
-behaviour to census here (see "Does this belong in the shared `Censuses` target?" below). The
-method is:
+behaviour to census here (see "Does this belong in the shared `Censuses` target?" below).
 
 1. **Baseline.** Run the checker and its `--self-test` as they stand, before any change.
 2. **Design the new shape from the one proven instance (#656), then measure its true scope.**
    "Any local `Handle` initialised from any call" was tried first and matched 672 declarations
    tree-wide - almost all `new T(...)` (never null), a same-family `DownCast` (null-safe by
-   construction, and this bridge's own established `Copy()`+`DownCast` cloning idiom), or a
-   builder's post-success result accessor. None of those is #656's shape, and auditing 672 by hand
-   would have been a bigger, less careful repeat of #618's own "blind to indirection" mistake with
-   a different indirection. Narrowing the producer to `BRep_Tool::` cut it to 63 real declarations
-   of the three tracked types (`Handle(Geom_Curve)`/`Handle(Geom2d_Curve)`/`Handle(Geom_Surface)`,
-   `occ::handle<>` spelling included). At least two members of that family document the null
-   themselves - `BRep_Tool.hxx`'s `Curve` ("May be a Null handle") and `CurveOnSurface` ("Returns
-   a NULL handle if this curve does not exist") - but not all: `Surface(const TopoDS_Face&)`'s own
-   doc comment says only "Returns the geometric surface of the face," no null mentioned anywhere.
-   Tracking `Geom_Surface` through this walk anyway is the right conservative over-approximation -
-   #656's own defect involved `Surface` too, alongside `Curve` and `CurveOnSurface` - but the
-   claim should say what was verified, not what would be tidy: `BRep_Tool::` is tracked as a
-   family because that is the natural boundary this bridge's own accessor usage falls into, not
-   because every member of it documents a null return.
+   construction), or a builder's post-success result accessor. None of those is #656's shape, and
+   auditing 672 by hand would have repeated #618's own "blind to indirection" mistake with a
+   different indirection. Narrowing the producer to `BRep_Tool::` cut it to 63 real declarations of
+   the three tracked types (`Handle(Geom_Curve)`/`Handle(Geom2d_Curve)`/`Handle(Geom_Surface)`,
+   `occ::handle<>` included). At least two members of that family document the null themselves -
+   `BRep_Tool.hxx`'s `Curve` ("May be a Null handle") and `CurveOnSurface` ("Returns a NULL handle
+   if this curve does not exist") - but `Surface(const TopoDS_Face&)` documents no such thing.
+   Tracking it anyway is a conservative over-approximation, not a documented-null claim.
 3. **Reuse, don't reinvent, the existing classification.** Once a local is tracked, it goes through
    the exact same `classify()` - the same DownCast exclusion, the same guarding-helper exclusion -
    that the wrapper-argument walk already uses and this repo's prior censuses (#618, #624/#630)
-   already hardened. The only new machinery is finding the declarations and fencing their scope
-   (see "Two things a wrapper argument never needed" below).
+   already hardened. The only new machinery is finding the declarations and resolving their scope.
 4. **Prove the design against the one instance we know is real**, not just synthetic fixtures:
    reverting `OCCTBRepToolsEvalAndUpdateTol` to its pre-#656 state (guarding `c3d`/`surf` but not
-   `c2d`) and confirming the upgraded detector reports `c2d` unguarded - the actual historical bug,
-   not a stand-in for it.
-5. **Run the upgraded checker over the real tree and triage every new finding**, per #666's own
-   instruction that a new finding is not automatically a defect: an OCCT call that copes (returns
-   normally, or raises a catchable `Standard_Failure` the surrounding `catch (...)` already
-   handles) is noise, not a bug, and gets an `ALLOWED` entry with a measured reason, matching
-   #556/#618's own standard.
-6. **Guard-removal matrix.** Every new conditional the upgrade introduces - not just the MISSED/CLEAN
-   fixture pass rate - is individually neutered and the self-test and real report are re-measured,
-   per this repo's `okf/policies/prove-the-test-fails.md` and Cluster A's own finding that a
-   `--self-test` can pass 6/6 while several of its guards have zero real coverage.
+   `c2d`) and confirming the upgraded detector reports `c2d` unguarded.
+5. **Run the upgraded checker over the real tree and triage every new finding.** A new finding is
+   not automatically a defect: an OCCT call that copes (returns normally, or raises a catchable
+   `Standard_Failure` the surrounding `catch (...)` already handles) is noise, and gets an `ALLOWED`
+   entry with a measured reason, matching #556/#618's own standard.
+6. **Guard-removal matrix.** Every new conditional the upgrade introduces is individually neutered
+   and the self-test and real report are re-measured, per `okf/policies/prove-the-test-fails.md`.
 
 ```bash
 python3 Scripts/check-null-handle-guards.py
@@ -245,16 +233,13 @@ one at a time, against both the self-test suite and the real report over
 | `classify()`'s guarding-helper exclusion removed (shared) | 17/19 | 2 CLEAN cases, one old, one new | **CHANGED**: 2 unguarded - same confirmation, for the other shared exclusion |
 
 **Every guard this upgrade adds is load-bearing on both axes** (a self-test case catches its
-removal, and the real report changes): G1 and G2 are new, and both reproduce a real failure mode
-found while building the detector rather than invented for the fixture afterward. The `extern "C"`
-row is the one exception - it stays at "unchanged" on the real report because there are zero real
-occurrences to change, which is the expected result for hardening against a theoretical case, not
-evidence the guard is decorative (its self-test row still fails without it).
-
-The last two rows are not new logic; they re-run existing guards through the new code path to
-confirm the new path actually depends on them rather than merely being adjacent to them - the same
-distinction Cluster A's own audit drew between guards J/K (real, but only ever exercised by
-`self_test()`'s own bypass) and guards A/D/G/L (real and load-bearing on the actual corpus).
+removal, and the real report changes): G1 and G2 both reproduce a real failure mode found while
+building the detector, not one invented for the fixture afterward. The `extern "C"` row is the one
+exception - it stays "unchanged" on the real report because there are zero real occurrences to
+change, the expected result for hardening against a theoretical case, not evidence of decoration
+(its self-test row still fails without it). The last two rows re-run existing, already-hardened
+`classify()` exclusions through the new code path, confirming the new path actually depends on the
+shared logic rather than a parallel copy of it.
 
 ### Extended: the Shape 3 follow-up (constructor-init connector, `occ::handle<>` local fixture)
 
@@ -271,22 +256,13 @@ Both rows are single-case failures with no real-report change, exactly as the ma
 zero-site measurement predicted before either fixture was written - neither shape was a live
 finding, both were pure fixture-coverage gaps.
 
-**A near-miss while building the removal test for the second row, worth recording since it is
-exactly the failure mode this whole exercise exists to catch.** `LOCAL_HANDLE_DECL` has two
-alternative type-spelling groups (`Handle(Type)` is group 1, `occ::handle<Type>` is group 2), so
-removing the `occ::handle<>` alternative shifts every later group index down by one everywhere the
-match is read. The first removal attempt patched `local_handle_sites()`'s own `m.group(3)`/
-`m.group(4)` reads but missed the scope fence's `later.group(3)` comparison a few lines below -
-which silently degraded into comparing a variable name against a producer name, never matching, so
-the scope fence stopped firing for every redeclaration case. That produced a false "1 unguarded,
-CHANGED" result and an unrelated CLEAN-case failure, which would have been read as "removing
-`occ::handle<>` support somehow also breaks the scope fence" - a plausible-sounding but wrong
-conclusion. Fixing the second reference (`later.group(2)`) reproduced the two-guard-removal
-harness correctly, giving the clean, single-case-failure result the table reports. Not a defect in
-the shipped checker - `local_handle_sites()` itself only ever reads `m.group(3)`/`m.group(4)`
-against the REAL, unmodified `LOCAL_HANDLE_DECL`, where the group numbering is fixed and correct -
-only in the throwaway ad hoc removal script built to test it, which is precisely why the *fixed*
-version of the removal test, not the first draft, is what belongs in this table.
+A near-miss while building the removal test for the second row: the first attempt at a throwaway
+"remove `occ::handle<>` support" script patched `local_handle_sites()`'s own group reads but missed
+a downstream group-index reference in the fence, silently breaking the fence for every case and
+producing a false "1 unguarded" result that would have read as "removing `occ::handle<>` somehow
+also breaks the scope fence." Not a defect in the shipped checker - only in the ad hoc removal
+script - but exactly the class of mistake `okf/policies/prove-the-test-fails.md` warns a removal
+check itself needs checking, so it is recorded here rather than silently fixed and forgotten.
 
 ## Which of #636 / #643 / #644 the upgraded checker catches
 
@@ -320,81 +296,82 @@ actually a null-handle-guard defect in the bridge.
   defect - see "Found, deliberately not taught" above and #710. The upgraded checker does not
   catch #644 as filed, and does not catch #710 either, by the design choice recorded there.
 
-## Corrections and things worth a sentence
+## Round-2 review (same PR): nine findings, addressed
 
-- **#666's own framing held up on measurement**: "teach the checker that shape first... it then
-  enumerates the rest of the family for free" is exactly what happened - one shape, taught once,
-  found the one real remaining instance (already fixed) and one genuinely new one (measured-safe),
-  with no per-function hand-auditing needed beyond triaging what the walk reported.
-- **CLAUDE.md's constructor-init false-positive claim was checked, not just repeated.** `Handle
-  (Geom_Curve) w(wrapper->curve);` uses no `=`, so `aliases()`'s `ASSIGN`-based binding recognition
-  never sees it as a copy - but the wrapper's own `wrapper->curve` occurrence, sitting right there
-  as a constructor argument, textually matches the existing direct-use pattern and gets classified
-  through `enclosing_call` returning `('w', 0)`, which is not a recognised helper, so it falls
-  through to `'use'`. Confirmed by direct trace-through of `classify()`/`enclosing_call()`, not
-  reasoned about in the abstract: the claim is accurate, and remains unaddressed, per this census's
-  scope (CLAUDE.md's list was correct here; nothing to correct, worth recording that verification
-  happened rather than assuming the docstring's word for it).
-- **`ALLOWED`'s `(file, function)` keying is now coarser than before, not just still-coarse.**
-  Before this census, a function name in `ALLOWED` exempted every wrapper-argument finding
-  `unguarded_sites()` could report for it. After this census, the identical entry ALSO exempts
-  anything `local_handle_sites()` finds for that same function name - a function cleared for one
-  reason now silently covers a second, unrelated reason too, with no way to tell from the table
-  which remit an entry was actually measured against. Not changed here: splitting the key (e.g.
-  `(file, function, origin)`) would double the bookkeeping for a table whose real safeguard has
-  always been "lives in a tracked file, survives review," and the same review discipline already
-  required for every entry extends naturally to asking "does this also cover a local handle" when
-  touching one. Worth revisiting if a function ever collects both an `ALLOWED` wrapper-argument
-  entry and a genuinely different local-handle finding that shouldn't share its reasoning - not
-  observed in this tree today.
-- **A new, previously unreported defect (#710) was worth more than confirming the three known
-  ones.** Consistent with every prior cluster census on this workstream: the checker upgrade's own
-  investigation - reading every real call site the new shape's design touched, not just running the
-  fixtures - found something none of #666, #644, or CLAUDE.md's blind-spot list mentioned. The three
-  named members turned out to need no checker change to explain (#636, #644) or were already
-  bridge-side mitigated (#643); the fifth alias form and its three live SIGSEGVs were not on
-  anyone's list going in.
-- **The Shape 3 follow-up's own zero-site measurement held, but the verification harness built to
-  prove it needed its own fix first.** The maintainer's pre-review measurement (0 occurrences of
-  both the constructor-init and `occ::handle<>`-local forms) was independently reproduced before
-  either fixture was written, and both post-fixture guard-removal rows confirm it: single-case
-  self-test failures, zero real-report change. The one wrinkle was in the removal *test* itself, not
-  the shipped detector - see the extended guard-removal matrix's note on the `occ::handle<>` group-
-  index near-miss. Recorded because it is a small, concrete instance of exactly the risk
-  `okf/policies/prove-the-test-fails.md` warns about: a removal check that looks right on first
-  read can still be measuring the wrong thing.
+A second, independent automated review round found nine more issues, none blocking the census
+conclusion above and all now fixed rather than deferred, since each was small and each landed
+before the gate was ever red for it:
+
+- **Headline, verified before fixing anything: the constructor-init connector `Handle(Geom_Curve)
+  curve(wrapper->curve);` really was reachable through `local_handle_sites()` too**, the identical
+  syntax variant CLAUDE.md already names as defeating the WRAPPER-argument walk's alias binding.
+  Confirmed live against the real detector (`Scripts/check-null-handle-guards.py`'s own docstring
+  covers the found-and-fixed distinction between the two mechanisms in detail); fixed in
+  `LOCAL_HANDLE_DECL`'s connector, fixture `T`.
+- **The scope fence was textual, not scope-aware, in two confirmed ways**: a sibling redeclaration
+  from any producer other than `BRep_Tool::` never fenced anything, and a redeclaration inside a
+  nested block ended the OUTER variable's tracking window right there, dropping a real use of the
+  outer variable resuming after the block closes - reproduced as a genuine miss (fixture `W`), not
+  a theoretical one. `var_declarations()`/`binds_to()` replace it with real C++ block-scope binding.
+  See the checker's own docstring (`local_handle_sites()`) for the full mechanism.
+- **A mid-window reassignment of a tracked local was misclassified as an unguarded use** - the
+  local-handle walk's missing counterpart to `unguarded_sites()`'s own `spans` exclusion. Fixed;
+  fixture `X` reproduces the false positive against the pre-fix code.
+- `probe_cluster_c.mm`'s `fork()` return was unchecked; a failure fell through to a misread verdict
+  of "returned normally." Fixed: reported as its own verdict.
+- The docstring wrongly claimed the `extern "C" { ... }` block form was still blind. It never was -
+  a function nested in such a block has no `extern "C"` text on its own signature line, so `FUNC`
+  parses it exactly like any other function. Corrected; fixture `V` locks it in.
+- `self_test()` proved only that the COMBINED `all_sites()` result was right per fixture, which
+  cannot distinguish "the mechanism this fixture is for still works" from "some other mechanism
+  compensated." Fixtures are now tagged by mechanism and checked against it directly too.
+- The `ALLOWED` table's `(file, function)` keying now also exempts `local_handle_sites()` findings,
+  not just `unguarded_sites()`'s - re-audited by measurement (clearing every exemption from the
+  local-handle walk surfaces exactly the one already-known finding, nothing hidden behind the other
+  23 entries today); the keying itself stays as the maintainer's own prior review round already
+  decided, for the reasons recorded in the checker's docstring.
+- The split declare-then-assign shape (`Handle(Geom_Curve) c; ... c = BRep_Tool::Curve(...);`) was
+  named as a blind spot without ever being measured. Measured now: zero occurrences tree-wide.
+- Cleanup-only, no behaviour change: `all_sites()` re-parsed every source file three times
+  (`parse_sources()` now shares one parse across all three walks); the report tuple's dual-purpose
+  `field`/`callee` slot is a named `Site.detail` now; this README was trimmed - it had grown past
+  this project's `docs/` norms and its own cited `556-null-handle-guard-sweep` precedent by
+  carrying its own review log, which is exactly the ephemeral content CLAUDE.md says not to commit.
+
+Guard-removal proof for the two new load-bearing guards (scope binding, reassignment exclusion):
+
+| guard removed | self-test | FAILS | real report |
+|---|---|---|---|
+| (none, baseline, post round-2) | 24/24 | | 0 unguarded (same 24 `ALLOWED` entries) |
+| scope fence reverted to the old textual "next same-name `BRep_Tool::` redeclaration" mechanism (reassignment exclusion kept) | 23/24 | `outer local resumes after a nested same-named redeclaration closes; the outer use is real` | unchanged (0 real occurrences either way) |
+| reassignment exclusion removed (scope binding kept) | 23/24 | `a plain reassignment of the tracked name is a rebind, not a read, even mid-window` | unchanged (0 real occurrences either way) |
+| both removed together (full revert to the pre-round-2 mechanism) | 22/24 | both of the above | unchanged |
+
+Both guards are new hardening against shapes with zero occurrences in this tree today, same as the
+Shape 3 follow-up's own two rows above - the real report does not move, only the self-test does,
+which is the expected signature for a fixture proving a fix rather than a live finding.
 
 ## Does this belong in the shared `Censuses` target too?
 
-**No - the gate script is the whole artifact, and here is why**, since Cluster A/B's own censuses
-both did add a `Censuses` entry and #666 explicitly asks the question.
-
-Cluster A and B's censuses are fundamentally **dynamic**: their subject is what a real call to a
-real public API returns on a real fixture (`box.edgeCount`, `filleted(edges:radius:)`'s duplicate-
-index behaviour), which only exists as a runtime measurement - a static read of the source could
-describe the code's *intent* but not what the built kernel actually does, so a Swift executable
-that builds fixtures and calls the API was the correct primary evidence, with a source-text
-classifier as secondary cross-check.
+**No.** Cluster A/B's censuses are fundamentally **dynamic**: their subject is what a real call to
+a real public API returns on a real fixture, which only exists as a runtime measurement, so a
+Swift executable calling the API was the right primary evidence there.
 
 This census's subject is the opposite: **a source-level shape in `Sources/OCCTBridge/src/*.mm`
 text** - does a local `Handle` declaration reach a use before an `IsNull()` check. That is exactly
-what `Scripts/check-null-handle-guards.py` already exists to answer, and it is not a question a
-Swift program calling the public API could answer at all: the public API never exposes "is this
-specific internal C++ line guarded," only whatever behaviour results once it is or isn't. Where
-this census DID need runtime evidence - is a specific unguarded call actually safe, or does it
-crash - the answer came from a direct, forked, OCCT-linked C++ probe
-(`probe_cluster_c.mm`), the same shape `Scripts/repro/556-null-handle-guard-sweep/repro_556.mm`
-already established as this family's own dynamic-evidence idiom, not from the Swift `Censuses`
-target: there is no Swift-level API to route a null `Handle(Geom_Curve)` into
-`BRepTools::EvalAndUpdateTol` or `GeomFill_SectionGenerator::AddCurve` and observe the crash from
-the Swift side, since the whole point is that the bridge is supposed to refuse it before OCCT ever
-sees it.
+what `Scripts/check-null-handle-guards.py` already exists to answer, and it is not a question the
+public Swift API could answer at all - it never exposes "is this internal C++ line guarded," only
+whatever behaviour results once it is or isn't. Where this census DID need runtime evidence - is a
+specific unguarded call actually safe, or does it crash - the answer came from a direct, forked,
+OCCT-linked C++ probe (`probe_cluster_c.mm`), the same idiom
+`Scripts/repro/556-null-handle-guard-sweep/repro_556.mm` already established for this family: there
+is no Swift-level way to route a null `Handle(Geom_Curve)` into `BRepTools::EvalAndUpdateTol` or
+`GeomFill_SectionGenerator::AddCurve` and observe the crash, since the bridge is supposed to refuse
+it before OCCT ever sees it.
 
-So: `python3 Scripts/check-null-handle-guards.py` (the enumeration, "for free" once the shape is
-taught) plus `probe_cluster_c.mm` (the crash-or-catch measurement for each finding) are the
-complete artifact. Nothing here would gain evidentiary value from a `ClusterC.swift` in the shared
-target, and adding one would just be a second, weaker copy of what the gate script already does
-authoritatively.
+So the checker (the enumeration, "for free" once the shape is taught) plus `probe_cluster_c.mm`
+(the crash-or-catch measurement per finding) are the complete artifact; a `ClusterC.swift` in the
+shared target would just be a second, weaker copy of what the gate script already does.
 
 ## Verify
 

--- a/Scripts/repro/cluster-c-null-handle-shapes/README.md
+++ b/Scripts/repro/cluster-c-null-handle-shapes/README.md
@@ -1,0 +1,322 @@
+# Cluster C census (#666): teaching the null-handle checker the #656 shape
+
+This directory is the census only. It does not fix #636, #643 or #644, Cluster C's three members.
+
+## The shared root, and why this census is a checker upgrade rather than a new probe
+
+`Scripts/check-null-handle-guards.py` already gates this family and runs in CI's `gate-scripts`
+job. It verifies that a bridge function guards its own `OCCTCurve3DRef`/`OCCTCurve2DRef`/
+`OCCTSurfaceRef` *argument* - both the wrapper pointer and the `Handle` inside it - before passing
+it to OCCT. #656 (`OCCTBRepToolsEvalAndUpdateTol`, already fixed on this branch) proved the checker
+blind to a second, independent origin for a risky handle: one fetched locally, mid-body, from
+`BRep_Tool::CurveOnSurface(edge, face, ...)`, never a wrapper argument at all, and handed straight
+to `BRepTools::EvalAndUpdateTol`, which dereferences it unconditionally. Every existing check
+reported that function clean while it SIGSEGV'd on ordinary topology.
+
+The job here is to teach the checker that shape, then let it enumerate the rest of the family for
+free - which is worth more than fixing the three known members by hand.
+
+## Method
+
+One artifact, not two independent halves like Cluster A/B: there is no dynamic Swift-level
+behaviour to census here (see "Does this belong in the shared `Censuses` target?" below). The
+method is:
+
+1. **Baseline.** Run the checker and its `--self-test` as they stand, before any change.
+2. **Design the new shape from the one proven instance (#656), then measure its true scope.**
+   "Any local `Handle` initialised from any call" was tried first and matched 672 declarations
+   tree-wide - almost all `new T(...)` (never null), a same-family `DownCast` (null-safe by
+   construction, and this bridge's own established `Copy()`+`DownCast` cloning idiom), or a
+   builder's post-success result accessor. None of those is #656's shape, and auditing 672 by hand
+   would have been a bigger, less careful repeat of #618's own "blind to indirection" mistake with
+   a different indirection. Narrowing the producer to `BRep_Tool::` - the accessor family OCCT
+   documents as legitimately returning a null handle for ordinary topology (no 3D curve; no pcurve
+   on a given face) - cut it to 63 real declarations of the three tracked types
+   (`Handle(Geom_Curve)`/`Handle(Geom2d_Curve)`/`Handle(Geom_Surface)`, `occ::handle<>` spelling
+   included).
+3. **Reuse, don't reinvent, the existing classification.** Once a local is tracked, it goes through
+   the exact same `classify()` - the same DownCast exclusion, the same guarding-helper exclusion -
+   that the wrapper-argument walk already uses and this repo's prior censuses (#618, #624/#630)
+   already hardened. The only new machinery is finding the declarations and fencing their scope
+   (see "Two things a wrapper argument never needed" below).
+4. **Prove the design against the one instance we know is real**, not just synthetic fixtures:
+   reverting `OCCTBRepToolsEvalAndUpdateTol` to its pre-#656 state (guarding `c3d`/`surf` but not
+   `c2d`) and confirming the upgraded detector reports `c2d` unguarded - the actual historical bug,
+   not a stand-in for it.
+5. **Run the upgraded checker over the real tree and triage every new finding**, per #666's own
+   instruction that a new finding is not automatically a defect: an OCCT call that copes (returns
+   normally, or raises a catchable `Standard_Failure` the surrounding `catch (...)` already
+   handles) is noise, not a bug, and gets an `ALLOWED` entry with a measured reason, matching
+   #556/#618's own standard.
+6. **Guard-removal matrix.** Every new conditional the upgrade introduces - not just the MISSED/CLEAN
+   fixture pass rate - is individually neutered and the self-test and real report are re-measured,
+   per this repo's `okf/policies/prove-the-test-fails.md` and Cluster A's own finding that a
+   `--self-test` can pass 6/6 while several of its guards have zero real coverage.
+
+```bash
+python3 Scripts/check-null-handle-guards.py
+python3 Scripts/check-null-handle-guards.py --self-test
+```
+
+## Baseline (before this census)
+
+```
+$ python3 Scripts/check-null-handle-guards.py --self-test
+... 12/12 cases correct
+$ python3 Scripts/check-null-handle-guards.py
+All bridge functions guard the geometry handle as well as the wrapper pointer.
+(23 site(s) exempt by name in ALLOWED, each with its reason.)
+```
+
+Zero unguarded sites, because the checker had no way to look for the #656 shape at all - not
+because nothing like it existed. #656 itself was already fixed on this branch before this census
+started, so "0 unguarded" at baseline is not evidence of anything; it is the blind spot itself.
+
+## What was taught, and what each newly finds
+
+### Shape 1 (mandatory): a local handle obtained from `BRep_Tool::`, not a wrapper argument
+
+`local_handle_sites()` in the checker. Scope: `Handle(Geom_Curve)`/`Handle(Geom2d_Curve)`/
+`Handle(Geom_Surface)` (or `occ::handle<>` spelling) declared as `name = BRep_Tool::Whatever(...)`.
+
+**Measured over the real tree: 63 declarations, 62 already guarded, 1 not.**
+
+The one: `OCCTGeomFillCoonsAlgPatchEval` (`OCCTBridge_Surface.mm:2375`), inside a local lambda,
+builds `new GeomAdaptor_Curve(curve, f, l)` from a `curve` obtained via `BRep_Tool::Curve` with no
+`IsNull()` check. Triaged as **measured-safe, not a defect**: `probe_cluster_c.mm` PART 1 confirms
+`GeomAdaptor_Curve` raises a catchable `Standard_Failure` on a null `Handle(Geom_Curve)`, on both
+the 1-arg and the 3-arg (trimmed) constructor form used here - the same verdict #618 already
+recorded in `ALLOWED` for `OCCTExtremaExtCC`'s wrapper-argument call to the same constructor, now
+confirmed for a curve arriving by this second route too:
+
+```
+$ /tmp/probe_cluster_c   (built from Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm)
+PART 1: GeomAdaptor_Curve on a null Handle(Geom_Curve) (ALLOWED entry for OCCTGeomFillCoonsAlgPatchEval)
+
+  GeomAdaptor_Curve(nullCurve) [1-arg, whole curve]                    Standard_Failure (catchable)
+  new GeomAdaptor_Curve(nullCurve, 0.0, 1.0) [3-arg, trimmed]          Standard_Failure (catchable)
+  new GeomAdaptor_Curve(nullCurve, 0.0, 1.0) then ->Value(0.5)         Standard_Failure (catchable)
+```
+
+Added to `ALLOWED`:
+
+```python
+('OCCTBridge_Surface.mm', 'OCCTGeomFillCoonsAlgPatchEval'):
+    'measured #666 (Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm): '
+    'GeomAdaptor_Curve raises a catchable Standard_Failure on a null Handle(Geom_Curve), on '
+    'both the 1-arg and the 3-arg (trimmed) constructor - same verdict #618 already recorded '
+    'for OCCTExtremaExtCC, now confirmed for a curve obtained from BRep_Tool::Curve rather '
+    'than a wrapper argument',
+```
+
+The other 62 already guard their local before the first dereferencing use, including
+`OCCTBRepToolsEvalAndUpdateTol` itself (`c3d`, `c2d`, `surf`, all three now correctly recognised
+GUARDED).
+
+**Two mechanisms this shape needed that the wrapper-argument walk did not**, both found by testing
+the design against a REAL function rather than trusting the fixtures alone:
+
+- **A producer allowlist, not "any call."** Covered above. The 672-vs-63 gap is itself evidence:
+  most locally-obtained handles in this bridge are safe by construction or by an existing
+  post-success check, and a detector that flagged all 672 would have buried one real finding in
+  hundreds of false ones - the same failure shape as #618's own "blind to indirection" bug, just
+  inverted (too broad instead of too narrow).
+- **A scope fence.** This bridge reuses generic local names (`surf`, `curve`, `pcurve`) across
+  sibling blocks in one function - most visibly a `switch` with one `Handle(Geom_Surface) surf =
+  BRep_Tool::Surface(...)` per `case`. An early version of this detector, built and run against the
+  real tree before any self-test fixture was written for it, mistook `OCCTFaceGetPrimaryAxis`'s
+  **second** `case`'s properly-guarded `surf` for a continuation of the **first** `case`'s `surf`
+  (consumed only by `DownCast`, itself null-safe) and reported the first as unguarded - a false
+  positive that would not have survived review, caught here before it shipped rather than after.
+  Fixed by treating a later `Handle(...) name = ...` redeclaration of the identical name, anywhere
+  later in the same function body, as the end of the earlier declaration's own tracking window.
+
+### Shape 2: `extern "C"` on the definition line no longer hides the function
+
+One-line `FUNC` regex fix (an optional `extern\s*"C"\s*` prefix). CLAUDE.md's own blind-spot list
+named this with "zero occurrences today," confirmed still true by grep - this is pure hardening,
+not a live finding. Real report is unchanged (0 unguarded, same 62/63 split); a dedicated MISSED
+fixture (`extern "C" int OCCTFixtureN(...)`) is what proves the parser can now see through it.
+
+### Found, deliberately not taught: a fifth alias form, with three real, live SIGSEGVs
+
+While confirming there was nothing else obviously in scope for #644 (Cluster C's own arity
+member), `OCCTBridge_Surface.mm` turned out to have nine sites shaped
+
+```objc
+const Handle(Geom_Curve)& curve = *(const Handle(Geom_Curve)*)curveRef;
+```
+
+- a raw pointer reinterpretation that exploits the wrapper struct's one-field layout, syntactically
+unrelated to `IDENT->field` and invisible to `aliases()` regardless of whether it is guarded. Six
+of the nine are safe in substance (immediately wrapped in `GeomAdaptor_Curve`, measured above to
+raise a catchable exception on null). **Three are not** - measured directly, each SIGSEGVs
+(uncatchable) on a null `Handle(Geom_Curve)`:
+
+```
+PART 2: GeomFill_* family on a null Handle(Geom_Curve), the fifth alias form the checker still cannot see
+
+  GeomFill_Profiler().AddCurve(nullCurve)                  [OCCTGeomFillProfilerAddCurve]          SIGSEGV (uncatchable)
+  GeomFill_SectionGenerator().AddCurve(nullCurve)          [OCCTGeomFillAppSurf, #644's own fn]     SIGSEGV (uncatchable)
+  GeomFill_SectionPlacement(loc, nullCurve) ctor            [OCCTGeomFillSectionPlacement]          SIGSEGV (uncatchable)
+```
+
+`OCCTGeomFillAppSurf` is **#644's own function** - and this is a genuinely different bug from the
+one #644 files: #644 is a valid single curve tripping an arity requirement inside `GeomFill_AppSurf`
+itself; this is *any* null curve, at *any* count, tripping `GeomFill_SectionGenerator::AddCurve`
+before `GeomFill_AppSurf` is even reached. Neither #644's issue text nor CLAUDE.md's blind-spot
+list mentions this fifth form.
+
+**Not taught here, and not fixed here.** Teaching the checker this shape would immediately turn it
+red on these three real sites - out of bounds for a census-only PR (the verify checklist requires
+the checker to still exit 0). Fixing three more bridge functions, each needing its own
+fallback-semantics and regression-test pass per this repo's "prove the test fails" policy, is
+equally out of bounds for "census only." **Filed as
+[#710](https://github.com/SecondMouseAU/OCCTSwift/issues/710)** with the measurement, the specific
+lines, and the suggested fix (teach the shape and fix the three sites together, in that follow-up,
+so the gate is never red for a commit in between). See `probe_cluster_c.mm` PART 2 for the
+reproducer.
+
+## Guard-removal matrix
+
+Per `okf/policies/prove-the-test-fails.md` and Cluster A's own corrective finding that a
+`--self-test` passing 6/6 is not evidence a guard is load-bearing until it has actually been
+removed and shown to change the outcome. Every new conditional this upgrade introduces, neutered
+one at a time, against both the self-test suite and the real report over
+`Sources/OCCTBridge/src/*.mm`:
+
+| guard removed | self-test | FAILS | real report |
+|---|---|---|---|
+| (none, baseline, post-upgrade) | 19/19 | | 0 unguarded (62/63 guarded, 1 in ALLOWED) |
+| G1: scope fence (`end_bound`) removed | 18/19 | `two sibling scopes reuse the same local name, each independently guarded via DownCast` | **CHANGED**: 1 unguarded - reproduces the exact `OCCTFaceGetPrimaryAxis` false positive found while building this detector |
+| G2: start bound (`start_bound`) removed | 15/19 | 4 CLEAN cases, all four local-handle CLEAN fixtures | **CHANGED, badly**: 62 unguarded - an earlier unrelated guard on the same bare name anywhere in the function is misread as covering every later declaration of that name |
+| `extern "C"` tolerance in `FUNC` removed | 18/19 | `extern "C" on the definition line must not hide the function` | unchanged (0 real occurrences either way; this guard is pure hardening) |
+| `ALLOWED` exemption removed from `local_handle_sites` | 19/19 | none | **CHANGED**: 1 unguarded - `OCCTGeomFillCoonsAlgPatchEval` reappears, confirming the exemption is what keeps the gate green for the one measured-safe finding |
+| producer allowlist widened to any call, not just `BRep_Tool::` | 19/19 | none | **CHANGED**: 18 unguarded (of 672 total candidates) - confirms the allowlist is doing real filtering, not decoration; none of the 18 was independently investigated, since widening the allowlist was never proposed as the actual design |
+| `classify()`'s `DownCast` exclusion removed (shared; now also exercises the new local-handle path) | 16/19 | 3 CLEAN cases, including 2 of the 3 new local-handle DownCast/redeclaration fixtures | **CHANGED**: 237 unguarded - this exclusion was already load-bearing for the wrapper-argument walk (per #556/#618); confirms the new local-handle path depends on the identical shared logic, not a parallel copy of it |
+| `classify()`'s guarding-helper exclusion removed (shared) | 17/19 | 2 CLEAN cases, one old, one new | **CHANGED**: 2 unguarded - same confirmation, for the other shared exclusion |
+
+**Every guard this upgrade adds is load-bearing on both axes** (a self-test case catches its
+removal, and the real report changes): G1 and G2 are new, and both reproduce a real failure mode
+found while building the detector rather than invented for the fixture afterward. The `extern "C"`
+row is the one exception - it stays at "unchanged" on the real report because there are zero real
+occurrences to change, which is the expected result for hardening against a theoretical case, not
+evidence the guard is decorative (its self-test row still fails without it).
+
+The last two rows are not new logic; they re-run existing guards through the new code path to
+confirm the new path actually depends on them rather than merely being adjacent to them - the same
+distinction Cluster A's own audit drew between guards J/K (real, but only ever exercised by
+`self_test()`'s own bypass) and guards A/D/G/L (real and load-bearing on the actual corpus).
+
+## Which of #636 / #643 / #644 the upgraded checker catches
+
+**None of the three.** This is the expected, correct answer, not a shortfall: none of the three is
+actually a null-handle-guard defect in the bridge.
+
+- **#636** (`Curve3D.extrema` SIGSEGVs on parallel curves). `OCCTCurve3DExtrema` and
+  `OCCTCurve3DMinDistanceToCurve` (`OCCTBridge_Curve3D.mm:1070-1106`) already guard both curve
+  arguments correctly (`if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return ...;`).
+  The crash is `GeomAPI_ExtremaCurveCurve`/`Extrema_ExtCC` being interrogated (`.Points()`,
+  `.Parameters()`, `.Distance()`) after construction on two **non-null, geometrically parallel**
+  curves - a numeric/degenerate-condition defect, not a null handle, in the same family as
+  `BRepExtrema_ExtCC`'s existing documented fix but needing its own guard (`isParallel` or
+  equivalent), which this checker has no way to express and should not be extended to express: it
+  is not about `Handle` nullity at all.
+- **#643** (`GeomTools_Curve2dSet`/`SurfaceSet` accept a null handle and SIGSEGV in `Write()`).
+  `OCCTGeomToolsCurve2dSetWrite`/`OCCTGeomToolsSurfaceSetWrite` (`OCCTBridge_IO.mm:1570-1637`)
+  already guard every array element correctly (`if (!c || c->curve.IsNull()) return nullptr;`
+  inside the loop, before `cs.Add(c->curve)`), an existing, already-recognised shape (form 5,
+  "array element through a cast," from #618). The checker correctly reports this function clean.
+  #643's own defect is **upstream, in OCCT's own container**: `GeomTools_Curve2dSet::Add`/
+  `GeomTools_SurfaceSet::Add` accept a null handle silently (unlike `GeomTools_CurveSet::Add`,
+  which drops it) and only crash later, inside `Write()`, on a null this bridge's own guard already
+  refuses to let through. No amount of bridge-side null-handle discipline can see inside OCCT's own
+  `Add()`/`Write()` pair; #643 is correctly scoped as a kernel patch, not a bridge gap.
+- **#644** (`Surface.appSurf(curves:)` SIGSEGVs on a single curve). The filed defect is an arity
+  requirement inside `GeomFill_AppSurf` on a **valid** single-curve input - confirmed by #644's own
+  text that substituting a guarded `0.0` for the NaN parameter still crashes. No null handle is
+  involved in the filed reproduction, so no null-handle checker, upgraded or not, could catch it.
+  **What this census's own investigation of the same function did find** is a different, related
+  defect - see "Found, deliberately not taught" above and #710. The upgraded checker does not
+  catch #644 as filed, and does not catch #710 either, by the design choice recorded there.
+
+## Corrections and things worth a sentence
+
+- **#666's own framing held up on measurement**: "teach the checker that shape first... it then
+  enumerates the rest of the family for free" is exactly what happened - one shape, taught once,
+  found the one real remaining instance (already fixed) and one genuinely new one (measured-safe),
+  with no per-function hand-auditing needed beyond triaging what the walk reported.
+- **CLAUDE.md's constructor-init false-positive claim was checked, not just repeated.** `Handle
+  (Geom_Curve) w(wrapper->curve);` uses no `=`, so `aliases()`'s `ASSIGN`-based binding recognition
+  never sees it as a copy - but the wrapper's own `wrapper->curve` occurrence, sitting right there
+  as a constructor argument, textually matches the existing direct-use pattern and gets classified
+  through `enclosing_call` returning `('w', 0)`, which is not a recognised helper, so it falls
+  through to `'use'`. Confirmed by direct trace-through of `classify()`/`enclosing_call()`, not
+  reasoned about in the abstract: the claim is accurate, and remains unaddressed, per this census's
+  scope (CLAUDE.md's list was correct here; nothing to correct, worth recording that verification
+  happened rather than assuming the docstring's word for it).
+- **`ALLOWED`'s `(file, function)` keying is now coarser than before, not just still-coarse.**
+  Before this census, a function name in `ALLOWED` exempted every wrapper-argument finding
+  `unguarded_sites()` could report for it. After this census, the identical entry ALSO exempts
+  anything `local_handle_sites()` finds for that same function name - a function cleared for one
+  reason now silently covers a second, unrelated reason too, with no way to tell from the table
+  which remit an entry was actually measured against. Not changed here: splitting the key (e.g.
+  `(file, function, origin)`) would double the bookkeeping for a table whose real safeguard has
+  always been "lives in a tracked file, survives review," and the same review discipline already
+  required for every entry extends naturally to asking "does this also cover a local handle" when
+  touching one. Worth revisiting if a function ever collects both an `ALLOWED` wrapper-argument
+  entry and a genuinely different local-handle finding that shouldn't share its reasoning - not
+  observed in this tree today.
+- **A new, previously unreported defect (#710) was worth more than confirming the three known
+  ones.** Consistent with every prior cluster census on this workstream: the checker upgrade's own
+  investigation - reading every real call site the new shape's design touched, not just running the
+  fixtures - found something none of #666, #644, or CLAUDE.md's blind-spot list mentioned. The three
+  named members turned out to need no checker change to explain (#636, #644) or were already
+  bridge-side mitigated (#643); the fifth alias form and its three live SIGSEGVs were not on
+  anyone's list going in.
+
+## Does this belong in the shared `Censuses` target too?
+
+**No - the gate script is the whole artifact, and here is why**, since Cluster A/B's own censuses
+both did add a `Censuses` entry and #666 explicitly asks the question.
+
+Cluster A and B's censuses are fundamentally **dynamic**: their subject is what a real call to a
+real public API returns on a real fixture (`box.edgeCount`, `filleted(edges:radius:)`'s duplicate-
+index behaviour), which only exists as a runtime measurement - a static read of the source could
+describe the code's *intent* but not what the built kernel actually does, so a Swift executable
+that builds fixtures and calls the API was the correct primary evidence, with a source-text
+classifier as secondary cross-check.
+
+This census's subject is the opposite: **a source-level shape in `Sources/OCCTBridge/src/*.mm`
+text** - does a local `Handle` declaration reach a use before an `IsNull()` check. That is exactly
+what `Scripts/check-null-handle-guards.py` already exists to answer, and it is not a question a
+Swift program calling the public API could answer at all: the public API never exposes "is this
+specific internal C++ line guarded," only whatever behaviour results once it is or isn't. Where
+this census DID need runtime evidence - is a specific unguarded call actually safe, or does it
+crash - the answer came from a direct, forked, OCCT-linked C++ probe
+(`probe_cluster_c.mm`), the same shape `Scripts/repro/556-null-handle-guard-sweep/repro_556.mm`
+already established as this family's own dynamic-evidence idiom, not from the Swift `Censuses`
+target: there is no Swift-level API to route a null `Handle(Geom_Curve)` into
+`BRepTools::EvalAndUpdateTol` or `GeomFill_SectionGenerator::AddCurve` and observe the crash from
+the Swift side, since the whole point is that the bridge is supposed to refuse it before OCCT ever
+sees it.
+
+So: `python3 Scripts/check-null-handle-guards.py` (the enumeration, "for free" once the shape is
+taught) plus `probe_cluster_c.mm` (the crash-or-catch measurement for each finding) are the
+complete artifact. Nothing here would gain evidentiary value from a `ClusterC.swift` in the shared
+target, and adding one would just be a second, weaker copy of what the gate script already does
+authoritatively.
+
+## Verify
+
+```bash
+swift build                                    # 0 errors, no OCCTSWIFT_LOCAL, pinned v2.0.0-kernel.1
+swift test                                     # full suite
+python3 Scripts/check-bridge-index.py
+python3 Scripts/check-null-handle-guards.py
+python3 Scripts/check-docs-defaults.py
+python3 Scripts/count-operations.py
+python3 Scripts/check-bridge-index.py --self-test
+python3 Scripts/check-null-handle-guards.py --self-test
+python3 Scripts/check-docs-defaults.py --self-test
+```

--- a/Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm
+++ b/Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm
@@ -22,7 +22,8 @@
 // and three of those nine are genuinely unguarded, reaching GeomFill_Profiler::AddCurve,
 // GeomFill_SectionGenerator::AddCurve (OCCTGeomFillAppSurf's own curve array - #644's own
 // function) and the GeomFill_SectionPlacement constructor with no IsNull() check at all. Measured
-// here, not fixed: see the census README's "Beyond the mandated scope" section for why.
+// here, not fixed: see the census README's "Found, deliberately not taught: a fifth alias form,
+// with three real, live SIGSEGVs" section for why.
 #include <GeomAdaptor_Curve.hxx>
 #include <GeomFill_Profiler.hxx>
 #include <GeomFill_SectionGenerator.hxx>
@@ -96,7 +97,11 @@ int main() {
         secGen.AddCurve(nullCurve);
         printf("      added ok\n");
     });
-    probe("GeomFill_SectionPlacement(loc, nullCurve) ctor            [OCCTGeomFillSectionPlacement]", [&] {
+    // Labelled ctor+Perform, not just ctor: the crash's exact origin within this body is not
+    // isolated (the probe forks the whole lambda, so a SIGSEGV anywhere inside it reads the same
+    // from outside). Matches OCCTGeomFillSectionPlacement's own call sequence (construct, then
+    // Perform, then IsDone) rather than claiming a narrower verdict than what was actually run.
+    probe("GeomFill_SectionPlacement(loc, nullCurve) ctor+Perform     [OCCTGeomFillSectionPlacement]", [&] {
         occ::handle<GeomFill_LocationDraft> loc = new GeomFill_LocationDraft(gp_Dir(0, 0, 1), 0.0);
         gp_Ax2 axes(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
         occ::handle<Geom_Curve> path = new Geom_Circle(axes, 5.0);

--- a/Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm
+++ b/Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm
@@ -44,6 +44,16 @@
 static void probe(const char* what, const std::function<void()>& body) {
     fflush(stdout);
     pid_t pid = fork();
+    if (pid < 0) {
+        // #666 round-2 review (item 3): unchecked fork() failure used to fall straight through to
+        // waitpid(pid, &st, 0) with pid == -1 and no outstanding child - which waits for ANY child
+        // instead of erroring, returns immediately via ECHILD, and leaves `st` at its initialised 0.
+        // The verdict switch below reads that as "returned normally": the opposite of what happened,
+        // and exactly the false-safety-verdict risk the review named (feeding a wrong ALLOWED
+        // justification under fork pressure). Report it as its own verdict instead of guessing.
+        printf("  %-68s %s\n", what, "fork() failed - no verdict");
+        return;
+    }
     if (pid == 0) {
         try { body(); }
         catch (Standard_Failure const& e) { printf("      caught: %s\n", e.GetMessageString()); fflush(stdout); _exit(3); }

--- a/Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm
+++ b/Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm
@@ -1,0 +1,111 @@
+// #666 (Cluster C) ground truth. Two independent measurements this census's triage depends on.
+// Each probe runs in a forked child, so a SIGSEGV is reported rather than ending the run - same
+// harness shape as Scripts/repro/556-null-handle-guard-sweep/repro_556.mm.
+//
+// Compile and run from the repo root, per CLAUDE.md's ground-truth recipe:
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/cluster-c-null-handle-shapes/probe_cluster_c.mm -o /tmp/probe_cluster_c
+//   /tmp/probe_cluster_c
+//
+// PART 1 answers whether OCCTBridge_Surface.mm's OCCTGeomFillCoonsAlgPatchEval - the checker's
+// one new #666 finding, a local Handle(Geom_Curve) obtained from BRep_Tool::Curve rather than a
+// wrapper argument - is safe to leave in ALLOWED: does GeomAdaptor_Curve raise a catchable
+// Standard_Failure on a null Handle(Geom_Curve), on both the 1-arg and 3-arg (trimmed) forms?
+//
+// PART 2 answers a question this census's own investigation of #644 raised but does not fix:
+// OCCTBridge_Surface.mm has NINE sites using a fifth alias form the checker (even after #666)
+// still cannot see - `const Handle(Geom_Curve)& x = *(const Handle(Geom_Curve)*)wrapperParam;` -
+// and three of those nine are genuinely unguarded, reaching GeomFill_Profiler::AddCurve,
+// GeomFill_SectionGenerator::AddCurve (OCCTGeomFillAppSurf's own curve array - #644's own
+// function) and the GeomFill_SectionPlacement constructor with no IsNull() check at all. Measured
+// here, not fixed: see the census README's "Beyond the mandated scope" section for why.
+#include <GeomAdaptor_Curve.hxx>
+#include <GeomFill_Profiler.hxx>
+#include <GeomFill_SectionGenerator.hxx>
+#include <GeomFill_SectionPlacement.hxx>
+#include <GeomFill_LocationDraft.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_Circle.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Dir.hxx>
+#include <Standard_Failure.hxx>
+#include <Standard_Handle.hxx>
+
+#include <cstdio>
+#include <functional>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void probe(const char* what, const std::function<void()>& body) {
+    fflush(stdout);
+    pid_t pid = fork();
+    if (pid == 0) {
+        try { body(); }
+        catch (Standard_Failure const& e) { printf("      caught: %s\n", e.GetMessageString()); fflush(stdout); _exit(3); }
+        catch (...) { fflush(stdout); _exit(4); }
+        fflush(stdout);
+        _exit(0);
+    }
+    int st = 0;
+    waitpid(pid, &st, 0);
+    const char* verdict;
+    if (WIFSIGNALED(st)) {
+        verdict = (WTERMSIG(st) == SIGSEGV) ? "SIGSEGV (uncatchable)" : "SIGNAL (uncatchable)";
+    } else if (WEXITSTATUS(st) == 3) {
+        verdict = "Standard_Failure (catchable)";
+    } else if (WEXITSTATUS(st) == 4) {
+        verdict = "other exception (catchable)";
+    } else {
+        verdict = "returned normally";
+    }
+    printf("  %-68s %s\n", what, verdict);
+}
+
+int main() {
+    occ::handle<Geom_Curve> nullCurve;
+
+    printf("PART 1: GeomAdaptor_Curve on a null Handle(Geom_Curve) "
+           "(ALLOWED entry for OCCTGeomFillCoonsAlgPatchEval)\n\n");
+
+    probe("GeomAdaptor_Curve(nullCurve) [1-arg, whole curve]", [&] {
+        GeomAdaptor_Curve a(nullCurve);
+    });
+    probe("new GeomAdaptor_Curve(nullCurve, 0.0, 1.0) [3-arg, trimmed]", [&] {
+        occ::handle<GeomAdaptor_Curve> a = new GeomAdaptor_Curve(nullCurve, 0.0, 1.0);
+    });
+    probe("new GeomAdaptor_Curve(nullCurve, 0.0, 1.0) then ->Value(0.5)", [&] {
+        occ::handle<GeomAdaptor_Curve> a = new GeomAdaptor_Curve(nullCurve, 0.0, 1.0);
+        gp_Pnt p = a->Value(0.5);
+        printf("      p = (%f, %f, %f)\n", p.X(), p.Y(), p.Z());
+    });
+
+    printf("\nPART 2: GeomFill_* family on a null Handle(Geom_Curve), the fifth alias form "
+           "(*(const Type*)wrapperParam) the checker still cannot see\n\n");
+
+    probe("GeomFill_Profiler().AddCurve(nullCurve)                  [OCCTGeomFillProfilerAddCurve]", [&] {
+        GeomFill_Profiler profiler;
+        profiler.AddCurve(nullCurve);
+        printf("      added ok\n");
+    });
+    probe("GeomFill_SectionGenerator().AddCurve(nullCurve)          [OCCTGeomFillAppSurf, #644's own fn]", [&] {
+        GeomFill_SectionGenerator secGen;
+        secGen.AddCurve(nullCurve);
+        printf("      added ok\n");
+    });
+    probe("GeomFill_SectionPlacement(loc, nullCurve) ctor            [OCCTGeomFillSectionPlacement]", [&] {
+        occ::handle<GeomFill_LocationDraft> loc = new GeomFill_LocationDraft(gp_Dir(0, 0, 1), 0.0);
+        gp_Ax2 axes(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+        occ::handle<Geom_Curve> path = new Geom_Circle(axes, 5.0);
+        occ::handle<GeomAdaptor_Curve> pathAdaptor = new GeomAdaptor_Curve(path);
+        loc->SetCurve(pathAdaptor);
+        GeomFill_SectionPlacement placement(loc, nullCurve);
+        placement.Perform(1e-7);
+        printf("      IsDone=%d\n", placement.IsDone());
+    });
+
+    return 0;
+}


### PR DESCRIPTION
## What & why

Part of #666 (Cluster C). This is the census only - it does not fix #636, #643 or #644.

`Scripts/check-null-handle-guards.py` already gates a bridge function's own
`OCCTCurve3DRef`/`OCCTCurve2DRef`/`OCCTSurfaceRef` *arguments*, but was blind to a handle obtained
locally mid-body (`BRep_Tool::Curve`/`CurveOnSurface`/`Surface`) and passed onward - the exact
shape that let #656's uncatchable SIGSEGV through every gate. `local_handle_sites()` closes it,
reusing the existing `classify()`/DownCast/guarding-helper machinery rather than duplicating it,
plus a scope fence for sibling blocks that reuse a generic local name. `FUNC` also now tolerates
`extern "C"` on the definition line, a second named blind spot.

Measured over the tree: 63 `BRep_Tool::`-sourced locals of the three tracked types, 62 already
guarded, 1 (`OCCTGeomFillCoonsAlgPatchEval`) reaching `GeomAdaptor_Curve` unguarded but measured
safe (catchable `Standard_Failure`, same verdict #618 already recorded for `OCCTExtremaExtCC`) -
added to `ALLOWED`. Self-test 12/12 -> 19/19; every new guard proven load-bearing by removal (see
the guard-removal matrix in the census README, not just a case count, per
`okf/policies/prove-the-test-fails.md`).

**None of Cluster C's three members are actually null-handle defects**, which the README's triage
covers in full: #636 is a parallel-curve numeric issue inside `GeomAPI_ExtremaCurveCurve`, not a
null handle; #643 is already guarded bridge-side (the remaining gap is upstream, inside OCCT's own
`GeomTools_*Set` container); #644 is an arity requirement on a *valid* single curve.

**A genuinely new, previously unreported defect was found while confirming #644's own function had
nothing else obviously in scope**: a fifth alias form (`*(const Handle(Type)*)wrapperParam`,
9 sites in `OCCTBridge_Surface.mm`, invisible to `aliases()`) has 3 sites reaching an unguarded,
measured, uncatchable SIGSEGV - one of them `OCCTGeomFillAppSurf` (#644's own function, a
*different* bug from #644's filed one). Deliberately **not taught and not fixed here**: teaching it
without fixing those three sites would leave this gate red, which is out of bounds for a
census-only PR. Filed as #710 with the measurement and suggested fix.

**Update (maintainer-approved follow-up, same PR, same branch):** two more zero-site hardening
fixes to `local_handle_sites()`, both measured against the real tree before being written and
confirmed to add zero new findings. (1) The constructor-init connector: `LOCAL_HANDLE_DECL`
required `name = BRep_Tool::...(` and missed `name(BRep_Tool::...(` - #656's exact shape written
with parens. (2) A dedicated fixture for the `occ::handle<>` spelling as a LOCAL declaration
(previously only exercised as a helper's parameter type) - the regex already covered it, nothing
had proven so. Self-test 19/19 -> 21/21, both new cases proven by removal, real report unchanged
at 0 unguarded / 24 `ALLOWED` throughout (see the extended guard-removal matrix, including a
transparently-recorded near-miss in the removal *test itself*, not the shipped detector).

**Second update (documentation-accuracy review, same PR, same branch, no behaviour change):**
self-test stays 21/21, real report stays 0 unguarded / 24 `ALLOWED` throughout - none of this
touched code paths, only comments/docstrings/README/probe labels.
- The ALLOWED docstring's own warning was stale: it said an entry "exempts EVERY wrapper argument
  of that function", true before this PR, incomplete after (it now also exempts every local-handle
  finding). Named the concrete, bounded cost: `OCCTGeomFillCoonsAlgPatchEval` passed the wrapper
  walk clean *before* #666 and was never in `ALLOWED`, so its new entry retroactively exempts
  wrapper-argument checking on it too. Added the norm (state which walk an entry was measured
  against) and applied it to the one entry this PR added.
- Softened an over-claim, verified directly against `BRep_Tool.hxx`: `Curve`/`CurveOnSurface`
  document returning a null handle, `Surface(const TopoDS_Face&)` does not. Tracking
  `Geom_Surface` anyway is the right conservative choice, now stated as that rather than implied
  to be uniformly documented.
- Measured four more shapes the local-handle walk can't see (deduced type, reference binding,
  global qualification, ternary initialiser) instead of assuming zero occurrences across the
  board: three are genuinely zero, one is real - `OCCTBRepToolCurveOnSurface` uses `auto c2d =
  BRep_Tool::CurveOnSurface(...)`, already guarded in substance, invisible to the walk either way.
- Fixed a stale cross-reference in `probe_cluster_c.mm` (pointed at a README heading that never
  existed) and relabelled its `GeomFill_SectionPlacement` probe, which also calls `Perform`/
  `IsDone`, not just the constructor - same SIGSEGV verdict, label now says what actually ran.
- Documented two related residuals in `local_handle_sites()`'s own docstring: the scope fence is
  textual, not scope-aware (a nested-block redeclaration still ends the outer variable's window),
  and a mid-window reassignment of a tracked name has no equivalent of `unguarded_sites()`'s
  "merely binding, not a read" exclusion - false-positive direction only, no known instance.

Full method, the guard-removal matrix, and the complete triage are in
[`Scripts/repro/cluster-c-null-handle-shapes/README.md`](https://github.com/SecondMouseAU/OCCTSwift/blob/fix/666-cluster-c-null-handle-shapes/Scripts/repro/cluster-c-null-handle-shapes/README.md),
including why this census's artifact is the gate script itself rather than a `Censuses` target
entry (no dynamic Swift-level behaviour to measure; the two things that needed runtime evidence -
is a finding safe, and is the fifth-form crash real - were answered by a direct forked C++ probe,
`probe_cluster_c.mm`, matching `Scripts/repro/556-null-handle-guard-sweep`'s own idiom).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR - the checker's own
      `--self-test` gained 9 new fixtures (12/12 -> 19/19 -> 21/21 across both commits), and every
      new conditional the upgrade introduces was proven load-bearing by removing it and confirming
      both the self-test and the real report change (guard-removal matrix in the census README).

## Notes for the reviewer

- `ALLOWED`'s `(file, function)` key is now coarser than before this PR: an entry now silently
  exempts a function from *both* the wrapper-argument walk and the new local-handle walk, not just
  the one it was originally measured against. Discussed and left as-is in the README (splitting the
  key would double the bookkeeping for a table whose real safeguard is review, not mechanism) -
  worth a second opinion if that trade-off looks wrong.
- #710 (the fifth alias form + 3 live SIGSEGVs) is a natural, small follow-up: teach the shape and
  fix the three sites together, so the gate is never red for a commit in between.
- Verify: clean `swift build` (0 errors, no new warnings, no `OCCTSWIFT_LOCAL`), full `swift test`
  (5356 passed, matching baseline), all four gate scripts + their `--self-test`s green,
  `swift run Censuses cluster-a` (45 rows) / `cluster-b` (16 rows) unaffected.

Closes: none. Part of #666, which stays open until #636/#643/#644 (or their replacements, e.g.
#710) are resolved.

