### PR TITLE
chore(#513, #667): build the Cluster D continuity census

### DIFF
--- a/Scripts/repro/censuses/CensusRunner.swift
+++ b/Scripts/repro/censuses/CensusRunner.swift
@@ -22,6 +22,7 @@ enum CensusRunner {
     static let censuses: [CensusEntry] = [
         CensusEntry(name: "cluster-a", summary: "sub-shape enumeration and orientation (#664)", run: ClusterA.run),
         CensusEntry(name: "cluster-b", summary: "fillet and chamfer edge-set contract (#665)", run: ClusterB.run),
+        CensusEntry(name: "cluster-d", summary: "continuity handling across the kernel and bridge (#513/#667)", run: ClusterD.run),
     ]
 
     static func main() {

--- a/Scripts/repro/censuses/ClusterD.swift
+++ b/Scripts/repro/censuses/ClusterD.swift
@@ -1,0 +1,619 @@
+// Cluster D census (#513/#667): continuity handling across the kernel and the bridge. #513 is
+// already written as prose -- 38 unaudited functions, four incompatible request encodings, two
+// live defects -- and named #490/#480/#398/#619 as the standing constraints this census must not
+// re-litigate: #490 already consolidated 19 continuity decoders down to 3
+// (`occtGeomAbsFromSurfaceContinuity`, `occtGeomAbsFromParametricContinuity`,
+// `occtGeomAbsFromAnalysisOrder`, all in `Sources/OCCTBridge/src/OCCTBridge_Internal.h`); #480
+// ruled the knot-splitting family's argument is a literal derivative order, never a `GeomAbs_Shape`;
+// #398 reduced nine continuity enums to two request vocabularies plus one result vocabulary
+// (`Sources/OCCTSwift/Continuity.swift`); #619 retired `continuityOrder` outright (it is
+// `@available(*, unavailable)` on this tree, not merely deprecated) rather than reinterpret it.
+//
+// This is the DYNAMIC half, following Cluster A/B's method: call each entry point against real
+// fixtures and record what comes back, as the primary evidence.
+// `classify_continuity_sites.py` (in this cluster's own
+// Scripts/repro/cluster-d-continuity/) is the STATIC cross-check: it classifies each named bridge
+// function's decoder by which of the three shared `occtGeomAbsFrom*` helpers its body calls (or
+// none, for the knot-splitting and plate families, which pass the literal integer through). Any
+// disagreement between the two would be reported in the README rather than reconciled away, per
+// Cluster A/B's own finding that this is the most valuable output a static cross-check produces --
+// this time there wasn't one, which the README also records rather than omits.
+//
+// Run with: swift run Censuses cluster-d
+//
+// This is the census only. It does not fix #437, #438, or BRepGraph.edgeMaxContinuity's stub.
+
+import Foundation
+import OCCTSwift
+import simd
+
+// MARK: - Report plumbing
+
+fileprivate func pad(_ s: String, _ width: Int) -> String {
+    s.count >= width ? s : s + String(repeating: " ", count: width - s.count)
+}
+
+fileprivate func printTable(_ title: String, _ header: [String], _ widths: [Int], _ rows: [[String]]) {
+    print("--- \(title) ---")
+    print(zip(header, widths).map { pad($0, $1) }.joined(separator: " | "))
+    print(widths.map { String(repeating: "-", count: $0) }.joined(separator: "-|-"))
+    for row in rows {
+        print(zip(row, widths).map { pad($0, $1) }.joined(separator: " | "))
+    }
+    print("row count: \(rows.count)")
+    print()
+}
+
+fileprivate func fmt(_ value: Double?) -> String {
+    guard let value else { return "nil" }
+    return String(format: "%.6f", value)
+}
+
+// MARK: - Shared knot-vector fixture (#480's own recipe, generalized across all four analyzers)
+//
+// `degree - multiplicity(knot) < ContinuityRange` is the rule GeomConvert_BSplineCurveKnotSplitting,
+// Geom2dConvert_BSplineCurveKnotSplitting, GeomConvert_BSplineSurfaceKnotSplitting and
+// Law_BSplineKnotSplitting all run, byte for byte identically (#480's own claim). Building the
+// SAME knot/multiplicity vector for all four geometry types in one place, rather than reproducing
+// each existing per-type test's private copy, is what lets this census show the claim rather than
+// cite it.
+
+fileprivate func knotVector(degree: Int, interiorKnots: Int, bumpAt: Int = 0, bumpMult: Int = 1)
+    -> (knots: [Double], mults: [Int32], poleCount: Int)
+{
+    var knots: [Double] = [0]
+    var mults: [Int32] = [Int32(degree + 1)]
+    for i in 1...interiorKnots {
+        knots.append(Double(i))
+        mults.append(Int32(i == bumpAt ? bumpMult : 1))
+    }
+    knots.append(Double(interiorKnots + 1))
+    mults.append(Int32(degree + 1))
+    let poleCount = Int(mults.reduce(0, +)) - degree - 1
+    return (knots, mults, poleCount)
+}
+
+// Neither measurement below touches a deprecated overload. `ContinuityClass` is `CaseIterable`
+// over all seven `GeomAbs_Shape` ordinals (through `.cN` = 6), and `continuityWith(order:)` and
+// `bsplineRestrictionAdvanced(continuity3d:continuity2d:)` both take it directly -- so `.c3`/`.cN`,
+// which `occtGeomAbsFromAnalysisOrder` saturates down to `.c2`, are reachable through the TYPED
+// entry point without needing the raw-Int siblings #490 deprecated. That was not obvious going in:
+// the first draft of this file reached for the deprecated overloads before noticing the typed one
+// already accepts every enum case, saturating ones included.
+
+/// #490: `bsplineRestrictionAdvanced`'s now-deprecated raw-Int overload used to read `2` as
+/// `GeomAbs_C1` (one class below `bsplineRestriction`'s own `.c2`). Confirms convergence holds on
+/// this tree by comparing the two current, typed call spellings against the same fixture at the
+/// same requested continuity. (The deprecated raw-Int overload is not exercised here: its body
+/// forwards to the identical C call with the identical converted `Int32`, so it is structurally
+/// guaranteed to agree -- confirmed by reading `Sources/OCCTSwift/Shape+ShapeHealing.swift`'s two
+/// `bsplineRestrictionAdvanced` overloads side by side, not by re-deriving it dynamically.)
+fileprivate func clusterDRecordBSplineRestrictionConvergence() {
+    var rows: [[String]] = []
+    for continuity in ParametricContinuity.allCases {
+        let b1 = SharedFixture.splitBoxCompound(order: .asSplit)
+        let b2 = SharedFixture.splitBoxCompound(order: .asSplit)
+        let viaPlain = b1.bsplineRestriction(continuity3d: continuity, continuity2d: continuity)
+        let viaAdvancedTyped = Shape.bsplineRestrictionAdvanced(
+            b2, continuity3d: continuity, continuity2d: continuity)
+        let vPlain = viaPlain?.volume
+        let vAdvTyped = viaAdvancedTyped?.volume
+        let allNil = vPlain == nil && vAdvTyped == nil
+        let allAgree = allNil || ([vPlain, vAdvTyped].compactMap { $0 }.count == 2
+            && abs((vPlain ?? 0) - (vAdvTyped ?? -1)) < 1e-6)
+        rows.append([
+            "\(continuity)", fmt(vPlain), fmt(vAdvTyped),
+            allAgree ? "AGREE (converged, #490)" : "DISAGREE",
+        ])
+    }
+    printTable("2e. bsplineRestriction vs bsplineRestrictionAdvanced(typed) -- same compound, same continuity",
+               ["continuity", "bsplineRestriction", "Advanced (typed)", "verdict"],
+               [12, 20, 20, 26], rows)
+}
+
+/// `occtGeomAbsFromAnalysisOrder` saturates at `GeomAbs_C2` (raw 4): `.c3` and `.cN`, both real
+/// `ContinuityClass` cases, decode to the same effective order as `.c2`. Measured via the typed
+/// `continuityWith(order:)` overload across every `ContinuityClass` case, not just the five the
+/// analyzer itself implements a branch for -- `ContinuityAnalysis.order` reports where the request
+/// actually landed.
+fileprivate func clusterDRecordAnalysisOrderSaturation() {
+    guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0)]),
+          let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)]) else {
+        print("Cluster D census: could not build the smooth-junction curve fixture.")
+        return
+    }
+    var rows: [[String]] = []
+    for requested in ContinuityClass.allCases {
+        let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound, order: requested)
+        rows.append(["\(requested)", analysis.map { "\($0.order)" } ?? "nil"])
+    }
+    printTable("4a. Curve3D.continuityWith(order: ContinuityClass) -- every case, effective order read back via ContinuityAnalysis.order",
+               ["requested", "effective order"], [12, 30], rows)
+
+    // Reading LocalAnalysis_SurfaceContinuity::SurfC2 directly (Libraries/occt-src, not shipped
+    // in the pinned kernel's headers): it needs a nonzero SECOND derivative in BOTH parametric
+    // directions on BOTH surfaces, or it reports LocalAnalysis_NullSecondDerivative and the whole
+    // analysis returns nil. A plane fails this in both directions (`identicalPlanes`'s own doc
+    // comment already says so). A cylinder was tried here first and ALSO failed it -- measured,
+    // not assumed -- because a cylinder's height parametrization is a straight line, so D2V is
+    // exactly zero even though D2U (around the curved direction) is not. A sphere has nonzero
+    // curvature in both directions and is what actually reaches the C2 branch.
+    guard let s1 = Surface.sphere(center: .zero, radius: 5.0),
+          let s2 = Surface.sphere(center: .zero, radius: 5.0) else {
+        print("Cluster D census: could not build the sphere fixture.")
+        return
+    }
+    var surfRows: [[String]] = []
+    for requested in ContinuityClass.allCases {
+        let analysis = s1.continuityWith(s2, u1: 0.1, v1: 0.1, u2: 0.1, v2: 0.1, order: requested)
+        surfRows.append(["\(requested)", analysis.map { "\($0.order)" } ?? "nil"])
+    }
+    printTable("4b. Surface.continuityWith(order: ContinuityClass) -- identical spheres (curvature in both directions), every case, effective order read back",
+               ["requested", "effective order"], [12, 30], surfRows)
+}
+
+enum ClusterD {
+    static func run() {
+        var totalMeasured = 0
+
+        // MARK: 1. Knot-splitting family: one contract across (at least) five public entry points
+        //
+        // #480: the argument is a literal derivative order, not a GeomAbs_Shape. Decoding it
+        // first would be wrong -- GeomAbs_C3 is ordinal 5, and would split a cubic at every
+        // interior knot where `.c3` (the literal value 3) must split at none. This section
+        // measures, rather than cites, that all five entry points agree.
+
+        do {
+            let (knots, mults, poleCount) = knotVector(degree: 3, interiorKnots: 4)
+            let curve3D = Curve3D.bspline(
+                poles: (0..<poleCount).map { SIMD3(Double($0), Double($0 % 3) - 1, 0) },
+                knots: knots, multiplicities: mults, degree: 3)
+            let curve2D = Curve2D.bspline(
+                poles: (0..<poleCount).map { SIMD2(Double($0), Double($0 % 3) - 1) },
+                knots: knots, multiplicities: mults, degree: 3)
+            let law = LawFunction.bspline(
+                poles: (0..<poleCount).map { Double($0 % 4) * 1.5 },
+                knots: knots, multiplicities: mults, degree: 3)
+            let surface = Surface.bspline(
+                poles: (0..<poleCount).map { u in
+                    (0..<poleCount).map { v in SIMD3<Double>(Double(u), Double(v), Double((u + v) % 3) * 0.5) }
+                },
+                knotsU: knots, multiplicitiesU: mults,
+                knotsV: knots, multiplicitiesV: mults,
+                degreeU: 3, degreeV: 3)
+
+            var rows: [[String]] = []
+            for continuity in ParametricContinuity.allCases {
+                let c3d = curve3D?.continuityBreaks(minContinuity: continuity)?.count
+                let c2d = curve2D?.splitIndicesAtDiscontinuities(continuity: continuity)?.count
+                let lawSplits = law?.knotSplitting(continuityOrder: continuity).count
+                let lawParams = law?.knotSplitParameters(continuityOrder: continuity).count
+                let surf = surface?.knotSplitting(uContinuity: continuity, vContinuity: continuity)
+                rows.append([
+                    "\(continuity)",
+                    c3d.map(String.init) ?? "nil",
+                    c2d.map(String.init) ?? "nil",
+                    lawSplits.map(String.init) ?? "nil",
+                    lawParams.map(String.init) ?? "nil",
+                    surf.map { "\($0.uSplitCount)/\($0.vSplitCount)" } ?? "nil",
+                ])
+            }
+            printTable(
+                "1. Knot-splitting: literal derivative order, identical cubic (4 simple interior knots) across all four analyzers",
+                ["continuity", "Curve3D.continuityBreaks", "Curve2D.splitIndicesAtDiscontinuities",
+                 "LawFunction.knotSplitting", "LawFunction.knotSplitParameters", "Surface.knotSplitting (u/v)"],
+                [12, 26, 38, 26, 29, 28],
+                rows)
+            totalMeasured += 5
+
+            // The "genuine kink" variant (#480's own second fixture): multiplicity 3 on a cubic
+            // leaves continuity 0 at that knot, so even .c0 already sees a real break there while
+            // interior SIMPLE knots still need .c3. Prints once as corroboration, not a new row.
+            let (kKnots, kMults, kPoles) = knotVector(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3)
+            let kinkLaw = LawFunction.bspline(
+                poles: (0..<kPoles).map { Double($0 % 4) * 1.5 },
+                knots: kKnots, multiplicities: kMults, degree: 3)
+            print("genuine-kink fixture (mult 3 at knot 2 of a cubic): "
+                  + "LawFunction.knotSplitParameters() default (.c1) = "
+                  + "\(kinkLaw?.knotSplitParameters() ?? [])"
+                  + " -- a real discontinuity the .c1 default is expected to find")
+            print()
+        }
+
+        // MARK: 2. ParametricContinuity decoder: raw-int saturation, where the Swift layer still
+        // permits an out-of-range value
+        //
+        // #398/#490 typed most of this family's callers against `ParametricContinuity`
+        // (`CaseIterable`, four values), which makes an out-of-range raw int UNCONSTRUCTIBLE at
+        // the Swift layer -- that is the intended effect of the typing work, not a gap in this
+        // census. The handful of sites below still take a raw `Int` (some deliberately, for
+        // backward compatibility; some because #490 left them untyped) and so are the only ones
+        // this census can probe for the shared decoder's saturation rule directly.
+
+        do {
+            let (kKnots, kMults, kPoles) = knotVector(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3)
+            let poles3D = (0..<kPoles).map { SIMD3<Double>(Double($0) * 2, Double($0 % 2) * 3, 0) }
+            let probes = [-1, 0, 1, 2, 3, 4, 5, 99]
+
+            var rows: [[String]] = []
+            for probe in probes {
+                let curve = Curve3D.bspline(poles: poles3D, knots: kKnots, multiplicities: kMults, degree: 3)
+                let pieceCount = curve?.splitByContinuity(criterion: probe).count
+                rows.append(["\(probe)", pieceCount.map(String.init) ?? "nil"])
+            }
+            printTable("2a. Curve3D.splitByContinuity(criterion: Int) -- pieces on a cubic with one genuine kink (mult 3)",
+                       ["probe", "piece count"], [8, 12], rows)
+            totalMeasured += 1
+
+            // 2b. The #438-shaped duplicate this census found beyond #513's own list:
+            // Surface.splitByContinuity (OCCTSurfaceSplitByContinuity, struct-return) and
+            // Surface.splitSurfaceByContinuity (OCCTSplitSurfaceContinuity, out-param return) both
+            // wrap ShapeUpgrade_SplitSurfaceContinuity and both now read `criterion` as
+            // ParametricContinuity's raw value (the doc comments on both say so, and both cite
+            // #490 for having previously disagreed). Measured side by side to confirm agreement
+            // holds today, not just that the doc comments assert it.
+            let poles2D = (0..<kPoles).map { u in (0..<kPoles).map { v in SIMD3<Double>(Double(u), Double(v), Double((u + v) % 3)) } }
+            var surfRows: [[String]] = []
+            for probe in probes {
+                let s1 = Surface.bspline(poles: poles2D, knotsU: kKnots, multiplicitiesU: kMults,
+                                          knotsV: kKnots, multiplicitiesV: kMults, degreeU: 3, degreeV: 3)
+                let s2 = Surface.bspline(poles: poles2D, knotsU: kKnots, multiplicitiesU: kMults,
+                                          knotsV: kKnots, multiplicitiesV: kMults, degreeU: 3, degreeV: 3)
+                let a = s1?.splitByContinuity(criterion: probe, tolerance: 1e-6)
+                let b = s2?.splitSurfaceByContinuity(criterion: probe, tolerance: 1e-6)
+                let agree = (a?.uSplitCount == b?.uSplitCount) && (a?.vSplitCount == b?.vSplitCount)
+                surfRows.append([
+                    "\(probe)",
+                    a.map { "\($0.uSplitCount)/\($0.vSplitCount)" } ?? "nil",
+                    b.map { "\($0.uSplitCount)/\($0.vSplitCount)" } ?? "nil",
+                    agree ? "AGREE" : "DISAGREE",
+                ])
+            }
+            printTable("2b. TWO public APIs over ONE OCCT class (ShapeUpgrade_SplitSurfaceContinuity) -- #438's shape, found again",
+                       ["probe", "splitByContinuity (u/v)", "splitSurfaceByContinuity (u/v)", "verdict"],
+                       [8, 26, 32, 10], surfRows)
+            totalMeasured += 2
+
+            // 2c. FilletBuilder.setContinuity / ThruSectionsBuilder.setContinuity: #513 named the
+            // former a live one-class-low defect from a raw cast; the current source (read before
+            // writing this census) already routes both through occtGeomAbsFromParametricContinuity
+            // with a comment citing #513 by number. Measured here as "does it still build, and
+            // does an out-of-range probe still saturate rather than crash", since the actual
+            // routing is confirmed by classify_continuity_sites.py's static read, not by
+            // re-deriving GeomAbs_Shape ordinals from a fillet's resulting volume.
+            let box = SharedFixture.plainBox()
+            var filletRows: [[String]] = []
+            for probe in probes {
+                guard let builder = FilletBuilder(shape: box) else { continue }
+                let e0 = box.edges()[0]
+                builder.addEdge(e0, radius: 2.0)
+                builder.setContinuity(probe, angularTolerance: 1e-4)
+                let volume = builder.build()?.volume
+                filletRows.append(["\(probe)", volume.map { String(format: "%.4f", $0) } ?? "nil (build failed)"])
+            }
+            printTable("2c. FilletBuilder.setContinuity(_:angularTolerance:) -- resulting volume per probe (box, one edge filleted r=2)",
+                       ["probe", "volume"], [8, 28], filletRows)
+            totalMeasured += 1
+
+            var loftRows: [[String]] = []
+            for probe in probes {
+                guard let w1 = Wire.circle(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), radius: 5),
+                      let w2 = Wire.circle(origin: SIMD3(0, 0, 10), normal: SIMD3(0, 0, 1), radius: 3),
+                      let s1 = Shape.fromWire(w1), let s2 = Shape.fromWire(w2) else { continue }
+                let loft = ThruSectionsBuilder(isSolid: true, isRuled: false)
+                loft.addWire(s1)
+                loft.addWire(s2)
+                loft.setContinuity(probe)
+                let ok = loft.build()
+                loftRows.append(["\(probe)", ok ? "built (volume \(fmt(loft.shape?.volume)))" : "build FAILED"])
+            }
+            printTable("2d. ThruSectionsBuilder.setContinuity(_:) -- two-circle loft, per probe",
+                       ["probe", "result"], [8, 40], loftRows)
+            totalMeasured += 1
+
+            // 2e. bsplineRestriction vs bsplineRestrictionAdvanced (typed): #490's headline claim
+            // was that these two entry points drove the SAME OCCT operation off two DIFFERENT
+            // numberings, and that passing the literal `2` silently meant C2 through one and C1
+            // through the other. Re-measured here, on this tree, rather than trusted from the
+            // issue text.
+            clusterDRecordBSplineRestrictionConvergence()
+            totalMeasured += 2
+
+            // 2f. #438 itself, generalized: divided(at:) vs dividedByContinuity(criterion:) on the
+            // SAME shape. Not fixed here -- #667 says do the census, then the instances fall out --
+            // but measured so the README states what "two public APIs, one OCCT class" actually
+            // produces today rather than repeating #438's prose description of the two setter calls.
+            // Neither a plain box nor a cylinder works as a fixture here: both this tree's own tests
+            // (`ShapeUpgradeDivideContinuityTests.divideBoxContinuity`, `AdvancedHealingTests.
+            // divideCylinder`) tolerate nil ("may return nil/the same shape if no divisions
+            // needed"), and measured here, BOTH APIs return nil on both at every continuity -- a
+            // planar box has no interior surface knots to divide at, and a cylinder's single
+            // lateral face is one smooth periodic surface with none either. A face built directly
+            // from a kinked BSpline surface (mult-3 knot, genuinely C0 at one interior knot) gives
+            // both APIs something real to divide.
+            let (dKnots, dMults, dPoles) = knotVector(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3)
+            func kinkedSurfaceShape() -> Shape? {
+                guard let surface = Surface.bspline(
+                    poles: (0..<dPoles).map { u in (0..<dPoles).map { v in SIMD3<Double>(Double(u), Double(v), Double((u + v) % 3) * 0.5) } },
+                    knotsU: dKnots, multiplicitiesU: dMults, knotsV: dKnots, multiplicitiesV: dMults,
+                    degreeU: 3, degreeV: 3) else { return nil }
+                let bounds = surface.domain
+                return Shape.face(from: surface, uRange: bounds.uMin...bounds.uMax, vRange: bounds.vMin...bounds.vMax)
+            }
+            var divideRows: [[String]] = []
+            for continuity in ParametricContinuity.allCases {
+                let viaDivided = kinkedSurfaceShape()?.divided(at: continuity)
+                let level = Shape.ContinuityLevel(rawValue: continuity.rawValue) ?? .c1
+                let viaDividedBy = kinkedSurfaceShape()?.dividedByContinuity(criterion: level, tolerance: 1e-4)
+                divideRows.append([
+                    "\(continuity)",
+                    viaDivided.map { "\($0.faceCount) faces" } ?? "nil",
+                    viaDividedBy.map { "\($0.faceCount) faces" } ?? "nil",
+                    (viaDivided?.faceCount == viaDividedBy?.faceCount) ? "SAME face count" : "DIFFERENT",
+                ])
+            }
+            printTable("2f. #438: divided(at:) vs dividedByContinuity(criterion:) -- same kinked-surface face, matching continuity",
+                       ["continuity", "divided(at:)", "dividedByContinuity(criterion:)", "verdict"],
+                       [12, 22, 34, 20], divideRows)
+            totalMeasured += 2
+
+            // 2g. Shape.ContinuityLevel's own g1/g2 extension (raw 5, 6) -- documented in
+            // OCCTBridge_Internal.h as a special case bolted onto occtGeomAbsFromParametricContinuity
+            // rather than reachable through it, because ShapeUpgrade_ShapeDivideContinuity's own
+            // SetCriterion does not recognise G1/G2 and would otherwise substitute its own C1
+            // default. Measured directly rather than re-read from the comment.
+            var levelRows: [[String]] = []
+            for level in Shape.ContinuityLevel.allCases {
+                let result = kinkedSurfaceShape()?.dividedByContinuity(criterion: level, tolerance: 1e-4)
+                levelRows.append(["\(level)", result.map { "\($0.faceCount) faces" } ?? "nil"])
+            }
+            printTable("2g. Shape.ContinuityLevel's full domain (0..6, includes g1/g2 special-cased in the bridge)",
+                       ["level", "dividedByContinuity result"], [8, 30], levelRows)
+            totalMeasured += 1
+        }
+
+        // MARK: 3. SurfaceContinuity family: filling (decodes through occtGeomAbsFromSurfaceContinuity)
+        // vs plate (raw pass-through into GeomPlate_PointConstraint/CurveConstraint's own literal
+        // order -- reading OCCTBridge_ProjLib_NLPlate.mm shows NO occtGeomAbsFrom* call in
+        // OCCTShapePlateCurves/PointsAdvanced/Mixed at all, just an `if (order > 2) order = 2;`
+        // clamp). #437's own claim -- a point constraint can never accept .g2 -- reproduced here
+        // against the current tree rather than assumed from the issue text.
+
+        do {
+            guard let e0 = Wire.line(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)),
+                  let e1 = Wire.line(from: SIMD3(10, 0, 0), to: SIMD3(10, 10, 5)),
+                  let e2 = Wire.line(from: SIMD3(10, 10, 5), to: SIMD3(0, 10, 3)),
+                  let e3 = Wire.line(from: SIMD3(0, 10, 3), to: SIMD3(0, 0, 0)) else {
+                print("Cluster D census: could not build the fill boundary fixture.")
+                return
+            }
+            var fillRows: [[String]] = []
+            for continuity in SurfaceContinuity.allCases {
+                let face = Shape.fill(boundaries: [e0, e1, e2, e3], parameters: FillingParameters(continuity: continuity))
+                fillRows.append(["\(continuity)", face != nil ? "built (area \(fmt(face?.surfaceArea)))" : "nil"])
+            }
+            printTable("3a. Shape.fill(boundaries:parameters:) -- SurfaceContinuity via occtGeomAbsFromSurfaceContinuity",
+                       ["continuity", "result"], [12, 34], fillRows)
+            totalMeasured += 1
+
+            let box = SharedFixture.plainBox()
+            var fsRows: [[String]] = []
+            for continuity in SurfaceContinuity.allCases {
+                let filling = FillingSurface()
+                for edge in box.edges().prefix(4) {
+                    filling.add(edge: edge, continuity: continuity)
+                }
+                let built = filling.build()
+                fsRows.append([
+                    "\(continuity)",
+                    built != nil ? "built" : "nil",
+                    fmt(filling.g0Error), fmt(filling.g1Error), fmt(filling.g2Error),
+                ])
+            }
+            printTable("3b. FillingSurface.add(edge:continuity:) -- first 4 box edges as boundary",
+                       ["continuity", "result", "g0Error", "g1Error", "g2Error"], [12, 10, 12, 12, 12], fsRows)
+            totalMeasured += 1
+
+            // #437 reproduction: point constraints reject order > 1 (.g2 = 2), curve constraints
+            // accept it. Both go through the SAME raw pass-through, not occtGeomAbsFromSurfaceContinuity.
+            let points: [SIMD3<Double>] = [
+                SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2), SIMD3(0, 10, 1), SIMD3(5, 5, 3),
+            ]
+            var plateRows: [[String]] = []
+            for continuity in SurfaceContinuity.allCases {
+                let uniformOrders = Array(repeating: continuity, count: points.count)
+                let pointResult = Shape.plateSurface(through: points, orders: uniformOrders)
+                plateRows.append(["point (plateSurface(through:orders:))", "\(continuity)",
+                                   pointResult != nil ? "built" : "nil -- #437"])
+            }
+            for continuity in SurfaceContinuity.allCases {
+                guard let curveWire = Wire.circle(origin: .zero, normal: SIMD3(0, 0, 1), radius: 8) else { continue }
+                let curveResult = Shape.plateSurface(constrainedBy: [curveWire], continuity: continuity)
+                plateRows.append(["curve (plateSurface(constrainedBy:continuity:))", "\(continuity)",
+                                   curveResult != nil ? "built" : "nil"])
+            }
+            printTable("3c. #437: plate point constraint vs curve constraint, same continuity domain, raw pass-through (no GeomAbs decode)",
+                       ["constraint kind", "continuity", "result"], [46, 12, 24], plateRows)
+            totalMeasured += 2
+
+            // Mixed constraint call: one point at .g2 alongside one curve at .g2, isolating which
+            // constraint kind fails the WHOLE call (#437's own second example).
+            if let curveWire = Wire.circle(origin: SIMD3(20, 0, 0), normal: SIMD3(0, 0, 1), radius: 5) {
+                let mixedPointG2 = Shape.plateSurface(
+                    pointConstraints: [(point: SIMD3(0, 0, 0), order: .g2)],
+                    curveConstraints: [(wire: curveWire, order: .g0)])
+                let mixedCurveG2 = Shape.plateSurface(
+                    pointConstraints: [(point: SIMD3(0, 0, 0), order: .g0)],
+                    curveConstraints: [(wire: curveWire, order: .g2)])
+                print("3d. plateSurface(pointConstraints:curveConstraints:) mixed call:")
+                print("    one .g2 POINT among otherwise-.g0 constraints -> \(mixedPointG2 != nil ? "built" : "nil -- the whole call fails on the point alone")")
+                print("    one .g2 CURVE among otherwise-.g0 constraints -> \(mixedCurveG2 != nil ? "built" : "nil")")
+                print()
+                totalMeasured += 1
+            }
+        }
+
+        // MARK: 4. AnalysisOrder decoder (occtGeomAbsFromAnalysisOrder): saturates at C2 (raw 4).
+        // `ContinuityAnalysis.order` reports the class the bridge actually settled on, which is
+        // what makes this decoder directly observable through the typed API alone (see the
+        // function's own doc comment for why no deprecated overload is needed here).
+
+        clusterDRecordAnalysisOrderSaturation()
+        totalMeasured += 2
+
+        // MARK: 5. Result side: two different OCCT calls answer "what continuity across this edge",
+        // only one of which was migrated to ContinuityClass (#485/#495). Measured on the same
+        // (edge, face1, face2) triples so any disagreement is visible directly.
+
+        do {
+            func sharedEdgeTriples(in shape: Shape) -> [(Shape, Shape, Shape)] {
+                let faces = shape.subShapes(ofType: .face)
+                return shape.subShapes(ofType: .edge).compactMap { edge in
+                    let adjacent = shape.adjacentFaces(forEdge: edge)
+                    guard adjacent.count == 2,
+                          let a = adjacent.first, let b = adjacent.last,
+                          a >= 0, a < faces.count, b >= 0, b < faces.count
+                    else { return nil }
+                    return (edge, faces[a], faces[b])
+                }
+            }
+
+            let box = SharedFixture.plainBox()
+            let filletedBox = Shape.box(width: 20, height: 20, depth: 20)?.filleted(radius: 3)
+            let cylinder = Shape.cylinder(radius: 5, height: 10)
+
+            var rows: [[String]] = []
+            if let firstBoxTriple = sharedEdgeTriples(in: box).first {
+                let (e, f1, f2) = firstBoxTriple
+                rows.append([
+                    "box sharp edge",
+                    "\(Shape.continuity(edge: e, face1: f1, face2: f2))",
+                    "\(Shape.continuityClassOfFaces(edge: e, face1: f1, face2: f2).map(String.init(describing:)) ?? "nil")",
+                ])
+            }
+            if let filletedBox, let g1Triple = sharedEdgeTriples(in: filletedBox).first(where: {
+                Shape.continuityClassOfFaces(edge: $0.0, face1: $0.1, face2: $0.2) == .g1
+            }) {
+                let (e, f1, f2) = g1Triple
+                rows.append([
+                    "filleted box, G1 join",
+                    "\(Shape.continuity(edge: e, face1: f1, face2: f2))",
+                    "\(Shape.continuityClassOfFaces(edge: e, face1: f1, face2: f2).map(String.init(describing:)) ?? "nil")",
+                ])
+            }
+            if let cylinder {
+                outer: for face in cylinder.subShapes(ofType: .face) {
+                    for edge in face.subShapes(ofType: .edge) {
+                        if Shape.continuityClassOfFaces(edge: edge, face1: face, face2: face) == .cN {
+                            rows.append([
+                                "cylinder seam (self-pair)",
+                                "\(Shape.continuity(edge: edge, face1: face, face2: face))",
+                                "\(ContinuityClass.cN)",
+                            ])
+                            break outer
+                        }
+                    }
+                }
+            }
+            printTable("5a. Shape.continuity(edge:face1:face2:) [BRep_Tool, raw Int, NOT migrated] vs continuityClassOfFaces [BRepLib, ContinuityClass, migrated #495]",
+                       ["fixture", "Shape.continuity (raw)", "continuityClassOfFaces"], [26, 24, 24], rows)
+            totalMeasured += 2
+
+            // The cylinder row above disagrees (0 vs cN). The first hypothesis tried -- BRep_Tool::
+            // Continuity reads a flag BRepLib::EncodeRegularity has to write first, and a raw
+            // Shape.cylinder() never ran it -- does NOT hold, measured directly: encoding
+            // regularity first and re-measuring the SAME self-paired seam edge still reports 0.
+            // Reading Issue495FaceContinuityTests' own comment again narrows it instead:
+            // BRepLib::ContinuityOfFaces "short-circuits to GeomAbs_CN when the two faces are the
+            // same face and the surface is elementary" -- a special case in THAT function's own
+            // algorithm, not a generic cached-vs-computed distinction. BRep_Tool::Continuity has no
+            // such shortcut and a seam seemingly never gets an explicit stored value either way.
+            // Left as a reported disagreement with a narrowed but unconfirmed mechanism, not a
+            // guess dressed as a finding -- the source for BRep_Tool::Continuity's storage lookup
+            // itself is not shipped in this release's headers to trace further.
+            if let cylinder, let encoded = cylinder.encodingRegularity() {
+                outer: for face in encoded.subShapes(ofType: .face) {
+                    for edge in face.subShapes(ofType: .edge) {
+                        if Shape.continuityClassOfFaces(edge: edge, face1: face, face2: face) == .cN {
+                            print("5a (continued). SAME cylinder AFTER Shape.encodingRegularity(): "
+                                  + "Shape.continuity(edge:face1:face2:) = \(Shape.continuity(edge: edge, face1: face, face2: face)) "
+                                  + "-- STILL disagrees with continuityClassOfFaces' cN; encoding regularity did not close the gap")
+                            print()
+                            break outer
+                        }
+                    }
+                }
+                totalMeasured += 1
+            }
+
+            if let firstBoxTriple = sharedEdgeTriples(in: box).first {
+                let (e, _, _) = firstBoxTriple
+                print("5b. Shape.maxContinuity(edge:) on the same box edge -> \(Shape.maxContinuity(edge: e))")
+                totalMeasured += 1
+            }
+
+            var resultRows: [[String]] = []
+            if let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)) {
+                resultRows.append(["Curve3D (analytic line)", "\(line.continuity)", "\(line.continuityClass)"])
+            }
+            // The exact fixture Continuity.swift's own doc comment for `continuityClass` uses
+            // (mult 4/2/4 leaves one derivative short of C2 at the middle knot): 6 poles.
+            if let c1Spline = Curve3D.bspline(
+                poles: (0..<6).map { SIMD3(Double($0), Double($0 % 2), 0) },
+                knots: [0, 0.5, 1], multiplicities: [4, 2, 4], degree: 3) {
+                resultRows.append(["Curve3D (mult-2 interior knot)", "\(c1Spline.continuity)", "\(c1Spline.continuityClass)"])
+            }
+            if let line2D = Curve2D.line(through: .zero, direction: SIMD2(1, 0)) {
+                resultRows.append(["Curve2D (analytic line)", "\(line2D.continuity)", "\(line2D.continuityClass)"])
+            }
+            if let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) {
+                resultRows.append(["Surface (analytic plane)", "\(plane.continuity)", "\(plane.continuityClass)"])
+            }
+            if let bezierCurve = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(1, 2, 0), SIMD3(2, -2, 0), SIMD3(3, 0, 0)]) {
+                resultRows.append(["Curve3D.bezierContinuity (Bezier curve)", "\(bezierCurve.bezierContinuity)", "n/a"])
+            }
+            printTable("5c. Result-side raw-cast family: continuity / continuityClass / bezierContinuity, per fixture",
+                       ["fixture", "continuity (raw)", "continuityClass"], [40, 18, 18], resultRows)
+            totalMeasured += 4
+        }
+
+        // MARK: 6. BRepGraph.edgeMaxContinuity: the live stub #513 flagged, still unfixed.
+        //
+        // OCCTBRepGraphEdgeMaxContinuity (OCCTBridge_BRepGraph.mm) is `int32_t OCCTBRepGraphEdgeMaxContinuity(OCCTBRepGraphRef, int32_t) { return 0; }`
+        // -- a hardcoded stub, source-read before writing this section. 0 is also GeomAbs_C0, an
+        // ordinary answer, so nothing about a single call site proves it is a stub rather than a
+        // real (if boring) measurement. What proves it: EVERY edge on a shape whose seam is
+        // genuinely CN reports 0 through the graph, while the shape-based sibling that reads the
+        // same BRep_Tool::MaxContinuity the graph's own comment says to use instead reports the
+        // real class on at least one edge of the identical shape.
+
+        do {
+            guard let cylinder = Shape.cylinder(radius: 5, height: 10),
+                  let graph = BRepGraph(shape: cylinder) else {
+                print("Cluster D census: could not build the BRepGraph fixture.")
+                return
+            }
+            let allZero = (0..<graph.edgeCount).allSatisfy { graph.edgeMaxContinuity($0) == 0 }
+            print("6. BRepGraph.edgeMaxContinuity(_:), cylinder, all \(graph.edgeCount) edges: "
+                  + "\(allZero ? "ALL report 0 (the stub)" : "NOT all zero -- would contradict the source read")")
+
+            var maxContinuities: [Int] = []
+            for edge in cylinder.subShapes(ofType: .edge) {
+                maxContinuities.append(Shape.maxContinuity(edge: edge))
+            }
+            let sawNonzero = maxContinuities.contains { $0 != 0 }
+            print("   Shape.maxContinuity(edge:) (BRep_Tool, the documented replacement), same cylinder, "
+                  + "per-edge values: \(maxContinuities) -- \(sawNonzero ? "at least one nonzero, confirming the graph path is the one losing information" : "all zero on this fixture too")")
+            print()
+            totalMeasured += 1
+        }
+
+        // MARK: 7. Summary
+
+        print("=== Cluster D summary ===")
+        print("distinct entry points measured: \(totalMeasured)")
+        print("See Scripts/repro/cluster-d-continuity/README.md for the encodings as measured, the")
+        print("static cross-check (classify_continuity_sites.py) and its guard-removal matrix, and")
+        print("the verdict on #437/#438/#513.")
+    }
+}

--- a/Scripts/repro/cluster-d-continuity/README.md
+++ b/Scripts/repro/cluster-d-continuity/README.md
@@ -1,0 +1,370 @@
+# Cluster D census (#513/#667): continuity handling across the kernel and the bridge
+
+The census artifact `docs/v2.0.0-plan.md` names as a hard prerequisite before #437 or #438 starts.
+#513 already wrote the finding as prose: 38 unaudited continuity-related bridge functions, four
+incompatible request encodings, two live defects. This directory turns that prose into a committed,
+executable artifact that measures the CURRENT tree, rather than a list in an issue body that goes
+stale the next time someone touches this code (which, per #490/#480/#619, several PRs already have,
+since #513 was filed).
+
+**This directory is the census only. It does not fix #437, #438, or `BRepGraph.edgeMaxContinuity`'s
+stub.** #490, #480, #398 and #619 are prior art on this exact area and are cited inline rather than
+rederived, per this issue's own instruction not to rediscover them.
+
+## Method
+
+Two independent halves, matching Cluster A/B's own method:
+
+1. **Dynamic (primary).** `Scripts/repro/censuses/ClusterD.swift`, run as the `cluster-d` subcommand
+   of the shared `Censuses` executable target (`swift run Censuses cluster-d`), calls each
+   identified entry point against real fixtures and prints the measured table below. A cell says a
+   class name, a piece count, a face count or `nil` because it was *measured*, not because a doc
+   comment or an issue's own table says so.
+2. **Static (secondary cross-check).** `classify_continuity_sites.py` scans the bridge source for
+   each named C function and classifies which of the three shared `occtGeomAbsFrom*` decoders
+   (`Sources/OCCTBridge/src/OCCTBridge_Internal.h`, #490) its body calls, or whether it forwards the
+   caller's integer as a literal order with no decode step at all. Unlike Cluster A/B, this
+   classifier's function list was built by reading each site's source before writing either half of
+   this census, so no disagreement between the two surfaced this time -- recorded as a finding in
+   its own right below, not silently dropped.
+
+```bash
+swift run Censuses cluster-d
+python3 Scripts/repro/cluster-d-continuity/classify_continuity_sites.py
+python3 Scripts/repro/cluster-d-continuity/classify_continuity_sites.py --self-test
+```
+
+## How many entry points, measured against #513's 38
+
+- **31 distinct entry points measured dynamically** (`ClusterD.swift`'s own running total, printed
+  at the end of its output).
+- **42 named bridge functions classified statically**: 34 request-side (take a continuity as
+  input) + 8 result-side (report a measured continuity back to Swift). Adding the 3 trivial
+  one-line alias forwards #485 already covered (`OCCTCurve3DContinuity`/`OCCTCurve2DContinuity`/
+  `OCCTSurfaceContinuity`, each `return OCCTxxxGetContinuity(x);` and nothing else) gives **45**,
+  close to #513's own opening count of 44. The two counts differ because #513 counted a function
+  and its ABI-compatibility alias as two members of "44 total, 6 audited"; this census counts the
+  alias as the same finding as the function it forwards to and reports it once.
+- **#513's own "38 unaudited" is stale, not wrong at the time it was written.** #490's PR comment
+  ("Flagged in #513's census; fixed here because it is the same defect this issue is about") shows
+  at least two of #513's named live defects (`OCCTFilletBuilderSetContinuity`'s raw cast,
+  `OCCTThruSectionsSetContinuity`'s old 0/1-only reading) were fixed as PART OF #490's own PR,
+  which also consolidated 19 decoders into the 3 named above. Measuring the CURRENT tree rather
+  than trusting #513's text is the entire point of this census, and it is why the table below
+  looks different from #513's own.
+
+## The four encodings, as measured (today: five families, one is not really a fourth "encoding")
+
+| family | decoder | domain | saturates at |
+|---|---|---|---|
+| `SurfaceContinuity` (g0/g1/g2) | `occtGeomAbsFromSurfaceContinuity` | filling family (`OCCTFillingAddEdge`/`AddFreeEdge`/`AddEdgeWithSupport`, `OCCTShapeFill*`) | C1 (order >= 2) |
+| `ParametricContinuity` (c0-c3) | `occtGeomAbsFromParametricContinuity` | 17 request-side sites (split/approx/restriction/loft/fillet/divide families) | CN (raw >= 4) |
+| analysis order (0-4, interleaved) | `occtGeomAbsFromAnalysisOrder` | `LocalAnalysis_Curve/SurfaceContinuity` via `continuityWith(order:)` | C2 (raw >= 4, i.e. `.c3`/`.cN` both saturate to `.c2`) |
+| literal derivative order (NOT a `GeomAbs_Shape`) | none -- #480 rules decoding this is a bug | the four `*KnotSplitting` analyzers, 9 Swift entry points | the geometry's own degree, not the enum's ceiling |
+| literal `GeomPlate_PointConstraint`/`CurveConstraint` order (NOT a `GeomAbs_Shape` either) | none | `OCCTShapePlateCurves`/`PlatePointsAdvanced`/`PlateMixed` | `[-1, 2]`; anything outside is clamped, not decoded |
+
+Measured today, this is **five families**, not four -- but two of the five (the knot-splitting
+literal order and the plate literal order) are not "encodings" of a `GeomAbs_Shape` at all; they are
+two DIFFERENT raw pass-throughs into two DIFFERENT OCCT APIs' own literal-integer conventions, which
+happen to numerically coincide with `SurfaceContinuity`'s/`ParametricContinuity`'s own raw values at
+the low end without ever being decoded through either. #480's own addendum comment on #513 already
+flagged this as "a fifth request-side encoding" before this census existed; measuring confirms it and
+adds that the plate family is a SIXTH such pass-through, structurally identical in kind to the
+knot-splitting one but into a completely different OCCT class.
+
+The genuinely interesting number is **3**: the three canonical `GeomAbs_Shape` decoders #490 already
+converged the bridge onto. #513's "four incompatible encodings" pre-dates that convergence.
+
+## Knot-splitting family: one contract, confirmed across all five entry points on one fixture
+
+A cubic BSpline (4 simple interior knots, degree 3) fed identically to
+`Curve3D.continuityBreaks`, `Curve2D.splitIndicesAtDiscontinuities`,
+`LawFunction.knotSplitting`/`knotSplitParameters`, and `Surface.knotSplitting` (both directions at
+once):
+
+| continuity | Curve3D | Curve2D | LawFunction (indices) | LawFunction (params) | Surface (u/v) |
+|---|---|---|---|---|---|
+| c0 | 2 | 2 | 2 | 2 | 2/2 |
+| c1 | 2 | 2 | 2 | 2 | 2/2 |
+| c2 | 2 | 2 | 2 | 2 | 2/2 |
+| c3 | 6 | 6 | 6 | 6 | 6/6 |
+
+Byte-identical across every entry point at every level. #480's claim ("all four run a byte-for-byte
+identical algorithm") is confirmed, not cited, and extended to the fifth entry point
+(`LawFunction.knotSplitParameters`) #480's own text did not separately measure.
+
+## ParametricContinuity: saturation confirmed live, at every raw-Int-reachable site
+
+Probing `-1, 0, 1, 2, 3, 4, 5, 99` against a cubic BSpline with one genuine kink (multiplicity 3 at
+one interior knot -- a real C0-but-not-C1 discontinuity):
+
+`Curve3D.splitByContinuity(criterion:)` piece counts: `-1`->1, `0`->1, `1`->2, `2`->2, `3`->5,
+`4`->5, `5`->5, `99`->5. Negative saturates to C0 (whole curve, one piece -- a BSpline is always at
+least C0). `1`/`2` (C1/C2) both split only at the genuine kink (2 pieces). `3` and above all
+saturate to the SAME 5-piece answer: a cubic can never be more than C2 at a simple knot, so "ask for
+C3" and "ask for CN" both mean "split at every interior knot," identically.
+
+`Surface.splitByContinuity` and `Surface.splitSurfaceByContinuity` -- **the #438-shaped duplicate
+this census found beyond #513's own list**: two public Swift APIs, two separate bridge functions
+(`OCCTSurfaceSplitByContinuity`, struct-return; `OCCTSplitSurfaceContinuity`, out-param return),
+both wrapping `ShapeUpgrade_SplitSurfaceContinuity`. `Surface.swift`'s own doc comment on
+`splitSurfaceByContinuity` already says the two "used to disagree" and "both now agree" (#490).
+Measured across all 8 probes on the identical fixture: **AGREE at every probe.** #490's convergence
+claim holds today.
+
+`FilletBuilder.setContinuity`/`ThruSectionsBuilder.setContinuity`: both accept every probed value
+without crashing (matching the doc comments' own claim that OCCT accepts every value here), but
+neither produces an OBSERVABLE difference in the resulting volume on the fixtures tried (a
+single-edge box fillet; a two-circle loft) -- this measures "does the fix survive an out-of-range
+integer," not "which class did the request decode to," which the static classifier already answers
+directly for both (`ParametricContinuity`, confirmed).
+
+`bsplineRestriction` vs `bsplineRestrictionAdvanced` (typed): identical volumes at every
+`ParametricContinuity` case on the same fixture. #490's headline claim (these two entry points used
+to drive the identical OCCT operation off two different numberings) is confirmed fixed, not merely
+asserted.
+
+## SurfaceContinuity family: filling and plate agree on the RAW VALUE, disagree on WHAT consumes it
+
+`Shape.fill(boundaries:parameters:)` on a 4-edge free-standing quad: `.g0` builds (area
+108.451979); `.g1`/`.g2` both return `nil`. Expected, and documented: "Free-standing wires have no
+surface to be tangent to, so fill positionally" is the API's own doc comment, and this fixture has
+no support faces at all.
+
+`FillingSurface.add(edge:continuity:)` on the first 4 edges of a plain box: `.g0`/`.g1`/`.g2` all
+build, and `g0Error`/`g1Error`/`g2Error` all report exactly `0.0` regardless of the requested
+continuity. This is a fixture limitation, reported as one rather than smoothed over: those 4 edges
+plausibly bound one of the box's own planar faces, so any degree/segment budget fits it exactly at
+every continuity asked -- the fixture cannot distinguish g0 from g2 here, not because the encoding
+does not, but because a flat quad gives every continuity level the same trivial answer.
+
+### #437, reproduced directly against the current tree
+
+| constraint kind | g0 | g1 | g2 |
+|---|---|---|---|
+| point (`plateSurface(through:orders:)`) | built | built | **nil** |
+| curve (`plateSurface(constrainedBy:continuity:)`) | built | nil | nil |
+
+`.g2` fails for POINT constraints, matching #437 exactly (`GeomPlate_PointConstraint` throws above
+order 1). The curve constraint's own `.g1`/`.g2` both return nil on THIS fixture (a plain circle,
+which measures a separate, tolerance/geometry-shaped failure, not #437's own point-vs-curve claim --
+#437's own ground-truth table already establishes curve constraints accept order 2 directly against
+`GeomPlate_CurveConstraint`, so this fixture's g1/g2 failures are the `GeomPlate_BuildPlateSurface`
+solver declining to converge on an unconstrained free circle, not the same defect).
+
+A mixed call (one `.g2` point among otherwise-`.g0` constraints) fails the WHOLE call; one `.g2`
+curve among otherwise-`.g0` constraints also fails on this fixture (see the curve caveat above).
+Source read, not measured further: `OCCTShapePlateCurves`/`PlatePointsAdvanced`/`PlateMixed` all
+clamp the raw `SurfaceContinuity` value directly into `GeomPlate_PointConstraint`/
+`CurveConstraint`'s own literal order parameter (`if (order > 2) order = 2;`) -- there is no
+`occtGeomAbsFrom*` call anywhere in any of the three, confirmed by the static classifier
+independently.
+
+## AnalysisOrder: saturates at C2, confirmed through the TYPED entry point alone
+
+`ContinuityClass` is `CaseIterable` over all seven `GeomAbs_Shape` ordinals (through `.cN`), and
+`continuityWith(order:)` takes it directly -- so `.c3`/`.cN`, which `occtGeomAbsFromAnalysisOrder`
+saturates down to `.c2`, are reachable WITHOUT the deprecated raw-`Int` overloads #490 replaced. This
+census does not exercise those deprecated overloads at all (see `ClusterD.swift`'s own header
+comment on the point: the first draft reached for them before noticing the typed API already covers
+the saturating cases).
+
+`Curve3D.continuityWith`, smooth-junction fixture, every `ContinuityClass` requested, effective
+order read back: `c0`->c0, `g1`->g1, `c1`->c1, `g2`->g2, `c2`->c2, `c3`->**c2**, `cN`->**c2**.
+
+`Surface.continuityWith` needed a fixture with curvature in BOTH parametric directions, not one:
+
+- **Identical planes** (the existing `identicalPlanes` test's own fixture): `.c2` and above return
+  `nil`. Expected and documented (`identicalPlanes`'s own comment: "Planes have no second
+  derivative, so the `.c2` default is NullSecondDerivative").
+- **Identical cylinders**, tried next: `.c2` and above STILL return `nil`. Reading
+  `LocalAnalysis_SurfaceContinuity::SurfC2` directly (`Libraries/occt-src`, not shipped in this
+  release's own headers) explains why: it requires a nonzero SECOND derivative in BOTH parametric
+  directions on BOTH surfaces. A cylinder's height parametrization is a straight line, so `D2V` is
+  exactly zero even though `D2U` (around the curved direction) is not -- the same failure mode as a
+  plane, from the other axis.
+- **Identical spheres** (curvature in both directions): `c0`->c0, `g1`->g1, `c1`->c1, `g2`->g2,
+  `c2`->c2, `c3`->**c2**, `cN`->**c2**. Saturation confirmed, matching the curve side exactly.
+
+## Result side: two different OCCT calls answer "what continuity across this edge," one migrated
+
+`Shape.continuity(edge:face1:face2:)` (`OCCTBRepToolContinuity`, `BRep_Tool::Continuity`, raw `Int`,
+NOT migrated) vs `Shape.continuityClassOfFaces(edge:face1:face2:)` (`OCCTBRepLibContinuityOfFaces`,
+`BRepLib::ContinuityOfFaces`, `ContinuityClass`, migrated by #495):
+
+| fixture | `Shape.continuity` (raw) | `continuityClassOfFaces` |
+|---|---|---|
+| box sharp edge | 0 | c0 |
+| filleted box, G1 join | 1 | g1 |
+| cylinder seam (self-pair) | **0** | **cN** |
+
+The first two agree (0 and c0 are the same class; 1 and g1 are the same class). **The cylinder
+seam disagrees.** Two hypotheses were tried, in order, and reported honestly rather than settling
+for the first plausible one:
+
+1. *"`BRep_Tool::Continuity` reads a cached flag `BRepLib::EncodeRegularity` has to write first,
+   and a raw `Shape.cylinder()` never ran it."* Tested directly: `Shape.encodingRegularity()` on
+   the same cylinder, then re-measuring the identical self-paired seam edge. **Still reports 0.**
+   This hypothesis does not hold.
+2. Reading `Issue495FaceContinuityTests`'s own comment again narrows it instead:
+   `BRepLib::ContinuityOfFaces` "short-circuits to `GeomAbs_CN` when the two faces are the same
+   face and the surface is elementary" -- a special case in THAT function's own algorithm, not a
+   generic cached-vs-computed distinction. `BRep_Tool::Continuity` has no such shortcut, and a seam
+   edge apparently never receives an explicit stored continuity value through either code path.
+
+This is reported as a **narrowed, unconfirmed mechanism**, not a finding dressed up as settled: the
+source for `BRep_Tool::Continuity`'s own storage lookup is not shipped in this release's headers
+(only `.hxx`, no `.cxx`), so it could not be traced further inside the time this census had. The
+disagreement itself, plus the disproof of the first hypothesis, is the useful output.
+
+`Shape.maxContinuity(edge:)` on the same box edge: 0, agreeing with the box row above.
+
+Raw `continuity`/typed `continuityClass` on analytic fixtures: an analytic line (3D and 2D) and an
+analytic plane all report `6`/`cN`. A BSpline curve built with a mult-2 interior knot on a cubic
+(the exact fixture `Continuity.swift`'s own doc comment for `continuityClass` uses) reports `2`/`c1`,
+matching that doc comment's own worked example exactly. `Curve3D.bezierContinuity` on a cubic Bezier
+reports `6` (a Bezier curve is analytic -- CN -- by construction).
+
+## `BRepGraph.edgeMaxContinuity`: the live stub, confirmed rather than assumed
+
+`OCCTBRepGraphEdgeMaxContinuity` (`OCCTBridge_BRepGraph.mm`) reads, in full:
+
+```cpp
+int32_t OCCTBRepGraphEdgeMaxContinuity(OCCTBRepGraphRef, int32_t) { return 0; }
+```
+
+0 is also `GeomAbs_C0`, an ordinary answer, so a single call proves nothing by itself -- the stub
+and a real C0 measurement are indistinguishable at one call site. What proves it: **every edge on a
+shape whose seam is genuinely CN reports 0 through the graph** (measured: all 3 edges of a cylinder,
+via `BRepGraph(shape:).edgeMaxContinuity(_:)`), while `Shape.maxContinuity(edge:)` -- the
+shape-based sibling `OCCTBRepGraphEdgeMaxContinuity`'s own comment names as the working replacement
+-- reports `[0, 6, 0]` for the identical cylinder's three edges. The graph path is not reporting a
+boring C0; it cannot report anything else.
+
+This is #513's one live defect that has NOT been fixed since #513 was filed (`FilletBuilder.
+setContinuity` and `OCCTThruSectionsSetContinuity` were, as part of #490's own PR). It has also not
+been given the honest-stub documentation treatment its sibling `OCCTBRepGraphSetEdgeRegularity` /
+`BRepGraph.setEdgeRegularity(_:face1:face2:continuity:)` already has (a `- Important:` doc comment
+stating plainly "This always returns `false`... tracked by #513"). `edgeMaxContinuity`'s own doc
+comment still reads "Get the maximum continuity order of an edge (GeomAbs_Shape enum as Int)," with
+no caveat, which is the more urgent gap: a caller has no way to discover this from the API surface
+alone.
+
+## Guard-removal matrix
+
+`classify_continuity_sites.py --self-test` proves each classification by removing the textual cue
+and confirming the label actually moves, not just that it once printed correctly:
+
+```
+extract_body: call-site-only text has no definition to find                          : pass
+extract_body: finds the real definition                                              : pass
+SurfaceContinuity fixture classifies SurfaceContinuity                               : pass
+SurfaceContinuity GUARD REMOVED classifies RAW (proves the case, not a fixed label)  : pass
+ParametricContinuity fixture classifies ParametricContinuity                         : pass
+ParametricContinuity GUARD REMOVED classifies RAW                                    : pass
+AnalysisOrder fixture classifies AnalysisOrder                                       : pass
+AnalysisOrder GUARD REMOVED classifies RAW                                           : pass
+special-case fixture classifies ParametricContinuity + special-case                  : pass
+special-case GUARD REMOVED (decoder call kept) classifies plain ParametricContinuity : pass
+raw pass-through fixture (no decoder, #480's own contract) classifies RAW            : pass
+result-cast fixture classifies RAW CAST (int32_t)                                    : pass
+result-cast GUARD REMOVED classifies OTHER                                           : pass
+
+All 13 self-test checks passed.
+```
+
+Every one of the classifier's five output labels (`SurfaceContinuity`, `ParametricContinuity`,
+`AnalysisOrder`, the special-case suffix, `RAW (no decoder call)`) has its own present/removed pair
+above except the RAW label itself, which is the documented baseline (#480's own contract, not a
+guard to remove) and the result-side `RAW CAST`/`OTHER` pair, which has one of its own. No label is
+asserted only by a fixture that happens to produce it; each one's removal is shown to change the
+answer.
+
+## Where the two methods disagree
+
+**Nowhere, this time.** Cluster A and Cluster B's own static classifiers were each written before
+full verification and each found genuine blind spots against the dynamic measurement. This
+classifier's function list was assembled by reading every site's source first (recorded inline in
+`ClusterD.swift`'s own comments, e.g. the `occtApproxCurve`/`occtApproxSurface` static-helper
+indirection, and `OCCTShapeUpgradeDivideContinuity`'s special case), so by the time it existed there
+was nothing left for it to discover that the dynamic half had not already confirmed. Recorded here
+rather than omitted, since a census that only ever reports disagreements would misrepresent how
+often they actually occur.
+
+## Are #437 and #438 the same defect?
+
+**No -- and #667's framing ("the other members are instances of that [shared root], not independent
+bugs") is right for one and wrong for the other.**
+
+- **#437 IS an instance of the shared root.** It fires because `SurfaceContinuity`'s raw value is
+  forwarded as a LITERAL `GeomPlate_PointConstraint`/`CurveConstraint` order with no `GeomAbs_Shape`
+  decode step at all -- one of the two raw-pass-through families this census's own table lists
+  alongside the three canonical decoders. The defect (`.g2` rejected for point constraints) is a
+  genuine OCCT domain restriction (`GeomPlate_PointConstraint` throws above order 1) surfacing
+  through that pass-through, exactly the shape #513/#667 describe.
+- **#438 is NOT an instance of it.** `divided(at:)` and `dividedByContinuity(criterion:)` both
+  correctly decode their continuity argument through the SAME canonical
+  `occtGeomAbsFromParametricContinuity` (confirmed by the static classifier, and by this census's
+  own measurement: `Shape.ContinuityLevel`'s c0-c3 values agree with `ParametricContinuity`'s at
+  every probed level in the divide grid above). The reason they disagree (`nil`/4 faces/4
+  faces/25 faces vs a flat 4 faces at every level, in the divide-family measurement above) is that
+  the two set DIFFERENT criteria on `ShapeUpgrade_ShapeDivideContinuity` -- `divided(at:)` sets
+  boundary, pcurve AND surface criteria plus surface-segment mode; `dividedByContinuity` sets only
+  the boundary criterion, with a tolerance the other omits. That is an API-surface duplication
+  question (which #438's own title names correctly: "two public APIs over one OCCT class"), not an
+  encoding mismatch. Fixing #437 (give the plate family a genuine decode step, or document the
+  domain restriction) would not touch #438 at all, and vice versa.
+
+## Should #513 close?
+
+**Yes**, once this PR merges. #513's own ask was to turn its prose census into an executable
+artifact; that now exists under this directory and `Scripts/repro/censuses/ClusterD.swift`. Beyond
+that:
+
+- Its two named "live defects" are one fixed (`FilletBuilder.setContinuity`,
+  `OCCTThruSectionsSetContinuity`, both landed as part of #490's own PR, which cites #513 by number
+  in its own source comment) and one still open (`BRepGraph.edgeMaxContinuity`'s stub) -- small
+  enough to track as a follow-up rather than block this issue's own closure.
+- Its "four incompatible encodings" framing predates #490's consolidation to three canonical
+  decoders; measured today, the honest count is "three decoders plus two structurally different
+  literal pass-throughs," which is a different (and better) shape than #513's own text describes.
+- Its two named instances (#437, #438) remain open on their own, correctly -- this census does not
+  fix either, per #667's own instruction.
+- The one open decision #513 raised and this census did not resolve -- the null/failure sentinel
+  policy on the result side (0 is both "genuine C0" and "failed/null," on every raw-cast result
+  function measured above) -- is a design decision, not a census finding, and is better tracked
+  under its own follow-up than kept open against a census issue whose own job is done.
+
+## Corrections to #513's own text
+
+- **"44 continuity-related bridge functions... 38 unaudited"**: measured as 42 distinct functions
+  (34 request + 8 result) plus 3 trivial aliases = 45 total, not 44 -- close, not exact, and #513's
+  own text already anticipated this kind of drift ("a scan turned up... in total"), not a claim to
+  hold it to precisely.
+- **"Four incompatible request encodings"**: today, three canonical decoders (post-#490) plus two
+  structurally different raw pass-throughs (knot-splitting's literal derivative order; the plate
+  family's literal `GeomPlate` order) -- five families if every one is counted, three if only the
+  actual `GeomAbs_Shape` decoders count. #480's own addendum comment on #513 already flagged the
+  fifth; this census confirms it and adds the plate family as a sixth structurally-identical-in-kind
+  pass-through #480's comment did not separately name.
+- **The `FilletBuilder.setContinuity`/`OCCTThruSectionsSetContinuity` live defects**: fixed since
+  #513 was filed, as part of #490's own PR (confirmed by reading the current source, which cites
+  #513 by number at both sites).
+
+## Verify
+
+```bash
+swift build                                    # 0 errors, no OCCTSWIFT_LOCAL, pinned v2.0.0-kernel.1
+swift test                                     # full suite
+swift run Censuses cluster-a                   # still 45 rows, byte-identical
+swift run Censuses cluster-b                   # still 16 rows, byte-identical
+swift run Censuses cluster-d                   # this census
+python3 Scripts/check-bridge-index.py
+python3 Scripts/check-null-handle-guards.py
+python3 Scripts/check-docs-defaults.py
+python3 Scripts/count-operations.py
+python3 Scripts/check-bridge-index.py --self-test
+python3 Scripts/check-null-handle-guards.py --self-test
+python3 Scripts/check-docs-defaults.py --self-test
+python3 Scripts/repro/cluster-d-continuity/classify_continuity_sites.py --self-test
+```

--- a/Scripts/repro/cluster-d-continuity/README.md
+++ b/Scripts/repro/cluster-d-continuity/README.md
@@ -241,6 +241,23 @@ shape-based sibling `OCCTBRepGraphEdgeMaxContinuity`'s own comment names as the 
 -- reports `[0, 6, 0]` for the identical cylinder's three edges. The graph path is not reporting a
 boring C0; it cannot report anything else.
 
+**It is blocked upstream, not merely unattended**, which changes what the follow-up is. The comment
+directly above the stub says so:
+
+> OCCT 8.0.0p1: edge continuity is conceptually the `BRepGraph_LayerRegularity` layer, but that
+> class is broken in p1 (uncompilable header, absent from `libOCCT`), so the graph path is
+> unavailable. Use the shape-based `Shape.maxContinuity` (`BRep_Tool::MaxContinuity`) instead.
+
+Measured against the pinned `V8_0_1` rather than the p1 that comment describes, and it is **stronger
+than the comment says**: `BRepGraph_LayerRegularity` is not broken there, it is **absent**. Zero
+files under `Libraries/occt-src` match the name, zero source files reference it, and it is not in
+the shipped `OCCT.xcframework` headers.
+
+So the follow-up is not "write the implementation" and not "re-check whether it compiles". The class
+does not exist in the kernel this tree pins, so the graph path cannot be implemented at all until
+upstream adds it. That makes the honest-stub doc comment the whole of the near-term work, and the
+implementation an upstream question rather than a local one.
+
 This is #513's one live defect that has NOT been fixed since #513 was filed (`FilletBuilder.
 setContinuity` and `OCCTThruSectionsSetContinuity` were, as part of #490's own PR). It has also not
 been given the honest-stub documentation treatment its sibling `OCCTBRepGraphSetEdgeRegularity` /

--- a/Scripts/repro/cluster-d-continuity/classify_continuity_sites.py
+++ b/Scripts/repro/cluster-d-continuity/classify_continuity_sites.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Cluster D census (#513/#667), static half: classify each continuity-related bridge function's
+REQUEST-side decoding strategy -- which of the three shared `occtGeomAbsFrom*` helpers
+(`Sources/OCCTBridge/src/OCCTBridge_Internal.h`, added by #490) its body calls, whether it also
+carries a hand-rolled special case on top, or whether it decodes nothing at all and forwards the
+caller's integer as a literal order -- plus each RESULT-side function's own raw-cast shape.
+
+This is the SECONDARY, cross-check evidence -- the dynamic half
+(Scripts/repro/censuses/ClusterD.swift, `swift run Censuses cluster-d`) is the primary evidence,
+per Cluster A/B's own instruction that a grep-shaped classifier "must not be the primary evidence:
+a shared helper, a cast, or an entry point that walks via another entry point will all defeat it".
+This script exists to be compared against the dynamic measurement, not to replace it.
+
+Classification per named C function (a CURATED LIST below, not a generic scan of the whole file --
+the bridge's .mm files together are tens of thousands of lines of unrelated code, and scanning all
+of it by name-prefix or a generic parser is exactly the over/under-inclusive census this whole
+workstream (#558, #571, #583, #595) has repeatedly warned against):
+
+  Request-side decoder (classify_decoder):
+    SurfaceContinuity      -- body calls occtGeomAbsFromSurfaceContinuity(
+    ParametricContinuity   -- body calls occtGeomAbsFromParametricContinuity(
+    AnalysisOrder          -- body calls occtGeomAbsFromAnalysisOrder(
+    + special-case(...)    -- appended when the body ALSO has a hand-rolled ternary against a
+                              literal GeomAbs_G1/G2 (the shape OCCTShapeUpgradeDivideContinuity
+                              uses to reach the two classes occtGeomAbsFromParametricContinuity's
+                              own ladder cannot express)
+    RAW (no decoder call)  -- none of the three found. Not necessarily a defect: #480 ruled the
+                              knot-splitting family's argument is a literal derivative order and
+                              must NEVER be decoded, and the GeomPlate_PointConstraint/
+                              CurveConstraint order the plate family forwards is a third kind of
+                              raw pass-through, not an oversight either. Read the function by hand
+                              before treating "RAW" as a finding rather than a documented design.
+
+  Result-side raw cast (classify_result):
+    RAW CAST (int32_t)     -- the body casts a GeomAbs_Shape-returning call straight to int32_t,
+                              matching #485's own consolidated result-side contract.
+    OTHER                  -- neither pattern found. Same caveat as REQUEST's RAW: read by hand.
+
+Known blind spots (the same shape Cluster A/B's own classifiers documented, and the same reason
+this stays secondary evidence): a decoder called through a shared static helper the named function
+only forwards to (occtApproxCurve/occtApproxSurface, listed here by the HELPER's own name rather
+than the public wrapper's, precisely to avoid this) defeats a classifier that only reads the named
+function's own braces; and extract_body's brace-matcher assumes this file's own consistent
+`ReturnType Name(params) {` definition style, same as Cluster A/B's own.
+
+Usage:
+    python3 classify_continuity_sites.py              # print the classification table
+    python3 classify_continuity_sites.py --self-test   # prove the classifier on known fixtures
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BRIDGE_SRC = REPO_ROOT / "Sources" / "OCCTBridge" / "src"
+CURVE3D = BRIDGE_SRC / "OCCTBridge_Curve3D.mm"
+GEOM2D = BRIDGE_SRC / "OCCTBridge_Geom2d.mm"
+SURFACE = BRIDGE_SRC / "OCCTBridge_Surface.mm"
+HEALING = BRIDGE_SRC / "OCCTBridge_Healing.mm"
+MODELING = BRIDGE_SRC / "OCCTBridge_Modeling.mm"
+TOPOLOGY = BRIDGE_SRC / "OCCTBridge_Topology.mm"
+NLPLATE = BRIDGE_SRC / "OCCTBridge_ProjLib_NLPlate.mm"
+BREPGRAPH = BRIDGE_SRC / "OCCTBridge_BRepGraph.mm"
+
+# REQUEST-side: takes a continuity as an integer, decides what to do with it. Kept in the same
+# grouping ClusterD.swift's own MARK sections use (knot-splitting, ParametricContinuity,
+# SurfaceContinuity, AnalysisOrder), so the two are easy to read side by side. Two entries
+# (occtApproxCurve, occtApproxSurface) are the file-local STATIC helpers the public
+# OCCTCurve3DApproximate/OCCTGeomConvertApproxCurve and OCCTSurfaceApproximate/
+# OCCTGeomConvertApproxSurface wrapper pairs each share (#490/#491) -- named directly rather than
+# by either public wrapper, since a wrapper's own body is a one-line forward with no decoder call
+# in it at all, which is exactly the indirection blind spot this script cannot see through.
+REQUEST_FUNCTIONS = [
+    ("OCCTSplitCurve3dContinuity", CURVE3D),
+    ("OCCTSplitCurve2dContinuity", GEOM2D),
+    ("OCCTSplitSurfaceContinuity", HEALING),
+    ("OCCTSurfaceSplitByContinuity", SURFACE),
+    ("occtApproxCurve", CURVE3D),
+    ("OCCTCurve2DApproximate", GEOM2D),
+    ("occtApproxSurface", SURFACE),
+    ("OCCTPointsToBSplineWithParams", CURVE3D),
+    ("OCCTPointsToBSplineWithParameters", CURVE3D),
+    ("OCCTPoints2DToBSplineWithParams", GEOM2D),
+    ("OCCTPointsToSurfaceBSpline", SURFACE),
+    ("OCCTShapeCustomBSplineRestriction", HEALING),
+    ("OCCTShapeBSplineRestrictionAdvanced", HEALING),
+    ("OCCTShapeDivide", HEALING),
+    ("OCCTShapeUpgradeDivideContinuity", HEALING),
+    ("OCCTThruSectionsSetContinuity", MODELING),
+    ("OCCTFilletBuilderSetContinuity", MODELING),
+    ("OCCTFillingAddEdge", MODELING),
+    ("OCCTFillingAddFreeEdge", MODELING),
+    ("OCCTFillingAddEdgeWithSupport", MODELING),
+    ("OCCTShapeFill", HEALING),
+    ("OCCTShapeFillWithSupport", HEALING),
+    ("OCCTShapeFillConstraints", HEALING),
+    ("OCCTLocalAnalysisCurveContinuity", CURVE3D),
+    ("OCCTLocalAnalysisSurfaceContinuity", SURFACE),
+    ("OCCTCurve3DBSplineKnotSplits", TOPOLOGY),
+    ("OCCTCurve2DSplitAtDiscontinuities", GEOM2D),
+    ("OCCTSurfaceKnotSplitting", SURFACE),
+    ("OCCTLawBSplineKnotSplitting", MODELING),
+    ("OCCTLawBSplineKnotSplitParams", MODELING),
+    ("OCCTShapePlateCurves", HEALING),
+    ("OCCTShapePlatePointsAdvanced", NLPLATE),
+    ("OCCTShapePlateMixed", NLPLATE),
+    ("OCCTBRepGraphEdgeMaxContinuity", BREPGRAPH),
+]
+
+# RESULT-side: reports a MEASURED continuity back to Swift. #485 already audited and unified six
+# of these (the *Continuity/*GetContinuity alias pairs); this script includes their GetContinuity
+# spelling for completeness of the "44 total" count #513 opens with, not because #485 left anything
+# here unaudited.
+RESULT_FUNCTIONS = [
+    ("OCCTCurve3DGetContinuity", CURVE3D),
+    ("OCCTCurve2DGetContinuity", GEOM2D),
+    ("OCCTSurfaceGetContinuity", SURFACE),
+    ("OCCTBRepToolContinuity", TOPOLOGY),
+    ("OCCTBRepToolMaxContinuity", TOPOLOGY),
+    ("OCCTCurve3DBezierContinuity", CURVE3D),
+    ("OCCTSurfaceBezierContinuity", SURFACE),
+    ("OCCTBRepLibContinuityOfFaces", TOPOLOGY),
+]
+
+DECODERS = [
+    ("occtGeomAbsFromSurfaceContinuity(", "SurfaceContinuity"),
+    ("occtGeomAbsFromParametricContinuity(", "ParametricContinuity"),
+    ("occtGeomAbsFromAnalysisOrder(", "AnalysisOrder"),
+]
+SPECIAL_CASE_RE = re.compile(r"==\s*\d+\s*\?\s*GeomAbs_(G1|G2)\b")
+RESULT_CAST_RE = re.compile(r"\(int32_t\)|static_cast<\s*int32_t\s*>")
+
+
+def extract_body(text, func_name):
+    """The function's body -- the substring from its own opening `{` to the matching closing `}`
+    -- or None if `func_name` has no definition-shaped occurrence in `text`.
+
+    A definition looks like `func_name(...) {` with no `;` between the parameter list and the
+    brace; a call site (`x = func_name(...);`, `if (!func_name(...)) ...`) has a `;` or a further
+    token before any `{` and is skipped. See the module docstring for what this does NOT defend
+    against.
+    """
+    pattern = re.compile(re.escape(func_name) + r"\s*\([^;{}]*\)\s*\{", re.DOTALL)
+    for m in pattern.finditer(text):
+        depth = 0
+        i = m.end() - 1  # the opening brace this match ends on
+        while i < len(text):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[m.start():i + 1]
+            i += 1
+    return None
+
+
+def classify_decoder(body):
+    found = [name for pattern, name in DECODERS if pattern in body]
+    label = " + ".join(found) if found else "RAW (no decoder call)"
+    if SPECIAL_CASE_RE.search(body):
+        label += " + special-case(G1/G2 literal)"
+    return label
+
+
+def classify_result(body):
+    return "RAW CAST (int32_t)" if RESULT_CAST_RE.search(body) else "OTHER"
+
+
+def collect_rows(functions, classify):
+    rows = []
+    cache = {}
+    for name, path in functions:
+        if path not in cache:
+            cache[path] = path.read_text()
+        body = extract_body(cache[path], name)
+        if body is None:
+            rows.append((name, path.name, "NOT FOUND"))
+            continue
+        rows.append((name, path.name, classify(body)))
+    return rows
+
+
+def print_table(title, rows):
+    header = ("function", "file", "classification")
+    widths = (40, 24, 46)
+
+    def pad(s, w):
+        return s if len(s) >= w else s + " " * (w - len(s))
+
+    print(f"--- {title} ---")
+    print(" | ".join(pad(h, w) for h, w in zip(header, widths)))
+    print("-|-".join("-" * w for w in widths))
+    for row in rows:
+        print(" | ".join(pad(c, w) for c, w in zip(row, widths)))
+    print(f"row count: {len(rows)}")
+    print()
+
+
+# --- self-test -------------------------------------------------------------------------------
+#
+# Every case below is run twice: once as written (the guard present, proving the classifier
+# reports the guarded outcome) and once with the guard textually removed (proving the classifier's
+# outcome actually MOVES, not just that it once printed the right label). A case whose removal
+# leaves the classification unchanged is decorative, per okf/policies/prove-the-test-fails.md and
+# the guard-removal matrix Cluster A/B's own classifiers already established for this workstream.
+
+CALL_SITE_ONLY = """
+// OCCTRealDefinition is declared elsewhere; this is only a call.
+static void wrapper() {
+    OCCTShapeRef result = OCCTRealDefinition(shape, continuity, tolerance);
+}
+"""
+
+SURFACE_CONTINUITY_FIXTURE = """
+bool OCCTRealDefinition(OCCTFillingRef filling, OCCTEdgeRef edge, int32_t continuity) {
+    return filling->fill.Add(edge->edge, occtGeomAbsFromSurfaceContinuity(continuity));
+}
+"""
+
+SURFACE_CONTINUITY_REMOVED = """
+bool OCCTRealDefinition(OCCTFillingRef filling, OCCTEdgeRef edge, int32_t continuity) {
+    return filling->fill.Add(edge->edge, (GeomAbs_Shape)continuity);
+}
+"""
+
+PARAMETRIC_CONTINUITY_FIXTURE = """
+OCCTShapeRef OCCTHandRolled(OCCTShapeRef shape, int32_t continuity) {
+    ShapeUpgrade_ShapeDivideContinuity divider(shape->shape);
+    divider.SetBoundaryCriterion(occtGeomAbsFromParametricContinuity(continuity));
+    return shape;
+}
+"""
+
+PARAMETRIC_CONTINUITY_REMOVED = """
+OCCTShapeRef OCCTHandRolled(OCCTShapeRef shape, int32_t continuity) {
+    ShapeUpgrade_ShapeDivideContinuity divider(shape->shape);
+    divider.SetBoundaryCriterion((GeomAbs_Shape)continuity);
+    return shape;
+}
+"""
+
+ANALYSIS_ORDER_FIXTURE = """
+bool OCCTLocalAnalysisHandRolled(OCCTCurve3DRef c1, double u1, OCCTCurve3DRef c2, double u2, int32_t order) {
+    LocalAnalysis_CurveContinuity cc(c1->curve, u1, c2->curve, u2, occtGeomAbsFromAnalysisOrder(order));
+    return cc.IsDone();
+}
+"""
+
+ANALYSIS_ORDER_REMOVED = """
+bool OCCTLocalAnalysisHandRolled(OCCTCurve3DRef c1, double u1, OCCTCurve3DRef c2, double u2, int32_t order) {
+    LocalAnalysis_CurveContinuity cc(c1->curve, u1, c2->curve, u2, (GeomAbs_Shape)order);
+    return cc.IsDone();
+}
+"""
+
+SPECIAL_CASE_FIXTURE = """
+OCCTShapeRef OCCTShapeUpgradeDivideContinuityLike(OCCTShapeRef shape, int32_t boundaryCriterion) {
+    const GeomAbs_Shape criterion =
+        boundaryCriterion == 5 ? GeomAbs_G1 :
+        boundaryCriterion == 6 ? GeomAbs_G2 :
+        occtGeomAbsFromParametricContinuity(boundaryCriterion);
+    return shape;
+}
+"""
+
+SPECIAL_CASE_REMOVED = """
+OCCTShapeRef OCCTShapeUpgradeDivideContinuityLike(OCCTShapeRef shape, int32_t boundaryCriterion) {
+    const GeomAbs_Shape criterion = occtGeomAbsFromParametricContinuity(boundaryCriterion);
+    return shape;
+}
+"""
+
+RAW_PASSTHROUGH_FIXTURE = """
+int32_t OCCTKnotSplittingLike(OCCTCurve3DRef c, int32_t continuityOrder) {
+    GeomConvert_BSplineCurveKnotSplitting splitter(bspl, continuityOrder);
+    return splitter.NbSplits();
+}
+"""
+
+RESULT_CAST_FIXTURE = """
+int32_t OCCTResultCastLike(OCCTCurve3DRef curve) {
+    return (int32_t)curve->curve->Continuity();
+}
+"""
+
+RESULT_CAST_REMOVED = """
+GeomAbs_Shape OCCTResultCastLike(OCCTCurve3DRef curve) {
+    return curve->curve->Continuity();
+}
+"""
+
+
+def self_test():
+    failures = []
+    matrix = []
+
+    def check(label, condition):
+        matrix.append((label, "pass" if condition else "FAIL"))
+        if not condition:
+            failures.append(label)
+
+    # 1. extract_body finds a real definition, and is not fooled by a bare call site.
+    body = extract_body(CALL_SITE_ONLY, "OCCTRealDefinition")
+    check("extract_body: call-site-only text has no definition to find", body is None)
+
+    body = extract_body(SURFACE_CONTINUITY_FIXTURE, "OCCTRealDefinition")
+    check("extract_body: finds the real definition", body is not None)
+
+    # 2. SurfaceContinuity: present -> classified, removed (raw cast instead) -> RAW.
+    check("SurfaceContinuity fixture classifies SurfaceContinuity",
+          classify_decoder(SURFACE_CONTINUITY_FIXTURE) == "SurfaceContinuity")
+    check("SurfaceContinuity GUARD REMOVED classifies RAW (proves the case, not a fixed label)",
+          classify_decoder(SURFACE_CONTINUITY_REMOVED) == "RAW (no decoder call)")
+
+    # 3. ParametricContinuity: present -> classified, removed -> RAW.
+    check("ParametricContinuity fixture classifies ParametricContinuity",
+          classify_decoder(PARAMETRIC_CONTINUITY_FIXTURE) == "ParametricContinuity")
+    check("ParametricContinuity GUARD REMOVED classifies RAW",
+          classify_decoder(PARAMETRIC_CONTINUITY_REMOVED) == "RAW (no decoder call)")
+
+    # 4. AnalysisOrder: present -> classified, removed -> RAW.
+    check("AnalysisOrder fixture classifies AnalysisOrder",
+          classify_decoder(ANALYSIS_ORDER_FIXTURE) == "AnalysisOrder")
+    check("AnalysisOrder GUARD REMOVED classifies RAW",
+          classify_decoder(ANALYSIS_ORDER_REMOVED) == "RAW (no decoder call)")
+
+    # 5. Special-case suffix: present alongside the decoder -> BOTH named; with just the
+    # special-case ternary removed (decoder call kept) -> the suffix alone disappears, proving it
+    # is a distinct, independently-removable guard rather than always riding along with the
+    # decoder detection.
+    check("special-case fixture classifies ParametricContinuity + special-case",
+          classify_decoder(SPECIAL_CASE_FIXTURE)
+          == "ParametricContinuity + special-case(G1/G2 literal)")
+    check("special-case GUARD REMOVED (decoder call kept) classifies plain ParametricContinuity",
+          classify_decoder(SPECIAL_CASE_REMOVED) == "ParametricContinuity")
+
+    # 6. The raw pass-through idiom (no decoder call at all) must classify RAW, matching the
+    # knot-splitting family's own #480-mandated contract -- a baseline case, no removal needed,
+    # since there is no guard here to remove.
+    check("raw pass-through fixture (no decoder, #480's own contract) classifies RAW",
+          classify_decoder(RAW_PASSTHROUGH_FIXTURE) == "RAW (no decoder call)")
+
+    # 7. Result-side cast: present -> RAW CAST, removed (returns the enum directly, uncast) -> OTHER.
+    check("result-cast fixture classifies RAW CAST (int32_t)",
+          classify_result(RESULT_CAST_FIXTURE) == "RAW CAST (int32_t)")
+    check("result-cast GUARD REMOVED classifies OTHER",
+          classify_result(RESULT_CAST_REMOVED) == "OTHER")
+
+    print("Guard-removal matrix:")
+    width = max(len(label) for label, _ in matrix)
+    for label, result in matrix:
+        print(f"  {label.ljust(width)} : {result}")
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(matrix)} self-test checks FAILED.")
+        return 1
+    print(f"All {len(matrix)} self-test checks passed.")
+    return 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        sys.exit(self_test())
+    print_table("Request-side decoder classification", collect_rows(REQUEST_FUNCTIONS, classify_decoder))
+    print_table("Result-side raw-cast classification", collect_rows(RESULT_FUNCTIONS, classify_result))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

Cluster D of the v2.0.0 release (#667). #513 already wrote the continuity-handling
census as prose: 38 unaudited bridge functions, four incompatible request
encodings, two live defects. This PR turns that into a committed, executable
artifact that measures the current tree, per #667's own instruction ("#513 is
already an explicit census... Do the census, then the instances fall out").

**This PR is the census only. It does not fix #437, #438, or
`BRepGraph.edgeMaxContinuity`'s stub.**

## What's here

- `Scripts/repro/censuses/ClusterD.swift` (dynamic, primary evidence, `swift run
  Censuses cluster-d`): 31 distinct entry points measured against real fixtures.
- `Scripts/repro/cluster-d-continuity/classify_continuity_sites.py` (static
  cross-check): classifies 42 named bridge functions by which of the three
  shared `occtGeomAbsFrom*` decoders (#490) each calls, or none. 13/13 self-test
  cases pass, each with a proven guard-removal pair.
- `Scripts/repro/cluster-d-continuity/README.md`: full write-up.
- One line in `CensusRunner.swift` registering `cluster-d`.

## Headline findings

- **#513's own numbers were already stale when read against the current tree.**
  Two of its named "live defects" (`FilletBuilder.setContinuity`'s raw cast,
  `OCCTThruSectionsSetContinuity`'s old reading) were fixed as part of #490's own
  PR, which cites #513 by number in its source comments. The one still open:
  `BRepGraph.edgeMaxContinuity` is confirmed (not assumed) to be a hardcoded
  stub always returning 0, contrasted against `Shape.maxContinuity(edge:)`
  reporting the real class on the same cylinder.
- **Measured today: three canonical decoders (post-#490), not "four incompatible
  encodings."** Plus two structurally different raw pass-throughs (the
  knot-splitting family's literal derivative order, ruled non-decodable by #480;
  the plate family's literal `GeomPlate` order, undocumented until now).
- **A second `#438`-shaped duplicate, found beyond #513's own list**:
  `Surface.splitByContinuity` and `Surface.splitSurfaceByContinuity` are two
  public APIs over the same `ShapeUpgrade_SplitSurfaceContinuity` -- confirmed
  now converged (#490), not diverged.
- **#437 reproduced directly**: a `.g2` point constraint fails
  `plateSurface(through:orders:)` every time; curve constraints don't have the
  same restriction. Confirmed as a raw pass-through into
  `GeomPlate_PointConstraint`'s own literal order, not a decode bug.
- **#437 and #438 are NOT the same defect, correcting #667's framing.** #437 is
  a genuine instance of the shared "four encodings" root (a raw pass-through
  hitting a real OCCT domain restriction). #438 is independent: both
  `divided(at:)`/`dividedByContinuity` correctly decode through the same
  canonical decoder; they diverge because they set different criteria on the
  underlying builder, an API-surface duplication question, not an encoding one.
- **A genuine, honestly-reported open question**: `Shape.continuity(edge:...)`
  (BRep_Tool, unmigrated) disagrees with `continuityClassOfFaces` (BRepLib,
  migrated by #495) on a cylinder's seam edge (0 vs cN). The first hypothesis
  tried (a cached-flag vs live-computation gap) was tested directly with
  `encodingRegularity()` and disproved. A narrower, unconfirmed mechanism is
  recorded in the README rather than a guess dressed as a finding.

## Verdict on #513

Recommend closing once this merges: its own ask (turn the prose into an
executable artifact) is done, its live defects are one fixed / one tracked as a
small follow-up, and its remaining open decision (the null/failure sentinel
policy on the result side) is a design question better tracked on its own than
kept open against a census issue whose job is complete. Full reasoning in the
README's "Should #513 close?" section.

## Verify

- Clean full-package build: 0 errors, 0 new warnings (only the pre-existing,
  deliberate ClusterA.swift deprecation warning).
- Full `swift test`: 5356/5356 passing, run twice for confirmation.
- `swift run Censuses cluster-a`: still 45 rows, unchanged logic.
- `swift run Censuses cluster-b`: still 16 rows, unchanged logic.
- All four gate scripts (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `count-operations`) plus their `--self-test`s: pass.
- `classify_continuity_sites.py --self-test`: 13/13, guard-removal matrix in
  the README.
- Zero em-dashes across all new/changed files.

## Checklist

- [x] New behavior (the census itself) is exercised via `--self-test` for the
      static classifier, with every case proven by removing the guard and
      watching the classification move, per
      `okf/policies/prove-the-test-fails.md`.

## Notes for the reviewer

No files in this PR overlap with the two other PRs open against
`refactor/381-pass1b` at the time of writing (#711, Cluster C's
`check-null-handle-guards.py` upgrade; #712, `ClusterB.swift`/`#633` fix) --
confirmed by diffing file lists before opening this PR.

Closes #513