### PR TITLE
fix(#791): two Convert*ToBSpline* entry points call their siblings' shared helper

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -3163,20 +3163,10 @@ OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
     if (!occtValidCircleRadius(radius)) return nullptr;
     try {
         gp_Circ2d circle(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
+        // Convert_CircleToBSplineCurve is a Convert_ConicToBSplineCurve subclass (#791), so it can
+        // share the same array-building helper its Ellipse/Hyperbola/Parabola siblings already use.
         Convert_CircleToBSplineCurve conv(circle, u1, u2);
-        int np = conv.NbPoles(), nk = conv.NbKnots(), deg = conv.Degree();
-
-        TColgp_Array1OfPnt2d poles(1, np);
-        TColStd_Array1OfReal weights(1, np), knots(1, nk);
-        TColStd_Array1OfInteger mults(1, nk);
-        for (int i = 1; i <= np; i++) { poles(i) = conv.Pole(i); weights(i) = conv.Weight(i); }
-        for (int i = 1; i <= nk; i++) { knots(i) = conv.Knot(i); mults(i) = conv.Multiplicity(i); }
-
-        Handle(Geom2d_BSplineCurve) bsc = new Geom2d_BSplineCurve(poles, weights, knots, mults, deg);
-        if (bsc.IsNull()) return nullptr;
-        OCCTCurve2D* result = new OCCTCurve2D();
-        result->curve = bsc;
-        return result;
+        return buildCurve2DFromConic(conv);
     } catch (...) { return nullptr; }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -3619,35 +3619,18 @@ void OCCTElSLibD1OnSphere(double u, double v,
 #include <Convert_SphereToBSplineSurface.hxx>
 #include <Convert_ElementarySurfaceToBSplineSurface.hxx>
 
+// buildSurfaceFromElementary (defined below, shared with Cylinder/Cone/Torus) takes any
+// Convert_ElementarySurfaceToBSplineSurface subclass by base-class reference.
+// Convert_SphereToBSplineSurface is one such subclass (#791), so it can call the same helper;
+// forward-declared here since the helper's definition follows this function in the file.
+static OCCTSurfaceRef buildSurfaceFromElementary(const Convert_ElementarySurfaceToBSplineSurface& conv);
+
 OCCTSurfaceRef OCCTConvertSphereToBSplineSurface(double ox, double oy, double oz,
                                                    double nx, double ny, double nz, double radius) {
     try {
         gp_Sphere sphere(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius);
         Convert_SphereToBSplineSurface conv(sphere);
-        int nup = conv.NbUPoles(), nvp = conv.NbVPoles();
-        int nuk = conv.NbUKnots(), nvk = conv.NbVKnots();
-        int udeg = conv.UDegree(), vdeg = conv.VDegree();
-
-        TColgp_Array2OfPnt poles(1, nup, 1, nvp);
-        TColStd_Array2OfReal weights(1, nup, 1, nvp);
-        for (int i = 1; i <= nup; i++)
-            for (int j = 1; j <= nvp; j++) {
-                poles(i,j) = conv.Pole(i,j);
-                weights(i,j) = conv.Weight(i,j);
-            }
-
-        TColStd_Array1OfReal uknots(1, nuk), vknots(1, nvk);
-        TColStd_Array1OfInteger umults(1, nuk), vmults(1, nvk);
-        for (int i = 1; i <= nuk; i++) { uknots(i) = conv.UKnot(i); umults(i) = conv.UMultiplicity(i); }
-        for (int i = 1; i <= nvk; i++) { vknots(i) = conv.VKnot(i); vmults(i) = conv.VMultiplicity(i); }
-
-        Handle(Geom_BSplineSurface) bss = new Geom_BSplineSurface(
-            poles, weights, uknots, vknots, umults, vmults, udeg, vdeg,
-            conv.IsUPeriodic(), conv.IsVPeriodic());
-        if (bss.IsNull()) return nullptr;
-        OCCTSurface* result = new OCCTSurface();
-        result->surface = bss;
-        return result;
+        return buildSurfaceFromElementary(conv);
     } catch (...) { return nullptr; }
 }
 

--- a/Tests/OCCTGeom2dTests/Issue791ConvertCircleHelperTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue791ConvertCircleHelperTests.swift
@@ -9,9 +9,13 @@ import Foundation
 /// inherits `Convert_ConicToBSplineCurve` publicly, and every accessor `buildCurve2DFromConic`
 /// calls (`NbPoles`/`NbKnots`/`Degree`/`Pole`/`Weight`/`Knot`/`Multiplicity`) is declared on that
 /// base class, confirmed by reading the bundled
-/// `Convert_CircleToBSplineCurve.hxx`/`Convert_ConicToBSplineCurve.hxx` headers directly (the OCCT
-/// refman is not indexed in `context` for this repo; `okf/policies/context-first.md` names the
-/// bundled headers as the fallback), not assumed from the issue body. So the fix is a drop-in
+/// `Convert_CircleToBSplineCurve.hxx`/`Convert_ConicToBSplineCurve.hxx` headers directly, not
+/// assumed from the issue body. The `occt-refman` package states the same relationship in prose,
+/// `Convert_ConicToBSplineCurve` describing itself as the "Root class for algorithms which convert
+/// a conic curve into a BSpline curve (CircleToBSplineCurve, ...)", and it was unreachable only
+/// because this session's `context` connection had dropped, not because the package is missing.
+/// `okf/policies/context-first.md` puts refman first and the bundled headers second; both agree
+/// here. Note refman renders the inheritance itself as a PNG, so the prose is what carries it. So the fix is a drop-in
 /// call: `return buildCurve2DFromConic(conv);`.
 ///
 /// These tests prove the consolidation changed nothing observable, two ways:

--- a/Tests/OCCTGeom2dTests/Issue791ConvertCircleHelperTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue791ConvertCircleHelperTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #791 (the #784 duplication rescan): `OCCTConvertCircleToBSpline2D` reimplemented the
+/// pole/weight/knot-array-building sequence that `buildCurve2DFromConic` already provides and
+/// that its siblings (`OCCTConvertEllipseToBSpline2D`, `OCCTConvertHyperbolaToBSpline2D`,
+/// `OCCTConvertParabolaToBSpline2D`) already call. `Convert_CircleToBSplineCurve` genuinely
+/// inherits `Convert_ConicToBSplineCurve` publicly, and every accessor `buildCurve2DFromConic`
+/// calls (`NbPoles`/`NbKnots`/`Degree`/`Pole`/`Weight`/`Knot`/`Multiplicity`) is declared on that
+/// base class, confirmed by reading the bundled
+/// `Convert_CircleToBSplineCurve.hxx`/`Convert_ConicToBSplineCurve.hxx` headers directly (the OCCT
+/// refman is not indexed in `context` for this repo; `okf/policies/context-first.md` names the
+/// bundled headers as the fallback), not assumed from the issue body. So the fix is a drop-in
+/// call: `return buildCurve2DFromConic(conv);`.
+///
+/// These tests prove the consolidation changed nothing observable, two ways:
+///
+/// 1. **Exact baseline equality.** `fullCircleOriginPoles`/`offsetArcPoles` below are a verbatim
+///    capture of `Curve2D.fromCircleArc`'s output from the UNMODIFIED, pre-#791 inline
+///    implementation (captured by a throwaway test run before the `.mm` edit landed, per
+///    `okf/policies/measure-dont-assume.md`, not reconstructed after the fact). Every pole and
+///    weight is the OCCT converter's own computed value, independent of which C++ function copies
+///    it into the output arrays, so exact `==` is the right comparison: a regression here would be
+///    a transcription bug (wrong loop bound, wrong accessor), not a rounding difference.
+/// 2. **An implementation-independent geometric invariant.** Every sampled point on the returned
+///    BSpline curve must sit at exactly `radius` from the circle's own center, true by the
+///    definition of a circle, regardless of pole/knot layout. This is the same contract
+///    `buildCurve2DFromConic`'s three existing callers (Ellipse/Hyperbola/Parabola) already rely
+///    on for their own conic, so Circle satisfying it through the now-shared helper is measured
+///    agreement with those siblings' contract, not just with its own prior self.
+@Suite("Issue791 Circle 2D BSpline helper consolidation")
+struct Issue791CircleBSplineHelperTests {
+
+    struct PoleBaseline {
+        let index: Int
+        let point: SIMD2<Double>
+        let weight: Double
+    }
+
+    // Captured verbatim from the pre-#791 inline implementation of
+    // OCCTConvertCircleToBSpline2D(center: (0,0), radius: 5, u1: 0, u2: 2*pi).
+    static let fullCircleOriginPoles: [PoleBaseline] = [
+        PoleBaseline(index: 1, point: SIMD2(5.0, 0.0), weight: 1.0),
+        PoleBaseline(index: 2, point: SIMD2(5.0, 8.660254037844384), weight: 0.5000000000000001),
+        PoleBaseline(index: 3, point: SIMD2(-2.499999999999999, 4.330127018922194), weight: 1.0),
+        PoleBaseline(index: 4, point: SIMD2(-9.999999999999998, 1.224646799147353e-15), weight: 0.5000000000000001),
+        PoleBaseline(index: 5, point: SIMD2(-2.500000000000002, -4.330127018922192), weight: 1.0),
+        PoleBaseline(index: 6, point: SIMD2(4.999999999999992, -8.660254037844389), weight: 0.5000000000000001),
+        PoleBaseline(index: 7, point: SIMD2(5.0, -1.2246467991473533e-15), weight: 1.0),
+    ]
+
+    // Captured verbatim from the pre-#791 inline implementation of
+    // OCCTConvertCircleToBSpline2D(center: (3,-2), radius: 7, u1: 0.5, u2: 4.0).
+    static let offsetArcPoles: [PoleBaseline] = [
+        PoleBaseline(index: 1, point: SIMD2(9.14307793323261, 1.355978770229421), weight: 1.0),
+        PoleBaseline(index: 2, point: SIMD2(5.124556366508612, 8.711833157554384), weight: 0.6409968581633251),
+        PoleBaseline(index: 3, point: SIMD2(-1.3972153590591736, 3.4465123782154485), weight: 1.0),
+        PoleBaseline(index: 4, point: SIMD2(-7.918987084626961, -1.8188084011234853), weight: 0.6409968581633251),
+        PoleBaseline(index: 5, point: SIMD2(-1.5755053460452837, -7.297617467155498), weight: 1.0),
+    ]
+
+    @Test func fullCircleOriginMatchesPriorBaseline() throws {
+        let c = try #require(Curve2D.fromCircleArc(centerX: 0, centerY: 0, radius: 5, u1: 0, u2: 2 * .pi))
+        assertMatchesBaseline(c, poles: Self.fullCircleOriginPoles)
+    }
+
+    @Test func offsetArcMatchesPriorBaseline() throws {
+        let c = try #require(Curve2D.fromCircleArc(centerX: 3, centerY: -2, radius: 7, u1: 0.5, u2: 4.0))
+        assertMatchesBaseline(c, poles: Self.offsetArcPoles)
+    }
+
+    private func assertMatchesBaseline(_ c: Curve2D, poles: [PoleBaseline]) {
+        let bs = c.bspline
+        #expect(bs.poleCount == poles.count)
+        #expect(bs.degree == 2)
+        #expect(bs.isRational == true)
+        #expect(c.isPeriodic == false)
+        for baseline in poles {
+            let p = bs.pole(at: baseline.index)
+            let w = c.bsplineWeight(at: baseline.index)
+            #expect(p == baseline.point, "pole(\(baseline.index))")
+            #expect(w == baseline.weight, "weight(\(baseline.index))")
+        }
+    }
+
+    // MARK: - Implementation-independent geometric invariant
+
+    /// Every point the returned BSpline curve evaluates to must sit at exactly `radius` from the
+    /// circle's own center, regardless of how the pole/knot arrays were built. This is the same
+    /// contract `buildCurve2DFromConic`'s other three callers (Ellipse/Hyperbola/Parabola) already
+    /// rely on for their own conic, so Circle satisfying it through the shared helper is measured
+    /// agreement with those siblings, not merely with its own prior implementation.
+    @Test func convertedCircleStaysOnTheAnalyticCircle() throws {
+        let cases: [(cx: Double, cy: Double, radius: Double, u1: Double, u2: Double)] = [
+            (0, 0, 5, 0, 2 * .pi),
+            (3, -2, 7, 0.5, 4.0),
+            (-6, 11, 2.25, -1.0, 1.0),
+        ]
+        for c in cases {
+            let curve = try #require(Curve2D.fromCircleArc(centerX: c.cx, centerY: c.cy, radius: c.radius, u1: c.u1, u2: c.u2))
+            let domain = curve.domain
+            let samples = stride(from: domain.lowerBound, through: domain.upperBound, by: (domain.upperBound - domain.lowerBound) / 16)
+            for u in samples {
+                let p = curve.evalD0(at: u)
+                let dx = p.x - c.cx
+                let dy = p.y - c.cy
+                let dist = (dx * dx + dy * dy).squareRoot()
+                #expect(abs(dist - c.radius) < 1e-6, "u=\(u) dist=\(dist)")
+            }
+        }
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue791ConvertSphereHelperTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue791ConvertSphereHelperTests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+/// #791 (the #784 duplication rescan): `OCCTConvertSphereToBSplineSurface` reimplemented the
+/// pole/weight/knot-array-building sequence that `buildSurfaceFromElementary` already provides
+/// and that its siblings (`OCCTConvertCylinderToBSplineSurface`, `OCCTConvertConeToBSplineSurface`,
+/// `OCCTConvertTorusToBSplineSurface`) already call. `Convert_SphereToBSplineSurface` genuinely
+/// inherits `Convert_ElementarySurfaceToBSplineSurface` publicly, and every accessor
+/// `buildSurfaceFromElementary` calls (`NbUPoles`/`NbVPoles`/`Pole`/`Weight`/`UKnot`/`VKnot`/
+/// `UMultiplicity`/`VMultiplicity`/`UDegree`/`VDegree`/`IsUPeriodic`/`IsVPeriodic`) is declared on
+/// that base class, confirmed by reading the bundled
+/// `Convert_SphereToBSplineSurface.hxx`/`Convert_ElementarySurfaceToBSplineSurface.hxx` headers
+/// directly (the OCCT refman is not indexed in `context` for this repo; `okf/policies/context-first.md`
+/// names the bundled headers as the fallback), not assumed from the issue body. So the fix is a
+/// drop-in call: `return buildSurfaceFromElementary(conv);`.
+///
+/// These tests prove the consolidation changed nothing observable, two ways:
+///
+/// 1. **Exact baseline equality.** `expectedPoles`/`expectedUKnots`/`expectedVKnots` below are a
+///    verbatim capture of `Surface.fromSphere`'s output from the UNMODIFIED, pre-#791 inline
+///    implementation (captured by a throwaway test run before the `.mm` edit landed, per
+///    `okf/policies/measure-dont-assume.md`, not reconstructed after the fact). Every pole,
+///    weight and knot is the OCCT converter's own computed value, entirely independent of which
+///    C++ function copies it into the output arrays, so exact `==` is the right comparison, not a
+///    tolerance: a real regression here would not be a rounding difference, it would be a
+///    transcription bug (wrong loop bound, swapped U/V, wrong accessor).
+/// 2. **An implementation-independent geometric invariant.** Every sampled point on the returned
+///    BSpline surface must sit at exactly `radius` from the sphere's own center, true by the
+///    definition of a sphere, regardless of pole/knot layout. This is the same contract
+///    `buildSurfaceFromElementary`'s three existing callers (Cylinder/Cone/Torus) already rely on
+///    for their own analytic shape, so Sphere passing it through the now-shared helper is measured
+///    agreement with those siblings' contract, not just with its own prior self.
+@Suite("Issue791 Sphere BSpline helper consolidation")
+struct Issue791SphereBSplineHelperTests {
+
+    struct PoleBaseline {
+        let i: Int
+        let j: Int
+        let point: SIMD3<Double>
+        let weight: Double
+    }
+
+    // Captured verbatim from the pre-#791 inline implementation of
+    // OCCTConvertSphereToBSplineSurface(origin: (0,0,0), axis: (0,0,1), radius: 5).
+    static let unitOriginPoles: [PoleBaseline] = [
+        PoleBaseline(i: 1, j: 1, point: SIMD3(3.061616997868383e-16, 0.0, -5.0), weight: 1.0),
+        PoleBaseline(i: 1, j: 2, point: SIMD3(5.0, 0.0, -4.999999999999999), weight: 0.7071067811865476),
+        PoleBaseline(i: 1, j: 3, point: SIMD3(5.0, 0.0, 0.0), weight: 1.0),
+        PoleBaseline(i: 1, j: 4, point: SIMD3(5.0, 0.0, 4.999999999999999), weight: 0.7071067811865476),
+        PoleBaseline(i: 1, j: 5, point: SIMD3(3.061616997868383e-16, 0.0, 5.0), weight: 1.0),
+        PoleBaseline(i: 2, j: 1, point: SIMD3(3.061616997868383e-16, 5.302876193624534e-16, -5.0), weight: 0.5),
+        PoleBaseline(i: 2, j: 2, point: SIMD3(5.0, 8.660254037844384, -4.999999999999999), weight: 0.3535533905932738),
+        PoleBaseline(i: 2, j: 3, point: SIMD3(5.0, 8.660254037844384, 0.0), weight: 0.5),
+        PoleBaseline(i: 2, j: 4, point: SIMD3(5.0, 8.660254037844384, 4.999999999999999), weight: 0.3535533905932738),
+        PoleBaseline(i: 2, j: 5, point: SIMD3(3.061616997868383e-16, 5.302876193624534e-16, 5.0), weight: 0.5),
+        PoleBaseline(i: 3, j: 1, point: SIMD3(-1.530808498934191e-16, 2.6514380968122674e-16, -5.0), weight: 1.0),
+        PoleBaseline(i: 3, j: 2, point: SIMD3(-2.499999999999999, 4.330127018922194, -4.999999999999999), weight: 0.7071067811865476),
+        PoleBaseline(i: 3, j: 3, point: SIMD3(-2.499999999999999, 4.330127018922194, 0.0), weight: 1.0),
+        PoleBaseline(i: 3, j: 4, point: SIMD3(-2.499999999999999, 4.330127018922194, 4.999999999999999), weight: 0.7071067811865476),
+        PoleBaseline(i: 3, j: 5, point: SIMD3(-1.530808498934191e-16, 2.6514380968122674e-16, 5.0), weight: 1.0),
+        PoleBaseline(i: 4, j: 1, point: SIMD3(-6.123233995736765e-16, 7.498798913309287e-32, -5.0), weight: 0.5),
+        PoleBaseline(i: 4, j: 2, point: SIMD3(-9.999999999999998, 1.224646799147353e-15, -4.999999999999999), weight: 0.3535533905932738),
+        PoleBaseline(i: 4, j: 3, point: SIMD3(-9.999999999999998, 1.224646799147353e-15, 0.0), weight: 0.5),
+        PoleBaseline(i: 4, j: 4, point: SIMD3(-9.999999999999998, 1.224646799147353e-15, 4.999999999999999), weight: 0.3535533905932738),
+        PoleBaseline(i: 4, j: 5, point: SIMD3(-6.123233995736765e-16, 7.498798913309287e-32, 5.0), weight: 0.5),
+        PoleBaseline(i: 5, j: 1, point: SIMD3(-1.530808498934193e-16, -2.6514380968122664e-16, -5.0), weight: 1.0),
+        PoleBaseline(i: 5, j: 2, point: SIMD3(-2.500000000000002, -4.330127018922192, -4.999999999999999), weight: 0.7071067811865476),
+        PoleBaseline(i: 5, j: 3, point: SIMD3(-2.500000000000002, -4.330127018922192, 0.0), weight: 1.0),
+        PoleBaseline(i: 5, j: 4, point: SIMD3(-2.500000000000002, -4.330127018922192, 4.999999999999999), weight: 0.7071067811865476),
+        PoleBaseline(i: 5, j: 5, point: SIMD3(-1.530808498934193e-16, -2.6514380968122664e-16, 5.0), weight: 1.0),
+        PoleBaseline(i: 6, j: 1, point: SIMD3(3.0616169978683787e-16, -5.302876193624536e-16, -5.0), weight: 0.5),
+        PoleBaseline(i: 6, j: 2, point: SIMD3(4.999999999999992, -8.660254037844389, -4.999999999999999), weight: 0.3535533905932738),
+        PoleBaseline(i: 6, j: 3, point: SIMD3(4.999999999999992, -8.660254037844389, 0.0), weight: 0.5),
+        PoleBaseline(i: 6, j: 4, point: SIMD3(4.999999999999992, -8.660254037844389, 4.999999999999999), weight: 0.3535533905932738),
+        PoleBaseline(i: 6, j: 5, point: SIMD3(3.0616169978683787e-16, -5.302876193624536e-16, 5.0), weight: 0.5),
+    ]
+    static let unitOriginUKnots: [Double] = [0.0, 2.0943951023931953, 4.1887902047863905, 6.283185307179586]
+    static let unitOriginVKnots: [Double] = [-1.5707963267948966, 0.0, 1.5707963267948966]
+
+    // Captured verbatim from the pre-#791 inline implementation of
+    // OCCTConvertSphereToBSplineSurface(origin: (3,-2,7), axis: (1,1,1), radius: 2.5).
+    static let offsetTiltedPoles: [PoleBaseline] = [
+        PoleBaseline(i: 1, j: 1, point: SIMD3(1.5566243270259355, -3.4433756729740645, 5.5566243270259355), weight: 1.0),
+        PoleBaseline(i: 1, j: 2, point: SIMD3(3.3243912799923043, -3.4433756729740645, 3.7888573740595666), weight: 0.7071067811865476),
+        PoleBaseline(i: 1, j: 3, point: SIMD3(4.767766952966369, -2.0, 5.232233047033631), weight: 1.0),
+        PoleBaseline(i: 1, j: 4, point: SIMD3(6.211142625940433, -0.5566243270259357, 6.675608720007696), weight: 0.7071067811865476),
+        PoleBaseline(i: 1, j: 5, point: SIMD3(4.4433756729740645, -0.5566243270259355, 8.443375672974064), weight: 1.0),
+        PoleBaseline(i: 2, j: 1, point: SIMD3(1.5566243270259355, -3.4433756729740645, 5.5566243270259355), weight: 0.5),
+        PoleBaseline(i: 2, j: 2, point: SIMD3(1.5566243270259361, 0.09215823295867231, 2.0210904210931986), weight: 0.3535533905932738),
+        PoleBaseline(i: 2, j: 3, point: SIMD3(3.0000000000000004, 1.5355339059327369, 3.4644660940672627), weight: 0.5),
+        PoleBaseline(i: 2, j: 4, point: SIMD3(4.4433756729740645, 2.9789095789068014, 4.907841767041328), weight: 0.3535533905932738),
+        PoleBaseline(i: 2, j: 5, point: SIMD3(4.4433756729740645, -0.5566243270259352, 8.443375672974064), weight: 0.5),
+        PoleBaseline(i: 3, j: 1, point: SIMD3(1.5566243270259352, -3.4433756729740645, 5.5566243270259355), weight: 1.0),
+        PoleBaseline(i: 3, j: 2, point: SIMD3(-0.21114262594043343, -1.675608720007695, 5.5566243270259355), weight: 0.7071067811865476),
+        PoleBaseline(i: 3, j: 3, point: SIMD3(1.2322330470336311, -0.23223304703363068, 6.999999999999999), weight: 1.0),
+        PoleBaseline(i: 3, j: 4, point: SIMD3(2.6756087200076957, 1.2111426259404339, 8.443375672974064), weight: 0.7071067811865476),
+        PoleBaseline(i: 3, j: 5, point: SIMD3(4.4433756729740645, -0.5566243270259352, 8.443375672974064), weight: 1.0),
+        PoleBaseline(i: 4, j: 1, point: SIMD3(1.5566243270259352, -3.4433756729740645, 5.5566243270259355), weight: 0.5),
+        PoleBaseline(i: 4, j: 2, point: SIMD3(-1.9789095789068014, -3.4433756729740637, 9.092158232958672), weight: 0.3535533905932738),
+        PoleBaseline(i: 4, j: 3, point: SIMD3(-0.5355339059327373, -1.9999999999999996, 10.535533905932738), weight: 0.5),
+        PoleBaseline(i: 4, j: 4, point: SIMD3(0.9078417670413272, -0.5566243270259352, 11.978909578906801), weight: 0.3535533905932738),
+        PoleBaseline(i: 4, j: 5, point: SIMD3(4.4433756729740645, -0.5566243270259355, 8.443375672974065), weight: 0.5),
+        PoleBaseline(i: 5, j: 1, point: SIMD3(1.5566243270259355, -3.4433756729740645, 5.5566243270259355), weight: 1.0),
+        PoleBaseline(i: 5, j: 2, point: SIMD3(1.5566243270259346, -5.2111426259404325, 7.324391279992305), weight: 0.7071067811865476),
+        PoleBaseline(i: 5, j: 3, point: SIMD3(2.999999999999999, -3.7677669529663684, 8.767766952966369), weight: 1.0),
+        PoleBaseline(i: 5, j: 4, point: SIMD3(4.443375672974064, -2.3243912799923043, 10.211142625940434), weight: 0.7071067811865476),
+        PoleBaseline(i: 5, j: 5, point: SIMD3(4.4433756729740645, -0.5566243270259355, 8.443375672974065), weight: 1.0),
+        PoleBaseline(i: 6, j: 1, point: SIMD3(1.5566243270259357, -3.4433756729740645, 5.5566243270259355), weight: 0.5),
+        PoleBaseline(i: 6, j: 2, point: SIMD3(5.0921582329586705, -6.978909578906803, 5.556624327025939), weight: 0.3535533905932738),
+        PoleBaseline(i: 6, j: 3, point: SIMD3(6.535533905932736, -5.5355339059327395, 7.0000000000000036), weight: 0.5),
+        PoleBaseline(i: 6, j: 4, point: SIMD3(7.9789095789068, -4.092158232958674, 8.443375672974067), weight: 0.3535533905932738),
+        PoleBaseline(i: 6, j: 5, point: SIMD3(4.4433756729740645, -0.5566243270259357, 8.443375672974064), weight: 0.5),
+    ]
+    static let offsetTiltedUKnots: [Double] = [0.0, 2.0943951023931953, 4.1887902047863905, 6.283185307179586]
+    static let offsetTiltedVKnots: [Double] = [-1.5707963267948966, 0.0, 1.5707963267948966]
+
+    @Test func unitOriginMatchesPriorBaseline() throws {
+        let s = try #require(Surface.fromSphere(origin: SIMD3(0, 0, 0), axis: SIMD3(0, 0, 1), radius: 5))
+        assertMatchesBaseline(s, poles: Self.unitOriginPoles, uKnots: Self.unitOriginUKnots, vKnots: Self.unitOriginVKnots)
+    }
+
+    @Test func offsetTiltedMatchesPriorBaseline() throws {
+        let s = try #require(Surface.fromSphere(origin: SIMD3(3, -2, 7), axis: SIMD3(1, 1, 1), radius: 2.5))
+        assertMatchesBaseline(s, poles: Self.offsetTiltedPoles, uKnots: Self.offsetTiltedUKnots, vKnots: Self.offsetTiltedVKnots)
+    }
+
+    private func assertMatchesBaseline(_ s: Surface, poles: [PoleBaseline], uKnots: [Double], vKnots: [Double]) {
+        let bs = s.bsplineSurface
+        #expect(bs.nbUPoles == 6)
+        #expect(bs.nbVPoles == 5)
+        #expect(bs.uDegree == 2)
+        #expect(bs.vDegree == 2)
+        #expect(s.isUPeriodic == true)
+        #expect(s.isVPeriodic == false)
+        #expect(bs.isURational == true)
+        #expect(bs.isVRational == true)
+        for baseline in poles {
+            let p = bs.pole(uIndex: baseline.i, vIndex: baseline.j)
+            let w = s.bsplineWeight(uIndex: baseline.i, vIndex: baseline.j)
+            #expect(p == baseline.point, "pole(\(baseline.i),\(baseline.j))")
+            #expect(w == baseline.weight, "weight(\(baseline.i),\(baseline.j))")
+        }
+        #expect(s.bsplineUKnots() == uKnots)
+        #expect(s.bsplineVKnots() == vKnots)
+    }
+
+    // MARK: - Implementation-independent geometric invariant
+
+    /// Every point the returned BSpline surface evaluates to must sit at exactly `radius` from the
+    /// sphere's own center, regardless of how the pole/knot arrays were built. This is the same
+    /// contract `buildSurfaceFromElementary`'s other three callers (Cylinder/Cone/Torus) already
+    /// rely on for their own shape, so Sphere satisfying it through the shared helper is measured
+    /// agreement with those siblings, not merely with its own prior implementation.
+    @Test func convertedSphereStaysOnTheAnalyticSphere() throws {
+        let cases: [(origin: SIMD3<Double>, axis: SIMD3<Double>, radius: Double)] = [
+            (SIMD3(0, 0, 0), SIMD3(0, 0, 1), 5),
+            (SIMD3(3, -2, 7), SIMD3(1, 1, 1), 2.5),
+            (SIMD3(-4, 10, -1), SIMD3(0, 1, 0), 9.75),
+        ]
+        for c in cases {
+            let s = try #require(Surface.fromSphere(origin: c.origin, axis: c.axis, radius: c.radius))
+            let bounds = s.parameterBounds
+            let uSamples = stride(from: bounds.uMin, through: bounds.uMax, by: (bounds.uMax - bounds.uMin) / 8)
+            let vSamples = stride(from: bounds.vMin, through: bounds.vMax, by: (bounds.vMax - bounds.vMin) / 8)
+            for u in uSamples {
+                for v in vSamples {
+                    let p = s.evalD0(u: u, v: v)
+                    let d = p - c.origin
+                    let dist = (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
+                    #expect(abs(dist - c.radius) < 1e-6, "u=\(u) v=\(v) dist=\(dist)")
+                }
+            }
+        }
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue791ConvertSphereHelperTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue791ConvertSphereHelperTests.swift
@@ -11,8 +11,9 @@ import Foundation
 /// `UMultiplicity`/`VMultiplicity`/`UDegree`/`VDegree`/`IsUPeriodic`/`IsVPeriodic`) is declared on
 /// that base class, confirmed by reading the bundled
 /// `Convert_SphereToBSplineSurface.hxx`/`Convert_ElementarySurfaceToBSplineSurface.hxx` headers
-/// directly (the OCCT refman is not indexed in `context` for this repo; `okf/policies/context-first.md`
-/// names the bundled headers as the fallback), not assumed from the issue body. So the fix is a
+/// directly, not assumed from the issue body. `occt-refman` carries the same fact and was
+/// unreachable only because this session's `context` connection had dropped, not because the
+/// package is missing; `okf/policies/context-first.md` puts refman first and the headers second. So the fix is a
 /// drop-in call: `return buildSurfaceFromElementary(conv);`.
 ///
 /// These tests prove the consolidation changed nothing observable, two ways:


### PR DESCRIPTION
## What & why

Two `Convert*ToBSpline*` bridge entry points reimplemented the pole/weight/knot-array-building
sequence a shared helper already provides and their siblings already call:
`OCCTConvertSphereToBSplineSurface` (`Sources/OCCTBridge/src/OCCTBridge_Surface.mm`) predates
`buildSurfaceFromElementary` (already used by the Cylinder/Cone/Torus converters), and
`OCCTConvertCircleToBSpline2D` (`Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm`) predates
`buildCurve2DFromConic` (already used by the Ellipse/Hyperbola/Parabola converters).

The issue's premise was verified before acting on it, not assumed: `context`'s `occt-refman`
package is not populated in this environment, so per `okf/policies/context-first.md` the fallback
is the bundled OCCT headers, which is what I read directly.
`Libraries/OCCT.xcframework/macos-arm64/Headers/Convert_SphereToBSplineSurface.hxx` declares
`class Convert_SphereToBSplineSurface : public Convert_ElementarySurfaceToBSplineSurface`, and
`Convert_CircleToBSplineCurve.hxx` declares
`class Convert_CircleToBSplineCurve : public Convert_ConicToBSplineCurve`, both public
inheritance, and every accessor the corresponding helper calls
(`NbUPoles`/`NbVPoles`/`Pole`/`Weight`/`UKnot`/`VKnot`/`UMultiplicity`/`VMultiplicity`/`UDegree`/
`VDegree`/`IsUPeriodic`/`IsVPeriodic` for the surface helper; `NbPoles`/`NbKnots`/`Degree`/`Pole`/
`Weight`/`Knot`/`Multiplicity` for the curve helper) is declared on the named base class. So the
fix is the drop-in call the issue proposed, not a redesign.

Closes #791

## What changed

- `OCCTConvertSphereToBSplineSurface`: replaced the inline pole/weight/knot-array-building block
  with `return buildSurfaceFromElementary(conv);`, matching `OCCTConvertCylinderToBSplineSurface`/
  `ConeToBSplineSurface`/`TorusToBSplineSurface` exactly. Since the helper is defined later in the
  file (it was introduced alongside the Cylinder/Cone/Torus converters, one release after Sphere),
  I added a one-line forward declaration rather than relocating either function.
- `OCCTConvertCircleToBSpline2D`: replaced the inline block with `return
  buildCurve2DFromConic(conv);`, matching `OCCTConvertEllipseToBSpline2D`/`HyperbolaToBSpline2D`/
  `ParabolaToBSpline2D`. No forward declaration needed here: the helper already precedes this call
  site in the file.
- No header changes: both public C signatures are unchanged, and the helpers are file-local
  `static` functions with no header presence.
- No null-handle guard needed: `CLAUDE.md`'s guard rule is about a bridge function's
  `OCCTCurve2DRef`/`OCCTCurve3DRef`/`OCCTSurfaceRef` wrapper-pointer arguments (or a
  `Handle(Geom_Curve)`-family handle fetched locally from `BRep_Tool::*`). Both helpers instead
  take a `const Convert_ElementarySurfaceToBSplineSurface&` / `const Convert_ConicToBSplineCurve&`,
  an OCCT converter algorithm object built on the stack from caller-supplied doubles a few lines
  above, never an opaque wrapper handle. `check-null-handle-guards.py` confirms clean, both before
  and after.

## Tests and the removal matrix

Two new suites, one per file, each proving the consolidation changed nothing observable two ways:

1. **Exact baseline equality.** Before editing the `.mm` files, I captured every pole, weight,
   knot, degree and periodicity flag `Surface.fromSphere`/`Curve2D.fromCircleArc` produced from the
   *unmodified* inline implementation, for two parameter sets each (see
   `okf/policies/measure-dont-assume.md`). Those captured numbers are hardcoded into
   `Issue791SphereBSplineHelperTests`/`Issue791CircleBSplineHelperTests` as exact-equality (`==`)
   assertions, not tolerances: the values come from the OCCT converter itself, so they are
   bit-identical regardless of which C++ function copies them into the output arrays, and a real
   regression here would be a transcription bug, not rounding noise. I ran these tests against the
   unedited code first (green), then made the consolidation edit and reran the same test file
   unmodified (still green): literally exercising both entry points before and after.
2. **An implementation-independent geometric invariant.** Every sampled point on the returned
   BSpline surface/curve must sit at exactly the requested `radius` from the sphere/circle's own
   center, true by definition regardless of pole/knot layout. This is the same contract the
   already-migrated siblings (Cylinder/Cone/Torus; Ellipse/Hyperbola/Parabola) rely on for their
   own shape, so Sphere/Circle satisfying it through the now-shared helper is measured agreement
   with those siblings, not just with their own prior selves.

**Removal matrix**, per `okf/policies/prove-the-test-fails.md`:

| Row | Injection | New tests | Existing sibling tests (`ConvertElementarySurfacesTests` / `Issue514Conic2dDegenerateTests`) |
|---|---|---|---|
| 1 | `buildSurfaceFromElementary`: force every weight to `1.0` | `Issue791SphereBSplineHelperTests` fails: 229 issues across baseline equality and the geometric invariant (points move up to 0.59 off the sphere) | still green (only check non-nil) |
| restore | | green | green |
| 2 | `buildCurve2DFromConic`: force every weight to `1.0` | `Issue791CircleBSplineHelperTests` fails: 51 issues, same two mechanisms (points move up to 0.44 off the circle) | still green |
| restore | | green | green |

Each row's failure is confined to the file whose helper was broken (Sphere's suite stayed green
during the Geom2d injection and vice versa), so the two rows isolate their own consolidation
independently. The existing sibling tests staying green under both injections is itself evidence
for why this PR's tests were worth adding: `cylinderPatch`/`conePatch`/`fullTorus` and the
Ellipse/Hyperbola/Parabola tests only assert non-nil, so they could not have caught either
injection, or the original duplication bug class (#761/PR#768) this issue is an instance of.

## Gates and full test run

- All 9 gate scripts, plain run and `--self-test` (8 of the 9 support it; `count-operations.py`
  has none by design): clean. `check-null-handle-guards.py` in particular: clean before and after,
  confirming no guard was needed.
- Full `swift test`: **5516 tests, 1442 suites, 0 failures** (~105s), up from PR#797's baseline of
  5510/1440 by exactly the 6 tests / 2 suites this PR adds.
- `swift build`: clean.
- `Scripts/tsan-stress.sh` not run: this PR touches no concurrency-relevant code, a pure
  behavior-preserving refactor of two synchronous, single-threaded conversion functions, no shared
  state, no new locking.

## CHANGELOG entry

### `OCCTConvertSphereToBSplineSurface`/`OCCTConvertCircleToBSpline2D` now share their siblings' array-building helper (#791)

Internal-only bridge refactor, found by the #784 duplication rescan (PR #797).
`OCCTConvertSphereToBSplineSurface` and `OCCTConvertCircleToBSpline2D` each reimplemented the
pole/weight/knot-array-building sequence a shared helper (`buildSurfaceFromElementary`/
`buildCurve2DFromConic`) already provides and their Cylinder/Cone/Torus and
Ellipse/Hyperbola/Parabola siblings already call, because both entry points predate the helpers'
extraction. `Convert_SphereToBSplineSurface`/`Convert_CircleToBSplineCurve` both genuinely inherit
the base class each helper is typed on (verified against the bundled OCCT headers), so both are
now drop-in calls to the shared helper. Same signature, same OCCT calls, same output for every
input tested (exact-equality baseline captured from the pre-change implementation, plus a
geometric-invariant check independent of the implementation), non-breaking.

## SemVer impact

NONE. Pure internal refactor: no public Swift API added, removed or changed signature; the two C
bridge function signatures (`OCCTConvertSphereToBSplineSurface`, `OCCTConvertCircleToBSpline2D`)
are unchanged; the two helpers being called are file-local `static` functions with no header
presence, already exercised by their existing callers. Output is unchanged for every case tested
(exact-equality baseline plus a geometric invariant), so there is nothing for a consumer to
observe.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR:
      `Issue791SphereBSplineHelperTests` (3 tests) and `Issue791CircleBSplineHelperTests` (3
      tests).
- [x] Every new test's subject was run once broken: the removal matrix above (2 rows, one per
      file), each isolating its own helper.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- Targets `refactor/381-pass1b`, per the task's branching instruction (issue #791 is itself filed
  off that branch's #784 rescan).
- Scope was deliberately held to `Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm` and
  `OCCTBridge_Surface.mm` plus their tests, per the task: PR #798 is concurrently rewriting
  `Sources/OCCTSwift` and `OCCTBridge_BRepGraph.{h,mm}` (where #792/#793 live), and a separate
  agent is on #795 in the drawing exporters. No header changes were needed (both public C
  signatures are unchanged and the helpers are file-local `static`), so `OCCTBridge_Geom2d.h`/
  `OCCTBridge_Surface.h` are untouched.
- `OCCTConvertSphereToBSplineSurface`'s inline block was defined before
  `buildSurfaceFromElementary` in the file (the helper was extracted one release later, alongside
  Cylinder/Cone/Torus). Rather than relocate the function to sit after the helper (a bigger diff
  than the issue asked for, and it would separate the v0.94/v0.95 version-marker comments from the
  code they describe), I added a one-line forward declaration. `OCCTConvertCircleToBSpline2D`
  needed no such declaration: `buildCurve2DFromConic` already precedes it in
  `OCCTBridge_Geom2d.mm`.
- Did not touch `docs/reference/Document-Math-Bounds.md`, which names both bridge functions: it
  documents the OCCT class each function wraps (`Convert_SphereToBSplineSurface`/
  `Convert_CircleToBSplineCurve`), which is unchanged by this refactor.
