### PR TITLE
fix(#640): the math dimension family rejects invalid input instead of trapping or reading out of bounds

### DIFF
--- a/Sources/OCCTSwift/MathDimension.swift
+++ b/Sources/OCCTSwift/MathDimension.swift
@@ -1,0 +1,93 @@
+//
+//  MathDimension.swift
+//  OCCTSwift
+//
+//  The one validator every problem-dimension argument in MathLibrary.swift and
+//  MathSolver.swift is checked against, plus the two shapes that check takes.
+//
+//  Driver: review of PR #716 (issue #640), finding 9. #634 (issue #622) bounded 21
+//  sampling-shaped result buffers and deliberately left this family unfixed: its numbers
+//  are problem dimensions that must agree with the caller's OWN arrays, not sampling
+//  capacities, so `Sampling.requested`/`capacity` was the wrong tool. #640 then fixed 18
+//  call sites by hand, each repeating one of two shapes -- "n is positive and every array
+//  n sizes is exactly that long", or "rows and cols are both positive and a flat array is
+//  exactly their product" -- with no shared validator: the same "no compiler help across
+//  N hand-duplicated sites" gap #634's own ad hoc guards left before it (5 of 20 invisible
+//  to review once). This file is that validator.
+//
+//  It also closes a defect the hand-written guards shared (review finding 8): `n * n` and
+//  `rows * cols` are plain `Int` multiplications, and a large enough positive dimension
+//  overflows that multiplication before the guard can reject it -- the exact process trap
+//  #640 exists to eliminate, reintroduced by the guard meant to prevent it.
+//  `Sampling.gridTotal` already carries the overflow-safe idiom
+//  (`multipliedReportingOverflow(by:)`); this reuses it rather than inventing another.
+//
+
+/// Validates a problem-dimension argument against the arrays it sizes.
+///
+/// Not `Sampling`: a problem dimension is not a subdivision count. It has no shared
+/// ceiling, and clamping one would hand back a garbage-dimension solve rather than
+/// truncating a result set. What every site in this family shares instead is the shape of
+/// the check, which is what this type factors out.
+enum MathDimension {
+
+    /// `n` must be positive, and every array length in `counts` must equal it exactly.
+    ///
+    /// This is the `startPoint.count == variables` shape: one dimension sizing one or more
+    /// flat, `n`-length arrays.
+    ///
+    /// ```swift
+    /// MathDimension.valid(3, matches: 3, 3)   // true
+    /// MathDimension.valid(-1, matches: 0)     // false -- not positive
+    /// MathDimension.valid(3, matches: 1)      // false -- length mismatch
+    /// ```
+    static func valid(_ n: Int, matches counts: Int...) -> Bool {
+        guard n > 0 else { return false }
+        return counts.allSatisfy { $0 == n }
+    }
+
+    /// Every array length in `counts` must equal `n` exactly.
+    ///
+    /// Unlike ``valid(_:matches:)`` this does not also require `n` to be positive, for the
+    /// sites where `n` is itself another array's `.count` and can never be negative (#640's
+    /// own five "invisible to a trap-shaped census" sites): requiring positivity there would
+    /// reject a legitimate empty input the original, unguarded code accepted.
+    ///
+    /// ```swift
+    /// MathDimension.consistent(0, matches: 0)    // true -- two empty arrays agree
+    /// MathDimension.consistent(50, matches: 1)   // false -- length mismatch
+    /// ```
+    static func consistent(_ n: Int, matches counts: Int...) -> Bool {
+        counts.allSatisfy { $0 == n }
+    }
+
+    /// `n` must be positive, and `count` must equal `n * n` exactly -- checked without
+    /// overflowing the multiplication (review finding 8): a large enough positive `n` makes
+    /// `n * n` trap before a plain `==` guard ever runs.
+    ///
+    /// ```swift
+    /// MathDimension.validSquare(2, count: 4)      // true
+    /// MathDimension.validSquare(.max, count: 1)   // false -- rejected, not trapped
+    /// ```
+    static func validSquare(_ n: Int, count: Int) -> Bool {
+        guard n > 0 else { return false }
+        let (product, overflowed) = n.multipliedReportingOverflow(by: n)
+        guard !overflowed else { return false }
+        return count == product
+    }
+
+    /// `rows` and `cols` must both be positive, and `count` must equal `rows * cols`
+    /// exactly -- checked without overflowing the multiplication (same reason as
+    /// ``validSquare(_:count:)``).
+    ///
+    /// ```swift
+    /// MathDimension.validRectangle(rows: 3, cols: 2, count: 6)          // true
+    /// MathDimension.validRectangle(rows: .max, cols: 2, count: 1)       // false -- rejected, not trapped
+    /// ```
+    static func validRectangle(rows: Int, cols: Int, count: Int) -> Bool {
+        guard rows > 0, cols > 0 else { return false }
+        let (product, overflowed) = rows.multipliedReportingOverflow(by: cols)
+        guard !overflowed else { return false }
+        return count == product
+    }
+}

--- a/Sources/OCCTSwift/MathLibrary.swift
+++ b/Sources/OCCTSwift/MathLibrary.swift
@@ -66,8 +66,15 @@ public enum MathGauss {
     }
 
     /// Compute determinant using Gauss elimination.
+    ///
+    /// `n` must be positive and match `matrix`'s length exactly (`matrix.count == n * n`).
+    /// Neither was checked before #640: the bridge loops `matrixData[i*n+j]` for
+    /// `i, j in 0..<n` unconditionally, so a positive `n` larger than `matrix` reads out of
+    /// bounds rather than failing, and a negative `n` was a `Standard_Failure` the bridge's
+    /// own `catch (...)` already absorbed into the same `0.0` this guard now returns.
     public static func determinant(matrix: [Double], n: Int) -> Double {
-        matrix.withUnsafeBufferPointer { buf in
+        guard n > 0, matrix.count == n * n else { return 0.0 }
+        return matrix.withUnsafeBufferPointer { buf in
             OCCTMathGaussDeterminant(buf.baseAddress!, Int32(n))
         }
     }
@@ -83,8 +90,13 @@ public enum MathSVD {
     ///   - cols: N
     ///   - rhs: Right-hand side (length M)
     /// - Returns: Solution vector (length N), or nil on failure
+    ///
+    /// `rows` and `cols` must both be positive. A consistency check alone is not enough
+    /// (#640): `rows: 0, cols: -1` satisfies `matrix.count == rows * cols` exactly (`0 == 0`)
+    /// and `rhs.count == rows` exactly (`0 == 0`), so without a positivity bound this still
+    /// reaches `Array(repeating:count:)` with a negative count and traps.
     public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) -> [Double]? {
-        guard matrix.count == rows * cols, rhs.count == rows else { return nil }
+        guard rows > 0, cols > 0, matrix.count == rows * cols, rhs.count == rows else { return nil }
         var solution = [Double](repeating: 0, count: cols)
         let ok = matrix.withUnsafeBufferPointer { mBuf in
             rhs.withUnsafeBufferPointer { bBuf in
@@ -124,8 +136,12 @@ public enum MathJacobi {
     ///   - matrix: Row-major NxN symmetric matrix
     ///   - n: Dimension
     /// - Returns: Eigenvalues, or nil on failure
+    ///
+    /// `n` must be positive. `eigenvalues(matrix: [1.0], n: -1)` satisfies
+    /// `matrix.count == n * n` exactly (`1 == (-1) * (-1)`) and would otherwise reach
+    /// `Array(repeating:count:)` with a negative count and trap (#640).
     public static func eigenvalues(matrix: [Double], n: Int) -> [Double]? {
-        guard matrix.count == n * n else { return nil }
+        guard n > 0, matrix.count == n * n else { return nil }
         var eigenvalues = [Double](repeating: 0, count: n)
         let ok = matrix.withUnsafeBufferPointer { mBuf in
             eigenvalues.withUnsafeMutableBufferPointer { eBuf in
@@ -140,8 +156,12 @@ public enum MathJacobi {
 public enum MathHouseholder {
 
     /// Solve overdetermined Ax=b using Householder QR (M >= N).
+    ///
+    /// `rows` and `cols` must both be positive, the same positivity gap as `MathSVD.solve`
+    /// (#640): `rows >= cols` alone does not exclude `rows: 0, cols: -1`.
     public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) -> [Double]? {
-        guard matrix.count == rows * cols, rhs.count == rows, rows >= cols else { return nil }
+        guard rows > 0, cols > 0, matrix.count == rows * cols, rhs.count == rows, rows >= cols
+        else { return nil }
         var solution = [Double](repeating: 0, count: cols)
         let ok = matrix.withUnsafeBufferPointer { mBuf in
             rhs.withUnsafeBufferPointer { bBuf in
@@ -174,8 +194,13 @@ public enum MathCrout {
     }
 
     /// Determinant of symmetric matrix via Crout.
+    ///
+    /// Same fix as `MathGauss.determinant` (#640): `n` must be positive and match `matrix`'s
+    /// length exactly, or the bridge's unconditional `matrixData[i*n+j]` loop reads out of
+    /// bounds.
     public static func determinant(matrix: [Double], n: Int) -> Double {
-        matrix.withUnsafeBufferPointer { buf in
+        guard n > 0, matrix.count == n * n else { return 0.0 }
+        return matrix.withUnsafeBufferPointer { buf in
             OCCTMathCroutDeterminant(buf.baseAddress!, Int32(n))
         }
     }

--- a/Sources/OCCTSwift/MathLibrary.swift
+++ b/Sources/OCCTSwift/MathLibrary.swift
@@ -67,13 +67,25 @@ public enum MathGauss {
 
     /// Compute determinant using Gauss elimination.
     ///
-    /// `n` must be positive and match `matrix`'s length exactly (`matrix.count == n * n`).
-    /// Neither was checked before #640: the bridge loops `matrixData[i*n+j]` for
-    /// `i, j in 0..<n` unconditionally, so a positive `n` larger than `matrix` reads out of
-    /// bounds rather than failing, and a negative `n` was a `Standard_Failure` the bridge's
-    /// own `catch (...)` already absorbed into the same `0.0` this guard now returns.
-    public static func determinant(matrix: [Double], n: Int) -> Double {
-        guard n > 0, matrix.count == n * n else { return 0.0 }
+    /// Returns `nil`, not `0.0`, when `n` is not positive or does not match `matrix`'s
+    /// length exactly (`matrix.count == n * n`) -- review finding 7 on #640: `0.0` is also
+    /// the determinant of a genuinely singular matrix, so a bare `Double` sentinel could not
+    /// tell "you gave me an invalid dimension" apart from "your matrix is singular", and it
+    /// silently covered the positive-but-mismatched `n` case that used to crash loudly
+    /// instead of returning anything at all. Before #640 the bridge looped
+    /// `matrixData[i*n+j]` for `i, j in 0..<n` unconditionally, so a positive `n` larger than
+    /// `matrix` read out of bounds rather than failing, and a negative `n` was a
+    /// `Standard_Failure` the bridge's own `catch (...)` already absorbed into a crash-free
+    /// (but, until now, indistinguishable) `0.0`. `n * n` itself is checked for overflow
+    /// (review finding 8), so a large positive `n` is rejected rather than trapping the
+    /// multiplication before this guard can run.
+    ///
+    /// ```swift
+    /// MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2)   // 5.0
+    /// MathGauss.determinant(matrix: [1.0], n: -1)                 // nil, not 0.0
+    /// ```
+    public static func determinant(matrix: [Double], n: Int) -> Double? {
+        guard MathDimension.validSquare(n, count: matrix.count) else { return nil }
         return matrix.withUnsafeBufferPointer { buf in
             OCCTMathGaussDeterminant(buf.baseAddress!, Int32(n))
         }
@@ -94,9 +106,17 @@ public enum MathSVD {
     /// `rows` and `cols` must both be positive. A consistency check alone is not enough
     /// (#640): `rows: 0, cols: -1` satisfies `matrix.count == rows * cols` exactly (`0 == 0`)
     /// and `rhs.count == rows` exactly (`0 == 0`), so without a positivity bound this still
-    /// reaches `Array(repeating:count:)` with a negative count and traps.
+    /// reaches `Array(repeating:count:)` with a negative count and traps. `rows * cols` is
+    /// itself checked for overflow (review finding 8), so a huge positive `rows`/`cols` is
+    /// rejected rather than trapping the multiplication before this guard can run.
+    ///
+    /// ```swift
+    /// MathSVD.solve(matrix: [1, 0, 0, 1, 1, 1], rows: 3, cols: 2, rhs: [1, 2, 3])   // != nil
+    /// MathSVD.solve(matrix: [], rows: 0, cols: -1, rhs: [])                        // nil
+    /// ```
     public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) -> [Double]? {
-        guard rows > 0, cols > 0, matrix.count == rows * cols, rhs.count == rows else { return nil }
+        guard MathDimension.validRectangle(rows: rows, cols: cols, count: matrix.count),
+              rhs.count == rows else { return nil }
         var solution = [Double](repeating: 0, count: cols)
         let ok = matrix.withUnsafeBufferPointer { mBuf in
             rhs.withUnsafeBufferPointer { bBuf in
@@ -139,9 +159,16 @@ public enum MathJacobi {
     ///
     /// `n` must be positive. `eigenvalues(matrix: [1.0], n: -1)` satisfies
     /// `matrix.count == n * n` exactly (`1 == (-1) * (-1)`) and would otherwise reach
-    /// `Array(repeating:count:)` with a negative count and trap (#640).
+    /// `Array(repeating:count:)` with a negative count and trap (#640). `n * n` is itself
+    /// checked for overflow (review finding 8), so `n: .max` is rejected rather than
+    /// trapping the multiplication before this guard can run.
+    ///
+    /// ```swift
+    /// MathJacobi.eigenvalues(matrix: [4.0, 1.0, 1.0, 4.0], n: 2)   // != nil
+    /// MathJacobi.eigenvalues(matrix: [1.0], n: -1)                 // nil, not a trap
+    /// ```
     public static func eigenvalues(matrix: [Double], n: Int) -> [Double]? {
-        guard n > 0, matrix.count == n * n else { return nil }
+        guard MathDimension.validSquare(n, count: matrix.count) else { return nil }
         var eigenvalues = [Double](repeating: 0, count: n)
         let ok = matrix.withUnsafeBufferPointer { mBuf in
             eigenvalues.withUnsafeMutableBufferPointer { eBuf in
@@ -158,9 +185,16 @@ public enum MathHouseholder {
     /// Solve overdetermined Ax=b using Householder QR (M >= N).
     ///
     /// `rows` and `cols` must both be positive, the same positivity gap as `MathSVD.solve`
-    /// (#640): `rows >= cols` alone does not exclude `rows: 0, cols: -1`.
+    /// (#640): `rows >= cols` alone does not exclude `rows: 0, cols: -1`. `rows * cols` is
+    /// itself checked for overflow (review finding 8).
+    ///
+    /// ```swift
+    /// MathHouseholder.solve(matrix: [1, 0, 0, 1, 1, 1], rows: 3, cols: 2, rhs: [1, 2, 3])   // != nil
+    /// MathHouseholder.solve(matrix: [], rows: 0, cols: -1, rhs: [])                        // nil
+    /// ```
     public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) -> [Double]? {
-        guard rows > 0, cols > 0, matrix.count == rows * cols, rhs.count == rows, rows >= cols
+        guard MathDimension.validRectangle(rows: rows, cols: cols, count: matrix.count),
+              rhs.count == rows, rows >= cols
         else { return nil }
         var solution = [Double](repeating: 0, count: cols)
         let ok = matrix.withUnsafeBufferPointer { mBuf in
@@ -195,11 +229,18 @@ public enum MathCrout {
 
     /// Determinant of symmetric matrix via Crout.
     ///
-    /// Same fix as `MathGauss.determinant` (#640): `n` must be positive and match `matrix`'s
-    /// length exactly, or the bridge's unconditional `matrixData[i*n+j]` loop reads out of
-    /// bounds.
-    public static func determinant(matrix: [Double], n: Int) -> Double {
-        guard n > 0, matrix.count == n * n else { return 0.0 }
+    /// Same fix as `MathGauss.determinant` (#640, review finding 7): returns `nil`, not
+    /// `0.0`, when `n` is not positive or does not match `matrix`'s length exactly, since a
+    /// bare `Double` sentinel cannot tell an invalid dimension apart from a genuinely
+    /// singular matrix. Before #640 the bridge's unconditional `matrixData[i*n+j]` loop read
+    /// out of bounds on a mismatch. `n * n` is checked for overflow (review finding 8).
+    ///
+    /// ```swift
+    /// MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2)   // 8.0
+    /// MathCrout.determinant(matrix: [1.0], n: -1)                 // nil, not 0.0
+    /// ```
+    public static func determinant(matrix: [Double], n: Int) -> Double? {
+        guard MathDimension.validSquare(n, count: matrix.count) else { return nil }
         return matrix.withUnsafeBufferPointer { buf in
             OCCTMathCroutDeterminant(buf.baseAddress!, Int32(n))
         }

--- a/Sources/OCCTSwift/MathSolver.swift
+++ b/Sources/OCCTSwift/MathSolver.swift
@@ -115,6 +115,13 @@ public enum MathSolver {
     ///   - values: Closure taking [Double] of length `variables`, returning [Double] of length `equations`
     ///   - jacobian: Closure taking [Double] of length `variables`, returning row-major Jacobian [Double] of length `equations * variables`
     /// - Returns: Solution point, or nil if the solver did not converge
+    ///
+    /// `variables` and `equations` must both be positive, and `startPoint.count` must equal
+    /// `variables` (#640). Neither was checked before: a negative `variables` reached
+    /// `Array(repeating:count:)` and trapped, and a positive `variables` that did not match
+    /// `startPoint`'s real length reached the bridge's unconditional `startPoint[i]` loop and
+    /// read out of bounds -- silently, since the loop has no way to fail other than reading
+    /// whatever memory happens to follow `startPoint`.
     public static func solveSystem(
         variables: Int,
         equations: Int,
@@ -124,6 +131,7 @@ public enum MathSolver {
         values: @escaping ([Double]) -> [Double],
         jacobian: @escaping ([Double]) -> [Double]
     ) -> [Double]? {
+        guard variables > 0, equations > 0, startPoint.count == variables else { return nil }
         typealias ValuesClosure = ([Double]) -> [Double]
         typealias JacobianClosure = ([Double]) -> [Double]
         let valBox = ClosureBox(values)
@@ -175,6 +183,10 @@ public enum MathSolver {
     ///   - maxIterations: Maximum iterations (default 200)
     ///   - function: Closure taking [Double], returning (value, gradient)
     /// - Returns: (point, minimum) tuple, or nil if the solver did not converge
+    ///
+    /// `variables` must be positive and equal `startPoint.count` (#640): neither was checked
+    /// before, so a mismatched positive `variables` reached the bridge's unconditional
+    /// `startPoint[i]` loop and read out of bounds.
     public static func minimize(
         variables: Int,
         startPoint: [Double],
@@ -182,6 +194,7 @@ public enum MathSolver {
         maxIterations: Int = 200,
         function: @escaping ([Double]) -> (value: Double, gradient: [Double])
     ) -> (point: [Double], minimum: Double)? {
+        guard variables > 0, startPoint.count == variables else { return nil }
         typealias Fn = ([Double]) -> (value: Double, gradient: [Double])
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -217,6 +230,9 @@ public enum MathSolver {
     ///   - maxIterations: Maximum iterations (default 200)
     ///   - function: Closure taking [Double], returning scalar value
     /// - Returns: (point, minimum) tuple, or nil if the solver did not converge
+    ///
+    /// Same guard as `minimize`, and for the same reason (#640): `variables` must be positive
+    /// and equal `startPoint.count`.
     public static func minimizePowell(
         variables: Int,
         startPoint: [Double],
@@ -224,6 +240,7 @@ public enum MathSolver {
         maxIterations: Int = 200,
         function: @escaping ([Double]) -> Double
     ) -> (point: [Double], minimum: Double)? {
+        guard variables > 0, startPoint.count == variables else { return nil }
         typealias Fn = ([Double]) -> Double
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -296,6 +313,10 @@ public enum MathSolver {
     ///   - iterations: Number of iterations (default 100)
     ///   - function: Closure taking [Double], returning scalar value
     /// - Returns: (point, minimum) tuple, or nil on failure
+    ///
+    /// `variables` must be positive and `lower`/`upper`/`steps` must each have `variables`
+    /// elements (#640): none of this was checked before, so the bridge's unconditional
+    /// `lower[i]`/`upper[i]`/`steps[i]` loop read out of bounds on a mismatch.
     public static func particleSwarm(
         variables: Int,
         lower: [Double],
@@ -305,6 +326,8 @@ public enum MathSolver {
         iterations: Int = 100,
         function: @escaping ([Double]) -> Double
     ) -> (point: [Double], minimum: Double)? {
+        guard variables > 0, lower.count == variables, upper.count == variables,
+              steps.count == variables else { return nil }
         typealias Fn = ([Double]) -> Double
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -338,12 +361,16 @@ public enum MathSolver {
     ///   - upper: Upper bounds for each variable
     ///   - function: Closure taking [Double], returning scalar value
     /// - Returns: (point, minimum) tuple, or nil on failure
+    ///
+    /// `variables` must be positive and `lower`/`upper` must each have `variables` elements
+    /// (#640), for the same reason as `particleSwarm`.
     public static func globalMinimize(
         variables: Int,
         lower: [Double],
         upper: [Double],
         function: @escaping ([Double]) -> Double
     ) -> (point: [Double], minimum: Double)? {
+        guard variables > 0, lower.count == variables, upper.count == variables else { return nil }
         typealias Fn = ([Double]) -> Double
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -374,11 +401,16 @@ public enum MathSolver {
     ///   - samples: Number of sample subdivisions (default 20)
     ///   - function: Closure returning (value, derivative) at x
     /// - Returns: Array of root values found
+    ///
+    /// `samples` is a sampler by name and by role, not a problem dimension (#640): it belongs
+    /// to #558's `Sampling` contract like every other subdivision count in this library, and
+    /// is bounded the same way rather than left to trap `Int32(samples)` past `Int32.max`.
     public static func findAllRoots(
         in range: ClosedRange<Double>,
         samples: Int = 20,
         function: @escaping (Double) -> (value: Double, derivative: Double)
     ) -> [Double] {
+        guard let samples = Sampling.requested(samples) else { return [] }
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
         defer { Unmanaged<ClosureBox<(Double) -> (value: Double, derivative: Double)>>.fromOpaque(ptr).release() }
@@ -442,6 +474,8 @@ public enum MathSolver {
     ///   - values: Closure returning equation values
     ///   - jacobian: Closure returning row-major Jacobian
     /// - Returns: Solution point, or nil if not converged
+    ///
+    /// Same guard as `solveSystem`, and for the same reason (#640).
     public static func solveSystemNewton(
         variables: Int,
         equations: Int,
@@ -451,6 +485,7 @@ public enum MathSolver {
         values: @escaping ([Double]) -> [Double],
         jacobian: @escaping ([Double]) -> [Double]
     ) -> [Double]? {
+        guard variables > 0, equations > 0, startPoint.count == variables else { return nil }
         typealias ValuesClosure = ([Double]) -> [Double]
         typealias JacobianClosure = ([Double]) -> [Double]
         let valBox = ClosureBox(values)
@@ -496,6 +531,9 @@ extension MathSolver {
     /// Minimize using Newton's method with Hessian (second derivatives).
     /// The closure takes x[n] and returns (value, gradient[n], hessian[n*n] row-major).
     /// This is the most precise minimizer when the Hessian is available.
+    ///
+    /// `n` must be positive and equal `startPoint.count` (#640), for the same reason as
+    /// `minimize`.
     public static func minimizeNewton(
         variables n: Int,
         startPoint: [Double],
@@ -503,6 +541,7 @@ extension MathSolver {
         maxIterations: Int = 40,
         function: @escaping ([Double]) -> (value: Double, gradient: [Double], hessian: [Double])
     ) -> (point: [Double], minimum: Double)? {
+        guard n > 0, startPoint.count == n else { return nil }
         typealias Closure = ([Double]) -> (value: Double, gradient: [Double], hessian: [Double])
         class Box { let fn: Closure; init(_ f: @escaping Closure) { fn = f } }
         let box = Box(function)
@@ -653,6 +692,9 @@ extension MathSolver {
     }
 
     /// Find all roots of f(x)=0 in a range using sampling + refinement.
+    ///
+    /// `samples` is bounded the same way as the other `findAllRoots` overload's, and for the
+    /// same reason (#640).
     public static func findAllRoots(
         in range: ClosedRange<Double>,
         samples: Int = 100,
@@ -661,6 +703,7 @@ extension MathSolver {
         epsNul: Double = 1e-8,
         function: @escaping (Double) -> (value: Double, derivative: Double)
     ) -> [Double] {
+        guard let samples = Sampling.requested(samples) else { return [] }
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
         defer { Unmanaged<ClosureBox<(Double) -> (value: Double, derivative: Double)>>.fromOpaque(ptr).release() }
@@ -681,10 +724,19 @@ extension MathSolver {
     }
 
     /// Solve overdetermined linear system Ax=b in least-squares sense.
+    ///
+    /// `rows` and `cols` must both be positive and match `matrix`/`rhs`'s real lengths
+    /// exactly (#640). Before this guard there was no consistency check at all -- unlike
+    /// `MathSVD.solve`/`MathHouseholder.solve`, which already checked `matrix.count ==
+    /// rows * cols` -- so a positive `rows`/`cols` that did not match `matrix`/`rhs`'s real
+    /// length reached the bridge's unconditional `matA[i*nCols+j]`/`b[i]` loops and read out
+    /// of bounds: not a trap, a silent wrong answer built from whatever memory happened to
+    /// follow the two arrays.
     public static func leastSquares(
         matrix: [Double], rows: Int, cols: Int,
         rhs: [Double]
     ) -> [Double]? {
+        guard rows > 0, cols > 0, matrix.count == rows * cols, rhs.count == rows else { return nil }
         var x = [Double](repeating: 0, count: cols)
         guard OCCTMathGaussLeastSquare(matrix, Int32(rows), Int32(cols), rhs, &x) else { return nil }
         return x
@@ -721,6 +773,11 @@ extension MathSolver {
 
     /// Solve constrained optimization via Uzawa method.
     /// Minimize ||x||^2 subject to constraintMatrix * x = constraintRHS.
+    ///
+    /// `nConstraints` and `nVars` must both be positive, and `constraintMatrix`/
+    /// `constraintRHS`/`startPoint` must each match them exactly (#640): none of this was
+    /// checked before, so the bridge's unconditional `contData[i*nVars+j]`/`secont[i]`/
+    /// `startPoint[i]` loops read out of bounds on any mismatch.
     public static func uzawa(
         constraintMatrix: [Double], nConstraints: Int, nVars: Int,
         constraintRHS: [Double],
@@ -728,6 +785,11 @@ extension MathSolver {
         epsLix: Double = 1e-6, epsLic: Double = 1e-6,
         maxIterations: Int = 500
     ) -> (result: [Double], iterations: Int)? {
+        guard nConstraints > 0, nVars > 0,
+              constraintMatrix.count == nConstraints * nVars,
+              constraintRHS.count == nConstraints,
+              startPoint.count == nVars
+        else { return nil }
         var result = [Double](repeating: 0, count: nVars)
         var nbIter: Int32 = 0
         guard OCCTMathUzawa(constraintMatrix, Int32(nConstraints), Int32(nVars),
@@ -738,9 +800,14 @@ extension MathSolver {
 
     /// Find eigenvalues of a symmetric tridiagonal matrix.
     /// diagonal and subdiagonal must be same length (last subdiagonal element unused).
+    ///
+    /// That "must" was only ever documentation until #640: the bridge loops
+    /// `subdiagonal[i]` for `i in 0..<diagonal.count` unconditionally, so a shorter
+    /// `subdiagonal` read out of bounds rather than failing.
     public static func eigenvalues(
         diagonal: [Double], subdiagonal: [Double]
     ) -> [Double]? {
+        guard subdiagonal.count == diagonal.count else { return nil }
         let n = diagonal.count
         var eigenvalues = [Double](repeating: 0, count: n)
         let count = OCCTMathEigenValues(diagonal, subdiagonal, Int32(n), &eigenvalues)
@@ -748,9 +815,12 @@ extension MathSolver {
     }
 
     /// Find eigenvalues and eigenvectors of a symmetric tridiagonal matrix.
+    ///
+    /// Same guard as `eigenvalues`, and for the same reason (#640).
     public static func eigenvaluesAndVectors(
         diagonal: [Double], subdiagonal: [Double]
     ) -> (eigenvalues: [Double], eigenvectors: [[Double]])? {
+        guard subdiagonal.count == diagonal.count else { return nil }
         let n = diagonal.count
         var eigenvalues = [Double](repeating: 0, count: n)
         var eigenvectors = [Double](repeating: 0, count: n * n)
@@ -813,10 +883,15 @@ extension MathSolver {
     }
 
     /// Multi-dimensional Gauss-Legendre integration.
+    ///
+    /// `upper` and `order` must have the same length as `lower` (#640): the bridge derives
+    /// `nVars` from `lower.count` alone and then loops `upper[i]`/`order[i]` for
+    /// `i in 0..<nVars` unconditionally, so a shorter `upper` or `order` read out of bounds.
     public static func gaussMultipleIntegration(
         lower: [Double], upper: [Double], order: [Int],
         function: @escaping ([Double]) -> Double
     ) -> Double? {
+        guard upper.count == lower.count, order.count == lower.count else { return nil }
         let nVars = lower.count
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -837,11 +912,18 @@ extension MathSolver {
     }
 
     /// Gauss-Legendre integration for function sets.
+    ///
+    /// `nEquations` must be positive, and `upper`/`order` must have the same length as
+    /// `lower` (#640): the first was an `Array(repeating:count:)` trap on a negative
+    /// `nEquations`, and the second is the same unguarded `upper[i]`/`order[i]` read as
+    /// `gaussMultipleIntegration`.
     public static func gaussSetIntegration(
         nEquations: Int,
         lower: [Double], upper: [Double], order: [Int],
         function: @escaping ([Double]) -> [Double]
     ) -> [Double]? {
+        guard nEquations > 0, upper.count == lower.count, order.count == lower.count
+        else { return nil }
         let nVars = lower.count
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()

--- a/Sources/OCCTSwift/MathSolver.swift
+++ b/Sources/OCCTSwift/MathSolver.swift
@@ -122,6 +122,20 @@ public enum MathSolver {
     /// `startPoint`'s real length reached the bridge's unconditional `startPoint[i]` loop and
     /// read out of bounds -- silently, since the loop has no way to fail other than reading
     /// whatever memory happens to follow `startPoint`.
+    ///
+    /// `values` and `jacobian`'s own **returned** arrays are checked the same way (review
+    /// finding 3/4 on #640): a `values` closure returning fewer than `equations` elements, or
+    /// a `jacobian` closure returning fewer than `equations * variables`, used to index the
+    /// short array and trap -- the identical failure #640 fixes for `startPoint`, relocated
+    /// from the caller's arguments to the caller's closure. A closure that returns the wrong
+    /// length now fails the call (`nil`), not the process.
+    ///
+    /// ```swift
+    /// MathSolver.solveSystem(variables: 1, equations: 1, startPoint: [0],
+    ///                         values: { x in [x[0]] }, jacobian: { _ in [1] })   // != nil
+    /// MathSolver.solveSystem(variables: 1, equations: 1, startPoint: [0],
+    ///                         values: { _ in [] }, jacobian: { _ in [1] })       // nil, not a trap
+    /// ```
     public static func solveSystem(
         variables: Int,
         equations: Int,
@@ -131,7 +145,7 @@ public enum MathSolver {
         values: @escaping ([Double]) -> [Double],
         jacobian: @escaping ([Double]) -> [Double]
     ) -> [Double]? {
-        guard variables > 0, equations > 0, startPoint.count == variables else { return nil }
+        guard MathDimension.valid(variables, matches: startPoint.count), equations > 0 else { return nil }
         typealias ValuesClosure = ([Double]) -> [Double]
         typealias JacobianClosure = ([Double]) -> [Double]
         let valBox = ClosureBox(values)
@@ -149,6 +163,7 @@ public enum MathSolver {
             for i in 0..<n { input[i] = x[i] }
             let result = pair.closure.0.closure(input)
             let m = Int(nEqs)
+            guard result.count == m else { return false }
             for i in 0..<m { vals[i] = result[i] }
             return true
         }
@@ -161,6 +176,7 @@ public enum MathSolver {
             for i in 0..<n { input[i] = x[i] }
             let result = pair.closure.1.closure(input)
             let total = Int(nEqs) * n
+            guard result.count == total else { return false }
             for i in 0..<total { jac[i] = result[i] }
             return true
         }
@@ -187,6 +203,17 @@ public enum MathSolver {
     /// `variables` must be positive and equal `startPoint.count` (#640): neither was checked
     /// before, so a mismatched positive `variables` reached the bridge's unconditional
     /// `startPoint[i]` loop and read out of bounds.
+    ///
+    /// `function`'s own returned `gradient` is checked the same way (review finding 5 on
+    /// #640): a closure returning fewer than `variables` gradient components used to index
+    /// the short array and trap. It now fails the call (`nil`) instead.
+    ///
+    /// ```swift
+    /// MathSolver.minimize(variables: 1, startPoint: [1.0],
+    ///                      function: { x in (x[0] * x[0], [2 * x[0]]) })   // != nil
+    /// MathSolver.minimize(variables: 1, startPoint: [1.0],
+    ///                      function: { x in (x[0] * x[0], []) })           // nil, not a trap
+    /// ```
     public static func minimize(
         variables: Int,
         startPoint: [Double],
@@ -194,7 +221,7 @@ public enum MathSolver {
         maxIterations: Int = 200,
         function: @escaping ([Double]) -> (value: Double, gradient: [Double])
     ) -> (point: [Double], minimum: Double)? {
-        guard variables > 0, startPoint.count == variables else { return nil }
+        guard MathDimension.valid(variables, matches: startPoint.count) else { return nil }
         typealias Fn = ([Double]) -> (value: Double, gradient: [Double])
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -207,6 +234,7 @@ public enum MathSolver {
             var input = [Double](repeating: 0, count: nv)
             for i in 0..<nv { input[i] = x[i] }
             let result = box.closure(input)
+            guard result.gradient.count == nv else { return false }
             value.pointee = result.value
             for i in 0..<nv { gradient[i] = result.gradient[i] }
             return true
@@ -233,6 +261,11 @@ public enum MathSolver {
     ///
     /// Same guard as `minimize`, and for the same reason (#640): `variables` must be positive
     /// and equal `startPoint.count`.
+    ///
+    /// ```swift
+    /// MathSolver.minimizePowell(variables: 1, startPoint: [1.0], function: { $0[0] * $0[0] })   // != nil
+    /// MathSolver.minimizePowell(variables: 1, startPoint: [], function: { $0[0] * $0[0] })       // nil
+    /// ```
     public static func minimizePowell(
         variables: Int,
         startPoint: [Double],
@@ -240,7 +273,7 @@ public enum MathSolver {
         maxIterations: Int = 200,
         function: @escaping ([Double]) -> Double
     ) -> (point: [Double], minimum: Double)? {
-        guard variables > 0, startPoint.count == variables else { return nil }
+        guard MathDimension.valid(variables, matches: startPoint.count) else { return nil }
         typealias Fn = ([Double]) -> Double
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -317,6 +350,13 @@ public enum MathSolver {
     /// `variables` must be positive and `lower`/`upper`/`steps` must each have `variables`
     /// elements (#640): none of this was checked before, so the bridge's unconditional
     /// `lower[i]`/`upper[i]`/`steps[i]` loop read out of bounds on a mismatch.
+    ///
+    /// ```swift
+    /// MathSolver.particleSwarm(variables: 1, lower: [-1], upper: [1], steps: [0.1],
+    ///                           function: { $0[0] * $0[0] })   // != nil
+    /// MathSolver.particleSwarm(variables: 1, lower: [], upper: [1], steps: [0.1],
+    ///                           function: { $0[0] * $0[0] })   // nil
+    /// ```
     public static func particleSwarm(
         variables: Int,
         lower: [Double],
@@ -326,8 +366,8 @@ public enum MathSolver {
         iterations: Int = 100,
         function: @escaping ([Double]) -> Double
     ) -> (point: [Double], minimum: Double)? {
-        guard variables > 0, lower.count == variables, upper.count == variables,
-              steps.count == variables else { return nil }
+        guard MathDimension.valid(variables, matches: lower.count, upper.count, steps.count)
+        else { return nil }
         typealias Fn = ([Double]) -> Double
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -364,13 +404,18 @@ public enum MathSolver {
     ///
     /// `variables` must be positive and `lower`/`upper` must each have `variables` elements
     /// (#640), for the same reason as `particleSwarm`.
+    ///
+    /// ```swift
+    /// MathSolver.globalMinimize(variables: 1, lower: [-1], upper: [1], function: { $0[0] * $0[0] })   // != nil
+    /// MathSolver.globalMinimize(variables: 1, lower: [], upper: [1], function: { $0[0] * $0[0] })       // nil
+    /// ```
     public static func globalMinimize(
         variables: Int,
         lower: [Double],
         upper: [Double],
         function: @escaping ([Double]) -> Double
     ) -> (point: [Double], minimum: Double)? {
-        guard variables > 0, lower.count == variables, upper.count == variables else { return nil }
+        guard MathDimension.valid(variables, matches: lower.count, upper.count) else { return nil }
         typealias Fn = ([Double]) -> Double
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -405,12 +450,20 @@ public enum MathSolver {
     /// `samples` is a sampler by name and by role, not a problem dimension (#640): it belongs
     /// to #558's `Sampling` contract like every other subdivision count in this library, and
     /// is bounded the same way rather than left to trap `Int32(samples)` past `Int32.max`.
+    /// The valid range is `1...10,000,000` (review finding 1): a search over one sample is
+    /// still a search, just a coarse one, so the minimum is `1`, not `Sampling.requested`'s
+    /// own default floor of `2` -- passing the default floor silently rejected the
+    /// documented-valid `samples: 1` and returned `[]` without ever calling `function`.
+    ///
+    /// ```swift
+    /// MathSolver.findAllRoots(in: -1.0...1.0, samples: 1) { x in (x, 1) }.isEmpty   // false
+    /// ```
     public static func findAllRoots(
         in range: ClosedRange<Double>,
         samples: Int = 20,
         function: @escaping (Double) -> (value: Double, derivative: Double)
     ) -> [Double] {
-        guard let samples = Sampling.requested(samples) else { return [] }
+        guard let samples = Sampling.requested(samples, atLeast: 1) else { return [] }
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
         defer { Unmanaged<ClosureBox<(Double) -> (value: Double, derivative: Double)>>.fromOpaque(ptr).release() }
@@ -475,7 +528,15 @@ public enum MathSolver {
     ///   - jacobian: Closure returning row-major Jacobian
     /// - Returns: Solution point, or nil if not converged
     ///
-    /// Same guard as `solveSystem`, and for the same reason (#640).
+    /// Same guard as `solveSystem`, and for the same reason (#640), including the
+    /// `values`/`jacobian` closure-length check (review finding 3/4).
+    ///
+    /// ```swift
+    /// MathSolver.solveSystemNewton(variables: 1, equations: 1, startPoint: [0],
+    ///                               values: { x in [x[0]] }, jacobian: { _ in [1] })   // != nil
+    /// MathSolver.solveSystemNewton(variables: 1, equations: 1, startPoint: [0],
+    ///                               values: { _ in [] }, jacobian: { _ in [1] })       // nil
+    /// ```
     public static func solveSystemNewton(
         variables: Int,
         equations: Int,
@@ -485,7 +546,7 @@ public enum MathSolver {
         values: @escaping ([Double]) -> [Double],
         jacobian: @escaping ([Double]) -> [Double]
     ) -> [Double]? {
-        guard variables > 0, equations > 0, startPoint.count == variables else { return nil }
+        guard MathDimension.valid(variables, matches: startPoint.count), equations > 0 else { return nil }
         typealias ValuesClosure = ([Double]) -> [Double]
         typealias JacobianClosure = ([Double]) -> [Double]
         let valBox = ClosureBox(values)
@@ -502,6 +563,7 @@ public enum MathSolver {
             for i in 0..<n { input[i] = x[i] }
             let result = pair.closure.0.closure(input)
             let m = Int(nEqs)
+            guard result.count == m else { return false }
             for i in 0..<m { vals[i] = result[i] }
             return true
         }
@@ -514,6 +576,7 @@ public enum MathSolver {
             for i in 0..<n { input[i] = x[i] }
             let result = pair.closure.1.closure(input)
             let total = Int(nEqs) * n
+            guard result.count == total else { return false }
             for i in 0..<total { jac[i] = result[i] }
             return true
         }
@@ -534,6 +597,17 @@ extension MathSolver {
     ///
     /// `n` must be positive and equal `startPoint.count` (#640), for the same reason as
     /// `minimize`.
+    ///
+    /// `function`'s own returned `gradient` and `hessian` are checked the same way (review
+    /// finding 5 on #640): a closure returning fewer than `n` gradient components, or fewer
+    /// than `n * n` Hessian components, used to index the short array and trap.
+    ///
+    /// ```swift
+    /// MathSolver.minimizeNewton(variables: 1, startPoint: [1.0],
+    ///                            function: { x in (x[0] * x[0], [2 * x[0]], [2.0]) })   // != nil
+    /// MathSolver.minimizeNewton(variables: 1, startPoint: [1.0],
+    ///                            function: { x in (x[0] * x[0], [2 * x[0]], []) })      // nil, not a trap
+    /// ```
     public static func minimizeNewton(
         variables n: Int,
         startPoint: [Double],
@@ -541,7 +615,7 @@ extension MathSolver {
         maxIterations: Int = 40,
         function: @escaping ([Double]) -> (value: Double, gradient: [Double], hessian: [Double])
     ) -> (point: [Double], minimum: Double)? {
-        guard n > 0, startPoint.count == n else { return nil }
+        guard MathDimension.valid(n, matches: startPoint.count) else { return nil }
         typealias Closure = ([Double]) -> (value: Double, gradient: [Double], hessian: [Double])
         class Box { let fn: Closure; init(_ f: @escaping Closure) { fn = f } }
         let box = Box(function)
@@ -554,6 +628,7 @@ extension MathSolver {
             let n = Int(nVars)
             let input = Array(UnsafeBufferPointer(start: x, count: n))
             let result = box.fn(input)
+            guard result.gradient.count == n, result.hessian.count == n * n else { return false }
             value.pointee = result.value
             for i in 0..<n { gradient[i] = result.gradient[i] }
             for i in 0..<(n*n) { hessian[i] = result.hessian[i] }
@@ -662,6 +737,18 @@ extension MathSolver {
     }
 
     /// Minimize using Fletcher-Reeves-Polak-Ribiere conjugate gradient.
+    ///
+    /// `nVars` is `startPoint.count` itself, not a separate caller-supplied dimension, so
+    /// there is no mismatch to guard against there. `function`'s own returned `gradient`
+    /// is still checked (the same closure-length gap as `minimize`'s, review findings 3-6 on
+    /// #640, not itself named there but sharing the identical `OCCTMathMultiVarGradCallback`
+    /// shape): a closure returning fewer than `startPoint.count` gradient components used to
+    /// index the short array and trap.
+    ///
+    /// ```swift
+    /// MathSolver.minimizeFRPR(startPoint: [1.0], function: { x in (x[0] * x[0], [2 * x[0]]) })   // != nil
+    /// MathSolver.minimizeFRPR(startPoint: [1.0], function: { x in (x[0] * x[0], []) })           // nil, not a trap
+    /// ```
     public static func minimizeFRPR(
         startPoint: [Double],
         tolerance: Double = 1e-8,
@@ -678,6 +765,7 @@ extension MathSolver {
             let box = Unmanaged<ClosureBox<([Double]) -> (value: Double, gradient: [Double])>>.fromOpaque(ctx).takeUnretainedValue()
             let input = Array(UnsafeBufferPointer(start: x, count: Int(n)))
             let result = box.closure(input)
+            guard result.gradient.count == Int(n) else { return false }
             value.pointee = result.value
             for i in 0..<Int(n) { gradient[i] = result.gradient[i] }
             return true
@@ -694,7 +782,14 @@ extension MathSolver {
     /// Find all roots of f(x)=0 in a range using sampling + refinement.
     ///
     /// `samples` is bounded the same way as the other `findAllRoots` overload's, and for the
-    /// same reason (#640).
+    /// same reason (#640): the valid range is `1...10,000,000` (review finding 1), so the
+    /// minimum here is `1`, not `Sampling.requested`'s own default floor of `2`.
+    ///
+    /// ```swift
+    /// // samples: 1 is accepted rather than rejected outright -- whether such a coarse
+    /// // sampling actually brackets a root is then the algorithm's decision, not the guard's.
+    /// _ = MathSolver.findAllRoots(in: -1.0...1.0, samples: 1, function: { x in (x, 1) })
+    /// ```
     public static func findAllRoots(
         in range: ClosedRange<Double>,
         samples: Int = 100,
@@ -703,7 +798,7 @@ extension MathSolver {
         epsNul: Double = 1e-8,
         function: @escaping (Double) -> (value: Double, derivative: Double)
     ) -> [Double] {
-        guard let samples = Sampling.requested(samples) else { return [] }
+        guard let samples = Sampling.requested(samples, atLeast: 1) else { return [] }
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
         defer { Unmanaged<ClosureBox<(Double) -> (value: Double, derivative: Double)>>.fromOpaque(ptr).release() }
@@ -731,12 +826,20 @@ extension MathSolver {
     /// rows * cols` -- so a positive `rows`/`cols` that did not match `matrix`/`rhs`'s real
     /// length reached the bridge's unconditional `matA[i*nCols+j]`/`b[i]` loops and read out
     /// of bounds: not a trap, a silent wrong answer built from whatever memory happened to
-    /// follow the two arrays.
+    /// follow the two arrays. `rows * cols` is itself checked for overflow (review finding
+    /// 8), so a huge positive `rows`/`cols` is rejected rather than trapping the
+    /// multiplication before this guard can run.
+    ///
+    /// ```swift
+    /// MathSolver.leastSquares(matrix: [1, 0, 0, 1, 1, 1], rows: 3, cols: 2, rhs: [1, 2, 3])   // != nil
+    /// MathSolver.leastSquares(matrix: [1.0], rows: 1000, cols: 1000, rhs: [1.0])              // nil, not a crash
+    /// ```
     public static func leastSquares(
         matrix: [Double], rows: Int, cols: Int,
         rhs: [Double]
     ) -> [Double]? {
-        guard rows > 0, cols > 0, matrix.count == rows * cols, rhs.count == rows else { return nil }
+        guard MathDimension.validRectangle(rows: rows, cols: cols, count: matrix.count),
+              rhs.count == rows else { return nil }
         var x = [Double](repeating: 0, count: cols)
         guard OCCTMathGaussLeastSquare(matrix, Int32(rows), Int32(cols), rhs, &x) else { return nil }
         return x
@@ -777,7 +880,15 @@ extension MathSolver {
     /// `nConstraints` and `nVars` must both be positive, and `constraintMatrix`/
     /// `constraintRHS`/`startPoint` must each match them exactly (#640): none of this was
     /// checked before, so the bridge's unconditional `contData[i*nVars+j]`/`secont[i]`/
-    /// `startPoint[i]` loops read out of bounds on any mismatch.
+    /// `startPoint[i]` loops read out of bounds on any mismatch. `nConstraints * nVars` is
+    /// itself checked for overflow (review finding 8).
+    ///
+    /// ```swift
+    /// MathSolver.uzawa(constraintMatrix: [1, 1], nConstraints: 1, nVars: 2,
+    ///                   constraintRHS: [1], startPoint: [0, 0])   // != nil
+    /// MathSolver.uzawa(constraintMatrix: [], nConstraints: 0, nVars: -1,
+    ///                   constraintRHS: [], startPoint: [])        // nil
+    /// ```
     public static func uzawa(
         constraintMatrix: [Double], nConstraints: Int, nVars: Int,
         constraintRHS: [Double],
@@ -785,8 +896,7 @@ extension MathSolver {
         epsLix: Double = 1e-6, epsLic: Double = 1e-6,
         maxIterations: Int = 500
     ) -> (result: [Double], iterations: Int)? {
-        guard nConstraints > 0, nVars > 0,
-              constraintMatrix.count == nConstraints * nVars,
+        guard MathDimension.validRectangle(rows: nConstraints, cols: nVars, count: constraintMatrix.count),
               constraintRHS.count == nConstraints,
               startPoint.count == nVars
         else { return nil }
@@ -803,11 +913,18 @@ extension MathSolver {
     ///
     /// That "must" was only ever documentation until #640: the bridge loops
     /// `subdiagonal[i]` for `i in 0..<diagonal.count` unconditionally, so a shorter
-    /// `subdiagonal` read out of bounds rather than failing.
+    /// `subdiagonal` read out of bounds rather than failing. `diagonal.count` is never
+    /// negative (it is a real array's own length), so unlike most of this family there is no
+    /// positivity bound to add -- only the consistency check.
+    ///
+    /// ```swift
+    /// MathSolver.eigenvalues(diagonal: [2.0, 2.0, 2.0], subdiagonal: [1.0, 1.0, 0.0])   // != nil
+    /// MathSolver.eigenvalues(diagonal: [Double](repeating: 1, count: 50), subdiagonal: [1.0])   // nil
+    /// ```
     public static func eigenvalues(
         diagonal: [Double], subdiagonal: [Double]
     ) -> [Double]? {
-        guard subdiagonal.count == diagonal.count else { return nil }
+        guard MathDimension.consistent(diagonal.count, matches: subdiagonal.count) else { return nil }
         let n = diagonal.count
         var eigenvalues = [Double](repeating: 0, count: n)
         let count = OCCTMathEigenValues(diagonal, subdiagonal, Int32(n), &eigenvalues)
@@ -817,10 +934,15 @@ extension MathSolver {
     /// Find eigenvalues and eigenvectors of a symmetric tridiagonal matrix.
     ///
     /// Same guard as `eigenvalues`, and for the same reason (#640).
+    ///
+    /// ```swift
+    /// MathSolver.eigenvaluesAndVectors(diagonal: [2.0, 2.0, 2.0], subdiagonal: [1.0, 1.0, 0.0])   // != nil
+    /// MathSolver.eigenvaluesAndVectors(diagonal: [Double](repeating: 1, count: 50), subdiagonal: [1.0])   // nil
+    /// ```
     public static func eigenvaluesAndVectors(
         diagonal: [Double], subdiagonal: [Double]
     ) -> (eigenvalues: [Double], eigenvectors: [[Double]])? {
-        guard subdiagonal.count == diagonal.count else { return nil }
+        guard MathDimension.consistent(diagonal.count, matches: subdiagonal.count) else { return nil }
         let n = diagonal.count
         var eigenvalues = [Double](repeating: 0, count: n)
         var eigenvectors = [Double](repeating: 0, count: n * n)
@@ -887,11 +1009,22 @@ extension MathSolver {
     /// `upper` and `order` must have the same length as `lower` (#640): the bridge derives
     /// `nVars` from `lower.count` alone and then loops `upper[i]`/`order[i]` for
     /// `i in 0..<nVars` unconditionally, so a shorter `upper` or `order` read out of bounds.
+    /// `lower.count` is never negative (it is a real array's own length), so there is no
+    /// positivity bound to add here, only the consistency check. Unlike `gaussSetIntegration`,
+    /// this genuinely supports any number of variables: `math_GaussMultipleIntegration`
+    /// integrates recursively over every dimension.
+    ///
+    /// ```swift
+    /// MathSolver.gaussMultipleIntegration(lower: [0, 0], upper: [1, 1], order: [10, 10]) { x in
+    ///     x[0] * x[0] + x[1] * x[1]
+    /// }   // 2.0 / 3.0
+    /// MathSolver.gaussMultipleIntegration(lower: [0, 0], upper: [1], order: [10]) { _ in 0 }   // nil
+    /// ```
     public static func gaussMultipleIntegration(
         lower: [Double], upper: [Double], order: [Int],
         function: @escaping ([Double]) -> Double
     ) -> Double? {
-        guard upper.count == lower.count, order.count == lower.count else { return nil }
+        guard MathDimension.consistent(lower.count, matches: upper.count, order.count) else { return nil }
         let nVars = lower.count
         let box = ClosureBox(function)
         let ptr = Unmanaged.passRetained(box).toOpaque()
@@ -917,12 +1050,42 @@ extension MathSolver {
     /// `lower` (#640): the first was an `Array(repeating:count:)` trap on a negative
     /// `nEquations`, and the second is the same unguarded `upper[i]`/`order[i]` read as
     /// `gaussMultipleIntegration`.
+    ///
+    /// **`lower` must also have exactly one element (review finding 2 on #640's own PR).**
+    /// `math_GaussSetIntegration`'s own header documents "the case M>1 is not implemented":
+    /// its constructor only ever varies the *first* integration variable
+    /// (`Lower.Value(Lower.Lower())`, `Upper.Value(Upper.Lower())`), leaving every other
+    /// component of its working vector unset. OCCT's own runtime check for this
+    /// (`Standard_NotImplemented_Raise_if(NbVar != 1, ...)`) does not survive this project's
+    /// `No_Exception` production kernel build (the same class of gap #487/#555/#603 measured
+    /// elsewhere), so instead of failing it silently integrates the wrong thing. Measured
+    /// directly against the pinned kernel: `gaussSetIntegration(nEquations: 1, lower: [0, 0],
+    /// upper: [1, 1], order: [10, 10]) { x in [x[0] + x[1]] }` returned `0.5`, which is
+    /// `INT x dx` over `[0, 1]` with the second variable silently pinned at `0` -- not
+    /// `INT INT (x + y) dx dy` over the unit square, which is `1.0`. Rejecting
+    /// `lower.count != 1` turns that silent wrong answer into `nil`, the same shape as every
+    /// other guard in this family. For genuinely multi-variable integration of a single
+    /// scalar function, use `gaussMultipleIntegration` instead, which supports it.
+    ///
+    /// `function`'s own returned array is checked the same way as `solveSystem`'s (review
+    /// finding 6): a closure returning fewer than `nEquations` elements used to index the
+    /// short array and trap.
+    ///
+    /// ```swift
+    /// MathSolver.gaussSetIntegration(nEquations: 2, lower: [0], upper: [2], order: [10]) { x in
+    ///     [x[0], x[0] * x[0]]
+    /// }   // [2.0, 2.666...]
+    /// MathSolver.gaussSetIntegration(nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10]) { x in
+    ///     [x[0] + x[1]]
+    /// }   // nil -- lower.count != 1, not the silent 0.5 this used to return
+    /// ```
     public static func gaussSetIntegration(
         nEquations: Int,
         lower: [Double], upper: [Double], order: [Int],
         function: @escaping ([Double]) -> [Double]
     ) -> [Double]? {
-        guard nEquations > 0, upper.count == lower.count, order.count == lower.count
+        guard lower.count == 1, nEquations > 0,
+              MathDimension.consistent(lower.count, matches: upper.count, order.count)
         else { return nil }
         let nVars = lower.count
         let box = ClosureBox(function)
@@ -934,6 +1097,7 @@ extension MathSolver {
             let box = Unmanaged<ClosureBox<([Double]) -> [Double]>>.fromOpaque(ctx).takeUnretainedValue()
             let input = Array(UnsafeBufferPointer(start: x, count: Int(nv)))
             let result = box.closure(input)
+            guard result.count == Int(ne) else { return false }
             for i in 0..<Int(ne) { values[i] = result[i] }
             return true
         }

--- a/Tests/OCCTIntegrationTests/OCCTIntegrationTests.swift
+++ b/Tests/OCCTIntegrationTests/OCCTIntegrationTests.swift
@@ -42,14 +42,28 @@ struct GaussMultipleIntegrationTests {
 @Suite("GaussSetIntegration")
 struct GaussSetIntegrationTests {
     @Test func integrateSet() {
+        // gaussSetIntegration supports exactly one integration variable
+        // (math_GaussSetIntegration's own header: "the case M>1 is not implemented") but any
+        // number of equations -- a "set" of functions of that one variable, each integrated
+        // separately. This case used to pass `lower: [0, 0], upper: [1, 1]` (two variables)
+        // and assert 0.5, which was never the integral of x + y over the unit square (that is
+        // 1.0): the class silently varies only the first component and pins the rest at 0,
+        // so the old assertion was pinning that silent defect (#640 review finding 2), not a
+        // correct answer. Fixed to the contract the class actually supports.
         let result = MathSolver.gaussSetIntegration(
-            nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10]
-        ) { x in [x[0] + x[1]] }
+            nEquations: 2, lower: [0], upper: [2], order: [10]
+        ) { x in [x[0], x[0] * x[0]] }
         #expect(result != nil)
         if let r = result {
-            #expect(r.count == 1)
-            #expect(abs(r[0] - 0.5) < 1e-6)
+            #expect(r.count == 2)
+            #expect(abs(r[0] - 2.0) < 1e-9)
+            #expect(abs(r[1] - 8.0 / 3.0) < 1e-9)
         }
+
+        // The old, invalid two-variable shape is now rejected rather than silently wrong.
+        #expect(MathSolver.gaussSetIntegration(
+            nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10]
+        ) { x in [x[0] + x[1]] } == nil)
     }
 }
 

--- a/Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift
+++ b/Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift
@@ -1,0 +1,292 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #640: the math solver/optimizer family traps on a negative "problem dimension" argument,
+// and reads out of bounds on a positive but mismatched one. PR #634 (issue #622) named this
+// family, deliberately left it unfixed -- its numbers are problem dimensions that must agree
+// with the caller's own arrays, so `Sampling.requested`/`capacity` is the wrong tool -- and
+// recorded 13 trapping sites in `Document.swift` for a future issue.
+//
+// #640 is that issue, but its own 13-site count was itself a re-statement of #634's census,
+// which only used one lens: does `Array(repeating:count:)` trap on a negative count. Reading
+// every candidate bridge function's C++ implementation (a third lens: does a raw pointer get
+// indexed up to a caller-supplied count with no check that the backing Swift array is that
+// long) found **20**, not 13:
+//
+//   MathGauss.determinant, MathSVD.solve, MathJacobi.eigenvalues, MathHouseholder.solve,
+//   MathCrout.determinant, MathSolver.solveSystem, .minimize, .minimizePowell,
+//   .particleSwarm, .globalMinimize, .solveSystemNewton, .minimizeNewton, .leastSquares,
+//   .uzawa, .eigenvalues(diagonal:subdiagonal:), .eigenvaluesAndVectors(diagonal:subdiagonal:),
+//   .gaussMultipleIntegration, .gaussSetIntegration, and both `findAllRoots(samples:)` overloads.
+//
+// Five of these were invisible to the trap-shaped census:
+// - `MathGauss.determinant`/`MathCrout.determinant` return a scalar `Double`, not an `Array`
+//   sized by the dimension, so there was nothing for lens 1 to see. The bridge still loops
+//   `matrixData[i*n+j]` for `i, j in 0..<n` unconditionally.
+// - `.eigenvalues(diagonal:subdiagonal:)`, `.eigenvaluesAndVectors`, and
+//   `.gaussMultipleIntegration` each derive their own dimension from an array's own `.count`
+//   (always non-negative), so lens 1 sees nothing to trap on -- but a SECOND array
+//   (`subdiagonal`/`upper`/`order`) is read up to that dimension with no check that it is
+//   actually that long.
+//
+// The out-of-bounds read is not unique to `leastSquares` either. Measured one call per
+// process (a crash or trap takes the whole process down with it), against this tree before
+// the fix below:
+//
+// | case                                                  | before #640          | after #640 |
+// |--------------------------------------------------------|----------------------|------------|
+// | MathSVD.solve(rows: 0, cols: -1)                        | traps (signal 5)     | nil        |
+// | MathJacobi.eigenvalues(matrix: [1.0], n: -1)             | traps (signal 5)     | nil        |
+// | MathHouseholder.solve(rows: 0, cols: -1)                 | traps (signal 5)     | nil        |
+// | MathSolver.leastSquares(rows: 0, cols: -1)               | traps (signal 5)     | nil        |
+// | MathSolver.leastSquares(rows: 1000, cols: 1000, 1-elem)  | SIGBUS (signal 10)   | nil        |
+// | MathSolver.solveSystem(variables: -1)                    | traps (signal 5)     | nil        |
+// | MathSolver.solveSystem(variables: 50, 1-elem startPoint) | SUCCEEDS w/ garbage  | nil        |
+// | MathSolver.minimize(variables: 50, 1-elem startPoint)    | SUCCEEDS w/ garbage  | nil        |
+// | MathSolver.minimizePowell(variables: -1)                 | traps (signal 5)     | nil        |
+// | MathSolver.particleSwarm(variables: -1)                  | traps (signal 5)     | nil        |
+// | MathSolver.particleSwarm(variables: 50, 1-elem bounds)   | SUCCEEDS w/ garbage  | nil        |
+// | MathSolver.globalMinimize(variables: -1)                 | traps (signal 5)     | nil        |
+// | MathSolver.solveSystemNewton(variables: -1)              | traps (signal 5)     | nil        |
+// | MathSolver.minimizeNewton(variables: -1)                 | traps (signal 5)     | nil        |
+// | MathSolver.gaussSetIntegration(nEquations: -1)           | traps (signal 5)     | nil        |
+// | MathSolver.gaussSetIntegration(1-elem lower, 5-elem up.) | SUCCEEDS w/ garbage  | nil        |
+// | MathSolver.uzawa(nVars: -1)                              | traps (signal 5)     | nil        |
+// | MathSolver.uzawa(nConstraints/nVars: 20, 1-elem arrays)  | SUCCEEDS w/ garbage  | nil        |
+// | MathGauss.determinant(matrix: [1.0], n: 1000)            | SIGBUS (signal 10)   | 0.0        |
+// | MathCrout.determinant(matrix: [1.0], n: 1000)            | SIGBUS (signal 10)   | 0.0        |
+// | MathSolver.eigenvalues(50-elem diag, 1-elem subdiag)     | SUCCEEDS w/ garbage  | nil        |
+// | MathSolver.eigenvaluesAndVectors(50-elem, 1-elem)        | SUCCEEDS w/ garbage  | nil        |
+// | MathSolver.gaussMultipleIntegration(50-elem, 1-elem)     | (nil this run; UB)   | nil        |
+// | MathSolver.findAllRoots(samples: Int32.max + 1)          | traps (signal 5)     | []         |
+// | MathSolver.findAllRoots(samples: -1)                     | uncontrolled result  | []         |
+//
+// "SUCCEEDS w/ garbage" is the more dangerous outcome the issue calls out: no crash, no
+// trap, a fully-populated, plausible-looking answer built from whatever memory happened to
+// follow the too-short array. `MathSolver.minimize(variables: 50, startPoint: [1.0])`
+// returned a 50-element point array of uninitialized-looking doubles (`4.147e-314`, ...)
+// and reported convergence.
+//
+// `findAllRoots(samples:)` is a different shape (#558's family, not #622's/#640's): `samples`
+// is a subdivision count, not a problem dimension, so it is bounded through
+// `Sampling.requested` like every other sampler instead of a positivity/consistency guard.
+//
+// Checked and confirmed correctly OUT of scope: `kronrodIntegrate`/`kronrodIntegrateAdaptive`/
+// `integGauss`/`integKronrod`/`integKronrodAdaptive`'s `points`/`gaussPoints` parameters trap
+// the same `Int32(_:)` way at `Int(Int32.max) + 1`, but they select a quadrature RULE order
+// inside OCCT, not an array length -- no bridge function indexes a raw pointer by them, and a
+// negative value is rejected cleanly via `IsDone() == false` (measured, not assumed). #622's
+// reasoning that this family is "kernel-side, not a Swift buffer" holds for these; it did not
+// hold for `findAllRoots`, which is why that one moved into `Sampling` and these did not.
+//
+// Every case in the table above was run in a standalone process before this fix landed and
+// confirmed to trap, crash, or silently succeed with the wrong answer; after the fix, the
+// identical calls below return their documented `nil`/`0.0`/`[]` instead, which is what makes
+// it possible to assert them in-process at all.
+@Suite("Issue #640: math dimension arguments reject negative and mismatched input")
+struct Issue640MathDimensionBounds {
+
+    // MARK: - MathLibrary.swift: the three sites #634 named plus the two determinants it could not see
+
+    @Test("MathGauss.determinant rejects a non-positive n and a matrix shorter than n*n")
+    func gaussDeterminantBounds() {
+        #expect(MathGauss.determinant(matrix: [1.0], n: -1) == 0.0)
+        #expect(MathGauss.determinant(matrix: [1.0], n: 0) == 0.0)
+        // n positive but matrix far shorter: this used to SIGBUS (bridge reads
+        // matrixData[i*n+j] for i,j in 0..<n unconditionally).
+        #expect(MathGauss.determinant(matrix: [1.0], n: 1000) == 0.0)
+        // Control: a real 2x2 still computes correctly.
+        let det = MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2)
+        #expect(abs(det - 5.0) < 1e-9)
+    }
+
+    @Test("MathCrout.determinant rejects a non-positive n and a matrix shorter than n*n")
+    func croutDeterminantBounds() {
+        #expect(MathCrout.determinant(matrix: [1.0], n: -1) == 0.0)
+        #expect(MathCrout.determinant(matrix: [1.0], n: 1000) == 0.0)
+        let det = MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2)
+        #expect(abs(det - 8.0) < 1e-9)
+    }
+
+    @Test("MathSVD.solve rejects a consistent-but-non-positive dimension")
+    func svdSolveBounds() {
+        // matrix.count == rows*cols holds exactly (0 == 0*-1); consistency alone is not
+        // enough (#640's headline case, restated for this sibling).
+        #expect(MathSVD.solve(matrix: [], rows: 0, cols: -1, rhs: []) == nil)
+        #expect(MathSVD.solve(matrix: [], rows: -1, cols: 0, rhs: []) == nil)
+        let A: [Double] = [1, 0, 0, 1, 1, 1]
+        let b: [Double] = [1, 2, 3]
+        #expect(MathSVD.solve(matrix: A, rows: 3, cols: 2, rhs: b) != nil)
+    }
+
+    @Test("MathJacobi.eigenvalues rejects a consistent-but-negative n")
+    func jacobiEigenvaluesBounds() {
+        // The issue's own example: matrix.count == n*n holds exactly (1 == (-1)*(-1)).
+        #expect(MathJacobi.eigenvalues(matrix: [1.0], n: -1) == nil)
+        #expect(MathJacobi.eigenvalues(matrix: [1.0], n: 0) == nil)
+        let matrix = [4.0, 1.0, 1.0, 4.0]
+        #expect(MathJacobi.eigenvalues(matrix: matrix, n: 2) != nil)
+    }
+
+    @Test("MathHouseholder.solve rejects a consistent-but-non-positive dimension")
+    func householderSolveBounds() {
+        #expect(MathHouseholder.solve(matrix: [], rows: 0, cols: -1, rhs: []) == nil)
+        let A: [Double] = [1, 0, 0, 1, 1, 1]
+        let b: [Double] = [1, 2, 3]
+        #expect(MathHouseholder.solve(matrix: A, rows: 3, cols: 2, rhs: b) != nil)
+    }
+
+    // MARK: - MathSolver.swift: the ten sites that had no consistency check at all
+
+    @Test("MathSolver.solveSystem rejects non-positive dimensions and a mismatched startPoint")
+    func solveSystemBounds() {
+        #expect(MathSolver.solveSystem(variables: -1, equations: 1, startPoint: [],
+                                        values: { _ in [0] }, jacobian: { _ in [0] }) == nil)
+        #expect(MathSolver.solveSystem(variables: 1, equations: -1, startPoint: [0],
+                                        values: { _ in [0] }, jacobian: { _ in [0] }) == nil)
+        // variables positive but startPoint shorter: this used to SUCCEED with heap garbage.
+        #expect(MathSolver.solveSystem(
+            variables: 50, equations: 1, startPoint: [1.0],
+            values: { x in [x.reduce(0, +)] },
+            jacobian: { x in [Double](repeating: 1, count: x.count) }
+        ) == nil)
+    }
+
+    @Test("MathSolver.minimize rejects a non-positive variables and a mismatched startPoint")
+    func minimizeBounds() {
+        #expect(MathSolver.minimize(variables: -1, startPoint: [], function: { _ in (0, []) }) == nil)
+        #expect(MathSolver.minimize(variables: 50, startPoint: [1.0],
+                                     function: { x in (x.reduce(0, +), x) }) == nil)
+    }
+
+    @Test("MathSolver.minimizePowell rejects a non-positive variables and a mismatched startPoint")
+    func minimizePowellBounds() {
+        #expect(MathSolver.minimizePowell(variables: -1, startPoint: [], function: { _ in 0 }) == nil)
+        #expect(MathSolver.minimizePowell(variables: 50, startPoint: [1.0], function: { x in x[0] }) == nil)
+    }
+
+    @Test("MathSolver.particleSwarm rejects a non-positive variables and mismatched bounds")
+    func particleSwarmBounds() {
+        #expect(MathSolver.particleSwarm(variables: -1, lower: [], upper: [], steps: [],
+                                          function: { _ in 0 }) == nil)
+        #expect(MathSolver.particleSwarm(variables: 50, lower: [0], upper: [1], steps: [0.1],
+                                          function: { x in x.reduce(0, +) }) == nil)
+    }
+
+    @Test("MathSolver.globalMinimize rejects a non-positive variables and mismatched bounds")
+    func globalMinimizeBounds() {
+        #expect(MathSolver.globalMinimize(variables: -1, lower: [], upper: [], function: { _ in 0 }) == nil)
+        #expect(MathSolver.globalMinimize(variables: 50, lower: [0], upper: [1],
+                                           function: { x in x.reduce(0, +) }) == nil)
+    }
+
+    @Test("MathSolver.solveSystemNewton rejects non-positive dimensions and a mismatched startPoint")
+    func solveSystemNewtonBounds() {
+        #expect(MathSolver.solveSystemNewton(variables: -1, equations: 1, startPoint: [],
+                                              values: { _ in [0] }, jacobian: { _ in [0] }) == nil)
+        #expect(MathSolver.solveSystemNewton(
+            variables: 50, equations: 1, startPoint: [1.0],
+            values: { x in [x.reduce(0, +)] },
+            jacobian: { x in [Double](repeating: 1, count: x.count) }
+        ) == nil)
+    }
+
+    @Test("MathSolver.minimizeNewton rejects a non-positive n and a mismatched startPoint")
+    func minimizeNewtonBounds() {
+        #expect(MathSolver.minimizeNewton(variables: -1, startPoint: [],
+                                           function: { _ in (0, [], []) }) == nil)
+        #expect(MathSolver.minimizeNewton(variables: 50, startPoint: [1.0],
+                                           function: { x in (0, x, x) }) == nil)
+    }
+
+    @Test("MathSolver.leastSquares rejects a non-positive dimension and reads no further out of bounds")
+    func leastSquaresBounds() {
+        #expect(MathSolver.leastSquares(matrix: [], rows: 0, cols: -1, rhs: []) == nil)
+        // rows/cols positive but matrix/rhs are 1 element: this used to SIGBUS at
+        // rows/cols 1000, and silently return `nil` from a garbage-fed IsDone() at smaller
+        // mismatches -- never a reliable failure, which is why it needed a guard rather than
+        // relying on the bridge to notice.
+        #expect(MathSolver.leastSquares(matrix: [1.0], rows: 1000, cols: 1000, rhs: [1.0]) == nil)
+        #expect(MathSolver.leastSquares(matrix: [1.0], rows: 3, cols: 3, rhs: [1.0]) == nil)
+        // Control: a real 3x2 overdetermined system still solves.
+        let A: [Double] = [1, 0, 0, 1, 1, 1]
+        let b: [Double] = [1, 2, 3]
+        #expect(MathSolver.leastSquares(matrix: A, rows: 3, cols: 2, rhs: b) != nil)
+    }
+
+    @Test("MathSolver.uzawa rejects non-positive dimensions and mismatched constraint arrays")
+    func uzawaBounds() {
+        #expect(MathSolver.uzawa(constraintMatrix: [], nConstraints: 0, nVars: -1,
+                                  constraintRHS: [], startPoint: []) == nil)
+        // nConstraints/nVars positive but every array is 1 element: this used to SUCCEED
+        // with heap garbage.
+        #expect(MathSolver.uzawa(constraintMatrix: [1.0], nConstraints: 20, nVars: 20,
+                                  constraintRHS: [1.0], startPoint: [1.0]) == nil)
+        let cont: [Double] = [1, 1]
+        let sec: [Double] = [1]
+        #expect(MathSolver.uzawa(constraintMatrix: cont, nConstraints: 1, nVars: 2,
+                                  constraintRHS: sec, startPoint: [0, 0]) != nil)
+    }
+
+    // MARK: - Sites invisible to a trap-shaped census: no Array(repeating:count:) at all
+
+    @Test("MathSolver.eigenvalues/eigenvaluesAndVectors reject a subdiagonal shorter than diagonal")
+    func eigenvaluesSubdiagonalLengthBounds() {
+        // diagonal.count (50) can never be negative, so nothing here ever traps -- the bridge
+        // just reads subdiagonal[i] for i in 0..<50 regardless, which used to succeed with
+        // heap garbage against a 1-element subdiagonal.
+        let longDiagonal = [Double](repeating: 1, count: 50)
+        #expect(MathSolver.eigenvalues(diagonal: longDiagonal, subdiagonal: [1.0]) == nil)
+        #expect(MathSolver.eigenvaluesAndVectors(diagonal: longDiagonal, subdiagonal: [1.0]) == nil)
+
+        let diag = [2.0, 2.0, 2.0]
+        let subdiag = [1.0, 1.0, 0.0]
+        #expect(MathSolver.eigenvalues(diagonal: diag, subdiagonal: subdiag) != nil)
+        #expect(MathSolver.eigenvaluesAndVectors(diagonal: diag, subdiagonal: subdiag) != nil)
+    }
+
+    @Test("MathSolver.gaussMultipleIntegration/.gaussSetIntegration reject mismatched arrays")
+    func gaussIntegrationLengthBounds() {
+        // lower.count (50) can never be negative; upper/order are the unguarded reads.
+        let longLower = [Double](repeating: 0, count: 50)
+        #expect(MathSolver.gaussMultipleIntegration(lower: longLower, upper: [1.0], order: [10],
+                                                     function: { x in x.reduce(0, +) }) == nil)
+        #expect(MathSolver.gaussSetIntegration(nEquations: -1, lower: [1], upper: [2], order: [10],
+                                                function: { _ in [0] }) == nil)
+        #expect(MathSolver.gaussSetIntegration(nEquations: 1, lower: [0], upper: [1, 2, 3, 4, 5],
+                                                order: [10, 10, 10, 10, 10],
+                                                function: { x in [x.reduce(0, +)] }) == nil)
+
+        let result = MathSolver.gaussMultipleIntegration(
+            lower: [0, 0], upper: [1, 1], order: [10, 10]
+        ) { x in x[0] * x[0] + x[1] * x[1] }
+        if let r = result { #expect(abs(r - 2.0 / 3.0) < 1e-6) } else { Issue.record("expected a result") }
+
+        let setResult = MathSolver.gaussSetIntegration(
+            nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10]
+        ) { x in [x[0] + x[1]] }
+        if let r = setResult { #expect(abs(r[0] - 0.5) < 1e-6) } else { Issue.record("expected a result") }
+    }
+
+    // MARK: - findAllRoots(samples:): a sampler, not a problem dimension (#558's family)
+
+    @Test("findAllRoots(samples:) routes through Sampling instead of trapping past Int32")
+    func findAllRootsSamplesBounds() {
+        let pastInt32 = Int(Int32.max) + 1
+        #expect(MathSolver.findAllRoots(in: 0...10, samples: pastInt32) { x in (x - 5, 1) }.count == 0)
+        #expect(MathSolver.findAllRoots(in: 0...10, samples: -1) { x in (x - 5, 1) }.count == 0)
+        #expect(MathSolver.findAllRoots(in: 0...10, samples: 0) { x in (x - 5, 1) }.count == 0)
+
+        #expect(MathSolver.findAllRoots(in: 0...10, samples: pastInt32, epsX: 1e-8, epsF: 1e-8,
+                                         epsNul: 1e-8) { x in (x - 5, 1) }.count == 0)
+        #expect(MathSolver.findAllRoots(in: 0...10, samples: -1, epsX: 1e-8, epsF: 1e-8,
+                                         epsNul: 1e-8) { x in (x - 5, 1) }.count == 0)
+
+        // Controls: a real search still finds the root at both defaults.
+        let roots1 = MathSolver.findAllRoots(in: -5.0...5.0, samples: 20) { x in (x, 1) }
+        #expect(roots1.contains { abs($0) < 1e-6 })
+        let roots2 = MathSolver.findAllRoots(in: -5.0...5.0) { x in (x, 1) }
+        #expect(roots2.contains { abs($0) < 1e-6 })
+    }
+}

--- a/Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift
+++ b/Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift
@@ -91,22 +91,51 @@ struct Issue640MathDimensionBounds {
 
     @Test("MathGauss.determinant rejects a non-positive n and a matrix shorter than n*n")
     func gaussDeterminantBounds() {
-        #expect(MathGauss.determinant(matrix: [1.0], n: -1) == 0.0)
-        #expect(MathGauss.determinant(matrix: [1.0], n: 0) == 0.0)
+        #expect(MathGauss.determinant(matrix: [1.0], n: -1) == nil)
+        #expect(MathGauss.determinant(matrix: [1.0], n: 0) == nil)
         // n positive but matrix far shorter: this used to SIGBUS (bridge reads
         // matrixData[i*n+j] for i,j in 0..<n unconditionally).
-        #expect(MathGauss.determinant(matrix: [1.0], n: 1000) == 0.0)
+        #expect(MathGauss.determinant(matrix: [1.0], n: 1000) == nil)
+        // n positive: this used to overflow n*n before the guard could reject it (review
+        // finding 8). Rejected, not trapped.
+        #expect(MathGauss.determinant(matrix: [1.0], n: .max) == nil)
         // Control: a real 2x2 still computes correctly.
-        let det = MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2)
-        #expect(abs(det - 5.0) < 1e-9)
+        if let det = MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2) {
+            #expect(abs(det - 5.0) < 1e-9)
+        } else {
+            Issue.record("expected a determinant")
+        }
+    }
+
+    @Test("MathGauss.determinant distinguishes an invalid dimension from a genuinely singular matrix")
+    func gaussDeterminantSentinelDistinguishability() {
+        // Review finding 7: before #640's fix, both an invalid dimension and a genuinely
+        // singular matrix returned the same bare `0.0` -- indistinguishable. Returning
+        // `Double?` makes them two different answers: `nil` (invalid input) and `.some(0.0)`
+        // (a real, correctly-computed zero).
+        #expect(MathGauss.determinant(matrix: [1.0], n: -1) == nil)
+        // [[1, 2], [2, 4]]: row 2 is 2x row 1, singular, determinant genuinely 0.
+        #expect(MathGauss.determinant(matrix: [1.0, 2.0, 2.0, 4.0], n: 2) == .some(0.0))
     }
 
     @Test("MathCrout.determinant rejects a non-positive n and a matrix shorter than n*n")
     func croutDeterminantBounds() {
-        #expect(MathCrout.determinant(matrix: [1.0], n: -1) == 0.0)
-        #expect(MathCrout.determinant(matrix: [1.0], n: 1000) == 0.0)
-        let det = MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2)
-        #expect(abs(det - 8.0) < 1e-9)
+        #expect(MathCrout.determinant(matrix: [1.0], n: -1) == nil)
+        #expect(MathCrout.determinant(matrix: [1.0], n: 1000) == nil)
+        #expect(MathCrout.determinant(matrix: [1.0], n: .max) == nil)
+        if let det = MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2) {
+            #expect(abs(det - 8.0) < 1e-9)
+        } else {
+            Issue.record("expected a determinant")
+        }
+    }
+
+    @Test("MathCrout.determinant distinguishes an invalid dimension from a genuinely singular matrix")
+    func croutDeterminantSentinelDistinguishability() {
+        #expect(MathCrout.determinant(matrix: [1.0], n: -1) == nil)
+        // [[1, 2], [2, 4]]: singular, determinant genuinely 0. Crout targets symmetric
+        // systems; this one is both symmetric and singular.
+        #expect(MathCrout.determinant(matrix: [1.0, 2.0, 2.0, 4.0], n: 2) == .some(0.0))
     }
 
     @Test("MathSVD.solve rejects a consistent-but-non-positive dimension")
@@ -115,6 +144,9 @@ struct Issue640MathDimensionBounds {
         // enough (#640's headline case, restated for this sibling).
         #expect(MathSVD.solve(matrix: [], rows: 0, cols: -1, rhs: []) == nil)
         #expect(MathSVD.solve(matrix: [], rows: -1, cols: 0, rhs: []) == nil)
+        // rows positive: this used to overflow rows*cols before the guard could reject it
+        // (review finding 8). Rejected, not trapped.
+        #expect(MathSVD.solve(matrix: [1.0], rows: .max, cols: 2, rhs: [1.0]) == nil)
         let A: [Double] = [1, 0, 0, 1, 1, 1]
         let b: [Double] = [1, 2, 3]
         #expect(MathSVD.solve(matrix: A, rows: 3, cols: 2, rhs: b) != nil)
@@ -125,6 +157,8 @@ struct Issue640MathDimensionBounds {
         // The issue's own example: matrix.count == n*n holds exactly (1 == (-1)*(-1)).
         #expect(MathJacobi.eigenvalues(matrix: [1.0], n: -1) == nil)
         #expect(MathJacobi.eigenvalues(matrix: [1.0], n: 0) == nil)
+        // n positive: overflow guard (review finding 8), same as the determinants.
+        #expect(MathJacobi.eigenvalues(matrix: [1.0], n: .max) == nil)
         let matrix = [4.0, 1.0, 1.0, 4.0]
         #expect(MathJacobi.eigenvalues(matrix: matrix, n: 2) != nil)
     }
@@ -132,6 +166,7 @@ struct Issue640MathDimensionBounds {
     @Test("MathHouseholder.solve rejects a consistent-but-non-positive dimension")
     func householderSolveBounds() {
         #expect(MathHouseholder.solve(matrix: [], rows: 0, cols: -1, rhs: []) == nil)
+        #expect(MathHouseholder.solve(matrix: [1.0], rows: .max, cols: 2, rhs: [1.0]) == nil)
         let A: [Double] = [1, 0, 0, 1, 1, 1]
         let b: [Double] = [1, 2, 3]
         #expect(MathHouseholder.solve(matrix: A, rows: 3, cols: 2, rhs: b) != nil)
@@ -151,6 +186,31 @@ struct Issue640MathDimensionBounds {
             values: { x in [x.reduce(0, +)] },
             jacobian: { x in [Double](repeating: 1, count: x.count) }
         ) == nil)
+        // Control: a real, correctly-dimensioned system still solves.
+        #expect(MathSolver.solveSystem(variables: 1, equations: 1, startPoint: [2.0],
+                                        values: { x in [x[0] - 3] },
+                                        jacobian: { _ in [1] }) != nil)
+    }
+
+    @Test("MathSolver.solveSystem/.solveSystemNewton reject a values/jacobian closure that returns the wrong length")
+    func solveSystemClosureLengthBounds() {
+        // Review findings 3/4: `startPoint`'s own length is checked above, but before this
+        // fix nothing checked the CLOSURE's returned array -- a `values` closure returning
+        // fewer than `equations` elements, or a `jacobian` closure returning fewer than
+        // `equations * variables`, indexed the short array and trapped the whole process.
+        // The guard turns that into `nil`.
+        #expect(MathSolver.solveSystem(variables: 1, equations: 1, startPoint: [2.0],
+                                        values: { _ in [] },
+                                        jacobian: { _ in [1] }) == nil)
+        #expect(MathSolver.solveSystem(variables: 1, equations: 1, startPoint: [2.0],
+                                        values: { x in [x[0] - 3] },
+                                        jacobian: { _ in [] }) == nil)
+        #expect(MathSolver.solveSystemNewton(variables: 1, equations: 1, startPoint: [2.0],
+                                              values: { _ in [] },
+                                              jacobian: { _ in [1] }) == nil)
+        #expect(MathSolver.solveSystemNewton(variables: 1, equations: 1, startPoint: [2.0],
+                                              values: { x in [x[0] - 3] },
+                                              jacobian: { _ in [] }) == nil)
     }
 
     @Test("MathSolver.minimize rejects a non-positive variables and a mismatched startPoint")
@@ -158,6 +218,32 @@ struct Issue640MathDimensionBounds {
         #expect(MathSolver.minimize(variables: -1, startPoint: [], function: { _ in (0, []) }) == nil)
         #expect(MathSolver.minimize(variables: 50, startPoint: [1.0],
                                      function: { x in (x.reduce(0, +), x) }) == nil)
+        // Control: a real, correctly-dimensioned minimization still runs.
+        #expect(MathSolver.minimize(variables: 1, startPoint: [1.0],
+                                     function: { x in (x[0] * x[0], [2 * x[0]]) }) != nil)
+    }
+
+    @Test("MathSolver.minimize/.minimizeNewton/.minimizeFRPR reject a function closure whose gradient/hessian is the wrong length")
+    func minimizeClosureLengthBounds() {
+        // Review finding 5: `function`'s own returned `gradient` (and, for `minimizeNewton`,
+        // `hessian`) is indexed up to `variables`/`variables * variables` with no length
+        // check before this fix -- the same trap-on-a-closure-return-value shape as
+        // findings 3/4, in the minimization family. `minimizeFRPR` shares the identical
+        // `OCCTMathMultiVarGradCallback` shape but was not itself named by the review; fixed
+        // and tested here for the same reason.
+        #expect(MathSolver.minimize(variables: 1, startPoint: [1.0],
+                                     function: { x in (x[0] * x[0], []) }) == nil)
+        #expect(MathSolver.minimizeNewton(variables: 1, startPoint: [1.0],
+                                           function: { x in (x[0] * x[0], [], [2.0]) }) == nil)
+        #expect(MathSolver.minimizeNewton(variables: 1, startPoint: [1.0],
+                                           function: { x in (x[0] * x[0], [2 * x[0]], []) }) == nil)
+        #expect(MathSolver.minimizeFRPR(startPoint: [1.0],
+                                         function: { x in (x[0] * x[0], []) }) == nil)
+        // Controls: correctly-shaped closures still run.
+        #expect(MathSolver.minimizeNewton(variables: 1, startPoint: [1.0],
+                                           function: { x in (x[0] * x[0], [2 * x[0]], [2.0]) }) != nil)
+        #expect(MathSolver.minimizeFRPR(startPoint: [1.0],
+                                         function: { x in (x[0] * x[0], [2 * x[0]]) }) != nil)
     }
 
     @Test("MathSolver.minimizePowell rejects a non-positive variables and a mismatched startPoint")
@@ -209,6 +295,8 @@ struct Issue640MathDimensionBounds {
         // relying on the bridge to notice.
         #expect(MathSolver.leastSquares(matrix: [1.0], rows: 1000, cols: 1000, rhs: [1.0]) == nil)
         #expect(MathSolver.leastSquares(matrix: [1.0], rows: 3, cols: 3, rhs: [1.0]) == nil)
+        // rows positive: overflow guard (review finding 8).
+        #expect(MathSolver.leastSquares(matrix: [1.0], rows: .max, cols: 2, rhs: [1.0]) == nil)
         // Control: a real 3x2 overdetermined system still solves.
         let A: [Double] = [1, 0, 0, 1, 1, 1]
         let b: [Double] = [1, 2, 3]
@@ -223,6 +311,9 @@ struct Issue640MathDimensionBounds {
         // with heap garbage.
         #expect(MathSolver.uzawa(constraintMatrix: [1.0], nConstraints: 20, nVars: 20,
                                   constraintRHS: [1.0], startPoint: [1.0]) == nil)
+        // nConstraints positive: overflow guard (review finding 8).
+        #expect(MathSolver.uzawa(constraintMatrix: [1.0], nConstraints: .max, nVars: 2,
+                                  constraintRHS: [1.0], startPoint: [1.0, 1.0]) == nil)
         let cont: [Double] = [1, 1]
         let sec: [Double] = [1]
         #expect(MathSolver.uzawa(constraintMatrix: cont, nConstraints: 1, nVars: 2,
@@ -258,15 +349,54 @@ struct Issue640MathDimensionBounds {
                                                 order: [10, 10, 10, 10, 10],
                                                 function: { x in [x.reduce(0, +)] }) == nil)
 
+        // gaussMultipleIntegration genuinely supports more than one variable
+        // (math_GaussMultipleIntegration integrates recursively): the double integral of
+        // x^2 + y^2 over the unit square is 1/3 + 1/3 = 2/3.
         let result = MathSolver.gaussMultipleIntegration(
             lower: [0, 0], upper: [1, 1], order: [10, 10]
         ) { x in x[0] * x[0] + x[1] * x[1] }
         if let r = result { #expect(abs(r - 2.0 / 3.0) < 1e-6) } else { Issue.record("expected a result") }
+    }
 
-        let setResult = MathSolver.gaussSetIntegration(
+    @Test("MathSolver.gaussSetIntegration rejects more than one variable instead of silently integrating only the first")
+    func gaussSetIntegrationRejectsMultipleVariables() {
+        // Review finding 2. `math_GaussSetIntegration`'s own header says "the case M>1 is
+        // not implemented", and the pinned kernel's `No_Exception` build compiles out
+        // OCCT's own runtime check for it (Standard_NotImplemented_Raise_if), so a call with
+        // more than one variable used to silently succeed at the WRONG answer instead of
+        // failing: measured directly against the unguarded implementation,
+        // `gaussSetIntegration(nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10])`
+        // integrating `x + y` returned 0.5 -- `INT x dx` over `[0, 1]` with `y` silently
+        // pinned at 0 the whole time, not `INT INT (x + y) dx dy` over the unit square, which
+        // is 1.0. Neither 0.5 nor 1.0 is an acceptable answer from this entry point for a
+        // 2-variable call: it must refuse, which is what this test pins.
+        #expect(MathSolver.gaussSetIntegration(
             nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10]
-        ) { x in [x[0] + x[1]] }
-        if let r = setResult { #expect(abs(r[0] - 0.5) < 1e-6) } else { Issue.record("expected a result") }
+        ) { x in [x[0] + x[1]] } == nil)
+
+        // The one-variable, multiple-EQUATION case (what "Set" actually names) is exactly
+        // what the class supports, and still works: integrate [x, x^2] over [0, 2] as two
+        // separate scalar integrals sharing one evaluation point.
+        let setResult = MathSolver.gaussSetIntegration(
+            nEquations: 2, lower: [0], upper: [2], order: [10]
+        ) { x in [x[0], x[0] * x[0]] }
+        if let r = setResult {
+            #expect(r.count == 2)
+            #expect(abs(r[0] - 2.0) < 1e-9)
+            #expect(abs(r[1] - 8.0 / 3.0) < 1e-9)
+        } else {
+            Issue.record("expected a result")
+        }
+    }
+
+    @Test("MathSolver.gaussSetIntegration rejects a function closure that returns the wrong length")
+    func gaussSetIntegrationClosureLengthBounds() {
+        // Review finding 6: the same closure-return-length gap as findings 3-6, in the
+        // Gauss integration family. A closure returning fewer than `nEquations` elements
+        // used to index the short array and trap.
+        #expect(MathSolver.gaussSetIntegration(
+            nEquations: 2, lower: [0], upper: [2], order: [10]
+        ) { x in [x[0]] } == nil)
     }
 
     // MARK: - findAllRoots(samples:): a sampler, not a problem dimension (#558's family)
@@ -288,5 +418,83 @@ struct Issue640MathDimensionBounds {
         #expect(roots1.contains { abs($0) < 1e-6 })
         let roots2 = MathSolver.findAllRoots(in: -5.0...5.0) { x in (x, 1) }
         #expect(roots2.contains { abs($0) < 1e-6 })
+    }
+
+    @Test("findAllRoots(samples:) accepts the documented minimum of 1, not Sampling's own default floor of 2")
+    func findAllRootsAcceptsMinimumOfOne() {
+        // Review finding 1: both overloads called `Sampling.requested(samples)` with no
+        // `atLeast:`, so the default floor of 2 applied even though this file's own doc
+        // comments and the reference docs document the valid range as 1...10,000,000.
+        // `samples: 1` was silently rejected before `function` was ever called -- proved
+        // here by counting calls rather than asserting a root is found, since whether one
+        // sample happens to bracket a root is the search algorithm's business, not the
+        // guard's.
+        var calls1 = 0
+        _ = MathSolver.findAllRoots(in: -1.0...1.0, samples: 1) { x in
+            calls1 += 1
+            return (x, 1)
+        }
+        #expect(calls1 > 0)
+
+        var calls2 = 0
+        _ = MathSolver.findAllRoots(in: -1.0...1.0, samples: 1, epsX: 1e-8, epsF: 1e-8, epsNul: 1e-8) { x in
+            calls2 += 1
+            return (x, 1)
+        }
+        #expect(calls2 > 0)
+
+        // samples: 0 is still outside the documented range and still rejected.
+        var calls3 = 0
+        _ = MathSolver.findAllRoots(in: -1.0...1.0, samples: 0) { x in
+            calls3 += 1
+            return (x, 1)
+        }
+        #expect(calls3 == 0)
+    }
+}
+
+// Review finding 9 on #640: the "n is positive and every array n sizes matches it exactly"
+// (or, for rows/cols, "the flat array is exactly their product") check was hand-duplicated
+// at 18 call sites with no shared validator, unlike `Sampling`'s own family. `MathDimension`
+// (Sources/OCCTSwift/MathDimension.swift) factors it out; these tests exercise it directly,
+// the same way Issue558SamplingCountBoundsTests.swift exercises `Sampling.requested`/
+// `capacity`/`gridTotal` directly, rather than only indirectly through the 18 call sites
+// that now share it.
+@Suite("Issue #640 review finding 9: MathDimension is the one shared validator")
+struct MathDimensionTests {
+
+    @Test("valid requires positivity and every given length to match exactly")
+    func validRequiresPositiveAndMatching() {
+        #expect(MathDimension.valid(3, matches: 3, 3))
+        #expect(!MathDimension.valid(3, matches: 3, 1))    // one mismatch among several
+        #expect(!MathDimension.valid(0, matches: 0))       // zero is not positive
+        #expect(!MathDimension.valid(-1, matches: 0))      // matches by coincidence, still rejected
+        #expect(MathDimension.valid(1, matches: 1))        // a single matching length is fine
+    }
+
+    @Test("consistent checks length agreement only, no positivity")
+    func consistentSkipsPositivity() {
+        #expect(MathDimension.consistent(0, matches: 0))    // two empty arrays agree
+        #expect(!MathDimension.consistent(0, matches: 1))
+        #expect(MathDimension.consistent(50, matches: 50))
+        #expect(!MathDimension.consistent(50, matches: 1))
+    }
+
+    @Test("validSquare checks n > 0, n * n == count, and does not overflow")
+    func validSquareChecksPositivityConsistencyAndOverflow() {
+        #expect(MathDimension.validSquare(2, count: 4))
+        #expect(!MathDimension.validSquare(2, count: 3))     // consistency fails
+        #expect(!MathDimension.validSquare(0, count: 0))     // 0 * 0 == 0 holds, but 0 is not positive
+        #expect(!MathDimension.validSquare(-1, count: 1))    // (-1)*(-1) == 1 holds, but -1 is not positive
+        #expect(!MathDimension.validSquare(.max, count: 1))  // would overflow n * n: rejected, not trapped
+    }
+
+    @Test("validRectangle checks rows > 0, cols > 0, rows * cols == count, and does not overflow")
+    func validRectangleChecksPositivityConsistencyAndOverflow() {
+        #expect(MathDimension.validRectangle(rows: 3, cols: 2, count: 6))
+        #expect(!MathDimension.validRectangle(rows: 3, cols: 2, count: 5))
+        #expect(!MathDimension.validRectangle(rows: 0, cols: -1, count: 0))   // 0 * -1 == 0 holds
+        #expect(!MathDimension.validRectangle(rows: .max, cols: 2, count: 1)) // overflow: rejected
+        #expect(!MathDimension.validRectangle(rows: 2, cols: .max, count: 1)) // overflow the other factor
     }
 }

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -1416,8 +1416,11 @@ struct MathGaussTests {
     }
 
     @Test func determinant() {
-        let det = MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2)
-        #expect(abs(det - 5.0) < 1e-10)
+        if let det = MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2) {
+            #expect(abs(det - 5.0) < 1e-10)
+        } else {
+            Issue.record("expected a determinant")
+        }
     }
 }
 
@@ -1511,8 +1514,11 @@ struct MathCroutTests {
     }
 
     @Test func determinant() {
-        let det = MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2)
-        #expect(abs(det - 8.0) < 1e-10)
+        if let det = MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2) {
+            #expect(abs(det - 8.0) < 1e-10)
+        } else {
+            Issue.record("expected a determinant")
+        }
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1379,6 +1379,99 @@ reached first. Worth recording, because it means the allocation size is the wron
 about when judging which of these entry points is dangerous — the `int32_t` cast is what fires, and
 it fires identically whether the element is 8 bytes or 88.
 
+#### The math dimension family traps on a consistent-but-negative dimension, and one site reads out of bounds (#640)
+
+`#622`'s own writeup deliberately left the math solver/optimizer family unfixed: its numbers are
+problem *dimensions* that must agree with the caller's own arrays, not sampling capacities, so
+`Sampling.requested`/`capacity` is the wrong tool and clamping one would hand back a
+garbage-dimension solve. That premise is correct. The remedy it suggested, a consistency check
+against the caller's arrays, is not, measured:
+
+```swift
+MathJacobi.eigenvalues(matrix: [1.0], n: -1)
+// matrix.count == n * n holds exactly: 1 == (-1) * (-1)
+// still aborts: Fatal error: Can't construct Array with count < 0
+```
+
+A consistency check alone cannot exclude this shape: whenever one factor of a product is zero, the
+other is unconstrained, so `rows: 0, cols: -1` (or the symmetric `n: -1` case above, where
+`matrix.count` is 1 either way) satisfies `matrix.count == rows * cols` for *any* value of the
+other factor. `MathSVD.solve` and `MathHouseholder.solve` have the identical gap. A positivity
+bound closes it, alongside the consistency check, not instead of it.
+
+**`MathSolver.leastSquares` is worse: it had no consistency check at all**, so a `rows`/`cols` pair
+that is positive but does not match `matrix`/`rhs`'s real length sails straight through and reaches
+the bridge's `matA[i*nCols+j]`/`b[i]` loops, which read unconditionally. That is an out-of-bounds
+read, not a trap: confirmed in a standalone process, `rows: 1000, cols: 1000` against a 1-element
+`matrix` crashes with `Bus error: 10`; smaller mismatches silently returned `nil` from a
+garbage-fed `IsDone()` instead, never a reliable failure either way.
+
+**Re-deriving the census by reading each candidate bridge function, rather than trusting the
+trap-shaped count either side had produced, found 20 affected entry points, not 13.** #634's own
+writeup had already grown the count from 10 to 13 under review (`MathSVD.solve`, `MathJacobi.
+eigenvalues`, `MathHouseholder.solve` were unnamed anywhere until then); measuring by allocation
+shape and by trapping `Int32(_:)` conversion, as suggested, reproduces that 13. A third lens, does
+a bridge function index a raw pointer up to a caller-supplied count with no check that the backing
+Swift array is actually that long, found five more, invisible to both prior lenses because none of
+them constructs a `[Double]` sized by the vulnerable dimension:
+
+- `MathGauss.determinant` / `MathCrout.determinant` return a scalar `Double`; the unconditional
+  `matrixData[i*n+j]` loop is exactly `leastSquares`'s shape, just with nothing to trap on. Both
+  crash with `Bus error: 10` at `n: 1000` against a 1-element `matrix`, confirmed in a standalone
+  process.
+- `MathSolver.eigenvalues(diagonal:subdiagonal:)` / `.eigenvaluesAndVectors` derive their dimension
+  from `diagonal.count` (never negative), but read `subdiagonal[i]` for `i in 0..<diagonal.count`
+  with no check that `subdiagonal` is that long: the `///` comment already said "must be same
+  length"; it was never enforced. Measured: a 50-element `diagonal` against a 1-element
+  `subdiagonal` returns eigenvalues up to `1.17e+131`, silently.
+- `MathSolver.gaussMultipleIntegration` derives `nVars` from `lower.count` and reads
+  `upper[i]`/`order[i]` up to it the same unguarded way. `.gaussSetIntegration` has both this gap
+  *and* the trapping one (`nEquations` sizes its result array).
+
+All 20 now require the dimension argument to be positive and every array it indexes into to match
+it exactly, closing the trap and the read together:
+
+| site | fix |
+|---|---|
+| `MathGauss.determinant`, `MathCrout.determinant` | `n > 0`, `matrix.count == n * n` |
+| `MathSVD.solve`, `MathHouseholder.solve` | `rows > 0`, `cols > 0` added to the existing consistency check |
+| `MathJacobi.eigenvalues` | `n > 0` added to the existing consistency check |
+| `MathSolver.solveSystem`, `.solveSystemNewton` | `variables > 0`, `equations > 0`, `startPoint.count == variables` |
+| `MathSolver.minimize`, `.minimizePowell`, `.minimizeNewton` | `variables > 0`, `startPoint.count == variables` |
+| `MathSolver.particleSwarm` | `variables > 0`, `lower`/`upper`/`steps`.count == variables` |
+| `MathSolver.globalMinimize` | `variables > 0`, `lower`/`upper`.count == variables` |
+| `MathSolver.leastSquares` | `rows > 0`, `cols > 0`, `matrix.count == rows * cols`, `rhs.count == rows` (new: had nothing) |
+| `MathSolver.uzawa` | `nConstraints > 0`, `nVars > 0`, and all three arrays checked against them (new: had nothing) |
+| `MathSolver.eigenvalues`, `.eigenvaluesAndVectors` | `subdiagonal.count == diagonal.count` (new) |
+| `MathSolver.gaussMultipleIntegration` | `upper.count == lower.count`, `order.count == lower.count` (new) |
+| `MathSolver.gaussSetIntegration` | `nEquations > 0` plus the same array checks as `gaussMultipleIntegration` |
+
+**Also in scope, reached by a different lens: `findAllRoots(samples:)` (both overloads) is a
+sampler by name and by role, not a problem dimension**, despite superficially trapping the same
+`Int32(_:)` way. It is routed through `Sampling.requested` instead, matching #558's own family,
+and rejects with `[]` rather than trapping past `Int32.max`. Checked alongside it and confirmed
+correctly excluded: `kronrodIntegrate`/`kronrodIntegrateAdaptive`/`integGauss`/`integKronrod`/
+`integKronrodAdaptive`'s `points`/`gaussPoints` parameters trap the identical way at
+`Int(Int32.max) + 1`, but select a quadrature rule order inside OCCT: no bridge function indexes
+an array by them, and a negative value is rejected cleanly via `IsDone() == false`, measured, not
+assumed. #634's "kernel-side, not a Swift buffer" reasoning holds for these; it did not hold for
+`findAllRoots`.
+
+Regression suite: `Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift`, 17 tests covering
+all 20 entry points plus a positive control per function. Proved by injection at four
+representative guards spanning both failure shapes: removing `MathJacobi.eigenvalues`'s positivity
+bound crashes the whole `swift test` process (`exited with unexpected signal code 5`, matching
+`raycast`'s own #622 precedent) rather than failing one test; removing `solveSystem`'s
+`startPoint.count == variables` check and `eigenvalues`'s `subdiagonal.count == diagonal.count`
+check both instead produce ordinary, reportable test failures with the exact garbage values quoted
+above; removing `findAllRoots`'s `Sampling.requested` call reproduces the same whole-process crash
+as the positivity case. All four restored and re-verified green. A fifth injection, removing only
+`MathGauss.determinant`'s consistency check and leaving positivity, did **not** reproduce the crash
+inside `swift test`'s process (unlike the standalone probe, which crashed reliably at the same
+input): the read is undefined behaviour, not a guaranteed crash, and its outcome depends on the
+process's own memory layout. This is the same point the out-of-bounds-read finding makes at the
+API level, one level down in the tooling used to demonstrate it.
+
 #### A fillet radius law goes to the edge's own slot, in the edge's own contour (#612)
 
 `filletEvolving`, `filleted(edges:startRadius:endRadius:)` and `filletedVariable` all wrote their

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1472,6 +1472,90 @@ input): the read is undefined behaviour, not a guaranteed crash, and its outcome
 process's own memory layout. This is the same point the out-of-bounds-read finding makes at the
 API level, one level down in the tooling used to demonstrate it.
 
+#### PR #716 review follow-up: three new closure-return-length traps, a mis-measured integral, and a shared validator (#640)
+
+An automated review of #716 (the PR above) found ten distinct defects, the most severe of which
+was the PR reintroducing its own bug class in three new places: guarding a caller's **argument**
+arrays against a dimension mismatch, then indexing a **closure's return value** against that same
+dimension with no check at all. A closure returning a short array trapped the process exactly the
+way #640 exists to prevent, just relocated from the caller's arguments to the caller's closure.
+Fixed at every site that shape occurs: `solveSystem`/`solveSystemNewton`'s `values`/`jacobian`
+callbacks, `minimize`/`minimizeNewton`'s `gradient`/`hessian`, and `gaussSetIntegration`'s
+`values`. `minimizeFRPR` shares the identical `OCCTMathMultiVarGradCallback` shape but was not
+itself named by the review; fixed and tested alongside the others for the same reason. Every
+guard was proved in a standalone process (the #705 technique, temporarily pointing
+`Sources/OCCTTest/main.swift` at a case-selecting probe): removing any one of them reproduces
+`Fatal error: Index out of range`, a process trap, not a test failure; restoring it returns `nil`.
+
+**The review's own finding 2 uncovered a real defect, not a wrong literal.** It read a new
+regression test, `gaussIntegrationLengthBounds()`, as asserting the double integral of `x + y`
+over the unit square is `0.5`, and pointed out the true value is `1.0` by symmetry. Both
+observations were correct, and neither was the actual story: measured directly against the pinned
+kernel, `gaussSetIntegration(nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10])`
+integrating `x + y` genuinely returns `0.5` -- but not because it computes any correct 2-variable
+integral. `math_GaussSetIntegration`'s own header documents "the case M>1 is not implemented": a
+probe built directly against the class confirms its constructor only ever varies the *first*
+integration variable (`Lower.Value(Lower.Lower())`), leaving every other component of its working
+vector pinned at its initial value, `0`. So `0.5` is `∫x dx` over `[0, 1]` with `y` silently held
+at `0` the entire time, never `∫∫(x + y) dx dy`. OCCT's own runtime check for this
+(`Standard_NotImplemented_Raise_if(NbVar != 1, ...)`) does not survive this project's
+`No_Exception` production kernel build (the same class of gap #487/#555/#603 measured elsewhere),
+so instead of failing loudly it silently computed the wrong thing. Changing the test's literal
+from `0.5` to `1.0` would have enshrined a *different* wrong answer -- `gaussSetIntegration` can
+never legitimately produce `1.0` for that call, because it never touches the second variable at
+all. The actual fix is a new guard: `gaussSetIntegration` now requires `lower.count == 1`,
+returning `nil` for any call with more than one variable, matching what the class actually
+supports (one variable, any number of equations -- a true "set of functions", each integrated
+over the same one-dimensional domain). `gaussMultipleIntegration` is unaffected: its own class,
+`math_GaussMultipleIntegration`, integrates recursively over every dimension and was confirmed
+correct at 2 variables independently. The pre-existing `Tests/OCCTIntegrationTests/
+OCCTIntegrationTests.swift`'s `GaussSetIntegrationTests.integrateSet()` predated #640 and carried
+the identical two-variable call and the identical `0.5` assertion; fixed to a valid one-variable,
+two-equation case (`[x, x^2]` over `[0, 2]`, giving `[2.0, 8/3]`) plus an explicit assertion that
+the old two-variable shape now returns `nil`.
+
+The remaining seven findings were all confirmed and fixed:
+
+- **Finding 1**: both `findAllRoots` overloads called `Sampling.requested(samples)` without
+  `atLeast: 1`, so the default floor of `2` applied even though this file's own doc comments and
+  the reference docs already documented the valid range as `1...10,000,000`. `samples: 1` was
+  silently rejected -- the closure was never called -- before returning `[]`. Fixed by passing
+  `atLeast: 1` at both call sites.
+- **Finding 7**: `MathGauss.determinant`/`MathCrout.determinant` returned a bare `Double`, so the
+  `0.0` sentinel for an invalid dimension was indistinguishable from `0.0`, the correct
+  determinant of a genuinely singular matrix. Both now return `Double?`; `nil` means invalid
+  input, `.some(0.0)` means a real, correctly-computed zero.
+- **Finding 8**: every positivity guard in this family computed `n * n` or `rows * cols` with the
+  plain `*` operator, which traps on overflow for a sufficiently large positive dimension (e.g.
+  `n: .max`) -- the exact process-trap #640 exists to eliminate, reintroduced by the guard meant
+  to prevent it. Fixed by routing every such guard through the new `MathDimension` type below,
+  which uses `multipliedReportingOverflow(by:)` (the same idiom `Sampling.gridTotal` already
+  carries) and rejects rather than traps.
+- **Finding 9**: the "dimension positive, and every array it sizes matches exactly" check (or,
+  for `rows`/`cols`, "the flat array is exactly their product") was hand-duplicated at 18 call
+  sites with no shared validator, unlike the `Sampling` family this same PR already reuses for
+  `findAllRoots`. `Sources/OCCTSwift/MathDimension.swift` factors it into four functions --
+  `valid`, `consistent`, `validSquare`, `validRectangle` -- and all 18 sites now share it,
+  fixing finding 8's overflow gap everywhere at once rather than site by site.
+- **Finding 10**: the 18 changed doc comments carried no fenced `swift` snippet, which CLAUDE.md
+  makes mandatory for public API changes since context7 only harvests fenced snippets. All 18
+  gained one, modeled on `Sampling.maximumSampleCount`'s doc.
+- Also removed: `docs/SEMVER.md`'s recorded-exception entry for this issue. The maintainer ruled
+  that mechanism is for breaks shipping *within* a major line; this work ships in v2.0.0, a
+  major, where breaking changes are permitted outright, so no exception entry is needed --
+  this note is the migration record instead. The counters at the top of `docs/SEMVER.md` are
+  restored to their pre-#640 values (thirteen recorded exceptions), and the pre-existing counter
+  drift #640's own PR fixed (a stale hardcoded number in #639's entry, once out of sync with the
+  count at the top of the file) is kept: that entry now reads the count in prose rather than
+  restating it as a number that can drift again.
+
+Full `swift test`: 5384 tests (5373 baseline + 11 new -- 7 in
+`Issue640MathDimensionBoundsTests.swift`, 4 in a new `MathDimensionTests` suite exercising
+`MathDimension` directly, the same way `Issue558SamplingCountBoundsTests.swift` exercises
+`Sampling.requested`/`capacity`/`gridTotal` directly). `swift run Censuses cluster-a`: 45 rows.
+`cluster-b`: 16 rows. All four gate scripts and their three `--self-tests` pass from the repo
+root.
+
 #### A fillet radius law goes to the edge's own slot, in the edge's own contour (#612)
 
 `filletEvolving`, `filleted(edges:startRadius:endRadius:)` and `filletedVariable` all wrote their

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,13 +17,13 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **fourteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **thirteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
 
 - [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
 - [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
 - [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
 
-The other eleven change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+The other ten change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
 
 - [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
 - [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
@@ -35,9 +35,8 @@ The other eleven change behaviour **without breaking the build**, which is the s
 - [#651](#recorded-exception-unreleased-nbedgesnbfacesnbvertices-are-deprecated-and-forward-to-the-deduplicated-count-651) deprecates `Shape.nbEdges`/`nbFaces`/`nbVertices` in favour of `edgeCount`/`faceCount`/`vertexCount`, and changes what the deprecated three return on the way.
 - [#699](#recorded-exception-unreleased-aag-adjacency-and-convexity-are-scoped-to-one-solid-699) restricts `AAG`'s adjacency/convexity checks to same-solid face pairs, further changing what `detectPocketsAAG()` can return on a multi-solid compound: the same public API #642 already named, corrected further rather than a new one opened.
 - [#705](#recorded-exception-unreleased-chamfer2d-refuses-a-repeated-edge-pair-instead-of-crashing-705) makes `chamfer2D(edgePairs:distances:)` return `nil` on a repeated edge pair; it used to SIGSEGV the process, uncatchably.
-- [#640](#recorded-exception-unreleased-the-math-dimension-family-rejects-invalid-input-instead-of-trapping-or-reading-out-of-bounds-640) makes twenty math-solver entry points return `nil`/`0.0`/`[]` on a non-positive or mismatched dimension; they used to trap the process or read out of bounds.
 
-A fifteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
+A fourteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead. `#640`'s math-dimension-family fix is not recorded here either, for a different reason: it ships in v2.0.0, a major, where breaking changes are permitted outright, so the recorded-exception mechanism (for breaks shipping *within* a major line) does not apply. See [`CHANGELOG.md`](CHANGELOG.md#the-math-dimension-family-traps-on-a-consistent-but-negative-dimension-and-one-site-reads-out-of-bounds-640) for the migration.
 
 ## Rules
 
@@ -402,52 +401,6 @@ The exception was taken because:
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 
-#### Recorded exception: Unreleased, the math dimension family rejects invalid input instead of trapping or reading out of bounds (#640)
-
-**Twenty behaviour changes across two files, none a compile error, and mostly not really breaks at
-all: the old answer for the inputs below was either an uncatchable process trap or an
-out-of-bounds memory read, never a defined contract.** #634 (issue #622) named this family,
-problem-dimension arguments (`n`, `rows`, `cols`, `variables`, `nConstraints`, `nVars`,
-`nEquations`) alongside the flat `[Double]`/`[Int]` arrays they size or index into, and
-deliberately left it unfixed, since the right bound is a consistency check against the caller's
-own arrays, not a `Sampling` ceiling. #640 supplies that check, plus the positivity bound #634
-itself found missing (a consistency check alone is satisfied by, for example, `rows: 0, cols:
--1`), plus five sites #634's own census could not see (`MathGauss.determinant`,
-`MathCrout.determinant`, `.eigenvalues(diagonal:subdiagonal:)`, `.eigenvaluesAndVectors`,
-`.gaussMultipleIntegration`) because none of them constructs a `[Double]` sized by the vulnerable
-dimension.
-
-| Break | What a caller does |
-|---|---|
-| `MathGauss.determinant`, `MathSVD.solve`, `MathJacobi.eigenvalues`, `MathHouseholder.solve`, `MathCrout.determinant` return `nil`/`0.0` for a non-positive dimension, or a dimension inconsistent with the supplied array's length | Nothing on a correctly-dimensioned call. A caller passing, for example, `rows: 0, cols: -1` (satisfies the pre-existing consistency check exactly) used to trap the process; it now returns `nil` |
-| `MathSolver.solveSystem`, `.minimize`, `.minimizePowell`, `.particleSwarm`, `.globalMinimize`, `.solveSystemNewton`, `.minimizeNewton`, `.leastSquares`, `.uzawa` return `nil` for a non-positive dimension or an array whose length does not match it | Nothing on a correctly-dimensioned call. A positive-but-mismatched dimension used to either trap (negative) or silently succeed with a plausible-looking result built from adjacent heap memory (positive but wrong): measured directly, `solveSystem(variables: 50, startPoint: [1.0])` returned a fully-populated 50-element "solution". Pass an array whose length matches the dimension argument |
-| `MathSolver.eigenvalues(diagonal:subdiagonal:)` / `.eigenvaluesAndVectors` return `nil` when `subdiagonal.count != diagonal.count` | The `///` doc already said "must be same length"; it is now enforced. A mismatched call used to succeed with heap garbage (measured: eigenvalues up to `1.17e+131` from a `[1.0]` subdiagonal against a 50-element diagonal) |
-| `MathSolver.gaussMultipleIntegration` / `.gaussSetIntegration` return `nil` when `upper`/`order` do not match `lower`'s length | Same as above: pass matching lengths |
-| `MathSolver.findAllRoots(in:samples:function:)` (both overloads) return `[]` for `samples` outside `1...10,000,000` (via `Sampling.requested`), rather than trapping on `Int32(samples)` past `Int32.max` | Nothing at the existing defaults (20, 100). A caller passing an absurd `samples` gets `[]` instead of crashing the process |
-
-The exception was taken because:
-
-- **The old answer was either a crash or undefined behaviour, never a defined contract**, the same
-  standard #705 was taken under. A trap takes the whole process down, so there was no prior answer
-  to disagree with, and an out-of-bounds read is memory-unsafe regardless of whether a given
-  execution happens to return something plausible-looking: two different processes given the
-  identical inputs demonstrated both a `Bus error` crash and a silent, wrong success, which is what
-  "undefined" means in practice, not a value any correct caller could have relied on.
-- **A correctly-dimensioned call is unaffected**, pinned by a positive control in
-  `Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift` for every one of the twenty entry
-  points.
-- **There is no spelling in which both survive.** As with #541/#568/#613, these are *value*
-  contracts (a dimension argument agreeing with an array's length), not types or names, so Swift
-  cannot overload on them.
-- **`findAllRoots(samples:)` moved to `Sampling.requested` rather than a positivity/consistency
-  guard**, because `samples` is a subdivision count (#558's family), not a problem dimension: the
-  distinction #634 itself drew, and #640 confirms by measurement rather than assumption for the
-  two lookalikes it also checked (`kronrodIntegrateAdaptive`, `integGauss`'s
-  `points`/`gaussPoints`, confirmed to select a quadrature rule order inside OCCT with no array
-  indexed by them, correctly excluded).
-- Named in [`CHANGELOG.md`](CHANGELOG.md#the-math-dimension-family-traps-on-a-consistent-but-negative-dimension-and-one-site-reads-out-of-bounds-640)
-  with the measurement, and to be named in the release notes.
-
 #### #639: additive fillet decline reporting, not an exception
 
 **Recorded here per #664's own rule of writing a public-API change down in this file before the
@@ -458,7 +411,7 @@ sibling (`filletedWithReport(edges:radius:)`, `filletedWithReport(edges:startRad
 fillet, alongside the shape, for a caller who wants to know (#639).
 
 This does **not** move the recorded-exceptions count above (checked against the current count of
-fourteen at the time of this edit, re-verified rather than assumed, since it has drifted before):
+thirteen at the time of this edit, re-verified rather than assumed, since it has drifted before):
 no existing method's signature or behaviour changed. `filleted(edges:radius:)` and its two
 siblings still return exactly what they always did, for exactly the same inputs; a caller who
 never calls the three new methods sees no difference at all. This is the **MINOR**, additive Swift

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -17,13 +17,13 @@ The policy is calibrated to the [SemVer 2.0.0](https://semver.org/) spec with on
 | **MINOR** (`x.y.0`) | xcframework rebuild against a new OCCT release **OR** additive new public Swift API | A new wrapped operation, a new type, a new bridge function exposed to Swift |
 | **PATCH** (`x.y.z`) | Bug fix, internal refactor, doc-only — **no public API surface change** | A `nil`-returning regression repaired, a wrong sort-order fixed, a dependency floor bump |
 
-The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **thirteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
+The load-bearing guarantee is the SemVer guarantee: **no breaking change without a major bump**. Within a major line, all minor and patch updates are safe to take blindly, with **fourteen** recorded exceptions. Three of them **do not compile** until the caller acts, so an upgrade cannot silently absorb them:
 
 - [v1.17.0](#recorded-exception-v1170-2026-07-29) breaks source compatibility in two named places.
 - [#495](#recorded-exception-unreleased--junction-analysis-flags-become-optional-495) in one, making junction-analysis flags optional.
 - [#619](#recorded-exception-unreleased-continuityorder-is-retired-rather-than-reinterpreted-619) retires `Curve3D.continuityOrder`, `Curve2D.continuityOrder` and `Surface.surfaceContinuityOrder` outright — deliberately, to convert a change that had already happened to their *values* into one a caller cannot miss.
 
-The other ten change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
+The other eleven change behaviour **without breaking the build**, which is the set to read before upgrading blindly:
 
 - [#499](#recorded-exception-unreleased-pathparser-forwards-to-osdpath-499) changes what two deprecated `PathParser` methods return.
 - [#541](#recorded-exception-unreleased-one-meaning-for-a-face-index-541) moves six sub-shape index conventions onto one.
@@ -35,8 +35,9 @@ The other ten change behaviour **without breaking the build**, which is the set 
 - [#651](#recorded-exception-unreleased-nbedgesnbfacesnbvertices-are-deprecated-and-forward-to-the-deduplicated-count-651) deprecates `Shape.nbEdges`/`nbFaces`/`nbVertices` in favour of `edgeCount`/`faceCount`/`vertexCount`, and changes what the deprecated three return on the way.
 - [#699](#recorded-exception-unreleased-aag-adjacency-and-convexity-are-scoped-to-one-solid-699) restricts `AAG`'s adjacency/convexity checks to same-solid face pairs, further changing what `detectPocketsAAG()` can return on a multi-solid compound: the same public API #642 already named, corrected further rather than a new one opened.
 - [#705](#recorded-exception-unreleased-chamfer2d-refuses-a-repeated-edge-pair-instead-of-crashing-705) makes `chamfer2D(edgePairs:distances:)` return `nil` on a repeated edge pair; it used to SIGSEGV the process, uncatchably.
+- [#640](#recorded-exception-unreleased-the-math-dimension-family-rejects-invalid-input-instead-of-trapping-or-reading-out-of-bounds-640) makes twenty math-solver entry points return `nil`/`0.0`/`[]` on a non-positive or mismatched dimension; they used to trap the process or read out of bounds.
 
-A fourteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
+A fifteenth was **not** taken: [#609](#held-for-the-next-major-v200)'s twelve breaks are held for v2.0.0 instead.
 
 ## Rules
 
@@ -401,6 +402,52 @@ The exception was taken because:
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 
+#### Recorded exception: Unreleased, the math dimension family rejects invalid input instead of trapping or reading out of bounds (#640)
+
+**Twenty behaviour changes across two files, none a compile error, and mostly not really breaks at
+all: the old answer for the inputs below was either an uncatchable process trap or an
+out-of-bounds memory read, never a defined contract.** #634 (issue #622) named this family,
+problem-dimension arguments (`n`, `rows`, `cols`, `variables`, `nConstraints`, `nVars`,
+`nEquations`) alongside the flat `[Double]`/`[Int]` arrays they size or index into, and
+deliberately left it unfixed, since the right bound is a consistency check against the caller's
+own arrays, not a `Sampling` ceiling. #640 supplies that check, plus the positivity bound #634
+itself found missing (a consistency check alone is satisfied by, for example, `rows: 0, cols:
+-1`), plus five sites #634's own census could not see (`MathGauss.determinant`,
+`MathCrout.determinant`, `.eigenvalues(diagonal:subdiagonal:)`, `.eigenvaluesAndVectors`,
+`.gaussMultipleIntegration`) because none of them constructs a `[Double]` sized by the vulnerable
+dimension.
+
+| Break | What a caller does |
+|---|---|
+| `MathGauss.determinant`, `MathSVD.solve`, `MathJacobi.eigenvalues`, `MathHouseholder.solve`, `MathCrout.determinant` return `nil`/`0.0` for a non-positive dimension, or a dimension inconsistent with the supplied array's length | Nothing on a correctly-dimensioned call. A caller passing, for example, `rows: 0, cols: -1` (satisfies the pre-existing consistency check exactly) used to trap the process; it now returns `nil` |
+| `MathSolver.solveSystem`, `.minimize`, `.minimizePowell`, `.particleSwarm`, `.globalMinimize`, `.solveSystemNewton`, `.minimizeNewton`, `.leastSquares`, `.uzawa` return `nil` for a non-positive dimension or an array whose length does not match it | Nothing on a correctly-dimensioned call. A positive-but-mismatched dimension used to either trap (negative) or silently succeed with a plausible-looking result built from adjacent heap memory (positive but wrong): measured directly, `solveSystem(variables: 50, startPoint: [1.0])` returned a fully-populated 50-element "solution". Pass an array whose length matches the dimension argument |
+| `MathSolver.eigenvalues(diagonal:subdiagonal:)` / `.eigenvaluesAndVectors` return `nil` when `subdiagonal.count != diagonal.count` | The `///` doc already said "must be same length"; it is now enforced. A mismatched call used to succeed with heap garbage (measured: eigenvalues up to `1.17e+131` from a `[1.0]` subdiagonal against a 50-element diagonal) |
+| `MathSolver.gaussMultipleIntegration` / `.gaussSetIntegration` return `nil` when `upper`/`order` do not match `lower`'s length | Same as above: pass matching lengths |
+| `MathSolver.findAllRoots(in:samples:function:)` (both overloads) return `[]` for `samples` outside `1...10,000,000` (via `Sampling.requested`), rather than trapping on `Int32(samples)` past `Int32.max` | Nothing at the existing defaults (20, 100). A caller passing an absurd `samples` gets `[]` instead of crashing the process |
+
+The exception was taken because:
+
+- **The old answer was either a crash or undefined behaviour, never a defined contract**, the same
+  standard #705 was taken under. A trap takes the whole process down, so there was no prior answer
+  to disagree with, and an out-of-bounds read is memory-unsafe regardless of whether a given
+  execution happens to return something plausible-looking: two different processes given the
+  identical inputs demonstrated both a `Bus error` crash and a silent, wrong success, which is what
+  "undefined" means in practice, not a value any correct caller could have relied on.
+- **A correctly-dimensioned call is unaffected**, pinned by a positive control in
+  `Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift` for every one of the twenty entry
+  points.
+- **There is no spelling in which both survive.** As with #541/#568/#613, these are *value*
+  contracts (a dimension argument agreeing with an array's length), not types or names, so Swift
+  cannot overload on them.
+- **`findAllRoots(samples:)` moved to `Sampling.requested` rather than a positivity/consistency
+  guard**, because `samples` is a subdivision count (#558's family), not a problem dimension: the
+  distinction #634 itself drew, and #640 confirms by measurement rather than assumption for the
+  two lookalikes it also checked (`kronrodIntegrateAdaptive`, `integGauss`'s
+  `points`/`gaussPoints`, confirmed to select a quadrature rule order inside OCCT with no array
+  indexed by them, correctly excluded).
+- Named in [`CHANGELOG.md`](CHANGELOG.md#the-math-dimension-family-traps-on-a-consistent-but-negative-dimension-and-one-site-reads-out-of-bounds-640)
+  with the measurement, and to be named in the release notes.
+
 #### #639: additive fillet decline reporting, not an exception
 
 **Recorded here per #664's own rule of writing a public-API change down in this file before the
@@ -410,16 +457,17 @@ sibling (`filletedWithReport(edges:radius:)`, `filletedWithReport(edges:startRad
 `filletEvolvingWithReport(_:)`) returning a new `Shape.FilletResult`: the edges OCCT declined to
 fillet, alongside the shape, for a caller who wants to know (#639).
 
-This does **not** move the "thirteen recorded exceptions" count above, checked and confirmed
-unchanged by this entry: no existing method's signature or behaviour changed. `filleted(edges:
-radius:)` and its two siblings still return exactly what they always did, for exactly the same
-inputs; a caller who never calls the three new methods sees no difference at all. This is the
-**MINOR**, additive Swift API, case the quick reference table already names, not the MAJOR-avoided,
+This does **not** move the recorded-exceptions count above (checked against the current count of
+fourteen at the time of this edit, re-verified rather than assumed, since it has drifted before):
+no existing method's signature or behaviour changed. `filleted(edges:radius:)` and its two
+siblings still return exactly what they always did, for exactly the same inputs; a caller who
+never calls the three new methods sees no difference at all. This is the **MINOR**, additive Swift
+API, case the quick reference table already names, not the MAJOR-avoided,
 compile-error-or-silent-behaviour-change case every entry above it is. It is recorded here anyway,
 rather than left to the release's own `CHANGELOG.md` entry, because #664 asks for every public-API
 change in this cluster of work to be written down at the same time it lands, and distinguishing
 "additive, no exception" from "exception" is itself information a reviewer of this file benefits
-from having next to the twelve that are.
+from having next to the ones that are.
 
 Two of the issue's own named members (`filletedWithFullHistory(radius:edges:)`,
 `FilletBuilder.contour(for:)`) needed no new API at all: both already carry a way to answer the

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -1251,6 +1251,9 @@ public static func determinant(matrix: [Double], n: Int) -> Double
 ```
 
 - **Parameters:** `matrix` — row-major N×N matrix; `n` — dimension.
+- **Bounds:** `n` must be positive and `matrix.count` must equal `n * n` exactly, or this returns
+  `0.0` (#640). Before this bound, a mismatched positive `n` read past the end of `matrix` inside
+  the bridge.
 - **OCCT:** `math_Gauss::Determinant` (via `OCCTMathGaussDeterminant`).
 
 ---
@@ -1269,6 +1272,10 @@ public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) 
 
 - **Parameters:** `matrix` — row-major M×N matrix; `rows` — M; `cols` — N; `rhs` — right-hand side (length M).
 - **Returns:** Solution vector of length N, or `nil` on failure.
+- **Bounds:** `rows` and `cols` must both be positive, and `matrix.count == rows * cols` /
+  `rhs.count == rows` must hold, or this returns `nil` (#640). A consistency check alone is not
+  enough: `rows: 0, cols: -1` satisfies `matrix.count == rows * cols` for any `matrix`, so the
+  positivity bound is required too.
 - **OCCT:** `math_SVD::Solve` (via `OCCTMathSVDSolve`).
 - **Example:**
   ```swift
@@ -1321,6 +1328,9 @@ public static func eigenvalues(matrix: [Double], n: Int) -> [Double]?
 
 - **Parameters:** `matrix` — row-major N×N symmetric matrix; `n` — dimension.
 - **Returns:** Eigenvalue array of length N, or `nil` on failure.
+- **Bounds:** `n` must be positive and `matrix.count` must equal `n * n` exactly, or this returns
+  `nil` (#640). `eigenvalues(matrix: [1.0], n: -1)` satisfies the consistency check alone
+  (`1 == (-1) * (-1)`), which is why positivity is checked separately rather than folded into it.
 - **OCCT:** `math_Jacobi::Values` (via `OCCTMathJacobiEigenvalues`).
 - **Example:**
   ```swift
@@ -1525,6 +1535,9 @@ public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) 
 
 - **Parameters:** `matrix` — row-major M×N matrix; `rows` — M (must be ≥ `cols`); `cols` — N; `rhs` — right-hand side (length M).
 - **Returns:** Solution vector of length N, or `nil` on failure or under-determined input.
+- **Bounds:** `rows` and `cols` must both be positive, in addition to `rows >= cols` and the
+  existing `matrix`/`rhs` length checks, or this returns `nil` (#640): `rows >= cols` alone does
+  not exclude `rows: 0, cols: -1`.
 - **OCCT:** `math_Householder::Solve` (via `OCCTMathHouseholderSolve`).
 - **Example:**
   ```swift
@@ -1571,6 +1584,8 @@ Compute the determinant of a symmetric matrix via Crout factorisation.
 public static func determinant(matrix: [Double], n: Int) -> Double
 ```
 
+- **Bounds:** `n` must be positive and `matrix.count` must equal `n * n` exactly, or this returns
+  `0.0` (#640), the same fix and for the same reason as `MathGauss.determinant`.
 - **OCCT:** `math_Crout::Determinant` (via `OCCTMathCroutDeterminant`).
 
 ---

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -1247,13 +1247,17 @@ public static func solve(matrix: [Double], rhs: [Double]) -> [Double]?
 Compute the determinant of an N×N matrix using Gaussian elimination.
 
 ```swift
-public static func determinant(matrix: [Double], n: Int) -> Double
+public static func determinant(matrix: [Double], n: Int) -> Double?
 ```
 
 - **Parameters:** `matrix` — row-major N×N matrix; `n` — dimension.
+- **Returns:** The determinant, or `nil` if `n`/`matrix` are invalid.
 - **Bounds:** `n` must be positive and `matrix.count` must equal `n * n` exactly, or this returns
-  `0.0` (#640). Before this bound, a mismatched positive `n` read past the end of `matrix` inside
-  the bridge.
+  `nil` (#640, revised by #716's review finding 7). Before this bound, a mismatched positive `n`
+  read past the end of `matrix` inside the bridge. `nil`, not `0.0`: `0.0` is also the determinant
+  of a genuinely singular matrix, so a bare `Double` sentinel could not distinguish an invalid
+  dimension from a real, correctly-computed zero. `n * n` is itself checked for overflow, so
+  `n: .max` is rejected rather than trapping the multiplication.
 - **OCCT:** `math_Gauss::Determinant` (via `OCCTMathGaussDeterminant`).
 
 ---
@@ -1275,7 +1279,9 @@ public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) 
 - **Bounds:** `rows` and `cols` must both be positive, and `matrix.count == rows * cols` /
   `rhs.count == rows` must hold, or this returns `nil` (#640). A consistency check alone is not
   enough: `rows: 0, cols: -1` satisfies `matrix.count == rows * cols` for any `matrix`, so the
-  positivity bound is required too.
+  positivity bound is required too. `rows * cols` is itself checked for overflow, so a huge
+  positive `rows`/`cols` is rejected rather than trapping the multiplication (#716's review
+  finding 8).
 - **OCCT:** `math_SVD::Solve` (via `OCCTMathSVDSolve`).
 - **Example:**
   ```swift
@@ -1331,6 +1337,8 @@ public static func eigenvalues(matrix: [Double], n: Int) -> [Double]?
 - **Bounds:** `n` must be positive and `matrix.count` must equal `n * n` exactly, or this returns
   `nil` (#640). `eigenvalues(matrix: [1.0], n: -1)` satisfies the consistency check alone
   (`1 == (-1) * (-1)`), which is why positivity is checked separately rather than folded into it.
+  `n * n` is itself checked for overflow, so `n: .max` is rejected rather than trapping the
+  multiplication (#716's review finding 8).
 - **OCCT:** `math_Jacobi::Values` (via `OCCTMathJacobiEigenvalues`).
 - **Example:**
   ```swift
@@ -1537,7 +1545,8 @@ public static func solve(matrix: [Double], rows: Int, cols: Int, rhs: [Double]) 
 - **Returns:** Solution vector of length N, or `nil` on failure or under-determined input.
 - **Bounds:** `rows` and `cols` must both be positive, in addition to `rows >= cols` and the
   existing `matrix`/`rhs` length checks, or this returns `nil` (#640): `rows >= cols` alone does
-  not exclude `rows: 0, cols: -1`.
+  not exclude `rows: 0, cols: -1`. `rows * cols` is itself checked for overflow (#716's review
+  finding 8).
 - **OCCT:** `math_Householder::Solve` (via `OCCTMathHouseholderSolve`).
 - **Example:**
   ```swift
@@ -1581,11 +1590,14 @@ public static func solve(matrix: [Double], rhs: [Double]) -> [Double]?
 Compute the determinant of a symmetric matrix via Crout factorisation.
 
 ```swift
-public static func determinant(matrix: [Double], n: Int) -> Double
+public static func determinant(matrix: [Double], n: Int) -> Double?
 ```
 
+- **Returns:** The determinant, or `nil` if `n`/`matrix` are invalid.
 - **Bounds:** `n` must be positive and `matrix.count` must equal `n * n` exactly, or this returns
-  `0.0` (#640), the same fix and for the same reason as `MathGauss.determinant`.
+  `nil` (#640, revised by #716's review finding 7), the same fix and for the same reason as
+  `MathGauss.determinant`: `nil`, not `0.0`, so an invalid dimension cannot be confused with a
+  genuinely singular matrix. `n * n` is itself checked for overflow (#716's review finding 8).
 - **OCCT:** `math_Crout::Determinant` (via `OCCTMathCroutDeterminant`).
 
 ---

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -747,7 +747,10 @@ public static func solveSystem(
   equal `variables`, or this returns `nil` (#640). None of this was checked before: a negative
   `variables` reached `Array(repeating:count:)` and trapped, and a positive `variables` that did
   not match `startPoint`'s real length reached the bridge's unconditional `startPoint[i]` loop
-  and read out of bounds.
+  and read out of bounds. `values`/`jacobian`'s own returned arrays are checked the same way
+  (#716's review findings 3/4): a `values` closure returning fewer than `equations` elements, or
+  a `jacobian` closure returning fewer than `equations * variables`, now fails the call (`nil`)
+  instead of indexing the short array and trapping.
 - **OCCT:** `math_FunctionSetRoot` via `OCCTMathFunctionSetRoot`.
 - **Example:**
   ```swift
@@ -781,7 +784,9 @@ public static func minimize(
 - **Returns:** `(minimizer, f(minimizer))`, or `nil` if not converged.
 - **Bounds:** `variables` must be positive and equal `startPoint.count`, or this returns `nil`
   (#640): a mismatched positive `variables` used to reach the bridge's unconditional
-  `startPoint[i]` loop and read out of bounds.
+  `startPoint[i]` loop and read out of bounds. `function`'s own returned `gradient` is checked
+  the same way (#716's review finding 5): a closure returning fewer than `variables` gradient
+  components now fails the call (`nil`) instead of trapping.
 - **OCCT:** `math_BFGS` via `OCCTMathBFGS`.
 - **Example:**
   ```swift
@@ -989,7 +994,8 @@ public static func solveSystemNewton(
 - **Parameters:** Same interface as `solveSystem`; internally uses `math_NewtonFunctionSetRoot`.
 - **Returns:** Solution array of length `variables`, or `nil`.
 - **Bounds:** Same as `solveSystem`: `variables` and `equations` must both be positive, and
-  `startPoint.count` must equal `variables`, or this returns `nil` (#640).
+  `startPoint.count` must equal `variables`, or this returns `nil` (#640), including the
+  `values`/`jacobian` closure-length check (#716's review finding 3/4).
 - **OCCT:** `math_NewtonFunctionSetRoot` via `OCCTMathNewtonFuncSetRoot`.
 - **Note:** More aggressive damping than `solveSystem`; prefer when starting close to the solution.
 
@@ -1564,7 +1570,10 @@ public static func minimizeNewton(
   - `function` — closure returning `(f(x), ∇f(x)[n], H(x)[n×n] row-major)`.
 - **Returns:** `(minimizer, f(minimizer))`, or `nil` if not converged.
 - **Bounds:** `n` must be positive and equal `startPoint.count`, or this returns `nil` (#640),
-  for the same reason as `minimize`.
+  for the same reason as `minimize`. `function`'s own returned `gradient` and `hessian` are
+  checked the same way (#716's review finding 5): a closure returning fewer than `n` gradient
+  components, or fewer than `n * n` Hessian components, now fails the call (`nil`) instead of
+  trapping.
 - **OCCT:** `math_NewtonMinimum` via `OCCTMathNewtonMinimum`.
 - **Note:** Quadratic convergence near the minimum; requires a positive-definite Hessian. Falls back gracefully but may not converge if the Hessian is indefinite away from the minimum — in that case, prefer `minimize` (BFGS).
 - **Example:**

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -743,6 +743,11 @@ public static func solveSystem(
   - `values` — closure returning equation values `F(x)`, length `equations`.
   - `jacobian` — closure returning the row-major Jacobian `J(x)`, length `equations × variables`.
 - **Returns:** Solution point array of length `variables`, or `nil` if not converged.
+- **Bounds:** `variables` and `equations` must both be positive, and `startPoint.count` must
+  equal `variables`, or this returns `nil` (#640). None of this was checked before: a negative
+  `variables` reached `Array(repeating:count:)` and trapped, and a positive `variables` that did
+  not match `startPoint`'s real length reached the bridge's unconditional `startPoint[i]` loop
+  and read out of bounds.
 - **OCCT:** `math_FunctionSetRoot` via `OCCTMathFunctionSetRoot`.
 - **Example:**
   ```swift
@@ -774,6 +779,9 @@ public static func minimize(
 
 - **Parameters:** `function` — closure returning `(f(x), ∇f(x))`.
 - **Returns:** `(minimizer, f(minimizer))`, or `nil` if not converged.
+- **Bounds:** `variables` must be positive and equal `startPoint.count`, or this returns `nil`
+  (#640): a mismatched positive `variables` used to reach the bridge's unconditional
+  `startPoint[i]` loop and read out of bounds.
 - **OCCT:** `math_BFGS` via `OCCTMathBFGS`.
 - **Example:**
   ```swift
@@ -807,6 +815,8 @@ public static func minimizePowell(
 
 - **Parameters:** `function` — closure returning a scalar value `f(x)`.
 - **Returns:** `(minimizer, f(minimizer))`, or `nil` if not converged.
+- **Bounds:** Same as `minimize`: `variables` must be positive and equal `startPoint.count`
+  (#640).
 - **OCCT:** `math_Powell` via `OCCTMathPowell`.
 - **Note:** Preferred when derivatives are unavailable or expensive; generally slower than BFGS for smooth functions.
 
@@ -862,6 +872,9 @@ public static func particleSwarm(
 
 - **Parameters:** `lower` / `upper` — per-variable bounds; `steps` — initial step sizes; `particles` — swarm size; `iterations` — number of swarm iterations.
 - **Returns:** `(minimizer, f(minimizer))`, or `nil` on failure.
+- **Bounds:** `variables` must be positive, and `lower`/`upper`/`steps` must each have
+  `variables` elements, or this returns `nil` (#640): none of this was checked before, so the
+  bridge's unconditional `lower[i]`/`upper[i]`/`steps[i]` loop read out of bounds on a mismatch.
 - **OCCT:** `math_PSO` via `OCCTMathPSO`.
 - **Note:** Good for highly multimodal or discontinuous objectives; does not require derivatives. Use `globalMinimize` for a deterministic alternative.
 
@@ -884,6 +897,8 @@ public static func globalMinimize(
 
 - **Parameters:** `lower` / `upper` — search domain bounds per variable; `function` — objective.
 - **Returns:** `(global minimizer, f(minimizer))`, or `nil` on failure.
+- **Bounds:** `variables` must be positive, and `lower`/`upper` must each have `variables`
+  elements, or this returns `nil` (#640), for the same reason as `particleSwarm`.
 - **OCCT:** `math_GlobOptMin` via `OCCTMathGlobOptMin`.
 - **Example:**
   ```swift
@@ -912,6 +927,10 @@ public static func findAllRoots(
 
 - **Parameters:** `samples` — number of sub-intervals for sign-change detection (more samples finds more roots but is slower).
 - **Returns:** Array of root values (may be empty). Up to 100 roots are returned.
+- **Bounds:** `samples` is a sampler by name and by role, not a problem dimension, so it is
+  bounded through `Sampling.requested` like every other subdivision count in this library:
+  outside `1...10,000,000` this returns `[]` instead of trapping `Int32(samples)` past
+  `Int32.max` (#640).
 - **OCCT:** `math_FunctionRoots` via `OCCTMathFunctionRoots`.
 - **Example:**
   ```swift
@@ -969,6 +988,8 @@ public static func solveSystemNewton(
 
 - **Parameters:** Same interface as `solveSystem`; internally uses `math_NewtonFunctionSetRoot`.
 - **Returns:** Solution array of length `variables`, or `nil`.
+- **Bounds:** Same as `solveSystem`: `variables` and `equations` must both be positive, and
+  `startPoint.count` must equal `variables`, or this returns `nil` (#640).
 - **OCCT:** `math_NewtonFunctionSetRoot` via `OCCTMathNewtonFuncSetRoot`.
 - **Note:** More aggressive damping than `solveSystem`; prefer when starting close to the solution.
 
@@ -1542,6 +1563,8 @@ public static func minimizeNewton(
   - `startPoint` — initial guess, length `n`.
   - `function` — closure returning `(f(x), ∇f(x)[n], H(x)[n×n] row-major)`.
 - **Returns:** `(minimizer, f(minimizer))`, or `nil` if not converged.
+- **Bounds:** `n` must be positive and equal `startPoint.count`, or this returns `nil` (#640),
+  for the same reason as `minimize`.
 - **OCCT:** `math_NewtonMinimum` via `OCCTMathNewtonMinimum`.
 - **Note:** Quadratic convergence near the minimum; requires a positive-definite Hessian. Falls back gracefully but may not converge if the Hessian is indefinite away from the minimum — in that case, prefer `minimize` (BFGS).
 - **Example:**

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -552,6 +552,9 @@ public static func findAllRoots(
 
 - **Parameters:** `range` — search interval; `samples` — number of sample points; `function` — value + derivative.
 - **Returns:** Array of root locations (may be empty).
+- **Bounds:** `samples` is bounded through `Sampling.requested` like the sibling
+  `findAllRoots(in:samples:function:)` overload: outside `1...10,000,000` this returns `[]`
+  instead of trapping `Int32(samples)` past `Int32.max` (#640).
 - **OCCT:** `OCCTMathFunctionAllRoots` → `math_FunctionAllRoots`.
 
 ---
@@ -569,6 +572,11 @@ public static func leastSquares(
 
 - **Parameters:** `matrix` — row-major matrix of size `rows × cols`; `rhs` — right-hand side vector.
 - **Returns:** Solution vector of length `cols`, or `nil` on failure.
+- **Bounds:** `rows` and `cols` must both be positive, and `matrix.count == rows * cols` /
+  `rhs.count == rows` must hold, or this returns `nil` (#640). Before this bound there was no
+  consistency check at all: a positive `rows`/`cols` that did not match `matrix`/`rhs`'s real
+  length reached the bridge's unconditional read loop and read out of bounds, rather than
+  failing.
 - **OCCT:** `OCCTMathGaussLeastSquare` → `math_GaussLeastSquare`.
 
 ---
@@ -609,6 +617,10 @@ public static func uzawa(
 
 - **Parameters:** `constraintMatrix` — row-major `nConstraints × nVars` matrix; `constraintRHS` — RHS vector; `startPoint` — initial guess.
 - **Returns:** `(solution, iterations)` or `nil` on failure.
+- **Bounds:** `nConstraints` and `nVars` must both be positive, and `constraintMatrix`/
+  `constraintRHS`/`startPoint` must each match them exactly, or this returns `nil` (#640). None
+  of this was checked before, so the bridge's unconditional read loops read out of bounds on any
+  mismatch.
 - **OCCT:** `OCCTMathUzawa` → `math_Uzawa`.
 
 ---
@@ -625,6 +637,10 @@ public static func eigenvalues(
 
 - **Parameters:** `diagonal` — n diagonal entries; `subdiagonal` — n entries (last unused).
 - **Returns:** Array of eigenvalues, or `nil` on failure.
+- **Bounds:** `subdiagonal.count` must equal `diagonal.count` exactly, or this returns `nil`
+  (#640). This "must be same length" was documentation only until #640: the bridge reads
+  `subdiagonal[i]` for `i in 0..<diagonal.count` unconditionally, so a shorter `subdiagonal`
+  used to read out of bounds rather than fail.
 - **OCCT:** `OCCTMathEigenValues` → `math_EigenVectors`.
 
 ---
@@ -640,6 +656,8 @@ public static func eigenvaluesAndVectors(
 ```
 
 - **Returns:** `(eigenvalues, eigenvectors)` where each eigenvector is a `[Double]` of length n, or `nil` on failure.
+- **Bounds:** Same as `eigenvalues(diagonal:subdiagonal:)`: `subdiagonal.count` must equal
+  `diagonal.count` exactly (#640).
 - **OCCT:** `OCCTMathEigenValuesAndVectors` → `math_EigenVectors`.
 
 ---
@@ -694,6 +712,10 @@ public static func gaussMultipleIntegration(
 
 - **Parameters:** `lower`/`upper` — integration bounds per dimension; `order` — Gauss point counts per dimension; `function` — n-variate integrand.
 - **Returns:** Integral value or `nil` on failure.
+- **Bounds:** `upper` and `order` must have the same length as `lower`, or this returns `nil`
+  (#640). The bridge derives the dimension count from `lower.count` alone and then reads
+  `upper[i]`/`order[i]` up to it unconditionally, so a shorter `upper` or `order` used to read
+  out of bounds.
 - **OCCT:** `OCCTMathGaussMultipleIntegration` → `math_GaussMultipleIntegration`.
 
 ---
@@ -712,6 +734,10 @@ public static func gaussSetIntegration(
 
 - **Parameters:** `nEquations` — number of integrals; `function` — closure mapping input vector to `nEquations`-length output.
 - **Returns:** Array of integral values (length `nEquations`), or `nil` on failure.
+- **Bounds:** `nEquations` must be positive, and `upper`/`order` must have the same length as
+  `lower`, or this returns `nil` (#640): the first was an `Array(repeating:count:)` trap on a
+  negative `nEquations`, and the second is the same unguarded read as
+  `gaussMultipleIntegration`.
 - **OCCT:** `OCCTMathGaussSetIntegration` → `math_GaussSetIntegration`.
 
 ---

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -576,7 +576,8 @@ public static func leastSquares(
   `rhs.count == rows` must hold, or this returns `nil` (#640). Before this bound there was no
   consistency check at all: a positive `rows`/`cols` that did not match `matrix`/`rhs`'s real
   length reached the bridge's unconditional read loop and read out of bounds, rather than
-  failing.
+  failing. `rows * cols` is itself checked for overflow, so a huge positive `rows`/`cols` is
+  rejected rather than trapping the multiplication (#716's review finding 8).
 - **OCCT:** `OCCTMathGaussLeastSquare` → `math_GaussLeastSquare`.
 
 ---
@@ -620,7 +621,7 @@ public static func uzawa(
 - **Bounds:** `nConstraints` and `nVars` must both be positive, and `constraintMatrix`/
   `constraintRHS`/`startPoint` must each match them exactly, or this returns `nil` (#640). None
   of this was checked before, so the bridge's unconditional read loops read out of bounds on any
-  mismatch.
+  mismatch. `nConstraints * nVars` is itself checked for overflow (#716's review finding 8).
 - **OCCT:** `OCCTMathUzawa` → `math_Uzawa`.
 
 ---
@@ -701,7 +702,8 @@ public static func kronrodIntegrateAdaptive(
 
 ### `MathSolver.gaussMultipleIntegration(lower:upper:order:function:)`
 
-Multi-dimensional Gauss-Legendre integration.
+Multi-dimensional Gauss-Legendre integration. Genuinely supports any number of variables:
+`math_GaussMultipleIntegration` integrates recursively over every dimension.
 
 ```swift
 public static func gaussMultipleIntegration(
@@ -717,12 +719,20 @@ public static func gaussMultipleIntegration(
   `upper[i]`/`order[i]` up to it unconditionally, so a shorter `upper` or `order` used to read
   out of bounds.
 - **OCCT:** `OCCTMathGaussMultipleIntegration` → `math_GaussMultipleIntegration`.
+- **Example:**
+  ```swift
+  let integral = MathSolver.gaussMultipleIntegration(
+      lower: [0, 0], upper: [1, 1], order: [10, 10]
+  ) { x in x[0] * x[0] + x[1] * x[1] }   // 2/3
+  ```
 
 ---
 
 ### `MathSolver.gaussSetIntegration(nEquations:lower:upper:order:function:)`
 
-Gauss-Legendre integration for a system of functions.
+Gauss-Legendre integration for a **set of functions of one variable**, each integrated
+separately. Unlike `gaussMultipleIntegration`, this does **not** support more than one
+integration variable: `lower` must have exactly one element.
 
 ```swift
 public static func gaussSetIntegration(
@@ -737,8 +747,28 @@ public static func gaussSetIntegration(
 - **Bounds:** `nEquations` must be positive, and `upper`/`order` must have the same length as
   `lower`, or this returns `nil` (#640): the first was an `Array(repeating:count:)` trap on a
   negative `nEquations`, and the second is the same unguarded read as
+  `gaussMultipleIntegration`. `function`'s own returned array is checked the same way as
+  `solveSystem`'s (#716's review finding 6): a closure returning fewer than `nEquations`
+  elements now fails the call (`nil`) instead of trapping.
+- **`lower` must also have exactly one element (#716's review finding 2).**
+  `math_GaussSetIntegration`'s own header documents "the case M>1 is not implemented": its
+  constructor only ever varies the *first* integration variable, leaving every other component
+  of its working vector unset. OCCT's own runtime check for this does not survive this
+  project's `No_Exception` production kernel build, so a call with more than one variable used
+  to silently succeed at the wrong answer instead of failing: measured directly,
+  `gaussSetIntegration(nEquations: 1, lower: [0, 0], upper: [1, 1], order: [10, 10])`
+  integrating `x + y` returned `0.5` (`∫x dx` over `[0, 1]` with `y` silently pinned at `0`), not
+  the `1.0` a genuine double integral of `x + y` over the unit square would be. This now returns
+  `nil` for `lower.count != 1` instead. For genuinely multi-variable integration, use
   `gaussMultipleIntegration`.
 - **OCCT:** `OCCTMathGaussSetIntegration` → `math_GaussSetIntegration`.
+- **Example:**
+  ```swift
+  // A "set" of two functions of the SAME one variable: integral of x and of x^2 over [0, 2].
+  let integrals = MathSolver.gaussSetIntegration(
+      nEquations: 2, lower: [0], upper: [2], order: [10]
+  ) { x in [x[0], x[0] * x[0]] }   // [2.0, 8.0/3.0]
+  ```
 
 ---
 


### PR DESCRIPTION
Closes #640

## The premise #634 got right, and the remedy it got wrong

#634 (issue #622) bounded 21 result-buffer capacities and deliberately left the math
solver/optimizer family alone: its numbers are problem *dimensions* that must agree with the
caller's own arrays, not sampling capacities, so `Sampling.requested`/`capacity` is the wrong
tool. That premise is correct. The remedy it suggested for a future fix, a consistency check
against the caller's arrays, is not, measured:

```swift
MathJacobi.eigenvalues(matrix: [1.0], n: -1)
// matrix.count == n * n holds exactly: 1 == (-1) * (-1)
// still aborts: Fatal error: Can't construct Array with count < 0
```

A consistency check alone cannot exclude this shape: whenever one factor of a product is zero,
the other is unconstrained. `MathSVD.solve` and `MathHouseholder.solve` have the identical gap.
A positivity bound closes it, alongside the consistency check, not instead of it.

**`MathSolver.leastSquares` is worse: it had no consistency check at all.** A `rows`/`cols` pair
that is positive but does not match `matrix`/`rhs`'s real length sails through and reaches the
bridge's `matA[i*nCols+j]`/`b[i]` loops, which read unconditionally. Confirmed in a standalone
process: `rows: 1000, cols: 1000` against a 1-element `matrix` crashes with `Bus error: 10`.

## The real affected set, against the issue's own list

The issue named 13 sites (itself a correction of #634's original 10). Re-deriving the census by
reading each candidate bridge function's C++ implementation, rather than trusting the trap-shaped
count either side had produced, found **20**, not 13. Five more were invisible to a trap-shaped
census because none of them constructs a `[Double]` sized by the vulnerable dimension:

- `MathGauss.determinant` / `MathCrout.determinant` return a scalar `Double`; the unconditional
  `matrixData[i*n+j]` loop is exactly `leastSquares`'s shape, with nothing to trap on. Both crash
  with `Bus error: 10` at `n: 1000` against a 1-element `matrix`.
- `MathSolver.eigenvalues(diagonal:subdiagonal:)` / `.eigenvaluesAndVectors` derive their
  dimension from `diagonal.count` (never negative), but read `subdiagonal[i]` up to it with no
  length check. The `///` doc already said "must be same length"; it was never enforced.
  Measured: a 50-element `diagonal` against a 1-element `subdiagonal` returns eigenvalues up to
  `1.17e+131`, silently.
- `MathSolver.gaussMultipleIntegration` derives `nVars` from `lower.count` and reads
  `upper[i]`/`order[i]` up to it the same unguarded way.

All 20 now require the dimension argument to be positive and every array it indexes into to
match it exactly:

| site | fix |
|---|---|
| `MathGauss.determinant`, `MathCrout.determinant` | `n > 0`, `matrix.count == n * n` |
| `MathSVD.solve`, `MathHouseholder.solve` | positivity added to the existing consistency check |
| `MathJacobi.eigenvalues` | positivity added to the existing consistency check |
| `MathSolver.solveSystem`, `.solveSystemNewton`, `.minimize`, `.minimizePowell`, `.minimizeNewton` | positivity + `startPoint.count == variables` (had neither) |
| `MathSolver.particleSwarm`, `.globalMinimize` | positivity + `lower`/`upper`/`steps.count == variables` (had neither) |
| `MathSolver.leastSquares` | full consistency + positivity (had neither) |
| `MathSolver.uzawa` | full consistency + positivity across all three arrays (had neither) |
| `MathSolver.eigenvalues`, `.eigenvaluesAndVectors` | `subdiagonal.count == diagonal.count` (new) |
| `MathSolver.gaussMultipleIntegration`, `.gaussSetIntegration` | array-length consistency (new) |

**Also in scope, reached by a different lens:** `findAllRoots(samples:)` (both overloads) is a
sampler by name and by role, not a problem dimension, despite trapping the same `Int32(_:)` way.
It now routes through `Sampling.requested` (#558's family) instead. Checked alongside it and
confirmed correctly excluded: `kronrodIntegrate`/`kronrodIntegrateAdaptive`/`integGauss`'s
`points`/`gaussPoints` select a quadrature rule order inside OCCT, not an array length; no bridge
function indexes anything by them, and a negative value is rejected cleanly via
`IsDone() == false`, measured, not assumed.

## Before / after, for the out-of-bounds site specifically

`MathSolver.leastSquares(matrix: [1.0], rows: 1000, cols: 1000, rhs: [1.0])`:

- **Before:** `Bus error: 10` (confirmed in a standalone process).
- **After:** `nil`.

Smaller mismatches were worse in a different way: before the fix, `rows: 3, cols: 3` against a
1-element `matrix` returned `nil` from a garbage-fed `IsDone()`, never a *reliable* failure, and
`MathSolver.solveSystem(variables: 50, startPoint: [1.0])` **succeeded**, returning a
fully-populated 50-element "solution" built from adjacent heap memory. Undefined behaviour, not a
guaranteed crash: the same point the "may return plausible numbers" framing in the issue makes.

## Injection matrix (prove-the-test-fails)

Every guard was validated by removing it and re-running `swift test --filter
Issue640MathDimensionBounds`, then restoring it. Four representative guards, covering both
failure shapes:

| guard removed | result | restored |
|---|---|---|
| `MathJacobi.eigenvalues`'s positivity bound | whole `swift test` process crashes (`exited with unexpected signal code 5`), test never reports | yes, green |
| `MathSolver.solveSystem`'s `startPoint.count == variables` check | ordinary test failure, garbage 50-element array printed in the assertion | yes, green |
| `MathSolver.eigenvalues`'s `subdiagonal.count == diagonal.count` check | ordinary test failure, eigenvalues up to `1.17e+131` printed | yes, green |
| `findAllRoots`'s `Sampling.requested` call | whole `swift test` process crashes, same as the positivity case | yes, green |

A fifth injection (`MathGauss.determinant`'s consistency check alone, positivity kept) did **not**
reproduce the crash inside `swift test`'s process, unlike the standalone probe, which crashed
reliably at the identical input. The read is undefined behaviour, not a guaranteed crash, and its
outcome depends on the process's own memory layout: recorded rather than glossed over.

Every one of the 20 sites was additionally exercised before and after the fix in a standalone
process (temporarily pointing `Sources/OCCTTest/main.swift` at a case-selecting probe, per the
`#705` technique), since a trap takes the whole harness down with it.

## What the issue and #634's reasoning got wrong

- #634's reasoning that a consistency check is the right remedy for this family was measured and
  is wrong on its own terms: it is *necessary*, not *sufficient*. A positivity bound is required
  alongside it.
- The issue's own "13" was itself incomplete: five more sites share the identical vulnerability
  but were invisible to the trap-shaped lens the census used, because their own dimension
  argument never traps a Swift array (it derives from another array's `.count`, or the function
  returns a scalar); only a *second* array they index into is unguarded.
- `findAllRoots(samples:)`'s inclusion is confirmed correct by measurement (traps past
  `Int32.max`, unaffected by consistency); `kronrodIntegrate`/`kronrodIntegrateAdaptive`/
  `integGauss`'s exclusion is also confirmed correct by measurement (no array indexed by
  `points`/`gaussPoints`, safely `IsDone() == false` on a negative value) rather than assumed from
  the issue's framing alone.

## Verify

- Clean `swift build`, 0 errors, no new warnings, no `OCCTSWIFT_LOCAL`.
- Full `swift test`: **5373 tests** (5356 baseline + 17 new), 0 failures, clean exit.
- `swift run Censuses cluster-a`: 45 rows. `cluster-b`: 16 rows.
- All four gate scripts (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
  `count-operations`) and their three `--self-test`s pass from the repo root.
- Zero em-dashes in the diff.
- `docs/SEMVER.md`: registered as recorded exception #14 (twenty entry points return `nil`/`0.0`/
  `[]` instead of trapping or reading out of bounds), and re-checked the counters at the top of
  the file, correcting a pre-existing drift found along the way (`#639`'s own back-reference
  still said "twelve" while the top of the file already said "thirteen").

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
