### PR TITLE
fix(#438): unify divided(at:) and dividedByContinuity onto one entry point

### DIFF
--- a/.claude/workflows/bridge-duplication-audit.js
+++ b/.claude/workflows/bridge-duplication-audit.js
@@ -1,0 +1,544 @@
+export const meta = {
+  name: 'bridge-duplication-audit',
+  description: 'Cross-reference/drift audit of the OCCT C++ bridge header pair (Pass 1b of #377, issue #381) — bridge-specific angles, aware of what Pass 1a (#380) has already landed on refactor/377-segmented-audit',
+  whenToUse: 'For issue #381 (Pass 1b: OCCTBridge.h + OCCTBridge_Internal.h). Sibling of duplication-audit.js but NOT a drop-in reuse: this header is a hand-written OCCT wrapper where per-function C-wrapper repetition is EXPECTED, not a finding, so the four Swift-app angles in duplication-audit.js do not apply. Looks instead for stale cross-reference-index entries, duplicate/inconsistent declarations, header/.mm split drift, and bridge-side duplication a Pass 1a Swift-side fix should have mirrored but did not. Defaults to issue 381 with no args; pass a different issue number or {files:[...]} to reuse this shape elsewhere.',
+  phases: [
+    { title: 'Scope' },
+    { title: 'Context' },
+    { title: 'Find' },
+    { title: 'Sweep' },
+    { title: 'Verify' },
+    { title: 'Synthesize' },
+  ],
+}
+
+// Purpose-built sibling of duplication-audit.js for #381 (Pass 1b) rather than a
+// reuse of it: #381's own scope text says this header's per-function boilerplate
+// is intentional, so the generic Swift-app angles (reimplemented helpers,
+// copy-pasted math, drifted docs, parallel primitives) would misfire here. Two
+// structural differences from duplication-audit.js:
+//
+// 1. OCCTBridge.h is 21,137 lines in ONE file with 598 "// MARK: -" lines (#381's
+//    text says "~70" — checked live via grep before writing this, that count is
+//    off by ~8.5x, so this script measures structure at run time rather than
+//    trusting either number). duplication-audit.js's file-clustering groups a
+//    single large file into one unsplit group; that would hand one finder the
+//    entire header. This script instead chunks OCCTBridge.h into line-range
+//    groups along MARK boundaries, sized to GROUP_LOC_THRESHOLD.
+// 2. A new Context phase fetches what Pass 1a (#380, the parallel foundation-layer
+//    pass) has actually landed on refactor/377-segmented-audit. #381 is declared
+//    to run in parallel with #380 with no dependency, but by the time this
+//    executes 1a has usually landed real Swift-side fixes — some of which may
+//    have left an unmirrored duplicate on the C side. That context feeds Angle 4
+//    below and is fetched live (via gh), not hardcoded, so it stays current as
+//    more Pass 1a PRs land.
+//
+// Branch note: this script only READS from refactor/377-segmented-audit (Pass
+// 1a's landed work) — it never files or targets anything there. Pass 1b's own
+// findings get filed by bridge-duplication-triage.js against a separate branch,
+// refactor/381-pass1b, kept apart from Pass 1a's branch while that branch is
+// still under code review.
+
+const REPO = 'SecondMouseAU/OCCTSwift'
+const PASS_1A_BRANCH = 'refactor/377-segmented-audit'
+const PASS_1A_ISSUE = 380
+const GROUP_LOC_THRESHOLD = 2500
+const GROUP_FINDER_CAP = 10
+const CROSS_CAP = 10
+const SWEEP_CAP = 10
+const MAX_FINDINGS = 25
+
+const NOT_FINDINGS_TEXT =
+  'Do NOT flag as duplication: the ordinary one-C-function-per-exposed-operation pattern (every\n' +
+  'wrapped OCCT op getting its own OCCTShape.../OCCTWire.../OCCTFace... declaration, its own Release\n' +
+  'function, its own repeated error-handling shape). That repetition is this header\'s documented,\n' +
+  'intended structure (CLAUDE.md\'s release process adds ~100 such declarations every release), not\n' +
+  'accidental drift. Only report duplication that is genuinely accidental: declarations that used to\n' +
+  'be one thing and diverged, or index/grouping metadata that fell out of sync with the code.\n'
+
+const ANGLES_TEXT =
+  '### Angle 1 — Stale cross-reference index\n' +
+  'OCCTBridge.h opens with an "OCCT Class Cross-Reference Index" (currently lines ~19-525) mapping\n' +
+  'OCCT C++ classes to the bridge functions/files that wrap them. Find entries that no longer match\n' +
+  'reality: a listed function that was renamed, removed, or moved to a different\n' +
+  'OCCTBridge_<Domain>.mm file since the index entry was written; a class the index credits with a\n' +
+  'wrapper that no longer calls it (or never did); or a class actually used by a shipped bridge\n' +
+  'function with no index entry at all.\n\n' +
+  '### Angle 2 — Duplicate or inconsistent declarations\n' +
+  'Find the same C function declared more than once, two declarations that should be one (near-\n' +
+  'identical signatures wrapping the same OCCT operation under different names — not the expected\n' +
+  'one-function-per-operation pattern, but a genuine accidental double), or a declaration whose\n' +
+  'parameter list/return type/nullability annotation has drifted from its\n' +
+  'OCCTBridge_<Domain>.mm implementation.\n\n' +
+  '### Angle 3 — Header/.mm split drift\n' +
+  'The header\'s MARK sections and the 16-way OCCTBridge_<Domain>.mm split were meant to mirror each\n' +
+  'other, but the header was never re-split to match as the .mm files evolved independently. Find a\n' +
+  '`// MARK:` group whose declarations are actually implemented across more than one .mm file, or\n' +
+  'implemented in a .mm file whose domain clearly does not match the MARK label.\n\n' +
+  '### Angle 4 — Bridge-side duplication a Pass 1a fix should have mirrored\n' +
+  'Pass 1a (#' + PASS_1A_ISSUE + ', see the Context section you were given) found and in many cases\n' +
+  'already fixed duplication/drift on the SWIFT side of this repo. For each Pass 1a finding listed as\n' +
+  'landed, check whether the underlying bridge functions have the analogous problem: two C functions\n' +
+  'still backing what is now a single unified Swift type/enum, a bridge-side tolerance/default\n' +
+  'constant that still disagrees the way the pre-fix Swift-side ones did, or a bridge function\n' +
+  'orphaned by a Pass 1a rename/removal that nothing calls anymore. Only report if you can name the\n' +
+  'specific bridge function(s) AND the specific Pass 1a issue/PR whose Swift-side change this should\n' +
+  'have mirrored.\n\n' +
+  NOT_FINDINGS_TEXT
+
+const ISSUE_SCOPE_SCHEMA = {
+  type: 'object', required: ['files'],
+  properties: {
+    title: { type: 'string' },
+    parentIssue: { type: 'number' },
+    scopeNotes: { type: 'string', description: 'the issue\'s own "## Scope" text, verbatim, if present' },
+    files: { type: 'array', items: {
+      type: 'object', required: ['path'],
+      properties: { path: { type: 'string' } },
+    }},
+    notes: { type: 'string', description: 'any listed file that turned out not to exist, or other discrepancies' },
+  },
+}
+const FILE_STRUCTURE_SCHEMA = {
+  type: 'object', required: ['files'],
+  properties: {
+    files: { type: 'array', items: {
+      type: 'object', required: ['path', 'totalLines'],
+      properties: {
+        path: { type: 'string' },
+        totalLines: { type: 'number', description: 'live `wc -l` result, not a number copied from anywhere else' },
+        markLines: { type: 'array', items: { type: 'number' }, description: 'line numbers of every "// MARK: -" occurrence, in ascending order, via `grep -n', },
+      },
+    }},
+  },
+}
+const PASS1A_SCHEMA = {
+  type: 'object', required: ['landed', 'stillOpen'],
+  properties: {
+    landed: { type: 'array', items: {
+      type: 'object', required: ['issue', 'title'],
+      properties: {
+        issue: { type: 'number' }, title: { type: 'string' }, pr: { type: 'number' },
+        summary: { type: 'string', description: 'one line: what Swift-side code actually changed, read from the merged PR diff' },
+      },
+    }},
+    stillOpen: { type: 'array', items: {
+      type: 'object', required: ['issue', 'title'],
+      properties: { issue: { type: 'number' }, title: { type: 'string' } },
+    }},
+  },
+}
+const CANDIDATES_SCHEMA = {
+  type: 'object', required: ['candidates'],
+  properties: {
+    candidates: { type: 'array', items: {
+      type: 'object', required: ['file', 'summary', 'failure_scenario'],
+      properties: {
+        file: { type: 'string', description: 'repo-relative path of the primary/worse-drifted location to fix' },
+        line: { type: 'number' },
+        summary: { type: 'string', description: 'one line naming both the primary location and its duplicate counterpart (file:line)' },
+        failure_scenario: { type: 'string', description: 'the concrete maintenance cost: what is duplicated/stale/drifted, or why it should be unified' },
+      },
+    }},
+  },
+}
+const GROUP_VERDICT_SCHEMA = {
+  type: 'object', required: ['verdicts'],
+  properties: {
+    verdicts: { type: 'array', items: {
+      type: 'object', required: ['index', 'verdict', 'evidence'],
+      properties: {
+        index: { type: 'number', description: 'the [i] label of the candidate this verdict is for' },
+        verdict: { enum: ['CONFIRMED', 'PLAUSIBLE', 'REFUTED'] },
+        evidence: { type: 'string' },
+      },
+    }},
+  },
+}
+const REPORT_SCHEMA = {
+  type: 'object', required: ['summary', 'decisions'],
+  properties: {
+    summary: { type: 'string' },
+    decisions: { type: 'array', items: {
+      type: 'object', required: ['index'],
+      properties: {
+        index: { type: 'number' },
+        merge: { type: 'array', items: { type: 'number' } },
+      },
+    }},
+  },
+}
+
+// ─── Phase 0: Scope ───
+phase('Scope')
+let ISSUE = null, DIRECT_FILES = null
+if (args === undefined || args === null) ISSUE = 381
+else if (typeof args === 'number') ISSUE = args
+else if (typeof args === 'string' && /^\d+$/.test(args.trim())) ISSUE = parseInt(args.trim(), 10)
+else if (args && typeof args === 'object') {
+  if (args.issue) ISSUE = Number(args.issue)
+  if (Array.isArray(args.files)) DIRECT_FILES = args.files.map(f => (typeof f === 'string' ? { path: f } : f))
+}
+if (!ISSUE && !DIRECT_FILES) {
+  return { error: 'bridge-duplication-audit needs an issue number (defaults to 381 with no args) or {files:[...]}.' }
+}
+
+let files, issueTitle = null, parentIssue = null, scopeNotes = ''
+if (DIRECT_FILES) {
+  files = DIRECT_FILES
+} else {
+  const scoped = await agent(
+    'Run `gh issue view ' + ISSUE + ' --repo ' + REPO + '` and read its body.\n\n' +
+    'Extract:\n' +
+    '1. title\n' +
+    '2. parentIssue — the parent issue number if the issue has one (from a "Part of ... #<N>" ' +
+    '   reference in the body), otherwise omit it.\n' +
+    '3. scopeNotes — the issue\'s own "## Scope" section text, verbatim, if present.\n' +
+    '4. files — every repo-relative, backtick-wrapped path listed under the "## Files" section.\n' +
+    '   Do NOT extract any LOC number that may appear next to a path or in the section heading — it\n' +
+    '   is frequently stale or absent; this script measures real sizes itself in the next phase.\n\n' +
+    'Then verify every listed file actually exists in the repo (e.g. `test -f <path>`) from the ' +
+    'current working directory. Drop any that do not exist and note the discrepancy in `notes`.\n\n' +
+    'Structured output only.',
+    { label: 'scope:issue' + ISSUE, schema: ISSUE_SCOPE_SCHEMA }
+  )
+  if (!scoped || !scoped.files || scoped.files.length === 0) {
+    return { error: 'Could not resolve a file scope from issue #' + ISSUE + ' (empty or missing "## Files" section).' }
+  }
+  files = scoped.files
+  issueTitle = scoped.title || null
+  parentIssue = scoped.parentIssue || null
+  scopeNotes = scoped.scopeNotes || ''
+  if (scoped.notes) log('Scope notes: ' + scoped.notes)
+}
+
+const ALL_FILES = files.map(f => f.path)
+log('Scope: ' + ALL_FILES.length + ' file(s)' + (issueTitle ? ' — ' + issueTitle : '') + ': ' + ALL_FILES.join(', '))
+
+const structure = await agent(
+  'For EACH of these files, run `wc -l <path>` for its live total line count, and ' +
+  '`grep -n \'^// MARK: -\' <path>` to list every MARK line\'s line number in ascending order (empty ' +
+  'array if the file has none — e.g. a small internal header may have no MARK sections at all):\n\n' +
+  ALL_FILES.map(f => '  - ' + f).join('\n') + '\n\n' +
+  'Report real, freshly-measured numbers — do not estimate or reuse any figure you may recall from ' +
+  'elsewhere. Structured output only.',
+  { label: 'scope:structure', schema: FILE_STRUCTURE_SCHEMA }
+)
+const structByPath = Object.create(null)
+for (const f of (structure && structure.files) || []) structByPath[f.path] = f
+for (const p of ALL_FILES) {
+  if (!structByPath[p]) { structByPath[p] = { path: p, totalLines: 0, markLines: [] } }
+}
+const totalLoc = ALL_FILES.reduce((s, p) => s + (structByPath[p].totalLines || 0), 0)
+log('Measured: ' + totalLoc + ' LOC across ' + ALL_FILES.length + ' file(s), ' +
+  ALL_FILES.map(p => p.split('/').pop() + '=' + (structByPath[p].markLines || []).length + ' MARKs').join(', '))
+
+// ─── Chunk each file into line-range groups along MARK boundaries, sized to
+// GROUP_LOC_THRESHOLD. A file under the threshold, or with no MARK lines at all,
+// becomes one whole-file group (mirrors duplication-audit.js's "don't split a
+// small cluster" rule, just applied within a file instead of across files).
+const chunkFile = (path, totalLines, markLines) => {
+  if (!totalLines) return []
+  if (totalLines <= GROUP_LOC_THRESHOLD || !markLines || markLines.length === 0) {
+    return [{ path, startLine: 1, endLine: totalLines }]
+  }
+  const chunks = []
+  let chunkStart = 1
+  let lastBoundary = 1
+  for (const m of markLines) {
+    if (m - chunkStart >= GROUP_LOC_THRESHOLD && lastBoundary > chunkStart) {
+      chunks.push({ path, startLine: chunkStart, endLine: lastBoundary - 1 })
+      chunkStart = lastBoundary
+    }
+    lastBoundary = m
+  }
+  chunks.push({ path, startLine: chunkStart, endLine: totalLines })
+  return chunks
+}
+const FILE_GROUPS = ALL_FILES.flatMap(p => chunkFile(p, structByPath[p].totalLines, structByPath[p].markLines))
+const marksIn = g => (structByPath[g.path].markLines || []).filter(m => m >= g.startLine && m <= g.endLine).length
+const groupLabel = g => g.path.split('/').pop().replace(/\.h$/, '') + '_L' + g.startLine + '-' + g.endLine
+log('Chunked into ' + FILE_GROUPS.length + ' finder group(s): ' + FILE_GROUPS.map(g => groupLabel(g) + '(' + marksIn(g) + ' MARKs)').join(', '))
+const chunkBoundaries = FILE_GROUPS.filter((g, i) => i > 0 && FILE_GROUPS[i - 1].path === g.path).map(g => g.path + ':' + g.startLine)
+
+const SCOPE_BLOCK =
+  '## Audit scope — issue #' + (ISSUE || '?') + (parentIssue ? ' (sub-issue of #' + parentIssue + ')' : '') +
+  (issueTitle ? ': ' + issueTitle : '') + '\n' +
+  'This is a STATIC audit of the existing, already-committed OCCT C++ bridge header pair — there is\n' +
+  'no diff or PR to review. It is a hand-written OCCT wrapper, not Swift application code: per-\n' +
+  'function C-wrapper repetition is expected here, so the usual Swift-side duplication angles do not\n' +
+  'apply (see below).\n' +
+  (scopeNotes ? '\n' + scopeNotes + '\n' : '') +
+  '\nFull scope (' + totalLoc + ' LOC across ' + ALL_FILES.length + ' file(s)):\n' +
+  ALL_FILES.map(p => '  - ' + p + ' (' + structByPath[p].totalLines + ' lines, ' + (structByPath[p].markLines || []).length + ' MARK sections)').join('\n') + '\n'
+
+const canonFile = raw => {
+  if (!raw) return ''
+  const p = raw.replace(/\\/g, '/')
+  let best = ''
+  for (const sf of ALL_FILES) {
+    if ((p === sf || p.endsWith('/' + sf)) && sf.length > best.length) best = sf
+  }
+  return best || p
+}
+const ingest = (cs, cap) => cs.slice(0, cap).map(c => ({ ...c, file: canonFile(c.file) }))
+const loc = c => c.file + (c.line != null ? ':' + c.line : '')
+const inBounds = (i, n) => Number.isInteger(i) && i >= 0 && i < n
+
+// ─── Phase: Context — what Pass 1a has actually landed on the audit branch,
+// fetched live (not a fixed snapshot) so this stays current as more Pass 1a PRs
+// merge. Feeds Angle 4 above.
+phase('Context')
+const pass1a = await agent(
+  'Compile what Pass 1a (issue #' + PASS_1A_ISSUE + ' of the #377 segmented duplication audit) has ' +
+  'already landed on branch `' + PASS_1A_BRANCH + '` in repo ' + REPO + '.\n\n' +
+  '1. Run `gh api repos/' + REPO + '/issues/' + PASS_1A_ISSUE + '/sub_issues --jq \'.[] | "\\(.number) [\\(.state)] \\(.title)"\'` ' +
+  'to list every Pass 1a finding issue.\n' +
+  '2. Run `gh pr list --repo ' + REPO + ' --base ' + PASS_1A_BRANCH + ' --state merged --json number,title,body --limit 200` ' +
+  'to list merged PRs targeting the audit branch, and match each to a finding issue number from step 1 ' +
+  '(PR title/body usually names it, e.g. "fix(#399): ..."; fall back to ' +
+  '`git log ' + PASS_1A_BRANCH + ' --oneline --grep=\'#<n>\'` for any that don\'t match by title/body alone). ' +
+  'A finding issue staying open on GitHub does NOT mean it is unfixed — these PRs target a non-default ' +
+  'branch, so GitHub does not auto-close on merge; treat a matched merged PR as landed regardless of the ' +
+  'issue\'s open/closed state.\n' +
+  '3. For each finding confirmed landed, write a ONE-LINE summary of the actual Swift-side code change ' +
+  '(run `gh pr diff <n>` if the PR title alone is not enough detail to summarize accurately).\n' +
+  '4. List every remaining Pass 1a finding (no matching merged PR found) as stillOpen — issue + title only.\n\n' +
+  'Structured output only.',
+  { label: 'context:pass1a', schema: PASS1A_SCHEMA }
+)
+const landed = (pass1a && pass1a.landed) || []
+const stillOpen = (pass1a && pass1a.stillOpen) || []
+log('Pass 1a context: ' + landed.length + ' landed on ' + PASS_1A_BRANCH + ', ' + stillOpen.length + ' still open')
+
+const PASS1A_BLOCK =
+  '## Pass 1a (#' + PASS_1A_ISSUE + ') status on `' + PASS_1A_BRANCH + '` — fetched live this run, use for Angle 4\n' +
+  (landed.length > 0
+    ? 'Landed (' + landed.length + '):\n' + landed.map(l => '  - #' + l.issue + (l.pr ? ' (PR #' + l.pr + ')' : '') + ': ' + l.title + (l.summary ? ' — ' + l.summary : '')).join('\n') + '\n'
+    : '(nothing landed yet — Angle 4 will have nothing to check against this run)\n') +
+  (stillOpen.length > 0
+    ? 'Not yet landed (' + stillOpen.length + ', no bridge-side mirror check applies until these land):\n' +
+      stillOpen.map(l => '  - #' + l.issue + ': ' + l.title).join('\n') + '\n'
+    : '')
+
+// ─── Find: one finder per line-range group (Angles 2-3, in-range duplication and
+// MARK/.mm split drift; may Grep the rest of the repo to check cross-group/cross-
+// file echoes) + 2 cross-cutting finders whose angles are inherently whole-scope.
+phase('Find')
+const groupFinders = FILE_GROUPS.map(g => () =>
+  agent(
+    '## Bridge duplication-audit finder — ' + groupLabel(g) + '\n\n' + SCOPE_BLOCK + '\n' + PASS1A_BLOCK + '\n' +
+    'Your assigned range: lines ' + g.startLine + '-' + g.endLine + ' of ' + g.path +
+    ' (' + marksIn(g) + ' MARK sections). Read exactly this range using your Read tool\'s offset/limit\n' +
+    '(offset=' + g.startLine + ', limit=' + (g.endLine - g.startLine + 1) + ').\n\n' +
+    'Review through Angles 2-4 below (Angle 1, the cross-reference index, is handled by a separate\n' +
+    'whole-file finder — skip it unless something in your range obviously contradicts the index).\n' +
+    'You may Grep the rest of the repo (not just your assigned range) to check whether a declaration\n' +
+    'in your range duplicates something elsewhere, or to find the OCCTBridge_<Domain>.mm file backing\n' +
+    'it — but only report a finding if its PRIMARY (worse-drifted, or newer/messier) location is\n' +
+    'inside your assigned range.\n\n' + ANGLES_TEXT + '\n' +
+    'Surface up to ' + GROUP_FINDER_CAP + ' candidates. Each needs a primary file+line, a one-line summary naming\n' +
+    'both the primary location and its duplicate/stale counterpart (file:line, or the .mm file it should\n' +
+    'match), and a failure_scenario stating the concrete cost. Pass every candidate through even if only\n' +
+    'half-confident — an independent verifier judges them next. If nothing qualifies, return an empty list.\n\n' +
+    'Structured output only.',
+    { label: 'find:' + groupLabel(g), phase: 'Find', schema: CANDIDATES_SCHEMA }
+  ).then(r => {
+    if (!r) return []
+    log('find:' + groupLabel(g) + ': ' + r.candidates.length + ' candidates')
+    return ingest(r.candidates, GROUP_FINDER_CAP)
+  })
+)
+
+const CROSS_CUTTING = [
+  {
+    label: 'cross-reference-index',
+    focus:
+      'Focus specifically on Angle 1 (stale cross-reference index). Read the full "OCCT Class Cross-\n' +
+      'Reference Index" section at the top of OCCTBridge.h in one pass. For a representative sample of\n' +
+      'its entries (do not exhaustively check all — sample broadly across domains, prioritize entries\n' +
+      'that look old or reference less-common OCCT classes), grep Sources/OCCTBridge/src/OCCTBridge_*.mm\n' +
+      'to confirm the listed function(s) still exist, still live in the file the index implies, and still\n' +
+      'call the listed OCCT class. Report every mismatch found.\n',
+  },
+  {
+    label: 'pass1a-mirror-gaps',
+    focus:
+      'Focus specifically on Angle 4 (bridge-side duplication a Pass 1a fix should have mirrored). You\n' +
+      'were given the live Pass 1a landed/not-yet-landed list above. For each LANDED Pass 1a finding,\n' +
+      'run `gh pr diff <pr>` on its PR to see exactly what Swift-side code changed, then grep\n' +
+      'OCCTBridge.h/OCCTBridge_Internal.h and the relevant OCCTBridge_<Domain>.mm file(s) for the bridge\n' +
+      'functions those Swift symbols call. Check whether the C side still has the pre-fix duplication\n' +
+      '(e.g. still two C functions/constants where the Swift side is now unified) or has an orphaned\n' +
+      'function nothing calls anymore post-fix.\n',
+  },
+]
+const crossFinders = CROSS_CUTTING.map(c => () =>
+  agent(
+    '## Bridge duplication-audit finder — cross-cutting: ' + c.label + '\n\n' + SCOPE_BLOCK + '\n' + PASS1A_BLOCK + '\n' +
+    c.focus + '\n' + NOT_FINDINGS_TEXT + '\n' +
+    'Surface up to ' + CROSS_CAP + ' candidates. Each needs a primary file+line, a one-line summary naming\n' +
+    'both locations involved (file:line for each, or the PR it should have mirrored for Angle 4), and a\n' +
+    'failure_scenario stating the concrete cost or observed drift. If nothing qualifies, return an empty list.\n\n' +
+    'Structured output only.',
+    { label: 'find:' + c.label, phase: 'Find', schema: CANDIDATES_SCHEMA }
+  ).then(r => {
+    if (!r) return []
+    log('find:' + c.label + ': ' + r.candidates.length + ' candidates')
+    return ingest(r.candidates, CROSS_CAP)
+  })
+)
+
+const findOuts = await parallel([...groupFinders, ...crossFinders])
+let allCandidates = findOuts.filter(Boolean).flat()
+let candidatesSeen = allCandidates.length
+log('Find done: ' + candidatesSeen + ' total candidates')
+
+// ─── Sweep: one fresh finder hunting only for gaps the group/cross-cutting
+// finders above missed — including anything straddling a chunk boundary our own
+// line-range split may have cut through.
+phase('Sweep')
+const knownBlock = allCandidates.length > 0
+  ? allCandidates.map(c => '- ' + loc(c) + ' — ' + c.summary).join('\n')
+  : '(none)'
+const sweep = await agent(
+  '## Bridge duplication-audit sweep — gaps only\n\n' + SCOPE_BLOCK + '\n' + PASS1A_BLOCK + '\n' +
+  '## Already-found candidates (do NOT re-derive or re-report these)\n' + knownBlock + '\n\n' +
+  'Re-scan the full file scope (Grep across all of it together) looking ONLY for duplication/drift not\n' +
+  'already listed above. Two things to check specifically: (1) OCCTBridge.h was split into line-range\n' +
+  'groups for the Find pass at these boundaries: ' + (chunkBoundaries.length > 0 ? chunkBoundaries.join(', ') : '(none, whole file fit in one group)') +
+  ' — a MARK section or duplicated pair straddling one of these boundaries may have fallen through both\n' +
+  'sides. (2) Angle 3 (header/.mm split drift) between groups that never directly compared their MARK\n' +
+  'sections against each other.\n\n' +
+  ANGLES_TEXT + '\n' +
+  'Surface up to ' + SWEEP_CAP + ' additional candidates. If nothing new, return an empty list — do not pad.\n\n' +
+  'Structured output only.',
+  { label: 'sweep', phase: 'Sweep', schema: CANDIDATES_SCHEMA }
+)
+if (sweep && sweep.candidates.length > 0) {
+  const sliced = ingest(sweep.candidates, SWEEP_CAP)
+  candidatesSeen += sliced.length
+  log('sweep: ' + sliced.length + ' candidates')
+  allCandidates = allCandidates.concat(sliced)
+}
+
+// ─── Verify: one verifier agent per distinct (file, line) location, judging
+// every candidate reported at that location independently.
+phase('Verify')
+const VERDICT_LADDER =
+  '- **CONFIRMED** — read both locations (and, for an Angle 4 claim, the cited Pass 1a PR diff) and\n' +
+  '  confirm genuine, accidental duplication/drift; name the concrete cost or the actual point of drift.\n' +
+  '- **PLAUSIBLE** — the duplication/drift is real but its cost or exact scope is uncertain. State\n' +
+  '  what would confirm it.\n' +
+  '- **REFUTED** — not actually duplicated/stale (different purpose despite surface similarity, the\n' +
+  '  index entry is in fact still accurate, or this is the expected one-function-per-operation\n' +
+  '  pattern misidentified as duplication). Quote the code that proves it.'
+
+const byLoc = Object.create(null)
+for (const c of allCandidates) (byLoc[loc(c)] ||= []).push(c)
+const groups = Object.values(byLoc)
+const verifierAgents = groups.length
+const verifiedOut = await parallel(groups.map(g => async () => {
+  const short = g[0].file.split('/').pop()
+  const r = await agent(
+    '## Bridge duplication-audit verifier\n\n' + SCOPE_BLOCK + '\n' + PASS1A_BLOCK + '\n' +
+    '## Candidate findings at ' + loc(g[0]) + '\n' +
+    g.map((c, i) => '[' + i + '] Summary: ' + c.summary + '\n    Cost claimed: ' + c.failure_scenario).join('\n') + '\n\n' +
+    'Read the primary file and every duplicate-counterpart file/location named in each candidate\'s\n' +
+    'summary (for an Angle 4 claim, also run `gh pr diff <pr>` on the cited Pass 1a PR). Return one\n' +
+    'verdict per candidate, judged independently — candidates at the same location may describe\n' +
+    'distinct issues, the same one, or a mix. Reference each by its [i] index.\n\n' +
+    VERDICT_LADDER + '\n\nStructured output only. Evidence must quote or cite the relevant line(s) from BOTH locations.',
+    { label: 'verify:' + short + '(' + g.length + ')', phase: 'Verify', schema: GROUP_VERDICT_SCHEMA }
+  )
+  if (!r) return []
+  const byIdx = {}
+  for (const v of r.verdicts) if (inBounds(v.index, g.length)) byIdx[v.index] = v
+  return g.flatMap((c, i) => byIdx[i] ? [{ ...c, verdict: byIdx[i].verdict, evidence: byIdx[i].evidence }] : [])
+}))
+const verified = verifiedOut.filter(Boolean).flat()
+const surviving = verified.filter(c => c.verdict !== 'REFUTED')
+const refuted = verified.filter(c => c.verdict === 'REFUTED')
+log('Verify done: ' + verified.length + ' verified -> ' + surviving.length + ' kept, ' + refuted.length + ' refuted')
+
+const stats = {
+  issue: ISSUE || undefined,
+  fileGroups: FILE_GROUPS.length,
+  crossCuttingFinders: CROSS_CUTTING.length,
+  finders: FILE_GROUPS.length + CROSS_CUTTING.length + 1,
+  candidates: candidatesSeen,
+  verifierAgents,
+  verified: verified.length,
+  refuted: refuted.length,
+  pass1aLanded: landed.length,
+  pass1aStillOpen: stillOpen.length,
+}
+
+if (surviving.length === 0) {
+  return {
+    level: 'xhigh',
+    target: 'issue #' + ISSUE + (parentIssue ? ' (sub-issue of #' + parentIssue + ')' : '') + (issueTitle ? ': ' + issueTitle : ''),
+    summary: 'No duplication/drift findings survived verification.',
+    findings: [],
+    stats,
+  }
+}
+
+// ─── Synthesize: rank, merge semantic dupes, cap the report.
+phase('Synthesize')
+const rank = c => (c.verdict === 'PLAUSIBLE' ? 1 : 0)
+const ranked = surviving.slice().sort((a, b) => rank(a) - rank(b))
+const block = ranked.map((c, i) =>
+  '### [' + i + '] ' + loc(c) + ' (' + c.verdict + ')\n' +
+  c.summary + '\nCost: ' + c.failure_scenario + '\nVerifier evidence: ' + c.evidence + '\n'
+).join('\n')
+
+const report = await agent(
+  '## Synthesis: final bridge duplication-audit report (issue #' + ISSUE + ')\n\n' +
+  ranked.length + ' findings survived independent verification. They are numbered [0]-[' + (ranked.length - 1) + '] below.\n\n' + block + '\n' +
+  '## Instructions\n' +
+  'Return decisions about findings BY INDEX — never re-emit finding text.\n' +
+  '1. For each distinct duplication/drift, emit one decision with its index. When several findings\n' +
+  '   describe the same root cause, keep one entry and list the others in its merge array.\n' +
+  '2. Order decisions most-costly first: prefer CONFIRMED behavioral drift (the two copies already\n' +
+  '   disagree, or the index is actively wrong) over duplication that is merely redundant but\n' +
+  '   currently consistent.\n' +
+  '3. Keep at most ' + MAX_FINDINGS + ' decisions; omit the least severe beyond the cap.\n' +
+  '4. Write a 2-3 sentence summary of the audit.\n\nStructured output only.',
+  { label: 'synthesize', schema: REPORT_SCHEMA }
+)
+
+const decisions = report && Array.isArray(report.decisions) ? report.decisions : []
+const seen = new Set()
+const claim = i => (inBounds(i, ranked.length) && !seen.has(i) ? (seen.add(i), true) : false)
+const findings = []
+for (const d of decisions) {
+  if (findings.length >= MAX_FINDINGS) break
+  if (!claim(d.index)) continue
+  const c = ranked[d.index]
+  const merged = (Array.isArray(d.merge) ? d.merge : []).filter(claim).map(i => ranked[i])
+  const verdict = merged.some(m => m.verdict === 'CONFIRMED') ? 'CONFIRMED' : c.verdict
+  const also = merged.length > 0 ? ' [same issue also flagged at: ' + merged.map(loc).join(', ') + ']' : ''
+  findings.push({ file: c.file, line: c.line, summary: c.summary + also, failure_scenario: c.failure_scenario, category: 'bridge-duplication', verdict })
+}
+const usedDecisions = findings.length > 0
+let backfilled = 0
+for (let i = 0; i < ranked.length && findings.length < MAX_FINDINGS; i++) {
+  if (seen.has(i)) continue
+  const c = ranked[i]
+  findings.push({ file: c.file, line: c.line, summary: c.summary, failure_scenario: c.failure_scenario, category: 'bridge-duplication', verdict: c.verdict })
+  backfilled++
+}
+const summary = usedDecisions && report
+  ? report.summary + (backfilled > 0 ? ' (' + backfilled + ' additional verified finding' + (backfilled === 1 ? '' : 's') + ' appended unmerged.)' : '')
+  : 'Synthesis step was skipped or its decisions were unusable — returning verified findings ranked, unmerged.'
+
+return {
+  level: 'xhigh',
+  target: 'issue #' + ISSUE + (parentIssue ? ' (sub-issue of #' + parentIssue + ')' : '') + (issueTitle ? ': ' + issueTitle : ''),
+  summary,
+  findings,
+  refuted: refuted.map(c => ({ file: c.file, line: c.line, summary: c.summary })),
+  pass1aContext: { landed, stillOpen },
+  stats: { ...stats, reported: findings.length },
+}

--- a/.claude/workflows/bridge-duplication-triage.js
+++ b/.claude/workflows/bridge-duplication-triage.js
@@ -1,0 +1,155 @@
+export const meta = {
+  name: 'bridge-duplication-triage',
+  description: 'Investigate confirmed bridge duplication-audit findings (Pass 1b / #381) and draft one GitHub sub-issue body per finding (site, divergence, Swift call sites, tests, underlying OCCT functions)',
+  whenToUse: 'After a bridge-duplication-audit workflow run (issue #381). Pass args as {parentIssue: <number>, findings: [{file, line, summary, failure_scenario}, ...]} — parentIssue defaults to 381 if omitted. Drafts only — does NOT create GitHub issues; the caller files the returned drafts (and links them as sub-issues) itself so each creation stays auditable. Drafted issue bodies target branch refactor/381-pass1b (a dedicated Pass 1b branch, separate from Pass 1a\'s refactor/377-segmented-audit while that one is under code review).',
+  phases: [{ title: 'Triage' }],
+}
+
+// Sibling of duplication-triage.js, purpose-built for bridge-duplication-audit.js
+// findings rather than a reuse of it. Differs in what "investigate this finding"
+// means: duplication-triage.js's findings are Swift application code, so its
+// interesting one-hop-DOWN question is "which OCCT C++ class does this call?".
+// A bridge-header finding already IS that layer, so the interesting question
+// runs one hop UP instead — "which Swift call sites in Sources/OCCTSwift reach
+// this bridge function, and are they covered by any test?" — plus, for an
+// Angle-4 (Pass-1a-mirror-gap) finding, a direct cross-check against the Pass 1a
+// PR diff the finding claims should have been mirrored.
+//
+// Branch note: drafted issues target refactor/381-pass1b, NOT Pass 1a's
+// refactor/377-segmented-audit. #377's own convention is one shared audit branch
+// for every child pass, but Pass 1a is still under code review as of this
+// writing — a dedicated Pass 1b branch keeps its own child PRs from landing on
+// top of 1a work that hasn't been reviewed yet. Where refactor/381-pass1b itself
+// eventually merges (onto refactor/377-segmented-audit once 1a's review lands,
+// or straight to main) is a later decision, not this script's concern.
+
+const REPO = 'SecondMouseAU/OCCTSwift'
+const PASS_1B_BRANCH = 'refactor/381-pass1b'
+const PASS_1A_BRANCH = 'refactor/377-segmented-audit'
+const PASS_1B_ISSUE = 381
+const PASS_1A_ISSUE = 380
+
+const DRAFT_SCHEMA = {
+  type: 'object', required: ['title', 'duplicationSite', 'divergence', 'swiftCallSites', 'tests', 'occtFunctions'],
+  properties: {
+    title: { type: 'string', description: 'a standalone, specific issue title for this finding (not the auditor summary verbatim)' },
+    duplicationSite: { type: 'string', description: 'markdown listing every file:line location involved in OCCTBridge.h/OCCTBridge_Internal.h/OCCTBridge_<Domain>.mm, with the specific declaration/symbol name at each' },
+    divergence: { type: 'string', description: 'markdown: the concrete behavioral/index/split difference already observed, or the maintenance-cost rationale if currently consistent' },
+    swiftCallSites: { type: 'string', description: 'markdown: every Sources/OCCTSwift/*.swift call site that invokes each implicated bridge function, found by grepping the C function name(s); explicitly say "no Swift call site found (orphaned)" per function with none' },
+    tests: { type: 'string', description: 'markdown: test coverage found for each affected Swift call site (file + suite/test name, found by grepping the Swift symbol names in swiftCallSites), or an explicit "no coverage found" statement per site' },
+    occtFunctions: { type: 'string', description: 'markdown: the specific OCCT C++ class/method each location\'s .mm implementation invokes (not just the C bridge function name)' },
+    pass1aCrossCheck: { type: 'string', description: 'ONLY for an Angle-4 (Pass 1a mirror gap) finding: what the cited Pass 1a PR diff actually changed on the Swift side, confirmed by reading it, and exactly what bridge-side change would mirror it. Omit for non-Angle-4 findings.' },
+  },
+}
+
+phase('Triage')
+let PARENT_ISSUE = PASS_1B_ISSUE
+let FINDINGS = null
+
+if (args && typeof args === 'object' && Array.isArray(args.findings) && args.findings.length > 0) {
+  FINDINGS = args.findings
+  PARENT_ISSUE = args.parentIssue || PASS_1B_ISSUE
+} else if (typeof args === 'string' && args.trim().length > 0) {
+  // Large structured args objects have arrived here as an unparsed string in
+  // this environment even when sent as valid JSON (observed directly: two
+  // attempts, both landed as a raw string, args.findings undefined either
+  // way) -- fall back to a plain file-path string instead, which passes
+  // through untouched, and have an agent Read + structure its contents.
+  const FINDINGS_FILE_SCHEMA = {
+    type: 'object', required: ['findings'],
+    properties: {
+      parentIssue: { type: 'number' },
+      findings: { type: 'array', items: {
+        type: 'object', required: ['file', 'summary', 'failure_scenario'],
+        properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } },
+      }},
+    },
+  }
+  const loaded = await agent(
+    'Read the JSON file at ' + args.trim() + ' with your Read tool. It is either a bare JSON array of ' +
+    'finding objects ({file, line, summary, failure_scenario}), or an object with a `findings` array and ' +
+    'optionally a `parentIssue` number. Return its exact contents restructured to {parentIssue?, findings}. ' +
+    'Do not alter, summarize, or truncate any finding\'s text.',
+    { label: 'load-findings-file', schema: FINDINGS_FILE_SCHEMA }
+  )
+  if (loaded && Array.isArray(loaded.findings) && loaded.findings.length > 0) {
+    FINDINGS = loaded.findings
+    PARENT_ISSUE = loaded.parentIssue || PASS_1B_ISSUE
+  }
+}
+
+if (!FINDINGS || FINDINGS.length === 0) {
+  return { error: 'bridge-duplication-triage needs {parentIssue, findings: [...]} via args, or a JSON file path string as args — findings is empty or missing.' }
+}
+log('Triaging ' + FINDINGS.length + ' finding(s) for sub-issues of #' + PARENT_ISSUE)
+
+const drafts = await parallel(FINDINGS.map((f, i) => async () => {
+  const loc = f.file + (f.line != null ? ':' + f.line : '')
+  const r = await agent(
+    '## Bridge duplication finding to triage (Pass 1b, #' + PARENT_ISSUE + ')\n\n' +
+    'Location: ' + loc + '\n' +
+    'Summary: ' + f.summary + '\n' +
+    'Cost/divergence noted by the auditor: ' + f.failure_scenario + '\n\n' +
+    'Your job: investigate this finding thoroughly enough to write a complete, actionable GitHub issue\n' +
+    'about the OCCT C++ bridge header pair (OCCTBridge.h / OCCTBridge_Internal.h), NOT Swift application\n' +
+    'code — the finding IS in the bridge layer.\n\n' +
+    '1. Read the primary file at the given location, and every OTHER file:line location this finding\'s\n' +
+    '   summary/failure_scenario mentions (parse its file:line references out of the text above) — this\n' +
+    '   commonly includes the corresponding OCCTBridge_<Domain>.mm implementation file(s).\n' +
+    '2. Grep Sources/OCCTSwift/*.swift for the specific C function name(s) involved at EACH location to\n' +
+    '   find every Swift call site that invokes them. If a function has none, say so explicitly (an\n' +
+    '   orphaned bridge declaration nothing calls is itself worth noting, not something to guess past).\n' +
+    '3. For each Swift call site found in step 2, grep Tests/ (per-domain Swift Testing targets) for\n' +
+    '   tests referencing that Swift symbol. List what you find (file + suite/test name); if none, say\n' +
+    '   so explicitly per call site — do not guess or assume coverage exists.\n' +
+    '4. For each location, identify the underlying OCCT bridge function\'s C++ implementation: read the\n' +
+    '   matching OCCTBridge_<Domain>.mm body and name the actual OCCT C++ class(es)/method(s) invoked\n' +
+    '   (e.g. GC_MakePlane, gce_MakePln, GeomLProp_SLProps) — not just the C bridge function name.\n' +
+    '5. If — and only if — the finding\'s summary references a Pass 1a issue/PR number (an "Angle 4"\n' +
+    '   finding, i.e. a bridge-side gap a Pass 1a Swift-side fix should have mirrored): run\n' +
+    '   `gh pr diff <pr> --repo ' + REPO + '` on that PR and confirm, from the actual diff, what the\n' +
+    '   Swift side changed to. State exactly what bridge-side change would mirror it. If the finding does\n' +
+    '   NOT reference a Pass 1a issue/PR, omit pass1aCrossCheck entirely — do not invent a cross-check.\n\n' +
+    'Return:\n' +
+    '- title: a concise, specific, standalone issue title for this finding\n' +
+    '- duplicationSite: markdown listing every file:line location involved, with the specific\n' +
+    '  declaration/symbol name at each\n' +
+    '- divergence: markdown describing what has actually drifted/gone stale between the copies (a\n' +
+    '  concrete difference you verified by reading both sides), or — if currently consistent — the\n' +
+    '  concrete maintenance-cost rationale for why it should still be unified\n' +
+    '- swiftCallSites: markdown listing every Swift call site per implicated function, or "orphaned"\n' +
+    '- tests: markdown listing test coverage found per call site, or an explicit no-coverage statement\n' +
+    '- occtFunctions: markdown listing the specific OCCT C++ class/method each location\'s .mm invokes\n' +
+    '- pass1aCrossCheck: only if step 5 applied\n\n' +
+    'Structured output only.',
+    { label: 'triage:' + loc.split('/').pop(), schema: DRAFT_SCHEMA }
+  )
+  if (!r) { log('triage[' + i + '] (' + loc + '): agent returned no result, skipping'); return null }
+  log('triage[' + i + '] (' + loc + '): drafted "' + r.title + '"')
+
+  const body =
+    'Part of the bridge duplication audit in #' + PARENT_ISSUE + ' (Pass 1b, itself a sub-issue of #377 — ' +
+    'parallel to Pass 1a / #' + PASS_1A_ISSUE + '). Per #377\'s ordering rule, triage or fix this before ' +
+    'starting #395 (the OCCTBridge.h breakout, which depends on #381). Branch: `' + PASS_1B_BRANCH + '` — ' +
+    'a dedicated branch for Pass 1b, separate from Pass 1a\'s `' + PASS_1A_BRANCH + '` while that branch is ' +
+    'still under code review. PRs from this issue target `' + PASS_1B_BRANCH + '`, not `main`.\n\n' +
+    '## Duplication site\n' + r.duplicationSite + '\n\n' +
+    '## Divergence\n' + r.divergence + '\n\n' +
+    '## Swift call sites\n' + r.swiftCallSites + '\n\n' +
+    '## Associated tests\n' + r.tests + '\n\n' +
+    '## Underlying OCCT functions\n' + r.occtFunctions + '\n\n' +
+    (r.pass1aCrossCheck ? '## Pass 1a cross-check\n' + r.pass1aCrossCheck + '\n\n' : '') +
+    '---\n<sub>Original audit finding: ' + f.summary + '</sub>\n'
+
+  return { sourceIndex: i, file: f.file, line: f.line, title: r.title, body }
+}))
+
+const results = drafts.filter(Boolean)
+log('Triage done: ' + results.length + '/' + FINDINGS.length + ' drafted')
+
+return {
+  parentIssue: PARENT_ISSUE,
+  drafted: results.length,
+  requested: FINDINGS.length,
+  drafts: results,
+}

--- a/.claude/workflows/duplication-audit.js
+++ b/.claude/workflows/duplication-audit.js
@@ -1,0 +1,422 @@
+export const meta = {
+  name: 'duplication-audit',
+  description: 'Static duplication audit of an existing file scope (reimplemented helpers, copy-pasted math, drifted docs, parallel primitives)',
+  whenToUse: 'For a #377-style segmented duplication-audit sub-issue (e.g. #380-#392): pass the issue number as args, or {files:[...]} directly for an ad hoc scope. This is NOT a diff/PR review — it reads existing, already-committed files rather than a git diff, and its finder angles are duplication-specific rather than correctness-bug angles. Use the plain "code-review" workflow instead for reviewing an actual diff/PR.',
+  phases: [
+    { title: 'Scope' },
+    { title: 'Find' },
+    { title: 'Sweep' },
+    { title: 'Verify' },
+    { title: 'Synthesize' },
+  ],
+}
+
+// Generalized from the issue #380 (Pass 1a of #377) duplication audit. #377
+// segments a repo-wide duplication sweep into per-layer sub-issues, each
+// listing a fixed "## Files" scope in its body (path + LOC per line) — this
+// script fetches that scope from the issue, bin-packs it into finder-sized
+// groups, then mirrors the stock code-review workflow's Find -> group-verify
+// -> Sweep -> Synthesize shape with duplication-specific angles instead of
+// correctness-bug angles, since there's no diff for a static audit like this.
+
+const REPO = 'SecondMouseAU/OCCTSwift'
+const GROUP_LOC_THRESHOLD = 2000
+const GROUP_FINDER_CAP = 10
+const CROSS_CAP = 10
+const SWEEP_CAP = 10
+const MAX_FINDINGS = 25
+
+const ANGLES_TEXT =
+  '### Angle 1 — Reimplemented helpers\n' +
+  'Find functions/methods that duplicate logic already implemented elsewhere in scope: the same\n' +
+  'algorithm/computation expressed twice under different names, a private helper that reimplements\n' +
+  'a public utility, or an inline computation that duplicates an existing static/instance method.\n\n' +
+  '### Angle 2 — Copy-pasted math\n' +
+  'Find near-duplicate mathematical formulas/algorithms that appear more than once with only\n' +
+  'superficial variation (renamed variables, minor rearrangement): distance/length calculations,\n' +
+  'dot/cross products, angle normalization, tolerance/epsilon comparisons, parametric interpolation,\n' +
+  'coordinate conversions. Flag each duplicate pair/group and note anywhere they diverge even\n' +
+  'slightly — a correctness bug can hide inside an otherwise-cosmetic duplication.\n\n' +
+  '### Angle 3 — Drifted doc comments\n' +
+  'Find /// doc comments that no longer accurately describe the implementation below them (stale\n' +
+  'parameter descriptions, wrong return-value claims, outdated behavioral guarantees), or two\n' +
+  'similar/parallel APIs whose doc comments make inconsistent or contradictory claims about\n' +
+  'equivalent behavior.\n\n' +
+  '### Angle 4 — Parallel primitives that should be one\n' +
+  'Find types, structs, or families of methods that overlap in responsibility and represent the\n' +
+  'same underlying concept through two different code paths (e.g. two ways to express the same\n' +
+  'kind of value, or two overlapping validation/conversion helpers). Name the concrete cost: the\n' +
+  'maintenance burden of keeping both in sync, or a place where they have already drifted apart.\n'
+
+const ISSUE_SCOPE_SCHEMA = {
+  type: 'object', required: ['files'],
+  properties: {
+    title: { type: 'string' },
+    parentIssue: { type: 'number' },
+    scopeNotes: { type: 'string', description: 'the issue\'s own "## Scope" text, verbatim, if present' },
+    files: { type: 'array', items: {
+      type: 'object', required: ['path'],
+      properties: { path: { type: 'string' }, loc: { type: 'number' } },
+    }},
+    notes: { type: 'string', description: 'any listed file that turned out not to exist, or other discrepancies' },
+  },
+}
+const CANDIDATES_SCHEMA = {
+  type: 'object', required: ['candidates'],
+  properties: {
+    candidates: { type: 'array', items: {
+      type: 'object', required: ['file', 'summary', 'failure_scenario'],
+      properties: {
+        file: { type: 'string', description: 'repo-relative path of the primary/worse-drifted location to fix' },
+        line: { type: 'number' },
+        summary: { type: 'string', description: 'one line naming both the primary location and its duplicate counterpart (file:line)' },
+        failure_scenario: { type: 'string', description: 'the concrete maintenance cost: what is duplicated, where it has drifted, or why it should be unified' },
+      },
+    }},
+  },
+}
+const GROUP_VERDICT_SCHEMA = {
+  type: 'object', required: ['verdicts'],
+  properties: {
+    verdicts: { type: 'array', items: {
+      type: 'object', required: ['index', 'verdict', 'evidence'],
+      properties: {
+        index: { type: 'number', description: 'the [i] label of the candidate this verdict is for' },
+        verdict: { enum: ['CONFIRMED', 'PLAUSIBLE', 'REFUTED'] },
+        evidence: { type: 'string' },
+      },
+    }},
+  },
+}
+const REPORT_SCHEMA = {
+  type: 'object', required: ['summary', 'decisions'],
+  properties: {
+    summary: { type: 'string' },
+    decisions: { type: 'array', items: {
+      type: 'object', required: ['index'],
+      properties: {
+        index: { type: 'number' },
+        merge: { type: 'array', items: { type: 'number' } },
+      },
+    }},
+  },
+}
+
+// ─── Phase 0: Scope ───
+phase('Scope')
+let ISSUE = null, DIRECT_FILES = null
+if (typeof args === 'number') ISSUE = args
+else if (typeof args === 'string' && /^\d+$/.test(args.trim())) ISSUE = parseInt(args.trim(), 10)
+else if (args && typeof args === 'object') {
+  if (args.issue) ISSUE = Number(args.issue)
+  if (Array.isArray(args.files)) DIRECT_FILES = args.files.map(f => (typeof f === 'string' ? { path: f } : f))
+}
+if (!ISSUE && !DIRECT_FILES) {
+  return { error: 'duplication-audit needs an issue number (e.g. Workflow({name:"duplication-audit", args: 380})) or {files:[...]}.' }
+}
+
+let files, issueTitle = null, parentIssue = null, scopeNotes = ''
+if (DIRECT_FILES) {
+  files = DIRECT_FILES
+} else {
+  const scoped = await agent(
+    'Run `gh issue view ' + ISSUE + ' --repo ' + REPO + '` and read its body.\n\n' +
+    'Extract:\n' +
+    '1. title\n' +
+    '2. parentIssue — the parent issue number if the issue has one (from the "parent:" field or a\n' +
+    '   "Part of ... #<N>" reference in the body), otherwise omit it.\n' +
+    '3. scopeNotes — the issue\'s own "## Scope" section text, verbatim, if present.\n' +
+    '4. files — the "## Files" section: a markdown list of backtick-wrapped repo-relative paths,\n' +
+    '   each followed by a LOC count in parentheses, e.g. "- `Sources/Foo.swift` (123)". Return each\n' +
+    '   file\'s path and loc exactly as listed.\n\n' +
+    'Then verify every listed file actually exists in the repo (e.g. `test -f <path>`) from the ' +
+    'current working directory. Drop any that do not exist and note the discrepancy in `notes`.\n\n' +
+    'Structured output only.',
+    { label: 'scope:issue' + ISSUE, schema: ISSUE_SCOPE_SCHEMA }
+  )
+  if (!scoped || !scoped.files || scoped.files.length === 0) {
+    return { error: 'Could not resolve a file scope from issue #' + ISSUE + ' (empty or missing "## Files" section).' }
+  }
+  files = scoped.files
+  issueTitle = scoped.title || null
+  parentIssue = scoped.parentIssue || null
+  scopeNotes = scoped.scopeNotes || ''
+  if (scoped.notes) log('Scope notes: ' + scoped.notes)
+}
+
+const ALL_FILES = files.map(f => f.path)
+const totalLoc = files.reduce((s, f) => s + (f.loc || 0), 0)
+log('Scope: ' + ALL_FILES.length + ' files' + (totalLoc > 0 ? ', ' + totalLoc + ' LOC' : '') + (issueTitle ? ' — ' + issueTitle : ''))
+
+// ─── Group files into finder-sized clusters. A "Name+Suffix.swift" file
+// (this repo's extension-file naming convention) stays paired with its
+// "Name.swift" base file; otherwise each file is its own cluster. Clusters
+// are then greedily bin-packed in listed order up to GROUP_LOC_THRESHOLD —
+// a file/cluster already at or over the threshold becomes its own
+// single-cluster group rather than being split.
+const baseName = p => {
+  const stem = p.split('/').pop().replace(/\.swift$/, '')
+  return stem.split('+')[0]
+}
+const clusterMap = new Map()
+const clusterOrder = []
+for (const f of files) {
+  const key = baseName(f.path)
+  if (!clusterMap.has(key)) { clusterMap.set(key, []); clusterOrder.push(key) }
+  clusterMap.get(key).push(f)
+}
+const clusters = clusterOrder.map(k => clusterMap.get(k))
+
+const FILE_GROUPS = []
+let current = []
+let currentLoc = 0
+for (const cluster of clusters) {
+  const clusterLoc = cluster.reduce((s, f) => s + (f.loc || 0), 0)
+  if (current.length > 0 && currentLoc + clusterLoc > GROUP_LOC_THRESHOLD) {
+    FILE_GROUPS.push(current)
+    current = []
+    currentLoc = 0
+  }
+  current = current.concat(cluster)
+  currentLoc += clusterLoc
+  if (currentLoc >= GROUP_LOC_THRESHOLD) {
+    FILE_GROUPS.push(current)
+    current = []
+    currentLoc = 0
+  }
+}
+if (current.length > 0) FILE_GROUPS.push(current)
+const groupLabel = g => g[0].path.split('/').pop().replace(/\.swift$/, '')
+log('Grouped into ' + FILE_GROUPS.length + ' finder group(s): ' + FILE_GROUPS.map(g => groupLabel(g) + '(' + g.length + ')').join(', '))
+
+const SCOPE_BLOCK =
+  '## Audit scope' + (ISSUE ? ' — issue #' + ISSUE + (parentIssue ? ' (sub-issue of #' + parentIssue + ')' : '') : '') +
+  (issueTitle ? ': ' + issueTitle : '') + '\n' +
+  'This is a STATIC duplication audit of existing, already-committed code — there is no diff or\n' +
+  'PR to review. Read the file contents directly.\n' +
+  (scopeNotes ? '\n' + scopeNotes + '\n' : '') +
+  '\nFull scope (' + ALL_FILES.length + ' files' + (totalLoc > 0 ? ', ' + totalLoc + ' LOC' : '') + '):\n' +
+  ALL_FILES.map(f => '  - ' + f).join('\n') + '\n'
+
+const canonFile = raw => {
+  if (!raw) return ''
+  const p = raw.replace(/\\/g, '/')
+  let best = ''
+  for (const sf of ALL_FILES) {
+    if ((p === sf || p.endsWith('/' + sf)) && sf.length > best.length) best = sf
+  }
+  return best || p
+}
+const ingest = (cs, cap) => cs.slice(0, cap).map(c => ({ ...c, file: canonFile(c.file) }))
+const loc = c => c.file + (c.line != null ? ':' + c.line : '')
+const inBounds = (i, n) => Number.isInteger(i) && i >= 0 && i < n
+
+// ─── Find: one finder per file group (in-group duplication, may Grep the
+// rest of the repo to check for cross-group echoes) + 2 cross-cutting
+// finders (duplication that spans group boundaries, which a single-group
+// reviewer can't see on its own).
+phase('Find')
+const groupFinders = FILE_GROUPS.map(g => () =>
+  agent(
+    '## Duplication-audit finder — file group: ' + groupLabel(g) + '\n\n' + SCOPE_BLOCK +
+    '\nYour assigned files for this pass:\n' + g.map(f => '  - ' + f.path).join('\n') + '\n\n' +
+    'Read every assigned file in full. Review through EACH of the following angles. You may Grep\n' +
+    'the rest of the repo (not just the files above) to check whether something in your assigned\n' +
+    'files duplicates code elsewhere — but only report a finding if its PRIMARY (worse-drifted, or\n' +
+    'newer/messier) location is inside your assigned files.\n\n' + ANGLES_TEXT + '\n' +
+    'Surface up to ' + GROUP_FINDER_CAP + ' candidates. Each needs a primary file+line, a one-line summary naming\n' +
+    'both the primary location and its duplicate counterpart (file:line), and a failure_scenario stating the\n' +
+    'concrete maintenance cost. Pass every candidate through even if only half-confident — an independent\n' +
+    'verifier judges them next. If nothing qualifies, return an empty list.\n\nStructured output only.',
+    { label: 'find:' + groupLabel(g), phase: 'Find', schema: CANDIDATES_SCHEMA }
+  ).then(r => {
+    if (!r) return []
+    log('find:' + groupLabel(g) + ': ' + r.candidates.length + ' candidates')
+    return ingest(r.candidates, GROUP_FINDER_CAP)
+  })
+)
+
+const CROSS_CUTTING = [
+  {
+    label: 'cross-parallel-types',
+    focus:
+      'Focus specifically on Angle 4 (parallel primitives that should be one) ACROSS the whole file\n' +
+      'scope: look for any pair or family of types/files that overlap in responsibility and represent\n' +
+      'the same underlying concept through two different code paths. For each pair, check whether the\n' +
+      'overlap is a genuine, documented design split or accidental duplication that has already\n' +
+      'drifted (inconsistent docs, a fix applied to one side but not the other, differing edge-case\n' +
+      'handling for what should be the same operation).\n',
+  },
+  {
+    label: 'cross-math-formulas',
+    focus:
+      'Focus specifically on Angle 2 (copy-pasted math) ACROSS the whole file scope: Grep for\n' +
+      'repeated formula shapes — distance/length, dot/cross product, angle normalization\n' +
+      '(degrees<->radians, periodic wraparound), tolerance/epsilon comparisons, linear/parametric\n' +
+      'interpolation — that recur in more than one file with only superficial variation. Report every\n' +
+      'recurring formula family found, even across files that are not in the same file group, and\n' +
+      'flag any place the duplicated copies use a DIFFERENT tolerance/epsilon constant or a subtly\n' +
+      'different formula for what should be the same computation.\n',
+  },
+]
+const crossFinders = CROSS_CUTTING.map(c => () =>
+  agent(
+    '## Duplication-audit finder — cross-cutting: ' + c.label + '\n\n' + SCOPE_BLOCK + '\n' +
+    'Read all files listed above (Grep first to locate candidate patterns, then Read the specific\n' +
+    'functions/sections you find, in full, before reporting).\n\n' + c.focus + '\n' +
+    'Surface up to ' + CROSS_CAP + ' candidates. Each needs a primary file+line, a one-line summary naming\n' +
+    'both locations involved (file:line for each), and a failure_scenario stating the concrete\n' +
+    'maintenance cost or observed drift. If nothing qualifies, return an empty list.\n\nStructured output only.',
+    { label: 'find:' + c.label, phase: 'Find', schema: CANDIDATES_SCHEMA }
+  ).then(r => {
+    if (!r) return []
+    log('find:' + c.label + ': ' + r.candidates.length + ' candidates')
+    return ingest(r.candidates, CROSS_CAP)
+  })
+)
+
+const findOuts = await parallel([...groupFinders, ...crossFinders])
+let allCandidates = findOuts.filter(Boolean).flat()
+let candidatesSeen = allCandidates.length
+log('Find done: ' + candidatesSeen + ' total candidates')
+
+// ─── Sweep: one fresh finder hunting only for cross-boundary gaps the
+// group/cross-cutting finders above missed.
+phase('Sweep')
+const knownBlock = allCandidates.length > 0
+  ? allCandidates.map(c => '- ' + loc(c) + ' — ' + c.summary).join('\n')
+  : '(none)'
+const sweep = await agent(
+  '## Duplication-audit sweep — gaps only\n\n' + SCOPE_BLOCK + '\n' +
+  '## Already-found candidates (do NOT re-derive or re-report these)\n' + knownBlock + '\n\n' +
+  'Re-scan the full file scope (Grep across all of them together) looking ONLY for duplication not\n' +
+  'already listed above. Focus on what a per-group/per-lens split tends to miss: duplication between\n' +
+  'files in DIFFERENT groups that neither group finder nor either cross-cutting finder happened to\n' +
+  'compare directly, and doc-comment drift between two files that are rarely read side-by-side.\n\n' +
+  ANGLES_TEXT + '\n' +
+  'Surface up to ' + SWEEP_CAP + ' additional candidates. If nothing new, return an empty list — do not pad.\n\nStructured output only.',
+  { label: 'sweep', phase: 'Sweep', schema: CANDIDATES_SCHEMA }
+)
+if (sweep && sweep.candidates.length > 0) {
+  const sliced = ingest(sweep.candidates, SWEEP_CAP)
+  candidatesSeen += sliced.length
+  log('sweep: ' + sliced.length + ' candidates')
+  allCandidates = allCandidates.concat(sliced)
+}
+
+// ─── Verify: one verifier agent per distinct (file, line) location, judging
+// every candidate reported at that location independently.
+phase('Verify')
+const VERDICT_LADDER =
+  '- **CONFIRMED** — read both locations and confirm genuine, substantive duplication (not just\n' +
+  '  superficial similarity); name the concrete maintenance cost or an actual point of drift.\n' +
+  '- **PLAUSIBLE** — the duplication is real but its cost is uncertain (e.g. unclear which side is\n' +
+  '  "correct", or the drift is cosmetic rather than behavioral). State what would confirm it.\n' +
+  '- **REFUTED** — not actually duplicated (different algorithm/purpose despite surface similarity),\n' +
+  '  or the parallel structure is a deliberate, already-documented design split. Quote the code that\n' +
+  '  proves it.'
+
+const byLoc = Object.create(null)
+for (const c of allCandidates) (byLoc[loc(c)] ||= []).push(c)
+const groups = Object.values(byLoc)
+const verifierAgents = groups.length
+const verifiedOut = await parallel(groups.map(g => async () => {
+  const short = g[0].file.split('/').pop()
+  const r = await agent(
+    '## Duplication-audit verifier\n\n' + SCOPE_BLOCK + '\n' +
+    '## Candidate findings at ' + loc(g[0]) + '\n' +
+    g.map((c, i) => '[' + i + '] Summary: ' + c.summary + '\n    Cost claimed: ' + c.failure_scenario).join('\n') + '\n\n' +
+    'Read the primary file and every duplicate-counterpart file/location named in each candidate\'s\n' +
+    'summary. Return one verdict per candidate, judged independently — candidates at the same\n' +
+    'location may describe distinct duplications, the same one, or a mix. Reference each by its [i] index.\n\n' +
+    VERDICT_LADDER + '\n\nStructured output only. Evidence must quote or cite the relevant line(s) from BOTH locations.',
+    { label: 'verify:' + short + '(' + g.length + ')', phase: 'Verify', schema: GROUP_VERDICT_SCHEMA }
+  )
+  if (!r) return []
+  const byIdx = {}
+  for (const v of r.verdicts) if (inBounds(v.index, g.length)) byIdx[v.index] = v
+  return g.flatMap((c, i) => byIdx[i] ? [{ ...c, verdict: byIdx[i].verdict, evidence: byIdx[i].evidence }] : [])
+}))
+const verified = verifiedOut.filter(Boolean).flat()
+const surviving = verified.filter(c => c.verdict !== 'REFUTED')
+const refuted = verified.filter(c => c.verdict === 'REFUTED')
+log('Verify done: ' + verified.length + ' verified -> ' + surviving.length + ' kept, ' + refuted.length + ' refuted')
+
+const stats = {
+  issue: ISSUE || undefined,
+  fileGroups: FILE_GROUPS.length,
+  crossCuttingFinders: CROSS_CUTTING.length,
+  finders: FILE_GROUPS.length + CROSS_CUTTING.length + 1,
+  candidates: candidatesSeen,
+  verifierAgents,
+  verified: verified.length,
+  refuted: refuted.length,
+}
+
+if (surviving.length === 0) {
+  return {
+    level: 'xhigh',
+    target: (ISSUE ? 'issue #' + ISSUE + (parentIssue ? ' (sub-issue of #' + parentIssue + ')' : '') : 'ad hoc scope') + (issueTitle ? ': ' + issueTitle : ''),
+    summary: 'No duplication findings survived verification.',
+    findings: [],
+    stats,
+  }
+}
+
+// ─── Synthesize: rank, merge semantic dupes (same pair found by more than
+// one finder), cap the report.
+phase('Synthesize')
+const rank = c => (c.verdict === 'PLAUSIBLE' ? 1 : 0)
+const ranked = surviving.slice().sort((a, b) => rank(a) - rank(b))
+const block = ranked.map((c, i) =>
+  '### [' + i + '] ' + loc(c) + ' (' + c.verdict + ')\n' +
+  c.summary + '\nCost: ' + c.failure_scenario + '\nVerifier evidence: ' + c.evidence + '\n'
+).join('\n')
+
+const report = await agent(
+  '## Synthesis: final duplication-audit report' + (ISSUE ? ' (issue #' + ISSUE + ')' : '') + '\n\n' +
+  ranked.length + ' findings survived independent verification. They are numbered [0]-[' + (ranked.length - 1) + '] below.\n\n' + block + '\n' +
+  '## Instructions\n' +
+  'Return decisions about findings BY INDEX — never re-emit finding text.\n' +
+  '1. For each distinct duplication, emit one decision with its index. When several findings describe\n' +
+  '   the same duplicate pair/group (same root cause), keep one entry and list the others in its merge array.\n' +
+  '2. Order decisions most-costly first: prefer duplications with CONFIRMED behavioral drift (the two\n' +
+  '   copies already disagree) over duplications that are merely redundant but currently consistent.\n' +
+  '3. Keep at most ' + MAX_FINDINGS + ' decisions; omit the least severe beyond the cap.\n' +
+  '4. Write a 2-3 sentence summary of the audit.\n\nStructured output only.',
+  { label: 'synthesize', schema: REPORT_SCHEMA }
+)
+
+const decisions = report && Array.isArray(report.decisions) ? report.decisions : []
+const seen = new Set()
+const claim = i => (inBounds(i, ranked.length) && !seen.has(i) ? (seen.add(i), true) : false)
+const findings = []
+for (const d of decisions) {
+  if (findings.length >= MAX_FINDINGS) break
+  if (!claim(d.index)) continue
+  const c = ranked[d.index]
+  const merged = (Array.isArray(d.merge) ? d.merge : []).filter(claim).map(i => ranked[i])
+  const verdict = merged.some(m => m.verdict === 'CONFIRMED') ? 'CONFIRMED' : c.verdict
+  const also = merged.length > 0 ? ' [same duplication also flagged at: ' + merged.map(loc).join(', ') + ']' : ''
+  findings.push({ file: c.file, line: c.line, summary: c.summary + also, failure_scenario: c.failure_scenario, category: 'duplication', verdict })
+}
+const usedDecisions = findings.length > 0
+let backfilled = 0
+for (let i = 0; i < ranked.length && findings.length < MAX_FINDINGS; i++) {
+  if (seen.has(i)) continue
+  const c = ranked[i]
+  findings.push({ file: c.file, line: c.line, summary: c.summary, failure_scenario: c.failure_scenario, category: 'duplication', verdict: c.verdict })
+  backfilled++
+}
+const summary = usedDecisions && report
+  ? report.summary + (backfilled > 0 ? ' (' + backfilled + ' additional verified finding' + (backfilled === 1 ? '' : 's') + ' appended unmerged.)' : '')
+  : 'Synthesis step was skipped or its decisions were unusable — returning verified findings ranked, unmerged.'
+
+return {
+  level: 'xhigh',
+  target: (ISSUE ? 'issue #' + ISSUE + (parentIssue ? ' (sub-issue of #' + parentIssue + ')' : '') : 'ad hoc scope') + (issueTitle ? ': ' + issueTitle : ''),
+  summary,
+  findings,
+  refuted: refuted.map(c => ({ file: c.file, line: c.line, summary: c.summary })),
+  stats: { ...stats, reported: findings.length },
+}

--- a/.claude/workflows/duplication-triage.js
+++ b/.claude/workflows/duplication-triage.js
@@ -1,0 +1,90 @@
+export const meta = {
+  name: 'duplication-triage',
+  description: 'Investigate confirmed duplication-audit findings and draft one GitHub sub-issue body per finding (site, divergence, tests, OCCT functions)',
+  whenToUse: 'After a duplication-audit workflow run (e.g. issue #380). Pass args as {parentIssue: <number>, findings: [{file, line, summary, failure_scenario}, ...]}. Drafts only — does NOT create GitHub issues; the caller files the returned drafts (and links them as sub-issues) itself so each creation stays auditable.',
+  phases: [{ title: 'Triage' }],
+}
+
+// Follow-up to duplication-audit.js: turns each CONFIRMED finding into a
+// filing-ready GitHub issue draft. Per-finding investigation (which tests
+// cover which side, which OCCT C++ API each bridge call wraps) needs real
+// file reads grounded per location, so this stays one agent per finding
+// rather than a batched prompt.
+
+const DRAFT_SCHEMA = {
+  type: 'object', required: ['title', 'duplicationSite', 'divergence', 'tests', 'occtFunctions'],
+  properties: {
+    title: { type: 'string', description: 'a standalone, specific issue title for this duplication (not the auditor summary verbatim)' },
+    duplicationSite: { type: 'string', description: 'markdown listing every file:line location involved, with the specific symbol name at each' },
+    divergence: { type: 'string', description: 'markdown: the concrete behavioral/doc difference already observed between the copies, or the maintenance-cost rationale if currently consistent' },
+    tests: { type: 'string', description: 'markdown: test coverage found for each location (file + test/suite name), or an explicit "no coverage found" statement per location' },
+    occtFunctions: { type: 'string', description: 'markdown: the specific OCCT C++ class/method each location\'s bridge call invokes (not just the C bridge function name)' },
+  },
+}
+
+if (!args || !Array.isArray(args.findings) || args.findings.length === 0) {
+  return { error: 'duplication-triage needs {parentIssue, findings: [...]} — findings is empty or missing.' }
+}
+const PARENT_ISSUE = args.parentIssue || null
+const FINDINGS = args.findings
+
+phase('Triage')
+log('Triaging ' + FINDINGS.length + ' finding(s)' + (PARENT_ISSUE ? ' for sub-issues of #' + PARENT_ISSUE : ''))
+
+const drafts = await parallel(FINDINGS.map((f, i) => async () => {
+  const loc = f.file + (f.line != null ? ':' + f.line : '')
+  const r = await agent(
+    '## Duplication finding to triage\n\n' +
+    'Location: ' + loc + '\n' +
+    'Summary: ' + f.summary + '\n' +
+    'Cost/divergence noted by the auditor: ' + f.failure_scenario + '\n\n' +
+    'Your job: investigate this finding thoroughly enough to write a complete, actionable GitHub issue.\n\n' +
+    '1. Read the primary file at the given location, and every OTHER file:line location this finding\'s\n' +
+    '   summary/failure_scenario mentions (there is always at least one duplicate counterpart — parse its\n' +
+    '   file:line references out of the text above).\n' +
+    '2. Grep Tests/ (per-domain Swift Testing targets) for tests that reference the specific Swift symbols\n' +
+    '   (method/type names) involved at EACH location. List what you find (file + suite/test name); if you\n' +
+    '   find none for a given location, say so explicitly — do not guess or assume coverage exists.\n' +
+    '3. For each location, find the underlying OCCT bridge function it calls: grep\n' +
+    '   Sources/OCCTBridge/include/OCCTBridge.h for the C function declaration and Sources/OCCTBridge/src/*.mm\n' +
+    '   for its implementation. Identify the actual OCCT C++ class(es)/method(s) invoked (e.g. GC_MakePlane,\n' +
+    '   gce_MakePln, GeomLProp_SLProps) — not just the C bridge function name.\n\n' +
+    'Return:\n' +
+    '- title: a concise, specific, standalone issue title for this duplication\n' +
+    '- duplicationSite: markdown listing every file:line location involved, with the specific symbol name at each\n' +
+    '- divergence: markdown describing what has actually drifted between the copies (a concrete behavioral or\n' +
+    '  doc difference you verified by reading both sides), or — if currently consistent — the concrete\n' +
+    '  maintenance-cost rationale for why it should still be unified\n' +
+    '- tests: markdown listing test coverage found for each location, or an explicit "No existing test\n' +
+    '  coverage found for <location>" statement per location with no coverage\n' +
+    '- occtFunctions: markdown listing the specific OCCT C++ class/method each location\'s bridge call invokes\n\n' +
+    'Structured output only.',
+    { label: 'triage:' + loc.split('/').pop(), schema: DRAFT_SCHEMA }
+  )
+  if (!r) { log('triage[' + i + '] (' + loc + '): agent returned no result, skipping'); return null }
+  log('triage[' + i + '] (' + loc + '): drafted "' + r.title + '"')
+
+  const body =
+    (PARENT_ISSUE
+      ? 'Part of the duplication audit in #' + PARENT_ISSUE + ' (itself a sub-issue of #377). Per #377\'s ' +
+        'ordering rule, triage or fix this before starting the next audit pass. Branch: ' +
+        '`refactor/377-segmented-audit` — PRs from this issue target that branch, not `main`.\n\n'
+      : '') +
+    '## Duplication site\n' + r.duplicationSite + '\n\n' +
+    '## Divergence\n' + r.divergence + '\n\n' +
+    '## Associated tests\n' + r.tests + '\n\n' +
+    '## Underlying OCCT functions\n' + r.occtFunctions + '\n\n' +
+    '---\n<sub>Original audit finding: ' + f.summary + '</sub>\n'
+
+  return { sourceIndex: i, file: f.file, line: f.line, title: r.title, body }
+}))
+
+const results = drafts.filter(Boolean)
+log('Triage done: ' + results.length + '/' + FINDINGS.length + ' drafted')
+
+return {
+  parentIssue: PARENT_ISSUE,
+  drafted: results.length,
+  requested: FINDINGS.length,
+  drafts: results,
+}

--- a/Scripts/repro/censuses/ClusterD.swift
+++ b/Scripts/repro/censuses/ClusterD.swift
@@ -111,6 +111,33 @@ fileprivate func clusterDRecordBSplineRestrictionConvergence() {
                [12, 20, 20, 26], rows)
 }
 
+/// #438 deprecated `Shape.dividedByContinuity(criterion:tolerance:)` in favour of
+/// `Shape.divided(at:tolerance:)`, which it now forwards to. The census still measures it
+/// deliberately: pinning that the forward actually passes `criterion`/`tolerance` through
+/// unchanged, which a future edit to either method could still break even though both now share
+/// one implementation.
+///
+/// Grouped into its own function for the same reason as `clusterARecordDeprecatedCounterRows`
+/// (`ClusterA.swift`): a deprecated context does not warn about the deprecated things it calls, so
+/// the cost becomes one warning at this single definition instead of one per call site.
+@available(*, deprecated, message: "Measures dividedByContinuity's forwarding contract deliberately (#438).")
+fileprivate func clusterDRecordDivideForwarding(fixture: () -> Shape?) {
+    var rows: [[String]] = []
+    for level in Shape.ContinuityLevel.allCases {
+        let viaDivided = fixture()?.divided(at: level, tolerance: 1e-4)
+        let viaDeprecated = fixture()?.dividedByContinuity(criterion: level, tolerance: 1e-4)
+        rows.append([
+            "\(level)",
+            viaDivided.map { "\($0.faceCount) faces" } ?? "nil",
+            viaDeprecated.map { "\($0.faceCount) faces" } ?? "nil",
+            (viaDivided?.faceCount == viaDeprecated?.faceCount) ? "forwards correctly" : "DIVERGED",
+        ])
+    }
+    printTable("2g. dividedByContinuity(criterion:tolerance:) (deprecated) forwards to divided(at:tolerance:)",
+               ["level", "divided(at:)", "dividedByContinuity (deprecated)", "verdict"],
+               [8, 22, 34, 20], rows)
+}
+
 /// `occtGeomAbsFromAnalysisOrder` saturates at `GeomAbs_C2` (raw 4): `.c3` and `.cN`, both real
 /// `ContinuityClass` cases, decode to the same effective order as `.c2`. Measured via the typed
 /// `continuityWith(order:)` overload across every `ContinuityClass` case, not just the five the
@@ -319,18 +346,26 @@ enum ClusterD {
             clusterDRecordBSplineRestrictionConvergence()
             totalMeasured += 2
 
-            // 2f. #438 itself, generalized: divided(at:) vs dividedByContinuity(criterion:) on the
-            // SAME shape. Not fixed here -- #667 says do the census, then the instances fall out --
-            // but measured so the README states what "two public APIs, one OCCT class" actually
-            // produces today rather than repeating #438's prose description of the two setter calls.
-            // Neither a plain box nor a cylinder works as a fixture here: both this tree's own tests
-            // (`ShapeUpgradeDivideContinuityTests.divideBoxContinuity`, `AdvancedHealingTests.
+            // 2f. #438: FIXED. divided(at:) and dividedByContinuity(criterion:) used to be two
+            // public entry points over the same ShapeUpgrade_ShapeDivideContinuity, setting
+            // DIFFERENT criteria (divided(at:) set boundary+pcurve+surface together;
+            // dividedByContinuity set only boundary, leaving pcurve/surface pinned at the class's
+            // own C1 constructor default regardless of the requested continuity). Fixed by
+            // widening divided(at:) to take ContinuityLevel plus a tolerance parameter and making
+            // dividedByContinuity(criterion:tolerance:) a deprecated forward to it, so there is
+            // now exactly one implementation. This section used to compare the two independently;
+            // now that one forwards to the other, a comparison between them proves only that the
+            // forward passes its arguments through, so it measures divided(at:) alone across its
+            // full domain and separately pins the deprecated spelling's forwarding contract.
+            //
+            // Neither a plain box nor a cylinder works as a fixture here: both this tree's own
+            // tests (`ShapeUpgradeDivideContinuityTests.divideBoxContinuity`, `AdvancedHealingTests.
             // divideCylinder`) tolerate nil ("may return nil/the same shape if no divisions
-            // needed"), and measured here, BOTH APIs return nil on both at every continuity -- a
-            // planar box has no interior surface knots to divide at, and a cylinder's single
+            // needed"), and measured here, divided(at:) returns nil on both at every continuity --
+            // a planar box has no interior surface knots to divide at, and a cylinder's single
             // lateral face is one smooth periodic surface with none either. A face built directly
             // from a kinked BSpline surface (mult-3 knot, genuinely C0 at one interior knot) gives
-            // both APIs something real to divide.
+            // it something real to divide.
             let (dKnots, dMults, dPoles) = knotVector(degree: 3, interiorKnots: 4, bumpAt: 2, bumpMult: 3)
             func kinkedSurfaceShape() -> Shape? {
                 guard let surface = Surface.bspline(
@@ -341,34 +376,19 @@ enum ClusterD {
                 return Shape.face(from: surface, uRange: bounds.uMin...bounds.uMax, vRange: bounds.vMin...bounds.vMax)
             }
             var divideRows: [[String]] = []
-            for continuity in ParametricContinuity.allCases {
-                let viaDivided = kinkedSurfaceShape()?.divided(at: continuity)
-                let level = Shape.ContinuityLevel(rawValue: continuity.rawValue) ?? .c1
-                let viaDividedBy = kinkedSurfaceShape()?.dividedByContinuity(criterion: level, tolerance: 1e-4)
-                divideRows.append([
-                    "\(continuity)",
-                    viaDivided.map { "\($0.faceCount) faces" } ?? "nil",
-                    viaDividedBy.map { "\($0.faceCount) faces" } ?? "nil",
-                    (viaDivided?.faceCount == viaDividedBy?.faceCount) ? "SAME face count" : "DIFFERENT",
-                ])
-            }
-            printTable("2f. #438: divided(at:) vs dividedByContinuity(criterion:) -- same kinked-surface face, matching continuity",
-                       ["continuity", "divided(at:)", "dividedByContinuity(criterion:)", "verdict"],
-                       [12, 22, 34, 20], divideRows)
-            totalMeasured += 2
-
-            // 2g. Shape.ContinuityLevel's own g1/g2 extension (raw 5, 6) -- documented in
-            // OCCTBridge_Internal.h as a special case bolted onto occtGeomAbsFromParametricContinuity
-            // rather than reachable through it, because ShapeUpgrade_ShapeDivideContinuity's own
-            // SetCriterion does not recognise G1/G2 and would otherwise substitute its own C1
-            // default. Measured directly rather than re-read from the comment.
-            var levelRows: [[String]] = []
             for level in Shape.ContinuityLevel.allCases {
-                let result = kinkedSurfaceShape()?.dividedByContinuity(criterion: level, tolerance: 1e-4)
-                levelRows.append(["\(level)", result.map { "\($0.faceCount) faces" } ?? "nil"])
+                let result = kinkedSurfaceShape()?.divided(at: level, tolerance: 1e-4)
+                divideRows.append(["\(level)", result.map { "\($0.faceCount) faces" } ?? "nil"])
             }
-            printTable("2g. Shape.ContinuityLevel's full domain (0..6, includes g1/g2 special-cased in the bridge)",
-                       ["level", "dividedByContinuity result"], [8, 30], levelRows)
+            printTable("2f. #438 fixed: divided(at:tolerance:) across its full domain (was two disagreeing entry points)",
+                       ["level", "divided(at:) result"], [8, 30], divideRows)
+            totalMeasured += 1
+
+            // 2g. dividedByContinuity(criterion:tolerance:) (deprecated by #438) forwards to
+            // divided(at:tolerance:) -- pins that the forward actually passes criterion/tolerance
+            // through unchanged, which a future edit to either method could still break even
+            // though both now share one implementation.
+            clusterDRecordDivideForwarding(fixture: kinkedSurfaceShape)
             totalMeasured += 1
         }
 

--- a/Scripts/repro/cluster-d-continuity/README.md
+++ b/Scripts/repro/cluster-d-continuity/README.md
@@ -52,6 +52,13 @@ python3 Scripts/repro/cluster-d-continuity/classify_continuity_sites.py --self-t
   which also consolidated 19 decoders into the 3 named above. Measuring the CURRENT tree rather
   than trusting #513's text is the entire point of this census, and it is why the table below
   looks different from #513's own.
+- **These counts are as measured when this census was written (#713), before #438's fix.** #438
+  removed `OCCTShapeUpgradeDivideContinuity` (folded into `OCCTShapeDivide`), so the current tree's
+  statically-classified count is **41** (33 request-side + 8 result-side), one fewer than the 42
+  above; the alias-inclusive total is 44, not 45. Left as originally measured rather than edited in
+  place, since the point of the count was #513's own audit coverage at the time, not a live gauge
+  this file re-derives on every subsequent fix — `python3 classify_continuity_sites.py` always
+  reports the current tree's true count.
 
 ## The four encodings, as measured (today: five families, one is not really a fourth "encoding")
 
@@ -342,6 +349,39 @@ bugs") is right for one and wrong for the other.**
   encoding mismatch. Fixing #437 (give the plate family a genuine decode step, or document the
   domain restriction) would not touch #438 at all, and vice versa.
 
+**#438 fixed**: `Shape.divided(at:)` widened to `divided(at:tolerance:)`, taking `ContinuityLevel`
+(the strict superset `dividedByContinuity` alone used to reach) and a `tolerance` parameter, and
+now sets boundary, pcurve AND surface criteria together plus `SetSurfaceSegmentMode(true)` --
+`dividedByContinuity`'s three-criteria omission, not `divided(at:)`'s completeness, was the
+narrower/incomplete usage relative to OCCT's own shape-healing guide, which always sets all three
+together. `dividedByContinuity(criterion:tolerance:)` is now `@available(*, deprecated,
+renamed: "divided(at:tolerance:)")` and forwards there; the two former bridge functions
+(`OCCTShapeDivide`, `OCCTShapeUpgradeDivideContinuity`) are now one (`OCCTShapeDivide`, widened
+with a `tolerance` parameter). Re-measured on the same kinked-BSpline-surface fixture, full
+`ContinuityLevel` domain, `tolerance: 1e-4`:
+
+| level | `divided(at:)` result |
+|---|---|
+| c0 | nil |
+| c1 | 4 faces |
+| c2 | 4 faces |
+| c3 | 25 faces |
+| cn | 25 faces |
+| g1 | 4 faces |
+| g2 | 4 faces |
+
+`g1`/`g2` matching `c1` is not a residual bug: `ShapeUpgrade_Split{Curve3d,Surface}Continuity::
+SetCriterion` has no case for `GeomAbs_G1`/`G2` and falls through to its own C1 default (read
+directly from `Libraries/occt-src`), the same substitution the pre-fix `dividedByContinuity`
+comment already documented. `c0` returning `nil` rather than the pre-fix `dividedByContinuity`'s
+"4 faces" is the one visible behaviour change for an existing `dividedByContinuity` caller who
+passed `.c0`: it now also sets the pcurve/surface criteria, which `Perform()` reads as "nothing
+met even the lowest bar to redo," matching `divided(at:)`'s own pre-fix `.c0` answer. Every other
+level is unchanged from `divided(at:)`'s own pre-fix behaviour. `dividedByContinuity`'s forward is
+also pinned directly (`swift run Censuses cluster-d`'s own "2g" table): identical result to
+`divided(at:)` at every one of the 7 levels above, confirming the deprecated spelling is a real
+forward and not a second, silently-diverging implementation.
+
 ## Should #513 close?
 
 **Yes**, once this PR merges. #513's own ask was to turn its prose census into an executable
@@ -356,8 +396,8 @@ that:
   decoders; measured today, the honest count is "three decoders plus two structurally different
   literal pass-throughs," which is a different (and better) shape than #513's own text describes.
 - Its two named instances were left open on their own, correctly, per #667's own instruction that
-  this census does not fix either. **#437 has since been fixed** (see the update in "#437,
-  reproduced directly against the current tree" above); #438 remains open.
+  this census does not fix either. **Both have since been fixed**: #437 (see the update in "#437,
+  reproduced directly against the current tree" above) and #438 (see "Fixed" above).
 - The one open decision #513 raised and this census did not resolve -- the null/failure sentinel
   policy on the result side (0 is both "genuine C0" and "failed/null," on every raw-cast result
   function measured above) -- is a design decision, not a census finding, and is better tracked

--- a/Scripts/repro/cluster-d-continuity/classify_continuity_sites.py
+++ b/Scripts/repro/cluster-d-continuity/classify_continuity_sites.py
@@ -21,9 +21,10 @@ workstream (#558, #571, #583, #595) has repeatedly warned against):
     ParametricContinuity   -- body calls occtGeomAbsFromParametricContinuity(
     AnalysisOrder          -- body calls occtGeomAbsFromAnalysisOrder(
     + special-case(...)    -- appended when the body ALSO has a hand-rolled ternary against a
-                              literal GeomAbs_G1/G2 (the shape OCCTShapeUpgradeDivideContinuity
-                              uses to reach the two classes occtGeomAbsFromParametricContinuity's
-                              own ladder cannot express)
+                              literal GeomAbs_G1/G2 (the shape OCCTShapeDivide uses to reach the
+                              two classes occtGeomAbsFromParametricContinuity's own ladder cannot
+                              express -- #438 moved this here from the now-removed
+                              OCCTShapeUpgradeDivideContinuity, its former second bridge function)
     RAW (no decoder call)  -- none of the three found. Not necessarily a defect: #480 ruled the
                               knot-splitting family's argument is a literal derivative order and
                               must NEVER be decoded, and the GeomPlate_PointConstraint/
@@ -85,8 +86,9 @@ REQUEST_FUNCTIONS = [
     ("OCCTPointsToSurfaceBSpline", SURFACE),
     ("OCCTShapeCustomBSplineRestriction", HEALING),
     ("OCCTShapeBSplineRestrictionAdvanced", HEALING),
+    # #438 removed OCCTShapeUpgradeDivideContinuity (folded into OCCTShapeDivide below, which
+    # picked up its tolerance parameter and special-case ternary): one entry point instead of two.
     ("OCCTShapeDivide", HEALING),
-    ("OCCTShapeUpgradeDivideContinuity", HEALING),
     ("OCCTThruSectionsSetContinuity", MODELING),
     ("OCCTFilletBuilderSetContinuity", MODELING),
     ("OCCTFillingAddEdge", MODELING),

--- a/Sources/OCCTBridge/include/OCCTBridge.h
+++ b/Sources/OCCTBridge/include/OCCTBridge.h
@@ -617,7 +617,8 @@
 //                                       OCCTShapeUpgradeConvertCurves3dToBezier,
 //                                       OCCTShapeUpgradeConvertSurfaceToBezier
 // ShapeUpgrade_ShapeDivideClosed      → OCCTShapeUpgradeDivideClosed
-// ShapeUpgrade_ShapeDivideContinuity  → OCCTShapeDivide, OCCTShapeUpgradeDivideContinuity
+// ShapeUpgrade_ShapeDivideContinuity  → OCCTShapeDivide (#438 folded a second, narrower entry
+//                                       point into this one; see OCCTBridge_Healing.mm)
 // ShapeUpgrade_UnifySameDomain        → OCCTShapeUnifySameDomain, OCCTShapeSimplify, OCCTUnifySameDomainCreate
 //
 // --- STEP/IGES/OBJ/PLY/STL ---

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -251,11 +251,16 @@ OCCTShapeRef OCCTShapePlateCurves(const OCCTWireRef* curves, int32_t curveCount,
 
 // MARK: - Advanced Healing (v0.17.0)
 
-/// Divide a shape at continuity discontinuities
+/// Divide a shape wherever its geometry drops below the required continuity.
+///
+/// The sole entry point behind `Shape.divided(at:tolerance:)` since #438 folded in
+/// `OCCTShapeUpgradeDivideContinuity`, the narrower bridge function that used to sit behind the
+/// now-deprecated `Shape.dividedByContinuity(criterion:tolerance:)`.
 /// @param shape Shape to divide
-/// @param continuity Target continuity (0=C0, 1=C1, 2=C2, 3=C3)
+/// @param continuity Target continuity (0=C0, 1=C1, 2=C2, 3=C3, 4=CN, 5=G1, 6=G2)
+/// @param tolerance Tolerance for the continuity check
 /// @return Divided shape, or NULL on failure
-OCCTShapeRef OCCTShapeDivide(OCCTShapeRef shape, int32_t continuity);
+OCCTShapeRef OCCTShapeDivide(OCCTShapeRef shape, int32_t continuity, double tolerance);
 
 /// Convert geometry to direct faces (canonical surfaces)
 OCCTShapeRef OCCTShapeDirectFaces(OCCTShapeRef shape);
@@ -694,14 +699,9 @@ int32_t OCCTShapeFixWireVertex(OCCTShapeRef shape, double precision);
 /// @return Divided shape, or NULL on failure
 OCCTShapeRef _Nullable OCCTShapeUpgradeDivideClosed(OCCTShapeRef shape, int32_t nbSplitPoints);
 
-// --- ShapeUpgrade_ShapeDivideContinuity ---
-
-/// Divide a shape at continuity breaks.
-/// @param shape Shape to process
-/// @param boundaryCriterion Minimum continuity level (0=C0, 1=C1, 2=C2, 3=C3, 4=CN, 5=G1, 6=G2)
-/// @param tolerance Tolerance for continuity check
-/// @return Divided shape, or NULL on failure
-OCCTShapeRef _Nullable OCCTShapeUpgradeDivideContinuity(OCCTShapeRef shape, int32_t boundaryCriterion, double tolerance);
+// --- ShapeUpgrade_ShapeDivideContinuity: OCCTShapeDivide (above), the sole entry point since
+// #438 folded in OCCTShapeUpgradeDivideContinuity, which used to sit behind the now-deprecated
+// Shape.dividedByContinuity(criterion:tolerance:).
 
 // --- ShapeFix_FixSmallSolid ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -1194,16 +1194,36 @@ OCCTShapeRef OCCTShapeRemoveLocations(OCCTShapeRef shape) {
 #include <ShapeCustom.hxx>
 #include <ShapeCustom_RestrictionParameters.hxx>
 
-OCCTShapeRef OCCTShapeDivide(OCCTShapeRef shape, int32_t continuity) {
+// #438: the sole entry point behind Shape.divided(at:tolerance:) now, folding in what used to be
+// a second, narrower bridge function (OCCTShapeUpgradeDivideContinuity) behind the now-deprecated
+// Shape.dividedByContinuity(criterion:tolerance:). That second function set ONLY
+// SetBoundaryCriterion, leaving SetPCurveCriterion/SetSurfaceCriterion pinned at the class's own
+// GeomAbs_C1 constructor default regardless of the requested continuity — measured
+// (Scripts/repro/cluster-d-continuity) as a flat result across every criterion 0..6 on a fixture
+// where this function's own three-criteria version varies (nil/4/4/25 faces at C0/C1/C2/C3). Per
+// the OCCT shape-healing guide's own worked example, all three criteria are meant to be set
+// together to the same target continuity.
+OCCTShapeRef OCCTShapeDivide(OCCTShapeRef shape, int32_t continuity, double tolerance) {
     if (!shape) return nullptr;
 
     try {
-        const GeomAbs_Shape cont = occtGeomAbsFromParametricContinuity(continuity);
+        // Shape.ContinuityLevel is ParametricContinuity's ladder (0=C0 .. 3=C3, 4=CN, which is
+        // where occtGeomAbsFromParametricContinuity saturates anyway) with the two geometric
+        // classes tacked on at 5 and 6. Those two are the only values here that are not the
+        // shared parametric decoding — and they are also the two ShapeUpgrade_Split*Continuity::
+        // SetCriterion does not recognise at all, so OCCT quietly substitutes its own C1 default
+        // for them. Kept because the public enum has always advertised them. #490, moved here
+        // from the now-removed OCCTShapeUpgradeDivideContinuity by #438.
+        const GeomAbs_Shape cont =
+            continuity == 5 ? GeomAbs_G1 :
+            continuity == 6 ? GeomAbs_G2 :
+            occtGeomAbsFromParametricContinuity(continuity);
 
         ShapeUpgrade_ShapeDivideContinuity divider(shape->shape);
         divider.SetBoundaryCriterion(cont);
         divider.SetPCurveCriterion(cont);
         divider.SetSurfaceCriterion(cont);
+        divider.SetTolerance(tolerance);
         divider.SetSurfaceSegmentMode(Standard_True);
         if (!divider.Perform()) return nullptr;
 
@@ -2323,33 +2343,12 @@ OCCTShapeRef OCCTShapeUpgradeDivideClosed(OCCTShapeRef shape, int32_t nbSplitPoi
     }
 }
 
-OCCTShapeRef OCCTShapeUpgradeDivideContinuity(OCCTShapeRef shape, int32_t boundaryCriterion, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideContinuity divider(shape->shape);
-
-        // Shape.ContinuityLevel is ParametricContinuity's ladder (0=C0 .. 3=C3, 4=CN, which is
-        // where occtGeomAbsFromParametricContinuity saturates anyway) with the two geometric
-        // classes tacked on at 5 and 6. Those two are the only values here that are not the
-        // shared parametric decoding — and they are also the two ShapeUpgrade_Split*Continuity::
-        // SetCriterion does not recognise at all, so OCCT quietly substitutes its own C1 default
-        // for them. Kept because the public enum has always advertised them. #490.
-        const GeomAbs_Shape criterion =
-            boundaryCriterion == 5 ? GeomAbs_G1 :
-            boundaryCriterion == 6 ? GeomAbs_G2 :
-            occtGeomAbsFromParametricContinuity(boundaryCriterion);
-
-        divider.SetBoundaryCriterion(criterion);
-        divider.SetTolerance(tolerance);
-        bool ok = divider.Perform();
-        if (!ok) return nullptr;
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
-}
+// OCCTShapeUpgradeDivideContinuity, the boundary-only entry point behind the now-deprecated
+// Shape.dividedByContinuity(criterion:tolerance:), was removed here (#438): it wrapped the same
+// ShapeUpgrade_ShapeDivideContinuity as OCCTShapeDivide above with a narrower, measurably
+// different call (SetBoundaryCriterion only, no SetPCurveCriterion/SetSurfaceCriterion). The
+// deprecated Swift entry point now forwards to Shape.divided(at:tolerance:), so this bridge
+// function has no remaining caller.
 
 // MARK: - ShapeFix Small Solids (v0.49)
 // --- ShapeFix_FixSmallSolid ---

--- a/Sources/OCCTSwift/Continuity.swift
+++ b/Sources/OCCTSwift/Continuity.swift
@@ -118,7 +118,7 @@ public typealias PlateConstraintOrder = SurfaceContinuity
 /// Minimum parametric continuity to require of a piece of geometry.
 ///
 /// Used wherever an operation splits, approximates or simplifies geometry against a continuity
-/// floor: ``Shape/divided(at:)``, ``Shape/bsplineRestriction(tol3d:tol2d:maxDegree:maxSegments:continuity3d:continuity2d:degreePriority:rational:)``,
+/// floor: ``Shape/bsplineRestriction(tol3d:tol2d:maxDegree:maxSegments:continuity3d:continuity2d:degreePriority:rational:)``,
 /// ``Curve3D/approxWithDetails(tolerance:continuity:maxSegments:maxDegree:)``,
 /// ``Surface/approxWithDetails(tolerance:uContinuity:vContinuity:maxSegments:maxDegree:)``, and
 /// the whole BSpline knot-splitting family: ``Curve3D/continuityBreaks(minContinuity:)``,
@@ -127,10 +127,11 @@ public typealias PlateConstraintOrder = SurfaceContinuity
 /// ``LawFunction/knotSplitting(continuityOrder:)`` and
 /// ``LawFunction/knotSplitParameters(continuityOrder:)``.
 ///
-/// ```swift
-/// // Split a shape wherever it drops below C2
-/// let pieces = shape.divided(at: .c2)
+/// `Shape/divided(at:tolerance:)` used to be one of these, but #438 widened it to the strict
+/// superset ``Shape/ContinuityLevel``, which also folded in the narrower, now-deprecated
+/// `Shape/dividedByContinuity(criterion:tolerance:)`.
 ///
+/// ```swift
 /// // Knots where a BSpline fails to be C3. A cubic interpolated curve is C2 at its
 /// // interior knots, so .c3 is the order that actually reports them.
 /// let breaks = bspline.continuityBreaks(minContinuity: .c3)

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -105,12 +105,33 @@ extension Shape {
     // GeomAbs_C0...C3, so it is parametric continuity. It is now `ParametricContinuity` in
     // Continuity.swift, shared with the other APIs that take a continuity floor. See #398.
 
-    /// Divide a shape at continuity discontinuities
+    /// Divide a shape wherever its geometry drops below the required continuity.
     ///
-    /// - Parameter continuity: Target continuity level
-    /// - Returns: Divided shape, or nil on failure
-    public func divided(at continuity: ParametricContinuity) -> Shape? {
-        guard let handle = OCCTShapeDivide(self.handle, continuity.rawValue) else { return nil }
+    /// Sets `ShapeUpgrade_ShapeDivideContinuity`'s boundary, pcurve AND surface criteria together
+    /// to `continuity`, plus `SetSurfaceSegmentMode(true)` — the usage OCCT's own shape-healing
+    /// guide demonstrates. Until #438 this was one of two public entry points over that same OCCT
+    /// class: ``dividedByContinuity(criterion:tolerance:)`` (now deprecated, forwarding here) set
+    /// only the boundary criterion, leaving pcurve/surface pinned at the class's own C1
+    /// constructor default regardless of the requested continuity — measured
+    /// (`Scripts/repro/cluster-d-continuity`) as a flat result across every criterion on a
+    /// fixture where this method's own three-criteria behaviour varies (nil/4/4/25 faces at
+    /// C0/C1/C2/C3).
+    ///
+    /// ```swift
+    /// let pieces = shape.divided(at: .c2)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - continuity: Minimum required continuity. `.cn`, `.g1` and `.g2` are accepted in
+    ///     addition to `.c0`...`.c3` (#438 widened this from ``ParametricContinuity``); OCCT's
+    ///     own criterion setters have no case for G1/G2 and would otherwise silently substitute
+    ///     their own C1 default, so those two are decoded ahead of the call instead.
+    ///   - tolerance: Tolerance for the continuity check. Defaults to `1e-7`
+    ///     (`Precision::Confusion()`), OCCT's own default and this method's behavior before #438
+    ///     added the parameter.
+    /// - Returns: Divided shape, or nil if no divisions were needed or on failure.
+    public func divided(at continuity: ContinuityLevel, tolerance: Double = 1e-7) -> Shape? {
+        guard let handle = OCCTShapeDivide(self.handle, continuity.rawValue, tolerance) else { return nil }
         return Shape(handle: handle)
     }
 
@@ -558,16 +579,14 @@ extension Shape {
 
     /// Divide this shape at continuity breaks.
     ///
-    /// Uses ShapeUpgrade_ShapeDivideContinuity to split faces/edges
-    /// at points where the geometry drops below the required continuity.
-    ///
-    /// - Parameters:
-    ///   - criterion: Minimum required continuity level (default: .c1)
-    ///   - tolerance: Tolerance for continuity check (default: 1e-4)
-    /// - Returns: Divided shape, or nil if no divisions needed or on failure
+    /// - Deprecated: Duplicated ``divided(at:tolerance:)`` over the same
+    ///   `ShapeUpgrade_ShapeDivideContinuity`, setting only the boundary criterion where
+    ///   ``divided(at:tolerance:)`` sets boundary, pcurve AND surface criteria together — the
+    ///   usage OCCT's own shape-healing guide demonstrates (#438). Forwards there now; both
+    ///   names run the identical call.
+    @available(*, deprecated, renamed: "divided(at:tolerance:)")
     public func dividedByContinuity(criterion: ContinuityLevel = .c1, tolerance: Double = 1e-4) -> Shape? {
-        guard let ref = OCCTShapeUpgradeDivideContinuity(handle, criterion.rawValue, tolerance) else { return nil }
-        return Shape(handle: ref)
+        divided(at: criterion, tolerance: tolerance)
     }
 
     // MARK: - ShapeFix_FixSmallSolid

--- a/Sources/OCCTSwift/Shape+Surface.swift
+++ b/Sources/OCCTSwift/Shape+Surface.swift
@@ -767,9 +767,12 @@ extension Shape {
     ///
     /// Deliberately kept separate from ``ParametricContinuity`` (#398): this is a strict
     /// superset, and `cn`, `g1` and `g2` are accepted only by
-    /// ``dividedByContinuity(criterion:tolerance:)``. Every other continuity-floor call site
-    /// silently defaults an unrecognised value, so widening them to this type would trade a
-    /// compile error for a wrong answer.
+    /// ``divided(at:tolerance:)``. Every other continuity-floor call site silently defaults an
+    /// unrecognised value, so widening them to this type would trade a compile error for a wrong
+    /// answer.
+    ///
+    /// - Note: Used by ``divided(at:tolerance:)`` alone since #438 folded the narrower
+    ///   ``dividedByContinuity(criterion:tolerance:)`` (now deprecated) into it.
     public enum ContinuityLevel: Int32, Sendable, CaseIterable {
         case c0 = 0, c1 = 1, c2 = 2, c3 = 3, cn = 4, g1 = 5, g2 = 6
     }

--- a/Tests/OCCTShapeHealingTests/Issue438DivideContinuityUnificationTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue438DivideContinuityUnificationTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import OCCTSwift
+
+// #438: `Shape` exposed `ShapeUpgrade_ShapeDivideContinuity` twice. `divided(at:)` set the
+// divider's boundary, pcurve AND surface criteria together (plus `SetSurfaceSegmentMode(true)`);
+// `dividedByContinuity(criterion:tolerance:)` set only the boundary criterion, leaving
+// pcurve/surface pinned at the class's own C1 constructor default no matter what continuity was
+// requested. Measured (Scripts/repro/cluster-d-continuity) as a flat "4 faces" from
+// `dividedByContinuity` across every criterion 0..6 on a fixture where `divided(at:)`'s own
+// three-criteria behaviour varies (nil/4/4/25 faces at C0/C1/C2/C3) -- the surface criterion, not
+// the boundary one, is what actually drives this fixture's split count.
+//
+// Fixed by widening `divided(at:)` to `divided(at:tolerance:)`, taking `ContinuityLevel` (the
+// strict superset only `dividedByContinuity` used to reach) and a `tolerance` parameter, and
+// deprecating `dividedByContinuity(criterion:tolerance:)` as a forward to it. These tests pin two
+// independent things: that the unified bridge call still varies with continuity (the actual fix,
+// against numbers measured from the corrected implementation, not merely "the two agree" — which
+// would be true by construction once one forwards to the other and would prove nothing about
+// whether the fix itself is correct), and that the deprecated spelling's forward is intact.
+@Suite("Issue #438: divided(at:) and dividedByContinuity unified over one OCCT class")
+struct Issue438DivideContinuityUnificationTests {
+
+    // Same recipe as Scripts/repro/censuses/ClusterD.swift's own `knotVector`/`kinkedSurfaceShape`:
+    // a cubic BSpline surface with a mult-3 interior knot in both U and V, genuinely C0 (not C1)
+    // at that knot in both parametric directions. Neither a plain box nor a cylinder works here —
+    // both this suite's own `AdvancedHealingTests.divideCylinder` and
+    // `ShapeUpgradeDivideContinuityTests.divideBoxContinuity` tolerate nil, and measured, a planar
+    // box has no interior surface knots to divide at, and a cylinder's single lateral face is one
+    // smooth periodic surface with none either.
+    private func kinkedSurfaceFace() -> Shape? {
+        let degree = 3, interiorKnots = 4, bumpAt = 2, bumpMult = 3
+        var knots: [Double] = [0]
+        var mults: [Int32] = [Int32(degree + 1)]
+        for i in 1...interiorKnots {
+            knots.append(Double(i))
+            mults.append(Int32(i == bumpAt ? bumpMult : 1))
+        }
+        knots.append(Double(interiorKnots + 1))
+        mults.append(Int32(degree + 1))
+        let poleCount = Int(mults.reduce(0, +)) - degree - 1
+
+        guard let surface = Surface.bspline(
+            poles: (0..<poleCount).map { u in
+                (0..<poleCount).map { v in
+                    SIMD3<Double>(Double(u), Double(v), Double((u + v) % 3) * 0.5)
+                }
+            },
+            knotsU: knots, multiplicitiesU: mults,
+            knotsV: knots, multiplicitiesV: mults,
+            degreeU: degree, degreeV: degree) else { return nil }
+        let bounds = surface.domain
+        return Shape.face(from: surface, uRange: bounds.uMin...bounds.uMax, vRange: bounds.vMin...bounds.vMax)
+    }
+
+    // MARK: - The actual fix: all three criteria, not just the boundary one
+
+    @Test("divided(at:tolerance:) varies with continuity because it sets all three criteria",
+          arguments: [
+            (Shape.ContinuityLevel.c0, nil as Int?),
+            (.c1, 4), (.c2, 4), (.c3, 25), (.cn, 25),
+            // G1/G2 are not recognised by ShapeUpgrade_Split*Continuity::SetCriterion, which
+            // falls through to its own C1 default for them (read from Libraries/occt-src) — so
+            // they are expected to agree with .c1, not to add new behaviour of their own.
+            (.g1, 4), (.g2, 4),
+          ])
+    func dividedVariesWithContinuity(level: Shape.ContinuityLevel, expectedFaces: Int?) throws {
+        let face = try #require(kinkedSurfaceFace())
+        let result = face.divided(at: level, tolerance: 1e-4)
+        #expect(result?.faceCount == expectedFaces)
+    }
+
+    @Test("C3 produces a different result from C1, proving the surface criterion is observable")
+    func dividedContinuityIsObservable() throws {
+        let atC1 = try #require(kinkedSurfaceFace()?.divided(at: .c1, tolerance: 1e-4))
+        let atC3 = try #require(kinkedSurfaceFace()?.divided(at: .c3, tolerance: 1e-4))
+        #expect(atC1.faceCount != atC3.faceCount)
+    }
+
+    // MARK: - The deprecated spelling forwards correctly
+
+    @Test("dividedByContinuity(criterion:tolerance:) (deprecated) matches divided(at:tolerance:) at every level",
+          arguments: Shape.ContinuityLevel.allCases)
+    @available(*, deprecated, message: "exercises the deprecated dividedByContinuity on purpose")
+    func dividedByContinuityForwardsToDivided(level: Shape.ContinuityLevel) throws {
+        let viaDivided = kinkedSurfaceFace()?.divided(at: level, tolerance: 1e-4)
+        let viaDeprecated = kinkedSurfaceFace()?.dividedByContinuity(criterion: level, tolerance: 1e-4)
+        #expect(viaDivided?.faceCount == viaDeprecated?.faceCount)
+    }
+
+    @Test("dividedByContinuity's default tolerance still forwards (no default drift)")
+    @available(*, deprecated, message: "exercises the deprecated dividedByContinuity on purpose")
+    func dividedByContinuityDefaultToleranceForwards() throws {
+        let viaDivided = kinkedSurfaceFace()?.divided(at: .c3, tolerance: 1e-4)
+        let viaDeprecatedDefault = kinkedSurfaceFace()?.dividedByContinuity(criterion: .c3)
+        #expect(viaDivided?.faceCount == viaDeprecatedDefault?.faceCount)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -794,7 +794,13 @@ struct ShapeUpgradeDivideClosedTests {
 
 @Suite("ShapeUpgrade DivideContinuity Tests")
 struct ShapeUpgradeDivideContinuityTests {
+    /// Exercises the deprecated spelling on purpose, so the annotation goes on the test rather
+    /// than leaving one warning per call site. Same convention as
+    /// `Issue438DivideContinuityUnificationTests` and `ClusterD.swift`'s forwarding record, which
+    /// #438 established when it deprecated this method: the whole point of that convention is that
+    /// a deliberate exercise costs one warning at its definition, not noise at every use.
     @Test("Divide box by continuity")
+    @available(*, deprecated, message: "exercises the deprecated dividedByContinuity on purpose")
     func divideBoxContinuity() throws {
         let box = Shape.box(width: 10, height: 10, depth: 10)!
         // Box has C0 at edges, so dividing by C1 should not change it

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -18,13 +18,17 @@ This page covers geometry repair, shape upgrade, point classification, proximity
 ### `ParametricContinuity`
 
 Minimum parametric continuity to require of a piece of geometry. Shared by every operation
-that splits, approximates or simplifies against a continuity floor: `Shape.divided(at:)`,
+that splits, approximates or simplifies against a continuity floor:
 `Shape.bsplineRestriction(...)`, `Curve3D.approxWithDetails(...)`,
 `Surface.approxWithDetails(tolerance:uContinuity:vContinuity:...)` and the whole BSpline
 knot-splitting family: `Curve3D.continuityBreaks(minContinuity:)`,
 `Curve2D.splitIndicesAtDiscontinuities(continuity:)`,
 `Surface.knotSplitting(uContinuity:vContinuity:)`, `LawFunction.knotSplitting(continuityOrder:)`
 and `LawFunction.knotSplitParameters(continuityOrder:)`.
+
+`Shape.divided(at:)` used to be one of these too, but #438 widened it to the strict superset
+[`Shape.ContinuityLevel`](Shape-Measurement.md#continuitylevel) — see
+[`divided(at:tolerance:)`](#dividedattolerance) below.
 
 What the value becomes depends on the consumer. Most decode it to a `GeomAbs_Shape` (`GeomAbs_C0`
 through `GeomAbs_C3`); the knot-splitting family instead passes it to OCCT as a literal derivative
@@ -40,32 +44,41 @@ public enum ParametricContinuity: Int32, Sendable, CaseIterable {
 }
 ```
 
-Pass to `divided(at:)` to split a shape wherever it drops below the specified continuity.
-
 > **Renamed in #398.** This type used to be called `GeometricContinuity`, which was a misnomer:
 > the value maps to `GeomAbs_C0...C3`, so it is *parametric* continuity (equal derivative
 > vectors), not the geometric G0/G1/G2 constraint order of
 > [`SurfaceContinuity`](Shape-Features.md#surfacecontinuity) (parallel tangent directions).
 > `GeometricContinuity`, `ApproxContinuity`, `Shape.BSplineContinuity` and
 > `Curve3D.ContinuityOrder` are now deprecated typealiases of it. No raw value moved.
->
-> `Shape.ContinuityLevel` is deliberately **not** folded in: it is a strict superset used by
-> `dividedByContinuity(criterion:tolerance:)`, adding `cn`, `g1` and `g2` cases that the other
-> call sites cannot accept.
 
 ---
 
-### `divided(at:)`
+### `divided(at:tolerance:)`
 
-Divide a shape at continuity discontinuities.
+Divide a shape wherever its geometry drops below the required continuity.
 
 ```swift
-public func divided(at continuity: ParametricContinuity) -> Shape?
+public func divided(at continuity: Shape.ContinuityLevel, tolerance: Double = 1e-7) -> Shape?
 ```
 
-Splits the shape wherever its underlying geometry drops below the requested continuity class.
+Sets `ShapeUpgrade_ShapeDivideContinuity`'s boundary, pcurve AND surface criteria together to
+`continuity`, plus `SetSurfaceSegmentMode(true)` — the usage OCCT's own shape-healing guide
+demonstrates. Until #438 this was one of two public entry points over that same OCCT class:
+[`dividedByContinuity(criterion:tolerance:)`](Shape-Measurement.md#dividedbycontinuitycriteriontolerance)
+(now deprecated, forwarding here) set only the boundary criterion, leaving pcurve/surface pinned
+at the class's own C1 constructor default regardless of the requested continuity — measured
+(`Scripts/repro/cluster-d-continuity`) as a flat result across every criterion on a fixture where
+this method's own three-criteria behaviour varies (nil/4/4/25 faces at C0/C1/C2/C3).
 
-- **Parameters:** `continuity` — target minimum continuity; the shape is split at any face/edge boundary that does not meet this standard.
+- **Parameters:**
+  - `continuity` — target minimum continuity; the shape is split at any face/edge boundary that
+    does not meet this standard. `.cn`, `.g1` and `.g2` are accepted in addition to `.c0`...`.c3`
+    (#438 widened this from `ParametricContinuity`); OCCT's own criterion setters have no case for
+    G1/G2 and would otherwise silently substitute their own C1 default, so those two are decoded
+    ahead of the call instead.
+  - `tolerance` — tolerance for the continuity check. Defaults to `1e-7`
+    (`Precision::Confusion()`), OCCT's own default and this method's behavior before #438 added
+    the parameter.
 - **Returns:** Divided shape, or nil on failure.
 - **OCCT:** `ShapeUpgrade_ShapeDivideContinuity` (via `OCCTShapeDivide`).
 - **Example:**

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -2194,27 +2194,38 @@ public enum ContinuityLevel: Int32, Sendable, CaseIterable {
 
 > **Deliberately kept separate from
 > [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity)** (#398). This is a strict
-> superset: `cn`, `g1` and `g2` are accepted only by `dividedByContinuity(criterion:tolerance:)`.
-> Every other continuity-floor call site silently defaults an unrecognised value, so widening
-> them to this type would trade a compile error for a wrong answer.
+> superset: `cn`, `g1` and `g2` are accepted only by
+> [`divided(at:tolerance:)`](Shape-Healing.md#dividedattolerance). Every other continuity-floor
+> call site silently defaults an unrecognised value, so widening them to this type would trade a
+> compile error for a wrong answer.
+>
+> Used by `divided(at:tolerance:)` alone since #438 folded the narrower
+> `dividedByContinuity(criterion:tolerance:)` (now deprecated) into it.
 
 ---
 
-### `dividedByContinuity(criterion:tolerance:)`
+### `dividedByContinuity(criterion:tolerance:)` *(deprecated)*
 
-Divide this shape at continuity breaks.
+Deprecated in favour of
+[`divided(at:tolerance:)`](Shape-Healing.md#dividedattolerance), which it now forwards to.
 
 ```swift
+@available(*, deprecated, renamed: "divided(at:tolerance:)")
 public func dividedByContinuity(criterion: ContinuityLevel = .c1, tolerance: Double = 1e-4) -> Shape?
 ```
 
-Splits faces and edges at points where the geometry drops below the required continuity level.
+This duplicated `divided(at:tolerance:)` over the same `ShapeUpgrade_ShapeDivideContinuity`,
+setting only the boundary criterion where `divided(at:tolerance:)` sets boundary, pcurve AND
+surface criteria together — the usage OCCT's own shape-healing guide demonstrates (#438). Both
+names now run the identical call; the two former bridge functions (`OCCTShapeDivide`,
+`OCCTShapeUpgradeDivideContinuity`) are now one (`OCCTShapeDivide`, which picked up a `tolerance`
+parameter).
 
-- **Parameters:**
-  - `criterion` — Minimum required continuity level.
-  - `tolerance` — Tolerance for continuity check.
-- **Returns:** Divided shape, or `nil` if no divisions needed or on failure.
-- **OCCT:** `ShapeUpgrade_ShapeDivideContinuity` (via `OCCTShapeUpgradeDivideContinuity`).
+- **OCCT:** `ShapeUpgrade_ShapeDivideContinuity` (via `OCCTShapeDivide`).
+- **Example:**
+  ```swift
+  shape.divided(at: .c1, tolerance: 1e-4)   // was: shape.dividedByContinuity(criterion: .c1, tolerance: 1e-4)
+  ```
 
 ---
 


### PR DESCRIPTION
## What & why

Closes #438

`Shape` exposed `ShapeUpgrade_ShapeDivideContinuity` through two public entry points, setting
different criteria on the same builder:

| Swift | criteria set | tolerance |
|---|---|---|
| `divided(at:)` | boundary, pcurve AND surface, plus `SetSurfaceSegmentMode(true)` | none (OCCT default) |
| `dividedByContinuity(criterion:tolerance:)` | boundary only | caller-supplied |

Cluster D's continuity census (#513/#667, `Scripts/repro/cluster-d-continuity/`) separated this
from #437, describing it as "two public APIs correctly decoding the same continuity through the
same canonical decoder, but setting different criteria on the builder": an API-duplication defect,
not an encoding mismatch. Per the census's own instruction, I consumed that finding rather than
re-deriving it.

Reading `ShapeUpgrade_ShapeDivideContinuity.cxx`'s constructor (all three criteria default to
`GeomAbs_C1`) and the OCCT shape-healing guide's own worked example (which sets all three criteria
together) shows `dividedByContinuity`'s boundary-only call was the incomplete one:
`SetPCurveCriterion`/`SetSurfaceCriterion` stay pinned at C1 no matter what continuity is
requested. Measured on a kinked-BSpline-surface fixture (mult-3 interior knot, genuinely C0),
`dividedByContinuity` returned a flat 4 faces at every criterion 0..6, where `divided(at:)`
actually varies: nil/4/4/25 faces at C0/C1/C2/C3 (surface splitting, not boundary splitting, is
what drives this fixture).

## The fix

Per #438's own "Option 1": widened `divided(at:)` to `divided(at:tolerance:)`, taking
`ContinuityLevel` (the strict superset that used to be reachable only through
`dividedByContinuity`) and a `tolerance` parameter defaulting to `1e-7`
(`Precision::Confusion()`, this method's own implicit behavior before the parameter existed).
`dividedByContinuity(criterion:tolerance:)` is now `@available(*, deprecated, renamed:
"divided(at:tolerance:)")` and forwards there. The two former bridge functions (`OCCTShapeDivide`,
`OCCTShapeUpgradeDivideContinuity`) are now one (`OCCTShapeDivide`, which picked up the `tolerance`
parameter and the G1/G2 special-case ternary the removed function used to carry).

One visible behaviour change for an existing `dividedByContinuity` caller: `.c0` now returns `nil`
instead of a 4-face result, because the pcurve/surface criteria are now genuinely applied, matching
what `divided(at:)` already did at `.c0`. Every other level is unchanged from `divided(at:)`'s own
prior behaviour. Not a `docs/SEMVER.md` exception: this lands in the still-unreleased v2.0.0 major.

### Census updated, not left stale

Per `docs/v2.0.0-plan.md`'s census-once rule, the census artifact is updated rather than
re-derived elsewhere:

- `Scripts/repro/cluster-d-continuity/README.md` gets a "Fixed" section (matching the #437
  precedent) with before/after numbers and the classified-function count correction (42 to 41
  static sites, one bridge function retired).
- `Scripts/repro/censuses/ClusterD.swift`'s section 2f/2g rewritten: it used to *compare*
  `divided(at:)` against `dividedByContinuity` as two independent implementations. Now that one
  forwards to the other, that comparison would be true by construction and prove nothing: the
  classic "parity test goes blind after unification" trap. Section 2f now measures `divided(at:)`
  alone across its full domain (the actual fix, pinned against real numbers); section 2g
  separately pins that the deprecated spelling's forward is intact (a narrower, still-meaningful
  claim: a future edit to either method that breaks argument pass-through would still be caught).
- `Scripts/repro/cluster-d-continuity/classify_continuity_sites.py`'s hardcoded site list drops
  the removed `OCCTShapeUpgradeDivideContinuity` entry; its docstring's special-case example is
  repointed at `OCCTShapeDivide`, which now carries that logic.

### Why the G1/G2 ternary is inlined, not a shared helper

First draft added a shared `occtGeomAbsFromContinuityLevel` helper in `OCCTBridge_Internal.h`.
Reverted: the static classifier (`classify_continuity_sites.py`) detects the G1/G2 special case by
pattern-matching an inline ternary in the function's own body (matching #490's format); with only
one caller left after this fix, a shared helper would have made `OCCTShapeDivide` register as
`RAW (no decoder call)`, a fresh blind spot the census would otherwise not have caught. Inlined the
ternary instead, matching the removed function's original shape.

## Prove-the-test-fails: the injection matrix

Per `okf/policies/prove-the-test-fails.md`, every case was run once with its guard broken.

New suite: `Tests/OCCTShapeHealingTests/Issue438DivideContinuityUnificationTests.swift`.

| case | guard broken | result |
|---|---|---|
| `dividedVariesWithContinuity` (7 cases) | `OCCTShapeDivide`: commented out `SetPCurveCriterion`/`SetSurfaceCriterion` (reproduces the original `dividedByContinuity` bug) | **red**: c0/c3/cn cases fail (flat "4 faces" at every level) |
| `dividedContinuityIsObservable` | same | **red**: C1 and C3 now report the same face count |
| `dividedByContinuityForwardsToDivided` (7 cases) | same | green (decorative for this guard: both sides call the same, still-broken, single implementation) |
| `dividedByContinuityDefaultToleranceForwards` | same | green (decorative for this guard, same reason) |
| `dividedVariesWithContinuity` (g1/g2 cases) | `OCCTShapeDivide`: removed the G1/G2 ternary, letting 5/6 fall through to `occtGeomAbsFromParametricContinuity`'s out-of-range branch (saturates to CN) | **red**: g1/g2 now report 25 faces instead of 4 |
| everything else | same | green (unaffected; this guard only touches the g1/g2 path) |
| `dividedByContinuityForwardsToDivided` (7 cases) | `dividedByContinuity`: hardcoded `divided(at: .c1, ...)`, ignoring the caller's `criterion` | **red**: c0/c3/cn cases diverge from `divided(at:)` called directly |
| `dividedByContinuityDefaultToleranceForwards` | same | **red** |
| `dividedVariesWithContinuity` / `dividedContinuityIsObservable` | same | green (unaffected; these never call the deprecated spelling) |

One injection was tried and discarded as decorative before landing on the above: hardcoding the
deprecated forward's `tolerance` to `1e-7` regardless of the caller's argument produced no failure
anywhere, because the fixture's face count is identical at `1e-4` and `1e-7` tolerance. Replaced
with the criterion-forwarding injection above, which does move the answer.

## Verification

- `swift build` (`env -u OCCTSWIFT_LOCAL`): 0 errors.
- `swift test` (`env -u OCCTSWIFT_LOCAL`): full suite, 5430 tests / 1415 suites, 0 failures.
- All five gate scripts plus their `--self-test`s: clean (`check-bridge-index`,
  `check-null-handle-guards`, `check-docs-defaults`, `derive-bridge-header-split --verify`,
  `count-operations`). README/API_REFERENCE totals unchanged (4306): no public API was added or
  removed, one was widened and one deprecated.
- `classify_continuity_sites.py` plus `--self-test`: clean, `OCCTShapeDivide` now classifies as
  `ParametricContinuity + special-case(G1/G2 literal)`.
- Not run: `Scripts/tsan-stress.sh`. This change touches no shared/global/static state and no
  threading primitive (`ShapeUpgrade_ShapeDivideContinuity` is a stack-local object per call, same
  as before), so it isn't concurrency-touching per CLAUDE.md's gate criterion.
- GitHub Actions is reportedly in a major outage; the above is local verification, not a CI run.

## CHANGELOG entry

### `Shape.divided(at:)` and `dividedByContinuity(criterion:tolerance:)` unified onto one entry point (#438)

`Shape` exposed `ShapeUpgrade_ShapeDivideContinuity` through two public entry points that set
different criteria on the same builder: `divided(at:)` set boundary, pcurve AND surface criteria
together, matching OCCT's own shape-healing guide; `dividedByContinuity(criterion:tolerance:)` set
only the boundary criterion, leaving pcurve/surface pinned at the class's own C1 default regardless
of the requested continuity. Measured (`Scripts/repro/cluster-d-continuity`) as a flat result
across every criterion on a fixture where `divided(at:)`'s own behaviour varies (nil/4/4/25 faces
at C0/C1/C2/C3).

`divided(at:)` is now `divided(at:tolerance:)`, taking `ContinuityLevel` (the strict superset
`dividedByContinuity` alone used to reach) and a `tolerance` parameter (default `1e-7`, matching
this method's prior implicit behavior). `dividedByContinuity(criterion:tolerance:)` is deprecated
and forwards to it. One behaviour change for existing `dividedByContinuity` callers: `.c0` now
returns `nil` rather than a spurious non-nil result, matching `divided(at:)`'s own `.c0` answer,
because the pcurve/surface criteria are now genuinely applied instead of silently ignored.

## Notes for the reviewer

- Files touched are exactly the two named in the issue (`Shape+Surface.swift`,
  `Shape+ShapeHealing.swift`) plus their bridge counterpart (`OCCTBridge_Healing.h`/`.mm`,
  `OCCTBridge_Internal.h`, `OCCTBridge.h`'s index) and the census/docs that describe them. Did not
  touch `Curve3D.swift`, `OCCTBridge_Curve3D.mm` (#730's files) or `OCCTBridge_BRepGraph.*`,
  `OCCTBridge_Properties.*`, `FeatureRecognition.swift` (#733's files).
- Targets `refactor/381-pass1b`, not `main`. Please do not merge without confirming that's still
  the intended base.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) - see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.