### PR TITLE
docs(#657): re-verify the ten upstream OCCT PRs, assess patch 0020 for filing

### DIFF
--- a/Scripts/repro/657-upstream-pr-status/README.md
+++ b/Scripts/repro/657-upstream-pr-status/README.md
@@ -1,0 +1,232 @@
+# #657: upstream OCCT PR status audit, and is patch 0020 fileable
+
+Housekeeping fallout from the OCCT 8.0.1 absorb (#654). Re-verifies the status of the ten open
+upstream OCCT PRs #657 lists, checks whether any actually needs a conflict-resolving rebase, and
+assesses whether carried patch `0020` (never filed) is ready to send. `okf` has a standing lesson
+that external status claims are re-verified, not copied from the issue that states them
+(`feedback-verify-external-status-claims`); this write-up is that verification, not a restatement.
+
+**No upstream action was taken.** Nothing here pushes to, comments on, or modifies any pull request
+or issue in `Open-Cascade-SAS/OCCT`, or any fork of it. `verify.sh` in this directory is read-only
+and reproduces every claim below from the GitHub API and a throwaway local clone; run it to
+re-check any of this after time has passed.
+
+## Method
+
+1. **Live PR state**: `gh api repos/Open-Cascade-SAS/OCCT/pulls/<n>` for each of the ten, plus
+   `.../issues/<n>/comments` and `.../pulls/<n>/reviews` for anything that reads like unanswered
+   feedback, plus `.../commits/<sha>/status` and `.../check-runs` for CI.
+2. **Does the patch still apply**: a `--filter=blob:none --depth 100` sparse clone of
+   `Open-Cascade-SAS/OCCT` at the current `master` tip, containing only the directories our eleven
+   patches (the ten plus `0020`) touch, then `git apply --check -p1` of this repo's own carried
+   `.patch` file against it. This is a stronger claim than GitHub's `mergeable` flag: it proves *our
+   patch file*, not just the PR branch (which can drift from it after a force-push), still matches
+   current upstream source close enough to apply with zero rejected hunks.
+3. **Is the PR branch itself in sync with our patch file**: for the two PRs with a review thread
+   (`1388`, `1399`), applied both our local `.patch` and the PR's live `.diff` (fetched fresh via
+   `Accept: application/vnd.github.v3.diff`) to separate copies of the same master checkout, then
+   diffed the *resulting file trees* rather than the raw diff text. That survives context-line
+   drift and blob-hash differences in `diff --git` headers that a raw text diff would flag as
+   spurious.
+4. **Fileability of `0020`**: compiled and ran the existing reproducer against the currently pinned
+   kernel (which already carries the fix), and ran the OCCT-root `.clang-format` over the patched
+   file to confirm no reformatting is needed before submission.
+
+## Per-PR status (verified 2026-08-07)
+
+| Our patch | Upstream PR | State | CI | Files touched upstream since PR opened | Applies to current master | Unanswered feedback |
+|---|---|---|---|---|---|---|
+| `0010` | [OCCT#1386](https://github.com/Open-Cascade-SAS/OCCT/pull/1386) | open | 17 green, 1 skipped | none | yes, byte-identical (prod code) | none, 0 comments |
+| `0011` | [OCCT#1388](https://github.com/Open-Cascade-SAS/OCCT/pull/1388) | open | 17 green, 1 skipped | none | yes | none, thread resolved, see below |
+| `0012` | [OCCT#1390](https://github.com/Open-Cascade-SAS/OCCT/pull/1390) | open | 17 green, 1 skipped | none | yes, byte-identical | none, 0 comments |
+| `0014` | [OCCT#1394](https://github.com/Open-Cascade-SAS/OCCT/pull/1394) | open | 17 green, 1 skipped | none | yes, byte-identical | none, 0 comments |
+| `0015` | [OCCT#1397](https://github.com/Open-Cascade-SAS/OCCT/pull/1397) | open | 17 green, 1 skipped | none | yes, byte-identical | none, 0 comments |
+| `0016` | [OCCT#1399](https://github.com/Open-Cascade-SAS/OCCT/pull/1399) | open | 17 green, 1 skipped | none | yes, byte-identical | none, thread resolved (issue's claim was wrong, see below) |
+| `0017` | [OCCT#1410](https://github.com/Open-Cascade-SAS/OCCT/pull/1410) | open | 17 green, 1 skipped | none (the two files this patch touches; see below) | yes, byte-identical | none, 0 comments |
+| `0018` | [OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417) | open | 17 green, 1 skipped | none (base *is* current master tip) | yes, byte-identical | **yes, 3 requested changes, 4 days old** |
+| `0019` | [OCCT#1418](https://github.com/Open-Cascade-SAS/OCCT/pull/1418) | open | 17 green, 1 skipped | none (base *is* current master tip) | yes, byte-identical | **yes, regression provenance plus a repro script, 7 days old** |
+| `0021` | [OCCT#1420](https://github.com/Open-Cascade-SAS/OCCT/pull/1420) | open | 17 green, 1 skipped | none (base *is* current master tip) | yes, byte-identical | none, 0 comments |
+
+All ten: `state: open`, `merged: false`, `closed_at: null`. The issue's core claim (all ten still
+open) is correct. Nothing has silently merged or closed without the issue being updated. CI is
+green on all ten (`17 success, 1 skipped` on every head commit); the combined status shows
+`pending` on all ten, which is consistent with an unresolved required-review gate on an
+external-contributor PR, not a failing check. No PR has zero reviews recorded
+(`pulls/<n>/reviews` is empty on all ten), so `mergeable_state: blocked` reads as "awaiting a
+maintainer review," not "has a conflict."
+
+## Finding 1: none of the ten need a conflict-resolving rebase
+
+`git apply --check -p1` of all ten carried `.patch` files against a fresh checkout of upstream
+`master` (`b8f597c677811d1f9f4d8a97f5ae2825c0353a42`, 2026-07-30) succeeds with **zero rejected
+hunks**, matching every PR's own `mergeable: true`. This is stronger than the issue's own claim
+("zero file-level collisions against the 74 files 8.0.1 touched") because it is measured against
+upstream `master` directly, not against our `V8_0_1` pin.
+
+The reason is simple once measured: `master` has moved by only 5 commits since the oldest of the
+ten PRs' base commits (`37dd5686`, the six sharing that base: `1386`, `1388`, `1390`, `1394`,
+`1397`, `1410`), 3 commits since `1399`'s base (`50314b69`), and by **zero** commits since `1417`,
+`1418` and `1420`'s base (`b8f597c6` **is** the current master tip). None of those handful of
+intervening commits touches a file any of our ten patches touches, confirmed by diffing each PR's
+base commit against `HEAD` and cross-referencing the changed-file list against each patch's own
+file list (`Scripts/repro/657-upstream-pr-status/verify.sh` reproduces this).
+
+**"Rebase" in the issue's sense is therefore GitHub's cosmetic "this branch is out-of-date with the
+base branch" banner, not a merge conflict.** Clicking "Update branch" on each of the ten (a
+maintainer-only action we did not take) would fast-forward the base pointer with no resulting diff
+to resolve. There is nothing to do here beyond what a maintainer does at merge time.
+
+`0017`/`1410` is worth calling out by name since the issue flagged it specifically ("re-verify the
+defect still reproduces on master," `ShapeFix` being the package `8.0.1` changed most heavily). The
+two files this patch touches, `ShapeFix_ComposeShell.cxx` and `ShapeUpgrade_WireDivide.cxx`, are
+**not** among the 26 files `8.0.1` touched in that package (`ShapeFix_Face.cxx` and
+`ShapeUpgrade_UnifySameDomain.cxx` were, but those are different files fixing different defects,
+`0001`/#263 and `0013`/#348, both already retired). Since the two files this patch actually touches
+are provably byte-identical to when the PR was opened, the null-context defect it fixes is
+unchanged in current master. There is nothing to re-run a crash reproducer against that the file
+diff does not already answer.
+
+## Finding 2: the issue's claim about `0016`/OCCT#1399 is wrong
+
+The issue states: "`0016`/OCCT#1399 still carries the mutex version of the `Storage_Schema` half
+... the PR was never updated to match." This is false, and was already false when #657 was filed.
+
+`gh api repos/Open-Cascade-SAS/OCCT/issues/1399/comments` shows the exchange completed on
+**2026-07-30**, three days before #657 was opened:
+
+- 2026-07-29, gkv311: suggests moving `Storage_Schema::ICurrentData()` to a
+  `mutable Handle(Storage_Data) myCurrentData` instance field instead of the mutex.
+- 2026-07-30, gsdali (us): "Done, and thanks for the pointer... Force-pushed onto the same
+  branch," describing exactly that change.
+
+Fetching the PR's live diff (`gh api .../pulls/1399 -H "Accept: application/vnd.github.v3.diff"`)
+confirms the pushed content: `Storage_Schema.cxx` reads `myCurrentData = aData;` and
+`myCurrentData->InternalData()`, not `Storage_Schema::ISetCurrentData(aData)` or
+`Storage_Schema::ICurrentData()`. Applying that live diff and this repo's own `0016` patch file to
+separate copies of the same master checkout produces **byte-identical file trees**. Our
+locally-carried patch already matches the revised design `Scripts/patches/README.md`'s own `0016`
+entry describes. There is nothing to push here; #657's premise for flagging this PR was already
+stale at filing time. Recommend a one-line correction on #657 itself (not done by this PR, since
+that is a comment on our own repo's issue rather than an upstream action, but left for the human to
+decide since it wasn't asked for).
+
+## Finding 3: `0011`/OCCT#1388 diverged in prose only, not in substance
+
+Same comparison method applied to `1388` (the other PR with a review thread) turns up a real but
+harmless difference: the live PR's pushed code (`OwnAutoNamingScope`, `myOwnAutonaming`,
+`SetOwnAutoNaming`/`UnsetOwnAutoNaming`, all matching what `Scripts/patches/README.md`'s `0011`
+entry describes) is logically and structurally identical to our locally-carried `0011` patch, but
+the **comments differ**. The PR carries OCCT's terse one-line house style (for example
+`Saves/restores the instance's own override, not a shared flag, no locking needed`), while our
+locally-carried `.patch` file still has OCCTSwift's own multi-sentence doc-comment voice from
+before the submission pass. A few declaration alignments also differ by one or two spaces, pure
+`clang-format` artifacts from the two files evolving independently after the fork point.
+
+Per `okf/policies/upstream-occt-style.md`, this divergence is **expected and not a defect**: "This
+is a context switch, not our default... OCCT's house style applies only to code destined for the
+OCCT tree." The local patch documents the fix for this codebase's own purposes; what actually ships
+to OCCT gets OCCT's formatting at submission time, and the two are allowed to diverge afterward.
+Noted for awareness, not as an action item. Re-syncing the local patch's comments to match the live
+PR would just be churn with no behavior change.
+
+## Finding 4: two PRs have real, unanswered reviewer feedback
+
+Neither is a "review comment" formally (`review_comments: 0` on both, which is GitHub's
+inline-diff-review count), but both carry a plain conversation comment from the same maintainer
+(gkv311) requesting or noting something concrete, with no reply from our side since:
+
+- **`0018`/[OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417)**, 2026-08-03 (4 days
+  unanswered as of this audit): three specific requested changes.
+  1. The added `if (theNbPoints <= 1) { ...; return; }` duplicates the (compiled-out-under
+     `No_Exception`) `Standard_ConstructionError_Raise_if` above it; gkv311 suggests either
+     replacing the `Raise_if` with a real `throw` or dropping the duplicate check and keeping only
+     the early return.
+  2. The new end-point check uses `Distance()` (a `sqrt()` per call inside a loop); OCCT's own
+     convention is `SquareDistance()` against a precomputed `tol*tol`.
+  3. The parameter name `theTol3d` is misleading since the same template also instantiates for
+     `Adaptor2d_Curve2d`; suggests renaming to `theTol`.
+
+  All three are small, mechanical, and consistent with the class's own existing conventions; none
+  changes the fix's logic.
+
+- **`0019`/[OCCT#1418](https://github.com/Open-Cascade-SAS/OCCT/pull/1418)**, 2026-07-31 (7 days
+  unanswered): gkv311 identifies this as **a regression since OCCT 7.6.0**, introduced by an
+  UndefinedBehaviorSanitizer cleanup commit (`3016a390713d2e893f4bfa797882b9f0266840e1`,
+  "0032495: Coding rules - eliminate CLang UndefinedBehaviorSanitizer warnings"), and supplies a
+  DRAW Tcl script reproducing the sphere-collapse case directly (`approxsurf r s 1.e-3 0 0 8 8 100`)
+  with commented-out assertions on the resulting surface's degree. This reads as an invitation to
+  add that script as an OCCT DRAW-level regression test alongside the fix, and as provenance worth
+  folding into the PR description (a note on *when* the bug was introduced, which the original PR
+  description does not have).
+
+Both need a human response before either PR can move; neither is something this task should answer
+on the maintainer's behalf given the hard constraint against upstream writes.
+
+## Finding 5: nothing else has quietly shipped or gone stale
+
+Diffing every PR's base commit against current `master` for the *whole* `src/` tree (not just the
+files our patches touch) turns up 26 changed files, all of them either unrelated defects or areas
+already retired from our carried-patch list (`ShapeFix_Face.cxx` is `0001`/#263,
+`ShapeUpgrade_UnifySameDomain.cxx` is `0013`/#348, `ShapeAnalysis_FreeBounds.*` is `0004`/#310 and
+its `0007`/#323 sibling, `BRepGProp_EdgeTool.cxx` is `0006`/#318, all already retired per
+`Scripts/patches/README.md`'s "Retired patches" section, and all already reflected there). Nothing
+on that list is one of the ten open patches under a different upstream PR number, and nothing on
+the ten's own list has been superseded. `okf/references/carried-occt-patches.md`'s status table for
+these ten already matches what's verified here; no update needed there either.
+
+## Patch `0020`: is it in a state to file?
+
+**Yes.** Checked against the three concrete bars the issue names:
+
+- **Still applies**: `git apply --check -p1 Scripts/patches/0020-*.patch` against the current
+  upstream `master` sparse checkout succeeds with zero rejected hunks (the touched file,
+  `BRepFeat_MakeCylindricalHole.cxx`, does not appear in the 26-file changed-list above at all).
+- **Reproducer runnable**: compiled and ran
+  `Scripts/repro/532-cylindrical-hole-part-selection/occt_532_part_selection.mm` against the
+  currently pinned `v2.0.0-kernel.1` xcframework (which already carries this fix). Output matches
+  the repro README's documented "after" column exactly, for example the two-plate compound's
+  `PerformUntilEnd` reports `removed=3141.5927` (not `0.0000`), the severed 8mm bar's three affected
+  modes all report `removed=1407.2952`, and `PerformBlind(20)` reports `1178.0972`. Confirms the
+  reproducer still compiles against current headers and its measurements are exactly what the
+  writeup claims.
+- **Format-clean**: fetched OCCT's own root `.clang-format` and ran `clang-format -style=file` over
+  the patched file (patch applied to a clean upstream checkout); the formatted output is
+  byte-identical to the unformatted patched output. No reformatting needed before submission.
+
+**On the second, unfixed defect** (`PerformThruNext`'s closest-interval fallback nesting
+`// parbar > Last` unreachably inside `if (parbar < First)`): recommend it **rides along as a
+one-line prose note in the PR description, not as a code change**. No geometry in the existing
+reproducer sweep reaches that fallback branch at all (it only runs when no tool part's barycentre
+falls in `[First, Last]`), so there is no measurement backing a fix, only the static observation
+that the branch is unreachable as written. Bundling an unverified change into the same PR as a
+measured, validated one raises its risk for no offsetting benefit, and OCCT's own house style
+(`okf/policies/upstream-occt-style.md`) favors minimal, surgical diffs. Flagging it in prose costs
+nothing and gives the maintainer full context, matching how `0016`'s own PR description flagged
+`AddPersistent`'s `static TCollection_AsciiString` as a drive-by finding without folding it into
+the same commit unasked.
+
+**On whether it needs a companion issue**: no. `okf/policies/upstream-occt-style.md` (and the
+maintainer's own comment it quotes, on
+[OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409#issuecomment-5124395058)) is
+explicit that a ready fix goes straight to a PR. `0018`, `0019` and `0021` were all filed that way,
+each noted in `Scripts/patches/README.md` as "a fix PR with no companion repro issue, per upstream's
+own guidance." The task description asked for an issue draft as well as a PR draft "ready to send";
+`draft-0020-pr.md` in this directory has the PR text only, with this recommendation stated up front,
+since drafting a companion issue would itself be the pattern the policy and precedent both argue
+against. If a human reviewing this disagrees and wants the issue anyway, the PR body's first three
+paragraphs (root cause plus the two other users' correct behavior) are already issue-shaped and can
+be split out verbatim.
+
+See [`draft-0020-pr.md`](draft-0020-pr.md) for the full drafted title and body, ready to paste into
+a new PR against `Open-Cascade-SAS/OCCT`, **not sent**, per this task's hard constraint against any
+upstream write.
+
+## Re-running this audit
+
+```bash
+Scripts/repro/657-upstream-pr-status/verify.sh
+```
+
+Takes under a minute (shallow, sparse clone; no OCCT build). Prints the same live-status table and
+apply-check results gathered above, so a re-run after time has passed will show its own current
+answer rather than this file's timestamp-frozen one.

--- a/Scripts/repro/657-upstream-pr-status/draft-0020-pr.md
+++ b/Scripts/repro/657-upstream-pr-status/draft-0020-pr.md
@@ -1,0 +1,133 @@
+# Draft upstream PR for patch `0020` (BRepFeat_MakeCylindricalHole part selection)
+
+**Status: drafted, not sent.** This task's hard constraint forbids opening, editing or commenting
+on anything in `Open-Cascade-SAS/OCCT`. Everything below is text a human can paste into a new PR
+against that repository's `master` branch in one sitting.
+
+Per `okf/policies/upstream-occt-style.md` and the precedent set by `0018`/[OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417),
+`0019`/[OCCT#1418](https://github.com/Open-Cascade-SAS/OCCT/pull/1418) and
+`0021`/[OCCT#1420](https://github.com/Open-Cascade-SAS/OCCT/pull/1420): **no companion issue, go
+straight to the PR.** The diff itself is already `Scripts/patches/0020-BRepFeat_MakeCylindricalHole-select-tool-parts-532.patch`,
+already `clang-format`-clean against OCCT's own root `.clang-format` (verified, see this
+directory's `README.md`), and already applies to current upstream `master` with zero rejected
+hunks.
+
+Branch to open the PR from: apply `Scripts/patches/0020-*.patch` to a clean checkout of
+`Open-Cascade-SAS/OCCT` `master` (`git apply -p1`) and push that as the PR branch. The patch file's
+own commit message (its `From:`/`Subject:`/body preamble) is already written to double as this PR's
+description; the text below is that same content reformatted as a PR body with headings, matching
+how `0019`'s and `0021`'s merged PR descriptions are structured.
+
+---
+
+## Title
+
+```
+Modeling Algorithms - BRepFeat_MakeCylindricalHole selects parts of the cut result, not parts of the tool
+```
+
+## Body
+
+`BRepFeat_MakeCylindricalHole`'s four modes that choose which piece of the drilling tool to keep,
+`PerformThruNext`, `PerformUntilEnd`, the ranged `Perform(Radius, PFrom, PTo)` and `PerformBlind`,
+all drive `BRepFeat_Builder` with the wrong operation:
+
+```cpp
+SetOperation(Fuse);        // -> BOPAlgo_CUT
+BOPAlgo_BOP::Perform();    // myShape := object CUT tool
+PartsOfTool(parts);        // explores myShape for solids
+... KeepPart(chosen) ...
+```
+
+`BRepFeat_Builder::PartsOfTool()` collects the solids of `myShape`, which is only the tool split by
+the object after the `BOPAlgo_COMMON` pass. After a `BOPAlgo_CUT`, `myShape` is the finished
+workpiece. So the selection loops compare barycentres of the cut result itself and then register
+those pieces as "kept parts of the tool." `PerformResult()` takes the kept-parts path with a keep
+set containing no tool part at all, and returns the object with the cylinder's faces imprinted on
+it and no material removed, reporting `BRepFeat_NoError` throughout.
+
+The other two users of the same builder already do this correctly. `BRepFeat_Form`
+(`BRepFeat_Form.cxx:806`) and `BRepFeat_RibSlot` (`BRepFeat_RibSlot.cxx:224`) both call the
+two-argument `SetOperation(myFuse, bFlag)` with `bFlag` true before `Perform()`, so
+`BOPAlgo_COMMON` runs and `PartsOfTool()` means what its name says. `PerformResult()` re-derives
+`myOperation` from `myFuse`, so the operation finally built is the cut either way.
+`BRepFeat_MakeCylindricalHole` calls the one-argument overload at all five sites.
+
+## Fix
+
+The two-argument call at the four part-selecting sites. `Perform(Radius)`, the infinite-cylinder
+through-all, selects no parts and never calls `PartsOfTool()`; it stays on the one-argument
+overload, which is why it was the one mode that already drilled a stack correctly and why the
+defect reads as "multi-body" rather than "part selection."
+
+## Reproducer
+
+The defect is invisible whenever the cut result happens to have one solid, the single-plate case
+every existing test uses. It appears as soon as it has two: a drill axis crossing two bodies of a
+compound, or, with no compound involved, a single bar the bore severs in half.
+
+Two 50x50x20 plates stacked on the drill axis (plate A at axis parameters 5..25, plate B at
+45..65), drilled at `r = 5` from `(0, 0, 15)` along `-Z`. One plate's bore removes `1570.7963`:
+
+```cpp
+TopoDS_Shape plates = /* compound of the two boxes */;
+TopoDS_Shape tool   = BRepPrimAPI_MakeCylinder(gp_Ax2(gp_Pnt(0, 0, 60), -gp::DZ()), 5.0, 60.0);
+BRepFeat_MakeCylindricalHole mkHole;
+mkHole.Init(plates, tool);
+mkHole.PerformUntilEnd();
+// before: BRepFeat_NoError, 0 volume removed
+// after:  BRepFeat_NoError, 3141.5927 removed (two 20mm bores)
+```
+
+| call | status | before | after |
+|---|---|---|---|
+| `Perform(R)` | `NoError` | 3141.5927 | 3141.5927 (unaffected) |
+| `PerformUntilEnd` | `NoError` | 0.0000 | 3141.5927 |
+| `PerformThruNext` | `NoError` | 1570.7963 | 1570.7963 |
+| `PerformBlind(20)` | `NoError` | 0.0000 | 1178.0972 |
+| `Perform(R, 0, 70)` | `NoError` | 0.0000 | 3141.5927 |
+| `Perform(R, 0, 30)` | `NoError` | 1570.7963 | 1570.7963 |
+| `Perform(R, 30, 70)` | `NoError` | 1570.7963 | 1570.7963 |
+
+And on a single 8mm-wide bar an `r = 5` bore severs, where "parts" was two pieces of one workpiece
+rather than two bodies:
+
+| call | status | before | after |
+|---|---|---|---|
+| `PerformUntilEnd` | `NoError` | 0.0000 | 1407.2952 |
+| `PerformThruNext` | `NoError` | 0.0000 | 1407.2952 |
+| `Perform(R, 0, 30)` | `NoError` | 0.0000 | 1407.2952 |
+
+A single plate (one solid before and after the cut) is byte-identical before and after this patch:
+`nbparts` is 1, and the selection branch never ran either way.
+
+## Behavior change beyond the bug
+
+A radius so large the bore swallows the whole workpiece (`r = 100` on a 50mm plate): under the old
+`BOPAlgo_CUT` path this emptied `myShape`, so `nbparts` was 0 and `PerformUntilEnd`/`PerformThruNext`
+returned `BRepFeat_InvalidPlacement`. Under `BOPAlgo_COMMON` the tool meets the whole workpiece,
+`nbparts` is 1, and both modes now return the same empty result `Perform(Radius)` and a plain
+`BRepAlgoAPI_Cut` against the same cylinder already returned. `nbparts == 0` now means what the
+"the tool meets nothing" guard reads as.
+
+## Note: a related, separate defect in the same heuristic, not touched by this PR
+
+`PerformThruNext`'s closest-interval fallback (`BRepFeat_MakeCylindricalHole.cxx:217-242`, used
+when no candidate part's barycentre lies in `[First, Last]`) has a misplaced brace: the
+`// parbar > Last` branch is nested inside `if (parbar < First)` as its `else`, so the "beyond
+`Last`" case is unreachable as written. `PerformBlind`'s equivalent fallback
+(`BRepFeat_MakeCylindricalHole.cxx:602-616`) has no such structure and compares
+`std::abs(First - parbar)` uniformly. No geometry in the reproducer above reaches this fallback (it
+only runs when the barycentre test above finds nothing in range), so this is reported for
+visibility rather than fixed here; happy to open a separate PR once there's a case to measure it
+against.
+
+## Validation
+
+`Scripts/repro/532-cylindrical-hole-part-selection/` in the downstream OCCTSwift wrapper (issue
+#532 there) measures every mode across six geometries, before and after: the two tables above, plus
+a three-plate compound (`PerformUntilEnd` 0.0000 -> 4712.3890) and two geometries whose *inputs* to
+the selection loop change (one solid to two real tool parts) while the *answer* does not, which is
+the non-regression evidence that matters (a channel and a hollow box, both one solid with multiple
+axis crossings). Full downstream test suite clean against a production rebuild of the patched
+kernel.

--- a/Scripts/repro/657-upstream-pr-status/verify.sh
+++ b/Scripts/repro/657-upstream-pr-status/verify.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# #657: re-verify the ten upstream OCCT PR statuses and patch 0020's fileability.
+#
+# Does two independent things per patch, neither of which trusts GitHub's own
+# "Update branch" banner or the state recorded in issue #657:
+#
+#   1. Queries the GitHub API directly for each PR's actual state/merged/mergeable
+#      flags, review comments and CI status (a status claim is only as good as the
+#      last time someone checked it; see okf's "verify external status claims"
+#      lesson).
+#   2. Applies this repo's own carried .patch file to a fresh, unmodified checkout
+#      of upstream OCCT's CURRENT master tip and checks it applies without a single
+#      rejected hunk. This is a stronger claim than GitHub's `mergeable` flag: it
+#      proves OUR patch file (not just the PR branch, which may have drifted from
+#      it) still matches current upstream source byte-for-byte in context.
+#
+# Requires: gh (authenticated), git, network access to github.com. Read-only:
+# makes no upstream writes, no comments, no PR/issue mutations of any kind.
+#
+# Usage: Scripts/repro/657-upstream-pr-status/verify.sh [scratch-dir]
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRATCH="${1:-$(mktemp -d)}"
+PATCH_DIR="$REPO_ROOT/Scripts/patches"
+
+echo "Scratch dir: $SCRATCH"
+mkdir -p "$SCRATCH"
+
+# our_patch_file:pr_number pairs for the ten patches issue #657 lists, plus 0020
+# (not upstream-filed, checked for fileability rather than PR status).
+PAIRS=(
+  "0010-Intf_Interference-O1-tangent-zone-checkpoint-breaker-319.patch:1386"
+  "0011-XCAFDoc_ShapeTool-AutoNamingScope-341.patch:1388"
+  "0012-CDF_Directory-XCAFApp_Application-thread-safety-344.patch:1390"
+  "0014-CDF-driver-reentrancy-mutex-349.patch:1394"
+  "0015-CDM_Application-metadata-lookup-table-mutex-353.patch:1397"
+  "0016-Resource_Manager-atomic-Debug-Storage_Schema-per-instance-374.patch:1399"
+  "0017-null-reshape-context-ComposeShell-WireDivide-484.patch:1410"
+  "0018-GCPnts-degenerate-count-and-duplicate-end-point-555.patch:1417"
+  "0019-AdvApp2Var-jacobi-max-wrong-workspace-slot-522.patch:1418"
+  "0021-CPnts-adaptive-arc-length-integration-603.patch:1420"
+)
+
+echo
+echo "== Step 1: live PR status from the GitHub API =="
+printf '%-70s %-6s %-6s %-8s %-10s %-8s %-8s\n' "patch" "PR" "state" "merged" "mergeable" "comments" "reviews"
+for pair in "${PAIRS[@]}"; do
+  patch="${pair%%:*}"
+  pr="${pair##*:}"
+  json=$(gh api "repos/Open-Cascade-SAS/OCCT/pulls/$pr" --jq '{state, merged, mergeable, comments, review_comments}')
+  state=$(echo "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
+  merged=$(echo "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["merged"])')
+  mergeable=$(echo "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["mergeable"])')
+  comments=$(echo "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["comments"])')
+  reviews=$(echo "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["review_comments"])')
+  printf '%-70s %-6s %-6s %-8s %-10s %-8s %-8s\n' "$patch" "$pr" "$state" "$merged" "$mergeable" "$comments" "$reviews"
+done
+
+echo
+echo "== Step 2: sparse checkout of upstream OCCT master tip =="
+if [ ! -d "$SCRATCH/occt-master" ]; then
+  git clone --filter=blob:none --no-checkout --depth 100 \
+    https://github.com/Open-Cascade-SAS/OCCT.git "$SCRATCH/occt-master"
+  (cd "$SCRATCH/occt-master" && git sparse-checkout init --cone && git sparse-checkout set \
+    src/ModelingAlgorithms/TKBO/BOPAlgo \
+    src/ModelingAlgorithms/TKGeomAlgo/Intf \
+    src/ModelingAlgorithms/TKGeomAlgo/GTests \
+    src/DataExchange/TKDEGLTF/RWGltf \
+    src/DataExchange/TKRWMesh/RWMesh \
+    src/DataExchange/TKXCAF/XCAFDoc \
+    src/DataExchange/TKXCAF/XCAFApp \
+    src/ApplicationFramework/TKCDF/CDF \
+    src/ApplicationFramework/TKCDF/PCDM \
+    src/ApplicationFramework/TKCDF/CDM \
+    src/ApplicationFramework/TKLCAF/TDocStd \
+    src/ApplicationFramework/TKXmlL/XmlLDrivers \
+    src/FoundationClasses/TKernel/Resource \
+    src/FoundationClasses/TKernel/Storage \
+    src/ModelingAlgorithms/TKShHealing/ShapeFix \
+    src/ModelingAlgorithms/TKShHealing/ShapeUpgrade \
+    src/ModelingData/TKGeomBase/GCPnts \
+    src/ModelingData/TKGeomBase/AdvApp2Var \
+    src/ModelingData/TKGeomBase/CPnts \
+    src/ModelingAlgorithms/TKFeat/BRepFeat \
+    && git checkout master)
+fi
+echo "master tip: $(git -C "$SCRATCH/occt-master" log -1 --format='%H %ci')"
+
+echo
+echo "== Step 3: does our carried patch file still apply cleanly to that tip? =="
+for pair in "${PAIRS[@]}" "0020-BRepFeat_MakeCylindricalHole-select-tool-parts-532.patch:(not filed)"; do
+  patch="${pair%%:*}"
+  pr="${pair##*:}"
+  rm -rf "$SCRATCH/check"
+  cp -R "$SCRATCH/occt-master" "$SCRATCH/check"
+  if (cd "$SCRATCH/check" && git apply --check -p1 "$PATCH_DIR/$patch" 2>"$SCRATCH/err.txt"); then
+    echo "OK      $patch (PR $pr) applies with zero rejected hunks"
+  else
+    echo "FAILED  $patch (PR $pr):"
+    sed 's/^/        /' "$SCRATCH/err.txt"
+  fi
+done
+
+echo
+echo "Done. This does not modify, comment on, or push to Open-Cascade-SAS/OCCT in any way."


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Housekeeping for #657: ten of our carried OCCT patches (`0010`-`0012`, `0014`-`0021`) each have
an open upstream PR that was authored against a pre-8.0.1 base, and patch `0020` has never been
filed upstream at all. Rather than trust the issue's own status table, re-verified everything
against the GitHub API and a throwaway clone of upstream `master`. **This PR makes no upstream
writes** (per the task's hard constraint): no comment, edit, push or close against
`Open-Cascade-SAS/OCCT` or any fork of it. Everything below is a prepared, verified assessment
for a human to act on.

Headline findings, full detail in
[`Scripts/repro/657-upstream-pr-status/README.md`](Scripts/repro/657-upstream-pr-status/README.md):

- All ten PRs are confirmed still open, with green CI (17 checks, 1 skipped, on every head
  commit). Nothing has silently merged or closed.
- **None of the ten needs a conflict-resolving rebase.** `git apply --check` of every carried
  `.patch` file against the current upstream `master` tip succeeds with zero rejected hunks.
  `master` has moved by at most 5 commits since any of these PRs' base, by zero for three of
  them, and none of those commits touches a file any of the ten patches touches. "Rebase" here
  is GitHub's cosmetic out-of-date banner, not an actual conflict.
- **The issue's claim about `0016`/OCCT#1399 is wrong.** It states the PR "was never updated" to
  the per-instance-field design maintainer review asked for. The PR's own comment thread shows
  that update was pushed on 2026-07-30, three days before #657 was filed, and the live diff is
  byte-identical to what this repo already carries.
- `0011`/OCCT#1388 has diverged from our locally-carried patch in comment style only (OCCT's
  terse house style on the live PR vs. our own verbose doc-comment voice locally), which
  `okf/policies/upstream-occt-style.md` says is expected, not a defect.
- **Two PRs carry real, unanswered maintainer feedback**: OCCT#1417 (three small requested
  changes, 4 days unanswered) and OCCT#1418 (regression provenance plus a DRAW repro script from
  the maintainer, 7 days unanswered). Both need a human reply.
- **Patch `0020` is fileable**: still applies cleanly to current `master`, its reproducer
  compiles and runs against the pinned kernel with output matching the documented post-fix
  values exactly, and the patched file needs no `clang-format` changes against OCCT's own style
  file. Drafted the PR title/body in
  [`Scripts/repro/657-upstream-pr-status/draft-0020-pr.md`](Scripts/repro/657-upstream-pr-status/draft-0020-pr.md),
  ready to send, not sent. Per `okf/policies/upstream-occt-style.md` and the precedent set by
  `0018`/`0019`/`0021`, recommends no companion issue, and recommends the second, unfixed
  defect in the same heuristic ride along as a prose note rather than a code change, since no
  reproduced case reaches it.

`Scripts/repro/657-upstream-pr-status/verify.sh` reproduces the live-status and apply-check
findings read-only; re-run it if time has passed since this audit.

Touches only `Scripts/` (new `Scripts/repro/657-upstream-pr-status/` directory); no `Sources/`
or `Tests/` files changed, and `docs/CHANGELOG.md` is untouched per
[`okf/policies/changelog-on-merge.md`](okf/policies/changelog-on-merge.md) (entry below instead).

Ref #657. Not closing it: the upstream actions it describes (responding to reviewers, updating
PR base branches, filing `0020`) are still undone and need a maintainer's own credentials to do.

## CHANGELOG entry

### Verified the status of ten open upstream OCCT PRs and assessed patch 0020 for filing (#657)

Re-verified all ten upstream OCCT PRs behind our pre-8.0.1-base carried patches (`0010`-`0012`,
`0014`-`0021`) against the GitHub API rather than trusting recorded status: all ten remain open
with green CI, none needs a conflict-resolving rebase (each patch still applies to current
upstream `master` with zero rejected hunks), and the belief that OCCT#1399 (patch `0016`) still
needed its `Storage_Schema` fix updated to match maintainer review was already stale, that update
shipped three days before it was recorded. Flagged OCCT#1417 and OCCT#1418 as carrying unanswered
maintainer feedback. Confirmed carried patch `0020` (`BRepFeat_MakeCylindricalHole` part
selection, #532), still unfiled upstream, is ready to submit: still applies, its reproducer runs
and matches its documented post-fix measurements, and it needs no reformatting against OCCT's own
`.clang-format`. Drafted the upstream PR text; no upstream issue, PR, comment or push was made.
See `Scripts/repro/657-upstream-pr-status/`.

## Checklist

- [x] This is an investigation/verification deliverable, not a behavior change; no new production
      code path exists to unit-test. `Scripts/repro/657-upstream-pr-status/verify.sh` is the
      re-runnable check backing every claim in the write-up, and was run end-to-end during this
      PR (see the PR description above for its output).

## Notes for the reviewer

- Hard constraint honored throughout: no push, comment, edit, close or PR/issue creation against
  `Open-Cascade-SAS/OCCT` or any fork. `draft-0020-pr.md` is text only, for a human to paste.
- The `0016`/OCCT#1399 finding means #657's own body has a stale claim; left uncorrected there
  since editing another issue's text wasn't asked for, but worth a maintainer's one-line comment
  on #657 itself if that seems useful.
- Ran the repo's five static gate scripts (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `derive-bridge-header-split --verify`, `count-operations`) locally; all
  clean, as expected for a `Scripts/`-only change. GitHub Actions is reportedly in a major
  outage, so CI may not report on this PR; this is the local verification in its place.
