### PR TITLE
fix(#762): a filleted or chamfered pocket junction is absorbed, not reclassified

### DIFF
--- a/Scripts/repro/762-filleted-pocket-detection/README.md
+++ b/Scripts/repro/762-filleted-pocket-detection/README.md
@@ -18,10 +18,11 @@ clang++ -std=c++17 -ObjC++ -w \
 /tmp/probe_762
 ```
 
-Recorded output is in `ground-truth-output.txt` (971 lines, every manifold edge of all ten
-fixture variants, not excerpted; fixtures 1 through 6 were measured before the fix was written,
-fixture 8 was added afterward, during review, to test a removal-matrix conjunction, see below).
-`probe_762.mm` calls `ChFi3d::DefineConnectType` with the
+Recorded output is in `ground-truth-output.txt` (every manifold edge of all ten fixture variants,
+not excerpted; fixtures 1 through 6 were measured before the fix was written, fixture 8 was added
+during a second review round to test a removal-matrix conjunction, and fixtures 9 and 10 were added
+during a third review round to ground-truth the OR-fusion bug described below, see "The OR-fusion
+bug" section). `probe_762.mm` calls `ChFi3d::DefineConnectType` with the
 identical arguments `OCCTEdgeGetConvexity` does (`smoothThreshold = 0.01`, `CorrectPoint = true`),
 against fixtures built with plain OCCT primitives, no bridge and no Swift, so this is OCCT's own
 classifier's answer, not this project's wrapper of it.
@@ -42,6 +43,8 @@ this fix inverted it), unless noted:
 | 6 | Filleted boss (convex feature, r = 1) | floor `.smooth` to cylinder `.smooth` to boss wall | 0 | 1, **open** (matches sharp boss, see below) |
 | 7 | Plain box, own top exterior edges filleted, r = 2 (not in the probe binary, measured directly against the Swift API, see below) | floor `.smooth` to cylinder (radially OUTWARD) | 0 | **0** (must never become 1) |
 | 8 | L-shaped pocket, reflex corner, one of its two reflex-corner walls filleted, r = 1 (added during review, see "The `.convex` guard" below) | floor `.smooth` to cylinder `.smooth` to fillet, then `.convex` to the unfilleted wall | n/a (built after the fix) | 2 pockets (the L's own coplanar floor split), both open |
+| 9 | South floor/wall junction filleted (r = 3), and, separately, the vertical corner edge between west and south walls also filleted (r = 2), west's own floor/wall junction left SHARP (added during round-4 review, see "The OR-fusion bug" below) | floor `.smooth` to horizontal fillet cylinder `.smooth` to torus `.smooth` to vertical corner-blend cylinder | n/a (built after the fix) | 1 pocket, 4 walls, enclosed; the vertical corner-blend cylinder correctly excluded |
+| 10 | Fully rounded pocket: all four floor/wall junctions filleted (r = 3) AND all four vertical corners separately filleted (r = 2) (added during round-4 review, a stress generalization of fixture 9) | a torus/corner-fillet ring: 8 curved junction faces plus 4 BSpline corner-reconciliation faces | n/a (built after the fix) | 1 pocket, exactly 4 (flat) walls, enclosed; all 12 curved/freeform faces correctly excluded |
 
 "pre-fix" / "post-fix" counts are from `Sources/OCCTTest/main.swift` scratch runs against
 `detectPocketsAAG()` before and after the fix in this PR (the scratch probe itself is not
@@ -214,18 +217,105 @@ conjunction does not reveal a new failure mode beyond B alone; it is consistent 
 now-real effect being masked once B is also disabled, the same shape of interaction as the
 visited-marking bug's masking, just between two live guards rather than a guard and a bug.
 
+## The OR-fusion bug: entering a junction vs. continuing past one
+
+A third review round on this PR found the `.smooth` crossable test for a face reached from an
+already-confirmed fillet (`currentIsConfirmedFillet == true`) checked `neighborNode.isVertical ||
+isRadiallyInwardFillet(neighbor)` with no further distinction of WHERE the candidate sits relative
+to the floor. Once `current` is confirmed, every vertical `.smooth` neighbor looked eligible to
+become the wall, including a face that is itself another junction, not the wall at all.
+
+This traces back to an earlier, algebraically equivalent form the review named directly: the
+original crossable test was `isRadiallyInwardFillet(edge.face1Index) ||
+isRadiallyInwardFillet(edge.face2Index)`, testing EITHER end of the edge. `buildGraph()` always
+populates `edge.face1Index`/`edge.face2Index` as exactly `{current, neighbor}` as a set (`i < j` in
+occurrence order, unrelated to which node the BFS is currently expanding from), so that OR is
+provably identical to `isRadiallyInwardFillet(current) || isRadiallyInwardFillet(neighbor)`. Once
+`current` is confirmed, its own half of the OR is trivially true, making the far side irrelevant to
+crossability, exactly the "entering vs. continuing" ambiguity the review named.
+
+Built to prove this is reachable, not argued (the review's explicit instruction, given this PR had
+already been wrong twice about something looking "untestable" or "geometrically impossible" that
+turned out to be a live bug: the `.convex` guard's own history above): fixture 9. A vertical,
+radially-inward, but non-planar corner-blend cylinder (the separately-filleted west/south corner)
+is reached only through the south fillet's own further torus junction, never directly from the
+floor. Before the fix, `detectPocketsAAG()` reports `floor=6 walls=[0, 2, 3, 7, 8]`, five wall
+indices; node 2 is the corner-blend cylinder, wrongly promoted. Fixture 10 generalizes this to all
+four corners of a fully rounded pocket and shows a far more dramatic failure: `walls=[0, 2, 3, 8,
+9, 10, 11, 12]`, eight indices, all four corner-blend cylinders wrongly promoted, not just one.
+
+### The fix that was tried first, and regressed real walls
+
+The first fix attempted required a wall candidate to be `isVertical && isPlanar`, reasoning that a
+curved face satisfying `isVertical` (its own sampled normal is horizontal, which a vertical-axis
+cylinder or torus satisfies regardless of curvature) could not be a genuine flat wall.  Measured
+against the full suite, this broke three pre-existing, unrelated tests:
+`Issue735PocketEnclosureTests.cylindricalPocketIsEnclosed` and two floor-boss enclosure tests,
+because a SHARP cylindrical pocket's own bore, and a boss's own cylindrical side wall, are
+genuinely curved walls reached directly (no fillet at all), and `isPlanar` excluded them too. The
+`isPlanar` requirement was answering "is this face flat," which is not the same question as "is
+this face a wall of this floor's own pocket," and a curved fillet junction and a curved genuine
+wall can look identical by that one property alone. This confirms the same shape of mistake as
+round 2's retracted "no fixture reached it" argument: a plausible-sounding local property is not
+the same as measuring the actual distinguishing structure, and it cost a second full pass through
+the suite to find.
+
+### The fix that shipped: `currentBordersFloorDirectly`
+
+The distinguishing property that actually separates a genuine wall from an incidental corner blend
+is not a property of the CANDIDATE face at all: it is a property of `current`, the node whose edges
+are being examined. `currentBordersFloorDirectly` is true when `current` is the floor itself, or a
+junction whose own entering edge came directly from the floor: exactly the fillet or chamfer built
+to blend the floor to its wall specifically, which by construction has exactly two "long"
+tangent/concave relationships (to the floor, and to that wall) and nothing else. A junction reached
+only through ANOTHER junction (a corner blend continuing the chain, e.g. fixture 9's torus and
+second fillet) is not that relationship: it exists to reconcile two OTHER faces, and its own far
+neighbor is not automatically this floor's wall just because it is vertical and radially inward,
+since a further corner blend can be both of those too.
+
+A vertical candidate reached when `currentBordersFloorDirectly` is false is absorbed as a further
+junction instead (kept in the search, not dropped), so a genuine wall further down the same chain
+is still reachable by whichever route finds it. Measured on fixtures 9 and 10, both now report
+exactly the intended walls (`[0, 3, 7, 8]` and `[0, 8, 9, 12]` respectively, each all planar), with
+every corner-blend cylinder and BSpline correctly absorbed as a junction instead.
+
+### Why not a hop limit
+
+Fixture 10 was built specifically to check whether a fixed hop limit would have worked instead
+(the review's own question: "if a bound is needed on junction chaining, prefer something
+principled"). Measured, not assumed: every wall in fixture 10 is found in exactly one hop past its
+own floor-bordering horizontal fillet (ground truth edges #1/#12/#14/#18), the identical depth as
+the single-corner fixtures above, even though the same shape also offers a longer route to the same
+wall through its own vertical corner cylinder and BSpline (ground truth edges #2/#9, #3/#12, etc.).
+The BFS finds a wall by whichever route reaches it first, so the longer route is never actually
+needed here, and no fixture built for this issue required a genuine wall to be found more than one
+hop past a floor-bordering junction. `currentBordersFloorDirectly` gates on a structural fact
+(whether `current`'s own entering edge came from the floor) rather than a hop count precisely
+because a fillet is built to blend exactly the two named faces it sits between: a floor-bordering
+fillet's OTHER tangent relationship is its wall by construction, independent of how much unrelated
+corner-to-corner chaining exists elsewhere in the same graph. Termination does not depend on this
+gate either: `visited` already bounds the total work to this floor's own face count regardless of
+how many junction faces a chain absorbs (see "A direct dead end stays revisitable" above for the
+matching argument about the dead-end case).
+
 ## Removal matrix, final
 
 | injection | what was disabled | tests that failed |
 |---|---|---|
 | A | `.smooth`-edge radially-inward gate, unconditionally crossable | 3: plain-box exterior fillet, both L-shape tests (sharp and filleted) |
-| B | Z-tolerance bypass for chain-discovered walls | 10: all 4 fillet-radius cases, chamfer, partial-fillet, filleted through-slot, inverted `Issue753FilletedJunctionDetectedTests`, L-shape reflex corner, and the new dead-end test |
+| B | Z-tolerance bypass for chain-discovered walls | 12: all 4 fillet-radius cases, chamfer, partial-fillet, filleted through-slot, inverted `Issue753FilletedJunctionDetectedTests`, L-shape reflex corner, the dead-end test, the fixture-9 corner-blend test, and the fixture-10 ring test |
 | C | `.convex` edge block, alone | **2**: filleted through-slot, L-shape reflex corner (see table above) |
-| D | B and C together | 10, identical to B's own set |
+| D | B and C together | 12, identical to B's own set |
 
-Four injections, twenty-two tests, and every one of the four now has a real, non-vacuous failure
-set: none reads as decorative on inspection alone, and each was confirmed by actually breaking the
-code and watching the intended tests, and no others, fail.
+Re-run in full after the `currentBordersFloorDirectly` fix, since crossability rules changed what
+each injection reaches: the failure sets above are unchanged in shape from the pre-round-4 matrix
+plus exactly the two new round-4 tests, both folding into B/D's set (their own mechanism is a
+fillet chain, so removing the Z-tolerance bypass breaks them the same way as every other
+chain-discovered wall), and neither appearing under A or C, confirming the new gate is independent
+of those two guards rather than overlapping or subsuming them. `Issue762FilletedPocketDetectionTests.swift`
+carries 15 `@Test` functions after this round (13 before), and all four injections were re-run
+against the full `Issue762|Issue753|Issue735|Issue747` filter (34 tests), confirming no other,
+unrelated test picked up a new failure under any of the four.
 
 ## The radial material-side test was duplicated, now shared
 

--- a/Scripts/repro/762-filleted-pocket-detection/README.md
+++ b/Scripts/repro/762-filleted-pocket-detection/README.md
@@ -143,74 +143,100 @@ open: the two exit ends have no neighbor at all (a `.convex` edge to the box's o
 so nothing is absorbed there and the enclosure test still sees the gap. The verdict (open) does not
 change. *Why* it is open does.
 
-## The `.convex` guard: load-bearing past a junction, but untested there
+## The visited-marking bug that had been hiding the `.convex` guard's own proof
 
-`wallsAndJunctions(fromFloor:floorZ:tolerance:)` never crosses a `.convex` edge. A first pass at the
-removal matrix (injection C, disabling that block alone) came back green on every test in this PR,
-which read as "decorative." That reading was wrong, caught in review, and worth recording precisely.
+`wallsAndJunctions(fromFloor:floorZ:tolerance:)` marked a face `visited` as soon as an edge into
+it was crossable, before deciding wall, junction, or dead end. Review found this directly: a face
+that failed the #724 Z-tolerance check as a DIRECT floor neighbor was marked visited regardless,
+so a SEPARATE edge reaching that same face through an already-absorbed junction, where the Z check
+is bypassed and would have accepted it, could never run. Fixed by marking `visited` only once the
+outcome is decided, leaving a dead end (a direct vertical neighbor that fails the Z check)
+revisitable through a later junction.
 
-The guard has two call sites with different backstops. For a DIRECT (1-hop) floor neighbor, the
-#724 Z-tolerance check is independent cover: even with `.convex` disabled, a direct neighbor still
-has to bottom out at the floor's own Z to become a wall, and nothing in this PR's fixtures happens
-to do that by coincidence. For a face reached PAST an already-absorbed junction, the Z check is
-deliberately bypassed (see "Why a chain-discovered wall skips the #724 Z-tolerance check" in
-`wallsAndJunctions`'s own doc comment), so `.convex` is the ONLY remaining protection there.
-Injection C alone came back clean because every fixture in the original set happened to exercise
-the direct-neighbor case, never the past-a-junction one in isolation. Untested and proven-safe read
-identically in a green run.
+Measured on this codebase's own fixtures, not only argued: a partially-filleted pocket's two SHARP
+walls each have a low-Z bound offset from the floor's exact Z by about `1.5e-7`, a
+`BRepFilletAPI_MakeFillet` corner-blending artifact invisible at the default tolerance but decisive
+at a smaller one (`1e-8`). At that tolerance, the direct route fails and the fillet's own separate
+`.concave` edge to the same wall is the only thing that finds it. Proved by injection: reverting
+the fix and rerunning drops both sharp walls entirely (`wallFaceIndices.count` 4 to 2, `isOpen`
+false to true); restoring the fix returns both. See
+`Issue762DeadEndRevisitableThroughJunctionTests` in the test suite for the committed version.
 
-Two fixtures were built specifically to isolate the past-a-junction case, both ground-truthed
-against `ChFi3d` first (fixtures 5 and 8), and both failed to isolate it, for related but distinct
-reasons:
+## The `.convex` guard: proven load-bearing, once dead ends could be retried
 
-- **The filleted through-slot (fixture 5).** Its open end's exterior wall is convex-connected to
-  the fillet, but that same exterior wall is ALSO a direct (1-hop) neighbor of the floor (the
-  floor's own polygon reaches the same exterior boundary the fillet does, since they share that
-  corner). The #724 Z-check resolves it via the direct route before the fillet's own convex edge is
-  ever tried.
-- **The L-shaped pocket, reflex corner, partially filleted (fixture 8).** Built to test the reflex
-  vertex of a non-convex floor boundary: at an ORDINARY corner of a rectangular pocket, two walls
-  meet via a `.concave` edge (fixture 1, edges #17-24); at a REFLEX corner (the inner corner of an
-  L, where a small block of material sticks into the cavity, the mirror image of a boss standing in
-  a room's corner), the hypothesis was that the two walls instead meet via `.convex`, matching how
-  two of a boss's own base fillets meet convexly going around its corner (fixture 6, edges
-  #9/#11/#13/#15). Measured: the hypothesis holds (edge #9, `Cylinder` to `Plane`, `.convex`). But
-  filleting only ONE of the two reflex-corner walls and leaving the other sharp does not isolate the
-  guard either: `BRepFilletAPI_MakeFillet`'s own corner-blending, needed to keep the result
-  watertight where a fillet ends at an unfilleted reflex corner, reshapes the unfilleted wall's own
-  face so the FLOOR borders it directly too (confirmed via exact bounding boxes on the Swift side,
-  not inferred from face areas: `Sources/OCCTTest/main.swift` scratch diagnostic). So the same
-  masking recurs, for a kernel-side reason rather than a floor-topology one.
+A first removal-matrix pass (injection C, disabling the `.convex` block alone) came back green on
+every test in this PR at the time, read as proof the guard was decorative. That reading was wrong,
+and the visited-marking bug above is why: it was not that no fixture could isolate the
+past-a-junction path where `.convex` is the only protection (the #724 Z-check independently covers
+DIRECT neighbors, so `.convex` only matters once `reachedThroughJunction` bypasses that check). Two
+fixtures were built specifically to isolate it (fixtures 5 and 8, both ground-truthed against
+`ChFi3d` first), and both appeared to fail: the filleted through-slot's open-end exterior wall, and
+the L-shaped pocket's reflex-corner far wall, were each also a direct (1-hop) floor neighbor, so the
+Z-check seemed to resolve them first.
 
-A geometric argument, not just "no fixture reached it," emerged from both attempts: a floor's own
-boundary is a closed loop, and every vertex on it has exactly two incident edges, both bordering
-something the floor is directly adjacent to at the same BFS level (level 0) the junction's own
-convex-edged neighbor would only be reached at level 1 or later. A reentrant floor/wall pairing is
-never itself `.convex`, so the floor's own two edges at any vertex are always crossable, and always
-explored one level before a junction reached from that same vertex gets a chance to explore its own
-neighbors. Whatever a junction's convex-edged neighbor turns out to be, tracing it back reaches a
-vertex the floor already has its own, earlier route to. The same reasoning was checked (not
-re-built as a fixture) against a floor-boss-inside-a-pocket configuration too: a boss's wall is
-always additionally reachable via the floor's own inner-wire boundary, independent of any outer-wall
-fillet's own corner.
+That conclusion rested on an unexamined assumption, the same one the bug made in code: that a
+direct neighbor failing the Z-check was fully resolved. Both "masking" direct routes were actually
+REJECTING (near-boundary Z-tolerance noise in each case: the through-slot's own construction, and
+the reflex corner's `BRepFilletAPI` corner-blending artifact landing exactly on the tolerance
+boundary), and a rejected direct neighbor used to be marked `visited` anyway, permanently closing
+off the very `.convex`-gated path under investigation. Neither "masking" fixture was independent
+confirmation of anything: both were the visited-marking bug, not yet found.
 
-This argument covers the pocket topologies this investigation could construct and reason through.
-It is not offered as an exhaustive proof over every shape `BRepFilletAPI`/`BRepAlgoAPI` can produce,
-and it has not been used to justify removing the guard: `.convex` stays blocked, at essentially zero
-runtime cost, with its status recorded accurately as untested-but-plausibly-necessary rather than
-proven either way. A fixture that would settle it needs a face with genuinely no OTHER route to the
-floor at all, which on this evidence likely means two separate solids sharing an edge rather than
-one solid's own corner. That is a real, specific target for the next person who wants to close it,
-not a dead end.
+With dead ends left revisitable and `Issue762ReflexCornerPartialFilletTests` restored to the
+default tolerance (rather than widened past the noise, which is what let it clear the direct route
+and hide this), injection C alone now fails on exactly those two fixtures:
 
-### Injection D: the conjunction, not each half separately
+| fixture | before injection C | under injection C |
+|---|---|---|
+| Filleted through-slot | `wallFaceIndices.count` 2, `isOpen` true | `wallFaceIndices.count` **4**, `isOpen` **false** |
+| L-shaped pocket, reflex corner | `wallCounts` `[2, 4]` | `wallCounts` `[2, **5**]` |
 
-Per review, `.convex` (injection C) and the Z-tolerance bypass (injection B) were also disabled
-TOGETHER (injection D), re-running the full 21-test suite (`Tests/OCCTModelingTests
-/Issue762FilletedPocketDetectionTests.swift`, `Issue753FilletedJunctionDetectedTests`,
-`Issue735PocketEnclosureTests`) after each. Injection D's failure set was IDENTICAL to injection B's
-own, 9 of 21 tests, the same 9 in both cases. The conjunction reveals nothing beyond injection B
-alone on this fixture set, which is itself consistent with (not independent confirmation of) the
-masking argument above: if `.convex`'s own removal changes no outcome by itself, removing it
-alongside something else that does change outcomes should not produce a different failure set
-either, unless the two guards interact on some fixture in a way that cancels out. None here do.
+`.convex` is not untested any more. It is what stops both of these, proven by the same injection
+that once read as clearing it.
+
+The earlier "geometric argument" this README used to make (that a floor's own polygon vertex
+always gives it an equally early, non-`.convex` route to whatever a junction's `.convex` neighbor
+could reach, so the guard's own contribution was always redundant) is retracted, not merely
+superseded. It was true of the graph as the code then implemented it, where a rejected direct
+neighbor's `visited` marking made that route's failure equivalent to its success, both closing off
+the second route equally. It was never true of the geometry itself, only of a bug that happened to
+make the two indistinguishable in every fixture built to tell them apart.
+
+### Injection D: the conjunction, re-measured
+
+`.convex` (injection C) and the Z-tolerance bypass (injection B) were disabled TOGETHER (injection
+D) again after both fixes, re-running the full 22-test suite. Injection D's failure set (10 of 22
+tests) is identical to injection B's own (also 10, now including the new dead-end test), not to
+injection C's smaller, more specific pair. With the Z-tolerance bypass gone, most fillet-mediated
+walls are not found at all regardless of `.convex`, so there is nothing left for a relaxed
+`.convex` to over-include on top of that: B's much larger breakage dominates C's narrower one. The
+conjunction does not reveal a new failure mode beyond B alone; it is consistent with C's own
+now-real effect being masked once B is also disabled, the same shape of interaction as the
+visited-marking bug's masking, just between two live guards rather than a guard and a bug.
+
+## Removal matrix, final
+
+| injection | what was disabled | tests that failed |
+|---|---|---|
+| A | `.smooth`-edge radially-inward gate, unconditionally crossable | 3: plain-box exterior fillet, both L-shape tests (sharp and filleted) |
+| B | Z-tolerance bypass for chain-discovered walls | 10: all 4 fillet-radius cases, chamfer, partial-fillet, filleted through-slot, inverted `Issue753FilletedJunctionDetectedTests`, L-shape reflex corner, and the new dead-end test |
+| C | `.convex` edge block, alone | **2**: filleted through-slot, L-shape reflex corner (see table above) |
+| D | B and C together | 10, identical to B's own set |
+
+Four injections, twenty-two tests, and every one of the four now has a real, non-vacuous failure
+set: none reads as decorative on inspection alone, and each was confirmed by actually breaking the
+code and watching the intended tests, and no others, fail.
+
+## The radial material-side test was duplicated, now shared
+
+Review also found `isRadiallyInwardFillet(_:)` (used above) and `detectHoles()`'s own inline
+material-side check had drifted into near-duplicates: identical `uMid`/`vMid` midpoint,
+identical `offset`/`radial`/`radialLength` computation, identical `1e-9` guard, identical final
+dot-product test, differing only in whether a sphere is handled (a fillet junction can be a corner
+blend; `detectHoles()` is already gated to `.cylinder`/`.cone` and never needs it). Factored into
+one shared, `static` helper, `AAG.isMaterialRadiallyInward(of:revolution:uv:allowSphere:)`, taking
+the already-computed `revolution`/`uv` both callers already have rather than recomputing them.
+`detectHoles()`'s own tests (`Issue747DetectHolesConvexClassifierTests`) and the `#762` suites here
+both continue to pass unchanged, confirming the extraction is behavior-preserving. #723 and #747
+both already fixed this exact test once, on the copy that existed at the time; the point of sharing
+it now is that a third fix only has to happen once.

--- a/Scripts/repro/762-filleted-pocket-detection/README.md
+++ b/Scripts/repro/762-filleted-pocket-detection/README.md
@@ -1,0 +1,141 @@
+# #762: `detectPocketsAAG()` cannot see a filleted or chamfered pocket
+
+Ground truth for [#762](https://github.com/SecondMouseAU/OCCTSwift/issues/762): what
+`ChFi3d::DefineConnectType` (the classifier `OCCTEdgeGetConvexity` calls, #723) reports at every
+floor/wall-adjacent junction of a sharp, filleted (several radii), chamfered, partially-filleted,
+filleted-through-slot, and filleted-boss fixture. Built and measured *before* writing the fix, per
+`docs/v2.0.0-plan.md`'s census-once rule and #723/#747's own precedent of ground-truthing against
+`ChFi3d` before choosing a criterion.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/762-filleted-pocket-detection/probe_762.mm -o /tmp/probe_762
+/tmp/probe_762
+```
+
+Recorded output is in `ground-truth-output.txt` (854 lines, every manifold edge of all nine
+fixture variants, not excerpted). `probe_762.mm` calls `ChFi3d::DefineConnectType` with the
+identical arguments `OCCTEdgeGetConvexity` does (`smoothThreshold = 0.01`, `CorrectPoint = true`),
+against fixtures built with plain OCCT primitives, no bridge and no Swift, so this is OCCT's own
+classifier's answer, not this project's wrapper of it.
+
+## Fixture summary
+
+All built on a 10x10x15 pocket in a 20mm cube (`Shape.box(width:height:depth:)`'s own centred
+fixture, matching `Issue753FilletedJunctionDetectedTests`, formerly `...NotDetectedTests` before
+this fix inverted it), unless noted:
+
+| # | fixture | floor/wall junction | detected pre-fix | detected post-fix |
+|---|---|---|---|---|
+| 1 | Sharp pocket (control) | `.concave`, direct | 1, enclosed | 1, enclosed (unchanged) |
+| 2 | Filleted pocket, r = 0.5 / 1 / 2 / 4 | floor `.smooth` to cylinder `.smooth` to wall | **0** | 1, enclosed |
+| 3 | Chamfered pocket, d = 1.0 (symmetric) | floor `.concave` to chamfer `.concave` to wall | **0** | 1, enclosed |
+| 4 | Partially filleted (2 of 4 edges, r = 1) | mixed: 2 direct `.concave`, 2 via fillet | **0** | 1, enclosed |
+| 5 | Filleted through-slot (open both ends, r = 1) | 2 walls via fillet; 2 open ends `.convex` | 0 (already open, no walls found at all) | 1, **open** (unchanged verdict) |
+| 6 | Filleted boss (convex feature, r = 1) | floor `.smooth` to cylinder `.smooth` to boss wall | 0 | 1, **open** (matches sharp boss, see below) |
+| 7 | Plain box, own top exterior edges filleted, r = 2 (not in the probe binary, measured directly against the Swift API, see below) | floor `.smooth` to cylinder (radially OUTWARD) | 0 | **0** (must never become 1) |
+
+"pre-fix" / "post-fix" counts are from `Sources/OCCTTest/main.swift` scratch runs against
+`detectPocketsAAG()` before and after the fix in this PR (the scratch probe itself is not
+committed, per this repo's convention: the numbers are transcribed here and in the PR body).
+
+## The two junction shapes, and why they need different handling
+
+**A fillet's two new edges are both `.smooth` (tangent), at both ends, by construction.** A fillet
+is G1-continuous with both faces it blends, so there is no local sign left to read at either edge:
+`ChFi3d::DefineConnectType` cannot report `.concave` or `.convex` for a tangent transition, and
+correctly does not. `concaveNeighbors(of:)` therefore finds nothing. This is fixture 2's mechanism,
+matching the issue's own description exactly.
+
+**A chamfer's two new edges are both `.concave`.** A symmetric chamfer at a pocket's floor/wall
+junction replaces one 270-degree reentrant corner with two 225-degree ones (still `>180`). This was
+worked out geometrically before measuring, then confirmed here (fixture 3's edges #1 through #24
+are `.concave` or `.convex`, never `.smooth`). `concaveNeighbors(of:)` **does** reach the chamfer
+face directly. The reason `detectPockets` still missed it is a *different* gate: the chamfer is
+planar at 45 degrees, fails `wallIndices`' own `isVertical` filter, and the pre-fix search never
+continued past a concave-but-non-vertical neighbor to find the real wall beyond it.
+
+So the fix needed two things: continue searching past a **non-wall face reached via `.concave`**
+(covers chamfers, unconditionally, since the edge already carries the right sign), and separately
+allow crossing a **`.smooth` edge into a face confirmed to curve the right way** (covers fillets,
+where the edge itself carries no sign and the fillet FACE's own curvature has to be asked instead).
+
+## The radial-curvature test, and the hypothesis it corrected
+
+The natural first hypothesis (mirroring `detectHoles()`'s #747/#760 material-side test) was this: a
+concave/pocket-like fillet's own outward normal points radially INWARD (toward its axis, like a
+hole's bore), and a convex/boss-like fillet's points radially OUTWARD (away from its axis, like a
+boss's own wall), so the radial sign alone would tell a pocket's fillet from a boss's.
+
+**Measured, this is wrong.** Fixture 6 (filleted boss) shows the identical `INWARD (dot=-1.000000)`
+signature as fixture 2 (filleted pocket): see `ground-truth-output.txt` lines under
+`=== 6. Filleted boss ===`, edges #1 through #4. Worked out after measuring, not before: a boss's
+own base junction is a *reentrant* (270-degree material) corner, exactly like a pocket's floor/wall
+junction. The "T-shape" cross-section at a boss's base wraps material around the corner on three
+sides (below the plate, and inside the boss above it), identical in kind to a pocket's own
+floor/wall corner, just mirrored. The distinguishing property between a pocket and a boss was never
+at this junction at all. It is which side of the far WALL the material is on, which #753's own
+existing enclosure test already resolves independent of this fix (see below).
+
+**What the radial test is actually for**, confirmed by contrast: filleting a genuinely CONVEX,
+external corner (the box's own exterior edge, `.convex` at the sharp edge, material occupying only
+90 degrees) gives the OPPOSITE, `OUTWARD`, signature. That specific case is not built into this
+probe directly, but it is derivable from the same `ChFi3d`/curvature relationship the measured
+fixtures establish, and implicit in why fixtures 2 and 6 (both reentrant) share a sign while a
+plain rounded external corner would not. The radial test's job is refusing to chain through a
+`.smooth`-connected face that curves the WRONG way for a junction, an ordinary convex rounding, or
+an unrelated incidentally-tangent face, not distinguishing a pocket's fillet from a boss's.
+
+## Consequence for the false-positive guard
+
+Because the radial test cannot (and does not try to) tell a pocket's fillet from a boss's, a
+filleted boss standing alone on a flat plate is **not** excluded from `PocketFeature.wallFaceIndices`
+by this fix. That is consistent with, not a regression of, the pre-existing, already-tested behavior
+for a *sharp* boss: `Issue753PocketBossWireScopeTests` already established that a floor boss's wall
+is a legitimate member of `wallFaceIndices` when the boss stands on a real pocket's floor, with
+`isOpen`'s own outer-wire-scoped test (#753, unchanged by this fix) correctly reporting the
+enclosure state regardless. Measured directly (`Sources/OCCTTest/main.swift` scratch run): a sharp
+boss on a bare plate already reports `1 pocket, isOpen: true` before this fix; a filleted boss on
+the same plate reports the identical `1 pocket, isOpen: true` after it. Neither is a false
+*enclosed* pocket, which is the property that actually matters to a consumer. See
+`Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift`'s
+`Issue762FilletedBossFalsePositiveTests` for the codified version of this measurement.
+
+## `detectHoles()`: checked, not assumed, and found unaffected
+
+The issue asked to verify, not assume, whether `detectHoles()` (rewritten in #760 onto surface
+type plus closed-in-U plus material side, not neighbor convexity) shares this blindness. Measured
+directly (`Sources/OCCTTest/main.swift` scratch run, not committed):
+
+| fixture | `detectHoles()` result |
+|---|---|
+| Blind hole, sharp rim (control) | 1 hole, radius 4.0, depth 10.0 |
+| Blind hole, filleted rim (r = 1) | 1 hole, radius 4.0, depth **9.0** |
+| Blind hole, chamfered rim (d = 1) | **2** holes: cylindrical bore (radius 4.0, depth 9.0) plus conical countersink (radius 4.5, depth 1.0) |
+
+`detectHoles()` never reports **zero** holes in either case: it has no neighbor-convexity
+dependency to lose in the first place (#760's whole point). The filleted-rim depth drops by exactly
+the fillet's own axial extent, because the cylindrical wall really is shorter now (the fillet
+consumes the top of it). That is an accurate consequence of the geometry changing, not a detection
+failure. The chamfered-rim case reports the countersink's conical face as its own hole segment,
+which is exactly what `detectHoles()`'s own doc comment says a conical wall means ("a
+countersink/counterbore transition"), again correct, not a symptom of #762's bug. **No fix needed
+here; not filed separately, since there is nothing to fix.**
+
+## Why the sharp-through-slot control was worth measuring twice
+
+Fixture 5's pre-fix count is `0`, same as its post-fix count of `1, open`, matching the *sharp*
+through-slot's own existing behavior exactly (`Issue735PocketEnclosureTests
+.twoWalledThroughSlotIsNotEnclosed`), but the two zeros mean different things. Before this fix, the
+filleted slot found **zero** pockets at all (both walls unreachable, same
+`.smooth`-with-no-concave-neighbor mechanism as fixture 2), which happened to look like "correctly
+not a pocket" by coincidence of it also being open, not because the code correctly recognized an
+open slot. After the fix, it is found (walls resolved through their fillets) AND correctly reported
+open: the two exit ends have no neighbor at all (a `.convex` edge to the box's own exterior wall),
+so nothing is absorbed there and the enclosure test still sees the gap. The verdict (open) does not
+change. *Why* it is open does.

--- a/Scripts/repro/762-filleted-pocket-detection/README.md
+++ b/Scripts/repro/762-filleted-pocket-detection/README.md
@@ -18,8 +18,10 @@ clang++ -std=c++17 -ObjC++ -w \
 /tmp/probe_762
 ```
 
-Recorded output is in `ground-truth-output.txt` (854 lines, every manifold edge of all nine
-fixture variants, not excerpted). `probe_762.mm` calls `ChFi3d::DefineConnectType` with the
+Recorded output is in `ground-truth-output.txt` (971 lines, every manifold edge of all ten
+fixture variants, not excerpted; fixtures 1 through 6 were measured before the fix was written,
+fixture 8 was added afterward, during review, to test a removal-matrix conjunction, see below).
+`probe_762.mm` calls `ChFi3d::DefineConnectType` with the
 identical arguments `OCCTEdgeGetConvexity` does (`smoothThreshold = 0.01`, `CorrectPoint = true`),
 against fixtures built with plain OCCT primitives, no bridge and no Swift, so this is OCCT's own
 classifier's answer, not this project's wrapper of it.
@@ -39,6 +41,7 @@ this fix inverted it), unless noted:
 | 5 | Filleted through-slot (open both ends, r = 1) | 2 walls via fillet; 2 open ends `.convex` | 0 (already open, no walls found at all) | 1, **open** (unchanged verdict) |
 | 6 | Filleted boss (convex feature, r = 1) | floor `.smooth` to cylinder `.smooth` to boss wall | 0 | 1, **open** (matches sharp boss, see below) |
 | 7 | Plain box, own top exterior edges filleted, r = 2 (not in the probe binary, measured directly against the Swift API, see below) | floor `.smooth` to cylinder (radially OUTWARD) | 0 | **0** (must never become 1) |
+| 8 | L-shaped pocket, reflex corner, one of its two reflex-corner walls filleted, r = 1 (added during review, see "The `.convex` guard" below) | floor `.smooth` to cylinder `.smooth` to fillet, then `.convex` to the unfilleted wall | n/a (built after the fix) | 2 pockets (the L's own coplanar floor split), both open |
 
 "pre-fix" / "post-fix" counts are from `Sources/OCCTTest/main.swift` scratch runs against
 `detectPocketsAAG()` before and after the fix in this PR (the scratch probe itself is not
@@ -139,3 +142,75 @@ open slot. After the fix, it is found (walls resolved through their fillets) AND
 open: the two exit ends have no neighbor at all (a `.convex` edge to the box's own exterior wall),
 so nothing is absorbed there and the enclosure test still sees the gap. The verdict (open) does not
 change. *Why* it is open does.
+
+## The `.convex` guard: load-bearing past a junction, but untested there
+
+`wallsAndJunctions(fromFloor:floorZ:tolerance:)` never crosses a `.convex` edge. A first pass at the
+removal matrix (injection C, disabling that block alone) came back green on every test in this PR,
+which read as "decorative." That reading was wrong, caught in review, and worth recording precisely.
+
+The guard has two call sites with different backstops. For a DIRECT (1-hop) floor neighbor, the
+#724 Z-tolerance check is independent cover: even with `.convex` disabled, a direct neighbor still
+has to bottom out at the floor's own Z to become a wall, and nothing in this PR's fixtures happens
+to do that by coincidence. For a face reached PAST an already-absorbed junction, the Z check is
+deliberately bypassed (see "Why a chain-discovered wall skips the #724 Z-tolerance check" in
+`wallsAndJunctions`'s own doc comment), so `.convex` is the ONLY remaining protection there.
+Injection C alone came back clean because every fixture in the original set happened to exercise
+the direct-neighbor case, never the past-a-junction one in isolation. Untested and proven-safe read
+identically in a green run.
+
+Two fixtures were built specifically to isolate the past-a-junction case, both ground-truthed
+against `ChFi3d` first (fixtures 5 and 8), and both failed to isolate it, for related but distinct
+reasons:
+
+- **The filleted through-slot (fixture 5).** Its open end's exterior wall is convex-connected to
+  the fillet, but that same exterior wall is ALSO a direct (1-hop) neighbor of the floor (the
+  floor's own polygon reaches the same exterior boundary the fillet does, since they share that
+  corner). The #724 Z-check resolves it via the direct route before the fillet's own convex edge is
+  ever tried.
+- **The L-shaped pocket, reflex corner, partially filleted (fixture 8).** Built to test the reflex
+  vertex of a non-convex floor boundary: at an ORDINARY corner of a rectangular pocket, two walls
+  meet via a `.concave` edge (fixture 1, edges #17-24); at a REFLEX corner (the inner corner of an
+  L, where a small block of material sticks into the cavity, the mirror image of a boss standing in
+  a room's corner), the hypothesis was that the two walls instead meet via `.convex`, matching how
+  two of a boss's own base fillets meet convexly going around its corner (fixture 6, edges
+  #9/#11/#13/#15). Measured: the hypothesis holds (edge #9, `Cylinder` to `Plane`, `.convex`). But
+  filleting only ONE of the two reflex-corner walls and leaving the other sharp does not isolate the
+  guard either: `BRepFilletAPI_MakeFillet`'s own corner-blending, needed to keep the result
+  watertight where a fillet ends at an unfilleted reflex corner, reshapes the unfilleted wall's own
+  face so the FLOOR borders it directly too (confirmed via exact bounding boxes on the Swift side,
+  not inferred from face areas: `Sources/OCCTTest/main.swift` scratch diagnostic). So the same
+  masking recurs, for a kernel-side reason rather than a floor-topology one.
+
+A geometric argument, not just "no fixture reached it," emerged from both attempts: a floor's own
+boundary is a closed loop, and every vertex on it has exactly two incident edges, both bordering
+something the floor is directly adjacent to at the same BFS level (level 0) the junction's own
+convex-edged neighbor would only be reached at level 1 or later. A reentrant floor/wall pairing is
+never itself `.convex`, so the floor's own two edges at any vertex are always crossable, and always
+explored one level before a junction reached from that same vertex gets a chance to explore its own
+neighbors. Whatever a junction's convex-edged neighbor turns out to be, tracing it back reaches a
+vertex the floor already has its own, earlier route to. The same reasoning was checked (not
+re-built as a fixture) against a floor-boss-inside-a-pocket configuration too: a boss's wall is
+always additionally reachable via the floor's own inner-wire boundary, independent of any outer-wall
+fillet's own corner.
+
+This argument covers the pocket topologies this investigation could construct and reason through.
+It is not offered as an exhaustive proof over every shape `BRepFilletAPI`/`BRepAlgoAPI` can produce,
+and it has not been used to justify removing the guard: `.convex` stays blocked, at essentially zero
+runtime cost, with its status recorded accurately as untested-but-plausibly-necessary rather than
+proven either way. A fixture that would settle it needs a face with genuinely no OTHER route to the
+floor at all, which on this evidence likely means two separate solids sharing an edge rather than
+one solid's own corner. That is a real, specific target for the next person who wants to close it,
+not a dead end.
+
+### Injection D: the conjunction, not each half separately
+
+Per review, `.convex` (injection C) and the Z-tolerance bypass (injection B) were also disabled
+TOGETHER (injection D), re-running the full 21-test suite (`Tests/OCCTModelingTests
+/Issue762FilletedPocketDetectionTests.swift`, `Issue753FilletedJunctionDetectedTests`,
+`Issue735PocketEnclosureTests`) after each. Injection D's failure set was IDENTICAL to injection B's
+own, 9 of 21 tests, the same 9 in both cases. The conjunction reveals nothing beyond injection B
+alone on this fixture set, which is itself consistent with (not independent confirmation of) the
+masking argument above: if `.convex`'s own removal changes no outcome by itself, removing it
+alongside something else that does change outcomes should not produce a different failure set
+either, unless the two guards interact on some fixture in a way that cancels out. None here do.

--- a/Scripts/repro/762-filleted-pocket-detection/README.md
+++ b/Scripts/repro/762-filleted-pocket-detection/README.md
@@ -298,24 +298,68 @@ gate either: `visited` already bounds the total work to this floor's own face co
 how many junction faces a chain absorbs (see "A direct dead end stays revisitable" above for the
 matching argument about the dead-end case).
 
+## `currentBordersFloorDirectly` reconstructed a fact the BFS already knew, and got it wrong
+
+A fourth review round found two problems with the fix above, both confirmed and both fixed.
+
+**Finding 1: the gate asked the wrong question.** `currentBordersFloorDirectly` first shipped as
+`adjacencyList[floorIndex][current] != nil`: "does some edge exist between the floor and
+`current`". That is not "was `current` reached directly from the floor". `adjacencyList` is built
+for every edge regardless of convexity, so a junction that only incidentally touches the floor
+through a non-crossable edge would satisfy the check without ever having been reached that way,
+reopening this method's own bug for a topology none of the ten ground-truthed fixtures happens to
+exercise. Not hypothetical here: `BRepFilletAPI_MakeFillet`'s own corner-blending is documented, in
+`Issue762ReflexCornerPartialFilletTests`'s own doc comment (re: WallX0), to reshape an unrelated
+face so the floor borders it directly by incident, not by the route actually taken to reach it.
+
+Fixed by carrying the fact instead of reconstructing it. The BFS frontier changed from a plain
+`[Int]` to `[(index: Int, bordersFloorDirectly: Bool)]`: each entry pairs a node with whether IT
+was reached directly from the floor, decided once, at the moment it is enqueued (`current ==
+floorIndex` at that moment). This never consults `adjacencyList[floorIndex]` at all, so it cannot
+be fooled by an incidental edge, by construction rather than by a narrower heuristic.
+
+**Finding 2: no removal-matrix row actually isolated this gate.** The two round-4 tests fold into
+injection B/D's failure set (the Z-tolerance-bypass mechanism), which is a real but DIFFERENT way
+to break them, not evidence about `currentBordersFloorDirectly` itself. A test comment pointed at
+"the PR body's removal-matrix update" for proof that was not there: the third guard on this PR
+believed proven by a row that was actually exercising something else (after injection C being
+masked by the `visited` bug, and injections B/D backstopping each other).
+
+Fixed with a dedicated injection E: force `currentBordersFloorDirectly` to its pre-fix effective
+value of `true` (as if every node bordered the floor directly), and confirm the failure set is
+disjoint from every other injection's own. Measured: exactly
+`Issue762VerticalCornerBlendNotAWallTests`/`Issue762FullyRoundedPocketChainingTests` fail, and no
+other test in the full `#762`/`#753`/`#735`/`#747` suite (34 tests) does. That disjointness is
+what makes E an isolation rather than a coincidence: those same two tests ALSO fail under B/D, for
+the unrelated Z-tolerance reason, so a row that merely observed them failing there would prove
+nothing about this specific gate.
+
 ## Removal matrix, final
 
-| injection | what was disabled | tests that failed |
-|---|---|---|
-| A | `.smooth`-edge radially-inward gate, unconditionally crossable | 3: plain-box exterior fillet, both L-shape tests (sharp and filleted) |
-| B | Z-tolerance bypass for chain-discovered walls | 12: all 4 fillet-radius cases, chamfer, partial-fillet, filleted through-slot, inverted `Issue753FilletedJunctionDetectedTests`, L-shape reflex corner, the dead-end test, the fixture-9 corner-blend test, and the fixture-10 ring test |
-| C | `.convex` edge block, alone | **2**: filleted through-slot, L-shape reflex corner (see table above) |
-| D | B and C together | 12, identical to B's own set |
+| injection | what it disables | what it isolates | tests that failed |
+|---|---|---|---|
+| A | `.smooth`-edge radially-inward gate, unconditionally crossable | whether a fillet is confirmed reentrant before crossing into it | 3: plain-box exterior fillet, both L-shape tests (sharp and filleted) |
+| B | Z-tolerance bypass for chain-discovered walls | whether a chain-discovered wall is trusted by contiguity instead of its own Z | 12: all 4 fillet-radius cases, chamfer, partial-fillet, filleted through-slot, inverted `Issue753FilletedJunctionDetectedTests`, L-shape reflex corner, the dead-end test, the fixture-9 corner-blend test, and the fixture-10 ring test |
+| C | `.convex` edge block, alone | whether a reentrant-the-wrong-way edge is refused | **2**: filleted through-slot, L-shape reflex corner (see table above) |
+| D | B and C together | both of the above at once | 12, identical to B's own set (B's breakage dominates) |
+| E | `currentBordersFloorDirectly`, forced `true` | whether a wall can only be accepted from the floor itself or a junction that borders it directly | **2**: exactly the fixture-9 and fixture-10 round-4 tests, and only those |
 
-Re-run in full after the `currentBordersFloorDirectly` fix, since crossability rules changed what
-each injection reaches: the failure sets above are unchanged in shape from the pre-round-4 matrix
-plus exactly the two new round-4 tests, both folding into B/D's set (their own mechanism is a
-fillet chain, so removing the Z-tolerance bypass breaks them the same way as every other
-chain-discovered wall), and neither appearing under A or C, confirming the new gate is independent
-of those two guards rather than overlapping or subsuming them. `Issue762FilletedPocketDetectionTests.swift`
-carries 15 `@Test` functions after this round (13 before), and all four injections were re-run
-against the full `Issue762|Issue753|Issue735|Issue747` filter (34 tests), confirming no other,
-unrelated test picked up a new failure under any of the four.
+Each row's "isolates" column states, and its own measurement confirms, that disabling exactly that
+mechanism (and nothing upstream or downstream of it) produces its own failure set: A and C fail
+disjoint, narrow sets that neither B/D nor E also produce; B and D collapse to the same set because
+B's breakage is a superset of what C alone can add; E's set is a strict subset of B/D's own
+(reached by both mechanisms) but distinguishable from it, since E fails ONLY those two tests while
+B/D fails twelve, proving E is doing its own, narrower job rather than merely restating B's.
+
+Re-run in full after both fixes above, since crossability rules changed what each injection
+reaches: the failure sets for A through D are unchanged in shape from the pre-round-4 matrix plus
+exactly the two new round-4 tests folding into B/D (their own mechanism is a fillet chain, so
+removing the Z-tolerance bypass breaks them the same way as every other chain-discovered wall).
+`Issue762FilletedPocketDetectionTests.swift`
+carries 15 `@Test` functions (unchanged this round; no new fixture was added, only the injection
+that isolates the existing gate), and all five injections (A through E) were re-run against the
+full `Issue762|Issue753|Issue735|Issue747` filter (34 tests), confirming no other, unrelated test
+picked up a new failure under any of the five.
 
 ## The radial material-side test was duplicated, now shared
 

--- a/Scripts/repro/762-filleted-pocket-detection/ground-truth-output.txt
+++ b/Scripts/repro/762-filleted-pocket-detection/ground-truth-output.txt
@@ -969,3 +969,255 @@ smoothThreshold = 0.01, CorrectPoint = true (matches OCCTEdgeGetConvexity exactl
       F1: Plane area=60 centroid=(-6,3,5) radial=N/A
       F2: Plane area=36 centroid=(-3,3,0) radial=N/A
   (38 manifold edges total)
+
+=== 9. South floor fillet (r=3) + separate vertical corner fillet (r=2), west junction left sharp ===
+  edge #1: TANGENT(smooth)
+      F1: Plane area=56 centroid=(1,-5,6.5) radial=N/A
+      F2: Cylinder area=37.6991 centroid=(1,-3.90986,1.09014) radial=INWARD (dot=-1.000000)
+  edge #2: TANGENT(smooth)
+      F1: Plane area=56 centroid=(1,-5,6.5) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #3: CONCAVE
+      F1: Plane area=56 centroid=(1,-5,6.5) radial=N/A
+      F2: Plane area=98.0686 centroid=(5,0.0852754,5.08528) radial=N/A
+  edge #4: CONVEX
+      F1: Plane area=56 centroid=(1,-5,6.5) radial=N/A
+      F2: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+  edge #5: TANGENT(smooth)
+      F1: Cylinder area=37.6991 centroid=(1,-3.90986,1.09014) radial=INWARD (dot=-1.000000)
+      F2: Torus area=11.218 centroid=(-4.1202,-3.55329,1.44671) radial=N/A
+  edge #6: CONCAVE
+      F1: Cylinder area=37.6991 centroid=(1,-3.90986,1.09014) radial=INWARD (dot=-1.000000)
+      F2: Plane area=98.0686 centroid=(5,0.0852754,5.08528) radial=N/A
+  edge #7: TANGENT(smooth)
+      F1: Cylinder area=37.6991 centroid=(1,-3.90986,1.09014) radial=INWARD (dot=-1.000000)
+      F2: Plane area=56 centroid=(1,1.5,0) radial=N/A
+  edge #8: TANGENT(smooth)
+      F1: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Torus area=11.218 centroid=(-4.1202,-3.55329,1.44671) radial=N/A
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=63.7854 centroid=(-5,1.01271,6.01271) radial=N/A
+  edge #10: CONVEX
+      F1: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+  edge #11: CONVEX
+      F1: Plane area=98.0686 centroid=(5,0.0852754,5.08528) radial=N/A
+      F2: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+  edge #12: CONCAVE
+      F1: Plane area=98.0686 centroid=(5,0.0852754,5.08528) radial=N/A
+      F2: Plane area=56 centroid=(1,1.5,0) radial=N/A
+  edge #13: CONCAVE
+      F1: Plane area=98.0686 centroid=(5,0.0852754,5.08528) radial=N/A
+      F2: Plane area=99.1416 centroid=(0.039424,5,5.03942) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+      F2: Plane area=63.7854 centroid=(-5,1.01271,6.01271) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+      F2: Plane area=99.1416 centroid=(0.039424,5,5.03942) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #17: CONVEX
+      F1: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #18: CONVEX
+      F1: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #19: CONVEX
+      F1: Plane area=300.858 centroid=(-0.0129913,-0.0129913,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #20: TANGENT(smooth)
+      F1: Torus area=11.218 centroid=(-4.1202,-3.55329,1.44671) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,1.5,0.72676) radial=INWARD (dot=-1.000000)
+  edge #21: TANGENT(smooth)
+      F1: Torus area=11.218 centroid=(-4.1202,-3.55329,1.44671) radial=N/A
+      F2: Plane area=63.7854 centroid=(-5,1.01271,6.01271) radial=N/A
+  edge #22: TANGENT(smooth)
+      F1: Plane area=56 centroid=(1,1.5,0) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,1.5,0.72676) radial=INWARD (dot=-1.000000)
+  edge #23: CONCAVE
+      F1: Plane area=56 centroid=(1,1.5,0) radial=N/A
+      F2: Plane area=99.1416 centroid=(0.039424,5,5.03942) radial=N/A
+  edge #24: CONCAVE
+      F1: Plane area=63.7854 centroid=(-5,1.01271,6.01271) radial=N/A
+      F2: Plane area=99.1416 centroid=(0.039424,5,5.03942) radial=N/A
+  edge #25: TANGENT(smooth)
+      F1: Plane area=63.7854 centroid=(-5,1.01271,6.01271) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,1.5,0.72676) radial=INWARD (dot=-1.000000)
+  edge #26: CONCAVE
+      F1: Plane area=99.1416 centroid=(0.039424,5,5.03942) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,1.5,0.72676) radial=INWARD (dot=-1.000000)
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #33: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #34: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (34 manifold edges total)
+
+=== 10. Fully rounded pocket: floor fillet (r=3) all four sides + vertical corner fillet (r=2) all four corners ===
+  edge #1: TANGENT(smooth)
+      F1: Plane area=42 centroid=(1.03092e-16,-5,6.5) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(-1.67954e-14,-4.01181,1.18402) radial=INWARD (dot=-1.000000)
+  edge #2: TANGENT(smooth)
+      F1: Plane area=42 centroid=(1.03092e-16,-5,6.5) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #3: TANGENT(smooth)
+      F1: Plane area=42 centroid=(1.03092e-16,-5,6.5) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #4: CONVEX
+      F1: Plane area=42 centroid=(1.03092e-16,-5,6.5) radial=N/A
+      F2: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+  edge #5: CONCAVE
+      F1: Cylinder area=24.6021 centroid=(-1.67954e-14,-4.01181,1.18402) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(-3.7665,-3.7665,1.48235) radial=N/A
+  edge #6: CONCAVE
+      F1: Cylinder area=24.6021 centroid=(-1.67954e-14,-4.01181,1.18402) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(3.7665,-3.7665,1.48235) radial=N/A
+  edge #7: TANGENT(smooth)
+      F1: Cylinder area=24.6021 centroid=(-1.67954e-14,-4.01181,1.18402) radial=INWARD (dot=-1.000000)
+      F2: Plane area=16 centroid=(5.72459e-17,2.77556e-17,0) radial=N/A
+  edge #8: CONCAVE
+      F1: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(-3.7665,-3.7665,1.48235) radial=N/A
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(-5,1.34813e-16,6.5) radial=N/A
+  edge #10: CONVEX
+      F1: Cylinder area=21.9911 centroid=(-4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+  edge #11: CONCAVE
+      F1: Cylinder area=21.9911 centroid=(4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(3.7665,-3.7665,1.48235) radial=N/A
+  edge #12: TANGENT(smooth)
+      F1: Cylinder area=21.9911 centroid=(4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(5,1.34813e-16,6.5) radial=N/A
+  edge #13: CONVEX
+      F1: Cylinder area=21.9911 centroid=(4.27324,-4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=42 centroid=(5,1.34813e-16,6.5) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=42 centroid=(-5,1.34813e-16,6.5) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #17: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #18: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=42 centroid=(1.03092e-16,5,6.5) radial=N/A
+  edge #19: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #20: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #21: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #22: CONVEX
+      F1: Plane area=303.434 centroid=(-1.82943e-17,5.85419e-17,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #23: CONCAVE
+      F1: BSpline area=9.9202 centroid=(-3.7665,-3.7665,1.48235) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(-4.01181,6.55701e-16,1.18402) radial=INWARD (dot=-1.000000)
+  edge #24: CONCAVE
+      F1: BSpline area=9.9202 centroid=(3.7665,-3.7665,1.48235) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(4.01181,1.95026e-14,1.18402) radial=INWARD (dot=-1.000000)
+  edge #25: TANGENT(smooth)
+      F1: Plane area=16 centroid=(5.72459e-17,2.77556e-17,0) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(-4.01181,6.55701e-16,1.18402) radial=INWARD (dot=-1.000000)
+  edge #26: TANGENT(smooth)
+      F1: Plane area=16 centroid=(5.72459e-17,2.77556e-17,0) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(4.01181,1.95026e-14,1.18402) radial=INWARD (dot=-1.000000)
+  edge #27: TANGENT(smooth)
+      F1: Plane area=16 centroid=(5.72459e-17,2.77556e-17,0) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(8.74247e-15,4.01181,1.18402) radial=INWARD (dot=-1.000000)
+  edge #28: TANGENT(smooth)
+      F1: Plane area=42 centroid=(-5,1.34813e-16,6.5) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(-4.01181,6.55701e-16,1.18402) radial=INWARD (dot=-1.000000)
+  edge #29: TANGENT(smooth)
+      F1: Plane area=42 centroid=(-5,1.34813e-16,6.5) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(-4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #30: TANGENT(smooth)
+      F1: Plane area=42 centroid=(5,1.34813e-16,6.5) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(4.01181,1.95026e-14,1.18402) radial=INWARD (dot=-1.000000)
+  edge #31: TANGENT(smooth)
+      F1: Plane area=42 centroid=(5,1.34813e-16,6.5) radial=N/A
+      F2: Cylinder area=21.9911 centroid=(4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+  edge #32: CONCAVE
+      F1: Cylinder area=21.9911 centroid=(4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(3.7665,3.7665,1.48235) radial=N/A
+  edge #33: TANGENT(smooth)
+      F1: Cylinder area=21.9911 centroid=(4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(1.03092e-16,5,6.5) radial=N/A
+  edge #34: CONCAVE
+      F1: Cylinder area=21.9911 centroid=(-4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(-3.7665,3.7665,1.48235) radial=N/A
+  edge #35: TANGENT(smooth)
+      F1: Cylinder area=21.9911 centroid=(-4.27324,4.27324,6.5) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(1.03092e-16,5,6.5) radial=N/A
+  edge #36: TANGENT(smooth)
+      F1: Plane area=42 centroid=(1.03092e-16,5,6.5) radial=N/A
+      F2: Cylinder area=24.6021 centroid=(8.74247e-15,4.01181,1.18402) radial=INWARD (dot=-1.000000)
+  edge #37: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #38: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #39: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #40: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #41: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #42: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #43: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #44: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #45: CONCAVE
+      F1: Cylinder area=24.6021 centroid=(-4.01181,6.55701e-16,1.18402) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(-3.7665,3.7665,1.48235) radial=N/A
+  edge #46: CONCAVE
+      F1: Cylinder area=24.6021 centroid=(4.01181,1.95026e-14,1.18402) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(3.7665,3.7665,1.48235) radial=N/A
+  edge #47: CONCAVE
+      F1: Cylinder area=24.6021 centroid=(8.74247e-15,4.01181,1.18402) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(-3.7665,3.7665,1.48235) radial=N/A
+  edge #48: CONCAVE
+      F1: Cylinder area=24.6021 centroid=(8.74247e-15,4.01181,1.18402) radial=INWARD (dot=-1.000000)
+      F2: BSpline area=9.9202 centroid=(3.7665,3.7665,1.48235) radial=N/A
+  (48 manifold edges total)

--- a/Scripts/repro/762-filleted-pocket-detection/ground-truth-output.txt
+++ b/Scripts/repro/762-filleted-pocket-detection/ground-truth-output.txt
@@ -1,0 +1,854 @@
+#762 ground truth: ChFi3d::DefineConnectType at floor/wall junctions
+smoothThreshold = 0.01, CorrectPoint = true (matches OCCTEdgeGetConvexity exactly)
+
+=== 1. Sharp pocket (control), 10x10x15 pocket in a 20mm cube ===
+  edge #1: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #2: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #3: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #4: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #5: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #6: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #7: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #8: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #9: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #10: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=100 centroid=(-2.88658e-16,-5,5) radial=N/A
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=100 centroid=(5,-2.88658e-16,5) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=100 centroid=(-2.88658e-16,5,5) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=100 centroid=(-5,-2.88658e-16,5) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #17: CONCAVE
+      F1: Plane area=100 centroid=(-2.88658e-16,-5,5) radial=N/A
+      F2: Plane area=100 centroid=(5,-2.88658e-16,5) radial=N/A
+  edge #18: CONCAVE
+      F1: Plane area=100 centroid=(-2.88658e-16,-5,5) radial=N/A
+      F2: Plane area=100 centroid=(-5,-2.88658e-16,5) radial=N/A
+  edge #19: CONCAVE
+      F1: Plane area=100 centroid=(-2.88658e-16,-5,5) radial=N/A
+      F2: Plane area=100 centroid=(-6.93889e-18,6.66134e-17,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Plane area=100 centroid=(5,-2.88658e-16,5) radial=N/A
+      F2: Plane area=100 centroid=(-2.88658e-16,5,5) radial=N/A
+  edge #21: CONCAVE
+      F1: Plane area=100 centroid=(5,-2.88658e-16,5) radial=N/A
+      F2: Plane area=100 centroid=(-6.93889e-18,6.66134e-17,0) radial=N/A
+  edge #22: CONCAVE
+      F1: Plane area=100 centroid=(-2.88658e-16,5,5) radial=N/A
+      F2: Plane area=100 centroid=(-5,-2.88658e-16,5) radial=N/A
+  edge #23: CONCAVE
+      F1: Plane area=100 centroid=(-2.88658e-16,5,5) radial=N/A
+      F2: Plane area=100 centroid=(-6.93889e-18,6.66134e-17,0) radial=N/A
+  edge #24: CONCAVE
+      F1: Plane area=100 centroid=(-5,-2.88658e-16,5) radial=N/A
+      F2: Plane area=100 centroid=(-6.93889e-18,6.66134e-17,0) radial=N/A
+  (24 manifold edges total)
+
+=== 2. Filleted pocket, radius=0.5 ===
+  edge #1: CONCAVE
+      F1: Plane area=95 centroid=(-3.27224e-16,-5,5.25) radial=N/A
+      F2: Plane area=95 centroid=(5,-9.34925e-17,5.25) radial=N/A
+  edge #2: TANGENT(smooth)
+      F1: Plane area=95 centroid=(-3.27224e-16,-5,5.25) radial=N/A
+      F2: Cylinder area=7.56858 centroid=(1.20284e-15,-4.82322,0.186203) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=95 centroid=(-3.27224e-16,-5,5.25) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=95 centroid=(-3.27224e-16,-5,5.25) radial=N/A
+      F2: Plane area=95 centroid=(-5,-9.34925e-17,5.25) radial=N/A
+  edge #5: TANGENT(smooth)
+      F1: Plane area=95 centroid=(5,-9.34925e-17,5.25) radial=N/A
+      F2: Cylinder area=7.56858 centroid=(4.82322,-2.0243e-15,0.186203) radial=INWARD (dot=-1.000000)
+  edge #6: CONVEX
+      F1: Plane area=95 centroid=(5,-9.34925e-17,5.25) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #7: CONCAVE
+      F1: Plane area=95 centroid=(5,-9.34925e-17,5.25) radial=N/A
+      F2: Plane area=95 centroid=(-3.27224e-16,5,5.25) radial=N/A
+  edge #8: CONCAVE
+      F1: Cylinder area=7.56858 centroid=(1.20284e-15,-4.82322,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=7.56858 centroid=(-4.82322,5.75605e-14,0.186203) radial=INWARD (dot=-1.000000)
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=7.56858 centroid=(1.20284e-15,-4.82322,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Plane area=81 centroid=(-2.08167e-17,-1.72701e-16,0) radial=N/A
+  edge #10: CONCAVE
+      F1: Cylinder area=7.56858 centroid=(1.20284e-15,-4.82322,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=7.56858 centroid=(4.82322,-2.0243e-15,0.186203) radial=INWARD (dot=-1.000000)
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=95 centroid=(-3.27224e-16,5,5.25) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=95 centroid=(-5,-9.34925e-17,5.25) radial=N/A
+  edge #17: TANGENT(smooth)
+      F1: Plane area=95 centroid=(-5,-9.34925e-17,5.25) radial=N/A
+      F2: Cylinder area=7.56858 centroid=(-4.82322,5.75605e-14,0.186203) radial=INWARD (dot=-1.000000)
+  edge #18: CONCAVE
+      F1: Plane area=95 centroid=(-5,-9.34925e-17,5.25) radial=N/A
+      F2: Plane area=95 centroid=(-3.27224e-16,5,5.25) radial=N/A
+  edge #19: TANGENT(smooth)
+      F1: Cylinder area=7.56858 centroid=(4.82322,-2.0243e-15,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Plane area=81 centroid=(-2.08167e-17,-1.72701e-16,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Cylinder area=7.56858 centroid=(4.82322,-2.0243e-15,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=7.56858 centroid=(7.33442e-16,4.82322,0.186203) radial=INWARD (dot=-1.000000)
+  edge #21: TANGENT(smooth)
+      F1: Plane area=95 centroid=(-3.27224e-16,5,5.25) radial=N/A
+      F2: Cylinder area=7.56858 centroid=(7.33442e-16,4.82322,0.186203) radial=INWARD (dot=-1.000000)
+  edge #22: TANGENT(smooth)
+      F1: Cylinder area=7.56858 centroid=(-4.82322,5.75605e-14,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Plane area=81 centroid=(-2.08167e-17,-1.72701e-16,0) radial=N/A
+  edge #23: CONCAVE
+      F1: Cylinder area=7.56858 centroid=(-4.82322,5.75605e-14,0.186203) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=7.56858 centroid=(7.33442e-16,4.82322,0.186203) radial=INWARD (dot=-1.000000)
+  edge #24: TANGENT(smooth)
+      F1: Plane area=81 centroid=(-2.08167e-17,-1.72701e-16,0) radial=N/A
+      F2: Cylinder area=7.56858 centroid=(7.33442e-16,4.82322,0.186203) radial=INWARD (dot=-1.000000)
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (32 manifold edges total)
+
+=== 2. Filleted pocket, radius=1 ===
+  edge #1: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+  edge #2: TANGENT(smooth)
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Cylinder area=14.5664 centroid=(2.43898e-15,-4.65705,0.382138) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+  edge #5: TANGENT(smooth)
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Cylinder area=14.5664 centroid=(4.65705,-2.68288e-15,0.382138) radial=INWARD (dot=-1.000000)
+  edge #6: CONVEX
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #7: CONCAVE
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+  edge #8: CONCAVE
+      F1: Cylinder area=14.5664 centroid=(2.43898e-15,-4.65705,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=14.5664 centroid=(-4.65705,1.29571e-13,0.382138) radial=INWARD (dot=-1.000000)
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=14.5664 centroid=(2.43898e-15,-4.65705,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Plane area=64 centroid=(1.5439e-16,0,0) radial=N/A
+  edge #10: CONCAVE
+      F1: Cylinder area=14.5664 centroid=(2.43898e-15,-4.65705,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=14.5664 centroid=(4.65705,-2.68288e-15,0.382138) radial=INWARD (dot=-1.000000)
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+  edge #17: TANGENT(smooth)
+      F1: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+      F2: Cylinder area=14.5664 centroid=(-4.65705,1.29571e-13,0.382138) radial=INWARD (dot=-1.000000)
+  edge #18: CONCAVE
+      F1: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+  edge #19: TANGENT(smooth)
+      F1: Cylinder area=14.5664 centroid=(4.65705,-2.68288e-15,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Plane area=64 centroid=(1.5439e-16,0,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Cylinder area=14.5664 centroid=(4.65705,-2.68288e-15,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=14.5664 centroid=(-5.12187e-15,4.65705,0.382138) radial=INWARD (dot=-1.000000)
+  edge #21: TANGENT(smooth)
+      F1: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+      F2: Cylinder area=14.5664 centroid=(-5.12187e-15,4.65705,0.382138) radial=INWARD (dot=-1.000000)
+  edge #22: TANGENT(smooth)
+      F1: Cylinder area=14.5664 centroid=(-4.65705,1.29571e-13,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Plane area=64 centroid=(1.5439e-16,0,0) radial=N/A
+  edge #23: CONCAVE
+      F1: Cylinder area=14.5664 centroid=(-4.65705,1.29571e-13,0.382138) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=14.5664 centroid=(-5.12187e-15,4.65705,0.382138) radial=INWARD (dot=-1.000000)
+  edge #24: TANGENT(smooth)
+      F1: Plane area=64 centroid=(1.5439e-16,0,0) radial=N/A
+      F2: Cylinder area=14.5664 centroid=(-5.12187e-15,4.65705,0.382138) radial=INWARD (dot=-1.000000)
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (32 manifold edges total)
+
+=== 2. Filleted pocket, radius=2 ===
+  edge #1: CONCAVE
+      F1: Plane area=80 centroid=(-1.38778e-16,-5,6) radial=N/A
+      F2: Plane area=80 centroid=(5,-3.33067e-16,6) radial=N/A
+  edge #2: TANGENT(smooth)
+      F1: Plane area=80 centroid=(-1.38778e-16,-5,6) radial=N/A
+      F2: Cylinder area=26.8496 centroid=(-1.26365e-14,-4.3619,0.808174) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=80 centroid=(-1.38778e-16,-5,6) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=80 centroid=(-1.38778e-16,-5,6) radial=N/A
+      F2: Plane area=80 centroid=(-5,-3.33067e-16,6) radial=N/A
+  edge #5: TANGENT(smooth)
+      F1: Plane area=80 centroid=(5,-3.33067e-16,6) radial=N/A
+      F2: Cylinder area=26.8496 centroid=(4.3619,-1.30807e-09,0.808174) radial=INWARD (dot=-1.000000)
+  edge #6: CONVEX
+      F1: Plane area=80 centroid=(5,-3.33067e-16,6) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #7: CONCAVE
+      F1: Plane area=80 centroid=(5,-3.33067e-16,6) radial=N/A
+      F2: Plane area=80 centroid=(-1.38778e-16,5,6) radial=N/A
+  edge #8: CONCAVE
+      F1: Cylinder area=26.8496 centroid=(-1.26365e-14,-4.3619,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=26.8496 centroid=(-4.3619,9.05322e-15,0.808174) radial=INWARD (dot=-1.000000)
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=26.8496 centroid=(-1.26365e-14,-4.3619,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Plane area=36 centroid=(6.93889e-17,1.85037e-17,0) radial=N/A
+  edge #10: CONCAVE
+      F1: Cylinder area=26.8496 centroid=(-1.26365e-14,-4.3619,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=26.8496 centroid=(4.3619,-1.30807e-09,0.808174) radial=INWARD (dot=-1.000000)
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=80 centroid=(-1.38778e-16,5,6) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=80 centroid=(-5,-3.33067e-16,6) radial=N/A
+  edge #17: TANGENT(smooth)
+      F1: Plane area=80 centroid=(-5,-3.33067e-16,6) radial=N/A
+      F2: Cylinder area=26.8496 centroid=(-4.3619,9.05322e-15,0.808174) radial=INWARD (dot=-1.000000)
+  edge #18: CONCAVE
+      F1: Plane area=80 centroid=(-5,-3.33067e-16,6) radial=N/A
+      F2: Plane area=80 centroid=(-1.38778e-16,5,6) radial=N/A
+  edge #19: TANGENT(smooth)
+      F1: Cylinder area=26.8496 centroid=(4.3619,-1.30807e-09,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Plane area=36 centroid=(6.93889e-17,1.85037e-17,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Cylinder area=26.8496 centroid=(4.3619,-1.30807e-09,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=26.8496 centroid=(1.30456e-09,4.3619,0.808174) radial=INWARD (dot=-1.000000)
+  edge #21: TANGENT(smooth)
+      F1: Plane area=80 centroid=(-1.38778e-16,5,6) radial=N/A
+      F2: Cylinder area=26.8496 centroid=(1.30456e-09,4.3619,0.808174) radial=INWARD (dot=-1.000000)
+  edge #22: TANGENT(smooth)
+      F1: Cylinder area=26.8496 centroid=(-4.3619,9.05322e-15,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Plane area=36 centroid=(6.93889e-17,1.85037e-17,0) radial=N/A
+  edge #23: CONCAVE
+      F1: Cylinder area=26.8496 centroid=(-4.3619,9.05322e-15,0.808174) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=26.8496 centroid=(1.30456e-09,4.3619,0.808174) radial=INWARD (dot=-1.000000)
+  edge #24: TANGENT(smooth)
+      F1: Plane area=36 centroid=(6.93889e-17,1.85037e-17,0) radial=N/A
+      F2: Cylinder area=26.8496 centroid=(1.30456e-09,4.3619,0.808174) radial=INWARD (dot=-1.000000)
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (32 manifold edges total)
+
+=== 2. Filleted pocket, radius=4 ===
+  edge #1: CONCAVE
+      F1: Plane area=60 centroid=(-4.25585e-16,-5,7) radial=N/A
+      F2: Plane area=60 centroid=(5,-2.40548e-16,7) radial=N/A
+  edge #2: TANGENT(smooth)
+      F1: Plane area=60 centroid=(-4.25585e-16,-5,7) radial=N/A
+      F2: Cylinder area=44.5664 centroid=(-1.221e-12,-3.97379,1.84591) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=60 centroid=(-4.25585e-16,-5,7) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=60 centroid=(-4.25585e-16,-5,7) radial=N/A
+      F2: Plane area=60 centroid=(-5,-1.4803e-16,7) radial=N/A
+  edge #5: TANGENT(smooth)
+      F1: Plane area=60 centroid=(5,-2.40548e-16,7) radial=N/A
+      F2: Cylinder area=44.5664 centroid=(3.97379,-1.38375e-12,1.84591) radial=INWARD (dot=-1.000000)
+  edge #6: CONVEX
+      F1: Plane area=60 centroid=(5,-2.40548e-16,7) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #7: CONCAVE
+      F1: Plane area=60 centroid=(5,-2.40548e-16,7) radial=N/A
+      F2: Plane area=60 centroid=(-4.25585e-16,5,7) radial=N/A
+  edge #8: CONCAVE
+      F1: Cylinder area=44.5664 centroid=(-1.221e-12,-3.97379,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=44.5664 centroid=(-3.97379,-1.15027e-12,1.84591) radial=INWARD (dot=-1.000000)
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=44.5664 centroid=(-1.221e-12,-3.97379,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Plane area=4 centroid=(1.30104e-17,-1.38778e-17,0) radial=N/A
+  edge #10: CONCAVE
+      F1: Cylinder area=44.5664 centroid=(-1.221e-12,-3.97379,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=44.5664 centroid=(3.97379,-1.38375e-12,1.84591) radial=INWARD (dot=-1.000000)
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=60 centroid=(-4.25585e-16,5,7) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=60 centroid=(-5,-1.4803e-16,7) radial=N/A
+  edge #17: TANGENT(smooth)
+      F1: Plane area=60 centroid=(-5,-1.4803e-16,7) radial=N/A
+      F2: Cylinder area=44.5664 centroid=(-3.97379,-1.15027e-12,1.84591) radial=INWARD (dot=-1.000000)
+  edge #18: CONCAVE
+      F1: Plane area=60 centroid=(-5,-1.4803e-16,7) radial=N/A
+      F2: Plane area=60 centroid=(-4.25585e-16,5,7) radial=N/A
+  edge #19: TANGENT(smooth)
+      F1: Cylinder area=44.5664 centroid=(3.97379,-1.38375e-12,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Plane area=4 centroid=(1.30104e-17,-1.38778e-17,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Cylinder area=44.5664 centroid=(3.97379,-1.38375e-12,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=44.5664 centroid=(-1.83715e-12,3.97379,1.84591) radial=INWARD (dot=-1.000000)
+  edge #21: TANGENT(smooth)
+      F1: Plane area=60 centroid=(-4.25585e-16,5,7) radial=N/A
+      F2: Cylinder area=44.5664 centroid=(-1.83715e-12,3.97379,1.84591) radial=INWARD (dot=-1.000000)
+  edge #22: TANGENT(smooth)
+      F1: Cylinder area=44.5664 centroid=(-3.97379,-1.15027e-12,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Plane area=4 centroid=(1.30104e-17,-1.38778e-17,0) radial=N/A
+  edge #23: CONCAVE
+      F1: Cylinder area=44.5664 centroid=(-3.97379,-1.15027e-12,1.84591) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=44.5664 centroid=(-1.83715e-12,3.97379,1.84591) radial=INWARD (dot=-1.000000)
+  edge #24: TANGENT(smooth)
+      F1: Plane area=4 centroid=(1.30104e-17,-1.38778e-17,0) radial=N/A
+      F2: Cylinder area=44.5664 centroid=(-1.83715e-12,3.97379,1.84591) radial=INWARD (dot=-1.000000)
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (32 manifold edges total)
+
+=== 3. Chamfered pocket, distance=1.0 (symmetric) ===
+  edge #1: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+  edge #2: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=12.7279 centroid=(-7.67601e-16,-4.51852,0.518519) radial=N/A
+  edge #3: CONVEX
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+  edge #5: CONCAVE
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=12.7279 centroid=(4.51852,-1.18629e-15,0.518519) radial=N/A
+  edge #6: CONVEX
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #7: CONCAVE
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+  edge #8: CONCAVE
+      F1: Plane area=12.7279 centroid=(-7.67601e-16,-4.51852,0.518519) radial=N/A
+      F2: Plane area=12.7279 centroid=(-4.51852,-8.23112e-16,0.518519) radial=N/A
+  edge #9: CONCAVE
+      F1: Plane area=12.7279 centroid=(-7.67601e-16,-4.51852,0.518519) radial=N/A
+      F2: Plane area=64 centroid=(2.09902e-16,1.11022e-16,0) radial=N/A
+  edge #10: CONCAVE
+      F1: Plane area=12.7279 centroid=(-7.67601e-16,-4.51852,0.518519) radial=N/A
+      F2: Plane area=12.7279 centroid=(4.51852,-1.18629e-15,0.518519) radial=N/A
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+  edge #17: CONCAVE
+      F1: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=12.7279 centroid=(-4.51852,-8.23112e-16,0.518519) radial=N/A
+  edge #18: CONCAVE
+      F1: Plane area=90 centroid=(-5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+  edge #19: CONCAVE
+      F1: Plane area=12.7279 centroid=(4.51852,-1.18629e-15,0.518519) radial=N/A
+      F2: Plane area=64 centroid=(2.09902e-16,1.11022e-16,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Plane area=12.7279 centroid=(4.51852,-1.18629e-15,0.518519) radial=N/A
+      F2: Plane area=12.7279 centroid=(-1.2418e-15,4.51852,0.518519) radial=N/A
+  edge #21: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,5,5.5) radial=N/A
+      F2: Plane area=12.7279 centroid=(-1.2418e-15,4.51852,0.518519) radial=N/A
+  edge #22: CONCAVE
+      F1: Plane area=12.7279 centroid=(-4.51852,-8.23112e-16,0.518519) radial=N/A
+      F2: Plane area=64 centroid=(2.09902e-16,1.11022e-16,0) radial=N/A
+  edge #23: CONCAVE
+      F1: Plane area=12.7279 centroid=(-4.51852,-8.23112e-16,0.518519) radial=N/A
+      F2: Plane area=12.7279 centroid=(-1.2418e-15,4.51852,0.518519) radial=N/A
+  edge #24: CONCAVE
+      F1: Plane area=64 centroid=(2.09902e-16,1.11022e-16,0) radial=N/A
+      F2: Plane area=12.7279 centroid=(-1.2418e-15,4.51852,0.518519) radial=N/A
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (32 manifold edges total)
+
+=== 4. Partially filleted pocket (2 of 4 edges, radius=1.0) ===
+  edge #1: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+  edge #2: TANGENT(smooth)
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Cylinder area=15.1372 centroid=(-0.176776,-4.64645,0.372406) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=90 centroid=(-1.72701e-16,-5,5.5) radial=N/A
+      F2: Plane area=99.7854 centroid=(-5,0.0102728,5.01027) radial=N/A
+  edge #5: TANGENT(smooth)
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Cylinder area=15.1372 centroid=(4.64645,0.176776,0.372406) radial=INWARD (dot=-1.000000)
+  edge #6: CONVEX
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+  edge #7: CONCAVE
+      F1: Plane area=90 centroid=(5,-1.4803e-16,5.5) radial=N/A
+      F2: Plane area=99.7854 centroid=(-0.0102728,5,5.01027) radial=N/A
+  edge #8: CONCAVE
+      F1: Cylinder area=15.1372 centroid=(-0.176776,-4.64645,0.372406) radial=INWARD (dot=-1.000000)
+      F2: Plane area=99.7854 centroid=(-5,0.0102728,5.01027) radial=N/A
+  edge #9: TANGENT(smooth)
+      F1: Cylinder area=15.1372 centroid=(-0.176776,-4.64645,0.372406) radial=INWARD (dot=-1.000000)
+      F2: Plane area=81 centroid=(-0.5,0.5,0) radial=N/A
+  edge #10: CONCAVE
+      F1: Cylinder area=15.1372 centroid=(-0.176776,-4.64645,0.372406) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=15.1372 centroid=(4.64645,0.176776,0.372406) radial=INWARD (dot=-1.000000)
+  edge #11: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=99.7854 centroid=(-0.0102728,5,5.01027) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=300 centroid=(0,2.07242e-16,10) radial=N/A
+      F2: Plane area=99.7854 centroid=(-5,0.0102728,5.01027) radial=N/A
+  edge #17: CONCAVE
+      F1: Plane area=99.7854 centroid=(-5,0.0102728,5.01027) radial=N/A
+      F2: Plane area=81 centroid=(-0.5,0.5,0) radial=N/A
+  edge #18: CONCAVE
+      F1: Plane area=99.7854 centroid=(-5,0.0102728,5.01027) radial=N/A
+      F2: Plane area=99.7854 centroid=(-0.0102728,5,5.01027) radial=N/A
+  edge #19: TANGENT(smooth)
+      F1: Cylinder area=15.1372 centroid=(4.64645,0.176776,0.372406) radial=INWARD (dot=-1.000000)
+      F2: Plane area=81 centroid=(-0.5,0.5,0) radial=N/A
+  edge #20: CONCAVE
+      F1: Cylinder area=15.1372 centroid=(4.64645,0.176776,0.372406) radial=INWARD (dot=-1.000000)
+      F2: Plane area=99.7854 centroid=(-0.0102728,5,5.01027) radial=N/A
+  edge #21: CONCAVE
+      F1: Plane area=99.7854 centroid=(-0.0102728,5,5.01027) radial=N/A
+      F2: Plane area=81 centroid=(-0.5,0.5,0) radial=N/A
+  edge #22: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #23: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #24: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  (29 manifold edges total)
+
+=== 5. Filleted through-slot (open both ends), radius=1.0 ===
+  edge #1: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=180 centroid=(-3.45403e-16,-3,5.5) radial=N/A
+  edge #2: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Cylinder area=31.4159 centroid=(6.09606e-16,-2.63662,0.36338) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=140 centroid=(-1.38778e-17,-6.5,10) radial=N/A
+  edge #4: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=80 centroid=(-8.32667e-17,1.11022e-16,0) radial=N/A
+  edge #5: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #6: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Cylinder area=31.4159 centroid=(5.38927e-16,2.63662,0.36338) radial=INWARD (dot=-1.000000)
+  edge #7: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #8: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=180 centroid=(-3.45403e-16,3,5.5) radial=N/A
+  edge #9: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #10: CONVEX
+      F1: Plane area=340.429 centroid=(-10,0,-0.880959) radial=N/A
+      F2: Plane area=140 centroid=(-1.38778e-17,6.5,10) radial=N/A
+  edge #11: CONVEX
+      F1: Plane area=180 centroid=(-3.45403e-16,-3,5.5) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #12: TANGENT(smooth)
+      F1: Plane area=180 centroid=(-3.45403e-16,-3,5.5) radial=N/A
+      F2: Cylinder area=31.4159 centroid=(6.09606e-16,-2.63662,0.36338) radial=INWARD (dot=-1.000000)
+  edge #13: CONVEX
+      F1: Plane area=180 centroid=(-3.45403e-16,-3,5.5) radial=N/A
+      F2: Plane area=140 centroid=(-1.38778e-17,-6.5,10) radial=N/A
+  edge #14: TANGENT(smooth)
+      F1: Cylinder area=31.4159 centroid=(6.09606e-16,-2.63662,0.36338) radial=INWARD (dot=-1.000000)
+      F2: Plane area=80 centroid=(-8.32667e-17,1.11022e-16,0) radial=N/A
+  edge #15: CONVEX
+      F1: Cylinder area=31.4159 centroid=(6.09606e-16,-2.63662,0.36338) radial=INWARD (dot=-1.000000)
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=140 centroid=(-1.38778e-17,-6.5,10) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #17: CONVEX
+      F1: Plane area=140 centroid=(-1.38778e-17,-6.5,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #18: CONVEX
+      F1: Plane area=80 centroid=(-8.32667e-17,1.11022e-16,0) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #19: TANGENT(smooth)
+      F1: Plane area=80 centroid=(-8.32667e-17,1.11022e-16,0) radial=N/A
+      F2: Cylinder area=31.4159 centroid=(5.38927e-16,2.63662,0.36338) radial=INWARD (dot=-1.000000)
+  edge #20: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #21: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #22: TANGENT(smooth)
+      F1: Cylinder area=31.4159 centroid=(5.38927e-16,2.63662,0.36338) radial=INWARD (dot=-1.000000)
+      F2: Plane area=180 centroid=(-3.45403e-16,3,5.5) radial=N/A
+  edge #23: CONVEX
+      F1: Cylinder area=31.4159 centroid=(5.38927e-16,2.63662,0.36338) radial=INWARD (dot=-1.000000)
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #24: CONVEX
+      F1: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #25: CONVEX
+      F1: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=180 centroid=(-3.45403e-16,3,5.5) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=180 centroid=(-3.45403e-16,3,5.5) radial=N/A
+      F2: Plane area=140 centroid=(-1.38778e-17,6.5,10) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=140 centroid=(-1.38778e-17,6.5,10) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=140 centroid=(-1.38778e-17,6.5,10) radial=N/A
+      F2: Plane area=340.429 centroid=(10,0,-0.880959) radial=N/A
+  (30 manifold edges total)
+
+=== 6. Filleted boss (convex feature, must NOT be a pocket), radius=1.0 ===
+  edge #1: TANGENT(smooth)
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Cylinder area=10.5664 centroid=(-3.39154,9.98178e-14,0.337521) radial=INWARD (dot=-1.000000)
+  edge #2: TANGENT(smooth)
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Cylinder area=10.5664 centroid=(5.26197e-14,-3.39154,0.337521) radial=INWARD (dot=-1.000000)
+  edge #3: TANGENT(smooth)
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Cylinder area=10.5664 centroid=(4.49285e-14,3.39154,0.337521) radial=INWARD (dot=-1.000000)
+  edge #4: TANGENT(smooth)
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Cylinder area=10.5664 centroid=(3.39154,5.68856e-14,0.337521) radial=INWARD (dot=-1.000000)
+  edge #5: CONVEX
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Plane area=100 centroid=(-10,-3.10862e-16,-2.5) radial=N/A
+  edge #6: CONVEX
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Plane area=100 centroid=(1.33227e-16,10,-2.5) radial=N/A
+  edge #7: CONVEX
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Plane area=100 centroid=(1.33227e-16,-10,-2.5) radial=N/A
+  edge #8: CONVEX
+      F1: Plane area=336 centroid=(-1.65212e-17,1.4803e-16,0) radial=N/A
+      F2: Plane area=100 centroid=(10,-3.10862e-16,-2.5) radial=N/A
+  edge #9: CONVEX
+      F1: Cylinder area=10.5664 centroid=(-3.39154,9.98178e-14,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=10.5664 centroid=(5.26197e-14,-3.39154,0.337521) radial=INWARD (dot=-1.000000)
+  edge #10: TANGENT(smooth)
+      F1: Cylinder area=10.5664 centroid=(-3.39154,9.98178e-14,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(-3,3.17207e-17,4.5) radial=N/A
+  edge #11: CONVEX
+      F1: Cylinder area=10.5664 centroid=(-3.39154,9.98178e-14,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=10.5664 centroid=(4.49285e-14,3.39154,0.337521) radial=INWARD (dot=-1.000000)
+  edge #12: TANGENT(smooth)
+      F1: Cylinder area=10.5664 centroid=(5.26197e-14,-3.39154,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(0,-3,4.5) radial=N/A
+  edge #13: CONVEX
+      F1: Cylinder area=10.5664 centroid=(5.26197e-14,-3.39154,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=10.5664 centroid=(3.39154,5.68856e-14,0.337521) radial=INWARD (dot=-1.000000)
+  edge #14: TANGENT(smooth)
+      F1: Cylinder area=10.5664 centroid=(4.49285e-14,3.39154,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(0,3,4.5) radial=N/A
+  edge #15: CONVEX
+      F1: Cylinder area=10.5664 centroid=(4.49285e-14,3.39154,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Cylinder area=10.5664 centroid=(3.39154,5.68856e-14,0.337521) radial=INWARD (dot=-1.000000)
+  edge #16: TANGENT(smooth)
+      F1: Cylinder area=10.5664 centroid=(3.39154,5.68856e-14,0.337521) radial=INWARD (dot=-1.000000)
+      F2: Plane area=42 centroid=(3,3.17207e-17,4.5) radial=N/A
+  edge #17: CONVEX
+      F1: Plane area=100 centroid=(-10,-3.10862e-16,-2.5) radial=N/A
+      F2: Plane area=100 centroid=(1.33227e-16,-10,-2.5) radial=N/A
+  edge #18: CONVEX
+      F1: Plane area=100 centroid=(-10,-3.10862e-16,-2.5) radial=N/A
+      F2: Plane area=100 centroid=(1.33227e-16,10,-2.5) radial=N/A
+  edge #19: CONVEX
+      F1: Plane area=100 centroid=(-10,-3.10862e-16,-2.5) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-5) radial=N/A
+  edge #20: CONVEX
+      F1: Plane area=100 centroid=(1.33227e-16,10,-2.5) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-5) radial=N/A
+  edge #21: CONVEX
+      F1: Plane area=100 centroid=(1.33227e-16,10,-2.5) radial=N/A
+      F2: Plane area=100 centroid=(10,-3.10862e-16,-2.5) radial=N/A
+  edge #22: CONVEX
+      F1: Plane area=100 centroid=(1.33227e-16,-10,-2.5) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-5) radial=N/A
+  edge #23: CONVEX
+      F1: Plane area=100 centroid=(1.33227e-16,-10,-2.5) radial=N/A
+      F2: Plane area=100 centroid=(10,-3.10862e-16,-2.5) radial=N/A
+  edge #24: CONVEX
+      F1: Plane area=100 centroid=(10,-3.10862e-16,-2.5) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-5) radial=N/A
+  edge #25: CONVEX
+      F1: Plane area=42 centroid=(-3,3.17207e-17,4.5) radial=N/A
+      F2: Plane area=42 centroid=(0,-3,4.5) radial=N/A
+  edge #26: CONVEX
+      F1: Plane area=42 centroid=(-3,3.17207e-17,4.5) radial=N/A
+      F2: Plane area=36 centroid=(7.80626e-17,3.70074e-17,8) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=42 centroid=(-3,3.17207e-17,4.5) radial=N/A
+      F2: Plane area=42 centroid=(0,3,4.5) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=42 centroid=(0,-3,4.5) radial=N/A
+      F2: Plane area=42 centroid=(3,3.17207e-17,4.5) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=42 centroid=(0,-3,4.5) radial=N/A
+      F2: Plane area=36 centroid=(7.80626e-17,3.70074e-17,8) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=42 centroid=(0,3,4.5) radial=N/A
+      F2: Plane area=42 centroid=(3,3.17207e-17,4.5) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=42 centroid=(0,3,4.5) radial=N/A
+      F2: Plane area=36 centroid=(7.80626e-17,3.70074e-17,8) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=42 centroid=(3,3.17207e-17,4.5) radial=N/A
+      F2: Plane area=36 centroid=(7.80626e-17,3.70074e-17,8) radial=N/A
+  (32 manifold edges total)

--- a/Scripts/repro/762-filleted-pocket-detection/ground-truth-output.txt
+++ b/Scripts/repro/762-filleted-pocket-detection/ground-truth-output.txt
@@ -852,3 +852,120 @@ smoothThreshold = 0.01, CorrectPoint = true (matches OCCTEdgeGetConvexity exactl
       F1: Plane area=42 centroid=(3,3.17207e-17,4.5) radial=N/A
       F2: Plane area=36 centroid=(7.80626e-17,3.70074e-17,8) radial=N/A
   (32 manifold edges total)
+
+=== 8. L-shaped pocket, reflex corner, one of its two walls filleted, radius=1.0 ===
+  edge #1: CONCAVE
+      F1: Plane area=59.7854 centroid=(6,-3.00997,5.01715) radial=N/A
+      F2: Plane area=54 centroid=(3,0,5.5) radial=N/A
+  edge #2: CONCAVE
+      F1: Plane area=59.7854 centroid=(6,-3.00997,5.01715) radial=N/A
+      F2: Cylinder area=9.42478 centroid=(3,-0.36338,0.36338) radial=INWARD (dot=-1.000000)
+  edge #3: CONVEX
+      F1: Plane area=59.7854 centroid=(6,-3.00997,5.01715) radial=N/A
+      F2: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+  edge #4: CONCAVE
+      F1: Plane area=59.7854 centroid=(6,-3.00997,5.01715) radial=N/A
+      F2: Plane area=66 centroid=(-0.272727,-3.22727,1.2326e-32) radial=N/A
+  edge #5: CONCAVE
+      F1: Plane area=59.7854 centroid=(6,-3.00997,5.01715) radial=N/A
+      F2: Plane area=120 centroid=(3.55271e-16,-6,5) radial=N/A
+  edge #6: TANGENT(smooth)
+      F1: Plane area=54 centroid=(3,0,5.5) radial=N/A
+      F2: Cylinder area=9.42478 centroid=(3,-0.36338,0.36338) radial=INWARD (dot=-1.000000)
+  edge #7: CONVEX
+      F1: Plane area=54 centroid=(3,0,5.5) radial=N/A
+      F2: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+  edge #8: CONVEX
+      F1: Plane area=54 centroid=(3,0,5.5) radial=N/A
+      F2: Plane area=60.2146 centroid=(0,2.98851,4.98298) radial=N/A
+  edge #9: CONVEX
+      F1: Cylinder area=9.42478 centroid=(3,-0.36338,0.36338) radial=INWARD (dot=-1.000000)
+      F2: Plane area=60.2146 centroid=(0,2.98851,4.98298) radial=N/A
+  edge #10: TANGENT(smooth)
+      F1: Cylinder area=9.42478 centroid=(3,-0.36338,0.36338) radial=INWARD (dot=-1.000000)
+      F2: Plane area=66 centroid=(-0.272727,-3.22727,1.2326e-32) radial=N/A
+  edge #11: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #12: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #13: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #14: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #15: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=120 centroid=(3.55271e-16,-6,5) radial=N/A
+  edge #16: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=60.2146 centroid=(0,2.98851,4.98298) radial=N/A
+  edge #17: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=60 centroid=(-3,6,5) radial=N/A
+  edge #18: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=60 centroid=(-6,3,5) radial=N/A
+  edge #19: CONVEX
+      F1: Plane area=292 centroid=(0.369863,0.369863,10) radial=N/A
+      F2: Plane area=60 centroid=(-6,-3,5) radial=N/A
+  edge #20: CONCAVE
+      F1: Plane area=66 centroid=(-0.272727,-3.22727,1.2326e-32) radial=N/A
+      F2: Plane area=120 centroid=(3.55271e-16,-6,5) radial=N/A
+  edge #21: CONCAVE
+      F1: Plane area=66 centroid=(-0.272727,-3.22727,1.2326e-32) radial=N/A
+      F2: Plane area=60.2146 centroid=(0,2.98851,4.98298) radial=N/A
+  edge #22: CONCAVE
+      F1: Plane area=66 centroid=(-0.272727,-3.22727,1.2326e-32) radial=N/A
+      F2: Plane area=60 centroid=(-6,-3,5) radial=N/A
+  edge #23: TANGENT(smooth)
+      F1: Plane area=66 centroid=(-0.272727,-3.22727,1.2326e-32) radial=N/A
+      F2: Plane area=36 centroid=(-3,3,0) radial=N/A
+  edge #24: CONCAVE
+      F1: Plane area=120 centroid=(3.55271e-16,-6,5) radial=N/A
+      F2: Plane area=60 centroid=(-6,-3,5) radial=N/A
+  edge #25: CONCAVE
+      F1: Plane area=60.2146 centroid=(0,2.98851,4.98298) radial=N/A
+      F2: Plane area=60 centroid=(-3,6,5) radial=N/A
+  edge #26: CONCAVE
+      F1: Plane area=60.2146 centroid=(0,2.98851,4.98298) radial=N/A
+      F2: Plane area=36 centroid=(-3,3,0) radial=N/A
+  edge #27: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+  edge #28: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+  edge #29: CONVEX
+      F1: Plane area=400 centroid=(-10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #30: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #31: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #32: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #33: CONVEX
+      F1: Plane area=400 centroid=(1.33227e-16,-10,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+  edge #34: CONVEX
+      F1: Plane area=400 centroid=(10,-3.10862e-16,-1.38778e-17) radial=N/A
+      F2: Plane area=400 centroid=(-1.38778e-17,1.33227e-16,-10) radial=N/A
+  edge #35: CONCAVE
+      F1: Plane area=60 centroid=(-3,6,5) radial=N/A
+      F2: Plane area=36 centroid=(-3,3,0) radial=N/A
+  edge #36: CONCAVE
+      F1: Plane area=60 centroid=(-3,6,5) radial=N/A
+      F2: Plane area=60 centroid=(-6,3,5) radial=N/A
+  edge #37: TANGENT(smooth)
+      F1: Plane area=60 centroid=(-6,3,5) radial=N/A
+      F2: Plane area=60 centroid=(-6,-3,5) radial=N/A
+  edge #38: CONCAVE
+      F1: Plane area=60 centroid=(-6,3,5) radial=N/A
+      F2: Plane area=36 centroid=(-3,3,0) radial=N/A
+  (38 manifold edges total)

--- a/Scripts/repro/762-filleted-pocket-detection/probe_762.mm
+++ b/Scripts/repro/762-filleted-pocket-detection/probe_762.mm
@@ -439,6 +439,144 @@ static TopoDS_Shape lShapedPocketPartiallyFilleted(double radius) {
     return mkFillet.Shape();
 }
 
+// The south floor/wall junction filleted (radius floorRadius), and, separately, the vertical
+// corner edge between the west and south walls also filleted (radius cornerRadius), with the
+// WEST floor/wall junction left SHARP (unfilleted). Ground-truths the OR-fusion bug (#762
+// review round 4): the ORIGINAL crossable test for a `.smooth` edge leaving an already
+// confirmed fillet was `isRadiallyInwardFillet(edge.face1Index) ||
+// isRadiallyInwardFillet(edge.face2Index)`, which tests EITHER end of the edge. Once the
+// south fillet is confirmed, that OR is trivially satisfied by the south fillet's own half
+// regardless of what is on the far side, so it wrongly crossed into this corner-blend
+// cylinder and, since the cylinder is vertical and radially inward too, wrongly accepted it
+// as a WALL. The corner-blend cylinder is reached only through the south fillet's own further
+// (non-floor-bordering) torus junction, never directly from the floor.
+static TopoDS_Shape southFilletPlusVerticalCornerFillet(double floorRadius, double cornerRadius) {
+    TopoDS_Shape box = centeredBox(20);
+    TopoDS_Shape tool = BRepPrimAPI_MakeBox(gp_Pnt(-5, -5, 0), 10, 10, 15).Shape();
+    TopoDS_Shape cut = BRepAlgoAPI_Cut(box, tool).Shape();
+
+    // South floor/wall junction: z=0, y=-5, x spanning [-5,5].
+    TopoDS_Edge southEdge;
+    bool foundSouth = false;
+    {
+        TopExp_Explorer exp(cut, TopAbs_EDGE);
+        for (; exp.More(); exp.Next()) {
+            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+            Bnd_Box bbox;
+            BRepBndLib::Add(edge, bbox);
+            double xmin, ymin, zmin, xmax, ymax, zmax;
+            bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+            if (abs(zmin) < 1e-6 && abs(zmax) < 1e-6 &&
+                abs(ymin - (-5)) < 1e-6 && abs(ymax - (-5)) < 1e-6) {
+                southEdge = edge;
+                foundSouth = true;
+                break;
+            }
+        }
+    }
+    if (!foundSouth) {
+        cerr << "  !! southFilletPlusVerticalCornerFillet: south edge not found\n";
+        return cut;
+    }
+
+    BRepFilletAPI_MakeFillet mkFillet1(cut);
+    mkFillet1.Add(floorRadius, southEdge);
+    mkFillet1.Build();
+    if (!mkFillet1.IsDone()) {
+        cerr << "  !! southFilletPlusVerticalCornerFillet: south fillet build FAILED\n";
+        return cut;
+    }
+    TopoDS_Shape filletedSouth = mkFillet1.Shape();
+
+    // Vertical corner edge between west (x=-5) and south (y=-5) walls: x=-5, y=-5, spanning z.
+    TopoDS_Edge cornerEdge;
+    bool foundCorner = false;
+    {
+        TopExp_Explorer exp(filletedSouth, TopAbs_EDGE);
+        for (; exp.More(); exp.Next()) {
+            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+            Bnd_Box bbox;
+            BRepBndLib::Add(edge, bbox);
+            double xmin, ymin, zmin, xmax, ymax, zmax;
+            bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+            if (abs(xmin - (-5)) < 1e-3 && abs(xmax - (-5)) < 1e-3 &&
+                abs(ymin - (-5)) < 1e-3 && abs(ymax - (-5)) < 1e-3 &&
+                (zmax - zmin) > 1.0) {
+                cornerEdge = edge;
+                foundCorner = true;
+                break;
+            }
+        }
+    }
+    if (!foundCorner) {
+        cerr << "  !! southFilletPlusVerticalCornerFillet: corner edge not found\n";
+        return filletedSouth;
+    }
+
+    BRepFilletAPI_MakeFillet mkFillet2(filletedSouth);
+    mkFillet2.Add(cornerRadius, cornerEdge);
+    mkFillet2.Build();
+    if (!mkFillet2.IsDone()) {
+        cerr << "  !! southFilletPlusVerticalCornerFillet: corner fillet build FAILED\n";
+        return filletedSouth;
+    }
+    return mkFillet2.Shape();
+}
+
+// All four floor/wall junctions filleted (radius floorRadius) AND all four vertical corners
+// separately filleted (radius cornerRadius): a torus/corner-fillet ring all the way around
+// the pocket. Stresses whether junction-to-junction chaining, now confined by the #762 review
+// round 4 fix to producing only further junctions past the first floor-bordering hop, still
+// finds exactly the four genuine flat walls without wandering into any of the eight curved
+// junction faces (four floor fillets, four corner fillets) or the four BSpline surfaces OCCT
+// inserts to reconcile the mismatched-radius corners.
+static TopoDS_Shape fullyRoundedPocket(double floorRadius, double cornerRadius) {
+    TopoDS_Shape cut = sharpPocket();
+    vector<TopoDS_Edge> floorEdges = pocketJunctionEdges(cut);
+    BRepFilletAPI_MakeFillet mkFillet1(cut);
+    for (auto& edge : floorEdges) mkFillet1.Add(floorRadius, edge);
+    mkFillet1.Build();
+    if (!mkFillet1.IsDone()) {
+        cerr << "  !! fullyRoundedPocket: floor fillet build FAILED\n";
+        return cut;
+    }
+    TopoDS_Shape filletedFloor = mkFillet1.Shape();
+
+    // TopTools_IndexedMapOfShape, not a plain TopExp_Explorer: a bare explorer over a solid
+    // visits each edge once per face-wire occurrence (twice for an edge shared by two faces),
+    // so counting matches directly against it would double-count every corner edge found.
+    vector<TopoDS_Edge> cornerEdges;
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(filletedFloor, TopAbs_EDGE, edgeMap);
+    for (int i = 1; i <= edgeMap.Extent(); i++) {
+        TopoDS_Edge edge = TopoDS::Edge(edgeMap(i));
+        Bnd_Box bbox;
+        BRepBndLib::Add(edge, bbox);
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        // A true vertical corner edge is a single (x,y) point swept in z: tight x/y extent of
+        // its own, at one of the pocket's four (+-5,+-5) corners. Distinguishes it from a
+        // diagonal boundary edge of the corner-reconciliation patch the floor fillet itself
+        // inserts, which can loosely satisfy a min-only x/y check but spans a wide x/y range.
+        if ((zmax - zmin) > 1.0 && (xmax - xmin) < 0.5 && (ymax - ymin) < 0.5 &&
+            abs(abs(xmin) - 5) < 1e-2 && abs(abs(ymin) - 5) < 1e-2) {
+            cornerEdges.push_back(edge);
+        }
+    }
+    if (cornerEdges.size() != 4) {
+        cerr << "  !! fullyRoundedPocket: expected 4 corner edges, found " << cornerEdges.size() << "\n";
+    }
+
+    BRepFilletAPI_MakeFillet mkFillet2(filletedFloor);
+    for (auto& edge : cornerEdges) mkFillet2.Add(cornerRadius, edge);
+    mkFillet2.Build();
+    if (!mkFillet2.IsDone()) {
+        cerr << "  !! fullyRoundedPocket: corner fillet build FAILED\n";
+        return filletedFloor;
+    }
+    return mkFillet2.Shape();
+}
+
 int main() {
     cout << "#762 ground truth: ChFi3d::DefineConnectType at floor/wall junctions\n";
     cout << "smoothThreshold = 0.01, CorrectPoint = true (matches OCCTEdgeGetConvexity exactly)\n";
@@ -461,6 +599,12 @@ int main() {
 
     reportJunctions(lShapedPocketPartiallyFilleted(1.0),
                      "8. L-shaped pocket, reflex corner, one of its two walls filleted, radius=1.0");
+
+    reportJunctions(southFilletPlusVerticalCornerFillet(3.0, 2.0),
+                     "9. South floor fillet (r=3) + separate vertical corner fillet (r=2), west junction left sharp");
+
+    reportJunctions(fullyRoundedPocket(3.0, 2.0),
+                     "10. Fully rounded pocket: floor fillet (r=3) all four sides + vertical corner fillet (r=2) all four corners");
 
     return 0;
 }

--- a/Scripts/repro/762-filleted-pocket-detection/probe_762.mm
+++ b/Scripts/repro/762-filleted-pocket-detection/probe_762.mm
@@ -1,0 +1,390 @@
+// #762 ground truth: what ChFi3d::DefineConnectType reports at every floor/wall-adjacent
+// junction of a filleted, chamfered, partially-filleted, filleted-open, and filleted-boss
+// fixture, plus (for any cylindrical/spherical junction face) whether its own outward normal
+// points radially inward (toward its axis/center) or outward.
+//
+// This mirrors OCCTEdgeGetConvexity's own call exactly: same smoothThreshold (0.01), same
+// CorrectPoint=true, same ChFi3d::DefineConnectType signature (OCCTBridge_BRepGraph.mm). No
+// bridge and no Swift: this is OCCT's own classifier, called the same way the bridge calls it,
+// against fixtures built with plain OCCT primitives (not centered like Shape.box, corner-based
+// like BRepPrimAPI_MakeBox always is; noted per fixture, not assumed).
+//
+// Build and run:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/762-filleted-pocket-detection/probe_762.mm -o /tmp/probe_762
+//   /tmp/probe_762
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <cmath>
+
+#include <gp_Pnt.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Vec.hxx>
+#include <gp_Cylinder.hxx>
+#include <gp_Sphere.hxx>
+#include <gp_Cone.hxx>
+#include <gp_Pln.hxx>
+
+#include <TopoDS.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
+#include <TopTools_ListOfShape.hxx>
+
+#include <BRep_Tool.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <GeomAbs_SurfaceType.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <Bnd_Box.hxx>
+#include <BRepBndLib.hxx>
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepFilletAPI_MakeChamfer.hxx>
+
+#include <ChFi3d.hxx>
+#include <ChFiDS_TypeOfConcavity.hxx>
+
+using namespace std;
+
+// ---------------------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------------------
+
+static string typeName(ChFiDS_TypeOfConcavity t) {
+    switch (t) {
+        case ChFiDS_Concave: return "CONCAVE";
+        case ChFiDS_Convex: return "CONVEX";
+        case ChFiDS_Tangential: return "TANGENT(smooth)";
+        case ChFiDS_FreeBound: return "FreeBound";
+        case ChFiDS_Other: return "Other";
+        case ChFiDS_Mixed: return "Mixed";
+    }
+    return "?";
+}
+
+static string surfaceTypeName(GeomAbs_SurfaceType t) {
+    switch (t) {
+        case GeomAbs_Plane: return "Plane";
+        case GeomAbs_Cylinder: return "Cylinder";
+        case GeomAbs_Cone: return "Cone";
+        case GeomAbs_Sphere: return "Sphere";
+        case GeomAbs_Torus: return "Torus";
+        case GeomAbs_BezierSurface: return "Bezier";
+        case GeomAbs_BSplineSurface: return "BSpline";
+        case GeomAbs_SurfaceOfRevolution: return "Revolution";
+        case GeomAbs_SurfaceOfExtrusion: return "Extrusion";
+        case GeomAbs_OffsetSurface: return "Offset";
+        default: return "Other";
+    }
+}
+
+struct FaceDescription {
+    GeomAbs_SurfaceType type;
+    string typeStr;
+    gp_Pnt centroid;
+    double area;
+    gp_Dir normalAtCentroidish; // approximate outward normal near the face's own mid-parameter
+    // For cylinder/sphere/cone: radial test result, "N/A" otherwise.
+    string radialTest;
+};
+
+// Outward-corrected normal at a face's mid-parameter point (accounts for face orientation).
+static bool midNormal(const TopoDS_Face& face, gp_Pnt& outPoint, gp_Dir& outNormal) {
+    BRepAdaptor_Surface surf(face, true);
+    double uMid = (surf.FirstUParameter() + surf.LastUParameter()) / 2.0;
+    double vMid = (surf.FirstVParameter() + surf.LastVParameter()) / 2.0;
+    gp_Pnt p;
+    gp_Vec du, dv;
+    surf.D1(uMid, vMid, p, du, dv);
+    gp_Vec n = du.Crossed(dv);
+    if (n.Magnitude() < 1e-12) return false;
+    n.Normalize();
+    if (face.Orientation() == TopAbs_REVERSED) n.Reverse();
+    outPoint = p;
+    outNormal = gp_Dir(n);
+    return true;
+}
+
+static FaceDescription describe(const TopoDS_Face& face) {
+    FaceDescription d;
+    BRepAdaptor_Surface surf(face);
+    d.type = surf.GetType();
+    d.typeStr = surfaceTypeName(d.type);
+    d.radialTest = "N/A";
+
+    GProp_GProps props;
+    BRepGProp::SurfaceProperties(face, props);
+    d.centroid = props.CentreOfMass();
+    d.area = props.Mass();
+
+    gp_Pnt p;
+    gp_Dir n;
+    if (midNormal(face, p, n)) {
+        d.normalAtCentroidish = n;
+
+        if (d.type == GeomAbs_Cylinder) {
+            gp_Cylinder cyl = surf.Cylinder();
+            gp_Ax1 axis = cyl.Axis();
+            gp_Vec toPoint(axis.Location(), p);
+            gp_Vec axisDir(axis.Direction());
+            gp_Vec radial = toPoint - axisDir * (toPoint.Dot(axisDir));
+            if (radial.Magnitude() > 1e-9) {
+                radial.Normalize();
+                double dot = gp_Vec(n).Dot(radial);
+                d.radialTest = dot < 0 ? "INWARD (dot=" + to_string(dot) + ")"
+                                       : "OUTWARD (dot=" + to_string(dot) + ")";
+            }
+        } else if (d.type == GeomAbs_Sphere) {
+            gp_Sphere sph = surf.Sphere();
+            gp_Vec radial(sph.Location(), p);
+            if (radial.Magnitude() > 1e-9) {
+                radial.Normalize();
+                double dot = gp_Vec(n).Dot(radial);
+                d.radialTest = dot < 0 ? "INWARD (dot=" + to_string(dot) + ")"
+                                       : "OUTWARD (dot=" + to_string(dot) + ")";
+            }
+        } else if (d.type == GeomAbs_Cone) {
+            gp_Cone cone = surf.Cone();
+            gp_Ax1 axis = cone.Axis();
+            gp_Vec toPoint(axis.Location(), p);
+            gp_Vec axisDir(axis.Direction());
+            gp_Vec radial = toPoint - axisDir * (toPoint.Dot(axisDir));
+            if (radial.Magnitude() > 1e-9) {
+                radial.Normalize();
+                double dot = gp_Vec(n).Dot(radial);
+                d.radialTest = dot < 0 ? "INWARD (dot=" + to_string(dot) + ")"
+                                       : "OUTWARD (dot=" + to_string(dot) + ")";
+            }
+        }
+    }
+    return d;
+}
+
+static string fmt(const FaceDescription& d) {
+    ostringstream ss;
+    ss << d.typeStr
+       << " area=" << d.area
+       << " centroid=(" << d.centroid.X() << "," << d.centroid.Y() << "," << d.centroid.Z() << ")"
+       << " radial=" << d.radialTest;
+    return ss.str();
+}
+
+static void reportJunctions(const TopoDS_Shape& shape, const string& label) {
+    cout << "\n=== " << label << " ===\n";
+
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
+    TopTools_IndexedDataMapOfShapeListOfShape edgeFaceMap;
+    TopExp::MapShapesAndAncestors(shape, TopAbs_EDGE, TopAbs_FACE, edgeFaceMap);
+
+    const double smoothThreshold = 0.01; // matches OCCTEdgeGetConvexity exactly
+
+    int edgeCount = 0;
+    for (int i = 1; i <= edgeMap.Extent(); i++) {
+        TopoDS_Edge edge = TopoDS::Edge(edgeMap(i));
+        if (BRep_Tool::Degenerated(edge)) continue;
+        if (!edgeFaceMap.Contains(edge)) continue;
+        const TopTools_ListOfShape& faces = edgeFaceMap.FindFromKey(edge);
+        if (faces.Extent() != 2) continue; // skip free/non-manifold edges
+
+        TopTools_ListIteratorOfListOfShape it(faces);
+        TopoDS_Face f1 = TopoDS::Face(it.Value());
+        it.Next();
+        TopoDS_Face f2 = TopoDS::Face(it.Value());
+
+        FaceDescription d1 = describe(f1);
+        FaceDescription d2 = describe(f2);
+
+        ChFiDS_TypeOfConcavity type =
+            ChFi3d::DefineConnectType(edge, f1, f2, smoothThreshold, true);
+
+        edgeCount++;
+        cout << "  edge #" << edgeCount << ": " << typeName(type) << "\n";
+        cout << "      F1: " << fmt(d1) << "\n";
+        cout << "      F2: " << fmt(d2) << "\n";
+    }
+    cout << "  (" << edgeCount << " manifold edges total)\n";
+}
+
+// ---------------------------------------------------------------------------------------
+// Fixtures. All shapes are built with plain BRepPrimAPI (corner-based, NOT centered like
+// Shape.box) unless noted: purely local coordinates, chosen to match
+// Issue753FilletedJunctionDetectedTests's own numbers (10x10x15 pocket in a 20mm cube)
+// wherever this probe's fixture corresponds to an existing Swift fixture, so the two are
+// directly comparable.
+// ---------------------------------------------------------------------------------------
+
+// A 20x20x20 box centered at the origin (spans -10..10), matching Shape.box(width:height:depth:).
+static TopoDS_Shape centeredBox(double size) {
+    double h = size / 2.0;
+    return BRepPrimAPI_MakeBox(gp_Pnt(-h, -h, -h), size, size, size).Shape();
+}
+
+// The floor/wall junction edges of a square pocket cut into centeredBox(20) at
+// origin (-5,-5,0) 10x10x15: the four edges at z=0 bounding the 10x10 footprint.
+static vector<TopoDS_Edge> pocketJunctionEdges(const TopoDS_Shape& shape) {
+    vector<TopoDS_Edge> result;
+    TopExp_Explorer exp(shape, TopAbs_EDGE);
+    for (; exp.More(); exp.Next()) {
+        TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+        Bnd_Box box;
+        BRepBndLib::Add(edge, box);
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        box.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        // At z=0, within the pocket footprint (-5<=x<=5, -5<=y<=5), and a straight edge
+        // (zero z-extent): excludes the box's own outer top-face edges, which sit at z=10.
+        if (abs(zmin) < 1e-6 && abs(zmax) < 1e-6 &&
+            xmin > -5.5 && xmax < 5.5 && ymin > -5.5 && ymax < 5.5) {
+            result.push_back(edge);
+        }
+    }
+    return result;
+}
+
+static TopoDS_Shape sharpPocket() {
+    TopoDS_Shape box = centeredBox(20);
+    TopoDS_Shape tool = BRepPrimAPI_MakeBox(gp_Pnt(-5, -5, 0), 10, 10, 15).Shape();
+    return BRepAlgoAPI_Cut(box, tool).Shape();
+}
+
+static TopoDS_Shape filletedPocket(double radius, int edgeCountToFillet = 4) {
+    TopoDS_Shape cut = sharpPocket();
+    vector<TopoDS_Edge> junctions = pocketJunctionEdges(cut);
+    BRepFilletAPI_MakeFillet mkFillet(cut);
+    int n = min((int)junctions.size(), edgeCountToFillet);
+    for (int i = 0; i < n; i++) {
+        mkFillet.Add(radius, junctions[i]);
+    }
+    mkFillet.Build();
+    if (!mkFillet.IsDone()) {
+        cerr << "  !! fillet build FAILED for radius " << radius << "\n";
+        return cut;
+    }
+    return mkFillet.Shape();
+}
+
+static TopoDS_Shape chamferedPocket(double distance) {
+    TopoDS_Shape cut = sharpPocket();
+    vector<TopoDS_Edge> junctions = pocketJunctionEdges(cut);
+
+    // BRepFilletAPI_MakeChamfer needs each edge's own adjacent face for a symmetric chamfer.
+    TopTools_IndexedDataMapOfShapeListOfShape edgeFaceMap;
+    TopExp::MapShapesAndAncestors(cut, TopAbs_EDGE, TopAbs_FACE, edgeFaceMap);
+
+    BRepFilletAPI_MakeChamfer mkChamfer(cut);
+    for (auto& edge : junctions) {
+        const TopTools_ListOfShape& faces = edgeFaceMap.FindFromKey(edge);
+        TopoDS_Face f1 = TopoDS::Face(faces.First());
+        mkChamfer.Add(distance, distance, edge, f1);
+    }
+    mkChamfer.Build();
+    if (!mkChamfer.IsDone()) {
+        cerr << "  !! chamfer build FAILED\n";
+        return cut;
+    }
+    return mkChamfer.Shape();
+}
+
+// Through-slot spanning the box's full width (x), open at both ends, with the two long
+// floor/wall junction edges (at y=-3 and y=3) filleted. Mirrors
+// Issue735PocketEnclosureTests.twoWalledThroughSlotIsNotEnclosed's own tool geometry.
+static TopoDS_Shape filletedThroughSlot(double radius) {
+    TopoDS_Shape box = centeredBox(20);
+    TopoDS_Shape tool = BRepPrimAPI_MakeBox(gp_Pnt(-15, -3, 0), 25, 6, 10).Shape();
+    TopoDS_Shape cut = BRepAlgoAPI_Cut(box, tool).Shape();
+
+    vector<TopoDS_Edge> junctions;
+    TopExp_Explorer exp(cut, TopAbs_EDGE);
+    for (; exp.More(); exp.Next()) {
+        TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+        Bnd_Box bbox;
+        BRepBndLib::Add(edge, bbox);
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        // At z=0, spanning the full slot length in x (long edges only, not the (nonexistent,
+        // since the slot is open) end edges).
+        if (abs(zmin) < 1e-6 && abs(zmax) < 1e-6 && (xmax - xmin) > 15.0) {
+            junctions.push_back(edge);
+        }
+    }
+
+    BRepFilletAPI_MakeFillet mkFillet(cut);
+    for (auto& edge : junctions) mkFillet.Add(radius, edge);
+    mkFillet.Build();
+    if (!mkFillet.IsDone()) {
+        cerr << "  !! through-slot fillet build FAILED\n";
+        return cut;
+    }
+    return mkFillet.Shape();
+}
+
+// A boss (square pillar) standing on a base plate, with its base (convex) junction filleted.
+// The base plate's top face is a legitimate AAG "floor" candidate (upward, horizontal,
+// planar); the boss's own side walls must NOT be reported as that floor's pocket walls.
+static TopoDS_Shape filletedBoss(double radius) {
+    TopoDS_Shape plate = BRepPrimAPI_MakeBox(gp_Pnt(-10, -10, -5), 20, 20, 5).Shape();
+    TopoDS_Shape boss = BRepPrimAPI_MakeBox(gp_Pnt(-3, -3, 0), 6, 6, 8).Shape();
+    TopoDS_Shape fused = BRepAlgoAPI_Fuse(plate, boss).Shape();
+
+    vector<TopoDS_Edge> junctions;
+    TopExp_Explorer exp(fused, TopAbs_EDGE);
+    for (; exp.More(); exp.Next()) {
+        TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+        Bnd_Box bbox;
+        BRepBndLib::Add(edge, bbox);
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        if (abs(zmin) < 1e-6 && abs(zmax) < 1e-6 &&
+            xmin > -3.5 && xmax < 3.5 && ymin > -3.5 && ymax < 3.5) {
+            junctions.push_back(edge);
+        }
+    }
+
+    BRepFilletAPI_MakeFillet mkFillet(fused);
+    for (auto& edge : junctions) mkFillet.Add(radius, edge);
+    mkFillet.Build();
+    if (!mkFillet.IsDone()) {
+        cerr << "  !! boss fillet build FAILED\n";
+        return fused;
+    }
+    return mkFillet.Shape();
+}
+
+int main() {
+    cout << "#762 ground truth: ChFi3d::DefineConnectType at floor/wall junctions\n";
+    cout << "smoothThreshold = 0.01, CorrectPoint = true (matches OCCTEdgeGetConvexity exactly)\n";
+
+    reportJunctions(sharpPocket(), "1. Sharp pocket (control), 10x10x15 pocket in a 20mm cube");
+
+    for (double r : {0.5, 1.0, 2.0, 4.0}) {
+        ostringstream label;
+        label << "2. Filleted pocket, radius=" << r;
+        reportJunctions(filletedPocket(r), label.str());
+    }
+
+    reportJunctions(chamferedPocket(1.0), "3. Chamfered pocket, distance=1.0 (symmetric)");
+
+    reportJunctions(filletedPocket(1.0, 2), "4. Partially filleted pocket (2 of 4 edges, radius=1.0)");
+
+    reportJunctions(filletedThroughSlot(1.0), "5. Filleted through-slot (open both ends), radius=1.0");
+
+    reportJunctions(filletedBoss(1.0), "6. Filleted boss (convex feature, must NOT be a pocket), radius=1.0");
+
+    return 0;
+}

--- a/Scripts/repro/762-filleted-pocket-detection/probe_762.mm
+++ b/Scripts/repro/762-filleted-pocket-detection/probe_762.mm
@@ -366,6 +366,79 @@ static TopoDS_Shape filletedBoss(double radius) {
     return mkFillet.Shape();
 }
 
+// An L-shaped pocket: two rectangular tools fused into an L, cut into a box's top. The
+// cavity's own floor boundary has a REFLEX vertex at the inner corner of the L (0,0), where a
+// small block of remaining material sticks into the cavity, the mirror image of a boss
+// standing in the corner of a room. At an ORDINARY (convex-from-the-cavity) corner, the two
+// walls meeting there share a CONCAVE vertical edge (measured on the plain rectangular pocket
+// above: fixture 1's edges #17-24). At THIS reflex vertex, the hypothesis under test was that
+// the two walls instead share a CONVEX vertical edge, by the same duality that makes a boss's
+// own corner convex (fixture 6's edges #9/#11/#13/#15: a boss's BASE junction is
+// reentrant/concave, just like a pocket's, but its own CORNER, where two base fillets meet
+// going around the boss, is convex).
+//
+// Filleting ONLY one of the two walls at the reflex corner (WallY0, at y=0, x in [0,6]) and
+// leaving the other (WallX0, at x=0, y in [0,6]) sharp was built to test the specific path a PR
+// #778 removal-matrix review named: floor, to a confirmed-radially-inward fillet (a junction,
+// absorbed), to a face reached by a CONVEX edge from that junction, with the floor having NO
+// other, direct route to that same face (so an earlier BFS visit could not mask the result the
+// way the through-slot fixture's own floor-to-exterior-wall direct edge did).
+//
+// Measured, that second condition does not hold here. The fillet does meet WallX0 via a
+// CONVEX edge (confirming the reflex-corner hypothesis itself), but BRepFilletAPI_MakeFillet's
+// own corner-blending, needed to keep the result watertight where the fillet ends at an
+// unfilleted reflex corner, reshapes WallX0's own face so that the FLOOR also borders it
+// directly (a CONCAVE edge, confirmed via exact bounding boxes on the Swift side, not
+// inferred from face areas alone). So this fixture is masked too, the same way the
+// through-slot fixture was, for a related but distinct reason: there, the floor's own polygon
+// vertex gave it a direct route; here, the fillet operation's own reshaping does. See the PR
+// body for the fuller discussion, including why every construction tried reduces to the same
+// masking, and the geometric argument for why that appears to be structural rather than a
+// series of fixture-building failures. Kept as a permanent regression test regardless, since
+// it is still a real correctness check on reflex-corner and partial-fillet geometry together.
+static TopoDS_Shape lShapedPocketPartiallyFilleted(double radius) {
+    TopoDS_Shape box = centeredBox(20);
+    TopoDS_Shape toolA = BRepPrimAPI_MakeBox(gp_Pnt(-6, -6, 0), 12, 6, 10).Shape();  // x[-6,6] y[-6,0]
+    TopoDS_Shape toolB = BRepPrimAPI_MakeBox(gp_Pnt(-6, 0, 0), 6, 6, 10).Shape();     // x[-6,0] y[0,6]
+    TopoDS_Shape toolL = BRepAlgoAPI_Fuse(toolA, toolB).Shape();
+    TopoDS_Shape cut = BRepAlgoAPI_Cut(box, toolL).Shape();
+
+    // WallY0: the floor/wall junction edge at y=0, z=0, x in [0,6] (bounds the remaining
+    // material block from below). Distinguished from every other z=0 junction edge in this
+    // fixture by its own bounding box (min.y == max.y == 0, and it does not run along x=-6,
+    // x=6, or y=-6).
+    TopoDS_Edge wallY0Edge;
+    bool found = false;
+    TopExp_Explorer exp(cut, TopAbs_EDGE);
+    for (; exp.More(); exp.Next()) {
+        TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+        Bnd_Box bbox;
+        BRepBndLib::Add(edge, bbox);
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        if (abs(zmin) < 1e-6 && abs(zmax) < 1e-6 &&
+            abs(ymin) < 1e-6 && abs(ymax) < 1e-6 &&
+            xmin > -1e-6 && xmax > 5.9 && xmax < 6.1) {
+            wallY0Edge = edge;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        cerr << "  !! lShapedPocketPartiallyFilleted: WallY0 edge not found\n";
+        return cut;
+    }
+
+    BRepFilletAPI_MakeFillet mkFillet(cut);
+    mkFillet.Add(radius, wallY0Edge);
+    mkFillet.Build();
+    if (!mkFillet.IsDone()) {
+        cerr << "  !! lShapedPocketPartiallyFilleted: fillet build FAILED\n";
+        return cut;
+    }
+    return mkFillet.Shape();
+}
+
 int main() {
     cout << "#762 ground truth: ChFi3d::DefineConnectType at floor/wall junctions\n";
     cout << "smoothThreshold = 0.01, CorrectPoint = true (matches OCCTEdgeGetConvexity exactly)\n";
@@ -385,6 +458,9 @@ int main() {
     reportJunctions(filletedThroughSlot(1.0), "5. Filleted through-slot (open both ends), radius=1.0");
 
     reportJunctions(filletedBoss(1.0), "6. Filleted boss (convex feature, must NOT be a pocket), radius=1.0");
+
+    reportJunctions(lShapedPocketPartiallyFilleted(1.0),
+                     "8. L-shaped pocket, reflex corner, one of its two walls filleted, radius=1.0");
 
     return 0;
 }

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -704,59 +704,87 @@ extension AAG {
     /// would make every filleted/chamfered wall fail the very check meant to confirm it is
     /// this floor's wall, re-introducing the bug this method exists to fix.
     ///
-    /// ## `.convex` never crosses: load-bearing past a junction, but untested there
+    /// ## A direct dead end stays revisitable through a later junction
+    ///
+    /// `visited` is marked only once an edge's outcome is decided (wall or junction), not as
+    /// soon as the edge is crossable. Review of an earlier version of this fix found the
+    /// opposite: `visited.insert(neighbor)` fired immediately after the `crossable` check, so a
+    /// face that failed the Z-tolerance check above AS A DIRECT NEIGHBOR (`reachedThroughJunction
+    /// == false`) was marked visited regardless, and a separate edge reaching that same face
+    /// through an already-absorbed junction later in the same search, where the Z check is
+    /// bypassed and WOULD have accepted it, could never run: `guard !visited.contains(neighbor)`
+    /// closed it off first.
+    ///
+    /// Measured, not assumed, that this is reachable on this codebase's own fixtures, not only
+    /// hypothetical: a partially-filleted pocket's two SHARP walls each have their own low-Z
+    /// bound offset from the floor's exact Z by about `1.5e-7` (a `BRepFilletAPI_MakeFillet`
+    /// corner-blending artifact where each meets the adjacent filleted wall's own fillet),
+    /// invisible at the default tolerance but decisive at a smaller one
+    /// (`Issue762DeadEndRevisitableThroughJunctionTests`, `1e-8`): the direct route fails, and
+    /// the fillet's own separate `.concave` edge to the same wall (not `.convex`, so not
+    /// screened by the guard below) is the only thing that finds it. Proved by injection:
+    /// reintroducing the early `visited.insert` and rerunning that exact fixture at that exact
+    /// tolerance drops both sharp walls entirely (`wallFaceIndices.count` 4 to 2, `isOpen`
+    /// false to true); the fix restores both.
+    ///
+    /// A wall and a junction are both true terminal outcomes for the EDGE just crossed, so both
+    /// mark `visited`: a wall stops the chain outright, and a junction is queued into `next`
+    /// exactly once regardless of how many other edges could also reach it. A dead end is not a
+    /// terminal outcome for the FACE, only for that one edge, so it alone is left out of
+    /// `visited` deliberately. This does not risk non-termination: the total work is still
+    /// bounded by this floor's own edge count, since a dead end can be retried at most once per
+    /// incoming edge (not per BFS level), and every retry either terminates (wall or junction,
+    /// marking `visited` and ending the retries) or dead-ends again along that specific edge.
+    ///
+    /// ## `.convex` never crosses: proven load-bearing past a junction, once dead ends could be retried
     ///
     /// `EdgeConvexity.convex` means the material turns the wrong way for absorption by
-    /// definition (interior angle `<180`, "fillet-like, going outward", see the enum's own
-    /// doc comment), so refusing to cross it is correct on its face. But that is a claim about
-    /// what the guard SHOULD do, not evidence that this codebase has watched it matter, and
-    /// the two are not the same thing (removal-matrix injection C, PR body).
+    /// definition (interior angle `<180`, "fillet-like, going outward", see the enum's own doc
+    /// comment), so refusing to cross it is correct on its face. Two earlier review rounds show
+    /// why that alone was not enough to call it proven, and why the visited-marking fix above
+    /// is what finally let a fixture demonstrate it.
     ///
     /// The guard has two call sites with different backstops. For a DIRECT (1-hop) floor
-    /// neighbor, the #724 Z-tolerance check is a second, independent line of defense: even if
-    /// `.convex` were not blocked, a direct neighbor still has to bottom out at the floor's own
-    /// Z to become a wall, and an unrelated convex-connected face never happens to do that by
-    /// coincidence in any fixture measured here. For a face reached PAST an already-absorbed
-    /// junction, `reachedThroughJunction` deliberately bypasses that Z check (see above), so
-    /// `.convex` is the ONLY remaining protection there. Injection C alone (removing the block
-    /// everywhere) came back green on all 19 tests in this PR precisely because every one of
-    /// them exercises the direct-neighbor case, where the Z-check backstop was still catching
-    /// it; none exercised the past-a-junction case in isolation. That is an untested path, not
-    /// a proven-safe one, and the two read identically in a green run.
+    /// neighbor, the #724 Z-tolerance check is a second, independent line of defense: even with
+    /// `.convex` unblocked, a direct neighbor still has to bottom out at the floor's own Z to
+    /// become a wall. For a face reached PAST an already-absorbed junction,
+    /// `reachedThroughJunction` deliberately bypasses that Z check, so `.convex` is the ONLY
+    /// remaining protection there. A first removal-matrix pass (injection C, disabling the
+    /// block alone) came back green on every test in the PR at the time, read as proof the
+    /// guard was decorative, and that reading was wrong: it measured only that direct neighbors
+    /// were screened by the Z-check, and no fixture then isolated the past-a-junction path.
     ///
-    /// Two fixtures were built specifically to isolate the past-a-junction case (both
-    /// ground-truthed against `ChFi3d` first, `Scripts/repro/762-filleted-pocket-detection/`,
-    /// fixtures 5 and 8) and both failed to isolate it, for related but distinct reasons: the
-    /// filleted through-slot's open-end exterior wall is ALSO a direct (1-hop) floor neighbor
-    /// (the floor's own polygon reaches the same exterior boundary the fillet does), so the
-    /// #724 Z-check resolves it before the fillet's own convex edge is ever tried. The L-shaped
-    /// pocket's reflex-corner fixture confirmed the hypothesised geometry (a fillet ending at
-    /// an unfilleted reflex corner DOES meet the far wall via `.convex`, the mirror image of
-    /// two boss-corner fillets meeting convexly), but `BRepFilletAPI_MakeFillet`'s own
-    /// corner-blending reshapes the far wall's face so the floor ALSO borders it directly,
-    /// masking the guard the same way, for a different, kernel-side reason.
+    /// A second pass built two fixtures specifically to isolate that path (both ground-truthed
+    /// against `ChFi3d` first, `Scripts/repro/762-filleted-pocket-detection/`, fixtures 5 and
+    /// 8) and both APPEARED to fail to isolate it: the filleted through-slot's open-end
+    /// exterior wall, and the L-shaped pocket's reflex-corner far wall, were each also a direct
+    /// (1-hop) floor neighbor, so the #724 Z-check seemed to resolve them before the fillet's
+    /// own `.convex` edge was ever tried. That conclusion rested on an unexamined assumption:
+    /// that a direct neighbor failing the Z-check was fully resolved, the same assumption the
+    /// visited-marking bug above made in code. It was not examined at the time because the bug
+    /// had not yet been found. Both "masked" fixtures were REJECTING their direct route, not
+    /// accepting it (near-boundary Z-tolerance noise on the through-slot's own construction, and
+    /// exactly on the boundary for the reflex corner's own `BRepFilletAPI` corner-blending
+    /// artifact), and a rejected direct neighbor used to be marked `visited` anyway, permanently
+    /// closing off the very `.convex`-gated path this section is about.
     ///
-    /// A pattern emerges from both attempts, general enough to state as geometry rather than
-    /// as "no fixture reached it": a floor's own boundary is a closed loop, and every vertex on
-    /// that loop has exactly two incident edges, both bordering something the floor is directly
-    /// adjacent to elsewhere in the SAME BFS's level-0 frontier (a reentrant floor/wall pairing
-    /// is never itself `.convex`, so nothing here contradicts that). Whatever a junction's own
-    /// convex-edged neighbor turns out to be, tracing it back reaches the same vertex, and the
-    /// floor's OTHER edge at that vertex reaches the same target one BFS level earlier,
-    /// independent of whether `.convex` blocks the junction's own path. This was checked
-    /// directly against a shared, floor-boss-inside-a-pocket configuration too (the boss's wall
-    /// is always additionally reachable via the floor's own inner-wire boundary), not only
-    /// against the two committed fixtures.
+    /// With dead ends left revisitable and `Issue762ReflexCornerPartialFilletTests` restored to
+    /// the default tolerance (rather than widened past the noise, which is what let it clear
+    /// the direct route and mask this entirely), injection C alone now fails on exactly those
+    /// two fixtures: the filleted through-slot's `wallFaceIndices.count` goes 2 to 4 and its
+    /// `isOpen` goes true to false (both exterior walls wrongly absorbed as walls of the
+    /// pocket), and the reflex-corner fixture's `wallCounts` goes `[2, 4]` to `[2, 5]` (WallX0
+    /// wrongly absorbed). `.convex` is not untested any more: it is what stops both, proven by
+    /// the same injection that once read as clearing it.
     ///
-    /// This is a real, geometry-grounded argument for why every construction tried reduces to
-    /// the same masking, and it is offered as exactly that: an argument, covering the pocket
-    /// topologies this investigation could construct and reason through, not an exhaustive
-    /// proof over every shape `BRepFilletAPI`/`BRepAlgoAPI` can produce. It has not been
-    /// disproven by a fixture, but it has also not been used to justify DELETING the guard:
-    /// the accurate status is untested-but-plausibly-necessary, and the guard stays in at
-    /// essentially zero cost until a fixture (a face with no other route to the floor at all,
-    /// perhaps from two solids sharing an edge rather than one solid's own corner) settles it
-    /// either way.
+    /// The earlier "geometric argument" this doc comment used to make (that a floor's own
+    /// polygon vertex always gives it an equally early, non-`.convex` route to whatever a
+    /// junction's `.convex` neighbor could reach, so the guard's own contribution was always
+    /// redundant) is retracted, not merely superseded: it was true of the graph as the CODE
+    /// then implemented it, where a rejected direct neighbor's `visited` marking made that
+    /// route's failure equivalent to its success, both closing off the second route. It was
+    /// never true of the geometry itself, only of a bug that happened to make the two
+    /// indistinguishable in every fixture built to tell them apart.
     private func wallsAndJunctions(fromFloor floorIndex: Int, floorZ: Double, tolerance: Double)
         -> (walls: [Int], junctions: [Int])
     {
@@ -783,23 +811,36 @@ extension AAG {
                         crossable = isRadiallyInwardFillet(edge.face1Index) || isRadiallyInwardFillet(edge.face2Index)
                     }
                     guard crossable else { continue }
-                    visited.insert(neighbor)
 
+                    // `visited` is only marked once the outcome is decided (#762 review), not
+                    // as soon as the edge is crossable. A DEAD END below (a direct vertical
+                    // neighbor that fails the #724 Z-check) must stay revisitable: the same
+                    // face can also be reached later through a junction, where the Z-check is
+                    // bypassed entirely, and marking it visited here would permanently hide
+                    // that second, accepting route behind the first, rejecting one. Wall and
+                    // junction are both true terminal outcomes for THIS edge (a wall stops the
+                    // chain; a junction is queued exactly once), so both mark visited; dead end
+                    // is not a terminal outcome for the face, only for this particular edge.
                     let candidate = nodes[neighbor]
                     guard candidate.isVertical else {
                         // Not a wall itself: a junction face (fillet or chamfer) absorbed into
                         // the floor/wall transition. Keep looking past it for the true wall.
+                        visited.insert(neighbor)
                         junctions.append(neighbor)
                         next.append(neighbor)
                         continue
                     }
                     if reachedThroughJunction || abs(candidate.bounds.min.z - floorZ) < tolerance {
+                        visited.insert(neighbor)
                         walls.append(neighbor)
                         // A found wall is terminal for this chain: do not look past it.
                     }
                     // else: a direct vertical neighbor that does not bottom out at this
-                    // floor's Z is the wrong (opening) end of some other wall (#724): a
-                    // dead end, not a wall and not a junction to search further from.
+                    // floor's Z is the wrong (opening) end of some other wall (#724), along
+                    // THIS edge specifically: a dead end for this edge, not a wall and not a
+                    // junction to search further from, but deliberately left out of `visited`
+                    // so a different edge reaching the same face through an already-absorbed
+                    // junction still gets a chance to accept it.
                 }
             }
             frontier = next
@@ -834,7 +875,32 @@ extension AAG {
         let face = faceOccurrences[nodeIndex]
         guard let revolution = face.revolutionProperties,
               let uv = face.uvBounds else { return false }
+        return AAG.isMaterialRadiallyInward(of: face, revolution: revolution, uv: uv, allowSphere: true)
+    }
 
+    /// Whether a face's own outward normal, sampled at its own UV mid-parameter, points back
+    /// toward its axis (or, when `allowSphere` is true and the face is a sphere, its center)
+    /// rather than away from it: the material-side test shared by ``detectHoles()`` (#747/#760,
+    /// which tells a hole's bore from a boss's or a standalone cylinder's own wall) and
+    /// ``isRadiallyInwardFillet(_:)`` (#762, which asks the identical question of a fillet
+    /// junction). Factored into one place after review found the two had drifted into
+    /// near-duplicates differing only in sphere handling: `detectHoles()` never needs it
+    /// (already gated to `.cylinder`/`.cone` before it gets here), a fillet junction can
+    /// legitimately be spherical (a corner blend). #723 and #747 both already fixed this exact
+    /// test once, on the OTHER copy that existed at the time; a second copy is a second chance
+    /// to miss the next one.
+    ///
+    /// `revolution` and `uv` are taken as parameters rather than recomputed here because both
+    /// callers already have them (`detectHoles()` needs `revolution.axis`/`.radius` and `uv`'s
+    /// own `vMin`/`vMax` afterward regardless; `isRadiallyInwardFillet(_:)` needs them to even
+    /// know whether to call this at all), so recomputing would be the same duplication moved
+    /// one call frame over rather than removed.
+    private static func isMaterialRadiallyInward(
+        of face: Face,
+        revolution: Face.RevolutionProperties,
+        uv: (uMin: Double, uMax: Double, vMin: Double, vMax: Double),
+        allowSphere: Bool
+    ) -> Bool {
         let uMid = (uv.uMin + uv.uMax) / 2
         let vMid = (uv.vMin + uv.vMax) / 2
         guard let midPoint = face.point(atU: uMid, v: vMid),
@@ -842,7 +908,7 @@ extension AAG {
 
         let offset = midPoint - revolution.axis.origin
         let radial: SIMD3<Double>
-        if face.surfaceType == .sphere {
+        if allowSphere, face.surfaceType == .sphere {
             // A sphere has no intrinsic axis direction (primaryAxis still reports one, but
             // it is not a property of the surface); radially-from-center is the only
             // meaningful test.
@@ -976,24 +1042,20 @@ extension AAG {
             guard let revolution = face.revolutionProperties else { continue }
             let axisUnit = simd_normalize(revolution.axis.direction)
 
-            let uMid = (uv.uMin + uv.uMax) / 2
-            let vMid = (uv.vMin + uv.vMax) / 2
-            guard let midPoint = face.point(atU: uMid, v: vMid),
-                  let midNormal = face.normal(atU: uMid, v: vMid) else {
+            // The material-side test (see isMaterialRadiallyInward's own doc comment, shared
+            // with isRadiallyInwardFillet(_:), #762): a hole's own outward normal points back
+            // toward the axis, opposite the radial direction. `allowSphere: false` is inert
+            // here in practice (this function is already gated to `.cylinder`/`.cone` above,
+            // so the surface-type check the sphere branch guards never fires either way) but
+            // states plainly that a sphere reaching here would use the axis-projection branch,
+            // not the from-center one a spherical fillet junction needs.
+            guard AAG.isMaterialRadiallyInward(of: face, revolution: revolution, uv: uv, allowSphere: false) else {
                 continue
             }
 
-            let offset = midPoint - revolution.axis.origin
-            let radial = offset - simd_dot(offset, axisUnit) * axisUnit
-            let radialLength = simd_length(radial)
-            guard radialLength > 1e-9 else { continue }
-
-            // The material-side test (see doc comment above): a hole's own outward normal
-            // points back toward the axis, opposite the radial direction.
-            guard simd_dot(midNormal, radial / radialLength) < 0 else { continue }
-
             // Depth along the wall's own axis, not a Z-aligned bounding box: works the same
             // for a vertical hole as for one bored on any other axis.
+            let uMid = (uv.uMin + uv.uMax) / 2
             guard let low = face.point(atU: uMid, v: uv.vMin),
                   let high = face.point(atU: uMid, v: uv.vMax) else {
                 continue

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -798,6 +798,25 @@ extension AAG {
             for current in frontier {
                 let reachedThroughJunction = current != floorIndex
                 guard current < adjacencyList.count else { continue }
+                // Whether `current` is itself a confirmed reentrant fillet, i.e. whether we
+                // are CONTINUING an already-verified chain rather than trying to ENTER a new
+                // one. `isRadiallyInwardFillet(current)` is always false for `current ==
+                // floorIndex` (a floor is planar, never a fillet), so this is the entering
+                // case at BFS level 0 by construction, not a separate check.
+                let currentIsConfirmedFillet = isRadiallyInwardFillet(current)
+                // Whether `current` is close enough to the floor, structurally, for a face it
+                // borders to be THIS floor's own wall (#762 review, round 4). "Close enough"
+                // means the floor itself, or a junction whose OWN entering edge came directly
+                // from the floor: exactly the fillet or chamfer built to blend the floor to its
+                // wall, which by construction has exactly two "long" tangent/concave
+                // relationships, to the floor and to that wall, and nothing else. A junction
+                // reached only through ANOTHER junction (a corner blend continuing the chain,
+                // e.g. the torus and second fillet in fixture 2 below) is not that specific
+                // relationship: it exists to reconcile two OTHER faces, and its own far
+                // neighbor is not automatically this floor's wall just because it is vertical
+                // and radially inward, since a further corner blend can be both of those too.
+                let currentBordersFloorDirectly = !reachedThroughJunction
+                    || (floorIndex < adjacencyList.count && adjacencyList[floorIndex][current] != nil)
                 for (neighbor, edgeIndex) in adjacencyList[current] {
                     guard !visited.contains(neighbor) else { continue }
                     let edge = edges[edgeIndex]
@@ -808,7 +827,25 @@ extension AAG {
                     case .concave:
                         crossable = true
                     case .smooth:
-                        crossable = isRadiallyInwardFillet(edge.face1Index) || isRadiallyInwardFillet(edge.face2Index)
+                        // ENTERING a fillet chain for the first time (`current` is not itself
+                        // one) requires the candidate to be a confirmed reentrant fillet: this
+                        // is the only sign a tangent edge carries (#762 review). CONTINUING an
+                        // already-confirmed chain accepts either the wall the fillet blends
+                        // into (a vertical face, checked below) or another face that
+                        // independently confirms the same reentrant curvature (a further corner
+                        // blend, e.g. a torus or a second fillet, continuing the same physical
+                        // corner). This is deliberately NOT `isRadiallyInwardFillet(edge.face1Index)
+                        // || isRadiallyInwardFillet(edge.face2Index)`: that tests EITHER end of
+                        // the edge, and once `current` is a confirmed fillet it always
+                        // satisfies its own half of that OR, making every `.smooth` edge
+                        // leaving it crossable regardless of what is actually on the far side,
+                        // including an unrelated tangent face. Crossability alone does not
+                        // decide wall vs. junction below; `currentBordersFloorDirectly` does.
+                        if currentIsConfirmedFillet {
+                            crossable = nodes[neighbor].isVertical || isRadiallyInwardFillet(neighbor)
+                        } else {
+                            crossable = isRadiallyInwardFillet(neighbor)
+                        }
                     }
                     guard crossable else { continue }
 
@@ -823,8 +860,22 @@ extension AAG {
                     // is not a terminal outcome for the face, only for this particular edge.
                     let candidate = nodes[neighbor]
                     guard candidate.isVertical else {
-                        // Not a wall itself: a junction face (fillet or chamfer) absorbed into
-                        // the floor/wall transition. Keep looking past it for the true wall.
+                        // Not a wall itself: a junction face (fillet, chamfer, or a curved
+                        // corner blend) absorbed into the floor/wall transition. Keep looking
+                        // past it for the true wall.
+                        visited.insert(neighbor)
+                        junctions.append(neighbor)
+                        next.append(neighbor)
+                        continue
+                    }
+                    guard currentBordersFloorDirectly else {
+                        // Vertical, but reached from a junction that does not itself border the
+                        // floor: not this floor's wall (that relationship belongs solely to the
+                        // floor-bordering junction), and not a dead end either, since it may
+                        // still be worth searching past (#762 review, round 4, fixture 2: a
+                        // vertical corner-blend cylinder between a floor-bordering fillet's own
+                        // torus and the genuine wall). Absorbed as a further junction instead of
+                        // a wall, regardless of how the Z-check below would have scored it.
                         visited.insert(neighbor)
                         junctions.append(neighbor)
                         next.append(neighbor)

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -785,17 +785,77 @@ extension AAG {
     /// route's failure equivalent to its success, both closing off the second route. It was
     /// never true of the geometry itself, only of a bug that happened to make the two
     /// indistinguishable in every fixture built to tell them apart.
+    ///
+    /// ## `currentBordersFloorDirectly`: carried by the BFS, not reconstructed from adjacency
+    ///
+    /// A fourth review round found the guard that decides whether a vertical `.smooth` neighbor
+    /// may become a wall, `currentBordersFloorDirectly`, first shipped as
+    /// `adjacencyList[floorIndex][current] != nil`: "does some edge exist between the floor and
+    /// `current`". That is a different, weaker question than "was `current` reached directly
+    /// from the floor". `adjacencyList` is built for every edge regardless of convexity, so a
+    /// junction that only incidentally touches the floor through a non-crossable edge would
+    /// wrongly satisfy it without ever having been reached that way, reintroducing this
+    /// method's own bug for a topology none of the ten ground-truthed fixtures happened to
+    /// exercise. Not hypothetical on this codebase: `BRepFilletAPI_MakeFillet`'s own
+    /// corner-blending is documented, in `Issue762ReflexCornerPartialFilletTests`'s own doc
+    /// comment (re: WallX0), to reshape an unrelated face so the floor borders it directly by
+    /// incident, not by the route actually taken to reach it.
+    ///
+    /// Fixed by carrying the fact instead of reconstructing it: each `frontier` entry pairs a
+    /// node index with whether IT was reached directly from the floor
+    /// (`bordersFloorDirectly`), decided once, at the exact moment it is enqueued
+    /// (`discoveredBordersFloorDirectly`, `current == floorIndex`). This is exact by
+    /// construction, not merely narrower: it cannot be fooled by any incidental edge, since it
+    /// never consults `adjacencyList[floorIndex]` at all.
+    ///
+    /// A dedicated removal-matrix row (injection E) isolates this specific gate: forcing
+    /// `currentBordersFloorDirectly` to its pre-fix effective value of `true` (as if every node
+    /// bordered the floor directly) fails exactly
+    /// `Issue762VerticalCornerBlendNotAWallTests`/`Issue762FullyRoundedPocketChainingTests` and
+    /// no other test in the full `#762`/`#753`/`#735`/`#747` suite. That isolation is the point:
+    /// those same two tests also fail under injection B/D (the Z-tolerance bypass), for a
+    /// different reason (every chain-discovered wall breaks there, not specifically the
+    /// corner-blend misclassification this gate closes), so a row that merely observes them
+    /// failing under an unrelated guard's removal would not have proven this gate does anything.
+    /// This is the third guard on this PR shown to need an isolating row rather than a
+    /// coincidentally-failing one: injection C was first masked by the visited-marking bug
+    /// above, injections B and D backstop each other, and this gate's own first "proof" folded
+    /// into B/D's set instead of exercising itself.
+    ///
+    /// Full removal matrix, A through E, re-run against the grown suite (34 tests) after this
+    /// fix, each row's isolation restated:
+    ///
+    /// | injection | disables | isolates | tests that fail |
+    /// |---|---|---|---|
+    /// | A | the `.smooth`-edge radially-inward gate | whether a fillet is confirmed reentrant before crossing into it | 3: plain-box exterior fillet, both L-shape tests |
+    /// | B | the #724 Z-tolerance bypass for chain-discovered walls | whether a chain-discovered wall is trusted by contiguity instead of its own Z | 12: every fillet/chamfer/chain-discovered-wall test, including both round-4 tests (a different mechanism than E, see above) |
+    /// | C | the `.convex` edge block | whether a reentrant-the-wrong-way edge is refused | 2: filleted through-slot, L-shape reflex corner |
+    /// | D | B and C together | both of the above at once | 12, identical to B's own set (B's breakage dominates) |
+    /// | E | `currentBordersFloorDirectly` (forced `true`) | whether a wall can only be accepted from the floor itself or a junction that borders it directly | 2: exactly the two round-4 tests, and only those |
     private func wallsAndJunctions(fromFloor floorIndex: Int, floorZ: Double, tolerance: Double)
         -> (walls: [Int], junctions: [Int])
     {
         var walls: [Int] = []
         var junctions: [Int] = []
         var visited: Set<Int> = [floorIndex]
-        var frontier = [floorIndex]
+        // Each frontier entry carries whether IT was reached directly from the floor, decided
+        // once, at the moment it was enqueued, rather than re-derived later from adjacency
+        // (#762 review, round 4 finding 1). A first version of this gate asked
+        // `adjacencyList[floorIndex][current] != nil`, "does some edge exist between the floor
+        // and `current`", which is the wrong question: `adjacencyList` is built for every edge
+        // regardless of convexity, so a junction that only incidentally touches the floor
+        // through a non-crossable edge would wrongly satisfy it without ever having been
+        // reached that way. That is not hypothetical on this codebase: `BRepFilletAPI_MakeFillet`'s
+        // own corner-blending is documented (`Issue762ReflexCornerPartialFilletTests`'s own doc
+        // comment, re: WallX0) to reshape an unrelated face so the floor borders it directly by
+        // incident, not by the route the BFS actually took. Carrying the fact the BFS already
+        // knows, instead of reconstructing a weaker version of it, removes that failure mode by
+        // construction rather than narrowing it.
+        var frontier: [(index: Int, bordersFloorDirectly: Bool)] = [(floorIndex, true)]
 
         while !frontier.isEmpty {
-            var next: [Int] = []
-            for current in frontier {
+            var next: [(index: Int, bordersFloorDirectly: Bool)] = []
+            for (current, currentBordersFloorDirectly) in frontier {
                 let reachedThroughJunction = current != floorIndex
                 guard current < adjacencyList.count else { continue }
                 // Whether `current` is itself a confirmed reentrant fillet, i.e. whether we
@@ -804,19 +864,24 @@ extension AAG {
                 // floorIndex` (a floor is planar, never a fillet), so this is the entering
                 // case at BFS level 0 by construction, not a separate check.
                 let currentIsConfirmedFillet = isRadiallyInwardFillet(current)
-                // Whether `current` is close enough to the floor, structurally, for a face it
-                // borders to be THIS floor's own wall (#762 review, round 4). "Close enough"
-                // means the floor itself, or a junction whose OWN entering edge came directly
-                // from the floor: exactly the fillet or chamfer built to blend the floor to its
-                // wall, which by construction has exactly two "long" tangent/concave
-                // relationships, to the floor and to that wall, and nothing else. A junction
-                // reached only through ANOTHER junction (a corner blend continuing the chain,
-                // e.g. the torus and second fillet in fixture 2 below) is not that specific
-                // relationship: it exists to reconcile two OTHER faces, and its own far
-                // neighbor is not automatically this floor's wall just because it is vertical
-                // and radially inward, since a further corner blend can be both of those too.
-                let currentBordersFloorDirectly = !reachedThroughJunction
-                    || (floorIndex < adjacencyList.count && adjacencyList[floorIndex][current] != nil)
+                // A newly discovered junction's OWN `bordersFloorDirectly` flag: true exactly
+                // when its entering edge (the one just crossed) came from the floor itself,
+                // i.e. `current == floorIndex`. Every node discovered while processing the
+                // floor's own frontier entry gets `true`; every node discovered one level
+                // deeper or beyond gets `false`, uniformly, since by construction none of them
+                // is reached with `current == floorIndex` (#762 review, round 4). "Close enough
+                // to the floor, structurally, for a face it borders to be THIS floor's own
+                // wall" means the floor itself, or a junction whose OWN entering edge came
+                // directly from the floor: exactly the fillet or chamfer built to blend the
+                // floor to its wall, which by construction has exactly two "long"
+                // tangent/concave relationships, to the floor and to that wall, and nothing
+                // else. A junction reached only through ANOTHER junction (a corner blend
+                // continuing the chain, e.g. the torus and second fillet in fixture 9) is not
+                // that specific relationship: it exists to reconcile two OTHER faces, and its
+                // own far neighbor is not automatically this floor's wall just because it is
+                // vertical and radially inward, since a further corner blend can be both of
+                // those too.
+                let discoveredBordersFloorDirectly = !reachedThroughJunction
                 for (neighbor, edgeIndex) in adjacencyList[current] {
                     guard !visited.contains(neighbor) else { continue }
                     let edge = edges[edgeIndex]
@@ -865,20 +930,20 @@ extension AAG {
                         // past it for the true wall.
                         visited.insert(neighbor)
                         junctions.append(neighbor)
-                        next.append(neighbor)
+                        next.append((neighbor, discoveredBordersFloorDirectly))
                         continue
                     }
                     guard currentBordersFloorDirectly else {
                         // Vertical, but reached from a junction that does not itself border the
                         // floor: not this floor's wall (that relationship belongs solely to the
                         // floor-bordering junction), and not a dead end either, since it may
-                        // still be worth searching past (#762 review, round 4, fixture 2: a
+                        // still be worth searching past (#762 review, round 4, fixture 9: a
                         // vertical corner-blend cylinder between a floor-bordering fillet's own
                         // torus and the genuine wall). Absorbed as a further junction instead of
                         // a wall, regardless of how the Z-check below would have scored it.
                         visited.insert(neighbor)
                         junctions.append(neighbor)
-                        next.append(neighbor)
+                        next.append((neighbor, discoveredBordersFloorDirectly))
                         continue
                     }
                     if reachedThroughJunction || abs(candidate.bounds.min.z - floorZ) < tolerance {

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -704,20 +704,59 @@ extension AAG {
     /// would make every filleted/chamfered wall fail the very check meant to confirm it is
     /// this floor's wall, re-introducing the bug this method exists to fix.
     ///
-    /// ## `.convex` never crosses, and this fixture set cannot independently prove that matters
+    /// ## `.convex` never crosses: load-bearing past a junction, but untested there
     ///
     /// `EdgeConvexity.convex` means the material turns the wrong way for absorption by
     /// definition (interior angle `<180`, "fillet-like, going outward", see the enum's own
-    /// doc comment), so refusing to cross it is correct on its face. Measured directly rather
-    /// than assumed (removal-matrix injection C, PR body): disabling this specific guard alone
-    /// changes the outcome of NONE of this fix's tests, including the ones built to be
-    /// false-positive guards. Every fixture that could plausibly trigger it turns out to be
-    /// screened by a different check first: a direct convex neighbor's own bounding box
-    /// never happens to bottom out at an unrelated floor's Z by coincidence in any fixture
-    /// here, and a convex-connected face reached through an already-absorbed junction is
-    /// already reachable (and already visited) via that junction's own concave/smooth
-    /// neighbors in every measured case. Left in place because it is still definitionally
-    /// correct and cheap, not because a fixture in this PR demonstrates it is load-bearing.
+    /// doc comment), so refusing to cross it is correct on its face. But that is a claim about
+    /// what the guard SHOULD do, not evidence that this codebase has watched it matter, and
+    /// the two are not the same thing (removal-matrix injection C, PR body).
+    ///
+    /// The guard has two call sites with different backstops. For a DIRECT (1-hop) floor
+    /// neighbor, the #724 Z-tolerance check is a second, independent line of defense: even if
+    /// `.convex` were not blocked, a direct neighbor still has to bottom out at the floor's own
+    /// Z to become a wall, and an unrelated convex-connected face never happens to do that by
+    /// coincidence in any fixture measured here. For a face reached PAST an already-absorbed
+    /// junction, `reachedThroughJunction` deliberately bypasses that Z check (see above), so
+    /// `.convex` is the ONLY remaining protection there. Injection C alone (removing the block
+    /// everywhere) came back green on all 19 tests in this PR precisely because every one of
+    /// them exercises the direct-neighbor case, where the Z-check backstop was still catching
+    /// it; none exercised the past-a-junction case in isolation. That is an untested path, not
+    /// a proven-safe one, and the two read identically in a green run.
+    ///
+    /// Two fixtures were built specifically to isolate the past-a-junction case (both
+    /// ground-truthed against `ChFi3d` first, `Scripts/repro/762-filleted-pocket-detection/`,
+    /// fixtures 5 and 8) and both failed to isolate it, for related but distinct reasons: the
+    /// filleted through-slot's open-end exterior wall is ALSO a direct (1-hop) floor neighbor
+    /// (the floor's own polygon reaches the same exterior boundary the fillet does), so the
+    /// #724 Z-check resolves it before the fillet's own convex edge is ever tried. The L-shaped
+    /// pocket's reflex-corner fixture confirmed the hypothesised geometry (a fillet ending at
+    /// an unfilleted reflex corner DOES meet the far wall via `.convex`, the mirror image of
+    /// two boss-corner fillets meeting convexly), but `BRepFilletAPI_MakeFillet`'s own
+    /// corner-blending reshapes the far wall's face so the floor ALSO borders it directly,
+    /// masking the guard the same way, for a different, kernel-side reason.
+    ///
+    /// A pattern emerges from both attempts, general enough to state as geometry rather than
+    /// as "no fixture reached it": a floor's own boundary is a closed loop, and every vertex on
+    /// that loop has exactly two incident edges, both bordering something the floor is directly
+    /// adjacent to elsewhere in the SAME BFS's level-0 frontier (a reentrant floor/wall pairing
+    /// is never itself `.convex`, so nothing here contradicts that). Whatever a junction's own
+    /// convex-edged neighbor turns out to be, tracing it back reaches the same vertex, and the
+    /// floor's OTHER edge at that vertex reaches the same target one BFS level earlier,
+    /// independent of whether `.convex` blocks the junction's own path. This was checked
+    /// directly against a shared, floor-boss-inside-a-pocket configuration too (the boss's wall
+    /// is always additionally reachable via the floor's own inner-wire boundary), not only
+    /// against the two committed fixtures.
+    ///
+    /// This is a real, geometry-grounded argument for why every construction tried reduces to
+    /// the same masking, and it is offered as exactly that: an argument, covering the pocket
+    /// topologies this investigation could construct and reason through, not an exhaustive
+    /// proof over every shape `BRepFilletAPI`/`BRepAlgoAPI` can produce. It has not been
+    /// disproven by a fixture, but it has also not been used to justify DELETING the guard:
+    /// the accurate status is untested-but-plausibly-necessary, and the guard stays in at
+    /// essentially zero cost until a fixture (a face with no other route to the floor at all,
+    /// perhaps from two solids sharing an edge rather than one solid's own corner) settles it
+    /// either way.
     private func wallsAndJunctions(fromFloor floorIndex: Int, floorZ: Double, tolerance: Double)
         -> (walls: [Int], junctions: [Int])
     {

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -460,9 +460,46 @@ extension AAG {
     /// genuine floor is geometrically the low end of its own walls, which is true independent of
     /// #723.
     ///
-    /// One known limitation: a filleted floor/wall junction would round the wall's bounding box
-    /// past the floor's own Z by roughly the fillet radius, which could exceed this tolerance. No
-    /// fixture in this codebase exercises that combination yet.
+    /// This Z check applies to a DIRECT (1-hop) concave neighbor. A wall reached only after
+    /// absorbing a fillet or chamfer junction (#762, below) skips it deliberately: that wall's
+    /// own bounding box is rounded past the floor's Z by roughly the fillet radius or chamfer
+    /// leg, by construction, so requiring the match there would fail the very walls #762 exists
+    /// to find.
+    ///
+    /// ## A filleted or chamfered junction is absorbed, not reclassified (#762)
+    ///
+    /// A fillet at a floor/wall junction is tangent to both surfaces (`ChFi3d::DefineConnectType`
+    /// reports `.smooth` at both new edges, by construction: a fillet is G1-continuous with
+    /// both faces it blends), so floor-to-fillet and fillet-to-wall both read smooth and the
+    /// floor has **no concave neighbor at all**, so `concaveNeighbors(of:)` alone can never find
+    /// it. `ChFi3d::DefineConnectType` is not wrong here: the concavity moved into the fillet
+    /// FACE's own curvature, not the edges, and reclassifying the edges would be exactly the
+    /// hand-rolled-formula regression #703/#723 already fixed.
+    ///
+    /// A chamfer has the same missing-pocket symptom for a different reason: measured
+    /// (`Scripts/repro/762-filleted-pocket-detection/`), a symmetric chamfer's two new edges
+    /// are both genuinely `.concave` (a 270-degree reentrant corner splits into two
+    /// 225-degree ones, still `>180`), so `concaveNeighbors(of:)` DOES reach the chamfer face
+    /// directly, but the chamfer is planar at an intermediate angle, fails the wall's own
+    /// `isVertical` filter, and the search used to stop there rather than continuing past it to
+    /// the true wall.
+    ///
+    /// `wallsAndJunctions(fromFloor:floorZ:tolerance:)` fixes both by tracing outward from the
+    /// floor through any non-wall face reached via a `.concave` edge (a chamfer, unconditionally)
+    /// or a `.smooth` edge into a face confirmed to curve the right way
+    /// (``isRadiallyInwardFillet(_:)``, a fillet), continuing until it lands on a genuine
+    /// vertical wall. See that method's own doc comment for the full mechanism, the ground truth
+    /// it rests on, and why the `.smooth` gate is necessary (not every tangent neighbor is a
+    /// junction to absorb; see "false-positive guards" there).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 20, height: 20, depth: 20)!
+    /// let pocketTool = Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15)!
+    /// let cut = box.subtracting(pocketTool)!
+    /// let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
+    /// let filleted = cut.filleted(edges: junctionEdges, radius: 1.0)!
+    /// print(filleted.detectPocketsAAG().count)   // 1, was 0
+    /// ```
     ///
     /// ## Enclosure is tested directly, not by wall count (#735)
     ///
@@ -506,20 +543,22 @@ extension AAG {
     /// a statement about *where* the pocket sits, not about whether it is closed, and the two are
     /// independent. Enclosure is a property of the wall loop, not of the pocket's position in space.
     ///
-    /// ## The tolerance filter's limitation was measured and did not reproduce (#753 finding 3)
+    /// ## The tolerance filter's limitation was measured and did not reproduce as hypothesized (#753 finding 3), then fixed for a different reason (#762)
     ///
-    /// Review raised a plausible-sounding compounding failure: a wall dropped by the `#724`
-    /// tolerance filter above (e.g. a filleted floor/wall junction rounding the wall's low-Z bound
-    /// past `floorZ`) would also drop its edges from the enclosure count, permanently misreporting
-    /// a fully enclosed filleted pocket as open. Measured directly with a filleted floor/wall
-    /// junction (radii 0.5 through 4 on a 10×10×15 pocket): the fillet does not reproduce this,
-    /// because it never reaches the tolerance filter at all. A fillet replaces the sharp floor/wall
-    /// edge with a tangent (`smooth`, not `concave`) transition through the fillet face, so the
-    /// filleted neighbor never appears in `concaveNeighbors(of:)` in the first place:
-    /// `wallIndices` comes back empty and the floor is skipped by the guard below before the
-    /// tolerance filter, or this enclosure test, ever runs. This is a pre-existing limitation of
-    /// pocket *detection* (a fully filleted pocket is not recognized as a pocket at all), unrelated
-    /// to #735/#753's change and not fixed here.
+    /// Review of #753 raised a plausible-sounding compounding failure: a wall dropped by the
+    /// `#724` tolerance filter above (e.g. a filleted floor/wall junction rounding the wall's
+    /// low-Z bound past `floorZ`) would also drop its edges from the enclosure count,
+    /// permanently misreporting a fully enclosed filleted pocket as open. Measured directly at
+    /// the time (radii 0.5 through 4 on a 10×10×15 pocket): the fillet did not reproduce that
+    /// specific failure, because a filleted pocket was not detected as a pocket AT ALL:
+    /// `concaveNeighbors(of:)` came back empty (the floor/wall edges are tangent, not concave,
+    /// see "A filleted or chamfered junction is absorbed, not reclassified" above) and the floor
+    /// was skipped before the tolerance filter, or this enclosure test, ever ran. #762 fixed
+    /// that non-detection; this enclosure test's own coverage check is now exercised by a
+    /// filleted pocket for the first time, against `wallIndices` UNION the absorbed junction
+    /// faces rather than `wallIndices` alone (see `detectPockets(tolerance:)`'s use of
+    /// `coveringFaces`), so the compounding failure review originally hypothesized is the thing
+    /// this union specifically forecloses, now that there is a filleted pocket for it to apply to.
     ///
     /// - Parameter tolerance: How close (model units) a wall's own low-Z bound must come to a
     ///   candidate floor's Z to count as resting on it. Defaults to
@@ -543,35 +582,33 @@ extension AAG {
         for (floorIndex, floorNode) in potentialFloors {
             guard let floorZ = floorNode.zLevel else { continue }
 
-            // Get concave neighbors (these should be walls)
-            let concaveNeighbors = self.concaveNeighbors(of: floorIndex)
-
-            // Filter to vertical faces that actually rest on this floor (#724): a wall's low Z
-            // bound must match the floor's own Z, or this floor is really that wall's opening,
-            // not its bottom.
-            let wallIndices = concaveNeighbors.filter { neighborIndex in
-                let wall = nodes[neighborIndex]
-                guard wall.isVertical else { return false }
-                return abs(wall.bounds.min.z - floorZ) < tolerance
-            }
+            // #762: walk concave AND absorbed-fillet/chamfer chains outward from the floor,
+            // not just its direct concave neighbors, so a filleted or chamfered floor/wall
+            // junction is found through the fillet/chamfer face instead of stopping at it. See
+            // this method's own doc comment ("A filleted or chamfered junction is absorbed,
+            // not reclassified") for the full reasoning.
+            let (wallIndices, junctionIndices) = wallsAndJunctions(fromFloor: floorIndex, floorZ: floorZ, tolerance: tolerance)
 
             // Need at least one wall to be a pocket
             guard !wallIndices.isEmpty else { continue }
 
-            // Calculate pocket bounds from floor and walls
+            // Calculate pocket bounds from floor, walls, and any absorbed junction faces
+            // (#762): a fillet/chamfer's own extent reaches slightly past where the trimmed
+            // wall now starts, so omitting it would silently under-report the pocket's bounds
+            // by roughly the fillet radius or chamfer leg.
             var minX = floorNode.bounds.min.x
             var minY = floorNode.bounds.min.y
             var maxX = floorNode.bounds.max.x
             var maxY = floorNode.bounds.max.y
             var maxZ = floorZ
 
-            for wallIndex in wallIndices {
-                let wallBounds = nodes[wallIndex].bounds
-                minX = min(minX, wallBounds.min.x)
-                minY = min(minY, wallBounds.min.y)
-                maxX = max(maxX, wallBounds.max.x)
-                maxY = max(maxY, wallBounds.max.y)
-                maxZ = max(maxZ, wallBounds.max.z)
+            for index in wallIndices + junctionIndices {
+                let faceBounds = nodes[index].bounds
+                minX = min(minX, faceBounds.min.x)
+                minY = min(minY, faceBounds.min.y)
+                maxX = max(maxX, faceBounds.max.x)
+                maxY = max(maxY, faceBounds.max.y)
+                maxZ = max(maxZ, faceBounds.max.z)
             }
 
             // Enclosure, not wall count (#735), tested per edge rather than by comparing counts
@@ -580,9 +617,14 @@ extension AAG {
             // into `?? []`/`isEmpty` (review finding 6) makes "no outer wire" and "an outer wire
             // with zero edges" the same case they already behave as: don't claim an enclosure
             // that wasn't established, default to open.
+            //
+            // #762: a floor's own outer-wire boundary edge borders the ABSORBED junction face
+            // (the fillet or chamfer), not the far wall, whenever one is interposed, so
+            // coverage is tested against walls UNION junctions, not walls alone.
             let floorOuterEdges = occFaces[floorIndex].outerWire?.edges() ?? []
+            let coveringFaces = wallIndices + junctionIndices
             let isOpen = floorOuterEdges.isEmpty || floorOuterEdges.contains { boundaryEdge in
-                !isEdgeCoveredByAWall(boundaryEdge, among: wallIndices, in: occFaces)
+                !isEdgeCoveredByAWall(boundaryEdge, among: coveringFaces, in: occFaces)
             }
 
             let pocket = PocketFeature(
@@ -605,8 +647,183 @@ extension AAG {
         return pockets
     }
 
-    /// Whether `edge` borders one of the faces at `wallIndices`, tested by structural identity
+    /// Finds a floor's walls by tracing concave edges, and any absorbed fillet/chamfer
+    /// junction, outward from it (#762). Returns the true (vertical) walls (what
+    /// ``PocketFeature/wallFaceIndices`` reports, with exactly the same meaning it had before
+    /// this fix), and, separately, every junction face absorbed along the way, which the
+    /// enclosure test in ``detectPockets(tolerance:)`` needs: the floor's own outer-wire
+    /// boundary edges border THOSE, not the far wall, whenever one is interposed.
+    ///
+    /// ## Why a fillet needs a chain, and a chamfer needs a shorter one
+    ///
+    /// Measured (`Scripts/repro/762-filleted-pocket-detection/`, ChFi3d::DefineConnectType
+    /// against a sharp/filleted/chamfered/partially-filleted/open/boss fixture set):
+    ///
+    /// - **A fillet's own two new edges are both `.smooth` (tangent)**, at BOTH ends, by
+    ///   construction: a fillet is G1-continuous with both faces it blends, so there is no
+    ///   local sign left to read at either edge; concave and convex fillets look identical
+    ///   there. The concavity moved into the fillet FACE's own curvature, not the edges.
+    /// - **A chamfer's own two new edges are both `.concave`** (for a pocket's floor/wall
+    ///   junction): a symmetric chamfer replacing a 270-degree reentrant corner leaves two
+    ///   225-degree transitions, still `>180`. `concaveNeighbors(of:)` already reaches a
+    ///   chamfer face directly; the reason `detectPockets` still missed a chamfered pocket
+    ///   before this fix is `wallIndices`' OWN `isVertical` filter, which a 45-degree chamfer
+    ///   face fails; the search just never continued past it to the real wall beyond.
+    ///
+    /// So a chamfer only ever needed the search to continue past a non-wall CONCAVE neighbor;
+    /// a fillet additionally needs `.smooth` edges to be crossable, gated by
+    /// ``isRadiallyInwardFillet(_:)`` since edge convexity alone carries no sign there.
+    ///
+    /// ## The `.smooth` gate: radially inward, not "concave"
+    ///
+    /// A `.smooth` edge is only crossed toward a face that is itself a legitimate
+    /// corner-rounding fillet: cylindrical, conical or spherical, with its own outward normal
+    /// pointing back toward its axis/center (radially inward) rather than away from it. This is
+    /// the identical material-side test ``detectHoles()`` uses (#747/#760) to tell a hole's bore
+    /// from a boss's wall, aimed at a narrower question here (see
+    /// ``isRadiallyInwardFillet(_:)``'s own doc comment for why this does NOT, and does not
+    /// need to, distinguish a pocket's fillet from a boss's).
+    ///
+    /// This specifically refuses to cross a `.smooth` edge into a face that curves the OTHER
+    /// way (radially outward): an ordinary convex/external rounding, e.g. the box's own
+    /// exterior edge filleted, which is not a floor/wall junction to absorb at all, and
+    /// refuses a `.smooth` edge between two faces where neither is such a fillet (an
+    /// unrelated, incidentally-tangent planar pair). Without this gate, unconditionally
+    /// crossing every `.smooth` edge would be exactly the "transitive tangency sweeps in
+    /// faces that are not walls at all" trap #762 itself warns about.
+    ///
+    /// ## Why a chain-discovered wall skips the #724 Z-tolerance check
+    ///
+    /// A direct (1-hop) concave neighbor still has to bottom out at the floor's own Z (#724
+    /// unchanged) to rule out grabbing the wrong (top, opening) end of a wall. A wall reached
+    /// only after absorbing at least one junction face is trusted by the CHAIN's own
+    /// contiguity instead: measured, a filleted or chamfered wall's own remaining planar
+    /// remnant no longer touches the floor's Z at all: it starts roughly a fillet radius or
+    /// chamfer leg distance above it, since the junction face itself is what actually bottoms
+    /// out there. Requiring the Z match on the far side of an already-verified junction chain
+    /// would make every filleted/chamfered wall fail the very check meant to confirm it is
+    /// this floor's wall, re-introducing the bug this method exists to fix.
+    ///
+    /// ## `.convex` never crosses, and this fixture set cannot independently prove that matters
+    ///
+    /// `EdgeConvexity.convex` means the material turns the wrong way for absorption by
+    /// definition (interior angle `<180`, "fillet-like, going outward", see the enum's own
+    /// doc comment), so refusing to cross it is correct on its face. Measured directly rather
+    /// than assumed (removal-matrix injection C, PR body): disabling this specific guard alone
+    /// changes the outcome of NONE of this fix's tests, including the ones built to be
+    /// false-positive guards. Every fixture that could plausibly trigger it turns out to be
+    /// screened by a different check first: a direct convex neighbor's own bounding box
+    /// never happens to bottom out at an unrelated floor's Z by coincidence in any fixture
+    /// here, and a convex-connected face reached through an already-absorbed junction is
+    /// already reachable (and already visited) via that junction's own concave/smooth
+    /// neighbors in every measured case. Left in place because it is still definitionally
+    /// correct and cheap, not because a fixture in this PR demonstrates it is load-bearing.
+    private func wallsAndJunctions(fromFloor floorIndex: Int, floorZ: Double, tolerance: Double)
+        -> (walls: [Int], junctions: [Int])
+    {
+        var walls: [Int] = []
+        var junctions: [Int] = []
+        var visited: Set<Int> = [floorIndex]
+        var frontier = [floorIndex]
+
+        while !frontier.isEmpty {
+            var next: [Int] = []
+            for current in frontier {
+                let reachedThroughJunction = current != floorIndex
+                guard current < adjacencyList.count else { continue }
+                for (neighbor, edgeIndex) in adjacencyList[current] {
+                    guard !visited.contains(neighbor) else { continue }
+                    let edge = edges[edgeIndex]
+                    let crossable: Bool
+                    switch edge.convexity {
+                    case .convex:
+                        crossable = false
+                    case .concave:
+                        crossable = true
+                    case .smooth:
+                        crossable = isRadiallyInwardFillet(edge.face1Index) || isRadiallyInwardFillet(edge.face2Index)
+                    }
+                    guard crossable else { continue }
+                    visited.insert(neighbor)
+
+                    let candidate = nodes[neighbor]
+                    guard candidate.isVertical else {
+                        // Not a wall itself: a junction face (fillet or chamfer) absorbed into
+                        // the floor/wall transition. Keep looking past it for the true wall.
+                        junctions.append(neighbor)
+                        next.append(neighbor)
+                        continue
+                    }
+                    if reachedThroughJunction || abs(candidate.bounds.min.z - floorZ) < tolerance {
+                        walls.append(neighbor)
+                        // A found wall is terminal for this chain: do not look past it.
+                    }
+                    // else: a direct vertical neighbor that does not bottom out at this
+                    // floor's Z is the wrong (opening) end of some other wall (#724): a
+                    // dead end, not a wall and not a junction to search further from.
+                }
+            }
+            frontier = next
+        }
+        return (walls, junctions)
+    }
+
+    /// Whether `nodeIndex`'s face is a cylindrical, conical or spherical fillet curving INTO
+    /// the material it borders (#762): its own outward normal, sampled at its own UV
+    /// mid-parameter, points back toward its axis (or, for a sphere, its center) rather than
+    /// away from it.
+    ///
+    /// This is the identical material-side test ``detectHoles()`` uses (#747/#760) to tell a
+    /// hole's bore from a boss's or a standalone cylinder's own wall, aimed at a narrower
+    /// question: not "is this whole face a hole," but "is this specific transition face a
+    /// rounded-INTO junction," the shape any corner-rounding fillet has, whether it is
+    /// rounding a pocket's own concave floor/wall corner or a boss's convex base.
+    ///
+    /// Ground-truthed (`Scripts/repro/762-filleted-pocket-detection/`) that a pocket's fillet
+    /// AND a boss's base fillet give the IDENTICAL radially-inward signature: both are
+    /// reentrant (material-wraps-270-degrees) corners at the sharp-edge level, and a fillet's
+    /// curvature sign reflects only whether it rounds INTO a reentrant corner (either case) or
+    /// OFF an external one (the box's own exterior edge, radially outward). This test
+    /// deliberately does NOT, and structurally cannot, distinguish a pocket's fillet from a
+    /// boss's: that distinction already exists, unchanged, in ``PocketFeature/isOpen``'s
+    /// outer-wire-scoped enclosure test (#753). A boss's wall was already a legitimate (if
+    /// unenclosing) member of `wallFaceIndices` before this fix, for a floor boss standing
+    /// inside a real pocket, and it stays exactly as legitimate, and exactly as correctly
+    /// `isOpen`, when its own base is filleted.
+    private func isRadiallyInwardFillet(_ nodeIndex: Int) -> Bool {
+        guard nodeIndex < faceOccurrences.count else { return false }
+        let face = faceOccurrences[nodeIndex]
+        guard let revolution = face.revolutionProperties,
+              let uv = face.uvBounds else { return false }
+
+        let uMid = (uv.uMin + uv.uMax) / 2
+        let vMid = (uv.vMin + uv.vMax) / 2
+        guard let midPoint = face.point(atU: uMid, v: vMid),
+              let midNormal = face.normal(atU: uMid, v: vMid) else { return false }
+
+        let offset = midPoint - revolution.axis.origin
+        let radial: SIMD3<Double>
+        if face.surfaceType == .sphere {
+            // A sphere has no intrinsic axis direction (primaryAxis still reports one, but
+            // it is not a property of the surface); radially-from-center is the only
+            // meaningful test.
+            radial = offset
+        } else {
+            let axisUnit = simd_normalize(revolution.axis.direction)
+            radial = offset - simd_dot(offset, axisUnit) * axisUnit
+        }
+        let radialLength = simd_length(radial)
+        guard radialLength > 1e-9 else { return false }
+        return simd_dot(midNormal, radial / radialLength) < 0
+    }
+
+    /// Whether `edge` borders one of the faces at `coveringFaces`, tested by structural identity
     /// rather than by counting (#753).
+    ///
+    /// `coveringFaces` is walls UNION absorbed junction faces (#762), not walls alone: a
+    /// floor's own outer-wire boundary edge borders the fillet or chamfer interposed at a
+    /// junction, not the far wall, whenever one is interposed, so testing against walls only
+    /// would misreport every filleted/chamfered pocket as open even though it is enclosed.
     ///
     /// `edge` is expected to be one of the floor's own outer-wire edges, obtained via
     /// ``Wire/edges()``, which converts the wire to its own standalone one-off `Shape` to extract
@@ -615,11 +832,11 @@ extension AAG {
     /// `shape` by its underlying geometry and location (`TopoDS_Shape::IsSame`, the same identity
     /// rule the wire-to-shape conversion preserves), not by index, so which throwaway shape the
     /// `Edge` was minted from does not matter here.
-    private func isEdgeCoveredByAWall(_ edge: Edge, among wallIndices: [Int], in occFaces: [Face]) -> Bool {
+    private func isEdgeCoveredByAWall(_ edge: Edge, among coveringFaces: [Int], in occFaces: [Face]) -> Bool {
         guard let (face1, face2) = edge.adjacentFaces(in: shape) else { return false }
-        return wallIndices.contains { wallIndex in
-            let wall = occFaces[wallIndex]
-            return facesAreSame(face1, wall) || (face2.map { facesAreSame($0, wall) } ?? false)
+        return coveringFaces.contains { coveringIndex in
+            let covering = occFaces[coveringIndex]
+            return facesAreSame(face1, covering) || (face2.map { facesAreSame($0, covering) } ?? false)
         }
     }
 

--- a/Tests/OCCTModelingTests/Issue735PocketEnclosureTests.swift
+++ b/Tests/OCCTModelingTests/Issue735PocketEnclosureTests.swift
@@ -246,25 +246,43 @@ struct Issue753EdgeFaceOrderIndependenceTests {
 // "rests on the floor" tolerance filter (e.g. a filleted floor/wall junction rounding the
 // wall's low-Z bound past the floor's own Z) would also drop its edges from the enclosure
 // count, permanently misreporting a fully enclosed filleted pocket as open. Measured directly
-// (radii 0.5 through 4 on a 10x10x15 pocket, `Sources/OCCTTest/main.swift` scratch probe,
-// restored before committing): it does not reproduce, for a more fundamental reason than the
-// one hypothesized. A fillet replaces the sharp floor/wall edge with a tangent (`smooth`, not
-// `concave`) transition through the fillet face, so the filleted neighbor never appears in
-// `concaveNeighbors(of:)` at all: `wallFaceIndices` comes back empty and the floor is skipped
-// before the tolerance filter, or the enclosure test, ever runs. This locks in that measured
-// behavior (a fully filleted pocket is not detected as a pocket at all) so a future change to
-// the concavity classification that starts recognizing it does not silently reintroduce the
-// originally-hypothesized failure without a test noticing.
-@Suite("A filleted floor/wall junction is not detected as a pocket at all (#753 finding 3, measured)")
-struct Issue753FilletedJunctionNotDetectedTests {
-    @Test("a filleted floor/wall junction pocket is not recognized as a pocket")
-    func filletedJunctionPocketIsNotDetected() throws {
+// at the time (radii 0.5 through 4 on a 10x10x15 pocket, `Sources/OCCTTest/main.swift` scratch
+// probe, restored before committing): it did not reproduce, for a more fundamental reason than
+// the one hypothesized. A fillet replaces the sharp floor/wall edge with a tangent (`smooth`,
+// not `concave`) transition through the fillet face, so the filleted neighbor never appeared in
+// `concaveNeighbors(of:)` at all: `wallFaceIndices` came back empty and the floor was skipped
+// before the tolerance filter, or the enclosure test, ever ran.
+//
+// That was a real, measured gap, not a false alarm, and #762 was filed to close it: nearly
+// every real machined pocket has a filleted floor/wall junction (an endmill cannot cut a sharp
+// internal corner), so a recognizer that only sees sharp pockets has the detection ratio
+// backwards for its actual input domain. This suite USED TO pin the negative result as a
+// characterization test, specifically so a future change to edge convexity classification that
+// started recognizing a filleted junction would not silently reintroduce the
+// originally-hypothesized #753 finding-3 failure without a test noticing. #762 IS that future
+// change: `AAG.wallsAndJunctions(fromFloor:floorZ:tolerance:)` (`FeatureRecognition.swift`)
+// traces concave edges and confirmed-radially-inward-fillet `.smooth` edges outward from the
+// floor, absorbing the fillet face, so the junction is now found THROUGH it rather than
+// reclassifying `ChFi3d::DefineConnectType`'s own correct `.smooth` verdict at the edge itself.
+//
+// Per this repo's own instruction for exactly this situation ("that test must invert when you
+// fix this"), the negative assertion below is now positive, and this suite is retitled to
+// describe what it proves today rather than what it used to pin. See
+// `Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift` for the fuller fixture
+// set (several radii, chamfer, partial fillet, and the false-positive guards) this single case
+// is now a subset of; kept here, inverted rather than deleted, because it is literally the
+// fixture #753 finding 3 and #762 both name.
+@Suite("A filleted floor/wall junction IS detected as an enclosed pocket (#753 finding 3 inverted by #762)")
+struct Issue753FilletedJunctionDetectedTests {
+    @Test("a filleted floor/wall junction pocket IS recognized as an enclosed pocket")
+    func filletedJunctionPocketIsDetected() throws {
         let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
         let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
         let cut = try #require(box.subtracting(pocketTool))
 
         // Confirm the sharp-cornered version is detected and enclosed before filleting it,
-        // so a negative result below is "the fillet removed it," not "the fixture was wrong."
+        // so the positive result below is "the fillet is now seen through," not "the fixture
+        // was never a pocket to begin with."
         let prePockets = cut.detectPocketsAAG()
         #expect(prePockets.count == 1)
 
@@ -273,6 +291,9 @@ struct Issue753FilletedJunctionNotDetectedTests {
         let filleted = try #require(cut.filleted(edges: junctionEdges, radius: 1.0))
 
         let postPockets = filleted.detectPocketsAAG()
-        #expect(postPockets.isEmpty)
+        #expect(postPockets.count == 1)
+        guard let pocket = postPockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
     }
 }

--- a/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
@@ -2,6 +2,29 @@ import Testing
 import Foundation
 @testable import OCCTSwift
 
+/// A fillet or chamfer that silently returned an unchanged shape would leave every assertion in
+/// these suites reading the SHARP fixture, which the control tests already prove detects correctly.
+/// The result would be a green test proving nothing, which is #703's exact shape: that fixture's
+/// boolean subtraction returned a perfectly good shape having removed zero volume.
+///
+/// `try #require(...)` only proves the call returned non-nil. This proves it did something: a fillet
+/// or chamfer replaces each target edge with at least one new face, so the face count must rise.
+///
+/// Raised self-reviewing #762 against `Scripts/census-unmeasured-values.py`'s sub-kind 2, which
+/// flagged these tests for pinning counts with no in-test fixture verification (#764).
+private func expectShapeChanged(
+    _ before: Shape,
+    _ after: Shape,
+    _ label: String,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let b = before.faces().count
+    let a = after.faces().count
+    #expect(a > b, "\(label): face count did not rise (\(b) to \(a)), so the operation added no geometry and this fixture is still the sharp one",
+            sourceLocation: sourceLocation)
+}
+
+
 // #762: a fillet at a pocket's floor/wall junction is tangent to both surfaces
 // (`ChFi3d::DefineConnectType` reports `.smooth` at both new edges, by construction, since a
 // fillet is G1-continuous with both faces it blends), so `concaveNeighbors(of:)` finds
@@ -53,6 +76,7 @@ struct Issue762FilletedPocketDetectionTests {
         let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
         #expect(junctionEdges.count == 4)
         let filleted = try #require(cut.filleted(edges: junctionEdges, radius: radius))
+        expectShapeChanged(cut, filleted, "filleted on cut")
 
         let pockets = filleted.detectPocketsAAG()
         #expect(pockets.count == 1)
@@ -111,6 +135,7 @@ struct Issue762PartialFilletDetectionTests {
         let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
         #expect(junctionEdges.count == 4)
         let filleted = try #require(cut.filleted(edges: Array(junctionEdges.prefix(2)), radius: 1.0))
+        expectShapeChanged(cut, filleted, "filleted on cut")
 
         let pockets = filleted.detectPocketsAAG()
         #expect(pockets.count == 1)
@@ -197,6 +222,7 @@ struct Issue762ReflexCornerPartialFilletTests {
         })
         #expect(wallY0Edges.count == 1)
         let filleted = try #require(cut.filleted(edges: wallY0Edges, radius: 1.0))
+        expectShapeChanged(cut, filleted, "filleted on cut")
 
         // Default tolerance: see this test's own doc comment for why WallX0 is correctly
         // absent here (the `.convex` guard, not a numerical near-miss).
@@ -246,6 +272,7 @@ struct Issue762DeadEndRevisitableThroughJunctionTests {
         let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
         #expect(junctionEdges.count == 4)
         let filleted = try #require(cut.filleted(edges: Array(junctionEdges.prefix(2)), radius: 1.0))
+        expectShapeChanged(cut, filleted, "filleted on cut")
 
         // Deliberately smaller than the sharp walls' own measured ~1.5e-7 natural offset, so
         // their direct route fails while the junction route (unconditional past #724's Z
@@ -320,6 +347,7 @@ struct Issue762VerticalCornerBlendNotAWallTests {
         })
         #expect(southEdge.count == 1)
         let filletedSouth = try #require(cut.filleted(edges: southEdge, radius: 3.0))
+        expectShapeChanged(cut, filletedSouth, "filleted on cut")
 
         let cornerEdge = filletedSouth.edges(where: {
             abs($0.bounds.min.x - (-5)) < 1e-3 && abs($0.bounds.max.x - (-5)) < 1e-3 &&
@@ -328,6 +356,7 @@ struct Issue762VerticalCornerBlendNotAWallTests {
         })
         #expect(cornerEdge.count == 1)
         let doubleFillet = try #require(filletedSouth.filleted(edges: cornerEdge, radius: 2.0))
+        expectShapeChanged(filletedSouth, doubleFillet, "filleted on filletedSouth")
 
         let pockets = doubleFillet.detectPocketsAAG()
         #expect(pockets.count == 1)
@@ -389,6 +418,7 @@ struct Issue762FullyRoundedPocketChainingTests {
         })
         #expect(floorEdges.count == 4)
         let filletedFloor = try #require(cut.filleted(edges: floorEdges, radius: 3.0))
+        expectShapeChanged(cut, filletedFloor, "filleted on cut")
 
         let cornerEdges = filletedFloor.edges(where: {
             ($0.bounds.max.z - $0.bounds.min.z) > 1.0 &&
@@ -399,6 +429,7 @@ struct Issue762FullyRoundedPocketChainingTests {
         })
         #expect(cornerEdges.count == 4)
         let doubleRing = try #require(filletedFloor.filleted(edges: cornerEdges, radius: 2.0))
+        expectShapeChanged(filletedFloor, doubleRing, "filleted on filletedFloor")
 
         let pockets = doubleRing.detectPocketsAAG()
         #expect(pockets.count == 1)
@@ -454,6 +485,7 @@ struct Issue762FilletedThroughSlotStaysOpenTests {
         })
         #expect(longEdges.count == 2)
         let filleted = try #require(cut.filleted(edges: longEdges, radius: 1.0))
+        expectShapeChanged(cut, filleted, "filleted on cut")
 
         let pockets = filleted.detectPocketsAAG()
         #expect(pockets.count == 1)
@@ -505,6 +537,7 @@ struct Issue762FilletedBossFalsePositiveTests {
         })
         #expect(baseEdges.count == 4)
         let filletedBoss = try #require(fused.filleted(edges: baseEdges, radius: 1.0))
+        expectShapeChanged(fused, filletedBoss, "filleted on fused")
 
         let pockets = filletedBoss.detectPocketsAAG()
         // Either the boss's fillet is absorbed and the plate's top is reported as an open
@@ -537,6 +570,7 @@ struct Issue762FilletedExternalCornerFalsePositiveTests {
         let topEdges = box.edges(where: { abs($0.bounds.min.z - 10) < 1e-6 && abs($0.bounds.max.z - 10) < 1e-6 })
         #expect(topEdges.count == 4)
         let filletedTop = try #require(box.filleted(edges: topEdges, radius: 2.0))
+        expectShapeChanged(box, filletedTop, "filleted on box")
 
         #expect(filletedTop.detectPocketsAAG().isEmpty)
     }

--- a/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
@@ -258,6 +258,143 @@ struct Issue762DeadEndRevisitableThroughJunctionTests {
     }
 }
 
+// MARK: - Junction-to-junction chaining (round 4 review)
+
+// PR #778's third review round found the `.smooth` crossable test for a face reached from an
+// already-confirmed fillet, `neighborNode.isVertical || isRadiallyInwardFillet(neighbor)`,
+// made no distinction between ENTERING a floor's own fillet and CONTINUING past it into a
+// further corner blend: once `current` was confirmed, every vertical `.smooth` neighbor
+// looked eligible to become the wall, including a corner-blend face that is itself another
+// junction, not the wall at all. These two suites are the guards against that, each proven to
+// matter by actually forcing `currentBordersFloorDirectly` true (its pre-fix effective value)
+// and re-running (see the PR body's removal-matrix update).
+
+@Suite("A vertical corner-blend fillet is a junction, not a wall (#762 review round 4)")
+struct Issue762VerticalCornerBlendNotAWallTests {
+
+    /// A vertical corner-blend cylinder is reentrant and radially inward exactly like a
+    /// genuine fillet, and vertical exactly like a genuine wall, so the pre-fix crossable test
+    /// wrongly accepted it as the wall itself once its own entering fillet was confirmed.
+    ///
+    /// Ground-truthed against `ChFi3d::DefineConnectType`
+    /// (`Scripts/repro/762-filleted-pocket-detection/`, fixture 9): the south floor/wall
+    /// junction is filleted (radius 3), and, separately, the vertical corner edge between the
+    /// west and south walls is ALSO filleted (radius 2), with the west floor/wall junction
+    /// left sharp. The corner-blend cylinder is reached only through the south fillet's own
+    /// further torus junction (`.smooth`, ground truth edge #5), never directly from the
+    /// floor.
+    ///
+    /// Fixed in `wallsAndJunctions(fromFloor:floorZ:tolerance:)`: `currentBordersFloorDirectly`
+    /// distinguishes a junction whose own entering edge came from the floor (the fillet built
+    /// to blend the floor to its wall specifically) from one reached only through another
+    /// junction. Only the former's vertical neighbor is eligible to become a wall; the
+    /// latter's is absorbed as a further junction regardless of the #724 Z-check, keeping the
+    /// search going without wrongly promoting it.
+    @Test("the vertical corner-blend cylinder is excluded from walls, not wrongly promoted")
+    func verticalCornerBlendCylinderIsExcludedFromWalls() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let southEdge = cut.edges(where: {
+            abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 &&
+            abs($0.bounds.min.y - (-5)) < 1e-6 && abs($0.bounds.max.y - (-5)) < 1e-6
+        })
+        #expect(southEdge.count == 1)
+        let filletedSouth = try #require(cut.filleted(edges: southEdge, radius: 3.0))
+
+        let cornerEdge = filletedSouth.edges(where: {
+            abs($0.bounds.min.x - (-5)) < 1e-3 && abs($0.bounds.max.x - (-5)) < 1e-3 &&
+            abs($0.bounds.min.y - (-5)) < 1e-3 && abs($0.bounds.max.y - (-5)) < 1e-3 &&
+            ($0.bounds.max.z - $0.bounds.min.z) > 1.0
+        })
+        #expect(cornerEdge.count == 1)
+        let doubleFillet = try #require(filletedSouth.filleted(edges: cornerEdge, radius: 2.0))
+
+        let pockets = doubleFillet.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
+
+        let occFaces = doubleFillet.orientedFaces()
+        for wallIndex in pocket.wallFaceIndices {
+            #expect(occFaces[wallIndex].surfaceType == .plane)
+        }
+    }
+}
+
+@Suite("Junction-to-junction chaining around a fully rounded pocket finds only the four genuine walls (#762 review round 4)")
+struct Issue762FullyRoundedPocketChainingTests {
+
+    /// Stresses the same fix on a much richer topology: all four floor/wall junctions
+    /// filleted (radius 3) AND all four vertical corners separately filleted (radius 2),
+    /// producing a torus/corner-fillet ring all the way around the pocket (eight curved
+    /// junction faces plus four BSpline surfaces OCCT inserts to reconcile the
+    /// mismatched-radius corners; ground-truthed,
+    /// `Scripts/repro/762-filleted-pocket-detection/`, fixture 10). Checks that
+    /// junction-to-junction chaining, confined by `currentBordersFloorDirectly` to producing
+    /// only further junctions past the first floor-bordering hop, still finds exactly the
+    /// four genuine flat walls without wandering into misclassifying any of the twelve curved
+    /// or freeform junction faces, and that the BFS terminates regardless: `visited` bounds
+    /// the total work to this floor's own face count no matter how many junction faces it
+    /// absorbs along the way.
+    ///
+    /// Measured (not assumed) where each wall is actually found here: every one of the four
+    /// is reached in exactly one hop past its own floor-bordering horizontal fillet (ground
+    /// truth edge #1/#12/#14/#18, wall to horizontal fillet cylinder, `.smooth`), the identical
+    /// depth as the single-corner fixture above, even though this shape ALSO offers a second,
+    /// longer route to the same wall through the vertical corner cylinder and BSpline (ground
+    /// truth edges #2/#9, #3/#12, etc.). The BFS reaches a wall by its shortest route first, so
+    /// the longer route is never actually needed to find it here.
+    ///
+    /// That is exactly why a fixed hop limit was rejected in favor of
+    /// `currentBordersFloorDirectly`, a structural fact (whether `current`'s own entering edge
+    /// came from the floor) rather than a count: a fillet is built to blend exactly the two
+    /// named faces it sits between, so a floor-bordering fillet's OTHER tangent relationship is
+    /// its wall by construction, regardless of how much unrelated corner-to-corner chaining
+    /// exists elsewhere in the same graph. No fixture built for this issue required a genuine
+    /// wall to be found more than one hop past a floor-bordering junction; this fixture
+    /// deliberately offers a longer alternative route to the same wall specifically to check
+    /// that the shorter, correct one still wins, not to demonstrate that a longer one is ever
+    /// required.
+    @Test("all four vertical corner-blend cylinders are excluded, only the four flat walls remain")
+    func fullyRoundedPocketFindsExactlyFourWalls() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let floorEdges = cut.edges(where: {
+            abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 &&
+            $0.bounds.min.x > -5.5 && $0.bounds.max.x < 5.5 &&
+            $0.bounds.min.y > -5.5 && $0.bounds.max.y < 5.5
+        })
+        #expect(floorEdges.count == 4)
+        let filletedFloor = try #require(cut.filleted(edges: floorEdges, radius: 3.0))
+
+        let cornerEdges = filletedFloor.edges(where: {
+            ($0.bounds.max.z - $0.bounds.min.z) > 1.0 &&
+            ($0.bounds.max.x - $0.bounds.min.x) < 0.5 &&
+            ($0.bounds.max.y - $0.bounds.min.y) < 0.5 &&
+            abs(abs($0.bounds.min.x) - 5) < 1e-2 &&
+            abs(abs($0.bounds.min.y) - 5) < 1e-2
+        })
+        #expect(cornerEdges.count == 4)
+        let doubleRing = try #require(filletedFloor.filleted(edges: cornerEdges, radius: 2.0))
+
+        let pockets = doubleRing.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
+
+        let occFaces = doubleRing.orientedFaces()
+        for wallIndex in pocket.wallFaceIndices {
+            #expect(occFaces[wallIndex].surfaceType == .plane)
+        }
+    }
+}
+
 // MARK: - False-positive guards
 
 // #762 named the risk explicitly: "transitive tangency could sweep in faces that are not

--- a/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
@@ -123,8 +123,8 @@ struct Issue762PartialFilletDetectionTests {
 @Suite("An L-shaped pocket's reflex corner, partially filleted, is still measured correctly (#762)")
 struct Issue762ReflexCornerPartialFilletTests {
 
-    /// Built specifically to test a removal-matrix conjunction a review of this fix's PR
-    /// raised: a wall reached PAST an already-absorbed junction (where the #724 Z-tolerance
+    /// Built specifically to test a removal-matrix conjunction an earlier review of this fix's
+    /// PR raised: a wall reached PAST an already-absorbed junction (where the #724 Z-tolerance
     /// check is deliberately bypassed) via a `.convex` edge, with no other, more direct route
     /// from the floor for an earlier BFS visit to have already resolved. `ChFi3d` was
     /// ground-truthed first (`Scripts/repro/762-filleted-pocket-detection/`, fixture 8): at
@@ -147,12 +147,18 @@ struct Issue762ReflexCornerPartialFilletTests {
     /// correctness check on reflex-corner geometry combined with a partial fillet, a
     /// combination nothing else in this file covers.
     ///
-    /// A wider tolerance (1e-3, not the default 1e-4) is used deliberately: at the default,
-    /// WallX0's own measured low-Z bound (-0.0001000...22, a `BRepFilletAPI` corner-blending
-    /// artifact) sits within a hair of the tolerance boundary itself, and whether it clears it
-    /// is numerical noise, not a property of this fix. `Issue762FilletedPocketDetectionTests`
-    /// above already covers the default tolerance on every other fixture; this one is about
-    /// the reflex-corner geometry, not about re-proving the default itself.
+    /// Runs at the DEFAULT tolerance (not a widened one). A second review round found the
+    /// earlier version of this test widened `tolerance` to 1e-3 specifically to make WallX0's
+    /// own near-boundary low-Z bound clear the check reliably, and that widening was concealing
+    /// a real, separate bug (`visited` marked too early, fixed below in
+    /// `Issue762DeadEndRevisitableThroughJunctionTests`): at the default tolerance, on the
+    /// UNFIXED code, whichever way that near-boundary noise happened to fall was the difference
+    /// between "found directly" and "silently dropped forever," not between "found directly"
+    /// and "found through the junction instead." With that bug fixed, WallX0 still does not
+    /// appear at the default tolerance, but for the reason already established above (the
+    /// `.convex` guard, not a numerical coincidence): its only OTHER route is the `.convex`
+    /// edge from the fillet, which stays blocked on purpose. `wallCounts` below is `[2, 4]`,
+    /// not `[3, 5]`, at the default tolerance for exactly that reason.
     ///
     /// The L-shape's own floor splits into two separate, coplanar faces (matched by the sharp,
     /// unfilleted control below), each reporting its own partial wall loop and `isOpen == true`
@@ -192,13 +198,63 @@ struct Issue762ReflexCornerPartialFilletTests {
         #expect(wallY0Edges.count == 1)
         let filleted = try #require(cut.filleted(edges: wallY0Edges, radius: 1.0))
 
-        let pockets = filleted.detectPocketsAAG(tolerance: 1e-3)
+        // Default tolerance: see this test's own doc comment for why WallX0 is correctly
+        // absent here (the `.convex` guard, not a numerical near-miss).
+        let pockets = filleted.detectPocketsAAG()
         #expect(pockets.count == 2)
         let wallCounts = pockets.map { $0.wallFaceIndices.count }.sorted()
-        #expect(wallCounts == [3, 5])
+        #expect(wallCounts == [2, 4])
         for pocket in pockets {
             #expect(pocket.isOpen)
         }
+    }
+}
+
+@Suite("A face rejected as a direct dead end stays reachable through its own junction (#762 review)")
+struct Issue762DeadEndRevisitableThroughJunctionTests {
+
+    /// Review of this fix found `wallsAndJunctions(fromFloor:floorZ:tolerance:)` marked
+    /// `visited` as soon as an edge was crossable, before deciding wall, junction, or dead end.
+    /// A face that failed the #724 Z-check as a DIRECT neighbor (`reachedThroughJunction ==
+    /// false`) was marked visited regardless, so a SEPARATE edge reaching that same face
+    /// through an already-absorbed junction (where the Z-check is bypassed) could never run:
+    /// the face was already, wrongly, closed off.
+    ///
+    /// Ground-truthed rather than assumed (`Sources/OCCTTest/main.swift` scratch diagnostic):
+    /// the partial-fillet fixture's two SHARP walls each have their own low-Z bound offset from
+    /// the floor's exact Z by about `1.5e-7`, a `BRepFilletAPI_MakeFillet` corner-blending
+    /// artifact where each meets the ADJACENT filleted wall's own fillet. That is far below the
+    /// default tolerance (`1e-4`), so it is invisible there, but a deliberately smaller
+    /// tolerance (`1e-8`, well under the measured offset) reliably fails each sharp wall's
+    /// DIRECT concave route from the floor while its OWN fillet's separate, `.concave` (not
+    /// `.convex`, so not screened by that unrelated guard) edge to the same wall would accept
+    /// it unconditionally once reached through the junction, since #724's Z check does not
+    /// apply there.
+    ///
+    /// Proved by injection: temporarily moving `visited.insert(neighbor)` back to before the
+    /// wall/junction/dead-end decision (the original, unfixed placement) and rerunning this
+    /// exact fixture at this exact tolerance drops both sharp walls entirely
+    /// (`wallFaceIndices.count` 4 to 2, `isOpen` false to true); restoring the fix returns both
+    /// walls and the correct enclosed verdict. See the PR body's removal-matrix update for the
+    /// full injection record.
+    @Test("a sharp wall that fails the direct Z-check is still found through its own fillet's junction")
+    func deadEndSharpWallIsStillFoundThroughItsOwnJunction() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
+        #expect(junctionEdges.count == 4)
+        let filleted = try #require(cut.filleted(edges: Array(junctionEdges.prefix(2)), radius: 1.0))
+
+        // Deliberately smaller than the sharp walls' own measured ~1.5e-7 natural offset, so
+        // their direct route fails while the junction route (unconditional past #724's Z
+        // check) still accepts them.
+        let pockets = filleted.detectPocketsAAG(tolerance: 1e-8)
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
     }
 }
 

--- a/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
@@ -265,9 +265,27 @@ struct Issue762DeadEndRevisitableThroughJunctionTests {
 // made no distinction between ENTERING a floor's own fillet and CONTINUING past it into a
 // further corner blend: once `current` was confirmed, every vertical `.smooth` neighbor
 // looked eligible to become the wall, including a corner-blend face that is itself another
-// junction, not the wall at all. These two suites are the guards against that, each proven to
-// matter by actually forcing `currentBordersFloorDirectly` true (its pre-fix effective value)
-// and re-running (see the PR body's removal-matrix update).
+// junction, not the wall at all. These two suites are the guards against that.
+//
+// A fourth review round found the first fix's own gate, `currentBordersFloorDirectly`, asked
+// the wrong question: `adjacencyList[floorIndex][current] != nil`, "does some edge exist
+// between the floor and `current`", not "was `current` reached directly from the floor". Since
+// `adjacencyList` is built for every edge regardless of convexity, a junction that only
+// incidentally touches the floor through a non-crossable edge (measured possible on this
+// codebase: `BRepFilletAPI_MakeFillet`'s own corner-blending, see
+// `Issue762ReflexCornerPartialFilletTests`'s own doc comment re: WallX0) could satisfy it
+// without ever having been reached that way. Fixed by carrying the fact the BFS already knows
+// instead of reconstructing it: each `frontier` entry now pairs a node index with whether IT
+// was reached directly from the floor, decided once at the moment it was enqueued.
+//
+// Proved to matter by a dedicated removal-matrix row, injection E (see
+// `wallsAndJunctions(fromFloor:floorZ:tolerance:)`'s own doc comment and the PR body's
+// "Update 4" section): forcing `currentBordersFloorDirectly` to its pre-fix effective value of
+// `true` fails exactly these two tests and no others in the full `Issue762|Issue753|Issue735|
+// Issue747` suite, which is what makes this row an isolation of THIS specific gate rather than
+// a row that happens to also break under a different guard's removal (injections B and D, which
+// these two tests ALSO fail under, exercise the separate Z-tolerance-bypass mechanism, not this
+// one).
 
 @Suite("A vertical corner-blend fillet is a junction, not a wall (#762 review round 4)")
 struct Issue762VerticalCornerBlendNotAWallTests {

--- a/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
@@ -120,6 +120,88 @@ struct Issue762PartialFilletDetectionTests {
     }
 }
 
+@Suite("An L-shaped pocket's reflex corner, partially filleted, is still measured correctly (#762)")
+struct Issue762ReflexCornerPartialFilletTests {
+
+    /// Built specifically to test a removal-matrix conjunction a review of this fix's PR
+    /// raised: a wall reached PAST an already-absorbed junction (where the #724 Z-tolerance
+    /// check is deliberately bypassed) via a `.convex` edge, with no other, more direct route
+    /// from the floor for an earlier BFS visit to have already resolved. `ChFi3d` was
+    /// ground-truthed first (`Scripts/repro/762-filleted-pocket-detection/`, fixture 8): at
+    /// the reflex vertex of an L-shaped pocket's own floor boundary, the two walls meeting
+    /// there DO share a `.convex` vertical edge (the mirror image of a boss's own corner,
+    /// where two base fillets also meet convexly), confirming the hypothesis. Filleting only
+    /// one of those two walls (WallY0) makes its fillet meet the other, unfilleted wall
+    /// (WallX0) via that same `.convex` edge, past the fillet junction.
+    ///
+    /// Measured, though, that WallX0 is ALSO directly reachable from the floor: unlike this
+    /// fix's other guard fixtures, this is not the floor's own polygon giving it a second
+    /// route (WallX0's floor-junction edge is on the OTHER side of the reflex vertex from the
+    /// filleted wall), but `BRepFilletAPI_MakeFillet`'s own corner-blending, needed to keep
+    /// the result watertight where a fillet ends at an unfilleted reflex corner, reshaping
+    /// WallX0's face so the floor borders it directly too. So this fixture, like the
+    /// through-slot fixture (masked by the floor's own direct edge to the same exterior wall
+    /// the fillet also reaches), does not isolate the `.convex` guard specifically; see the PR
+    /// body for the fuller removal-matrix discussion and why every construction tried reduces
+    /// to the same kind of masking. Kept as a permanent test regardless: it is a real
+    /// correctness check on reflex-corner geometry combined with a partial fillet, a
+    /// combination nothing else in this file covers.
+    ///
+    /// A wider tolerance (1e-3, not the default 1e-4) is used deliberately: at the default,
+    /// WallX0's own measured low-Z bound (-0.0001000...22, a `BRepFilletAPI` corner-blending
+    /// artifact) sits within a hair of the tolerance boundary itself, and whether it clears it
+    /// is numerical noise, not a property of this fix. `Issue762FilletedPocketDetectionTests`
+    /// above already covers the default tolerance on every other fixture; this one is about
+    /// the reflex-corner geometry, not about re-proving the default itself.
+    ///
+    /// The L-shape's own floor splits into two separate, coplanar faces (matched by the sharp,
+    /// unfilleted control below), each reporting its own partial wall loop and `isOpen == true`
+    /// since neither alone fully encloses the combined L cavity. That split is pre-existing,
+    /// present identically before and after filleting, and not something this fix changes or
+    /// needs to change.
+    @Test("the sharp L-shaped pocket (control) reports two open, coplanar floor pieces")
+    func sharpLShapedPocketReportsTwoOpenFloors() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let toolA = try #require(Shape.box(origin: SIMD3(-6, -6, 0), width: 12, height: 6, depth: 10))
+        let toolB = try #require(Shape.box(origin: SIMD3(-6, 0, 0), width: 6, height: 6, depth: 10))
+        let toolL = try #require(toolA.union(toolB))
+        let cut = try #require(box.subtracting(toolL))
+
+        let pockets = cut.detectPocketsAAG()
+        #expect(pockets.count == 2)
+        for pocket in pockets {
+            #expect(pocket.isOpen)
+        }
+    }
+
+    @Test("an L-shaped pocket with one reflex-corner wall filleted is still measured, and stays open")
+    func filletedReflexCornerPocketIsStillMeasured() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let toolA = try #require(Shape.box(origin: SIMD3(-6, -6, 0), width: 12, height: 6, depth: 10))
+        let toolB = try #require(Shape.box(origin: SIMD3(-6, 0, 0), width: 6, height: 6, depth: 10))
+        let toolL = try #require(toolA.union(toolB))
+        let cut = try #require(box.subtracting(toolL))
+
+        // WallY0: the floor/wall junction edge at y=0, z=0, x in [0,6] (bounds the reflex
+        // corner's own material block from below).
+        let wallY0Edges = cut.edges(where: { edge in
+            abs(edge.bounds.min.z) < 1e-6 && abs(edge.bounds.max.z) < 1e-6 &&
+            abs(edge.bounds.min.y) < 1e-6 && abs(edge.bounds.max.y) < 1e-6 &&
+            edge.bounds.min.x > -1e-6 && edge.bounds.max.x > 5.9 && edge.bounds.max.x < 6.1
+        })
+        #expect(wallY0Edges.count == 1)
+        let filleted = try #require(cut.filleted(edges: wallY0Edges, radius: 1.0))
+
+        let pockets = filleted.detectPocketsAAG(tolerance: 1e-3)
+        #expect(pockets.count == 2)
+        let wallCounts = pockets.map { $0.wallFaceIndices.count }.sorted()
+        #expect(wallCounts == [3, 5])
+        for pocket in pockets {
+            #expect(pocket.isOpen)
+        }
+    }
+}
+
 // MARK: - False-positive guards
 
 // #762 named the risk explicitly: "transitive tangency could sweep in faces that are not

--- a/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift
@@ -1,0 +1,250 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #762: a fillet at a pocket's floor/wall junction is tangent to both surfaces
+// (`ChFi3d::DefineConnectType` reports `.smooth` at both new edges, by construction, since a
+// fillet is G1-continuous with both faces it blends), so `concaveNeighbors(of:)` finds
+// nothing and `detectPocketsAAG()` cannot see the pocket at all. A chamfer has the same
+// missing-pocket symptom for a different, independently measured reason: both its new edges
+// ARE `.concave`, but the chamfer face itself fails the wall's own `isVertical` filter, and
+// the pre-fix search never continued past it to the true wall.
+//
+// Ground-truthed against `ChFi3d::DefineConnectType` directly before writing this fix, in
+// `Scripts/repro/762-filleted-pocket-detection/`, across a sharp control, four fillet
+// radii, a chamfer, a partially-filleted pocket, a filleted through-slot, a filleted boss,
+// and a filleted plain box (the last two are false-positive guards, not detection targets).
+//
+// Fixed in `AAG.wallsAndJunctions(fromFloor:floorZ:tolerance:)`
+// (`Sources/OCCTSwift/FeatureRecognition.swift`): trace concave edges AND `.smooth` edges
+// into a confirmed radially-inward fillet outward from the floor, absorbing any junction
+// face found along the way, until a genuine vertical wall is reached. See that method's own
+// doc comment for the full mechanism and why a chain-discovered wall skips the #724
+// Z-tolerance check that a direct concave neighbor still has to pass.
+
+@Suite("A filleted pocket's floor/wall junction is detected through the fillet (#762)")
+struct Issue762FilletedPocketDetectionTests {
+
+    /// The issue's own construction, byte for byte: a 10x10x15 pocket in a 20mm cube. Confirms
+    /// the sharp version is detected and enclosed. This is the fixture the fillet variants
+    /// below are built from, so a negative result there is meaningful only against this
+    /// positive control.
+    @Test("the sharp pocket (control) is detected and enclosed")
+    func sharpPocketIsDetectedAndEnclosed() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let pockets = cut.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
+    }
+
+    /// Filleting all four floor/wall junction edges must NOT make the pocket disappear.
+    /// Radii 0.5 through 4, matching the range #753 originally measured as "not detected."
+    @Test("a filleted floor/wall junction pocket IS detected and enclosed", arguments: [0.5, 1.0, 2.0, 4.0])
+    func filletedJunctionPocketIsDetected(radius: Double) throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
+        #expect(junctionEdges.count == 4)
+        let filleted = try #require(cut.filleted(edges: junctionEdges, radius: radius))
+
+        let pockets = filleted.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
+        #expect(abs(pocket.zLevel) < 1e-6)
+    }
+}
+
+@Suite("A chamfered pocket's floor/wall junction is detected through the chamfer (#762)")
+struct Issue762ChamferedPocketDetectionTests {
+
+    /// Ground-truthed: a symmetric chamfer's two new edges are both `.concave` (a 270-degree
+    /// reentrant corner splits into two 225-degree ones), so `concaveNeighbors(of:)` already
+    /// reaches the chamfer directly. The pre-fix miss was the chamfer face's own
+    /// `isVertical` filter stopping the search one hop too early, not a missing edge.
+    @Test("a chamfered floor/wall junction pocket IS detected and enclosed")
+    func chamferedJunctionPocketIsDetected() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let allEdges = cut.edges()
+        let allFaces = cut.faces()
+        var chamferSpecs: [(edgeIndex: Int, faceIndex: Int, dist1: Double, dist2: Double)] = []
+        for (i, edge) in allEdges.enumerated() {
+            guard abs(edge.bounds.min.z) < 1e-6, abs(edge.bounds.max.z) < 1e-6 else { continue }
+            guard let (face1, _) = edge.adjacentFaces(in: cut) else { continue }
+            guard let faceIndex = allFaces.firstIndex(where: { abs($0.area() - face1.area()) < 1e-6 }) else { continue }
+            chamferSpecs.append((edgeIndex: i, faceIndex: faceIndex, dist1: 1.0, dist2: 1.0))
+        }
+        #expect(chamferSpecs.count == 4)
+        let chamfered = try #require(cut.chamferedTwoDistances(chamferSpecs))
+
+        let pockets = chamfered.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
+    }
+}
+
+@Suite("A pocket filleted on only some junctions mixes direct and chained wall discovery (#762)")
+struct Issue762PartialFilletDetectionTests {
+
+    /// Two of the four floor/wall edges filleted, two left sharp: the sharp pair must still be
+    /// found directly (concave, one hop) and the filleted pair through the chain, in the same
+    /// pocket, with all four walls present and the pocket still enclosed.
+    @Test("a pocket filleted on only some junctions is still fully detected and enclosed")
+    func partiallyFilletedPocketIsDetected() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let pocketTool = try #require(Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(pocketTool))
+
+        let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
+        #expect(junctionEdges.count == 4)
+        let filleted = try #require(cut.filleted(edges: Array(junctionEdges.prefix(2)), radius: 1.0))
+
+        let pockets = filleted.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 4)
+        #expect(!pocket.isOpen)
+    }
+}
+
+// MARK: - False-positive guards
+
+// #762 named the risk explicitly: "transitive tangency could sweep in faces that are not
+// walls at all." These three suites are the guards against that, each proven to matter by
+// actually removing it (see the PR body's removal matrix) rather than by inspection alone.
+
+@Suite("A filleted through-slot stays open, matching its sharp counterpart's own verdict (#762)")
+struct Issue762FilletedThroughSlotStaysOpenTests {
+
+    /// The sharp two-walled through-slot (`Issue735PocketEnclosureTests
+    /// .twoWalledThroughSlotIsNotEnclosed`'s own fixture): both ends open, `isOpen == true`.
+    @Test("the sharp through-slot (control) is not enclosed")
+    func sharpThroughSlotIsNotEnclosed() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.box(origin: SIMD3(-15, -3, 0), width: 25, height: 6, depth: 10))
+        let cut = try #require(box.subtracting(tool))
+
+        let pockets = cut.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 2)
+        #expect(pocket.isOpen)
+    }
+
+    /// Filleting the slot's two long floor/wall junctions must not close it: the two walls
+    /// are now found through their fillets (0 walls pre-fix, since `concaveNeighbors(of:)`
+    /// found nothing at all through a tangent junction), but the two open ends still have no
+    /// neighbor whatsoever there (a `.convex` edge to the box's own exterior side wall), so
+    /// nothing is absorbed on those sides and the enclosure test still sees the gap.
+    @Test("a filleted through-slot is still not enclosed")
+    func filletedThroughSlotIsNotEnclosed() throws {
+        let box = try #require(Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(Shape.box(origin: SIMD3(-15, -3, 0), width: 25, height: 6, depth: 10))
+        let cut = try #require(box.subtracting(tool))
+
+        let longEdges = cut.edges(where: { edge in
+            abs(edge.bounds.min.z) < 1e-6 && abs(edge.bounds.max.z) < 1e-6 &&
+            (edge.bounds.max.x - edge.bounds.min.x) > 15.0
+        })
+        #expect(longEdges.count == 2)
+        let filleted = try #require(cut.filleted(edges: longEdges, radius: 1.0))
+
+        let pockets = filleted.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.wallFaceIndices.count == 2)
+        #expect(pocket.isOpen)
+    }
+}
+
+@Suite("A filleted boss is not falsely reported as an ENCLOSED pocket (#762)")
+struct Issue762FilletedBossFalsePositiveTests {
+
+    /// Ground-truthed (`Scripts/repro/762-filleted-pocket-detection/`): a boss's own base
+    /// junction is a reentrant (270-degree material) corner, geometrically identical in kind
+    /// to a pocket's own floor/wall corner. Filleting it gives the IDENTICAL
+    /// radially-inward signature a pocket's fillet does, so this fix cannot and does not try
+    /// to distinguish the two AT the junction. `Issue753PocketBossWireScopeTests` already
+    /// established that a floor boss's wall legitimately belongs in `wallFaceIndices`
+    /// (sharp, pre-#762): measured directly, a SHARP boss standing alone on a bare plate
+    /// already reports `1 pocket, isOpen: true` before this fix. There was never a "0
+    /// pockets" baseline to preserve for a boss. The property that actually matters is that a
+    /// filleted boss produces the SAME verdict a sharp one does, never a false ENCLOSED
+    /// (`isOpen == false`) pocket.
+    @Test("the sharp boss (control) reports isOpen == true, not zero pockets")
+    func sharpBossReportsOpenNotZero() throws {
+        let plate = try #require(Shape.box(origin: SIMD3(-10, -10, -5), width: 20, height: 20, depth: 5))
+        let boss = try #require(Shape.box(origin: SIMD3(-3, -3, 0), width: 6, height: 6, depth: 8))
+        let fused = try #require(plate.union(boss))
+
+        let pockets = fused.detectPocketsAAG()
+        #expect(pockets.count == 1)
+        guard let pocket = pockets.first else { return }
+        #expect(pocket.isOpen)
+    }
+
+    /// The false-positive guard: filleting the boss's base must not turn this into a false
+    /// ENCLOSED pocket. It is fine (and consistent with the sharp control) for it to still
+    /// appear in the array, as long as it is correctly `isOpen`.
+    @Test("a filleted boss reports isOpen == true, matching its sharp counterpart, never falsely enclosed")
+    func filletedBossIsNeverFalselyEnclosed() throws {
+        let plate = try #require(Shape.box(origin: SIMD3(-10, -10, -5), width: 20, height: 20, depth: 5))
+        let boss = try #require(Shape.box(origin: SIMD3(-3, -3, 0), width: 6, height: 6, depth: 8))
+        let fused = try #require(plate.union(boss))
+
+        let baseEdges = fused.edges(where: { edge in
+            abs(edge.bounds.min.z) < 1e-6 && abs(edge.bounds.max.z) < 1e-6 &&
+            edge.bounds.min.x > -3.5 && edge.bounds.max.x < 3.5 &&
+            edge.bounds.min.y > -3.5 && edge.bounds.max.y < 3.5
+        })
+        #expect(baseEdges.count == 4)
+        let filletedBoss = try #require(fused.filleted(edges: baseEdges, radius: 1.0))
+
+        let pockets = filletedBoss.detectPocketsAAG()
+        // Either the boss's fillet is absorbed and the plate's top is reported as an open
+        // "pocket" (matching the sharp control), or it is not reported at all: both are
+        // safe. What must never happen is a pocket entry with isOpen == false.
+        for pocket in pockets {
+            #expect(pocket.isOpen)
+        }
+    }
+}
+
+@Suite("A plain box with its own exterior edges filleted is never reported as any pocket (#762)")
+struct Issue762FilletedExternalCornerFalsePositiveTests {
+
+    /// The radial-curvature guard's own reason for existing: a plain box's own top-to-side
+    /// edge is genuinely CONVEX (material occupies only 90 degrees there, not a reentrant
+    /// 270), so filleting it curves radially OUTWARD, the opposite signature from a pocket's
+    /// or a boss's fillet. Without `isRadiallyInwardFillet(_:)` gating which `.smooth` edges
+    /// are crossable, this fixture is wrongly reported as an ENCLOSED pocket (proven by
+    /// actually removing the guard: see the PR body's removal matrix, injection A).
+    @Test("the sharp box (control) has no pockets")
+    func sharpBoxHasNoPockets() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        #expect(box.detectPocketsAAG().isEmpty)
+    }
+
+    @Test("a box with its own top exterior edges filleted still has no pockets")
+    func filletedExteriorEdgeBoxHasNoPockets() throws {
+        let box = try #require(Shape.box(width: 20, height: 20, depth: 20))
+        let topEdges = box.edges(where: { abs($0.bounds.min.z - 10) < 1e-6 && abs($0.bounds.max.z - 10) < 1e-6 })
+        #expect(topEdges.count == 4)
+        let filletedTop = try #require(box.filleted(edges: topEdges, radius: 2.0))
+
+        #expect(filletedTop.detectPocketsAAG().isEmpty)
+    }
+}


### PR DESCRIPTION
## What & why

`AAG.detectPockets(tolerance:)` selected a floor's walls from `concaveNeighbors(of:)`. A fillet
at a pocket's floor/wall junction is tangent to both surfaces (`ChFi3d::DefineConnectType`
reports `.smooth` at both new edges, by construction: a fillet is G1-continuous with both
faces it blends), so `concaveNeighbors(of:)` found nothing and `detectPocketsAAG()` could not
see the pocket at all. A chamfer had the same missing-pocket symptom for a different reason:
both its new edges genuinely classify `.concave`, but the chamfer face is planar at an
intermediate angle, fails the wall's own `isVertical` filter, and the pre-fix search never
continued past it to the real wall beyond.

Since nearly every real machined pocket has a filleted floor/wall junction (an endmill cannot
cut a sharp internal corner), this was total non-detection of the pockets anyone would
actually machine.

Closes #762

Fixed by tracing outward from the floor through any non-wall face reached via a `.concave`
edge (a chamfer, unconditionally) or a `.smooth` edge into a face confirmed to curve the right
way (a fillet, gated by a new radially-inward test), absorbing each junction face until a
genuine vertical wall is reached. See `AAG.wallsAndJunctions(fromFloor:floorZ:tolerance:)`'s own
doc comment (`Sources/OCCTSwift/FeatureRecognition.swift`) for the full mechanism.

## Ground truth first (`Scripts/repro/762-filleted-pocket-detection/`)

Per `docs/v2.0.0-plan.md`'s census-once rule and #723/#747's own precedent, `ChFi3d::DefineConnectType`
was measured directly (same call, same arguments `OCCTEdgeGetConvexity` uses) against a sharp,
filleted (four radii), chamfered, partially-filleted, filleted-through-slot, and filleted-boss
fixture set before any criterion was written.

| # | fixture | floor/wall junction | pre-fix | post-fix |
|---|---|---|---|---|
| 1 | Sharp pocket (control) | `.concave`, direct | 1, enclosed | 1, enclosed (unchanged) |
| 2 | Filleted pocket, r = 0.5/1/2/4 | floor `.smooth` to cylinder `.smooth` to wall | **0** | 1, enclosed |
| 3 | Chamfered pocket, d = 1.0 | floor `.concave` to chamfer `.concave` to wall | **0** | 1, enclosed |
| 4 | Partially filleted (2 of 4 edges) | mixed direct + chained | **0** | 1, enclosed |
| 5 | Filleted through-slot (open both ends) | 2 walls via fillet, 2 open ends `.convex` | 0 | 1, **open** (unchanged verdict) |
| 6 | Filleted boss (convex feature) | floor `.smooth` to cylinder `.smooth` to boss wall | 0 | 1, **open** (matches sharp boss) |
| 7 | Plain box, own top exterior edges filleted | floor `.smooth` to cylinder, radially OUTWARD | 0 | **0** (must never become 1) |
| 8 | L-shaped pocket, reflex corner, one of the two reflex-corner walls filleted (added during review, see "Removal matrix, final" below) | floor `.smooth` to fillet `.smooth`, then `.convex` to the unfilleted wall | n/a | 2 pockets (the L's own coplanar floor split), both open |
| 9 | South floor/wall junction filleted (r=3), plus a SEPARATELY filleted vertical corner (r=2) between west and south, west's own junction left sharp (added during a third review round, see "Update 3" below) | floor `.smooth` to horizontal fillet `.smooth` to torus `.smooth` to vertical corner-blend cylinder | n/a | 1 pocket, 4 walls, enclosed; the corner-blend cylinder correctly excluded |
| 10 | Fully rounded pocket: all four floor/wall junctions filleted (r=3) AND all four vertical corners separately filleted (r=2) (added during the same round, a stress generalization of fixture 9) | a torus/corner-fillet ring: 8 curved junction faces plus 4 BSpline corner-reconciliation faces | n/a | 1 pocket, exactly 4 (flat) walls, enclosed; all 12 curved/freeform faces correctly excluded |

Full edge-by-edge measurement (fixtures 1-6 measured before the fix, fixture 8 added during a
second review round, fixtures 9-10 added during a third) in `ground-truth-output.txt`; method and
reasoning in `README.md`.

**A hypothesis the measurement corrected**: the natural first idea (mirroring #747/#760's
material-side test for holes) was that a pocket's fillet curves radially inward while a boss's
curves radially outward, so the sign alone would tell them apart. Measured, this is wrong:
fixture 6 (boss) gives the identical `INWARD` signature as fixture 2 (pocket). A boss's base
junction is a reentrant (270 degree material) corner, geometrically the same shape as a
pocket's floor/wall corner. The radial test's real job is refusing to chain through a
genuinely convex/external fillet (fixture 7), not distinguishing a pocket from a boss. That
distinction already exists, unchanged, in `PocketFeature.isOpen`'s outer-wire-scoped
enclosure test (#753).

## `detectHoles()`: checked, not assumed

The issue asked whether #760's rewrite of `detectHoles()` (surface type + closed-in-U +
material side, no neighbor-convexity dependency) shares this blindness. Measured directly: a
filleted hole rim still reports 1 hole (depth correctly shrinks by the fillet's own extent,
since the wall really is shorter); a chamfered rim reports 2 holes (the cylindrical bore plus
the countersink's own conical segment, exactly what `detectHoles()`'s doc comment already
documents a conical wall as meaning). It never reports zero. **Not affected; nothing filed.**

## Removal matrix, final

**Update 2**: a further review found a real bug in `wallsAndJunctions`, and fixing it changed the
"Removal matrix, corrected" conclusion below from the previous update. `visited.insert(neighbor)`
fired as soon as an edge was crossable, before deciding wall, junction, or dead end. A face
rejected as a direct dead end (fails the #724 Z-check with `reachedThroughJunction == false`) was
marked visited regardless, permanently closing off a separate edge that could have reached the
same face through an already-absorbed junction, where the Z-check is bypassed and would have
accepted it. Fixed by marking `visited` only in the wall and junction branches, leaving a dead end
revisitable. New test, proven to fail on the unfixed code:
`Issue762DeadEndRevisitableThroughJunctionTests` (the partial-fillet fixture's sharp walls have a
natural ~1.5e-7 low-Z offset, invisible at the default tolerance but decisive at `1e-8`, where the
direct route fails and only the junction route accepts them).

This bug is also why the previous "Removal matrix, corrected" section's own conclusion about
`.convex` was itself wrong, not just incomplete: both fixtures built to isolate that guard
(fixture 5, the filleted through-slot; fixture 8, the L-shaped reflex corner) had their masking
DIRECT routes REJECTING (near-boundary Z-tolerance noise), and a rejected direct neighbor used to
be marked `visited` anyway, closing off `.convex`'s own path regardless of `.convex` itself.
`Issue762ReflexCornerPartialFilletTests` is now restored to the default tolerance (was widened to
`1e-3`, which is what let it clear the direct route and conceal this). With the bug fixed,
injection C (disabling `.convex` alone) now genuinely fails on both fixtures:

| fixture | before injection C | under injection C |
|---|---|---|
| Filleted through-slot | `wallFaceIndices.count` 2, `isOpen` true | `wallFaceIndices.count` **4**, `isOpen` **false** |
| L-shaped pocket, reflex corner | `wallCounts` `[2, 4]` | `wallCounts` `[2, **5**]` |

The earlier "geometric argument" for why `.convex` could never matter is retracted, not
superseded: it was true of the buggy code (a rejected direct neighbor's `visited` marking made
its failure equivalent to success, closing the second route either way), never true of the
geometry itself.

Four injections, each disabled independently (then B+C together), full 22-test suite
(`Issue762FilletedPocketDetectionTests.swift` plus the related `#753`/`#735` suites) re-run after
each. See "Update 3" below for the re-run after that suite grew by two more tests.

Also factored `isRadiallyInwardFillet(_:)` and `detectHoles()`'s own inline radial material-side
test (identical down to the `1e-9` guard, differing only in sphere handling) into one shared
helper, `AAG.isMaterialRadiallyInward(of:revolution:uv:allowSphere:)`. #723 and #747 both already
fixed this exact test once; a third copy was a second chance to miss the next fix.
`detectHoles()`'s own tests (`Issue747DetectHolesConvexClassifierTests`) pass unchanged.

## Update 3: entering vs. continuing a junction were fused into one OR

A third review round found the `.smooth` crossable test for a face reached from an
already-confirmed fillet, `neighborNode.isVertical || isRadiallyInwardFillet(neighbor)`, made no
distinction between ENTERING a floor's own fillet and CONTINUING past it into a further corner
blend. This traces back to the original crossable test's own shape,
`isRadiallyInwardFillet(edge.face1Index) || isRadiallyInwardFillet(edge.face2Index)`:
`buildGraph()` always populates `face1Index`/`face2Index` as exactly `{current, neighbor}`, so
that OR is provably identical to `isRadiallyInwardFillet(current) ||
isRadiallyInwardFillet(neighbor)`. Once `current` is confirmed, its own half is trivially true,
making the far side irrelevant to crossability.

Built to prove this is reachable rather than argued, per the review's explicit instruction (this
guard's own history above already went from "looks decorative" to "proven load-bearing" once a
real bug was fixed underneath it, so a third "this can't happen" claim was not going to be
accepted without a fixture): fixtures 9 and 10. Before this fix, fixture 9 reports `floor=6
walls=[0, 2, 3, 7, 8]`, five wall indices, node 2 being the corner-blend cylinder wrongly promoted.
Fixture 10 generalizes this to all four corners: `walls=[0, 2, 3, 8, 9, 10, 11, 12]`, all four
corner-blend cylinders wrongly promoted.

**A first fix was tried and regressed real tests.** Requiring `isVertical && isPlanar` for a wall
candidate broke `Issue735PocketEnclosureTests.cylindricalPocketIsEnclosed` and two floor-boss
enclosure tests: a sharp cylindrical pocket's own bore, and a boss's cylindrical side wall, are
genuinely curved walls reached directly, and `isPlanar` excluded them too. `isPlanar` answers "is
this face flat," not "is this face a wall of this floor's own pocket," and the two questions
diverge exactly on a curved genuine wall.

**Fixed with `currentBordersFloorDirectly`**: a wall can only be accepted from a position that is
the floor itself, or a junction whose own entering edge came directly from the floor (the fillet
or chamfer built to blend the floor to its wall specifically, which by construction has exactly
two "long" tangent/concave relationships and nothing else). A junction reached only through
another junction absorbs its vertical neighbor as a further junction instead, regardless of the
#724 Z-check, keeping the search going without wrongly promoting it. Both fixtures now report
exactly the intended walls, all planar, with every corner-blend cylinder and BSpline absorbed as a
junction instead.

**Why not a hop limit** (the review's own question, "prefer something principled"): measured, not
assumed, every wall in fixture 10 is found in exactly one hop past its own floor-bordering
horizontal fillet, even though the same shape also offers a longer route to the same wall through
its own vertical corner cylinder and BSpline. The BFS finds a wall by whichever route reaches it
first, so the longer route is never actually needed. `currentBordersFloorDirectly` gates on a
structural fact (whether `current`'s own entering edge came from the floor) rather than a hop
count, because a fillet is built to blend exactly the two named faces it sits between: a
floor-bordering fillet's OTHER tangent relationship is its wall by construction, independent of
how much unrelated corner-to-corner chaining exists elsewhere in the graph. Termination does not
depend on this gate either: `visited` already bounds the total work to this floor's own face
count regardless of how many junction faces a chain absorbs.

Full removal matrix (A-D) re-run against the grown suite, since crossability rules changed what
each injection reaches:

| injection | what was disabled | tests that failed |
|---|---|---|
| A | the `.smooth`-edge radially-inward gate made unconditionally crossable | 3, unchanged from before this update |
| B | the Z-tolerance bypass for chain-discovered walls removed | 12: the same 10 as before this update, plus the fixture-9 corner-blend test and the fixture-10 ring test |
| C | the `.convex` edge block made unconditionally crossable, alone | **2**, unchanged from before this update |
| D | B and C together | 12, identical to B's own failure set |

The two new tests fold into B/D exactly where their own fillet-chain mechanism predicts (removing
the Z-tolerance bypass breaks every chain-discovered wall the same way), and neither appears under
A or C, confirming `currentBordersFloorDirectly` is independent of those two guards rather than
overlapping or subsuming them.

Full 5500-test suite, all 5 gate scripts plus self-tests, and the census/changelog-transcription
self-tests all pass after this update.

## Update 4: `currentBordersFloorDirectly` reconstructed a fact the BFS already knew, and got it wrong

A fourth review round found two problems, both confirmed and both fixed.

**Finding 1: the gate asked the wrong question.** `currentBordersFloorDirectly` first shipped as
`adjacencyList[floorIndex][current] != nil`, "does some edge exist between the floor and
`current`", which is not "was `current` reached directly from the floor". `adjacencyList` is built
for every edge regardless of convexity, so a junction that only incidentally touches the floor
through a non-crossable edge would satisfy the check without ever having been reached that way.
Not hypothetical: `BRepFilletAPI_MakeFillet`'s own corner-blending is documented, in
`Issue762ReflexCornerPartialFilletTests`'s own doc comment (re: WallX0), to reshape an unrelated
face so the floor borders it directly by incident, not by the route actually taken to reach it.

Fixed by carrying the fact instead of reconstructing it. The BFS frontier changed from `[Int]` to
`[(index: Int, bordersFloorDirectly: Bool)]`: each entry pairs a node with whether IT was reached
directly from the floor, decided once at the moment it is enqueued. This never consults
`adjacencyList[floorIndex]` at all, so it cannot be fooled by an incidental edge.

**Finding 2: no removal-matrix row isolated this gate.** The two round-4 tests only failed as
collateral under injection B/D (the Z-tolerance bypass), a different mechanism, and a test comment
pointed at "the PR body's removal-matrix update" for proof that was not there. This is the third
guard on this PR believed proven by a row that was actually exercising something else (injection C
was masked by the `visited` bug; injections B and D backstop each other).

Fixed with a dedicated injection E: force `currentBordersFloorDirectly` to its pre-fix effective
value of `true`, and confirm the failure set is disjoint from every other injection's own.
Measured: exactly `Issue762VerticalCornerBlendNotAWallTests`/`Issue762FullyRoundedPocketChainingTests`
fail, and no other test in the 34-test suite. Fixed the test comment's dangling pointer to
reference this row.

Full matrix, A through E, each row's isolation restated and re-confirmed:

| injection | disables | isolates | tests that fail |
|---|---|---|---|
| A | the `.smooth`-edge radially-inward gate | whether a fillet is confirmed reentrant before crossing into it | 3: plain-box exterior fillet, both L-shape tests |
| B | the #724 Z-tolerance bypass for chain-discovered walls | whether a chain-discovered wall is trusted by contiguity instead of its own Z | 12: every fillet/chamfer/chain-discovered-wall test, including both round-4 tests (a different mechanism than E) |
| C | the `.convex` edge block | whether a reentrant-the-wrong-way edge is refused | 2: filleted through-slot, L-shape reflex corner |
| D | B and C together | both of the above at once | 12, identical to B's own set |
| E | `currentBordersFloorDirectly`, forced `true` | whether a wall can only be accepted from the floor itself or a junction that borders it directly | **2**: exactly the two round-4 tests, and only those |

Full 5500-test suite (unchanged count; no new fixture, only the isolating injection), all 5 gate
scripts plus self-tests, and the census/changelog-transcription self-tests all pass after this
update.

## `Issue753FilletedJunctionNotDetectedTests` inverted

Per the brief, this characterization test could not simply be deleted: it pinned the exact
behavior #762 fixes. Renamed `Issue753FilletedJunctionDetectedTests`, its single assertion
flipped from `postPockets.isEmpty` to `postPockets.count == 1` with `!isOpen` and 4 walls, and
its surrounding comment rewritten to say what it proves today instead of what it used to pin
(`Tests/OCCTModelingTests/Issue735PocketEnclosureTests.swift`).

## CHANGELOG entry

### `detectPocketsAAG()` now finds a pocket whose floor/wall junction is filleted or chamfered (#762)

A fillet at a pocket's floor/wall junction is tangent to both surfaces (`ChFi3d::DefineConnectType`
reports `.smooth` at both new edges by construction), so `concaveNeighbors(of:)` found nothing
and the pocket was invisible. A chamfer's two new edges classify `.concave` correctly, but the
chamfer face is planar at an intermediate angle and fails the wall's own `isVertical` filter,
so the search never continued past it. Since nearly every real machined pocket has a filleted
floor/wall junction, this was non-detection of the pockets anyone would actually cut, not an
edge case.

Fixed by tracing outward from the floor through any absorbed junction face, a chamfer via its
own correct `.concave` classification, a fillet via a new radially-inward curvature test, until
a genuine wall is reached. Ground-truthed against `ChFi3d::DefineConnectType` directly first
(`Scripts/repro/762-filleted-pocket-detection/`), including false-positive guards for a
filleted through-slot (must stay open), a filleted boss (must never report a false *enclosed*
pocket), and a plain box with its own exterior edges filleted (must report no pocket at all).

```swift
let box = Shape.box(width: 20, height: 20, depth: 20)!
let pocketTool = Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15)!
let cut = box.subtracting(pocketTool)!
let junctionEdges = cut.edges(where: { abs($0.bounds.min.z) < 1e-6 && abs($0.bounds.max.z) < 1e-6 })
let filleted = cut.filleted(edges: junctionEdges, radius: 1.0)!
print(filleted.detectPocketsAAG().count)   // 1, was 0
```

`detectHoles()` was checked against the same blindness and found unaffected (see above); no
change made there.

## SemVer impact

MINOR. `detectPocketsAAG()`/`AAG.detectPockets(tolerance:)` now return pockets they previously
missed entirely for filleted or chamfered floor/wall junctions, which is new, additive
detection capability rather than a behavior change to any case that was previously correct. No
public signature changed. It is not a pure bugfix PATCH because the change is large enough in
practical effect (most real machined pockets now detected for the first time) that a consumer
relying on the old "filleted pockets are invisible" behavior as a signal (unlikely, but not
impossible) would see a real difference in output shape (an array that used to come back empty
or without a given entry now returns a populated `PocketFeature`). A caller iterating
`detectPocketsAAG()` results and adding new logic per pocket would see more, correct, entries.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR:
      `Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift` (15 tests across 10
      suites, including the 4-radius parameterized fillet test, the reflex-corner suite, the
      dead-end/visited-marking suite, the 2 junction-to-junction-chaining suites added in Update
      3, and the 3 false-positive-guard suites), plus the inverted
      `Issue753FilletedJunctionDetectedTests`.
- [x] Every new test and every new `--self-test` case was run once with its subject broken; see
      the removal matrix above (injections A through E, each row's own isolation confirmed) and
      Update 3/4's own re-runs.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- Diff confined to `Sources/OCCTSwift/FeatureRecognition.swift` (`detectPockets`, the
  `wallsAndJunctions`/`isRadiallyInwardFillet` helpers, the new shared
  `isMaterialRadiallyInward`, `detectHoles()`'s own use of it, and `isEdgeCoveredByAWall`'s
  renamed parameter), `Tests/OCCTModelingTests/Issue735PocketEnclosureTests.swift` (the one
  inverted suite), `Tests/OCCTModelingTests/Issue762FilletedPocketDetectionTests.swift`, and the
  `Scripts/repro/762-filleted-pocket-detection/` ground-truth artifact.
- `PocketFeature.wallFaceIndices` keeps exactly its pre-existing meaning (the true vertical
  walls); the absorbed junction faces (fillets/chamfers) are used internally for the enclosure
  test but are not exposed as a new public field, to keep the change minimal.
- `Sources/OCCTTest/main.swift` was used as a scratch measurement harness across review rounds
  (confirming pre/post-fix counts on every fixture, the `detectHoles()` check, the L-shape
  fixture's exact topology via its own bounding boxes, and the partial-fillet fixture's natural
  `~1.5e-7` Z-noise) and is restored byte-identical each time (`git diff --exit-code
  Sources/OCCTTest/main.swift` is clean).
- Full suite (`swift test`): 5500 tests, all passing (was 5495 before the first review round,
  5498 before Update 3, unchanged at 5500 through Update 4). All 5 static gate scripts
  (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
  `derive-bridge-header-split --verify`, `count-operations`) and their/the census's/the
  changelog-transcription audit's `--self-test`s pass clean.
- Targets `refactor/381-pass1b` per instruction, not `main`.




