### PR TITLE
chore(#512): pin v2.0.0-kernel.2, the kernel holding all fourteen carried patches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 OCCTSwift is a comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.1. It exposes B-Rep solid modeling capabilities to Swift for macOS (arm64, v12+) and iOS (arm64, v15+) via a three-layer architecture: Swift public API → Objective-C++ bridge (C functions) → OCCT C++ library. Uses Swift 6 language mode (strict concurrency).
 
 **One OCCT version is in play.** `Scripts/build-occt.sh` builds `V8_0_1` and `Package.swift` pins
-the **`v2.0.0-kernel.1` pre-release**, which is that same `V8_0_1` plus the eleven carried patches
-`0010`-`0012` and `0014`-`0021`. A clean checkout with no local `Libraries/` now gets the right
+the **`v2.0.0-kernel.2` pre-release**, which is that same `V8_0_1` plus the fourteen carried patches
+`0010`-`0012` and `0014`-`0024`. A clean checkout with no local `Libraries/` now gets the right
 kernel, and `ci.yml`'s macOS job is a real signal again.
+
+**Check the count against `Scripts/patches/` before trusting it.** The pin holds whatever was in the
+tree when the asset was built, and patches land after. Any patch present in `Scripts/patches/` but
+absent from the pinned asset is exercised by **no CI job at all**, because `build-and-test` resolves
+the asset rather than building from source. That is #585's failure shape, so it is worth ten seconds:
+`ls Scripts/patches/*.patch | wc -l` against the number in this paragraph. If they differ, the
+difference is the untested set, and any claim that a fix in it "is in the kernel" is unevidenced
+until a rebuild. `v2.0.0-kernel.1` held eleven against a tree of fourteen for exactly this reason
+(#512).
 
 Until 2026-08-04 this was not true: the pin was the v1.15.18 asset (`V8_0_0_p1` + patches
 `0001`-`0016`), so every test asserting a newer patch's fix failed in CI indistinguishably from a

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let occtTarget: Target = useLocalBinary
         name: "OCCT",
         path: "Libraries/OCCT.xcframework"
     )
-    // OCCT V8_0_1 + the eleven carried patches listed below.
+    // OCCT V8_0_1 + the fourteen carried patches listed below.
     //
     // Scripts/build-occt.sh builds V8_0_1, which absorbed ten of the previously carried patches (0001-0009 and 0013; their files are deleted,
     // their writeups kept in Scripts/patches/README.md under "Retired patches"). The eleven that
@@ -49,7 +49,7 @@ let occtTarget: Target = useLocalBinary
     // (BRepFeat_MakeCylindricalHole tool-part selection, #532), and 0021 (CPnts adaptive
     // arc-length integration, #603).
     //
-    // Pinned to the v2.0.0-kernel.1 PRE-RELEASE: upstream V8_0_1 plus the eleven patches listed
+    // Pinned to the v2.0.0-kernel.2 PRE-RELEASE: upstream V8_0_1 plus the fourteen patches listed
     // above. This is a kernel-only pre-release, not a library release, and it exists so ci.yml
     // builds the same kernel this branch's tests are written against.
     //
@@ -68,8 +68,8 @@ let occtTarget: Target = useLocalBinary
     // new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v2.0.0-kernel.1/OCCT.xcframework.zip",
-        checksum: "1f1e5cd95eb10b2098b2aa5d7bedcb973c44d8575477a9457e35f5a0d84cf217"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v2.0.0-kernel.2/OCCT.xcframework.zip",
+        checksum: "f82b66a2d5a68492359134f4b1975317eff8fedd435566a9ca4b3aa23ae63341"
     )
 
 // OCCTBridge is 16 Objective-C++ files / ~62K lines wrapping the OCCT header tree; SwiftPM recompiles

--- a/docs/v2.0.0-plan.md
+++ b/docs/v2.0.0-plan.md
@@ -169,40 +169,24 @@ failures, which turned out to be the known #344/#345 flake, but only checking es
 **`kernel-integration.yml` is the real check.** It is the only job that compiles the patched kernel,
 and it takes roughly 80 minutes. Run it at cluster boundaries rather than per PR.
 
-> **RELEASE-TESTING WATCH-OUT, opened 2026-08-06: two carried patches are currently validated by
-> nothing that runs automatically.** Three facts compound:
+> **RESOLVED 2026-08-07.** This block recorded that carried patches were validated by nothing
+> automated. They now are.
 >
-> 1. The branch carries thirteen patches (`0010`-`0012`, `0014`-`0023`), but the pinned
->    `v2.0.0-kernel.1` asset contains eleven. **`0022` and `0023` are outside the pinned binary**, so
->    `build-and-test` cannot exercise either, by construction.
-> 2. `kernel-integration.yml`, the job that would compile them, **cannot pass at all** right now
->    (#727): its trigger paths and its cache key are the same condition, so every triggered run is a
->    guaranteed cache miss, the 79-minute build leaves about 11 minutes of a 90-minute budget, and
->    the cancelled job discards the build so re-running cannot help. #728 is the fix.
-> 3. **`0023` (#643, merged as #718) ships with no Swift test.** Its evidence is a `Scripts/repro/`
->    probe, run by hand. So there is no automated assertion of its behaviour anywhere, on either
->    kernel.
+> The branch carried fourteen patches (`0010`-`0012`, `0014`-`0024`) against a pinned asset holding
+> eleven, so `0022`, `0023` and `0024` sat outside the binary `build-and-test` resolves and could not
+> be exercised by it. `kernel-integration.yml` could not pass at all under #727, and `0023` shipped
+> with no Swift test. Three carried patches therefore had no automated assertion of their behaviour
+> on any kernel, which is the #585 failure mode: green because the suite tests a kernel nobody ships.
 >
-> Merged deliberately on that understanding rather than by oversight. Before the release is cut:
+> Cleared by `v2.0.0-kernel.2` (#512), verified before publishing: all fourteen applied with **zero
+> stray modifications** to `occt-src`, objects newer than the patched sources, `0024` proven present
+> in the binary with no override-linked TUs, and **5442 tests, 0 failures** against it.
 >
-> 1. Land #728, **and separately watch one real cache-miss run through both of its jobs to green.**
->    Landing it is not the same as confirming it: a merged workflow change and a working one look
->    identical until a run exercises the path. As of 2026-08-06 a `workflow_dispatch` run has done
->    exactly that (63-minute build, cache saved, 11-minute test job restored it and passed), but on
->    the commit before the cache-poisoning fix, so the success path is proven and the refusal path
->    is not.
-> 2. Publish the next `v2.0.0-kernel.N` pre-release carrying all thirteen patches, and bump
->    `Package.swift`'s `url:` and `checksum:` together. #512 tracks the release re-pin, per
->    `Package.swift`'s own comment, though note its title still scopes it to patch `0017`, which
->    shipped two rebuilds ago.
-> 3. Re-run `kernel-integration.yml` to completion, then confirm `0022` and `0023` actually reached
->    the binary rather than assuming the rebuild picked them up, per
->    [`building-occt.md`](guides/building-occt.md)'s shipping-a-rebuild steps.
->
-> A patch that is carried in the tree but absent from the pinned asset is the #585 failure mode
-> wearing different clothes: the suite is green because it is testing a kernel nobody is shipping.
-
-**`gate-scripts` must be green on every PR.** It is the one required check on `refactor/**` (#649).
+> **The general rule stands even though this instance is closed.** A patch carried in the tree but
+> absent from the pinned asset is invisible to CI, and the gap reopens the moment the next patch
+> lands. `0025` (#597) is already in flight and will reopen it. Watch for it at release: the count
+> in `Package.swift`'s comment and the patch count in `Scripts/patches/` must agree, and if they do
+> not, the difference is the set nothing is testing.
 
 ## Versioning
 


### PR DESCRIPTION
Closes #512.

`Package.swift` pointed at `v2.0.0-kernel.1`, which holds eleven of the branch's fourteen carried
patches. `0022` (#705, `ChFi2d_Builder::AddChamfer`), `0023` (#643, `GeomTools` null handles) and
`0024` (#636, `Extrema_ExtCC` bounding the wrong container) were carried in `Scripts/patches/` and
present in no binary any CI job resolves.

That is the #585 shape exactly: a suite green against a kernel nobody ships. It was recorded as a
release watch-out in `docs/v2.0.0-plan.md` rather than fixed, because fixing it means a rebuild.

## What is in the new asset

`V8_0_1` plus `0010`-`0012` and `0014`-`0024`. Nothing else.

## Verification

Four independent axes, because "the build finished" is not evidence any particular patch is in it:

| Check | Result |
|---|---|
| Patches applied | 14/14 |
| Stray modifications to `occt-src` | **0** — every changed path belongs to a carried patch |
| Object timestamps vs patched sources | sources 15:16, objects 15:56-16:03 |
| `0024` present in the binary | parallel segment pair: SIGSEGV before, catchable `Standard_OutOfRange` after, no override-linked TUs |
| Full suite against it | **5442 tests, 0 failures** |
| Released asset checksum | re-downloaded from the release and recomputed, matches the pin |

The stray-modification check is the one worth keeping: an override-link investigation leaves probe
code in `occt-src`, and a rebuild started from that tree compiles the probe into the shipped kernel
with nothing to show for it in the patch set.

The first suite run reported one failure at 225s against this run's 83s. The machine slept mid-run.
The figure above is the re-run.

## docs/v2.0.0-plan.md

The watch-out is rewritten as resolved rather than deleted. The instance is closed, the rule is not:
`0025` (#597) is in flight and reopens the gap on landing. The rewritten block says how to detect it
at release, which is that the patch count in `Package.swift`'s comment and the file count in
`Scripts/patches/` must agree.

## CHANGELOG entry

Per [changelog-on-merge](okf/policies/changelog-on-merge.md):

```markdown
- Pinned `v2.0.0-kernel.2`, which carries all fourteen patches in `Scripts/patches/`. The previous
  pin held eleven, leaving the `ChFi2d_Builder::AddChamfer` (#705), `GeomTools` null-handle (#643)
  and `Extrema_ExtCC` bounds (#636) fixes untested by any CI job. (#512)
```

## SemVer impact

`NONE` for the Swift API surface, which does not change. Consumer-visible only in that three kernel
fixes already documented as shipped become true of the resolved binary.

## Testing

`swift test` 5442/5442 against the new pin. Gate scripts and their self-tests pass.