### PR TITLE
chore(#726): census pass 1, values that were never computed but read as measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,15 @@ jobs:
         if: '!cancelled()'
         run: python3 Scripts/count-operations.py
 
+      # #726's census is the one entry here that is NOT a gate, and only its --self-test runs.
+      # A gate answers "is the tree clean" and exits 1 when it is not; this answers "which sites
+      # need a human to adjudicate" and exits 0 either way, so running it bare would add a step
+      # that can never fail and therefore never signal. Its detector can still rot, which is the
+      # failure the other four exist to prevent, so the self-test is what CI holds it to.
+      - name: census-unmeasured-values.py --self-test
+        if: '!cancelled()'
+        run: python3 Scripts/census-unmeasured-values.py --self-test
+
   build-and-test:
     name: swift build + test (macOS)
     runs-on: macos-15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 
 ### Static Gate Scripts
 
-Five pure-Python checks over the repo's own text. No OCCT, no build, ~3s for all five. **CI runs
-every one of them, plus each `--self-test`, in `ci.yml`'s `gate-scripts` job** — a separate
+Five gates plus one census, all pure Python over the repo's own text. No OCCT, no build, ~3s for
+the lot. **CI runs every gate, plus every `--self-test` including the census's, in `ci.yml`'s
+`gate-scripts` job** — a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
 its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a
 defect and 0 when clean; `check-bridge-index`, `check-null-handle-guards` and
@@ -63,9 +64,16 @@ python3 Scripts/check-null-handle-guards.py      # every bridge fn guards the Ha
 python3 Scripts/check-docs-defaults.py           # every default docs/reference/ restates matches its declaration
 python3 Scripts/derive-bridge-header-split.py --verify  # every declaration sits in the header its .mm owns (#673)
 python3 Scripts/count-operations.py              # README + API_REFERENCE totals match the derived count
+python3 Scripts/census-unmeasured-values.py      # CENSUS, not a gate: values returned as measurements that were never computed (#726)
 ```
 
-The first four take `--self-test`, which runs a fixture battery proving the *detector* catches each
+`census-unmeasured-values.py` is the one entry that is **not a gate**. It exits 0 whether or not it
+finds anything, because its output is a list of sites for a human to adjudicate, not a verdict on
+the tree. CI therefore runs only its `--self-test`: a bare run could never fail and so could never
+signal. Its detector can still go blind, which is the failure every other entry here exists to
+prevent, so that is what CI holds it to.
+
+Four of the five gates take `--self-test`, as does the census, which runs a fixture battery proving the *detector* catches each
 failure mode. Run it whenever you change one of these scripts — three gate scripts on this branch
 were confidently wrong (#618, #624/#630, #626), and a detector that reports "all clear" because it
 is blind looks exactly like one reporting "all clear" because the tree is clean.
@@ -73,7 +81,7 @@ is blind looks exactly like one reporting "all clear" because the tree is clean.
 running the report, so writing `count-operations.py --self-test` to match its siblings fails loudly
 instead of passing forever.
 
-**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs the same nine invocations
+**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs the same ten invocations
 locally, flag for flag. It is **opt-in and not installed by cloning** — enable it deliberately:
 
 ```bash

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Census #726, first pass: values that were never computed but are returned through an API whose
+shape says they were measured.
+
+Two sub-kinds, per the issue:
+
+  1. PRODUCTION code assigning a bare literal to one field of an aggregate result while a sibling
+     field of the same local variable, reached under the same control-flow condition, is assigned
+     from a real computation. The seed instance is `OCCTBridge_Healing.mm`'s
+     `result.selfIntersectionCount = 0;  // Would require more expensive computation`, sitting right
+     next to `result.smallEdgeCount = smallEdges;`, which IS a loop-computed count: same variable,
+     same depth (both unconditional, at the end of the try block), one fabricated.
+
+  2. TEST code pinning a `<collection>.count <op> <int literal>` assertion on a fixture produced by
+     an operation that can plausibly do nothing (a boolean op, a feature-recognition call, a
+     healing/fix/sew pass, ...), with no OTHER assertion in the same test that independently
+     confirms the fixture actually did what its shape implies (a volume/area/length/distance
+     delta, etc). The known instance is #703's "real pocket" fixture: `detectPocket()`
+     (`Tests/OCCTModelingTests/OCCTModelingTests.swift`) asserted `pockets.count >= 1` against a
+     tool box placed at `origin: SIMD3(5, 5, 10)`, entirely above `Shape.box`'s centred top face
+     at z=10, so the boolean subtraction removed ZERO volume, and the "1" the test paired with real
+     computed values `#expect(p.depth > 0)` was reading the sign bug OCCTEdgeGetConvexity's own
+     face1/face2 order-dependence produces on a PLAIN, uncut box (see #703, PR #720). No assertion
+     anywhere in that test checked that `result` differs from `box` at all.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: this repo's own history of censuses built by grep and
+written into an issue body is a list of wrong numbers. #558 said 14, measured 28; #571 said 3,
+measured 6; #583 said five, measured six; #595 said six, measured nine; #640 said 13, measured 20.
+A derivation that can be re-run does not go stale the same way a hand-count does.
+
+WHAT THIS DOES NOT DO, DELIBERATELY: this is a CENSUS, not a gate. It is not wired into
+`ci.yml`'s `gate-scripts` job, and its exit code in report mode is always 0 (barring a crash) even
+when it finds candidates. Every one of the sites below still needs a human verdict. Some are
+real instances of the class; several measured here are the OPPOSITE, a value that already uses the
+"make absence representable" fix #583/#595/#609 established (e.g. `OCCTShapeAxis.hasExtent`
+correctly gating `extentMin`/`extentMax` into a `nil` on the Swift side). And #726 itself scopes
+the gate-script question ("a struct field assigned only a literal across every path") as a
+follow-up spike, not something this pass commits to.
+
+SUB-KIND 1 ALGORITHM. For every function body in `Sources/OCCTBridge/src/*.{mm,h}`:
+
+  - Find every `catch (...) { ... }` block and exclude assignments inside it: a literal fallback on
+    an exception path is recovery, not "never measured" (`OCCTCurve3DCircleEccentricity`'s
+    `catch (...) { return 0; }` is fine; its SUCCESS path calls `c->Eccentricity()`).
+  - Find every local variable assigned at least 2 distinct `var.field = <RHS>;` fields (the
+    aggregate-result shape: a `Result`-ish local built up field by field, not necessarily named
+    `result` and not looked up by struct-type name, since #558/#571/#583/#595 all warn that a
+    name-prefix census is exactly the kind of count that turns out wrong).
+  - For each field, classify its non-catch assignment(s) `literal` (every RHS is a bare numeric,
+    `true`/`false`, `nullptr`/`NULL`, or `""` literal) or `computed` (anything else: a call, a
+    parameter, a member access, an expression).
+  - Track each assignment's CONDITIONAL DEPTH: the number of enclosing `if (...) {`, `else if`,
+    bare `else {`, or `switch (...) {` blocks (a `for`/`while`/lambda body does NOT add depth,
+    since every statement inside one loop iteration runs together, so two fields set in the same
+    loop body are exactly as "unconditional relative to each other" as two set at the top of the
+    function; this is what makes `OCCTShapeRevolutionAxes`'s `a.hasExtent = false;` next to
+    `a.originX = p.X();`, both inside the same `for`, comparable at all).
+  - Flag `(function, field)` when the field is `literal`-only AND some sibling field of the same
+    local variable has a `computed` assignment at THE SAME conditional depth. Depth-matching is
+    what tells `OCCTBridge_Healing.mm`'s `selfIntersectionCount = 0` (depth 0, next to
+    `smallEdgeCount` also at depth 0) apart from `OCCTImportSTEPWithDiagnostics`'s
+    `result.sewingApplied = true;` (depth 1, inside `if (!sewedShape.IsNull() && ...)`, with no
+    computed sibling at that same depth in that same block). The latter is a literal that is only
+    ever reached because a real check passed, which is a legitimate encoding of a real fact, not a
+    fabrication, and the algorithm has to tell the two apart structurally or it drowns in the second
+    shape (see the removal matrix in the self-test below).
+
+SUB-KIND 2 ALGORITHM. For every `@Test func` body in `Tests/**/*.swift`:
+
+  - Collect every `#expect(...)` call (paren-matched, so a nested call or a trailing message
+    argument does not truncate it).
+  - A call is a COUNT-PIN if its text matches `<expr>.count (==|>=|<=) <int literal>`.
+  - A call is a VERIFICATION if its text mentions one of a small set of measurement nouns (volume,
+    area, length, mass, distance, delta, deviation, thickness, extent, overlap) alongside a
+    comparison operator: it checks a continuous quantity against something, not just that a
+    collection has a shape.
+  - The receiver chain of a count-pin is checked against a CURATED list of operation names that can
+    plausibly do nothing to their input (booleans, feature recognition, healing/fix/sew, offset/
+    sweep/loft, section, fillet/chamfer): #726's own text warns that "scanning all of it by
+    name-prefix or a generic parser is exactly the over/under-inclusive census this whole
+    workstream has repeatedly warned against" (`classify_continuity_sites.py`, Cluster D), and an
+    unscoped version of this rule flags 565 of the ~850 raw `.count <op> <int>` sites in Tests/,
+    almost all of them provably-by-construction topology counts on a primitive
+    (`box.faces().count == 6`) that need no independent check.
+  - A test function is flagged when it has >=1 count-pin whose receiver matches the curated list,
+    and the function has NO verification call anywhere in its body.
+
+WHAT THIS STILL CANNOT SEE, measured while adjudicating the first real run against this tree (see
+Scripts/repro/726-unmeasured-values/README.md for the full per-site table). Each of these is a
+real, observed source of noise in the candidate list, not a hypothetical:
+
+  - CONDITIONAL DEPTH IS A COUNT, NOT AN IDENTITY. Two literal assignments in two DIFFERENT,
+    unrelated `if` blocks that happen to sit at the same nesting depth look identical to this
+    script, which pairs either one against a computed sibling from either block. `OCCTCheckFace`'s
+    input-validation guard (`if (!face) { result.isValid = false; ... }`, depth 1) gets flagged
+    only because a completely unrelated `if` block later in the SAME function (the per-status-code
+    loop body) also sits at depth 1 and has a computed sibling (`result.errorCount++`). The guard
+    clause itself has no computed sibling of its own. Sound in the cases this pass measured, but
+    read the surrounding branches before trusting a flagged site, not just the flagged line.
+  - A LOCAL CONFIG/OPTIONS STRUCT PASSED INTO A CALL IS SYNTACTICALLY IDENTICAL TO A RESULT STRUCT
+    RETURNED FROM ONE. `BRepGraph::ShapesView::Options opts; opts.Parallel = parallel; opts.
+    CreateAutoProduct = false;` is an INPUT the function constructs and hands to `Add()`. Nothing
+    about it is "returned through an API" in #726's sense, but it has the exact same
+    literal-beside-computed-sibling shape a result struct does. This script does not distinguish
+    "local var later passed as an argument" from "local var later returned"; every config-struct
+    site in the first run's 64 candidates (5 of them) needed a human to notice the struct never
+    leaves the function as a return value.
+  - A FIELD ASSIGNED TWO OR MORE DIFFERENT LITERAL VALUES ACROSS DIFFERENT BRANCHES OF THE SAME
+    FUNCTION IS THE COMMON, LEGITIMATE CASE, NOT THE RARE ONE, and this script does not
+    distinguish it from a field pinned to the SAME literal on every reached path. `result.isValid =
+    false;` at the top of a function, flipped to `result.isValid = true;` only after real
+    computation succeeds, is both "literal-only" (every RHS is a bare literal) and exactly the
+    "make absence representable" idiom #583/#595/#609 already established as the FIX for this whole
+    class of bug, not an instance of it. Likewise `result.type = 1;` in one branch and `result.
+    type = 2;` in the next is a branch-selected classification tag, not a fabrication. Of the first
+    run's 64 candidates, 26 were exactly this "default, then flip on success" shape and 2 were a
+    branch-selected tag; only a field that is the SAME literal on EVERY assignment this script
+    found (not just every assignment at one matched depth) is the dangerous shape. Checking that
+    is a manual step this script does not perform, and the two genuine hits of the first run
+    (`OCCTBRepGPropVinertGK`'s `errorReached`/`absoluteError`, both always `0.0`) were found by
+    reading the site, not by a rule this script encodes.
+  - A PLAIN VALUE-TYPE CONSTRUCTOR THAT ECHOES ITS OWN PARAMETERS INTO SOME FIELDS AND FIXED
+    DEFAULTS INTO OTHERS IS NOT A MEASUREMENT API AT ALL. `OCCTXCAFPrsStyleCreate()` and its two
+    siblings (`...CreateWithSurfColor`, `...CreateFull`) build a plain style value; `result.surfR =
+    0; ...; result.hasSurfColor = false;` are legitimate "no color set" defaults, not a computation
+    that was skipped, and the Swift side (`PresentationStyle.swift`) already turns
+    `hasSurfColor`/`hasCurvColor` into the `nil` these defaults are meant to signal. 19 of the first
+    run's 64 candidates were this shape, all in two files.
+  - SUB-KIND 2's VERIFICATION CHECK ONLY READS `#expect(...)` BODIES, SO A VERIFICATION PERFORMED
+    THROUGH A HELPER CALL WAS INVISIBLE UNTIL THIS WAS FOUND AND FIXED MID-PASS.
+    `Issue442FixSolidMultiBodyTests.swift`/`Issue443FirstOfNTests.swift` both define a private
+    `expectVolume(_:_:_:)` wrapping `#expect(abs(volume - expected) < 1e-6, ...)`; every call site
+    reads `expectVolume(healed, 2000.0, "...")`, which is not itself a `#expect(...)` call, so the
+    verification inside it was invisible to a scan that only reads `#expect(` bodies. This alone
+    accounted for 21 of the first run's 68 test candidates. `verifying_helpers()` now recognises a
+    same-file function whose OWN body contains a VERIFICATION-matching `#expect` as equivalent to
+    writing the check inline; a test calling it by name gets the same credit. What is NOT fixed,
+    because it cannot be with a keyword scan: an abbreviated identifier defeats the keyword match
+    even inline (`#expect(abs(v - 1000.0) < 1e-6)`, `#expect(pv < ov)` for "pocket volume"/"outer
+    volume") and a different counting property standing in as verification is invisible too
+    (`#expect(connected.edgeCount == 7)`, proving a merge happened, is not one of the ten nouns
+    VERIFICATION looks for). 5 sites in the first run's 68 are this shape; each was confirmed by
+    reading the site, not detected, and is called out individually in the README's table.
+
+Usage (from the repo root):
+
+    python3 Scripts/census-unmeasured-values.py                 # both sub-kinds, full listing
+    python3 Scripts/census-unmeasured-values.py --production    # sub-kind 1 only
+    python3 Scripts/census-unmeasured-values.py --tests         # sub-kind 2 only
+    python3 Scripts/census-unmeasured-values.py --quiet         # counts only
+    python3 Scripts/census-unmeasured-values.py --self-test     # prove each shape is caught
+
+Exit status is always 0 in report mode (this is a census, not a gate, see above); `--self-test`
+exits 1 if any fixture is misclassified. Exits 2 if run from anywhere but the repo root (#625).
+"""
+import argparse
+import glob
+import os
+import re
+import sys
+
+BRIDGE_SRC_DIR = os.path.join('Sources', 'OCCTBridge', 'src')
+BRIDGE_INCLUDE_DIR = os.path.join('Sources', 'OCCTBridge', 'include')
+TESTS_DIR = 'Tests'
+
+# ---------------------------------------------------------------------------
+# Shared: comment/string stripping, function extraction (brace-depth walk).
+# Same approach as check-null-handle-guards.py / derive-swift-file-split.py:
+# blank out comments and string bodies but preserve every character's
+# position, so line numbers computed afterwards still line up.
+# ---------------------------------------------------------------------------
+
+def strip_comments(text):
+    out, i, n = [], 0, len(text)
+    while i < n:
+        if text.startswith('//', i):
+            j = text.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif text.startswith('/*', i):
+            j = text.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append(''.join(c if c == '\n' else ' ' for c in text[i:j]))
+            i = j
+        elif text[i] == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == '\\':
+                    j += 1
+                j += 1
+            out.append(text[i:j + 1])
+            i = j + 1
+        else:
+            out.append(text[i])
+            i += 1
+    return ''.join(out)
+
+
+C_FUNC = re.compile(r'^(?:static\s+)?[A-Za-z_][\w:<>,\s\*&]*?\b(\w+)\s*\(([^;{]*?)\)\s*\{', re.M | re.S)
+NOT_A_FUNCTION = {'if', 'for', 'while', 'switch', 'catch', 'return'}
+
+
+def c_functions(text):
+    """(name, params, body_start, body_end) for every C/Objective-C++ function definition."""
+    for m in C_FUNC.finditer(text):
+        name, params = m.group(1), m.group(2)
+        if name in NOT_A_FUNCTION:
+            continue
+        start = i = m.end() - 1
+        depth = 0
+        while i < len(text):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        yield name, params, start, i
+
+
+SWIFT_FUNC = re.compile(
+    r'func\s+(\w+)\s*\([^)]*\)(?:\s*(?:async|throws|rethrows))*\s*(?:->\s*[^\{]+?)?\{'
+)
+
+
+def swift_functions(text):
+    """(name, body_start, body_end) for every Swift function definition (test methods)."""
+    for m in SWIFT_FUNC.finditer(text):
+        name = m.group(1)
+        start = i = m.end() - 1
+        depth = 0
+        while i < len(text):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        yield name, start, i
+
+
+# ===========================================================================
+# Sub-kind 1: production literal-vs-computed sibling census.
+# ===========================================================================
+
+CATCH = re.compile(r'\bcatch\s*\([^)]*\)\s*\{')
+
+
+def catch_spans(body):
+    spans = []
+    for m in CATCH.finditer(body):
+        depth, i = 0, m.end() - 1
+        while i < len(body):
+            if body[i] == '{':
+                depth += 1
+            elif body[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        spans.append((m.start(), i))
+    return spans
+
+
+IF_SWITCH = re.compile(r'\b(?:if|switch)\s*\(')
+BARE_ELSE = re.compile(r'\belse\b(?!\s*if\b)')
+
+
+def conditional_brace_positions(body):
+    """Positions of every `{` that OPENS an if/else-if/bare-else/switch block. Paren depth is
+    counted explicitly so a condition with its own parens (`if (a && (b || c))`) does not end the
+    scan early, which is the failure mode a naive backward-lookbehind regex would have."""
+    positions = set()
+    for m in IF_SWITCH.finditer(body):
+        i = m.end() - 1
+        depth = 0
+        while i < len(body):
+            if body[i] == '(':
+                depth += 1
+            elif body[i] == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        j = i + 1
+        while j < len(body) and body[j] in ' \t\r\n':
+            j += 1
+        if j < len(body) and body[j] == '{':
+            positions.add(j)
+    for m in BARE_ELSE.finditer(body):
+        j = m.end()
+        while j < len(body) and body[j] in ' \t\r\n':
+            j += 1
+        if j < len(body) and body[j] == '{':
+            positions.add(j)
+    return positions
+
+
+def depth_segments(body):
+    """[(start, end, conditional_depth), ...] covering the whole body. A `for`/`while`/lambda/
+    plain brace opens a new segment at the SAME depth as its enclosing one; an if/else-if/else/
+    switch brace opens one depth deeper."""
+    cond_braces = conditional_brace_positions(body)
+    segments = []
+    stack = [0]
+    last = 0
+    for i, c in enumerate(body):
+        if c == '{':
+            segments.append((last, i + 1, stack[-1]))
+            stack.append(stack[-1] + (1 if i in cond_braces else 0))
+            last = i + 1
+        elif c == '}':
+            segments.append((last, i + 1, stack[-1]))
+            if len(stack) > 1:
+                stack.pop()
+            last = i + 1
+    segments.append((last, len(body), stack[-1] if stack else 0))
+    return segments
+
+
+def depth_at(segments, pos):
+    for s, e, d in segments:
+        if s <= pos < e:
+            return d
+    return 0
+
+
+FIELD_ASSIGN = re.compile(r'\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*=\s*([^=][^;]*);')
+LITERAL_RHS = re.compile(
+    r'^-?\s*(?:\d+\.?\d*(?:[eE][-+]?\d+)?[fFlL]?|\.\d+[fFlL]?|true|false|nullptr|NULL|""|\'\S\')\s*$'
+)
+
+
+def is_literal(rhs):
+    return bool(LITERAL_RHS.match(rhs.strip().strip('() \t\r\n')))
+
+
+def production_candidates(sources):
+    """(file, line, function, var, field, rhs) for every literal field with a same-depth,
+    non-catch, computed sibling on the same local variable."""
+    found = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        lines = raw.splitlines()
+        for name, params, bs, be in c_functions(text):
+            body = text[bs:be + 1]
+            cspans = catch_spans(body)
+            segs = depth_segments(body)
+            # var -> field -> list of (is_lit, pos, depth, rhs)
+            fields = {}
+            for m in FIELD_ASSIGN.finditer(body):
+                if any(s <= m.start() < e for s, e in cspans):
+                    continue  # exception-recovery fallback, not "never measured"
+                var, field, rhs = m.group(1), m.group(2), m.group(3).strip()
+                fields.setdefault(var, {}).setdefault(field, []).append(
+                    (is_literal(rhs), m.start(), depth_at(segs, m.start()), rhs))
+            for var, fmap in fields.items():
+                if len(fmap) < 2:
+                    continue
+                computed_depths = set()
+                for field, assigns in fmap.items():
+                    if any(not lit for lit, _, _, _ in assigns):
+                        computed_depths.update(d for lit, _, d, _ in assigns if not lit)
+                if not computed_depths:
+                    continue
+                for field, assigns in fmap.items():
+                    if not all(lit for lit, _, _, _ in assigns):
+                        continue  # this field has a computed assignment itself
+                    for lit, pos, d, rhs in assigns:
+                        if d in computed_depths:
+                            line = text.count('\n', 0, bs + pos) + 1
+                            found.append((os.path.basename(path), line, name, var, field, rhs,
+                                          lines[line - 1].strip() if line <= len(lines) else ''))
+                            break  # one report per field is enough
+    return found
+
+
+def bridge_sources():
+    paths = sorted(glob.glob(os.path.join(BRIDGE_SRC_DIR, '*.mm'))) + \
+        sorted(glob.glob(os.path.join(BRIDGE_SRC_DIR, '*.h'))) + \
+        sorted(glob.glob(os.path.join(BRIDGE_INCLUDE_DIR, '*.h')))
+    return [(p, open(p, errors='ignore').read()) for p in paths]
+
+
+# ===========================================================================
+# Sub-kind 2: test pinned-count-with-no-fixture-verification census.
+# ===========================================================================
+
+EXPECT_CALL = re.compile(r'#expect\s*\(')
+
+
+def expect_bodies(body):
+    """Text inside each `#expect( ... )` in a function body, paren- and string-matched."""
+    out = []
+    for m in EXPECT_CALL.finditer(body):
+        i, depth, start = m.end(), 1, m.end()
+        n = len(body)
+        while i < n and depth > 0:
+            c = body[i]
+            if c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+            elif c == '"':
+                i += 1
+                while i < n and body[i] != '"':
+                    if body[i] == '\\':
+                        i += 1
+                    i += 1
+            i += 1
+        out.append(body[start:i - 1])
+    return out
+
+
+COUNT_PIN = re.compile(r'\.count\s*(?:==|>=|<=)\s*\d+\b')
+VERIFICATION = re.compile(
+    r'\b(?:volume|area|length|mass|distance|delta|deviation|thickness|extent|overlap)\w*\b'
+    r'[^;]{0,60}?(?:==|!=|<=|>=|<|>)'
+    r'|(?:==|!=|<=|>=|<|>)[^;]{0,60}?'
+    r'\b(?:volume|area|length|mass|distance|delta|deviation|thickness|extent|overlap)\w*\b',
+    re.IGNORECASE)
+
+# Curated, not a generic scan: operation families that can plausibly do nothing to their input
+# (leave a shape unchanged, or produce a result indistinguishable from "found nothing"). This is
+# the same discipline classify_continuity_sites.py documents for Cluster D. An unscoped version
+# of this rule (any receiver at all) flags 565 of ~850 raw `.count <op> <int>` sites in Tests/,
+# nearly all of them provably-correct topology counts on a primitive shape.
+RISKY_PRODUCER = re.compile(
+    r'\b(?:detectPocket\w*|recognizeFeature\w*|defeatur\w*|removeFeature\w*|subtracting|union\w*|'
+    r'intersecting|booleanFuse\w*|booleanCut\w*|booleanCommon\w*|fillet\w*|chamfer\w*|'
+    r'freeBound\w*|sectionWire\w*|offsetting|sweep\w*|loft\w*|thicken\w*|shell\w*|draft\w*|'
+    r'hollow\w*|unify\w*|heal\w*|fix\w*|sew\w*|import\w*|readSTEP\w*|readIGES\w*|readOBJ\w*|'
+    r'readSTL\w*)\b', re.IGNORECASE)
+
+
+def verifying_helpers(text):
+    """Names of every function in this file whose own body contains a VERIFICATION-matching
+    #expect. A test that calls one of these BY NAME gets the same credit as writing the check
+    inline: the shape `Issue442FixSolidMultiBodyTests.swift`'s private
+    `expectVolume(_:_:_:)` uses (wrapping `#expect(abs(volume - expected) < 1e-6, ...)`), which is
+    otherwise invisible, since the call site `expectVolume(healed, 2000.0, "...")` is not itself a
+    `#expect(...)` call, so a scan that only reads `#expect(` bodies never sees the verification at
+    all."""
+    helpers = set()
+    for name, bs, be in swift_functions(text):
+        body = text[bs:be + 1]
+        if any(VERIFICATION.search(e) for e in expect_bodies(body)):
+            helpers.add(name)
+    return helpers
+
+
+def test_candidates(sources):
+    """(file, line, function, count_pins, total_expects) for every @Test function with a
+    risky-producer count-pin and no verification assertion anywhere in the body, inline or via a
+    same-file helper (see verifying_helpers)."""
+    found = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        helpers = verifying_helpers(text)
+        for name, bs, be in swift_functions(text):
+            body = text[bs:be + 1]
+            exps = expect_bodies(body)
+            pins = [e for e in exps if COUNT_PIN.search(e)]
+            if not pins:
+                continue
+            risky_pins = [e for e in pins if RISKY_PRODUCER.search(body[:body.find(e)])]
+            if not risky_pins:
+                continue
+            if any(VERIFICATION.search(e) for e in exps):
+                continue
+            if any(re.search(r'\b' + re.escape(h) + r'\s*\(', body)
+                   for h in helpers if h != name):
+                continue
+            line = text.count('\n', 0, bs) + 1
+            found.append((os.path.basename(path), line, name, len(pins), len(exps)))
+    return found
+
+
+def test_sources():
+    paths = sorted(glob.glob(os.path.join(TESTS_DIR, '**', '*.swift'), recursive=True))
+    return [(p, open(p, errors='ignore').read()) for p in paths]
+
+
+# ===========================================================================
+# Self-test. Each MISSED fixture must be reported; each CLEAN fixture must
+# not be. Per okf/policies/prove-the-test-fails.md, every fixture below was
+# separately proven to exercise its own guard: the mechanism was deleted from
+# a working copy of this file, --self-test re-run, and the affected case
+# confirmed to flip before the file was restored (see the README's guard-
+# removal matrix). A --self-test that passes 6/6 without that check is
+# exactly the failure this policy exists to catch.
+# ===========================================================================
+
+PROD_MISSED = [
+    ('top-level literal beside a top-level computed sibling (the Healing.mm seed shape)', '''
+OCCTFixtureResult OCCTFixtureAnalyze(OCCTShapeRef shape) {
+    OCCTFixtureResult result = {};
+    try {
+        int smallEdges = 0;
+        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
+            smallEdges++;
+        }
+        result.smallEdgeCount = smallEdges;
+        result.selfIntersectionCount = 0;  // Would require more expensive computation
+        result.isValid = true;
+        return result;
+    } catch (...) { return result; }
+}'''),
+    ('literal and computed sibling both inside the SAME if-branch (depth-matching, not just depth-0)', '''
+OCCTFixtureForm OCCTFixtureRecognize(OCCTShapeRef shape, double tolerance) {
+    OCCTFixtureForm result = {};
+    try {
+        ShapeAnalysis_CanonicalRecognition recog(shape->shape);
+        gp_Pln pln;
+        if (recog.IsPlane(tolerance, pln)) {
+            result.type = 1;
+            result.gap = recog.GetGap();
+            return result;
+        }
+        return result;
+    } catch (...) { return result; }
+}'''),
+    ('literal and computed sibling both inside the same for-loop body (the ShapeAxis shape)', '''
+int32_t OCCTFixtureAxes(OCCTShapeRef shape, OCCTFixtureAxis* outAxes, int32_t maxAxes) {
+    try {
+        std::vector<OCCTFixtureAxis> collected;
+        for (TopExp_Explorer ex(shape->shape, TopAbs_FACE); ex.More(); ex.Next()) {
+            OCCTFixtureAxis a;
+            a.originX = ex.Current().Location().X();
+            a.hasExtent = false;
+            collected.push_back(a);
+        }
+        return (int32_t)collected.size();
+    } catch (...) { return -1; }
+}'''),
+]
+
+# The other failure mode: a literal reached only under a real, checked condition, with no computed
+# sibling reached under that SAME condition, is a legitimate encoding of a fact ("this branch ran"),
+# not a fabrication. #624/#630 was a sibling gate reporting correct code as wrong; this is the same
+# risk here, in the opposite direction of PROD_MISSED's third fixture.
+PROD_CLEAN = [
+    ('literal true only inside a real, checked if-condition, no computed sibling at that depth', '''
+OCCTFixtureImportResult OCCTFixtureImport(const char* path) {
+    OCCTFixtureImportResult result = {nullptr, -1, false};
+    try {
+        TopoDS_Shape shape = readIt(path);
+        if (shape.IsNull()) return result;
+        result.originalType = static_cast<int>(shape.ShapeType());
+        BRepBuilderAPI_Sewing sewing(1.0e-4);
+        sewing.Add(shape);
+        sewing.Perform();
+        TopoDS_Shape sewed = sewing.SewedShape();
+        if (!sewed.IsNull() && !sewed.IsSame(shape)) {
+            shape = sewed;
+            result.sewingApplied = true;
+        }
+        result.shape = new OCCTFixtureShape(shape);
+        return result;
+    } catch (...) { return result; }
+}'''),
+    ('a field set ONLY inside catch (an error-code fallback), never on the success path, beside '
+     'fields the success path genuinely computes', '''
+OCCTFixtureResult OCCTFixtureCompute(OCCTShapeRef shape) {
+    OCCTFixtureResult result = {};
+    try {
+        result.count = realCompute(shape);
+        result.tolerance = deriveTolerance(shape);
+        return result;
+    } catch (...) {
+        result.errorCode = -1;
+        return result;
+    }
+}'''),
+    ('no computed sibling at all: a plain default-value constructor, not an aggregate measurement', '''
+OCCTFixtureStyle OCCTFixtureStyleCreate(void) {
+    OCCTFixtureStyle result;
+    result.r = 0; result.g = 0; result.b = 0;
+    result.alpha = 1.0f;
+    return result;
+}'''),
+]
+
+TEST_MISSED = [
+    ('the #703 shape: risky-producer count-pin, no verification anywhere in the test', '''
+    @Test func fixtureDetectsPocket() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let pocket = Shape.box(origin: SIMD3(5, 5, 10), width: 10, height: 10, depth: 15)!
+        let result = box.subtracting(pocket)!
+        let pockets = result.detectPocketsAAG()
+        #expect(pockets.count >= 1)
+        if let p = pockets.first {
+            #expect(p.depth > 0)
+        }
+    }'''),
+]
+
+TEST_CLEAN = [
+    ('same shape, but with a volume-delta verification alongside the count-pin', '''
+    @Test func fixtureDetectsPocketVerified() {
+        let box = Shape.box(width: 20, height: 20, depth: 20)!
+        let pocket = Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15)!
+        let result = box.subtracting(pocket)!
+        #expect((result.volume ?? 0) < (box.volume ?? 0))
+        let pockets = result.detectPocketsAAG()
+        #expect(pockets.count >= 1)
+    }'''),
+    ('a count-pin whose receiver is not on the curated risky-producer list', '''
+    @Test func fixtureBoxHasSixFaces() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        #expect(box.faces().count == 6)
+    }'''),
+    ('a count-pin verified through a same-file helper call, not an inline #expect (the '
+     'Issue442/Issue443 expectVolume shape, real in this tree, found only after the first '
+     'run flagged 21 of 68 sites this way)', '''
+    private func expectVolume(_ shape: Shape, _ expected: Double, _ what: String) {
+        guard let volume = shape.volume else { return }
+        #expect(abs(volume - expected) < 1e-6, what)
+    }
+    @Test func fixtureFixSolidCountVerifiedByHelper() {
+        let healed = twoBoxes()!.fixSolid()
+        expectVolume(healed, 2000.0, "two boxes")
+        #expect(healed.solids().count == 2)
+    }'''),
+]
+
+
+def _run_prod_fixture(src):
+    sources = [('fixture.mm', src)]
+    return production_candidates(sources)
+
+
+def _run_test_fixture(src):
+    wrapped = "import Testing\nstruct Fixture {\n" + src + "\n}\n"
+    sources = [('fixture.swift', wrapped)]
+    return test_candidates(sources)
+
+
+def self_test():
+    failed = 0
+    print('sub-kind 1 (production literal-vs-computed sibling):')
+    for name, src in PROD_MISSED:
+        hit = _run_prod_fixture(src)
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} should flag, {name}: '
+              f'{[(h[2], h[4]) for h in hit] if hit else "NOT REPORTED"}')
+    for name, src in PROD_CLEAN:
+        hit = _run_prod_fixture(src)
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} should be clean, {name}: '
+              f'{[(h[2], h[4]) for h in hit] + ["wrongly flagged"] if hit else "not flagged"}')
+
+    print('sub-kind 2 (test pinned count with no fixture verification):')
+    for name, src in TEST_MISSED:
+        hit = _run_test_fixture(src)
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} should flag, {name}: '
+              f'{[h[2] for h in hit] if hit else "NOT REPORTED"}')
+    for name, src in TEST_CLEAN:
+        hit = _run_test_fixture(src)
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} should be clean, {name}: '
+              f'{[h[2] for h in hit] + ["wrongly flagged"] if hit else "not flagged"}')
+
+    total = len(PROD_MISSED) + len(PROD_CLEAN) + len(TEST_MISSED) + len(TEST_CLEAN)
+    print(f'{total - failed}/{total} cases correct')
+    return 1 if failed else 0
+
+
+# ===========================================================================
+# Report mode.
+# ===========================================================================
+
+def report_production(quiet):
+    if not os.path.isdir(BRIDGE_SRC_DIR):
+        print(f'{BRIDGE_SRC_DIR} not found - run from the repo root', file=sys.stderr)
+        return 2
+    sites = production_candidates(bridge_sources())
+    print(f'sub-kind 1 (production): {len(sites)} candidate(s)')
+    if not quiet:
+        for f, line, func, var, field, rhs, src in sites:
+            print(f'  {f}:{line}  {func}(): {var}.{field} = {rhs}')
+            print(f'      {src}')
+    return 0
+
+
+def report_tests(quiet):
+    if not os.path.isdir(TESTS_DIR):
+        print(f'{TESTS_DIR} not found - run from the repo root', file=sys.stderr)
+        return 2
+    sites = test_candidates(test_sources())
+    print(f'sub-kind 2 (tests): {len(sites)} candidate(s)')
+    if not quiet:
+        for f, line, func, pins, total in sites:
+            print(f'  {f}:{line}  {func}()  ({pins} count-pin(s) of {total} #expect(s), '
+                  f'no fixture verification)')
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--production', action='store_true', help='sub-kind 1 only')
+    ap.add_argument('--tests', action='store_true', help='sub-kind 2 only')
+    ap.add_argument('--quiet', action='store_true', help='counts only')
+    ap.add_argument('--self-test', action='store_true', help='prove each shape is caught')
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    both = not args.production and not args.tests
+    rc = 0
+    if args.production or both:
+        rc = report_production(args.quiet) or rc
+    if args.tests or both:
+        rc = report_tests(args.quiet) or rc
+    return rc
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -78,6 +78,11 @@ run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py
 run "derive-bridge-header-split.py --self-test" Scripts/derive-bridge-header-split.py --self-test
 run "derive-bridge-header-split.py --verify"    Scripts/derive-bridge-header-split.py --verify
 run "count-operations.py"                     Scripts/count-operations.py
+# Self-test only. census-unmeasured-values.py is #726's census, not a gate: it exits 0 whether or
+# not it finds sites, because its output is a list for a human to adjudicate rather than a verdict.
+# Running it bare here would add a check that cannot fail. Its detector can still go blind, so that
+# is what both this hook and CI hold it to.
+run "census-unmeasured-values.py --self-test" Scripts/census-unmeasured-values.py --self-test
 
 if [ ${#failed[@]} -ne 0 ]; then
     echo ""

--- a/Scripts/repro/726-unmeasured-values/README.md
+++ b/Scripts/repro/726-unmeasured-values/README.md
@@ -1,0 +1,335 @@
+# OCCTSwift#726, first pass: values that were never computed but are returned as if measured
+
+Census only. No source under `Sources/` or `Tests/` is touched by this pass, since five other PRs
+are in flight against `refactor/381-pass1b` that do, and this pass's whole output is a measured
+list for those to draw from, not a diff. The detector is
+[`Scripts/census-unmeasured-values.py`](../../census-unmeasured-values.py); this file records what
+running it against `refactor/381-pass1b` (`d2ae082`) actually found, and the per-site verdict for
+every candidate, because #726 itself lists five prior censuses in this exact family that reported a
+number nobody had measured: #558 said 14, measured 28; #571 said 3, measured 6; #583 said five,
+measured six; #595 said six, measured nine; #640 said 13, measured 20.
+
+## Measured counts
+
+Sub-kind 2's raw count moved mid-pass, and both numbers matter: **68 is what the detector found
+before its own blind spot was found and fixed; 47 is what it finds now.** See "A mid-pass fix"
+below the sub-kind 2 table for the mechanism and the guard-removal proof.
+
+```
+sub-kind 1 (production): 64 candidate(s)
+sub-kind 2 (tests): 47 candidate(s)   (68 before the mid-pass verifying_helpers() fix)
+```
+
+Of those 111 current raw candidates, adjudicated by hand below:
+
+| | count | meaning |
+|---|---|---|
+| **Confirmed real instances (sub-kind 1)** | **2** (3 sites) | `selfIntersectionCount` (the known seed), plus a new pair, `errorReached`/`absoluteError` in `OCCTBRepGPropVinertGK` |
+| Known-good "absence made representable" pattern | 7 | already fixed, per the #583/#595/#609 idiom; controls, not findings |
+| Legitimate default-then-flip status/success flag | 26 | `isValid`/`success`/`isSet` etc., toggles across real control flow |
+| Legitimate branch-selected classification tag | 2 | `type`/`kind`, a different literal per branch, not a fabrication |
+| Structural default for an alpha-less color quantity | 2 | `Quantity_Color`/glTF `EmissiveFactor` have no alpha; `1.0` is a domain fact |
+| Out of scope: local config/options struct, not a returned result | 5 | syntactically identical shape, semantically a different thing |
+| Out of scope: plain value-type constructor, not a measurement API | 19 | echoes its own parameters; nothing was "skipped" |
+| **Confirmed real instances (sub-kind 2)** | **11** | needs a follow-up issue each; see the per-file table below |
+| Sub-kind 2: low-risk (deterministic/inspectable fixture) | 31 | construction makes the geometric relationship verifiable by reading the test |
+| Sub-kind 2: already verified, script still can't see it | 5 | an abbreviated identifier or a different counting property defeats the keyword scan; found by reading the site |
+
+## Known-positive and known-negative controls
+
+Required by the task brief: at least one independently-confirmed real instance the detector must
+catch, and at least one literal that is genuinely correct that it must not flag.
+
+**Known positive (sub-kind 1), independently confirmed before the detector ran:**
+`Sources/OCCTBridge/src/OCCTBridge_Healing.mm:248`, `OCCTShapeAnalyze`:
+`result.selfIntersectionCount = 0;  // Would require more expensive computation`. This is #726's
+own seed instance, already documented in `Sources/OCCTBridge/include/OCCTBridge_Healing.h:26` and
+`Sources/OCCTSwift/ShapeAnalysisResult.swift:17`. The detector reports it.
+
+**Known positive (sub-kind 2), independently confirmed by reading PR #720 (open against this same
+base, not yet merged) before the detector ran:** `Tests/OCCTModelingTests/OCCTModelingTests.swift`,
+`detectPocket()` (in `struct AAGTests`). The pre-#720 fixture places a pocket tool box at
+`origin: SIMD3(5, 5, 10)` against a `Shape.box(width: 20, height: 20, depth: 20)`. `Shape.box`
+centres its box, so the outer box spans -10...10 on every axis and the tool's z-range (10...25)
+never overlaps it at all. `#expect(pockets.count >= 1)` passed anyway, for the wrong reason: the
+same `OCCTEdgeGetConvexity` face1/face2 order-dependence #703 fixed made even a **plain, uncut**
+box falsely report a pocket. PR #720's own fix adds exactly the missing check:
+`#expect((result.volume ?? 0) < (box.volume ?? 0), "pocket tool must actually remove material, or
+this fixture proves nothing")`. Nothing in the pre-#720 test checked that. The detector reports it.
+
+**Known negative #1 (a real computation that happens to be zero, not a placeholder):**
+`OCCTCurve3DCircleEccentricity` (`OCCTBridge_Curve3D.mm:3442`):
+```cpp
+double OCCTCurve3DCircleEccentricity(OCCTCurve3DRef curve) {
+    if (!curve) return 0;
+    try {
+        Handle(Geom_Circle) c = Handle(Geom_Circle)::DownCast(curve->curve);
+        if (c.IsNull()) return 0;
+        return c->Eccentricity();   // the success path is a REAL OCCT call
+    } catch (...) { return 0; }
+}
+```
+A circle's eccentricity genuinely is `0`; the value comes from `Geom_Circle::Eccentricity()`, not a
+literal. This function is outside the detector's own shape entirely (a scalar return, not a
+`var.field =` aggregate), so it does not appear in the candidate list at all, which is itself the
+correct answer for this site, confirmed here by inspection rather than reported as a `0/N`
+result the detector cannot produce for something it structurally cannot see.
+
+**Known negative #2, inside the detector's actual shape (a literal correctly gating a real
+absence, the #583/#595/#609 idiom the detector's own candidates get adjudicated against):**
+`OCCTShapeRevolutionAxes`/`OCCTShapeSymmetryAxes` (`OCCTBridge_Topology.mm:653`, `:694`):
+`a.extentMin = 0; a.extentMax = 0; a.hasExtent = false;` sits beside real computed fields
+(`a.originX = p.X(); ...`) in the same `for` loop, and the detector DOES flag it (correctly, per
+its own stated shape: a literal beside a same-depth computed sibling). The adjudication is what
+says it is not a bug: `Sources/OCCTSwift/ShapeAxis.swift:34` reads
+`self.extent = a.hasExtent ? (a.extentMin...a.extentMax) : nil`, so absence is already
+representable as `nil`, which is the fix this whole issue family (#583/#595/#609) established as
+correct. The detector gets this one right in the only sense a structural, non-semantic detector
+can: it produces the candidate for a human to look at, and does not silently drop it either.
+
+## Guard-removal matrix
+
+Per `okf/policies/prove-the-test-fails.md`: a `--self-test` proves nothing by existing. Each of the
+7 structural mechanisms below was deleted from a working copy of the script in turn, the
+`--self-test` suite re-run, and the case count confirmed to drop, then the file was restored from
+an untouched backup and `diff`'d byte-identical before moving to the next one. All fixtures pass
+before every experiment and after every restore; only the experiment column differs. Mechanism 7
+was added mid-pass, after the first real run's 68 sub-kind-2 candidates were being read by hand and
+turned out to include a systematic false-positive family (see "A mid-pass fix" below); mechanisms
+1-6 were proven against the original 9-fixture self-test, mechanism 7 against the resulting
+10-fixture one.
+
+| # | Mechanism removed | Fixture(s) that flip | Before | During | Confirms |
+|---|---|---|---|---|---|
+| 1 | Catch-block exclusion (`catch_spans` returns `[]`) | "field set ONLY inside catch" | clean | **wrongly flagged** | An exception-recovery literal is not "never measured" |
+| 2 | Depth-matching (`if d in computed_depths` becomes always true) | "literal only inside a checked if, no same-depth sibling" (`sewingApplied`) | clean | **wrongly flagged** | A literal gated by a real condition is not a fabrication |
+| 3 | "Needs *a* computed sibling at all" (the `continue` guard removed, depth check also bypassed) | the same `sewingApplied` fixture, and the plain-constructor fixture | clean, clean | **both wrongly flagged** | A pure-literal constructor (no aggregate measurement at all) needs this gate |
+| 4 | Curated `RISKY_PRODUCER` list (becomes: matches any receiver) | "a count-pin whose receiver is not on the curated list" (`box.faces().count == 6`) | clean | **wrongly flagged** | An unscoped version floods on primitive topology counts (565/850 raw sites, measured separately) |
+| 5 | `VERIFICATION` exclusion (becomes: never matches) | the volume-verified pocket fixture | clean | **wrongly flagged** | Without it, a test that DOES verify its fixture gets flagged anyway |
+| 6 | `COUNT_PIN` regex (becomes: never matches) | the #703-shaped fixture itself | flagged | **NOT REPORTED** | The core detection signal for sub-kind 2 |
+| 7 | `verifying_helpers()` (becomes: returns an empty set unconditionally) | the `expectVolume`-style helper-call fixture | clean | **wrongly flagged** | Without it, a verification performed through a same-file helper is invisible, which is exactly the 21-site false-positive family below |
+
+Each row was run individually (edit, `python3 Scripts/census-unmeasured-values.py --self-test`,
+restore, `diff` confirms identical to backup) before the next. Full transcript is reproducible by
+re-running the same 7 edits described in the mechanism column against
+`Scripts/census-unmeasured-values.py` as committed; the self-test's own fixtures
+(`PROD_MISSED`/`PROD_CLEAN`/`TEST_MISSED`/`TEST_CLEAN`) are the ones exercised.
+
+No mechanism removal left its target fixture's classification unchanged: every mechanism this
+script has is load-bearing for at least one fixture, which is the bar this policy sets, not merely
+"the self-test passes."
+
+## A mid-pass fix: verification performed through a helper call
+
+The first full run of the sub-kind 2 detector reported 68 candidates. Reading every one of them by
+hand (see the per-site table below) found a single mechanism accounting for 21 of the 68, all in
+two files: `Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift` and
+`Issue443FirstOfNTests.swift` both define a private helper,
+
+```swift
+private func expectVolume(_ shape: Shape, _ expected: Double, _ what: String,
+                          sourceLocation: SourceLocation = #_sourceLocation) {
+    guard let volume = shape.volume else {
+        Issue.record("\(what): volume is nil, the solid came back inverted", sourceLocation: sourceLocation)
+        return
+    }
+    #expect(abs(volume - expected) < 1e-6, "\(what): volume \(volume), expected \(expected)",
+            sourceLocation: sourceLocation)
+}
+```
+
+and every call site reads `expectVolume(healed, 2000.0, "two boxes")`, a plain function call, not a
+`#expect(...)` call. The detector's `VERIFICATION` check only ever read text inside `#expect(...)`
+bodies, so a verification performed one call frame away was invisible; every count-pinned test in
+those two files that also called `expectVolume` was a false positive.
+
+Fixed by adding `verifying_helpers(text)`: it scans every function in the file, and any whose OWN
+body contains a VERIFICATION-matching `#expect` is registered by name; a test calling one of those
+names by name is treated the same as writing the check inline. This dropped the sub-kind 2 raw
+count from 68 to 47 with zero new sites appearing (verified by diffing the two runs' site lists;
+see the guard-removal matrix's mechanism 7 for proof the fix is load-bearing, not decorative).
+
+**What this does not fix, because a keyword scan cannot:** 5 of the 68 already have a real,
+independent verification that the detector still cannot see, called out individually in the table
+below. Two shapes recur: an abbreviated identifier defeats the keyword match even inline
+(`#expect(abs(v - 1000.0) < 1e-6)`, `#expect(pv < ov)` for "pocket volume" against "outer volume"),
+and a different counting property stands in as the verification
+(`#expect(connected.edgeCount == 7)`, proving two faces actually merged, is not one of the ten
+nouns `VERIFICATION` looks for). Both were found by reading the site, not by the script.
+
+## Sub-kind 1: full per-site table (64 candidates)
+
+Legend: **REAL** = confirmed instance of the class, needs a follow-up issue. **GOOD** = known-good
+"absence made representable" pattern, a control not a finding. **FLIP** = legitimate
+default-then-flip status/success flag. **TAG** = legitimate branch-selected classification literal.
+**ALPHA** = structural default for a color quantity with no alpha channel upstream. **CFG** = a
+local config/options struct passed as an argument, not a value returned to the caller (out of
+`#726`'s scope: it is never "returned through an API"). **CTOR** = a plain value-type constructor
+echoing its own parameters, not a measurement API.
+
+| Site | Field | Verdict | Why |
+|---|---|---|---|
+| `OCCTBridge_BRepGraph.mm:216` `OCCTBRepGraphCreate` | `opts.CreateAutoProduct` | CFG | `BRepGraph::ShapesView::Options` passed into `Add()`, never returned |
+| `OCCTBridge_BRepGraph.mm:1962` `OCCTBRepGraphBuilderAppendFlattenedShape` | `opts.CreateAutoProduct` | CFG | same `Options` shape |
+| `OCCTBridge_BRepGraph.mm:1963` `OCCTBRepGraphBuilderAppendFlattenedShape` | `opts.Flatten` | CFG | same |
+| `OCCTBridge_BRepGraph.mm:1973` `OCCTBRepGraphBuilderAppendFullShape` | `opts.CreateAutoProduct` | CFG | same |
+| `OCCTBridge_Curve3D.mm:2208` `OCCTGeomConvertCurveToAnalytical` | `result.success` | FLIP | `true` only after `occtCurveToAnalytical(...)` genuinely succeeds |
+| `OCCTBridge_Document.mm:427` `OCCTDocumentGetLabelColor` | `result.isSet` | FLIP | `true` only when `colorTool->GetColor` actually found a color |
+| `OCCTBridge_Document.mm:520` `OCCTDocumentGetLabelMaterial` | `result.baseColor.isSet` | FLIP | `true` only inside the PBR-material-found branch |
+| `OCCTBridge_Document.mm:530` `OCCTDocumentGetLabelMaterial` | `result.emissive.a` | ALPHA | `pbr.EmissiveFactor` is a `Graphic3d_Vec3` (glTF emissive has no alpha); `1.0` is opaque by definition |
+| `OCCTBridge_Document.mm:531` `OCCTDocumentGetLabelMaterial` | `result.emissive.isSet` | FLIP | same branch as `baseColor.isSet` |
+| `OCCTBridge_Document.mm:775` `OCCTDocumentGetDimensionInfo` | `info.isValid` | FLIP | default before the label/attribute lookup, flipped `true` only on full success (`:798`) |
+| `OCCTBridge_Document.mm:807` `OCCTDocumentGetGeomToleranceInfo` | `info.isValid` | FLIP | same pattern |
+| `OCCTBridge_Document.mm:3050` `OCCTDocumentGetShapeColor` | `result.a` | ALPHA | `Quantity_Color` (not `ColorRGBA`) has no alpha channel; `1.0` is the domain default |
+| `OCCTBridge_Document.mm:3051` `OCCTDocumentGetShapeColor` | `result.isSet` | FLIP | `true` only when `GetColor` found one |
+| `OCCTBridge_Document.mm:4290-4325` `OCCTXCAFPrsStyleCreate*` (11 fields across 3 functions) | `surfR/G/B`, `hasSurfColor`, `curvR/G/B`, `hasCurvColor`, `isEmpty` | CTOR | plain style-value constructors; `hasSurfColor`/`hasCurvColor` already gate `PresentationStyle.swift`'s optional `surfaceColor`/`curveColor` into `nil` |
+| `OCCTBridge_Geom2d.mm:2593` `OCCTBisectorPointOnBisCreate` | `result.isInfinite` | CTOR | plain point-value constructor from caller-supplied params, not a computation |
+| `OCCTBridge_Healing.mm:248` `OCCTShapeAnalyze` | `result.selfIntersectionCount` | **REAL** | the known seed: `0` on every call, comment admits "would require more expensive computation" |
+| `OCCTBridge_Healing.mm:251` `OCCTShapeAnalyze` | `result.isValid` | FLIP | `true` after the shell/edge/face/wire scan completes |
+| `OCCTBridge_Healing.mm:1632-1634` `OCCTShapeCheckSmallFaces` | `isSpotFace`, `isStripFace`, `isTwisted` | FLIP | each initialised `false` per loop iteration, flipped `true` a few lines below by a real `checker.Is*`/`CheckTwisted` call |
+| `OCCTBridge_Healing.mm:1835` `OCCTCheckFace` | `result.isValid` | FLIP | input-validation guard (`if (!face)`); see the depth-coincidence note below |
+| `OCCTBridge_Healing.mm:1895` `OCCTCheckSolid` | `result.isValid` | FLIP | same guard shape |
+| `OCCTBridge_Healing.mm:2049` `checkSubShape` | `result.isValid` | FLIP | set `true` then conditionally flipped back `false` per real status code |
+| `OCCTBridge_Healing.mm:2413` `OCCTShapeNearestPlane` | `result.success` | FLIP | `true` only inside `if (ShapeAnalysis_Geom::NearestPlane(...))`, alongside real computed fields |
+| `OCCTBridge_IO.mm:828` `OCCTImportSTEPWithDiagnostics` | `result.solidCreated` | FLIP | `true` only inside `if (solidsCreated > 0)`, beside the real `result.solidsCreated = solidsCreated` |
+| `OCCTBridge_Modeling.mm:5361` `OCCTChFi2dFilletAlgo` | `result.success` | FLIP | reached only after `fillet.NbResults`/`fillet.Result` both succeed |
+| `OCCTBridge_Modeling.mm:5438` `OCCTChFi2dAnaFillet` | `result.success` | FLIP | reached only after `fillet.Perform(radius)` succeeds |
+| `OCCTBridge_Properties.mm:519` `OCCTFaceProjectPoint` | `result.isValid` | FLIP | default before `GeomAPI_ProjectPointOnSurf`, flipped on `proj.NbPoints() > 0` |
+| `OCCTBridge_Properties.mm:590` `OCCTEdgeProjectPoint` | `result.isValid` | FLIP | same pattern |
+| `OCCTBridge_Properties.mm:760` `OCCTWireGetCurveInfo` | `result.isValid` | FLIP | default before the real length/closed/periodic/endpoint computation, flipped at `:787` |
+| `OCCTBridge_Properties.mm:896` `OCCTWireGetCurvePointAt` | `result.isValid` | FLIP | flipped `true` at the end after real position/tangent/curvature work |
+| `OCCTBridge_Properties.mm:897` `OCCTWireGetCurvePointAt` | `result.hasNormal` | **GOOD** | flipped `true` only when the normal is well-defined (`:945`), the same "absence made representable" idiom as `hasExtent` |
+| `OCCTBridge_Properties.mm:1341` `OCCTBRepGPropVinertGK` | `result.errorReached` | **REAL** | `0.0` on every call; comment reads `// GetErrorReached is inline-only in OCCT 8.0.0`, a real technical constraint, but the field still reads as measured and never is |
+| `OCCTBridge_Properties.mm:1342` `OCCTBRepGPropVinertGK` | `result.absoluteError` | **REAL** | same function, same story, no comment at all on this one |
+| `OCCTBridge_Properties.mm:1844` `OCCTShapeGetProperties` | `result.isValid` | FLIP | default before volume/mass/inertia/area, flipped at `:1879` |
+| `OCCTBridge_Properties.mm:1981` `OCCTShapeDistance` | `result.isValid` | FLIP | `true` only inside `if (distCalc.IsDone() && ...)` |
+| `OCCTBridge_Spatial.mm:2268` `OCCTMathIntegKronrodAdaptive` | `config.Adaptive` | CFG | `MathInteg::KronrodConfig` passed into `Kronrod(...)`, never returned |
+| `OCCTBridge_Surface.mm:1207` `OCCTShapeRecognizeCanonical` | `result.type` | TAG | `1` for the plane branch, `2` for cylinder, etc.; a branch-selected classification, not a fabrication |
+| `OCCTBridge_Surface.mm:2932` `occtSurfToAnaSurfResult` | `result.success` | FLIP | `true` only after `occtSurfaceToAnalytical(...)` succeeds |
+| `OCCTBridge_Topology.mm:653` `OCCTShapeRevolutionAxes` | `extentMin`, `extentMax`, `hasExtent` | **GOOD** | known-negative control #2 above: gated into `nil` by `ShapeAxis.swift:34` |
+| `OCCTBridge_Topology.mm:694` `OCCTShapeSymmetryAxes` | `extentMin`, `extentMax`, `hasExtent` | **GOOD** | same gate, same file |
+| `OCCTBridge_Topology.mm:694` `OCCTShapeSymmetryAxes` | `kind` | TAG | `7` marks "symmetry-derived axis" as a class distinct from the revolution-axis kinds 1-5, not a skipped classification |
+| `OCCTBridge_Topology.mm:713` `OCCTShapeSymmetryAxes` | `extentMin`, `extentMax`, `hasExtent`, `kind` | GOOD/TAG | identical shape and verdict to `:694`, on a second `OCCTShapeAxis a;` in the `HasSymmetryAxis()` branch; the script counts one report per (function, field name), so this line is deduplicated out of the 64 rather than double-counted, not missed |
+| `OCCTBridge_Topology.mm:1299` `OCCTBRepExtremaExtPC` | `result.isValid` | FLIP | `true` at the end after real point/parameter/distance/count work |
+| `OCCTBridge_Topology.mm:1362` `OCCTShapePolyhedralDistance` | `result.success` | FLIP | `true` only inside `if (ok)`, beside real distance/point fields |
+
+**A structural note on the three `FLIP` sites at `OCCTBridge_Healing.mm:1835/1895/2049`:** these are
+flagged because a computed sibling exists at the SAME NUMERIC CONDITIONAL DEPTH elsewhere in the
+same function (e.g. `OCCTCheckFace`'s per-status-code loop body, `result.errorCount++`), not because
+the guard clause itself has a computed sibling. The detector counts nesting depth, not branch
+identity; see "WHAT THIS STILL CANNOT SEE" in the script's own docstring. Adjudicated FLIP because
+reading the surrounding branches shows the guard clause is ordinary null-input validation.
+
+**Follow-up recommendation:** file one new issue for `OCCTBRepGPropVinertGK`'s `errorReached`/
+`absoluteError` (both `OCCTBridge_Properties.mm:1341-1342`), in the same spirit as
+`selfIntersectionCount`'s own existing entry. Not filed as part of this census-only pass.
+
+## Sub-kind 2: full per-site table (68 candidates from the first run, 47 flagged today)
+
+Every candidate the first run reported, in that run's order, read individually against its own
+test file. **Still flagged** says whether today's script (after the mid-pass fix above) still
+reports the site; the 21 rows marked "no" are exactly the `expectVolume`-helper family the fix
+targets. Verdicts: **LOW-RISK** (the fixture's geometric relationship is verifiable by construction
+or already re-derived from known structure), **NEEDS-FOLLOWUP** (not verifiable by inspection,
+and nothing else in the test would catch a silent no-op), **ALREADY-FIXED** (a real, independent
+verification exists that the detector cannot see, inline or through a helper).
+
+| Site | Function | Verdict | Still flagged | Why |
+|---|---|---|---|---|
+| `Issue617FaceGridLayoutTests.swift:254` | `squareAndSingleGridsStillWork` | LOW-RISK | yes | count is `uSamples x vSamples`, deterministic, and cross-checked against a computed expected point |
+| `OCCTBRepGraphTests.swift:717` | `shellSolids` | LOW-RISK | yes | plain box trivially has 1 shell / 1 solid by construction, no risky op involved |
+| `OCCTCurveTests.swift:20` | `loftedShapeEdgePolylines` | NEEDS-FOLLOWUP | yes | both profile circles default to z=0 despite a comment claiming different Z heights; the loft may be a degenerate, coplanar shape |
+| `OCCTIOTests.swift:1757` | `stepProgressCallbackFires` | LOW-RISK | yes | companion `stepRoundTripPreservesGeometry` (same file) already verifies STEP roundtrip volume/area/face/edge fidelity |
+| `OCCTIntegrationTests.swift:186` | `cylinderWithHolesSlicing` | LOW-RISK | yes | holes at r=10 are clearly inside the r=25 cylinder and drilled through; a no-op would give 1 wire, not 4 |
+| `OCCTIntegrationTests.swift:233` | `plateWithHolesSection` | LOW-RISK | yes | holes at (+-25, +-25) are clearly inside the 100x100 plate and drilled through; wire count of 5 follows by construction |
+| `OCCTIntegrationTests.swift:346` | `pocketSectionAndOffset` | ALREADY-FIXED | yes | the test already checks `pv < ov` (pocket volume less than outer volume); the abbreviated names defeat `VERIFICATION`'s keyword match |
+| `Issue497DefeaturingTests.swift:112` | `outOfRangeIndexFails` | LOW-RISK | yes | `realFaces.count == 6` is a plain box's deterministic face count, not a risky-op output |
+| `Issue497DefeaturingTests.swift:150` | `withoutSmallFacesKeepsEverything` | ALREADY-FIXED | yes | the same block also asserts `abs(v - 1000.0) < 1e-6`; the abbreviated `v` defeats the keyword match |
+| `Issue505FilletBuilderEdgeTypeTests.swift:64` | `edgeFromAnotherContourIsRejected` | LOW-RISK | yes | `edges.count == 12` is a box's deterministic edge count; the real guard logic is a nil/non-nil check |
+| `Issue578DefeatureFaceMembershipTests.swift:68` | `foreignFaceInMixedRequestFails` | LOW-RISK | yes | the fixture's face was chosen precisely because removing it restores the plain box's known volume |
+| `Issue612FilletContourSelectionTests.swift:81` | `fixtureHasATangentContinuousRim` | LOW-RISK | yes | extruding an explicit 2-line/2-arc profile deterministically gives matching top/bottom rim counts |
+| `Issue639FilletDeclinedEdgeReportTests.swift:40` | `filletedWithReportNamesDeclinedEdges` | LOW-RISK | yes | declined set matches an exact, pre-measured index set; `edges.count == 12` is the box's known count |
+| `Issue639FilletDeclinedEdgeReportTests.swift:149` | `historyRecordNamesDeclinedEdges` | LOW-RISK | yes | `Set(declined) == Set(declinedIndices)` is an exact match; accepted edges also independently checked |
+| `Issue639FilletDeclinedEdgeReportTests.swift:194` | `declinedEdgeNamedTwiceIsReportedTwice` | LOW-RISK | yes | `Set(declinedEdgeIndices) == [declined]` pins the specific edge; the count of 2 cannot pass by coincidence |
+| `Issue642AAGNodeIdentityTests.swift:55` | `detectPocketsAgreesAcrossOrder` | NEEDS-FOLLOWUP | yes | `detectPocketsAAG().count` pinned to 1 with no volume/area check that a real pocket exists |
+| `Issue642AAGNodeIdentityTests.swift:77` | `upwardHorizontalCountAgreesAcrossOrder` | NEEDS-FOLLOWUP | yes | an `isUpward && isHorizontal` node count pinned to 2 with no independent geometric confirmation |
+| `Issue642AAGNodeIdentityTests.swift:115` | `sharedWallNodesShareDistinctIndexAndOpposeUpward` | LOW-RISK | yes | exactly one shared face is deterministic for a single plane-split box; `isUpward`/`isHorizontal` checked directly |
+| `Issue655SectionWiresOrientationTests.swift:82` | `internalEdgeExcluded` | LOW-RISK | yes | explicit square plus a disjoint floating edge; also checks the surviving wire has 4 edges and is closed |
+| `Issue655SectionWiresOrientationTests.swift:98` | `forwardEdgeNotExcluded` | LOW-RISK | yes | contrast case for the row above; simple explicit coordinates make the wire count inspectable |
+| `Issue655SectionWiresOrientationTests.swift:112` | `externalEdgeExcluded` | LOW-RISK | yes | same explicit, inspectable fixture as the two rows above, only the orientation flag differs |
+| `Issue699AAGSolidScopedAdjacencyTests.swift:69` | `detectPocketsAgreesAcrossOrder` | NEEDS-FOLLOWUP | yes | same `detectPocketsAAG().count` pinning concern as the Issue642 version, on a vertical-cut fixture |
+| `Issue699AAGSolidScopedAdjacencyTests.swift:89` | `nodeCountUnaffected` | LOW-RISK | yes | split into exactly 2 pieces by an earlier guard; 12 nodes = 2 boxes x 6 faces is deterministic |
+| `Issue699AAGSolidScopedAdjacencyTests.swift:106` | `edgeCountIsTwoIndependentBoxGraphs` | LOW-RISK | yes | a companion test in the same file confirms no cross-solid adjacency via neighbor-set disjointness |
+| `Issue699AAGSolidScopedAdjacencyTests.swift:180` | `horizontalFixtureStillAgreesAtCorrectedCount` | NEEDS-FOLLOWUP | yes | same `detectPocketsAAG` count-pin concern, reused at the "corrected" value 1 |
+| `Issue699AAGSolidScopedAdjacencyTests.swift:225` | `countMismatchFallsBackToUnrestrictedComparison` | NEEDS-FOLLOWUP | yes | `detectPocketsAAG().count == 2` pinned on a fallback fixture; the test's own comment admits it proves little |
+| `Issue699AAGSolidScopedAdjacencyTests.swift:253` | `threeSolidCompoundPartitions` | LOW-RISK | yes | 3 disjoint, known boxes; `solids.count == 3` and `nodes == 18` (3x6) are deterministic construction facts |
+| `OCCTModelingTests.swift:1047` | `detectPocket` | **NEEDS-FOLLOWUP** | yes | the confirmed #726/#703 anchor bug, still live: the pocket tool's z-range never overlaps the box's own |
+| `OCCTModelingTests.swift:1199` | `loftedEdgePolylines` | NEEDS-FOLLOWUP | yes | bottom and top rectangles both default to z=0; the loft fixture may be coplanar/degenerate, unverified |
+| `OCCTModelingTests.swift:3053` | `splitSingleShell` | NEEDS-FOLLOWUP | yes | the sole assertion sits inside `if let`, so a nil/failed split silently skips all verification |
+| `OCCTModelingTests.swift:5160` | `modified` | NEEDS-FOLLOWUP | yes | `mod.count >= 0` is vacuously true for any array; it verifies nothing about whether the face was modified |
+| `Issue442FixSolidMultiBodyTests.swift:64` | `fixSolidMultiBody` | ALREADY-FIXED | no | calls the private `expectVolume(healed, 2000.0, ...)` helper |
+| `Issue442FixSolidMultiBodyTests.swift:83` | `fixSolidSingleBody` | ALREADY-FIXED | no | `expectVolume` helper, target 1000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:99` | `fixSolidHollow` | ALREADY-FIXED | no | `expectVolume` helper, target 7000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:115` | `fixSolidMulticonnex` | ALREADY-FIXED | no | `expectVolume` helper, target 2000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:182` | `solidFromShellSkipsCavity` | ALREADY-FIXED | no | `expectVolume` helper, target 8000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:201` | `solidFromShellMulticonnex` | ALREADY-FIXED | no | `expectVolume` helper, target 2000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:223` | `solidFromShellCavityWithWiderSibling` | ALREADY-FIXED | no | `expectVolume` helper, target 35000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:251` | `solidFromShellFreeShells` | ALREADY-FIXED | no | `expectVolume` helper, target 2000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:273` | `solidFromShellDeduplicates` | ALREADY-FIXED | no | `expectVolume` helper, target 1000.0 |
+| `Issue442FixSolidMultiBodyTests.swift:314` | `documentedUnclosedCheck` | LOW-RISK | yes | reuses `twoBoxes().fixSolid()`, already volume-verified by the companion `fixSolidMultiBody` in the same file |
+| `Issue442FixSolidMultiBodyTests.swift:390` | `reproducerTable` | ALREADY-FIXED | no | the loop body calls `expectVolume(shape, 2000.0, label)` for every row |
+| `Issue443FirstOfNTests.swift:69` | `solidFromSewnMultiBody` | ALREADY-FIXED | no | private `expectVolume` helper (same pattern), target 2000.0 |
+| `Issue443FirstOfNTests.swift:89` | `solidFromAgreesWithSibling` | ALREADY-FIXED | no | two `expectVolume` calls, one per code path, both target 2000.0 |
+| `Issue443FirstOfNTests.swift:107` | `solidFromSingleShell` | ALREADY-FIXED | no | `expectVolume` helper, target 1000.0 |
+| `Issue443FirstOfNTests.swift:134` | `solidFromKeepsOpenBody` | LOW-RISK | yes | face count 11 = 6+5 is derived from the fixture's own explicit face slicing; rules out a dropped body |
+| `Issue443FirstOfNTests.swift:151` | `solidFromSkipsCavity` | ALREADY-FIXED | no | `expectVolume` helper, target 8000.0 |
+| `Issue443FirstOfNTests.swift:170` | `solidFromMulticonnex` | ALREADY-FIXED | no | `expectVolume` helper, target 2000.0 |
+| `Issue443FirstOfNTests.swift:210` | `sewnHollowIsOneBody` | ALREADY-FIXED | no | loop calls `expectVolume(result, 8000.0, ...)` for both code paths |
+| `Issue443FirstOfNTests.swift:232` | `sewnAndUnsewnHollowAgree` | ALREADY-FIXED | no | two `expectVolume` calls, both target 8000.0 |
+| `Issue443FirstOfNTests.swift:281` | `touchingBodiesNotPruned` | ALREADY-FIXED | no | `expectVolume` helper, target 2000.0 |
+| `Issue443FirstOfNTests.swift:303` | `solidWithHistoryMultiBody` | ALREADY-FIXED | no | `expectVolume` helper, target 2000.0 |
+| `Issue443FirstOfNTests.swift:335` | `solidWithHistoryQueryableForEveryBody` | LOW-RISK | yes | every face of both boxes is individually checked `!isDeleted` in the shared history, stronger than a count |
+| `Issue443FirstOfNTests.swift:379` | `solidWithHistoryKeepsOpenBody` | LOW-RISK | yes | same open-shell reasoning as `solidFromKeepsOpenBody`: face count 11 rules out a dropped body |
+| `Issue443FirstOfNTests.swift:464` | `upgradedHollow` | ALREADY-FIXED | no | two `expectVolume` calls (input 7000.0, result 8000.0) |
+| `Issue443FirstOfNTests.swift:482` | `upgradedNestedBody` | ALREADY-FIXED | no | `expectVolume` helper, target 8512.0 |
+| `Issue484ConnectedFacesTests.swift:87` | `genuinelyDisconnectedFacesGetConnected` | ALREADY-FIXED | yes | also checks `connected.edgeCount == 7` (down from a confirmed 8); `edgeCount` is not one of `VERIFICATION`'s ten nouns |
+| `Issue484FaceFixContextTests.swift:21` | `periodicConicalFaceSurvivesFaceFix` | LOW-RISK | yes | fixing one face deterministically yields one face; the #317 regression concern was a crash, not a miscount |
+| `Issue484FaceFixContextTests.swift:59` | `unhealedPeriodicConicalUVFaceSurvivesFaceFix` | LOW-RISK | yes | the doc's own claim is "completes and returns a face"; `count == 1` states exactly that |
+| `Issue484FaceFixContextTests.swift:82` | `wellFormedBoxFacesUnaffected` | LOW-RISK | yes | box face count (6) is deterministic; per-face `fixed().count == 1` is a structural invariant of the operation |
+| `OCCTSurfaceTests.swift:5667` | `coaxialDedup` | NEEDS-FOLLOWUP | yes | nothing confirms both a cylindrical and a toroidal face actually survive the union before dedup is asserted to 1 axis |
+| `Issue211OuterShellTests.swift:42` | `innerShells` | ALREADY-FIXED | yes | a bounding-box check (`bb.max.x - bb.min.x` around 8.0) confirms the found shell is the cavity, not the outer body; bbox spans are not a `VERIFICATION` noun |
+| `Issue439OuterShellMultiSolidTests.swift:68` | `multiSolidInnerShellsEmpty` | LOW-RISK | yes | subtracting one fully-enclosed cavity from a box deterministically gives exactly 1 cavity shell |
+| `Issue439OuterShellMultiSolidTests.swift:81` | `outerShellsPerSolid` | ALREADY-FIXED | yes | bounding-box spans confirm the two shells match the two known box positions; same bbox blind spot as `innerShells` |
+| `Issue502SubShapeTraversalTests.swift:176` | `indexedAndArrayAccessMatch` | LOW-RISK | yes | `shells.count == 2` is the well-established hollow-box (20-cube minus an enclosed 8-cube) deterministic shell count |
+| `Issue613IndexContractTests.swift:102` | `concaveEdgeIsTheConcaveEdge` | LOW-RISK | yes | `concave.map(\.index) == [corner]` pins the exact, geometrically located edge, not merely a count of 1 |
+| `Issue614FaceOrientationTests.swift:117` | `sharedWallFacesOutOfBothSolids` | LOW-RISK | yes | counts deterministic for a one-plane box split; the outward-normal claim is confirmed via a dot-product check |
+| `OCCTTopologyTests.swift:1348` | `boxShells` | LOW-RISK | yes | a plain box's shell count is trivially 1 by construction, no risky operation involved |
+
+**Follow-up recommendation:** file one issue per cluster among the 11 NEEDS-FOLLOWUP rows, not one
+issue per site: (1) the confirmed, still-live #726/#703 anchor at `OCCTModelingTests.swift:1047`
+`detectPocket()`, matching PR #720's own fix; (2) the `detectPocketsAAG()`/AAG-node-count family
+with no geometric backstop (`Issue642AAGNodeIdentityTests.swift:55,77`,
+`Issue699AAGSolidScopedAdjacencyTests.swift:69,180,225`, the last of which has a comment already
+admitting it proves little); (3) two loft fixtures whose "different Z heights" intent is not
+actually in the code (`OCCTCurveTests.swift:20`, `OCCTModelingTests.swift:1199`); (4) three
+structurally weak assertions with no shared cause (`OCCTModelingTests.swift:3053`'s `if let`-gated
+check, `OCCTModelingTests.swift:5160`'s vacuous `count >= 0`, `OCCTSurfaceTests.swift:5667`'s
+unconfirmed dedup input).
+
+## Methodology notes
+
+- **The starting-point grep is not the detector.** `grep -rniE "would require|not implemented|
+  placeholder|hardcod" Sources/` (the task's own seed) returns 16 lines on this tree; 15 of them are
+  comments describing an ALREADY-FIXED historical defect (documented in `CLAUDE.md`'s "Known OCCT
+  Bugs"), and only one, the seed itself, is live. Neither of this pass's two real production finds
+  (`errorReached`/`absoluteError`) uses any of those four words: the comment reads "GetErrorReached
+  is inline-only in OCCT 8.0.0", which the keyword grep cannot see. This is exactly why #726 calls
+  the grep "the STARTING point, not the answer".
+- **A name-prefix census would have been wrong here too.** Filtering candidates by field name
+  (`*Count`, `*Error`, `is*`) would have caught `selfIntersectionCount` and `errorReached` but also
+  every `isValid`/`isSet`/`success` FLIP site and every `hasExtent`/`hasNormal` GOOD site. The
+  behavioural signal (same-depth literal beside a same-depth computed sibling, single value versus
+  toggling across branches) is what separates them, not the name.
+- Full self-test transcript, guard-removal matrix, and this table are reproducible by running
+  `python3 Scripts/census-unmeasured-values.py --self-test` and
+  `python3 Scripts/census-unmeasured-values.py` from the repo root.


### PR DESCRIPTION
## What & why

First pass of #726 (epic). Scope is a measured census only: no fixes, no `Sources/` or `Tests/`
changes. Adds `Scripts/census-unmeasured-values.py`, a runnable detector for the two sub-kinds
#726 describes for this pass, and `Scripts/repro/726-unmeasured-values/README.md`, the full
per-site adjudication.

**Sub-kind 1** (production): a bridge result field assigned a bare literal while a sibling field
of the same local variable, reached at the same control-flow depth, is assigned from a real
computation. **Sub-kind 2** (tests): a `.count <op> <int literal>` assertion pinned on a fixture
produced by an operation that could plausibly do nothing, with no other assertion in the same test
independently confirming the fixture did what its shape implies.

Measured against `refactor/381-pass1b`:

- **Sub-kind 1: 64 candidates.** 2 confirmed real (3 sites): the known `selfIntersectionCount`
  seed, plus a new pair, `OCCTBRepGPropVinertGK`'s `errorReached`/`absoluteError` (both hardcoded
  `0.0`, one with a comment explaining why the real getter can't be called on this OCCT version).
  The rest are adjudicated as legitimate: 7 already use the "make absence representable" fix
  #583/#595/#609 established (controls, not findings), 26 are default-then-flip status flags, 2
  are branch-selected classification tags, 2 are structural defaults for an alpha-less color
  quantity, and 24 are out of the detector's actual scope (a local config struct passed as an
  argument, or a plain value constructor), which the README documents as a named blind spot.
- **Sub-kind 2: 47 candidates** (68 before a mid-pass fix, see below). 11 confirmed real, including
  the still-live #703/#720 pocket fixture (a boolean subtraction that removes zero volume, passing
  only because of the since-fixed `OCCTEdgeGetConvexity` sign bug). 31 are low-risk, deterministic
  fixtures. 5 already have a real, independent verification the keyword scan can't see (an
  abbreviated identifier or a different counting property).

**A mid-pass fix, not just a footnote.** Reading the first run's 68 test candidates by hand found
one mechanism accounting for 21 of them: `Issue442FixSolidMultiBodyTests.swift`/
`Issue443FirstOfNTests.swift` verify volume through a private `expectVolume(...)` helper wrapping
`#expect(...)`, which a scan that only reads `#expect(` bodies can't see through. Fixed with
`verifying_helpers()`, which credits a call to any same-file function whose own body contains a
matching `#expect`. Verified via diff that this dropped the raw count from 68 to 47 with zero new
sites appearing.

Per `okf/policies/prove-the-test-fails.md`: all 7 structural mechanisms (not just the sub-kind-2
fix) were proven load-bearing by deleting each from a working copy in turn, confirming the
`--self-test` case count dropped, then restoring and `diff`-confirming byte-identical before the
next. The full removal matrix, known-positive/known-negative controls, and the complete per-site
adjudication table for both sub-kinds are in the README.

Not filed as part of this PR, per #726's own scoping ("fixes come in follow-up PRs, one per
cluster of sites"): a new issue for `OCCTBRepGPropVinertGK`'s `errorReached`/`absoluteError`, and
one issue per cluster among the 11 sub-kind-2 NEEDS-FOLLOWUP rows (the live #703 anchor itself, the
`detectPocketsAAG()`/AAG-node-count family with no geometric backstop, two loft fixtures with a
z-height mistake, and three structurally weak assertions with no shared cause). The gate-script
question #726 raises ("a struct field assigned only a literal across every path") is explicitly
scoped as a follow-up spike, not something this pass commits to.

## Checklist

- [x] New behavior (the census script) is covered by its own `--self-test`, with every mechanism
      proven load-bearing per `okf/policies/prove-the-test-fails.md` (see the guard-removal
      matrix in the README), not just added.
- [x] Confined to `Scripts/`; no `Sources/`/`Tests/`/`Package.swift` changes, since five other PRs
      are in flight against this same base touching source files.
- [x] All five existing gate scripts and their `--self-test`s re-run clean after this change.

## Notes for the reviewer

This is deliberately NOT wired into `ci.yml`'s `gate-scripts` job. It's a census, not a gate: its
exit code in report mode is always 0, and many of its candidates are legitimate code the detector
simply cannot yet distinguish from a real instance (documented explicitly in the script's own
"WHAT THIS STILL CANNOT SEE" section and the README's methodology notes). Wiring it into CI would
require either the gate-script spike #726 defers, or fixing every flagged site first, neither of
which is this pass's job.

Part of #726. Not closing it: this is the first of several follow-up passes/PRs for the clusters
this census surfaces.