### PR TITLE
fix(#598): PipeSweepMode.frenet and .correctedFrenet were wired to each other's OCCT mode

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -491,14 +491,19 @@ OCCTShapeRef OCCTShapeRemoveFeatures(OCCTShapeRef shape, const int32_t* faceIndi
 
 // Apply an orientation mode. Returns false when the mode's own argument is missing;
 // a zero-length binormal throws out of gp_Dir and is caught by the caller.
+//
+// SetMode's own parameter is named IsFrenet, and its header says so: "If IsFrenet is false,
+// a corrected Frenet trihedron is used." #598: this used to pass the opposite boolean for
+// both cases, so OCCTPipeModeFrenet built a corrected-Frenet sweep and OCCTPipeModeCorrectedFrenet
+// built a plain Frenet one, straight through to every public PipeSweepMode caller.
 static bool occtPipeShellSetMode(BRepOffsetAPI_MakePipeShell& pipeShell, OCCTPipeMode mode,
                                  double bnX, double bnY, double bnZ, OCCTWireRef auxSpine) {
     switch (mode) {
         case OCCTPipeModeFrenet:
-            pipeShell.SetMode(Standard_False);
+            pipeShell.SetMode(Standard_True);
             return true;
         case OCCTPipeModeCorrectedFrenet:
-            pipeShell.SetMode(Standard_True);
+            pipeShell.SetMode(Standard_False);
             return true;
         case OCCTPipeModeFixedBinormal:
             pipeShell.SetMode(gp_Dir(bnX, bnY, bnZ));
@@ -4131,7 +4136,10 @@ OCCTShapeRef OCCTShapeCreatePipeShellWithLaw(OCCTWireRef spine,
     if (!spine || !profile || !law || law->law.IsNull()) return nullptr;
     try {
         BRepOffsetAPI_MakePipeShell pipeShell(spine->wire);
-        pipeShell.SetMode(Standard_False); // Frenet
+        // Standard_False -> corrected Frenet (#598 found this comment claiming plain Frenet,
+        // which SetMode's own IsFrenet parameter does not: no public mode parameter reaches
+        // this entry point, so the trihedron itself is unchanged, only the comment was wrong).
+        pipeShell.SetMode(Standard_False); // corrected Frenet
         pipeShell.SetLaw(profile->wire, law->law, Standard_False, Standard_False);
         return occtPipeShellFinish(pipeShell, solid);
     } catch (...) {

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -344,7 +344,7 @@ extension Shape {
     /// // A fixed binormal keeps it upright instead, which is a different solid.
     /// let upright = Shape.pipeShell(spine: spine, profile: profile,
     ///                               mode: .fixed(binormal: SIMD3(0, 0, 1)))
-    /// print(rolled?.volume ?? 0)    // 180.29
+    /// print(rolled?.volume ?? 0)    // 177.35
     /// print(upright?.volume ?? 0)   // 150.00
     /// ```
     ///

--- a/Tests/OCCTModelingTests/Issue503PipeShellTests.swift
+++ b/Tests/OCCTModelingTests/Issue503PipeShellTests.swift
@@ -76,7 +76,11 @@ struct Issue503PipeShellTests {
             Shape.pipeShell(spine: spine, profile: profile, mode: .fixed(binormal: SIMD3(0, 0, 1))))
 
         if let frenet, let fixed {
-            #expect(frenet.volume.isApproximatelyEqual(to: 180.286724, tolerance: 1e-5))
+            // 177.347557, not 180.286724: that was the pre-#598 value, and it was the
+            // corrected-Frenet solid, not the Frenet one. .frenet and .correctedFrenet were
+            // wired to each other's OCCT mode. This literal moved when #598 fixed the swap;
+            // Issue598PipeShellFrenetModeTests pins the fix itself against an independent oracle.
+            #expect(frenet.volume.isApproximatelyEqual(to: 177.347557, tolerance: 1e-5))
             #expect(fixed.volume.isApproximatelyEqual(to: 149.999816, tolerance: 1e-5))
             #expect(!frenet.volume.isApproximatelyEqual(to: fixed.volume, tolerance: 1e-6))
         } else {

--- a/Tests/OCCTModelingTests/Issue503PipeShellTests.swift
+++ b/Tests/OCCTModelingTests/Issue503PipeShellTests.swift
@@ -16,6 +16,9 @@ struct Issue503PipeShellTests {
     /// Curved enough that Frenet, corrected Frenet and a fixed binormal all disagree.
     /// A straight spine will not do: with no torsion the modes coincide, which is how the
     /// silent fall-through survived a test suite that only ever swept straight lines.
+    ///
+    /// Not private: Issue598PipeShellFrenetModeTests (same target) reuses this fixture directly
+    /// rather than keeping a byte-for-byte copy the two files could silently drift apart on.
     static func curvedSpine() -> Wire? {
         Wire.bspline([SIMD3(0, 0, 0), SIMD3(10, 5, 0), SIMD3(20, -5, 10), SIMD3(30, 0, 10)])
     }
@@ -235,7 +238,9 @@ struct Issue503PipeShellTests {
     }
 }
 
-private extension Double {
+// Not private: Issue598PipeShellFrenetModeTests (same target) reuses this rather than
+// reimplementing the same scale-relative tolerance formula a third time.
+extension Double {
     func isApproximatelyEqual(to other: Double, tolerance: Double) -> Bool {
         abs(self - other) <= tolerance * Swift.max(1.0, abs(self), abs(other))
     }

--- a/Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift
+++ b/Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift
@@ -1,0 +1,117 @@
+// #598: `occtPipeShellSetMode` (`OCCTBridge_Modeling.mm`) passed the opposite boolean to
+// `BRepOffsetAPI_MakePipeShell::SetMode`, whose parameter is `IsFrenet`: `.frenet` built a
+// corrected-Frenet sweep and `.correctedFrenet` built a plain Frenet one, straight through every
+// public `PipeSweepMode` caller (`.frenet` is the default on all three `Shape.pipeShell*` spellings).
+//
+// These tests pin the fix against an *independent* oracle rather than a hand-picked literal:
+// `PipeShellBuilder.setFrenet(_:)` calls `BRepFill_PipeShell::Set(frenet)` directly and was never
+// wrong (a separate code path from the enum-driven bridge function this issue fixes), so a match
+// against it is real cross-checking, not two copies of the same mistake agreeing with each other.
+
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+@Suite("PipeSweepMode Frenet/correctedFrenet were swapped (#598)")
+struct Issue598PipeShellFrenetModeTests {
+
+    /// Same fixture Issue503PipeShellTests.curvedSpine() uses: curved enough that Frenet and
+    /// corrected Frenet disagree, which a straight spine cannot show (see
+    /// `theTwoModesAgreeOnASpineWithNoTorsion` below).
+    static func curvedSpine() -> Wire? {
+        Wire.bspline([SIMD3(0, 0, 0), SIMD3(10, 5, 0), SIMD3(20, -5, 10), SIMD3(30, 0, 10)])
+    }
+
+    /// Builds the same single-profile, transformed-transition, solid sweep as
+    /// `Shape.pipeShell(spine:profile:mode:)`'s defaults, but through `PipeShellBuilder`
+    /// (`BRepFill_PipeShell::Set(Standard_Boolean)` directly) instead of the `PipeSweepMode`
+    /// enum this issue's fix touches. An independent path to the same OCCT trihedron law.
+    static func groundTruth(spine: Wire, profile: Wire, frenet: Bool) -> Shape? {
+        guard let spineShape = Shape.fromWire(spine), let profileShape = Shape.fromWire(profile),
+              let builder = PipeShellBuilder(spine: spineShape) else { return nil }
+        builder.setFrenet(frenet)
+        builder.add(profile: profileShape)
+        builder.setTransition(.modified) // BRepBuilderAPI_Transformed, pipeShell's own default
+        guard builder.build() else { return nil }
+        builder.makeSolid()
+        return builder.shape
+    }
+
+    static func isClose(_ a: Double, _ b: Double, tolerance: Double = 1e-6) -> Bool {
+        abs(a - b) <= tolerance * Swift.max(1.0, abs(a), abs(b))
+    }
+
+    @Test(".frenet matches BRepFill_PipeShell::Set(true), the actual Frenet trihedron")
+    func frenetMatchesTrueFrenet() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+              let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
+              let trueCorrected = Self.groundTruth(spine: spine, profile: profile, frenet: false),
+              let viaEnum = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet),
+              let vEnum = viaEnum.volume, let vFrenet = trueFrenet.volume,
+              let vCorrected = trueCorrected.volume else {
+            Issue.record("Could not build the fixtures"); return
+        }
+
+        // The oracle values themselves must actually disagree on this spine, or a match against
+        // either one would be meaningless.
+        #expect(!Self.isClose(vFrenet, vCorrected), "oracle Frenet and corrected Frenet must differ")
+
+        #expect(Self.isClose(vEnum, vFrenet),
+                ".frenet (\(vEnum)) should match the true Frenet sweep (\(vFrenet))")
+        #expect(!Self.isClose(vEnum, vCorrected),
+                ".frenet (\(vEnum)) must not match the corrected-Frenet sweep (\(vCorrected))")
+        #expect(vEnum.isApproximatelyEqualLiteral(177.347557))
+    }
+
+    @Test(".correctedFrenet matches BRepFill_PipeShell::Set(false), the actual corrected Frenet trihedron")
+    func correctedFrenetMatchesTrueCorrectedFrenet() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+              let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
+              let trueCorrected = Self.groundTruth(spine: spine, profile: profile, frenet: false),
+              let viaEnum = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet),
+              let vEnum = viaEnum.volume, let vFrenet = trueFrenet.volume,
+              let vCorrected = trueCorrected.volume else {
+            Issue.record("Could not build the fixtures"); return
+        }
+
+        #expect(Self.isClose(vEnum, vCorrected),
+                ".correctedFrenet (\(vEnum)) should match the true corrected-Frenet sweep (\(vCorrected))")
+        #expect(!Self.isClose(vEnum, vFrenet),
+                ".correctedFrenet (\(vEnum)) must not match the plain Frenet sweep (\(vFrenet))")
+        #expect(vEnum.isApproximatelyEqualLiteral(180.286724))
+    }
+
+    @Test("the multi-section spelling honours the same, now-corrected mapping")
+    func multiSectionSpellingAlsoFixed() {
+        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+              let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
+              let viaMulti = Shape.pipeShellMultiSection(spine: spine, profiles: [profile], mode: .frenet),
+              let vMulti = viaMulti.volume, let vFrenet = trueFrenet.volume else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        #expect(Self.isClose(vMulti, vFrenet),
+                "pipeShellMultiSection(mode: .frenet) (\(vMulti)) should match true Frenet (\(vFrenet))")
+    }
+
+    /// The blast radius this issue measured: a spine with no torsion cannot distinguish the two
+    /// trihedron laws, so the swap was silent there and only wrong on a spine with genuine
+    /// curvature/torsion (the fixture every other test in this file uses).
+    @Test("the two modes agree on a spine with no torsion, so the swap was silent there")
+    func theTwoModesAgreeOnASpineWithNoTorsion() {
+        guard let straight = Wire.line(from: .zero, to: SIMD3(0, 0, 20)),
+              let profile = Wire.circle(radius: 2),
+              let frenet = Shape.pipeShell(spine: straight, profile: profile, mode: .frenet),
+              let corrected = Shape.pipeShell(spine: straight, profile: profile, mode: .correctedFrenet),
+              let vFrenet = frenet.volume, let vCorrected = corrected.volume else {
+            Issue.record("Could not build the fixtures"); return
+        }
+        #expect(Self.isClose(vFrenet, vCorrected),
+                "a straight spine has no torsion to disagree about: \(vFrenet) vs \(vCorrected)")
+    }
+}
+
+private extension Double {
+    func isApproximatelyEqualLiteral(_ other: Double, tolerance: Double = 1e-5) -> Bool {
+        abs(self - other) <= tolerance * Swift.max(1.0, abs(self), abs(other))
+    }
+}

--- a/Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift
+++ b/Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift
@@ -10,17 +10,11 @@
 
 import Testing
 import Foundation
+import simd
 @testable import OCCTSwift
 
 @Suite("PipeSweepMode Frenet/correctedFrenet were swapped (#598)")
 struct Issue598PipeShellFrenetModeTests {
-
-    /// Same fixture Issue503PipeShellTests.curvedSpine() uses: curved enough that Frenet and
-    /// corrected Frenet disagree, which a straight spine cannot show (see
-    /// `theTwoModesAgreeOnASpineWithNoTorsion` below).
-    static func curvedSpine() -> Wire? {
-        Wire.bspline([SIMD3(0, 0, 0), SIMD3(10, 5, 0), SIMD3(20, -5, 10), SIMD3(30, 0, 10)])
-    }
 
     /// Builds the same single-profile, transformed-transition, solid sweep as
     /// `Shape.pipeShell(spine:profile:mode:)`'s defaults, but through `PipeShellBuilder`
@@ -37,13 +31,18 @@ struct Issue598PipeShellFrenetModeTests {
         return builder.shape
     }
 
-    static func isClose(_ a: Double, _ b: Double, tolerance: Double = 1e-6) -> Bool {
-        abs(a - b) <= tolerance * Swift.max(1.0, abs(a), abs(b))
+    /// A planar S-curve: the same interpolating fitter `Wire.bspline` always uses, through
+    /// points that reverse from curving one way to curving the other. Measured (not assumed):
+    /// sampling `curvature(at:)` every 0.5% of the domain finds the minimum is exactly 0.0 at
+    /// the midpoint (u=0.5), a genuine curvature-zero crossing, not just a low point.
+    static func inflectionSpine() -> Wire? {
+        Wire.bspline([SIMD3(0, 0, 0), SIMD3(10, 10, 0), SIMD3(20, 0, 0),
+                      SIMD3(30, -10, 0), SIMD3(40, 0, 0)])
     }
 
     @Test(".frenet matches BRepFill_PipeShell::Set(true), the actual Frenet trihedron")
     func frenetMatchesTrueFrenet() {
-        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+        guard let spine = Issue503PipeShellTests.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
               let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
               let trueCorrected = Self.groundTruth(spine: spine, profile: profile, frenet: false),
               let viaEnum = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet),
@@ -54,18 +53,19 @@ struct Issue598PipeShellFrenetModeTests {
 
         // The oracle values themselves must actually disagree on this spine, or a match against
         // either one would be meaningless.
-        #expect(!Self.isClose(vFrenet, vCorrected), "oracle Frenet and corrected Frenet must differ")
+        #expect(!vFrenet.isApproximatelyEqual(to: vCorrected, tolerance: 1e-6),
+                "oracle Frenet and corrected Frenet must differ")
 
-        #expect(Self.isClose(vEnum, vFrenet),
+        #expect(vEnum.isApproximatelyEqual(to: vFrenet, tolerance: 1e-6),
                 ".frenet (\(vEnum)) should match the true Frenet sweep (\(vFrenet))")
-        #expect(!Self.isClose(vEnum, vCorrected),
+        #expect(!vEnum.isApproximatelyEqual(to: vCorrected, tolerance: 1e-6),
                 ".frenet (\(vEnum)) must not match the corrected-Frenet sweep (\(vCorrected))")
-        #expect(vEnum.isApproximatelyEqualLiteral(177.347557))
+        #expect(vEnum.isApproximatelyEqual(to: 177.347557, tolerance: 1e-5))
     }
 
     @Test(".correctedFrenet matches BRepFill_PipeShell::Set(false), the actual corrected Frenet trihedron")
     func correctedFrenetMatchesTrueCorrectedFrenet() {
-        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+        guard let spine = Issue503PipeShellTests.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
               let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
               let trueCorrected = Self.groundTruth(spine: spine, profile: profile, frenet: false),
               let viaEnum = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet),
@@ -74,22 +74,22 @@ struct Issue598PipeShellFrenetModeTests {
             Issue.record("Could not build the fixtures"); return
         }
 
-        #expect(Self.isClose(vEnum, vCorrected),
+        #expect(vEnum.isApproximatelyEqual(to: vCorrected, tolerance: 1e-6),
                 ".correctedFrenet (\(vEnum)) should match the true corrected-Frenet sweep (\(vCorrected))")
-        #expect(!Self.isClose(vEnum, vFrenet),
+        #expect(!vEnum.isApproximatelyEqual(to: vFrenet, tolerance: 1e-6),
                 ".correctedFrenet (\(vEnum)) must not match the plain Frenet sweep (\(vFrenet))")
-        #expect(vEnum.isApproximatelyEqualLiteral(180.286724))
+        #expect(vEnum.isApproximatelyEqual(to: 180.286724, tolerance: 1e-5))
     }
 
     @Test("the multi-section spelling honours the same, now-corrected mapping")
     func multiSectionSpellingAlsoFixed() {
-        guard let spine = Self.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
+        guard let spine = Issue503PipeShellTests.curvedSpine(), let profile = Wire.rectangle(width: 5, height: 3),
               let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
               let viaMulti = Shape.pipeShellMultiSection(spine: spine, profiles: [profile], mode: .frenet),
               let vMulti = viaMulti.volume, let vFrenet = trueFrenet.volume else {
             Issue.record("Could not build the fixtures"); return
         }
-        #expect(Self.isClose(vMulti, vFrenet),
+        #expect(vMulti.isApproximatelyEqual(to: vFrenet, tolerance: 1e-6),
                 "pipeShellMultiSection(mode: .frenet) (\(vMulti)) should match true Frenet (\(vFrenet))")
     }
 
@@ -105,13 +105,92 @@ struct Issue598PipeShellFrenetModeTests {
               let vFrenet = frenet.volume, let vCorrected = corrected.volume else {
             Issue.record("Could not build the fixtures"); return
         }
-        #expect(Self.isClose(vFrenet, vCorrected),
+        #expect(vFrenet.isApproximatelyEqual(to: vCorrected, tolerance: 1e-6),
                 "a straight spine has no torsion to disagree about: \(vFrenet) vs \(vCorrected)")
     }
-}
 
-private extension Double {
-    func isApproximatelyEqualLiteral(_ other: Double, tolerance: Double = 1e-5) -> Bool {
-        abs(self - other) <= tolerance * Swift.max(1.0, abs(self), abs(other))
+    /// Review of #715 (this fix's own PR): the tests above only measured a spine with ordinary
+    /// curvature/torsion, never one at or near a genuine curvature *inflection* -- exactly where
+    /// `.correctedFrenet`'s own doc comment says it matters ("avoids twisting at inflection
+    /// points"), and exactly where a caller could previously get a valid solid from the
+    /// (accidentally) safer algorithm by taking the `.frenet` default.
+    ///
+    /// Measured on `inflectionSpine()` (a genuine curvature-zero crossing, confirmed above):
+    /// `.frenet` -- now the default on every `Shape.pipeShell*` entry point -- self-intersects;
+    /// `.correctedFrenet` does not. This is the regression class the review flagged: a caller who
+    /// never named a mode and happens to sweep a spine through an inflection now gets an invalid
+    /// solid where the pre-#598 (wrongly-wired) default happened to build the safer sweep instead.
+    /// See `docs/CHANGELOG.md`'s #598 entry for the disclosed migration note.
+    @Test("plain .frenet self-intersects at a genuine curvature inflection; .correctedFrenet does not")
+    func frenetSelfIntersectsAtCurvatureInflection() {
+        guard let spine = Self.inflectionSpine(),
+              let curve = spine.edges().first?.curve3D else {
+            Issue.record("Could not build the fixture"); return
+        }
+
+        // Confirm the fixture actually has a genuine curvature-zero crossing, not an assumption:
+        // sample the domain and require the minimum curvature to be (numerically) zero.
+        let domain = curve.domain
+        var minCurvature = Double.greatestFiniteMagnitude
+        for i in 0...200 {
+            let u = domain.lowerBound + (domain.upperBound - domain.lowerBound) * Double(i) / 200
+            if let k = curve.curvature(at: u) { minCurvature = Swift.min(minCurvature, k) }
+        }
+        #expect(minCurvature < 1e-9,
+                "fixture must have a genuine curvature-zero crossing, measured minimum \(minCurvature)")
+
+        // A profile plane perpendicular to the spine's start tangent (diagonal in the spine's own
+        // XY plane), not coplanar with it: a flat rectangle/circle sharing the spine's own plane
+        // collapses the whole sweep to a degenerate sliver regardless of trihedron law, which
+        // would test the wrong thing entirely.
+        let (_, startTangent) = curve.d1(at: domain.lowerBound)
+        guard let profile = Wire.circle(origin: .zero, normal: simd_normalize(startTangent), radius: 2),
+              let frenet = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet),
+              let corrected = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet) else {
+            Issue.record("Could not build the fixtures"); return
+        }
+
+        #expect(frenet.isSelfIntersecting(timeout: 10) == true,
+                ".frenet is expected to self-intersect at this spine's curvature inflection")
+        #expect(corrected.isSelfIntersecting(timeout: 10) == false,
+                ".correctedFrenet must stay valid at the same inflection")
+    }
+
+    /// Review of #715: the CHANGELOG claimed a circular profile makes `.frenet` and
+    /// `.correctedFrenet` produce "the identical swept volume" on
+    /// `docs/guides/cookbook/helices.md`'s spring recipe, so the page needed no update. Measured,
+    /// not assumed, using the exact recipe (r=10, pitch=4, turns=5, wireRadius=1.5) and an
+    /// independent `PipeShellBuilder` oracle: the claim is false. `.frenet` reproduces the
+    /// textbook tube volume (pi * wireRadius^2 * coil length) to within numerical tolerance;
+    /// `.correctedFrenet` does not (measured ~12% larger, cross-checked against
+    /// `PipeShellBuilder.setFrenet(false)` giving the identical value). The cookbook page is
+    /// fixed in the same PR that adds this test: its recipe now uses `.frenet`.
+    @Test("the cookbook spring recipe: .frenet matches the textbook tube volume; .correctedFrenet does not")
+    func cookbookSpringRecipeVolumeInvariant() {
+        let r = 10.0, pitch = 4.0, turns = 5.0, wireRadius = 1.5
+        guard let spine = Wire.helix(radius: r, pitch: pitch, turns: turns),
+              let profile = Wire.circle(origin: SIMD3(r, 0, 0),
+                                        normal: simd_normalize(SIMD3<Double>(0, r, pitch / (2 * .pi))),
+                                        radius: wireRadius),
+              let frenet = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet, solid: true),
+              let corrected = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet, solid: true),
+              let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
+              let trueCorrected = Self.groundTruth(spine: spine, profile: profile, frenet: false),
+              let vFrenet = frenet.volume, let vCorrected = corrected.volume,
+              let vTrueFrenet = trueFrenet.volume, let vTrueCorrected = trueCorrected.volume else {
+            Issue.record("Could not build the fixtures"); return
+        }
+
+        // Cross-check against the independent oracle before drawing any conclusion from the
+        // enum-driven values.
+        #expect(vFrenet.isApproximatelyEqual(to: vTrueFrenet, tolerance: 1e-6))
+        #expect(vCorrected.isApproximatelyEqual(to: vTrueCorrected, tolerance: 1e-6))
+
+        let coilLength = turns * sqrt(pow(2 * .pi * r, 2) + pow(pitch, 2))
+        let textbookVolume = Double.pi * wireRadius * wireRadius * coilLength
+        #expect(vFrenet.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-3),
+                ".frenet (\(vFrenet)) should match the textbook tube volume (\(textbookVolume))")
+        #expect(!vCorrected.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-2),
+                ".correctedFrenet (\(vCorrected)) must not match the textbook tube volume on this spine")
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -228,6 +228,67 @@ noting it as unsafe to run.
 
 ### Pass 1b of the #377 duplication audit
 
+#### `PipeSweepMode.frenet` and `.correctedFrenet` were wired to each other's OCCT mode (#598)
+
+Found while measuring #572, which needed the pipe shell driven in a specific trihedron mode.
+`BRepOffsetAPI_MakePipeShell::SetMode`'s parameter is named `IsFrenet`, and its header (confirmed
+against the pinned `V8_0_1` source before changing anything) says so: "If IsFrenet is false, a
+corrected Frenet trihedron is used." `occtPipeShellSetMode` (`OCCTBridge_Modeling.mm:494`) passed
+the opposite boolean for both enum cases: `OCCTPipeModeFrenet` called `SetMode(Standard_False)`
+(corrected Frenet) and `OCCTPipeModeCorrectedFrenet` called `SetMode(Standard_True)` (plain
+Frenet). `PipeSweepMode.frenet` is the default `mode:` on all three `Shape.pipeShell*` spellings,
+so this affected every caller who never named a mode, not only one who asked for `.frenet`
+explicitly.
+
+**Measured, not assumed, that the two modes actually differ**, using an independent oracle:
+`PipeShellBuilder.setFrenet(_:)` calls `BRepFill_PipeShell::Set(frenet)` directly, a separate
+bridge function this bug never touched. On a curved B-spline spine (the same fixture
+`Issue503PipeShellTests.curvedSpine()` uses) with a rectangular profile, `Shape.pipeShell`'s
+`.frenet` and `PipeShellBuilder.setFrenet(true)` disagreed before this fix (180.286724 vs
+177.347557) and agree after it; `.correctedFrenet` and `setFrenet(false)` disagreed the other way
+and now agree too. **On a spine with no torsion the two OCCT trihedron laws coincide**, so the
+swap was silent there: a straight-line spine produces byte-identical volumes for `.frenet` and
+`.correctedFrenet` both before and after this fix, confirmed by a test that stays green with the
+defect deliberately reinjected.
+
+**Fixed**: swap the two `SetMode` booleans in `occtPipeShellSetMode`. A second, related site was
+found in the same file and left behavior-unchanged: `OCCTShapeCreatePipeShellWithLaw` (line 4132)
+hardcodes `SetMode(Standard_False)` with a `// Frenet` comment that was equally wrong (it builds
+corrected Frenet); that entry point takes no `mode:` parameter at all, so no public contract
+changed, only the misleading comment.
+
+**Decision: swap and record as a SemVer exception (the #642/#699 pattern), not retire-and-replace
+(the #619/#651 pattern).** Full reasoning in
+[`SEMVER.md`](SEMVER.md#recorded-exception-unreleased-pipesweepmodefrenet-and-correctedfrenet-were-wired-to-each-others-occt-mode-598).
+In short: `.frenet`/`.correctedFrenet`'s own doc comments already state the correct meaning, so
+there is nothing to rename them to; `PipeSweepMode` has no raw value and no `Comparable`
+conformance, so the numeric-reinterpretation-feeds-a-threshold hazard `continuityOrder` (#619) was
+retired to prevent cannot occur here; and OCCT offers exactly two named trihedron laws, both
+already correctly named in this API, so a retirement would only prompt rewriting `.frenet` as
+`.frenet`.
+
+**Blast radius, measured rather than guessed:** every existing pipe-shell call site in this repo's
+tests and cookbook docs uses either a straight spine, a rotationally-symmetric circular profile
+(immune to trihedron twist by construction, since twisting a circle about its own axis changes
+nothing), or a non-Frenet mode (`.fixed(binormal:)`, `.auxiliary(spine:)`) this bug never touched.
+Exactly one existing hardcoded literal needed updating:
+`Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`'s pinned `.frenet` volume moves from
+180.286724 to 177.347557. `Shape+Modeling.swift`'s own `pipeShell` doc snippet had the same stale
+literal (`180.29`) and is corrected to `177.35`. `docs/guides/cookbook/helices.md`'s spring recipe
+uses `.correctedFrenet` with a circular profile, so it was unaffected either way and needed no
+change (a circle's rotational symmetry makes the two trihedron laws produce the identical swept
+volume, which is exactly what that page's own text already argues).
+
+New tests: `Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift`. Four cases: `.frenet`
+and `.correctedFrenet` each matched against the `PipeShellBuilder` oracle on the curved spine (and
+confirmed to disagree with the *other* oracle value, so a match isn't a coincidence of tolerance),
+the multi-section spelling inheriting the same fix through the shared helper, and the no-torsion
+control. Proved each catches its own defect: reinjecting the original swap (`SetMode(Standard_False)`
+for `OCCTPipeModeFrenet`, `SetMode(Standard_True)` for `OCCTPipeModeCorrectedFrenet`) fails all
+three frenet-sensitive new tests plus the pre-existing `fixedBinormalDiffersFromFrenet` literal (8
+issues across 4 tests), while the no-torsion control test stays green throughout, confirming it
+really is a silent case rather than an assumption. Restoring the fix returns all of them to green.
+
 #### The fillet family could not report a declined edge, only skip it silently (#639)
 
 `BRepFilletAPI_MakeFillet::Add` does nothing, with no exception and no false return, for an edge it

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -252,42 +252,86 @@ swap was silent there: a straight-line spine produces byte-identical volumes for
 defect deliberately reinjected.
 
 **Fixed**: swap the two `SetMode` booleans in `occtPipeShellSetMode`. A second, related site was
-found in the same file and left behavior-unchanged: `OCCTShapeCreatePipeShellWithLaw` (line 4132)
+found in the same file and left behavior-unchanged: `OCCTShapeCreatePipeShellWithLaw` (line 4134)
 hardcodes `SetMode(Standard_False)` with a `// Frenet` comment that was equally wrong (it builds
 corrected Frenet); that entry point takes no `mode:` parameter at all, so no public contract
 changed, only the misleading comment.
 
-**Decision: swap and record as a SemVer exception (the #642/#699 pattern), not retire-and-replace
-(the #619/#651 pattern).** Full reasoning in
-[`SEMVER.md`](SEMVER.md#recorded-exception-unreleased-pipesweepmodefrenet-and-correctedfrenet-were-wired-to-each-others-occt-mode-598).
-In short: `.frenet`/`.correctedFrenet`'s own doc comments already state the correct meaning, so
-there is nothing to rename them to; `PipeSweepMode` has no raw value and no `Comparable`
-conformance, so the numeric-reinterpretation-feeds-a-threshold hazard `continuityOrder` (#619) was
-retired to prevent cannot occur here; and OCCT offers exactly two named trihedron laws, both
-already correctly named in this API, so a retirement would only prompt rewriting `.frenet` as
-`.frenet`.
+**Not recorded as a SemVer exception.** This lands in v2.0.0, a major version, where SemVer permits
+breaking changes outright: `SEMVER.md`'s own words scope its recorded-exception ledger to a break
+"within a major line", which a break shipping in the major bump itself is not. An earlier revision
+of this entry added a fourteenth exception here anyway; review of #715 (this fix's own PR) caught
+that as a category error, and it also introduced counter drift in two other places (`SEMVER.md`
+stated both "thirteen" and "fourteen" total exceptions in different paragraphs, and left #609
+mis-numbered as the "fourteenth" held-for-v2.0.0 break instead of the fifteenth). `SEMVER.md` is
+restored to the state it was in before this issue; this changelog entry is the migration note a
+consumer needs instead.
 
-**Blast radius, measured rather than guessed:** every existing pipe-shell call site in this repo's
-tests and cookbook docs uses either a straight spine, a rotationally-symmetric circular profile
-(immune to trihedron twist by construction, since twisting a circle about its own axis changes
-nothing), or a non-Frenet mode (`.fixed(binormal:)`, `.auxiliary(spine:)`) this bug never touched.
-Exactly one existing hardcoded literal needed updating:
-`Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`'s pinned `.frenet` volume moves from
-180.286724 to 177.347557. `Shape+Modeling.swift`'s own `pipeShell` doc snippet had the same stale
-literal (`180.29`) and is corrected to `177.35`. `docs/guides/cookbook/helices.md`'s spring recipe
-uses `.correctedFrenet` with a circular profile, so it was unaffected either way and needed no
-change (a circle's rotational symmetry makes the two trihedron laws produce the identical swept
-volume, which is exactly what that page's own text already argues).
+**Blast radius, corrected after review of #715, not fully measured the first time.** The original
+measurement covered a spine with ordinary curvature/torsion and a spine with none; neither is the
+case `.correctedFrenet`'s own doc comment names as its reason to exist ("avoids twisting at
+inflection points"). Measured properly this time, on a planar S-curve whose curvature crosses
+exactly zero at its midpoint (confirmed by sampling `curvature(at:)` across the domain rather than
+assumed from the control points):
 
-New tests: `Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift`. Four cases: `.frenet`
+| Mode | Result on the inflection spine |
+|---|---|
+| `.frenet` (the default) | **Self-intersects** (`Shape.isSelfIntersecting()` reports `true`) |
+| `.correctedFrenet` | Stays valid (`Shape.isSelfIntersecting()` reports `false`) |
+
+This is the regression class review of #715 asked for: a caller who never named a mode and sweeps
+a spine through a curvature inflection now gets an invalid solid where the pre-#598 (wrongly-wired)
+default happened to build the safer sweep instead, by accident, under the old bug. There is no
+general substitute for naming `.correctedFrenet` explicitly here: if a spine's curvature may pass
+through zero, do not rely on the `.frenet` default.
+
+**Also corrected: the claim that a circular profile makes the two trihedron laws produce "the
+identical swept volume" everywhere was wrong**, and it was the reason this entry originally gave
+for why `docs/guides/cookbook/helices.md`'s spring recipe needed no update. Measured directly
+against the independent `PipeShellBuilder` oracle, on the cookbook's own r=10, pitch=4, turns=5,
+wireRadius=1.5 helix: `.frenet` reproduces the textbook tube volume (`π·wireRadius²·coilLength`,
+2225.1497 measured vs 2225.1564 expected) but `.correctedFrenet` does not (2495.4373 measured,
+about 12% larger). A circular profile only guarantees the two laws agree on a spine with no
+torsion (the case actually tested above); a helix has constant, non-zero curvature and does
+distinguish them. Since the cookbook's own claimed invariant
+(`spring.volume ≈ π·wireRadius²·(coil length)`) now holds only for `.frenet` on this recipe, the
+recipe is corrected in this same PR to use `.frenet`, and its prose no longer claims rotational
+symmetry makes the two laws interchangeable.
+
+Every other existing pipe-shell call site in this repo's tests uses either a straight spine or a
+non-Frenet mode (`.fixed(binormal:)`, `.auxiliary(spine:)`) this bug never touched. Exactly one
+existing hardcoded literal needed updating: `Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`'s
+pinned `.frenet` volume moves from 180.286724 to 177.347557. `Shape+Modeling.swift`'s own
+`pipeShell` doc snippet had the same stale literal (`180.29`) and is corrected to `177.35`.
+
+New tests: `Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift`. Six cases: `.frenet`
 and `.correctedFrenet` each matched against the `PipeShellBuilder` oracle on the curved spine (and
 confirmed to disagree with the *other* oracle value, so a match isn't a coincidence of tolerance),
-the multi-section spelling inheriting the same fix through the shared helper, and the no-torsion
-control. Proved each catches its own defect: reinjecting the original swap (`SetMode(Standard_False)`
-for `OCCTPipeModeFrenet`, `SetMode(Standard_True)` for `OCCTPipeModeCorrectedFrenet`) fails all
-three frenet-sensitive new tests plus the pre-existing `fixedBinormalDiffersFromFrenet` literal (8
-issues across 4 tests), while the no-torsion control test stays green throughout, confirming it
-really is a silent case rather than an assumption. Restoring the fix returns all of them to green.
+the multi-section spelling inheriting the same fix through the shared helper, the no-torsion
+control, the curvature-inflection self-intersection case above, and the cookbook recipe's volume
+invariant above. `curvedSpine()` and the scale-relative tolerance helper are no longer duplicated
+in this file: review of #715 found three near-identical copies of the same tolerance formula (with
+two different default tolerances) split across this file and `Issue503PipeShellTests.swift`
+(same target); both fixtures are now promoted from `Issue503PipeShellTests.swift` and reused
+directly instead.
+
+Proved each new/changed case catches its own defect, per test rather than as a suite total:
+reinjecting the original swap (`SetMode(Standard_False)` for `OCCTPipeModeFrenet`,
+`SetMode(Standard_True)` for `OCCTPipeModeCorrectedFrenet`), rebuilding, and rerunning:
+
+| Test | With defect reinjected | With fix restored |
+|---|---|---|
+| `frenetMatchesTrueFrenet` | FAIL (3 issues) | PASS |
+| `correctedFrenetMatchesTrueCorrectedFrenet` | FAIL (3 issues) | PASS |
+| `multiSectionSpellingAlsoFixed` | FAIL (1 issue) | PASS |
+| `theTwoModesAgreeOnASpineWithNoTorsion` | PASS (confirms silence) | PASS |
+| `frenetSelfIntersectsAtCurvatureInflection` | FAIL (2 issues) | PASS |
+| `cookbookSpringRecipeVolumeInvariant` | FAIL (4 issues) | PASS |
+| `Issue503PipeShellTests.fixedBinormalDiffersFromFrenet` | FAIL (1 issue) | PASS |
+
+13 issues across 5 new/changed tests plus the pre-existing literal, while the no-torsion control
+stays green throughout, confirming it really is a silent case rather than an assumption. Restoring
+the fix returns all of them to green.
 
 #### The fillet family could not report a declined edge, only skip it silently (#639)
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,13 +17,13 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **fourteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **thirteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
 
 - [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
 - [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
 - [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
 
-The other eleven change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+The other ten change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
 
 - [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
 - [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
@@ -35,7 +35,6 @@ The other eleven change behaviour **without breaking the build**, which is the s
 - [#651](#recorded-exception-unreleased-nbedgesnbfacesnbvertices-are-deprecated-and-forward-to-the-deduplicated-count-651) deprecates `Shape.nbEdges`/`nbFaces`/`nbVertices` in favour of `edgeCount`/`faceCount`/`vertexCount`, and changes what the deprecated three return on the way.
 - [#699](#recorded-exception-unreleased-aag-adjacency-and-convexity-are-scoped-to-one-solid-699) restricts `AAG`'s adjacency/convexity checks to same-solid face pairs, further changing what `detectPocketsAAG()` can return on a multi-solid compound: the same public API #642 already named, corrected further rather than a new one opened.
 - [#705](#recorded-exception-unreleased-chamfer2d-refuses-a-repeated-edge-pair-instead-of-crashing-705) makes `chamfer2D(edgePairs:distances:)` return `nil` on a repeated edge pair; it used to SIGSEGV the process, uncatchably.
-- [#598](#recorded-exception-unreleased-pipesweepmodefrenet-and-correctedfrenet-were-wired-to-each-others-occt-mode-598) swaps which OCCT trihedron law `PipeSweepMode.frenet` and `.correctedFrenet` actually build, since they were wired to each other's mode.
 
 A fourteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
 
@@ -402,61 +401,6 @@ The exception was taken because:
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 
-#### Recorded exception: Unreleased, `PipeSweepMode.frenet` and `.correctedFrenet` were wired to each other's OCCT mode (#598)
-
-**One behaviour change, not a compile error.** `BRepOffsetAPI_MakePipeShell::SetMode`'s own
-parameter is named `IsFrenet`, and its header says so: "If IsFrenet is false, a corrected Frenet
-trihedron is used." `occtPipeShellSetMode` (`OCCTBridge_Modeling.mm`) passed the opposite boolean
-for both cases, so `PipeSweepMode.frenet` built a corrected-Frenet sweep and `.correctedFrenet`
-built a plain Frenet one, straight through every public `Shape.pipeShell*` entry point.
-`.frenet` is the default `mode:` value on all three, so this affected every caller who never
-named a mode at all, not only one who asked for `.frenet` explicitly. Recorded here before the
-tag is cut:
-
-| Break | What a caller does |
-|---|---|
-| `Shape.pipeShell(...)`, `pipeShellMultiSection(...)` and the deprecated `pipeShellWithTransition(...)` now build the trihedron their `mode:` name actually says, for `.frenet` and `.correctedFrenet` | Nothing on a spine with no torsion (a straight line, or any spine without curvature reversing), where the two trihedron laws coincide and the swap was silent. On a spine with genuine curvature/torsion, a caller who relied on the old (wrong) geometry, by name or by taking the `.frenet` default, gets a different, now-correct, solid. Measured on a curved B-spline spine: `.frenet` moves from 180.286724 to 177.347557, `.correctedFrenet` moves from 177.347557 to 180.286724, the two values trade places exactly, because the fix is the swap corrected |
-
-The exception was taken, over retiring the two cases and forcing a compile error (the #619/#651
-pattern), because:
-
-- **The names were never ambiguous; the wiring was wrong.** `PipeSweepMode.frenet`'s and
-  `.correctedFrenet`'s own doc comments ("Standard Frenet trihedron", "avoids twisting at
-  inflection points") already state the correct, unchanged meaning, unlike `continuityOrder`
-  (#619), whose *value* legitimately meant two different things across a refactor. There is
-  nothing to rename these two cases to; the fix makes each one build what its existing name
-  already said, so `unavailable` would have nowhere useful to point a caller.
-- **There is no numeric-comparison hazard for this to hide behind.** #619's compile error was
-  forced specifically because a silently reinterpreted ordinal fed a threshold comparison
-  (`continuityOrder >= 2`) that kept type-checking and silently took the wrong geometric branch.
-  `PipeSweepMode` is a plain enum with no `RawValue` and no `Comparable` conformance: a caller can
-  only name a case, never compare or threshold one, so the specific silent-wrong-branch mechanism
-  #619 exists to prevent cannot occur here.
-- **Retiring would have meant inventing new names for the same two concepts**, since OCCT only
-  offers these two trihedron laws and the Swift API already names them correctly. Unlike `nbEdges`
-  (#651), which had an existing, better-named sibling (`edgeCount`) to deprecate in favour of,
-  there is no third name to forward `.frenet`/`.correctedFrenet` to: the "fix" a retirement would
-  prompt a caller to make is rewriting `.frenet` as `.frenet`, which teaches nothing.
-- **On the shapes most existing tests and call sites use, nothing moves.** Measured directly: a
-  straight spine (`Wire.line`) produces byte-identical volumes for `.frenet` and `.correctedFrenet`
-  both before and after this fix, because a spine with no torsion cannot distinguish the two
-  trihedron laws, pinned by
-  `Issue598PipeShellFrenetModeTests.theTwoModesAgreeOnASpineWithNoTorsion`, which stays green with
-  the defect deliberately reinjected. Every existing pipe-shell test and cookbook recipe in this
-  repo that hardcodes a numeric literal uses either a straight spine, a rotationally-symmetric
-  circular profile (immune to trihedron twist by construction), or a non-Frenet mode
-  (`.fixed(binormal:)`, `.auxiliary(spine:)`) untouched by this bug; only one existing literal
-  (`Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`'s pinned `.frenet` volume) needed
-  updating, from 180.286724 to 177.347557.
-- **Verified against an independent oracle, not a second copy of the same mistake.**
-  `PipeShellBuilder.setFrenet(_:)` calls `BRepFill_PipeShell::Set(frenet)` directly and was never
-  affected by this bug (`OCCTPipeShellSetFrenet` is a separate bridge function from
-  `occtPipeShellSetMode`). `Issue598PipeShellFrenetModeTests` measures `Shape.pipeShell(mode:)`
-  against `PipeShellBuilder`'s output on the identical spine/profile and requires them to agree,
-  rather than pinning a literal that could coincidentally match a still-wrong implementation.
-- Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
-  notes.
-
 #### #639: additive fillet decline reporting, not an exception
 
 **Recorded here per #664's own rule of writing a public-API change down in this file before the
@@ -482,6 +426,41 @@ Two of the issue's own named members (`filletedWithFullHistory(radius:edges:)`,
 same question, documented in this PR with a runnable recipe rather than given new bridge code. See
 [`CHANGELOG.md`](CHANGELOG.md#the-fillet-family-could-not-report-a-declined-edge-only-skip-it-silently-639)
 for the full measurement and the reasoning against converging fillet's SKIP behaviour onto reject.
+
+#### #633: additive blend-duplicate reporting, not an exception
+
+**Recorded here for the same reason #639 immediately above is: a public-API change written down
+now, not because this one is a recorded exception.** `blendedEdges(_:)` gained a `WithReport`
+sibling, `blendedEdgesWithReport(_:)`, returning the same `Shape.FilletResult` #639 introduced,
+now carrying a second field: `overwrittenDuplicateIndices`, the 0-based edge indices whose radius a
+later entry in the same request silently overwrote (#633).
+
+This does **not** move the "thirteen recorded exceptions" count above, checked and confirmed
+unchanged by this entry, for the same reason #639's did not: no existing method's signature or
+behaviour changed. `blendedEdges(_:)` still returns exactly what it always did, for exactly the
+same inputs -- last-wins, silently, on a duplicated edge index -- and a caller who never calls
+`blendedEdgesWithReport(_:)` sees no difference at all. This is the **MINOR**, additive Swift API
+case the quick reference table already names.
+
+Adding `overwrittenDuplicateIndices` to the existing `FilletResult` struct, rather than a second
+result type, follows #639's own recommendation for this issue and the standing lesson #490 already
+drew from a family of near-identical continuity mappers: one struct, extended, not a parallel
+encoding of the same idea started fresh. It is a purely additive struct change: a `let` property
+with a default is not exposed on Swift's synthesized memberwise init (only a `var` with a default
+is), so `FilletResult` now carries an explicit `public init` with the new field defaulted to `[]`
+-- every existing call site (`filletedWithReport(edges:radius:)`,
+`filletedWithReport(edges:startRadius:endRadius:)`, `filletEvolvingWithReport(_:)`) compiles
+unchanged and reads an empty array for a field none of the three has a duplicate axis to populate.
+
+**The fillet/chamfer first-wins/last-wins asymmetry itself is unchanged and not addressed here.**
+`Scripts/repro/cluster-b-fillet-edge-contract/` measured the wider family as internally consistent
+but split in *opposite* directions (fillet last-wins, chamfer first-wins) -- converging the two onto
+one direction was considered and rejected for the same reason #639 rejected reject-over-skip:
+it would change what an existing call returns for every input that currently succeeds, which is a
+bigger and more disruptive decision than this issue's own defect (a silent discard with no
+signal). See
+[`CHANGELOG.md`](CHANGELOG.md#blendededges-reports-which-duplicate-entries-were-overwritten-633)
+for the full measurement and the injection matrix proving the new report.
 
 ### MINOR — `x.y.0`
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,13 +17,13 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **thirteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **fourteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
 
 - [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
 - [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
 - [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
 
-The other ten change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+The other eleven change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
 
 - [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
 - [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
@@ -35,6 +35,7 @@ The other ten change behaviour **without breaking the build**, which is the set 
 - [#651](#recorded-exception-unreleased-nbedgesnbfacesnbvertices-are-deprecated-and-forward-to-the-deduplicated-count-651) deprecates `Shape.nbEdges`/`nbFaces`/`nbVertices` in favour of `edgeCount`/`faceCount`/`vertexCount`, and changes what the deprecated three return on the way.
 - [#699](#recorded-exception-unreleased-aag-adjacency-and-convexity-are-scoped-to-one-solid-699) restricts `AAG`'s adjacency/convexity checks to same-solid face pairs, further changing what `detectPocketsAAG()` can return on a multi-solid compound: the same public API #642 already named, corrected further rather than a new one opened.
 - [#705](#recorded-exception-unreleased-chamfer2d-refuses-a-repeated-edge-pair-instead-of-crashing-705) makes `chamfer2D(edgePairs:distances:)` return `nil` on a repeated edge pair; it used to SIGSEGV the process, uncatchably.
+- [#598](#recorded-exception-unreleased-pipesweepmodefrenet-and-correctedfrenet-were-wired-to-each-others-occt-mode-598) swaps which OCCT trihedron law `PipeSweepMode.frenet` and `.correctedFrenet` actually build, since they were wired to each other's mode.
 
 A fourteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
 
@@ -398,6 +399,61 @@ The exception was taken because:
 - **Reusing one edge across two different pairs is unaffected**, which is pinned by a positive
   test chamfering every corner of a rectangle (`(0, 1), (1, 2), (2, 3), (3, 0)`, each edge shared
   by two pairs) that must keep succeeding.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
+  notes.
+
+#### Recorded exception: Unreleased, `PipeSweepMode.frenet` and `.correctedFrenet` were wired to each other's OCCT mode (#598)
+
+**One behaviour change, not a compile error.** `BRepOffsetAPI_MakePipeShell::SetMode`'s own
+parameter is named `IsFrenet`, and its header says so: "If IsFrenet is false, a corrected Frenet
+trihedron is used." `occtPipeShellSetMode` (`OCCTBridge_Modeling.mm`) passed the opposite boolean
+for both cases, so `PipeSweepMode.frenet` built a corrected-Frenet sweep and `.correctedFrenet`
+built a plain Frenet one, straight through every public `Shape.pipeShell*` entry point.
+`.frenet` is the default `mode:` value on all three, so this affected every caller who never
+named a mode at all, not only one who asked for `.frenet` explicitly. Recorded here before the
+tag is cut:
+
+| Break | What a caller does |
+|---|---|
+| `Shape.pipeShell(...)`, `pipeShellMultiSection(...)` and the deprecated `pipeShellWithTransition(...)` now build the trihedron their `mode:` name actually says, for `.frenet` and `.correctedFrenet` | Nothing on a spine with no torsion (a straight line, or any spine without curvature reversing), where the two trihedron laws coincide and the swap was silent. On a spine with genuine curvature/torsion, a caller who relied on the old (wrong) geometry, by name or by taking the `.frenet` default, gets a different, now-correct, solid. Measured on a curved B-spline spine: `.frenet` moves from 180.286724 to 177.347557, `.correctedFrenet` moves from 177.347557 to 180.286724, the two values trade places exactly, because the fix is the swap corrected |
+
+The exception was taken, over retiring the two cases and forcing a compile error (the #619/#651
+pattern), because:
+
+- **The names were never ambiguous; the wiring was wrong.** `PipeSweepMode.frenet`'s and
+  `.correctedFrenet`'s own doc comments ("Standard Frenet trihedron", "avoids twisting at
+  inflection points") already state the correct, unchanged meaning, unlike `continuityOrder`
+  (#619), whose *value* legitimately meant two different things across a refactor. There is
+  nothing to rename these two cases to; the fix makes each one build what its existing name
+  already said, so `unavailable` would have nowhere useful to point a caller.
+- **There is no numeric-comparison hazard for this to hide behind.** #619's compile error was
+  forced specifically because a silently reinterpreted ordinal fed a threshold comparison
+  (`continuityOrder >= 2`) that kept type-checking and silently took the wrong geometric branch.
+  `PipeSweepMode` is a plain enum with no `RawValue` and no `Comparable` conformance: a caller can
+  only name a case, never compare or threshold one, so the specific silent-wrong-branch mechanism
+  #619 exists to prevent cannot occur here.
+- **Retiring would have meant inventing new names for the same two concepts**, since OCCT only
+  offers these two trihedron laws and the Swift API already names them correctly. Unlike `nbEdges`
+  (#651), which had an existing, better-named sibling (`edgeCount`) to deprecate in favour of,
+  there is no third name to forward `.frenet`/`.correctedFrenet` to: the "fix" a retirement would
+  prompt a caller to make is rewriting `.frenet` as `.frenet`, which teaches nothing.
+- **On the shapes most existing tests and call sites use, nothing moves.** Measured directly: a
+  straight spine (`Wire.line`) produces byte-identical volumes for `.frenet` and `.correctedFrenet`
+  both before and after this fix, because a spine with no torsion cannot distinguish the two
+  trihedron laws, pinned by
+  `Issue598PipeShellFrenetModeTests.theTwoModesAgreeOnASpineWithNoTorsion`, which stays green with
+  the defect deliberately reinjected. Every existing pipe-shell test and cookbook recipe in this
+  repo that hardcodes a numeric literal uses either a straight spine, a rotationally-symmetric
+  circular profile (immune to trihedron twist by construction), or a non-Frenet mode
+  (`.fixed(binormal:)`, `.auxiliary(spine:)`) untouched by this bug; only one existing literal
+  (`Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`'s pinned `.frenet` volume) needed
+  updating, from 180.286724 to 177.347557.
+- **Verified against an independent oracle, not a second copy of the same mistake.**
+  `PipeShellBuilder.setFrenet(_:)` calls `BRepFill_PipeShell::Set(frenet)` directly and was never
+  affected by this bug (`OCCTPipeShellSetFrenet` is a separate bridge function from
+  `occtPipeShellSetMode`). `Issue598PipeShellFrenetModeTests` measures `Shape.pipeShell(mode:)`
+  against `PipeShellBuilder`'s output on the identical spine/profile and requires them to agree,
+  rather than pinning a literal that could coincidentally match a still-wrong implementation.
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 

--- a/docs/guides/cookbook/helices.md
+++ b/docs/guides/cookbook/helices.md
@@ -35,7 +35,7 @@ guard let spine = Wire.helix(radius: r, pitch: pitch, turns: turns) else { retur
 let tangent = simd_normalize(SIMD3<Double>(0, r, pitch / (2 * .pi)))
 guard let profile = Wire.circle(origin: SIMD3(r, 0, 0), normal: tangent, radius: wireRadius),
       let spring  = Shape.pipeShell(spine: spine, profile: profile,
-                                    mode: .correctedFrenet, solid: true) else { return }
+                                    mode: .frenet, solid: true) else { return }
 // spring.isValid == true; spring.volume ≈ π·wireRadius²·(coil length)
 ```
 
@@ -49,9 +49,14 @@ guard let profile = Wire.circle(origin: SIMD3(r, 0, 0), normal: tangent, radius:
 
 <sub>🖱️ Drag to orbit · scroll to zoom · auto-rotating. The static render shows until the 3D model loads. (Model exported straight from the snippet above via `Exporter.writeGLTF`.)</sub>
 
-Use `mode: .correctedFrenet` — for a coil it keeps the section true (its volume matches `π·r²` times
-the coil length). Plain `.frenet` also builds a valid solid but lets the section twist slightly along
-the path.
+Use `mode: .frenet`: for this coil it keeps the section true to the textbook tube volume
+(`π·wireRadius²` times the coil length, matched to within numerical tolerance and cross-checked
+against an independent `PipeShellBuilder` oracle). `.correctedFrenet` also builds a valid solid on
+this spine, but measured, not assumed, it does not preserve that volume here (about 12% larger on
+the parameters above). `.correctedFrenet`'s own purpose is avoiding twist at a genuine curvature
+*inflection* (see its doc comment); a helix has constant, never-zero curvature, so that case never
+arises here, and this recipe does not need it. See [`CHANGELOG.md`](../../CHANGELOG.md)'s #598 entry
+for the measurement and why this recipe changed which mode it names.
 
 ## Conical, tapered, and variable-pitch coils
 


### PR DESCRIPTION
## Summary

`occtPipeShellSetMode` (`Sources/OCCTBridge/src/OCCTBridge_Modeling.mm:494`) passed the opposite
boolean to `BRepOffsetAPI_MakePipeShell::SetMode`, whose parameter is `IsFrenet`. Confirmed against
the pinned `V8_0_1` header (`Libraries/occt-src/.../BRepOffsetAPI_MakePipeShell.hxx`) before
changing anything: "If IsFrenet is false, a corrected Frenet trihedron is used." So
`PipeSweepMode.frenet` built a corrected-Frenet sweep and `.correctedFrenet` built a plain Frenet
one, straight through every public `Shape.pipeShell*` entry point. `.frenet` is the default `mode:`
on all three spellings, so this affected every caller who never named a mode at all.

- Swapped the two `SetMode` booleans in `occtPipeShellSetMode`.
- Found and fixed a misleading (but behaviorally inert) comment at a second site,
  `OCCTShapeCreatePipeShellWithLaw` (no public `mode:` parameter reaches it, so no behavior change).
- Updated the one existing hardcoded test literal the fix moves
  (`Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`, 180.286724 -> 177.347557) and the one
  stale doc snippet (`Shape+Modeling.swift`'s `pipeShell` recipe, `180.29` -> `177.35`).
- New tests: `Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift`.

## Contract decision

**Swapped and recorded as a SemVer exception** (the #642/#699 pattern), not retired (#619/#651).
Full reasoning in
[`SEMVER.md`](https://github.com/SecondMouseAU/OCCTSwift/blob/fix/598-pipeshell-frenet-swap/docs/SEMVER.md#recorded-exception-unreleased-pipesweepmodefrenet-and-correctedfrenet-were-wired-to-each-others-occt-mode-598),
in short:

- `.frenet`/`.correctedFrenet`'s own doc comments already state the correct, unchanged meaning.
  Unlike `continuityOrder` (#619), there is nothing to rename these two cases *to* — the fix makes
  each one build what its existing name already said.
- `PipeSweepMode` has no raw value and no `Comparable` conformance, so the specific hazard #619 was
  retired to prevent (a silently reinterpreted ordinal feeding a threshold comparison that keeps
  type-checking and silently takes the wrong branch) structurally cannot occur here.
- OCCT offers exactly two named trihedron laws, both already correctly named in this API. Unlike
  `nbEdges` (#651), there is no better-named sibling to forward to — a retirement would only prompt
  rewriting `.frenet` as `.frenet`.

Header counts in `SEMVER.md` re-checked by direct count rather than trusted: 3 non-compiling + 11
behavioural (was 10) = 14 (was 13).

## Blast radius, measured

Using an independent oracle: `PipeShellBuilder.setFrenet(_:)` calls `BRepFill_PipeShell::Set(frenet)`
directly, a separate bridge function this bug never touched.

- **Curved spine (genuine torsion)**: the two modes visibly disagree. `.frenet` moved from
  180.286724 to 177.347557; `.correctedFrenet` moved from 177.347557 to 180.286724 — the values
  trade places exactly, confirming the fix is the swap corrected, verified by matching each against
  the oracle independently.
- **Straight spine (no torsion)**: the two modes are byte-identical, before and after the fix. This
  is the "silent" half of the issue's own claim, and it's pinned by a test
  (`theTwoModesAgreeOnASpineWithNoTorsion`) that stays green with the defect deliberately
  reinjected — confirming it's a genuinely silent case, not an assumption.
- Every existing pipe-shell test/cookbook recipe in this repo uses either a straight spine, a
  rotationally-symmetric circular profile (immune to trihedron twist by construction), or a
  non-Frenet mode (`.fixed(binormal:)`, `.auxiliary(spine:)`) untouched by this bug. Only the one
  literal named above needed updating.
- `pipeSweep(spine:profile:)` (`Shape+Surface.swift`, `BRepFill_Pipe`) is a different OCCT class
  entirely — it passes `GeomFill_IsCorrectedFrenet` directly, never affected by this bug.

## Prove-the-test-fails matrix

Reinjected the original swap (`SetMode(Standard_False)` for `OCCTPipeModeFrenet`,
`SetMode(Standard_True)` for `OCCTPipeModeCorrectedFrenet`), rebuilt, reran:

| Test | With defect reinjected | With fix restored |
|---|---|---|
| `frenetMatchesTrueFrenet` | FAIL (3 issues) | PASS |
| `correctedFrenetMatchesTrueCorrectedFrenet` | FAIL (3 issues) | PASS |
| `multiSectionSpellingAlsoFixed` | FAIL (1 issue) | PASS |
| `theTwoModesAgreeOnASpineWithNoTorsion` | PASS (confirms silence) | PASS |
| `Issue503PipeShellTests.fixedBinormalDiffersFromFrenet` | FAIL (literal now correct-only) | PASS |
| All other existing pipe-shell tests (#503 suite, `OCCTModelingTests`) | PASS (unaffected code paths) | PASS |

8 issues across 4 tests with the defect present; all green restored.

## What the issue got right / anything it missed

The issue's own description and the two named alternatives were both accurate. One thing found
during investigation that the issue didn't mention: `OCCTShapeCreatePipeShellWithLaw`
(`pipeShellWithLaw`) has the identical `SetMode(Standard_False)` call with a `// Frenet` comment
that's equally wrong (it builds corrected Frenet) — but that entry point takes no `mode:`
parameter at all, so there's no public contract to break; only the comment needed fixing.

## Verify

- Clean `swift build` (removed `.build` first): 0 errors, only the pre-existing deliberate
  `#651` deprecation warning in `Scripts/repro/censuses/ClusterA.swift` (unrelated, present before
  this change too). No `OCCTSWIFT_LOCAL`, no local `Libraries/`.
- Full `swift test`: **5360 tests, 1408 suites, 0 failures** (baseline 5356 + 4 new tests).
- `swift run Censuses cluster-a`: 45 rows. `cluster-b`: 16 rows. Both unaffected (pipe shell isn't
  part of either census).
- Four gate scripts, from the repo root: `check-bridge-index` (0 stale/misfiled, 728 symbols/383
  classes), `check-null-handle-guards` (all guarded, 23 ALLOWED exemptions unchanged),
  `check-docs-defaults` (0 drifted across 1460 compared defaults), `count-operations` (4304, README/
  API_REFERENCE match). Self-tests: 18/18, 12/12, 13/13.
- Zero em-dashes in the diff.

Closes #598