### PR TITLE
fix(#724): a pocket floor must rest on its wall, not just touch it

### DIFF
--- a/Scripts/repro/703-edge-convexity-order/README.md
+++ b/Scripts/repro/703-edge-convexity-order/README.md
@@ -1,12 +1,17 @@
-# #703 — `OCCTEdgeGetConvexity` face1/face2 order dependence
+# #703: `OCCTEdgeGetConvexity` face1/face2 order dependence
 
-Ground truth for the [automated review of PR #720](https://github.com/SecondMouseAU/OCCTSwift/pull/720)
-(the #703 fix). The order-dependence bug itself and the ChFi3d ground-truth scorecard against it
-are in the PR's own verification comment; this directory covers the two findings from that review
-that needed independent measurement rather than code inspection: finding 2/9 (sliver-face/zero-
-centroid instability) and finding 7 (performance).
+Ground-truth measurements for two questions raised while fixing #703, both of which needed a probe
+rather than code inspection: whether a sliver face destabilises a centroid-based convexity formula,
+and what that formula cost. The order-dependence bug itself, and the `ChFi3d` scorecard against it,
+are in PR #720's verification comment.
 
-## Finding 2/9 — sliver-face centroid stability
+Both questions came from PR #720's automated review, but they are recorded here by what they
+measure rather than by that review's finding numbers. Those numbers are not a stable citation: PR
+#717 drew two review passes whose numbering disagreed, and the second retracted five of the first's
+seven findings, so an ordinal can silently come to mean a different finding. The measurements below
+outlive whichever review prompted them.
+
+## Sliver-face centroid stability
 
 `repro_sliver.mm` fuses two 20mm boxes overlapping by a deliberately tiny sliver, the textbook way
 to make `BRepAlgoAPI` emit a genuine sliver face, and inspects every resulting face under area 1.0
@@ -33,9 +38,9 @@ reproduced with a normal boolean operation.
 
 `OCCTFaceGetAreaCentroid` (`OCCTBridge_Properties.mm`) still declines any face under area `1e-9`,
 several orders of magnitude below the smallest sliver measured here, added defensively and for
-free while restructuring for finding 7's fix below, not because this probe found a live bug.
+free while restructuring for the performance fix below, not because this probe found a live bug.
 
-## Finding 7 — redundant `SurfaceProperties` integration
+## The cost of the centroid formula
 
 Before this fix, `OCCTEdgeGetConvexity` called `BRepGProp::SurfaceProperties` on `face1` and
 `face2` directly, once per call. `AAG.buildGraph()` calls it once per **adjacent face pair**, so a

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -160,7 +160,7 @@ void OCCTFaceGetBounds(OCCTFaceRef face, double* minX, double* minY, double* min
 /// Get the bounding box of a face from its exact geometry, ignoring any triangulation the face
 /// may carry (#733). `OCCTFaceGetBounds` calls `BRepBndLib::Add` with `useTriangulation=true`
 /// (the default), which OCCT's own docs say enlarges the box by the mesh's deflection whenever a
-/// triangulation is present — so its answer silently depends on whether the shape happened to be
+/// triangulation is present, so its answer silently depends on whether the shape happened to be
 /// meshed before this call, not just on the face's geometry. This variant always passes
 /// `useTriangulation=false`, so the result is deterministic across meshed and unmeshed shapes.
 /// @param face The face to get bounds from

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -157,6 +157,15 @@ OCCTWireRef OCCTFaceGetOuterWire(OCCTFaceRef face);
 /// @param face The face to get bounds from
 void OCCTFaceGetBounds(OCCTFaceRef face, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ);
 
+/// Get the bounding box of a face from its exact geometry, ignoring any triangulation the face
+/// may carry (#733). `OCCTFaceGetBounds` calls `BRepBndLib::Add` with `useTriangulation=true`
+/// (the default), which OCCT's own docs say enlarges the box by the mesh's deflection whenever a
+/// triangulation is present — so its answer silently depends on whether the shape happened to be
+/// meshed before this call, not just on the face's geometry. This variant always passes
+/// `useTriangulation=false`, so the result is deterministic across meshed and unmeshed shapes.
+/// @param face The face to get bounds from
+void OCCTFaceGetBoundsExact(OCCTFaceRef face, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ);
+
 /// Check if a face is planar (flat)
 /// @param face The face to check
 /// @return true if the face is planar

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -4145,6 +4145,18 @@ void OCCTFaceGetBounds(OCCTFaceRef face, double* minX, double* minY, double* min
     }
 }
 
+void OCCTFaceGetBoundsExact(OCCTFaceRef face, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ) {
+    if (!face || !minX || !minY || !minZ || !maxX || !maxY || !maxZ) return;
+
+    try {
+        Bnd_Box box;
+        BRepBndLib::Add(face->face, box, false);
+        box.Get(*minX, *minY, *minZ, *maxX, *maxY, *maxZ);
+    } catch (...) {
+        *minX = *minY = *minZ = *maxX = *maxY = *maxZ = 0;
+    }
+}
+
 bool OCCTFaceIsPlanar(OCCTFaceRef face) {
     if (!face) return false;
 

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -85,9 +85,20 @@ public final class Face: @unchecked Sendable {
     ///   than before it, with no other change. Code that needs a bound tied only to the face's own
     ///   geometry, independent of any prior meshing, should use ``exactBounds`` instead (#733).
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
+        boundsVia(OCCTFaceGetBounds)
+    }
+
+    /// The two bounds accessors differ only in which bridge function they call, so the six-out-
+    /// parameter dance lives here once. A third variant, or a validity check on the result, then
+    /// has one place to go rather than two that can drift apart.
+    private func boundsVia(
+        _ fn: (OCCTFaceRef?, UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?,
+               UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?,
+               UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?) -> Void
+    ) -> (min: SIMD3<Double>, max: SIMD3<Double>) {
         var minX: Double = 0, minY: Double = 0, minZ: Double = 0
         var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
-        OCCTFaceGetBounds(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
+        fn(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
         return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
     }
 
@@ -103,10 +114,7 @@ public final class Face: @unchecked Sendable {
     /// (0.001) still drifted 5x past it. `exactBounds` is unaffected by meshing at any deflection,
     /// which is what ``AAG`` uses internally for its own floor/wall matching.
     internal var exactBounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
-        var minX: Double = 0, minY: Double = 0, minZ: Double = 0
-        var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
-        OCCTFaceGetBoundsExact(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
-        return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
+        boundsVia(OCCTFaceGetBoundsExact)
     }
 
     /// Check if the face is planar (flat)

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -78,10 +78,34 @@ public final class Face: @unchecked Sendable {
     }
 
     /// Get the bounding box of the face
+    ///
+    /// - Note: This box is enlarged by the face's mesh deflection whenever the shape has already
+    ///   been meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior) — the same
+    ///   `Face` can report a looser box after a call to ``Shape/mesh(linearDeflection:angularDeflection:)``
+    ///   than before it, with no other change. Code that needs a bound tied only to the face's own
+    ///   geometry, independent of any prior meshing, should use ``exactBounds`` instead (#733).
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         var minX: Double = 0, minY: Double = 0, minZ: Double = 0
         var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
         OCCTFaceGetBounds(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
+        return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
+    }
+
+    /// The face's bounding box computed from its exact geometry only, ignoring any triangulation
+    /// the face may carry (#733).
+    ///
+    /// `bounds` calls into `BRepBndLib::Add` with `useTriangulation=true` (OCCT's own default),
+    /// which enlarges the result by the mesh's deflection whenever a triangulation is present —
+    /// so its answer depends on whether *anything* meshed this shape before this call, not only on
+    /// the face's geometry. Measured on the cylindrical wall of a bored pocket (#733's repro): at
+    /// the library's own default deflection (0.1) the low-Z bound drifted by 0.029 units after
+    /// meshing, ~300x AAG's own 1e-4 floor/wall tolerance, and even the finest deflection tried
+    /// (0.001) still drifted 5x past it. `exactBounds` is unaffected by meshing at any deflection,
+    /// which is what ``AAG`` uses internally for its own floor/wall matching.
+    internal var exactBounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
+        var minX: Double = 0, minY: Double = 0, minZ: Double = 0
+        var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
+        OCCTFaceGetBoundsExact(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
         return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
     }
 

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -80,7 +80,7 @@ public final class Face: @unchecked Sendable {
     /// Get the bounding box of the face
     ///
     /// - Note: This box is enlarged by the face's mesh deflection whenever the shape has already
-    ///   been meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior) — the same
+    ///   been meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior); the same
     ///   `Face` can report a looser box after a call to ``Shape/mesh(linearDeflection:angularDeflection:)``
     ///   than before it, with no other change. Code that needs a bound tied only to the face's own
     ///   geometry, independent of any prior meshing, should use ``exactBounds`` instead (#733).
@@ -95,7 +95,7 @@ public final class Face: @unchecked Sendable {
     /// the face may carry (#733).
     ///
     /// `bounds` calls into `BRepBndLib::Add` with `useTriangulation=true` (OCCT's own default),
-    /// which enlarges the result by the mesh's deflection whenever a triangulation is present —
+    /// which enlarges the result by the mesh's deflection whenever a triangulation is present,
     /// so its answer depends on whether *anything* meshed this shape before this call, not only on
     /// the face's geometry. Measured on the cylindrical wall of a bored pocket (#733's repro): at
     /// the library's own default deflection (0.1) the low-Z bound drifted by 0.029 units after

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -186,9 +186,9 @@ public final class AAG: @unchecked Sendable {
                 isDownward: face.isDownwardFacing(),
                 isVertical: face.isVertical(),
                 zLevel: face.zLevel,
-                // #733: exactBounds, not bounds -- AAG's own floor/wall matching (see
-                // detectPockets()'s floorRestsOnWallTolerance) compares this box against a 1e-4
-                // tolerance, and `bounds` silently grows by the mesh deflection once anything has
+                // #733: exactBounds, not bounds. AAG's own floor/wall matching (see
+                // detectPockets()'s defaultFloorRestsOnWallTolerance) compares this box against a
+                // 1e-4 tolerance, and `bounds` silently grows by the mesh deflection once anything has
                 // meshed this shape. AAGNode represents the shape's geometry, not its incidental
                 // tessellation state, so its bounds must not move depending on whether the caller
                 // happened to call mesh() first.
@@ -452,7 +452,7 @@ extension AAG {
     ///   candidate floor's Z to count as resting on it. Defaults to
     ///   ``defaultFloorRestsOnWallTolerance``. Scale this with the model: the default is tuned for
     ///   millimeter-scale parts, and a shape modeled in meters or in thousandths of an inch may
-    ///   need a different value (#733) -- `AAGNode.bounds` itself is unaffected by meshing either
+    ///   need a different value (#733). `AAGNode.bounds` itself is unaffected by meshing either
     ///   way (#733), so widening this is about the model's own units, not about tessellation noise.
     public func detectPockets(tolerance: Double = defaultFloorRestsOnWallTolerance) -> [PocketFeature] {
         var pockets: [PocketFeature] = []
@@ -597,7 +597,7 @@ extension Shape {
     /// print(result.detectPocketsAAG().count)   // 1
     /// ```
     ///
-    /// - Parameter tolerance: Forwarded to ``AAG/detectPockets(tolerance:)`` -- see its doc for
+    /// - Parameter tolerance: Forwarded to ``AAG/detectPockets(tolerance:)``. See its doc for
     ///   what it controls and why it defaults the way it does (#733).
     public func detectPocketsAAG(tolerance: Double = AAG.defaultFloorRestsOnWallTolerance) -> [PocketFeature] {
         let aag = buildAAG()

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -68,7 +68,9 @@ public struct AAGNode: Sendable {
     /// Z level if horizontal planar face
     public let zLevel: Double?
 
-    /// Bounding box of the face
+    /// Bounding box of the face's exact geometry (#733). Unlike ``Face/bounds``, this is never
+    /// enlarged by mesh triangulation, so it does not change depending on whether the shape has
+    /// been meshed before ``AAG`` was built from it.
     public let bounds: (min: SIMD3<Double>, max: SIMD3<Double>)
 }
 
@@ -184,7 +186,13 @@ public final class AAG: @unchecked Sendable {
                 isDownward: face.isDownwardFacing(),
                 isVertical: face.isVertical(),
                 zLevel: face.zLevel,
-                bounds: face.bounds
+                // #733: exactBounds, not bounds -- AAG's own floor/wall matching (see
+                // detectPockets()'s floorRestsOnWallTolerance) compares this box against a 1e-4
+                // tolerance, and `bounds` silently grows by the mesh deflection once anything has
+                // meshed this shape. AAGNode represents the shape's geometry, not its incidental
+                // tessellation state, so its bounds must not move depending on whether the caller
+                // happened to call mesh() first.
+                bounds: face.exactBounds
             )
             nodes.append(node)
         }

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -393,11 +393,17 @@ public struct PocketFeature: Sendable {
 // MARK: - Feature Recognition Extensions
 
 extension AAG {
-    /// Tolerance (model units) used to decide whether a candidate floor sits at the bottom of one
-    /// of its candidate walls (#724). Far tighter than any real pocket depth in the test suite
-    /// (millimeters or more), far looser than the ~1e-7 bounding-box noise `OCCTFaceGetBounds`
-    /// reports on an exact primitive.
-    private static let floorRestsOnWallTolerance = 1e-4
+    /// Default tolerance (model units) used to decide whether a candidate floor sits at the
+    /// bottom of one of its candidate walls (#724). Far tighter than any real pocket depth in the
+    /// test suite (millimeters or more), far looser than the ~1e-7 bounding-box noise
+    /// `Face.exactBounds` reports on an exact primitive.
+    ///
+    /// This is a default, not a fixed constant: ``detectPockets(tolerance:)`` and
+    /// ``Shape/detectPocketsAAG(tolerance:)`` both take a caller-supplied `tolerance:` parameter
+    /// with this value as its default (#733), matching every other tolerance in this module
+    /// (`Curve3D`, `Surface`, `Shape`'s own geometry methods, ...) rather than hardcoding one
+    /// millimeter-scale constant for every caller regardless of the model's own units.
+    public static let defaultFloorRestsOnWallTolerance = 1e-4
 
     /// Detect pockets in the shape using AAG analysis
     ///
@@ -441,7 +447,14 @@ extension AAG {
     /// One known limitation: a filleted floor/wall junction would round the wall's bounding box
     /// past the floor's own Z by roughly the fillet radius, which could exceed this tolerance. No
     /// fixture in this codebase exercises that combination yet.
-    public func detectPockets() -> [PocketFeature] {
+    ///
+    /// - Parameter tolerance: How close (model units) a wall's own low-Z bound must come to a
+    ///   candidate floor's Z to count as resting on it. Defaults to
+    ///   ``defaultFloorRestsOnWallTolerance``. Scale this with the model: the default is tuned for
+    ///   millimeter-scale parts, and a shape modeled in meters or in thousandths of an inch may
+    ///   need a different value (#733) -- `AAGNode.bounds` itself is unaffected by meshing either
+    ///   way (#733), so widening this is about the model's own units, not about tessellation noise.
+    public func detectPockets(tolerance: Double = defaultFloorRestsOnWallTolerance) -> [PocketFeature] {
         var pockets: [PocketFeature] = []
 
         // Find all upward-facing horizontal faces as potential floors
@@ -461,7 +474,7 @@ extension AAG {
             let wallIndices = concaveNeighbors.filter { neighborIndex in
                 let wall = nodes[neighborIndex]
                 guard wall.isVertical else { return false }
-                return abs(wall.bounds.min.z - floorZ) < Self.floorRestsOnWallTolerance
+                return abs(wall.bounds.min.z - floorZ) < tolerance
             }
 
             // Need at least one wall to be a pocket
@@ -583,8 +596,11 @@ extension Shape {
     /// let result = box.subtracting(pocket)!
     /// print(result.detectPocketsAAG().count)   // 1
     /// ```
-    public func detectPocketsAAG() -> [PocketFeature] {
+    ///
+    /// - Parameter tolerance: Forwarded to ``AAG/detectPockets(tolerance:)`` -- see its doc for
+    ///   what it controls and why it defaults the way it does (#733).
+    public func detectPocketsAAG(tolerance: Double = AAG.defaultFloorRestsOnWallTolerance) -> [PocketFeature] {
         let aag = buildAAG()
-        return aag.detectPockets()
+        return aag.detectPockets(tolerance: tolerance)
     }
 }

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -407,12 +407,54 @@ public struct PocketFeature: Sendable {
 // MARK: - Feature Recognition Extensions
 
 extension AAG {
+    /// Tolerance (model units) used to decide whether a candidate floor sits at the bottom of one
+    /// of its candidate walls (#724). Far tighter than any real pocket depth in the test suite
+    /// (millimeters or more), far looser than the ~1e-7 bounding-box noise `OCCTFaceGetBounds`
+    /// reports on an exact primitive.
+    private static let floorRestsOnWallTolerance = 1e-4
+
     /// Detect pockets in the shape using AAG analysis
     ///
     /// A pocket is identified by:
     /// 1. An upward-facing horizontal floor face
-    /// 2. Surrounded by vertical wall faces
+    /// 2. Surrounded by vertical wall faces, each resting on that floor (#724)
     /// 3. Connected to walls via concave edges
+    ///
+    /// ## A wall only floors where it bottoms out (#724)
+    ///
+    /// A blind pocket's floor is not the only upward-facing horizontal planar face touching a
+    /// concave edge to one of its walls: the exterior surface the pocket opens THROUGH, at the
+    /// wall's other end, is upward-facing and horizontal too, and is a false "floor" whenever that
+    /// rim edge classifies concave, which a curved wall's rim can do even for a correctly-open
+    /// pocket, pending #723's replacement of the underlying convexity formula. Requiring the
+    /// candidate wall's own bounding-box minimum Z to match the floor's Z (rather than trusting
+    /// every concave-and-vertical neighbor) tells the two apart without depending on that edge's
+    /// classification at all: a pocket floor is upward-facing, so it is always the LOW end of the
+    /// walls that rise from it, and a wall's high end is where it opens, whether to the exterior,
+    /// to a shallower pocket's floor above it, or to open air; never to a floor of its own.
+    ///
+    /// A single blind cylindrical pocket bored partway into a box is the fixture that first
+    /// surfaced this: the wall's own top rim (mis)classified concave made the box's outer top
+    /// face, sitting at the wall's high end rather than its low end, register as a second pocket
+    /// floor for the very same wall.
+    ///
+    /// ```swift
+    /// let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
+    /// let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
+    /// let cut  = box.subtracting(tool)!
+    /// print(cut.detectPocketsAAG().count)   // 1, not 2
+    /// ```
+    ///
+    /// This does not depend on which of the wall's two rims classifies concave: a wall whose
+    /// bounding box does not bottom out at a given candidate floor's Z is excluded from that
+    /// floor's walls regardless of why it was a concave neighbor in the first place. It also
+    /// requires nothing about every edge classification in the graph being correct, only that a
+    /// genuine floor is geometrically the low end of its own walls, which is true independent of
+    /// #723.
+    ///
+    /// One known limitation: a filleted floor/wall junction would round the wall's bounding box
+    /// past the floor's own Z by roughly the fillet radius, which could exceed this tolerance. No
+    /// fixture in this codebase exercises that combination yet.
     public func detectPockets() -> [PocketFeature] {
         var pockets: [PocketFeature] = []
 
@@ -427,9 +469,13 @@ extension AAG {
             // Get concave neighbors (these should be walls)
             let concaveNeighbors = self.concaveNeighbors(of: floorIndex)
 
-            // Filter to vertical faces only
+            // Filter to vertical faces that actually rest on this floor (#724): a wall's low Z
+            // bound must match the floor's own Z, or this floor is really that wall's opening,
+            // not its bottom.
             let wallIndices = concaveNeighbors.filter { neighborIndex in
-                nodes[neighborIndex].isVertical
+                let wall = nodes[neighborIndex]
+                guard wall.isVertical else { return false }
+                return abs(wall.bounds.min.z - floorZ) < Self.floorRestsOnWallTolerance
             }
 
             // Need at least one wall to be a pocket

--- a/Tests/OCCTModelingTests/Issue724PocketGroupingFloorTests.swift
+++ b/Tests/OCCTModelingTests/Issue724PocketGroupingFloorTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #724: `detectPocketsAAG()` reported 2 pockets for a single blind cylindrical pocket. Ground
+// truth from OCCT's own classifier, `ChFi3d::DefineConnectType`: 13 convex, 1 concave (floor to
+// wall), 1 tangential (the cylinder's own seam). One concave edge joining a wall to a floor is one
+// pocket.
+//
+// The defect is in GROUPING, not classification (#723 is the separate, in-flight fix for
+// `OCCTEdgeGetConvexity` itself, replacing its formula with `ChFi3d::DefineConnectType`). Measured
+// directly: `detectPockets()`'s current formula still (mis)classifies a curved wall's rim, where
+// the wall meets the exterior surface it opens through, as concave, even on this branch, after
+// #703's face1/face2 order fix. #703 fixed a planar/planar order-dependence; it did not make
+// `OCCTEdgeGetConvexity` correct for a planar/cylindrical pair, which is exactly what a bored
+// pocket's rim is. That residual misclassification feeds `detectPockets()`'s
+// `isUpward && isHorizontal && isPlanar` floor test: the box's own exterior top face satisfies it
+// too, and once its rim edge to the cylindrical wall is (wrongly) concave, it looks exactly like a
+// second, shallower floor for the same wall.
+//
+// The fix does not touch classification at all. It adds one more requirement to a candidate wall,
+// independent of why that wall's edge classified concave: the floor must sit at the wall's own
+// lowest Z. A pocket floor is upward-facing, so it is always the LOW end of the walls that rise
+// from it; a wall's high end is where it opens, whether to the exterior, to a shallower pocket's
+// floor, or to open air, never to a floor of its own. See `AAG.detectPockets()`'s doc comment in
+// `FeatureRecognition.swift` for the full reasoning, including the one acknowledged limitation
+// (a filleted floor/wall junction).
+@Suite("detectPocketsAAG() does not double-count a pocket's floor (#724)")
+struct Issue724PocketGroupingFloorTests {
+
+    // MARK: - The headline
+
+    /// The issue's own construction, byte for byte. A cylinder bored from the box's top face
+    /// partway down (tool height 20 against a box that is only 10 above the tool's own base at
+    /// z=0) leaves one real floor, at z=0, walled by the cylinder's lateral surface. The box's own
+    /// top face, at z=10, is the pocket's OPENING, not a second floor.
+    @Test("a single blind cylindrical pocket reports exactly one pocket")
+    func blindCylindricalPocketReportsOne() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(0, 0, 0), direction: SIMD3(0, 0, 1), radius: 4, height: 20))
+        let cut = try #require(box.subtracting(tool))
+
+        let pockets = cut.detectPocketsAAG()
+        #expect(pockets.count == 1)
+
+        guard let pocket = pockets.first else { return }
+        // The real floor is at z=0 (the bottom of the bore), not z=10 (the box's own top, where
+        // the bore opens to the exterior). Asserting the level, not just the count, rules out the
+        // fix accidentally keeping the WRONG one of the two candidates.
+        #expect(abs(pocket.zLevel - 0.0) < 1e-6)
+        // One wall: the cylinder's lateral face. The false floor at z=10 shared that exact same
+        // wall face, which is what made this bug a duplicate-count rather than a wrong-index bug.
+        #expect(pocket.wallFaceIndices.count == 1)
+    }
+
+    // MARK: - The mechanism generalizes across depth
+
+    /// Same shape, three tool heights that all leave the same z=0 floor but change how far the
+    /// tool's own top extends past the box's top face. If the fix were keyed to the specific
+    /// numbers in the issue rather than the general "floor is the wall's low Z" rule, at least one
+    /// of these would still double-count.
+    @Test("holds across tool heights that all clear the box's top face",
+          arguments: [15.0, 20.0, 40.0])
+    func holdsAcrossToolHeight(height: Double) throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(0, 0, 0), direction: SIMD3(0, 0, 1), radius: 4, height: height))
+        let cut = try #require(box.subtracting(tool))
+
+        #expect(cut.detectPocketsAAG().count == 1, "height=\(height)")
+    }
+
+    // MARK: - Non-regression: a genuine multi-wall pocket keeps every wall
+
+    /// The doc-comment fixture (`Shape.detectPocketsAAG()`'s own example): a square pocket whose
+    /// four walls all bottom out at the same floor. #724's fix filters a wall OUT of a floor's
+    /// `wallFaceIndices` when the wall's own low Z does not match that floor; it must not filter
+    /// a wall out just for being one of several that DO match. All four walls of a real, single-
+    /// level pocket share the same floor Z, so all four must survive.
+    @Test("a genuine four-walled pocket keeps all four walls")
+    func genuineFourWalledPocketKeepsAllWalls() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let result = try #require(box.subtracting(pocketTool))
+
+        let pockets = result.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        #expect(pockets.first?.wallFaceIndices.count == 4)
+    }
+
+    /// The suite's own pinned square-pocket fixture (`Issue703EdgeConvexityOrderTests`), at
+    /// several depths, stays at exactly one pocket. This fixture already has 8 concave edges
+    /// (4 floor/wall + 4 wall/wall corners) with none of the rim-misclassification #724's own
+    /// headline exercises, confirming the fix changes nothing for a pocket that was already
+    /// correctly grouped.
+    @Test("the pinned square-pocket fixture is unaffected, at several depths",
+          arguments: [2.0, 10.0, 25.0])
+    func pinnedSquarePocketFixtureUnaffected(depth: Double) throws {
+        let box = try #require(Shape.box(width: 30, height: 30, depth: 30))
+        let pocket = try #require(Shape.box(
+            origin: SIMD3(-5, -5, 15 - depth), width: 10, height: 10, depth: depth + 1))
+        let pocketed = try #require(box.subtracting(pocket))
+
+        #expect(pocketed.detectPocketsAAG().count == 1, "depth=\(depth)")
+    }
+
+    /// A plain box has no concave edges at all (#703), so there is no floor candidate in the first
+    /// place; #724's extra wall-bottom check must not manufacture one.
+    @Test("a plain box still reports zero pockets")
+    func plainBoxStillReportsZero() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        #expect(box.detectPocketsAAG().count == 0)
+    }
+}

--- a/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
+++ b/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
@@ -6,7 +6,7 @@ import Foundation
 // floor's Z within a 1e-4 tolerance (`AAG.defaultFloorRestsOnWallTolerance`). That comparison used
 // `Face.bounds`, which calls `BRepBndLib::Add` with `useTriangulation=true` (OCCT's own default).
 // OCCT's own header documents the consequence: once a face carries a triangulation, the returned
-// box is enlarged by "the sum of the triangulation deflection and the face tolerance" -- so the
+// box is enlarged by "the sum of the triangulation deflection and the face tolerance", so the
 // SAME face reports a looser box after `Shape.mesh(...)` runs than before it, with nothing else
 // changing.
 //
@@ -14,14 +14,13 @@ import Foundation
 // (`useTriangulation=true` takes the triangulation's `MinMax()` then enlarges by
 // `T->Deflection() + BRep_Tool::Tolerance(F)`; `useTriangulation=false` always takes the exact
 // analytic branch instead): a planar wall triangulates exactly (zero curvature, zero chordal
-// deviation), so a
-// square pocket's four planar walls never drifted, at any deflection -- this defect is invisible
-// on #724's own square-pocket fixtures. A CURVED wall (the cylindrical bore that is #724's own
-// headline fixture) does deviate: at the library's own default deflection (0.1), the wall's
-// low-Z bound drifted 0.029 units off the true floor Z, ~290x the 1e-4 tolerance; even the finest
-// deflection tried (0.001) still drifted 5x past it. Every drift measured, at every deflection
-// from 0.001 to 5.0, exceeded the tolerance -- so meshing this shape at all, before calling
-// `detectPocketsAAG()`, drops the pocket entirely (`pockets.count` 1 -> 0).
+// deviation), so a square pocket's four planar walls never drifted, at any deflection. This defect
+// is invisible on #724's own square-pocket fixtures. A CURVED wall (the cylindrical bore that is
+// #724's own headline fixture) does deviate: at the library's own default deflection (0.1), the
+// wall's low-Z bound drifted 0.029 units off the true floor Z, ~290x the 1e-4 tolerance; even the
+// finest deflection tried (0.001) still drifted 5x past it. Every drift measured, at every
+// deflection from 0.001 to 5.0, exceeded the tolerance, so meshing this shape at all, before
+// calling `detectPocketsAAG()`, drops the pocket entirely (`pockets.count` 1 -> 0).
 //
 // Fixed by giving `AAGNode.bounds` its own bridge call, `OCCTFaceGetBoundsExact`
 // (`BRepBndLib::Add(face, box, useTriangulation: false)`), so it reflects only the face's exact
@@ -88,22 +87,23 @@ struct Issue733MeshTriangulationBoundsTests {
                 #expect(drift < 1e-4, "deflection=\(deflection) drift=\(drift)")
             }
         }
-        #expect(checkedAWall, "fixture produced no candidate wall to check -- test is vacuous")
+        #expect(checkedAWall, "fixture produced no candidate wall to check, test is vacuous")
     }
 }
 
 // #733, second finding: `floorRestsOnWallTolerance` was a `private static let`, the only
 // hardcoded, non-configurable tolerance anywhere in this module (every other tolerance in
-// `Curve3D`, `Surface`, `Shape`, etc. -- 296 occurrences -- is a caller-supplied parameter with a
-// default). A shape modeled in meters or thousandths of an inch has no way to widen or narrow the
-// 1e-4 default to match its own scale. Fixed by promoting it to a `tolerance:` parameter on both
-// `AAG.detectPockets(tolerance:)` and `Shape.detectPocketsAAG(tolerance:)`, defaulting to the same
-// 1e-4 (now `AAG.defaultFloorRestsOnWallTolerance`, a public constant), so existing call sites are
-// unaffected and only a caller who explicitly wants a different value needs to know it exists.
+// `Curve3D`, `Surface`, `Shape`, etc., 296 occurrences total, is a caller-supplied parameter with
+// a default). A shape modeled in meters or thousandths of an inch has no way to widen or narrow
+// the 1e-4 default to match its own scale. Fixed by promoting it to a `tolerance:` parameter on
+// both `AAG.detectPockets(tolerance:)` and `Shape.detectPocketsAAG(tolerance:)`, defaulting to the
+// same 1e-4 (now `AAG.defaultFloorRestsOnWallTolerance`, a public constant), so existing call
+// sites are unaffected and only a caller who explicitly wants a different value needs to know it
+// exists.
 @Suite("detectPocketsAAG(tolerance:) is caller-configurable (#733)")
 struct Issue733ConfigurableToleranceTests {
     /// An absurdly tight tolerance (tighter than the ~1e-7 floating-point noise `exactBounds`
-    /// itself carries on an exact primitive) must reject even a real, exactly-modeled pocket --
+    /// itself carries on an exact primitive) must reject even a real, exactly-modeled pocket,
     /// proving the parameter actually reaches the comparison, not just that it type-checks.
     @Test("an absurdly tight tolerance rejects a real pocket")
     func absurdlyTightToleranceRejectsRealPocket() throws {
@@ -116,7 +116,7 @@ struct Issue733ConfigurableToleranceTests {
     }
 
     /// The same absurdly tight tolerance reaches `AAG.detectPockets(tolerance:)` directly, not
-    /// only through the `Shape` convenience wrapper -- both entry points take the parameter.
+    /// only through the `Shape` convenience wrapper: both entry points take the parameter.
     @Test("AAG.detectPockets(tolerance:) itself honors a tight tolerance")
     func aagDetectPocketsHonorsTolerance() throws {
         let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
@@ -129,7 +129,7 @@ struct Issue733ConfigurableToleranceTests {
     }
 
     /// A caller who explicitly widens the tolerance (e.g. for a coarser model scale) must still
-    /// find the pocket -- the parameter is not a one-way ratchet toward stricter answers only.
+    /// find the pocket: the parameter is not a one-way ratchet toward stricter answers only.
     @Test("a generous tolerance still finds the pocket")
     func generousToleranceStillFindsPocket() throws {
         let box = try #require(Shape.box(width: 20, height: 20, depth: 20))

--- a/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
+++ b/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #733 (review of #724): #724's fix compares a candidate wall's `bounds.min.z` against its
+// floor's Z within a 1e-4 tolerance (`AAG.defaultFloorRestsOnWallTolerance`). That comparison used
+// `Face.bounds`, which calls `BRepBndLib::Add` with `useTriangulation=true` (OCCT's own default).
+// OCCT's own header documents the consequence: once a face carries a triangulation, the returned
+// box is enlarged by "the sum of the triangulation deflection and the face tolerance" -- so the
+// SAME face reports a looser box after `Shape.mesh(...)` runs than before it, with nothing else
+// changing.
+//
+// Measured directly against this branch, `BRepBndLib.cxx` read alongside to confirm the mechanism
+// (`useTriangulation=true` takes the triangulation's `MinMax()` then enlarges by
+// `T->Deflection() + BRep_Tool::Tolerance(F)`; `useTriangulation=false` always takes the exact
+// analytic branch instead): a planar wall triangulates exactly (zero curvature, zero chordal
+// deviation), so a
+// square pocket's four planar walls never drifted, at any deflection -- this defect is invisible
+// on #724's own square-pocket fixtures. A CURVED wall (the cylindrical bore that is #724's own
+// headline fixture) does deviate: at the library's own default deflection (0.1), the wall's
+// low-Z bound drifted 0.029 units off the true floor Z, ~290x the 1e-4 tolerance; even the finest
+// deflection tried (0.001) still drifted 5x past it. Every drift measured, at every deflection
+// from 0.001 to 5.0, exceeded the tolerance -- so meshing this shape at all, before calling
+// `detectPocketsAAG()`, drops the pocket entirely (`pockets.count` 1 -> 0).
+//
+// Fixed by giving `AAGNode.bounds` its own bridge call, `OCCTFaceGetBoundsExact`
+// (`BRepBndLib::Add(face, box, useTriangulation: false)`), so it reflects only the face's exact
+// geometry and never depends on whether anything meshed the shape first. `Face.bounds` (the public
+// API existing callers already use) is left unchanged; only `AAG`'s own internal bounds capture
+// moved, since AAG's floor/wall matching is about the shape's geometry, never its tessellation.
+@Suite("AAG bounds are unaffected by prior meshing (#733)")
+struct Issue733MeshTriangulationBoundsTests {
+
+    /// The reproducer: mesh the shape between building it and calling `detectPocketsAAG()`, the
+    /// combined workflow this repo's own MCP tools invite (mesh for preview, then recognize
+    /// features on the same value). Before the fix this dropped the pocket outright at every
+    /// deflection tried; after the fix it must not drop at any of them.
+    @Test("meshing a shape before detecting pockets does not drop a real pocket",
+          arguments: [0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 5.0])
+    func meshingDoesNotDropTheCylindricalPocket(deflection: Double) throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(0, 0, 0), direction: SIMD3(0, 0, 1), radius: 4, height: 20))
+        let cut = try #require(box.subtracting(tool))
+
+        _ = cut.mesh(linearDeflection: deflection, angularDeflection: 0.5)
+
+        let pockets = cut.detectPocketsAAG()
+        #expect(pockets.count == 1, "deflection=\(deflection)")
+        guard let pocket = pockets.first else { return }
+        #expect(abs(pocket.zLevel - 0.0) < 1e-6, "deflection=\(deflection)")
+        #expect(pocket.wallFaceIndices.count == 1, "deflection=\(deflection)")
+    }
+
+    /// Non-regression companion: the same fixture, unmeshed, must still report the pocket. A fix
+    /// that special-cased "meshed" input rather than making the bounds computation itself
+    /// tessellation-independent could pass the test above while being wrong for the ordinary path.
+    @Test("the same fixture, never meshed, still reports the pocket")
+    func unmeshedFixtureStillReportsThePocket() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(0, 0, 0), direction: SIMD3(0, 0, 1), radius: 4, height: 20))
+        let cut = try #require(box.subtracting(tool))
+
+        #expect(cut.detectPocketsAAG().count == 1)
+    }
+
+    /// Direct measurement of the mechanism, not just its downstream effect: a wall's own
+    /// `AAGNode.bounds.min.z` must stay within the tolerance the grouping check applies, regardless
+    /// of meshing. Asserts the quantity #724's comparison actually reads, rather than only the
+    /// count that comparison feeds.
+    @Test("a cylindrical wall's AAGNode bounds do not drift after meshing",
+          arguments: [0.001, 0.1, 1.0, 5.0])
+    func wallBoundsDoNotDriftAfterMeshing(deflection: Double) throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(0, 0, 0), direction: SIMD3(0, 0, 1), radius: 4, height: 20))
+        let cut = try #require(box.subtracting(tool))
+
+        _ = cut.mesh(linearDeflection: deflection, angularDeflection: 0.5)
+
+        let aag = cut.buildAAG()
+        var checkedAWall = false
+        for (index, node) in aag.nodes.enumerated() where node.isUpward && node.isHorizontal && node.isPlanar {
+            guard let floorZ = node.zLevel else { continue }
+            for wallIndex in aag.concaveNeighbors(of: index) {
+                let wall = aag.nodes[wallIndex]
+                guard wall.isVertical else { continue }
+                checkedAWall = true
+                let drift = abs(wall.bounds.min.z - floorZ)
+                #expect(drift < 1e-4, "deflection=\(deflection) drift=\(drift)")
+            }
+        }
+        #expect(checkedAWall, "fixture produced no candidate wall to check -- test is vacuous")
+    }
+}

--- a/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
+++ b/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
@@ -91,3 +91,51 @@ struct Issue733MeshTriangulationBoundsTests {
         #expect(checkedAWall, "fixture produced no candidate wall to check -- test is vacuous")
     }
 }
+
+// #733, second finding: `floorRestsOnWallTolerance` was a `private static let`, the only
+// hardcoded, non-configurable tolerance anywhere in this module (every other tolerance in
+// `Curve3D`, `Surface`, `Shape`, etc. -- 296 occurrences -- is a caller-supplied parameter with a
+// default). A shape modeled in meters or thousandths of an inch has no way to widen or narrow the
+// 1e-4 default to match its own scale. Fixed by promoting it to a `tolerance:` parameter on both
+// `AAG.detectPockets(tolerance:)` and `Shape.detectPocketsAAG(tolerance:)`, defaulting to the same
+// 1e-4 (now `AAG.defaultFloorRestsOnWallTolerance`, a public constant), so existing call sites are
+// unaffected and only a caller who explicitly wants a different value needs to know it exists.
+@Suite("detectPocketsAAG(tolerance:) is caller-configurable (#733)")
+struct Issue733ConfigurableToleranceTests {
+    /// An absurdly tight tolerance (tighter than the ~1e-7 floating-point noise `exactBounds`
+    /// itself carries on an exact primitive) must reject even a real, exactly-modeled pocket --
+    /// proving the parameter actually reaches the comparison, not just that it type-checks.
+    @Test("an absurdly tight tolerance rejects a real pocket")
+    func absurdlyTightToleranceRejectsRealPocket() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let result = try #require(box.subtracting(pocketTool))
+
+        #expect(result.detectPocketsAAG().count == 1)
+        #expect(result.detectPocketsAAG(tolerance: 1e-12).count == 0)
+    }
+
+    /// The same absurdly tight tolerance reaches `AAG.detectPockets(tolerance:)` directly, not
+    /// only through the `Shape` convenience wrapper -- both entry points take the parameter.
+    @Test("AAG.detectPockets(tolerance:) itself honors a tight tolerance")
+    func aagDetectPocketsHonorsTolerance() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let result = try #require(box.subtracting(pocketTool))
+        let aag = result.buildAAG()
+
+        #expect(aag.detectPockets().count == 1)
+        #expect(aag.detectPockets(tolerance: 1e-12).count == 0)
+    }
+
+    /// A caller who explicitly widens the tolerance (e.g. for a coarser model scale) must still
+    /// find the pocket -- the parameter is not a one-way ratchet toward stricter answers only.
+    @Test("a generous tolerance still finds the pocket")
+    func generousToleranceStillFindsPocket() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let result = try #require(box.subtracting(pocketTool))
+
+        #expect(result.detectPocketsAAG(tolerance: 1.0).count == 1)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,52 @@ All notable changes to OCCTSwift.
 
 ## Unreleased
 
+### `detectPocketsAAG()` no longer double-counts a single pocket's floor (#724)
+
+A single blind cylindrical pocket reported two pockets instead of one:
+
+```swift
+let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
+let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
+let cut  = box.subtracting(tool)!
+print(cut.detectPocketsAAG().count)   // was 2, now 1
+```
+
+Ground truth for this solid, from OCCT's own classifier `ChFi3d::DefineConnectType`: 13 convex
+edges, 1 concave (the bore's floor meeting its cylindrical wall), 1 tangential (the cylinder's own
+seam). One concave edge joining a wall to a floor is one pocket.
+
+This was a grouping defect, not a classification one, and is independent of #703 above and of
+#723 (in flight separately, replacing `OCCTEdgeGetConvexity`'s formula with
+`ChFi3d::DefineConnectType`): `AAG.detectPockets()` selects a floor candidate on
+`isUpward && isHorizontal && isPlanar` plus at least one concave, vertical neighbor, with no check
+that the neighbor is actually resting on that floor rather than merely touching it somewhere along
+its height. A curved wall's rim, where it meets the exterior surface it opens through, can
+classify concave under the current formula even after #703's face1/face2 fix, since that fix
+addressed a planar/planar order-dependence and left a planar/cylindrical pair's classification
+unchanged. The box's own top face satisfies the floor predicate exactly as well as the real floor
+does, and once its rim edge to the bore's wall is (wrongly) concave, it is indistinguishable from a
+second, shallower floor sharing the same wall.
+
+**Fixed**: a wall only counts toward a given floor candidate if the wall's own bounding-box minimum
+Z matches that floor's Z, within a tolerance far tighter than any real pocket depth and far looser
+than bounding-box noise on an exact primitive. A pocket floor is upward-facing, so it is always the
+low end of the walls that rise from it; a wall's high end is where it opens, whether to the
+exterior, to a shallower pocket's floor, or to open air, never to a floor of its own. This holds
+regardless of whether the wall's rim classified concave for a legitimate reason or a wrong one, so
+the fix does not depend on #723 landing and will not need revisiting when it does.
+
+**Migration note**: `detectPocketsAAG()`/`AAG.detectPockets()` can now report fewer pockets, and a
+`PocketFeature.wallFaceIndices` can now be shorter, for any shape where a wall's rim classified
+concave without the wall actually bottoming out at that candidate floor. A genuine multi-wall
+pocket, where every wall shares the same floor Z, is unaffected: measured on the existing
+square-pocket fixtures (`Issue703EdgeConvexityOrderTests`, `Shape.detectPocketsAAG()`'s own doc
+example), the pocket count and each wall count are unchanged. One known limitation, not exercised
+by any fixture in this codebase: a filleted floor/wall junction would round the wall's bounding box
+past the floor's own Z by roughly the fillet radius, which could exceed the tolerance.
+
+Tests: `Tests/OCCTModelingTests/Issue724PocketGroupingFloorTests.swift` (new).
+
 ### `OCCTEdgeGetConvexity` no longer depends on which face is passed first (#703)
 
 Found via Cluster A's census (#664, `Scripts/repro/cluster-a-subshape-enumeration/`) while

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,53 +15,41 @@ All notable changes to OCCTSwift.
 
 ## Unreleased
 
-### `detectPocketsAAG()` no longer double-counts a single pocket's floor (#724)
+### `kernel-integration.yml` no longer discards a successful 79-minute build on timeout (#727)
 
-A single blind cylindrical pocket reported two pockets instead of one:
+The workflow's trigger paths (`Scripts/patches/**`, `Scripts/build-occt.sh`) and its xcframework
+cache key (`hashFiles` of those same two globs) were the same condition, so every run the workflow
+exists to do was, by construction, a first-time cache miss: there was no run where the ~79-minute
+build could be skipped. With build and `swift test` as one job, `actions/cache`'s save runs as an
+automatic post step queued for the end of the job; a job cancelled by its own `timeout-minutes`
+partway through `swift test` never reaches that post step, so it reports **skipped**, not
+cancelled, discarding a build that had already finished successfully one step earlier. Measured on
+PR #718's job 92538270414: 79 min to build OCCT (success), 10 min into `swift test` before the
+90-minute job timeout fired (cancelled), cache save skipped. Retrying reruns the same build and
+times out at the same place, so there was no path to green by re-running.
 
-```swift
-let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
-let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
-let cut  = box.subtracting(tool)!
-print(cut.detectPocketsAAG().count)   // was 2, now 1
-```
+Split into two jobs: `build-kernel` builds and caches `Libraries/OCCT.xcframework`
+(`timeout-minutes: 120`, roughly 50% margin over the measured 79 min), and `swift-test` (`needs:
+build-kernel`, `timeout-minutes: 30`) restores that cache and runs `swift test` against it. The
+build job now has nothing left to run after the build, so its cache save is no longer hostage to
+the test job's runtime, and each job's timeout matches what it actually does instead of both
+sharing one 90-minute budget. The xcframework reaches the second job only through `actions/cache`,
+never `actions/upload-artifact`: the two jobs compute the same cache key independently (`hashFiles`
+of the same commit each checks out), rather than passing it as a job output.
 
-Ground truth for this solid, from OCCT's own classifier `ChFi3d::DefineConnectType`: 13 convex
-edges, 1 concave (the bore's floor meeting its cylindrical wall), 1 tangential (the cylinder's own
-seam). One concave edge joining a wall to a floor is one pocket.
+The build job's own cache handling also moved from the combined `actions/cache` action to explicit
+`actions/cache/restore` plus `actions/cache/save` (the latter `if: always()`), placed immediately
+after the build step instead of left as an automatic post step. Splitting the job already closes
+the main gap; this closes a narrower, related one the split does not: this workflow's own
+`concurrency.cancel-in-progress` cancels the *whole* in-progress run, both jobs, if a new commit
+lands on the same ref while the build is still going, and an `if: always()` step still gets a
+chance to run after that cancellation signal, unlike a not-yet-started automatic post step.
 
-This was a grouping defect, not a classification one, and is independent of #703 above and of
-#723 (in flight separately, replacing `OCCTEdgeGetConvexity`'s formula with
-`ChFi3d::DefineConnectType`): `AAG.detectPockets()` selects a floor candidate on
-`isUpward && isHorizontal && isPlanar` plus at least one concave, vertical neighbor, with no check
-that the neighbor is actually resting on that floor rather than merely touching it somewhere along
-its height. A curved wall's rim, where it meets the exterior surface it opens through, can
-classify concave under the current formula even after #703's face1/face2 fix, since that fix
-addressed a planar/planar order-dependence and left a planar/cylindrical pair's classification
-unchanged. The box's own top face satisfies the floor predicate exactly as well as the real floor
-does, and once its rim edge to the bore's wall is (wrongly) concave, it is indistinguishable from a
-second, shallower floor sharing the same wall.
+**Verified**: the two-job workflow parses and its `workflow_dispatch` trigger is reachable.
+**Not verified in this change**: a real cache-miss run start to finish, the ~80-minute cost this fix
+exists to stop wasting, had not completed by the time the PR was opened. See the PR description for
+exactly what ran and what remained outstanding.
 
-**Fixed**: a wall only counts toward a given floor candidate if the wall's own bounding-box minimum
-Z matches that floor's Z, within a tolerance far tighter than any real pocket depth and far looser
-than bounding-box noise on an exact primitive. A pocket floor is upward-facing, so it is always the
-low end of the walls that rise from it; a wall's high end is where it opens, whether to the
-exterior, to a shallower pocket's floor, or to open air, never to a floor of its own. This holds
-regardless of whether the wall's rim classified concave for a legitimate reason or a wrong one, so
-the fix does not depend on #723 landing and will not need revisiting when it does.
-
-**Migration note**: `detectPocketsAAG()`/`AAG.detectPockets()` can now report fewer pockets, and a
-`PocketFeature.wallFaceIndices` can now be shorter, for any shape where a wall's rim classified
-concave without the wall actually bottoming out at that candidate floor. A genuine multi-wall
-pocket, where every wall shares the same floor Z, is unaffected: measured on the existing
-square-pocket fixtures (`Issue703EdgeConvexityOrderTests`, `Shape.detectPocketsAAG()`'s own doc
-example), the pocket count and each wall count are unchanged. One known limitation, not exercised
-by any fixture in this codebase: a filleted floor/wall junction would round the wall's bounding box
-past the floor's own Z by roughly the fillet radius, which could exceed the tolerance.
-
-Tests: `Tests/OCCTModelingTests/Issue724PocketGroupingFloorTests.swift` (new).
-
-||||||| 49b5e3b
 ### `Surface.appSurf(curves:)` rejects fewer than 2 curves instead of crashing; two sibling `GeomFill_*` null-handle guards (#644, #710)
 
 Two independent, uncatchable SIGSEGVs in `OCCTGeomFillAppSurf` (`OCCTBridge_Surface.mm`) and its
@@ -160,8 +148,6 @@ with evidence rather than implemented:
   automated gate covers arity the way `check-null-handle-guards.py` covers null handles is accurate
   and is left as a genuine, but separate, future census.
 
-||||||| abc0f32
-||||||| d0884ad
 ### `OCCTEdgeGetConvexity` replaces its hand-rolled formula with OCCT's own classifier (#723)
 
 #703 (below) fixed the face1/face2 argument-order dependence by replacing a scalar triple product

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -163,6 +163,11 @@ public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) { get }
 
 - **Returns:** Tuple of min and max corners of the AABB. Returns `(.zero, .zero)` on error.
 - **OCCT:** `BRepBndLib::Add` + `Bnd_Box::Get`.
+- **Note:** This box is enlarged by the face's mesh deflection whenever the shape has already been
+  meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior) — the same face can
+  report a looser box after a call to `Shape.mesh(linearDeflection:angularDeflection:)` than before
+  it, with no other change (#733). `AAG`'s own floor/wall matching (`detectPockets(tolerance:)`)
+  reads a tessellation-independent bound internally for this reason.
 - **Example:**
   ```swift
   let face = Shape.box(width: 10, height: 5, depth: 2)!.faces()[0]

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -164,7 +164,7 @@ public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) { get }
 - **Returns:** Tuple of min and max corners of the AABB. Returns `(.zero, .zero)` on error.
 - **OCCT:** `BRepBndLib::Add` + `Bnd_Box::Get`.
 - **Note:** This box is enlarged by the face's mesh deflection whenever the shape has already been
-  meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior) — the same face can
+  meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior); the same face can
   report a looser box after a call to `Shape.mesh(linearDeflection:angularDeflection:)` than before
   it, with no other change (#733). `AAG`'s own floor/wall matching (`detectPockets(tolerance:)`)
   reads a tessellation-independent bound internally for this reason.

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -347,7 +347,25 @@ Detects pocket features in the shape by AAG analysis.
 public func detectPockets() -> [PocketFeature]
 ```
 
-A pocket is identified when: (1) an upward-facing, horizontal, planar face exists as the floor; (2) that floor has at least one concave-edge neighbor; (3) the concave neighbors are vertical faces (walls). Results are sorted by ascending `zLevel` (deepest pocket first).
+A pocket is identified when: (1) an upward-facing, horizontal, planar face exists as the floor; (2) that floor has at least one concave-edge neighbor; (3) the concave neighbors are vertical faces (walls); (4) each such wall's own bounding-box minimum Z matches the floor's Z (#724), meaning the wall must actually rest ON that floor, not merely open past it. Results are sorted by ascending `zLevel` (deepest pocket first).
+
+Requirement (4) exists because a wall's own exterior opening can satisfy (1)-(3) too: the exterior
+surface a pocket opens through is upward-facing, horizontal and planar exactly like the real floor,
+and its rim edge to the wall can classify concave in the same cases a real floor's does (a curved
+wall's rim commonly does, pending #723's replacement of `OCCTEdgeGetConvexity`'s formula). Without
+(4), a single blind cylindrical pocket reported **two** pockets: the real floor at the bottom of
+the bore, and the box's own top face at the wall's other end, for what is physically one cavity. A
+floor is always the low end of the walls that rise from it; a wall's high end is where it opens,
+never where it floors. This does not depend on any edge's classification being correct, only on
+the floor actually sitting at the bottom of its own walls, which is a geometric fact independent of
+#723.
+
+```swift
+let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
+let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
+let cut  = box.subtracting(tool)!
+print(cut.detectPocketsAAG().count)   // 1, not 2 (#724)
+```
 
 - **Returns:** Array of `PocketFeature` values, sorted deepest-first.
 - **Example:**

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -56,7 +56,7 @@ public struct AAGNode: Sendable {
 }
 ```
 
-All fields are populated once during `AAG.buildGraph()` by querying the corresponding `Face` properties. `normal` is `nil` for degenerate faces; `zLevel` is `nil` for non-planar or non-horizontal faces.
+All fields are populated once during `AAG.buildGraph()` by querying the corresponding `Face` properties. `normal` is `nil` for degenerate faces; `zLevel` is `nil` for non-planar or non-horizontal faces. `bounds` is the face's exact-geometry bounding box (`Face.exactBounds`, not `Face.bounds`), so it is unaffected by any triangulation the face carries — meshing a shape before building an `AAG` from it does not change this value (#733).
 
 - `faceIndex`: this node's position in the graph, the index every `AAG` method (`neighbors(of:)`, `edge(between:and:)`, `concaveNeighbors(of:)`, `convexNeighbors(of:)`) takes and returns. An occurrence index into `Shape.orientedFaces()`, not a distinct face index.
 - `distinctFaceIndex`: this occurrence's underlying face, its position in `Shape.faces()`, the deduplicated enumeration. Two nodes with the same `distinctFaceIndex` are the two sides of one face shared between two solids in a compound, same geometry, opposite orientation, opposed normals. On a shape whose faces are not shared, every node has `distinctFaceIndex == faceIndex`.

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -56,7 +56,7 @@ public struct AAGNode: Sendable {
 }
 ```
 
-All fields are populated once during `AAG.buildGraph()` by querying the corresponding `Face` properties. `normal` is `nil` for degenerate faces; `zLevel` is `nil` for non-planar or non-horizontal faces. `bounds` is the face's exact-geometry bounding box (`Face.exactBounds`, not `Face.bounds`), so it is unaffected by any triangulation the face carries — meshing a shape before building an `AAG` from it does not change this value (#733).
+All fields are populated once during `AAG.buildGraph()` by querying the corresponding `Face` properties. `normal` is `nil` for degenerate faces; `zLevel` is `nil` for non-planar or non-horizontal faces. `bounds` is the face's exact-geometry bounding box (`Face.exactBounds`, not `Face.bounds`), so it is unaffected by any triangulation the face carries: meshing a shape before building an `AAG` from it does not change this value (#733).
 
 - `faceIndex`: this node's position in the graph, the index every `AAG` method (`neighbors(of:)`, `edge(between:and:)`, `concaveNeighbors(of:)`, `convexNeighbors(of:)`) takes and returns. An occurrence index into `Shape.orientedFaces()`, not a distinct face index.
 - `distinctFaceIndex`: this occurrence's underlying face, its position in `Shape.faces()`, the deduplicated enumeration. Two nodes with the same `distinctFaceIndex` are the two sides of one face shared between two solids in a compound, same geometry, opposite orientation, opposed normals. On a shape whose faces are not shared, every node has `distinctFaceIndex == faceIndex`.
@@ -371,11 +371,11 @@ print(cut.detectPocketsAAG().count)   // 1, not 2 (#724)
 
 The comparison in (4) reads `AAGNode.bounds`, which is always the wall's exact-geometry bounding
 box (`Face.exactBounds`), never the mesh-enlarged one `Face.bounds` can return once a shape has
-been meshed -- so a prior call to `Shape.mesh(...)`/`meshWithProgress(...)` does not change the
+been meshed, so a prior call to `Shape.mesh(...)`/`meshWithProgress(...)` does not change the
 result (#733).
 
 - **Parameters:**
-  - `tolerance` — how close (model units) a wall's own low-Z bound must come to a candidate floor's
+  - `tolerance`: how close (model units) a wall's own low-Z bound must come to a candidate floor's
     Z to count as resting on it. Defaults to `defaultFloorRestsOnWallTolerance` (1e-4). Not a fixed
     constant (#733): a shape modeled at a different scale than millimeters may need a different
     value.
@@ -462,7 +462,7 @@ public func detectPocketsAAG(tolerance: Double = AAG.defaultFloorRestsOnWallTole
 
 Equivalent to `buildAAG().detectPockets(tolerance:)`. Selects on each node's `isUpward`, `isHorizontal` and `isPlanar`, which `buildAAG()` derives per face occurrence, so the result no longer depends on a compound's member order (#642): before that fix, a face shared between two solids in a compound could report a different pocket count depending only on which order the solids were compounded in, for identical geometry. #699 closed a second, independent source of the same symptom: `concaveNeighbors(of:)` (which `detectPockets()` reads to find candidate walls) used to include neighbors from a *different* solid than the floor's own, which could make the result order-dependent on a fixture #642 alone did not fix (a vertical, rather than horizontal, two-solid split) and could inflate the count with a wall that was never really adjacent to that floor in either solid.
 
-- **Parameters:** `tolerance` — forwarded to `AAG.detectPockets(tolerance:)`; see its doc.
+- **Parameters:** `tolerance`: forwarded to `AAG.detectPockets(tolerance:)`; see its doc.
 - **Returns:** Array of `PocketFeature` values, sorted deepest-first.
 - **Example:**
   ```swift

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -341,20 +341,20 @@ Pure-Swift computed property; no bridge call.
 
 These methods extend `AAG` with higher-level feature detection.
 
-### `AAG.detectPockets()`
+### `AAG.detectPockets(tolerance:)`
 
 Detects pocket features in the shape by AAG analysis.
 
 ```swift
-public func detectPockets() -> [PocketFeature]
+public func detectPockets(tolerance: Double = defaultFloorRestsOnWallTolerance) -> [PocketFeature]
 ```
 
-A pocket is identified when: (1) an upward-facing, horizontal, planar face exists as the floor; (2) that floor has at least one concave-edge neighbor; (3) the concave neighbors are vertical faces (walls); (4) each such wall's own bounding-box minimum Z matches the floor's Z (#724), meaning the wall must actually rest ON that floor, not merely open past it. Results are sorted by ascending `zLevel` (deepest pocket first).
+A pocket is identified when: (1) an upward-facing, horizontal, planar face exists as the floor; (2) that floor has at least one concave-edge neighbor; (3) the concave neighbors are vertical faces (walls); (4) each such wall's own bounding-box minimum Z matches the floor's Z within `tolerance` (#724), meaning the wall must actually rest ON that floor, not merely open past it. Results are sorted by ascending `zLevel` (deepest pocket first).
 
 Requirement (4) exists because a wall's own exterior opening can satisfy (1)-(3) too: the exterior
 surface a pocket opens through is upward-facing, horizontal and planar exactly like the real floor,
 and its rim edge to the wall can classify concave in the same cases a real floor's does (a curved
-wall's rim commonly does, pending #723's replacement of `OCCTEdgeGetConvexity`'s formula). Without
+wall's rim commonly does, prior to #723's replacement of `OCCTEdgeGetConvexity`'s formula). Without
 (4), a single blind cylindrical pocket reported **two** pockets: the real floor at the bottom of
 the bore, and the box's own top face at the wall's other end, for what is physically one cavity. A
 floor is always the low end of the walls that rise from it; a wall's high end is where it opens,
@@ -369,6 +369,16 @@ let cut  = box.subtracting(tool)!
 print(cut.detectPocketsAAG().count)   // 1, not 2 (#724)
 ```
 
+The comparison in (4) reads `AAGNode.bounds`, which is always the wall's exact-geometry bounding
+box (`Face.exactBounds`), never the mesh-enlarged one `Face.bounds` can return once a shape has
+been meshed -- so a prior call to `Shape.mesh(...)`/`meshWithProgress(...)` does not change the
+result (#733).
+
+- **Parameters:**
+  - `tolerance` — how close (model units) a wall's own low-Z bound must come to a candidate floor's
+    Z to count as resting on it. Defaults to `defaultFloorRestsOnWallTolerance` (1e-4). Not a fixed
+    constant (#733): a shape modeled at a different scale than millimeters may need a different
+    value.
 - **Returns:** Array of `PocketFeature` values, sorted deepest-first.
 - **Example:**
   ```swift
@@ -379,6 +389,19 @@ print(cut.detectPocketsAAG().count)   // 1, not 2 (#724)
       print("floor \(p.floorFaceIndex), depth \(p.depth), open: \(p.isOpen)")
   }
   ```
+
+---
+
+### `AAG.defaultFloorRestsOnWallTolerance`
+
+The default value of `detectPockets(tolerance:)`'s `tolerance` parameter (#733).
+
+```swift
+public static let defaultFloorRestsOnWallTolerance: Double  // 1e-4
+```
+
+Public so a caller who widens or narrows the tolerance can still express it relative to the
+library's own default rather than hardcoding `1e-4` again.
 
 ---
 
@@ -429,16 +452,17 @@ Convenience wrapper around `AAG(shape: self)`. The graph's nodes are face occurr
 
 ---
 
-### `Shape.detectPocketsAAG()`
+### `Shape.detectPocketsAAG(tolerance:)`
 
 Detects pockets using AAG-based feature recognition.
 
 ```swift
-public func detectPocketsAAG() -> [PocketFeature]
+public func detectPocketsAAG(tolerance: Double = AAG.defaultFloorRestsOnWallTolerance) -> [PocketFeature]
 ```
 
-Equivalent to `buildAAG().detectPockets()`. Selects on each node's `isUpward`, `isHorizontal` and `isPlanar`, which `buildAAG()` derives per face occurrence, so the result no longer depends on a compound's member order (#642): before that fix, a face shared between two solids in a compound could report a different pocket count depending only on which order the solids were compounded in, for identical geometry. #699 closed a second, independent source of the same symptom: `concaveNeighbors(of:)` (which `detectPockets()` reads to find candidate walls) used to include neighbors from a *different* solid than the floor's own, which could make the result order-dependent on a fixture #642 alone did not fix (a vertical, rather than horizontal, two-solid split) and could inflate the count with a wall that was never really adjacent to that floor in either solid.
+Equivalent to `buildAAG().detectPockets(tolerance:)`. Selects on each node's `isUpward`, `isHorizontal` and `isPlanar`, which `buildAAG()` derives per face occurrence, so the result no longer depends on a compound's member order (#642): before that fix, a face shared between two solids in a compound could report a different pocket count depending only on which order the solids were compounded in, for identical geometry. #699 closed a second, independent source of the same symptom: `concaveNeighbors(of:)` (which `detectPockets()` reads to find candidate walls) used to include neighbors from a *different* solid than the floor's own, which could make the result order-dependent on a fixture #642 alone did not fix (a vertical, rather than horizontal, two-solid split) and could inflate the count with a wall that was never really adjacent to that floor in either solid.
 
+- **Parameters:** `tolerance` — forwarded to `AAG.detectPockets(tolerance:)`; see its doc.
 - **Returns:** Array of `PocketFeature` values, sorted deepest-first.
 - **Example:**
   ```swift


### PR DESCRIPTION
## What & why

`detectPocketsAAG()` reported 2 pockets for a single blind cylindrical pocket. The defect is in
grouping, not classification: `AAG.detectPockets()` picks a floor candidate on
`isUpward && isHorizontal && isPlanar` plus at least one concave, vertical neighbor, with no check
that the neighbor actually bottoms out at that floor rather than merely touching it somewhere along
its height. A curved wall's rim, where it meets the exterior surface a pocket opens through, can
still classify concave under the current formula even after #703's face1/face2 order fix (that fix
addressed a planar/planar order-dependence, not a planar/cylindrical pair), so the box's own top
face satisfied the floor predicate exactly as well as the real floor and looked like a second,
shallower floor sharing the same wall.

Fix: a candidate wall only counts toward a floor if the wall's own bounding-box minimum Z matches
that floor's Z, within a tolerance far tighter than any real pocket depth and far looser than
bounding-box noise on an exact primitive. A pocket floor is always the low end of the walls that
rise from it; a wall's high end is where it opens, never where it floors. This does not touch
`OCCTEdgeGetConvexity` and does not depend on #723 (the separate, in-flight replacement of that
formula with `ChFi3d::DefineConnectType`) landing first: it holds regardless of why a rim edge
classified concave.

**Update (review response):** two more fixes landed on top of the above, both prompted by this PR's
own reviews rather than #724 itself. See "Review response" below for the measurements.

1. The floor/wall Z-match tolerance was compared against `Face.bounds`, which enlarges by the mesh's
   deflection once a shape has been meshed (`BRepBndLib::Add`'s `useTriangulation=true` default).
   Meshing a shape and then calling `detectPocketsAAG()` on it, the combined workflow this repo's
   own MCP tools invite, silently dropped real pockets. Fixed with a new bridge entry point,
   `OCCTFaceGetBoundsExact`, that always uses the shape's exact geometry.
2. The tolerance itself was a hardcoded `private static let`, the only non-configurable tolerance in
   the whole module. Promoted to a `tolerance:` parameter on both `AAG.detectPockets(tolerance:)`
   and `Shape.detectPocketsAAG(tolerance:)`, defaulting to the same value.

Closes #724

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification): see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.

## CHANGELOG entry

### `detectPocketsAAG()` no longer double-counts a single pocket's floor; its floor/wall match survives meshing and is now caller-configurable (#724, #733)

A single blind cylindrical pocket reported two pockets instead of one:

```swift
let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
let cut  = box.subtracting(tool)!
print(cut.detectPocketsAAG().count)   // was 2, now 1
```

Ground truth for this solid, from OCCT's own classifier `ChFi3d::DefineConnectType`: 13 convex
edges, 1 concave (the bore's floor meeting its cylindrical wall), 1 tangential (the cylinder's own
seam). One concave edge joining a wall to a floor is one pocket.

This was a grouping defect, not a classification one, and is independent of #703 (the
face1/face2 order fix) and of #723 (the separate replacement of `OCCTEdgeGetConvexity`'s formula
with `ChFi3d::DefineConnectType`): `AAG.detectPockets()` selected a floor candidate on
`isUpward && isHorizontal && isPlanar` plus at least one concave, vertical neighbor, with no check
that the neighbor was actually resting on that floor rather than merely touching it somewhere along
its height. A curved wall's rim, where it meets the exterior surface it opens through, can classify
concave under the convexity formula even after #703's fix, since that fix addressed a
planar/planar order-dependence and left a planar/cylindrical pair's classification unchanged. The
box's own top face satisfies the floor predicate exactly as well as the real floor does, and once
its rim edge to the bore's wall is (wrongly) concave, it is indistinguishable from a second,
shallower floor sharing the same wall.

**Fixed**: a wall only counts toward a given floor candidate if the wall's own bounding-box minimum
Z matches that floor's Z, within a tolerance (`AAG.defaultFloorRestsOnWallTolerance`, 1e-4) far
tighter than any real pocket depth and far looser than bounding-box noise on an exact primitive. A
pocket floor is upward-facing, so it is always the low end of the walls that rise from it; a wall's
high end is where it opens, whether to the exterior, to a shallower pocket's floor, or to open air,
never to a floor of its own. This holds regardless of whether the wall's rim classified concave for
a legitimate reason or a wrong one, so the fix does not depend on #723 and did not need revisiting
when it landed.

**Two further fixes, both from this PR's own review:**

- The Z-match compared against `Face.bounds`, which `BRepBndLib::Add` enlarges by the mesh's
  deflection once a shape has been meshed. Measured on the fixture above: at the mesh library's own
  default deflection (0.1), a meshed shape's wall bound drifted ~290x past the tolerance, and every
  deflection tried (0.001-5.0) exceeded it, dropping the pocket outright once the shape had been
  meshed at all before calling `detectPocketsAAG()`. A planar-walled pocket never drifted (a plane
  triangulates without curvature error), which is why the fix above's own fixtures didn't catch it.
  Fixed with a new internal `Face.exactBounds` (backed by a new bridge entry point,
  `OCCTFaceGetBoundsExact`, `BRepBndLib::Add(..., useTriangulation: false)`), used only inside `AAG`;
  `Face.bounds` itself is unchanged for every other caller.
- The tolerance was a hardcoded `private static let`, the only non-configurable tolerance anywhere
  in this module (every other tolerance, 296 of them, is a caller-supplied parameter with a
  default). Promoted to a `tolerance:` parameter on both `AAG.detectPockets(tolerance:)` and
  `Shape.detectPocketsAAG(tolerance:)`, defaulting to the same 1e-4
  (`AAG.defaultFloorRestsOnWallTolerance`, now public). Existing call sites are unaffected.

**Migration note**: `detectPocketsAAG()`/`AAG.detectPockets()` can now report fewer pockets, and a
`PocketFeature.wallFaceIndices` can now be shorter, for any shape where a wall's rim classified
concave without the wall actually bottoming out at that candidate floor. A genuine multi-wall
pocket, where every wall shares the same floor Z, is unaffected: measured on the existing
square-pocket fixtures (`Issue703EdgeConvexityOrderTests`, `Shape.detectPocketsAAG()`'s own doc
example), the pocket count and each wall count are unchanged, meshed or not. One known limitation,
not exercised by any fixture in this codebase: a filleted floor/wall junction would round the wall's
bounding box past the floor's own Z by roughly the fillet radius, which could exceed the default
tolerance; pass a larger `tolerance:` for that case.

Tests: `Tests/OCCTModelingTests/Issue724PocketGroupingFloorTests.swift`,
`Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift` (both new).

## SemVer impact

**PATCH.** `AAG.detectPockets()`/`Shape.detectPocketsAAG()` can now report a different (corrected)
pocket count and, for callers who opt in, take a `tolerance:` parameter with a default matching the
prior hardcoded value; no existing call site changes behavior or stops compiling. The floor/wall
check itself is brand new in this same `Unreleased` section (introduced by #724, not by a prior
release), so both the bug fixes and the added parameter are corrections to code nobody has shipped
yet, not a break to anything a consumer of a released version could be depending on.

## Notes for the reviewer

### Original #724 fix

- **Injection matrix** (prove-the-test-fails, per `okf/policies/prove-the-test-fails.md`): reverted
  just the fix (`git stash` on `FeatureRecognition.swift` only, keeping the new test file) and
  reran `Issue724PocketGroupingFloorTests`:

  | Test | Unfixed code | Fixed code |
  |---|---|---|
  | `blindCylindricalPocketReportsOne` (the issue's own repro) | FAIL (`2 != 1`) | PASS |
  | `holdsAcrossToolHeight` @ 15/20/40 | FAIL, all 3 (`2 != 1`) | PASS |
  | `genuineFourWalledPocketKeepsAllWalls` | PASS (unaffected) | PASS |
  | `pinnedSquarePocketFixtureUnaffected` @ 2/10/25 | PASS (unaffected) | PASS |
  | `plainBoxStillReportsZero` | PASS (unaffected) | PASS |

  The three "unaffected" cases confirm the fix doesn't regress an already-correct grouping; the two
  failing cases are the actual defect.

### Review response (this update)

Both reviews are addressed individually in PR comments, each with its own injection matrix. Summary:

- **First review** (10 findings): findings 3 and 6 fixed by #734 (merged); findings 1, 4, 9 concerned
  centroid code #734 deleted outright (moot); findings 2 and 5 refuted by measurement, see PR
  comments for the drift table. Finding 5's probe surfaced a real, unrelated bug, filed as #735
  (`PocketFeature.isOpen` counts walls instead of testing enclosure).
- **Second review** (6 findings): the conflict-marker finding fixed by #745 (merged, on the base;
  this branch's own stale copy of `docs/CHANGELOG.md` is cleaned up in this update too, see below).
  Finding 1 (mesh triangulation) reproduces and is fixed here; see the CHANGELOG entry above for
  the measurement. Finding 3 (zeroed bounds on an internal exception) is plausible but not
  reproduced; it is the identical class of issue as the first review's finding 7 and is pre-existing
  (the same code path already runs for any unmeshed shape, unaffected by this PR), tracked by #726.
  Finding 4 (`detectHoles()` double-reporting) does not reproduce as stated (`detectHoles()`'s
  per-node loop cannot double-report a single face occurrence), but measuring it surfaced a real,
  more severe, pre-existing defect (`detectHoles()` now reports **zero** holes for an ordinary
  blind or through cylindrical hole, since #723's more correct classifier means neither shape can
  ever satisfy its "all neighbors concave" criterion), filed separately as #747. Finding 5 (hardcoded
  tolerance) is fixed here. Finding 6 (doc duplication across CHANGELOG/reference/source/test) is
  refuted: the "no duplicate content" rule targets the `docs/` hierarchy's cross-file redundancy
  (README vs API_REFERENCE vs docs/reference/), not source `///` comments (intentionally
  self-contained, harvested by context7) or test-file headers (this repo's own established
  convention: every `Issue*Tests.swift` file restates its issue's reasoning at comparable length).

- **`docs/CHANGELOG.md` cleanup**: this branch's own copy had carried three stray diff3 `|||||||`
  markers since before this PR branched (the same defect #745 fixed on `refactor/381-pass1b`
  directly; that fix never reached this branch). Per `okf/policies/changelog-on-merge.md` (now in
  force), this PR shouldn't touch that file at all, so its content was replaced wholesale with the
  base branch's current copy (the diff against `origin/refactor/381-pass1b` for that file is now
  empty), and the entry moved to this PR body instead.

- **Gate scripts**: all five pass (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `derive-bridge-header-split --verify`, `count-operations`); no public
  operation count changed (`detectPockets`/`detectPocketsAAG` gained a defaulted parameter, not a
  new overload, so `count-operations.py`'s derived total is unchanged at 4306).

- **Full suite**: `swift test` (no `OCCTSWIFT_LOCAL`, no `OCCTSWIFT_BRIDGE_PREBUILT`): 5437 tests,
  1417 suites, all pass. `OCCTModelingTests` alone (where every AAG/pocket/hole test lives): 605
  tests, 162 suites, all pass.

- **Worktree note for reviewers**: developed in an isolated worktree off `origin/fix/703-edge-convexity-order`
  (PR #720's head) after the originally-assigned shared worktree was found mid-task to be actively
  checked out to other branches by a concurrent session; the diff here is against that same base and
  should apply cleanly once #720 merges into `refactor/381-pass1b`.

