### PR TITLE
feat(#772): opt-in self-intersection check for analyze(tolerance:)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -223,6 +223,20 @@ let package = Package(
             ]
         ),
 
+        // Shared dispatch logic for every "one executable target, many named entries" shared
+        // target below (Censuses, Harnesses): the registry type and the list/all/run-by-name
+        // switch, factored out after #772 review found Harnesses had reproduced Censuses' own
+        // dispatch code almost line for line instead of sharing it. A plain library target, not
+        // an executable: both executables below declare it as a dependency. Its own directory
+        // holds only this one Swift file, so it needs no `exclude:` either.
+        .target(
+            name: "RunnerCore",
+            path: "Scripts/repro/runner-core",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+
         // #694: one shared executable target for every cluster census docs/v2.0.0-plan.md's
         // census-once rule asks for, replacing the one-target-per-cluster `ClusterACensus`
         // (#664 was the first). `swift run Censuses <cluster>` (or `all`, or no argument to list).
@@ -236,7 +250,7 @@ let package = Package(
         // maintain was #694's other objection to one target per cluster.
         .executableTarget(
             name: "Censuses",
-            dependencies: ["OCCTSwift"],
+            dependencies: ["OCCTSwift", "RunnerCore"],
             path: "Scripts/repro/censuses",
             swiftSettings: [
                 .swiftLanguageMode(.v6)
@@ -248,13 +262,14 @@ let package = Package(
         // the same #694 reasoning: a manifest path into a per-issue repro directory couples
         // `swift build` to a directory name that does get renamed, and a second `exclude:` list
         // per harness is a second thing to maintain. `swift run Harnesses <name>` (or `all`, or
-        // no argument to list); see HarnessRunner.swift for the dispatch logic. Source lives
-        // under Scripts/repro/harnesses/, not Scripts/repro/<issue-dir>/: an issue's own repro
+        // no argument to list); see HarnessRunner.swift for the registry and RunnerCore's
+        // GenericRunner for the dispatch logic it shares with Censuses. Source lives under
+        // Scripts/repro/harnesses/, not Scripts/repro/<issue-dir>/: an issue's own repro
         // directory keeps only its README and captured output (neither is Swift source SwiftPM
         // needs to see), so no `exclude:` is needed here at all.
         .executableTarget(
             name: "Harnesses",
-            dependencies: ["OCCTSwift"],
+            dependencies: ["OCCTSwift", "RunnerCore"],
             path: "Scripts/repro/harnesses",
             swiftSettings: [
                 .swiftLanguageMode(.v6)

--- a/Package.swift
+++ b/Package.swift
@@ -229,7 +229,7 @@ let package = Package(
         // Source lives under Scripts/repro/censuses/, not Scripts/repro/<cluster-dir>/: a cluster's
         // own repro directory keeps its README and any static cross-check script (neither is Swift
         // source SwiftPM needs to see), so renaming that directory no longer touches the manifest
-        // at all -- the whole point, since #694 was raised because renaming
+        // at all, the whole point, since #694 was raised because renaming
         // Scripts/repro/cluster-a-subshape-enumeration/ broke `swift build`/`swift test`
         // repo-wide with "error: invalid custom path". No `exclude:` is needed here because every
         // file this target's own directory holds is Swift source; a second `exclude:` list to
@@ -243,16 +243,19 @@ let package = Package(
             ]
         ),
 
-        // #772: measure(-dont-assume) harness deciding whether Shape.analyze(tolerance:)
-        // should gain a self-intersection pass. `swift run AnalyzeSelfIntersectionTiming`.
-        // README.md and measured-output.txt are the committed evidence this target produced,
-        // not Swift source, so both need excluding the same way Fixtures/ does above for
-        // OCCTStressTests -- without it SwiftPM reports them as unhandled on every build.
+        // One shared executable target for ad hoc measurement harnesses backing an
+        // issue-specific decision, the timing/perf sibling of Censuses just above and built on
+        // the same #694 reasoning: a manifest path into a per-issue repro directory couples
+        // `swift build` to a directory name that does get renamed, and a second `exclude:` list
+        // per harness is a second thing to maintain. `swift run Harnesses <name>` (or `all`, or
+        // no argument to list); see HarnessRunner.swift for the dispatch logic. Source lives
+        // under Scripts/repro/harnesses/, not Scripts/repro/<issue-dir>/: an issue's own repro
+        // directory keeps only its README and captured output (neither is Swift source SwiftPM
+        // needs to see), so no `exclude:` is needed here at all.
         .executableTarget(
-            name: "AnalyzeSelfIntersectionTiming",
+            name: "Harnesses",
             dependencies: ["OCCTSwift"],
-            path: "Scripts/repro/772-analyze-self-intersection",
-            exclude: ["README.md", "measured-output.txt"],
+            path: "Scripts/repro/harnesses",
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -242,6 +242,21 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+
+        // #772: measure(-dont-assume) harness deciding whether Shape.analyze(tolerance:)
+        // should gain a self-intersection pass. `swift run AnalyzeSelfIntersectionTiming`.
+        // README.md and measured-output.txt are the committed evidence this target produced,
+        // not Swift source, so both need excluding the same way Fixtures/ does above for
+        // OCCTStressTests -- without it SwiftPM reports them as unhandled on every build.
+        .executableTarget(
+            name: "AnalyzeSelfIntersectionTiming",
+            dependencies: ["OCCTSwift"],
+            path: "Scripts/repro/772-analyze-self-intersection",
+            exclude: ["README.md", "measured-output.txt"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
     ],
     cxxLanguageStandard: .cxx17
 )

--- a/Scripts/repro/772-analyze-self-intersection/README.md
+++ b/Scripts/repro/772-analyze-self-intersection/README.md
@@ -1,0 +1,118 @@
+# #772: should `Shape.analyze(tolerance:)` measure self-intersection?
+
+Measurement backing the design decision in #772 (okf/policies/measure-dont-assume.md: this issue
+is explicitly a "measure before choosing" task, not a "pick the option that sounds right" one).
+
+## Background
+
+`ShapeAnalysisResult.selfIntersectionCount` was always `0` and never computed (#702/#763):
+the bridge's own comment on the field read "would require more expensive computation". #763/PR#770
+removes the fabricated field, which leaves `analyze(tolerance:)` reporting nothing at all about
+self-intersection. #772 asks whether it should measure it, with three candidate answers:
+
+1. Leave it out, document `analyze()` as a cheap-defect scan and point at
+   `isSelfIntersecting(timeout:)`/`isSelfIntersecting(hardTimeout:)` as the separate, expensive
+   check.
+2. An opt-in parameter, `analyze(tolerance:checkSelfIntersection:hardTimeout:)`, defaulting off.
+3. Report it as unmeasured rather than absent: an optional that is `nil` unless requested.
+
+The issue is explicit that the choice must follow a measurement, not precede it, and flags a
+specific trap for option 3: #771 found that `ShapeAxis.hasExtent` used the "gate an optional"
+pattern while never actually flipping (`false` at every assignment site, `true` at none), so the
+`nil` it produced was indistinguishable from a field that had simply been deleted. Picking option 3
+here without a passing "the gate actually flips" test would repeat that exact defect.
+
+## Method
+
+`main.swift` (built as the `AnalyzeSelfIntersectionTiming` executable target, see `Package.swift`)
+times `Shape.analyze(tolerance:)` (the existing cheap small-edge/small-face/gap scan) against
+`Shape.isSelfIntersecting(timeout:)` (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, the same
+machinery #319 gave a working cooperative timeout) across four shapes, chosen to span "trivial" to
+"the worst artifact on record for this check":
+
+1. **A plain box** (`Shape.box`): the primitive case.
+2. **A moderately complex fused/filleted solid**: a plate, a boss fused on, four through-holes
+   cut, all edges filleted (16 faces, 39 edges). Representative of an ordinary mechanical part.
+3. **A real mesh-sewn imported solid**: the #348 fixture
+   (`Tests/OCCTStressTests/Fixtures/unify-crash-mmd-kiha10-body5.brep`), a body extracted from a
+   real reconstruction pipeline (OCCTReconstruct#194). 662 faces, 1072 edges; genuinely
+   self-intersects.
+4. **The #319 pathological artifact**
+   (`Scripts/repro/319-selfintersection/dualskin_lateral.15.brep`): a single-face shell whose
+   B-spline surface folds enormously (bounding box ~1.6e6 x 3.8e6 mm for a ~260 mm part). Measured
+   pre-#319-fix at 619s CPU against a 30s deadline that never fired. This branch's pinned kernel
+   carries the #319 fix (patch 0010: O(1) tangent-zone lookup + a checkpointed breaker), so this
+   run is also a live regression check that the fix still holds on the exact artifact it was filed
+   against.
+
+Run with:
+
+```bash
+swift run -c release AnalyzeSelfIntersectionTiming
+```
+
+(Release build matters here: debug-mode overhead is comparable in magnitude to the cheap scan
+itself on the small shapes, which would make the "ordinary shape" rows noise rather than signal.)
+
+## Measured (2026-08-08, macOS arm64, this branch's pinned kernel, `v2.0.0-kernel.2`)
+
+Three independent runs; the numbers below are one representative run (`measured-output.txt`), all
+runs agreed to within roughly 2x on the sub-10ms figures (expected noise at that scale) and within
+a few percent on the two informative figures (the mesh-sewn import and the pathological artifact).
+
+| Shape | Faces | Edges | `analyze(tolerance:)` | `isSelfIntersecting(timeout: 30)` | Result | Overhead |
+|---|---|---|---|---|---|---|
+| 1. Simple box | 6 | 12 | 0.001 s | 0.001 s | clean | ~1x |
+| 2. Moderately complex fused/filleted solid | 16 | 39 | 0.001-0.003 s | 0.003-0.008 s | clean | 2x-3x |
+| 3. Mesh-sewn imported solid (kiha10 body5) | 662 | 1072 | 0.04-0.14 s | 0.06-0.28 s | self-intersects | 1.2x-3.2x |
+| 4. #319 pathological artifact | 1 | 3 | 0.007-0.017 s | 30.0-30.4 s | self-intersects | ~1800x-4100x |
+
+`4b`, the same artifact through `isSelfIntersecting(hardTimeout: 5)` (#319's true wall-clock-bound
+variant): returns at 5.01s, confirming the hard deadline holds even though the cooperative
+`timeout:` variant ran to ~30s on this artifact.
+
+## What the numbers say
+
+On every ordinary shape tested, including a real 662-face mesh-sewn import that genuinely
+self-intersects, the self-intersection check costs low-single-digit-multiple of the existing cheap
+scan, tens of milliseconds in absolute terms. That is cheap enough that a caller who wants the
+answer should be able to opt into it without a second thought.
+
+On the one artifact known to be pathological for this specific check, the same call costs
+~1800x-4100x the cheap scan (in absolute terms 16-17ms vs 30+ seconds at the default
+`hardTimeout`), and pre-#319 it never returned at all. That is not a tail-latency inconvenience;
+it turns a call documented and used as a cheap synchronous scan into one that can occasionally
+block a caller's thread for tens of seconds to indefinitely, on input the caller has no way to
+distinguish from "one more STEP import" ahead of time. Real degenerate CAD/reconstruction input of
+exactly this shape (a wildly folded B-spline surface) is not a contrived worst case: this exact
+artifact came from a real reconstruction pipeline.
+
+That combination, cheap on every ordinary shape measured but catastrophic on realistic pathological
+input, decides the question in #772's own terms: **making the check unconditional (or opt-in but
+defaulting on) would occasionally turn a cheap call into an unbounded one, silently.** Opt-in with
+a default of `false` is not a foregone conclusion overridden by caution here; it is what "small
+overhead on ordinary input, unbounded-shaped overhead on pathological input" implies for a function
+documented as the cheap scan.
+
+## Decision
+
+**Option 2, opt-in parameter, default off** (`analyze(tolerance:checkSelfIntersection:hardTimeout:)`),
+combined with option 3's discipline for representing the result: `ShapeAnalysisResult.hasSelfIntersection`
+is `Bool?`, non-nil exactly when `checkSelfIntersection: true` was passed and the check resolved
+before `hardTimeout`. `nil` means unmeasured (not requested, or requested but indeterminate), never
+a fabricated "clean". This satisfies #771's own bar for option 3: the field is reachable and
+populated on a real path (proved by
+`Issue772SelfIntersectionAnalysisTests.checkSelfIntersectionTrueOnCleanShapePopulatesFalse` /
+`checkSelfIntersectionTrueOnSelfIntersectingShapePopulatesTrue`), not an always-closed gate.
+
+The type is `Bool?`, not the `Int?` the issue's own option-3 sketch mentioned: `isSelfIntersecting`
+only ever answers yes/no/indeterminate (`BOPAlgo_ArgumentAnalyzer` runs with `StopOnFirstFaulty`),
+never a count of intersections, so an `Int?` here would imply a precision the check does not
+provide, which is the same class of defect #763 removed.
+
+`hardTimeout`, not the cooperative `timeout:`, backs the new parameter: `isSelfIntersecting(timeout:)`'s
+own documentation still warns of un-polled internal stretches capable of running well past the
+requested deadline even after #319's fix (this run's own ~30.0-30.4s vs a 30s deadline shows the
+fix holding on the one artifact it was proven against, not a guarantee against every artifact).
+`isSelfIntersecting(hardTimeout:)` is the API #319 built specifically to give a true wall-clock
+bound regardless.

--- a/Scripts/repro/772-analyze-self-intersection/README.md
+++ b/Scripts/repro/772-analyze-self-intersection/README.md
@@ -24,8 +24,11 @@ here without a passing "the gate actually flips" test would repeat that exact de
 
 ## Method
 
-`main.swift` (built as the `AnalyzeSelfIntersectionTiming` executable target, see `Package.swift`)
-times `Shape.analyze(tolerance:)` (the existing cheap small-edge/small-face/gap scan) against
+`Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift` (one harness in the shared
+`Harnesses` executable target, see `Package.swift` and `Scripts/repro/harnesses/HarnessRunner.swift`;
+this directory keeps only this README and the captured output, not Swift source, the same
+arrangement #694 established for `Censuses`) times `Shape.analyze(tolerance:)` (the existing
+cheap small-edge/small-face/gap scan) against
 `Shape.isSelfIntersecting(timeout:)` (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, the same
 machinery #319 gave a working cooperative timeout) across four shapes, chosen to span "trivial" to
 "the worst artifact on record for this check":
@@ -48,7 +51,7 @@ machinery #319 gave a working cooperative timeout) across four shapes, chosen to
 Run with:
 
 ```bash
-swift run -c release AnalyzeSelfIntersectionTiming
+swift run -c release Harnesses 772-self-intersection
 ```
 
 (Release build matters here: debug-mode overhead is comparable in magnitude to the cheap scan

--- a/Scripts/repro/772-analyze-self-intersection/README.md
+++ b/Scripts/repro/772-analyze-self-intersection/README.md
@@ -22,16 +22,39 @@ pattern while never actually flipping (`false` at every assignment site, `true` 
 `nil` it produced was indistinguishable from a field that had simply been deleted. Picking option 3
 here without a passing "the gate actually flips" test would repeat that exact defect.
 
-## Method
+## Round 1: the measurement that shipped, and what was wrong with it
+
+The first version of this harness timed `Shape.analyze(tolerance:)` against
+`Shape.isSelfIntersecting(timeout:)` (a direct synchronous `OCCTShapeSelfIntersectsBounded` call)
+on every ordinary shape, and concluded the overhead was small enough to ship as an opt-in
+parameter forwarding to `isSelfIntersecting(hardTimeout:)`.
+
+Review caught the mismatch: `isSelfIntersecting(hardTimeout:)` is a **different, more expensive**
+mechanism (`Shape.swift:2150-2169`) than the one the harness measured. It `deepCopy()`s the whole
+shape, hands the copy to a `DispatchQueue.global` worker that calls
+`OCCTShapeSelfIntersectsBounded(probe.handle, 0)` (0 = no cooperative bound at all on that call),
+and waits on the caller's thread with a `DispatchSemaphore`. The number that justified "cheap
+enough to opt into" was never the number the shipped code path actually cost; the only place
+`hardTimeout:` was measured at all was the pathological artifact, at one deadline.
+
+This section is kept, not deleted, because the same measure-first policy that governs the design
+decision governs the record of getting the measurement wrong the first time.
+
+## Round 2: measuring both entry points, on every row
 
 `Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift` (one harness in the shared
 `Harnesses` executable target, see `Package.swift` and `Scripts/repro/harnesses/HarnessRunner.swift`;
 this directory keeps only this README and the captured output, not Swift source, the same
-arrangement #694 established for `Censuses`) times `Shape.analyze(tolerance:)` (the existing
-cheap small-edge/small-face/gap scan) against
-`Shape.isSelfIntersecting(timeout:)` (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, the same
-machinery #319 gave a working cooperative timeout) across four shapes, chosen to span "trivial" to
-"the worst artifact on record for this check":
+arrangement #694 established for `Censuses`) now times, on every shape, at the same deadline:
+
+- `Shape.analyze(tolerance:)` (the existing cheap small-edge/small-face/gap scan)
+- `Shape.deepCopy()` alone (the step `isSelfIntersecting(hardTimeout:)` takes before spawning its
+  worker, isolated so its share of that mechanism's cost is visible on its own)
+- `Shape.isSelfIntersecting(timeout:)` (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, the
+  same machinery #319 gave a working cooperative timeout)
+- `Shape.isSelfIntersecting(hardTimeout:)` (the background-thread, true-wall-clock variant)
+
+across four shapes, chosen to span "trivial" to "the worst artifact on record for this check":
 
 1. **A plain box** (`Shape.box`): the primitive case.
 2. **A moderately complex fused/filleted solid**: a plate, a boss fused on, four through-holes
@@ -59,63 +82,114 @@ itself on the small shapes, which would make the "ordinary shape" rows noise rat
 
 ## Measured (2026-08-08, macOS arm64, this branch's pinned kernel, `v2.0.0-kernel.2`)
 
-Three independent runs; the numbers below are one representative run (`measured-output.txt`), all
-runs agreed to within roughly 2x on the sub-10ms figures (expected noise at that scale) and within
-a few percent on the two informative figures (the mesh-sewn import and the pathological artifact).
+Several independent runs; the numbers below are one representative run (`measured-output.txt`),
+all runs agreeing to within roughly 2x on the sub-10ms figures (expected noise at that scale) and
+within a few percent on the informative ones (the mesh-sewn import and the pathological artifact).
 
-| Shape | Faces | Edges | `analyze(tolerance:)` | `isSelfIntersecting(timeout: 30)` | Result | Overhead |
+| Shape | Faces | Edges | `analyze(tolerance:)` | `deepCopy()` | `timeout: 30` (shipped) | `hardTimeout: 30` (rejected) |
 |---|---|---|---|---|---|---|
-| 1. Simple box | 6 | 12 | 0.001 s | 0.001 s | clean | ~1x |
-| 2. Moderately complex fused/filleted solid | 16 | 39 | 0.001-0.003 s | 0.003-0.008 s | clean | 2x-3x |
-| 3. Mesh-sewn imported solid (kiha10 body5) | 662 | 1072 | 0.04-0.14 s | 0.06-0.28 s | self-intersects | 1.2x-3.2x |
-| 4. #319 pathological artifact | 1 | 3 | 0.007-0.017 s | 30.0-30.4 s | self-intersects | ~1800x-4100x |
+| 1. Simple box | 6 | 12 | ~0.0005-0.002 s | ~0.00004-0.001 s | ~0.0005-0.007 s, clean | ~0.0004-0.0007 s, clean |
+| 2. Moderately complex fused/filleted solid | 16 | 39 | ~0.001-0.003 s | ~0.00003-0.001 s | ~0.0025-0.003 s, clean | ~0.0025-0.003 s, clean |
+| 3. Mesh-sewn imported solid (kiha10 body5) | 662 | 1072 | ~0.04-0.19 s | ~0.0008-0.001 s | ~0.06-0.10 s, self-intersects | ~0.05-0.10 s, self-intersects |
+| 4. #319 pathological artifact | 1 | 3 | ~0.007-0.017 s | ~0.00001 s | ~30.0-30.15 s, **self-intersects** | ~30.0-30.02 s, **indeterminate** |
 
-`4b`, the same artifact through `isSelfIntersecting(hardTimeout: 5)` (#319's true wall-clock-bound
-variant): returns at 5.01s, confirming the hard deadline holds even though the cooperative
-`timeout:` variant ran to ~30s on this artifact.
+`4b`, the same artifact through `isSelfIntersecting(hardTimeout: 5)`: returns at ~5.0-5.01s,
+confirming the hard deadline holds at a short bound even though its internal call is unbounded.
 
 ## What the numbers say
 
-On every ordinary shape tested, including a real 662-face mesh-sewn import that genuinely
-self-intersects, the self-intersection check costs low-single-digit-multiple of the existing cheap
-scan, tens of milliseconds in absolute terms. That is cheap enough that a caller who wants the
-answer should be able to opt into it without a second thought.
+**`deepCopy()` is cheap everywhere measured**, under 1ms even on the 662-face mesh-sewn import.
+The overhead-comparison table for `timeout:` vs `hardTimeout:` on the three ordinary shapes is
+close either way (0.8x-2.0x for both), so the deep copy is not, on its own, the reason to prefer
+one mechanism over the other. This corrects Round 1's framing: the concern was never really "is
+the deep copy too expensive", it was "is the mechanism the code actually calls the one that was
+measured", and once it was, a second and more decisive difference showed up.
 
-On the one artifact known to be pathological for this specific check, the same call costs
-~1800x-4100x the cheap scan (in absolute terms 16-17ms vs 30+ seconds at the default
-`hardTimeout`), and pre-#319 it never returned at all. That is not a tail-latency inconvenience;
-it turns a call documented and used as a cheap synchronous scan into one that can occasionally
-block a caller's thread for tens of seconds to indefinitely, on input the caller has no way to
-distinguish from "one more STEP import" ahead of time. Real degenerate CAD/reconstruction input of
-exactly this shape (a wildly folded B-spline surface) is not a contrived worst case: this exact
-artifact came from a real reconstruction pipeline.
+**On the #319 pathological artifact, `hardTimeout:` gives a worse answer than `timeout:`, for the
+same wall-clock cost.** `timeout:` reliably returns a conclusive `self-intersects` around 30.05-30.15s;
+`hardTimeout:` reliably returns `nil` (indeterminate) at almost exactly 30.0s, every run. The
+reason is structural, not incidental: `hardTimeout:`'s internal `OCCTShapeSelfIntersectsBounded`
+call passes `0` (unbounded), so the background computation has no cooperative deadline of its own
+to help it find the fault before the caller's semaphore gives up; `timeout:`'s own internal
+checkpoint-based breaker does. The same total time budget buys a real answer through one
+mechanism and a shrug through the other, on exactly the artifact this feature exists to handle.
+`hardTimeout:` also leaves that computation running, abandoned and still unbounded, after
+returning `nil` (documented on `isSelfIntersecting(hardTimeout:)` itself); `timeout:`'s own call is
+the one the caller's thread is already inside, so nothing extra is orphaned.
 
-That combination, cheap on every ordinary shape measured but catastrophic on realistic pathological
-input, decides the question in #772's own terms: **making the check unconditional (or opt-in but
-defaulting on) would occasionally turn a cheap call into an unbounded one, silently.** Opt-in with
-a default of `false` is not a foregone conclusion overridden by caution here; it is what "small
-overhead on ordinary input, unbounded-shaped overhead on pathological input" implies for a function
-documented as the cheap scan.
+**On every ordinary shape, including a real 662-face mesh-sewn import that genuinely
+self-intersects, both entry points cost a low single-digit multiple of the existing cheap scan**,
+well under a second in absolute terms. That is cheap enough that a caller who wants the answer
+should be able to opt into it without a second thought, whichever mechanism backs it.
+
+**On the pathological artifact, the shipped mechanism costs ~3500x-4200x the cheap scan** (in
+absolute terms a few milliseconds vs 30+ seconds at a 30s timeout), and pre-#319 it never returned
+at all. That is not a tail-latency inconvenience: it turns a call documented and used as a cheap
+synchronous scan into one that can occasionally block a caller's thread for tens of seconds, on
+input the caller has no way to distinguish from "one more STEP import" ahead of time. Real
+degenerate CAD/reconstruction input of exactly this shape (a wildly folded B-spline surface) is
+not a contrived worst case: this exact artifact came from a real reconstruction pipeline.
+
+That combination, cheap on every ordinary shape measured but severe on realistic pathological
+input, decides the opt-in-vs-default question in #772's own terms: making the check unconditional
+(or opt-in but defaulting on) would occasionally turn a cheap call into a many-second one,
+silently. The `hardTimeout:` vs `timeout:` finding decides the second, narrower question review
+raised: given the check is opt-in either way, which mechanism should back it.
 
 ## Decision
 
-**Option 2, opt-in parameter, default off** (`analyze(tolerance:checkSelfIntersection:hardTimeout:)`),
-combined with option 3's discipline for representing the result: `ShapeAnalysisResult.hasSelfIntersection`
-is `Bool?`, non-nil exactly when `checkSelfIntersection: true` was passed and the check resolved
-before `hardTimeout`. `nil` means unmeasured (not requested, or requested but indeterminate), never
-a fabricated "clean". This satisfies #771's own bar for option 3: the field is reachable and
-populated on a real path (proved by
-`Issue772SelfIntersectionAnalysisTests.checkSelfIntersectionTrueOnCleanShapePopulatesFalse` /
-`checkSelfIntersectionTrueOnSelfIntersectingShapePopulatesTrue`), not an always-closed gate.
+**Option 2, opt-in parameter, default off**, combined with option 3's discipline for representing
+the result, as before. What changed: the parameter is `analyze(tolerance:selfIntersectionTimeout:)`,
+a single `Double?` (not the two separate parameters, `checkSelfIntersection: Bool` and
+`hardTimeout: Double`, the first version shipped), and it forwards to
+**`isSelfIntersecting(timeout:)`, not `isSelfIntersecting(hardTimeout:)`**.
+
+`ShapeAnalysisResult.hasSelfIntersection` is `Bool?`, non-nil exactly when
+`selfIntersectionTimeout` was non-`nil` and the check resolved before it. `nil` means unmeasured
+(not requested, or requested but indeterminate), never a fabricated "clean". This satisfies #771's
+own bar for option 3: the field is reachable and populated on a real path (proved by
+`Issue772SelfIntersectionAnalysisTests.nonNilTimeoutOnCleanShapePopulatesFalse` /
+`nonNilTimeoutOnSelfIntersectingShapePopulatesTrue`), not an always-closed gate.
 
 The type is `Bool?`, not the `Int?` the issue's own option-3 sketch mentioned: `isSelfIntersecting`
 only ever answers yes/no/indeterminate (`BOPAlgo_ArgumentAnalyzer` runs with `StopOnFirstFaulty`),
 never a count of intersections, so an `Int?` here would imply a precision the check does not
 provide, which is the same class of defect #763 removed.
 
-`hardTimeout`, not the cooperative `timeout:`, backs the new parameter: `isSelfIntersecting(timeout:)`'s
-own documentation still warns of un-polled internal stretches capable of running well past the
-requested deadline even after #319's fix (this run's own ~30.0-30.4s vs a 30s deadline shows the
-fix holding on the one artifact it was proven against, not a guarantee against every artifact).
-`isSelfIntersecting(hardTimeout:)` is the API #319 built specifically to give a true wall-clock
-bound regardless.
+**Why `timeout:`, not `hardTimeout:`**, settled from the measurement above rather than from which
+one sounds safer: `hardTimeout:`'s wall-clock guarantee is real, but `analyze()` is already a
+fully synchronous call with no async variant, so a caller here has already committed to blocking;
+the guarantee buys nothing over `timeout:` in that context, and on the one artifact where it
+mattered it cost a worse answer at the same wall-clock price, plus an abandoned, still-unbounded
+background computation. `isSelfIntersecting(timeout:)`'s own documentation still warns of un-polled
+internal stretches capable of running past the requested deadline on *some* pathological input even
+after #319's fix (this run's own ~30.05-30.15s vs a 30s deadline shows the fix holding on the one
+artifact it was proven against, not a guarantee against every artifact); that residual risk is
+`isSelfIntersecting(timeout:)`'s own pre-existing, already-documented risk, which `analyze()`
+inherits by forwarding to it rather than introduces. A caller who genuinely needs the hard
+wall-clock guarantee despite that (for example no process/subprocess isolation available) should
+call `isSelfIntersecting(hardTimeout:)` directly and accept its documented trade-offs; `analyze()`
+does not make that call on the caller's behalf.
+
+**Two parameters became one** (`checkSelfIntersection: Bool` + `hardTimeout: Double` to
+`selfIntersectionTimeout: Double?`) for a reason found by review, not by this measurement: the
+two-parameter form let a caller supply `hardTimeout: 5` while forgetting
+`checkSelfIntersection: true`, which compiled, ran, and silently discarded the timeout, returning
+`hasSelfIntersection == nil` indistinguishable from the ordinary default-off case. Collapsing them
+into one optional (supplying a value *is* opting in) makes that mistake unrepresentable;
+`Issue772SelfIntersectionAnalysisTests.timeoutAloneCannotBeSuppliedWithoutOptingIn` is the
+regression test, including a comment showing the exact call the old signature allowed.
+
+**Blocking is now documented explicitly.** `analyze()`'s own doc comment previously said the check
+was "orders of magnitude more expensive" without ever saying "blocks the calling thread"; it now
+has its own `- Important` note to that effect, naming the up-to-`selfIntersectionTimeout`-seconds
+stall and warning against a UI/main-thread call site, matching what `isSelfIntersecting(timeout:)`
+already documents.
+
+**Abandoned background computations**: no longer a documentation-only mitigation. Since
+`analyze()` no longer wires into `isSelfIntersecting(hardTimeout:)` at all, the specific risk
+review raised (looping `analyze(checkSelfIntersection: true, hardTimeout: <small>)` over many
+files piling up abandoned, deep-copied, still-running background computations) does not reach
+`analyze()` by construction. `isSelfIntersecting(hardTimeout:)` itself still carries that
+documented trade-off for any caller who reaches it directly (unchanged, out of scope for #772: see
+the issue's own "Not in scope" section).

--- a/Scripts/repro/772-analyze-self-intersection/main.swift
+++ b/Scripts/repro/772-analyze-self-intersection/main.swift
@@ -1,0 +1,169 @@
+// #772: measure the cost of adding a self-intersection pass to Shape.analyze(tolerance:)
+// before choosing between the issue's three options (okf/policies/measure-dont-assume.md:
+// this issue is explicitly a "measure before choosing" task).
+//
+// Times Shape.analyze(tolerance:) (the existing cheap small-edge/small-face/gap scan) against
+// Shape.isSelfIntersecting(timeout:) (the BOPAlgo_ArgumentAnalyzer self-interference check that
+// #319 gave a working cooperative timeout) across a spread of shapes: a plain box, a moderately
+// complex fused/filleted solid, a real mesh-sewn imported solid, and the #319 pathological
+// artifact known to have run 619s against a 30s deadline on stock OCCT.
+//
+// Run with: swift run AnalyzeSelfIntersectionTiming
+// (first run downloads/builds the pinned OCCT.xcframework if no local Libraries/ is present)
+
+import Foundation
+import OCCTSwift
+
+// MARK: - Timing
+
+/// Wall-clock elapsed seconds for `body`, via the monotonic Dispatch clock (available on the
+/// package's macOS 12 / iOS 15 minimum deployment target; `ContinuousClock` needs macOS 13+).
+func measureSeconds(_ body: () -> Void) -> Double {
+    let start = DispatchTime.now().uptimeNanoseconds
+    body()
+    let end = DispatchTime.now().uptimeNanoseconds
+    return Double(end - start) / 1_000_000_000
+}
+
+func fmt(_ seconds: Double) -> String {
+    if seconds >= 1 {
+        return String(format: "%.3f s", seconds)
+    }
+    return String(format: "%.6f s", seconds)
+}
+
+// MARK: - Fixture shapes
+
+func simpleBox() -> Shape {
+    Shape.box(width: 10, height: 10, depth: 10)!
+}
+
+/// A moderately complex fused solid: a plate, a boss fused on, four through-holes cut, all
+/// edges filleted. Dozens of faces, several boolean ops and a fillet: representative of an
+/// ordinary mechanical part, not a primitive and not a pathological artifact.
+func moderatelyComplexFusedSolid() -> Shape {
+    let base = Shape.box(width: 100, height: 60, depth: 20)!
+    let boss = Shape.cylinder(radius: 15, height: 40)!.translated(by: SIMD3(50, 30, 0))!
+    var result = base.union(boss) ?? base
+    for x: Double in [20, 40, 60, 80] {
+        let hole = Shape.cylinder(radius: 5, height: 30)!.translated(by: SIMD3(x, 15, -5))!
+        result = result.subtracting(hole) ?? result
+    }
+    result = result.filleted(radius: 2) ?? result
+    return result
+}
+
+/// A real mesh-sewn imported solid: the #348 fixture (`unify-crash-mmd-kiha10-body5.brep`),
+/// a body extracted from a real reconstruction pipeline (OCCTReconstruct#194). Loose faces
+/// sewn from mesh data, not authored B-Rep: the shape of a real "imported" input.
+func meshSewnImportedSolid() throws -> Shape {
+    // #filePath -> .../Scripts/repro/772-analyze-self-intersection/main.swift; one
+    // deletingLastPathComponent() lands IN the directory containing the file (not its parent),
+    // so reaching the repo root (parent of Scripts/) takes four, not three.
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // .../772-analyze-self-intersection
+        .deletingLastPathComponent()  // .../repro
+        .deletingLastPathComponent()  // .../Scripts
+        .deletingLastPathComponent()  // repo root
+        .appendingPathComponent("Tests/OCCTStressTests/Fixtures/unify-crash-mmd-kiha10-body5.brep")
+    return try Shape.loadBREP(from: fixtureURL)
+}
+
+/// The #319 pathological artifact: a single-face shell whose B-spline surface folds
+/// enormously (bounding box ~1.6e6 x 3.8e6 mm for a ~260 mm part). Measured pre-fix at 619s
+/// CPU against a 30s cooperative deadline that never fired. This branch's pinned kernel
+/// carries the #319 fix (patch 0010: O(1) tangent-zone lookup + a checkpointed breaker), so
+/// this is also the regression check that the fix still holds on the exact artifact it was
+/// filed against.
+func pathologicalArtifact() throws -> Shape {
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // .../772-analyze-self-intersection
+        .deletingLastPathComponent()  // .../repro
+        .appendingPathComponent("319-selfintersection/dualskin_lateral.15.brep")
+    return try Shape.loadBREP(from: fixtureURL)
+}
+
+// MARK: - Report
+
+struct Row {
+    let name: String
+    let faces: Int
+    let edges: Int
+    let analyzeSeconds: Double
+    let selfIntersectSeconds: Double
+    let selfIntersectOutcome: String
+}
+
+var rows: [Row] = []
+
+@MainActor
+func report(name: String, shape: Shape, selfIntersectTimeout: Double) {
+    let faces = shape.subShapeCount(ofType: .face)
+    let edges = shape.subShapeCount(ofType: .edge)
+
+    let analyzeSeconds = measureSeconds { _ = shape.analyze(tolerance: 1e-6) }
+
+    var outcome: Bool?
+    let siSeconds = measureSeconds {
+        outcome = shape.isSelfIntersecting(timeout: selfIntersectTimeout)
+    }
+    let outcomeStr: String
+    switch outcome {
+    case .some(true):  outcomeStr = "self-intersects"
+    case .some(false): outcomeStr = "clean"
+    case nil:          outcomeStr = "indeterminate (timed out)"
+    }
+
+    let row = Row(name: name, faces: faces, edges: edges,
+                  analyzeSeconds: analyzeSeconds, selfIntersectSeconds: siSeconds,
+                  selfIntersectOutcome: outcomeStr)
+    rows.append(row)
+
+    print("\(name)")
+    print("  faces=\(faces) edges=\(edges)")
+    print("  analyze(tolerance:):                 \(fmt(analyzeSeconds))")
+    print("  isSelfIntersecting(timeout: \(Int(selfIntersectTimeout))):     \(fmt(siSeconds))  [\(outcomeStr)]")
+    let overhead = analyzeSeconds > 0 ? siSeconds / analyzeSeconds : Double.infinity
+    print("  overhead (self-intersect / analyze): \(String(format: "%.1f", overhead))x")
+    print()
+}
+
+print("#772 timing: Shape.analyze(tolerance:) vs Shape.isSelfIntersecting(timeout:)")
+print("=================================================================")
+print()
+
+report(name: "1. Simple box", shape: simpleBox(), selfIntersectTimeout: 30)
+report(name: "2. Moderately complex fused/filleted solid", shape: moderatelyComplexFusedSolid(), selfIntersectTimeout: 30)
+
+do {
+    let mesh = try meshSewnImportedSolid()
+    report(name: "3. Mesh-sewn imported solid (kiha10 body5, #348 fixture)", shape: mesh, selfIntersectTimeout: 30)
+} catch {
+    print("3. Mesh-sewn imported solid: FAILED TO LOAD (\(error))")
+}
+
+do {
+    let pathological = try pathologicalArtifact()
+    report(name: "4. #319 pathological artifact (dualskin_lateral.15)", shape: pathological, selfIntersectTimeout: 30)
+
+    // Also measure the true hard wall-clock bound (#319's own follow-up API) at a short
+    // deadline, since the cooperative timeout above can only ask OCCT to stop at its next
+    // checkpoint, not guarantee a return by the deadline.
+    print("4b. Same artifact, isSelfIntersecting(hardTimeout: 5): true wall-clock bound")
+    let hardSeconds = measureSeconds { _ = pathological.isSelfIntersecting(hardTimeout: 5) }
+    print("  actual wall-clock: \(fmt(hardSeconds)) (background check left running past the deadline is abandoned, not cancelled)")
+    print()
+} catch {
+    print("4. #319 pathological artifact: FAILED TO LOAD (\(error))")
+}
+
+print("=================================================================")
+print("Summary (markdown table):")
+print()
+print("| Shape | Faces | Edges | analyze(tolerance:) | isSelfIntersecting(timeout: 30) | Result | Overhead |")
+print("|---|---|---|---|---|---|---|")
+for row in rows {
+    let overhead = row.analyzeSeconds > 0 ? row.selfIntersectSeconds / row.analyzeSeconds : Double.infinity
+    let overheadStr = overhead.isFinite ? String(format: "%.1fx", overhead) : "n/a"
+    print("| \(row.name) | \(row.faces) | \(row.edges) | \(fmt(row.analyzeSeconds)) | \(fmt(row.selfIntersectSeconds)) | \(row.selfIntersectOutcome) | \(overheadStr) |")
+}

--- a/Scripts/repro/772-analyze-self-intersection/measured-output.txt
+++ b/Scripts/repro/772-analyze-self-intersection/measured-output.txt
@@ -1,0 +1,46 @@
+#772 timing: Shape.analyze(tolerance:) vs Shape.isSelfIntersecting(timeout:)
+=================================================================
+
+1. Simple box
+  faces=6 edges=12
+  analyze(tolerance:):                 0.000456 s
+  isSelfIntersecting(timeout: 30):     0.000501 s  [clean]
+  overhead (self-intersect / analyze): 1.1x
+
+2. Moderately complex fused/filleted solid
+  faces=16 edges=39
+  analyze(tolerance:):                 0.001267 s
+  isSelfIntersecting(timeout: 30):     0.002379 s  [clean]
+  overhead (self-intersect / analyze): 1.9x
+
+3. Mesh-sewn imported solid (kiha10 body5, #348 fixture)
+  faces=662 edges=1072
+  analyze(tolerance:):                 0.037005 s
+  isSelfIntersecting(timeout: 30):     0.060073 s  [self-intersects]
+  overhead (self-intersect / analyze): 1.6x
+
+4. #319 pathological artifact (dualskin_lateral.15)
+  faces=1 edges=3
+  analyze(tolerance:):                 0.007758 s
+  isSelfIntersecting(timeout: 30):     30.026 s  [self-intersects]
+  overhead (self-intersect / analyze): 3870.2x
+
+4b. Same artifact, isSelfIntersecting(hardTimeout: 5): true wall-clock bound
+  actual wall-clock: 5.010 s (background check left running past the deadline is abandoned, not cancelled)
+
+=================================================================
+Summary (markdown table):
+
+| Shape | Faces | Edges | analyze(tolerance:) | isSelfIntersecting(timeout: 30) | Result | Overhead |
+|---|---|---|---|---|---|---|
+| 1. Simple box | 6 | 12 | 0.000456 s | 0.000501 s | clean | 1.1x |
+| 2. Moderately complex fused/filleted solid | 16 | 39 | 0.001267 s | 0.002379 s | clean | 1.9x |
+| 3. Mesh-sewn imported solid (kiha10 body5, #348 fixture) | 662 | 1072 | 0.037005 s | 0.060073 s | self-intersects | 1.6x |
+| 4. #319 pathological artifact (dualskin_lateral.15) | 1 | 3 | 0.007758 s | 30.026 s | self-intersects | 3870.2x |
+
+---
+
+Captured from `swift run -c release AnalyzeSelfIntersectionTiming` on macOS arm64, this branch's
+pinned kernel (v2.0.0-kernel.2, remote binaryTarget since no local Libraries/OCCT.xcframework was
+present in the worktree this was measured from). One representative run of three; see README.md
+"Measured" section for the range across all three and how the decision follows from these numbers.

--- a/Scripts/repro/772-analyze-self-intersection/measured-output.txt
+++ b/Scripts/repro/772-analyze-self-intersection/measured-output.txt
@@ -1,42 +1,54 @@
-#772 timing: Shape.analyze(tolerance:) vs Shape.isSelfIntersecting(timeout:)
+#772 timing: Shape.analyze(tolerance:) vs both isSelfIntersecting entry points
 =================================================================
 
 1. Simple box
   faces=6 edges=12
-  analyze(tolerance:):                 0.000456 s
-  isSelfIntersecting(timeout: 30):     0.000501 s  [clean]
-  overhead (self-intersect / analyze): 1.1x
+  analyze(tolerance:):                          0.000501 s
+  deepCopy() alone:                             0.000037 s
+  isSelfIntersecting(timeout: 30):             0.000524 s  [clean]  <- what analyze(selfIntersectionTimeout:) calls
+  isSelfIntersecting(hardTimeout: 30):         0.000445 s  [clean]  (measured for comparison, not used by analyze())
+  overhead vs analyze(), timeout (shipped):     1.0x
+  overhead vs analyze(), hardTimeout (rejected):0.9x
 
 2. Moderately complex fused/filleted solid
   faces=16 edges=39
-  analyze(tolerance:):                 0.001267 s
-  isSelfIntersecting(timeout: 30):     0.002379 s  [clean]
-  overhead (self-intersect / analyze): 1.9x
+  analyze(tolerance:):                          0.001266 s
+  deepCopy() alone:                             0.000030 s
+  isSelfIntersecting(timeout: 30):             0.002486 s  [clean]  <- what analyze(selfIntersectionTimeout:) calls
+  isSelfIntersecting(hardTimeout: 30):         0.002519 s  [clean]  (measured for comparison, not used by analyze())
+  overhead vs analyze(), timeout (shipped):     2.0x
+  overhead vs analyze(), hardTimeout (rejected):2.0x
 
 3. Mesh-sewn imported solid (kiha10 body5, #348 fixture)
   faces=662 edges=1072
-  analyze(tolerance:):                 0.037005 s
-  isSelfIntersecting(timeout: 30):     0.060073 s  [self-intersects]
-  overhead (self-intersect / analyze): 1.6x
+  analyze(tolerance:):                          0.039823 s
+  deepCopy() alone:                             0.000850 s
+  isSelfIntersecting(timeout: 30):             0.056468 s  [self-intersects]  <- what analyze(selfIntersectionTimeout:) calls
+  isSelfIntersecting(hardTimeout: 30):         0.054596 s  [self-intersects]  (measured for comparison, not used by analyze())
+  overhead vs analyze(), timeout (shipped):     1.4x
+  overhead vs analyze(), hardTimeout (rejected):1.4x
 
 4. #319 pathological artifact (dualskin_lateral.15)
   faces=1 edges=3
-  analyze(tolerance:):                 0.007758 s
-  isSelfIntersecting(timeout: 30):     30.026 s  [self-intersects]
-  overhead (self-intersect / analyze): 3870.2x
+  analyze(tolerance:):                          0.007188 s
+  deepCopy() alone:                             0.000006 s
+  isSelfIntersecting(timeout: 30):             30.080 s  [self-intersects]  <- what analyze(selfIntersectionTimeout:) calls
+  isSelfIntersecting(hardTimeout: 30):         30.013 s  [indeterminate (timed out)]  (measured for comparison, not used by analyze())
+  overhead vs analyze(), timeout (shipped):     4184.7x
+  overhead vs analyze(), hardTimeout (rejected):4175.3x
 
 4b. Same artifact, isSelfIntersecting(hardTimeout: 5): true wall-clock bound
-  actual wall-clock: 5.010 s (background check left running past the deadline is abandoned, not cancelled)
+  actual wall-clock: 5.004 s (background check left running past the deadline is abandoned, not cancelled, and unbounded internally: see Shape.swift:2158)
 
 =================================================================
 Summary (markdown table):
 
-| Shape | Faces | Edges | analyze(tolerance:) | isSelfIntersecting(timeout: 30) | Result | Overhead |
-|---|---|---|---|---|---|---|
-| 1. Simple box | 6 | 12 | 0.000456 s | 0.000501 s | clean | 1.1x |
-| 2. Moderately complex fused/filleted solid | 16 | 39 | 0.001267 s | 0.002379 s | clean | 1.9x |
-| 3. Mesh-sewn imported solid (kiha10 body5, #348 fixture) | 662 | 1072 | 0.037005 s | 0.060073 s | self-intersects | 1.6x |
-| 4. #319 pathological artifact (dualskin_lateral.15) | 1 | 3 | 0.007758 s | 30.026 s | self-intersects | 3870.2x |
+| Shape | Faces | Edges | analyze(tolerance:) | deepCopy() | timeout: 30 (shipped path) | hardTimeout: 30 (rejected) | Overhead (shipped) |
+|---|---|---|---|---|---|---|---|
+| 1. Simple box | 6 | 12 | 0.000501 s | 0.000037 s | 0.000524 s [clean] | 0.000445 s [clean] | 1.0x |
+| 2. Moderately complex fused/filleted solid | 16 | 39 | 0.001266 s | 0.000030 s | 0.002486 s [clean] | 0.002519 s [clean] | 2.0x |
+| 3. Mesh-sewn imported solid (kiha10 body5, #348 fixture) | 662 | 1072 | 0.039823 s | 0.000850 s | 0.056468 s [self-intersects] | 0.054596 s [self-intersects] | 1.4x |
+| 4. #319 pathological artifact (dualskin_lateral.15) | 1 | 3 | 0.007188 s | 0.000006 s | 30.080 s [self-intersects] | 30.013 s [indeterminate (timed out)] | 4184.7x |
 
 ---
 
@@ -44,3 +56,10 @@ Captured from `swift run -c release Harnesses 772-self-intersection` on macOS ar
 pinned kernel (v2.0.0-kernel.2, remote binaryTarget since no local Libraries/OCCT.xcframework was
 present in the worktree this was measured from). One representative run of three; see README.md
 "Measured" section for the range across all three and how the decision follows from these numbers.
+
+Review round 2 replaced this file's earlier content: the first version measured only
+`isSelfIntersecting(timeout:)` on the ordinary rows while `analyze()` at the time actually called
+`isSelfIntersecting(hardTimeout:)`, a different and more expensive mechanism never measured on
+anything but the pathological artifact. This version measures `deepCopy()` alone and both
+self-intersection entry points, at the same deadline, on every row. `analyze()` now forwards to
+`timeout:`, not `hardTimeout:`; see README.md for why.

--- a/Scripts/repro/772-analyze-self-intersection/measured-output.txt
+++ b/Scripts/repro/772-analyze-self-intersection/measured-output.txt
@@ -40,7 +40,7 @@ Summary (markdown table):
 
 ---
 
-Captured from `swift run -c release AnalyzeSelfIntersectionTiming` on macOS arm64, this branch's
+Captured from `swift run -c release Harnesses 772-self-intersection` on macOS arm64, this branch's
 pinned kernel (v2.0.0-kernel.2, remote binaryTarget since no local Libraries/OCCT.xcframework was
 present in the worktree this was measured from). One representative run of three; see README.md
 "Measured" section for the range across all three and how the decision follows from these numbers.

--- a/Scripts/repro/censuses/CensusRunner.swift
+++ b/Scripts/repro/censuses/CensusRunner.swift
@@ -1,65 +1,30 @@
-// Dispatch for the shared Censuses target (#694). `swift run Censuses <cluster>` runs that
+// Registry for the shared Censuses target (#694). `swift run Censuses <cluster>` runs that
 // cluster's census; with no argument or `list` it lists what is available instead of failing,
-// and `all` runs every census in turn. Kept out of main.swift itself: a `let` at main.swift's
-// top level runs main-actor isolated under Swift 6 language mode's top-level-code rule, which
-// then cannot be read from an ordinary `nonisolated` function declared in another file. Giving
-// the registry and the dispatch logic an ordinary (non-top-level) home avoids that entirely.
+// and `all` runs every census in turn. Dispatch itself lives in RunnerCore's GenericRunner (#772
+// review: this file used to duplicate that logic instead of sharing it with HarnessRunner.swift).
+// Kept out of main.swift itself: a `let` at main.swift's top level runs main-actor isolated under
+// Swift 6 language mode's top-level-code rule, which then cannot be read from an ordinary
+// `nonisolated` function declared in another file. Giving the registry an ordinary (non-top-level)
+// home avoids that entirely.
 //
 // Adding a cluster: give it a `<Name>.swift` file in this directory with an `enum <Name> { static
 // func run() }`, and add one line to `censuses` below. The cluster's own `README.md` and any
 // static cross-check script stay in its own `Scripts/repro/<cluster-dir>/`, unlisted in
 // `Package.swift`, since neither is Swift source SwiftPM needs to see.
 
-import Foundation
-
-struct CensusEntry: Sendable {
-    let name: String
-    let summary: String
-    let run: @Sendable () -> Void
-}
+import RunnerCore
 
 enum CensusRunner {
-    static let censuses: [CensusEntry] = [
-        CensusEntry(name: "cluster-a", summary: "sub-shape enumeration and orientation (#664)", run: ClusterA.run),
-        CensusEntry(name: "cluster-b", summary: "fillet and chamfer edge-set contract (#665)", run: ClusterB.run),
-        CensusEntry(name: "cluster-d", summary: "continuity handling across the kernel and bridge (#513/#667)", run: ClusterD.run),
+    static let censuses: [RunnableEntry] = [
+        RunnableEntry(name: "cluster-a", summary: "sub-shape enumeration and orientation (#664)", run: ClusterA.run),
+        RunnableEntry(name: "cluster-b", summary: "fillet and chamfer edge-set contract (#665)", run: ClusterB.run),
+        RunnableEntry(name: "cluster-d", summary: "continuity handling across the kernel and bridge (#513/#667)", run: ClusterD.run),
     ]
 
     static func main() {
-        let arguments = Array(CommandLine.arguments.dropFirst())
-
-        switch arguments.first {
-        case nil, "list":
-            printUsage()
-
-        case "all":
-            for (offset, entry) in censuses.enumerated() {
-                if offset > 0 { print() }
-                print("=== \(entry.name): \(entry.summary) ===")
-                entry.run()
-            }
-
-        case let requested?:
-            guard let entry = censuses.first(where: { $0.name == requested }) else {
-                FileHandle.standardError.write(Data("Censuses: no such census \"\(requested)\"\n\n".utf8))
-                printUsage()
-                exit(1)
-            }
-            entry.run()
-        }
-    }
-
-    private static func printUsage() {
-        print("Censuses: runnable measurement artifacts for docs/v2.0.0-plan.md's census-once rule.")
-        print()
-        print("Usage: swift run Censuses <cluster>")
-        print("       swift run Censuses all      # run every census in turn")
-        print("       swift run Censuses list     # this listing (also the no-argument default)")
-        print()
-        print("Available censuses:")
-        for entry in censuses {
-            let name = entry.name.count >= 12 ? entry.name : entry.name + String(repeating: " ", count: 12 - entry.name.count)
-            print("  \(name) \(entry.summary)")
-        }
+        GenericRunner.main(
+            toolName: "Censuses",
+            blurb: "Censuses: runnable measurement artifacts for docs/v2.0.0-plan.md's census-once rule.",
+            entries: censuses)
     }
 }

--- a/Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift
+++ b/Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift
@@ -131,6 +131,13 @@ fileprivate struct SelfIntersectionTimingRow {
     let timeoutOutcome: String
     let hardTimeoutSeconds: Double
     let hardTimeoutOutcome: String
+
+    /// Computed once here so `report()`'s per-row print and `run()`'s summary table read the same
+    /// number rather than each deriving it (#773 review). A formula with two call sites is a
+    /// formula that gets changed in one of them.
+    var overheadTimeout: Double {
+        analyzeSeconds > 0 ? timeoutSeconds / analyzeSeconds : Double.infinity
+    }
 }
 
 /// Measures `analyze(tolerance:)`, `deepCopy()` alone, `isSelfIntersecting(timeout:)`, and
@@ -159,13 +166,13 @@ fileprivate func report(name: String, shape: Shape, deadline: Double,
         hardTimeoutOutcome = shape.isSelfIntersecting(hardTimeout: deadline)
     }
 
-    rows.append(SelfIntersectionTimingRow(
+    let row = SelfIntersectionTimingRow(
         name: name, faces: faces, edges: edges,
         analyzeSeconds: analyzeSeconds, deepCopySeconds: deepCopySeconds,
         timeoutSeconds: timeoutSeconds, timeoutOutcome: describe(timeoutOutcome),
-        hardTimeoutSeconds: hardTimeoutSeconds, hardTimeoutOutcome: describe(hardTimeoutOutcome)))
+        hardTimeoutSeconds: hardTimeoutSeconds, hardTimeoutOutcome: describe(hardTimeoutOutcome))
+    rows.append(row)
 
-    let overheadTimeout = analyzeSeconds > 0 ? timeoutSeconds / analyzeSeconds : Double.infinity
     let overheadHard = analyzeSeconds > 0 ? hardTimeoutSeconds / analyzeSeconds : Double.infinity
 
     print("\(name)")
@@ -174,7 +181,7 @@ fileprivate func report(name: String, shape: Shape, deadline: Double,
     print("  deepCopy() alone:                             \(fmt(deepCopySeconds))")
     print("  isSelfIntersecting(timeout: \(Int(deadline))):             \(fmt(timeoutSeconds))  [\(describe(timeoutOutcome))]  <- what analyze(selfIntersectionTimeout:) calls")
     print("  isSelfIntersecting(hardTimeout: \(Int(deadline))):         \(fmt(hardTimeoutSeconds))  [\(describe(hardTimeoutOutcome))]  (measured for comparison, not used by analyze())")
-    print("  overhead vs analyze(), timeout (shipped):     \(String(format: "%.1f", overheadTimeout))x")
+    print("  overhead vs analyze(), timeout (shipped):     \(String(format: "%.1f", row.overheadTimeout))x")
     print("  overhead vs analyze(), hardTimeout (rejected):\(String(format: "%.1f", overheadHard))x")
     print()
 }
@@ -224,8 +231,7 @@ enum AnalyzeSelfIntersectionTiming {
         print("| Shape | Faces | Edges | analyze(tolerance:) | deepCopy() | timeout: 30 (shipped path) | hardTimeout: 30 (rejected) | Overhead (shipped) |")
         print("|---|---|---|---|---|---|---|---|")
         for row in rows {
-            let overheadTimeout = row.analyzeSeconds > 0 ? row.timeoutSeconds / row.analyzeSeconds : Double.infinity
-            let overheadStr = overheadTimeout.isFinite ? String(format: "%.1fx", overheadTimeout) : "n/a"
+            let overheadStr = row.overheadTimeout.isFinite ? String(format: "%.1fx", row.overheadTimeout) : "n/a"
             print("| \(row.name) | \(row.faces) | \(row.edges) | \(fmt(row.analyzeSeconds)) | \(fmt(row.deepCopySeconds)) | \(fmt(row.timeoutSeconds)) [\(row.timeoutOutcome)] | \(fmt(row.hardTimeoutSeconds)) [\(row.hardTimeoutOutcome)] | \(overheadStr) |")
         }
     }

--- a/Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift
+++ b/Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift
@@ -8,8 +8,14 @@
 // complex fused/filleted solid, a real mesh-sewn imported solid, and the #319 pathological
 // artifact known to have run 619s against a 30s deadline on stock OCCT.
 //
-// Run with: swift run AnalyzeSelfIntersectionTiming
+// Run with: swift run Harnesses 772-self-intersection
 // (first run downloads/builds the pinned OCCT.xcframework if no local Libraries/ is present)
+//
+// See Scripts/repro/772-analyze-self-intersection/README.md for the method, the full measured
+// table across three runs, and the reasoning from those numbers to the chosen option. This file
+// holds only the Swift source: the shared Harnesses target (see HarnessRunner.swift) keeps that
+// repro directory to just its README and captured output, the same arrangement #694 established
+// for Censuses.
 
 import Foundation
 import OCCTSwift
@@ -18,14 +24,14 @@ import OCCTSwift
 
 /// Wall-clock elapsed seconds for `body`, via the monotonic Dispatch clock (available on the
 /// package's macOS 12 / iOS 15 minimum deployment target; `ContinuousClock` needs macOS 13+).
-func measureSeconds(_ body: () -> Void) -> Double {
+fileprivate func measureSeconds(_ body: () -> Void) -> Double {
     let start = DispatchTime.now().uptimeNanoseconds
     body()
     let end = DispatchTime.now().uptimeNanoseconds
     return Double(end - start) / 1_000_000_000
 }
 
-func fmt(_ seconds: Double) -> String {
+fileprivate func fmt(_ seconds: Double) -> String {
     if seconds >= 1 {
         return String(format: "%.3f s", seconds)
     }
@@ -34,14 +40,14 @@ func fmt(_ seconds: Double) -> String {
 
 // MARK: - Fixture shapes
 
-func simpleBox() -> Shape {
+fileprivate func simpleBox() -> Shape {
     Shape.box(width: 10, height: 10, depth: 10)!
 }
 
 /// A moderately complex fused solid: a plate, a boss fused on, four through-holes cut, all
 /// edges filleted. Dozens of faces, several boolean ops and a fillet: representative of an
 /// ordinary mechanical part, not a primitive and not a pathological artifact.
-func moderatelyComplexFusedSolid() -> Shape {
+fileprivate func moderatelyComplexFusedSolid() -> Shape {
     let base = Shape.box(width: 100, height: 60, depth: 20)!
     let boss = Shape.cylinder(radius: 15, height: 40)!.translated(by: SIMD3(50, 30, 0))!
     var result = base.union(boss) ?? base
@@ -56,12 +62,14 @@ func moderatelyComplexFusedSolid() -> Shape {
 /// A real mesh-sewn imported solid: the #348 fixture (`unify-crash-mmd-kiha10-body5.brep`),
 /// a body extracted from a real reconstruction pipeline (OCCTReconstruct#194). Loose faces
 /// sewn from mesh data, not authored B-Rep: the shape of a real "imported" input.
-func meshSewnImportedSolid() throws -> Shape {
-    // #filePath -> .../Scripts/repro/772-analyze-self-intersection/main.swift; one
+fileprivate func meshSewnImportedSolid() throws -> Shape {
+    // #filePath -> .../Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift; one
     // deletingLastPathComponent() lands IN the directory containing the file (not its parent),
-    // so reaching the repo root (parent of Scripts/) takes four, not three.
+    // so reaching the repo root (parent of Scripts/) takes three from here (harnesses/, repro/,
+    // Scripts/), not four: this file lives one directory shallower than the old per-issue
+    // main.swift did.
     let fixtureURL = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()  // .../772-analyze-self-intersection
+        .deletingLastPathComponent()  // .../harnesses
         .deletingLastPathComponent()  // .../repro
         .deletingLastPathComponent()  // .../Scripts
         .deletingLastPathComponent()  // repo root
@@ -75,9 +83,9 @@ func meshSewnImportedSolid() throws -> Shape {
 /// carries the #319 fix (patch 0010: O(1) tangent-zone lookup + a checkpointed breaker), so
 /// this is also the regression check that the fix still holds on the exact artifact it was
 /// filed against.
-func pathologicalArtifact() throws -> Shape {
+fileprivate func pathologicalArtifact() throws -> Shape {
     let fixtureURL = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()  // .../772-analyze-self-intersection
+        .deletingLastPathComponent()  // .../harnesses
         .deletingLastPathComponent()  // .../repro
         .appendingPathComponent("319-selfintersection/dualskin_lateral.15.brep")
     return try Shape.loadBREP(from: fixtureURL)
@@ -85,7 +93,7 @@ func pathologicalArtifact() throws -> Shape {
 
 // MARK: - Report
 
-struct Row {
+fileprivate struct SelfIntersectionTimingRow {
     let name: String
     let faces: Int
     let edges: Int
@@ -94,10 +102,8 @@ struct Row {
     let selfIntersectOutcome: String
 }
 
-var rows: [Row] = []
-
-@MainActor
-func report(name: String, shape: Shape, selfIntersectTimeout: Double) {
+fileprivate func report(name: String, shape: Shape, selfIntersectTimeout: Double,
+                        into rows: inout [SelfIntersectionTimingRow]) {
     let faces = shape.subShapeCount(ofType: .face)
     let edges = shape.subShapeCount(ofType: .edge)
 
@@ -114,10 +120,10 @@ func report(name: String, shape: Shape, selfIntersectTimeout: Double) {
     case nil:          outcomeStr = "indeterminate (timed out)"
     }
 
-    let row = Row(name: name, faces: faces, edges: edges,
-                  analyzeSeconds: analyzeSeconds, selfIntersectSeconds: siSeconds,
-                  selfIntersectOutcome: outcomeStr)
-    rows.append(row)
+    rows.append(SelfIntersectionTimingRow(
+        name: name, faces: faces, edges: edges,
+        analyzeSeconds: analyzeSeconds, selfIntersectSeconds: siSeconds,
+        selfIntersectOutcome: outcomeStr))
 
     print("\(name)")
     print("  faces=\(faces) edges=\(edges)")
@@ -128,42 +134,51 @@ func report(name: String, shape: Shape, selfIntersectTimeout: Double) {
     print()
 }
 
-print("#772 timing: Shape.analyze(tolerance:) vs Shape.isSelfIntersecting(timeout:)")
-print("=================================================================")
-print()
+enum AnalyzeSelfIntersectionTiming {
+    static func run() {
+        var rows: [SelfIntersectionTimingRow] = []
 
-report(name: "1. Simple box", shape: simpleBox(), selfIntersectTimeout: 30)
-report(name: "2. Moderately complex fused/filleted solid", shape: moderatelyComplexFusedSolid(), selfIntersectTimeout: 30)
+        print("#772 timing: Shape.analyze(tolerance:) vs Shape.isSelfIntersecting(timeout:)")
+        print("=================================================================")
+        print()
 
-do {
-    let mesh = try meshSewnImportedSolid()
-    report(name: "3. Mesh-sewn imported solid (kiha10 body5, #348 fixture)", shape: mesh, selfIntersectTimeout: 30)
-} catch {
-    print("3. Mesh-sewn imported solid: FAILED TO LOAD (\(error))")
-}
+        report(name: "1. Simple box", shape: simpleBox(), selfIntersectTimeout: 30, into: &rows)
+        report(name: "2. Moderately complex fused/filleted solid",
+               shape: moderatelyComplexFusedSolid(), selfIntersectTimeout: 30, into: &rows)
 
-do {
-    let pathological = try pathologicalArtifact()
-    report(name: "4. #319 pathological artifact (dualskin_lateral.15)", shape: pathological, selfIntersectTimeout: 30)
+        do {
+            let mesh = try meshSewnImportedSolid()
+            report(name: "3. Mesh-sewn imported solid (kiha10 body5, #348 fixture)",
+                   shape: mesh, selfIntersectTimeout: 30, into: &rows)
+        } catch {
+            print("3. Mesh-sewn imported solid: FAILED TO LOAD (\(error))")
+        }
 
-    // Also measure the true hard wall-clock bound (#319's own follow-up API) at a short
-    // deadline, since the cooperative timeout above can only ask OCCT to stop at its next
-    // checkpoint, not guarantee a return by the deadline.
-    print("4b. Same artifact, isSelfIntersecting(hardTimeout: 5): true wall-clock bound")
-    let hardSeconds = measureSeconds { _ = pathological.isSelfIntersecting(hardTimeout: 5) }
-    print("  actual wall-clock: \(fmt(hardSeconds)) (background check left running past the deadline is abandoned, not cancelled)")
-    print()
-} catch {
-    print("4. #319 pathological artifact: FAILED TO LOAD (\(error))")
-}
+        do {
+            let pathological = try pathologicalArtifact()
+            report(name: "4. #319 pathological artifact (dualskin_lateral.15)",
+                   shape: pathological, selfIntersectTimeout: 30, into: &rows)
 
-print("=================================================================")
-print("Summary (markdown table):")
-print()
-print("| Shape | Faces | Edges | analyze(tolerance:) | isSelfIntersecting(timeout: 30) | Result | Overhead |")
-print("|---|---|---|---|---|---|---|")
-for row in rows {
-    let overhead = row.analyzeSeconds > 0 ? row.selfIntersectSeconds / row.analyzeSeconds : Double.infinity
-    let overheadStr = overhead.isFinite ? String(format: "%.1fx", overhead) : "n/a"
-    print("| \(row.name) | \(row.faces) | \(row.edges) | \(fmt(row.analyzeSeconds)) | \(fmt(row.selfIntersectSeconds)) | \(row.selfIntersectOutcome) | \(overheadStr) |")
+            // Also measure the true hard wall-clock bound (#319's own follow-up API) at a
+            // short deadline, since the cooperative timeout above can only ask OCCT to stop
+            // at its next checkpoint, not guarantee a return by the deadline.
+            print("4b. Same artifact, isSelfIntersecting(hardTimeout: 5): true wall-clock bound")
+            let hardSeconds = measureSeconds { _ = pathological.isSelfIntersecting(hardTimeout: 5) }
+            print("  actual wall-clock: \(fmt(hardSeconds)) (background check left running past the deadline is abandoned, not cancelled)")
+            print()
+        } catch {
+            print("4. #319 pathological artifact: FAILED TO LOAD (\(error))")
+        }
+
+        print("=================================================================")
+        print("Summary (markdown table):")
+        print()
+        print("| Shape | Faces | Edges | analyze(tolerance:) | isSelfIntersecting(timeout: 30) | Result | Overhead |")
+        print("|---|---|---|---|---|---|---|")
+        for row in rows {
+            let overhead = row.analyzeSeconds > 0 ? row.selfIntersectSeconds / row.analyzeSeconds : Double.infinity
+            let overheadStr = overhead.isFinite ? String(format: "%.1fx", overhead) : "n/a"
+            print("| \(row.name) | \(row.faces) | \(row.edges) | \(fmt(row.analyzeSeconds)) | \(fmt(row.selfIntersectSeconds)) | \(row.selfIntersectOutcome) | \(overheadStr) |")
+        }
+    }
 }

--- a/Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift
+++ b/Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift
@@ -3,19 +3,39 @@
 // this issue is explicitly a "measure before choosing" task).
 //
 // Times Shape.analyze(tolerance:) (the existing cheap small-edge/small-face/gap scan) against
-// Shape.isSelfIntersecting(timeout:) (the BOPAlgo_ArgumentAnalyzer self-interference check that
-// #319 gave a working cooperative timeout) across a spread of shapes: a plain box, a moderately
+// BOTH self-intersection entry points, across a spread of shapes: a plain box, a moderately
 // complex fused/filleted solid, a real mesh-sewn imported solid, and the #319 pathological
 // artifact known to have run 619s against a 30s deadline on stock OCCT.
+//
+// Review round 2 finding: the first version of this harness measured only
+// `isSelfIntersecting(timeout:)` for the ordinary rows (a direct synchronous
+// `OCCTShapeSelfIntersectsBounded` call) while `analyze(tolerance:checkSelfIntersection:hardTimeout:)`
+// at the time actually wired into `isSelfIntersecting(hardTimeout:)` (`Shape.swift:2150-2169`), a
+// different and more expensive mechanism: `deepCopy()` the whole shape, hand the copy to a
+// `DispatchQueue.global` worker calling `OCCTShapeSelfIntersectsBounded(probe.handle, 0)` (0 =
+// no cooperative bound at all on that call), then `DispatchSemaphore.wait` on the caller's side.
+// So the number that justified "cheap enough to opt into" was never the number the shipped code
+// path actually cost. This version measures `deepCopy()` alone and both self-intersection entry
+// points, at the same deadline, on every row, so the gap is visible rather than replaced.
+//
+// What that measurement found: `deepCopy()` is cheap everywhere (under 1ms on every fixture,
+// including the 662-face mesh-sewn import), but on the #319 pathological artifact
+// `isSelfIntersecting(hardTimeout:)` reliably returned `nil` (indeterminate) at the deadline,
+// while `isSelfIntersecting(timeout:)` reliably returned a conclusive `true` around the same
+// wall-clock cost: the same total budget for a strictly worse answer, because `hardTimeout:`'s
+// internal call has no cooperative deadline of its own (passes 0) and the caller-side semaphore
+// is the only bound. `Shape.analyze(tolerance:selfIntersectionTimeout:)` was changed to forward
+// to `isSelfIntersecting(timeout:)` as a result: `analyze()` is already fully synchronous, so
+// `hardTimeout:`'s wall-clock guarantee buys nothing a caller doesn't already have, at the cost
+// of a worse answer on the one artifact that mattered.
 //
 // Run with: swift run Harnesses 772-self-intersection
 // (first run downloads/builds the pinned OCCT.xcframework if no local Libraries/ is present)
 //
 // See Scripts/repro/772-analyze-self-intersection/README.md for the method, the full measured
-// table across three runs, and the reasoning from those numbers to the chosen option. This file
-// holds only the Swift source: the shared Harnesses target (see HarnessRunner.swift) keeps that
-// repro directory to just its README and captured output, the same arrangement #694 established
-// for Censuses.
+// table, and the reasoning from those numbers to the chosen option. This file holds only the
+// Swift source: the shared Harnesses target (see HarnessRunner.swift) keeps that repro directory
+// to just its README and captured output, the same arrangement #694 established for Censuses.
 
 import Foundation
 import OCCTSwift
@@ -36,6 +56,14 @@ fileprivate func fmt(_ seconds: Double) -> String {
         return String(format: "%.3f s", seconds)
     }
     return String(format: "%.6f s", seconds)
+}
+
+fileprivate func describe(_ outcome: Bool?) -> String {
+    switch outcome {
+    case .some(true):  return "self-intersects"
+    case .some(false): return "clean"
+    case nil:          return "indeterminate (timed out)"
+    }
 }
 
 // MARK: - Fixture shapes
@@ -98,39 +126,56 @@ fileprivate struct SelfIntersectionTimingRow {
     let faces: Int
     let edges: Int
     let analyzeSeconds: Double
-    let selfIntersectSeconds: Double
-    let selfIntersectOutcome: String
+    let deepCopySeconds: Double
+    let timeoutSeconds: Double
+    let timeoutOutcome: String
+    let hardTimeoutSeconds: Double
+    let hardTimeoutOutcome: String
 }
 
-fileprivate func report(name: String, shape: Shape, selfIntersectTimeout: Double,
+/// Measures `analyze(tolerance:)`, `deepCopy()` alone, `isSelfIntersecting(timeout:)`, and
+/// `isSelfIntersecting(hardTimeout:)`, all at the same `deadline`, on the same shape.
+/// `analyze(tolerance:selfIntersectionTimeout:)` forwards to `isSelfIntersecting(timeout:)`; the
+/// `hardTimeout:` figure is kept alongside it so the gap between the two mechanisms, and the
+/// reasoning for picking one over the other, stays visible rather than replaced.
+fileprivate func report(name: String, shape: Shape, deadline: Double,
                         into rows: inout [SelfIntersectionTimingRow]) {
     let faces = shape.subShapeCount(ofType: .face)
     let edges = shape.subShapeCount(ofType: .edge)
 
     let analyzeSeconds = measureSeconds { _ = shape.analyze(tolerance: 1e-6) }
 
-    var outcome: Bool?
-    let siSeconds = measureSeconds {
-        outcome = shape.isSelfIntersecting(timeout: selfIntersectTimeout)
+    // deepCopy() in isolation, the same call isSelfIntersecting(hardTimeout:) makes internally,
+    // so its share of that mechanism's cost is visible rather than folded into one number.
+    let deepCopySeconds = measureSeconds { _ = shape.deepCopy() }
+
+    var timeoutOutcome: Bool?
+    let timeoutSeconds = measureSeconds {
+        timeoutOutcome = shape.isSelfIntersecting(timeout: deadline)
     }
-    let outcomeStr: String
-    switch outcome {
-    case .some(true):  outcomeStr = "self-intersects"
-    case .some(false): outcomeStr = "clean"
-    case nil:          outcomeStr = "indeterminate (timed out)"
+
+    var hardTimeoutOutcome: Bool?
+    let hardTimeoutSeconds = measureSeconds {
+        hardTimeoutOutcome = shape.isSelfIntersecting(hardTimeout: deadline)
     }
 
     rows.append(SelfIntersectionTimingRow(
         name: name, faces: faces, edges: edges,
-        analyzeSeconds: analyzeSeconds, selfIntersectSeconds: siSeconds,
-        selfIntersectOutcome: outcomeStr))
+        analyzeSeconds: analyzeSeconds, deepCopySeconds: deepCopySeconds,
+        timeoutSeconds: timeoutSeconds, timeoutOutcome: describe(timeoutOutcome),
+        hardTimeoutSeconds: hardTimeoutSeconds, hardTimeoutOutcome: describe(hardTimeoutOutcome)))
+
+    let overheadTimeout = analyzeSeconds > 0 ? timeoutSeconds / analyzeSeconds : Double.infinity
+    let overheadHard = analyzeSeconds > 0 ? hardTimeoutSeconds / analyzeSeconds : Double.infinity
 
     print("\(name)")
     print("  faces=\(faces) edges=\(edges)")
-    print("  analyze(tolerance:):                 \(fmt(analyzeSeconds))")
-    print("  isSelfIntersecting(timeout: \(Int(selfIntersectTimeout))):     \(fmt(siSeconds))  [\(outcomeStr)]")
-    let overhead = analyzeSeconds > 0 ? siSeconds / analyzeSeconds : Double.infinity
-    print("  overhead (self-intersect / analyze): \(String(format: "%.1f", overhead))x")
+    print("  analyze(tolerance:):                          \(fmt(analyzeSeconds))")
+    print("  deepCopy() alone:                             \(fmt(deepCopySeconds))")
+    print("  isSelfIntersecting(timeout: \(Int(deadline))):             \(fmt(timeoutSeconds))  [\(describe(timeoutOutcome))]  <- what analyze(selfIntersectionTimeout:) calls")
+    print("  isSelfIntersecting(hardTimeout: \(Int(deadline))):         \(fmt(hardTimeoutSeconds))  [\(describe(hardTimeoutOutcome))]  (measured for comparison, not used by analyze())")
+    print("  overhead vs analyze(), timeout (shipped):     \(String(format: "%.1f", overheadTimeout))x")
+    print("  overhead vs analyze(), hardTimeout (rejected):\(String(format: "%.1f", overheadHard))x")
     print()
 }
 
@@ -138,18 +183,18 @@ enum AnalyzeSelfIntersectionTiming {
     static func run() {
         var rows: [SelfIntersectionTimingRow] = []
 
-        print("#772 timing: Shape.analyze(tolerance:) vs Shape.isSelfIntersecting(timeout:)")
+        print("#772 timing: Shape.analyze(tolerance:) vs both isSelfIntersecting entry points")
         print("=================================================================")
         print()
 
-        report(name: "1. Simple box", shape: simpleBox(), selfIntersectTimeout: 30, into: &rows)
+        report(name: "1. Simple box", shape: simpleBox(), deadline: 30, into: &rows)
         report(name: "2. Moderately complex fused/filleted solid",
-               shape: moderatelyComplexFusedSolid(), selfIntersectTimeout: 30, into: &rows)
+               shape: moderatelyComplexFusedSolid(), deadline: 30, into: &rows)
 
         do {
             let mesh = try meshSewnImportedSolid()
             report(name: "3. Mesh-sewn imported solid (kiha10 body5, #348 fixture)",
-                   shape: mesh, selfIntersectTimeout: 30, into: &rows)
+                   shape: mesh, deadline: 30, into: &rows)
         } catch {
             print("3. Mesh-sewn imported solid: FAILED TO LOAD (\(error))")
         }
@@ -157,14 +202,17 @@ enum AnalyzeSelfIntersectionTiming {
         do {
             let pathological = try pathologicalArtifact()
             report(name: "4. #319 pathological artifact (dualskin_lateral.15)",
-                   shape: pathological, selfIntersectTimeout: 30, into: &rows)
+                   shape: pathological, deadline: 30, into: &rows)
 
-            // Also measure the true hard wall-clock bound (#319's own follow-up API) at a
-            // short deadline, since the cooperative timeout above can only ask OCCT to stop
-            // at its next checkpoint, not guarantee a return by the deadline.
+            // The true hard wall-clock bound (#319's own follow-up API) at a SHORT deadline,
+            // since the cooperative timeout above can only ask OCCT to stop at its next
+            // checkpoint, not guarantee a return by the deadline, and hardTimeout:'s own
+            // internal OCCTShapeSelfIntersectsBounded call passes 0 (unbounded): the ONLY
+            // bound on that path is this semaphore wait, so this is the case that actually
+            // proves the guarantee holds regardless of what the background computation does.
             print("4b. Same artifact, isSelfIntersecting(hardTimeout: 5): true wall-clock bound")
             let hardSeconds = measureSeconds { _ = pathological.isSelfIntersecting(hardTimeout: 5) }
-            print("  actual wall-clock: \(fmt(hardSeconds)) (background check left running past the deadline is abandoned, not cancelled)")
+            print("  actual wall-clock: \(fmt(hardSeconds)) (background check left running past the deadline is abandoned, not cancelled, and unbounded internally: see Shape.swift:2158)")
             print()
         } catch {
             print("4. #319 pathological artifact: FAILED TO LOAD (\(error))")
@@ -173,12 +221,12 @@ enum AnalyzeSelfIntersectionTiming {
         print("=================================================================")
         print("Summary (markdown table):")
         print()
-        print("| Shape | Faces | Edges | analyze(tolerance:) | isSelfIntersecting(timeout: 30) | Result | Overhead |")
-        print("|---|---|---|---|---|---|---|")
+        print("| Shape | Faces | Edges | analyze(tolerance:) | deepCopy() | timeout: 30 (shipped path) | hardTimeout: 30 (rejected) | Overhead (shipped) |")
+        print("|---|---|---|---|---|---|---|---|")
         for row in rows {
-            let overhead = row.analyzeSeconds > 0 ? row.selfIntersectSeconds / row.analyzeSeconds : Double.infinity
-            let overheadStr = overhead.isFinite ? String(format: "%.1fx", overhead) : "n/a"
-            print("| \(row.name) | \(row.faces) | \(row.edges) | \(fmt(row.analyzeSeconds)) | \(fmt(row.selfIntersectSeconds)) | \(row.selfIntersectOutcome) | \(overheadStr) |")
+            let overheadTimeout = row.analyzeSeconds > 0 ? row.timeoutSeconds / row.analyzeSeconds : Double.infinity
+            let overheadStr = overheadTimeout.isFinite ? String(format: "%.1fx", overheadTimeout) : "n/a"
+            print("| \(row.name) | \(row.faces) | \(row.edges) | \(fmt(row.analyzeSeconds)) | \(fmt(row.deepCopySeconds)) | \(fmt(row.timeoutSeconds)) [\(row.timeoutOutcome)] | \(fmt(row.hardTimeoutSeconds)) [\(row.hardTimeoutOutcome)] | \(overheadStr) |")
         }
     }
 }

--- a/Scripts/repro/harnesses/HarnessRunner.swift
+++ b/Scripts/repro/harnesses/HarnessRunner.swift
@@ -1,66 +1,30 @@
-// Dispatch for the shared Harnesses target. Same shared-target shape as the Censuses target's
-// own CensusRunner.swift (#694): one manifest entry covers every harness, so a harness's own
-// repro directory (`Scripts/repro/<issue-dir>/`) holds only its README and captured output, not
-// Swift source, and renaming that directory never touches Package.swift. `swift run Harnesses
+// Registry for the shared Harnesses target, the timing/perf sibling of Censuses (#694's pattern:
+// one shared executable target, not one per repro directory, so renaming a repro directory never
+// touches Package.swift and there is no second exclude: list to maintain). `swift run Harnesses
 // <name>` runs that harness; with no argument or `list` it lists what is available, and `all`
-// runs every harness in turn.
+// runs every harness in turn. Dispatch itself lives in RunnerCore's GenericRunner, shared with
+// CensusRunner.swift (#772 review: this file used to duplicate that logic instead).
 //
 // Adding a harness: give it a `<Name>.swift` file in this directory with an `enum <Name> {
 // static func run() }`, and add one line to `harnesses` below. Keep helper types and functions
 // `fileprivate`: everything in this directory is one compilation target, so an unqualified name
 // is visible to every other harness's file too (see ClusterB.swift/ClusterD.swift's identically-
-// named but independent `fmt` for the established precedent).
+// named but independent `fmt` for the established precedent). The harness's own `README.md` and
+// captured output stay in its own `Scripts/repro/<issue-dir>/`, unlisted in `Package.swift`.
 
-import Foundation
-
-struct HarnessEntry: Sendable {
-    let name: String
-    let summary: String
-    let run: @Sendable () -> Void
-}
+import RunnerCore
 
 enum HarnessRunner {
-    static let harnesses: [HarnessEntry] = [
-        HarnessEntry(name: "772-self-intersection",
-                     summary: "analyze(tolerance:) vs isSelfIntersecting(timeout:) cost (#772)",
-                     run: AnalyzeSelfIntersectionTiming.run),
+    static let harnesses: [RunnableEntry] = [
+        RunnableEntry(name: "772-self-intersection",
+                      summary: "analyze(tolerance:) vs isSelfIntersecting(timeout:) cost (#772)",
+                      run: AnalyzeSelfIntersectionTiming.run),
     ]
 
     static func main() {
-        let arguments = Array(CommandLine.arguments.dropFirst())
-
-        switch arguments.first {
-        case nil, "list":
-            printUsage()
-
-        case "all":
-            for (offset, entry) in harnesses.enumerated() {
-                if offset > 0 { print() }
-                print("=== \(entry.name): \(entry.summary) ===")
-                entry.run()
-            }
-
-        case let requested?:
-            guard let entry = harnesses.first(where: { $0.name == requested }) else {
-                FileHandle.standardError.write(Data("Harnesses: no such harness \"\(requested)\"\n\n".utf8))
-                printUsage()
-                exit(1)
-            }
-            entry.run()
-        }
-    }
-
-    private static func printUsage() {
-        print("Harnesses: runnable measurement harnesses backing issue-specific decisions.")
-        print()
-        print("Usage: swift run Harnesses <name>")
-        print("       swift run Harnesses all      # run every harness in turn")
-        print("       swift run Harnesses list     # this listing (also the no-argument default)")
-        print()
-        print("Available harnesses:")
-        for entry in harnesses {
-            let name = entry.name.count >= 24 ? entry.name : entry.name + String(repeating: " ", count: 24 - entry.name.count)
-            print("  \(name) \(entry.summary)")
-        }
+        GenericRunner.main(
+            toolName: "Harnesses",
+            blurb: "Harnesses: runnable measurement harnesses backing issue-specific decisions.",
+            entries: harnesses)
     }
 }

--- a/Scripts/repro/harnesses/HarnessRunner.swift
+++ b/Scripts/repro/harnesses/HarnessRunner.swift
@@ -1,0 +1,66 @@
+// Dispatch for the shared Harnesses target. Same shared-target shape as the Censuses target's
+// own CensusRunner.swift (#694): one manifest entry covers every harness, so a harness's own
+// repro directory (`Scripts/repro/<issue-dir>/`) holds only its README and captured output, not
+// Swift source, and renaming that directory never touches Package.swift. `swift run Harnesses
+// <name>` runs that harness; with no argument or `list` it lists what is available, and `all`
+// runs every harness in turn.
+//
+// Adding a harness: give it a `<Name>.swift` file in this directory with an `enum <Name> {
+// static func run() }`, and add one line to `harnesses` below. Keep helper types and functions
+// `fileprivate`: everything in this directory is one compilation target, so an unqualified name
+// is visible to every other harness's file too (see ClusterB.swift/ClusterD.swift's identically-
+// named but independent `fmt` for the established precedent).
+
+import Foundation
+
+struct HarnessEntry: Sendable {
+    let name: String
+    let summary: String
+    let run: @Sendable () -> Void
+}
+
+enum HarnessRunner {
+    static let harnesses: [HarnessEntry] = [
+        HarnessEntry(name: "772-self-intersection",
+                     summary: "analyze(tolerance:) vs isSelfIntersecting(timeout:) cost (#772)",
+                     run: AnalyzeSelfIntersectionTiming.run),
+    ]
+
+    static func main() {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+
+        switch arguments.first {
+        case nil, "list":
+            printUsage()
+
+        case "all":
+            for (offset, entry) in harnesses.enumerated() {
+                if offset > 0 { print() }
+                print("=== \(entry.name): \(entry.summary) ===")
+                entry.run()
+            }
+
+        case let requested?:
+            guard let entry = harnesses.first(where: { $0.name == requested }) else {
+                FileHandle.standardError.write(Data("Harnesses: no such harness \"\(requested)\"\n\n".utf8))
+                printUsage()
+                exit(1)
+            }
+            entry.run()
+        }
+    }
+
+    private static func printUsage() {
+        print("Harnesses: runnable measurement harnesses backing issue-specific decisions.")
+        print()
+        print("Usage: swift run Harnesses <name>")
+        print("       swift run Harnesses all      # run every harness in turn")
+        print("       swift run Harnesses list     # this listing (also the no-argument default)")
+        print()
+        print("Available harnesses:")
+        for entry in harnesses {
+            let name = entry.name.count >= 24 ? entry.name : entry.name + String(repeating: " ", count: 24 - entry.name.count)
+            print("  \(name) \(entry.summary)")
+        }
+    }
+}

--- a/Scripts/repro/harnesses/main.swift
+++ b/Scripts/repro/harnesses/main.swift
@@ -1,0 +1,7 @@
+// Harnesses: one executable target for ad hoc measurement harnesses backing an issue-specific
+// decision (as opposed to Censuses, the sibling target for docs/v2.0.0-plan.md's cluster
+// census-once work). See HarnessRunner.swift for the dispatch logic; this file only exists
+// because SwiftPM requires exactly one main.swift per executable target to hold the entry
+// point's top-level statement.
+
+HarnessRunner.main()

--- a/Scripts/repro/runner-core/GenericRunner.swift
+++ b/Scripts/repro/runner-core/GenericRunner.swift
@@ -1,0 +1,71 @@
+// Shared dispatch logic for the repo's "one executable target, many named entries" shared
+// targets (#694: Censuses; the same reasoning's Harnesses sibling). Review on #772/#773 found
+// `HarnessRunner.swift` had reproduced `CensusRunner.swift`'s `main()`/`printUsage()` almost line
+// for line instead of extracting it, exactly the per-target duplication #694 was meant to
+// eliminate. This is that extraction: a small library target both executables depend on, so a
+// future change to the dispatch/list/error-handling logic (a new flag, a wording change) is made
+// once, here, rather than ported by hand into every runner.
+//
+// A tool-specific `<Tool>Runner.swift` (`CensusRunner.swift`, `HarnessRunner.swift`) stays in
+// each executable target's own directory: it owns the registry (the list of named entries) and
+// the tool's display name/blurb, and forwards to `GenericRunner.main` for everything else.
+
+import Foundation
+
+/// One named, runnable entry in a shared-target registry (a cluster census, a measurement
+/// harness, ...).
+public struct RunnableEntry: Sendable {
+    public let name: String
+    public let summary: String
+    public let run: @Sendable () -> Void
+
+    public init(name: String, summary: String, run: @escaping @Sendable () -> Void) {
+        self.name = name
+        self.summary = summary
+        self.run = run
+    }
+}
+
+public enum GenericRunner {
+    /// `swift run <toolName> <name>` runs that entry; `all` runs every entry in turn; `list` (or
+    /// no argument) prints the usage/listing below instead of failing; an unrecognised name
+    /// prints the same listing to stderr and exits 1.
+    public static func main(toolName: String, blurb: String, entries: [RunnableEntry]) {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+
+        switch arguments.first {
+        case nil, "list":
+            printUsage(toolName: toolName, blurb: blurb, entries: entries)
+
+        case "all":
+            for (offset, entry) in entries.enumerated() {
+                if offset > 0 { print() }
+                print("=== \(entry.name): \(entry.summary) ===")
+                entry.run()
+            }
+
+        case let requested?:
+            guard let entry = entries.first(where: { $0.name == requested }) else {
+                FileHandle.standardError.write(Data("\(toolName): no such entry \"\(requested)\"\n\n".utf8))
+                printUsage(toolName: toolName, blurb: blurb, entries: entries)
+                exit(1)
+            }
+            entry.run()
+        }
+    }
+
+    private static func printUsage(toolName: String, blurb: String, entries: [RunnableEntry]) {
+        print(blurb)
+        print()
+        print("Usage: swift run \(toolName) <name>")
+        print("       swift run \(toolName) all      # run every entry in turn")
+        print("       swift run \(toolName) list     # this listing (also the no-argument default)")
+        print()
+        print("Available:")
+        let width = entries.map(\.name.count).max() ?? 0
+        for entry in entries {
+            let name = entry.name.count >= width ? entry.name : entry.name + String(repeating: " ", count: width - entry.name.count)
+            print("  \(name) \(entry.summary)")
+        }
+    }
+}

--- a/Scripts/repro/runner-core/GenericRunner.swift
+++ b/Scripts/repro/runner-core/GenericRunner.swift
@@ -64,7 +64,7 @@ public enum GenericRunner {
         print("Available:")
         let width = entries.map(\.name.count).max() ?? 0
         for entry in entries {
-            let name = entry.name.count >= width ? entry.name : entry.name + String(repeating: " ", count: width - entry.name.count)
+            let name = entry.name.count == width ? entry.name : entry.name + String(repeating: " ", count: width - entry.name.count)
             print("  \(name) \(entry.summary)")
         }
     }

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -226,20 +226,54 @@ extension Shape {
     ///   demoted or otherwise open shell now reports its actual gap correctly. A "clean" result
     ///   here has never meant "this is a solid": check `shapeType` or ``isValidSolid`` for that.
     ///
+    /// - Important: Passing `selfIntersectionTimeout` makes this call **synchronously block the
+    ///   calling thread** for up to that many seconds (more, if OCCT never reaches a checkpoint to
+    ///   poll: see ``isSelfIntersecting(timeout:)``'s own `- Important` note, which this inherits
+    ///   unchanged). Do not pass it from a UI/main thread without accepting that stall; the
+    ///   `tolerance`-only call has no such risk.
+    ///
     /// - Parameters:
     ///   - tolerance: Size threshold for detecting small features.
-    ///   - checkSelfIntersection: If `true`, also runs ``isSelfIntersecting(hardTimeout:)`` and
-    ///     populates ``ShapeAnalysisResult/hasSelfIntersection``. Default `false`, because that
-    ///     check is orders of magnitude more expensive than the rest of this scan and, on
-    ///     pathological input, the gap is not small: measured on the #319 artifact, ~1800x the
-    ///     cost of the rest of the scan combined (16ms vs 30s at the default `hardTimeout`). On
-    ///     ordinary shapes the measured overhead was 1x-3x, cheap enough to opt into whenever a
-    ///     caller actually wants the answer. See `Scripts/repro/772-analyze-self-intersection/`
-    ///     for the full measurement across a spread of shapes, from a primitive to that
-    ///     pathological artifact (#772).
-    ///   - hardTimeout: Only used when `checkSelfIntersection` is `true`; forwarded to
-    ///     ``isSelfIntersecting(hardTimeout:)`` as its true wall-clock deadline. Default 30s.
+    ///   - selfIntersectionTimeout: `nil` (the default) skips the self-intersection check
+    ///     entirely and leaves ``ShapeAnalysisResult/hasSelfIntersection`` `nil`. A non-`nil`
+    ///     value opts in, forwarded as the `timeout:` to ``isSelfIntersecting(timeout:)`` (the
+    ///     cooperative-timeout check, not the ``isSelfIntersecting(hardTimeout:)`` background-
+    ///     thread variant: see "Why `timeout:`, not `hardTimeout:`" below). There is no way to
+    ///     supply a timeout that does not enable the check: the two used to be separate
+    ///     parameters (`checkSelfIntersection: Bool`, `hardTimeout: Double`) until review found
+    ///     that shape silently discarded a caller's `hardTimeout` whenever they forgot
+    ///     `checkSelfIntersection: true`, compiling and running with no signal at all (#772).
+    ///     Collapsing them into one optional makes that mistake unrepresentable.
+    ///
+    ///     This check is orders of magnitude more expensive than the rest of this scan, and on
+    ///     pathological input the gap is not small: measured on the #319 artifact, ~3000x-4000x
+    ///     the cost of the rest of the scan combined (a few ms vs 30s at a 30s timeout). On
+    ///     ordinary shapes, including a real 662-face mesh-sewn import, the measured overhead was
+    ///     1x-3x, cheap enough to opt into whenever a caller actually wants the answer. See
+    ///     `Scripts/repro/772-analyze-self-intersection/` for the full measurement across a
+    ///     spread of shapes, from a primitive to that pathological artifact (#772).
     /// - Returns: Analysis result with problem counts, or nil on failure.
+    ///
+    /// ### Why `timeout:`, not `hardTimeout:`
+    ///
+    /// `isSelfIntersecting(hardTimeout:)` looks like the safer choice (a true wall-clock
+    /// guarantee), but measuring both on every fixture, not just the pathological one, found it
+    /// is not a strict improvement here: its `deepCopy()` step is cheap (under 1ms on every
+    /// fixture measured, including the 662-face import), but its internal
+    /// `OCCTShapeSelfIntersectsBounded` call passes **0 (unbounded)**, so the only bound left is
+    /// a `DispatchSemaphore.wait` racing a computation with no cooperative deadline of its own.
+    /// On the #319 pathological artifact this produced a **worse** answer than `timeout:` at the
+    /// same deadline: `timeout:` reliably returned a conclusive `self-intersects` around 30.1s
+    /// (its internal checkpoint found the fault before its own deadline logic gave up), while
+    /// `hardTimeout:` reliably returned `nil` (indeterminate) at exactly 30.0s, the same
+    /// wall-clock budget spent for a strictly less useful answer, on top of leaving an abandoned,
+    /// still-unbounded background computation running (``isSelfIntersecting(hardTimeout:)``'s own
+    /// documented trade). `analyze()` is already a fully synchronous call with no async variant,
+    /// so a caller here has already committed to blocking; `hardTimeout:`'s wall-clock guarantee
+    /// buys nothing over `timeout:` in that context and cost a worse answer on the one artifact
+    /// where it mattered. A caller that genuinely needs the hard guarantee (e.g. no
+    /// process/subprocess isolation available) should call ``isSelfIntersecting(hardTimeout:)``
+    /// directly and accept its documented trade-offs; `analyze()` does not make that call for you.
     ///
     /// ## Example
     ///
@@ -252,23 +286,20 @@ extension Shape {
     ///     }
     /// }
     ///
-    /// // Opt into the expensive check when it's actually needed:
-    /// if let analysis = shape.analyze(tolerance: 0.001, checkSelfIntersection: true) {
+    /// // Opt into the expensive, thread-blocking check when it's actually needed:
+    /// if let analysis = shape.analyze(tolerance: 0.001, selfIntersectionTimeout: 30) {
     ///     switch analysis.hasSelfIntersection {
     ///     case .some(true):  print("self-intersects")
     ///     case .some(false): print("clean")
-    ///     case nil:          print("indeterminate, hardTimeout elapsed first")
+    ///     case nil:          print("indeterminate, timeout elapsed before a checkpoint")
     ///     }
     /// }
     /// ```
-    public func analyze(tolerance: Double = 1e-6, checkSelfIntersection: Bool = false,
-                        hardTimeout: Double = 30) -> ShapeAnalysisResult? {
+    public func analyze(tolerance: Double = 1e-6, selfIntersectionTimeout: Double? = nil) -> ShapeAnalysisResult? {
         let result = OCCTShapeAnalyze(handle, tolerance)
         guard result.isValid else { return nil }
 
-        let hasSelfIntersection: Bool? = checkSelfIntersection
-            ? isSelfIntersecting(hardTimeout: hardTimeout)
-            : nil
+        let hasSelfIntersection: Bool? = selfIntersectionTimeout.flatMap { isSelfIntersecting(timeout: $0) }
 
         return ShapeAnalysisResult(
             smallEdgeCount: Int(result.smallEdgeCount),

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -220,34 +220,61 @@ extension Shape {
 
     /// Analyze a shape for problems such as small edges, gaps, and invalid topology.
     ///
-    /// - Note: This never reports self-intersections (the `selfIntersectionCount` field that used
-    ///   to sit here was always 0, never computed, and was removed in #763); use
-    ///   ``isSelfIntersecting(timeout:)`` for a real check. `freeEdgeCount`/`freeFaceCount` were
-    ///   also hardcoded to 0 for every shape before #702; a demoted or otherwise open shell now
-    ///   reports its actual gap correctly. A "clean" result here has never meant "this is a
-    ///   solid": check `shapeType` or ``isValidSolid`` for that.
-    /// - Parameter tolerance: Size threshold for detecting small features
-    /// - Returns: Analysis result with problem counts, or nil on failure
+    /// - Note: This never reports self-intersection unless asked to (the `selfIntersectionCount`
+    ///   field that used to sit here was always 0, never computed, and was removed in #763).
+    ///   `freeEdgeCount`/`freeFaceCount` were also hardcoded to 0 for every shape before #702; a
+    ///   demoted or otherwise open shell now reports its actual gap correctly. A "clean" result
+    ///   here has never meant "this is a solid": check `shapeType` or ``isValidSolid`` for that.
+    ///
+    /// - Parameters:
+    ///   - tolerance: Size threshold for detecting small features.
+    ///   - checkSelfIntersection: If `true`, also runs ``isSelfIntersecting(hardTimeout:)`` and
+    ///     populates ``ShapeAnalysisResult/hasSelfIntersection``. Default `false`, because that
+    ///     check is orders of magnitude more expensive than the rest of this scan and, on
+    ///     pathological input, the gap is not small: measured on the #319 artifact, ~1800x the
+    ///     cost of the rest of the scan combined (16ms vs 30s at the default `hardTimeout`). On
+    ///     ordinary shapes the measured overhead was 1x-3x, cheap enough to opt into whenever a
+    ///     caller actually wants the answer. See `Scripts/repro/772-analyze-self-intersection/`
+    ///     for the full measurement across a spread of shapes, from a primitive to that
+    ///     pathological artifact (#772).
+    ///   - hardTimeout: Only used when `checkSelfIntersection` is `true`; forwarded to
+    ///     ``isSelfIntersecting(hardTimeout:)`` as its true wall-clock deadline. Default 30s.
+    /// - Returns: Analysis result with problem counts, or nil on failure.
     ///
     /// ## Example
     ///
     /// ```swift
     /// let shape = Shape.load(from: stepURL)!
     /// if let analysis = shape.analyze(tolerance: 0.001) {
-    ///     print("Found \(analysis.totalProblems) problems")
+    ///     print("Found \(analysis.totalProblems) problems")   // self-intersection not included
     ///     if analysis.hasInvalidTopology {
     ///         print("Shape has invalid topology!")
     ///     }
     /// }
+    ///
+    /// // Opt into the expensive check when it's actually needed:
+    /// if let analysis = shape.analyze(tolerance: 0.001, checkSelfIntersection: true) {
+    ///     switch analysis.hasSelfIntersection {
+    ///     case .some(true):  print("self-intersects")
+    ///     case .some(false): print("clean")
+    ///     case nil:          print("indeterminate, hardTimeout elapsed first")
+    ///     }
+    /// }
     /// ```
-    public func analyze(tolerance: Double = 1e-6) -> ShapeAnalysisResult? {
+    public func analyze(tolerance: Double = 1e-6, checkSelfIntersection: Bool = false,
+                        hardTimeout: Double = 30) -> ShapeAnalysisResult? {
         let result = OCCTShapeAnalyze(handle, tolerance)
         guard result.isValid else { return nil }
+
+        let hasSelfIntersection: Bool? = checkSelfIntersection
+            ? isSelfIntersecting(hardTimeout: hardTimeout)
+            : nil
 
         return ShapeAnalysisResult(
             smallEdgeCount: Int(result.smallEdgeCount),
             smallFaceCount: Int(result.smallFaceCount),
             gapCount: Int(result.gapCount),
+            hasSelfIntersection: hasSelfIntersection,
             freeEdgeCount: Int(result.freeEdgeCount),
             freeFaceCount: Int(result.freeFaceCount),
             hasInvalidTopology: result.hasInvalidTopology

--- a/Sources/OCCTSwift/ShapeAnalysisResult.swift
+++ b/Sources/OCCTSwift/ShapeAnalysisResult.swift
@@ -13,6 +13,41 @@ public struct ShapeAnalysisResult {
     /// Number of gaps between edges/faces
     public let gapCount: Int
 
+    /// Whether the shape self-intersects, or `nil` if ``Shape/analyze(tolerance:checkSelfIntersection:hardTimeout:)``
+    /// was not asked to check (#772).
+    ///
+    /// `nil` means **unmeasured, not clean**: it covers two distinct cases the type deliberately
+    /// does not distinguish, the caller passed `checkSelfIntersection: false` (the default), or
+    /// passed `true` but the check did not resolve within `hardTimeout`
+    /// (matches ``Shape/isSelfIntersecting(hardTimeout:)``'s own `nil` = indeterminate). Either
+    /// way, treat `nil` as "unknown", the same rule `isSelfIntersecting` already documents.
+    ///
+    /// This is opt-in rather than always-on because the underlying check
+    /// (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, #319) is orders of magnitude more
+    /// expensive than the small-edge/small-face/gap scan the rest of this type reports, and on
+    /// pathological input the gap is not small: measured on the #319 artifact, ~1800x the cost
+    /// of the rest of the scan combined (16ms vs 30s at the default `hardTimeout`). On ordinary
+    /// shapes (a primitive, a several-boolean-and-fillet part, a 662-face mesh-sewn import) the
+    /// measured overhead was 1x-3x, cheap enough to opt into freely. See
+    /// `Scripts/repro/772-analyze-self-intersection/` for the full measurement.
+    ///
+    /// This is the replacement for the `selfIntersectionCount` field removed in #763 (it was
+    /// always 0, never computed). Non-`nil` is reachable on a real path (not an always-closed
+    /// gate, see #771): pass `checkSelfIntersection: true` to a shape the check resolves for
+    /// within `hardTimeout`.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.analyze()!.hasSelfIntersection)                                  // nil: not asked
+    /// print(box.analyze(checkSelfIntersection: true)!.hasSelfIntersection)       // Optional(false)
+    ///
+    /// let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
+    /// let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)!
+    /// let overlapping = Shape.compound([a, b])!
+    /// print(overlapping.analyze(checkSelfIntersection: true)!.hasSelfIntersection) // Optional(true)
+    /// ```
+    public let hasSelfIntersection: Bool?
+
     /// Number of free (unconnected) edges across every shell of the analyzed shape, via
     /// `ShapeAnalysis_Shell`. Before #702 this was hardcoded to 0 for every shape: the bridge
     /// called `LoadShells()`, which only registers a shell for bookkeeping and runs no edge
@@ -38,19 +73,22 @@ public struct ShapeAnalysisResult {
     /// Total number of problems found.
     ///
     /// Sums each independent defect category once: small edges, small faces, gaps, free edges,
-    /// and invalid topology (a flat +1, not a count). ``freeFaceCount`` is deliberately excluded:
-    /// see its doc comment for why including it would double-count the same open-shell defect
-    /// ``freeEdgeCount`` already reports.
-    ///
-    /// Self-intersections are not part of this total: `analyze(tolerance:)` never measured them
-    /// (a `selfIntersectionCount` field existed through v1.x but was always 0, never computed, and
-    /// was removed in #763 rather than kept as a permanently-zero placeholder). Use
-    /// ``Shape/isSelfIntersecting(timeout:)`` for a real self-intersection check.
+    /// self-intersection (a flat +1 when ``hasSelfIntersection`` is `true`, `+0` when it is
+    /// `false` **or `nil`**: a `nil` here means "not checked", not "clean", so this total does
+    /// not reflect self-intersection at all unless the analysis was run with
+    /// `checkSelfIntersection: true`), and invalid topology (a flat +1, not a count).
+    /// ``freeFaceCount`` is deliberately excluded: see its doc comment for why including it
+    /// would double-count the same open-shell defect ``freeEdgeCount`` already reports.
     public var totalProblems: Int {
-        smallEdgeCount + smallFaceCount + gapCount + freeEdgeCount + (hasInvalidTopology ? 1 : 0)
+        smallEdgeCount + smallFaceCount + gapCount + freeEdgeCount
+            + (hasInvalidTopology ? 1 : 0)
+            + (hasSelfIntersection == true ? 1 : 0)
     }
 
-    /// Whether the shape appears to be healthy (no problems found)
+    /// Whether the shape appears to be healthy (no problems found).
+    ///
+    /// - Important: If the analysis did not request `checkSelfIntersection: true`, this says
+    ///   nothing about self-intersection either way; see ``hasSelfIntersection``.
     public var isHealthy: Bool {
         totalProblems == 0 && !hasInvalidTopology
     }

--- a/Sources/OCCTSwift/ShapeAnalysisResult.swift
+++ b/Sources/OCCTSwift/ShapeAnalysisResult.swift
@@ -13,38 +13,41 @@ public struct ShapeAnalysisResult {
     /// Number of gaps between edges/faces
     public let gapCount: Int
 
-    /// Whether the shape self-intersects, or `nil` if ``Shape/analyze(tolerance:checkSelfIntersection:hardTimeout:)``
+    /// Whether the shape self-intersects, or `nil` if ``Shape/analyze(tolerance:selfIntersectionTimeout:)``
     /// was not asked to check (#772).
     ///
     /// `nil` means **unmeasured, not clean**: it covers two distinct cases the type deliberately
-    /// does not distinguish, the caller passed `checkSelfIntersection: false` (the default), or
-    /// passed `true` but the check did not resolve within `hardTimeout`
-    /// (matches ``Shape/isSelfIntersecting(hardTimeout:)``'s own `nil` = indeterminate). Either
-    /// way, treat `nil` as "unknown", the same rule `isSelfIntersecting` already documents.
+    /// does not distinguish, the caller passed `selfIntersectionTimeout: nil` (the default), or
+    /// passed a timeout but the check did not resolve within it (matches
+    /// ``Shape/isSelfIntersecting(timeout:)``'s own `nil` = indeterminate). Either way, treat
+    /// `nil` as "unknown", the same rule `isSelfIntersecting` already documents.
     ///
     /// This is opt-in rather than always-on because the underlying check
     /// (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, #319) is orders of magnitude more
     /// expensive than the small-edge/small-face/gap scan the rest of this type reports, and on
-    /// pathological input the gap is not small: measured on the #319 artifact, ~1800x the cost
-    /// of the rest of the scan combined (16ms vs 30s at the default `hardTimeout`). On ordinary
+    /// pathological input the gap is not small: measured on the #319 artifact, ~3000x-4000x the
+    /// cost of the rest of the scan combined (a few ms vs 30s at a 30s timeout). On ordinary
     /// shapes (a primitive, a several-boolean-and-fillet part, a 662-face mesh-sewn import) the
     /// measured overhead was 1x-3x, cheap enough to opt into freely. See
-    /// `Scripts/repro/772-analyze-self-intersection/` for the full measurement.
+    /// `Scripts/repro/772-analyze-self-intersection/` for the full measurement, including why the
+    /// analysis forwards to ``Shape/isSelfIntersecting(timeout:)`` rather than
+    /// ``Shape/isSelfIntersecting(hardTimeout:)`` (measuring both, not just the pathological
+    /// case, found the latter is not a strict improvement here).
     ///
     /// This is the replacement for the `selfIntersectionCount` field removed in #763 (it was
     /// always 0, never computed). Non-`nil` is reachable on a real path (not an always-closed
-    /// gate, see #771): pass `checkSelfIntersection: true` to a shape the check resolves for
-    /// within `hardTimeout`.
+    /// gate, see #771): pass a non-`nil` `selfIntersectionTimeout` to a shape the check resolves
+    /// for within it.
     ///
     /// ```swift
     /// let box = Shape.box(width: 10, height: 10, depth: 10)!
-    /// print(box.analyze()!.hasSelfIntersection)                                  // nil: not asked
-    /// print(box.analyze(checkSelfIntersection: true)!.hasSelfIntersection)       // Optional(false)
+    /// print(box.analyze()!.hasSelfIntersection)                                    // nil: not asked
+    /// print(box.analyze(selfIntersectionTimeout: 30)!.hasSelfIntersection)         // Optional(false)
     ///
     /// let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
     /// let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)!
     /// let overlapping = Shape.compound([a, b])!
-    /// print(overlapping.analyze(checkSelfIntersection: true)!.hasSelfIntersection) // Optional(true)
+    /// print(overlapping.analyze(selfIntersectionTimeout: 30)!.hasSelfIntersection) // Optional(true)
     /// ```
     public let hasSelfIntersection: Bool?
 
@@ -75,8 +78,8 @@ public struct ShapeAnalysisResult {
     /// Sums each independent defect category once: small edges, small faces, gaps, free edges,
     /// self-intersection (a flat +1 when ``hasSelfIntersection`` is `true`, `+0` when it is
     /// `false` **or `nil`**: a `nil` here means "not checked", not "clean", so this total does
-    /// not reflect self-intersection at all unless the analysis was run with
-    /// `checkSelfIntersection: true`), and invalid topology (a flat +1, not a count).
+    /// not reflect self-intersection at all unless the analysis was run with a non-`nil`
+    /// `selfIntersectionTimeout`), and invalid topology (a flat +1, not a count).
     /// ``freeFaceCount`` is deliberately excluded: see its doc comment for why including it
     /// would double-count the same open-shell defect ``freeEdgeCount`` already reports.
     public var totalProblems: Int {
@@ -87,7 +90,7 @@ public struct ShapeAnalysisResult {
 
     /// Whether the shape appears to be healthy (no problems found).
     ///
-    /// - Important: If the analysis did not request `checkSelfIntersection: true`, this says
+    /// - Important: If the analysis did not pass a non-`nil` `selfIntersectionTimeout`, this says
     ///   nothing about self-intersection either way; see ``hasSelfIntersection``.
     public var isHealthy: Bool {
         totalProblems == 0 && !hasInvalidTopology

--- a/Tests/OCCTShapeHealingTests/Issue772SelfIntersectionAnalysisTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue772SelfIntersectionAnalysisTests.swift
@@ -10,8 +10,8 @@ import simd
 /// `Scripts/repro/772-analyze-self-intersection/`): the real self-intersection check
 /// (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, #319) costs 1x-3x the rest of
 /// `analyze()`'s scan on ordinary shapes, including a real 662-face mesh-sewn import, but
-/// ~1800x on the #319 pathological artifact (16ms vs 30s at the default `hardTimeout`). That gap
-/// is why the check is opt-in (`checkSelfIntersection: false` by default) rather than always-on.
+/// ~3000x-4000x on the #319 pathological artifact (a few ms vs 30s at a 30s timeout). That gap is
+/// why the check is opt-in (`selfIntersectionTimeout: nil` by default) rather than always-on.
 ///
 /// `ShapeAnalysisResult.hasSelfIntersection` is `Bool?`, not the `Int?` the issue's option 3
 /// sketch suggested: `isSelfIntersecting` itself only ever answers yes/no/indeterminate
@@ -20,9 +20,20 @@ import simd
 /// removing.
 ///
 /// Per #771 (a gate that never flips is the same defect as an always-nil optional): this suite's
-/// `checkSelfIntersectionTrueOnCleanShapePopulatesFalse` and
-/// `checkSelfIntersectionTrueOnSelfIntersectingShapePopulatesTrue` are the reachable-and-populated
-/// proof that `hasSelfIntersection` actually flips, on both outcomes, not just the default `nil`.
+/// `nonNilTimeoutOnCleanShapePopulatesFalse` and
+/// `nonNilTimeoutOnSelfIntersectingShapePopulatesTrue` are the reachable-and-populated proof that
+/// `hasSelfIntersection` actually flips, on both outcomes, not just the default `nil`.
+///
+/// Review round 2 found two more defects, both fixed here rather than merely documented:
+/// (1) the first version forwarded to `isSelfIntersecting(hardTimeout:)`, measured (this suite's
+/// harness, not this file) to be no cheaper on ordinary shapes and to return a **worse** answer
+/// (`nil`/indeterminate instead of a conclusive `true`) than `isSelfIntersecting(timeout:)` on the
+/// #319 pathological artifact, at the same wall-clock cost; `analyze()` now forwards to
+/// `timeout:` instead. (2) the two parameters that gated the check
+/// (`checkSelfIntersection: Bool`, `hardTimeout: Double`) let a caller supply a timeout while
+/// forgetting the boolean, compiling and silently discarding it; they are now one
+/// `selfIntersectionTimeout: Double?`, where supplying a value *is* opting in, so that mistake is
+/// unrepresentable. `timeoutAloneCannotBeSuppliedWithoutOptingIn` below is the compile-time proof.
 @Suite("Issue 772: analyze() self-intersection is opt-in and representable")
 struct Issue772SelfIntersectionAnalysis {
 
@@ -50,17 +61,17 @@ struct Issue772SelfIntersectionAnalysis {
         #expect(overlapping.hasSelfIntersection == nil)
     }
 
-    @Test("checkSelfIntersection: true on a clean shape populates false")
-    func checkSelfIntersectionTrueOnCleanShapePopulatesFalse() throws {
+    @Test("a non-nil selfIntersectionTimeout on a clean shape populates false")
+    func nonNilTimeoutOnCleanShapePopulatesFalse() throws {
         let box = Shape.box(width: 10, height: 10, depth: 10)!
-        let analysis = try #require(box.analyze(tolerance: 0.001, checkSelfIntersection: true))
+        let analysis = try #require(box.analyze(tolerance: 0.001, selfIntersectionTimeout: 30))
         #expect(analysis.hasSelfIntersection == false)
     }
 
-    @Test("checkSelfIntersection: true on a self-intersecting shape populates true")
-    func checkSelfIntersectionTrueOnSelfIntersectingShapePopulatesTrue() throws {
+    @Test("a non-nil selfIntersectionTimeout on a self-intersecting shape populates true")
+    func nonNilTimeoutOnSelfIntersectingShapePopulatesTrue() throws {
         let overlapping = overlappingCompound()
-        let analysis = try #require(overlapping.analyze(tolerance: 0.001, checkSelfIntersection: true))
+        let analysis = try #require(overlapping.analyze(tolerance: 0.001, selfIntersectionTimeout: 30))
         #expect(analysis.hasSelfIntersection == true)
     }
 
@@ -69,13 +80,30 @@ struct Issue772SelfIntersectionAnalysis {
         let overlapping = overlappingCompound()
 
         let unchecked = try #require(overlapping.analyze(tolerance: 0.001))
-        let checked = try #require(overlapping.analyze(tolerance: 0.001, checkSelfIntersection: true))
+        let checked = try #require(overlapping.analyze(tolerance: 0.001, selfIntersectionTimeout: 30))
 
         // Same shape, same tolerance: the two analyses can only differ by the self-intersection
-        // contribution, since `checkSelfIntersection` is the only input that changed.
+        // contribution, since `selfIntersectionTimeout` is the only input that changed.
         #expect(checked.totalProblems == unchecked.totalProblems + 1)
         // The cheap topology scan alone has no way to see a global 3D overlap between two
         // otherwise-valid closed solids, so only the checked analysis can mark this unhealthy.
         #expect(checked.isHealthy == false)
+    }
+
+    /// Review round 2, finding 3: `analyze(tolerance:checkSelfIntersection:hardTimeout:)` let a
+    /// caller pass `hardTimeout: 5` while forgetting `checkSelfIntersection: true`, which compiled
+    /// and ran, silently discarding the timeout and returning `hasSelfIntersection == nil`,
+    /// indistinguishable from the ordinary default-off case. There is no longer a separate
+    /// boolean to forget: `selfIntersectionTimeout: Double?` makes "supply a timeout but do not
+    /// opt in" a state that cannot be constructed at all, so this test is a compile-time argument
+    /// as much as a runtime one. The commented-out line is what the old API allowed; it does not
+    /// exist as a spelling on the new one (there is no `hardTimeout:` label on `analyze` at all).
+    @Test("supplying a timeout IS opting in; there is no separate flag left to forget")
+    func timeoutAloneCannotBeSuppliedWithoutOptingIn() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        // Old, no-longer-expressible footgun: box.analyze(tolerance: 0.001, hardTimeout: 5)
+        // would compile, run, and silently return hasSelfIntersection == nil.
+        let analysis = try #require(box.analyze(tolerance: 0.001, selfIntersectionTimeout: 5))
+        #expect(analysis.hasSelfIntersection == false)
     }
 }

--- a/Tests/OCCTShapeHealingTests/Issue772SelfIntersectionAnalysisTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue772SelfIntersectionAnalysisTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #772: `ShapeAnalysisResult.selfIntersectionCount` was always 0 and never computed (#763),
+/// leaving `Shape.analyze(tolerance:)` reporting nothing about self-intersection at all.
+///
+/// Measured before choosing (okf/policies/measure-dont-assume.md,
+/// `Scripts/repro/772-analyze-self-intersection/`): the real self-intersection check
+/// (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, #319) costs 1x-3x the rest of
+/// `analyze()`'s scan on ordinary shapes, including a real 662-face mesh-sewn import, but
+/// ~1800x on the #319 pathological artifact (16ms vs 30s at the default `hardTimeout`). That gap
+/// is why the check is opt-in (`checkSelfIntersection: false` by default) rather than always-on.
+///
+/// `ShapeAnalysisResult.hasSelfIntersection` is `Bool?`, not the `Int?` the issue's option 3
+/// sketch suggested: `isSelfIntersecting` itself only ever answers yes/no/indeterminate
+/// (`BOPAlgo_ArgumentAnalyzer` runs with `StopOnFirstFaulty`), never a count, so an `Int?` here
+/// would fabricate a precision the check does not provide, the same class of problem #763 was
+/// removing.
+///
+/// Per #771 (a gate that never flips is the same defect as an always-nil optional): this suite's
+/// `checkSelfIntersectionTrueOnCleanShapePopulatesFalse` and
+/// `checkSelfIntersectionTrueOnSelfIntersectingShapePopulatesTrue` are the reachable-and-populated
+/// proof that `hasSelfIntersection` actually flips, on both outcomes, not just the default `nil`.
+@Suite("Issue 772: analyze() self-intersection is opt-in and representable")
+struct Issue772SelfIntersectionAnalysis {
+
+    /// Two boxes offset so their faces genuinely interfere, in one compound: the same fast,
+    /// deterministic self-intersecting fixture `Issue208SelfIntersection`/
+    /// `Issue319HardBoundedSelfIntersection` already use, so this suite reuses a construction the
+    /// self-intersection check is already known to resolve quickly and conclusively for, rather
+    /// than the #319 pathological artifact (which takes ~30s and belongs in the timing harness,
+    /// not the test suite).
+    func overlappingCompound() -> Shape {
+        let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10)!
+        let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)!
+        return Shape.compound([a, b])!
+    }
+
+    @Test("default analyze() does not check self-intersection: hasSelfIntersection is nil")
+    func defaultDoesNotCheck() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let analysis = try #require(box.analyze(tolerance: 0.001))
+        #expect(analysis.hasSelfIntersection == nil)
+
+        // Also true for a shape that WOULD be flagged if checked: the default must stay cheap
+        // and silent, not quietly run the expensive pass.
+        let overlapping = try #require(overlappingCompound().analyze(tolerance: 0.001))
+        #expect(overlapping.hasSelfIntersection == nil)
+    }
+
+    @Test("checkSelfIntersection: true on a clean shape populates false")
+    func checkSelfIntersectionTrueOnCleanShapePopulatesFalse() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let analysis = try #require(box.analyze(tolerance: 0.001, checkSelfIntersection: true))
+        #expect(analysis.hasSelfIntersection == false)
+    }
+
+    @Test("checkSelfIntersection: true on a self-intersecting shape populates true")
+    func checkSelfIntersectionTrueOnSelfIntersectingShapePopulatesTrue() throws {
+        let overlapping = overlappingCompound()
+        let analysis = try #require(overlapping.analyze(tolerance: 0.001, checkSelfIntersection: true))
+        #expect(analysis.hasSelfIntersection == true)
+    }
+
+    @Test("totalProblems includes self-intersection only when it was actually checked and found")
+    func totalProblemsReflectsOnlyWhatWasChecked() throws {
+        let overlapping = overlappingCompound()
+
+        let unchecked = try #require(overlapping.analyze(tolerance: 0.001))
+        let checked = try #require(overlapping.analyze(tolerance: 0.001, checkSelfIntersection: true))
+
+        // Same shape, same tolerance: the two analyses can only differ by the self-intersection
+        // contribution, since `checkSelfIntersection` is the only input that changed.
+        #expect(checked.totalProblems == unchecked.totalProblems + 1)
+        // The cheap topology scan alone has no way to see a global 3D overlap between two
+        // otherwise-valid closed solids, so only the checked analysis can mark this unhealthy.
+        #expect(checked.isHealthy == false)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -100,7 +100,7 @@ struct ShapeAnalysisTests {
         // deliberately excluded: it is a derived summary of the same scan freeEdgeCount already
         // counts (this shell has at least one free edge), not an independent defect, so including
         // both would double-count one open shell's boundary gap (#717 review, the totalProblems double-count).
-        // hasSelfIntersection is nil here (checkSelfIntersection defaults to false, #772), so it
+        // hasSelfIntersection is nil here (selfIntersectionTimeout defaults to nil, #772), so it
         // contributes 0, same as the pre-#772 formula, but is included explicitly so this test
         // stays a true mirror of totalProblems's implementation rather than a numeric coincidence.
         let expectedTotal = analysis.smallEdgeCount + analysis.smallFaceCount +

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -100,11 +100,16 @@ struct ShapeAnalysisTests {
         // deliberately excluded: it is a derived summary of the same scan freeEdgeCount already
         // counts (this shell has at least one free edge), not an independent defect, so including
         // both would double-count one open shell's boundary gap (#717 review, the totalProblems double-count).
+        // hasSelfIntersection is nil here (checkSelfIntersection defaults to false, #772), so it
+        // contributes 0, same as the pre-#772 formula, but is included explicitly so this test
+        // stays a true mirror of totalProblems's implementation rather than a numeric coincidence.
         let expectedTotal = analysis.smallEdgeCount + analysis.smallFaceCount +
                            analysis.gapCount +
                            analysis.freeEdgeCount +
-                           (analysis.hasInvalidTopology ? 1 : 0)
+                           (analysis.hasInvalidTopology ? 1 : 0) +
+                           (analysis.hasSelfIntersection == true ? 1 : 0)
         #expect(analysis.totalProblems == expectedTotal)
+        #expect(analysis.hasSelfIntersection == nil)
     }
 }
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1545,6 +1545,7 @@ public struct ShapeAnalysisResult {
     public let smallEdgeCount: Int
     public let smallFaceCount: Int
     public let gapCount: Int
+    public let hasSelfIntersection: Bool?
     public let freeEdgeCount: Int
     public let freeFaceCount: Int
     public let hasInvalidTopology: Bool
@@ -1555,10 +1556,25 @@ public struct ShapeAnalysisResult {
 
 `isHealthy` is `true` when `totalProblems == 0 && !hasInvalidTopology`.
 
-- **This never reports self-intersections.** A `selfIntersectionCount` field used to sit here
-  (through v1.x) but was always 0, never computed (the bridge's own comment read "would require
-  more expensive computation"); it was removed in #763 rather than kept as a permanent zero. Use
-  `isSelfIntersecting(timeout:)` for a real answer.
+- **This never reports self-intersection unless asked to.** A `selfIntersectionCount` field used
+  to sit here (through v1.x) but was always 0, never computed (the bridge's own comment read
+  "would require more expensive computation"); it was removed in #763 rather than kept as a
+  permanent zero. Use `hasSelfIntersection`, populated via
+  `analyze(tolerance:checkSelfIntersection:hardTimeout:)`, or `isSelfIntersecting(timeout:)`
+  directly, for a real answer.
+- **`hasSelfIntersection` is `nil` unless `analyze(checkSelfIntersection: true)` was used (#772).**
+  The self-intersection check (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, #319) is
+  orders of magnitude more expensive than the rest of this scan, and on pathological input the
+  gap is not small: measured on the #319 pathological artifact, roughly 1800x-4100x the cost of
+  the rest of the scan combined (a few milliseconds vs 30+ seconds at the default `hardTimeout`).
+  On ordinary shapes, including a real 662-face mesh-sewn import, the measured overhead was
+  1x-3x, cheap enough to opt into freely; see `Scripts/repro/772-analyze-self-intersection/` for
+  the full measurement. `nil` covers two cases the type deliberately does not distinguish: not
+  requested, or requested but indeterminate (the check did not resolve within `hardTimeout`,
+  matching `isSelfIntersecting`'s own `nil` = indeterminate). `nil` is never "clean": only
+  `hasSelfIntersection == false` means that. `totalProblems` adds a flat +1 when
+  `hasSelfIntersection == true`, +0 for `false` or `nil`, so it never reflects self-intersection
+  unless the analysis actually checked for it.
 - **`freeEdgeCount`/`freeFaceCount` were hardcoded to 0 for every shape before #702**: the bridge
   called `ShapeAnalysis_Shell::LoadShells()`, which only registers a shell for bookkeeping,
   instead of `CheckOrientedShells()`, the call that actually populates the free-edge set. Now
@@ -1580,21 +1596,39 @@ public struct ShapeAnalysisResult {
 
 ---
 
-### `analyze(tolerance:)`
+### `analyze(tolerance:checkSelfIntersection:hardTimeout:)`
 
 Analyzes a shape for problems such as small edges, gaps, and invalid topology.
 
 ```swift
-public func analyze(tolerance: Double = 1e-6) -> ShapeAnalysisResult?
+public func analyze(tolerance: Double = 1e-6, checkSelfIntersection: Bool = false,
+                    hardTimeout: Double = 30) -> ShapeAnalysisResult?
 ```
 
-- **Parameters:** `tolerance` — size threshold for detecting small features.
+- **Parameters:**
+  - `tolerance`: size threshold for detecting small features.
+  - `checkSelfIntersection`: if `true`, also runs `isSelfIntersecting(hardTimeout:)` and
+    populates `ShapeAnalysisResult.hasSelfIntersection`. Default `false` (#772): that check costs
+    1x-3x the rest of this scan on ordinary shapes but roughly 1800x-4100x on pathological input
+    (measured, `Scripts/repro/772-analyze-self-intersection/`), so it stays opt-in rather than
+    silently turning a cheap call into an occasionally unbounded-shaped one.
+  - `hardTimeout`: only used when `checkSelfIntersection` is `true`; forwarded to
+    `isSelfIntersecting(hardTimeout:)` as its true wall-clock deadline. Default 30 seconds.
 - **Returns:** `ShapeAnalysisResult` with problem counts, or `nil` if the analysis itself fails.
-- **OCCT:** `ShapeAnalysis_Shell` + `ShapeAnalysis_CheckSmallFace` + `BRepCheck_Analyzer` (via `OCCTShapeAnalyze`).
+- **OCCT:** `ShapeAnalysis_Shell` + `ShapeAnalysis_CheckSmallFace` + `BRepCheck_Analyzer` (via `OCCTShapeAnalyze`), plus `BOPAlgo_ArgumentAnalyzer` when `checkSelfIntersection` is `true`.
 - **Example:**
   ```swift
   if let a = shape.analyze(tolerance: 0.001) {
-      if !a.isHealthy { print("\(a.totalProblems) problems found") }
+      if !a.isHealthy { print("\(a.totalProblems) problems found") }   // self-intersection not included
+  }
+
+  // Opt into the expensive check when it's actually needed:
+  if let a = shape.analyze(tolerance: 0.001, checkSelfIntersection: true) {
+      switch a.hasSelfIntersection {
+      case .some(true):  print("self-intersects")
+      case .some(false): print("clean")
+      case nil:          print("indeterminate, hardTimeout elapsed first")
+      }
   }
   ```
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1560,21 +1560,23 @@ public struct ShapeAnalysisResult {
   to sit here (through v1.x) but was always 0, never computed (the bridge's own comment read
   "would require more expensive computation"); it was removed in #763 rather than kept as a
   permanent zero. Use `hasSelfIntersection`, populated via
-  `analyze(tolerance:checkSelfIntersection:hardTimeout:)`, or `isSelfIntersecting(timeout:)`
-  directly, for a real answer.
-- **`hasSelfIntersection` is `nil` unless `analyze(checkSelfIntersection: true)` was used (#772).**
-  The self-intersection check (`BOPAlgo_ArgumentAnalyzer`'s self-interference test, #319) is
-  orders of magnitude more expensive than the rest of this scan, and on pathological input the
-  gap is not small: measured on the #319 pathological artifact, roughly 1800x-4100x the cost of
-  the rest of the scan combined (a few milliseconds vs 30+ seconds at the default `hardTimeout`).
-  On ordinary shapes, including a real 662-face mesh-sewn import, the measured overhead was
-  1x-3x, cheap enough to opt into freely; see `Scripts/repro/772-analyze-self-intersection/` for
-  the full measurement. `nil` covers two cases the type deliberately does not distinguish: not
-  requested, or requested but indeterminate (the check did not resolve within `hardTimeout`,
-  matching `isSelfIntersecting`'s own `nil` = indeterminate). `nil` is never "clean": only
-  `hasSelfIntersection == false` means that. `totalProblems` adds a flat +1 when
-  `hasSelfIntersection == true`, +0 for `false` or `nil`, so it never reflects self-intersection
-  unless the analysis actually checked for it.
+  `analyze(tolerance:selfIntersectionTimeout:)`, or `isSelfIntersecting(timeout:)` directly, for a
+  real answer.
+- **`hasSelfIntersection` is `nil` unless `analyze(selfIntersectionTimeout:)` was passed a
+  non-`nil` value (#772).** The self-intersection check (`BOPAlgo_ArgumentAnalyzer`'s
+  self-interference test, #319) is orders of magnitude more expensive than the rest of this scan,
+  and on pathological input the gap is not small: measured on the #319 pathological artifact,
+  roughly 3000x-4000x the cost of the rest of the scan combined (a few milliseconds vs 30+
+  seconds at a 30s timeout). On ordinary shapes, including a real 662-face mesh-sewn import, the
+  measured overhead was 1x-3x, cheap enough to opt into freely; see
+  `Scripts/repro/772-analyze-self-intersection/` for the full measurement, including why this
+  forwards to `isSelfIntersecting(timeout:)` and not `isSelfIntersecting(hardTimeout:)` (measuring
+  both, not just the pathological case, found the latter is not a strict improvement here). `nil`
+  covers two cases the type deliberately does not distinguish: not requested, or requested but
+  indeterminate (the check did not resolve within the timeout, matching `isSelfIntersecting`'s own
+  `nil` = indeterminate). `nil` is never "clean": only `hasSelfIntersection == false` means that.
+  `totalProblems` adds a flat +1 when `hasSelfIntersection == true`, +0 for `false` or `nil`, so
+  it never reflects self-intersection unless the analysis actually checked for it.
 - **`freeEdgeCount`/`freeFaceCount` were hardcoded to 0 for every shape before #702**: the bridge
   called `ShapeAnalysis_Shell::LoadShells()`, which only registers a shell for bookkeeping,
   instead of `CheckOrientedShells()`, the call that actually populates the free-edge set. Now
@@ -1596,38 +1598,61 @@ public struct ShapeAnalysisResult {
 
 ---
 
-### `analyze(tolerance:checkSelfIntersection:hardTimeout:)`
+### `analyze(tolerance:selfIntersectionTimeout:)`
 
 Analyzes a shape for problems such as small edges, gaps, and invalid topology.
 
 ```swift
-public func analyze(tolerance: Double = 1e-6, checkSelfIntersection: Bool = false,
-                    hardTimeout: Double = 30) -> ShapeAnalysisResult?
+public func analyze(tolerance: Double = 1e-6, selfIntersectionTimeout: Double? = nil) -> ShapeAnalysisResult?
 ```
 
+- **Important:** passing `selfIntersectionTimeout` makes this call **synchronously block the
+  calling thread** for up to that many seconds (more, if OCCT never reaches a checkpoint to poll:
+  see `isSelfIntersecting(timeout:)`'s own warning, inherited unchanged). Do not pass it from a
+  UI/main thread without accepting that stall.
 - **Parameters:**
   - `tolerance`: size threshold for detecting small features.
-  - `checkSelfIntersection`: if `true`, also runs `isSelfIntersecting(hardTimeout:)` and
-    populates `ShapeAnalysisResult.hasSelfIntersection`. Default `false` (#772): that check costs
-    1x-3x the rest of this scan on ordinary shapes but roughly 1800x-4100x on pathological input
-    (measured, `Scripts/repro/772-analyze-self-intersection/`), so it stays opt-in rather than
-    silently turning a cheap call into an occasionally unbounded-shaped one.
-  - `hardTimeout`: only used when `checkSelfIntersection` is `true`; forwarded to
-    `isSelfIntersecting(hardTimeout:)` as its true wall-clock deadline. Default 30 seconds.
+  - `selfIntersectionTimeout`: `nil` (the default) skips the self-intersection check entirely and
+    leaves `ShapeAnalysisResult.hasSelfIntersection` `nil`. A non-`nil` value opts in, forwarded
+    as the `timeout:` to `isSelfIntersecting(timeout:)` (the cooperative check, not
+    `isSelfIntersecting(hardTimeout:)`: measuring both, not just on a pathological artifact, found
+    the `hardTimeout:` background-thread mechanism is not a strict improvement, see below). There
+    is no way to supply a timeout that does not enable the check: the two used to be separate
+    parameters (`checkSelfIntersection: Bool`, `hardTimeout: Double`) until review found that
+    shape let a caller's `hardTimeout` be silently discarded whenever they forgot
+    `checkSelfIntersection: true`, compiling and running with no signal at all (#772). Collapsing
+    them into one optional makes that mistake unrepresentable.
+
+    Costs 1x-3x the rest of this scan on ordinary shapes, including a real 662-face mesh-sewn
+    import, but roughly 3000x-4000x on the #319 pathological artifact (measured,
+    `Scripts/repro/772-analyze-self-intersection/`), so it stays opt-in rather than silently
+    turning a cheap call into an occasionally unbounded-shaped one.
 - **Returns:** `ShapeAnalysisResult` with problem counts, or `nil` if the analysis itself fails.
-- **OCCT:** `ShapeAnalysis_Shell` + `ShapeAnalysis_CheckSmallFace` + `BRepCheck_Analyzer` (via `OCCTShapeAnalyze`), plus `BOPAlgo_ArgumentAnalyzer` when `checkSelfIntersection` is `true`.
+- **OCCT:** `ShapeAnalysis_Shell` + `ShapeAnalysis_CheckSmallFace` + `BRepCheck_Analyzer` (via `OCCTShapeAnalyze`), plus `BOPAlgo_ArgumentAnalyzer` when `selfIntersectionTimeout` is non-`nil`.
+- **Why `timeout:`, not `hardTimeout:`:** `isSelfIntersecting(hardTimeout:)` looks like the safer
+  default (a true wall-clock guarantee via `deepCopy()` + a background thread + a semaphore), but
+  its `deepCopy()` step, while cheap on its own (under 1ms on every fixture measured), guards an
+  internal `OCCTShapeSelfIntersectsBounded` call that passes 0 (unbounded); the only bound left is
+  the caller-side semaphore wait. On the #319 pathological artifact this produced a **worse**
+  answer than `timeout:` at the same deadline: `timeout:` reliably returned a conclusive
+  `self-intersects` around 30.1s, while `hardTimeout:` reliably returned `nil` (indeterminate) at
+  exactly 30.0s, the same wall-clock budget for a strictly less useful answer, plus an abandoned
+  background computation left running. `analyze()` is already fully synchronous, so a caller has
+  already committed to blocking; `hardTimeout:`'s guarantee buys nothing over `timeout:` in that
+  context. A caller that genuinely needs the hard guarantee should call
+  `isSelfIntersecting(hardTimeout:)` directly and accept its documented trade-offs.
 - **Example:**
   ```swift
   if let a = shape.analyze(tolerance: 0.001) {
       if !a.isHealthy { print("\(a.totalProblems) problems found") }   // self-intersection not included
   }
 
-  // Opt into the expensive check when it's actually needed:
-  if let a = shape.analyze(tolerance: 0.001, checkSelfIntersection: true) {
+  // Opt into the expensive, thread-blocking check when it's actually needed:
+  if let a = shape.analyze(tolerance: 0.001, selfIntersectionTimeout: 30) {
       switch a.hasSelfIntersection {
       case .some(true):  print("self-intersects")
       case .some(false): print("clean")
-      case nil:          print("indeterminate, hardTimeout elapsed first")
+      case nil:          print("indeterminate, timeout elapsed before a checkpoint")
       }
   }
   ```


### PR DESCRIPTION
## What & why

#772 asks whether `Shape.analyze(tolerance:)` should measure self-intersection now that
`ShapeAnalysisResult.selfIntersectionCount` (always 0, never computed) is gone (#763/PR#770). The
issue is explicit that this is a measure-first decision, not a pick-the-option-that-sounds-right
one (`okf/policies/measure-dont-assume.md`).

**This PR went through two measurement rounds; the second one changed the design.** Round 1
measured `isSelfIntersecting(timeout:)` on ordinary shapes and shipped a parameter that actually
called `isSelfIntersecting(hardTimeout:)`, a different mechanism never measured except on the
pathological artifact. Review caught this. Round 2 measures both entry points, plus `deepCopy()`
alone, at the same deadline, on every row, and the numbers changed which mechanism `analyze()`
uses. Full harness and captured output at `Scripts/repro/772-analyze-self-intersection/`
(`README.md`, `measured-output.txt`); the harness itself is
`Scripts/repro/harnesses/AnalyzeSelfIntersectionTiming.swift`, one entry in the shared
`Harnesses` executable target (`Package.swift`, `swift run Harnesses 772-self-intersection`).

### Round 2 measurement (current, correct)

| Shape | Faces | Edges | `analyze(tolerance:)` | `deepCopy()` | `timeout: 30` (shipped) | `hardTimeout: 30` (rejected) |
|---|---|---|---|---|---|---|
| Simple box | 6 | 12 | ~0.0005-0.002 s | ~0.00004-0.001 s | ~0.0005-0.007 s, clean | ~0.0004-0.0007 s, clean |
| Moderately complex fused/filleted solid | 16 | 39 | ~0.001-0.003 s | ~0.00003-0.001 s | ~0.0025-0.003 s, clean | ~0.0025-0.003 s, clean |
| Mesh-sewn imported solid (#348 fixture, 662 faces) | 662 | 1072 | ~0.04-0.19 s | ~0.0008-0.001 s | ~0.06-0.10 s, self-intersects | ~0.05-0.10 s, self-intersects |
| #319 pathological artifact | 1 | 3 | ~0.007-0.017 s | ~0.00001 s | ~30.0-30.15 s, **self-intersects** | ~30.0-30.02 s, **indeterminate** |

Two findings decide the design:

1. **`deepCopy()` is cheap everywhere** (under 1ms, including the 662-face import), so it was
   never really the cost concern review named. Both mechanisms cost about the same on ordinary
   shapes (0.8x-2.0x vs `analyze()`'s own baseline scan).
2. **On the pathological artifact, `hardTimeout:` gives a worse answer than `timeout:` for the
   same wall-clock cost.** `timeout:` reliably returns a conclusive `self-intersects` around
   30.05-30.15s; `hardTimeout:` reliably returns `nil` (indeterminate) at almost exactly 30.0s,
   every run. Structural, not incidental: `hardTimeout:`'s internal `OCCTShapeSelfIntersectsBounded`
   call passes `0` (unbounded), so the background computation has no cooperative deadline of its
   own to find the fault before the caller's semaphore gives up; `timeout:`'s own internal
   checkpoint-based breaker does. `hardTimeout:` also leaves that computation running, abandoned
   and still unbounded, after returning `nil`.

**Decision: `analyze(tolerance:selfIntersectionTimeout:)` forwards to
`isSelfIntersecting(timeout:)`, not `isSelfIntersecting(hardTimeout:)`.** `analyze()` is already a
fully synchronous call with no async variant, so a caller has already committed to blocking;
`hardTimeout:`'s wall-clock guarantee buys nothing over `timeout:` in that context, and on the one
artifact where it mattered it cost a worse answer at the same price, plus an abandoned background
computation. A caller who genuinely needs the hard guarantee should call
`isSelfIntersecting(hardTimeout:)` directly and accept its documented trade-offs.

The opt-in-vs-default-on question from round 1 is unchanged by round 2's correction: cheap
(1x-2x) on every ordinary shape but ~3500x-4200x on the pathological one (a real reconstruction
pipeline artifact, not a contrived case) still means an unconditional or default-on check would
occasionally turn a cheap call into a many-second one, silently. `ShapeAnalysisResult.hasSelfIntersection`
is `Bool?` (not the `Int?` the issue's option-3 sketch suggested, since `isSelfIntersecting` never
answers with a count), non-nil exactly when `selfIntersectionTimeout` was non-`nil` and the check
resolved, satisfying #771's bar against an always-closed gate.

Full reasoning and both rounds' numbers: `Scripts/repro/772-analyze-self-intersection/README.md`.

**Baseline note**: branched from `origin/refactor/381-pass1b` before PR #770 merged (baseline was
`809f148`, `selfIntersectionCount` still present); rebased onto `ad1078e` (post-#770 merge) once
#770 landed mid-task, dropping every reference to the now-removed field so this PR does not
reintroduce it.

Closes #772

## CHANGELOG entry

### `Shape.analyze(tolerance:)` can now check self-intersection (opt-in) (#772)

`analyze(tolerance:selfIntersectionTimeout:)` gains one new parameter, `selfIntersectionTimeout:
Double? = nil`. `nil` (the default) skips the self-intersection check entirely; a non-`nil` value
opts in, forwarded as the `timeout:` to `isSelfIntersecting(timeout:)` (the same
`BOPAlgo_ArgumentAnalyzer` check `isSelfIntersecting` uses), and populates the new
`ShapeAnalysisResult.hasSelfIntersection: Bool?` field: `nil` when not requested, or requested but
indeterminate; `true`/`false` when the check resolved. `totalProblems` adds a flat +1 when
`hasSelfIntersection == true`, matching how `hasInvalidTopology` is counted.

Passing a non-`nil` `selfIntersectionTimeout` makes this call **block the calling thread** for up
to that many seconds (more, if OCCT never reaches a checkpoint to poll); do not pass it from a
UI/main thread without accepting that stall.

Measured before deciding (`Scripts/repro/772-analyze-self-intersection/`): the check costs 1x-2x
the rest of `analyze()`'s scan on ordinary shapes but ~3500x-4200x on a known pathological
artifact (a few ms vs 30+ seconds), so it defaults off rather than running unconditionally.

```swift
// Default stays cheap; self-intersection is not reported unless asked for.
let analysis = shape.analyze(tolerance: 0.001)
print(analysis?.hasSelfIntersection)   // nil

// Opt into the expensive, thread-blocking check when it's actually needed.
let checked = shape.analyze(tolerance: 0.001, selfIntersectionTimeout: 30)
switch checked?.hasSelfIntersection {
case .some(true):  print("self-intersects")
case .some(false): print("clean")
case nil:          print("indeterminate or not requested")
}
```

## SemVer impact

MINOR. Purely additive: `analyze(tolerance:selfIntersectionTimeout:)` adds one new parameter with
a default, so every existing call site keeps compiling and keeps its current behavior unchanged.
`ShapeAnalysisResult` gains a new field (`hasSelfIntersection: Bool?`); no existing field changed
type or was removed, and the struct's memberwise initializer is not public, so no external caller
constructs one directly. No migration needed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR:
      `Tests/OCCTShapeHealingTests/Issue772SelfIntersectionAnalysisTests.swift` (5 tests, one
      added in round 2 specifically for the collapsed-parameter fix), plus one existing test
      (`analysisResultProperties`) updated to include the new field in its own
      independently-recomputed `totalProblems` mirror.
- [x] Every new test was run once with its subject broken, and the failure is reported below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Round 1 packaging fix**: the first pushed commit added the harness as its own
`AnalyzeSelfIntersectionTiming` executable target, path pointing directly into
`Scripts/repro/772-analyze-self-intersection/`, with `exclude: ["README.md",
"measured-output.txt"]`, reintroducing what #694 removed one-target-per-cluster for. Moved the
Swift source into a new shared `Harnesses` target (`Scripts/repro/harnesses/`).

**Round 2, five findings, all fixed:**

1. **The mismeasurement (serious).** The harness measured `isSelfIntersecting(timeout:)` for
   ordinary shapes while `analyze()` actually called `isSelfIntersecting(hardTimeout:)`.
   Re-measured both mechanisms, plus `deepCopy()` alone, on every row, at the same deadline (see
   table above). Result: switched `analyze()` to forward to `timeout:` instead, since
   `hardTimeout:` is not a strict improvement (same cost on ordinary shapes, a worse answer on
   the pathological one) and buys nothing for an already-synchronous caller.
2. **Missing blocking warning.** `analyze()`'s doc now has an explicit `- Important` note: passing
   `selfIntersectionTimeout` blocks the calling thread for up to that many seconds, matching
   `isSelfIntersecting(timeout:)`'s own warning.
3. **Silently inert parameter.** The old `checkSelfIntersection: Bool` + `hardTimeout: Double`
   let a caller supply a timeout while forgetting the boolean, compiling and discarding it
   silently. Collapsed into one `selfIntersectionTimeout: Double?`: supplying a value now IS
   opting in, making that mistake unrepresentable. New test:
   `timeoutAloneCannotBeSuppliedWithoutOptingIn`.
4. **Abandoned background computations.** Resolved by construction, not documentation: since
   `analyze()` no longer uses `isSelfIntersecting(hardTimeout:)` at all (per finding 1's fix), the
   specific risk of piling up abandoned, deep-copied probe shapes across a loop of `analyze()`
   calls does not reach `analyze()`. `isSelfIntersecting(hardTimeout:)` itself is unchanged and
   still carries that documented trade-off for any caller who reaches it directly (out of scope
   for #772, per the issue's own "Not in scope" section).
5. **`HarnessRunner` duplicated `CensusRunner`.** Factored the shared dispatch logic
   (list/all/run-by-name, error handling, usage printing) into a new `RunnerCore` library target
   (`Scripts/repro/runner-core/GenericRunner.swift`), which both `Harnesses` and `Censuses` now
   depend on. One manifest edit, no per-target duplication left.

**Removal matrix (prove-the-test-fails, `okf/policies/prove-the-test-fails.md`)**, re-run against
the final round-2 implementation:

- Always-nil gate (`hasSelfIntersection` forced to `nil` unconditionally): 4 of 5 tests FAILED
  (`nonNilTimeoutOnCleanShapePopulatesFalse`, `nonNilTimeoutOnSelfIntersectingShapePopulatesTrue`,
  `totalProblemsReflectsOnlyWhatWasChecked`, `timeoutAloneCannotBeSuppliedWithoutOptingIn`); the
  default-stays-nil test still passed (orthogonal to this defect). Restored (`diff` confirmed
  byte-identical to pre-injection), re-ran: all 5 pass.
- (Round 1's always-check injection was re-verified against round 1's implementation before the
  round-2 rewrite; see the prior review thread for that run's output.)

**Gates**: all 5 static gates + their `--self-test`s, plus the census and changelog-transcription
self-tests, all clean after both rounds. `count-operations.py`: 4306 == 4306 (unaffected; a
signature/parameter change, not a new entry point).

**Full `swift test`**: 5488 tests, 1429 suites, 0 failures, ~113s wall clock, after round 2.

**Docs**: `docs/reference/Shape-Features.md`'s `ShapeAnalysisResult`/`analyze(...)` sections
updated with the new field/parameter, a fenced `swift` snippet, the measured overhead figures, and
the `timeout:` vs `hardTimeout:` reasoning (context7 harvests the snippets).
