### PR TITLE
fix(#673): derive-bridge-header-split.py verifies a declaration's header, not just its .mm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,28 @@ jobs:
   #     job would be red for a reason that has nothing to do with it, which is the same as not
   #     having it. That state is fixable by bumping the pin, and is fixed today, but the
   #     separation is what makes the gate survive the next time it happens.
-  #   - ubuntu-latest, because all four are pure Python over the repo's own text: no Xcode, no
+  #   - ubuntu-latest, because all five are pure Python over the repo's own text: no Xcode, no
   #     OCCT, no swift build. A macOS runner would cost 10x the minutes to run the identical checks.
   #   - each script's --self-test runs alongside its real invocation. A gate whose detector is
   #     wrong reports "all clear" just as confidently as a gate whose subject is clean; this branch
   #     shipped three gate scripts that were confidently wrong (#618, #624/#630, #626), so the
   #     detector's own fixtures are part of what CI checks, not a developer-only convenience.
   #   - `if: '!cancelled()'` on every step after the first, so one failing gate does not hide the
-  #     other three. Without it a contributor fixes them one CI round trip at a time. It is
+  #     other four. Without it a contributor fixes them one CI round trip at a time. It is
   #     `!cancelled()` rather than `always()` so the concurrency group's cancel-in-progress still
   #     takes effect.
   #
-  # Two of the four (check-bridge-index, check-null-handle-guards) resolve their inputs relative to
-  # the working directory and exit 2 with "run from the repo root" elsewhere; the other two resolve
-  # from __file__. A GitHub Actions step starts at the repo root, so both kinds are satisfied.
+  # Three of the five (check-bridge-index, check-null-handle-guards, derive-bridge-header-split)
+  # resolve their inputs relative to the working directory and exit 2 with "run from the repo root"
+  # elsewhere; the other two resolve from __file__. A GitHub Actions step starts at the repo root,
+  # so both kinds are satisfied.
+  #
+  # derive-bridge-header-split.py joined as the fifth in #673: --verify answers a question that
+  # keeps mattering after the one-time #395 split it was written for -- does each bridge
+  # declaration still sit in the header its .mm owns -- and every ~100-operation release adds
+  # declarations by hand, so the drift this checks for is ongoing, not a one-off migration risk.
+  # It runs `--verify`, not the bare form: the bare form only prints the manifest and always exits
+  # 0, unlike its three self-test-carrying siblings above, whose bare invocation already gates.
   # Deliberately NO `name:` key. The check-run name GitHub publishes is a job's `name:` when it has
   # one and the job id otherwise, and that string is what a required-status-check rule matches. A
   # prose name reads like a comment, so rewording it for clarity would silently stop satisfying the
@@ -104,9 +112,18 @@ jobs:
         if: '!cancelled()'
         run: python3 Scripts/check-docs-defaults.py
 
-      # No --self-test of its own. It takes no options other than --fix/--audit and ignores an
-      # unrecognised one, so it is invoked bare; `--self-test` would be silently accepted and run
-      # the ordinary report, which reads as a passing self-test that never existed.
+      - name: derive-bridge-header-split.py --self-test
+        if: '!cancelled()'
+        run: python3 Scripts/derive-bridge-header-split.py --self-test
+
+      - name: derive-bridge-header-split.py --verify
+        if: '!cancelled()'
+        run: python3 Scripts/derive-bridge-header-split.py --verify
+
+      # No --self-test of its own. It takes no options other than --fix/--audit and rejects an
+      # unrecognised one (exit 2), so it is invoked bare; `--self-test` would otherwise be the
+      # natural thing to write when extending this list, and read as a passing self-test that
+      # never existed rather than the usage error it actually is.
       - name: count-operations.py
         if: '!cancelled()'
         run: python3 Scripts/count-operations.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,12 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 
 ### Static Gate Scripts
 
-Four pure-Python checks over the repo's own text. No OCCT, no build, ~3s for all four. **CI runs
+Five pure-Python checks over the repo's own text. No OCCT, no build, ~3s for all five. **CI runs
 every one of them, plus each `--self-test`, in `ci.yml`'s `gate-scripts` job** — a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
 its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a
-defect and 0 when clean; `check-bridge-index` and `check-null-handle-guards` exit **2** if run
-from anywhere but the repo root (#625).
+defect and 0 when clean; `check-bridge-index`, `check-null-handle-guards` and
+`derive-bridge-header-split` exit **2** if run from anywhere but the repo root (#625).
 
 **`gate-scripts` is a required status check on `refactor/**`** (#649), via a repository ruleset — the
 repo's only branch protection. Three consequences worth knowing before you touch it:
@@ -58,13 +58,14 @@ repo's only branch protection. Three consequences worth knowing before you touch
   been taken: measure a run of green results first rather than requiring it on one.
 
 ```bash
-python3 Scripts/check-bridge-index.py        # OCCTBridge.h's class → symbol index: stale / misfiled entries
-python3 Scripts/check-null-handle-guards.py  # every bridge fn guards the Handle, not just the pointer
-python3 Scripts/check-docs-defaults.py       # every default docs/reference/ restates matches its declaration
-python3 Scripts/count-operations.py          # README + API_REFERENCE totals match the derived count
+python3 Scripts/check-bridge-index.py            # OCCTBridge.h's class → symbol index: stale / misfiled entries
+python3 Scripts/check-null-handle-guards.py      # every bridge fn guards the Handle, not just the pointer
+python3 Scripts/check-docs-defaults.py           # every default docs/reference/ restates matches its declaration
+python3 Scripts/derive-bridge-header-split.py --verify  # every declaration sits in the header its .mm owns (#673)
+python3 Scripts/count-operations.py              # README + API_REFERENCE totals match the derived count
 ```
 
-The first three take `--self-test`, which runs a fixture battery proving the *detector* catches each
+The first four take `--self-test`, which runs a fixture battery proving the *detector* catches each
 failure mode. Run it whenever you change one of these scripts — three gate scripts on this branch
 were confidently wrong (#618, #624/#630, #626), and a detector that reports "all clear" because it
 is blind looks exactly like one reporting "all clear" because the tree is clean.
@@ -72,7 +73,7 @@ is blind looks exactly like one reporting "all clear" because the tree is clean.
 running the report, so writing `count-operations.py --self-test` to match its siblings fails loudly
 instead of passing forever.
 
-**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs the same seven invocations
+**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs the same nine invocations
 locally, flag for flag. It is **opt-in and not installed by cloning** — enable it deliberately:
 
 ```bash

--- a/Scripts/derive-bridge-header-split.py
+++ b/Scripts/derive-bridge-header-split.py
@@ -105,9 +105,17 @@ def compute(mm_texts, header_texts):
                  reported for that second header even though a correct declaration
                  exists elsewhere.
     """
-    definitions = {mm: set(DEFN.findall(text)) for mm, text in mm_texts.items()}
+    # Comment-stripped on every path, not just the misfiled one. `declared` and `definitions`
+    # scanned raw text until #673's review pointed out they carry the identical false-positive
+    # shape this script's own `home` computation was hardened against: a symbol named only inside
+    # a comment. In a header that reads as a spurious `declared` entry, and if nothing defines it,
+    # a false UNMAPPED; in a `.mm` it makes one file look like a second definer, a false AMBIGUOUS.
+    # The umbrella header's cross-reference index block is exactly the shape that would do it.
+    # Today's tree is clean either way, so this is hardening rather than a fix, but leaving one of
+    # three scans raw while hardening the other two is the inconsistency that lets it come back.
+    definitions = {mm: set(DEFN.findall(strip_comments(text))) for mm, text in mm_texts.items()}
 
-    concatenated = "".join(header_texts.values())
+    concatenated = strip_comments("".join(header_texts.values()))
     declared = set(DECL.findall(concatenated)) - set(TYPEDEF.findall(concatenated))
 
     mapping, ambiguous, unmapped = {}, {}, []
@@ -199,6 +207,32 @@ SELF_TEST = [
             "OCCTBridge_B.h": "/* mentions OCCTFooA(void) here too */\n",
         },
         lambda mapping, ambiguous, unmapped, misfiled: not misfiled,
+    ),
+    (
+        # The review of #673 noted the six cases above all exercise the `home`/misfiled path,
+        # which was hardened against comment mentions, while `declared` and `definitions` scanned
+        # raw text and carried the identical shape. These two cover that, one per scan.
+        "a symbol named only in a header comment is not declared (#673 review)",
+        {"OCCTBridge_A.mm": "void OCCTFooA(void) {}\n"},
+        {
+            "OCCTBridge_A.h": "void OCCTFooA(void);\n",
+            # OCCTGoneAway is defined by nothing. Counted as declared, it is a false UNMAPPED.
+            "OCCTBridge_B.h": "// index: SomeClass -> OCCTGoneAway(void), retired in v1.9\n",
+        },
+        lambda mapping, ambiguous, unmapped, misfiled: not unmapped and "OCCTGoneAway" not in mapping,
+    ),
+    (
+        "a symbol named only in a .mm comment does not make it a second definer (#673 review)",
+        {
+            "OCCTBridge_A.mm": "void OCCTFooA(void) {}\n",
+            # A mention, not a definition, inside a BLOCK comment whose inner line begins with
+            # the identifier. A `//` line cannot reach DEFN at all, which is anchored at ^ with
+            # [A-Za-z_], so a `//` fixture here would pass with or without stripping and prove
+            # nothing. This shape does reach it.
+            "OCCTBridge_B.mm": "/* dispatch notes:\nvoid OCCTFooA(void) handles the planar case\n*/\n",
+        },
+        {"OCCTBridge_A.h": "void OCCTFooA(void);\n"},
+        lambda mapping, ambiguous, unmapped, misfiled: not ambiguous and mapping.get("OCCTFooA") == "OCCTBridge_A.h",
     ),
 ]
 

--- a/Scripts/derive-bridge-header-split.py
+++ b/Scripts/derive-bridge-header-split.py
@@ -11,17 +11,29 @@ prove nothing moved to the wrong header.
     python3 Scripts/derive-bridge-header-split.py            # print the manifest summary
     python3 Scripts/derive-bridge-header-split.py --list      # print every symbol and its target
     python3 Scripts/derive-bridge-header-split.py --verify    # exit 1 if the split is not total
+    python3 Scripts/derive-bridge-header-split.py --self-test # prove each failure mode is caught
 
 Exits 2 if run from anywhere but the repo root, matching the other gate scripts (#625).
+`--self-test` runs on synthetic fixtures and does not need the repo tree, so it is exempt.
 
 Why this is a script and not a list in an issue: the repo's history is full of censuses that were
 built by grep, written into an issue body, and then turned out to be wrong once measured (#558,
 #571, #583, #595, #573). A derivation that can be re-run does not go stale in the same way.
 
 Before #395 this read a single 21,896-line OCCTBridge.h. After #395 the declarations live across
-16 files (Sources/OCCTBridge/include/OCCTBridge*.h); this reads all of them and concatenates their
-text before deriving, so the script keeps meaning the same thing (does every declared function map
-to exactly one .mm file) whether run pre-split, mid-split, or on the settled post-split tree.
+16 files (Sources/OCCTBridge/include/OCCTBridge*.h). `--verify` originally only asked whether every
+declared function maps to exactly one .mm file, which was the whole question before there was more
+than one header to get wrong. #673: after the split there is a second question -- is each
+declaration actually in the header its .mm owns? A declaration can sit in the wrong domain header
+and still map to exactly one .mm, so the first question passing says nothing about the second.
+This now tracks declarations per header file, not just concatenated across all of them, so it can
+answer both: MISFILED symbols below are declared somewhere other than the header their .mm owns.
+
+Comments are excluded from the per-header declaration scan. The umbrella's cross-reference index
+names hundreds of symbols in `// Class -> OCCTFoo (aside)` lines, and a mention followed by a
+parenthetical aside matches the same `name(` shape a real declaration does -- reading those as
+declarations was how a hand check for #673 first turned up 29 apparent duplicates, all of them
+comment mentions rather than a second real declaration.
 """
 
 import argparse
@@ -42,6 +54,20 @@ DEFN = re.compile(r"^[A-Za-z_][\w\s\*\(\)<>,:]*?\b(OCCT[A-Za-z0-9_]+)\s*\(", re.
 DECL = re.compile(r"\b(OCCT[A-Za-z0-9_]+)\s*\(")
 # Opaque handle typedefs stay in the umbrella header, they are not functions.
 TYPEDEF = re.compile(r"typedef\s+struct\s+\w+\s*\*\s*(OCCT[A-Za-z0-9_]+)\s*;")
+LINE_COMMENT = re.compile(r"//[^\n]*")
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+
+def strip_comments(text):
+    """Remove // line comments and /* */ block comments (#673).
+
+    A per-header declaration scan has to run on this, not the raw text: the cross-reference
+    index names symbols in `// Class -> OCCTFoo (aside)` lines, and a parenthetical aside
+    right after the name matches the same `name(` shape DECL looks for. Left in, a mention
+    inside a comment reads as a second declaration of a symbol that is for real declared
+    somewhere else -- the false "duplicate" shape #673's hand check found.
+    """
+    return LINE_COMMENT.sub("", BLOCK_COMMENT.sub(" ", text))
 
 
 def target_header(mm_name):
@@ -55,17 +81,34 @@ def header_files():
     return sorted(glob.glob(os.path.join(HEADER_DIR, "OCCTBridge*.h")))
 
 
-def derive():
-    definitions = {}
-    for name in sorted(os.listdir(SRC_DIR)):
-        if name.endswith(".mm"):
-            text = open(os.path.join(SRC_DIR, name), errors="ignore").read()
-            definitions[name] = set(DEFN.findall(text))
+def declared_in(header_text):
+    """The real (non-comment) OCCT-prefixed declarations in one header's text."""
+    stripped = strip_comments(header_text)
+    return set(DECL.findall(stripped)) - set(TYPEDEF.findall(stripped))
 
-    header = ""
-    for path in header_files():
-        header += open(path, errors="ignore").read()
-    declared = set(DECL.findall(header)) - set(TYPEDEF.findall(header))
+
+def compute(mm_texts, header_texts):
+    """Everything this script reports, computed from in-memory text.
+
+    Kept separate from disk I/O so `--self-test` can run the exact same logic `--verify`
+    runs, on synthetic fixtures, rather than a parallel implementation that could drift
+    from what the real gate checks. `mm_texts` and `header_texts` are name -> file text.
+
+    Returns (mapping, ambiguous, unmapped, misfiled):
+      mapping    symbol -> the one header its owning .mm's domain header should be
+      ambiguous  symbol -> headers, when more than one .mm defines the same symbol
+      unmapped   symbols the header(s) declare that no .mm defines
+      misfiled   (symbol, wrong headers, expected header) for #673: a header, other than
+                 the one mapping says the symbol belongs in, that declares it for real.
+                 Checked per declaration site, not per symbol, so a symbol correctly
+                 declared in its own header AND, wrongly, also in a second one is still
+                 reported for that second header even though a correct declaration
+                 exists elsewhere.
+    """
+    definitions = {mm: set(DEFN.findall(text)) for mm, text in mm_texts.items()}
+
+    concatenated = "".join(header_texts.values())
+    declared = set(DECL.findall(concatenated)) - set(TYPEDEF.findall(concatenated))
 
     mapping, ambiguous, unmapped = {}, {}, []
     for symbol in sorted(declared):
@@ -76,7 +119,101 @@ def derive():
             ambiguous[symbol] = [target_header(o) for o in owners]
         else:
             unmapped.append(symbol)
-    return mapping, ambiguous, unmapped
+
+    home = collections.defaultdict(set)
+    for header, text in header_texts.items():
+        for symbol in declared_in(text):
+            home[symbol].add(header)
+
+    misfiled = []
+    for symbol, expected in mapping.items():
+        wrong = home.get(symbol, set()) - {expected}
+        if wrong:
+            misfiled.append((symbol, sorted(wrong), expected))
+
+    return mapping, ambiguous, unmapped, sorted(misfiled)
+
+
+def derive():
+    mm_texts = {}
+    for name in sorted(os.listdir(SRC_DIR)):
+        if name.endswith(".mm"):
+            mm_texts[name] = open(os.path.join(SRC_DIR, name), errors="ignore").read()
+
+    header_texts = {}
+    for path in header_files():
+        header_texts[os.path.basename(path)] = open(path, errors="ignore").read()
+
+    return compute(mm_texts, header_texts)
+
+
+# Each case is its own tiny .mm/.h universe, not a shared fixture, so removing one guard
+# cannot make an unrelated case fail for the wrong reason. `check` is handed compute()'s
+# own return value and answers True/False for that one case's claim only -- the same
+# function --verify calls, not a parallel implementation that could drift from it.
+SELF_TEST = [
+    (
+        "clean split: nothing flagged",
+        {"OCCTBridge_A.mm": "void OCCTFooA(void) {}\n"},
+        {"OCCTBridge_A.h": "void OCCTFooA(void);\n"},
+        lambda mapping, ambiguous, unmapped, misfiled: (
+            mapping.get("OCCTFooA") == "OCCTBridge_A.h" and not ambiguous and not unmapped and not misfiled
+        ),
+    ),
+    (
+        "ambiguous: two .mm files define the same symbol",
+        {
+            "OCCTBridge_A.mm": "void OCCTFooA(void) {}\n",
+            "OCCTBridge_B.mm": "void OCCTFooA(void) {}\n",
+        },
+        {"OCCTBridge_A.h": "void OCCTFooA(void);\n"},
+        lambda mapping, ambiguous, unmapped, misfiled: "OCCTFooA" in ambiguous,
+    ),
+    (
+        "unmapped: header declares a symbol no .mm defines",
+        {"OCCTBridge_A.mm": ""},
+        {"OCCTBridge_A.h": "void OCCTGhost(void);\n"},
+        lambda mapping, ambiguous, unmapped, misfiled: "OCCTGhost" in unmapped,
+    ),
+    (
+        "misfiled: declared in B.h, defined in A.mm (#673)",
+        {"OCCTBridge_A.mm": "void OCCTFooA(void) {}\n"},
+        {"OCCTBridge_A.h": "", "OCCTBridge_B.h": "void OCCTFooA(void);\n"},
+        lambda mapping, ambiguous, unmapped, misfiled: (
+            "OCCTFooA", ["OCCTBridge_B.h"], "OCCTBridge_A.h") in misfiled,
+    ),
+    (
+        "line-comment mention elsewhere is not a misfile (#673)",
+        {"OCCTBridge_A.mm": "void OCCTFooA(void) {}\n"},
+        {
+            "OCCTBridge_A.h": "void OCCTFooA(void);\n",
+            "OCCTBridge_B.h": "// SomeClass -> OCCTFooA (see the real header)\n",
+        },
+        lambda mapping, ambiguous, unmapped, misfiled: not misfiled,
+    ),
+    (
+        "block-comment mention elsewhere is not a misfile (#673)",
+        {"OCCTBridge_A.mm": "void OCCTFooA(void) {}\n"},
+        {
+            "OCCTBridge_A.h": "void OCCTFooA(void);\n",
+            "OCCTBridge_B.h": "/* mentions OCCTFooA(void) here too */\n",
+        },
+        lambda mapping, ambiguous, unmapped, misfiled: not misfiled,
+    ),
+]
+
+
+def self_test():
+    """Prove each failure mode this script covers is caught, and each correct shape is not."""
+    failed = 0
+    for name, mm_texts, header_texts, check in SELF_TEST:
+        mapping, ambiguous, unmapped, misfiled = compute(mm_texts, header_texts)
+        ok = check(mapping, ambiguous, unmapped, misfiled)
+        failed += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'}  {name}")
+    total = len(SELF_TEST)
+    print(f"{total - failed}/{total} cases correct")
+    return 1 if failed else 0
 
 
 def main():
@@ -84,13 +221,17 @@ def main():
     ap.add_argument("--list", action="store_true", help="print every symbol and its target header")
     ap.add_argument("--verify", action="store_true", help="exit 1 unless every symbol maps to one header")
     ap.add_argument("--json", metavar="PATH", help="write the manifest as JSON")
+    ap.add_argument("--self-test", action="store_true", help="prove each failure mode is caught")
     args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
 
     if not os.path.isdir(SRC_DIR) or not os.path.isfile(UMBRELLA):
         print(f"error: run from the repo root (expected {SRC_DIR} and {UMBRELLA})", file=sys.stderr)
         return 2
 
-    mapping, ambiguous, unmapped = derive()
+    mapping, ambiguous, unmapped, misfiled = derive()
 
     if args.list:
         for symbol, header in sorted(mapping.items(), key=lambda kv: (kv[1], kv[0])):
@@ -99,23 +240,28 @@ def main():
         for header, count in collections.Counter(mapping.values()).most_common():
             print(f"  {count:5d}  {header}")
 
-    print(f"\nmapped: {len(mapping)}   ambiguous: {len(ambiguous)}   unmapped: {len(unmapped)}")
+    print(f"\nmapped: {len(mapping)}   ambiguous: {len(ambiguous)}   "
+          f"unmapped: {len(unmapped)}   misfiled: {len(misfiled)}")
 
     for symbol, headers in sorted(ambiguous.items()):
         print(f"  AMBIGUOUS  {symbol}: {', '.join(headers)}", file=sys.stderr)
     for symbol in unmapped:
         print(f"  UNMAPPED   {symbol}", file=sys.stderr)
+    for symbol, wrong, expected in misfiled:
+        print(f"  MISFILED   {symbol}: declared in {', '.join(wrong)}, owned by {expected}", file=sys.stderr)
 
     if args.json:
         json.dump(mapping, open(args.json, "w"), indent=0, sort_keys=True)
         print(f"manifest written to {args.json}")
 
-    if args.verify and (ambiguous or unmapped):
+    if args.verify and (ambiguous or unmapped or misfiled):
         print(
             "\nThe split is not total. Resolve each symbol above before moving declarations:\n"
             "  AMBIGUOUS means two .mm files define the same symbol, which is a real defect.\n"
             "  UNMAPPED means the header declares something no .mm defines, so it is either dead\n"
-            "  or defined somewhere the parser does not look.",
+            "  or defined somewhere the parser does not look.\n"
+            "  MISFILED means the symbol is declared in a header other than the one its .mm owns\n"
+            "  (#673) -- move the declaration to the header the summary above says it should be in.",
             file=sys.stderr,
         )
         return 1

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Opt-in pre-commit hook: runs the same four static gate scripts CI's `gate-scripts` job runs.
+# Opt-in pre-commit hook: runs the same five static gate scripts CI's `gate-scripts` job runs.
 #
 # NOT installed by cloning. A repo cannot install its own hooks — `.git/hooks` is not versioned —
 # and that is the right default here: a hook that appears in a contributor's workflow without them
@@ -27,7 +27,7 @@
 #   which resolves to the worktree you are committing in, not the main checkout.
 #
 # Skip it for one commit with `git commit --no-verify`. CI is the authority either way: this hook is
-# a faster local copy of the same checks, never a substitute. The seven INVOCATIONS below are
+# a faster local copy of the same checks, never a substitute. The nine INVOCATIONS below are
 # deliberately identical to the CI job's, flag for flag, so a disagreement can never come from the
 # two running different things. Three ways they can still diverge, none of them worth closing here:
 #
@@ -75,6 +75,8 @@ run "check-null-handle-guards.py --self-test" Scripts/check-null-handle-guards.p
 run "check-null-handle-guards.py"             Scripts/check-null-handle-guards.py
 run "check-docs-defaults.py --self-test"      Scripts/check-docs-defaults.py --self-test
 run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py
+run "derive-bridge-header-split.py --self-test" Scripts/derive-bridge-header-split.py --self-test
+run "derive-bridge-header-split.py --verify"    Scripts/derive-bridge-header-split.py --verify
 run "count-operations.py"                     Scripts/count-operations.py
 
 if [ ${#failed[@]} -ne 0 ]; then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,53 @@ All notable changes to OCCTSwift.
 
 ## Unreleased
 
+### `derive-bridge-header-split.py` now verifies each declaration is in the header its `.mm` owns (#673)
+
+`--verify` only ever asked whether every declared bridge function maps to exactly one `.mm` file,
+which was the whole question before #395 split the header. After that split there is a second
+question it did not ask: is the declaration actually in the header its `.mm` owns? A declaration
+could sit in `OCCTBridge_Surface.h` while its implementation lived in `OCCTBridge_Modeling.mm` and
+`--verify` would still report clean, because the symbol still maps to exactly one `.mm`.
+
+The script now tracks declarations per header file, not just concatenated across all sixteen, so
+it can answer both. A hand check at the time #673 was filed found 0 misfiled of 4022, with 29
+apparent duplicates all traced to mentions inside the umbrella's cross-reference index comment
+block. Re-measuring rather than trusting that number: **0 misfiled of 4018** today (the drop from
+4022 is unrelated churn, not a regression). Comments have to be excluded from the per-header scan
+for the same reason the hand check found 29 false duplicates: `// Class -> OCCTFoo (aside)` names a
+symbol followed immediately by `(`, the same shape a real declaration has, so an unstripped scan
+credits whichever header holds the comment with a second declaration of a symbol that is for real
+declared somewhere else.
+
+**Gained a `--self-test`**, the one thing this script's three siblings already had and it did not.
+Six cases, each proven by removing the guard it covers and watching the count drop, not merely
+added and trusted:
+
+| case | guard removed | result |
+|---|---|---|
+| clean split: nothing flagged | dropped `- {expected}` from the wrong-header set | 3/6 |
+| ambiguous: two `.mm` files define the same symbol | disabled the `ambiguous` branch | 5/6 |
+| unmapped: header declares a symbol no `.mm` defines | disabled the `unmapped` branch | 5/6 |
+| misfiled: declared in B.h, defined in A.mm | disabled misfiled detection outright | 5/6 |
+| line-comment mention elsewhere is not a misfile | dropped `//` stripping | 5/6 |
+| block-comment mention elsewhere is not a misfile | dropped `/* */` stripping | 5/6 |
+
+Each restored to 6/6 after its own row. The "clean split" row also catches the two comment-guard
+rows collapsing at once, since all three share the same `wrong = home - {expected}` computation;
+the other four guards are each isolated to exactly one row.
+
+**Joins `ci.yml`'s `gate-scripts` job as the fifth script**, run with `--verify` (its bare form
+only prints the manifest and always exits 0). Unlike the other two `derive-*.py` scripts in
+`Scripts/`, which are one-time censuses for a split not yet done, this one protects an invariant
+from a split already shipped (#395) that every ~100-operation release can still violate by hand.
+The pre-commit hook (`Scripts/git-hooks/pre-commit`) gains the matching two invocations to stay
+flag-for-flag identical to CI, and `CLAUDE.md`'s Static Gate Scripts section, `ci.yml`'s own header
+comment, and the hook's header comment are updated from four/seven to five/nine accordingly. In the
+same pass, `ci.yml`'s comment for `count-operations.py` is corrected: it said the script "ignores
+an unrecognised" option, which was true only until the same-day commit that made it exit 2 instead
+(confirmed still correct: `count-operations.py --self-test` and `--bogus` both exit 2 with a usage
+message).
+
 ### CI builds the same kernel the branch is written against
 
 `Package.swift` now pins the [`v2.0.0-kernel.1`](https://github.com/SecondMouseAU/OCCTSwift/releases/tag/v2.0.0-kernel.1)


### PR DESCRIPTION
## Summary

`Scripts/derive-bridge-header-split.py --verify` only ever asked whether every
declared bridge function maps to exactly one `.mm` file, which was the whole
question before #395 split the header into 16 files. After that split there is a
second question it did not ask: is the declaration actually in the header its `.mm`
owns? A declaration could sit in `OCCTBridge_Surface.h` while its implementation
lived in `OCCTBridge_Modeling.mm`, and the script would still report clean, because
the symbol still maps to exactly one `.mm`.

- Tracks declarations per header file (not just concatenated across all 16), and
  flags any header, other than the one its owning `.mm` maps to, that declares a
  symbol for real.
- Strips `//` and `/* */` comments before the per-header scan. The umbrella's
  cross-reference index names symbols in `// Class -> OCCTFoo (aside)` lines, which
  match the same `name(` shape a real declaration has; an unstripped scan credits
  the comment's header with a second declaration of a symbol declared for real
  elsewhere, the 29 false duplicates the issue's own hand check found.
- Adds `--self-test`, the one thing this script's three siblings already had and it
  did not. 6 cases.
- Joins `ci.yml`'s `gate-scripts` job as the fifth script (see rationale below).
- Fixes a stale comment in `ci.yml`: it said `count-operations.py` "ignores an
  unrecognised" option, true only until a same-day commit made it exit 2 instead.

## Re-measured misfiled count

The issue recorded a hand check of **0 misfiled of 4022** at filing time. Re-measured
rather than trusted, per the issue's own instruction: **0 misfiled of 4018** today.
The drop from 4022 to 4018 is unrelated churn between then and now (declarations
removed elsewhere on this branch), not a regression. `--verify` still exits 0 with
`ambiguous: 0  unmapped: 0  misfiled: 0`.

## Guard-removal matrix

Every self-test case was proven by removing the guard it covers, watching the count
drop, then restoring it (`okf/policies/prove-the-test-fails.md`):

| case | guard removed | result | restored |
|---|---|---|---|
| clean split: nothing flagged | dropped `- {expected}` from the wrong-header set | 3/6 | 6/6 |
| ambiguous: two `.mm` files define the same symbol | disabled the `ambiguous` branch | 5/6 | 6/6 |
| unmapped: header declares a symbol no `.mm` defines | disabled the `unmapped` branch | 5/6 | 6/6 |
| misfiled: declared in B.h, defined in A.mm | disabled misfiled detection outright | 5/6 | 6/6 |
| line-comment mention elsewhere is not a misfile | dropped `//` stripping | 5/6 | 6/6 |
| block-comment mention elsewhere is not a misfile | dropped `/* */` stripping | 5/6 | 6/6 |

No case was decorative: every guard's removal moved exactly the case(s) it covers,
and only those. (The "clean split" guard is shared with the two comment-guard cases,
since all three read the same `wrong = home - {expected}` computation, which is why
removing it drops three rows at once while the other four guards each isolate to one
row.)

## Should this be a CI gate?

Yes. Joined `ci.yml`'s `gate-scripts` job as the fifth script, run with `--verify`
(the bare form only prints the manifest and always exits 0, unlike its three
self-test-carrying siblings whose bare invocation already gates). Unlike this
script's two `derive-*.py` siblings, which are one-time censuses for a split not yet
done, this one protects an invariant from a split already shipped (#395) that every
~100-operation release can still violate by hand, exactly the ongoing-drift risk the
job's own header comment explains the other four gates exist to catch. It is pure
Python, no OCCT, no build, and its `--self-test` follows the same fixture discipline
CI already checks for the other three.

`Scripts/git-hooks/pre-commit`, `CLAUDE.md`'s Static Gate Scripts section, and the
job's own header comment are all updated to match (four/seven invocations to
five/nine).

## What the issue got wrong

Nothing substantive. The issue's own hand check (0 misfiled, 29 comment-mention
false duplicates) held up under re-measurement, just with a slightly different total
(4018 vs 4022) from unrelated churn. The only thing worth flagging is unrelated to
the issue's own text: `ci.yml`'s comment for `count-operations.py` said it "ignores
an unrecognised" option, but a same-day commit (visible via `git blame`) had already
made it exit 2 with a usage message twenty minutes after that comment was written.
Fixed as a drive-by since I was touching the same job.

## Verify

- Clean `swift build`, 0 errors, no `OCCTSWIFT_LOCAL`, no local `Libraries/`.
- Full `swift test`: **5356 tests in 1407 suites, all passing**, matching the stated
  baseline exactly (Python-only change, Swift suite untouched as expected).
- All five gate scripts (`check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `derive-bridge-header-split.py --verify`,
  `count-operations.py`) plus the four `--self-test`s, all exit 0 from the repo root.
- `derive-bridge-header-split.py --verify` exits 0 on the tree (0 misfiled of 4018).
- Zero em-dashes introduced (checked every added line programmatically).

Closes #673

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
