### PR TITLE
refactor(#795): unify PDF/SVG/DXF drawing-collection onto DrawingDispatch.swift

### DIFF
--- a/Sources/OCCTSwift/DXFExporter.swift
+++ b/Sources/OCCTSwift/DXFExporter.swift
@@ -56,7 +56,7 @@ extension Exporter {
 
 /// Pure-Swift DXF R12 ASCII writer. Public so callers can stage entities manually
 /// (useful for tests and for scripts that compose DXFs from mixed sources).
-public final class DXFWriter: @unchecked Sendable {
+public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     public let deflection: Double
     private var lines: [(a: SIMD2<Double>, b: SIMD2<Double>, layer: String)] = []
     private var polylines: [(points: [SIMD2<Double>], closed: Bool, layer: String)] = []
@@ -95,417 +95,46 @@ public final class DXFWriter: @unchecked Sendable {
         texts.append((position, text, height, rotationDeg, layer))
     }
 
-    /// Emit a single pre-built dimension as exploded LINE + TEXT entities.
-    /// Useful for tests and for scripts that compose drawings from
-    /// dimension values without going through a `Drawing`.
+    /// Emit a single pre-built dimension as exploded LINE + TEXT entities. Useful for tests
+    /// and for scripts that compose drawings from dimension values without going through a
+    /// `Drawing`. Routes through the shared `DrawingDispatch.swift` dispatcher
+    /// (`emitDimension`), the same as `PDFWriter`/`SVGWriter` -- see #795: this used to be a
+    /// completely separate, independently hand-written pipeline (`emitLinear`/`emitRadial`/
+    /// `emitDiameter`/`emitAngular`/`emitOrdinate`, plus its own `formatTolerance`/
+    /// `TolerancedLabel`, byte-for-byte identical to `DrawingDispatch.swift`'s own private
+    /// copies), kept apart out of caution that DXF's entities might need a different
+    /// intermediate representation. They don't: `DXFWriter` already implements the same five
+    /// primitives `PDFWriter`/`SVGWriter` route through `DrawingPrimitiveOps`, so it gets the
+    /// identical dispatch for free.
     public func addDimension(_ d: DrawingDimension) {
-        switch d {
-        case .linear(let lin):   emitLinear(lin)
-        case .radial(let rad):   emitRadial(rad)
-        case .diameter(let dia): emitDiameter(dia)
-        case .angular(let ang):  emitAngular(ang)
-        case .ordinate(let ord): emitOrdinate(ord)
-        }
+        emitDimension(d, into: primitiveOps())
     }
 
     // MARK: - Collection from Drawing
+    //
+    // Both overloads forward to `DrawingDispatch.swift`'s shared `collectDrawing(...)` --
+    // the same body `PDFWriter`/`SVGWriter` call. Annotation collection (centrelines,
+    // centermarks, text labels, hatches, cutting-plane lines, balloons) goes through
+    // `DrawingDispatch.swift`'s `emitAnnotation`, reached the same way -- previously DXF's
+    // own `collectAnnotations`/`emitBalloon`/`emitCuttingPlaneLine`/`emitHatch`, the
+    // identical logic calling `self.addX` directly instead of through the shared `ops`
+    // bundle. #795.
 
+    /// Collect a `Drawing`'s edges, annotations and dimensions onto this writer, optionally
+    /// translated and uniformly scaled -- the shared collection pipeline every 2D exporter
+    /// (PDF, SVG, DXF) uses.
     public func collectFromDrawing(_ drawing: Drawing,
                                    translate: SIMD2<Double> = .zero,
                                    scale: Double = 1.0) {
-        collectProjectedEdges(drawing.visibleEdges, layer: "VISIBLE",
-                              translate: translate, scale: scale)
-        collectProjectedEdges(drawing.hiddenEdges,  layer: "HIDDEN",
-                              translate: translate, scale: scale)
-        collectProjectedEdges(drawing.outlineEdges, layer: "OUTLINE",
-                              translate: translate, scale: scale)
-        collectAnnotations(drawing.annotations, translate: translate, scale: scale)
-        collectDimensions(drawing.dimensions, translate: translate, scale: scale)
+        collectDrawing(drawing, translate: translate, scale: scale, into: self)
     }
 
-    /// Collect a `TransformedDrawing` onto this writer — convenience for
-    /// multi-view sheet composition.
+    /// Collect a `TransformedDrawing` onto this writer -- convenience for multi-view sheet
+    /// composition.
     public func collectFromDrawing(_ transformed: TransformedDrawing) {
         collectFromDrawing(transformed.source,
                            translate: transformed.translate,
                            scale: transformed.scale)
-    }
-
-    private func collectProjectedEdges(_ compound: Shape?, layer: String,
-                                       translate: SIMD2<Double>, scale: Double) {
-        guard let compound else { return }
-        let polys = compound.allEdgePolylines(deflection: deflection)
-        func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
-        for poly in polys {
-            guard poly.count >= 2 else { continue }
-            let points2D = poly.map { t(SIMD2($0.x, $0.y)) }
-            if points2D.count == 2 {
-                addLine(from: points2D[0], to: points2D[1], layer: layer)
-            } else {
-                addPolyline(points2D, closed: false, layer: layer)
-            }
-        }
-    }
-
-    private func collectAnnotations(_ anns: [DrawingAnnotation],
-                                    translate: SIMD2<Double> = .zero,
-                                    scale: Double = 1.0) {
-        for a in anns {
-            let transformed = (translate == .zero && scale == 1.0) ? a : a.transformed(translate: translate, scale: scale)
-            switch transformed {
-            case .centreline(let c):
-                addLine(from: c.from, to: c.to, layer: "CENTER")
-            case .centermark(let m):
-                let h = m.extent / 2
-                addLine(from: SIMD2(m.centre.x - h, m.centre.y),
-                        to:   SIMD2(m.centre.x + h, m.centre.y), layer: "CENTER")
-                addLine(from: SIMD2(m.centre.x, m.centre.y - h),
-                        to:   SIMD2(m.centre.x, m.centre.y + h), layer: "CENTER")
-            case .textLabel(let t):
-                addText(t.text, at: t.position, height: t.height,
-                        rotationDeg: t.rotation * 180 / .pi, layer: "TEXT")
-            case .hatch(let h):
-                emitHatch(h)
-            case .cuttingPlaneLine(let cpl):
-                emitCuttingPlaneLine(cpl)
-            case .balloon(let b):
-                emitBalloon(b)
-            }
-        }
-    }
-
-    private func emitBalloon(_ b: DrawingAnnotation.Balloon) {
-        addCircle(centre: b.centre, radius: b.radius, layer: "DIMENSION")
-        addText(String(b.itemNumber), at: b.centre, height: b.radius * 0.9, layer: "TEXT")
-        if let target = b.leaderTo {
-            // Leader exits the balloon at the point on the circle nearest the target.
-            let dir = target - b.centre
-            let len = simd_length(dir)
-            if len > 1e-9 {
-                let exit = b.centre + (dir / len) * b.radius
-                addLine(from: exit, to: target, layer: "DIMENSION")
-            }
-        }
-    }
-
-    /// Render an ISO 128-40 cutting-plane line: heavy-chain ends, thin-chain
-    /// middle, perpendicular arrows, and a label at each end.
-    private func emitCuttingPlaneLine(_ cpl: DrawingAnnotation.CuttingPlaneLine) {
-        let start = cpl.traceStart
-        let end = cpl.traceEnd
-        let traceDir = end - start
-        let traceLen = simd_length(traceDir)
-        guard traceLen > 1e-6 else { return }
-        let u = traceDir / traceLen
-        let heavyLen = min(10.0, traceLen * 0.2)
-
-        let heavyEndA = start + u * heavyLen
-        let heavyEndB = end - u * heavyLen
-
-        // Heavy chain at each end (rendered on CENTER layer — consumers can
-        // reassign to a bolder layer if they maintain thin/thick linetype sep).
-        addLine(from: start, to: heavyEndA, layer: "CENTER")
-        addLine(from: heavyEndB, to: end, layer: "CENTER")
-        // Thin chain middle
-        addLine(from: heavyEndA, to: heavyEndB, layer: "CENTER")
-
-        // Arrows perpendicular at each trace endpoint.
-        let a = cpl.arrowDirection
-        let arrowLen = 8.0
-        let arrowWidth = 3.0
-        let perp = SIMD2(-a.y, a.x)
-        func arrow(at p: SIMD2<Double>) {
-            let tip = p + a * arrowLen
-            let base1 = tip - a * arrowLen * 0.4 + perp * arrowWidth / 2
-            let base2 = tip - a * arrowLen * 0.4 - perp * arrowWidth / 2
-            addLine(from: p, to: tip, layer: "TEXT")
-            addLine(from: tip, to: base1, layer: "TEXT")
-            addLine(from: tip, to: base2, layer: "TEXT")
-        }
-        arrow(at: start)
-        arrow(at: end)
-
-        // Labels slightly beyond each arrow tip.
-        let labelOffset = arrowLen + 4.0
-        addText(cpl.label, at: start + a * labelOffset, height: 5.0, layer: "TEXT")
-        addText(cpl.label, at: end + a * labelOffset, height: 5.0, layer: "TEXT")
-    }
-
-    /// Tessellate a hatch pattern into individual line segments inside its
-    /// boundary. Algorithm: rotate boundary + islands into hatch-aligned coords
-    /// (so hatch lines become horizontal), scan horizontally at `spacing`
-    /// intervals, intersect with all boundary edges, pair intersections up
-    /// (even-odd rule), rotate each segment back into world coords.
-    private func emitHatch(_ h: DrawingAnnotation.Hatch) {
-        guard h.boundary.count >= 3, h.spacing > 0 else { return }
-        let cosA = cos(-h.angle), sinA = sin(-h.angle)
-        func rotateForward(_ p: SIMD2<Double>) -> SIMD2<Double> {
-            SIMD2(cosA * p.x - sinA * p.y, sinA * p.x + cosA * p.y)
-        }
-        let cosB = cos(h.angle), sinB = sin(h.angle)
-        func rotateBack(_ p: SIMD2<Double>) -> SIMD2<Double> {
-            SIMD2(cosB * p.x - sinB * p.y, sinB * p.x + cosB * p.y)
-        }
-        // Collect all boundary segments in rotated space.
-        var segments: [(SIMD2<Double>, SIMD2<Double>)] = []
-        func addPolygonSegments(_ poly: [SIMD2<Double>]) {
-            guard poly.count >= 2 else { return }
-            let rotated = poly.map(rotateForward)
-            for i in 0..<rotated.count {
-                let j = (i + 1) % rotated.count
-                segments.append((rotated[i], rotated[j]))
-            }
-        }
-        addPolygonSegments(h.boundary)
-        for island in h.islands { addPolygonSegments(island) }
-
-        // Find rotated bounding box.
-        var minY = Double.infinity, maxY = -Double.infinity
-        for s in segments {
-            minY = min(minY, s.0.y, s.1.y)
-            maxY = max(maxY, s.0.y, s.1.y)
-        }
-        guard minY.isFinite else { return }
-
-        // Scan horizontal lines from minY to maxY at h.spacing intervals.
-        var y = ceil(minY / h.spacing) * h.spacing
-        while y < maxY {
-            var xs: [Double] = []
-            for s in segments {
-                let (a, b) = s
-                // Ignore horizontal segments (they don't define crossings).
-                if abs(a.y - b.y) < 1e-12 { continue }
-                // Only consider segments that straddle y.
-                let minSeg = min(a.y, b.y), maxSeg = max(a.y, b.y)
-                if y < minSeg || y >= maxSeg { continue }
-                let t = (y - a.y) / (b.y - a.y)
-                xs.append(a.x + t * (b.x - a.x))
-            }
-            xs.sort()
-            // Pair up intersections (even-odd rule) and emit segments in
-            // world space.
-            var i = 0
-            while i + 1 < xs.count {
-                let p0 = rotateBack(SIMD2(xs[i], y))
-                let p1 = rotateBack(SIMD2(xs[i + 1], y))
-                addLine(from: p0, to: p1, layer: h.layer)
-                i += 2
-            }
-            y += h.spacing
-        }
-    }
-
-    private func collectDimensions(_ dims: [DrawingDimension],
-                                   translate: SIMD2<Double> = .zero,
-                                   scale: Double = 1.0) {
-        for d in dims {
-            let transformed = (translate == .zero && scale == 1.0) ? d : d.transformed(translate: translate, scale: scale)
-            switch transformed {
-            case .linear(let lin):   emitLinear(lin)
-            case .radial(let rad):   emitRadial(rad)
-            case .diameter(let dia): emitDiameter(dia)
-            case .angular(let ang):  emitAngular(ang)
-            case .ordinate(let ord): emitOrdinate(ord)
-            }
-        }
-    }
-
-    // MARK: - Tolerance formatting
-    //
-    // Every dimension emitter runs the (nominal-label, tolerance) pair
-    // through `formatTolerance` to get a `main` line plus optional `upper`
-    // and `lower` stacked lines. Inline cases (.symmetric, .fitClass) fold
-    // the tolerance into `main`; multi-value cases (.bilateral, .unilateral,
-    // .limits) return stacked lines that each emitter places perpendicular
-    // to the text baseline at ~55% height.
-
-    private struct TolerancedLabel {
-        let main: String
-        let upper: String?
-        let lower: String?
-    }
-
-    private func formatTolerance(base: String, tolerance: DrawingTolerance) -> TolerancedLabel {
-        switch tolerance {
-        case .none:
-            return TolerancedLabel(main: base, upper: nil, lower: nil)
-        case .symmetric(let v):
-            return TolerancedLabel(main: base + " ±" + String(format: "%.3f", v),
-                                   upper: nil, lower: nil)
-        case .fitClass(let s):
-            return TolerancedLabel(main: base + " " + s, upper: nil, lower: nil)
-        case .bilateral(let plus, let minus):
-            return TolerancedLabel(main: base,
-                                   upper: "+" + String(format: "%.3f", plus),
-                                   lower: "-" + String(format: "%.3f", minus))
-        case .unilateral(let v):
-            if v >= 0 {
-                return TolerancedLabel(main: base,
-                                       upper: "+" + String(format: "%.3f", v),
-                                       lower: "0")
-            } else {
-                return TolerancedLabel(main: base,
-                                       upper: "0",
-                                       lower: String(format: "%.3f", v))
-            }
-        case .limits(let lower, let upper):
-            return TolerancedLabel(main: base,
-                                   upper: String(format: "%.3f", upper),
-                                   lower: String(format: "%.3f", lower))
-        }
-    }
-
-    /// Emit `parts.main` at `position`, then any stacked upper/lower lines
-    /// at ±`stackOffset`. `stackOffset` must already be oriented along the
-    /// perpendicular to the text baseline.
-    private func emitTolerancedText(_ parts: TolerancedLabel,
-                                     at position: SIMD2<Double>,
-                                     height: Double,
-                                     rotationDeg: Double,
-                                     stackOffset: SIMD2<Double>) {
-        addText(parts.main, at: position, height: height, rotationDeg: rotationDeg, layer: "TEXT")
-        let smallHeight = height * 0.55
-        if let u = parts.upper {
-            addText(u, at: position + stackOffset, height: smallHeight,
-                    rotationDeg: rotationDeg, layer: "TEXT")
-        }
-        if let l = parts.lower {
-            addText(l, at: position - stackOffset, height: smallHeight,
-                    rotationDeg: rotationDeg, layer: "TEXT")
-        }
-    }
-
-    private func emitLinear(_ d: DrawingDimension.Linear) {
-        // Render dimension as: two extension lines + the dimension line + the text label.
-        // Direction of dimension line = perpendicular to the from-to vector, offset distance.
-        let dir = simd_normalize(d.to - d.from)
-        let perp = SIMD2<Double>(-dir.y, dir.x)
-        let from2 = d.from + perp * d.offset
-        let to2   = d.to   + perp * d.offset
-        // Extension lines (from measured endpoint to dimension line endpoint)
-        addLine(from: d.from, to: from2, layer: "DIMENSION")
-        addLine(from: d.to,   to: to2,   layer: "DIMENSION")
-        // The dimension line itself
-        addLine(from: from2, to: to2, layer: "DIMENSION")
-        // Label
-        let mid = (from2 + to2) / 2
-        let base = d.label ?? String(format: "%.2f", d.value)
-        let rotDeg = atan2(dir.y, dir.x) * 180 / .pi
-        let parts = formatTolerance(base: base, tolerance: d.tolerance)
-        emitTolerancedText(parts, at: mid + perp * 2, height: 3.5,
-                           rotationDeg: rotDeg, stackOffset: perp * 2.0)
-    }
-
-    private func emitRadial(_ d: DrawingDimension.Radial) {
-        let endOnCircle = SIMD2(d.centre.x + d.radius * cos(d.leaderAngle),
-                                 d.centre.y + d.radius * sin(d.leaderAngle))
-        let leaderTip = SIMD2(d.centre.x + (d.radius + 10) * cos(d.leaderAngle),
-                               d.centre.y + (d.radius + 10) * sin(d.leaderAngle))
-        addCircle(centre: d.centre, radius: d.radius, layer: "DIMENSION")
-        addLine(from: endOnCircle, to: leaderTip, layer: "DIMENSION")
-        let base = d.label ?? String(format: "R%.2f", d.value)
-        let parts = formatTolerance(base: base, tolerance: d.tolerance)
-        // Stack perpendicular to the leader direction.
-        let perp = SIMD2(-sin(d.leaderAngle), cos(d.leaderAngle))
-        emitTolerancedText(parts, at: leaderTip, height: 3.5,
-                           rotationDeg: 0, stackOffset: perp * 2.0)
-    }
-
-    private func emitDiameter(_ d: DrawingDimension.Diameter) {
-        let cos_ = cos(d.leaderAngle)
-        let sin_ = sin(d.leaderAngle)
-        let pA = SIMD2(d.centre.x - d.radius * cos_, d.centre.y - d.radius * sin_)
-        let pB = SIMD2(d.centre.x + d.radius * cos_, d.centre.y + d.radius * sin_)
-        addLine(from: pA, to: pB, layer: "DIMENSION")
-        let tip = SIMD2(pB.x + 5 * cos_, pB.y + 5 * sin_)
-        let base = d.label ?? String(format: "⌀%.2f", d.value)
-        let parts = formatTolerance(base: base, tolerance: d.tolerance)
-        let perp = SIMD2(-sin_, cos_)
-        emitTolerancedText(parts, at: tip, height: 3.5,
-                           rotationDeg: 0, stackOffset: perp * 2.0)
-    }
-
-    private func emitAngular(_ d: DrawingDimension.Angular) {
-        let v1 = simd_normalize(d.ray1 - d.vertex)
-        let v2 = simd_normalize(d.ray2 - d.vertex)
-        let a1 = atan2(v1.y, v1.x)
-        let a2 = atan2(v2.y, v2.x)
-        var start = a1, end = a2
-        if end < start { swap(&start, &end) }
-        addArc(centre: d.vertex, radius: d.arcRadius,
-               startAngleDeg: start * 180 / .pi,
-               endAngleDeg: end * 180 / .pi,
-               layer: "DIMENSION")
-        let midAngle = (start + end) / 2
-        let textPos = SIMD2(d.vertex.x + (d.arcRadius + 3) * cos(midAngle),
-                             d.vertex.y + (d.arcRadius + 3) * sin(midAngle))
-        let base = d.label ?? String(format: "%.1f°", d.value * 180 / .pi)
-        let parts = formatTolerance(base: base, tolerance: d.tolerance)
-        // Stack along the radial direction.
-        let radial = SIMD2(cos(midAngle), sin(midAngle))
-        emitTolerancedText(parts, at: textPos, height: 3.5,
-                           rotationDeg: 0, stackOffset: radial * 2.0)
-    }
-
-    // MARK: - Ordinate dimensions (ISO 129-1 §9.3)
-    //
-    // Renders a small "+" origin mark at `origin`, then for each feature
-    // emits an X extension line (origin.y → feature.y, at feature.x) and a
-    // Y extension line (origin.x → feature.x, at feature.y), with the
-    // numeric offset text placed at the outboard end of each extension.
-    // The same `tolerance` is applied to every feature label.
-
-    private func emitOrdinate(_ d: DrawingDimension.Ordinate) {
-        // Origin mark: a small cross.
-        let crossExtent = 3.0
-        addLine(from: SIMD2(d.origin.x - crossExtent, d.origin.y),
-                to:   SIMD2(d.origin.x + crossExtent, d.origin.y), layer: "DIMENSION")
-        addLine(from: SIMD2(d.origin.x, d.origin.y - crossExtent),
-                to:   SIMD2(d.origin.x, d.origin.y + crossExtent), layer: "DIMENSION")
-
-        let tickLen = 2.0
-        for feature in d.features {
-            let dx = feature.position.x - d.origin.x
-            let dy = feature.position.y - d.origin.y
-
-            // X ordinate: vertical extension line from origin.y down-or-up to feature.y at feature.x,
-            // text above with the X offset. Place the extension line running from the feature's
-            // X on the origin baseline down to the feature's Y.
-            if dx != 0 {
-                let xTop = SIMD2(feature.position.x, d.origin.y)
-                let xBottom = SIMD2(feature.position.x, feature.position.y)
-                addLine(from: xTop, to: xBottom, layer: "DIMENSION")
-                // Short perpendicular tick at the origin baseline end.
-                addLine(from: SIMD2(feature.position.x, d.origin.y - tickLen),
-                        to:   SIMD2(feature.position.x, d.origin.y + tickLen),
-                        layer: "DIMENSION")
-                let xBase = feature.label ?? String(format: "%.2f", dx)
-                let xParts = formatTolerance(base: xBase, tolerance: d.tolerance)
-                emitTolerancedText(xParts,
-                                    at: SIMD2(feature.position.x, d.origin.y - 5),
-                                    height: 3.5,
-                                    rotationDeg: 90,
-                                    stackOffset: SIMD2(2.0, 0))
-            }
-
-            // Y ordinate: horizontal extension line from origin.x across to feature.x at feature.y.
-            if dy != 0 {
-                let yLeft = SIMD2(d.origin.x, feature.position.y)
-                let yRight = SIMD2(feature.position.x, feature.position.y)
-                addLine(from: yLeft, to: yRight, layer: "DIMENSION")
-                // Short perpendicular tick at the origin baseline end.
-                addLine(from: SIMD2(d.origin.x - tickLen, feature.position.y),
-                        to:   SIMD2(d.origin.x + tickLen, feature.position.y),
-                        layer: "DIMENSION")
-                let yBase = feature.label ?? String(format: "%.2f", dy)
-                let yParts = formatTolerance(base: yBase, tolerance: d.tolerance)
-                emitTolerancedText(yParts,
-                                    at: SIMD2(d.origin.x - 5, feature.position.y),
-                                    height: 3.5,
-                                    rotationDeg: 0,
-                                    stackOffset: SIMD2(0, 2.0))
-            }
-        }
     }
 
     // MARK: - Serialization

--- a/Sources/OCCTSwift/DXFExporter.swift
+++ b/Sources/OCCTSwift/DXFExporter.swift
@@ -63,6 +63,8 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     private var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
     private var arcs: [(centre: SIMD2<Double>, radius: Double, startAngleDeg: Double, endAngleDeg: Double, layer: String)] = []
     private var texts: [(position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double, layer: String)] = []
+    /// `DrawingPrimitiveSink.primitiveOps()`'s cache -- see `DrawingDispatch.swift`. #800.
+    internal var cachedPrimitiveOps: DrawingPrimitiveOps?
 
     public init(deflection: Double = 0.1) {
         self.deflection = deflection

--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -1,19 +1,34 @@
 import Foundation
 import simd
 
-// MARK: - Shared annotation + dimension dispatch (#85, v0.150)
+// MARK: - Shared annotation + dimension dispatch (#85, v0.150; unified onto DXF, #795)
 //
-// DXFWriter has its own inline dispatch for every annotation and dimension
-// case (v0.148 and earlier). To avoid triplicating that logic across the
-// PDFWriter and SVGWriter added in v0.150, the dispatch is lifted here as
-// free functions that take a `DrawingPrimitiveOps` closure bundle. Any
-// writer implementing the five 2D primitives (addLine, addPolyline,
-// addCircle, addArc, addText) gets full annotation + dimension rendering
-// for free.
+// DXFWriter used to carry its own inline dispatch for every annotation and dimension
+// case (v0.148 and earlier), duplicated instead of shared when PDFWriter/SVGWriter were
+// added in v0.150 out of caution — DXF's test coverage was load-bearing and a refactor
+// risked regressions with no user-visible benefit (the original rationale for keeping it
+// separate, recorded below until #795). The dispatch lives here as free functions that
+// take a `DrawingPrimitiveOps` closure bundle; any writer implementing the five 2D
+// primitives (addLine, addPolyline, addCircle, addArc, addText) gets full annotation +
+// dimension rendering for free.
 //
-// DXFWriter continues to use its own inline logic — not because it couldn't
-// be ported, but because its test coverage is load-bearing and a refactor
-// would risk regressions with no user-visible benefit.
+// #795 found that DXFWriter's inline copy had drifted into being the SAME logic, not a
+// different one: `formatTolerance`/`TolerancedLabel` were byte-for-byte identical to this
+// file's own (private) copies, and DXF's `emitLinear`/`emitRadial`/`emitDiameter`/
+// `emitAngular`/`emitOrdinate`/`collectAnnotations`/`emitBalloon`/`emitCuttingPlaneLine`/
+// `emitHatch` were the identical logic as this file's `emitDimension`/`emitAnnotation`
+// family, just calling `self.addLine(from:to:layer:)` etc. directly instead of through an
+// `ops` closure bundle — DXFWriter already implements the same five primitives PDF/SVG do,
+// so the "different intermediate representation" concern that justified keeping DXF
+// separate never actually applied. Golden-output tests
+// (`Tests/OCCTIOTests/OCCTIOTests.swift`, `ExporterDrawingCollectionGoldenTests`) proved
+// the unification byte-identical before it was made permanent.
+//
+// `DrawingPrimitiveSink` is the shared conformance: any writer holding the five staging
+// methods gets `primitiveOps()` for free. `collectFromDrawing` stays an explicit `public`
+// declaration on each writer (so it keeps documenting and dispatching exactly where it
+// always did) but its body is one call into this file's shared `collectDrawing(...)`,
+// removing the need for each writer to hand-roll its own copy of the collection loop.
 
 internal struct DrawingPrimitiveOps {
     let addLine: (SIMD2<Double>, SIMD2<Double>, String) -> Void
@@ -21,6 +36,110 @@ internal struct DrawingPrimitiveOps {
     let addCircle: (SIMD2<Double>, Double, String) -> Void
     let addArc: (SIMD2<Double>, Double, Double, Double, String) -> Void
     let addText: (String, SIMD2<Double>, Double, Double, String) -> Void
+}
+
+/// A writer that can stage the five 2D drawing primitives PDF, SVG and DXF all
+/// understand. Conforming gets `primitiveOps()` via the default implementation below —
+/// each writer keeps its own explicit `public func collectFromDrawing` (so the public
+/// declaration a consumer sees, and `docs/reference/Export-Vector.md` documents, still
+/// lives in `PDFExporter.swift`/`SVGExporter.swift`/`DXFExporter.swift` exactly as before),
+/// but its BODY is one call into this file's shared `collectDrawing(...)`. #795.
+internal protocol DrawingPrimitiveSink: AnyObject {
+    var deflection: Double { get }
+    func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String)
+    func addPolyline(_ points: [SIMD2<Double>], closed: Bool, layer: String)
+    func addCircle(centre: SIMD2<Double>, radius: Double, layer: String)
+    func addArc(centre: SIMD2<Double>, radius: Double,
+                startAngleDeg: Double, endAngleDeg: Double, layer: String)
+    func addText(_ text: String, at position: SIMD2<Double>,
+                 height: Double, rotationDeg: Double, layer: String)
+}
+
+extension DrawingPrimitiveSink {
+    /// Ops closure bundle wrapping this sink's own staging methods, for the shared
+    /// annotation/dimension dispatchers below.
+    func primitiveOps() -> DrawingPrimitiveOps {
+        DrawingPrimitiveOps(
+            addLine:     { [weak self] a, b, layer in self?.addLine(from: a, to: b, layer: layer) },
+            addPolyline: { [weak self] pts, closed, layer in self?.addPolyline(pts, closed: closed, layer: layer) },
+            addCircle:   { [weak self] c, r, layer in self?.addCircle(centre: c, radius: r, layer: layer) },
+            addArc:      { [weak self] c, r, sDeg, eDeg, layer in self?.addArc(centre: c, radius: r, startAngleDeg: sDeg, endAngleDeg: eDeg, layer: layer) },
+            addText:     { [weak self] txt, pos, h, rot, layer in self?.addText(txt, at: pos, height: h, rotationDeg: rot, layer: layer) }
+        )
+    }
+}
+
+/// Stage every edge/annotation/dimension from `drawing` onto `sink`, optionally translated
+/// and uniformly scaled — the shared collection pipeline every 2D exporter (PDF, SVG, DXF)
+/// uses. Each writer's own `public func collectFromDrawing` is a one-line call into this;
+/// kept as a free function (not a `DrawingPrimitiveSink` default method) precisely so each
+/// writer keeps an explicit `public` declaration of its own — an `internal` protocol's
+/// extension methods are not reliably part of a conforming `public` type's visible API
+/// from outside the module, and `docs/reference/Export-Vector.md` documents this method
+/// once per writer, resolved by which `.swift` file declares it. #795.
+internal func collectDrawing(_ drawing: Drawing,
+                              translate: SIMD2<Double>,
+                              scale: Double,
+                              into sink: DrawingPrimitiveSink) {
+    let ops = sink.primitiveOps()
+    collectProjectedEdges(drawing.visibleEdges, layer: "VISIBLE",
+                           translate: translate, scale: scale,
+                           deflection: sink.deflection, into: ops)
+    collectProjectedEdges(drawing.hiddenEdges, layer: "HIDDEN",
+                           translate: translate, scale: scale,
+                           deflection: sink.deflection, into: ops)
+    collectProjectedEdges(drawing.outlineEdges, layer: "OUTLINE",
+                           translate: translate, scale: scale,
+                           deflection: sink.deflection, into: ops)
+    for a in drawing.annotations {
+        let t = (translate == .zero && scale == 1.0) ? a : a.transformed(translate: translate, scale: scale)
+        emitAnnotation(t, into: ops)
+    }
+    for d in drawing.dimensions {
+        let t = (translate == .zero && scale == 1.0) ? d : d.transformed(translate: translate, scale: scale)
+        emitDimension(t, into: ops)
+    }
+}
+
+/// Tessellate `compound`'s edges (via `allEdgePolylines`) and stage each resulting
+/// polyline as a line (2-point case) or polyline, translated/scaled, on `layer`. Shared by
+/// every `collectDrawing` call for the visible/hidden/outline edge passes — previously
+/// three (PDF/SVG/DXF) independently hand-written copies of the identical loop. #795.
+private func collectProjectedEdges(_ compound: Shape?, layer: String,
+                                    translate: SIMD2<Double>, scale: Double,
+                                    deflection: Double, into ops: DrawingPrimitiveOps) {
+    guard let compound else { return }
+    let polys = compound.allEdgePolylines(deflection: deflection)
+    func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
+    for poly in polys {
+        guard poly.count >= 2 else { continue }
+        let points2D = poly.map { t(SIMD2($0.x, $0.y)) }
+        if points2D.count == 2 {
+            ops.addLine(points2D[0], points2D[1], layer)
+        } else {
+            ops.addPolyline(points2D, false, layer)
+        }
+    }
+}
+
+/// Per-layer stroke weight (mm) per ISO 128-20, shared by PDF and SVG — the two formats
+/// whose stroke widths are specified in the same physical unit their content streams are
+/// scaled to (PDF's CTM maps mm -> pt before any `w` operator; SVG's viewBox is 1:1 with
+/// the staged mm coordinates). DXF has no equivalent concept (colour + linetype per layer,
+/// no per-entity line weight), so it is not part of this table. #795.
+internal func strokeWidthMM(for layer: String) -> Double {
+    switch layer {
+    case "VISIBLE", "OUTLINE", "BORDER", "TITLE":  return 0.5
+    case "HIDDEN", "CENTER", "DIMENSION", "TEXT":   return 0.25
+    case "HATCH":                                    return 0.18
+    default:                                         return 0.25
+    }
+}
+
+/// Shared PDF/SVG coordinate/length formatting (4 decimal places). DXF formats numbers
+/// separately (`%.6f`, via its own `pair(_:_:)` helper) so is not part of this. #795.
+internal func formatMM(_ v: Double) -> String {
+    String(format: "%.4f", v)
 }
 
 // MARK: - Annotation dispatch

--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -46,6 +46,12 @@ internal struct DrawingPrimitiveOps {
 /// but its BODY is one call into this file's shared `collectDrawing(...)`. #795.
 internal protocol DrawingPrimitiveSink: AnyObject {
     var deflection: Double { get }
+    /// Backing storage for `primitiveOps()`'s cache. `nil` until first use; each writer
+    /// declares this as a plain stored `var` starting `nil`. #800 review: without this, every
+    /// call to `addDimension`/`collectFromDrawing` allocated a fresh 5-closure
+    /// `DrawingPrimitiveOps`, which matters for `addDimension`'s documented loop-of-many-calls
+    /// use case (composing a DXF from dimension values without going through a `Drawing`).
+    var cachedPrimitiveOps: DrawingPrimitiveOps? { get set }
     func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String)
     func addPolyline(_ points: [SIMD2<Double>], closed: Bool, layer: String)
     func addCircle(centre: SIMD2<Double>, radius: Double, layer: String)
@@ -57,15 +63,19 @@ internal protocol DrawingPrimitiveSink: AnyObject {
 
 extension DrawingPrimitiveSink {
     /// Ops closure bundle wrapping this sink's own staging methods, for the shared
-    /// annotation/dimension dispatchers below.
+    /// annotation/dimension dispatchers below. Built once per instance and cached rather
+    /// than reallocated on every call (#800 review).
     func primitiveOps() -> DrawingPrimitiveOps {
-        DrawingPrimitiveOps(
+        if let cached = cachedPrimitiveOps { return cached }
+        let built = DrawingPrimitiveOps(
             addLine:     { [weak self] a, b, layer in self?.addLine(from: a, to: b, layer: layer) },
             addPolyline: { [weak self] pts, closed, layer in self?.addPolyline(pts, closed: closed, layer: layer) },
             addCircle:   { [weak self] c, r, layer in self?.addCircle(centre: c, radius: r, layer: layer) },
             addArc:      { [weak self] c, r, sDeg, eDeg, layer in self?.addArc(centre: c, radius: r, startAngleDeg: sDeg, endAngleDeg: eDeg, layer: layer) },
             addText:     { [weak self] txt, pos, h, rot, layer in self?.addText(txt, at: pos, height: h, rotationDeg: rot, layer: layer) }
         )
+        cachedPrimitiveOps = built
+        return built
     }
 }
 
@@ -81,16 +91,21 @@ internal func collectDrawing(_ drawing: Drawing,
                               translate: SIMD2<Double>,
                               scale: Double,
                               into sink: DrawingPrimitiveSink) {
-    let ops = sink.primitiveOps()
+    // Edges are the highest-volume primitive stream (one call per tessellated segment), so
+    // they go straight to `sink`'s own methods -- no closure indirection. #800 review.
     collectProjectedEdges(drawing.visibleEdges, layer: "VISIBLE",
                            translate: translate, scale: scale,
-                           deflection: sink.deflection, into: ops)
+                           deflection: sink.deflection, into: sink)
     collectProjectedEdges(drawing.hiddenEdges, layer: "HIDDEN",
                            translate: translate, scale: scale,
-                           deflection: sink.deflection, into: ops)
+                           deflection: sink.deflection, into: sink)
     collectProjectedEdges(drawing.outlineEdges, layer: "OUTLINE",
                            translate: translate, scale: scale,
-                           deflection: sink.deflection, into: ops)
+                           deflection: sink.deflection, into: sink)
+    // Annotations/dimensions are comparatively low-volume and their dispatchers need to stay
+    // format-agnostic (shared with `addDimension`'s single-value entry point), so they go
+    // through the (now-cached) closure bundle.
+    let ops = sink.primitiveOps()
     for a in drawing.annotations {
         let t = (translate == .zero && scale == 1.0) ? a : a.transformed(translate: translate, scale: scale)
         emitAnnotation(t, into: ops)
@@ -102,12 +117,15 @@ internal func collectDrawing(_ drawing: Drawing,
 }
 
 /// Tessellate `compound`'s edges (via `allEdgePolylines`) and stage each resulting
-/// polyline as a line (2-point case) or polyline, translated/scaled, on `layer`. Shared by
-/// every `collectDrawing` call for the visible/hidden/outline edge passes — previously
-/// three (PDF/SVG/DXF) independently hand-written copies of the identical loop. #795.
+/// polyline as a line (2-point case) or polyline, translated/scaled, on `layer`, calling
+/// `sink`'s own `addLine`/`addPolyline` directly (no `DrawingPrimitiveOps` closure
+/// indirection: this runs once per tessellated segment, the highest-volume primitive stream
+/// in a drawing, #800 review). Shared by every `collectDrawing` call for the
+/// visible/hidden/outline edge passes — previously three (PDF/SVG/DXF) independently
+/// hand-written copies of the identical loop. #795.
 private func collectProjectedEdges(_ compound: Shape?, layer: String,
                                     translate: SIMD2<Double>, scale: Double,
-                                    deflection: Double, into ops: DrawingPrimitiveOps) {
+                                    deflection: Double, into sink: DrawingPrimitiveSink) {
     guard let compound else { return }
     let polys = compound.allEdgePolylines(deflection: deflection)
     func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
@@ -115,9 +133,9 @@ private func collectProjectedEdges(_ compound: Shape?, layer: String,
         guard poly.count >= 2 else { continue }
         let points2D = poly.map { t(SIMD2($0.x, $0.y)) }
         if points2D.count == 2 {
-            ops.addLine(points2D[0], points2D[1], layer)
+            sink.addLine(from: points2D[0], to: points2D[1], layer: layer)
         } else {
-            ops.addPolyline(points2D, false, layer)
+            sink.addPolyline(points2D, closed: false, layer: layer)
         }
     }
 }

--- a/Sources/OCCTSwift/PDFExporter.swift
+++ b/Sources/OCCTSwift/PDFExporter.swift
@@ -71,6 +71,8 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     private var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
     private var arcs: [(centre: SIMD2<Double>, radius: Double, startDeg: Double, endDeg: Double, layer: String)] = []
     private var texts: [(position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double, layer: String)] = []
+    /// `DrawingPrimitiveSink.primitiveOps()`'s cache -- see `DrawingDispatch.swift`. #800.
+    internal var cachedPrimitiveOps: DrawingPrimitiveOps?
 
     public init(pageSize: SIMD2<Double> = SIMD2(841, 595), deflection: Double = 0.1) {
         self.pageSize = pageSize

--- a/Sources/OCCTSwift/PDFExporter.swift
+++ b/Sources/OCCTSwift/PDFExporter.swift
@@ -62,7 +62,7 @@ extension Exporter {
     }
 }
 
-public final class PDFWriter: @unchecked Sendable {
+public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     public let pageSize: SIMD2<Double>
     public let deflection: Double
 
@@ -117,54 +117,13 @@ public final class PDFWriter: @unchecked Sendable {
     public func collectFromDrawing(_ drawing: Drawing,
                                     translate: SIMD2<Double> = .zero,
                                     scale: Double = 1.0) {
-        collectProjectedEdges(drawing.visibleEdges, layer: "VISIBLE",
-                               translate: translate, scale: scale)
-        collectProjectedEdges(drawing.hiddenEdges, layer: "HIDDEN",
-                               translate: translate, scale: scale)
-        collectProjectedEdges(drawing.outlineEdges, layer: "OUTLINE",
-                               translate: translate, scale: scale)
-        let ops = primitiveOps()
-        for a in drawing.annotations {
-            let t = (translate == .zero && scale == 1.0) ? a : a.transformed(translate: translate, scale: scale)
-            emitAnnotation(t, into: ops)
-        }
-        for d in drawing.dimensions {
-            let t = (translate == .zero && scale == 1.0) ? d : d.transformed(translate: translate, scale: scale)
-            emitDimension(t, into: ops)
-        }
+        collectDrawing(drawing, translate: translate, scale: scale, into: self)
     }
 
     public func collectFromDrawing(_ transformed: TransformedDrawing) {
         collectFromDrawing(transformed.source,
                             translate: transformed.translate,
                             scale: transformed.scale)
-    }
-
-    private func collectProjectedEdges(_ compound: Shape?, layer: String,
-                                        translate: SIMD2<Double>, scale: Double) {
-        guard let compound else { return }
-        let polys = compound.allEdgePolylines(deflection: deflection)
-        func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
-        for poly in polys {
-            guard poly.count >= 2 else { continue }
-            let points2D = poly.map { t(SIMD2($0.x, $0.y)) }
-            if points2D.count == 2 {
-                addLine(from: points2D[0], to: points2D[1], layer: layer)
-            } else {
-                addPolyline(points2D, closed: false, layer: layer)
-            }
-        }
-    }
-
-    /// Ops closure bundle for shared annotation/dimension dispatchers.
-    private func primitiveOps() -> DrawingPrimitiveOps {
-        DrawingPrimitiveOps(
-            addLine:     { [weak self] a, b, layer in self?.addLine(from: a, to: b, layer: layer) },
-            addPolyline: { [weak self] pts, closed, layer in self?.addPolyline(pts, closed: closed, layer: layer) },
-            addCircle:   { [weak self] c, r, layer in self?.addCircle(centre: c, radius: r, layer: layer) },
-            addArc:      { [weak self] c, r, sDeg, eDeg, layer in self?.addArc(centre: c, radius: r, startAngleDeg: sDeg, endAngleDeg: eDeg, layer: layer) },
-            addText:     { [weak self] txt, pos, h, rot, layer in self?.addText(txt, at: pos, height: h, rotationDeg: rot, layer: layer) }
-        )
     }
 
     // MARK: - PDF 1.4 serialization
@@ -191,7 +150,7 @@ public final class PDFWriter: @unchecked Sendable {
         addObject(2, body: "<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
         addObject(3, body: """
             << /Type /Page /Parent 2 0 R \
-            /MediaBox [0 0 \(fmt(pageSize.x)) \(fmt(pageSize.y))] \
+            /MediaBox [0 0 \(formatMM(pageSize.x)) \(formatMM(pageSize.y))] \
             /Contents 4 0 R \
             /Resources << /Font << /F1 5 0 R >> >> >>
             """.replacingOccurrences(of: "\n", with: ""))
@@ -229,7 +188,7 @@ public final class PDFWriter: @unchecked Sendable {
         // CTM: map mm → pts so all geometry/line widths/text heights stay in mm.
         let mmToPt = 72.0 / 25.4
         s += "q\n"
-        s += "\(fmt(mmToPt)) 0 0 \(fmt(mmToPt)) 0 0 cm\n"
+        s += "\(formatMM(mmToPt)) 0 0 \(formatMM(mmToPt)) 0 0 cm\n"
         s += "0 0 0 RG\n"
 
         // Group entities by layer so we can set linewidth + dash once per group.
@@ -265,18 +224,9 @@ public final class PDFWriter: @unchecked Sendable {
     }
 
     private static func stylePreamble(for layer: String) -> String {
-        let w = strokeWidth(for: layer)
+        let w = strokeWidthMM(for: layer)
         let dash = dashPattern(for: layer)
-        return "\(fmt(w)) w\n\(dash) d\n"
-    }
-
-    private static func strokeWidth(for layer: String) -> Double {
-        switch layer {
-        case "VISIBLE", "OUTLINE", "BORDER", "TITLE":  return 0.5
-        case "HIDDEN", "CENTER", "DIMENSION", "TEXT":   return 0.25
-        case "HATCH":                                    return 0.18
-        default:                                         return 0.25
-        }
+        return "\(formatMM(w)) w\n\(dash) d\n"
     }
 
     private static func dashPattern(for layer: String) -> String {
@@ -291,13 +241,13 @@ public final class PDFWriter: @unchecked Sendable {
     private func emitLayerGeometry(layer: String) -> String {
         var s = ""
         for l in lines where l.layer == layer {
-            s += "\(fmt(l.a.x)) \(fmt(l.a.y)) m \(fmt(l.b.x)) \(fmt(l.b.y)) l S\n"
+            s += "\(formatMM(l.a.x)) \(formatMM(l.a.y)) m \(formatMM(l.b.x)) \(formatMM(l.b.y)) l S\n"
         }
         for p in polylines where p.layer == layer {
             guard let first = p.points.first else { continue }
-            s += "\(fmt(first.x)) \(fmt(first.y)) m\n"
+            s += "\(formatMM(first.x)) \(formatMM(first.y)) m\n"
             for pt in p.points.dropFirst() {
-                s += "\(fmt(pt.x)) \(fmt(pt.y)) l\n"
+                s += "\(formatMM(pt.x)) \(formatMM(pt.y)) l\n"
             }
             if p.closed { s += "h " }
             s += "S\n"
@@ -319,8 +269,8 @@ public final class PDFWriter: @unchecked Sendable {
             let rad = t.rotationDeg * .pi / 180
             let cosR = cos(rad), sinR = sin(rad)
             let pdfString = PDFWriter.escapeString(t.text)
-            s += "BT\n/F1 \(fmt(t.height)) Tf\n"
-            s += "\(fmt(cosR)) \(fmt(sinR)) \(fmt(-sinR)) \(fmt(cosR)) \(fmt(t.position.x)) \(fmt(t.position.y)) Tm\n"
+            s += "BT\n/F1 \(formatMM(t.height)) Tf\n"
+            s += "\(formatMM(cosR)) \(formatMM(sinR)) \(formatMM(-sinR)) \(formatMM(cosR)) \(formatMM(t.position.x)) \(formatMM(t.position.y)) Tm\n"
             s += "(\(pdfString)) Tj\nET\n"
         }
         return s
@@ -332,11 +282,11 @@ public final class PDFWriter: @unchecked Sendable {
     private static func circlePath(centre: SIMD2<Double>, radius: Double) -> String {
         let k = 0.5522847498 * radius
         let cx = centre.x, cy = centre.y
-        var s = "\(fmt(cx + radius)) \(fmt(cy)) m\n"
-        s += "\(fmt(cx + radius)) \(fmt(cy + k)) \(fmt(cx + k)) \(fmt(cy + radius)) \(fmt(cx)) \(fmt(cy + radius)) c\n"
-        s += "\(fmt(cx - k)) \(fmt(cy + radius)) \(fmt(cx - radius)) \(fmt(cy + k)) \(fmt(cx - radius)) \(fmt(cy)) c\n"
-        s += "\(fmt(cx - radius)) \(fmt(cy - k)) \(fmt(cx - k)) \(fmt(cy - radius)) \(fmt(cx)) \(fmt(cy - radius)) c\n"
-        s += "\(fmt(cx + k)) \(fmt(cy - radius)) \(fmt(cx + radius)) \(fmt(cy - k)) \(fmt(cx + radius)) \(fmt(cy)) c\n"
+        var s = "\(formatMM(cx + radius)) \(formatMM(cy)) m\n"
+        s += "\(formatMM(cx + radius)) \(formatMM(cy + k)) \(formatMM(cx + k)) \(formatMM(cy + radius)) \(formatMM(cx)) \(formatMM(cy + radius)) c\n"
+        s += "\(formatMM(cx - k)) \(formatMM(cy + radius)) \(formatMM(cx - radius)) \(formatMM(cy + k)) \(formatMM(cx - radius)) \(formatMM(cy)) c\n"
+        s += "\(formatMM(cx - radius)) \(formatMM(cy - k)) \(formatMM(cx - k)) \(formatMM(cy - radius)) \(formatMM(cx)) \(formatMM(cy - radius)) c\n"
+        s += "\(formatMM(cx + k)) \(formatMM(cy - radius)) \(formatMM(cx + radius)) \(formatMM(cy - k)) \(formatMM(cx + radius)) \(formatMM(cy)) c\n"
         s += "h S\n"
         return s
     }
@@ -357,7 +307,7 @@ public final class PDFWriter: @unchecked Sendable {
         var current = a0
         let startX = centre.x + radius * cos(current)
         let startY = centre.y + radius * sin(current)
-        s += "\(fmt(startX)) \(fmt(startY)) m\n"
+        s += "\(formatMM(startX)) \(formatMM(startY)) m\n"
         for _ in 0..<chunkCount {
             let next = current + chunkAngle
             let halfAngle = chunkAngle / 2
@@ -369,7 +319,7 @@ public final class PDFWriter: @unchecked Sendable {
             let t3 = SIMD2(-sin(next),    cos(next))    * radius * kappa * direction
             let p1 = p0 + t0
             let p2 = p3 - t3
-            s += "\(fmt(p1.x)) \(fmt(p1.y)) \(fmt(p2.x)) \(fmt(p2.y)) \(fmt(p3.x)) \(fmt(p3.y)) c\n"
+            s += "\(formatMM(p1.x)) \(formatMM(p1.y)) \(formatMM(p2.x)) \(formatMM(p2.y)) \(formatMM(p3.x)) \(formatMM(p3.y)) c\n"
             current = next
         }
         s += "S\n"
@@ -390,8 +340,4 @@ public final class PDFWriter: @unchecked Sendable {
         }
         return out
     }
-}
-
-private func fmt(_ v: Double) -> String {
-    String(format: "%.4f", v)
 }

--- a/Sources/OCCTSwift/SVGExporter.swift
+++ b/Sources/OCCTSwift/SVGExporter.swift
@@ -53,6 +53,8 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
     private var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
     private var arcs: [(centre: SIMD2<Double>, radius: Double, startDeg: Double, endDeg: Double, layer: String)] = []
     private var texts: [(position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double, layer: String)] = []
+    /// `DrawingPrimitiveSink.primitiveOps()`'s cache -- see `DrawingDispatch.swift`. #800.
+    internal var cachedPrimitiveOps: DrawingPrimitiveOps?
 
     public init(viewBox: (min: SIMD2<Double>, size: SIMD2<Double>)? = nil,
                  deflection: Double = 0.1) {
@@ -194,10 +196,14 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
             // Counter-flip the group's Y-flip so text reads right-side up.
             let rot = formatMM(-t.rotationDeg)
             let x = formatMM(t.position.x), y = formatMM(t.position.y)
+            // Negate the NUMBER, then format -- not the other way around. Prefixing a literal
+            // "-" onto an already-formatted string doubles up for a negative coordinate
+            // (e.g. y = -10 would print "--10.0000", which is not a valid SVG number: #800 review).
+            let negX = formatMM(-t.position.x), negY = formatMM(-t.position.y)
             let escaped = SVGWriter.escapeXML(t.text)
             s += "<text x=\"\(x)\" y=\"\(y)\" font-family=\"Helvetica\" "
             s += "font-size=\"\(formatMM(t.height))\" "
-            s += "transform=\"matrix(1,0,0,-1,0,0) translate(\(x),-\(y)) rotate(\(rot)) translate(-\(x),\(y))\" "
+            s += "transform=\"matrix(1,0,0,-1,0,0) translate(\(x),\(negY)) rotate(\(rot)) translate(\(negX),\(y))\" "
             s += "fill=\"black\" stroke=\"none\">\(escaped)</text>\n"
         }
         return s

--- a/Sources/OCCTSwift/SVGExporter.swift
+++ b/Sources/OCCTSwift/SVGExporter.swift
@@ -42,7 +42,7 @@ extension Exporter {
     }
 }
 
-public final class SVGWriter: @unchecked Sendable {
+public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
     /// Explicit viewBox override. When nil, the writer computes the viewBox
     /// from the staged content's bounding box at `write(to:)` time.
     public var viewBox: (min: SIMD2<Double>, size: SIMD2<Double>)?
@@ -100,21 +100,7 @@ public final class SVGWriter: @unchecked Sendable {
     public func collectFromDrawing(_ drawing: Drawing,
                                     translate: SIMD2<Double> = .zero,
                                     scale: Double = 1.0) {
-        collectProjectedEdges(drawing.visibleEdges, layer: "VISIBLE",
-                               translate: translate, scale: scale)
-        collectProjectedEdges(drawing.hiddenEdges, layer: "HIDDEN",
-                               translate: translate, scale: scale)
-        collectProjectedEdges(drawing.outlineEdges, layer: "OUTLINE",
-                               translate: translate, scale: scale)
-        let ops = primitiveOps()
-        for a in drawing.annotations {
-            let t = (translate == .zero && scale == 1.0) ? a : a.transformed(translate: translate, scale: scale)
-            emitAnnotation(t, into: ops)
-        }
-        for d in drawing.dimensions {
-            let t = (translate == .zero && scale == 1.0) ? d : d.transformed(translate: translate, scale: scale)
-            emitDimension(t, into: ops)
-        }
+        collectDrawing(drawing, translate: translate, scale: scale, into: self)
     }
 
     public func collectFromDrawing(_ transformed: TransformedDrawing) {
@@ -123,42 +109,16 @@ public final class SVGWriter: @unchecked Sendable {
                             scale: transformed.scale)
     }
 
-    private func collectProjectedEdges(_ compound: Shape?, layer: String,
-                                        translate: SIMD2<Double>, scale: Double) {
-        guard let compound else { return }
-        let polys = compound.allEdgePolylines(deflection: deflection)
-        func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
-        for poly in polys {
-            guard poly.count >= 2 else { continue }
-            let points2D = poly.map { t(SIMD2($0.x, $0.y)) }
-            if points2D.count == 2 {
-                addLine(from: points2D[0], to: points2D[1], layer: layer)
-            } else {
-                addPolyline(points2D, closed: false, layer: layer)
-            }
-        }
-    }
-
-    private func primitiveOps() -> DrawingPrimitiveOps {
-        DrawingPrimitiveOps(
-            addLine:     { [weak self] a, b, layer in self?.addLine(from: a, to: b, layer: layer) },
-            addPolyline: { [weak self] pts, closed, layer in self?.addPolyline(pts, closed: closed, layer: layer) },
-            addCircle:   { [weak self] c, r, layer in self?.addCircle(centre: c, radius: r, layer: layer) },
-            addArc:      { [weak self] c, r, sDeg, eDeg, layer in self?.addArc(centre: c, radius: r, startAngleDeg: sDeg, endAngleDeg: eDeg, layer: layer) },
-            addText:     { [weak self] txt, pos, h, rot, layer in self?.addText(txt, at: pos, height: h, rotationDeg: rot, layer: layer) }
-        )
-    }
-
     // MARK: - SVG serialization
 
     public func write(to url: URL) throws {
         let vb = viewBox ?? computedViewBox()
         var s = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         s += "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" "
-        s += "viewBox=\"\(fmt(vb.min.x)) \(fmt(vb.min.y)) \(fmt(vb.size.x)) \(fmt(vb.size.y))\" "
-        s += "width=\"\(fmt(vb.size.x))mm\" height=\"\(fmt(vb.size.y))mm\">\n"
+        s += "viewBox=\"\(formatMM(vb.min.x)) \(formatMM(vb.min.y)) \(formatMM(vb.size.x)) \(formatMM(vb.size.y))\" "
+        s += "width=\"\(formatMM(vb.size.x))mm\" height=\"\(formatMM(vb.size.y))mm\">\n"
         // Flip Y so drawing-space mathematical Y (up) maps to SVG screen Y (down).
-        s += "<g transform=\"translate(0,\(fmt(vb.min.y + vb.size.y))) scale(1,-1)\">\n"
+        s += "<g transform=\"translate(0,\(formatMM(vb.min.y + vb.size.y))) scale(1,-1)\">\n"
 
         let layerOrder = ["VISIBLE", "OUTLINE", "BORDER", "TITLE",
                            "HIDDEN", "CENTER", "DIMENSION", "HATCH", "TEXT"]
@@ -166,9 +126,9 @@ public final class SVGWriter: @unchecked Sendable {
             let chunks = emitLayerGeometry(layer: layer)
                         + emitLayerText(layer: layer)
             if !chunks.isEmpty {
-                let strokeWidth = SVGWriter.strokeWidth(for: layer)
+                let strokeWidth = strokeWidthMM(for: layer)
                 let dash = SVGWriter.dashPattern(for: layer)
-                var groupAttrs = "stroke=\"black\" stroke-width=\"\(fmt(strokeWidth))\" fill=\"none\""
+                var groupAttrs = "stroke=\"black\" stroke-width=\"\(formatMM(strokeWidth))\" fill=\"none\""
                 if !dash.isEmpty { groupAttrs += " stroke-dasharray=\"\(dash)\"" }
                 s += "<g id=\"\(layer)\" \(groupAttrs)>\n\(chunks)</g>\n"
             }
@@ -208,10 +168,10 @@ public final class SVGWriter: @unchecked Sendable {
     private func emitLayerGeometry(layer: String) -> String {
         var s = ""
         for l in lines where l.layer == layer {
-            s += "<line x1=\"\(fmt(l.a.x))\" y1=\"\(fmt(l.a.y))\" x2=\"\(fmt(l.b.x))\" y2=\"\(fmt(l.b.y))\"/>\n"
+            s += "<line x1=\"\(formatMM(l.a.x))\" y1=\"\(formatMM(l.a.y))\" x2=\"\(formatMM(l.b.x))\" y2=\"\(formatMM(l.b.y))\"/>\n"
         }
         for p in polylines where p.layer == layer {
-            let pts = p.points.map { "\(fmt($0.x)),\(fmt($0.y))" }.joined(separator: " ")
+            let pts = p.points.map { "\(formatMM($0.x)),\(formatMM($0.y))" }.joined(separator: " ")
             if p.closed {
                 s += "<polygon points=\"\(pts)\"/>\n"
             } else {
@@ -219,7 +179,7 @@ public final class SVGWriter: @unchecked Sendable {
             }
         }
         for c in circles where c.layer == layer {
-            s += "<circle cx=\"\(fmt(c.centre.x))\" cy=\"\(fmt(c.centre.y))\" r=\"\(fmt(c.radius))\"/>\n"
+            s += "<circle cx=\"\(formatMM(c.centre.x))\" cy=\"\(formatMM(c.centre.y))\" r=\"\(formatMM(c.radius))\"/>\n"
         }
         for a in arcs where a.layer == layer {
             s += svgArcPath(centre: a.centre, radius: a.radius,
@@ -232,11 +192,11 @@ public final class SVGWriter: @unchecked Sendable {
         var s = ""
         for t in texts where t.layer == layer {
             // Counter-flip the group's Y-flip so text reads right-side up.
-            let rot = fmt(-t.rotationDeg)
-            let x = fmt(t.position.x), y = fmt(t.position.y)
+            let rot = formatMM(-t.rotationDeg)
+            let x = formatMM(t.position.x), y = formatMM(t.position.y)
             let escaped = SVGWriter.escapeXML(t.text)
             s += "<text x=\"\(x)\" y=\"\(y)\" font-family=\"Helvetica\" "
-            s += "font-size=\"\(fmt(t.height))\" "
+            s += "font-size=\"\(formatMM(t.height))\" "
             s += "transform=\"matrix(1,0,0,-1,0,0) translate(\(x),-\(y)) rotate(\(rot)) translate(-\(x),\(y))\" "
             s += "fill=\"black\" stroke=\"none\">\(escaped)</text>\n"
         }
@@ -255,16 +215,7 @@ public final class SVGWriter: @unchecked Sendable {
         // screen-Y. SVG's "positive angle" is CW in screen-Y; setting sweep
         // to `span > 0 ? 1 : 0` gives the expected visual result.
         let sweep = span > 0 ? 1 : 0
-        return "<path d=\"M \(fmt(start.x)) \(fmt(start.y)) A \(fmt(radius)) \(fmt(radius)) 0 \(largeArc) \(sweep) \(fmt(end.x)) \(fmt(end.y))\"/>\n"
-    }
-
-    private static func strokeWidth(for layer: String) -> Double {
-        switch layer {
-        case "VISIBLE", "OUTLINE", "BORDER", "TITLE":  return 0.5
-        case "HIDDEN", "CENTER", "DIMENSION", "TEXT":   return 0.25
-        case "HATCH":                                    return 0.18
-        default:                                         return 0.25
-        }
+        return "<path d=\"M \(formatMM(start.x)) \(formatMM(start.y)) A \(formatMM(radius)) \(formatMM(radius)) 0 \(largeArc) \(sweep) \(formatMM(end.x)) \(formatMM(end.y))\"/>\n"
     }
 
     private static func dashPattern(for layer: String) -> String {
@@ -284,6 +235,3 @@ public final class SVGWriter: @unchecked Sendable {
     }
 }
 
-private func fmt(_ v: Double) -> String {
-    String(format: "%.4f", v)
-}

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2795,41 +2795,40 @@ private let golden795SVG = #"""
 <line x1="20.0000" y1="-2.5000" x2="20.0000" y2="5.5000"/>
 <line x1="20.0000" y1="5.5000" x2="18.5000" y2="2.3000"/>
 <line x1="20.0000" y1="5.5000" x2="21.5000" y2="2.3000"/>
-<text x="0.0000" y="-10.0000" font-family="Helvetica" font-size="4.0000" transform="matrix(1,0,0,-1,0,0) translate(0.0000,--10.0000) rotate(-0.0000) translate(-0.0000,-10.0000)" fill="black" stroke="none">PART-001</text>
+<text x="0.0000" y="-10.0000" font-family="Helvetica" font-size="4.0000" transform="matrix(1,0,0,-1,0,0) translate(0.0000,10.0000) rotate(-0.0000) translate(-0.0000,-10.0000)" fill="black" stroke="none">PART-001</text>
 <text x="20.0000" y="39.5000" font-family="Helvetica" font-size="5.0000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,-39.5000) rotate(-0.0000) translate(-20.0000,39.5000)" fill="black" stroke="none">A</text>
 <text x="20.0000" y="9.5000" font-family="Helvetica" font-size="5.0000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,-9.5000) rotate(-0.0000) translate(-20.0000,9.5000)" fill="black" stroke="none">A</text>
 <text x="45.0000" y="20.0000" font-family="Helvetica" font-size="4.5000" transform="matrix(1,0,0,-1,0,0) translate(45.0000,-20.0000) rotate(-0.0000) translate(-45.0000,20.0000)" fill="black" stroke="none">1</text>
-<text x="-8.0000" y="5.0000" font-family="Helvetica" font-size="4.5000" transform="matrix(1,0,0,-1,0,0) translate(-8.0000,-5.0000) rotate(-0.0000) translate(--8.0000,5.0000)" fill="black" stroke="none">2</text>
-<text x="20.0000" y="-6.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--6.0000) rotate(-0.0000) translate(-20.0000,-6.0000)" fill="black" stroke="none">40.00</text>
-<text x="20.0000" y="-12.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--12.0000) rotate(-0.0000) translate(-20.0000,-12.0000)" fill="black" stroke="none">40.00 ±0.050</text>
-<text x="20.0000" y="-18.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--18.0000) rotate(-0.0000) translate(-20.0000,-18.0000)" fill="black" stroke="none">40.00</text>
-<text x="20.0000" y="-16.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--16.0000) rotate(-0.0000) translate(-20.0000,-16.0000)" fill="black" stroke="none">+0.100</text>
-<text x="20.0000" y="-20.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--20.0000) rotate(-0.0000) translate(-20.0000,-20.0000)" fill="black" stroke="none">-0.050</text>
-<text x="20.0000" y="-24.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--24.0000) rotate(-0.0000) translate(-20.0000,-24.0000)" fill="black" stroke="none">40.00</text>
-<text x="20.0000" y="-22.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--22.0000) rotate(-0.0000) translate(-20.0000,-22.0000)" fill="black" stroke="none">+0.100</text>
-<text x="20.0000" y="-26.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--26.0000) rotate(-0.0000) translate(-20.0000,-26.0000)" fill="black" stroke="none">0</text>
-<text x="20.0000" y="-30.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--30.0000) rotate(-0.0000) translate(-20.0000,-30.0000)" fill="black" stroke="none">40.00</text>
-<text x="20.0000" y="-28.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--28.0000) rotate(-0.0000) translate(-20.0000,-28.0000)" fill="black" stroke="none">0</text>
-<text x="20.0000" y="-32.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--32.0000) rotate(-0.0000) translate(-20.0000,-32.0000)" fill="black" stroke="none">-0.100</text>
-<text x="20.0000" y="-36.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--36.0000) rotate(-0.0000) translate(-20.0000,-36.0000)" fill="black" stroke="none">40.00 H7</text>
-<text x="20.0000" y="-42.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--42.0000) rotate(-0.0000) translate(-20.0000,-42.0000)" fill="black" stroke="none">40.00</text>
-<text x="20.0000" y="-40.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--40.0000) rotate(-0.0000) translate(-20.0000,-40.0000)" fill="black" stroke="none">20.050</text>
-<text x="20.0000" y="-44.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--44.0000) rotate(-0.0000) translate(-20.0000,-44.0000)" fill="black" stroke="none">19.950</text>
+<text x="-8.0000" y="5.0000" font-family="Helvetica" font-size="4.5000" transform="matrix(1,0,0,-1,0,0) translate(-8.0000,-5.0000) rotate(-0.0000) translate(8.0000,5.0000)" fill="black" stroke="none">2</text>
+<text x="20.0000" y="-6.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,6.0000) rotate(-0.0000) translate(-20.0000,-6.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-12.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,12.0000) rotate(-0.0000) translate(-20.0000,-12.0000)" fill="black" stroke="none">40.00 ±0.050</text>
+<text x="20.0000" y="-18.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,18.0000) rotate(-0.0000) translate(-20.0000,-18.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-16.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,16.0000) rotate(-0.0000) translate(-20.0000,-16.0000)" fill="black" stroke="none">+0.100</text>
+<text x="20.0000" y="-20.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,20.0000) rotate(-0.0000) translate(-20.0000,-20.0000)" fill="black" stroke="none">-0.050</text>
+<text x="20.0000" y="-24.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,24.0000) rotate(-0.0000) translate(-20.0000,-24.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-22.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,22.0000) rotate(-0.0000) translate(-20.0000,-22.0000)" fill="black" stroke="none">+0.100</text>
+<text x="20.0000" y="-26.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,26.0000) rotate(-0.0000) translate(-20.0000,-26.0000)" fill="black" stroke="none">0</text>
+<text x="20.0000" y="-30.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,30.0000) rotate(-0.0000) translate(-20.0000,-30.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-28.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,28.0000) rotate(-0.0000) translate(-20.0000,-28.0000)" fill="black" stroke="none">0</text>
+<text x="20.0000" y="-32.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,32.0000) rotate(-0.0000) translate(-20.0000,-32.0000)" fill="black" stroke="none">-0.100</text>
+<text x="20.0000" y="-36.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,36.0000) rotate(-0.0000) translate(-20.0000,-36.0000)" fill="black" stroke="none">40.00 H7</text>
+<text x="20.0000" y="-42.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,42.0000) rotate(-0.0000) translate(-20.0000,-42.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-40.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,40.0000) rotate(-0.0000) translate(-20.0000,-40.0000)" fill="black" stroke="none">20.050</text>
+<text x="20.0000" y="-44.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,44.0000) rotate(-0.0000) translate(-20.0000,-44.0000)" fill="black" stroke="none">19.950</text>
 <text x="35.5885" y="21.5000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(35.5885,-21.5000) rotate(-0.0000) translate(-35.5885,21.5000)" fill="black" stroke="none">R8.00 ±0.020</text>
 <text x="25.0000" y="21.1603" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(25.0000,-21.1603) rotate(-0.0000) translate(-25.0000,21.1603)" fill="black" stroke="none">⌀10.00</text>
 <text x="12.7279" y="12.7279" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(12.7279,-12.7279) rotate(-0.0000) translate(-12.7279,12.7279)" fill="black" stroke="none">90.0°</text>
 <text x="14.1421" y="14.1421" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(14.1421,-14.1421) rotate(-0.0000) translate(-14.1421,14.1421)" fill="black" stroke="none">+0.500</text>
 <text x="11.3137" y="11.3137" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(11.3137,-11.3137) rotate(-0.0000) translate(-11.3137,11.3137)" fill="black" stroke="none">-0.500</text>
-<text x="40.0000" y="-5.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(40.0000,--5.0000) rotate(-90.0000) translate(-40.0000,-5.0000)" fill="black" stroke="none">40.00</text>
-<text x="-5.0000" y="25.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(-5.0000,-25.0000) rotate(-0.0000) translate(--5.0000,25.0000)" fill="black" stroke="none">25.00</text>
-<text x="40.0000" y="-5.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(40.0000,--5.0000) rotate(-90.0000) translate(-40.0000,-5.0000)" fill="black" stroke="none">40.00</text>
-<text x="-5.0000" y="25.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(-5.0000,-25.0000) rotate(-0.0000) translate(--5.0000,25.0000)" fill="black" stroke="none">25.00</text>
+<text x="40.0000" y="-5.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(40.0000,5.0000) rotate(-90.0000) translate(-40.0000,-5.0000)" fill="black" stroke="none">40.00</text>
+<text x="-5.0000" y="25.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(-5.0000,-25.0000) rotate(-0.0000) translate(5.0000,25.0000)" fill="black" stroke="none">25.00</text>
+<text x="40.0000" y="-5.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(40.0000,5.0000) rotate(-90.0000) translate(-40.0000,-5.0000)" fill="black" stroke="none">40.00</text>
+<text x="-5.0000" y="25.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(-5.0000,-25.0000) rotate(-0.0000) translate(5.0000,25.0000)" fill="black" stroke="none">25.00</text>
 </g>
 </g>
 </svg>
 
 """#
-
 private let golden795DXF = #"""
 0
 SECTION
@@ -4626,5 +4625,119 @@ struct ExporterDrawingCollectionGoldenTests {
         #expect(pdf.entityCounts.texts == svg.entityCounts.texts)
         #expect(pdf.entityCounts.texts == dxf.entityCounts.texts)
         #expect(pdf.entityCounts.texts == 3)  // main + upper + lower
+    }
+}
+
+// MARK: - #800 review: no writer emits a malformed double-sign numeric token
+//
+// A golden test pins BYTES, not correctness -- a golden regenerated from a still-broken
+// implementation is indistinguishable from one refreshed to hide a regression until the
+// bytes are read by eye. `emitLayerText` (SVGExporter.swift) used to build its
+// counter-rotation transform by string-concatenating a literal "-" in front of an
+// already-formatted coordinate instead of negating the number first, so a negative x or y
+// produced an invalid double-minus SVG number token (e.g. `translate(0.0000,--10.0000)`
+// for y = -10). That bug predated this PR but the golden fixture above captured it as
+// "correct" until now. These tests assert the property directly, so a future
+// regeneration that reintroduces the bug fails here regardless of what the golden bytes say.
+
+private func xmlAttributeValues(in content: String) -> [String] {
+    // Manual scan rather than a text-content regex: attribute values are always inside a
+    // `="..."` pair, which structurally excludes a `<text>`/`<title>` element's own inner
+    // text content (arbitrary user-supplied labels, which legitimately might contain "--").
+    var values: [String] = []
+    var searchStart = content.startIndex
+    while let eq = content.range(of: "=\"", range: searchStart..<content.endIndex) {
+        let valueStart = eq.upperBound
+        guard let closeQuote = content.range(of: "\"", range: valueStart..<content.endIndex) else { break }
+        values.append(String(content[valueStart..<closeQuote.lowerBound]))
+        searchStart = closeQuote.upperBound
+    }
+    return values
+}
+
+private func pdfContentStreamNonTextTokens(_ content: String) -> String {
+    // Strip every `(...)` string literal (the payload of a `Tj` text-show operator, the
+    // only place arbitrary label text appears) before scanning; everything left is PDF
+    // operators and the numbers this writer formats itself.
+    var stripped = ""
+    var depth = 0
+    for ch in content {
+        if ch == "(" { depth += 1; continue }
+        if ch == ")" { depth -= 1; continue }
+        if depth == 0 { stripped.append(ch) }
+    }
+    return stripped
+}
+
+private func dxfNonTextValues(_ content: String) -> [String] {
+    // DXF alternates group-code/value line pairs; group code 1 is the TEXT entity's own
+    // string payload (arbitrary label text), every other code's value is this writer's own
+    // formatted number or a fixed enum-ish string (layer/linetype/style names).
+    let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    var values: [String] = []
+    var i = 0
+    while i + 1 < lines.count {
+        if lines[i] != "1" { values.append(lines[i + 1]) }
+        i += 2
+    }
+    return values
+}
+
+@Suite("#800 review: no writer emits a malformed double-sign numeric token")
+struct DoubleMinusRegressionTests {
+    @Test("SVGWriter's counter-rotation transform never doubles a minus sign for a negative text position")
+    func svgTextTransformNegativePosition() throws {
+        let writer = SVGWriter()
+        writer.addText("label", at: SIMD2(-8, -10), height: 3.5, rotationDeg: 0, layer: "TEXT")
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("800_negative_text_\(UUID()).svg")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content.contains("<text"), "expected a <text> element to have been written")
+        for value in xmlAttributeValues(in: content) {
+            #expect(!value.contains("--"),
+                    "malformed double-sign numeric attribute value: \"\(value)\" in \(content)")
+        }
+    }
+
+    @Test("No XML attribute value in SVGWriter's golden-drawing output contains a double minus sign")
+    func svgGoldenHasNoDoubleMinus() throws {
+        let writer = SVGWriter()
+        writer.collectFromDrawing(makeGolden795Drawing())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("800_svg_golden_scan_\(UUID()).svg")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let offenders = xmlAttributeValues(in: content).filter { $0.contains("--") }
+        #expect(offenders.isEmpty, "malformed double-sign attribute value(s): \(offenders)")
+    }
+
+    @Test("No numeric operand in PDFWriter's content stream contains a double minus sign")
+    func pdfGoldenHasNoDoubleMinus() throws {
+        let writer = PDFWriter()
+        writer.collectFromDrawing(makeGolden795Drawing())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("800_pdf_golden_scan_\(UUID()).pdf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let data = try Data(contentsOf: url)
+        let content = String(data: data, encoding: .isoLatin1) ?? ""
+        let nonText = pdfContentStreamNonTextTokens(content)
+        #expect(!nonText.contains("--"), "malformed double-sign numeric token found outside text payloads")
+    }
+
+    @Test("No numeric value in DXFWriter's golden-drawing output contains a double minus sign")
+    func dxfGoldenHasNoDoubleMinus() throws {
+        let writer = DXFWriter()
+        writer.collectFromDrawing(makeGolden795Drawing())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("800_dxf_golden_scan_\(UUID()).dxf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let offenders = dxfNonTextValues(content).filter { $0.contains("--") }
+        #expect(offenders.isEmpty, "malformed double-sign value(s): \(offenders)")
     }
 }

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2654,3 +2654,1977 @@ struct MultibodyRobustImportTests {
         #expect(shape.isValid)
     }
 }
+
+// MARK: - #795: exporter drawing-collection consolidation golden output
+//
+// PDFExporter.primitiveOps()/collectFromDrawing()/collectProjectedEdges() and
+// SVGExporter's own copies scored 1.00 containment against each other (#784 duplication
+// rescan); DXFExporter shared collectProjectedEdges too and separately reimplemented
+// DrawingDispatch.swift's own formatTolerance/TolerancedLabel byte-for-byte, plus its whole
+// dimension + annotation dispatch. These are public export FORMATS -- a byte changed here is a
+// consumer-visible break, not a refactor detail (see #795). The golden bytes below were
+// captured from the pre-consolidation implementation (one independent copy of the
+// collection/dispatch pipeline per writer) and must stay byte-for-byte identical once all
+// three route through DrawingDispatch.swift's shared `DrawingPrimitiveSink` protocol.
+//
+// The fixture drawing exercises every `DrawingAnnotation` case (centreline, centermark,
+// textLabel, hatch, cuttingPlaneLine, and two balloons -- one with a leader, one without) and
+// every `DrawingTolerance` case on a linear dimension, plus one each of
+// radial/diameter/angular/ordinate -- the exact surface formatTolerance/emitAnnotation/
+// emitDimension cover. All edges come from a plain box's straight sides, so the fixture's
+// geometry is immune to any HLR-deflection nondeterminism a curved edge would introduce.
+
+private func makeGolden795Drawing() -> Drawing {
+    let box = Shape.box(width: 40, height: 25, depth: 15)!
+    let drawing = Drawing.frontView(of: box)!
+
+    drawing.addCentreLine(from: SIMD2(-5, 12.5), to: SIMD2(45, 12.5))
+    drawing.addCentermark(centre: SIMD2(20, 12.5), extent: 6)
+    drawing.addTextLabel("PART-001", at: SIMD2(0, -10), height: 4, rotation: 0)
+    drawing.addHatch(boundary: [SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 10), SIMD2(0, 10)],
+                      angle: 0, spacing: 5.0)
+    _ = drawing.addCuttingPlaneLine(label: "A",
+                                     cuttingPlaneOrigin: SIMD3(20, 12.5, 0),
+                                     cuttingPlaneNormal: SIMD3(1, 0, 0),
+                                     sectionViewDirection: SIMD3(0, 1, 0),
+                                     viewDirection: SIMD3(0, 0, 1),
+                                     traceLength: 30)
+    drawing.addBalloon(itemNumber: 1, at: SIMD2(45, 20), leaderTo: SIMD2(40, 15))
+    drawing.addBalloon(itemNumber: 2, at: SIMD2(-8, 5))
+
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -8,
+                                  tolerance: .none)))
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -14,
+                                  tolerance: .symmetric(0.05))))
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -20,
+                                  tolerance: .bilateral(plus: 0.10, minus: 0.05))))
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -26,
+                                  tolerance: .unilateral(0.10))))
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -32,
+                                  tolerance: .unilateral(-0.10))))
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -38,
+                                  tolerance: .fitClass("H7"))))
+    drawing.append(.linear(.init(from: SIMD2(0, 0), to: SIMD2(40, 0), offset: -44,
+                                  tolerance: .limits(lower: 19.95, upper: 20.05))))
+    drawing.append(.radial(.init(centre: SIMD2(20, 12.5), radius: 8, leaderAngle: .pi / 6,
+                                  tolerance: .symmetric(0.02))))
+    drawing.append(.diameter(.init(centre: SIMD2(20, 12.5), radius: 5, leaderAngle: .pi / 3,
+                                    tolerance: .none)))
+    drawing.append(.angular(.init(vertex: SIMD2(0, 0), ray1: SIMD2(40, 0), ray2: SIMD2(0, 25),
+                                   arcRadius: 15, tolerance: .bilateral(plus: 0.5, minus: 0.5))))
+    drawing.append(.ordinate(.init(origin: SIMD2(0, 0),
+                                    features: [.init(position: SIMD2(40, 0)),
+                                               .init(position: SIMD2(0, 25)),
+                                               .init(position: SIMD2(40, 25))],
+                                    tolerance: .none)))
+    return drawing
+}
+
+private let golden795SVG = #"""
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-20.0000 -49.0000 75.0000 93.5000" width="75.0000mm" height="93.5000mm">
+<g transform="translate(0,44.5000) scale(1,-1)">
+<g id="VISIBLE" stroke="black" stroke-width="0.5000" fill="none">
+<line x1="-7.5000" y1="-20.0000" x2="7.5000" y2="-20.0000"/>
+<line x1="-7.5000" y1="20.0000" x2="7.5000" y2="20.0000"/>
+<line x1="-7.5000" y1="-20.0000" x2="-7.5000" y2="20.0000"/>
+<line x1="7.5000" y1="-20.0000" x2="7.5000" y2="20.0000"/>
+</g>
+<g id="HIDDEN" stroke="black" stroke-width="0.2500" fill="none" stroke-dasharray="3,2">
+<line x1="-7.5000" y1="-20.0000" x2="7.5000" y2="-20.0000"/>
+<line x1="-7.5000" y1="20.0000" x2="7.5000" y2="20.0000"/>
+<line x1="-7.5000" y1="-20.0000" x2="-7.5000" y2="20.0000"/>
+<line x1="7.5000" y1="-20.0000" x2="7.5000" y2="20.0000"/>
+</g>
+<g id="CENTER" stroke="black" stroke-width="0.2500" fill="none" stroke-dasharray="8,2,2,2">
+<line x1="-5.0000" y1="12.5000" x2="45.0000" y2="12.5000"/>
+<line x1="17.0000" y1="12.5000" x2="23.0000" y2="12.5000"/>
+<line x1="20.0000" y1="9.5000" x2="20.0000" y2="15.5000"/>
+<line x1="20.0000" y1="27.5000" x2="20.0000" y2="21.5000"/>
+<line x1="20.0000" y1="3.5000" x2="20.0000" y2="-2.5000"/>
+<line x1="20.0000" y1="21.5000" x2="20.0000" y2="3.5000"/>
+</g>
+<g id="DIMENSION" stroke="black" stroke-width="0.2500" fill="none">
+<line x1="41.4645" y1="16.4645" x2="40.0000" y2="15.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-8.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-8.0000"/>
+<line x1="0.0000" y1="-8.0000" x2="40.0000" y2="-8.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-14.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-14.0000"/>
+<line x1="0.0000" y1="-14.0000" x2="40.0000" y2="-14.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-20.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-20.0000"/>
+<line x1="0.0000" y1="-20.0000" x2="40.0000" y2="-20.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-26.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-26.0000"/>
+<line x1="0.0000" y1="-26.0000" x2="40.0000" y2="-26.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-32.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-32.0000"/>
+<line x1="0.0000" y1="-32.0000" x2="40.0000" y2="-32.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-38.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-38.0000"/>
+<line x1="0.0000" y1="-38.0000" x2="40.0000" y2="-38.0000"/>
+<line x1="0.0000" y1="0.0000" x2="0.0000" y2="-44.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="-44.0000"/>
+<line x1="0.0000" y1="-44.0000" x2="40.0000" y2="-44.0000"/>
+<line x1="26.9282" y1="16.5000" x2="35.5885" y2="21.5000"/>
+<line x1="17.5000" y1="8.1699" x2="22.5000" y2="16.8301"/>
+<line x1="-3.0000" y1="0.0000" x2="3.0000" y2="0.0000"/>
+<line x1="0.0000" y1="-3.0000" x2="0.0000" y2="3.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="0.0000"/>
+<line x1="40.0000" y1="-2.0000" x2="40.0000" y2="2.0000"/>
+<line x1="0.0000" y1="25.0000" x2="0.0000" y2="25.0000"/>
+<line x1="-2.0000" y1="25.0000" x2="2.0000" y2="25.0000"/>
+<line x1="40.0000" y1="0.0000" x2="40.0000" y2="25.0000"/>
+<line x1="40.0000" y1="-2.0000" x2="40.0000" y2="2.0000"/>
+<line x1="0.0000" y1="25.0000" x2="40.0000" y2="25.0000"/>
+<line x1="-2.0000" y1="25.0000" x2="2.0000" y2="25.0000"/>
+<circle cx="45.0000" cy="20.0000" r="5.0000"/>
+<circle cx="-8.0000" cy="5.0000" r="5.0000"/>
+<circle cx="20.0000" cy="12.5000" r="8.0000"/>
+<path d="M 15.0000 0.0000 A 15.0000 15.0000 0 0 1 0.0000 15.0000"/>
+</g>
+<g id="HATCH" stroke="black" stroke-width="0.1800" fill="none">
+<line x1="0.0000" y1="0.0000" x2="10.0000" y2="0.0000"/>
+<line x1="0.0000" y1="5.0000" x2="10.0000" y2="5.0000"/>
+</g>
+<g id="TEXT" stroke="black" stroke-width="0.2500" fill="none">
+<line x1="20.0000" y1="27.5000" x2="20.0000" y2="35.5000"/>
+<line x1="20.0000" y1="35.5000" x2="18.5000" y2="32.3000"/>
+<line x1="20.0000" y1="35.5000" x2="21.5000" y2="32.3000"/>
+<line x1="20.0000" y1="-2.5000" x2="20.0000" y2="5.5000"/>
+<line x1="20.0000" y1="5.5000" x2="18.5000" y2="2.3000"/>
+<line x1="20.0000" y1="5.5000" x2="21.5000" y2="2.3000"/>
+<text x="0.0000" y="-10.0000" font-family="Helvetica" font-size="4.0000" transform="matrix(1,0,0,-1,0,0) translate(0.0000,--10.0000) rotate(-0.0000) translate(-0.0000,-10.0000)" fill="black" stroke="none">PART-001</text>
+<text x="20.0000" y="39.5000" font-family="Helvetica" font-size="5.0000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,-39.5000) rotate(-0.0000) translate(-20.0000,39.5000)" fill="black" stroke="none">A</text>
+<text x="20.0000" y="9.5000" font-family="Helvetica" font-size="5.0000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,-9.5000) rotate(-0.0000) translate(-20.0000,9.5000)" fill="black" stroke="none">A</text>
+<text x="45.0000" y="20.0000" font-family="Helvetica" font-size="4.5000" transform="matrix(1,0,0,-1,0,0) translate(45.0000,-20.0000) rotate(-0.0000) translate(-45.0000,20.0000)" fill="black" stroke="none">1</text>
+<text x="-8.0000" y="5.0000" font-family="Helvetica" font-size="4.5000" transform="matrix(1,0,0,-1,0,0) translate(-8.0000,-5.0000) rotate(-0.0000) translate(--8.0000,5.0000)" fill="black" stroke="none">2</text>
+<text x="20.0000" y="-6.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--6.0000) rotate(-0.0000) translate(-20.0000,-6.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-12.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--12.0000) rotate(-0.0000) translate(-20.0000,-12.0000)" fill="black" stroke="none">40.00 ±0.050</text>
+<text x="20.0000" y="-18.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--18.0000) rotate(-0.0000) translate(-20.0000,-18.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-16.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--16.0000) rotate(-0.0000) translate(-20.0000,-16.0000)" fill="black" stroke="none">+0.100</text>
+<text x="20.0000" y="-20.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--20.0000) rotate(-0.0000) translate(-20.0000,-20.0000)" fill="black" stroke="none">-0.050</text>
+<text x="20.0000" y="-24.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--24.0000) rotate(-0.0000) translate(-20.0000,-24.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-22.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--22.0000) rotate(-0.0000) translate(-20.0000,-22.0000)" fill="black" stroke="none">+0.100</text>
+<text x="20.0000" y="-26.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--26.0000) rotate(-0.0000) translate(-20.0000,-26.0000)" fill="black" stroke="none">0</text>
+<text x="20.0000" y="-30.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--30.0000) rotate(-0.0000) translate(-20.0000,-30.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-28.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--28.0000) rotate(-0.0000) translate(-20.0000,-28.0000)" fill="black" stroke="none">0</text>
+<text x="20.0000" y="-32.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--32.0000) rotate(-0.0000) translate(-20.0000,-32.0000)" fill="black" stroke="none">-0.100</text>
+<text x="20.0000" y="-36.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--36.0000) rotate(-0.0000) translate(-20.0000,-36.0000)" fill="black" stroke="none">40.00 H7</text>
+<text x="20.0000" y="-42.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--42.0000) rotate(-0.0000) translate(-20.0000,-42.0000)" fill="black" stroke="none">40.00</text>
+<text x="20.0000" y="-40.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--40.0000) rotate(-0.0000) translate(-20.0000,-40.0000)" fill="black" stroke="none">20.050</text>
+<text x="20.0000" y="-44.0000" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(20.0000,--44.0000) rotate(-0.0000) translate(-20.0000,-44.0000)" fill="black" stroke="none">19.950</text>
+<text x="35.5885" y="21.5000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(35.5885,-21.5000) rotate(-0.0000) translate(-35.5885,21.5000)" fill="black" stroke="none">R8.00 ±0.020</text>
+<text x="25.0000" y="21.1603" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(25.0000,-21.1603) rotate(-0.0000) translate(-25.0000,21.1603)" fill="black" stroke="none">⌀10.00</text>
+<text x="12.7279" y="12.7279" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(12.7279,-12.7279) rotate(-0.0000) translate(-12.7279,12.7279)" fill="black" stroke="none">90.0°</text>
+<text x="14.1421" y="14.1421" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(14.1421,-14.1421) rotate(-0.0000) translate(-14.1421,14.1421)" fill="black" stroke="none">+0.500</text>
+<text x="11.3137" y="11.3137" font-family="Helvetica" font-size="1.9250" transform="matrix(1,0,0,-1,0,0) translate(11.3137,-11.3137) rotate(-0.0000) translate(-11.3137,11.3137)" fill="black" stroke="none">-0.500</text>
+<text x="40.0000" y="-5.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(40.0000,--5.0000) rotate(-90.0000) translate(-40.0000,-5.0000)" fill="black" stroke="none">40.00</text>
+<text x="-5.0000" y="25.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(-5.0000,-25.0000) rotate(-0.0000) translate(--5.0000,25.0000)" fill="black" stroke="none">25.00</text>
+<text x="40.0000" y="-5.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(40.0000,--5.0000) rotate(-90.0000) translate(-40.0000,-5.0000)" fill="black" stroke="none">40.00</text>
+<text x="-5.0000" y="25.0000" font-family="Helvetica" font-size="3.5000" transform="matrix(1,0,0,-1,0,0) translate(-5.0000,-25.0000) rotate(-0.0000) translate(--5.0000,25.0000)" fill="black" stroke="none">25.00</text>
+</g>
+</g>
+</svg>
+
+"""#
+
+private let golden795DXF = #"""
+0
+SECTION
+2
+HEADER
+9
+$ACADVER
+1
+AC1009
+9
+$INSUNITS
+70
+4
+0
+ENDSEC
+0
+SECTION
+2
+TABLES
+0
+TABLE
+2
+LTYPE
+70
+4
+0
+LTYPE
+2
+CONTINUOUS
+70
+0
+3
+Solid line
+72
+65
+73
+0
+40
+0.000000
+0
+LTYPE
+2
+DASHED
+70
+0
+3
+Dashed ____ ____ ____
+72
+65
+73
+2
+40
+7.500000
+49
+5.000000
+49
+-2.500000
+0
+LTYPE
+2
+CHAIN
+70
+0
+3
+Chain ____ _ ____ _
+72
+65
+73
+4
+40
+15.000000
+49
+10.000000
+49
+-2.500000
+49
+0.000000
+49
+-2.500000
+0
+ENDTAB
+0
+TABLE
+2
+LAYER
+70
+11
+0
+LAYER
+2
+0
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+LAYER
+2
+VISIBLE
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+LAYER
+2
+HIDDEN
+70
+0
+62
+8
+6
+DASHED
+0
+LAYER
+2
+OUTLINE
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+LAYER
+2
+CENTER
+70
+0
+62
+1
+6
+CHAIN
+0
+LAYER
+2
+DIMENSION
+70
+0
+62
+5
+6
+CONTINUOUS
+0
+LAYER
+2
+TEXT
+70
+0
+62
+3
+6
+CONTINUOUS
+0
+LAYER
+2
+HATCH
+70
+0
+62
+9
+6
+CONTINUOUS
+0
+LAYER
+2
+SECTION
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+LAYER
+2
+BORDER
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+LAYER
+2
+TITLE
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+ENDTAB
+0
+TABLE
+2
+STYLE
+70
+1
+0
+STYLE
+2
+STANDARD
+70
+0
+40
+0.000000
+41
+1.000000
+50
+0.000000
+71
+0
+42
+2.500000
+3
+txt
+4
+
+0
+ENDTAB
+0
+ENDSEC
+0
+SECTION
+2
+BLOCKS
+0
+ENDSEC
+0
+SECTION
+2
+ENTITIES
+0
+LINE
+8
+VISIBLE
+10
+-7.500000
+20
+-20.000000
+30
+0.000000
+11
+7.500000
+21
+-20.000000
+31
+0.000000
+0
+LINE
+8
+VISIBLE
+10
+-7.500000
+20
+20.000000
+30
+0.000000
+11
+7.500000
+21
+20.000000
+31
+0.000000
+0
+LINE
+8
+VISIBLE
+10
+-7.500000
+20
+-20.000000
+30
+0.000000
+11
+-7.500000
+21
+20.000000
+31
+0.000000
+0
+LINE
+8
+VISIBLE
+10
+7.500000
+20
+-20.000000
+30
+0.000000
+11
+7.500000
+21
+20.000000
+31
+0.000000
+0
+LINE
+8
+HIDDEN
+10
+-7.500000
+20
+-20.000000
+30
+0.000000
+11
+7.500000
+21
+-20.000000
+31
+0.000000
+0
+LINE
+8
+HIDDEN
+10
+-7.500000
+20
+20.000000
+30
+0.000000
+11
+7.500000
+21
+20.000000
+31
+0.000000
+0
+LINE
+8
+HIDDEN
+10
+-7.500000
+20
+-20.000000
+30
+0.000000
+11
+-7.500000
+21
+20.000000
+31
+0.000000
+0
+LINE
+8
+HIDDEN
+10
+7.500000
+20
+-20.000000
+30
+0.000000
+11
+7.500000
+21
+20.000000
+31
+0.000000
+0
+LINE
+8
+CENTER
+10
+-5.000000
+20
+12.500000
+30
+0.000000
+11
+45.000000
+21
+12.500000
+31
+0.000000
+0
+LINE
+8
+CENTER
+10
+17.000000
+20
+12.500000
+30
+0.000000
+11
+23.000000
+21
+12.500000
+31
+0.000000
+0
+LINE
+8
+CENTER
+10
+20.000000
+20
+9.500000
+30
+0.000000
+11
+20.000000
+21
+15.500000
+31
+0.000000
+0
+LINE
+8
+HATCH
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+10.000000
+21
+0.000000
+31
+0.000000
+0
+LINE
+8
+HATCH
+10
+0.000000
+20
+5.000000
+30
+0.000000
+11
+10.000000
+21
+5.000000
+31
+0.000000
+0
+LINE
+8
+CENTER
+10
+20.000000
+20
+27.500000
+30
+0.000000
+11
+20.000000
+21
+21.500000
+31
+0.000000
+0
+LINE
+8
+CENTER
+10
+20.000000
+20
+3.500000
+30
+0.000000
+11
+20.000000
+21
+-2.500000
+31
+0.000000
+0
+LINE
+8
+CENTER
+10
+20.000000
+20
+21.500000
+30
+0.000000
+11
+20.000000
+21
+3.500000
+31
+0.000000
+0
+LINE
+8
+TEXT
+10
+20.000000
+20
+27.500000
+30
+0.000000
+11
+20.000000
+21
+35.500000
+31
+0.000000
+0
+LINE
+8
+TEXT
+10
+20.000000
+20
+35.500000
+30
+0.000000
+11
+18.500000
+21
+32.300000
+31
+0.000000
+0
+LINE
+8
+TEXT
+10
+20.000000
+20
+35.500000
+30
+0.000000
+11
+21.500000
+21
+32.300000
+31
+0.000000
+0
+LINE
+8
+TEXT
+10
+20.000000
+20
+-2.500000
+30
+0.000000
+11
+20.000000
+21
+5.500000
+31
+0.000000
+0
+LINE
+8
+TEXT
+10
+20.000000
+20
+5.500000
+30
+0.000000
+11
+18.500000
+21
+2.300000
+31
+0.000000
+0
+LINE
+8
+TEXT
+10
+20.000000
+20
+5.500000
+30
+0.000000
+11
+21.500000
+21
+2.300000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+41.464466
+20
+16.464466
+30
+0.000000
+11
+40.000000
+21
+15.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-8.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-8.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-8.000000
+30
+0.000000
+11
+40.000000
+21
+-8.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-14.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-14.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-14.000000
+30
+0.000000
+11
+40.000000
+21
+-14.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-20.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-20.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-20.000000
+30
+0.000000
+11
+40.000000
+21
+-20.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-26.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-26.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-26.000000
+30
+0.000000
+11
+40.000000
+21
+-26.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-32.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-32.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-32.000000
+30
+0.000000
+11
+40.000000
+21
+-32.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-38.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-38.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-38.000000
+30
+0.000000
+11
+40.000000
+21
+-38.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+11
+0.000000
+21
+-44.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+-44.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-44.000000
+30
+0.000000
+11
+40.000000
+21
+-44.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+26.928203
+20
+16.500000
+30
+0.000000
+11
+35.588457
+21
+21.500000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+17.500000
+20
+8.169873
+30
+0.000000
+11
+22.500000
+21
+16.830127
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+-3.000000
+20
+0.000000
+30
+0.000000
+11
+3.000000
+21
+0.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+-3.000000
+30
+0.000000
+11
+0.000000
+21
+3.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+0.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+-2.000000
+30
+0.000000
+11
+40.000000
+21
+2.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+25.000000
+30
+0.000000
+11
+0.000000
+21
+25.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+-2.000000
+20
+25.000000
+30
+0.000000
+11
+2.000000
+21
+25.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+0.000000
+30
+0.000000
+11
+40.000000
+21
+25.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+40.000000
+20
+-2.000000
+30
+0.000000
+11
+40.000000
+21
+2.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+0.000000
+20
+25.000000
+30
+0.000000
+11
+40.000000
+21
+25.000000
+31
+0.000000
+0
+LINE
+8
+DIMENSION
+10
+-2.000000
+20
+25.000000
+30
+0.000000
+11
+2.000000
+21
+25.000000
+31
+0.000000
+0
+CIRCLE
+8
+DIMENSION
+10
+45.000000
+20
+20.000000
+30
+0.000000
+40
+5.000000
+0
+CIRCLE
+8
+DIMENSION
+10
+-8.000000
+20
+5.000000
+30
+0.000000
+40
+5.000000
+0
+CIRCLE
+8
+DIMENSION
+10
+20.000000
+20
+12.500000
+30
+0.000000
+40
+8.000000
+0
+ARC
+8
+DIMENSION
+10
+0.000000
+20
+0.000000
+30
+0.000000
+40
+15.000000
+50
+0.000000
+51
+90.000000
+0
+TEXT
+8
+TEXT
+10
+0.000000
+20
+-10.000000
+30
+0.000000
+40
+4.000000
+1
+PART-001
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+39.500000
+30
+0.000000
+40
+5.000000
+1
+A
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+9.500000
+30
+0.000000
+40
+5.000000
+1
+A
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+45.000000
+20
+20.000000
+30
+0.000000
+40
+4.500000
+1
+1
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+-8.000000
+20
+5.000000
+30
+0.000000
+40
+4.500000
+1
+2
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-6.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-12.000000
+30
+0.000000
+40
+3.500000
+1
+40.00 ±0.050
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-18.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-16.000000
+30
+0.000000
+40
+1.925000
+1
++0.100
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-20.000000
+30
+0.000000
+40
+1.925000
+1
+-0.050
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-24.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-22.000000
+30
+0.000000
+40
+1.925000
+1
++0.100
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-26.000000
+30
+0.000000
+40
+1.925000
+1
+0
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-30.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-28.000000
+30
+0.000000
+40
+1.925000
+1
+0
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-32.000000
+30
+0.000000
+40
+1.925000
+1
+-0.100
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-36.000000
+30
+0.000000
+40
+3.500000
+1
+40.00 H7
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-42.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-40.000000
+30
+0.000000
+40
+1.925000
+1
+20.050
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+20.000000
+20
+-44.000000
+30
+0.000000
+40
+1.925000
+1
+19.950
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+35.588457
+20
+21.500000
+30
+0.000000
+40
+3.500000
+1
+R8.00 ±0.020
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+25.000000
+20
+21.160254
+30
+0.000000
+40
+3.500000
+1
+⌀10.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+12.727922
+20
+12.727922
+30
+0.000000
+40
+3.500000
+1
+90.0°
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+14.142136
+20
+14.142136
+30
+0.000000
+40
+1.925000
+1
++0.500
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+11.313708
+20
+11.313708
+30
+0.000000
+40
+1.925000
+1
+-0.500
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+40.000000
+20
+-5.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+90.000000
+0
+TEXT
+8
+TEXT
+10
+-5.000000
+20
+25.000000
+30
+0.000000
+40
+3.500000
+1
+25.00
+50
+0.000000
+0
+TEXT
+8
+TEXT
+10
+40.000000
+20
+-5.000000
+30
+0.000000
+40
+3.500000
+1
+40.00
+50
+90.000000
+0
+TEXT
+8
+TEXT
+10
+-5.000000
+20
+25.000000
+30
+0.000000
+40
+3.500000
+1
+25.00
+50
+0.000000
+0
+ENDSEC
+0
+EOF
+
+"""#
+
+private let golden795PDFBase64 = """
+JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwg
+L1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVu
+dCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA4NDEuMDAwMCA1OTUuMDAwMF0gL0NvbnRlbnRzIDQgMCBSIC9SZXNvdXJjZXMgPDwgL0Zv
+bnQgPDwgL0YxIDUgMCBSID4+ID4+ID4+CmVuZG9iago0IDAgb2JqCjw8IC9MZW5ndGggNTA0MiA+PgpzdHJlYW0KcQoyLjgzNDYg
+MCAwIDIuODM0NiAwIDAgY20KMCAwIDAgUkcKMC41MDAwIHcKW10gMCBkCi03LjUwMDAgLTIwLjAwMDAgbSA3LjUwMDAgLTIwLjAw
+MDAgbCBTCi03LjUwMDAgMjAuMDAwMCBtIDcuNTAwMCAyMC4wMDAwIGwgUwotNy41MDAwIC0yMC4wMDAwIG0gLTcuNTAwMCAyMC4w
+MDAwIGwgUwo3LjUwMDAgLTIwLjAwMDAgbSA3LjUwMDAgMjAuMDAwMCBsIFMKMC4yNTAwIHcKWzMgMl0gMCBkCi03LjUwMDAgLTIw
+LjAwMDAgbSA3LjUwMDAgLTIwLjAwMDAgbCBTCi03LjUwMDAgMjAuMDAwMCBtIDcuNTAwMCAyMC4wMDAwIGwgUwotNy41MDAwIC0y
+MC4wMDAwIG0gLTcuNTAwMCAyMC4wMDAwIGwgUwo3LjUwMDAgLTIwLjAwMDAgbSA3LjUwMDAgMjAuMDAwMCBsIFMKMC4yNTAwIHcK
+WzggMiAyIDJdIDAgZAotNS4wMDAwIDEyLjUwMDAgbSA0NS4wMDAwIDEyLjUwMDAgbCBTCjE3LjAwMDAgMTIuNTAwMCBtIDIzLjAw
+MDAgMTIuNTAwMCBsIFMKMjAuMDAwMCA5LjUwMDAgbSAyMC4wMDAwIDE1LjUwMDAgbCBTCjIwLjAwMDAgMjcuNTAwMCBtIDIwLjAw
+MDAgMjEuNTAwMCBsIFMKMjAuMDAwMCAzLjUwMDAgbSAyMC4wMDAwIC0yLjUwMDAgbCBTCjIwLjAwMDAgMjEuNTAwMCBtIDIwLjAw
+MDAgMy41MDAwIGwgUwowLjI1MDAgdwpbXSAwIGQKNDEuNDY0NSAxNi40NjQ1IG0gNDAuMDAwMCAxNS4wMDAwIGwgUwowLjAwMDAg
+MC4wMDAwIG0gMC4wMDAwIC04LjAwMDAgbCBTCjQwLjAwMDAgMC4wMDAwIG0gNDAuMDAwMCAtOC4wMDAwIGwgUwowLjAwMDAgLTgu
+MDAwMCBtIDQwLjAwMDAgLTguMDAwMCBsIFMKMC4wMDAwIDAuMDAwMCBtIDAuMDAwMCAtMTQuMDAwMCBsIFMKNDAuMDAwMCAwLjAw
+MDAgbSA0MC4wMDAwIC0xNC4wMDAwIGwgUwowLjAwMDAgLTE0LjAwMDAgbSA0MC4wMDAwIC0xNC4wMDAwIGwgUwowLjAwMDAgMC4w
+MDAwIG0gMC4wMDAwIC0yMC4wMDAwIGwgUwo0MC4wMDAwIDAuMDAwMCBtIDQwLjAwMDAgLTIwLjAwMDAgbCBTCjAuMDAwMCAtMjAu
+MDAwMCBtIDQwLjAwMDAgLTIwLjAwMDAgbCBTCjAuMDAwMCAwLjAwMDAgbSAwLjAwMDAgLTI2LjAwMDAgbCBTCjQwLjAwMDAgMC4w
+MDAwIG0gNDAuMDAwMCAtMjYuMDAwMCBsIFMKMC4wMDAwIC0yNi4wMDAwIG0gNDAuMDAwMCAtMjYuMDAwMCBsIFMKMC4wMDAwIDAu
+MDAwMCBtIDAuMDAwMCAtMzIuMDAwMCBsIFMKNDAuMDAwMCAwLjAwMDAgbSA0MC4wMDAwIC0zMi4wMDAwIGwgUwowLjAwMDAgLTMy
+LjAwMDAgbSA0MC4wMDAwIC0zMi4wMDAwIGwgUwowLjAwMDAgMC4wMDAwIG0gMC4wMDAwIC0zOC4wMDAwIGwgUwo0MC4wMDAwIDAu
+MDAwMCBtIDQwLjAwMDAgLTM4LjAwMDAgbCBTCjAuMDAwMCAtMzguMDAwMCBtIDQwLjAwMDAgLTM4LjAwMDAgbCBTCjAuMDAwMCAw
+LjAwMDAgbSAwLjAwMDAgLTQ0LjAwMDAgbCBTCjQwLjAwMDAgMC4wMDAwIG0gNDAuMDAwMCAtNDQuMDAwMCBsIFMKMC4wMDAwIC00
+NC4wMDAwIG0gNDAuMDAwMCAtNDQuMDAwMCBsIFMKMjYuOTI4MiAxNi41MDAwIG0gMzUuNTg4NSAyMS41MDAwIGwgUwoxNy41MDAw
+IDguMTY5OSBtIDIyLjUwMDAgMTYuODMwMSBsIFMKLTMuMDAwMCAwLjAwMDAgbSAzLjAwMDAgMC4wMDAwIGwgUwowLjAwMDAgLTMu
+MDAwMCBtIDAuMDAwMCAzLjAwMDAgbCBTCjQwLjAwMDAgMC4wMDAwIG0gNDAuMDAwMCAwLjAwMDAgbCBTCjQwLjAwMDAgLTIuMDAw
+MCBtIDQwLjAwMDAgMi4wMDAwIGwgUwowLjAwMDAgMjUuMDAwMCBtIDAuMDAwMCAyNS4wMDAwIGwgUwotMi4wMDAwIDI1LjAwMDAg
+bSAyLjAwMDAgMjUuMDAwMCBsIFMKNDAuMDAwMCAwLjAwMDAgbSA0MC4wMDAwIDI1LjAwMDAgbCBTCjQwLjAwMDAgLTIuMDAwMCBt
+IDQwLjAwMDAgMi4wMDAwIGwgUwowLjAwMDAgMjUuMDAwMCBtIDQwLjAwMDAgMjUuMDAwMCBsIFMKLTIuMDAwMCAyNS4wMDAwIG0g
+Mi4wMDAwIDI1LjAwMDAgbCBTCjUwLjAwMDAgMjAuMDAwMCBtCjUwLjAwMDAgMjIuNzYxNCA0Ny43NjE0IDI1LjAwMDAgNDUuMDAw
+MCAyNS4wMDAwIGMKNDIuMjM4NiAyNS4wMDAwIDQwLjAwMDAgMjIuNzYxNCA0MC4wMDAwIDIwLjAwMDAgYwo0MC4wMDAwIDE3LjIz
+ODYgNDIuMjM4NiAxNS4wMDAwIDQ1LjAwMDAgMTUuMDAwMCBjCjQ3Ljc2MTQgMTUuMDAwMCA1MC4wMDAwIDE3LjIzODYgNTAuMDAw
+MCAyMC4wMDAwIGMKaCBTCi0zLjAwMDAgNS4wMDAwIG0KLTMuMDAwMCA3Ljc2MTQgLTUuMjM4NiAxMC4wMDAwIC04LjAwMDAgMTAu
+MDAwMCBjCi0xMC43NjE0IDEwLjAwMDAgLTEzLjAwMDAgNy43NjE0IC0xMy4wMDAwIDUuMDAwMCBjCi0xMy4wMDAwIDIuMjM4NiAt
+MTAuNzYxNCAwLjAwMDAgLTguMDAwMCAwLjAwMDAgYwotNS4yMzg2IDAuMDAwMCAtMy4wMDAwIDIuMjM4NiAtMy4wMDAwIDUuMDAw
+MCBjCmggUwoyOC4wMDAwIDEyLjUwMDAgbQoyOC4wMDAwIDE2LjkxODMgMjQuNDE4MyAyMC41MDAwIDIwLjAwMDAgMjAuNTAwMCBj
+CjE1LjU4MTcgMjAuNTAwMCAxMi4wMDAwIDE2LjkxODMgMTIuMDAwMCAxMi41MDAwIGMKMTIuMDAwMCA4LjA4MTcgMTUuNTgxNyA0
+LjUwMDAgMjAuMDAwMCA0LjUwMDAgYwoyNC40MTgzIDQuNTAwMCAyOC4wMDAwIDguMDgxNyAyOC4wMDAwIDEyLjUwMDAgYwpoIFMK
+MTUuMDAwMCAwLjAwMDAgbQoxNS4wMDAwIDguMjg0MyA4LjI4NDMgMTUuMDAwMCAwLjAwMDAgMTUuMDAwMCBjClMKMC4xODAwIHcK
+W10gMCBkCjAuMDAwMCAwLjAwMDAgbSAxMC4wMDAwIDAuMDAwMCBsIFMKMC4wMDAwIDUuMDAwMCBtIDEwLjAwMDAgNS4wMDAwIGwg
+UwowLjI1MDAgdwpbXSAwIGQKQlQKL0YxIDQuMDAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDAuMDAwMCAtMTAu
+MDAwMCBUbQooUEFSVC0wMDEpIFRqCkVUCkJUCi9GMSA1LjAwMDAgVGYKMS4wMDAwIDAuMDAwMCAtMC4wMDAwIDEuMDAwMCAyMC4w
+MDAwIDM5LjUwMDAgVG0KKEEpIFRqCkVUCkJUCi9GMSA1LjAwMDAgVGYKMS4wMDAwIDAuMDAwMCAtMC4wMDAwIDEuMDAwMCAyMC4w
+MDAwIDkuNTAwMCBUbQooQSkgVGoKRVQKQlQKL0YxIDQuNTAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDQ1LjAw
+MDAgMjAuMDAwMCBUbQooMSkgVGoKRVQKQlQKL0YxIDQuNTAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIC04LjAw
+MDAgNS4wMDAwIFRtCigyKSBUagpFVApCVAovRjEgMy41MDAwIFRmCjEuMDAwMCAwLjAwMDAgLTAuMDAwMCAxLjAwMDAgMjAuMDAw
+MCAtNi4wMDAwIFRtCig0MC4wMCkgVGoKRVQKQlQKL0YxIDMuNTAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDIw
+LjAwMDAgLTEyLjAwMDAgVG0KKDQwLjAwIMKxMC4wNTApIFRqCkVUCkJUCi9GMSAzLjUwMDAgVGYKMS4wMDAwIDAuMDAwMCAtMC4w
+MDAwIDEuMDAwMCAyMC4wMDAwIC0xOC4wMDAwIFRtCig0MC4wMCkgVGoKRVQKQlQKL0YxIDEuOTI1MCBUZgoxLjAwMDAgMC4wMDAw
+IC0wLjAwMDAgMS4wMDAwIDIwLjAwMDAgLTE2LjAwMDAgVG0KKCswLjEwMCkgVGoKRVQKQlQKL0YxIDEuOTI1MCBUZgoxLjAwMDAg
+MC4wMDAwIC0wLjAwMDAgMS4wMDAwIDIwLjAwMDAgLTIwLjAwMDAgVG0KKC0wLjA1MCkgVGoKRVQKQlQKL0YxIDMuNTAwMCBUZgox
+LjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDIwLjAwMDAgLTI0LjAwMDAgVG0KKDQwLjAwKSBUagpFVApCVAovRjEgMS45MjUw
+IFRmCjEuMDAwMCAwLjAwMDAgLTAuMDAwMCAxLjAwMDAgMjAuMDAwMCAtMjIuMDAwMCBUbQooKzAuMTAwKSBUagpFVApCVAovRjEg
+MS45MjUwIFRmCjEuMDAwMCAwLjAwMDAgLTAuMDAwMCAxLjAwMDAgMjAuMDAwMCAtMjYuMDAwMCBUbQooMCkgVGoKRVQKQlQKL0Yx
+IDMuNTAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDIwLjAwMDAgLTMwLjAwMDAgVG0KKDQwLjAwKSBUagpFVApC
+VAovRjEgMS45MjUwIFRmCjEuMDAwMCAwLjAwMDAgLTAuMDAwMCAxLjAwMDAgMjAuMDAwMCAtMjguMDAwMCBUbQooMCkgVGoKRVQK
+QlQKL0YxIDEuOTI1MCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDIwLjAwMDAgLTMyLjAwMDAgVG0KKC0wLjEwMCkg
+VGoKRVQKQlQKL0YxIDMuNTAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDIwLjAwMDAgLTM2LjAwMDAgVG0KKDQw
+LjAwIEg3KSBUagpFVApCVAovRjEgMy41MDAwIFRmCjEuMDAwMCAwLjAwMDAgLTAuMDAwMCAxLjAwMDAgMjAuMDAwMCAtNDIuMDAw
+MCBUbQooNDAuMDApIFRqCkVUCkJUCi9GMSAxLjkyNTAgVGYKMS4wMDAwIDAuMDAwMCAtMC4wMDAwIDEuMDAwMCAyMC4wMDAwIC00
+MC4wMDAwIFRtCigyMC4wNTApIFRqCkVUCkJUCi9GMSAxLjkyNTAgVGYKMS4wMDAwIDAuMDAwMCAtMC4wMDAwIDEuMDAwMCAyMC4w
+MDAwIC00NC4wMDAwIFRtCigxOS45NTApIFRqCkVUCkJUCi9GMSAzLjUwMDAgVGYKMS4wMDAwIDAuMDAwMCAtMC4wMDAwIDEuMDAw
+MCAzNS41ODg1IDIxLjUwMDAgVG0KKFI4LjAwIMKxMC4wMjApIFRqCkVUCkJUCi9GMSAzLjUwMDAgVGYKMS4wMDAwIDAuMDAwMCAt
+MC4wMDAwIDEuMDAwMCAyNS4wMDAwIDIxLjE2MDMgVG0KKOKMgDEwLjAwKSBUagpFVApCVAovRjEgMy41MDAwIFRmCjEuMDAwMCAw
+LjAwMDAgLTAuMDAwMCAxLjAwMDAgMTIuNzI3OSAxMi43Mjc5IFRtCig5MC4wwrApIFRqCkVUCkJUCi9GMSAxLjkyNTAgVGYKMS4w
+MDAwIDAuMDAwMCAtMC4wMDAwIDEuMDAwMCAxNC4xNDIxIDE0LjE0MjEgVG0KKCswLjUwMCkgVGoKRVQKQlQKL0YxIDEuOTI1MCBU
+ZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIDExLjMxMzcgMTEuMzEzNyBUbQooLTAuNTAwKSBUagpFVApCVAovRjEgMy41
+MDAwIFRmCjAuMDAwMCAxLjAwMDAgLTEuMDAwMCAwLjAwMDAgNDAuMDAwMCAtNS4wMDAwIFRtCig0MC4wMCkgVGoKRVQKQlQKL0Yx
+IDMuNTAwMCBUZgoxLjAwMDAgMC4wMDAwIC0wLjAwMDAgMS4wMDAwIC01LjAwMDAgMjUuMDAwMCBUbQooMjUuMDApIFRqCkVUCkJU
+Ci9GMSAzLjUwMDAgVGYKMC4wMDAwIDEuMDAwMCAtMS4wMDAwIDAuMDAwMCA0MC4wMDAwIC01LjAwMDAgVG0KKDQwLjAwKSBUagpF
+VApCVAovRjEgMy41MDAwIFRmCjEuMDAwMCAwLjAwMDAgLTAuMDAwMCAxLjAwMDAgLTUuMDAwMCAyNS4wMDAwIFRtCigyNS4wMCkg
+VGoKRVQKUQoKZW5kc3RyZWFtCmVuZG9iago1IDAgb2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQg
+L0hlbHZldGljYSAvRW5jb2RpbmcgL1dpbkFuc2lFbmNvZGluZyA+PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBm
+IAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNjQgMDAwMDAgbiAKMDAwMDAwMDEyMSAwMDAwMCBuIAowMDAwMDAwMjU3IDAw
+MDAwIG4gCjAwMDAwMDUzNTEgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgo1NDQ4
+CiUlRU9GCg==
+"""
+
+@Suite("#795 exporter drawing-collection consolidation -- golden output")
+struct ExporterDrawingCollectionGoldenTests {
+    @Test("SVGWriter.collectFromDrawing output is byte-identical to the pre-consolidation capture")
+    func svgGolden() throws {
+        let writer = SVGWriter()
+        writer.collectFromDrawing(makeGolden795Drawing())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("795_golden_\(UUID()).svg")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content == golden795SVG)
+    }
+
+    @Test("DXFWriter.collectFromDrawing output is byte-identical to the pre-consolidation capture")
+    func dxfGolden() throws {
+        let writer = DXFWriter()
+        writer.collectFromDrawing(makeGolden795Drawing())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("795_golden_\(UUID()).dxf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content == golden795DXF)
+    }
+
+    @Test("PDFWriter.collectFromDrawing output is byte-identical to the pre-consolidation capture")
+    func pdfGolden() throws {
+        let writer = PDFWriter()
+        writer.collectFromDrawing(makeGolden795Drawing())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("795_golden_\(UUID()).pdf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let actual = try Data(contentsOf: url)
+        guard let expected = Data(base64Encoded: golden795PDFBase64,
+                                   options: .ignoreUnknownCharacters) else {
+            Issue.record("failed to decode golden PDF base64 fixture")
+            return
+        }
+        #expect(actual == expected)
+    }
+
+    /// Direct-API path (not via `Drawing`): `addDimension`/`addLine`/etc. staged by hand,
+    /// exercising `primitiveOps()` without `collectFromDrawing` in the loop. Not a golden-byte
+    /// comparison -- a lightweight structural check that every writer's direct entity-staging
+    /// API still produces the same entity counts after the consolidation.
+    @Test("Direct addDimension/addLine staging produces matching entity counts across all three writers")
+    func directStagingEntityCountsMatch() {
+        let dim = DrawingDimension.linear(.init(from: SIMD2(0, 0), to: SIMD2(10, 0),
+                                                 tolerance: .bilateral(plus: 0.1, minus: 0.05)))
+        let pdf = PDFWriter(); pdf.addLine(from: .zero, to: SIMD2(1, 1)); pdf.addDimension(dim)
+        let svg = SVGWriter(); svg.addLine(from: .zero, to: SIMD2(1, 1)); svg.addDimension(dim)
+        let dxf = DXFWriter(); dxf.addLine(from: .zero, to: SIMD2(1, 1)); dxf.addDimension(dim)
+        #expect(pdf.entityCounts.lines == svg.entityCounts.lines)
+        #expect(pdf.entityCounts.lines == dxf.entityCounts.lines)
+        #expect(pdf.entityCounts.texts == svg.entityCounts.texts)
+        #expect(pdf.entityCounts.texts == dxf.entityCounts.texts)
+        #expect(pdf.entityCounts.texts == 3)  // main + upper + lower
+    }
+}


### PR DESCRIPTION
## What & why

The largest finding from the #784 duplication rescan: `PDFExporter.swift`/`SVGExporter.swift`
duplicated `primitiveOps()`/`collectFromDrawing()`/`collectProjectedEdges()` almost verbatim
(score 1.00), and `DXFExporter.swift` separately reimplemented `DrawingDispatch.swift`'s own
`formatTolerance`/`TolerancedLabel` byte for byte, plus its whole dimension and annotation
dispatch pipeline (`emitLinear`/`emitRadial`/`emitDiameter`/`emitAngular`/`emitOrdinate`,
`collectAnnotations`/`emitBalloon`/`emitCuttingPlaneLine`/`emitHatch`), kept apart since v0.150
out of a documented, reasonable caution that DXF's entities might need a different intermediate
representation than PDF/SVG's line/text primitives.

Measured that they don't need one: `DXFWriter` already implements the same five primitives
(`addLine`/`addPolyline`/`addCircle`/`addArc`/`addText`), with identical signatures, that PDF/SVG
route through `DrawingPrimitiveOps`. All three writers now share one collection pipeline and one
dimension/annotation dispatcher, living in `DrawingDispatch.swift`. `DXFExporter.swift` goes from
637 to 254 lines.

**These are public export formats**, so the constraint driving every design decision here was:
output must be byte-identical before and after. See "Evidence" below.

### What moved into `DrawingDispatch.swift`

- `DrawingPrimitiveSink`, an internal protocol giving any conformer `primitiveOps()` for free
  (was hand-rolled identically in `PDFWriter` and `SVGWriter`, and is new for `DXFWriter`).
- `collectDrawing(_:translate:scale:into:)`, the shared edge + annotation + dimension collection
  body. Each writer keeps its own **explicit `public func collectFromDrawing`** (both overloads),
  whose body is now one line calling this.
- `collectProjectedEdges(...)`, previously three independently hand-written copies of the
  identical tessellate-and-stage loop (PDF, SVG, DXF).
- `strokeWidthMM(for:)` and `formatMM(_:)`, previously duplicated between PDF and SVG only. Both
  are genuinely shared design commitments, not a coincidence of today's stroke model: both
  writers' header comments already independently stated the same ISO 128-20 weight table before
  this PR, and both express lengths in the same physical unit (mm) their content streams are
  scaled to. DXF has no equivalent concept (colour + linetype per layer, no per-entity line
  weight) and is correctly not part of either.

### What I deliberately left separate

- `dashPattern(for:)` on PDF and SVG: same mm lengths, genuinely different string syntax per
  consumer (`"[3 2] 0"` vs `"3,2"`). Not merged.
- DXF's own number formatting (`%.6f` via its `pair(_:_:)` helper): a different precision from
  PDF/SVG's shared `%.4f`, so DXF is intentionally not part of `formatMM`.
- `entityCounts`: identical one-line getters on all three writers, but outside this issue's scope
  and not surfaced by the #784 rescan (a one-liner, like the #792 precedent noted in the rescan's
  own README); left alone rather than scope-creeping the PR.

### A design decision the issue explicitly left open, resolved by direct reading

The issue's "Fix" section only asked for the `formatTolerance` piece plus factoring DXF's own
`addDimension`/`collectDimensions` switch into one dispatcher, and separately posed as "a real
open question" whether DXF's whole dimension pipeline could route through the shared
`emitDimension`/`DrawingPrimitiveOps` abstraction, given DXF does not use it for everything.
Reading DXF's `emitLinear`/`emitRadial`/`emitDiameter`/`emitAngular`/`emitOrdinate` line by line
against `DrawingDispatch.swift`'s own showed them to be the **identical logic**, just calling
`self.addLine(from:to:layer:)` directly instead of through an `ops` closure. The same was true,
undocumented by the issue, of DXF's `collectAnnotations`/`emitBalloon`/`emitCuttingPlaneLine`/
`emitHatch` against `emitAnnotation`'s family. Both are now routed through the shared dispatcher;
DXF's own copies (about 380 lines) are deleted rather than kept as a second, independent
implementation of the same question.

### A real regression caught before landing, not shipped

First pass put `collectFromDrawing` itself into the `DrawingPrimitiveSink` protocol extension as
a default method. `swift build`/`swift test` (via `@testable import`) stayed green throughout, but
`check-docs-defaults.py` failed: it could no longer find `collectFromDrawing`'s declaration in
`PDFExporter.swift`/`SVGExporter.swift`/`DXFExporter.swift` to match against
`docs/reference/Export-Vector.md`, because the declaration had moved to `DrawingDispatch.swift`.
That census failure was the signal for a real problem, not a tooling gap: an internal protocol's
extension-provided method is not reliably part of a conforming `public` type's externally visible
API, and `@testable import`-based tests cannot tell the difference between "public" and
"internal" the way a real external consumer can. Fixed by keeping an explicit `public func
collectFromDrawing` on each writer (same signatures, same default values, same file, same
declaration the docs page already resolves by filename), with the body forwarding one line into
the shared `collectDrawing(...)` free function instead of inheriting a protocol default. No docs
edit was needed once this was fixed, consistent with the constraint that this PR touch only
`Sources/OCCTSwift/{PDFExporter,SVGExporter,DXFExporter,DrawingDispatch}.swift` and their tests.

Closes #795

## Evidence

**Golden-output tests** (`ExporterDrawingCollectionGoldenTests` in
`Tests/OCCTIOTests/OCCTIOTests.swift`) capture the pre-consolidation PDF/SVG/DXF bytes for a
fixture drawing exercising every `DrawingAnnotation` case (centreline, centermark, textLabel,
hatch, cuttingPlaneLine, and two balloons, one with a leader and one without) and every
`DrawingTolerance` case on a linear dimension (`.none`/`.symmetric`/`.bilateral`/`.unilateral`
both signs/`.fitClass`/`.limits`), plus one each of radial/diameter/angular/ordinate dimensions.
All edges come from a plain box's straight sides, so the fixture is immune to any HLR-deflection
nondeterminism a curved edge would introduce. The captured PDF/SVG/DXF bytes are embedded as
literals in the test (PDF as base64, since it contains a few non-ASCII marker bytes; SVG/DXF as
raw Swift string literals, since both are plain UTF-8 text) and compared byte-for-byte
(`String`/`Data` equality) against fresh output from the consolidated code. All four tests
(SVG/DXF/PDF golden byte comparison, plus a direct-API entity-count structural check) pass after
consolidation.

**Removal matrix** (per `prove-the-test-fails.md`): each shared mechanism was broken in turn, the
golden suite run, the break confirmed to fail exactly the predicted subset, then restored and
confirmed green again.

| Row | Mechanism broken | Shared by | PDF golden | SVG golden | DXF golden |
|---|---|---|---|---|---|
| A | `strokeWidthMM` (HATCH 0.18 to 0.99) | PDF+SVG only | FAIL | FAIL | pass |
| B | `formatMM` (%.4f to %.2f) | PDF+SVG only | FAIL | FAIL | pass |
| C | `collectProjectedEdges` (line endpoints swapped) | all three | FAIL | FAIL | FAIL |
| D | `formatTolerance` (symmetric sign: plus/minus symbol changed) | all three, DXF newly | FAIL | FAIL | **FAIL** |
| E | `emitBalloon` (leader-line guard disabled) | all three, DXF newly | FAIL | FAIL | **FAIL** |

Rows A/B confirm the PDF+SVG-only helpers are correctly NOT shared with DXF (DXF stays green,
as it should, since it has no stroke-width or shared-precision concept). Row C confirms all three
now genuinely share the edge-collection loop. **Rows D and E are the ones that matter for this
issue**: before this PR, breaking `formatTolerance` or `emitBalloon` in `DrawingDispatch.swift`
would never have failed a DXF test, because DXF had its own independent copy of both. After, DXF's
golden test fails exactly like PDF/SVG's, proving DXF is no longer maintaining a second copy of
either. This directly demonstrates the exact bug class #795 raised: a tolerance-formatting bug
fixed only in the obviously shared file would previously have silently missed DXF.

Every injection was restored and the golden suite re-confirmed green before moving to the next
row; final state is clean (`git diff --stat` on `DrawingDispatch.swift` shows only the real
consolidation, no leftover injected changes).

## Full verification

- `swift build` clean.
- `swift test`: 5514 tests, 1441 suites, all pass.
- All 9 `Scripts/*.py` scripts (the 7 in CLAUDE.md's "Static Gate Scripts" plus
  `derive-shape-domain-split.py`/`derive-swift-file-split.py`) pass, each with its `--self-test`
  where supported. `check-docs-defaults.py` in particular: 3428/3431 restated declarations
  matched (the 3 unmatched are pre-existing baseline entries unrelated to this change), 0 drifted.
  `count-operations.py`: README/API_REFERENCE totals unchanged (4306), since no public entry point
  was added or removed, only their implementations consolidated.

## CHANGELOG entry

### PDF/SVG/DXF exporters share one drawing-collection pipeline instead of three independent copies (#795)

`PDFExporter.swift`, `SVGExporter.swift` and `DXFExporter.swift` now route their edge, annotation
and dimension collection through one shared implementation in `DrawingDispatch.swift`
(`DrawingPrimitiveSink`, `collectDrawing`, `collectProjectedEdges`, `strokeWidthMM`, `formatMM`),
instead of each independently hand-rolling its own copy. `DXFExporter.swift`'s own
`formatTolerance`/`TolerancedLabel` and its separate dimension/annotation dispatch pipeline
(`emitLinear`/`emitRadial`/`emitDiameter`/`emitAngular`/`emitOrdinate`,
`collectAnnotations`/`emitBalloon`/`emitCuttingPlaneLine`/`emitHatch`) are removed in favour of
the same shared dispatcher PDF/SVG already used, closing the gap where a tolerance-formatting fix
made to the shared file could previously miss DXF entirely. No public API signature changed and
output is byte-identical, verified by golden-output tests over every annotation and tolerance
case. Internal only.

## SemVer impact

NONE. No public type, method, or default value was added, removed, or changed;
`collectFromDrawing`, `addDimension`, `addLine`/`addPolyline`/`addCircle`/`addArc`/`addText`, and
every other public member of `PDFWriter`/`SVGWriter`/`DXFWriter` keep their exact prior signatures
and behavior. Output is proven byte-identical for every case a golden test exercises (see
Evidence). This is an internal implementation consolidation; nothing for a consumer to migrate.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR: `ExporterDrawingCollectionGoldenTests`
      (golden byte comparisons for all three formats, plus a direct-API entity-count check).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here: see the five-row removal matrix under "Evidence" above. (No new
      `--self-test` cases were added; this PR does not touch a gate script.)
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- Scope was deliberately held to `Sources/OCCTSwift/{PDFExporter,SVGExporter,DXFExporter,DrawingDispatch}.swift`
  and their existing test home (`Tests/OCCTIOTests/OCCTIOTests.swift`, where `PDFWriterTests`/
  `SVGWriterTests`/DXF export tests already lived), per the parallel-PR constraint (#798 rewrites
  thirteen other files in `Sources/OCCTSwift`; a separate PR covers #791 in the bridge). No other
  files are touched, including `docs/reference/Export-Vector.md`, `docs/CHANGELOG.md`, and
  `docs/SEMVER.md`.
- The annotation-dispatch duplication in DXF (`collectAnnotations`/`emitBalloon`/
  `emitCuttingPlaneLine`/`emitHatch` against `DrawingDispatch.swift`'s `emitAnnotation` family)
  was not called out in the #795 issue body at all; it was found by direct reading while
  consolidating the dimension pipeline, in the same spirit as #792's precedent (a one-line
  duplication the rescan's shingle threshold was blind to because the call syntax differs, direct
  method calls versus a closure bundle, even though the logic is byte-identical). Fixed in the
  same PR since it is the same underlying pipeline.
- Existing DXFWriter tests scattered across `OCCTDrawingTests`/`OCCTCurveTests`/
  `OCCTFoundationTests`/`OCCTMiscTests` (tolerance formatting, ordinate dimensioning, balloon
  entity counts) were run unmodified and all pass, since they assert on `entityCounts`/file
  content rather than on which internal function produced them.
