### PR TITLE
chore(#755): re-cut carried patch 0018 for OCCT#1417's review

### DIFF
--- a/Scripts/patches/0018-GCPnts-degenerate-count-and-duplicate-end-point-555.patch
+++ b/Scripts/patches/0018-GCPnts-degenerate-count-and-duplicate-end-point-555.patch
@@ -1,24 +1,26 @@
 diff --git a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx
-index 4cccafa0..b0250f3f 100644
+index 4cccafa0..8da83102 100644
 --- a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx
 +++ b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx
-@@ -130,6 +130,14 @@ void GCPnts_QuasiUniformAbscissa::initialize(const TheCurve& theC,
-   Standard_ConstructionError_Raise_if(
-     theNbPoints <= 1,
-     "GCPnts_QuasiUniformAbscissa::Initialize(), number of points should be >= 2");
+@@ -127,9 +127,13 @@ void GCPnts_QuasiUniformAbscissa::initialize(const TheCurve& theC,
+     return;
+   }
+
+-  Standard_ConstructionError_Raise_if(
+-    theNbPoints <= 1,
+-    "GCPnts_QuasiUniformAbscissa::Initialize(), number of points should be >= 2");
 +  if (theNbPoints <= 1)
 +  {
-+    // The check above is compiled out in a build defining No_Exception. Without this the code
-+    // below stores into myParams, which is allocated empty for such a count.
++    // Not-done in every build, independent of whether No_Exception is defined.
 +    myDone     = false;
 +    myNbPoints = 0;
 +    return;
 +  }
- 
+
    // evaluate the approximative length of the 3dCurve
    myNbPoints           = theNbPoints;
 diff --git a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx
-index 64b5a983..1f6e1094 100644
+index 64b5a983..068bf955 100644
 --- a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx
 +++ b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx
 @@ -94,7 +94,8 @@ static bool Perform(NCollection_Array1<double>& theParameters,
@@ -27,33 +29,32 @@ index 64b5a983..1f6e1094 100644
                      int&                        theNbPoints,
 -                    const double                theEPSILON)
 +                    const double                theEPSILON,
-+                    const double                theTol3d)
++                    const double                theTol)
  {
    bool   isLocalDone = true;
    double aUU1 = std::min(theU1, theU2), aUU2 = std::max(theU1, theU2);
-@@ -104,6 +105,7 @@ static bool Perform(NCollection_Array1<double>& theParameters,
+@@ -104,6 +105,8 @@ static bool Perform(NCollection_Array1<double>& theParameters,
    double aDelta  = (theAbscissa / theTotalLength) * (aUU2 - aUU1);
    int    anIndex = 1;
    theParameters.SetValue(anIndex, aUU1);
 +  const typename GCPnts_TCurveTypes<TheCurve>::Point aPEnd = theC.Value(aUU2);
++  const double aTol2 = theTol * theTol;
    for (bool isNotDone = true; isNotDone;)
    {
      double aUi = theParameters.Value(anIndex) + aDelta;
-@@ -125,7 +127,12 @@ static bool Perform(NCollection_Array1<double>& theParameters,
+@@ -125,7 +128,10 @@ static bool Perform(NCollection_Array1<double>& theParameters,
      {
        anIndex += 1;
        aUi = anAbscissaFinder.Parameter();
 -      if (std::abs(aUi - aUU2) <= theEPSILON)
-+      // theEPSILON is a parametric tolerance obtained from theTol3d through Resolution(),
-+      // which converts using the curve's largest derivative; where the local derivative is
-+      // much smaller it is far too tight. Also accept a point that coincides with the end
-+      // within theTol3d, otherwise the walk takes one more step and appends a duplicate.
++      // theEPSILON is a parametric tolerance derived from theTol via Resolution(), which can be
++      // far tighter than theTol locally; also accept a point within theTol of the end in 3D.
 +      if (std::abs(aUi - aUU2) <= theEPSILON
-+          || (aUU2 - aUi < aDelta && theC.Value(aUi).Distance(aPEnd) <= theTol3d))
++          || (aUU2 - aUi < aDelta && theC.Value(aUi).SquareDistance(aPEnd) <= aTol2))
        {
          theParameters.SetValue(anIndex, aUU2);
          isNotDone = false;
-@@ -437,7 +444,8 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
+@@ -437,7 +443,8 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
                         theU2,
                         aL,
                         myNbPoints,
@@ -63,20 +64,24 @@ index 64b5a983..1f6e1094 100644
        break;
      }
    }
-@@ -497,6 +505,12 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
-     "GCPnts_UniformAbscissa::Initialize() - number of points should be >= 2");
+@@ -492,11 +499,13 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
+                                         const double    theU2,
+                                         const double    theTol)
+ {
+-  Standard_ConstructionError_Raise_if(
+-    theNbPoints <= 1,
+-    "GCPnts_UniformAbscissa::Initialize() - number of points should be >= 2");
    myNbPoints = 0;
    myDone     = false;
 +  if (theNbPoints <= 1)
 +  {
-+    // The check above is compiled out in a build defining No_Exception, and the abscissa below
-+    // would be computed from a zero or negative divisor.
++    // Not-done in every build, independent of whether No_Exception is defined.
 +    return;
 +  }
- 
+
    const double anEPSILON = theC.Resolution(std::max(theTol, Precision::Confusion()));
    // although very similar to Initialize with Abscissa this avoid
-@@ -550,7 +564,8 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
+@@ -550,7 +559,8 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
                         theU2,
                         aL,
                         myNbPoints,

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -214,13 +214,49 @@ See [`Scripts/repro/484-null-reshape-context/`](https://github.com/SecondMouseAU
 
 2. **A point count below 2 stores out of bounds.** Both classes document `theNbPoints >= 2` and enforce it with `Standard_ConstructionError_Raise_if`, which compiles to nothing under `No_Exception`, how the shipped Release kernel is built (see `0016`'s neighbour issue #487). `GCPnts_QuasiUniformAbscissa`'s Bezier/BSpline branch then allocates `new NCollection_HArray1<double>(1, theNbPoints)`, an empty range for such a count, and the next statement is an unconditional `myParams->SetValue(1, theU1)`. `SetValue`'s own bounds check is a `Raise_if` too, so the store lands out of bounds: uncatchable SIGSEGV, same class as `0001`/#263, `0004`/#310, `0005`/#317 and `0006`/#318.
 
-**Fix:** for the second, an ordinary `if` after each `Raise_if`, leaving the object not done for a count below 2. The `Raise_if` stays, so a build with exceptions enabled throws exactly as before; this only stops the undefined behaviour where the check is compiled out. Applied to both classes, since `GCPnts_UniformAbscissa` had the same missing precondition without the crash (it answered a request for zero points with five). For the first, `Perform` also accepts a point that coincides with the end **in 3D** within the caller's tolerance, not only one close in parameter: the 3D tolerance is threaded in alongside the parametric one, the end point is evaluated once outside the walk, and the distance test sits behind a cheap `aUU2 - aUi < aDelta` gate so it runs on the final step rather than every step. Keeping the exact end parameter is the point: clamping `myNbPoints` to the request, the other obvious fix, would drop it and leave the distribution stopping short of the curve.
+**Fix:** for the second, an ordinary `if` that **replaces** each `Raise_if` (not one added alongside
+it), leaving the object not done for a count below 2 in every build, not only one that defines
+`No_Exception`. Applied to both classes, since `GCPnts_UniformAbscissa` had the same missing
+precondition without the crash (it answered a request for zero points with five). For the first,
+`Perform` also accepts a point that coincides with the end **in 3D** within the caller's tolerance,
+not only one close in parameter: the tolerance is threaded in alongside the parametric one, squared
+once outside the loop, and compared with `SquareDistance()` rather than `Distance()` on every
+candidate step; the end point is evaluated once outside the walk, and the distance test sits behind
+a cheap `aUU2 - aUi < aDelta` gate so it runs on the final step rather than every step. Keeping the
+exact end parameter is the point: clamping `myNbPoints` to the request, the other obvious fix, would
+drop it and leave the distribution stopping short of the curve.
 
 No public API signature changes.
 
+**Revised 2026-08-07 (#755), patch content above updated in place, not a new patch number.**
+Maintainer gkv311 [reviewed the upstream PR](https://github.com/Open-Cascade-SAS/OCCT/pull/1417#issuecomment-3150937)
+with three requests. Two were mechanical (`SquareDistance()`/hoisted tolerance instead of `Distance()`
+in the loop; the `Perform` parameter renamed `theTol3d` to `theTol`, since the same template also
+instantiates on `Adaptor2d_Curve2d`, where "3d" was simply wrong). The third needed a decision, not
+just compliance: he offered two ways to stop duplicating `Standard_ConstructionError_Raise_if`, an
+assert-grade macro meant to compile away under `No_Exception`: (a) replace it with an unconditional
+`throw`, or (b) drop the duplicate and answer not-done unconditionally. We build with
+`BUILD_RELEASE_DISABLE_EXCEPTIONS=ON` (`No_Exception` defined), so (a) would start throwing for a
+degenerate count in our own build where it currently cannot, and (b) would not. Measured rather than
+guessed: every one of the 9 bridge call sites that construct either class with a caller-supplied count
+(one of them a shared static helper with 2 further callers, 11 total) already wraps the construction
+in `catch (...)`, and `Issue558SamplingCountBoundsTests.swift` asserts the not-done/empty-result
+contract for exactly this input across every one of those entry points, so both options are
+observably identical for OCCTSwift's own contract. Chose **(b)**: it is the option that does not
+depend on a build flag, and it is what #555 argued for in the first place, a silent not-done rather
+than an exception. Confirmed directly by compiling both variants **without** `No_Exception` and
+constructing each class with a degenerate count: the pre-review patch still throws
+`Standard_ConstructionError` there (exceptions enabled, so the un-replaced `Raise_if` fires);
+after this revision, neither class throws in either build configuration. Re-ran the full
+232/6766-configuration equivalence sweep and the degenerate-count sweep (5 curve types, both
+classes, counts `{0, 1, -3}`) against the revised patch, override-linked with production flags: both
+verdicts unchanged from the numbers below.
+
 **Validation** (fast path, no full rebuild, see the `#0001` entry above for the override-link technique, but compile the two TUs with `-DNDEBUG -DNo_Exception` to match the production build, or the `Raise_if` comes back and the measurement is of a kernel nobody ships): across 17 curve types and counts 2 to 200, 6766 configurations, **232 lines change and they are exactly the 232 that were over-requesting**; every other line is byte-identical, and on the changed lines the last parameter is still exactly the end. Over-request goes to 0, and every degenerate count on every curve returns `IsDone() == false` for both classes. Confirmed against the rebuilt xcframework with no override-linked TUs, matching the override-linked prediction byte for byte. Full `swift test` (4842 tests / 1346 suites) clean.
 
-See [`Scripts/repro/555-gcpnts-count-contract/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/555-gcpnts-count-contract) for the reproducers and full writeup. Filed upstream as [Open-Cascade-SAS/OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417), a fix PR with no companion repro issue, per upstream's own guidance on [OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409#issuecomment-5124395058). Based on `b8f597c6`; the two touched files are byte-identical between upstream `master` and our `V8_0_0_p1` pin, so the patch is the same change on both.
+See [`Scripts/repro/555-gcpnts-count-contract/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/555-gcpnts-count-contract) for the reproducers and full writeup, and
+[`Scripts/repro/555-gcpnts-count-contract/upstream/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/555-gcpnts-count-contract/upstream)
+for the prepared post-review commit and the drafted reply. Filed upstream as [Open-Cascade-SAS/OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417), a fix PR with no companion repro issue, per upstream's own guidance on [OCCT#1409](https://github.com/Open-Cascade-SAS/OCCT/issues/1409#issuecomment-5124395058). Based on `b8f597c6`; the two touched files are byte-identical between upstream `master` and our `V8_0_0_p1` pin, so the patch is the same change on both.
 
 **Retire** once the bundled OCCT includes this fix.
 

--- a/Scripts/repro/555-gcpnts-count-contract/README.md
+++ b/Scripts/repro/555-gcpnts-count-contract/README.md
@@ -157,6 +157,11 @@ where it currently cannot. Measured before choosing:
   inside `try { ... } catch (...) { return 0/nullptr/false; }`.
 - `Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift` asserts the not-done/empty-result
   contract for a count of 1 (and 0, -1, past-ceiling) across every one of those entry points.
+- Nothing in the kernel itself calls the count-based `initialize()` with an unvalidated count either:
+  grepped `Libraries/occt-src/src` for both classes outside their own `GCPnts` package. 5 production
+  call sites and 1 Draw test command all hardcode the count or clamp/reject it first
+  (`std::max(2, aNbPoints)`, `std::max(3, aNbSamplePoints)`, `if (aSrcNbPnts < 2) { ...; return 1;
+  }`, or a literal like `N = 40`).
 
 So an exception and a not-done result produce the identical Swift-visible answer today, through the
 existing `catch (...)`. Chose the not-done option: it does not depend on `No_Exception` being defined

--- a/Scripts/repro/555-gcpnts-count-contract/README.md
+++ b/Scripts/repro/555-gcpnts-count-contract/README.md
@@ -64,15 +64,21 @@ points with five is not a defensible result.
 
 `Scripts/patches/0018-GCPnts-degenerate-count-and-duplicate-end-point-555.patch`.
 
-- **Defect 2**: an ordinary `if` after each `Raise_if`, leaving the object not done for a count below
-  2. The `Raise_if` stays, so a build with exceptions enabled still throws exactly as before; this
-  only stops the undefined behaviour in builds where the check is compiled out. Applied to both
+- **Defect 2**: an ordinary `if` that replaces each `Raise_if`, leaving the object not done for a
+  count below 2 in every build, not only one where the check is compiled out. Applied to both
   classes, since `GCPnts_UniformAbscissa` had the same missing precondition without the crash.
+  (Revised 2026-08-07, #755: the first version of this patch left `Raise_if` in place and added a
+  duplicate `if` after it, so a build with exceptions enabled still threw. Upstream review pointed
+  out the duplication; see "Upstream review" below for why replacing it outright was the right
+  choice for a build that defines `No_Exception`, which is how this project ships.)
 - **Defect 1**: `Perform` also accepts a point that coincides with the end **in 3D** within the
-  caller's tolerance, not only one that is close in parameter. The 3D tolerance is threaded in
-  alongside the parametric one, the end point is evaluated once outside the walk, and the distance
-  test is gated behind a cheap `aUU2 - aUi < aDelta` check so it runs on the final step rather than
-  every step.
+  caller's tolerance, not only one that is close in parameter. The tolerance is threaded in
+  alongside the parametric one, squared once outside the loop, and compared with `SquareDistance()`
+  rather than `Distance()` on every candidate step (revised 2026-08-07 per the same review; the
+  parameter is also named `theTol` rather than `theTol3d`, since `Perform` also instantiates on
+  `Adaptor2d_Curve2d`). The end point is evaluated once outside the walk, and the distance test is
+  gated behind a cheap `aUU2 - aUi < aDelta` check so it runs on the final step rather than every
+  step.
 
 Nothing in either class' public API changes. Filed upstream as
 [Open-Cascade-SAS/OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417).
@@ -132,3 +138,38 @@ Compiling the override TUs **without** `-DNo_Exception` makes the `Raise_if` liv
 cases then abort with an uncaught `Standard_ConstructionError` instead of either crashing (stock) or
 returning not-done (patched), which looks like a patch that broke something. Match the production
 defines, or the measurement is of a build that does not exist.
+
+## Upstream review (#755)
+
+Maintainer gkv311 [reviewed the PR](https://github.com/Open-Cascade-SAS/OCCT/pull/1417#issuecomment-3150937)
+and asked for three changes. Two were mechanical: `SquareDistance()` against a tolerance squared once
+outside the loop, instead of `Distance()` inside it; and `theTol3d` renamed to `theTol`, since `Perform`
+also instantiates on `Adaptor2d_Curve2d`. The third needed a decision: replacing the duplicated
+`Standard_ConstructionError_Raise_if` with an unconditional `throw`, or with an unconditional not-done.
+
+We build with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON` (`No_Exception` defined), so this was not
+cosmetic for us: an unconditional `throw` would start raising for a degenerate count in our own build,
+where it currently cannot. Measured before choosing:
+
+- Every bridge call site that constructs `GCPnts_UniformAbscissa`/`GCPnts_QuasiUniformAbscissa` with a
+  caller-supplied count (9 direct construction sites across `OCCTBridge_Curve3D.mm` and
+  `OCCTBridge_Geom2d.mm`, one of them a shared `static` helper with 2 further callers) is already
+  inside `try { ... } catch (...) { return 0/nullptr/false; }`.
+- `Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift` asserts the not-done/empty-result
+  contract for a count of 1 (and 0, -1, past-ceiling) across every one of those entry points.
+
+So an exception and a not-done result produce the identical Swift-visible answer today, through the
+existing `catch (...)`. Chose the not-done option: it does not depend on `No_Exception` being defined
+(a single behaviour in every build, rather than two depending on a compile flag), and it is what #555
+argued for originally. Confirmed directly, not assumed: compiled both the pre-review and the revised
+patch **without** `No_Exception` and constructed each class with a degenerate count: the pre-review
+patch still threw `Standard_ConstructionError` there (the un-replaced `Raise_if` is live without
+`No_Exception`); the revised patch throws in neither build configuration.
+
+Re-ran both reproducers against the revised patch, override-linked with production flags
+(`-DNDEBUG -DNo_Exception`): `repro_555_count.mm` and `repro_555_equivalence.mm` both report the same
+numbers as "Results" above, byte for byte.
+
+See [`upstream/`](upstream/) for the prepared post-review commit
+(`0001-gcpnts-review-fixes.patch`, `git am`-verified) and the drafted reply
+(`reply-to-gkv311.md`), neither pushed nor posted; see #755.

--- a/Scripts/repro/555-gcpnts-count-contract/upstream/0001-gcpnts-review-fixes.patch
+++ b/Scripts/repro/555-gcpnts-count-contract/upstream/0001-gcpnts-review-fixes.patch
@@ -1,0 +1,162 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: gsdali <51393997+gsdali@users.noreply.github.com>
+Date: Fri, 7 Aug 2026 08:42:00 +0000
+Subject: [PATCH] Modeling Data - Fix GCPnts arc-length sampler point counts
+
+GCPnts_UniformAbscissa::NbPoints() is not bounded by the requested count. initialize()
+sizes myParams at theNbPoints + 5 and the walk fills it until it reaches the end
+parameter or runs out of room, so a caller that sizes its own buffer from the requested
+count rather than from NbPoints() is handed more points than it asked for.
+GCPnts_QuasiUniformAbscissa inherits this for every curve that is neither Bezier nor
+BSpline, since it forwards to GCPnts_UniformAbscissa for those, so the same class
+returns exactly theNbPoints on a Bezier and possibly more on an ellipse.
+
+The cause is a tolerance mismatch. Perform() terminates on
+abs(aUi - aUU2) <= theEPSILON, where theEPSILON is theC.Resolution(theTol): a parametric
+tolerance derived from a 3D one using the curve's largest derivative. On an ellipse with
+major radius 1e6 and minor radius 1e-3 that is about 1e-13, while the local derivative
+at the end of that curve is 1e-3, so the parametric tolerance actually corresponding to
+1e-7 in 3D there is about 1e-4. The walk stops 1.557e-08 short of the end, does not
+treat that as done, takes one more step and snaps it to the end. The appended point is a
+duplicate: 1.175e-10 from its neighbour in 3D. On that curve, 22 of the counts from 2 to
+60 return one point more than requested.
+
+- Perform() also accepts a point that coincides with the end within the caller's 3D
+  tolerance, not only one that is close in parameter. The tolerance is squared once,
+  outside the loop, and compared against SquareDistance() rather than calling Distance()
+  on every iteration; the parameter is named theTol rather than theTol3d, since Perform()
+  also instantiates on Adaptor2d_Curve2d. The end point is evaluated once before the
+  walk, and the distance test is gated behind aUU2 - aUi < aDelta so it runs on the final
+  step rather than on every step.
+
+Clamping myNbPoints to theNbPoints was the other option and is worse: the surplus point
+is the one carrying the exact end parameter, so clamping leaves the distribution
+stopping short of the curve.
+
+Separately, a point count below 2 stores out of bounds. Both classes document
+theNbPoints >= 2 and previously enforced it with Standard_ConstructionError_Raise_if,
+which compiles to nothing when No_Exception is defined, as it is for Release builds
+with BUILD_RELEASE_DISABLE_EXCEPTIONS. GCPnts_QuasiUniformAbscissa::initialize() then
+allocates NCollection_HArray1<double>(1, theNbPoints), an empty range for such a count,
+and the next statement is an unconditional myParams->SetValue(1, theU1). SetValue()'s own
+bounds check is a Raise_if too, so the store lands out of bounds. Reproduced on a 4-pole
+Bezier and an 8-point BSpline fit with theNbPoints = 0 and with a negative count.
+
+- Both classes now leave the object not done for a count below 2 by construction, not by
+  a macro that a build configuration can compile away: the ordinary if replaces
+  Standard_ConstructionError_Raise_if rather than duplicating its condition alongside it,
+  so the result is the same whether or not No_Exception is defined. GCPnts_UniformAbscissa
+  had the same missing precondition without the out-of-bounds store, answering a request
+  for zero points with five, and is guarded the same way.
+
+No public API signature changes.
+
+Measured across 17 curve types (line, circles of radius 1e-6 to 1e7, two ellipses,
+hyperbola, parabola, two Beziers, two BSplines, two offsets, a trimmed circle) and counts
+2 to 200 for both classes, 6766 configurations: 232 results change from the unpatched
+baseline and they are exactly the 232 that were returning more points than requested.
+Every other result is identical parameter for parameter, and on the changed ones the
+last parameter is still exactly the end. Re-measured after the count-below-2 guard
+stopped duplicating Standard_ConstructionError_Raise_if: identical 232/6766, and a
+degenerate count now answers IsDone() == false in every build rather than only when
+No_Exception is defined.
+---
+ .../TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx    | 10 +++++++---
+ .../TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx         | 24 +++++++++++++++-------
+ 2 files changed, 24 insertions(+), 10 deletions(-)
+
+diff --git a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx
+index 4cccafa0..8da83102 100644
+--- a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx
++++ b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_QuasiUniformAbscissa.cxx
+@@ -127,9 +127,13 @@ void GCPnts_QuasiUniformAbscissa::initialize(const TheCurve& theC,
+     return;
+   }
+
+-  Standard_ConstructionError_Raise_if(
+-    theNbPoints <= 1,
+-    "GCPnts_QuasiUniformAbscissa::Initialize(), number of points should be >= 2");
++  if (theNbPoints <= 1)
++  {
++    // Not-done in every build, independent of whether No_Exception is defined.
++    myDone     = false;
++    myNbPoints = 0;
++    return;
++  }
+
+   // evaluate the approximative length of the 3dCurve
+   myNbPoints           = theNbPoints;
+diff --git a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx
+index 64b5a983..068bf955 100644
+--- a/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx
++++ b/src/ModelingData/TKGeomBase/GCPnts/GCPnts_UniformAbscissa.cxx
+@@ -94,7 +94,8 @@ static bool Perform(NCollection_Array1<double>& theParameters,
+                     const double                theU2,
+                     const double                theTotalLength,
+                     int&                        theNbPoints,
+-                    const double                theEPSILON)
++                    const double                theEPSILON,
++                    const double                theTol)
+ {
+   bool   isLocalDone = true;
+   double aUU1 = std::min(theU1, theU2), aUU2 = std::max(theU1, theU2);
+@@ -104,6 +105,8 @@ static bool Perform(NCollection_Array1<double>& theParameters,
+   double aDelta  = (theAbscissa / theTotalLength) * (aUU2 - aUU1);
+   int    anIndex = 1;
+   theParameters.SetValue(anIndex, aUU1);
++  const typename GCPnts_TCurveTypes<TheCurve>::Point aPEnd = theC.Value(aUU2);
++  const double aTol2 = theTol * theTol;
+   for (bool isNotDone = true; isNotDone;)
+   {
+     double aUi = theParameters.Value(anIndex) + aDelta;
+@@ -125,7 +128,10 @@ static bool Perform(NCollection_Array1<double>& theParameters,
+     {
+       anIndex += 1;
+       aUi = anAbscissaFinder.Parameter();
+-      if (std::abs(aUi - aUU2) <= theEPSILON)
++      // theEPSILON is a parametric tolerance derived from theTol via Resolution(), which can be
++      // far tighter than theTol locally; also accept a point within theTol of the end in 3D.
++      if (std::abs(aUi - aUU2) <= theEPSILON
++          || (aUU2 - aUi < aDelta && theC.Value(aUi).SquareDistance(aPEnd) <= aTol2))
+       {
+         theParameters.SetValue(anIndex, aUU2);
+         isNotDone = false;
+@@ -437,7 +443,8 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
+                        theU2,
+                        aL,
+                        myNbPoints,
+-                       anEPSILON);
++                       anEPSILON,
++                       std::max(theTol, Precision::Confusion()));
+       break;
+     }
+   }
+@@ -492,11 +499,13 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
+                                         const double    theU2,
+                                         const double    theTol)
+ {
+-  Standard_ConstructionError_Raise_if(
+-    theNbPoints <= 1,
+-    "GCPnts_UniformAbscissa::Initialize() - number of points should be >= 2");
+   myNbPoints = 0;
+   myDone     = false;
++  if (theNbPoints <= 1)
++  {
++    // Not-done in every build, independent of whether No_Exception is defined.
++    return;
++  }
+
+   const double anEPSILON = theC.Resolution(std::max(theTol, Precision::Confusion()));
+   // although very similar to Initialize with Abscissa this avoid
+@@ -550,7 +559,8 @@ void GCPnts_UniformAbscissa::initialize(const TheCurve& theC,
+                        theU2,
+                        aL,
+                        myNbPoints,
+-                       anEPSILON);
++                       anEPSILON,
++                       std::max(theTol, Precision::Confusion()));
+       break;
+     }
+   }
+--
+2.43.0

--- a/Scripts/repro/555-gcpnts-count-contract/upstream/reply-to-gkv311.md
+++ b/Scripts/repro/555-gcpnts-count-contract/upstream/reply-to-gkv311.md
@@ -3,9 +3,7 @@ not yet posted (see #755's hard constraint: prepare and stop, do not comment on 
 
 ---
 
-Thank you for the review. Prepared an update addressing all three points; commit ready at
-`Scripts/repro/555-gcpnts-count-contract/upstream/0001-gcpnts-review-fixes.patch` in our tracking
-repo, to be force-pushed to this branch.
+Thank you for the review. Pushed an update addressing all three points.
 
 **1. The `No_Exception` guard.** Took option (b), replacing `Standard_ConstructionError_Raise_if`
 with the plain `if` rather than adding an unconditional `throw` alongside it. Both classes now
@@ -28,8 +26,9 @@ does not pre-validate: grepped `src/` for both classes outside their own `GCPnts
 production call sites and one Draw test command construct either class with a count; every one
 either hardcodes it (`N = 40`, `NbOfPnts = 61`, `npt = 4`/`8`) or clamps/rejects it first
 (`std::max(2, aNbPoints)`, `std::max(3, aNbSamplePoints)`, the Draw command's own
-`if (aSrcNbPnts < 2) { ...; return 1; }`). So (a) would not change observed behavior for any caller
-in the tree today either, on top of not changing it for us.
+`if (aSrcNbPnts < 2) { ...; return 1; }`). So no caller in the tree can reach the degenerate
+branch at all today, and neither option changes observed behavior anywhere in OCCT, on top of not
+changing it for us.
 
 Given that, we preferred (b) over (a) for a reason external to our own build: an explicit
 `if (...) throw ...;` makes every OCCT-internal caller of these two classes' count-based

--- a/Scripts/repro/555-gcpnts-count-contract/upstream/reply-to-gkv311.md
+++ b/Scripts/repro/555-gcpnts-count-contract/upstream/reply-to-gkv311.md
@@ -23,6 +23,14 @@ for a count of 1 across every one of those entry points, which is what a silent 
 directly and what a thrown exception produces once our own `catch (...)` converts it, so neither
 option changes an observable answer on our side.
 
+We also checked whether anything in the tree calls the count-based `initialize()` with a count it
+does not pre-validate: grepped `src/` for both classes outside their own `GCPnts` package. Five
+production call sites and one Draw test command construct either class with a count; every one
+either hardcodes it (`N = 40`, `NbOfPnts = 61`, `npt = 4`/`8`) or clamps/rejects it first
+(`std::max(2, aNbPoints)`, `std::max(3, aNbSamplePoints)`, the Draw command's own
+`if (aSrcNbPnts < 2) { ...; return 1; }`). So (a) would not change observed behavior for any caller
+in the tree today either, on top of not changing it for us.
+
 Given that, we preferred (b) over (a) for a reason external to our own build: an explicit
 `if (...) throw ...;` makes every OCCT-internal caller of these two classes' count-based
 `initialize()` newly exception-throwing for a degenerate count, in every build, including ones built

--- a/Scripts/repro/555-gcpnts-count-contract/upstream/reply-to-gkv311.md
+++ b/Scripts/repro/555-gcpnts-count-contract/upstream/reply-to-gkv311.md
@@ -1,0 +1,51 @@
+Reply drafted for [OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417#issuecomment-3150937),
+not yet posted (see #755's hard constraint: prepare and stop, do not comment on OCCT#1417).
+
+---
+
+Thank you for the review. Prepared an update addressing all three points; commit ready at
+`Scripts/repro/555-gcpnts-count-contract/upstream/0001-gcpnts-review-fixes.patch` in our tracking
+repo, to be force-pushed to this branch.
+
+**1. The `No_Exception` guard.** Took option (b), replacing `Standard_ConstructionError_Raise_if`
+with the plain `if` rather than adding an unconditional `throw` alongside it. Both classes now
+answer a count below 2 with `IsDone() == false`, in every build, not only one that defines
+`No_Exception`: the `if` replaces the precondition check entirely rather than duplicating it below
+a macro that only sometimes compiles to anything.
+
+We build with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`, so this was not a coin flip for us: measured
+before choosing, not reasoned out. Every one of our call sites into these two classes' count-based
+`initialize()` (9 across the bridge, one of them a shared static helper with 2 further callers, so
+11 total) already wraps the construction in `catch (...)`, so a caller-visible degenerate-count
+result is identical whether the kernel throws or returns not-done: both options were safe for us.
+Our own tests (`Issue558SamplingCountBoundsTests.swift`) assert the not-done/empty-result contract
+for a count of 1 across every one of those entry points, which is what a silent not-done produces
+directly and what a thrown exception produces once our own `catch (...)` converts it, so neither
+option changes an observable answer on our side.
+
+Given that, we preferred (b) over (a) for a reason external to our own build: an explicit
+`if (...) throw ...;` makes every OCCT-internal caller of these two classes' count-based
+`initialize()` newly exception-throwing for a degenerate count, in every build, including ones built
+specifically to avoid that overhead. (b) keeps the existing not-done contract, and it no longer
+depends on a build flag to have that shape. We did confirm directly (compiled both variants without
+`No_Exception` and probed a degenerate count on each): the current PR's guard still throws
+`Standard_ConstructionError` there today; after this update, neither class throws for this input in
+either build configuration.
+
+**2. `Distance()` in a loop.** Hoisted `theTol * theTol` once above the loop as `aTol2` and compare
+`SquareDistance()` against it instead of calling `Distance()` (and the implicit `std::sqrt()`) on
+every candidate step.
+
+**3. `theTol3d` renamed to `theTol`.** Renamed the parameter and checked both call sites: both are
+inside `GCPnts_UniformAbscissa::initialize()` overloads that already have their own `theTol`
+parameter, and both already pass it straight through (`std::max(theTol, Precision::Confusion())`)
+as a plain argument expression, not through an intermediate local also named `theTol`. `Perform()` is
+a free function at namespace scope, not a member of the class whose `initialize()` calls it, so there
+is no enclosing scope for either `theTol` to shadow; renaming introduces no shadowing anywhere in
+the file.
+
+Re-measured the full 6766-configuration equivalence sweep (17 curve types x point counts 2-200,
+both classes) after all three changes: identical to the pre-review patch, 232 changed configurations,
+all of them the over-request cases, nothing else moved. Re-ran the degenerate-count sweep across
+5 curve types x both classes x counts {0, 1, -3}: unchanged, `IsDone() == false` throughout, no
+crash. Full downstream `swift test` suite (OCCTSwift, the consumer this was filed from) unaffected.


### PR DESCRIPTION
## What & why

Maintainer gkv311 [reviewed](https://github.com/Open-Cascade-SAS/OCCT/pull/1417#issuecomment-3150937)
our upstream OCCT PR (`Scripts/patches/0018-*`, filed from #555) and asked for three changes. Two
were mechanical: compare `SquareDistance()` against a tolerance squared once outside the loop
instead of calling `Distance()` inside it, and rename the `Perform` parameter `theTol3d` to `theTol`
since the same template also instantiates on `Adaptor2d_Curve2d`. The third needed a decision, not
just compliance: whether a degenerate point count should start throwing `Standard_ConstructionError`
in every build, or answer not-done in every build, to stop duplicating
`Standard_ConstructionError_Raise_if` (an assert-grade macro this project's own build compiles away
via `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`).

This PR re-cuts the carried patch to match the review, re-verifies it (override-link, not a full
kernel rebuild), and prepares (but does not push or post) the follow-up upstream commit and reply.

Closes #755

## The decision on point 1, with the measurement

Measured before choosing, per the issue's own instruction:

- **Every bridge call site that constructs `GCPnts_UniformAbscissa`/`GCPnts_QuasiUniformAbscissa`
  with a caller-supplied count already wraps the construction in `catch (...)`.** Grepped
  `Sources/OCCTBridge/src/*.mm` for both classes: 9 direct construction sites
  (`OCCTBridge_Curve3D.mm` lines 835, 1135, 1724, 3076, 3092, 3109, 3126, 5743;
  `OCCTBridge_Geom2d.mm` line 5237). 8 are directly inside `try { ... } catch (...) { return
  0/nullptr/false; }`. The 9th (`OCCTBridge_Curve3D.mm:5741`, the `static` helper
  `sampleAdaptorUniform`) is not itself wrapped, but its comment says so explicitly ("Callers keep
  their own try/catch ... so a thrown Standard_Failure/StdFail_NotDone can never cross the extern
  "C" boundary") and both its callers (`OCCTBridge_Curve3D.mm:5806`, `:5858`) are:
  `try { return sampleAdaptorUniform(...); }`. So all 11 reachable paths (9 + 2 via the helper) sit
  inside a `catch (...)` today.
- **`Tests/OCCTCurveTests/Issue558SamplingCountBoundsTests.swift` asserts the not-done/empty-result
  contract for exactly this input.** `curve3DRequests`, `curve2DRequests`, `edgeRequests`,
  `uniformAbscissaRequests` all iterate `n in [-1, 0, 1, ...]` (1 is the degenerate case this guard
  covers) and assert `.count == 0` / `nil`.
- **Nothing in OCCT itself calls the count-based `initialize()` with an unvalidated count.** Grepped
  `Libraries/occt-src/src` for both classes outside their own `GCPnts` package: 5 production call
  sites (`PrsDim_AngleDimension.cxx`, `BRepFill_TrimShellCorner.cxx`,
  `BRepExtrema_ProximityValueTool.cxx`, `BRepBuilderAPI_Sewing.cxx`,
  `ShapeAnalysis_CanonicalRecognition.cxx`, `ProjLib_ComputeApproxOnPolarSurface.cxx`) and one Draw
  test command (`GeometryTest_CurveCommands.cxx`). Every one either hardcodes the count
  (`N = 40`, `NbOfPnts = 61`, `npt = 4`/`8`) or clamps it before construction
  (`std::max(2, aNbPoints)`, `std::max(3, aNbSamplePoints)`, the Draw command's own
  `if (aSrcNbPnts < 2) { ...; return 1; }`). So today, choosing (a) over (b) would not have changed
  behavior for any caller found in the tree either, on top of not changing it for OCCTSwift.

Given both, a caller-visible degenerate-count result is identical today whether the kernel throws
(caught, converted to the empty/nil result) or returns not-done directly (the same empty/nil
result), so **both options were safe for OCCTSwift's own contract**, and the choice had to be made on a
different ground, not "which one breaks us."

Chose **(b)**, replacing `Standard_ConstructionError_Raise_if` outright rather than adding an
unconditional `throw` beside it: it is the option that does not depend on `No_Exception` being
defined (we build with `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`, so option (a) would make a degenerate
count throw in our own build for the first time), and it is what #555 argued for originally, a
silent not-done rather than an exception.

Confirmed directly, not assumed: compiled the pre-review and revised patch **without**
`No_Exception` and constructed each class with a degenerate count. Pre-review patch: still throws
`Standard_ConstructionError` (the un-replaced `Raise_if` is live without `No_Exception`). Revised
patch: throws in neither build configuration.

```
GCPnts_UniformAbscissa(nbPoints=1):            THREW Standard_ConstructionError   (pre-review, no No_Exception)
GCPnts_QuasiUniformAbscissa(bezier, nbPoints=1): THREW Standard_ConstructionError  (pre-review, no No_Exception)
GCPnts_UniformAbscissa(nbPoints=1):             NO THROW, done=0                  (revised, no No_Exception)
GCPnts_QuasiUniformAbscissa(bezier, nbPoints=1): NO THROW, done=0                 (revised, no No_Exception)
```

## Verification

**Override-link, not a full rebuild** (the issue's own guidance; a full `Scripts/build-occt.sh` is
~75 minutes and not warranted for a review-response patch). Reconstructed the pristine (pre-0018)
files by reverse-applying the existing patch (`patch -p1 -R`), confirmed the round-trip is exact
(re-applying the pre-review patch reproduces the current `occt-src` byte for byte), then hand-edited
the pristine files per the review and diffed to produce the revised patch. Compiled three variants
of both files (pristine / current unrevised / revised) with the **production flags**
(`-DNDEBUG -DNo_Exception`, matching `BUILD_RELEASE_DISABLE_EXCEPTIONS=ON`) and override-linked each
ahead of `libOCCT-macos.a`:

- `Scripts/repro/555-gcpnts-count-contract/repro_555_count.mm`: byte-identical output between the
  current (unrevised) and revised override-linked binaries. Over-request 0/60 for both classes on
  the pathological ellipse; every degenerate count (0, 1, -3) on every one of 5 curve types returns
  `done=0` for both classes, no crash.
- `Scripts/repro/555-gcpnts-count-contract/repro_555_equivalence.mm` (17 curve types x point counts
  2-200 x both classes, 6766 configurations x 2 = 13532 lines): **diffed the current and revised
  outputs directly, 0 lines differ.**

This worktree has a local kernel: `Libraries` is a symlink to the shared checkout's `Libraries/`
(created for this task; `.gitignore`d, not part of the diff), which has `occt-src` and a rebuilt
`OCCT.xcframework` already carrying the pre-review 0018. `OCCTSWIFT_LOCAL=1` was set for every
`swift build`/`swift test` invocation below. The rebuilt xcframework itself was **not** rebuilt with
the revised patch in this PR (that is a separate, deliberately-deferred step per the release
process); the override-link technique is what lets the revised kernel source be measured without
that rebuild.

**Swift-side** (against the current, unrevised-kernel `Libraries/OCCT.xcframework`; this PR touches
no bridge or Swift source, so this checks for regressions from the patch-file/doc changes only):

- `swift build --target OCCTCurveTests`: clean (pre-existing unrelated warnings only).
- `swift test --filter "Issue558SamplingCountBounds"`: 21/21 pass.
- `swift test --filter "QuasiUniformAbscissaTests|GCPntsQuasiUniformTests|UniformAbscissaTests"`:
  7/7 pass.
- Full `swift test`: **5462 tests in 1423 suites, all pass.**

**Gate scripts** (all five, plus the four `--self-test`s, plus the census and merge-history audit
`--self-test`s, per `CLAUDE.md`'s "Static Gate Scripts"):

| script | result |
|---|---|
| `check-bridge-index.py` | 0 stale, 0 misfiled |
| `check-bridge-index.py --self-test` | 18/18 |
| `check-null-handle-guards.py` | clean (24 ALLOWED exemptions, unchanged) |
| `check-null-handle-guards.py --self-test` | 24/24 |
| `check-docs-defaults.py` | 0 drifted |
| `check-docs-defaults.py --self-test` | 13/13 |
| `derive-bridge-header-split.py --verify` | 0 ambiguous/unmapped/misfiled |
| `derive-bridge-header-split.py --self-test` | 8/8 |
| `count-operations.py` (no `--self-test`, see `CLAUDE.md`) | README/API_REFERENCE totals match |
| `census-unmeasured-values.py --self-test` | 10/10 |
| `check-changelog-transcription.py --self-test` | 11/11 |

No new test or `--self-test` case is added in this PR (see Checklist), so
[okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md) has nothing new to
apply here; the equivalence sweep above is the "prove it did not move" evidence for a diff that
does not add coverage of its own.

## CHANGELOG entry

None. This revises an internal carried OCCT source patch
(`Scripts/patches/0018-GCPnts-degenerate-count-and-duplicate-end-point-555.patch`) in response to
upstream review, before the corresponding kernel rebuild ships. No OCCTSwift public API or behavior
changes: verified by the equivalence sweep above (0 of 13532 lines differ from the pre-review
patch) and the full `swift test` run (5462 tests, all pass, against the unrebuilt kernel this PR
does not touch).

## SemVer impact

NONE. No public Swift API changes, no OCCTSwift-observable behavior changes. The touched files are
an internal carried-patch text file, its own README section, a reproducer's README, and new
prepared-but-unpushed upstream artifacts.

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR: N/A, no OCCTSwift-observable
      behavior changes (see "Verification" and the equivalence sweep).
- [ ] Every new test and every new `--self-test` case was run once with its subject broken: N/A, no
      new test or `--self-test` case is added in this PR.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Hard constraints observed**: nothing was pushed to `gsdali/OCCT`, nothing was posted to
  [OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417). The prepared follow-up commit
  (`git am`-verified against a throwaway repo built from the reconstructed pristine files) and the
  drafted reply are both under
  [`Scripts/repro/555-gcpnts-count-contract/upstream/`](Scripts/repro/555-gcpnts-count-contract/upstream/),
  ready for a human to push/post.
- **The rebuilt `Libraries/OCCT.xcframework` still carries the pre-review 0018.** Rebuilding it with
  the revised patch is a separate step (a real `Scripts/build-occt.sh` run, ~75 minutes), deliberately
  out of scope here per the issue; the override-link measurements above are what stand in for that
  rebuild until it happens, most likely alongside a future kernel re-pin.
- **Point 3's "shadowing" check**: verified `Perform` is a free `static` function at namespace scope,
  not a member of `GCPnts_UniformAbscissa`, so renaming its `theTol3d` parameter to `theTol`
  introduces no shadowing against either `initialize()` overload's own `theTol` parameter (both call
  sites already pass `theTol` straight through as a plain expression, not through an intermediate
  local of the same name).
- `Scripts/patches/README.md`'s `0018` section and the repro's own `README.md` are both updated in
  place (not a new patch number), matching this project's existing convention for a revised carried
  patch (e.g. the `0011`/`#363` and `0016`/`#374` entries).
