### PR TITLE
chore(#636): carry the upstream Extrema_ExtCC::Points() kernel patch

### DIFF
--- a/Scripts/patches/0024-Extrema_ExtCC-Points-bound-against-mypoints-636.patch
+++ b/Scripts/patches/0024-Extrema_ExtCC-Points-bound-against-mypoints-636.patch
@@ -1,0 +1,43 @@
+diff --git a/src/ModelingAlgorithms/TKGeomAlgo/Geom2dAPI/Geom2dAPI_ExtremaCurveCurve.hxx b/src/ModelingAlgorithms/TKGeomAlgo/Geom2dAPI/Geom2dAPI_ExtremaCurveCurve.hxx
+index cc8f9c87..36b80b57 100644
+--- a/src/ModelingAlgorithms/TKGeomAlgo/Geom2dAPI/Geom2dAPI_ExtremaCurveCurve.hxx
++++ b/src/ModelingAlgorithms/TKGeomAlgo/Geom2dAPI/Geom2dAPI_ExtremaCurveCurve.hxx
+@@ -102,6 +102,9 @@ public:
+   //! number of extrema computed by this algorithm.
+   Standard_EXPORT double Distance(const int Index) const;
+ 
++  //! Returns True if the two curves are parallel.
++  bool IsParallel() const { return myExtCC.IsParallel(); }
++
+   //! Returns the points P1 on the first curve and P2 on
+   //! the second curve, which are the ends of the shortest
+   //! extremum computed by this algorithm.
+diff --git a/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.cxx b/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.cxx
+index 135a99b2..9a40df9f 100644
+--- a/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.cxx
++++ b/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.cxx
+@@ -361,7 +361,9 @@ int Extrema_ExtCC::NbExt() const
+ 
+ void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const
+ {
+-  if (N < 1 || N > NbExt())
++  // NbExt() counts mySqDist; some parallel-curve branches append a distance with no matching
++  // point pair (an equidistant family has no unique point), so bound against mypoints instead.
++  if (N < 1 || 2 * N > mypoints.Length())
+   {
+     throw Standard_OutOfRange();
+   }
+diff --git a/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.hxx b/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.hxx
+index c71f670e..19113744 100644
+--- a/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.hxx
++++ b/src/ModelingData/TKGeomBase/Extrema/Extrema_ExtCC.hxx
+@@ -97,6 +97,9 @@ public:
+ 
+   //! Returns the points of the Nth extremum distance.
+   //! P1 is on the first curve, P2 on the second one.
++  //! Exceptions
++  //! Standard_OutOfRange if N is not in [1, NbExt()], or if N has a distance but no
++  //! representative point pair (a parallel curve pair with an equidistant family).
+   Standard_EXPORT void Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const;
+ 
+   //! if the curve is a trimmed curve,

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -518,8 +518,13 @@ two for every touched file, so there is no rebase to do before filing. `clang-fo
 --Werror` against OCCT's own `.clang-format` reports zero violations on all three changed files.
 
 See [`Scripts/repro/636-extrema-parallel/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/636-extrema-parallel)
-for the reproducer and the full caller survey. Not yet filed upstream (prepared, not sent, per this
-issue's own scope) — see that directory's `draft-issue.md`/`draft-pr.md`.
+for the reproducer and the full caller survey. **Filed upstream 2026-08-07 as
+[Open-Cascade-SAS/OCCT#1445](https://github.com/Open-Cascade-SAS/OCCT/pull/1445)**, PR only and no
+companion issue, per `okf/policies/upstream-occt-style.md` and the precedent of `0018`, `0019` and
+`0021`: the fix was ready, so the PR description carries the repro and root cause that a standalone
+issue would have. Verified applying cleanly to upstream `master` at `b8f597c6` immediately before
+filing. That directory's `draft-issue.md` is retained as the text to use if the defect ever needs
+reporting ahead of a fix; `draft-pr.md` is what was sent.
 
 **Retire** once the bundled OCCT includes this fix.
 

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -433,6 +433,102 @@ for the reproducer. Filed upstream as [Open-Cascade-SAS/OCCT#1434](https://githu
 
 **Retire** once the bundled OCCT includes this fix.
 
+## 0024-Extrema_ExtCC-Points-bound-against-mypoints-636.patch
+
+**Fixes the upstream OCCT defect behind [#636](https://github.com/SecondMouseAU/OCCTSwift/issues/636)**,
+already mitigated bridge-side (`OCCTCurve3DExtrema`, `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`,
+PR #730): `Curve3D.extrema(with:maxCount:)` SIGSEGV'd, uncatchably, on parallel curves at every
+capacity including its own default, both for unbounded lines and for finite segments whose
+projected ranges overlap.
+
+`Extrema_ExtCC::NbExt()` counts `mySqDist`; `Extrema_ExtCC::Points()` reads a different container,
+`mypoints`, but bounds-checks the request against `NbExt()`. Several branches of
+`PrepareParallelResult` append a distance to `mySqDist` with no matching pair in `mypoints`, because
+in those branches the curves are parallel over a continuous range and there genuinely is no unique
+closest point to report — only a distance. `NbExt()` reports `1` in exactly those cases, so
+`Points(1)` indexes an empty `NCollection_Sequence`. `Points()`'s own bounds check is a raw `throw`,
+not compiled out under `No_Exception` (this project's Release kernel is built with
+`BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`) — but it checks the wrong bound, so it never fires. The check
+that would catch the real problem, `NCollection_Sequence::Value()`'s own `Standard_OutOfRange_Raise_if`,
+*is* built from that macro and *is* compiled to nothing under `No_Exception`; with no guard left,
+indexing an empty sequence walks a null node. Confirmed with a standalone binary linked directly
+against `libOCCT-macos.a`: a genuine SIGSEGV, not a C++ exception a `catch (...)` could absorb.
+`GeomAPI_ExtremaCurveCurve::Points()` (what `OCCTCurve3DExtrema` calls) has the identical shape one
+layer up — its own bounds check is also a `Raise_if` no-op under `No_Exception` — so nothing between
+the bridge and the null-node dereference does anything until this patch.
+
+**Caller survey before choosing a fix shape** (the issue asked for one; two alternatives were
+considered and rejected):
+
+- *Redefine `NbExt()` to count `mypoints` instead of `mySqDist`.* Rejected:
+  `GeomAPI_ExtremaCurveCurve::LowerDistance()` reaches `SquareDistance(myIndex)`, which
+  bounds-checks against `NbExt()` too. Redefining it would make the parallel-distance-only case
+  (which has a perfectly well-defined distance, just no unique point) start refusing
+  `LowerDistance()` as well — measured that this caller currently gets a correct answer in exactly
+  the branches this patch touches, and unifying the counts would have broken it.
+- *Gate `Points()` on `IsParallel()`* (what the bridge does, one layer up, for its own purpose).
+  Traced every branch of `PrepareParallelResult` by hand: `IsParallel()` is true in precisely the
+  branches that leave `mypoints` empty and false in precisely the branches that populate it, no
+  exceptions found — so this is equivalent to the fix actually made, *today*. Chose the
+  container-bound version instead because it is self-defending against the shape of the bug (an
+  index into a container with fewer entries than claimed) rather than relying on a correspondence
+  between two fields that nothing enforces, and because `SquareDistance()` already bounds against
+  the container it reads (`mySqDist`) — `Points()` doing the same against `mypoints` matches an
+  existing pattern in the same file rather than adding a new one.
+
+**Fix:** bounds `Points()` against `mypoints.Length()` instead of `NbExt()`:
+
+```cpp
+void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const
+{
+  if (N < 1 || 2 * N > mypoints.Length())
+  {
+    throw Standard_OutOfRange();
+  }
+  P1 = mypoints.Value(2 * N - 1);
+  P2 = mypoints.Value(2 * N);
+}
+```
+
+Plus a matching `//! Exceptions` doc line on the header declaration, and a **companion, behavior-neutral
+addition** to `Geom2dAPI_ExtremaCurveCurve.hxx`: a one-line `IsParallel()` forwarder, matching the
+3D sibling's own convenience method (`Extrema_ExtCC2d::IsParallel()` was already public and already
+reachable via the existing `Extrema()` accessor, so this closes an ergonomic gap, not a capability
+one). The 2D curve-curve class was measured, not assumed, to be already safe: its own `NbExtrema()`
+correctly reports `0` in every fixture this patch's 3D counterpart makes crash, so `Points()` is
+genuinely unreachable there today, in both bridge call sites that use it
+(`OCCTCurve2DMinDistance`, `OCCTCurve2DAllExtrema` — the latter is the "very likely a 2D sibling"
+follow-up PR #730 flagged but didn't confirm; this patch's repro confirms it is not).
+
+**Validation** (override-link, no full rebuild, see the `#0001` entry above for the technique,
+compiled with `-DNDEBUG -DNo_Exception` to match the production build): four fixtures — finite
+parallel segments with overlapping projected ranges, the same with disjoint ranges, two infinite
+parallel `Geom_Line`s, and finite parallel segments whose projected ranges touch at exactly one
+point. The first two are the issue's own ground truth; the third is PR #730's own regression
+fixture shape; the fourth was added after tracing `PrepareParallelResult`'s line-line branch by
+hand suggested it might be a counter-example to the `IsParallel()`/`mypoints` correspondence above —
+measuring it disproved that (see the repro README's "four fixtures" table). Before the patch, the
+overlapping and infinite cases SIGSEGV (exit 139) through both `GeomAPI_ExtremaCurveCurve::Points()`
+and `Extrema_ExtCC::Points()` directly; after, both throw a catchable `Standard_OutOfRange`. The
+disjoint and touching cases are **byte-identical** before and after, in both the returned points and
+`LowerDistance()`/`Distance()` (which read `mySqDist` and are untouched by this patch, measured
+across all four fixtures rather than assumed). Confirmed the patch applies cleanly (`git apply
+--check`) to both the pinned `V8_0_1` tag and current upstream `master`, byte-identical between the
+two for every touched file, so there is no rebase to do before filing. `clang-format --dry-run
+--Werror` against OCCT's own `.clang-format` reports zero violations on all three changed files.
+
+See [`Scripts/repro/636-extrema-parallel/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/636-extrema-parallel)
+for the reproducer and the full caller survey. Not yet filed upstream (prepared, not sent, per this
+issue's own scope) — see that directory's `draft-issue.md`/`draft-pr.md`.
+
+**Retire** once the bundled OCCT includes this fix.
+
+**Pin consequence**: this is the third patch (after `0022`, `0023`) carried in the tree but outside
+the pinned `v2.0.0-kernel.1` binary asset — see `docs/v2.0.0-plan.md`'s release watch-out. The next
+kernel rebuild needs to carry all three, and confirm all three actually reached the binary rather
+than assuming the rebuild picked them up, per `docs/guides/building-occt.md`'s shipping-a-rebuild
+steps.
+
 # Retired patches
 
 The `.patch` files below are **deleted**. Each fix now comes from the pinned OCCT release itself, so

--- a/Scripts/repro/636-extrema-parallel/README.md
+++ b/Scripts/repro/636-extrema-parallel/README.md
@@ -1,0 +1,330 @@
+# OCCTSwift#636 kernel reproducer: `Extrema_ExtCC::Points()` on parallel curves
+
+Standalone, deterministic kernel-level reproducer for the uncatchable SIGSEGV behind
+[#636](https://github.com/SecondMouseAU/OCCTSwift/issues/636). This directory is the kernel-level
+root cause and the carried patch's own evidence, separate from the bridge-side fix
+(`OCCTCurve3DExtrema`, `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`, shipped first in PR #730,
+same PR1-then-PR2 pattern as #298/#341/#344/#349/#705). **That bridge fix is not touched, undone,
+or duplicated here.**
+
+## Root cause
+
+`Extrema_ExtCC::NbExt()` (`Extrema_ExtCC.cxx`) counts `mySqDist`:
+
+```cpp
+int Extrema_ExtCC::NbExt() const { ...; return mySqDist.Length(); }
+```
+
+`Extrema_ExtCC::Points()` reads a different container, `mypoints`, but bounds-checks the request
+against `NbExt()`:
+
+```cpp
+void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const {
+  if (N < 1 || N > NbExt()) throw Standard_OutOfRange();
+  P1 = mypoints.Value(2 * N - 1);
+  P2 = mypoints.Value(2 * N);
+}
+```
+
+`PrepareParallelResult` (`Extrema_ExtCC.cxx`, ~line 397) has several branches that append to
+`mySqDist` without appending the matching pair to `mypoints`, because in those branches there
+genuinely is no discrete answer: the curves are parallel over a continuous range and every point in
+it is equally close, so there is no unique "the" closest pair to report, only a distance. Measured
+directly against every branch of that function (traced line by line, then confirmed with the four
+fixtures below): **`NbExt()` reports 1 in exactly the same cases where `mypoints` is empty**,
+tracking `Extrema_ExtCC::IsParallel()` in every branch this file has. `Points(1)` in that state
+indexes an empty `NCollection_Sequence`.
+
+**Why this is a genuine SIGSEGV, not a caught exception.** `Points()`'s own bounds check is a raw
+`throw Standard_OutOfRange()` — that line is not wrapped in the `Standard_OutOfRange_Raise_if`
+macro and is not compiled out under `No_Exception` (this project's kernel is built with
+`BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`, i.e. `-DNo_Exception`). It simply checks the wrong bound:
+`NbExt()` says 1, so `N=1` passes. The check that *would* catch the real problem is one level down,
+inside `NCollection_Sequence::Value(size_t)`:
+
+```cpp
+const TheItemType& Value(const size_t theIndex) const {
+  Standard_OutOfRange_Raise_if(theIndex == 0 || theIndex > mySize, "NCollection_Sequence::Value");
+  ...
+}
+```
+
+That check *is* built from the macro, and *is* compiled to nothing under `No_Exception`. With no
+guard left standing, `Find(1)` on a zero-length sequence walks a null node and dereferences it —
+the genuine SIGSEGV. Confirmed with a standalone binary linked directly against the pinned
+`libOCCT-macos.a` (below), not assumed from reading the two headers.
+
+`GeomAPI_ExtremaCurveCurve::Points()` (the wrapper `OCCTCurve3DExtrema` actually calls) has the
+identical shape one layer up — its own bounds check also uses the `_Raise_if` macro and is also a
+no-op under `No_Exception` — so before this fix, nothing between the bridge and the null-node
+dereference does anything.
+
+## The four fixtures, and why each one is in the set
+
+All four run through `GeomAPI_ExtremaCurveCurve` (what the bridge calls) and directly through
+`Extrema_ExtCC` (what it wraps), so the probe also answers "does fixing the low-level class's own
+`throw` survive being reached through a wrapper whose own guard is a no-op" — it does, since the
+`throw` inside `Extrema_ExtCC::Points()` is a real language-level throw with no macro over it.
+
+| # | Fixture | `IsParallel()` | `NbExtrema()` | `Points(1)` before | `Points(1)` after |
+|---|---|---|---|---|---|
+| 1 | Two finite segments, **overlapping** projected ranges | `1` | `1` | **SIGSEGV** | `Standard_OutOfRange` (catchable) |
+| 2 | Two finite segments, **disjoint** projected ranges | `0` | `1` | returns real nearest pair | **unchanged, byte-identical** |
+| 3 | Two infinite `Geom_Line`s, parallel | `1` | `1` | **SIGSEGV** | `Standard_OutOfRange` (catchable) |
+| 4 | Two finite segments, projected ranges **touch at exactly one point** | `0` | `1` | returns real unique pair | **unchanged, byte-identical** |
+
+Case 1 and 2 are the exact two the issue's own ground truth section describes. Case 3 is the
+fixture shape PR #730's own regression tests use (an unbounded pair). Case 4 was added while
+tracing `PrepareParallelResult` by hand: a first read of the line-line branch looked like it might
+leave `IsParallel()==true` with a real point pair populated (which would have meant "gate `Points()`
+on `IsParallel()`" is not a generally safe kernel-level fix, only safe for the specific narrower
+bridge guard PR #730 already ships). **Measuring it disproved that reading**: the finite line-line
+branch resets `myIsParallel = false` on entry and only sets it back to `true` when the projected
+ranges' overlap is wider than `Precision::Confusion()` — the touching-at-one-point case never
+re-sets it, so `IsParallel()` correctly reports `false` here too, and a real point pair is (and
+always was) returned. Reported as a finding in the PR rather than assumed from the first reading.
+See "Caller survey" below for what this means for the choice of fix.
+
+## Reproducer
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/636-extrema-parallel/probe_636.mm -o /tmp/probe_636
+/tmp/probe_636
+```
+
+Each case forks (`probe()`, same idiom as
+[`Scripts/repro/643-geomtools-null-write/probe_643.mm`](../643-geomtools-null-write/probe_643.mm)),
+so a SIGSEGV in the child is reported to the parent rather than ending the run. Against the pinned
+`v2.0.0-kernel.1` (stock, this patch not applied):
+
+```
+-- 1. OVERLAPPING projected ranges (finite, parallel) --
+  IsParallel()  = 1
+  NbExtrema()   = 1
+      LowerDistance() = 1.000000
+  GeomAPI_ExtremaCurveCurve::LowerDistance()     returned normally
+      Distance(1) = 1.000000
+  GeomAPI_ExtremaCurveCurve::SquareDistance/Distance(1) returned normally
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      SIGSEGV (uncatchable)
+  Extrema_ExtCC::Points(1, ...) [direct, low-level] SIGSEGV (uncatchable)
+
+-- 2. DISJOINT projected ranges (finite, parallel) --
+  IsParallel()  = 0
+  NbExtrema()   = 1
+      P1=(10.000,0.000,0.000) P2=(20.000,1.000,0.000)
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      returned normally
+  ...
+
+-- 3. UNBOUNDED (infinite Geom_Line, parallel) --
+  IsParallel()  = 1
+  NbExtrema()   = 1
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      SIGSEGV (uncatchable)
+  Extrema_ExtCC::Points(1, ...) [direct, low-level] SIGSEGV (uncatchable)
+
+-- 4. TOUCHING at one point (finite, parallel, IsParallel stays true) --
+  IsParallel()  = 0
+  NbExtrema()   = 1
+      P1=(10.000,0.000,0.000) P2=(10.000,1.000,0.000)
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      returned normally
+```
+
+raw exit 139 on cases 1 and 3, deterministic, every run.
+
+### Verifying the patch (override-link, no full rebuild)
+
+Compile the patched `Extrema_ExtCC.cxx` standalone with the same flags the production kernel is
+built with, and link it *before* `-lOCCT-macos` (technique documented in
+`Scripts/patches/README.md`'s `#0001` entry):
+
+```bash
+clang++ -c -std=gnu++17 -O0 -g -w -DNDEBUG -DNo_Exception -DOCC_CONVERT_SIGNALS \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  Extrema_ExtCC_patched.cxx -o /tmp/Extrema_ExtCC_patched.o
+
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  Scripts/repro/636-extrema-parallel/probe_636.mm /tmp/Extrema_ExtCC_patched.o \
+  -o /tmp/probe_636_patched \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++
+/tmp/probe_636_patched
+```
+
+`-DNDEBUG -DNo_Exception` matters: without it, `NCollection_Sequence::Value()`'s own `Raise_if`
+compiles back in, and the override no longer measures the kernel this project actually ships.
+
+After the patch:
+
+```
+-- 1. OVERLAPPING projected ranges (finite, parallel) --
+      caught Standard_OutOfRange:
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      Standard_OutOfRange (catchable)
+      caught Standard_OutOfRange:
+  Extrema_ExtCC::Points(1, ...) [direct, low-level] Standard_OutOfRange (catchable)
+
+-- 2. DISJOINT projected ranges (finite, parallel) --
+      P1=(10.000,0.000,0.000) P2=(20.000,1.000,0.000)     <- unchanged
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      returned normally
+
+-- 3. UNBOUNDED (infinite Geom_Line, parallel) --
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      Standard_OutOfRange (catchable)
+
+-- 4. TOUCHING at one point (finite, parallel, IsParallel stays true) --
+      P1=(10.000,0.000,0.000) P2=(10.000,1.000,0.000)     <- unchanged
+  GeomAPI_ExtremaCurveCurve::Points(1, ...)      returned normally
+```
+
+`LowerDistance()`/`Distance(1)` report the identical values (`1.000000`, `10.049876`) before and
+after in every case — unsurprising, since the fix touches only `Points()`'s own bounds check and
+never touches `mySqDist` or `NbExt()`, but measured rather than assumed, since this is exactly the
+value the bridge's `Curve3D.minDistance(to:)` depends on (see "Caller survey").
+
+This is the injection/removal proof the repo's
+[`prove-the-test-fails`](../../../okf/policies/prove-the-test-fails.md) policy asks for: the "stock"
+run above is the defect-injected state (literally the unpatched line), showing red; the "patched"
+run is the fix, showing green on the crash cases and byte-identical on the two that must not move.
+
+`clang-format --dry-run --Werror` against OCCT's own `.clang-format` reports zero violations on all
+three changed files (`Extrema_ExtCC.cxx`, `Extrema_ExtCC.hxx`,
+`Geom2dAPI_ExtremaCurveCurve.hxx` — see "Companion fix" below); the added lines needed no
+reformatting.
+
+**Patch confirmed to apply cleanly** (`git apply --check`) both to the pinned `V8_0_1` tag and to
+current upstream `master` (`b8f597c6`, "Coding - Bump version to 8.0.1 (#1412)") — `master` and
+`V8_0_1` are byte-identical for all three touched files, so there is no rebase to do before filing.
+
+## Fix
+
+`Scripts/patches/0024-Extrema_ExtCC-Points-bound-against-mypoints-636.patch`. Bounds `Points()`
+against the container it actually reads:
+
+```cpp
+void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const
+{
+  // NbExt() counts mySqDist; some parallel-curve branches append a distance with no matching
+  // point pair (an equidistant family has no unique point), so bound against mypoints instead.
+  if (N < 1 || 2 * N > mypoints.Length())
+  {
+    throw Standard_OutOfRange();
+  }
+
+  P1 = mypoints.Value(2 * N - 1);
+  P2 = mypoints.Value(2 * N);
+}
+```
+
+Plus a matching `//! Exceptions` doc line on the header declaration.
+
+## Caller survey (why this shape, not the other two the issue raised)
+
+The issue's own text offered two starting points and asked for a survey before picking one:
+
+**"Make `NbExt()` and `Points()` agree about which container defines the count."** Rejected after
+tracing who reads `NbExt()`: `GeomAPI_ExtremaCurveCurve::LowerDistance()` calls
+`myExtCC.SquareDistance(myIndex)`, and `SquareDistance()` bounds-checks against `NbExt()` too
+(`if ((N < 1) || (N > NbExt())) throw ...`). Redefining `NbExt()` to mean "how many point pairs
+exist" (e.g. `mypoints.Length() / 2`) would make it `0` in every case that currently returns `1`
+with a distance-only result — and then `SquareDistance(1)`, and therefore
+`LowerDistance()`/`Distance()`, would also start refusing on exactly the parallel-distance-only
+case that legitimately wants an answer (`LowerDistance()` genuinely has a well-defined value even
+when there is no unique closest point — the perpendicular distance between two parallel lines is
+still just a number). Measured, not assumed: case 1's `LowerDistance()` returns `1.000000` both
+before and after this fix, and that call path is entirely through `SquareDistance()`/`NbExt()`,
+neither of which this patch touches. Unifying the two counts would have broken that caller.
+
+**"Enforce the `IsParallel()` precondition on `Points()`."** This is what the bridge does, one layer
+up, for its own narrower purpose (return empty and stop, PR #730). At the kernel level it turns out
+to be *equivalent* to the fix actually made — case-by-case tracing of every branch in
+`PrepareParallelResult` (general non-analytic types, line-circle mismatch, line-line both
+sub-cases, circle-circle's three sub-cases) shows `IsParallel()` is true in precisely the branches
+that leave `mypoints` empty, and false in precisely the branches that populate it, no exceptions
+found across the whole function. Case 4 above was where this got checked hardest, since a first
+read suggested a counter-example; measurement did not confirm it. Given the two are equivalent
+*today*, the choice was: gate on `IsParallel()` (documents the semantic reason), or bound against
+`mypoints.Length()` directly (self-defending against the *shape* of the actual bug — an index into
+a container that does not have as many entries as claimed — regardless of whether some future
+change to `PrepareParallelResult` ever breaks the `IsParallel()`/`mypoints` correspondence this
+patch measured but does not enforce anywhere). Chose the latter: `NbExt()`'s own sibling accessor,
+`SquareDistance()`, already bounds against the container it reads (`mySqDist`); `Points()` doing
+the same against `mypoints` is the smaller, more local, more idiomatic change, and matches the
+existing pattern in the same file rather than adding a new one.
+
+**Who else reads these two methods**, so the fix's blast radius is explicit rather than assumed:
+
+- `GeomAPI_ExtremaCurveCurve::NbExtrema()`/`Points()`/`Parameters()`/`Distance()` — thin forwarders,
+  all now benefit from the corrected bound (the wrapper's own bounds check is a `Raise_if`
+  no-op under `No_Exception`, so before this fix nothing stood between it and the crash).
+- `GeomAPI_ExtremaCurveCurve::NearestPoints()` — calls `Points(myIndex, ...)` unconditionally
+  whenever `myIsDone` is true, with **no** `IsParallel()` check of its own. This is a second,
+  independent path to the same crash that PR #730's bridge guard does not sit in front of.
+  Confirmed by grep that `GeomAPI_ExtremaCurveCurve` (the 3D, curve-curve class this patch touches)
+  is constructed in exactly two places in the whole bridge, both in
+  `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm` (`OCCTCurve3DExtrema`, `OCCTCurve3DMinDistanceToCurve`
+  — matching PR #730's own audit), and neither calls `NearestPoints()`. So this path is not
+  reachable through OCCTSwift today, but it is reachable from any other OCCT consumer of this
+  class, which is exactly who this patch is for. (Its 2D sibling,
+  `Geom2dAPI_ExtremaCurveCurve::NearestPoints()`, *is* called by this bridge —
+  `OCCTCurve2DMinDistance`, `OCCTBridge_Geom2d.mm` — but is already safe there, not because of a
+  guard, but because `Geom2dAPI_ExtremaCurveCurve::NbExtrema()` genuinely reports `0` in the
+  parallel case, per this file's own "Companion fix" measurement; the call site's existing
+  `if (ext.NbExtrema() == 0) return result;` check is what keeps it from ever calling
+  `NearestPoints()` when parallel, and it works because the count is honest, not despite it not
+  being. A different class entirely, `GeomAPI_ExtremaSurfaceSurface`
+  (`OCCTBridge_Surface.mm`'s `OCCTSurfaceExtrema`), has the same `NbExtrema()`-then-`NearestPoints()`
+  shape for surface-surface extrema; not investigated here — a different underlying algorithm
+  (`Extrema_ExtSS`), out of this issue's scope, and not shown to share this defect.)
+- `GeomAPI_ExtremaCurveCurve::TotalPerform()` (backs `TotalNearestPoints`/
+  `TotalLowerDistanceParameters`/`TotalLowerDistance`) — already guards its own `Points()` call with
+  `if (myIsDone && !myExtCC.IsParallel())`, so it was never exposed to this defect. Also not called
+  by this bridge.
+- `LowerDistance()`/`LowerDistanceParameters()`/`Distance()`/`SquareDistance()` — read `mySqDist`
+  only, unaffected by this patch in every branch (measured across all four fixtures above).
+
+## Companion fix: `Geom2dAPI_ExtremaCurveCurve::IsParallel()`
+
+The issue asked whether to add this "if it is genuinely three lines." It is three lines, and it is
+included in the same patch (`Geom2dAPI_ExtremaCurveCurve.hxx`):
+
+```cpp
+//! Returns True if the two curves are parallel.
+bool IsParallel() const { return myExtCC.IsParallel(); }
+```
+
+One correction to the issue's own framing: it is not quite true that "a caller holding only the 2D
+wrapper cannot write PR #730's guard." `Geom2dAPI_ExtremaCurveCurve` already exposes
+`const Extrema_ExtCC2d& Extrema() const`, and `Extrema_ExtCC2d::IsParallel()` is public, so
+`geom2dExt.Extrema().IsParallel()` already compiles and works today — confirmed by compiling and
+running exactly that call against the pinned kernel (below). The gap is ergonomic, not a hard
+block: the 3D API gets a one-line `IsParallel()` convenience the 2D API does not, for no reason
+tied to either class's actual capability. This patch closes that asymmetry; it changes nothing
+about `Extrema_ExtCC2d` itself and is behavior-neutral (a new inline forwarder, no existing method
+touched).
+
+Confirmed the 2D path needs no crash-side fix, matching the issue's own measurement: the identical
+overlapping-range fixture (`GCE2d_MakeSegment`, `(0,0)`-`(10,0)` and `(3,1)`-`(13,1)`) through
+`Geom2dAPI_ExtremaCurveCurve` reports `IsParallel()=1` and `NbExtrema()=0`, so the `1..NbExtrema()`
+loop any caller writes around `Points()` never executes on this path — `Points()` is genuinely
+unreachable when parallel, in 2D, today. `Extrema_ExtCC2d.cxx`'s own `PrepareParallelResult`
+equivalent evidently never has the asymmetry `Extrema_ExtCC.cxx`'s does, but that was not traced
+line-by-line the way the 3D file was above, since it is not the file this issue's crash is in and
+the measured behavior (via the same fixture, both directly and through the wrapper) already answers
+the only question this PR needs answered: is `Points()` reachable when parallel in 2D. It is not.
+
+**This closes a follow-up PR #730 itself flagged rather than fixed.** PR #730's own notes say
+`OCCTBridge_Geom2d.mm`'s `OCCTCurve2DAllExtrema` "has the identical unguarded `.Points()` call and
+is very likely the 2D sibling of this same defect." Measured here, it is not: `OCCTCurve2DAllExtrema`
+loops `for (i = 0; i < min(ext.NbExtrema(), max); i++) ext.Points(i + 1, ...)`, and since
+`NbExtrema()` is `0` in every case this issue's fixtures make parallel, the loop body — the only
+place this function calls `Points()` — never runs. `OCCTCurve2DMinDistance`
+(same file, `Geom2dAPI_ExtremaCurveCurve::NearestPoints()`, see "who else reads" above) is protected
+the same way, by the same measured fact about the count. Neither needed a change.
+
+## Upstream
+
+Not yet filed — this PR only prepares the filing (see `draft-issue.md` / `draft-pr.md` in this
+directory). Per this repo's hard constraint on this task, no push, comment, edit, or PR/issue
+creation was made against `Open-Cascade-SAS/OCCT` or any fork of it.

--- a/Scripts/repro/636-extrema-parallel/draft-issue.md
+++ b/Scripts/repro/636-extrema-parallel/draft-issue.md
@@ -1,0 +1,72 @@
+# Draft upstream issue for `Extrema_ExtCC::Points()` on parallel curves
+
+**Status: drafted, not sent, and not the recommended filing.** `okf/policies/upstream-occt-style.md`
+is explicit: "if we're submitting a fix, open the PR directly — the PR description carries the
+repro and root cause, same as an issue would have. Only open a standalone issue when we don't yet
+have a fix ready to attach." A fix is ready (`Scripts/patches/0024-*.patch`, validated in
+`Scripts/repro/636-extrema-parallel/README.md`), so per that policy and the precedent set by
+`0018`/`0019`/`0020`/`0021` (each recommends the PR alone, no companion issue), **`draft-pr.md` in
+this directory is what should actually be filed.**
+
+This file exists only because the task that produced this PR asked for both an issue draft and a
+PR draft to be prepared. If a human decides to report the defect before a fix is reviewed and ready
+(the one case the policy does call for a standalone issue), the text below is ready to paste.
+
+---
+
+## Title
+
+```
+Extrema_ExtCC::Points() indexes an empty sequence when NbExt() reports a parallel-only distance
+```
+
+## Body
+
+`Extrema_ExtCC::NbExt()` returns `mySqDist.Length()`. `Extrema_ExtCC::Points()` reads a different
+container, `mypoints`, but bounds-checks the requested index against `NbExt()` rather than against
+`mypoints.Length()`.
+
+Several branches of `PrepareParallelResult` — reached whenever the two curves are found to be
+parallel — append a distance to `mySqDist` without appending a matching point pair to `mypoints`,
+because in those branches there is a continuous family of equidistant points and no single unique
+answer to give. Concretely: two unbounded parallel lines, or two finite parallel segments whose
+projected ranges overlap over a genuine interval (not just touch at one point). In both cases
+`NbExt()` reports `1`.
+
+Calling `Points(1, ...)` in that state indexes `mypoints` past its actual (zero) length.
+`Points()`'s own bounds check does not catch this, since it checks `N > NbExt()`, not
+`2 * N > mypoints.Length()`. Under a Release build with `BUILD_RELEASE_DISABLE_EXCEPTIONS`
+(`-DNo_Exception`), the check that *would* catch it — `NCollection_Sequence::Value()`'s own
+`Standard_OutOfRange_Raise_if` — is compiled to nothing, so the result is an unguarded null-node
+dereference (SIGSEGV), not a C++ exception.
+
+`GeomAPI_ExtremaCurveCurve::Points()`, the public wrapper, has the identical shape (its own bounds
+check is also a `Raise_if` no-op under `No_Exception`), so this is reachable from ordinary use of
+the public API, not just the internal class.
+
+## Reproducer
+
+```cpp
+Handle(Geom_TrimmedCurve) c1 = GC_MakeSegment(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Value();
+Handle(Geom_TrimmedCurve) c2 = GC_MakeSegment(gp_Pnt(3, 1, 0), gp_Pnt(13, 1, 0)).Value();
+GeomAPI_ExtremaCurveCurve ext(c1, c2);
+// ext.IsParallel() == true, ext.NbExtrema() == 1
+gp_Pnt p1, p2;
+ext.Points(1, p1, p2);  // SIGSEGV on a Release / No_Exception build
+```
+
+Also reproduces with two unbounded `Geom_Line`s. Does **not** reproduce (correctly returns a real
+point pair) when the two segments' projected ranges are disjoint, or when they touch at exactly one
+point — in both of those cases the library already sets `IsParallel()` back to `false` and
+populates `mypoints` correctly.
+
+## Environment
+
+Confirmed on OCCT `V8_0_1`, macOS arm64, Release configuration with
+`BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`. Also confirmed present, unchanged, on current `master`
+(`b8f597c6`).
+
+## Suggested fix
+
+Bound `Points()` against `mypoints.Length()` instead of `NbExt()`. A patch is available; see the
+companion PR draft (`draft-pr.md`) rather than duplicating it here.

--- a/Scripts/repro/636-extrema-parallel/draft-pr.md
+++ b/Scripts/repro/636-extrema-parallel/draft-pr.md
@@ -1,0 +1,155 @@
+# Draft upstream PR for patch `0024` (`Extrema_ExtCC::Points()` on parallel curves)
+
+**Status: drafted, not sent.** This task's hard constraint forbids opening, editing, pushing to, or
+commenting on anything in `Open-Cascade-SAS/OCCT` or any fork of it. Everything below is text a
+human can paste into a new PR against that repository's `master` branch in one sitting.
+
+Per `okf/policies/upstream-occt-style.md` and the precedent set by `0018`/[OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417),
+`0019`/[OCCT#1418](https://github.com/Open-Cascade-SAS/OCCT/pull/1418),
+`0020`/(drafted in `Scripts/repro/657-upstream-pr-status/draft-0020-pr.md`, not yet sent) and
+`0021`/[OCCT#1420](https://github.com/Open-Cascade-SAS/OCCT/pull/1420): **no companion issue, go
+straight to the PR.** See `draft-issue.md` in this directory for why a standalone issue draft
+exists anyway alongside this one, and why it is not the recommended filing.
+
+The diff is `Scripts/patches/0024-Extrema_ExtCC-Points-bound-against-mypoints-636.patch`, already
+`clang-format`-clean against OCCT's own root `.clang-format` (verified, see this directory's
+`README.md`), and confirmed to apply to current upstream `master` (`b8f597c6`,
+"Coding - Bump version to 8.0.1 (#1412)") with zero rejected hunks.
+
+Branch to open the PR from: apply `Scripts/patches/0024-*.patch` to a clean checkout of
+`Open-Cascade-SAS/OCCT` `master` (`git apply -p1`) and push that as the PR branch.
+
+---
+
+## Title
+
+```
+ModelingData, ModelingAlgorithms - Extrema_ExtCC::Points() indexes an empty sequence on some parallel-curve results
+```
+
+## Body
+
+`Extrema_ExtCC::NbExt()` counts one container (`mySqDist`); `Extrema_ExtCC::Points()` reads a
+different one (`mypoints`), but bounds-checks the request against `NbExt()`:
+
+```cpp
+int Extrema_ExtCC::NbExt() const { ...; return mySqDist.Length(); }
+
+void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const {
+  if (N < 1 || N > NbExt()) throw Standard_OutOfRange();
+  P1 = mypoints.Value(2 * N - 1);
+  P2 = mypoints.Value(2 * N);
+}
+```
+
+Several branches of `PrepareParallelResult` (called whenever the two curves are found to be
+parallel) append a distance to `mySqDist` with no matching pair appended to `mypoints`, because in
+those branches there is no discrete answer to give: the curves are parallel over a continuous range
+(or unbounded), every point in it is equally close, and there is no unique "the" closest pair, only
+a distance. `NbExt()` reports `1` in exactly the cases this happens, so `Points(1)` indexes
+`mypoints` at an index past its actual length.
+
+`Points()`'s own bounds check does not catch this because it checks the wrong container's length
+(`NbExt()`, not `mypoints.Length()`). The check that *would* catch it sits one level down, inside
+`NCollection_Sequence::Value(size_t)`:
+
+```cpp
+const TheItemType& Value(const size_t theIndex) const {
+  Standard_OutOfRange_Raise_if(theIndex == 0 || theIndex > mySize, "NCollection_Sequence::Value");
+  ...
+}
+```
+
+Under a Release build configured with `BUILD_RELEASE_DISABLE_EXCEPTIONS` (`-DNo_Exception`), that
+macro-based check compiles to nothing, and indexing a zero-length sequence walks a null node and
+dereferences it: a segmentation fault, not a C++ exception. Confirmed with a standalone reproducer
+linked directly against a `No_Exception`-configured build.
+
+`GeomAPI_ExtremaCurveCurve::Points()`, the public wrapper most callers actually use, has the
+identical shape one level up: its own bounds check is also built from
+`Standard_OutOfRange_Raise_if` and is also compiled away under `No_Exception`, so nothing stands
+between a caller of the public API and the crash in that configuration.
+
+## Fix
+
+Bound `Points()` against the container it actually reads:
+
+```cpp
+void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const
+{
+  if (N < 1 || 2 * N > mypoints.Length())
+  {
+    throw Standard_OutOfRange();
+  }
+  P1 = mypoints.Value(2 * N - 1);
+  P2 = mypoints.Value(2 * N);
+}
+```
+
+`NbExt()` is left unchanged: it is also used by `SquareDistance()`, and legitimate callers
+(`GeomAPI_ExtremaCurveCurve::LowerDistance()`) rely on getting a real distance back in exactly the
+parallel-distance-only case this fix's `Points()` now refuses — the perpendicular distance between
+two parallel lines is a well-defined number even though there is no unique closest point pair.
+Redefining `NbExt()` to track `mypoints` instead would have broken that caller; this was verified by
+tracing `LowerDistance()`'s call path (`SquareDistance(myIndex)`, which bounds against `NbExt()`
+too) before deciding, not assumed. A short `//! Exceptions` line is added to the header declaration.
+
+Also includes a companion, behavior-neutral one-line addition to `Geom2dAPI_ExtremaCurveCurve`,
+which does not have this defect (its own `NbExtrema()` already reports `0` in the equivalent
+parallel case, confirmed by measurement) but was missing the `IsParallel()` convenience its 3D
+sibling `GeomAPI_ExtremaCurveCurve` has:
+
+```cpp
+//! Returns True if the two curves are parallel.
+bool IsParallel() const { return myExtCC.IsParallel(); }
+```
+
+(`Extrema_ExtCC2d::IsParallel()` was already public and already reachable through the existing
+`Extrema()` accessor, so this is a convenience, not a new capability.)
+
+## Reproducer
+
+Four fixtures, run through both `GeomAPI_ExtremaCurveCurve` (the typical entry point) and
+`Extrema_ExtCC` directly:
+
+1. Two finite, parallel line segments whose projected ranges **overlap** over a genuine interval —
+   crashes.
+2. Two finite, parallel line segments whose projected ranges are **disjoint** — does not crash, has
+   a real unique nearest-point answer, unaffected by this fix.
+3. Two **unbounded**, parallel `Geom_Line`s — crashes.
+4. Two finite, parallel line segments whose projected ranges **touch at exactly one point** — does
+   not crash, has a real unique answer, unaffected by this fix. (Included because a first read of
+   the source suggested this might be a case where `IsParallel()` is true but a point pair still
+   exists; measuring it showed the source resets `IsParallel()` to false here, so it is not such a
+   case — reported since the reasoning is useful even though it turned out not to be a
+   counterexample.)
+
+```cpp
+// Case 1 (crashes before this patch):
+Handle(Geom_TrimmedCurve) c1 = GC_MakeSegment(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Value();
+Handle(Geom_TrimmedCurve) c2 = GC_MakeSegment(gp_Pnt(3, 1, 0), gp_Pnt(13, 1, 0)).Value();
+GeomAPI_ExtremaCurveCurve ext(c1, c2);
+// ext.IsParallel() == true, ext.NbExtrema() == 1, ext.LowerDistance() == 1.0 (fine)
+gp_Pnt p1, p2;
+ext.Points(1, p1, p2);  // before: SIGSEGV.  after: throws Standard_OutOfRange.
+```
+
+| fixture | `IsParallel()` | `NbExtrema()` | `Points(1)` before | `Points(1)` after |
+|---|---|---|---|---|
+| 1. overlapping | `1` | `1` | SIGSEGV | `Standard_OutOfRange` |
+| 2. disjoint | `0` | `1` | real pair | unchanged |
+| 3. unbounded | `1` | `1` | SIGSEGV | `Standard_OutOfRange` |
+| 4. touching | `0` | `1` | real pair | unchanged |
+
+`LowerDistance()`/`Distance(1)` return the identical values before and after in every fixture
+(measured, since this fix does not touch `mySqDist` or `NbExt()`).
+
+## Validation
+
+Compiled the patched `Extrema_ExtCC.cxx` standalone with `-DNDEBUG -DNo_Exception` (matching a
+Release, exceptions-disabled configuration) and linked it ahead of the stock archive. Fixtures 1 and
+3 go from a deterministic SIGSEGV (raw exit 139) to a caught `Standard_OutOfRange`; fixtures 2 and 4
+are byte-identical before and after, in both the returned points and the distance values. Full
+before/after transcripts and the reproducer source are in the downstream OCCTSwift wrapper's
+[`Scripts/repro/636-extrema-parallel/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/636-extrema-parallel)
+(issue [#636](https://github.com/SecondMouseAU/OCCTSwift/issues/636) there).

--- a/Scripts/repro/636-extrema-parallel/probe_636.mm
+++ b/Scripts/repro/636-extrema-parallel/probe_636.mm
@@ -1,0 +1,189 @@
+// #636 kernel-level ground truth. Bridge-side, `OCCTCurve3DExtrema` already guards this with an
+// `IsParallel()` check (PR #730, `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`) - that guard is
+// not touched here. This probe isolates the kernel defect underneath it: `Extrema_ExtCC::NbExt()`
+// counts `mySqDist` while `Extrema_ExtCC::Points()` reads `mypoints`, and several branches of
+// `PrepareParallelResult` (Extrema_ExtCC.cxx) append a distance without a matching point pair, so
+// `NbExt()` over-reports and `Points()` indexes an empty `NCollection_Sequence`.
+//
+// Four fixtures, chosen to separate the shapes PrepareParallelResult actually produces (all
+// verified against Extrema_ExtCC.cxx's source, not guessed from behavior):
+//
+//   1. OVERLAPPING  - two finite parallel segments whose projected ranges overlap over a genuine
+//      interval (Delta() > Precision::Confusion()). IsParallel=1, NbExtrema=1, no point pair
+//      exists at all (there is a whole equidistant family) - crashes on stock, and correctly
+//      SHOULD refuse to answer Points(1) even after the fix: there is no single right answer.
+//   2. DISJOINT     - two finite parallel segments whose projected ranges don't overlap.
+//      PrepareParallelResult explicitly resets IsParallel=0 and returns the real nearest-endpoint
+//      pair. Never crashes, and must not change under this fix - it is the control case proving
+//      the fix doesn't regress the ordinary "parallel lines, but there IS a unique answer" path.
+//   3. UNBOUNDED    - two infinite Geom_Line's, parallel. isFirstInfinite/isLastInfinite branch:
+//      "infinite number of solutions", distance only, no point pair. Crashes on stock, same shape
+//      as case 1 but through a different branch (this is the fixture PR #730's own regression
+//      tests use).
+//   4. TOUCHING     - two finite parallel segments whose projected ranges intersect at EXACTLY one
+//      point (Delta() <= Precision::Confusion(), range not void). This is the case that makes
+//      "gate Points() on IsParallel()" the wrong general-purpose kernel fix: IsParallel() stays
+//      TRUE here (PrepareParallelResult never resets it in this branch) AND a real, unique point
+//      pair is appended and always has been reachable. Must not change under this fix, and this is
+//      exactly the shape the bridge-side IsParallel() guard (correctly, for its own narrower job)
+//      trades away: it would return empty for this case too, discarding a real answer. Not fixed
+//      here (out of scope, PR #730 owns that file) - reported so a future 2D/bridge pass has the
+//      finding on record.
+//
+// Every fixture is run through GeomAPI_ExtremaCurveCurve (the same class OCCTCurve3DExtrema calls),
+// not just the internal Extrema_ExtCC, because GeomAPI_ExtremaCurveCurve::Points() has its own
+// bounds check that is ALSO compiled to nothing under No_Exception (it uses the
+// Standard_OutOfRange_Raise_if macro, same as NCollection_Sequence::Value() does) - so this probe
+// also answers "does a real, raw `throw` inside Extrema_ExtCC::Points() survive being called
+// through a wrapper whose own guard is a no-op". LowerDistance()/SquareDistance(1) are probed too,
+// on every fixture, to confirm they are unaffected in every branch (they only ever read mySqDist,
+// which every branch populates correctly - this fix does not touch NbExt() or mySqDist at all).
+//
+// Compile and run against the pinned kernel (v2.0.0-kernel.1, no override):
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/636-extrema-parallel/probe_636.mm -o /tmp/probe_636
+//   /tmp/probe_636
+//
+// To validate the patch without a full kernel rebuild, override-link the patched
+// Extrema_ExtCC.cxx ahead of the archive - see this directory's README for the exact command,
+// which follows Scripts/patches/README.md's `#0001` entry for the technique, compiled with
+// `-DNDEBUG -DNo_Exception` to match the production build (or Raise_if comes back and this
+// measures a kernel nobody ships).
+//
+// Each case forks so a SIGSEGV in the child is reported to the parent rather than ending the run
+// (same idiom as Scripts/repro/643-geomtools-null-write/probe_643.mm's `probe()`).
+
+#include <GC_MakeSegment.hxx>
+#include <GeomAPI_ExtremaCurveCurve.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Extrema_ExtCC.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <Standard_Failure.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cerrno>
+#include <cstdio>
+#include <functional>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void probe(const char* what, const std::function<void()>& body) {
+    fflush(stdout);
+    pid_t pid = fork();
+    if (pid == 0) {
+        try { body(); }
+        catch (Standard_OutOfRange const& e) {
+            printf("      caught Standard_OutOfRange: %s\n", e.GetMessageString());
+            fflush(stdout);
+            _exit(3);
+        }
+        catch (Standard_Failure const& e) {
+            printf("      caught Standard_Failure: %s\n", e.GetMessageString());
+            fflush(stdout);
+            _exit(4);
+        }
+        catch (...) { fflush(stdout); _exit(5); }
+        fflush(stdout);
+        _exit(0);
+    }
+    if (pid < 0) {
+        printf("  %-46s fork() failed (errno %d) - not measured\n", what, errno);
+        return;
+    }
+    int st = 0;
+    if (waitpid(pid, &st, 0) < 0) {
+        printf("  %-46s waitpid() failed (errno %d) - not measured\n", what, errno);
+        return;
+    }
+    const char* verdict;
+    if (WIFSIGNALED(st)) {
+        verdict = (WTERMSIG(st) == SIGSEGV) ? "SIGSEGV (uncatchable)" : "SIGNAL (uncatchable)";
+    } else if (WEXITSTATUS(st) == 3) {
+        verdict = "Standard_OutOfRange (catchable)";
+    } else if (WEXITSTATUS(st) == 4) {
+        verdict = "Standard_Failure (catchable)";
+    } else if (WEXITSTATUS(st) == 5) {
+        verdict = "other exception (catchable)";
+    } else {
+        verdict = "returned normally";
+    }
+    printf("  %-46s %s\n", what, verdict);
+}
+
+static void runCase(const char* label,
+                     const occ::handle<Geom_Curve>& c1,
+                     const occ::handle<Geom_Curve>& c2) {
+    printf("-- %s --\n", label);
+
+    GeomAPI_ExtremaCurveCurve ext(c1, c2);
+    printf("  IsParallel()  = %d\n", (int)ext.IsParallel());
+    printf("  NbExtrema()   = %d\n", ext.NbExtrema());
+
+    probe("GeomAPI_ExtremaCurveCurve::LowerDistance()", [&] {
+        printf("      LowerDistance() = %.6f\n", ext.LowerDistance());
+    });
+    if (ext.NbExtrema() >= 1) {
+        probe("GeomAPI_ExtremaCurveCurve::SquareDistance/Distance(1)", [&] {
+            printf("      Distance(1) = %.6f\n", ext.Distance(1));
+        });
+        probe("GeomAPI_ExtremaCurveCurve::Points(1, ...)", [&] {
+            gp_Pnt p1, p2;
+            ext.Points(1, p1, p2);
+            printf("      P1=(%.3f,%.3f,%.3f) P2=(%.3f,%.3f,%.3f)\n",
+                   p1.X(), p1.Y(), p1.Z(), p2.X(), p2.Y(), p2.Z());
+        });
+
+        // Same fixture, straight through the low-level class GeomAPI_ExtremaCurveCurve wraps -
+        // confirms the defect (and the fix) sit in Extrema_ExtCC itself, not in the wrapper.
+        probe("Extrema_ExtCC::Points(1, ...) [direct, low-level]", [&] {
+            GeomAdaptor_Curve a1(c1), a2(c2);
+            Extrema_ExtCC extcc(a1, a2);
+            extcc.Perform();
+            Extrema_POnCurv p1, p2;
+            extcc.Points(1, p1, p2);
+            printf("      NbExt()=%d P1 param=%.3f P2 param=%.3f\n",
+                   extcc.NbExt(), p1.Parameter(), p2.Parameter());
+        });
+    }
+    printf("\n");
+}
+
+int main() {
+    printf("#636 Extrema_ExtCC parallel-curve ground truth\n\n");
+
+    // 1. OVERLAPPING projected ranges - finite segments, no unique closest pair exists.
+    {
+        occ::handle<Geom_TrimmedCurve> c1 = GC_MakeSegment(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Value();
+        occ::handle<Geom_TrimmedCurve> c2 = GC_MakeSegment(gp_Pnt(3, 1, 0), gp_Pnt(13, 1, 0)).Value();
+        runCase("1. OVERLAPPING projected ranges (finite, parallel)", c1, c2);
+    }
+
+    // 2. DISJOINT projected ranges - finite segments, exactly one real answer, must stay unaffected.
+    {
+        occ::handle<Geom_TrimmedCurve> c1 = GC_MakeSegment(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Value();
+        occ::handle<Geom_TrimmedCurve> c2 = GC_MakeSegment(gp_Pnt(20, 1, 0), gp_Pnt(30, 1, 0)).Value();
+        runCase("2. DISJOINT projected ranges (finite, parallel)", c1, c2);
+    }
+
+    // 3. UNBOUNDED - two infinite lines, parallel. PR #730's own fixture shape.
+    {
+        occ::handle<Geom_Line> c1 = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+        occ::handle<Geom_Line> c2 = new Geom_Line(gp_Pnt(0, 1, 0), gp_Dir(1, 0, 0));
+        runCase("3. UNBOUNDED (infinite Geom_Line, parallel)", c1, c2);
+    }
+
+    // 4. TOUCHING at exactly one point - IsParallel stays true, but a real unique pair exists.
+    {
+        occ::handle<Geom_TrimmedCurve> c1 = GC_MakeSegment(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Value();
+        occ::handle<Geom_TrimmedCurve> c2 = GC_MakeSegment(gp_Pnt(10, 1, 0), gp_Pnt(20, 1, 0)).Value();
+        runCase("4. TOUCHING at one point (finite, parallel, IsParallel stays true)", c1, c2);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Takes #636 through the kernel-patch process. PR #730 already fixed the crash bridge-side (an
`IsParallel()` guard in `OCCTCurve3DExtrema`, `Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm`) —
**that fix is not touched, undone, or duplicated here.** This PR is the kernel-level follow-through:
a prepared, upstream-bound patch plus its evidence, following the same PR1-then-PR2 pattern as
#298/#341/#344/#349/#705.

**Root cause.** `Extrema_ExtCC::NbExt()` counts `mySqDist`; `Extrema_ExtCC::Points()` reads a
different container, `mypoints`, but bounds-checks the request against `NbExt()`. Several branches
of `PrepareParallelResult` append a distance to `mySqDist` with no matching pair in `mypoints`,
because in those branches the curves are parallel over a continuous range (or unbounded) and there
genuinely is no unique closest point — only a distance. `NbExt()` reports `1` in exactly those
cases, so `Points(1)` indexes past `mypoints`' real length. `Points()`'s own bounds check is a raw
`throw`, not compiled out under `No_Exception` (this project's Release kernel is built with
`BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`) — but it checks the wrong bound, so it never fires. The check
that would actually catch it, `NCollection_Sequence::Value()`'s own `Standard_OutOfRange_Raise_if`,
*is* built from that macro and *is* compiled to nothing under `No_Exception`; with no guard left,
indexing an empty sequence walks a null node. Confirmed with a standalone binary linked against the
pinned `libOCCT-macos.a`: a genuine SIGSEGV. `GeomAPI_ExtremaCurveCurve::Points()` (what
`OCCTCurve3DExtrema` calls) has the identical shape one layer up.

**Fix.** Bounds `Points()` against `mypoints.Length()` instead of `NbExt()`:

```cpp
void Extrema_ExtCC::Points(const int N, Extrema_POnCurv& P1, Extrema_POnCurv& P2) const
{
  if (N < 1 || 2 * N > mypoints.Length())
  {
    throw Standard_OutOfRange();
  }
  P1 = mypoints.Value(2 * N - 1);
  P2 = mypoints.Value(2 * N);
}
```

**Caller survey** (the issue asked for one before choosing a shape):

- *Redefine `NbExt()` to count `mypoints`.* Rejected: `GeomAPI_ExtremaCurveCurve::LowerDistance()`
  reaches `SquareDistance(myIndex)`, which bounds against `NbExt()` too, and legitimately wants a
  value in the parallel-distance-only case (the perpendicular distance between two parallel lines is
  well-defined even with no unique closest point). Measured: `LowerDistance()` returns the identical
  value before and after this patch on every fixture. Unifying the counts would have broken it.
- *Gate `Points()` on `IsParallel()`* (what the bridge does, one layer up). Traced every branch of
  `PrepareParallelResult` by hand: `IsParallel()` is true in precisely the branches that leave
  `mypoints` empty, false in precisely the branches that populate it — equivalent to the fix made,
  *today*. Chose the container-bound version anyway: it is self-defending against the actual bug
  shape (an index into a container with fewer entries than claimed) rather than relying on a
  correspondence nothing enforces, and matches `SquareDistance()`'s own existing pattern of bounding
  against the container it reads.
- Full survey of every caller of `NbExt()`/`Points()` (including `NearestPoints()`, a second,
  independent path to the same crash with no `IsParallel()` guard of its own, not reachable through
  this bridge today but reachable from any other OCCT consumer) is in the repro README.

**Companion, behavior-neutral fix**: `Geom2dAPI_ExtremaCurveCurve::IsParallel()`, a one-line
forwarder matching its 3D sibling. The issue asked whether to include this "if it is genuinely three
lines" — it is. One correction to the issue's own framing: a caller holding only the 2D wrapper
*can* already write PR #730's guard, via the existing `Extrema().IsParallel()` accessor; the gap is
ergonomic, not a hard block. Measured (not assumed) that the 2D class needs no crash-side fix: its
`NbExtrema()` already reports `0` in the equivalent parallel case, which also closes a follow-up PR
#730 itself flagged but didn't confirm (`OCCTCurve2DAllExtrema` "is very likely the 2D sibling of
this same defect" — it is not).

**Pin consequence**: `0022` and `0023` are already outside the pinned `v2.0.0-kernel.1` asset (see
`docs/v2.0.0-plan.md`'s release watch-out). This patch, `0024`, makes three. The next kernel
rebuild's release sequence needs to carry all three and confirm each actually reached the binary,
per `docs/guides/building-occt.md`'s shipping-a-rebuild steps — not assumed from the rebuild having
run.

Ref #636. Not closing it: #730 already does, and this PR is the kernel-level follow-through it left
open, not a duplicate fix.

## Verification

- Four fixtures (finite-overlapping, finite-disjoint, unbounded, finite-touching-at-one-point),
  through both `GeomAPI_ExtremaCurveCurve` and `Extrema_ExtCC` directly. Before the patch: cases 1
  and 3 SIGSEGV (exit 139), deterministic. After: both throw a catchable `Standard_OutOfRange`;
  cases 2 and 4 (and `LowerDistance()`/`Distance()` in every case) are byte-identical before and
  after. This is the prove-the-test-fails injection/removal proof: the "stock" run is the
  defect-injected state, the "patched" run is the fix.
- Validated via **override-link, not a full kernel rebuild**: compiled the patched
  `Extrema_ExtCC.cxx` standalone with `-DNDEBUG -DNo_Exception` (matching the production build) and
  linked it ahead of the pinned archive.
- Patch confirmed to apply cleanly (`git apply --check`) to both the pinned `V8_0_1` tag and current
  upstream `master` (`b8f597c6`) — byte-identical between the two for every touched file.
- `clang-format --dry-run --Werror` against OCCT's own `.clang-format`: zero violations on all three
  changed files.
- Ran this repo's five static gate scripts locally (`Scripts/`-only change, no `Sources/`/`Tests/`
  touched): all clean.
- Full detail, transcripts, and the caller survey: `Scripts/repro/636-extrema-parallel/README.md`.

## Checklist

- [x] This is a kernel-patch/investigation deliverable (prepared but not filed upstream, per the
      task's hard constraint against touching `Open-Cascade-SAS/OCCT`). No `Sources/`/`Tests/`
      change, so there is no new Swift-visible behavior to unit-test; the override-link
      before/after transcript in `Scripts/repro/636-extrema-parallel/README.md` is the regression
      evidence, matching the pattern used by every other carried-patch PR (`0020`-`0023`).

## Notes for the reviewer

- Hard constraint honored throughout: no push, comment, edit, close, or PR/issue creation against
  `Open-Cascade-SAS/OCCT` or any fork. `draft-issue.md`/`draft-pr.md` in the repro directory are
  text only, for a human to paste. Per `okf/policies/upstream-occt-style.md` and the precedent set
  by `0018`-`0021`, the PR draft is the recommended filing; the issue draft is included only because
  this task's own instructions asked for one, and says so at its own top.
- `Libraries/occt-src` is a shared checkout (symlinked from the main repo across every worktree).
  All edits made there for validation were reverted before this PR was opened — confirmed
  `git status` clean on the touched files before finishing.
- `docs/CHANGELOG.md` is untouched per
  [`okf/policies/changelog-on-merge.md`](okf/policies/changelog-on-merge.md) (entry below instead).

## CHANGELOG entry

### Prepared the upstream kernel fix for `Extrema_ExtCC::Points()` on parallel curves (#636)

`Extrema_ExtCC::NbExt()` counts `mySqDist`; `Extrema_ExtCC::Points()` reads a different container,
`mypoints`, but bounds-checked the request against `NbExt()`. Several branches of
`PrepareParallelResult` leave a distance in `mySqDist` with no matching pair in `mypoints` (a
genuinely parallel curve pair has no unique closest point, only a distance), so `NbExt()` reported
`1` in exactly the cases `Points(1)` indexed an empty sequence — a SIGSEGV under this project's
`No_Exception` Release build, already mitigated bridge-side in PR #730. `Scripts/patches/0024-*`
bounds `Points()` against `mypoints.Length()` instead, validated via override-link against the
pinned kernel (not a full rebuild): the crash becomes a catchable `Standard_OutOfRange`, and the two
non-crashing fixtures are byte-identical before and after. Includes a companion, behavior-neutral
`IsParallel()` forwarder on `Geom2dAPI_ExtremaCurveCurve`, closing an ergonomic (not crash) gap
between the 2D and 3D wrappers. Upstream issue/PR text drafted, not filed. See
`Scripts/repro/636-extrema-parallel/`.
