### PR TITLE
fix(#721): .correctedFrenet's reported divergence was a profile-placement bug

### DIFF
--- a/Scripts/repro/721-frenet-corrected-frenet/README.md
+++ b/Scripts/repro/721-frenet-corrected-frenet/README.md
@@ -1,0 +1,84 @@
+# #721 — `.correctedFrenet`'s reported divergence is a profile-placement artifact
+
+The issue: `.correctedFrenet` pipe sweeps were reported up to 27% off the true volume (and
+reversing sign) on `Wire.helix(radius: 10, pitch: p, turns: 3)` swept with a circular profile,
+while `.frenet` was exact. Two rounds of measurement on the issue reproduced that table. A prior
+investigation branch (`investigate/721-frenet-corrected-frenet`) found a real, separate mechanism —
+`BRepFill_Edge3DLaw` gives each of `Wire.helix(turns: n)`'s `n` edges an independent
+`GeomFill_CorrectedFrenet`, whose twist-angle law resets to zero at the start of every edge — and
+called it volume-neutral for a circular profile, which the second round of measurement's own table
+contradicted.
+
+**Neither the per-edge reset nor `.correctedFrenet` is the cause.** The profile in every prior
+measurement, and in the already-shipped `Issue598PipeShellFrenetModeTests.cookbookSpringRecipeVolumeInvariant`
+test and `docs/guides/cookbook/helices.md`'s "coiled spring" recipe it was modeled on, was placed at
+`SIMD3(r, 0, 0)` with tangent `normalize(0, r, pitch/2pi)`, describing that as the helix's own start
+point and tangent. It is neither: `Wire.helix`'s default `clockwise: false` reverses the build axis
+to -Z, so the wire's actual start is `(-r, ~0, 0)`, descending, and the real tangent's Z-component
+has the opposite sign. `.frenet`'s volume happens not to depend on this (`BRepOffsetAPI_MakePipeShell`
+re-derives the Frenet trihedron from the spine itself, and a circle has no preferred rotation, so a
+profile plane merely consistent with *some* congruent — here, mirrored — helix still sweeps
+correctly). `.correctedFrenet`'s per-edge twist-angle law is referenced to the input frame and is
+not insensitive to it.
+
+With the profile placed at the spine's own **measured** start point and tangent, `.frenet` and
+`.correctedFrenet` agree with each other and with the textbook tube volume to ~1e-6 relative, at
+every pitch (1, 4, 12, 30) and turn count (1 through 8, including half-turns — 0 through 7 internal
+edge boundaries) tested. The per-edge reset is real (confirmed directly, see probe 1 below) but
+volume-neutral, exactly as the issue's own symmetry argument predicts.
+
+## Probes
+
+```bash
+clang++ -std=c++17 -ObjC++ -w -O2 \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/721-frenet-corrected-frenet/<file>.mm -o /tmp/probe
+/tmp/probe
+```
+
+- **`occt_721_boundary_probe.mm`** — the issue's own suggested discriminator ("does a single-edge
+  spine show no divergence, with the error scaling with boundary count?"), run first, with the
+  profile's origin/tangent **measured** from the actual wire (`BRepAdaptor_CompCurve::D1`). Result:
+  no divergence at any turn count (1, 2, 3, 6) at any pitch (4, 12, 30) — contradicting the issue's
+  own reproduction using what looked like the same construction. Also instruments
+  `GeomFill_CorrectedFrenet::D0` directly against `GeomFill_Frenet::D0` on a single edge (turns=1,
+  no boundary at all): confirms a real, large, *smooth* drift within one edge (up to -159° by the
+  end of one turn at pitch=30) that costs nothing in swept volume — the smooth-twist/circular-profile
+  symmetry argument holding within an edge, independent of any boundary question.
+- **`occt_721_boundary_probe2.mm`** — same sweep, profile placed with the issue's own **analytic**
+  formula instead of a measured one. This one *does* reproduce the reported divergence pattern
+  (rising through pitch=4/turns=6, and at pitch=12 rising to 1.29 then reversing to 0.98 and back —
+  an oscillation with period related to edge count). The only difference from probe 1 is how the
+  profile is placed, which is what the isolation in probe 3 confirms directly.
+- **`occt_721_boundary_probe3.mm`** — isolates which half of the analytic formula's mismatch
+  (wrong origin, wrong tangent sign, or both) drives the divergence, at the issue's own worst case
+  (pitch=12, turns=3) and the shipped test's fixture (pitch=4, turns=5). Both mismatches together
+  (`origin=(+r,0,0)`, `tangent=(0,r,+c)` — the "textbook, as shipped" row) leave `.frenet` exact by
+  a mirror-symmetry coincidence but reproduce `.correctedFrenet`'s reported ratios (1.2758, 1.1215)
+  almost exactly. Correcting both (`origin=(-r,0,0)`, `tangent=(0,r,-c)`, matching a direct
+  measurement) collapses both modes back to 1.0000.
+
+## Where the fix landed
+
+Not the kernel, not the bridge — `Sources/OCCTBridge/src/OCCTBridge_Modeling.mm`'s
+`OCCTShapeCreatePipeShellMultiSection` and `OCCTWireCreateHelix` were read line-for-line against
+these probes and match exactly; there is nothing to patch there. The fix is:
+
+- `Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift`'s
+  `cookbookSpringRecipeVolumeInvariant` corrected to measure the profile placement instead of
+  computing it, and its "must not match" assertion replaced with "must match" (both modes now
+  agree); its old construction is kept as a second test,
+  `misplacedProfileReproducesIssue721Divergence`, a permanent regression against reintroducing it.
+- `Tests/OCCTModelingTests/Issue721CorrectedFrenetPlacementTests.swift` (new): the dense
+  pitch/turns sweep with the correct construction, plus a direct instrument confirming the per-edge
+  reset is real without affecting volume.
+- `docs/guides/cookbook/helices.md`'s "coiled spring" recipe corrected to measure the tangent from
+  the wire, and its prose no longer claims `.correctedFrenet` fails to preserve the tube volume.
+- `docs/CHANGELOG.md`'s pre-existing #598 entry (still `## Unreleased`) carried the same wrong
+  claim (that a circular profile only guarantees agreement on a torsion-free spine); corrected in
+  place rather than left to mislead the next reader.
+- `Sources/OCCTSwift/Wire.swift`'s `Wire.helix` doc comment gained a note on where the wire
+  actually starts under the default `clockwise: false`, and to measure rather than compute that
+  point/tangent analytically — the mistake this whole issue traces back to.

--- a/Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe.mm
+++ b/Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe.mm
@@ -1,0 +1,217 @@
+// #721 discriminator: does .correctedFrenet's volume divergence from .frenet require an
+// internal wire boundary (Wire.helix(turns: n) produces n edges, BRepFill_Edge3DLaw builds an
+// independent GeomFill_CorrectedFrenet per edge), or does it appear even on a single edge?
+//
+// Method: same fixture as the issue (radius=10, wireRadius=1.5, correctly-placed circular
+// profile at the spine's own start point/tangent), sweep `turns` across {1, 2, 3, 6} (0, 1, 2, 5
+// internal boundaries respectively) at three pitches, and separately instrument
+// GeomFill_CorrectedFrenet::D0 directly on ONE edge (turns=1) to see whether the correction
+// angle drifts away from zero WITHIN that single edge (no boundary involved at all).
+//
+// RESULT: no divergence at any turns count tested, at any pitch -- both Frenet and corrected
+// Frenet match the textbook volume to ~1e-6 relative. This appears to contradict the issue's own
+// reproduction (which used what looked like the same "correctly-placed" construction); see
+// occt_721_boundary_probe2.mm and occt_721_boundary_probe3.mm, and this directory's README, for
+// how that's resolved: the issue's own profile placement was not actually on the spine.
+//
+// Build and run (from the repo root):
+//   clang++ -std=c++17 -ObjC++ -w -O2 \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe.mm \
+//     -o /tmp/occt_721_boundary_probe
+//   /tmp/occt_721_boundary_probe
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include <BRep_Tool.hxx>
+#include <BRepAdaptor_CompCurve.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepGProp.hxx>
+#include <BRepOffsetAPI_MakePipeShell.hxx>
+#include <BRepTools_WireExplorer.hxx>
+#include <GProp_GProps.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <GeomAbs_CurveType.hxx>
+#include <GeomFill_CorrectedFrenet.hxx>
+#include <GeomFill_Frenet.hxx>
+#include <HelixBRep_BuilderHelix.hxx>
+#include <NCollection_Array1.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+
+static TopoDS_Wire buildHelixWire(double radius, double pitch, double turns) {
+  gp_Pnt origin(0, 0, 0);
+  gp_Dir dir(0, 0, 1);
+  dir.Reverse(); // clockwise == false, matches OCCTWireCreateHelix
+  gp_Ax3 axis(origin, dir);
+
+  double diameter = radius * 2.0;
+  NCollection_Array1<double> pitchArr(1, 1);
+  pitchArr.SetValue(1, pitch);
+  NCollection_Array1<double> nbTurnsArr(1, 1);
+  nbTurnsArr.SetValue(1, turns);
+
+  HelixBRep_BuilderHelix builder;
+  builder.SetParameters(axis, diameter, pitchArr, nbTurnsArr);
+  builder.Perform();
+  if (builder.ErrorStatus() != 0) {
+    printf("  !! HelixBRep_BuilderHelix ErrorStatus=%d\n", builder.ErrorStatus());
+    return TopoDS_Wire();
+  }
+  return TopoDS::Wire(builder.Shape());
+}
+
+static TopoDS_Wire buildCircleProfile(const gp_Pnt& origin, const gp_Dir& normal, double radius) {
+  gp_Ax2 ax2(origin, normal);
+  gp_Circ circ(ax2, radius);
+  TopoDS_Edge e = BRepBuilderAPI_MakeEdge(circ).Edge();
+  return BRepBuilderAPI_MakeWire(e).Wire();
+}
+
+static double volumeOf(const TopoDS_Shape& s) {
+  GProp_GProps props;
+  BRepGProp::VolumeProperties(s, props);
+  return props.Mass();
+}
+
+// ------------------------------------------------------------------------------------------
+// Part 1: volume sweep varying `turns` (hence internal-boundary count) at fixed pitch.
+// ------------------------------------------------------------------------------------------
+static void sweepTurns(double pitch) {
+  const double R = 10.0, wireR = 1.5;
+  double turnsList[] = {1.0, 2.0, 3.0, 6.0};
+  printf("=== pitch=%g ===\n", pitch);
+  printf("%6s %6s %12s %12s %8s %12s %8s\n", "turns", "edges", "textbook", "frenet", "ratio",
+         "corrFrenet", "ratio");
+  for (double turns : turnsList) {
+    TopoDS_Wire spine = buildHelixWire(R, pitch, turns);
+    if (spine.IsNull()) { printf("turns=%g: spine build failed\n", turns); continue; }
+
+    int nEdges = 0;
+    BRepTools_WireExplorer wexp;
+    for (wexp.Init(spine); wexp.More(); wexp.Next()) nEdges++;
+
+    double c = pitch / (2.0 * M_PI);
+    double lenAnalytic = turns * 2.0 * M_PI * std::sqrt(R * R + c * c);
+    double textbook = M_PI * wireR * wireR * lenAnalytic;
+
+    TopoDS_Vertex v1, v2;
+    TopExp::Vertices(spine, v1, v2);
+    gp_Pnt startPnt = BRep_Tool::Pnt(v1);
+    BRepAdaptor_CompCurve ccStart(spine);
+    gp_Pnt p0; gp_Vec t0;
+    ccStart.D1(ccStart.FirstParameter(), p0, t0);
+    gp_Dir profileNormal(t0);
+    TopoDS_Wire profile = buildCircleProfile(startPnt, profileNormal, wireR);
+
+    double vFrenet = 0, vCorrected = 0;
+    bool doneF = false, doneC = false;
+    {
+      BRepOffsetAPI_MakePipeShell mkPipe(spine);
+      mkPipe.SetMode(true);
+      mkPipe.Add(profile);
+      mkPipe.Build();
+      doneF = mkPipe.IsDone();
+      if (doneF) { mkPipe.MakeSolid(); vFrenet = volumeOf(mkPipe.Shape()); }
+    }
+    {
+      BRepOffsetAPI_MakePipeShell mkPipe(spine);
+      mkPipe.SetMode(false);
+      mkPipe.Add(profile);
+      mkPipe.Build();
+      doneC = mkPipe.IsDone();
+      if (doneC) { mkPipe.MakeSolid(); vCorrected = volumeOf(mkPipe.Shape()); }
+    }
+
+    printf("%6g %6d %12.4f %12.4f %8.4f %12.4f %8.4f   [doneF=%d doneC=%d]\n", turns, nEdges,
+           textbook, vFrenet, doneF ? vFrenet / textbook : -1.0, vCorrected,
+           doneC ? vCorrected / textbook : -1.0, doneF, doneC);
+  }
+  printf("\n");
+}
+
+// ------------------------------------------------------------------------------------------
+// Part 2: does the correction angle drift away from zero WITHIN a single edge (turns=1, one
+// full 2*pi turn, no internal boundary at all)? Mimics BRepFill_Edge3DLaw's own construction:
+// build a fresh GeomAdaptor_Curve for the edge and drive GeomFill_CorrectedFrenet directly.
+// ------------------------------------------------------------------------------------------
+static void probeSingleEdgeDrift(double pitch) {
+  const double R = 10.0;
+  printf("=== single-edge (turns=1) correction-angle drift probe, pitch=%g ===\n", pitch);
+  TopoDS_Wire spine = buildHelixWire(R, pitch, 1.0);
+  if (spine.IsNull()) { printf("  spine build failed\n"); return; }
+
+  int nEdges = 0;
+  BRepTools_WireExplorer wexp;
+  TopoDS_Edge e;
+  for (wexp.Init(spine); wexp.More(); wexp.Next()) { nEdges++; e = TopoDS::Edge(wexp.Current()); }
+  printf("  wire has %d edge(s)\n", nEdges);
+  if (nEdges != 1) { printf("  !! expected exactly 1 edge for turns=1, skipping\n"); return; }
+
+  double f, l;
+  occ::handle<Geom_Curve> curveGeom = BRep_Tool::Curve(e, f, l);
+  TopAbs_Orientation orient = e.Orientation();
+  occ::handle<Geom_Curve> curveForAdaptor = curveGeom;
+  double ff = f, ll = l;
+  if (orient == TopAbs_REVERSED) {
+    occ::handle<Geom_TrimmedCurve> rev = new Geom_TrimmedCurve(curveGeom, f, l);
+    rev->Reverse();
+    curveForAdaptor = rev;
+    ff = curveForAdaptor->FirstParameter();
+    ll = curveForAdaptor->LastParameter();
+  }
+  occ::handle<GeomAdaptor_Curve> adaptor = new GeomAdaptor_Curve(curveForAdaptor, ff, ll);
+  printf("  edge param range [%.6f, %.6f]\n", ff, ll);
+
+  GeomFill_Frenet frenet;
+  frenet.SetCurve(adaptor);
+  GeomFill_CorrectedFrenet corrected;
+  bool isFrenetFlag = corrected.SetCurve(adaptor);
+  printf("  GeomFill_CorrectedFrenet::SetCurve returned isFrenet=%d (true means NO correction "
+         "will ever be applied by D0 -- it degenerates to plain Frenet)\n", isFrenetFlag);
+
+  int nSamples = 21;
+  for (int i = 0; i < nSamples; ++i) {
+    double u = ff + (ll - ff) * (double)i / (nSamples - 1);
+    gp_Vec T, N, B;
+    frenet.D0(u, T, N, B);
+    gp_Vec Tc, Nc, Bc;
+    corrected.D0(u, Tc, Nc, Bc);
+    // Angle between the plain-Frenet normal and the corrected normal at the SAME parameter:
+    // this is exactly the extra rotation GeomFill_CorrectedFrenet::D0 applies around T.
+    double dotNNc = N.Normalized().Dot(Nc.Normalized());
+    dotNNc = std::max(-1.0, std::min(1.0, dotNNc));
+    double angleDeg = std::acos(dotNNc) * 180.0 / M_PI;
+    // signed: project the rotation onto T to get a sign
+    gp_Vec cross = N.Crossed(Nc);
+    double sign = cross.Dot(T) < 0 ? -1.0 : 1.0;
+    printf("    u=%.4f (frac=%.3f)  angle(N_frenet, N_corrected) = %+8.4f deg\n", u,
+           (u - ff) / (ll - ff), sign * angleDeg);
+  }
+  printf("\n");
+}
+
+int main() {
+  sweepTurns(4.0);
+  sweepTurns(12.0);
+  sweepTurns(30.0);
+  probeSingleEdgeDrift(4.0);
+  probeSingleEdgeDrift(12.0);
+  probeSingleEdgeDrift(30.0);
+  return 0;
+}

--- a/Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe2.mm
+++ b/Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe2.mm
@@ -1,0 +1,121 @@
+// #721 discriminator, take 2: the first attempt (occt_721_boundary_probe.mm) used a profile
+// normal MEASURED from the actual spine (BRepAdaptor_CompCurve::D1 at FirstParameter) and found
+// NO divergence at turns in {1,2,3,6}. That contradicts the shipped, currently-passing test
+// Issue598PipeShellFrenetModeTests.cookbookSpringRecipeVolumeInvariant (r=10, pitch=4, turns=5,
+// wireRadius=1.5), confirmed via `swift test` to measure .correctedFrenet ~12% high. Isolated
+// the difference to the profile's normal being ANALYTIC (normalize(0, r, pitch/2pi)) rather than
+// measured off the wire -- reproduced 1.1215 with the analytic normal at turns=5. This probe
+// holds the analytic-normal construction fixed and sweeps `turns` densely to find out what
+// actually predicts the divergence.
+//
+// Build and run (from the repo root):
+//   clang++ -std=c++17 -ObjC++ -w -O2 \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe2.mm \
+//     -o /tmp/occt_721_boundary_probe2
+//   /tmp/occt_721_boundary_probe2
+
+#include <cmath>
+#include <cstdio>
+
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepGProp.hxx>
+#include <BRepOffsetAPI_MakePipeShell.hxx>
+#include <BRepTools_WireExplorer.hxx>
+#include <GProp_GProps.hxx>
+#include <HelixBRep_BuilderHelix.hxx>
+#include <NCollection_Array1.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+
+static TopoDS_Wire buildHelixWire(double radius, double pitch, double turns) {
+  gp_Pnt origin(0, 0, 0);
+  gp_Dir dir(0, 0, 1);
+  dir.Reverse(); // clockwise == false
+  gp_Ax3 axis(origin, dir);
+  double diameter = radius * 2.0;
+  NCollection_Array1<double> pitchArr(1, 1);
+  pitchArr.SetValue(1, pitch);
+  NCollection_Array1<double> nbTurnsArr(1, 1);
+  nbTurnsArr.SetValue(1, turns);
+  HelixBRep_BuilderHelix builder;
+  builder.SetParameters(axis, diameter, pitchArr, nbTurnsArr);
+  builder.Perform();
+  if (builder.ErrorStatus() != 0) return TopoDS_Wire();
+  return TopoDS::Wire(builder.Shape());
+}
+
+static double volumeOf(const TopoDS_Shape& s) {
+  GProp_GProps props;
+  BRepGProp::VolumeProperties(s, props);
+  return props.Mass();
+}
+
+static void sweepTurns(double pitch) {
+  const double R = 10.0, wireR = 1.5;
+  double turnsList[] = {1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 7.0, 8.0};
+  printf("=== pitch=%g (analytic-normal profile, matching the confirmed-passing test) ===\n", pitch);
+  printf("%6s %6s %12s %12s %8s %12s %8s\n", "turns", "edges", "textbook", "frenet", "ratio",
+         "corrFrenet", "ratio");
+  for (double turns : turnsList) {
+    TopoDS_Wire spine = buildHelixWire(R, pitch, turns);
+    if (spine.IsNull()) { printf("turns=%g: spine build failed\n", turns); continue; }
+
+    int nEdges = 0;
+    BRepTools_WireExplorer wexp;
+    for (wexp.Init(spine); wexp.More(); wexp.Next()) nEdges++;
+
+    double c = pitch / (2.0 * M_PI);
+    double lenAnalytic = turns * 2.0 * M_PI * std::sqrt(R * R + c * c);
+    double textbook = M_PI * wireR * wireR * lenAnalytic;
+
+    // Analytic profile placement: origin (R,0,0), normal = normalize(0, R, pitch/2pi).
+    gp_Pnt origin(R, 0, 0);
+    gp_Vec nvec(0, R, c);
+    gp_Dir normal(nvec);
+    gp_Circ circ(gp_Ax2(origin, normal), wireR);
+    TopoDS_Edge e = BRepBuilderAPI_MakeEdge(circ).Edge();
+    TopoDS_Wire profile = BRepBuilderAPI_MakeWire(e).Wire();
+
+    double vFrenet = 0, vCorrected = 0;
+    bool doneF = false, doneC = false;
+    {
+      BRepOffsetAPI_MakePipeShell mkPipe(spine);
+      mkPipe.SetMode(true);
+      mkPipe.Add(profile);
+      mkPipe.Build();
+      doneF = mkPipe.IsDone();
+      if (doneF) { mkPipe.MakeSolid(); vFrenet = volumeOf(mkPipe.Shape()); }
+    }
+    {
+      BRepOffsetAPI_MakePipeShell mkPipe(spine);
+      mkPipe.SetMode(false);
+      mkPipe.Add(profile);
+      mkPipe.Build();
+      doneC = mkPipe.IsDone();
+      if (doneC) { mkPipe.MakeSolid(); vCorrected = volumeOf(mkPipe.Shape()); }
+    }
+
+    printf("%6g %6d %12.4f %12.4f %8.4f %12.4f %8.4f   [doneF=%d doneC=%d]\n", turns, nEdges,
+           textbook, vFrenet, doneF ? vFrenet / textbook : -1.0, vCorrected,
+           doneC ? vCorrected / textbook : -1.0, doneF, doneC);
+  }
+  printf("\n");
+}
+
+int main() {
+  sweepTurns(4.0);
+  sweepTurns(12.0);
+  return 0;
+}

--- a/Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe3.mm
+++ b/Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe3.mm
@@ -1,0 +1,128 @@
+// #721 discriminator, take 3. probe2 showed the shipped-test/issue construction
+// (origin=(R,0,0), normal=normalize(0,R,pitch/2pi)) reproduces the divergence, while probe1's
+// construction (origin = the wire's OWN start vertex, normal MEASURED via
+// BRepAdaptor_CompCurve::D1) shows none. Comparing the two directly: v1 (the real start vertex)
+// is (-R,0,0), NOT (R,0,0) -- Wire.helix's clockwise=false reverses the build axis to -Z, so the
+// wire's own local "theta=0" lands at global -X, not +X -- and the measured tangent's Z-component
+// has the OPPOSITE SIGN from the "textbook" analytic formula's (the spine descends in -Z, the
+// formula assumes ascent in +Z). Both the issue's own round-2 measurement and the shipped
+// Issue598PipeShellFrenetModeTests.cookbookSpringRecipeVolumeInvariant test use the "textbook"
+// formula, i.e. a profile that is NOT positioned on or tangent to the real spine at its start.
+//
+// This probe isolates which of the two mismatches (origin, or tangent Z-sign) actually drives
+// the divergence, by testing all four combinations at a fixed pitch/turns, then sweeping turns
+// for whichever variant(s) turn out to matter.
+//
+// Build and run (from the repo root):
+//   clang++ -std=c++17 -ObjC++ -w -O2 \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/721-frenet-corrected-frenet/occt_721_boundary_probe3.mm \
+//     -o /tmp/occt_721_boundary_probe3
+//   /tmp/occt_721_boundary_probe3
+
+#include <cmath>
+#include <cstdio>
+
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepGProp.hxx>
+#include <BRepOffsetAPI_MakePipeShell.hxx>
+#include <BRepTools_WireExplorer.hxx>
+#include <GProp_GProps.hxx>
+#include <HelixBRep_BuilderHelix.hxx>
+#include <NCollection_Array1.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+
+static TopoDS_Wire buildHelixWire(double radius, double pitch, double turns) {
+  gp_Pnt origin(0, 0, 0);
+  gp_Dir dir(0, 0, 1);
+  dir.Reverse(); // clockwise == false
+  gp_Ax3 axis(origin, dir);
+  double diameter = radius * 2.0;
+  NCollection_Array1<double> pitchArr(1, 1);
+  pitchArr.SetValue(1, pitch);
+  NCollection_Array1<double> nbTurnsArr(1, 1);
+  nbTurnsArr.SetValue(1, turns);
+  HelixBRep_BuilderHelix builder;
+  builder.SetParameters(axis, diameter, pitchArr, nbTurnsArr);
+  builder.Perform();
+  if (builder.ErrorStatus() != 0) return TopoDS_Wire();
+  return TopoDS::Wire(builder.Shape());
+}
+
+static double volumeOf(const TopoDS_Shape& s) {
+  GProp_GProps props;
+  BRepGProp::VolumeProperties(s, props);
+  return props.Mass();
+}
+
+static void run(const char* label, double R, double pitch, double turns, double wireR,
+                 double originX, double normalY, double normalZ) {
+  TopoDS_Wire spine = buildHelixWire(R, pitch, turns);
+  if (spine.IsNull()) { printf("%s: spine build failed\n", label); return; }
+
+  double c = pitch / (2.0 * M_PI);
+  double lenAnalytic = turns * 2.0 * M_PI * std::sqrt(R * R + c * c);
+  double textbook = M_PI * wireR * wireR * lenAnalytic;
+
+  gp_Pnt origin(originX, 0, 0);
+  gp_Vec nvec(0, normalY, normalZ);
+  gp_Dir normal(nvec);
+  gp_Circ circ(gp_Ax2(origin, normal), wireR);
+  TopoDS_Edge e = BRepBuilderAPI_MakeEdge(circ).Edge();
+  TopoDS_Wire profile = BRepBuilderAPI_MakeWire(e).Wire();
+
+  double vFrenet = 0, vCorrected = 0;
+  bool doneF = false, doneC = false;
+  {
+    BRepOffsetAPI_MakePipeShell mkPipe(spine);
+    mkPipe.SetMode(true);
+    mkPipe.Add(profile);
+    mkPipe.Build();
+    doneF = mkPipe.IsDone();
+    if (doneF) { mkPipe.MakeSolid(); vFrenet = volumeOf(mkPipe.Shape()); }
+  }
+  {
+    BRepOffsetAPI_MakePipeShell mkPipe(spine);
+    mkPipe.SetMode(false);
+    mkPipe.Add(profile);
+    mkPipe.Build();
+    doneC = mkPipe.IsDone();
+    if (doneC) { mkPipe.MakeSolid(); vCorrected = volumeOf(mkPipe.Shape()); }
+  }
+  printf("%-28s origin=(%+5.1f,0,0) normal=(0,%.4f,%+.4f)  frenetRatio=%.4f  corrRatio=%.4f  [doneF=%d doneC=%d]\n",
+         label, originX, normalY, normalZ,
+         doneF ? vFrenet / textbook : -1.0, doneC ? vCorrected / textbook : -1.0, doneF, doneC);
+}
+
+int main() {
+  double R = 10.0, wireR = 1.5;
+  printf("=== isolating origin vs tangent-sign, pitch=12, turns=3 (issue's own worst case) ===\n");
+  {
+    double pitch = 12.0, turns = 3.0, c = pitch / (2 * M_PI);
+    run("A: textbook (as shipped)", R, pitch, turns, wireR, +R, R, +c);
+    run("B: flip normal Z only",     R, pitch, turns, wireR, +R, R, -c);
+    run("C: flip origin only",       R, pitch, turns, wireR, -R, R, +c);
+    run("D: flip both (= measured)", R, pitch, turns, wireR, -R, R, -c);
+  }
+  printf("\n=== same isolation, pitch=4, turns=5 (the shipped-test fixture) ===\n");
+  {
+    double pitch = 4.0, turns = 5.0, c = pitch / (2 * M_PI);
+    run("A: textbook (as shipped)", R, pitch, turns, wireR, +R, R, +c);
+    run("B: flip normal Z only",     R, pitch, turns, wireR, +R, R, -c);
+    run("C: flip origin only",       R, pitch, turns, wireR, -R, R, +c);
+    run("D: flip both (= measured)", R, pitch, turns, wireR, -R, R, -c);
+  }
+  return 0;
+}

--- a/Sources/OCCTSwift/Wire.swift
+++ b/Sources/OCCTSwift/Wire.swift
@@ -1112,6 +1112,17 @@ extension Wire {
     ///   - clockwise: Winding direction (default: false = counter-clockwise)
     /// - Returns: A helical wire, or nil on failure
     ///
+    /// - Important: `clockwise: false` reverses the internal build axis, so the wire's actual
+    ///   start point and winding are not simply `origin + (radius, 0, 0)` ascending along `axis`
+    ///   as a naive right-handed parametrization would suggest. If you need the exact start point
+    ///   or tangent (for example to place a profile for `Shape.pipeShell`), measure it from the
+    ///   wire itself rather than computing it analytically:
+    ///   `spine.edges().first?.curve3D?.d1(at: domain.lowerBound)`. Computing it analytically and
+    ///   getting the axis convention backwards is exactly what produced OCCTSwift #721, where a
+    ///   profile ended up 2×radius from the spine with an inverted tangent, silently corrupting
+    ///   `.correctedFrenet` sweeps (but not `.frenet`, by an unrelated coincidence) on the
+    ///   resulting pipe shell.
+    ///
     /// ## Example
     ///
     /// ```swift

--- a/Sources/OCCTSwift/Wire.swift
+++ b/Sources/OCCTSwift/Wire.swift
@@ -1117,7 +1117,13 @@ extension Wire {
     ///   as a naive right-handed parametrization would suggest. If you need the exact start point
     ///   or tangent (for example to place a profile for `Shape.pipeShell`), measure it from the
     ///   wire itself rather than computing it analytically:
-    ///   `spine.edges().first?.curve3D?.d1(at: domain.lowerBound)`. Computing it analytically and
+    ///
+    ///   ```swift
+    ///   guard let curve = spine.edges().first?.curve3D else { return }
+    ///   let (start, tangent) = curve.d1(at: curve.domain.lowerBound)
+    ///   ```
+    ///
+    ///   Computing it analytically and
     ///   getting the axis convention backwards is exactly what produced OCCTSwift #721, where a
     ///   profile ended up 2×radius from the spine with an inverted tangent, silently corrupting
     ///   `.correctedFrenet` sweeps (but not `.frenet`, by an unrelated coincidence) on the

--- a/Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift
+++ b/Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift
@@ -158,20 +158,39 @@ struct Issue598PipeShellFrenetModeTests {
 
     /// Review of #715: the CHANGELOG claimed a circular profile makes `.frenet` and
     /// `.correctedFrenet` produce "the identical swept volume" on
-    /// `docs/guides/cookbook/helices.md`'s spring recipe, so the page needed no update. Measured,
-    /// not assumed, using the exact recipe (r=10, pitch=4, turns=5, wireRadius=1.5) and an
-    /// independent `PipeShellBuilder` oracle: the claim is false. `.frenet` reproduces the
-    /// textbook tube volume (pi * wireRadius^2 * coil length) to within numerical tolerance;
-    /// `.correctedFrenet` does not (measured ~12% larger, cross-checked against
-    /// `PipeShellBuilder.setFrenet(false)` giving the identical value). The cookbook page is
-    /// fixed in the same PR that adds this test: its recipe now uses `.frenet`.
-    @Test("the cookbook spring recipe: .frenet matches the textbook tube volume; .correctedFrenet does not")
+    /// `docs/guides/cookbook/helices.md`'s spring recipe, so the page needed no update. This test
+    /// used to measure the opposite (`.correctedFrenet` ~12% larger than textbook) -- but #721
+    /// found that measurement's own construction was wrong, not `.correctedFrenet`.
+    ///
+    /// The recipe placed the profile at `SIMD3(r, 0, 0)` with tangent
+    /// `normalize(0, r, pitch/2pi)`, describing that as "the helix start, with its normal along
+    /// the helix tangent there." It is neither. `Wire.helix`'s default `clockwise: false` reverses
+    /// the build axis to -Z (see its doc comment), so the wire's actual start is `(-r, ~0, 0)`,
+    /// descending, and the real tangent's Z-component has the opposite sign from the formula
+    /// above. Measured directly (`spine.edges().first!.curve3D!.d1(at: domain.lowerBound)`): the
+    /// real start point is `(-10, 0, 0)`, 20 units from where the old recipe put the profile.
+    ///
+    /// `.frenet`'s volume was insensitive to this (still matched textbook to 1e-6) only by an
+    /// unrelated coincidence: `BRepOffsetAPI_MakePipeShell` re-derives the Frenet trihedron from
+    /// the spine itself and a circle has no preferred rotation, so a profile whose *plane* is
+    /// merely consistent with *some* congruent helix (this one, mirrored) still sweeps to the
+    /// right volume under `.frenet`. `.correctedFrenet` is not insensitive to it: its per-edge
+    /// twist-angle law is referenced to the input frame, and the mismatch propagates into a real,
+    /// large error. With the profile at its *actual* measured position and tangent, both modes
+    /// agree with each other and with the textbook volume to 1e-6 relative -- see
+    /// `Issue721CorrectedFrenetPlacementTests` for the full sweep across pitch and turn count that
+    /// established this. There is no `.correctedFrenet` defect on this fixture family.
+    @Test("the cookbook spring recipe, correctly placed: .frenet and .correctedFrenet both match the textbook tube volume")
     func cookbookSpringRecipeVolumeInvariant() {
         let r = 10.0, pitch = 4.0, turns = 5.0, wireRadius = 1.5
         guard let spine = Wire.helix(radius: r, pitch: pitch, turns: turns),
-              let profile = Wire.circle(origin: SIMD3(r, 0, 0),
-                                        normal: simd_normalize(SIMD3<Double>(0, r, pitch / (2 * .pi))),
-                                        radius: wireRadius),
+              let firstEdge = spine.edges().first, let curve = firstEdge.curve3D else {
+            Issue.record("Could not build the spine"); return
+        }
+        // The profile belongs at the spine's own measured start point and tangent, not at a
+        // point/tangent merely consistent with *some* congruent helix (#721).
+        let (p0, t0) = curve.d1(at: curve.domain.lowerBound)
+        guard let profile = Wire.circle(origin: p0, normal: simd_normalize(t0), radius: wireRadius),
               let frenet = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet, solid: true),
               let corrected = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet, solid: true),
               let trueFrenet = Self.groundTruth(spine: spine, profile: profile, frenet: true),
@@ -190,7 +209,55 @@ struct Issue598PipeShellFrenetModeTests {
         let textbookVolume = Double.pi * wireRadius * wireRadius * coilLength
         #expect(vFrenet.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-3),
                 ".frenet (\(vFrenet)) should match the textbook tube volume (\(textbookVolume))")
-        #expect(!vCorrected.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-2),
-                ".correctedFrenet (\(vCorrected)) must not match the textbook tube volume on this spine")
+        #expect(vCorrected.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-3),
+                ".correctedFrenet (\(vCorrected)) should also match the textbook tube volume (\(textbookVolume)) once the profile is correctly placed (#721)")
+        #expect(vFrenet.isApproximatelyEqual(to: vCorrected, tolerance: 1e-4),
+                ".frenet (\(vFrenet)) and .correctedFrenet (\(vCorrected)) must agree: a circular profile is symmetric under rotation about the tangent, the only axis the two laws differ on")
+    }
+
+    /// #721: the measurement that made the old version of the test above (and the old cookbook
+    /// recipe) look like a `.correctedFrenet` defect. Kept as a permanent regression against
+    /// reintroducing the mis-placed-profile construction: it reproduces the issue's own reported
+    /// numbers (`.correctedFrenet` 27.6% high at pitch=12, reversing to -19.9% at pitch=30) from a
+    /// profile that is 20 units from the spine, proving the divergence is a property of that
+    /// specific mistake and not of `.correctedFrenet`, `GeomFill_CorrectedFrenet`, or
+    /// `BRepFill_Edge3DLaw`'s per-edge trihedron construction.
+    ///
+    /// Injection check (the "prove the test fails" policy, `okf/policies/prove-the-test-fails.md`):
+    /// replacing the mis-signed tangent below with the correctly-measured one from the test above
+    /// collapses `corrRatio` to 1.0 and fails the `!isApproximatelyEqual` assertion -- confirmed
+    /// by hand while writing this test, not left as an assumption.
+    @Test("a profile placed at the mirror point with a mirror tangent reproduces #721's reported divergence")
+    func misplacedProfileReproducesIssue721Divergence() {
+        let r = 10.0, wireRadius = 1.5
+        for (pitch, turns, expectedRatio) in [(1.0, 3.0, 1.005), (4.0, 3.0, 1.075),
+                                              (12.0, 3.0, 1.276), (30.0, 3.0, 0.801)] {
+            guard let spine = Wire.helix(radius: r, pitch: pitch, turns: turns) else {
+                Issue.record("Could not build spine at pitch \(pitch)"); continue
+            }
+            // The ORIGINAL (wrong) recipe: origin at (r, 0, 0) -- the antipode of the wire's real
+            // start (-r, 0, 0) -- with a tangent sign that matches an ascending helix, not the
+            // descending one `clockwise: false` actually builds.
+            let mismatchedTangent = simd_normalize(SIMD3<Double>(0, r, pitch / (2 * .pi)))
+            guard let profile = Wire.circle(origin: SIMD3(r, 0, 0), normal: mismatchedTangent, radius: wireRadius),
+                  let frenet = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet, solid: true),
+                  let corrected = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet, solid: true),
+                  let vFrenet = frenet.volume, let vCorrected = corrected.volume else {
+                Issue.record("Could not build the sweeps at pitch \(pitch)"); continue
+            }
+            let coilLength = turns * sqrt(pow(2 * .pi * r, 2) + pow(pitch, 2))
+            let textbookVolume = Double.pi * wireRadius * wireRadius * coilLength
+            let corrRatio = vCorrected / textbookVolume
+
+            #expect(vFrenet.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-3),
+                    "pitch \(pitch): .frenet stays correct even with this mis-placed profile")
+            // Smallest reported divergence is pitch=1 at 0.51%; 2e-3 stays well below that while
+            // sitting far above the ~1e-6 relative noise floor a genuine match shows elsewhere in
+            // this file, so it can't accidentally pass on numerical noise.
+            #expect(!vCorrected.isApproximatelyEqual(to: textbookVolume, tolerance: 2e-3),
+                    "pitch \(pitch): .correctedFrenet should reproduce the reported divergence, got ratio \(corrRatio)")
+            #expect(corrRatio.isApproximatelyEqual(to: expectedRatio, tolerance: 5e-3),
+                    "pitch \(pitch): expected ratio close to the issue's own \(expectedRatio), got \(corrRatio)")
+        }
     }
 }

--- a/Tests/OCCTModelingTests/Issue721CorrectedFrenetPlacementTests.swift
+++ b/Tests/OCCTModelingTests/Issue721CorrectedFrenetPlacementTests.swift
@@ -124,3 +124,29 @@ struct Issue721CorrectedFrenetPlacementTests {
                 "expected a real discontinuity in the corrected-Frenet normal across the internal edge boundary, measured \(angleDeg) degrees")
     }
 }
+
+/// Compiles and runs `Wire.helix`'s own doc snippet verbatim. The first version of that snippet
+/// referenced an undefined `domain` and would not have compiled if anyone pasted it, which is the
+/// same class of defect as the unverified placement formula that produced #721 in the first place.
+/// A snippet shipped alongside a warning about unverified formulas should itself be verified.
+@Suite("Wire.helix's doc snippet compiles and measures the real start (#721)")
+struct Issue721HelixDocSnippetTests {
+    @Test("the documented way to measure a helix start point works and disagrees with the naive one")
+    func snippetCompilesAndIsNotTheNaiveAnswer() throws {
+        let spine = try #require(Wire.helix(radius: 10, pitch: 4, turns: 3))
+
+        // Verbatim from the doc comment on Wire.helix.
+        guard let curve = spine.edges().first?.curve3D else {
+            Issue.record("helix has no first edge curve")
+            return
+        }
+        let (start, tangent) = curve.d1(at: curve.domain.lowerBound)
+
+        // The measured start is NOT origin + (radius, 0, 0): that assumption is #721.
+        let naive = SIMD3(10.0, 0.0, 0.0)
+        let offBy = (start - naive)
+        #expect((offBy.x * offBy.x + offBy.y * offBy.y + offBy.z * offBy.z).squareRoot() > 1.0,
+                "the naive start should be measurably wrong, that is the point of the warning")
+        #expect(tangent.z < 0, "the real tangent descends; the naive one was assumed ascending")
+    }
+}

--- a/Tests/OCCTModelingTests/Issue721CorrectedFrenetPlacementTests.swift
+++ b/Tests/OCCTModelingTests/Issue721CorrectedFrenetPlacementTests.swift
@@ -1,0 +1,126 @@
+// #721: ".correctedFrenet pipe sweeps are up to 27% off the true volume and reverse sign, while
+// .frenet is exact." Two rounds of measurement on the issue reproduced that table (pitch 1/4/12/30,
+// radius=10, turns=3, circular profile radius=1.5) and a prior investigation branch narrowed a
+// real, separate mechanism: `Wire.helix(turns: n)` builds n edges, and `BRepFill_Edge3DLaw` gives
+// each edge its own independent `GeomFill_CorrectedFrenet`, whose twist-angle law resets to zero
+// at the start of every edge -- a genuine ~0.4 rad discontinuity at pitch=4, confirmed directly by
+// sampling `GeomFill_CorrectedFrenet::D0` against `GeomFill_Frenet::D0` on the same parameter.
+//
+// That mechanism turned out not to be the cause of the reported volumes. This file's own dense
+// sweep (below) found NO divergence at any turn count (1 through 8, including half-turns, so 0
+// through 7 internal edge boundaries) once the profile is placed at the spine's own measured start
+// point and tangent -- the per-edge reset is real but volume-neutral for a circular profile,
+// exactly as the issue's own symmetry argument predicts (the two laws differ only by a rotation
+// about the tangent, and a circle is invariant under that rotation).
+//
+// The actual cause: both rounds of measurement, and the already-shipped
+// `Issue598PipeShellFrenetModeTests.cookbookSpringRecipeVolumeInvariant` (and
+// `docs/guides/cookbook/helices.md`'s "coiled spring" recipe it was modeled on), placed the
+// profile at `SIMD3(r, 0, 0)` with tangent `normalize(0, r, pitch/2pi)`, describing that as "the
+// helix start, with its normal along the tangent there." `Wire.helix`'s default `clockwise: false`
+// reverses the build axis to -Z, so the wire's actual start is `(-r, ~0, 0)`, descending -- the
+// profile in every prior measurement sat 2r away from the spine, with a tangent whose Z-component
+// had the wrong sign.
+//
+// `.frenet`'s volume happened not to depend on this: `BRepOffsetAPI_MakePipeShell` re-derives the
+// Frenet trihedron from the spine itself, and a circle has no preferred rotation, so a profile
+// plane merely consistent with *some* congruent (here, mirrored) helix still sweeps to the right
+// volume. `.correctedFrenet`'s per-edge twist-angle law is referenced to the input frame and is not
+// insensitive to it -- the mismatch is exactly what produced the reported numbers (reproduced
+// below at the issue's own ratios, to 3 significant figures).
+
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+@Suite("#721: .correctedFrenet's reported divergence is a profile-placement artifact, not a defect")
+struct Issue721CorrectedFrenetPlacementTests {
+
+    /// The spine's own measured start point and tangent -- the only placement that is actually
+    /// "on the spine, tangent to it," as opposed to a point/tangent consistent with some other,
+    /// merely congruent helix.
+    static func measuredStartFrame(of spine: Wire) -> (origin: SIMD3<Double>, tangent: SIMD3<Double>)? {
+        guard let firstEdge = spine.edges().first, let curve = firstEdge.curve3D else { return nil }
+        let (p0, t0) = curve.d1(at: curve.domain.lowerBound)
+        return (p0, simd_normalize(t0))
+    }
+
+    /// The discriminator the issue asked for: does the divergence require an internal wire
+    /// boundary (`turns` > 1, hence >1 edge), scaling with boundary count? Swept densely,
+    /// including half-turns so odd boundary counts are covered, at every pitch the issue itself
+    /// measured. With a correctly-placed profile the answer is no at every single point: both
+    /// modes match the textbook tube volume and each other to ~1e-6 relative, regardless of edge
+    /// count. The per-edge twist-angle reset (real, see the file header) is volume-neutral here.
+    @Test("frenet and correctedFrenet agree with the textbook volume at every turn count, pitch, and internal-boundary count")
+    func agreementHoldsAcrossPitchAndTurnCount() {
+        let r = 10.0, wireRadius = 1.5
+        let pitches = [1.0, 4.0, 12.0, 30.0]
+        let turnsList = [1.0, 1.5, 2.0, 2.5, 3.0, 5.0, 6.0, 8.0] // 0 through 7 internal boundaries
+
+        for pitch in pitches {
+            for turns in turnsList {
+                guard let spine = Wire.helix(radius: r, pitch: pitch, turns: turns) else {
+                    Issue.record("Could not build spine at pitch \(pitch) turns \(turns)"); continue
+                }
+                let edgeCount = spine.edges().count
+                guard let (origin, tangent) = Self.measuredStartFrame(of: spine),
+                      let profile = Wire.circle(origin: origin, normal: tangent, radius: wireRadius),
+                      let frenet = Shape.pipeShell(spine: spine, profile: profile, mode: .frenet, solid: true),
+                      let corrected = Shape.pipeShell(spine: spine, profile: profile, mode: .correctedFrenet, solid: true),
+                      let vFrenet = frenet.volume, let vCorrected = corrected.volume else {
+                    Issue.record("Could not build the sweeps at pitch \(pitch) turns \(turns)"); continue
+                }
+
+                let c = pitch / (2 * Double.pi)
+                let coilLength = turns * 2 * Double.pi * (r * r + c * c).squareRoot()
+                let textbookVolume = Double.pi * wireRadius * wireRadius * coilLength
+
+                #expect(vFrenet.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-4),
+                        "pitch \(pitch) turns \(turns) (\(edgeCount) edges): .frenet (\(vFrenet)) should match textbook (\(textbookVolume))")
+                #expect(vCorrected.isApproximatelyEqual(to: textbookVolume, tolerance: 1e-4),
+                        "pitch \(pitch) turns \(turns) (\(edgeCount) edges): .correctedFrenet (\(vCorrected)) should match textbook (\(textbookVolume))")
+                #expect(vFrenet.isApproximatelyEqual(to: vCorrected, tolerance: 1e-4),
+                        "pitch \(pitch) turns \(turns) (\(edgeCount) edges): the two trihedron laws must agree on a circular profile")
+            }
+        }
+    }
+
+    /// A direct instrument on the mechanism the prior investigation branch flagged: does
+    /// `GeomFill_CorrectedFrenet`'s per-edge reset actually perturb `Shape.pipeShell`'s frame
+    /// evolution across an internal wire boundary? `Shape.correctedFrenet(at:)`
+    /// (`Shape+Surface.swift`, `OCCTGeomFillCorrectedFrenet`) works per-*edge*, exactly matching
+    /// `BRepFill_Edge3DLaw`'s own construction (an independent `GeomFill_CorrectedFrenet` built
+    /// fresh on each edge's own `BRepAdaptor_Curve`), so this samples edge 1 at its own last
+    /// parameter and edge 2 at its own first parameter -- the two sides of the internal boundary
+    /// `Wire.helix(turns: 2)` introduces. Included as evidence, not as the volume claim: the frame
+    /// does move (confirming the reset is real), and it still costs nothing in the swept volume
+    /// test above, at this and every other boundary count checked.
+    @Test("the per-edge frame reset is real (not what the volume test above is failing to detect)")
+    func perEdgeResetIsReal() {
+        let r = 10.0, pitch = 12.0
+        guard let spine = Wire.helix(radius: r, pitch: pitch, turns: 2) else {
+            Issue.record("Could not build the fixture"); return
+        }
+        let edges = spine.edges()
+        guard edges.count == 2,
+              let curve1 = edges[0].curve3D, let curve2 = edges[1].curve3D,
+              let edgeShape1 = Shape.fromEdge(edges[0]), let edgeShape2 = Shape.fromEdge(edges[1]) else {
+            Issue.record("Expected a 2-edge wire with readable curves"); return
+        }
+
+        guard let frameBefore = edgeShape1.correctedFrenet(at: curve1.domain.upperBound),
+              let frameAfter = edgeShape2.correctedFrenet(at: curve2.domain.lowerBound) else {
+            Issue.record("Could not sample the trihedron across the boundary"); return
+        }
+
+        let cosAngle = simd_dot(simd_normalize(frameBefore.normal), simd_normalize(frameAfter.normal))
+        let angleDeg = acos(Swift.max(-1, Swift.min(1, cosAngle))) * 180 / .pi
+
+        // The curve is C-infinity smooth across this point (it is one continuous helix, split
+        // into edges only by Wire.helix's per-turn construction) -- a continuous law would show a
+        // near-zero angle here. The per-edge reset means it does not.
+        #expect(angleDeg > 1.0,
+                "expected a real discontinuity in the corrected-Frenet normal across the internal edge boundary, measured \(angleDeg) degrees")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -848,6 +848,21 @@ distinguish them. Since the cookbook's own claimed invariant
 recipe is corrected in this same PR to use `.frenet`, and its prose no longer claims rotational
 symmetry makes the two laws interchangeable.
 
+**Revised after OCCTSwift #721: the paragraph above was itself wrong, not just the cookbook.** The
+"about 12% larger" measurement placed the profile at `SIMD3(r, 0, 0)` with tangent
+`normalize(0, r, pitch/2pi)`, describing that as the helix's own start point and tangent. It is
+neither: `Wire.helix`'s default `clockwise: false` reverses the build axis to -Z, so the wire's
+actual start is `(-r, ~0, 0)`, descending, and the real tangent's Z-component has the opposite
+sign. With the profile placed at the spine's own measured start point and tangent instead,
+`.frenet` and `.correctedFrenet` agree with each other and with the textbook volume to ~1e-6
+relative, at every pitch and turn count tested (see #721's own PR for the full sweep). The
+rotational-symmetry argument this entry originally walked back was correct after all; the
+measurement that contradicted it was constructing the wrong profile, not testing a real
+`.correctedFrenet` limitation. `docs/guides/cookbook/helices.md`'s recipe and this repo's own
+`Issue598PipeShellFrenetModeTests.cookbookSpringRecipeVolumeInvariant` are corrected in #721's PR to
+measure the tangent from the wire rather than compute it analytically, and `.correctedFrenet` is
+restored as a mode that also produces the textbook volume on a helical spring.
+
 Every other existing pipe-shell call site in this repo's tests uses either a straight spine or a
 non-Frenet mode (`.fixed(binormal:)`, `.auxiliary(spine:)`) this bug never touched. Exactly one
 existing hardcoded literal needed updating: `Issue503PipeShellTests.fixedBinormalDiffersFromFrenet`'s

--- a/docs/guides/cookbook/helices.md
+++ b/docs/guides/cookbook/helices.md
@@ -31,9 +31,12 @@ start, with its normal along the helix tangent there:
 let r = 10.0, pitch = 4.0, turns = 5.0, wireRadius = 1.5
 guard let spine = Wire.helix(radius: r, pitch: pitch, turns: turns) else { return }
 
-// helix tangent at the start point (r, 0, 0): d/dt(r·cos t, r·sin t, pitch·t/2π) at t = 0
-let tangent = simd_normalize(SIMD3<Double>(0, r, pitch / (2 * .pi)))
-guard let profile = Wire.circle(origin: SIMD3(r, 0, 0), normal: tangent, radius: wireRadius),
+// Measure the spine's own start point and tangent — don't compute them analytically.
+// `Wire.helix`'s default clockwise: false reverses the build axis, so the wire's actual start
+// is (-r, ~0, 0), descending, not (r, 0, 0) ascending as a naive right-handed formula would give.
+guard let firstEdge = spine.edges().first, let curve = firstEdge.curve3D else { return }
+let (origin, tangent) = curve.d1(at: curve.domain.lowerBound)
+guard let profile = Wire.circle(origin: origin, normal: simd_normalize(tangent), radius: wireRadius),
       let spring  = Shape.pipeShell(spine: spine, profile: profile,
                                     mode: .frenet, solid: true) else { return }
 // spring.isValid == true; spring.volume ≈ π·wireRadius²·(coil length)
@@ -49,14 +52,18 @@ guard let profile = Wire.circle(origin: SIMD3(r, 0, 0), normal: tangent, radius:
 
 <sub>🖱️ Drag to orbit · scroll to zoom · auto-rotating. The static render shows until the 3D model loads. (Model exported straight from the snippet above via `Exporter.writeGLTF`.)</sub>
 
-Use `mode: .frenet`: for this coil it keeps the section true to the textbook tube volume
-(`π·wireRadius²` times the coil length, matched to within numerical tolerance and cross-checked
-against an independent `PipeShellBuilder` oracle). `.correctedFrenet` also builds a valid solid on
-this spine, but measured, not assumed, it does not preserve that volume here (about 12% larger on
-the parameters above). `.correctedFrenet`'s own purpose is avoiding twist at a genuine curvature
-*inflection* (see its doc comment); a helix has constant, never-zero curvature, so that case never
-arises here, and this recipe does not need it. See [`CHANGELOG.md`](../../CHANGELOG.md)'s #598 entry
-for the measurement and why this recipe changed which mode it names.
+`mode: .frenet` and `mode: .correctedFrenet` both keep the section true to the textbook tube volume
+here (`π·wireRadius²` times the coil length, matched to within numerical tolerance and cross-checked
+against an independent `PipeShellBuilder` oracle) — a circle is rotationally symmetric, so the two
+trihedron laws, which differ only by a rotation about the tangent, must sweep the identical solid.
+An earlier version of this page claimed `.correctedFrenet` did *not* preserve that volume (~12%
+larger); that was a bug in the recipe's own profile placement, not in `.correctedFrenet` — the
+snippet above computed the tangent from a formula rather than measuring it from the wire, and got
+both the origin and the sign wrong (see the code comment). `.frenet`'s output happened to be
+insensitive to that particular mistake; `.correctedFrenet`'s was not. See OCCTSwift
+[#721](https://github.com/SecondMouseAU/OCCTSwift/issues/721) for the full investigation, including
+a dense sweep across pitch and turn count confirming the two modes agree everywhere once the
+profile is placed correctly.
 
 ## Conical, tapered, and variable-pitch coils
 


### PR DESCRIPTION
## What & why

#721 reported `.correctedFrenet` pipe sweeps up to 27% off the true volume (and reversing sign)
against `.frenet`, on `Wire.helix` swept with a circular profile. Two rounds of measurement on the
issue reproduced that table, and a prior investigation branch found a real, separate mechanism
(`BRepFill_Edge3DLaw` gives each of `Wire.helix(turns: n)`'s `n` edges an independent
`GeomFill_CorrectedFrenet`, whose twist-angle law resets at every edge boundary) but called it
volume-neutral, which the second round's own table contradicted.

Neither the per-edge reset nor `.correctedFrenet` is the cause. Both rounds of measurement, and the
already-shipped `Issue598PipeShellFrenetModeTests.cookbookSpringRecipeVolumeInvariant` test (and
`docs/guides/cookbook/helices.md`'s recipe it was modeled on), placed the profile at
`SIMD3(r, 0, 0)` with tangent `normalize(0, r, pitch/2pi)`, describing that as the helix's own start
point and tangent. It is neither: `Wire.helix`'s default `clockwise: false` reverses the build axis,
so the wire's actual start is `(-r, ~0, 0)`, descending, with the opposite tangent sign — the
profile in every prior measurement sat `2×radius` from the spine. `.frenet`'s volume happened not
to depend on this (`BRepOffsetAPI_MakePipeShell` re-derives the Frenet trihedron from the spine
itself, and a circle has no preferred rotation); `.correctedFrenet`'s per-edge twist-angle law is
referenced to the input frame and is not insensitive to it — the mismatch is exactly what produced
the reported numbers (reproduced in the probes below to 3 significant figures).

With the profile placed at the spine's own **measured** start point and tangent, `.frenet` and
`.correctedFrenet` agree with each other and with the textbook volume to ~1e-6 relative, at every
pitch (1, 4, 12, 30) and turn count (1 through 8, including half-turns — 0 through 7 internal edge
boundaries) tested. The per-edge reset is real (confirmed directly) but volume-neutral for a
circular profile, exactly as the issue's own symmetry argument predicts.

No kernel or bridge change: `Sources/OCCTBridge/src/OCCTBridge_Modeling.mm`'s
`OCCTShapeCreatePipeShellMultiSection` and `OCCTWireCreateHelix` were read line-for-line against the
probes and match exactly. The fix is the mis-placed-profile construction, wherever it appeared:

- `Tests/OCCTModelingTests/Issue598PipeShellFrenetModeTests.swift`: `cookbookSpringRecipeVolumeInvariant`
  corrected to measure the profile placement instead of computing it; its old (wrong) construction
  is kept as a new, separate regression test (`misplacedProfileReproducesIssue721Divergence`)
  reproducing the issue's own reported ratios, so it can't be reintroduced silently.
- `Tests/OCCTModelingTests/Issue721CorrectedFrenetPlacementTests.swift` (new): the dense pitch/turns
  sweep that resolved the issue, plus a direct instrument confirming the per-edge reset is real
  without costing any volume.
- `docs/guides/cookbook/helices.md`: the "coiled spring" recipe now measures the tangent from the
  wire, and the prose no longer claims `.correctedFrenet` fails to preserve the tube volume.
- `docs/CHANGELOG.md`: the pre-existing `#598` entry (still `## Unreleased`) carried the same wrong
  claim; corrected in place per the "fixes the changelog itself" exception in
  `okf/policies/changelog-on-merge.md` (not adding a new entry — my own entry is below, per that
  policy).
- `Sources/OCCTSwift/Wire.swift`: `Wire.helix`'s doc comment now says where the wire actually starts
  under `clockwise: false`, and to measure rather than compute that point/tangent analytically.
- `Scripts/repro/721-frenet-corrected-frenet/`: three probes and a README walking through the
  discriminator experiment the issue suggested (does a single-edge spine avoid the divergence?
  originally looked like "no, even multi-edge with a measured tangent shows nothing," which is what
  led to isolating the actual profile-placement mismatch).

Closes #721

## CHANGELOG entry

### `.correctedFrenet`'s reported pipe-sweep volume divergence was a profile-placement bug, not a defect (#721)

`Wire.helix`'s default `clockwise: false` reverses the build axis, so the wire's actual start point
is `(-radius, ~0, 0)`, descending — not `(radius, 0, 0)` ascending, as a naive right-handed
parametrization (and both rounds of #721's own measurement, and the pre-existing
`docs/guides/cookbook/helices.md` "coiled spring" recipe) assumed. `.frenet`'s volume happened not
to depend on the resulting mismatch; `.correctedFrenet`'s did, reproducing the issue's reported
divergence (up to 27.6%, reversing sign at high pitch) exactly. With the profile placed at the
spine's own measured start point and tangent, both trihedron laws agree with each other and the
textbook tube volume at every pitch and turn count tested. `Wire.helix`'s doc comment and the
cookbook recipe now say to measure the tangent from the wire rather than compute it analytically.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — `Issue721CorrectedFrenetPlacementTests.swift`
      (new) and the corrected/added tests in `Issue598PipeShellFrenetModeTests.swift`. Every new
      assertion was proven to fail by injecting the original defect first (see the PR's test-file
      doc comments for the injection notes).

## Notes for the reviewer

- **GitHub Actions is reportedly in a major outage** at the time of this PR; only local verification
  is available. Locally: `swift build` (whole package) clean; `swift test --filter OCCTModelingTests`
  597/597 passing; all four self-testable gate scripts pass `--self-test` and a real run
  (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
  `derive-bridge-header-split --verify`), plus `count-operations.py` (unaffected, doc-only/test-only
  change — no new public API).
- Built/tested against the actual pinned `v2.0.0-kernel.1` release artifact (`env -u OCCTSWIFT_LOCAL`;
  the shared `Libraries/OCCT.xcframework` was independently confirmed byte-identical to the release
  asset before trusting it for the C++ probes).
- No kernel or bridge change proposed — see "What & why" for why one isn't needed here.