### PR TITLE
fix(#633): blendedEdges reports which duplicate entries were overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,304 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,306 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/repro/censuses/ClusterB.swift
+++ b/Scripts/repro/censuses/ClusterB.swift
@@ -186,7 +186,7 @@ enum ClusterB {
             let firstOnlyVolume = box.blendedEdges([(0, 2.0)])?.volume
             let dupVerdict: String
             if volumesAgree(dupVolume, lastOnlyVolume) && !volumesAgree(dupVolume, firstOnlyVolume) {
-                dupVerdict = "OVERWRITE: last radius wins (dup \(fmt(dupVolume)) == last-only \(fmt(lastOnlyVolume)), != first-only \(fmt(firstOnlyVolume))) -- #633"
+                dupVerdict = "OVERWRITE: last radius wins (dup \(fmt(dupVolume)) == last-only \(fmt(lastOnlyVolume)), != first-only \(fmt(firstOnlyVolume))) -- #633 fixed: blendedEdgesWithReport(_:) sibling reports overwrittenDuplicateIndices"
             } else if volumesAgree(dupVolume, firstOnlyVolume) {
                 dupVerdict = "OVERWRITE: first radius wins (dup \(fmt(dupVolume)) == first-only \(fmt(firstOnlyVolume)))"
             } else {
@@ -202,7 +202,7 @@ enum ClusterB {
             record("fillet-edges (per-edge radius)", "blendedEdges(_:)",
                    duplicate: dupVerdict,
                    outOfRange: outOfRange == nil ? "REJECT (nil)" : "measured non-nil",
-                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea)))" : "REJECT (nil)",
+                   declined: declined != nil ? "SKIP (non-nil, area \(fmt(declined?.surfaceArea)) vs unfilleted \(fmt(shellPlainArea))) -- #633 fixed: blendedEdgesWithReport(_:) sibling also reports declinedEdgeIndices, adopting #639's mechanism" : "REJECT (nil)",
                    empty: box.blendedEdges([]) == nil ? "REJECT (nil)" : "non-nil",
                    note: "compound out-of-range: \(compoundOutOfRange == nil ? "REJECT (nil), matches single-solid" : "non-nil")")
         }

--- a/Scripts/repro/cluster-b-fillet-edge-contract/README.md
+++ b/Scripts/repro/cluster-b-fillet-edge-contract/README.md
@@ -57,7 +57,7 @@ python3 Scripts/repro/cluster-b-fillet-edge-contract/classify_fillet_sites.py --
 |---|---|---|---|---|---|
 | fillet-edges | `filleted(edges:radius:)` | N/A: uniform radius (dup 991.415927 == single 991.415927) | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) -- **#639 fixed**: `filletedWithReport(edges:radius:)` sibling reports `declinedEdgeIndices` | REJECT (nil) |
 | fillet-linear | `filleted(edges:startRadius:endRadius:)` | N/A: uniform law (dup 990.523733 == single 990.523733) | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) -- **#639 fixed**: `filletedWithReport(edges:startRadius:endRadius:)` sibling reports `declinedEdgeIndices` | REJECT (nil) |
-| fillet-edges (per-edge radius) | `blendedEdges(_:)` | **OVERWRITE: last radius wins** (dup 946.349541 == last-only 946.349541, != first-only 991.415927) -- #633 | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) | REJECT (nil) |
+| fillet-edges (per-edge radius) | `blendedEdges(_:)` | **OVERWRITE: last radius wins** (dup 946.349541 == last-only 946.349541, != first-only 991.415927) -- **#633 fixed**: `blendedEdgesWithReport(_:)` sibling reports `overwrittenDuplicateIndices` | REJECT (nil) | SKIP (non-nil, area 465.097336 vs unfilleted 500.000000) -- **#633 fixed**: the same sibling also reports `declinedEdgeIndices`, adopting #639's mechanism | REJECT (nil) |
 | fillet-variable | `filletedVariable(edgeIndex:radiusProfile:)` | N/A: scalar edgeIndex, no list | REJECT (nil) | REJECT (nil): single edge, no partial fillet possible | N/A: no list; `radiusProfile` needs >=2 points, stricter than `filletEvolving`'s >=1 |
 | fillet-evolving | `filletEvolving(_:)` | **OVERWRITE: last law wins** (dup 946.349541 == last-only 946.349541), documented on `EvolvingFilletEdge`, same mechanism as #633 | REJECT (nil) | SKIP (non-nil, area 465.097336) -- **#639 fixed**: `filletEvolvingWithReport(_:)` now reports `declinedEdgeIndices` | REJECT (nil) |
 | fillet-edges (with history) | `filletedWithFullHistory(radius:edges:)` | N/A: uniform radius (dup 997.853982 == single-edge 997.853982) | REJECT (nil) | SKIP (non-nil, area 465.097336) -- **#639**: needed no new API; `history.record(of:)`'s `!isDeleted && generated.isEmpty` already names the declined set | REJECT (nil) |
@@ -93,12 +93,20 @@ loop at all, reproduce the identical direction per family. The behaviour lives i
 `BRepFilletAPI_MakeFillet::Add`/`BRepFilletAPI_MakeChamfer::Add` themselves, not in anything this
 bridge's own loops do.
 
-**#633 asks for one contract, chosen and applied across the whole family.** This measurement says
-the fillet side is internally consistent (three independent entry points, plus the class API, all
-last-wins) and the chamfer side is *also* internally consistent (two entry points plus its own
-class API, all first-wins) -- so unifying the two families onto one contract is a bigger decision
-than #633's own title suggests, since it means picking a *direction* and changing it for one whole
-family, not just deciding to reject/dedupe/document.
+**#633 asked for one contract, chosen and applied across the whole family; what actually landed is
+report, not converge -- the same decision #639 made for the OCCT-declined axis of this same grid.**
+Changing what `blendedEdges(_:)` returns for an input it already accepts would be a behaviour
+change on every existing caller who happens to name an edge twice, for a benefit (picking a
+"winning" direction) no caller asked for. `blendedEdgesWithReport(_:)` reports which entries a
+duplicate overwrote (`Shape.FilletResult.overwrittenDuplicateIndices`, extending the same struct
+#639 introduced rather than adding a second reporting shape), and `blendedEdges(_:)` itself is
+byte-for-byte unchanged. **This measurement's own finding stands, unrevised**: the fillet side is
+internally consistent (three independent entry points, plus the class API, all last-wins) and the
+chamfer side is *also* internally consistent (two entry points plus its own class API, all
+first-wins) -- unifying the two families onto one contract is still a bigger decision than #633's
+own title suggested, since it means picking a *direction* and changing it for one whole family, not
+just deciding to reject/dedupe/document. That decision remains open; #633 closes on observability
+alone, matching #639.
 
 ## New findings (not in #520/#568/#612/#633/#639)
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -137,14 +137,27 @@ OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance);
 /// OCCTShapeFilletEdges and OCCTShapeFilletEdgesLinear. Implemented in OCCTBridge_Healing.mm
 /// while the other two are in OCCTBridge_Modeling.mm, which is how it came to be the one without
 /// a radius precondition. #489
+///
+/// #633: `declinedEdgeIndices`/`outDeclinedCount` report which of `edgeIndices` OCCT declined,
+/// same contract #639 gave OCCTShapeFilletEdges/OCCTShapeFilletEdgesLinear/OCCTShapeFilletEvolving.
+/// Both are nullable and the existing skip behaviour is unchanged when they are null;
+/// `blendedEdges(_:)` passes null for both, `blendedEdgesWithReport(_:)` does not. The *other* axis
+/// this function's caller has to report -- the same edge index named twice, which silently
+/// overwrites one radius with another at the shared fillet slot -- needs no OCCT round trip at all,
+/// since it is a property of `edgeIndices` itself; it is computed Swift-side.
 /// @param shape The shape to blend
 /// @param edgeIndices Array of edge indices (0-based; an index naming no edge of `shape` rejects
 ///   the whole call, #520)
 /// @param radii Array of radii (one per edge); every element must be > 0, or the whole call fails
 /// @param count Number of edges
+/// @param declinedEdgeIndices Optional (may be NULL): buffer of at least `count` int32s to receive
+///   the 0-based indices of requested edges OCCT declined to fillet, in `edgeIndices`' own order.
+///   Same contract as OCCTShapeFilletEdges.
+/// @param outDeclinedCount Optional (may be NULL): same contract as OCCTShapeFilletEdges.
 /// @return Blended shape, or NULL on failure
 OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
-                                  const int32_t* edgeIndices, const double* radii, int32_t count);
+                                  const int32_t* edgeIndices, const double* radii, int32_t count,
+                                  int32_t* declinedEdgeIndices, int32_t* outDeclinedCount);
 
 /// Parameters for surface filling operation
 ///

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -714,8 +714,14 @@ OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance) {
 // Shares occtShapeFilletEdgeList (OCCTBridge_Internal.h) with OCCTShapeFilletEdges and
 // OCCTShapeFilletEdgesLinear in OCCTBridge_Modeling.mm, supplying only the per-edge radius.
 // This is the entry point that had no radius precondition at all; see that helper. #489
+//
+// #633: `declinedEdgeIndices`/`outDeclinedCount` report which of `edgeIndices` OCCT declined
+// (occtFilletWriteDeclined), the same contract #639 gave the other three edge-list entry points.
+// Both are nullable and the existing skip behaviour is unchanged when they are null.
 OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
-                                  const int32_t* edgeIndices, const double* radii, int32_t count) {
+                                  const int32_t* edgeIndices, const double* radii, int32_t count,
+                                  int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
+    if (outDeclinedCount) *outDeclinedCount = 0;
     if (!occtValidFilletRadii(radii, count)) return nullptr;
 
     return occtShapeFilletEdgeList(shape, edgeIndices, count,
@@ -723,7 +729,7 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
                                            const TopoDS_Edge& edge, int32_t entry) {
         fillet.Add(radii[entry], edge);
         return true;
-    });
+    }, declinedEdgeIndices, outDeclinedCount);
 }
 
 // MARK: - Surface filling (#430/#434)

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -72,6 +72,30 @@ extension Shape {
         /// edge twice reports it twice, so the count matches how many entries of the caller's list
         /// were refused. Use `Set(declinedEdgeIndices)` for distinct edges.
         public let declinedEdgeIndices: [Int]
+        /// 0-based edge indices, matching ``Edge/index``, whose radius a *later* entry in the same
+        /// request overwrote (#633). Empty for every `WithReport` sibling except
+        /// ``Shape/blendedEdgesWithReport(_:)``, the one entry point that takes a per-edge radius
+        /// array where naming an edge twice is even possible.
+        ///
+        /// `BRepFilletAPI_MakeFillet::Add(radius, edge)` resolves the edge's own slot within its
+        /// contour and writes there, so a second `Add` on the same edge silently replaces the first
+        /// radius rather than erroring or combining the two. This mirrors the request list, the
+        /// same convention as `declinedEdgeIndices`: an edge index requested three times reports
+        /// two overwritten entries here (the two radii that lost), not one. Use
+        /// `Set(overwrittenDuplicateIndices)` for distinct edges.
+        public let overwrittenDuplicateIndices: [Int]
+
+        /// Explicit rather than the synthesized memberwise init: a `let` property with a default
+        /// value is fixed and dropped from Swift's synthesized memberwise init entirely (it is not
+        /// an overridable parameter, unlike a `var` with a default), so the three existing
+        /// `WithReport` call sites -- none of which have anything to say about a duplicate index --
+        /// need `overwrittenDuplicateIndices` to keep defaulting to empty without themselves
+        /// changing.
+        public init(shape: Shape, declinedEdgeIndices: [Int], overwrittenDuplicateIndices: [Int] = []) {
+            self.shape = shape
+            self.declinedEdgeIndices = declinedEdgeIndices
+            self.overwrittenDuplicateIndices = overwrittenDuplicateIndices
+        }
     }
 
     /// Fillet specific edges with uniform radius
@@ -740,6 +764,12 @@ extension Shape {
     /// this shape, on the same all-or-nothing basis: one that does not rejects the batch rather
     /// than being skipped, so a result is never a partial fillet reported as a complete one.
     ///
+    /// The same edge index named twice is **not** rejected and does not combine the two radii: OCCT
+    /// writes both `Add` calls to that edge's own slot within its fillet contour, so the *second*
+    /// silently overwrites the first (#633). This is unchanged, existing behaviour, documented here
+    /// because it used to be undocumented and silent; use ``blendedEdgesWithReport(_:)`` for the
+    /// same fillet with a report naming which entries a duplicate overwrote.
+    ///
     /// - Parameter edgeRadii: Array of (0-based edgeIndex, radius) pairs; each radius must be > 0
     /// - Returns: Filleted shape, or nil on failure, including an empty array, a non-positive
     ///   radius anywhere in the array, or an index that names no edge of this shape
@@ -770,12 +800,80 @@ extension Shape {
             handle,
             &indices,
             &radii,
-            Int32(edgeRadii.count)
+            Int32(edgeRadii.count),
+            nil,
+            nil
         ) else {
             return nil
         }
         return Shape(handle: result)
     }
+
+    /// ``blendedEdges(_:)``, also reporting which requested edges OCCT declined to fillet, and
+    /// which duplicate entries were silently overwritten (#633).
+    ///
+    /// `blendedEdges(_:)` does not deduplicate `edgeRadii`: naming the same edge index twice writes
+    /// the same fillet slot twice, and only the *last* radius written survives -- the earlier one is
+    /// discarded with no signal, the same shape of silent-wrong-answer #639 found on the declined-edge
+    /// axis of this family. That existing behaviour is unchanged here; this method only adds a way
+    /// to observe it, following #639's recommendation to extend ``FilletResult`` rather than invent
+    /// a second reporting shape for the same idea.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// if let report = box.blendedEdgesWithReport([(0, 2.0), (0, 5.0)]) {
+    ///     print(report.overwrittenDuplicateIndices)   // [0]: edge 0's first radius (2.0) lost
+    ///     print(report.declinedEdgeIndices)            // []: every edge of a closed box fillets
+    /// }
+    /// ```
+    ///
+    /// - Parameter edgeRadii: Array of (0-based edgeIndex, radius) pairs; each radius must be > 0
+    /// - Returns: A ``FilletResult``, or nil on failure under the same conditions as
+    ///   ``blendedEdges(_:)``.
+    public func blendedEdgesWithReport(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> FilletResult? {
+        guard !edgeRadii.isEmpty, edgeRadii.allSatisfy({ $0.radius > 0 }) else { return nil }
+
+        var indices = edgeRadii.map { Int32($0.edgeIndex) }
+        var radii = edgeRadii.map { $0.radius }
+
+        var declined = [Int32](repeating: 0, count: edgeRadii.count)
+        var declinedCount: Int32 = 0
+        let result: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
+            OCCTShapeBlendEdges(
+                handle,
+                &indices,
+                &radii,
+                Int32(edgeRadii.count),
+                declinedBuffer.baseAddress,
+                &declinedCount
+            )
+        }
+        guard let result else { return nil }
+        let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
+        return FilletResult(shape: Shape(handle: result), declinedEdgeIndices: declinedIndices,
+                            overwrittenDuplicateIndices: Shape.overwrittenDuplicateIndices(in: edgeRadii))
+    }
+
+    /// 0-based edge indices from `edgeRadii` that a later entry in the same request overwrote.
+    ///
+    /// This is a property of `edgeRadii` itself: `edgeIndex` maps to a unique edge via `Shape`'s own
+    /// `TopExp` enumeration, so two entries naming the same numeric index always name the same edge,
+    /// and no OCCT round trip is needed to tell which entries lost. Mirrors ``FilletResult`` /
+    /// `declinedEdgeIndices`'s own convention: every overwritten *entry* is reported, not just the
+    /// distinct edges, so `[(0, 1.0), (0, 2.0), (0, 3.0)]` reports `[0, 0]` -- two entries lost, one
+    /// (the last) won -- not `[0]`.
+    private static func overwrittenDuplicateIndices(in edgeRadii: [(edgeIndex: Int, radius: Double)]) -> [Int] {
+        var lastPosition: [Int: Int] = [:]
+        for (position, pair) in edgeRadii.enumerated() {
+            lastPosition[pair.edgeIndex] = position
+        }
+        var overwritten: [Int] = []
+        for (position, pair) in edgeRadii.enumerated() where lastPosition[pair.edgeIndex] != position {
+            overwritten.append(pair.edgeIndex)
+        }
+        return overwritten
+    }
+
     /// Create a wedge (tapered box).
     ///
     /// A wedge is a box whose top face is narrowed in the X direction.

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -85,12 +85,16 @@ extension Shape {
         /// `Set(overwrittenDuplicateIndices)` for distinct edges.
         public let overwrittenDuplicateIndices: [Int]
 
-        /// Explicit rather than the synthesized memberwise init: a `let` property with a default
-        /// value is fixed and dropped from Swift's synthesized memberwise init entirely (it is not
-        /// an overridable parameter, unlike a `var` with a default), so the three existing
-        /// `WithReport` call sites -- none of which have anything to say about a duplicate index --
-        /// need `overwrittenDuplicateIndices` to keep defaulting to empty without themselves
-        /// changing.
+        /// Explicit rather than the synthesized memberwise init, and the reason is this method,
+        /// not the three that came before it. A `let` property with a default value is dropped from
+        /// Swift's synthesized memberwise init entirely: it is not an overridable parameter the way
+        /// a `var` with a default is, so a caller **cannot pass it at all**.
+        ///
+        /// The three existing `WithReport` call sites would have compiled unchanged against the
+        /// synthesized init, silently taking the `[]` default, since none of them has anything to
+        /// say about a duplicate index. `blendedEdgesWithReport(_:)` is the first caller that needs
+        /// to pass a **non-default** value, and that is what the synthesized init structurally
+        /// cannot express.
         public init(shape: Shape, declinedEdgeIndices: [Int], overwrittenDuplicateIndices: [Int] = []) {
             self.shape = shape
             self.declinedEdgeIndices = declinedEdgeIndices

--- a/Tests/OCCTModelingTests/Issue633BlendedEdgesDuplicateReportTests.swift
+++ b/Tests/OCCTModelingTests/Issue633BlendedEdgesDuplicateReportTests.swift
@@ -1,0 +1,186 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// `BRepFilletAPI_MakeFillet::Add(radius, edge)` resolves the edge's own slot within its fillet
+/// contour and writes there, so a second `Add` call naming the same edge index silently overwrites
+/// the first radius rather than combining the two or erroring. `blendedEdges(_:)` never deduplicates
+/// its `edgeRadii` list, so a caller who names one edge twice (by accident, or by building the list
+/// from a selection with a repeat) gets a shape built from only the *last* radius, with no signal
+/// that the earlier one was ever discarded. #633.
+///
+/// Measured directly (`swift run Censuses cluster-b`), not assumed from the issue's own numbers:
+/// on a plain 10mm box, `blendedEdges([(0, 2.0), (0, 5.0)])` gives the identical volume to
+/// `blendedEdges([(0, 5.0)])` (946.349541) and differs from `blendedEdges([(0, 2.0)])` (991.415927)
+/// -- last-wins, confirmed on this tree rather than trusted from the census's own writeup.
+///
+/// `blendedEdgesWithReport(_:)` is the new entry point (#709's recommendation for this issue,
+/// taken as given): it changes nothing about the shape `blendedEdges(_:)` already returns, and adds
+/// a `Shape.FilletResult` naming both axes this family can silently discard on -- the declined-edge
+/// axis #639 already reports for its three siblings, and the duplicate-overwrite axis this issue is
+/// about -- rather than inventing a second, parallel reporting type for the same idea (#490's lesson).
+@Suite("blendedEdges reports overwritten duplicates (#633)")
+struct Issue633BlendedEdgesDuplicateReport {
+
+    /// A 10mm box with one face dropped and the rest sewn back together: an open shell whose free
+    /// boundary edges `BRepFilletAPI_MakeFillet::Add` declines. Identical construction to
+    /// `Issue639FilletDeclinedEdgeReport.openShell()` and the Cluster B census's own fixture.
+    static func openShell() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        let faces = box.faces().compactMap { Shape.fromFace($0) }
+        guard faces.count == 6 else { return nil }
+        return Shape.sew(shapes: Array(faces.dropFirst()))
+    }
+
+    /// Measured by the Cluster B census on this exact fixture; reused here rather than re-derived.
+    static let declinedIndices = [6, 9, 10, 11]
+
+    // MARK: - overwrittenDuplicateIndices: a single duplicated edge
+
+    @Test("a duplicated edge index reports one overwritten entry, and the shape is unchanged")
+    func duplicatedEdgeReportsOneOverwrittenEntry() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        guard let report = box.blendedEdgesWithReport([(0, 2.0), (0, 5.0)]) else {
+            Issue.record("blendedEdgesWithReport unexpectedly returned nil")
+            return
+        }
+        #expect(report.overwrittenDuplicateIndices == [0])
+        #expect(report.declinedEdgeIndices.isEmpty)
+
+        // Reporting must not change the built geometry: last-wins, exactly like the non-reporting
+        // sibling, and exactly like naming edge 0 with only the winning radius.
+        guard let plain = box.blendedEdges([(0, 2.0), (0, 5.0)]),
+              let lastOnly = box.blendedEdges([(0, 5.0)]) else {
+            Issue.record("blendedEdges unexpectedly returned nil")
+            return
+        }
+        #expect(abs((report.shape.volume ?? -1) - (plain.volume ?? -2)) < 1e-9)
+        #expect(abs((report.shape.volume ?? -1) - (lastOnly.volume ?? -2)) < 1e-9)
+    }
+
+    // MARK: - overwrittenDuplicateIndices mirrors the request list, like declinedEdgeIndices
+
+    @Test("an edge named three times reports two overwritten entries, not one")
+    func tripleDuplicateReportsTwoOverwrittenEntries() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        guard let report = box.blendedEdgesWithReport([(0, 2.0), (0, 3.0), (0, 5.0)]) else {
+            Issue.record("blendedEdgesWithReport unexpectedly returned nil")
+            return
+        }
+        // Two entries lost (the 2.0 and the 3.0), one (the 5.0) won: the count matches how many
+        // entries of the caller's list were discarded, the same convention #639 established for
+        // declinedEdgeIndices. Deduplicating to the distinct edge index would report [0], which is
+        // the defect this test exists to catch.
+        #expect(report.overwrittenDuplicateIndices == [0, 0])
+
+        guard let lastOnly = box.blendedEdges([(0, 5.0)]) else {
+            Issue.record("blendedEdges unexpectedly returned nil")
+            return
+        }
+        #expect(abs((report.shape.volume ?? -1) - (lastOnly.volume ?? -2)) < 1e-9)
+    }
+
+    // MARK: - No duplicates: empty report
+
+    @Test("distinct edge indices report no overwritten entries")
+    func distinctIndicesReportNoOverwrites() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        guard let report = box.blendedEdgesWithReport([(0, 1.0), (1, 2.0), (2, 0.5)]) else {
+            Issue.record("blendedEdgesWithReport unexpectedly returned nil")
+            return
+        }
+        #expect(report.overwrittenDuplicateIndices.isEmpty)
+        #expect(report.declinedEdgeIndices.isEmpty)
+    }
+
+    // MARK: - declinedEdgeIndices: blendedEdgesWithReport adopts #639's mechanism too
+
+    @Test("blendedEdgesWithReport names the same declined set #639 measured for its siblings")
+    func declinedEdgesAreNamedOnAnOpenShell() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edgeCount = shell.edges().count
+        #expect(edgeCount == 12)
+        let request = (0..<edgeCount).map { ($0, 1.0) }
+
+        guard let report = shell.blendedEdgesWithReport(request) else {
+            Issue.record("blendedEdgesWithReport unexpectedly returned nil")
+            return
+        }
+        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        #expect(report.overwrittenDuplicateIndices.isEmpty)
+
+        // Reporting must not change the built geometry: same skip-not-reject answer as the
+        // non-reporting sibling (#633 does not touch this axis, only #639 already fixed it for
+        // the three other entry points; this method adopts that fix rather than re-deriving it).
+        guard let plain = shell.blendedEdges(request) else {
+            Issue.record("blendedEdges unexpectedly returned nil")
+            return
+        }
+        #expect(abs((report.shape.surfaceArea ?? -1) - (plain.surfaceArea ?? -2)) < 1e-9)
+    }
+
+    // MARK: - Both axes at once are independent
+
+    @Test("a duplicated accepted edge and a declined edge are reported independently")
+    func duplicateAndDeclineAreReportedIndependently() {
+        guard let shell = Self.openShell() else {
+            Issue.record("open shell fixture failed to build")
+            return
+        }
+        let edgeCount = shell.edges().count
+        guard let accepted = (0..<edgeCount).first(where: { !Self.declinedIndices.contains($0) }) else {
+            Issue.record("fixture has no accepted edge")
+            return
+        }
+        // Duplicate an accepted edge, and request every declined edge once.
+        var request: [(edgeIndex: Int, radius: Double)] = [(accepted, 1.0), (accepted, 2.0)]
+        request.append(contentsOf: Self.declinedIndices.map { ($0, 1.0) })
+
+        guard let report = shell.blendedEdgesWithReport(request) else {
+            Issue.record("blendedEdgesWithReport unexpectedly returned nil")
+            return
+        }
+        #expect(report.overwrittenDuplicateIndices == [accepted])
+        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+    }
+
+    // MARK: - The all-or-nothing contracts blendedEdges already has are unaffected
+
+    @Test("blendedEdgesWithReport rejects an out-of-range index, an empty list, and a bad radius")
+    func rejectsTheSameInputsBlendedEdgesRejects() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        #expect(box.blendedEdgesWithReport([]) == nil)
+        #expect(box.blendedEdgesWithReport([(0, 1.0), (99_999, 2.0)]) == nil)
+        #expect(box.blendedEdgesWithReport([(0, 1.0), (1, 0.0)]) == nil)
+    }
+
+    @Test("blendedEdgesWithReport reports no declines or overwrites on a closed solid's own edge list")
+    func emptyReportsOnAClosedSolid() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box fixture failed to build")
+            return
+        }
+        let request = (0..<box.edges().count).map { ($0, 1.0) }
+        guard let report = box.blendedEdgesWithReport(request) else {
+            Issue.record("blendedEdgesWithReport unexpectedly returned nil on a closed box")
+            return
+        }
+        #expect(report.declinedEdgeIndices.isEmpty)
+        #expect(report.overwrittenDuplicateIndices.isEmpty)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed — see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,320** of the entry points (~77% of the `Total` below); the rest are real, callable,
+categorisation covering **3,326** of the entry points (~77% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -36,7 +36,7 @@ a map of the major areas, and the `Total` as the count.
 | **Primitives** | 13 | box, cylinder, cylinder(at:), sphere, cone, torus, surface, wedge, halfSpace, vertex, shell(from surface), shell(from Surface), nonUniformScale |
 | **Sweeps** | 24 | pipe sweep, pipeShell, pipeShellMultiSection, pipeShellWithTransition (deprecated, #503), pipeShellWithLaw, extrude, revolve, loft, loft(ruled+vertex), ruled, revolutionFromCurve, ruledShell, advancedEvolved, pipeSweep, compatibleWires, thruSectionsCreate, thruSectionsAddWire, thruSectionsAddVertex, thruSectionsSetSmoothing, thruSectionsSetMaxDegree, thruSectionsSetContinuity, thruSectionsBuild, thruSectionsShape, thruSectionsRelease |
 | **Booleans** | 12 | union (+), subtract (-), intersect (&), section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory |
-| **Modifications** | 36 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, filletedWithReport, filletedWithReport(startRadius:endRadius:), filletEvolvingWithReport, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
+| **Modifications** | 37 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, filletedWithReport, filletedWithReport(startRadius:endRadius:), filletEvolvingWithReport, blendedEdgesWithReport, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
 | **Transforms** | 10 | translate, rotate, scale, mirror, mirrorAboutPoint, mirrorAboutAxis, scaleAboutPoint, translated(from:to:), transformed(matrix:), gTransformed(matrix:) |
 | **Wires** | 31 | rectangle, circle, polygon, polygon3D, line, arc, bspline, nurbs, path, join, offset, offset3D, interpolate, fillet2D, filletAll2D, chamfer2D, chamferAll2D, helix, helixTapered, orderedEdgeCount, orderedEdgePoints, orderedEdgePointCount, analyze, wireFromEdges, edges, allEdgePolylines, allEdgePolylinesIndexed, edgePolyline, bounds |
 | **Curve Analysis** | 6 | length, curveInfo, point(at:), tangent(at:), curvature(at:), curvePoint(at:) |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,304** | |
+| **Total** | **4,306** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -986,17 +986,21 @@ addressable. (#614)
 |-----------|------------|
 | `shape.filletEvolving(_:)` | `BRepFilletAPI_MakeFillet.SetRadius(UandR)` |
 
-#### Fillet Decline Reporting (#639)
+#### Fillet Decline Reporting (#639) and Duplicate-Overwrite Reporting (#633)
 | Swift API | OCCT Class |
 |-----------|------------|
 | `shape.filletedWithReport(edges:radius:)` | `BRepFilletAPI_MakeFillet` + `Contour(edge)` per requested edge |
 | `shape.filletedWithReport(edges:startRadius:endRadius:)` | `BRepFilletAPI_MakeFillet.Add(R1, R2, E)` + `Contour(edge)` |
 | `shape.filletEvolvingWithReport(_:)` | `BRepFilletAPI_MakeFillet.SetRadius(UandR)` + `Contour(edge)` |
+| `shape.blendedEdgesWithReport(_:)` | `BRepFilletAPI_MakeFillet.Add(radius, edge)` + `Contour(edge)` |
 
-Each shares its non-reporting sibling's build, and additionally reports which requested edges
-`Contour(edge) == 0` after `Add()`: the ones OCCT declined to fillet (a free-boundary edge of an
-open shell, most commonly), which the non-reporting siblings silently skip. See
-`Shape.FilletResult`.
+Each of the first three shares its non-reporting sibling's build, and additionally reports which
+requested edges `Contour(edge) == 0` after `Add()`: the ones OCCT declined to fillet (a
+free-boundary edge of an open shell, most commonly), which the non-reporting siblings silently
+skip. `blendedEdgesWithReport(_:)` reports that too, plus a second, independent axis its siblings
+have no way to trigger: `overwrittenDuplicateIndices`, the requested edges whose radius a *later*
+entry in the same call silently overwrote at that edge's own fillet-contour slot (#633), computed
+Swift-side from the request array rather than from OCCT. See `Shape.FilletResult`.
 
 #### Per-Face Variable Offset (v0.38.0)
 | Swift API | OCCT Class |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -303,6 +303,65 @@ moves the file's own "twelve recorded exceptions" count. `Scripts/repro/cluster-
 is unchanged: the census measures the contract, this issue only adds a way to observe one axis of
 it, and the measured grid itself (SKIP/REJECT per cell) does not move.
 
+#### `blendedEdges(_:)` reports which duplicate entries were overwritten (#633)
+
+The last open member of Cluster B (#665). `BRepFilletAPI_MakeFillet::Add(radius, edge)` resolves an
+edge's own slot within its fillet contour and writes there, so naming the same edge index twice in
+`blendedEdges(_:)`'s `edgeRadii` writes that slot twice -- the *second* `Add` silently overwrites the
+first, with no exception, no false return and nothing in the result to say a radius was ever
+discarded. Re-measured on this tree rather than trusted from the issue: `blendedEdges([(0, 2.0),
+(0, 5.0)])` gives the identical volume (946.349541) to `blendedEdges([(0, 5.0)])` and differs from
+`blendedEdges([(0, 2.0)])` (991.415927) -- last-wins, confirmed.
+
+**Sequenced deliberately after #639**, which decided the reporting mechanism for the family's other
+silent axis (an edge OCCT declines outright) and recommended, in its own PR, extending the same
+shape to also cover this one rather than re-deriving a mechanism. That recommendation is taken
+here without a reason found to deviate: **report, do not reject or pick a "winning" direction.**
+Converging `blendedEdges(_:)` onto reject, or onto first-wins (matching the chamfer family, see
+below), would change what it returns for every existing caller who happens to name an edge twice
+and currently gets a built shape -- a behaviour change wider than this issue, and the same move #639
+rejected for its own axis.
+
+**Fixed**: `blendedEdgesWithReport(_:)` is a new `WithReport` sibling, returning
+`Shape.FilletResult`, now with a second field, `overwrittenDuplicateIndices` -- the 0-based edge
+indices whose radius a later entry in the same request overwrote, mirroring the request list the
+same way `declinedEdgeIndices` already does (an edge named three times reports two overwritten
+entries, not one distinct index). Computing it needs no OCCT round trip at all: an edge index maps
+to exactly one edge via `Shape`'s own `TopExp` enumeration, so which entries lose is a property of
+the caller's `edgeRadii` array alone, resolved Swift-side. `blendedEdgesWithReport(_:)` also adopts
+#639's declined-edge mechanism for this entry point (`OCCTShapeBlendEdges` gained the same two
+nullable trailing out-parameters `OCCTShapeFilletEdges`/`OCCTShapeFilletEdgesLinear` already carry,
+threaded through the shared `occtShapeFilletEdgeList` skeleton) rather than leaving that field
+permanently empty for this one sibling: a report that answered one axis and silently stayed blank
+on the other would be the same shape of silent-wrong-answer this whole cluster exists to fix.
+`blendedEdges(_:)` itself, and every other `FilletResult`-returning method, are unchanged -- the new
+field defaults to `[]` for `filletedWithReport(edges:radius:)`,
+`filletedWithReport(edges:startRadius:endRadius:)` and `filletEvolvingWithReport(_:)`, none of
+which has a duplicate axis of its own to report.
+
+**`filletEvolving(_:)` measures the identical last-wins mechanism** (documented on
+`EvolvingFilletEdge`'s own doc comment, and confirmed again by this PR's re-measurement), and is
+deliberately left alone here: extending `filletEvolvingWithReport(_:)` with the same field is a
+natural follow-up, not a requirement of this issue, which is scoped to `blendedEdges(_:)` by its
+own title.
+
+New tests: `Tests/OCCTModelingTests/Issue633BlendedEdgesDuplicateReportTests.swift`, seven cases.
+Proven against three independent injections, each restored and confirmed green afterward:
+
+| Injection | Result |
+|---|---|
+| The Swift-side helper drops the report (`return []`) | The 3 tests asserting a non-empty `overwrittenDuplicateIndices` fail; the 4 that expect it empty, or check `declinedEdgeIndices` only, correctly stay green |
+| The Swift-side helper deduplicates (`Array(Set(overwritten))`) instead of mirroring the request | Only the triple-duplicate test fails (`[0, 0]` collapses to `[0]`); the single-duplicate test is insensitive to this distinction and stays green, as does everything else |
+| `OCCTShapeBlendEdges` stops forwarding its two new out-parameters (`nullptr, nullptr` always) | The 2 tests asserting a non-empty `declinedEdgeIndices` fail; both duplicate-only tests, unaffected by this axis, correctly stay green |
+
+This is additive, non-breaking Swift API (one new method, one new field on an existing struct, no
+existing signature or behaviour changed), recorded in
+[`SEMVER.md`](SEMVER.md#633-additive-blend-duplicate-reporting-not-an-exception) -- checked and
+confirmed the file's "thirteen recorded exceptions" count is unaffected.
+`Scripts/repro/cluster-b-fillet-edge-contract/` and `Scripts/repro/censuses/ClusterB.swift` are
+updated to annotate the now-fixed cell; the measured grid itself does not move (`swift run Censuses
+cluster-b` still emits 16 rows).
+
 #### `AAG` rode the lossy `faces()`, so `detectPocketsAAG()` answered 2 or 1 for the same geometry depending on compound member order (#642)
 
 `AAG.buildGraph()` built its node set from `Shape.faces()`, the `IsSame`-keyed enumeration #614

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -427,6 +427,41 @@ same question, documented in this PR with a runnable recipe rather than given ne
 [`CHANGELOG.md`](CHANGELOG.md#the-fillet-family-could-not-report-a-declined-edge-only-skip-it-silently-639)
 for the full measurement and the reasoning against converging fillet's SKIP behaviour onto reject.
 
+#### #633: additive blend-duplicate reporting, not an exception
+
+**Recorded here for the same reason #639 immediately above is: a public-API change written down
+now, not because this one is a recorded exception.** `blendedEdges(_:)` gained a `WithReport`
+sibling, `blendedEdgesWithReport(_:)`, returning the same `Shape.FilletResult` #639 introduced,
+now carrying a second field: `overwrittenDuplicateIndices`, the 0-based edge indices whose radius a
+later entry in the same request silently overwrote (#633).
+
+This does **not** move the "thirteen recorded exceptions" count above, checked and confirmed
+unchanged by this entry, for the same reason #639's did not: no existing method's signature or
+behaviour changed. `blendedEdges(_:)` still returns exactly what it always did, for exactly the
+same inputs -- last-wins, silently, on a duplicated edge index -- and a caller who never calls
+`blendedEdgesWithReport(_:)` sees no difference at all. This is the **MINOR**, additive Swift API
+case the quick reference table already names.
+
+Adding `overwrittenDuplicateIndices` to the existing `FilletResult` struct, rather than a second
+result type, follows #639's own recommendation for this issue and the standing lesson #490 already
+drew from a family of near-identical continuity mappers: one struct, extended, not a parallel
+encoding of the same idea started fresh. It is a purely additive struct change: a `let` property
+with a default is not exposed on Swift's synthesized memberwise init (only a `var` with a default
+is), so `FilletResult` now carries an explicit `public init` with the new field defaulted to `[]`
+-- every existing call site (`filletedWithReport(edges:radius:)`,
+`filletedWithReport(edges:startRadius:endRadius:)`, `filletEvolvingWithReport(_:)`) compiles
+unchanged and reads an empty array for a field none of the three has a duplicate axis to populate.
+
+**The fillet/chamfer first-wins/last-wins asymmetry itself is unchanged and not addressed here.**
+`Scripts/repro/cluster-b-fillet-edge-contract/` measured the wider family as internally consistent
+but split in *opposite* directions (fillet last-wins, chamfer first-wins) -- converging the two onto
+one direction was considered and rejected for the same reason #639 rejected reject-over-skip:
+it would change what an existing call returns for every input that currently succeeds, which is a
+bigger and more disruptive decision than this issue's own defect (a silent discard with no
+signal). See
+[`CHANGELOG.md`](CHANGELOG.md#blendededges-reports-which-duplicate-entries-were-overwritten-633)
+for the full measurement and the injection matrix proving the new report.
+
 ### MINOR — `x.y.0`
 
 A minor bump is for additive change. Two routes:

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1115,23 +1115,33 @@ public func filleted(edges: [Edge], radius: Double) -> Shape?
 
 ### `Shape.FilletResult`
 
-Result of a fillet call that also reports which requested edges OCCT declined (#639).
+Result of a fillet call that also reports which requested edges OCCT declined (#639), and -- for
+`blendedEdgesWithReport(_:)` -- which duplicate entries were silently overwritten (#633).
 
 ```swift
 public struct FilletResult: Sendable {
     public let shape: Shape
     public let declinedEdgeIndices: [Int]
+    public let overwrittenDuplicateIndices: [Int]
 }
 ```
 
 - **Fields:** `shape`: the filleted shape, identical to what the non-reporting sibling returns for
   the same input. `declinedEdgeIndices`: 0-based indices, matching `Edge.index`, of the requested
   edges OCCT declined to fillet. Empty when every requested edge was accepted.
-- **Notes:** there is no *reason* alongside the list. `BRepFilletAPI_MakeFillet::Add` returns
+  `overwrittenDuplicateIndices`: 0-based edge indices whose radius a *later* entry in the same
+  request overwrote. Empty for every `WithReport` sibling except `blendedEdgesWithReport(_:)`, the
+  one entry point whose per-edge radius array can name the same edge twice.
+- **Notes:** there is no *reason* alongside either list. `BRepFilletAPI_MakeFillet::Add` returns
   nothing, and `NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a contour that failed
   during `Build()`, which an edge OCCT never added to any contour never reaches. `Contour(edge) ==
   0`, populated by `Add()` and not `Build()`, is the only signal OCCT itself exposes, so this reports
-  *which* edges were declined, not *why*.
+  *which* edges were declined, not *why*. Both lists mirror the caller's request rather than
+  deduplicating it: an edge requested three times, and declined, is reported three times in
+  `declinedEdgeIndices`; an edge requested three times whose radius is overwritten twice is reported
+  twice in `overwrittenDuplicateIndices` -- the count matches how many entries of the request were
+  refused or discarded, not how many distinct edges were involved. Use `Set(...)` on either field
+  for distinct edges.
 
 ---
 
@@ -1794,7 +1804,11 @@ public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Sha
 - **OCCT:** `BRepFilletAPI_MakeFillet` (via `OCCTShapeBlendEdges`).
 - **Notes:** one non-positive radius rejects the whole batch, the same contract
   [`filleted(edges:radius:)`](#filletededgesradius) applies to its single radius (#489), and one
-  index that does not resolve rejects it too rather than being skipped (#520).
+  index that does not resolve rejects it too rather than being skipped (#520). The same edge index
+  named twice is **not** rejected: `BRepFilletAPI_MakeFillet::Add(radius, edge)` writes to that
+  edge's own fillet-contour slot, so the *second* call silently overwrites the first radius (#633).
+  Unchanged, existing behaviour -- see [`blendedEdgesWithReport(_:)`](#blendededgeswithreport_) for
+  the same fillet with a report naming which entries a duplicate overwrote.
 - **Example:**
   ```swift
   let blended = shape.blendedEdges([
@@ -1808,6 +1822,40 @@ public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Sha
 
   // Rejected: 99_999 names no edge, so the batch fails rather than filleting edge 0
   let outOfRange = shape.blendedEdges([(0, 1.0), (99_999, 2.0)])  // nil
+
+  // Not rejected: edge 0's first radius (1.0) is silently overwritten by the second (3.0)
+  let overwritten = shape.blendedEdges([(0, 1.0), (0, 3.0)])
+  ```
+
+---
+
+### `blendedEdgesWithReport(_:)`
+
+`blendedEdges(_:)`, also reporting which requested edges OCCT declined to fillet, and which
+duplicate entries a later request overwrote (#633).
+
+```swift
+public func blendedEdgesWithReport(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> FilletResult?
+```
+
+- **Parameters:** same as `blendedEdges(_:)`.
+- **Returns:** a `FilletResult`, or `nil` on failure under the same conditions as
+  `blendedEdges(_:)`.
+- **OCCT:** `BRepFilletAPI_MakeFillet.Add(radius, edge)` (via `OCCTShapeBlendEdges`), reading
+  `Contour(edge)` for each requested edge after `Add()` and before `Build()` for the declined-edge
+  axis; the duplicate-overwrite axis is computed Swift-side from `edgeRadii` itself and needs no
+  OCCT call at all, since an edge index maps to exactly one edge regardless of how many times it is
+  requested.
+- **Notes:** neither report changes the shape returned, which is byte-identical to what
+  `blendedEdges(_:)` gives for the same input. See `Shape.FilletResult` above for the mirror-the-
+  request convention both of its list fields share.
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  if let report = box.blendedEdgesWithReport([(0, 2.0), (0, 5.0)]) {
+      print(report.overwrittenDuplicateIndices)   // [0]: edge 0's first radius (2.0) was overwritten
+      print(report.declinedEdgeIndices)            // []: every edge of a closed box fillets
+  }
   ```
 
 ---


### PR DESCRIPTION
## What & why

`BRepFilletAPI_MakeFillet::Add(radius, edge)` resolves an edge's own slot within its fillet
contour and writes there, so `blendedEdges(_:)` naming the same edge index twice in its
`edgeRadii` list writes that slot twice: the *second* `Add` silently overwrites the first radius,
with no exception, no false return, and nothing in the result to say a radius was ever discarded.

Re-measured on this tree rather than trusted from the issue (`swift run Censuses cluster-b`):
`blendedEdges([(0, 2.0), (0, 5.0)])` gives the identical volume (946.349541) to
`blendedEdges([(0, 5.0)])` and differs from `blendedEdges([(0, 2.0)])` (991.415927) -- last-wins,
confirmed.

Closes #633

This is the last open member of Cluster B (#665).

## The decision

Sequenced deliberately after #639, which decided the reporting mechanism for this same family's
other silent axis (an edge OCCT declines outright) and, in its own PR, recommended extending the
same `Shape.FilletResult` shape to also cover this issue's axis rather than re-deriving a
mechanism. That recommendation is taken here; I found no reason to deviate from it.

**Report, do not reject or pick a "winning" direction.** Converging `blendedEdges(_:)` onto reject,
or onto first-wins (matching the chamfer family, measured below), would change what it returns for
every existing caller who happens to name an edge twice and currently gets a built shape -- a
behaviour change wider than this issue, and the same move #639 rejected for its own axis.
`blendedEdges(_:)` itself is byte-for-byte unchanged.

**Fillet and chamfer disagree on duplicate-index direction, measured again rather than assumed.**
`Scripts/repro/cluster-b-fillet-edge-contract/`'s own headline finding stands: the fillet family
(`blendedEdges`, `filletEvolving`, `FilletBuilder.addEdge`) is last-wins, the chamfer family
(`chamferedTwoDistances`, `chamferedDistAngle`, `ChamferBuilder.addEdge`) is first-wins, both
internally consistent within their own family. Unifying the two onto one direction is a bigger,
separate decision (picking a direction and changing it for a whole family) than this issue's own
title suggests, and is left open.

## What changed

`blendedEdgesWithReport(_:)`, a new `WithReport` sibling, returns the existing
`Shape.FilletResult` -- extended with a second field, `overwrittenDuplicateIndices` -- rather than
a new result type (#490's standing lesson against parallel encodings of one idea). It mirrors
`declinedEdgeIndices`'s own convention: an edge requested three times, with two of those overwritten,
reports `[edge, edge]`, not `[edge]` -- the count matches how many entries of the caller's list were
discarded, not how many distinct edges were involved.

Computing the duplicate report needs no OCCT round trip at all: an edge index maps to exactly one
edge via `Shape`'s own `TopExp` enumeration, so which entries lose is a property of the caller's
`edgeRadii` array alone, resolved Swift-side (`Shape.overwrittenDuplicateIndices(in:)`,
`Shape+Modeling.swift`).

`blendedEdgesWithReport(_:)` also adopts #639's declined-edge mechanism for this entry point --
`OCCTShapeBlendEdges` gained the same two nullable trailing out-parameters
`OCCTShapeFilletEdges`/`OCCTShapeFilletEdgesLinear` already carry, threaded through the shared
`occtShapeFilletEdgeList` skeleton -- rather than leaving that field permanently empty for this one
sibling. A report that answered one axis and silently stayed blank on the other would be the same
shape of silent-wrong-answer this whole cluster exists to fix.

`FilletResult` gained an explicit `public init`: a `let` property with a default value is dropped
entirely from Swift's synthesized memberwise init (only a `var` with a default is exposed as an
overridable parameter -- confirmed by hand before relying on it, see the doc comment on the new
init), so the three existing `WithReport` call sites needed an explicit default to keep compiling
unchanged.

**`filletEvolving(_:)` measures the identical last-wins mechanism** (documented on
`EvolvingFilletEdge`'s own doc comment, confirmed again by this PR's re-measurement), and is
deliberately left alone: extending `filletEvolvingWithReport(_:)` with the same field is a natural
follow-up, not a requirement of an issue scoped to `blendedEdges(_:)` by its own title.

## Docs

- `docs/SEMVER.md`: recorded as additive, following #639's own "not an exception" precedent --
  re-checked the counter arithmetic (three non-compiling + ten behavioural = thirteen sections) and
  confirmed this PR does not move it.
- `docs/CHANGELOG.md`, `docs/API_REFERENCE.md` (+2 to the derived operation count via
  `Scripts/count-operations.py --fix`: the new method, and the new explicit `FilletResult.init` the
  counter also picks up as a public entry point -- 4,304 to 4,306), `README.md` headline count.
- `docs/reference/Shape-Features.md`: `Shape.FilletResult`, `blendedEdges(_:)` and the new
  `blendedEdgesWithReport(_:)` entries.
- `Scripts/repro/cluster-b-fillet-edge-contract/README.md` and `ClusterB.swift`: the measured grid
  values did not move (still OVERWRITE/SKIP the same way), only the annotations on the now-fixed
  row, plus a paragraph correcting the "one contract, chosen and applied" framing to "report, not
  converge," matching what #639 actually did for its own axis.

## Test plan

- [x] New test: `Tests/OCCTModelingTests/Issue633BlendedEdgesDuplicateReportTests.swift`, 7 cases,
      following `okf/policies/prove-the-test-fails.md`. Injection matrix (each restored and
      confirmed green afterward):

  | Injection | Result |
  |---|---|
  | The Swift-side helper drops the report (`return []`) | The 3 tests asserting a non-empty `overwrittenDuplicateIndices` fail; the 4 that expect it empty, or check `declinedEdgeIndices` only, correctly stay green |
  | The Swift-side helper deduplicates (`Array(Set(overwritten))`) instead of mirroring the request | Only the triple-duplicate test fails (`[0, 0]` collapses to `[0]`); the single-duplicate test is insensitive to this distinction and stays green |
  | `OCCTShapeBlendEdges` stops forwarding its two new out-parameters (`nullptr, nullptr` always) | The 2 tests asserting a non-empty `declinedEdgeIndices` fail; both duplicate-only tests, unaffected by this axis, correctly stay green |

- [x] Clean `swift build`, 0 errors, no new warnings, no `OCCTSWIFT_LOCAL`, no local `Libraries/`
      (pins `v2.0.0-kernel.1`).
- [x] Full `swift test`, no env overrides: **5,363 tests passing** (baseline 5,356 + 7 new), 2
      consecutive clean runs, no crash flake.
- [x] `swift run Censuses cluster-a` 45 rows, `cluster-b` 16 rows -- unchanged.
- [x] Four gate scripts (`check-bridge-index.py`, `check-null-handle-guards.py`,
      `check-docs-defaults.py`, `count-operations.py`) and the three `--self-test`s, from the repo
      root: all pass.
- [x] Zero em-dashes (code, docs, this PR body).

## Notes for the reviewer

- The fillet/chamfer first-wins/last-wins asymmetry itself is unchanged and not addressed here --
  see "The decision" above. Converging the two families is a real question with a real cost (a
  behaviour change on every existing caller of at least one family), and is deliberately left open
  rather than folded into an observability fix.
- `overwrittenDuplicateIndices` is computed entirely Swift-side; the only bridge change is
  threading #639's existing declined-edge out-parameters through `OCCTShapeBlendEdges`, following
  the exact pattern already established for its three siblings.
- The `FilletResult.init` needing to be explicit (rather than relying on the synthesized
  memberwise init) surprised me -- verified with a standalone Swift snippet before writing the fix,
  since a `let` property's default silently *not* becoming an overridable init parameter is easy to
  assume works like a `var`'s does.
