### PR TITLE
docs: three lessons from pass 1b, each rediscovered two or three times

### DIFF
--- a/okf/policies/measure-dont-assume.md
+++ b/okf/policies/measure-dont-assume.md
@@ -56,6 +56,46 @@ The pattern is one thing. In each case a value that could have been observed was
 from something adjacent to it, and the computation was wrong in a way that produced a plausible
 number rather than an obvious error.
 
+## The adjacent number reads as the one you need
+
+Every failure in the "Why" section above is a value computed from something next to the value
+wanted. That is the whole mechanism, and naming it is more useful than the instances, because the
+wrong number is always plausible: it has the right type, the right order of magnitude, and it came
+from a real measurement of a real thing.
+
+More instances, all 2026-08-07:
+
+- **A benchmark of the wrong function.** `#772`'s timing table justified an opt-in default by
+  measuring `isSelfIntersecting(timeout:)`. The parameter that shipped called
+  `isSelfIntersecting(hardTimeout:)`, a different mechanism with a `deepCopy()`, a background
+  dispatch, and an inner call passing `0` as its bound. Re-measured, the conclusion held but for a
+  different reason, and the mechanism was swapped.
+- **A neighbouring fixture's figures.** `#597`'s claim that no threshold could separate a diverged
+  fit from a healthy one cited numbers belonging to a different fixture. The two regressing tests'
+  own values were never taken, and when taken they sat three orders of magnitude away, which
+  narrowed the conclusion from impossible to unjustified.
+- **A census keyed on one spelling.** My own stray-modification check reported a file as unowned
+  because it matched `diff --git` headers, and one of fifteen patches is a bare unified diff. Ten
+  seconds of parser, a false alarm about a kernel about to be published.
+
+The tell is that you did not take the measurement, you took **a** measurement. Ask what exactly was
+measured, of what exactly, and whether that is the thing the claim is about.
+
+## An argument that explains everything may be describing a defect
+
+The hardest case, because it does not feel like an assumption. You measure, you find a consistent
+pattern, and you write a correct-looking explanation of it. The explanation is of the bug.
+
+`#762` spent a round establishing that a guard could not matter. Two fixtures were built to isolate
+it and both were masked; a geometric argument was written for why every construction reduces to the
+same masking; it was scoped honestly as an argument rather than a proof, and it explained all seven
+fixtures. It was describing a `visited`-marking bug two functions away. Fixing that made the guard's
+removal fail immediately, and the argument was retracted in the source rather than deleted.
+
+The tell, in hindsight: it was an argument for why **a piece of code could never matter**. Treat
+that with the suspicion "this test cannot fail" deserves. Code that cannot matter should be
+deletable, so if you are not willing to delete it, the argument is weaker than it reads.
+
 ## How to apply
 
 ### Measuring

--- a/okf/policies/prove-the-test-fails.md
+++ b/okf/policies/prove-the-test-fails.md
@@ -51,6 +51,51 @@ Both versions looked exactly like coverage. Only removing the guard and watching
 pass revealed they were not, and a third pass found the guard itself had an adjacent hole where a
 closing `*/` shared a line with real code (#680).
 
+## A green removal row is ambiguous, not reassuring
+
+Removing a guard and seeing nothing fail has two explanations, and the count alone cannot tell them
+apart: the guard does nothing, or **something else is standing in front of it**. Three instances in
+one day, 2026-08-07:
+
+- **A guard masked by a different bug.** `#762`'s `.convex` block came back green under removal, was
+  called decorative, and a geometric argument was written for why it could never matter. Fixing an
+  unrelated defect two functions away, a `visited` marking that fired before the wall/junction
+  decision, made the same removal fail two tests. The argument had been describing the bug.
+- **Two guards backstopping each other.** In the same walk, removing the Z-tolerance bypass and
+  removing the `.convex` block each hid the other's effect, so neither injection isolated anything,
+  and nor did removing both together.
+- **A row exercising one of two mechanisms.** `#771`'s row 5 used only value-typed fixtures, so
+  "disable local binding" and "disable value-typed binding" were the same experiment. The row was
+  green for a reason unrelated to its label.
+
+So state, per row, **which mechanism it isolates and how you know**. Disjointness is the usual
+evidence: `#762`'s injection E fails exactly two tests of 34, and those two also fail under an
+unrelated row, so only the disjointness distinguishes isolation from coincidence.
+
+A row that adds nothing is worth keeping if it is labelled as adding nothing. `#762`'s row D
+produces the same failure set as row B and says so, which answers a real question rather than
+padding the table.
+
+## A matrix proves guards, not fixtures
+
+These are different claims and it is easy to offer the first as evidence for the second. I did, on
+2026-08-07, and the injection corrected me within the hour.
+
+A removal matrix modifies the **source**. A fixture that has stopped meaning its name is a property
+of the **test**, and a matrix cannot see it: with a dud fixture, the affected rows simply fail fewer
+tests, which shows up as a changed count nobody is comparing rather than as a failure.
+
+Measured, in `#762`'s own suite: replacing one `filleted(...)` with the unfilleted shape, so the
+fillet silently does nothing, left **all 15 tests passing**. A no-op fillet leaves the sharp pocket,
+and the sharp pocket is the control fixture that reports the same one pocket, four walls, not open.
+Every assertion downstream was reading a fixture that had stopped meaning its name, in a suite
+written specifically to avoid that.
+
+So a test whose subject is an operation needs an assertion that **the operation did something**,
+separate from any guard the matrix covers. `try #require(op())` proves non-nil, not non-trivial. A
+cheap structural delta works: `#762` asserts the face count rose, since a fillet or chamfer replaces
+each target edge with at least one new face.
+
 ## How to apply
 
 For a test: break the code it covers, run it, see red, restore, see green.


### PR DESCRIPTION
Four sections across two policies, all from work done on 2026-08-07. Every one was rediscovered at
least twice, which is the argument for writing them down rather than the argument that they are
obvious.

## `prove-the-test-fails.md`

**A green removal row is ambiguous, not reassuring.** Removing a guard and seeing nothing fail has
two explanations and the count cannot separate them: the guard does nothing, or something else is in
front of it.

| instance | what was in front of it |
|---|---|
| #762's `.convex` block | a `visited`-marking bug two functions away |
| #762's injections B and C | each other |
| #771's matrix row 5 | its own fixture, which could not tell two mechanisms apart |

The remedy is to state per row which mechanism it isolates and how you know. Disjointness is the
usual evidence.

**A matrix proves guards, not fixtures.** I made this mistake myself and the injection corrected me
within the hour. A matrix modifies the source; a fixture that has stopped meaning its name is a
property of the test, and shows up as a changed count nobody is comparing rather than a failure.
Measured: replacing one `filleted(...)` with the unfilleted shape left **all 15 of #762's tests
passing**.

## `measure-dont-assume.md`

**The adjacent number reads as the one you need.** This is the mechanism behind every entry already
in that file's "Why" section, so it is promoted to its own named rule. The wrong number is always
plausible: right type, right magnitude, a real measurement of a real thing. Fresh cases include
#772's benchmark of a different function than the one that shipped, #597 citing a neighbouring
fixture's figures, and my own census missing a patch because it keyed on one diff-header spelling.

**An argument that explains everything may be describing a defect.** The hardest of the four,
because it does not feel like an assumption. #762's geometric argument explained all seven fixtures
and was describing a bug. The tell is that it argued a piece of code could never matter, which
deserves the suspicion "this test cannot fail" gets.

## Why now rather than at the tag

These are not release-gating, but they **are** #784-gating. That issue's duplication rescan and
deprecation adjudication will be done by someone reading these files, and two of the four rules are
directly about how to trust a removal matrix and a measurement. Landing them after the rescan would
be landing them after they were needed.

## CHANGELOG entry

None. Contributor-facing process documentation, no consumer-visible effect.

## SemVer impact

`NONE`.