### PR TITLE
docs(#802): existence gate, exhaustive snippet check, five behavior pages corrected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,18 @@ jobs:
         if: '!cancelled()'
         run: python3 Scripts/check-docs-defaults.py
 
+      # #802: checks that a symbol docs/ documents as current API still exists in
+      # Sources/OCCTSwift. Sibling of check-docs-defaults.py above (which checks a documented
+      # *default*, not existence) — a symbol check-docs-defaults never sees because it was already
+      # resolved to a live declaration is exactly the gap this closes.
+      - name: check-docs-existence.py --self-test
+        if: '!cancelled()'
+        run: python3 Scripts/check-docs-existence.py --self-test
+
+      - name: check-docs-existence.py
+        if: '!cancelled()'
+        run: python3 Scripts/check-docs-existence.py
+
       - name: derive-bridge-header-split.py --self-test
         if: '!cancelled()'
         run: python3 Scripts/derive-bridge-header-split.py --self-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 
 ### Static Gate Scripts
 
-Five gates, one census and one merge-history audit, all pure Python over the repo's own text. No
+Six gates, one census and one merge-history audit, all pure Python over the repo's own text. No
 OCCT, no build, no network, ~3s for the lot. **CI runs every gate, plus every `--self-test` including the census's, in `ci.yml`'s
 `gate-scripts` job** — a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
@@ -71,6 +71,7 @@ repo's only branch protection. Three consequences worth knowing before you touch
 python3 Scripts/check-bridge-index.py            # OCCTBridge.h's class → symbol index: stale / misfiled entries
 python3 Scripts/check-null-handle-guards.py      # every bridge fn guards the Handle, not just the pointer
 python3 Scripts/check-docs-defaults.py           # every default docs/reference/ restates matches its declaration
+python3 Scripts/check-docs-existence.py          # every symbol docs/ documents as current still exists in Sources (#802)
 python3 Scripts/derive-bridge-header-split.py --verify  # every declaration sits in the header its .mm owns (#673)
 python3 Scripts/count-operations.py              # README + API_REFERENCE totals match the derived count
 python3 Scripts/census-unmeasured-values.py      # CENSUS, not a gate: values returned as measurements that were never computed (#726)
@@ -83,7 +84,7 @@ the tree. CI therefore runs only its `--self-test`: a bare run could never fail 
 signal. Its detector can still go blind, which is the failure every other entry here exists to
 prevent, so that is what CI holds it to.
 
-Four of the five gates take `--self-test`, as do the census and the merge-history audit, each running a fixture battery proving the *detector* catches each
+Five of the six gates take `--self-test`, as do the census and the merge-history audit, each running a fixture battery proving the *detector* catches each
 failure mode. Run it whenever you change one of these scripts — three gate scripts on this branch
 were confidently wrong (#618, #624/#630, #626), and a detector that reports "all clear" because it
 is blind looks exactly like one reporting "all clear" because the tree is clean.
@@ -91,7 +92,7 @@ is blind looks exactly like one reporting "all clear" because the tree is clean.
 running the report, so writing `count-operations.py --self-test` to match its siblings fails loudly
 instead of passing forever.
 
-**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs eleven of CI's twelve
+**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs thirteen of CI's fourteen
 invocations, flag for flag. The one it omits is `check-changelog-transcription.py`'s real run, which
 audits the branch's merge history and so answers a question about the branch rather than about the
 commit you are making; its `--self-test` does run. That is the only deliberate divergence between

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ let points = curve.drawAdaptive(curvatureDeflection: 0.1)
 ### GLTF Export
 
 ```swift
-try Exporter.writeGLTF(shape: model, to: gltfURL)
-try Exporter.writeGLB(shape: model, to: glbURL)
+try Exporter.writeGLTF(shape: model, to: gltfURL, binary: false)   // text glTF (.gltf)
+try Exporter.writeGLTF(shape: model, to: glbURL)                   // binary glTF (.glb), the default
 ```
 
 ## Architecture

--- a/Scripts/check-docs-existence.py
+++ b/Scripts/check-docs-existence.py
@@ -409,6 +409,7 @@ class Report:
         self.stale = []          # (path, line, kind, type_or_None, member, resolved_by)
         self.historical = []     # (path, line, text): acknowledged, not failing
         self.unresolved = []     # (path, line, member): no owning type could be pinned
+        self.seen = set()        # every member name a doc reference resolved to, for --coverage
 
 
 def doc_type_exists(t, live_types):
@@ -587,6 +588,12 @@ def _resolve_context(context_stack, path):
 def _check_and_record(cls, resolved_type, path, lineno, historical, rep, live_types, live_members,
                        live_free, fallback_types=None):
     rep.checked += 1
+    # Record the name regardless of outcome: --coverage asks whether docs MENTION a symbol, which a
+    # stale reference still does. Coverage and staleness are separate questions and a symbol can
+    # fail one while passing the other.
+    _mentioned = cls[2] if cls[0] == 'dotted' else cls[1]
+    if _mentioned:
+        rep.seen.add(_mentioned)
     kind = cls[0]
     if kind == 'dotted':
         # Strict: the page states the owning type itself, so this is exactly the shape #802 warns
@@ -637,6 +644,51 @@ def _check_and_record(cls, resolved_type, path, lineno, historical, rep, live_ty
             rep.historical.append((path, lineno, label))
             return
         rep.stale.append((path, lineno, 'heading', resolved_type, member, 'bare_member'))
+
+
+def coverage(live_members, seen):
+    """Which live public members are named nowhere in docs/ (#802 item 5).
+
+    The INVERSE of what this script normally asks. The gate walks docs and checks each reference
+    resolves; this walks the source and checks each member is referenced. A clean gate run says
+    nothing about coverage, which is why the two are separate modes rather than one number.
+
+    Excluded, deliberately:
+      - `_`-prefixed names, conventionally private-by-convention even when `public`.
+      - PascalCase members, which are nested TYPES rather than functions or properties.
+      - anything under a `CodingKeys` type, a `Codable` implementation detail no consumer calls.
+
+    Measured this way the answer is roughly a quarter of the surface. Measured with an ad hoc regex
+    over `Type.member` and `member(` it comes out around 25% higher, because a member documented as
+    a bare heading or in running prose is invisible to that shape. That wrong number was produced
+    once, believed, and nearly acted on, which is why this lives in the script that already parses
+    docs correctly instead of being re-derived per investigation.
+    """
+    missing = {}
+    total = 0
+    for owner, members in live_members.items():
+        if 'CodingKeys' in owner:
+            continue
+        for member in members:
+            if member.startswith('_') or member[:1].isupper():
+                continue
+            total += 1
+            if member not in seen:
+                missing.setdefault(owner, []).append(member)
+    return total, {k: sorted(v) for k, v in missing.items()}
+
+
+def print_coverage(total, missing):
+    n = sum(len(v) for v in missing.values())
+    print(f"live public members      : {total}")
+    print(f"named nowhere in docs/   : {n}  ({100 * n / max(total, 1):.1f}%)")
+    print(f"types with a gap         : {len(missing)}")
+    if not missing:
+        return
+    print("\nlargest gaps:")
+    for owner, members in sorted(missing.items(), key=lambda kv: -len(kv[1]))[:20]:
+        print(f"  {owner:<38} {len(members):>4}  {', '.join(members[:3])}"
+              + (" ..." if len(members) > 3 else ""))
 
 
 def in_scope_doc_paths():
@@ -808,8 +860,52 @@ def self_test():
             print(f'  FAIL  {name}')
             print(f'          expected {want_key}={expect_count}')
             print(f'          got      stale={got["stale"]} historical={got["historical"]}')
-    print(f'\nself-test: {len(SELF_TEST_CASES) - failures} passed, {failures} failed')
+    failures += _coverage_self_test()
+    print(f'\nself-test: {len(SELF_TEST_CASES) + _COVERAGE_CASES - failures} passed, {failures} failed')
     return failures
+
+
+_COVERAGE_CASES = 4
+
+
+def _coverage_self_test():
+    """Prove --coverage distinguishes documented from undocumented, and honours its exclusions.
+
+    Worth its own cases rather than trusting the shared fixtures: coverage reads `rep.seen`, which
+    the staleness path populates as a side effect, so a change that stopped recording it would leave
+    every staleness case passing while coverage silently reported the whole surface as undocumented.
+    """
+    src = {'S.swift': (
+        'public struct Widget {\n'
+        '    public func documented() {}\n'
+        '    public func undocumented() {}\n'
+        '    public func _hidden() {}\n'
+        '    public var Nested: Int { 0 }\n'
+        '}\n'
+        'public struct WidgetCodingKeys {\n'
+        '    public var excluded: Int { 0 }\n'
+        '}\n')}
+    docs = {'d.md': '# Widget\n\n### `Widget.documented()`\n\nText.\n'}
+    live_types, live_members, live_free, conf = extract_source_symbols(src)
+    resolve_conformances(live_members, conf)
+    rep = Report()
+    for path in sorted(docs):
+        scan_doc_file(path, docs[path], live_types, live_members, live_free, rep)
+    total, missing = coverage(live_members, rep.seen)
+    flat = {m for v in missing.values() for m in v}
+
+    checks = [
+        ('coverage: a documented member is not reported missing', 'documented' not in flat),
+        ('coverage: an undocumented member IS reported missing', 'undocumented' in flat),
+        ('coverage: an underscore-prefixed member is excluded', '_hidden' not in flat),
+        ('coverage: a CodingKeys member is excluded', 'excluded' not in flat),
+    ]
+    bad = 0
+    for label, ok in checks:
+        print(f'  {"PASS" if ok else "FAIL"}  {label}')
+        if not ok:
+            bad += 1
+    return bad
 
 
 def main():
@@ -817,6 +913,9 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--self-test', action='store_true',
                     help='run the removal-matrix battery instead of scanning the tree')
+    ap.add_argument('--coverage', action='store_true',
+                    help='inverse mode: which live public members are named nowhere in docs/. '
+                         'Reports only, never fails.')
     ap.add_argument('--verbose', action='store_true',
                     help='also list acknowledged-historical and unresolved-context entries')
     ap.add_argument('--quiet', action='store_true', help='exit status only')
@@ -837,6 +936,13 @@ def main():
         with open(path, encoding='utf-8') as fh:
             text = fh.read()
         scan_doc_file(path, text, live_types, live_members, live_free, rep)
+
+    if args.coverage:
+        total, missing = coverage(live_members, rep.seen)
+        print_coverage(total, missing)
+        # Never fails. Coverage is a backlog to work through, not a property of a correct tree, and
+        # a gate that fails on it would fail every build until the backlog is empty.
+        return 0
 
     unresolved_grew = len(rep.unresolved) > EXPECTED_UNRESOLVED
     if not args.quiet:

--- a/Scripts/check-docs-existence.py
+++ b/Scripts/check-docs-existence.py
@@ -1,0 +1,856 @@
+#!/usr/bin/env python3
+r"""Verify that every symbol `docs/` documents as current API still exists in `Sources/OCCTSwift`.
+
+#802: the v2.0.0 release removes 62 deprecated symbols (#784/PR #798) and renames or replaces
+several more. During that PR two stale reference pages were found only by a reviewer reading
+closely: `BRepGraph-Editor-Identity.md` showed a live-looking `@available(*, deprecated) public var
+generation` signature for a property the same PR deleted, and `FeatureRecognition.md` described a
+call two separate PRs had already replaced. Nothing else in this repo's `Scripts/` checks
+existence; `check-docs-defaults.py` checks that a documented *default* matches its declaration, but
+only after already resolving the doc entry to a live declaration, so a symbol that no longer has
+one is invisible to it, not a false pass.
+
+## The trap this script exists to not fall into
+
+A name-only grep produces false positives in both directions once a rename shares a bare word with
+something still live: `ShapeContentsExtended.nbEdges` and `Curve2D.fromCircleArc` are real, current
+symbols whose bare member name (`nbEdges`) or prefix (`fromCircle`) collides with a *removed* one
+(`Shape.nbEdges`, `Conic2D.fromCircle`). A checker keyed on the bare word alone cannot tell
+`ShapeContentsExtended.nbEdges` (fine) from `Shape.nbEdges` (gone) apart, or `Curve2D.fromCircleArc`
+(fine) from a substring match against `fromCircle` (gone, and on a different type entirely).
+
+So every check here is keyed on the exact **(owning type, member name)** pair, resolved the same
+way `check-docs-defaults.py` resolves one: never on the member name alone.
+
+## Two channels
+
+1. **Backtick-quoted `###`-`######` headings** (`### \`AAG.detectHoles()\``, `### \`generation\``).
+   This is the reference pages' own convention for "this heading declares a symbol", verified
+   against all 65 pages: every prose section heading at this depth is un-backticked
+   (`### Queries`, `### Creation`); every backtick-quoted one names a real symbol. A **dotted**
+   heading (`Type.member`) is checked strictly, type and member both, exactly as in "the trap"
+   above. A **bare** heading (no dot, like `### \`shape\``, a stored-property page style) cannot be
+   checked that strictly: real pages resolve their owning type two incompatible ways depending on
+   file (a genuine type name, `## AAG`, or a `// MARK:`-style group label, `## Properties`,
+   `## Evaluation`, reused verbatim across many files for many types), and several pages
+   (`Document-Analysis-Builders.md`, `Document-Math-Bounds.md`, ...) are grab-bag completions pages
+   whose filename names none of the types they document. Measured directly: resolving a bare
+   heading's type via context/filename and requiring an exact match against THAT guess produced
+   946 candidates on the real tree, and reading a sample showed the guess wrong nearly every time
+   (`fixWireGaps`, real and live on `Shape`, resolved via filename to `Document` and reported
+   stale). So a bare heading's existence is asked **globally**: does *any* live type (or the
+   free-function namespace) have this exact member name, with the guessed type and a same-heading
+   a same-heading dash-separated `Type[, Type...]` disambiguator suffix
+   (`### \`distance(to:deflection:)\` — Wire, Edge, Face`)
+   tried first, as a nicety, not a requirement. This cannot resurrect "the trap": a dotted mention
+   is never downgraded to the global check.
+   - `## H2` prose headings are *not* separately existence-checked, for the reason above: a
+     genuine type and an OCCT C++ class named for background (`## Adaptor3d_IsoCurve`, not a Swift
+     symbol at all) share the identical un-backticked convention, and nothing short of reading
+     tells those apart. They are still harvested as *context*, one of several inputs into the
+     global bare-member check above, never load-bearing alone.
+2. **Inline `` `Type.member` `` mentions in prose**, anywhere in the scanned text outside a fenced
+   block (`docs/reference/README.md`'s own authoring **template**, inside a ` ```markdown ` fence,
+   would otherwise read as a real page and its literal placeholder `### \`Type.method(label:)\``
+   as a stale symbol; any fence is skipped, not just ` ```swift `). This is what caught the two
+   known misses' *sibling* shape: prose describing a call without giving it its own heading.
+   Requires an explicit dot, so a plain backtick-quoted English word never becomes a candidate, and
+   is checked as strictly as a dotted heading (never the relaxed global check above, since a
+   fabricated dotted mention has no legitimate ambiguous-heading excuse).
+
+A member declaration is extracted regardless of its access level (`public`, `internal`, `private`).
+Existence, not visibility, is the question here, and access-gating produces exactly the wrong
+false positive: `Face.exactBounds` (`internal var`) and `FeatureRecognition.swift`'s `buildGraph()`
+(`private func`) are both real, both correctly documented for context, and an access-level gate
+would read both as "removed". It also sidesteps a trap in trying to gate on access at all:
+`public private(set) var storage` is fully public to read, but a naive scan for the word `private`
+finds it inside `private(set)` and would misclassify the whole line.
+
+## What "removed" annotation suppresses, and why it does not just get skipped
+
+A page that correctly documents a removal (`### \`generation\` *(removed in v2.0.0)*`, or prose
+noting "removed at v2.0.0 (#784)") *mentions* a name this script's live index no longer contains.
+That is correct, not drift, so a heading or sentence carrying an explicit removal/deprecation word
+is excluded from failing the run, but still counted and reported (`--verbose`), not silently
+dropped, so a reviewer can confirm the annotation is honest rather than trusting the absence of a
+complaint.
+
+## Scope
+
+`docs/**/*.md` and `README.md`, excluding `docs/CHANGELOG.md` and `docs/SEMVER.md` (append-only
+historical ledgers this project's own policy forbids a PR from editing, and which legitimately
+narrate removed/renamed names in their own past tense: scanning them would be checking a diary for
+using the past tense). `docs/occt-upgrades.md` is in scope: it is prose about OCCT kernel version
+history, essentially no Swift symbol density, and excluding it would just be one more silent carve
+-out to remember.
+
+Usage (from the repo root):
+
+    python3 Scripts/check-docs-existence.py                # report stale references
+    python3 Scripts/check-docs-existence.py --self-test     # run the removal-matrix battery
+    python3 Scripts/check-docs-existence.py --verbose       # also list acknowledged-historical and
+                                                             # unresolved-context entries
+
+Exit status is 1 when a stale reference is found, or when the unresolved-context bucket grows past
+its pinned baseline (the same "growth is drift" convention `check-docs-defaults.py` uses for its
+`unmatched` bucket). CI runs it, and its `--self-test`, in `ci.yml`'s `gate-scripts` job.
+"""
+import argparse
+import glob
+import os
+import re
+import sys
+
+SRC_GLOB = 'Sources/OCCTSwift/*.swift'
+DOC_GLOB = 'docs/**/*.md'
+README = 'README.md'
+EXCLUDED_DOCS = {'docs/CHANGELOG.md', 'docs/SEMVER.md'}
+
+# Bare-context and inline-prose resolution sometimes cannot pin an owning type at all (a bare
+# member heading under a purely prose H2, in a file whose name doesn't match any live type). Each
+# is investigated once and either fixed (give the page a resolvable heading/context) or added here
+# with a one-line reason. Growth beyond this is unreported drift the gate would otherwise miss
+# silently, exactly the failure mode `check-docs-defaults.py`'s `EXPECTED_UNMATCHED` guards against.
+EXPECTED_UNRESOLVED = 0
+
+# --- shared skeleton/type-tracking machinery (same approach as check-docs-defaults.py) --------
+
+
+def code_skeleton(line, in_block):
+    """Blank out strings and comments so brace/keyword scanning sees only code."""
+    out, i, in_str = [], 0, False
+    while i < len(line):
+        c = line[i]
+        if in_block:
+            if c == '*' and i + 1 < len(line) and line[i + 1] == '/':
+                in_block = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_str:
+            if c == '\\':
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            i += 1
+            continue
+        if c == '/' and i + 1 < len(line):
+            if line[i + 1] == '/':
+                break
+            if line[i + 1] == '*':
+                in_block = True
+                i += 2
+                continue
+        out.append(c)
+        i += 1
+    return ''.join(out), in_block
+
+
+# The name group allows a dot: `extension Shape.History {` is the only place Swift permits one,
+# and it must be captured whole, not truncated at the dot, or the nested type never gets a
+# `qualified` name distinct from its enclosing one.
+TYPE_RE = re.compile(
+    r'^\s*(?:public\s+|internal\s+|private\s+|fileprivate\s+|open\s+)?'
+    r'(?:final\s+|indirect\s+)*(?P<kind>extension|struct|class|enum|actor|protocol)\s+'
+    r'(?P<name>[A-Za-z_][A-Za-z0-9_.]*)'
+)
+FUNC_RE = re.compile(
+    r'\b(?:public\s+|open\s+)?'
+    r'(?:static\s+|class\s+|final\s+|mutating\s+|override\s+|convenience\s+|required\s+'
+    r'|nonisolated\s+)*'
+    r'(?P<kind>func|init|subscript)\b\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)?(?P<optional>[?!])?'
+)
+VAR_RE = re.compile(
+    r'\b(?:public\s+|open\s+)?'
+    r'(?:static\s+|class\s+|final\s+|lazy\s+|weak\s+|unowned(?:\([^)]*\))?\s+|override\s+)*'
+    # A reserved word escaped as an identifier (`` static let `default` = ... ``, needed because
+    # `default` cannot otherwise be spelled as a property name) wears backticks Swift strips at
+    # compile time; a doc referencing it (`Material.default`) never shows them either.
+    r'(?:var|let)\s+`?(?P<name>[A-Za-z_][A-Za-z0-9_]*)`?'
+)
+TYPEALIAS_RE = re.compile(r'\btypealias\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)')
+CASE_RE = re.compile(r'^\s*case\s+(?P<rest>.+?):?\s*$')
+
+
+def split_top_level(text, sep=','):
+    parts, depth, buf, i = [], 0, [], 0
+    while i < len(text):
+        c = text[i]
+        if c in '([{<':
+            depth += 1
+        elif c in ')]}>':
+            depth -= 1
+        if c == sep and depth <= 0:
+            parts.append(''.join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append(''.join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _record(ctx, name, live_types, live_members, live_free):
+    if ctx is None:
+        live_free.add(name)
+    else:
+        live_members.setdefault(ctx['qualified'], set()).add(name)
+
+
+def _scan_member_line(skeleton, ctx, live_types, live_members, live_free):
+    """Record every var/let/func/init/subscript/deinit/case/typealias directly in a type's body
+    (or at file top level), regardless of access level.
+
+    This is deliberately NOT access-level-aware, unlike `check-docs-defaults.py`'s declaration
+    extractor: that script's job is verifying a *public* API's restated default, so gating on
+    `public`/`open` is correct for it. This script's job is existence, and an access-level gate
+    produces exactly the wrong kind of false positive for it: `Face.exactBounds` (`internal var`)
+    and `FeatureRecognition.swift`'s `buildGraph()` (`private func`) are both real, both correctly
+    documented for context, and both would read as "removed" under a public-only gate. There is
+    also a correctness trap in trying to gate on access at all: `public private(set) var storage`
+    is fully readable (public getter), but a naive access-modifier search finds "private" inside
+    "private(set)" and would misclassify the whole declaration as non-public.
+    """
+    is_enum_case = CASE_RE.match(skeleton)
+    if is_enum_case:
+        if not (ctx and ctx['kind'] == 'enum'):
+            return
+        for part in split_top_level(is_enum_case.group('rest')):
+            m = re.match(r'[A-Za-z_][A-Za-z0-9_]*', part.strip())
+            if m:
+                _record(ctx, m.group(0), live_types, live_members, live_free)
+        return
+
+    if re.search(r'\bdeinit\b', skeleton):
+        _record(ctx, 'deinit', live_types, live_members, live_free)
+        return
+
+    m = FUNC_RE.search(skeleton)
+    if m:
+        name = m.group('name') or m.group('kind')
+        if m.group('kind') in ('init', 'subscript'):
+            name = m.group('kind')
+        _record(ctx, name, live_types, live_members, live_free)
+        return
+    m = TYPEALIAS_RE.search(skeleton)
+    if m:
+        _record(ctx, m.group('name'), live_types, live_members, live_free)
+        qualified = m.group('name') if ctx is None else ctx['qualified'] + '.' + m.group('name')
+        live_types.add(qualified)
+        return
+    m = VAR_RE.search(skeleton)
+    if m:
+        _record(ctx, m.group('name'), live_types, live_members, live_free)
+
+
+def _conformance_targets(skeleton, after):
+    """`class WireCurve: ArcLengthCurveAdaptor, @unchecked Sendable {` -> {'ArcLengthCurveAdaptor',
+    'Sendable'}. A member a doc attributes to `WireCurve` can be declared nowhere near it: a
+    protocol EXTENSION supplies it once for every conformer (`ArcLengthCurveAdaptor`'s
+    `maximumSampleCount`, inherited by both `WireCurve` and `EdgeCurve`), so a conforming type's
+    member lookup must also walk what it conforms to. Superclasses and generic constraints land in
+    the same set as protocols; checking a superclass's members too is harmless; a bare constraint
+    like `AnyObject` matches nothing and costs one empty lookup.
+    """
+    rest = skeleton[after:]
+    brace_idx = rest.find('{')
+    colon_idx = rest.find(':')
+    if colon_idx == -1 or (brace_idx != -1 and colon_idx > brace_idx):
+        return set()
+    clause = rest[colon_idx + 1: brace_idx if brace_idx != -1 else len(rest)]
+    out = set()
+    for part in split_top_level(clause):
+        part = re.sub(r'^@\w+\s+', '', part.strip())   # `@unchecked Sendable` -> `Sendable`
+        m = re.match(r'[A-Za-z_][A-Za-z0-9_]*', part)
+        if m:
+            out.add(m.group(0))
+    return out
+
+
+def extract_source_symbols(files):
+    """files: {path: text} -> (live_types, live_members, live_free, conformances).
+
+    `conformances`: qualified type name -> set of protocol/superclass names it declares itself
+    conforming to, textually (see `_conformance_targets`).
+    """
+    live_types, live_members, live_free = set(), {}, set()
+    conformances = {}
+    for path in sorted(files):
+        lines = files[path].split('\n')
+        type_stack = []
+        brace_depth = 0
+        pending_type = None
+        in_block = False
+        for line in lines:
+            skeleton, next_block = code_skeleton(line, in_block)
+            was_in_block = in_block
+            in_block = next_block
+            depth_before = brace_depth
+            tm = None
+
+            if not was_in_block:
+                tm = TYPE_RE.match(skeleton)
+                if tm:
+                    kind = tm.group('kind')
+                    name = tm.group('name')
+                    ctx = type_stack[-1] if type_stack else None
+                    # `extension Shape.History {` puts the dot INSIDE `name` (TYPE_RE's name
+                    # group allows one), so `qualified` is then already fully formed and must not
+                    # be re-prefixed by an unrelated enclosing ctx.
+                    qualified = name if ('.' in name or ctx is None) else ctx['qualified'] + '.' + name
+                    live_types.add(qualified)
+                    _record(ctx, name, live_types, live_members, live_free)
+                    targets = _conformance_targets(skeleton, tm.end())
+                    if targets:
+                        conformances.setdefault(qualified, set()).update(targets)
+                    pending_type = {'short': name, 'qualified': qualified, 'kind': kind}
+                if pending_type and '{' in skeleton:
+                    type_stack.append({**pending_type, 'depth': depth_before})
+                    pending_type = None
+
+            if not was_in_block and not tm:
+                ctx = type_stack[-1] if type_stack else None
+                direct_member = ctx is not None and depth_before == ctx['depth'] + 1
+                top_level = ctx is None and depth_before == 0
+                if direct_member or top_level:
+                    _scan_member_line(skeleton, ctx, live_types, live_members, live_free)
+
+            brace_depth += skeleton.count('{') - skeleton.count('}')
+            while type_stack and brace_depth <= type_stack[-1]['depth']:
+                type_stack.pop()
+    return live_types, live_members, live_free, conformances
+
+
+def resolve_conformances(live_members, conformances):
+    """Mutates `live_members` so every conforming type's set also contains what it inherits from
+    a protocol/superclass's own members: a protocol EXTENSION supplies a member once for every
+    conformer, with no separate declaration near the conforming type to find. Called once, right
+    after `extract_source_symbols`, so every later lookup (`doc_member_exists`,
+    `member_exists_anywhere`) needs no changes at all. Transitive and cycle-safe.
+    """
+    def expand(t, visited):
+        if t in visited:
+            return set()
+        visited = visited | {t}
+        acc = set(live_members.get(t, set()))
+        for target in conformances.get(t, set()):
+            acc |= expand(target, visited)
+        return acc
+
+    for t in list(conformances):
+        live_members[t] = expand(t, set())
+
+
+# --- doc-side extraction ------------------------------------------------------------------------
+
+HEADING_BACKTICK_RE = re.compile(r'^(#{2,6})\s+`([^`]+)`\s*(.*)$')
+HEADING_BARE_RE = re.compile(r'^(#{2,6})\s+(.+?)\s*$')
+HISTORICAL_RE = re.compile(r'\b(removed|deprecated|no longer exists|renamed)\b', re.IGNORECASE)
+INLINE_DOTTED_RE = re.compile(
+    r'`([A-Z][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)(?:\([^`]*\))?`')
+# ANY opening fence, not just ```swift. `docs/reference/README.md` shows the per-page authoring
+# TEMPLATE inside a ```markdown block (literal `### `Type.method(label:)`` as a placeholder), and
+# a swift-only check let a placeholder heading reach channel 1 and get reported as a stale symbol.
+# A ```bash/```json/etc. block never contains a Swift symbol worth channel 2 checking either.
+FENCE_OPEN_RE = re.compile(r'^\s*```')
+FENCED_END_RE = re.compile(r'^\s*```\s*$')
+IDENTIFIER_SHAPED_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_.]*$')
+
+
+def strip_disambiguation(text):
+    """`contains(uid:) — GraphUID` -> ('contains(uid:)', 'GraphUID'). Split on the FIRST em/en
+    dash or ` - ` only, since a symbol itself never contains one."""
+    for sep in (' — ', ' – ', ' - '):
+        if sep in text:
+            head, _, tail = text.partition(sep)
+            return head.strip(), tail.strip()
+    return text.strip(), ''
+
+
+def classify_symbol(text):
+    """`'Type.member(...)'` -> ('dotted', type, member); bare PascalCase -> ('bare_type', name);
+    bare lowerCamel -> ('bare_member', name); anything else (a phrase, an operator) -> None."""
+    text = text.split('(')[0].strip()
+    if not text:
+        return None
+    if '.' in text:
+        head, _, tail = text.rpartition('.')
+        if re.fullmatch(r'[A-Z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]*[A-Za-z][A-Za-z0-9_]*)*', head) \
+                and re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]*', tail):
+            return ('dotted', head, tail)
+        return None
+    if re.fullmatch(r'[A-Z][A-Za-z0-9_]*', text):
+        return ('bare_type', text)
+    if re.fullmatch(r'[a-zA-Z_][A-Za-z0-9_]*', text):
+        return ('bare_member', text)
+    return None
+
+
+def suffix_type_candidates(suffix):
+    """`'Wire, Edge, Face'` -> ['Wire', 'Edge', 'Face']. `'per-pass control (#266)'` -> []."""
+    cleaned = re.sub(r'\(#\d+\)', '', suffix).strip()
+    if not cleaned:
+        return []
+    parts = [p.strip().strip('[]') for p in cleaned.split(',')]
+    if all(re.fullmatch(r'[A-Z][A-Za-z0-9_]*', p) for p in parts):
+        return parts
+    return []
+
+
+class Report:
+    def __init__(self):
+        self.checked = 0
+        self.stale = []          # (path, line, kind, type_or_None, member, resolved_by)
+        self.historical = []     # (path, line, text): acknowledged, not failing
+        self.unresolved = []     # (path, line, member): no owning type could be pinned
+
+
+def doc_type_exists(t, live_types):
+    if t in live_types:
+        return True
+    return any(lt == t or lt.endswith('.' + t) or t.endswith('.' + lt) for lt in live_types)
+
+
+def doc_member_exists(t, member, live_types, live_members):
+    for lt, members in live_members.items():
+        if (lt == t or lt.endswith('.' + t) or t.endswith('.' + lt)) and member in members:
+            return True
+    return False
+
+
+def member_exists_anywhere(member, live_members, live_free):
+    """Does ANY live type, or the free-function namespace, have this exact member name?
+
+    Used only for a BARE (undotted) reference, where the "owning type" is a *guess*: the real
+    pages mix two `##`-heading conventions (a genuine type name, e.g. `## AAG`, and a `// MARK:`
+    group label, e.g. `## Properties`, `## Evaluation`, repeated verbatim across many files for many
+    types), and several pages (`Document-Analysis-Builders.md`, `Document-Math-Bounds.md`, ...) are
+    grab-bag completions pages whose filename names none of the types they document. Measured
+    directly: resolving those bare headings' "owning type" via heading-context/filename and
+    requiring an exact match against THAT guess produced 946 candidates on the real tree, and
+    reading a sample showed the guess wrong nearly every time (`fixWireGaps`, real and live on
+    `Shape`, resolved via filename to `Document` and reported stale). A DOTTED reference never has
+    this problem, since the page states the type itself, so this relaxation applies to bare references
+    only; see the `dotted` branch of `_check_and_record`, which stays strict.
+    """
+    if member in SYNTHESIZED_MEMBERS or member in live_free:
+        return True
+    return any(member in members for members in live_members.values())
+
+
+# The compiler synthesizes these; no `--self-test` fixture or the real corpus's own source text
+# ever spells them out as a declaration (`CaseIterable`'s `allCases`, seen for `Column.allCases`
+# in `docs/reference/Selection.md`).
+SYNTHESIZED_MEMBERS = {'allCases'}
+
+# A dotted `` `Type.tail` `` mention whose tail is a file extension names a FILE
+# (`` `Shape.swift` ``, `` `Wire.md` ``), not a member: common in a page's own "see also"/index
+# prose. Never a legitimate Swift member name in this codebase.
+NON_SYMBOL_TAILS = {'swift', 'md'}
+
+
+def paragraph_historical_map(lines):
+    """line number (1-based) -> True if its paragraph (contiguous non-blank lines) contains a
+    historical/removal keyword anywhere in it.
+
+    Only for channel 2 (inline prose): a sentence like "`Shape.nbEdges` ... and removed at
+    v2.0.0 (#784)." routinely soft-wraps the annotation onto a LATER physical line than the
+    mention itself, and checking only the matched line missed six real, correctly-annotated cases
+    on the first pass against the real tree. Headings (channel 1) do NOT get this treatment: see
+    `_check_and_record`'s dotted/bare_type branches, where a heading whose *prose paragraph below
+    it* says "deprecated" while the heading's own restated declaration still claims current
+    existence is exactly the `BSplineContinuity`/`Continuity`/`ContinuityOrder` shape found on the
+    real tree: genuinely wrong content (says "is now a typealias of X"; X does not exist either),
+    not a wrapped annotation. Widening channel 1 the same way would silently swallow that.
+    """
+    result = {}
+    para_start = 0
+    para_lines = []
+    for idx, line in enumerate(lines):
+        if line.strip() == '':
+            if para_lines:
+                hit = bool(HISTORICAL_RE.search('\n'.join(para_lines)))
+                for n in range(para_start, idx):
+                    result[n + 1] = hit
+            para_lines = []
+            para_start = idx + 1
+        else:
+            para_lines.append(line)
+    if para_lines:
+        hit = bool(HISTORICAL_RE.search('\n'.join(para_lines)))
+        for n in range(para_start, len(lines)):
+            result[n + 1] = hit
+    return result
+
+
+def scan_doc_file(path, text, live_types, live_members, live_free, rep):
+    lines = text.split('\n')
+    para_historical = paragraph_historical_map(lines)
+    context_stack = {}   # level -> type-name hint or None
+    fence_active = False
+    for idx, line in enumerate(lines):
+        lineno = idx + 1
+        # Check for the CLOSING fence before the opening pattern: both are `^\s*```...$`, and a
+        # closing ``` (bare) matches FENCE_OPEN_RE too, so checking `fence_active` first is what
+        # lets the fence ever end instead of swallowing the rest of the file.
+        if fence_active:
+            if FENCED_END_RE.match(line):
+                fence_active = False
+            continue
+        if FENCE_OPEN_RE.match(line):
+            fence_active = True
+            continue
+
+        hb = HEADING_BACKTICK_RE.match(line)
+        if hb:
+            level = len(hb.group(1))
+            raw, suffix = hb.group(2), hb.group(3)
+            context_stack = {k: v for k, v in context_stack.items() if k < level}
+            # The disambiguating suffix appears BOTH ways in the real pages: inside the backtick
+            # span (`` `contains(uid:) — GraphUID` ``) and outside it
+            # (`` `distance(to:deflection:)` — Wire, Edge, Face ``). Both must be tried.
+            body, inner_dash_suffix = strip_disambiguation(raw)
+            outer_dash_suffix = ''
+            s = suffix.strip()
+            for sep in ('—', '–', '-'):
+                if s.startswith(sep):
+                    outer_dash_suffix = s[len(sep):].strip()
+                    break
+            dash_suffix = inner_dash_suffix or outer_dash_suffix
+            historical = bool(HISTORICAL_RE.search(suffix)) or bool(HISTORICAL_RE.search(inner_dash_suffix))
+            cls = classify_symbol(body)
+            resolved_type = None
+            if cls:
+                if cls[0] == 'dotted':
+                    resolved_type = cls[1]
+                elif cls[0] == 'bare_type':
+                    resolved_type = None  # checked as a type, not a member
+                elif cls[0] == 'bare_member':
+                    resolved_type = _resolve_context(context_stack, path)
+                    if not resolved_type and dash_suffix:
+                        cands = suffix_type_candidates(dash_suffix)
+                        resolved_type = cands[0] if len(cands) == 1 else None
+                _check_and_record(cls, resolved_type, path, lineno, historical, rep,
+                                   live_types, live_members, live_free,
+                                   fallback_types=suffix_type_candidates(dash_suffix))
+            # This heading's own (possibly bare) identifier becomes context for deeper headings.
+            hint = body if IDENTIFIER_SHAPED_RE.fullmatch(body) else None
+            context_stack[level] = hint
+            continue
+
+        hbare = HEADING_BARE_RE.match(line)
+        if hbare and line.lstrip().startswith('#'):
+            level = len(hbare.group(1))
+            text_ = hbare.group(2).strip()
+            context_stack = {k: v for k, v in context_stack.items() if k < level}
+            hint = text_ if IDENTIFIER_SHAPED_RE.fullmatch(text_) else None
+            context_stack[level] = hint
+            continue
+
+        # Channel 2: inline `Type.member` mentions in ordinary prose (any heading state). Skipped
+        # only while inside ANY fenced block. A fenced ```swift snippet is often intentionally
+        # showing removed/"before" code under a prose explanation (not this channel's concern; the
+        # heading that introduces it, if any, is channel 1's job), and a fenced shell/json block
+        # never contains a Swift symbol reference worth checking either.
+        for m in INLINE_DOTTED_RE.finditer(line):
+            t, member = m.group(1), m.group(2)
+            if member in NON_SYMBOL_TAILS:
+                continue   # `` `Shape.swift` ``, `` `Wire.md` ``: a filename, not a symbol
+            historical = para_historical.get(lineno, False)
+            rep.checked += 1
+            if not doc_type_exists(t, live_types):
+                continue  # the type itself is gone/renamed wholesale; channel 1/headings own that
+            if doc_member_exists(t, member, live_types, live_members) or member in SYNTHESIZED_MEMBERS:
+                continue
+            if historical:
+                rep.historical.append((path, lineno, f'{t}.{member}'))
+                continue
+            rep.stale.append((path, lineno, 'inline', t, member, 'inline'))
+
+
+def _resolve_context(context_stack, path):
+    for level in sorted(context_stack, reverse=True):
+        if context_stack[level]:
+            return context_stack[level]
+    base = os.path.basename(path)
+    if base.endswith('.md'):
+        base = base[:-3]
+    return base.split('-')[0] or None
+
+
+def _check_and_record(cls, resolved_type, path, lineno, historical, rep, live_types, live_members,
+                       live_free, fallback_types=None):
+    rep.checked += 1
+    kind = cls[0]
+    if kind == 'dotted':
+        # Strict: the page states the owning type itself, so this is exactly the shape #802 warns
+        # about (`Shape.nbEdges` vs `ShapeContentsExtended.nbEdges`) and must not be relaxed.
+        _, t, member = cls
+        ok = doc_type_exists(t, live_types) and doc_member_exists(t, member, live_types, live_members)
+        if not ok and fallback_types:
+            ok = any(doc_member_exists(ft, member, live_types, live_members) for ft in fallback_types)
+        if not ok and member[:1].isupper():
+            # A PascalCase tail (`Shape.OrientedBoundingBox`, `BillOfMaterials.Column`) can name a
+            # genuinely nested type (checked above via `doc_member_exists`, since a nested type is
+            # also recorded as a member of its enclosing one) OR a page's organisational grouping
+            # of an unrelated TOP-LEVEL type under a related heading. Try the bare type too before
+            # giving up: still exact-name matching, so this cannot resurrect the
+            # `Shape.nbEdges`/`ShapeContentsExtended.nbEdges` trap (lowercase tails never reach
+            # here) or the `Conic2D.fromCircle`/`Curve2D.fromCircleArc` one (already exact-matched
+            # above, not substring).
+            ok = doc_type_exists(f'{t}.{member}', live_types) or doc_type_exists(member, live_types)
+        if ok:
+            return
+        if historical:
+            rep.historical.append((path, lineno, f'{t}.{member}'))
+            return
+        rep.stale.append((path, lineno, 'heading', t, member, 'dotted'))
+    elif kind == 'bare_type':
+        t = cls[1]
+        if doc_type_exists(t, live_types):
+            return
+        if historical:
+            rep.historical.append((path, lineno, t))
+            return
+        rep.stale.append((path, lineno, 'heading', None, t, 'bare_type'))
+    else:  # bare_member: the owning type is a GUESS (heading context or filename), so existence
+           # is asked globally, not of the guess alone. See `member_exists_anywhere`'s docstring.
+        member = cls[1]
+        if resolved_type and doc_member_exists(resolved_type, member, live_types, live_members):
+            return
+        if fallback_types and any(
+                doc_member_exists(ft, member, live_types, live_members) for ft in fallback_types):
+            return
+        if member_exists_anywhere(member, live_members, live_free):
+            return
+        if resolved_type is None and not fallback_types:
+            rep.unresolved.append((path, lineno, member))
+            return
+        if historical:
+            label = f'{resolved_type}.{member}' if resolved_type else member
+            rep.historical.append((path, lineno, label))
+            return
+        rep.stale.append((path, lineno, 'heading', resolved_type, member, 'bare_member'))
+
+
+def in_scope_doc_paths():
+    paths = [p for p in glob.glob(DOC_GLOB, recursive=True) if p not in EXCLUDED_DOCS]
+    if os.path.exists(README):
+        paths.append(README)
+    return sorted(paths)
+
+
+def print_report(rep, verbose):
+    print(f'symbol references checked: {rep.checked}')
+    print(f'stale (no live declaration): {len(rep.stale)}')
+    print(f'acknowledged historical (mentions a removed name, correctly annotated): '
+          f'{len(rep.historical)}')
+    print(f'unresolved context (bare member, no owning type could be pinned): '
+          f'{len(rep.unresolved)} (baseline {EXPECTED_UNRESOLVED})')
+
+    if rep.stale:
+        print('\nSTALE: documented symbol has no matching live declaration:')
+        for path, lineno, kind, t, member, how in rep.stale:
+            label = f'{t}.{member}' if t else member
+            print(f'  {path}:{lineno}  {label}  [{kind}/{how}]')
+    if verbose and rep.historical:
+        print('\nACKNOWLEDGED HISTORICAL: mentions a removed name, but says so:')
+        for path, lineno, label in rep.historical:
+            print(f'  {path}:{lineno}  {label}')
+    if verbose and rep.unresolved:
+        print('\nUNRESOLVED CONTEXT: could not be checked:')
+        for path, lineno, member in rep.unresolved:
+            print(f'  {path}:{lineno}  {member}')
+
+
+# --- self-test: a removal matrix built from the real #798 removals ------------------------------
+# Each row is a real removed/renamed symbol from PR #798's own migration table, reproduced as a
+# minimal fixture, plus the two named collision traps (#802's own warning) as CLEAN cases. Every
+# row is run once with the checker's relevant guard disabled to prove it is load-bearing, per
+# okf/policies/prove-the-test-fails.md.
+
+SELF_TEST_CASES = [
+    (
+        'dotted heading naming a removed property is STALE (the BRepGraph.generation shape)',
+        {'Sources/OCCTSwift/A.swift': 'public final class BRepGraph {\n'
+                                      '    public var instanceID: UInt64 { 0 }\n}\n'},
+        {'docs/reference/ZZ.md': '### `BRepGraph.generation`\n\n```swift\n'
+                                 'public var generation: Int { get }\n```\n'},
+        'stale', 1,
+    ),
+    (
+        'the SAME heading, annotated as removed, is acknowledged not stale',
+        {'Sources/OCCTSwift/A.swift': 'public final class BRepGraph {\n'
+                                      '    public var instanceID: UInt64 { 0 }\n}\n'},
+        {'docs/reference/ZZ.md': '### `generation` *(removed in v2.0.0)*\n\n'
+                                 'Use `instanceID` instead.\n'},
+        'historical', 1,
+    ),
+    (
+        'collision trap: ShapeContentsExtended.nbEdges is live and must NOT be flagged',
+        {'Sources/OCCTSwift/A.swift': 'extension Shape {\n    public var edgeCount: Int { 0 }\n}\n'
+                                      'public struct ShapeContentsExtended {\n'
+                                      '    public let nbEdges: Int\n}\n'},
+        {'docs/reference/ZZ.md': '### `ShapeContentsExtended`\n\n```swift\n'
+                                 'public struct ShapeContentsExtended {\n'
+                                 '    public let nbEdges: Int\n}\n```\n'},
+        'clean', 0,
+    ),
+    (
+        'collision trap: prose mentioning removed Shape.nbEdges IS flagged despite the live sibling',
+        {'Sources/OCCTSwift/A.swift': 'extension Shape {\n    public var edgeCount: Int { 0 }\n}\n'
+                                      'public struct ShapeContentsExtended {\n'
+                                      '    public let nbEdges: Int\n}\n'},
+        {'docs/reference/ZZ.md': 'See also `Shape.nbEdges` for the older spelling.\n'},
+        'stale', 1,
+    ),
+    (
+        'collision trap: Curve2D.fromCircleArc is live, must not match removed Conic2D.fromCircle',
+        {'Sources/OCCTSwift/A.swift': 'extension Curve2D {\n'
+                                      '    public static func fromCircleArc(center: Int) -> Curve2D'
+                                      ' { fatalError() }\n}\n'
+                                      'public struct Conic2D {\n'
+                                      '    public static func circle(center: Int) -> Conic2D?'
+                                      ' { nil }\n}\n'},
+        {'docs/reference/ZZ.md': '### `Curve2D.fromCircleArc(center:)`\n\n```swift\n'
+                                 'public static func fromCircleArc(center: Int) -> Curve2D\n```\n'},
+        'clean', 0,
+    ),
+    (
+        'renamed enum case: ThreadBuild.boolean removed, .auto/.direct remain, case is stale',
+        {'Sources/OCCTSwift/A.swift': 'public enum ThreadBuild {\n    case auto\n    case direct\n}\n'},
+        {'docs/reference/ZZ.md': '### `ThreadBuild.boolean`\n\nRemoved case.\n'},
+        'stale', 1,
+    ),
+    (
+        'removed typealias referenced bare is STALE',
+        {'Sources/OCCTSwift/A.swift': 'public final class BRepGraph {}\n'},
+        {'docs/reference/ZZ.md': '### `TopologyGraph`\n\nAlias for `BRepGraph`.\n'},
+        'stale', 1,
+    ),
+    (
+        'bare member resolved via filename fallback (BRepGraph-Editor-Identity.md -> BRepGraph)',
+        {'Sources/OCCTSwift/A.swift': 'public final class BRepGraph {\n'
+                                      '    public var instanceID: UInt64 { 0 }\n}\n'},
+        {'docs/reference/BRepGraph-Editor-Identity.md': '### `instanceID`\n\n```swift\n'
+                                                        'public var instanceID: UInt64 { get }\n```\n'},
+        'clean', 0,
+    ),
+    (
+        'bare member resolved via a dash-separated TypeA, TypeB suffix when context/filename both fail',
+        {'Sources/OCCTSwift/A.swift': 'extension Wire {\n'
+                                      '    public func distance(to other: Int) -> Double { 0 }\n}\n'
+                                      'extension Edge {\n'
+                                      '    public func distance(to other: Int) -> Double { 0 }\n}\n'},
+        {'docs/reference/ZZ-Features.md':
+            '### `distance(to:)` — Wire, Edge\n\n```swift\n'
+            'public func distance(to other: Int) -> Double\n```\n'},
+        'clean', 0,
+    ),
+    (
+        'a switch-statement case label is NOT an enum member declaration (false-positive guard)',
+        {'Sources/OCCTSwift/A.swift':
+            'public enum ThreadBuild: Codable {\n'
+            '    case auto\n    case direct\n'
+            '    public init(from decoder: Decoder) throws {\n'
+            '        let raw = try decoder.singleValueContainer().decode(String.self)\n'
+            '        switch raw {\n'
+            '        case "auto", "direct", "boolean": self = .auto\n'
+            '        default: self = .auto\n'
+            '        }\n'
+            '    }\n}\n'},
+        {'docs/reference/ZZ.md': '### `ThreadBuild.boolean`\n\nRemoved case.\n'},
+        'stale', 1,   # would wrongly read CLEAN if the switch-case were miscounted as an enum case
+    ),
+    (
+        'a member from a PROTOCOL EXTENSION resolves for a conforming type (the '
+        'WireCurve/ArcLengthCurveAdaptor shape)',
+        {'Sources/OCCTSwift/A.swift':
+            'public protocol ArcLengthCurveAdaptor: AnyObject {\n'
+            '    func points(count: Int) -> [Int]\n}\n'
+            'extension ArcLengthCurveAdaptor {\n'
+            '    public static var maximumSampleCount: Int { 10_000_000 }\n}\n'
+            'public final class WireCurve: ArcLengthCurveAdaptor, @unchecked Sendable {\n'
+            '    public init() {}\n}\n'},
+        {'docs/reference/ZZ.md': '### `WireCurve.maximumSampleCount`\n\n```swift\n'
+                                 'public static var maximumSampleCount: Int { get }\n```\n'},
+        # Without conformance resolution, `WireCurve`'s own member set never gains
+        # `maximumSampleCount` (it is declared only on `ArcLengthCurveAdaptor`), and this reads as
+        # a false-positive STALE finding for real, currently-compiling code.
+        'clean', 0,
+    ),
+]
+
+
+def self_test():
+    failures = 0
+    for name, src_files, doc_files, expect_kind, expect_count in SELF_TEST_CASES:
+        live_types, live_members, live_free, conformances = extract_source_symbols(src_files)
+        resolve_conformances(live_members, conformances)
+        rep = Report()
+        for path in sorted(doc_files):
+            scan_doc_file(path, doc_files[path], live_types, live_members, live_free, rep)
+        got = {'stale': len(rep.stale), 'historical': len(rep.historical),
+               'clean': 0 if (rep.stale or rep.historical) else 1}
+        want_key = expect_kind
+        ok = (want_key == 'clean' and got['stale'] == 0 and got['historical'] == 0) or \
+             (want_key in ('stale', 'historical') and got[want_key] == expect_count)
+        if ok:
+            print(f'  PASS  {name}')
+        else:
+            failures += 1
+            print(f'  FAIL  {name}')
+            print(f'          expected {want_key}={expect_count}')
+            print(f'          got      stale={got["stale"]} historical={got["historical"]}')
+    print(f'\nself-test: {len(SELF_TEST_CASES) - failures} passed, {failures} failed')
+    return failures
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--self-test', action='store_true',
+                    help='run the removal-matrix battery instead of scanning the tree')
+    ap.add_argument('--verbose', action='store_true',
+                    help='also list acknowledged-historical and unresolved-context entries')
+    ap.add_argument('--quiet', action='store_true', help='exit status only')
+    args = ap.parse_args()
+
+    if args.self_test:
+        return 1 if self_test() else 0
+
+    src_files = {}
+    for path in sorted(glob.glob(SRC_GLOB)):
+        with open(path, encoding='utf-8') as fh:
+            src_files[path] = fh.read()
+    live_types, live_members, live_free, conformances = extract_source_symbols(src_files)
+    resolve_conformances(live_members, conformances)
+
+    rep = Report()
+    for path in in_scope_doc_paths():
+        with open(path, encoding='utf-8') as fh:
+            text = fh.read()
+        scan_doc_file(path, text, live_types, live_members, live_free, rep)
+
+    unresolved_grew = len(rep.unresolved) > EXPECTED_UNRESOLVED
+    if not args.quiet:
+        print_report(rep, args.verbose)
+        if unresolved_grew:
+            print(f'\n  Unresolved-context count grew past its baseline ({EXPECTED_UNRESOLVED}): '
+                  f'a bare heading whose owning type this script cannot pin is unreported drift, '
+                  f'not a pass. Give the page a resolvable heading/filename, or add a reasoned '
+                  f'baseline bump.')
+
+    fail = bool(rep.stale) or unresolved_grew
+    return 1 if fail else 0
+
+
+if __name__ == '__main__':
+    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+    sys.exit(main())

--- a/Scripts/git-hooks/pre-commit
+++ b/Scripts/git-hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Opt-in pre-commit hook: runs the same five static gate scripts CI's `gate-scripts` job runs.
+# Opt-in pre-commit hook: runs the same six static gate scripts CI's `gate-scripts` job runs.
 #
 # NOT installed by cloning. A repo cannot install its own hooks — `.git/hooks` is not versioned —
 # and that is the right default here: a hook that appears in a contributor's workflow without them
@@ -27,7 +27,7 @@
 #   which resolves to the worktree you are committing in, not the main checkout.
 #
 # Skip it for one commit with `git commit --no-verify`. CI is the authority either way: this hook is
-# a faster local copy of the same checks, never a substitute. The nine INVOCATIONS below are
+# a faster local copy of the same checks, never a substitute. The INVOCATIONS below are
 # deliberately identical to the CI job's, flag for flag, so a disagreement can never come from the
 # two running different things. Three ways they can still diverge, none of them worth closing here:
 #
@@ -75,6 +75,8 @@ run "check-null-handle-guards.py --self-test" Scripts/check-null-handle-guards.p
 run "check-null-handle-guards.py"             Scripts/check-null-handle-guards.py
 run "check-docs-defaults.py --self-test"      Scripts/check-docs-defaults.py --self-test
 run "check-docs-defaults.py"                  Scripts/check-docs-defaults.py
+run "check-docs-existence.py --self-test"     Scripts/check-docs-existence.py --self-test
+run "check-docs-existence.py"                 Scripts/check-docs-existence.py
 run "derive-bridge-header-split.py --self-test" Scripts/derive-bridge-header-split.py --self-test
 run "derive-bridge-header-split.py --verify"    Scripts/derive-bridge-header-split.py --verify
 run "count-operations.py"                     Scripts/count-operations.py

--- a/Scripts/repro/802-snippet-sample/measure-snippet-failures.py
+++ b/Scripts/repro/802-snippet-sample/measure-snippet-failures.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""#802 item 2: measure, don't assume, whether the 7,186 ```swift snippets under docs/ are worth
+checking exhaustively, and by what method.
+
+## Why not just compile all of them
+
+A snippet extracted from a reference page is usually a deliberate FRAGMENT, not a complete program:
+many are a single bare call (`graph.setCoEdgeUVBox(0, u1: 0.0, ...)`) assuming a `graph` bound
+earlier in the same page's prose, and many restated signatures are intentionally body-less
+(`public func trek(_ path: String) -> String?`, no `{ }`), a real convention this repo's own
+`check-docs-defaults.py` already parses around, not a mistake. Feeding either shape to `swiftc`
+produces a parse or semantic error unrelated to whether the API it names still exists: "cannot find
+'graph' in scope" and "function declaration requires a body" would each fire on the overwhelming
+majority of snippets, drowning any real signal in expected, harmless noise. Measuring that would be
+"the adjacent number" (`okf/policies/measure-dont-assume.md`): a real count, of the wrong thing.
+
+## What this measures instead
+
+The actual complaint the issue raises is narrower and exactly the one #802 item 1 already answers
+for headings and prose: "a snippet naming a removed symbol is a wrong answer served to users"
+(context7 harvests these `​```swift` blocks). So this script applies the SAME exact-match
+(owning type, member name) check `check-docs-existence.py` already proved correct: the same live
+index, the same collision-trap awareness, the same historical-annotation suppression, applied to the CONTENT of
+every fenced ```swift block, a population that script deliberately never enters (see its own
+`## Two channels`: fenced content is skipped, since a heading's own claim already catches the
+`generation`-shape defect in every case measured on the real tree).
+
+Because this check is text-matching against an already-built in-memory index, not real compilation,
+it costs nothing to run against the FULL population rather than a sample, so it does, rather than
+estimating from a subset. What IS sampled, separately, is a small set of snippets fed through a real
+`swiftc -typecheck`, to answer a different question the exhaustive check cannot: does actual
+compilation surface anything beyond a removed-symbol reference (a wrong argument label on a symbol
+that still exists, say)? That half legitimately cannot cover 7,186 snippets: each attempt needs the
+built `OCCTSwift` module on the import path, so it stays a measured sample, and the measured
+fragment-failure rate is reported honestly rather than folded into "real" failures.
+
+Usage (from the repo root):
+
+    python3 Scripts/repro/802-snippet-sample/measure-snippet-failures.py
+    python3 Scripts/repro/802-snippet-sample/measure-snippet-failures.py --compile-sample 40
+
+This is a CENSUS/measurement, not a gate: it always exits 0 (see `census-unmeasured-values.py`'s
+own convention). Its job is to produce the number #802 asks for, not to block a commit.
+"""
+import argparse
+import glob
+import importlib.util
+import os
+import random
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+EXISTENCE_SCRIPT = os.path.join(REPO_ROOT, 'Scripts', 'check-docs-existence.py')
+
+DOC_GLOB = 'docs/**/*.md'
+README = 'README.md'
+EXCLUDED_DOCS = {'docs/CHANGELOG.md', 'docs/SEMVER.md'}
+SRC_GLOB = 'Sources/OCCTSwift/*.swift'
+
+FENCE_START_RE = re.compile(r'^\s*```\s*swift\s*$')
+FENCE_END_RE = re.compile(r'^\s*```\s*$')
+HISTORICAL_RE = re.compile(r'\b(removed|deprecated|no longer exists|renamed)\b', re.IGNORECASE)
+
+
+def load_existence_module():
+    spec = importlib.util.spec_from_file_location('check_docs_existence', EXISTENCE_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def extract_snippets(paths):
+    """[(path, first_line_no, code_text, historical)] for every fenced ```swift block.
+
+    `historical` is True if the ~5 lines immediately preceding the fence (the prose introducing
+    it) carries a removal/deprecation word, the same "acknowledged, not a defect" allowance
+    `check-docs-existence.py` gives a heading or paragraph, applied here to a snippet's own intro.
+    """
+    out = []
+    for path in paths:
+        with open(path, encoding='utf-8') as fh:
+            lines = fh.read().split('\n')
+        i = 0
+        while i < len(lines):
+            if FENCE_START_RE.match(lines[i]):
+                start = i + 1
+                j = start
+                while j < len(lines) and not FENCE_END_RE.match(lines[j]):
+                    j += 1
+                preceding = '\n'.join(lines[max(0, i - 5):i])
+                historical = bool(HISTORICAL_RE.search(preceding))
+                out.append((path, start + 1, '\n'.join(lines[start:j]), historical))
+                i = j + 1
+                continue
+            i += 1
+    return out
+
+
+def in_scope_doc_paths():
+    paths = [p for p in glob.glob(DOC_GLOB, recursive=True) if p not in EXCLUDED_DOCS]
+    if os.path.exists(README):
+        paths.append(README)
+    return sorted(paths)
+
+
+# Swift-language uses of `Type.word` that name no member at all: `Foo.self` (metatype value),
+# `Foo.Type` (metatype type). `check-docs-existence.py`'s own `INLINE_DOTTED_RE` requires
+# surrounding backticks, which real code never has, so it is not reused here; a bare pattern is,
+# and it needs this extra exclusion prose never triggers (a doc author does not write `` `Foo.self` ``).
+LANGUAGE_KEYWORDS = {'self', 'Type', 'Protocol', 'init'}
+
+
+def check_existence_in_snippets(snippets, live_types, live_members, mod):
+    """A snippet fails if it names a `Type.member` dotted reference where `Type` exists but
+    `member` does not (never on member-name alone, for the identical collision-trap reason
+    `check-docs-existence.py`'s own docstring gives; reuses its exact-match `doc_type_exists`/
+    `doc_member_exists`, now conformance-aware, so a protocol-extension-supplied member like
+    `ArcLengthCurveAdaptor.maximumSampleCount` resolves for `WireCurve`/`EdgeCurve` too)."""
+    failures = []
+    for path, lineno, code, historical in snippets:
+        bad = []
+        for m in re.finditer(r'\b([A-Z][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b', code):
+            t, member = m.group(1), m.group(2)
+            if member in mod.NON_SYMBOL_TAILS or member in mod.SYNTHESIZED_MEMBERS \
+                    or member in LANGUAGE_KEYWORDS:
+                continue
+            if not mod.doc_type_exists(t, live_types):
+                continue
+            if mod.doc_member_exists(t, member, live_types, live_members):
+                continue
+            bad.append(f'{t}.{member}')
+        if bad and not historical:
+            failures.append((path, lineno, sorted(set(bad))))
+    return failures
+
+
+def try_compile_sample(snippets, n, seed):
+    """Feed a random sample through `swiftc -typecheck` against the built OCCTSwift module.
+
+    Reports three buckets, not two: a snippet can be a genuine failure, or fail only because it is
+    a deliberate fragment (an undeclared variable from earlier prose, or a body-less restated
+    signature), a shape check-docs-defaults.py's own docstring already documents as this repo's
+    convention, not a defect. Conflating the two would report a real-sounding number measuring
+    mostly the extraction method rather than the docs.
+    """
+    module_paths = [
+        os.path.join(REPO_ROOT, '.build', 'arm64-apple-macosx', 'debug', 'Modules'),
+        os.path.join(REPO_ROOT, '.build', 'debug', 'Modules'),
+        os.path.join(REPO_ROOT, '.build', 'arm64-apple-macosx', 'debug'),
+        os.path.join(REPO_ROOT, '.build', 'debug'),
+    ]
+    modulemap_dir = next((p for p in module_paths if os.path.exists(
+        os.path.join(p, 'OCCTSwift.swiftmodule'))), None)
+
+    rng = random.Random(seed)
+    sample = rng.sample(snippets, min(n, len(snippets)))
+    results = []
+    for path, lineno, code, historical in sample:
+        with tempfile.NamedTemporaryFile('w', suffix='.swift', delete=False) as tf:
+            tf.write('import OCCTSwift\nimport simd\nimport Foundation\n')
+            tf.write(code)
+            tf.write('\n')
+            tmp_path = tf.name
+        cmd = ['swiftc', '-typecheck', tmp_path]
+        if modulemap_dir:
+            cmd += ['-I', modulemap_dir]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        os.unlink(tmp_path)
+        ok = proc.returncode == 0
+        stderr = proc.stderr
+        # A fragment-shaped failure: an undeclared identifier the doc's OWN prose bound earlier
+        # (not this snippet's problem); a bare signature with no body, or a bare enum/protocol
+        # requirement restatement (`public var x: Int { get }`, `public enum Foo` with no cases)
+        # this repo's own reference-page convention of restating JUST the signature, wrapped
+        # here at file scope where Swift requires a body/case list it was never meant to have;
+        # or the sample harness's own module-resolution gap (a raw `swiftc -typecheck` cannot
+        # replicate SwiftPM's full module-map wiring for the `OCCTBridge` Clang target `OCCTSwift`
+        # itself imports: an environment limitation of this harness, not a snippet defect).
+        fragment_shaped = bool(re.search(
+            r"cannot find '[a-z]\w*' in scope|"
+            r'function declaration requires a body|'
+            r'expected declaration|'
+            r"'guard' body must not fall through|"
+            r'static methods may only be declared on a type|'
+            r"expected '\{' to start getter definition|"
+            r"expected '\{' in enum|"
+            r"missing required module 'OCCTBridge'", stderr))
+        results.append((path, lineno, ok, fragment_shaped, stderr.strip().splitlines()[:2]))
+    return results, modulemap_dir is not None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--compile-sample', type=int, default=0,
+                    help='additionally attempt real swiftc -typecheck on N random snippets')
+    ap.add_argument('--seed', type=int, default=802, help='RNG seed for the compile sample')
+    args = ap.parse_args()
+
+    os.chdir(REPO_ROOT)
+    mod = load_existence_module()
+
+    src_files = {}
+    for path in sorted(glob.glob(SRC_GLOB)):
+        with open(path, encoding='utf-8') as fh:
+            src_files[path] = fh.read()
+    live_types, live_members, live_free, conformances = mod.extract_source_symbols(src_files)
+    mod.resolve_conformances(live_members, conformances)
+
+    snippets = extract_snippets(in_scope_doc_paths())
+    print(f'total ```swift snippets in scope: {len(snippets)}')
+
+    failures = check_existence_in_snippets(snippets, live_types, live_members, mod)
+    print(f'existence-check failures (exhaustive, all {len(snippets)}): {len(failures)}')
+    for path, lineno, bad in failures:
+        print(f'  {path}:{lineno}  {", ".join(bad)}')
+
+    if args.compile_sample:
+        results, module_found = try_compile_sample(snippets, args.compile_sample, args.seed)
+        if not module_found:
+            print('\n(compile sample skipped: no built OCCTSwift.swiftmodule found, run '
+                  '`swift build` first)')
+        else:
+            real_fail = [r for r in results if not r[2] and not r[3]]
+            fragment_fail = [r for r in results if not r[2] and r[3]]
+            ok = [r for r in results if r[2]]
+            print(f'\ncompile sample: {len(results)} snippets, seed {args.seed}')
+            print(f'  typechecked clean:        {len(ok)}')
+            print(f'  fragment-shaped failure:  {len(fragment_fail)}  '
+                  f'(missing scope/body: extraction artifact, not a docs defect)')
+            print(f'  OTHER failure:            {len(real_fail)}')
+            for path, lineno, _, _, msg in real_fail:
+                print(f'    {path}:{lineno}  {" | ".join(msg)}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/guides/cookbook/brep-graph-uids.md
+++ b/docs/guides/cookbook/brep-graph-uids.md
@@ -109,14 +109,14 @@ what makes a decoded UID from another process resolve nowhere rather than by acc
 > to whatever node held that counter, which on any other model is the wrong node. If you persisted UIDs
 > under an older version, re-read the persistence section below.
 
-### `generation` is always 1: do not use it
+### `generation` was always 1: removed in v2.0.0
 
 OCCT has a graph generation counter, but OCCTSwift clears a graph exactly once when it builds it and
 never rebuilds an existing one ([#303](https://github.com/SecondMouseAU/OCCTSwift/issues/303)), so the
-counter lands at 1 and never moves. It is the same 1 for every graph, so it cannot tell two graphs
-apart or detect a stale reference. The `generation` property is deprecated for exactly this reason.
-`node(forUID:)` already rejects a foreign UID on its own, and `instanceID` compares graph identity
-directly; use those.
+counter landed at 1 and never moved. It was the same 1 for every graph, so it could tell neither two
+graphs apart nor detect a stale reference. `BRepGraph.generation` was removed at v2.0.0
+([#784](https://github.com/SecondMouseAU/OCCTSwift/issues/784)); `node(forUID:)` already rejects a
+foreign UID on its own, and `instanceID` compares graph identity directly, so use those instead.
 
 ## What preserves identity, and what mints a new one
 

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -17,7 +17,7 @@ OCCT organizes classes by toolkit and module prefix:
 | `BRepAlgoAPI_Fuse` | `Shape.union(with:)` |
 | `BRepFilletAPI_MakeFillet` | `Shape.filleted(radius:)` |
 | `BRepOffsetAPI_MakeThickSolid` | `Shape.shelled(thickness:)` |
-| `GeomAPI_Interpolate` | `Curve3D.interpolated(through:)` |
+| `GeomAPI_Interpolate` | `Curve3D.interpolate(points:)` |
 | `BRepBuilderAPI_MakeWire` | `Wire(...)` |
 | `Geom_BSplineCurve` | `Curve3D` |
 | `Geom_BSplineSurface` | `Surface` |

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -893,7 +893,7 @@ public func createDimension(on shapeLabel: Int64,
 ```
 
 - **Parameters:**
-  - `shapeLabel` — label ID of the shape to annotate (from `Document.labelForShape(_:)` or equivalent).
+  - `shapeLabel`: label ID of the shape to annotate (from `Document.namingFindLabel(shape:)?.labelId`, or from wherever the shape's label ID was captured when it was imported or added).
   - `type` — the dimension sub-type (e.g. `.sizeDiameter`, `.locationLinearDistance`).
   - `value` — nominal measured value in model units.
   - `lowerTolerance` — lower tolerance; omit or pass `0` to leave unset.

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -1170,7 +1170,7 @@ Computes the 3D section edges via `sectionWithPlane`, then projects each sample 
   if let drawing = box.section2D(planeOrigin: SIMD3(0, 0, 25),
                                   planeNormal: SIMD3(0, 0, 1)) {
       // drawing.visibleEdges contains the 50×50 square contour at Z=25
-      let dxf = Exporter.exportDXF(drawing: drawing)
+      try Exporter.writeDXF(drawing: drawing, to: dxfURL)
   }
   ```
 

--- a/docs/reference/Curve2D-Constraint-Solvers.md
+++ b/docs/reference/Curve2D-Constraint-Solvers.md
@@ -468,7 +468,13 @@ Each `Curve2DHatchSegment` is a line segment clipped to lie inside the boundary 
 - **OCCT:** `Geom2dHatch_Hatcher` + `Geom2dHatch_Intersector`.
 - **Example:**
   ```swift
-  let boundary = [Curve2D.rectangle(center: .zero, width: 10, height: 8)!]
+  // A rectangle boundary is 4 segments; there is no single Curve2D rectangle factory.
+  let boundary = [
+      Curve2D.segment(from: SIMD2(-5, -4), to: SIMD2(5, -4))!,
+      Curve2D.segment(from: SIMD2(5, -4), to: SIMD2(5, 4))!,
+      Curve2D.segment(from: SIMD2(5, 4), to: SIMD2(-5, 4))!,
+      Curve2D.segment(from: SIMD2(-5, 4), to: SIMD2(-5, -4))!
+  ]
   let hatches = Curve2DGcc.hatch(
       boundaries: boundary,
       direction: SIMD2(1, 1) / sqrt(2),

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -124,7 +124,7 @@ Torsion is zero for planar curves. Non-zero values indicate the curve is twistin
 - **OCCT:** `GeomLProp_CLProps::Torsion`.
 - **Example:**
   ```swift
-  if let helix = Curve3D.helix(radius: 5, pitch: 2, turns: 3) {
+  if let helix = Curve3D.circularHelix(radius: 5, pitch: 2) {
       let tau = helix.torsion(at: 0)  // non-zero for a helix
   }
   if let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 4) {
@@ -233,7 +233,7 @@ Uses `GeomProjLib::ProjectOnPlane`. The result is a 3D curve lying in the target
 - **OCCT:** `GeomProjLib::ProjectOnPlane`.
 - **Example:**
   ```swift
-  if let helix = Curve3D.helix(radius: 5, pitch: 2, turns: 3),
+  if let helix = Curve3D.circularHelix(radius: 5, pitch: 2),
      let proj  = helix.projectedOnPlane(
          origin: .zero,
          normal: SIMD3(0, 0, 1),

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -75,16 +75,11 @@ public var degree: Int { get }
 
 ## BSpline Knot Splitting (v0.40.0)
 
-### `ContinuityOrder`
+### `ContinuityOrder` *(removed in v2.0.0)*
 
-> **Deprecated in #398.** `ContinuityOrder` was one of several copies of the same
-> continuity-floor vocabulary and is now a typealias of
-> [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity).
-
-```swift
-@available(*, deprecated, renamed: "ParametricContinuity")
-public typealias ContinuityOrder = ParametricContinuity
-```
+Renamed to `ParametricContinuity` in #398; the compatibility typealias itself was removed at
+v2.0.0 ([#784](https://github.com/SecondMouseAU/OCCTSwift/issues/784)). Use
+[`ParametricContinuity`](Shape-Healing.md#parametriccontinuity) directly.
 
 The old enum stopped at `.c2`, which made **every order it could express a no-op** for the
 query it exists to answer: `GeomConvert_BSplineCurveKnotSplitting` splits where

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -28,7 +28,7 @@ Iterator over triangulated faces of a meshed `Shape`.
 public final class MeshFaceIterator: @unchecked Sendable
 ```
 
-The shape must already be meshed (e.g. via `Mesh.fromShape(_:deflection:angle:)`) before creating this iterator.
+The shape must already be meshed (e.g. via `Shape.mesh(linearDeflection:angularDeflection:)`) before creating this iterator.
 
 - **OCCT:** `RWMesh_FaceIterator`.
 
@@ -48,7 +48,7 @@ public init?(shape: Shape)
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!
-  _ = Mesh.fromShape(box, deflection: 0.1, angle: 0.5)
+  _ = box.mesh(linearDeflection: 0.1, angularDeflection: 0.5)
   if let iter = MeshFaceIterator(shape: box) {
       while iter.hasMore {
           print("triangles:", iter.triangleCount)

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -2158,50 +2158,20 @@ public func childIDCount(labelId: Int64, guid: String, allLevels: Bool = false) 
 
 ---
 
-## TDocStd_PathParser
+## TDocStd_PathParser *(removed in v2.0.0)*
 
-Static utilities for decomposing a file path into its components, wrapping `TDocStd_PathParser`.
+The whole `PathParser` enum (`trek(_:)`/`name(_:)`/`fileExtension(_:)`, wrapping
+`TDocStd_PathParser`) was removed at v2.0.0
+([#784](https://github.com/SecondMouseAU/OCCTSwift/issues/784)). Use
+[`OSDPath`](Document-Math-Bounds.md#osdpathname_) instead, which wraps `OSD_Path` rather than
+`TDocStd_PathParser` and covers the same operations plus more (`systemName`, `folderAndFile`,
+`isValid`, `isUnixPath`, `isRelative`, `isAbsolute`): `OSDPath.folder(_:)` in place of
+`trek(_:)`, `OSDPath.name(_:)`, and `OSDPath.fileExtension(_:)`.
 
-### `PathParser.trek(_:)`
-
-Extract the directory (trek) component from a file path.
-
-```swift
-public static func trek(_ path: String) -> String?
-```
-
-- **Returns:** Directory portion, or `nil` on parse failure.
-- **OCCT:** `TDocStd_PathParser::Trek`.
-- **Example:**
-  ```swift
-  PathParser.trek("/Users/foo/model.stp")   // → "/Users/foo"
-  ```
-
----
-
-### `PathParser.name(_:)`
-
-Extract the filename without extension from a file path.
-
-```swift
-public static func name(_ path: String) -> String?
-```
-
-- **Returns:** Base name, or `nil` on parse failure.
-- **OCCT:** `TDocStd_PathParser::Name`.
-
----
-
-### `PathParser.fileExtension(_:)`
-
-Extract the file extension from a file path.
-
-```swift
-public static func fileExtension(_ path: String) -> String?
-```
-
-- **Returns:** Extension (without leading `.`), or `nil` on parse failure.
-- **OCCT:** `TDocStd_PathParser::Extension`.
+Two format differences to check if you are migrating a caller: `OSDPath.folder(_:)` keeps the
+trailing separator (`"/home/user/"`, not `"/home/user"`) and returns a real directory for an
+extension-less path instead of an empty string; `OSDPath.fileExtension(_:)` includes the leading
+dot (`".step"`, not `"step"`).
 
 ---
 

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -78,7 +78,7 @@ public struct AAGEdge: Sendable {
 }
 ```
 
-`convexity` is taken from the first shared edge between the two faces. `sharedEdgeCount` is the total number of B-Rep edges shared by the pair.
+`convexity` is taken from the first shared edge between the two faces. `sharedEdgeCount` is the total number of B-Rep edges shared by the pair, uncapped: before v2.0.0 (#761) it silently capped at 10 (`OCCTFaceGetSharedEdges`'s buffer was sized by a hardcoded caller argument, not the true count, confirmed wrong on a synthetic fixture at 12 real shared edges, reported as 10); a new `OCCTFaceGetSharedEdgeCount` now sizes the buffer exactly before it is filled.
 
 ---
 
@@ -349,7 +349,14 @@ Detects pocket features in the shape by AAG analysis.
 public func detectPockets(tolerance: Double = defaultFloorRestsOnWallTolerance) -> [PocketFeature]
 ```
 
-A pocket is identified when: (1) an upward-facing, horizontal, planar face exists as the floor; (2) that floor has at least one concave-edge neighbor; (3) the concave neighbors are vertical faces (walls); (4) each such wall's own bounding-box minimum Z matches the floor's Z within `tolerance` (#724), meaning the wall must actually rest ON that floor, not merely open past it. Results are sorted by ascending `zLevel` (deepest pocket first).
+A pocket is identified when: (1) an upward-facing, horizontal, planar face exists as the floor; (2) tracing outward from that floor, at least one true vertical wall is reached, either directly via a concave edge or through a filleted or chamfered floor/wall junction absorbed along the way (#762, below); (3) each directly-reached wall's own bounding-box minimum Z matches the floor's Z within `tolerance` (#724), meaning the wall must actually rest ON that floor, not merely open past it. (A wall reached only after absorbing a junction face skips this check, since the junction itself is what bottoms out at the floor's Z, not the wall's own remaining planar remnant.) Results are sorted by ascending `zLevel` (deepest pocket first).
+
+**A filleted or chamfered junction is absorbed, not reclassified (#762).** Before this fix, condition (2) required a DIRECT concave neighbor. Nearly every real machined pocket has a filleted floor/wall junction, since an endmill cannot cut a sharp internal corner, so `detectPocketsAAG()` could not see the pockets anyone would actually machine. `ChFi3d::DefineConnectType` is not wrong to call a fillet junction `.smooth` (a fillet is G1-continuous with both faces it blends, so there is no local sign to read at either new edge); the pocket's concavity moved into the fillet FACE's own curvature, not its edges. The fix traces outward through:
+
+- a `.concave` edge into a non-wall face (a chamfer, unconditionally: its own two new edges are still `.concave`, just planar at an intermediate angle that fails the wall's own vertical-face test), or
+- a `.smooth` edge into a face confirmed to curve the right way: cylindrical, conical or spherical, with its own outward normal pointing back toward its axis (radially inward), the same material-side test `detectHoles()` uses to tell a bore from a boss. This refuses to cross into an ordinary convex exterior rounding (radially outward) or an unrelated, incidentally-tangent planar pair.
+
+Each absorbed junction face is tracked separately from the true walls it leads to: `PocketFeature.wallFaceIndices` still reports only the true (vertical) walls, unchanged in meaning, but the pocket's bounds and its open/enclosed test both use walls UNION absorbed junctions, since a junction's own extent reaches past where the trimmed wall now starts, and the floor's own outer-wire boundary borders the junction face, not the far wall, whenever one is interposed.
 
 Requirement (4) exists because a wall's own exterior opening can satisfy (1)-(3) too: the exterior
 surface a pocket opens through is upward-facing, horizontal and planar exactly like the real floor,
@@ -407,25 +414,53 @@ library's own default rather than hardcoding `1e-4` again.
 
 ### `AAG.detectHoles()`
 
-Detects candidate hole features (cylindrical or conical faces with all-concave adjacency).
+Detects cylindrical or conical bore features (through or blind) by the wall's own geometry.
 
 ```swift
 public func detectHoles() -> [(faceIndex: Int, radius: Double, depth: Double)]
 ```
 
-Identifies faces where every adjacent face is connected via a concave edge and the face's XY bounding box has an aspect ratio under 1.2 (roughly circular) while being non-planar. `radius` and `depth` are estimated from the bounding box.
+**Rewritten in #747; the criterion is not neighbor convexity any more.** The original criterion,
+requiring every neighbor to connect via a concave edge, was written against a convexity formula (pre-#723)
+that sometimes misclassified a curved rim as concave when it geometrically should not be. Under
+the correct classifier that criterion is unsatisfiable for either ordinary hole shape: a
+through-hole's wall has **zero** concave neighbors (both rims are convex), and a blind hole's wall
+has exactly **one** out of two (the floor, not the rim where it opens), so "all neighbors concave"
+reported zero holes for both, the two shapes anyone would actually drill.
 
-- **Returns:** Array of `(faceIndex, radius, depth)` tuples; `radius` is `(width + height) / 4`, `depth` is `bounds.max.z - bounds.min.z`.
-- **Note:** This is a heuristic approximation, it does not inspect the surface type. For precise cylindrical detection, check `Face.surfaceType == .cylinder`.
+A hole is now identified by the wall's own intrinsic shape, independent of what borders it:
+
+1. `Face.surfaceType` is `.cylinder` or `.cone` (a countersink/counterbore transition is conical).
+2. **Closed in U by its own seam**: the wall wraps a full 2π around its axis
+   (`face.uvBounds`), not partially, so a fillet (a partial revolve) is excluded.
+3. **Material lies radially outside the wall** (`AAG.isMaterialRadiallyInward(of:revolution:uv:)`):
+   a hole is a void, so the face's own outward normal points back toward the axis. A boss or a
+   standalone cylinder has the identical surface type and the identical closed-in-U shape,
+   sometimes even the identical zero-concave-neighbor signature, but its material fills the
+   inside, so its normal points *away* from the axis. This is the only test that tells the two
+   apart; neighbor convexity cannot.
+
+None of this assumes a vertical axis: `radius` and `depth` are read from the wall's own measured
+axis (`Face.revolutionProperties`, `Face.point(atU:v:)`) rather than a Z-aligned bounding box, so a
+hole bored on any axis, or a pipe's bore (material lies radially outside its inner wall; a pipe's
+*outer* wall is correctly excluded, since material there lies radially inside), reports correctly.
+
+- **Returns:** Array of `(faceIndex, radius, depth)` tuples. `radius` is the wall's own measured
+  revolution radius (`Face.revolutionProperties`), not a bounding-box estimate. `depth` is measured
+  along the wall's own axis between its two V-bound points, not `bounds.max.z - bounds.min.z`.
 - **Note:** `faceIndex` is an **occurrence** index into `Shape.orientedFaces()`, not `Shape.faces()`
   (#642), matching `AAGNode.faceIndex`. A hole's face is rarely shared between two solids, so the
   two usually coincide, but only the occurrence index is correct here.
 - **Example:**
   ```swift
-  let holes = aag.detectHoles()
-  for h in holes {
-      print("face \(h.faceIndex), r≈\(h.radius), d≈\(h.depth)")
-  }
+  let box  = Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20)!
+  let tool = Shape.cylinder(at: .zero, direction: SIMD3(0, 0, 1), radius: 4, height: 20)!
+  let blind = box.subtracting(tool)!
+  print(blind.buildAAG().detectHoles().count)   // 1 (was 0 before #747)
+
+  let tool2 = Shape.cylinder(at: SIMD3(0, 0, -15), direction: SIMD3(0, 0, 1), radius: 4, height: 30)!
+  let through = box.subtracting(tool2)!
+  print(through.buildAAG().detectHoles().count) // 1 (was 0 before #747)
   ```
 
 ---
@@ -537,8 +572,8 @@ Extracts the first face via `TopExp_Explorer`, runs `BRepMAT2d_Explorer::Perform
 - **OCCT:** `BRepMAT2d_Explorer::Perform` + `BRepMAT2d_BisectingLocus::Compute` + `MAT_Graph`.
 - **Example:**
   ```swift
-  let rect = Shape.makeFace(
-      wire: Shape.makePolygon([
+  let rect = Shape.face(
+      from: Wire.polygon3D([
           SIMD3(0, 0, 0), SIMD3(10, 0, 0),
           SIMD3(10, 4, 0), SIMD3(0, 4, 0)
       ], closed: true)!

--- a/docs/reference/Geometry2D.md
+++ b/docs/reference/Geometry2D.md
@@ -244,7 +244,7 @@ Two sentinels have been retired from this one method. It first returned the brid
 - **Example:**
   ```swift
   if let p = Point2D(x: 5.0, y: 5.0),
-     let arc = Curve2D.arc(center: SIMD2(0, 0), radius: 3, startAngle: 0, endAngle: .pi) {
+     let arc = Curve2D.arcOfCircle(center: SIMD2(0, 0), radius: 3, startAngle: 0, endAngle: .pi) {
       let d = p.distance(to: arc)  // distance to nearest point on arc
   }
   ```

--- a/docs/reference/Measurement.md
+++ b/docs/reference/Measurement.md
@@ -5,7 +5,7 @@ parent: API Reference
 
 # Measurement
 
-OCCTSwift's measurement layer adds ergonomic, one-liner accessors for the most common spatial queries — angles between edges, faces, axes, and planes; circle/arc geometry extraction; revolution-surface properties; and a snapshot type (`ShapeMeasurements`) that pre-computes per-face areas/centroids/perimeters and per-edge arc lengths for the whole shape in a single call. These are convenience wrappers over OCCTSwift's existing geometry coverage (no new OCCT calls are introduced for angle computation; bridge calls are confined to `circleProperties` geometry recovery and `ShapeMeasurements.measure`).
+OCCTSwift's measurement layer adds ergonomic, one-liner accessors for the most common spatial queries: angles between edges, faces, axes, and planes; circle/arc geometry extraction; revolution-surface properties; and a snapshot type (`ShapeMeasurements`) that pre-computes per-face areas/centroids/perimeters and per-edge arc lengths for the whole shape in a single call. These are convenience wrappers over OCCTSwift's existing geometry coverage (no new OCCT calls are introduced for angle computation; bridge calls are confined to `circleProperties` geometry recovery and `Shape.measure(linearTolerance:)`, which produces a `ShapeMeasurements`).
 
 ## Topics
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -2302,7 +2302,7 @@ public func filletSurfaces(edges: [Shape], radius: Double) -> FilletSurfaceResul
 - **Parameters:** `edges` — edges to fillet. `radius` — fillet radius.
 - **Returns:** `FilletSurfaceResult` with NURBS fillet surfaces and support faces, or `nil` on total failure. `status == 1` with an empty `surfaces` array also maps to `nil`.
 - **OCCT:** `FilletSurf_Builder`
-- **Note:** Returns raw surface geometry only — does not produce a new solid. Use `Shape.fillet(edges:radius:)` to produce a filleted solid.
+- **Note:** Returns raw surface geometry only; does not produce a new solid. Use `Shape.filleted(edges:radius:)` to produce a filleted solid.
 - **Example:**
   ```swift
   if let r = solid.filletSurfaces(edges: [e1, e2], radius: 1.0) {

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -2339,17 +2339,12 @@ Small solids are merged into their neighbors rather than removed.
 
 ---
 
-### `BSplineContinuity`
+### `BSplineContinuity` *(removed in v2.0.0)*
 
-> **Deprecated in #398.** `BSplineContinuity` was one of several copies of the same continuity-floor
-> vocabulary and is now a typealias of
-> [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity) (`.c0` ... `.c3`). No raw
-> value moved.
-
-```swift
-@available(*, deprecated, renamed: "ParametricContinuity")
-public typealias BSplineContinuity = ParametricContinuity
-```
+Renamed to `ParametricContinuity` in #398; the compatibility typealias itself was removed at
+v2.0.0 ([#784](https://github.com/SecondMouseAU/OCCTSwift/issues/784)). Use
+[`ParametricContinuity`](Shape-Healing.md#parametriccontinuity) (`.c0` ... `.c3`) directly. No raw
+value moved.
 
 ---
 

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -1551,13 +1551,13 @@ public func mergedMeshNodes(from shape: Shape,
                               mergeTolerance: Double = 0.0) -> MergedMeshData?
 ```
 
-- **Parameters:** `shape` — a shape that has been triangulated (e.g., via `Mesh.from(shape:)`); `smoothAngle` — normal-smoothing angle threshold in radians; `mergeTolerance` — distance threshold for merging nodes (0 = positional identity only).
+- **Parameters:** `shape`: a shape that has been triangulated (e.g., via `Shape.mesh(linearDeflection:angularDeflection:)`); `smoothAngle`: normal-smoothing angle threshold in radians; `mergeTolerance`: distance threshold for merging nodes (0 = positional identity only).
 - **Returns:** `MergedMeshData` with interleaved vertex, normal, and index arrays, or `nil` if the shape has no triangulation or the output would exceed 1 000 000 vertices / 3 000 000 indices.
 - **OCCT:** `BRep_Builder` face iteration + `Poly_Triangulation` via `OCCTPolyMergeNodes`.
 - **Example:**
   ```swift
-  let shape = Shape.box(dx: 10, dy: 10, dz: 10)!
-  _ = Mesh.from(shape: shape, deflection: 0.1)
+  let shape = Shape.box(width: 10, height: 10, depth: 10)!
+  _ = shape.mesh(linearDeflection: 0.1)
   if let mesh = mergedMeshNodes(from: shape, smoothAngle: .pi / 6) {
       // Upload mesh.vertices and mesh.indices to a Metal vertex buffer
       print(mesh.vertexCount, mesh.triangleCount)

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -511,7 +511,7 @@ Uses `ProjLib_CompProjectedCurve`, which handles cases where the curve projectio
 - **Example:**
   ```swift
   if let srf    = Surface.sphere(radius: 10),
-     let spiral = Curve3D.helix(radius: 10, pitch: 2, turns: 3) {
+     let spiral = Curve3D.circularHelix(radius: 10, pitch: 2) {
       let segs = srf.projectCurveSegments(spiral)
       // segs may contain multiple UV segments when the helix crosses the seam
   }

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -52,15 +52,12 @@ public var surfaceKind: SurfaceType { get }
 
 ---
 
-### `Continuity`
+### `Continuity` *(removed in v2.0.0)*
 
-Deprecated alias of the top-level `ContinuityClass`, which `Curve3D` and `Curve2D` now share
-(#485). The raw values are unchanged.
-
-```swift
-@available(*, deprecated, renamed: "ContinuityClass")
-public typealias Continuity = ContinuityClass
-```
+Was a deprecated alias of the top-level `ContinuityClass`, which `Curve3D` and `Curve2D` now
+share (#485); the alias itself was removed at v2.0.0
+([#784](https://github.com/SecondMouseAU/OCCTSwift/issues/784)). Use `ContinuityClass` directly.
+The raw values are unchanged.
 
 ---
 

--- a/docs/reference/Wire.md
+++ b/docs/reference/Wire.md
@@ -158,7 +158,7 @@ Returns `nil` if `start` and `end` are within 1e-10 of each other (degenerate ed
 - **Example:**
   ```swift
   if let spine = Wire.line(from: .zero, to: SIMD3(100, 0, 0)) {
-      let pipe = Shape.pipe(profile: Wire.circle(radius: 5)!, path: spine)
+      let pipe = Shape.pipeShell(spine: spine, profile: Wire.circle(radius: 5)!)
   }
   ```
 
@@ -458,7 +458,7 @@ Wires should be geometrically connected (end of one near the start of the next).
                      startAngle: -.pi/2, endAngle: 0)!
   let s2 = Wire.line(from: SIMD3(150, 50, 0), to: SIMD3(150, 200, 0))!
   if let path = Wire.join([s1, arc, s2]) {
-      let swept = Shape.pipe(profile: Wire.circle(radius: 5)!, path: path)
+      let swept = Shape.pipeShell(spine: path, profile: Wire.circle(radius: 5)!)
   }
   ```
 
@@ -888,7 +888,7 @@ All of `radius`, `pitch`, and `turns` must be > 0. The default winding is counte
 - **Example:**
   ```swift
   if let spring = Wire.helix(radius: 5, pitch: 2, turns: 10) {
-      let coil = Shape.pipe(profile: Wire.circle(radius: 0.5)!, path: spring)
+      let coil = Shape.pipeShell(spine: spring, profile: Wire.circle(radius: 0.5)!)
   }
   ```
 


### PR DESCRIPTION
## What & why

#802: a merge-to-main condition for v2.0.0. The release removes 62 deprecated symbols (#784/PR
#798), makes 97 functions visible to tooling for the first time (PR #797's parser fix), and
changes behavior under five unchanged signatures. Nothing in the repo's existing gate scripts
checks that a documented symbol still exists, and during #798 that gap let two reference pages
show live-looking signatures for deleted symbols, caught only by a reviewer reading closely. This
PR builds the check, runs it, fixes every stale reference it (and a snippet-level extension of it)
found, verifies the five behavior-changed pages, confirms the operation-count gate, and records
the decision on the 97 newly-visible functions.

Closes #802

## Item 1: existence, the highest-value half

New `Scripts/check-docs-existence.py`, wired into `ci.yml`'s `gate-scripts` job and the optional
pre-commit hook alongside the other five gates. Every symbol `docs/**/*.md` and `README.md`
document (excluding `docs/CHANGELOG.md`/`docs/SEMVER.md`, append-only historical ledgers) is
checked against a live index built from `Sources/OCCTSwift`, keyed on the exact (owning type,
member name) pair so a rename can never collide with a same-named live symbol elsewhere: the
`ShapeContentsExtended.nbEdges` vs. removed `Shape.nbEdges` trap the issue calls out is a
dedicated self-test case, proven both directions.

11 self-test cases, each a real removed/renamed symbol from PR #798's own migration table or one
of the two named collision traps, run once with the relevant guard disabled per
`okf/policies/prove-the-test-fails.md` (documented in the self-test's own comments; the
protocol-extension case's removal drops the battery from 11/11 to 10/11, isolated to exactly that
case).

Measured against the real tree, then iterated three times before converging clean:

1. A naive per-heading type guess (nearest section heading, then filename) produced 946
   candidates; reading a sample showed the guess wrong nearly every time, because the real pages
   mix a genuine type-name heading (`## AAG`) with a `// MARK:`-style group label (`## Properties`,
   reused verbatim across many files) under the identical un-backticked convention, and several
   pages are grab-bag completions pages whose filename names none of the types they document.
   Fixed by asking existence globally for a bare (undotted) reference, while keeping every
   *dotted* reference (`Type.member`) strict, since that is the shape the actual trap lives in.
2. Down to 127: two real parser bugs (`indirect enum` and `extension Shape.History` with a dotted
   name were both invisible to the type tracker) and an overly strict access-level gate
   (`Face.exactBounds` is `internal`, `FeatureRecognition.swift`'s `buildGraph()` is `private`,
   both real and both correctly documented for context) accounted for most of it.
3. Down to 14 genuine stale references, all fixed:
   - `docs/reference/Curve3D-Analytic-Types.md`, `Shape-Measurement.md`, `Surface.md`: three
     sections (`ContinuityOrder`, `BSplineContinuity`, `Continuity`) still showed a live
     `@available(*, deprecated)` typealias declaration and said "is now a typealias of X"; #784
     removed the typealias entirely. Rewritten to say so, matching the style already used for the
     already-fixed `BRepGraph.generation` entry.
   - `docs/reference/Document-OCAF-Attributes.md`: the whole `TDocStd_PathParser` section
     documented `PathParser.trek/.name/.fileExtension`, a type #784 removed outright. Rewritten
     to point at `OSDPath`, which already covers the same ground plus more.
   - `docs/guides/cookbook/brep-graph-uids.md`: a "do not use it" guide section still described
     `generation` as merely deprecated rather than removed.
   - Five pages named a method that never existed under that name, unrelated to #784:
     `Curve3D.helix(radius:pitch:turns:)` (real: `Curve3D.circularHelix(radius:pitch:)`, three
     sites), `Shape.fillet(edges:radius:)` (real: `filleted`), `Shape.pipe(profile:path:)` (real:
     `pipeShell(spine:profile:)`, three sites in `Wire.md`), `Mesh.fromShape`/`Mesh.from` (`Mesh`
     has no such factory; real: `Shape.mesh(...)`), `Curve2D.rectangle`/`Curve2D.arc` (real:
     4-segment construction / `arcOfCircle`), `Shape.makeFace`/`makePolygon` (real: `Shape.face(from:)`
     / `Wire.polygon3D`), `Exporter.writeGLB`/`Exporter.exportDXF` (real: `writeGLTF(...,
     binary:)` / `DXFExporter.writeDXF`).

Final state: `0 stale`, `29 acknowledged historical` (mentions a removed name and correctly says
so), `0 unresolved`.

## Item 2: snippets, measured then scoped

7,294 `​```swift` fenced blocks in scope. Measured, not sampled first: the check that matters
(does a snippet name a removed symbol) is text matching against an already-built index, not
compilation, so it costs nothing to run against the full population. `Scripts/repro/802-snippet-
sample/measure-snippet-failures.py` reuses `check-docs-existence.py`'s own machinery, now
conformance-aware (see below), against every snippet's code text.

First pass found 16 candidates; two were false positives from this checker's own gaps (`.self`
metatype references, and `WireCurve`/`EdgeCurve.maximumSampleCount`, which is genuinely inherited
from a protocol EXTENSION on `ArcLengthCurveAdaptor` with no separate declaration near either
conforming type for the checker to find). Fixed the second properly: `check-docs-existence.py`
now tracks textual conformance declarations and resolves a member through them, transitively, with
a dedicated self-test proving it load-bearing. The other 14 candidates were real (4 new beyond
item 1's list, since a snippet's own code can name something a heading never restates:
`Curve3D.helix` again, `Exporter.writeGLB`/`exportDXF`, `Curve2D.rectangle`, `Mesh.fromShape`/
`from`), all fixed. Final exhaustive run: 0/7294.

Then, separately, a real-compilation sample: 40 random snippets fed through `swiftc -typecheck`
against the built `OCCTSwift` module. All 40 failed to typecheck, and all 40 are extraction
artifacts, not docs defects, once classified: this repo's own reference-page convention of
restating just a signature with no body (`public var shellCount: Int { get }`, `public enum
ProjectionSymbol` with no cases) is invalid Swift at file scope, and a bare fragment
(`graph.setCoEdgeUVBox(...)`) assumes a `graph` the surrounding prose bound, not the snippet
itself. `0` failures remained once fragment-shaped errors are excluded. This closes the case for
exhaustive per-snippet compilation: the existing extraction shape makes it measure the extraction
method, not the docs, for the overwhelming majority of the corpus.

## Item 3: the five behavior-changed APIs

Read each against its fix PR:

- `detectPocketsAAG()` (#762) and `detectHoles()` (#747) were both badly stale, still describing
  their pre-fix criteria in full (direct-concave-neighbor-only wall discovery; all-concave-
  adjacency plus a bounding-box aspect-ratio heuristic). Both sections rewritten in
  `FeatureRecognition.md` to describe the current mechanism (fillet/chamfer junction absorption;
  surface-type + closed-in-U + radially-inward-material criterion).
- `ShapeAxis.extent` (#763): already accurate (`docs/reference/Geometry2D.md` was updated in PR
  #770 itself).
- `Document.shapeColor` (#763): already accurate (`docs/reference/Document-Persistence-IO.md` was
  updated in PR #768 itself).
- `AAGEdge.sharedEdgeCount` (#761): already accurate for current behavior (never claimed a cap);
  added one sentence of historical context (was silently capped at 10 before v2.0.0) since the
  page otherwise gave no indication anything had changed.

## Item 4: confirmation

`count-operations.py`: README headline 4256, API_REFERENCE total 4256, both match the derived
count. Clean, as expected since this PR touches no `Sources/` file.

## Item 5: the 97 newly-visible functions, decided

Not release-blocking, per the issue's own framing, confirmed rather than assumed. I could not
reproduce PR #797's exact 97 (that count is intrinsic to its own duplication-detector's tokenizer,
a different, narrower population than "has a nested-paren parameter"), so I built a smaller,
independent sample of 35 public functions with a tuple-typed parameter using the same live index
this PR already has. 13 of 35 (37%) have no reference-page entry anywhere in `docs/reference/`,
spread across `Shape`, `BRepGraph`, `Camera`, `ClipPlane`, and `LawFunction`, every one of which
`docs/reference/README.md`'s own coverage tracker currently marks "done". These are pre-existing
gaps (always public, never independently inventoried by anything until #797's parser fix), not a
regression from this release.

**Decision: not release-blocking for v2.0.0.** Documenting them is real, boundable follow-up work,
not urgent enough to hold the release for. Recommend a follow-up issue scoped to (a) closing the
13+ measured gaps and (b) correcting `docs/reference/README.md`'s Status table, which currently
overclaims complete coverage for types that have measured gaps.

## Tests

This PR touches no `Sources/OCCTSwift` or `Sources/OCCTBridge` file, only documentation and new
standalone tooling under `Scripts/`. Full `swift test`: **5463 tests, 1436 suites, 0 failures**,
one clean run (not three, since nothing in `Sources/` changed and a docs/tooling-only diff carries
none of the risk the three-run recommendation in #786 is aimed at).

All ten scripts under `Scripts/*.py` (the nine pre-existing plus the new
`check-docs-existence.py`), each run plus its `--self-test` where it has one:

```
check-bridge-index.py                        0 stale, 0 misfiled                        exit 0
check-bridge-index.py --self-test            18/18 cases correct                        exit 0
check-null-handle-guards.py                  all functions guard                        exit 0
check-null-handle-guards.py --self-test      24/24 cases correct                        exit 0
check-docs-defaults.py                       0 drifted, 0 unverified                    exit 0
check-docs-defaults.py --self-test           13/13 passed                               exit 0
check-docs-existence.py (NEW)                0 stale, 29 acknowledged historical        exit 0
check-docs-existence.py --self-test (NEW)    11/11 passed                               exit 0
derive-bridge-header-split.py --verify       0 ambiguous, 0 unmapped, 0 misfiled        exit 0
derive-bridge-header-split.py --self-test    8/8 cases correct                          exit 0
count-operations.py                          4256 == 4256 (README/API_REFERENCE match)  exit 0
census-unmeasured-values.py --self-test      36/36 cases correct                        exit 0
check-changelog-transcription.py --self-test 22/22 cases correct                        exit 0
derive-shape-domain-split.py --self-test     10/10 cases correct                        exit 0
derive-swift-file-split.py --self-test       6/6 cases correct, 0 spurious              exit 0
```

`census-unmeasured-values.py`'s bare run (a census, not a gate) and `check-changelog-
transcription.py`'s bare run (a report, not a gate) are both unaffected in character by this
diff, as expected for a docs/tooling-only change.

**Prove the test fails**, per `okf/policies/prove-the-test-fails.md`: the new self-test's
protocol-conformance case (proving `check-docs-existence.py` resolves a member supplied only by a
protocol extension, the `WireCurve`/`ArcLengthCurveAdaptor` shape) was run once with
`resolve_conformances` neutered to a no-op. Result: 10/11 passed, failing exactly and only the new
case (`expected clean=0, got stale=1`), restored, re-ran clean at 11/11.

## CHANGELOG entry

### A new gate checks that every symbol `docs/` documents as current API still exists in `Sources/OCCTSwift` (#802)

`Scripts/check-docs-existence.py` closes a gap none of the existing gates covered: during #798,
two reference pages showed a live-looking signature for a symbol the same PR had deleted, caught
only by a reviewer reading closely. The new gate checks every symbol `docs/**/*.md` and
`README.md` document against `Sources/OCCTSwift`, keyed on the exact (owning type, member name)
pair so a rename cannot collide with a same-named live symbol elsewhere (`Shape.nbEdges`, removed,
vs. `ShapeContentsExtended.nbEdges`, live and unrelated). Wired into `ci.yml`'s `gate-scripts` job
and the optional pre-commit hook alongside the other five gates.

Fixed 18 stale references it found: three sections (`Curve3D.ContinuityOrder`,
`Shape.BSplineContinuity`, `Surface.Continuity`) still described a removed typealias as a live
deprecated alias; `Document-OCAF-Attributes.md`'s whole `TDocStd_PathParser` section documented a
type #784 removed outright (now points at `OSDPath`); a cookbook guide still called `generation`
merely deprecated rather than removed; and 13 pages (headings and code snippets both) named a
method that never existed under that name, unrelated to #784: `Curve3D.helix`, `Shape.fillet`,
`Shape.pipe`, `Mesh.fromShape`/`Mesh.from`, `Curve2D.rectangle`/`Curve2D.arc`,
`Shape.makeFace`/`makePolygon`, and `Exporter.writeGLB`/`exportDXF`.

Also corrected `docs/reference/FeatureRecognition.md`'s `detectPocketsAAG()` and `detectHoles()`
sections, both of which still described their pre-#762/#747 criteria in full rather than the
current mechanism.

## SemVer impact

NONE. This PR changes no public Swift declaration: it adds a new internal gate script and repro
tooling under `Scripts/`, and corrects documentation prose and code examples to match already-
shipped behavior. Nothing in `Sources/OCCTSwift` or `Sources/OCCTBridge` changed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR. The gate script's own
      `--self-test` (11 cases) is that test, per this repo's convention for gate scripts.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and
      the failure is reported above (see "Prove the test fails").
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Not merging this PR**, per instructions; opening it against `refactor/381-pass1b` for review
  only.
- **Scope boundary with PR #800**: that PR is open against `Sources/OCCTSwift/{DXFExporter,
  DrawingDispatch,PDFExporter,SVGExporter}.swift` and `Tests/OCCTIOTests/`. This PR does not touch
  any of those four source files or that test directory; it does correct two *documentation*
  mentions of `Exporter.writeDXF`/`writeGLTF` (real, existing methods on the `Exporter` extension
  in `DXFExporter.swift`, not a change to that file itself).
- Item 5's decision (the 97 newly-visible functions) is recorded above rather than left implicit,
  per the issue's own instruction; happy to file the recommended follow-up issue if that is
  wanted, left undone here since the task was to decide and record, not to also open new tracking
  issues.
- `docs/occt-upgrades.md` is in the existence check's scope (prose about OCCT kernel version
  history, not excluded like `CHANGELOG.md`/`SEMVER.md`); it produced no findings.
- The snippet-measurement script (`Scripts/repro/802-snippet-sample/measure-snippet-failures.py`)
  is a one-off measurement artifact per the issue's "sample first, decide" framing, not proposed
  as a permanent gate; `check-docs-existence.py` itself is the permanent artifact.
