### PR TITLE
fix(#636): guard GeomAPI_ExtremaCurveCurve against parallel curves

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -1072,6 +1072,11 @@ double OCCTCurve3DMinDistanceToCurve(OCCTCurve3DRef c1, OCCTCurve3DRef c2) {
     try {
         GeomAPI_ExtremaCurveCurve extrema(c1->curve, c2->curve);
         if (extrema.NbExtrema() == 0) return -1.0;
+        // No IsParallel() guard needed here (#636): LowerDistance() only reads
+        // Extrema_ExtCC::mySqDist, which Extrema_ExtCC::PrepareParallelResult populates correctly
+        // even on parallel curves. Only Points()/Parameters() (below, in OCCTCurve3DExtrema) index
+        // the mypoints sequence that is left empty in that case. Measured against two parallel
+        // Geom_Line curves: returns the correct offset distance, no crash.
         return extrema.LowerDistance();
     } catch (...) {
         return -1.0;
@@ -1082,6 +1087,18 @@ int32_t OCCTCurve3DExtrema(OCCTCurve3DRef c1, OCCTCurve3DRef c2, OCCTCurveExtrem
     if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !outExtrema || maxCount <= 0) return 0;
     try {
         GeomAPI_ExtremaCurveCurve extrema(c1->curve, c2->curve);
+        // GeomAPI_ExtremaCurveCurve wraps Extrema_ExtCC (the same class BRepExtrema_ExtCC's
+        // documented parallel-curve crash traces back to, one layer down). On parallel curves,
+        // Extrema_ExtCC::PrepareParallelResult appends a single distance to mySqDist but leaves
+        // mypoints empty; NbExtrema() reports 1 (mySqDist.Length()), so Points() below indexes an
+        // empty NCollection_Sequence. This build's OCCT disables Standard_OutOfRange in Release
+        // (BUILD_RELEASE_DISABLE_EXCEPTIONS), so that indexing is not a caught exception: it is
+        // an OS SIGSEGV, uncatchable by the catch(...) below (#636). Query IsParallel() before
+        // touching any solution, mirroring the guard already in place for the sibling
+        // Extrema_ExtCC/Extrema_ExtCS entry points in this same file (OCCTExtremaExtCC /
+        // OCCTExtremaExtCS). LowerDistance()-only callers (OCCTCurve3DMinDistanceToCurve) are
+        // unaffected: mySqDist is populated correctly even when parallel, only mypoints is not.
+        if (extrema.IsParallel()) return 0;
         int32_t nb = extrema.NbExtrema();
         int32_t count = (nb < maxCount) ? nb : maxCount;
         for (int32_t i = 0; i < count; i++) {

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -791,6 +791,28 @@ extension Curve3D {
     ///   represents that case as a single unbounded family of equidistant solutions rather than a
     ///   finite set of point pairs, so there is no `(point1, point2)` pair to report (#636). Use
     ///   ``minDistance(to:)`` to get the (well-defined) distance in that case.
+    ///
+    /// An empty array therefore means one of two different things, and this method cannot tell you
+    /// which: the curves are parallel, or they simply have no extremal relationship. If you need to
+    /// distinguish them, ``extremaCC(range1:other:range2:)`` returns a `CurveCurveExtrema` carrying
+    /// `isParallel` alongside the count, from the same underlying computation.
+    ///
+    /// ```swift
+    /// let a = Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0))!
+    /// let b = Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0))!
+    ///
+    /// let pairs = a.extrema(with: b)              // [], but why?
+    /// if pairs.isEmpty {
+    ///     let info = a.extremaCC(other: b)
+    ///     print(info.isParallel)                  // true: an infinite equidistant family
+    ///     print(a.minDistance(to: b) ?? 0)        // 5.0, the well-defined separation
+    /// }
+    /// ```
+    ///
+    /// "Parallel" here is OCCT's own predicate, which is narrower than "the tangent directions are
+    /// parallel". Two parallel segments whose parameter ranges do not overlap have a single
+    /// well-defined nearest-endpoint pair; `isParallel` is false for them, and this method returns
+    /// that pair normally.
     public func extrema(with other: Curve3D, maxCount: Int = 20) -> [CurveExtremaResult] {
         let maxCount = Sampling.capacity(maxCount)
         guard maxCount > 0 else { return [] }

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -787,7 +787,10 @@ extension Curve3D {
     ///   - other: The other curve
     ///   - maxCount: Output *capacity* (default 20), clamped into `0...`
     ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
-    /// - Returns: Array of extremal distance results
+    /// - Returns: Array of extremal distance results. Empty when the curves are parallel: OCCT
+    ///   represents that case as a single unbounded family of equidistant solutions rather than a
+    ///   finite set of point pairs, so there is no `(point1, point2)` pair to report (#636). Use
+    ///   ``minDistance(to:)`` to get the (well-defined) distance in that case.
     public func extrema(with other: Curve3D, maxCount: Int = 20) -> [CurveExtremaResult] {
         let maxCount = Sampling.capacity(maxCount)
         guard maxCount > 0 else { return [] }

--- a/Tests/OCCTCurveTests/Issue636ExtremaParallelCurvesTests.swift
+++ b/Tests/OCCTCurveTests/Issue636ExtremaParallelCurvesTests.swift
@@ -14,11 +14,22 @@ import Foundation
 /// unbounded pair, or a bounded pair whose projected ranges overlap, where there is no single
 /// discrete closest point when a whole span is equidistant) never append the matching pair to
 /// `mypoints`. `NbExtrema()` reports 1 (`mySqDist.Length()`), so `Points()` indexes an empty
-/// `NCollection_Sequence`. This project's OCCT is built with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`
-/// (`No_Exception`), so the bounds check that would normally throw `Standard_OutOfRange` compiles
-/// to nothing, and the out-of-range access is undefined behaviour: measured (via a standalone
-/// ground-truth binary linked directly against `libOCCT-macos.a`) to be a genuine SIGSEGV, not a
-/// C++ exception. A `catch (...)` around the call cannot help: an OS signal never reaches it.
+/// `NCollection_Sequence`.
+///
+/// Which check fails, precisely, because it is not the obvious one. `Extrema_ExtCC::Points()` does
+/// carry `if (N < 1 || N > NbExt()) throw Standard_OutOfRange();`, and that is a RAW throw, not a
+/// `_Raise_if` macro, so `No_Exception` does not remove it. It simply asks the wrong question:
+/// `NbExt()` counts `mySqDist`, and the index is about to be used against `mypoints`. The check
+/// that would have caught it is one level down, in `NCollection_Sequence::Value(const int)`, and
+/// that one IS a `Standard_OutOfRange_Raise_if` macro, which this project's
+/// `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON` build compiles to nothing. So the out-of-range read is
+/// undefined behaviour: measured (via a standalone ground-truth binary linked directly against
+/// `libOCCT-macos.a`) to be a genuine SIGSEGV, not a C++ exception. A `catch (...)` around the call
+/// cannot help: an OS signal never reaches it.
+///
+/// That distinction is the whole basis of the kernel fix in #743 / patch `0024`: the repair is not
+/// to restore an exception, it is to make `Points()` bound against the container it actually
+/// indexes.
 ///
 /// Both fixtures below reproduced the crash before the fix (confirmed via the same standalone
 /// ground-truth binary, `GeomAPI_ExtremaCurveCurve` constructed directly): two unbounded parallel

--- a/Tests/OCCTCurveTests/Issue636ExtremaParallelCurvesTests.swift
+++ b/Tests/OCCTCurveTests/Issue636ExtremaParallelCurvesTests.swift
@@ -31,10 +31,31 @@ import Foundation
 @Suite("Curve3D.extrema returns empty, not SIGSEGV, on parallel curves (#636)")
 struct Issue636ExtremaParallelCurvesTests {
 
+    /// The two crashing shapes, defined once. `minDistanceUnaffectedByTheGuard` below exercises the
+    /// same geometry as the two tests above it, and the point of that test is that it is the same
+    /// geometry, so the fixtures are shared rather than copied. Copies drift: tighten one and the
+    /// test asserting the contrast silently starts contrasting something else.
+    ///
+    /// Both pairs are 5.0 apart, which every distance assertion here depends on.
+    private static let parallelOffset = 5.0
+
+    private static func unboundedParallelLines() throws -> (Curve3D, Curve3D) {
+        (try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0))),
+         try #require(Curve3D.line(through: SIMD3(0, parallelOffset, 0), direction: SIMD3(1, 0, 0))))
+    }
+
+    /// Bounded, and their projected ranges OVERLAP, which is the condition that makes
+    /// `Extrema_ExtCC` report a solution it never stored. Disjoint ranges are a different case:
+    /// `IsParallel()` returns false for those and the endpoint solution is real, so they are not a
+    /// fixture for this bug. See the suite's own note and PR #730's verification comment.
+    private static func overlappingParallelSegments() throws -> (Curve3D, Curve3D) {
+        (try #require(Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))),
+         try #require(Curve3D.segment(from: SIMD3(0, parallelOffset, 0), to: SIMD3(10, parallelOffset, 0))))
+    }
+
     @Test("Two unbounded parallel lines: extrema is empty, not a crash")
     func parallelUnboundedLinesReturnEmpty() throws {
-        let a = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
-        let b = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+        let (a, b) = try Self.unboundedParallelLines()
 
         #expect(a.extrema(with: b).isEmpty)
         #expect(a.extrema(with: b, maxCount: 1).isEmpty)
@@ -43,8 +64,7 @@ struct Issue636ExtremaParallelCurvesTests {
 
     @Test("Two bounded parallel segments with overlapping projected ranges: extrema is empty")
     func parallelBoundedSegmentsReturnEmpty() throws {
-        let a = try #require(Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)))
-        let b = try #require(Curve3D.segment(from: SIMD3(0, 5, 0), to: SIMD3(10, 5, 0)))
+        let (a, b) = try Self.overlappingParallelSegments()
 
         #expect(a.extrema(with: b).isEmpty)
     }
@@ -55,15 +75,28 @@ struct Issue636ExtremaParallelCurvesTests {
     /// `mypoints` sequence, so it needs no guard and must keep reporting the real distance.
     @Test("minDistance(to:) keeps reporting the true offset for the same parallel pairs")
     func minDistanceUnaffectedByTheGuard() throws {
-        let a = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
-        let b = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+        let (a, b) = try Self.unboundedParallelLines()
         let d = try #require(a.minDistance(to: b))
-        #expect(abs(d - 5.0) < 1e-9)
+        #expect(abs(d - Self.parallelOffset) < 1e-9)
 
-        let s1 = try #require(Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)))
-        let s2 = try #require(Curve3D.segment(from: SIMD3(0, 5, 0), to: SIMD3(10, 5, 0)))
+        let (s1, s2) = try Self.overlappingParallelSegments()
         let sd = try #require(s1.minDistance(to: s2))
-        #expect(abs(sd - 5.0) < 1e-9)
+        #expect(abs(sd - Self.parallelOffset) < 1e-9)
+    }
+
+    /// The case PR #730's review argued was silently regressed by the guard, measured and kept as a
+    /// regression lock. Two parallel segments whose projected ranges are DISJOINT have one real
+    /// nearest-endpoint solution, and `IsParallel()` returns false for them, so the guard never
+    /// fires and that solution is still returned. If a future change widens the guard to test
+    /// tangent direction rather than trusting `IsParallel()`, this goes red.
+    @Test("Parallel segments with disjoint ranges keep their real endpoint solution")
+    func disjointParallelSegmentsStillReportTheirEndpointSolution() throws {
+        let a = try #require(Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)))
+        let b = try #require(Curve3D.segment(from: SIMD3(20, 5, 0), to: SIMD3(30, 5, 0)))
+
+        #expect(!a.extrema(with: b).isEmpty)
+        let d = try #require(a.minDistance(to: b))
+        #expect(abs(d - hypot(10.0, 5.0)) < 1e-6)   // (10,0,0) to (20,5,0)
     }
 
     @Test("Non-parallel curves are unaffected: extrema still reports real solutions")
@@ -72,5 +105,24 @@ struct Issue636ExtremaParallelCurvesTests {
         let b = try #require(Curve3D.line(through: SIMD3(5, -5, 1), direction: SIMD3(0, 1, 0)))
         let result = a.extrema(with: b)
         #expect(!result.isEmpty)
+    }
+}
+
+/// Compiles and runs the doc snippet on `Curve3D.extrema(with:maxCount:)` verbatim. A doc snippet
+/// that does not compile is the documentation equivalent of a pinned value nobody measured (#726),
+/// and this one asserts specific numbers.
+@Suite("The extrema doc snippet is runnable and its printed values are true (#636)")
+struct Issue636ExtremaDocSnippetTests {
+    @Test("the snippet's API calls resolve and its stated values hold")
+    func snippetHolds() throws {
+        let a = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+        let b = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+
+        let pairs = a.extrema(with: b)
+        #expect(pairs.isEmpty)
+
+        let info = a.extremaCC(other: b)
+        #expect(info.isParallel)
+        #expect(abs((a.minDistance(to: b) ?? 0) - 5.0) < 1e-9)
     }
 }

--- a/Tests/OCCTCurveTests/Issue636ExtremaParallelCurvesTests.swift
+++ b/Tests/OCCTCurveTests/Issue636ExtremaParallelCurvesTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// MARK: - #636: Curve3D.extrema SIGSEGVs on parallel curves at every capacity
+
+/// `Curve3D.extrema(with:maxCount:)` (`OCCTCurve3DExtrema` in `OCCTBridge_Curve3D.mm`) wraps
+/// `GeomAPI_ExtremaCurveCurve`, which in turn wraps `Extrema_ExtCC`: the same class
+/// `BRepExtrema_ExtCC`'s documented parallel-curve crash (see `CLAUDE.md`'s Known OCCT Bugs) traces
+/// back to, one layer down.
+///
+/// On parallel curves, `Extrema_ExtCC::PrepareParallelResult` reports exactly one "extremum" by
+/// appending a distance to its private `mySqDist` sequence, but several of its branches (an
+/// unbounded pair, or a bounded pair whose projected ranges overlap, where there is no single
+/// discrete closest point when a whole span is equidistant) never append the matching pair to
+/// `mypoints`. `NbExtrema()` reports 1 (`mySqDist.Length()`), so `Points()` indexes an empty
+/// `NCollection_Sequence`. This project's OCCT is built with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`
+/// (`No_Exception`), so the bounds check that would normally throw `Standard_OutOfRange` compiles
+/// to nothing, and the out-of-range access is undefined behaviour: measured (via a standalone
+/// ground-truth binary linked directly against `libOCCT-macos.a`) to be a genuine SIGSEGV, not a
+/// C++ exception. A `catch (...)` around the call cannot help: an OS signal never reaches it.
+///
+/// Both fixtures below reproduced the crash before the fix (confirmed via the same standalone
+/// ground-truth binary, `GeomAPI_ExtremaCurveCurve` constructed directly): two unbounded parallel
+/// `Geom_Line`s (`Curve3D.line(through:direction:)`), and two *bounded* parallel segments with
+/// overlapping projected ranges (`Curve3D.segment(from:to:)`, `GC_MakeSegment` over `Geom_Line`,
+/// the same fixture shape `Issue622AllocationBoundsTests` deliberately avoided making parallel,
+/// per its own comment). The fix (`OCCTCurve3DExtrema`) queries `IsParallel()` and returns empty
+/// before touching any solution, mirroring the guard already in place for the sibling
+/// `Extrema_ExtCC`/`Extrema_ExtCS` entry points in the same file.
+@Suite("Curve3D.extrema returns empty, not SIGSEGV, on parallel curves (#636)")
+struct Issue636ExtremaParallelCurvesTests {
+
+    @Test("Two unbounded parallel lines: extrema is empty, not a crash")
+    func parallelUnboundedLinesReturnEmpty() throws {
+        let a = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+        let b = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+
+        #expect(a.extrema(with: b).isEmpty)
+        #expect(a.extrema(with: b, maxCount: 1).isEmpty)
+        #expect(a.extrema(with: b, maxCount: 20).isEmpty) // the reported default capacity
+    }
+
+    @Test("Two bounded parallel segments with overlapping projected ranges: extrema is empty")
+    func parallelBoundedSegmentsReturnEmpty() throws {
+        let a = try #require(Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)))
+        let b = try #require(Curve3D.segment(from: SIMD3(0, 5, 0), to: SIMD3(10, 5, 0)))
+
+        #expect(a.extrema(with: b).isEmpty)
+    }
+
+    /// `minDistance(to:)` (`OCCTCurve3DMinDistanceToCurve`) shares the same
+    /// `GeomAPI_ExtremaCurveCurve` construction but only ever calls `LowerDistance()`, which reads
+    /// `mySqDist`, which is populated correctly in every parallel branch. It never touches the empty
+    /// `mypoints` sequence, so it needs no guard and must keep reporting the real distance.
+    @Test("minDistance(to:) keeps reporting the true offset for the same parallel pairs")
+    func minDistanceUnaffectedByTheGuard() throws {
+        let a = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+        let b = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+        let d = try #require(a.minDistance(to: b))
+        #expect(abs(d - 5.0) < 1e-9)
+
+        let s1 = try #require(Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)))
+        let s2 = try #require(Curve3D.segment(from: SIMD3(0, 5, 0), to: SIMD3(10, 5, 0)))
+        let sd = try #require(s1.minDistance(to: s2))
+        #expect(abs(sd - 5.0) < 1e-9)
+    }
+
+    @Test("Non-parallel curves are unaffected: extrema still reports real solutions")
+    func nonParallelCurvesStillReportSolutions() throws {
+        let a = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+        let b = try #require(Curve3D.line(through: SIMD3(5, -5, 1), direction: SIMD3(0, 1, 0)))
+        let result = a.extrema(with: b)
+        #expect(!result.isEmpty)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5230,6 +5230,57 @@ their truncation contract again. This is the same defect and the same fix as
 unmodified bridge first: the count-agreement test failed at 100 versus 150, which is the property
 the truncation broke.
 
+#### `Curve3D.extrema` SIGSEGV'd, uncatchably, on parallel curves at every capacity (#636)
+
+Found while building a fixture for #622: a parallel-curve fixture for `extrema(with:)` crashed the
+process outright, unrelated to the count bound #622 was about. `CLAUDE.md`'s Known OCCT Bugs
+already documents the topological sibling (`BRepExtrema_ExtCC` crashes on parallel edges, guarded
+with `isParallel`); `OCCTCurve3DExtrema` (`OCCTBridge_Curve3D.mm`), reached from the Swift API by a
+different bridge path through `GeomAPI_ExtremaCurveCurve`, had no equivalent guard.
+
+**Root cause, confirmed against the pinned `V8_0_1` source before touching anything**:
+`GeomAPI_ExtremaCurveCurve` wraps `Extrema_ExtCC`. On parallel curves,
+`Extrema_ExtCC::PrepareParallelResult` reports exactly one "extremum" by appending a distance to
+its private `mySqDist` sequence, but several of its branches (an unbounded pair, or a bounded pair
+whose projected ranges overlap, where a whole span is equidistant rather than one discrete closest
+point) never append the matching pair to `mypoints`. `NbExtrema()` reports 1
+(`mySqDist.Length()`), so `Points()` indexes an empty `NCollection_Sequence`. This project's OCCT
+is built with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON` (`No_Exception`), so the bounds check that
+would normally throw `Standard_OutOfRange` compiles to nothing: the out-of-range access is
+undefined behaviour, confirmed via a standalone binary linked directly against `libOCCT-macos.a` to
+be a genuine SIGSEGV, not a C++ exception. A `catch (...)` around the call cannot help: an OS
+signal never reaches it.
+
+**Measured against two fixtures**, both crashing before the fix and both built from real `Curve3D`
+factory methods: two unbounded parallel `Geom_Line`s (`Curve3D.line(through:direction:)`), and two
+*bounded* parallel segments with overlapping projected ranges (`Curve3D.segment(from:to:)`, the
+exact fixture shape `Issue622AllocationBoundsTests` deliberately avoided making parallel, per its
+own comment).
+
+**Fixed**: `OCCTCurve3DExtrema` now queries `IsParallel()` and returns empty before touching any
+solution, mirroring the guard already in place for the sibling `Extrema_ExtCC`/`Extrema_ExtCS`
+entry points in the same file (`OCCTExtremaExtCC`/`OCCTExtremaExtCS`). `OCCTCurve3DMinDistanceToCurve`
+(`Curve3D.minDistance(to:)`), which shares the same `GeomAPI_ExtremaCurveCurve` construction, needed
+no change: it only calls `LowerDistance()`, which reads `mySqDist`, populated correctly in every
+parallel branch, and never touches the empty `mypoints`. Measured, not assumed: it already
+reported the correct offset distance for both parallel fixtures before this fix.
+
+Audited the rest of the bridge for the same shape (every `GeomAPI_ExtremaCurveCurve`,
+`Extrema_ExtCC`/`Extrema_ExtCS`, and `BRepExtrema_ExtCC` call site): `OCCTCurve3DExtrema` was the
+only unguarded one. `OCCTBridge_Geom2d.mm`'s `OCCTCurve2DAllExtrema` (`Geom2dAPI_ExtremaCurveCurve`)
+has the identical unguarded `.Points()` call and is very likely the 2D sibling of this same defect,
+but that file is outside this PR's scope; noted here as a follow-up rather than fixed.
+
+`Issue636ExtremaParallelCurvesTests` (`Tests/OCCTCurveTests`), 4 tests. Since this is an uncatchable
+OS-signal crash, an in-process test cannot observe "before" without taking the whole test runner
+down with it: the defect and the fix were instead proven out-of-process first, via a temporary
+probe in `Sources/OCCTTest/main.swift` (restored byte-identical afterward) run as
+`swift run OCCTTest`. With the guard removed: SIGSEGV (exit 139). With the guard restored: clean
+exit reporting the expected empty result. The permanent, safe-to-run-in-process regression tests
+landed only once both were confirmed.
+
+Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
+
 ### `OCCT.xcframework` rebuilt: the #484 null-context guard is now in the kernel binary (#512)
 
 A carried patch does nothing until the xcframework is rebuilt from source, so `0017` above was inert

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5645,57 +5645,6 @@ their truncation contract again. This is the same defect and the same fix as
 unmodified bridge first: the count-agreement test failed at 100 versus 150, which is the property
 the truncation broke.
 
-#### `Curve3D.extrema` SIGSEGV'd, uncatchably, on parallel curves at every capacity (#636)
-
-Found while building a fixture for #622: a parallel-curve fixture for `extrema(with:)` crashed the
-process outright, unrelated to the count bound #622 was about. `CLAUDE.md`'s Known OCCT Bugs
-already documents the topological sibling (`BRepExtrema_ExtCC` crashes on parallel edges, guarded
-with `isParallel`); `OCCTCurve3DExtrema` (`OCCTBridge_Curve3D.mm`), reached from the Swift API by a
-different bridge path through `GeomAPI_ExtremaCurveCurve`, had no equivalent guard.
-
-**Root cause, confirmed against the pinned `V8_0_1` source before touching anything**:
-`GeomAPI_ExtremaCurveCurve` wraps `Extrema_ExtCC`. On parallel curves,
-`Extrema_ExtCC::PrepareParallelResult` reports exactly one "extremum" by appending a distance to
-its private `mySqDist` sequence, but several of its branches (an unbounded pair, or a bounded pair
-whose projected ranges overlap, where a whole span is equidistant rather than one discrete closest
-point) never append the matching pair to `mypoints`. `NbExtrema()` reports 1
-(`mySqDist.Length()`), so `Points()` indexes an empty `NCollection_Sequence`. This project's OCCT
-is built with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON` (`No_Exception`), so the bounds check that
-would normally throw `Standard_OutOfRange` compiles to nothing: the out-of-range access is
-undefined behaviour, confirmed via a standalone binary linked directly against `libOCCT-macos.a` to
-be a genuine SIGSEGV, not a C++ exception. A `catch (...)` around the call cannot help: an OS
-signal never reaches it.
-
-**Measured against two fixtures**, both crashing before the fix and both built from real `Curve3D`
-factory methods: two unbounded parallel `Geom_Line`s (`Curve3D.line(through:direction:)`), and two
-*bounded* parallel segments with overlapping projected ranges (`Curve3D.segment(from:to:)`, the
-exact fixture shape `Issue622AllocationBoundsTests` deliberately avoided making parallel, per its
-own comment).
-
-**Fixed**: `OCCTCurve3DExtrema` now queries `IsParallel()` and returns empty before touching any
-solution, mirroring the guard already in place for the sibling `Extrema_ExtCC`/`Extrema_ExtCS`
-entry points in the same file (`OCCTExtremaExtCC`/`OCCTExtremaExtCS`). `OCCTCurve3DMinDistanceToCurve`
-(`Curve3D.minDistance(to:)`), which shares the same `GeomAPI_ExtremaCurveCurve` construction, needed
-no change: it only calls `LowerDistance()`, which reads `mySqDist`, populated correctly in every
-parallel branch, and never touches the empty `mypoints`. Measured, not assumed: it already
-reported the correct offset distance for both parallel fixtures before this fix.
-
-Audited the rest of the bridge for the same shape (every `GeomAPI_ExtremaCurveCurve`,
-`Extrema_ExtCC`/`Extrema_ExtCS`, and `BRepExtrema_ExtCC` call site): `OCCTCurve3DExtrema` was the
-only unguarded one. `OCCTBridge_Geom2d.mm`'s `OCCTCurve2DAllExtrema` (`Geom2dAPI_ExtremaCurveCurve`)
-has the identical unguarded `.Points()` call and is very likely the 2D sibling of this same defect,
-but that file is outside this PR's scope; noted here as a follow-up rather than fixed.
-
-`Issue636ExtremaParallelCurvesTests` (`Tests/OCCTCurveTests`), 4 tests. Since this is an uncatchable
-OS-signal crash, an in-process test cannot observe "before" without taking the whole test runner
-down with it: the defect and the fix were instead proven out-of-process first, via a temporary
-probe in `Sources/OCCTTest/main.swift` (restored byte-identical afterward) run as
-`swift run OCCTTest`. With the guard removed: SIGSEGV (exit 139). With the guard restored: clean
-exit reporting the expected empty result. The permanent, safe-to-run-in-process regression tests
-landed only once both were confirmed.
-
-Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
-
 ### `OCCT.xcframework` rebuilt: the #484 null-context guard is now in the kernel binary (#512)
 
 A carried patch does nothing until the xcframework is rebuilt from source, so `0017` above was inert

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -406,9 +406,10 @@ Returns up to `maxCount` results. For simple queries where only the minimum dist
 
 - **Parameters:** `other` — the second curve; `maxCount` — output *capacity* (default 20), clamped
   into `0...Sampling.maximumSampleCount` (10,000,000); 0 or less returns empty (#622).
-- **Warning:** SIGSEGVs (uncatchable) on two **parallel** curves, at every capacity including the
-  default — a `GeomAPI_ExtremaCurveCurve` defect unrelated to the count bound (#622).
-- **Returns:** Array of `CurveExtremaResult` values (may be empty if the algorithm finds nothing).
+- **Returns:** Array of `CurveExtremaResult` values. Empty when the curves are parallel: OCCT
+  represents that case as a single unbounded family of equidistant solutions rather than a finite
+  set of point pairs, so there is no `(point1, point2)` pair to report. Also empty if the algorithm
+  finds nothing. Use `minDistance(to:)` for the (well-defined) distance in the parallel case.
 - **OCCT:** `GeomAPI_ExtremaCurveCurve`.
 - **Example:**
   ```swift

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -92,8 +92,9 @@ how the family interprets the caller's edge list, so both depend on A.
 
 **C. Crash guards.** `Curve3D.extrema` on parallel curves (#636), `GeomTools_Curve2dSet`/`SurfaceSet`
 null handles (#643), `Surface.appSurf` with a single curve (#644). #656 is the same family and is
-already fixed. The census here is not a probe but a **checker upgrade**: teach
-`check-null-handle-guards.py` the shape it is currently blind to, and it enumerates the rest.
+already fixed; #636 and #643 are now fixed too, leaving #644. The census here is not a probe but a
+**checker upgrade**: teach `check-null-handle-guards.py` the shape it is currently blind to, and it
+enumerates the rest.
 
 **D. Continuity.** #513 is already an explicit census of 38 unaudited functions and four
 incompatible request encodings. #437 (`plateSurface` can never accept `.g2`) and #438 (two public


### PR DESCRIPTION
## What & why

`Curve3D.extrema(with:maxCount:)` SIGSEGV'd, uncatchably, on parallel curves at every capacity,
including its own default of 20. `GeomAPI_ExtremaCurveCurve` wraps `Extrema_ExtCC`, the same class
`BRepExtrema_ExtCC`'s documented parallel-curve crash (`CLAUDE.md`'s Known OCCT Bugs) traces back to
one layer down, and had no equivalent guard. On parallel curves, `Extrema_ExtCC::PrepareParallelResult`
reports `NbExtrema() == 1` by appending to `mySqDist` while leaving `mypoints` empty in several
branches (an unbounded pair, or a bounded pair whose projected ranges overlap), so `Points()` indexes
an empty `NCollection_Sequence`. This project's OCCT is built with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`
(`No_Exception`), so the `Standard_OutOfRange` bounds check that would normally catch this compiles to
nothing: it's a genuine SIGSEGV, confirmed with a standalone binary linked directly against
`libOCCT-macos.a`, not a C++ exception a `catch (...)` could absorb.

`OCCTCurve3DExtrema` now queries `IsParallel()` and returns empty before touching any solution,
mirroring the guard already in place for the sibling `Extrema_ExtCC`/`Extrema_ExtCS` entry points in
the same file. `OCCTCurve3DMinDistanceToCurve` needed no change: `LowerDistance()` only reads
`mySqDist`, which stays correct in every parallel branch, confirmed by measurement rather than assumed.

Audited every other `GeomAPI_ExtremaCurveCurve`/`Extrema_ExtCC`/`Extrema_ExtCS`/`BRepExtrema_ExtCC`
call site in the bridge: `OCCTCurve3DExtrema` was the only unguarded one. `OCCTBridge_Geom2d.mm`'s
`OCCTCurve2DAllExtrema` has the identical unguarded `.Points()` call and is very likely the 2D sibling
of this same defect, but that file is out of this PR's scope (see below); noted as a follow-up rather
than fixed.

Closes #636

## Verification

- Premise verified by measurement before implementing anything: a standalone C++ binary linked
  directly against the pinned `libOCCT-macos.a` reproduced the SIGSEGV via
  `GeomAPI_ExtremaCurveCurve` on both an unbounded parallel `Geom_Line` pair and a bounded parallel
  `GC_MakeSegment` pair (the latter is the exact fixture shape `Issue622AllocationBoundsTests`
  deliberately avoided making parallel, per its own comment).
- Proved the test fails, out-of-process (an in-process SIGSEGV would kill the test runner):
  temporarily probed the crash via `Sources/OCCTTest/main.swift` (restored byte-identical
  afterward) run as `swift run OCCTTest`. Guard removed: SIGSEGV, exit 139. Guard restored: clean
  exit, both fixtures report 0 extrema.
- New `Issue636ExtremaParallelCurvesTests` (`Tests/OCCTCurveTests`), 4 tests, safe to run in-process
  because the guarded path never reaches the crash. Full `OCCTCurveTests` target (541 tests) green.
- All five static gate scripts and their `--self-test`s pass, including `check-null-handle-guards.py`.
- Built and tested with `env -u OCCTSWIFT_LOCAL -u OCCTSWIFT_BRIDGE_PREBUILT` against the pinned
  `v2.0.0-kernel.1` release binary (no local `Libraries/`), before and after rebasing onto the
  current `refactor/381-pass1b` tip.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification).

## Notes for the reviewer

- Confined to `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`, `Sources/OCCTSwift/Curve3D.swift`,
  and the curve test target, per the file-ownership constraints of five other in-flight PRs against
  this base. Also touches `docs/CHANGELOG.md`, `docs/reference/Curve3D-Analysis.md` (a stale
  "SIGSEGVs, uncatchably" warning this fix resolves), and `docs/v2.0.0-plan.md` (Cluster C status),
  none of which are owned by those PRs.
- `OCCTBridge_Geom2d.mm`'s `OCCTCurve2DAllExtrema` looks like the same defect on the 2D side
  (unguarded `Geom2dAPI_ExtremaCurveCurve.Points()`), found during the audit but not fixed here
  since that file is outside this PR's declared scope. Worth its own issue.
- No kernel patch, no `OCCT.xcframework` rebuild: bridge and Swift only.

## CHANGELOG entry


Found while building a fixture for #622: a parallel-curve fixture for `extrema(with:)` crashed the
process outright, unrelated to the count bound #622 was about. `CLAUDE.md`'s Known OCCT Bugs
already documents the topological sibling (`BRepExtrema_ExtCC` crashes on parallel edges, guarded
with `isParallel`); `OCCTCurve3DExtrema` (`OCCTBridge_Curve3D.mm`), reached from the Swift API by a
different bridge path through `GeomAPI_ExtremaCurveCurve`, had no equivalent guard.

**Root cause, confirmed against the pinned `V8_0_1` source before touching anything**:
`GeomAPI_ExtremaCurveCurve` wraps `Extrema_ExtCC`. On parallel curves,
`Extrema_ExtCC::PrepareParallelResult` reports exactly one "extremum" by appending a distance to
its private `mySqDist` sequence, but several of its branches (an unbounded pair, or a bounded pair
whose projected ranges overlap, where a whole span is equidistant rather than one discrete closest
point) never append the matching pair to `mypoints`. `NbExtrema()` reports 1
(`mySqDist.Length()`), so `Points()` indexes an empty `NCollection_Sequence`. This project's OCCT
is built with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON` (`No_Exception`), so the bounds check that
would normally throw `Standard_OutOfRange` compiles to nothing: the out-of-range access is
undefined behaviour, confirmed via a standalone binary linked directly against `libOCCT-macos.a` to
be a genuine SIGSEGV, not a C++ exception. A `catch (...)` around the call cannot help: an OS
signal never reaches it.

**Measured against two fixtures**, both crashing before the fix and both built from real `Curve3D`
factory methods: two unbounded parallel `Geom_Line`s (`Curve3D.line(through:direction:)`), and two
*bounded* parallel segments with overlapping projected ranges (`Curve3D.segment(from:to:)`, the
exact fixture shape `Issue622AllocationBoundsTests` deliberately avoided making parallel, per its
own comment).

**Fixed**: `OCCTCurve3DExtrema` now queries `IsParallel()` and returns empty before touching any
solution, mirroring the guard already in place for the sibling `Extrema_ExtCC`/`Extrema_ExtCS`
entry points in the same file (`OCCTExtremaExtCC`/`OCCTExtremaExtCS`). `OCCTCurve3DMinDistanceToCurve`
(`Curve3D.minDistance(to:)`), which shares the same `GeomAPI_ExtremaCurveCurve` construction, needed
no change: it only calls `LowerDistance()`, which reads `mySqDist`, populated correctly in every
parallel branch, and never touches the empty `mypoints`. Measured, not assumed: it already
reported the correct offset distance for both parallel fixtures before this fix.

Audited the rest of the bridge for the same shape (every `GeomAPI_ExtremaCurveCurve`,
`Extrema_ExtCC`/`Extrema_ExtCS`, and `BRepExtrema_ExtCC` call site): `OCCTCurve3DExtrema` was the
only unguarded one. `OCCTBridge_Geom2d.mm`'s `OCCTCurve2DAllExtrema` (`Geom2dAPI_ExtremaCurveCurve`)
has the identical unguarded `.Points()` call and is very likely the 2D sibling of this same defect,
but that file is outside this PR's scope; noted here as a follow-up rather than fixed.

`Issue636ExtremaParallelCurvesTests` (`Tests/OCCTCurveTests`), 4 tests. Since this is an uncatchable
OS-signal crash, an in-process test cannot observe "before" without taking the whole test runner
down with it: the defect and the fix were instead proven out-of-process first, via a temporary
probe in `Sources/OCCTTest/main.swift` (restored byte-identical afterward) run as
`swift run OCCTTest`. With the guard removed: SIGSEGV (exit 139). With the guard restored: clean
exit reporting the expected empty result. The permanent, safe-to-run-in-process regression tests
landed only once both were confirmed.

Bridge and Swift only: no kernel patch, no `OCCT.xcframework` rebuild.
