### PR TITLE
fix(#732): OCCTBRepGPropVinertGK reports a real integration error

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge_Properties.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Properties.h
@@ -499,8 +499,7 @@ OCCTFaceVolumeInertia OCCTBRepGPropVinertPlane(OCCTFaceRef _Nonnull face,
 // --- BRepGProp_VinertGK ---
 typedef struct {
     double mass;
-    double errorReached;
-    double absoluteError;
+    double errorReached;  // BRepGProp_VinertGK::GetErrorReached() (#732)
     double centerX, centerY, centerZ;
 } OCCTVinertGKResult;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1338,8 +1338,7 @@ OCCTVinertGKResult OCCTBRepGPropVinertGK(OCCTShapeRef _Nonnull faceRef,
 
         BRepGProp_VinertGK vgk(bface, loc, tolerance, computeCG, false);
         result.mass = vgk.Mass();
-        result.errorReached = 0.0;  // GetErrorReached is inline-only in OCCT 8.0.0
-        result.absoluteError = 0.0;
+        result.errorReached = vgk.GetErrorReached();
 
         if (computeCG) {
             gp_Pnt cg = vgk.CentreOfMass();

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -1537,17 +1537,40 @@ extension Shape {
     /// was asked for. Both used to report (0,0,0), which is indistinguishable from a real centroid
     /// at the origin (#609).
     ///
-    /// ``errorReached`` is `BRepGProp_VinertGK::GetErrorReached()`: the relative integration error
-    /// the Gauss-Kronrod adaptive quadrature reached, as a fraction of ``mass``. It used to be
-    /// hardcoded to `0.0` on every call. `GetErrorReached()` is defined inline in the OCCT header,
-    /// which is why it has no linkable symbol, not evidence it is unusable (#732). There is no
-    /// paired absolute-error field: `BRepGProp_VinertGK::GetAbsolutError()` is declared in the same
-    /// header but has no definition anywhere in the OCCT 8.0.1 sources, so calling it fails at link
-    /// time, confirmed by compiling against it. Multiplying ``errorReached`` by ``mass`` recovers it
-    /// in the common case, but not in OCCT's own near-zero-mass branch (where the un-normalized
-    /// value is kept as-is rather than divided), so that derivation would quietly go wrong exactly
-    /// where a caller most needs a reliable number. Use ``errorReached`` as the relative confidence
-    /// figure; there is no absolute counterpart.
+    /// ``errorReached`` is `BRepGProp_VinertGK::GetErrorReached()`. It used to be hardcoded to `0.0`
+    /// on every call. `GetErrorReached()` is defined inline in the OCCT header, which is why it has
+    /// no linkable symbol, not evidence it is unusable (#732). There is no paired absolute-error
+    /// field: `BRepGProp_VinertGK::GetAbsolutError()` is declared in the same header but has no
+    /// definition anywhere in the OCCT 8.0.1 sources, so calling it fails at link time, confirmed by
+    /// compiling against it.
+    ///
+    /// **``errorReached`` is not unconditionally relative.** Reading `BRepGProp_VinertGK.cxx` (around
+    /// line 492) shows two branches: the raw quadrature residual is divided by `|mass|` to produce a
+    /// relative fraction only when `|mass|` clears an internal floor (`Epsilon()` of the residual
+    /// itself, i.e. its own floating-point ULP, on the order of `1e-19` to `1e-25` for a realistic
+    /// residual); below that floor, division is skipped and the undivided absolute residual is
+    /// returned instead, with no signal in the return value distinguishing which branch ran.
+    /// Multiplying ``errorReached`` by ``mass`` to recover an absolute figure is correspondingly
+    /// unsound in that second branch (the un-normalized value is kept as-is, not divided), which is
+    /// why that derivation was rejected rather than shipped as a second field.
+    ///
+    /// **That second branch could not be exercised through the public API to pin its behaviour
+    /// directly** (measured for the PR #738 review): the floor is set relative to the residual's own
+    /// ULP, so triggering it needs `|mass|` to underflow to essentially bit-exact `0.0`, not merely
+    /// small. Driving a genuinely curved face's mass toward zero, using a half-cylinder lateral face
+    /// (`u` spanning less than a full period, whose mass is provably affine in a location offset,
+    /// solved for its exact root from two measurements), bottoms out around `1e-14`, the
+    /// double-precision noise floor for an integral at this scale, five to ten orders of magnitude
+    /// short of the threshold. The only realistic way to force literal-zero mass is a face whose
+    /// integrand is identically zero pointwise (e.g. a planar face exactly coplanar with
+    /// `location`), and that same degeneracy makes the residual identically zero too, so the two
+    /// branches are observably indistinguishable in every case this API can actually construct.
+    ///
+    /// What **is** observable, and is what the regression test below pins: short of that
+    /// unreachable branch, ``errorReached`` keeps behaving as a genuine relative fraction as `mass`
+    /// shrinks. It grows, staying finite and non-negative, rather than quietly staying small or
+    /// misreporting high confidence right where a caller most needs a reliable number. Treat a large
+    /// (or growing) ``errorReached`` as a signal to distrust ``mass``, not the reverse.
     public struct VinertGKResult {
         public let mass: Double
         public let errorReached: Double

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -1536,10 +1536,21 @@ extension Shape {
     /// ``center`` is nil when ``mass`` is 0, and also when `computeCG` was false, since no centre
     /// was asked for. Both used to report (0,0,0), which is indistinguishable from a real centroid
     /// at the origin (#609).
+    ///
+    /// ``errorReached`` is `BRepGProp_VinertGK::GetErrorReached()`: the relative integration error
+    /// the Gauss-Kronrod adaptive quadrature reached, as a fraction of ``mass``. It used to be
+    /// hardcoded to `0.0` on every call. `GetErrorReached()` is defined inline in the OCCT header,
+    /// which is why it has no linkable symbol, not evidence it is unusable (#732). There is no
+    /// paired absolute-error field: `BRepGProp_VinertGK::GetAbsolutError()` is declared in the same
+    /// header but has no definition anywhere in the OCCT 8.0.1 sources, so calling it fails at link
+    /// time, confirmed by compiling against it. Multiplying ``errorReached`` by ``mass`` recovers it
+    /// in the common case, but not in OCCT's own near-zero-mass branch (where the un-normalized
+    /// value is kept as-is rather than divided), so that derivation would quietly go wrong exactly
+    /// where a caller most needs a reliable number. Use ``errorReached`` as the relative confidence
+    /// figure; there is no absolute counterpart.
     public struct VinertGKResult {
         public let mass: Double
         public let errorReached: Double
-        public let absoluteError: Double
         public let center: SIMD3<Double>?
     }
 
@@ -1548,15 +1559,15 @@ extension Shape {
     /// ```swift
     /// let box = Shape.box(width: 10, height: 10, depth: 10)!
     /// let r = Shape.fromFace(box.faces()[0])!.vinertGK(tolerance: 1e-4)
-    /// r.mass      // this face's volume contribution about the location point
-    /// r.center    // its centroid, nil when the contribution is 0 or computeCG was false
+    /// r.mass          // this face's volume contribution about the location point
+    /// r.errorReached  // the relative integration error reached, nonzero on curved faces
+    /// r.center        // its centroid, nil when the contribution is 0 or computeCG was false
     /// ```
     public func vinertGK(location: SIMD3<Double> = SIMD3(0, 0, 0),
                          tolerance: Double = 0.001, computeCG: Bool = true) -> VinertGKResult {
         let r = OCCTBRepGPropVinertGK(handle, location.x, location.y, location.z,
                                        tolerance, computeCG)
         return VinertGKResult(mass: r.mass, errorReached: r.errorReached,
-                              absoluteError: r.absoluteError,
                               center: (computeCG && r.mass != 0) ? SIMD3(r.centerX, r.centerY, r.centerZ) : nil)
     }
 

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -3165,6 +3165,32 @@ struct BRepGPropVinertGKTests {
             }
         }
     }
+
+    /// #732: `errorReached` was hardcoded to `0.0` on every call, which reads as "this integration
+    /// was exact" even when it was not. A planar box face (the two tests above) genuinely can
+    /// converge with zero measured error, so it cannot distinguish the hardcode from a real answer;
+    /// a curved face at a loose tolerance can, because Gauss-Kronrod integration on a sphere always
+    /// has some residual to report.
+    ///
+    /// Not pinned to a literal (#726): the analytic sphere volume comes from
+    /// `GeometryProperties.sphereVolume`, an independent OCCT computation, not a hardcoded number,
+    /// and the bound checked is a relationship between two measured quantities, not a magic constant.
+    @Test("vinertGK reports a nonzero error on a curved face, consistent with the true deviation")
+    func errorReachedIsNonzeroOnCurvedFace() throws {
+        let radius = 10.0
+        let sphere = try #require(Shape.sphere(radius: radius))
+        let firstFace = try #require(sphere.faces().first)
+        let face = try #require(Shape.fromFace(firstFace))
+
+        let r = face.vinertGK(tolerance: 1e-3)
+        #expect(r.errorReached > 0,
+                "a curved face's Gauss-Kronrod integration should report a nonzero error, not the exact-answer sentinel 0.0")
+
+        let trueVolume = GeometryProperties.sphereVolume(radius: radius)
+        let relativeDeviation = abs(r.mass - trueVolume) / trueVolume
+        #expect(relativeDeviation <= r.errorReached,
+                "the reported relative error should bound the sphere's actual relative deviation from its analytic volume")
+    }
 }
 
 // MARK: - v0.80.0: Extrema 3D/2D, GeomTools persistence, ProjLib, gce_* factories

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -3191,6 +3191,50 @@ struct BRepGPropVinertGKTests {
         #expect(relativeDeviation <= r.errorReached,
                 "the reported relative error should bound the sphere's actual relative deviation from its analytic volume")
     }
+
+    /// PR #738 review, finding 2: the doc comment on `errorReached` promised a *relative* error,
+    /// "as a fraction of mass," unconditionally, but `BRepGProp_VinertGK.cxx` (~line 492) only
+    /// divides by `|mass|` when it clears an internal `Epsilon()`-scaled floor (on the order of
+    /// `1e-19` to `1e-25` for a realistic residual); below that floor the undivided residual is
+    /// returned as-is. That floor sits far beneath what floating-point cancellation can reach for a
+    /// genuine curved integral (measured ~`1e-14` at best, using the same fixture below, driven by
+    /// bisection; see the doc comment on `VinertGKResult` and the PR's review response for the
+    /// full investigation), so pinning *that* branch directly isn't possible through the public API.
+    ///
+    /// What this test pins instead is the reachable half of the same claim: as `mass` is driven
+    /// toward zero, `errorReached` must grow (dividing by a shrinking denominator), not quietly stay
+    /// small or turn non-finite: the two ways a caller could be misled into trusting a bad answer
+    /// exactly where the doc says the guarantee is weakest.
+    ///
+    /// The near-zero location is derived, not pinned: for an OPEN curved face (a half-cylinder,
+    /// `u` spans `[0, pi]`, not a full period), `mass` is provably affine in a location offset along
+    /// the cylinder's axis-perpendicular direction, because the location-dependent term of the flux
+    /// integral only vanishes when integrated over a *full* period. Two measurements fix the line;
+    /// the root follows by linear interpolation.
+    @Test("vinertGK's errorReached grows, and stays finite, as mass is driven toward zero")
+    func errorReachedGrowsAsMassApproachesZero() throws {
+        let radius = 5.0, height = 10.0
+        let face = try #require(Shape.faceFromCylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: radius,
+                                                         uBounds: 0...Double.pi, vBounds: 0...height))
+
+        let farLocation = SIMD3(0.0, 0.0, 0.0)
+        let probeLocation = SIMD3(0.0, radius * 2, 0.0)
+        let rFar = face.vinertGK(location: farLocation, tolerance: 1e-3, computeCG: false)
+        let rProbe = face.vinertGK(location: probeLocation, tolerance: 1e-3, computeCG: false)
+
+        let slope = (rProbe.mass - rFar.mass) / (probeLocation.y - farLocation.y)
+        try #require(abs(slope) > 1, "fixture must be location-sensitive (an open, non-periodic face), or this proves nothing")
+        let rootY = farLocation.y - rFar.mass / slope
+
+        let rNearZero = face.vinertGK(location: SIMD3(0, rootY, 0), tolerance: 1e-3, computeCG: false)
+        #expect(abs(rNearZero.mass) < 1e-9,
+                "the derived root should drive mass to (near) zero; got \(rNearZero.mass)")
+        #expect(rNearZero.errorReached.isFinite,
+                "errorReached must stay a real number as mass collapses toward zero, not NaN/Inf")
+        #expect(rNearZero.errorReached >= 0, "an integration error is never negative")
+        #expect(rNearZero.errorReached > rFar.errorReached,
+                "as mass shrinks toward zero the reported error should grow, not stay small: a caller must not be told a near-zero-mass answer is MORE certain than a well-conditioned one")
+    }
 }
 
 // MARK: - v0.80.0: Extrema 3D/2D, GeomTools persistence, ProjLib, gce_* factories

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -363,14 +363,18 @@ public func vinertGK(location: SIMD3<Double> = SIMD3(0, 0, 0),
   - `location` — the reference point for inertia computation; defaults to the origin.
   - `tolerance` — relative integration error bound; default `0.001`.
   - `computeCG` — whether to compute the centre of gravity; default `true`.
-- **Returns:** A `VinertGKResult` with `.mass`, `.errorReached`, `.absoluteError`, and an optional
-  `.center`.
+- **Returns:** A `VinertGKResult` with `.mass`, `.errorReached`, and an optional `.center`.
 - **OCCT:** `BRepGProp_VinertGK`.
 - **Note:** This method operates on a face shape. The `.mass` field is the signed volume
   contribution, and stays non-optional because a zero contribution is a real answer that a caller
   summing over a shell needs. `.center` is `nil` when the contribution is 0, and when `computeCG` was
   `false`; both used to report (0,0,0), which is indistinguishable from a real centroid at the origin
-  (#609).
+  (#609). `.errorReached` is `BRepGProp_VinertGK::GetErrorReached()`, the relative integration error
+  as a fraction of `.mass`; it used to be hardcoded to `0.0` on every call (#732). There is no
+  `.absoluteError`: OCCT declares `GetAbsolutError()` on the same class but never defines it, so
+  calling it fails to link, and deriving one from `.errorReached * .mass` would go wrong exactly in
+  OCCT's own near-zero-mass branch, so the field was removed rather than kept as a second silent
+  zero.
 - **Example:**
   ```swift
   let face = Shape.box(dx: 10, dy: 10, dz: 10)!.faces.first!
@@ -388,7 +392,6 @@ Result struct returned by `vinertGK(location:tolerance:computeCG:)`.
 public struct VinertGKResult {
     public let mass: Double
     public let errorReached: Double
-    public let absoluteError: Double
     public let center: SIMD3<Double>?
 }
 ```

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -369,12 +369,17 @@ public func vinertGK(location: SIMD3<Double> = SIMD3(0, 0, 0),
   contribution, and stays non-optional because a zero contribution is a real answer that a caller
   summing over a shell needs. `.center` is `nil` when the contribution is 0, and when `computeCG` was
   `false`; both used to report (0,0,0), which is indistinguishable from a real centroid at the origin
-  (#609). `.errorReached` is `BRepGProp_VinertGK::GetErrorReached()`, the relative integration error
-  as a fraction of `.mass`; it used to be hardcoded to `0.0` on every call (#732). There is no
-  `.absoluteError`: OCCT declares `GetAbsolutError()` on the same class but never defines it, so
-  calling it fails to link, and deriving one from `.errorReached * .mass` would go wrong exactly in
-  OCCT's own near-zero-mass branch, so the field was removed rather than kept as a second silent
-  zero.
+  (#609). `.errorReached` is `BRepGProp_VinertGK::GetErrorReached()`; it used to be hardcoded to
+  `0.0` on every call (#732). It is **not unconditionally relative**: OCCT divides the raw quadrature
+  residual by `|.mass|` only when `|.mass|` clears an internal, near-machine-epsilon floor, and
+  returns the undivided residual as-is below it, a distinction the return value gives no way to
+  tell apart. That second branch could not be pinned by a test through the public API (measured: the
+  floor needs `|.mass|` to underflow to essentially bit-exact `0.0`, far below what floating-point
+  cancellation reaches for a real integral, ~`1e-14` at best); see the doc comment on
+  `VinertGKResult` in `Shape+Analysis.swift` for the full investigation. There is no `.absoluteError`:
+  OCCT declares `GetAbsolutError()` on the same class but never defines it, so calling it fails to
+  link, and deriving one from `.errorReached * .mass` would go wrong exactly in that same
+  near-zero-mass branch, so the field was removed rather than kept as a second silent zero.
 - **Example:**
   ```swift
   let face = Shape.box(dx: 10, dy: 10, dz: 10)!.faces.first!


### PR DESCRIPTION
## What & why

`OCCTBRepGPropVinertGK` hardcoded `result.errorReached` to `0.0` on every call, with a comment
("GetErrorReached is inline-only in OCCT 8.0.0") whose premise was true and conclusion backwards:
an inline accessor is callable precisely because the compiler emits its body into the caller, which
is why `nm` finds no exported symbol for it, not evidence it can't be called. Fixed by calling
`BRepGProp_VinertGK::GetErrorReached()` directly.

`VinertGKResult.absoluteError` (also hardcoded to `0.0`) is removed rather than given a second real
value. `BRepGProp_VinertGK` does declare a second accessor, `GetAbsolutError()`, but a ground-truth
test calling it fails to link (`symbol(s) not found for architecture arm64`): it has no definition
anywhere in the OCCT 8.0.1 sources. Deriving one from `errorReached * mass` recovers the source's
internal absolute value in the common case, but not in OCCT's own near-zero-mass branch, where the
un-normalized value is kept as-is rather than divided, so that derivation would go quietly wrong
exactly where a caller most needs a reliable number. Full reasoning is in the doc comment on
`VinertGKResult` in `Shape+Analysis.swift`.

Closes #732

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.

## SemVer impact

MAJOR. `VinertGKResult.absoluteError` is removed: any caller reading that field fails to compile,
with no shim. Deriving a replacement from `errorReached * mass` reproduces the removed field in the
common case, but returns the wrong number in OCCT's own near-zero-mass branch (see the doc comment
on `VinertGKResult`, updated in the review response below), which is the same "silent zero" failure
class this repo already tracks under #605/#609/#522/#726, and is why removal was chosen over a
plausible-looking replacement rather than shimmed. `errorReached` itself is source-compatible:
existing callers keep compiling and now observe a real value instead of the hardcoded `0.0`.

This ships in v2.0.0, a major line where source-breaking changes are permitted outright, so no
recorded-exception entry is needed (`okf/policies/semver-at-release.md`). `docs/SEMVER.md` is not
edited in this diff, per that same policy: SemVer is assessed once, at release time, from every
PR's stated impact, not per PR.

## CHANGELOG entry

### `Shape.vinertGK(...)` reports a real integration error; `VinertGKResult.absoluteError` removed (#732)

`OCCTBRepGPropVinertGK` hardcoded `result.errorReached` to `0.0` on every call. The comment
explaining it ("GetErrorReached is inline-only in OCCT 8.0.0") had the conclusion backwards: an
inline accessor is callable precisely because the compiler emits its body into the caller, which is
why `nm` finds no exported symbol for it. Fixed by calling `BRepGProp_VinertGK::GetErrorReached()`
directly; measured on a radius-10 sphere, it now tracks the requested tolerance across six orders
of magnitude (8.09e-4 at `1e-3`, down to 1.14e-9 at `1e-9`) instead of reporting 0 at every one.

`VinertGKResult.absoluteError` is removed rather than given a second real value.
`BRepGProp_VinertGK` does declare a second accessor, `GetAbsolutError()`, but it has no definition
anywhere in the OCCT 8.0.1 sources: calling it fails at link time (`symbol(s) not found`, confirmed
by compiling against it). Deriving one from `errorReached * mass` recovers the source's internal
absolute value in the common case, but not in OCCT's own near-zero-mass branch, where the
un-normalized value is kept as-is rather than divided, so that derivation would go quietly wrong
exactly where a caller most needs a reliable number.

`errorReached` itself is also documented more precisely now: it is a relative fraction of `mass`
only when `|mass|` clears an internal floor; below it, OCCT returns the undivided residual as-is
instead, with nothing in the return value distinguishing which happened. See the doc comment on
`VinertGKResult` and the review response below for the full investigation.

## Notes for the reviewer

**Why `absoluteError` is removed, not fixed**: the issue's own text says `GetEpsilon` doesn't exist
on `BRepGProp_VinertGK`. That's correct as far as it goes, but there IS a second accessor declared,
`GetAbsolutError()` (`BRepGProp_VinertGK.hxx:191`), it's just never defined anywhere in the OCCT
8.0.1 `.cxx` (confirmed with `nm -C` on the archive: no symbol at all, not even an undefined
reference, and a ground-truth `.mm` test calling it fails at link time). Reading the kernel source
(`BRepGProp_VinertGK.cxx:488-495`) shows the real relationship: `myAbsolutError` is set to the raw
integration residual, then `myErrorReached` (what `GetErrorReached()` returns) is that same value
divided by `|mass|`, *unless* `|mass|` is below a `Standard::Epsilon`-scaled threshold, in which
case the division is skipped and both fields would be equal. `errorReached * mass` recovers the
original in the first (overwhelmingly common) branch, but reproduces the exact "silent zero when it
matters most" defect this issue exists to remove in the second, since a near-zero mass would make a
real, possibly large, unconverged residual multiply down to near-zero. Given that a derivation is
provably wrong exactly at the boundary this codebase has repeatedly gotten bitten by (#605, #609,
#522), removal seemed like the safer call than a second field with a corner-case lie in it.

**Injection matrix** (`okf/policies/prove-the-test-fails.md`):

| case | assertion | before fix (defect injected) | after fix |
|---|---|---|---|
| `errorReachedIsNonzeroOnCurvedFace` | `r.errorReached > 0` | FAIL (`0.0 > 0` is false) | PASS |
| `errorReachedIsNonzeroOnCurvedFace` | `relativeDeviation <= r.errorReached` | FAIL (`3.59e-9 <= 0.0` is false) | PASS |

Injection was done by reverting `result.errorReached` to the hardcoded `0.0` (the exact pre-fix
line), rerunning `swift test --filter BRepGPropVinertGKTests`, confirming both new assertions turn
red with the expected failure messages, then restoring the fix and confirming green again.

**Verification**: `swift build` clean (no warnings from touched files); `swift test --filter
BRepGPropVinertGKTests` and `--filter ZeroMassResultsTests` pass; full `OCCTAnalysisTests` target
(530 tests) passes; all five gate scripts and their `--self-test`s pass
(`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
`derive-bridge-header-split --verify`, `count-operations`). Built and tested with
`env -u OCCTSWIFT_LOCAL -u OCCTSWIFT_BRIDGE_PREBUILT` so the freshly-built bridge (not a stale
prebuilt one) is what's under test. No kernel patch, no `docs/CHANGELOG.md` edit in this diff per
`okf/policies/changelog-on-merge.md`, the entry above is transcribed at merge time.

GitHub Actions is reportedly in a major outage at the time of this PR; CI may not report. All
verification above is local.

## Response to review (secondmouseAU-bot, run #2)

**Finding 1 does not apply, and the file edit it asks for is now forbidden.**
`okf/policies/semver-at-release.md` landed after this review ran: PRs no longer edit
`docs/SEMVER.md` at all; they state their impact in the PR body instead (see `## SemVer impact`
above). Separately, the recorded-exception ledger the finding points to is, on its own terms, for
breaks shipping *within* a major line; this ships in v2.0.0, a major, where breaking changes are
permitted outright, exactly the precedent `docs/SEMVER.md` already records for a comparable case
(#640: "ships in v2.0.0 ... the recorded-exception mechanism ... does not apply"). Full response
posted as a PR comment.

**Finding 2 is correct, and is fixed.** Verified directly in `BRepGProp_VinertGK.cxx` (lines
486-495): `myAbsolutError` is always the raw residual; `myErrorReached` divides by `|mass|` only
when `|mass|` clears `Epsilon(myAbsolutError)` (about `1e-19` to `1e-25` for a realistic residual),
and equals the undivided residual otherwise. The doc comment on `errorReached` promised the relative
fraction unconditionally; rewritten to describe both branches. Attempted to construct a fixture that
lands in the undivided branch to pin it directly and could not (measured, not assumed): a
half-cylinder lateral face's mass is provably affine in a location offset, letting the exact
zero-crossing be solved from two measurements rather than searched; driving it there and bisecting
further bottoms out around `1e-14` mass, five to ten orders of magnitude short of the
`~1e-19`-to-`~1e-25` threshold OCCT's own guard needs. The only way to force literal-zero mass
through the public API is a face whose integrand is identically zero pointwise (a planar face
exactly coplanar with `location`), which forces the residual to identically zero too, so the two
branches are observably indistinguishable in every case this API can construct. Recorded in the doc
comment rather than claimed as tested.

What *is* both reachable and testable is the neighbouring half of the same claim: as mass shrinks
toward (but short of) that unreachable floor, `errorReached` should grow, not quietly stay small or
turn non-finite. New test `errorReachedGrowsAsMassApproachesZero` (`OCCTAnalysisTests.swift`) pins
exactly that, using the same derived-not-pinned half-cylinder fixture. Full injection matrix posted
as a PR comment.

**Finding 3 does not hold.** The opt-in prebuilt `OCCTBridge.xcframework` path is force-disabled for
the whole v2.0.0 line: `Package.swift` sets `let useBridgePrebuilt = false && ...`, so
`OCCTSWIFT_BRIDGE_PREBUILT=1` has no effect regardless of what any PR touches
(`docs/guides/prebuilt-bridge.md`'s own banner: "Disabled on the v2.0.0 line ... `Package.swift`
currently forces the source build and ignores `OCCTSWIFT_BRIDGE_PREBUILT` entirely"). There is no
consumer reachable through that path right now who could observe a stale `errorReached = 0.0`,
because nobody can opt into the prebuilt path at all on this line.

**Finding 4 does not hold.** The repo is pinned to OCCT 8.0.1 (`V8_0_1` plus eleven carried patches,
released as `v2.0.0-kernel.1`), not 8.0.0-p1: `Scripts/build-occt.sh:23` sets
`OCCT_VERSION="8.0.1"`, `docs/guides/building-occt.md:286` matches, and `CLAUDE.md`'s project
summary states the same pin. "Zero other references to 8.0.1" does not hold either: well over
twenty tracked files already said "8.0.1" before this PR touched anything, including `README.md`
and `Package.swift`. The comment this PR replaced said "OCCT 8.0.0" because it was already stale
relative to the repo's actual pin, not because "8.0.1" is a new or incorrect term.
