### PR TITLE
fix(#761): AAG's sharedEdgeCount is no longer capped at 10

### DIFF
--- a/Scripts/repro/761-aag-brepgraph-adjacency/README.md
+++ b/Scripts/repro/761-aag-brepgraph-adjacency/README.md
@@ -1,0 +1,192 @@
+# #761: does AAG duplicate BRepGraph's adjacency, and can it converge onto it?
+
+The census `docs/v2.0.0-plan.md`'s census-once rule asks for, built before touching any
+production code. `AAG` (`Sources/OCCTSwift/FeatureRecognition.swift`) maintains its own hand-rolled
+face/edge adjacency (`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`/`OCCTEdgeGetConvexity`), and
+`BRepGraph` (`Sources/OCCTSwift/BRepGraph.swift`) already exposes `adjacentFaces(of:)`/
+`sharedEdges(between:and:)` as first-class operations over a `BRepGraph_Tool`-backed graph. The
+issue asked whether these are the same question, drifted, or genuinely different, and to
+consolidate onto whichever is correct if they converge.
+
+**Method**: build both an `AAG` and a `BRepGraph` from the same `Shape`, map every AAG face
+occurrence (`Shape.orientedFaces()`-indexed, #642) onto its `BRepGraph` face node via
+`BRepGraph.findNode(for:)`, then measure what each side reports for the same questions, on a
+spread of fixtures. Executable, committed artifact: `swift run Censuses issue-761`, source at
+`Scripts/repro/censuses/Issue761.swift`, registered in `Scripts/repro/censuses/CensusRunner.swift`.
+This directory keeps only this README, per the convention `cluster-a-subshape-enumeration/`
+established (#694): SwiftPM only needs to see the Swift source under `Scripts/repro/censuses/`.
+
+## Headline finding: not the same question, once a face is shared across solids
+
+`BRepGraph::ShapesView::FindNode` hashes on `TopTools_ShapeMapHasher`
+(`Sources/.../TopTools_ShapeMapHasher.hxx`), whose `operator()(S1, S2)` is `S1.IsSame(S2)` --
+same underlying `TShape` and `Location`, orientation ignored. That is the *identical* collapse
+rule `Shape.faces()` uses, and the one #642's own fix moved `AAG`'s node set away from
+(`orientedFaces()`, one node per occurrence, not per distinct face) specifically because it lost
+information for whichever occurrence didn't survive the dedup.
+
+Measured directly (Part 1 of the census): on both two-solid split fixtures, `AAG.nodes.count` is
+12 (one per occurrence) while `BRepGraph.faceCount` is 11 (deduplicated) -- the same 12-vs-11 gap
+`Shape.orientedFaces().count` vs `Shape.faces().count` shows for the identical fixture. Mapping
+every occurrence to its `BRepGraph` node via `findNode(for:)` confirms why: the shared wall's two
+occurrences (opposite orientation, same `TShape`) always resolve to the **same** `BRepGraph` node
+index (Part 2: "shared-face occurrence pairs... of which BRepGraph collapses to ONE node: 1", on
+both split fixtures).
+
+That collapse is not just a different index space -- it changes what `adjacentFaces(of:)` can
+answer. Part 3 queries that single collapsed wall node's neighbors directly:
+
+```
+vertical split fixture:
+  BRepGraph.adjacentFaces(of: wallNode=5) = 8 faces, spanning solid groups [0, 1]
+horizontal split fixture:
+  BRepGraph.adjacentFaces(of: wallNode=2) = 8 faces, spanning solid groups [0, 1]
+```
+
+`BRepGraph` cannot tell "the wall as solid A sees it" apart from "the wall as solid B sees it" --
+there is only one node, and its neighbor list is the union of both solids' faces. That is exactly
+the cross-solid contamination #699 fixed on the `AAG` side by restricting `buildGraph()`'s pairwise
+loop to same-solid pairs, a fix that is only *expressible* because `AAG` keeps the two occurrences
+as separate nodes. Part 2's pairwise comparison confirms the practical consequence: on each split
+fixture, 12 of the 35 cross-solid pairs are pairs `BRepGraph.sharedEdges` reports as genuinely
+sharing an edge (real, structural topology), while `AAG`, correctly per its own #699 contract,
+refuses to ever call them adjacent. Neither number is "wrong" -- they are answers to different
+questions (compound-wide topological incidence vs. per-solid boundary adjacency), and #699 is the
+reason `AAG` needs the *latter*.
+
+**Same-solid pairs agree completely.** Where no cross-solid identity is in play, `AAG`'s adjacency
+test and shared-edge count agree with `BRepGraph`'s exactly: 0 disagreements across every same-solid
+pair on every fixture (plain box: 15 pairs; each split fixture: 30 pairs; three disjoint boxes: 45
+pairs). The divergence is entirely and only about cross-solid shared identity, not about the
+underlying edge-sharing computation itself, which both sides compute correctly and identically.
+
+## A real, independent correctness bug: the 10-edge cap
+
+`AAG.buildGraph()` called `OCCTFaceGetSharedEdges(shape, face1, face2, &buffer, 10)` with a
+hardcoded `maxEdges` of 10, so `AAGEdge.sharedEdgeCount` silently truncated on any face pair
+sharing more than 10 edges -- #753's own doc comment predicted this ("plausible after healing
+splits a boundary into segments") but it had never been measured. `BRepGraph.sharedEdges(between:and:)`
+has no such cap (`bgSharedEdges` in `OCCTBridge_BRepGraph.mm` appends to an unbounded
+`std::vector`), which is exactly the second, independent construction
+[`measure-dont-assume.md`](../../../okf/policies/measure-dont-assume.md) asks for, and it caught a
+real disagreement.
+
+`manySharedEdgesFixture()` (a 100mm box with 11 small notches carved across the top/front edge, each
+notch straddling both planes and splitting the shared boundary) measures 12 real shared edges
+between the top and front faces:
+
+```
+--- Part 4: the 10-edge cap ---
+  fixture face occurrences: 50
+  top face occurrence index 2, area 9868.0
+  front face occurrence index 1, area 9868.0
+  AAG.edge(between:).sharedEdgeCount = Optional(12)
+  BRepGraph.sharedEdges(between:and:).count = 12
+  FIXED: AAG's sharedEdgeCount (12) now agrees with BRepGraph past the old 10-cap threshold
+```
+
+(Before the fix below, the first line read `Optional(10)` -- confirmed by reverting the fix locally
+and re-running.) This is a real, narrow, independent bug: nothing about it depends on cross-solid
+identity, shared faces, or compounds. It reproduces on a single ordinary solid.
+
+## Can AAG converge onto BRepGraph for the cap fix? Measured: no, it would regress performance
+
+The natural fix reading the issue's own framing ("that alone is a correctness reason to prefer
+[BRepGraph]") is to route `sharedEdgeCount` through `BRepGraph.sharedEdges(between:and:)` instead.
+Measured before implementing anything, on a plate with a grid of drilled holes (`holedPlate(gridSize:)`,
+the same shape of fixture #703's own performance measurement used):
+
+```
+--- Part 7: cost of a naive per-pair BRepGraph.sharedEdges swap ---
+  grid 4x4 (22 occurrences, 231 pairs, 60 graph edges):
+    AAG.buildGraph() today (direct bridge calls): 1.2 / 1.1 / 1.1 ms
+    via BRepGraph.sharedEdges, all pairs:          2.1 / 2.3 / 2.1 ms
+  grid 8x8 (70 occurrences, 2415 pairs, 204 graph edges):
+    AAG.buildGraph() today (direct bridge calls): 11.0 / 10.9 / 11.0 ms
+    via BRepGraph.sharedEdges, all pairs:          70.8 / 69.5 / 73.3 ms
+```
+
+2.4x slower at 22 occurrences, 8x slower (and climbing) at 70. This is not a constant-factor
+regression: `OCCTFaceGetSharedEdges` is O(e1 * e2), each face's own small (typically 4-6) edge set,
+independent of the shape's total size. `bgSharedEdges` (`OCCTBridge_BRepGraph.mm`) is O(E), a linear
+scan of every edge in the whole graph, per call -- OCCT 8.0.0p1 dropped `TopoView::FaceOps`'s direct
+face-face helpers, so there is no indexed face-to-face incidence to query instead, only this
+derived, unindexed one. Swapping the inner call while keeping `AAG.buildGraph()`'s O(n^2) outer
+loop turns O(n^2 * small-constant) into O(n^2 * E), and E grows with n for a bounded-degree face
+graph, so the ratio gets worse as models get bigger, not better.
+
+**A smarter hybrid was also measured, and still lost.** Restricting the BRepGraph-routed lookup to
+only the pairs *already confirmed adjacent* by the existing cheap direct call (a roughly
+linear-sized subset, not O(n^2)):
+
+```
+--- Part 8: cost of fixing the cap ONLY for already-adjacent pairs ---
+  grid 4x4 (22 occurrences, 44 confirmed-adjacent pairs):
+    extra: sharedEdges on confirmed-adjacent pairs only: 0.97 / 0.86 / 0.81 ms
+  grid 8x8 (70 occurrences, 140 confirmed-adjacent pairs):
+    extra: sharedEdges on confirmed-adjacent pairs only: 7.84 / 7.90 / 7.65 ms
+```
+
+Compare against Part 6's own `AAG.buildGraph() alone` row for the same fixtures (1.1ms / 10.9ms):
+the "smart" hybrid's *extra* cost alone is comparable to `buildGraph()`'s entire current running
+time, before even counting the one-time cost of building the `BRepGraph` and the occurrence-to-node
+map (Part 6: `BRepGraph(shape:) alone`, another 0.6-2.3ms). Total cost roughly doubles. `bgSharedEdges`'s
+per-call scan cost (governed by the whole graph's edge count) is simply too close to
+`buildGraph()`'s *entire* current O(n^2) probe's cost to make routing even a subset of it through
+BRepGraph a win.
+
+## The fix that was actually made
+
+Neither consolidation path pays for itself. The bug is real and worth fixing at its root instead:
+a new bridge function, `OCCTFaceGetSharedEdgeCount(shape, face1, face2)` (`OCCTBridge_BRepGraph.h`/
+`.mm`), runs the *same* O(e1 * e2) comparison `OCCTFaceGetSharedEdges` already runs, just counting
+instead of allocating and writing edge wrappers. `AAG.buildGraph()` now calls it first to size its
+buffer exactly, then calls `OCCTFaceGetSharedEdges` with that exact size -- no cap, no BRepGraph
+involved, same asymptotic cost as before (the O(e1 * e2) comparison now runs twice instead of once,
+over each face's own small edge set, never the whole shape). Measured after the fix: `AAG.buildGraph()`
+alone on the 8x8 grid fixture is 10.8-10.9ms, statistically indistinguishable from the 9.5-11.0ms
+range measured before this change.
+
+## The enclosure test (#735/#753's second half) is a different case, not fixed here
+
+The issue also named `PocketFeature.isOpen`'s enclosure test (`isEdgeCoveredByAWall`,
+`Edge.adjacentFaces(in:)` + a hand-rolled `facesAreSame`) as a second, independent instance of the
+same pattern. Measured for correctness on two fixtures (a blind cylindrical pocket, 1 floor edge;
+a blind rectangular pocket, 4 floor edges): `Face.outerWire?.edges().count` agrees exactly with
+`BRepGraph.outerWire(of:)` + `wireCoEdgeCount`, and every boundary edge's face-count from
+`Edge.adjacentFaces(in:)` agrees exactly with `BRepGraph.faces(of:)` once mapped across. Unlike the
+face-to-face case above, this is genuinely the same computation reachable two ways, because
+`BRepGraph`'s edge-to-face incidence (`OCCTBRepGraphEdgeFaceIndices`, backing `faces(of:)`) is a
+real indexed structure populated once at graph construction, not a derived linear scan --
+`OCCTBRepGraphEdgeNbFaces` reads `Topo().Edges().NbFaces(...)` directly.
+
+That indexing shows up as a real, measured **performance difference in BRepGraph's favor**:
+`Edge.adjacentFaces(in:)` (`OCCTEdgeGetAdjacentFaces`) rebuilds a whole-shape
+`TopExp::MapShapesAndAncestors` edge-to-face map from scratch on *every call*:
+
+```
+--- Part 5: PocketFeature.isOpen's enclosure test vs BRepGraph ---
+  blind cylindrical pocket (1 floor edge):
+    per-edge cost, Edge.adjacentFaces(in:):        4.9 / 5.0 / 4.1 us/edge
+    per-edge cost, BRepGraph.faces(of:) (mapped):  2.0 / 1.1 / 1.0 us/edge
+  blind rectangular pocket (4 floor edges):
+    per-edge cost, Edge.adjacentFaces(in:):        5.8 / 5.8 / 5.8 us/edge
+    per-edge cost, BRepGraph.faces(of:) (mapped):  0.7 / 0.7 / 0.7 us/edge
+```
+
+Consolidating this specific piece onto `BRepGraph` looks like a genuine win, not a regression --
+the opposite conclusion from the face-to-face case above, and worth remembering as a reason "not
+the same question" cannot be generalized from one half of this issue to the other. **Not
+implemented in this PR**: it touches the public `detectPockets()` code path for a performance gain
+rather than a correctness fix (the two constructions already agree on every case measured), and
+building it out (constructing a `BRepGraph` for this specific call path, handling the case where a
+floor face itself doesn't map cleanly, re-verifying `#753`'s own removal-matrix tests still pass
+against a different code path) is a separable piece of work. Left as a well-evidenced follow-up
+rather than folded into this issue's scope.
+
+## Reproduce
+
+```bash
+swift run Censuses issue-761
+swift test --filter Issue761SharedEdgeCountCapTests
+```

--- a/Scripts/repro/censuses/CensusRunner.swift
+++ b/Scripts/repro/censuses/CensusRunner.swift
@@ -23,6 +23,7 @@ enum CensusRunner {
         CensusEntry(name: "cluster-a", summary: "sub-shape enumeration and orientation (#664)", run: ClusterA.run),
         CensusEntry(name: "cluster-b", summary: "fillet and chamfer edge-set contract (#665)", run: ClusterB.run),
         CensusEntry(name: "cluster-d", summary: "continuity handling across the kernel and bridge (#513/#667)", run: ClusterD.run),
+        CensusEntry(name: "issue-761", summary: "AAG vs BRepGraph face/edge adjacency (#761)", run: Issue761.run),
     ]
 
     static func main() {

--- a/Scripts/repro/censuses/Issue761.swift
+++ b/Scripts/repro/censuses/Issue761.swift
@@ -1,0 +1,557 @@
+// #761 census: does AAG's hand-rolled pairwise face/edge adjacency
+// (`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`/`OCCTEdgeGetConvexity`, all
+// `OCCTBridge_BRepGraph.mm`) answer the same question as `BRepGraph`'s own
+// `adjacentFaces(of:)`/`sharedEdges(between:and:)`, built over a `BRepGraph_Tool`-backed graph?
+//
+// Method: build both an `AAG` and a `BRepGraph` from the same `Shape`, map each AAG face
+// OCCURRENCE (`Shape.orientedFaces()`-indexed, #642) onto its `BRepGraph` face node via
+// `BRepGraph.findNode(for:)`, then compare what each side reports for every occurrence pair.
+// `findNode` is a `TopTools_ShapeMapHasher`-keyed lookup (`IsSame`: same TShape + Location,
+// orientation ignored -- confirmed by reading `BRepGraphInc_Storage.hxx:1886` and
+// `TopTools_ShapeMapHasher.hxx`), the SAME collapse rule `Shape.faces()` uses and #642 moved AAG
+// away from for exactly this reason. So the headline structural fact this census exists to
+// measure, not assume, is: does that collapse actually change an answer, or is it merely a
+// different index space wrapping the same underlying fact?
+
+import Foundation
+import OCCTSwift
+import simd
+
+enum Issue761 {
+    // MARK: - Fixtures private to this census
+
+    /// Three solids, far enough apart that none of their faces touch. No shared face anywhere,
+    /// so this is the control case: AAG occurrence indices and BRepGraph's dedup indices must be
+    /// a straight bijection here if the two questions are ever the same question.
+    static func threeDisjointBoxesCompound() -> Shape? {
+        let boxes = (0..<3).compactMap {
+            Shape.box(origin: SIMD3(Double($0) * 20, 0, 0), width: 10, height: 10, depth: 10)
+        }
+        guard boxes.count == 3 else { return nil }
+        return Shape.compound(boxes)
+    }
+
+    /// A single 100mm box with 11 small notches cut across the top/front edge, so the remaining
+    /// top face and front face share more than 10 separate boundary-edge segments -- the fixture
+    /// #753's own doc comment predicted ("plausible after healing splits a boundary into
+    /// segments") but never measured. Each notch is a small box straddling both the z=50 (top)
+    /// and y=-50 (front) planes near x=x0, removing a bite from both faces and splitting their
+    /// shared edge at that point.
+    static func manySharedEdgesFixture() -> Shape? {
+        guard var shape = Shape.box(width: 100, height: 100, depth: 100) else { return nil }
+        let positions = stride(from: -45.0, through: 45.0, by: 9.0)
+        for x0 in positions {
+            guard let notch = Shape.box(origin: SIMD3(x0 - 3, -52, 48), width: 6, height: 4, depth: 4),
+                  let cut = shape.subtracting(notch) else { return nil }
+            shape = cut
+        }
+        return shape
+    }
+
+    /// A plate with a grid of through-holes -- the same shape of fixture #703's own performance
+    /// measurement used (a 300x300x20mm plate, 256 holes), scaled down here to keep this census
+    /// fast to run repeatedly. Big enough to separate an O(n) from an O(n^2) cost, small enough
+    /// to build in well under a second.
+    static func holedPlate(gridSize: Int) -> Shape? {
+        guard let plate = Shape.box(origin: SIMD3(-75, -75, -10), width: 150, height: 150, depth: 20) else {
+            return nil
+        }
+        var result = plate
+        let spacing = 150.0 / Double(gridSize + 1)
+        for ix in 1...gridSize {
+            for iy in 1...gridSize {
+                let x = -75 + Double(ix) * spacing
+                let y = -75 + Double(iy) * spacing
+                guard let hole = Shape.cylinder(at: SIMD3(x, y, -15), direction: SIMD3(0, 0, 1), radius: spacing * 0.2, height: 40),
+                      let cut = result.subtracting(hole) else { continue }
+                result = cut
+            }
+        }
+        return result
+    }
+
+    // MARK: - Occurrence -> BRepGraph node mapping
+
+    struct GraphMap {
+        let graph: BRepGraph
+        /// AAG occurrence index -> BRepGraph face-node index, or -1 if `findNode` missed.
+        let nodeOf: [Int]
+    }
+
+    static func buildGraphMap(shape: Shape, occurrences: [Face]) -> GraphMap? {
+        guard let graph = BRepGraph(shape: shape) else { return nil }
+        var nodeOf = [Int](repeating: -1, count: occurrences.count)
+        for (i, face) in occurrences.enumerated() {
+            guard let faceShape = Shape.fromFace(face) else { continue }
+            if let node = graph.findNode(for: faceShape), node.kind == .face {
+                nodeOf[i] = node.index
+            }
+        }
+        return GraphMap(graph: graph, nodeOf: nodeOf)
+    }
+
+    /// Mirrors `AAG.solidGroups(occurrenceCount:in:)` (private in `FeatureRecognition.swift`) so
+    /// this census can classify pairs the same way `AAG.buildGraph()` does, without reaching into
+    /// AAG's private state. Same derivation, re-measured here rather than assumed to still match:
+    /// `Shape.solids`/`orientedFaces()` are both public, so nothing here needed a fork.
+    static func solidGroups(occurrenceCount: Int, in shape: Shape) -> [Int]? {
+        let bodies = shape.solids
+        guard bodies.count > 1 else { return nil }
+        let counts = bodies.map { $0.orientedFaces().count }
+        guard counts.reduce(0, +) == occurrenceCount else { return nil }
+        var groups = [Int](repeating: -1, count: occurrenceCount)
+        var cursor = 0
+        for (bodyIndex, count) in counts.enumerated() {
+            for k in 0..<count { groups[cursor + k] = bodyIndex }
+            cursor += count
+        }
+        return groups
+    }
+
+    // MARK: - Part 1: node/index-space comparison
+
+    static func runNodeCountComparison() {
+        print("--- Part 1: node counts (occurrence vs dedup) ---")
+        print("fixture                     (columns: occurrences / distinct / BRepGraph.faceCount / BRepGraph.activeFaceCount)")
+        let fixtures: [(String, Shape?)] = [
+            ("plain box", SharedFixture.plainBox()),
+            ("vertical split, order A", SharedFixture.splitBoxCompound(order: .asSplit)),
+            ("vertical split, order B", SharedFixture.splitBoxCompound(order: .reversed)),
+            ("horizontal split, order A", SharedFixture.horizontalSplitBoxCompound(order: .asSplit)),
+            ("horizontal split, order B", SharedFixture.horizontalSplitBoxCompound(order: .reversed)),
+            ("three disjoint boxes", threeDisjointBoxesCompound()),
+        ]
+        for (name, shapeOpt) in fixtures {
+            guard let shape = shapeOpt else { print("\(name): FIXTURE FAILED"); continue }
+            let occ = shape.orientedFaces()
+            let distinct = Set(occ.map(\.index)).count
+            let graph = BRepGraph(shape: shape)
+            let brgFace = graph?.faceCount ?? -1
+            let brgActive = graph?.activeFaceCount ?? -1
+            print(row(name, occ.count, distinct, brgFace, brgActive))
+        }
+        print("")
+    }
+
+    private static func row(_ name: String, _ a: Int, _ b: Int, _ c: Int, _ d: Int) -> String {
+        let paddedName = name.count >= 28 ? name : name + String(repeating: " ", count: 28 - name.count)
+        func pad(_ v: Int) -> String {
+            let s = String(v)
+            return s.count >= 10 ? s : String(repeating: " ", count: 10 - s.count) + s
+        }
+        return "\(paddedName)\(pad(a))\(pad(b))\(pad(c))\(pad(d))"
+    }
+
+    // MARK: - Part 2: pairwise adjacency / sharedEdges agreement
+
+    struct PairwiseResult {
+        var sameSolidPairsCompared = 0
+        var sameSolidAdjacencyDisagreements = 0
+        var sameSolidCountDisagreements = 0
+        var sameSolidCountDisagreementsCappedByTen = 0
+        var crossSolidPairsTopologicallyReal = 0
+        var crossSolidPairsTotal = 0
+        var sharedFaceOccurrencePairs = 0
+        var sharedFaceOccurrencePairsCollapseToSameNode = 0
+    }
+
+    static func runPairwiseComparison(name: String, shape: Shape) -> PairwiseResult {
+        var result = PairwiseResult()
+        let aag = shape.buildAAG()
+        let occ = shape.orientedFaces()
+        guard let map = buildGraphMap(shape: shape, occurrences: occ) else {
+            print("\(name): could not build BRepGraph map")
+            return result
+        }
+        let groups = solidGroups(occurrenceCount: occ.count, in: shape)
+
+        for i in 0..<occ.count {
+            for j in (i + 1)..<occ.count {
+                if occ[i].index == occ[j].index {
+                    // The two sides of one shared face. AAG never compares this pair (identity
+                    // guard). Report separately whether BRepGraph's node model collapses them.
+                    result.sharedFaceOccurrencePairs += 1
+                    if map.nodeOf[i] >= 0, map.nodeOf[i] == map.nodeOf[j] {
+                        result.sharedFaceOccurrencePairsCollapseToSameNode += 1
+                    }
+                    continue
+                }
+                guard map.nodeOf[i] >= 0, map.nodeOf[j] >= 0 else { continue }
+
+                let sameSolid = groups == nil || groups![i] == groups![j]
+                let aagEdge = aag.edge(between: i, and: j)
+                let aagAdjacent = aagEdge != nil
+                let graphShared = map.graph.sharedEdges(between: map.nodeOf[i], and: map.nodeOf[j])
+                let graphAdjacent = !graphShared.isEmpty
+
+                if sameSolid {
+                    result.sameSolidPairsCompared += 1
+                    if aagAdjacent != graphAdjacent {
+                        result.sameSolidAdjacencyDisagreements += 1
+                    } else if aagAdjacent, let e = aagEdge, e.sharedEdgeCount != graphShared.count {
+                        result.sameSolidCountDisagreements += 1
+                        if e.sharedEdgeCount == 10, graphShared.count > 10 {
+                            result.sameSolidCountDisagreementsCappedByTen += 1
+                        }
+                    }
+                } else {
+                    result.crossSolidPairsTotal += 1
+                    if graphAdjacent {
+                        result.crossSolidPairsTopologicallyReal += 1
+                        // AAG's own contract (#699): a cross-solid pair is never adjacent in
+                        // buildGraph()'s output, full stop, regardless of what raw topology says.
+                        if aagAdjacent {
+                            print("  UNEXPECTED: AAG reports pair (\(i),\(j)) adjacent across solids")
+                        }
+                    }
+                }
+            }
+        }
+
+        print("\(name):")
+        print("  same-solid pairs compared:                    \(result.sameSolidPairsCompared)")
+        print("  same-solid adjacency disagreements:            \(result.sameSolidAdjacencyDisagreements)")
+        print("  same-solid sharedEdgeCount disagreements:      \(result.sameSolidCountDisagreements)"
+              + " (of which capped-at-10: \(result.sameSolidCountDisagreementsCappedByTen))")
+        print("  cross-solid pairs total:                       \(result.crossSolidPairsTotal)")
+        print("  cross-solid pairs BRepGraph calls real, AAG doesn't:  \(result.crossSolidPairsTopologicallyReal)")
+        print("  shared-face occurrence pairs (both sides of one wall): \(result.sharedFaceOccurrencePairs)")
+        print("  ...of which BRepGraph collapses to ONE node:   \(result.sharedFaceOccurrencePairsCollapseToSameNode)")
+        return result
+    }
+
+    // MARK: - Part 3: the shared wall's compound-wide neighbor set (BRepGraph, unfiltered)
+
+    static func runWallNeighborDemo(shape: Shape) {
+        let occ = shape.orientedFaces()
+        guard let map = buildGraphMap(shape: shape, occurrences: occ) else { return }
+        let byDistinct = Dictionary(grouping: Array(occ.enumerated()), by: { $0.element.index })
+        guard let wallGroup = byDistinct.first(where: { $0.value.count > 1 })?.value, wallGroup.count == 2 else {
+            print("  (no shared wall found in this fixture)")
+            return
+        }
+        let (i0, _) = wallGroup[0]
+        let wallNode = map.nodeOf[i0]
+        guard wallNode >= 0 else { print("  (wall face not found in BRepGraph)"); return }
+        let neighbors = map.graph.adjacentFaces(of: wallNode)
+        let groups = solidGroups(occurrenceCount: occ.count, in: shape)
+        // Translate each BRepGraph neighbor index back to a representative occurrence, to report
+        // which solid group it belongs to.
+        var neighborGroups: [Int] = []
+        for n in neighbors {
+            if let occIdx = map.nodeOf.firstIndex(of: n), let g = groups {
+                neighborGroups.append(g[occIdx])
+            }
+        }
+        print("  BRepGraph.adjacentFaces(of: wallNode=\(wallNode)) = \(neighbors.count) faces, "
+              + "spanning solid groups \(Set(neighborGroups).sorted())")
+        print("  (AAG's own adjacency for EITHER wall occurrence only ever spans ONE group, by #699 construction)")
+    }
+
+    // MARK: - Part 4: the 10-cap
+
+    static func runTenCapMeasurement() {
+        print("--- Part 4: the 10-edge cap ---")
+        guard let shape = manySharedEdgesFixture() else {
+            print("  could not build the many-shared-edges fixture")
+            return
+        }
+        let occ = shape.orientedFaces()
+        print("  fixture face occurrences: \(occ.count)")
+        // Identify the (largest) top face (z high, upward, horizontal) and front face (y low,
+        // vertical, normal ~ -Y) by measurement, not by a hardcoded index -- the notch cuts add
+        // several small new faces whose index position isn't predictable.
+        let aag = shape.buildAAG()
+        guard let topIdx = aag.nodes.indices.max(by: { a, b in
+            let na = aag.nodes[a], nb = aag.nodes[b]
+            let aScore = (na.isUpward && na.isHorizontal) ? area(occ[a]) : -1
+            let bScore = (nb.isUpward && nb.isHorizontal) ? area(occ[b]) : -1
+            return aScore < bScore
+        }) else { print("  could not find a top face"); return }
+        guard let frontIdx = aag.nodes.indices.max(by: { a, b in
+            let na = aag.nodes[a], nb = aag.nodes[b]
+            let aScore = (na.isVertical && (na.normal?.y ?? 0) < -0.9) ? area(occ[a]) : -1
+            let bScore = (nb.isVertical && (nb.normal?.y ?? 0) < -0.9) ? area(occ[b]) : -1
+            return aScore < bScore
+        }) else { print("  could not find a front face"); return }
+
+        print("  top face occurrence index \(topIdx), area \(area(occ[topIdx]))")
+        print("  front face occurrence index \(frontIdx), area \(area(occ[frontIdx]))")
+
+        let aagEdge = aag.edge(between: topIdx, and: frontIdx)
+        print("  AAG.edge(between:).sharedEdgeCount = \(aagEdge?.sharedEdgeCount as Any)")
+
+        guard let map = buildGraphMap(shape: shape, occurrences: occ),
+              map.nodeOf[topIdx] >= 0, map.nodeOf[frontIdx] >= 0 else {
+            print("  could not map top/front faces into BRepGraph")
+            return
+        }
+        let graphShared = map.graph.sharedEdges(between: map.nodeOf[topIdx], and: map.nodeOf[frontIdx])
+        print("  BRepGraph.sharedEdges(between:and:).count = \(graphShared.count)")
+        if let e = aagEdge {
+            if graphShared.count > e.sharedEdgeCount {
+                print("  DEFECT PRESENT: AAG undercounts by \(graphShared.count - e.sharedEdgeCount) edge(s) (10-cap)")
+            } else if e.sharedEdgeCount == graphShared.count, graphShared.count > 10 {
+                print("  FIXED: AAG's sharedEdgeCount (\(e.sharedEdgeCount)) now agrees with BRepGraph"
+                      + " past the old 10-cap threshold")
+            } else {
+                print("  fixture did not exceed 10 shared edges as built; see README for what was tried")
+            }
+        }
+        print("")
+    }
+
+    private static func area(_ face: Face) -> Double { face.area() }
+
+    // MARK: - Part 5: the enclosure test (#735/#753) vs BRepGraph's outerWire/faces(of:)
+
+    static func runEnclosureComparison() {
+        print("--- Part 5: PocketFeature.isOpen's enclosure test vs BRepGraph ---")
+        guard let cylBox = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20),
+              let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20),
+              let cylCut = cylBox.subtracting(tool) else {
+            print("  could not build the blind cylindrical-pocket fixture")
+            return
+        }
+        runEnclosureCheck(name: "blind cylindrical pocket (1 floor edge)", shape: cylCut)
+
+        guard let rectBox = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20),
+              let rectTool = Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15),
+              let rectCut = rectBox.subtracting(rectTool) else {
+            print("  could not build the rectangular-pocket fixture")
+            return
+        }
+        runEnclosureCheck(name: "blind rectangular pocket (4 floor edges)", shape: rectCut)
+        print("")
+    }
+
+    private static func runEnclosureCheck(name: String, shape: Shape) {
+        print("  \(name):")
+        let pockets = shape.detectPocketsAAG()
+        guard let pocket = pockets.first else { print("    no pocket detected"); return }
+        let occ = shape.orientedFaces()
+        let floor = occ[pocket.floorFaceIndex]
+        guard let outer = floor.outerWire else { print("    floor has no outer wire"); return }
+        let floorEdges = outer.edges()
+        print("    floor's own outer wire edge count (Face.outerWire?.edges().count): \(floorEdges.count)")
+
+        guard let map = buildGraphMap(shape: shape, occurrences: occ), map.nodeOf[pocket.floorFaceIndex] >= 0 else {
+            print("    could not map floor face into BRepGraph")
+            return
+        }
+        let floorNode = map.nodeOf[pocket.floorFaceIndex]
+        let wireNode = map.graph.outerWire(of: floorNode)
+        guard wireNode >= 0 else { print("    BRepGraph reports no outer wire for the floor"); return }
+        let coedgeCount = map.graph.wireCoEdgeCount(wireNode)
+        print("    BRepGraph.outerWire(of:) -> wireCoEdgeCount: \(coedgeCount)")
+        print("    agreement: \(floorEdges.count == coedgeCount ? "YES" : "NO, \(floorEdges.count) vs \(coedgeCount)")")
+
+        // Per-edge: does Edge.adjacentFaces(in:) (the hand-rolled half of #753's fix) agree with
+        // BRepGraph.faces(of:) once each edge is mapped across? Every floor boundary edge should
+        // border exactly the floor and one wall -- a genuine 2-manifold edge in a single solid, so
+        // this is the regime where the two ought to already agree (no cross-solid identity to
+        // collapse: this fixture has one solid).
+        var agree = 0
+        var disagree = 0
+        for edge in floorEdges {
+            guard let (f1, f2) = edge.adjacentFaces(in: shape) else { continue }
+            // Find this edge's BRepGraph node the same way faces were mapped, via findNode on a
+            // Shape wrapping the edge.
+            guard let wrapped = Shape.fromEdge(edge) else { continue }
+            guard let node = map.graph.findNode(for: wrapped), node.kind == .edge else { continue }
+            let brgFaces = map.graph.faces(of: node.index)
+            let handRolledCount = f2 == nil ? 1 : 2
+            if brgFaces.count == handRolledCount {
+                agree += 1
+            } else {
+                disagree += 1
+            }
+            _ = f1
+        }
+        print("    per-edge face-count agreement: \(agree) agree, \(disagree) disagree (of \(floorEdges.count) edges)")
+
+        // Cost: Edge.adjacentFaces(in:) (OCCTEdgeGetAdjacentFaces) rebuilds a whole-shape
+        // TopExp::MapShapesAndAncestors edge->face map FROM SCRATCH on every call
+        // (OCCTBridge_BRepGraph.mm); BRepGraph's own edge->face incidence is a real indexed
+        // structure populated once at construction (unlike its face-to-face helpers -- see the
+        // AAG doc comment). Measured per-call cost, not assumed, since the two are NOT
+        // interchangeable performance-wise even where they agree on the answer.
+        let handRolledTimes = (0..<3).map { _ -> Double in
+            let start = Date()
+            for edge in floorEdges { _ = edge.adjacentFaces(in: shape) }
+            return Date().timeIntervalSince(start) * 1_000_000 / Double(floorEdges.count)
+        }
+        let graphTimes = (0..<3).map { _ -> Double in
+            let start = Date()
+            for edge in floorEdges {
+                guard let wrapped = Shape.fromEdge(edge), let node = map.graph.findNode(for: wrapped) else { continue }
+                _ = map.graph.faces(of: node.index)
+            }
+            return Date().timeIntervalSince(start) * 1_000_000 / Double(floorEdges.count)
+        }
+        print("    per-edge cost, Edge.adjacentFaces(in:):        "
+              + "\(handRolledTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) us/edge")
+        print("    per-edge cost, BRepGraph.faces(of:) (mapped):  "
+              + "\(graphTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) us/edge")
+    }
+
+    // MARK: - Part 6: performance
+
+    static func runPerformanceMeasurement() {
+        print("--- Part 6: performance ---")
+        for gridSize in [4, 8] {
+            guard let plate = holedPlate(gridSize: gridSize) else {
+                print("  gridSize \(gridSize): fixture build failed")
+                continue
+            }
+            let faceCount = plate.orientedFaces().count
+            let aagTimes = (0..<3).map { _ -> Double in
+                let start = Date()
+                _ = plate.buildAAG()
+                return Date().timeIntervalSince(start) * 1000
+            }
+            let graphTimes = (0..<3).map { _ -> Double in
+                let start = Date()
+                _ = BRepGraph(shape: plate)
+                return Date().timeIntervalSince(start) * 1000
+            }
+            let bothTimes = (0..<3).map { _ -> Double in
+                let start = Date()
+                let occ = plate.orientedFaces()
+                _ = plate.buildAAG()
+                _ = buildGraphMap(shape: plate, occurrences: occ)
+                return Date().timeIntervalSince(start) * 1000
+            }
+            print("  grid \(gridSize)x\(gridSize) (\(faceCount) face occurrences):")
+            print("    AAG.buildGraph() alone:              \(aagTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) ms")
+            print("    BRepGraph(shape:) alone:              \(graphTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) ms")
+            print("    AAG.buildGraph() + BRepGraph + map:   \(bothTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) ms")
+        }
+        print("")
+    }
+
+    // MARK: - Part 7: the naive consolidation's own cost
+    //
+    // `AAG.buildGraph()`'s inner pairwise check (`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`)
+    // is O(e1 * e2) per pair -- each face's OWN edge set, typically 4-6 edges, compared directly,
+    // no reference to the rest of the shape. `BRepGraph.sharedEdges(between:and:)` is O(E) per
+    // call: `bgSharedEdges` (`OCCTBridge_BRepGraph.mm`) scans EVERY edge in the whole graph, not
+    // just the two faces' own. Swapping the inner call naively, keeping the same O(n^2) outer
+    // pair loop, changes the total cost from O(n^2 * small-constant) to O(n^2 * E) -- and E grows
+    // with n for a bounded-degree face graph (E ~ O(n)), so this is a real complexity regression,
+    // not just a constant-factor one. Measured directly rather than assumed.
+    static func runNaiveConsolidationCost() {
+        print("--- Part 7: cost of a naive per-pair BRepGraph.sharedEdges swap ---")
+        for gridSize in [4, 8] {
+            guard let plate = holedPlate(gridSize: gridSize) else {
+                print("  gridSize \(gridSize): fixture build failed")
+                continue
+            }
+            let occ = plate.orientedFaces()
+            guard let map = buildGraphMap(shape: plate, occurrences: occ) else {
+                print("  gridSize \(gridSize): could not build graph map")
+                continue
+            }
+            let n = occ.count
+
+            // The direct approach's own cost is Part 6's "AAG.buildGraph() alone" row for this
+            // same fixture: `Face.handle`/`Shape.handle` are `internal` to OCCTSwift, so this
+            // census (a separate module) cannot call `OCCTFacesAreAdjacent` itself the way
+            // `AAG.buildGraph()` does -- `AAG.buildGraph()` already IS that timing.
+            let directTimes = (0..<3).map { _ -> Double in
+                let start = Date()
+                _ = plate.buildAAG()
+                return Date().timeIntervalSince(start) * 1000
+            }
+
+            let viaGraphTimes = (0..<3).map { _ -> Double in
+                let start = Date()
+                var found = 0
+                for i in 0..<n {
+                    for j in (i + 1)..<n {
+                        guard map.nodeOf[i] >= 0, map.nodeOf[j] >= 0, map.nodeOf[i] != map.nodeOf[j] else { continue }
+                        if !map.graph.sharedEdges(between: map.nodeOf[i], and: map.nodeOf[j]).isEmpty { found += 1 }
+                    }
+                }
+                _ = found
+                return Date().timeIntervalSince(start) * 1000
+            }
+
+            print("  grid \(gridSize)x\(gridSize) (\(n) occurrences, \(n * (n - 1) / 2) pairs, \(map.graph.edgeCount) graph edges):")
+            print("    AAG.buildGraph() today (direct bridge calls): \(directTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) ms")
+            print("    via BRepGraph.sharedEdges, all pairs:          \(viaGraphTimes.map { String(format: "%.1f", $0) }.joined(separator: " / ")) ms")
+        }
+        print("")
+    }
+
+    // MARK: - Part 8: the fix actually worth making -- BRepGraph only for CONFIRMED-adjacent pairs
+    //
+    // The O(n^2) adjacency TEST stays on the cheap direct bridge call (`OCCTFacesAreAdjacent`,
+    // O(e1*e2) per pair, unaffected by this). Only once a pair is already known adjacent -- an
+    // O(n)-sized subset for a bounded-degree face graph, not O(n^2) -- does it pay BRepGraph's
+    // O(E) `sharedEdges` cost, to get the TRUE count instead of the capped-at-10 one. This
+    // measures whether that hybrid's added cost is small enough to be worth it.
+    static func runHybridFixCost() {
+        print("--- Part 8: cost of fixing the cap ONLY for already-adjacent pairs ---")
+        for gridSize in [4, 8] {
+            guard let plate = holedPlate(gridSize: gridSize) else {
+                print("  gridSize \(gridSize): fixture build failed")
+                continue
+            }
+            let occ = plate.orientedFaces()
+            let aag = plate.buildAAG()
+            guard let map = buildGraphMap(shape: plate, occurrences: occ) else {
+                print("  gridSize \(gridSize): could not build graph map")
+                continue
+            }
+            let n = occ.count
+            var adjacentPairs: [(Int, Int)] = []
+            for i in 0..<n {
+                for j in (i + 1)..<n where aag.edge(between: i, and: j) != nil {
+                    adjacentPairs.append((i, j))
+                }
+            }
+            let extraTimes = (0..<3).map { _ -> Double in
+                let start = Date()
+                for (i, j) in adjacentPairs {
+                    guard map.nodeOf[i] >= 0, map.nodeOf[j] >= 0, map.nodeOf[i] != map.nodeOf[j] else { continue }
+                    _ = map.graph.sharedEdges(between: map.nodeOf[i], and: map.nodeOf[j]).count
+                }
+                return Date().timeIntervalSince(start) * 1000
+            }
+            print("  grid \(gridSize)x\(gridSize) (\(n) occurrences, \(adjacentPairs.count) confirmed-adjacent pairs):")
+            print("    BRepGraph build + map (one-time, Part 6's own row above)")
+            print("    extra: sharedEdges on confirmed-adjacent pairs only: "
+                  + "\(extraTimes.map { String(format: "%.2f", $0) }.joined(separator: " / ")) ms")
+        }
+        print("")
+    }
+
+    // MARK: - Entry point
+
+    static func run() {
+        runNodeCountComparison()
+
+        print("--- Part 2: pairwise adjacency / sharedEdges agreement ---")
+        _ = runPairwiseComparison(name: "plain box", shape: SharedFixture.plainBox())
+        _ = runPairwiseComparison(name: "vertical split, order A", shape: SharedFixture.splitBoxCompound(order: .asSplit))
+        _ = runPairwiseComparison(name: "horizontal split, order A", shape: SharedFixture.horizontalSplitBoxCompound(order: .asSplit))
+        if let three = threeDisjointBoxesCompound() {
+            _ = runPairwiseComparison(name: "three disjoint boxes", shape: three)
+        }
+        print("")
+
+        print("--- Part 3: the shared wall's neighbor set, BRepGraph-unfiltered ---")
+        print("vertical split fixture:")
+        runWallNeighborDemo(shape: SharedFixture.splitBoxCompound(order: .asSplit))
+        print("horizontal split fixture:")
+        runWallNeighborDemo(shape: SharedFixture.horizontalSplitBoxCompound(order: .asSplit))
+        print("")
+
+        runTenCapMeasurement()
+        runEnclosureComparison()
+        runPerformanceMeasurement()
+        runNaiveConsolidationCost()
+        runHybridFixCost()
+    }
+}

--- a/Sources/OCCTBridge/include/OCCTBridge_BRepGraph.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_BRepGraph.h
@@ -51,11 +51,32 @@ OCCTEdgeConvexity OCCTEdgeGetConvexity(OCCTShapeRef shape, OCCTEdgeRef edge, OCC
 /// Get all edges shared between two faces
 /// @param shape The shape containing the faces
 /// @param face1 First face
-/// @param face2 Second face  
+/// @param face2 Second face
 /// @param outEdges Output array for shared edges (caller allocates)
 /// @param maxEdges Maximum number of edges to return
-/// @return Number of shared edges found
+/// @return Number of shared edges found, truncated at maxEdges if the true count is larger. Call
+///   OCCTFaceGetSharedEdgeCount first to size outEdges exactly and avoid truncation (#761).
 int32_t OCCTFaceGetSharedEdges(OCCTShapeRef shape, OCCTFaceRef face1, OCCTFaceRef face2, OCCTEdgeRef* outEdges, int32_t maxEdges);
+
+/// The true number of edges shared between two faces, with no cap.
+///
+/// `AAG.buildGraph()` (`FeatureRecognition.swift`) used to call `OCCTFaceGetSharedEdges` directly
+/// with a hardcoded `maxEdges: 10`, so `AAGEdge.sharedEdgeCount` silently truncated at 10 on any
+/// face pair sharing more edges -- plausible after healing splits a boundary into segments, and
+/// reproduced directly: an 11-notch synthetic fixture measured 12 shared edges between two faces,
+/// reported as 10 (`Scripts/repro/761-aag-brepgraph-adjacency/`). This is the same count-then-fetch
+/// idiom `BRepGraph.swift`'s own `fetchIndices` helper already uses for every `...Count`/
+/// `...Indices` bridge pair: call this first to size the buffer exactly, then call
+/// OCCTFaceGetSharedEdges with that exact count. Same O(e1 * e2) cost as OCCTFaceGetSharedEdges
+/// itself (each face's own edge count, never the whole shape), so sizing correctly costs nothing
+/// beyond running that comparison twice, which #761's own measurement found negligible next to the
+/// alternative of routing through BRepGraph.sharedEdges(between:and:) instead (a real, measured
+/// performance regression at model scale -- see that repro directory's README for the numbers).
+/// @param shape The shape containing the faces
+/// @param face1 First face
+/// @param face2 Second face
+/// @return Number of shared edges, uncapped.
+int32_t OCCTFaceGetSharedEdgeCount(OCCTShapeRef shape, OCCTFaceRef face1, OCCTFaceRef face2);
 
 /// Check if two faces are adjacent (share at least one edge)
 bool OCCTFacesAreAdjacent(OCCTShapeRef shape, OCCTFaceRef face1, OCCTFaceRef face2);

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -3174,6 +3174,33 @@ int32_t OCCTFaceGetSharedEdges(OCCTShapeRef shape, OCCTFaceRef face1, OCCTFaceRe
     }
 }
 
+int32_t OCCTFaceGetSharedEdgeCount(OCCTShapeRef shape, OCCTFaceRef face1, OCCTFaceRef face2) {
+    if (!shape || !face1 || !face2) return 0;
+
+    try {
+        // Same comparison OCCTFaceGetSharedEdges runs, just counting instead of allocating and
+        // writing OCCTEdge wrappers -- see #761 for why AAG.buildGraph() needs this uncapped.
+        TopTools_IndexedMapOfShape edges1, edges2;
+        TopExp::MapShapes(face1->face, TopAbs_EDGE, edges1);
+        TopExp::MapShapes(face2->face, TopAbs_EDGE, edges2);
+
+        int32_t count = 0;
+        for (int i = 1; i <= edges1.Extent(); i++) {
+            const TopoDS_Edge& e1 = TopoDS::Edge(edges1(i));
+            for (int j = 1; j <= edges2.Extent(); j++) {
+                const TopoDS_Edge& e2 = TopoDS::Edge(edges2(j));
+                if (e1.IsSame(e2)) {
+                    count++;
+                    break;
+                }
+            }
+        }
+        return count;
+    } catch (...) {
+        return 0;
+    }
+}
+
 bool OCCTFacesAreAdjacent(OCCTShapeRef shape, OCCTFaceRef face1, OCCTFaceRef face2) {
     if (!shape || !face1 || !face2) return false;
     

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -141,6 +141,51 @@ public struct AAGEdge: Sendable {
 /// // Order-independent: both sides of the shared wall are their own node either way.
 /// print(orderA.detectPocketsAAG().count == orderB.detectPocketsAAG().count)   // true
 /// ```
+///
+/// ## Why this does not build on `BRepGraph` (#761)
+///
+/// `BRepGraph` (`BRepGraph.swift`) answers the same two raw questions this type does --
+/// `adjacentFaces(of:)`/`sharedEdges(between:and:)` look like a ready-made replacement for the
+/// pairwise `OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges` calls `buildGraph()` makes below.
+/// Measured (`Scripts/repro/761-aag-brepgraph-adjacency/`), not assumed, they are not
+/// interchangeable, for two independent reasons:
+///
+/// 1. **`BRepGraph`'s face-node identity is `IsSame`-deduplicated**, exactly the collapse rule
+///    `Shape.faces()` uses and #642's own fix moved AAG's node set away from
+///    (`BRepGraph::ShapesView::FindNode` hashes on `TopTools_ShapeMapHasher`, which is `IsSame`:
+///    same underlying face, either orientation, one node). A face shared by two solids has ONE
+///    `BRepGraph` node, not two occurrence nodes -- confirmed by mapping every occurrence of
+///    `orientedFaces()` to its `BRepGraph` node via `findNode(for:)` on both split fixtures: the
+///    wall's two occurrences always resolve to the identical node index. Querying that one node's
+///    `adjacentFaces(of:)` returns neighbors from BOTH solids merged (measured: 8 faces spanning
+///    both solid groups on the vertical- and horizontal-cut fixtures), because `BRepGraph` has no
+///    concept of "this face as seen from solid A" versus "from solid B" to keep them apart. That
+///    is exactly the cross-solid contamination #699 fixed by restricting `buildGraph()`'s own
+///    pairwise loop to same-solid pairs -- a fix that is possible here because `AAG` keeps a
+///    separate node per occurrence, and would not be expressible against a graph that has already
+///    thrown that distinction away.
+/// 2. **A per-pair swap is measurably slower, and the gap widens with model size.** `BRepGraph`'s
+///    own `adjacentFaces(of:)`/`sharedEdges(between:and:)` (`bgAdjacentFaces`/`bgSharedEdges`,
+///    `OCCTBridge_BRepGraph.mm`) each linearly scan every edge in the WHOLE graph, because OCCT
+///    8.0.0p1 dropped `TopoView::FaceOps`'s direct face-face helpers and there is no indexed
+///    face-to-face incidence to query instead. `OCCTFaceGetSharedEdges` compares only the two
+///    faces' own (small, typically 4-6) edge sets. Measured on a plate with a grid of drilled
+///    holes: replacing the inner call, same O(n^2) outer loop, cost 2.4x more wall time at 22
+///    face occurrences and 8x more at 70 -- growing, not constant, because the graph's own edge
+///    count grows with the model while each face's own edge count does not. Restricting the swap
+///    to only the pairs already confirmed adjacent (a much smaller, roughly-linear subset) still
+///    roughly doubled the total cost of `buildGraph()`, because `BRepGraph`'s per-call scan cost is
+///    comparable to this type's ENTIRE current O(n^2) probe, before even counting the cost of
+///    building the `BRepGraph` and the occurrence-to-node map in the first place.
+///
+/// What #761 fixed instead: the one genuine correctness gap the comparison surfaced,
+/// `AAGEdge.sharedEdgeCount` silently capping at 10 (`OCCTFaceGetSharedEdges`'s buffer, sized by a
+/// hardcoded caller argument, not the true count) even though `BRepGraph.sharedEdges(between:and:)`
+/// has no such cap -- confirmed on a synthetic fixture at 12 real shared edges, reported as 10.
+/// Fixed at the root, in the SAME direct call this type already makes: a new
+/// `OCCTFaceGetSharedEdgeCount` sizes the buffer exactly before `OCCTFaceGetSharedEdges` fills it,
+/// same O(e1 * e2) cost as before (run twice on each face's own small edge set, never the whole
+/// shape), with none of the scaling cost a `BRepGraph`-routed fix would have carried.
 public final class AAG: @unchecked Sendable {
     /// The shape this graph represents
     public let shape: Shape
@@ -238,24 +283,38 @@ public final class AAG: @unchecked Sendable {
 
                 // Check if adjacent
                 if OCCTFacesAreAdjacent(shape.handle, face1.handle, face2.handle) {
-                    // Get shared edge count and convexity
-                    var sharedEdges: [OCCTEdgeRef?] = Array(repeating: nil, count: 10)
-                    let edgeCount = OCCTFaceGetSharedEdges(
-                        shape.handle, face1.handle, face2.handle,
-                        &sharedEdges, 10
-                    )
-
-                    // Get convexity from first shared edge
+                    // #761: size the buffer from the TRUE count first, rather than a fixed 10.
+                    // The old fixed size silently truncated `AAGEdge.sharedEdgeCount` whenever a
+                    // face pair shared more than 10 edges -- measured directly (a synthetic
+                    // 11-notch fixture shares 12 edges between two faces; the old code reported
+                    // 10). This costs the same O(e1 * e2) comparison OCCTFaceGetSharedEdges itself
+                    // runs, twice instead of once, over each face's own (small) edge set -- never
+                    // the whole shape, so it does not scale with face/edge count the way routing
+                    // through BRepGraph.sharedEdges(between:and:) would have (measured separately,
+                    // see Scripts/repro/761-aag-brepgraph-adjacency/README.md: a naive per-pair
+                    // swap onto BRepGraph was 2-8x slower and getting worse with model size, since
+                    // that primitive scans every edge in the whole graph, not just these two
+                    // faces' own).
+                    let trueCount = Int(OCCTFaceGetSharedEdgeCount(shape.handle, face1.handle, face2.handle))
                     var convexity: EdgeConvexity = .smooth
-                    if edgeCount > 0, let firstEdge = sharedEdges[0] {
-                        let occtConvexity = OCCTEdgeGetConvexity(
-                            shape.handle, firstEdge,
-                            face1.handle, face2.handle
+                    if trueCount > 0 {
+                        var sharedEdges: [OCCTEdgeRef?] = Array(repeating: nil, count: trueCount)
+                        let fetchedCount = OCCTFaceGetSharedEdges(
+                            shape.handle, face1.handle, face2.handle,
+                            &sharedEdges, Int32(trueCount)
                         )
-                        convexity = EdgeConvexity(fromOCCT: occtConvexity)
+
+                        // Get convexity from first shared edge
+                        if fetchedCount > 0, let firstEdge = sharedEdges[0] {
+                            let occtConvexity = OCCTEdgeGetConvexity(
+                                shape.handle, firstEdge,
+                                face1.handle, face2.handle
+                            )
+                            convexity = EdgeConvexity(fromOCCT: occtConvexity)
+                        }
 
                         // Release edges
-                        for k in 0..<Int(edgeCount) {
+                        for k in 0..<Int(fetchedCount) {
                             if let edge = sharedEdges[k] {
                                 OCCTEdgeRelease(edge)
                             }
@@ -267,7 +326,7 @@ public final class AAG: @unchecked Sendable {
                         face1Index: i,
                         face2Index: j,
                         convexity: convexity,
-                        sharedEdgeCount: Int(edgeCount)
+                        sharedEdgeCount: trueCount
                     )
                     edges.append(edge)
 
@@ -492,10 +551,14 @@ extension AAG {
     /// `sharedEdgeCount` is a **total** across the whole face pair, inner wires included, so a boss
     /// wall's own inner-wire edge was being added to the same sum as the outer boundary's: closed
     /// three walls plus one boss edge could reach four and look complete while the outer loop
-    /// itself still had a real gap. It is also capped: `OCCTFaceGetSharedEdges`'s fixed buffer
-    /// silently truncates past its slot count, so a floor/wall pair sharing more edges than that
-    /// (plausible after healing splits a boundary into segments) would undercount regardless of
-    /// wire scope. Testing membership per edge instead of comparing sums removes both failure modes
+    /// itself still had a real gap. It was also capped at the time: `OCCTFaceGetSharedEdges`'s
+    /// fixed buffer silently truncated past its slot count, so a floor/wall pair sharing more
+    /// edges than that (plausible after healing splits a boundary into segments, and confirmed on
+    /// a synthetic fixture by #761) would undercount regardless of wire scope -- `buildGraph()`
+    /// now sizes that buffer from `OCCTFaceGetSharedEdgeCount` instead of a fixed 10, so
+    /// `AAGEdge.sharedEdgeCount` itself is no longer capped, but the per-edge test below still
+    /// does not depend on it being accurate, which is the point: it does not read
+    /// `sharedEdgeCount` at all. Testing membership per edge instead of comparing sums removes both failure modes
     /// structurally: the loop never visits an inner-wire edge in the first place, and it never reads
     /// a total that could be capped.
     ///

--- a/Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift
+++ b/Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift
@@ -1,0 +1,159 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #761: investigating whether AAG's hand-rolled pairwise face/edge adjacency
+// (`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`/`OCCTEdgeGetConvexity`) duplicates
+// `BRepGraph`'s own `adjacentFaces(of:)`/`sharedEdges(between:and:)` found the two are NOT the
+// same question wherever a face is shared across solids: `BRepGraph`'s face-node identity is
+// `IsSame`-deduplicated (the same collapse #642 moved AAG's own node set away from), so a shared
+// face is ONE `BRepGraph` node whose adjacency merges both solids -- measured directly via
+// `Scripts/repro/761-aag-brepgraph-adjacency/`, which is the census this issue asks for. A naive
+// per-pair swap onto `BRepGraph.sharedEdges(between:and:)` was also measured to be 2-8x slower
+// (and getting worse with model size) than AAG's current direct bridge calls, so `AAG.buildGraph()`
+// keeps its own pairwise design rather than routing through `BRepGraph`.
+//
+// One genuine, independent correctness bug DID fall out of the comparison, and is what this suite
+// covers: `AAGEdge.sharedEdgeCount` used to come from `OCCTFaceGetSharedEdges(..., maxEdges: 10)`,
+// a hardcoded cap with no relationship to how many edges two faces actually share. `BRepGraph`'s
+// `sharedEdges(between:and:)` has no such cap (an unbounded `std::vector` on the bridge side), and
+// used as the second, independent construction this policy asks for, it disagreed with AAG's own
+// answer on a fixture built specifically to share more than 10 edges between two faces: BRepGraph
+// reported 12, AAG reported 10 (silently truncated). Fixed by sizing the buffer from a new
+// `OCCTFaceGetSharedEdgeCount` bridge call first, in `AAG.buildGraph()` itself -- same O(e1 * e2)
+// cost as before (each face's own small edge set, never the whole shape), not by routing through
+// BRepGraph (which the same census measured to be a real performance regression for this specific
+// call shape).
+@Suite("AAG.buildGraph()'s sharedEdgeCount is not capped at 10 (#761)")
+struct Issue761SharedEdgeCountCapTests {
+
+    // MARK: - Fixture
+
+    /// A 100mm box with 11 small notches cut across the top/front edge, so the remaining top face
+    /// and front face share more than 10 separate boundary-edge segments. Each notch is a small
+    /// box straddling both the z=50 (top) and y=-50 (front) planes near x=x0, removing a bite from
+    /// both faces and splitting their shared edge there. Matches
+    /// `Scripts/repro/761-aag-brepgraph-adjacency/`'s own `manySharedEdgesFixture()` -- kept as a
+    /// second, independent construction here (a fresh build in the test target) rather than a
+    /// shared helper, since the point is to catch a regression in either copy.
+    static func manySharedEdgesFixture() -> Shape? {
+        guard var shape = Shape.box(width: 100, height: 100, depth: 100) else { return nil }
+        for x0 in stride(from: -45.0, through: 45.0, by: 9.0) {
+            guard let notch = Shape.box(origin: SIMD3(x0 - 3, -52, 48), width: 6, height: 4, depth: 4),
+                  let cut = shape.subtracting(notch) else { return nil }
+            shape = cut
+        }
+        return shape
+    }
+
+    /// Finds the largest occurrence matching a predicate on its `AAGNode`, by area. Used to locate
+    /// the top and front faces without depending on their (unpredictable, since the notches add
+    /// several small new faces) index position.
+    private static func largestFace(_ aag: AAG, occ: [Face], where predicate: (AAGNode) -> Bool) -> Int? {
+        aag.nodes.indices.filter { predicate(aag.nodes[$0]) }.max { occ[$0].area() < occ[$1].area() }
+    }
+
+    /// The floor/wall pair this suite measures: the box's top face and front face, both still
+    /// single connected faces after the notch cuts, sharing 12 edges (11 notches split the shared
+    /// boundary into 12 remaining segments).
+    private static func topAndFrontFaces(in shape: Shape) -> (aag: AAG, topIndex: Int, frontIndex: Int)? {
+        let occ = shape.orientedFaces()
+        let aag = shape.buildAAG()
+        guard let topIndex = largestFace(aag, occ: occ, where: { $0.isUpward && $0.isHorizontal }),
+              let frontIndex = largestFace(aag, occ: occ, where: { $0.isVertical && ($0.normal?.y ?? 0) < -0.9 })
+        else { return nil }
+        return (aag, topIndex, frontIndex)
+    }
+
+    // MARK: - The headline
+
+    @Test("sharedEdgeCount reports the true count, not a value capped at 10")
+    func sharedEdgeCountIsNotCappedAtTen() {
+        guard let shape = Self.manySharedEdgesFixture(),
+              let (aag, topIndex, frontIndex) = Self.topAndFrontFaces(in: shape) else {
+            Issue.record("could not build the many-shared-edges fixture")
+            return
+        }
+
+        guard let edge = aag.edge(between: topIndex, and: frontIndex) else {
+            Issue.record("expected the top and front faces to be adjacent")
+            return
+        }
+
+        // Pinned to the measured value (Scripts/repro/761-aag-brepgraph-adjacency/README.md):
+        // 11 notches leave 12 shared boundary segments. Before this fix this was 10 (the old
+        // hardcoded cap), not a geometric fact about the fixture.
+        #expect(edge.sharedEdgeCount == 12)
+        #expect(edge.sharedEdgeCount > 10, "the whole point of this fixture is to exceed the old cap")
+    }
+
+    /// The second, independent construction the measurement policy asks for: `BRepGraph`'s own
+    /// `sharedEdges(between:and:)`, mapped to the same two occurrences via `findNode(for:)`, has
+    /// no such cap (an unbounded `std::vector` on the bridge side, `bgSharedEdges` in
+    /// `OCCTBridge_BRepGraph.mm`). It must agree with AAG's own count exactly now that AAG is no
+    /// longer capped -- this is precisely the disagreement this issue's census found before the fix.
+    @Test("agrees with BRepGraph's own uncapped sharedEdges count")
+    func agreesWithBRepGraphsUncappedCount() {
+        guard let shape = Self.manySharedEdgesFixture(),
+              let (aag, topIndex, frontIndex) = Self.topAndFrontFaces(in: shape) else {
+            Issue.record("could not build the many-shared-edges fixture")
+            return
+        }
+        guard let aagEdge = aag.edge(between: topIndex, and: frontIndex) else {
+            Issue.record("expected the top and front faces to be adjacent")
+            return
+        }
+
+        let occ = shape.orientedFaces()
+        guard let graph = BRepGraph(shape: shape),
+              let topFaceShape = Shape.fromFace(occ[topIndex]),
+              let frontFaceShape = Shape.fromFace(occ[frontIndex]),
+              let topNode = graph.findNode(for: topFaceShape), topNode.kind == .face,
+              let frontNode = graph.findNode(for: frontFaceShape), frontNode.kind == .face
+        else {
+            Issue.record("could not map the top/front faces into BRepGraph")
+            return
+        }
+
+        let graphShared = graph.sharedEdges(between: topNode.index, and: frontNode.index)
+        #expect(aagEdge.sharedEdgeCount == graphShared.count)
+    }
+
+    // MARK: - No regression on the ordinary case
+
+    /// A plain box shares no more than one edge between any two adjacent faces. The fix must not
+    /// change this -- it only changes how the buffer is SIZED, not the comparison itself.
+    @Test("a plain box's adjacent faces still share exactly one edge")
+    func plainBoxUnaffected() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build the box")
+            return
+        }
+        let aag = box.buildAAG()
+        for i in 0..<aag.nodes.count {
+            for j in (i + 1)..<aag.nodes.count {
+                if let edge = aag.edge(between: i, and: j) {
+                    #expect(edge.sharedEdgeCount == 1)
+                }
+            }
+        }
+    }
+
+    /// Convexity classification (which reads only the FIRST shared edge, unaffected by how the
+    /// count is sized) still resolves. This fixture's top/front pair should classify convex like
+    /// any ordinary box corner -- the notches remove material, they do not add a concave junction
+    /// at the corner itself.
+    @Test("convexity still resolves for the many-shared-edges pair")
+    func convexityStillResolves() {
+        guard let shape = Self.manySharedEdgesFixture(),
+              let (aag, topIndex, frontIndex) = Self.topAndFrontFaces(in: shape) else {
+            Issue.record("could not build the many-shared-edges fixture")
+            return
+        }
+        guard let edge = aag.edge(between: topIndex, and: frontIndex) else {
+            Issue.record("expected the top and front faces to be adjacent")
+            return
+        }
+        #expect(edge.convexity == .convex)
+    }
+}


### PR DESCRIPTION
## What & why

#761 asked whether `AAG`'s hand-rolled pairwise face/edge adjacency
(`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`/`OCCTEdgeGetConvexity`) duplicates `BRepGraph`'s
own `adjacentFaces(of:)`/`sharedEdges(between:and:)`, and to consolidate onto whichever is correct
if so.

**Measured (`Scripts/repro/761-aag-brepgraph-adjacency/`, `swift run Censuses issue-761`), not
assumed: they are not the same question once a face is shared across solids, and a full
consolidation would regress performance.**

- `BRepGraph::ShapesView::FindNode` hashes on `TopTools_ShapeMapHasher`, which is `IsSame`-based
  (same TShape + Location, orientation ignored) -- the identical collapse rule `Shape.faces()`
  uses and #642's own fix moved AAG's node set away from. A face shared by two solids is ONE
  `BRepGraph` node, not two occurrence nodes: confirmed by mapping every `orientedFaces()`
  occurrence to its `BRepGraph` node on both split fixtures, the wall's two occurrences always
  collapse to the same index. Querying that node's `adjacentFaces(of:)` merges both solids'
  neighbors (measured: 8 faces spanning both solid groups) -- exactly the cross-solid contamination
  #699 fixed on the AAG side, which is only expressible because AAG keeps a separate node per
  occurrence.
- Where no shared face is in play, the two agree completely: 0 disagreements across every
  same-solid pair, on every fixture measured.
- A naive per-pair swap of AAG's inner adjacency check onto `BRepGraph.sharedEdges(between:and:)`
  was measured 2.4x slower at 22 face occurrences and 8x slower at 70, growing with model size,
  because that primitive scans every edge in the whole graph per call rather than each face's own
  small edge set. A smarter hybrid (BRepGraph only for already-confirmed-adjacent pairs) still
  roughly doubled `buildGraph()`'s total cost.

**One genuine, independent correctness bug fell out of the comparison**, and is what this PR
fixes: `AAG.buildGraph()` sized its shared-edges buffer at a hardcoded 10
(`OCCTFaceGetSharedEdges(..., maxEdges: 10)`), so `AAGEdge.sharedEdgeCount` silently truncated on
any face pair sharing more edges -- #753's own doc comment predicted this but it had never been
measured. Reproduced on a synthetic fixture (a box with 11 notches carved across one edge, leaving
12 real shared boundary segments between two faces): AAG reported 10, `BRepGraph.sharedEdges`
(uncapped) reported 12.

**Fix**: a new `OCCTFaceGetSharedEdgeCount` bridge call (same O(e1 * e2) comparison
`OCCTFaceGetSharedEdges` already runs, just counting) sizes the buffer exactly before
`OCCTFaceGetSharedEdges` fills it. No BRepGraph involved in the fix -- the census showed that would
cost more than it's worth. Measured after the fix: `AAG.buildGraph()` performance on a 70-face
stress fixture is statistically unchanged (10.8-10.9ms vs the pre-fix 9.5-11.0ms range).

A second finding (`PocketFeature.isOpen`'s enclosure test, #735/#753) measured the *opposite*
conclusion -- `BRepGraph.faces(of:)` is 3-8x *faster* per edge than `Edge.adjacentFaces(in:)`,
because BRepGraph's edge-to-face incidence is a real indexed structure while
`OCCTEdgeGetAdjacentFaces` rebuilds a whole-shape map from scratch on every call -- but is not
implemented here; see the repro README's own section on it.

Closes #761

## CHANGELOG entry

### `AAG`'s `sharedEdgeCount` is no longer silently capped at 10 shared edges (#761)

`AAG.buildGraph()` used to size its shared-edges buffer at a hardcoded 10
(`OCCTFaceGetSharedEdges`), so `AAGEdge.sharedEdgeCount` silently truncated on any face pair
sharing more than 10 edges. A new `OCCTFaceGetSharedEdgeCount` bridge call now sizes the buffer
exactly first, at the same asymptotic cost. Also documents, with a measured comparison
(`Scripts/repro/761-aag-brepgraph-adjacency/`), why `AAG`'s pairwise adjacency does not build on
`BRepGraph`'s: `BRepGraph`'s face-node identity is `IsSame`-deduplicated, so a face shared across
solids is one node whose adjacency merges both solids, and a naive swap onto
`BRepGraph.sharedEdges(between:and:)` measured 2-8x slower, growing with model size.

```swift
let shape = /* a shape with a face pair sharing more than 10 boundary edges */
let aag = shape.buildAAG()
// sharedEdgeCount now reports the true count instead of capping at 10.
print(aag.edge(between: 0, and: 1)?.sharedEdgeCount as Any)
```

## SemVer impact

PATCH. `AAGEdge.sharedEdgeCount` can now return a larger, more accurate value on the (rare) face
pairs that share more than 10 edges; no public API signature changed. A consumer that happened to
rely on the old truncated value would see a different number, but the old value was a bug (a
silent undercount), not a documented contract.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR:
      `Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift` (4 tests).
- [x] Every new test was run once with its subject broken, and the failure is reported here (see
      below).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Removal matrix

Injected the pre-fix behavior (`min(10, trueCount)`) into `AAG.buildGraph()`, ran the new suite,
restored, ran again:

| test | with defect injected | restored |
|---|---|---|
| `sharedEdgeCountIsNotCappedAtTen` | FAIL (`10 != 12`, `10 > 10` false) | PASS |
| `agreesWithBRepGraphsUncappedCount` | FAIL (`10 != 12`) | PASS |
| `plainBoxUnaffected` | PASS (correctly unaffected -- no pair in this fixture ever approaches 10) | PASS |
| `convexityStillResolves` | PASS (correctly unaffected -- convexity only reads the first shared edge, untouched by the cap) | PASS |

The two tests that exist specifically to catch this defect both caught it; the two regression
guards correctly stayed green throughout, confirming they aren't false-alarming on unrelated
changes.

## Notes for the reviewer

- The full comparison, method, and every number quoted above is in
  `Scripts/repro/761-aag-brepgraph-adjacency/README.md`, reproducible via
  `swift run Censuses issue-761`.
- All 5 gate scripts + their `--self-test`s pass; full `swift test` (5489 tests) passes.
- The enclosure-test half of #761's scope (`PocketFeature.isOpen`, #735/#753) was measured but not
  acted on in this PR -- it's a genuine performance opportunity in BRepGraph's favor, not a
  correctness fix, and touches a different public code path. Left as a documented follow-up in the
  repro README rather than folded in here.