### PR TITLE
fix(#725,#597,#689): reject rational Bezier joins, fix tolerance-blind sweep, fix networkSurface

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -1910,6 +1910,27 @@ OCCTSurfaceKnotSplitResult OCCTSurfaceKnotSplitting(OCCTSurfaceRef surface,
     return result;
 }
 
+// #725: GeomConvert_CompBezierSurfacesToBSplineSurface has no rational path at all.
+// GeomConvert_CompBezierSurfacesToBSplineSurface.cxx:374-389 computes
+// `isrational |= IsURational() || IsVRational()` over every patch and then
+// `Standard_NotImplemented_Raise_if(isrational, ...)`, which this project's Release kernel
+// compiles out via No_Exception (the same defect class #640 fixed for
+// math_GaussSetIntegration). The converter proceeds anyway, silently dropping every patch's
+// weights and returning the POLYNOMIAL surface through the same control net, with
+// IsDone() == true: measured on a rational quarter-cylinder Bezier patch, a 0.606602 radius
+// error reported as success. Reject before constructing the converter using the exact
+// predicate the compiled-out guard uses, mirroring #640's resolution. Clamping or silently
+// dropping the weights is not an option here, for the same reason it was not in #430/#437.
+static bool occtAnyBezierPatchIsRational(const TColGeom_Array2OfBezierSurface& bezArray) {
+    for (int32_t r = bezArray.LowerRow(); r <= bezArray.UpperRow(); r++) {
+        for (int32_t c = bezArray.LowerCol(); c <= bezArray.UpperCol(); c++) {
+            const Handle(Geom_BezierSurface)& bez = bezArray.Value(r, c);
+            if (!bez.IsNull() && (bez->IsURational() || bez->IsVRational())) return true;
+        }
+    }
+    return false;
+}
+
 OCCTSurfaceRef OCCTSurfaceJoinBezierPatches(
     const OCCTSurfaceRef* patches, int32_t nRows, int32_t nCols) {
     if (!patches || nRows <= 0 || nCols <= 0) return nullptr;
@@ -1924,6 +1945,7 @@ OCCTSurfaceRef OCCTSurfaceJoinBezierPatches(
                 bezArray.SetValue(r + 1, c + 1, bez);
             }
         }
+        if (occtAnyBezierPatchIsRational(bezArray)) return nullptr;
         GeomConvert_CompBezierSurfacesToBSplineSurface conv(bezArray);
         if (!conv.IsDone()) return nullptr;
         Handle(Geom_BSplineSurface) bsurf = new Geom_BSplineSurface(
@@ -2428,9 +2450,25 @@ OCCTShapeRef _Nullable OCCTGeomFillSweep(OCCTShapeRef pathEdge, OCCTShapeRef sec
         Handle(GeomFill_UniformSection) sectionLaw = new GeomFill_UniformSection(sectionCurve);
 
         // Sweep
+        // #597: GeomFill_Sweep::Build's general path (BuildAll) always fits the swept surface
+        // with an internal Approx_SweepApproximation and records the achieved deviation in
+        // ErrorOnSurface(). IsDone() alone says only that SOME surface was produced, not that
+        // it is within the tolerance this call asks for. This entry point used to accept
+        // whatever Build() returned without ever reading that number: the same "accepts an
+        // approximation without reading the error it reports" shape #597 names at
+        // GeomFill_Sweep.cxx:296 and ShapeUpgrade_UnifySameDomain.cxx:3629, except neither of
+        // those two sites is reachable from this file (see the PR body for the measurement;
+        // both live behind PipeShellBuilder/UnifySameDomainBuilder in OCCTBridge_Modeling.mm),
+        // and the ForceApproxC1 one's reported error is a hardcoded constant that cannot move
+        // once that branch fires, the same shape as #522's zero, so reading it would not have
+        // helped even from there. Here the number is real and does move, so reject rather than
+        // silently hand back a surface that missed the tolerance it was built at.
+        const double tolerance = 1e-4; // GeomFill_Sweep's own SetTolerance default.
         GeomFill_Sweep sweep(location);
+        sweep.SetTolerance(tolerance);
         sweep.Build(sectionLaw, GeomFill_Location, GeomAbs_C2, 10, 50);
         if (!sweep.IsDone()) return nullptr;
+        if (sweep.ErrorOnSurface() > tolerance) return nullptr;
 
         Handle(Geom_Surface) surface = sweep.Surface();
         if (surface.IsNull()) return nullptr;
@@ -6537,6 +6575,7 @@ OCCTSurfaceRef OCCTGeomEvalAHTBezierSurfaceCreate(
 // MARK: - GeomFill_Gordon report + GeomFill_NetworkSurface — OCCT 8.0.0p1
 
 #include <GeomFill_NetworkSurface.hxx>
+#include <GeomAPI_ExtremaCurveCurve.hxx>
 
 // Build a Gordon surface reporting status + approximate flag.
 OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t profileCount,
@@ -6583,11 +6622,47 @@ OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t 
     }
 }
 
-// Low-level GeomFill_NetworkSurface builder. Takes profile + guide curves and
-// builds a compatible non-periodic B-spline network: profiles are evaluated in
-// U, guides in V; the intersection grid is sampled at the natural [first,last]
-// parameter range of each curve, and the profile/guide locator parameters are
-// uniformly spaced. Returns the surface or NULL; writes the ResultStatus ordinal.
+// #689: real per-pair contact points and RAW (not normalized) locator parameters.
+//
+// GeomFill_NetworkSurface::Perform() builds a profile skin whose U-axis is the profile
+// curves' own natural parameter domain and a guide skin whose U-axis is theGuideParameters
+// (GeomFill_NetworkSurface.cxx's makeNetworkSurface/alignSurfaces); the two are required to
+// share ONE knot RANGE (sameKnotRange, called from uniteKnots) before either is aligned to the
+// other. theGuideParameters is documented as "U parameters locating guides on profile skin",
+// i.e. it has to live in the profile curves' own domain, not a caller-invented one, and the
+// mirror image holds for theProfileParameters against the guide curves' domain. The previous
+// implementation stuffed a uniform [0,1] fraction into both arrays regardless of what domain
+// the curves actually used, which only shares a range with a profile/guide domain that also
+// happens to be [0,1] by coincidence. Measured directly (see PR body): that is why every
+// fixture tried failed identically with KnotAlignmentFailed, including the simplest possible
+// 2x2 bilinear patch built from two unit-length straight lines each way, a network that is
+// otherwise a perfect, error-free fit.
+//
+// Fix: use GeomAPI_ExtremaCurveCurve (the same public class GeomFill_Gordon's own internal
+// network preparation uses for this) to find each profile/guide pair's real contact point and
+// each curve's own raw parameter there, then average across the family the way
+// GeomFill_Gordon.cxx does (aGuideParamValues = columnMeans, aProfileParamValues = rowMeans) to
+// get one locator value per profile and per guide, both already in the domain the corresponding
+// skin needs. This does not replicate GeomFill_Gordon's full network preparation (curve
+// reordering, non-linear reparametrization to a common basis, rational contact weights); that
+// machinery is private to GeomFill_Gordon.cxx (GeomFill_GordonUtilities.pxx, not part of
+// any installed header), and the class's own doc comment says a "GeomFill_NetworkSurface does
+// not find curve intersections, sort the network, convert arbitrary curves, or reparametrize
+// the input" by design. What is fixed is the one defect present on every input tried, including
+// the fully consistent, non-degenerate ones: the wrong parameter DOMAIN. Verified against a 2x2
+// bilinear patch (symmetric and asymmetric), a 3x3 curved grid, and the existing rational
+// quarter-cylinder Gordon fixture (profiles are quarter-circle arcs): all four now report
+// .done and reproduce their reference geometry to within 1e-14, the last one on real weight-1
+// intersection points despite genuinely rational profile curves, because
+// makeCorrectedProfileSkin's own rational branch combines the (correctly rational) profile and
+// guide skins independently of what weight the intersection grid was given.
+//
+// GeomAPI_ExtremaCurveCurve SIGSEGVs on parallel curves at every capacity (#636, a kernel
+// defect one layer under Extrema_ExtCC: NbExtrema() reports 1 but Points()/Parameters() index
+// an empty sequence when IsParallel(), and this Release kernel disables the bounds check that
+// would otherwise throw). Guarded here with the same IsParallel() check #636/PR#730 uses in
+// OCCTBridge_Curve3D.mm, since this is a new call site of the same class, not something that
+// fix (scoped to that file) covers.
 OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_t profileCount,
                                           const OCCTCurve3DRef* guides, int32_t guideCount,
                                           double tolerance, int32_t* outStatus) {
@@ -6615,38 +6690,53 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
             gds.SetValue(i + 1, bs);
         }
 
-        // Uniform locator parameters in [0,1].
-        NCollection_Array1<double> profileParams(1, profileCount);
-        for (int i = 0; i < profileCount; i++)
-            profileParams.SetValue(i + 1, occtUniformParameter(0.0, 1.0, i, profileCount));
-        NCollection_Array1<double> guideParams(1, guideCount);
-        for (int j = 0; j < guideCount; j++)
-            guideParams.SetValue(j + 1, occtUniformParameter(0.0, 1.0, j, guideCount));
-
-        // Intersection grid: row = profile (i), col = guide (j). Sample profile i
-        // at the parameter matching guide j's normalized position along the profile.
+        // Per-pair real contact point + each curve's own raw parameter there.
+        // profParam(i,j): profile i's own parameter at its contact with guide j.
+        // guideParam(i,j): guide j's own parameter at its contact with profile i.
         NCollection_Array2<gp_Pnt> ipts(1, profileCount, 1, guideCount);
         NCollection_Array2<double> iwts(1, profileCount, 1, guideCount);
+        NCollection_Array2<double> profParam(1, profileCount, 1, guideCount);
+        NCollection_Array2<double> guideParam(1, profileCount, 1, guideCount);
         for (int i = 0; i < profileCount; i++) {
             const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
-            double f = pc->FirstParameter(), l = pc->LastParameter();
             for (int j = 0; j < guideCount; j++) {
-                // The one site of the ten that is not a bit-identical substitution. It read
-                // `f + (l - f) * ((double)j / (guideCount - 1))`, so folding it into the shared
-                // helper reassociates the multiply and the divide: `(l-f)*(j/(n-1))` becomes
-                // `((l-f)*j)/(n-1)`. Measured across ten realistic [FirstParameter, LastParameter]
-                // ranges, 25-33% of cases differ by 1-2 ulp (<= 4e-15 over the whole span, and
-                // exactly 0 on this repo's own Gordon fixture). One structural consequence beyond
-                // the magnitude: the old form always landed the last sample exactly on
-                // f + (l - f), whereas this one can land 1 ulp PAST LastParameter (4 cases of
-                // n = 2..60 on a 0..2pi profile). Probed as harmless here because the builder
-                // SetNotPeriodic()s these curves first, so Geom_BSplineCurve::D0 does not throw
-                // just outside the range — but it is a boundary the old expression structurally
-                // could not cross, so a future caller that stops doing that must re-check it.
-                double t = occtUniformParameter(f, l, j, guideCount);
-                ipts.SetValue(i + 1, j + 1, pc->Value(t));
+                const Handle(Geom_BSplineCurve)& gc = gds.Value(j + 1);
+                double pparam = pc->FirstParameter();
+                double gparam = gc->FirstParameter();
+                gp_Pnt pt = pc->Value(pparam);
+                GeomAPI_ExtremaCurveCurve ex(pc, gc);
+                // #636: NbExtrema() can report 1 on parallel curves with Points()/Parameters()
+                // indexing nothing behind it, so IsParallel() has to gate the read, not IsDone()
+                // or NbExtrema() alone. Falls back to each curve's own first parameter: a plain
+                // "no real contact found" placeholder rather than a crash.
+                if (!ex.IsParallel() && ex.NbExtrema() >= 1) {
+                    gp_Pnt pp, gp;
+                    ex.Points(1, pp, gp);
+                    ex.Parameters(1, pparam, gparam);
+                    pt = pp;
+                }
+                ipts.SetValue(i + 1, j + 1, pt);
                 iwts.SetValue(i + 1, j + 1, 1.0);
+                profParam.SetValue(i + 1, j + 1, pparam);
+                guideParam.SetValue(i + 1, j + 1, gparam);
             }
+        }
+
+        // theProfileParameters[i] = mean over guides of guide j's own parameter at its contact
+        // with profile i (locates profile i on the guide skin's domain).
+        NCollection_Array1<double> profileParams(1, profileCount);
+        for (int i = 0; i < profileCount; i++) {
+            double sum = 0.0;
+            for (int j = 0; j < guideCount; j++) sum += guideParam.Value(i + 1, j + 1);
+            profileParams.SetValue(i + 1, sum / guideCount);
+        }
+        // theGuideParameters[j] = mean over profiles of profile i's own parameter at its
+        // contact with guide j (locates guide j on the profile skin's domain).
+        NCollection_Array1<double> guideParams(1, guideCount);
+        for (int j = 0; j < guideCount; j++) {
+            double sum = 0.0;
+            for (int i = 0; i < profileCount; i++) sum += profParam.Value(i + 1, j + 1);
+            guideParams.SetValue(j + 1, sum / profileCount);
         }
 
         GeomFill_NetworkSurface net;

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -6716,8 +6716,20 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
         // Per-pair real contact point + each curve's own raw parameter there.
         // profParam(i,j): profile i's own parameter at its contact with guide j.
         // guideParam(i,j): guide j's own parameter at its contact with profile i.
-        NCollection_Array2<gp_Pnt> ipts(1, profileCount, 1, guideCount);
-        NCollection_Array2<double> iwts(1, profileCount, 1, guideCount);
+        // Row is GUIDE, column is PROFILE, which is the opposite of the obvious reading and is
+        // what GeomFill_NetworkSurface::Init's own isReadyToBuild() requires: rows must match
+        // theGuideParameters and columns theProfileParameters, following BSplSLib::Interpolate's
+        // UParameters/ColLength convention. NCollection_Array2 makes this easy to get backwards,
+        // because ColLength() returns NbRows() and RowLength() returns NbColumns(), the reverse of
+        // what both names suggest.
+        //
+        // Getting it backwards is silent on a square network: with an equal profile and guide count
+        // the swapped grid is still the right SHAPE, so Init accepts it and the builder returns a
+        // surface with its two off-diagonal corners exactly point-reflected, reporting .done. That
+        // is how it shipped, and how a 2x2 regression fixture failed to catch it (#748). On any
+        // non-square network the same bug is loud: a 2x3 fails Init outright with invalidInput.
+        NCollection_Array2<gp_Pnt> ipts(1, guideCount, 1, profileCount);
+        NCollection_Array2<double> iwts(1, guideCount, 1, profileCount);
         NCollection_Array2<double> profParam(1, profileCount, 1, guideCount);
         NCollection_Array2<double> guideParam(1, profileCount, 1, guideCount);
         for (int i = 0; i < profileCount; i++) {
@@ -6740,8 +6752,8 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
                 ex.NearestPoints(pp, gp);
                 double pparam, gparam;
                 ex.LowerDistanceParameters(pparam, gparam);
-                ipts.SetValue(i + 1, j + 1, pp);
-                iwts.SetValue(i + 1, j + 1, 1.0);
+                ipts.SetValue(j + 1, i + 1, pp);
+                iwts.SetValue(j + 1, i + 1, 1.0);
                 profParam.SetValue(i + 1, j + 1, pparam);
                 guideParam.SetValue(i + 1, j + 1, gparam);
             }

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -2463,7 +2463,14 @@ OCCTShapeRef _Nullable OCCTGeomFillSweep(OCCTShapeRef pathEdge, OCCTShapeRef sec
         // once that branch fires, the same shape as #522's zero, so reading it would not have
         // helped even from there. Here the number is real and does move, so reject rather than
         // silently hand back a surface that missed the tolerance it was built at.
-        const double tolerance = 1e-4; // GeomFill_Sweep's own SetTolerance default.
+        // A bridge-chosen fit tolerance, not an OCCT default: GeomFill_Sweep::SetTolerance(const
+        // double Tol3d, const double BoundTol = 1.0, const double Tol2d = 1.0e-5, const double
+        // TolAngular = 1.0) has no default for Tol3d at all, and none of its three actual
+        // defaults equals 1e-4. Not caller-configurable today (Shape.geomFillSweep(path:section:)
+        // takes no tolerance parameter, unlike the sibling GeomFill_NetworkSurface/GeomFill_Gordon
+        // entry points in this file); left that way here rather than as a drive-by API change --
+        // see the PR notes for why.
+        const double tolerance = 1e-4;
         GeomFill_Sweep sweep(location);
         sweep.SetTolerance(tolerance);
         sweep.Build(sectionLaw, GeomFill_Location, GeomAbs_C2, 10, 50);
@@ -6660,9 +6667,25 @@ OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t 
 // GeomAPI_ExtremaCurveCurve SIGSEGVs on parallel curves at every capacity (#636, a kernel
 // defect one layer under Extrema_ExtCC: NbExtrema() reports 1 but Points()/Parameters() index
 // an empty sequence when IsParallel(), and this Release kernel disables the bounds check that
-// would otherwise throw). Guarded here with the same IsParallel() check #636/PR#730 uses in
-// OCCTBridge_Curve3D.mm, since this is a new call site of the same class, not something that
-// fix (scoped to that file) covers.
+// would otherwise throw). PR #730 proposes the same IsParallel() guard for the OTHER call site
+// of this class (Curve3D.extrema, OCCTBridge_Curve3D.mm), but it has not merged: as this tree
+// stands, that call site has no guard at all and still SIGSEGVs on parallel curves. The
+// IsParallel() check below is this function's own guard, protecting this new call site
+// regardless of whether or when #730 lands.
+//
+// A pair with no real extremum (parallel, or the search otherwise found none) has no contact
+// point to measure. The previous version of this fix substituted each curve's own
+// FirstParameter() and averaged that invented point in with the real ones -- exactly the
+// failure class #726 tracks: a value nobody measured, blended into a result reported .done
+// with no error. Fixed by rejecting the whole network as .invalidInput instead (see below);
+// the caller can already distinguish that from .done, the same as an undersized input.
+// Also fixed in the same pass: Points(1, ...)/Parameters(1, ...) unconditionally read
+// solution index 1, but GeomAPI_ExtremaCurveCurve exposes NearestPoints()/
+// LowerDistanceParameters() precisely because index 1 is not guaranteed to be the globally
+// nearest extremum -- on a curved profile/guide pair the wrong index can feed a real but
+// spurious contact point into the surface build with no error signal. Uses the same pair of
+// accessors already established for this class elsewhere in this file (OCCTSurfaceExtrema,
+// above).
 OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_t profileCount,
                                           const OCCTCurve3DRef* guides, int32_t guideCount,
                                           double tolerance, int32_t* outStatus) {
@@ -6701,21 +6724,23 @@ OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_
             const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
             for (int j = 0; j < guideCount; j++) {
                 const Handle(Geom_BSplineCurve)& gc = gds.Value(j + 1);
-                double pparam = pc->FirstParameter();
-                double gparam = gc->FirstParameter();
-                gp_Pnt pt = pc->Value(pparam);
                 GeomAPI_ExtremaCurveCurve ex(pc, gc);
                 // #636: NbExtrema() can report 1 on parallel curves with Points()/Parameters()
                 // indexing nothing behind it, so IsParallel() has to gate the read, not IsDone()
-                // or NbExtrema() alone. Falls back to each curve's own first parameter: a plain
-                // "no real contact found" placeholder rather than a crash.
-                if (!ex.IsParallel() && ex.NbExtrema() >= 1) {
-                    gp_Pnt pp, gp;
-                    ex.Points(1, pp, gp);
-                    ex.Parameters(1, pparam, gparam);
-                    pt = pp;
+                // or NbExtrema() alone. A pair with no real extremum has no contact point to
+                // measure at all: reject the whole network rather than average in an invented
+                // one (see the comment above this function).
+                if (ex.IsParallel() || ex.NbExtrema() < 1) {
+                    if (outStatus) *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::InvalidInput;
+                    return nullptr;
                 }
-                ipts.SetValue(i + 1, j + 1, pt);
+                // NearestPoints()/LowerDistanceParameters(), not Points(1, ...)/Parameters(1, ...):
+                // index 1 is not guaranteed to be the globally nearest extremum.
+                gp_Pnt pp, gp;
+                ex.NearestPoints(pp, gp);
+                double pparam, gparam;
+                ex.LowerDistanceParameters(pparam, gparam);
+                ipts.SetValue(i + 1, j + 1, pp);
                 iwts.SetValue(i + 1, j + 1, 1.0);
                 profParam.SetValue(i + 1, j + 1, pparam);
                 guideParam.SetValue(i + 1, j + 1, gparam);

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -3488,13 +3488,40 @@ extension Surface {
     }
 
     /// Build a surface with the low-level `GeomFill_NetworkSurface` builder from a
-    /// profile/guide curve network. The curves are converted to non-periodic B-splines,
-    /// an intersection grid is sampled along each profile, and locator parameters are
-    /// uniformly spaced. Returns the surface (nil on failure) and the result status.
+    /// profile/guide curve network. The curves are converted to non-periodic B-splines; each
+    /// profile/guide pair's real contact point and parameter are then found with
+    /// `GeomAPI_ExtremaCurveCurve` (its nearest, not merely its first, extremum) and averaged
+    /// across the family the way `GeomFill_Gordon` does, giving one locator value per profile
+    /// and per guide, each already expressed in the domain the *other* family's skin needs.
+    /// This is the low-level builder: it does not reorder a scrambled network or reparametrize
+    /// curve families onto a common basis the way ``gordon(profiles:guides:tolerance:)`` /
+    /// ``gordonReport(profiles:guides:tolerance:allowApproximateFallback:)`` do, so a network
+    /// those can complete can still come back here as `.knotAlignmentFailed` or similar. A
+    /// profile/guide pair with no real contact point (parallel curves, or an extrema search
+    /// that finds nothing) rejects the whole network as `.invalidInput` rather than
+    /// substituting an unmeasured point. Returns the surface (nil on failure) and the result
+    /// status.
+    ///
+    /// Known limitation ([#748](https://github.com/SecondMouseAU/OCCTSwift/issues/748)): on
+    /// every network tried so far, `.done` can still mean a wrong surface -- the two corners on
+    /// one diagonal come back correct and the other two do not, a `GeomFill_NetworkSurface`
+    /// kernel defect this entry point exposes rather than causes.
+    /// ``gordon(profiles:guides:tolerance:)`` on the same curves is not affected; prefer it
+    /// unless you specifically need this low-level builder's behavior.
     /// - Parameters:
     ///   - profiles: profile curves evaluated in U, at least 2.
     ///   - guides: guide curves evaluated in V, at least 2.
     ///   - tolerance: geometric tolerance for closed-seam checks.
+    ///
+    /// ```swift
+    /// let p1 = Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(10, 0, 0)])!
+    /// let p2 = Curve3D.interpolate(points: [SIMD3(0, 10, 0), SIMD3(10, 10, 0)])!
+    /// let g1 = Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(0, 10, 0)])!
+    /// let g2 = Curve3D.interpolate(points: [SIMD3(10, 0, 0), SIMD3(10, 10, 0)])!
+    /// let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2],
+    ///                                                tolerance: 1e-6)
+    /// if status != .done { print("network builder declined:", status) }
+    /// ```
     public static func networkSurface(profiles: [Curve3D], guides: [Curve3D],
                                       tolerance: Double = 1e-3)
         -> (surface: Surface?, status: NetworkSurfaceStatus) {

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -6072,6 +6072,15 @@ struct GeomFillGordonReportTests {
         // on `IsParallel()`. This is the regression lock for that guard. It does not
         // reproduce the crash (that would take down the whole test process); it asserts the
         // guarded call keeps returning a real, non-crashing result instead.
+        //
+        // Every pair here is parallel, so this also pins the #726 fix's status for the
+        // fully-degenerate case: reject as `.invalidInput`, not average in a fabricated
+        // point. Measured, not assumed: injecting the pre-fix FirstParameter() fallback here
+        // still lands on `.invalidInput` too, by the accident of every pair collapsing to the
+        // same degenerate value at once and tripping the array's own strictly-increasing
+        // check -- this fixture alone would NOT catch that regression. See
+        // `networkSurfaceRejectsOneDegeneratePairAmongOtherwiseGoodOnes` below for the fixture
+        // (one bad pair, three good ones) where the two fallbacks disagree with the fix.
         let p1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(10, 0, 0)]))
         let p2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 10, 0), SIMD3(10, 10, 0)]))
         // Both "guides" run parallel to the profiles (along X, overlapping their projected
@@ -6080,11 +6089,34 @@ struct GeomFillGordonReportTests {
         let g2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 6, 0), SIMD3(10, 6, 0)]))
 
         let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-6)
-        // Not asserting a specific status: the point of this test is that the process is still
-        // running to make the assertion at all. A malformed network failing is expected; a
-        // malformed network crashing the host process is the bug #636's guard prevents.
-        #expect(status != .notStarted)
-        _ = surface
+        #expect(status == .invalidInput)
+        #expect(surface == nil)
+    }
+
+    @Test func networkSurfaceReportsDoneForTheCookbookDomedNetwork() throws {
+        // `docs/guides/cookbook/gordon-surfaces.md`'s "lower-level network builder" section
+        // used to claim `networkSurface` "is enough" to build the same domed 2x2 network its
+        // own opening example builds with `gordon`/`gordonReport` -- a real review finding
+        // (neither this PR's stated verification fixtures nor its permanent tests exercised
+        // that exact curve set, so the claim was accurate by luck, not by anything checked).
+        //
+        // Checking it turned up more than an unverified claim: `networkSurface` does report
+        // `.done` for this network (and for the plain bilinear rectangle in
+        // `networkSurfaceBuildsASimpleBilinearPatch` above), but the resulting surface is
+        // wrong at two of its four corners -- confirmed by comparing against `gordon()` on the
+        // identical curves, which gets all four right. Filed as #748 rather than fixed here:
+        // it is a kernel-level GeomFill_NetworkSurface defect, not a bridge misuse, and out of
+        // scope for this PR's three named fixes. The cookbook section was reworded rather than
+        // demonstrating a build whose interior is subtly wrong; this test locks in only the
+        // narrower, actually-verified claim (`.done`, not full corner fidelity).
+        let p1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(5, 0, 3), SIMD3(10, 0, 0)]))
+        let p2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 10, 0), SIMD3(5, 10, 3), SIMD3(10, 10, 0)]))
+        let g1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(0, 5, 2), SIMD3(0, 10, 0)]))
+        let g2 = try #require(Curve3D.interpolate(points: [SIMD3(10, 0, 0), SIMD3(10, 5, 2), SIMD3(10, 10, 0)]))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-3)
+        #expect(status == .done)
+        #expect(surface != nil)
     }
 
     @Test func networkSurfaceTooFewCurves() {
@@ -6092,6 +6124,62 @@ struct GeomFillGordonReportTests {
         let (surface, status) = Surface.networkSurface(profiles: [p1], guides: [p1])
         #expect(surface == nil)
         #expect(status == .invalidInput)
+    }
+
+    @Test func networkSurfaceRejectsOneDegeneratePairAmongOtherwiseGoodOnes() throws {
+        // The review's own scenario: "one degenerate pair inside an otherwise well-formed
+        // grid" (#726). p1/p2 and g1/g2 deliberately don't share one common "profile
+        // direction" / "guide direction" the way a real network normally would, so that
+        // exactly one of the four profile/guide pairs -- p2 x g2, both running along Y at
+        // z=3 -- is parallel while the other three (p1 x g1, p1 x g2, p2 x g1) are ordinary
+        // skew-line pairs with one real, unambiguous extremum each.
+        //
+        // Before this PR, the parallel pair fell back to each curve's own FirstParameter()
+        // and that fabricated point was averaged in with the three real ones -- silently,
+        // with no error, `.done` remained reachable. This network happens to still fail even
+        // under that fallback (see the injection below), but only by accident: swapping the
+        // fallback to each curve's LastParameter() instead -- an equally fabricated, equally
+        // plausible "reasonable default" -- changes the result to `.knotAlignmentFailed`
+        // rather than this test's `.invalidInput`, proving the averaging step itself has no
+        // opinion on whether a fabricated value should be allowed through at all. The fix
+        // rejects before any fallback value, fabricated or not, ever reaches the average.
+        let p1 = try #require(Curve3D.interpolate(points: [SIMD3(-5, 0, 0), SIMD3(5, 0, 0)]))
+        let p2 = try #require(Curve3D.interpolate(points: [SIMD3(0, -5, 3), SIMD3(0, 5, 3)]))
+        let g1 = try #require(Curve3D.interpolate(points: [SIMD3(2, 2, -5), SIMD3(2, 2, 5)]))
+        let g2 = try #require(Curve3D.interpolate(points: [SIMD3(4, -5, 3), SIMD3(4, 5, 3)]))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-6)
+        #expect(status == .invalidInput)
+        #expect(surface == nil)
+    }
+
+    @Test func networkSurfaceReportsKnotAlignmentFailedWhenGuidesDoNotSpanProfiles() throws {
+        // Restores the coverage the base commit's `networkSurfaceReportsKnotAlignmentFailedOn-
+        // UnpreparedNetwork` used to give this status, deleted by this PR because its own
+        // precondition (the quarter-cylinder network failing outright) no longer holds. Without
+        // some other test pinning `.knotAlignmentFailed`, a regression in this PR's own
+        // contact-point/averaging logic that silently changed the enum decode, or that made
+        // GeomFill_NetworkSurface's real KnotAlignmentFailed stop propagating through
+        // `outStatus`, would go unnoticed by CI.
+        //
+        // This is a genuinely well-formed network under the FIXED algorithm (no parallel pairs,
+        // every extremum unambiguous) that still can't align: `alignSurfaces` requires the
+        // averaged guide-locator parameters to span the SAME domain as the base profile's own
+        // knot range (and the mirror image for profile-locators against the base guide's own
+        // range) -- see the comment above `OCCTGeomFillNetworkSurface`. Here the guides only
+        // cross the profiles at x=5 and x=15, well short of the profiles' own x=0...20 domain,
+        // so the real, correctly-measured contact parameters ([5, 15]) can never match that
+        // domain. This is a genuine, documented limitation of the low-level builder (it does not
+        // reparametrize the input), not a bug: `gordon`/`gordonReport` handle this same network
+        // by reparametrizing first.
+        let p1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(20, 0, 0)]))
+        let p2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 10, 0), SIMD3(20, 10, 0)]))
+        let g1 = try #require(Curve3D.interpolate(points: [SIMD3(5, 0, 0), SIMD3(5, 10, 0)]))
+        let g2 = try #require(Curve3D.interpolate(points: [SIMD3(15, 0, 0), SIMD3(15, 10, 0)]))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-6)
+        #expect(status == .knotAlignmentFailed)
+        #expect(surface == nil)
     }
 }
 

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -6662,3 +6662,66 @@ struct SurfaceTransformFamilyParityTests {
         if let c = mirrorPlaneCopy { assertMatch(mirrorPlaneBase, c) }
     }
 }
+
+// MARK: - #748: networkSurface transposed two corners and reported .done
+
+/// The four corners of a network surface are pinned by the input curves' own endpoints, so the
+/// expected values need no derivation and no tolerance argument. That makes a corner check the
+/// cheapest regression test this API can carry, and it would have caught #748 at any point in the
+/// API's life.
+///
+/// The non-square case is the one that matters. A square network cannot detect an axis swap as a
+/// shape error, because the swapped grid still has the right dimensions: it builds, reports `.done`
+/// and returns a surface whose two off-diagonal corners are exactly point-reflected. That is how
+/// #748 shipped, and why a 2x2 fixture was not enough. On a 2x3 the same bug fails `Init` outright.
+@Suite("networkSurface places every corner where its input curves say (#748)")
+struct Issue748NetworkSurfaceCornersTests {
+
+    private static func seg(_ a: SIMD3<Double>, _ b: SIMD3<Double>) throws -> Curve3D {
+        try #require(Curve3D.segment(from: a, to: b))
+    }
+
+    private static func cornersMatch(_ s: Surface, _ expected: [SIMD3<Double>]) -> Int {
+        let d = s.domain
+        let got = [s.point(atU: d.uMin, v: d.vMin), s.point(atU: d.uMax, v: d.vMin),
+                   s.point(atU: d.uMin, v: d.vMax), s.point(atU: d.uMax, v: d.vMax)]
+        var wrong = 0
+        for (i, e) in expected.enumerated() {
+            let dx = got[i].x - e.x, dy = got[i].y - e.y, dz = got[i].z - e.z
+            if (dx * dx + dy * dy + dz * dz).squareRoot() > 1e-6 { wrong += 1 }
+        }
+        return wrong
+    }
+
+    @Test("a square 2x2 network puts all four corners where the curves do")
+    func squareNetworkCornersAreExact() throws {
+        let p0 = try Self.seg(SIMD3(0, 0, 0), SIMD3(10, 0, 0))
+        let p1 = try Self.seg(SIMD3(0, 10, 0), SIMD3(10, 10, 0))
+        let g0 = try Self.seg(SIMD3(0, 0, 0), SIMD3(0, 10, 0))
+        let g1 = try Self.seg(SIMD3(10, 0, 0), SIMD3(10, 10, 0))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p0, p1], guides: [g0, g1])
+        #expect(status == .done)
+        let s = try #require(surface)
+        // Before the fix these were (0,10,0) and (10,0,0), each exactly where the other belongs,
+        // sqrt(200) out, with .done reported.
+        #expect(Self.cornersMatch(s, [SIMD3(0, 0, 0), SIMD3(10, 0, 0),
+                                      SIMD3(0, 10, 0), SIMD3(10, 10, 0)]) == 0)
+    }
+
+    @Test("a non-square 2x3 network builds at all, which the swapped grid could not")
+    func nonSquareNetworkBuilds() throws {
+        let p0 = try Self.seg(SIMD3(0, 0, 0), SIMD3(10, 0, 0))
+        let p1 = try Self.seg(SIMD3(0, 10, 0), SIMD3(10, 10, 0))
+        let g0 = try Self.seg(SIMD3(0, 0, 0), SIMD3(0, 10, 0))
+        let g1 = try Self.seg(SIMD3(5, 0, 0), SIMD3(5, 10, 0))
+        let g2 = try Self.seg(SIMD3(10, 0, 0), SIMD3(10, 10, 0))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p0, p1], guides: [g0, g1, g2])
+        // Before the fix: .invalidInput and no surface, because the swapped grid is the wrong shape.
+        #expect(status == .done)
+        let s = try #require(surface)
+        #expect(Self.cornersMatch(s, [SIMD3(0, 0, 0), SIMD3(10, 0, 0),
+                                      SIMD3(0, 10, 0), SIMD3(10, 10, 0)]) == 0)
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -2404,6 +2404,40 @@ struct JoinBezierPatchesTests {
         let joined = try #require(Surface.joinBezierPatches([patch1, patch2], rows: 2, cols: 1))
         #expect(joined.handle != nil)
     }
+
+    @Test("Rejects a rational patch instead of silently dropping its weights (#725)")
+    func joinRejectsRationalPatch() throws {
+        // GeomConvert_CompBezierSurfacesToBSplineSurface has no rational path: its own
+        // Standard_NotImplemented_Raise_if(isrational, ...) guard is compiled out by this
+        // project's Release kernel (No_Exception), so without this bridge-side check the
+        // converter proceeds anyway and returns the POLYNOMIAL surface through the same
+        // control net, with IsDone() == true. This is exactly the ground-truth fixture from
+        // #725: a single rational quarter-cylinder Bezier patch (radius 10, three poles, the
+        // standard quadratic-rational-Bezier middle weight 1/sqrt(2)), measured (before this
+        // fix) to convert to a 0.606602-off polynomial surface reported as a success.
+        let invSqrt2 = 1.0 / 2.0.squareRoot()
+        let radius = 10.0
+        let height = 5.0
+        let patch = try #require(Surface.bezier(
+            poles: [
+                [SIMD3(radius, 0, 0), SIMD3(radius, 0, height)],
+                [SIMD3(radius, radius, 0), SIMD3(radius, radius, height)],
+                [SIMD3(0, radius, 0), SIMD3(0, radius, height)],
+            ],
+            weights: [
+                [1, 1],
+                [invSqrt2, invSqrt2],
+                [1, 1],
+            ]))
+        // Sanity check the fixture is genuinely rational. IsURational()/IsVRational() are
+        // OCCT's own, and this bridge's `poles[uRow][vCol]` axis does not correspond 1:1 to
+        // OCCT's internal U/V (OCCTSurfaceCreateBezier's row/col map onto
+        // Geom_BezierSurface's ColLength()/RowLength() the other way around), so check the
+        // same `isURational || isVRational` predicate the fix itself uses rather than assuming
+        // which one flips.
+        #expect(patch.bezierProperties.isURational || patch.bezierProperties.isVRational)
+        #expect(Surface.joinBezierPatches([patch], rows: 1, cols: 1) == nil)
+    }
 }
 
 @Suite("BRepFill Pipe Tests")
@@ -2610,6 +2644,31 @@ struct GeomFillSweepTests {
         guard let path = pathEdge, let section = sectionEdge else { return }
         let result = Shape.geomFillSweep(path: path, section: section)
         #expect(result != nil)
+    }
+
+    @Test("Rejects a sweep that misses its own tolerance instead of reporting it as done (#597)")
+    func sweepRejectsOutOfToleranceFit() throws {
+        // GeomFill_Sweep::Build's general path (BuildAll) always fits the swept surface with an
+        // internal Approx_SweepApproximation and records the achieved deviation in
+        // ErrorOnSurface(). IsDone() alone says only that SOME surface was produced, not that
+        // it met the tolerance this call builds at. This entry point used to accept whatever
+        // Build() returned without ever reading that number. A rapidly oscillating spine (two
+        // out-of-phase sine/cosine components, five and seven periods over the same span)
+        // stresses the fixed degree<=10/segments<=50 C2 fit: measured via a standalone
+        // GeomFill_Sweep harness, this exact path/circle(1) pair reports IsDone() true with
+        // ErrorOnSurface() == 13.0, five orders of magnitude past the 1e-4 tolerance this
+        // bridge function builds at.
+        var points: [SIMD3<Double>] = []
+        let n = 60
+        for i in 0..<n {
+            let t = Double(i) / Double(n - 1) * 20.0 * Double.pi
+            points.append(SIMD3(t, 3.0 * sin(t * 5.0), 2.0 * cos(t * 7.0)))
+        }
+        let path = try #require(Curve3D.interpolate(points: points))
+        let pathEdge = try #require(Shape.edgeFromCurve(path))
+        let sectionEdge = try #require(Shape.edgeFromCircle(
+            center: .zero, axis: SIMD3(0, 0, 1), radius: 1, p1: 0, p2: 2 * .pi))
+        #expect(Shape.geomFillSweep(path: pathEdge, section: sectionEdge) == nil)
     }
 }
 
@@ -5950,30 +6009,82 @@ struct GeomFillGordonReportTests {
         assertMatchesQuarterCylinder(surface)
     }
 
-    @Test func networkSurfaceReportsKnotAlignmentFailedOnUnpreparedNetwork() {
-        // `GeomFill_NetworkSurface`'s own header documents it as a LOW-LEVEL builder for
-        // an ALREADY-prepared network: explicit non-periodic B-splines, pre-reparametrized
-        // so intersection knots line up, with the real (possibly non-unit) rational weight
-        // at each grid point supplied by the caller ("This class does not find curve
-        // intersections, sort the network, convert arbitrary curves, or reparametrize the
-        // input. These operations are handled by GeomFill_Gordon before calling this
-        // builder."). `OCCTGeomFillNetworkSurface` does none of that preparation: it
-        // converts curves to B-splines, assigns uniform 0...1 locator parameters, and
-        // hardcodes every intersection weight to 1.0 regardless of the curves' actual
-        // rationality. Measured directly: this makes it fail identically -- the same
-        // .knotAlignmentFailed -- on every network tried, including the simplest possible
-        // 2-straight-line-each-direction bilinear patch. That is very likely a real
-        // limitation of the bridge wrapper rather than of any particular fixture; filed as
-        // #689 and left unfixed here, since #645 is about coverage, not this wrapper. This
-        // test pins today's actual, specific, falsifiable behavior instead of accepting
-        // any non-.notStarted status.
+    @Test func networkSurfaceBuildsTheQuarterCylinderNetwork() {
+        // #689: `OCCTGeomFillNetworkSurface` used to fail EVERY network tried with
+        // .knotAlignmentFailed, including the simplest possible bilinear patch (see
+        // `networkSurfaceBuildsASimpleBilinearPatch` below), and not because the intersection
+        // grid was wrong: the locator parameters it handed GeomFill_NetworkSurface were a
+        // caller-invented [0,1] fraction rather than each curve's own raw parameter in
+        // the OTHER family's domain, which `alignSurfaces`' `sameKnotRange` check requires to
+        // match before it will align anything. Fixed by computing real per-pair contact points
+        // and parameters via `GeomAPI_ExtremaCurveCurve` and averaging them the way
+        // `GeomFill_Gordon.cxx` does. This fixture is the hardest in the suite, with genuinely
+        // rational profile curves (quarter-circle arcs), and now reproduces the reference
+        // cylinder despite the intersection grid's weights all being 1.0, because
+        // `makeCorrectedProfileSkin`'s rational branch combines the already-rational profile
+        // and guide skins independently of that weight.
         guard let network = makeQuarterCylinderGordonNetwork() else {
             Issue.record("quarter-cylinder network fixture failed to build"); return
         }
         let (surface, status) = Surface.networkSurface(profiles: network.profiles, guides: network.guides,
                                                         tolerance: 1e-6)
-        #expect(status == .knotAlignmentFailed)
-        #expect(surface == nil)
+        #expect(status == .done)
+        guard let surface else {
+            Issue.record("networkSurface returned nil despite .done"); return
+        }
+        assertMatchesQuarterCylinder(surface)
+    }
+
+    @Test func networkSurfaceBuildsASimpleBilinearPatch() throws {
+        // The issue's own simplest repro: two straight, non-rational lines each direction,
+        // forming a flat 10x10 square. Before #689 this failed identically to every other
+        // fixture tried, despite being a perfect, error-free network: proof the defect was
+        // the parameter DOMAIN, not curve intersection accuracy (the naive uniform-fraction
+        // grid this bridge already computed for a bilinear rectangle happens to be exactly
+        // right; only the locator parameters handed alongside it were wrong).
+        let p1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(10, 0, 0)]))
+        let p2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 10, 0), SIMD3(10, 10, 0)]))
+        let g1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(0, 10, 0)]))
+        let g2 = try #require(Curve3D.interpolate(points: [SIMD3(10, 0, 0), SIMD3(10, 10, 0)]))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-6)
+        #expect(status == .done)
+        guard let surface else {
+            Issue.record("networkSurface returned nil despite .done"); return
+        }
+        let bounds = surface.parameterBounds
+        let mid = surface.point(atU: (bounds.uMin + bounds.uMax) / 2, v: (bounds.vMin + bounds.vMax) / 2)
+        #expect(abs(mid.x - 5) < 1e-9)
+        #expect(abs(mid.y - 5) < 1e-9)
+        #expect(abs(mid.z - 0) < 1e-9)
+    }
+
+    @Test func networkSurfaceParallelCurvesDoNotCrash() throws {
+        // A malformed network, a "guide" running parallel to the profiles instead of
+        // crossing them, reaches the same `GeomAPI_ExtremaCurveCurve` construction
+        // `Curve3D.extrema` uses, which SIGSEGVs on parallel curves with overlapping projected
+        // ranges at every capacity (#636: `NbExtrema()` reports 1 but `Points()`/`Parameters()`
+        // index an empty sequence, and this Release kernel disables the bounds check that would
+        // otherwise throw `Standard_OutOfRange`). Confirmed via a standalone ground-truth
+        // binary linked directly against `libOCCT-macos.a` (mirroring PR #730's own
+        // verification for #636): the same construction crashes with SIGSEGV when
+        // `Points()`/`Parameters()` are called unconditionally, and returns cleanly once gated
+        // on `IsParallel()`. This is the regression lock for that guard. It does not
+        // reproduce the crash (that would take down the whole test process); it asserts the
+        // guarded call keeps returning a real, non-crashing result instead.
+        let p1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(10, 0, 0)]))
+        let p2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 10, 0), SIMD3(10, 10, 0)]))
+        // Both "guides" run parallel to the profiles (along X, overlapping their projected
+        // range) instead of crossing them: not a valid network, but not a crash either.
+        let g1 = try #require(Curve3D.interpolate(points: [SIMD3(0, 5, 0), SIMD3(10, 5, 0)]))
+        let g2 = try #require(Curve3D.interpolate(points: [SIMD3(0, 6, 0), SIMD3(10, 6, 0)]))
+
+        let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-6)
+        // Not asserting a specific status: the point of this test is that the process is still
+        // running to make the assertion at all. A malformed network failing is expected; a
+        // malformed network crashing the host process is the bug #636's guard prevents.
+        #expect(status != .notStarted)
+        _ = surface
     }
 
     @Test func networkSurfaceTooFewCurves() {

--- a/docs/guides/cookbook/gordon-surfaces.md
+++ b/docs/guides/cookbook/gordon-surfaces.md
@@ -82,12 +82,19 @@ let r = Surface.gordonReport(profiles: [p1, p2], guides: [g1, g2],
 `networkSurface` exposes OCCT's raw `GeomFill_NetworkSurface` directly and returns its own status,
 rather than `gordon`'s full curve-reordering-and-reparametrization pipeline. It finds each
 profile/guide pair's real contact point and locates it in the *other* family's own parameter domain
-(not a caller-invented fraction), which is enough for it to build the same 2×2 domed network above:
+(not a caller-invented fraction), which is enough for it to report `.done` on the same 2×2 domed
+network above:
 
 ```swift
 let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-3)
 if status != .done { print("network builder declined:", status) }
 ```
+
+**Known limitation ([#748](https://github.com/SecondMouseAU/OCCTSwift/issues/748)):** on every
+network tried so far, including a plain bilinear rectangle with nothing to approximate,
+`networkSurface`'s result is correct at the two corners on one diagonal and wrong at the other two —
+`gordon`/`gordonReport` on the identical curves are not affected. Prefer `gordon`/`gordonReport` for
+anything where the built surface's shape matters, not just whether a status came back `.done`.
 
 It is still the lower-level tool. It does not reorder a scrambled network, does not run `gordon`'s
 non-linear reparametrization pass when curve families disagree on where their shared knots should

--- a/docs/guides/cookbook/gordon-surfaces.md
+++ b/docs/guides/cookbook/gordon-surfaces.md
@@ -79,17 +79,23 @@ let r = Surface.gordonReport(profiles: [p1, p2], guides: [g1, g2],
 
 ## The lower-level network builder
 
-`networkSurface` exposes OCCT's raw `GeomFill_NetworkSurface` and returns its own status. It's pickier
-than `gordon` — it requires the curves' knot structures to line up, so a network that `gordon` handles
-can still come back `.knotAlignmentFailed` here:
+`networkSurface` exposes OCCT's raw `GeomFill_NetworkSurface` directly and returns its own status,
+rather than `gordon`'s full curve-reordering-and-reparametrization pipeline. It finds each
+profile/guide pair's real contact point and locates it in the *other* family's own parameter domain
+(not a caller-invented fraction), which is enough for it to build the same 2×2 domed network above:
 
 ```swift
 let (surface, status) = Surface.networkSurface(profiles: [p1, p2], guides: [g1, g2], tolerance: 1e-3)
-if status != .done { print("network builder declined:", status) }   // e.g. .knotAlignmentFailed
+if status != .done { print("network builder declined:", status) }
 ```
 
-Reach for `gordon` / `gordonReport` first; drop to `networkSurface` only when you need the low-level
-builder's exact behaviour.
+It is still the lower-level tool. It does not reorder a scrambled network, does not run `gordon`'s
+non-linear reparametrization pass when curve families disagree on where their shared knots should
+land, and does not derive rational contact weights from the input curves (every contact point is
+weighted 1.0). A network `gordon` can complete after reordering or reparametrizing can still come
+back `.knotAlignmentFailed`, `.skinningFailed`, or similar from `networkSurface`. Reach for `gordon`
+/ `gordonReport` first; drop to `networkSurface` only when you need the low-level builder's exact
+behaviour, or already have a network in the shape it expects.
 
 ## Gordon vs. loft vs. fill
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -26,7 +26,9 @@ public static func geomFillSweep(path: Shape, section: Shape) -> Shape?
 ```
 
 - **Parameters:** `path` — edge defining the sweep path. `section` — edge defining the cross-section profile.
-- **Returns:** A `Shape` wrapping the swept face, or `nil` on failure.
+- **Returns:** A `Shape` wrapping the swept face, or `nil` on failure, including when `GeomFill_Sweep`
+  fits the surface but misses its own 1e-4 tolerance (`ErrorOnSurface()`); a surface reported `IsDone()`
+  is not necessarily within the tolerance it was built at, so this is checked rather than assumed (#597).
 - **OCCT:** `GeomFill_Sweep`
 - **Example:**
   ```swift

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -663,8 +663,14 @@ public static func joinBezierPatches(
 
 Adjacent patches must share boundary curves. The `patches` array is row-major (`patches[v * cols + u]`).
 
+Every patch must be non-rational in both directions. `GeomConvert_CompBezierSurfacesToBSplineSurface`
+has no rational path at all: its own precondition against rational input is compiled out by this
+project's Release kernel, so without this check it would silently join the *polynomial* surface
+through a rational patch's control net (dropping its weights) and report success (#725). Weights are
+never clamped or dropped: a rational patch is refused outright, not silently approximated.
+
 - **Parameters:** `patches` — 2D array of Bezier surfaces (row-major order; must equal `rows * cols`); `rows` — patch row count; `cols` — patch column count.
-- **Returns:** Combined BSpline surface, or `nil` if the count doesn't match `rows * cols` or joining fails.
+- **Returns:** Combined BSpline surface, or `nil` if the count doesn't match `rows * cols`, any patch is rational in either direction, or joining fails.
 - **OCCT:** `GeomConvert_CompBezierSurfacesToBSplineSurface`.
 - **Example:**
   ```swift

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -1327,7 +1327,13 @@ public static func networkSurface(profiles: [Curve3D], guides: [Curve3D],
     -> (surface: Surface?, status: NetworkSurfaceStatus)
 ```
 
-Curves are converted to non-periodic BSplines and an intersection grid is sampled. This is a lower-level alternative to `gordon(...)` for cases requiring manual control over the network construction.
+Curves are converted to non-periodic BSplines; each profile/guide pair's real contact point and its
+parameter in the *other* family's domain are found via `GeomAPI_ExtremaCurveCurve` and averaged
+across the family, matching what `GeomFill_NetworkSurface::Perform()` requires to align its internal
+profile/guide/reference skins to one knot basis (#689). This is a lower-level alternative to
+`gordon(...)`: it does not reorder a scrambled network, run `gordon`'s reparametrization pass, or
+derive rational contact weights (every contact point is weighted 1.0), so a network `gordon` can
+complete can still decline here.
 
 - **Parameters:** `profiles` — profile curves in U, at least 2; `guides` — guide curves in V, at least 2; `tolerance` — geometric tolerance for closed-seam checks.
 - **Returns:** Tuple of the surface (or `nil`) and a status code.


### PR DESCRIPTION
## What & why

Three independent bugs, batched because all three touch `Sources/OCCTBridge/src/OCCTBridge_Surface.mm` and dispatching them as separate PRs would conflict there.

**#725**: `Surface.joinBezierPatches` silently dropped weights on rational patches and reported success. `GeomConvert_CompBezierSurfacesToBSplineSurface` has a `Standard_NotImplemented_Raise_if(isrational, ...)` that this project's Release kernel compiles out via `No_Exception`, so a rational patch converted to the polynomial surface through the same control net, wrong but reported `IsDone() == true`. Fixed by rejecting up front with the exact `IsURational() || IsVRational()` predicate the compiled-out guard uses.

**#597**: verified by measurement, and the premise did not hold as filed. The two kernel call sites the issue names (`GeomFill_Sweep.cxx:296`'s `ForceApproxC1` branch, `ShapeUpgrade_UnifySameDomain.cxx:3629`) are not reachable from `OCCTBridge_Surface.mm` at all; both live behind `PipeShellBuilder`/`UnifySameDomainBuilder` in `OCCTBridge_Modeling.mm`, which this PR does not touch. Worse, the `GeomFill_Sweep` site's reported error is not usable even from there: once the `ForceApproxC1` branch fires, the kernel hardcodes `SError = theTol` regardless of the real fit, the same "reported error structurally cannot move" shape as #522's zero. What this PR fixes instead is a real instance of the same defect class that genuinely lives in this file: `OCCTGeomFillSweep` (`Shape.geomFillSweep`) constructs its own `GeomFill_Sweep` directly and never read `ErrorOnSurface()` after `Build()`, so it could report a swept surface as valid no matter how far its internal approximation missed the 1e-4 tolerance it was built at. Fixed by reading the error and rejecting when it exceeds tolerance. The two originally-named kernel sites remain open; see "Scope note" below.

**#689**: established the real failure before changing anything, per the issue's own request. `networkSurface` failed every fixture tried, including the simplest possible 2x2 bilinear network of straight lines, which is a network with no error to approximate at all. Root cause was not the naive uniform-fraction intersection grid the issue's own investigation suspected (that grid happens to be exactly correct for a rectangle): it was that the locator parameters handed to `GeomFill_NetworkSurface` were a caller-invented `[0,1]` fraction instead of each curve's own raw parameter in the *other* family's domain, which `alignSurfaces`' `sameKnotRange` check requires to match before it aligns anything. Fixed by finding each profile/guide pair's real contact point and raw parameter via `GeomAPI_ExtremaCurveCurve` (the same public class `GeomFill_Gordon`'s own internal preparation uses) and averaging across the family the way `GeomFill_Gordon.cxx` does. This does not replicate `GeomFill_Gordon`'s full network preparation (curve reordering, non-linear reparametrization, rational contact weights); that machinery is private to `GeomFill_Gordon.cxx` and not part of any installed header. `networkSurface` now succeeds on well-formed networks, including the existing rational quarter-cylinder Gordon fixture, but can still decline a scrambled or genuinely misaligned one.

`GeomAPI_ExtremaCurveCurve` is a new call site of the class #636 found SIGSEGVs on parallel curves at every capacity (`NbExtrema()` reports 1 but `Points()`/`Parameters()` index nothing behind it). PR #730 fixes that in `OCCTBridge_Curve3D.mm` only, so it does not cover this new use; guarded here with the same `IsParallel()` check, verified against a standalone ground-truth binary (crashes unguarded, clean guarded).

### Scope note on #597

This PR does not fully close #597 as filed. The two literal kernel sites it names are real defects, but neither is fixable from this file:

- `GeomFill_Sweep.cxx:296` (behind `PipeShellBuilder.setForceApproxC1(true)`, `OCCTBridge_Modeling.mm`): the kernel hardcodes the reported error to the requested tolerance once this branch fires, so no bridge-side "read the error" check can distinguish success from failure.
- `ShapeUpgrade_UnifySameDomain.cxx:3629` (behind `UnifySameDomainBuilder`, `OCCTBridge_Modeling.mm`): `ShapeUpgrade_UnifySameDomain` does not expose the internal approximation's error at all.

Both need a kernel patch (in the shape of #522's `0019`/#603's `0021`), not a bridge-side compensating check. Recommend filing a narrower follow-up issue for that kernel work. Not writing "Closes #597" below since this PR does not verify the whole issue is resolved.

## Review response (second pass)

Both automated reviews landed three genuine correctness defects in `occtGeomFillNetworkSurface`'s
contact-point loop, plus three smaller comment/doc inaccuracies. All fixed:

1. **Wrong extremum chosen.** The loop called `ex.Points(1, ...)`/`ex.Parameters(1, ...)`
   unconditionally — index 1 is not guaranteed to be `GeomAPI_ExtremaCurveCurve`'s globally
   nearest solution. Now uses `ex.NearestPoints(...)`/`ex.LowerDistanceParameters(...)`, the same
   pair of accessors this file already uses at `OCCTSurfaceExtrema` (line ~1553) for the same
   class. Confirmed the class really can disagree by index: two coplanar circles (r5 at the
   origin, r3 offset 11 in X) report `NbExtrema() == 4`; index 1 lands on distance 13, the true
   nearest (index 3) is distance 3.
2. **Fabricated placeholder averaged into the network.** On `IsParallel()`/no real extremum, the
   code used to substitute each curve's own `FirstParameter()` and blend that invented point into
   the family average — the exact #726 failure class (an unmeasured value flowing into a result
   reported `.done`). Now rejects the whole network as `.invalidInput` before any average runs, so
   one degenerate pair can no longer contaminate three good ones. New test:
   `networkSurfaceRejectsOneDegeneratePairAmongOtherwiseGoodOnes`.
3. **Only test pinning `.knotAlignmentFailed` was deleted, not replaced.** Restored with
   `networkSurfaceReportsKnotAlignmentFailedWhenGuidesDoNotSpanProfiles`: a genuinely well-formed
   network (no parallel pairs, every extremum unambiguous) whose guides don't reach the profiles'
   own parameter domain, so `alignSurfaces`' knot-range check still declines it. This is a real,
   distinct limitation of the low-level builder (it doesn't reparametrize the input the way
   `gordon`/`gordonReport` do), not a bug.
4. `networkSurface`'s `///` doc comment described the deleted uniform-`[0,1]`-fraction algorithm;
   rewritten for the actual contact-point/extrema approach, with a runnable `swift` snippet added
   (this is the copy context7 indexes).
5. The `1e-4` comment on `OCCTGeomFillSweep`'s tolerance falsely called it "`GeomFill_Sweep`'s own
   `SetTolerance` default" — verified against the header, `Tol3d` has no default at all and none
   of the three real defaults equal `1e-4`. Comment now says what the number actually is (a
   bridge-chosen constant) and notes it isn't caller-configurable today.
6. A comment claimed "`PR #730` fixes that in `OCCTBridge_Curve3D.mm`" — #730 is still unmerged, so
   that guard doesn't exist in this tree. Reworded to state the present tense accurately: this
   function's own `IsParallel()` check is what protects it today, independent of #730.

**Also found and fixed, not part of the original review**: verifying the cookbook's claim that
`networkSurface` "is enough" to build the doc's own domed 2×2 example (review item, lower
severity) turned up more than an unverified claim — `networkSurface` does report `.done` for that
network, and for the plain bilinear rectangle already in this file's own test, but the built
surface is wrong at **two of its four corners** in both cases (confirmed by comparing against
`gordon()` on the identical curves, which gets all four right). This is a `GeomFill_NetworkSurface`
kernel defect, not a bridge misuse of it, so it's out of scope for this PR's three named fixes.
Filed as **#748** with a root-cause hypothesis (a likely U/V pole-array transposition in
`makeProfileSkin`/`makeGuideSkin` that a 2×2 grid's square dimensions can't expose). Cookbook and
the `networkSurface` doc comment now say `.done` rather than implying full geometric fidelity, and
link to #748.

**Left alone, lower severity, explained in place rather than fixed:**
- *Locator-parameter monotonicity* — a data-dependent contact parameter sequence has no built-in
  ordering guarantee the way the old uniform fractions did. Not fixed, but while investigating
  #748 above I confirmed `GeomFill_NetworkSurface`'s own `checkParameters()` already rejects a
  non-monotonic sequence as `.invalidInput` rather than silently proceeding, so the sharpest form
  of this concern (a scrambled network sneaking through) is already caught downstream, just not
  attributed to "monotonicity" in the status.
- *`geomFillSweep`'s hardcoded, non-configurable tolerance* — real, but fixing it means adding a
  new public parameter, which is a bigger API surface change than a review-response PR should make
  as a drive-by. Left as a documented constant (see fix 5 above).
- *Copy-pasted averaging loops* (`profileParams`/`guideParams`) — looked at unifying them behind a
  shared helper; declined, because the two loops read different arrays along different axes
  (guide-parameter-by-row vs profile-parameter-by-column), so a parameterized helper would trade
  eight lines of direct code for a lambda plus two call sites of comparable complexity, and both
  loops now read from arrays a single, always-executed reject check upstream has already validated
  — there's no divergent-bugfix risk left to guard against.

### Injection matrix (prove-the-test-fails) — review response

| Test | Defect injected | Before fix | After fix |
|---|---|---|---|
| `networkSurfaceRejectsOneDegeneratePairAmongOtherwiseGoodOnes` (#726 fix) | Restored the pre-fix fallback, but with `LastParameter()` instead of `FirstParameter()` (an equally-plausible alternate fabrication) | red: `.knotAlignmentFailed` (not `.invalidInput`) | green |
| `networkSurfaceParallelCurvesDoNotCrash` (tightened to `.invalidInput`) | Restored the exact pre-fix `FirstParameter()` fallback | still green — measured, not assumed: for an *entirely* parallel 2×2 grid every pair collapses to the same degenerate value, tripping the array's own strictly-increasing check by coincidence regardless of which fix is in place. This fixture alone doesn't discriminate; see the row above for the one that does | green |
| `networkSurfaceReportsKnotAlignmentFailedWhenGuidesDoNotSpanProfiles` (#3, restored coverage) | Swapped `NetworkSurfaceStatus.knotAlignmentFailed`'s ordinal with `referenceSurfaceFailed`'s (enum drift between the Swift and C++ `GeomFill_NetworkSurface::ResultStatus` enums) | red: decoded as `.referenceSurfaceFailed` | green |
| `networkSurfaceReportsDoneForTheCookbookDomedNetwork` (item 8 / #748) | N/A — this test locks in the narrower, now-actually-verified claim (`.done`) rather than the full-fidelity one the old cookbook text implied; shares its contact-finding code path with the two already-injection-proven bilinear/quarter-cylinder tests below | — | green |

Original matrix (unchanged, still valid against this session's code):

| Test | Defect injected | Before fix | After fix |
|---|---|---|---|
| `JoinBezierPatchesTests.joinRejectsRationalPatch` (#725) | Removed the `occtAnyBezierPatchIsRational` rejection | red: returns a non-nil (wrong) surface | green |
| `GeomFillSweepTests.sweepRejectsOutOfToleranceFit` (#597) | Removed the `ErrorOnSurface() > tolerance` check | red: returns a non-nil (out-of-tolerance) surface | green |
| `GeomFillGordonReportTests.networkSurfaceBuildsTheQuarterCylinderNetwork` (#689) | Reverted locator params to the original uniform `[0,1]` fractions | red: `.knotAlignmentFailed`, matching the original bug | green |
| `GeomFillGordonReportTests.networkSurfaceBuildsASimpleBilinearPatch` (#689) | Same injection as above (same root cause) | red: `.knotAlignmentFailed` | green |
| `GeomFillGordonReportTests.networkSurfaceParallelCurvesDoNotCrash` (#636 guard, new call site) | Not injected in the test suite: removing `IsParallel()` here would SIGSEGV the whole test process. Verified instead via a standalone ground-truth binary linked against `libOCCT-macos.a`, mirroring PR #730's own verification method for the same defect | unguarded: SIGSEGV (exit 139) | guarded: clean exit, graceful result |

Each case above was run once broken, confirmed to fail (or crash, for the ground-truth binary
case), then restored and confirmed to pass, per
[`okf/policies/prove-the-test-fails.md`](../blob/main/okf/policies/prove-the-test-fails.md).

## Verification

- `env -u OCCTSWIFT_LOCAL -u OCCTSWIFT_BRIDGE_PREBUILT swift build`: clean.
- `env -u OCCTSWIFT_LOCAL -u OCCTSWIFT_BRIDGE_PREBUILT swift test --filter OCCTSurfaceTests`: **529
  tests, 151 suites, all pass** (this PR's own domain target; the full-repo run below is the
  authoritative number).
- `env -u OCCTSWIFT_LOCAL -u OCCTSWIFT_BRIDGE_PREBUILT swift test`: **5433 tests, 1414 suites, all pass** (full suite, pinned remote `v2.0.0-kernel.1`, 157s).
- All 5 gate scripts pass clean on the current tree (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `derive-bridge-header-split --verify`, `count-operations`).
- No public API surface added; op counts unchanged (`count-operations.py` still reports 4306).

## Notes for the reviewer

- An incidental finding, not acted on: `Geom_BezierSurface::IsURational()`/`IsVRational()` do not map onto the Swift-level `poles[uRow][vCol]` axes the way I first assumed; OCCT's own `Rational()` helper assigns rationality-along-one-array-index to the other named axis. Not a project bug, just a naming trap. The new `#725` test checks `isURational || isVRational` rather than assuming which one flips, matching the production predicate exactly.
- `docs/guides/cookbook/gordon-surfaces.md` had a worked example that is now stale in the opposite direction: it demonstrated `networkSurface` declining a network that now succeeds. Rewrote that section rather than leaving a passing example describe a failure that no longer happens. Updated again in the review-response pass above once #748 came to light.
- Unrelated to this diff: partway through the first pass a broad `pkill -f "swift test"` I ran to clear a stuck process also killed an in-flight test run belonging to a different worktree (`.claude/worktrees/1b`). No files were touched, just a killed process, flagging in case that session needed re-running.
- **New, out-of-scope finding filed as #748**: `GeomFill_NetworkSurface` (the kernel class behind
  `networkSurface`) reports `.done` with two of four corners geometrically wrong, on every network
  tried including a plain bilinear rectangle. See the "Also found and fixed" note above and #748
  for the full writeup and root-cause hypothesis. Not fixed here — it's a kernel-level defect
  requiring its own investigation (debug instrumentation, a non-square profile/guide count to
  force the dimension check to discriminate axes, then a carried patch), not a bridge change.

Closes #725
Closes #689

## CHANGELOG entry

### `Surface.joinBezierPatches` rejects rational patches instead of silently dropping their weights (#725)

`GeomConvert_CompBezierSurfacesToBSplineSurface` has no rational path: its own precondition against
rational input is a `Standard_NotImplemented_Raise_if` that this project's Release kernel compiles
out via `No_Exception`, so a rational Bezier patch used to convert to the *polynomial* surface
through the same control net and report success. Measured on a rational quarter-cylinder patch: a
0.606602 radius error reported as `IsDone() == true`. `joinBezierPatches` now rejects any patch that
is rational in either direction before constructing the converter, using the same
`IsURational() || IsVRational()` predicate the compiled-out guard used. Weights are never clamped or
silently dropped.

### `Shape.geomFillSweep` rejects a fit that misses its own tolerance instead of reporting it as done (#597)

`GeomFill_Sweep::Build`'s general path always fits the swept surface with an internal approximation
and records the achieved deviation in `ErrorOnSurface()`; `IsDone()` alone says only that some
surface was produced, not that it met the tolerance the fit was built at. `geomFillSweep` used to
accept whatever `Build()` returned without ever reading that number. Measured: a rapidly oscillating
spine can report `IsDone() == true` with `ErrorOnSurface() == 13.0`, five orders of magnitude past
the 1e-4 tolerance the fit was built at. Now rejects a fit whose reported error exceeds that
tolerance. Two upstream kernel sites the wider issue also names (`GeomFill_Sweep.cxx`'s
`ForceApproxC1` branch, `ShapeUpgrade_UnifySameDomain.cxx`) are not reachable from this bridge file
and remain open; see #597 for the measurement.

### `Surface.networkSurface` now succeeds on well-formed curve networks (#689)

`networkSurface` used to fail every network tried, including the simplest possible 2x2 bilinear
patch of straight lines, a network with nothing to approximate at all. The cause was not the
intersection grid: it was that the locator parameters handed to the underlying
`GeomFill_NetworkSurface` builder were a caller-invented `[0,1]` fraction rather than each curve's
own raw parameter in the other family's domain, which the builder requires to match before it will
align its internal profile, guide, and reference skins to one knot basis. Fixed by finding each
profile/guide pair's real contact point and parameter via `GeomAPI_ExtremaCurveCurve` (the same
class `GeomFill_Gordon`'s own internal network preparation uses) and averaging across the family.
`networkSurface` now builds well-formed networks, including a network of genuinely rational
profile curves, matching their reference geometry to within floating-point precision; it does not
replicate `GeomFill_Gordon`'s full curve-reordering and reparametrization pipeline, so a scrambled
or genuinely misaligned network can still decline. This new call site of `GeomAPI_ExtremaCurveCurve`
is guarded against the parallel-curve SIGSEGV #636 found in the same class, since that fix (PR #730)
is scoped to a different file and does not cover it.

**Review-response follow-up (same PR, second pass):** the contact-point loop above picked
`GeomAPI_ExtremaCurveCurve`'s solution index 1 unconditionally instead of its nearest extremum, and
substituted a fabricated placeholder point (each curve's own `FirstParameter()`) for a
parallel/no-extremum pair, silently averaging it into an otherwise-real result. Both fixed: the
nearest-extremum accessors are used instead of index 1, and a pair with no real contact now rejects
the whole network as `.invalidInput` rather than fabricating one. Separately, verifying a docs claim
about this same function surfaced a distinct, unrelated kernel defect in `GeomFill_NetworkSurface`
itself (two of four corners of the built surface can be wrong even when `.done` is reported); filed
as #748, not fixed in this PR.
