### PR TITLE
fix(#747): detectHoles() finds holes by their own geometry, not neighbor convexity

### DIFF
--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -520,11 +520,58 @@ extension AAG {
         return pockets
     }
 
-    /// Detect holes (through or blind) in the shape
+    /// Detect holes (through or blind) in the shape.
     ///
-    /// A hole is identified by:
-    /// 1. A cylindrical or conical face
-    /// 2. With concave edges connecting to other faces
+    /// ## What "is a hole" means, under `ChFi3d::DefineConnectType` (#747)
+    ///
+    /// The original criterion -- every neighbor connects via a concave edge -- was written
+    /// against a convexity formula (pre-#723) that sometimes misclassified a curved rim as
+    /// concave when it geometrically should not be. Under the correct classifier that
+    /// criterion is unsatisfiable for either ordinary hole shape: a through-hole's wall has
+    /// **zero** concave neighbors (both rims are convex -- the solid occupies 90 degrees
+    /// there, not the 270 that makes an edge concave), and a blind hole's wall has exactly
+    /// **one** out of two (the floor, not the rim where it opens). "All neighbors concave"
+    /// can never hold for either, which is why #747 measured zero holes for both.
+    ///
+    /// A hole is not defined by its neighbors' convexity at all -- that only ever describes
+    /// the rims where the hole *meets other geometry*, and a through-hole has no such junction
+    /// that is concave. What every hole's lateral wall shares, independent of depth, is the
+    /// wall's own intrinsic shape:
+    ///
+    /// 1. **Cylindrical or conical** -- the two developable surface types a drilled or bored
+    ///    feature produces (a conical wall covers a countersink/counterbore transition).
+    /// 2. **Closed in U by its own seam.** The wall wraps all the way around its axis, bounded
+    ///    only by rim(s) in V, not by additional edges along U. A partial revolve -- an edge
+    ///    fillet is the common example -- is bounded by two more edges along U as well, and is
+    ///    not a hole.
+    /// 3. **Material lies radially outside the wall, not inside it.** A hole is a void: the
+    ///    solid occupies the space between the bore and the surrounding stock, so the face's
+    ///    own outward normal (already corrected for ``Face/orientation``, see
+    ///    ``Face/normal(atU:v:)``) points *back toward the axis*. A boss or a standalone solid
+    ///    cylinder is the mirror image of the same topology -- same surface type, same closed-
+    ///    in-U shape, sometimes even the same neighbor-convexity signature (a standalone
+    ///    cylinder's wall has zero concave neighbors too) -- but its material fills the inside,
+    ///    so its normal points *away* from the axis. Nothing about neighbor convexity
+    ///    distinguishes the two; this does, directly, from the wall's own geometry.
+    ///
+    /// This also does not assume the hole's axis is vertical: it reads the wall's actual axis
+    /// (``Face/primaryAxis``) rather than inferring one from a Z-aligned bounding box, which
+    /// the previous aspect-ratio heuristic did implicitly. A pipe's bore is correctly reported
+    /// as a hole by this same rule (material lies radially outside its inner wall), and a
+    /// pipe's outer wall is correctly excluded (material lies radially inside it) -- a case the
+    /// old formula, keyed off a fixed Z axis and a bounding-box aspect ratio, could not
+    /// distinguish from a first-principles derivation.
+    ///
+    /// ```swift
+    /// let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
+    /// let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
+    /// let blind = box.subtracting(tool)!
+    /// print(blind.buildAAG().detectHoles().count)   // 1, was 0
+    ///
+    /// let tool2 = Shape.cylinder(at: SIMD3(0, 0, -15), direction: SIMD3(0, 0, 1), radius: 4, height: 30)!
+    /// let through = box.subtracting(tool2)!
+    /// print(through.buildAAG().detectHoles().count) // 1, was 0
+    /// ```
     ///
     /// - Note: `faceIndex` is an **occurrence** index into ``Shape/orientedFaces()``, not
     ///   ``Shape/faces()`` (#642), matching ``AAGNode/faceIndex``. A hole's face is rarely one
@@ -532,29 +579,52 @@ extension AAG {
     ///   same thing and only the occurrence one is correct here.
     public func detectHoles() -> [(faceIndex: Int, radius: Double, depth: Double)] {
         var holes: [(faceIndex: Int, radius: Double, depth: Double)] = []
+        let faces = shape.orientedFaces()
 
-        // Find cylindrical faces that are holes (all edges are concave)
-        for (index, node) in nodes.enumerated() {
-            // Check if all neighbors are connected via concave edges
-            let allNeighbors = neighbors(of: index)
-            let concaveNeighbors = self.concaveNeighbors(of: index)
+        for index in nodes.indices {
+            guard index < faces.count else { continue }
+            let face = faces[index]
 
-            // If all adjacencies are concave, this might be a hole
-            guard allNeighbors.count == concaveNeighbors.count && allNeighbors.count >= 1 else {
+            // A drilled or bored hole's lateral wall is cylindrical, or conical for a
+            // countersink/counterbore transition (#747).
+            guard face.surfaceType == .cylinder || face.surfaceType == .cone else { continue }
+
+            // Closed in U: the wall must wrap all the way around its own axis. `uvBounds` is
+            // the face's trimmed parameter range (`BRepTools::UVBounds`), and a periodic
+            // cylinder/cone is canonically parameterized over a full 2*pi in U; a partial
+            // revolve (an edge fillet, a half-pipe) is trimmed to less than that.
+            guard let uv = face.uvBounds, uv.uMax - uv.uMin >= 2 * Double.pi - 1e-6 else {
                 continue
             }
 
-            // For now, use bounds to estimate if circular
-            let width = node.bounds.max.x - node.bounds.min.x
-            let height = node.bounds.max.y - node.bounds.min.y
-            let depth = node.bounds.max.z - node.bounds.min.z
+            guard let revolution = face.revolutionProperties else { continue }
+            let axisUnit = simd_normalize(revolution.axis.direction)
 
-            // Check if roughly circular in XY (for vertical holes)
-            let aspectRatio = max(width, height) / min(width, height)
-            if aspectRatio < 1.2 && !node.isPlanar {
-                let radius = (width + height) / 4.0
-                holes.append((faceIndex: index, radius: radius, depth: depth))
+            let uMid = (uv.uMin + uv.uMax) / 2
+            let vMid = (uv.vMin + uv.vMax) / 2
+            guard let midPoint = face.point(atU: uMid, v: vMid),
+                  let midNormal = face.normal(atU: uMid, v: vMid) else {
+                continue
             }
+
+            let offset = midPoint - revolution.axis.origin
+            let radial = offset - simd_dot(offset, axisUnit) * axisUnit
+            let radialLength = simd_length(radial)
+            guard radialLength > 1e-9 else { continue }
+
+            // The material-side test (see doc comment above): a hole's own outward normal
+            // points back toward the axis, opposite the radial direction.
+            guard simd_dot(midNormal, radial / radialLength) < 0 else { continue }
+
+            // Depth along the wall's own axis, not a Z-aligned bounding box: works the same
+            // for a vertical hole as for one bored on any other axis.
+            guard let low = face.point(atU: uMid, v: uv.vMin),
+                  let high = face.point(atU: uMid, v: uv.vMax) else {
+                continue
+            }
+            let depth = abs(simd_dot(high - low, axisUnit))
+
+            holes.append((faceIndex: index, radius: revolution.radius, depth: depth))
         }
 
         return holes

--- a/Tests/OCCTModelingTests/Issue747DetectHolesConvexClassifierTests.swift
+++ b/Tests/OCCTModelingTests/Issue747DetectHolesConvexClassifierTests.swift
@@ -1,0 +1,217 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #747: `detectHoles()` required every neighbor of a candidate face to connect via a concave
+// edge. #723 replaced the hand-rolled convexity formula with OCCT's own `ChFi3d::DefineConnectType`
+// and, correctly, that made the requirement unsatisfiable for either ordinary hole shape:
+//
+// - A through-hole's cylindrical wall has ZERO concave neighbors. At a hole's rim the solid
+//   occupies the quarter-space outside the cylinder and below/above the opening face -- a 90
+//   degree material angle, not the 270 that makes an edge concave. Both rims classify convex.
+// - A blind hole's wall has exactly ONE concave neighbor out of two: the floor, not the rim where
+//   it opens to the exterior.
+//
+// "All neighbors concave" can hold for neither, so `detectHoles()` reported zero for both --
+// total non-detection of the two hole shapes anyone would actually drill.
+//
+// ## What replaces it
+//
+// A hole is not defined by its neighbors' convexity -- that only ever describes the rims where
+// the hole meets other geometry, and a through-hole has no concave junction at all. What every
+// hole's lateral wall shares, independent of depth, is its own intrinsic shape:
+//
+// 1. Cylindrical or conical (the two developable surface types a drilled/bored feature produces).
+// 2. Closed in U by its own seam -- it wraps all the way around its axis, bounded only by rims in
+//    V, not by extra edges along U (a partial revolve, e.g. an edge fillet, is not a hole).
+// 3. Material lies radially OUTSIDE the wall, not inside it: the wall's own outward-pointing
+//    normal (already corrected for face orientation) points back toward the axis. A boss or a
+//    standalone solid cylinder is the mirror image of the same topology -- same surface type,
+//    same closed-in-U shape, and (for a through-boss-like standalone cylinder) even the same
+//    zero-concave-neighbor signature as a through-hole -- but its material fills the inside, so
+//    its normal points away from the axis.
+//
+// See `AAG.detectHoles()`'s own doc comment in `FeatureRecognition.swift` for the full reasoning.
+@Suite("AAG.detectHoles() finds holes under the correct convexity classifier (#747)")
+struct Issue747DetectHolesConvexClassifierTests {
+
+    // MARK: - The headline: the issue's own two fixtures
+
+    /// The issue's own blind-hole construction, byte for byte. Before the fix this reported
+    /// zero holes because the wall's two neighbors (floor: concave, rim: convex) never satisfy
+    /// "all concave".
+    @Test("a blind cylindrical hole reports exactly one hole")
+    func blindHoleReportsExactlyOneHole() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20))
+        let cut = try #require(box.subtracting(tool))
+
+        let holes = cut.buildAAG().detectHoles()
+        #expect(holes.count == 1)
+        guard let hole = holes.first else { return }
+        #expect(abs(hole.radius - 4.0) < 1e-4)
+        #expect(abs(hole.depth - 10.0) < 1e-4)
+    }
+
+    /// The issue's own through-hole construction. Before the fix this reported zero holes
+    /// because the wall's two neighbors are BOTH convex -- "all concave" can never hold for a
+    /// through-hole, by construction, independent of geometry.
+    @Test("a through cylindrical hole reports exactly one hole")
+    func throughHoleReportsExactlyOneHole() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(0, 0, -15), direction: SIMD3(0, 0, 1), radius: 4, height: 30))
+        let cut = try #require(box.subtracting(tool))
+
+        let holes = cut.buildAAG().detectHoles()
+        #expect(holes.count == 1)
+        guard let hole = holes.first else { return }
+        #expect(abs(hole.radius - 4.0) < 1e-4)
+        #expect(abs(hole.depth - 20.0) < 1e-4)
+    }
+
+    // MARK: - The ground-truth table row: through-hole plate at several thicknesses
+
+    /// The exact fixture `Issue703EdgeConvexityOrderTests.throughHoleHasNoConcaveEdges` pins as
+    /// "zero concave edges" -- the fixture whose own ground truth is the reason "all neighbors
+    /// concave" can never identify this shape as a hole. One physical hole at every thickness.
+    @Test("a through-hole plate reports one hole at several thicknesses",
+          arguments: [20.0, 40.0, 60.0, 120.0])
+    func throughHolePlateAcrossThicknesses(thickness: Double) throws {
+        let plate = try #require(Shape.box(width: 50, height: 50, depth: thickness))
+        let drill = try #require(Shape.cylinder(
+            at: SIMD3(0, 0, -thickness / 2 - 5), direction: SIMD3(0, 0, 1),
+            radius: 10, height: thickness + 10))
+        let drilled = try #require(plate.subtracting(drill))
+
+        let holes = drilled.buildAAG().detectHoles()
+        let label: Comment = "thickness=\(thickness)"
+        #expect(holes.count == 1, label)
+        guard let hole = holes.first else { return }
+        #expect(abs(hole.radius - 10.0) < 1e-4, label)
+        #expect(abs(hole.depth - thickness) < 1e-4, label)
+    }
+
+    // MARK: - False positives a weaker criterion would produce
+
+    /// A round boss (a cylinder fused onto a box, sticking up) has the SAME topological
+    /// signature as a blind hole -- its wall's two neighbors are one concave (base rim), one
+    /// convex (top cap rim) -- but it is not a hole: the boss's material fills the inside of
+    /// the cylinder. Only the material-side (radial normal direction) check tells them apart.
+    @Test("a round boss is not reported as a hole")
+    func roundBossIsNotAHole() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let boss = try #require(Shape.cylinder(at: SIMD3(0, 0, 10), direction: SIMD3(0, 0, 1), radius: 4, height: 5))
+        let fused = try #require(box.union(boss))
+
+        #expect(fused.buildAAG().detectHoles().isEmpty)
+    }
+
+    /// A standalone solid cylinder's lateral wall has ZERO concave neighbors, same as a
+    /// through-hole -- this is the sharpest possible counter-example to "closed cylindrical
+    /// face, no concave neighbors implies hole": the topology (surface type, closed in U,
+    /// neighbor convexity) is identical to a genuine through-hole, and only the material-side
+    /// check distinguishes a bore (void inside) from a solid peg (material inside).
+    @Test("a standalone solid cylinder is not reported as a hole")
+    func standaloneCylinderIsNotAHole() throws {
+        let cylinder = try #require(Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20))
+        #expect(cylinder.buildAAG().detectHoles().isEmpty)
+    }
+
+    /// A fillet on a CONCAVE interior corner (here, a vertical wall-to-wall corner of a square
+    /// pocket) is deliberately the sharper counter-example, not a fillet on an ordinary convex
+    /// box edge: measured directly, its material-side sign matches a genuine hole's (material
+    /// lies radially outside the fillet's own cylindrical patch, same as a bore), so it clears
+    /// the material-side check on its own. Only the fillet's own U extent -- one quarter turn
+    /// (~pi/2), not a full 2*pi -- is what excludes it. A convex-edge fillet would ALSO be
+    /// excluded, but by the material-side check instead, silently proving nothing about "closed
+    /// in U" specifically (confirmed by removing that guard in isolation: the convex-edge
+    /// fixture still passed, while this one flipped to reporting a false hole at exactly the
+    /// fillet's own radius).
+    @Test("a filleted concave interior corner is not reported as a hole")
+    func filletedConcaveCornerIsNotAHole() throws {
+        let box = try #require(Shape.box(width: 30, height: 30, depth: 30))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 5), width: 10, height: 10, depth: 11))
+        let pocketed = try #require(box.subtracting(pocketTool))
+
+        // The pocket tool's footprint is (-5...5, -5...5) at z in [5, 16], so its four vertical
+        // wall-to-wall corners sit at (x, y) = (+-5, +-5). Find one geometrically rather than by
+        // a fixed edge index, which is not stable across OCCT's own edge enumeration order.
+        let verticalEdges = pocketed.edges(parallelTo: SIMD3(0, 0, 1))
+        let cornerEdge = verticalEdges.first { edge in
+            guard let p = edge.point(at: 0.5) else { return false }
+            return abs(abs(p.x) - 5) < 1e-3 && abs(abs(p.y) - 5) < 1e-3 && p.z > 5 && p.z < 16
+        }
+        let edge = try #require(cornerEdge, "could not find the pocket's vertical corner edge")
+
+        let builder = try #require(FilletBuilder(shape: pocketed))
+        builder.addEdge(edge, radius: 1.0)
+        let filleted = try #require(builder.build())
+
+        #expect(filleted.buildAAG().detectHoles().isEmpty)
+    }
+
+    // MARK: - The material-side discriminator, isolated on one shape
+
+    /// A pipe: the SAME axis, the SAME closed-in-U cylindrical shape, on both its inner and
+    /// outer wall -- differing only in which side is material. The inner wall is a genuine
+    /// through-hole (material lies radially outside it, the pipe's own wall thickness); the
+    /// outer wall is not (material lies radially inside it, same as a solid cylinder's wall).
+    /// This isolates the discriminator #747 turns on: everything else about the two faces
+    /// (surface type, closed-in-U, axis) is identical.
+    @Test("a pipe's inner bore is a hole, its outer wall is not")
+    func pipeInnerBoreIsAHoleOuterWallIsNot() throws {
+        let outer = try #require(Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 10, height: 30))
+        let inner = try #require(Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 6, height: 30))
+        let pipe = try #require(outer.subtracting(inner))
+
+        let holes = pipe.buildAAG().detectHoles()
+        #expect(holes.count == 1)
+        guard let hole = holes.first else { return }
+        #expect(abs(hole.radius - 6.0) < 1e-4)
+        #expect(abs(hole.depth - 30.0) < 1e-4)
+    }
+
+    // MARK: - Axis generality: the fix reads the wall's own axis, not an assumed vertical one
+
+    /// A through-hole bored along X rather than Z. The previous implementation inferred
+    /// "circular" from a Z-implicit bounding-box aspect ratio (X/Y as the circular dimensions,
+    /// Z as depth), which is wrong for any non-vertical hole: here the true circular dimensions
+    /// are Y/Z (~8 units) and the true depth is along X (~20 units), the opposite of what that
+    /// heuristic assumed. Reading the wall's actual axis (`Face.primaryAxis`) gets this right
+    /// regardless of orientation.
+    @Test("a through-hole bored on a horizontal (X) axis is detected")
+    func horizontalHoleIsDetected() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.cylinder(at: SIMD3(-15, 0, 0), direction: SIMD3(1, 0, 0), radius: 4, height: 30))
+        let cut = try #require(box.subtracting(tool))
+
+        let holes = cut.buildAAG().detectHoles()
+        #expect(holes.count == 1)
+        guard let hole = holes.first else { return }
+        #expect(abs(hole.radius - 4.0) < 1e-4)
+        #expect(abs(hole.depth - 20.0) < 1e-4)
+    }
+
+    // MARK: - Non-regression: shapes with no cylindrical/conical face at all
+
+    /// A plain box has no cylindrical or conical face whatsoever, so there is no candidate in
+    /// the first place; the new criterion must not manufacture one.
+    @Test("a plain box has no holes")
+    func plainBoxHasNoHoles() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        #expect(box.buildAAG().detectHoles().isEmpty)
+    }
+
+    /// A square (rectangular) pocket's walls are planar, not cylindrical -- a different feature
+    /// family entirely. `detectHoles()` must not report anything for it, independent of what
+    /// `detectPockets()` reports for the same shape.
+    @Test("a square pocket has no holes")
+    func squarePocketHasNoHoles() throws {
+        let box = try #require(Shape.box(width: 30, height: 30, depth: 30))
+        let pocket = try #require(Shape.box(origin: SIMD3(-5, -5, 5), width: 10, height: 10, depth: 11))
+        let pocketed = try #require(box.subtracting(pocket))
+
+        #expect(pocketed.buildAAG().detectHoles().isEmpty)
+    }
+}


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`AAG.detectHoles()` required every neighbor of a candidate face to connect via a concave edge.
#723 replaced the hand-rolled convexity formula with OCCT's own `ChFi3d::DefineConnectType`,
correctly, and that made the requirement unsatisfiable for either ordinary hole shape: a
through-hole's cylindrical wall has **zero** concave neighbors (both rims are convex -- the solid
occupies a 90 degree angle there, not the 270 that makes an edge concave), and a blind hole's wall
has exactly **one** concave neighbor out of two (the floor, not the rim where it opens). `detectHoles()`
reported zero holes for both, which is total non-detection of the two shapes anyone would actually
drill.

Replaced the criterion with one built from the wall's own intrinsic geometry rather than its
neighbors' convexity: cylindrical or conical, closed in U by its own seam, and material lying
radially **outside** the wall rather than inside it. See the full reasoning in
`AAG.detectHoles()`'s own doc comment.

Closes #747

## Why this criterion, not a fixture-fit

A hole is not defined by its neighbors' convexity — that only ever describes the rims where the
hole meets other geometry, and a through-hole has no concave junction at all. What every hole's
lateral wall shares, independent of depth, is its own shape:

1. **Cylindrical or conical** — the two developable surface types a drilled/bored feature produces
   (a conical wall covers a countersink/counterbore transition).
2. **Closed in U by its own seam** — wraps all the way around its axis (`uvBounds` spans a full
   `2*pi`), bounded only by rims in V. A partial revolve (an edge fillet) is bounded by additional
   edges along U and is not a hole.
3. **Material lies radially outside the wall, not inside it** — a hole is a void: the solid
   occupies the space between the bore and the surrounding stock, so the wall's own outward
   normal (`Face.normal(atU:v:)`, already corrected for face orientation) points *back toward the
   axis*. A boss or a standalone solid cylinder is the mirror image of the same topology — same
   surface type, same closed-in-U shape, and (for a standalone cylinder) even the *same
   zero-concave-neighbor signature as a through-hole* — but its material fills the inside, so its
   normal points away from the axis. This is the sharpest available counter-example to any
   neighbor-convexity-based criterion: a standalone solid cylinder and a genuine through-hole are
   topologically identical in every way neighbor convexity can see. Only the wall's own material
   side tells them apart.

This also reads the wall's actual axis (`Face.primaryAxis`) instead of assuming Z, so a hole bored
on any axis is found and correctly measured — verified directly against a horizontal (X-axis)
through-hole and a pipe (whose inner and outer walls share one axis but differ in which side is
material).

Measured against the issue's own ground truth and several deliberately adversarial fixtures (all
in `Tests/OCCTModelingTests/Issue747DetectHolesConvexClassifierTests.swift`):

| fixture | expected | measured |
|---|---|---|
| blind hole (issue's own fixture) | 1 hole, r=4, depth=10 | 1, r=4.0, depth=10.0 |
| through hole (issue's own fixture) | 1 hole, r=4, depth=20 | 1, r=4.0, depth=20.0 |
| through-hole plate, thickness 20/40/60/120 (ground-truth table row) | 1 hole each | 1 each, r=10.0, depth=thickness |
| round boss | 0 holes | 0 |
| standalone solid cylinder | 0 holes | 0 |
| filleted concave interior corner | 0 holes | 0 |
| pipe (inner bore vs outer wall) | 1 hole (inner only) | 1, r=6.0 (inner), outer excluded |
| horizontal (X-axis) through-hole | 1 hole, r=4, depth=20 | 1, r=4.0, depth=20.0 |
| plain box / L-shape / square pocket | 0 holes | 0 |

## Injection matrix (prove the test fails)

Every guard was independently disabled and the corresponding tests confirmed to fail, then the
guard was restored and the suite confirmed green again.

| injection | what was disabled | tests that failed | tests that stayed green |
|---|---|---|---|
| A | restored the original #747 bug ("all neighbors concave") | blind hole, through hole, through-hole plate (all 4 thicknesses), pipe, horizontal hole — every genuine-hole test | round boss, standalone cylinder, filleted corner, plain box, square pocket (these never had holes to find under either criterion) |
| B | material-side (radial-normal-direction) check | standalone cylinder, round boss, pipe (count became 2, radius reported the outer wall's) | everything else, including all genuine-hole tests |
| C | closed-in-U check | filleted concave interior corner (reported a false hole at exactly the fillet's own radius, 1.0) | everything else |
| D | axis read (hardcoded Z instead of `Face.primaryAxis`) | horizontal (X-axis) hole (depth computed via the wrong axis, off by ~20) | every vertical-axis test, since Z happened to still be correct for those |

One test needed a fixture correction during this process, worth recording: the fillet guard was
first tested with a fillet on an ordinary **convex** box edge. Disabling the closed-in-U check did
**not** fail that test — the convex-edge fillet's material-side sign already matches a boss's
(positive), so it was already excluded by guard B, and the test proved nothing about guard C
specifically. Replaced with a fillet on a **concave** interior corner (a square pocket's
wall-to-wall corner): its material-side sign matches a hole's (confirmed by direct measurement:
`radial outward dot = -0.9999...`), so only the closed-in-U check excludes it. Disabling that
guard in isolation now reproduces the false positive (`faceIndex: 2, radius: 1.0000000000000004,
depth: 10.0`, exactly the fillet's own radius). This is exactly the failure mode
`okf/policies/prove-the-test-fails.md` warns about — a test that looks like coverage but isn't —
caught by actually running the removal, not by inspection.

## CHANGELOG entry

### `AAG.detectHoles()` no longer reports zero holes for an ordinary blind or through cylindrical hole (#747)

`detectHoles()` required every neighbor of a candidate face to connect via a concave edge — a
criterion written against the convexity formula #723 replaced, and unsatisfiable under the correct
one for both a through-hole (zero concave neighbors) and a blind hole (one out of two). Replaced
with a criterion built from the wall's own geometry: cylindrical or conical, closed in U by its own
seam, and with material lying radially outside the wall rather than inside it — which also
correctly excludes a boss or standalone cylinder (topologically identical to a hole in every way
neighbor convexity can see) and correctly finds a hole bored on any axis, not only a vertical one.

```swift
let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
let cut  = box.subtracting(tool)!
print(cut.buildAAG().detectHoles().count)   // 1, was 0
```

## SemVer impact

PATCH. `detectHoles()`'s return values change (it now reports holes it previously missed
entirely, and the reported `radius`/`depth` for any hole it did find before could differ slightly
since they are now computed from the wall's exact axis/geometry rather than a bounding-box
estimate). No public signature changed. `detectHoles()` had zero test coverage anywhere in the
suite before this PR (`grep -rl detectHoles Tests/` matched nothing), so no existing caller could
have been relying on the old (broken) zero-holes behavior as correct.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (
      `Tests/OCCTModelingTests/Issue747DetectHolesConvexClassifierTests.swift`, 10 tests / 13 cases).
- [x] Every new test was run once with its subject broken (see the injection matrix above), and the
      failure is reported here.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- Diff is confined to `Sources/OCCTSwift/FeatureRecognition.swift` (`detectHoles()` only —
  `detectPockets()` and `AAGNode` are untouched) and the new test file. `Sources/OCCTTest/main.swift`
  was used as a measurement harness while developing this fix and is restored byte-identical
  (`git diff --exit-code Sources/OCCTTest/main.swift` is clean).
- Deliberately did not touch `#735` (`isOpen` / pocket enclosure), which is in flight in parallel
  in the same file on a different branch.
- `Face.revolutionProperties` and `Face.primaryAxis` (both pre-existing) supplied the axis/radius
  math directly — no new bridge functions were needed.
- Full suite: 5472 tests, all pass (`env -u OCCTSWIFT_LOCAL swift test`). Gate scripts
  (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`) all clean.
