### PR TITLE
chore(#763): triage Document.mm + IO.mm's 26 unmeasured-value candidates

### DIFF
--- a/Scripts/repro/726-unmeasured-values/triage-document.md
+++ b/Scripts/repro/726-unmeasured-values/triage-document.md
@@ -1,0 +1,117 @@
+# #763 triage: `OCCTBridge_Document.mm` + `OCCTBridge_IO.mm` (26 of 62 candidates)
+
+Parent: #726. Sibling issue: #763 ("Unmeasured values, production half: adjudicate the census's 62
+bridge candidates"), the `OCCTBridge_Document.mm` (25) + `OCCTBridge_IO.mm` (1) half specifically.
+Candidate list reproduced with:
+
+```
+python3 Scripts/census-unmeasured-values.py | grep -E "^  OCCTBridge_(Document|IO)\.mm:"
+```
+
+Line numbers below are as reported **before** this pass's fix (`OCCTDocumentGetShapeColor` gained
+5 lines, shifting everything after it in the file by that amount; re-running the census today
+reports `OCCTDocumentGetShapeColor`'s own `result.a` line gone and every later line number +5).
+
+## Verdicts, per #763
+
+1. **Not an instance.** The literal is correct.
+2. **Compute it.** Non-breaking.
+3. **Make the absence representable** (`nil`/sentinel). Usually breaking.
+4. **Remove the field.** Breaking.
+
+Finer tags (reused from `Scripts/repro/726-unmeasured-values/README.md`'s own taxonomy, all of
+which collapse to Verdict 1 except where noted): **FLIP** = legitimate default-then-flip
+success/validity flag. **ALPHA** = structural default for a color quantity with no alpha channel
+anywhere in the data it is drawn from. **CTOR** = plain value-type constructor echoing its own
+parameters, not a measurement API returned from OCCT.
+
+## Result: 25 Verdict 1, 1 Verdict 2, 0 Verdict 3, 0 Verdict 4
+
+| # | Site | Function | Field | Verdict | Evidence |
+|---|---|---|---|---|---|
+| 1 | `OCCTBridge_Document.mm:427` | `OCCTDocumentGetLabelColor` | `result.isSet = true` | 1 (FLIP) | Read the full function. Sits immediately after `result.r/g/b/a` are assigned from a real `Quantity_ColorRGBA` returned by `doc->colorTool->GetColor(label, xcafType, color)`. `isSet` is `true` only on the path where a color was actually found (two call sites in the function, both after a real fetch) — the "make absence representable" idiom, not a fabrication. |
+| 2 | `OCCTBridge_Document.mm:520` | `OCCTDocumentGetLabelMaterial` | `baseColor.isSet = true` | 1 (FLIP) | Same idiom, one level in: set immediately after `baseColor.r/g/b/a` are populated from `pbr.BaseColor` (a real `Quantity_ColorRGBA`), inside `if (visMat->HasPbrMaterial())`. |
+| 3 | `OCCTBridge_Document.mm:530` | `OCCTDocumentGetLabelMaterial` | `emissive.a = 1.0` | 1 (ALPHA) | Verified against the OCCT header, not assumed: `XCAFDoc_VisMaterialPBR::EmissiveFactor` is `NCollection_Vec3<float>` (`Libraries/OCCT.xcframework/macos-arm64/Headers/XCAFDoc_VisMaterialPBR.hxx:40`) — RGB only, matching the glTF spec's `emissiveFactor` (no alpha channel exists anywhere upstream for this quantity). `1.0` (fully opaque) is the only sensible constant for an `OCCTColor`-shaped slot with no real alpha to read. Genuinely different from candidate #7 below, which looked structurally identical but was not. |
+| 4 | `OCCTBridge_Document.mm:531` | `OCCTDocumentGetLabelMaterial` | `emissive.isSet = true` | 1 (FLIP) | Same branch as #3; `emissive.r/g/b` are real (`pbr.EmissiveFactor.x/y/z()`) immediately above. |
+| 5 | `OCCTBridge_Document.mm:775` | `OCCTDocumentGetDimensionInfo` | `info.isValid = false` | 1 (FLIP) | Default set before the `try` block even opens; flipped to `true` only at `:798`, after `dimObj->GetType()`/`GetValues()`/`GetLowerTolValue()`/`GetUpperTolValue()` all ran. Textbook default-then-flip. |
+| 6 | `OCCTBridge_Document.mm:807` | `OCCTDocumentGetGeomToleranceInfo` | `info.isValid = false` | 1 (FLIP) | Identical shape to #5: default before `try`, flipped at `:825` after `tolObj->GetType()`/`GetValue()`. |
+| 7 | `OCCTBridge_Document.mm:3050` | `OCCTDocumentGetShapeColor` | `result.a = 1.0` | **2 (FIXED)** | **Overrides this repro directory's own prior README verdict of ALPHA for this exact site** ("`Quantity_Color` (not `ColorRGBA`) has no alpha channel; `1.0` is the domain default"). That verdict conflated "the C++ value type this call reads into has no alpha field" with "no alpha data exists to read" — they are not the same claim, and the second is false. Read `Libraries/occt-src/.../XCAFDoc_ColorTool.cxx:77-101`: `GetColor(TDF_Label, Quantity_Color&)` internally calls `GetColor(TDF_Label, Quantity_ColorRGBA&)` and then does `col = aCol.GetRGB()` — the underlying `XCAFDoc_Color` attribute always stores full RGBA (`ColorAttribute->GetColorRGBA()`), regardless of which overload a caller uses to read it. A real, non-1.0 alpha reaches this exact storage today: `STEPCAFControl_Reader.cxx:2341` calls `CTool->SetColor(aLabelForStyle, colRGBA, XCAFDoc_ColorSurf)` with a `Quantity_ColorRGBA` carrying the STEP file's own transparency. Second construction, per `measure-dont-assume.md`: `OCCTDocumentGetLabelColor` (candidate #1, same file) does the exact same "get color by X" operation for a label key and already reads via the RGBA overload correctly — this function was the one-off inconsistency, not the norm. **Fixed**: switched to `Quantity_ColorRGBA` + `color.Alpha()`. Non-breaking (same field, same type, corrected value). |
+| 8 | `OCCTBridge_Document.mm:3051` | `OCCTDocumentGetShapeColor` | `result.isSet = true` | 1 (FLIP) | Set only inside `if (hasColor)`, beside the (now-fixed) real `r/g/b/a`. Correct presence flag, independent of #7's defect. |
+| 9 | `OCCTBridge_Document.mm:4290` | `OCCTXCAFPrsStyleCreate` | `result.surfR = 0` | 1 (CTOR) | Traced every call site of all three `OCCTXCAFPrsStyleCreate*` functions (`grep` across `Sources/`): the only caller is `PresentationStyle.swift`'s private `toOCCT()`, which builds this C struct **from Swift-supplied parameters** to feed `OCCTXCAFPrsStyleIsEqual` — it is never used to read a style back out of a document. A plain value constructor, not a measurement API; #726's own scope is values "returned through an API" that reads as measured, and this reads as "caller building a request," matching the CFG/CTOR false-positive shape the census's own header names explicitly for these exact three functions. |
+| 10 | `OCCTBridge_Document.mm:4290` | `OCCTXCAFPrsStyleCreate` | `result.surfG = 0` | 1 (CTOR) | Same as #9. |
+| 11 | `OCCTBridge_Document.mm:4290` | `OCCTXCAFPrsStyleCreate` | `result.surfB = 0` | 1 (CTOR) | Same as #9. |
+| 12 | `OCCTBridge_Document.mm:4291` | `OCCTXCAFPrsStyleCreate` | `result.surfAlpha = 1.0f` | 1 (CTOR) | Same as #9; also the correct "no color" default given `hasSurfColor = false` on the same path. |
+| 13 | `OCCTBridge_Document.mm:4292` | `OCCTXCAFPrsStyleCreate` | `result.hasSurfColor = false` | 1 (CTOR/GOOD) | Same as #9. `PresentationStyle.swift:8` (`surfaceColor: (...)?`) is the consumer, and it is nil exactly when no color was supplied — the "make absence representable" pattern already applied on the Swift side. |
+| 14 | `OCCTBridge_Document.mm:4293` | `OCCTXCAFPrsStyleCreate` | `result.curvR = 0` | 1 (CTOR) | Same as #9. |
+| 15 | `OCCTBridge_Document.mm:4293` | `OCCTXCAFPrsStyleCreate` | `result.curvG = 0` | 1 (CTOR) | Same as #9. |
+| 16 | `OCCTBridge_Document.mm:4293` | `OCCTXCAFPrsStyleCreate` | `result.curvB = 0` | 1 (CTOR) | Same as #9. |
+| 17 | `OCCTBridge_Document.mm:4294` | `OCCTXCAFPrsStyleCreate` | `result.hasCurvColor = false` | 1 (CTOR/GOOD) | Same as #13, for `curveColor`. |
+| 18 | `OCCTBridge_Document.mm:4307` | `OCCTXCAFPrsStyleCreateWithSurfColor` | `result.hasSurfColor = true` | 1 (CTOR) | This constructor's own parameters are `(r, g, b, alpha)` for the surface color, so `hasSurfColor` is unconditionally true by construction — correct, not fabricated. |
+| 19 | `OCCTBridge_Document.mm:4308` | `OCCTXCAFPrsStyleCreateWithSurfColor` | `result.curvR = 0` | 1 (CTOR) | No curve-color parameter exists on this constructor; `curvR/G/B` are placeholder defaults, inert because guarded by `hasCurvColor = false` at every consumer (`OCCTXCAFPrsStyleIsEqual` only calls `SetColorCurv` `if (s->hasCurvColor)`). |
+| 20 | `OCCTBridge_Document.mm:4308` | `OCCTXCAFPrsStyleCreateWithSurfColor` | `result.curvG = 0` | 1 (CTOR) | Same as #19. |
+| 21 | `OCCTBridge_Document.mm:4308` | `OCCTXCAFPrsStyleCreateWithSurfColor` | `result.curvB = 0` | 1 (CTOR) | Same as #19. |
+| 22 | `OCCTBridge_Document.mm:4309` | `OCCTXCAFPrsStyleCreateWithSurfColor` | `result.hasCurvColor = false` | 1 (CTOR) | Same as #19 — the gate itself. |
+| 23 | `OCCTBridge_Document.mm:4321` | `OCCTXCAFPrsStyleCreateFull` | `result.hasSurfColor = true` | 1 (CTOR) | This constructor's parameters include both a surface and curve color unconditionally, so both `has*` flags are true by construction on every call — correct. |
+| 24 | `OCCTBridge_Document.mm:4323` | `OCCTXCAFPrsStyleCreateFull` | `result.hasCurvColor = true` | 1 (CTOR) | Same as #23. |
+| 25 | `OCCTBridge_Document.mm:4325` | `OCCTXCAFPrsStyleCreateFull` | `result.isEmpty = false` | 1 (CTOR, verified by formula) | Went further than "plausible constant": read `XCAFPrs_Style::IsEmpty()`'s actual body (`Libraries/OCCT.xcframework/.../Headers/XCAFPrs_Style.hxx:35`): `return !myHasColorSurf && !myHasColorCurv && myMaterial.IsNull() && myIsVisible;`. Since this constructor always sets both colors (`hasSurfColor`/`hasCurvColor` both unconditionally `true`, #23/#24), the formula evaluates to `false` for every possible input to *this specific constructor*, with no exception. The literal is not merely plausible, it is provably the only correct value here. |
+| 26 | `OCCTBridge_IO.mm:828` | `OCCTImportSTEPWithDiagnostics` | `result.solidCreated = true` | 1 (FLIP) | Set only inside `if (solidsCreated > 0)`, beside the real, computed `result.solidsCreated = solidsCreated` at the same line/depth — the literal is reached only because a real count was positive, the same "boolean flag flipped true because a condition held" idiom as `result.sewingApplied = true` four lines above it in the same function (already adjudicated FLIP in the parent census's own header comment, for that sibling site). |
+
+## The one correction to record
+
+Candidate #7 (`OCCTDocumentGetShapeColor`'s `result.a`) was pre-labeled **ALPHA** (ostensibly the
+same "no alpha channel" shape as candidate #3's `emissive.a`) in this repro directory's own
+`README.md`, written during the original census pass. Reading the function is what #763 asks for
+before trusting a census line, and doing so here overturns that verdict: `Quantity_Color` lacking
+an alpha *field* does not mean the `XCAFDoc_ColorTool` storage this function reads from lacks alpha
+*data* — it does not, and OCCT's own STEP importer proves it by writing real transparency through
+the RGBA overload of the same `SetColor` this bridge's `GetColor` call is the mirror of. This is the
+cautionary case #763 itself names (matching #605's shape): a value that looked like a correct
+structural constant on a first pass was actually a wrong choice of accessor, only visible by reading
+the OCCT source underneath the call rather than the OCCT value type's own field list.
+
+## Fix implemented (Verdict 2)
+
+`Sources/OCCTBridge/src/OCCTBridge_Document.mm`, `OCCTDocumentGetShapeColor`: switched the read from
+`Quantity_Color` to `Quantity_ColorRGBA`, populating `result.a` from `color.Alpha()` instead of the
+literal `1.0`. Mirrors `OCCTDocumentGetLabelColor`, which already did this correctly for the
+label-keyed sibling.
+
+**Companion fix, not itself a census candidate, needed to make the above testable and coherent:**
+`OCCTDocumentSetShapeColor` (the writer) stores through the RGB-only `SetColor` overload, so no
+alpha set through it was ever recoverable — and `Document.setShapeColor(_:color:type:)` was silently
+dropping `color.alpha` before it even reached the bridge, despite `Color` already carrying an
+`alpha` field. Left as-is, the getter fix could never be exercised by any Swift-reachable write path
+except a file import. Added a new, additive C function `OCCTDocumentSetShapeColorRGBA` (using the
+`Quantity_ColorRGBA` `SetColor` overload) and pointed `Document.setShapeColor` at it instead of the
+old RGB-only function, now forwarding `color.alpha`. No existing signature changed — the new bridge
+function is additive, and the Swift-facing API (`setShapeColor(_:color:type:)`) keeps its exact
+signature; only its internal behavior is corrected. **SemVer: PATCH-compatible / non-breaking**
+(same public signatures on the Swift side; new function added to the bridge's C surface, not a
+removal or a type change).
+
+## Removal matrix (prove the test fails)
+
+New tests, `Tests/OCCTXCAFTests/OCCTXCAFTests.swift`, suite `XDE ColorTool by Shape`:
+
+- `shapeColorPreservesAlpha` — sets a shape color with `alpha: 0.5`, asserts the read-back color's
+  `alpha` is `0.5` (was always `1.0` before the fix).
+- `shapeColorOpaqueUnaffected` — regression guard: a fully-opaque color still round-trips to `1.0`.
+
+| Step | `shapeColorPreservesAlpha` | `shapeColorOpaqueUnaffected` | Pre-existing `setAndGetColor` |
+|---|---|---|---|
+| Defect injected (reverted `OCCTDocumentGetShapeColor` to the original `Quantity_Color`/hardcoded `1.0`, kept the RGBA setter fix) | **FAILED** — `abs(got.alpha - 0.5) → 0.5` not `< 1e-5` | passed (0.5 alpha bug happens to be invisible at alpha=1.0) | passed (never asserted on alpha) |
+| Fix restored | passed | passed | passed |
+
+Defect injection method: reverted only the `Quantity_ColorRGBA color; ... result.a = color.Alpha();`
+block back to `Quantity_Color color; ... result.a = 1.0;` (the exact original code), left the new
+`OCCTDocumentSetShapeColorRGBA` setter untouched, ran `swift test --filter XDEColorToolByShapeTests`,
+confirmed the new alpha test failed with the expected assertion message, restored from a backup of
+the pre-edit file, re-ran, confirmed all 4 tests in the suite passed.
+
+## Gates and full suite
+
+`Scripts/census-unmeasured-values.py` re-run after the fix confirms `OCCTDocumentGetShapeColor`'s
+`result.a` line no longer appears in the `OCCTBridge_Document.mm` candidate list (it is now a
+computed field, `color.Alpha()`), and no new candidates were introduced by the new
+`OCCTDocumentSetShapeColorRGBA` function (it has no aggregate result struct — void return, no
+literal-vs-computed sibling shape for the census to flag).

--- a/Sources/OCCTBridge/include/OCCTBridge_Document.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Document.h
@@ -895,8 +895,18 @@ bool OCCTDocumentExpandShape(OCCTDocumentRef doc, int64_t labelId);
 void OCCTDocumentSetShapeColor(OCCTDocumentRef doc, OCCTShapeRef shape,
     int32_t colorType, double r, double g, double b);
 
+/// Set RGBA color on a shape (not by label), preserving alpha (#763).
+/// `OCCTDocumentSetShapeColor` above stores through the RGB-only
+/// `XCAFDoc_ColorTool::SetColor` overload, so alpha is unrecoverable afterwards; this uses the
+/// RGBA overload so a subsequent `OCCTDocumentGetShapeColor` reports the real value.
+/// @param colorType 0=generic, 1=surface, 2=curve
+void OCCTDocumentSetShapeColorRGBA(OCCTDocumentRef doc, OCCTShapeRef shape,
+    int32_t colorType, double r, double g, double b, float alpha);
+
 /// Get color for a shape (not by label).
-/// @return OCCTColor with isSet=true if color was found
+/// @return OCCTColor with isSet=true if color was found. `a` is the color's real alpha (#763):
+///   1.0 for a color stored via the RGB-only `SetColor` overload, and the stored value otherwise
+///   (e.g. a STEP import with a transparent surface style, or `OCCTDocumentSetShapeColorRGBA`).
 OCCTColor OCCTDocumentGetShapeColor(OCCTDocumentRef doc, OCCTShapeRef shape, int32_t colorType);
 
 /// Check if color is set on a shape.

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -3037,17 +3037,30 @@ void OCCTDocumentSetShapeColor(OCCTDocumentRef doc, OCCTShapeRef shape,
     } catch (...) {}
 }
 
+void OCCTDocumentSetShapeColorRGBA(OCCTDocumentRef doc, OCCTShapeRef shape,
+    int32_t colorType, double r, double g, double b, float alpha) {
+    if (!doc || !shape || doc->colorTool.IsNull()) return;
+    try {
+        Quantity_ColorRGBA color(Quantity_Color(r, g, b, Quantity_TOC_RGB), alpha);
+        doc->colorTool->SetColor(shape->shape, color, static_cast<XCAFDoc_ColorType>(colorType));
+    } catch (...) {}
+}
+
 OCCTColor OCCTDocumentGetShapeColor(OCCTDocumentRef doc, OCCTShapeRef shape, int32_t colorType) {
     OCCTColor result = {0, 0, 0, 1.0, false};
     if (!doc || !shape || doc->colorTool.IsNull()) return result;
     try {
-        Quantity_Color color;
+        // #763: read via the RGBA overload (XCAFDoc_ColorTool::GetColor(shape, type, Quantity_Color&)
+        // internally fetches the RGBA value and then discards alpha) so a real stored alpha -
+        // e.g. from a STEP import's transparent surface style, or OCCTDocumentSetShapeColorRGBA -
+        // is reported instead of the hardcoded 1.0 OCCTDocumentGetLabelColor already avoids.
+        Quantity_ColorRGBA color;
         bool hasColor = doc->colorTool->GetColor(shape->shape, static_cast<XCAFDoc_ColorType>(colorType), color);
         if (hasColor) {
-            result.r = color.Red();
-            result.g = color.Green();
-            result.b = color.Blue();
-            result.a = 1.0;
+            result.r = color.GetRGB().Red();
+            result.g = color.GetRGB().Green();
+            result.b = color.GetRGB().Blue();
+            result.a = color.Alpha();
             result.isSet = true;
         }
     } catch (...) {}

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -3030,11 +3030,12 @@ bool OCCTDocumentExpandShape(OCCTDocumentRef doc, int64_t labelId) {
 
 void OCCTDocumentSetShapeColor(OCCTDocumentRef doc, OCCTShapeRef shape,
     int32_t colorType, double r, double g, double b) {
-    if (!doc || !shape || doc->colorTool.IsNull()) return;
-    try {
-        Quantity_Color color(r, g, b, Quantity_TOC_RGB);
-        doc->colorTool->SetColor(shape->shape, color, static_cast<XCAFDoc_ColorType>(colorType));
-    } catch (...) {}
+    // #763: delegates rather than storing through the RGB-only SetColor overload. It has no callers
+    // left (Document.setShapeColor moved to the RGBA entry point), but it stays exported and so
+    // stays reachable, and the two bodies side by side were one copy-paste away from silently
+    // reintroducing the alpha loss this pass just fixed. Opaque is the only alpha an RGB-only
+    // caller can mean.
+    OCCTDocumentSetShapeColorRGBA(doc, shape, colorType, r, g, b, 1.0f);
 }
 
 void OCCTDocumentSetShapeColorRGBA(OCCTDocumentRef doc, OCCTShapeRef shape,

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -963,16 +963,34 @@ extension Document {
 
 extension Document {
     /// Set color on a shape directly (not by label).
+    ///
+    /// `color.alpha` is preserved (#763) — previously it was silently dropped, so a subsequent
+    /// ``shapeColor(_:type:)`` always reported fully opaque regardless of what was set here.
+    ///
     /// - Parameters:
     ///   - shape: The shape to color
     ///   - color: The color to set
     ///   - type: Color type — generic (0), surface (1), or curve (2)
+    ///
+    /// ```swift
+    /// let doc = Document.create()!
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// doc.addShape(box)
+    /// doc.setShapeColor(box, color: Color(red: 1, green: 0, blue: 0, alpha: 0.5))
+    /// let readBack = doc.shapeColor(box)
+    /// // readBack?.alpha == 0.5
+    /// ```
     public func setShapeColor(_ shape: Shape, color: Color, type: OCCTColorType = OCCTColorTypeSurface) {
-        OCCTDocumentSetShapeColor(handle, shape.handle, Int32(type.rawValue),
-                                   color.red, color.green, color.blue)
+        OCCTDocumentSetShapeColorRGBA(handle, shape.handle, Int32(type.rawValue),
+                                       color.red, color.green, color.blue, Float(color.alpha))
     }
 
     /// Get color for a shape (not by label).
+    ///
+    /// `alpha` reflects the real stored value (#763) — a shape colored via
+    /// ``setShapeColor(_:color:type:)`` or imported from a file with a transparent surface style
+    /// reports its actual alpha, rather than always 1.0.
+    ///
     /// - Parameters:
     ///   - shape: The shape to query
     ///   - type: Color type — generic (0), surface (1), or curve (2)

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -2372,6 +2372,55 @@ struct XDEColorToolByShapeTests {
             }
         }
     }
+
+    // #763: `shapeColor` used to hardcode `a = 1.0` regardless of what was actually stored —
+    // `XCAFDoc_ColorTool::GetColor(shape, type, Quantity_Color&)` fetches the real RGBA value
+    // internally and then discards alpha, and the bridge was reading it through that overload.
+    // A shape colored with a translucent color must read back its real alpha, not a fabricated
+    // fully-opaque constant.
+    @Test("Shape color round-trips a non-opaque alpha (#763)")
+    func shapeColorPreservesAlpha() {
+        guard let doc = Document.create() else {
+            #expect(Bool(false), "Failed to create document")
+            return
+        }
+        guard let box = Shape.box(width: 10, height: 20, depth: 30) else {
+            #expect(Bool(false), "Failed to create box")
+            return
+        }
+        doc.addShape(box)
+        let translucent = Color(red: 0.2, green: 0.4, blue: 0.6, alpha: 0.5)
+        doc.setShapeColor(box, color: translucent)
+        #expect(doc.isShapeColorSet(box))
+        if let got = doc.shapeColor(box) {
+            #expect(abs(got.red - 0.2) < 1e-5)
+            #expect(abs(got.green - 0.4) < 1e-5)
+            #expect(abs(got.blue - 0.6) < 1e-5)
+            #expect(abs(got.alpha - 0.5) < 1e-5)
+        } else {
+            #expect(Bool(false), "Expected a color to be set")
+        }
+    }
+
+    @Test("Shape color round-trips full opacity (#763 regression guard)")
+    func shapeColorOpaqueUnaffected() {
+        guard let doc = Document.create() else {
+            #expect(Bool(false), "Failed to create document")
+            return
+        }
+        guard let box = Shape.box(width: 10, height: 20, depth: 30) else {
+            #expect(Bool(false), "Failed to create box")
+            return
+        }
+        doc.addShape(box)
+        let opaque = Color(red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0)
+        doc.setShapeColor(box, color: opaque)
+        if let got = doc.shapeColor(box) {
+            #expect(abs(got.alpha - 1.0) < 1e-5)
+        } else {
+            #expect(Bool(false), "Expected a color to be set")
+        }
+    }
 }
 
 @Suite("XDE Area Volume Centroid")

--- a/docs/reference/Document-Persistence-IO.md
+++ b/docs/reference/Document-Persistence-IO.md
@@ -1287,7 +1287,7 @@ Methods on `Document` for assigning and querying colors directly on `Shape` valu
 
 ### `setShapeColor(_:color:type:)`
 
-Set a color on a shape.
+Set a color on a shape, including alpha (#763).
 
 ```swift
 public func setShapeColor(_ shape: Shape, color: Color, type: OCCTColorType = OCCTColorTypeSurface)
@@ -1295,23 +1295,40 @@ public func setShapeColor(_ shape: Shape, color: Color, type: OCCTColorType = OC
 
 - **Parameters:**
   - `shape` — the shape to color.
-  - `color` — RGB color value.
+  - `color` — RGBA color value. `color.alpha` is stored, not just RGB.
   - `type` — `OCCTColorTypeGeneric` (0), `OCCTColorTypeSurface` (1), or `OCCTColorTypeCurve` (2). Default is surface color.
-- **OCCT:** `XCAFDoc_ColorTool::SetColor`.
+- **OCCT:** `XCAFDoc_ColorTool::SetColor` (the `Quantity_ColorRGBA` overload).
+- Before #763, `color.alpha` was silently dropped on write (stored through the RGB-only
+  `SetColor` overload), so a subsequent `shapeColor(_:type:)` always read back `alpha == 1.0`
+  regardless of what was set here.
+
+```swift
+let doc = Document.create()!
+let box = Shape.box(width: 10, height: 10, depth: 10)!
+doc.addShape(box)
+doc.setShapeColor(box, color: Color(red: 1, green: 0, blue: 0, alpha: 0.5))
+let readBack = doc.shapeColor(box)
+// readBack?.alpha == 0.5
+```
 
 ---
 
 ### `shapeColor(_:type:)`
 
-Get the color assigned to a shape.
+Get the color assigned to a shape, with its real alpha (#763).
 
 ```swift
 public func shapeColor(_ shape: Shape, type: OCCTColorType = OCCTColorTypeSurface) -> Color?
 ```
 
 - **Parameters:** `shape` — shape to query; `type` — color type.
-- **Returns:** `Color` if a color of the given type is set, `nil` otherwise.
-- **OCCT:** `XCAFDoc_ColorTool::GetColor`.
+- **Returns:** `Color` if a color of the given type is set, `nil` otherwise. `alpha` is the real
+  stored value: before #763 it was hardcoded to `1.0` regardless of what was actually set (the
+  bridge read through `XCAFDoc_ColorTool`'s RGB-only `GetColor` overload, which fetches the real
+  RGBA value internally and then discards alpha). A shape colored via `setShapeColor(_:color:type:)`
+  with `alpha < 1.0`, or imported from a file with a transparent surface style, now reports its
+  actual alpha.
+- **OCCT:** `XCAFDoc_ColorTool::GetColor` (the `Quantity_ColorRGBA` overload).
 
 ---
 


### PR DESCRIPTION
## What & why

Triages the `OCCTBridge_Document.mm` (25) + `OCCTBridge_IO.mm` (1) half of #763's 62
unmeasured-value candidates (parent: #726) — 26 of 62. Each candidate got a verdict (1: not an
instance / 2: compute it / 3: make absence representable / 4: remove the field) established by
reading the function and the OCCT call it wraps, not by the census line or the identifier alone,
per `okf/policies/measure-dont-assume.md`.

**Result: 25 Verdict 1 (not an instance), 1 Verdict 2 (compute it), 0 Verdict 3, 0 Verdict 4.**
No breaking changes in this PR.

Full per-candidate table with evidence: [`Scripts/repro/726-unmeasured-values/triage-document.md`](https://github.com/SecondMouseAU/OCCTSwift/blob/chore/763-triage-document/Scripts/repro/726-unmeasured-values/triage-document.md).

### The one fix (Verdict 2, non-breaking)

`OCCTDocumentGetShapeColor` hardcoded `result.a = 1.0`, reading through
`XCAFDoc_ColorTool::GetColor(shape, type, Quantity_Color&)` — the RGB-only overload. Reading
`XCAFDoc_ColorTool.cxx` directly shows that overload *internally* fetches the full RGBA value and
then discards alpha (`col = aCol.GetRGB();`); the underlying `XCAFDoc_Color` attribute always
stores real RGBA. A real, non-1.0 alpha reaches this exact storage today via STEP import
(`STEPCAFControl_Reader.cxx:2341` sets shape colors with `Quantity_ColorRGBA` carrying the file's
transparency). `OCCTDocumentGetLabelColor`, the label-keyed sibling three functions up in the same
file, already reads the RGBA overload correctly — this was the one inconsistent site.

**This overrides this repro directory's own prior README verdict for that exact site** (`ALPHA`,
"`Quantity_Color` has no alpha channel; `1.0` is the domain default"). That verdict conflated "the
C++ value type this call reads into has no alpha field" with "no alpha data exists to read" — not
the same claim, and the second is false here. Recorded as its own section in the triage table: this
is the #605-shaped case #763 warns about, a plausible-looking constant that was actually a wrong
choice of accessor, caught only by reading the OCCT source underneath the call.

**Companion change, not itself a census candidate:** `OCCTDocumentSetShapeColor` (the writer) only
ever stored through the RGB-only `SetColor` overload, and `Document.setShapeColor` was silently
dropping `color.alpha` before it reached the bridge at all, despite `Color` already carrying an
`alpha` field. Left alone, the getter fix would have been untestable from Swift except via a file
import. Added an additive `OCCTDocumentSetShapeColorRGBA` bridge function and pointed
`Document.setShapeColor` at it, forwarding `color.alpha`. No existing signature changed.

### Why 25 of 26 were "not an instance"

Most of this file's candidates are exactly the false-positive shapes the census's own header
comment documents: 6 are default-then-flip validity/presence flags (a literal `false`/`true` at the
top of a function, flipped only after a real OCCT call succeeds — the "make absence representable"
idiom #583/#595/#609 already established, not an instance of the bug those fixed), 1 is a genuine
structural constant (`XCAFDoc_VisMaterialPBR::EmissiveFactor` is `NCollection_Vec3<float>` per the
OCCT header — no alpha field exists anywhere upstream for emissive color), 18 are three plain
value-type constructors (`OCCTXCAFPrsStyleCreate*`) that build a request from Swift-supplied
parameters and are never used to read a style back out of a document (traced every call site: the
only caller is `PresentationStyle.toOCCT()`), and 1 is the `sewingApplied`-shaped "flag flipped true
because a real count was positive" idiom. Each is verified against the OCCT header/source or a
call-site trace, recorded in the table — not asserted from the field name.

## Tests

`Tests/OCCTXCAFTests/OCCTXCAFTests.swift`, suite `XDE ColorTool by Shape`:
- `shapeColorPreservesAlpha` — sets alpha 0.5 on a shape color, asserts it reads back as 0.5.
- `shapeColorOpaqueUnaffected` — regression guard: a fully-opaque color still round-trips to 1.0.

### Removal matrix (prove the test fails)

| Step | `shapeColorPreservesAlpha` | `shapeColorOpaqueUnaffected` | pre-existing `setAndGetColor` |
|---|---|---|---|
| Defect injected (reverted `OCCTDocumentGetShapeColor` to `Quantity_Color`/hardcoded `1.0`; kept the RGBA setter) | **FAILED** — `abs(got.alpha - 0.5) → 0.5` not `< 1e-5` | passed (bug invisible at alpha=1.0) | passed (never asserted on alpha) |
| Fix restored | passed | passed | passed |

## Gates and full suite

- All 5 gate scripts: clean (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `derive-bridge-header-split --verify`, `count-operations`).
- All 5 gates' `--self-test`, plus `census-unmeasured-values.py --self-test`: all green
  (18/18, 24/24, 13/13, 8/8, 10/10 respectively).
- `census-unmeasured-values.py` re-run after the fix: `OCCTDocumentGetShapeColor`'s `result.a` line
  is gone from the `OCCTBridge_Document.mm` candidate list; the new `OCCTDocumentSetShapeColorRGBA`
  introduced no new candidates (void return, no aggregate-result shape for the census to flag).
- Full `swift test`: **5483 tests, 1428 suites, 0 failures.**

## CHANGELOG entry

### `Document.shapeColor`/`setShapeColor` now round-trip alpha correctly (#763)

`Document.shapeColor(_:type:)` previously always reported `alpha == 1.0` regardless of what was
actually stored, because the bridge read a shape's color through `XCAFDoc_ColorTool`'s RGB-only
`GetColor` overload. It now reads the RGBA overload and reports the real value — for example, a
STEP import with a transparent surface style. `Document.setShapeColor(_:color:type:)` previously
silently dropped `color.alpha` on write; it is now stored and round-trips through `shapeColor`.

## SemVer impact

PATCH. No public signature changed. `Document.setShapeColor`/`shapeColor` keep their exact
signatures; a new additive bridge function (`OCCTDocumentSetShapeColorRGBA`) was added to the C
surface, which is not part of the Swift-facing API surface `count-operations.py` tracks. Consumers
see a corrected value from `shapeColor` (previously always `1.0`) and a previously-dropped `alpha`
on `setShapeColor` now actually taking effect — a bug fix, not a behavior a correct caller could
have been relying on to be otherwise.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported above
      (removal matrix).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- This is the `OCCTBridge_Document.mm` + `OCCTBridge_IO.mm` half of #763 (26 of 62 candidates).
  The other 36 (Topology/Healing/Properties/BRepGraph + six others) are separate work per #763's
  own table (Pass 2a / #382).
- `docs/reference/Document-Persistence-IO.md`'s `setShapeColor`/`shapeColor` entries were updated
  to describe the corrected alpha handling, per `docs/` staying current with behavior changes.
- Flagging explicitly for review: the override of this repro directory's own prior `README.md`
  verdict on `OCCTDocumentGetShapeColor`'s `result.a` (was `ALPHA`, now Verdict 2/fixed). I did not
  edit that README in this PR — it documents the *first census run's* first-pass analysis, and
  correcting it retroactively felt like it belonged in a PR about the README itself rather than one
  fixing the bug it missed. Happy to add a note there too if preferred.
- No verdict-3/4 (breaking) candidates in this half — nothing to flag against the v2.0.0 line here.
