### PR TITLE
investigate(#748): root-cause networkSurface's corner transposition (fix belongs in #741)

### DIFF
--- a/Scripts/repro/748-networksurface-corner-transpose/README.md
+++ b/Scripts/repro/748-networksurface-corner-transpose/README.md
@@ -1,0 +1,152 @@
+# #748 — the profile/guide contact grid is built transposed
+
+`GeomFill_NetworkSurface` itself is correct. `OCCTGeomFillNetworkSurface`
+(`Sources/OCCTBridge/src/OCCTBridge_Surface.mm`, currently owned by open PR #741,
+`fix/725-597-689-surface-mm` @ `c311a7b`) builds the intersection-point grid it hands the
+builder with its two axes swapped relative to what `GeomFill_NetworkSurface::Init`'s own
+`isReadyToBuild()` requires, and what a 2-profile x 2-guide fixture cannot detect because both
+axis lengths happen to be 2.
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/748-networksurface-corner-transpose/occt_748_networksurface_test.mm \
+  -o /tmp/occt_748_test
+/tmp/occt_748_test
+```
+
+## The mechanism
+
+`GeomFill_NetworkSurface.cxx`'s `isReadyToBuild()` requires:
+
+```cpp
+theIntersectionPoints.ColLength() == theGuideParameters.Length()   // guide axis
+theIntersectionPoints.RowLength() == theProfileParameters.Length() // profile axis
+```
+
+`NCollection_Array2::ColLength()` returns `NbRows()` and `RowLength()` returns `NbColumns()` (the
+names are the reverse of what they read as). So the contact grid the kernel expects has the
+**guide** index as its row and the **profile** index as its column — matching `BSplSLib::Interpolate`'s
+own documented convention (`UParameters` pairs with `ColLength`, and `theGuideParameters` is passed
+as `UParameters` at the `makeNetworkSurface` call site three lines below).
+
+`OCCTGeomFillNetworkSurface` builds it the other way round:
+
+```cpp
+// Sources/OCCTBridge/src/OCCTBridge_Surface.mm:6719-6720 (PR #741, c311a7b)
+NCollection_Array2<gp_Pnt> ipts(1, profileCount, 1, guideCount);
+NCollection_Array2<double> iwts(1, profileCount, 1, guideCount);
+...
+// :6743-6744, inside `for (i = profile) for (j = guide)`
+ipts.SetValue(i + 1, j + 1, pp);
+iwts.SetValue(i + 1, j + 1, 1.0);
+```
+
+Row = profile index, column = guide index — backwards. On the reference-surface interpolation
+(`BSplSLib::Interpolate(..., theGuideParameters, theProfileParameters, aReferencePoles, ...)`),
+the kernel reads `aReferencePoles(rowIdx, colIdx)` as "guide `rowIdx`, profile `colIdx`"; what is
+actually stored there is "profile `rowIdx`, guide `colIdx`". A cell is only correct where
+`rowIdx == colIdx` — because a profile/guide pair's own contact point does not depend on which
+name you call which curve, `profile[k] ∩ guide[k]` is the same point either way. Off that diagonal
+it is not: `aReferencePoles(1,2)` is read as `guide[0] ∩ profile[1]` but actually holds
+`profile[0] ∩ guide[1]`, a different point in general.
+
+`makeCorrectedProfileSkin` computes `Result = ProfileSkinPole + GuideSkinPole − ReferencePole`
+pole-by-pole once all three surfaces share one knot basis. Only the reference surface's poles are
+transposed (the profile and guide skins are built straight from `profs`/`gds`, never touching
+`ipts`), so the two off-diagonal output corners come out as `2 × correct − wrong`, and the two
+diagonal corners — where the swap is a no-op — are exact. That is exactly `#748`'s measured
+signature.
+
+## Reproduced bit-for-bit against the issue's own numbers
+
+`occt_748_networksurface_test.mm` ports `OCCTGeomFillNetworkSurface`'s body verbatim (`transpose =
+false`), then only the four `ipts`/`iwts` lines above (`transpose = true`), on the exact fixture
+from the issue and from PR #741's own comment thread — two straight profiles at y=0/y=10, two
+straight guides at x=0/x=10:
+
+```
+BUGGY  (as in PR #741 head): status=1 done=true
+  (u0,v0) -> (0.0000, 0.0000, 0.0000)    expected (0, 0, 0)    ok
+  (u1,v0) -> (20.0000, -10.0000, 0.0000) expected (10, 0, 0)   err=14.142136  WRONG
+  (u0,v1) -> (-10.0000, 20.0000, 0.0000) expected (0, 10, 0)   err=14.142136  WRONG
+  (u1,v1) -> (10.0000, 10.0000, 0.0000)  expected (10, 10, 0)  ok
+
+FIXED  (ipts transposed): status=1 done=true
+  (u0,v0) -> (0, 0, 0)    ok
+  (u1,v0) -> (10, 0, 0)   ok
+  (u0,v1) -> (0, 10, 0)   ok
+  (u1,v1) -> (10, 10, 0)  ok
+```
+
+`14.142136` is `sqrt(200)`, the same diagonal the issue measured, and `(-10,20,0)` /
+`(20,-10,0)` are the same point-reflections the issue reported byte for byte (`(-10,20,0) ==
+2*(0,10,0) - (10,0,0)`) — this is the same defect, not a similar one.
+
+## The second construction: a non-square grid the 2x2 case can't produce
+
+A 2-profile x 2-guide grid can never fail `isReadyToBuild()`'s dimension check on a transposed
+array, because `2 == 2` either way round. Adding one more guide (2 profiles x 3 guides, still a
+perfect bilinear-consistent network, an extra guide crossing at y=5) forces the check to actually
+discriminate the two axes:
+
+```
+--- asymmetric 2 profiles x 3 guides ---
+BUGGY  (as in PR #741 head): status=2 done=false      <- InvalidInput: dimension check finally fires
+FIXED  (ipts transposed):    status=1 done=true
+  all 4 corners + midpoint exact
+```
+
+This is exactly the corroboration [`measure-dont-assume.md`](../../../okf/policies/measure-dont-assume.md)
+asks for: a second, orthogonal construction (a shape the coincidence can't survive) that agrees
+with the first only once the real defect is fixed, and that fails loudly — not silently wrong —
+while the defect stands. It also rules out the issue's own original hypothesis (a transposition
+inside `makeProfileSkin`/`makeGuideSkin`'s pole grids): those two functions are untouched by
+`transpose` above and are independently self-consistent with `Geom_BSplineSurface`'s documented
+`Poles.ColLength() == U` / `Poles.RowLength() == V` convention — confirmed by hand-tracing both
+functions' `NCollection_Array2` construction against that convention before writing this probe.
+
+## Not a kernel defect
+
+`GeomFill_NetworkSurface.cxx` (`Libraries/occt-src/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/`)
+is internally consistent and correctly documented; nothing here is carried as a
+`Scripts/patches/` patch, and nothing is proposed upstream. This is a caller-side (bridge) axis
+mismatch, introduced when `OCCTGeomFillNetworkSurface` was rewritten for #689 (PR #741) to compute
+real per-pair contact points instead of a uniform `[0,1]` fraction — the pre-#741 code on
+`refactor/381-pass1b` built `ipts` the same way (row=profile, col=guide) but it did not matter
+there, because that code never got past `KnotAlignmentFailed` on any fixture tried (see #689's own
+investigation), so the wrong grid was never actually consumed by a successful build.
+
+## Where the fix belongs
+
+`Sources/OCCTBridge/src/OCCTBridge_Surface.mm` and `Sources/OCCTSwift/Surface.swift` are owned by
+open PR #741 (`fix/725-597-689-surface-mm`) as of this writing, so this repro deliberately does not
+patch them. The fix, once applied there, is exactly the four lines this probe's `transpose = true`
+branch demonstrates:
+
+```cpp
+// was:
+NCollection_Array2<gp_Pnt> ipts(1, profileCount, 1, guideCount);
+NCollection_Array2<double> iwts(1, profileCount, 1, guideCount);
+...
+ipts.SetValue(i + 1, j + 1, pp);
+iwts.SetValue(i + 1, j + 1, 1.0);
+
+// fix:
+NCollection_Array2<gp_Pnt> ipts(1, guideCount, 1, profileCount);
+NCollection_Array2<double> iwts(1, guideCount, 1, profileCount);
+...
+ipts.SetValue(j + 1, i + 1, pp);
+iwts.SetValue(j + 1, i + 1, 1.0);
+```
+
+`profParam`/`guideParam` (the two arrays that feed `profileParams`/`guideParams`) are unaffected —
+they are consumed locally with the same `(i + 1, j + 1)` indexing they are filled with, never
+handed to the kernel, so they carry no axis contract to violate.
+
+A corner check — the four corners of a network surface are pinned by the input curves' own
+endpoints, so the expected values need no derivation — belongs in
+`Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift` alongside that fix, in the same PR; that file is
+also part of #741's diff.

--- a/Scripts/repro/748-networksurface-corner-transpose/occt_748_networksurface_test.mm
+++ b/Scripts/repro/748-networksurface-corner-transpose/occt_748_networksurface_test.mm
@@ -1,0 +1,158 @@
+// Ground-truth reproducer for #748: GeomFill_NetworkSurface reports .done with two of
+// four corners transposed.
+//
+// Replicates OCCTGeomFillNetworkSurface (Sources/OCCTBridge/src/OCCTBridge_Surface.mm,
+// PR #741 head c311a7b) verbatim in `buggyNetworkSurface`, then a corrected version in
+// `fixedNetworkSurface` that only transposes the ipts/iwts array so its axes match what
+// GeomFill_NetworkSurface::Init's own isReadyToBuild() dimension check requires
+// (ColLength() == guideCount, RowLength() == profileCount). Everything else is identical.
+
+#include <GeomAPI_Interpolate.hxx>
+#include <GeomAPI_ExtremaCurveCurve.hxx>
+#include <GeomFill_NetworkSurface.hxx>
+#include <GeomConvert.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <TColgp_HArray1OfPnt.hxx>
+#include <NCollection_Array1.hxx>
+#include <NCollection_Array2.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cstdio>
+#include <cmath>
+
+static occ::handle<Geom_BSplineCurve> interp(std::initializer_list<gp_Pnt> pts) {
+    Handle(TColgp_HArray1OfPnt) arr = new TColgp_HArray1OfPnt(1, (int)pts.size());
+    int i = 1;
+    for (auto& p : pts) arr->SetValue(i++, p);
+    GeomAPI_Interpolate gi(arr, Standard_False, 1e-6);
+    gi.Perform();
+    occ::handle<Geom_Curve> c = gi.Curve();
+    return GeomConvert::CurveToBSplineCurve(c);
+}
+
+// Verbatim port of OCCTGeomFillNetworkSurface's body (PR #741, c311a7b), minus the C ABI
+// wrapper. `transpose` selects the ipts/iwts axis convention.
+static occ::handle<Geom_BSplineSurface> networkSurface(
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>>& profs,
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>>& gds,
+    double tolerance, GeomFill_NetworkSurface::ResultStatus& outStatus, bool transpose) {
+    int profileCount = profs.Length();
+    int guideCount = gds.Length();
+
+    NCollection_Array2<gp_Pnt> ipts(1, transpose ? guideCount : profileCount, 1, transpose ? profileCount : guideCount);
+    NCollection_Array2<double> iwts(1, transpose ? guideCount : profileCount, 1, transpose ? profileCount : guideCount);
+    NCollection_Array2<double> profParam(1, profileCount, 1, guideCount);
+    NCollection_Array2<double> guideParam(1, profileCount, 1, guideCount);
+    for (int i = 0; i < profileCount; i++) {
+        const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
+        for (int j = 0; j < guideCount; j++) {
+            const Handle(Geom_BSplineCurve)& gc = gds.Value(j + 1);
+            GeomAPI_ExtremaCurveCurve ex(pc, gc);
+            if (ex.IsParallel() || ex.NbExtrema() < 1) {
+                outStatus = GeomFill_NetworkSurface::ResultStatus::InvalidInput;
+                return nullptr;
+            }
+            gp_Pnt pp, gp;
+            ex.NearestPoints(pp, gp);
+            double pparam, gparam;
+            ex.LowerDistanceParameters(pparam, gparam);
+            if (transpose) {
+                ipts.SetValue(j + 1, i + 1, pp);
+                iwts.SetValue(j + 1, i + 1, 1.0);
+            } else {
+                ipts.SetValue(i + 1, j + 1, pp);
+                iwts.SetValue(i + 1, j + 1, 1.0);
+            }
+            profParam.SetValue(i + 1, j + 1, pparam);
+            guideParam.SetValue(i + 1, j + 1, gparam);
+        }
+    }
+
+    NCollection_Array1<double> profileParams(1, profileCount);
+    for (int i = 0; i < profileCount; i++) {
+        double sum = 0.0;
+        for (int j = 0; j < guideCount; j++) sum += guideParam.Value(i + 1, j + 1);
+        profileParams.SetValue(i + 1, sum / guideCount);
+    }
+    NCollection_Array1<double> guideParams(1, guideCount);
+    for (int j = 0; j < guideCount; j++) {
+        double sum = 0.0;
+        for (int i = 0; i < profileCount; i++) sum += profParam.Value(i + 1, j + 1);
+        guideParams.SetValue(j + 1, sum / profileCount);
+    }
+
+    GeomFill_NetworkSurface net;
+    net.Init(profs, gds, profileParams, guideParams, ipts, iwts, tolerance, false, false);
+    net.Perform();
+    outStatus = net.Status();
+    if (!net.IsDone()) return nullptr;
+    return net.Surface();
+}
+
+static void printCorner(const char* label, const occ::handle<Geom_BSplineSurface>& surf, double u, double v, double ex, double ey, double ez) {
+    gp_Pnt p = surf->Value(u, v);
+    double d = p.Distance(gp_Pnt(ex, ey, ez));
+    printf("  %-6s u=%.2f v=%.2f -> (%.4f, %.4f, %.4f)  expected (%.2f, %.2f, %.2f)  err=%.6f  %s\n",
+           label, u, v, p.X(), p.Y(), p.Z(), ex, ey, ez, d, d > 1e-6 ? "WRONG" : "ok");
+}
+
+int main() {
+    // Plain bilinear rectangle, exactly issue #748's fixture.
+    auto p1 = interp({gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)});   // profile at y=0
+    auto p2 = interp({gp_Pnt(0, 10, 0), gp_Pnt(10, 10, 0)}); // profile at y=10
+    auto g1 = interp({gp_Pnt(0, 0, 0), gp_Pnt(0, 10, 0)});   // guide at x=0
+    auto g2 = interp({gp_Pnt(10, 0, 0), gp_Pnt(10, 10, 0)}); // guide at x=10
+
+    for (bool transpose : {false, true}) {
+        NCollection_Array1<occ::handle<Geom_BSplineCurve>> profs(1, 2);
+        profs.SetValue(1, p1);
+        profs.SetValue(2, p2);
+        NCollection_Array1<occ::handle<Geom_BSplineCurve>> gds(1, 2);
+        gds.SetValue(1, g1);
+        gds.SetValue(2, g2);
+
+        GeomFill_NetworkSurface::ResultStatus status;
+        auto surf = networkSurface(profs, gds, 1e-6, status, transpose);
+        printf("%s: status=%d done=%s\n", transpose ? "FIXED  (ipts transposed)" : "BUGGY  (as in PR #741 head)",
+               (int)status, surf.IsNull() ? "false" : "true");
+        if (surf.IsNull()) continue;
+        double u0 = surf->UKnots().First(), u1 = surf->UKnots().Last();
+        double v0 = surf->VKnots().First(), v1 = surf->VKnots().Last();
+        printCorner("(u0,v0)", surf, u0, v0, 0, 0, 0);
+        printCorner("(u1,v0)", surf, u1, v0, 10, 0, 0);
+        printCorner("(u0,v1)", surf, u0, v1, 0, 10, 0);
+        printCorner("(u1,v1)", surf, u1, v1, 10, 10, 0);
+        printf("\n");
+    }
+
+    // Non-square 2 profiles x 3 guides, to force the dimension check the issue's own
+    // hypothesis wanted: with profileCount != guideCount the buggy (untransposed) build
+    // should now fail outright (a real dimension mismatch), not silently transpose.
+    printf("--- asymmetric 2 profiles x 3 guides ---\n");
+    auto p3 = interp({gp_Pnt(0, 5, 0), gp_Pnt(10, 5, 0)}); // extra guide crossing at y=5
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>> profs2(1, 2);
+    profs2.SetValue(1, p1);
+    profs2.SetValue(2, p2);
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>> gds3(1, 3);
+    gds3.SetValue(1, g1);
+    auto gmid = interp({gp_Pnt(5, 0, 0), gp_Pnt(5, 10, 0)});
+    gds3.SetValue(2, gmid);
+    gds3.SetValue(3, g2);
+    for (bool transpose : {false, true}) {
+        GeomFill_NetworkSurface::ResultStatus status;
+        auto surf = networkSurface(profs2, gds3, 1e-6, status, transpose);
+        printf("%s: status=%d done=%s\n", transpose ? "FIXED  (ipts transposed)" : "BUGGY  (as in PR #741 head)",
+               (int)status, surf.IsNull() ? "false" : "true");
+        if (surf.IsNull()) continue;
+        double u0 = surf->UKnots().First(), u1 = surf->UKnots().Last();
+        double v0 = surf->VKnots().First(), v1 = surf->VKnots().Last();
+        printCorner("(u0,v0)", surf, u0, v0, 0, 0, 0);
+        printCorner("(u1,v0)", surf, u1, v0, 10, 0, 0);
+        printCorner("(u0,v1)", surf, u0, v1, 0, 10, 0);
+        printCorner("(u1,v1)", surf, u1, v1, 10, 10, 0);
+        printCorner("(mid)", surf, (u0+u1)/2, (v0+v1)/2, 5, 5, 0);
+        printf("\n");
+    }
+    return 0;
+}


### PR DESCRIPTION
## What this is

Root-causes #748 (`GeomFill_NetworkSurface` reports `.done` with two of four corners
transposed) with a measured, reproduced-bit-for-bit mechanism. **Does not fix it** — the fix
lives in `Sources/OCCTBridge/src/OCCTBridge_Surface.mm` / `Sources/OCCTSwift/Surface.swift`,
both owned by open PR #741, which this branch must not touch per its brief. This PR adds only
`Scripts/repro/748-networksurface-corner-transpose/` (free directory) with the reproducer and
write-up, and reports the exact fix here so it can land on #741's branch.

## Root cause (measured, not the issue's own hypothesis)

The issue's own hypothesis suspected a transposition inside `GeomFill_NetworkSurface.cxx`'s
`makeProfileSkin`/`makeGuideSkin`. Hand-traced both against `Geom_BSplineSurface`'s documented
`Poles.ColLength() == U` / `Poles.RowLength() == V` convention (`NCollection_Array2::ColLength()`
returns `NbRows()`, `RowLength()` returns `NbColumns()` — the names are the reverse of what they
read as) — both functions are self-consistent and correct. **Not a kernel defect**: nothing here
touches `Libraries/occt-src`, nothing is carried as a `Scripts/patches/` entry, nothing is
proposed upstream.

The real defect is in `OCCTGeomFillNetworkSurface` (PR #741, `fix/725-597-689-surface-mm` @
`c311a7b`), lines 6719-6720 and 6743-6744:

```cpp
// Built row=profile, col=guide:
NCollection_Array2<gp_Pnt> ipts(1, profileCount, 1, guideCount);
NCollection_Array2<double> iwts(1, profileCount, 1, guideCount);
...
ipts.SetValue(i + 1, j + 1, pp);   // i = profile index, j = guide index
iwts.SetValue(i + 1, j + 1, 1.0);
```

`GeomFill_NetworkSurface::Init`'s own `isReadyToBuild()` requires the opposite:

```cpp
theIntersectionPoints.ColLength() == theGuideParameters.Length()   // row axis = guide
theIntersectionPoints.RowLength() == theProfileParameters.Length() // col axis = profile
```

matching `BSplSLib::Interpolate`'s documented `UParameters`↔`ColLength` convention (guide
parameters are passed as `UParameters` three lines below in `makeNetworkSurface`). A 2x2 fixture
can't detect the swap (both axis lengths are 2), so `isReadyToBuild()` passes and
`makeCorrectedProfileSkin`'s `Profile + Guide − Reference` sum reads the reference surface's
off-diagonal poles from the wrong cell. The two diagonal corners are a no-op under the swap
(`profile[k] ∩ guide[k]` is the same point regardless of which array axis you call which), so
they come out exact; the two off-diagonal corners come out as `2 × correct − wrong`.

## Reproduced bit-for-bit

`Scripts/repro/748-networksurface-corner-transpose/occt_748_networksurface_test.mm` ports
`OCCTGeomFillNetworkSurface`'s body verbatim, on the issue's own fixture:

```
BUGGY  (as in PR #741 head): status=1 done=true
  (u1,v0) -> (20, -10, 0)   expected (10, 0, 0)   err=14.142136  WRONG
  (u0,v1) -> (-10, 20, 0)   expected (0, 10, 0)   err=14.142136  WRONG
FIXED  (ipts/iwts axes swapped): all 4 corners exact
```

`14.142136 = sqrt(200)` and the point-reflections match the issue's own numbers exactly. A
second, orthogonal construction — 2 profiles x 3 guides, which the 2x2 coincidence can't
survive — corroborates: the buggy build now fails outright (`status=2`, `InvalidInput`, the
dimension check finally discriminating) instead of silently transposing, and the fixed build is
exact at all four corners plus the midpoint.

## The fix (for PR #741, not applied here)

```cpp
NCollection_Array2<gp_Pnt> ipts(1, guideCount, 1, profileCount);
NCollection_Array2<double> iwts(1, guideCount, 1, profileCount);
...
ipts.SetValue(j + 1, i + 1, pp);
iwts.SetValue(j + 1, i + 1, 1.0);
```

`profParam`/`guideParam` need no change — they're consumed locally with the same `(i+1,j+1)`
indexing they're filled with, never handed to the kernel.

## Does this change whether #689 can close?

**No, #689 must not close via #741 as it stands.** As of `c311a7b`, `networkSurface` reports
`.done` with 2 of 4 corners wrong on every fixture that reaches this code path, including the
PR's own `networkSurfaceBuildsASimpleBilinearPatch` test (which only ever sampled the midpoint).
That is the #726 failure class at the level of a whole surface: a confident wrong answer is worse
than the visible `KnotAlignmentFailed` failure #689 replaced. #689 can close once the fix above
(or an equivalent) lands in #741 and a corner check is in place to guard it — the four corners are
pinned by the input curves' own endpoints, so that test needs no tolerance argument and no
derivation. Recommend it land in `Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift` in the same PR,
since that file is already part of #741's diff.

## Verification

- `python3 Scripts/check-bridge-index.py` / `check-null-handle-guards.py` /
  `check-docs-defaults.py` / `derive-bridge-header-split.py --verify` / `count-operations.py`:
  all clean (no bridge/doc changes in this PR).
- Reproducer compiled and run against the shipped `Libraries/OCCT.xcframework`, both the buggy
  and fixed variant, on both fixtures (see README for full transcript).

## CHANGELOG entry

None — no shipped behavior changes in this PR (investigation + repro only, no code fix).

## SemVer impact

None — no public API or behavior change.

Closes: none (root-cause only; #748 stays open until #741 carries the fix)