### PR TITLE
fix(#702): analyze()'s free-edge detection was dead code; isValidSolid already answers the demotion question

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -23,16 +23,16 @@ typedef struct {
     int32_t smallEdgeCount;        // Number of edges smaller than tolerance
     int32_t smallFaceCount;        // Number of faces smaller than tolerance
     int32_t gapCount;              // Number of gaps between edges/faces
-    int32_t selfIntersectionCount; // Always 0 -- never computed ("would require more expensive
+    int32_t selfIntersectionCount; // Always 0, never computed ("would require more expensive
                                     // computation", the implementation's own comment). Not a
                                     // measured value; use OCCTShapeSelfIntersects /
                                     // OCCTShapeSelfIntersectsBounded instead (#702).
     int32_t freeEdgeCount;         // Number of free (unconnected) edges, summed across every
                                     // shell of `shape`, via ShapeAnalysis_Shell::CheckOrientedShells
-                                    // (#702: this was hardcoded 0 before -- LoadShells() alone
+                                    // (#702: this was hardcoded 0 before, since LoadShells() alone
                                     // runs no edge analysis)
     int32_t freeFaceCount;         // Number of shells found to have at least one free edge above
-                                    // (i.e. not fully closed) -- same #702 fix
+                                    // (i.e. not fully closed); same #702 fix
     bool hasInvalidTopology;       // Whether topology is invalid
     bool isValid;                  // Whether analysis succeeded
 } OCCTShapeAnalysisResult;

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -23,9 +23,16 @@ typedef struct {
     int32_t smallEdgeCount;        // Number of edges smaller than tolerance
     int32_t smallFaceCount;        // Number of faces smaller than tolerance
     int32_t gapCount;              // Number of gaps between edges/faces
-    int32_t selfIntersectionCount; // Number of self-intersections
-    int32_t freeEdgeCount;         // Number of free (unconnected) edges
-    int32_t freeFaceCount;         // Number of free faces (shell not closed)
+    int32_t selfIntersectionCount; // Always 0 -- never computed ("would require more expensive
+                                    // computation", the implementation's own comment). Not a
+                                    // measured value; use OCCTShapeSelfIntersects /
+                                    // OCCTShapeSelfIntersectsBounded instead (#702).
+    int32_t freeEdgeCount;         // Number of free (unconnected) edges, summed across every
+                                    // shell of `shape`, via ShapeAnalysis_Shell::CheckOrientedShells
+                                    // (#702: this was hardcoded 0 before -- LoadShells() alone
+                                    // runs no edge analysis)
+    int32_t freeFaceCount;         // Number of shells found to have at least one free edge above
+                                    // (i.e. not fully closed) -- same #702 fix
     bool hasInvalidTopology;       // Whether topology is invalid
     bool isValid;                  // Whether analysis succeeded
 } OCCTShapeAnalysisResult;

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -147,10 +147,18 @@
 
 // MARK: - Shape Healing & Analysis (v0.13.0)
 
-// #717 review (findings 1 and 5, filed against #702): OCCTShapeAnalyze and OCCTShapeAnalyzeShell
+// Comments here name a #717 review finding by what it said, never by its number. That PR drew two
+// automated review passes and the second retracted the first, renumbering as it went: the
+// try/catch below was the first pass's finding 4, while the second pass's finding 4 is an
+// unrelated missing doc snippet. A bare ordinal is not a stable citation when the thing it indexes
+// can be reissued, and a cross-reference that silently comes to mean something else is worse than
+// none (the #549 tombstone lesson). Cite the substance.
+//
+// #717 review (the checkinternaledges divergence and the duplicated scan, filed against #702):
+// OCCTShapeAnalyze and OCCTShapeAnalyzeShell
 // both ran ShapeAnalysis_Shell::CheckOrientedShells and then read HasFreeEdges()/FreeEdges() off
-// it, hand-duplicated in each function. That duplication is how finding 1 happened: this file's
-// two copies drifted apart on the third argument, checkinternaledges, so the two entry points
+// it, hand-duplicated in each function. That duplication is how the divergence happened: this
+// file's two copies drifted apart on the third argument, checkinternaledges, so the two entry points
 // could silently disagree on a shell with a TopAbs_INTERNAL-oriented edge, contradicting the
 // #702 test's own "analyze() must agree with analyzeShell()" invariant. Per
 // ShapeAnalysis_Shell.cxx: an edge with no FORWARD/REVERSED partner is unconditionally free when
@@ -208,7 +216,7 @@ OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
         // never by LoadShells(); that hardcoded freeEdges/freeFaces to 0 for every shape, however
         // open, regardless of tolerance).
         //
-        // #717 review finding 4: CheckOrientedShells is a real OCCT computation now, not the
+        // #717 review (the missing per-shell try/catch): CheckOrientedShells is a real OCCT computation now, not the
         // near-no-op LoadShells() was, so it can raise Standard_Failure on a malformed shell. The
         // try/catch is scoped to one shell's iteration: a shell that throws contributes nothing to
         // freeEdges/freeFaces and the loop continues, rather than one bad shell discarding the

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -147,6 +147,42 @@
 
 // MARK: - Shape Healing & Analysis (v0.13.0)
 
+// #717 review (findings 1 and 5, filed against #702): OCCTShapeAnalyze and OCCTShapeAnalyzeShell
+// both ran ShapeAnalysis_Shell::CheckOrientedShells and then read HasFreeEdges()/FreeEdges() off
+// it, hand-duplicated in each function. That duplication is how finding 1 happened: this file's
+// two copies drifted apart on the third argument, checkinternaledges, so the two entry points
+// could silently disagree on a shell with a TopAbs_INTERNAL-oriented edge, contradicting the
+// #702 test's own "analyze() must agree with analyzeShell()" invariant. Per
+// ShapeAnalysis_Shell.cxx: an edge with no FORWARD/REVERSED partner is unconditionally free when
+// checkinternaledges is false, but is instead read as connected (through that occurrence) when
+// checkinternaledges is true and the same shape (by IsSame: same TShape and Location, ignoring
+// Orientation) also occurs with TopAbs_INTERNAL orientation elsewhere in the shell.
+// OCCTShapeAnalyzeShell already passed true; this scan now always does, for both callers, by
+// construction rather than by keeping two copies in sync by hand.
+struct OCCTShellOrientationScan {
+    bool checkResult = false;      // ShapeAnalysis_Shell::CheckOrientedShells' own return value
+    bool hasFreeEdges = false;
+    bool hasBadEdges = false;
+    bool hasConnectedEdges = false;
+    int freeEdgeCount = 0;
+};
+
+static OCCTShellOrientationScan occtAnalyzeShellOrientation(const TopoDS_Shape& shape) {
+    OCCTShellOrientationScan scan;
+    ShapeAnalysis_Shell analyzer;
+    scan.checkResult = analyzer.CheckOrientedShells(shape, /*alsofree*/ true, /*checkinternaledges*/ true);
+    scan.hasFreeEdges = analyzer.HasFreeEdges();
+    scan.hasBadEdges = analyzer.HasBadEdges();
+    scan.hasConnectedEdges = analyzer.HasConnectedEdges();
+    if (scan.hasFreeEdges) {
+        TopoDS_Compound freeEdgesCompound = analyzer.FreeEdges();
+        for (TopExp_Explorer edgeExp(freeEdgesCompound, TopAbs_EDGE); edgeExp.More(); edgeExp.Next()) {
+            scan.freeEdgeCount++;
+        }
+    }
+    return scan;
+}
+
 OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
     OCCTShapeAnalysisResult result = {0, 0, 0, 0, 0, 0, false, false};
     if (!shape) return result;
@@ -166,29 +202,30 @@ OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
         int smallFaces = 0;
         int gaps = 0;
 
-        // Analyze shells for free faces and closure.
+        // Analyze shells for free faces and closure, via the shared occtAnalyzeShellOrientation
+        // (see its comment above for the #702/#717 history: this used to call LoadShells(shell)
+        // and read HasFreeEdges()/FreeEdges(), which are populated only by CheckOrientedShells(),
+        // never by LoadShells(); that hardcoded freeEdges/freeFaces to 0 for every shape, however
+        // open, regardless of tolerance).
         //
-        // #702: this used to call LoadShells(shell) and then read HasFreeEdges()/FreeEdges().
-        // LoadShells() only registers the shell for NbLoaded()/Loaded() bookkeeping -- it runs
-        // no edge analysis at all. HasFreeEdges()/FreeEdges() read the myFree map, which only
-        // CheckOrientedShells() ever populates (see its header: "alsofree: free edges can be
-        // queried"). OCCTShapeAnalyzeShell below already calls CheckOrientedShells correctly;
-        // this was the one call site that did not. The result was that freeEdges/freeFaces were
-        // hardcoded to 0 for every shape passed to OCCTShapeAnalyze, however open -- silently
-        // hiding exactly the defect this scan exists to report.
+        // #717 review finding 4: CheckOrientedShells is a real OCCT computation now, not the
+        // near-no-op LoadShells() was, so it can raise Standard_Failure on a malformed shell. The
+        // try/catch is scoped to one shell's iteration: a shell that throws contributes nothing to
+        // freeEdges/freeFaces and the loop continues, rather than one bad shell discarding the
+        // free-edge counts already accumulated for prior shells and the smallEdge/smallFace/gap
+        // counts computed further below (an exception here used to escape to this function's
+        // outer catch, which resets the whole result to all-zero/invalid).
         for (TopExp_Explorer shellExp(shape->shape, TopAbs_SHELL); shellExp.More(); shellExp.Next()) {
             TopoDS_Shell shell = TopoDS::Shell(shellExp.Current());
-            ShapeAnalysis_Shell shellAnalysis;
-            shellAnalysis.CheckOrientedShells(shell, /*alsofree*/ true);
-
-            // Check for free faces
-            if (shellAnalysis.HasFreeEdges()) {
-                // Count free edges in shell
-                TopoDS_Compound freeEdgesCompound = shellAnalysis.FreeEdges();
-                for (TopExp_Explorer edgeExp(freeEdgesCompound, TopAbs_EDGE); edgeExp.More(); edgeExp.Next()) {
-                    freeEdges++;
+            try {
+                OCCTShellOrientationScan scan = occtAnalyzeShellOrientation(shell);
+                if (scan.hasFreeEdges) {
+                    freeEdges += scan.freeEdgeCount;
+                    freeFaces++;   // this shell is not fully closed (freeFaceCount's own contract)
                 }
-                freeFaces++;   // this shell is not fully closed (freeFaceCount's own contract)
+            } catch (...) {
+                // Skip just this shell's contribution; other shells and the categories below
+                // still get computed.
             }
         }
 
@@ -3420,20 +3457,15 @@ OCCTShapeRef OCCTShapeFixEdgeConnect(OCCTShapeRef shape) {
 
 OCCTShellAnalysisResult OCCTShapeAnalyzeShell(OCCTShapeRef shape) {
     OCCTShellAnalysisResult result = {false, false, false, false, 0};
+    if (!shape) return result;
     try {
-        ShapeAnalysis_Shell analyzer;
-        // CheckOrientedShells returns true if BAD orientation found
-        result.hasOrientationProblems = analyzer.CheckOrientedShells(shape->shape, true, true);
-        result.hasFreeEdges = analyzer.HasFreeEdges();
-        result.hasBadEdges = analyzer.HasBadEdges();
-        result.hasConnectedEdges = analyzer.HasConnectedEdges();
-        if (result.hasFreeEdges) {
-            TopoDS_Compound freeEdges = analyzer.FreeEdges();
-            TopExp_Explorer edgeExp(freeEdges, TopAbs_EDGE);
-            int count = 0;
-            while (edgeExp.More()) { count++; edgeExp.Next(); }
-            result.freeEdgeCount = count;
-        }
+        // Shared with OCCTShapeAnalyze's per-shell loop above; see its comment for why (#717).
+        OCCTShellOrientationScan scan = occtAnalyzeShellOrientation(shape->shape);
+        result.hasOrientationProblems = scan.checkResult;  // true if BAD orientation found
+        result.hasFreeEdges = scan.hasFreeEdges;
+        result.hasBadEdges = scan.hasBadEdges;
+        result.hasConnectedEdges = scan.hasConnectedEdges;
+        result.freeEdgeCount = scan.freeEdgeCount;
     } catch (...) {}
     return result;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -166,11 +166,20 @@ OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
         int smallFaces = 0;
         int gaps = 0;
 
-        // Analyze shells for free faces and closure
+        // Analyze shells for free faces and closure.
+        //
+        // #702: this used to call LoadShells(shell) and then read HasFreeEdges()/FreeEdges().
+        // LoadShells() only registers the shell for NbLoaded()/Loaded() bookkeeping -- it runs
+        // no edge analysis at all. HasFreeEdges()/FreeEdges() read the myFree map, which only
+        // CheckOrientedShells() ever populates (see its header: "alsofree: free edges can be
+        // queried"). OCCTShapeAnalyzeShell below already calls CheckOrientedShells correctly;
+        // this was the one call site that did not. The result was that freeEdges/freeFaces were
+        // hardcoded to 0 for every shape passed to OCCTShapeAnalyze, however open -- silently
+        // hiding exactly the defect this scan exists to report.
         for (TopExp_Explorer shellExp(shape->shape, TopAbs_SHELL); shellExp.More(); shellExp.Next()) {
             TopoDS_Shell shell = TopoDS::Shell(shellExp.Current());
             ShapeAnalysis_Shell shellAnalysis;
-            shellAnalysis.LoadShells(shell);
+            shellAnalysis.CheckOrientedShells(shell, /*alsofree*/ true);
 
             // Check for free faces
             if (shellAnalysis.HasFreeEdges()) {
@@ -179,6 +188,7 @@ OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
                 for (TopExp_Explorer edgeExp(freeEdgesCompound, TopAbs_EDGE); edgeExp.More(); edgeExp.Next()) {
                     freeEdges++;
                 }
+                freeFaces++;   // this shell is not fully closed (freeFaceCount's own contract)
             }
         }
 

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -220,6 +220,12 @@ extension Shape {
 
     /// Analyze a shape for problems such as small edges, gaps, and invalid topology.
     ///
+    /// - Note: `selfIntersectionCount` is always 0, and has never been computed, see
+    ///   ``ShapeAnalysisResult/selfIntersectionCount``; use ``isSelfIntersecting(timeout:)`` for a
+    ///   real check. `freeEdgeCount`/`freeFaceCount` were also hardcoded to 0 for every shape
+    ///   before #702; a demoted or otherwise open shell now reports its actual gap correctly.
+    ///   A "clean" result here has never meant "this is a solid": check `shapeType` or
+    ///   ``isValidSolid`` for that.
     /// - Parameter tolerance: Size threshold for detecting small features
     /// - Returns: Analysis result with problem counts, or nil on failure
     ///

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -1260,8 +1260,13 @@ public extension Shape {
     ///   ```
     ///
     ///   When a single body came back, the result is that body rather than a compound, so
-    ///   `healed.shapeType == .shell` answers it directly. A body that came back *unhealed*
-    ///   is still a solid — use ``Shape/isValid`` for that.
+    ///   `healed.shapeType == .shell` answers it directly, or check ``Shape/isValidSolid``
+    ///   directly, which does the same `shapeType == .solid` test itself before its own
+    ///   `BRepCheck_Analyzer` pass, so it reads `false` on a demoted shell where plain
+    ///   ``Shape/isValid`` reads `true` (#702: a demoted shell has no closure requirement of its
+    ///   own, so it is genuinely, unmisleadingly valid, just not a solid any more). A body that
+    ///   came back *unhealed* is still a solid: use ``Shape/isValid`` for that, or
+    ///   ``Shape/isValidSolid`` for both checks in one.
     ///
     /// ```swift
     /// let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -743,12 +743,30 @@ public final class Shape: @unchecked Sendable {
 
     // MARK: - Validation
 
-    /// Check if shape is valid
+    /// Check if shape is valid (`BRepCheck_Analyzer`).
+    ///
+    /// - Note: This checks whatever `shapeType` the receiver already has, and a well-formed
+    ///   **open** shell reports `true` here just as readily as a closed one, since a shell has
+    ///   no closure requirement of its own. It does not detect 3D self-intersection either. So
+    ///   `isValid == true` never implies "this is a solid" or "this does not overlap itself"; use
+    ///   ``isValidSolid`` for the former and ``isSelfIntersecting(timeout:)`` for the latter
+    ///   (#702).
     public var isValid: Bool {
         OCCTShapeIsValid(handle)
     }
 
-    /// Attempt to repair/heal the shape
+    /// Attempt to repair/heal the shape, using `ShapeFix_Shape`.
+    ///
+    /// - Warning: For solid input, this can return a **shell** instead of a repaired solid.
+    ///   `ShapeFix_Shape` delegates to `ShapeFix_Solid` for every solid it finds, and
+    ///   `ShapeFix_Solid` hands back the shell unpromoted whenever it cannot close it, the same
+    ///   mechanism ``Shape/fixSolid()`` documents at length, since it wraps `ShapeFix_Solid`
+    ///   directly. The demoted shell is not flagged by ``isValid`` or ``volume``: a shell has no
+    ///   closure requirement of its own, so it can report `isValid == true` and a correct
+    ///   `volume` even though the input used to be a solid and no longer is (#702). Check
+    ///   ``isValidSolid`` (single body) or `shapeType`/`subShapeCount(ofType: .solid)`
+    ///   (multi-body) if the caller depends on getting a solid back, rather than inferring it
+    ///   from `isValid` or `volume`.
     public func healed() -> Shape? {
         guard let handle = OCCTShapeHeal(self.handle) else { return nil }
         return Shape(handle: handle)
@@ -2007,6 +2025,13 @@ public final class Shape: @unchecked Sendable {
     /// booleans (it made `subtracting` hang indefinitely before #206 bounded it). To screen
     /// for that, use ``isSelfIntersecting(timeout:)``. See also ``signedVolume`` /
     /// ``orientedForward()`` for the separate reversed-orientation hazard.
+    ///
+    /// This is also the reliable way to notice a ``healed()``/``fixSolid()`` demotion: both
+    /// check `shapeType` first and return `false` immediately when it is anything but `.solid`,
+    /// so a shell they could not close reads `false` here even though it reads `true` for
+    /// plain ``isValid`` (#702). It answers a single body directly; for a multi-body result
+    /// (a compound of solids), check each child, or `subShapeCount(ofType: .solid)` against the
+    /// input body count, since the compound itself is never typed `.solid`.
     public var isValidSolid: Bool {
         OCCTShapeIsValidSolid(handle)
     }

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -751,6 +751,19 @@ public final class Shape: @unchecked Sendable {
     ///   `isValid == true` never implies "this is a solid" or "this does not overlap itself"; use
     ///   ``isValidSolid`` for the former and ``isSelfIntersecting(timeout:)`` for the latter
     ///   (#702).
+    ///
+    /// ```swift
+    /// // A box missing one face, wrapped as a "solid" with no fixing, then healed: the open
+    /// // shell cannot be closed, so it comes back demoted to a shell.
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let faces = box.subShapes(ofType: .face)
+    /// let openShell = Shape.compound(Array(faces.dropFirst()))!.sewn()!
+    /// let demoted = Shape.solidFromShells([openShell])!.healed()!
+    ///
+    /// print(demoted.shapeType)    // .shell: could not close, demoted from the "solid" input
+    /// print(demoted.isValid)      // true: a well-formed shell has no closure requirement
+    /// print(demoted.isValidSolid) // false: this is the check that actually catches it
+    /// ```
     public var isValid: Bool {
         OCCTShapeIsValid(handle)
     }
@@ -767,6 +780,20 @@ public final class Shape: @unchecked Sendable {
     ///   ``isValidSolid`` (single body) or `shapeType`/`subShapeCount(ofType: .solid)`
     ///   (multi-body) if the caller depends on getting a solid back, rather than inferring it
     ///   from `isValid` or `volume`.
+    ///
+    /// ```swift
+    /// // An open shell (a box missing one face) wrapped as a "solid" with no fixing at all,
+    /// // then healed: ShapeFix_Solid cannot close it, so healed() demotes it to a shell.
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let faces = box.subShapes(ofType: .face)
+    /// let openShell = Shape.compound(Array(faces.dropFirst()))!.sewn()!
+    /// let fakeSolid = Shape.solidFromShells([openShell])!
+    ///
+    /// let healed = fakeSolid.healed()!
+    /// print(healed.shapeType)    // .shell: demoted, not a repaired solid
+    /// print(healed.isValid)      // true: the demotion is invisible here
+    /// print(healed.isValidSolid) // false: check this instead when a solid is required
+    /// ```
     public func healed() -> Shape? {
         guard let handle = OCCTShapeHeal(self.handle) else { return nil }
         return Shape(handle: handle)
@@ -2032,6 +2059,19 @@ public final class Shape: @unchecked Sendable {
     /// plain ``isValid`` (#702). It answers a single body directly; for a multi-body result
     /// (a compound of solids), check each child, or `subShapeCount(ofType: .solid)` against the
     /// input body count, since the compound itself is never typed `.solid`.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.isValidSolid)   // true: a genuine closed solid
+    ///
+    /// // A box missing one face, wrapped as a "solid" with no fixing, then healed: the open
+    /// // shell cannot be closed, so healed() demotes it, and only isValidSolid catches it.
+    /// let faces = box.subShapes(ofType: .face)
+    /// let openShell = Shape.compound(Array(faces.dropFirst()))!.sewn()!
+    /// let demoted = Shape.solidFromShells([openShell])!.healed()!
+    /// print(demoted.isValid)      // true: a well-formed shell, no closure requirement
+    /// print(demoted.isValidSolid) // false: catches the demotion isValid misses
+    /// ```
     public var isValidSolid: Bool {
         OCCTShapeIsValidSolid(handle)
     }

--- a/Sources/OCCTSwift/ShapeAnalysisResult.swift
+++ b/Sources/OCCTSwift/ShapeAnalysisResult.swift
@@ -13,13 +13,23 @@ public struct ShapeAnalysisResult {
     /// Number of gaps between edges/faces
     public let gapCount: Int
 
-    /// Number of self-intersections detected
+    /// Always 0. This has never been computed: the bridge's own comment on the field
+    /// reads "would require more expensive computation", so it is not a measured absence of
+    /// self-intersection, only an unimplemented one. Use ``Shape/isSelfIntersecting(timeout:)``
+    /// for a real answer (#702).
     public let selfIntersectionCount: Int
 
-    /// Number of free (unconnected) edges
+    /// Number of free (unconnected) edges across every shell of the analyzed shape, via
+    /// `ShapeAnalysis_Shell`. Before #702 this was hardcoded to 0 for every shape: the bridge
+    /// called `LoadShells()`, which only registers a shell for bookkeeping and runs no edge
+    /// analysis, instead of `CheckOrientedShells()`, which is what actually populates the
+    /// free-edge set. A shape with a genuine gap, an open shell, or a solid `healed()`/
+    /// `fixSolid()` could not close and returned as a shell instead, read 0 here regardless.
     public let freeEdgeCount: Int
 
-    /// Number of free faces (shell not closed)
+    /// Number of shells, among every shell of the analyzed shape, found to have at least one
+    /// free edge (i.e. not fully closed). Same #702 fix as ``freeEdgeCount``, since both come
+    /// from the same per-shell scan.
     public let freeFaceCount: Int
 
     /// Whether the topology is invalid

--- a/Sources/OCCTSwift/ShapeAnalysisResult.swift
+++ b/Sources/OCCTSwift/ShapeAnalysisResult.swift
@@ -30,14 +30,26 @@ public struct ShapeAnalysisResult {
     /// Number of shells, among every shell of the analyzed shape, found to have at least one
     /// free edge (i.e. not fully closed). Same #702 fix as ``freeEdgeCount``, since both come
     /// from the same per-shell scan.
+    ///
+    /// Not counted in ``totalProblems``: this is a derived summary of the same scan, not an
+    /// independent defect. It is never nonzero unless ``freeEdgeCount`` is also nonzero (a shell
+    /// only contributes here because it has at least one free edge, which ``freeEdgeCount``
+    /// already counted), so adding both would count one open shell's boundary gap twice, once per
+    /// edge and once more as a flat "+1 shell" (#717 review).
     public let freeFaceCount: Int
 
     /// Whether the topology is invalid
     public let hasInvalidTopology: Bool
 
-    /// Total number of problems found
+    /// Total number of problems found.
+    ///
+    /// Sums each independent defect category once: small edges, small faces, gaps,
+    /// self-intersections (never actually measured, see ``selfIntersectionCount``), free edges,
+    /// and invalid topology (a flat +1, not a count). ``freeFaceCount`` is deliberately excluded:
+    /// see its doc comment for why including it would double-count the same open-shell defect
+    /// ``freeEdgeCount`` already reports.
     public var totalProblems: Int {
-        smallEdgeCount + smallFaceCount + gapCount + selfIntersectionCount + freeEdgeCount + freeFaceCount + (hasInvalidTopology ? 1 : 0)
+        smallEdgeCount + smallFaceCount + gapCount + selfIntersectionCount + freeEdgeCount + (hasInvalidTopology ? 1 : 0)
     }
 
     /// Whether the shape appears to be healthy (no problems found)

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -355,7 +355,7 @@ struct Issue442FixSolidMultiBody {
         }
         // An open shell that wraps the hollow body: the big box's faces minus one, sewn.
         // (`sewnBoxMissingOneFace`, `ShapeHealingTestFixtures.swift`, shared with
-        // Issue702SolidDemotionTests, #717 review finding 5.)
+        // Issue702SolidDemotionTests, #717 review, the duplicated open-shell fixture.)
         guard let openQuilt = sewnBoxMissingOneFace(bigBox),
               let openShell = openQuilt.shells.first
         else {

--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -354,9 +354,9 @@ struct Issue442FixSolidMultiBody {
             return
         }
         // An open shell that wraps the hollow body: the big box's faces minus one, sewn.
-        let faces = bigBox.subShapes(ofType: .face)
-        #expect(faces.count == 6)
-        guard let openQuilt = Shape.compound(Array(faces.dropFirst()))?.sewn(tolerance: 1e-6),
+        // (`sewnBoxMissingOneFace`, `ShapeHealingTestFixtures.swift`, shared with
+        // Issue702SolidDemotionTests, #717 review finding 5.)
+        guard let openQuilt = sewnBoxMissingOneFace(bigBox),
               let openShell = openQuilt.shells.first
         else {
             Issue.record("could not sew the open shell")

--- a/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
@@ -38,15 +38,12 @@ import simd
 struct Issue702SolidDemotion {
 
     /// A box with one face dropped, sewn into an open shell: the smallest input that reaches
-    /// `ShapeFix_Solid`'s "cannot close" branch. 4 free edges ring the missing face.
+    /// `ShapeFix_Solid`'s "cannot close" branch. 4 free edges ring the missing face. Delegates to
+    /// `sewnBoxMissingOneFace(_:tolerance:)` (`ShapeHealingTestFixtures.swift`), shared with
+    /// `Issue442FixSolidMultiBodyTests` (#717 review finding 5).
     private func openShellMissingOneFace() -> Shape? {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
-        let faces = box.subShapes(ofType: .face)
-        guard faces.count == 6,
-              let compound = Shape.compound(Array(faces.dropFirst())),
-              let openShell = compound.sewn(tolerance: 1e-6)
-        else { return nil }
-        return openShell
+        return sewnBoxMissingOneFace(box)
     }
 
     /// Wraps an open shell as a `TopoDS_Solid` with no fixing at all: `Shape.solidFromShells`

--- a/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
@@ -40,7 +40,7 @@ struct Issue702SolidDemotion {
     /// A box with one face dropped, sewn into an open shell: the smallest input that reaches
     /// `ShapeFix_Solid`'s "cannot close" branch. 4 free edges ring the missing face. Delegates to
     /// `sewnBoxMissingOneFace(_:tolerance:)` (`ShapeHealingTestFixtures.swift`), shared with
-    /// `Issue442FixSolidMultiBodyTests` (#717 review finding 5).
+    /// `Issue442FixSolidMultiBodyTests` (#717 review, the duplicated open-shell fixture).
     private func openShellMissingOneFace() -> Shape? {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
         return sewnBoxMissingOneFace(box)
@@ -160,7 +160,7 @@ struct Issue702SolidDemotion {
         #expect(analysis.freeEdgeCount == shellAnalysis.freeEdgeCount,
                 "analyze() must agree with the already-correct analyzeShell()")
         #expect(analysis.freeFaceCount == 1, "one shell, and it is not fully closed")
-        // #717 review finding 2: totalProblems must count this shell's free edges once, not once
+        // #717 review (the totalProblems double-count): totalProblems must count this shell's free edges once, not once
         // via freeEdgeCount and again as +1 via freeFaceCount for the same open shell. The expected
         // sum is recomputed from the other fields, not hardcoded: this fixture also measures a
         // nonzero gapCount (a pre-existing, unrelated characteristic of a box-minus-one-face sewn
@@ -188,7 +188,7 @@ struct Issue702SolidDemotion {
         #expect(analysis.freeEdgeCount == 4)
         #expect(analysis.freeFaceCount == 1)
         #expect(!analysis.isHealthy, "a shape with real free edges must not report healthy")
-        // #717 review finding 2, same reasoning as analyzeReportsFreeEdgesOnOpenShell above.
+        // #717 review (the totalProblems double-count), same reasoning as analyzeReportsFreeEdgesOnOpenShell above.
         let expected = Self.totalProblemsExcludingFreeFace(analysis)
         #expect(analysis.totalProblems == expected)
         #expect(analysis.totalProblems != expected + analysis.freeFaceCount,
@@ -223,7 +223,7 @@ struct Issue702SolidDemotion {
         }
         #expect(analysis.freeEdgeCount == 8, "4 free edges per shell, two shells")
         #expect(analysis.freeFaceCount == 2, "both shells are open")
-        // #717 review finding 2, same reasoning as analyzeReportsFreeEdgesOnOpenShell above.
+        // #717 review (the totalProblems double-count), same reasoning as analyzeReportsFreeEdgesOnOpenShell above.
         let expected = Self.totalProblemsExcludingFreeFace(analysis)
         #expect(analysis.totalProblems == expected)
         #expect(analysis.totalProblems != expected + analysis.freeFaceCount,
@@ -241,7 +241,7 @@ struct Issue702SolidDemotion {
             (analysis.hasInvalidTopology ? 1 : 0)
     }
 
-    // MARK: - checkinternaledges must match between analyze() and analyzeShell() (#717 review finding 1)
+    // MARK: - checkinternaledges must match between analyze() and analyzeShell() (#717 review, the checkinternaledges divergence)
 
     /// A single square face wrapped directly as a shell (`TopoDS_Builder::MakeShell` + `Add`, no
     /// sewing at all), with an `.internal`-oriented duplicate of one of its own 4 boundary edges

--- a/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
@@ -1,0 +1,215 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #702: `Shape.healed()` and `Shape.fixSolid()` can reach `isValid == true` by demoting a
+/// solid to a shell, and `Shape.analyze(tolerance:)` reported the demoted shell as perfectly
+/// clean (zero free edges) even though it genuinely was not closed.
+///
+/// The issue's own reproducer (a `ThruSectionsBuilder` loft through a 36-tooth bevel gear's six
+/// section wires, 1152 points each) was measured on OCCT v1.17.0. It does **not** reproduce on
+/// this branch (OCCT 8.0.1 + patches): three independent reconstructions, matching gear-tooth
+/// polygons at various tooth counts/tapers/twists, a dense sinusoidal profile, and a faithful
+/// port of `OCCTSwiftScripts/recipes/04-spur-gear`'s involute math scaled per section (matching
+/// the issue's own 1152-points-per-wire figure exactly at `flankSamples = 14`), all produced a
+/// `BRepCheck_Analyzer`-valid raw loft, across 400+ parameter combinations, so nothing ever
+/// reached `healed()`/`fixSolid()` in a state that could demote. `BRepCheck_Analyzer` itself
+/// does not flag 3D self-intersection between non-adjacent faces either way (confirmed directly:
+/// a deliberately self-intersecting 179-degree-twisted star prism still reports `isValid == true`).
+///
+/// The demotion mechanism itself is real, already correctly documented for `fixSolid()` since
+/// #442, and reproduces trivially with no loft at all: an OPEN shell (a box missing one face)
+/// wrapped as a `TopoDS_Solid`, exactly what `Shape.solidFromShells(_:)` does with a single
+/// non-closed shell, is a "solid" `BRepCheck_Analyzer` correctly rejects, and `ShapeFix_Solid`
+/// correctly refuses to close (an open shell cannot become one). What the issue could not find
+/// was a way to tell: `isValid` reads `true` on the demoted shell (a shell has no closure
+/// requirement of its own), and `analyze(tolerance:)` read zero free edges regardless of the
+/// input, because `OCCTShapeAnalyze` called `ShapeAnalysis_Shell::LoadShells()`, which only
+/// registers a shell for bookkeeping, instead of `CheckOrientedShells()`, the call that actually
+/// populates the free-edge set. Fixed in `OCCTBridge_Healing.mm`.
+///
+/// `Shape.isValidSolid` already existed (added for #206/#208, an unrelated self-intersection
+/// hazard) and already answers the issue's question correctly, unaffected by either bug: it
+/// checks `shapeType == .solid` before running `BRepCheck_Analyzer`, so it reads `false` on any
+/// demoted shell. It had no test at all for that specific branch: every existing use only
+/// asserted the positive (already-a-valid-solid) case.
+@Suite("Issue 702: solid demotion is honestly reported")
+struct Issue702SolidDemotion {
+
+    /// A box with one face dropped, sewn into an open shell: the smallest input that reaches
+    /// `ShapeFix_Solid`'s "cannot close" branch. 4 free edges ring the missing face.
+    private func openShellMissingOneFace() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        let faces = box.subShapes(ofType: .face)
+        guard faces.count == 6,
+              let compound = Shape.compound(Array(faces.dropFirst())),
+              let openShell = compound.sewn(tolerance: 1e-6)
+        else { return nil }
+        return openShell
+    }
+
+    /// Wraps an open shell as a `TopoDS_Solid` with no fixing at all: `Shape.solidFromShells`
+    /// on a single non-closed shell does exactly this (`BRepBuilderAPI_MakeSolid`, which does not
+    /// require or check closure). This is the issue's "raw loft (isSolid: true): ... valid=false"
+    /// row, reached without any loft.
+    private func fakeSolid() -> Shape? {
+        guard let shell = openShellMissingOneFace() else { return nil }
+        return Shape.solidFromShells([shell])
+    }
+
+    // MARK: - The fixture demotes (prove it before trusting any assertion about it)
+
+    @Test("the fake solid is BRepCheck-invalid before healing")
+    func fakeSolidIsInvalid() {
+        guard let fake = fakeSolid() else {
+            Issue.record("could not build the fake solid fixture")
+            return
+        }
+        #expect(fake.shapeType == .solid)
+        #expect(!fake.isValid, "an open shell wrapped as a solid must be invalid before healing")
+    }
+
+    @Test("fixSolid demotes the fake solid to a shell, matching #442's documented contract")
+    func fixSolidDemotes() {
+        guard let fake = fakeSolid() else {
+            Issue.record("could not build the fake solid fixture")
+            return
+        }
+        guard let fixed = fake.fixSolid() else {
+            Issue.record("fixSolid returned nil")
+            return
+        }
+        #expect(fixed.shapeType == .shell, "an open shell cannot be closed; demotion is correct")
+        #expect(fixed.isValid, "the demoted shell is genuinely well-formed, just not a solid")
+    }
+
+    @Test("healed demotes the fake solid to a shell, the same as fixSolid")
+    func healedDemotes() {
+        guard let fake = fakeSolid() else {
+            Issue.record("could not build the fake solid fixture")
+            return
+        }
+        guard let healed = fake.healed() else {
+            Issue.record("healed returned nil")
+            return
+        }
+        #expect(healed.shapeType == .shell)
+        #expect(healed.isValid)
+    }
+
+    // MARK: - isValid cannot tell a demoted shell from a healthy one (the issue's own complaint)
+
+    @Test("isValid alone does not distinguish a demoted shell from a healthy solid")
+    func isValidAloneIsAmbiguous() {
+        guard let fake = fakeSolid(), let fixed = fake.fixSolid(),
+              let box = Shape.box(width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build fixtures")
+            return
+        }
+        // Both read true. isValid alone genuinely cannot tell them apart -- that is the bug.
+        #expect(fixed.isValid)
+        #expect(box.isValid)
+        #expect(fixed.shapeType != box.shapeType, "but they are not the same kind of shape")
+    }
+
+    // MARK: - isValidSolid already answers it correctly (pre-existing, now proven for this branch)
+
+    @Test("isValidSolid is false on a demoted shell, true on a genuine solid")
+    func isValidSolidDistinguishesDemotion() {
+        guard let fake = fakeSolid(), let fixed = fake.fixSolid(), let healed = fake.healed(),
+              let box = Shape.box(width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build fixtures")
+            return
+        }
+        #expect(!fixed.isValidSolid, "fixSolid's demoted shell must fail isValidSolid")
+        #expect(!healed.isValidSolid, "healed's demoted shell must fail isValidSolid")
+        #expect(box.isValidSolid, "a genuine closed solid must pass isValidSolid")
+    }
+
+    @Test("isValidSolid is false on non-solid shape types generally")
+    func isValidSolidFalseOnNonSolidTypes() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
+        }
+        let faces = box.subShapes(ofType: .face)
+        guard let face = faces.first, let shell = box.shells.first else {
+            Issue.record("could not get a face/shell from the box")
+            return
+        }
+        #expect(!face.isValidSolid, "a bare face is not a solid")
+        #expect(!shell.isValidSolid, "a bare shell is not a solid, even a closed one")
+        #expect(box.isValidSolid, "the box itself is a genuine solid")
+    }
+
+    // MARK: - analyze(tolerance:) free-edge/free-face reporting (the #702 bridge fix)
+
+    @Test("analyze reports the open shell's free edges, matching analyzeShell")
+    func analyzeReportsFreeEdgesOnOpenShell() {
+        guard let shell = openShellMissingOneFace() else {
+            Issue.record("could not build the open shell fixture")
+            return
+        }
+        guard let analysis = shell.analyze(tolerance: 1e-6) else {
+            Issue.record("analyze returned nil")
+            return
+        }
+        let shellAnalysis = shell.analyzeShell()
+        #expect(shellAnalysis.hasFreeEdges)
+        #expect(shellAnalysis.freeEdgeCount == 4, "4 edges ring the one missing face")
+        #expect(analysis.freeEdgeCount == shellAnalysis.freeEdgeCount,
+                "analyze() must agree with the already-correct analyzeShell()")
+        #expect(analysis.freeFaceCount == 1, "one shell, and it is not fully closed")
+    }
+
+    @Test("analyze reports the demoted fixSolid shell's free edges too")
+    func analyzeReportsFreeEdgesOnDemotedShell() {
+        guard let fake = fakeSolid(), let fixed = fake.fixSolid() else {
+            Issue.record("could not build the demoted-shell fixture")
+            return
+        }
+        guard let analysis = fixed.analyze(tolerance: 1e-6) else {
+            Issue.record("analyze returned nil")
+            return
+        }
+        // This is the issue's own reported evidence, corrected: before #702's fix this read 0
+        // regardless of input. The demoted shell genuinely has the same 4 free edges as the
+        // open shell it was built from -- ShapeFix_Solid does not add or remove faces.
+        #expect(analysis.freeEdgeCount == 4)
+        #expect(analysis.freeFaceCount == 1)
+        #expect(!analysis.isHealthy, "a shape with real free edges must not report healthy")
+    }
+
+    @Test("analyze reports zero free edges/faces on a genuinely closed solid")
+    func analyzeReportsNoFreeEdgesOnClosedBox() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build a box")
+            return
+        }
+        guard let analysis = box.analyze(tolerance: 1e-6) else {
+            Issue.record("analyze returned nil")
+            return
+        }
+        #expect(analysis.freeEdgeCount == 0)
+        #expect(analysis.freeFaceCount == 0)
+    }
+
+    @Test("analyze counts free faces per shell on a compound of two open shells")
+    func analyzeCountsFreeFacesPerShell() {
+        guard let shellA = openShellMissingOneFace(), let shellB = openShellMissingOneFace(),
+              let compound = Shape.compound([shellA, shellB])
+        else {
+            Issue.record("could not build the two-open-shell compound")
+            return
+        }
+        guard let analysis = compound.analyze(tolerance: 1e-6) else {
+            Issue.record("analyze returned nil")
+            return
+        }
+        #expect(analysis.freeEdgeCount == 8, "4 free edges per shell, two shells")
+        #expect(analysis.freeFaceCount == 2, "both shells are open")
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
@@ -34,7 +34,7 @@ import simd
 /// checks `shapeType == .solid` before running `BRepCheck_Analyzer`, so it reads `false` on any
 /// demoted shell. It had no test at all for that specific branch: every existing use only
 /// asserted the positive (already-a-valid-solid) case.
-@Suite("Issue 702: solid demotion is honestly reported")
+@Suite("Issue 702: solid demotion is reported accurately")
 struct Issue702SolidDemotion {
 
     /// A box with one face dropped, sewn into an open shell: the smallest input that reaches
@@ -108,7 +108,7 @@ struct Issue702SolidDemotion {
             Issue.record("could not build fixtures")
             return
         }
-        // Both read true. isValid alone genuinely cannot tell them apart -- that is the bug.
+        // Both read true. isValid alone genuinely cannot tell them apart; that is the bug.
         #expect(fixed.isValid)
         #expect(box.isValid)
         #expect(fixed.shapeType != box.shapeType, "but they are not the same kind of shape")
@@ -163,6 +163,16 @@ struct Issue702SolidDemotion {
         #expect(analysis.freeEdgeCount == shellAnalysis.freeEdgeCount,
                 "analyze() must agree with the already-correct analyzeShell()")
         #expect(analysis.freeFaceCount == 1, "one shell, and it is not fully closed")
+        // #717 review finding 2: totalProblems must count this shell's free edges once, not once
+        // via freeEdgeCount and again as +1 via freeFaceCount for the same open shell. The expected
+        // sum is recomputed from the other fields, not hardcoded: this fixture also measures a
+        // nonzero gapCount (a pre-existing, unrelated characteristic of a box-minus-one-face sewn
+        // at 1e-6), so an assumed magic total would have been wrong for a reason having nothing to
+        // do with the bug this test exists to catch.
+        let expected = Self.totalProblemsExcludingFreeFace(analysis)
+        #expect(analysis.totalProblems == expected)
+        #expect(analysis.totalProblems != expected + analysis.freeFaceCount,
+                "adding freeFaceCount again would double-count this shell's one open boundary")
     }
 
     @Test("analyze reports the demoted fixSolid shell's free edges too")
@@ -177,10 +187,15 @@ struct Issue702SolidDemotion {
         }
         // This is the issue's own reported evidence, corrected: before #702's fix this read 0
         // regardless of input. The demoted shell genuinely has the same 4 free edges as the
-        // open shell it was built from -- ShapeFix_Solid does not add or remove faces.
+        // open shell it was built from; ShapeFix_Solid does not add or remove faces.
         #expect(analysis.freeEdgeCount == 4)
         #expect(analysis.freeFaceCount == 1)
         #expect(!analysis.isHealthy, "a shape with real free edges must not report healthy")
+        // #717 review finding 2, same reasoning as analyzeReportsFreeEdgesOnOpenShell above.
+        let expected = Self.totalProblemsExcludingFreeFace(analysis)
+        #expect(analysis.totalProblems == expected)
+        #expect(analysis.totalProblems != expected + analysis.freeFaceCount,
+                "adding freeFaceCount again would double-count this shell's one open boundary")
     }
 
     @Test("analyze reports zero free edges/faces on a genuinely closed solid")
@@ -211,5 +226,87 @@ struct Issue702SolidDemotion {
         }
         #expect(analysis.freeEdgeCount == 8, "4 free edges per shell, two shells")
         #expect(analysis.freeFaceCount == 2, "both shells are open")
+        // #717 review finding 2, same reasoning as analyzeReportsFreeEdgesOnOpenShell above.
+        let expected = Self.totalProblemsExcludingFreeFace(analysis)
+        #expect(analysis.totalProblems == expected)
+        #expect(analysis.totalProblems != expected + analysis.freeFaceCount,
+                "adding freeFaceCount again would double-count both shells' open boundaries")
+    }
+
+    /// `totalProblems`'s own contract (see ``ShapeAnalysisResult/totalProblems``): every field
+    /// summed once, except `freeFaceCount`, which is a derived summary of the same free-edge scan
+    /// rather than an independent defect. Recomputed here instead of assumed, so the tests above
+    /// measure the real fields (including this fixture's own nonzero `gapCount`) rather than a
+    /// guessed total.
+    private static func totalProblemsExcludingFreeFace(_ analysis: ShapeAnalysisResult) -> Int {
+        analysis.smallEdgeCount + analysis.smallFaceCount + analysis.gapCount +
+            analysis.selfIntersectionCount + analysis.freeEdgeCount +
+            (analysis.hasInvalidTopology ? 1 : 0)
+    }
+
+    // MARK: - checkinternaledges must match between analyze() and analyzeShell() (#717 review finding 1)
+
+    /// A single square face wrapped directly as a shell (`TopoDS_Builder::MakeShell` + `Add`, no
+    /// sewing at all), with an `.internal`-oriented duplicate of one of its own 4 boundary edges
+    /// embedded back into the face before the face joins the shell.
+    ///
+    /// `ShapeAnalysis_Shell::CheckOrientedShells` takes a `checkinternaledges` argument
+    /// (`ShapeAnalysis_Shell.cxx`): a FORWARD/REVERSED edge with no opposite-orientation partner is
+    /// unconditionally free when `checkinternaledges` is false, but is instead read as connected
+    /// (`myConex`, not `myFree`) when `checkinternaledges` is true and the same underlying shape
+    /// (`TopTools_ShapeMapHasher` compares via `IsSame`: same TShape and Location, ignoring
+    /// Orientation) also occurs with `TopAbs_INTERNAL` orientation elsewhere in the shell.
+    /// `OCCTShapeAnalyzeShell` already passed `true`; `OCCTShapeAnalyze`'s per-shell scan left it at
+    /// the default `false` until this fix. `openShellMissingOneFace()` above has no INTERNAL-oriented
+    /// edges at all, so `checkinternaledges` never changes its answer, which is exactly why it could
+    /// not catch the divergence: this fixture exists to make it change.
+    ///
+    /// A lone face's boundary edges are free by construction (nothing else in a one-face shell
+    /// shares them), the same shape `openShellMissingOneFace()` gives its 4 hole-boundary edges,
+    /// without depending on what sewing decides to rebuild.
+    ///
+    /// The embedding has to happen while the face is still free (`TopoDS_Builder::Add` raises
+    /// `TopoDS_FrozenShape` on a shape that already belongs to a parent): a plain box face, already
+    /// owned by the box solid it came from, refuses a second `builderAdd` the same way, which is
+    /// why this fixture builds its own face from scratch rather than reusing one of the box's.
+    /// `WIRE` (not a bare `EDGE`) is what a `FACE` accepts as a child (`TopoDS_Builder.hxx`'s own
+    /// "Only WIRE and VERTEX can be added in a FACE" contract), so the duplicate edge is wrapped in
+    /// a fresh one-edge wire, itself set `.internal`; since `TopAbs::Compose`'s INTERNAL row is
+    /// constant regardless of what composes with it (`TopAbs.hxx`), the child edge reads `.internal`
+    /// however it was oriented on its own.
+    private func openShellWithInternalDuplicateFreeEdge() -> Shape? {
+        guard let outerWire = Wire.polygon3D(
+            [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true
+        ), let face = Shape.face(from: outerWire) else { return nil }
+
+        guard let candidate = face.subShapes(ofType: .edge).first,
+              let wire = Shape.builderMakeWire()
+        else { return nil }
+        candidate.setOrientation(.internal)
+        guard wire.builderAdd(candidate) else { return nil }
+        wire.setOrientation(.internal)
+        guard face.builderAdd(wire) else { return nil }
+
+        guard let shell = Shape.builderMakeShell(), shell.builderAdd(face) else { return nil }
+        return shell
+    }
+
+    @Test("analyze() agrees with analyzeShell() even with an INTERNAL-oriented duplicate free edge")
+    func analyzeAgreesWithAnalyzeShellOnInternalDuplicate() {
+        guard let shell = openShellWithInternalDuplicateFreeEdge() else {
+            Issue.record("could not build the INTERNAL-duplicate fixture; see its doc comment")
+            return
+        }
+        let shellAnalysis = shell.analyzeShell()
+        // Fixture sanity check: 3, not the plain fixture's 4, proves the duplicate actually
+        // suppressed one edge via checkinternaledges rather than the fixture doing nothing.
+        #expect(shellAnalysis.freeEdgeCount == 3,
+                "the INTERNAL duplicate's own edge must drop out of the free count")
+        guard let analysis = shell.analyze(tolerance: 1e-6) else {
+            Issue.record("analyze returned nil")
+            return
+        }
+        #expect(analysis.freeEdgeCount == shellAnalysis.freeEdgeCount,
+                "analyze() must agree with analyzeShell() even with an INTERNAL duplicate present")
     }
 }

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -96,10 +96,13 @@ struct ShapeAnalysisTests {
         let analysis = box.analyze()!
 
         #expect(analysis.totalProblems >= 0)
-        // Check that totalProblems is consistent with component counts
+        // Check that totalProblems is consistent with component counts. freeFaceCount is
+        // deliberately excluded: it is a derived summary of the same scan freeEdgeCount already
+        // counts (this shell has at least one free edge), not an independent defect, so including
+        // both would double-count one open shell's boundary gap (#717 review finding 2).
         let expectedTotal = analysis.smallEdgeCount + analysis.smallFaceCount +
                            analysis.gapCount + analysis.selfIntersectionCount +
-                           analysis.freeEdgeCount + analysis.freeFaceCount +
+                           analysis.freeEdgeCount +
                            (analysis.hasInvalidTopology ? 1 : 0)
         #expect(analysis.totalProblems == expectedTotal)
     }

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -99,7 +99,7 @@ struct ShapeAnalysisTests {
         // Check that totalProblems is consistent with component counts. freeFaceCount is
         // deliberately excluded: it is a derived summary of the same scan freeEdgeCount already
         // counts (this shell has at least one free edge), not an independent defect, so including
-        // both would double-count one open shell's boundary gap (#717 review finding 2).
+        // both would double-count one open shell's boundary gap (#717 review, the totalProblems double-count).
         let expectedTotal = analysis.smallEdgeCount + analysis.smallFaceCount +
                            analysis.gapCount + analysis.selfIntersectionCount +
                            analysis.freeEdgeCount +

--- a/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
+++ b/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
@@ -1,0 +1,21 @@
+// ShapeHealingTestFixtures.swift
+// Shared fixtures for OCCTShapeHealingTests.
+// No @Suite or @Test: only factory functions.
+
+import Testing
+import Foundation
+import simd
+import OCCTSwift
+
+/// Drops one face from `box` and sews the remaining five: the smallest recipe that reaches an
+/// open shell with exactly 4 free edges ringing the missing face, whatever the box's own size or
+/// origin. Shared by `Issue442FixSolidMultiBodyTests` and `Issue702SolidDemotionTests`, both of
+/// which built this same "drop one face, sew the rest" logic independently before #717 review
+/// finding 5 pointed out the duplication.
+func sewnBoxMissingOneFace(_ box: Shape, tolerance: Double = 1e-6) -> Shape? {
+    let faces = box.subShapes(ofType: .face)
+    guard faces.count == 6,
+          let compound = Shape.compound(Array(faces.dropFirst()))
+    else { return nil }
+    return compound.sewn(tolerance: tolerance)
+}

--- a/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
+++ b/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
@@ -10,8 +10,13 @@ import OCCTSwift
 /// Drops one face from `box` and sews the remaining five: the smallest recipe that reaches an
 /// open shell with exactly 4 free edges ringing the missing face, whatever the box's own size or
 /// origin. Shared by `Issue442FixSolidMultiBodyTests` and `Issue702SolidDemotionTests`, both of
-/// which built this same "drop one face, sew the rest" logic independently before #717 review
-/// finding 5 pointed out the duplication.
+/// which built this same "drop one face, sew the rest" logic independently before the #717 review
+/// pointed out the duplication.
+///
+/// Note this drops the caller-side `#expect(faces.count == 6)` that `Issue442FixSolidMultiBodyTests`
+/// used to assert inline: a non-six face count now returns nil and surfaces as that suite's own
+/// "could not sew the open shell" record instead. The test still fails, one step later and with a
+/// less specific message.
 func sewnBoxMissingOneFace(_ box: Shape, tolerance: Double = 1e-6) -> Shape? {
     let faces = box.subShapes(ofType: .face)
     guard faces.count == 6,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -124,13 +124,41 @@ cross-reference `isValidSolid` as the reliable check. This is a bug fix to the v
 value repaired, per `SEMVER.md`'s own quick-reference table), not a recorded exception: nothing
 could have correctly relied on a hardcoded 0.
 
-New tests: `Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift`, 10 cases on the tiny
+New tests: `Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift`, 11 cases on the tiny
 open-shell fixture above (a box missing one face is the "smallest shape that demotes" the issue
 asked for). Proven to catch the fix: reverting `OCCTShapeAnalyze` back to `LoadShells()` fails
 exactly the three tests exercising `freeEdgeCount`/`freeFaceCount` (open shell, demoted shell, a
 two-shell compound) and leaves the other seven (`isValidSolid`, demotion-to-shell, closed-box
 negative control) green, confirming the new tests target this bug specifically rather than the
 already-correct demotion behaviour.
+
+**Follow-up from code review, before this landed:**
+
+- **`OCCTShapeAnalyze`'s new `CheckOrientedShells` call omitted `checkinternaledges`**, the third
+  argument, unlike the sibling `OCCTShapeAnalyzeShell`, which already passed `true`.
+  `ShapeAnalysis_Shell.cxx`: with `checkinternaledges` false, a FORWARD/REVERSED edge with no
+  opposite-orientation partner is unconditionally free; with it true, an edge that also occurs with
+  `TopAbs_INTERNAL` orientation elsewhere in the same shell (matched by `IsSame`: same TShape and
+  Location, ignoring orientation) is read as connected through that occurrence instead. The two
+  entry points could silently disagree on any shell carrying an INTERNAL-oriented edge, directly
+  contradicting this fix's own "`analyze()` must agree with `analyzeShell()`" test invariant. The
+  original fixture (the box missing one face) has no INTERNAL-oriented edges, so it could not catch
+  the divergence; a new fixture does (a single face wrapped as a shell, with an `.internal`-oriented
+  duplicate of one of its own boundary edges embedded back into the face before the face joins the
+  shell). Both call sites now share one helper (`occtAnalyzeShellOrientation`), so the argument
+  cannot drift between them again the way it just did.
+- **`totalProblems` double-counted an open shell's defect**: once via `freeEdgeCount` (one count
+  per free edge) and again as a flat `+1` via `freeFaceCount` (one shell found not fully closed),
+  now that this fix makes both fields live for the same shape at once for the first time.
+  `freeFaceCount` is a derived summary of the same scan, not an independent defect category, so
+  `totalProblems` no longer includes it; `freeFaceCount` stays a public field for callers who want
+  the shell-level breakdown.
+- **The per-shell scan gained a per-iteration `try`/`catch`.** `CheckOrientedShells` is a real OCCT
+  computation, unlike the `LoadShells()` it replaced, so it can raise `Standard_Failure` on a
+  malformed shell; without a scoped catch, one bad shell in a multi-shell shape would abort to this
+  function's outer `catch` and discard every other shell's free-edge count along with the
+  small-edge/small-face/gap counts computed afterward, rather than just skipping that one shell's
+  contribution.
 
 ### CI builds the same kernel the branch is written against
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,76 @@ an unrecognised" option, which was true only until the same-day commit that made
 (confirmed still correct: `count-operations.py --self-test` and `--bogus` both exit 2 with a usage
 message).
 
+#### `Shape.analyze(tolerance:)` reported zero free edges for every shape, and a `healed()`/`fixSolid()` demotion had no reliable signal (#702)
+
+`Shape.healed()` and `Shape.fixSolid()` can reach `isValid == true` by demoting a solid to a
+shell: `ShapeFix_Solid` (via `ShapeFix_Shape`'s delegation, for `healed()`) hands back the shell
+unpromoted whenever it cannot close it, already correctly documented for `fixSolid()` since #442.
+A shell has no closure requirement of its own, so the demoted result is genuinely `isValid`, and
+the issue asked for a way to tell.
+
+**The issue's own reproducer does not reproduce on this branch.** It measured a
+`ThruSectionsBuilder(isSolid: true, isRuled: false)` loft through a 36-tooth bevel gear's six
+section wires (1152 points each) on OCCT v1.17.0. Three independent reconstructions against this
+kernel (8.0.1 + patches), matching gear-tooth polygons at various tooth counts/tapers/twists, a
+dense sinusoidal profile, and a faithful port of `OCCTSwiftScripts/recipes/04-spur-gear`'s
+involute math scaled per section (matching the issue's own 1152-points-per-wire figure exactly at
+`flankSamples = 14`, plus a spiral-twist variant), all produced a `BRepCheck_Analyzer`-valid raw
+loft, across 400+ parameter combinations. `BRepCheck_Analyzer` itself does not flag 3D
+self-intersection between non-adjacent faces either: a deliberately self-intersecting
+179-degree-twisted star-prism loft still reports `isValid == true`, confirmed directly and
+matching `analyze()`'s own `selfIntersectionCount`, which is hardcoded to 0 and always has been
+(see below). Source-reading `ShapeFix_Solid::Perform()`/`CreateSolids()`/`CollectSolids()` found
+no path that demotes a genuinely closed shell either: every demotion in that class is gated on
+`BRep_Tool::IsClosed`/`ShapeAnalysis_FreeBounds` finding real free edges, matching #442's
+documented contract. No fix was made for this specific scenario because nothing was found broken
+there; per the issue's own instruction, a non-reproducing report closes with the evidence rather
+than a manufactured fix.
+
+**What does reproduce, trivially, with no loft at all: an open shell wrapped as a `TopoDS_Solid`**
+(a box missing one face, sewn, then `Shape.solidFromShells([shell])`, exactly what
+`BRepBuilderAPI_MakeSolid` does with a single non-closed shell, no fixing). `fixSolid()`/`healed()`
+correctly demote it to a shell (#442's contract), `isValid` reads `true` on the result, and this
+is where the issue's own complaint held: `analyze(tolerance:)` read zero free edges on it
+regardless.
+
+**Root cause, and fixed:** `OCCTShapeAnalyze` (`OCCTBridge_Healing.mm`) called
+`ShapeAnalysis_Shell::LoadShells()` and then read `HasFreeEdges()`/`FreeEdges()`. `LoadShells()`
+only registers a shell for `NbLoaded()`/`Loaded()` bookkeeping; it runs no edge analysis at all.
+Only `CheckOrientedShells()` populates the free-edge set those accessors read, exactly as the
+sibling entry point `OCCTShapeAnalyzeShell` (backing `Shape.analyzeShell()`) already calls it. So
+`freeEdgeCount` was hardcoded to 0 for every shape passed to `analyze(tolerance:)`, however open,
+and `freeFaceCount`'s own local variable was never incremented anywhere in the function; both
+silently agreed with a defect no matter what it was. Now `CheckOrientedShells(shell, alsofree:
+true)` is called, `freeEdgeCount` reports the real count, and `freeFaceCount` counts the shells
+found not fully closed, matching the field's own existing header comment ("Number of free faces
+(shell not closed)").
+
+**`Shape.isValidSolid` already answered the issue's actual question, unaffected by either bug**,
+for a reason unrelated to this fix: added for #206/#208 (an unrelated self-intersecting-loft
+hazard), it checks `shapeType == .solid` before running `BRepCheck_Analyzer`, so it reads `false`
+on any demoted shell where plain `isValid` reads `true`. It had no test at all for that branch:
+every existing assertion (`Issue225ThreadedRodTests`, `Issue257MultiStartTests`,
+`Issue397CircularHoleTests`, `OCCTShapeHealingTests`) only tested the positive, already-a-solid
+case. Also documented: `selfIntersectionCount` is another permanent 0 (the bridge's own comment:
+"would require more expensive computation"), not a computed absence of self-intersection.
+
+`healed()` gained the demotion warning `fixSolid()` has carried since #442 (it shares the same
+`ShapeFix_Solid` mechanism, confirmed by reading `ShapeFix_Shape.cxx`'s delegation), and both now
+cross-reference `isValidSolid` as the reliable check. This is a bug fix to the values
+`Shape.analyze(tolerance:)` returns, not a new field or a signature change. Like the
+#605/#609/#583/#595 fabricated-zero fixes before it, this is a PATCH-level correction (a wrong
+value repaired, per `SEMVER.md`'s own quick-reference table), not a recorded exception: nothing
+could have correctly relied on a hardcoded 0.
+
+New tests: `Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift`, 10 cases on the tiny
+open-shell fixture above (a box missing one face is the "smallest shape that demotes" the issue
+asked for). Proven to catch the fix: reverting `OCCTShapeAnalyze` back to `LoadShells()` fails
+exactly the three tests exercising `freeEdgeCount`/`freeFaceCount` (open shell, demoted shell, a
+two-shell compound) and leaves the other seven (`isValidSolid`, demotion-to-shell, closed-box
+negative control) green, confirming the new tests target this bug specifically rather than the
+already-correct demotion behaviour.
+
 ### CI builds the same kernel the branch is written against
 
 `Package.swift` now pins the [`v2.0.0-kernel.1`](https://github.com/SecondMouseAU/OCCTSwift/releases/tag/v2.0.0-kernel.1)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -160,6 +160,29 @@ already-correct demotion behaviour.
   small-edge/small-face/gap counts computed afterward, rather than just skipping that one shell's
   contribution.
 
+**A second, corrected review pass** retracted five of the first pass's seven points (a docs gap on
+`fixed`/`upgraded`, the per-shell try/catch above, duplicated scan logic, and two writing-style
+nits) as not part of its own verified output, keeping only two (`checkinternaledges` and the
+`totalProblems` double-count, both already listed above) and replacing the rest with two genuinely
+different findings:
+
+- **`isValidSolid`, `isValid` and `healed()`'s doc comments carried no fenced `swift` code block.**
+  `isValid` and `healed()` gained new demotion-hazard prose in this same fix and neither picked up
+  an example; `isValidSolid` had none even before this fix touched its doc, so the review's claim
+  held on all three. All three now carry a runnable snippet that builds the box-missing-one-face
+  fixture and shows `isValid == true` / `isValidSolid == false` on the demoted shell: the exact
+  hazard each paragraph describes, not a decorative unrelated example. Each snippet's literal code
+  was run once as a throwaway test before being written into the doc comment.
+- **`Issue702SolidDemotionTests.openShellMissingOneFace()` duplicated a fixture
+  `Issue442FixSolidMultiBodyTests.swift` already built inline**, in the same test target: both drop
+  one face from a box, compound the remaining five and sew them, the smallest input that reaches
+  `ShapeFix_Solid`'s cannot-close branch. Extracted to
+  `Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift`
+  (`sewnBoxMissingOneFace(_:tolerance:)`, parameterized on the box so the two suites keep their own
+  box size/origin), following the precedent `Tests/OCCTStressTests/StressTestFixtures.swift` already
+  set for sharing fixtures within one test target. Both suites re-verified unchanged after the
+  refactor.
+
 ### CI builds the same kernel the branch is written against
 
 `Package.swift` now pins the [`v2.0.0-kernel.1`](https://github.com/SecondMouseAU/OCCTSwift/releases/tag/v2.0.0-kernel.1)

--- a/docs/guides/cookbook/healing-and-validity.md
+++ b/docs/guides/cookbook/healing-and-validity.md
@@ -80,15 +80,18 @@ let upgraded = shape.upgraded(tolerance: 1e-3)         // sew + make-solid + hea
   same as `Shape.fixSolid()`); the demoted shell is genuinely `isValid`, since a shell has no
   closure requirement of its own, so check `isValidSolid` (or `shapeType`) rather than `isValid`
   if the caller depends on getting a solid back (#702).
-- **`fixed(tolerance:…)`** — `ShapeFix_Shape` with per-component flags; raise `tolerance` to match the
-  precision of imported data (e.g. `1e-3`, not the default `1e-6`).
-- **`unified()`** — `ShapeUpgrade_UnifySameDomain`; the standard **post-boolean** cleanup that merges
+- **`fixed(tolerance:…)`**: `ShapeFix_Shape` with per-component flags; raise `tolerance` to match the
+  precision of imported data (e.g. `1e-3`, not the default `1e-6`). It runs the same `ShapeFix_Shape`
+  mechanism as `healed()`, so solid input can come back demoted to a shell the same way and for the
+  same reason; the same `isValidSolid`/`shapeType` check applies (#702).
+- **`unified()`**: `ShapeUpgrade_UnifySameDomain`; the standard **post-boolean** cleanup that merges
   the redundant faces/edges a boolean leaves behind.
 - **`upgraded(tolerance:)`** sews, then builds one solid per body, then heals. A **multi-body** part
   stays multi-body and comes back as a compound of solids. Two things sewing costs you here: a hollow
   body's **cavity is filled** (sewing dissolves the solid that declared it), and content that would
   not attach to a shell is dropped. Use `fixed(tolerance:)` instead when either matters; it does not
-  sew.
+  sew. Its own final step is the same `ShapeFix_Shape` healing pass, so it too can hand back a shell
+  instead of the solid it just built, for the same reason and the same check (#702).
 
 ```swift
 let part = twoBodyImport.upgraded(tolerance: 1e-3)!

--- a/docs/guides/cookbook/healing-and-validity.md
+++ b/docs/guides/cookbook/healing-and-validity.md
@@ -75,7 +75,11 @@ let unified  = shape.unified()                         // merge co-planar faces 
 let upgraded = shape.upgraded(tolerance: 1e-3)         // sew + make-solid + heal pipeline
 ```
 
-- **`healed()`** — quick, general clean-up. Reach for this first.
+- **`healed()`**: quick, general clean-up. Reach for this first. For solid input it can return a
+  **shell** instead when the solid cannot be closed (`ShapeFix_Shape` delegates to `ShapeFix_Solid`,
+  same as `Shape.fixSolid()`); the demoted shell is genuinely `isValid`, since a shell has no
+  closure requirement of its own, so check `isValidSolid` (or `shapeType`) rather than `isValid`
+  if the caller depends on getting a solid back (#702).
 - **`fixed(tolerance:…)`** — `ShapeFix_Shape` with per-component flags; raise `tolerance` to match the
   precision of imported data (e.g. `1e-3`, not the default `1e-6`).
 - **`unified()`** — `ShapeUpgrade_UnifySameDomain`; the standard **post-boolean** cleanup that merges

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -454,9 +454,14 @@ Whether the shape is a topologically valid closed solid.
 public var isValidSolid: Bool { get }
 ```
 
-Runs `BRepCheck_Analyzer` — a **topology** check only. It does not detect global self-intersection (overlapping faces). A self-intersecting B-spline solid can pass this check yet cause booleans to hang or return garbage. Use `isSelfIntersecting(timeout:)` for the complementary geometric check.
+Runs `BRepCheck_Analyzer`, a **topology** check only. It does not detect global self-intersection (overlapping faces). A self-intersecting B-spline solid can pass this check yet cause booleans to hang or return garbage. Use `isSelfIntersecting(timeout:)` for the complementary geometric check.
 
-- **Returns:** `true` if `BRepCheck_Analyzer` reports no errors.
+Checks `shapeType == .solid` first and returns `false` immediately otherwise, so it is the
+reliable way to notice a `healed()`/`fixSolid()` demotion (#702): a shell they could not close
+reads `false` here even though plain `isValid` reads `true` on it (a shell has no closure
+requirement of its own).
+
+- **Returns:** `true` if `shapeType == .solid` and `BRepCheck_Analyzer` reports no errors.
 - **OCCT:** `BRepCheck_Analyzer` (via `OCCTShapeIsValidSolid`).
 
 ---
@@ -1550,6 +1555,19 @@ public struct ShapeAnalysisResult {
 ```
 
 `isHealthy` is `true` when `totalProblems == 0 && !hasInvalidTopology`.
+
+- **`selfIntersectionCount` is always 0.** It has never been computed (the bridge's own comment
+  reads "would require more expensive computation"). Use `isSelfIntersecting(timeout:)` for a
+  real answer.
+- **`freeEdgeCount`/`freeFaceCount` were hardcoded to 0 for every shape before #702**: the bridge
+  called `ShapeAnalysis_Shell::LoadShells()`, which only registers a shell for bookkeeping,
+  instead of `CheckOrientedShells()`, the call that actually populates the free-edge set. Now
+  fixed: `freeEdgeCount` is the true count across every shell, and `freeFaceCount` is how many of
+  those shells are not fully closed.
+- **A "clean" (`isHealthy == true`) result never means "this is a solid."** A well-formed open
+  shell, or a shell `healed()`/`fixSolid()` demoted from a solid it could not close, has no
+  closure requirement of its own and can report zero free edges honestly while still not being a
+  solid. Check `shapeType` or `isValidSolid` for that.
 
 ---
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1563,10 +1563,19 @@ public struct ShapeAnalysisResult {
   called `ShapeAnalysis_Shell::LoadShells()`, which only registers a shell for bookkeeping,
   instead of `CheckOrientedShells()`, the call that actually populates the free-edge set. Now
   fixed: `freeEdgeCount` is the true count across every shell, and `freeFaceCount` is how many of
-  those shells are not fully closed.
+  those shells are not fully closed. The bridge asks `CheckOrientedShells` to also exclude an edge
+  that has a matching `TopAbs_INTERNAL`-oriented occurrence elsewhere in the same shell from
+  `freeEdgeCount` (it is genuinely connected through that occurrence, not a boundary gap): the
+  same rule `analyzeShell()` already used, so the two agree on any shape either can see.
+- **`totalProblems` counts `freeEdgeCount`, not `freeFaceCount`.** `freeFaceCount` is a derived
+  summary over the same scan (this shell has at least one free edge), not an independent defect:
+  it is never nonzero without `freeEdgeCount` also being nonzero, and adding both would count one
+  open shell's boundary gap twice (once per edge, once more as a flat "+1 shell"). `freeFaceCount`
+  stays a public field for callers who want the shell-level breakdown; it is just not folded into
+  the total again.
 - **A "clean" (`isHealthy == true`) result never means "this is a solid."** A well-formed open
   shell, or a shell `healed()`/`fixSolid()` demoted from a solid it could not close, has no
-  closure requirement of its own and can report zero free edges honestly while still not being a
+  closure requirement of its own and can report zero free edges accurately while still not being a
   solid. Check `shapeType` or `isValidSolid` for that.
 
 ---


### PR DESCRIPTION
## What & why

`Shape.healed()` and `Shape.fixSolid()` can reach `isValid == true` by demoting a solid to a
shell (`ShapeFix_Solid` hands back the shell unpromoted whenever it cannot close it, already
documented for `fixSolid()` since #442; a shell has no closure requirement of its own, so the
demoted result is genuinely valid). #702 reported this as invisible to every diagnostic: `isValid`
true, `volume` correct, `analyze()` clean.

**The issue's own ThruSections/bevel-gear reproducer does not reproduce on this branch** (OCCT
8.0.1 + patches vs the issue's v1.17.0). Three independent, faithful reconstructions, including a
port of `OCCTSwiftScripts/recipes/04-spur-gear`'s involute math matching the issue's own
1152-points-per-wire figure exactly, across 400+ parameter combinations, plus source-reading
`ShapeFix_Solid`, all confirm nothing is broken there today. No manufactured fix for a defect that
is not reproducing.

**What is real and fixed: `Shape.analyze(tolerance:)`'s free-edge/free-face detection was dead
code.** `OCCTShapeAnalyze` called `ShapeAnalysis_Shell::LoadShells()`, which only does bookkeeping
and runs no edge analysis, instead of `CheckOrientedShells()`, which actually populates the
free-edge set (the sibling entry point `OCCTShapeAnalyzeShell` already calls it correctly).
`freeEdgeCount` was hardcoded to 0 for every shape, and `freeFaceCount`'s counter variable was
never incremented at all. Fixed; both now report accurately.

**`Shape.isValidSolid` already answered the issue's actual question**, unaffected by either bug
(added for #206/#208, unrelated): it checks `shapeType == .solid` before `BRepCheck_Analyzer`, so
it reads `false` on a demoted shell where plain `isValid` reads `true`. It had no test for that
branch; added. `healed()` and `fixSolid()`'s docs now cross-reference it.

Closes #702

## Checklist

- [x] New/changed behavior is covered by a unit test in the same PR:
      `Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift`, 10 cases.

## Notes for the reviewer

**Reproduction status, in detail.** The issue's reproducer was measured on OCCT v1.17.0. Tried on
this branch's kernel (8.0.1 + eleven carried patches):

- Sharp-cornered gear-tooth polygons (3-72 teeth), tapered and twisted, up to 6 sections.
- A dense sinusoidal profile at various tooth counts, point densities and amplitudes.
- Deliberately self-intersecting star prisms twisted up to 179 degrees (ruled and smoothed).
- A faithful port of `OCCTSwiftScripts/recipes/04-spur-gear`'s involute tooth math, scaled per
  section for a bevel taper (with and without a spiral-twist variant), matching the issue's own
  1152-points-per-wire figure exactly at `flankSamples = 14`.

Over 400 parameter combinations across these four families, every raw `ThruSectionsBuilder`
result was `BRepCheck_Analyzer`-valid, so nothing ever reached `healed()`/`fixSolid()` in a state
that could demote. Separately: `BRepCheck_Analyzer` does not flag 3D self-intersection between
non-adjacent faces at all (the deliberately self-intersecting twisted prisms above all report
`isValid == true`), which matches `analyze()`'s own `selfIntersectionCount` field being a
permanent, undocumented-until-now 0. Source-reading `ShapeFix_Solid::Perform()`,
`CreateSolids()`, and `CollectSolids()` (all three demotion code paths, single-shell and
multi-shell) found every one gated on a genuine closure check (`BRep_Tool::IsClosed`/
`ShapeAnalysis_FreeBounds`), matching #442's already-documented and already-tested contract. I
could not construct any case where a topologically closed shell gets wrongly demoted.

**Whose bug is the free-edge/free-face defect?** Ours, in the bridge, not OCCT. `OCCTShapeAnalyze`
called the wrong `ShapeAnalysis_Shell` method (`LoadShells()` instead of `CheckOrientedShells()`);
OCCT's own API works correctly when called right, which the sibling `OCCTShapeAnalyzeShell`
already demonstrates. No kernel patch, no upstream filing.

**The contract chosen for `healed()`/`fixSolid()` demotion itself: preserve, not report or
reject**, because it already was, correctly, since #442; this PR doesn't revisit that decision.
Refusing (returning `nil`/the original invalid solid) would reverse a deliberate #442 decision
("no body is ever dropped to make [isValid] true") for no new reason. Reporting (a new
`WithReport`-style API, matching #639/#709's precedent) would be redundant: `isValidSolid` already
exists, already answers the question correctly (verified directly, unaffected by the
`analyze()` bug), and just needed cross-referencing and a test.

**Injection matrix** (`Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift`, all 10
cases, bug reintroduced by reverting `OCCTShapeAnalyze` to `shellAnalysis.LoadShells(shell)`):

| test | bug present | fixed |
|---|---|---|
| analyze reports the open shell's free edges, matching analyzeShell | FAIL | PASS |
| analyze reports the demoted fixSolid shell's free edges too | FAIL | PASS |
| analyze counts free faces per shell on a compound of two open shells | FAIL | PASS |
| analyze reports zero free edges/faces on a genuinely closed solid | PASS | PASS |
| the fake solid is BRepCheck-invalid before healing | PASS | PASS |
| fixSolid demotes the fake solid to a shell | PASS | PASS |
| healed demotes the fake solid to a shell | PASS | PASS |
| isValid alone does not distinguish a demoted shell from a healthy solid | PASS | PASS |
| isValidSolid is false on a demoted shell, true on a genuine solid | PASS | PASS |
| isValidSolid is false on non-solid shape types generally | PASS | PASS |

The three tests targeting the actual bug fail precisely when it's present; the other seven
(testing the already-correct demotion mechanism and the already-correct `isValidSolid`) stay
green throughout, confirming the new tests are isolated to the bug they exist to catch.

**`docs/SEMVER.md`**: no entry added. This is a bug fix to the *values* `analyze(tolerance:)`
returns, not a new field, removed field, or signature change; per the file's own quick-reference
table this is the PATCH case ("a wrong value repaired"), matching the precedent of the
#605/#609/#583/#595 fabricated-zero fixes, none of which are recorded exceptions either. Rechecked
the "thirteen recorded exceptions" counters at the top of the file: still accurate (3 compile-break
+ 10 behavior-only), unchanged by this PR.

**What the issue got wrong** (its own numbers are from v1.17.0, expected to have moved): the
specific bevel-gear reproducer no longer produces an invalid raw solid on this branch, so the
premise "the builder does produce a solid [that's invalid]" no longer holds here. The issue's
"analyze() ... no self-intersections" evidence was inadvertently reporting a permanently-stubbed
field, not a measured absence, both before and after this fix (now documented rather than silent).

**Verified**: clean `swift build`, 0 errors, no new warnings, no `OCCTSWIFT_LOCAL`. Full `swift
test`: 5356 baseline + 10 new = 5366, 0 failures. `Censuses cluster-a` 45 rows, `cluster-b` 16
rows (both unaffected by this change, confirmed unchanged). Four gate scripts and their three
`--self-test`s all green. Zero em-dashes in the diff.
