### PR TITLE
fix(#763): triage core bridge files' unmeasured-value candidates

### DIFF
--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -31,9 +31,17 @@ A derivation that can be re-run does not go stale the same way a hand-count does
 WHAT THIS DOES NOT DO, DELIBERATELY: this is a CENSUS, not a gate. It is not wired into
 `ci.yml`'s `gate-scripts` job, and its exit code in report mode is always 0 (barring a crash) even
 when it finds candidates. Every one of the sites below still needs a human verdict. Some are
-real instances of the class; several measured here are the OPPOSITE, a value that already uses the
-"make absence representable" fix #583/#595/#609 established (e.g. `OCCTShapeAxis.hasExtent`
-correctly gating `extentMin`/`extentMax` into a `nil` on the Swift side). And #726 itself scopes
+real instances of the class; several measured are the OPPOSITE, a value that already uses the
+"make absence representable" fix #583/#595/#609 established.
+
+DO NOT TRUST AN EXAMPLE IN THIS COMMENT OVER A MEASUREMENT. Until #763 this paragraph named
+`OCCTShapeAxis.hasExtent` as its example of the correct pattern, "correctly gating
+`extentMin`/`extentMax` into a `nil` on the Swift side". It was not correct. All three assignments
+in `OCCTBridge_Topology.mm` set it `false` and nothing anywhere set it `true`, so `ShapeAxis.extent`
+was unconditionally `nil` and the gating never gated anything. It was the same defect as
+`selfIntersectionCount`, one layer removed, dressed as the remedy for it. The census had flagged
+that exact site and a reader dismissed it from the shape of the code rather than by checking whether
+the flag ever flips. And #726 itself scopes
 the gate-script question ("a struct field assigned only a literal across every path") as a
 follow-up spike, not something this pass commits to.
 

--- a/Scripts/repro/726-unmeasured-values/triage-core.md
+++ b/Scripts/repro/726-unmeasured-values/triage-core.md
@@ -2,8 +2,8 @@
 
 Scope: `OCCTBridge_Topology.mm` (9), `OCCTBridge_Healing.mm` (9), `OCCTBridge_Properties.mm` (7),
 `OCCTBridge_BRepGraph.mm` (4), `OCCTBridge_Surface.mm` (2), `OCCTBridge_Modeling.mm` (2),
-`OCCTBridge_Spatial.mm` (1), `OCCTBridge_Geom2d.mm` (1), `OCCTBridge_Curve3D.mm` (1). The sibling
-36 (`OCCTBridge_Document.mm`/`OCCTBridge_IO.mm`) are triaged separately on
+`OCCTBridge_Spatial.mm` (1), `OCCTBridge_Geom2d.mm` (1), `OCCTBridge_Curve3D.mm` (1) — 36 lines
+total. The sibling 26 (`OCCTBridge_Document.mm`/`OCCTBridge_IO.mm`) are triaged separately on
 `chore/763-triage-document`.
 
 File:line below is where `python3 Scripts/census-unmeasured-values.py` reported the candidate on
@@ -21,17 +21,24 @@ label turned out to be checking the wrong thing.
 
 ## Verdict counts
 
-| Verdict | Count |
-|---|---|
-| 1. Not an instance | 34 |
-| 2. Compute it | 1 (7 fields, 2 functions — see below) |
-| 3. Make absence representable | 0 |
-| 4. Remove the field | 1 |
+Counted per census *line* (36 total, matching `census-unmeasured-values.py`'s own unit — one line
+per flagged `(function, field)` pair, so `OCCTShapeSymmetryAxes`'s two `OCCTShapeAxis`
+constructions at lines 694/713 share one line each for `extentMin`/`extentMax`/`hasExtent`/`kind`,
+per the script's own (function, field-name) dedup):
 
-35 of 36 lines are verdict 1; two lines carry the two non-1 verdicts. The `hasExtent` finding
-spans 7 of the 36 census lines (both `OCCTShapeRevolutionAxes` and `OCCTShapeSymmetryAxes`'s
-`extentMin`/`extentMax`/`hasExtent`, plus `OCCTShapeSymmetryAxes`'s `kind` which stays verdict 1
-after the fix), counted here as one implementation item.
+| Verdict | Count | Lines |
+|---|---|---|
+| 1. Not an instance | 29 | all except the 7 below |
+| 2. Compute it | 6 | `Topology.mm:653` `extentMin`/`extentMax`/`hasExtent`, `Topology.mm:694` `extentMin`/`extentMax`/`hasExtent` — one implementation (`occtComputeAxisExtent`, see below) covering both call sites |
+| 3. Make absence representable | 0 | — |
+| 4. Remove the field | 1 | `Healing.mm:303` `selfIntersectionCount` |
+
+`Topology.mm:694`'s fourth field, `kind`, stays **verdict 1** even though it sits on the same line
+as three verdict-2 fields — it is a real branch-selected constant (always 7, "symmetry"), not a
+fabricated measurement, and untouched by the extent fix. So of `OCCTShapeSymmetryAxes`'s four
+flagged fields at that line, three are verdict 2 and one is verdict 1; `OCCTShapeRevolutionAxes`'s
+three flagged fields at `:653` are all verdict 2. 29 (verdict 1) + 6 (verdict 2) + 1 (verdict 4) =
+36.
 
 ## Verdict 4: remove `selfIntersectionCount` — IMPLEMENTED
 

--- a/Scripts/repro/726-unmeasured-values/triage-core.md
+++ b/Scripts/repro/726-unmeasured-values/triage-core.md
@@ -1,0 +1,290 @@
+# #763 triage: the non-Document/IO half (36 of 62 candidates)
+
+Scope: `OCCTBridge_Topology.mm` (9), `OCCTBridge_Healing.mm` (9), `OCCTBridge_Properties.mm` (7),
+`OCCTBridge_BRepGraph.mm` (4), `OCCTBridge_Surface.mm` (2), `OCCTBridge_Modeling.mm` (2),
+`OCCTBridge_Spatial.mm` (1), `OCCTBridge_Geom2d.mm` (1), `OCCTBridge_Curve3D.mm` (1). The sibling
+36 (`OCCTBridge_Document.mm`/`OCCTBridge_IO.mm`) are triaged separately on
+`chore/763-triage-document`.
+
+File:line below is where `python3 Scripts/census-unmeasured-values.py` reported the candidate on
+`refactor/381-pass1b` at `809f148` (branch point for this work), before any fix in this PR moved
+lines around. Each row's evidence is independent verification per
+`okf/policies/measure-dont-assume.md`: the function was read in full and, where an OCCT call is
+involved, its real behaviour was checked against the header (or `occt-refman`), not inferred from
+the identifier or the census's own pattern name.
+
+An earlier census-only pass (`Scripts/repro/726-unmeasured-values/README.md`, written against an
+earlier commit on this same branch) already adjudicated most of these sites. Its verdicts are
+noted where they agree. **One of them is corrected here** — see the `hasExtent` rows below — which
+is itself the point of re-verifying rather than transcribing: a previous "GOOD (already fixed)"
+label turned out to be checking the wrong thing.
+
+## Verdict counts
+
+| Verdict | Count |
+|---|---|
+| 1. Not an instance | 34 |
+| 2. Compute it | 1 (7 fields, 2 functions — see below) |
+| 3. Make absence representable | 0 |
+| 4. Remove the field | 1 |
+
+35 of 36 lines are verdict 1; two lines carry the two non-1 verdicts. The `hasExtent` finding
+spans 7 of the 36 census lines (both `OCCTShapeRevolutionAxes` and `OCCTShapeSymmetryAxes`'s
+`extentMin`/`extentMax`/`hasExtent`, plus `OCCTShapeSymmetryAxes`'s `kind` which stays verdict 1
+after the fix), counted here as one implementation item.
+
+## Verdict 4: remove `selfIntersectionCount` — IMPLEMENTED
+
+**`OCCTBridge_Healing.mm:303`, `OCCTShapeAnalyze()`: `result.selfIntersectionCount = 0;  // Would
+require more expensive computation`.**
+
+This is #726's own named seed instance. Verified independently before acting:
+
+- Grepped every reference: the field was read by exactly two Swift call sites
+  (`Shape+Analysis.swift`'s `analyze(tolerance:)` construction, and
+  `ShapeAnalysisResult.totalProblems`'s sum), and by two test files
+  (`Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift`,
+  `Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift`), both of which only re-derive
+  `totalProblems` from the same fields `analyze()` returns — no test asserted a *specific*
+  self-intersection count, because there was never a real one to assert.
+- Confirmed `Shape.isSelfIntersecting(timeout:)` / `isSelfIntersecting(hardTimeout:)`
+  (`Sources/OCCTSwift/Shape.swift:2107`/`2150`) already answer the question this field claims to,
+  via `OCCTShapeSelfIntersectsBounded` → `BOPAlgo_ArgumentAnalyzer`'s real self-interference check
+  (the #319 kernel work: `Intf_Interference`, cooperative and hard-timeout variants). This is a
+  materially different, working computation, not a stub.
+  `isSelfIntersecting(hardTimeout:)` additionally runs on a `deepCopy()` on a background thread
+  with a real wall-clock deadline, TSan-verified per its doc comment.
+- The field's own header comment already documented it as unimplemented and #702 (PR #717)
+  documented the same on the Swift side. Nothing about the field can ever go from "false negative"
+  to "true measurement" without becoming a duplicate, worse-typed version of
+  `isSelfIntersecting`. There is no forward-compatible reason to keep it.
+
+**Verdict: 4 — remove.** Implemented:
+
+- `OCCTShapeAnalysisResult` (`OCCTBridge_Healing.h`): field deleted, aggregate initializer at
+  `OCCTShapeAnalyze`'s top (`{0,0,0,0,0,0,false,false}` → `{0,0,0,0,0,false,false}`) updated to
+  match the new 7-field layout.
+  `OCCTBridge_Healing.mm:303`: assignment deleted.
+- `ShapeAnalysisResult` (Swift, `ShapeAnalysisResult.swift`): stored property deleted;
+  `totalProblems` no longer sums it (numerically a no-op, since the term was always 0 — the
+  *type* is what changes, not any existing computed answer).
+- `Shape+Analysis.swift`: construction call site updated; doc comment on `analyze(tolerance:)`
+  updated to point at `isSelfIntersecting(timeout:)` without referencing the removed field.
+- Docs: `docs/reference/Shape-Features.md`, `docs/guides/cookbook/healing-and-validity.md` — both
+  named the field explicitly and are updated (see "Documentation" below).
+- Tests: `OCCTShapeHealingTests.swift`'s `analysisResultProperties()` and
+  `Issue702SolidDemotionTests.swift`'s `totalProblemsExcludingFreeFace(_:)` helper both dropped the
+  term from their independently-recomputed `expectedTotal` (both still pass — see "Test results"
+  below; this alone is not a strong regression check since the term contributed 0 either way, but
+  it does prove the removal doesn't break either file's compile or its arithmetic).
+
+**Not a `prove-the-test-fails` candidate in the injection sense**: this is a field *removal*, not
+a new detector or a new positive check, so there is no "inject the defect, watch a test go red"
+cycle that applies — the compiler is the enforcement (any code still reading the field fails to
+build), and it did, twice, until the two test files and the aggregate initializer were updated.
+Both are reported under "Build/compile fallout" below.
+
+## Verdict 2: compute `ShapeAxis.extent` (`hasExtent`/`extentMin`/`extentMax`) — IMPLEMENTED
+
+**`OCCTBridge_Topology.mm:653` (`OCCTShapeRevolutionAxes`) and `:694`/`:713`
+(`OCCTShapeSymmetryAxes`, both `OCCTShapeAxis` constructions): `a.extentMin = 0; a.extentMax = 0;
+a.hasExtent = false;` on every reached path, for both functions, unconditionally.**
+
+**This is where the earlier census-only pass's verdict does not hold up, and it is worth being
+explicit about why**, since `okf/policies/measure-dont-assume.md` is largely about this exact
+trap. `Scripts/repro/726-unmeasured-values/README.md` (an earlier pass, written against an earlier
+commit on this branch) labelled this "GOOD — known-negative control #2: gated into `nil` by
+`ShapeAxis.swift:34`", i.e. verdict 1, on the reasoning that `self.extent = a.hasExtent ? (...) :
+nil` is exactly the #583/#595/#609 "absence made representable" idiom.
+
+Measured directly, independent of that reasoning:
+
+```
+grep -rn "hasExtent" Sources/OCCTBridge/src/*.mm Sources/OCCTBridge/include/*.h Sources/OCCTSwift/*.swift
+```
+
+`hasExtent` is assigned `false` at exactly three sites in the whole tree and **`true` at none**.
+The #583/#595/#609 idiom requires a field that is `false` on some real paths and `true` on others,
+established by real control flow (`isValid`/`success` flags elsewhere in this exact triage are the
+correct version of that shape — see the "Not an instance" table below, where dozens of them are
+verified to actually flip). `hasExtent` does not flip. It is the *same literal on every reached
+path*, which the census script's own docstring names explicitly as "the dangerous shape... only a
+field that is the SAME literal on EVERY assignment this script found... is the dangerous shape."
+Wrapping a permanently-`false` flag in an `Optional` at the Swift layer does not change that the
+underlying value was never computed — it changes what the "never measured" case looks like from
+`0`/`0` to `nil`, one layer removed from `selfIntersectionCount`'s own shape, not a different
+class of thing.
+
+Confirmed the field was also **completely dead on the read side**: `grep -rn "\.extent\b"` across
+`Sources/OCCTSwift/*.swift` and `Tests/**/*.swift` finds `ShapeAxis.extent` written (by its two
+initializers) and never read anywhere in this repository, including its own test suite — no test
+constructed a `ShapeAxis` by hand or asserted anything about `.extent`.
+
+Checked the header's own contract before deciding what to implement (not inventing new semantics):
+`OCCTBridge_Topology.h`'s `OCCTShapeAxis` struct already documented the exact intended contract —
+`extentMin // along direction from origin (-inf as -DBL_MAX)`, `extentMax // +inf as DBL_MAX` —
+years before this fix. This reads as an incomplete feature (the v0.137 axis-extraction release,
+`docs/CHANGELOG.md`'s v0.137.0 entry, never mentions `extent` as delivered functionality at all),
+not a deliberately deferred one like `selfIntersectionCount`'s "would require more expensive
+computation".
+
+**Verdict: 2 — compute it (non-breaking: `extent`'s type does not change, `ClosedRange<Double>?`
+either way; only some previously-impossible non-nil values become reachable).**
+
+### Implementation
+
+New static helper `occtComputeAxisExtent` (`OCCTBridge_Topology.mm`, ahead of
+`OCCTShapeRevolutionAxes`): computes `BRepBndLib::Add`'s geometric bounding box of the axis's own
+shape (the face, for a revolution axis; the whole shape, for a symmetry axis), then projects all 8
+corners onto the axis direction from the axis origin — the min and max of those 8 dot products is
+the reported `extentMin`/`extentMax`. `Bnd_Box::IsVoid()` (no boundable geometry) reports
+`hasExtent = false`; `Bnd_Box::IsOpen()` (untrimmed/unbounded geometry) reports `hasExtent = true`
+with `+-std::numeric_limits<double>::max()`, honouring the header's own already-documented
+`+-DBL_MAX` sentinel contract rather than treating `Bnd_Box`'s internal `Precision::Infinite()`
+(1e100) as if it were a real measured bound.
+
+This is exact wherever the bounding box is tight along the query direction — a bounded
+cylindrical/conical face along its own axis (no curvature bulges past the two flat end caps along
+that direction), a box along one of its own principal axes — and a safe enclosing interval
+otherwise (curved geometry whose true extent along an arbitrary direction is less than its box's).
+Both exact cases are the ones this PR's new tests check.
+
+Wired into all three call sites: `OCCTShapeRevolutionAxes` (per-face, axis = the face's own
+`gp_Ax1`), and both `OCCTShapeSymmetryAxes` constructions (whole-shape, axis origin = the
+already-computed centre of mass, direction = the relevant principal axis).
+
+`a.kind = 7` at these same two `OCCTShapeSymmetryAxes` sites is unaffected and **stays verdict
+1**: it is a branch-selected classification constant (`.symmetry`, distinguishing these axes from
+the revolution-axis kinds 1-5), not a fabricated measurement — every symmetry axis this function
+returns genuinely is kind 7, by construction, the same as `OCCTShapeRecognizeCanonical`'s
+`result.type` rows below.
+
+### Tests (new, in `Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift` and
+`Tests/OCCTTopologyTests/OCCTTopologyTests.swift`)
+
+- `ShapeRevolutionAxesTests.cylinderRevolutionAxisHasExtent`: a radius-5/height-20 cylinder's
+  lateral face reports a non-nil `extent` whose span (`upperBound - lowerBound`) is `20`, matching
+  `Shape.cylinder`'s own height. Asserts the *span* rather than absolute bounds because the axis
+  direction's sign is not fixed (the pre-existing `cylinderOneAxis` test already accepts either
+  sign), and the span is sign-independent while the absolute bounds are not.
+- `ShapeSymmetryAxesTests.cylinderSymmetryAxisHasExtent`: the same cylinder's symmetry axis (whose
+  origin is the shape's centre of mass, at half the height) reports `extent` of exactly
+  `-10...10`, sign-independent for the same reason (a symmetric interval about zero is invariant
+  under negating the projection direction).
+
+**Prove the test fails** (`okf/policies/prove-the-test-fails.md`): both tests were run once with
+the fix reverted (the three `occtComputeAxisExtent(...)` call sites replaced back with the
+original `a.extentMin = 0; a.extentMax = 0; a.hasExtent = false;` literals), confirmed red, then
+restored and confirmed green.
+
+| State | `cylinderRevolutionAxisHasExtent` | `cylinderSymmetryAxisHasExtent` |
+|---|---|---|
+| Defect injected (`hasExtent` hardcoded `false`) | FAILED — "expected a non-nil extent on the cylinder's revolution axis" | FAILED — "expected a non-nil extent on the cylinder's symmetry axis" |
+| Fix restored | PASSED | PASSED |
+
+Restore verified byte-identical to the pre-injection file (`diff` against a backup) before
+re-running.
+
+### Documentation
+
+- `Sources/OCCTBridge/include/OCCTBridge_Topology.h`: `hasExtent`'s field comment gained one line
+  clarifying it is `false` only for a void bounding box, not for "unbounded but real" (which now
+  gets the `+-DBL_MAX` sentinel and `hasExtent = true`).
+- `docs/reference/Geometry2D.md`'s `ShapeAxis.extent` section: rewritten. It previously stated,
+  as fact, `nil` for "most face types" and showed a worked example asserting `nil` for a
+  cylinder's revolution axis — both true before this fix and wrong after it. Now documents which
+  producers populate it (`revolutionAxes`/`symmetryAxes`, bounding-box-projection method) and
+  which don't (`primaryAxis`, never wired to it), with measured example values from the new tests.
+
+## Full per-candidate table (all 36)
+
+Legend: **FLIP** = default-then-flip success/validity flag, driven by real control flow (the
+#583/#595/#609 fix pattern, correctly applied). **GOOD** = already-representable absence, verified
+to actually flip (not just structurally resemble the pattern). **TAG** = branch-selected
+classification literal, not a fabrication. **CFG** = a local options/config struct passed as an
+argument, never returned — outside #726's "returned through an API" scope entirely. **CTOR** = a
+plain value constructor mirroring an upstream OCCT constructor's own signature exactly (verified
+against the real header). **COMPUTE** / **REMOVE** = the two action verdicts above.
+
+| File:line (original) | Function | Field | Verdict | Evidence |
+|---|---|---|---|---|
+| `BRepGraph.mm:218` | `OCCTBRepGraphCreate` | `opts.CreateAutoProduct` | 1 (CFG) | `opts` is a local `BRepGraph::ShapesView::Options`, passed by value into `Add()` two lines later; the function returns an `OCCTBRepGraphRef`, never `opts`. |
+| `BRepGraph.mm:1964` | `OCCTBRepGraphBuilderAppendFlattenedShape` | `opts.CreateAutoProduct` | 1 (CFG) | Same `Options` shape; function is `void`. |
+| `BRepGraph.mm:1965` | `OCCTBRepGraphBuilderAppendFlattenedShape` | `opts.Flatten` | 1 (CFG) | Same. |
+| `BRepGraph.mm:1975` | `OCCTBRepGraphBuilderAppendFullShape` | `opts.CreateAutoProduct` | 1 (CFG) | Same; function is `void`. |
+| `Curve3D.mm:2225` | `OCCTGeomConvertCurveToAnalytical` | `result.success` | 1 (FLIP) | `= true` only after `occtCurveToAnalytical(...)` returns `true` two lines above; every earlier path (`!curveRef`, conversion failure) returns with `success` at its `{...}` default `false`. |
+| `Geom2d.mm:2593` | `OCCTBisectorPointOnBisCreate` | `result.isInfinite` | 1 (CTOR) | Read `Bisector_PointOnBis.hxx` directly: its real 5-arg constructor (`Param1,Param2,ParamBis,Distance,Point`) has no `IsInfinite` parameter either — `IsInfinite(bool)` is a separate setter this ctor doesn't call. The bridge mirrors the real constructor exactly. Also fully orphaned: not called from anywhere in the bridge, no Swift wrapper. |
+| `Healing.mm:303` | `OCCTShapeAnalyze` | `result.selfIntersectionCount` | **4 — REMOVE** | See above. |
+| `Healing.mm:306` | `OCCTShapeAnalyze` | `result.isValid` | 1 (FLIP) | `false` default, `= true` only at the end after the shell/edge/face/wire/gap scan completes without throwing. |
+| `Healing.mm:1707-1709` | `OCCTShapeCheckSmallFaces` | `isSpotFace`/`isStripFace`/`isTwisted` | 1 (FLIP) | Each reset `false` per loop iteration, then individually flipped `true` a few lines below by its own real `checker.IsSpotFace`/`IsStripSupport`/`CheckTwisted` call. |
+| `Healing.mm:1910` | `OCCTCheckFace` | `result.isValid` | 1 (FLIP) | Null-input guard (`if (!face)`); the census's own docstring names this exact function as the "conditional depth is a count, not an identity" blind spot — the computed sibling it's paired against (`result.errorCount++`) is in an unrelated branch of the same function, not this guard. Read in full: the guard clause has no computed sibling of its own; it's ordinary input validation. |
+| `Healing.mm:1970` | `OCCTCheckSolid` | `result.isValid` | 1 (FLIP) | Same guard shape as `OCCTCheckFace`. |
+| `Healing.mm:2124` | `checkSubShape` (static) | `result.isValid` | 1 (FLIP) | `false` default; `= true` unconditionally after a real `BRepCheck_*` constructor + `Minimum()` succeed, then conditionally flipped back `false` per real status code in the loop below. |
+| `Healing.mm:2467` | `OCCTShapeNearestPlane` | `result.success` | 1 (FLIP) | `= true` only inside `if (ShapeAnalysis_Geom::NearestPlane(pts, pln, dmax))`, beside the real computed `maxDeviation`/normal/origin fields in the same block. |
+| `Modeling.mm:5361` | `OCCTChFi2dFilletAlgo` | `result.success` | 1 (FLIP) | `= true` only after `fillet.Perform(radius)` succeeds AND the resulting `filletEdge` is non-null. |
+| `Modeling.mm:5438` | `OCCTChFi2dAnaFillet` | `result.success` | 1 (FLIP) | Same shape, `ChFi2d_AnaFilletAlgo`. |
+| `Properties.mm:519` | `OCCTFaceProjectPoint` | `result.isValid` | 1 (FLIP) | `false` default; `GeomAPI_ProjectPointOnSurf` — `= true` only after `proj.NbPoints() > 0`. |
+| `Properties.mm:590` | `OCCTEdgeProjectPoint` | `result.isValid` | 1 (FLIP) | Same shape via `occtNearestPointOnCurveRange`. |
+| `Properties.mm:760` | `OCCTWireGetCurveInfo` | `result.isValid` | 1 (FLIP) | `false` default; `= true` at the end after the real length/closed/periodic/endpoint computation. |
+| `Properties.mm:896` | `OCCTWireGetCurvePointAt` | `result.isValid` | 1 (FLIP) | Same shape. |
+| `Properties.mm:897` | `OCCTWireGetCurvePointAt` | `result.hasNormal` | 1 (GOOD) | Verified it actually flips: `= true` only when curvature is non-degenerate (`> 1e-10`) AND the normal-direction vector's own magnitude is non-degenerate — read the full branch (lines 918-951), both guards are real. Swift side (`Wire.swift`) gates this into `SIMD3<Double>?`. |
+| `Properties.mm:1843` | `OCCTShapeGetProperties` | `result.isValid` | 1 (FLIP) | `false` default; `= true` only after `occtVolumeMassProperties` succeeds and volume/mass/inertia/area are all computed — the #609 fix (`occtVolumeMassProperties` itself refuses a zero-mass framework) is what this function relies on, already in place. |
+| `Properties.mm:1980` | `OCCTShapeDistance` | `result.isValid` | 1 (FLIP) | `= true` only inside `if (distCalc.IsDone() && distCalc.NbSolution() > 0)`, beside the real distance/point fields set in the same block. |
+| `Spatial.mm:2268` | `OCCTMathIntegKronrodAdaptive` | `config.Adaptive` | 1 (CFG) | `config` is a local `MathInteg::KronrodConfig` passed by value into `MathInteg::Kronrod(...)` on the next line; never returned. This is what makes the function the *Adaptive* variant, as opposed to the two-functions-above `OCCTMathIntegKronrod`, which doesn't set it at all. |
+| `Surface.mm:1207` | `OCCTShapeRecognizeCanonical` | `result.type` | 1 (TAG) | `= 1` only inside `if (recog.IsPlane(tolerance, pln))`; siblings `= 2/3/4/5` guard cylinder/cone/sphere/line the same way, each behind its own real `recog.Is*` check. |
+| `Surface.mm:2977` | `occtSurfToAnaSurfResult` (static) | `result.success` | 1 (FLIP) | `= true` only after `occtSurfaceToAnalytical(...)` returns `true`. |
+| `Topology.mm:653` | `OCCTShapeRevolutionAxes` | `a.extentMin`/`extentMax`/`hasExtent` | **2 — COMPUTE** | See above. |
+| `Topology.mm:694` | `OCCTShapeSymmetryAxes` | `a.extentMin`/`extentMax`/`hasExtent` | **2 — COMPUTE** | See above (both `OCCTShapeAxis` construction sites in this function). |
+| `Topology.mm:694` | `OCCTShapeSymmetryAxes` | `a.kind` | 1 (TAG) | `= 7` unconditionally on both construction sites — genuinely always kind 7 (symmetry) for everything this function returns; not a skipped classification (contrast with `OCCTShapeRecognizeCanonical.type`, which selects among several literals). |
+| `Topology.mm:1299` | `OCCTBRepExtremaExtPC` | `result.isValid` | 1 (FLIP) | `= true` at the end only after `occtNearestPointOnCurveRange` (the shared #539/#580 helper) succeeds; every earlier failure path (`edge.IsNull()`, `curve.IsNull()`, no nearest point) returns with `isValid` at its `{}` default `false`. |
+| `Topology.mm:1362` | `OCCTShapePolyhedralDistance` | `result.success` | 1 (FLIP) | `= true` only inside `if (ok)`, `ok` being `BRepExtrema_Poly::Distance`'s own out-parameter success flag. |
+
+## Documentation, in full
+
+- `Sources/OCCTBridge/include/OCCTBridge_Healing.h` — `selfIntersectionCount` field deleted, one
+  comment line left in its place explaining the removal and pointing at the replacement API.
+- `Sources/OCCTBridge/include/OCCTBridge_Topology.h` — `hasExtent`'s comment extended (see above).
+- `Sources/OCCTSwift/ShapeAnalysisResult.swift` — field deleted; `totalProblems`'s doc comment
+  updated to stop citing the removed field and instead point at `isSelfIntersecting(timeout:)`.
+- `Sources/OCCTSwift/Shape+Analysis.swift` — `analyze(tolerance:)`'s doc comment updated.
+- `docs/reference/Shape-Features.md` — `ShapeAnalysisResult`'s field table and prose updated.
+- `docs/guides/cookbook/healing-and-validity.md` — the `analyze(tolerance:)` snippet no longer
+  prints the removed field.
+- `docs/reference/Geometry2D.md` — `ShapeAxis.extent` section rewritten with the real contract and
+  measured example values (see above).
+- `docs/CHANGELOG.md` / `docs/SEMVER.md` — deliberately **not** touched, per
+  `okf/policies/changelog-on-merge.md` / `okf/policies/semver-at-release.md`; both are carried in
+  this PR's body instead (`## CHANGELOG entry`, `## SemVer impact`).
+
+## Build/compile fallout from the removal
+
+Removing `selfIntersectionCount` broke the build twice before it was clean, both caught by
+`swift build` immediately:
+
+1. `OCCTBridge_Healing.mm:195`'s positional aggregate initializer
+   (`OCCTShapeAnalysisResult result = {0, 0, 0, 0, 0, 0, false, false};`) had one element too many
+   for the now-7-field struct (`excess elements in struct initializer`). Fixed by dropping one
+   `0`.
+2. Two Swift test files referenced `analysis.selfIntersectionCount` directly in their own
+   independently-recomputed `expectedTotal`/`totalProblemsExcludingFreeFace` sums
+   (`OCCTShapeHealingTests.swift`, `Issue702SolidDemotionTests.swift`) — both updated to drop the
+   term (see "Verdict 4" above).
+
+## Test results
+
+Full evidence, gate-by-gate and full-suite, is in the PR body. Summary:
+
+- All 5 gate scripts (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
+  `derive-bridge-header-split --verify`, `count-operations`) plus their `--self-test`s: clean.
+- `census-unmeasured-values.py --self-test`: 10/10 (its own fixture battery, unrelated to this
+  PR's specific fixes, unaffected).
+- `census-unmeasured-values.py` (report mode) on this branch after the fix: 55 production
+  candidates, down from the pre-fix 62 — the 7-candidate drop is exactly `selfIntersectionCount`
+  (1) plus `extentMin`/`extentMax`/`hasExtent` at both call sites (6), matching this triage. The
+  `OCCTShapeSymmetryAxes.kind` TAG candidate is still reported (now at a shifted line number, same
+  (function, field) pair as before) — expected, since `kind` was never touched.
+  `check-changelog-transcription.py`'s report is unrelated to this diff (it audits the branch's
+  past merge history, not this PR).
+- New tests (`cylinderRevolutionAxisHasExtent`, `cylinderSymmetryAxisHasExtent`): proven to fail
+  with the defect injected, pass restored (table above).
+- Full `swift test`: see PR body for the final count and pass/fail summary.

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -23,10 +23,11 @@ typedef struct {
     int32_t smallEdgeCount;        // Number of edges smaller than tolerance
     int32_t smallFaceCount;        // Number of faces smaller than tolerance
     int32_t gapCount;              // Number of gaps between edges/faces
-    int32_t selfIntersectionCount; // Always 0, never computed ("would require more expensive
-                                    // computation", the implementation's own comment). Not a
-                                    // measured value; use OCCTShapeSelfIntersects /
-                                    // OCCTShapeSelfIntersectsBounded instead (#702).
+    // selfIntersectionCount REMOVED (#726/#763): it was always 0, never computed ("would require
+    // more expensive computation", the field's own former comment) -- see OCCTShapeSelfIntersects /
+    // OCCTShapeSelfIntersectsBounded for the real answer (#702 documented the field as honest about
+    // never being computed; #763 removed it, since a field that can never carry information has no
+    // reason to exist).
     int32_t freeEdgeCount;         // Number of free (unconnected) edges, summed across every
                                     // shell of `shape`, via ShapeAnalysis_Shell::CheckOrientedShells
                                     // (#702: this was hardcoded 0 before, since LoadShells() alone

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -438,7 +438,10 @@ typedef struct {
     double directionX, directionY, directionZ;
     double extentMin;       // along direction from origin (-inf as -DBL_MAX)
     double extentMax;       // +inf as DBL_MAX
-    bool   hasExtent;
+    bool   hasExtent;       // false only when the axis's own shape has no boundable geometry at
+                             // all (an empty/void bounding box); an unbounded-but-real shape still
+                             // reports true, with extentMin/extentMax at the +-DBL_MAX sentinels
+                             // above (#763)
     int32_t kind;
 } OCCTShapeAxis;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -192,7 +192,7 @@ static OCCTShellOrientationScan occtAnalyzeShellOrientation(const TopoDS_Shape& 
 }
 
 OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
-    OCCTShapeAnalysisResult result = {0, 0, 0, 0, 0, 0, false, false};
+    OCCTShapeAnalysisResult result = {0, 0, 0, 0, 0, false, false};
     if (!shape) return result;
 
     try {
@@ -300,7 +300,7 @@ OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
         result.smallEdgeCount = smallEdges;
         result.smallFaceCount = smallFaces;
         result.gapCount = gaps;
-        result.selfIntersectionCount = 0;  // Would require more expensive computation
+        // selfIntersectionCount REMOVED (#726/#763): see OCCTBridge_Healing.h's field comment.
         result.freeEdgeCount = freeEdges;
         result.freeFaceCount = freeFaces;
         result.isValid = true;

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -19,6 +19,8 @@
 #import "../include/OCCTBridge.h"
 #import "OCCTBridge_Internal.h"
 
+#include <limits>
+
 #include <BRep_Tool.hxx>
 #include <BRep_Builder.hxx>
 #include <BRepAdaptor_Curve.hxx>
@@ -591,6 +593,73 @@ void OCCTMeshRelease(OCCTMeshRef mesh) {
 
 // MARK: - Shape Axis Extraction (v0.137)
 
+// #726/#763: OCCTShapeAxis.extentMin/extentMax/hasExtent were hardcoded 0/0/false on every call
+// (three sites: OCCTShapeRevolutionAxes below and both OCCTShapeAxis constructions inside
+// OCCTShapeSymmetryAxes) since the feature's introduction in v0.137 -- never wired up, though the
+// struct's own field comments already documented the intended contract ("extentMin: along
+// direction from origin (-inf as -DBL_MAX)", "extentMax: +inf as DBL_MAX"). Because
+// ShapeAxis.swift's `self.extent = a.hasExtent ? (...) : nil` already gates that into an Optional,
+// this reads exactly like the #583/#595/#609 "absence made representable" fix on a first look --
+// which is how an earlier census pass (Scripts/repro/726-unmeasured-values/README.md) classified
+// it. It is not: `hasExtent` is `false` on literally every reached path, so `extent` was `nil` for
+// every caller unconditionally, the same defect class as `selfIntersectionCount`, just one layer
+// removed. Fixed here by actually computing it, per the contract the header already promised.
+//
+// Method: BRepBndLib::Add's geometric (not triangulation) bounding box of the shape the axis
+// belongs to (a face for a revolution axis, the whole shape for a symmetry axis), then the 8
+// corners of that box projected onto the axis direction from the axis origin -- min and max of
+// those 8 dot products. This is exact for the cases a bounding box IS tight along the query
+// direction (a bounded cylindrical/conical face along its own axis, a box along a principal axis,
+// both verified directly in OCCTTopologyTests), and a safe enclosing interval otherwise (curved
+// geometry whose true extent is less than its box's). `IsOpen()` (an untrimmed natural-bounds
+// face, or a genuinely infinite shape) reports the axis as extending to +-DBL_MAX rather than
+// treating the box's own infinity sentinel (Precision::Infinite() = 1e100) as if it were a real
+// measured bound; `IsVoid()` (no boundable geometry at all) reports no extent, `hasExtent = false`.
+static void occtComputeAxisExtent(const TopoDS_Shape& forShape, const gp_Pnt& origin,
+                                   const gp_Dir& direction,
+                                   double& outMin, double& outMax, bool& outHasExtent) {
+    outMin = 0.0;
+    outMax = 0.0;
+    outHasExtent = false;
+    if (forShape.IsNull()) return;
+    try {
+        Bnd_Box box;
+        BRepBndLib::Add(forShape, box);
+        if (box.IsVoid()) return;
+        if (box.IsOpen()) {
+            outMin = -std::numeric_limits<double>::max();
+            outMax = std::numeric_limits<double>::max();
+            outHasExtent = true;
+            return;
+        }
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        box.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        const double ox = origin.X(), oy = origin.Y(), oz = origin.Z();
+        const double dx = direction.X(), dy = direction.Y(), dz = direction.Z();
+        double tMin = std::numeric_limits<double>::infinity();
+        double tMax = -std::numeric_limits<double>::infinity();
+        for (int ix = 0; ix < 2; ix++) {
+            double px = (ix == 0) ? xmin : xmax;
+            for (int iy = 0; iy < 2; iy++) {
+                double py = (iy == 0) ? ymin : ymax;
+                for (int iz = 0; iz < 2; iz++) {
+                    double pz = (iz == 0) ? zmin : zmax;
+                    double t = (px - ox) * dx + (py - oy) * dy + (pz - oz) * dz;
+                    if (t < tMin) tMin = t;
+                    if (t > tMax) tMax = t;
+                }
+            }
+        }
+        outMin = tMin;
+        outMax = tMax;
+        outHasExtent = true;
+    } catch (...) {
+        outMin = 0.0;
+        outMax = 0.0;
+        outHasExtent = false;
+    }
+}
+
 static bool axesCoincide(const OCCTShapeAxis& a, double ox, double oy, double oz,
                           double dx, double dy, double dz, double tol) {
     gp_Dir d1(a.directionX, a.directionY, a.directionZ);
@@ -650,7 +719,7 @@ int32_t OCCTShapeRevolutionAxes(OCCTShapeRef shape, double tolerance,
             OCCTShapeAxis a;
             a.originX = p.X(); a.originY = p.Y(); a.originZ = p.Z();
             a.directionX = d.X(); a.directionY = d.Y(); a.directionZ = d.Z();
-            a.extentMin = 0; a.extentMax = 0; a.hasExtent = false;
+            occtComputeAxisExtent(face, p, d, a.extentMin, a.extentMax, a.hasExtent);
             a.kind = kind;
             collected.push_back(a);
         }
@@ -691,7 +760,9 @@ int32_t OCCTShapeSymmetryAxes(OCCTShapeRef shape, double fractionalTolerance,
                 OCCTShapeAxis a;
                 a.originX = cm.X(); a.originY = cm.Y(); a.originZ = cm.Z();
                 a.directionX = axes[i].X(); a.directionY = axes[i].Y(); a.directionZ = axes[i].Z();
-                a.extentMin = 0; a.extentMax = 0; a.hasExtent = false; a.kind = 7;
+                occtComputeAxisExtent(shape->shape, cm, gp_Dir(axes[i].X(), axes[i].Y(), axes[i].Z()),
+                                      a.extentMin, a.extentMax, a.hasExtent);
+                a.kind = 7;
                 collected.push_back(a);
             }
         } else if (pp.HasSymmetryAxis()) {
@@ -710,7 +781,10 @@ int32_t OCCTShapeSymmetryAxes(OCCTShapeRef shape, double fractionalTolerance,
             a.directionX = axes[uniqueIdx].X();
             a.directionY = axes[uniqueIdx].Y();
             a.directionZ = axes[uniqueIdx].Z();
-            a.extentMin = 0; a.extentMax = 0; a.hasExtent = false; a.kind = 7;
+            occtComputeAxisExtent(shape->shape, cm,
+                                  gp_Dir(axes[uniqueIdx].X(), axes[uniqueIdx].Y(), axes[uniqueIdx].Z()),
+                                  a.extentMin, a.extentMax, a.hasExtent);
+            a.kind = 7;
             collected.push_back(a);
         }
         int32_t count = std::min((int32_t)collected.size(), maxAxes);

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -220,12 +220,12 @@ extension Shape {
 
     /// Analyze a shape for problems such as small edges, gaps, and invalid topology.
     ///
-    /// - Note: `selfIntersectionCount` is always 0, and has never been computed, see
-    ///   ``ShapeAnalysisResult/selfIntersectionCount``; use ``isSelfIntersecting(timeout:)`` for a
-    ///   real check. `freeEdgeCount`/`freeFaceCount` were also hardcoded to 0 for every shape
-    ///   before #702; a demoted or otherwise open shell now reports its actual gap correctly.
-    ///   A "clean" result here has never meant "this is a solid": check `shapeType` or
-    ///   ``isValidSolid`` for that.
+    /// - Note: This never reports self-intersections (the `selfIntersectionCount` field that used
+    ///   to sit here was always 0, never computed, and was removed in #763); use
+    ///   ``isSelfIntersecting(timeout:)`` for a real check. `freeEdgeCount`/`freeFaceCount` were
+    ///   also hardcoded to 0 for every shape before #702; a demoted or otherwise open shell now
+    ///   reports its actual gap correctly. A "clean" result here has never meant "this is a
+    ///   solid": check `shapeType` or ``isValidSolid`` for that.
     /// - Parameter tolerance: Size threshold for detecting small features
     /// - Returns: Analysis result with problem counts, or nil on failure
     ///
@@ -248,7 +248,6 @@ extension Shape {
             smallEdgeCount: Int(result.smallEdgeCount),
             smallFaceCount: Int(result.smallFaceCount),
             gapCount: Int(result.gapCount),
-            selfIntersectionCount: Int(result.selfIntersectionCount),
             freeEdgeCount: Int(result.freeEdgeCount),
             freeFaceCount: Int(result.freeFaceCount),
             hasInvalidTopology: result.hasInvalidTopology

--- a/Sources/OCCTSwift/ShapeAnalysisResult.swift
+++ b/Sources/OCCTSwift/ShapeAnalysisResult.swift
@@ -13,12 +13,6 @@ public struct ShapeAnalysisResult {
     /// Number of gaps between edges/faces
     public let gapCount: Int
 
-    /// Always 0. This has never been computed: the bridge's own comment on the field
-    /// reads "would require more expensive computation", so it is not a measured absence of
-    /// self-intersection, only an unimplemented one. Use ``Shape/isSelfIntersecting(timeout:)``
-    /// for a real answer (#702).
-    public let selfIntersectionCount: Int
-
     /// Number of free (unconnected) edges across every shell of the analyzed shape, via
     /// `ShapeAnalysis_Shell`. Before #702 this was hardcoded to 0 for every shape: the bridge
     /// called `LoadShells()`, which only registers a shell for bookkeeping and runs no edge
@@ -43,13 +37,17 @@ public struct ShapeAnalysisResult {
 
     /// Total number of problems found.
     ///
-    /// Sums each independent defect category once: small edges, small faces, gaps,
-    /// self-intersections (never actually measured, see ``selfIntersectionCount``), free edges,
+    /// Sums each independent defect category once: small edges, small faces, gaps, free edges,
     /// and invalid topology (a flat +1, not a count). ``freeFaceCount`` is deliberately excluded:
     /// see its doc comment for why including it would double-count the same open-shell defect
     /// ``freeEdgeCount`` already reports.
+    ///
+    /// Self-intersections are not part of this total: `analyze(tolerance:)` never measured them
+    /// (a `selfIntersectionCount` field existed through v1.x but was always 0, never computed, and
+    /// was removed in #763 rather than kept as a permanently-zero placeholder). Use
+    /// ``Shape/isSelfIntersecting(timeout:)`` for a real self-intersection check.
     public var totalProblems: Int {
-        smallEdgeCount + smallFaceCount + gapCount + selfIntersectionCount + freeEdgeCount + (hasInvalidTopology ? 1 : 0)
+        smallEdgeCount + smallFaceCount + gapCount + freeEdgeCount + (hasInvalidTopology ? 1 : 0)
     }
 
     /// Whether the shape appears to be healthy (no problems found)

--- a/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
@@ -237,7 +237,7 @@ struct Issue702SolidDemotion {
     /// guessed total.
     private static func totalProblemsExcludingFreeFace(_ analysis: ShapeAnalysisResult) -> Int {
         analysis.smallEdgeCount + analysis.smallFaceCount + analysis.gapCount +
-            analysis.selfIntersectionCount + analysis.freeEdgeCount +
+            analysis.freeEdgeCount +
             (analysis.hasInvalidTopology ? 1 : 0)
     }
 

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -101,7 +101,7 @@ struct ShapeAnalysisTests {
         // counts (this shell has at least one free edge), not an independent defect, so including
         // both would double-count one open shell's boundary gap (#717 review, the totalProblems double-count).
         let expectedTotal = analysis.smallEdgeCount + analysis.smallFaceCount +
-                           analysis.gapCount + analysis.selfIntersectionCount +
+                           analysis.gapCount +
                            analysis.freeEdgeCount +
                            (analysis.hasInvalidTopology ? 1 : 0)
         #expect(analysis.totalProblems == expectedTotal)

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -5825,6 +5825,25 @@ struct ShapeRevolutionAxesTests {
         // Both share the Z axis at the origin → dedup to 1.
         #expect(axes.count == 1)
     }
+
+    // #726/#763: extentMin/extentMax/hasExtent were hardcoded 0/0/false on every call, so
+    // `extent` was `nil` for every axis regardless of input. Fixed by measuring the face's own
+    // bounding box along the axis direction. A cylindrical face's true Z-extent (in whichever
+    // sign OCCT hands back `Axis().Direction()`, not fixed -- see `cylinderOneAxis` above, which
+    // itself accepts either sign) is exactly its bounding box's, since no curvature bulges past
+    // the two flat end circles along the axis. The SPAN (upperBound - lowerBound) is
+    // sign-independent and is what's asserted; `Shape.cylinder`'s own height is the ground truth.
+    @Test("Cylinder's revolution axis reports a real, non-nil extent matching its height")
+    func cylinderRevolutionAxisHasExtent() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 20) else { Issue.record("cylinder nil"); return }
+        let axes = cyl.revolutionAxes()
+        #expect(axes.count == 1)
+        guard let a = axes.first, let extent = a.extent else {
+            Issue.record("expected a non-nil extent on the cylinder's revolution axis")
+            return
+        }
+        #expect(abs((extent.upperBound - extent.lowerBound) - 20) < 1e-6)
+    }
 }
 
 @Suite("v0.137 Surface.torusAxis / revolutionAxis")

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -5039,4 +5039,25 @@ struct ShapeSymmetryAxesTests {
         guard let box = Shape.box(width: 10, height: 7, depth: 3) else { Issue.record("box nil"); return }
         #expect(box.symmetryAxes().isEmpty)
     }
+
+    // #726/#763: same defect as `Shape.revolutionAxes`' extent (see the sibling test in
+    // OCCTSurfaceTests.swift) -- extentMin/extentMax/hasExtent were hardcoded 0/0/false on every
+    // call here too. The symmetry axis's own extent is measured over the WHOLE SHAPE's bounding
+    // box (not one face), from the axis origin (the shape's centre of mass, per
+    // `GProp_GProps::CentreOfMass`). A cylinder's centroid sits at half its height, so its axial
+    // span should read as symmetric about 0: -10...10 for a height-20 cylinder, independent of
+    // which sign OCCT reports the axis direction in.
+    @Test("Cylinder's symmetry axis reports a real, non-nil extent centred on the centroid")
+    func cylinderSymmetryAxisHasExtent() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 20) else { Issue.record("cylinder nil"); return }
+        let axes = cyl.symmetryAxes()
+        #expect(axes.count == 1)
+        guard let a = axes.first, let extent = a.extent else {
+            Issue.record("expected a non-nil extent on the cylinder's symmetry axis")
+            return
+        }
+        #expect(abs((extent.upperBound - extent.lowerBound) - 20) < 1e-6)
+        #expect(abs(extent.lowerBound + 10) < 1e-6)
+        #expect(abs(extent.upperBound - 10) < 1e-6)
+    }
 }

--- a/docs/guides/cookbook/healing-and-validity.md
+++ b/docs/guides/cookbook/healing-and-validity.md
@@ -38,8 +38,7 @@ For a defect inventory rather than a yes/no, `analyze(tolerance:)` returns count
 ```swift
 if let report = box.analyze(tolerance: 1e-3) {
     print(report.smallEdgeCount, report.gapCount,
-          report.selfIntersectionCount, report.freeEdgeCount,
-          report.hasInvalidTopology)
+          report.freeEdgeCount, report.hasInvalidTopology)
 }
 ```
 

--- a/docs/reference/Geometry2D.md
+++ b/docs/reference/Geometry2D.md
@@ -768,18 +768,25 @@ public let direction: SIMD3<Double>
 
 #### `extent`
 
-The optional parametric extent along the axis.
+The optional extent along the axis, measured in real 3D units (not the surface's parametric U/V), as a signed offset from `origin` along `direction`.
 
 ```swift
 public let extent: ClosedRange<Double>?
 ```
 
-`nil` for axes where no extent is computed (most face types). When present, the range describes the axis length limits in the surface's own parameterisation.
+`nil` for `Face.primaryAxis` (never computed there) and for a shape with no boundable geometry at all. For `Shape.revolutionAxes(tolerance:)` and `Shape.symmetryAxes(fractionalTolerance:)`, `extent` is the geometric bounding box of the axis's own shape (the face, for a revolution axis; the whole shape, for a symmetry axis) projected onto the axis direction from `origin` — exact when the box is tight along that direction (a bounded cylindrical/conical face along its own axis, a box along a principal axis), a safe enclosing interval otherwise. An untrimmed/unbounded shape reports `-Double.greatestFiniteMagnitude...Double.greatestFiniteMagnitude` rather than `nil` — `hasExtent` (bridge-side) distinguishes "unbounded but known" from "couldn't measure at all". Before #763 this field was `nil` unconditionally: `hasExtent` was hardcoded `false` on every call.
 
 - **Example:**
   ```swift
+  // Shape.cylinder(radius:height:) bases the cylinder at the origin, so the lateral face's
+  // own axial span is exactly 0...height.
   let ax = Shape.cylinder(radius: 5, height: 20)!.revolutionAxes().first
-  print(ax?.extent as Any)  // nil for revolution axes
+  print(ax?.extent as Any)          // Optional(0.0...20.0) (or -20.0...0.0, axis direction sign varies)
+
+  // symmetryAxes()'s origin is the shape's centre of mass, so a cylinder's axial span is
+  // centred on zero.
+  let sym = Shape.cylinder(radius: 5, height: 20)!.symmetryAxes().first
+  print(sym?.extent as Any)         // Optional(-10.0...10.0)
   ```
 
 ---

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1545,7 +1545,6 @@ public struct ShapeAnalysisResult {
     public let smallEdgeCount: Int
     public let smallFaceCount: Int
     public let gapCount: Int
-    public let selfIntersectionCount: Int
     public let freeEdgeCount: Int
     public let freeFaceCount: Int
     public let hasInvalidTopology: Bool
@@ -1556,9 +1555,10 @@ public struct ShapeAnalysisResult {
 
 `isHealthy` is `true` when `totalProblems == 0 && !hasInvalidTopology`.
 
-- **`selfIntersectionCount` is always 0.** It has never been computed (the bridge's own comment
-  reads "would require more expensive computation"). Use `isSelfIntersecting(timeout:)` for a
-  real answer.
+- **This never reports self-intersections.** A `selfIntersectionCount` field used to sit here
+  (through v1.x) but was always 0, never computed (the bridge's own comment read "would require
+  more expensive computation"); it was removed in #763 rather than kept as a permanent zero. Use
+  `isSelfIntersecting(timeout:)` for a real answer.
 - **`freeEdgeCount`/`freeFaceCount` were hardcoded to 0 for every shape before #702**: the bridge
   called `ShapeAnalysis_Shell::LoadShells()`, which only registers a shell for bookkeeping,
   instead of `CheckOrientedShells()`, the call that actually populates the free-edge set. Now


### PR DESCRIPTION
## What & why

Works the non-Document/IO half of #726's unmeasured-values sweep: the 36 census candidates
(of 62 total) in `OCCTBridge_Topology.mm`, `OCCTBridge_Healing.mm`, `OCCTBridge_Properties.mm`,
`OCCTBridge_BRepGraph.mm`, `OCCTBridge_Surface.mm`, `OCCTBridge_Modeling.mm`,
`OCCTBridge_Spatial.mm`, `OCCTBridge_Geom2d.mm`, `OCCTBridge_Curve3D.mm`. The sibling 26
(`OCCTBridge_Document.mm`/`OCCTBridge_IO.mm`) are triaged separately on
`chore/763-triage-document`.

Full per-candidate table with evidence: `Scripts/repro/726-unmeasured-values/triage-core.md`.

Closes #763 (its non-Document/IO half).

**Verdict counts** (per census line, 36 total):

| Verdict | Lines |
|---|---|
| 1. Not an instance | 29 |
| 2. Compute it | 6 |
| 3. Make absence representable | 0 |
| 4. Remove the field | 1 |

29 lines are legitimate default-then-flip success flags (`isValid`/`success`, driven by real
control flow), branch-selected classification tags (`result.type`, `a.kind`), or local
config/options structs passed as arguments and never returned (`BRepGraph::ShapesView::Options`,
`MathInteg::KronrodConfig`) — outside #726's "returned through an API" scope entirely. One
(`OCCTBisectorPointOnBisCreate`'s `isInfinite`) is a plain constructor verified against
`Bisector_PointOnBis.hxx`'s own real 5-arg constructor, which has no `IsInfinite` parameter
either. Two candidates needed action.

## Breaking changes, each under its own heading

### 1. `ShapeAnalysisResult.selfIntersectionCount` removed (verdict 4)

`OCCTBridge_Healing.mm:303`, `OCCTShapeAnalyze()`: `result.selfIntersectionCount = 0;  // Would
require more expensive computation`. This is #726's own named seed instance.

Verified before removing, not assumed: `Shape.isSelfIntersecting(timeout:)` /
`isSelfIntersecting(hardTimeout:)` (`Shape.swift:2107`/`2150`) already answer the question this
field claimed to, via `OCCTShapeSelfIntersectsBounded` → `BOPAlgo_ArgumentAnalyzer`'s real
self-interference check (the #319 kernel work). Grepped every reader: two Swift call sites and two
test files, none of which asserted a specific self-intersection count (there was never a real one
to assert) — both test files only re-derive `totalProblems` from the remaining fields and are
updated to drop the term (numerically a no-op, since it was always 0).

**Migration**: delete any read of `ShapeAnalysisResult.selfIntersectionCount`. Use
`shape.isSelfIntersecting(timeout:)` for a real check.

### 2. `ShapeAxis.extent` now sometimes non-nil for `revolutionAxes()`/`symmetryAxes()` (verdict 2, non-breaking in type, behavior-changing)

`OCCTBridge_Topology.mm:653`/`:694`, `OCCTShapeRevolutionAxes`/`OCCTShapeSymmetryAxes`:
`a.extentMin = 0; a.extentMax = 0; a.hasExtent = false;` on every reached path, unconditionally,
in both functions.

An earlier census-only pass (`Scripts/repro/726-unmeasured-values/README.md`, committed earlier on
this same base branch) labelled this "GOOD — already fixed", reasoning that `hasExtent` gating
`extent` into a Swift-side `nil` is the same fix `#583`/`#595`/`#609` applied elsewhere. Re-verified
rather than trusted (`okf/policies/measure-dont-assume.md`): `hasExtent` is `false` at all three
assignment sites in the tree and **`true` at none** — it never actually flips, unlike a real
success flag, so `extent` was `nil` unconditionally for every caller. Same defect class as
`selfIntersectionCount`, one layer removed. The struct's own header comment already documented the
intended contract (`extentMin`/`extentMax`, `+-DBL_MAX` sentinels for the unbounded case), so this
was an incomplete feature (v0.137, never mentioned as delivered in the CHANGELOG), not a
deliberately deferred one.

Computed: `occtComputeAxisExtent` (`OCCTBridge_Topology.mm`) projects the axis's own shape's
`BRepBndLib`/`Bnd_Box` geometric bounding box onto the axis direction from its origin — exact
where the box is tight along that direction (a bounded cylindrical/conical face along its own
axis, a box along a principal axis; both are what the new tests check), a safe enclosing interval
otherwise. `IsVoid()` → `hasExtent = false`; `IsOpen()` → `hasExtent = true` with `+-DBL_MAX`,
honoring the header's pre-existing sentinel contract rather than leaking `Bnd_Box`'s internal
`Precision::Infinite()` (1e100) as if it were a real bound.

**No signature or type change** — `ShapeAxis.extent: ClosedRange<Double>?` is unchanged — but this
is a real behavior change: code that (incorrectly) assumed `extent` is always `nil` for
`revolutionAxes()`/`symmetryAxes()` results will now sometimes see a real value. Flagging under
its own heading per the instructions even though it doesn't break a build, since it changes
observable output.

**Migration**: none required (additive information). If any caller special-cased "extent is always
nil" for these two entry points, that assumption no longer holds.

## Tests

- `Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift` and
  `Issue702SolidDemotionTests.swift`: updated to drop `selfIntersectionCount` from their own
  independently-recomputed problem-count sums (both still pass; the term was always 0 so this is
  not a strong regression check on its own, but does prove the removal compiles and the arithmetic
  is unaffected).
- New: `Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift`'s
  `cylinderRevolutionAxisHasExtent` — a radius-5/height-20 cylinder's revolution axis reports a
  non-nil `extent` whose span is 20 (matches the cylinder's own height; asserts span rather than
  absolute bounds because the axis direction's sign isn't fixed, same as the pre-existing
  `cylinderOneAxis` test already accepts).
- New: `Tests/OCCTTopologyTests/OCCTTopologyTests.swift`'s `cylinderSymmetryAxisHasExtent` — the
  same cylinder's symmetry axis (origin = centre of mass, at half height) reports `extent` of
  exactly `-10...10`.

**Prove the test fails** (`okf/policies/prove-the-test-fails.md`): both new tests were run once
with the fix reverted (the three `occtComputeAxisExtent(...)` call sites replaced back with the
original hardcoded literals) — both failed with the expected message. Restored (verified
byte-identical via `diff` against a pre-injection backup) and re-ran — both passed.

| State | `cylinderRevolutionAxisHasExtent` | `cylinderSymmetryAxisHasExtent` |
|---|---|---|
| Defect injected | FAILED — "expected a non-nil extent on the cylinder's revolution axis" | FAILED — "expected a non-nil extent on the cylinder's symmetry axis" |
| Fix restored | PASSED | PASSED |

## Gate scripts (all clean)

All 5 static gates + their `--self-test`s, plus the census's own `--self-test`:

```
check-bridge-index.py                       0 stale, 0 misfiled                       exit 0
check-bridge-index.py --self-test           18/18 cases correct                       exit 0
check-null-handle-guards.py                 all functions guard                       exit 0
check-null-handle-guards.py --self-test     24/24 cases correct                       exit 0
check-docs-defaults.py                      0 drifted, 0 unverified                   exit 0
check-docs-defaults.py --self-test          13/13 passed                              exit 0
derive-bridge-header-split.py --verify      0 ambiguous, 0 unmapped, 0 misfiled        exit 0
derive-bridge-header-split.py --self-test   8/8 cases correct                         exit 0
count-operations.py                         4306 == 4306 (README/API_REFERENCE match)  exit 0
census-unmeasured-values.py --self-test     10/10 cases correct                       exit 0
```

`census-unmeasured-values.py` (report mode) on this branch: **55** production candidates, down
from **62** before this PR. The 7-line drop is exactly `selfIntersectionCount` (1) plus
`extentMin`/`extentMax`/`hasExtent` at both call sites (6), matching this PR's fixes.
`OCCTShapeSymmetryAxes.kind` (the TAG candidate) is still reported, at a shifted line number —
expected, since `kind` was untouched and remains verdict 1.

`check-changelog-transcription.py`'s report (not a gate) is unaffected by this diff — it audits
the branch's past merge history, not this PR's content.

## Full `swift test`

**5483 tests, 1428 suites, 0 failures**, ~78s wall clock. Includes the two new extent tests and
the two edited healing tests, all passing.

## CHANGELOG entry

### `ShapeAnalysisResult.selfIntersectionCount` removed; `ShapeAxis.extent` now computed for `revolutionAxes()`/`symmetryAxes()` (#763)

`ShapeAnalysisResult.selfIntersectionCount` is removed. It was always `0`, never computed (the
bridge's own comment admitted "would require more expensive computation") — use
`Shape.isSelfIntersecting(timeout:)` for a real self-intersection check.

`ShapeAxis.extent` (from `Shape.revolutionAxes(tolerance:)` and
`Shape.symmetryAxes(fractionalTolerance:)`) is now genuinely computed rather than always `nil`: it
reports the axis's own shape's bounding box projected onto the axis direction, in real 3D units.
`Face.primaryAxis` is unaffected and still never populates `extent`.

```swift
// Before: always nil
let axis = Shape.cylinder(radius: 5, height: 20)!.revolutionAxes().first
axis?.extent  // nil, always, regardless of the cylinder's actual height

// After: a real measured extent
axis?.extent  // Optional(0.0...20.0) (or -20.0...0.0 — axis direction sign varies)
```

## SemVer impact

MAJOR. `ShapeAnalysisResult.selfIntersectionCount` is a public stored property that no longer
exists; any consumer reading it will not compile. Suggested migration: the field was always `0`
and never computed, so there is nothing to migrate a *value* to — replace the read with
`shape.isSelfIntersecting(timeout:)` if a real self-intersection check is actually needed, or
delete the read if it was only ever checking a constant.

`ShapeAxis.extent` changing from unconditionally-`nil` to sometimes-non-nil for
`revolutionAxes()`/`symmetryAxes()` is source-compatible (no signature change) but is a real
behavior change, called out under its own heading above; on its own this would be MINOR at most,
folded into the MAJOR bump the field removal already requires this release.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — two new tests (extent),
      two updated tests (removal, compile + arithmetic).
- [x] Every new test was run once with its subject broken, and the failure is reported above
      (extent tests). The removal has no equivalent injection cycle (see triage doc's
      "Build/compile fallout" section for why — it's a field deletion enforced by the compiler,
      not a new positive check).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- The `hasExtent` finding directly contradicts an earlier census-only pass's verdict on the same
  candidate (see triage doc, "Verdict 2" section, for the full reasoning on why "gates into an
  Optional" isn't sufficient evidence that a field is fixed — it has to actually flip on some real
  path, and this one never did).
- `occtComputeAxisExtent`'s bounding-box-projection method is exact for the cases this PR's tests
  check (a bounded cylindrical face/shape along its own axis) and a safe (non-tight) enclosing
  interval for curved geometry viewed along an arbitrary direction otherwise (e.g. a sphere's
  symmetry axes, or a cone's axis) — not claimed to be a tight geodesic extent in general, and the
  doc update (`docs/reference/Geometry2D.md`) says so.
- Did not touch `Scripts/repro/726-unmeasured-values/README.md` (the earlier, broader census-only
  pass covering all 62 candidates) — it's a point-in-time investigation record, not something this
  PR's scope calls for updating; `triage-core.md` is the new, current source for this PR's 36.
