### PR TITLE
docs: record that patches 0022 and 0023 are validated by nothing automated

### DIFF
--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -168,6 +168,28 @@ failures, which turned out to be the known #344/#345 flake, but only checking es
 **`kernel-integration.yml` is the real check.** It is the only job that compiles the patched kernel,
 and it takes roughly 80 minutes. Run it at cluster boundaries rather than per PR.
 
+> **RELEASE-TESTING WATCH-OUT, opened 2026-08-06: two carried patches are currently validated by
+> nothing that runs automatically.** Three facts compound:
+>
+> 1. The branch carries thirteen patches (`0010`-`0012`, `0014`-`0023`), but the pinned
+>    `v2.0.0-kernel.1` asset contains eleven. **`0022` and `0023` are outside the pinned binary**, so
+>    `build-and-test` cannot exercise either, by construction.
+> 2. `kernel-integration.yml`, the job that would compile them, **cannot pass at all** right now
+>    (#727): its trigger paths and its cache key are the same condition, so every triggered run is a
+>    guaranteed cache miss, the 79-minute build leaves about 11 minutes of a 90-minute budget, and
+>    the cancelled job discards the build so re-running cannot help. #728 is the fix.
+> 3. **`0023` (#643, merged as #718) ships with no Swift test.** Its evidence is a `Scripts/repro/`
+>    probe, run by hand. So there is no automated assertion of its behaviour anywhere, on either
+>    kernel.
+>
+> Merged deliberately on that understanding rather than by oversight. Before the release is cut:
+> land #728, publish the next `v2.0.0-kernel.N` pre-release carrying all thirteen patches, bump
+> `Package.swift`'s `url:` and `checksum:`, and re-run `kernel-integration.yml` to completion. Then
+> confirm `0022` and `0023` actually reached the binary rather than assuming the rebuild picked them
+> up, per `docs/guides/building-occt.md`'s shipping-a-rebuild steps. A patch that is carried in the
+> tree but absent from the pinned asset is the #585 failure mode wearing different clothes: the
+> suite is green because it is testing a kernel nobody is shipping.
+
 **`gate-scripts` must be green on every PR.** It is the one required check on `refactor/**` (#649).
 
 ## Versioning

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -183,12 +183,23 @@ and it takes roughly 80 minutes. Run it at cluster boundaries rather than per PR
 >    kernel.
 >
 > Merged deliberately on that understanding rather than by oversight. Before the release is cut:
-> land #728, publish the next `v2.0.0-kernel.N` pre-release carrying all thirteen patches, bump
-> `Package.swift`'s `url:` and `checksum:`, and re-run `kernel-integration.yml` to completion. Then
-> confirm `0022` and `0023` actually reached the binary rather than assuming the rebuild picked them
-> up, per `docs/guides/building-occt.md`'s shipping-a-rebuild steps. A patch that is carried in the
-> tree but absent from the pinned asset is the #585 failure mode wearing different clothes: the
-> suite is green because it is testing a kernel nobody is shipping.
+>
+> 1. Land #728, **and separately watch one real cache-miss run through both of its jobs to green.**
+>    Landing it is not the same as confirming it: a merged workflow change and a working one look
+>    identical until a run exercises the path. As of 2026-08-06 a `workflow_dispatch` run has done
+>    exactly that (63-minute build, cache saved, 11-minute test job restored it and passed), but on
+>    the commit before the cache-poisoning fix, so the success path is proven and the refusal path
+>    is not.
+> 2. Publish the next `v2.0.0-kernel.N` pre-release carrying all thirteen patches, and bump
+>    `Package.swift`'s `url:` and `checksum:` together. #512 tracks the release re-pin, per
+>    `Package.swift`'s own comment, though note its title still scopes it to patch `0017`, which
+>    shipped two rebuilds ago.
+> 3. Re-run `kernel-integration.yml` to completion, then confirm `0022` and `0023` actually reached
+>    the binary rather than assuming the rebuild picked them up, per
+>    [`building-occt.md`](guides/building-occt.md)'s shipping-a-rebuild steps.
+>
+> A patch that is carried in the tree but absent from the pinned asset is the #585 failure mode
+> wearing different clothes: the suite is green because it is testing a kernel nobody is shipping.
 
 **`gate-scripts` must be green on every PR.** It is the one required check on `refactor/**` (#649).
 


### PR DESCRIPTION
## What

Adds a release-testing watch-out to `docs/v2.0.0-plan.md` under Execution mechanics. Docs only.

## Why

Merging #718 (#643, patch `0023`) put the release into a state worth naming now rather than
rediscovering during release testing. Three facts, none individually new, compound:

1. The branch carries **thirteen** patches (`0010`-`0012`, `0014`-`0023`). The pinned
   `v2.0.0-kernel.1` asset contains **eleven**. So `0022` and `0023` are outside the binary that
   `build-and-test` resolves, and that job cannot exercise them by construction.
2. `kernel-integration.yml`, the only job that compiles the patched kernel, **cannot pass at all**
   right now (#727). Its trigger paths and cache key are the same condition, so every triggered run
   is a guaranteed cache miss; the 79-minute build leaves about 11 minutes of a 90-minute budget,
   and the cancelled job discards the build so re-running cannot help. #728 is the fix.
3. `0023` shipped with **no Swift test**. Its evidence is the hand-run
   `Scripts/repro/643-geomtools-null-write` probe.

Together: two carried patches currently have no automated assertion of their behaviour on any
kernel. That is the #585 failure mode wearing different clothes, a suite green because it is
testing a kernel nobody is shipping.

#718 was merged deliberately on this understanding, not by oversight. This just makes the
understanding durable.

## The sequence to clear it before the release is cut

1. Land #728.
2. Publish the next `v2.0.0-kernel.N` pre-release carrying all thirteen patches.
3. Bump `Package.swift`'s `url:` and `checksum:` (the release commit's job, per #512).
4. Re-run `kernel-integration.yml` to completion.
5. Confirm `0022` and `0023` actually reached the binary rather than assuming the rebuild picked
   them up, per `docs/guides/building-occt.md`'s shipping-a-rebuild steps.

Related: #643, #718, #727, #728, #585, #512.