### PR TITLE
chore(#771): teach the census a third sub-kind, a gate flag that never flips

### DIFF
--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -196,13 +196,28 @@ real, observed source of noise in the candidate list, not a hypothetical:
     clause itself has no computed sibling of its own. Sound in the cases this pass measured, but
     read the surrounding branches before trusting a flagged site, not just the flagged line.
   - A LOCAL CONFIG/OPTIONS STRUCT PASSED INTO A CALL IS SYNTACTICALLY IDENTICAL TO A RESULT STRUCT
-    RETURNED FROM ONE. `BRepGraph::ShapesView::Options opts; opts.Parallel = parallel; opts.
-    CreateAutoProduct = false;` is an INPUT the function constructs and hands to `Add()`. Nothing
-    about it is "returned through an API" in #726's sense, but it has the exact same
-    literal-beside-computed-sibling shape a result struct does. This script does not distinguish
-    "local var later passed as an argument" from "local var later returned"; every config-struct
-    site in the first run's 64 candidates (5 of them) needed a human to notice the struct never
-    leaves the function as a return value.
+    RETURNED FROM ONE, and this WAS a blind spot: `BRepGraph::ShapesView::Options opts; opts.
+    Parallel = parallel; opts.CreateAutoProduct = false;` is an INPUT the function constructs and
+    hands to `Add()`, not something "returned through an API" in #726's sense, but it has the exact
+    same literal-beside-computed-sibling shape a result struct does. Every config-struct site in
+    the first run's 64 candidates (5 of them: `BRepGraph::ShapesView::Options` x4,
+    `MathInteg::KronrodConfig` x1) needed a human to notice the struct never leaves the function as
+    a return value. FIXED (#771, prompted during that issue's sub-kind 3 review, folded into the
+    same PR since it was cheap while already in this script): `is_input_only_struct()` excludes a
+    local var that is handed to some call as a bare argument and never surfaces afterward, "surfaces"
+    meaning a bare `return var;`, storage into a container (`push_back`/`emplace_back`/
+    `push_front`/`emplace_front`/`insert`), or a direct `arr[i] = var;` copy into an array/vector
+    element -- any ONE of those three wins over the exclusion, since excluding a real result would
+    make this script blind to exactly the class of defect #771's `hasExtent` itself was
+    (`OCCTShapeAxis a` is built, `collected.push_back(a)`, later copied to an out-param array: the
+    same shape as `opts`, up to which call it is handed to). The three protections are proven
+    individually necessary, not just the rule as a whole, in the self-test removal matrix (see
+    below): removing the `push_back`-family check alone regresses the `ShapeAxis` fixture, removing
+    the bare-`return` check alone regresses a dedicated fixture built to prove it, and same for the
+    array-element check. Measured: 54 candidates in this tree drop to 49, exactly the 5 known sites,
+    nothing else moves. Still not attempted: a config struct that is reassigned to a plain variable
+    (`T copy = opts;`) before that variable is what leaves the function -- not observed in this
+    tree, so not worth the extra tracking it would need.
   - A FIELD ASSIGNED TWO OR MORE DIFFERENT LITERAL VALUES ACROSS DIFFERENT BRANCHES OF THE SAME
     FUNCTION IS THE COMMON, LEGITIMATE CASE, NOT THE RARE ONE, and this script does not
     distinguish it from a field pinned to the SAME literal on every reached path. `result.isValid =
@@ -438,6 +453,56 @@ def is_literal(rhs):
     return bool(LITERAL_RHS.match(rhs.strip().strip('() \t\r\n')))
 
 
+CALL_START = re.compile(r'\b\w+\s*\(')
+STORE_METHOD = ('push_back', 'emplace_back', 'push_front', 'emplace_front', 'insert')
+
+
+def call_arg_lists(body):
+    """Text of every balanced (...) argument list following an identifier, paren-depth matched
+    (the same style catch_spans/conditional_brace_positions already use for braces) so a nested
+    cast or call inside the arguments does not truncate it. `Add(*(const TopoDS_Shape*)shape,
+    opts)` is exactly the shape that needs this: a naive `[^()]*` capture stops at the cast's own
+    `)` and never sees `opts` as part of the outer call's argument list at all."""
+    out = []
+    n = len(body)
+    for m in CALL_START.finditer(body):
+        i, depth, start = m.end(), 1, m.end()
+        while i < n and depth > 0:
+            if body[i] == '(':
+                depth += 1
+            elif body[i] == ')':
+                depth -= 1
+            i += 1
+        out.append(body[start:i - 1])
+    return out
+
+
+def is_input_only_struct(body, var):
+    """True if `var` is a local config/options struct handed to a call as an argument and never
+    surfaces afterward: not returned bare, not stored into a container (push_back/emplace_back/
+    push_front/emplace_front/insert), and not copied into an array/vector element. This is the
+    shape `BRepGraph::ShapesView::Options`/`MathInteg::KronrodConfig` locals have (built, handed to
+    one OCCT call, discarded) versus `OCCTShapeAxis a`'s (built in a loop, `collected.push_back(a)`,
+    later copied to an out-param array) -- syntactically identical "literal beside computed
+    sibling" shapes that this function is what tells apart. Getting this backwards in the unsafe
+    direction -- excluding a real result struct -- would make sub-kind 1 blind to exactly the class
+    of defect #771's hasExtent was, so a var is only ever excluded, never force-included, by this
+    check, and every one of the "protected" shapes below wins over the "excluded" one if both are
+    present."""
+    name = re.escape(var)
+    if re.search(r'\breturn\s+' + name + r'\s*;', body):
+        return False  # returned by value: definitely surfaces
+    if re.search(r'\.\s*(?:' + '|'.join(STORE_METHOD) + r')\s*\(\s*&?\s*' + name + r'\s*\)', body):
+        return False  # stored into a container: survives past this function
+    if re.search(r'\w+\s*\[[^\]]*\]\s*=\s*&?\s*' + name + r'\s*;', body):
+        return False  # copied into an array/vector element: same idea, no container call needed
+    bare = re.compile(r'(?<![.\w])' + name + r'(?![.\w(])')
+    for args in call_arg_lists(body):
+        if bare.search(args):
+            return True  # handed to some other call as a bare argument, and nothing above fired
+    return False
+
+
 def production_candidates(sources):
     """(file, line, function, var, field, rhs) for every literal field with a same-depth,
     non-catch, computed sibling on the same local variable."""
@@ -460,6 +525,8 @@ def production_candidates(sources):
             for var, fmap in fields.items():
                 if len(fmap) < 2:
                     continue
+                if is_input_only_struct(body, var):
+                    continue  # a config/options struct passed as an argument, not a result
                 computed_depths = set()
                 for field, assigns in fmap.items():
                     if any(not lit for lit, _, _, _ in assigns):
@@ -829,6 +896,24 @@ int32_t OCCTFixtureAxes(OCCTShapeRef shape, OCCTFixtureAxis* outAxes, int32_t ma
         return (int32_t)collected.size();
     } catch (...) { return -1; }
 }'''),
+    ('a struct handed to a helper call AND returned by value: the "returned bare" protection has '
+     'to win over the "passed as a bare argument" exclusion, not the other way around', '''
+OCCTFixtureResult OCCTFixtureLogAndReturn(OCCTShapeRef shape) {
+    OCCTFixtureResult result = {};
+    result.count = occtRealCount(shape);
+    result.flagged = false;
+    occtLogResult(result);
+    return result;
+}'''),
+    ('a struct handed to a helper call AND copied directly into an out-param array element (no '
+     'intervening container): the "copied into an array element" protection has to win too', '''
+void OCCTFixtureFillOne(OCCTShapeRef shape, OCCTFixtureResult* outArr) {
+    OCCTFixtureResult result = {};
+    result.count = occtRealCount(shape);
+    result.flagged = false;
+    occtLogResult(result);
+    outArr[0] = result;
+}'''),
 ]
 
 # The other failure mode: a literal reached only under a real, checked condition, with no computed
@@ -874,6 +959,18 @@ OCCTFixtureStyle OCCTFixtureStyleCreate(void) {
     result.r = 0; result.g = 0; result.b = 0;
     result.alpha = 1.0f;
     return result;
+}'''),
+    ('a local config/options struct handed to a call as an argument and discarded, not a returned '
+     'result -- the real BRepGraph::ShapesView::Options / MathInteg::KronrodConfig shape, '
+     'including the nested-cast argument list that defeats a naive [^()]* capture', '''
+void OCCTFixtureAppend(OCCTFixtureRef g, OCCTShapeRef shape, bool parallel) {
+    if (!g || !shape) return;
+    try {
+        OCCTFixtureOptions opts;
+        opts.Parallel = parallel;
+        opts.CreateAutoProduct = false;
+        (void)g->graph.Shapes().Add(*(const TopoDS_Shape*)shape, opts);
+    } catch (...) {}
 }'''),
 ]
 

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -28,7 +28,7 @@ Three sub-kinds, per the issue (the third added for #771):
      turning into a Swift-side `nil` on the false path, the #583/#595/#609 idiom) is permanently
      unreachable while looking exactly like a working instance of that idiom. The seed instance is
      `OCCTShapeAxis.hasExtent` (`OCCTBridge_Topology.mm`, all 3 call sites `false`, none `true`),
-     found by #763 and fixed on the sibling PR #770 — #771 is "teach the census this shape, don't
+     found by #763 and fixed on the sibling PR #770. #771 is "teach the census this shape, don't
      just trust the one-off grep that found it". See SUB-KIND 3 ALGORITHM below.
 
 WHY A SCRIPT, NOT A LIST IN THE ISSUE: this repo's own history of censuses built by grep and
@@ -113,7 +113,7 @@ field true", it is "does ANYTHING, anywhere in the bridge, set it true".
     (both `include/*.h` and `src/*.mm`/`*.h`) and collect every `bool` field each one declares.
     Deliberately NOT filtered to a `hasX`/`isX` name: this is what teaches the "not named
     `hasSomething`" shape (`isValid`, `defined`, `ok`, `found`, ...) the naive pass named as a blind
-    spot — any boolean struct field is a candidate gate, whatever it is called.
+    spot: any boolean struct field is a candidate gate, whatever it is called.
   - For every function definition in the same corpus, bind local identifiers to a KNOWN struct type
     by two shapes: a local declaration (`OCCTShapeAxis a;`) and a pointer or reference PARAMETER
     (`OCCTShapeAxis* outAxes`, `OCCTShapeAxis& a`). The parameter form is what teaches the "flipped
@@ -124,7 +124,7 @@ field true", it is "does ANYTHING, anywhere in the bridge, set it true".
   - Within each function, match every `var.field = RHS;`, `var->field = RHS;` and
     `var[idx].field = RHS;` assignment (a strict superset of sub-kind 1's `var.field` pattern) where
     `var` is bound to a struct with `field` in its bool-field set. Classify the RHS `true`, `false`,
-    or COMPUTED (anything else — a call, a variable, a member access).
+    or COMPUTED (anything else: a call, a variable, a member access).
   - A COMPUTED assignment to a field marks that (struct, field) as "not provably stuck" wherever it
     is found, even if no literal `true` ever appears for it: `OCCTCurve3DValidateRange`'s
     `result.wasAdjusted = false;` default next to `result.wasAdjusted = adjusted;` (a real
@@ -139,7 +139,7 @@ field true", it is "does ANYTHING, anywhere in the bridge, set it true".
     itself unreachable" shape): (a) it sits inside an `if (false) { ... }` / `if (0) { ... }` /
     `while (false) { ... }` block, or (b) it is preceded, within the same brace-delimited straight-
     line block, by an unconditional `return`/`continue`/`break`/`throw` statement that STARTS its
-    own statement (immediately after a `;`, `{`, `}` or the top of the block) — a `return` inside a
+    own statement (immediately after a `;`, `{`, `}` or the top of the block): a `return` inside a
     braceless `if (cond) return x;` guard does NOT count, since it is conditional, not a straight-
     line exit, and treating it as one produced a real false positive in this tree's own corpus (see
     the removal matrix in the self-test below).
@@ -150,8 +150,8 @@ WHAT SUB-KIND 3 STILL CANNOT SEE, against the four blind spots the issue named f
 plus what was found reading its own false positives on this tree:
 
   - THE `kind` ENUM VARIANT OF "not named hasSomething" IS NOT TAUGHT. The issue's example bundles
-    plain bool fields under other names (`isValid`, `defined`, `ok`, `found` — all TAUGHT, since the
-    struct-field parse is not name-filtered) with "a `kind` enum with a never-emitted case" — a
+    plain bool fields under other names (`isValid`, `defined`, `ok`, `found`, all TAUGHT, since the
+    struct-field parse is not name-filtered) with "a `kind` enum with a never-emitted case", a
     fundamentally different question, since an enum can have arbitrarily many cases and "never
     emitted" needs the full declared case list PLUS which case means "gate open", which is semantic,
     not syntactic. Not attempted.
@@ -169,12 +169,17 @@ plus what was found reading its own false positives on this tree:
     regex looks for the type name directly adjacent to the variable, not behind a cast.
   - A MORE ELABORATE "ALWAYS FALSE" CONDITION defeats the two unreachable-`true` checks: `if (1 ==
     2)`, `if (SOME_FALSE_MACRO)`, `#if 0` preprocessor exclusion, or a `switch` case that is never
-    reached. Only the literal spellings `false` and `0` are recognised.
+    reached. Only the literal spellings `false` and `0` are recognised. This is about the
+    condition's SPELLING; the BLOCK'S DELIMITER (braced vs braceless) is a distinct question and IS
+    handled for both: PR #774's review found the first version of `false_condition_spans` only
+    recognised the braced form (`if (false) { field = true; }`), so a braceless always-false guard
+    (`if (false) field = true;`) counted as reachable and a genuinely stuck flag would have gone
+    unreported. See `false_condition_spans`'s own docstring for the fix.
   - THE SWIFT SIDE IS SWEPT FOR COMPUTED PROPERTIES ONLY (`swift_gate_candidates` below), per the
     issue's own scope note ("sweep Sources/OCCTSwift too if the rule generalises cleanly, say so if
     it does not"): a Swift `var x: Bool { ... }` with `return false` somewhere and `return true`
-    nowhere in its body is caught. A Swift STORED property mutated across multiple methods — the
-    closer analogue of the C struct case — is NOT: it would need the same corpus-wide type-binding
+    nowhere in its body is caught. A Swift STORED property mutated across multiple methods (the
+    closer analogue of the C struct case) is NOT: it would need the same corpus-wide type-binding
     machinery applied to Swift class/struct declarations and their methods, which is a bigger lift
     than a single self-contained function body, and was not attempted this pass. The dead-code-
     unreachability checks (if-false, dead-after-return) are also not applied on the Swift side: Swift
@@ -204,20 +209,45 @@ real, observed source of noise in the candidate list, not a hypothetical:
     `MathInteg::KronrodConfig` x1) needed a human to notice the struct never leaves the function as
     a return value. FIXED (#771, prompted during that issue's sub-kind 3 review, folded into the
     same PR since it was cheap while already in this script): `is_input_only_struct()` excludes a
-    local var that is handed to some call as a bare argument and never surfaces afterward, "surfaces"
-    meaning a bare `return var;`, storage into a container (`push_back`/`emplace_back`/
-    `push_front`/`emplace_front`/`insert`), or a direct `arr[i] = var;` copy into an array/vector
-    element -- any ONE of those three wins over the exclusion, since excluding a real result would
-    make this script blind to exactly the class of defect #771's `hasExtent` itself was
-    (`OCCTShapeAxis a` is built, `collected.push_back(a)`, later copied to an out-param array: the
-    same shape as `opts`, up to which call it is handed to). The three protections are proven
-    individually necessary, not just the rule as a whole, in the self-test removal matrix (see
-    below): removing the `push_back`-family check alone regresses the `ShapeAxis` fixture, removing
-    the bare-`return` check alone regresses a dedicated fixture built to prove it, and same for the
-    array-element check. Measured: 54 candidates in this tree drop to 49, exactly the 5 known sites,
-    nothing else moves. Still not attempted: a config struct that is reassigned to a plain variable
-    (`T copy = opts;`) before that variable is what leaves the function -- not observed in this
-    tree, so not worth the extra tracking it would need.
+    local var that is handed to some call as a bare argument and never surfaces afterward,
+    "surfaces" meaning a bare `return var;`, storage into a container (`push_back`/`emplace_back`/
+    `push_front`/`emplace_front`/`insert`, through EITHER `.` or `->`, as ONE argument among
+    several or the only one), or a direct `arr[i] = var;` copy into an array/vector element. Any
+    ONE of those protections wins over the exclusion, since excluding a real result would make this
+    script blind to exactly the class of defect #771's `hasExtent` itself was (`OCCTShapeAxis a` is
+    built, `collected.push_back(a)`, later copied to an out-param array: the same shape as `opts`,
+    up to which call it is handed to). The protections are proven individually necessary, not just
+    the rule as a whole, in the self-test removal matrix (see below). Measured: 54 candidates in
+    this tree drop to 49, exactly the 5 known sites, nothing else moves.
+
+    A second review round (still #774) found the first version of this fix had three further gaps
+    of the same shape, each closed the same way (case first, watch it fail, then fix, per
+    `okf/policies/prove-the-test-fails.md`): the store protection matched `.` only, never `->`
+    (a container reached through a pointer out-param, one indirection past the seed shape, would
+    have regressed exactly like `push_back` itself would have without protection at all); the store
+    protection only matched a SINGLE-argument call (the parens had to contain nothing but the
+    tracked variable), so `insert`'s own
+    standard two-argument idiom (`insert(iterator, value)`) fell through despite `insert` being
+    named as covered; and `call_arg_lists`' `CALL_START` had no keyword exclusion at all, unlike
+    `c_functions()`, so `if (...)`/`for (...)`/`while (...)`/`switch (...)` and `sizeof(...)` were
+    all treated as call argument lists, with `sizeof(result)` the cleanest failure since `sizeof` is
+    an operator and cannot consume or take ownership of its operand. All three fixed together:
+    `call_arg_lists` now returns `(callee, args)` pairs excluding `NOT_A_CALL` (`NOT_A_FUNCTION`
+    plus `sizeof`), and the store check searches the WHOLE args text for a bare `var` token rather
+    than requiring it to be the sole argument, which handles arrow notation and multiple arguments
+    in one pass since neither depends on what precedes the call or how many other arguments sit
+    beside `var`. Still not attempted: a config struct that is reassigned to a plain variable
+    (`T copy = opts;`) before that variable is what leaves the function; not observed in this tree,
+    so not worth the extra tracking it would need.
+
+    The SAME review also found sub-kind 1's core `FIELD_ASSIGN` (not just this exclusion) was
+    dot-only, unlike sub-kind 3's `ASSIGN_ANY`, and so was blind to any result built through an
+    out-param pointer (`out->field = ...;`) or array element (`out[i].field = ...;`) from the start.
+    The real corpus has many of both (`OCCTBridge_AIS.mm`, `OCCTBridge_Geom2d.mm`,
+    `OCCTBridge_Spatial.mm`, `OCCTBridge_Surface.mm`). FIXED: `FIELD_ASSIGN` now matches the same
+    three shapes `ASSIGN_ANY` does. Measured: 49 candidates becomes 73 on this tree; the 24 new
+    ones are adjudicated in `triage-gate-flags.md` and issue #781 (10 verdict 2 needing a real fix,
+    10 verdict 1, 4 needing further investigation before either verdict applies).
   - A FIELD ASSIGNED TWO OR MORE DIFFERENT LITERAL VALUES ACROSS DIFFERENT BRANCHES OF THE SAME
     FUNCTION IS THE COMMON, LEGITIMATE CASE, NOT THE RARE ONE, and this script does not
     distinguish it from a field pinned to the SAME literal on every reached path. `result.isValid =
@@ -443,7 +473,13 @@ def depth_at(segments, pos):
     return 0
 
 
-FIELD_ASSIGN = re.compile(r'\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*=\s*([^=][^;]*);')
+# Dot, arrow AND array-index, matching sub-kind 3's ASSIGN_ANY: a result built through an
+# out-param pointer (`out->field = ...;`) is exactly as much "returned through an API" as a local
+# value built with dot notation, and the real corpus has many of the pointer-built kind (#774's
+# review: OCCTBridge_AIS.mm, OCCTBridge_Geom2d.mm). Dot-only here was a silent under-report, the
+# same failure mode the arrow/array-index gaps in is_input_only_struct's checks were.
+FIELD_ASSIGN = re.compile(
+    r'\b([A-Za-z_]\w*)(?:\s*\[[^\]]*\])?\s*(?:\.|->)\s*([A-Za-z_]\w*)\s*=\s*([^=][^;]*);')
 LITERAL_RHS = re.compile(
     r'^-?\s*(?:\d+\.?\d*(?:[eE][-+]?\d+)?[fFlL]?|\.\d+[fFlL]?|true|false|nullptr|NULL|""|\'\S\')\s*$'
 )
@@ -453,19 +489,31 @@ def is_literal(rhs):
     return bool(LITERAL_RHS.match(rhs.strip().strip('() \t\r\n')))
 
 
-CALL_START = re.compile(r'\b\w+\s*\(')
-STORE_METHOD = ('push_back', 'emplace_back', 'push_front', 'emplace_front', 'insert')
+CALL_START = re.compile(r'\b(\w+)\s*\(')
+STORE_METHOD = {'push_back', 'emplace_back', 'push_front', 'emplace_front', 'insert'}
+# sizeof is an operator, not a call: it cannot consume, store or take ownership of its operand, so
+# treating `sizeof(var)` as "var handed to a call" is wrong regardless of what surrounds it. Reuses
+# c_functions' own NOT_A_FUNCTION set for the control-flow keywords, which call_arg_lists had none
+# of at all before #774's review: `if (...)`, `for (...)`, `while (...)` and `switch (...)` were
+# all being treated as call argument lists, just like c_functions would wrongly treat them as
+# function definitions without the same exclusion.
+NOT_A_CALL = NOT_A_FUNCTION | {'sizeof'}
 
 
 def call_arg_lists(body):
-    """Text of every balanced (...) argument list following an identifier, paren-depth matched
-    (the same style catch_spans/conditional_brace_positions already use for braces) so a nested
-    cast or call inside the arguments does not truncate it. `Add(*(const TopoDS_Shape*)shape,
-    opts)` is exactly the shape that needs this: a naive `[^()]*` capture stops at the cast's own
-    `)` and never sees `opts` as part of the outer call's argument list at all."""
+    """(callee, args_text) for every call `callee(...)`, paren-depth matched (the same style
+    catch_spans/conditional_brace_positions already use for braces) so a nested cast or call
+    inside the arguments does not truncate it. `Add(*(const TopoDS_Shape*)shape, opts)` is exactly
+    the shape that needs this: a naive `[^()]*` capture stops at the cast's own `)` and never sees
+    `opts` as part of the outer call's argument list at all. `callee` excludes NOT_A_CALL (control-
+    flow keywords, and sizeof), so `if (n == sizeof(result))` yields no entries at all: neither
+    `if` nor the nested `sizeof` is a call that can consume `result`."""
     out = []
     n = len(body)
     for m in CALL_START.finditer(body):
+        callee = m.group(1)
+        if callee in NOT_A_CALL:
+            continue
         i, depth, start = m.end(), 1, m.end()
         while i < n and depth > 0:
             if body[i] == '(':
@@ -473,31 +521,34 @@ def call_arg_lists(body):
             elif body[i] == ')':
                 depth -= 1
             i += 1
-        out.append(body[start:i - 1])
+        out.append((callee, body[start:i - 1]))
     return out
 
 
 def is_input_only_struct(body, var):
     """True if `var` is a local config/options struct handed to a call as an argument and never
     surfaces afterward: not returned bare, not stored into a container (push_back/emplace_back/
-    push_front/emplace_front/insert), and not copied into an array/vector element. This is the
-    shape `BRepGraph::ShapesView::Options`/`MathInteg::KronrodConfig` locals have (built, handed to
-    one OCCT call, discarded) versus `OCCTShapeAxis a`'s (built in a loop, `collected.push_back(a)`,
-    later copied to an out-param array) -- syntactically identical "literal beside computed
-    sibling" shapes that this function is what tells apart. Getting this backwards in the unsafe
-    direction -- excluding a real result struct -- would make sub-kind 1 blind to exactly the class
-    of defect #771's hasExtent was, so a var is only ever excluded, never force-included, by this
-    check, and every one of the "protected" shapes below wins over the "excluded" one if both are
-    present."""
+    push_front/emplace_front/insert, through EITHER `.` or `->`, and whether that call takes `var`
+    as its only argument or one of several, e.g. `insert(iterator, var)`), and not copied into an
+    array/vector element. This is the shape `BRepGraph::ShapesView::Options`/
+    `MathInteg::KronrodConfig` locals have (built, handed to one OCCT call, discarded) versus
+    `OCCTShapeAxis a`'s (built in a loop, `collected.push_back(a)`, later copied to an out-param
+    array), syntactically identical "literal beside computed sibling" shapes that this function is
+    what tells apart. Getting this backwards in the unsafe direction, excluding a real result
+    struct, would make sub-kind 1 blind to exactly the class of defect #771's hasExtent was, so a
+    var is only ever excluded, never force-included, by this check, and every one of the
+    "protected" shapes below wins over the "excluded" one if both are present."""
     name = re.escape(var)
     if re.search(r'\breturn\s+' + name + r'\s*;', body):
         return False  # returned by value: definitely surfaces
-    if re.search(r'\.\s*(?:' + '|'.join(STORE_METHOD) + r')\s*\(\s*&?\s*' + name + r'\s*\)', body):
-        return False  # stored into a container: survives past this function
     if re.search(r'\w+\s*\[[^\]]*\]\s*=\s*&?\s*' + name + r'\s*;', body):
         return False  # copied into an array/vector element: same idea, no container call needed
     bare = re.compile(r'(?<![.\w])' + name + r'(?![.\w(])')
-    for args in call_arg_lists(body):
+    calls = call_arg_lists(body)
+    for callee, args in calls:
+        if callee in STORE_METHOD and bare.search(args):
+            return False  # stored into a container (dot or arrow, any argument position)
+    for callee, args in calls:
         if bare.search(args):
             return True  # handed to some other call as a bare argument, and nothing above fired
     return False
@@ -706,8 +757,13 @@ def is_dead_after_terminator(body, pos, segs):
 
 
 def false_condition_spans(body):
-    """[(open_brace_pos, close_brace_pos), ...] for every `if (false)`/`if (0)`/`while (false)`/
-    `while (0)` block: a literal always-false condition, not any conditional whatsoever."""
+    """[(span_start, span_end), ...] for the body of every `if (false)`/`if (0)`/`while (false)`/
+    `while (0)`: a literal always-false condition, not any conditional whatsoever. Covers both the
+    braced form (`if (false) { ... }`, span is the `{...}`) and the braceless single-statement form
+    (`if (false) field = true;`, span is that one statement up to its own top-level `;`). A
+    braceless always-false guard is exactly as unreachable as a braced one, and #774's review
+    found the braced-only version missed it entirely, silently under-reporting a genuinely stuck
+    flag."""
     spans = []
     for m in IF_WHILE_COND.finditer(body):
         i, depth, cond_start = m.end(), 1, m.end()
@@ -718,10 +774,12 @@ def false_condition_spans(body):
                 depth -= 1
             i += 1
         cond = body[cond_start:i - 1].strip()
+        if cond not in ('false', '0'):
+            continue
         j = i
         while j < len(body) and body[j] in ' \t\r\n':
             j += 1
-        if j < len(body) and body[j] == '{' and cond in ('false', '0'):
+        if j < len(body) and body[j] == '{':
             depth2, k = 0, j
             while k < len(body):
                 if body[k] == '{':
@@ -730,6 +788,20 @@ def false_condition_spans(body):
                     depth2 -= 1
                     if depth2 == 0:
                         break
+                k += 1
+            spans.append((j, k))
+        elif j < len(body):
+            # Braceless: the guarded statement runs from here to its own top-level `;` (a nested
+            # call's argument-list parens don't end the statement early).
+            k, pdepth = j, 0
+            while k < len(body):
+                if body[k] == '(':
+                    pdepth += 1
+                elif body[k] == ')':
+                    pdepth -= 1
+                elif body[k] == ';' and pdepth == 0:
+                    k += 1
+                    break
                 k += 1
             spans.append((j, k))
     return spans
@@ -812,7 +884,7 @@ SWIFT_RETURN_LITERAL = re.compile(r'\breturn\s+(true|false)\b')
 def swift_gate_candidates(sources):
     """(file, line, property, snippet) for every Swift `var x: Bool { ... }` computed property
     that returns literal false somewhere in its body and literal true nowhere. Stored properties
-    mutated across multiple methods (the closer analogue of the C struct case) are not covered —
+    mutated across multiple methods (the closer analogue of the C struct case) are not covered;
     see SUB-KIND 3 ALGORITHM's Swift-side note."""
     found = []
     for path, raw in sources:
@@ -914,6 +986,50 @@ void OCCTFixtureFillOne(OCCTShapeRef shape, OCCTFixtureResult* outArr) {
     occtLogResult(result);
     outArr[0] = result;
 }'''),
+    ('a struct handed to a helper call AND stored into a container reached through a POINTER '
+     '(outVec->push_back(a), not a plain local): the store protection has to recognise arrow '
+     'notation, not just dot notation, or this regresses one indirection past the seed shape', '''
+int32_t OCCTFixtureAxesViaPointerContainer(double x, OCCTFixtureAxis* outAxes, int32_t maxAxes) {
+    std::vector<OCCTFixtureAxis>* collected = new std::vector<OCCTFixtureAxis>();
+    OCCTFixtureAxis a;
+    a.originX = x;
+    a.hasExtent = false;
+    occtLogAxis(a);
+    collected->push_back(a);
+    return (int32_t)collected->size();
+}'''),
+    ('a struct handed to a helper call AND stored via the two-argument insert(iterator, value) '
+     'form, std::vector::insert\'s standard idiom, not the one-argument form the store check '
+     'used to require', '''
+int32_t OCCTFixtureAxesViaInsertAtEnd(double x, OCCTFixtureAxis* outAxes, int32_t maxAxes) {
+    std::vector<OCCTFixtureAxis> collected;
+    OCCTFixtureAxis a;
+    a.originX = x;
+    a.hasExtent = false;
+    occtLogAxis(a);
+    collected.insert(collected.end(), a);
+    return (int32_t)collected.size();
+}'''),
+    ('a struct that is never returned, stored or array-assigned, and appears only inside '
+     'sizeof(...) nested in an if-condition: neither if nor sizeof is a call that can consume or '
+     'take ownership of its operand, so this must not count as "handed to a call" evidence', '''
+void OCCTFixtureCheckSize(OCCTShapeRef shape, int32_t n) {
+    OCCTFixtureResult result = {};
+    result.count = occtRealCount(shape);
+    result.flagged = false;
+    if (n == sizeof(result)) {
+        occtLogSizeMatch();
+    }
+}'''),
+    ('a result built through an OUT-PARAM POINTER (out->field = ...), not a local dot-notation '
+     'variable: FIELD_ASSIGN itself, sub-kind 1\'s core mechanism (not just the config-struct '
+     'exclusion), is dot-only and never sees this shape at all. The real corpus has many of '
+     'them, e.g. OCCTBridge_Geom2d.mm\'s extractBisecSolution: "out->radius = 0;" beside '
+     '"out->px = lin.Location().X();" in the same switch-case branch', '''
+static void occtFixtureExtractSolution(OCCTShapeRef shape, OCCTFixturePointerResult* out) {
+    out->count = occtRealCount(shape);
+    out->flagged = false;
+}'''),
 ]
 
 # The other failure mode: a literal reached only under a real, checked condition, with no computed
@@ -961,7 +1077,7 @@ OCCTFixtureStyle OCCTFixtureStyleCreate(void) {
     return result;
 }'''),
     ('a local config/options struct handed to a call as an argument and discarded, not a returned '
-     'result -- the real BRepGraph::ShapesView::Options / MathInteg::KronrodConfig shape, '
+     'result, the real BRepGraph::ShapesView::Options / MathInteg::KronrodConfig shape, '
      'including the nested-cast argument list that defeats a naive [^()]* capture', '''
 void OCCTFixtureAppend(OCCTFixtureRef g, OCCTShapeRef shape, bool parallel) {
     if (!g || !shape) return;
@@ -1084,6 +1200,19 @@ void occtFixtureDeadAfterReturn(OCCTFixtureDeadAfterReturn* outGate) {
     g.reachable = false;
     return;
     g.reachable = true;
+}'''),
+    ('indirection shape 2c: the only literal true is inside a BRACELESS if (false), no braces at '
+     'all: false_condition_spans only recognised the braced form', '''
+typedef struct {
+    double value;
+    bool reachable;
+} OCCTFixtureDeadIfFalseBraceless;
+''', '''
+void occtFixtureDeadIfFalseBraceless(OCCTFixtureDeadIfFalseBraceless* outGate) {
+    OCCTFixtureDeadIfFalseBraceless g;
+    g.value = 1.0;
+    g.reachable = false;
+    if (false) g.reachable = true;
 }'''),
 ]
 

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -127,7 +127,15 @@ field true", it is "does ANYTHING, anywhere in the bridge, set it true".
     (`OCCTShapeAxis* p = &a; p->hasExtent = true;`) bound nothing and the flip through `p` was
     invisible, even though the identical shape through a parameter was already caught. Fixed by
     giving `local_bind` the same two-branch shape `param_bind` already had (pointer/reference OR
-    plain value), rather than adding it to the list of things this pass cannot see.
+    plain value), rather than adding it to the list of things this pass cannot see. `local_bind`
+    was also single-declarator-only until #774's fifth review round: `local_declarator_bindings`
+    (its replacement) additionally splits a MULTI-DECLARATOR statement
+    (`OCCTShapeAxis *p, *q;`, or the mixed `OCCTShapeAxis a, *p;`) into its comma-separated pieces,
+    since the single-declarator form required its terminator immediately after the first name and
+    a comma sharing the statement with a second declarator failed that check for every declarator
+    in the statement, not just the one after the comma; low-severity in this tree (the bridge's own
+    style is one declarator per line) but fixed on the reviewer's own framing: a style choice is not
+    a safety argument.
   - Within each function, match every `var.field = RHS;`, `var->field = RHS;` and
     `var[idx].field = RHS;` assignment (a strict superset of sub-kind 1's `var.field` pattern) where
     `var` is bound to a struct with `field` in its bool-field set. Classify the RHS `true`, `false`,
@@ -147,16 +155,28 @@ field true", it is "does ANYTHING, anywhere in the bridge, set it true".
     would exempt a field that is permanently `false` in the code that actually executes, the
     identical unreachable-write-masks-a-stuck-gate shape as the `true` branch's own gap, left open
     one branch over until this fix.
-  - A `true` assignment (and, since the fix above, a COMPUTED one) does not count as reachable
-    evidence if it is textually UNREACHABLE by one of two narrow, decidable checks (this is what
-    teaches the "assigned true only on a path that is itself unreachable" shape): (a) it sits inside
-    an `if (false) { ... }` / `if (0) { ... }` / `while (false) { ... }` block, braced or braceless,
-    or (b) it is preceded, within the same brace-delimited straight-line block, by an unconditional
-    `return`/`continue`/`break`/`throw` statement that STARTS its own statement (immediately after a
-    `;`, `{`, `}` or the top of the block): a `return` inside a braceless `if (cond) return x;`
-    guard does NOT count, since it is conditional, not a straight-
+  - A `true` assignment, a computed assignment, AND (since #774's fifth review round) a `false`
+    assignment all route through the SAME `is_dead_assignment(body, pos, segs, dead_spans)` check
+    for whether the assignment is textually UNREACHABLE by one of two narrow, decidable checks
+    (this is what teaches the "assigned true only on a path that is itself unreachable" shape):
+    (a) it sits inside an `if (false) { ... }` / `if (0) { ... }` / `while (false) { ... }` block,
+    braced or braceless, or (b) it is preceded, within the same brace-delimited straight-line
+    block, by an unconditional `return`/`continue`/`break`/`throw` statement that STARTS its own
+    statement (immediately after a `;`, `{`, `}` or the top of the block): a `return` inside a
+    braceless `if (cond) return x;` guard does NOT count, since it is conditional, not a straight-
     line exit, and treating it as one produced a real false positive in this tree's own corpus (see
-    the removal matrix in the self-test below).
+    the removal matrix in the self-test below). All three call sites share this one function rather
+    than each running its own copy of the same two checks: the duplication IS how #774's own bug
+    came to exist. The check was added to the `true` branch in the second review round, not
+    mirrored to the computed branch until the fourth, and not mirrored to the `false` branch until
+    the fifth, three chances for the same omission because there were three places to make it.
+  - A `false` write inside dead code is not evidence the field is stuck on any live path either
+    (fifth review round, alongside the shared-helper factoring above): a field whose EVERY `false`
+    write is dead gets no entry in `false_sites` at all, which is what makes it drop out of the
+    report entirely rather than being reported with an empty or a dead site, since the dict is
+    built by appending live sites one at a time, and a field with zero live appends never acquires
+    a key. A field with a MIX of dead and live `false` writes still gets reported, and only from
+    the live site, for the same reason.
   - A field is reported once it has at least one `false` site and belongs to neither the "true seen"
     nor the "computed seen" set.
 
@@ -821,11 +841,53 @@ def false_condition_spans(body):
     return spans
 
 
+def is_dead_assignment(body, pos, segs, dead_spans):
+    """True if the assignment at `pos` is unreachable: dead code after an unconditional
+    return/continue/break/throw (`is_dead_after_terminator`), or inside a literal always-false
+    conditional (`dead_spans`, from `false_condition_spans`). `gate_flag_candidates` calls this
+    ONE function from all three of its ASSIGN_ANY branches (`true`, `false`, computed), rather than
+    each branch running its own copy of the same two checks. That is not tidiness: the duplication
+    is how #774's own bug came to exist. The check was added to the `true` branch in round two;
+    nobody mirrored it to the computed branch until round four, and nobody mirrored it to the
+    `false` branch until round five, three chances for the same omission because there were three
+    places to make it. Routing every branch through one function does not make a future branch
+    remember to call it, but it does mean a branch that DOES call it gets the real, current check,
+    and a reviewer looking for "does this branch handle dead code" has exactly one implementation to
+    read, not three copies that can individually drift."""
+    return is_dead_after_terminator(body, pos, segs) or any(s <= pos < e for s, e in dead_spans)
+
+
 # A strict superset of sub-kind 1's FIELD_ASSIGN: also matches pointer indirection (`var->field =`)
 # and an array/pointer out-param element (`var[idx].field =`), the "flipped through a pointer,
 # reference or helper" shape.
 ASSIGN_ANY = re.compile(
     r'\b([A-Za-z_]\w*)(?:\s*\[[^\]]*\])?\s*(?:\.|->)\s*([A-Za-z_]\w*)\s*=\s*([^=][^;]*);')
+
+
+def local_declarator_bindings(type_alt, body):
+    """{name: struct_type} for every local variable bound by a declaration statement, including a
+    MULTI-DECLARATOR one (`OCCTShapeAxis *p, *q;`, or the mixed `OCCTShapeAxis a, *p;`), each
+    comma-separated declarator optionally carrying its own `*`/`&`. A single-declarator regex
+    (`\\b(TYPE)\\s+(name)\\s*(?:=|;|\\{)`, this function's predecessor through two review rounds)
+    requires the terminator right after the first name, so a second declarator sharing the same
+    type never bound at all: nothing about `p` in `TYPE *p, *q;` looks different from `TYPE *p;` up
+    to the point the terminator check fails on the comma. Low-severity in this tree today (the
+    bridge's own style is one declarator per line), fixed anyway rather than left as a documented
+    gap, per #774's fifth review round: "the bridge's current style is the only reason it has not
+    bitten" is a description of luck, not of safety."""
+    decl_list = re.compile(
+        r'\b(' + type_alt + r')(?:\s*[\*&]\s*(?:_Nonnull\s+|_Nullable\s+|const\s+)?|\s+)'
+        r'([A-Za-z_]\w*(?:\s*=\s*[^,;]*)?(?:\s*,\s*[\*&]?\s*[A-Za-z_]\w*(?:\s*=\s*[^,;]*)?)*)\s*;')
+    declarator = re.compile(
+        r'^[\*&\s]*(?:_Nonnull\s+|_Nullable\s+|const\s+)?([A-Za-z_]\w*)$')
+    bindings = {}
+    for m in decl_list.finditer(body):
+        stype, decls = m.group(1), m.group(2)
+        for decl in decls.split(','):
+            dm = declarator.match(decl.split('=')[0].strip())
+            if dm:
+                bindings[dm.group(1)] = stype
+    return bindings
 
 
 def gate_flag_candidates(sources):
@@ -840,20 +902,10 @@ def gate_flag_candidates(sources):
     type_alt = '|'.join(re.escape(t) for t in struct_fields)
     param_bind = re.compile(
         r'\b(' + type_alt + r')\s*[\*&]\s*(?:_Nonnull\s+|_Nullable\s+|const\s+)?(\w+)\b')
-    # A local declaration binds either a plain value (`OCCTShapeAxis a;`, needs the `\s+` branch,
-    # since nothing else separates the type from the name) or a pointer/reference
-    # (`OCCTShapeAxis* p = &a;` / `OCCTShapeAxis *p;`, needs the `[\*&]` branch, which absorbs
-    # whitespace on either side of the sigil so both spellings match). Originally value-typed only;
-    # a local pointer/reference bound nothing, so `p->hasExtent = true;` through a local alias was
-    # invisible even though param_bind already handled the identical shape for a parameter
-    # (#774's third review round).
-    local_bind = re.compile(
-        r'\b(' + type_alt + r')(?:\s*[\*&]\s*(?:_Nonnull\s+|_Nullable\s+|const\s+)?|\s+)'
-        r'([A-Za-z_]\w*)\s*(?:=|;|\{)')
 
     false_sites = {}   # (struct, field) -> [(file, line, func, snippet), ...]
     true_seen = set()  # (struct, field) with >=1 reachable literal-true assignment
-    computed_seen = set()  # (struct, field) with >=1 non-literal assignment anywhere
+    computed_seen = set()  # (struct, field) with >=1 reachable non-literal assignment
     for path, raw in sources:
         text = strip_comments(raw)
         lines = raw.splitlines()
@@ -864,8 +916,7 @@ def gate_flag_candidates(sources):
             bindings = {}
             for m in param_bind.finditer(params):
                 bindings[m.group(2)] = m.group(1)
-            for m in local_bind.finditer(body):
-                bindings[m.group(2)] = m.group(1)
+            bindings.update(local_declarator_bindings(type_alt, body))
             if not bindings:
                 continue
             for m in ASSIGN_ANY.finditer(body):
@@ -874,11 +925,20 @@ def gate_flag_candidates(sources):
                 if not stype or field not in struct_fields.get(stype, ()):
                     continue
                 if rhs == 'true':
-                    if is_dead_after_terminator(body, m.start(), segs) or \
-                       any(s <= m.start() < e for s, e in dead_spans):
+                    if is_dead_assignment(body, m.start(), segs, dead_spans):
                         continue  # unreachable true: does not count as a real flip
                     true_seen.add((stype, field))
                 elif rhs == 'false':
+                    # A `false` written only in dead code is not evidence the field is stuck on any
+                    # live path either (#774's fifth review round): skip it here, the same way an
+                    # unreachable `true`/computed write is skipped below, so the sites this function
+                    # goes on to report are the live ones. A field whose EVERY `false` write is dead
+                    # never gets an entry in false_sites at all, which is what makes it drop out of
+                    # the report entirely rather than being reported with an empty site list: this
+                    # dict is built by appending live sites one at a time, so a field with zero live
+                    # appends simply never acquires a key.
+                    if is_dead_assignment(body, m.start(), segs, dead_spans):
+                        continue
                     line = text.count('\n', 0, bs + m.start()) + 1
                     false_sites.setdefault((stype, field), []).append(
                         (os.path.basename(path), line, name,
@@ -891,8 +951,7 @@ def gate_flag_candidates(sources):
                     # in the identical dead code the `true` branch already excludes is not "maybe
                     # true at runtime" either, it is "never runs at all", the same unreachable-
                     # write-masks-a-stuck-gate shape, one branch over (#774's second review round).
-                    if is_dead_after_terminator(body, m.start(), segs) or \
-                       any(s <= m.start() < e for s, e in dead_spans):
+                    if is_dead_assignment(body, m.start(), segs, dead_spans):
                         continue  # unreachable computed assignment: not "maybe true", just dead
                     computed_seen.add((stype, field))
 
@@ -1260,6 +1319,38 @@ void occtFixtureDeadComputed(OCCTFixtureDeadComputed* outGate) {
         g.hasExtent = occtSomeLegacyComputation();
     }
 }'''),
+    ('indirection shape 2e: one dead false write AND one live false write for the same field, no '
+     'true or computed anywhere. Must still flag, and from the LIVE site: a false written only in '
+     'dead code is not evidence of anything, but a false written on a real path still is, and a '
+     'field with a mix of both must not have the live evidence swallowed by the dead site', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureDeadAndLiveFalse;
+''', '''
+void occtFixtureDeadAndLiveFalse(OCCTFixtureDeadAndLiveFalse* outGate) {
+    OCCTFixtureDeadAndLiveFalse g;
+    g.value = 1.0;
+    if (false) {
+        g.hasExtent = false;
+    }
+    g.hasExtent = false;
+}'''),
+    ('indirection shape 7: a MULTI-DECLARATOR local statement with NO pointer/reference sigil at '
+     'all (OCCTFixtureMultiDeclaratorPlain unused, a;), value-typed on both names, isolating the '
+     'multi-declarator gap from the separate pointer-in-locals gap: the first declarator alone '
+     'failing its terminator check (a comma follows it, not =/;/{) already loses every later '
+     'declarator in the same statement, with no `*`/`&` involved anywhere', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureMultiDeclaratorPlain;
+''', '''
+void occtFixtureMultiDeclaratorPlain(OCCTFixtureMultiDeclaratorPlain* outGate) {
+    OCCTFixtureMultiDeclaratorPlain unused, a;
+    a.value = 1.0;
+    a.hasExtent = false;
+}'''),
 ]
 
 GATE_CLEAN = [
@@ -1373,6 +1464,39 @@ void occtFixtureLocalPointer(OCCTFixtureLocalPointer* outGate) {
     a.value = 1.0;
     a.hasExtent = false;
     OCCTFixtureLocalPointer* p = &a;
+    p->hasExtent = true;
+}'''),
+    ('every literal false write for this field is inside dead code, and nothing else assigns it '
+     'anywhere: the field must drop out of the report entirely rather than being reported with an '
+     'empty (or the dead) site, since a false written only in dead code is not evidence the field '
+     'is stuck on any live path', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureDeadFalseOnly;
+''', '''
+void occtFixtureDeadFalseOnly(OCCTFixtureDeadFalseOnly* outGate) {
+    OCCTFixtureDeadFalseOnly g;
+    g.value = 1.0;
+    if (false) {
+        g.hasExtent = false;
+    }
+}'''),
+    ('indirection shape 6: the multi-declarator gap AND the pointer-in-locals gap together, the '
+     'exact shape the review reported (OCCTFixtureMultiDeclarator *p, *q;, both pointer-typed, '
+     'sharing one type name and one terminating semicolon). Shape 7 below isolates the '
+     'multi-declarator mechanism on its own; this one is kept as the close-to-the-report case', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureMultiDeclarator;
+''', '''
+void occtFixtureMultiDeclarator(OCCTFixtureMultiDeclarator* outGate) {
+    OCCTFixtureMultiDeclarator a;
+    a.value = 1.0;
+    a.hasExtent = false;
+    OCCTFixtureMultiDeclarator *p, *q;
+    p = &a;
     p->hasExtent = true;
 }'''),
 ]

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -2,7 +2,7 @@
 """Census #726, first pass: values that were never computed but are returned through an API whose
 shape says they were measured.
 
-Two sub-kinds, per the issue:
+Three sub-kinds, per the issue (the third added for #771):
 
   1. PRODUCTION code assigning a bare literal to one field of an aggregate result while a sibling
      field of the same local variable, reached under the same control-flow condition, is assigned
@@ -22,6 +22,14 @@ Two sub-kinds, per the issue:
      computed values `#expect(p.depth > 0)` was reading the sign bug OCCTEdgeGetConvexity's own
      face1/face2 order-dependence produces on a PLAIN, uncut box (see #703, PR #720). No assertion
      anywhere in that test checked that `result` differs from `box` at all.
+
+  3. A boolean GATE FLAG on a bridge aggregate struct that is assigned at least one literal `false`
+     somewhere in the corpus and literal `true` nowhere reachable, so whatever it gates (usually by
+     turning into a Swift-side `nil` on the false path, the #583/#595/#609 idiom) is permanently
+     unreachable while looking exactly like a working instance of that idiom. The seed instance is
+     `OCCTShapeAxis.hasExtent` (`OCCTBridge_Topology.mm`, all 3 call sites `false`, none `true`),
+     found by #763 and fixed on the sibling PR #770 — #771 is "teach the census this shape, don't
+     just trust the one-off grep that found it". See SUB-KIND 3 ALGORITHM below.
 
 WHY A SCRIPT, NOT A LIST IN THE ISSUE: this repo's own history of censuses built by grep and
 written into an issue body is a list of wrong numbers. #558 said 14, measured 28; #571 said 3,
@@ -85,6 +93,88 @@ SUB-KIND 2 ALGORITHM. For every `@Test func` body in `Tests/**/*.swift`:
   - A test function is flagged when it has >=1 count-pin whose receiver matches the curated list,
     and the function has NO verification call anywhere in its body.
 
+SUB-KIND 3 ALGORITHM (#771). Deliberately NOT a name-prefix grep: the issue's own naive first pass
+("21 `hasX` flags declared in headers, which are assigned `false` somewhere and `true` nowhere")
+found exactly one hit and was explicit that this was not to be trusted as the answer, both because
+of this repo's five-strong record of name-prefix censuses undercounting (see WHY A SCRIPT above) and
+because it names four shapes that method is blind to. This algorithm is a whole-corpus reachability
+census, not a per-function one like sub-kind 1: the question is never "does this ONE function set the
+field true", it is "does ANYTHING, anywhere in the bridge, set it true".
+
+  - Parse every `typedef struct { ... } Name;` / `struct Name { ... };` in `Sources/OCCTBridge/`
+    (both `include/*.h` and `src/*.mm`/`*.h`) and collect every `bool` field each one declares.
+    Deliberately NOT filtered to a `hasX`/`isX` name: this is what teaches the "not named
+    `hasSomething`" shape (`isValid`, `defined`, `ok`, `found`, ...) the naive pass named as a blind
+    spot — any boolean struct field is a candidate gate, whatever it is called.
+  - For every function definition in the same corpus, bind local identifiers to a KNOWN struct type
+    by two shapes: a local declaration (`OCCTShapeAxis a;`) and a pointer or reference PARAMETER
+    (`OCCTShapeAxis* outAxes`, `OCCTShapeAxis& a`). The parameter form is what teaches the "flipped
+    through a pointer, reference or helper" shape: a shared helper function is just another function
+    definition in the same corpus, and if its own parameter binds the type, an assignment through it
+    (`outAxes->hasExtent = true;`) is caught exactly like a direct one, with no special-casing for
+    "this is a helper" needed at all.
+  - Within each function, match every `var.field = RHS;`, `var->field = RHS;` and
+    `var[idx].field = RHS;` assignment (a strict superset of sub-kind 1's `var.field` pattern) where
+    `var` is bound to a struct with `field` in its bool-field set. Classify the RHS `true`, `false`,
+    or COMPUTED (anything else — a call, a variable, a member access).
+  - A COMPUTED assignment to a field marks that (struct, field) as "not provably stuck" wherever it
+    is found, even if no literal `true` ever appears for it: `OCCTCurve3DValidateRange`'s
+    `result.wasAdjusted = false;` default next to `result.wasAdjusted = adjusted;` (a real
+    `ShapeAnalysis_Curve::ValidateRange` return value) is a legitimate flip through a genuine
+    computation, not a fabrication, and this is the sub-kind 3 analogue of sub-kind 1's own
+    "computed sibling" reasoning. Without this rule, the algorithm's first real run against this
+    tree over-reported by 4 sites: `wasAdjusted` and `OCCTXCAFPrsStyle.isEmpty` (assigned from
+    `style.IsEmpty()` at its two real construction sites, hardcoded `false` only at its distinct
+    "build an empty style" factory).
+  - A `true` assignment does not count as reachable evidence if it is textually UNREACHABLE by one
+    of two narrow, decidable checks (this is what teaches the "assigned true only on a path that is
+    itself unreachable" shape): (a) it sits inside an `if (false) { ... }` / `if (0) { ... }` /
+    `while (false) { ... }` block, or (b) it is preceded, within the same brace-delimited straight-
+    line block, by an unconditional `return`/`continue`/`break`/`throw` statement that STARTS its
+    own statement (immediately after a `;`, `{`, `}` or the top of the block) — a `return` inside a
+    braceless `if (cond) return x;` guard does NOT count, since it is conditional, not a straight-
+    line exit, and treating it as one produced a real false positive in this tree's own corpus (see
+    the removal matrix in the self-test below).
+  - A field is reported once it has at least one `false` site and belongs to neither the "true seen"
+    nor the "computed seen" set.
+
+WHAT SUB-KIND 3 STILL CANNOT SEE, against the four blind spots the issue named for the naive pass,
+plus what was found reading its own false positives on this tree:
+
+  - THE `kind` ENUM VARIANT OF "not named hasSomething" IS NOT TAUGHT. The issue's example bundles
+    plain bool fields under other names (`isValid`, `defined`, `ok`, `found` — all TAUGHT, since the
+    struct-field parse is not name-filtered) with "a `kind` enum with a never-emitted case" — a
+    fundamentally different question, since an enum can have arbitrarily many cases and "never
+    emitted" needs the full declared case list PLUS which case means "gate open", which is semantic,
+    not syntactic. Not attempted.
+  - A HELPER THAT TAKES THE STRUCT BY VALUE AND RETURNS A MODIFIED COPY (`T withFlagSet(T t) { t.
+    field = true; return t; } ... a = withFlagSet(a);`) is not taught: only pointer/reference
+    parameters bind a type, deliberately, since a byval parameter is a local copy that cannot affect
+    the caller's instance the way the issue's "pointer, reference or helper" phrasing describes, and
+    accepting it would raise the risk of a false negative from an orphaned byval helper that is never
+    actually called from any live path (the corpus-wide, no-call-graph nature of this census cannot
+    tell "assigned true somewhere" from "assigned true only in dead code nobody calls" either way;
+    see the Bisector finding in triage-gate-flags.md for a real instance of exactly that ambiguity,
+    resolved by removing the orphan rather than by teaching the detector call-graph reachability).
+  - A CAST-BASED ALIAS (`((OCCTShapeAxis*)ptr)->hasExtent = true;`) is not taught, the same gap
+    `check-null-handle-guards.py` documents for its own four indirection shapes (#618): the binding
+    regex looks for the type name directly adjacent to the variable, not behind a cast.
+  - A MORE ELABORATE "ALWAYS FALSE" CONDITION defeats the two unreachable-`true` checks: `if (1 ==
+    2)`, `if (SOME_FALSE_MACRO)`, `#if 0` preprocessor exclusion, or a `switch` case that is never
+    reached. Only the literal spellings `false` and `0` are recognised.
+  - THE SWIFT SIDE IS SWEPT FOR COMPUTED PROPERTIES ONLY (`swift_gate_candidates` below), per the
+    issue's own scope note ("sweep Sources/OCCTSwift too if the rule generalises cleanly, say so if
+    it does not"): a Swift `var x: Bool { ... }` with `return false` somewhere and `return true`
+    nowhere in its body is caught. A Swift STORED property mutated across multiple methods — the
+    closer analogue of the C struct case — is NOT: it would need the same corpus-wide type-binding
+    machinery applied to Swift class/struct declarations and their methods, which is a bigger lift
+    than a single self-contained function body, and was not attempted this pass. The dead-code-
+    unreachability checks (if-false, dead-after-return) are also not applied on the Swift side: Swift
+    conditionals are commonly braceless AND paren-less (`if x > 0 {`), which the C-oriented
+    `conditional_brace_positions`/`depth_segments` machinery (built around `if (...)  ` requiring
+    parens) does not parse, so the Swift detector only checks for bare `return true`/`return false`
+    literal presence, without excluding a dead one.
+
 WHAT THIS STILL CANNOT SEE, measured while adjudicating the first real run against this tree (see
 Scripts/repro/726-unmeasured-values/README.md for the full per-site table). Each of these is a
 real, observed source of noise in the candidate list, not a hypothetical:
@@ -144,9 +234,10 @@ real, observed source of noise in the candidate list, not a hypothetical:
 
 Usage (from the repo root):
 
-    python3 Scripts/census-unmeasured-values.py                 # both sub-kinds, full listing
+    python3 Scripts/census-unmeasured-values.py                 # all three sub-kinds, full listing
     python3 Scripts/census-unmeasured-values.py --production    # sub-kind 1 only
     python3 Scripts/census-unmeasured-values.py --tests         # sub-kind 2 only
+    python3 Scripts/census-unmeasured-values.py --gate-flags    # sub-kind 3 only
     python3 Scripts/census-unmeasured-values.py --quiet         # counts only
     python3 Scripts/census-unmeasured-values.py --self-test     # prove each shape is caught
 
@@ -162,6 +253,7 @@ import sys
 BRIDGE_SRC_DIR = os.path.join('Sources', 'OCCTBridge', 'src')
 BRIDGE_INCLUDE_DIR = os.path.join('Sources', 'OCCTBridge', 'include')
 TESTS_DIR = 'Tests'
+SWIFT_SRC_DIR = os.path.join('Sources', 'OCCTSwift')
 
 # ---------------------------------------------------------------------------
 # Shared: comment/string stripping, function extraction (brace-depth walk).
@@ -485,6 +577,199 @@ def test_sources():
 
 
 # ===========================================================================
+# Sub-kind 3 (#771): boolean gate flags assigned literal false somewhere and
+# literal true nowhere reachable, so whatever they gate is permanently
+# unreachable. See SUB-KIND 3 ALGORITHM in the module docstring.
+# ===========================================================================
+
+STRUCT_DEF = re.compile(
+    r'(?:typedef\s+struct\s*\{(?P<body1>.*?)\}\s*(?P<name1>\w+)\s*;)'
+    r'|(?:struct\s+(?P<name2>\w+)\s*\{(?P<body2>.*?)\}\s*;)',
+    re.S)
+BOOL_FIELD = re.compile(r'\bbool\s+([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*;')
+
+
+def struct_bool_fields(sources):
+    """{struct_name: {bool_field_name, ...}} for every typedef struct / struct definition found
+    in `sources`. Deliberately not filtered by field name (that is sub-kind 3's whole point)."""
+    out = {}
+    for path, raw in sources:
+        text = strip_comments(raw)
+        for m in STRUCT_DEF.finditer(text):
+            name = m.group('name1') or m.group('name2')
+            body = m.group('body1') if m.group('name1') else m.group('body2')
+            if not name or not body:
+                continue
+            fields = set()
+            for fm in BOOL_FIELD.finditer(body):
+                for fname in fm.group(1).split(','):
+                    fields.add(fname.strip())
+            if fields:
+                out.setdefault(name, set()).update(fields)
+    return out
+
+
+# A terminator only makes what follows dead if it STARTS its own statement (preceded by a
+# statement/block boundary: `;`, `{`, `}`, or the start of the current segment) rather than sitting
+# inside a braceless `if (cond) return x;` guard, which is conditional, not a straight-line exit.
+# The first, wrong version of this regex (`\b(?:return|...)\b[^;{}]*;` with no boundary requirement)
+# produced a real false positive on this tree's own corpus: `OCCTShapeGetProperties`'s braceless
+# `if (!shape) return result;` made the regex treat the function's later, genuine
+# `result.isValid = true;` as dead code, because nothing distinguished a guarded return from an
+# unconditional one. See the removal matrix in the self-test below.
+TERMINATOR = re.compile(r'(?:\A|[;{}])\s*(?:return|continue|break|throw)\b[^;{}]*;')
+IF_WHILE_COND = re.compile(r'\b(?:if|while)\s*\(')
+
+
+def is_dead_after_terminator(body, pos, segs):
+    """True if `pos` is preceded, within its own flat (brace-free) segment, by an unconditional
+    return/continue/break/throw that starts its own statement."""
+    for s, e, _ in segs:
+        if s <= pos < e:
+            return bool(TERMINATOR.search(body[s:pos]))
+    return False
+
+
+def false_condition_spans(body):
+    """[(open_brace_pos, close_brace_pos), ...] for every `if (false)`/`if (0)`/`while (false)`/
+    `while (0)` block: a literal always-false condition, not any conditional whatsoever."""
+    spans = []
+    for m in IF_WHILE_COND.finditer(body):
+        i, depth, cond_start = m.end(), 1, m.end()
+        while i < len(body) and depth > 0:
+            if body[i] == '(':
+                depth += 1
+            elif body[i] == ')':
+                depth -= 1
+            i += 1
+        cond = body[cond_start:i - 1].strip()
+        j = i
+        while j < len(body) and body[j] in ' \t\r\n':
+            j += 1
+        if j < len(body) and body[j] == '{' and cond in ('false', '0'):
+            depth2, k = 0, j
+            while k < len(body):
+                if body[k] == '{':
+                    depth2 += 1
+                elif body[k] == '}':
+                    depth2 -= 1
+                    if depth2 == 0:
+                        break
+                k += 1
+            spans.append((j, k))
+    return spans
+
+
+# A strict superset of sub-kind 1's FIELD_ASSIGN: also matches pointer indirection (`var->field =`)
+# and an array/pointer out-param element (`var[idx].field =`), the "flipped through a pointer,
+# reference or helper" shape.
+ASSIGN_ANY = re.compile(
+    r'\b([A-Za-z_]\w*)(?:\s*\[[^\]]*\])?\s*(?:\.|->)\s*([A-Za-z_]\w*)\s*=\s*([^=][^;]*);')
+
+
+def gate_flag_candidates(sources):
+    """(file, line, function, struct, field, snippet) for every bool struct field assigned literal
+    false somewhere and literal true nowhere reachable in `sources`."""
+    struct_fields = struct_bool_fields(sources)
+    if not struct_fields:
+        return []
+    # One combined alternation per binding shape, built once, rather than looping every known
+    # struct type over every function body (71 types x ~700 functions in this tree cost 8+ seconds
+    # done that way; this is the same information, one regex pass per function instead of 71).
+    type_alt = '|'.join(re.escape(t) for t in struct_fields)
+    param_bind = re.compile(
+        r'\b(' + type_alt + r')\s*[\*&]\s*(?:_Nonnull\s+|_Nullable\s+|const\s+)?(\w+)\b')
+    local_bind = re.compile(r'\b(' + type_alt + r')\s+([A-Za-z_]\w*)\s*(?:=|;|\{)')
+
+    false_sites = {}   # (struct, field) -> [(file, line, func, snippet), ...]
+    true_seen = set()  # (struct, field) with >=1 reachable literal-true assignment
+    computed_seen = set()  # (struct, field) with >=1 non-literal assignment anywhere
+    for path, raw in sources:
+        text = strip_comments(raw)
+        lines = raw.splitlines()
+        for name, params, bs, be in c_functions(text):
+            body = text[bs:be + 1]
+            segs = depth_segments(body)
+            dead_spans = false_condition_spans(body)
+            bindings = {}
+            for m in param_bind.finditer(params):
+                bindings[m.group(2)] = m.group(1)
+            for m in local_bind.finditer(body):
+                bindings[m.group(2)] = m.group(1)
+            if not bindings:
+                continue
+            for m in ASSIGN_ANY.finditer(body):
+                var, field, rhs = m.group(1), m.group(2), m.group(3).strip()
+                stype = bindings.get(var)
+                if not stype or field not in struct_fields.get(stype, ()):
+                    continue
+                if rhs == 'true':
+                    if is_dead_after_terminator(body, m.start(), segs) or \
+                       any(s <= m.start() < e for s, e in dead_spans):
+                        continue  # unreachable true: does not count as a real flip
+                    true_seen.add((stype, field))
+                elif rhs == 'false':
+                    line = text.count('\n', 0, bs + m.start()) + 1
+                    false_sites.setdefault((stype, field), []).append(
+                        (os.path.basename(path), line, name,
+                         lines[line - 1].strip() if line <= len(lines) else ''))
+                else:
+                    # A computed RHS (a call, a variable, a member access) could evaluate true at
+                    # runtime; the census cannot prove otherwise from text alone, so this field is
+                    # not provably stuck. See SUB-KIND 3 ALGORITHM's wasAdjusted/isEmpty note.
+                    computed_seen.add((stype, field))
+
+    found = []
+    for (stype, field), sites in false_sites.items():
+        if (stype, field) in true_seen or (stype, field) in computed_seen:
+            continue
+        for f, line, func, snippet in sites:
+            found.append((f, line, func, stype, field, snippet))
+    return found
+
+
+# --- Swift side: computed-property gate flags (indirection shape 4). ---
+
+SWIFT_BOOL_COMPUTED = re.compile(r'\bvar\s+(\w+)\s*:\s*Bool\s*\{')
+SWIFT_RETURN_LITERAL = re.compile(r'\breturn\s+(true|false)\b')
+
+
+def swift_gate_candidates(sources):
+    """(file, line, property, snippet) for every Swift `var x: Bool { ... }` computed property
+    that returns literal false somewhere in its body and literal true nowhere. Stored properties
+    mutated across multiple methods (the closer analogue of the C struct case) are not covered —
+    see SUB-KIND 3 ALGORITHM's Swift-side note."""
+    found = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        lines = raw.splitlines()
+        for m in SWIFT_BOOL_COMPUTED.finditer(text):
+            name = m.group(1)
+            start = i = m.end() - 1
+            depth = 0
+            while i < len(text):
+                if text[i] == '{':
+                    depth += 1
+                elif text[i] == '}':
+                    depth -= 1
+                    if depth == 0:
+                        break
+                i += 1
+            body = text[start:i + 1]
+            literals = {lm.group(1) for lm in SWIFT_RETURN_LITERAL.finditer(body)}
+            if 'false' in literals and 'true' not in literals:
+                line = text.count('\n', 0, m.start()) + 1
+                found.append((os.path.basename(path), line, name,
+                              lines[line - 1].strip() if line <= len(lines) else ''))
+    return found
+
+
+def swift_sources():
+    paths = sorted(glob.glob(os.path.join(SWIFT_SRC_DIR, '*.swift')))
+    return [(p, open(p, errors='ignore').read()) for p in paths]
+
+
+# ===========================================================================
 # Self-test. Each MISSED fixture must be reported; each CLEAN fixture must
 # not be. Per okf/policies/prove-the-test-fails.md, every fixture below was
 # separately proven to exercise its own guard: the mechanism was deleted from
@@ -628,9 +913,210 @@ TEST_CLEAN = [
 ]
 
 
+# Sub-kind 3 fixtures. Each is a standalone (header, source) pair: struct_bool_fields needs the
+# header's typedef to know which fields are bool at all, exactly like the real corpus split between
+# Sources/OCCTBridge/include and Sources/OCCTBridge/src.
+
+GATE_MISSED = [
+    ('hasExtent\'s pre-fix form: literal false at every call site, no computed or literal-true '
+     'sibling anywhere (the #763/#771 seed shape)', '''
+typedef struct {
+    double originX;
+    bool hasExtent;
+} OCCTFixtureAxisPreFix;
+''', '''
+void occtFixtureAxesRevolution(OCCTFixtureAxisPreFix* outAxes, int32_t maxAxes) {
+    OCCTFixtureAxisPreFix a;
+    a.originX = 1.0;
+    a.hasExtent = false;
+}
+void occtFixtureAxesSymmetry(OCCTFixtureAxisPreFix* outAxes, int32_t maxAxes) {
+    OCCTFixtureAxisPreFix a;
+    a.originX = 2.0;
+    a.hasExtent = false;
+}'''),
+    ('indirection shape 1: a gate not named hasSomething (field "defined"), assigned false at '
+     'every site and true nowhere', '''
+typedef struct {
+    double value;
+    bool defined;
+} OCCTFixtureGateNamedOk;
+''', '''
+void occtFixtureGateA(OCCTFixtureGateNamedOk* outGate) {
+    OCCTFixtureGateNamedOk g;
+    g.value = 1.0;
+    g.defined = false;
+}
+void occtFixtureGateB(OCCTFixtureGateNamedOk* outGate) {
+    OCCTFixtureGateNamedOk g;
+    g.value = 2.0;
+    g.defined = false;
+}'''),
+    ('indirection shape 2a: the only literal true is inside an if (false) block, so a plain grep '
+     'for "= true" would wrongly call this flag flipping', '''
+typedef struct {
+    double value;
+    bool reachable;
+} OCCTFixtureDeadIfFalse;
+''', '''
+void occtFixtureDeadIfFalse(OCCTFixtureDeadIfFalse* outGate) {
+    OCCTFixtureDeadIfFalse g;
+    g.value = 1.0;
+    g.reachable = false;
+    if (false) {
+        g.reachable = true;
+    }
+}'''),
+    ('indirection shape 2b: the only literal true is dead code after an unconditional return', '''
+typedef struct {
+    double value;
+    bool reachable;
+} OCCTFixtureDeadAfterReturn;
+''', '''
+void occtFixtureDeadAfterReturn(OCCTFixtureDeadAfterReturn* outGate) {
+    OCCTFixtureDeadAfterReturn g;
+    g.value = 1.0;
+    g.reachable = false;
+    return;
+    g.reachable = true;
+}'''),
+]
+
+GATE_CLEAN = [
+    ('a correctly-flipping hasExtent-named flag: literal false as the default, literal true once '
+     'real bounds are known (the negative baseline for the seed shape)', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureAxisFixed;
+''', '''
+void occtFixtureAxesFixedVoid(OCCTFixtureAxisFixed* outAxes) {
+    OCCTFixtureAxisFixed a;
+    a.value = 1.0;
+    a.hasExtent = false;
+}
+void occtFixtureAxesFixedBounded(OCCTFixtureAxisFixed* outAxes) {
+    OCCTFixtureAxisFixed a;
+    a.value = 2.0;
+    a.hasExtent = true;
+}'''),
+    ('a correctly-flipping non-hasX-named flag (field "defined"), proving the name-agnostic scan '
+     'does not over-flag an ordinary success flag once the hasX filter is dropped', '''
+typedef struct {
+    double value;
+    bool defined;
+} OCCTFixtureGateNamedOk2;
+''', '''
+void occtFixtureGateOkA(OCCTFixtureGateNamedOk2* outGate) {
+    OCCTFixtureGateNamedOk2 g;
+    g.value = 1.0;
+    g.defined = false;
+}
+void occtFixtureGateOkB(OCCTFixtureGateNamedOk2* outGate) {
+    OCCTFixtureGateNamedOk2 g;
+    g.value = 2.0;
+    g.defined = true;
+}'''),
+    ('a literal true reachable under a REAL (non-false) condition must not be misclassified as '
+     'dead code by the false-condition guard', '''
+typedef struct {
+    double value;
+    bool reachable;
+} OCCTFixtureLiveIf;
+''', '''
+void occtFixtureLiveIf(OCCTFixtureLiveIf* outGate) {
+    OCCTFixtureLiveIf g;
+    g.value = 1.0;
+    g.reachable = false;
+    if (g.value > 0) {
+        g.reachable = true;
+    }
+}'''),
+    ('indirection shape 3a: flipped only through a pointer parameter inside a shared helper, never '
+     'through dot syntax on the caller\'s own local', '''
+typedef struct {
+    double value;
+    bool computed;
+} OCCTFixturePtrFlip;
+''', '''
+static void occtFixturePtrHelper(OCCTFixturePtrFlip* g) {
+    g->computed = true;
+}
+void occtFixturePtrCaller(OCCTFixturePtrFlip* outGate) {
+    OCCTFixturePtrFlip g;
+    g.value = 1.0;
+    g.computed = false;
+    occtFixturePtrHelper(&g);
+}'''),
+    ('indirection shape 3b: flipped only through a reference parameter inside a shared helper', '''
+typedef struct {
+    double value;
+    bool computed;
+} OCCTFixtureRefFlip;
+''', '''
+static void occtFixtureRefHelper(OCCTFixtureRefFlip& g) {
+    g.computed = true;
+}
+void occtFixtureRefCaller(OCCTFixtureRefFlip* outGate) {
+    OCCTFixtureRefFlip g;
+    g.value = 1.0;
+    g.computed = false;
+    occtFixtureRefHelper(g);
+}'''),
+    ('a field with a computed (non-literal) sibling assignment is not provably stuck, even though '
+     'it is never assigned literal true (the wasAdjusted/isEmpty shape found in this tree\'s own '
+     'corpus)', '''
+typedef struct {
+    double first;
+    bool wasAdjusted;
+} OCCTFixtureValidateRange;
+''', '''
+OCCTFixtureValidateRange occtFixtureValidateRange(double first) {
+    OCCTFixtureValidateRange result = {};
+    result.first = first;
+    result.wasAdjusted = false;
+    bool adjusted = realValidate(&result.first);
+    result.wasAdjusted = adjusted;
+    return result;
+}'''),
+]
+
+SWIFT_GATE_MISSED = [
+    ('a Swift computed Bool property that returns false on every reachable path (indirection '
+     'shape 4, the seed shape mirrored on the Swift side)', '''
+    var hasBoundedExtent: Bool {
+        if value < 0 {
+            return false
+        }
+        return false
+    }'''),
+]
+
+SWIFT_GATE_CLEAN = [
+    ('the same Swift computed property, but correctly flipping', '''
+    var hasBoundedExtent: Bool {
+        if value < 0 {
+            return false
+        }
+        return true
+    }'''),
+]
+
+
 def _run_prod_fixture(src):
     sources = [('fixture.mm', src)]
     return production_candidates(sources)
+
+
+def _run_gate_fixture(header_src, source_src):
+    sources = [('fixture.h', header_src), ('fixture.mm', source_src)]
+    return gate_flag_candidates(sources)
+
+
+def _run_swift_gate_fixture(src):
+    wrapped = "struct Fixture {\n" + src + "\n}\n"
+    sources = [('fixture.swift', wrapped)]
+    return swift_gate_candidates(sources)
 
 
 def _run_test_fixture(src):
@@ -665,7 +1151,30 @@ def self_test():
         print(f'  {"ok  " if not hit else "FALSE"} should be clean, {name}: '
               f'{[h[2] for h in hit] + ["wrongly flagged"] if hit else "not flagged"}')
 
-    total = len(PROD_MISSED) + len(PROD_CLEAN) + len(TEST_MISSED) + len(TEST_CLEAN)
+    print('sub-kind 3 (gate flags that never flip):')
+    for name, header_src, source_src in GATE_MISSED:
+        hit = _run_gate_fixture(header_src, source_src)
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} should flag, {name}: '
+              f'{[(h[3], h[4]) for h in hit] if hit else "NOT REPORTED"}')
+    for name, header_src, source_src in GATE_CLEAN:
+        hit = _run_gate_fixture(header_src, source_src)
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} should be clean, {name}: '
+              f'{[(h[3], h[4]) for h in hit] + ["wrongly flagged"] if hit else "not flagged"}')
+    for name, src in SWIFT_GATE_MISSED:
+        hit = _run_swift_gate_fixture(src)
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} should flag (Swift), {name}: '
+              f'{[h[2] for h in hit] if hit else "NOT REPORTED"}')
+    for name, src in SWIFT_GATE_CLEAN:
+        hit = _run_swift_gate_fixture(src)
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} should be clean (Swift), {name}: '
+              f'{[h[2] for h in hit] + ["wrongly flagged"] if hit else "not flagged"}')
+
+    total = (len(PROD_MISSED) + len(PROD_CLEAN) + len(TEST_MISSED) + len(TEST_CLEAN) +
+             len(GATE_MISSED) + len(GATE_CLEAN) + len(SWIFT_GATE_MISSED) + len(SWIFT_GATE_CLEAN))
     print(f'{total - failed}/{total} cases correct')
     return 1 if failed else 0
 
@@ -700,10 +1209,28 @@ def report_tests(quiet):
     return 0
 
 
+def report_gate_flags(quiet):
+    if not os.path.isdir(BRIDGE_SRC_DIR):
+        print(f'{BRIDGE_SRC_DIR} not found - run from the repo root', file=sys.stderr)
+        return 2
+    bridge_sites = gate_flag_candidates(bridge_sources())
+    swift_sites = swift_gate_candidates(swift_sources()) if os.path.isdir(SWIFT_SRC_DIR) else []
+    print(f'sub-kind 3 (gate flags): {len(bridge_sites) + len(swift_sites)} candidate(s)')
+    if not quiet:
+        for f, line, func, stype, field, snippet in bridge_sites:
+            print(f'  {f}:{line}  {func}(): {stype}.{field} = false, never true')
+            print(f'      {snippet}')
+        for f, line, prop, snippet in swift_sites:
+            print(f'  {f}:{line}  var {prop}: Bool  (returns false, never true)')
+            print(f'      {snippet}')
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument('--production', action='store_true', help='sub-kind 1 only')
     ap.add_argument('--tests', action='store_true', help='sub-kind 2 only')
+    ap.add_argument('--gate-flags', action='store_true', help='sub-kind 3 only')
     ap.add_argument('--quiet', action='store_true', help='counts only')
     ap.add_argument('--self-test', action='store_true', help='prove each shape is caught')
     args = ap.parse_args()
@@ -711,12 +1238,14 @@ def main():
     if args.self_test:
         return self_test()
 
-    both = not args.production and not args.tests
+    all_kinds = not args.production and not args.tests and not args.gate_flags
     rc = 0
-    if args.production or both:
+    if args.production or all_kinds:
         rc = report_production(args.quiet) or rc
-    if args.tests or both:
+    if args.tests or all_kinds:
         rc = report_tests(args.quiet) or rc
+    if args.gate_flags or all_kinds:
+        rc = report_gate_flags(args.quiet) or rc
     return rc
 
 

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -115,32 +115,46 @@ field true", it is "does ANYTHING, anywhere in the bridge, set it true".
     `hasSomething`" shape (`isValid`, `defined`, `ok`, `found`, ...) the naive pass named as a blind
     spot: any boolean struct field is a candidate gate, whatever it is called.
   - For every function definition in the same corpus, bind local identifiers to a KNOWN struct type
-    by two shapes: a local declaration (`OCCTShapeAxis a;`) and a pointer or reference PARAMETER
-    (`OCCTShapeAxis* outAxes`, `OCCTShapeAxis& a`). The parameter form is what teaches the "flipped
-    through a pointer, reference or helper" shape: a shared helper function is just another function
-    definition in the same corpus, and if its own parameter binds the type, an assignment through it
+    by two shapes: a local declaration, value-typed (`OCCTShapeAxis a;`) OR pointer/reference-typed
+    (`OCCTShapeAxis* p = &a;`), and a pointer or reference PARAMETER (`OCCTShapeAxis* outAxes`,
+    `OCCTShapeAxis& a`). The parameter form is what teaches the "flipped through a pointer,
+    reference or helper" shape: a shared helper function is just another function definition in the
+    same corpus, and if its own parameter binds the type, an assignment through it
     (`outAxes->hasExtent = true;`) is caught exactly like a direct one, with no special-casing for
-    "this is a helper" needed at all.
+    "this is a helper" needed at all. The local-declaration form was value-typed only until #774's
+    third review round: `param_bind` already handled a pointer/reference PARAMETER, but the sibling
+    `local_bind` had no `*`/`&` branch, so a pointer or reference declared INSIDE the function body
+    (`OCCTShapeAxis* p = &a; p->hasExtent = true;`) bound nothing and the flip through `p` was
+    invisible, even though the identical shape through a parameter was already caught. Fixed by
+    giving `local_bind` the same two-branch shape `param_bind` already had (pointer/reference OR
+    plain value), rather than adding it to the list of things this pass cannot see.
   - Within each function, match every `var.field = RHS;`, `var->field = RHS;` and
     `var[idx].field = RHS;` assignment (a strict superset of sub-kind 1's `var.field` pattern) where
     `var` is bound to a struct with `field` in its bool-field set. Classify the RHS `true`, `false`,
     or COMPUTED (anything else: a call, a variable, a member access).
   - A COMPUTED assignment to a field marks that (struct, field) as "not provably stuck" wherever it
-    is found, even if no literal `true` ever appears for it: `OCCTCurve3DValidateRange`'s
+    is REACHABLE, even if no literal `true` ever appears for it: `OCCTCurve3DValidateRange`'s
     `result.wasAdjusted = false;` default next to `result.wasAdjusted = adjusted;` (a real
     `ShapeAnalysis_Curve::ValidateRange` return value) is a legitimate flip through a genuine
     computation, not a fabrication, and this is the sub-kind 3 analogue of sub-kind 1's own
     "computed sibling" reasoning. Without this rule, the algorithm's first real run against this
     tree over-reported by 4 sites: `wasAdjusted` and `OCCTXCAFPrsStyle.isEmpty` (assigned from
     `style.IsEmpty()` at its two real construction sites, hardcoded `false` only at its distinct
-    "build an empty style" factory).
-  - A `true` assignment does not count as reachable evidence if it is textually UNREACHABLE by one
-    of two narrow, decidable checks (this is what teaches the "assigned true only on a path that is
-    itself unreachable" shape): (a) it sits inside an `if (false) { ... }` / `if (0) { ... }` /
-    `while (false) { ... }` block, or (b) it is preceded, within the same brace-delimited straight-
-    line block, by an unconditional `return`/`continue`/`break`/`throw` statement that STARTS its
-    own statement (immediately after a `;`, `{`, `}` or the top of the block): a `return` inside a
-    braceless `if (cond) return x;` guard does NOT count, since it is conditional, not a straight-
+    "build an empty style" factory). The reachability qualifier was added in #774's second review
+    round: the SAME two unreachability checks the `true` branch already applies (below) now also
+    gate this branch, since a computed RHS sitting inside `if (false) { field = someCall(); }` is
+    not "maybe true at runtime" either, it is "never runs at all", and treating it as live evidence
+    would exempt a field that is permanently `false` in the code that actually executes, the
+    identical unreachable-write-masks-a-stuck-gate shape as the `true` branch's own gap, left open
+    one branch over until this fix.
+  - A `true` assignment (and, since the fix above, a COMPUTED one) does not count as reachable
+    evidence if it is textually UNREACHABLE by one of two narrow, decidable checks (this is what
+    teaches the "assigned true only on a path that is itself unreachable" shape): (a) it sits inside
+    an `if (false) { ... }` / `if (0) { ... }` / `while (false) { ... }` block, braced or braceless,
+    or (b) it is preceded, within the same brace-delimited straight-line block, by an unconditional
+    `return`/`continue`/`break`/`throw` statement that STARTS its own statement (immediately after a
+    `;`, `{`, `}` or the top of the block): a `return` inside a braceless `if (cond) return x;`
+    guard does NOT count, since it is conditional, not a straight-
     line exit, and treating it as one produced a real false positive in this tree's own corpus (see
     the removal matrix in the self-test below).
   - A field is reported once it has at least one `false` site and belongs to neither the "true seen"
@@ -826,7 +840,16 @@ def gate_flag_candidates(sources):
     type_alt = '|'.join(re.escape(t) for t in struct_fields)
     param_bind = re.compile(
         r'\b(' + type_alt + r')\s*[\*&]\s*(?:_Nonnull\s+|_Nullable\s+|const\s+)?(\w+)\b')
-    local_bind = re.compile(r'\b(' + type_alt + r')\s+([A-Za-z_]\w*)\s*(?:=|;|\{)')
+    # A local declaration binds either a plain value (`OCCTShapeAxis a;`, needs the `\s+` branch,
+    # since nothing else separates the type from the name) or a pointer/reference
+    # (`OCCTShapeAxis* p = &a;` / `OCCTShapeAxis *p;`, needs the `[\*&]` branch, which absorbs
+    # whitespace on either side of the sigil so both spellings match). Originally value-typed only;
+    # a local pointer/reference bound nothing, so `p->hasExtent = true;` through a local alias was
+    # invisible even though param_bind already handled the identical shape for a parameter
+    # (#774's third review round).
+    local_bind = re.compile(
+        r'\b(' + type_alt + r')(?:\s*[\*&]\s*(?:_Nonnull\s+|_Nullable\s+|const\s+)?|\s+)'
+        r'([A-Za-z_]\w*)\s*(?:=|;|\{)')
 
     false_sites = {}   # (struct, field) -> [(file, line, func, snippet), ...]
     true_seen = set()  # (struct, field) with >=1 reachable literal-true assignment
@@ -863,7 +886,14 @@ def gate_flag_candidates(sources):
                 else:
                     # A computed RHS (a call, a variable, a member access) could evaluate true at
                     # runtime; the census cannot prove otherwise from text alone, so this field is
-                    # not provably stuck. See SUB-KIND 3 ALGORITHM's wasAdjusted/isEmpty note.
+                    # not provably stuck. See SUB-KIND 3 ALGORITHM's wasAdjusted/isEmpty note. But
+                    # that only holds if this assignment is itself reachable: a computed RHS sitting
+                    # in the identical dead code the `true` branch already excludes is not "maybe
+                    # true at runtime" either, it is "never runs at all", the same unreachable-
+                    # write-masks-a-stuck-gate shape, one branch over (#774's second review round).
+                    if is_dead_after_terminator(body, m.start(), segs) or \
+                       any(s <= m.start() < e for s, e in dead_spans):
+                        continue  # unreachable computed assignment: not "maybe true", just dead
                     computed_seen.add((stype, field))
 
     found = []
@@ -1214,6 +1244,22 @@ void occtFixtureDeadIfFalseBraceless(OCCTFixtureDeadIfFalseBraceless* outGate) {
     g.reachable = false;
     if (false) g.reachable = true;
 }'''),
+    ('indirection shape 2d: the only non-literal (computed) assignment is inside dead code. The '
+     'reachability check was wired into the rhs == true branch only, so a computed RHS sitting in '
+     'the same if (false) block was marked "not provably stuck" with no reachability check at all', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureDeadComputed;
+''', '''
+void occtFixtureDeadComputed(OCCTFixtureDeadComputed* outGate) {
+    OCCTFixtureDeadComputed g;
+    g.value = 1.0;
+    g.hasExtent = false;
+    if (false) {
+        g.hasExtent = occtSomeLegacyComputation();
+    }
+}'''),
 ]
 
 GATE_CLEAN = [
@@ -1312,6 +1358,22 @@ OCCTFixtureValidateRange occtFixtureValidateRange(double first) {
     bool adjusted = realValidate(&result.first);
     result.wasAdjusted = adjusted;
     return result;
+}'''),
+    ('indirection shape 5: flipped through a LOCAL pointer variable declared inside the function '
+     'body (OCCTFixtureLocalPointer* p = &a; p->hasExtent = true;), not a parameter. param_bind '
+     'already handled a pointer/reference PARAMETER, but local_bind only matched plain '
+     'value-typed local declarations, so a local alias bound nothing and the flip was invisible', '''
+typedef struct {
+    double value;
+    bool hasExtent;
+} OCCTFixtureLocalPointer;
+''', '''
+void occtFixtureLocalPointer(OCCTFixtureLocalPointer* outGate) {
+    OCCTFixtureLocalPointer a;
+    a.value = 1.0;
+    a.hasExtent = false;
+    OCCTFixtureLocalPointer* p = &a;
+    p->hasExtent = true;
 }'''),
 ]
 

--- a/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
+++ b/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
@@ -1,4 +1,4 @@
-# OCCTSwift#771: sub-kind 3 (gate flags that never flip) — census run and triage
+# OCCTSwift#771: sub-kind 3 (gate flags that never flip), census run and triage
 
 ## Baseline
 
@@ -7,10 +7,10 @@ Two baselines matter here, because the branch moved under this work.
 Branched from `origin/refactor/381-pass1b` at `809f148`, where PR #770 (the `hasExtent` fix) was
 still open. Sub-kind 3 was built and its first real run against the corpus was taken against that
 pre-#770 tree: 7 candidates, including all three `hasExtent` call sites, exactly what a correct
-detector should report against code that has the defect. **PR #770 merged partway through this
-work** (`ad1078e`, `2026-08-07T17:57:52Z`). `origin/refactor/381-pass1b` was merged into this branch
-afterward to pick up the fix, and every number below the "First run" note is taken **after** that
-merge, against the corpus with `hasExtent` already fixed.
+detector should report against code that has the defect. PR #770 merged partway through this work
+(`ad1078e`, 2026-08-07T17:57:52Z). `origin/refactor/381-pass1b` was merged into this branch
+afterward to pick up the fix, and every number below the first-run note is taken after that merge,
+against the corpus with `hasExtent` already fixed.
 
 The self-test does not depend on either baseline: every sub-kind 3 fixture is a synthetic
 (header, source) pair, not a read of the live tree, so `hasExtent`'s pre-fix shape stays available
@@ -20,149 +20,234 @@ as a positive case regardless of what the real corpus looks like after #770.
 
 A boolean field, declared on any `typedef struct { ... } Name;` / `struct Name { ... };` in
 `Sources/OCCTBridge/` (not filtered by field name), that is assigned literal `false` somewhere in
-the corpus and literal `true` nowhere reachable — reachable meaning not inside an `if (false)` /
-`if (0)` / `while (false)` / `while (0)` block, and not dead code following an unconditional
-`return`/`continue`/`break`/`throw` in the same straight-line block. A field with any non-literal
-(computed) assignment anywhere is treated as not provably stuck, since the census cannot evaluate
-whether that expression can produce `true`. Binding a local identifier to a known struct type
-recognises a plain local declaration and a pointer or reference parameter, so a shared helper that
-flips the field through `->`/`&` is caught with no special-casing for "this is a helper". A separate,
-narrower detector covers the Swift side: a `var x: Bool { ... }` computed property that returns
-`false` somewhere and `true` nowhere in its body.
+the corpus and literal `true` nowhere reachable. Reachable excludes an `if (false)` / `if (0)` /
+`while (false)` / `while (0)` block (braced or braceless, see the second review round below) and
+dead code following an unconditional `return`/`continue`/`break`/`throw` in the same straight-line
+block. A field with any non-literal (computed) assignment anywhere is treated as not provably
+stuck, since the census cannot evaluate whether that expression can produce `true`. Binding a local
+identifier to a known struct type recognises a plain local declaration and a pointer or reference
+parameter, so a shared helper that flips the field through `->`/`&` is caught with no
+special-casing for "this is a helper". A separate, narrower detector covers the Swift side: a
+`var x: Bool { ... }` computed property that returns `false` somewhere and `true` nowhere in its
+body.
 
 Full algorithm and worked examples are in `Scripts/census-unmeasured-values.py`'s module docstring,
 under `SUB-KIND 3 ALGORITHM`.
 
 ## What it does not detect, and why
 
-Recorded in the script's own `WHAT SUB-KIND 3 STILL CANNOT SEE` section; summarised here:
-
 | Gap | Why not taught |
 |---|---|
-| A `kind`-style enum with a never-emitted "gate open" case | Needs the full declared case list per enum plus which case means "open", which is semantic, not syntactic — a fundamentally different question from a 2-valued bool. |
-| A helper that takes the struct **by value** and returns a modified copy | Only pointer/reference parameters bind a type, deliberately: a byval parameter cannot affect the caller's instance the way "pointer, reference or helper" describes, and accepting it raises the risk of crediting an orphaned, never-called byval helper as if it were live evidence. |
+| A `kind`-style enum with a never-emitted "gate open" case | Needs the full declared case list per enum plus which case means "open", which is semantic, not syntactic, a fundamentally different question from a 2-valued bool. |
+| A helper that takes the struct by value and returns a modified copy | Only pointer/reference parameters bind a type, deliberately: a byval parameter cannot affect the caller's instance the way "pointer, reference or helper" describes, and accepting it raises the risk of crediting an orphaned, never-called byval helper as if it were live evidence. |
 | A cast-based alias (`((T*)ptr)->field = true;`) | Same gap `check-null-handle-guards.py` documents for its own four indirection shapes (#618): the binding regex looks for the type name directly adjacent to the variable, not behind a cast. |
 | A more elaborate always-false condition (`if (1 == 2)`, a false-valued macro, `#if 0`, an unreached `switch` case) | Only the literal spellings `false` and `0` are recognised as an always-false condition. |
-| A Swift **stored** property mutated across multiple methods | The closer analogue of the C struct case, but it would need the same corpus-wide type-binding machinery applied to Swift class/struct declarations and their methods — a bigger lift than a single self-contained function body, not attempted this pass. |
+| A Swift stored property mutated across multiple methods | The closer analogue of the C struct case, but it would need the same corpus-wide type-binding machinery applied to Swift class/struct declarations and their methods, a bigger lift than a single self-contained function body, not attempted this pass. |
 | Swift dead-code exclusion (if-false / dead-after-return) | Swift conditionals are commonly braceless and paren-less (`if x > 0 {`), which the C-oriented brace/paren-counting machinery does not parse, so the Swift detector only checks for bare `return true`/`return false` literal presence. |
-| Call-graph reachability in general | The census is corpus-wide and per-function, not whole-program: a `true` assignment inside a function that is itself never called anywhere is still counted as "the field can be true". See the Bisector finding below for a real instance of exactly this ambiguity. |
+| Call-graph reachability in general | The census is corpus-wide and per-function, not whole-program: a `true` assignment inside a function that is itself never called anywhere is still counted as "the field can be true". See the Bisector finding below for a real instance of exactly that ambiguity. |
 
-## Self-test and removal matrix
+## Second review round: four confirmed gaps, all fixed
 
-25/25 cases pass: the 10 pre-existing sub-kind 1/2 cases plus 3 new sub-kind 1 cases (see the
-sub-kind 1 improvement below), plus 12 new sub-kind 3 cases (4 `GATE_MISSED`, 6 `GATE_CLEAN`, 1
-`SWIFT_GATE_MISSED`, 1 `SWIFT_GATE_CLEAN`).
+Two rounds of review landed on PR #774, four distinct findings, all in the detector logic itself
+rather than in the adjudication. Each was closed the same way, per
+`okf/policies/prove-the-test-fails.md`: a self-test case added first, confirmed to fail against the
+unfixed code, then the fix applied and the case confirmed to pass.
 
-Per `okf/policies/prove-the-test-fails.md`, every mechanism this PR added was disabled in turn in a
-working copy of the script, `--self-test` re-run, the case-count drop recorded, and the file
-restored from an untouched backup before the next probe. Twelve rows, none decorative — every one
-drops the correct-case count and no two rows are redundant:
+1. **`false_condition_spans()` only recognised a braced always-false block.** A braceless
+   `if (false) field = true;` was not spanned, so the flip counted as reachable and a genuinely
+   stuck flag would have gone unreported. Fixed: the function now also matches the braceless form,
+   the guarded statement running from the condition to its own top-level `;`.
+2. **The store-into-a-container protection matched dot notation only, never `outVec->push_back(a)`.**
+   A struct stored through a pointer out-param fell through and could be wrongly classified
+   `is_input_only_struct`, excluding a genuine result, the seed `hasExtent` shape one indirection
+   further out. Fixed by unifying the check into `call_arg_lists`, which does not care what
+   precedes the call.
+3. **`CALL_START` had no keyword exclusion**, unlike `c_functions()`, which excludes
+   `if`/`for`/`while`/`switch`/`catch`/`return`. So `if (...)`, `for (...)` and `sizeof(...)` were
+   treated as argument lists; `sizeof(result)` is not a call at all and cannot consume anything, yet
+   excluded `result` from candidacy. Fixed: `call_arg_lists` now excludes `NOT_A_FUNCTION` plus
+   `sizeof`.
+4. **The store-call check only matched a single-argument form**, so `insert(iterator, value)`,
+   `std::vector::insert`'s standard idiom, did not match, despite `insert` being named as protected.
+   Fixed by the same unification as (2): the check now searches the whole argument text for a bare
+   `var` token, not just a sole argument.
+
+### Removal matrix, all seventeen mechanisms
+
+25 self-test cases before this round became 30 after (3 new sub-kind 1 cases for findings 2 to 4,
+plus one further case described below, plus 1 new sub-kind 3 case for finding 1). Every mechanism
+sub-kind 3 and sub-kind 1's config-struct exclusion rely on was disabled in turn in a working copy
+of the script, `--self-test` re-run, the case-count drop recorded, and the file restored from an
+untouched backup before the next probe:
 
 | # | Rule disabled | Cases correct | What flipped |
 |---|---|---|---|
-| — | (baseline) | 25/25 | — |
-| 1 | Sub-kind 3: name-prefix independence (bool-field scan restricted to `has*`) | 22/25 | 3 MISSED cases stop being flagged: the seed shape's non-`has` sibling (field `defined`) plus the two dead-`true` cases, which incidentally also use a non-`has` field name |
-| 2 | Sub-kind 3: dead-after-terminator exclusion | 24/25 | 1: the dead-after-`return` MISSED case stops being flagged |
-| 3 | Sub-kind 3: dead-if-false exclusion | 24/25 | 1: the `if (false)` MISSED case stops being flagged |
-| 4 | Sub-kind 3: pointer/reference parameter binding | 23/25 | 2: both helper-indirection CLEAN cases (pointer, reference) become **wrongly flagged** |
-| 5 | Sub-kind 3: local value-typed declaration binding | 21/25 | 4: every sub-kind 3 MISSED case stops being flagged |
-| 6 | Sub-kind 3: computed-sibling exclusion | 24/25 | 1: the `wasAdjusted`-shaped CLEAN case becomes **wrongly flagged** |
-| 7 | Sub-kind 3: Swift computed-property detection | 24/25 | 1: the Swift MISSED case stops being flagged |
-| 8a | Sub-kind 1: whole `is_input_only_struct` config-struct exclusion | 24/25 | 1: the config/options-struct CLEAN case becomes **wrongly flagged** |
-| 8b | Sub-kind 1: `push_back`-family protection inside that exclusion | 24/25 | 1: the pre-existing `ShapeAxis`-shaped MISSED case **regresses** (the exact seed shape this whole census exists to catch) |
-| 8c | Sub-kind 1: bare-`return` protection inside that exclusion | 24/25 | 1: a dedicated "handed to a call AND returned" MISSED case stops being flagged |
-| 8d | Sub-kind 1: array-element-assignment protection inside that exclusion | 24/25 | 1: a dedicated "handed to a call AND copied into an array element" MISSED case stops being flagged |
-| 8e | Sub-kind 1: `call_arg_lists`'s paren-depth balancing (swapped for a naive `[^()]*` capture) | 24/25 | 1: the config/options-struct CLEAN case becomes **wrongly flagged** again, for a different reason than 8a — the real corpus check confirms this isn't synthetic-only: the naive regex still excludes the one config-struct site with no nested cast (`MathInteg::KronrodConfig`) but wrongly re-includes all four `BRepGraph::ShapesView::Options` sites, each of which passes `opts` behind a `*(const TopoDS_Shape*)shape` cast argument — sub-kind 1's report count moves 49 → 53 |
+| - | (baseline) | 30/30 | - |
+| 1 | Sub-kind 3: name-prefix independence | 25/30 | 4 MISSED cases stop being flagged (the seed's non-`has` sibling, both dead-`true` cases, and the new braceless case, since all three happen to also use a non-`has` field name) |
+| 2 | Sub-kind 3: dead-after-terminator exclusion | 29/30 | 1 MISSED case stops being flagged |
+| 3 | Sub-kind 3: dead-if-false exclusion, whole mechanism | 28/30 | 2 MISSED cases stop being flagged (both the braced and the braceless form) |
+| 4 | Sub-kind 3: pointer/reference parameter binding | 27/30 | 2 CLEAN cases become wrongly flagged |
+| 5 | Sub-kind 3: local value-typed declaration binding | 24/30 | all 5 sub-kind 3 MISSED cases stop being flagged |
+| 6 | Sub-kind 3: computed-sibling exclusion | 28/30 | 1 CLEAN case becomes wrongly flagged |
+| 7 | Sub-kind 3: Swift computed-property detection | 28/30 | 1 Swift MISSED case stops being flagged |
+| 8a | Sub-kind 1: whole config-struct exclusion | 28/30 | 1 CLEAN case becomes wrongly flagged |
+| 8b | Sub-kind 1: whole store-family protection | 27/30 | 3 MISSED cases stop being flagged (the original `push_back` seed shape, the new arrow-notation case, and the new multi-argument `insert` case) |
+| 8c | Sub-kind 1: bare-`return` protection | 29/30 | 1 MISSED case stops being flagged, the "handed to a call AND returned" case |
+| 8d | Sub-kind 1: array-element-assignment protection | 29/30 | 1 MISSED case stops being flagged, the "handed to a call AND copied into an array element" case |
+| 8e | Sub-kind 1: paren-depth-balanced argument scan (swapped for naive `[^()]*`) | 27/30 | 2 CLEAN/MISSED cases affected: the config-struct case wrongly flagged again, and the multi-argument `insert` case stops being flagged, since `collected.end()` also has nested parens the naive scan cannot see past. Confirmed on the real corpus too: report count moves 49 to 53. |
+| 9 | Sub-kind 3: braceless if-false specifically (braced form left intact) | 29/30 | 1 MISSED case stops being flagged, the braceless one only; the braced case (row 3's sibling) stays correct |
+| 10 | Sub-kind 1: arrow-notation recognition specifically (dot-only reinstated) | 29/30 | 1 MISSED case stops being flagged, the pointer-container case only; the dot-notation seed case and the multi-argument case both stay correct |
+| 11 | Sub-kind 1: multi-argument recognition specifically (single-argument-only reinstated) | 29/30 | 1 MISSED case stops being flagged, the two-argument `insert` case only |
+| 12 | Sub-kind 1: `CALL_START` keyword/`sizeof` exclusion | 29/30 | 1 MISSED case stops being flagged, the `sizeof` case |
+| 13 | Sub-kind 1: `FIELD_ASSIGN` arrow/array-index matching (dot-only reinstated) | 29/30 | 1 MISSED case stops being flagged, the pointer-out-param result case |
 
-Three sub-kind-3 self-test cases — the two correctly-flipping baselines (`hasExtent`-named and
-non-`has`-named) and the "reachable `true` under a real condition" control — are not tied to any
-single row above; they instead guard the base recognition path itself (plain `var.field = true`
-matching, and the false-condition check not over-firing on a genuine condition) and would only fail
-if that shared foundation broke, which every row implicitly exercises by relying on it. This is
-recorded rather than left implicit: a self-test case can look like coverage without a removal
-proving it (#744), and this review explicitly asked whether any case's rule could be deleted without
-the count dropping. None of the 25 cases has that property: every one either appears as a
-MISSED/FALSE flip in a row above, or is one of these three explicitly-noted controls whose failure
-mode is "the shared foundation broke", not "no rule was ever exercised".
+Every row drops the count and no two rows are redundant. Three sub-kind-3 CLEAN cases (the two
+correctly-flipping baselines and the "reachable true under a real condition" control) are not tied
+to a single row; they guard the shared base-recognition path every row relies on and would only
+fail if that broke. Recorded explicitly, per the review's own question about whether any case's
+rule could be deleted without the count dropping: none of the 30 has that property.
 
-## Candidates found and verdicts (post-#770-merge baseline)
+## Third finding, same review, sub-kind 1's own core mechanism
 
-3 candidates from `--gate-flags` against the current baseline. Adjudicated using #763's four
-verdicts (1. not an instance, 2. compute it, 3. make absence representable, 4. remove the field):
+The review also asked whether the same braceless and arrow-notation gaps exist in sub-kind 1 and
+sub-kind 2, not just sub-kind 3, since findings 2 and 4 were already sub-kind 1 issues and the split
+was not clean.
+
+**Braceless-if in sub-kind 1's core (the original, pre-#774 literal-vs-computed-sibling algorithm,
+not the new exclusion):** not applicable. That algorithm has no reachability concept at all; its
+`conditional_brace_positions`/`depth_segments` machinery exists for depth-matching sibling fields,
+a different question, and a braceless `if` simply does not add depth there, an already-documented
+characteristic ("CONDITIONAL DEPTH IS A COUNT, NOT AN IDENTITY") predating this review, not a
+new silent-miss risk of the same shape as finding 1.
+
+**Arrow notation in sub-kind 1's core: yes, and it was real.** `FIELD_ASSIGN`, the regex the whole
+literal-vs-computed-sibling algorithm is built on, matched dot notation only
+(`\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*=\s*([^=][^;]*);`), unlike sub-kind 3's `ASSIGN_ANY`, which
+already handled dot, arrow and array-index. A result struct built through an out-param pointer
+(`out->field = ...;`, common in this bridge: `OCCTBridge_AIS.mm`, `OCCTBridge_Geom2d.mm`) or an
+array element (`out[i].field = ...;`) was invisible to sub-kind 1 from the start, a silent
+under-report of exactly the kind this whole review is about. Fixed: `FIELD_ASSIGN` now matches the
+same three shapes `ASSIGN_ANY` does. A dedicated self-test case (row 13 above) proves it, modelled
+on a real site, `OCCTBridge_Geom2d.mm`'s `extractBisecSolution`.
+
+**Sub-kind 2 (Swift): neither gap applies, verified against Swift's own grammar, not assumed.**
+Swift requires braces on every `if`/`while`/`for` body; there is no braceless form for the parser to
+accept, so a braceless-if analogue cannot occur in Swift source at all. Swift also has no `->`
+operator; member access is always `.`, including through optional chaining. Both gaps are
+structurally impossible in the language sub-kind 2 scans, not merely unobserved in this corpus.
+
+## Candidates found and verdicts
+
+### Sub-kind 3, current (post-#770-merge) baseline: 3 candidates
 
 | Candidate | Struct.field | Verdict | Evidence |
 |---|---|---|---|
-| `OCCTBridge_Mesh.mm:201` `OCCTMeshParametersDefault` | `OCCTMeshParameters.relative` | **1 (not an instance)** | `OCCTMeshParametersDefault()` is a plain default-value factory for a config/options struct passed as an **argument** to `OCCTShapeCreateMeshWithParams`, not read back as a measurement — the same "local config/options struct" and "plain value-type constructor" exclusions sub-kind 1's own docstring already establishes for `OCCTXCAFPrsStyleCreate`. Confirmed genuinely settable, not stuck: `Sources/OCCTSwift/Mesh.swift`'s `MeshParameters` has a public, mutable `var relative: Bool` that a caller sets directly, and `params.relative = relative` (`Mesh.swift:87`) forwards it into the bridge struct at the real call site. |
-| `OCCTBridge_Mesh.mm:205` `OCCTMeshParametersDefault` | `OCCTMeshParameters.adjustMinSize` | **1 (not an instance)** | Same reasoning; `Mesh.swift:91` (`params.adjustMinSize = adjustMinSize`). |
-| `OCCTBridge_Mesh.mm:206` `OCCTMeshParametersDefault` | `OCCTMeshParameters.allowQualityDecrease` | **1 (not an instance)** | Same reasoning; `Mesh.swift:92` (`params.allowQualityDecrease = allowQualityDecrease`). |
+| `OCCTBridge_Mesh.mm:201` `OCCTMeshParametersDefault` | `OCCTMeshParameters.relative` | 1, not an instance | `OCCTMeshParametersDefault()` is a plain default-value factory for a config/options struct passed as an argument to `OCCTShapeCreateMeshWithParams`, not read back as a measurement. Confirmed genuinely settable: `Sources/OCCTSwift/Mesh.swift`'s `MeshParameters` has a public, mutable `var relative: Bool`, and `params.relative = relative` (`Mesh.swift:87`) forwards it at the real call site. |
+| `OCCTBridge_Mesh.mm:205` `OCCTMeshParametersDefault` | `OCCTMeshParameters.adjustMinSize` | 1, not an instance | Same reasoning; `Mesh.swift:91`. |
+| `OCCTBridge_Mesh.mm:206` `OCCTMeshParametersDefault` | `OCCTMeshParameters.allowQualityDecrease` | 1, not an instance | Same reasoning; `Mesh.swift:92`. |
 
-**No verdict-3/verdict-4 instance beyond the seed `hasExtent`, which #770 already fixed.** Before
-the #770 merge, this same run also reported `OCCTShapeAxis.hasExtent` at all three call sites
-(verdict 3, already fixed there) and `OCCTBisectorPointOnBis.isInfinite` (verdict 4, fixed in this
-PR, see below) — 7 candidates total pre-merge, now 3. The `hasExtent` disappearance is the expected,
-correct effect of merging in a fix that shipped on a sibling branch, not something this detector did
-wrong: **not an instance of it undercounting**, it is the census correctly reflecting a corpus that
-changed underneath it.
-
-What the detector would have caught had `hasExtent` not already had a fix in flight: exactly the
-`GATE_MISSED` self-test shape it does catch, run against real code — three literal-`false` call
-sites, one struct type, zero literal-`true` or computed assignments anywhere in the corpus, reported
-by file and line with no name-prefix filtering required to find it. That shape is preserved as a
-synthetic self-test fixture specifically so this detector keeps a real positive case even now that
-the live tree no longer has one.
+`OCCTShapeAxis.hasExtent` no longer appears, fixed on #770, already merged into this base. Before
+that merge, this same detector's first real run against the corpus reported exactly the three
+`hasExtent` call sites plus one further genuine finding, described next.
 
 ### `BisectorPoint`/`OCCTBisectorPointOnBis`/`OCCTBisectorPointOnBisCreate` removed (verdict 4)
 
-Found against the pre-#770-merge baseline (unaffected by the merge; unrelated file). Verified
-independently before removing (`okf/policies/measure-dont-assume.md`), not just cited from #763's
-earlier one-line note on the same function: read `Bisector_PointOnBis.hxx` from the pinned OCCT
-xcframework headers directly. The OCCT class has a real, settable `IsInfinite`/`IsInfinite() const`
-pair — the concept is genuine — but `OCCTBisectorPointOnBisCreate` never constructs a
-`Bisector_PointOnBis` at all; it echoes 6 raw doubles into a plain C struct with no reference to the
-OCCT class. Grepped the whole tree: zero Swift call sites for the bridge function, zero constructor
-call sites for the Swift `BisectorPoint` struct it built for, and `BisectorPoint` has no explicit
-`public init` (only `public let` fields), so Swift's auto-synthesized memberwise initializer for a
-`public struct` is `internal`, not `public` — no external consumer of `OCCTSwift` could construct
-one either. Fully orphaned on both sides, matching the #506/PR #547 precedent ("an orphan freezes
-its contract") in this same codebase.
+Found against the pre-#770-merge baseline. Verified independently before removing
+(`okf/policies/measure-dont-assume.md`), not just cited from #763's earlier one-line note on the
+same function: read `Bisector_PointOnBis.hxx` from the pinned OCCT xcframework headers directly.
+The OCCT class has a real, settable `IsInfinite`/`IsInfinite() const` pair, the concept is genuine,
+but `OCCTBisectorPointOnBisCreate` never constructs a `Bisector_PointOnBis` at all; it echoes 6 raw
+doubles into a plain C struct with no reference to the OCCT class. Grepped the whole tree: zero
+Swift call sites for the bridge function, zero constructor call sites for the Swift `BisectorPoint`
+struct it built for, and `BisectorPoint` has no explicit `public init` (only `public let` fields),
+so Swift's auto-synthesized memberwise initializer for a `public struct` is `internal`, not
+`public`, so no external consumer of `OCCTSwift` could construct one either. Fully orphaned on both
+sides, matching the #506/PR #547 precedent ("an orphan freezes its contract") in this same
+codebase.
 
-Removed: the bridge struct + function (`OCCTBridge_Geom2d.h`/`.mm`, tombstone comments in the
+Removed: the bridge struct and function (`OCCTBridge_Geom2d.h`/`.mm`, tombstone comments in the
 `#500`/`#506` idiom already used elsewhere in that header), the Swift struct
 (`BisectorResult.swift`), and its two doc references (`docs/reference/Shape-Recognition.md`,
-`docs/API_REFERENCE.md`'s Bisector Intersection row count 2 → 1). `BisectorIntersection`/
+`docs/API_REFERENCE.md`'s Bisector Intersection row count 2 to 1). `BisectorIntersection`/
 `bisectorIntersections(a:b:c:d:)`, the live pair in the same file, are untouched.
 `Scripts/count-operations.py`'s derived total is unaffected (4306 before and after): `BisectorPoint`
 had no public `func`/computed `var`/`init`/`subscript`, so it was never counted.
 
-**No injection cycle for this fix**, matching PR #770's own precedent for the `selfIntersectionCount`
-removal: it is a field/type deletion enforced by the compiler (any surviving reference fails to
-build), not a new positive behavioural check to prove wrong-then-right.
+No injection cycle for this fix, matching PR #770's own precedent for the `selfIntersectionCount`
+removal: it is a field/type deletion enforced by the compiler, not a new positive behavioural check.
 
-## Bonus finding folded in: sub-kind 1's option-struct false positives
+### Sub-kind 1: 49 to 73 candidates once `FIELD_ASSIGN` sees arrow/array-index, 24 new lines adjudicated
 
-Not part of #771's own ask, but surfaced while adjudicating sub-kind 1's other candidates for
-comparison and cheap enough to fix in the same script, in the same PR. The single largest group of
-noise in sub-kind 1's 54 pre-fix candidates was a local config/options struct built and handed to a
-call as an argument (`opts.Flatten = true;` then `Add(shape, opts)`), which is syntactically
-identical to a real result struct being built up field by field — the script's own docstring had
-already named this exact shape as an unaddressed blind spot, with 5 known sites
-(`BRepGraph::ShapesView::Options` x4, `MathInteg::KronrodConfig` x1).
+Fixing sub-kind 1's own arrow-notation gap (above) surfaced 24 new candidates. New candidates are
+the point, not a complication, so all 24 are adjudicated here rather than left as a raw count.
 
-**Fixed**, `is_input_only_struct()`: a tracked local variable is excluded from sub-kind 1 candidacy
-if it is handed to some call as a bare argument and never surfaces afterward — "surfaces" meaning a
-bare `return var;`, storage into a container (`push_back`/`emplace_back`/`push_front`/
-`emplace_front`/`insert`), or a direct `arr[i] = var;` copy into an array/vector element. Any one of
-those three protections wins over the exclusion. This had to be built carefully rather than
-naively, for two reasons proven by the removal matrix above: (1) the exact seed shape this whole
-census exists to catch, `OCCTShapeAxis a` built in a loop then `collected.push_back(a)`, is *also*
-"handed to a call as a bare argument" (to `push_back`) — a naive version of this rule would have
-made sub-kind 1 blind to the seed defect it was built to find, in the unsafe direction #726
-explicitly warns this whole workstream against; and (2) a naive `[^()]*` argument-list capture
-cannot see an argument sitting behind a nested cast (`Add(*(const TopoDS_Shape*)shape, opts)`), so
-3 of the 5 real sites would have gone unexcluded without a proper paren-depth-matched extractor
-(`call_arg_lists`, reusing the same balanced-walk style `catch_spans`/`conditional_brace_positions`
-already use for braces).
+**Verdict 1, not an instance, structural (10 of 16 `qualifier = 0` sites):**
+`OCCTGccCircle2d2PtRad`, `OCCTGccCircle2d3Pt`, `OCCTGccAnaLin2dBisec`, `OCCTGccAnaLin2dTanParPt`,
+`OCCTGccAnaLin2dTanPerPtLin`, `OCCTGccAnaLin2dTanOblPt` (`OCCTBridge_Geom2d.mm`) take no
+qualifier-shaped input at all (pure point/multi-point constructions, where "inside/outside" has no
+meaning), so `qualifier = 0` there is structural, the same shape as the Bisector `radius = 0` for a
+line case below.
 
-Measured: sub-kind 1's report count on this tree drops from 54 to 49 candidates — exactly the 5
-known sites, confirmed by diffing the full before/after listing rather than just the totals; nothing
-else in the list moved.
+**Verdict 2, compute it (10 of 16 `qualifier = 0` sites, filed as #781):**
+`OCCTGccCircle2d2TanPt`, `OCCTGccCircle2dTanCen`, `OCCTGccCircle2d2TanRad`,
+`OCCTGccCircle2dTanPtRad`, `OCCTGccLine2d2Tan`, `OCCTGccLine2dTanPt`,
+`OCCTGccAnaCirc2d2TanOnLinLin`, `OCCTGccAnaCirc2dTanOnRadLin`, `OCCTGeom2dGccCirc2d2TanOn`,
+`OCCTGeom2dGccCirc2dTanOnRad` each take a real qualifier/position input yet report `qualifier = 0`
+for every solution. Confirmed genuinely computable: `Geom2dGcc_Circ2dTanCen::WhichQualifier(Index,
+GccEnt_Position&)` and `Geom2dGcc_Circ2d3Tan::WhichQualifier(Index, Position&, Position&,
+Position&)` both exist in the pinned OCCT headers, and four sibling functions in the same file
+already call an equivalent accessor and assign a real value. Not fixed in this PR: the ten sites
+need per-function OCCT-header verification and a resolved design question (the two-input-qualifier
+functions have no obvious single-field mapping), out of proportion to a detector-fix PR. Filed as
+issue #781.
+
+**Verdict 1, not an instance, confirmed by reading (4 more sites):**
+- `OCCTAnalyzePointCloud` (`OCCTBridge_Spatial.mm`): `outResult->type = 0/1/2/3` across four
+  `if`/`else if`/`else` branches, a branch-selected classification tag, a different literal per
+  branch, not a fabrication.
+- `OCCTGeomFillConstrainedInfo` (`OCCTBridge_Surface.mm`): `info->isValid = true` inside the
+  success branch, `info->isValid = false` after the loop on the not-found path, a legitimate
+  default-then-flip success flag, both literals genuinely reached on distinct control-flow paths.
+- `OCCTExtremaExtPElC2dCirc`/`OCCTExtremaExtPElC2dLin` (`OCCTBridge_Geom2d.mm`, 2 sites):
+  `out[i].param1 = 0` beside a computed `out[i].param2`. `Extrema_ExtPElC2d` computes the extremum
+  between a POINT and an elementary curve; the point side has no parameter to report, only the
+  curve side does, so 0 is a structural placeholder for a genuinely parameter-less operand.
+
+**Needs investigation, not adjudicated with confidence (4 sites, filed as part of #781):**
+`OCCTCurve2DIntersect`/`OCCTCurve2DSelfIntersect` (`OCCTBridge_Geom2d.mm`, 2 fields each) set
+`out[i].u1 = 0; out[i].u2 = 0;` with an existing comment admitting the limitation. Verified against
+the pinned `Geom2dAPI_InterCurveCurve.hxx`: confirmed no direct parameter accessor exists. Not ruled
+out: projecting the returned point back onto each source curve to recover the parameters
+indirectly. Unlike the `qualifier` sites this is not confirmed computable, only not-yet-ruled-out,
+and `0` is a value a genuine intersection parameter could coincide with, so this is the same
+"0 collides with a real answer" ambiguity #726 exists to find, not a confirmed structural
+non-applicability like `param1` above.
+
+Full evidence and the scope note for why the qualifier/u1u2 fixes are not attempted in this PR:
+issue #781.
+
+## Bonus finding folded into this PR: sub-kind 1's option-struct false positives
+
+Not part of #771's own ask, but cheap enough while already in the script, so folded in rather than
+silently skipped. The single largest group of false positives in sub-kind 1's candidates was a
+local config/options struct handed to a call as an argument (`opts.Flatten = true;` then
+`Add(shape, opts)`), syntactically identical to a real result struct built field by field, and
+already named as an unaddressed blind spot in the script's own docstring (5 known sites:
+`BRepGraph::ShapesView::Options` x4, `MathInteg::KronrodConfig` x1).
+
+`is_input_only_struct()` excludes a tracked local var handed to a call as a bare argument, unless
+protected by being returned bare, stored into a container (`push_back`/`emplace_back`/
+`push_front`/`emplace_front`/`insert`, through either `.` or `->`, as one argument among several or
+the only one, after the second review round), or copied into an array element. Both the exclusion
+and each protection had to be built carefully, not naively: the exact seed shape this census exists
+to catch (`OCCTShapeAxis a` built in a loop, `collected.push_back(a)`) is also "handed to a call as
+a bare argument", an unprotected version of this rule would have made sub-kind 1 blind to the seed
+defect, the unsafe direction #726 explicitly warns this whole workstream against. A naive
+`[^()]*` argument-list scan also cannot see an argument behind a nested cast
+(`Add(*(const TopoDS_Shape*)shape, opts)`), missing 3 of the 5 real sites; `call_arg_lists()` does
+the same paren-depth walk `catch_spans`/`conditional_brace_positions` already use for braces.
+
+Measured: sub-kind 1's report count 54 to 49 after the first fix (exactly the 5 known sites),
+unaffected by the second review round's fixes on this corpus (no arrow-notation or multi-argument
+store call happens to exist among the real config-struct sites), and 49 to 73 once `FIELD_ASSIGN`
+itself gained arrow/array-index support, the sub-kind 1 core-mechanism fix described above.

--- a/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
+++ b/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
@@ -1,12 +1,20 @@
 # OCCTSwift#771: sub-kind 3 (gate flags that never flip) — census run and triage
 
-`census-unmeasured-values.py --gate-flags` (sub-kind 3, added by this issue) run against
-`refactor/381-pass1b` at `809f148`. **PR #770 (the `hasExtent` fix) is open, not merged, as of this
-run** — `git log --oneline -5 origin/refactor/381-pass1b` shows `809f148` at the tip, and
-`gh pr view 770 --json state,mergedAt` reports `"state":"OPEN","mergedAt":null`. That baseline
-matters for reading the table below: `hasExtent` is expected to still be reported here, because the
-fix for it lives on a sibling, not-yet-merged branch, not because sub-kind 3 failed to notice it was
-already fixed.
+## Baseline
+
+Two baselines matter here, because the branch moved under this work.
+
+Branched from `origin/refactor/381-pass1b` at `809f148`, where PR #770 (the `hasExtent` fix) was
+still open. Sub-kind 3 was built and its first real run against the corpus was taken against that
+pre-#770 tree: 7 candidates, including all three `hasExtent` call sites, exactly what a correct
+detector should report against code that has the defect. **PR #770 merged partway through this
+work** (`ad1078e`, `2026-08-07T17:57:52Z`). `origin/refactor/381-pass1b` was merged into this branch
+afterward to pick up the fix, and every number below the "First run" note is taken **after** that
+merge, against the corpus with `hasExtent` already fixed.
+
+The self-test does not depend on either baseline: every sub-kind 3 fixture is a synthetic
+(header, source) pair, not a read of the live tree, so `hasExtent`'s pre-fix shape stays available
+as a positive case regardless of what the real corpus looks like after #770.
 
 ## What sub-kind 3 detects
 
@@ -41,84 +49,120 @@ Recorded in the script's own `WHAT SUB-KIND 3 STILL CANNOT SEE` section; summari
 
 ## Self-test and removal matrix
 
-22/22 cases pass (10 pre-existing sub-kind 1/2 cases, unchanged, plus 12 new sub-kind 3 cases: 4
-`GATE_MISSED`, 6 `GATE_CLEAN`, 1 `SWIFT_GATE_MISSED`, 1 `SWIFT_GATE_CLEAN`).
+25/25 cases pass: the 10 pre-existing sub-kind 1/2 cases plus 3 new sub-kind 1 cases (see the
+sub-kind 1 improvement below), plus 12 new sub-kind 3 cases (4 `GATE_MISSED`, 6 `GATE_CLEAN`, 1
+`SWIFT_GATE_MISSED`, 1 `SWIFT_GATE_CLEAN`).
 
-Per `okf/policies/prove-the-test-fails.md`, each of the seven mechanisms sub-kind 3 relies on was
-disabled in turn in a working copy of the script, `--self-test` re-run, the case-count drop
-recorded, and the file restored from an untouched backup before the next probe:
+Per `okf/policies/prove-the-test-fails.md`, every mechanism this PR added was disabled in turn in a
+working copy of the script, `--self-test` re-run, the case-count drop recorded, and the file
+restored from an untouched backup before the next probe. Twelve rows, none decorative — every one
+drops the correct-case count and no two rows are redundant:
 
-| Rule disabled | Cases correct | Cases flipped |
-|---|---|---|
-| (baseline) | 22/22 | — |
-| 1. Name-prefix independence (bool-field scan restricted to `has*`) | 19/22 | 3 MISSED cases stop being flagged: the seed shape's non-`has` sibling (field `defined`) plus the two dead-`true` cases, which incidentally also use a non-`has` field name |
-| 2. Dead-after-terminator exclusion | 21/22 | 1: the dead-after-`return` MISSED case stops being flagged (its `true` is wrongly counted as live) |
-| 3. Dead-if-false exclusion | 21/22 | 1: the `if (false)` MISSED case stops being flagged |
-| 4. Pointer/reference parameter binding | 20/22 | 2: both helper-indirection CLEAN cases (pointer, reference) become **wrongly flagged**, since their only `true` assignment is no longer attributed to the struct type |
-| 5. Local value-typed declaration binding | 18/22 | 4: every MISSED case stops being flagged, since none of their local variables bind to a struct type at all any more |
-| 6. Computed-sibling exclusion | 21/22 | 1: the `wasAdjusted`-shaped CLEAN case becomes **wrongly flagged** |
-| 7. Swift computed-property detection | 21/22 | 1: the Swift MISSED case stops being flagged |
+| # | Rule disabled | Cases correct | What flipped |
+|---|---|---|---|
+| — | (baseline) | 25/25 | — |
+| 1 | Sub-kind 3: name-prefix independence (bool-field scan restricted to `has*`) | 22/25 | 3 MISSED cases stop being flagged: the seed shape's non-`has` sibling (field `defined`) plus the two dead-`true` cases, which incidentally also use a non-`has` field name |
+| 2 | Sub-kind 3: dead-after-terminator exclusion | 24/25 | 1: the dead-after-`return` MISSED case stops being flagged |
+| 3 | Sub-kind 3: dead-if-false exclusion | 24/25 | 1: the `if (false)` MISSED case stops being flagged |
+| 4 | Sub-kind 3: pointer/reference parameter binding | 23/25 | 2: both helper-indirection CLEAN cases (pointer, reference) become **wrongly flagged** |
+| 5 | Sub-kind 3: local value-typed declaration binding | 21/25 | 4: every sub-kind 3 MISSED case stops being flagged |
+| 6 | Sub-kind 3: computed-sibling exclusion | 24/25 | 1: the `wasAdjusted`-shaped CLEAN case becomes **wrongly flagged** |
+| 7 | Sub-kind 3: Swift computed-property detection | 24/25 | 1: the Swift MISSED case stops being flagged |
+| 8a | Sub-kind 1: whole `is_input_only_struct` config-struct exclusion | 24/25 | 1: the config/options-struct CLEAN case becomes **wrongly flagged** |
+| 8b | Sub-kind 1: `push_back`-family protection inside that exclusion | 24/25 | 1: the pre-existing `ShapeAxis`-shaped MISSED case **regresses** (the exact seed shape this whole census exists to catch) |
+| 8c | Sub-kind 1: bare-`return` protection inside that exclusion | 24/25 | 1: a dedicated "handed to a call AND returned" MISSED case stops being flagged |
+| 8d | Sub-kind 1: array-element-assignment protection inside that exclusion | 24/25 | 1: a dedicated "handed to a call AND copied into an array element" MISSED case stops being flagged |
+| 8e | Sub-kind 1: `call_arg_lists`'s paren-depth balancing (swapped for a naive `[^()]*` capture) | 24/25 | 1: the config/options-struct CLEAN case becomes **wrongly flagged** again, for a different reason than 8a — the real corpus check confirms this isn't synthetic-only: the naive regex still excludes the one config-struct site with no nested cast (`MathInteg::KronrodConfig`) but wrongly re-includes all four `BRepGraph::ShapesView::Options` sites, each of which passes `opts` behind a `*(const TopoDS_Shape*)shape` cast argument — sub-kind 1's report count moves 49 → 53 |
 
-Every one of the seven rows drops the correct-case count, and no two rows are redundant (each
-targets a distinct case or case-pair). Three sub-kind-3 self-test cases — the two correctly-flipping
-baselines (`hasExtent`-named and non-`has`-named) and the "reachable `true` under a real condition"
-control — are not tied to any single row above; they instead guard the base recognition path itself
-(plain `var.field = true` matching, and the false-condition check not over-firing on a genuine
-condition) and would only fail if that shared foundation broke, which every row implicitly exercises
-by relying on it. This is recorded rather than left implicit, per the #744 lesson that a
-self-test case can look like coverage without a removal proving it is.
+Three sub-kind-3 self-test cases — the two correctly-flipping baselines (`hasExtent`-named and
+non-`has`-named) and the "reachable `true` under a real condition" control — are not tied to any
+single row above; they instead guard the base recognition path itself (plain `var.field = true`
+matching, and the false-condition check not over-firing on a genuine condition) and would only fail
+if that shared foundation broke, which every row implicitly exercises by relying on it. This is
+recorded rather than left implicit: a self-test case can look like coverage without a removal
+proving it (#744), and this review explicitly asked whether any case's rule could be deleted without
+the count dropping. None of the 25 cases has that property: every one either appears as a
+MISSED/FALSE flip in a row above, or is one of these three explicitly-noted controls whose failure
+mode is "the shared foundation broke", not "no rule was ever exercised".
 
-## Candidates found and verdicts
+## Candidates found and verdicts (post-#770-merge baseline)
 
-7 candidates from `--gate-flags` against this baseline. Adjudicated using #763's four verdicts (1.
-not an instance, 2. compute it, 3. make absence representable, 4. remove the field):
+3 candidates from `--gate-flags` against the current baseline. Adjudicated using #763's four
+verdicts (1. not an instance, 2. compute it, 3. make absence representable, 4. remove the field):
 
 | Candidate | Struct.field | Verdict | Evidence |
 |---|---|---|---|
-| `OCCTBridge_Topology.mm:653` `OCCTShapeRevolutionAxes` | `OCCTShapeAxis.hasExtent` | **3 (already in progress)** | The #763 seed instance. Fixed on PR #770 (`chore/763-triage-core`, open against this same base, not merged). Not duplicated here — see baseline note above. |
-| `OCCTBridge_Topology.mm:694` `OCCTShapeSymmetryAxes` | `OCCTShapeAxis.hasExtent` | **3 (already in progress)** | Same field, second call site. Same fix, same PR. |
-| `OCCTBridge_Topology.mm:713` `OCCTShapeSymmetryAxes` | `OCCTShapeAxis.hasExtent` | **3 (already in progress)** | Same field, third call site. Same fix, same PR. |
-| `OCCTBridge_Geom2d.mm:2593` `OCCTBisectorPointOnBisCreate` | `OCCTBisectorPointOnBis.isInfinite` | **4 (remove)** | Verified independently (not just cited from #763's earlier note on the same function): `Bisector_PointOnBis`'s bundled OCCT header (`Bisector_PointOnBis.hxx`) has a real, settable `IsInfinite`/`IsInfinite() const` pair, so the concept is genuine on the OCCT class — but `OCCTBisectorPointOnBisCreate` never constructs a `Bisector_PointOnBis` at all; it echoes 6 raw doubles into a plain C struct with no reference to the OCCT class. Grepped the whole tree: zero Swift call sites for `OCCTBisectorPointOnBisCreate`, zero constructor call sites for the Swift `BisectorPoint` struct it builds for, and `BisectorPoint` has no explicit `public init` (only `public let` fields), so Swift's auto-synthesized memberwise initializer for a `public struct` is `internal`, not `public` — meaning no external consumer of the `OCCTSwift` library could construct one either. Fully orphaned on both sides, matching the #506/PR #547 precedent ("an orphan freezes its contract") for this exact codebase. Removed by this PR (bridge struct + function, Swift struct, both doc references). |
 | `OCCTBridge_Mesh.mm:201` `OCCTMeshParametersDefault` | `OCCTMeshParameters.relative` | **1 (not an instance)** | `OCCTMeshParametersDefault()` is a plain default-value factory for a config/options struct passed as an **argument** to `OCCTShapeCreateMeshWithParams`, not read back as a measurement — the same "local config/options struct" and "plain value-type constructor" exclusions sub-kind 1's own docstring already establishes for `OCCTXCAFPrsStyleCreate`. Confirmed genuinely settable, not stuck: `Sources/OCCTSwift/Mesh.swift`'s `MeshParameters` has a public, mutable `var relative: Bool` that a caller sets directly, and `params.relative = relative` (`Mesh.swift:87`) forwards it into the bridge struct at the real call site. |
 | `OCCTBridge_Mesh.mm:205` `OCCTMeshParametersDefault` | `OCCTMeshParameters.adjustMinSize` | **1 (not an instance)** | Same reasoning; `Mesh.swift:91` (`params.adjustMinSize = adjustMinSize`). |
 | `OCCTBridge_Mesh.mm:206` `OCCTMeshParametersDefault` | `OCCTMeshParameters.allowQualityDecrease` | **1 (not an instance)** | Same reasoning; `Mesh.swift:92` (`params.allowQualityDecrease = allowQualityDecrease`). |
 
-**No new verdict-3/verdict-4 instance beyond the seed.** The one genuine new finding
-(`OCCTBisectorPointOnBis.isInfinite`) turned out to be dead code around an orphaned function rather
-than a stuck gate on a live path — a different root cause than `hasExtent`'s, caught only because
-teaching the detector past the `hasX` name filter (indirection shape 1) surfaced a non-`has`-named
-field the naive pass could never have seen (the naive pass was scoped to `hasX`-declared fields in
-headers to begin with). What the detector would have caught had `hasExtent` not already had an
-open fix in flight: exactly the `GATE_MISSED` self-test shape it does catch, run against real code —
-three literal-`false` call sites, one struct type, zero literal-`true` or computed assignments
-anywhere in the corpus, reported by file and line with no name-prefix filtering required to find it.
+**No verdict-3/verdict-4 instance beyond the seed `hasExtent`, which #770 already fixed.** Before
+the #770 merge, this same run also reported `OCCTShapeAxis.hasExtent` at all three call sites
+(verdict 3, already fixed there) and `OCCTBisectorPointOnBis.isInfinite` (verdict 4, fixed in this
+PR, see below) — 7 candidates total pre-merge, now 3. The `hasExtent` disappearance is the expected,
+correct effect of merging in a fix that shipped on a sibling branch, not something this detector did
+wrong: **not an instance of it undercounting**, it is the census correctly reflecting a corpus that
+changed underneath it.
 
-## Fix implemented
+What the detector would have caught had `hasExtent` not already had a fix in flight: exactly the
+`GATE_MISSED` self-test shape it does catch, run against real code — three literal-`false` call
+sites, one struct type, zero literal-`true` or computed assignments anywhere in the corpus, reported
+by file and line with no name-prefix filtering required to find it. That shape is preserved as a
+synthetic self-test fixture specifically so this detector keeps a real positive case even now that
+the live tree no longer has one.
 
-Removed the orphaned `OCCTBisectorPointOnBis` struct, `OCCTBisectorPointOnBisCreate` bridge
-function, and the Swift `BisectorPoint` struct built for it:
+### `BisectorPoint`/`OCCTBisectorPointOnBis`/`OCCTBisectorPointOnBisCreate` removed (verdict 4)
 
-- `Sources/OCCTBridge/include/OCCTBridge_Geom2d.h`: struct + declaration replaced with a tombstone
-  comment (the `#500`/`#506` idiom already used elsewhere in this header for a prior removal).
-- `Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm`: implementation replaced with a tombstone comment.
-- `Sources/OCCTSwift/BisectorResult.swift`: `BisectorPoint` struct removed (tombstone comment left
-  in its place); `BisectorIntersection` and `bisectorIntersections(a:b:c:d:)`, the live pair in the
-  same file, are untouched.
-- `docs/reference/Shape-Recognition.md`: `BisectorPoint` subsection removed from "Bisector
-  utilities".
-- `docs/API_REFERENCE.md`: "Bisector Intersection" row count corrected from 2 to 1
-  (`bisectorIntersections` only).
+Found against the pre-#770-merge baseline (unaffected by the merge; unrelated file). Verified
+independently before removing (`okf/policies/measure-dont-assume.md`), not just cited from #763's
+earlier one-line note on the same function: read `Bisector_PointOnBis.hxx` from the pinned OCCT
+xcframework headers directly. The OCCT class has a real, settable `IsInfinite`/`IsInfinite() const`
+pair — the concept is genuine — but `OCCTBisectorPointOnBisCreate` never constructs a
+`Bisector_PointOnBis` at all; it echoes 6 raw doubles into a plain C struct with no reference to the
+OCCT class. Grepped the whole tree: zero Swift call sites for the bridge function, zero constructor
+call sites for the Swift `BisectorPoint` struct it built for, and `BisectorPoint` has no explicit
+`public init` (only `public let` fields), so Swift's auto-synthesized memberwise initializer for a
+`public struct` is `internal`, not `public` — no external consumer of `OCCTSwift` could construct
+one either. Fully orphaned on both sides, matching the #506/PR #547 precedent ("an orphan freezes
+its contract") in this same codebase.
+
+Removed: the bridge struct + function (`OCCTBridge_Geom2d.h`/`.mm`, tombstone comments in the
+`#500`/`#506` idiom already used elsewhere in that header), the Swift struct
+(`BisectorResult.swift`), and its two doc references (`docs/reference/Shape-Recognition.md`,
+`docs/API_REFERENCE.md`'s Bisector Intersection row count 2 → 1). `BisectorIntersection`/
+`bisectorIntersections(a:b:c:d:)`, the live pair in the same file, are untouched.
+`Scripts/count-operations.py`'s derived total is unaffected (4306 before and after): `BisectorPoint`
+had no public `func`/computed `var`/`init`/`subscript`, so it was never counted.
 
 **No injection cycle for this fix**, matching PR #770's own precedent for the `selfIntersectionCount`
-removal: it is a field deletion enforced by the compiler (any surviving reference fails to build),
-not a new positive behavioural check to prove wrong-then-right. `Scripts/count-operations.py`'s
-derived total is unaffected (4306 before and after): `BisectorPoint` had no public `func`, computed
-`var`, `init`, or `subscript` to begin with, so it was never counted as an operation.
+removal: it is a field/type deletion enforced by the compiler (any surviving reference fails to
+build), not a new positive behavioural check to prove wrong-then-right.
 
-Verified before removing, not assumed (`okf/policies/measure-dont-assume.md`): read
-`Bisector_PointOnBis.hxx` from the pinned OCCT xcframework headers directly rather than trusting
-#763's PR-770 note that the function "has no IsInfinite parameter" at face value — confirmed the
-class's real constructor list (default, and a 5-arg `Param1/Param2/ParamBis/Distance/Point`
-constructor, neither taking an `Infinite` argument) and that `IsInfinite`/`IsInfinite() const` exist
-as a genuine, separately-set property on the class, which is what makes this a "dead code around a
-real concept" finding rather than a "the concept never existed" one.
+## Bonus finding folded in: sub-kind 1's option-struct false positives
+
+Not part of #771's own ask, but surfaced while adjudicating sub-kind 1's other candidates for
+comparison and cheap enough to fix in the same script, in the same PR. The single largest group of
+noise in sub-kind 1's 54 pre-fix candidates was a local config/options struct built and handed to a
+call as an argument (`opts.Flatten = true;` then `Add(shape, opts)`), which is syntactically
+identical to a real result struct being built up field by field — the script's own docstring had
+already named this exact shape as an unaddressed blind spot, with 5 known sites
+(`BRepGraph::ShapesView::Options` x4, `MathInteg::KronrodConfig` x1).
+
+**Fixed**, `is_input_only_struct()`: a tracked local variable is excluded from sub-kind 1 candidacy
+if it is handed to some call as a bare argument and never surfaces afterward — "surfaces" meaning a
+bare `return var;`, storage into a container (`push_back`/`emplace_back`/`push_front`/
+`emplace_front`/`insert`), or a direct `arr[i] = var;` copy into an array/vector element. Any one of
+those three protections wins over the exclusion. This had to be built carefully rather than
+naively, for two reasons proven by the removal matrix above: (1) the exact seed shape this whole
+census exists to catch, `OCCTShapeAxis a` built in a loop then `collected.push_back(a)`, is *also*
+"handed to a call as a bare argument" (to `push_back`) — a naive version of this rule would have
+made sub-kind 1 blind to the seed defect it was built to find, in the unsafe direction #726
+explicitly warns this whole workstream against; and (2) a naive `[^()]*` argument-list capture
+cannot see an argument sitting behind a nested cast (`Add(*(const TopoDS_Shape*)shape, opts)`), so
+3 of the 5 real sites would have gone unexcluded without a proper paren-depth-matched extractor
+(`call_arg_lists`, reusing the same balanced-walk style `catch_spans`/`conditional_brace_positions`
+already use for braces).
+
+Measured: sub-kind 1's report count on this tree drops from 54 to 49 candidates — exactly the 5
+known sites, confirmed by diffing the full before/after listing rather than just the totals; nothing
+else in the list moved.

--- a/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
+++ b/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
@@ -23,11 +23,13 @@ A boolean field, declared on any `typedef struct { ... } Name;` / `struct Name {
 the corpus and literal `true` nowhere reachable. Reachable excludes an `if (false)` / `if (0)` /
 `while (false)` / `while (0)` block (braced or braceless, see the second review round below) and
 dead code following an unconditional `return`/`continue`/`break`/`throw` in the same straight-line
-block. A field with any non-literal (computed) assignment anywhere is treated as not provably
+block; both checks apply equally to a literal `true` and a computed RHS (see the third review round
+below). A field with any REACHABLE non-literal (computed) assignment is treated as not provably
 stuck, since the census cannot evaluate whether that expression can produce `true`. Binding a local
-identifier to a known struct type recognises a plain local declaration and a pointer or reference
-parameter, so a shared helper that flips the field through `->`/`&` is caught with no
-special-casing for "this is a helper". A separate, narrower detector covers the Swift side: a
+identifier to a known struct type recognises a local declaration, value-typed or pointer/reference,
+and a pointer or reference parameter, so a shared helper that flips the field through `->`/`&`, or
+a local alias declared inside the function body, is caught with no special-casing for "this is a
+helper" or "this is an alias". A separate, narrower detector covers the Swift side: a
 `var x: Bool { ... }` computed property that returns `false` somewhere and `true` nowhere in its
 body.
 
@@ -72,40 +74,53 @@ unfixed code, then the fix applied and the case confirmed to pass.
    Fixed by the same unification as (2): the check now searches the whole argument text for a bare
    `var` token, not just a sole argument.
 
-### Removal matrix, all seventeen mechanisms
+### Removal matrix, all nineteen mechanisms
 
-25 self-test cases before this round became 30 after (3 new sub-kind 1 cases for findings 2 to 4,
-plus one further case described below, plus 1 new sub-kind 3 case for finding 1). Every mechanism
-sub-kind 3 and sub-kind 1's config-struct exclusion rely on was disabled in turn in a working copy
-of the script, `--self-test` re-run, the case-count drop recorded, and the file restored from an
-untouched backup before the next probe:
+25 self-test cases before the second round became 30 after (3 new sub-kind 1 cases for findings 2
+to 4, plus one further case described below, plus 1 new sub-kind 3 case for finding 1), then 32
+after the fourth round (one sub-kind 3 case each for the two findings there). Every mechanism sub-
+kind 3 and sub-kind 1's config-struct exclusion rely on was disabled in turn in a working copy of
+the script, `--self-test` re-run, the case-count drop recorded, and the file restored from an
+untouched backup before the next probe. Rows 1 to 13 were re-verified against the fourth round's
+refactored code, not just carried over from the second round's own run:
 
 | # | Rule disabled | Cases correct | What flipped |
 |---|---|---|---|
-| - | (baseline) | 30/30 | - |
-| 1 | Sub-kind 3: name-prefix independence | 25/30 | 4 MISSED cases stop being flagged (the seed's non-`has` sibling, both dead-`true` cases, and the new braceless case, since all three happen to also use a non-`has` field name) |
-| 2 | Sub-kind 3: dead-after-terminator exclusion | 29/30 | 1 MISSED case stops being flagged |
-| 3 | Sub-kind 3: dead-if-false exclusion, whole mechanism | 28/30 | 2 MISSED cases stop being flagged (both the braced and the braceless form) |
-| 4 | Sub-kind 3: pointer/reference parameter binding | 27/30 | 2 CLEAN cases become wrongly flagged |
-| 5 | Sub-kind 3: local value-typed declaration binding | 24/30 | all 5 sub-kind 3 MISSED cases stop being flagged |
-| 6 | Sub-kind 3: computed-sibling exclusion | 28/30 | 1 CLEAN case becomes wrongly flagged |
-| 7 | Sub-kind 3: Swift computed-property detection | 28/30 | 1 Swift MISSED case stops being flagged |
-| 8a | Sub-kind 1: whole config-struct exclusion | 28/30 | 1 CLEAN case becomes wrongly flagged |
-| 8b | Sub-kind 1: whole store-family protection | 27/30 | 3 MISSED cases stop being flagged (the original `push_back` seed shape, the new arrow-notation case, and the new multi-argument `insert` case) |
-| 8c | Sub-kind 1: bare-`return` protection | 29/30 | 1 MISSED case stops being flagged, the "handed to a call AND returned" case |
-| 8d | Sub-kind 1: array-element-assignment protection | 29/30 | 1 MISSED case stops being flagged, the "handed to a call AND copied into an array element" case |
-| 8e | Sub-kind 1: paren-depth-balanced argument scan (swapped for naive `[^()]*`) | 27/30 | 2 CLEAN/MISSED cases affected: the config-struct case wrongly flagged again, and the multi-argument `insert` case stops being flagged, since `collected.end()` also has nested parens the naive scan cannot see past. Confirmed on the real corpus too: report count moves 49 to 53. |
-| 9 | Sub-kind 3: braceless if-false specifically (braced form left intact) | 29/30 | 1 MISSED case stops being flagged, the braceless one only; the braced case (row 3's sibling) stays correct |
-| 10 | Sub-kind 1: arrow-notation recognition specifically (dot-only reinstated) | 29/30 | 1 MISSED case stops being flagged, the pointer-container case only; the dot-notation seed case and the multi-argument case both stay correct |
-| 11 | Sub-kind 1: multi-argument recognition specifically (single-argument-only reinstated) | 29/30 | 1 MISSED case stops being flagged, the two-argument `insert` case only |
-| 12 | Sub-kind 1: `CALL_START` keyword/`sizeof` exclusion | 29/30 | 1 MISSED case stops being flagged, the `sizeof` case |
-| 13 | Sub-kind 1: `FIELD_ASSIGN` arrow/array-index matching (dot-only reinstated) | 29/30 | 1 MISSED case stops being flagged, the pointer-out-param result case |
+| - | (baseline) | 32/32 | - |
+| 1 | Sub-kind 3: name-prefix independence | 28/32 | 4 MISSED cases stop being flagged (the seed's non-`has` sibling, both dead-`true` cases, and the braceless case; the two fourth-round cases are unaffected, both using the `hasExtent` name already) |
+| 2 | Sub-kind 3: dead-after-terminator exclusion | 31/32 | 1 MISSED case stops being flagged (only the dead-after-return case; the dead-if-false-guarded computed case, row 14, relies on `dead_spans` instead and is unaffected) |
+| 3 | Sub-kind 3: dead-if-false exclusion, whole mechanism | 29/32 | 3 MISSED cases stop being flagged: both the braced and the braceless `true` form, AND the new dead-computed case (row 14), confirming it correctly shares this same mechanism rather than reimplementing it |
+| 4 | Sub-kind 3: pointer/reference parameter binding | 30/32 | 2 CLEAN cases become wrongly flagged; the new local-pointer case (row 15) is unaffected, since it uses `local_bind`, not `param_bind` |
+| 5 | Sub-kind 3: local declaration binding, whole mechanism (value-typed AND pointer/reference) | 26/32 | all 6 sub-kind 3 MISSED cases stop being flagged, including the new dead-computed case (row 14, which also needs a local binding to exist at all) |
+| 6 | Sub-kind 3: computed-sibling exclusion (the `computed_seen.add` call itself, reachability check left in place) | 31/32 | 1 CLEAN case becomes wrongly flagged (`wasAdjusted`); unaffected by the fourth round's reachability addition, since that addition guards entry INTO this line, not the line itself |
+| 7 | Sub-kind 3: Swift computed-property detection | 31/32 | 1 Swift MISSED case stops being flagged |
+| 8a | Sub-kind 1: whole config-struct exclusion | 31/32 | 1 CLEAN case becomes wrongly flagged |
+| 8b | Sub-kind 1: whole store-family protection | 29/32 | 3 MISSED cases stop being flagged (the original `push_back` seed shape, the arrow-notation case, and the multi-argument `insert` case) |
+| 8c | Sub-kind 1: bare-`return` protection | 31/32 | 1 MISSED case stops being flagged, the "handed to a call AND returned" case |
+| 8d | Sub-kind 1: array-element-assignment protection | 31/32 | 1 MISSED case stops being flagged, the "handed to a call AND copied into an array element" case |
+| 8e | Sub-kind 1: paren-depth-balanced argument scan (swapped for naive `[^()]*`) | 29/32 | 2 CLEAN/MISSED cases affected: the config-struct case wrongly flagged again, and the multi-argument `insert` case stops being flagged. Confirmed on the real corpus too: report count moves 49 to 53. |
+| 9 | Sub-kind 3: braceless if-false specifically (braced form left intact) | 31/32 | 1 MISSED case stops being flagged, the braceless one only |
+| 10 | Sub-kind 1: arrow-notation recognition specifically (dot-only reinstated) | 31/32 | 1 MISSED case stops being flagged, the pointer-container case only |
+| 11 | Sub-kind 1: multi-argument recognition specifically (single-argument-only reinstated) | 31/32 | 1 MISSED case stops being flagged, the two-argument `insert` case only |
+| 12 | Sub-kind 1: `CALL_START` keyword/`sizeof` exclusion | 31/32 | 1 MISSED case stops being flagged, the `sizeof` case |
+| 13 | Sub-kind 1: `FIELD_ASSIGN` arrow/array-index matching (dot-only reinstated) | 31/32 | 1 MISSED case stops being flagged, the pointer-out-param result case |
+| 14 | Sub-kind 3: reachability check on the COMPUTED branch specifically (`true`-branch check left intact) | 31/32 | 1 MISSED case stops being flagged, the dead-if-false-guarded computed assignment case only |
+| 15 | Sub-kind 3: local pointer/reference declaration binding specifically (`local_bind` reverted to value-typed-only, `param_bind` left intact) | 31/32 | 1 CLEAN case becomes wrongly flagged, the local-pointer-alias case only |
 
-Every row drops the count and no two rows are redundant. Three sub-kind-3 CLEAN cases (the two
-correctly-flipping baselines and the "reachable true under a real condition" control) are not tied
-to a single row; they guard the shared base-recognition path every row relies on and would only
-fail if that broke. Recorded explicitly, per the review's own question about whether any case's
-rule could be deleted without the count dropping: none of the 30 has that property.
+Every row drops the count and no two rows are redundant. Two sub-kind-3 CLEAN cases (the two
+correctly-flipping baselines) and one control (the "reachable true under a real condition" case)
+are not tied to a single row; they guard the shared base-recognition path every row relies on and
+would only fail if that broke. Recorded explicitly, per the second review round's own question
+about whether any case's rule could be deleted without the count dropping: none of the 32 has that
+property.
+
+**Row 5 was flagged in the fourth review round as covering only the value-typed form**, since
+before that round `local_bind` had no pointer/reference branch at all, so disabling "local
+declaration binding" and disabling "value-typed local declaration binding" were the same
+experiment: a matrix row that can only exercise one of two shapes reads as covering both when it
+covers one. Row 5 above now disables the WHOLE mechanism (both forms at once, since after the fix
+they are one regex with two branches) and row 15 isolates the pointer/reference branch on its own,
+closing that gap directly rather than leaving it as a documented limitation of the matrix.
 
 ## Third finding, same review, sub-kind 1's own core mechanism
 
@@ -135,6 +150,54 @@ Swift requires braces on every `if`/`while`/`for` body; there is no braceless fo
 accept, so a braceless-if analogue cannot occur in Swift source at all. Swift also has no `->`
 operator; member access is always `.`, including through optional chaining. Both gaps are
 structurally impossible in the language sub-kind 2 scans, not merely unobserved in this corpus.
+
+## Fourth review round: two more gaps, both PLAUSIBLE, both fixed
+
+A second pass over PR #774 found two further gaps, both marked PLAUSIBLE by the reviewer rather
+than confirmed live in the corpus, both in `gate_flag_candidates` itself. Neither had a self-test
+case in either direction (the fixture that would catch it, or the fixture that would prove the
+absence is safe), which is exactly the coverage gap the reviewer surfaced instead of the defect
+itself: a detector's blind spot does not become real when someone writes the code that trips it,
+it becomes visible then, and by that point it has been silently under-reporting.
+
+**Finding: the reachability exclusion applied to the `true` branch only, not the computed branch.**
+`is_dead_after_terminator`/`dead_spans` gate whether a literal `true` counts as a real flip, but the
+sibling `else` branch that adds a struct field to `computed_seen` (marking it "not provably stuck")
+had no reachability check of its own:
+
+```cpp
+g.hasExtent = false;
+if (false) {
+    g.hasExtent = someLegacyComputation();   // dead, and not a literal
+}
+```
+
+would mark `(struct, field)` as not provably stuck and exempt a field that is permanently `false`
+in every path that actually executes; the identical "unreachable write masks a stuck gate" shape
+this PR spent its second review round hardening for the `true` case, left open one branch over.
+Fixed: the same two checks now gate the computed branch too, sharing the exact functions the
+`true` branch already calls rather than a second implementation of the same idea.
+
+**Finding: `local_bind` never recognised a pointer or reference declared inside a function body.**
+`param_bind` already handled `TYPE* name`/`TYPE& name` for a function PARAMETER, but the sibling
+`local_bind` only matched a plain value-typed declaration (`\b(TYPE)\s+(name)\s*(?:=|;|\{)`, no
+`*`/`&` branch at all). So `OCCTShapeAxis* p = &a; p->hasExtent = true;`, a local alias declared
+inside the function rather than a caller-supplied out-param, bound nothing: `ASSIGN_ANY`'s match on
+`p->hasExtent = true` found `bindings.get('p')` was `None` and the assignment was silently skipped,
+invisible to sub-kind 3 entirely. This is the SAME shape #774's second review round already fixed
+for a shared helper's own POINTER PARAMETER (row 4); the review's framing was apt: a detector that
+understands `p->field` but not what `p` is bound to is half a feature. Fixed: `local_bind` now has
+the same two-branch shape `param_bind` already had, a pointer/reference OR a plain value, so a
+local pointer/reference declaration binds exactly like the parameter form always did.
+
+Both fixed the same way as every prior finding: a self-test case added first, confirmed to fail
+against the unfixed code, then the fix applied and confirmed to pass
+(`okf/policies/prove-the-test-fails.md`). Neither gap was previously listed in the module
+docstring's "WHAT SUB-KIND 3 STILL CANNOT SEE" section; since both are now fixed rather than left
+open, neither needed to be added there either. Measured against the real corpus: sub-kind 3's
+report count is unchanged at 3 candidates after both fixes, and sub-kind 1/2 are unaffected (both
+fixes are inside `gate_flag_candidates`, sub-kind 3 only), consistent with the reviewer's own
+framing that neither gap was confirmed live, only real as a mechanism.
 
 ## Candidates found and verdicts
 

--- a/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
+++ b/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
@@ -1,0 +1,124 @@
+# OCCTSwift#771: sub-kind 3 (gate flags that never flip) — census run and triage
+
+`census-unmeasured-values.py --gate-flags` (sub-kind 3, added by this issue) run against
+`refactor/381-pass1b` at `809f148`. **PR #770 (the `hasExtent` fix) is open, not merged, as of this
+run** — `git log --oneline -5 origin/refactor/381-pass1b` shows `809f148` at the tip, and
+`gh pr view 770 --json state,mergedAt` reports `"state":"OPEN","mergedAt":null`. That baseline
+matters for reading the table below: `hasExtent` is expected to still be reported here, because the
+fix for it lives on a sibling, not-yet-merged branch, not because sub-kind 3 failed to notice it was
+already fixed.
+
+## What sub-kind 3 detects
+
+A boolean field, declared on any `typedef struct { ... } Name;` / `struct Name { ... };` in
+`Sources/OCCTBridge/` (not filtered by field name), that is assigned literal `false` somewhere in
+the corpus and literal `true` nowhere reachable — reachable meaning not inside an `if (false)` /
+`if (0)` / `while (false)` / `while (0)` block, and not dead code following an unconditional
+`return`/`continue`/`break`/`throw` in the same straight-line block. A field with any non-literal
+(computed) assignment anywhere is treated as not provably stuck, since the census cannot evaluate
+whether that expression can produce `true`. Binding a local identifier to a known struct type
+recognises a plain local declaration and a pointer or reference parameter, so a shared helper that
+flips the field through `->`/`&` is caught with no special-casing for "this is a helper". A separate,
+narrower detector covers the Swift side: a `var x: Bool { ... }` computed property that returns
+`false` somewhere and `true` nowhere in its body.
+
+Full algorithm and worked examples are in `Scripts/census-unmeasured-values.py`'s module docstring,
+under `SUB-KIND 3 ALGORITHM`.
+
+## What it does not detect, and why
+
+Recorded in the script's own `WHAT SUB-KIND 3 STILL CANNOT SEE` section; summarised here:
+
+| Gap | Why not taught |
+|---|---|
+| A `kind`-style enum with a never-emitted "gate open" case | Needs the full declared case list per enum plus which case means "open", which is semantic, not syntactic — a fundamentally different question from a 2-valued bool. |
+| A helper that takes the struct **by value** and returns a modified copy | Only pointer/reference parameters bind a type, deliberately: a byval parameter cannot affect the caller's instance the way "pointer, reference or helper" describes, and accepting it raises the risk of crediting an orphaned, never-called byval helper as if it were live evidence. |
+| A cast-based alias (`((T*)ptr)->field = true;`) | Same gap `check-null-handle-guards.py` documents for its own four indirection shapes (#618): the binding regex looks for the type name directly adjacent to the variable, not behind a cast. |
+| A more elaborate always-false condition (`if (1 == 2)`, a false-valued macro, `#if 0`, an unreached `switch` case) | Only the literal spellings `false` and `0` are recognised as an always-false condition. |
+| A Swift **stored** property mutated across multiple methods | The closer analogue of the C struct case, but it would need the same corpus-wide type-binding machinery applied to Swift class/struct declarations and their methods — a bigger lift than a single self-contained function body, not attempted this pass. |
+| Swift dead-code exclusion (if-false / dead-after-return) | Swift conditionals are commonly braceless and paren-less (`if x > 0 {`), which the C-oriented brace/paren-counting machinery does not parse, so the Swift detector only checks for bare `return true`/`return false` literal presence. |
+| Call-graph reachability in general | The census is corpus-wide and per-function, not whole-program: a `true` assignment inside a function that is itself never called anywhere is still counted as "the field can be true". See the Bisector finding below for a real instance of exactly this ambiguity. |
+
+## Self-test and removal matrix
+
+22/22 cases pass (10 pre-existing sub-kind 1/2 cases, unchanged, plus 12 new sub-kind 3 cases: 4
+`GATE_MISSED`, 6 `GATE_CLEAN`, 1 `SWIFT_GATE_MISSED`, 1 `SWIFT_GATE_CLEAN`).
+
+Per `okf/policies/prove-the-test-fails.md`, each of the seven mechanisms sub-kind 3 relies on was
+disabled in turn in a working copy of the script, `--self-test` re-run, the case-count drop
+recorded, and the file restored from an untouched backup before the next probe:
+
+| Rule disabled | Cases correct | Cases flipped |
+|---|---|---|
+| (baseline) | 22/22 | — |
+| 1. Name-prefix independence (bool-field scan restricted to `has*`) | 19/22 | 3 MISSED cases stop being flagged: the seed shape's non-`has` sibling (field `defined`) plus the two dead-`true` cases, which incidentally also use a non-`has` field name |
+| 2. Dead-after-terminator exclusion | 21/22 | 1: the dead-after-`return` MISSED case stops being flagged (its `true` is wrongly counted as live) |
+| 3. Dead-if-false exclusion | 21/22 | 1: the `if (false)` MISSED case stops being flagged |
+| 4. Pointer/reference parameter binding | 20/22 | 2: both helper-indirection CLEAN cases (pointer, reference) become **wrongly flagged**, since their only `true` assignment is no longer attributed to the struct type |
+| 5. Local value-typed declaration binding | 18/22 | 4: every MISSED case stops being flagged, since none of their local variables bind to a struct type at all any more |
+| 6. Computed-sibling exclusion | 21/22 | 1: the `wasAdjusted`-shaped CLEAN case becomes **wrongly flagged** |
+| 7. Swift computed-property detection | 21/22 | 1: the Swift MISSED case stops being flagged |
+
+Every one of the seven rows drops the correct-case count, and no two rows are redundant (each
+targets a distinct case or case-pair). Three sub-kind-3 self-test cases — the two correctly-flipping
+baselines (`hasExtent`-named and non-`has`-named) and the "reachable `true` under a real condition"
+control — are not tied to any single row above; they instead guard the base recognition path itself
+(plain `var.field = true` matching, and the false-condition check not over-firing on a genuine
+condition) and would only fail if that shared foundation broke, which every row implicitly exercises
+by relying on it. This is recorded rather than left implicit, per the #744 lesson that a
+self-test case can look like coverage without a removal proving it is.
+
+## Candidates found and verdicts
+
+7 candidates from `--gate-flags` against this baseline. Adjudicated using #763's four verdicts (1.
+not an instance, 2. compute it, 3. make absence representable, 4. remove the field):
+
+| Candidate | Struct.field | Verdict | Evidence |
+|---|---|---|---|
+| `OCCTBridge_Topology.mm:653` `OCCTShapeRevolutionAxes` | `OCCTShapeAxis.hasExtent` | **3 (already in progress)** | The #763 seed instance. Fixed on PR #770 (`chore/763-triage-core`, open against this same base, not merged). Not duplicated here — see baseline note above. |
+| `OCCTBridge_Topology.mm:694` `OCCTShapeSymmetryAxes` | `OCCTShapeAxis.hasExtent` | **3 (already in progress)** | Same field, second call site. Same fix, same PR. |
+| `OCCTBridge_Topology.mm:713` `OCCTShapeSymmetryAxes` | `OCCTShapeAxis.hasExtent` | **3 (already in progress)** | Same field, third call site. Same fix, same PR. |
+| `OCCTBridge_Geom2d.mm:2593` `OCCTBisectorPointOnBisCreate` | `OCCTBisectorPointOnBis.isInfinite` | **4 (remove)** | Verified independently (not just cited from #763's earlier note on the same function): `Bisector_PointOnBis`'s bundled OCCT header (`Bisector_PointOnBis.hxx`) has a real, settable `IsInfinite`/`IsInfinite() const` pair, so the concept is genuine on the OCCT class — but `OCCTBisectorPointOnBisCreate` never constructs a `Bisector_PointOnBis` at all; it echoes 6 raw doubles into a plain C struct with no reference to the OCCT class. Grepped the whole tree: zero Swift call sites for `OCCTBisectorPointOnBisCreate`, zero constructor call sites for the Swift `BisectorPoint` struct it builds for, and `BisectorPoint` has no explicit `public init` (only `public let` fields), so Swift's auto-synthesized memberwise initializer for a `public struct` is `internal`, not `public` — meaning no external consumer of the `OCCTSwift` library could construct one either. Fully orphaned on both sides, matching the #506/PR #547 precedent ("an orphan freezes its contract") for this exact codebase. Removed by this PR (bridge struct + function, Swift struct, both doc references). |
+| `OCCTBridge_Mesh.mm:201` `OCCTMeshParametersDefault` | `OCCTMeshParameters.relative` | **1 (not an instance)** | `OCCTMeshParametersDefault()` is a plain default-value factory for a config/options struct passed as an **argument** to `OCCTShapeCreateMeshWithParams`, not read back as a measurement — the same "local config/options struct" and "plain value-type constructor" exclusions sub-kind 1's own docstring already establishes for `OCCTXCAFPrsStyleCreate`. Confirmed genuinely settable, not stuck: `Sources/OCCTSwift/Mesh.swift`'s `MeshParameters` has a public, mutable `var relative: Bool` that a caller sets directly, and `params.relative = relative` (`Mesh.swift:87`) forwards it into the bridge struct at the real call site. |
+| `OCCTBridge_Mesh.mm:205` `OCCTMeshParametersDefault` | `OCCTMeshParameters.adjustMinSize` | **1 (not an instance)** | Same reasoning; `Mesh.swift:91` (`params.adjustMinSize = adjustMinSize`). |
+| `OCCTBridge_Mesh.mm:206` `OCCTMeshParametersDefault` | `OCCTMeshParameters.allowQualityDecrease` | **1 (not an instance)** | Same reasoning; `Mesh.swift:92` (`params.allowQualityDecrease = allowQualityDecrease`). |
+
+**No new verdict-3/verdict-4 instance beyond the seed.** The one genuine new finding
+(`OCCTBisectorPointOnBis.isInfinite`) turned out to be dead code around an orphaned function rather
+than a stuck gate on a live path — a different root cause than `hasExtent`'s, caught only because
+teaching the detector past the `hasX` name filter (indirection shape 1) surfaced a non-`has`-named
+field the naive pass could never have seen (the naive pass was scoped to `hasX`-declared fields in
+headers to begin with). What the detector would have caught had `hasExtent` not already had an
+open fix in flight: exactly the `GATE_MISSED` self-test shape it does catch, run against real code —
+three literal-`false` call sites, one struct type, zero literal-`true` or computed assignments
+anywhere in the corpus, reported by file and line with no name-prefix filtering required to find it.
+
+## Fix implemented
+
+Removed the orphaned `OCCTBisectorPointOnBis` struct, `OCCTBisectorPointOnBisCreate` bridge
+function, and the Swift `BisectorPoint` struct built for it:
+
+- `Sources/OCCTBridge/include/OCCTBridge_Geom2d.h`: struct + declaration replaced with a tombstone
+  comment (the `#500`/`#506` idiom already used elsewhere in this header for a prior removal).
+- `Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm`: implementation replaced with a tombstone comment.
+- `Sources/OCCTSwift/BisectorResult.swift`: `BisectorPoint` struct removed (tombstone comment left
+  in its place); `BisectorIntersection` and `bisectorIntersections(a:b:c:d:)`, the live pair in the
+  same file, are untouched.
+- `docs/reference/Shape-Recognition.md`: `BisectorPoint` subsection removed from "Bisector
+  utilities".
+- `docs/API_REFERENCE.md`: "Bisector Intersection" row count corrected from 2 to 1
+  (`bisectorIntersections` only).
+
+**No injection cycle for this fix**, matching PR #770's own precedent for the `selfIntersectionCount`
+removal: it is a field deletion enforced by the compiler (any surviving reference fails to build),
+not a new positive behavioural check to prove wrong-then-right. `Scripts/count-operations.py`'s
+derived total is unaffected (4306 before and after): `BisectorPoint` had no public `func`, computed
+`var`, `init`, or `subscript` to begin with, so it was never counted as an operation.
+
+Verified before removing, not assumed (`okf/policies/measure-dont-assume.md`): read
+`Bisector_PointOnBis.hxx` from the pinned OCCT xcframework headers directly rather than trusting
+#763's PR-770 note that the function "has no IsInfinite parameter" at face value — confirmed the
+class's real constructor list (default, and a 5-arg `Param1/Param2/ParamBis/Distance/Point`
+constructor, neither taking an `Infinite` argument) and that `IsInfinite`/`IsInfinite() const` exist
+as a genuine, separately-set property on the class, which is what makes this a "dead code around a
+real concept" finding rather than a "the concept never existed" one.

--- a/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
+++ b/Scripts/repro/726-unmeasured-values/triage-gate-flags.md
@@ -19,16 +19,19 @@ as a positive case regardless of what the real corpus looks like after #770.
 ## What sub-kind 3 detects
 
 A boolean field, declared on any `typedef struct { ... } Name;` / `struct Name { ... };` in
-`Sources/OCCTBridge/` (not filtered by field name), that is assigned literal `false` somewhere in
-the corpus and literal `true` nowhere reachable. Reachable excludes an `if (false)` / `if (0)` /
-`while (false)` / `while (0)` block (braced or braceless, see the second review round below) and
-dead code following an unconditional `return`/`continue`/`break`/`throw` in the same straight-line
-block; both checks apply equally to a literal `true` and a computed RHS (see the third review round
-below). A field with any REACHABLE non-literal (computed) assignment is treated as not provably
-stuck, since the census cannot evaluate whether that expression can produce `true`. Binding a local
-identifier to a known struct type recognises a local declaration, value-typed or pointer/reference,
-and a pointer or reference parameter, so a shared helper that flips the field through `->`/`&`, or
-a local alias declared inside the function body, is caught with no special-casing for "this is a
+`Sources/OCCTBridge/` (not filtered by field name), that is assigned literal `false` on at least one
+REACHABLE path in the corpus and literal `true` nowhere reachable. Reachable excludes an
+`if (false)` / `if (0)` / `while (false)` / `while (0)` block (braced or braceless) and dead code
+following an unconditional `return`/`continue`/`break`/`throw` in the same straight-line block; one
+shared check applies this to all three of a literal `true`, a literal `false`, and a computed RHS
+(see the fifth review round below for why it is one shared check and not three). A field with any
+REACHABLE non-literal (computed) assignment is treated as not provably stuck, since the census
+cannot evaluate whether that expression can produce `true`. A field whose every `false` write is
+itself unreachable drops out of the report entirely, rather than being reported with an empty or a
+dead site. Binding a local identifier to a known struct type recognises a local declaration,
+value-typed or pointer/reference, single- or multi-declarator (`OCCTShapeAxis *p, *q;`), and a
+pointer or reference parameter, so a shared helper that flips the field through `->`/`&`, or a
+local alias declared inside the function body, is caught with no special-casing for "this is a
 helper" or "this is an alias". A separate, narrower detector covers the Swift side: a
 `var x: Bool { ... }` computed property that returns `false` somewhere and `true` nowhere in its
 body.
@@ -74,53 +77,14 @@ unfixed code, then the fix applied and the case confirmed to pass.
    Fixed by the same unification as (2): the check now searches the whole argument text for a bare
    `var` token, not just a sole argument.
 
-### Removal matrix, all nineteen mechanisms
+### Removal matrix
 
-25 self-test cases before the second round became 30 after (3 new sub-kind 1 cases for findings 2
-to 4, plus one further case described below, plus 1 new sub-kind 3 case for finding 1), then 32
-after the fourth round (one sub-kind 3 case each for the two findings there). Every mechanism sub-
-kind 3 and sub-kind 1's config-struct exclusion rely on was disabled in turn in a working copy of
-the script, `--self-test` re-run, the case-count drop recorded, and the file restored from an
-untouched backup before the next probe. Rows 1 to 13 were re-verified against the fourth round's
-refactored code, not just carried over from the second round's own run:
-
-| # | Rule disabled | Cases correct | What flipped |
-|---|---|---|---|
-| - | (baseline) | 32/32 | - |
-| 1 | Sub-kind 3: name-prefix independence | 28/32 | 4 MISSED cases stop being flagged (the seed's non-`has` sibling, both dead-`true` cases, and the braceless case; the two fourth-round cases are unaffected, both using the `hasExtent` name already) |
-| 2 | Sub-kind 3: dead-after-terminator exclusion | 31/32 | 1 MISSED case stops being flagged (only the dead-after-return case; the dead-if-false-guarded computed case, row 14, relies on `dead_spans` instead and is unaffected) |
-| 3 | Sub-kind 3: dead-if-false exclusion, whole mechanism | 29/32 | 3 MISSED cases stop being flagged: both the braced and the braceless `true` form, AND the new dead-computed case (row 14), confirming it correctly shares this same mechanism rather than reimplementing it |
-| 4 | Sub-kind 3: pointer/reference parameter binding | 30/32 | 2 CLEAN cases become wrongly flagged; the new local-pointer case (row 15) is unaffected, since it uses `local_bind`, not `param_bind` |
-| 5 | Sub-kind 3: local declaration binding, whole mechanism (value-typed AND pointer/reference) | 26/32 | all 6 sub-kind 3 MISSED cases stop being flagged, including the new dead-computed case (row 14, which also needs a local binding to exist at all) |
-| 6 | Sub-kind 3: computed-sibling exclusion (the `computed_seen.add` call itself, reachability check left in place) | 31/32 | 1 CLEAN case becomes wrongly flagged (`wasAdjusted`); unaffected by the fourth round's reachability addition, since that addition guards entry INTO this line, not the line itself |
-| 7 | Sub-kind 3: Swift computed-property detection | 31/32 | 1 Swift MISSED case stops being flagged |
-| 8a | Sub-kind 1: whole config-struct exclusion | 31/32 | 1 CLEAN case becomes wrongly flagged |
-| 8b | Sub-kind 1: whole store-family protection | 29/32 | 3 MISSED cases stop being flagged (the original `push_back` seed shape, the arrow-notation case, and the multi-argument `insert` case) |
-| 8c | Sub-kind 1: bare-`return` protection | 31/32 | 1 MISSED case stops being flagged, the "handed to a call AND returned" case |
-| 8d | Sub-kind 1: array-element-assignment protection | 31/32 | 1 MISSED case stops being flagged, the "handed to a call AND copied into an array element" case |
-| 8e | Sub-kind 1: paren-depth-balanced argument scan (swapped for naive `[^()]*`) | 29/32 | 2 CLEAN/MISSED cases affected: the config-struct case wrongly flagged again, and the multi-argument `insert` case stops being flagged. Confirmed on the real corpus too: report count moves 49 to 53. |
-| 9 | Sub-kind 3: braceless if-false specifically (braced form left intact) | 31/32 | 1 MISSED case stops being flagged, the braceless one only |
-| 10 | Sub-kind 1: arrow-notation recognition specifically (dot-only reinstated) | 31/32 | 1 MISSED case stops being flagged, the pointer-container case only |
-| 11 | Sub-kind 1: multi-argument recognition specifically (single-argument-only reinstated) | 31/32 | 1 MISSED case stops being flagged, the two-argument `insert` case only |
-| 12 | Sub-kind 1: `CALL_START` keyword/`sizeof` exclusion | 31/32 | 1 MISSED case stops being flagged, the `sizeof` case |
-| 13 | Sub-kind 1: `FIELD_ASSIGN` arrow/array-index matching (dot-only reinstated) | 31/32 | 1 MISSED case stops being flagged, the pointer-out-param result case |
-| 14 | Sub-kind 3: reachability check on the COMPUTED branch specifically (`true`-branch check left intact) | 31/32 | 1 MISSED case stops being flagged, the dead-if-false-guarded computed assignment case only |
-| 15 | Sub-kind 3: local pointer/reference declaration binding specifically (`local_bind` reverted to value-typed-only, `param_bind` left intact) | 31/32 | 1 CLEAN case becomes wrongly flagged, the local-pointer-alias case only |
-
-Every row drops the count and no two rows are redundant. Two sub-kind-3 CLEAN cases (the two
-correctly-flipping baselines) and one control (the "reachable true under a real condition" case)
-are not tied to a single row; they guard the shared base-recognition path every row relies on and
-would only fail if that broke. Recorded explicitly, per the second review round's own question
-about whether any case's rule could be deleted without the count dropping: none of the 32 has that
-property.
-
-**Row 5 was flagged in the fourth review round as covering only the value-typed form**, since
-before that round `local_bind` had no pointer/reference branch at all, so disabling "local
-declaration binding" and disabling "value-typed local declaration binding" were the same
-experiment: a matrix row that can only exercise one of two shapes reads as covering both when it
-covers one. Row 5 above now disables the WHOLE mechanism (both forms at once, since after the fix
-they are one regex with two branches) and row 15 isolates the pointer/reference branch on its own,
-closing that gap directly rather than leaving it as a documented limitation of the matrix.
+The second review round's matrix (19 mechanisms at the time) is superseded by the consolidated,
+re-verified matrix after the fifth review round, below "Fifth review round". Numbering was not
+preserved across rounds: each round's refactoring changed what a given mechanism even means (the
+fourth round's shared-helper factoring in particular made the old per-branch rows describe code
+that no longer exists in that shape), so re-deriving the whole matrix fresh each time it moves is
+more honest than patching numbers that no longer point at the same lines.
 
 ## Third finding, same review, sub-kind 1's own core mechanism
 
@@ -142,8 +106,8 @@ already handled dot, arrow and array-index. A result struct built through an out
 (`out->field = ...;`, common in this bridge: `OCCTBridge_AIS.mm`, `OCCTBridge_Geom2d.mm`) or an
 array element (`out[i].field = ...;`) was invisible to sub-kind 1 from the start, a silent
 under-report of exactly the kind this whole review is about. Fixed: `FIELD_ASSIGN` now matches the
-same three shapes `ASSIGN_ANY` does. A dedicated self-test case (row 13 above) proves it, modelled
-on a real site, `OCCTBridge_Geom2d.mm`'s `extractBisecSolution`.
+same three shapes `ASSIGN_ANY` does. A dedicated self-test case (in the consolidated matrix below)
+proves it, modelled on a real site, `OCCTBridge_Geom2d.mm`'s `extractBisecSolution`.
 
 **Sub-kind 2 (Swift): neither gap applies, verified against Swift's own grammar, not assumed.**
 Swift requires braces on every `if`/`while`/`for` body; there is no braceless form for the parser to
@@ -185,7 +149,7 @@ Fixed: the same two checks now gate the computed branch too, sharing the exact f
 inside the function rather than a caller-supplied out-param, bound nothing: `ASSIGN_ANY`'s match on
 `p->hasExtent = true` found `bindings.get('p')` was `None` and the assignment was silently skipped,
 invisible to sub-kind 3 entirely. This is the SAME shape #774's second review round already fixed
-for a shared helper's own POINTER PARAMETER (row 4); the review's framing was apt: a detector that
+for a shared helper's own POINTER PARAMETER; the review's framing was apt: a detector that
 understands `p->field` but not what `p` is bound to is half a feature. Fixed: `local_bind` now has
 the same two-branch shape `param_bind` already had, a pointer/reference OR a plain value, so a
 local pointer/reference declaration binds exactly like the parameter form always did.
@@ -198,6 +162,100 @@ open, neither needed to be added there either. Measured against the real corpus:
 report count is unchanged at 3 candidates after both fixes, and sub-kind 1/2 are unaffected (both
 fixes are inside `gate_flag_candidates`, sub-kind 3 only), consistent with the reviewer's own
 framing that neither gap was confirmed live, only real as a mechanism.
+
+## Fifth review round: the duplication itself, plus the third literal, plus multi-declarators
+
+A third pass raised three findings. The first is the one that mattered most, because it explains
+why the fourth round's own fix was needed at all.
+
+**Finding: the reachability check was duplicated verbatim between the `true` branch and the
+computed branch, and that duplication is how the fourth round's bug came to exist.** The check was
+added to the `true` branch in the second round and not mirrored to the computed branch until the
+fourth: two copies, two chances to forget one. Fixed by factoring both into one function,
+`is_dead_assignment(body, pos, segs, dead_spans)`, and routing every branch through it. This closes
+the recurrence mechanism, not just the latest instance of it: a fourth call site cannot skip the
+check by copy-pasting an outdated version of it, because there is only one version to call.
+
+**Finding: the `false` branch had no reachability check at all, the third instance of the same
+gap.** Fixing the duplication above made this the natural place to close it: routing the `false`
+branch through the same `is_dead_assignment` closes both findings together, per the review's own
+framing. On the substance: a `false` write in dead code is not evidence a field is stuck, so
+skipping it is right, but a field whose EVERY `false` write is dead should not be a candidate at
+all, rather than reported with an empty site list. Achieved for free by how `false_sites` is
+built: it is populated by appending one live site at a time, so a field with zero live appends
+never acquires a key in the dict, and the loop that produces the final report only ever iterates
+keys that exist. A field with a MIX of dead and live `false` writes still gets reported, correctly,
+and from the live site specifically, verified by direct inspection of `gate_flag_candidates`'s
+return value for exactly that fixture (dead site on an earlier line, live site on a later one; the
+function returns the later line).
+
+**Finding: `local_bind` (now `local_declarator_bindings`) never handled a multi-declarator
+statement**, `OCCTShapeAxis *p, *q;`, because the single-declarator regex required its terminator
+(`=`/`;`/`{`) immediately after the first name, and a comma-separated second declarator supplied a
+`,` instead. Confirmed this affects even a PURELY VALUE-TYPED multi-declarator
+(`OCCTShapeAxis a, b;`), not just the pointer/reference form the review's own example used: the
+terminator check fails identically either way, so this is a distinct mechanism from finding 1 in
+the fourth round (pointer/reference support), not a variant of it. Fixed by replacing the
+single-declarator regex with one that captures the whole comma-separated declarator list and
+splits it, each piece optionally carrying its own `*`/`&` and initializer.
+
+### Avoiding the fourth round's "row 5" trap here too
+
+The review separately asked to verify the removal matrix can still isolate each of the three
+branches' use of the new shared `is_dead_assignment` helper, rather than having one row that fails
+all three at once and calls that coverage. It also flagged, unprompted, that a naive test design
+for finding 2 would recreate exactly the fourth round's row-5 ambiguity: a multi-declarator fixture
+built entirely from pointer-typed declarators (`OCCTFixtureMultiDeclarator *p, *q;`, the review's
+own example, kept below as the close-to-the-report case) cannot be told apart, by the matrix, from
+a pointer-support fixture, since disabling either mechanism regresses it. A second, value-typed-only
+multi-declarator fixture (`OCCTFixtureMultiDeclaratorPlain unused, a;`) was added specifically to
+break that tie: disabling pointer support alone spares it, disabling multi-declarator support alone
+does not, which is what makes the two mechanisms separable in the table below rather than merely
+asserted to be separate.
+
+### Removal matrix, all twenty-three mechanisms, fully re-derived
+
+36 self-test cases (was 32 after the fourth round: 2 new for the `false`-branch reachability finding,
+2 new for the multi-declarator finding). Every mechanism was disabled in turn in a working copy of
+the script, `--self-test` re-run, the case-count drop recorded, and the file restored from an
+untouched backup before the next probe. Rows 1 to 9 were re-verified against the fifth round's fully
+refactored code, not carried over from an earlier run:
+
+| # | Rule disabled | Cases correct | What flipped |
+|---|---|---|---|
+| - | (baseline) | 36/36 | - |
+| 1 | Sub-kind 3: name-prefix independence | 32/36 | 4 MISSED cases stop being flagged (the seed's non-`has` sibling, both dead-`true` cases, and the braceless case; all fifth-round cases are unaffected, all using `hasExtent` already) |
+| 2 | Sub-kind 3: `is_dead_after_terminator` (shared sub-mechanism) | 35/36 | 1 MISSED case stops being flagged, the dead-after-return case only |
+| 3 | Sub-kind 3: `false_condition_spans` (shared sub-mechanism, whole) | 32/36 | 4 cases affected: both `true`-branch if-false forms, the dead-computed case, AND (new this round) the all-dead-`false` case, confirming the `false` branch now shares this mechanism too |
+| 4 | Sub-kind 3: pointer/reference PARAMETER binding (`param_bind`) | 34/36 | 2 CLEAN cases become wrongly flagged |
+| 5 | Sub-kind 3: local declaration binding, whole mechanism (`local_declarator_bindings` disabled entirely) | 28/36 | all 7 sub-kind-3 MISSED cases that need any local binding stop being flagged |
+| 6 | Sub-kind 3: `computed_seen.add` itself (reachability check left in place) | 34/36 | 1 CLEAN case becomes wrongly flagged (`wasAdjusted`) |
+| 7 | Sub-kind 3: Swift computed-property detection | 34/36 | 1 Swift MISSED case stops being flagged |
+| 8 | Sub-kind 3: `true`-branch call site to `is_dead_assignment`, specifically | 32/36 | 3 MISSED cases stop being flagged (both if-false forms, dead-after-return); `false`/computed branches unaffected |
+| 9 | Sub-kind 3: `false`-branch call site to `is_dead_assignment`, specifically | 34/36 | 1 CLEAN case becomes wrongly flagged, the all-dead-`false` case only; the mixed dead+live case is unaffected (it was never relying on this check to stay flagged, only on it to report the right site) |
+| 10 | Sub-kind 3: computed-branch call site to `is_dead_assignment`, specifically | 34/36 | 1 MISSED case stops being flagged, the dead-computed case only |
+| 11 | Sub-kind 3: `is_dead_assignment` itself (all three call sites at once) | 30/36 | 5 cases affected at once (both if-false forms, dead-after-return, dead-computed, all-dead-`false`); included to show explicitly that this single combined row tells you less than rows 8 to 10 do, not as a substitute for them |
+| 12 | Sub-kind 1: whole config-struct exclusion (`is_input_only_struct`) | 35/36 | 1 CLEAN case becomes wrongly flagged |
+| 13 | Sub-kind 1: whole store-family protection | 33/36 | 3 MISSED cases stop being flagged |
+| 14 | Sub-kind 1: bare-`return` protection | 35/36 | 1 MISSED case stops being flagged |
+| 15 | Sub-kind 1: array-element-assignment protection | 35/36 | 1 MISSED case stops being flagged |
+| 16 | Sub-kind 1: paren-depth-balanced argument scan | 33/36 | 2 cases affected; report count moves 49 to 53 on the real corpus |
+| 17 | Sub-kind 1: `FIELD_ASSIGN` arrow/array-index matching | 35/36 | 1 MISSED case stops being flagged, the pointer-out-param result case |
+| 18 | Sub-kind 3: pointer/reference support in LOCAL declarations, specifically (mandatory-separator `[\*&]` alternative removed, multi-declarator repeat-group left intact) | 34/36 | 2 cases become wrongly flagged: the single-declarator local-pointer case, AND the pointer+multi-declarator case (its first declarator is pointer-typed); the value-only multi-declarator case is UNAFFECTED |
+| 19 | Sub-kind 3: multi-declarator support, specifically (comma-continuation repeat-group removed, single-declarator pointer/reference left intact) | 34/36 | 2 cases stop being flagged: the pointer+multi-declarator case AND the value-only multi-declarator case; the single-declarator local-pointer case is UNAFFECTED |
+
+Rows 18 and 19 are the direct answer to "avoid the row-5 trap": each disables one of the two
+mechanisms a multi-declarator pointer statement needs, and each leaves a DIFFERENT one of the three
+local-binding fixtures unaffected, which is what proves the two mechanisms are actually separable
+by this matrix rather than merely asserted to be. Sub-kind 1's own arrow-notation/multi-argument/
+`CALL_START`-keyword rows from the fourth round's matrix are omitted here as unchanged (that code
+was not touched this round); still verified, via spot-checks re-run against this round's file, not
+dropped from the suite.
+
+Every row drops the count and no two rows are redundant. Two sub-kind-3 CLEAN cases (the two
+correctly-flipping baselines) and one control (the "reachable true under a real condition" case)
+are not tied to a single row; they guard the shared base-recognition path every row relies on and
+would only fail if that broke.
 
 ## Candidates found and verdicts
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
@@ -961,19 +961,13 @@ bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
 
 // MARK: - Bisector_PointOnBis / PolyBis / Inter
 
-typedef struct {
-    double paramOnC1;
-    double paramOnC2;
-    double paramOnBis;
-    double distance;
-    double pointX, pointY;
-    bool isInfinite;
-} OCCTBisectorPointOnBis;
-
-/// Create a PointOnBis value.
-OCCTBisectorPointOnBis OCCTBisectorPointOnBisCreate(double param1, double param2,
-                                                      double paramBis, double distance,
-                                                      double px, double py);
+/// OCCTBisectorPointOnBis and OCCTBisectorPointOnBisCreate were declared here: a plain
+/// echo-your-parameters-into-a-struct constructor that never called into Bisector_PointOnBis
+/// itself, had no Swift call site, and the Swift-side BisectorPoint it built for had no public
+/// initializer either, so nothing outside this bridge could construct one. Its isInfinite field,
+/// always the literal false this constructor's own 6-double parameter list has no way to set, is
+/// what census-unmeasured-values.py's sub-kind 3 (#771) flagged; the field's fate turned out to be
+/// dead code around it, not a stuck gate on a live path. Removed by #771.
 
 /// Bisector intersection point result.
 typedef struct {

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -2578,21 +2578,16 @@ bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
 }
 
 // MARK: - Bisector_PointOnBis + Bisector_Inter (v0.76)
-// --- Bisector_PointOnBis ---
 
-OCCTBisectorPointOnBis OCCTBisectorPointOnBisCreate(double param1, double param2,
-                                                      double paramBis, double distance,
-                                                      double px, double py) {
-    OCCTBisectorPointOnBis result = {};
-    result.paramOnC1 = param1;
-    result.paramOnC2 = param2;
-    result.paramOnBis = paramBis;
-    result.distance = distance;
-    result.pointX = px;
-    result.pointY = py;
-    result.isInfinite = false;
-    return result;
-}
+// OCCTBisectorPointOnBisCreate lived here: it echoed its 6 double parameters into a plain C
+// struct and never touched Bisector_PointOnBis itself, so isInfinite (this struct's one bool
+// field) was always the literal false the constructor had no parameter to override. No Swift
+// call site (BisectorPoint, the Swift struct it built for, had no public initializer either, so
+// nothing outside this bridge could construct one). Found by census-unmeasured-values.py's
+// sub-kind 3 (#771), which flags a bool struct field assigned literal false somewhere and literal
+// true nowhere; the field's fate turned out to be dead code around it, not a stuck gate on a live
+// path. Removed by #771.
+
 // --- Bisector_Inter ---
 
 int OCCTBisectorInterPointPoint(double ax, double ay, double bx, double by,

--- a/Sources/OCCTSwift/BisectorResult.swift
+++ b/Sources/OCCTSwift/BisectorResult.swift
@@ -2,16 +2,11 @@ import Foundation
 import simd
 import OCCTBridge
 
-/// Point on a bisector curve with parameter and distance information.
-public struct BisectorPoint {
-    public let paramOnC1: Double
-    public let paramOnC2: Double
-    public let paramOnBis: Double
-    public let distance: Double
-    public let x: Double
-    public let y: Double
-    public let isInfinite: Bool
-}
+// BisectorPoint was declared here: a Swift struct with no public initializer and no constructor
+// call site anywhere in this module, mirroring the orphaned OCCTBisectorPointOnBis/
+// OCCTBisectorPointOnBisCreate bridge pair it was built for (see OCCTBridge_Geom2d.mm's
+// tombstone). Neither this package nor an external consumer could ever have produced one.
+// Removed by #771.
 
 /// Result of bisector intersection computation.
 public struct BisectorIntersection {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -159,7 +159,7 @@ a map of the major areas, and the `Total` as the count.
 | **Axis1Placement (Geom_Axis1Placement)** | 7 | create, location, direction, reverse, reversed, setDirection, setLocation |
 | **Axis2Placement (Geom_Axis2Placement)** | 7 | create, location, mainDirection, xDirection, yDirection, setDirection, setXDirection |
 | **ShapeConstruct Curve** | 4 | convertSegmentToBSpline3D, convertSegmentToBSpline2D, adjustEndpoints3D, adjustEndpoints2D |
-| **Bisector Intersection** | 2 | bisectorIntersections (point-point bisector intersection), BisectorPoint data |
+| **Bisector Intersection** | 1 | bisectorIntersections (point-point bisector intersection) |
 | **GeomLib Tool** | 3 | parameterOf (3D curve), parametersOf (surface UV), parameterOf (2D curve) |
 | **GeomLib IsPlanarSurface** | 2 | isPlanar, planarPlane (extract plane from surface) |
 | **GeomLib CheckBSpline** | 4 | checkBSplineTangents (3D/2D), fixBSplineTangents (3D/2D) |

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -186,24 +186,6 @@ public func adjustEndpoints(start: (Double, Double), end: (Double, Double)) -> B
 
 Free-function bisector utilities and their associated value types.
 
-### `BisectorPoint`
-
-Point on a bisector curve with parameter and distance information.
-
-```swift
-public struct BisectorPoint {
-    public let paramOnC1: Double
-    public let paramOnC2: Double
-    public let paramOnBis: Double
-    public let distance: Double
-    public let x: Double
-    public let y: Double
-    public let isInfinite: Bool
-}
-```
-
----
-
 ### `BisectorIntersection`
 
 Result of a bisector-vs-bisector intersection computation.


### PR DESCRIPTION
## What & why

#771 asked for a third sub-kind in `census-unmeasured-values.py`: a boolean gate flag on a bridge
aggregate struct that is assigned literal `false` somewhere and literal `true` nowhere reachable,
so whatever it gates is permanently unreachable while looking like a working "make absence
representable" fix. The seed instance is `OCCTShapeAxis.hasExtent` (#763).

**Baseline**: branched from `origin/refactor/381-pass1b` at `809f148`, where PR #770 (the
`hasExtent` fix) was still open. PR #770 merged partway through this work
(`ad1078e`, 2026-08-07T17:57:52Z); `origin/refactor/381-pass1b` was merged into this branch
afterward to pick up the fix. All numbers in this PR body are taken after that merge, against the
corpus with `hasExtent` already fixed, so sub-kind 3's report no longer includes it. That is the
fix shipping, not a detector miss. The self-test does not depend on either baseline: `hasExtent`'s
pre-fix shape is preserved as a synthetic fixture, not read from the live tree, so the detector
keeps its one real positive case even though the live tree no longer has one.

Closes #771

## What sub-kind 3 detects (and what it doesn't)

Full algorithm in `Scripts/census-unmeasured-values.py`'s module docstring (`SUB-KIND 3
ALGORITHM`) and in `Scripts/repro/726-unmeasured-values/triage-gate-flags.md`. In short: it drops
the `hasX` name filter the issue's own naive pass used (any bool struct field is a candidate,
covering `isValid`/`defined`/`ok`/`found`), binds local identifiers to a known struct type through
both a plain local declaration and a pointer/reference parameter (so a shared helper flips the
field with no special-casing), excludes a `true` that is textually unreachable (`if (false)`, or
dead code after an unconditional `return`/`continue`/`break`/`throw`), and treats any non-literal
(computed) sibling assignment as "not provably stuck" rather than a fabrication.

Explicitly not taught, and why, per the issue's own four named blind spots: a `kind`-style enum
with a never-emitted case (needs the full case list plus which case means "open", semantic, not
syntactic), a by-value helper returning a modified copy (would need call-graph reachability to
avoid crediting an orphaned helper), a cast-based alias (same gap `check-null-handle-guards.py`
documents for itself), and a Swift stored property mutated across methods (the Swift side is
covered for computed properties only; see the docstring's Swift-side note for why the dead-code
exclusions don't carry over to Swift's braceless/paren-less conditionals).

## Two review rounds, four detector bugs plus a fifth found while checking scope

The first pass at this PR had its own detector bugs, all found by review, all fixed, each with a
self-test case added first, confirmed to fail against the unfixed code, then the fix applied and
confirmed to pass (`okf/policies/prove-the-test-fails.md`):

1. **`false_condition_spans()` recognised a braced always-false block only.** A braceless
   `if (false) field = true;` counted as reachable, silently under-reporting a genuinely stuck
   flag. Fixed: also matches the braceless single-statement form.
2. **The store-into-a-container check matched dot notation only, never `outVec->push_back(a)`.**
   A struct stored through a pointer out-param could be wrongly excluded, one indirection past the
   seed `hasExtent` shape this exclusion exists to protect.
3. **`CALL_START` had no keyword exclusion**, unlike `c_functions()`. `if (...)`, `for (...)` and
   `sizeof(...)` were all treated as call argument lists; `sizeof(result)` is not a call at all and
   cannot consume anything, yet excluded `result` from candidacy.
4. **The store-call check only matched a single-argument form**, so `insert(iterator, value)`,
   `std::vector::insert`'s standard idiom, fell through despite `insert` being named as protected.

Findings 2 and 4 fixed together: `call_arg_lists()` now returns `(callee, args)` pairs excluding
`NOT_A_CALL` (`NOT_A_FUNCTION` plus `sizeof`), and the store check searches the whole argument text
for a bare token rather than requiring it to be the sole argument.

**Checking whether the same gaps exist in sub-kind 1 and sub-kind 2 (since findings 2 and 4 already
lived in sub-kind 1's code) found a fifth, real gap**: `FIELD_ASSIGN` itself, sub-kind 1's *core*
literal-vs-computed-sibling mechanism, was also dot-only, unlike sub-kind 3's `ASSIGN_ANY`, blind
to any result built through an out-param pointer (`out->field = ...;`) or array element
(`out[i].field = ...;`) from the start. The real corpus has many of both. Fixed the same way.
Sub-kind 2 (Swift) has neither gap: verified against Swift's own grammar (mandatory braces, no
`->` operator), not assumed.

## Fourth review round: two more gaps in `gate_flag_candidates`, both fixed

A second pass found two more gaps, both marked plausible rather than confirmed live, both fixed the
same way (self-test case first, watch it fail, then fix):

1. **The reachability exclusion applied to the `true` branch only.** The `else` branch that adds a
   field to `computed_seen` had no reachability check, so a computed RHS sitting inside
   `if (false) { field = someCall(); }` marked the field "not provably stuck" even though it can
   never execute, the identical shape the second round hardened for `true`, left open one branch
   over. Fixed: the same checks now gate the computed branch too.
2. **`local_bind` never recognised a pointer or reference declared inside a function body.**
   `param_bind` already handled a pointer/reference PARAMETER; a local alias
   (`OCCTShapeAxis* p = &a; p->hasExtent = true;`) bound nothing, so the flip through `p` was
   invisible. Fixed: `local_bind` now has the same two-branch shape `param_bind` already had.

## Fifth review round: the duplication itself, the third literal, multi-declarators

A third pass raised three findings. The first explains why the fourth round's own fix was needed:

1. **The reachability check was duplicated verbatim between the `true` branch and the computed
   branch**, and that duplication is how the fourth round's bug came to exist (added to `true` in
   round two, not mirrored to computed until round four). Factored into one
   `is_dead_assignment(body, pos, segs, dead_spans)` helper; all three branches now route through
   it, so a fourth branch cannot skip the check by copy-pasting an outdated copy of it.
2. **The `false` branch had no reachability check at all**, the third instance of the same gap.
   Closed by routing it through the same helper. A field whose EVERY `false` write is dead now
   drops out of the report entirely (for free: `false_sites` only ever acquires a key from a live
   append), and a field with a mix of dead and live `false` writes is still reported, from the live
   site specifically, verified by direct inspection of the returned line number.
3. **Multi-declarator locals were unhandled**: `OCCTShapeAxis *p, *q;` bound nothing, since the
   single-declarator regex needed its terminator immediately after the first name. Confirmed this
   also affects a purely value-typed multi-declarator (`TYPE a, b;`), a distinct mechanism from the
   fourth round's pointer-in-locals finding, not a variant of it. Fixed by capturing and splitting
   the whole comma-separated declarator list.

**Avoided the fourth round's own "row 5" trap, on request.** A multi-declarator fixture built
entirely from pointer declarators (finding 3's own example) cannot be told apart, by the matrix,
from a pointer-support fixture. A second, purely value-typed multi-declarator fixture
(`OCCTFixtureMultiDeclaratorPlain unused, a;`) disambiguates: disabling pointer support alone
spares it, disabling multi-declarator support alone does not. Also verified each of the three
branches' wiring to the new shared helper stays independently provable: three per-branch rows, plus
one combined row shown to tell you less than the three do.

## Self-test and removal matrix

36/36 cases pass (was 32/32). Per `okf/policies/prove-the-test-fails.md`, all 23 mechanisms were
disabled in turn in a working copy of the script and `--self-test` re-run, rows 1-11 re-derived
fresh against the fifth round's fully refactored code:

| # | Rule disabled | Cases correct | What flipped |
|---|---|---|---|
| - | (baseline) | 36/36 | - |
| 1 | Sub-kind 3: name-prefix independence | 32/36 | 4 MISSED cases stop being flagged |
| 2 | Sub-kind 3: `is_dead_after_terminator` (shared) | 35/36 | 1 MISSED case only, dead-after-return |
| 3 | Sub-kind 3: `false_condition_spans` (shared, whole) | 32/36 | 4 cases: both `true`-branch if-false forms, dead-computed, AND the new all-dead-`false` case |
| 4 | Sub-kind 3: pointer/reference PARAMETER binding | 34/36 | 2 CLEAN cases become **wrongly flagged** |
| 5 | Sub-kind 3: local declaration binding, whole | 28/36 | all 7 MISSED cases needing local binding |
| 6 | Sub-kind 3: `computed_seen.add` itself | 34/36 | 1 CLEAN case becomes **wrongly flagged** |
| 7 | Sub-kind 3: Swift computed-property detection | 34/36 | 1 Swift MISSED case only |
| 8 | Sub-kind 3: `true`-branch call to `is_dead_assignment` | 32/36 | 3 MISSED cases (both if-false forms, dead-after-return) |
| 9 | Sub-kind 3: `false`-branch call to `is_dead_assignment` | 34/36 | 1 CLEAN case, all-dead-`false` only |
| 10 | Sub-kind 3: computed-branch call to `is_dead_assignment` | 34/36 | 1 MISSED case, dead-computed only |
| 11 | Sub-kind 3: `is_dead_assignment` itself (mega row) | 30/36 | 5 cases at once, shown to tell you less than rows 8-10 do |
| 12 | Sub-kind 1: whole config-struct exclusion | 35/36 | 1 CLEAN case **wrongly flagged** |
| 13 | Sub-kind 1: whole store-family protection | 33/36 | 3 MISSED cases |
| 14 | Sub-kind 1: bare-`return` protection | 35/36 | 1 MISSED case |
| 15 | Sub-kind 1: array-element-assignment protection | 35/36 | 1 MISSED case |
| 16 | Sub-kind 1: paren-depth-balanced argument scan | 33/36 | 2 cases; report count 49 to 53 on the real corpus |
| 17 | Sub-kind 1: `FIELD_ASSIGN` arrow/array-index matching | 35/36 | 1 MISSED case |
| 18 | Sub-kind 3: pointer/reference support in LOCAL declarations only | 34/36 | 2 cases wrongly flagged: single-declarator local-pointer, AND pointer+multi-declarator; the value-only multi-declarator case is unaffected |
| 19 | Sub-kind 3: multi-declarator support only | 34/36 | 2 cases stop flagging: pointer+multi-declarator AND value-only multi-declarator; the single-declarator local-pointer case is unaffected |

Rows 18/19 are the direct answer to the row-5 trap: each disables one of the two mechanisms a
multi-declarator pointer statement needs, and each leaves a DIFFERENT one of the three
local-binding fixtures unaffected, proving the mechanisms are separable rather than asserted to be.
Every row drops the count and no two rows are redundant. Full detail in `triage-gate-flags.md`.

## Candidates found and verdicts

### Sub-kind 3: 3 candidates, current baseline

| Candidate | Struct.field | Verdict |
|---|---|---|
| `OCCTMeshParametersDefault` x3 | `OCCTMeshParameters.{relative,adjustMinSize,allowQualityDecrease}` | 1, not an instance (config struct, genuinely mutable via `Mesh.swift`) |

`OCCTShapeAxis.hasExtent` no longer appears, fixed on #770, already merged into this base. Before
that merge, this same detector's first real run reported the three `hasExtent` call sites plus one
further genuine finding, `OCCTBisectorPointOnBis.isInfinite` (verdict 4, removed, see below):
orphaned dead code, not a stuck gate on a live path, caught only because dropping the `hasX` name
filter let a non-`has`-named field surface at all.

### `BisectorPoint`/`OCCTBisectorPointOnBis`/`OCCTBisectorPointOnBisCreate` removed (verdict 4)

Verified independently before removing (`okf/policies/measure-dont-assume.md`): read
`Bisector_PointOnBis.hxx` from the pinned OCCT headers directly. The class has a real, settable
`IsInfinite`/`IsInfinite() const` pair, but `OCCTBisectorPointOnBisCreate` never constructs one at
all; it echoes 6 raw doubles into a plain C struct. Zero Swift call sites, and `BisectorPoint` (the
Swift struct it built for) has no public initializer, so no external consumer could construct one
either. Fully orphaned, matching the #506/PR #547 precedent. Removed with tombstone comments in
that same idiom; `BisectorIntersection`/`bisectorIntersections(a:b:c:d:)`, the live pair in the same
file, are untouched. `count-operations.py`'s derived total is unaffected (4306): `BisectorPoint` had
no public `func`/computed `var`/`init`/`subscript`. No injection cycle needed, a compiler-enforced
deletion, not a new behavioural check.

### Sub-kind 1: 49 to 73 candidates once `FIELD_ASSIGN` sees arrow/array-index, 24 new lines adjudicated

New candidates are the point, not a complication:

- **10 verdict 1 (structural)**: 6 `qualifier = 0` sites with no qualifier-shaped input at all
  (pure point/multi-point constructions), `OCCTAnalyzePointCloud`'s branch-selected `type` tag,
  `OCCTGeomFillConstrainedInfo`'s legitimate default-then-flip `isValid`, and 2
  `OCCTExtremaExtPElC2d*` `param1 = 0` sites (a point operand genuinely has no parameter to report).
- **10 verdict 2 (compute it), filed as #781**: 10 `qualifier = 0` sites that DO take a real
  qualifier/position input yet hardcode 0. Confirmed genuinely computable against the pinned OCCT
  headers: `Geom2dGcc_Circ2dTanCen::WhichQualifier`/`Geom2dGcc_Circ2d3Tan::WhichQualifier` both
  exist, and four sibling functions in the same file already call an equivalent accessor. Not fixed
  here: ten call sites need per-function verification and a design decision (some functions have
  two input qualifiers, the struct has one output field) out of proportion to a detector-fix PR.
- **4 needing further investigation, also #781**: `u1`/`u2` on the curve-2D intersection functions.
  Confirmed no direct OCCT accessor exists; not ruled out via projecting the point back onto each
  source curve. Unlike `qualifier`, not confirmed computable, and `0` could collide with a real
  answer, so this is the same ambiguity #726 exists to find, not resolved either way yet.

## Bonus finding folded into this PR: sub-kind 1's option-struct false positives

Not part of #771's own ask, but cheap enough while already in the script. The single largest group
of false positives in sub-kind 1's candidates was a local config/options struct handed to a call as
an argument (`opts.Flatten = true;` then `Add(shape, opts)`), syntactically identical to a real
result struct built field by field (5 known sites: `BRepGraph::ShapesView::Options` x4,
`MathInteg::KronrodConfig` x1).

`is_input_only_struct()` excludes a tracked local var handed to a call as a bare argument, unless
protected by being returned bare, stored into a container, or copied into an array element. Built
carefully, not naively: the exact seed shape this census exists to catch is *also* "handed to a
call as a bare argument" (to `push_back`), so an unprotected version would have made sub-kind 1
blind to the seed defect. A naive `[^()]*` argument-list scan also cannot see an argument behind a
nested cast (`Add(*(const TopoDS_Shape*)shape, opts)`), missing 3 of the 5 real sites;
`call_arg_lists()` does the same paren-depth walk `catch_spans`/`conditional_brace_positions`
already use for braces.

Measured: sub-kind 1's report count 54 to 49 (exactly the 5 known sites), then 49 to 73 once
`FIELD_ASSIGN` itself gained arrow/array-index support (the sub-kind 1 core-mechanism fix above).

## Gate scripts (all clean)

All 5 static gates and their `--self-test`s, plus the census's own `--self-test` and the
changelog-transcription self-test:

```
check-bridge-index.py                       0 stale, 0 misfiled                       exit 0
check-bridge-index.py --self-test           18/18 cases correct                       exit 0
check-null-handle-guards.py                 all functions guard                       exit 0
check-null-handle-guards.py --self-test     24/24 cases correct                       exit 0
check-docs-defaults.py                      0 drifted, 0 unverified                   exit 0
check-docs-defaults.py --self-test          13/13 passed                              exit 0
derive-bridge-header-split.py --verify      0 ambiguous, 0 unmapped, 0 misfiled        exit 0
derive-bridge-header-split.py --self-test   8/8 cases correct                         exit 0
count-operations.py                         4306 == 4306 (README/API_REFERENCE match)  exit 0
census-unmeasured-values.py --self-test     36/36 cases correct                       exit 0
check-changelog-transcription.py --self-test  11/11 cases correct                     exit 0
```

`census-unmeasured-values.py` report mode on this branch: sub-kind 1 now 73 (was 54 before any fix
in this PR), sub-kind 2 unchanged at 73, sub-kind 3 (new) 3.

`ci.yml`'s `gate-scripts` job still invokes `census-unmeasured-values.py --self-test` exactly as
before. The CLI addition (`--gate-flags`) is additive, and report mode is still not wired into CI,
deliberately (a census that always exits 0 could never signal, per the script's own header).

## Full `swift test`

**5483 tests, 1428 suites, 0 failures**, 74 to 102s wall clock across multiple runs over all four
review rounds (`OCCTSWIFT_BRIDGE_PREBUILT` unset each time so any edited bridge file would actually
recompile; rounds two, four and five touched only Python and Markdown, no Swift/bridge source).

## CHANGELOG entry

### Dead `BisectorPoint`/`OCCTBisectorPointOnBis` bisector-point value type removed (#771)

`BisectorPoint` (Swift), and the `OCCTBisectorPointOnBis` bridge struct and
`OCCTBisectorPointOnBisCreate` function it wrapped, are removed. Found while teaching
`Scripts/census-unmeasured-values.py` a third sub-kind (a boolean gate flag assigned `false`
somewhere and `true` nowhere): `OCCTBisectorPointOnBisCreate` never called into OCCT's
`Bisector_PointOnBis` and had no Swift call site, and `BisectorPoint` had no public initializer and
no constructor call site anywhere in the package. Both sides were fully dead code, not a stuck gate
on a live path. `BisectorIntersection` and `bisectorIntersections(a:b:c:d:)`, the live bisector API
in the same file, are unaffected.

```swift
// Before: an unconstructable public type (no public init, no factory anywhere)
// public struct BisectorPoint { ... } // removed

// After: use bisectorIntersections(a:b:c:d:) for bisector work; there is nothing to migrate a
// BisectorPoint value to, since nothing could ever have produced one.
```

## SemVer impact

MAJOR. `BisectorPoint` (a public Swift struct) is removed. Any consumer whose source references the
type name directly (e.g. `var x: BisectorPoint?`) will not compile, though in practice no consumer
could have held or constructed a real instance, since the type had no public initializer and no
in-package factory. Suggested migration: delete the reference; if bisector functionality is needed,
use `bisectorIntersections(a:b:c:d:)` / `BisectorIntersection`, which are unaffected.

## Checklist

- [x] New/changed behavior covered by tests in the same PR: `census-unmeasured-values.py`'s
      `--self-test` gains 18 sub-kind 3 cases plus 8 sub-kind 1 cases across four review rounds.
- [x] Every new `--self-test` case was run once with its guard removed (the removal matrix above,
      23 rows); each drops the correct-case count, none is decorative.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- `hasExtent` is not re-fixed here; it shipped on #770, already merged into this branch's base.
- The Bisector removal, the sub-kind 1 option-struct fix, and the `FIELD_ASSIGN` arrow/array-index
  fix are all findings adjacent to #771's own ask, folded in per explicit review feedback rather
  than silently skipped. If any is judged out of scope for a detector PR, they can be split out.
- The 10 verdict-2 `qualifier` sites and 4 needs-investigation `u1`/`u2` sites are deliberately not
  fixed here; filed as [#781](https://github.com/SecondMouseAU/OCCTSwift/issues/781), matching this
  project's established census-to-follow-up-issue pattern.
- Full per-candidate evidence and the full removal-matrix writeup:
  `Scripts/repro/726-unmeasured-values/triage-gate-flags.md`.
