### PR TITLE
policy: CHANGELOG entries are written in the PR body, not the diff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,31 @@ policies / strategies / decisions and keep them current in THIS PR.
 
 Closes #
 
+## CHANGELOG entry
+
+<!--
+REQUIRED, and it goes HERE rather than in docs/CHANGELOG.md. Do not edit the `## Unreleased`
+section in your diff: every PR appends to the top of the same list, so every PR conflicts with
+every other PR that lands first. Whoever merges this copies the block below into the file.
+See okf/policies/changelog-on-merge.md.
+
+Write it finished, not as notes. The merger transcribes verbatim; they do not draft.
+Delete this section only if the change genuinely warrants no entry, and say why in
+"Notes for the reviewer".
+-->
+
+### <one-line summary of the change> (#<issue>)
+
+<!-- The entry as it should read under `## Unreleased`, including code fences and links. -->
+
 ## Checklist
 
 - [ ] New or changed behavior is covered by a unit test in the same PR (not just manual
-      verification) — see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
+      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
       for the ecosystem-wide test-coverage standard this is piloting.
+- [ ] Every new test and every new `--self-test` case was run once with its subject broken, and the
+      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
+- [ ] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
 
 ## Notes for the reviewer
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,10 @@ section in your diff: every PR appends to the top of the same list, so every PR 
 every other PR that lands first. Whoever merges this copies the block below into the file.
 See okf/policies/changelog-on-merge.md.
 
-Write it finished, not as notes. The merger transcribes verbatim; they do not draft.
-Delete this section only if the change genuinely warrants no entry, and say why in
-"Notes for the reviewer".
+Write it finished, not as notes: see the policy for why the merger transcribes rather than drafts.
+
+If the change genuinely warrants no entry, replace the heading below with "None, <reason>" rather
+than deleting the section, so the decision is visible instead of looking like an omission.
 -->
 
 ### <one-line summary of the change> (#<issue>)
@@ -34,6 +35,9 @@ Delete this section only if the change genuinely warrants no entry, and say why 
 - [ ] Every new test and every new `--self-test` case was run once with its subject broken, and the
       failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
 - [ ] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
+      Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the
+      policy's two exceptions and the file is expected in their diff. Say which one applies in
+      "Notes for the reviewer".
 
 ## Notes for the reviewer
 

--- a/okf/index.md
+++ b/okf/index.md
@@ -51,3 +51,4 @@ See [`references/`](references/index.md) — OpenCASCADE upstream and licensing 
 - [Upstream OCCT PRs follow OCCT's house style](policies/upstream-occt-style.md)
 - [Issue labels and project-board tracking](policies/issue-tracking.md)
 - [Code structure](policies/code-structure.md)
+- [CHANGELOG entries are written in the PR, not the diff](policies/changelog-on-merge.md)

--- a/okf/policies/changelog-on-merge.md
+++ b/okf/policies/changelog-on-merge.md
@@ -1,0 +1,103 @@
+---
+type: policy
+title: CHANGELOG entries are written in the PR, not the diff
+description: A PR carries its CHANGELOG entry in its body, under a fixed heading. The merging agent transcribes it into docs/CHANGELOG.md at merge time. Nobody edits the Unreleased section in a feature branch.
+tags: [policy, process, changelog, merging, agents]
+timestamp: 2026-08-07
+---
+
+# CHANGELOG entries are written in the PR, not the diff
+
+**A pull request must not modify the `## Unreleased` section of `docs/CHANGELOG.md`.** It carries
+its entry in the PR body instead, under a `## CHANGELOG entry` heading. Whoever merges the PR copies
+that block into `docs/CHANGELOG.md` on the base branch as part of merging.
+
+The entry is still mandatory. [Documentation updates are mandatory](docs-current.md) is unchanged.
+Only the file the entry lives in until merge has moved.
+
+## Why
+
+Every PR appends to the top of the same section of the same file, so every PR conflicts with every
+other PR that lands before it. The conflict is never semantic: it is two additions to one list, and
+the resolution is always "keep both". It costs a merge, a resolution, a push, and a fresh CI round
+trip, and it recurs for each sibling that lands first.
+
+Measured on 2026-08-06, a single day on `refactor/381-pass1b`:
+
+- **29 commits** touched `docs/CHANGELOG.md`.
+- **Seven** separate resolutions of the same keep-both conflict: three on the base branch, and
+  **four on one PR alone** (#728), which re-conflicted each time a sibling merged ahead of it.
+- #728 was a two-file change, one of them the CHANGELOG. It spent more wall-clock in conflict
+  resolution than in review.
+- The `## Unreleased` section is 15 entries. Every one of them was an opportunity for this.
+
+The cost is quadratic in the number of PRs in flight, and this branch routinely has six or more.
+
+There is a second, quieter cost. Each resolution is a hand edit to a file with conflict markers in
+it, and the only check that nothing was dropped is whoever is doing it counting entries before and
+after. That is a manual integrity check running several times a day on the project's own release
+record.
+
+## How to apply
+
+### If you are opening a PR
+
+Put the entry in the PR body, verbatim as it should appear in the file:
+
+```markdown
+## CHANGELOG entry
+
+### `Shape.thing` no longer returns the wrong answer (#123)
+
+Prose exactly as it should land under `## Unreleased`, including any code fences,
+tables and issue links.
+```
+
+Do not touch `docs/CHANGELOG.md`. If your diff contains it, that is a review finding.
+
+Write it as the finished text, not as notes. The merger transcribes; they do not draft.
+
+### If you are merging a PR
+
+Merging is not complete until the entry is in the file. Either:
+
+- add it to `docs/CHANGELOG.md` on the base branch in a commit immediately after the merge, or
+- add it to the PR's own branch immediately before merging, once no other PR is between you and the
+  base.
+
+The second is fine and sometimes tidier; it just has to be the last thing before the merge, or the
+conflict comes back.
+
+Copy the block verbatim. If it is wrong, that is a review comment on the PR, not an edit in transit.
+
+### Exceptions
+
+- **The release commit** rewrites the whole section, moving `## Unreleased` under a version heading.
+  That commit edits the file directly, by definition.
+- **A PR that fixes the CHANGELOG itself**, for instance a stale cross-reference, edits the file
+  directly. It is not adding an entry.
+
+## The failure mode this introduces, and the guard for it
+
+Moving the entry out of the diff means it can be **forgotten at merge**, which the old way made
+impossible. That is a real trade and worth stating plainly rather than discovering.
+
+Three things hold it:
+
+1. `## CHANGELOG entry` is a required heading in
+   [`.github/pull_request_template.md`](../../.github/pull_request_template.md). A PR without one is
+   incomplete, the same as a PR without a test.
+2. The merger's own checklist: the merge is not done until the entry is in the file. Treat a merged
+   PR with no entry the way you would treat a merged PR whose tests never ran.
+3. It is recoverable. The text is in the PR body forever, so a missed entry is a lookup, not a
+   reconstruction. That is strictly better than a dropped entry during a conflict resolution, which
+   leaves no trace anywhere.
+
+A missed entry is a visible gap in a released changelog. A silently dropped one during a hand
+conflict resolution is not visible at all, and the old way produced several opportunities for that
+per day.
+
+## Related
+
+- [Documentation updates are mandatory](docs-current.md), which this does not weaken.
+- [No em-dashes, banned words in prose](writing-style.md) applies to the entry, wherever it lives.

--- a/okf/policies/changelog-on-merge.md
+++ b/okf/policies/changelog-on-merge.md
@@ -55,7 +55,9 @@ tables and issue links.
 
 Do not touch `docs/CHANGELOG.md`. If your diff contains it, that is a review finding.
 
-Write it as the finished text, not as notes. The merger transcribes; they do not draft.
+Write it as the finished text, not as notes. The merger transcribes; they do not draft. This
+sentence is the canonical statement of that rule; the PR template points here rather than
+restating it.
 
 ### If you are merging a PR
 
@@ -85,7 +87,7 @@ impossible. That is a real trade and worth stating plainly rather than discoveri
 Three things hold it:
 
 1. `## CHANGELOG entry` is a required heading in
-   [`.github/pull_request_template.md`](../../.github/pull_request_template.md). A PR without one is
+   [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md). A PR without one is
    incomplete, the same as a PR without a test.
 2. The merger's own checklist: the merge is not done until the entry is in the file. Treat a merged
    PR with no entry the way you would treat a merged PR whose tests never ran.


### PR DESCRIPTION
## What & why

Every PR appends to the top of the same section of `docs/CHANGELOG.md`, so every PR conflicts with
every other PR that lands before it. The conflict is never semantic: two additions to one list, and
the resolution is always "keep both". It costs a merge, a resolution, a push and a fresh CI round
trip, and it recurs for each sibling that lands first, so the cost is quadratic in the number of PRs
in flight. This branch routinely has six or more.

Measured on 2026-08-06 on this branch:

- **29 commits** touched `docs/CHANGELOG.md`.
- The same keep-both conflict was resolved **seven times**: three on the base branch, and **four on
  one PR alone** (#728), which re-conflicted each time a sibling merged ahead of it. #728 is a
  two-file change and spent more wall-clock in conflict resolution than in review.

The quieter cost is that each resolution is a hand edit to a file carrying conflict markers, and the
only check that nothing was dropped is a human counting entries before and after. That is a manual
integrity check on the project's own release record, running several times a day.

**New rule:** a PR carries its entry in its body under a required `## CHANGELOG entry` heading, and
whoever merges transcribes it verbatim into the file. The entry stays mandatory
([docs-current](okf/policies/docs-current.md) is unweakened); only the file it lives in until merge
has moved.

## CHANGELOG entry

<!-- Deliberately none: this is a process and tooling change with no effect on the library's
public surface or behaviour. Recorded here rather than omitted silently, per the new policy. -->

No entry. Process change only, no library surface or behaviour is affected.

## Notes for the reviewer

**The failure this introduces is named in the policy rather than left to be discovered.** An entry
can now be forgotten at merge, which the old way made impossible. Three things hold it: the required
template heading, the merger's checklist, and, the real argument, that the text lives in the PR body
permanently. A missed entry is therefore a lookup rather than a reconstruction, and strictly better
than an entry silently dropped during a hand conflict resolution, which leaves no trace anywhere.

Two exceptions are carved out: the release commit, which rewrites the whole section by definition,
and a PR that fixes the CHANGELOG itself.

The template also gains a prove-the-test-fails checkbox. That was already policy
(`okf/policies/prove-the-test-fails.md`) but nothing prompted for it.

This same commit goes to `main` as well, since it governs PRs against both.