### PR TITLE
fix: strip the diff3 conflict markers my resolutions left in the CHANGELOG, and gate against them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,21 @@ jobs:
         if: '!cancelled()'
         run: python3 Scripts/count-operations.py
 
+      # A hand-resolved conflict can leave a marker behind, and this repo sets
+      # merge.conflictStyle=diff3, whose `|||||||` ancestor line is exactly the one a resolver
+      # written for the default two-way style does not think to strip. Five of them reached
+      # docs/CHANGELOG.md on this branch across several merges before a reviewer noticed, because
+      # nothing was looking. grep is the whole check; the point is that something looks at all.
+      - name: no conflict markers in tracked files
+        if: '!cancelled()'
+        run: |
+          if git grep -nE '^(<<<<<<< |\|\|\|\|\|\|\| |>>>>>>> )' -- . ; then
+            echo "::error::merge conflict markers found in tracked files (see matches above)"
+            exit 1
+          fi
+          echo "no conflict markers in tracked files"
+
+
       # #726's census is the one entry here that is NOT a gate, and only its --self-test runs.
       # A gate answers "is the tree clean" and exits 1 when it is not; this answers "which sites
       # need a human to adjudicate" and exits 0 either way, so running it bare would add a step

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -78,6 +78,15 @@ run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py
 run "derive-bridge-header-split.py --self-test" Scripts/derive-bridge-header-split.py --self-test
 run "derive-bridge-header-split.py --verify"    Scripts/derive-bridge-header-split.py --verify
 run "count-operations.py"                     Scripts/count-operations.py
+
+# Not a Python gate, so it does not go through run(). merge.conflictStyle is diff3 in this repo, and
+# a resolver written for the default two-way style strips <<<<<<< / ======= / >>>>>>> and leaves the
+# ||||||| ancestor line behind. Five reached docs/CHANGELOG.md before anyone noticed.
+if git grep -nE '^(<<<<<<< |\|\|\|\|\|\|\| |>>>>>>> )' -- . ; then
+    echo ""
+    echo "--- FAIL: merge conflict markers in tracked files (listed above)"
+    failed+=("conflict-markers")
+fi
 # Self-test only. census-unmeasured-values.py is #726's census, not a gate: it exits 0 whether or
 # not it finds sites, because its output is a list for a human to adjudicate rather than a verdict.
 # Running it bare here would add a check that cannot fail. Its detector can still go blind, so that

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,9 +50,6 @@ chance to run after that cancellation signal, unlike a not-yet-started automatic
 exists to stop wasting, had not completed by the time the PR was opened. See the PR description for
 exactly what ran and what remained outstanding.
 
-||||||| d2ae082
-||||||| 133f8b1
-||||||| 2754b6d
 ### `Surface.appSurf(curves:)` rejects fewer than 2 curves instead of crashing; two sibling `GeomFill_*` null-handle guards (#644, #710)
 
 Two independent, uncatchable SIGSEGVs in `OCCTGeomFillAppSurf` (`OCCTBridge_Surface.mm`) and its
@@ -151,8 +148,6 @@ with evidence rather than implemented:
   automated gate covers arity the way `check-null-handle-guards.py` covers null handles is accurate
   and is left as a genuine, but separate, future census.
 
-||||||| abc0f32
-||||||| d0884ad
 ### `OCCTEdgeGetConvexity` replaces its hand-rolled formula with OCCT's own classifier (#723)
 
 #703 (below) fixed the face1/face2 argument-order dependence by replacing a scalar triple product


### PR DESCRIPTION
## What & why

Five literal `||||||| <sha>` lines are sitting in `docs/CHANGELOG.md` on `refactor/381-pass1b`.
They are mine. I resolved the same adjacent-entry conflict about seven times today with a filter
that dropped `<<<<<<<`, `=======` and `>>>>>>>`, and this repo sets `merge.conflictStyle=diff3`,
whose fourth marker is precisely the one a filter written for the default two-way style does not
think to exist.

**The damage is smaller than it looks.** Every ancestor block was empty, because each conflict was a
pure addition on both sides, so no stale content was duplicated. It is five stray marker lines in
published documentation, not corrupted prose. Verified before claiming it.

Found by the automated review on #733, not by us, which is the part actually worth fixing: nothing
in this repo looked for conflict markers in any file, so a resolver's blind spot could reach the
base branch and survive several more merges without anyone noticing.

## The gate

CI and the pre-commit hook now both `git grep` every tracked file for all four markers. It is a
grep; the point is not sophistication, it is that something looks at all.

Proven per `okf/policies/prove-the-test-fails.md`:

| injected | hook |
|---|---|
| `\|\|\|\|\|\|\| deadbee` | fails, names `conflict-markers` |
| `<<<<<<< HEAD` | fails |
| clean tree | passes |

It also caught me mid-fix: a `git checkout --` intended to undo an injection reverted the real
marker removal with it, and the gate refused to pass until I noticed. That is the wipes-work hazard
`okf` already records, caught by a check that did not exist an hour ago.

## CHANGELOG entry

None. Repairing the CHANGELOG itself, which is the policy's own second exception
(`okf/policies/changelog-on-merge.md`), plus CI tooling.

## Notes for the reviewer

The obvious follow-up is whether the resolution should have been automated rather than done by hand
seven times. `okf/policies/changelog-on-merge.md` and #742 exist precisely so it stops happening;
this PR cleans up the damage from before that lands.