### PR TITLE
fix(#437): plateSurface's point constraints reject .g2 in Swift instead of relying on OCCT's own throw

### DIFF
--- a/Scripts/repro/cluster-d-continuity/README.md
+++ b/Scripts/repro/cluster-d-continuity/README.md
@@ -160,6 +160,16 @@ clamp the raw `SurfaceContinuity` value directly into `GeomPlate_PointConstraint
 `occtGeomAbsFrom*` call anywhere in any of the three, confirmed by the static classifier
 independently.
 
+**Fixed** (the follow-up PR this census named as a prerequisite for): the point half of
+`plateSurface(through:orders:)` and `plateSurface(pointConstraints:curveConstraints:)` now reject
+`.g2` in Swift (`SurfaceContinuity.isUnsupportedForPointConstraint`), before building any
+`GeomPlate_PointConstraint`, instead of relying on OCCT's own throw being caught by the bridge's
+`catch (...)`. The measured table above is unchanged by that fix -- a point `.g2` was already
+`nil` and stays `nil` -- because the fix moves *where* the rejection happens, not *whether* it
+does; re-running `swift run Censuses cluster-d` after the fix reproduces this section byte for
+byte. The clamp-into-`[0,2]` source read above still describes the curve path and the raw-order
+mechanism generally; only the point path gained a guard ahead of it.
+
 ## AnalysisOrder: saturates at C2, confirmed through the TYPED entry point alone
 
 `ContinuityClass` is `CaseIterable` over all seven `GeomAbs_Shape` ordinals (through `.cN`), and
@@ -345,8 +355,9 @@ that:
 - Its "four incompatible encodings" framing predates #490's consolidation to three canonical
   decoders; measured today, the honest count is "three decoders plus two structurally different
   literal pass-throughs," which is a different (and better) shape than #513's own text describes.
-- Its two named instances (#437, #438) remain open on their own, correctly -- this census does not
-  fix either, per #667's own instruction.
+- Its two named instances were left open on their own, correctly, per #667's own instruction that
+  this census does not fix either. **#437 has since been fixed** (see the update in "#437,
+  reproduced directly against the current tree" above); #438 remains open.
 - The one open decision #513 raised and this census did not resolve -- the null/failure sentinel
   policy on the result side (0 is both "genuine C0" and "failed/null," on every raw-cast result
   function measured above) -- is a design decision, not a census finding, and is better tracked

--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -48,9 +48,10 @@
 /// ```
 ///
 /// - Note: Not every API accepts every order. A bare point cannot carry curvature, so
-///   ``Shape/plateSurface(through:orders:degree:pointsOnCurves:iterations:tolerance:)``
-///   fails outright if any point is given ``g2`` (`GeomPlate_PointConstraint` throws above
-///   order 1).
+///   ``Shape/plateSurface(through:orders:degree:pointsOnCurves:iterations:tolerance:)`` and the
+///   point half of ``Shape/plateSurface(pointConstraints:curveConstraints:degree:tolerance:)``
+///   reject ``g2`` up front, before building any constraint (`GeomPlate_PointConstraint` throws
+///   above order 1; see ``SurfaceContinuity/isUnsupportedForPointConstraint``, #437).
 public enum SurfaceContinuity: Int32, Sendable, CaseIterable {
     /// Positional continuity (G0). The surface passes through the constraint.
     case g0 = 0
@@ -58,6 +59,33 @@ public enum SurfaceContinuity: Int32, Sendable, CaseIterable {
     case g1 = 1
     /// Curvature continuity (G2). The surface matches curvature along the constraint.
     case g2 = 2
+}
+
+extension SurfaceContinuity {
+    /// Whether this order can never be honoured by a bare *point* constraint (#437).
+    ///
+    /// `GeomPlate_PointConstraint`'s point constructor throws above order 1
+    /// (`GeomPlate_PointConstraint.cxx`, pinned `V8_0_1`):
+    ///
+    /// ```cpp
+    /// if ((myOrder > 1) || (myOrder < -1)) {
+    ///   throw Standard_Failure("GeomPlate_PointConstraint : the constraint must 0 or -1 with a point");
+    /// }
+    /// ```
+    ///
+    /// A bare point carries no curvature to match, so ``g2`` is genuinely out of domain for a
+    /// point constraint: this is not an OCCT defect. `GeomPlate_CurveConstraint` has no such
+    /// restriction (it accepts order up to 2 directly), so this only ever applies to a *point*.
+    ///
+    /// `Shape.plateSurface(through:orders:...)` and the point half of
+    /// `Shape.plateSurface(pointConstraints:curveConstraints:...)` check this before building any
+    /// `GeomPlate_PointConstraint`, so a `.g2` point order fails immediately with the reason on
+    /// record here rather than reaching `GeomPlate_BuildPlateSurface`, throwing, and being
+    /// swallowed by the bridge's `catch (...)`, which produced the same `nil`, but for a reason
+    /// nothing on the Swift side asserted, and only because OCCT happens to throw there today.
+    var isUnsupportedForPointConstraint: Bool {
+        self == .g2
+    }
 }
 
 extension SurfaceContinuity {

--- a/Sources/OCCTSwift/Shape+Surface.swift
+++ b/Sources/OCCTSwift/Shape+Surface.swift
@@ -359,7 +359,7 @@ extension Shape {
         tolerance: Double = 0.01
     ) -> Shape? {
         guard points.count >= 3, points.count == orders.count else { return nil }
-        guard !orders.contains(where: \.isUnsupportedForPointConstraint) else { return nil }
+        guard !Shape.plateRejectsPointOrders(orders) else { return nil }
 
         var flatPoints: [Double] = []
         for p in points {
@@ -378,8 +378,23 @@ extension Shape {
         return Shape(handle: result)
     }
 
+    /// Whether any order in a batch of *point* constraints would fail
+    /// `GeomPlate_PointConstraint`'s own domain check (#437), i.e. whether any element is
+    /// ``SurfaceContinuity/isUnsupportedForPointConstraint``.
+    ///
+    /// The one shared implementation behind both plate-point entry points' rejection guard:
+    /// `plateSurface(through:orders:)` and, via ``plateMixedRejectsPointOrders(_:)``,
+    /// `plateSurface(pointConstraints:curveConstraints:)`. Each passes its own `orders` shape
+    /// (a flat array here, a `(point, order)` tuple array there), but both defer the actual
+    /// domain question to this one function rather than each re-testing
+    /// `isUnsupportedForPointConstraint` inline.
+    static func plateRejectsPointOrders(_ orders: some Sequence<SurfaceContinuity>) -> Bool {
+        orders.contains(where: \.isUnsupportedForPointConstraint)
+    }
+
     /// Whether any point constraint here would fail `GeomPlate_PointConstraint`'s own domain
-    /// check (#437), i.e. whether any `order` is ``SurfaceContinuity/isUnsupportedForPointConstraint``.
+    /// check (#437). Thin adapter over ``plateRejectsPointOrders(_:)`` for the mixed overload's
+    /// `(point, order)` tuple shape.
     ///
     /// Deliberately takes only `points`, not `curves`: `GeomPlate_CurveConstraint` has no such
     /// restriction, so curve orders must never be able to influence this decision. That is a
@@ -388,7 +403,7 @@ extension Shape {
     static func plateMixedRejectsPointOrders(
         _ points: [(point: SIMD3<Double>, order: SurfaceContinuity)]
     ) -> Bool {
-        points.contains(where: { $0.order.isUnsupportedForPointConstraint })
+        plateRejectsPointOrders(points.map(\.order))
     }
 
     /// Create a plate surface with mixed point and curve constraints.
@@ -400,6 +415,15 @@ extension Shape {
     /// order 2 outright, #437) but is fine for a **curve** constraint (`GeomPlate_CurveConstraint`
     /// accepts order 2 directly); see ``SurfaceContinuity/isUnsupportedForPointConstraint``. Only
     /// `points`' orders are checked; `curves`' orders are not.
+    ///
+    /// ```swift
+    /// // A point held to G0 alongside a rectangular boundary wire held to G0.
+    /// // A .g2 point order here would make the whole call return nil (see above).
+    /// let surface = Shape.plateSurface(
+    ///     pointConstraints: [(point: SIMD3(5, 5, 3), order: .g0)],
+    ///     curveConstraints: [(wire: boundaryWire, order: .g0)]
+    /// )
+    /// ```
     ///
     /// - Parameters:
     ///   - points: Point constraints with positions and orders (`.g2` always rejected, see above)

--- a/Sources/OCCTSwift/Shape+Surface.swift
+++ b/Sources/OCCTSwift/Shape+Surface.swift
@@ -331,12 +331,20 @@ extension Shape {
 
     /// Create a plate surface through points with specified constraint orders per point.
     ///
-    /// Each point can independently specify G0 (position only), G1 (position + tangent),
-    /// or G2 (position + tangent + curvature) continuity.
+    /// Each point can independently specify G0 (position only) or G1 (position + tangent)
+    /// continuity. **`.g2` always returns `nil`**: a bare point carries no curvature to match,
+    /// so `GeomPlate_PointConstraint` rejects order 2 outright (#437). This is checked here,
+    /// before any constraint is built; see ``SurfaceContinuity/isUnsupportedForPointConstraint``.
+    ///
+    /// ```swift
+    /// // .g2 anywhere in `orders` is rejected up front; the call below is always nil.
+    /// let rejected = Shape.plateSurface(through: points,
+    ///                                    orders: Array(repeating: .g2, count: points.count))
+    /// ```
     ///
     /// - Parameters:
     ///   - points: Array of 3D points the surface must satisfy
-    ///   - orders: Constraint order per point (`.g0`, `.g1`, or `.g2`)
+    ///   - orders: Constraint order per point (`.g0` or `.g1`; `.g2` is rejected, see above)
     ///   - degree: Maximum polynomial degree (default 3)
     ///   - pointsOnCurves: Number of sample points on curves (default 15)
     ///   - iterations: Number of solver iterations (default 2)
@@ -351,6 +359,7 @@ extension Shape {
         tolerance: Double = 0.01
     ) -> Shape? {
         guard points.count >= 3, points.count == orders.count else { return nil }
+        guard !orders.contains(where: \.isUnsupportedForPointConstraint) else { return nil }
 
         var flatPoints: [Double] = []
         for p in points {
@@ -369,13 +378,31 @@ extension Shape {
         return Shape(handle: result)
     }
 
+    /// Whether any point constraint here would fail `GeomPlate_PointConstraint`'s own domain
+    /// check (#437), i.e. whether any `order` is ``SurfaceContinuity/isUnsupportedForPointConstraint``.
+    ///
+    /// Deliberately takes only `points`, not `curves`: `GeomPlate_CurveConstraint` has no such
+    /// restriction, so curve orders must never be able to influence this decision. That is a
+    /// property of this function's own *signature*, not just its body: there is no `curves`
+    /// parameter for a future edit to reach for by mistake.
+    static func plateMixedRejectsPointOrders(
+        _ points: [(point: SIMD3<Double>, order: SurfaceContinuity)]
+    ) -> Bool {
+        points.contains(where: { $0.order.isUnsupportedForPointConstraint })
+    }
+
     /// Create a plate surface with mixed point and curve constraints.
     ///
     /// Combines point constraints (each with its own continuity order) and
     /// curve constraints (wires with continuity orders) into a single plate surface.
     ///
+    /// `.g2` is rejected up front for a **point** constraint (`GeomPlate_PointConstraint` rejects
+    /// order 2 outright, #437) but is fine for a **curve** constraint (`GeomPlate_CurveConstraint`
+    /// accepts order 2 directly); see ``SurfaceContinuity/isUnsupportedForPointConstraint``. Only
+    /// `points`' orders are checked; `curves`' orders are not.
+    ///
     /// - Parameters:
-    ///   - points: Point constraints with positions and orders
+    ///   - points: Point constraints with positions and orders (`.g2` always rejected, see above)
     ///   - curves: Curve constraints with wires and orders
     ///   - degree: Maximum polynomial degree (default 3)
     ///   - tolerance: Approximation tolerance (default 0.01)
@@ -387,6 +414,7 @@ extension Shape {
         tolerance: Double = 0.01
     ) -> Shape? {
         guard !points.isEmpty || !curves.isEmpty else { return nil }
+        guard !Shape.plateMixedRejectsPointOrders(points) else { return nil }
 
         var flatPoints: [Double] = []
         var pointOrders: [Int32] = []

--- a/Tests/OCCTSurfaceTests/Issue398ContinuityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue398ContinuityTests.swift
@@ -79,8 +79,12 @@ struct Issue398ContinuityTests {
 
     // MARK: - Orders OCCT will not accept
 
-    // NOTE: both tests below pin a BUG, not desired behaviour. Flip the `== nil` expectations
-    // when #437 lands and .g2 either clamps or is rejected up front.
+    // #437 (fixed): `.g2` on a point constraint is now rejected deliberately, in Swift, before
+    // any `GeomPlate_PointConstraint` is built -- see `SurfaceContinuity.isUnsupportedForPointConstraint`
+    // and `Issue437PlatePointG2Tests`. The `== nil` answer below does NOT change: it was already
+    // `nil` (OCCT throws, the bridge's `catch (...)` swallows it), and stays `nil` now that the
+    // rejection is explicit. What changed is *why* -- these two tests alone cannot show that; see
+    // `Issue437PlatePointG2Tests`'s own class comment for the guard-removal matrix that does.
     @Test("Plate point constraints reject curvature order")
     func plateThroughPointsRejectsCurvatureOrder() {
         // GeomPlate_PointConstraint throws above order 1: a bare point carries no curvature

--- a/Tests/OCCTSurfaceTests/Issue437PlatePointG2Tests.swift
+++ b/Tests/OCCTSurfaceTests/Issue437PlatePointG2Tests.swift
@@ -1,0 +1,138 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #437: `GeomPlate_PointConstraint`'s point constructor throws above order 1 -- a bare point
+/// carries no curvature to match, so `.g2` can never work for a *point* constraint. Cluster D's
+/// census (#513/#667) measured this as a genuine instance of the shared root: `SurfaceContinuity`'s
+/// raw value is forwarded as a literal `GeomPlate_PointConstraint`/`CurveConstraint` order with no
+/// `GeomAbs_Shape` decode step at all.
+///
+/// Fixed by rejecting `.g2` for a point constraint in Swift, before any `GeomPlate_PointConstraint`
+/// is built, rather than relying on OCCT's own throw (caught by the bridge's `catch (...)`) to
+/// produce the same `nil` by accident. `GeomPlate_CurveConstraint` has no such restriction (it
+/// accepts order 2 directly), so only point orders are checked -- curve orders are untouched.
+///
+/// ## Prove-the-test-fails: what actually caught the injected defects, and what didn't
+///
+/// Measured, not assumed (`okf/policies/prove-the-test-fails.md`): every `.g2`-on-a-point input
+/// reachable through the public API was **already** `nil` before this fix, because OCCT's own
+/// throw is caught by the bridge's blanket `catch (...)`. That means the public-contract tests
+/// below (`allG2Rejected`, `oneG2AmongValidOrdersRejected`, `mixedPointG2RejectedAlongsideValidCurve`,
+/// plus the pre-existing `Issue398ContinuityTests` pair) **stayed green when the new Swift-side
+/// guard was removed and re-tested** -- confirmed by literally deleting each guard clause in turn,
+/// rebuilding, and re-running this suite. They still pin a real contract (the public answer must
+/// stay `nil`), so they are kept, but they do not by themselves prove the new mechanism exists;
+/// they are labelled below rather than counted as such. Only `pointConstraintSupport` and
+/// `mixedGuardIgnoresCurveOrders`, which call the new pure-Swift guards directly, went red when
+/// the guards they cover were broken.
+///
+/// | case | guard broken | result |
+/// |---|---|---|
+/// | `pointConstraintSupport` | `isUnsupportedForPointConstraint` forced to `false` | **red** |
+/// | `mixedGuardIgnoresCurveOrders` | same (transitively) | **red** |
+/// | `mixedGuardIgnoresCurveOrders` | `plateMixedRejectsPointOrders` forced to `false` | **red** |
+/// | `allG2Rejected` | `plateSurface(through:orders:)`'s guard clause deleted | green (decorative for this guard) |
+/// | `oneG2AmongValidOrdersRejected` | same | green (decorative) |
+/// | `g0AndG1StillBuild` | same | green (never touches `.g2`, unaffected either way) |
+/// | `mixedPointG2RejectedAlongsideValidCurve` | `plateSurface(pointConstraints:curveConstraints:)`'s guard clause deleted | green (decorative for this guard) |
+/// | `mixedPointG0G1StillBuild` | same | green (never touches `.g2`, unaffected either way) |
+/// | `Issue398ContinuityTests.plateThroughPointsRejectsCurvatureOrder` | `isUnsupportedForPointConstraint` forced to `false` | green (decorative, pre-existing) |
+/// | `Issue398ContinuityTests.plateThroughPointsRejectsMixedCurvatureOrder` | same | green (decorative, pre-existing) |
+@Suite("Plate point constraint G2 domain restriction (#437)")
+struct Issue437PlatePointG2Tests {
+
+    private let pentagon: [SIMD3<Double>] = [
+        SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2), SIMD3(0, 10, 1), SIMD3(5, 5, 3)
+    ]
+
+    private var rectangleWire: Wire {
+        Wire.path([SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)],
+                  closed: true)!
+    }
+
+    // MARK: - The guards themselves -- these are the tests that actually prove the mechanism
+
+    @Test("g0 and g1 are supported for a point constraint; g2 is not")
+    func pointConstraintSupport() {
+        #expect(!SurfaceContinuity.g0.isUnsupportedForPointConstraint)
+        #expect(!SurfaceContinuity.g1.isUnsupportedForPointConstraint)
+        #expect(SurfaceContinuity.g2.isUnsupportedForPointConstraint)
+    }
+
+    // `GeomPlate_CurveConstraint` (unlike the point constructor) accepts order 2 directly, so a
+    // curve .g2 constraint must never be rejected by this guard. Proving that by actually
+    // building a curve .g2 plate surface would conflate two different questions: whether the
+    // guard inspected `curves` (an encoding question, #437's own claim) and whether
+    // `GeomPlate_BuildPlateSurface`'s solver converges at G2 on a given wire (a tolerance/geometry
+    // question the census already found separate and fixture-dependent -- measured nil on both a
+    // circle and this suite's own rectangle wire when tried here). So this tests
+    // `plateMixedRejectsPointOrders` directly: its signature takes no `curves` parameter at all,
+    // which makes "curve orders cannot affect this decision" a fact about the function's shape,
+    // not its convergence luck.
+    @Test("The mixed-constraint guard's decision depends only on point orders")
+    func mixedGuardIgnoresCurveOrders() {
+        #expect(!Shape.plateMixedRejectsPointOrders([]))
+        #expect(!Shape.plateMixedRejectsPointOrders([(point: SIMD3(0, 0, 0), order: .g0)]))
+        #expect(!Shape.plateMixedRejectsPointOrders([(point: SIMD3(0, 0, 0), order: .g1)]))
+        #expect(Shape.plateMixedRejectsPointOrders([(point: SIMD3(0, 0, 0), order: .g2)]))
+
+        // One g2 among several otherwise-valid points still poisons the batch.
+        let mixed: [(point: SIMD3<Double>, order: SurfaceContinuity)] = [
+            (point: SIMD3(0, 0, 0), order: .g0),
+            (point: SIMD3(1, 0, 0), order: .g1),
+            (point: SIMD3(0, 1, 0), order: .g2)
+        ]
+        #expect(Shape.plateMixedRejectsPointOrders(mixed))
+    }
+
+    // MARK: - Public contract: plateSurface(through:orders:)
+    //
+    // These pin the observable answer (still `nil` for a point .g2, as it was before this PR),
+    // labelled per the class comment above: measured to stay green with the new guard deleted,
+    // because OCCT's own throw is already caught by the bridge. Kept as contract tests, not as
+    // proof of the new mechanism.
+
+    @Test("All-g2 orders are rejected")
+    func allG2Rejected() {
+        let orders = Array(repeating: SurfaceContinuity.g2, count: pentagon.count)
+        #expect(Shape.plateSurface(through: pentagon, orders: orders) == nil)
+    }
+
+    @Test("A single g2 among otherwise-valid orders poisons the whole call")
+    func oneG2AmongValidOrdersRejected() {
+        var orders: [SurfaceContinuity] = Array(repeating: .g0, count: pentagon.count)
+        orders[2] = .g2
+        #expect(Shape.plateSurface(through: pentagon, orders: orders) == nil)
+    }
+
+    @Test("g0 and g1 orders still build")
+    func g0AndG1StillBuild() {
+        let g0 = Shape.plateSurface(through: pentagon, orders: Array(repeating: .g0, count: pentagon.count))
+        let g1 = Shape.plateSurface(through: pentagon, orders: Array(repeating: .g1, count: pentagon.count))
+        #expect(g0 != nil)
+        #expect(g1 != nil)
+    }
+
+    // MARK: - Public contract: plateSurface(pointConstraints:curveConstraints:)
+    //
+    // Same labelling as the section above: contract tests, not proof of the mechanism.
+
+    @Test("A g2 point constraint is rejected even alongside otherwise-valid curve constraints")
+    func mixedPointG2RejectedAlongsideValidCurve() {
+        let shape = Shape.plateSurface(
+            pointConstraints: [(point: SIMD3(5, 5, 3), order: .g2)],
+            curveConstraints: [(wire: rectangleWire, order: .g0)]
+        )
+        #expect(shape == nil)
+    }
+
+    @Test("g0/g1 point constraints alongside a curve constraint still build")
+    func mixedPointG0G1StillBuild() {
+        let g0 = Shape.plateSurface(
+            pointConstraints: [(point: SIMD3(5, 5, 3), order: .g0)],
+            curveConstraints: [(wire: rectangleWire, order: .g0)]
+        )
+        #expect(g0 != nil)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue437PlatePointG2Tests.swift
+++ b/Tests/OCCTSurfaceTests/Issue437PlatePointG2Tests.swift
@@ -27,11 +27,27 @@ import simd
 /// `mixedGuardIgnoresCurveOrders`, which call the new pure-Swift guards directly, went red when
 /// the guards they cover were broken.
 ///
+/// After the automated review on PR #719 pointed out the point-order rejection check was
+/// implemented twice (inline in `plateSurface(through:orders:)`, and again in
+/// `plateMixedRejectsPointOrders`), both were consolidated onto one shared
+/// `Shape.plateRejectsPointOrders(_:)`. `sharedPointOrderGuardIsUnified` exercises that function
+/// directly and goes red when it is forced to always return `false`.
+/// `mixedGuardIgnoresCurveOrders` also goes red under that same injection, transitively through
+/// `plateMixedRejectsPointOrders`. `allG2Rejected`/`oneG2AmongValidOrdersRejected` do **not**:
+/// forcing `plateRejectsPointOrders` to `false` only removes the Swift-side rejection, and the
+/// `.g2` orders those two tests use still reach `GeomPlate_PointConstraint` and throw there,
+/// caught by the bridge into the same `nil`, measured rather than assumed, same as the
+/// guard-clause deletion below.
+///
 /// | case | guard broken | result |
 /// |---|---|---|
 /// | `pointConstraintSupport` | `isUnsupportedForPointConstraint` forced to `false` | **red** |
 /// | `mixedGuardIgnoresCurveOrders` | same (transitively) | **red** |
 /// | `mixedGuardIgnoresCurveOrders` | `plateMixedRejectsPointOrders` forced to `false` | **red** |
+/// | `mixedGuardIgnoresCurveOrders` | `plateRejectsPointOrders` forced to `false` | **red** (transitively) |
+/// | `sharedPointOrderGuardIsUnified` | `plateRejectsPointOrders` forced to `false` | **red** |
+/// | `allG2Rejected` | `plateRejectsPointOrders` forced to `false` | green (OCCT's own throw still catches `.g2`) |
+/// | `oneG2AmongValidOrdersRejected` | same | green (same reason) |
 /// | `allG2Rejected` | `plateSurface(through:orders:)`'s guard clause deleted | green (decorative for this guard) |
 /// | `oneG2AmongValidOrdersRejected` | same | green (decorative) |
 /// | `g0AndG1StillBuild` | same | green (never touches `.g2`, unaffected either way) |
@@ -46,9 +62,12 @@ struct Issue437PlatePointG2Tests {
         SIMD3(0, 0, 0), SIMD3(10, 0, 1), SIMD3(10, 10, 2), SIMD3(0, 10, 1), SIMD3(5, 5, 3)
     ]
 
-    private var rectangleWire: Wire {
-        Wire.path([SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)],
-                  closed: true)!
+    // `try #require` rather than force-unwrap: a nil here should fail the one test that asked
+    // for it, not abort the whole `swift test` binary and silently discard every other suite's
+    // results in the same run.
+    private func rectangleWire() throws -> Wire {
+        try #require(Wire.path([SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)],
+                                closed: true))
     }
 
     // MARK: - The guards themselves -- these are the tests that actually prove the mechanism
@@ -86,6 +105,19 @@ struct Issue437PlatePointG2Tests {
         #expect(Shape.plateMixedRejectsPointOrders(mixed))
     }
 
+    // Both entry points' rejection checks (`plateSurface(through:orders:)`'s inline guard and
+    // `plateMixedRejectsPointOrders`, above) now defer to this one function rather than each
+    // re-testing `isUnsupportedForPointConstraint` independently, which is the consolidation
+    // the automated review on PR #719 asked for. Exercised directly, and against a plain array
+    // (`plateSurface(through:orders:)`'s shape) rather than the tuple array
+    // `plateMixedRejectsPointOrders` covers above, so this is not just a copy of that test.
+    @Test("The shared point-order guard is the one implementation both entry points defer to")
+    func sharedPointOrderGuardIsUnified() {
+        #expect(!Shape.plateRejectsPointOrders([SurfaceContinuity]()))
+        #expect(!Shape.plateRejectsPointOrders([SurfaceContinuity.g0, .g1]))
+        #expect(Shape.plateRejectsPointOrders([SurfaceContinuity.g0, .g2, .g1]))
+    }
+
     // MARK: - Public contract: plateSurface(through:orders:)
     //
     // These pin the observable answer (still `nil` for a point .g2, as it was before this PR),
@@ -119,19 +151,19 @@ struct Issue437PlatePointG2Tests {
     // Same labelling as the section above: contract tests, not proof of the mechanism.
 
     @Test("A g2 point constraint is rejected even alongside otherwise-valid curve constraints")
-    func mixedPointG2RejectedAlongsideValidCurve() {
+    func mixedPointG2RejectedAlongsideValidCurve() throws {
         let shape = Shape.plateSurface(
             pointConstraints: [(point: SIMD3(5, 5, 3), order: .g2)],
-            curveConstraints: [(wire: rectangleWire, order: .g0)]
+            curveConstraints: [(wire: try rectangleWire(), order: .g0)]
         )
         #expect(shape == nil)
     }
 
     @Test("g0/g1 point constraints alongside a curve constraint still build")
-    func mixedPointG0G1StillBuild() {
+    func mixedPointG0G1StillBuild() throws {
         let g0 = Shape.plateSurface(
             pointConstraints: [(point: SIMD3(5, 5, 3), order: .g0)],
-            curveConstraints: [(wire: rectangleWire, order: .g0)]
+            curveConstraints: [(wire: try rectangleWire(), order: .g0)]
         )
         #expect(g0 != nil)
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,50 @@ All notable changes to OCCTSwift.
 
 ## Unreleased
 
+### `plateSurface`'s point constraints reject `.g2` in Swift instead of relying on OCCT's own throw (#437)
+
+Cluster D's continuity census (#513/#667, `Scripts/repro/cluster-d-continuity/`) measured #437 as a
+genuine instance of the cluster's shared root: `SurfaceContinuity`'s raw value is forwarded as a
+literal `GeomPlate_PointConstraint`/`GeomPlate_CurveConstraint` order, with no `GeomAbs_Shape`
+decode step at all. `GeomPlate_PointConstraint`'s point constructor throws above order 1 (pinned
+`V8_0_1`, `GeomPlate_PointConstraint.cxx`): a bare point carries no curvature to match, so `.g2`
+was always out of domain for a point constraint. `GeomPlate_CurveConstraint` has no such
+restriction and accepts order 2 directly, so this is a point-only defect.
+
+`Shape.plateSurface(through:orders:...)` and the point half of
+`Shape.plateSurface(pointConstraints:curveConstraints:...)` clamped the incoming order into
+`[0, 2]` and passed it straight to the constructor, which threw, unwound past the whole constraint
+loop, and was swallowed by the bridge's blanket `catch (...)`, returning `nil` with no indication
+which constraint was at fault.
+
+**Rejected at the Swift boundary instead of clamped or split into a new type.** Three options were
+on the table (`SurfaceContinuity.g2` documented as unsupported here already, from #436):
+
+- **Clamp to `[0, 1]` in the bridge.** Silently substitutes a lower order than the caller asked
+  for, the same class of behaviour #430/#432/#434 deliberately moved away from ("used or the
+  constraint fails, never silently substituted").
+- **Give point constraints a narrower type that cannot express curvature.** Most precise, but adds
+  a fourth continuity vocabulary right where #398/#490 spent real effort collapsing nine into two,
+  and unlike #619 (which *retired* a parameter because its name lied about what it took), this
+  would be introducing a new type for a shared enum that is correct everywhere else it is used
+  (`Shape.fill`, `FillingSurface`, curve constraints all accept `.g2` legitimately).
+- **Reject in Swift, before building any constraint.** Chosen. Keeps the single `SurfaceContinuity`
+  vocabulary, and makes the `nil` a deliberate, documented decision instead of an accidental
+  side effect of OCCT happening to throw where our bridge happens to catch.
+
+The public answer does not change: a point `.g2` was already `nil` and stays `nil`. What changes
+is that the rejection is now asserted in Swift
+(`SurfaceContinuity.isUnsupportedForPointConstraint`, `Shape.plateMixedRejectsPointOrders`) rather
+than incidentally produced by relying on OCCT's internal domain check, and it no longer builds any
+`GeomPlate_PointConstraint`s before failing. `Issue437PlatePointG2Tests` has the guard-removal
+matrix proving which of its own cases exercise the new mechanism and which pin the (unchanged)
+public contract only, per `okf/policies/prove-the-test-fails.md`.
+
+**Not fixed here:** #438, a different, API-duplication-shaped defect in the same file that the
+census's own measurement confirmed is unrelated to this one (two public APIs correctly decoding
+the same continuity through the same canonical decoder, but setting different criteria on the
+builder).
+
 ### `derive-bridge-header-split.py` now verifies each declaration is in the header its `.mm` owns (#673)
 
 `--verify` only ever asked whether every declared bridge function maps to exactly one `.mm` file,

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1709,8 +1709,11 @@ public enum SurfaceContinuity: Int32, Sendable, CaseIterable {
 ```
 
 Not every API accepts every order. A bare point carries no curvature to match, so
-`GeomPlate_PointConstraint` throws above order 1 and `Shape.plateSurface(through:orders:)`
-returns `nil` if any point is given `.g2`.
+`GeomPlate_PointConstraint` throws above order 1. `Shape.plateSurface(through:orders:)` and the
+point half of `Shape.plateSurface(pointConstraints:curveConstraints:)` reject `.g2` in Swift
+before building any constraint, so a point given `.g2` returns `nil` deliberately rather than by
+relying on OCCT's own throw being caught (#437). Curve constraints have no such restriction:
+`GeomPlate_CurveConstraint` accepts order 2 directly, so `.g2` is fine for a curve.
 
 > **Renamed in #398.** `PlateConstraintOrder` and `FillingContinuity` were separate copies of
 > this same vocabulary and are now deprecated typealiases of `SurfaceContinuity`. The `.c0`,
@@ -2057,11 +2060,14 @@ public static func plateSurface(
 ) -> Shape?
 ```
 
-Each point independently specifies G0 (position), G1 (position + tangent), or G2 (position + tangent + curvature) continuity.
+Each point independently specifies G0 (position) or G1 (position + tangent) continuity.
+**`.g2` always returns `nil`**: `GeomPlate_PointConstraint` rejects order 2 outright for a bare
+point (#437), and this is checked in Swift, via `SurfaceContinuity.isUnsupportedForPointConstraint`,
+before any constraint is built, rather than relying on OCCT's own throw.
 
 - **Parameters:**
   - `points` — 3D points (minimum 3); must match `orders.count`.
-  - `orders` — per-point constraint orders.
+  - `orders` — per-point constraint orders (`.g0` or `.g1`; `.g2` is rejected, see above).
   - `degree` — maximum polynomial degree (default 3).
   - `pointsOnCurves` — sample points on internal curves (default 15).
   - `iterations` — solver iterations (default 2).
@@ -2084,10 +2090,14 @@ public static func plateSurface(
 ) -> Shape?
 ```
 
-At least one of `points` or `curves` must be non-empty.
+At least one of `points` or `curves` must be non-empty. `.g2` is rejected up front for a **point**
+constraint (`GeomPlate_PointConstraint` rejects order 2 outright, #437) but is fine for a
+**curve** constraint (`GeomPlate_CurveConstraint` accepts order 2 directly); only `points`'
+orders are checked.
 
 - **Parameters:**
-  - `points` — point constraints, each with a position and a `SurfaceContinuity`.
+  - `points` — point constraints, each with a position and a `SurfaceContinuity` (`.g2` always
+    rejected, see above).
   - `curves` — curve constraints, each with a `Wire` and a `SurfaceContinuity`.
   - `degree` — maximum polynomial degree (default 3).
   - `tolerance` — approximation tolerance.


### PR DESCRIPTION
## Summary

Closes #437

`GeomPlate_PointConstraint`'s point constructor throws above order 1 (pinned `V8_0_1`,
`GeomPlate_PointConstraint.cxx`): a bare point carries no curvature to match, so `.g2` was always
out of domain for a point constraint. `Shape.plateSurface(through:orders:...)` and the point half
of `Shape.plateSurface(pointConstraints:curveConstraints:...)` clamped the raw `SurfaceContinuity`
value straight into that constructor's literal order parameter, which threw, unwound the whole
constraint loop, and was swallowed by the bridge's blanket `catch (...)`, producing `nil` with no
indication which constraint was at fault.

Cluster D's continuity census (#513/#667, `Scripts/repro/cluster-d-continuity/`) measured #437 as
a genuine instance of the cluster's shared root: `SurfaceContinuity`'s raw value is forwarded as a
literal `GeomPlate_PointConstraint`/`GeomPlate_CurveConstraint` order with no `GeomAbs_Shape`
decode step at all. The census explicitly separated this from #438 (a different, API-duplication
defect in the same file) and left both open for follow-up PRs. This PR fixes #437 only; #438 is
untouched.

## What OCCT actually accepts (measured from the pinned V8_0_1 headers, not recall)

`GeomPlate_PointConstraint(gp_Pnt, order, tolDist)`:

```cpp
if ((myOrder > 1) || (myOrder < -1)) {
  throw Standard_Failure("GeomPlate_PointConstraint : the constraint must 0 or -1 with a point");
}
```

So `-1`, `0`, `1` are accepted (`.g0`/`.g1` reachable through the public API); `2` (`.g2`) throws.
The header's own doc comment ("Raises ConstructionError if Order is not 0 or -1") is itself wrong
in the other direction, since order 1 is accepted; the issue had already found this.
`GeomPlate_CurveConstraint(curve, order)` has no such restriction and accepts order up to 2
directly (`if ((Tang < -1) || (Tang > 2)) throw ...`), confirmed by reading
`GeomPlate_CurveConstraint.cxx`. So this is a point-only defect.

## The decision: reject at the Swift boundary

Three options were on the table:

1. **Clamp to `[0, 1]` in the bridge.** Rejected: silently substitutes a lower order than the
   caller asked for, the same class of behaviour #430/#432/#434 deliberately moved away from
   ("used or the constraint fails, never silently substituted").
2. **Give point constraints a narrower type that cannot express curvature** (the #619
   compile-time pattern). Rejected: this is a *shared* enum (`SurfaceContinuity`) that is correct
   everywhere else it's used (`Shape.fill`, `FillingSurface`, curve constraints all accept `.g2`
   legitimately) — introducing a new type here goes against #398/#490's own consolidation of nine
   continuity enums down to two, right where those issues are explicitly cited as prior art not to
   re-derive. Unlike #619 (which *retired* a parameter because its name lied about what it took),
   this would be adding vocabulary for one narrow case.
3. **Reject in Swift, before building any constraint.** Chosen. Keeps the single
   `SurfaceContinuity` vocabulary, and turns the `nil` from an accidental side effect of OCCT
   happening to throw where the bridge happens to catch into an asserted, documented decision.

New: `SurfaceContinuity.isUnsupportedForPointConstraint` and `Shape.plateMixedRejectsPointOrders`
(both internal), checked before any `GeomPlate_PointConstraint` is built.

## Prove-the-test-fails: the injection matrix

Per `okf/policies/prove-the-test-fails.md`, every case was run once with its guard broken. The
honest finding: the **public-contract tests could not detect the new guard's removal**, because
every `.g2`-on-a-point input was *already* `nil` before this fix (OCCT's own throw, caught by the
bridge). Confirmed by literally deleting each guard clause, rebuilding, and re-running.

| case | guard broken | result |
|---|---|---|
| `pointConstraintSupport` | `isUnsupportedForPointConstraint` forced to `false` | **red** |
| `mixedGuardIgnoresCurveOrders` | same (transitively) | **red** |
| `mixedGuardIgnoresCurveOrders` | `plateMixedRejectsPointOrders` forced to `false` | **red** |
| `allG2Rejected` | `plateSurface(through:orders:)`'s guard clause deleted | green (decorative for this guard) |
| `oneG2AmongValidOrdersRejected` | same | green (decorative) |
| `g0AndG1StillBuild` | same | green (never touches `.g2`, unaffected either way) |
| `mixedPointG2RejectedAlongsideValidCurve` | `plateSurface(pointConstraints:curveConstraints:)`'s guard clause deleted | green (decorative for this guard) |
| `mixedPointG0G1StillBuild` | same | green (unaffected) |
| `Issue398ContinuityTests.plateThroughPointsRejectsCurvatureOrder` | `isUnsupportedForPointConstraint` forced to `false` | green (decorative, pre-existing) |
| `Issue398ContinuityTests.plateThroughPointsRejectsMixedCurvatureOrder` | same | green (decorative, pre-existing) |

Only the two tests that call the new pure-Swift guards directly (`pointConstraintSupport`,
`mixedGuardIgnoresCurveOrders`) actually prove the mechanism; the rest are labelled as
public-contract pins, not proof, per the class doc comment on `Issue437PlatePointG2Tests`.

`mixedGuardIgnoresCurveOrders` also proves the guard's *scope*: proving "a curve `.g2` constraint
isn't rejected" by actually building one would conflate two different questions (the guard's
scope vs. `GeomPlate_BuildPlateSurface`'s solver convergence at G2, which the census already found
separate and fixture-dependent — measured `nil` on both a circle and this suite's own rectangle
wire). So it tests `plateMixedRejectsPointOrders` directly: its signature takes no `curves`
parameter at all, making "curve orders cannot affect this decision" a fact about the function's
shape, not convergence luck.

## What the issue and census got wrong (or that's worth flagging)

- Nothing wrong, but worth noting: the header's own "Raises ConstructionError if Order is not 0 or
  -1" doc comment is imprecise (order 1 is accepted) — already caught by #437's own ground-truth
  table, confirmed again here against the pinned headers.
- The census's own attempt at a curve-side `.g2` positive-control fixture (a plain circle) fails
  to converge; this PR independently found the same on a rectangle wire, confirming the census's
  point that this is a fixture/convergence issue, not an encoding one, and adjusted the new test's
  approach accordingly (tests the guard function directly rather than an end-to-end OCCT build).

## Verify

- [x] Clean `swift build` (`rm -rf .build` first), 0 errors, no new warnings, no `OCCTSWIFT_LOCAL`
- [x] Full `swift test`: 5370 tests, 0 failures (plus the 7 new tests in this PR)
- [x] `swift run Censuses cluster-a` — 45 rows, unchanged
- [x] `swift run Censuses cluster-b` — 16 rows, unchanged
- [x] `swift run Censuses cluster-d` — re-run; the `#437` row is unchanged (still `nil`), matching
      that the public answer doesn't change, only where/why it's decided; README updated to record
      the fix
- [x] `check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py`,
      `count-operations.py`, and all three `--self-test`s, from the repo root
- [x] Zero em-dashes in new/changed prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)